### PR TITLE
fix(github): prevent duplicate review tasks via atomic PR reservation

### DIFF
--- a/apps/backend/internal/github/review_pr_task_test.go
+++ b/apps/backend/internal/github/review_pr_task_test.go
@@ -6,6 +6,17 @@ import (
 	"testing"
 )
 
+// recordingTaskDeleter records DeleteTask calls so tests can assert that
+// the cleanup path with an empty task_id never invokes the deleter.
+type recordingTaskDeleter struct {
+	calls []string
+}
+
+func (r *recordingTaskDeleter) DeleteTask(_ context.Context, taskID string) error {
+	r.calls = append(r.calls, taskID)
+	return nil
+}
+
 // TestReserveReviewPRTask_AtomicUnderConcurrency verifies that when N goroutines
 // race to reserve the same (watch_id, repo, pr_number), exactly one wins.
 // This is the core invariant that prevents duplicate review tasks from being
@@ -165,5 +176,118 @@ func TestAssignReviewPRTaskID_UpdatesTaskID(t *testing.T) {
 	}
 	if records[0].TaskID != "task-xyz" {
 		t.Errorf("TaskID = %q, want %q", records[0].TaskID, "task-xyz")
+	}
+}
+
+// TestAssignReviewPRTaskID_ErrorsWhenNoReservation surfaces the narrow race
+// where the dedup row was removed between Reserve and Assign (e.g. by a
+// concurrent cleanup sweep). Silent no-op would leak the task with no dedup
+// record, so we require an error.
+func TestAssignReviewPRTaskID_ErrorsWhenNoReservation(t *testing.T) {
+	_, store, _ := setupSyncTest(t)
+	ctx := context.Background()
+
+	watch := &ReviewWatch{WorkspaceID: "ws-1", Enabled: true}
+	if err := store.CreateReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("CreateReviewWatch: %v", err)
+	}
+
+	// No reservation was made — Assign must return an error, not silently no-op.
+	err := store.AssignReviewPRTaskID(ctx, watch.ID, "acme", "widget", 42, "task-xyz")
+	if err == nil {
+		t.Fatal("expected error when no reservation exists, got nil")
+	}
+}
+
+// TestCleanupMergedReviewTasks_OrphanReservation verifies that an orphan
+// reservation row (empty task_id — process was killed between Reserve and
+// Assign) is cleaned up when the PR reaches a terminal state, WITHOUT
+// calling DeleteTask(""). The previous code relied on DeleteTask("")
+// returning a "not found"-shaped error, which was fragile.
+func TestCleanupMergedReviewTasks_OrphanReservation(t *testing.T) {
+	_, svc, mockClient, store := setupPollerTest(t)
+	ctx := context.Background()
+
+	watch := &ReviewWatch{WorkspaceID: "ws-1", Enabled: true}
+	if err := store.CreateReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("CreateReviewWatch: %v", err)
+	}
+
+	// Simulate a crash between Reserve and Assign: a reservation row exists
+	// with empty task_id.
+	if _, err := store.ReserveReviewPRTask(
+		ctx, watch.ID, "acme", "widget", 42,
+		"https://github.com/acme/widget/pull/42",
+	); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+
+	// PR is merged so cleanup is triggered.
+	mockClient.AddPR(&PR{Number: 42, State: prStateMerged, RepoOwner: "acme", RepoName: "widget"})
+
+	// Recording deleter: DeleteTask must NOT be called for the orphan row.
+	rec := &recordingTaskDeleter{}
+	svc.SetTaskDeleter(rec)
+
+	deleted, err := svc.CleanupMergedReviewTasks(ctx, watch)
+	if err != nil {
+		t.Fatalf("CleanupMergedReviewTasks: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected DeleteTask NOT to be called for orphan reservation, got calls=%v", rec.calls)
+	}
+
+	// The orphan dedup row must be gone.
+	remaining, err := store.ListReviewPRTasksByWatch(ctx, watch.ID)
+	if err != nil {
+		t.Fatalf("ListReviewPRTasksByWatch: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("expected 0 remaining rows, got %d", len(remaining))
+	}
+}
+
+// TestCleanupMergedReviewTasks_OrphanReservationKeptWhilePROpen ensures the
+// orphan row is retained while the PR is still open, so a subsequent poller
+// tick can retry the task creation (by first releasing, then reserving again).
+func TestCleanupMergedReviewTasks_OrphanReservationKeptWhilePROpen(t *testing.T) {
+	_, svc, mockClient, store := setupPollerTest(t)
+	ctx := context.Background()
+
+	watch := &ReviewWatch{WorkspaceID: "ws-1", Enabled: true}
+	if err := store.CreateReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("CreateReviewWatch: %v", err)
+	}
+
+	if _, err := store.ReserveReviewPRTask(
+		ctx, watch.ID, "acme", "widget", 42,
+		"https://github.com/acme/widget/pull/42",
+	); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+
+	// PR is still open — cleanup should NOT remove this row.
+	mockClient.AddPR(&PR{Number: 42, State: "open", RepoOwner: "acme", RepoName: "widget"})
+
+	rec := &recordingTaskDeleter{}
+	svc.SetTaskDeleter(rec)
+
+	deleted, err := svc.CleanupMergedReviewTasks(ctx, watch)
+	if err != nil {
+		t.Fatalf("CleanupMergedReviewTasks: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 deleted while PR open, got %d", deleted)
+	}
+
+	remaining, err := store.ListReviewPRTasksByWatch(ctx, watch.ID)
+	if err != nil {
+		t.Fatalf("ListReviewPRTasksByWatch: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("expected 1 row retained while PR open, got %d", len(remaining))
 	}
 }

--- a/apps/backend/internal/github/review_pr_task_test.go
+++ b/apps/backend/internal/github/review_pr_task_test.go
@@ -1,0 +1,169 @@
+package github
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestReserveReviewPRTask_AtomicUnderConcurrency verifies that when N goroutines
+// race to reserve the same (watch_id, repo, pr_number), exactly one wins.
+// This is the core invariant that prevents duplicate review tasks from being
+// created: the reservation must be atomic BEFORE the slow task-creation work.
+func TestReserveReviewPRTask_AtomicUnderConcurrency(t *testing.T) {
+	_, store, _ := setupSyncTest(t)
+	ctx := context.Background()
+
+	watch := &ReviewWatch{WorkspaceID: "ws-1", Enabled: true}
+	if err := store.CreateReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("CreateReviewWatch: %v", err)
+	}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var wins int
+	var errs []error
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			reserved, err := store.ReserveReviewPRTask(
+				ctx, watch.ID, "acme", "widget", 42,
+				"https://github.com/acme/widget/pull/42",
+			)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+				return
+			}
+			if reserved {
+				wins++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors from concurrent Reserve: %v", errs)
+	}
+	if wins != 1 {
+		t.Errorf("expected exactly 1 reservation to win, got %d", wins)
+	}
+
+	// The dedup row must exist exactly once.
+	records, err := store.ListReviewPRTasksByWatch(ctx, watch.ID)
+	if err != nil {
+		t.Fatalf("ListReviewPRTasksByWatch: %v", err)
+	}
+	if len(records) != 1 {
+		t.Errorf("expected 1 dedup record, got %d", len(records))
+	}
+}
+
+// TestReserveReviewPRTask_ReturnsFalseWhenAlreadyReserved verifies that a
+// second reservation for the same PR returns (false, nil) rather than an
+// error, so callers can treat it as a signal to bail out.
+func TestReserveReviewPRTask_ReturnsFalseWhenAlreadyReserved(t *testing.T) {
+	_, store, _ := setupSyncTest(t)
+	ctx := context.Background()
+
+	watch := &ReviewWatch{WorkspaceID: "ws-1", Enabled: true}
+	if err := store.CreateReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("CreateReviewWatch: %v", err)
+	}
+
+	first, err := store.ReserveReviewPRTask(
+		ctx, watch.ID, "acme", "widget", 42,
+		"https://github.com/acme/widget/pull/42",
+	)
+	if err != nil {
+		t.Fatalf("first Reserve: %v", err)
+	}
+	if !first {
+		t.Fatal("first reservation must succeed")
+	}
+
+	second, err := store.ReserveReviewPRTask(
+		ctx, watch.ID, "acme", "widget", 42,
+		"https://github.com/acme/widget/pull/42",
+	)
+	if err != nil {
+		t.Fatalf("second Reserve returned error (want (false, nil)): %v", err)
+	}
+	if second {
+		t.Error("second reservation must return false")
+	}
+}
+
+// TestReleaseReviewPRTask_RemovesReservation verifies that releasing a
+// reservation makes the slot available again (e.g. when task creation fails
+// and we want a subsequent poller tick to retry).
+func TestReleaseReviewPRTask_RemovesReservation(t *testing.T) {
+	_, store, _ := setupSyncTest(t)
+	ctx := context.Background()
+
+	watch := &ReviewWatch{WorkspaceID: "ws-1", Enabled: true}
+	if err := store.CreateReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("CreateReviewWatch: %v", err)
+	}
+
+	if _, err := store.ReserveReviewPRTask(
+		ctx, watch.ID, "acme", "widget", 42,
+		"https://github.com/acme/widget/pull/42",
+	); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+
+	if err := store.ReleaseReviewPRTask(ctx, watch.ID, "acme", "widget", 42); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	// After release, a new reservation must succeed again.
+	reserved, err := store.ReserveReviewPRTask(
+		ctx, watch.ID, "acme", "widget", 42,
+		"https://github.com/acme/widget/pull/42",
+	)
+	if err != nil {
+		t.Fatalf("second Reserve: %v", err)
+	}
+	if !reserved {
+		t.Error("expected reservation to succeed after release")
+	}
+}
+
+// TestAssignReviewPRTaskID_UpdatesTaskID verifies that the task_id of a
+// reserved (and thus initially empty-task_id) dedup row is updated so
+// downstream cleanup logic can find and delete the task.
+func TestAssignReviewPRTaskID_UpdatesTaskID(t *testing.T) {
+	_, store, _ := setupSyncTest(t)
+	ctx := context.Background()
+
+	watch := &ReviewWatch{WorkspaceID: "ws-1", Enabled: true}
+	if err := store.CreateReviewWatch(ctx, watch); err != nil {
+		t.Fatalf("CreateReviewWatch: %v", err)
+	}
+
+	if _, err := store.ReserveReviewPRTask(
+		ctx, watch.ID, "acme", "widget", 42,
+		"https://github.com/acme/widget/pull/42",
+	); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+
+	if err := store.AssignReviewPRTaskID(ctx, watch.ID, "acme", "widget", 42, "task-xyz"); err != nil {
+		t.Fatalf("AssignReviewPRTaskID: %v", err)
+	}
+
+	records, err := store.ListReviewPRTasksByWatch(ctx, watch.ID)
+	if err != nil {
+		t.Fatalf("ListReviewPRTasksByWatch: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].TaskID != "task-xyz" {
+		t.Errorf("TaskID = %q, want %q", records[0].TaskID, "task-xyz")
+	}
+}

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -995,6 +995,17 @@ func (s *Service) CleanupMergedReviewTasks(ctx context.Context, watch *ReviewWat
 	}
 	deleted := 0
 	for _, rpt := range prTasks {
+		// Orphan reservation: process was killed after ReserveReviewPRTask
+		// succeeded but before AssignReviewPRTaskID ran, so task_id is empty
+		// and there is no task to delete. Clean up the dedup row once the PR
+		// reaches a terminal state, same gating as the normal path.
+		if rpt.TaskID == "" {
+			if should, _ := s.shouldDeleteReviewTask(ctx, rpt); should {
+				_ = s.store.DeleteReviewPRTask(ctx, rpt.ID)
+				deleted++
+			}
+			continue
+		}
 		shouldDelete, reason := s.shouldDeleteReviewTask(ctx, rpt)
 		if !shouldDelete {
 			continue

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -771,7 +771,12 @@ func (s *Service) CheckReviewWatch(ctx context.Context, watch *ReviewWatch) ([]*
 		zap.String("watch_id", watch.ID),
 		zap.Int("total_prs", len(prs)))
 
-	// Filter out PRs we already created tasks for
+	// Pre-filter PRs that are already tracked. This is a best-effort check
+	// that avoids publishing events for PRs that clearly have tasks; it does
+	// NOT need to be race-free, because the orchestrator's createReviewTask
+	// atomically reserves the dedup slot before doing any task-creation work
+	// (see ReserveReviewPRTask). So a race here at most causes an extra event
+	// that the reservation step will drop.
 	var newPRs []*PR
 	for _, pr := range prs {
 		exists, err := s.store.HasReviewPRTask(ctx, watch.ID, pr.RepoOwner, pr.RepoName, pr.Number)
@@ -955,17 +960,27 @@ func (s *Service) ListRepoBranches(ctx context.Context, owner, repo string) ([]R
 	return s.client.ListRepoBranches(ctx, owner, repo)
 }
 
-// RecordReviewPRTask records that a task was created for a review PR.
-func (s *Service) RecordReviewPRTask(ctx context.Context, watchID, repoOwner, repoName string, prNumber int, prURL, taskID string) error {
-	rpt := &ReviewPRTask{
-		ReviewWatchID: watchID,
-		RepoOwner:     repoOwner,
-		RepoName:      repoName,
-		PRNumber:      prNumber,
-		PRURL:         prURL,
-		TaskID:        taskID,
-	}
-	return s.store.CreateReviewPRTask(ctx, rpt)
+// ReserveReviewPRTask atomically claims the dedup slot for a (watch, repo, PR)
+// tuple before task creation begins. Returns true if this caller won and
+// should proceed to create the task, false if another caller already holds
+// the slot (duplicate, skip). This closes the race window that existed when
+// the dedup row was only written AFTER the slow clone + task-creation work,
+// which could produce duplicate tasks when two pollers or events raced.
+func (s *Service) ReserveReviewPRTask(ctx context.Context, watchID, repoOwner, repoName string, prNumber int, prURL string) (bool, error) {
+	return s.store.ReserveReviewPRTask(ctx, watchID, repoOwner, repoName, prNumber, prURL)
+}
+
+// AssignReviewPRTaskID attaches a task ID to a previously reserved slot so
+// downstream cleanup (CleanupMergedReviewTasks) can locate and delete the
+// task when its PR is merged or closed.
+func (s *Service) AssignReviewPRTaskID(ctx context.Context, watchID, repoOwner, repoName string, prNumber int, taskID string) error {
+	return s.store.AssignReviewPRTaskID(ctx, watchID, repoOwner, repoName, prNumber, taskID)
+}
+
+// ReleaseReviewPRTask removes a reservation when task creation fails, so a
+// later poll can retry this PR instead of it being blocked by an orphan row.
+func (s *Service) ReleaseReviewPRTask(ctx context.Context, watchID, repoOwner, repoName string, prNumber int) error {
+	return s.store.ReleaseReviewPRTask(ctx, watchID, repoOwner, repoName, prNumber)
 }
 
 // CleanupMergedReviewTasks checks PRs tracked by a review watch and deletes

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -472,12 +472,25 @@ func (s *Store) ReserveReviewPRTask(ctx context.Context, reviewWatchID, repoOwne
 
 // AssignReviewPRTaskID sets the task_id on a reserved dedup row. Called after
 // the task has been created so cleanup logic can locate and delete it later.
+// Returns an error if no row was updated, which surfaces the narrow race where
+// the reservation was removed (e.g. by a concurrent cleanup sweep) between
+// Reserve and Assign — otherwise the task would leak with no dedup record.
 func (s *Store) AssignReviewPRTaskID(ctx context.Context, reviewWatchID, repoOwner, repoName string, prNumber int, taskID string) error {
-	_, err := s.db.ExecContext(ctx, `
+	res, err := s.db.ExecContext(ctx, `
 		UPDATE github_review_pr_tasks SET task_id = ?
 		WHERE review_watch_id = ? AND repo_owner = ? AND repo_name = ? AND pr_number = ?`,
 		taskID, reviewWatchID, repoOwner, repoName, prNumber)
-	return err
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("assign task ID: reservation row not found for watch=%s pr=%d", reviewWatchID, prNumber)
+	}
+	return nil
 }
 
 // ReleaseReviewPRTask removes a reservation for a (watch, repo, PR) tuple.

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -449,6 +449,48 @@ func (s *Store) HasReviewPRTask(ctx context.Context, reviewWatchID, repoOwner, r
 	return count > 0, err
 }
 
+// ReserveReviewPRTask atomically claims a slot for a (watch, repo, PR) tuple
+// using INSERT OR IGNORE against the UNIQUE constraint. Returns true if this
+// caller won the race and should proceed to create the task, false if another
+// caller already holds the slot. The caller is expected to call
+// AssignReviewPRTaskID once the task is created, or ReleaseReviewPRTask if
+// task creation fails.
+func (s *Store) ReserveReviewPRTask(ctx context.Context, reviewWatchID, repoOwner, repoName string, prNumber int, prURL string) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO github_review_pr_tasks (id, review_watch_id, repo_owner, repo_name, pr_number, pr_url, task_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		uuid.New().String(), reviewWatchID, repoOwner, repoName, prNumber, prURL, "", time.Now().UTC())
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}
+
+// AssignReviewPRTaskID sets the task_id on a reserved dedup row. Called after
+// the task has been created so cleanup logic can locate and delete it later.
+func (s *Store) AssignReviewPRTaskID(ctx context.Context, reviewWatchID, repoOwner, repoName string, prNumber int, taskID string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE github_review_pr_tasks SET task_id = ?
+		WHERE review_watch_id = ? AND repo_owner = ? AND repo_name = ? AND pr_number = ?`,
+		taskID, reviewWatchID, repoOwner, repoName, prNumber)
+	return err
+}
+
+// ReleaseReviewPRTask removes a reservation for a (watch, repo, PR) tuple.
+// Used when task creation fails so a later poll can retry instead of the PR
+// being permanently blocked by an orphan reservation.
+func (s *Store) ReleaseReviewPRTask(ctx context.Context, reviewWatchID, repoOwner, repoName string, prNumber int) error {
+	_, err := s.db.ExecContext(ctx, `
+		DELETE FROM github_review_pr_tasks
+		WHERE review_watch_id = ? AND repo_owner = ? AND repo_name = ? AND pr_number = ?`,
+		reviewWatchID, repoOwner, repoName, prNumber)
+	return err
+}
+
 // ListReviewPRTasksByWatch lists all dedup records for a given review watch.
 func (s *Store) ListReviewPRTasksByWatch(ctx context.Context, watchID string) ([]*ReviewPRTask, error) {
 	var tasks []*ReviewPRTask

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -30,7 +30,9 @@ type GitHubService interface {
 	AssociatePRWithTask(ctx context.Context, taskID string, pr *github.PR) (*github.TaskPR, error)
 	GetTaskPR(ctx context.Context, taskID string) (*github.TaskPR, error)
 	ListActivePRWatches(ctx context.Context) ([]*github.PRWatch, error)
-	RecordReviewPRTask(ctx context.Context, watchID, repoOwner, repoName string, prNumber int, prURL, taskID string) error
+	ReserveReviewPRTask(ctx context.Context, watchID, repoOwner, repoName string, prNumber int, prURL string) (bool, error)
+	AssignReviewPRTaskID(ctx context.Context, watchID, repoOwner, repoName string, prNumber int, taskID string) error
+	ReleaseReviewPRTask(ctx context.Context, watchID, repoOwner, repoName string, prNumber int) error
 }
 
 // ReviewTaskCreator creates tasks from review watch events.
@@ -125,6 +127,29 @@ func (s *Service) createReviewTask(ctx context.Context, evt *github.NewReviewPRE
 		zap.String("base_branch", pr.BaseBranch),
 		zap.String("review_watch_id", evt.ReviewWatchID))
 
+	// Atomically claim the dedup slot BEFORE the slow clone + task creation
+	// so two concurrent events for the same PR cannot both produce a task.
+	// Without this, the previous flow checked-then-wrote the dedup row after
+	// task creation completed (10-30s window), which allowed duplicates.
+	if s.githubService != nil {
+		reserved, reserveErr := s.githubService.ReserveReviewPRTask(
+			ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number, pr.HTMLURL,
+		)
+		if reserveErr != nil {
+			s.logger.Error("failed to reserve review PR slot",
+				zap.String("review_watch_id", evt.ReviewWatchID),
+				zap.Int("pr_number", pr.Number),
+				zap.Error(reserveErr))
+			return
+		}
+		if !reserved {
+			s.logger.Debug("review PR already reserved by concurrent handler, skipping",
+				zap.String("review_watch_id", evt.ReviewWatchID),
+				zap.Int("pr_number", pr.Number))
+			return
+		}
+	}
+
 	title := fmt.Sprintf("PR #%d: %s", pr.Number, pr.Title)
 	description := interpolateReviewPrompt(evt.Prompt, pr)
 
@@ -154,18 +179,28 @@ func (s *Service) createReviewTask(ctx context.Context, evt *github.NewReviewPRE
 			zap.String("review_watch_id", evt.ReviewWatchID),
 			zap.Int("pr_number", pr.Number),
 			zap.Error(err))
+		// Release the reservation so a later poll can retry this PR.
+		if s.githubService != nil {
+			if relErr := s.githubService.ReleaseReviewPRTask(
+				ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number,
+			); relErr != nil {
+				s.logger.Warn("failed to release review PR reservation after task-create failure",
+					zap.Int("pr_number", pr.Number),
+					zap.Error(relErr))
+			}
+		}
 		return
 	}
 
-	// Record dedup entry so this PR won't be picked up again
+	// Attach the task ID to the reservation so cleanup can locate the task.
 	if s.githubService != nil {
-		if recordErr := s.githubService.RecordReviewPRTask(
-			ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number, pr.HTMLURL, task.ID,
-		); recordErr != nil {
-			s.logger.Error("failed to record review PR task",
+		if assignErr := s.githubService.AssignReviewPRTaskID(
+			ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number, task.ID,
+		); assignErr != nil {
+			s.logger.Error("failed to assign task ID to review PR reservation",
 				zap.String("task_id", task.ID),
 				zap.Int("pr_number", pr.Number),
-				zap.Error(recordErr))
+				zap.Error(assignErr))
 		}
 
 		// Associate PR with task so the frontend can display PR info

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -127,90 +127,22 @@ func (s *Service) createReviewTask(ctx context.Context, evt *github.NewReviewPRE
 		zap.String("base_branch", pr.BaseBranch),
 		zap.String("review_watch_id", evt.ReviewWatchID))
 
-	// Atomically claim the dedup slot BEFORE the slow clone + task creation
-	// so two concurrent events for the same PR cannot both produce a task.
-	// Without this, the previous flow checked-then-wrote the dedup row after
-	// task creation completed (10-30s window), which allowed duplicates.
-	if s.githubService != nil {
-		reserved, reserveErr := s.githubService.ReserveReviewPRTask(
-			ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number, pr.HTMLURL,
-		)
-		if reserveErr != nil {
-			s.logger.Error("failed to reserve review PR slot",
-				zap.String("review_watch_id", evt.ReviewWatchID),
-				zap.Int("pr_number", pr.Number),
-				zap.Error(reserveErr))
-			return
-		}
-		if !reserved {
-			s.logger.Debug("review PR already reserved by concurrent handler, skipping",
-				zap.String("review_watch_id", evt.ReviewWatchID),
-				zap.Int("pr_number", pr.Number))
-			return
-		}
+	if !s.reserveReviewPR(ctx, evt) {
+		return
 	}
 
-	title := fmt.Sprintf("PR #%d: %s", pr.Number, pr.Title)
-	description := interpolateReviewPrompt(evt.Prompt, pr)
-
-	// Resolve repository: clone if needed, find-or-create DB record
 	repositories := s.resolveReviewRepository(ctx, evt.WorkspaceID, pr)
-
-	task, err := s.reviewTaskCreator.CreateReviewTask(ctx, &ReviewTaskRequest{
-		WorkspaceID:    evt.WorkspaceID,
-		WorkflowID:     evt.WorkflowID,
-		WorkflowStepID: evt.WorkflowStepID,
-		Title:          title,
-		Description:    description,
-		Repositories:   repositories,
-		Metadata: map[string]interface{}{
-			"review_watch_id":     evt.ReviewWatchID,
-			"pr_number":           pr.Number,
-			"pr_url":              pr.HTMLURL,
-			"pr_repo":             repoSlug,
-			"pr_author":           pr.AuthorLogin,
-			"pr_branch":           pr.HeadBranch,
-			"agent_profile_id":    evt.AgentProfileID,
-			"executor_profile_id": evt.ExecutorProfileID,
-		},
-	})
+	task, err := s.reviewTaskCreator.CreateReviewTask(ctx, buildReviewTaskRequest(evt, repositories, repoSlug))
 	if err != nil {
 		s.logger.Error("failed to create review task",
 			zap.String("review_watch_id", evt.ReviewWatchID),
 			zap.Int("pr_number", pr.Number),
 			zap.Error(err))
-		// Release the reservation so a later poll can retry this PR.
-		if s.githubService != nil {
-			if relErr := s.githubService.ReleaseReviewPRTask(
-				ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number,
-			); relErr != nil {
-				s.logger.Warn("failed to release review PR reservation after task-create failure",
-					zap.Int("pr_number", pr.Number),
-					zap.Error(relErr))
-			}
-		}
+		s.releaseReviewPR(ctx, evt)
 		return
 	}
 
-	// Attach the task ID to the reservation so cleanup can locate the task.
-	if s.githubService != nil {
-		if assignErr := s.githubService.AssignReviewPRTaskID(
-			ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number, task.ID,
-		); assignErr != nil {
-			s.logger.Error("failed to assign task ID to review PR reservation",
-				zap.String("task_id", task.ID),
-				zap.Int("pr_number", pr.Number),
-				zap.Error(assignErr))
-		}
-
-		// Associate PR with task so the frontend can display PR info
-		if _, assocErr := s.githubService.AssociatePRWithTask(ctx, task.ID, pr); assocErr != nil {
-			s.logger.Error("failed to associate PR with review task",
-				zap.String("task_id", task.ID),
-				zap.Int("pr_number", pr.Number),
-				zap.Error(assocErr))
-		}
-	}
+	s.attachTaskToReservation(ctx, evt, task.ID)
 
 	s.logger.Info("created review task",
 		zap.String("task_id", task.ID),
@@ -224,6 +156,96 @@ func (s *Service) createReviewTask(ctx context.Context, evt *github.NewReviewPRE
 		return
 	}
 	s.autoStartReviewTask(ctx, evt, task)
+}
+
+// reserveReviewPR atomically claims the dedup slot before the slow clone +
+// task creation. Returns false (caller must bail) if another handler already
+// holds the slot or if the reserve call errored. A nil githubService means
+// dedup is disabled and we always proceed.
+func (s *Service) reserveReviewPR(ctx context.Context, evt *github.NewReviewPREvent) bool {
+	if s.githubService == nil {
+		return true
+	}
+	pr := evt.PR
+	reserved, err := s.githubService.ReserveReviewPRTask(
+		ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number, pr.HTMLURL,
+	)
+	if err != nil {
+		s.logger.Error("failed to reserve review PR slot",
+			zap.String("review_watch_id", evt.ReviewWatchID),
+			zap.Int("pr_number", pr.Number),
+			zap.Error(err))
+		return false
+	}
+	if !reserved {
+		s.logger.Debug("review PR already reserved by concurrent handler, skipping",
+			zap.String("review_watch_id", evt.ReviewWatchID),
+			zap.Int("pr_number", pr.Number))
+		return false
+	}
+	return true
+}
+
+// releaseReviewPR removes the reservation when task creation fails so a later
+// poll can retry this PR instead of it being blocked by an orphan row.
+func (s *Service) releaseReviewPR(ctx context.Context, evt *github.NewReviewPREvent) {
+	if s.githubService == nil {
+		return
+	}
+	pr := evt.PR
+	if err := s.githubService.ReleaseReviewPRTask(
+		ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number,
+	); err != nil {
+		s.logger.Warn("failed to release review PR reservation after task-create failure",
+			zap.Int("pr_number", pr.Number),
+			zap.Error(err))
+	}
+}
+
+// attachTaskToReservation stamps the created task ID onto the reservation and
+// associates the PR with the task so the frontend can display PR info.
+func (s *Service) attachTaskToReservation(ctx context.Context, evt *github.NewReviewPREvent, taskID string) {
+	if s.githubService == nil {
+		return
+	}
+	pr := evt.PR
+	if err := s.githubService.AssignReviewPRTaskID(
+		ctx, evt.ReviewWatchID, pr.RepoOwner, pr.RepoName, pr.Number, taskID,
+	); err != nil {
+		s.logger.Error("failed to assign task ID to review PR reservation",
+			zap.String("task_id", taskID),
+			zap.Int("pr_number", pr.Number),
+			zap.Error(err))
+	}
+	if _, err := s.githubService.AssociatePRWithTask(ctx, taskID, pr); err != nil {
+		s.logger.Error("failed to associate PR with review task",
+			zap.String("task_id", taskID),
+			zap.Int("pr_number", pr.Number),
+			zap.Error(err))
+	}
+}
+
+// buildReviewTaskRequest builds the ReviewTaskRequest payload from an event.
+func buildReviewTaskRequest(evt *github.NewReviewPREvent, repositories []ReviewTaskRepository, repoSlug string) *ReviewTaskRequest {
+	pr := evt.PR
+	return &ReviewTaskRequest{
+		WorkspaceID:    evt.WorkspaceID,
+		WorkflowID:     evt.WorkflowID,
+		WorkflowStepID: evt.WorkflowStepID,
+		Title:          fmt.Sprintf("PR #%d: %s", pr.Number, pr.Title),
+		Description:    interpolateReviewPrompt(evt.Prompt, pr),
+		Repositories:   repositories,
+		Metadata: map[string]interface{}{
+			"review_watch_id":     evt.ReviewWatchID,
+			"pr_number":           pr.Number,
+			"pr_url":              pr.HTMLURL,
+			"pr_repo":             repoSlug,
+			"pr_author":           pr.AuthorLogin,
+			"pr_branch":           pr.HeadBranch,
+			"agent_profile_id":    evt.AgentProfileID,
+			"executor_profile_id": evt.ExecutorProfileID,
+		},
+	}
 }
 
 // shouldAutoStartStep checks if the workflow step has the OnEnterAutoStartAgent action.

--- a/apps/backend/internal/orchestrator/event_handlers_github_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kandev/kandev/internal/github"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -28,6 +29,14 @@ type mockGitHubService struct {
 	createWatchBranch   string
 	updatedBranch       string
 	updatedPRNumber     int
+
+	// Review PR reservation tracking.
+	reserveCalls   int
+	reserveReturn  bool // what ReserveReviewPRTask returns (default false; tests set true to let flow proceed)
+	reserveErr     error
+	assignCalls    int
+	assignedTaskID string
+	releaseCalls   int
 }
 
 func (m *mockGitHubService) Client() github.Client { return m.client }
@@ -69,7 +78,17 @@ func (m *mockGitHubService) ResetPRWatch(_ context.Context, _, branch string) er
 func (m *mockGitHubService) ListActivePRWatches(context.Context) ([]*github.PRWatch, error) {
 	return nil, nil
 }
-func (m *mockGitHubService) RecordReviewPRTask(context.Context, string, string, string, int, string, string) error {
+func (m *mockGitHubService) ReserveReviewPRTask(_ context.Context, _, _, _ string, _ int, _ string) (bool, error) {
+	m.reserveCalls++
+	return m.reserveReturn, m.reserveErr
+}
+func (m *mockGitHubService) AssignReviewPRTaskID(_ context.Context, _, _, _ string, _ int, taskID string) error {
+	m.assignCalls++
+	m.assignedTaskID = taskID
+	return nil
+}
+func (m *mockGitHubService) ReleaseReviewPRTask(_ context.Context, _, _, _ string, _ int) error {
+	m.releaseCalls++
 	return nil
 }
 
@@ -636,3 +655,132 @@ func TestListTasksNeedingPRWatch(t *testing.T) {
 		}
 	})
 }
+
+// countingReviewTaskCreator records how many times CreateReviewTask was called.
+type countingReviewTaskCreator struct {
+	calls  int
+	err    error
+	taskID string
+}
+
+func (c *countingReviewTaskCreator) CreateReviewTask(_ context.Context, _ *ReviewTaskRequest) (*models.Task, error) {
+	c.calls++
+	if c.err != nil {
+		return nil, c.err
+	}
+	id := c.taskID
+	if id == "" {
+		id = "task-created"
+	}
+	return &models.Task{ID: id}, nil
+}
+
+// newReviewEvent builds a NewReviewPREvent for createReviewTask tests.
+func newReviewEvent() *github.NewReviewPREvent {
+	return &github.NewReviewPREvent{
+		ReviewWatchID:  "w1",
+		WorkspaceID:    "ws1",
+		WorkflowID:     "wf1",
+		WorkflowStepID: "step1",
+		PR: &github.PR{
+			Number: 42, Title: "Some PR", HTMLURL: "https://gh/acme/widget/pull/42",
+			RepoOwner: "acme", RepoName: "widget",
+		},
+	}
+}
+
+// setupReviewTaskTest builds a Service with a seeded workflow step (needed
+// because createReviewTask runs shouldAutoStartStep after task creation).
+func setupReviewTaskTest(t *testing.T) (*Service, *mockStepGetter) {
+	t.Helper()
+	repo := setupTestRepo(t)
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+		Events: wfmodels.StepEvents{}, // no auto-start action
+	}
+	return createTestService(repo, stepGetter, newMockTaskRepo()), stepGetter
+}
+
+// TestCreateReviewTask_SkipsWhenAlreadyReserved is the regression test for the
+// duplicate review-task bug: if another handler has already reserved the
+// dedup slot for this PR, createReviewTask must NOT call CreateReviewTask.
+func TestCreateReviewTask_SkipsWhenAlreadyReserved(t *testing.T) {
+	svc, _ := setupReviewTaskTest(t)
+	ghSvc := &mockGitHubService{reserveReturn: false} // reservation lost to concurrent handler
+	svc.SetGitHubService(ghSvc)
+	creator := &countingReviewTaskCreator{}
+	svc.SetReviewTaskCreator(creator)
+
+	svc.createReviewTask(context.Background(), newReviewEvent())
+
+	if ghSvc.reserveCalls != 1 {
+		t.Errorf("expected 1 Reserve call, got %d", ghSvc.reserveCalls)
+	}
+	if creator.calls != 0 {
+		t.Errorf("expected CreateReviewTask NOT to be called when reservation lost, got %d calls", creator.calls)
+	}
+	if ghSvc.releaseCalls != 0 {
+		t.Errorf("expected no Release calls when reservation was never held, got %d", ghSvc.releaseCalls)
+	}
+}
+
+// TestCreateReviewTask_ReservesThenAssignsTaskID verifies the happy path:
+// Reserve -> CreateReviewTask -> AssignReviewPRTaskID.
+func TestCreateReviewTask_ReservesThenAssignsTaskID(t *testing.T) {
+	svc, _ := setupReviewTaskTest(t)
+	ghSvc := &mockGitHubService{reserveReturn: true}
+	svc.SetGitHubService(ghSvc)
+	creator := &countingReviewTaskCreator{taskID: "task-999"}
+	svc.SetReviewTaskCreator(creator)
+
+	svc.createReviewTask(context.Background(), newReviewEvent())
+
+	if ghSvc.reserveCalls != 1 {
+		t.Errorf("expected 1 Reserve call, got %d", ghSvc.reserveCalls)
+	}
+	if creator.calls != 1 {
+		t.Errorf("expected 1 CreateReviewTask call, got %d", creator.calls)
+	}
+	if ghSvc.assignCalls != 1 {
+		t.Errorf("expected 1 AssignReviewPRTaskID call, got %d", ghSvc.assignCalls)
+	}
+	if ghSvc.assignedTaskID != "task-999" {
+		t.Errorf("AssignReviewPRTaskID got taskID=%q, want %q", ghSvc.assignedTaskID, "task-999")
+	}
+	if ghSvc.releaseCalls != 0 {
+		t.Errorf("expected no Release calls on happy path, got %d", ghSvc.releaseCalls)
+	}
+}
+
+// TestCreateReviewTask_ReleasesOnTaskCreationFailure verifies that a failed
+// CreateReviewTask triggers a Release so the slot can be retried on the next
+// poll instead of being permanently blocked by an orphan reservation.
+func TestCreateReviewTask_ReleasesOnTaskCreationFailure(t *testing.T) {
+	svc, _ := setupReviewTaskTest(t)
+	ghSvc := &mockGitHubService{reserveReturn: true}
+	svc.SetGitHubService(ghSvc)
+	creator := &countingReviewTaskCreator{err: assertErrTaskCreate}
+	svc.SetReviewTaskCreator(creator)
+
+	svc.createReviewTask(context.Background(), newReviewEvent())
+
+	if ghSvc.reserveCalls != 1 {
+		t.Errorf("expected 1 Reserve call, got %d", ghSvc.reserveCalls)
+	}
+	if creator.calls != 1 {
+		t.Errorf("expected 1 CreateReviewTask call, got %d", creator.calls)
+	}
+	if ghSvc.releaseCalls != 1 {
+		t.Errorf("expected 1 Release call after task-create failure, got %d", ghSvc.releaseCalls)
+	}
+	if ghSvc.assignCalls != 0 {
+		t.Errorf("expected no Assign call after failure, got %d", ghSvc.assignCalls)
+	}
+}
+
+var assertErrTaskCreate = &taskCreateErr{"simulated task creation failure"}
+
+type taskCreateErr struct{ msg string }
+
+func (e *taskCreateErr) Error() string { return e.msg }

--- a/apps/web/e2e/tests/pr/pr-watcher-merged-cleanup.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-merged-cleanup.spec.ts
@@ -51,8 +51,12 @@ test.describe("PR watcher merged cleanup", () => {
     );
 
     // --- Trigger watch → should create a task for PR #101 ---
-    const triggerResult = await apiClient.triggerReviewWatch(watch.id);
-    expect(triggerResult.new_prs).toBeGreaterThanOrEqual(1);
+    // createReviewWatch already kicked off an initial poll; this explicit
+    // trigger is belt-and-suspenders. We do NOT assert on new_prs here
+    // because the atomic dedup reservation means whichever poll runs first
+    // claims the PR, and the subsequent trigger correctly returns 0 "new".
+    // The real check is the task-exists poll below.
+    await apiClient.triggerReviewWatch(watch.id);
 
     // Task creation is async (goroutine), poll until it appears
     let prTask: { id: string; title: string } | undefined;


### PR DESCRIPTION
## Summary

The PR review watcher could create duplicate review tasks for the same PR because the dedup record was only written *after* the slow clone + task-creation work (10-30s window), leaving a race where two concurrent `CheckReviewWatch` calls would both see no dedup row and both spawn a task. This change makes the dedup slot an atomic claim using `INSERT OR IGNORE` against the existing `UNIQUE(review_watch_id, repo_owner, repo_name, pr_number)` constraint, so the first caller wins and the loser bails silently.

## Important Changes

- **New store primitives** in `internal/github/store.go`: `ReserveReviewPRTask` (atomic claim), `AssignReviewPRTaskID` (fill in task_id after success), `ReleaseReviewPRTask` (roll back on failure).
- **Rewrote `createReviewTask`** in `internal/orchestrator/event_handlers_github.go` to reserve → create task → assign task_id, releasing the reservation if task creation fails so a later poll can retry.
- **Interface change**: `GitHubService` in the orchestrator now exposes the three reservation methods instead of the old `RecordReviewPRTask`.
- The pre-filter in `CheckReviewWatch` stays (best-effort optimisation); correctness now rests on the atomic reservation, not the filter.

## Validation

- `make fmt` — clean
- `make test` — 594 tests pass (includes new 20-goroutine concurrency test proving exactly one reservation wins)
- `make lint` — 0 issues
- `go build ./...` — success
- New tests:
  - `TestReserveReviewPRTask_AtomicUnderConcurrency` — 20 goroutines race; exactly 1 wins
  - `TestReserveReviewPRTask_ReturnsFalseWhenAlreadyReserved` — second call returns `(false, nil)`
  - `TestReleaseReviewPRTask_RemovesReservation` — slot retryable after release
  - `TestAssignReviewPRTaskID_UpdatesTaskID` — task_id updated on success
  - `TestCreateReviewTask_SkipsWhenAlreadyReserved` — no CreateReviewTask call when slot taken
  - `TestCreateReviewTask_ReservesThenAssignsTaskID` — happy path
  - `TestCreateReviewTask_ReleasesOnTaskCreationFailure` — reservation released on failure so retry works

## Possible Improvements

If the backend is killed *between* reservation and task creation completion, an orphan dedup row with an empty `task_id` will sit there until the PR is merged/closed (then `CleanupMergedReviewTasks` removes it). Acceptable tradeoff vs. creating duplicate tasks, which is the bug this fixes.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes