### PR TITLE
fix: hide 'Approval Required' badge when agent is working

### DIFF
--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -75,7 +75,7 @@ function KanbanCardBody({
               {task.sessionCount} sessions
             </Badge>
           )}
-          {task.reviewStatus === 'pending' && (
+          {task.reviewStatus === 'pending' && task.state !== 'IN_PROGRESS' && (
             <div className="flex items-center gap-1 text-amber-700 dark:text-amber-600">
               <IconAlertCircle className="h-3.5 w-3.5" />
               <span className="text-[10px] font-medium">Approval Required</span>


### PR DESCRIPTION
## Problem
The 'Approval Required' badge on kanban cards was showing even when the agent was actively working on a task. This was confusing because there was nothing to approve yet.

## Solution
Added a check to hide the badge when `task.state` is `'IN_PROGRESS'`, which indicates the agent is currently working. The badge will still appear correctly after the agent completes work and the task moves to a review step.

## Changes
- **apps/web/components/kanban-card.tsx**: Added `task.state !== 'IN_PROGRESS'` condition to the approval badge visibility check (line 78)

## Testing
- ✅ Linting passed
- ✅ TypeScript compilation passed
- ✅ Production build completed successfully

## Manual Testing Needed
- [ ] Badge appears after agent completes and moves to review step
- [ ] Badge correctly hides when agent starts working on a task with pending review status
- [ ] Badge works correctly with different task states