### PR TITLE
fix: cancel button always disabled when agent is running

### DIFF
--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -126,7 +126,6 @@ const ChatInputToolbar = memo(function ChatInputToolbar({
                 variant="secondary"
                 size="icon"
                 className="h-7 w-7 rounded-full cursor-pointer bg-destructive/10 text-destructive hover:bg-destructive/20"
-                disabled={isDisabled}
                 onClick={onCancel}
               >
                 <IconPlayerStopFilled className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- The cancel/stop button in the chat input toolbar was always disabled when the agent was running, making it impossible to cancel a running prompt
- Root cause: `isDisabled` was computed as `isAgentBusy || isStarting || isSending`, and this same flag was passed to the cancel button's `disabled` prop — but the cancel button is only rendered when `isAgentBusy` is `true`, so it was permanently disabled whenever visible
- Fix: removed the `disabled` prop from the cancel button so it's always clickable when shown

## Test plan
- [ ] Start an agent prompt and verify the stop button is clickable
- [ ] Click the stop button and verify the agent cancels successfully
- [ ] Verify the submit button is still disabled while the agent is running
- [ ] Verify the submit button works normally when the agent is idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)