### PR TITLE
Fix diff view not updating when agent modifies files

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers.go
+++ b/apps/backend/internal/orchestrator/event_handlers.go
@@ -1149,7 +1149,7 @@ func (s *Service) isSnapshotDuplicate(existing, new *models.GitSnapshot) bool {
 		return false
 	}
 
-	// Compare file paths, staged status, and line counts
+	// Compare file paths, staged status, line counts, and diff content
 	for path, newFileData := range new.Files {
 		existingFileData, exists := existing.Files[path]
 		if !exists {
@@ -1162,7 +1162,8 @@ func (s *Service) isSnapshotDuplicate(existing, new *models.GitSnapshot) bool {
 
 		if newInfo.staged != existingInfo.staged ||
 			newInfo.additions != existingInfo.additions ||
-			newInfo.deletions != existingInfo.deletions {
+			newInfo.deletions != existingInfo.deletions ||
+			newInfo.diff != existingInfo.diff {
 			return false
 		}
 	}
@@ -1175,6 +1176,7 @@ type fileInfoCompare struct {
 	staged    bool
 	additions int
 	deletions int
+	diff      string
 }
 
 // extractFileInfo extracts comparable fields from a file info interface
@@ -1197,6 +1199,10 @@ func extractFileInfo(fileData interface{}) fileInfoCompare {
 			info.deletions = int(deletions)
 		} else if deletions, ok := fileMap["deletions"].(int); ok {
 			info.deletions = deletions
+		}
+		// Extract diff content for comparison
+		if diff, ok := fileMap["diff"].(string); ok {
+			info.diff = diff
 		}
 	}
 	return info

--- a/apps/web/components/task/task-changes-panel.tsx
+++ b/apps/web/components/task/task-changes-panel.tsx
@@ -99,8 +99,9 @@ const TaskChangesPanel = memo(function TaskChangesPanel({
   }, [cumulativeDiff]);
 
   const selectedFile = selectedDiffPath && gitStatus?.files ? gitStatus.files[selectedDiffPath] : null;
-  // Use provided content if available, otherwise fall back to git status
-  const selectedDiffContent = selectedDiff?.content ?? selectedFile?.diff ?? '';
+  // Prioritize current git status for uncommitted files, use provided content only for historical diffs
+  // This ensures that when a file is modified by the agent, we show the latest diff
+  const selectedDiffContent = selectedFile?.diff ?? selectedDiff?.content ?? '';
   const isSingleDiffSelected = Boolean(selectedDiffPath && (hasProvidedContent || selectedFile));
   // Discard only works for uncommitted changes (not committed/historical diffs)
   const canDiscard = Boolean(selectedDiffPath && selectedFile && !hasProvidedContent);
@@ -192,7 +193,8 @@ const TaskChangesPanel = memo(function TaskChangesPanel({
       <SessionPanelContent>
         {isSingleDiffSelected && selectedDiffContent ? (
           // Render single file diff (from commit, snapshot, or uncommitted)
-          <div key={`selected-${selectedDiffPath}-${selectedDiffContent.length}`} className="space-y-4">
+          // Use timestamp from git status to ensure re-render when file changes
+          <div key={`selected-${selectedDiffPath}-${gitStatus?.timestamp ?? ''}-${selectedDiffContent.length}`} className="space-y-4">
             <FileDiffViewer
               filePath={selectedDiffPath!}
               diff={normalizeDiffContent(selectedDiffContent)}

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -3,17 +3,6 @@ import type { SessionRuntimeSlice, SessionRuntimeSliceState } from './types';
 
 const maxProcessOutputBytes = 2 * 1024 * 1024;
 
-/** Helper to compare two string arrays for equality */
-function arraysEqual(a: string[] | undefined, b: string[] | undefined): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
-
 function trimProcessOutput(value: string) {
   if (value.length <= maxProcessOutputBytes) {
     return value;
@@ -94,23 +83,8 @@ export const createSessionRuntimeSlice: StateCreator<
     }),
   setGitStatus: (sessionId, gitStatus) =>
     set((draft) => {
-      const existing = draft.gitStatus.bySessionId[sessionId];
-      // Skip update if git status content hasn't meaningfully changed
-      // Compare branch, file counts, and modified/added/deleted arrays
-      if (existing) {
-        const sameContent =
-          existing.branch === gitStatus.branch &&
-          existing.ahead === gitStatus.ahead &&
-          existing.behind === gitStatus.behind &&
-          arraysEqual(existing.modified, gitStatus.modified) &&
-          arraysEqual(existing.added, gitStatus.added) &&
-          arraysEqual(existing.deleted, gitStatus.deleted) &&
-          arraysEqual(existing.untracked, gitStatus.untracked) &&
-          arraysEqual(existing.renamed, gitStatus.renamed);
-        if (sameContent) {
-          return; // Skip update - no meaningful changes
-        }
-      }
+      // Always update git status - the timestamp and file diffs may have changed
+      // even if the file lists are the same. The backend sends updates when content changes.
       draft.gitStatus.bySessionId[sessionId] = gitStatus;
     }),
   clearGitStatus: (sessionId) =>


### PR DESCRIPTION
## Problem

When an agent modifies a file that's already being viewed in the diff panel, the diff view continues to show the old content instead of updating to reflect the new changes. This persists even after page refresh.

## Root Causes

Found **two bugs** - one in the frontend and one in the backend:

### 1. Frontend State Management Bug
**Location:** `apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts`

The `setGitStatus` function had an optimization that compared file lists (modified, added, deleted) and skipped updates if they were the same. However, it **did not compare the actual diff content** in the `files` object.

When a file changed from "a" to "aa", it remained in the `modified` array, so the update was skipped and the new diff content was never stored.

### 2. Backend Snapshot Deduplication Bug
**Location:** `apps/backend/internal/orchestrator/event_handlers.go`

The `isSnapshotDuplicate` function compared file metadata (staged status, additions/deletions counts) but **not the actual diff content**. When a file's content changed, if the metadata was the same, the snapshot was incorrectly marked as a duplicate and not saved to the database.

## Changes

### Frontend
- **session-runtime-slice.ts**: Removed premature optimization in `setGitStatus` - now always updates when backend sends new git status
- **task-changes-panel.tsx**: Reversed diff content priority to show current git status over historical content; improved React key to include timestamp

### Backend
- **event_handlers.go**: Updated `isSnapshotDuplicate` to compare actual diff content
  - Added `diff` field to `fileInfoCompare` struct
  - Updated `extractFileInfo` to extract diff content
  - Updated comparison logic to include diff content check

## Testing

- ✅ Frontend linting passes
- ✅ Backend tests pass (all tests successful)
- ✅ Manual testing confirms diff view now updates correctly

## Impact

This fixes a critical UX bug where users couldn't see the latest changes made by agents in the diff view, leading to confusion about what the agent actually did.