### PR TITLE
chore: remove deprecated backward compatibility code

### DIFF
--- a/apps/backend/internal/agent/lifecycle/manager.go
+++ b/apps/backend/internal/agent/lifecycle/manager.go
@@ -694,7 +694,7 @@ func (m *Manager) getAgentConfigForExecution(execution *AgentExecution) (*regist
 
 	// Map agent name to registry ID (e.g., "auggie" -> "auggie-agent")
 	agentTypeName := profileInfo.AgentName + "-agent"
-	agentConfig, err := m.registry.GetAgentType(agentTypeName)
+	agentConfig, err := m.registry.Get(agentTypeName)
 	if err != nil {
 		return nil, fmt.Errorf("agent type not found: %s", agentTypeName)
 	}

--- a/apps/backend/internal/agent/registry/registry.go
+++ b/apps/backend/internal/agent/registry/registry.go
@@ -194,11 +194,6 @@ func (r *Registry) Get(id string) (*AgentTypeConfig, error) {
 	return config, nil
 }
 
-// GetAgentType is an alias for Get for backward compatibility
-func (r *Registry) GetAgentType(id string) (*AgentTypeConfig, error) {
-	return r.Get(id)
-}
-
 // GetDefault returns the default agent type configuration.
 // It tries "augment-agent" first, then falls back to the first enabled agent.
 func (r *Registry) GetDefault() (*AgentTypeConfig, error) {

--- a/apps/backend/internal/gateway/websocket/client.go
+++ b/apps/backend/internal/gateway/websocket/client.go
@@ -272,10 +272,6 @@ func (c *Client) sendHistoricalLogs(taskID string) {
 	}
 }
 
-// sendPendingPermissions is deprecated. Pending permissions are now stored as messages
-// and sent via sendHistoricalLogs. This function is kept for reference but is unused.
-// func (c *Client) sendPendingPermissions(taskID string) {}
-
 // handleUnsubscribe handles task.unsubscribe action
 func (c *Client) handleUnsubscribe(msg *ws.Message) {
 	var req SubscribeRequest

--- a/apps/backend/internal/gateway/websocket/hub.go
+++ b/apps/backend/internal/gateway/websocket/hub.go
@@ -14,10 +14,6 @@ import (
 // HistoricalLogsProvider is a function that retrieves historical logs for a task
 type HistoricalLogsProvider func(ctx context.Context, taskID string) ([]*ws.Message, error)
 
-// PendingPermissionsProvider is deprecated. Pending permissions are now stored as messages
-// and retrieved via the HistoricalLogsProvider.
-// type PendingPermissionsProvider func(ctx context.Context, taskID string) ([]*ws.Message, error)
-
 // Hub manages all WebSocket client connections
 type Hub struct {
 	// All registered clients
@@ -42,8 +38,6 @@ type Hub struct {
 
 	// Optional provider for historical logs on subscription
 	historicalLogsProvider HistoricalLogsProvider
-	// NOTE: pendingPermissionsProvider is deprecated. Pending permissions are now stored
-	// as messages and retrieved via the historicalLogsProvider.
 
 	mu     sync.RWMutex
 	logger *logger.Logger
@@ -392,11 +386,3 @@ func (h *Hub) GetHistoricalLogs(ctx context.Context, taskID string) ([]*ws.Messa
 	}
 	return h.historicalLogsProvider(ctx, taskID)
 }
-
-// SetPendingPermissionsProvider is deprecated. Pending permissions are now stored as messages
-// and retrieved via the HistoricalLogsProvider. This method is a no-op for backwards compatibility.
-// func (h *Hub) SetPendingPermissionsProvider(provider PendingPermissionsProvider) {}
-
-// GetPendingPermissions is deprecated. Pending permissions are now stored as messages
-// and retrieved via the HistoricalLogsProvider. This method always returns nil.
-// func (h *Hub) GetPendingPermissions(ctx context.Context, taskID string) ([]*ws.Message, error) {}

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -98,7 +98,7 @@ type LaunchAgentResponse struct {
 	WorktreeBranch   string
 }
 
-// TaskExecution tracks an active task execution (kept for API compatibility)
+// TaskExecution tracks an active task execution
 type TaskExecution struct {
 	TaskID           string
 	AgentExecutionID string
@@ -937,17 +937,6 @@ func (e *Executor) MarkCompletedBySession(ctx context.Context, sessionID string,
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 	}
-}
-
-// MarkCompleted marks an execution as completed by task ID (uses most recent session)
-// Deprecated: Use MarkCompletedBySession instead when session ID is available
-func (e *Executor) MarkCompleted(ctx context.Context, taskID string, state v1.TaskSessionState) {
-	ctx2 := context.Background()
-	session, err := e.repo.GetActiveTaskSessionByTaskID(ctx2, taskID)
-	if err != nil {
-		return
-	}
-	e.MarkCompletedBySession(ctx, session.ID, state)
 }
 
 // MockAgentManagerClient is a placeholder implementation

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -47,9 +47,6 @@ func DefaultServiceConfig() ServiceConfig {
 	}
 }
 
-// InputRequestHandler is called when an agent requests user input.
-type InputRequestHandler func(ctx context.Context, taskID, sessionID, agentID, message string) error
-
 // MessageCreator is an interface for creating messages on tasks
 type MessageCreator interface {
 	CreateAgentMessage(ctx context.Context, taskID, content, agentSessionID string) error
@@ -79,9 +76,6 @@ type Service struct {
 	// Agent stream event handlers (for WebSocket streaming)
 	streamHandlers []func(payload *lifecycle.AgentStreamEventPayload)
 	streamMu       sync.RWMutex
-
-	// Input request handler (for agent-user conversation)
-	inputRequestHandler InputRequestHandler
 
 	// Message creator for saving agent responses
 	messageCreator MessageCreator
@@ -695,12 +689,6 @@ func (s *Service) broadcastStreamEvent(payload *lifecycle.AgentStreamEventPayloa
 	for _, handler := range handlers {
 		handler(payload)
 	}
-}
-
-// SetInputRequestHandler sets the handler for agent input requests
-func (s *Service) SetInputRequestHandler(handler InputRequestHandler) {
-	s.inputRequestHandler = handler
-	s.logger.Debug("input request handler set")
 }
 
 // Event handlers


### PR DESCRIPTION
## Summary

Removes deprecated and unused backward compatibility code from the backend.

## Changes

- **agent/registry/registry.go**: Remove \ alias, use \ directly
- **agent/lifecycle/manager.go**: Update caller to use \ instead of \
- **gateway/websocket/hub.go**: Remove deprecated \ comment blocks
- **gateway/websocket/client.go**: Remove deprecated \ comment block
- **orchestrator/executor/executor.go**: Remove deprecated \ method
- **orchestrator/service.go**: Remove unused \ type, field, and \ method
- **cmd/kandev/main.go**: Remove unused \ wiring (~50 lines)

## What was kept

- \ and \ fields on TaskSession (still in use)
- \ route alias (used by frontend SSR)
- Worktree flattening logic (used by frontend)

## Testing

- \ passes