### PR TITLE
fix(agentctl): prevent OOM from large untracked files in workspace tracker

### DIFF
--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -189,7 +188,10 @@ func (wt *WorkspaceTracker) enrichUntrackedFileDiffs(_ context.Context, update *
 			continue
 		}
 
-		absPath := filepath.Join(wt.workDir, filePath)
+		absPath, err := wt.sanitizePath(filePath)
+		if err != nil {
+			continue
+		}
 
 		// Check file size before reading.
 		info, err := os.Stat(absPath)
@@ -224,6 +226,11 @@ func (wt *WorkspaceTracker) enrichUntrackedFileDiffs(_ context.Context, update *
 		}
 
 		lines := strings.Split(string(content), "\n")
+		// Trim trailing empty element from newline-terminated files
+		// (e.g. "a\nb\n" splits to ["a","b",""] — the empty tail is not a real line).
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
 		fileInfo.Additions = len(lines)
 		fileInfo.Deletions = 0
 

--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
@@ -1,13 +1,27 @@
 package process
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/kandev/kandev/internal/agentctl/types"
 	"go.uber.org/zap"
+)
+
+const (
+	// maxUntrackedFileSize is the maximum size of an untracked file to read for
+	// diff generation. Files larger than this are skipped to prevent excessive
+	// memory usage (the workspace tracker polls every few seconds).
+	maxUntrackedFileSize = 10 << 20 // 10 MB
+
+	// binaryDetectBytes is the number of bytes read from the beginning of a file
+	// to detect whether it is binary (contains null bytes).
+	binaryDetectBytes = 8192
 )
 
 // enrichWithDiffData adds diff information (additions, deletions, diff content) to file info
@@ -165,25 +179,59 @@ func (wt *WorkspaceTracker) enrichWithStagedDiff(ctx context.Context, update *ty
 
 // enrichUntrackedFileDiffs builds a synthetic git diff for untracked files showing all
 // lines as additions, so the diff viewer can display their full content.
-func (wt *WorkspaceTracker) enrichUntrackedFileDiffs(ctx context.Context, update *types.GitStatusUpdate) {
+//
+// Safety guards to prevent OOM (the workspace tracker polls every few seconds):
+//   - Files larger than maxUntrackedFileSize are skipped.
+//   - Binary files (containing null bytes) are skipped.
+func (wt *WorkspaceTracker) enrichUntrackedFileDiffs(_ context.Context, update *types.GitStatusUpdate) {
 	for filePath, fileInfo := range update.Files {
 		if fileInfo.Status != fileStatusUntracked {
 			continue
 		}
-		catCmd := exec.CommandContext(ctx, "cat", filePath)
-		catCmd.Dir = wt.workDir
-		catOut, err := catCmd.Output()
+
+		absPath := filepath.Join(wt.workDir, filePath)
+
+		// Check file size before reading.
+		info, err := os.Stat(absPath)
 		if err != nil {
 			continue
 		}
-		content := string(catOut)
-		lines := strings.Split(content, "\n")
+		if info.Size() > maxUntrackedFileSize {
+			wt.logger.Debug("skipping large untracked file for diff",
+				zap.String("path", filePath),
+				zap.Int64("size_bytes", info.Size()))
+			fileInfo.DiffSkipReason = "too_large"
+			update.Files[filePath] = fileInfo
+			continue
+		}
+
+		content, err := os.ReadFile(absPath)
+		if err != nil {
+			continue
+		}
+
+		// Skip binary files (contain null bytes in the first few KB).
+		detectLen := len(content)
+		if detectLen > binaryDetectBytes {
+			detectLen = binaryDetectBytes
+		}
+		if bytes.ContainsRune(content[:detectLen], 0) {
+			wt.logger.Debug("skipping binary untracked file for diff",
+				zap.String("path", filePath))
+			fileInfo.DiffSkipReason = "binary"
+			update.Files[filePath] = fileInfo
+			continue
+		}
+
+		lines := strings.Split(string(content), "\n")
 		fileInfo.Additions = len(lines)
 		fileInfo.Deletions = 0
 
 		// Format as a proper git diff with all required headers.
 		// The @git-diff-view/react library requires the full git diff format.
 		var diffBuilder strings.Builder
+		// Pre-grow to avoid repeated allocations.
+		diffBuilder.Grow(len(content) + len(lines) + 256)
 		diffBuilder.WriteString("diff --git a/" + filePath + " b/" + filePath + "\n")
 		diffBuilder.WriteString("new file mode 100644\n")
 		diffBuilder.WriteString("index 0000000..0000000\n")

--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
@@ -1,0 +1,117 @@
+package process
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentctl/types"
+)
+
+// makeUntrackedUpdate creates a GitStatusUpdate with untracked files.
+func makeUntrackedUpdate(paths ...string) types.GitStatusUpdate {
+	files := make(map[string]types.FileInfo, len(paths))
+	untracked := make([]string, 0, len(paths))
+	for _, p := range paths {
+		files[p] = types.FileInfo{Status: fileStatusUntracked}
+		untracked = append(untracked, p)
+	}
+	return types.GitStatusUpdate{
+		Files:     files,
+		Untracked: untracked,
+	}
+}
+
+func TestEnrichUntrackedFileDiffs_SmallTextFile(t *testing.T) {
+	dir := t.TempDir()
+	content := "line1\nline2\nline3\n"
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(dir, log)
+	update := makeUntrackedUpdate("hello.txt")
+
+	wt.enrichUntrackedFileDiffs(context.Background(), &update)
+
+	fi := update.Files["hello.txt"]
+	if fi.Diff == "" {
+		t.Fatal("expected diff to be populated for small text file")
+	}
+	if fi.Additions == 0 {
+		t.Fatal("expected additions > 0")
+	}
+	if !strings.Contains(fi.Diff, "+line1") {
+		t.Errorf("diff should contain +line1, got: %s", fi.Diff[:min(200, len(fi.Diff))])
+	}
+}
+
+func TestEnrichUntrackedFileDiffs_SkipsBinaryFile(t *testing.T) {
+	dir := t.TempDir()
+	// Binary content: contains null bytes.
+	binary := make([]byte, 1024)
+	binary[100] = 0
+	binary[200] = 0
+	copy(binary, []byte("ELF"))
+	if err := os.WriteFile(filepath.Join(dir, "app.bin"), binary, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(dir, log)
+	update := makeUntrackedUpdate("app.bin")
+
+	wt.enrichUntrackedFileDiffs(context.Background(), &update)
+
+	fi := update.Files["app.bin"]
+	if fi.Diff != "" {
+		t.Error("expected binary file to be skipped, but diff was populated")
+	}
+	if fi.DiffSkipReason != "binary" {
+		t.Errorf("expected DiffSkipReason=%q, got %q", "binary", fi.DiffSkipReason)
+	}
+}
+
+func TestEnrichUntrackedFileDiffs_SkipsLargeFile(t *testing.T) {
+	dir := t.TempDir()
+	// Create a file larger than maxUntrackedFileSize (1 MB).
+	large := make([]byte, maxUntrackedFileSize+1)
+	for i := range large {
+		large[i] = 'x'
+	}
+	if err := os.WriteFile(filepath.Join(dir, "big.dat"), large, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(dir, log)
+	update := makeUntrackedUpdate("big.dat")
+
+	wt.enrichUntrackedFileDiffs(context.Background(), &update)
+
+	fi := update.Files["big.dat"]
+	if fi.Diff != "" {
+		t.Error("expected large file to be skipped, but diff was populated")
+	}
+	if fi.DiffSkipReason != "too_large" {
+		t.Errorf("expected DiffSkipReason=%q, got %q", "too_large", fi.DiffSkipReason)
+	}
+}
+
+func TestEnrichUntrackedFileDiffs_SkipsNonexistentFile(t *testing.T) {
+	dir := t.TempDir()
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(dir, log)
+	update := makeUntrackedUpdate("does-not-exist.txt")
+
+	// Should not panic or error.
+	wt.enrichUntrackedFileDiffs(context.Background(), &update)
+
+	fi := update.Files["does-not-exist.txt"]
+	if fi.Diff != "" {
+		t.Error("expected missing file to be skipped")
+	}
+}

--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
@@ -24,6 +24,8 @@ func makeUntrackedUpdate(paths ...string) types.GitStatusUpdate {
 	}
 }
 
+// TestEnrichUntrackedFileDiffs_SmallTextFile verifies that small text files
+// produce a valid synthetic diff with correct addition counts.
 func TestEnrichUntrackedFileDiffs_SmallTextFile(t *testing.T) {
 	dir := t.TempDir()
 	content := "line1\nline2\nline3\n"
@@ -41,14 +43,16 @@ func TestEnrichUntrackedFileDiffs_SmallTextFile(t *testing.T) {
 	if fi.Diff == "" {
 		t.Fatal("expected diff to be populated for small text file")
 	}
-	if fi.Additions == 0 {
-		t.Fatal("expected additions > 0")
+	if fi.Additions != 3 {
+		t.Errorf("expected 3 additions (trailing newline should not count), got %d", fi.Additions)
 	}
 	if !strings.Contains(fi.Diff, "+line1") {
 		t.Errorf("diff should contain +line1, got: %s", fi.Diff[:min(200, len(fi.Diff))])
 	}
 }
 
+// TestEnrichUntrackedFileDiffs_SkipsBinaryFile verifies that files containing
+// null bytes are detected as binary and skipped with the appropriate reason.
 func TestEnrichUntrackedFileDiffs_SkipsBinaryFile(t *testing.T) {
 	dir := t.TempDir()
 	// Binary content: contains null bytes.
@@ -75,9 +79,11 @@ func TestEnrichUntrackedFileDiffs_SkipsBinaryFile(t *testing.T) {
 	}
 }
 
+// TestEnrichUntrackedFileDiffs_SkipsLargeFile verifies that files exceeding
+// maxUntrackedFileSize are skipped with the "too_large" reason.
 func TestEnrichUntrackedFileDiffs_SkipsLargeFile(t *testing.T) {
 	dir := t.TempDir()
-	// Create a file larger than maxUntrackedFileSize (1 MB).
+	// Create a file larger than maxUntrackedFileSize (10 MB).
 	large := make([]byte, maxUntrackedFileSize+1)
 	for i := range large {
 		large[i] = 'x'
@@ -101,6 +107,8 @@ func TestEnrichUntrackedFileDiffs_SkipsLargeFile(t *testing.T) {
 	}
 }
 
+// TestEnrichUntrackedFileDiffs_SkipsNonexistentFile verifies that missing files
+// are silently skipped without panicking or populating a diff.
 func TestEnrichUntrackedFileDiffs_SkipsNonexistentFile(t *testing.T) {
 	dir := t.TempDir()
 	log := newTestLogger(t)

--- a/apps/backend/internal/agentctl/types/streams/git.go
+++ b/apps/backend/internal/agentctl/types/streams/git.go
@@ -78,6 +78,10 @@ type FileInfo struct {
 
 	// Diff contains the unified diff content for this file.
 	Diff string `json:"diff,omitempty"`
+
+	// DiffSkipReason explains why the diff was not generated (e.g., "binary", "too_large").
+	// Empty when a diff is available.
+	DiffSkipReason string `json:"diff_skip_reason,omitempty"`
 }
 
 // GitCommitNotification is sent when a new commit is detected in the workspace.

--- a/apps/web/components/task/commit-detail-panel.tsx
+++ b/apps/web/components/task/commit-detail-panel.tsx
@@ -12,6 +12,17 @@ import { setPanelTitle } from "@/lib/layout/panel-portal-manager";
 import type { FileInfo } from "@/lib/state/store";
 import { requestCommitDiff } from "./commit-diff-request";
 
+function diffSkipLabel(reason?: string): string {
+  switch (reason) {
+    case "binary":
+      return "binary file";
+    case "too_large":
+      return "file too large to preview";
+    default:
+      return "binary or empty diff";
+  }
+}
+
 type CommitDetailPanelProps = {
   panelId: string;
   params: Record<string, unknown>;
@@ -209,7 +220,7 @@ function CommitFileList({
             />
           ) : (
             <div className="px-3 py-2 text-xs text-muted-foreground">
-              {path} -- binary or empty diff
+              {path} -- {diffSkipLabel(file.diff_skip_reason)}
             </div>
           )}
         </div>

--- a/apps/web/components/task/commit-detail-panel.tsx
+++ b/apps/web/components/task/commit-detail-panel.tsx
@@ -12,6 +12,7 @@ import { setPanelTitle } from "@/lib/layout/panel-portal-manager";
 import type { FileInfo } from "@/lib/state/store";
 import { requestCommitDiff } from "./commit-diff-request";
 
+/** Returns a human-readable label for a diff skip reason. */
 function diffSkipLabel(reason?: string): string {
   switch (reason) {
     case "binary":

--- a/apps/web/lib/state/slices/session-runtime/types.ts
+++ b/apps/web/lib/state/slices/session-runtime/types.ts
@@ -48,6 +48,7 @@ export type FileInfo = {
   deletions?: number;
   old_path?: string;
   diff?: string;
+  diff_skip_reason?: "binary" | "too_large";
 };
 
 export type GitStatusEntry = {

--- a/apps/web/lib/types/backend.ts
+++ b/apps/web/lib/types/backend.ts
@@ -262,6 +262,7 @@ export type FileInfo = {
   deletions?: number;
   old_path?: string;
   diff?: string;
+  diff_skip_reason?: "binary" | "too_large";
 };
 
 export type ProcessOutputPayload = {


### PR DESCRIPTION
The workspace tracker's `enrichUntrackedFileDiffs` read the full content of every untracked file on each git status polling cycle (~2-3s) to build synthetic diffs. When large unignored binaries existed in the workspace, allocation rates exceeded GC throughput (~170 MB/s observed via pprof), causing the agentctl process to grow to 26 GB+ and triggering the Linux OOM killer — which cascaded into a SIGTERM on the kandev backend.

## Important Changes

- **File size cap (10 MB):** files larger than `maxUntrackedFileSize` are skipped with `diff_skip_reason: "too_large"`
- **Binary detection:** first 8 KB checked for null bytes (same heuristic as Git); binary files are skipped with `diff_skip_reason: "binary"`
- **`DiffSkipReason` field:** added to `FileInfo` (Go + TypeScript) so the UI can display a meaningful label ("binary file", "file too large to preview") instead of a blank diff
- **Replaced `exec.Command("cat", ...)` with `os.ReadFile()`** — avoids spawning a subprocess per file per poll cycle
- **Path traversal protection:** uses `sanitizePath` to validate file paths stay within workspace
- **Off-by-one fix:** trailing newline no longer inflates the additions count

## Validation

```
cd apps/backend && make fmt && go vet ./... && go test ./internal/agentctl/server/process/ -count=1 && go build ./...
cd apps/web && pnpm exec tsc --noEmit
```

4 unit tests covering: small text file (enriched), binary file (skipped), large file (skipped), nonexistent file (skipped).

## Possible Improvements

The 10 MB file cap is not chosen scientifically — it's a practical threshold that covers virtually all source files while excluding large binaries/assets. The actual constraint is the polling frequency (~2-3s): files within the cap get re-read and re-allocated every cycle, but the GC can comfortably handle this volume. We could increase the cap if needed — larger text files would still work fine as long as GC throughput keeps up. A "click to expand" pattern (like GitHub's large diff handling) would be the ideal long-term solution for files above the threshold.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
