### PR TITLE
feat: improve session restoration for complete/failed/cancelled

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -68,19 +68,20 @@ func (a *lifecycleAdapter) LaunchAgent(ctx context.Context, req *executor.Launch
 	// The RepositoryURL field contains a local filesystem path for the workspace
 	// If empty, the agent will run without a mounted workspace
 	launchReq := &lifecycle.LaunchRequest{
-		TaskID:          req.TaskID,
-		SessionID:       req.SessionID,
-		TaskTitle:       req.TaskTitle,
-		AgentProfileID:  req.AgentProfileID,
-		WorkspacePath:   req.RepositoryURL, // May be empty - lifecycle manager handles this
-		TaskDescription: req.TaskDescription,
-		Env:             req.Env,
-		ACPSessionID:    req.ACPSessionID,
-		Metadata:        req.Metadata,
-		ModelOverride:   req.ModelOverride,
-		ExecutorType:    req.ExecutorType,
-		ExecutorConfig:  req.ExecutorConfig,
-		SetupScript:     req.SetupScript,
+		TaskID:              req.TaskID,
+		SessionID:           req.SessionID,
+		TaskTitle:           req.TaskTitle,
+		AgentProfileID:      req.AgentProfileID,
+		WorkspacePath:       req.RepositoryURL, // May be empty - lifecycle manager handles this
+		TaskDescription:     req.TaskDescription,
+		Env:                 req.Env,
+		ACPSessionID:        req.ACPSessionID,
+		Metadata:            req.Metadata,
+		ModelOverride:       req.ModelOverride,
+		ExecutorType:        req.ExecutorType,
+		ExecutorConfig:      req.ExecutorConfig,
+		PreviousExecutionID: req.PreviousExecutionID,
+		SetupScript:         req.SetupScript,
 		// Worktree configuration for concurrent agent execution
 		UseWorktree:          req.UseWorktree,
 		RepositoryID:         req.RepositoryID,
@@ -236,6 +237,11 @@ func (a *lifecycleAdapter) PollRemoteStatusForRecords(ctx context.Context, recor
 
 func (a *lifecycleAdapter) CleanupStaleExecutionBySessionID(ctx context.Context, sessionID string) error {
 	return a.mgr.CleanupStaleExecutionBySessionID(ctx, sessionID)
+}
+
+func (a *lifecycleAdapter) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID, sessionID string) error {
+	_, err := a.mgr.EnsureWorkspaceExecutionForSession(ctx, taskID, sessionID)
+	return err
 }
 
 func (a *lifecycleAdapter) GetRemoteRuntimeStatusBySession(ctx context.Context, sessionID string) (*executor.RemoteRuntimeStatus, error) {

--- a/apps/backend/internal/agent/lifecycle/executor_backend.go
+++ b/apps/backend/internal/agent/lifecycle/executor_backend.go
@@ -64,9 +64,6 @@ const (
 	MetadataKeyRemoteAuthHome  = "remote_auth_target_home"
 	MetadataKeyGitUserName     = "git_user_name"
 	MetadataKeyGitUserEmail    = "git_user_email"
-	MetadataKeyRemoteReconnect = "remote_reconnect_required"
-	MetadataKeyRemoteName      = "remote_reconnect_name"
-	MetadataKeyRemoteExecID    = "remote_previous_execution_id"
 )
 
 // RemoteStatus describes runtime health/details for remote executors.
@@ -95,16 +92,17 @@ type RemoteStatusProvider interface {
 
 // ExecutorCreateRequest contains parameters for creating an agentctl instance.
 type ExecutorCreateRequest struct {
-	InstanceID     string
-	TaskID         string
-	SessionID      string
-	AgentProfileID string
-	WorkspacePath  string
-	Protocol       string
-	Env            map[string]string
-	Metadata       map[string]interface{}
-	McpServers     []McpServerConfig
-	AgentConfig    agents.Agent // Agent type info needed by runtimes
+	InstanceID          string
+	TaskID              string
+	SessionID           string
+	AgentProfileID      string
+	WorkspacePath       string
+	Protocol            string
+	Env                 map[string]string
+	Metadata            map[string]interface{}
+	McpServers          []McpServerConfig
+	AgentConfig         agents.Agent // Agent type info needed by runtimes
+	PreviousExecutionID string       // Non-empty when reconnecting to a previous execution
 
 	// OnProgress is an optional callback for streaming preparation progress.
 	// Executors that perform multi-step setup (e.g. Sprites, remote Docker) can

--- a/apps/backend/internal/agent/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/lifecycle/manager_launch.go
@@ -183,16 +183,17 @@ func (m *Manager) launchBuildExecutorRequest(ctx context.Context, executionID st
 	metadata := buildLaunchMetadata(reqWithWorktree, mainRepoGitDir, worktreeID, worktreeBranch)
 
 	execReq := &ExecutorCreateRequest{
-		InstanceID:     executionID,
-		TaskID:         reqWithWorktree.TaskID,
-		SessionID:      reqWithWorktree.SessionID,
-		AgentProfileID: reqWithWorktree.AgentProfileID,
-		WorkspacePath:  reqWithWorktree.WorkspacePath,
-		Protocol:       string(agentConfig.Runtime().Protocol),
-		Env:            env,
-		Metadata:       metadata,
-		AgentConfig:    agentConfig,
-		McpServers:     mcpServers,
+		InstanceID:          executionID,
+		TaskID:              reqWithWorktree.TaskID,
+		SessionID:           reqWithWorktree.SessionID,
+		AgentProfileID:      reqWithWorktree.AgentProfileID,
+		WorkspacePath:       reqWithWorktree.WorkspacePath,
+		Protocol:            string(agentConfig.Runtime().Protocol),
+		Env:                 env,
+		Metadata:            metadata,
+		AgentConfig:         agentConfig,
+		McpServers:          mcpServers,
+		PreviousExecutionID: reqWithWorktree.PreviousExecutionID,
 		OnProgress: func(step PrepareStep, stepIndex int, totalSteps int) {
 			m.eventPublisher.PublishPrepareProgress(reqWithWorktree.SessionID, &PrepareProgressEventPayload{
 				TaskID:     reqWithWorktree.TaskID,

--- a/apps/backend/internal/agent/lifecycle/types.go
+++ b/apps/backend/internal/agent/lifecycle/types.go
@@ -171,8 +171,9 @@ type LaunchRequest struct {
 	ModelOverride   string // If set, use this model instead of the profile's model
 
 	// Executor configuration - determines which runtime to use
-	ExecutorType   string            // Executor type (e.g., "local", "worktree", "local_docker") - determines runtime
-	ExecutorConfig map[string]string // Executor config (docker_host, git_token, etc.)
+	ExecutorType        string            // Executor type (e.g., "local", "worktree", "local_docker") - determines runtime
+	ExecutorConfig      map[string]string // Executor config (docker_host, git_token, etc.)
+	PreviousExecutionID string            // Previous execution ID for runtime reconnect
 
 	// Environment preparation
 	SetupScript string // Setup script to run before agent starts
@@ -240,6 +241,12 @@ type WorkspaceInfo struct {
 	AgentProfileID string // Optional - agent profile for the task
 	AgentID        string // Agent type ID (e.g., "auggie", "codex") - required for runtime creation
 	ACPSessionID   string // Agent's session ID for conversation resumption (from session metadata)
+
+	// Executor-aware fields for correct runtime selection and remote reconnection
+	ExecutorType     string                 // Executor type (e.g., "local_pc", "sprites")
+	RuntimeName      string                 // Runtime name from ExecutorRunning record
+	AgentExecutionID string                 // Previous execution ID (for remote reconnect)
+	Metadata         map[string]interface{} // Additional metadata (reconnect flags)
 }
 
 // WorkspaceInfoProvider provides workspace information for tasks

--- a/apps/backend/internal/integration/simulated_agent_manager_test.go
+++ b/apps/backend/internal/integration/simulated_agent_manager_test.go
@@ -418,3 +418,6 @@ func (s *SimulatedAgentManagerClient) PollRemoteStatusForRecords(ctx context.Con
 func (s *SimulatedAgentManagerClient) CleanupStaleExecutionBySessionID(ctx context.Context, sessionID string) error {
 	return nil
 }
+func (s *SimulatedAgentManagerClient) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID, sessionID string) error {
+	return nil
+}

--- a/apps/backend/internal/orchestrator/dto/dto.go
+++ b/apps/backend/internal/orchestrator/dto/dto.go
@@ -95,10 +95,11 @@ type TaskSessionStatusResponse struct {
 	AgentProfileID string `json:"agent_profile_id,omitempty"`
 
 	// Runtime status
-	IsAgentRunning bool   `json:"is_agent_running"`        // Agent process is currently running
-	IsResumable    bool   `json:"is_resumable"`            // Session can be resumed
-	NeedsResume    bool   `json:"needs_resume"`            // Session needs resumption (page reload scenario)
-	ResumeReason   string `json:"resume_reason,omitempty"` // Why resume is needed (e.g., "agent_not_running")
+	IsAgentRunning        bool   `json:"is_agent_running"`        // Agent process is currently running
+	IsResumable           bool   `json:"is_resumable"`            // Session can be resumed
+	NeedsResume           bool   `json:"needs_resume"`            // Session needs resumption (page reload scenario)
+	NeedsWorkspaceRestore bool   `json:"needs_workspace_restore"` // Session workspace can be restored (terminal state)
+	ResumeReason          string `json:"resume_reason,omitempty"` // Why resume is needed (e.g., "agent_not_running")
 
 	// ACP session info
 	ACPSessionID string `json:"acp_session_id,omitempty"`

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -147,6 +147,9 @@ func (m *mockAgentManager) PollRemoteStatusForRecords(_ context.Context, _ []exe
 func (m *mockAgentManager) CleanupStaleExecutionBySessionID(_ context.Context, _ string) error {
 	return nil
 }
+func (m *mockAgentManager) EnsureWorkspaceExecutionForSession(_ context.Context, _, _ string) error {
+	return nil
+}
 
 // --- Helpers ---
 

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -114,6 +114,11 @@ type AgentManagerClient interface {
 	// tracking store. Used when the agent process has exited but the execution entry
 	// was not cleaned up (e.g. prepared workspace where agent was never started).
 	CleanupStaleExecutionBySessionID(ctx context.Context, sessionID string) error
+
+	// EnsureWorkspaceExecutionForSession ensures an agentctl execution exists for a
+	// session so that workspace operations (file tree, terminals, git) are accessible.
+	// Used for restoring workspace access on terminal-state sessions.
+	EnsureWorkspaceExecutionForSession(ctx context.Context, taskID, sessionID string) error
 }
 
 // RemoteRuntimeStatus mirrors runtime status details needed by orchestrator/UI.
@@ -150,20 +155,21 @@ type AgentProfileInfo struct {
 
 // LaunchAgentRequest contains parameters for launching an agent
 type LaunchAgentRequest struct {
-	TaskID          string
-	SessionID       string
-	TaskTitle       string // Human-readable task title for semantic worktree naming
-	AgentProfileID  string
-	RepositoryURL   string
-	Branch          string
-	TaskDescription string // Task description to send via ACP prompt
-	Priority        int
-	Metadata        map[string]interface{}
-	Env             map[string]string
-	ACPSessionID    string            // ACP session ID to resume, if available
-	ModelOverride   string            // If set, use this model instead of the profile's model
-	ExecutorType    string            // Executor type (e.g., "local", "worktree", "local_docker") - determines runtime
-	ExecutorConfig  map[string]string // Executor config (docker_host, git_token, etc.)
+	TaskID              string
+	SessionID           string
+	TaskTitle           string // Human-readable task title for semantic worktree naming
+	AgentProfileID      string
+	RepositoryURL       string
+	Branch              string
+	TaskDescription     string // Task description to send via ACP prompt
+	Priority            int
+	Metadata            map[string]interface{}
+	Env                 map[string]string
+	ACPSessionID        string            // ACP session ID to resume, if available
+	ModelOverride       string            // If set, use this model instead of the profile's model
+	ExecutorType        string            // Executor type (e.g., "local", "worktree", "local_docker") - determines runtime
+	ExecutorConfig      map[string]string // Executor config (docker_host, git_token, etc.)
+	PreviousExecutionID string            // Previous execution ID for runtime reconnect
 
 	// Setup script from executor profile (runs in execution environment before agent starts)
 	SetupScript string

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -334,13 +334,8 @@ func (e *Executor) applyRunningRecordToResumeRequest(ctx context.Context, req *L
 		return nil
 	}
 
-	if req.ExecutorType == string(models.ExecutorTypeSprites) && running.AgentExecutionID != "" {
-		if req.Metadata == nil {
-			req.Metadata = make(map[string]interface{})
-		}
-		req.Metadata[lifecycle.MetadataKeyRemoteReconnect] = true
-		req.Metadata[lifecycle.MetadataKeyRemoteExecID] = running.AgentExecutionID
-		req.Metadata[lifecycle.MetadataKeyRemoteName] = spriteNameFromExecutionID(running.AgentExecutionID)
+	if running.AgentExecutionID != "" {
+		req.PreviousExecutionID = running.AgentExecutionID
 	}
 
 	if running.ResumeToken != "" && startAgent {
@@ -361,17 +356,6 @@ func (e *Executor) applyRunningRecordToResumeRequest(ctx context.Context, req *L
 	}
 
 	return running
-}
-
-func spriteNameFromExecutionID(executionID string) string {
-	if executionID == "" {
-		return ""
-	}
-	trimmed := executionID
-	if len(trimmed) > 12 {
-		trimmed = trimmed[:12]
-	}
-	return "kandev-" + trimmed
 }
 
 // applyResumeRepoConfig resolves repository details and applies them to req.

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -89,6 +89,9 @@ func (m *mockAgentManager) PollRemoteStatusForRecords(ctx context.Context, recor
 func (m *mockAgentManager) CleanupStaleExecutionBySessionID(ctx context.Context, sessionID string) error {
 	return nil
 }
+func (m *mockAgentManager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID, sessionID string) error {
+	return nil
+}
 
 func (m *mockAgentManager) ResolveAgentProfile(ctx context.Context, profileID string) (*AgentProfileInfo, error) {
 	if m.resolveAgentProfileFunc != nil {

--- a/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
+++ b/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
@@ -88,6 +88,9 @@ func (m *mockAgentManager) PollRemoteStatusForRecords(ctx context.Context, recor
 func (m *mockAgentManager) CleanupStaleExecutionBySessionID(ctx context.Context, sessionID string) error {
 	return nil
 }
+func (m *mockAgentManager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID, sessionID string) error {
+	return nil
+}
 
 func (m *mockAgentManager) CancelAgent(ctx context.Context, sessionID string) error {
 	return nil

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -752,6 +752,7 @@ func (s *Service) GetTaskSessionStatus(ctx context.Context, taskID, sessionID st
 			resp.IsAgentRunning = false
 			resp.IsResumable = false
 			resp.NeedsResume = false
+			resp.NeedsWorkspaceRestore = canRestoreWorkspace(&resp)
 			return resp, nil
 		}
 		return s.validateResumeEligibility(session, resp), nil
@@ -773,6 +774,7 @@ func (s *Service) GetTaskSessionStatus(ctx context.Context, taskID, sessionID st
 	resp.IsAgentRunning = false
 	resp.IsResumable = false
 	resp.NeedsResume = false
+	resp.NeedsWorkspaceRestore = canRestoreWorkspace(&resp)
 	return resp, nil
 }
 
@@ -822,6 +824,10 @@ func (s *Service) applyRemoteRuntimeStatus(ctx context.Context, sessionID string
 }
 
 // populateWorktreeInfo copies worktree path and branch into the response if present.
+func canRestoreWorkspace(resp *dto.TaskSessionStatusResponse) bool {
+	return resp != nil && resp.WorktreePath != nil && *resp.WorktreePath != ""
+}
+
 func populateWorktreeInfo(session *models.TaskSession, resp *dto.TaskSessionStatusResponse) {
 	if len(session.Worktrees) == 0 {
 		return

--- a/apps/backend/internal/task/service/service_turns_test.go
+++ b/apps/backend/internal/task/service/service_turns_test.go
@@ -1,0 +1,210 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestGetWorkspaceInfoForSession_BasicFields(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	now := time.Now().UTC()
+
+	session := &models.TaskSession{
+		ID:             "session-1",
+		TaskID:         "task-123",
+		AgentProfileID: "profile-1",
+		State:          models.TaskSessionStateCompleted,
+		AgentProfileSnapshot: map[string]interface{}{
+			"agent_name": "auggie",
+		},
+		Metadata: map[string]interface{}{
+			"acp_session_id": "acp-123",
+		},
+		StartedAt: now,
+		UpdatedAt: now,
+	}
+	if err := repo.CreateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	// Add a worktree to the session
+	if err := repo.CreateTaskSessionWorktree(ctx, &models.TaskSessionWorktree{
+		ID:             "wt1",
+		SessionID:      "session-1",
+		WorktreeID:     "wid1",
+		RepositoryID:   "repo1",
+		WorktreePath:   "/tmp/worktrees/session-1",
+		WorktreeBranch: "feature/test",
+		CreatedAt:      now,
+	}); err != nil {
+		t.Fatalf("failed to create worktree: %v", err)
+	}
+
+	info, err := svc.GetWorkspaceInfoForSession(ctx, "task-123", "session-1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceInfoForSession returned error: %v", err)
+	}
+
+	if info.TaskID != "task-123" {
+		t.Errorf("expected TaskID 'task-123', got %q", info.TaskID)
+	}
+	if info.SessionID != "session-1" {
+		t.Errorf("expected SessionID 'session-1', got %q", info.SessionID)
+	}
+	if info.WorkspacePath != "/tmp/worktrees/session-1" {
+		t.Errorf("expected WorkspacePath '/tmp/worktrees/session-1', got %q", info.WorkspacePath)
+	}
+	if info.AgentProfileID != "profile-1" {
+		t.Errorf("expected AgentProfileID 'profile-1', got %q", info.AgentProfileID)
+	}
+	if info.AgentID != "auggie" {
+		t.Errorf("expected AgentID 'auggie', got %q", info.AgentID)
+	}
+	if info.ACPSessionID != "acp-123" {
+		t.Errorf("expected ACPSessionID 'acp-123', got %q", info.ACPSessionID)
+	}
+}
+
+func TestGetWorkspaceInfoForSession_InfersTaskID(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	now := time.Now().UTC()
+
+	session := &models.TaskSession{
+		ID:        "session-1",
+		TaskID:    "task-123",
+		State:     models.TaskSessionStateCompleted,
+		StartedAt: now,
+		UpdatedAt: now,
+	}
+	if err := repo.CreateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	// Pass empty taskID - should be inferred from the session
+	info, err := svc.GetWorkspaceInfoForSession(ctx, "", "session-1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceInfoForSession returned error: %v", err)
+	}
+	if info.TaskID != "task-123" {
+		t.Errorf("expected TaskID 'task-123' inferred from session, got %q", info.TaskID)
+	}
+}
+
+func TestGetWorkspaceInfoForSession_ExecutorInfo(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	now := time.Now().UTC()
+
+	// Create executor
+	exec := &models.Executor{
+		ID:        "exec-1",
+		Name:      "My Sprites Executor",
+		Type:      models.ExecutorTypeSprites,
+		Status:    "active",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := repo.CreateExecutor(ctx, exec); err != nil {
+		t.Fatalf("failed to create executor: %v", err)
+	}
+
+	// Create session with executor reference
+	session := &models.TaskSession{
+		ID:         "session-1",
+		TaskID:     "task-123",
+		ExecutorID: "exec-1",
+		State:      models.TaskSessionStateCompleted,
+		AgentProfileSnapshot: map[string]interface{}{
+			"agent_name": "auggie",
+		},
+		StartedAt: now,
+		UpdatedAt: now,
+	}
+	if err := repo.CreateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	// Create executor running record
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "er-1",
+		SessionID:        "session-1",
+		TaskID:           "task-123",
+		ExecutorID:       "exec-1",
+		Runtime:          "sprites",
+		AgentExecutionID: "agent-exec-abc123",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("failed to upsert executor running: %v", err)
+	}
+
+	info, err := svc.GetWorkspaceInfoForSession(ctx, "task-123", "session-1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceInfoForSession returned error: %v", err)
+	}
+
+	if info.ExecutorType != "sprites" {
+		t.Errorf("expected ExecutorType 'sprites', got %q", info.ExecutorType)
+	}
+	if info.RuntimeName != "sprites" {
+		t.Errorf("expected RuntimeName 'sprites', got %q", info.RuntimeName)
+	}
+	if info.AgentExecutionID != "agent-exec-abc123" {
+		t.Errorf("expected AgentExecutionID 'agent-exec-abc123', got %q", info.AgentExecutionID)
+	}
+}
+
+func TestGetWorkspaceInfoForSession_NoExecutorRunning(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	now := time.Now().UTC()
+
+	session := &models.TaskSession{
+		ID:        "session-1",
+		TaskID:    "task-123",
+		State:     models.TaskSessionStateCompleted,
+		StartedAt: now,
+		UpdatedAt: now,
+	}
+	if err := repo.CreateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	// No executor running record - should still succeed with empty executor fields
+	info, err := svc.GetWorkspaceInfoForSession(ctx, "task-123", "session-1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceInfoForSession returned error: %v", err)
+	}
+	if info.RuntimeName != "" {
+		t.Errorf("expected empty RuntimeName, got %q", info.RuntimeName)
+	}
+	if info.AgentExecutionID != "" {
+		t.Errorf("expected empty AgentExecutionID, got %q", info.AgentExecutionID)
+	}
+	if info.ExecutorType != "" {
+		t.Errorf("expected empty ExecutorType, got %q", info.ExecutorType)
+	}
+}
+
+func TestGetWorkspaceInfoForSession_SessionNotFound(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.GetWorkspaceInfoForSession(ctx, "task-123", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent session")
+	}
+}

--- a/apps/web/lib/services/session-launch-helpers.ts
+++ b/apps/web/lib/services/session-launch-helpers.ts
@@ -90,6 +90,17 @@ export function buildResumeRequest(taskId: string, sessionId: string): BuildResu
   };
 }
 
+export function buildRestoreWorkspaceRequest(taskId: string, sessionId: string): BuildResult {
+  return {
+    request: {
+      task_id: taskId,
+      intent: "restore_workspace",
+      session_id: sessionId,
+    },
+    layout: "default",
+  };
+}
+
 export function buildWorkflowStepRequest(
   taskId: string,
   sessionId: string,

--- a/apps/web/lib/services/session-launch-service.ts
+++ b/apps/web/lib/services/session-launch-service.ts
@@ -1,6 +1,6 @@
 import { getWebSocketClient } from "@/lib/ws/connection";
 
-export type SessionIntent = "prepare" | "start" | "start_created" | "resume" | "workflow_step";
+export type SessionIntent = "prepare" | "start" | "start_created" | "resume" | "workflow_step" | "restore_workspace";
 
 export type LaunchSessionRequest = {
   task_id: string;


### PR DESCRIPTION
When a session reaches a terminal state (COMPLETED, FAILED, CANCELLED) with an associated worktree, the frontend had no way to restore workspace access (file tree, terminals, git status) without a full agent resume. Added a lightweight `restore_workspace` intent that creates an agentctl-only execution, plus fixed runtime safety issues and added comprehensive test coverage.

### Important Changes
- New `IntentRestoreWorkspace` / `launchRestoreWorkspace` path in orchestrator session launch
- `NeedsWorkspaceRestore` flag in session status DTO, gated on terminal state + valid worktree path
- `EnsureWorkspaceExecutionForSession` on `AgentManagerClient` interface creates agentctl execution without agent process
- `WorkspaceInfo` now carries executor-aware fields (`ExecutorType`, `RuntimeName`, `AgentExecutionID`) for correct runtime selection
- Frontend `use-session-resumption` hook handles new `needs_workspace_restore` status and calls `buildRestoreWorkspaceRequest`

### Validation
- `make fmt lint test` — 0 lint issues, all tests pass
- Added 17 new unit tests:
  - `TestBuildRemoteReconnectMetadata` (5 cases) — bounds checking for short execution IDs
  - `TestLaunchRestoreWorkspace_*` (5 cases) — missing session, wrong task, success, worktree info
  - `TestCanRestoreWorkspace` (4 cases) — nil/empty/valid inputs
  - `TestGetTaskSessionStatus_NeedsWorkspaceRestore_*` (2 cases) — terminal with/without worktree
  - `TestGetWorkspaceInfoForSession_*` (5 cases) — basic fields, inferred task ID, executor info, no executor, not found

### Possible Improvements
Low risk. The `canRestoreWorkspace` check only considers worktree path presence — in the future it could also verify the worktree directory still exists on disk before offering restore.