### PR TITLE
fix(web): align top-bar right button heights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ normalized-*.jsonl
 # Serena MCP
 .serena/*
 .gitnexus
+
+# playwright-cli snapshots/console logs
+.playwright-cli/

--- a/apps/web/components/task/quick-chat-button.tsx
+++ b/apps/web/components/task/quick-chat-button.tsx
@@ -18,7 +18,7 @@ export function QuickChatButton({ workspaceId }: { workspaceId?: string | null }
   return (
     <KeyboardShortcutTooltip shortcut={quickChatShortcut} description="Quick Chat">
       <Button
-        size="icon"
+        size="icon-sm"
         variant="outline"
         className="cursor-pointer"
         onClick={handleOpenQuickChat}


### PR DESCRIPTION
The QuickChatButton on the task details top-bar used `size="icon"` (28px) while sibling buttons used `size="sm"` (24px), making the message-bubble button visibly taller than the Commit, Layout, Editors, and Settings buttons. Switched to `size="icon-sm"` so all top-bar right buttons render at a consistent 24px height.

## Validation

- `pnpm --filter @kandev/web lint` — 0 warnings
- Verified live with playwright-cli against a dev server: all 7 button elements in `header` on the task details page now measure 24px (`allSame: true`). The previously taller QuickChatButton is now flush with the rest.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.