### PR TITLE
feat(web): pin agent tabs in center tab strip

### DIFF
--- a/apps/web/app/dockview-theme.css
+++ b/apps/web/app/dockview-theme.css
@@ -82,6 +82,13 @@
   background: var(--background);
 }
 
+/* The generic `.dv-tab:hover` rule below uses a semi-transparent background
+   (color-mix with transparent) — on a sticky pinned tab that would let the
+   scrolled-behind tabs bleed through. Keep the hover state opaque. */
+.dockview-theme-kandev .dv-tab.dv-pinned-tab:hover {
+  background: var(--muted);
+}
+
 /* ── Individual tabs — pill style ── */
 .dockview-theme-kandev .dv-tab {
   padding: 0;

--- a/apps/web/app/dockview-theme.css
+++ b/apps/web/app/dockview-theme.css
@@ -71,6 +71,17 @@
   display: none !important;
 }
 
+/* ── Pinned tabs (agent/session chats) ──
+   Stay visible on the left when the tab strip overflows horizontally.
+   `--dv-pin-offset` is set per-tab by usePinnedDockviewTab so multiple
+   pinned tabs stack side-by-side instead of overlapping at x=0. */
+.dockview-theme-kandev .dv-tab.dv-pinned-tab {
+  position: sticky;
+  left: var(--dv-pin-offset, 0);
+  z-index: 2;
+  background: var(--background);
+}
+
 /* ── Individual tabs — pill style ── */
 .dockview-theme-kandev .dv-tab {
   padding: 0;

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useEffect, useRef, memo } from "react";
+import { usePinnedDockviewTab } from "./use-pinned-dockview-tab";
 import {
   DockviewReact,
   DockviewDefaultTab,
@@ -145,7 +146,13 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps>> =
 
 // --- TAB COMPONENTS ---
 function PermanentTab(props: IDockviewPanelHeaderProps) {
-  return <DockviewDefaultTab {...props} hideClose />;
+  const ref = useRef<HTMLDivElement>(null);
+  usePinnedDockviewTab(ref);
+  return (
+    <div ref={ref} className="flex h-full items-center">
+      <DockviewDefaultTab {...props} hideClose />
+    </div>
+  );
 }
 
 const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeaderProps>> = {

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import { IconStar } from "@tabler/icons-react";
 import { AgentLogo } from "@/components/agent-logo";
+import { usePinnedDockviewTab } from "./use-pinned-dockview-tab";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -256,6 +257,8 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const actions = useSessionTabActions(sessionId, taskId, api, containerApi);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isActive, setIsActive] = useState(api.isActive);
+  const pinRef = useRef<HTMLDivElement>(null);
+  usePinnedDockviewTab(pinRef);
 
   useEffect(() => {
     const disposable = api.onDidActiveChange((e) => setIsActive(e.isActive));
@@ -275,7 +278,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
           className="flex h-full items-center"
           data-testid={sessionId ? `session-tab-${sessionId}` : undefined}
         >
-          <div className="flex items-center">
+          <div ref={pinRef} className="flex items-center">
             {isPrimary && showMultiSessionBadges && (
               <IconStar className="h-3 w-3 fill-foreground/50 stroke-0 shrink-0 ml-2" />
             )}

--- a/apps/web/components/task/use-pinned-dockview-tab.test.ts
+++ b/apps/web/components/task/use-pinned-dockview-tab.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRef, type RefObject } from "react";
+import { usePinnedDockviewTab, updatePinnedOffsets } from "./use-pinned-dockview-tab";
+
+/**
+ * Build a `.dv-tab` wrapper with an inner ref target, matching the layout
+ * Dockview produces. `offsetWidth`, `marginLeft`, and `marginRight` are stubbed
+ * because jsdom doesn't run layout.
+ */
+function buildTab(options: { container: HTMLElement; offsetWidth: number; margin?: number }): {
+  dvTab: HTMLElement;
+  inner: HTMLElement;
+} {
+  const dvTab = document.createElement("div");
+  dvTab.className = "dv-tab";
+  Object.defineProperty(dvTab, "offsetWidth", {
+    configurable: true,
+    value: options.offsetWidth,
+  });
+  if (options.margin !== undefined) {
+    dvTab.style.marginLeft = `${options.margin}px`;
+    dvTab.style.marginRight = `${options.margin}px`;
+  }
+
+  const inner = document.createElement("span");
+  dvTab.appendChild(inner);
+  options.container.appendChild(dvTab);
+
+  return { dvTab, inner };
+}
+
+const PINNED_CLASS = "dv-pinned-tab";
+const PIN_OFFSET_VAR = "--dv-pin-offset";
+
+describe("updatePinnedOffsets", () => {
+  it("returns without error when container is null", () => {
+    expect(() => updatePinnedOffsets(null)).not.toThrow();
+  });
+
+  it("sets --dv-pin-offset to 0 on a single pinned tab", () => {
+    const container = document.createElement("div");
+    const { dvTab } = buildTab({ container, offsetWidth: 80 });
+    dvTab.classList.add(PINNED_CLASS);
+
+    updatePinnedOffsets(container);
+
+    expect(dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("0px");
+  });
+
+  it("stacks multiple pinned tabs side-by-side by accumulating widths", () => {
+    const container = document.createElement("div");
+    const a = buildTab({ container, offsetWidth: 80 });
+    const b = buildTab({ container, offsetWidth: 100 });
+    const c = buildTab({ container, offsetWidth: 60 });
+    a.dvTab.classList.add(PINNED_CLASS);
+    b.dvTab.classList.add(PINNED_CLASS);
+    c.dvTab.classList.add(PINNED_CLASS);
+
+    updatePinnedOffsets(container);
+
+    expect(a.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("0px");
+    expect(b.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("80px");
+    expect(c.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("180px");
+  });
+
+  it("includes horizontal margins in the cumulative offset", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    // Two pinned tabs with width=80 and margin: 0 2px each — the second tab's
+    // offset should be 80 + 2 + 2 = 84, not 80. Attaching to document.body is
+    // required for jsdom's getComputedStyle to reflect inline margins.
+    const a = buildTab({ container, offsetWidth: 80, margin: 2 });
+    const b = buildTab({ container, offsetWidth: 80, margin: 2 });
+    a.dvTab.classList.add(PINNED_CLASS);
+    b.dvTab.classList.add(PINNED_CLASS);
+
+    try {
+      updatePinnedOffsets(container);
+
+      expect(a.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("0px");
+      expect(b.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("84px");
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
+  it("skips non-pinned siblings", () => {
+    const container = document.createElement("div");
+    const pinned = buildTab({ container, offsetWidth: 80 });
+    const notPinned = buildTab({ container, offsetWidth: 999 });
+    const alsoPinned = buildTab({ container, offsetWidth: 50 });
+    pinned.dvTab.classList.add(PINNED_CLASS);
+    alsoPinned.dvTab.classList.add(PINNED_CLASS);
+
+    updatePinnedOffsets(container);
+
+    expect(pinned.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("0px");
+    expect(notPinned.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("");
+    // The non-pinned tab's width does not contribute to the cumulative offset.
+    expect(alsoPinned.dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("80px");
+  });
+});
+
+describe("usePinnedDockviewTab", () => {
+  let resizeObserverMock: ReturnType<typeof vi.fn>;
+  let mutationObserverMock: ReturnType<typeof vi.fn>;
+  let disconnectCalls: number;
+
+  beforeEach(() => {
+    disconnectCalls = 0;
+    const makeObserver = () => ({
+      observe: vi.fn(),
+      disconnect: vi.fn(() => {
+        disconnectCalls += 1;
+      }),
+      unobserve: vi.fn(),
+      takeRecords: vi.fn(() => []),
+    });
+    resizeObserverMock = vi.fn().mockImplementation(makeObserver);
+    mutationObserverMock = vi.fn().mockImplementation(makeObserver);
+    vi.stubGlobal("ResizeObserver", resizeObserverMock);
+    vi.stubGlobal("MutationObserver", mutationObserverMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderWithTabRef(inner: HTMLElement) {
+    return renderHook(() => {
+      const ref = useRef<HTMLElement | null>(inner);
+      usePinnedDockviewTab(ref as RefObject<HTMLElement | null>);
+    });
+  }
+
+  it("adds the dv-pinned-tab class to the wrapping .dv-tab", () => {
+    const container = document.createElement("div");
+    const { dvTab, inner } = buildTab({ container, offsetWidth: 80 });
+
+    renderWithTabRef(inner);
+
+    expect(dvTab.classList.contains(PINNED_CLASS)).toBe(true);
+  });
+
+  it("computes the initial --dv-pin-offset on mount", () => {
+    const container = document.createElement("div");
+    const { dvTab, inner } = buildTab({ container, offsetWidth: 80 });
+
+    renderWithTabRef(inner);
+
+    expect(dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("0px");
+  });
+
+  it("registers a ResizeObserver on the .dv-tab and a MutationObserver on its parent", () => {
+    const container = document.createElement("div");
+    const { inner } = buildTab({ container, offsetWidth: 80 });
+
+    renderWithTabRef(inner);
+
+    expect(resizeObserverMock).toHaveBeenCalledOnce();
+    expect(mutationObserverMock).toHaveBeenCalledOnce();
+  });
+
+  it("removes the class, CSS variable, and disconnects observers on unmount", () => {
+    const container = document.createElement("div");
+    const { dvTab, inner } = buildTab({ container, offsetWidth: 80 });
+
+    const { unmount } = renderWithTabRef(inner);
+    expect(dvTab.classList.contains(PINNED_CLASS)).toBe(true);
+    expect(dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("0px");
+
+    unmount();
+
+    expect(dvTab.classList.contains(PINNED_CLASS)).toBe(false);
+    expect(dvTab.style.getPropertyValue(PIN_OFFSET_VAR)).toBe("");
+    // Both the resize + mutation observers should be disconnected.
+    expect(disconnectCalls).toBe(2);
+  });
+
+  it("no-ops if the ref element is not inside a .dv-tab", () => {
+    const orphan = document.createElement("span");
+
+    expect(() => renderWithTabRef(orphan)).not.toThrow();
+    // No observers should have been constructed.
+    expect(resizeObserverMock).not.toHaveBeenCalled();
+    expect(mutationObserverMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/use-pinned-dockview-tab.ts
+++ b/apps/web/components/task/use-pinned-dockview-tab.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type RefObject } from "react";
+import { useLayoutEffect, type RefObject } from "react";
 
 const PINNED_CLASS = "dv-pinned-tab";
 const OFFSET_VAR = "--dv-pin-offset";
@@ -10,16 +10,21 @@ const OFFSET_VAR = "--dv-pin-offset";
  * that multiple pinned tabs stack side-by-side instead of overlapping at x=0.
  *
  * The first pinned tab sticks at `left: 0`, the second at `left: width_of_first`,
- * and so on. Uses a CSS custom property consumed by `.dv-pinned-tab` in
- * `dockview-theme.css`.
+ * and so on. Widths include horizontal margins so the trailing `margin: 0 2px`
+ * gap between `.dv-tab`s is preserved when the tabs are pinned.
+ *
+ * Exported for unit testing.
  */
-function updatePinnedOffsets(container: HTMLElement | null): void {
+export function updatePinnedOffsets(container: HTMLElement | null): void {
   if (!container) return;
   const pinned = container.querySelectorAll<HTMLElement>(`.${PINNED_CLASS}`);
   let offset = 0;
   pinned.forEach((el) => {
     el.style.setProperty(OFFSET_VAR, `${offset}px`);
-    offset += el.offsetWidth;
+    const style = getComputedStyle(el);
+    const marginLeft = parseFloat(style.marginLeft) || 0;
+    const marginRight = parseFloat(style.marginRight) || 0;
+    offset += el.offsetWidth + marginLeft + marginRight;
   });
 }
 
@@ -29,9 +34,13 @@ function updatePinnedOffsets(container: HTMLElement | null): void {
  *
  * `ref` must point to an element rendered directly inside the Dockview tab
  * wrapper — we walk up to `.dv-tab` and attach the pin class there.
+ *
+ * Uses `useLayoutEffect` so the class is applied before the browser paints,
+ * avoiding a one-frame flash of a non-sticky tab when the strip is already
+ * scrolled at mount time.
  */
 export function usePinnedDockviewTab(ref: RefObject<HTMLElement | null>): void {
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
     const dvTab = el.closest<HTMLElement>(".dv-tab");

--- a/apps/web/components/task/use-pinned-dockview-tab.ts
+++ b/apps/web/components/task/use-pinned-dockview-tab.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+const PINNED_CLASS = "dv-pinned-tab";
+const OFFSET_VAR = "--dv-pin-offset";
+
+/**
+ * Recompute sticky `left` offsets for every pinned tab inside `container` so
+ * that multiple pinned tabs stack side-by-side instead of overlapping at x=0.
+ *
+ * The first pinned tab sticks at `left: 0`, the second at `left: width_of_first`,
+ * and so on. Uses a CSS custom property consumed by `.dv-pinned-tab` in
+ * `dockview-theme.css`.
+ */
+function updatePinnedOffsets(container: HTMLElement | null): void {
+  if (!container) return;
+  const pinned = container.querySelectorAll<HTMLElement>(`.${PINNED_CLASS}`);
+  let offset = 0;
+  pinned.forEach((el) => {
+    el.style.setProperty(OFFSET_VAR, `${offset}px`);
+    offset += el.offsetWidth;
+  });
+}
+
+/**
+ * Mark the parent `.dv-tab` element (created by Dockview) as pinned so it stays
+ * visible on the left when the tab strip overflows horizontally.
+ *
+ * `ref` must point to an element rendered directly inside the Dockview tab
+ * wrapper — we walk up to `.dv-tab` and attach the pin class there.
+ */
+export function usePinnedDockviewTab(ref: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const dvTab = el.closest<HTMLElement>(".dv-tab");
+    if (!dvTab) return;
+
+    dvTab.classList.add(PINNED_CLASS);
+    const tabsContainer = dvTab.parentElement;
+    updatePinnedOffsets(tabsContainer);
+
+    // Recompute when this tab or a sibling resizes (e.g. title changes length,
+    // another session tab appears/disappears).
+    const resizeObserver = new ResizeObserver(() => updatePinnedOffsets(tabsContainer));
+    resizeObserver.observe(dvTab);
+
+    // Recompute when siblings are added/removed (new pinned tabs, reordering).
+    const mutationObserver = tabsContainer
+      ? new MutationObserver(() => updatePinnedOffsets(tabsContainer))
+      : null;
+    if (tabsContainer) {
+      mutationObserver?.observe(tabsContainer, { childList: true });
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver?.disconnect();
+      dvTab.classList.remove(PINNED_CLASS);
+      dvTab.style.removeProperty(OFFSET_VAR);
+      updatePinnedOffsets(tabsContainer);
+    };
+  }, [ref]);
+}

--- a/apps/web/e2e/tests/session/session-layout.spec.ts
+++ b/apps/web/e2e/tests/session/session-layout.spec.ts
@@ -133,6 +133,94 @@ test.describe("Session layout", () => {
     await session.expectTerminalHasText(TERMINAL_MARKER);
   });
 
+  test("agent tab stays pinned when center tab strip overflows", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(60_000);
+
+    await seedTaskWithSession(testPage, apiClient, seedData, "Pinned Tab Test");
+
+    // The session tab (agent chat) lives in the center group. Our hook marks
+    // the wrapping `.dv-tab` with `dv-pinned-tab`.
+    const sessionDvTab = testPage
+      .locator(".dv-tab.dv-pinned-tab:has([data-testid^='session-tab-'])")
+      .first();
+    await expect(sessionDvTab).toBeVisible({ timeout: 10_000 });
+
+    // Sanity check: the sticky CSS rule is actually active.  This catches
+    // regressions where the `dv-pinned-tab` class is present but the CSS
+    // rule is removed, overridden, or the element isn't inside a scrollable
+    // ancestor that engages sticky.
+    const stickyPosition = await sessionDvTab.evaluate(
+      (el) => getComputedStyle(el as HTMLElement).position,
+    );
+    expect(stickyPosition).toBe("sticky");
+
+    // Scope to the center group's tabs container (the one that holds the
+    // session tab).
+    const tabsContainer = testPage
+      .locator(
+        ".dv-tabs-and-actions-container:has([data-testid^='session-tab-']) .dv-tabs-container.dv-horizontal",
+      )
+      .first();
+
+    // Simulate a user opening many diff/file tabs by injecting placeholder
+    // `.dv-tab` siblings directly into the tabs container.  Going through
+    // the + menu and opening real panels would also work, but that takes
+    // several UI round-trips per tab and introduces dropdown flakiness.
+    // The feature under test is purely about CSS sticky positioning, which
+    // depends only on the DOM layout of siblings inside the scrolling
+    // container — so synthetic siblings exercise the same code path.
+    await tabsContainer.evaluate((el) => {
+      const container = el as HTMLElement;
+      for (let i = 0; i < 12; i++) {
+        const dummy = document.createElement("div");
+        dummy.className = "dv-tab";
+        dummy.setAttribute("data-e2e-dummy-tab", "true");
+        dummy.textContent = `Diff [file_${i}.go]`;
+        dummy.style.cssText =
+          "padding: 0 12px; min-width: 140px; display: inline-flex; align-items: center; flex-shrink: 0;";
+        container.appendChild(dummy);
+      }
+    });
+
+    // Confirm the strip now overflows its visible width.
+    await expect
+      .poll(
+        async () =>
+          tabsContainer.evaluate(
+            (el) => (el as HTMLElement).scrollWidth > (el as HTMLElement).clientWidth,
+          ),
+        { timeout: 5_000, message: "Expected the tab strip to overflow" },
+      )
+      .toBe(true);
+
+    // Scroll the strip all the way to the right — without sticky, this would
+    // push the session tab off-screen.
+    await tabsContainer.evaluate((el) => {
+      (el as HTMLElement).scrollLeft = (el as HTMLElement).scrollWidth;
+    });
+
+    // With sticky positioning, the session tab should remain glued to the
+    // left edge of the tab strip, regardless of scrollLeft.
+    await expect
+      .poll(
+        async () => {
+          const sessionBox = await sessionDvTab.boundingBox();
+          const containerBox = await tabsContainer.boundingBox();
+          if (!sessionBox || !containerBox) return Number.POSITIVE_INFINITY;
+          return Math.abs(sessionBox.x - containerBox.x);
+        },
+        {
+          timeout: 5_000,
+          message: "Expected the session tab to stay pinned at the tab strip's left edge",
+        },
+      )
+      .toBeLessThan(5);
+  });
+
   test("closing maximized panel exits maximize and restores layout", async ({
     testPage,
     apiClient,


### PR DESCRIPTION
When many diff or file tabs pile up in the center group, the agent/session tab scrolls off-screen and users have to "Close Others" just to find their chat. This pins the agent/session tabs to the left edge of the strip so they stay visible while the rest scrolls underneath.

## Important Changes

- `usePinnedDockviewTab` hook walks up to the Dockview-created `.dv-tab` wrapper, applies `dv-pinned-tab`, and recomputes cumulative `left` offsets (via a CSS custom property) so multiple pinned tabs stack instead of overlapping at `left: 0`.
- Hook is wired into `PermanentTab` (generic "Agent" tab) and `SessionTab` (per-session tabs). No changes to tab ordering or Dockview internals.

## Validation

- `make -C apps/backend test lint` — pass
- `pnpm --filter @kandev/web lint` (eslint `--max-warnings 0`) — clean
- `pnpm --filter @kandev/web test` — 252 tests pass
- `npx tsc --noEmit` in `apps/web` — no new errors
- New E2E `session-layout.spec.ts › agent tab stays pinned when center tab strip overflows` — 3/3 passing runs; asserts `position: sticky` is computed on the session tab and its `boundingBox.x` stays at the container's left edge after scrolling the overflowing strip to the right.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.