### PR TITLE
fix: include untracked files in workspace file search

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_files.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_files.go
@@ -39,8 +39,11 @@ func (wt *WorkspaceTracker) getFileList(ctx context.Context) (types.FileListUpda
 		Files:     []types.FileEntry{},
 	}
 
-	// Use git ls-files to get tracked files
-	cmd := exec.CommandContext(ctx, "git", "ls-files")
+	// Use git ls-files to get tracked files AND untracked files (excluding ignored)
+	// --cached: include tracked files
+	// --others: include untracked files
+	// --exclude-standard: respect .gitignore
+	cmd := exec.CommandContext(ctx, "git", "ls-files", "--cached", "--others", "--exclude-standard")
 	cmd.Dir = wt.workDir
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
## Problem

When an agent creates a new file, the `@filename` autocomplete in the chat doesn't find it. This happens because the file search only returns files tracked by git.

## Root Cause

The `getFileList` function in `workspace_files.go` uses `git ls-files` which only returns tracked files. Newly created files are untracked until staged or committed.

## Solution

Changed the git command to include untracked files:

```bash
git ls-files --cached --others --exclude-standard
```

- `--cached`: include tracked files (existing behavior)
- `--others`: include untracked files (fixes the bug)
- `--exclude-standard`: respect .gitignore to avoid showing generated/ignored files

## Testing

- All existing tests pass
- New files created by agents will now appear in `@filename` autocomplete immediately