### PR TITLE
cleanup: remove dead FileListUpdate streaming path

### DIFF
--- a/apps/backend/internal/agentctl/client/client.go
+++ b/apps/backend/internal/agentctl/client/client.go
@@ -259,7 +259,6 @@ type (
 	GitCommitNotification  = types.GitCommitNotification
 	GitResetNotification   = types.GitResetNotification
 	FileInfo               = types.FileInfo
-	FileListUpdate         = types.FileListUpdate
 	FileEntry              = types.FileEntry
 	FileTreeNode           = types.FileTreeNode
 	FileTreeRequest        = types.FileTreeRequest
@@ -718,7 +717,6 @@ type WorkspaceStreamCallbacks struct {
 	OnGitCommit     func(notification *GitCommitNotification)
 	OnGitReset      func(notification *GitResetNotification)
 	OnFileChange    func(notification *FileChangeNotification)
-	OnFileList      func(update *FileListUpdate)
 	OnProcessOutput func(output *types.ProcessOutput)
 	OnProcessStatus func(status *types.ProcessStatusUpdate)
 	OnConnected     func()
@@ -804,10 +802,6 @@ func (c *Client) StreamWorkspace(ctx context.Context, callbacks WorkspaceStreamC
 			case types.WorkspaceMessageTypeFileChange:
 				if callbacks.OnFileChange != nil && msg.FileChange != nil {
 					callbacks.OnFileChange(msg.FileChange)
-				}
-			case types.WorkspaceMessageTypeFileList:
-				if callbacks.OnFileList != nil && msg.FileList != nil {
-					callbacks.OnFileList(msg.FileList)
 				}
 			case types.WorkspaceMessageTypeProcessOutput:
 				if callbacks.OnProcessOutput != nil && msg.ProcessOutput != nil {

--- a/apps/backend/internal/agentctl/types/types.go
+++ b/apps/backend/internal/agentctl/types/types.go
@@ -161,7 +161,6 @@ const (
 	WorkspaceMessageTypePong          WorkspaceMessageType = "pong"
 	WorkspaceMessageTypeGitStatus     WorkspaceMessageType = "git_status"
 	WorkspaceMessageTypeFileChange    WorkspaceMessageType = "file_change"
-	WorkspaceMessageTypeFileList      WorkspaceMessageType = "file_list"
 	WorkspaceMessageTypeError         WorkspaceMessageType = "error"
 	WorkspaceMessageTypeConnected     WorkspaceMessageType = "connected"
 	WorkspaceMessageTypeShellResize   WorkspaceMessageType = "shell_resize"
@@ -191,9 +190,6 @@ type WorkspaceStreamMessage struct {
 
 	// File change fields (for file_change)
 	FileChange *FileChangeNotification `json:"file_change,omitempty"`
-
-	// File list fields (for file_list)
-	FileList *FileListUpdate `json:"file_list,omitempty"`
 
 	// Process fields (for process_output, process_status)
 	ProcessOutput *ProcessOutput       `json:"process_output,omitempty"`
@@ -260,15 +256,6 @@ func NewWorkspaceFileChange(notification *FileChangeNotification) WorkspaceStrea
 		Type:       WorkspaceMessageTypeFileChange,
 		Timestamp:  timeNowUnixMilli(),
 		FileChange: notification,
-	}
-}
-
-// NewWorkspaceFileList creates a file list message
-func NewWorkspaceFileList(update *FileListUpdate) WorkspaceStreamMessage {
-	return WorkspaceStreamMessage{
-		Type:      WorkspaceMessageTypeFileList,
-		Timestamp: timeNowUnixMilli(),
-		FileList:  update,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove `notifyWorkspaceStreamFileList()` and its call sites from `workspace_tracker.go`
- Remove `WorkspaceMessageTypeFileList` constant, `FileList` field from `WorkspaceStreamMessage`, and `NewWorkspaceFileList()` factory from `types.go`
- Remove `OnFileList` callback, its switch case, and `FileListUpdate` type alias re-export from `client.go`

The `FileListUpdate` streaming path was never consumed — `OnFileList` was never wired up in the lifecycle `StreamCallbacks`, so messages were silently dropped. The `currentFiles` state and its backing data types (`FileListUpdate`, `FileEntry`) are kept since `SearchFiles()` depends on them.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests green)
- [ ] Verify file search still works in the UI (reads `currentFiles` which is still updated)
- [ ] Verify file change notifications still flow to the frontend via `FileChangeNotification`

🤖 Generated with [Claude Code](https://claude.com/claude-code)