### PR TITLE
Improve agent message rendering with better spacing and inline code styling

### DIFF
--- a/apps/web/components/task/chat/messages/chat-message.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.tsx
@@ -48,8 +48,102 @@ export function ChatMessage({ comment, label, className, showRichBlocks }: ChatM
       {isUser ? (
         <p className="whitespace-pre-wrap">{comment.content || '(empty)'}</p>
       ) : (
-        <div className="prose prose-sm dark:prose-invert max-w-none prose-p:my-2 prose-p:leading-relaxed prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 prose-pre:my-3 prose-code:px-1.5 prose-code:py-0.5 prose-code:bg-background/50 prose-code:rounded prose-code:text-xs prose-code:before:content-none prose-code:after:content-none prose-pre:bg-background/80 prose-pre:text-xs prose-strong:text-foreground prose-headings:text-foreground">
-          <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+        <div className="prose prose-sm dark:prose-invert max-w-none prose-p:my-4 prose-p:leading-relaxed prose-ul:my-4 prose-ul:list-disc prose-ul:pl-6 prose-ol:my-4 prose-ol:list-decimal prose-ol:pl-6 prose-li:my-1.5 prose-pre:my-5 prose-strong:text-foreground prose-strong:font-bold prose-headings:text-foreground prose-headings:font-bold">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkBreaks]}
+            components={{
+              code: ({ node, className, children, ...props }) => {
+                // Check if it's inline code (no className means inline, className with language-* means code block)
+                const isInline = !className || !className.startsWith('language-');
+
+                // Inline code (backticks)
+                if (isInline) {
+                  return (
+                    <code
+                      style={{
+                        padding: '2px 6px',
+                        backgroundColor: 'rgba(59, 130, 246, 0.2)',
+                        color: 'rgb(96, 165, 250)',
+                        borderRadius: '4px',
+                        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                        fontSize: '0.9em',
+                      }}
+                      {...props}
+                    >
+                      {children}
+                    </code>
+                  );
+                }
+                // Code blocks (triple backticks)
+                return (
+                  <code
+                    className={className}
+                    style={{
+                      display: 'block',
+                      padding: '12px',
+                      backgroundColor: 'rgba(0, 0, 0, 0.3)',
+                      borderRadius: '6px',
+                      overflowX: 'auto',
+                      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                      fontSize: '0.85em',
+                    }}
+                    {...props}
+                  >
+                    {children}
+                  </code>
+                );
+              },
+              ol: ({ node, children, ...props }) => (
+                <ol
+                  style={{
+                    listStyleType: 'decimal',
+                    paddingLeft: '1.5rem',
+                    marginTop: '1rem',
+                    marginBottom: '1rem',
+                  }}
+                  {...props}
+                >
+                  {children}
+                </ol>
+              ),
+              ul: ({ node, children, ...props }) => (
+                <ul
+                  style={{
+                    listStyleType: 'disc',
+                    paddingLeft: '1.5rem',
+                    marginTop: '1rem',
+                    marginBottom: '1rem',
+                  }}
+                  {...props}
+                >
+                  {children}
+                </ul>
+              ),
+              li: ({ node, children, ...props }) => (
+                <li
+                  style={{
+                    marginTop: '0.375rem',
+                    marginBottom: '0.375rem',
+                  }}
+                  {...props}
+                >
+                  {children}
+                </li>
+              ),
+              p: ({ node, children, ...props }) => (
+                <p
+                  style={{
+                    marginTop: '1rem',
+                    marginBottom: '1rem',
+                    lineHeight: '1.625',
+                  }}
+                  {...props}
+                >
+                  {children}
+                </p>
+              ),
+            }}
+          >
             {comment.content || '(empty)'}
           </ReactMarkdown>
           {showRichBlocks ? <RichBlocks comment={comment} /> : null}


### PR DESCRIPTION
## Changes

This PR improves the rendering of agent messages in the chat interface by addressing spacing issues and making inline code more visually distinct.

### Spacing Improvements
- **Paragraphs**: Increased vertical spacing from 8px to 16px (`my-2` → `my-4`)
- **Lists**: Increased vertical spacing from 8px to 16px (`my-2` → `my-4`)
- **List items**: Increased spacing from 2px to 6px (`my-0.5` → `my-1.5`)
- **Code blocks**: Increased spacing from 12px to 20px (`my-3` → `my-5`)
- **Paragraphs**: Added relaxed line height (1.625) for better readability

### Custom ReactMarkdown Component Renderers
Added custom component renderers with inline styles to fix issues where Tailwind prose modifiers were not applying:

- **Inline code** (backticks): 
  - Blue background (`rgba(59, 130, 246, 0.2)`)
  - Blue text (`rgb(96, 165, 250)`)
  - Monospace font
  - Minimal padding (2px 6px)
  - Now visually distinct from regular text

- **Code blocks** (triple backticks):
  - Dark background (`rgba(0, 0, 0, 0.3)`)
  - Block display with padding (12px)
  - Horizontal scrolling for long lines
  - Monospace font

- **Ordered lists** (`<ol>`):
  - Decimal numbering (`list-style-type: decimal`)
  - Proper left padding (1.5rem) so numbers are visible
  - Vertical margins (1rem)

- **Unordered lists** (`<ul>`):
  - Disc bullets (`list-style-type: disc`)
  - Proper left padding (1.5rem) so bullets are visible
  - Vertical margins (1rem)

- **List items** (`<li>`):
  - Vertical spacing (0.375rem) for readability

- **Paragraphs** (`<p>`):
  - Vertical margins (1rem)
  - Relaxed line height (1.625)

### Technical Details
- Used inline styles instead of Tailwind classes because prose modifiers were not flowing through to the rendered elements
- Detection logic for inline vs block code: checks if `className` starts with `language-` (code blocks have this, inline code doesn't)
- All styling uses inline styles to ensure they apply immediately without build/cache issues

### Before
- Cramped spacing between paragraphs and lists
- Inline code looked almost identical to regular text
- List markers (numbers and bullets) were not visible
- Line spacing within paragraphs was too tight

### After
- ✅ Better breathing room between all elements
- ✅ Inline code clearly visible with blue background and text
- ✅ List numbers and bullets properly displayed
- ✅ Relaxed line height for easier reading
- ✅ Overall more professional and readable appearance

## Files Changed
- `apps/web/components/task/chat/messages/chat-message.tsx`: Added custom ReactMarkdown component renderers and improved spacing