### PR TITLE
feat(worktree): semantic naming and branch cleanup on task deletion

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -642,6 +642,7 @@ func (a *lifecycleAdapter) LaunchAgent(ctx context.Context, req *executor.Launch
 	// If empty, the agent will run without a mounted workspace
 	launchReq := &lifecycle.LaunchRequest{
 		TaskID:          req.TaskID,
+		TaskTitle:       req.TaskTitle,
 		AgentType:       req.AgentType,
 		WorkspacePath:   req.RepositoryURL, // May be empty - lifecycle manager handles this
 		TaskDescription: req.TaskDescription,

--- a/apps/backend/internal/agent/lifecycle/manager.go
+++ b/apps/backend/internal/agent/lifecycle/manager.go
@@ -60,6 +60,7 @@ type AgentInstance struct {
 // LaunchRequest contains parameters for launching an agent
 type LaunchRequest struct {
 	TaskID          string
+	TaskTitle       string                 // Human-readable task title for semantic worktree naming
 	AgentType       string
 	WorkspacePath   string                 // Host path to workspace (original repository path)
 	TaskDescription string                 // Task description to send via ACP prompt
@@ -607,6 +608,7 @@ func (m *Manager) getOrCreateWorktree(ctx context.Context, req *LaunchRequest) (
 	// Create request with optional WorktreeID for resumption
 	createReq := worktree.CreateRequest{
 		TaskID:         req.TaskID,
+		TaskTitle:      req.TaskTitle,
 		RepositoryID:   req.RepositoryID,
 		RepositoryPath: req.RepositoryPath,
 		BaseBranch:     req.BaseBranch,

--- a/apps/backend/internal/agent/worktree/worktree.go
+++ b/apps/backend/internal/agent/worktree/worktree.go
@@ -49,6 +49,11 @@ type CreateRequest struct {
 	// TaskID is the unique task identifier (required).
 	TaskID string
 
+	// TaskTitle is the human-readable task title (optional).
+	// If provided, it will be used to generate semantic worktree/branch names.
+	// The title is sanitized and truncated to 20 characters.
+	TaskTitle string
+
 	// RepositoryID is the repository identifier (required).
 	RepositoryID string
 

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -58,6 +58,7 @@ type AgentManagerClient interface {
 // LaunchAgentRequest contains parameters for launching an agent
 type LaunchAgentRequest struct {
 	TaskID          string
+	TaskTitle       string // Human-readable task title for semantic worktree naming
 	AgentType       string
 	RepositoryURL   string
 	Branch          string
@@ -276,6 +277,7 @@ func (e *Executor) Execute(ctx context.Context, task *v1.Task) (*TaskExecution, 
 	// Create a LaunchAgentRequest from the task
 	req := &LaunchAgentRequest{
 		TaskID:          task.ID,
+		TaskTitle:       task.Title,
 		AgentType:       *task.AgentType,
 		TaskDescription: task.Description,
 		Priority:        task.Priority,


### PR DESCRIPTION
## Summary

This PR improves worktree naming to be more human-readable and ensures proper cleanup.

### Changes

#### 1. Semantic Worktree Naming
Worktrees and branches now use the task title instead of just the task ID:

- **Directory format**: \  
  Example: \
- **Branch format**: \  
  Example: \

The sanitization process:
- Converts title to lowercase
- Replaces special characters with hyphens
- Removes consecutive hyphens
- Truncates to 20 characters
- Falls back to task ID if title is empty or all special characters

#### 2. Branch Deletion Logging
Improved logging for branch deletion from the main repository when tasks are deleted. The functionality was already implemented but now has clearer logging to track the cleanup process.

### Files Changed
- \ - Added \, \, \ functions
- \ - Added \ field to \
- \ - Updated \ to use semantic names, improved branch deletion logging
- \ - Added \ field to \
- \ - Added \ field to \
- \ - Updated lifecycle adapter to pass \
- \ - Added tests for sanitization functions

### Testing
- All existing tests pass
- Added unit tests for \ and \ functions
