### PR TITLE
fix: git status not showing after page refresh

### DIFF
--- a/apps/web/hooks/domains/session/use-session-git-status.ts
+++ b/apps/web/hooks/domains/session/use-session-git-status.ts
@@ -1,16 +1,83 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useAppStore } from '@/components/state-provider';
 import { getWebSocketClient } from '@/lib/ws/connection';
+import type { GitSnapshot } from '@/lib/state/slices/session-runtime/types';
 
 /**
  * Hook to get the current git status for a session.
  * Git status is populated via WebSocket from git snapshot updates.
+ * On mount, fetches the latest snapshot to populate initial status.
  * For historical snapshots, use useSessionGitSnapshots hook.
  */
 export function useSessionGitStatus(sessionId: string | null) {
   const gitStatus = useAppStore((state) =>
     sessionId ? state.gitStatus.bySessionId[sessionId] : undefined
   );
+  const setGitStatus = useAppStore((state) => state.setGitStatus);
+
+  // Fetch latest git snapshot to populate initial status
+  const fetchLatestSnapshot = useCallback(async () => {
+    if (!sessionId) return;
+
+    const client = getWebSocketClient();
+    if (!client) return;
+
+    try {
+      const response = await client.request<{ snapshots?: GitSnapshot[] }>(
+        'session.git.snapshots',
+        {
+          session_id: sessionId,
+          limit: 1, // Only fetch the latest snapshot
+        }
+      );
+
+      if (response?.snapshots && response.snapshots.length > 0) {
+        const latest = response.snapshots[0];
+
+        // Extract file paths by status from the files object
+        const modified: string[] = [];
+        const added: string[] = [];
+        const deleted: string[] = [];
+        const untracked: string[] = [];
+        const renamed: string[] = [];
+
+        if (latest.files) {
+          Object.entries(latest.files).forEach(([path, fileInfo]) => {
+            const status = fileInfo.status?.toLowerCase();
+            if (status === 'modified') modified.push(path);
+            else if (status === 'added') added.push(path);
+            else if (status === 'deleted') deleted.push(path);
+            else if (status === 'untracked') untracked.push(path);
+            else if (status === 'renamed') renamed.push(path);
+          });
+        }
+
+        // Populate git status from latest snapshot
+        setGitStatus(sessionId, {
+          branch: latest.branch,
+          remote_branch: latest.remote_branch,
+          modified,
+          added,
+          deleted,
+          untracked,
+          renamed,
+          ahead: latest.ahead,
+          behind: latest.behind,
+          files: latest.files,
+          timestamp: latest.created_at,
+        });
+      }
+    } catch (error) {
+      console.error('Failed to fetch latest git snapshot:', error);
+    }
+  }, [sessionId, setGitStatus]);
+
+  // Fetch initial status on mount if not already loaded
+  useEffect(() => {
+    if (sessionId && !gitStatus) {
+      fetchLatestSnapshot();
+    }
+  }, [sessionId, gitStatus, fetchLatestSnapshot]);
 
   // Subscribe to session updates to receive git status via WebSocket
   useEffect(() => {


### PR DESCRIPTION
## Problem

When refreshing the page, git status (files, commits, branch info) would disappear and not reload.

## Root Cause

The `useSessionGitStatus` hook was only subscribing to WebSocket updates but never fetching the initial git status on page load. When the page refreshed:
1. The Zustand store was reset (empty state)
2. The hook subscribed to WebSocket for future updates
3. But no initial data was fetched, so git status remained empty

## Solution

Modified `apps/web/hooks/domains/session/use-session-git-status.ts` to:

1. **Fetch latest git snapshot on mount** - Uses the existing `session.git.snapshots` WebSocket request with `limit: 1`
2. **Parse snapshot data** - Extracts file paths by status (modified, added, deleted, untracked, renamed) from the snapshot's files object
3. **Populate git status** - Calls `setGitStatus` with the parsed data
4. **Continue WebSocket subscription** - Still receives real-time updates as before

## Testing

To verify the fix:

1. Start a session with git changes (modified files, commits)
2. Verify git status is visible in Files panel and Changes panel
3. Refresh the page (F5 or Ctrl+R)
4. Verify git status persists and displays correctly

## Changes

- Modified `apps/web/hooks/domains/session/use-session-git-status.ts`
  - Added `fetchLatestSnapshot` callback to request latest git snapshot
  - Added effect to fetch initial status on mount if not already loaded
  - Properly parses file status arrays from snapshot data
  - Maintains existing WebSocket subscription for real-time updates