### PR TITLE
test(integration): use temp repo paths

### DIFF
--- a/apps/backend/internal/integration/integration_test.go
+++ b/apps/backend/internal/integration/integration_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -178,11 +180,12 @@ func createWorkspace(t *testing.T, client *WSClient) string {
 func createRepository(t *testing.T, client *WSClient, workspaceID string) string {
 	t.Helper()
 
+	repoPath := createTempRepoDir(t)
 	resp, err := client.SendRequest("repo-1", ws.ActionRepositoryCreate, map[string]interface{}{
 		"workspace_id": workspaceID,
 		"name":         "Test Repo",
 		"source_type":  "local",
-		"local_path":   "/tmp/repo",
+		"local_path":   repoPath,
 	})
 	require.NoError(t, err)
 
@@ -191,6 +194,16 @@ func createRepository(t *testing.T, client *WSClient, workspaceID string) string
 	require.NoError(t, err)
 
 	return payload["id"].(string)
+}
+
+func createTempRepoDir(t *testing.T) string {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	repoPath := filepath.Join(baseDir, "repo")
+	require.NoError(t, os.MkdirAll(repoPath, 0o755))
+
+	return repoPath
 }
 
 // readPump reads messages from the WebSocket connection

--- a/apps/backend/internal/integration/orchestrator_test.go
+++ b/apps/backend/internal/integration/orchestrator_test.go
@@ -645,7 +645,7 @@ func (ts *OrchestratorTestServer) CreateTestTask(t *testing.T, agentProfileID st
 	repository, err := ts.TaskSvc.CreateRepository(context.Background(), &taskservice.CreateRepositoryRequest{
 		WorkspaceID: workspace.ID,
 		Name:        "Test Repo",
-		LocalPath:   "/tmp/repo",
+		LocalPath:   createTempRepoDir(t),
 	})
 	require.NoError(t, err)
 
@@ -1460,7 +1460,7 @@ func TestOrchestratorEndToEndWorkflow(t *testing.T) {
 		"workspace_id": workspaceID,
 		"name":         "Test Repo",
 		"source_type":  "local",
-		"local_path":   "/tmp/repo",
+		"local_path":   createTempRepoDir(t),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Integration tests were relying on shared /tmp paths, which can collide across runs and environments.

Using per-test temp directories makes test runs more isolated and reliable across machines and CI.
