### PR TITLE
fix: prevent approval button showing while agent is working

### DIFF
--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -131,7 +131,9 @@ export function TaskChatPanel({
 
   // Check if we should show the approve button
   // Show when session has a review_status that is not approved (meaning it's in a review step)
-  const showApproveButton = session?.review_status != null && session.review_status !== 'approved';
+  // Also hide while agent is working to prevent premature approval
+  const showApproveButton =
+    session?.review_status != null && session.review_status !== 'approved' && !isWorking;
 
   const handleSubmit = async (event?: FormEvent) => {
     event?.preventDefault();


### PR DESCRIPTION
## Problem

After approving a task during the planning stage, the approval button remained visible even though the agent was actively working. Users could see the task in 'review' stage with the approval button still present while the agent was processing.

## Root Cause

Two issues combined to cause this bug:

1. **Backend**: The `updateTaskSessionState` function wasn't including `review_status` and `workflow_step_id` in the WebSocket event payload, so the frontend never received the cleared status when the agent started working.

2. **Frontend**: The `showApproveButton` logic only checked if `review_status` was 'waiting', but didn't verify that the agent wasn't currently working.

## Solution

1. **Backend** (`event_handlers.go`): Added `review_status` and `workflow_step_id` to the session state event payload so frontend receives state updates when the agent starts running.

2. **Frontend** (`task-chat-panel.tsx`): Added `\!isWorking` check to the `showApproveButton` condition to hide the button while the agent is running or streaming.

Now the approval button only shows when:
- Session has a `review_status` that is 'waiting' (awaiting plan or review approval)
- AND agent is NOT currently working (not in running or streaming state)

## Testing

- Backend builds successfully (`go build ./...`)
- Go vet passes
- Frontend linting passes