### PR TITLE
feat: implement turn cancellation for agent sessions

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -172,6 +172,11 @@ func (a *lifecycleAdapter) PromptAgent(ctx context.Context, agentInstanceID stri
 	}, nil
 }
 
+// CancelAgent interrupts the current agent turn without terminating the process.
+func (a *lifecycleAdapter) CancelAgent(ctx context.Context, sessionID string) error {
+	return a.mgr.CancelAgentBySessionID(ctx, sessionID)
+}
+
 // RespondToPermissionBySessionID sends a response to a permission request for a session
 func (a *lifecycleAdapter) RespondToPermissionBySessionID(ctx context.Context, sessionID, pendingID, optionID string, cancelled bool) error {
 	return a.mgr.RespondToPermissionBySessionID(sessionID, pendingID, optionID, cancelled)

--- a/apps/backend/internal/agentctl/server/api/server.go
+++ b/apps/backend/internal/agentctl/server/api/server.go
@@ -69,6 +69,7 @@ func (s *Server) setupRoutes() {
 		api.POST("/acp/session/new", s.handleACPNewSession)
 		api.POST("/acp/session/load", s.handleACPLoadSession)
 		api.POST("/acp/prompt", s.handleACPPrompt)
+		api.POST("/acp/cancel", s.handleACPCancel)
 		api.GET("/acp/stream", s.handleACPStreamWS)
 
 		// Permission request handling

--- a/apps/backend/internal/integration/orchestrator_test.go
+++ b/apps/backend/internal/integration/orchestrator_test.go
@@ -451,6 +451,13 @@ func (s *SimulatedAgentManagerClient) CleanupStaleExecutionBySessionID(ctx conte
 	return nil
 }
 
+// CancelAgent cancels the current agent turn for a session
+func (s *SimulatedAgentManagerClient) CancelAgent(ctx context.Context, sessionID string) error {
+	s.logger.Info("simulated: cancelling agent turn",
+		zap.String("session_id", sessionID))
+	return nil
+}
+
 // ============================================
 // ORCHESTRATOR TEST SERVER
 // ============================================

--- a/apps/backend/internal/orchestrator/controller/controller.go
+++ b/apps/backend/internal/orchestrator/controller/controller.go
@@ -175,6 +175,18 @@ func (c *Controller) RespondToPermission(ctx context.Context, req dto.Permission
 	}, nil
 }
 
+// CancelAgent interrupts the current agent turn without terminating the process.
+func (c *Controller) CancelAgent(ctx context.Context, req dto.CancelAgentRequest) (dto.CancelAgentResponse, error) {
+	if err := c.service.CancelAgent(ctx, req.SessionID); err != nil {
+		return dto.CancelAgentResponse{}, err
+	}
+
+	return dto.CancelAgentResponse{
+		Success:   true,
+		SessionID: req.SessionID,
+	}, nil
+}
+
 // GetTaskExecution returns the execution state for a task
 func (c *Controller) GetTaskExecution(ctx context.Context, req dto.GetTaskExecutionRequest) (dto.TaskExecutionResponse, error) {
 	execution, exists := c.service.GetTaskExecution(req.TaskID)

--- a/apps/backend/internal/orchestrator/dto/dto.go
+++ b/apps/backend/internal/orchestrator/dto/dto.go
@@ -173,3 +173,14 @@ type TaskExecutionResponse struct {
 	Progress         int    `json:"progress,omitempty"`
 	StartedAt        string `json:"started_at,omitempty"`
 }
+
+// CancelAgentRequest is the payload for the agent.cancel WebSocket action.
+type CancelAgentRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+// CancelAgentResponse is the response for the agent.cancel WebSocket action.
+type CancelAgentResponse struct {
+	Success   bool   `json:"success"`
+	SessionID string `json:"session_id"`
+}

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -51,6 +51,9 @@ type AgentManagerClient interface {
 	// Returns PromptResult indicating if the agent needs input
 	PromptAgent(ctx context.Context, agentExecutionID string, prompt string) (*PromptResult, error)
 
+	// CancelAgent interrupts the current agent turn without terminating the process.
+	CancelAgent(ctx context.Context, sessionID string) error
+
 	// RespondToPermission sends a response to a permission request
 	RespondToPermissionBySessionID(ctx context.Context, sessionID, pendingID, optionID string, cancelled bool) error
 
@@ -1006,6 +1009,13 @@ func (m *MockAgentManagerClient) RespondToPermissionBySessionID(ctx context.Cont
 		zap.String("pending_id", pendingID),
 		zap.String("option_id", optionID),
 		zap.Bool("cancelled", cancelled))
+	return nil
+}
+
+// CancelAgent mocks cancelling the current agent turn
+func (m *MockAgentManagerClient) CancelAgent(ctx context.Context, sessionID string) error {
+	m.logger.Info("mock: cancelling agent turn",
+		zap.String("session_id", sessionID))
 	return nil
 }
 

--- a/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
+++ b/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
@@ -82,6 +82,10 @@ func (m *mockAgentManager) CleanupStaleExecutionBySessionID(ctx context.Context,
 	return nil
 }
 
+func (m *mockAgentManager) CancelAgent(ctx context.Context, sessionID string) error {
+	return nil
+}
+
 // testTaskRepository is an in-memory task repository for testing
 type testTaskRepository struct {
 	tasks map[string]*v1.Task

--- a/apps/web/components/task/chat/messages/status-message.tsx
+++ b/apps/web/components/task/chat/messages/status-message.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { IconAlertTriangle, IconInfoCircle, IconPointFilled } from '@tabler/icons-react';
+import { IconAlertTriangle, IconInfoCircle, IconPointFilled, IconHandStop } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
 import type { Message } from '@/lib/types/http';
 import type { StatusMetadata } from '@/components/task/chat/types';
@@ -11,10 +11,11 @@ export function StatusMessage({ comment }: { comment: Message }) {
     typeof metadata?.progress === 'number' ? Math.min(Math.max(metadata.progress, 0), 100) : null;
   const statusLine = metadata?.stage || metadata?.status;
   const message = metadata?.message || comment.content || statusLine || 'Status update';
-  const isError = comment.type === 'error';
+  const isError = comment.type === 'error' || metadata?.variant === 'error';
+  const isWarning = metadata?.variant === 'warning' || metadata?.cancelled === true;
 
   // Simple system message: no metadata, no progress, just a short message
-  const isSimpleStatus = !isError && progress === null && !statusLine && !metadata?.message;
+  const isSimpleStatus = !isError && !isWarning && progress === null && !statusLine && !metadata?.message;
 
   if (isSimpleStatus) {
     return (
@@ -27,8 +28,21 @@ export function StatusMessage({ comment }: { comment: Message }) {
     );
   }
 
-  const Icon = isError ? IconAlertTriangle : IconInfoCircle;
-  const iconClass = isError ? 'text-red-500' : 'text-muted-foreground';
+  // Cancelled turn gets a special compact warning style
+  if (metadata?.cancelled) {
+    return (
+      <div className="flex items-center justify-center py-1">
+        <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/30 text-xs text-amber-600 dark:text-amber-400">
+          <IconHandStop className="h-3 w-3" />
+          <span>{message}</span>
+        </div>
+      </div>
+    );
+  }
+
+  const Icon = isError ? IconAlertTriangle : isWarning ? IconAlertTriangle : IconInfoCircle;
+  const iconClass = isError ? 'text-red-500' : isWarning ? 'text-amber-500' : 'text-muted-foreground';
+  const label = isError ? 'Error' : isWarning ? 'Warning' : 'Status';
 
   return (
     <div
@@ -36,12 +50,14 @@ export function StatusMessage({ comment }: { comment: Message }) {
         'w-full rounded-lg border px-4 py-3 text-sm',
         isError
           ? 'border-red-500/40 bg-red-500/10 text-foreground'
+          : isWarning
+          ? 'border-amber-500/40 bg-amber-500/10 text-foreground'
           : 'border-border/60 bg-muted/30 text-foreground'
       )}
     >
       <div className="flex items-center gap-2 mb-2 text-[11px] uppercase tracking-wide opacity-70">
         <Icon className={cn('h-3.5 w-3.5', iconClass)} />
-        <span>{isError ? 'Error' : 'Status'}</span>
+        <span>{label}</span>
       </div>
       <div className="whitespace-pre-wrap">{message}</div>
       {progress !== null && (

--- a/apps/web/components/task/chat/types.ts
+++ b/apps/web/components/task/chat/types.ts
@@ -14,6 +14,8 @@ export type StatusMetadata = {
   status?: string;
   stage?: string;
   message?: string;
+  variant?: 'default' | 'warning' | 'error';
+  cancelled?: boolean;
 };
 
 export type TodoMetadata =

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -250,6 +250,20 @@ export function TaskChatPanel({
     );
   }, [resolvedSessionId, taskId]);
 
+  // Cancels the current agent turn without terminating the agent process,
+  // allowing the user to interrupt and send a new prompt.
+  const handleCancelTurn = useCallback(async () => {
+    if (!resolvedSessionId) return;
+    const client = getWebSocketClient();
+    if (!client) return;
+
+    try {
+      await client.request('agent.cancel', { session_id: resolvedSessionId }, 15000);
+    } catch (error) {
+      console.error('Failed to cancel agent turn:', error);
+    }
+  }, [resolvedSessionId]);
+
   const handleSubmit = async (event?: FormEvent) => {
     event?.preventDefault();
     const trimmed = messageInput.trim();
@@ -428,6 +442,7 @@ export function TaskChatPanel({
                 variant={isAgentBusy ? 'destructive' : 'default'}
                 className={cn('h-7', isAgentBusy && 'gap-2')}
                 disabled={isStarting || isSending}
+                onClick={isAgentBusy ? handleCancelTurn : undefined}
               >
                 {isAgentBusy ? (
                   <>


### PR DESCRIPTION
## Summary

Add the ability to cancel an agent's current turn without terminating the agent process. This allows users to interrupt long-running operations and send a new prompt without restarting the session.

## Changes

### Backend
- Add `agent.cancel` WebSocket action and handler
- Add `CancelAgent` method to orchestrator service and controller
- Add Cancel endpoint to agentctl HTTP API (`/api/v1/acp/cancel`)
- Add `CancelAgent` to lifecycle manager (delegates to agentctl)
- Update session state to `WAITING_FOR_INPUT` after cancellation
- Create status message with cancelled metadata for UI feedback

### Frontend
- Wire Stop button `onClick` handler in `TaskChatPanel`
- Add `cancelled`/`variant` metadata support in `StatusMessage` component
- Display amber badge for cancelled turns in chat history

### Code Cleanup
- Remove unused `handleCancelTurn` from `use-session-agent` hook
- Standardize comments to use 'interrupts the current agent turn' pattern
- Remove verbose debug `console.log` statements

## Testing
- All backend tests pass (`go test ./...`)
- Frontend build passes (`pnpm build`)
- Manual testing confirms cancellation works end-to-end

## Files Changed (15)
- `apps/backend/cmd/kandev/adapters.go`
- `apps/backend/internal/agent/lifecycle/manager.go`
- `apps/backend/internal/agentctl/client/acp.go`
- `apps/backend/internal/agentctl/server/api/acp.go`
- `apps/backend/internal/agentctl/server/api/server.go`
- `apps/backend/internal/integration/orchestrator_test.go`
- `apps/backend/internal/orchestrator/controller/controller.go`
- `apps/backend/internal/orchestrator/dto/dto.go`
- `apps/backend/internal/orchestrator/executor/executor.go`
- `apps/backend/internal/orchestrator/handlers/handlers.go`
- `apps/backend/internal/orchestrator/scheduler/scheduler_test.go`
- `apps/backend/internal/orchestrator/service.go`
- `apps/web/components/task/chat/messages/status-message.tsx`
- `apps/web/components/task/chat/types.ts`
- `apps/web/components/task/task-chat-panel.tsx`