### PR TITLE
feat(backend): auto-launch agentctl subprocess in standalone mode

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -218,8 +218,9 @@ func main() {
 		log.Info("Starting agentctl for standalone mode...")
 
 		agentctlLauncher = launcher.New(launcher.Config{
-			Host: cfg.Agent.StandaloneHost,
-			Port: cfg.Agent.StandalonePort,
+			Host:                   cfg.Agent.StandaloneHost,
+			Port:                   cfg.Agent.StandalonePort,
+			AutoApprovePermissions: true, // Always auto-approve in standalone mode (reindex, etc.)
 		}, log)
 
 		if err := agentctlLauncher.Start(ctx); err != nil {

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -2,7 +2,7 @@ export type AppConfig = {
   apiBaseUrl: string;
 };
 
-const DEFAULT_API_BASE_URL = 'http://localhost:8080';
+const DEFAULT_API_BASE_URL = 'http://nova:8080';
 
 export function getBackendConfig(): AppConfig {
   if (typeof window === 'undefined') {


### PR DESCRIPTION
## Summary

This PR enables kandev to automatically spawn and manage agentctl as a child process when running in standalone mode, providing a single-command experience.

## Changes

### New: Launcher Package
- `apps/backend/internal/agent/agentctl/launcher/launcher.go`
  - Spawns agentctl with `--mode=standalone` flags
  - Health check with exponential backoff before proceeding
  - Pipes agentctl stdout/stderr through kandev logger
  - Binary discovery (same dir as executable, PATH, common dev paths)

### CLI Flags
New command-line flags for kandev:
- `-agent-runtime`: Set to `standalone` or `docker`
- `-port`: HTTP server port
- `-log-level`: Log level (debug, info, warn, error)
- `-config`: Path to config file
- `-help`, `-version`: Help and version info

### Process Cleanup
Ensures agentctl is always terminated when kandev stops:

| Scenario | Mechanism |
|----------|-----------|
| Ctrl+C / SIGTERM / SIGHUP | Signal handler → graceful shutdown |
| kill -9 / crash | Pdeathsig → kernel sends SIGTERM to child |
| Panic in kandev | Panic recovery → Stop() before re-panic |
| Terminal closed | SIGHUP handler → graceful shutdown |

Key implementation details:
- `Setpgid: true` - New process group prevents Ctrl+C propagation
- `Pdeathsig: SIGTERM` - Kernel kills child if parent dies
- Graceful SIGTERM with SIGKILL fallback on timeout

## Usage

```bash
# Single command to start kandev with standalone agentctl
kandev -agent-runtime=standalone

# With other options
kandev -agent-runtime=standalone -port=9000 -log-level=debug
```

## Testing

- [x] Build succeeds
- [x] `kandev -help` shows usage
- [x] Ctrl+C cleanly stops both processes
- [ ] Manual testing in standalone mode
