### PR TITLE
fix: Load most recent messages and fix lazy loading pagination

### DIFF
--- a/apps/web/app/s/[sessionId]/page.tsx
+++ b/apps/web/app/s/[sessionId]/page.tsx
@@ -46,9 +46,10 @@ export default async function SessionPage({
     const availableAgents = availableAgentsResponse.agents ?? [];
     let messagesResponse: ListMessagesResponse | null = null;
     try {
+      // Load most recent messages in descending order, then reverse to show oldest-to-newest
       messagesResponse = await listTaskSessionMessages(
         sessionId,
-        { limit: 50, sort: 'asc' },
+        { limit: 50, sort: 'desc' },
         { cache: 'no-store' }
       );
     } catch (error) {
@@ -58,11 +59,12 @@ export default async function SessionPage({
       );
     }
 
-    const messages = messagesResponse?.messages ?? [];
+    const messages = messagesResponse?.messages ? [...messagesResponse.messages].reverse() : [];
     const taskState = taskToState(task, sessionId, {
       items: messages,
       hasMore: messagesResponse?.has_more ?? false,
-      oldestCursor: messagesResponse?.cursor ?? (messages[0]?.id ?? null),
+      // oldestCursor should be the first (oldest) message ID for lazy loading older messages
+      oldestCursor: messages[0]?.id ?? null,
     });
 
     initialState = {

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -73,6 +73,8 @@ export const createSessionSlice: StateCreator<
           oldestCursor: null,
         };
       }
+      // Always reset isLoading to false after prepending messages
+      draft.messages.metaBySession[sessionId].isLoading = false;
       if (meta?.hasMore !== undefined) {
         draft.messages.metaBySession[sessionId].hasMore = meta.hasMore;
       }


### PR DESCRIPTION
## Problem

Task sessions with more than 50 messages were not displaying correctly:

1. **Only oldest 50 messages shown**: When opening a session with 122 messages, users only saw messages 1-50 (the oldest ones) instead of the most recent messages
2. **Lazy loading stuck**: The "Loading older messages..." indicator would appear when scrolling up, but no additional messages would load
3. **Incorrect cursor tracking**: The `oldestCursor` was being set to the API's cursor field (last message in response) instead of the actual oldest message ID

## Root Causes

### Issue 1: Loading oldest messages instead of newest
- SSR and WebSocket fetching used `sort: 'asc'` with `limit: 50`
- This returned messages 1-50 (oldest) instead of messages 73-122 (most recent)
- Users expect to see the latest conversation when opening a session

### Issue 2: Incorrect oldestCursor
- The `oldestCursor` was set to `response.cursor` which is the **last message ID** in the API response
- For `sort: 'asc'`, this was the newest message in the batch, not the oldest
- Lazy loading uses `before: oldestCursor` to fetch older messages, so wrong cursor = wrong pagination

### Issue 3: Loading state stuck
- `prependMessages` function didn't reset `isLoading` to `false`
- After the first lazy load attempt, `isLoading` stayed `true` forever
- This prevented any subsequent lazy load attempts

## Solution

### 1. Load most recent messages first
- Changed to `sort: 'desc'` with `limit: 50` to get the most recent 50 messages
- Reverse the array to display in chronological order (oldest to newest)
- Applied to SSR (both pages) and WebSocket fetching

### 2. Fix oldestCursor tracking
- Always set `oldestCursor` to `messages[0].id` (the actual oldest message after reversing)
- Never use `response.cursor` for this purpose

### 3. Fix prependMessages loading state
- Added `draft.messages.metaBySession[sessionId].isLoading = false` in `prependMessages`
- Ensures loading state is properly reset after each lazy load

### 4. Add debug logging
- Added console logs to `useLazyLoadMessages` for troubleshooting

## Testing

Tested with session `f7a71089-45e6-4451-8d0a-2e59593c9aaa` which has 122 messages:

**Before:**
- ❌ Only showed messages 1-50 (oldest)
- ❌ Lazy loading stuck after first attempt
- ❌ Could not access messages 51-122

**After:**
- ✅ Shows messages 73-122 (most recent 50)
- ✅ Scrolling up loads messages 53-72, then 33-52, etc.
- ✅ All 122 messages accessible through lazy loading
- ✅ Users see the latest conversation immediately

## Files Changed

- `apps/web/app/page.tsx` - SSR message loading for home page
- `apps/web/app/s/[sessionId]/page.tsx` - SSR message loading for session page
- `apps/web/hooks/domains/session/use-session-messages.ts` - WebSocket message fetching
- `apps/web/lib/state/slices/session/session-slice.ts` - Fix prependMessages loading state
- `apps/web/hooks/use-lazy-load-messages.ts` - Add debug logging