### PR TITLE
feat(web): render short tool-call output inline

### DIFF
--- a/apps/web/components/task/chat/messages/tool-call-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-call-message.tsx
@@ -149,7 +149,9 @@ const INLINE_OUTPUT_MAX_LENGTH = 120;
 function getInlineOutput(output: unknown): string | null {
   if (typeof output !== "string") return null;
   const trimmed = output.trim();
-  if (!trimmed || trimmed.includes("\n") || trimmed.length > INLINE_OUTPUT_MAX_LENGTH) return null;
+  // Reject both \n and \r — shell tool output can carry \r progress-bar overwrites
+  // that would render as multiple visual lines even without a \n.
+  if (!trimmed || /[\n\r]/.test(trimmed) || trimmed.length > INLINE_OUTPUT_MAX_LENGTH) return null;
   return trimmed;
 }
 

--- a/apps/web/components/task/chat/messages/tool-call-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-call-message.tsx
@@ -142,6 +142,17 @@ function parseToolCallOutput(metadata: ToolCallMetadata | undefined) {
   return { output, isHttpError };
 }
 
+// Short, single-line tool output renders inline in the header (e.g. "Launching skill: e2e")
+// rather than behind an expand chevron.
+const INLINE_OUTPUT_MAX_LENGTH = 120;
+
+function getInlineOutput(output: unknown): string | null {
+  if (typeof output !== "string") return null;
+  const trimmed = output.trim();
+  if (!trimmed || trimmed.includes("\n") || trimmed.length > INLINE_OUTPUT_MAX_LENGTH) return null;
+  return trimmed;
+}
+
 function parseToolCallMetadata(comment: Message, permissionMessage: Message | undefined) {
   const metadata = comment.metadata as ToolCallMetadata | undefined;
   const toolName = metadata?.tool_name ?? "";
@@ -150,7 +161,10 @@ function parseToolCallMetadata(comment: Message, permissionMessage: Message | un
   const { permissionMetadata, permissionStatus, isPermissionPending } =
     parsePermission(permissionMessage);
   const hasOutput = hasToolOutput(output);
-  const hasExpandableContent = hasOutput || isPermissionPending;
+  const inlineOutput = getInlineOutput(output);
+  // When output is shown inline, there's nothing more to expand — skip the expand affordance
+  // unless a permission prompt still needs to be rendered.
+  const hasExpandableContent = (hasOutput && !inlineOutput) || isPermissionPending;
   const isSuccess = status === "complete" && !permissionStatus;
   return {
     toolName,
@@ -162,6 +176,7 @@ function parseToolCallMetadata(comment: Message, permissionMessage: Message | un
     isPermissionPending,
     hasOutput,
     hasExpandableContent,
+    inlineOutput,
     isSuccess,
   };
 }
@@ -238,6 +253,7 @@ export const ToolCallMessage = memo(function ToolCallMessage({
     isPermissionPending,
     hasOutput,
     hasExpandableContent,
+    inlineOutput,
     isSuccess,
   } = parseToolCallMetadata(comment, permissionMessage);
   const { isResponding, handleApprove, handleReject } = usePermissionResponseHandlers({
@@ -271,6 +287,9 @@ export const ToolCallMessage = memo(function ToolCallMessage({
             )}
           >
             <span className="font-mono text-xs text-muted-foreground">{title}</span>
+            {inlineOutput && (
+              <span className="text-xs text-muted-foreground/80">{inlineOutput}</span>
+            )}
             {!isSuccess && getToolCallStatusIcon(status, permissionStatus)}
           </span>
         </div>

--- a/apps/web/components/task/chat/messages/tool-call-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-call-message.tsx
@@ -290,7 +290,14 @@ export const ToolCallMessage = memo(function ToolCallMessage({
           >
             <span className="font-mono text-xs text-muted-foreground">{title}</span>
             {inlineOutput && (
-              <span className="text-xs text-muted-foreground/80">{inlineOutput}</span>
+              <span
+                className={cn(
+                  "text-xs",
+                  isHttpError ? "text-red-600 dark:text-red-400" : "text-muted-foreground/80",
+                )}
+              >
+                {inlineOutput}
+              </span>
             )}
             {!isSuccess && getToolCallStatusIcon(status, permissionStatus)}
           </span>

--- a/apps/web/components/task/chat/messages/tool-call-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-call-message.tsx
@@ -269,7 +269,7 @@ export const ToolCallMessage = memo(function ToolCallMessage({
   const rawTitle = metadata?.title ?? comment.content ?? "Tool call";
   const title = transformPathsInText(rawTitle, worktreePath);
 
-  const formattedOutput = hasOutput ? formatToolOutput(output) : null;
+  const formattedOutput = hasOutput && !inlineOutput ? formatToolOutput(output) : null;
 
   return (
     <ExpandableRow


### PR DESCRIPTION
Short tool-call output (e.g. "Launching skill: e2e") previously required clicking the row to expand — a wasted extra interaction for content that fits on one line. Single-line outputs up to 120 chars now render inline next to the tool title, matching the existing `ThinkingMessage` pattern.

## Validation

- `pnpm --filter @kandev/web lint --max-warnings 0`
- `pnpm exec tsc --noEmit`
- Manual check of the diff against the `ThinkingMessage` inline-short-text behavior

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.