### PR TITLE
fix: bind KANDEV_AGENT_STANDALONE_PORT env var to config

### DIFF
--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -193,6 +193,12 @@ func LoadWithPath(configPath string) (*Config, error) {
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 
+	// Explicit bindings for snake_case env vars (camelCase config keys)
+	// AutomaticEnv does not handle camelCase to SNAKE_CASE conversion,
+	// so we explicitly bind keys where env var naming differs from config key naming.
+	_ = v.BindEnv("agent.standalonePort", "KANDEV_AGENT_STANDALONE_PORT")
+	_ = v.BindEnv("agent.standaloneHost", "KANDEV_AGENT_STANDALONE_HOST")
+
 	// Configure config file
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")


### PR DESCRIPTION
## Problem

When running `make dev`, if port 9999 is busy, the system should automatically find and use an available port. However, it was failing with:

```
port 9999 not available: listen tcp 127.0.0.1:9999: bind
```

## Root Cause

Viper's `AutomaticEnv()` with `SetEnvKeyReplacer(strings.NewReplacer(".", "_"))` only converts dots to underscores, but does **not** handle camelCase to SNAKE_CASE conversion.

| Config Key | Viper expects | CLI sets |
|------------|---------------|----------|
| `server.port` | `KANDEV_SERVER_PORT` | `KANDEV_SERVER_PORT` ✅ |
| `agent.standalonePort` | `KANDEV_AGENT_STANDALONEPORT` | `KANDEV_AGENT_STANDALONE_PORT` ❌ |

This caused the CLI's dynamically picked port to be ignored, and the launcher always defaulted to 9999.

## Fix

Add explicit `BindEnv` calls for snake_case env vars that map to camelCase config keys:

```go
_ = v.BindEnv("agent.standalonePort", "KANDEV_AGENT_STANDALONE_PORT")
_ = v.BindEnv("agent.standaloneHost", "KANDEV_AGENT_STANDALONE_HOST")
```

## Testing

Verified with a test program that the env var is now correctly read:

```
With BindEnv: agent.standalonePort = 54321
Without BindEnv: agent.standalonePort = 9999
```
