### PR TITLE
fix(web): stop vertical scroll on mobile column tabs

### DIFF
--- a/apps/web/components/kanban/mobile-column-tabs.tsx
+++ b/apps/web/components/kanban/mobile-column-tabs.tsx
@@ -43,7 +43,7 @@ export function MobileColumnTabs({
   return (
     <div
       ref={tabsRef}
-      className="flex overflow-x-auto scrollbar-hide border-b border-border px-4 gap-1"
+      className="flex overflow-x-auto overflow-y-hidden scrollbar-hide border-b border-border px-4 gap-1"
     >
       {steps.map((step, index) => (
         <button


### PR DESCRIPTION
On mobile, the column tabs allow for a vertical scroll when there's only a horizontal scroll.
This PR prevents the vertical scroll from happening.

## Screenshots

(Scrolling down so that the effect is visible)

| Before: | After: |
|--------|-------|
|<img width="781" height="315" alt="image" src="https://github.com/user-attachments/assets/f9832d2d-2cc0-4f1a-9b15-8eb7910451b5" /> | <img width="781" height="315" alt="image" src="https://github.com/user-attachments/assets/de50b0d2-b8f0-40f8-a8b3-1895744da6a8" /> |


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
