### PR TITLE
fix(backend): reject session resume when task is archived

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -104,6 +104,7 @@ type mockAgentManager struct {
 	restartProcessErr   error
 	promptErr           error
 	promptResult        *executor.PromptResult
+	launchAgentFunc     func(context.Context, *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error)
 
 	mu                      sync.Mutex
 	stopAgentWithReasonArgs []stopAgentCall // tracks StopAgentWithReason calls
@@ -129,7 +130,10 @@ type passthroughStdinCall struct {
 	Data      string
 }
 
-func (m *mockAgentManager) LaunchAgent(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+func (m *mockAgentManager) LaunchAgent(ctx context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+	if m.launchAgentFunc != nil {
+		return m.launchAgentFunc(ctx, req)
+	}
 	return nil, nil
 }
 func (m *mockAgentManager) StartAgentProcess(_ context.Context, _ string) error { return nil }

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -60,6 +60,7 @@ var (
 	ErrExecutionNotFound       = errors.New("execution not found")
 	ErrExecutionAlreadyRunning = errors.New("execution already running")
 	ErrNoCloneURL              = errors.New("repository has no clone URL: provider owner and name are required")
+	ErrTaskArchived            = errors.New("task is archived")
 )
 
 // PromptResult contains the result of a prompt operation

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -309,6 +309,10 @@ func (e *Executor) validateAndLockResume(ctx context.Context, session *models.Ta
 			zap.Error(err))
 		return nil, func() {}, err
 	}
+	if taskModel.ArchivedAt != nil {
+		unlock()
+		return nil, func() {}, ErrTaskArchived
+	}
 	task := taskModel.ToAPI()
 	if task == nil {
 		unlock()

--- a/apps/backend/internal/orchestrator/executor/executor_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_test.go
@@ -1,11 +1,48 @@
 package executor
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agent/lifecycle"
 	"github.com/kandev/kandev/internal/task/models"
 )
+
+func TestResumeSession_RejectsArchivedTask(t *testing.T) {
+	repo := newMockRepository()
+	agentMgr := &mockAgentManager{}
+	exec := newTestExecutor(t, agentMgr, repo)
+
+	now := time.Now().UTC()
+	archivedAt := now.Add(-time.Minute)
+
+	repo.tasks["task-1"] = &models.Task{
+		ID:         "task-1",
+		ArchivedAt: &archivedAt,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	repo.sessions["sess-1"] = &models.TaskSession{
+		ID:             "sess-1",
+		TaskID:         "task-1",
+		AgentProfileID: "profile-1",
+		State:          models.TaskSessionStateWaitingForInput,
+	}
+	repo.executorsRunning["sess-1"] = &models.ExecutorRunning{
+		SessionID: "sess-1",
+		TaskID:    "task-1",
+	}
+
+	_, err := exec.ResumeSession(context.Background(), repo.sessions["sess-1"], true)
+	if err == nil {
+		t.Fatal("expected error when task is archived, got nil")
+	}
+	if !errors.Is(err, ErrTaskArchived) {
+		t.Fatalf("expected ErrTaskArchived, got: %v", err)
+	}
+}
 
 func TestBuildExecutorRunning(t *testing.T) {
 	t.Run("basic field mapping", func(t *testing.T) {

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -573,6 +573,16 @@ func (s *Service) ResumeTaskSession(ctx context.Context, taskID, sessionID strin
 				return existing, nil
 			}
 		}
+		// Task was archived while the resume was in flight — return the error
+		// without mutating task/session state (archive already handled cleanup).
+		// Check both the sentinel (early rejection) and re-read the task to catch
+		// the race where archive completed after the executor's archived check.
+		if errors.Is(err, executor.ErrTaskArchived) {
+			return nil, err
+		}
+		if task, taskErr := s.repo.GetTask(ctx, taskID); taskErr == nil && task != nil && task.ArchivedAt != nil {
+			return nil, executor.ErrTaskArchived
+		}
 		s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateFailed, err.Error(), false, session)
 		if stateErr := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateFailed); stateErr != nil {
 			s.logger.Warn("failed to update task state to FAILED after resume error",

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -580,7 +580,7 @@ func (s *Service) ResumeTaskSession(ctx context.Context, taskID, sessionID strin
 		if errors.Is(err, executor.ErrTaskArchived) {
 			return nil, err
 		}
-		if task, taskErr := s.repo.GetTask(ctx, taskID); taskErr == nil && task != nil && task.ArchivedAt != nil {
+		if task, taskErr := s.repo.GetTask(resumeCtx, taskID); taskErr == nil && task != nil && task.ArchivedAt != nil {
 			return nil, executor.ErrTaskArchived
 		}
 		s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateFailed, err.Error(), false, session)

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -433,6 +433,81 @@ func TestResumeTaskSession_NotResumable(t *testing.T) {
 	}
 }
 
+func TestResumeTaskSession_ArchivedTaskSkipsFailedState(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	taskRepo := newMockTaskRepo()
+	agentMgr := &mockAgentManager{}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+
+	// Archive the task after seeding
+	if err := repo.ArchiveTask(ctx, "task1"); err != nil {
+		t.Fatalf("failed to archive task: %v", err)
+	}
+
+	// Insert executor running record so we pass the "not resumable" check
+	now := time.Now().UTC()
+	_ = repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID: "er1", SessionID: "session1", TaskID: "task1",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	_, err := svc.ResumeTaskSession(ctx, "task1", "session1")
+	if !errors.Is(err, executor.ErrTaskArchived) {
+		t.Fatalf("expected ErrTaskArchived, got: %v", err)
+	}
+
+	// Task state should NOT have been updated to FAILED
+	if _, ok := taskRepo.updatedStates["task1"]; ok {
+		t.Error("task state should not be updated when task is archived")
+	}
+}
+
+func TestResumeTaskSession_ArchivedDuringLaunch(t *testing.T) {
+	// Simulates the race: task is NOT archived when the executor checks,
+	// but LaunchAgent fails (archive's async cleanup killed the agent),
+	// and by the time the error path re-reads the task it IS archived.
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	taskRepo := newMockTaskRepo()
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			// Simulate archive completing while launch is in progress:
+			// archive the task, then fail the launch (as if async cleanup killed the process).
+			_ = repo.ArchiveTask(ctx, "task1")
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	now := time.Now().UTC()
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+
+	// Set agent profile ID so the executor doesn't reject the session early
+	session, _ := repo.GetTaskSession(ctx, "session1")
+	session.AgentProfileID = "profile-1"
+	_ = repo.UpdateTaskSession(ctx, session)
+
+	_ = repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID: "er1", SessionID: "session1", TaskID: "task1",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	_, err := svc.ResumeTaskSession(ctx, "task1", "session1")
+	if !errors.Is(err, executor.ErrTaskArchived) {
+		t.Fatalf("expected ErrTaskArchived, got: %v", err)
+	}
+
+	// Task state should NOT have been updated to FAILED
+	if _, ok := taskRepo.updatedStates["task1"]; ok {
+		t.Error("task state should not be updated when task is archived during launch")
+	}
+}
+
 // --- CompleteTask ---
 
 func TestCompleteTask_UpdatesTaskState(t *testing.T) {


### PR DESCRIPTION
Archiving a task while its agent session was resuming caused a race condition: the resume would proceed past validation, but the archive's async cleanup would kill the agent mid-flight, producing an ACP session error toast. This adds an archived-task guard at two levels to eliminate the race window entirely.

## Important Changes

- `executor_resume.go`: early gate in `validateAndLockResume` rejects resume if `ArchivedAt` is set
- `task_operations.go`: late catch re-reads the task on any resume failure; if archived in the meantime, returns `ErrTaskArchived` instead of marking the task as FAILED

## Validation

- `go test -run TestResumeSession_RejectsArchivedTask ./internal/orchestrator/executor/`
- `go test -run TestResumeTaskSession ./internal/orchestrator/`
- `make -C apps/backend fmt test lint` (all pass, 0 issues)

## Checklist

- [ ] Tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or discussed with team)