### PR TITLE
fix(agentctl): standalone mode workspace path and worktree lookup

### DIFF
--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -20,7 +20,7 @@ LDFLAGS += -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildTime
 all: build
 
 ## Build the unified kandev binary
-build:
+build: build-agentctl
 	@echo "Building $(BINARY_NAME)..."
 	@mkdir -p $(BUILD_DIR)
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/kandev
@@ -28,7 +28,6 @@ build:
 ## Build all binaries (unified + individual services + agentctl)
 build-all: build build-agentctl
 	@echo "Building individual services..."
-	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/orchestrator ./cmd/orchestrator
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agent-manager ./cmd/agent-manager
 
 ## Build the agentctl sidecar binary

--- a/apps/backend/cmd/agentctl/main.go
+++ b/apps/backend/cmd/agentctl/main.go
@@ -1,6 +1,10 @@
 // Package main is the entry point for the agentctl binary
 // agentctl is a sidecar process that manages agent subprocess communication
 // via HTTP API, bridging the agent's ACP protocol with the kandev backend.
+//
+// It supports two modes:
+// - Docker mode: Single instance, used when running inside a container
+// - Standalone mode: Multiple instances, used when running directly on host machine
 package main
 
 import (
@@ -14,14 +18,15 @@ import (
 
 	"github.com/kandev/kandev/internal/agentctl/api"
 	"github.com/kandev/kandev/internal/agentctl/config"
+	"github.com/kandev/kandev/internal/agentctl/instance"
 	"github.com/kandev/kandev/internal/agentctl/process"
 	"github.com/kandev/kandev/internal/common/logger"
 	"go.uber.org/zap"
 )
 
 func main() {
-	// Load configuration from environment
-	cfg := config.Load()
+	// Load multi-instance configuration
+	cfg := config.LoadMulti()
 
 	// Initialize logger
 	log, err := logger.NewLogger(logger.LoggingConfig{
@@ -35,26 +40,100 @@ func main() {
 	}
 	defer log.Sync()
 
+	// Determine mode
+	mode := detectMode(cfg.Mode)
+
 	log.Info("starting agentctl",
-		zap.Int("port", cfg.Port),
-		zap.String("agent_command", cfg.AgentCommand),
-		zap.String("workdir", cfg.WorkDir),
-		zap.Bool("auto_start", cfg.AutoStart))
+		zap.String("mode", mode),
+		zap.Int("control_port", cfg.ControlPort),
+		zap.Int("max_instances", cfg.MaxInstances))
+
+	if mode == "docker" {
+		runDockerMode(cfg, log)
+	} else {
+		runStandaloneMode(cfg, log)
+	}
+}
+
+// detectMode determines the operating mode based on config and environment
+func detectMode(configMode string) string {
+	if configMode == "docker" || configMode == "standalone" {
+		return configMode
+	}
+	// Auto-detect: check for Docker container indicators
+	if isRunningInDocker() {
+		return "docker"
+	}
+	return "standalone"
+}
+
+// isRunningInDocker checks if we're running inside a Docker container
+func isRunningInDocker() bool {
+	// Check for /.dockerenv file
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	// Check for /proc/1/cgroup containing "docker"
+	if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+		if len(data) > 0 {
+			content := string(data)
+			if len(content) > 0 && (contains(content, "docker") || contains(content, "kubepods")) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// runDockerMode runs agentctl in Docker mode (single instance, same as legacy behavior)
+func runDockerMode(cfg *config.MultiConfig, log *logger.Logger) {
+	// Load full config from environment (including AutoApprovePermissions)
+	singleCfg := config.Load()
+	// Override with multi-config values if they differ from defaults
+	singleCfg.Port = cfg.ControlPort
+	if cfg.DefaultAgentCommand != "" {
+		singleCfg.AgentCommand = cfg.DefaultAgentCommand
+		singleCfg.AgentArgs = parseCommand(cfg.DefaultAgentCommand)
+	}
+	if cfg.DefaultWorkDir != "" {
+		singleCfg.WorkDir = cfg.DefaultWorkDir
+	}
+	// Parse agent args
+	singleCfg.AgentArgs = parseCommand(singleCfg.AgentCommand)
+	singleCfg.AgentEnv = collectAgentEnv()
+
+	log.Info("running in Docker mode (single instance)",
+		zap.Int("port", singleCfg.Port),
+		zap.String("agent_command", singleCfg.AgentCommand),
+		zap.String("workdir", singleCfg.WorkDir),
+		zap.Bool("auto_approve_permissions", singleCfg.AutoApprovePermissions))
 
 	// Create process manager
-	procMgr := process.NewManager(cfg, log)
+	procMgr := process.NewManager(singleCfg, log)
 
 	// Create HTTP API server
-	server := api.NewServer(cfg, procMgr, log)
+	server := api.NewServer(singleCfg, procMgr, log)
 
 	// Start HTTP server
-	addr := fmt.Sprintf(":%d", cfg.Port)
+	addr := fmt.Sprintf(":%d", singleCfg.Port)
 	httpServer := &http.Server{
 		Addr:    addr,
 		Handler: server.Router(),
 	}
 
-	// Start server in goroutine
 	go func() {
 		log.Info("HTTP server starting", zap.String("address", addr))
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -63,37 +142,117 @@ func main() {
 		}
 	}()
 
-	// Auto-start agent if configured
-	if cfg.AutoStart {
-		log.Info("auto-starting agent process")
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		if err := procMgr.Start(ctx); err != nil {
-			log.Error("failed to auto-start agent", zap.Error(err))
+	// Wait for shutdown signal
+	waitForShutdown(log, func(ctx context.Context) {
+		if err := procMgr.Stop(ctx); err != nil {
+			log.Error("error stopping agent process", zap.Error(err))
 		}
-		cancel()
+		if err := httpServer.Shutdown(ctx); err != nil {
+			log.Error("error shutting down HTTP server", zap.Error(err))
+		}
+	})
+}
+
+// runStandaloneMode runs agentctl in standalone mode (multiple instances)
+func runStandaloneMode(cfg *config.MultiConfig, log *logger.Logger) {
+	log.Info("running in standalone mode (multi-instance)",
+		zap.Int("control_port", cfg.ControlPort),
+		zap.Int("instance_port_base", cfg.InstancePortBase),
+		zap.Int("instance_port_max", cfg.InstancePortMax),
+		zap.Int("max_instances", cfg.MaxInstances))
+
+	// Create instance manager
+	instMgr := instance.NewManager(cfg, log)
+
+	// Set the server factory to create API servers for each instance
+	instMgr.SetServerFactory(func(instCfg *config.Config, procMgr *process.Manager, instLog *logger.Logger) http.Handler {
+		return api.NewServer(instCfg, procMgr, instLog).Router()
+	})
+
+	// Create control server
+	controlServer := api.NewControlServer(cfg, instMgr, log)
+
+	// Start control server on control port
+	addr := fmt.Sprintf(":%d", cfg.ControlPort)
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: controlServer.Router(),
 	}
 
+	go func() {
+		log.Info("control server starting", zap.String("address", addr))
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Error("control server error", zap.Error(err))
+			os.Exit(1)
+		}
+	}()
+
 	// Wait for shutdown signal
+	waitForShutdown(log, func(ctx context.Context) {
+		if err := instMgr.Shutdown(ctx); err != nil {
+			log.Error("error shutting down instance manager", zap.Error(err))
+		}
+		if err := httpServer.Shutdown(ctx); err != nil {
+			log.Error("error shutting down control server", zap.Error(err))
+		}
+	})
+}
+
+// waitForShutdown waits for shutdown signal and calls cleanup
+func waitForShutdown(log *logger.Logger, cleanup func(ctx context.Context)) {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 
 	log.Info("shutting down agentctl...")
 
-	// Graceful shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Stop agent process
-	if err := procMgr.Stop(ctx); err != nil {
-		log.Error("error stopping agent process", zap.Error(err))
-	}
-
-	// Shutdown HTTP server
-	if err := httpServer.Shutdown(ctx); err != nil {
-		log.Error("error shutting down HTTP server", zap.Error(err))
-	}
+	cleanup(ctx)
 
 	log.Info("agentctl stopped")
+}
+
+// parseCommand splits a command string into arguments
+func parseCommand(cmd string) []string {
+	var args []string
+	for _, part := range splitFields(cmd) {
+		if part != "" {
+			args = append(args, part)
+		}
+	}
+	return args
+}
+
+func splitFields(s string) []string {
+	var result []string
+	var current string
+	for _, r := range s {
+		if r == ' ' || r == '\t' {
+			if current != "" {
+				result = append(result, current)
+				current = ""
+			}
+		} else {
+			current += string(r)
+		}
+	}
+	if current != "" {
+		result = append(result, current)
+	}
+	return result
+}
+
+// collectAgentEnv collects environment variables to pass to the agent
+func collectAgentEnv() []string {
+	var env []string
+	for _, e := range os.Environ() {
+		// Exclude AGENTCTL_* variables
+		if len(e) < 9 || e[:9] != "AGENTCTL_" {
+			env = append(env, e)
+		}
+	}
+	return env
 }
 

--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -183,7 +183,7 @@ func main() {
 		}
 
 		// Lifecycle Manager (uses agentctl for agent communication)
-		lifecycleMgr = lifecycle.NewManager(dockerClient, agentRegistry, eventBus, log)
+		lifecycleMgr = lifecycle.NewManager(dockerClient, agentRegistry, eventBus, cfg.Agent, log)
 		lifecycleMgr.SetCredentialsManager(credsMgr)
 
 		if err := lifecycleMgr.Start(ctx); err != nil {

--- a/apps/backend/internal/agent/agentctl/standalone.go
+++ b/apps/backend/internal/agent/agentctl/standalone.go
@@ -1,0 +1,197 @@
+// Package agentctl provides a client for communicating with agentctl.
+// This file contains the StandaloneCtl client for the multi-instance control API.
+package agentctl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
+)
+
+// StandaloneCtl is a client for the agentctl control API in standalone mode.
+// It manages creation and deletion of agent instances.
+type StandaloneCtl struct {
+	baseURL    string
+	httpClient *http.Client
+	logger     *logger.Logger
+}
+
+// CreateInstanceRequest contains the parameters for creating a new agent instance.
+type CreateInstanceRequest struct {
+	ID            string            `json:"id,omitempty"`
+	WorkspacePath string            `json:"workspace_path"`
+	AgentCommand  string            `json:"agent_command,omitempty"`
+	Env           map[string]string `json:"env,omitempty"`
+	AutoStart     bool              `json:"auto_start,omitempty"`
+}
+
+// CreateInstanceResponse contains the result of creating a new agent instance.
+type CreateInstanceResponse struct {
+	ID   string `json:"id"`
+	Port int    `json:"port"`
+}
+
+// InstanceInfo contains information about an agent instance.
+type InstanceInfo struct {
+	ID            string            `json:"id"`
+	Port          int               `json:"port"`
+	Status        string            `json:"status"`
+	WorkspacePath string            `json:"workspace_path"`
+	AgentCommand  string            `json:"agent_command"`
+	Env           map[string]string `json:"env,omitempty"`
+	CreatedAt     time.Time         `json:"created_at"`
+}
+
+// NewStandaloneCtl creates a new StandaloneCtl client.
+func NewStandaloneCtl(host string, port int, log *logger.Logger) *StandaloneCtl {
+	return &StandaloneCtl{
+		baseURL: fmt.Sprintf("http://%s:%d", host, port),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: log.WithFields(zap.String("component", "standalone-agentctl")),
+	}
+}
+
+// Health checks if the standalone agentctl is healthy.
+func (s *StandaloneCtl) Health(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", s.baseURL+"/health", nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health check failed: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// CreateInstance creates a new agent instance.
+func (s *StandaloneCtl) CreateInstance(ctx context.Context, req *CreateInstanceRequest) (*CreateInstanceResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.baseURL+"/api/v1/instances", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create instance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		json.NewDecoder(resp.Body).Decode(&errResp)
+		return nil, fmt.Errorf("failed to create instance: %s (status %d)", errResp.Error, resp.StatusCode)
+	}
+
+	var result CreateInstanceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	s.logger.Info("created agent instance",
+		zap.String("instance_id", result.ID),
+		zap.Int("port", result.Port))
+
+	return &result, nil
+}
+
+// DeleteInstance stops and removes an agent instance.
+func (s *StandaloneCtl) DeleteInstance(ctx context.Context, instanceID string) error {
+	req, err := http.NewRequestWithContext(ctx, "DELETE", s.baseURL+"/api/v1/instances/"+instanceID, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete instance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		json.NewDecoder(resp.Body).Decode(&errResp)
+		return fmt.Errorf("failed to delete instance: %s (status %d)", errResp.Error, resp.StatusCode)
+	}
+
+	s.logger.Info("deleted agent instance", zap.String("instance_id", instanceID))
+	return nil
+}
+
+// GetInstance gets information about a specific instance.
+func (s *StandaloneCtl) GetInstance(ctx context.Context, instanceID string) (*InstanceInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", s.baseURL+"/api/v1/instances/"+instanceID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("instance %q not found", instanceID)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get instance: status %d", resp.StatusCode)
+	}
+
+	var info InstanceInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &info, nil
+}
+
+// ListInstances lists all running agent instances.
+func (s *StandaloneCtl) ListInstances(ctx context.Context) ([]*InstanceInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", s.baseURL+"/api/v1/instances", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list instances: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list instances: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Instances []*InstanceInfo `json:"instances"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return result.Instances, nil
+}
+

--- a/apps/backend/internal/agent/lifecycle/manager_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_test.go
@@ -9,10 +9,20 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/docker"
 	"github.com/kandev/kandev/internal/agent/registry"
+	"github.com/kandev/kandev/internal/common/config"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events/bus"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
+
+// testAgentConfig returns a default AgentConfig for testing (docker mode)
+func testAgentConfig() config.AgentConfig {
+	return config.AgentConfig{
+		Runtime:        "docker",
+		StandaloneHost: "localhost",
+		StandalonePort: 9999,
+	}
+}
 
 // MockDockerClient implements a mock for the docker.Client for testing
 type MockDockerClient struct {
@@ -137,7 +147,7 @@ func newTestManager(mockDocker *MockDockerClient, eventBus bus.EventBus) *testMa
 	reg := newTestRegistry()
 
 	// Create a real manager first
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	return &testManager{
 		Manager:    mgr,
@@ -150,7 +160,7 @@ func TestNewManager(t *testing.T) {
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
 
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	if mgr == nil {
 		t.Fatal("expected non-nil manager")
@@ -164,7 +174,7 @@ func TestManager_GetInstance(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	// Manually add an instance for testing
 	instance := &AgentInstance{
@@ -202,7 +212,7 @@ func TestManager_GetInstanceByTaskID(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	instance := &AgentInstance{
 		ID:          "test-instance-id",
@@ -238,7 +248,7 @@ func TestManager_GetInstanceByContainerID(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	instance := &AgentInstance{
 		ID:          "test-instance-id",
@@ -274,7 +284,7 @@ func TestManager_ListInstances(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	// Empty list
 	list := mgr.ListInstances()
@@ -298,7 +308,7 @@ func TestManager_UpdateStatus(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	instance := &AgentInstance{
 		ID:     "test-instance-id",
@@ -332,7 +342,7 @@ func TestManager_UpdateProgress(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	instance := &AgentInstance{
 		ID:       "test-instance-id",
@@ -367,7 +377,7 @@ func TestManager_MarkCompleted_Success(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	instance := &AgentInstance{
 		ID:          "test-instance-id",
@@ -408,7 +418,7 @@ func TestManager_MarkCompleted_Failure(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	instance := &AgentInstance{
 		ID:          "test-instance-id",
@@ -445,7 +455,7 @@ func TestManager_MarkCompleted_NotFound(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	err := mgr.MarkCompleted("non-existent", 0, "")
 	if err == nil {
@@ -457,7 +467,7 @@ func TestManager_RemoveInstance(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	instance := &AgentInstance{
 		ID:          "test-instance-id",
@@ -493,7 +503,7 @@ func TestManager_StartStop(t *testing.T) {
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
-	mgr := NewManager(nil, reg, eventBus, log)
+	mgr := NewManager(nil, reg, eventBus, testAgentConfig(), log)
 
 	ctx := context.Background()
 

--- a/apps/backend/internal/agentctl/api/control_server.go
+++ b/apps/backend/internal/agentctl/api/control_server.go
@@ -1,0 +1,138 @@
+// Package api provides the HTTP REST API for agentctl control server
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kandev/kandev/internal/agentctl/config"
+	"github.com/kandev/kandev/internal/agentctl/instance"
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
+)
+
+// ControlServer provides instance CRUD endpoints on the control port (9999).
+type ControlServer struct {
+	cfg     *config.MultiConfig
+	instMgr *instance.Manager
+	logger  *logger.Logger
+	router  *gin.Engine
+}
+
+// NewControlServer creates a new ControlServer for multi-instance management.
+func NewControlServer(cfg *config.MultiConfig, instMgr *instance.Manager, log *logger.Logger) *ControlServer {
+	gin.SetMode(gin.ReleaseMode)
+
+	cs := &ControlServer{
+		cfg:     cfg,
+		instMgr: instMgr,
+		logger:  log.WithFields(zap.String("component", "control-server")),
+		router:  gin.New(),
+	}
+
+	cs.setupRoutes()
+	return cs
+}
+
+// Router returns the HTTP handler for the control server.
+func (m *ControlServer) Router() http.Handler {
+	return m.router
+}
+
+func (m *ControlServer) setupRoutes() {
+	// Health check
+	m.router.GET("/health", m.handleHealth)
+
+	// Instance management API
+	api := m.router.Group("/api/v1")
+	{
+		api.POST("/instances", m.handleCreateInstance)
+		api.GET("/instances", m.handleListInstances)
+		api.GET("/instances/:id", m.handleGetInstance)
+		api.DELETE("/instances/:id", m.handleDeleteInstance)
+	}
+}
+
+func (m *ControlServer) handleHealth(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status":    "ok",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"mode":      m.cfg.Mode,
+	})
+}
+
+func (m *ControlServer) handleCreateInstance(c *gin.Context) {
+	var req instance.CreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		m.logger.Warn("invalid create instance request", zap.Error(err))
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid request body: " + err.Error(),
+		})
+		return
+	}
+
+	// Validate required fields
+	if req.WorkspacePath == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "workspace_path is required",
+		})
+		return
+	}
+
+	resp, err := m.instMgr.CreateInstance(c.Request.Context(), &req)
+	if err != nil {
+		m.logger.Error("failed to create instance", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to create instance: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, resp)
+}
+
+func (m *ControlServer) handleListInstances(c *gin.Context) {
+	instances := m.instMgr.ListInstances()
+	c.JSON(http.StatusOK, instances)
+}
+
+func (m *ControlServer) handleGetInstance(c *gin.Context) {
+	id := c.Param("id")
+
+	inst, found := m.instMgr.GetInstance(id)
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "instance not found",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, inst.Info())
+}
+
+func (m *ControlServer) handleDeleteInstance(c *gin.Context) {
+	id := c.Param("id")
+
+	// First check if instance exists
+	if _, found := m.instMgr.GetInstance(id); !found {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "instance not found",
+		})
+		return
+	}
+
+	err := m.instMgr.StopInstance(c.Request.Context(), id)
+	if err != nil {
+		m.logger.Error("failed to stop instance", zap.String("id", id), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to stop instance: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "instance stopped successfully",
+	})
+}
+

--- a/apps/backend/internal/agentctl/config/multi_config.go
+++ b/apps/backend/internal/agentctl/config/multi_config.go
@@ -1,0 +1,55 @@
+// Package config provides configuration for agentctl.
+// This file contains multi-instance configuration for running multiple agent instances.
+package config
+
+// MultiConfig holds configuration for multi-instance mode.
+// It extends the base configuration with settings for managing multiple concurrent agent instances.
+type MultiConfig struct {
+	// ControlPort is the main control API port
+	ControlPort int
+
+	// InstancePortBase is the starting port for instances
+	InstancePortBase int
+
+	// InstancePortMax is the maximum port for instances
+	InstancePortMax int
+
+	// MaxInstances is the maximum number of concurrent instances
+	MaxInstances int
+
+	// DefaultAgentCommand is the default command for agents
+	DefaultAgentCommand string
+
+	// DefaultWorkDir is the default working directory for agents
+	DefaultWorkDir string
+
+	// AutoApprovePermissions auto-approves permission requests (for testing/CI)
+	AutoApprovePermissions bool
+
+	// LogLevel is the logging level (debug, info, warn, error)
+	LogLevel string
+
+	// LogFormat is the logging format (json, text)
+	LogFormat string
+
+	// Mode determines how instances are run: "standalone", "docker", or "auto"
+	Mode string
+}
+
+// LoadMulti loads multi-instance configuration from environment variables.
+// Environment variables use the AGENTCTL_ prefix.
+func LoadMulti() *MultiConfig {
+	return &MultiConfig{
+		ControlPort:            getEnvInt("AGENTCTL_CONTROL_PORT", 9999),
+		InstancePortBase:       getEnvInt("AGENTCTL_INSTANCE_PORT_BASE", 10001),
+		InstancePortMax:        getEnvInt("AGENTCTL_INSTANCE_PORT_MAX", 10100),
+		MaxInstances:           getEnvInt("AGENTCTL_MAX_INSTANCES", 10),
+		DefaultAgentCommand:    getEnv("AGENTCTL_AGENT_COMMAND", "auggie --acp"),
+		DefaultWorkDir:         getEnv("AGENTCTL_WORKDIR", "/workspace"),
+		AutoApprovePermissions: getEnvBool("AGENTCTL_AUTO_APPROVE_PERMISSIONS", false),
+		LogLevel:               getEnv("AGENTCTL_LOG_LEVEL", "info"),
+		LogFormat:              getEnv("AGENTCTL_LOG_FORMAT", "json"),
+		Mode:                   getEnv("AGENTCTL_MODE", "auto"),
+	}
+}
+

--- a/apps/backend/internal/agentctl/instance/instance.go
+++ b/apps/backend/internal/agentctl/instance/instance.go
@@ -1,0 +1,119 @@
+// Package instance provides data structures for multi-agent instance management.
+// It defines the core types used to represent, create, and serialize agent instances
+// that run as separate processes with their own HTTP servers.
+package instance
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/process"
+)
+
+// Instance represents a single agent instance running as a subprocess.
+// Each instance has its own process manager, HTTP server, and configuration.
+type Instance struct {
+	// ID is the unique identifier for this instance
+	ID string
+
+	// Port is the HTTP port this instance is listening on
+	Port int
+
+	// Status is the current status of the instance (e.g., "running", "stopped", "error")
+	Status string
+
+	// WorkspacePath is the absolute path to the workspace directory for this instance
+	WorkspacePath string
+
+	// AgentCommand is the command used to start the agent subprocess
+	AgentCommand string
+
+	// Env contains environment variables passed to the agent process
+	Env map[string]string
+
+	// CreatedAt is the timestamp when this instance was created
+	CreatedAt time.Time
+
+	// manager is the process manager handling the agent subprocess (unexported)
+	manager *process.Manager
+
+	// server is the HTTP server for this instance's API (unexported)
+	server *http.Server
+}
+
+// CreateRequest contains the parameters for creating a new agent instance.
+type CreateRequest struct {
+	// ID is an optional identifier for the instance. If empty, one will be generated.
+	ID string `json:"id,omitempty"`
+
+	// WorkspacePath is the required absolute path to the workspace directory.
+	WorkspacePath string `json:"workspace_path"`
+
+	// AgentCommand is an optional command to start the agent. If empty, a default is used.
+	AgentCommand string `json:"agent_command,omitempty"`
+
+	// Env contains optional environment variables to pass to the agent process.
+	Env map[string]string `json:"env,omitempty"`
+
+	// AutoStart indicates whether to start the agent automatically after creation.
+	AutoStart bool `json:"auto_start,omitempty"`
+}
+
+// CreateResponse contains the result of creating a new agent instance.
+type CreateResponse struct {
+	// ID is the unique identifier assigned to the created instance
+	ID string `json:"id"`
+
+	// Port is the HTTP port the instance is listening on
+	Port int `json:"port"`
+}
+
+// InstanceInfo contains serializable information about an instance for API responses.
+// It mirrors the exported fields from Instance and is safe for JSON serialization.
+type InstanceInfo struct {
+	// ID is the unique identifier for this instance
+	ID string `json:"id"`
+
+	// Port is the HTTP port this instance is listening on
+	Port int `json:"port"`
+
+	// Status is the current status of the instance
+	Status string `json:"status"`
+
+	// WorkspacePath is the absolute path to the workspace directory
+	WorkspacePath string `json:"workspace_path"`
+
+	// AgentCommand is the command used to start the agent subprocess
+	AgentCommand string `json:"agent_command"`
+
+	// Env contains environment variables passed to the agent process
+	Env map[string]string `json:"env,omitempty"`
+
+	// CreatedAt is the timestamp when this instance was created
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Info returns a safe copy of the instance data for API serialization.
+// This method creates an InstanceInfo struct containing only the exported,
+// serializable fields from the Instance.
+func (i *Instance) Info() *InstanceInfo {
+	// Create a copy of the environment map to prevent external modification
+	var envCopy map[string]string
+	if i.Env != nil {
+		envCopy = make(map[string]string, len(i.Env))
+		for k, v := range i.Env {
+			envCopy[k] = v
+		}
+	}
+
+	return &InstanceInfo{
+		ID:            i.ID,
+		Port:          i.Port,
+		Status:        i.Status,
+		WorkspacePath: i.WorkspacePath,
+		AgentCommand:  i.AgentCommand,
+		Env:           envCopy,
+		CreatedAt:     i.CreatedAt,
+	}
+}
+

--- a/apps/backend/internal/agentctl/instance/manager.go
+++ b/apps/backend/internal/agentctl/instance/manager.go
@@ -1,0 +1,269 @@
+// Package instance provides utilities for managing multi-agent instances.
+package instance
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kandev/kandev/internal/agentctl/config"
+	"github.com/kandev/kandev/internal/agentctl/process"
+	"github.com/kandev/kandev/internal/common/logger"
+	"go.uber.org/zap"
+)
+
+// ServerFactory creates an HTTP handler for an instance given its config and process manager.
+type ServerFactory func(cfg *config.Config, procMgr *process.Manager, log *logger.Logger) http.Handler
+
+// Manager manages multiple agent instances.
+// It handles creation, tracking, and removal of agent instances,
+// each with their own HTTP server on a dedicated port.
+type Manager struct {
+	config        *config.MultiConfig
+	logger        *logger.Logger
+	instances     map[string]*Instance
+	portAlloc     *PortAllocator
+	serverFactory ServerFactory
+	mu            sync.RWMutex
+}
+
+// NewManager creates a new instance manager.
+func NewManager(cfg *config.MultiConfig, log *logger.Logger) *Manager {
+	return &Manager{
+		config:    cfg,
+		logger:    log.WithFields(zap.String("component", "instance-manager")),
+		instances: make(map[string]*Instance),
+		portAlloc: NewPortAllocator(cfg.InstancePortBase, cfg.InstancePortMax),
+	}
+}
+
+// SetServerFactory sets the factory function for creating HTTP handlers for instances.
+// This must be called before creating any instances.
+func (m *Manager) SetServerFactory(factory ServerFactory) {
+	m.serverFactory = factory
+}
+
+// CreateInstance creates a new agent instance.
+func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*CreateResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if max instances reached
+	if len(m.instances) >= m.config.MaxInstances {
+		return nil, fmt.Errorf("maximum number of instances (%d) reached", m.config.MaxInstances)
+	}
+
+	// Generate ID if not provided
+	id := req.ID
+	if id == "" {
+		id = uuid.New().String()
+	}
+
+	// Check if ID already exists
+	if _, exists := m.instances[id]; exists {
+		return nil, fmt.Errorf("instance with ID %s already exists", id)
+	}
+
+	// Allocate a port
+	port, err := m.portAlloc.Allocate(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate port: %w", err)
+	}
+
+	// Determine agent command
+	agentCmd := req.AgentCommand
+	if agentCmd == "" {
+		agentCmd = m.config.DefaultAgentCommand
+	}
+
+	// Ensure auggie has the correct workspace-root for standalone mode
+	// The workspace path is the actual worktree path on the host, not /workspace
+	if req.WorkspacePath != "" && !strings.Contains(agentCmd, "--workspace-root") {
+		agentCmd = agentCmd + " --workspace-root " + req.WorkspacePath
+	}
+
+	// Create config for the process manager
+	instanceCfg := &config.Config{
+		Port:                   port,
+		AgentCommand:           agentCmd,
+		WorkDir:                req.WorkspacePath,
+		AutoStart:              req.AutoStart,
+		AutoApprovePermissions: m.config.AutoApprovePermissions,
+		LogLevel:               m.config.LogLevel,
+		LogFormat:              m.config.LogFormat,
+	}
+	// Parse agent args
+	instanceCfg.AgentArgs = strings.Fields(instanceCfg.AgentCommand)
+	// Collect environment
+	instanceCfg.AgentEnv = collectEnvForInstance(req.Env)
+
+	// Create process manager
+	procMgr := process.NewManager(instanceCfg, m.logger)
+
+	// Create HTTP handler using factory
+	var handler http.Handler
+	if m.serverFactory != nil {
+		handler = m.serverFactory(instanceCfg, procMgr, m.logger)
+	} else {
+		// Default to a simple handler if no factory is set
+		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("server factory not configured"))
+		})
+	}
+
+	// Create HTTP server
+	httpServer := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: handler,
+	}
+
+	// Start HTTP server in background
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			m.logger.Error("instance server error", zap.String("instance_id", id), zap.Error(err))
+		}
+	}()
+
+	// Create and store instance
+	inst := &Instance{
+		ID:            id,
+		Port:          port,
+		Status:        "running",
+		WorkspacePath: req.WorkspacePath,
+		AgentCommand:  agentCmd,
+		Env:           req.Env,
+		CreatedAt:     time.Now(),
+		manager:       procMgr,
+		server:        httpServer,
+	}
+	m.instances[id] = inst
+
+	m.logger.Info("created instance",
+		zap.String("instance_id", id),
+		zap.Int("port", port),
+		zap.String("workspace", req.WorkspacePath))
+
+	return &CreateResponse{
+		ID:   id,
+		Port: port,
+	}, nil
+}
+
+// GetInstance returns an instance by ID.
+func (m *Manager) GetInstance(id string) (*Instance, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	inst, ok := m.instances[id]
+	return inst, ok
+}
+
+// ListInstances returns info for all instances.
+func (m *Manager) ListInstances() []*InstanceInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]*InstanceInfo, 0, len(m.instances))
+	for _, inst := range m.instances {
+		result = append(result, inst.Info())
+	}
+	return result
+}
+
+// StopInstance stops and removes an instance by ID.
+func (m *Manager) StopInstance(ctx context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, ok := m.instances[id]
+	if !ok {
+		return fmt.Errorf("instance %s not found", id)
+	}
+
+	// Stop the process manager
+	if inst.manager != nil {
+		if err := inst.manager.Stop(ctx); err != nil {
+			m.logger.Warn("error stopping process manager",
+				zap.String("instance_id", id),
+				zap.Error(err))
+		}
+	}
+
+	// Shutdown HTTP server
+	if inst.server != nil {
+		if err := inst.server.Shutdown(ctx); err != nil {
+			m.logger.Warn("error shutting down HTTP server",
+				zap.String("instance_id", id),
+				zap.Error(err))
+		}
+	}
+
+	// Release port
+	m.portAlloc.Release(inst.Port)
+
+	// Remove from instances map
+	delete(m.instances, id)
+
+	m.logger.Info("stopped instance",
+		zap.String("instance_id", id),
+		zap.Int("port", inst.Port))
+
+	return nil
+}
+
+// Shutdown stops all instances gracefully.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	ids := make([]string, 0, len(m.instances))
+	for id := range m.instances {
+		ids = append(ids, id)
+	}
+	m.mu.Unlock()
+
+	var lastErr error
+	for _, id := range ids {
+		if err := m.StopInstance(ctx, id); err != nil {
+			m.logger.Error("error stopping instance during shutdown",
+				zap.String("instance_id", id),
+				zap.Error(err))
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}
+
+// collectEnvForInstance collects environment variables for an instance.
+// It starts with os.Environ() (excluding AGENTCTL_* vars), then adds/overrides
+// with the provided env map.
+func collectEnvForInstance(env map[string]string) []string {
+	// Start with current environment, excluding AGENTCTL_* vars
+	envMap := make(map[string]string)
+	for _, e := range os.Environ() {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 2 {
+			key := parts[0]
+			if !strings.HasPrefix(key, "AGENTCTL_") {
+				envMap[key] = parts[1]
+			}
+		}
+	}
+
+	// Add/override with provided env
+	for k, v := range env {
+		envMap[k] = v
+	}
+
+	// Convert back to []string
+	result := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		result = append(result, fmt.Sprintf("%s=%s", k, v))
+	}
+	return result
+}
+

--- a/apps/backend/internal/agentctl/instance/port_allocator.go
+++ b/apps/backend/internal/agentctl/instance/port_allocator.go
@@ -1,0 +1,64 @@
+// Package instance provides utilities for managing multi-agent instances,
+// including dynamic port allocation for agent services.
+package instance
+
+import (
+	"fmt"
+	"sync"
+)
+
+// PortAllocator manages dynamic port allocation for multi-agent instances.
+// It tracks which ports are in use and provides thread-safe allocation
+// and release of ports within a configured range.
+type PortAllocator struct {
+	basePort  int
+	maxPort   int
+	allocated map[int]string // maps port to instance ID
+	mu        sync.Mutex
+}
+
+// NewPortAllocator creates a new PortAllocator that manages ports
+// in the range [basePort, maxPort].
+func NewPortAllocator(basePort, maxPort int) *PortAllocator {
+	return &PortAllocator{
+		basePort:  basePort,
+		maxPort:   maxPort,
+		allocated: make(map[int]string),
+	}
+}
+
+// Allocate finds and reserves an available port for the given instance ID.
+// It performs a linear search starting from basePort up to maxPort.
+// Returns the allocated port number, or an error if no ports are available.
+func (p *PortAllocator) Allocate(instanceID string) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for port := p.basePort; port <= p.maxPort; port++ {
+		if _, exists := p.allocated[port]; !exists {
+			p.allocated[port] = instanceID
+			return port, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no available ports in range [%d, %d]", p.basePort, p.maxPort)
+}
+
+// Release frees a port for reuse. If the port is not currently allocated,
+// this operation is a no-op.
+func (p *PortAllocator) Release(port int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	delete(p.allocated, port)
+}
+
+// IsAvailable checks if a specific port is available for allocation.
+func (p *PortAllocator) IsAvailable(port int) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	_, exists := p.allocated[port]
+	return !exists
+}
+

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Database            DatabaseConfig            `mapstructure:"database"`
 	NATS                NATSConfig                `mapstructure:"nats"`
 	Docker              DockerConfig              `mapstructure:"docker"`
+	Agent               AgentConfig               `mapstructure:"agent"`
 	Auth                AuthConfig                `mapstructure:"auth"`
 	Logging             LoggingConfig             `mapstructure:"logging"`
 	RepositoryDiscovery RepositoryDiscoveryConfig `mapstructure:"repositoryDiscovery"`
@@ -87,6 +88,20 @@ type WorktreeConfig struct {
 	CleanupOnRemove bool   `mapstructure:"cleanupOnRemove"` // Remove worktree directory on task deletion
 }
 
+// AgentConfig holds agent runtime configuration.
+type AgentConfig struct {
+	// Runtime specifies the agent runtime mode: "docker" or "standalone"
+	// - "docker": Agents run in Docker containers (default)
+	// - "standalone": Agents run via standalone agentctl on the host machine
+	Runtime string `mapstructure:"runtime"`
+
+	// StandaloneHost is the host where standalone agentctl is running (default: localhost)
+	StandaloneHost string `mapstructure:"standaloneHost"`
+
+	// StandalonePort is the control port for standalone agentctl (default: 9999)
+	StandalonePort int `mapstructure:"standalonePort"`
+}
+
 // ReadTimeoutDuration returns the read timeout as a time.Duration.
 func (s *ServerConfig) ReadTimeoutDuration() time.Duration {
 	return time.Duration(s.ReadTimeout) * time.Second
@@ -132,6 +147,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("docker.tlsVerify", false)
 	v.SetDefault("docker.defaultNetwork", "kandev-network")
 	v.SetDefault("docker.volumeBasePath", "/var/lib/kandev/volumes")
+
+	// Agent defaults
+	v.SetDefault("agent.runtime", "docker")
+	v.SetDefault("agent.standaloneHost", "localhost")
+	v.SetDefault("agent.standalonePort", 9999)
 
 	// Auth defaults
 	v.SetDefault("auth.jwtSecret", "")


### PR DESCRIPTION
## Summary

Fixes workspace path handling in standalone mode for agentctl.

## Changes

### Core Fixes
- **WorkspacePath field**: Added \ to \ struct to track actual workspace path
- **NewSession fix**: Fixed hardcoded \ in \ to use \
- **Worktree lookup**: Fixed \ to lookup existing worktree by TaskID first, not just WorktreeID from metadata
- **Standalone command**: Added \ argument to agent command in standalone mode
- **Session validation**: Added check for session file existence before passing \ env var

### Debug Improvements
- Added debug logging for agent environment variables (WORKSPACE, AUGMENT, AUGGIE)

## Root Cause

The worktree lookup bug was always present but masked in Docker mode by volume mounts:

**Docker mode**: Even if worktree lookup failed, the volume mount \ ensured the correct directory was available.

**Standalone mode**: No volume mount magic, so the worktree lookup failure caused the agent to run in the wrong directory (repository root instead of worktree).

## Testing

- Tested standalone mode with existing task that has worktree in DB
- Verified agent receives correct worktree path instead of repository path
- Verified \ argument is passed correctly to auggie