### PR TITLE
fix(web): recalculate dockview layout after fast-path session switch

### DIFF
--- a/apps/web/lib/state/dockview-session-switch.test.ts
+++ b/apps/web/lib/state/dockview-session-switch.test.ts
@@ -43,14 +43,11 @@ function makeParams(overrides?: Partial<SessionSwitchParams>): SessionSwitchPara
 
 describe("performSessionSwitch", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-    vi.mocked(getSessionLayout).mockReturnValue(null);
-    vi.mocked(savedLayoutMatchesLive).mockReturnValue(false);
-    vi.mocked(layoutStructuresMatch).mockReturnValue(false);
+    vi.clearAllMocks();
   });
 
   it("calls api.layout on the fast path when structures match", () => {
-    vi.mocked(layoutStructuresMatch).mockReturnValue(true);
+    vi.mocked(layoutStructuresMatch).mockReturnValueOnce(true);
     const params = makeParams();
 
     performSessionSwitch(params);
@@ -59,8 +56,10 @@ describe("performSessionSwitch", () => {
   });
 
   it("calls api.layout on the fast path when saved layout matches", () => {
-    vi.mocked(getSessionLayout).mockReturnValue({ grid: {} } as unknown as ReturnType<typeof getSessionLayout>);
-    vi.mocked(savedLayoutMatchesLive).mockReturnValue(true);
+    vi.mocked(getSessionLayout).mockReturnValueOnce({ grid: {} } as unknown as ReturnType<
+      typeof getSessionLayout
+    >);
+    vi.mocked(savedLayoutMatchesLive).mockReturnValueOnce(true);
     const params = makeParams();
 
     performSessionSwitch(params);
@@ -70,7 +69,6 @@ describe("performSessionSwitch", () => {
   });
 
   it("calls api.layout on the slow path (buildDefault fallback)", () => {
-    vi.mocked(layoutStructuresMatch).mockReturnValue(false);
     const params = makeParams();
 
     performSessionSwitch(params);

--- a/apps/web/lib/state/dockview-session-switch.test.ts
+++ b/apps/web/lib/state/dockview-session-switch.test.ts
@@ -16,7 +16,8 @@ vi.mock("./layout-manager", () => ({
   layoutStructuresMatch: vi.fn(() => false),
 }));
 
-import { layoutStructuresMatch } from "./layout-manager";
+import { getSessionLayout } from "@/lib/local-storage";
+import { layoutStructuresMatch, savedLayoutMatchesLive } from "./layout-manager";
 
 function makeMockApi() {
   return {
@@ -42,7 +43,10 @@ function makeParams(overrides?: Partial<SessionSwitchParams>): SessionSwitchPara
 
 describe("performSessionSwitch", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.mocked(getSessionLayout).mockReturnValue(null);
+    vi.mocked(savedLayoutMatchesLive).mockReturnValue(false);
+    vi.mocked(layoutStructuresMatch).mockReturnValue(false);
   });
 
   it("calls api.layout on the fast path when structures match", () => {
@@ -52,6 +56,17 @@ describe("performSessionSwitch", () => {
     performSessionSwitch(params);
 
     expect(params.api.layout).toHaveBeenCalledWith(800, 600);
+  });
+
+  it("calls api.layout on the fast path when saved layout matches", () => {
+    vi.mocked(getSessionLayout).mockReturnValue({ grid: {} } as any);
+    vi.mocked(savedLayoutMatchesLive).mockReturnValue(true);
+    const params = makeParams();
+
+    performSessionSwitch(params);
+
+    expect(params.api.layout).toHaveBeenCalledWith(800, 600);
+    expect(params.api.fromJSON).not.toHaveBeenCalled();
   });
 
   it("calls api.layout on the slow path (buildDefault fallback)", () => {

--- a/apps/web/lib/state/dockview-session-switch.test.ts
+++ b/apps/web/lib/state/dockview-session-switch.test.ts
@@ -7,7 +7,12 @@ vi.mock("@/lib/local-storage", () => ({
 }));
 
 vi.mock("./dockview-layout-builders", () => ({
-  applyLayoutFixups: vi.fn(() => ({ sidebar: "g1", center: "g2" })),
+  applyLayoutFixups: vi.fn(() => ({
+    sidebarGroupId: "g1",
+    centerGroupId: "g2",
+    rightTopGroupId: "g3",
+    rightBottomGroupId: "g4",
+  })),
 }));
 
 vi.mock("./layout-manager", () => ({

--- a/apps/web/lib/state/dockview-session-switch.test.ts
+++ b/apps/web/lib/state/dockview-session-switch.test.ts
@@ -59,7 +59,7 @@ describe("performSessionSwitch", () => {
   });
 
   it("calls api.layout on the fast path when saved layout matches", () => {
-    vi.mocked(getSessionLayout).mockReturnValue({ grid: {} } as any);
+    vi.mocked(getSessionLayout).mockReturnValue({ grid: {} } as unknown as ReturnType<typeof getSessionLayout>);
     vi.mocked(savedLayoutMatchesLive).mockReturnValue(true);
     const params = makeParams();
 

--- a/apps/web/lib/state/dockview-session-switch.test.ts
+++ b/apps/web/lib/state/dockview-session-switch.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { performSessionSwitch, type SessionSwitchParams } from "./dockview-session-switch";
+
+// Mock dependencies
+vi.mock("@/lib/local-storage", () => ({
+  getSessionLayout: vi.fn(() => null),
+}));
+
+vi.mock("./dockview-layout-builders", () => ({
+  applyLayoutFixups: vi.fn(() => ({ sidebar: "g1", center: "g2" })),
+}));
+
+vi.mock("./layout-manager", () => ({
+  fromDockviewApi: vi.fn(() => ({ columns: [] })),
+  savedLayoutMatchesLive: vi.fn(() => false),
+  layoutStructuresMatch: vi.fn(() => false),
+}));
+
+import { layoutStructuresMatch } from "./layout-manager";
+
+function makeMockApi() {
+  return {
+    panels: [],
+    layout: vi.fn(),
+    fromJSON: vi.fn(),
+    getPanel: vi.fn(),
+  } as unknown as SessionSwitchParams["api"];
+}
+
+function makeParams(overrides?: Partial<SessionSwitchParams>): SessionSwitchParams {
+  return {
+    api: makeMockApi(),
+    oldSessionId: "old-session",
+    newSessionId: "new-session",
+    safeWidth: 800,
+    safeHeight: 600,
+    buildDefault: vi.fn(),
+    getDefaultLayout: vi.fn(() => ({ columns: [] })),
+    ...overrides,
+  };
+}
+
+describe("performSessionSwitch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls api.layout on the fast path when structures match", () => {
+    vi.mocked(layoutStructuresMatch).mockReturnValue(true);
+    const params = makeParams();
+
+    performSessionSwitch(params);
+
+    expect(params.api.layout).toHaveBeenCalledWith(800, 600);
+  });
+
+  it("calls api.layout on the slow path (buildDefault fallback)", () => {
+    vi.mocked(layoutStructuresMatch).mockReturnValue(false);
+    const params = makeParams();
+
+    performSessionSwitch(params);
+
+    expect(params.api.layout).toHaveBeenCalledWith(800, 600);
+    expect(params.buildDefault).toHaveBeenCalledWith(params.api);
+  });
+});

--- a/apps/web/lib/state/dockview-session-switch.ts
+++ b/apps/web/lib/state/dockview-session-switch.ts
@@ -83,6 +83,7 @@ function tryFastSessionSwitch(params: SessionSwitchParams): LayoutGroupIds | nul
   // Session-scoped portals (terminal, browser, etc.) will be re-acquired
   // via usePortalSlot's sessionId dependency change.
   removeEphemeralPanels(api, newSessionId);
+  api.layout(params.safeWidth, params.safeHeight);
   return applyLayoutFixups(api);
 }
 


### PR DESCRIPTION
## Summary
- Switching tasks via the sidebar sometimes squished all panels to the left half of the screen, leaving the right side empty.
- The fast path in `tryFastSessionSwitch` removed ephemeral panels but skipped `api.layout()`, so Dockview never redistributed column widths. Both slow-path branches already made this call.
- Added the missing `api.layout(safeWidth, safeHeight)` call after panel removal.

## Test plan
- [ ] Switch between tasks rapidly via the left sidebar — layout should fill the full width every time
- [ ] Verify panels resize correctly when the fast path is taken (structurally identical layouts)
- [ ] Confirm slow-path switches (different layout structures) still work as before