### PR TITLE
fix: skip ExtraFiles liveness pipe on Windows to fix agentctl startup

### DIFF
--- a/apps/backend/internal/agentctl/client/launcher/launcher.go
+++ b/apps/backend/internal/agentctl/client/launcher/launcher.go
@@ -151,16 +151,14 @@ func (l *Launcher) Start(ctx context.Context) error {
 	// - Pdeathsig on Linux: kernel sends SIGTERM to child when parent dies.
 	l.cmd.SysProcAttr = buildSysProcAttr()
 
-	// Parent liveness pipe: agentctl inherits the read-end (FD 3 via ExtraFiles)
-	// and blocks on it. When this process dies — even via SIGKILL — the kernel
-	// closes the write-end, breaking the pipe. agentctl detects the break and
-	// initiates graceful shutdown. This is the portable equivalent of Pdeathsig.
-	pipeRead, pipeWrite, err := os.Pipe()
+	// Parent liveness pipe (Unix only): agentctl inherits the read-end via
+	// ExtraFiles and blocks on it. When the parent dies the kernel closes the
+	// write-end, signaling agentctl to shut down. On Windows this is a no-op
+	// because ExtraFiles is not supported; cleanup relies on gracefulStop.
+	pipeWrite, err := setupLivenessPipe(l.cmd)
 	if err != nil {
-		return fmt.Errorf("failed to create parent liveness pipe: %w", err)
+		return err
 	}
-	l.cmd.ExtraFiles = []*os.File{pipeRead} // child FD 3
-	l.cmd.Env = append(l.cmd.Env, "KANDEV_PARENT_PIPE_FD=3")
 
 	// Capture stdout and stderr
 	stdout, err := l.cmd.StdoutPipe()
@@ -174,14 +172,13 @@ func (l *Launcher) Start(ctx context.Context) error {
 
 	// Start the process
 	if err := l.cmd.Start(); err != nil {
-		_ = pipeRead.Close()
-		_ = pipeWrite.Close()
+		closePipeOnStartFailure(pipeWrite, l.cmd)
 		return fmt.Errorf("failed to start agentctl: %w", err)
 	}
 
 	// Close read-end in parent (child inherited it). Keep write-end open —
 	// it closes automatically when this process exits, signaling agentctl.
-	_ = pipeRead.Close()
+	closeChildPipeEnd(l.cmd)
 	l.parentPipe = pipeWrite
 
 	l.logger.Info("agentctl process started", zap.Int("pid", l.cmd.Process.Pid))

--- a/apps/backend/internal/agentctl/client/launcher/launcher.go
+++ b/apps/backend/internal/agentctl/client/launcher/launcher.go
@@ -178,6 +178,7 @@ func (l *Launcher) Start(ctx context.Context) error {
 
 	// Close read-end in parent (child inherited it). Keep write-end open —
 	// it closes automatically when this process exits, signaling agentctl.
+	// On Windows these are no-ops (no liveness pipe); parentPipe stays nil.
 	closeChildPipeEnd(l.cmd)
 	l.parentPipe = pipeWrite
 

--- a/apps/backend/internal/agentctl/client/launcher/launcher_pipe_unix.go
+++ b/apps/backend/internal/agentctl/client/launcher/launcher_pipe_unix.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package launcher
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// setupLivenessPipe creates a pipe and configures the command to pass the
+// read-end to the child via ExtraFiles (FD 3). The child monitors this pipe;
+// when the parent dies the kernel closes the write-end, breaking the pipe and
+// signaling the child to shut down. Returns the write-end (caller must keep it
+// open) or an error.
+func setupLivenessPipe(cmd *exec.Cmd) (*os.File, error) {
+	pipeRead, pipeWrite, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create parent liveness pipe: %w", err)
+	}
+
+	cmd.ExtraFiles = []*os.File{pipeRead} // child FD 3
+	cmd.Env = append(cmd.Env, "KANDEV_PARENT_PIPE_FD=3")
+
+	return pipeWrite, nil
+}
+
+// closePipeOnStartFailure cleans up both pipe ends when cmd.Start fails.
+func closePipeOnStartFailure(pipeWrite *os.File, cmd *exec.Cmd) {
+	if pipeWrite != nil {
+		_ = pipeWrite.Close()
+	}
+	if len(cmd.ExtraFiles) > 0 {
+		_ = cmd.ExtraFiles[0].Close()
+	}
+}
+
+// closeChildPipeEnd closes the read-end of the pipe in the parent process
+// after the child has inherited it.
+func closeChildPipeEnd(cmd *exec.Cmd) {
+	if len(cmd.ExtraFiles) > 0 {
+		_ = cmd.ExtraFiles[0].Close()
+	}
+}

--- a/apps/backend/internal/agentctl/client/launcher/launcher_pipe_unix_test.go
+++ b/apps/backend/internal/agentctl/client/launcher/launcher_pipe_unix_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package launcher
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSetupLivenessPipe_SetsExtraFiles(t *testing.T) {
+	cmd := exec.Command("true")
+	cmd.Env = []string{}
+
+	pipeWrite, err := setupLivenessPipe(cmd)
+	if err != nil {
+		t.Fatalf("setupLivenessPipe: %v", err)
+	}
+	defer func() { _ = pipeWrite.Close() }()
+
+	if pipeWrite == nil {
+		t.Fatal("expected non-nil write-end")
+	}
+	if len(cmd.ExtraFiles) != 1 {
+		t.Fatalf("expected 1 ExtraFile, got %d", len(cmd.ExtraFiles))
+	}
+	defer func() { _ = cmd.ExtraFiles[0].Close() }()
+
+	found := false
+	for _, env := range cmd.Env {
+		if strings.HasPrefix(env, "KANDEV_PARENT_PIPE_FD=") {
+			found = true
+			if env != "KANDEV_PARENT_PIPE_FD=3" {
+				t.Errorf("expected KANDEV_PARENT_PIPE_FD=3, got %s", env)
+			}
+		}
+	}
+	if !found {
+		t.Error("KANDEV_PARENT_PIPE_FD not set in cmd.Env")
+	}
+}
+
+func TestSetupLivenessPipe_PipeIsReadable(t *testing.T) {
+	cmd := exec.Command("true")
+	cmd.Env = []string{}
+
+	pipeWrite, err := setupLivenessPipe(cmd)
+	if err != nil {
+		t.Fatalf("setupLivenessPipe: %v", err)
+	}
+
+	pipeRead := cmd.ExtraFiles[0]
+
+	// Close write-end; read should return immediately (EOF).
+	_ = pipeWrite.Close()
+
+	buf := make([]byte, 1)
+	_, err = pipeRead.Read(buf)
+	_ = pipeRead.Close()
+	if err == nil {
+		t.Error("expected error (EOF) after closing write-end")
+	}
+}

--- a/apps/backend/internal/agentctl/client/launcher/launcher_pipe_windows.go
+++ b/apps/backend/internal/agentctl/client/launcher/launcher_pipe_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package launcher
+
+import (
+	"os"
+	"os/exec"
+)
+
+// setupLivenessPipe is a no-op on Windows. ExtraFiles is not supported by
+// Go's Windows process creation. The agentctl child handles the missing
+// KANDEV_PARENT_PIPE_FD env var gracefully (monitorParentLiveness returns nil).
+// On Windows, process cleanup relies on gracefulStop (CTRL_BREAK_EVENT).
+func setupLivenessPipe(_ *exec.Cmd) (*os.File, error) {
+	return nil, nil
+}
+
+// closePipeOnStartFailure is a no-op on Windows (no pipe to clean up).
+func closePipeOnStartFailure(_ *os.File, _ *exec.Cmd) {}
+
+// closeChildPipeEnd is a no-op on Windows (no pipe to close).
+func closeChildPipeEnd(_ *exec.Cmd) {}

--- a/apps/backend/internal/agentctl/client/launcher/launcher_pipe_windows_test.go
+++ b/apps/backend/internal/agentctl/client/launcher/launcher_pipe_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package launcher
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestSetupLivenessPipe_NoopOnWindows(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "echo", "test")
+	cmd.Env = []string{}
+
+	pipeWrite, err := setupLivenessPipe(cmd)
+	if err != nil {
+		t.Fatalf("setupLivenessPipe: %v", err)
+	}
+	if pipeWrite != nil {
+		t.Error("expected nil write-end on Windows")
+	}
+	if len(cmd.ExtraFiles) != 0 {
+		t.Errorf("expected no ExtraFiles on Windows, got %d", len(cmd.ExtraFiles))
+	}
+}

--- a/apps/backend/internal/agentctl/client/launcher/launcher_test.go
+++ b/apps/backend/internal/agentctl/client/launcher/launcher_test.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package launcher
 
 import (


### PR DESCRIPTION
Kandev fails to start on native Windows because `launcher.go` unconditionally uses `cmd.ExtraFiles` to pass a parent liveness pipe to agentctl. Go's `syscall.StartProcess` on Windows does not support `ExtraFiles`, returning `EWINDOWS` ("not supported by windows") and preventing agentctl from ever starting.

This extracts the pipe setup into platform-specific files using build tags: Unix continues using `ExtraFiles` as before, while Windows skips it entirely. The agentctl child already handles the missing `KANDEV_PARENT_PIPE_FD` env var gracefully, and Windows shutdown relies on `CTRL_BREAK_EVENT` via `gracefulStop()`.

## Important Changes

- New `launcher_pipe_unix.go` / `launcher_pipe_windows.go` with build tags for platform-specific liveness pipe setup
- Removed `//go:build !windows` from `launcher_test.go` since `closeParentPipe` tests are cross-platform

## Validation

- `make -C apps/backend test` -- all pass including new pipe tests
- `make -C apps/backend lint` -- clean
- `GOOS=windows go vet ./internal/agentctl/client/launcher/...` -- Windows cross-compilation verified
- `pnpm --filter @kandev/web lint` -- clean

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of the code has been performed
- [ ] Tests have been added/updated for the changes
- [ ] Documentation has been updated (if applicable)

Closes #468