### PR TITLE
fix: release notes button not visible on new database

### DIFF
--- a/apps/backend/internal/user/store/sqlite.go
+++ b/apps/backend/internal/user/store/sqlite.go
@@ -185,6 +185,9 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 	settings.UserID = userID
 	if settingsRaw == "" || settingsRaw == "{}" {
 		settings.RepositoryIDs = []string{}
+		settings.ShowReleaseNotification = true
+		settings.ReviewAutoMarkOnScroll = true
+		settings.ChatSubmitKey = "cmd_enter"
 		return settings, nil
 	}
 	var payload struct {


### PR DESCRIPTION
Two bugs prevented the topbar release notification from showing on a fresh database.

**Backend (`store/sqlite.go`):** When user settings are empty (`{}`), `scanUserSettings` returned early before applying field defaults, leaving `ShowReleaseNotification` as `false` (Go zero value). Also fixed `ReviewAutoMarkOnScroll` and `ChatSubmitKey` which had the same early-return issue.

**Script (`generate-release-notes.mjs`):** When the current version tag (e.g. `0.8`) has no entry in `CHANGELOG.md` yet, the script wrote empty notes — making `hasReleaseNotes()` always return `false` and the button never render. Now falls back to the most recent changelog version that has notes.

**Validation**
- Traced `scanUserSettings` with `settingsRaw = "{}"` — confirmed all three defaults now applied before early return
- Ran `node scripts/generate-release-notes.mjs` locally: `[release-notes] version 0.8 not in CHANGELOG.md — fell back to 0.7`
- Verified `generated/release-notes.json` now has `version: "0.7"` with populated notes, making `hasReleaseNotes()` return `true`