### PR TITLE
fix: resume failed task sessions instead of returning errors

### DIFF
--- a/apps/backend/internal/task/handlers/message_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_test.go
@@ -1,0 +1,140 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/task/controller"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/service"
+)
+
+// sessionStateSequencer is a mock repository that returns a sequence of session states.
+// Each call to GetTaskSession returns the next state in the sequence.
+type sessionStateSequencer struct {
+	mockRepository
+	mu     sync.Mutex
+	states []models.TaskSessionState
+	errors []string
+	call   int
+}
+
+func (s *sessionStateSequencer) GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.call
+	if idx >= len(s.states) {
+		idx = len(s.states) - 1
+	}
+	s.call++
+	errMsg := ""
+	if idx < len(s.errors) {
+		errMsg = s.errors[idx]
+	}
+	return &models.TaskSession{
+		ID:           id,
+		State:        s.states[idx],
+		ErrorMessage: errMsg,
+	}, nil
+}
+
+func newTestMessageHandlers(t *testing.T, repo *sessionStateSequencer) *MessageHandlers {
+	t.Helper()
+	log, err := logger.NewLogger(logger.LoggingConfig{
+		Level:  "error",
+		Format: "json",
+	})
+	require.NoError(t, err)
+	svc := service.NewService(repo, nil, log, service.RepositoryDiscoveryConfig{})
+	taskCtrl := controller.NewTaskController(svc)
+	return NewMessageHandlers(nil, taskCtrl, nil, log)
+}
+
+func TestWaitForSessionReady_ImmediatelyReady(t *testing.T) {
+	repo := &sessionStateSequencer{
+		states: []models.TaskSessionState{models.TaskSessionStateWaitingForInput},
+	}
+	h := newTestMessageHandlers(t, repo)
+
+	err := h.waitForSessionReady(context.Background(), "session-1")
+	assert.NoError(t, err)
+}
+
+func TestWaitForSessionReady_TransitionsToReady(t *testing.T) {
+	repo := &sessionStateSequencer{
+		states: []models.TaskSessionState{
+			models.TaskSessionStateStarting,
+			models.TaskSessionStateStarting,
+			models.TaskSessionStateWaitingForInput,
+		},
+	}
+	h := newTestMessageHandlers(t, repo)
+
+	err := h.waitForSessionReady(context.Background(), "session-1")
+	assert.NoError(t, err)
+}
+
+func TestWaitForSessionReady_Failed(t *testing.T) {
+	repo := &sessionStateSequencer{
+		states: []models.TaskSessionState{
+			models.TaskSessionStateStarting,
+			models.TaskSessionStateFailed,
+		},
+		errors: []string{"", "agent crashed"},
+	}
+	h := newTestMessageHandlers(t, repo)
+
+	err := h.waitForSessionReady(context.Background(), "session-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent crashed")
+}
+
+func TestWaitForSessionReady_FailedEmptyMessage(t *testing.T) {
+	repo := &sessionStateSequencer{
+		states: []models.TaskSessionState{models.TaskSessionStateFailed},
+	}
+	h := newTestMessageHandlers(t, repo)
+
+	err := h.waitForSessionReady(context.Background(), "session-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session failed during resume")
+}
+
+func TestWaitForSessionReady_Cancelled(t *testing.T) {
+	repo := &sessionStateSequencer{
+		states: []models.TaskSessionState{models.TaskSessionStateCancelled},
+	}
+	h := newTestMessageHandlers(t, repo)
+
+	err := h.waitForSessionReady(context.Background(), "session-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected state")
+}
+
+func TestWaitForSessionReady_ContextCancelled(t *testing.T) {
+	repo := &sessionStateSequencer{
+		states: []models.TaskSessionState{
+			models.TaskSessionStateStarting,
+			models.TaskSessionStateStarting,
+			models.TaskSessionStateStarting,
+		},
+	}
+	h := newTestMessageHandlers(t, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a brief delay
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		cancel()
+	}()
+
+	err := h.waitForSessionReady(ctx, "session-1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
## Summary
- **Preserve ExecutorRunning records for resumable failed sessions** on backend startup, so the ResumeToken (ACP session ID) is not lost and users can resume later
- **Replace naive 3x500ms retry loop** with proper `waitForSessionReady` polling (1s interval, 90s timeout) that waits for the agent to actually be ready before sending the prompt
- Add unit tests for the new `waitForSessionReady` method

## Test plan
- [ ] Fail a task session (e.g., agent crash), restart the backend, then send a message to resume — should succeed instead of returning "session is not resumable"
- [ ] Fail a task session without restarting the backend, send a message — should auto-resume and deliver the prompt once the agent is ready
- [ ] Verify completed/cancelled sessions still get their ExecutorRunning records cleaned up on restart
- [ ] Run `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)