### PR TITLE
fix(web): add bottom margin to settings layout

### DIFF
--- a/apps/web/components/settings/settings-layout-client.tsx
+++ b/apps/web/components/settings/settings-layout-client.tsx
@@ -33,7 +33,7 @@ export function SettingsLayoutClient({ children }: { children: React.ReactNode }
               </Breadcrumb>
             </div>
           </header>
-          <div className="flex flex-1 flex-col gap-4 p-4 pt-0">{children}</div>
+          <div className="flex flex-1 flex-col gap-4 p-4 pt-0 mb-20">{children}</div>
         </SidebarInset>
       </SidebarProvider>
     </TooltipProvider>


### PR DESCRIPTION
## Summary

The Settings layout does not offer enough margin (either on the bottom or sides) to prevent the ConfigChatPanel trigger from overlapping some controls when at the bottom of the page.
This PR adds an extra margin at the bottom to prevent this.

Resolves #580 

## Screenshots

| Before: | After: |
|--------|--------|
| <img width="594" height="313" alt="image" src="https://github.com/user-attachments/assets/7db9fe85-2e47-45ba-9eb9-99943d07a48d" /> | <img width="580" height="324" alt="image" src="https://github.com/user-attachments/assets/b4defd86-371a-42ac-ac0a-20458161a124" /> |


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] ~~My changes have tests that cover the new functionality and edge cases.~~
