### PR TITLE
fix: disable Cmd+Enter keyboard shortcut when chat input is disabled

### DIFF
--- a/apps/web/components/task/chat/rich-text-input.tsx
+++ b/apps/web/components/task/chat/rich-text-input.tsx
@@ -179,10 +179,12 @@ export const RichTextInput = forwardRef<RichTextInputHandle, RichTextInputProps>
         if (event.defaultPrevented) return;
       }
 
-      // Submit only on Cmd/Ctrl+Enter
+      // Submit only on Cmd/Ctrl+Enter, and only if not disabled
       if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
-        onSubmit?.();
+        if (!disabled) {
+          onSubmit?.();
+        }
       }
     };
 


### PR DESCRIPTION
## Problem

When the agent is working, the send button is disabled/hidden but the Cmd+Enter keyboard shortcut still worked, allowing users to send messages when they shouldn't be able to.

## Solution

Added a check for the `disabled` state in the `handleKeyDown` function before calling `onSubmit`, ensuring the keyboard shortcut behavior matches the send button behavior.

## Changes

- Modified `apps/web/components/task/chat/rich-text-input.tsx`
- Added guard clause to check `!disabled` before submitting via Cmd+Enter

## Behavior

The input is now properly disabled (including keyboard shortcuts) when:
- Session state is 'CREATED' or 'RUNNING' (agent is busy)
- `isStarting` is true (session is starting)
- `isSending` is true (message is being sent)

## Testing

- ✅ Cmd+Enter works normally when agent is idle
- ✅ Cmd+Enter is blocked when agent is busy
- ✅ Send button and keyboard shortcut behavior are now consistent