### PR TITLE
fix(docs): correct GitHub org URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You must understand the code you submit. You're welcome to use AI tools to help 
 
 ## Bug Reports
 
-Search [existing issues](https://github.com/cflynn7/kandev/issues) first. If your bug isn't already reported, open one with:
+Search [existing issues](https://github.com/kdlbs/kandev/issues) first. If your bug isn't already reported, open one with:
 
 - Steps to reproduce
 - Expected vs actual behavior


### PR DESCRIPTION
## Summary
- Fixed incorrect GitHub org in CONTRIBUTING.md issues link (`cflynn7` → `kdlbs`)

## Test plan
- [x] Verified the corrected URL matches the canonical repo (`github.com/kdlbs/kandev`)
- [x] No other broken links in the file