### PR TITLE
feat: Add file unstaging functionality

### DIFF
--- a/apps/backend/internal/agentctl/client/git.go
+++ b/apps/backend/internal/agentctl/client/git.go
@@ -109,6 +109,17 @@ func (c *Client) GitStage(ctx context.Context, paths []string) (*GitOperationRes
 	return c.gitOperation(ctx, "/api/v1/git/stage", payload)
 }
 
+// GitUnstage unstages files from the index.
+// If paths is empty, unstages all changes (git reset HEAD).
+func (c *Client) GitUnstage(ctx context.Context, paths []string) (*GitOperationResult, error) {
+	payload := struct {
+		Paths []string `json:"paths"`
+	}{
+		Paths: paths,
+	}
+	return c.gitOperation(ctx, "/api/v1/git/unstage", payload)
+}
+
 // GitCreatePR creates a pull request using the gh CLI.
 func (c *Client) GitCreatePR(ctx context.Context, title, body, baseBranch string) (*PRCreateResult, error) {
 	payload := struct {

--- a/apps/backend/internal/agentctl/server/api/git.go
+++ b/apps/backend/internal/agentctl/server/api/git.go
@@ -46,6 +46,11 @@ type GitStageRequest struct {
 	Paths []string `json:"paths"` // Empty = stage all
 }
 
+// GitUnstageRequest for POST /api/v1/git/unstage
+type GitUnstageRequest struct {
+	Paths []string `json:"paths"` // Empty = unstage all
+}
+
 // GitShowCommitRequest for GET /api/v1/git/commit/:sha
 type GitShowCommitRequest struct {
 	CommitSHA string `uri:"sha" binding:"required"`
@@ -242,6 +247,28 @@ func (s *Server) handleGitStage(c *gin.Context) {
 	result, err := gitOp.Stage(c.Request.Context(), req.Paths)
 	if err != nil {
 		s.handleGitError(c, "stage", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// handleGitUnstage handles POST /api/v1/git/unstage
+func (s *Server) handleGitUnstage(c *gin.Context) {
+	var req GitUnstageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, process.GitOperationResult{
+			Success:   false,
+			Operation: "unstage",
+			Error:     "invalid request: " + err.Error(),
+		})
+		return
+	}
+
+	gitOp := s.procMgr.GitOperator()
+	result, err := gitOp.Unstage(c.Request.Context(), req.Paths)
+	if err != nil {
+		s.handleGitError(c, "unstage", err)
 		return
 	}
 

--- a/apps/backend/internal/agentctl/server/api/server.go
+++ b/apps/backend/internal/agentctl/server/api/server.go
@@ -102,6 +102,7 @@ func (s *Server) setupRoutes() {
 		api.POST("/git/abort", s.handleGitAbort)
 		api.POST("/git/commit", s.handleGitCommit)
 		api.POST("/git/stage", s.handleGitStage)
+		api.POST("/git/unstage", s.handleGitUnstage)
 		api.POST("/git/create-pr", s.handleGitCreatePR)
 		api.GET("/git/commit/:sha", s.handleGitShowCommit)
 	}

--- a/apps/backend/pkg/websocket/actions.go
+++ b/apps/backend/pkg/websocket/actions.go
@@ -190,6 +190,7 @@ const (
 	ActionWorktreeAbort    = "worktree.abort"     // Abort in-progress merge or rebase
 	ActionWorktreeCommit   = "worktree.commit"    // Commit changes
 	ActionWorktreeStage    = "worktree.stage"     // Stage files for commit
+	ActionWorktreeUnstage  = "worktree.unstage"   // Unstage files from index
 	ActionWorktreeCreatePR = "worktree.create_pr" // Create a pull request
 
 	// User actions

--- a/apps/web/components/task/task-files-panel.tsx
+++ b/apps/web/components/task/task-files-panel.tsx
@@ -194,11 +194,19 @@ const TaskFilesPanel = memo(function TaskFilesPanel({ onSelectDiff, onOpenFile }
                             {file.staged ? (
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <div className="flex items-center justify-center h-4 w-4 rounded bg-emerald-500/20 text-emerald-600">
-                                    <IconCheck className="h-3 w-3" />
-                                  </div>
+                                  <button
+                                    type="button"
+                                    className="group/unstage flex items-center justify-center h-4 w-4 rounded bg-emerald-500/20 text-emerald-600 hover:bg-rose-500/20 hover:text-rose-600"
+                                    onClick={(event) => {
+                                      event.stopPropagation();
+                                      void gitOps.unstage([file.path]);
+                                    }}
+                                  >
+                                    <IconCheck className="h-3 w-3 group-hover/unstage:hidden" />
+                                    <IconMinus className="h-2.5 w-2.5 hidden group-hover/unstage:block" />
+                                  </button>
                                 </TooltipTrigger>
-                                <TooltipContent>Staged for commit</TooltipContent>
+                                <TooltipContent>Click to unstage</TooltipContent>
                               </Tooltip>
                             ) : (
                               <Tooltip>
@@ -214,7 +222,7 @@ const TaskFilesPanel = memo(function TaskFilesPanel({ onSelectDiff, onOpenFile }
                                     <IconPlus className="h-2.5 w-2.5" />
                                   </button>
                                 </TooltipTrigger>
-                                <TooltipContent>Stage file</TooltipContent>
+                                <TooltipContent>Click to stage</TooltipContent>
                               </Tooltip>
                             )}
                             <button type="button" className="min-w-0 text-left cursor-pointer">

--- a/apps/web/hooks/use-git-operations.ts
+++ b/apps/web/hooks/use-git-operations.ts
@@ -29,6 +29,7 @@ interface UseGitOperationsReturn {
   abort: (operation: 'merge' | 'rebase') => Promise<GitOperationResult>;
   commit: (message: string, stageAll?: boolean) => Promise<GitOperationResult>;
   stage: (paths?: string[]) => Promise<GitOperationResult>;
+  unstage: (paths?: string[]) => Promise<GitOperationResult>;
   createPR: (title: string, body: string, baseBranch?: string) => Promise<PRCreateResult>;
 
   // State
@@ -109,6 +110,10 @@ export function useGitOperations(sessionId: string | null): UseGitOperationsRetu
     return executeOperation<GitOperationResult>('worktree.stage', { paths: paths ?? [] });
   }, [executeOperation]);
 
+  const unstage = useCallback(async (paths?: string[]) => {
+    return executeOperation<GitOperationResult>('worktree.unstage', { paths: paths ?? [] });
+  }, [executeOperation]);
+
   const createPR = useCallback(async (title: string, body: string, baseBranch?: string): Promise<PRCreateResult> => {
     if (!sessionId) {
       throw new Error('No session ID provided');
@@ -151,6 +156,7 @@ export function useGitOperations(sessionId: string | null): UseGitOperationsRetu
     abort,
     commit,
     stage,
+    unstage,
     createPR,
     isLoading,
     error,


### PR DESCRIPTION
## Overview
This PR adds the ability to unstage files in the UI, complementing the existing file staging feature.

## Changes

### Backend (6 files)
- Added `Unstage()` method to GitOperator using `git reset HEAD --`
- Created API endpoint `/api/v1/git/unstage`
- Added WebSocket action `worktree.unstage`
- Implemented proper error handling and locking mechanisms

### Frontend (2 files)
- Added `unstage()` method to `useGitOperations` hook
- Updated UI to show interactive minus button on hover for staged files
- Consistent tooltips: 'Click to stage' and 'Click to unstage'

## UI Behavior
- **Unstaged files**: Dashed border button with plus icon → Click to stage
- **Staged files (default)**: Solid emerald background with checkmark icon
- **Staged files (hover)**: Solid rose background with minus icon → Click to unstage

## Technical Details
- Uses safe git command (`git reset HEAD --`) that only unstages without modifying working directory
- Follows existing patterns for git operations
- Backend builds successfully verified

## Testing
- [x] Backend builds successfully
- [x] Manual testing of staging/unstaging workflow
- [x] Verify git status updates correctly