### PR TITLE
fix(agents): detect GitHub Copilot on Linux

### DIFF
--- a/apps/backend/internal/agent/agents/copilot.go
+++ b/apps/backend/internal/agent/agents/copilot.go
@@ -62,14 +62,15 @@ func (a *Copilot) Logo(v LogoVariant) []byte {
 
 func (a *Copilot) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
 	install := OSPaths{
-		MacOS: []string{"~/.copilot/pkg"},
+		Linux: []string{"~/.copilot/config.json"},
+		MacOS: []string{"~/.copilot/config.json", "~/.copilot/pkg"},
 	}
 	mcp := OSPaths{
 		Linux: []string{"~/.copilot/mcp-config.json"},
 		MacOS: []string{"~/.copilot/mcp-config.json"},
 	}
 
-	result, err := Detect(ctx, WithFileExists(install.Resolve()...))
+	result, err := Detect(ctx, WithFileExists(install.Resolve()...), WithCommand("copilot"))
 	if err != nil {
 		return result, err
 	}

--- a/apps/backend/internal/agent/agents/copilot_acp.go
+++ b/apps/backend/internal/agent/agents/copilot_acp.go
@@ -66,14 +66,15 @@ func (a *CopilotACP) Logo(v LogoVariant) []byte {
 
 func (a *CopilotACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
 	install := OSPaths{
-		MacOS: []string{"~/.copilot/pkg"},
+		Linux: []string{"~/.copilot/config.json"},
+		MacOS: []string{"~/.copilot/config.json", "~/.copilot/pkg"},
 	}
 	mcp := OSPaths{
 		Linux: []string{"~/.copilot/mcp-config.json"},
 		MacOS: []string{"~/.copilot/mcp-config.json"},
 	}
 
-	result, err := Detect(ctx, WithFileExists(install.Resolve()...))
+	result, err := Detect(ctx, WithFileExists(install.Resolve()...), WithCommand("copilot"))
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
Copilot was never detected on Linux because `IsInstalled` only checked `~/.copilot/pkg`, which is a macOS-only path. Users with Copilot installed and authenticated on Linux always saw the agent as unavailable.

## Validation

Tested locally on Linux with `@github/copilot` installed via nvm — agent now shows as detected.

```
go test ./internal/agent/agents/...  # ok
go test ./internal/agent/discovery/... # ok
```

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.