### PR TITLE
refactor: session-centric execution and terminal improvements

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -435,9 +435,6 @@ func main() {
 	workspaceController := taskcontroller.NewWorkspaceController(taskSvc)
 	boardController := taskcontroller.NewBoardController(taskSvc)
 	taskController := taskcontroller.NewTaskController(taskSvc)
-	if worktreeMgr != nil {
-		taskController.SetWorktreeLookup(worktreeMgr) // Enable worktree info in task responses
-	}
 	messageController := taskcontroller.NewMessageController(taskSvc)
 	repositoryController := taskcontroller.NewRepositoryController(taskSvc)
 	executorController := taskcontroller.NewExecutorController(taskSvc)

--- a/apps/backend/internal/agent/worktree/manager_test.go
+++ b/apps/backend/internal/agent/worktree/manager_test.go
@@ -43,13 +43,21 @@ func (s *mockStore) CreateWorktree(ctx context.Context, wt *Worktree) error {
 	return nil
 }
 
-func (s *mockStore) GetWorktreeByTaskID(ctx context.Context, taskID string) (*Worktree, error) {
+func (s *mockStore) GetWorktreeBySessionID(ctx context.Context, sessionID string) (*Worktree, error) {
 	for _, wt := range s.worktrees {
-		if wt.TaskID == taskID {
+		if wt.SessionID == sessionID {
 			return wt, nil
 		}
 	}
 	return nil, nil
+}
+
+func (s *mockStore) GetWorktreeByID(ctx context.Context, id string) (*Worktree, error) {
+	wt, ok := s.worktrees[id]
+	if !ok {
+		return nil, nil
+	}
+	return wt, nil
 }
 
 func (s *mockStore) GetWorktreesByTaskID(ctx context.Context, taskID string) ([]*Worktree, error) {
@@ -60,14 +68,6 @@ func (s *mockStore) GetWorktreesByTaskID(ctx context.Context, taskID string) ([]
 		}
 	}
 	return result, nil
-}
-
-func (s *mockStore) GetWorktreeByID(ctx context.Context, id string) (*Worktree, error) {
-	wt, ok := s.worktrees[id]
-	if !ok {
-		return nil, nil
-	}
-	return wt, nil
 }
 
 func (s *mockStore) GetWorktreesByRepositoryID(ctx context.Context, repoID string) ([]*Worktree, error) {

--- a/apps/backend/internal/agent/worktree/store.go
+++ b/apps/backend/internal/agent/worktree/store.go
@@ -158,6 +158,70 @@ func (s *SQLiteStore) GetWorktreeByID(ctx context.Context, id string) (*Worktree
 	return wt, nil
 }
 
+// GetWorktreeBySessionID retrieves the worktree by session ID.
+func (s *SQLiteStore) GetWorktreeBySessionID(ctx context.Context, sessionID string) (*Worktree, error) {
+	wt := &Worktree{}
+	var mergedAt, deletedAt sql.NullTime
+	var repositoryPath, baseBranch sql.NullString
+
+	err := s.db.QueryRowContext(ctx, `
+		SELECT
+			tsw.worktree_id,
+			tsw.session_id,
+			s.task_id,
+			tsw.repository_id,
+			r.local_path,
+			tsw.worktree_path,
+			tsw.worktree_branch,
+			s.base_branch,
+			tsw.status,
+			tsw.created_at,
+			tsw.updated_at,
+			tsw.merged_at,
+			tsw.deleted_at
+		FROM task_session_worktrees tsw
+		INNER JOIN task_sessions s ON tsw.session_id = s.id
+		LEFT JOIN repositories r ON tsw.repository_id = r.id
+		WHERE tsw.session_id = ? AND tsw.status = ?
+	`, sessionID, StatusActive).Scan(
+		&wt.ID,
+		&wt.SessionID,
+		&wt.TaskID,
+		&wt.RepositoryID,
+		&repositoryPath,
+		&wt.Path,
+		&wt.Branch,
+		&baseBranch,
+		&wt.Status,
+		&wt.CreatedAt,
+		&wt.UpdatedAt,
+		&mergedAt,
+		&deletedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil // Not found, return nil without error
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if repositoryPath.Valid {
+		wt.RepositoryPath = repositoryPath.String
+	}
+	if baseBranch.Valid {
+		wt.BaseBranch = baseBranch.String
+	}
+	if mergedAt.Valid {
+		wt.MergedAt = &mergedAt.Time
+	}
+	if deletedAt.Valid {
+		wt.DeletedAt = &deletedAt.Time
+	}
+
+	return wt, nil
+}
+
 // GetWorktreeByTaskID retrieves the most recent active worktree by task ID.
 // Since multiple worktrees can exist per task, this returns the most recently created active one.
 func (s *SQLiteStore) GetWorktreeByTaskID(ctx context.Context, taskID string) (*Worktree, error) {

--- a/apps/backend/internal/orchestrator/controller/controller.go
+++ b/apps/backend/internal/orchestrator/controller/controller.go
@@ -62,7 +62,7 @@ func (c *Controller) TriggerTask(ctx context.Context, req dto.TriggerTaskRequest
 
 // StartTask starts task execution
 func (c *Controller) StartTask(ctx context.Context, req dto.StartTaskRequest) (dto.StartTaskResponse, error) {
-	execution, err := c.service.StartTask(ctx, req.TaskID, req.AgentProfileID, req.Priority)
+	execution, err := c.service.StartTask(ctx, req.TaskID, req.AgentProfileID, req.Priority, req.Prompt)
 	if err != nil {
 		return dto.StartTaskResponse{}, err
 	}

--- a/apps/backend/internal/orchestrator/dto/dto.go
+++ b/apps/backend/internal/orchestrator/dto/dto.go
@@ -45,6 +45,7 @@ type StartTaskRequest struct {
 	TaskID         string `json:"task_id"`
 	AgentProfileID string `json:"agent_profile_id,omitempty"`
 	Priority       int    `json:"priority,omitempty"`
+	Prompt         string `json:"prompt,omitempty"` // Initial prompt to send to the agent
 }
 
 // StartTaskResponse is the response for orchestrator.start

--- a/apps/backend/internal/orchestrator/handlers/handlers.go
+++ b/apps/backend/internal/orchestrator/handlers/handlers.go
@@ -85,6 +85,7 @@ type wsStartTaskRequest struct {
 	TaskID         string `json:"task_id"`
 	AgentProfileID string `json:"agent_profile_id,omitempty"`
 	Priority       int    `json:"priority,omitempty"`
+	Prompt         string `json:"prompt,omitempty"`
 }
 
 func (h *Handlers) wsStartTask(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
@@ -103,6 +104,7 @@ func (h *Handlers) wsStartTask(ctx context.Context, msg *ws.Message) (*ws.Messag
 		TaskID:         req.TaskID,
 		AgentProfileID: req.AgentProfileID,
 		Priority:       req.Priority,
+		Prompt:         req.Prompt,
 	})
 	if err != nil {
 		h.logger.Error("failed to start task", zap.String("task_id", req.TaskID), zap.Error(err))

--- a/apps/backend/internal/orchestrator/scheduler/scheduler.go
+++ b/apps/backend/internal/orchestrator/scheduler/scheduler.go
@@ -188,9 +188,6 @@ func (s *Scheduler) HandleTaskCompleted(taskID string, success bool) {
 	} else {
 		atomic.AddInt64(&s.totalFailed, 1)
 	}
-
-	// Remove from executor tracking
-	s.executor.RemoveExecution(taskID)
 }
 
 // RetryTask re-queues a failed task if retry limit not exceeded

--- a/apps/backend/internal/task/dto/dto.go
+++ b/apps/backend/internal/task/dto/dto.go
@@ -106,9 +106,6 @@ type TaskDTO struct {
 	CreatedAt    time.Time              `json:"created_at"`
 	UpdatedAt    time.Time              `json:"updated_at"`
 	Metadata     map[string]interface{} `json:"metadata,omitempty"`
-	// Worktree information (populated if worktree exists for this task)
-	WorktreePath   *string `json:"worktree_path,omitempty"`
-	WorktreeBranch *string `json:"worktree_branch,omitempty"`
 }
 
 type TaskRepositoryDTO struct {

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -77,6 +77,7 @@ type Repository interface {
 	UpdateTaskSessionState(ctx context.Context, id string, state models.TaskSessionState, errorMessage string) error
 	ListTaskSessions(ctx context.Context, taskID string) ([]*models.TaskSession, error)
 	ListActiveTaskSessions(ctx context.Context) ([]*models.TaskSession, error)
+	ListActiveTaskSessionsByTaskID(ctx context.Context, taskID string) ([]*models.TaskSession, error)
 	HasActiveTaskSessionsByAgentProfile(ctx context.Context, agentProfileID string) (bool, error)
 	HasActiveTaskSessionsByExecutor(ctx context.Context, executorID string) (bool, error)
 	HasActiveTaskSessionsByEnvironment(ctx context.Context, environmentID string) (bool, error)

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -146,17 +146,13 @@ export function TaskSessionSidebar({ workspaceId, boardId }: TaskSessionSidebarP
           state: string;
         }>(
           'orchestrator.start',
-          { task_id: taskId, agent_profile_id: data.agentProfileId },
+          {
+            task_id: taskId,
+            agent_profile_id: data.agentProfileId,
+            prompt: data.prompt.trim(),
+          },
           15000
         );
-
-        if (response?.session_id && data.prompt.trim()) {
-          await client.request(
-            'message.add',
-            { task_id: taskId, session_id: response.session_id, content: data.prompt.trim() },
-            10000
-          );
-        }
 
         await loadSelectedSessions(true);
 

--- a/apps/web/hooks/use-session-git-status.ts
+++ b/apps/web/hooks/use-session-git-status.ts
@@ -1,12 +1,46 @@
 import { useEffect } from 'react';
 import { useAppStore } from '@/components/state-provider';
 import { getWebSocketClient } from '@/lib/ws/connection';
+import type { GitStatusEntry } from '@/lib/state/store';
 
 export function useSessionGitStatus(sessionId: string | null) {
   const gitStatus = useAppStore((state) =>
     sessionId ? state.gitStatus.bySessionId[sessionId] : undefined
   );
-  const clearGitStatus = useAppStore((state) => state.clearGitStatus);
+  const session = useAppStore((state) =>
+    sessionId ? state.taskSessions.items[sessionId] : undefined
+  );
+  const setGitStatus = useAppStore((state) => state.setGitStatus);
+
+  // Populate git status from session metadata if not already in store
+  useEffect(() => {
+    if (!sessionId || gitStatus) return;
+
+    // Try to extract git_status from session metadata
+    const metadata = session?.metadata;
+    if (!metadata || typeof metadata !== 'object') return;
+
+    const storedGitStatus = metadata.git_status;
+    if (!storedGitStatus || typeof storedGitStatus !== 'object') return;
+
+    // Map stored git status to GitStatusEntry
+    const gs = storedGitStatus as Record<string, unknown>;
+    const entry: GitStatusEntry = {
+      branch: (gs.branch as string) ?? null,
+      remote_branch: (gs.remote_branch as string) ?? null,
+      modified: (gs.modified as string[]) ?? [],
+      added: (gs.added as string[]) ?? [],
+      deleted: (gs.deleted as string[]) ?? [],
+      untracked: (gs.untracked as string[]) ?? [],
+      renamed: (gs.renamed as string[]) ?? [],
+      ahead: (gs.ahead as number) ?? 0,
+      behind: (gs.behind as number) ?? 0,
+      files: (gs.files as Record<string, GitStatusEntry['files'][string]>) ?? {},
+      timestamp: (gs.timestamp as string) ?? null,
+    };
+
+    setGitStatus(sessionId, entry);
+  }, [sessionId, gitStatus, session?.metadata, setGitStatus]);
 
   useEffect(() => {
     if (!sessionId) return;
@@ -15,13 +49,10 @@ export function useSessionGitStatus(sessionId: string | null) {
       const unsubscribe = client.subscribeSession(sessionId);
       return () => {
         unsubscribe();
-        clearGitStatus(sessionId);
+        // Don't clear git status on cleanup - keep it cached for when user switches back
       };
     }
-    return () => {
-      clearGitStatus(sessionId);
-    };
-  }, [clearGitStatus, sessionId]);
+  }, [sessionId]);
 
   return gitStatus;
 }

--- a/apps/web/lib/types/http.ts
+++ b/apps/web/lib/types/http.ts
@@ -103,9 +103,6 @@ export type Task = {
   created_at: string;
   updated_at: string;
   metadata?: Record<string, unknown> | null;
-  // Worktree information (present if agent has created a worktree for this task)
-  worktree_path?: string | null;
-  worktree_branch?: string | null;
 };
 
 export type CreateTaskResponse = Task & {


### PR DESCRIPTION
## Summary

This PR includes significant improvements to session management, terminal handling, orchestrator execution, and worktree architecture. The changes span both frontend and backend, improving reliability, code organization, and user experience.

---

## Frontend Changes

### Terminal Improvements (`shell-terminal.tsx`)

1. **Fixed terminal not subscribing on page refresh**
   - Removed `isAgentctlReady` gate from `canSubscribe` - shell works as long as session is active
   - This was causing the terminal prompt to not appear after page refresh

2. **Fixed garbage characters appearing in terminal (13RR, 29RR)**
   - Terminal cursor position responses (DSR queries like `\x1b[6n` returning `\x1b[29;1R`) were being sent to the shell as commands
   - Added filter in `onData` handler to block these terminal query responses

3. **Improved terminal rendering on tab visibility changes**
   - Added `IntersectionObserver` to handle terminal sizing when tab becomes visible
   - Added initial fit timeout (100ms) for proper sizing after render
   - Reset output tracking (`lastOutputLengthRef`) when session changes

4. **Clean prompt after subscribing**
   - Send Ctrl+L after loading shell buffer to clear screen and redraw prompt cleanly
   - Fixes issues with garbage escape sequences in the buffer

### Git Status Improvements (`use-session-git-status.ts`)

1. **Populate git status from session metadata**
   - If git status is not in store, extract it from session metadata on mount
   - Prevents git status from disappearing when switching between sessions

2. **Keep git status cached**
   - Removed `clearGitStatus()` on cleanup - data is now preserved when switching sessions

### Session Page Improvements (`app/s/[sessionId]/page.tsx`)

1. **Load all sessions for task on SSR**
   - Fetch all sessions for the task, not just the current one
   - Populates the session sidebar correctly on page load

2. **Improved worktree hydration**
   - Hydrate worktrees for all sessions, not just the current one

### Session Sidebar (`task-session-sidebar.tsx`)

1. **Pass prompt directly to orchestrator.start**
   - Send prompt as part of the start request instead of sending a separate `message.add` after
   - Reduces race conditions and simplifies the flow

### Task Agent Hook (`use-task-agent.ts`)

1. **Get worktree info from active session**
   - Worktree path/branch now comes from the active session, not the task
   - Tasks no longer have worktree info directly (moved to sessions)

2. **Support prompt in handleStartAgent**
   - Added optional `prompt` parameter to `handleStartAgent()`

### Type Cleanup (`lib/types/http.ts`)

- Removed `worktree_path` and `worktree_branch` from Task type (now on sessions)

---

## Backend Changes

### Orchestrator Execution Refactoring (`executor/executor.go`)

1. **Removed in-memory execution cache**
   - Eliminated `executions map[string]*TaskExecution` and associated mutex
   - All execution state now read from database
   - Fixes issues with stale in-memory state after backend restarts

2. **Session-centric execution management**
   - Changed `Stop()` to take `sessionID` instead of `taskID`
   - Added `StopByTaskID()` for stopping all sessions of a task
   - Added `GetExecutionBySession()` for session-specific lookup
   - Added `UpdateProgressBySession()` and `MarkCompletedBySession()`

3. **Async prompt sending**
   - Initial prompt is now sent asynchronously after `orchestrator.start` returns
   - Prevents blocking the start response while waiting for agent to process

4. **Added prompt to start request**
   - `orchestrator.start` now accepts a `prompt` parameter
   - Passed through to `ExecuteWithProfile()`

5. **Removed deprecated methods**
   - `LoadActiveSessionsFromDB()`, `SyncWithRecoveredExecutions()`, `RemoveExecution()`, `UpdateExecutionState()`

### Worktree Manager Refactoring (`worktree/manager.go`, `worktree/store.go`)

1. **Session-keyed worktrees**
   - Changed in-memory cache from `taskID -> worktree` to `sessionID -> worktree`
   - Each session now gets its own isolated worktree

2. **Added `GetWorktreeBySessionID()`**
   - New store method to lookup worktree by session ID
   - Required for session-centric worktree management

3. **Removed task-level worktree lookup**
   - Removed `GetWorktreeInfo()` (WorktreeLookup interface)
   - Tasks no longer have worktree info directly

### Lifecycle Session (`lifecycle/session.go`)

1. **Async initial prompt**
   - `InitializeAndPrompt` now sends the initial prompt in a goroutine
   - Allows `orchestrator.start` to return immediately

### Task Controller (`task/controller/task.go`)

1. **Removed worktree enrichment**
   - Removed `WorktreeLookup` interface and `enrichWithWorktree()`
   - Worktree info is now only on sessions, not tasks

### Task DTO (`task/dto/dto.go`)

- Removed `WorktreePath` and `WorktreeBranch` from TaskDTO

### Task Handlers (`task/handlers/task_handlers.go`)

- Updated `StartTask` calls to pass prompt parameter

### Repository (`task/repository/`)

- Added `ListActiveTaskSessionsByTaskID()` for listing all active sessions of a task

### Orchestrator Service (`orchestrator/service.go`)

1. **StartTask accepts prompt**
   - Added `prompt` parameter to `StartTask()`

2. **Added `StopSession()`**
   - Stop a specific session by ID

3. **Updated `CompleteTask()`**
   - Now calls `StopByTaskID()` to stop all sessions

### Orchestrator DTO (`orchestrator/dto/dto.go`)

- Added `Prompt` field to `StartTaskRequest`

### Scheduler (`scheduler/scheduler.go`)

- Removed `RemoveExecution()` call in `HandleTaskCompleted()`

---

## Testing

- [x] Backend tests pass (`make test`)
- [x] Frontend lint passes (`pnpm lint`)
- [x] Manual testing: terminal works correctly on page refresh
- [x] Manual testing: git status persists when switching sessions
- [x] Manual testing: no garbage characters in terminal
- [x] Manual testing: sessions load correctly in sidebar on page refresh