### PR TITLE
feat(codex): add support for mcpToolCall item type

### DIFF
--- a/apps/backend/pkg/codex/types.go
+++ b/apps/backend/pkg/codex/types.go
@@ -177,7 +177,7 @@ type TurnStartResult struct {
 // Item represents a Codex item (message, command, file change, etc.)
 type Item struct {
 	ID     string `json:"id"`
-	Type   string `json:"type"`   // "userMessage", "agentMessage", "commandExecution", "fileChange", "reasoning"
+	Type   string `json:"type"`   // "userMessage", "agentMessage", "commandExecution", "fileChange", "reasoning", "mcpToolCall"
 	Status string `json:"status"` // "inProgress", "completed", "failed"
 
 	// For commandExecution type
@@ -194,6 +194,13 @@ type Item struct {
 	// or plain strings. FlexibleContent handles both formats.
 	Summary FlexibleContent `json:"summary,omitempty"`
 	Content FlexibleContent `json:"content,omitempty"`
+
+	// For mcpToolCall type
+	Server       string          `json:"server,omitempty"`
+	Tool         string          `json:"tool,omitempty"`
+	Arguments    json.RawMessage `json:"arguments,omitempty"`
+	Result       json.RawMessage `json:"result,omitempty"`
+	ToolError    string          `json:"error,omitempty"` // Named ToolError to avoid conflict with Error type
 }
 
 // ContentPart represents a content part in a Codex item.


### PR DESCRIPTION
## Summary

Add handling for Codex `mcpToolCall` items so MCP tool calls (like `create_task_plan_kandev`) are properly displayed in the chat UI.

## Problem

Codex agent's MCP tool calls were not showing up in the chat UI. Other agents' MCP tool calls worked correctly, indicating the issue was in the Codex adapter specifically.

## Root Cause

The Codex adapter only processed `commandExecution` and `fileChange` item types in `handleNotification`. When Codex invokes MCP tools, it sends `mcpToolCall` items which were being silently ignored.

## Changes

### `apps/backend/pkg/codex/types.go`
- Added MCP tool call fields to the `Item` struct: `Server`, `Tool`, `Arguments`, `Result`, `ToolError`

### `apps/backend/internal/agentctl/server/adapter/transport/codex/normalize.go`
- Added `CodexItemMcpToolCall` constant
- Added `normalizeMcpToolCall()` method to convert MCP tool call data to `NormalizedPayload`

### `apps/backend/internal/agentctl/server/adapter/transport/codex/adapter.go`
- Added handling for `mcpToolCall` in `NotifyItemStarted` (sends `EventTypeToolCall`)
- Added handling for `mcpToolCall` in `NotifyItemCompleted` (sends `EventTypeToolUpdate`)

## Testing

- ✅ Build passes (`make -C apps/backend build`)
- ✅ All tests pass (`make -C apps/backend test`)
