### PR TITLE
perf: streaming buffer and log batcher for efficient message persistence

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -293,11 +293,14 @@ func startAgentInfrastructure(
 	// ============================================
 	log.Info("Initializing Orchestrator...")
 
-	orchestratorSvc, msgCreator, err := provideOrchestrator(cfg, log, eventBus, repos.Task, services.Task, services.User,
+	orchestratorSvc, msgCreator, orchestratorCleanup, err := provideOrchestrator(cfg, log, eventBus, repos.Task, services.Task, services.User,
 		lifecycleMgr, agentRegistry, services.Workflow, repos.Secrets, repoCloner)
 	if err != nil {
 		log.Error("Failed to initialize orchestrator", zap.Error(err))
 		return false
+	}
+	if orchestratorCleanup != nil {
+		addCleanup(func() error { orchestratorCleanup(); return nil })
 	}
 
 	// Wire GitHub service into orchestrator for PR auto-detection on push

--- a/apps/backend/internal/integration/test_server_test.go
+++ b/apps/backend/internal/integration/test_server_test.go
@@ -199,6 +199,10 @@ func (a *testMessageCreatorAdapter) AppendThinkingMessage(ctx context.Context, m
 	return a.svc.AppendThinkingContent(ctx, messageID, additionalContent)
 }
 
+func (a *testMessageCreatorAdapter) FinalizeStreamingMessages(ctx context.Context, sessionID string) {
+	a.svc.FinalizeStreamingMessages(ctx, sessionID)
+}
+
 // testTurnServiceAdapter adapts the task service to the orchestrator.TurnService interface for tests
 type testTurnServiceAdapter struct {
 	svc *taskservice.Service

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -123,6 +123,9 @@ func (m *mockRepository) ListWorkflows(ctx context.Context, workspaceID string) 
 func (m *mockRepository) CreateMessage(ctx context.Context, message *models.Message) error {
 	return nil
 }
+func (m *mockRepository) CreateMessages(ctx context.Context, messages []*models.Message) error {
+	return nil
+}
 func (m *mockRepository) GetMessage(ctx context.Context, id string) (*models.Message, error) {
 	return nil, nil
 }
@@ -136,6 +139,9 @@ func (m *mockRepository) FindMessageByPendingID(ctx context.Context, pendingID s
 	return nil, nil
 }
 func (m *mockRepository) UpdateMessage(ctx context.Context, message *models.Message) error {
+	return nil
+}
+func (m *mockRepository) AppendContent(ctx context.Context, messageID, additionalContent string) error {
 	return nil
 }
 func (m *mockRepository) ListMessages(ctx context.Context, sessionID string) ([]*models.Message, error) {

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -60,11 +60,13 @@ type WorkflowRepository interface {
 // MessageRepository handles message persistence and lookups.
 type MessageRepository interface {
 	CreateMessage(ctx context.Context, message *models.Message) error
+	CreateMessages(ctx context.Context, messages []*models.Message) error
 	GetMessage(ctx context.Context, id string) (*models.Message, error)
 	GetMessageByToolCallID(ctx context.Context, sessionID, toolCallID string) (*models.Message, error)
 	GetMessageByPendingID(ctx context.Context, sessionID, pendingID string) (*models.Message, error)
 	FindMessageByPendingID(ctx context.Context, pendingID string) (*models.Message, error)
 	UpdateMessage(ctx context.Context, message *models.Message) error
+	AppendContent(ctx context.Context, messageID, additionalContent string) error
 	ListMessages(ctx context.Context, sessionID string) ([]*models.Message, error)
 	ListMessagesPaginated(ctx context.Context, sessionID string, opts models.ListMessagesOptions) ([]*models.Message, bool, error)
 	DeleteMessage(ctx context.Context, id string) error

--- a/apps/backend/internal/task/service/log_batcher.go
+++ b/apps/backend/internal/task/service/log_batcher.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+)
+
+const (
+	defaultLogFlushInterval = 500 * time.Millisecond
+	defaultMaxLogBatch      = 100
+)
+
+// LogBatcher accumulates log messages and batch-inserts them into the
+// database in a single transaction instead of individual INSERTs.
+//
+// The WS event for each log message is published immediately by the caller
+// so the frontend sees logs in real-time. Only the DB write is deferred.
+type LogBatcher struct {
+	mu       sync.Mutex
+	pending  []*models.Message
+	repo     repository.MessageRepository
+	logger   *logger.Logger
+	interval time.Duration
+	maxBatch int
+	done     chan struct{}
+	wg       sync.WaitGroup
+}
+
+// NewLogBatcher creates a new log message batcher.
+func NewLogBatcher(repo repository.MessageRepository, log *logger.Logger) *LogBatcher {
+	return &LogBatcher{
+		repo:     repo,
+		logger:   log,
+		interval: defaultLogFlushInterval,
+		maxBatch: defaultMaxLogBatch,
+	}
+}
+
+// Start begins the periodic flush goroutine.
+func (b *LogBatcher) Start() {
+	b.done = make(chan struct{})
+	b.wg.Add(1)
+	go b.flushLoop()
+}
+
+// Stop flushes all remaining messages and stops the flush goroutine.
+func (b *LogBatcher) Stop() {
+	close(b.done)
+	b.wg.Wait()
+	// Final flush after goroutine exits
+	b.flush(context.Background())
+}
+
+// Add enqueues a log message for batch insertion.
+// If the batch reaches maxBatch, an immediate flush is triggered.
+func (b *LogBatcher) Add(message *models.Message) {
+	b.mu.Lock()
+	b.pending = append(b.pending, message)
+	shouldFlush := len(b.pending) >= b.maxBatch
+	b.mu.Unlock()
+
+	if shouldFlush {
+		b.flush(context.Background())
+	}
+}
+
+func (b *LogBatcher) flushLoop() {
+	defer b.wg.Done()
+	ticker := time.NewTicker(b.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-b.done:
+			return
+		case <-ticker.C:
+			b.flush(context.Background())
+		}
+	}
+}
+
+func (b *LogBatcher) flush(ctx context.Context) {
+	b.mu.Lock()
+	if len(b.pending) == 0 {
+		b.mu.Unlock()
+		return
+	}
+	batch := b.pending
+	b.pending = nil
+	b.mu.Unlock()
+
+	if err := b.repo.CreateMessages(ctx, batch); err != nil {
+		b.logger.Error("failed to batch-insert log messages",
+			zap.Int("count", len(batch)),
+			zap.Error(err))
+	}
+}

--- a/apps/backend/internal/task/service/log_batcher_test.go
+++ b/apps/backend/internal/task/service/log_batcher_test.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// mockBatchRepo tracks CreateMessages calls for LogBatcher tests.
+type mockBatchRepo struct {
+	mockMessageRepo
+	batchMu     sync.Mutex
+	batchCalls  int
+	batchedMsgs []*models.Message
+}
+
+func newMockBatchRepo() *mockBatchRepo {
+	return &mockBatchRepo{
+		mockMessageRepo: mockMessageRepo{
+			messages: make(map[string]*models.Message),
+			appends:  make(map[string]string),
+		},
+	}
+}
+
+func (m *mockBatchRepo) CreateMessages(_ context.Context, msgs []*models.Message) error {
+	m.batchMu.Lock()
+	defer m.batchMu.Unlock()
+	m.batchCalls++
+	m.batchedMsgs = append(m.batchedMsgs, msgs...)
+	return nil
+}
+
+func (m *mockBatchRepo) getBatchCalls() int {
+	m.batchMu.Lock()
+	defer m.batchMu.Unlock()
+	return m.batchCalls
+}
+
+func (m *mockBatchRepo) getBatchedCount() int {
+	m.batchMu.Lock()
+	defer m.batchMu.Unlock()
+	return len(m.batchedMsgs)
+}
+
+func TestLogBatcher_Add(t *testing.T) {
+	repo := newMockBatchRepo()
+	batcher := NewLogBatcher(repo, testLogger())
+
+	// Add a message without starting the batcher — should accumulate
+	batcher.Add(&models.Message{ID: "log-1", Content: "test log"})
+
+	batcher.mu.Lock()
+	pendingCount := len(batcher.pending)
+	batcher.mu.Unlock()
+
+	if pendingCount != 1 {
+		t.Errorf("expected 1 pending message, got %d", pendingCount)
+	}
+
+	// No DB writes should have happened
+	if got := repo.getBatchCalls(); got != 0 {
+		t.Errorf("expected 0 batch calls, got %d", got)
+	}
+}
+
+func TestLogBatcher_PeriodicFlush(t *testing.T) {
+	repo := newMockBatchRepo()
+	batcher := NewLogBatcher(repo, testLogger())
+	batcher.interval = 50 * time.Millisecond
+	batcher.Start()
+	defer batcher.Stop()
+
+	batcher.Add(&models.Message{ID: "log-1", Content: "first"})
+	batcher.Add(&models.Message{ID: "log-2", Content: "second"})
+
+	// Wait for flush
+	time.Sleep(100 * time.Millisecond)
+
+	if got := repo.getBatchedCount(); got != 2 {
+		t.Errorf("expected 2 batched messages, got %d", got)
+	}
+	if got := repo.getBatchCalls(); got != 1 {
+		t.Errorf("expected 1 batch call, got %d", got)
+	}
+}
+
+func TestLogBatcher_MaxBatchFlush(t *testing.T) {
+	repo := newMockBatchRepo()
+	batcher := NewLogBatcher(repo, testLogger())
+	batcher.interval = 1 * time.Hour // Ensure periodic flush doesn't fire
+	batcher.maxBatch = 5
+	batcher.Start()
+	defer batcher.Stop()
+
+	// Add exactly maxBatch messages
+	for i := 0; i < 5; i++ {
+		batcher.Add(&models.Message{ID: "log-" + string(rune('a'+i)), Content: "msg"})
+	}
+
+	// Give a moment for the flush goroutine triggered by Add
+	time.Sleep(20 * time.Millisecond)
+
+	if got := repo.getBatchedCount(); got != 5 {
+		t.Errorf("expected 5 batched messages after max batch, got %d", got)
+	}
+}
+
+func TestLogBatcher_Stop(t *testing.T) {
+	repo := newMockBatchRepo()
+	batcher := NewLogBatcher(repo, testLogger())
+	batcher.interval = 1 * time.Hour // Long interval
+	batcher.Start()
+
+	batcher.Add(&models.Message{ID: "log-1", Content: "pending"})
+	batcher.Add(&models.Message{ID: "log-2", Content: "pending2"})
+
+	// Stop should flush remaining
+	batcher.Stop()
+
+	if got := repo.getBatchedCount(); got != 2 {
+		t.Errorf("expected 2 batched messages after Stop, got %d", got)
+	}
+}
+
+func TestLogBatcher_ConcurrentAdds(t *testing.T) {
+	repo := newMockBatchRepo()
+	batcher := NewLogBatcher(repo, testLogger())
+	batcher.interval = 50 * time.Millisecond
+	batcher.Start()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			batcher.Add(&models.Message{ID: "log-concurrent", Content: "x"})
+		}(i)
+	}
+	wg.Wait()
+
+	// Stop to force final flush
+	batcher.Stop()
+
+	if got := repo.getBatchedCount(); got != 50 {
+		t.Errorf("expected 50 batched messages, got %d", got)
+	}
+}
+
+func TestLogBatcher_EmptyFlush(t *testing.T) {
+	repo := newMockBatchRepo()
+	batcher := NewLogBatcher(repo, testLogger())
+	batcher.interval = 50 * time.Millisecond
+	batcher.Start()
+
+	// Let a few ticks pass with no messages
+	time.Sleep(120 * time.Millisecond)
+
+	batcher.Stop()
+
+	// No batch calls should have been made
+	if got := repo.getBatchCalls(); got != 0 {
+		t.Errorf("expected 0 batch calls for empty batcher, got %d", got)
+	}
+}

--- a/apps/backend/internal/task/service/service.go
+++ b/apps/backend/internal/task/service/service.go
@@ -122,6 +122,8 @@ type Service struct {
 	workflowStepCreator WorkflowStepCreator
 	workflowStepGetter  WorkflowStepGetter
 	startStepResolver   StartStepResolver
+	streamBuf           *StreamingBuffer
+	logBatcher          *LogBatcher
 }
 
 // NewService creates a new task service
@@ -168,4 +170,15 @@ func (s *Service) SetWorkflowStepGetter(getter WorkflowStepGetter) {
 // SetStartStepResolver wires the start step resolver for CreateTask.
 func (s *Service) SetStartStepResolver(resolver StartStepResolver) {
 	s.startStepResolver = resolver
+}
+
+// SetStreamingBuffer wires the streaming write buffer for coalescing
+// streaming message content writes.
+func (s *Service) SetStreamingBuffer(buf *StreamingBuffer) {
+	s.streamBuf = buf
+}
+
+// SetLogBatcher wires the log message batcher for batching log inserts.
+func (s *Service) SetLogBatcher(batcher *LogBatcher) {
+	s.logBatcher = batcher
 }

--- a/apps/backend/internal/task/service/streaming_buffer.go
+++ b/apps/backend/internal/task/service/streaming_buffer.go
@@ -1,0 +1,283 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+)
+
+const (
+	defaultFlushInterval = 500 * time.Millisecond
+)
+
+// bufEntry holds the cached state of a streaming message.
+type bufEntry struct {
+	message  *models.Message // full cached message (loaded on first access)
+	pending  string          // accumulated content delta since last flush
+	dirty    bool
+	thinking bool // true if this entry tracks metadata.thinking, not content
+}
+
+// StreamingBuffer coalesces streaming message writes by caching messages in
+// memory and flushing accumulated content to the database periodically.
+//
+// Instead of a GET + full-row UPDATE per text chunk (~40 round-trips per
+// agent response), the buffer reduces this to 1 GET + ~5-8 SQL appends.
+//
+// The buffer is safe because:
+//   - CREATEs still go through the normal immediate DB path
+//   - The first APPEND loads the message from DB (guaranteed to exist)
+//   - Subsequent APPENDs update the in-memory cache only
+//   - A background goroutine flushes dirty entries every 500ms
+//   - Callers receive the cached message (with full content) for WS events
+type StreamingBuffer struct {
+	mu       sync.Mutex
+	entries  map[string]*bufEntry
+	repo     repository.MessageRepository
+	logger   *logger.Logger
+	interval time.Duration
+	done     chan struct{}
+	wg       sync.WaitGroup
+}
+
+// NewStreamingBuffer creates a new streaming write buffer.
+func NewStreamingBuffer(repo repository.MessageRepository, log *logger.Logger) *StreamingBuffer {
+	return &StreamingBuffer{
+		entries:  make(map[string]*bufEntry),
+		repo:     repo,
+		logger:   log,
+		interval: defaultFlushInterval,
+	}
+}
+
+// Start begins the periodic flush goroutine.
+func (b *StreamingBuffer) Start() {
+	b.done = make(chan struct{})
+	b.wg.Add(1)
+	go b.flushLoop()
+}
+
+// Stop flushes all remaining entries and stops the flush goroutine.
+func (b *StreamingBuffer) Stop() {
+	close(b.done)
+	b.wg.Wait()
+	// Final flush after goroutine exits
+	b.flushAll(context.Background())
+}
+
+// Append accumulates a text chunk for the given message. On first call for a
+// messageID it loads the message from the database; subsequent calls use the
+// cached copy. Returns a snapshot of the message with full accumulated content,
+// suitable for publishing WS events.
+func (b *StreamingBuffer) Append(ctx context.Context, messageID, content string) (*models.Message, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	entry, ok := b.entries[messageID]
+	if !ok {
+		msg, err := b.repo.GetMessage(ctx, messageID)
+		if err != nil {
+			return nil, err
+		}
+		entry = &bufEntry{message: msg}
+		b.entries[messageID] = entry
+	}
+
+	entry.message.Content += content
+	entry.pending += content
+	entry.dirty = true
+
+	return entry.message, nil
+}
+
+// AppendThinking accumulates a thinking text chunk for the given message.
+// Thinking content is stored in metadata.thinking rather than in the content
+// field, so it requires a full metadata UPDATE on flush.
+func (b *StreamingBuffer) AppendThinking(ctx context.Context, messageID, content string) (*models.Message, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	entry, ok := b.entries[messageID]
+	if !ok {
+		msg, err := b.repo.GetMessage(ctx, messageID)
+		if err != nil {
+			return nil, err
+		}
+		entry = &bufEntry{message: msg, thinking: true}
+		b.entries[messageID] = entry
+	}
+
+	if entry.message.Metadata == nil {
+		entry.message.Metadata = make(map[string]interface{})
+	}
+
+	existing := ""
+	if v, ok := entry.message.Metadata["thinking"].(string); ok {
+		existing = v
+	}
+	entry.message.Metadata["thinking"] = existing + content
+	entry.pending += content
+	entry.dirty = true
+
+	return entry.message, nil
+}
+
+// Finalize force-flushes and removes a specific message from the buffer.
+// Call this when a streaming message is complete (e.g., on turn boundary).
+func (b *StreamingBuffer) Finalize(ctx context.Context, messageID string) {
+	b.mu.Lock()
+	entry, ok := b.entries[messageID]
+	if !ok {
+		b.mu.Unlock()
+		return
+	}
+	delta := entry.pending
+	isThinking := entry.thinking
+	msg := entry.message
+	entry.pending = ""
+	entry.dirty = false
+	delete(b.entries, messageID)
+	b.mu.Unlock()
+
+	if delta == "" {
+		return
+	}
+
+	if isThinking {
+		b.flushThinkingEntry(ctx, msg)
+	} else {
+		b.flushContentEntry(ctx, messageID, delta)
+	}
+}
+
+// FinalizeAll force-flushes all entries for a given session.
+func (b *StreamingBuffer) FinalizeAll(ctx context.Context, sessionID string) {
+	b.mu.Lock()
+	var toFlush []struct {
+		id       string
+		delta    string
+		thinking bool
+		msg      *models.Message
+	}
+	for id, entry := range b.entries {
+		if entry.message.TaskSessionID != sessionID {
+			continue
+		}
+		if entry.dirty && entry.pending != "" {
+			toFlush = append(toFlush, struct {
+				id       string
+				delta    string
+				thinking bool
+				msg      *models.Message
+			}{id, entry.pending, entry.thinking, entry.message})
+		}
+		entry.pending = ""
+		entry.dirty = false
+		delete(b.entries, id)
+	}
+	b.mu.Unlock()
+
+	for _, item := range toFlush {
+		if item.thinking {
+			b.flushThinkingEntry(ctx, item.msg)
+		} else {
+			b.flushContentEntry(ctx, item.id, item.delta)
+		}
+	}
+}
+
+func (b *StreamingBuffer) flushLoop() {
+	defer b.wg.Done()
+	ticker := time.NewTicker(b.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-b.done:
+			return
+		case <-ticker.C:
+			b.flushAll(context.Background())
+		}
+	}
+}
+
+func (b *StreamingBuffer) flushAll(ctx context.Context) {
+	b.mu.Lock()
+	var contentFlush []struct {
+		id    string
+		delta string
+	}
+	var thinkingFlush []*models.Message
+
+	for id, entry := range b.entries {
+		if !entry.dirty || entry.pending == "" {
+			continue
+		}
+		if entry.thinking {
+			// Clone metadata for thread safety
+			meta := cloneMetadata(entry.message.Metadata)
+			msgCopy := *entry.message
+			msgCopy.Metadata = meta
+			thinkingFlush = append(thinkingFlush, &msgCopy)
+		} else {
+			contentFlush = append(contentFlush, struct {
+				id    string
+				delta string
+			}{id, entry.pending})
+		}
+		entry.pending = ""
+		entry.dirty = false
+	}
+	b.mu.Unlock()
+
+	for _, item := range contentFlush {
+		b.flushContentEntry(ctx, item.id, item.delta)
+	}
+	for _, msg := range thinkingFlush {
+		b.flushThinkingEntry(ctx, msg)
+	}
+}
+
+func (b *StreamingBuffer) flushContentEntry(ctx context.Context, messageID, delta string) {
+	if err := b.repo.AppendContent(ctx, messageID, delta); err != nil {
+		b.logger.Error("failed to flush streaming content",
+			zap.String("message_id", messageID),
+			zap.Int("delta_len", len(delta)),
+			zap.Error(err))
+	}
+}
+
+func (b *StreamingBuffer) flushThinkingEntry(ctx context.Context, msg *models.Message) {
+	if err := b.repo.UpdateMessage(ctx, msg); err != nil {
+		b.logger.Error("failed to flush thinking content",
+			zap.String("message_id", msg.ID),
+			zap.Error(err))
+	}
+}
+
+func cloneMetadata(m map[string]interface{}) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+	// Deep-enough clone: re-marshal + unmarshal to get independent copy.
+	// This is called infrequently (only on flush ticks), so the cost is fine.
+	data, err := json.Marshal(m)
+	if err != nil {
+		// Fallback: shallow copy
+		cp := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			cp[k] = v
+		}
+		return cp
+	}
+	cp := make(map[string]interface{})
+	_ = json.Unmarshal(data, &cp)
+	return cp
+}

--- a/apps/backend/internal/task/service/streaming_buffer_test.go
+++ b/apps/backend/internal/task/service/streaming_buffer_test.go
@@ -1,0 +1,349 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// mockMessageRepo implements the subset of repository.MessageRepository
+// needed by StreamingBuffer.
+type mockMessageRepo struct {
+	mu       sync.Mutex
+	messages map[string]*models.Message
+	appends  map[string]string // messageID → appended content
+	updates  []*models.Message
+}
+
+func newMockRepo() *mockMessageRepo {
+	return &mockMessageRepo{
+		messages: make(map[string]*models.Message),
+		appends:  make(map[string]string),
+	}
+}
+
+func (m *mockMessageRepo) GetMessage(_ context.Context, id string) (*models.Message, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	msg, ok := m.messages[id]
+	if !ok {
+		return nil, fmt.Errorf("message not found: %s", id)
+	}
+	// Return a copy
+	cp := *msg
+	if msg.Metadata != nil {
+		cp.Metadata = make(map[string]interface{}, len(msg.Metadata))
+		for k, v := range msg.Metadata {
+			cp.Metadata[k] = v
+		}
+	}
+	return &cp, nil
+}
+
+func (m *mockMessageRepo) AppendContent(_ context.Context, id, content string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	msg, ok := m.messages[id]
+	if !ok {
+		return fmt.Errorf("message not found: %s", id)
+	}
+	msg.Content += content
+	m.appends[id] += content
+	return nil
+}
+
+func (m *mockMessageRepo) UpdateMessage(_ context.Context, msg *models.Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	existing, ok := m.messages[msg.ID]
+	if !ok {
+		return fmt.Errorf("message not found: %s", msg.ID)
+	}
+	existing.Content = msg.Content
+	existing.Metadata = msg.Metadata
+	m.updates = append(m.updates, msg)
+	return nil
+}
+
+func (m *mockMessageRepo) CreateMessage(_ context.Context, _ *models.Message) error { return nil }
+func (m *mockMessageRepo) CreateMessages(_ context.Context, _ []*models.Message) error {
+	return nil
+}
+func (m *mockMessageRepo) GetMessageByToolCallID(_ context.Context, _, _ string) (*models.Message, error) {
+	return nil, nil
+}
+func (m *mockMessageRepo) GetMessageByPendingID(_ context.Context, _, _ string) (*models.Message, error) {
+	return nil, nil
+}
+func (m *mockMessageRepo) FindMessageByPendingID(_ context.Context, _ string) (*models.Message, error) {
+	return nil, nil
+}
+func (m *mockMessageRepo) ListMessages(_ context.Context, _ string) ([]*models.Message, error) {
+	return nil, nil
+}
+func (m *mockMessageRepo) ListMessagesPaginated(_ context.Context, _ string, _ models.ListMessagesOptions) ([]*models.Message, bool, error) {
+	return nil, false, nil
+}
+func (m *mockMessageRepo) DeleteMessage(_ context.Context, _ string) error { return nil }
+
+func (m *mockMessageRepo) addMessage(msg *models.Message) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages[msg.ID] = msg
+}
+
+func (m *mockMessageRepo) getContent(id string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.messages[id].Content
+}
+
+func (m *mockMessageRepo) getAppendedContent(id string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.appends[id]
+}
+
+func (m *mockMessageRepo) getUpdateCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.updates)
+}
+
+func testLogger() *logger.Logger {
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "debug", Format: "console", OutputPath: "stdout"})
+	return log
+}
+
+func TestStreamingBuffer_Append(t *testing.T) {
+	repo := newMockRepo()
+	repo.addMessage(&models.Message{
+		ID:            "msg-1",
+		TaskSessionID: "session-1",
+		Content:       "Hello",
+	})
+
+	buf := NewStreamingBuffer(repo, testLogger())
+
+	// First append: should load from DB and cache
+	msg, err := buf.Append(context.Background(), "msg-1", " world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content != "Hello world" {
+		t.Errorf("expected 'Hello world', got %q", msg.Content)
+	}
+
+	// Second append: should use cached version (no DB read)
+	msg, err = buf.Append(context.Background(), "msg-1", "!")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Content != "Hello world!" {
+		t.Errorf("expected 'Hello world!', got %q", msg.Content)
+	}
+
+	// DB should still have original content (not flushed yet)
+	if got := repo.getContent("msg-1"); got != "Hello" {
+		t.Errorf("expected DB content 'Hello' (not flushed), got %q", got)
+	}
+}
+
+func TestStreamingBuffer_Finalize(t *testing.T) {
+	repo := newMockRepo()
+	repo.addMessage(&models.Message{
+		ID:            "msg-1",
+		TaskSessionID: "session-1",
+		Content:       "base",
+	})
+
+	buf := NewStreamingBuffer(repo, testLogger())
+
+	// Accumulate some content
+	_, _ = buf.Append(context.Background(), "msg-1", " extra")
+	_, _ = buf.Append(context.Background(), "msg-1", " more")
+
+	// Finalize should flush to DB
+	buf.Finalize(context.Background(), "msg-1")
+
+	// DB should have the appended delta
+	if got := repo.getAppendedContent("msg-1"); got != " extra more" {
+		t.Errorf("expected appended content ' extra more', got %q", got)
+	}
+
+	// Entry should be removed from buffer
+	buf.mu.Lock()
+	_, exists := buf.entries["msg-1"]
+	buf.mu.Unlock()
+	if exists {
+		t.Error("expected entry to be removed after Finalize")
+	}
+}
+
+func TestStreamingBuffer_PeriodicFlush(t *testing.T) {
+	repo := newMockRepo()
+	repo.addMessage(&models.Message{
+		ID:            "msg-1",
+		TaskSessionID: "session-1",
+		Content:       "",
+	})
+
+	buf := NewStreamingBuffer(repo, testLogger())
+	buf.interval = 50 * time.Millisecond
+	buf.Start()
+	defer buf.Stop()
+
+	// Append content
+	_, _ = buf.Append(context.Background(), "msg-1", "chunk1")
+	_, _ = buf.Append(context.Background(), "msg-1", "chunk2")
+
+	// Wait for flush
+	time.Sleep(100 * time.Millisecond)
+
+	// DB should have received the appended delta
+	if got := repo.getAppendedContent("msg-1"); got != "chunk1chunk2" {
+		t.Errorf("expected appended 'chunk1chunk2', got %q", got)
+	}
+}
+
+func TestStreamingBuffer_AppendThinking(t *testing.T) {
+	repo := newMockRepo()
+	repo.addMessage(&models.Message{
+		ID:            "msg-t1",
+		TaskSessionID: "session-1",
+		Content:       "",
+		Metadata:      map[string]interface{}{"thinking": "I need to"},
+	})
+
+	buf := NewStreamingBuffer(repo, testLogger())
+
+	msg, err := buf.AppendThinking(context.Background(), "msg-t1", " think more")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	thinking, _ := msg.Metadata["thinking"].(string)
+	if thinking != "I need to think more" {
+		t.Errorf("expected thinking 'I need to think more', got %q", thinking)
+	}
+
+	// Finalize should flush via UpdateMessage
+	buf.Finalize(context.Background(), "msg-t1")
+
+	if repo.getUpdateCount() != 1 {
+		t.Errorf("expected 1 UpdateMessage call for thinking flush, got %d", repo.getUpdateCount())
+	}
+}
+
+func TestStreamingBuffer_FinalizeAll(t *testing.T) {
+	repo := newMockRepo()
+	repo.addMessage(&models.Message{
+		ID:            "msg-a",
+		TaskSessionID: "session-1",
+		Content:       "",
+	})
+	repo.addMessage(&models.Message{
+		ID:            "msg-b",
+		TaskSessionID: "session-1",
+		Content:       "",
+	})
+	repo.addMessage(&models.Message{
+		ID:            "msg-c",
+		TaskSessionID: "session-2",
+		Content:       "",
+	})
+
+	buf := NewStreamingBuffer(repo, testLogger())
+
+	_, _ = buf.Append(context.Background(), "msg-a", "a-content")
+	_, _ = buf.Append(context.Background(), "msg-b", "b-content")
+	_, _ = buf.Append(context.Background(), "msg-c", "c-content")
+
+	// FinalizeAll for session-1 should flush msg-a and msg-b but not msg-c
+	buf.FinalizeAll(context.Background(), "session-1")
+
+	if got := repo.getAppendedContent("msg-a"); got != "a-content" {
+		t.Errorf("msg-a: expected 'a-content', got %q", got)
+	}
+	if got := repo.getAppendedContent("msg-b"); got != "b-content" {
+		t.Errorf("msg-b: expected 'b-content', got %q", got)
+	}
+	if got := repo.getAppendedContent("msg-c"); got != "" {
+		t.Errorf("msg-c should not be flushed yet, got %q", got)
+	}
+
+	// msg-c should still be in buffer
+	buf.mu.Lock()
+	_, cExists := buf.entries["msg-c"]
+	buf.mu.Unlock()
+	if !cExists {
+		t.Error("msg-c should still be in buffer")
+	}
+}
+
+func TestStreamingBuffer_ConcurrentAppends(t *testing.T) {
+	repo := newMockRepo()
+	repo.addMessage(&models.Message{
+		ID:            "msg-1",
+		TaskSessionID: "session-1",
+		Content:       "",
+	})
+
+	buf := NewStreamingBuffer(repo, testLogger())
+	buf.interval = 50 * time.Millisecond
+	buf.Start()
+	defer buf.Stop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = buf.Append(context.Background(), "msg-1", "x")
+		}()
+	}
+	wg.Wait()
+
+	// Verify in-memory content length
+	buf.mu.Lock()
+	entry := buf.entries["msg-1"]
+	contentLen := len(entry.message.Content)
+	buf.mu.Unlock()
+
+	if contentLen != 100 {
+		t.Errorf("expected 100 chars in buffer, got %d", contentLen)
+	}
+
+	// Finalize and verify DB
+	buf.Finalize(context.Background(), "msg-1")
+	if got := repo.getContent("msg-1"); len(got) != 100 {
+		t.Errorf("expected 100 chars in DB after finalize, got %d", len(got))
+	}
+}
+
+func TestStreamingBuffer_Stop(t *testing.T) {
+	repo := newMockRepo()
+	repo.addMessage(&models.Message{
+		ID:            "msg-1",
+		TaskSessionID: "session-1",
+		Content:       "start",
+	})
+
+	buf := NewStreamingBuffer(repo, testLogger())
+	buf.interval = 1 * time.Hour // Long interval to ensure flush happens on Stop, not timer
+	buf.Start()
+
+	_, _ = buf.Append(context.Background(), "msg-1", " end")
+
+	// Stop should flush everything
+	buf.Stop()
+
+	if got := repo.getAppendedContent("msg-1"); got != " end" {
+		t.Errorf("expected appended ' end' after Stop, got %q", got)
+	}
+}


### PR DESCRIPTION
Reduce database round-trips during streaming agent responses by buffering message writes in memory and flushing periodically. Instead of a GET + UPDATE per text chunk (~40 round-trips per response), the buffer coalesces writes into ~5-8 SQL appends, and log messages are batch-inserted in a single transaction.

## Important Changes

- **StreamingBuffer**: Caches messages in memory, accumulates content deltas, and flushes via `AppendContent` (for regular content) or `UpdateMessage` (for thinking metadata) every 500ms or on explicit finalize.
- **LogBatcher**: Accumulates log messages and batch-inserts them via `CreateMessages` instead of individual `CreateMessage` calls.
- **Repository changes**: Added `CreateMessages` (batch insert) and `AppendContent` (SQL string concatenation) to SQLite message repository.
- **Service integration**: `AppendMessageContent` and `AppendThinkingContent` now route through the buffer when configured; `FinalizeStreamingMessages` flushes all buffered entries for a session on turn complete.

## Validation

- Added comprehensive unit tests for `StreamingBuffer` covering append, finalize, periodic flush, thinking content, concurrent appends, and session-level finalize.
- Added unit tests for `LogBatcher` covering add, periodic flush, max batch threshold, concurrent adds, and stop behavior.
- Existing integration tests updated to support new finalize interface.
- All tests pass with proper synchronization and thread-safety verification.

## Possible Improvements

Low risk: The buffer assumes messages exist in the database before first append (enforced by loading on first access). If a message is deleted externally between append calls, subsequent appends will fail gracefully with a logged error. Consider adding metrics to track flush latency and batch sizes in production.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.

https://claude.ai/code/session_01LGtz678tU1mgAvCMzpeEDb