### PR TITLE
feat(claude-code): add Claude Opus 4.6 model support

### DIFF
--- a/apps/backend/internal/agent/registry/agents.json
+++ b/apps/backend/internal/agent/registry/agents.json
@@ -436,6 +436,14 @@
             "is_default": true
           },
           {
+            "id": "claude-opus-4-6",
+            "name": "Claude Opus 4.6",
+            "description": "Latest and most capable model for complex tasks",
+            "provider": "anthropic",
+            "context_window": 200000,
+            "is_default": false
+          },
+          {
             "id": "claude-opus-4-5",
             "name": "Claude Opus 4.5",
             "description": "Most capable model for complex tasks",


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-6` (Claude Opus 4.6) to the claude-code agent's available models in `agents.json`

## Test plan
- [ ] Verify the claude-code agent lists Opus 4.6 in available models via `GET /api/v1/agent-models/claude-code`
- [ ] Verify selecting Opus 4.6 works end-to-end in a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)