### PR TITLE
fix: Update session/task states when ask_user_question tool is used

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -562,6 +562,9 @@ func main() {
 		workflowCtrl,
 		clarificationStore,
 		msgCreator,
+		taskRepo,  // SessionRepository
+		taskRepo,  // TaskRepository (same instance)
+		eventBus,  // EventBus
 		planService,
 		log,
 	)


### PR DESCRIPTION
## Summary

This PR fixes the issue where the `ask_user_question_kandev` MCP tool doesn't update the session and task states when an agent asks the user a question.

## Problem

When agents use `ask_user_question_kandev`, the system:
- ✅ Creates a clarification request message with `RequestsInput: true`
- ✅ Publishes a `message.added` event
- ❌ **Does NOT update the session state to `WAITING_FOR_INPUT`**
- ❌ **Does NOT update the task state to `REVIEW`**

This is inconsistent with how permission requests work, which DO update these states.

## Solution

This PR adds state management to `handleAskUserQuestion` similar to the permission request flow:

### Before waiting for user response:
- Update session state to `WAITING_FOR_INPUT`
- Update task state to `REVIEW`
- Publish `TaskSessionStateChanged` event

### After user responds:
- Restore session state to `RUNNING`
- Restore task state to `IN_PROGRESS`
- Publish `TaskSessionStateChanged` event

## Changes

### `apps/backend/internal/mcp/handlers/handlers.go`
- Added `SessionRepository`, `TaskRepository`, and `EventBus` interfaces
- Updated `Handlers` struct to include new dependencies
- Updated `NewHandlers` constructor to accept new parameters
- Added `setSessionWaitingForInput()` helper method
- Updated `handleAskUserQuestion()` to call state updates before and after waiting

### `apps/backend/cmd/kandev/main.go`
- Updated MCP handlers initialization to pass `taskRepo` and `eventBus`

## Testing

- ✅ Build successful: `make -C apps/backend build`
- ✅ All tests pass: `make -C apps/backend test`
- ✅ No regressions in existing functionality

## Benefits

- **Consistency**: Clarification requests now work the same as permission requests
- **UI Feedback**: Frontend can properly display waiting state
- **State Tracking**: Proper session lifecycle management
- **Event-Driven**: Frontend receives real-time updates via WebSocket events

## Related

This makes the clarification request flow consistent with the permission request implementation in `apps/backend/internal/orchestrator/event_handlers.go`.