### PR TITLE
fix(orchestrator): unstick sessions when agent crashes mid-turn

### DIFF
--- a/apps/backend/internal/agent/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/lifecycle/manager_interaction.go
@@ -274,11 +274,21 @@ func (m *Manager) ResetAgentContext(ctx context.Context, executionID string) err
 	return nil
 }
 
-// CancelAgentBySessionID cancels the current agent turn for a specific session
+// ErrNoExecutionForSession is returned when no live execution is tracked for a session,
+// typically because the agent process has crashed, exited, or the session state is stuck
+// (for example after a backend restart that did not re-register the execution).
+//
+// Callers should treat this as a "there is nothing to cancel/stop" signal and still reconcile
+// the session's state in the database, otherwise the session will appear stuck as RUNNING
+// with no agent to drive it.
+var ErrNoExecutionForSession = errors.New("no execution for session")
+
+// CancelAgentBySessionID cancels the current agent turn for a specific session.
+// Returns ErrNoExecutionForSession (wrapped) when no execution is tracked for the session.
 func (m *Manager) CancelAgentBySessionID(ctx context.Context, sessionID string) error {
 	execution, exists := m.executionStore.GetBySessionID(sessionID)
 	if !exists {
-		return fmt.Errorf("no agent running for session %q", sessionID)
+		return fmt.Errorf("session %q: %w", sessionID, ErrNoExecutionForSession)
 	}
 
 	return m.CancelAgent(ctx, execution.ID)

--- a/apps/backend/internal/integration/cancel_after_crash_test.go
+++ b/apps/backend/internal/integration/cancel_after_crash_test.go
@@ -1,0 +1,97 @@
+// Package integration provides end-to-end integration tests for the Kandev backend.
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kandev/kandev/internal/task/models"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// TestOrchestratorCancelAfterAgentCrash_UnsticksSession reproduces the "stuck session" bug.
+//
+// Scenario: an agent subprocess crashes while the task's session is in RUNNING state. The
+// lifecycle manager no longer tracks an execution for the session, but the DB still says
+// RUNNING. The user clicks "pause"/"end turn" in the UI, which sends `agent.cancel`. The
+// expected UX is that the session unsticks — transitions to WAITING_FOR_INPUT — so the user
+// can send a new prompt. Today the cancel propagates the lifecycle's "no execution for session"
+// error, leaving the session stuck forever.
+func TestOrchestratorCancelAfterAgentCrash_UnsticksSession(t *testing.T) {
+	ts := NewOrchestratorTestServer(t)
+	defer ts.Close()
+
+	taskID := ts.CreateTestTask(t, "augment-agent", 2)
+
+	client := NewOrchestratorWSClient(t, ts.Server.URL)
+	defer client.Close()
+
+	// Start the task so a session is created and an execution is registered in the simulator.
+	startResp, err := client.SendRequest("start-1", ws.ActionOrchestratorStart, map[string]interface{}{
+		"task_id":          taskID,
+		"agent_profile_id": "augment-agent",
+	})
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, startResp.Type, "start should succeed")
+
+	var startPayload map[string]interface{}
+	require.NoError(t, startResp.ParsePayload(&startPayload))
+	sessionID, _ := startPayload["session_id"].(string)
+	require.NotEmpty(t, sessionID)
+
+	// Pin the session to RUNNING to model the stuck state observed in production
+	// (task_session_state=RUNNING, is_agent_working=true, agentctl_execution_id=null).
+	// We write directly to the repo because the simulator only emits AgentReady, not
+	// the AgentRunning event that would normally drive the transition.
+	require.NoError(t, ts.TaskRepo.UpdateTaskSessionState(
+		context.Background(), sessionID, models.TaskSessionStateRunning, "",
+	))
+
+	// Kill the simulated agent mid-turn. The execution is dropped from the manager's store
+	// so subsequent CancelAgent lookups return ErrNoExecutionForSession, exactly like the
+	// real lifecycle manager after a subprocess crash.
+	ts.AgentManager.CrashAgentForSession(sessionID)
+
+	// User clicks "pause" / "end turn" — the WS path the frontend actually uses.
+	cancelResp, err := client.SendRequest("cancel-1", ws.ActionAgentCancel, map[string]interface{}{
+		"session_id": sessionID,
+	})
+	require.NoError(t, err)
+
+	// 1. The cancel must succeed (not error out), so the frontend can clear its "working" spinner.
+	assert.Equal(t, ws.MessageTypeResponse, cancelResp.Type,
+		"cancel should succeed even when no execution exists for the session; got: %+v", cancelResp)
+
+	// 2. The session must transition out of RUNNING so the user can send a new prompt.
+	// Poll briefly because the state update may happen asynchronously after the WS response.
+	deadline := time.Now().Add(2 * time.Second)
+	var finalState models.TaskSessionState
+	for time.Now().Before(deadline) {
+		session, gErr := ts.TaskRepo.GetTaskSession(context.Background(), sessionID)
+		require.NoError(t, gErr)
+		finalState = session.State
+		if finalState == models.TaskSessionStateWaitingForInput {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	assert.Equal(t, models.TaskSessionStateWaitingForInput, finalState,
+		"session should unstick to WAITING_FOR_INPUT after cancel when no execution exists")
+
+	// 3. A status message documenting the cancel should exist so there's a breadcrumb in chat.
+	msgs, err := ts.TaskRepo.ListMessages(context.Background(), sessionID)
+	require.NoError(t, err)
+	foundCancel := false
+	for _, m := range msgs {
+		if m.Type == models.MessageTypeStatus && m.Content == "Turn cancelled by user" {
+			foundCancel = true
+			break
+		}
+	}
+	assert.True(t, foundCancel,
+		"expected a 'Turn cancelled by user' status message to be recorded")
+}

--- a/apps/backend/internal/integration/simulated_agent_manager_test.go
+++ b/apps/backend/internal/integration/simulated_agent_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/agent/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/client"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/common/logger"
@@ -387,11 +388,45 @@ func (s *SimulatedAgentManagerClient) IsAgentRunningForSession(ctx context.Conte
 	return false
 }
 
-// CancelAgent cancels the current agent turn for a session
+// CancelAgent cancels the current agent turn for a session.
+// Returns lifecycle.ErrNoExecutionForSession when no live execution exists for the session
+// (for example, after CrashAgentForSession has been used to simulate a crash), matching the
+// real lifecycle adapter's behaviour.
 func (s *SimulatedAgentManagerClient) CancelAgent(ctx context.Context, sessionID string) error {
 	s.logger.Info("simulated: cancelling agent turn",
 		zap.String("session_id", sessionID))
-	return nil
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, inst := range s.instances {
+		if inst.sessionID == sessionID {
+			return nil
+		}
+	}
+	return fmt.Errorf("session %q: %w", sessionID, lifecycle.ErrNoExecutionForSession)
+}
+
+// CrashAgentForSession simulates an agent subprocess crashing mid-turn.
+// It stops the agent simulation goroutine and removes the instance from the tracking map,
+// so subsequent lookups (CancelAgent, IsAgentRunningForSession) behave as if the execution
+// is gone. The session's state in the DB is deliberately left untouched — this mirrors the
+// real-world stuck state where the session is still RUNNING but no execution exists.
+func (s *SimulatedAgentManagerClient) CrashAgentForSession(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for execID, inst := range s.instances {
+		if inst.sessionID != sessionID {
+			continue
+		}
+		select {
+		case <-inst.stopCh:
+			// already stopped
+		default:
+			close(inst.stopCh)
+		}
+		delete(s.instances, execID)
+		return
+	}
 }
 
 // ResolveAgentProfile resolves an agent profile ID to profile information

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -3,12 +3,14 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/agent/lifecycle"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
@@ -228,9 +230,22 @@ func (s *Service) retryClarificationAfterCancel(ctx context.Context, data clarif
 
 // cancelAgentSilent cancels the agent turn without creating a visible message
 // in the chat. Used by clarification recovery so the cancel-and-retry is seamless.
+//
+// If the agent manager reports no live execution for the session, the session may be stuck
+// (agent crashed mid-turn). In that case, skip the cancel signal but still reconcile the
+// session's state so clarification recovery can proceed with a fresh prompt.
 func (s *Service) cancelAgentSilent(ctx context.Context, taskID, sessionID string) error {
 	if err := s.agentManager.CancelAgent(ctx, sessionID); err != nil {
-		return fmt.Errorf("cancel agent: %w", err)
+		if !errors.Is(err, lifecycle.ErrNoExecutionForSession) {
+			return fmt.Errorf("cancel agent: %w", err)
+		}
+		// Agent crashed or exited mid-turn — clarification recovery cannot signal a cancel,
+		// but we still reconcile state below so a fresh prompt can run. Error level so this
+		// surfaces for root-cause investigation of the crash.
+		s.logger.Error("agent process appears to have crashed during clarification recovery",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
 	}
 
 	s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateWaitingForInput, "", true, nil)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/agent/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/client"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
@@ -1603,6 +1604,12 @@ func (s *Service) RespondToPermission(ctx context.Context, sessionID, pendingID,
 
 // CancelAgent interrupts the current agent turn without terminating the process,
 // allowing the user to send a new prompt.
+//
+// Idempotent w.r.t. missing executions: if the agent manager reports no live execution
+// for the session (ErrNoExecutionForSession), the method still reconciles the session's
+// DB state (transitions to WAITING_FOR_INPUT, records the cancel message, completes the
+// turn) so the user can unstick a session whose agent subprocess crashed. Other errors
+// still fail the cancel.
 func (s *Service) CancelAgent(ctx context.Context, sessionID string) error {
 	s.logger.Debug("cancelling agent turn", zap.String("session_id", sessionID))
 
@@ -1615,7 +1622,16 @@ func (s *Service) CancelAgent(ctx context.Context, sessionID string) error {
 	}
 
 	if err := s.agentManager.CancelAgent(ctx, sessionID); err != nil {
-		return fmt.Errorf("cancel agent: %w", err)
+		if !errors.Is(err, lifecycle.ErrNoExecutionForSession) {
+			return fmt.Errorf("cancel agent: %w", err)
+		}
+		// The session was live but there is no execution to cancel — the agent process
+		// crashed, exited, or never re-registered after a backend restart. Log at error
+		// level so operators notice the stuck state; we still reconcile DB state below
+		// so the UI unsticks.
+		s.logger.Error("agent process appears to have crashed: no live execution for session on cancel",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
 	}
 
 	// Transition to WAITING_FOR_INPUT so the user can send a new prompt


### PR DESCRIPTION
Sessions could get stuck in RUNNING with no way to recover when an agent process crashed mid-turn — the pause/end-turn button did nothing because cancel propagated the lifecycle manager's "no execution for session" error. Cancel is now idempotent w.r.t. missing executions: the crash is surfaced via an error log and the session reconciles to WAITING_FOR_INPUT so the user can send a fresh prompt.

## Important Changes

- New sentinel `lifecycle.ErrNoExecutionForSession`; callers use \`errors.Is\` to distinguish "agent is gone" from other failures.
- \`Service.CancelAgent\` and \`cancelAgentSilent\` (clarification recovery) treat the sentinel as a success-with-warning: log at error level, still transition state + record cancel message + complete turn.

## Validation

- New integration test \`TestOrchestratorCancelAfterAgentCrash_UnsticksSession\` (RED → GREEN): starts a task, pins session to RUNNING, simulates a crash via a new \`CrashAgentForSession\` helper on the simulated agent manager, then asserts the WS cancel returns success, the session transitions to WAITING_FOR_INPUT, and a \`"Turn cancelled by user"\` status message is persisted.
- \`make fmt\`, \`make test\` (743 passed), \`make lint\` (0 issues).

## Possible Improvements

Low risk — the fix only changes behaviour on the error path that previously failed the cancel. Doesn't address the root cause of the agent crash itself; error log is the breadcrumb for follow-up investigation.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.