### PR TITLE
fix: refetch git status when switching back to a previously viewed task

### DIFF
--- a/apps/web/hooks/domains/session/use-session-git-status.ts
+++ b/apps/web/hooks/domains/session/use-session-git-status.ts
@@ -96,10 +96,19 @@ export function useSessionGitStatus(sessionId: string | null) {
     }
     prevSessionIdRef.current = sessionId;
 
-    // Skip fetch if we already have status or already fetched for this session
-    const currentStatus = storeApi.getState().gitStatus.bySessionId[sessionId];
-    if (currentStatus || hasFetchedRef.current) {
+    // Skip fetch if we already fetched for this session (and session hasn't changed)
+    // When session changed, always refetch to get the latest status even if cached
+    if (hasFetchedRef.current) {
       return;
+    }
+
+    // If we haven't fetched yet and status already exists (e.g., from WebSocket), skip
+    if (!sessionChanged) {
+      const currentStatus = storeApi.getState().gitStatus.bySessionId[sessionId];
+      if (currentStatus) {
+        hasFetchedRef.current = true;
+        return;
+      }
     }
 
     hasFetchedRef.current = true;


### PR DESCRIPTION
## Summary
- Fixes stale git status (diff stats) shown in the task sidebar when switching back to a previously viewed task
- The `useSessionGitStatus` hook was short-circuiting refetches when cached status existed in the store, even after a session change
- Now always refetches from the backend via `session.git.snapshots` when the active session changes, while still avoiding duplicate fetches on re-renders

## Test plan
- [ ] Open two tasks that have different git changes
- [ ] View Task A, note the diff stats in the sidebar
- [ ] Switch to Task B, make some git changes on Task A's branch (e.g., via agent or external terminal)
- [ ] Switch back to Task A — verify the diff stats update without needing a page refresh
- [ ] Verify no duplicate fetch requests on re-renders (check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)