### PR TITLE
fix(web): read session state at call time in comment run to prevent stale queue

### DIFF
--- a/apps/web/components/editors/codemirror/use-codemirror-editor-state.ts
+++ b/apps/web/components/editors/codemirror/use-codemirror-editor-state.ts
@@ -429,15 +429,9 @@ export function useCodeMirrorEditorState(opts: UseCodeMirrorEditorStateOpts) {
   );
 
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
-  const activeSession = useAppStore((state) => {
-    const sid = state.tasks.activeSessionId;
-    return sid ? (state.taskSessions.items[sid] ?? null) : null;
-  });
-  const isAgentBusy = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
   const { runComment } = useRunComment({
     sessionId: sessionId ?? null,
     taskId: activeTaskId ?? null,
-    isAgentBusy,
   });
 
   const createCommentFromSelection = useCallback(
@@ -481,17 +475,17 @@ export function useCodeMirrorEditorState(opts: UseCodeMirrorEditorStateOpts) {
   );
 
   const handleCommentSubmitAndRun = useCallback(
-    (annotation: string) => {
+    async (annotation: string) => {
       const comment = createCommentFromSelection(annotation);
       if (comment) {
-        runComment(comment);
+        const { queued } = await runComment(comment);
         toast({
           title: "Comment sent",
-          description: isAgentBusy ? "Queued for the agent." : "Sent to the agent.",
+          description: queued ? "Queued for the agent." : "Sent to the agent.",
         });
       }
     },
-    [createCommentFromSelection, runComment, isAgentBusy, toast],
+    [createCommentFromSelection, runComment, toast],
   );
 
   const handlePopoverClose = useCallback(() => {

--- a/apps/web/components/editors/codemirror/use-codemirror-editor-state.ts
+++ b/apps/web/components/editors/codemirror/use-codemirror-editor-state.ts
@@ -478,11 +478,19 @@ export function useCodeMirrorEditorState(opts: UseCodeMirrorEditorStateOpts) {
     async (annotation: string) => {
       const comment = createCommentFromSelection(annotation);
       if (comment) {
-        const { queued } = await runComment(comment);
-        toast({
-          title: "Comment sent",
-          description: queued ? "Queued for the agent." : "Sent to the agent.",
-        });
+        try {
+          const { queued } = await runComment(comment);
+          toast({
+            title: "Comment sent",
+            description: queued ? "Queued for the agent." : "Sent to the agent.",
+          });
+        } catch {
+          toast({
+            title: "Failed to send comment",
+            description: "Please try again.",
+            variant: "error",
+          });
+        }
       }
     },
     [createCommentFromSelection, runComment, toast],

--- a/apps/web/components/editors/monaco/use-monaco-editor-state.ts
+++ b/apps/web/components/editors/monaco/use-monaco-editor-state.ts
@@ -335,15 +335,9 @@ export function useMonacoEditorComments(opts: UseMonacoEditorStateOpts) {
   );
 
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
-  const activeSession = useAppStore((state) => {
-    const sid = state.tasks.activeSessionId;
-    return sid ? (state.taskSessions.items[sid] ?? null) : null;
-  });
-  const isAgentBusy = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
   const { runComment } = useRunComment({
     sessionId: sessionId ?? null,
     taskId: activeTaskId ?? null,
-    isAgentBusy,
   });
 
   const createCommentFromForm = useCallback(
@@ -395,10 +389,10 @@ export function useMonacoEditorComments(opts: UseMonacoEditorStateOpts) {
       const comment = createCommentFromForm(annotation);
       if (comment) {
         try {
-          await runComment(comment);
+          const { queued } = await runComment(comment);
           toast({
             title: "Comment sent",
-            description: isAgentBusy ? "Queued for the agent." : "Sent to the agent.",
+            description: queued ? "Queued for the agent." : "Sent to the agent.",
           });
         } catch {
           toast({
@@ -409,16 +403,16 @@ export function useMonacoEditorComments(opts: UseMonacoEditorStateOpts) {
         }
       }
     },
-    [createCommentFromForm, runComment, isAgentBusy, toast],
+    [createCommentFromForm, runComment, toast],
   );
 
   const handleCommentRun = useCallback(
     async (comment: DiffComment) => {
       try {
-        await runComment(comment);
+        const { queued } = await runComment(comment);
         toast({
           title: "Comment sent",
-          description: isAgentBusy ? "Queued for the agent." : "Sent to the agent.",
+          description: queued ? "Queued for the agent." : "Sent to the agent.",
         });
       } catch {
         toast({
@@ -428,7 +422,7 @@ export function useMonacoEditorComments(opts: UseMonacoEditorStateOpts) {
         });
       }
     },
-    [runComment, isAgentBusy, toast],
+    [runComment, toast],
   );
 
   const handleDeleteComment = useCallback(

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -26,6 +26,7 @@ import { requestFileContent, updateFileContent } from "@/lib/ws/workspace-files"
 import { generateUnifiedDiff, calculateHash } from "@/lib/utils/file-diff";
 import { useGlobalViewMode } from "@/hooks/use-global-view-mode";
 import { useAppStore } from "@/components/state-provider";
+import { useToast } from "@/components/toast-provider";
 import { useRunComment } from "@/hooks/domains/comments/use-run-comment";
 import type { DiffComment } from "@/lib/diff/types";
 import type { ReviewFile } from "./types";
@@ -383,15 +384,29 @@ function FileDiffHeader({
 
 function useCommentRunHandler(sessionId: string) {
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
+  const { toast } = useToast();
   const { runComment } = useRunComment({
     sessionId,
     taskId: activeTaskId ?? null,
   });
   return useCallback(
-    (comment: DiffComment) => {
-      runComment(comment).catch((err) => console.error("Failed to run diff comment:", err));
+    async (comment: DiffComment) => {
+      try {
+        const { queued } = await runComment(comment);
+        toast({
+          title: "Comment sent",
+          description: queued ? "Queued for the agent." : "Sent to the agent.",
+        });
+      } catch (err) {
+        console.error("Failed to run diff comment:", err);
+        toast({
+          title: "Failed to send comment",
+          description: "Please try again.",
+          variant: "error",
+        });
+      }
     },
-    [runComment],
+    [runComment, toast],
   );
 }
 

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -387,7 +387,12 @@ function useCommentRunHandler(sessionId: string) {
     sessionId,
     taskId: activeTaskId ?? null,
   });
-  return useCallback((comment: DiffComment) => runComment(comment), [runComment]);
+  return useCallback(
+    (comment: DiffComment) => {
+      runComment(comment).catch((err) => console.error("Failed to run diff comment:", err));
+    },
+    [runComment],
+  );
 }
 
 async function revertBlock(sessionId: string, filePath: string, info: RevertBlockInfo) {

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -383,15 +383,9 @@ function FileDiffHeader({
 
 function useCommentRunHandler(sessionId: string) {
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
-  const activeSession = useAppStore((state) => {
-    const sid = state.tasks.activeSessionId;
-    return sid ? (state.taskSessions.items[sid] ?? null) : null;
-  });
-  const isAgentBusy = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
   const { runComment } = useRunComment({
     sessionId,
     taskId: activeTaskId ?? null,
-    isAgentBusy,
   });
   return useCallback((comment: DiffComment) => runComment(comment), [runComment]);
 }

--- a/apps/web/components/task/task-plan-panel.tsx
+++ b/apps/web/components/task/task-plan-panel.tsx
@@ -194,7 +194,6 @@ export const TaskPlanPanel = memo(function TaskPlanPanel({
         textSelection={textSelection}
         activeSessionId={activeSessionId}
         taskId={taskId}
-        isAgentBusy={isAgentBusy}
         commentState={commentState}
         editorRef={editorInstanceRef}
         onClose={selectionState.handleSelectionClose}
@@ -217,7 +216,6 @@ function PlanSelectionPopoverWrapper({
   textSelection,
   activeSessionId,
   taskId,
-  isAgentBusy,
   commentState,
   editorRef,
   onClose,
@@ -225,7 +223,6 @@ function PlanSelectionPopoverWrapper({
   textSelection: TextSelection | null;
   activeSessionId: string | null | undefined;
   taskId: string | null;
-  isAgentBusy: boolean;
   commentState: ReturnType<typeof usePlanComments>;
   editorRef: React.RefObject<Editor | null>;
   onClose: () => void;
@@ -233,7 +230,6 @@ function PlanSelectionPopoverWrapper({
   const { runComment } = useRunComment({
     sessionId: activeSessionId ?? null,
     taskId,
-    isAgentBusy,
   });
 
   const addCommentAndApplyMark = useCallback(

--- a/apps/web/components/task/task-plan-panel.tsx
+++ b/apps/web/components/task/task-plan-panel.tsx
@@ -272,7 +272,7 @@ function PlanSelectionPopoverWrapper({
         createdAt: new Date().toISOString(),
         status: "pending",
       };
-      runComment(newComment);
+      runComment(newComment).catch((err) => console.error("Failed to run plan comment:", err));
     },
     [addCommentAndApplyMark, activeSessionId, runComment, textSelection],
   );

--- a/apps/web/e2e/tests/task/comment-run-not-queued.spec.ts
+++ b/apps/web/e2e/tests/task/comment-run-not-queued.spec.ts
@@ -1,0 +1,130 @@
+import { type Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** MCP script that creates plan content the agent can interact with. */
+const PLAN_SCRIPT = [
+  'e2e:thinking("Creating plan...")',
+  "e2e:delay(100)",
+  'e2e:mcp:kandev:create_task_plan_kandev({"task_id":"{task_id}","content":"## Plan\\n\\n1. Analyze requirements\\n2. Implement solution\\n3. Write tests","title":"Implementation Plan"})',
+  "e2e:delay(100)",
+  'e2e:message("Plan created.")',
+].join("\n");
+
+/** Create a task with agent, navigate to session, wait for idle. */
+async function seedTaskAndWaitForIdle(
+  testPage: Page,
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+  description = "/e2e:simple-message",
+) {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    title,
+    seedData.agentProfileId,
+    {
+      description,
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+
+  await testPage.goto(`/t/${task.id}`);
+
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+
+  return { session, taskId: task.id, sessionId: task.session_id! };
+}
+
+/**
+ * Open the plan comment popover, type a comment, and click Run.
+ * Returns the comment text so callers can assert on it.
+ */
+async function addPlanCommentAndRun(
+  testPage: Page,
+  session: SessionPage,
+  commentText: string,
+): Promise<void> {
+  const editor = session.planPanel.locator(".ProseMirror");
+  await editor.click();
+
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await testPage.keyboard.press(`${modifier}+a`);
+  await testPage.keyboard.press(`${modifier}+Shift+c`);
+
+  const textarea = testPage.locator('textarea[placeholder="Add your comment or instruction..."]');
+  await expect(textarea).toBeVisible({ timeout: 5_000 });
+  await textarea.fill(commentText);
+
+  const runBtn = testPage.getByRole("button", { name: "Run", exact: true });
+  await expect(runBtn).toBeVisible({ timeout: 5_000 });
+  await runBtn.click();
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Comment "Run" should send directly when agent is idle, not queue
+// ---------------------------------------------------------------------------
+
+test.describe("Comment run sends directly when agent is idle", () => {
+  test.describe.configure({ retries: 1 });
+
+  test("plan comment Run after agent was previously running sends directly, not queued", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    // 1. Create a task that produces plan content. Agent runs and finishes.
+    const { session } = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "Comment queue bug test",
+      PLAN_SCRIPT,
+    );
+
+    // 2. Toggle plan mode — the plan panel should show content.
+    await session.togglePlanMode();
+    await expect(session.planModeInput()).toBeVisible({ timeout: 10_000 });
+    await expect(session.planPanel.getByText("Analyze requirements", { exact: false })).toBeVisible(
+      {
+        timeout: 15_000,
+      },
+    );
+
+    // 3. Run a slow command so the session goes through RUNNING -> WAITING_FOR_INPUT again.
+    //    This ensures isAgentBusy was recently true.
+    await session.sendMessage("/slow 3s");
+    await expect(session.agentStatus()).toBeVisible({ timeout: 15_000 });
+    await expect(session.planModeInput()).toBeVisible({ timeout: 30_000 });
+
+    // 4. Agent is now idle. Add a plan comment and click Run.
+    await addPlanCommentAndRun(testPage, session, "Refactor step 1 to use dependency injection");
+
+    // 5. The comment should NOT be queued — no queue indicator should appear.
+    const queueIndicator = testPage.getByTitle("Cancel queued message");
+    await expect(queueIndicator).not.toBeVisible({ timeout: 3_000 });
+
+    // 6. The comment should appear in the chat as a direct message.
+    await expect(
+      session.chat.getByText("Refactor step 1 to use dependency injection", { exact: false }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // 7. The agent should start processing (proves it was sent as message.add, not queued).
+    await expect(session.agentStatus()).toBeVisible({ timeout: 15_000 });
+
+    // 8. Wait for agent to complete.
+    await expect(session.planModeInput()).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/apps/web/hooks/domains/comments/use-run-comment.test.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { DiffComment, PlanComment } from "@/lib/state/slices/comments";
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports that use them
+// ---------------------------------------------------------------------------
+
+const mockRequest = vi.fn();
+const mockAppendToQueue = vi.fn();
+const mockMarkCommentsSent = vi.fn();
+let mockStoreState: Record<string, unknown> = {};
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock("@/lib/api/domains/queue-api", () => ({
+  appendToQueue: (...args: unknown[]) => mockAppendToQueue(...args),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStoreApi: () => ({ getState: () => mockStoreState }),
+}));
+
+vi.mock("@/lib/state/slices/comments", () => ({
+  useCommentsStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ markCommentsSent: mockMarkCommentsSent }),
+}));
+
+vi.mock("@/lib/state/slices/comments/format", () => ({
+  formatReviewCommentsAsMarkdown: (comments: DiffComment[]) => `[diff] ${comments[0]?.text ?? ""}`,
+  formatPlanCommentsAsMarkdown: (comments: PlanComment[]) => `[plan] ${comments[0]?.text ?? ""}`,
+  formatPRFeedbackAsMarkdown: () => "[pr-feedback]",
+}));
+
+import { useRunComment } from "./use-run-comment";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStoreState(sessionState: string, planMode = false) {
+  return {
+    tasks: { activeSessionId: "sess-1" },
+    taskSessions: {
+      items: { "sess-1": { state: sessionState } },
+    },
+    chatInput: {
+      planModeBySessionId: { "sess-1": planMode },
+    },
+  };
+}
+
+function makeDiffComment(text = "fix this"): DiffComment {
+  return {
+    id: "c-1",
+    source: "diff",
+    sessionId: "sess-1",
+    filePath: "src/app.ts",
+    startLine: 10,
+    endLine: 12,
+    side: "additions",
+    codeContent: "const x = 1;",
+    text,
+    createdAt: new Date().toISOString(),
+    status: "pending",
+  };
+}
+
+function makePlanComment(text = "split step 2"): PlanComment {
+  return {
+    id: "c-2",
+    source: "plan",
+    sessionId: "sess-1",
+    text,
+    selectedText: "step 2",
+    createdAt: new Date().toISOString(),
+    status: "pending",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+function renderCommentHook(sessionId: string | null = "sess-1") {
+  return renderHook(() => useRunComment({ sessionId, taskId: "task-1" }));
+}
+
+function setup() {
+  vi.clearAllMocks();
+  mockStoreState = makeStoreState("WAITING_FOR_INPUT");
+}
+
+describe("useRunComment — idle agent sends directly", () => {
+  beforeEach(setup);
+
+  it("sends directly via message.add when agent is idle", async () => {
+    mockStoreState = makeStoreState("WAITING_FOR_INPUT");
+    const { result } = renderCommentHook();
+
+    let res: { queued: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.runComment(makeDiffComment());
+    });
+
+    expect(res).toEqual({ queued: false });
+    expect(mockRequest).toHaveBeenCalledWith(
+      "message.add",
+      expect.objectContaining({
+        task_id: "task-1",
+        session_id: "sess-1",
+        has_review_comments: true,
+      }),
+      10000,
+    );
+    expect(mockAppendToQueue).not.toHaveBeenCalled();
+    expect(mockMarkCommentsSent).toHaveBeenCalledWith(["c-1"]);
+  });
+
+  it("reads fresh store state at call time, not from closure", async () => {
+    mockStoreState = makeStoreState("RUNNING");
+    const { result } = renderCommentHook();
+
+    // Agent finishes — store changes but hook NOT re-rendered
+    mockStoreState = makeStoreState("WAITING_FOR_INPUT");
+
+    let res: { queued: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.runComment(makeDiffComment());
+    });
+
+    expect(res).toEqual({ queued: false });
+    expect(mockRequest).toHaveBeenCalled();
+    expect(mockAppendToQueue).not.toHaveBeenCalled();
+  });
+
+  it("re-throws when message.add fails", async () => {
+    mockRequest.mockRejectedValueOnce(new Error("WS timeout"));
+    const { result } = renderCommentHook();
+
+    await expect(
+      act(async () => {
+        await result.current.runComment(makeDiffComment());
+      }),
+    ).rejects.toThrow("WS timeout");
+
+    expect(mockMarkCommentsSent).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRunComment — busy agent queues", () => {
+  beforeEach(setup);
+
+  it("queues via appendToQueue when agent is RUNNING", async () => {
+    mockStoreState = makeStoreState("RUNNING");
+    const { result } = renderCommentHook();
+
+    let res: { queued: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.runComment(makeDiffComment());
+    });
+
+    expect(res).toEqual({ queued: true });
+    expect(mockAppendToQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ session_id: "sess-1", task_id: "task-1" }),
+    );
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockMarkCommentsSent).toHaveBeenCalledWith(["c-1"]);
+  });
+
+  it("queues via appendToQueue when agent is STARTING", async () => {
+    mockStoreState = makeStoreState("STARTING");
+    const { result } = renderCommentHook();
+
+    let res: { queued: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.runComment(makeDiffComment());
+    });
+
+    expect(res).toEqual({ queued: true });
+    expect(mockAppendToQueue).toHaveBeenCalled();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRunComment — edge cases", () => {
+  beforeEach(setup);
+
+  it("returns { queued: false } when sessionId is null", async () => {
+    const { result } = renderCommentHook(null);
+
+    let res: { queued: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.runComment(makeDiffComment());
+    });
+
+    expect(res).toEqual({ queued: false });
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockAppendToQueue).not.toHaveBeenCalled();
+  });
+
+  it("includes plan_mode when plan mode is enabled", async () => {
+    mockStoreState = makeStoreState("WAITING_FOR_INPUT", true);
+    const { result } = renderCommentHook();
+
+    await act(async () => {
+      await result.current.runComment(makePlanComment());
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      "message.add",
+      expect.objectContaining({ plan_mode: true }),
+      10000,
+    );
+  });
+
+  it("omits has_review_comments for plan comments", async () => {
+    const { result } = renderCommentHook();
+
+    await act(async () => {
+      await result.current.runComment(makePlanComment());
+    });
+
+    const payload = mockRequest.mock.calls[0][1];
+    expect(payload.has_review_comments).toBeUndefined();
+  });
+});

--- a/apps/web/hooks/domains/comments/use-run-comment.test.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.test.ts
@@ -227,16 +227,16 @@ describe("useRunComment — edge cases", () => {
     expect(payload.has_review_comments).toBeUndefined();
   });
 
-  it("returns { queued: false } without marking sent when WS client is null", async () => {
+  it("throws when WS client is null and does not mark comment sent", async () => {
     mockGetWebSocketClient.mockReturnValueOnce(null as unknown as { request: typeof mockRequest });
     const { result } = renderCommentHook();
 
-    let res: { queued: boolean } | undefined;
-    await act(async () => {
-      res = await result.current.runComment(makeDiffComment());
-    });
+    await expect(
+      act(async () => {
+        await result.current.runComment(makeDiffComment());
+      }),
+    ).rejects.toThrow("WebSocket client unavailable");
 
-    expect(res).toEqual({ queued: false });
     expect(mockRequest).not.toHaveBeenCalled();
     expect(mockMarkCommentsSent).not.toHaveBeenCalled();
   });

--- a/apps/web/hooks/domains/comments/use-run-comment.test.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.test.ts
@@ -43,7 +43,6 @@ import { useRunComment } from "./use-run-comment";
 
 function makeStoreState(sessionState: string, planMode = false) {
   return {
-    tasks: { activeSessionId: "sess-1" },
     taskSessions: {
       items: { "sess-1": { state: sessionState } },
     },

--- a/apps/web/hooks/domains/comments/use-run-comment.test.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.test.ts
@@ -9,10 +9,11 @@ import type { DiffComment, PlanComment } from "@/lib/state/slices/comments";
 const mockRequest = vi.fn();
 const mockAppendToQueue = vi.fn();
 const mockMarkCommentsSent = vi.fn();
+const mockGetWebSocketClient = vi.fn(() => ({ request: mockRequest }));
 let mockStoreState: Record<string, unknown> = {};
 
 vi.mock("@/lib/ws/connection", () => ({
-  getWebSocketClient: () => ({ request: mockRequest }),
+  getWebSocketClient: () => mockGetWebSocketClient(),
 }));
 
 vi.mock("@/lib/api/domains/queue-api", () => ({
@@ -225,5 +226,19 @@ describe("useRunComment — edge cases", () => {
 
     const payload = mockRequest.mock.calls[0][1];
     expect(payload.has_review_comments).toBeUndefined();
+  });
+
+  it("returns { queued: false } without marking sent when WS client is null", async () => {
+    mockGetWebSocketClient.mockReturnValueOnce(null as unknown as { request: typeof mockRequest });
+    const { result } = renderCommentHook();
+
+    let res: { queued: boolean } | undefined;
+    await act(async () => {
+      res = await result.current.runComment(makeDiffComment());
+    });
+
+    expect(res).toEqual({ queued: false });
+    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockMarkCommentsSent).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/hooks/domains/comments/use-run-comment.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.ts
@@ -114,8 +114,7 @@ export function useRunComment({ sessionId, taskId }: UseRunCommentParams) {
       // stale closures that could cause incorrect behavior (e.g. queuing
       // comments when the agent is idle, or sending with wrong plan mode).
       const state = storeApi.getState();
-      const sid = state.tasks.activeSessionId;
-      const activeSession = sid ? (state.taskSessions.items[sid] ?? null) : null;
+      const activeSession = state.taskSessions.items[sessionId] ?? null;
       const isAgentBusy = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
       const planModeEnabled = state.chatInput.planModeBySessionId[sessionId] ?? false;
       const content = formatSingleComment(comment);

--- a/apps/web/hooks/domains/comments/use-run-comment.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.ts
@@ -124,7 +124,7 @@ export function useRunComment({ sessionId, taskId }: UseRunCommentParams) {
           await appendToQueue(buildQueuePayload(sessionId, taskId, content, planModeEnabled));
         } else {
           const client = getWebSocketClient();
-          if (!client) return { queued: false };
+          if (!client) throw new Error("WebSocket client unavailable");
           await client.request(
             "message.add",
             buildMessagePayload(sessionId, taskId, content, planModeEnabled, comment),

--- a/apps/web/hooks/domains/comments/use-run-comment.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { appendToQueue } from "@/lib/api/domains/queue-api";
-import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+import { useAppStoreApi } from "@/components/state-provider";
 import { useCommentsStore } from "@/lib/state/slices/comments";
 import {
   formatReviewCommentsAsMarkdown,
@@ -54,6 +54,45 @@ type UseRunCommentParams = {
   taskId: string | null;
 };
 
+type QueuePayload = {
+  session_id: string;
+  task_id: string;
+  content: string;
+  plan_mode?: boolean;
+};
+
+type MessagePayload = {
+  task_id: string;
+  session_id: string;
+  content: string;
+  plan_mode?: boolean;
+  has_review_comments?: boolean;
+};
+
+function buildQueuePayload(
+  sessionId: string,
+  taskId: string,
+  content: string,
+  planModeEnabled: boolean,
+): QueuePayload {
+  const payload: QueuePayload = { session_id: sessionId, task_id: taskId, content };
+  if (planModeEnabled) payload.plan_mode = true;
+  return payload;
+}
+
+function buildMessagePayload(
+  sessionId: string,
+  taskId: string,
+  content: string,
+  planModeEnabled: boolean,
+  comment: Comment,
+): MessagePayload {
+  const payload: MessagePayload = { task_id: taskId, session_id: sessionId, content };
+  if (planModeEnabled) payload.plan_mode = true;
+  if (comment.source !== "plan") payload.has_review_comments = true;
+  return payload;
+}
+
 /**
  * Hook that provides a function to immediately send a comment to the agent.
  *
@@ -66,46 +105,30 @@ type UseRunCommentParams = {
 export function useRunComment({ sessionId, taskId }: UseRunCommentParams) {
   const markCommentsSent = useCommentsStore((s) => s.markCommentsSent);
   const storeApi = useAppStoreApi();
-  const planModeEnabled = useAppStore((s) =>
-    sessionId ? (s.chatInput.planModeBySessionId[sessionId] ?? false) : false,
-  );
 
   const runComment = useCallback(
     async (comment: Comment): Promise<{ queued: boolean }> => {
       if (!sessionId || !taskId) return { queued: false };
 
-      // Read session state fresh at call time to avoid stale closures.
-      // Previously, isAgentBusy was captured in the useCallback closure and
-      // could be stale if the session state changed between the last render
-      // and the user clicking "Run".
+      // Read all derived values fresh from the store at call time to avoid
+      // stale closures that could cause incorrect behavior (e.g. queuing
+      // comments when the agent is idle, or sending with wrong plan mode).
       const state = storeApi.getState();
       const sid = state.tasks.activeSessionId;
       const activeSession = sid ? (state.taskSessions.items[sid] ?? null) : null;
       const isAgentBusy = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
-
+      const planModeEnabled = state.chatInput.planModeBySessionId[sessionId] ?? false;
       const content = formatSingleComment(comment);
 
       try {
         if (isAgentBusy) {
-          await appendToQueue({
-            session_id: sessionId,
-            task_id: taskId,
-            content,
-            ...(planModeEnabled && { plan_mode: true }),
-          });
+          await appendToQueue(buildQueuePayload(sessionId, taskId, content, planModeEnabled));
         } else {
           const client = getWebSocketClient();
           if (!client) return { queued: false };
-
           await client.request(
             "message.add",
-            {
-              task_id: taskId,
-              session_id: sessionId,
-              content,
-              ...(planModeEnabled && { plan_mode: true }),
-              ...(comment.source !== "plan" && { has_review_comments: true }),
-            },
+            buildMessagePayload(sessionId, taskId, content, planModeEnabled, comment),
             10000,
           );
         }
@@ -117,7 +140,7 @@ export function useRunComment({ sessionId, taskId }: UseRunCommentParams) {
         throw error;
       }
     },
-    [sessionId, taskId, storeApi, planModeEnabled, markCommentsSent],
+    [sessionId, taskId, storeApi, markCommentsSent],
   );
 
   return { runComment };

--- a/apps/web/hooks/domains/comments/use-run-comment.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { appendToQueue } from "@/lib/api/domains/queue-api";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useCommentsStore } from "@/lib/state/slices/comments";
 import {
   formatReviewCommentsAsMarkdown,
@@ -52,7 +52,6 @@ function formatSingleComment(comment: Comment): string {
 type UseRunCommentParams = {
   sessionId: string | null;
   taskId: string | null;
-  isAgentBusy: boolean;
 };
 
 /**
@@ -60,16 +59,29 @@ type UseRunCommentParams = {
  *
  * If the agent is idle, sends as a direct message.
  * If the agent is busy, appends to the queued message (or creates a new one).
+ *
+ * The busy check reads fresh state from the store at call time to avoid
+ * stale closures that could incorrectly queue comments when the agent is idle.
  */
-export function useRunComment({ sessionId, taskId, isAgentBusy }: UseRunCommentParams) {
+export function useRunComment({ sessionId, taskId }: UseRunCommentParams) {
   const markCommentsSent = useCommentsStore((s) => s.markCommentsSent);
+  const storeApi = useAppStoreApi();
   const planModeEnabled = useAppStore((s) =>
     sessionId ? (s.chatInput.planModeBySessionId[sessionId] ?? false) : false,
   );
 
   const runComment = useCallback(
-    async (comment: Comment) => {
-      if (!sessionId || !taskId) return;
+    async (comment: Comment): Promise<{ queued: boolean }> => {
+      if (!sessionId || !taskId) return { queued: false };
+
+      // Read session state fresh at call time to avoid stale closures.
+      // Previously, isAgentBusy was captured in the useCallback closure and
+      // could be stale if the session state changed between the last render
+      // and the user clicking "Run".
+      const state = storeApi.getState();
+      const sid = state.tasks.activeSessionId;
+      const activeSession = sid ? (state.taskSessions.items[sid] ?? null) : null;
+      const isAgentBusy = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
 
       const content = formatSingleComment(comment);
 
@@ -83,7 +95,7 @@ export function useRunComment({ sessionId, taskId, isAgentBusy }: UseRunCommentP
           });
         } else {
           const client = getWebSocketClient();
-          if (!client) return;
+          if (!client) return { queued: false };
 
           await client.request(
             "message.add",
@@ -99,12 +111,13 @@ export function useRunComment({ sessionId, taskId, isAgentBusy }: UseRunCommentP
         }
 
         markCommentsSent([comment.id]);
+        return { queued: isAgentBusy };
       } catch (error) {
         console.error("Failed to send comment to agent:", error);
         throw error;
       }
     },
-    [sessionId, taskId, isAgentBusy, planModeEnabled, markCommentsSent],
+    [sessionId, taskId, storeApi, planModeEnabled, markCommentsSent],
   );
 
   return { runComment };


### PR DESCRIPTION
Comments added to files, diffs, or plans and immediately run via the "Run" button were sometimes queued instead of starting a new agent prompt, even when the agent was idle. The `useRunComment` hook captured `isAgentBusy` in a `useCallback` closure that could become stale if the session state changed between the last render and the user's click.

## Important Changes

- `useRunComment` no longer accepts `isAgentBusy` as a parameter. Instead, it reads the session state fresh from the Zustand store via `useAppStoreApi().getState()` at call time.
- The hook now returns `{ queued: boolean }` so callers can show accurate toast messages without needing their own busy-state tracking.

## Validation

- `npx tsc --noEmit` -- no type errors
- `make lint` -- 0 issues (Go + ESLint)
- All 4 queue-related E2E tests pass (3 existing + 1 new regression test)
- New E2E test: `comment-run-not-queued.spec.ts` -- verifies plan comment Run sends directly after agent was previously running

## Possible Improvements

- The same stale-closure pattern exists in `useMessageHandler` (chat input). It hasn't been reported as a bug there (likely because the chat input re-renders more reliably), but could be addressed separately.

## Checklist

- [ ] Self-reviewed
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or documented)