### PR TITLE
fix: session recovery after backend restart

### DIFF
--- a/apps/backend/internal/agent/lifecycle/session.go
+++ b/apps/backend/internal/agent/lifecycle/session.go
@@ -13,6 +13,7 @@ import (
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/common/appctx"
+	"github.com/kandev/kandev/internal/common/constants"
 	"github.com/kandev/kandev/internal/common/logger"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 	"github.com/kandev/kandev/pkg/agent"
@@ -332,7 +333,8 @@ func (sm *SessionManager) InitializeAndPrompt(
 
 		go func() {
 			// Use detached context that respects stopCh for graceful shutdown
-			promptCtx, cancel := appctx.Detached(ctx, sm.stopCh, 10*time.Minute)
+			// Use PromptTimeout (60 min) to match the HTTP client/server timeouts
+			promptCtx, cancel := appctx.Detached(ctx, sm.stopCh, constants.PromptTimeout)
 			defer cancel()
 
 			_, err := sm.SendPrompt(promptCtx, execution, effectivePrompt, false, markReady)

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -524,6 +524,9 @@ func (s *Service) resumeExecutorsOnStartup(ctx context.Context) {
 				zap.String("session_id", sessionID),
 				zap.Error(err))
 			_ = s.repo.UpdateTaskSessionState(ctx, sessionID, models.TaskSessionStateFailed, err.Error())
+			// Clear the stale execution ID to prevent "execution not found" errors
+			// when the user tries to prompt after the failed resume
+			_ = s.repo.ClearSessionExecutionID(ctx, sessionID)
 			_ = s.repo.DeleteExecutorRunningBySessionID(ctx, sessionID)
 			continue
 		}

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -173,6 +173,9 @@ func (m *mockRepository) UpdateTaskSession(ctx context.Context, session *models.
 func (m *mockRepository) UpdateTaskSessionState(ctx context.Context, id string, state models.TaskSessionState, errorMessage string) error {
 	return nil
 }
+func (m *mockRepository) ClearSessionExecutionID(ctx context.Context, id string) error {
+	return nil
+}
 func (m *mockRepository) ListTaskSessions(ctx context.Context, taskID string) ([]*models.TaskSession, error) {
 	return nil, nil
 }

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -68,6 +68,7 @@ type Repository interface {
 	GetActiveTaskSessionByTaskID(ctx context.Context, taskID string) (*models.TaskSession, error)
 	UpdateTaskSession(ctx context.Context, session *models.TaskSession) error
 	UpdateTaskSessionState(ctx context.Context, id string, state models.TaskSessionState, errorMessage string) error
+	ClearSessionExecutionID(ctx context.Context, id string) error
 	ListTaskSessions(ctx context.Context, taskID string) ([]*models.TaskSession, error)
 	ListActiveTaskSessions(ctx context.Context) ([]*models.TaskSession, error)
 	ListActiveTaskSessionsByTaskID(ctx context.Context, taskID string) ([]*models.TaskSession, error)


### PR DESCRIPTION
## Problem

When the backend restarts after a timeout scenario, sending a prompt to an agent would fail with:
```
"error": "execution \"3efbaf93-00de-48c9-9516-1d20871eaee6\" not found"
```

## Root Cause

In `resumeExecutorsOnStartup()`, when `ResumeSession()` fails:
1. The session state was updated to `FAILED`
2. The `ExecutorRunning` record was deleted
3. **But the `AgentExecutionID` was NOT cleared** from the database

This caused `PromptTask` to read the **stale** `AgentExecutionID` from the database and try to use it with `PromptAgent`, which failed because the execution no longer exists in the in-memory `ExecutionStore` after restart.

## Solution

1. Added `ClearSessionExecutionID()` method to the repository interface and SQLite implementation
2. Call `ClearSessionExecutionID()` in `resumeExecutorsOnStartup()` when `ResumeSession()` fails
3. This ensures the stale execution ID is removed from the database, allowing the user to start a fresh session

## Additional Fix

Also includes a fix for the initial prompt timeout:
- Changed initial prompt timeout from 10 minutes to 60 minutes (`constants.PromptTimeout`) to match HTTP client/server timeouts
- This was causing `context deadline exceeded` errors for long-running initial prompts

## Files Changed

- `apps/backend/internal/task/repository/interface.go` - Added `ClearSessionExecutionID` to interface
- `apps/backend/internal/task/repository/sqlite/session.go` - Implemented `ClearSessionExecutionID` method
- `apps/backend/internal/orchestrator/service.go` - Call `ClearSessionExecutionID` on resume failure
- `apps/backend/internal/task/handlers/process_handlers_test.go` - Updated mock to implement new interface method
- `apps/backend/internal/agent/lifecycle/session.go` - Changed initial prompt timeout to use `constants.PromptTimeout`
