### PR TITLE
feat: introduce lane actions (clear, archive, move)

### DIFF
--- a/apps/web/components/kanban-board-grid.tsx
+++ b/apps/web/components/kanban-board-grid.tsx
@@ -38,6 +38,9 @@ export type KanbanBoardGridProps = {
   archivingTaskId?: string | null;
   onCreateTask?: () => void;
   isLoading?: boolean;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 };
 
 type ColumnGridProps = Pick<
@@ -53,6 +56,9 @@ type ColumnGridProps = Pick<
   | "showMaximizeButton"
   | "deletingTaskId"
   | "archivingTaskId"
+  | "onClearLane"
+  | "onArchiveLane"
+  | "onMoveLane"
 >;
 
 function getTasksForStep(tasks: Task[], stepId: string) {
@@ -89,6 +95,9 @@ function MobileLayout({
   activeColumnIndex,
   setActiveColumnIndex,
   currentStepId,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: ColumnGridProps & {
   showLoading: boolean;
   activeTask: Task | null;
@@ -125,6 +134,9 @@ function MobileLayout({
               showMaximizeButton={showMaximizeButton}
               deletingTaskId={deletingTaskId}
               archivingTaskId={archivingTaskId}
+              onClearLane={onClearLane}
+              onArchiveLane={onArchiveLane}
+              onMoveLane={onMoveLane}
             />
             <MobileDropTargets
               steps={steps}
@@ -158,6 +170,9 @@ function TabletLayout({
   archivingTaskId,
   showLoading,
   activeTask,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: ColumnGridProps & { showLoading: boolean; activeTask: Task | null }) {
   return (
     <>
@@ -181,6 +196,9 @@ function TabletLayout({
                   showMaximizeButton={showMaximizeButton}
                   deletingTaskId={deletingTaskId}
                   archivingTaskId={archivingTaskId}
+                  onClearLane={onClearLane}
+                  onArchiveLane={onArchiveLane}
+                  onMoveLane={onMoveLane}
                 />
               </div>
             ))}
@@ -208,6 +226,9 @@ function DesktopLayout({
   archivingTaskId,
   showLoading,
   activeTask,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: ColumnGridProps & { showLoading: boolean; activeTask: Task | null }) {
   return (
     <>
@@ -234,6 +255,9 @@ function DesktopLayout({
                 showMaximizeButton={showMaximizeButton}
                 deletingTaskId={deletingTaskId}
                 archivingTaskId={archivingTaskId}
+                onClearLane={onClearLane}
+                onArchiveLane={onArchiveLane}
+                onMoveLane={onMoveLane}
               />
             ))}
           </div>
@@ -275,6 +299,9 @@ export function KanbanBoardGrid({
   archivingTaskId,
   onCreateTask,
   isLoading,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: KanbanBoardGridProps) {
   const { isMobile, isTablet } = useResponsiveBreakpoint();
   const activeColumnIndex = useAppStore((state) => state.mobileKanban.activeColumnIndex);
@@ -334,6 +361,9 @@ export function KanbanBoardGrid({
     showMaximizeButton,
     deletingTaskId,
     archivingTaskId,
+    onClearLane,
+    onArchiveLane,
+    onMoveLane,
   };
 
   let layoutContent: React.ReactNode;

--- a/apps/web/components/kanban-board.tsx
+++ b/apps/web/components/kanban-board.tsx
@@ -158,6 +158,9 @@ function useKanbanBoardHooks(
     handleWorkflowChange,
     deletingTaskId,
     archivingTaskId,
+    handleClearLane,
+    handleArchiveLane,
+    handleMoveLane,
   } = useKanbanActions({ workspaceState, workflowsState });
   const { enablePreviewOnClick, userSettings, commitSettings, activeSteps, isMounted } =
     useKanbanData({
@@ -183,6 +186,9 @@ function useKanbanBoardHooks(
     commitSettings,
     activeSteps,
     isMounted,
+    handleClearLane,
+    handleArchiveLane,
+    handleMoveLane,
   };
 }
 
@@ -308,6 +314,9 @@ export function KanbanBoard({ onPreviewTask, onOpenTask }: KanbanBoardProps = {}
         showMaximizeButton={s.enablePreviewOnClick}
         searchQuery={s.searchQuery}
         selectedRepositoryIds={s.userSettings.repositoryIds}
+        onClearLane={s.handleClearLane}
+        onArchiveLane={s.handleArchiveLane}
+        onMoveLane={s.handleMoveLane}
       />
       {s.isMobile && (
         <>

--- a/apps/web/components/kanban-column.tsx
+++ b/apps/web/components/kanban-column.tsx
@@ -206,6 +206,7 @@ function ColumnMenu({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
+            data-testid={`lane-menu-trigger-${currentStepId}`}
             className={cn(
               "transition-opacity text-muted-foreground hover:text-foreground hover:bg-muted rounded-sm p-1 -m-1 cursor-pointer",
               menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100",
@@ -221,6 +222,7 @@ function ColumnMenu({
           {onMoveLane && steps && steps.filter((s) => s.id !== currentStepId).length > 0 && (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger
+                data-testid="lane-menu-move-all"
                 className="cursor-pointer"
                 onClick={(e) => e.stopPropagation()}
                 onPointerDown={(e) => e.stopPropagation()}
@@ -234,6 +236,7 @@ function ColumnMenu({
                     .map((s) => (
                       <DropdownMenuItem
                         key={s.id}
+                        data-testid={`lane-menu-move-to-${s.id}`}
                         className="cursor-pointer"
                         onSelect={() => onMoveLane(tasks, s.id)}
                       >
@@ -248,6 +251,7 @@ function ColumnMenu({
           {onMoveLane && onArchiveLane && <DropdownMenuSeparator />}
           {onArchiveLane && (
             <DropdownMenuItem
+              data-testid="lane-menu-archive-all"
               className="cursor-pointer"
               onSelect={() => setArchiveConfirmOpen(true)}
             >
@@ -257,6 +261,7 @@ function ColumnMenu({
           {onArchiveLane && onClearLane && <DropdownMenuSeparator />}
           {onClearLane && (
             <DropdownMenuItem
+              data-testid="lane-menu-clear"
               className="text-destructive focus:text-destructive cursor-pointer"
               onSelect={() => setClearConfirmOpen(true)}
             >
@@ -278,6 +283,7 @@ function ColumnMenu({
             <AlertDialogFooter>
               <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
               <AlertDialogAction
+                data-testid="lane-confirm-archive"
                 disabled={isArchiving}
                 className="cursor-pointer"
                 onClick={handleArchiveConfirm}
@@ -302,6 +308,7 @@ function ColumnMenu({
             <AlertDialogFooter>
               <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
               <AlertDialogAction
+                data-testid="lane-confirm-clear"
                 disabled={isClearing}
                 className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 onClick={handleClearConfirm}

--- a/apps/web/components/kanban-column.tsx
+++ b/apps/web/components/kanban-column.tsx
@@ -1,9 +1,31 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useDroppable } from "@dnd-kit/core";
+import { IconDots } from "@tabler/icons-react";
 import { KanbanCard, Task } from "./kanban-card";
 import { Badge } from "@kandev/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@kandev/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@kandev/ui/dropdown-menu";
 import { cn, getRepositoryDisplayName } from "@/lib/utils";
 import { useAppStore } from "@/components/state-provider";
 import type { Repository } from "@/lib/types/http";
@@ -27,6 +49,9 @@ interface KanbanColumnProps {
   onDeleteTask: (task: Task) => void;
   onArchiveTask?: (task: Task) => void;
   onMoveTask?: (task: Task, targetStepId: string) => void;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
   steps?: WorkflowStep[];
   showMaximizeButton?: boolean;
   deletingTaskId?: string | null;
@@ -43,6 +68,9 @@ export function KanbanColumn({
   onDeleteTask,
   onArchiveTask,
   onMoveTask,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
   steps,
   showMaximizeButton,
   deletingTaskId,
@@ -79,7 +107,7 @@ export function KanbanColumn({
     >
       {/* Column Header */}
       {!hideHeader && (
-        <div className="flex items-center justify-between pb-2 mb-3 px-1">
+        <div className="group flex items-center justify-between pb-2 mb-3 px-1">
           <div className="flex items-center gap-2">
             <div className={cn("w-2 h-2 rounded-full", step.color)} />
             <h2 className="font-semibold text-sm">{step.title}</h2>
@@ -87,6 +115,17 @@ export function KanbanColumn({
               {tasks.length}
             </Badge>
           </div>
+          {(onClearLane || onArchiveLane || onMoveLane) && tasks.length > 0 && (
+            <ColumnMenu
+              tasks={tasks}
+              stepTitle={step.title}
+              currentStepId={step.id}
+              steps={steps}
+              onClearLane={onClearLane}
+              onArchiveLane={onArchiveLane}
+              onMoveLane={onMoveLane}
+            />
+          )}
         </div>
       )}
 
@@ -111,5 +150,168 @@ export function KanbanColumn({
         ))}
       </div>
     </div>
+  );
+}
+
+function ColumnMenu({
+  tasks,
+  stepTitle,
+  currentStepId,
+  steps,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
+}: {
+  tasks: Task[];
+  stepTitle: string;
+  currentStepId?: string;
+  steps?: WorkflowStep[];
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
+  const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
+
+  const handleClearConfirm = async () => {
+    if (!onClearLane) return;
+    setIsClearing(true);
+    try {
+      await onClearLane(tasks);
+    } finally {
+      setIsClearing(false);
+      setClearConfirmOpen(false);
+    }
+  };
+
+  const handleArchiveConfirm = async () => {
+    if (!onArchiveLane) return;
+    setIsArchiving(true);
+    try {
+      await onArchiveLane(tasks);
+    } finally {
+      setIsArchiving(false);
+      setArchiveConfirmOpen(false);
+    }
+  };
+
+  const taskWord = tasks.length !== 1 ? "tasks" : "task";
+
+  return (
+    <>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "transition-opacity text-muted-foreground hover:text-foreground hover:bg-muted rounded-sm p-1 -m-1 cursor-pointer",
+              menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+            )}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            aria-label="Lane options"
+          >
+            <IconDots className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {onMoveLane && steps && steps.filter((s) => s.id !== currentStepId).length > 0 && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                className="cursor-pointer"
+                onClick={(e) => e.stopPropagation()}
+                onPointerDown={(e) => e.stopPropagation()}
+              >
+                Move all to
+              </DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent>
+                  {steps
+                    .filter((s) => s.id !== currentStepId)
+                    .map((s) => (
+                      <DropdownMenuItem
+                        key={s.id}
+                        className="cursor-pointer"
+                        onSelect={() => onMoveLane(tasks, s.id)}
+                      >
+                        <div className={cn("w-2 h-2 rounded-full mr-2", s.color)} />
+                        {s.title}
+                      </DropdownMenuItem>
+                    ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+          )}
+          {onMoveLane && onArchiveLane && <DropdownMenuSeparator />}
+          {onArchiveLane && (
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={() => setArchiveConfirmOpen(true)}
+            >
+              Archive all
+            </DropdownMenuItem>
+          )}
+          {onArchiveLane && onClearLane && <DropdownMenuSeparator />}
+          {onClearLane && (
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive cursor-pointer"
+              onSelect={() => setClearConfirmOpen(true)}
+            >
+              Clear lane
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {onArchiveLane && (
+        <AlertDialog open={archiveConfirmOpen} onOpenChange={setArchiveConfirmOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Archive all</AlertDialogTitle>
+              <AlertDialogDescription>
+                Archive all {tasks.length} {taskWord} in &quot;{stepTitle}&quot;?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                disabled={isArchiving}
+                className="cursor-pointer"
+                onClick={handleArchiveConfirm}
+              >
+                Archive all
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {onClearLane && (
+        <AlertDialog open={clearConfirmOpen} onOpenChange={setClearConfirmOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Clear lane</AlertDialogTitle>
+              <AlertDialogDescription>
+                Delete all {tasks.length} {taskWord} in &quot;{stepTitle}&quot;? This action cannot
+                be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                disabled={isClearing}
+                className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={handleClearConfirm}
+              >
+                Delete all
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
   );
 }

--- a/apps/web/components/kanban-column.tsx
+++ b/apps/web/components/kanban-column.tsx
@@ -153,6 +153,131 @@ export function KanbanColumn({
   );
 }
 
+function MoveAllSubmenu({
+  tasks,
+  currentStepId,
+  steps,
+  onMoveLane,
+}: {
+  tasks: Task[];
+  currentStepId?: string;
+  steps: WorkflowStep[];
+  onMoveLane: (tasks: Task[], targetStepId: string) => Promise<void>;
+}) {
+  const otherSteps = steps.filter((s) => s.id !== currentStepId);
+  if (otherSteps.length === 0) return null;
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger
+        data-testid="lane-menu-move-all"
+        className="cursor-pointer"
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        Move all to
+      </DropdownMenuSubTrigger>
+      <DropdownMenuPortal>
+        <DropdownMenuSubContent>
+          {otherSteps.map((s) => (
+            <DropdownMenuItem
+              key={s.id}
+              data-testid={`lane-menu-move-to-${s.id}`}
+              className="cursor-pointer"
+              onSelect={() => onMoveLane(tasks, s.id)}
+            >
+              <div className={cn("w-2 h-2 rounded-full mr-2", s.color)} />
+              {s.title}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuSubContent>
+      </DropdownMenuPortal>
+    </DropdownMenuSub>
+  );
+}
+
+function ArchiveConfirmDialog({
+  open,
+  onOpenChange,
+  isArchiving,
+  onConfirm,
+  tasks,
+  stepTitle,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isArchiving: boolean;
+  onConfirm: () => void;
+  tasks: Task[];
+  stepTitle: string;
+}) {
+  const taskWord = tasks.length !== 1 ? "tasks" : "task";
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Archive all</AlertDialogTitle>
+          <AlertDialogDescription>
+            Archive all {tasks.length} {taskWord} in &quot;{stepTitle}&quot;?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            data-testid="lane-confirm-archive"
+            disabled={isArchiving}
+            className="cursor-pointer"
+            onClick={onConfirm}
+          >
+            Archive all
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function ClearConfirmDialog({
+  open,
+  onOpenChange,
+  isClearing,
+  onConfirm,
+  tasks,
+  stepTitle,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isClearing: boolean;
+  onConfirm: () => void;
+  tasks: Task[];
+  stepTitle: string;
+}) {
+  const taskWord = tasks.length !== 1 ? "tasks" : "task";
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Clear lane</AlertDialogTitle>
+          <AlertDialogDescription>
+            Delete all {tasks.length} {taskWord} in &quot;{stepTitle}&quot;? This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            data-testid="lane-confirm-clear"
+            disabled={isClearing}
+            className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={onConfirm}
+          >
+            Delete all
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
 function ColumnMenu({
   tasks,
   stepTitle,
@@ -198,8 +323,6 @@ function ColumnMenu({
     }
   };
 
-  const taskWord = tasks.length !== 1 ? "tasks" : "task";
-
   return (
     <>
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
@@ -219,34 +342,13 @@ function ColumnMenu({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          {onMoveLane && steps && steps.filter((s) => s.id !== currentStepId).length > 0 && (
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger
-                data-testid="lane-menu-move-all"
-                className="cursor-pointer"
-                onClick={(e) => e.stopPropagation()}
-                onPointerDown={(e) => e.stopPropagation()}
-              >
-                Move all to
-              </DropdownMenuSubTrigger>
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent>
-                  {steps
-                    .filter((s) => s.id !== currentStepId)
-                    .map((s) => (
-                      <DropdownMenuItem
-                        key={s.id}
-                        data-testid={`lane-menu-move-to-${s.id}`}
-                        className="cursor-pointer"
-                        onSelect={() => onMoveLane(tasks, s.id)}
-                      >
-                        <div className={cn("w-2 h-2 rounded-full mr-2", s.color)} />
-                        {s.title}
-                      </DropdownMenuItem>
-                    ))}
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
+          {onMoveLane && steps && (
+            <MoveAllSubmenu
+              tasks={tasks}
+              currentStepId={currentStepId}
+              steps={steps}
+              onMoveLane={onMoveLane}
+            />
           )}
           {onMoveLane && onArchiveLane && <DropdownMenuSeparator />}
           {onArchiveLane && (
@@ -272,52 +374,25 @@ function ColumnMenu({
       </DropdownMenu>
 
       {onArchiveLane && (
-        <AlertDialog open={archiveConfirmOpen} onOpenChange={setArchiveConfirmOpen}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Archive all</AlertDialogTitle>
-              <AlertDialogDescription>
-                Archive all {tasks.length} {taskWord} in &quot;{stepTitle}&quot;?
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                data-testid="lane-confirm-archive"
-                disabled={isArchiving}
-                className="cursor-pointer"
-                onClick={handleArchiveConfirm}
-              >
-                Archive all
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <ArchiveConfirmDialog
+          open={archiveConfirmOpen}
+          onOpenChange={setArchiveConfirmOpen}
+          isArchiving={isArchiving}
+          onConfirm={handleArchiveConfirm}
+          tasks={tasks}
+          stepTitle={stepTitle}
+        />
       )}
 
       {onClearLane && (
-        <AlertDialog open={clearConfirmOpen} onOpenChange={setClearConfirmOpen}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Clear lane</AlertDialogTitle>
-              <AlertDialogDescription>
-                Delete all {tasks.length} {taskWord} in &quot;{stepTitle}&quot;? This action cannot
-                be undone.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                data-testid="lane-confirm-clear"
-                disabled={isClearing}
-                className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                onClick={handleClearConfirm}
-              >
-                Delete all
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <ClearConfirmDialog
+          open={clearConfirmOpen}
+          onOpenChange={setClearConfirmOpen}
+          isClearing={isClearing}
+          onConfirm={handleClearConfirm}
+          tasks={tasks}
+          stepTitle={stepTitle}
+        />
       )}
     </>
   );

--- a/apps/web/components/kanban/swimlane-container.tsx
+++ b/apps/web/components/kanban/swimlane-container.tsx
@@ -46,6 +46,9 @@ export type SwimlaneContainerProps = {
   showMaximizeButton?: boolean;
   searchQuery?: string;
   selectedRepositoryIds?: string[];
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 };
 
 function getEmptyMessage(
@@ -113,6 +116,9 @@ type WorkflowItemProps = {
   deletingTaskId?: string | null;
   archivingTaskId?: string | null;
   showMaximizeButton?: boolean;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 };
 
 function SortableWorkflowItem({ wf, hideHeader, isSortable, ...rest }: WorkflowItemProps) {
@@ -215,6 +221,9 @@ export function SwimlaneContainer({
   showMaximizeButton,
   searchQuery,
   selectedRepositoryIds = [],
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: SwimlaneContainerProps) {
   const { isMobile } = useResponsiveBreakpoint();
   const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
@@ -299,6 +308,9 @@ export function SwimlaneContainer({
                 deletingTaskId={deletingTaskId}
                 archivingTaskId={archivingTaskId}
                 showMaximizeButton={showMaximizeButton}
+                onClearLane={onClearLane}
+                onArchiveLane={onArchiveLane}
+                onMoveLane={onMoveLane}
               />
             );
           })}

--- a/apps/web/components/kanban/swimlane-kanban-content.tsx
+++ b/apps/web/components/kanban/swimlane-kanban-content.tsx
@@ -36,6 +36,9 @@ export type SwimlaneKanbanContentProps = {
   deletingTaskId?: string | null;
   archivingTaskId?: string | null;
   showMaximizeButton?: boolean;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 };
 
 type SwimlaneKanbanDndOptions = {
@@ -183,6 +186,9 @@ function MobileKanbanLayout({
   showMaximizeButton,
   deletingTaskId,
   archivingTaskId,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: {
   steps: WorkflowStep[];
   tasks: Task[];
@@ -198,6 +204,9 @@ function MobileKanbanLayout({
   showMaximizeButton?: boolean;
   deletingTaskId?: string | null;
   archivingTaskId?: string | null;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 }) {
   const taskCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -231,6 +240,9 @@ function MobileKanbanLayout({
         showMaximizeButton={showMaximizeButton}
         deletingTaskId={deletingTaskId}
         archivingTaskId={archivingTaskId}
+        onClearLane={onClearLane}
+        onArchiveLane={onArchiveLane}
+        onMoveLane={onMoveLane}
       />
       <MobileDropTargets steps={steps} currentStepId={currentStepId} isDragging={!!activeTask} />
     </div>
@@ -249,6 +261,9 @@ function TabletKanbanLayout({
   showMaximizeButton,
   deletingTaskId,
   archivingTaskId,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: {
   steps: WorkflowStep[];
   tasks: Task[];
@@ -261,6 +276,9 @@ function TabletKanbanLayout({
   showMaximizeButton?: boolean;
   deletingTaskId?: string | null;
   archivingTaskId?: string | null;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 }) {
   const getTasksForStep = useTasksByStep(tasks);
 
@@ -284,6 +302,9 @@ function TabletKanbanLayout({
             showMaximizeButton={showMaximizeButton}
             deletingTaskId={deletingTaskId}
             archivingTaskId={archivingTaskId}
+            onClearLane={onClearLane}
+            onArchiveLane={onArchiveLane}
+            onMoveLane={onMoveLane}
           />
         </div>
       ))}
@@ -303,6 +324,9 @@ function DesktopKanbanLayout({
   showMaximizeButton,
   deletingTaskId,
   archivingTaskId,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: {
   steps: WorkflowStep[];
   tasks: Task[];
@@ -315,6 +339,9 @@ function DesktopKanbanLayout({
   showMaximizeButton?: boolean;
   deletingTaskId?: string | null;
   archivingTaskId?: string | null;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 }) {
   const getTasksForStep = useTasksByStep(tasks);
 
@@ -338,6 +365,9 @@ function DesktopKanbanLayout({
           deletingTaskId={deletingTaskId}
           archivingTaskId={archivingTaskId}
           showMaximizeButton={showMaximizeButton}
+          onClearLane={onClearLane}
+          onArchiveLane={onArchiveLane}
+          onMoveLane={onMoveLane}
         />
       ))}
     </div>
@@ -357,6 +387,9 @@ export function SwimlaneKanbanContent({
   deletingTaskId,
   archivingTaskId,
   showMaximizeButton,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: SwimlaneKanbanContentProps) {
   const { isMobile, isTablet } = useResponsiveBreakpoint();
   const { activeIndex, setActiveIndex } = useMobileColumnIndex(steps, tasks);
@@ -377,6 +410,9 @@ export function SwimlaneKanbanContent({
     showMaximizeButton,
     deletingTaskId,
     archivingTaskId,
+    onClearLane,
+    onArchiveLane,
+    onMoveLane,
   };
 
   let layoutContent: React.ReactNode;

--- a/apps/web/components/kanban/swipeable-columns.tsx
+++ b/apps/web/components/kanban/swipeable-columns.tsx
@@ -19,6 +19,9 @@ type SwipeableColumnsProps = {
   showMaximizeButton?: boolean;
   deletingTaskId?: string | null;
   archivingTaskId?: string | null;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 };
 
 export function SwipeableColumns({
@@ -35,6 +38,9 @@ export function SwipeableColumns({
   showMaximizeButton,
   deletingTaskId,
   archivingTaskId,
+  onClearLane,
+  onArchiveLane,
+  onMoveLane,
 }: SwipeableColumnsProps) {
   // Stable options to avoid Embla reinitializing on every activeIndex change
   const [initialIndex] = useState(activeIndex);
@@ -119,6 +125,9 @@ export function SwipeableColumns({
               deletingTaskId={deletingTaskId}
               archivingTaskId={archivingTaskId}
               hideHeader
+              onClearLane={onClearLane}
+              onArchiveLane={onArchiveLane}
+              onMoveLane={onMoveLane}
             />
           </div>
         ))}

--- a/apps/web/e2e/pages/kanban-page.ts
+++ b/apps/web/e2e/pages/kanban-page.ts
@@ -33,4 +33,37 @@ export class KanbanPage {
       has: this.page.locator('[data-testid="task-card-title"]', { hasText: title }),
     });
   }
+
+  laneMenuTrigger(stepId: string): Locator {
+    return this.page.getByTestId(`lane-menu-trigger-${stepId}`);
+  }
+
+  async openLaneMenu(stepId: string): Promise<void> {
+    await this.columnByStepId(stepId).hover();
+    await this.laneMenuTrigger(stepId).click();
+  }
+
+  laneMenuMoveAll(): Locator {
+    return this.page.getByTestId("lane-menu-move-all");
+  }
+
+  laneMenuMoveToStep(stepId: string): Locator {
+    return this.page.getByTestId(`lane-menu-move-to-${stepId}`);
+  }
+
+  laneMenuArchiveAll(): Locator {
+    return this.page.getByTestId("lane-menu-archive-all");
+  }
+
+  laneMenuClear(): Locator {
+    return this.page.getByTestId("lane-menu-clear");
+  }
+
+  laneConfirmArchive(): Locator {
+    return this.page.getByTestId("lane-confirm-archive");
+  }
+
+  laneConfirmClear(): Locator {
+    return this.page.getByTestId("lane-confirm-clear");
+  }
 }

--- a/apps/web/e2e/tests/kanban/lane-actions.spec.ts
+++ b/apps/web/e2e/tests/kanban/lane-actions.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+
+test.describe("Lane actions", () => {
+  test("hides lane menu when column has no tasks", async ({ testPage, seedData }) => {
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.columnByStepId(seedData.startStepId).hover();
+    await expect(kanban.laneMenuTrigger(seedData.startStepId)).not.toBeVisible();
+  });
+
+  test("archive all removes tasks from lane", async ({ testPage, apiClient, seedData }) => {
+    await apiClient.createTask(seedData.workspaceId, "Archive Task A", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Archive Task B", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await expect(kanban.taskCardByTitle("Archive Task A")).toBeVisible();
+    await expect(kanban.taskCardByTitle("Archive Task B")).toBeVisible();
+
+    await kanban.openLaneMenu(seedData.startStepId);
+    await kanban.laneMenuArchiveAll().click();
+    await kanban.laneConfirmArchive().click();
+
+    await expect(kanban.taskCardByTitle("Archive Task A")).not.toBeVisible();
+    await expect(kanban.taskCardByTitle("Archive Task B")).not.toBeVisible();
+  });
+
+  test("cancel archive keeps tasks in lane", async ({ testPage, apiClient, seedData }) => {
+    await apiClient.createTask(seedData.workspaceId, "Keep Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.openLaneMenu(seedData.startStepId);
+    await kanban.laneMenuArchiveAll().click();
+    await testPage.getByRole("button", { name: "Cancel" }).click();
+
+    await expect(kanban.taskCardByTitle("Keep Task")).toBeVisible();
+  });
+
+  test("clear lane deletes all tasks", async ({ testPage, apiClient, seedData }) => {
+    await apiClient.createTask(seedData.workspaceId, "Delete Task A", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Delete Task B", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.openLaneMenu(seedData.startStepId);
+    await kanban.laneMenuClear().click();
+    await kanban.laneConfirmClear().click();
+
+    await expect(kanban.taskCardByTitle("Delete Task A")).not.toBeVisible();
+    await expect(kanban.taskCardByTitle("Delete Task B")).not.toBeVisible();
+  });
+
+  test("cancel clear keeps tasks in lane", async ({ testPage, apiClient, seedData }) => {
+    await apiClient.createTask(seedData.workspaceId, "Survivor Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.openLaneMenu(seedData.startStepId);
+    await kanban.laneMenuClear().click();
+    await testPage.getByRole("button", { name: "Cancel" }).click();
+
+    await expect(kanban.taskCardByTitle("Survivor Task")).toBeVisible();
+  });
+
+  test("move all to another lane", async ({ testPage, apiClient, seedData }) => {
+    // Use Backlog (position 0) as the source — not the start step — so it's always a different step
+    const backlogStep = seedData.steps.find((s) => s.position === 0 && !s.is_start_step);
+    const targetStep = seedData.steps.find((s) => s.id !== backlogStep?.id);
+    if (!backlogStep || !targetStep) throw new Error("Not enough workflow steps for move test");
+
+    await apiClient.createTask(seedData.workspaceId, "Move Task A", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: backlogStep.id,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Move Task B", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: backlogStep.id,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await expect(kanban.taskCardInColumn("Move Task A", backlogStep.id)).toBeVisible();
+    await expect(kanban.taskCardInColumn("Move Task B", backlogStep.id)).toBeVisible();
+
+    await kanban.openLaneMenu(backlogStep.id);
+    await kanban.laneMenuMoveAll().hover();
+    await kanban.laneMenuMoveToStep(targetStep.id).click();
+
+    await expect(kanban.taskCardInColumn("Move Task A", targetStep.id)).toBeVisible();
+    await expect(kanban.taskCardInColumn("Move Task B", targetStep.id)).toBeVisible();
+    await expect(kanban.taskCardInColumn("Move Task A", backlogStep.id)).not.toBeVisible();
+    await expect(kanban.taskCardInColumn("Move Task B", backlogStep.id)).not.toBeVisible();
+  });
+});

--- a/apps/web/hooks/domains/kanban/use-kanban-actions.ts
+++ b/apps/web/hooks/domains/kanban/use-kanban-actions.ts
@@ -97,6 +97,9 @@ export function useKanbanActions({ workspaceState, workflowsState }: UseKanbanAc
     setEditingTask,
     deletingTaskId,
     archivingTaskId,
+    handleClearLane,
+    handleArchiveLane,
+    handleMoveLane,
   } = useTaskCRUD();
 
   // Handle task dialog success (create/update)
@@ -168,5 +171,10 @@ export function useKanbanActions({ workspaceState, workflowsState }: UseKanbanAc
     // Navigation actions
     handleWorkspaceChange,
     handleWorkflowChange,
+
+    // Lane actions
+    handleClearLane,
+    handleArchiveLane,
+    handleMoveLane,
   };
 }

--- a/apps/web/hooks/use-lane-task-actions.ts
+++ b/apps/web/hooks/use-lane-task-actions.ts
@@ -2,7 +2,6 @@
 
 import { useCallback } from "react";
 import type { StoreApi } from "zustand";
-import type { Task } from "@/components/kanban-card";
 import type { KanbanState } from "@/lib/state/slices";
 import type { AppState } from "@/lib/state/store";
 import type { useTaskActions } from "@/hooks/use-task-actions";
@@ -54,11 +53,14 @@ export function useLaneTaskActions({
   );
 
   const handleMoveLane = useCallback(
-    async (tasks: Task[], targetStepId: string) => {
+    async (tasks: KanbanState["tasks"][number][], targetStepId: string) => {
       if (!workflowId || tasks.length === 0) return;
 
+      const actionableTasks = tasks.filter((t) => t.workflowStepId !== targetStepId);
+      if (actionableTasks.length === 0) return;
+
       const currentTasks = store.getState().kanban.tasks;
-      const movedIds = new Set(tasks.map((t) => t.id));
+      const movedIds = new Set(actionableTasks.map((t) => t.id));
       const maxTargetPos = currentTasks
         .filter(
           (t: KanbanState["tasks"][number]) =>
@@ -70,7 +72,7 @@ export function useLaneTaskActions({
         );
 
       const results = await Promise.allSettled(
-        tasks.map((task, i) =>
+        actionableTasks.map((task, i) =>
           moveTaskById(task.id, {
             workflow_id: workflowId!,
             workflow_step_id: targetStepId,
@@ -80,7 +82,7 @@ export function useLaneTaskActions({
       );
 
       const succeededMoves = new Map(
-        tasks
+        actionableTasks
           .map((task, i) =>
             results[i].status === "fulfilled" ? ([task.id, maxTargetPos + 1 + i] as const) : null,
           )

--- a/apps/web/hooks/use-lane-task-actions.ts
+++ b/apps/web/hooks/use-lane-task-actions.ts
@@ -8,8 +8,16 @@ import type { useTaskActions } from "@/hooks/use-task-actions";
 
 type TaskActions = ReturnType<typeof useTaskActions>;
 
+// Max concurrent API requests per bulk operation. Avoids thundering-herd
+// against the backend when a lane has many tasks.
 const BULK_ACTION_BATCH_SIZE = 10;
 
+/**
+ * Runs `worker` over `items` in serial batches of BULK_ACTION_BATCH_SIZE,
+ * collecting settled results in the same order as the input array.
+ * Index passed to `worker` is the global index across all batches so callers
+ * can use it for stable position assignment.
+ */
 async function allSettledInBatches<T>(
   items: T[],
   worker: (item: T, index: number) => Promise<unknown>,
@@ -22,6 +30,11 @@ async function allSettledInBatches<T>(
   return results;
 }
 
+/**
+ * Runs `action` on each task in batches, then calls `applySuccess` with the
+ * set of IDs whose requests fulfilled. Partial failures are silently ignored —
+ * only successful task IDs are passed to the store update.
+ */
 async function performBulkAction(
   tasks: KanbanState["tasks"][number][],
   action: (id: string) => Promise<unknown>,
@@ -70,9 +83,12 @@ export function useLaneTaskActions({
     async (tasks: KanbanState["tasks"][number][], targetStepId: string) => {
       if (!workflowId || tasks.length === 0) return;
 
+      // Skip tasks already in the target step — moving them would be a no-op
+      // and would wastefully re-sequence their positions.
       const actionableTasks = tasks.filter((t) => t.workflowStepId !== targetStepId);
       if (actionableTasks.length === 0) return;
 
+      // Snapshot current tasks before any mutations so position math is stable.
       const currentTasks = store.getState().kanban.tasks;
       const movedIds = new Set(actionableTasks.map((t) => t.id));
       const maxTargetPos = currentTasks

--- a/apps/web/hooks/use-lane-task-actions.ts
+++ b/apps/web/hooks/use-lane-task-actions.ts
@@ -9,6 +9,18 @@ import type { useTaskActions } from "@/hooks/use-task-actions";
 
 type TaskActions = ReturnType<typeof useTaskActions>;
 
+async function performBulkAction(
+  tasks: KanbanState["tasks"][number][],
+  action: (id: string) => Promise<unknown>,
+  applySuccess: (succeededIds: Set<string>) => void,
+): Promise<void> {
+  const results = await Promise.allSettled(tasks.map((task) => action(task.id)));
+  const succeededIds = new Set(
+    tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
+  );
+  applySuccess(succeededIds);
+}
+
 export function useLaneTaskActions({
   workflowId,
   store,
@@ -23,21 +35,19 @@ export function useLaneTaskActions({
   moveTaskById: TaskActions["moveTaskById"];
 }) {
   const handleClearLane = useCallback(
-    async (tasks: Task[]) => {
+    async (tasks: KanbanState["tasks"][number][]) => {
       if (!workflowId || tasks.length === 0) return;
-
-      const results = await Promise.allSettled(tasks.map((task) => deleteTaskById(task.id)));
-
-      const deletedIds = new Set(
-        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
-      );
-      store.getState().hydrate({
-        kanban: {
-          ...store.getState().kanban,
-          tasks: store
-            .getState()
-            .kanban.tasks.filter((item: KanbanState["tasks"][number]) => !deletedIds.has(item.id)),
-        },
+      await performBulkAction(tasks, deleteTaskById, (deletedIds) => {
+        store.getState().hydrate({
+          kanban: {
+            ...store.getState().kanban,
+            tasks: store
+              .getState()
+              .kanban.tasks.filter(
+                (item: KanbanState["tasks"][number]) => !deletedIds.has(item.id),
+              ),
+          },
+        });
       });
     },
     [deleteTaskById, workflowId, store],
@@ -91,23 +101,19 @@ export function useLaneTaskActions({
   );
 
   const handleArchiveLane = useCallback(
-    async (tasks: Task[]) => {
+    async (tasks: KanbanState["tasks"][number][]) => {
       if (!workflowId || tasks.length === 0) return;
-
-      const results = await Promise.allSettled(tasks.map((task) => archiveTaskById(task.id)));
-
-      const archivedIds = new Set(
-        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
-      );
-      store.getState().hydrate({
-        kanban: {
-          ...store.getState().kanban,
-          tasks: store
-            .getState()
-            .kanban.tasks.filter(
-              (item: KanbanState["tasks"][number]) => !archivedIds.has(item.id),
-            ),
-        },
+      await performBulkAction(tasks, archiveTaskById, (archivedIds) => {
+        store.getState().hydrate({
+          kanban: {
+            ...store.getState().kanban,
+            tasks: store
+              .getState()
+              .kanban.tasks.filter(
+                (item: KanbanState["tasks"][number]) => !archivedIds.has(item.id),
+              ),
+          },
+        });
       });
     },
     [archiveTaskById, workflowId, store],

--- a/apps/web/hooks/use-lane-task-actions.ts
+++ b/apps/web/hooks/use-lane-task-actions.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useCallback } from "react";
+import type { StoreApi } from "zustand";
+import type { Task } from "@/components/kanban-card";
+import type { KanbanState } from "@/lib/state/slices";
+import type { AppState } from "@/lib/state/store";
+import type { useTaskActions } from "@/hooks/use-task-actions";
+
+type TaskActions = ReturnType<typeof useTaskActions>;
+
+export function useLaneTaskActions({
+  workflowId,
+  store,
+  deleteTaskById,
+  archiveTaskById,
+  moveTaskById,
+}: {
+  workflowId: string | null | undefined;
+  store: StoreApi<AppState>;
+  deleteTaskById: TaskActions["deleteTaskById"];
+  archiveTaskById: TaskActions["archiveTaskById"];
+  moveTaskById: TaskActions["moveTaskById"];
+}) {
+  const handleClearLane = useCallback(
+    async (tasks: Task[]) => {
+      if (!workflowId || tasks.length === 0) return;
+
+      const results = await Promise.allSettled(tasks.map((task) => deleteTaskById(task.id)));
+
+      const deletedIds = new Set(
+        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
+      );
+      store.getState().hydrate({
+        kanban: {
+          ...store.getState().kanban,
+          tasks: store
+            .getState()
+            .kanban.tasks.filter((item: KanbanState["tasks"][number]) => !deletedIds.has(item.id)),
+        },
+      });
+    },
+    [deleteTaskById, workflowId, store],
+  );
+
+  const handleMoveLane = useCallback(
+    async (tasks: Task[], targetStepId: string) => {
+      if (!workflowId || tasks.length === 0) return;
+
+      const currentTasks = store.getState().kanban.tasks;
+      const movedIds = new Set(tasks.map((t) => t.id));
+      const maxTargetPos = currentTasks
+        .filter(
+          (t: KanbanState["tasks"][number]) =>
+            t.workflowStepId === targetStepId && !movedIds.has(t.id),
+        )
+        .reduce(
+          (max: number, t: KanbanState["tasks"][number]) => Math.max(max, t.position ?? 0),
+          -1,
+        );
+
+      const results = await Promise.allSettled(
+        tasks.map((task, i) =>
+          moveTaskById(task.id, {
+            workflow_id: workflowId!,
+            workflow_step_id: targetStepId,
+            position: maxTargetPos + 1 + i,
+          }),
+        ),
+      );
+
+      const succeededMoves = new Map(
+        tasks
+          .map((task, i) =>
+            results[i].status === "fulfilled" ? ([task.id, maxTargetPos + 1 + i] as const) : null,
+          )
+          .filter((entry): entry is [string, number] => entry !== null),
+      );
+      store.getState().hydrate({
+        kanban: {
+          ...store.getState().kanban,
+          tasks: store.getState().kanban.tasks.map((t: KanbanState["tasks"][number]) => {
+            const newPos = succeededMoves.get(t.id);
+            if (newPos === undefined) return t;
+            return { ...t, workflowStepId: targetStepId, position: newPos };
+          }),
+        },
+      });
+    },
+    [moveTaskById, workflowId, store],
+  );
+
+  const handleArchiveLane = useCallback(
+    async (tasks: Task[]) => {
+      if (!workflowId || tasks.length === 0) return;
+
+      const results = await Promise.allSettled(tasks.map((task) => archiveTaskById(task.id)));
+
+      const archivedIds = new Set(
+        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
+      );
+      store.getState().hydrate({
+        kanban: {
+          ...store.getState().kanban,
+          tasks: store
+            .getState()
+            .kanban.tasks.filter(
+              (item: KanbanState["tasks"][number]) => !archivedIds.has(item.id),
+            ),
+        },
+      });
+    },
+    [archiveTaskById, workflowId, store],
+  );
+
+  return { handleClearLane, handleMoveLane, handleArchiveLane };
+}

--- a/apps/web/hooks/use-lane-task-actions.ts
+++ b/apps/web/hooks/use-lane-task-actions.ts
@@ -8,12 +8,26 @@ import type { useTaskActions } from "@/hooks/use-task-actions";
 
 type TaskActions = ReturnType<typeof useTaskActions>;
 
+const BULK_ACTION_BATCH_SIZE = 10;
+
+async function allSettledInBatches<T>(
+  items: T[],
+  worker: (item: T, index: number) => Promise<unknown>,
+): Promise<PromiseSettledResult<unknown>[]> {
+  const results: PromiseSettledResult<unknown>[] = [];
+  for (let i = 0; i < items.length; i += BULK_ACTION_BATCH_SIZE) {
+    const batch = items.slice(i, i + BULK_ACTION_BATCH_SIZE);
+    results.push(...(await Promise.allSettled(batch.map((item, offset) => worker(item, i + offset)))));
+  }
+  return results;
+}
+
 async function performBulkAction(
   tasks: KanbanState["tasks"][number][],
   action: (id: string) => Promise<unknown>,
   applySuccess: (succeededIds: Set<string>) => void,
 ): Promise<void> {
-  const results = await Promise.allSettled(tasks.map((task) => action(task.id)));
+  const results = await allSettledInBatches(tasks, (task) => action(task.id));
   const succeededIds = new Set(
     tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
   );
@@ -71,14 +85,12 @@ export function useLaneTaskActions({
           -1,
         );
 
-      const results = await Promise.allSettled(
-        actionableTasks.map((task, i) =>
-          moveTaskById(task.id, {
-            workflow_id: workflowId!,
-            workflow_step_id: targetStepId,
-            position: maxTargetPos + 1 + i,
-          }),
-        ),
+      const results = await allSettledInBatches(actionableTasks, (task, i) =>
+        moveTaskById(task.id, {
+          workflow_id: workflowId!,
+          workflow_step_id: targetStepId,
+          position: maxTargetPos + 1 + i,
+        }),
       );
 
       const succeededMoves = new Map(

--- a/apps/web/hooks/use-task-crud.ts
+++ b/apps/web/hooks/use-task-crud.ts
@@ -90,9 +90,11 @@ export function useTaskCRUD() {
     async (tasks: Task[]) => {
       if (!kanban.workflowId || tasks.length === 0) return;
 
-      await Promise.all(tasks.map((task) => deleteTaskById(task.id)));
+      const results = await Promise.allSettled(tasks.map((task) => deleteTaskById(task.id)));
 
-      const deletedIds = new Set(tasks.map((t) => t.id));
+      const deletedIds = new Set(
+        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
+      );
       store.getState().hydrate({
         kanban: {
           ...store.getState().kanban,
@@ -121,7 +123,7 @@ export function useTaskCRUD() {
           -1,
         );
 
-      await Promise.all(
+      const results = await Promise.allSettled(
         tasks.map((task, i) =>
           moveTaskById(task.id, {
             workflow_id: kanban.workflowId!,
@@ -131,13 +133,18 @@ export function useTaskCRUD() {
         ),
       );
 
+      const succeededMoves = new Map(
+        tasks
+          .filter((_, i) => results[i].status === "fulfilled")
+          .map((task, idx) => [task.id, maxTargetPos + 1 + idx]),
+      );
       store.getState().hydrate({
         kanban: {
           ...store.getState().kanban,
           tasks: store.getState().kanban.tasks.map((t: KanbanState["tasks"][number]) => {
-            if (!movedIds.has(t.id)) return t;
-            const idx = tasks.findIndex((m) => m.id === t.id);
-            return { ...t, workflowStepId: targetStepId, position: maxTargetPos + 1 + idx };
+            const newPos = succeededMoves.get(t.id);
+            if (newPos === undefined) return t;
+            return { ...t, workflowStepId: targetStepId, position: newPos };
           }),
         },
       });
@@ -149,9 +156,11 @@ export function useTaskCRUD() {
     async (tasks: Task[]) => {
       if (!kanban.workflowId || tasks.length === 0) return;
 
-      await Promise.all(tasks.map((task) => archiveTaskById(task.id)));
+      const results = await Promise.allSettled(tasks.map((task) => archiveTaskById(task.id)));
 
-      const archivedIds = new Set(tasks.map((t) => t.id));
+      const archivedIds = new Set(
+        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
+      );
       store.getState().hydrate({
         kanban: {
           ...store.getState().kanban,

--- a/apps/web/hooks/use-task-crud.ts
+++ b/apps/web/hooks/use-task-crud.ts
@@ -135,8 +135,8 @@ export function useTaskCRUD() {
 
       const succeededMoves = new Map(
         tasks
-          .filter((_, i) => results[i].status === "fulfilled")
-          .map((task, idx) => [task.id, maxTargetPos + 1 + idx]),
+          .map((task, i) => (results[i].status === "fulfilled" ? [task.id, maxTargetPos + 1 + i] as const : null))
+          .filter((entry): entry is [string, number] => entry !== null),
       );
       store.getState().hydrate({
         kanban: {

--- a/apps/web/hooks/use-task-crud.ts
+++ b/apps/web/hooks/use-task-crud.ts
@@ -3,6 +3,7 @@
 import { useCallback, useState } from "react";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useTaskActions } from "@/hooks/use-task-actions";
+import { useLaneTaskActions } from "@/hooks/use-lane-task-actions";
 import type { Task } from "@/components/kanban-card";
 import type { KanbanState } from "@/lib/state/slices";
 
@@ -86,92 +87,13 @@ export function useTaskCRUD() {
     }
   }, []);
 
-  const handleClearLane = useCallback(
-    async (tasks: Task[]) => {
-      if (!kanban.workflowId || tasks.length === 0) return;
-
-      const results = await Promise.allSettled(tasks.map((task) => deleteTaskById(task.id)));
-
-      const deletedIds = new Set(
-        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
-      );
-      store.getState().hydrate({
-        kanban: {
-          ...store.getState().kanban,
-          tasks: store
-            .getState()
-            .kanban.tasks.filter((item: KanbanState["tasks"][number]) => !deletedIds.has(item.id)),
-        },
-      });
-    },
-    [deleteTaskById, kanban.workflowId, store],
-  );
-
-  const handleMoveLane = useCallback(
-    async (tasks: Task[], targetStepId: string) => {
-      if (!kanban.workflowId || tasks.length === 0) return;
-
-      const currentTasks = store.getState().kanban.tasks;
-      const movedIds = new Set(tasks.map((t) => t.id));
-      const maxTargetPos = currentTasks
-        .filter(
-          (t: KanbanState["tasks"][number]) =>
-            t.workflowStepId === targetStepId && !movedIds.has(t.id),
-        )
-        .reduce(
-          (max: number, t: KanbanState["tasks"][number]) => Math.max(max, t.position ?? 0),
-          -1,
-        );
-
-      const results = await Promise.allSettled(
-        tasks.map((task, i) =>
-          moveTaskById(task.id, {
-            workflow_id: kanban.workflowId!,
-            workflow_step_id: targetStepId,
-            position: maxTargetPos + 1 + i,
-          }),
-        ),
-      );
-
-      const succeededMoves = new Map(
-        tasks
-          .map((task, i) => (results[i].status === "fulfilled" ? [task.id, maxTargetPos + 1 + i] as const : null))
-          .filter((entry): entry is [string, number] => entry !== null),
-      );
-      store.getState().hydrate({
-        kanban: {
-          ...store.getState().kanban,
-          tasks: store.getState().kanban.tasks.map((t: KanbanState["tasks"][number]) => {
-            const newPos = succeededMoves.get(t.id);
-            if (newPos === undefined) return t;
-            return { ...t, workflowStepId: targetStepId, position: newPos };
-          }),
-        },
-      });
-    },
-    [moveTaskById, kanban.workflowId, store],
-  );
-
-  const handleArchiveLane = useCallback(
-    async (tasks: Task[]) => {
-      if (!kanban.workflowId || tasks.length === 0) return;
-
-      const results = await Promise.allSettled(tasks.map((task) => archiveTaskById(task.id)));
-
-      const archivedIds = new Set(
-        tasks.filter((_, i) => results[i].status === "fulfilled").map((t) => t.id),
-      );
-      store.getState().hydrate({
-        kanban: {
-          ...store.getState().kanban,
-          tasks: store
-            .getState()
-            .kanban.tasks.filter((item: KanbanState["tasks"][number]) => !archivedIds.has(item.id)),
-        },
-      });
-    },
-    [archiveTaskById, kanban.workflowId, store],
-  );
+  const { handleClearLane, handleMoveLane, handleArchiveLane } = useLaneTaskActions({
+    workflowId: kanban.workflowId,
+    store,
+    deleteTaskById,
+    archiveTaskById,
+    moveTaskById,
+  });
 
   return {
     isDialogOpen,

--- a/apps/web/hooks/use-task-crud.ts
+++ b/apps/web/hooks/use-task-crud.ts
@@ -17,7 +17,7 @@ export function useTaskCRUD() {
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
   const [archivingTaskId, setArchivingTaskId] = useState<string | null>(null);
-  const { deleteTaskById, archiveTaskById } = useTaskActions();
+  const { deleteTaskById, archiveTaskById, moveTaskById } = useTaskActions();
   const kanban = useAppStore((state) => state.kanban);
   const store = useAppStoreApi();
 
@@ -86,6 +86,84 @@ export function useTaskCRUD() {
     }
   }, []);
 
+  const handleClearLane = useCallback(
+    async (tasks: Task[]) => {
+      if (!kanban.workflowId || tasks.length === 0) return;
+
+      await Promise.all(tasks.map((task) => deleteTaskById(task.id)));
+
+      const deletedIds = new Set(tasks.map((t) => t.id));
+      store.getState().hydrate({
+        kanban: {
+          ...store.getState().kanban,
+          tasks: store
+            .getState()
+            .kanban.tasks.filter((item: KanbanState["tasks"][number]) => !deletedIds.has(item.id)),
+        },
+      });
+    },
+    [deleteTaskById, kanban.workflowId, store],
+  );
+
+  const handleMoveLane = useCallback(
+    async (tasks: Task[], targetStepId: string) => {
+      if (!kanban.workflowId || tasks.length === 0) return;
+
+      const currentTasks = store.getState().kanban.tasks;
+      const movedIds = new Set(tasks.map((t) => t.id));
+      const maxTargetPos = currentTasks
+        .filter(
+          (t: KanbanState["tasks"][number]) =>
+            t.workflowStepId === targetStepId && !movedIds.has(t.id),
+        )
+        .reduce(
+          (max: number, t: KanbanState["tasks"][number]) => Math.max(max, t.position ?? 0),
+          -1,
+        );
+
+      await Promise.all(
+        tasks.map((task, i) =>
+          moveTaskById(task.id, {
+            workflow_id: kanban.workflowId!,
+            workflow_step_id: targetStepId,
+            position: maxTargetPos + 1 + i,
+          }),
+        ),
+      );
+
+      store.getState().hydrate({
+        kanban: {
+          ...store.getState().kanban,
+          tasks: store.getState().kanban.tasks.map((t: KanbanState["tasks"][number]) => {
+            if (!movedIds.has(t.id)) return t;
+            const idx = tasks.findIndex((m) => m.id === t.id);
+            return { ...t, workflowStepId: targetStepId, position: maxTargetPos + 1 + idx };
+          }),
+        },
+      });
+    },
+    [moveTaskById, kanban.workflowId, store],
+  );
+
+  const handleArchiveLane = useCallback(
+    async (tasks: Task[]) => {
+      if (!kanban.workflowId || tasks.length === 0) return;
+
+      await Promise.all(tasks.map((task) => archiveTaskById(task.id)));
+
+      const archivedIds = new Set(tasks.map((t) => t.id));
+      store.getState().hydrate({
+        kanban: {
+          ...store.getState().kanban,
+          tasks: store
+            .getState()
+            .kanban.tasks.filter((item: KanbanState["tasks"][number]) => !archivedIds.has(item.id)),
+        },
+      });
+    },
+    [archiveTaskById, kanban.workflowId, store],
+  );
+
   return {
     isDialogOpen,
     setIsDialogOpen,
@@ -98,5 +176,8 @@ export function useTaskCRUD() {
     handleDialogOpenChange,
     deletingTaskId,
     archivingTaskId,
+    handleClearLane,
+    handleArchiveLane,
+    handleMoveLane,
   };
 }

--- a/apps/web/lib/kanban/view-registry.ts
+++ b/apps/web/lib/kanban/view-registry.ts
@@ -19,6 +19,9 @@ export type ViewContentProps = {
   deletingTaskId?: string | null;
   archivingTaskId?: string | null;
   showMaximizeButton?: boolean;
+  onClearLane?: (tasks: Task[]) => Promise<void>;
+  onArchiveLane?: (tasks: Task[]) => Promise<void>;
+  onMoveLane?: (tasks: Task[], targetStepId: string) => Promise<void>;
 };
 
 export type ViewRegistryEntry = {


### PR DESCRIPTION
<!--
AGENT INSTRUCTIONS — read this before filling in the template below.

Generate each section using the rules below. Remove a section entirely if it adds no value for the size of the change. Remove all agent instruction comments from the final output.

SUMMARY (required)
  1–2 sentences max. Do not include a "Summary" heading — write directly as prose.
  Lead with the problem or goal, end with the outcome.
  Say WHY, not what. No filler phrases ("This PR...", "In order to...", "As part of...").

IMPORTANT CHANGES (optional)
  Include only for significant architectural changes. Skip for small or straightforward changes.
  Very short bullet list. Each bullet says WHAT changed and why (very short).

VALIDATION (required)
  How this was tested or verified. List commands or checks run (e.g. `go test ./...`, `make lint`).

DIAGRAM (optional)
  Include a Mermaid diagram only when it genuinely helps the reader understand a non-obvious flow,
  architecture change, or component relationship. Skip if the change is self-explanatory.

POSSIBLE IMPROVEMENTS (optional)
  One line: risk level + what could go wrong or be improved. Skip if negligible.

RELATED ISSUES
  Use "Closes #N" if this resolves an issue. Remove the line if there is no related issue.

RULES
  - Do not add "🤖 Generated with..." or any tool attribution footer.
  - Do not leave placeholder text or unfilled sections in the output.
  - Render the final PR body without any of these instruction comments.
  - Always keep the Checklist section as-is; do not remove or pre-fill its items.
-->

<!-- Summary: replace this comment with 1–2 sentences of prose, no heading -->

## Summary
Often, the list of tasks on the board becomes too large.
This change helps keep our board cleaner by allowing us to manage an entire lane.

## Important Changes

<!-- Optional: bullet list of significant architectural changes. Remove section if not needed. -->
This change adds a menu to each column header (visible on hover, stays visible while open) with three bulk actions:
• Move all to → — moves all cards in the lane to another step
• Archive all — archives all cards, with confirmation dialog
• Clear lane — deletes all cards, with confirmation dialog and destructive styling

## Validation

<!-- List commands run or manual steps taken to verify the change. -->
<img width="2890" height="1117" alt="image" src="https://github.com/user-attachments/assets/72b12137-d9de-4b28-af80-e69e92b7c6e9" />


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
