### PR TITLE
fix(web): prevent session failure toast from re-appearing after dismiss

### DIFF
--- a/apps/web/hooks/use-session-failure-toast.test.ts
+++ b/apps/web/hooks/use-session-failure-toast.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { SessionFailureNotification } from "@/lib/state/slices/ui/types";
+
+let mockNotification: SessionFailureNotification | null = null;
+const mockClearNotification = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      sessionFailureNotification: mockNotification,
+      setSessionFailureNotification: mockClearNotification,
+    }),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+import { useSessionFailureToast } from "./use-session-failure-toast";
+
+describe("useSessionFailureToast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNotification = null;
+  });
+
+  it("shows toast when notification is set", () => {
+    mockNotification = { sessionId: "s-1", taskId: "t-1", message: "boom" };
+    renderHook(() => useSessionFailureToast());
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "Task failed to start",
+      description: "boom",
+      variant: "error",
+    });
+    expect(mockClearNotification).toHaveBeenCalledWith(null);
+  });
+
+  it("does not show toast when notification is null", () => {
+    mockNotification = null;
+    renderHook(() => useSessionFailureToast());
+
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(mockClearNotification).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates toasts for the same sessionId across rerenders", () => {
+    mockNotification = { sessionId: "s-1", taskId: "t-1", message: "first" };
+    const { rerender } = renderHook(() => useSessionFailureToast());
+    expect(mockToast).toHaveBeenCalledTimes(1);
+
+    mockToast.mockClear();
+    mockClearNotification.mockClear();
+
+    mockNotification = { sessionId: "s-1", taskId: "t-1", message: "duplicate" };
+    rerender();
+
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(mockClearNotification).toHaveBeenCalledWith(null);
+  });
+
+  it("shows toast for a different sessionId", () => {
+    mockNotification = { sessionId: "s-1", taskId: "t-1", message: "first" };
+    const { rerender } = renderHook(() => useSessionFailureToast());
+    expect(mockToast).toHaveBeenCalledTimes(1);
+
+    mockToast.mockClear();
+
+    mockNotification = { sessionId: "s-2", taskId: "t-1", message: "second" };
+    rerender();
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "Task failed to start",
+      description: "second",
+      variant: "error",
+    });
+  });
+});

--- a/apps/web/hooks/use-session-failure-toast.ts
+++ b/apps/web/hooks/use-session-failure-toast.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 
+/** Watches for session failure notifications and shows an error toast. Mount once inside ToastProvider. */
 export function useSessionFailureToast() {
   const notification = useAppStore((s) => s.sessionFailureNotification);
   const clearNotification = useAppStore((s) => s.setSessionFailureNotification);

--- a/apps/web/hooks/use-session-failure-toast.ts
+++ b/apps/web/hooks/use-session-failure-toast.ts
@@ -1,20 +1,22 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 
-/**
- * Watches for session failure notifications in the store and shows an error toast.
- * Mount once in a global layout component inside ToastProvider.
- */
 export function useSessionFailureToast() {
   const notification = useAppStore((s) => s.sessionFailureNotification);
   const clearNotification = useAppStore((s) => s.setSessionFailureNotification);
   const { toast } = useToast();
+  const shownRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (!notification) return;
+    if (shownRef.current.has(notification.sessionId)) {
+      clearNotification(null);
+      return;
+    }
+    shownRef.current.add(notification.sessionId);
     toast({
       title: "Task failed to start",
       description: notification.message,

--- a/apps/web/lib/ws/handlers/agent-session.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerTaskSessionHandlers } from "./agent-session";
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
+
+function makeStore(overrides: Record<string, unknown> = {}) {
+  const state: Record<string, unknown> = {
+    taskSessions: { items: {} },
+    taskSessionsByTask: { itemsByTaskId: {} },
+    setTaskSession: vi.fn(),
+    setTaskSessionsForTask: vi.fn(),
+    setSessionFailureNotification: vi.fn(),
+    setContextWindow: vi.fn(),
+    ...overrides,
+  };
+  return {
+    getState: () => state as unknown as AppState,
+    setState: vi.fn(),
+    subscribe: vi.fn(),
+    destroy: vi.fn(),
+    getInitialState: vi.fn(),
+  } as unknown as StoreApi<AppState>;
+}
+
+function makeMessage(payload: Record<string, unknown>) {
+  return { id: "msg-1", type: "notification", action: "session.state_changed", payload };
+}
+
+describe("session.state_changed handler", () => {
+  let store: ReturnType<typeof makeStore>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handler: (msg: any) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets failure notification on first FAILED event", () => {
+    store = makeStore({
+      taskSessions: {
+        items: { "s-1": { id: "s-1", task_id: "t-1", state: "STARTING" } },
+      },
+    });
+    handler = registerTaskSessionHandlers(store)["session.state_changed"]!;
+
+    handler(
+      makeMessage({
+        task_id: "t-1",
+        session_id: "s-1",
+        new_state: "FAILED",
+        error_message: "container crashed",
+      }),
+    );
+
+    expect(store.getState().setSessionFailureNotification).toHaveBeenCalledWith({
+      sessionId: "s-1",
+      taskId: "t-1",
+      message: "container crashed",
+    });
+  });
+
+  it("does not set failure notification when session is already FAILED", () => {
+    store = makeStore({
+      taskSessions: {
+        items: { "s-1": { id: "s-1", task_id: "t-1", state: "FAILED" } },
+      },
+    });
+    handler = registerTaskSessionHandlers(store)["session.state_changed"]!;
+
+    handler(
+      makeMessage({
+        task_id: "t-1",
+        session_id: "s-1",
+        new_state: "FAILED",
+        error_message: "container crashed",
+      }),
+    );
+
+    expect(store.getState().setSessionFailureNotification).not.toHaveBeenCalled();
+  });
+
+  it("sets failure notification for unknown session (first event)", () => {
+    store = makeStore();
+    handler = registerTaskSessionHandlers(store)["session.state_changed"]!;
+
+    handler(
+      makeMessage({
+        task_id: "t-1",
+        session_id: "s-new",
+        new_state: "FAILED",
+        error_message: "timeout",
+      }),
+    );
+
+    expect(store.getState().setSessionFailureNotification).toHaveBeenCalledWith({
+      sessionId: "s-new",
+      taskId: "t-1",
+      message: "timeout",
+    });
+  });
+
+  it("respects suppress_toast flag", () => {
+    store = makeStore({
+      taskSessions: {
+        items: { "s-1": { id: "s-1", task_id: "t-1", state: "STARTING" } },
+      },
+    });
+    handler = registerTaskSessionHandlers(store)["session.state_changed"]!;
+
+    handler(
+      makeMessage({
+        task_id: "t-1",
+        session_id: "s-1",
+        new_state: "FAILED",
+        error_message: "missing branch",
+        suppress_toast: true,
+      }),
+    );
+
+    expect(store.getState().setSessionFailureNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -162,7 +162,11 @@ export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandle
       upsertTaskSessionList(store, taskId, sessionId, payload, sessionUpdate);
       extractContextWindow(store, sessionId, payload);
 
-      if (newState === "FAILED" && payload.suppress_toast !== true) {
+      if (
+        newState === "FAILED" &&
+        payload.suppress_toast !== true &&
+        existingSession?.state !== "FAILED"
+      ) {
         store.getState().setSessionFailureNotification({
           sessionId,
           taskId,

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -165,7 +165,7 @@ export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandle
       if (
         newState === "FAILED" &&
         payload.suppress_toast !== true &&
-        existingSession?.state !== "FAILED"
+        existingSession?.state !== "FAILED" // replay guard; hook dedup is the second layer
       ) {
         store.getState().setSessionFailureNotification({
           sessionId,


### PR DESCRIPTION
Error toasts like "Failed to start session" kept re-appearing after being dismissed — on window resize, navigation, and even after page refresh — because the WS handler unconditionally set the failure notification whenever it received a FAILED state event, without checking if the session was already known to be failed.

## Important Changes

- **WS handler guard** (`agent-session.ts`): Only set `sessionFailureNotification` when the session's previous state in the store was not already `FAILED`, preventing duplicate/replayed events from re-triggering the toast.
- **Hook dedup** (`use-session-failure-toast.ts`): Track shown session IDs via a ref-backed Set so the same session failure is never toasted twice within a page lifecycle.

## Validation

- `pnpm format` — no changes needed
- `pnpm lint` — passes clean
- `pnpm test` — all 200 tests pass
- `tsc --noEmit` — no new type errors (2 pre-existing unrelated errors)

## Checklist

- [ ] Reviewed my own code
- [ ] Added or updated tests as needed
- [ ] Ran `make fmt`, `make typecheck`, `make test`, `make lint`