### PR TITLE
feat(mcp): add start_agent and local_path params to create_task

### DIFF
--- a/apps/backend/internal/agentctl/server/mcp/handlers.go
+++ b/apps/backend/internal/agentctl/server/mcp/handlers.go
@@ -96,7 +96,15 @@ func (s *Server) createTaskHandler() server.ToolHandlerFunc {
 			return mcp.NewToolResultError("workspace_id and workflow_id are required when creating a top-level task (no parent_id)"), nil
 		}
 
-		payload := map[string]string{
+		// Default start_agent to true if not provided
+		startAgent := true
+		if args := req.GetArguments(); args["start_agent"] != nil {
+			if v, ok := args["start_agent"].(bool); ok {
+				startAgent = v
+			}
+		}
+
+		payload := map[string]interface{}{
 			"parent_id":           parentID,
 			"workspace_id":        workspaceID,
 			"workflow_id":         workflowID,
@@ -106,7 +114,30 @@ func (s *Server) createTaskHandler() server.ToolHandlerFunc {
 			"agent_profile_id":    req.GetString("agent_profile_id", ""),
 			"executor_profile_id": req.GetString("executor_profile_id", ""),
 			"source_task_id":      s.taskID,
+			"start_agent":         startAgent,
 		}
+
+		// Add repository info (only valid for top-level tasks)
+		repositoryID := req.GetString("repository_id", "")
+		localPath := req.GetString("local_path", "")
+		baseBranch := req.GetString("base_branch", "")
+		if (repositoryID != "" || localPath != "") && parentID != "" {
+			return mcp.NewToolResultError("repository_id and local_path are only valid for top-level tasks; subtasks inherit their repository from the parent"), nil
+		}
+		if repositoryID != "" || localPath != "" {
+			repo := map[string]string{}
+			if repositoryID != "" {
+				repo["repository_id"] = repositoryID
+			}
+			if localPath != "" {
+				repo["local_path"] = localPath
+			}
+			if baseBranch != "" {
+				repo["base_branch"] = baseBranch
+			}
+			payload["repositories"] = []map[string]string{repo}
+		}
+
 		var result map[string]interface{}
 		if err := s.backend.RequestPayload(ctx, ws.ActionMCPCreateTask, payload, &result); err != nil {
 			return mcp.NewToolResultError(err.Error()), nil

--- a/apps/backend/internal/agentctl/server/mcp/handlers_test.go
+++ b/apps/backend/internal/agentctl/server/mcp/handlers_test.go
@@ -62,11 +62,12 @@ func TestCreateTask_SelfResolvesToTaskID(t *testing.T) {
 	assert.False(t, result.IsError)
 	assert.Equal(t, ws.ActionMCPCreateTask, backend.lastAction)
 
-	payload, ok := backend.lastPayload.(map[string]string)
+	payload, ok := backend.lastPayload.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "task-current", payload["parent_id"], "self should resolve to current task ID")
 	assert.Equal(t, "Write tests", payload["title"])
 	assert.Equal(t, "task-current", payload["source_task_id"], "source_task_id should be set to current task")
+	assert.Equal(t, true, payload["start_agent"], "start_agent should default to true")
 }
 
 func TestCreateTask_SelfWithNoTaskContext_ReturnsError(t *testing.T) {
@@ -94,7 +95,7 @@ func TestCreateTask_ExplicitParentID(t *testing.T) {
 
 	assert.False(t, result.IsError)
 
-	payload, ok := backend.lastPayload.(map[string]string)
+	payload, ok := backend.lastPayload.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "task-abc", payload["parent_id"])
 }
@@ -125,7 +126,7 @@ func TestCreateTask_NoParentID_WithIDs_CreatesTopLevelTask(t *testing.T) {
 
 	assert.False(t, result.IsError)
 
-	payload, ok := backend.lastPayload.(map[string]string)
+	payload, ok := backend.lastPayload.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "", payload["parent_id"])
 	assert.Equal(t, "ws-1", payload["workspace_id"])
@@ -145,7 +146,7 @@ func TestCreateTask_SourceTaskID_AlwaysSet(t *testing.T) {
 		"workflow_id":  "wf-1",
 	})
 
-	payload, ok := backend.lastPayload.(map[string]string)
+	payload, ok := backend.lastPayload.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "my-task-123", payload["source_task_id"])
 }
@@ -162,7 +163,77 @@ func TestCreateTask_SourceTaskID_EmptyWhenNoTaskContext(t *testing.T) {
 		"workflow_id":  "wf-1",
 	})
 
-	payload, ok := backend.lastPayload.(map[string]string)
+	payload, ok := backend.lastPayload.(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "", payload["source_task_id"])
+}
+
+func TestCreateTask_StartAgentFalse_DoesNotAutoStart(t *testing.T) {
+	backend := &testBackend{
+		response: map[string]interface{}{"id": "task-new", "title": "Plan task"},
+	}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
+		"title":        "Plan task",
+		"workspace_id": "ws-1",
+		"workflow_id":  "wf-1",
+		"start_agent":  false,
+	})
+
+	assert.False(t, result.IsError)
+
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, payload["start_agent"], "start_agent should be false when explicitly set")
+}
+
+func TestCreateTask_WithRepositoryID(t *testing.T) {
+	backend := &testBackend{
+		response: map[string]interface{}{"id": "task-new", "title": "Task with repo"},
+	}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
+		"title":         "Task with repo",
+		"workspace_id":  "ws-1",
+		"workflow_id":   "wf-1",
+		"repository_id": "repo-123",
+		"base_branch":   "main",
+	})
+
+	assert.False(t, result.IsError)
+
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+
+	repos, ok := payload["repositories"].([]map[string]string)
+	require.True(t, ok, "repositories should be a slice")
+	require.Len(t, repos, 1)
+	assert.Equal(t, "repo-123", repos[0]["repository_id"])
+	assert.Equal(t, "main", repos[0]["base_branch"])
+}
+
+func TestCreateTask_WithLocalPath(t *testing.T) {
+	backend := &testBackend{
+		response: map[string]interface{}{"id": "task-new", "title": "Task with local path"},
+	}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
+		"title":        "Task with local path",
+		"workspace_id": "ws-1",
+		"workflow_id":  "wf-1",
+		"local_path":   "/Users/me/projects/myrepo",
+	})
+
+	assert.False(t, result.IsError)
+
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+
+	repos, ok := payload["repositories"].([]map[string]string)
+	require.True(t, ok, "repositories should be a slice")
+	require.Len(t, repos, 1)
+	assert.Equal(t, "/Users/me/projects/myrepo", repos[0]["local_path"])
 }

--- a/apps/backend/internal/agentctl/server/mcp/server.go
+++ b/apps/backend/internal/agentctl/server/mcp/server.go
@@ -291,8 +291,23 @@ func (s *Server) registerKanbanTools() {
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("create_task_kandev",
-			mcp.WithDescription("Create a new task or subtask and auto-start an agent on it. For subtasks (parent_id='self'), the executor profile and agent profile are automatically inherited from the parent session — no need to ask. For top-level tasks, use ask_user_question_kandev first if you do not already know which executor profile and agent profile the user wants to use. IMPORTANT: 'description' is the initial prompt the sub-agent receives — it is the ONLY context the sub-agent has to start working. Always provide a detailed description for subtasks."),
-			mcp.WithString("parent_id", mcp.Description("Parent task ID for subtasks. Use 'self' to create a subtask of your current task. Omit to create a top-level task.")),
+			mcp.WithDescription(`Create a new task or subtask and auto-start an agent on it.
+
+WHEN TO USE parent_id='self':
+- Breaking down your current task into phases/steps → use parent_id='self'
+- Creating tasks from a plan → use parent_id='self' (inherits repo, workspace, workflow)
+- Delegating work to another agent → use parent_id='self'
+
+WHEN TO OMIT parent_id (top-level task):
+- Creating an unrelated, standalone task
+- Requires workspace_id, workflow_id, and repository (use repository_id or local_path)
+
+IMPORTANT:
+- Subtasks inherit repositories, workspace, workflow, agent profile, and executor from parent
+- Top-level tasks need explicit repository via repository_id or local_path
+- 'description' is the sub-agent's initial prompt — be specific and detailed
+- Set start_agent=false to create without starting an agent`),
+			mcp.WithString("parent_id", mcp.Description("Parent task ID for subtasks. Use 'self' to create a subtask of your current task (RECOMMENDED for plan phases, delegated work). Omit only for unrelated top-level tasks.")),
 			mcp.WithString("workspace_id", mcp.Description("The workspace ID (required for top-level tasks, inherited from parent for subtasks)")),
 			mcp.WithString("workflow_id", mcp.Description("The workflow ID (required for top-level tasks, inherited from parent for subtasks)")),
 			mcp.WithString("workflow_step_id", mcp.Description("The workflow step ID (optional, auto-resolved if omitted)")),
@@ -300,6 +315,10 @@ func (s *Server) registerKanbanTools() {
 			mcp.WithString("description", mcp.Description("The initial prompt for the sub-agent. This is the ONLY context the agent receives when it starts — treat it as the agent's first user message. REQUIRED for subtasks: without a description the sub-agent starts with no context and cannot do useful work. Be specific and detailed.")),
 			mcp.WithString("agent_profile_id", mcp.Description("Agent profile ID to use. For subtasks, inherited from the parent session. For top-level tasks, ask the user which agent profile they want (e.g. Claude Code, OpenCode) if not already known.")),
 			mcp.WithString("executor_profile_id", mcp.Description("Executor profile ID to use (determines the runtime environment: local, worktree, docker, etc.). For subtasks, inherited from the parent session. For top-level tasks, ask the user which executor profile they want if not already known.")),
+			mcp.WithBoolean("start_agent", mcp.Description("Whether to auto-start an agent on the created task. Default: true. Set to false to create the task without starting an agent.")),
+			mcp.WithString("repository_id", mcp.Description("Repository ID for top-level tasks. Not needed for subtasks (inherited from parent).")),
+			mcp.WithString("local_path", mcp.Description("Local repository folder path (e.g. '/Users/me/projects/myrepo') for top-level tasks. Will create/find the repository automatically. Preferred for local worktree flow.")),
+			mcp.WithString("base_branch", mcp.Description("Base branch for the repository (e.g. 'main'). Optional, defaults to repository's default branch.")),
 		),
 		s.wrapHandler("create_task_kandev", s.createTaskHandler()),
 	)

--- a/apps/backend/internal/integration/mcp_integration_test.go
+++ b/apps/backend/internal/integration/mcp_integration_test.go
@@ -236,3 +236,50 @@ func TestMCPCreateTask_StartAgentTrue_RequiresDescription(t *testing.T) {
 	// Should fail because the sub-agent needs the description as initial prompt
 	assert.Equal(t, ws.MessageTypeError, resp.Type, "start_agent=true should require description for subtask")
 }
+
+func TestMCPCreateTask_SourceTaskID_TopLevel_Succeeds(t *testing.T) {
+	ts, parentTaskID, workspaceID, workflowID, _ := setupMCPTestServer(t)
+	defer ts.Close()
+
+	client := NewWSClient(t, ts.Server.URL)
+	defer client.Close()
+
+	// source_task_id is set by agentctl to the current task; verify the path succeeds
+	// and the task is created (even though parentTaskID has no repositories).
+	resp, err := client.SendRequest("top-source", ws.ActionMCPCreateTask, map[string]interface{}{
+		"workspace_id":   workspaceID,
+		"workflow_id":    workflowID,
+		"title":          "Top Level with Source Task",
+		"source_task_id": parentTaskID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type, "valid source_task_id should not cause failure")
+
+	var payload map[string]interface{}
+	require.NoError(t, resp.ParsePayload(&payload))
+	assert.NotEmpty(t, payload["id"])
+}
+
+func TestMCPCreateTask_SourceTaskID_NotFound_StillCreatesTask(t *testing.T) {
+	ts, _, workspaceID, workflowID, _ := setupMCPTestServer(t)
+	defer ts.Close()
+
+	client := NewWSClient(t, ts.Server.URL)
+	defer client.Close()
+
+	// Non-existent source_task_id must silently fall through (Warn log only),
+	// not cause a validation error. This covers the error-swallow branch at
+	// resolveTaskRepositories:422.
+	resp, err := client.SendRequest("top-notfound", ws.ActionMCPCreateTask, map[string]interface{}{
+		"workspace_id":   workspaceID,
+		"workflow_id":    workflowID,
+		"title":          "Top Level with Missing Source Task",
+		"source_task_id": "nonexistent-task-id-xyz",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type, "missing source_task_id should silently succeed, not fail")
+
+	var payload map[string]interface{}
+	require.NoError(t, resp.ParsePayload(&payload))
+	assert.NotEmpty(t, payload["id"])
+}

--- a/apps/backend/internal/integration/mcp_integration_test.go
+++ b/apps/backend/internal/integration/mcp_integration_test.go
@@ -198,3 +198,41 @@ func TestMCPCreateTask_InvalidParentID_ReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ws.MessageTypeError, resp.Type)
 }
+
+func TestMCPCreateTask_StartAgentFalse_DoesNotRequireDescription(t *testing.T) {
+	ts, parentTaskID, _, _, _ := setupMCPTestServer(t)
+	defer ts.Close()
+
+	client := NewWSClient(t, ts.Server.URL)
+	defer client.Close()
+
+	// With start_agent=false, description should NOT be required for subtasks
+	resp, err := client.SendRequest("subtask-1", ws.ActionMCPCreateTask, map[string]interface{}{
+		"parent_id":   parentTaskID,
+		"title":       "Subtask without description",
+		"start_agent": false, // Don't auto-start, so no description needed
+	})
+	require.NoError(t, err)
+
+	// Should succeed because start_agent=false means no agent needs the description
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type, "start_agent=false should allow subtask without description")
+}
+
+func TestMCPCreateTask_StartAgentTrue_RequiresDescription(t *testing.T) {
+	ts, parentTaskID, _, _, _ := setupMCPTestServer(t)
+	defer ts.Close()
+
+	client := NewWSClient(t, ts.Server.URL)
+	defer client.Close()
+
+	// With start_agent=true (default), description IS required for subtasks
+	resp, err := client.SendRequest("subtask-1", ws.ActionMCPCreateTask, map[string]interface{}{
+		"parent_id": parentTaskID,
+		"title":     "Subtask without description",
+		// start_agent defaults to true, description is required
+	})
+	require.NoError(t, err)
+
+	// Should fail because the sub-agent needs the description as initial prompt
+	assert.Equal(t, ws.MessageTypeError, resp.Type, "start_agent=true should require description for subtask")
+}

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -288,19 +288,28 @@ func (h *Handlers) handleListTasks(ctx context.Context, msg *ws.Message) (*ws.Me
 		})
 }
 
-// handleCreateTask creates a new task and auto-starts an agent session.
+// mcpRepositoryInput matches the repository input structure from MCP create_task
+type mcpRepositoryInput struct {
+	RepositoryID string `json:"repository_id"`
+	LocalPath    string `json:"local_path"`
+	BaseBranch   string `json:"base_branch"`
+}
+
+// handleCreateTask creates a new task and optionally auto-starts an agent session.
 func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
 	// Use local struct with JSON tags since dto.CreateTaskRequest lacks them
 	var req struct {
-		ParentID          string `json:"parent_id"`
-		SourceTaskID      string `json:"source_task_id"`
-		WorkspaceID       string `json:"workspace_id"`
-		WorkflowID        string `json:"workflow_id"`
-		WorkflowStepID    string `json:"workflow_step_id"`
-		Title             string `json:"title"`
-		Description       string `json:"description"`
-		AgentProfileID    string `json:"agent_profile_id"`
-		ExecutorProfileID string `json:"executor_profile_id"`
+		ParentID          string               `json:"parent_id"`
+		SourceTaskID      string               `json:"source_task_id"`
+		WorkspaceID       string               `json:"workspace_id"`
+		WorkflowID        string               `json:"workflow_id"`
+		WorkflowStepID    string               `json:"workflow_step_id"`
+		Title             string               `json:"title"`
+		Description       string               `json:"description"`
+		AgentProfileID    string               `json:"agent_profile_id"`
+		ExecutorProfileID string               `json:"executor_profile_id"`
+		StartAgent        *bool                `json:"start_agent"`  // nil means default to true for backward compatibility
+		Repositories      []mcpRepositoryInput `json:"repositories"` // explicit repositories for top-level tasks
 	}
 	if err := json.Unmarshal(msg.Payload, &req); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
@@ -308,51 +317,26 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 	if req.Title == "" {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "title is required", nil)
 	}
-	if req.ParentID != "" && req.Description == "" {
+
+	// Default start_agent to true for backward compatibility
+	startAgent := req.StartAgent == nil || *req.StartAgent
+
+	// Only require description for subtasks if we're starting an agent
+	if req.ParentID != "" && req.Description == "" && startAgent {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "description is required for subtasks: it is the sub-agent's initial prompt and the only context it receives to start working", nil)
 	}
 
-	// Inherit workspace/workflow/repositories from parent when not explicitly provided.
-	// WorkflowStepID is intentionally NOT inherited — the service layer resolves
-	// the start step so subtasks always begin at the first workflow step, not the
-	// parent's current (potentially advanced) step.
-	var inheritedRepos []service.TaskRepositoryInput
-	if req.ParentID != "" {
-		parent, err := h.taskSvc.GetTask(ctx, req.ParentID)
-		if err != nil {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "invalid parent_id: "+err.Error(), nil)
-		}
-		if req.WorkspaceID == "" {
-			req.WorkspaceID = parent.WorkspaceID
-		}
-		if req.WorkflowID == "" {
-			req.WorkflowID = parent.WorkflowID
-		}
-		for _, r := range parent.Repositories {
-			inheritedRepos = append(inheritedRepos, service.TaskRepositoryInput{
-				RepositoryID:   r.RepositoryID,
-				BaseBranch:     r.BaseBranch,
-				CheckoutBranch: r.CheckoutBranch,
-			})
-		}
+	// Resolve repositories and inherit workspace/workflow from parent if needed.
+	resolved, err := h.resolveTaskRepositories(ctx, req.ParentID, req.SourceTaskID, req.Repositories)
+	if err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, err.Error(), nil)
 	}
-
-	// For top-level tasks, inherit repositories from the calling agent's current task
-	// so the new task is associated with the same codebase.
-	if req.ParentID == "" && req.SourceTaskID != "" {
-		sourceTask, err := h.taskSvc.GetTask(ctx, req.SourceTaskID)
-		if err != nil {
-			h.logger.Warn("source task not found, skipping repo inheritance",
-				zap.String("source_task_id", req.SourceTaskID), zap.Error(err))
-		} else {
-			for _, r := range sourceTask.Repositories {
-				inheritedRepos = append(inheritedRepos, service.TaskRepositoryInput{
-					RepositoryID:   r.RepositoryID,
-					BaseBranch:     r.BaseBranch,
-					CheckoutBranch: r.CheckoutBranch,
-				})
-			}
-		}
+	repos := resolved.Repos
+	if req.WorkspaceID == "" {
+		req.WorkspaceID = resolved.WorkspaceID
+	}
+	if req.WorkflowID == "" {
+		req.WorkflowID = resolved.WorkflowID
 	}
 
 	if req.WorkspaceID == "" {
@@ -369,29 +353,108 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		WorkflowStepID: req.WorkflowStepID,
 		Title:          req.Title,
 		Description:    req.Description,
-		Repositories:   inheritedRepos,
+		Repositories:   repos,
 	})
 	if err != nil {
 		h.logger.Error("failed to create task", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to create task", nil)
 	}
 
-	// Auto-start agent session asynchronously
-	h.autoStartTask(task, req.AgentProfileID, req.ExecutorProfileID)
+	// Auto-start agent session asynchronously only if requested
+	if startAgent {
+		h.autoStartTask(task, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
+	}
 
 	return ws.NewResponse(msg.ID, msg.Action, dto.FromTask(task))
 }
 
+// taskRepoResult holds the output of resolveTaskRepositories.
+type taskRepoResult struct {
+	Repos       []service.TaskRepositoryInput
+	WorkspaceID string // inherited from parent, empty otherwise
+	WorkflowID  string // inherited from parent, empty otherwise
+}
+
+// resolveTaskRepositories builds the repository list for a new task.
+// Priority: explicit repositories > parent task repos > source task repos.
+// When inheriting from a parent, it also returns the parent's workspace/workflow IDs.
+func (h *Handlers) resolveTaskRepositories(
+	ctx context.Context,
+	parentID, sourceTaskID string,
+	explicit []mcpRepositoryInput,
+) (taskRepoResult, error) {
+	if len(explicit) > 0 {
+		var repos []service.TaskRepositoryInput
+		for _, r := range explicit {
+			repos = append(repos, service.TaskRepositoryInput{
+				RepositoryID: r.RepositoryID,
+				LocalPath:    r.LocalPath,
+				BaseBranch:   r.BaseBranch,
+			})
+		}
+		return taskRepoResult{Repos: repos}, nil
+	}
+
+	if parentID != "" {
+		parent, err := h.taskSvc.GetTask(ctx, parentID)
+		if err != nil {
+			return taskRepoResult{}, fmt.Errorf("invalid parent_id: %w", err)
+		}
+		var repos []service.TaskRepositoryInput
+		for _, r := range parent.Repositories {
+			repos = append(repos, service.TaskRepositoryInput{
+				RepositoryID:   r.RepositoryID,
+				BaseBranch:     r.BaseBranch,
+				CheckoutBranch: r.CheckoutBranch,
+			})
+		}
+		return taskRepoResult{
+			Repos:       repos,
+			WorkspaceID: parent.WorkspaceID,
+			WorkflowID:  parent.WorkflowID,
+		}, nil
+	}
+
+	// For top-level tasks, inherit from the calling agent's current task.
+	if sourceTaskID != "" {
+		sourceTask, err := h.taskSvc.GetTask(ctx, sourceTaskID)
+		if err != nil {
+			h.logger.Warn("source task not found, skipping repo inheritance",
+				zap.String("source_task_id", sourceTaskID), zap.Error(err))
+			return taskRepoResult{}, nil
+		}
+		var repos []service.TaskRepositoryInput
+		for _, r := range sourceTask.Repositories {
+			repos = append(repos, service.TaskRepositoryInput{
+				RepositoryID:   r.RepositoryID,
+				BaseBranch:     r.BaseBranch,
+				CheckoutBranch: r.CheckoutBranch,
+			})
+		}
+		return taskRepoResult{Repos: repos}, nil
+	}
+
+	return taskRepoResult{}, nil
+}
+
 // autoStartTask launches an agent session for a newly created task in the background.
-// It resolves the agent profile: explicit > parent's session > workspace default.
+// It resolves the agent profile: explicit > parent's session > source task's session > workspace default.
 // It resolves the executor: explicit executor_profile_id > parent's executor_profile_id >
-// parent's executor_id > "exec-worktree" (default for MCP-created tasks).
-func (h *Handlers) autoStartTask(task *models.Task, agentProfileID, executorProfileID string) {
+// source task's executor_profile_id > parent's executor_id > "exec-worktree" (default for MCP-created tasks).
+func (h *Handlers) autoStartTask(task *models.Task, agentProfileID, executorProfileID, sourceTaskID string) {
 	if h.sessionLauncher == nil {
 		return
 	}
 
 	executorID := h.inheritFromParentSession(task.ParentID, &agentProfileID, &executorProfileID)
+
+	// For top-level tasks, inherit from the source task (the calling agent's task)
+	if task.ParentID == "" && sourceTaskID != "" {
+		sourceExecutorID := h.inheritFromParentSession(sourceTaskID, &agentProfileID, &executorProfileID)
+		if executorID == "" {
+			executorID = sourceExecutorID
+		}
+	}
 
 	// Fall back to workspace defaults for agent profile and worktree executor
 	if agentProfileID == "" {

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -119,7 +119,7 @@ func TestAutoStartTask_DefaultsToWorktreeExecutor(t *testing.T) {
 	}
 
 	// Call with agent profile but no executor info
-	h.autoStartTask(task, "agent-profile-1", "")
+	h.autoStartTask(task, "agent-profile-1", "", "")
 
 	select {
 	case <-launcher.called:
@@ -147,7 +147,7 @@ func TestAutoStartTask_ExplicitExecutorProfilePreserved(t *testing.T) {
 	}
 
 	// Call with explicit executor profile
-	h.autoStartTask(task, "agent-profile-1", "exec-profile-docker")
+	h.autoStartTask(task, "agent-profile-1", "exec-profile-docker", "")
 
 	select {
 	case <-launcher.called:
@@ -158,4 +158,44 @@ func TestAutoStartTask_ExplicitExecutorProfilePreserved(t *testing.T) {
 	req := launcher.getRequest()
 	assert.Equal(t, "exec-profile-docker", req.ExecutorProfileID, "explicit executor profile should be preserved")
 	assert.Equal(t, "", req.ExecutorID, "executorID should be empty when profile is set")
+}
+
+func TestResolveTaskRepositories_ExplicitRepos(t *testing.T) {
+	log := testLogger(t)
+	h := &Handlers{logger: log.WithFields()}
+
+	explicit := []mcpRepositoryInput{
+		{RepositoryID: "repo-1", BaseBranch: "main"},
+		{LocalPath: "/tmp/myrepo"},
+	}
+	result, err := h.resolveTaskRepositories(context.Background(), "", "", explicit)
+	require.NoError(t, err)
+	require.Len(t, result.Repos, 2)
+	assert.Equal(t, "repo-1", result.Repos[0].RepositoryID)
+	assert.Equal(t, "main", result.Repos[0].BaseBranch)
+	assert.Equal(t, "/tmp/myrepo", result.Repos[1].LocalPath)
+	assert.Empty(t, result.WorkspaceID, "workspace should not be set for explicit repos")
+	assert.Empty(t, result.WorkflowID, "workflow should not be set for explicit repos")
+}
+
+func TestResolveTaskRepositories_NoInputs_ReturnsEmpty(t *testing.T) {
+	log := testLogger(t)
+	h := &Handlers{logger: log.WithFields()}
+
+	result, err := h.resolveTaskRepositories(context.Background(), "", "", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Repos)
+}
+
+func TestResolveTaskRepositories_ExplicitRepos_SkipsParentLookup(t *testing.T) {
+	log := testLogger(t)
+	h := &Handlers{logger: log.WithFields()}
+
+	// Even with a parentID, explicit repos should be used without looking up the parent
+	// (taskSvc is nil — if it tried to call GetTask it would panic).
+	explicit := []mcpRepositoryInput{{RepositoryID: "repo-explicit"}}
+	result, err := h.resolveTaskRepositories(context.Background(), "some-parent", "some-source", explicit)
+	require.NoError(t, err)
+	require.Len(t, result.Repos, 1)
+	assert.Equal(t, "repo-explicit", result.Repos[0].RepositoryID)
 }


### PR DESCRIPTION
Agents creating tasks from plans would always auto-start immediately and couldn't specify repositories for top-level tasks. This adds control parameters to the MCP create_task tool.

## Important Changes

- **`start_agent` param** (default `true`): Set to `false` to create tasks without auto-starting an agent
- **`local_path` param**: Specify local repository folder path for top-level tasks (worktree flow)
- **`repository_id` + `base_branch` params**: Explicit repository configuration for top-level tasks
- **Improved tool description**: Clear guidance on when to use `parent_id='self'` vs top-level tasks
- **Relaxed validation**: Description no longer required for subtasks when `start_agent=false`

## Validation

- `go build ./...`
- `go test ./internal/agentctl/server/mcp/... ./internal/mcp/... ./internal/integration/...`
- Added tests for new parameters

## Checklist

- [ ] Tested locally
- [ ] Follows Conventional Commits
- [ ] No unnecessary files or debug code