### PR TITLE
fix: align MCP tool parameters and JSON tags with backend

### DIFF
--- a/apps/backend/internal/agentctl/server/mcp/server.go
+++ b/apps/backend/internal/agentctl/server/mcp/server.go
@@ -206,31 +206,31 @@ func (s *Server) registerKanbanTools() {
 		s.wrapHandler("list_workspaces", s.listWorkspacesHandler()),
 	)
 	s.mcpServer.AddTool(
-		mcp.NewTool("list_boards",
-			mcp.WithDescription("List all boards in a workspace."),
+		mcp.NewTool("list_workflows",
+			mcp.WithDescription("List all workflows in a workspace."),
 			mcp.WithString("workspace_id", mcp.Required(), mcp.Description("The workspace ID")),
 		),
-		s.wrapHandler("list_boards", s.listBoardsHandler()),
+		s.wrapHandler("list_workflows", s.listWorkflowsHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("list_workflow_steps",
-			mcp.WithDescription("List all workflow steps in a board."),
-			mcp.WithString("board_id", mcp.Required(), mcp.Description("The board ID")),
+			mcp.WithDescription("List all workflow steps in a workflow."),
+			mcp.WithString("workflow_id", mcp.Required(), mcp.Description("The workflow ID")),
 		),
 		s.wrapHandler("list_workflow_steps", s.listWorkflowStepsHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("list_tasks",
-			mcp.WithDescription("List all tasks on a board."),
-			mcp.WithString("board_id", mcp.Required(), mcp.Description("The board ID")),
+			mcp.WithDescription("List all tasks in a workflow."),
+			mcp.WithString("workflow_id", mcp.Required(), mcp.Description("The workflow ID")),
 		),
 		s.wrapHandler("list_tasks", s.listTasksHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("create_task",
-			mcp.WithDescription("Create a new task on a board."),
+			mcp.WithDescription("Create a new task in a workflow."),
 			mcp.WithString("workspace_id", mcp.Required(), mcp.Description("The workspace ID")),
-			mcp.WithString("board_id", mcp.Required(), mcp.Description("The board ID")),
+			mcp.WithString("workflow_id", mcp.Required(), mcp.Description("The workflow ID")),
 			mcp.WithString("workflow_step_id", mcp.Required(), mcp.Description("The workflow step ID")),
 			mcp.WithString("title", mcp.Required(), mcp.Description("The task title")),
 			mcp.WithString("description", mcp.Description("The task description")),


### PR DESCRIPTION
## Summary

This PR fixes the MCP tool integration between agentctl and the backend. The MCP tools were failing with validation errors like "workspace_id is required" even when the parameter was provided.

## Root Causes

### 1. Terminology mismatch between agentctl and backend
- **agentctl** used: `list_boards`, `board_id` (Kanban terminology)
- **backend** uses: `list_workflows`, `workflow_id` (Workflow terminology)

### 2. Response type mismatch
- agentctl expected `[]map[string]interface{}` (array)
- backend returns `{workspaces: [...], total: N}` (object with wrapper)

### 3. Missing JSON tags in DTO structs
- `dto.CreateTaskRequest` and `dto.UpdateTaskRequest` lack JSON tags
- When `json.Unmarshal` parses snake_case fields (`workspace_id`), they don't map to PascalCase fields (`WorkspaceID`)

## Changes

### agentctl MCP handlers (`internal/agentctl/server/mcp/handlers.go`)
- Changed `ActionMCPListBoards` → `ActionMCPListWorkflows`
- Renamed `listBoardsHandler()` → `listWorkflowsHandler()`
- Changed all `board_id` parameters → `workflow_id`
- Fixed response type from `[]map[string]interface{}` → `map[string]interface{}`

### agentctl MCP server (`internal/agentctl/server/mcp/server.go`)
- Updated tool registrations to use `workflow_id` instead of `board_id`
- Renamed `list_boards` tool → `list_workflows`
- Updated descriptions to use "workflow" terminology

### Backend MCP handlers (`internal/mcp/handlers/handlers.go`)
- Added local structs with proper JSON tags for `handleCreateTask` and `handleUpdateTask`

## Testing
- All existing tests pass
- Build completes successfully