### PR TITLE
fix: standardize branding to KanDev across UI

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,7 +11,7 @@ import { GlobalCommands } from "@/components/global-commands";
 import { DiffWorkerPoolProvider } from "@/components/diff-worker-pool-provider";
 
 export const metadata: Metadata = {
-  title: "Kandev - AI Kanban",
+  title: "KanDev - AI Kanban",
   description: "AI-powered workflow management for developers",
 };
 
@@ -50,7 +50,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta name="apple-mobile-web-app-title" content="Kandev" />
+        <meta name="apple-mobile-web-app-title" content="KanDev" />
       </head>
       <body className="antialiased font-sans">
         {apiPort || mcpPort || debugMode ? (

--- a/apps/web/app/manifest.json
+++ b/apps/web/app/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Kandev",
-  "short_name": "Kandev",
+  "name": "KanDev",
+  "short_name": "KanDev",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",

--- a/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
+++ b/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
@@ -191,7 +191,7 @@ function McpServersEditor({
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="text-xs rounded-full border border-primary/50 bg-primary/10 px-2 py-1 text-primary">
-              ✓ Kandev MCP
+              ✓ KanDev MCP
             </span>
           </TooltipTrigger>
           <TooltipContent side="bottom" className="max-w-[320px] text-xs">

--- a/apps/web/components/settings/settings-app-sidebar.tsx
+++ b/apps/web/components/settings/settings-app-sidebar.tsx
@@ -268,7 +268,7 @@ export function SettingsAppSidebar() {
             <SidebarMenuButton size="lg" asChild>
               <Link href="/">
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">Kandev</span>
+                  <span className="truncate font-semibold">KanDev</span>
                 </div>
               </Link>
             </SidebarMenuButton>

--- a/apps/web/components/settings/sprites-settings.tsx
+++ b/apps/web/components/settings/sprites-settings.tsx
@@ -193,7 +193,7 @@ export function SpritesInstancesCard({ secretId }: { secretId?: string }) {
           <div>
             <CardTitle>Running Sprites</CardTitle>
             <CardDescription>
-              Active Kandev sprites. Sprites are destroyed when agents stop.
+              Active KanDev sprites. Sprites are destroyed when agents stop.
             </CardDescription>
           </div>
           {instances.length > 0 && (


### PR DESCRIPTION
## Description

Standardize all user-facing brand name instances from "Kandev" to "KanDev".

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Tests

## Changes Made

- Page title: "Kandev - AI Kanban" → "KanDev - AI Kanban"
- PWA manifest name and short_name
- Apple mobile web app title meta tag
- Settings sidebar header
- MCP config badge ("✓ Kandev MCP" → "✓ KanDev MCP")
- Sprites settings description

## Testing

- [ ] Unit tests pass (`go test ./...`)
- [x] Build passes (`go build ./...`)
- [ ] E2E tests pass (if applicable)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Related Issues

## Screenshots (if applicable)
<img width="954" height="867" alt="image" src="https://github.com/user-attachments/assets/7ca6ad9a-31b9-45e6-b91e-1d06ba2069dc" />
<img width="954" height="595" alt="image" src="https://github.com/user-attachments/assets/96034479-31d5-4eda-b8c5-66ab27baf162" />