### PR TITLE
fix: strip origin/ prefix from base branch for rebase/merge operations

### DIFF
--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -150,14 +150,16 @@ const TaskTopBar = memo(function TaskTopBar({
   }, [handleGitOperation, push]);
 
   const handleRebase = useCallback(() => {
-    // Rebase onto the base branch (e.g., origin/main)
-    const targetBranch = baseBranch || 'origin/main';
+    // Rebase onto the base branch (e.g., main)
+    // Backend expects just the branch name without 'origin/' prefix
+    const targetBranch = baseBranch?.replace(/^origin\//, '') || 'main';
     handleGitOperation(() => rebase(targetBranch), 'Rebase');
   }, [handleGitOperation, rebase, baseBranch]);
 
   const handleMerge = useCallback(() => {
-    // Merge from the base branch (e.g., origin/main)
-    const targetBranch = baseBranch || 'origin/main';
+    // Merge from the base branch (e.g., main)
+    // Backend expects just the branch name without 'origin/' prefix
+    const targetBranch = baseBranch?.replace(/^origin\//, '') || 'main';
     handleGitOperation(() => merge(targetBranch), 'Merge');
   }, [handleGitOperation, merge, baseBranch]);
 


### PR DESCRIPTION
## Problem

Git rebase and merge operations were failing with:
```
fatal: couldn't find remote ref origin/main
```

## Root Cause

The frontend was passing `origin/main` as the base branch to the backend, but the backend expects just the branch name (e.g., `main`) and constructs the `origin/` prefix itself.

This caused the git fetch command to become:
```
git fetch origin origin/main
```

Instead of the correct:
```
git fetch origin main
```

## Solution

Strip the `origin/` prefix from the base branch in the frontend before sending to the backend:
```typescript
const targetBranch = baseBranch?.replace(/^origin\//, '') || 'main';
```

This ensures:
- If `baseBranch` is `origin/main`, it becomes `main`
- If `baseBranch` is already `main`, it stays `main`
- If `baseBranch` is undefined/null, it defaults to `main`