### PR TITLE
fix: remove transparent background that was hiding diff line colors

### DIFF
--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -452,10 +452,6 @@ export const DiffViewer = memo(function DiffViewer({
       lineDiffType: 'word',
       overflow: wordWrap ? 'wrap' : 'scroll',
       unsafeCSS: `
-        * {
-          background: transparent !important;
-        }
-
         /* Reduce icon size */
         [data-change-icon] {
           width: 12px !important;


### PR DESCRIPTION
Fixes the diff viewer to properly show green/red background blocks for additions and deletions.

## Problem
The `unsafeCSS` rule with `background: transparent !important` was overriding the library's default green/red background colors for addition/deletion lines. This was introduced in #171 but broke the visual diff highlighting.

## Solution
Removed the `* { background: transparent !important; }` rule while keeping the other useful CSS customizations (icon size and header padding).

## Result
- ✅ Diff lines now show proper green backgrounds for additions
- ✅ Diff lines now show proper red backgrounds for deletions
- ✅ Line numbers still show in different colors
- ✅ Other CSS customizations preserved