### PR TITLE
feat: Add force push option to git push menu

### DIFF
--- a/apps/web/components/task/mobile/session-mobile-top-bar.tsx
+++ b/apps/web/components/task/mobile/session-mobile-top-bar.tsx
@@ -15,6 +15,7 @@ import {
   IconDots,
   IconCheck,
   IconLoader2,
+  IconAlertTriangle,
 } from '@tabler/icons-react';
 import { Button } from '@kandev/ui/button';
 import {
@@ -31,6 +32,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from '@kandev/ui/dropdown-menu';
 import { Textarea } from '@kandev/ui/textarea';
 import { Checkbox } from '@kandev/ui/checkbox';
@@ -124,8 +128,8 @@ export const SessionMobileTopBar = memo(function SessionMobileTopBar({
     handleGitOperation(() => pull(), 'Pull');
   }, [handleGitOperation, pull]);
 
-  const handlePush = useCallback(() => {
-    handleGitOperation(() => push(), 'Push');
+  const handlePush = useCallback((force = false) => {
+    handleGitOperation(() => push({ force }), force ? 'Force Push' : 'Push');
   }, [handleGitOperation, push]);
 
   const handleRebase = useCallback(() => {
@@ -265,14 +269,33 @@ export const SessionMobileTopBar = memo(function SessionMobileTopBar({
               <IconCloudDownload className="h-4 w-4 text-blue-500" />
               <span className="flex-1">Pull</span>
             </DropdownMenuItem>
-            <DropdownMenuItem
-              className="cursor-pointer gap-3"
-              onClick={handlePush}
-              disabled={isGitLoading || !sessionId}
-            >
-              <IconCloudUpload className="h-4 w-4 text-green-500" />
-              <span className="flex-1">Push</span>
-            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                className="cursor-pointer gap-3"
+                disabled={isGitLoading || !sessionId}
+              >
+                <IconCloudUpload className="h-4 w-4 text-green-500" />
+                <span className="flex-1">Push</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem
+                  className="cursor-pointer gap-3"
+                  onClick={() => handlePush(false)}
+                  disabled={isGitLoading || !sessionId}
+                >
+                  <IconCloudUpload className="h-4 w-4 text-green-500" />
+                  <span>Push</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="cursor-pointer gap-3"
+                  onClick={() => handlePush(true)}
+                  disabled={isGitLoading || !sessionId}
+                >
+                  <IconAlertTriangle className="h-4 w-4 text-orange-500" />
+                  <span>Force Push</span>
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
             <DropdownMenuSeparator />
             <DropdownMenuItem
               className="cursor-pointer gap-3"

--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -17,6 +17,7 @@ import {
   IconCloudUpload,
   IconGitCherryPick,
   IconGitCommit,
+  IconAlertTriangle,
 } from '@tabler/icons-react';
 import { Button } from '@kandev/ui/button';
 import {
@@ -33,6 +34,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from '@kandev/ui/dropdown-menu';
 import { Textarea } from '@kandev/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@kandev/ui/tooltip';
@@ -158,8 +162,8 @@ const TaskTopBar = memo(function TaskTopBar({
     handleGitOperation(() => pull(), 'Pull');
   }, [handleGitOperation, pull]);
 
-  const handlePush = useCallback(() => {
-    handleGitOperation(() => push(), 'Push');
+  const handlePush = useCallback((force = false) => {
+    handleGitOperation(() => push({ force }), force ? 'Force Push' : 'Push');
   }, [handleGitOperation, push]);
 
   const handleRebase = useCallback(() => {
@@ -480,20 +484,39 @@ const TaskTopBar = memo(function TaskTopBar({
                   </span>
                 )}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                className="cursor-pointer gap-3"
-                onClick={handlePush}
-                disabled={isGitLoading || !activeSessionId}
-              >
-                <IconCloudUpload className="h-4 w-4 text-green-500" />
-                <span className="flex-1">Push</span>
-                {/* Only show push count when upstream matches current branch (origin/<branch>) */}
-                {hasMatchingUpstream && (gitStatus?.ahead ?? 0) > 0 && (
-                  <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">
-                    ↑{gitStatus?.ahead}
-                  </span>
-                )}
-              </DropdownMenuItem>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger
+                  className="cursor-pointer gap-3"
+                  disabled={isGitLoading || !activeSessionId}
+                >
+                  <IconCloudUpload className="h-4 w-4 text-green-500" />
+                  <span className="flex-1">Push</span>
+                  {/* Only show push count when upstream matches current branch (origin/<branch>) */}
+                  {hasMatchingUpstream && (gitStatus?.ahead ?? 0) > 0 && (
+                    <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">
+                      ↑{gitStatus?.ahead}
+                    </span>
+                  )}
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-3"
+                    onClick={() => handlePush(false)}
+                    disabled={isGitLoading || !activeSessionId}
+                  >
+                    <IconCloudUpload className="h-4 w-4 text-green-500" />
+                    <span>Push</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-3"
+                    onClick={() => handlePush(true)}
+                    disabled={isGitLoading || !activeSessionId}
+                  >
+                    <IconAlertTriangle className="h-4 w-4 text-orange-500" />
+                    <span>Force Push</span>
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="cursor-pointer gap-3"


### PR DESCRIPTION
## Summary
Adds force push capability to the frontend UI by exposing the existing backend force push functionality through a nested submenu.

## Changes
- Add nested submenu to Push menu item with two options:
  - **Push** - Normal push (green cloud icon)
  - **Force Push** - Force push with warning icon (orange alert triangle)
- Update `handlePush` callback to accept `force` parameter
- Implement in both desktop (`task-top-bar.tsx`) and mobile (`session-mobile-top-bar.tsx`) UIs

## Safety Features
✅ Backend uses `--force-with-lease` instead of `--force`
- Only force pushes if remote branch hasn't been updated by someone else
- Prevents accidentally overwriting commits from other developers

✅ Visual warning with orange alert triangle icon
✅ Nested menu requires deliberate two-click action

## Technical Details
- No backend changes required (already supports force push)
- Uses native shadcn dropdown submenu components
- Maintains consistency between desktop and mobile UIs
- Follows existing codebase patterns

## Testing
- [ ] Normal push works without force parameter
- [ ] Force push option appears in dropdown submenu
- [ ] Force push sends `force: true` to backend
- [ ] Visual distinction between push and force push is clear
- [ ] Mobile UI works correctly
- [ ] Desktop UI works correctly

## Screenshots
The Push menu item now opens a submenu with:
```
├── Push ☁️ (green)
└── Force Push ⚠️ (orange)
```