### PR TITLE
feat(backend): build agentctl to bin/ and use pre-built binary in Dockerfile

### DIFF
--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -14,7 +14,7 @@ BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 
 LDFLAGS += -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildTime=$(BUILD_TIME)
 
-.PHONY: all build clean run dev dev-db dev-db-reset test lint fmt vet help
+.PHONY: all build build-all build-agentctl clean run dev dev-db dev-db-reset test lint fmt vet help
 
 ## Default target
 all: build
@@ -25,11 +25,17 @@ build:
 	@mkdir -p $(BUILD_DIR)
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/kandev
 
-## Build all binaries (unified + individual services)
-build-all: build
+## Build all binaries (unified + individual services + agentctl)
+build-all: build build-agentctl
 	@echo "Building individual services..."
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/orchestrator ./cmd/orchestrator
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agent-manager ./cmd/agent-manager
+
+## Build the agentctl sidecar binary
+build-agentctl:
+	@echo "Building agentctl..."
+	@mkdir -p $(BUILD_DIR)
+	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agentctl ./cmd/agentctl
 
 ## Clean build artifacts
 clean:
@@ -115,7 +121,8 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  build         Build the unified kandev binary (default)"
-	@echo "  build-all     Build all binaries (unified + individual services)"
+	@echo "  build-all     Build all binaries (unified + individual services + agentctl)"
+	@echo "  build-agentctl Build the agentctl sidecar binary"
 	@echo "  clean         Remove build artifacts"
 	@echo "  run           Build and run the application"
 	@echo "  dev           Run in development mode with pre-seeded database"

--- a/apps/backend/dockerfiles/augment-agent/Dockerfile
+++ b/apps/backend/dockerfiles/augment-agent/Dockerfile
@@ -1,22 +1,9 @@
 # Augment Agent Dockerfile
 # A coding agent powered by Auggie CLI (Augment Code) with agentctl sidecar
-
-# Stage 1: Build agentctl from Go source
-FROM golang:1.24-alpine AS builder
-
-WORKDIR /build
-
-# Copy go mod files
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy source code
-COPY . .
-
-# Build agentctl binary
-RUN CGO_ENABLED=0 GOOS=linux go build -o /agentctl ./cmd/agentctl
-
-# Stage 2: Final image with Node.js and agentctl
+#
+# Prerequisites: Build agentctl before building this image:
+#   make build-agentctl
+#
 FROM node:20-slim
 
 # Install dependencies
@@ -32,8 +19,8 @@ RUN apt-get update && apt-get install -y \
 # Install Auggie CLI from npm
 RUN npm install -g @augmentcode/auggie
 
-# Copy agentctl binary from builder
-COPY --from=builder /agentctl /usr/local/bin/agentctl
+# Copy pre-built agentctl binary (run `make build-agentctl` first)
+COPY bin/agentctl /usr/local/bin/agentctl
 RUN chmod +x /usr/local/bin/agentctl
 
 # Create agent directory


### PR DESCRIPTION
## Summary

This PR adds proper build support for `agentctl` and simplifies the Docker build process.

## Changes

### Makefile
- Added `build-agentctl` target that builds `./cmd/agentctl` to `bin/agentctl`
- Updated `build-all` target to include `agentctl`
- Updated help text to document the new target

### Dockerfile (augment-agent)
- Removed multi-stage build that compiled agentctl from Go source
- Now copies the pre-built `bin/agentctl` binary directly
- Added prerequisite comment noting to run `make build-agentctl` first

## Benefits

- **Faster Docker builds**: No longer needs to download Go dependencies and compile during image build
- **Consistent binaries**: Same binary used for local development and Docker images
- **Simpler Dockerfile**: Single-stage build, easier to understand and maintain

## Usage

```bash
cd apps/backend

# Build agentctl
make build-agentctl

# Or build everything
make build-all

# Then build Docker image
docker build -t kandev/augment-agent:latest -f dockerfiles/augment-agent/Dockerfile .
```

