### PR TITLE
fix: refetch messages and git status when switching between tasks

### DIFF
--- a/apps/web/hooks/domains/session/use-session-git-status.ts
+++ b/apps/web/hooks/domains/session/use-session-git-status.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAppStore } from '@/components/state-provider';
 import { getWebSocketClient } from '@/lib/ws/connection';
 import type { GitSnapshot } from '@/lib/state/slices/session-runtime/types';
@@ -14,70 +14,80 @@ export function useSessionGitStatus(sessionId: string | null) {
     sessionId ? state.gitStatus.bySessionId[sessionId] : undefined
   );
   const setGitStatus = useAppStore((state) => state.setGitStatus);
-
-  // Fetch latest git snapshot to populate initial status
-  const fetchLatestSnapshot = useCallback(async () => {
-    if (!sessionId) return;
-
-    const client = getWebSocketClient();
-    if (!client) return;
-
-    try {
-      const response = await client.request<{ snapshots?: GitSnapshot[] }>(
-        'session.git.snapshots',
-        {
-          session_id: sessionId,
-          limit: 1, // Only fetch the latest snapshot
-        }
-      );
-
-      if (response?.snapshots && response.snapshots.length > 0) {
-        const latest = response.snapshots[0];
-
-        // Extract file paths by status from the files object
-        const modified: string[] = [];
-        const added: string[] = [];
-        const deleted: string[] = [];
-        const untracked: string[] = [];
-        const renamed: string[] = [];
-
-        if (latest.files) {
-          Object.entries(latest.files).forEach(([path, fileInfo]) => {
-            const status = fileInfo.status?.toLowerCase();
-            if (status === 'modified') modified.push(path);
-            else if (status === 'added') added.push(path);
-            else if (status === 'deleted') deleted.push(path);
-            else if (status === 'untracked') untracked.push(path);
-            else if (status === 'renamed') renamed.push(path);
-          });
-        }
-
-        // Populate git status from latest snapshot
-        setGitStatus(sessionId, {
-          branch: latest.branch,
-          remote_branch: latest.remote_branch,
-          modified,
-          added,
-          deleted,
-          untracked,
-          renamed,
-          ahead: latest.ahead,
-          behind: latest.behind,
-          files: latest.files,
-          timestamp: latest.created_at,
-        });
-      }
-    } catch (error) {
-      console.error('Failed to fetch latest git snapshot:', error);
-    }
-  }, [sessionId, setGitStatus]);
+  const prevSessionIdRef = useRef<string | null>(null);
 
   // Fetch initial status on mount if not already loaded
+  // Also refetch when switching to a different session
   useEffect(() => {
-    if (sessionId && !gitStatus) {
-      fetchLatestSnapshot();
+    if (!sessionId) return;
+
+    // Detect session change to force refetch
+    const sessionChanged = prevSessionIdRef.current !== null &&
+                           prevSessionIdRef.current !== sessionId;
+    prevSessionIdRef.current = sessionId;
+
+    // Skip fetch if status exists and session hasn't changed
+    if (gitStatus && !sessionChanged) {
+      return;
     }
-  }, [sessionId, gitStatus, fetchLatestSnapshot]);
+
+    // Fetch latest git snapshot
+    const fetchSnapshot = async () => {
+      const client = getWebSocketClient();
+      if (!client) return;
+
+      try {
+        const response = await client.request<{ snapshots?: GitSnapshot[] }>(
+          'session.git.snapshots',
+          {
+            session_id: sessionId,
+            limit: 1, // Only fetch the latest snapshot
+          }
+        );
+
+        if (response?.snapshots && response.snapshots.length > 0) {
+          const latest = response.snapshots[0];
+
+          // Extract file paths by status from the files object
+          const modified: string[] = [];
+          const added: string[] = [];
+          const deleted: string[] = [];
+          const untracked: string[] = [];
+          const renamed: string[] = [];
+
+          if (latest.files) {
+            Object.entries(latest.files).forEach(([path, fileInfo]) => {
+              const status = fileInfo.status?.toLowerCase();
+              if (status === 'modified') modified.push(path);
+              else if (status === 'added') added.push(path);
+              else if (status === 'deleted') deleted.push(path);
+              else if (status === 'untracked') untracked.push(path);
+              else if (status === 'renamed') renamed.push(path);
+            });
+          }
+
+          // Populate git status from latest snapshot
+          setGitStatus(sessionId, {
+            branch: latest.branch,
+            remote_branch: latest.remote_branch,
+            modified,
+            added,
+            deleted,
+            untracked,
+            renamed,
+            ahead: latest.ahead,
+            behind: latest.behind,
+            files: latest.files,
+            timestamp: latest.created_at,
+          });
+        }
+      } catch (error) {
+        console.error('Failed to fetch latest git snapshot:', error);
+      }
+    };
+
+    fetchSnapshot();
+  }, [sessionId, gitStatus, setGitStatus]);
 
   // Subscribe to session updates to receive git status via WebSocket
   useEffect(() => {


### PR DESCRIPTION
## Problem

When switching between tasks on the session page, messages and git status that arrived while viewing a different task were lost.

### Root Cause
- Message/git status fetching had guard conditions that skipped fetching if data already existed in the store
- WebSocket subscriptions are session-scoped (only active session receives updates)
- No refresh mechanism when switching back to a previously viewed session

## Solution

Implemented **session change detection** to force refetch when switching between tasks:

### Changes Made

#### 1. \
- Added \ to track previous session ID
- Detects when session changes (not just initial mount)
- Resets fetch guard to force refetch when switching sessions
- Preserves SSR optimization for initial page load

#### 2. \
- Added session change detection
- Inlined fetch logic to avoid dependency chain issues
- Forces refetch when switching to a different session

## Testing

To test this fix:
1. Open a session for Task A
2. Send a message
3. Switch to Task B
4. While viewing Task B, trigger a message in Task A (via another client or API)
5. Switch back to Task A
6. ✅ Verify the new message appears

Same test applies for git status changes.

## Impact

- ✅ Messages that arrive while viewing another task are now visible when switching back
- ✅ Git status is refreshed when switching between sessions
- ✅ SSR optimization still works (no unnecessary fetches on initial load)
- ✅ No performance degradation (fetches only on session change)

Fixes the issue where messages and file changes are not visible when switching back to a previously viewed task session.