### PR TITLE
fix: refactor shell streaming to use event bus pattern

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -225,16 +225,6 @@ func (a *orchestratorAdapter) ResumeTaskSession(ctx context.Context, taskID, tas
 	return err
 }
 
-// shellSessionResumerAdapter adapts the orchestrator service to the shell handlers' SessionResumer interface
-type shellSessionResumerAdapter struct {
-	svc *orchestrator.Service
-}
-
-func (a *shellSessionResumerAdapter) ResumeTaskSession(ctx context.Context, taskID, taskSessionID string) error {
-	_, err := a.svc.ResumeTaskSession(ctx, taskID, taskSessionID)
-	return err
-}
-
 // messageCreatorAdapter adapts the task service to the orchestrator.MessageCreator interface
 type messageCreatorAdapter struct {
 	svc *taskservice.Service

--- a/apps/backend/cmd/kandev/gateway.go
+++ b/apps/backend/cmd/kandev/gateway.go
@@ -55,10 +55,7 @@ func provideGateway(
 		workspaceFileHandlers.RegisterHandlers(gateway.Dispatcher)
 
 		shellHandlers := agenthandlers.NewShellHandlers(lifecycleMgr, log)
-		shellHandlers.SetHub(gateway.Hub)
-		shellHandlers.SetSessionResumer(&shellSessionResumerAdapter{svc: orchestratorSvc})
 		shellHandlers.RegisterHandlers(gateway.Dispatcher)
-		lifecycleMgr.SetShellStreamStarter(shellHandlers)
 	}
 
 	go gateway.Hub.Run(ctx)

--- a/apps/backend/internal/agent/handlers/shell_handlers.go
+++ b/apps/backend/internal/agent/handlers/shell_handlers.go
@@ -4,57 +4,28 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
 
 	"github.com/kandev/kandev/internal/agent/lifecycle"
-	agentctl "github.com/kandev/kandev/internal/agentctl/client"
 	"github.com/kandev/kandev/internal/common/logger"
 	ws "github.com/kandev/kandev/pkg/websocket"
 	"go.uber.org/zap"
 )
 
-// SessionResumer is an interface for resuming task sessions
-type SessionResumer interface {
-	ResumeTaskSession(ctx context.Context, taskID, taskSessionID string) error
-}
-
-// ShellHandlers provides WebSocket handlers for shell terminal operations
+// ShellHandlers provides WebSocket handlers for shell terminal operations.
+// Shell output is streamed via the lifecycle manager and event bus.
+// This handler provides shell.status, shell.subscribe (for buffer), and shell.input.
 type ShellHandlers struct {
-	lifecycleMgr    *lifecycle.Manager
-	logger          *logger.Logger
-	hub             ShellOutputBroadcaster
-	sessionResumer  SessionResumer
-
-	// Track active shell streams per session
-	activeStreams map[string]context.CancelFunc
-	mu            sync.RWMutex
-
-	// Input channels for sending input to shell streams
-	inputChannels map[string]chan<- agentctl.ShellMessage
-	inputMu       sync.RWMutex
+	lifecycleMgr *lifecycle.Manager
+	logger       *logger.Logger
 }
 
 // NewShellHandlers creates a new ShellHandlers instance
 func NewShellHandlers(lifecycleMgr *lifecycle.Manager, log *logger.Logger) *ShellHandlers {
 	return &ShellHandlers{
-		lifecycleMgr:  lifecycleMgr,
-		logger:        log.WithFields(zap.String("component", "shell_handlers")),
-		activeStreams: make(map[string]context.CancelFunc),
-		inputChannels: make(map[string]chan<- agentctl.ShellMessage),
+		lifecycleMgr: lifecycleMgr,
+		logger:       log.WithFields(zap.String("component", "shell_handlers")),
 	}
 }
-
-// SetHub sets the hub for broadcasting shell output
-func (h *ShellHandlers) SetHub(hub ShellOutputBroadcaster) {
-	h.hub = hub
-}
-
-// SetSessionResumer sets the session resumer for auto-resuming sessions on shell subscribe
-func (h *ShellHandlers) SetSessionResumer(resumer SessionResumer) {
-	h.sessionResumer = resumer
-}
-
 
 // RegisterHandlers registers shell handlers with the WebSocket dispatcher
 func (h *ShellHandlers) RegisterHandlers(d *ws.Dispatcher) {
@@ -126,7 +97,9 @@ type ShellSubscribeRequest struct {
 	SessionID string `json:"session_id"`
 }
 
-// wsShellSubscribe subscribes to shell output for a session and starts the shell stream if needed
+// wsShellSubscribe subscribes to shell output for a session.
+// Shell output is streamed via the event bus (lifecycle manager handles this).
+// This endpoint returns the buffered shell output for catchup.
 func (h *ShellHandlers) wsShellSubscribe(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
 	var req ShellSubscribeRequest
 	if err := msg.ParsePayload(&req); err != nil {
@@ -143,13 +116,9 @@ func (h *ShellHandlers) wsShellSubscribe(ctx context.Context, msg *ws.Message) (
 		return nil, fmt.Errorf("no agent running for session %s", req.SessionID)
 	}
 
-	// Start the shell stream (idempotent - does nothing if already running)
-	if err := h.StartShellStream(ctx, req.SessionID); err != nil {
-		return nil, fmt.Errorf("failed to start shell stream: %w", err)
-	}
-
 	// Get buffered output to include in response
 	// This ensures client gets current shell state without duplicate broadcasts
+	// Shell output streaming is handled by the lifecycle manager via event bus
 	buffer := ""
 	if client := execution.GetAgentCtlClient(); client != nil {
 		if b, err := client.ShellBuffer(ctx); err == nil {
@@ -175,169 +144,23 @@ func (h *ShellHandlers) wsShellInput(ctx context.Context, msg *ws.Message) (*ws.
 		return nil, fmt.Errorf("session_id is required")
 	}
 
-	// Verify the agent execution exists for this session
-	if _, ok := h.lifecycleMgr.GetExecutionBySessionID(req.SessionID); !ok {
+	// Get the agent execution for this session
+	execution, ok := h.lifecycleMgr.GetExecutionBySessionID(req.SessionID)
+	if !ok {
 		return nil, fmt.Errorf("no agent running for session %s", req.SessionID)
 	}
 
-	// Send input via the shell stream
-	if err := h.SendShellInput(req.SessionID, req.Data); err != nil {
-		return nil, err
+	// Use the workspace stream from AgentExecution (managed by lifecycle)
+	workspaceStream := execution.GetWorkspaceStream()
+	if workspaceStream == nil {
+		return nil, fmt.Errorf("no workspace stream for session %s", req.SessionID)
+	}
+
+	if err := workspaceStream.WriteShellInput(req.Data); err != nil {
+		return nil, fmt.Errorf("failed to send shell input: %w", err)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 		"success": true,
 	})
-}
-
-// StartShellStream starts streaming shell output for a session using the configured hub.
-// This implements the lifecycle.ShellStreamStarter interface.
-func (h *ShellHandlers) StartShellStream(ctx context.Context, sessionID string) error {
-	if h.hub == nil {
-		return fmt.Errorf("hub not configured")
-	}
-	return h.StartShellStreamWithHub(ctx, sessionID, h.hub)
-}
-
-// StartShellStreamWithHub starts streaming shell output for a session to a specific hub
-func (h *ShellHandlers) StartShellStreamWithHub(ctx context.Context, sessionID string, hub ShellOutputBroadcaster) error {
-	h.mu.Lock()
-	if _, exists := h.activeStreams[sessionID]; exists {
-		h.mu.Unlock()
-		return nil // Already streaming
-	}
-
-	streamCtx, cancel := context.WithCancel(context.Background()) // Use background context so stream survives request
-	h.activeStreams[sessionID] = cancel
-	h.mu.Unlock()
-
-	// Use a channel to wait for stream setup to complete
-	readyCh := make(chan error, 1)
-	go h.runShellStreamWithReady(streamCtx, sessionID, hub, readyCh)
-
-	// Wait for stream to be ready (or fail)
-	select {
-	case err := <-readyCh:
-		return err
-	case <-ctx.Done():
-		cancel()
-		return ctx.Err()
-	}
-}
-
-// StopShellStream stops the shell stream for a session
-func (h *ShellHandlers) StopShellStream(sessionID string) {
-	h.mu.Lock()
-	if cancel, exists := h.activeStreams[sessionID]; exists {
-		cancel()
-		delete(h.activeStreams, sessionID)
-	}
-	h.mu.Unlock()
-}
-
-// ShellOutputBroadcaster interface for broadcasting shell output
-type ShellOutputBroadcaster interface {
-	BroadcastToSession(sessionID string, msg *ws.Message)
-}
-
-// runShellStreamWithReady runs the shell output stream for a session and signals when ready
-func (h *ShellHandlers) runShellStreamWithReady(ctx context.Context, sessionID string, hub ShellOutputBroadcaster, readyCh chan<- error) {
-	defer func() {
-		h.mu.Lock()
-		delete(h.activeStreams, sessionID)
-		h.mu.Unlock()
-	}()
-
-	execution, ok := h.lifecycleMgr.GetExecutionBySessionID(sessionID)
-	if !ok {
-		h.logger.Debug("no agent execution for shell stream", zap.String("session_id", sessionID))
-		readyCh <- fmt.Errorf("no agent execution for session %s", sessionID)
-		return
-	}
-
-	client := execution.GetAgentCtlClient()
-	if client == nil {
-		h.logger.Debug("no client for shell stream", zap.String("session_id", sessionID))
-		readyCh <- fmt.Errorf("no agent client for session %s", sessionID)
-		return
-	}
-
-	if err := client.WaitForReady(ctx, 10*time.Second); err != nil {
-		h.logger.Error("agentctl not ready for shell stream", zap.String("session_id", sessionID), zap.Error(err))
-		readyCh <- fmt.Errorf("agentctl not ready: %w", err)
-		return
-	}
-
-	outputCh, inputCh, err := client.StreamShell(ctx)
-	if err != nil {
-		h.logger.Error("failed to start shell stream", zap.String("session_id", sessionID), zap.Error(err))
-		readyCh <- fmt.Errorf("failed to start shell stream: %w", err)
-		return
-	}
-
-	// Store input channel for sending input
-	h.storeInputChannel(sessionID, inputCh)
-	defer h.removeInputChannel(sessionID)
-
-	h.logger.Info("shell stream started", zap.String("session_id", sessionID))
-
-	// Signal that we're ready - input channel is now stored
-	readyCh <- nil
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case msg, ok := <-outputCh:
-			if !ok {
-				return
-			}
-			// Broadcast shell output to session subscribers
-			notification, err := ws.NewNotification(ws.ActionShellOutput, map[string]interface{}{
-				"session_id": sessionID,
-				"type":       msg.Type,
-				"data":       msg.Data,
-				"code":       msg.Code,
-			})
-			if err != nil {
-				h.logger.Debug("failed to create shell output notification", zap.Error(err))
-				continue
-			}
-			hub.BroadcastToSession(sessionID, notification)
-		}
-	}
-}
-
-
-func (h *ShellHandlers) storeInputChannel(sessionID string, ch chan<- agentctl.ShellMessage) {
-	h.inputMu.Lock()
-	h.inputChannels[sessionID] = ch
-	h.inputMu.Unlock()
-}
-
-func (h *ShellHandlers) removeInputChannel(sessionID string) {
-	h.inputMu.Lock()
-	if ch, exists := h.inputChannels[sessionID]; exists {
-		close(ch)
-		delete(h.inputChannels, sessionID)
-	}
-	h.inputMu.Unlock()
-}
-
-// SendShellInput sends input to an active shell stream
-func (h *ShellHandlers) SendShellInput(sessionID, data string) error {
-	h.inputMu.RLock()
-	ch, exists := h.inputChannels[sessionID]
-	h.inputMu.RUnlock()
-
-	if !exists {
-		return fmt.Errorf("no active shell stream for session %s", sessionID)
-	}
-
-	select {
-	case ch <- agentctl.ShellMessage{Type: "input", Data: data}:
-		return nil
-	default:
-		return fmt.Errorf("shell input channel full")
-	}
 }

--- a/apps/backend/internal/agent/handlers/shell_handlers_test.go
+++ b/apps/backend/internal/agent/handlers/shell_handlers_test.go
@@ -91,12 +91,6 @@ func TestNewShellHandlers(t *testing.T) {
 	if handlers.logger == nil {
 		t.Error("expected non-nil logger")
 	}
-	if handlers.activeStreams == nil {
-		t.Error("expected non-nil activeStreams map")
-	}
-	if handlers.inputChannels == nil {
-		t.Error("expected non-nil inputChannels map")
-	}
 }
 
 func TestRegisterHandlers(t *testing.T) {
@@ -263,29 +257,6 @@ func TestWsShellInput_NoInstanceFound(t *testing.T) {
 	if err.Error() != expectedErr {
 		t.Errorf("expected '%s', got: %v", expectedErr, err)
 	}
-}
-
-func TestSendShellInput_NoActiveStream(t *testing.T) {
-	log := newTestLogger()
-	handlers := NewShellHandlers(nil, log)
-
-	err := handlers.SendShellInput("non-existent-session", "test input")
-	if err == nil {
-		t.Error("expected error for non-existent stream")
-	}
-	expectedErr := "no active shell stream for session non-existent-session"
-	if err.Error() != expectedErr {
-		t.Errorf("expected '%s', got: %v", expectedErr, err)
-	}
-}
-
-func TestStopShellStream_NonExistent(t *testing.T) {
-	log := newTestLogger()
-	handlers := NewShellHandlers(nil, log)
-
-	// StopShellStream should not panic when called with non-existent sessionID
-	handlers.StopShellStream("non-existent-session")
-	// No panic = success
 }
 
 func TestNewShellHandlers_WithManager(t *testing.T) {

--- a/apps/backend/internal/agent/lifecycle/event_types.go
+++ b/apps/backend/internal/agent/lifecycle/event_types.go
@@ -108,3 +108,32 @@ type PermissionRequestEventPayload struct {
 	ActionDetails map[string]interface{} `json:"action_details,omitempty"`
 }
 
+// ShellOutputEventPayload is the payload for shell output events.
+type ShellOutputEventPayload struct {
+	TaskID    string `json:"task_id"`
+	SessionID string `json:"session_id"`
+	AgentID   string `json:"agent_id"`
+	Type      string `json:"type"` // Always "output" for shell output events
+	Data      string `json:"data"`
+	Timestamp string `json:"timestamp"`
+}
+
+// GetSessionID returns the session ID for this event (used by event routing).
+func (p ShellOutputEventPayload) GetSessionID() string {
+	return p.SessionID
+}
+
+// ShellExitEventPayload is the payload for shell exit events.
+type ShellExitEventPayload struct {
+	TaskID    string `json:"task_id"`
+	SessionID string `json:"session_id"`
+	AgentID   string `json:"agent_id"`
+	Type      string `json:"type"` // Always "exit" for shell exit events
+	Code      int    `json:"code"` // Exit code
+	Timestamp string `json:"timestamp"`
+}
+
+// GetSessionID returns the session ID for this event (used by event routing).
+func (p ShellExitEventPayload) GetSessionID() string {
+	return p.SessionID
+}

--- a/apps/backend/internal/agentctl/types/streams/doc.go
+++ b/apps/backend/internal/agentctl/types/streams/doc.go
@@ -27,24 +27,28 @@
 //
 // Message type: PermissionNotification
 //
-// # Git Status Stream (/api/v1/workspace/git-status/stream)
+// # Unified Workspace Stream (/api/v1/workspace/stream)
 //
-// Streams git status updates when the workspace state changes.
+// Bidirectional WebSocket that consolidates all workspace-related streams:
+//   - Shell I/O (input, output, exit, resize)
+//   - Git status updates
+//   - File change notifications
+//   - File list updates
+//   - Ping/pong keepalive
 //
-// Message type: GitStatusUpdate
+// Message type: WorkspaceStreamMessage (defined in types/types.go)
 //
-// # File Changes Stream (/api/v1/workspace/file-changes/stream)
-//
-// Streams file system change notifications when files are created,
-// modified, deleted, or renamed in the workspace.
-//
-// Message type: FileChangeNotification
-//
-// # Shell Stream (/api/v1/shell/stream)
-//
-// Bidirectional WebSocket for interactive shell I/O.
-//
-// Message type: ShellMessage (input/output/ping/pong/exit)
+// Message types (use WorkspaceMsg* constants):
+//   - shell_output: Shell output data
+//   - shell_input: Shell input data (client -> server)
+//   - shell_exit: Shell process exited
+//   - shell_resize: Terminal resize (client -> server)
+//   - git_status: Git status update
+//   - file_change: File change notification
+//   - file_list: File list update
+//   - ping/pong: Keepalive messages
+//   - connected: Connection established
+//   - error: Error occurred
 //
 // All streams use JSON-encoded messages over WebSocket connections.
 package streams

--- a/apps/backend/internal/agentctl/types/types.go
+++ b/apps/backend/internal/agentctl/types/types.go
@@ -6,6 +6,7 @@ package types
 
 import (
 	"context"
+	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 )
@@ -111,14 +112,135 @@ type PermissionResponse struct {
 // PermissionHandler is called when the agent requests permission for an action.
 type PermissionHandler func(ctx context.Context, req *PermissionRequest) (*PermissionResponse, error)
 
-// Subscriber types for internal use.
-type (
-	// GitStatusSubscriber is a channel that receives git status updates.
-	GitStatusSubscriber chan GitStatusUpdate
+// WorkspaceMessageType represents the type of workspace stream message
+type WorkspaceMessageType string
 
-	// FilesSubscriber is a channel that receives file listing updates.
-	FilesSubscriber chan FileListUpdate
-
-	// FileChangeSubscriber is a channel that receives file change notifications.
-	FileChangeSubscriber chan FileChangeNotification
+const (
+	// Workspace stream message types
+	WorkspaceMessageTypeShellOutput WorkspaceMessageType = "shell_output"
+	WorkspaceMessageTypeShellInput  WorkspaceMessageType = "shell_input"
+	WorkspaceMessageTypeShellExit   WorkspaceMessageType = "shell_exit"
+	WorkspaceMessageTypePing        WorkspaceMessageType = "ping"
+	WorkspaceMessageTypePong        WorkspaceMessageType = "pong"
+	WorkspaceMessageTypeGitStatus   WorkspaceMessageType = "git_status"
+	WorkspaceMessageTypeFileChange  WorkspaceMessageType = "file_change"
+	WorkspaceMessageTypeFileList    WorkspaceMessageType = "file_list"
+	WorkspaceMessageTypeError       WorkspaceMessageType = "error"
+	WorkspaceMessageTypeConnected   WorkspaceMessageType = "connected"
+	WorkspaceMessageTypeShellResize WorkspaceMessageType = "shell_resize"
 )
+
+// WorkspaceStreamMessage is the unified message format for the workspace stream.
+// It carries all workspace events (shell I/O, git status, file changes) with
+// message type differentiation.
+type WorkspaceStreamMessage struct {
+	Type      WorkspaceMessageType `json:"type"`
+	Timestamp int64                `json:"timestamp"` // Unix milliseconds
+
+	// Shell fields (for shell_output, shell_input, shell_exit)
+	Data string `json:"data,omitempty"` // Shell output or input data
+	Code int    `json:"code,omitempty"` // Exit code for shell_exit
+
+	// Shell resize fields (for shell_resize)
+	Cols int `json:"cols,omitempty"`
+	Rows int `json:"rows,omitempty"`
+
+	// Git status fields (for git_status)
+	GitStatus *GitStatusUpdate `json:"git_status,omitempty"`
+
+	// File change fields (for file_change)
+	FileChange *FileChangeNotification `json:"file_change,omitempty"`
+
+	// File list fields (for file_list)
+	FileList *FileListUpdate `json:"file_list,omitempty"`
+
+	// Error fields (for error)
+	Error string `json:"error,omitempty"`
+}
+
+// NewWorkspaceShellOutput creates a shell output message
+func NewWorkspaceShellOutput(data string) WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypeShellOutput,
+		Timestamp: timeNowUnixMilli(),
+		Data:      data,
+	}
+}
+
+// NewWorkspaceShellInput creates a shell input message
+func NewWorkspaceShellInput(data string) WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypeShellInput,
+		Timestamp: timeNowUnixMilli(),
+		Data:      data,
+	}
+}
+
+// NewWorkspaceGitStatus creates a git status message
+func NewWorkspaceGitStatus(status *GitStatusUpdate) WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypeGitStatus,
+		Timestamp: timeNowUnixMilli(),
+		GitStatus: status,
+	}
+}
+
+// NewWorkspaceFileChange creates a file change message
+func NewWorkspaceFileChange(notification *FileChangeNotification) WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:       WorkspaceMessageTypeFileChange,
+		Timestamp:  timeNowUnixMilli(),
+		FileChange: notification,
+	}
+}
+
+// NewWorkspaceFileList creates a file list message
+func NewWorkspaceFileList(update *FileListUpdate) WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypeFileList,
+		Timestamp: timeNowUnixMilli(),
+		FileList:  update,
+	}
+}
+
+// NewWorkspacePong creates a pong message
+func NewWorkspacePong() WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypePong,
+		Timestamp: timeNowUnixMilli(),
+	}
+}
+
+// NewWorkspaceConnected creates a connected message
+func NewWorkspaceConnected() WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypeConnected,
+		Timestamp: timeNowUnixMilli(),
+	}
+}
+
+// NewWorkspacePing creates a ping message
+func NewWorkspacePing() WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypePing,
+		Timestamp: timeNowUnixMilli(),
+	}
+}
+
+// NewWorkspaceShellResize creates a shell resize message
+func NewWorkspaceShellResize(cols, rows int) WorkspaceStreamMessage {
+	return WorkspaceStreamMessage{
+		Type:      WorkspaceMessageTypeShellResize,
+		Timestamp: timeNowUnixMilli(),
+		Cols:      cols,
+		Rows:      rows,
+	}
+}
+
+// WorkspaceStreamSubscriber is a channel that receives unified workspace messages
+type WorkspaceStreamSubscriber chan WorkspaceStreamMessage
+
+// timeNowUnixMilli returns current time in unix milliseconds
+func timeNowUnixMilli() int64 {
+	return time.Now().UnixMilli()
+}

--- a/apps/backend/internal/events/types.go
+++ b/apps/backend/internal/events/types.go
@@ -104,6 +104,32 @@ const (
 	FileChangeNotified = "file.change.notified" // File changed in workspace
 )
 
+// Event types for shell I/O
+const (
+	ShellOutput = "shell.output" // Shell output data
+	ShellExit   = "shell.exit"   // Shell process exited
+)
+
+// BuildShellOutputSubject creates a shell output subject for a specific session
+func BuildShellOutputSubject(sessionID string) string {
+	return ShellOutput + "." + sessionID
+}
+
+// BuildShellOutputWildcardSubject creates a wildcard subscription for all shell output events
+func BuildShellOutputWildcardSubject() string {
+	return ShellOutput + ".*"
+}
+
+// BuildShellExitSubject creates a shell exit subject for a specific session
+func BuildShellExitSubject(sessionID string) string {
+	return ShellExit + "." + sessionID
+}
+
+// BuildShellExitWildcardSubject creates a wildcard subscription for all shell exit events
+func BuildShellExitWildcardSubject() string {
+	return ShellExit + ".*"
+}
+
 // BuildAgentStreamSubject creates an agent stream subject for a specific session
 func BuildAgentStreamSubject(sessionID string) string {
 	return AgentStream + "." + sessionID

--- a/apps/backend/pkg/websocket/actions.go
+++ b/apps/backend/pkg/websocket/actions.go
@@ -159,10 +159,10 @@ const (
 	ActionWorkspaceFileChanges    = "session.workspace.file.changes" // Notification
 
 	// Shell actions
-	ActionShellStatus    = "session.shell.status" // Get shell status
-	ActionShellSubscribe = "shell.subscribe"      // Subscribe to shell output
-	ActionShellInput     = "shell.input"          // Send input to shell
-	ActionShellOutput    = "session.shell.output" // Shell output notification
+	ActionShellStatus        = "session.shell.status" // Get shell status
+	ActionShellSubscribe     = "shell.subscribe"      // Subscribe to shell output
+	ActionShellInput         = "shell.input"          // Send input to shell
+	ActionSessionShellOutput = "session.shell.output" // Shell output notification (also used for exit with type: "exit")
 
 	// User actions
 	ActionUserGet             = "user.get"


### PR DESCRIPTION
## Summary

Refactors shell output/exit streaming to follow the event bus pattern (matching git status and file changes), and fixes the file browser race condition.

## Changes

### Backend - Shell Streaming Refactor
- Shell output now flows through the proper event bus:
  `StreamManager → Manager handlers → EventPublisher → EventBus → main.go subscribers → Hub.BroadcastToSession()`
- Added `Type` field to shell payloads (`"output"` or `"exit"`) for frontend compatibility
- Both output and exit events are now sent via `session.shell.output` action with a type discriminator

### Code Cleanup
- Removed unused interfaces: `ShellOutputBroadcaster`, `SessionResumer`
- Removed unused struct: `shellSessionResumerAdapter`
- Removed unused fields from `ShellHandlers`: `hub`, `sessionResumer`
- Removed dead code:
  - `NotifyWorkspaceStreamShellOutput/Exit` methods
  - `NewWorkspaceShellExit`, `NewWorkspaceError` functions
- Cleaned up duplicate/unused websocket action constants

### Frontend - File Browser Fix
- Removed `isReady` gate from `file-browser.tsx`
- File tree now loads immediately without waiting for `agentctl_ready` event
- Fixes race condition where file tree wouldn't load if the ready event was missed

## Testing
- All backend tests pass
- `staticcheck` passes
- `deadcode` passes (only test-only function flagged)