### PR TITLE
fix(backend): always enable cgo on build

### DIFF
--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -40,7 +40,7 @@ build-mock-agent:
 build: build-agentctl build-mock-agent
 	@echo "Building $(BINARY_NAME)..."
 	@$(MKDIR) $(BUILD_DIR)
-	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/kandev
+	CGO_ENABLED=1 $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/kandev
 
 ## Build all binaries (unified + individual services + agentctl)
 build-all: build build-agentctl
@@ -84,7 +84,7 @@ start-debug: build
 ## Run tests
 test:
 	@echo "Running tests..."
-	$(GO) test ./...
+	CGO_ENABLED=1 $(GO) test ./...
 
 ## Run E2E tests (real agents, costs money — manual only)
 ## Set agent commands via env vars: E2E_CLAUDE_CODE_COMMAND, E2E_AMP_COMMAND

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -103,7 +103,7 @@ test-sprites-e2e: build-agentctl-linux
 ## Run tests with coverage
 test-coverage:
 	@echo "Running tests with coverage..."
-	$(GO) test -v -coverprofile=coverage.out ./...
+	CGO_ENABLED=1 $(GO) test -v -coverprofile=coverage.out ./...
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
 ## Run linter (requires golangci-lint)
@@ -135,10 +135,10 @@ deps:
 build-cross:
 	@echo "Building for multiple platforms..."
 	@$(MKDIR) $(BUILD_DIR)
-	GOOS=linux GOARCH=amd64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/kandev
-	GOOS=darwin GOARCH=amd64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 ./cmd/kandev
-	GOOS=darwin GOARCH=arm64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 ./cmd/kandev
-	GOOS=windows GOARCH=amd64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./cmd/kandev
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 ./cmd/kandev
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 ./cmd/kandev
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 ./cmd/kandev
+	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 $(GO) build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe ./cmd/kandev
 
 ## Show help
 help:


### PR DESCRIPTION
If the backend is built without `cgo`, the repositories will always fail to initialize, as `go-sqlite3` requires `cgo` to work.
Thus, this PR directly sets the `CGO_ENABLED=1` flag on the backend build. Additionally, it also sets `CGO_ENABLED=1` on `make test`, given that it also depends on `cgo` for `go-sqlite3` to work properly.

Resolves #585

## Validation

Ran `make dev` and `make build` on apps/backend. Everything works properly after setting the flag.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
