### PR TITLE
fix: improve plan comment formatting to match code review style

### DIFF
--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -43,10 +43,7 @@ function buildSubmitMessage(
   }
   if (planComments.length > 0) {
     const planMarkdown = formatPlanCommentsAsMarkdown(planComments);
-    const header = "### Plan Comments\n\n";
-    finalMessage = finalMessage
-      ? `${header}${planMarkdown}\n\n---\n\n${finalMessage}`
-      : `${header}${planMarkdown}`;
+    finalMessage = finalMessage ? `${planMarkdown}${finalMessage}` : planMarkdown;
   }
   return finalMessage;
 }

--- a/apps/web/e2e/tests/task/plan-mode-followup.spec.ts
+++ b/apps/web/e2e/tests/task/plan-mode-followup.spec.ts
@@ -165,7 +165,7 @@ test.describe("Plan mode follow-up messages", () => {
     await runBtn.click();
 
     // The comment should appear in the chat formatted as plan comment markdown.
-    await expect(session.chat.getByText("Comment 1:", { exact: false })).toBeVisible({
+    await expect(session.chat.getByText("Plan Comments", { exact: false })).toBeVisible({
       timeout: 15_000,
     });
     await expect(

--- a/apps/web/hooks/use-message-handler.ts
+++ b/apps/web/hooks/use-message-handler.ts
@@ -4,6 +4,7 @@ import { useQueue } from "./domains/session/use-queue";
 import type { MessageAttachment } from "@/components/task/chat/chat-input-container";
 import type { ActiveDocument } from "@/lib/state/slices/ui/types";
 import type { PlanComment } from "@/lib/state/slices/comments";
+import { toBlockquote } from "@/lib/state/slices/comments/format";
 import type { ContextFile } from "@/lib/state/context-files-store";
 import type { CustomPrompt } from "@/lib/types/http";
 
@@ -25,12 +26,7 @@ function buildDocumentContext(
         if (c.selectedText) {
           context += "```\n" + c.selectedText + "\n```\n";
         }
-        // Handle multiline text by prefixing each line with >
-        const blockquote = c.text
-          .split("\n")
-          .map((line) => `> ${line}`)
-          .join("\n");
-        context += blockquote + "\n\n";
+        context += toBlockquote(c.text) + "\n\n";
       }
     }
 

--- a/apps/web/hooks/use-message-handler.ts
+++ b/apps/web/hooks/use-message-handler.ts
@@ -25,7 +25,12 @@ function buildDocumentContext(
         if (c.selectedText) {
           context += "```\n" + c.selectedText + "\n```\n";
         }
-        context += `> ${c.text}\n\n`;
+        // Handle multiline text by prefixing each line with >
+        const blockquote = c.text
+          .split("\n")
+          .map((line) => `> ${line}`)
+          .join("\n");
+        context += blockquote + "\n\n";
       }
     }
 

--- a/apps/web/hooks/use-message-handler.ts
+++ b/apps/web/hooks/use-message-handler.ts
@@ -20,10 +20,13 @@ function buildDocumentContext(
     let context = `\n\n<kandev-system>\nACTIVE DOCUMENT: The user is editing the task plan side-by-side with this chat.\nRead the current plan using the plan_get MCP tool to understand the context before responding.\nAny plan modifications should use the plan_update MCP tool.`;
 
     if (planComments && planComments.length > 0) {
-      context += `\n\nUser comments on the plan:`;
-      planComments.forEach((c, i) => {
-        context += `\nComment ${i + 1}:\n- Selected text: "${c.selectedText}"\n- Comment: "${c.text}"`;
-      });
+      context += `\n\nUser comments on the plan:\n`;
+      for (const c of planComments) {
+        if (c.selectedText) {
+          context += "```\n" + c.selectedText + "\n```\n";
+        }
+        context += `> ${c.text}\n\n`;
+      }
     }
 
     context += `\n</kandev-system>`;

--- a/apps/web/lib/state/slices/comments/format.test.ts
+++ b/apps/web/lib/state/slices/comments/format.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatPlanCommentsAsMarkdown,
+  formatReviewCommentsAsMarkdown,
+  formatPRFeedbackAsMarkdown,
+  formatCommentsForMessage,
+} from "./format";
+import type { PlanComment, DiffComment, PRFeedbackComment } from "./types";
+
+function makePlanComment(overrides: Partial<PlanComment> = {}): PlanComment {
+  return {
+    id: "plan-1",
+    sessionId: "sess-1",
+    source: "plan",
+    text: "fix this",
+    selectedText: "some code",
+    createdAt: new Date().toISOString(),
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("formatPlanCommentsAsMarkdown", () => {
+  it("returns empty string for empty input", () => {
+    expect(formatPlanCommentsAsMarkdown([])).toBe("");
+    expect(formatPlanCommentsAsMarkdown(null as unknown as PlanComment[])).toBe("");
+    expect(formatPlanCommentsAsMarkdown(undefined as unknown as PlanComment[])).toBe("");
+  });
+
+  it("formats comment with selected text", () => {
+    const comments = [makePlanComment({ selectedText: "const x = 1;", text: "rename variable" })];
+    const result = formatPlanCommentsAsMarkdown(comments);
+
+    expect(result).toContain("### Plan Comments");
+    expect(result).toContain("```\nconst x = 1;\n```");
+    expect(result).toContain("> rename variable");
+    expect(result).toContain("---");
+  });
+
+  it("formats comment without selected text", () => {
+    const comments = [makePlanComment({ selectedText: "", text: "general feedback" })];
+    const result = formatPlanCommentsAsMarkdown(comments);
+
+    expect(result).toContain("### Plan Comments");
+    expect(result).not.toContain("```\n\n```"); // No empty code block
+    expect(result).toContain("> general feedback");
+  });
+
+  it("formats multiple comments", () => {
+    const comments = [
+      makePlanComment({ selectedText: "code1", text: "comment1" }),
+      makePlanComment({ id: "plan-2", selectedText: "code2", text: "comment2" }),
+    ];
+    const result = formatPlanCommentsAsMarkdown(comments);
+
+    expect(result).toContain("```\ncode1\n```");
+    expect(result).toContain("> comment1");
+    expect(result).toContain("```\ncode2\n```");
+    expect(result).toContain("> comment2");
+  });
+
+  it("handles multiline comment text with blockquotes", () => {
+    const comments = [makePlanComment({ text: "line one\nline two\nline three" })];
+    const result = formatPlanCommentsAsMarkdown(comments);
+
+    expect(result).toContain("> line one\n> line two\n> line three");
+  });
+
+  it("includes header and separator", () => {
+    const comments = [makePlanComment()];
+    const result = formatPlanCommentsAsMarkdown(comments);
+
+    expect(result.startsWith("### Plan Comments\n")).toBe(true);
+    expect(result).toContain("\n---\n");
+  });
+});
+
+describe("formatReviewCommentsAsMarkdown", () => {
+  function makeDiffComment(overrides: Partial<DiffComment> = {}): DiffComment {
+    return {
+      id: "diff-1",
+      sessionId: "sess-1",
+      source: "diff",
+      filePath: "src/app.ts",
+      startLine: 10,
+      endLine: 12,
+      side: "additions",
+      codeContent: "const x = 1;",
+      text: "fix this",
+      createdAt: new Date().toISOString(),
+      status: "pending",
+      ...overrides,
+    };
+  }
+
+  it("returns empty string for empty input", () => {
+    expect(formatReviewCommentsAsMarkdown([])).toBe("");
+  });
+
+  it("formats single comment", () => {
+    const result = formatReviewCommentsAsMarkdown([makeDiffComment()]);
+
+    expect(result).toContain("### Review Comments");
+    expect(result).toContain("**src/app.ts:10-12**");
+    expect(result).toContain("```\nconst x = 1;\n```");
+    expect(result).toContain("> fix this");
+  });
+
+  it("formats same-line range", () => {
+    const result = formatReviewCommentsAsMarkdown([makeDiffComment({ startLine: 5, endLine: 5 })]);
+    expect(result).toContain("**src/app.ts:5**");
+  });
+});
+
+describe("formatPRFeedbackAsMarkdown", () => {
+  function makePRFeedback(overrides: Partial<PRFeedbackComment> = {}): PRFeedbackComment {
+    return {
+      id: "pr-1",
+      sessionId: "sess-1",
+      source: "pr-feedback",
+      text: "",
+      prNumber: 123,
+      feedbackType: "review",
+      content: "Please fix the failing tests",
+      createdAt: new Date().toISOString(),
+      status: "pending",
+      ...overrides,
+    };
+  }
+
+  it("returns empty string for empty input", () => {
+    expect(formatPRFeedbackAsMarkdown([])).toBe("");
+  });
+
+  it("formats PR feedback", () => {
+    const result = formatPRFeedbackAsMarkdown([makePRFeedback()]);
+
+    expect(result).toContain("### PR Feedback");
+    expect(result).toContain("Please fix the failing tests");
+    expect(result).toContain("---");
+  });
+});
+
+describe("formatCommentsForMessage", () => {
+  it("separates comments by type", () => {
+    const diff: DiffComment = {
+      id: "d1",
+      sessionId: "s",
+      source: "diff",
+      filePath: "f.ts",
+      startLine: 1,
+      endLine: 1,
+      side: "additions",
+      codeContent: "code",
+      text: "fix",
+      createdAt: "",
+      status: "pending",
+    };
+    const plan: PlanComment = {
+      id: "p1",
+      sessionId: "s",
+      source: "plan",
+      selectedText: "text",
+      text: "comment",
+      createdAt: "",
+      status: "pending",
+    };
+
+    const result = formatCommentsForMessage([diff, plan]);
+
+    expect(result.diffComments).toHaveLength(1);
+    expect(result.planComments).toHaveLength(1);
+    expect(result.prFeedbackComments).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/state/slices/comments/format.ts
+++ b/apps/web/lib/state/slices/comments/format.ts
@@ -39,17 +39,25 @@ export function formatReviewCommentsAsMarkdown(comments: DiffComment[]): string 
 
 /**
  * Format plan comments as markdown for sending to agent.
+ * Uses the same style as code review comments: code block for selected text + blockquote for comment.
  */
 export function formatPlanCommentsAsMarkdown(comments: PlanComment[]): string {
   if (!comments || comments.length === 0) return "";
 
-  const lines: string[] = [];
-  for (let i = 0; i < comments.length; i++) {
-    const c = comments[i];
-    lines.push(`Comment ${i + 1}:`);
-    lines.push(`- Selected text: "${c.selectedText}"`);
-    lines.push(`- Comment: "${c.text}"`);
+  const lines: string[] = ["### Plan Comments", ""];
+
+  for (const c of comments) {
+    if (c.selectedText) {
+      lines.push("```");
+      lines.push(c.selectedText);
+      lines.push("```");
+    }
+    lines.push(`> ${c.text}`);
+    lines.push("");
   }
+
+  lines.push("---");
+  lines.push("");
   return lines.join("\n");
 }
 

--- a/apps/web/lib/state/slices/comments/format.ts
+++ b/apps/web/lib/state/slices/comments/format.ts
@@ -37,6 +37,14 @@ export function formatReviewCommentsAsMarkdown(comments: DiffComment[]): string 
   return lines.join("\n");
 }
 
+/** Convert text to blockquote, handling multiline text properly. */
+function toBlockquote(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
 /**
  * Format plan comments as markdown for sending to agent.
  * Uses the same style as code review comments: code block for selected text + blockquote for comment.
@@ -52,7 +60,7 @@ export function formatPlanCommentsAsMarkdown(comments: PlanComment[]): string {
       lines.push(c.selectedText);
       lines.push("```");
     }
-    lines.push(`> ${c.text}`);
+    lines.push(toBlockquote(c.text));
     lines.push("");
   }
 

--- a/apps/web/lib/state/slices/comments/format.ts
+++ b/apps/web/lib/state/slices/comments/format.ts
@@ -38,7 +38,7 @@ export function formatReviewCommentsAsMarkdown(comments: DiffComment[]): string 
 }
 
 /** Convert text to blockquote, handling multiline text properly. */
-function toBlockquote(text: string): string {
+export function toBlockquote(text: string): string {
   return text
     .split("\n")
     .map((line) => `> ${line}`)


### PR DESCRIPTION
## Summary

Fixes poor formatting of plan comments when translated to agent messages. Previously plan comments used ugly bullet-style formatting with inline quotes. Now they use the same clean formatting as code review comments with code blocks for selected text and blockquotes for the comment.

## Changes

- **`apps/web/lib/state/slices/comments/format.ts`**: Updated `formatPlanCommentsAsMarkdown()` to use code blocks for selected text and blockquotes for comment text
- **`apps/web/hooks/use-message-handler.ts`**: Updated `buildDocumentContext()` with consistent formatting
- **`apps/web/components/task/chat/chat-input-area.tsx`**: Removed duplicate header that was causing "### Plan Comments" to appear twice

## Testing

Manual testing - plan comments now display cleanly without duplicate headers or separators.
