### PR TITLE
fix: apply display filters in list view

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -323,7 +323,7 @@ func (m *mockRepository) DeleteTask(ctx context.Context, id string) error       
 func (m *mockRepository) ListTasks(ctx context.Context, workflowID string) ([]*models.Task, error) {
 	return nil, nil
 }
-func (m *mockRepository) ListTasksByWorkspace(ctx context.Context, workspaceID string, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
+func (m *mockRepository) ListTasksByWorkspace(ctx context.Context, workspaceID, workflowID, repositoryID, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
 	return nil, 0, nil
 }
 func (m *mockRepository) ListTasksByWorkflowStep(ctx context.Context, workflowStepID string) ([]*models.Task, error) {

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -61,7 +61,7 @@ func (m *mockRepository) DeleteTask(ctx context.Context, id string) error {
 func (m *mockRepository) ListTasks(ctx context.Context, workflowID string) ([]*models.Task, error) {
 	return nil, nil
 }
-func (m *mockRepository) ListTasksByWorkspace(ctx context.Context, workspaceID string, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
+func (m *mockRepository) ListTasksByWorkspace(ctx context.Context, workspaceID, workflowID, repositoryID, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
 	return nil, 0, nil
 }
 func (m *mockRepository) ListTasksByWorkflowStep(ctx context.Context, workflowStepID string) ([]*models.Task, error) {

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -50,13 +50,15 @@ func (h *TaskHandlers) httpListTasksByWorkspace(c *gin.Context) {
 	}
 
 	query := c.Query("query")
+	workflowID := c.Query("workflow_id")
+	repositoryID := c.Query("repository_id")
 	includeArchived := c.Query("include_archived") == queryValueTrue
 	includeEphemeral := c.Query("include_ephemeral") == queryValueTrue
 	onlyEphemeral := c.Query("only_ephemeral") == queryValueTrue
 	excludeConfig := c.Query("exclude_config") == queryValueTrue
 
 	tasks, total, err := h.service.ListTasksByWorkspace(
-		c.Request.Context(), c.Param("id"), query, page, pageSize, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig,
+		c.Request.Context(), c.Param("id"), workflowID, repositoryID, query, page, pageSize, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig,
 	)
 	if err != nil {
 		handleNotFound(c, h.logger, err, "tasks not found")

--- a/apps/backend/internal/task/repository/archive_repository_test.go
+++ b/apps/backend/internal/task/repository/archive_repository_test.go
@@ -114,7 +114,7 @@ func TestSQLiteRepository_ListTasksByWorkspace_IncludeArchived(t *testing.T) {
 	_ = repo.ArchiveTask(ctx, "task-2")
 
 	// Without includeArchived: should return only active task
-	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", 1, 10, false, false, false, false)
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to list tasks: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestSQLiteRepository_ListTasksByWorkspace_IncludeArchived(t *testing.T) {
 	}
 
 	// With includeArchived: should return both tasks
-	tasks, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "", 1, 10, true, false, false, false)
+	tasks, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "", 1, 10, true, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to list tasks with archived: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestSQLiteRepository_ListTasksByWorkspace_IncludeArchived(t *testing.T) {
 	}
 
 	// Search with includeArchived=false should filter archived
-	_, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "Task", 1, 10, false, false, false, false)
+	_, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "Task", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to search tasks: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestSQLiteRepository_ListTasksByWorkspace_IncludeArchived(t *testing.T) {
 	}
 
 	// Search with includeArchived=true should include archived
-	_, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "Task", 1, 10, true, false, false, false)
+	_, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "Task", 1, 10, true, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to search tasks with archived: %v", err)
 	}

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -25,7 +25,7 @@ type TaskRepository interface {
 	UpdateTask(ctx context.Context, task *models.Task) error
 	DeleteTask(ctx context.Context, id string) error
 	ListTasks(ctx context.Context, workflowID string) ([]*models.Task, error)
-	ListTasksByWorkspace(ctx context.Context, workspaceID string, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error)
+	ListTasksByWorkspace(ctx context.Context, workspaceID, workflowID, repositoryID, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error)
 	ListTasksByWorkflowStep(ctx context.Context, workflowStepID string) ([]*models.Task, error)
 	ArchiveTask(ctx context.Context, id string) error
 	ListTasksForAutoArchive(ctx context.Context) ([]*models.Task, error)

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -179,7 +179,7 @@ func (r *Repository) ListTasksByWorkflowStep(ctx context.Context, workflowStepID
 // If includeArchived is false, archived tasks are excluded
 // If includeEphemeral is false, ephemeral tasks are excluded
 // If onlyEphemeral is true, only ephemeral tasks are returned
-func (r *Repository) ListTasksByWorkspace(ctx context.Context, workspaceID string, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
+func (r *Repository) ListTasksByWorkspace(ctx context.Context, workspaceID, workflowID, repositoryID, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
 	ctx, span := tracing.Tracer("kandev-db").Start(ctx, "db.ListTasksByWorkspace")
 	defer span.End()
 	// Calculate offset
@@ -212,9 +212,9 @@ func (r *Repository) ListTasksByWorkspace(ctx context.Context, workspaceID strin
 	var err error
 
 	if query == "" {
-		rows, total, err = r.queryAllTasks(ctx, workspaceID, filter, pageSize, offset)
+		rows, total, err = r.queryAllTasks(ctx, workspaceID, filter, workflowID, repositoryID, pageSize, offset)
 	} else {
-		rows, total, err = r.searchTasks(ctx, workspaceID, query, filter, pageSize, offset, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig)
+		rows, total, err = r.searchTasks(ctx, workspaceID, query, filter, workflowID, repositoryID, pageSize, offset, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig)
 	}
 
 	if err != nil {
@@ -231,24 +231,33 @@ func (r *Repository) ListTasksByWorkspace(ctx context.Context, workspaceID strin
 }
 
 // queryAllTasks fetches all tasks (no search) for a workspace with pagination.
-func (r *Repository) queryAllTasks(ctx context.Context, workspaceID, archiveFilter string, pageSize, offset int) (*sql.Rows, int, error) {
+func (r *Repository) queryAllTasks(ctx context.Context, workspaceID, archiveFilter, workflowID, repositoryID string, pageSize, offset int) (*sql.Rows, int, error) {
+	filter := archiveFilter
+	args := []interface{}{workspaceID}
+	if workflowID != "" {
+		filter += " AND workflow_id = ?"
+		args = append(args, workflowID)
+	}
+	if repositoryID != "" {
+		filter += " AND id IN (SELECT task_id FROM task_repositories WHERE repository_id = ?)"
+		args = append(args, repositoryID)
+	}
 	var total int
-	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`SELECT COUNT(*) FROM tasks WHERE workspace_id = ?`+archiveFilter), workspaceID).Scan(&total)
-	if err != nil {
+	if err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`SELECT COUNT(*) FROM tasks WHERE workspace_id = ?`+filter), args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
 		SELECT id, workspace_id, workflow_id, workflow_step_id, title, description, state, priority, position, metadata, is_ephemeral, parent_id, archived_at, created_at, updated_at
 		FROM tasks
-		WHERE workspace_id = ?`+archiveFilter+`
+		WHERE workspace_id = ?`+filter+`
 		ORDER BY updated_at DESC
 		LIMIT ? OFFSET ?
-	`), workspaceID, pageSize, offset)
+	`), append(args, pageSize, offset)...)
 	return rows, total, err
 }
 
 // searchTasks fetches tasks matching a search query for a workspace with pagination.
-func (r *Repository) searchTasks(ctx context.Context, workspaceID, query, filter string, pageSize, offset int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) (*sql.Rows, int, error) {
+func (r *Repository) searchTasks(ctx context.Context, workspaceID, query, filter, workflowID, repositoryID string, pageSize, offset int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) (*sql.Rows, int, error) {
 	searchPattern := "%" + query + "%"
 	like := dialect.Like(r.ro.DriverName())
 
@@ -266,6 +275,17 @@ func (r *Repository) searchTasks(ctx context.Context, workspaceID, query, filter
 		tFilter += " AND (t.metadata IS NULL OR json_extract(t.metadata, '$.config_mode') IS NOT 1)"
 	}
 
+	// Collect extra filter args in query-argument order
+	var extraArgs []interface{}
+	if workflowID != "" {
+		tFilter += " AND t.workflow_id = ?"
+		extraArgs = append(extraArgs, workflowID)
+	}
+	if repositoryID != "" {
+		tFilter += " AND tr.repository_id = ?"
+		extraArgs = append(extraArgs, repositoryID)
+	}
+
 	countQuery := fmt.Sprintf(`
 		SELECT COUNT(DISTINCT t.id) FROM tasks t
 		LEFT JOIN task_repositories tr ON t.id = tr.task_id
@@ -278,8 +298,9 @@ func (r *Repository) searchTasks(ctx context.Context, workspaceID, query, filter
 			r.local_path %s ?
 		)
 	`, tFilter, like, like, like, like)
+	countArgs := append(append([]interface{}{workspaceID}, extraArgs...), searchPattern, searchPattern, searchPattern, searchPattern)
 	var total int
-	if err := r.ro.QueryRowContext(ctx, r.ro.Rebind(countQuery), workspaceID, searchPattern, searchPattern, searchPattern, searchPattern).Scan(&total); err != nil {
+	if err := r.ro.QueryRowContext(ctx, r.ro.Rebind(countQuery), countArgs...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 
@@ -298,7 +319,8 @@ func (r *Repository) searchTasks(ctx context.Context, workspaceID, query, filter
 		ORDER BY t.updated_at DESC
 		LIMIT ? OFFSET ?
 	`, tFilter, like, like, like, like)
-	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(selectQuery), workspaceID, searchPattern, searchPattern, searchPattern, searchPattern, pageSize, offset)
+	selectArgs := append(countArgs, pageSize, offset)
+	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(selectQuery), selectArgs...)
 	return rows, total, err
 }
 

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -319,7 +319,7 @@ func (r *Repository) searchTasks(ctx context.Context, workspaceID, query, filter
 		ORDER BY t.updated_at DESC
 		LIMIT ? OFFSET ?
 	`, tFilter, like, like, like, like)
-	selectArgs := append(countArgs, pageSize, offset)
+	selectArgs := append(append([]interface{}{}, countArgs...), pageSize, offset)
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(selectQuery), selectArgs...)
 	return rows, total, err
 }

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -231,28 +231,27 @@ func (r *Repository) ListTasksByWorkspace(ctx context.Context, workspaceID, work
 }
 
 // queryAllTasks fetches all tasks (no search) for a workspace with pagination.
-func (r *Repository) queryAllTasks(ctx context.Context, workspaceID, archiveFilter, workflowID, repositoryID string, pageSize, offset int) (*sql.Rows, int, error) {
-	filter := archiveFilter
+func (r *Repository) queryAllTasks(ctx context.Context, workspaceID, taskFilter, workflowID, repositoryID string, pageSize, offset int) (*sql.Rows, int, error) {
 	args := []interface{}{workspaceID}
 	if workflowID != "" {
-		filter += " AND workflow_id = ?"
+		taskFilter += " AND workflow_id = ?"
 		args = append(args, workflowID)
 	}
 	if repositoryID != "" {
-		filter += " AND id IN (SELECT task_id FROM task_repositories WHERE repository_id = ?)"
+		taskFilter += " AND id IN (SELECT task_id FROM task_repositories WHERE repository_id = ?)"
 		args = append(args, repositoryID)
 	}
 	var total int
-	if err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`SELECT COUNT(*) FROM tasks WHERE workspace_id = ?`+filter), args...).Scan(&total); err != nil {
+	if err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`SELECT COUNT(*) FROM tasks WHERE workspace_id = ?`+taskFilter), args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
 		SELECT id, workspace_id, workflow_id, workflow_step_id, title, description, state, priority, position, metadata, is_ephemeral, parent_id, archived_at, created_at, updated_at
 		FROM tasks
-		WHERE workspace_id = ?`+filter+`
+		WHERE workspace_id = ?`+taskFilter+`
 		ORDER BY updated_at DESC
 		LIMIT ? OFFSET ?
-	`), append(args, pageSize, offset)...)
+	`), append(append([]interface{}{}, args...), pageSize, offset)...)
 	return rows, total, err
 }
 

--- a/apps/backend/internal/task/repository/task_repository_test.go
+++ b/apps/backend/internal/task/repository/task_repository_test.go
@@ -196,7 +196,7 @@ func TestSQLiteRepository_ListTasksByWorkspace(t *testing.T) {
 	_ = repo.CreateTask(ctx, &models.Task{ID: "task-4", WorkspaceID: "ws-2", WorkflowID: "wf-456", WorkflowStepID: "step-2", Title: "Task Four"})
 
 	// Test basic listing without search
-	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", 1, 10, false, false, false, false)
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to list tasks by workspace: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestSQLiteRepository_ListTasksByWorkspace(t *testing.T) {
 	}
 
 	// Test pagination
-	tasks, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "", 1, 2, false, false, false, false)
+	tasks, total, err = repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "", 1, 2, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to list tasks with pagination: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestSQLiteRepository_ListTasksByWorkspace(t *testing.T) {
 	}
 
 	// Test page 2
-	tasksPage2, _, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", 2, 2, false, false, false, false)
+	tasksPage2, _, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "", 2, 2, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to list tasks page 2: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestSQLiteRepository_ListTasksByWorkspaceWithSearch(t *testing.T) {
 	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-1", TaskID: "task-1", RepositoryID: "repo-1", BaseBranch: "main"})
 
 	// Test search by title
-	_, totalAuth, err := repo.ListTasksByWorkspace(ctx, "ws-1", "authentication", 1, 10, false, false, false, false)
+	_, totalAuth, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "authentication", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to search tasks by title: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestSQLiteRepository_ListTasksByWorkspaceWithSearch(t *testing.T) {
 	}
 
 	// Test search by description
-	tasksDarkMode, totalDarkMode, err := repo.ListTasksByWorkspace(ctx, "ws-1", "dark mode", 1, 10, false, false, false, false)
+	tasksDarkMode, totalDarkMode, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "dark mode", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to search tasks by description: %v", err)
 	}
@@ -271,7 +271,7 @@ func TestSQLiteRepository_ListTasksByWorkspaceWithSearch(t *testing.T) {
 	}
 
 	// Test search by repository name
-	tasksRepo, totalRepo, err := repo.ListTasksByWorkspace(ctx, "ws-1", "MyProject", 1, 10, false, false, false, false)
+	tasksRepo, totalRepo, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "MyProject", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to search tasks by repository name: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestSQLiteRepository_ListTasksByWorkspaceWithSearch(t *testing.T) {
 	}
 
 	// Test search by repository local_path
-	_, totalPath, err := repo.ListTasksByWorkspace(ctx, "ws-1", "myproject", 1, 10, false, false, false, false)
+	_, totalPath, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "myproject", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to search tasks by repository path: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestSQLiteRepository_ListTasksByWorkspaceWithSearch(t *testing.T) {
 	}
 
 	// Test search with no results
-	tasksNone, totalNone, err := repo.ListTasksByWorkspace(ctx, "ws-1", "nonexistent", 1, 10, false, false, false, false)
+	tasksNone, totalNone, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "nonexistent", 1, 10, false, false, false, false)
 	if err != nil {
 		t.Fatalf("failed to search tasks with no results: %v", err)
 	}

--- a/apps/backend/internal/task/repository/task_repository_test.go
+++ b/apps/backend/internal/task/repository/task_repository_test.go
@@ -304,6 +304,178 @@ func TestSQLiteRepository_ListTasksByWorkspaceWithSearch(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepository_ListTasksByWorkspace_WorkflowFilter(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-a", WorkspaceID: "ws-1", Name: "Workflow A"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-b", WorkspaceID: "ws-1", Name: "Workflow B"})
+
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-1", WorkspaceID: "ws-1", WorkflowID: "wf-a", WorkflowStepID: "s-1", Title: "Alpha task"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-2", WorkspaceID: "ws-1", WorkflowID: "wf-a", WorkflowStepID: "s-1", Title: "Beta task"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-3", WorkspaceID: "ws-1", WorkflowID: "wf-b", WorkflowStepID: "s-1", Title: "Gamma task"})
+
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "wf-a", "", "", 1, 10, false, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace failed: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("expected total 2 for wf-a, got %d", total)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks, got %d", len(tasks))
+	}
+	for _, task := range tasks {
+		if task.WorkflowID != "wf-a" {
+			t.Errorf("expected workflow wf-a, got %s", task.WorkflowID)
+		}
+	}
+}
+
+func TestSQLiteRepository_ListTasksByWorkspace_RepositoryFilter(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateRepository(ctx, &models.Repository{ID: "repo-1", WorkspaceID: "ws-1", Name: "Repo One", LocalPath: "/repo/one"})
+	_ = repo.CreateRepository(ctx, &models.Repository{ID: "repo-2", WorkspaceID: "ws-1", Name: "Repo Two", LocalPath: "/repo/two"})
+
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-1", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "s-1", Title: "Task One"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-2", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "s-1", Title: "Task Two"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-3", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "s-1", Title: "Task Three"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-1", TaskID: "t-1", RepositoryID: "repo-1"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-2", TaskID: "t-2", RepositoryID: "repo-2"})
+
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "repo-1", "", 1, 10, false, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace failed: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected total 1 for repo-1, got %d", total)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "t-1" {
+		t.Errorf("expected only t-1, got %v", tasks)
+	}
+}
+
+func TestSQLiteRepository_ListTasksByWorkspace_WorkflowAndRepositoryFilter(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-a", WorkspaceID: "ws-1", Name: "Workflow A"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-b", WorkspaceID: "ws-1", Name: "Workflow B"})
+	_ = repo.CreateRepository(ctx, &models.Repository{ID: "repo-1", WorkspaceID: "ws-1", Name: "Repo One", LocalPath: "/repo/one"})
+
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-1", WorkspaceID: "ws-1", WorkflowID: "wf-a", WorkflowStepID: "s-1", Title: "Match task"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-2", WorkspaceID: "ws-1", WorkflowID: "wf-a", WorkflowStepID: "s-1", Title: "No repo task"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-3", WorkspaceID: "ws-1", WorkflowID: "wf-b", WorkflowStepID: "s-1", Title: "Wrong workflow"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-1", TaskID: "t-1", RepositoryID: "repo-1"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-3", TaskID: "t-3", RepositoryID: "repo-1"})
+
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "wf-a", "repo-1", "", 1, 10, false, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace failed: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected total 1 (wf-a + repo-1), got %d", total)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "t-1" {
+		t.Errorf("expected only t-1, got %v", tasks)
+	}
+}
+
+func TestSQLiteRepository_ListTasksByWorkspace_WorkflowFilterWithQuery(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-a", WorkspaceID: "ws-1", Name: "Workflow A"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-b", WorkspaceID: "ws-1", Name: "Workflow B"})
+
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-1", WorkspaceID: "ws-1", WorkflowID: "wf-a", WorkflowStepID: "s-1", Title: "Fix login bug"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-2", WorkspaceID: "ws-1", WorkflowID: "wf-a", WorkflowStepID: "s-1", Title: "Fix payment bug"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-3", WorkspaceID: "ws-1", WorkflowID: "wf-b", WorkflowStepID: "s-1", Title: "Fix login bug"})
+
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "wf-a", "", "login", 1, 10, false, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace failed: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 result (wf-a + 'login'), got %d", total)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "t-1" {
+		t.Errorf("expected only t-1, got %v", tasks)
+	}
+}
+
+func TestSQLiteRepository_ListTasksByWorkspace_RepositoryFilterWithQuery(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateRepository(ctx, &models.Repository{ID: "repo-1", WorkspaceID: "ws-1", Name: "Repo One", LocalPath: "/repo/one"})
+
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-1", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "s-1", Title: "Fix auth bug"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-2", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "s-1", Title: "Fix auth elsewhere"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-1", TaskID: "t-1", RepositoryID: "repo-1"})
+
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "repo-1", "auth", 1, 10, false, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace failed: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 result (repo-1 + 'auth'), got %d", total)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "t-1" {
+		t.Errorf("expected only t-1, got %v", tasks)
+	}
+}
+
+func TestSQLiteRepository_ListTasksByWorkspace_DistinctWithMultipleRepos(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateRepository(ctx, &models.Repository{ID: "repo-1", WorkspaceID: "ws-1", Name: "Repo One", LocalPath: "/repo/one"})
+	_ = repo.CreateRepository(ctx, &models.Repository{ID: "repo-2", WorkspaceID: "ws-1", Name: "Repo Two", LocalPath: "/repo/two"})
+
+	// t-1 is linked to two repositories — must not appear twice in results
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-1", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "s-1", Title: "Multi-repo task"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "t-2", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "s-1", Title: "Single-repo task"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-1", TaskID: "t-1", RepositoryID: "repo-1"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-2", TaskID: "t-1", RepositoryID: "repo-2"})
+	_ = repo.CreateTaskRepository(ctx, &models.TaskRepository{ID: "tr-3", TaskID: "t-2", RepositoryID: "repo-1"})
+
+	tasks, total, err := repo.ListTasksByWorkspace(ctx, "ws-1", "", "", "task", 1, 10, false, false, false, false)
+	if err != nil {
+		t.Fatalf("ListTasksByWorkspace failed: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("expected total 2 distinct tasks, got %d", total)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 rows (no duplicates), got %d", len(tasks))
+	}
+	seen := make(map[string]int)
+	for _, task := range tasks {
+		seen[task.ID]++
+	}
+	if seen["t-1"] != 1 {
+		t.Errorf("expected t-1 exactly once, appeared %d times", seen["t-1"])
+	}
+}
+
 func TestSQLiteRepository_Persistence(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "persistence_test.db")

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -668,8 +668,9 @@ func (s *Service) ListTasks(ctx context.Context, workflowID string) ([]*models.T
 
 // ListTasksByWorkspace returns paginated tasks for a workspace with task repositories loaded.
 // If query is non-empty, filters by task title, description, repository name, or repository path.
-func (s *Service) ListTasksByWorkspace(ctx context.Context, workspaceID string, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
-	tasks, total, err := s.tasks.ListTasksByWorkspace(ctx, workspaceID, query, page, pageSize, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig)
+// workflowID and repositoryID, when non-empty, further restrict results to that workflow/repository.
+func (s *Service) ListTasksByWorkspace(ctx context.Context, workspaceID, workflowID, repositoryID, query string, page, pageSize int, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig bool) ([]*models.Task, int, error) {
+	tasks, total, err := s.tasks.ListTasksByWorkspace(ctx, workspaceID, workflowID, repositoryID, query, page, pageSize, includeArchived, includeEphemeral, onlyEphemeral, excludeConfig)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/apps/web/app/actions/workspaces.ts
+++ b/apps/web/app/actions/workspaces.ts
@@ -101,11 +101,15 @@ export async function listTasksByWorkspaceAction(
   page = 1,
   pageSize = 50,
   query = "",
+  workflowId?: string | null,
+  repositoryId?: string | null,
 ): Promise<ListTasksResponse> {
   const url = new URL(`${apiBaseUrl}/api/v1/workspaces/${workspaceId}/tasks`);
   url.searchParams.set("page", String(page));
   url.searchParams.set("page_size", String(pageSize));
   if (query) url.searchParams.set("query", query);
+  if (workflowId) url.searchParams.set("workflow_id", workflowId);
+  if (repositoryId) url.searchParams.set("repository_id", repositoryId);
   return fetchJson<ListTasksResponse>(url.toString());
 }
 

--- a/apps/web/app/actions/workspaces.ts
+++ b/apps/web/app/actions/workspaces.ts
@@ -96,14 +96,19 @@ export async function listWorkflowsAction(workspaceId: string): Promise<ListWork
   return fetchJson<ListWorkflowsResponse>(url.toString());
 }
 
+type ListTasksOptions = {
+  page?: number;
+  pageSize?: number;
+  query?: string;
+  workflowId?: string | null;
+  repositoryId?: string | null;
+};
+
 export async function listTasksByWorkspaceAction(
   workspaceId: string,
-  page = 1,
-  pageSize = 50,
-  query = "",
-  workflowId?: string | null,
-  repositoryId?: string | null,
+  options: ListTasksOptions = {},
 ): Promise<ListTasksResponse> {
+  const { page = 1, pageSize = 50, query, workflowId, repositoryId } = options;
   const url = new URL(`${apiBaseUrl}/api/v1/workspaces/${workspaceId}/tasks`);
   url.searchParams.set("page", String(page));
   url.searchParams.set("page_size", String(pageSize));

--- a/apps/web/app/tasks/page.tsx
+++ b/apps/web/app/tasks/page.tsx
@@ -9,7 +9,14 @@ import { fetchUserSettings } from "@/lib/api";
 import { StateHydrator } from "@/components/state-hydrator";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { TasksPageClient } from "./tasks-page-client";
-import type { Workflow, Task, WorkflowStep, Repository, Workspace, UserSettingsResponse } from "@/lib/types/http";
+import type {
+  Workflow,
+  Task,
+  WorkflowStep,
+  Repository,
+  Workspace,
+  UserSettingsResponse,
+} from "@/lib/types/http";
 import type { AppState } from "@/lib/state/store";
 
 type WorkspaceData = {
@@ -21,19 +28,30 @@ type WorkspaceData = {
   activeWorkflowId: string | null;
 };
 
-async function fetchWorkspaceData(workspaceId: string, settingsResponse: UserSettingsResponse | null): Promise<WorkspaceData> {
+async function fetchWorkspaceData(
+  workspaceId: string,
+  settingsResponse: UserSettingsResponse | null,
+): Promise<WorkspaceData> {
   const savedWorkflowId = settingsResponse?.settings?.workflow_filter_id ?? null;
   const savedRepositoryId = settingsResponse?.settings?.repository_ids?.[0] ?? null;
 
-  const [workflowsResponse, repositoriesResponse, tasksResponse, stepsResponse] = await Promise.all([
-    listWorkflowsAction(workspaceId),
-    listRepositoriesAction(workspaceId),
-    listTasksByWorkspaceAction(workspaceId, { page: 1, pageSize: 25, workflowId: savedWorkflowId, repositoryId: savedRepositoryId }),
-    listWorkspaceWorkflowStepsAction(workspaceId),
-  ]);
+  const [workflowsResponse, repositoriesResponse, tasksResponse, stepsResponse] = await Promise.all(
+    [
+      listWorkflowsAction(workspaceId),
+      listRepositoriesAction(workspaceId),
+      listTasksByWorkspaceAction(workspaceId, {
+        page: 1,
+        pageSize: 25,
+        workflowId: savedWorkflowId,
+        repositoryId: savedRepositoryId,
+      }),
+      listWorkspaceWorkflowStepsAction(workspaceId),
+    ],
+  );
 
   const workflows = workflowsResponse.workflows;
-  const activeWorkflowId = workflows.find((w) => w.id === savedWorkflowId)?.id ?? workflows[0]?.id ?? null;
+  const activeWorkflowId =
+    workflows.find((w) => w.id === savedWorkflowId)?.id ?? workflows[0]?.id ?? null;
 
   return {
     workflows,

--- a/apps/web/app/tasks/page.tsx
+++ b/apps/web/app/tasks/page.tsx
@@ -28,7 +28,6 @@ export default async function TasksPage({
   let workspaceId = workspaceParam;
   let userSettingsResponse: UserSettingsResponse | null = null;
   let activeWorkflowId: string | null = null;
-  let activeRepositoryId: string | null = null;
 
   try {
     const [workspacesResponse, settingsResponse] = await Promise.all([
@@ -45,32 +44,25 @@ export default async function TasksPage({
 
     if (workspaceId) {
       // Fetch all data in parallel (including steps via single batch endpoint)
+      // Resolve active filters before fetching tasks so the server applies them
+      const savedWorkflowId = settingsResponse?.settings?.workflow_filter_id || null;
+      const savedRepositoryId = settingsResponse?.settings?.repository_ids?.[0] ?? null;
+
       const [workflowsResponse, repositoriesResponse, tasksResponse, stepsResponse] =
         await Promise.all([
           listWorkflowsAction(workspaceId),
           listRepositoriesAction(workspaceId),
-          listTasksByWorkspaceAction(workspaceId, 1, 25),
+          listTasksByWorkspaceAction(workspaceId, 1, 25, "", savedWorkflowId, savedRepositoryId),
           listWorkspaceWorkflowStepsAction(workspaceId),
         ]);
 
       workflows = workflowsResponse.workflows;
       repositories = repositoriesResponse.repositories;
 
-      // Resolve active workflow: user settings > first workflow
-      const savedWorkflowId = settingsResponse?.settings?.workflow_filter_id || null;
-      const preferred = workflows.find((w) => w.id === savedWorkflowId);
-      activeWorkflowId = preferred?.id ?? workflows[0]?.id ?? null;
-
-      // Resolve active repository filter from user settings
-      activeRepositoryId = settingsResponse?.settings?.repository_ids?.[0] ?? null;
+      activeWorkflowId = workflows.find((w) => w.id === savedWorkflowId)?.id ?? workflows[0]?.id ?? null;
 
       total = tasksResponse.total;
-
-      // Pre-filter by workflow + repository to match the active display filters,
-      // so the initial render is already correct without waiting for store hydration.
       tasks = tasksResponse.tasks;
-      if (activeWorkflowId) tasks = tasks.filter((t) => t.workflow_id === activeWorkflowId);
-      if (activeRepositoryId) tasks = tasks.filter((t) => t.repositories?.some((r) => r.repository_id === activeRepositoryId));
       steps = stepsResponse.steps;
     }
   } catch (error) {

--- a/apps/web/app/tasks/page.tsx
+++ b/apps/web/app/tasks/page.tsx
@@ -5,8 +5,12 @@ import {
   listRepositoriesAction,
   listWorkspaceWorkflowStepsAction,
 } from "@/app/actions/workspaces";
+import { fetchUserSettings } from "@/lib/api";
+import { StateHydrator } from "@/components/state-hydrator";
+import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { TasksPageClient } from "./tasks-page-client";
-import type { Workflow, Task, WorkflowStep, Repository, Workspace } from "@/lib/types/http";
+import type { Workflow, Task, WorkflowStep, Repository, Workspace, UserSettingsResponse } from "@/lib/types/http";
+import type { AppState } from "@/lib/state/store";
 
 export default async function TasksPage({
   searchParams,
@@ -22,14 +26,21 @@ export default async function TasksPage({
   let tasks: Task[] = [];
   let total = 0;
   let workspaceId = workspaceParam;
+  let userSettingsResponse: UserSettingsResponse | null = null;
+  let activeWorkflowId: string | null = null;
+  let activeRepositoryId: string | null = null;
 
   try {
-    const workspacesResponse = await listWorkspacesAction();
+    const [workspacesResponse, settingsResponse] = await Promise.all([
+      listWorkspacesAction(),
+      fetchUserSettings({ cache: "no-store" }).catch(() => null),
+    ]);
     workspaces = workspacesResponse.workspaces;
+    userSettingsResponse = settingsResponse;
 
-    // Use first workspace if none specified
-    if (!workspaceId && workspaces.length > 0) {
-      workspaceId = workspaces[0].id;
+    // Use workspace from user settings or URL param or first workspace
+    if (!workspaceId) {
+      workspaceId = settingsResponse?.settings?.workspace_id || workspaces[0]?.id;
     }
 
     if (workspaceId) {
@@ -44,23 +55,70 @@ export default async function TasksPage({
 
       workflows = workflowsResponse.workflows;
       repositories = repositoriesResponse.repositories;
-      tasks = tasksResponse.tasks;
+
+      // Resolve active workflow: user settings > first workflow
+      const savedWorkflowId = settingsResponse?.settings?.workflow_filter_id || null;
+      const preferred = workflows.find((w) => w.id === savedWorkflowId);
+      activeWorkflowId = preferred?.id ?? workflows[0]?.id ?? null;
+
+      // Resolve active repository filter from user settings
+      activeRepositoryId = settingsResponse?.settings?.repository_ids?.[0] ?? null;
+
       total = tasksResponse.total;
+
+      // Pre-filter by workflow + repository to match the active display filters,
+      // so the initial render is already correct without waiting for store hydration.
+      tasks = tasksResponse.tasks;
+      if (activeWorkflowId) tasks = tasks.filter((t) => t.workflow_id === activeWorkflowId);
+      if (activeRepositoryId) tasks = tasks.filter((t) => t.repositories?.some((r) => r.repository_id === activeRepositoryId));
       steps = stepsResponse.steps;
     }
   } catch (error) {
     console.error("Failed to load tasks page data:", error);
   }
 
+  const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
+
+  const initialState: Partial<AppState> = {
+    workspaces: {
+      items: workspaces,
+      activeId: workspaceId ?? null,
+    },
+    workflows: {
+      items: workflows.map((w) => ({
+        id: w.id,
+        workspaceId: w.workspace_id,
+        name: w.name,
+        description: w.description ?? null,
+        sortOrder: w.sort_order ?? 0,
+        ...(w.agent_profile_id ? { agent_profile_id: w.agent_profile_id } : {}),
+      })),
+      activeId: activeWorkflowId,
+    },
+    userSettings: { ...mappedUserSettings, workspaceId: workspaceId ?? null },
+    ...(workspaceId
+      ? {
+          repositories: {
+            itemsByWorkspaceId: { [workspaceId]: repositories },
+            loadingByWorkspaceId: { [workspaceId]: false },
+            loadedByWorkspaceId: { [workspaceId]: true },
+          },
+        }
+      : {}),
+  };
+
   return (
-    <TasksPageClient
-      workspaces={workspaces}
-      initialWorkspaceId={workspaceId}
-      initialWorkflows={workflows}
-      initialSteps={steps}
-      initialRepositories={repositories}
-      initialTasks={tasks}
-      initialTotal={total}
-    />
+    <>
+      <StateHydrator initialState={initialState} />
+      <TasksPageClient
+        workspaces={workspaces}
+        initialWorkspaceId={workspaceId}
+        initialWorkflows={workflows}
+        initialSteps={steps}
+        initialRepositories={repositories}
+        initialTasks={tasks}
+        initialTotal={total}
+      />
+    </>
   );
 }

--- a/apps/web/app/tasks/page.tsx
+++ b/apps/web/app/tasks/page.tsx
@@ -12,6 +12,39 @@ import { TasksPageClient } from "./tasks-page-client";
 import type { Workflow, Task, WorkflowStep, Repository, Workspace, UserSettingsResponse } from "@/lib/types/http";
 import type { AppState } from "@/lib/state/store";
 
+type WorkspaceData = {
+  workflows: Workflow[];
+  repositories: Repository[];
+  tasks: Task[];
+  total: number;
+  steps: WorkflowStep[];
+  activeWorkflowId: string | null;
+};
+
+async function fetchWorkspaceData(workspaceId: string, settingsResponse: UserSettingsResponse | null): Promise<WorkspaceData> {
+  const savedWorkflowId = settingsResponse?.settings?.workflow_filter_id ?? null;
+  const savedRepositoryId = settingsResponse?.settings?.repository_ids?.[0] ?? null;
+
+  const [workflowsResponse, repositoriesResponse, tasksResponse, stepsResponse] = await Promise.all([
+    listWorkflowsAction(workspaceId),
+    listRepositoriesAction(workspaceId),
+    listTasksByWorkspaceAction(workspaceId, { page: 1, pageSize: 25, workflowId: savedWorkflowId, repositoryId: savedRepositoryId }),
+    listWorkspaceWorkflowStepsAction(workspaceId),
+  ]);
+
+  const workflows = workflowsResponse.workflows;
+  const activeWorkflowId = workflows.find((w) => w.id === savedWorkflowId)?.id ?? workflows[0]?.id ?? null;
+
+  return {
+    workflows,
+    repositories: repositoriesResponse.repositories,
+    tasks: tasksResponse.tasks,
+    total: tasksResponse.total,
+    steps: stepsResponse.steps,
+    activeWorkflowId,
+  };
+}
+
 export default async function TasksPage({
   searchParams,
 }: {
@@ -43,27 +76,14 @@ export default async function TasksPage({
     }
 
     if (workspaceId) {
-      // Fetch all data in parallel (including steps via single batch endpoint)
-      // Resolve active filters before fetching tasks so the server applies them
-      const savedWorkflowId = settingsResponse?.settings?.workflow_filter_id || null;
-      const savedRepositoryId = settingsResponse?.settings?.repository_ids?.[0] ?? null;
-
-      const [workflowsResponse, repositoriesResponse, tasksResponse, stepsResponse] =
-        await Promise.all([
-          listWorkflowsAction(workspaceId),
-          listRepositoriesAction(workspaceId),
-          listTasksByWorkspaceAction(workspaceId, 1, 25, "", savedWorkflowId, savedRepositoryId),
-          listWorkspaceWorkflowStepsAction(workspaceId),
-        ]);
-
-      workflows = workflowsResponse.workflows;
-      repositories = repositoriesResponse.repositories;
-
-      activeWorkflowId = workflows.find((w) => w.id === savedWorkflowId)?.id ?? workflows[0]?.id ?? null;
-
-      total = tasksResponse.total;
-      tasks = tasksResponse.tasks;
-      steps = stepsResponse.steps;
+      // Fetch all data in parallel; resolve active filters so the server applies them
+      const data = await fetchWorkspaceData(workspaceId, settingsResponse);
+      workflows = data.workflows;
+      repositories = data.repositories;
+      tasks = data.tasks;
+      total = data.total;
+      steps = data.steps;
+      activeWorkflowId = data.activeWorkflowId;
     }
   } catch (error) {
     console.error("Failed to load tasks page data:", error);

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -276,6 +276,8 @@ function useTasksPageEffects({
   fetchTasks,
   pagination,
   showArchived,
+  activeWorkflowId,
+  selectedRepositoryId,
 }: {
   debouncedQuery: string;
   setPagination: (next: PaginationState | ((prev: PaginationState) => PaginationState)) => void;
@@ -283,10 +285,12 @@ function useTasksPageEffects({
   fetchTasks: () => void;
   pagination: PaginationState;
   showArchived: boolean;
+  activeWorkflowId: string | null;
+  selectedRepositoryId: string | null;
 }) {
   useEffect(() => {
     void Promise.resolve().then(() => setPagination((prev) => ({ ...prev, pageIndex: 0 })));
-  }, [debouncedQuery, setPagination]);
+  }, [debouncedQuery, activeWorkflowId, selectedRepositoryId, setPagination]);
 
   useEffect(() => {
     if (activeWorkspaceId) fetchTasks();
@@ -311,7 +315,6 @@ function useTasksPageComputed({
   deletingTaskId,
   router,
   activeWorkflowId,
-  tasks,
 }: {
   total: number;
   pagination: PaginationState;
@@ -323,7 +326,6 @@ function useTasksPageComputed({
   deletingTaskId: string | null;
   router: ReturnType<typeof useRouter>;
   activeWorkflowId: string | null;
-  tasks: Task[];
 }) {
   const pageCount = useMemo(
     () => Math.ceil(total / pagination.pageSize),
@@ -352,7 +354,7 @@ function useTasksPageComputed({
     : workflows[0];
   const defaultStep = steps.find((s) => s.workflow_id === defaultWorkflow?.id);
 
-  return { pageCount, columns, handleRowClick, defaultWorkflow, defaultStep, filteredTasks: tasks };
+  return { pageCount, columns, handleRowClick, defaultWorkflow, defaultStep };
 }
 
 function useTasksPageSetup(props: TasksPageClientProps) {
@@ -389,6 +391,8 @@ function useTasksPageSetup(props: TasksPageClientProps) {
     fetchTasks: ops.fetchTasks,
     pagination: viewState.pagination,
     showArchived: viewState.showArchived,
+    activeWorkflowId,
+    selectedRepositoryId,
   });
   const computed = useTasksPageComputed({
     total: viewState.total,
@@ -401,7 +405,6 @@ function useTasksPageSetup(props: TasksPageClientProps) {
     deletingTaskId: ops.deletingTaskId,
     router,
     activeWorkflowId,
-    tasks: viewState.tasks,
   });
   return { ...viewState, ...ops, ...computed, activeWorkspaceId, debouncedQuery };
 }
@@ -422,7 +425,7 @@ export function TasksPageClient(props: TasksPageClientProps) {
         showArchived={s.showArchived}
         setShowArchived={s.setShowArchived}
         columns={s.columns}
-        tasks={s.filteredTasks}
+        tasks={s.tasks}
         total={s.total}
         pageCount={s.pageCount}
         pagination={s.pagination}

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -27,6 +27,8 @@ interface TasksPageClientProps {
 
 type UseTaskOperationsParams = {
   activeWorkspaceId: string | null;
+  activeWorkflowId: string | null;
+  selectedRepositoryId: string | null;
   pagination: PaginationState;
   debouncedQuery: string;
   showArchived: boolean;
@@ -36,6 +38,8 @@ type UseTaskOperationsParams = {
 
 function useTaskOperations({
   activeWorkspaceId,
+  activeWorkflowId,
+  selectedRepositoryId,
   pagination,
   debouncedQuery,
   showArchived,
@@ -55,6 +59,8 @@ function useTaskOperations({
         pageSize: pagination.pageSize,
         query: debouncedQuery,
         includeArchived: showArchived,
+        workflowId: activeWorkflowId,
+        repositoryId: selectedRepositoryId,
       });
       setTasks(result.tasks);
       setTotal(result.total);
@@ -69,6 +75,8 @@ function useTaskOperations({
     }
   }, [
     activeWorkspaceId,
+    activeWorkflowId,
+    selectedRepositoryId,
     pagination.pageIndex,
     pagination.pageSize,
     debouncedQuery,
@@ -301,8 +309,6 @@ function useTasksPageComputed({
   router,
   activeWorkflowId,
   tasks,
-  allRepositoriesSelected,
-  selectedRepositoryId,
 }: {
   total: number;
   pagination: PaginationState;
@@ -315,8 +321,6 @@ function useTasksPageComputed({
   router: ReturnType<typeof useRouter>;
   activeWorkflowId: string | null;
   tasks: Task[];
-  allRepositoriesSelected: boolean;
-  selectedRepositoryId: string | null;
 }) {
   const pageCount = useMemo(
     () => Math.ceil(total / pagination.pageSize),
@@ -345,20 +349,7 @@ function useTasksPageComputed({
     : workflows[0];
   const defaultStep = steps.find((s) => s.workflow_id === defaultWorkflow?.id);
 
-  const filteredTasks = useMemo(() => {
-    let result = tasks;
-    if (activeWorkflowId) {
-      result = result.filter((t) => t.workflow_id === activeWorkflowId);
-    }
-    if (!allRepositoriesSelected && selectedRepositoryId) {
-      result = result.filter((t) =>
-        t.repositories?.some((r) => r.repository_id === selectedRepositoryId),
-      );
-    }
-    return result;
-  }, [tasks, activeWorkflowId, allRepositoriesSelected, selectedRepositoryId]);
-
-  return { pageCount, columns, handleRowClick, defaultWorkflow, defaultStep, filteredTasks };
+  return { pageCount, columns, handleRowClick, defaultWorkflow, defaultStep, filteredTasks: tasks };
 }
 
 function useTasksPageSetup(props: TasksPageClientProps) {
@@ -367,7 +358,6 @@ function useTasksPageSetup(props: TasksPageClientProps) {
     activeWorkspaceId,
     activeWorkflowId,
     repositories: storeRepositories,
-    allRepositoriesSelected,
     selectedRepositoryId,
   } = useKanbanDisplaySettings();
   const viewState = useTasksPageViewState({
@@ -381,6 +371,8 @@ function useTasksPageSetup(props: TasksPageClientProps) {
   const debouncedQuery = useDebounce(viewState.searchQuery, 300);
   const ops = useTaskOperations({
     activeWorkspaceId,
+    activeWorkflowId,
+    selectedRepositoryId,
     pagination: viewState.pagination,
     debouncedQuery,
     showArchived: viewState.showArchived,
@@ -407,8 +399,6 @@ function useTasksPageSetup(props: TasksPageClientProps) {
     router,
     activeWorkflowId,
     tasks: viewState.tasks,
-    allRepositoriesSelected,
-    selectedRepositoryId,
   });
   return { ...viewState, ...ops, ...computed, activeWorkspaceId, debouncedQuery };
 }

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -131,6 +131,7 @@ type TasksPageBodyProps = {
   setShowArchived: (show: boolean) => void;
   columns: ReturnType<typeof getColumns>;
   tasks: Task[];
+  total: number;
   pageCount: number;
   pagination: PaginationState;
   setPagination: (next: PaginationState | ((prev: PaginationState) => PaginationState)) => void;
@@ -143,6 +144,7 @@ function TasksPageBody({
   setShowArchived,
   columns,
   tasks,
+  total,
   pageCount,
   pagination,
   setPagination,
@@ -156,7 +158,7 @@ function TasksPageBody({
           <div>
             <h1 className="text-xl font-semibold">All Tasks</h1>
             <p className="text-sm text-muted-foreground">
-              {tasks.length} task{tasks.length !== 1 ? "s" : ""} found
+              {total} task{total !== 1 ? "s" : ""} found
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -174,6 +176,7 @@ function TasksPageBody({
           columns={columns}
           data={tasks}
           pageCount={pageCount}
+          rowCount={total}
           pagination={pagination}
           onPaginationChange={setPagination}
           isLoading={isLoading}
@@ -420,6 +423,7 @@ export function TasksPageClient(props: TasksPageClientProps) {
         setShowArchived={s.setShowArchived}
         columns={s.columns}
         tasks={s.filteredTasks}
+        total={s.total}
         pageCount={s.pageCount}
         pagination={s.pagination}
         setPagination={s.setPagination}

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -119,7 +119,6 @@ function useTaskOperations({
 }
 
 type TasksPageBodyProps = {
-  total: number;
   showArchived: boolean;
   setShowArchived: (show: boolean) => void;
   columns: ReturnType<typeof getColumns>;
@@ -132,7 +131,6 @@ type TasksPageBodyProps = {
 };
 
 function TasksPageBody({
-  total,
   showArchived,
   setShowArchived,
   columns,
@@ -150,7 +148,7 @@ function TasksPageBody({
           <div>
             <h1 className="text-xl font-semibold">All Tasks</h1>
             <p className="text-sm text-muted-foreground">
-              {total} task{total !== 1 ? "s" : ""} found
+              {tasks.length} task{tasks.length !== 1 ? "s" : ""} found
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -302,6 +300,9 @@ function useTasksPageComputed({
   deletingTaskId,
   router,
   activeWorkflowId,
+  tasks,
+  allRepositoriesSelected,
+  selectedRepositoryId,
 }: {
   total: number;
   pagination: PaginationState;
@@ -313,6 +314,9 @@ function useTasksPageComputed({
   deletingTaskId: string | null;
   router: ReturnType<typeof useRouter>;
   activeWorkflowId: string | null;
+  tasks: Task[];
+  allRepositoriesSelected: boolean;
+  selectedRepositoryId: string | null;
 }) {
   const pageCount = useMemo(
     () => Math.ceil(total / pagination.pageSize),
@@ -341,7 +345,20 @@ function useTasksPageComputed({
     : workflows[0];
   const defaultStep = steps.find((s) => s.workflow_id === defaultWorkflow?.id);
 
-  return { pageCount, columns, handleRowClick, defaultWorkflow, defaultStep };
+  const filteredTasks = useMemo(() => {
+    let result = tasks;
+    if (activeWorkflowId) {
+      result = result.filter((t) => t.workflow_id === activeWorkflowId);
+    }
+    if (!allRepositoriesSelected && selectedRepositoryId) {
+      result = result.filter((t) =>
+        t.repositories?.some((r) => r.repository_id === selectedRepositoryId),
+      );
+    }
+    return result;
+  }, [tasks, activeWorkflowId, allRepositoriesSelected, selectedRepositoryId]);
+
+  return { pageCount, columns, handleRowClick, defaultWorkflow, defaultStep, filteredTasks };
 }
 
 function useTasksPageSetup(props: TasksPageClientProps) {
@@ -350,6 +367,8 @@ function useTasksPageSetup(props: TasksPageClientProps) {
     activeWorkspaceId,
     activeWorkflowId,
     repositories: storeRepositories,
+    allRepositoriesSelected,
+    selectedRepositoryId,
   } = useKanbanDisplaySettings();
   const viewState = useTasksPageViewState({
     initialWorkflows: props.initialWorkflows,
@@ -387,6 +406,9 @@ function useTasksPageSetup(props: TasksPageClientProps) {
     deletingTaskId: ops.deletingTaskId,
     router,
     activeWorkflowId,
+    tasks: viewState.tasks,
+    allRepositoriesSelected,
+    selectedRepositoryId,
   });
   return { ...viewState, ...ops, ...computed, activeWorkspaceId, debouncedQuery };
 }
@@ -404,11 +426,10 @@ export function TasksPageClient(props: TasksPageClientProps) {
         isSearchLoading={s.isLoading && !!s.debouncedQuery}
       />
       <TasksPageBody
-        total={s.total}
         showArchived={s.showArchived}
         setShowArchived={s.setShowArchived}
         columns={s.columns}
-        tasks={s.tasks}
+        tasks={s.filteredTasks}
         pageCount={s.pageCount}
         pagination={s.pagination}
         setPagination={s.setPagination}

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -127,11 +127,11 @@ function useTaskOperations({
 }
 
 type TasksPageBodyProps = {
+  total: number;
   showArchived: boolean;
   setShowArchived: (show: boolean) => void;
   columns: ReturnType<typeof getColumns>;
   tasks: Task[];
-  total: number;
   pageCount: number;
   pagination: PaginationState;
   setPagination: (next: PaginationState | ((prev: PaginationState) => PaginationState)) => void;
@@ -140,11 +140,11 @@ type TasksPageBodyProps = {
 };
 
 function TasksPageBody({
+  total,
   showArchived,
   setShowArchived,
   columns,
   tasks,
-  total,
   pageCount,
   pagination,
   setPagination,

--- a/apps/web/components/ui/data-table.tsx
+++ b/apps/web/components/ui/data-table.tsx
@@ -15,6 +15,7 @@ interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   pageCount?: number;
+  rowCount?: number;
   pagination?: PaginationState;
   onPaginationChange?: (pagination: PaginationState) => void;
   isLoading?: boolean;
@@ -25,6 +26,7 @@ export function DataTable<TData, TValue>({
   columns,
   data,
   pageCount = -1,
+  rowCount,
   pagination,
   onPaginationChange,
   isLoading = false,
@@ -35,6 +37,7 @@ export function DataTable<TData, TValue>({
     data,
     columns,
     pageCount,
+    rowCount,
     state: {
       pagination,
     },

--- a/apps/web/lib/api/domains/kanban-api.ts
+++ b/apps/web/lib/api/domains/kanban-api.ts
@@ -123,7 +123,14 @@ export async function archiveTask(taskId: string, options?: ApiRequestOptions) {
 
 export async function listTasksByWorkspace(
   workspaceId: string,
-  params: { page?: number; pageSize?: number; query?: string; includeArchived?: boolean; workflowId?: string | null; repositoryId?: string | null } = {},
+  params: {
+    page?: number;
+    pageSize?: number;
+    query?: string;
+    includeArchived?: boolean;
+    workflowId?: string | null;
+    repositoryId?: string | null;
+  } = {},
   options?: ApiRequestOptions,
 ) {
   const baseUrl = options?.baseUrl ?? getBackendConfig().apiBaseUrl;

--- a/apps/web/lib/api/domains/kanban-api.ts
+++ b/apps/web/lib/api/domains/kanban-api.ts
@@ -123,7 +123,7 @@ export async function archiveTask(taskId: string, options?: ApiRequestOptions) {
 
 export async function listTasksByWorkspace(
   workspaceId: string,
-  params: { page?: number; pageSize?: number; query?: string; includeArchived?: boolean } = {},
+  params: { page?: number; pageSize?: number; query?: string; includeArchived?: boolean; workflowId?: string | null; repositoryId?: string | null } = {},
   options?: ApiRequestOptions,
 ) {
   const baseUrl = options?.baseUrl ?? getBackendConfig().apiBaseUrl;
@@ -132,5 +132,7 @@ export async function listTasksByWorkspace(
   if (params.pageSize) url.searchParams.set("page_size", String(params.pageSize));
   if (params.query) url.searchParams.set("query", params.query);
   if (params.includeArchived) url.searchParams.set("include_archived", "true");
+  if (params.workflowId) url.searchParams.set("workflow_id", params.workflowId);
+  if (params.repositoryId) url.searchParams.set("repository_id", params.repositoryId);
   return fetchJson<ListTasksResponse>(url.toString(), options);
 }

--- a/apps/web/lib/ws/handlers/users.ts
+++ b/apps/web/lib/ws/handlers/users.ts
@@ -5,16 +5,14 @@ import type { WsHandlers } from "@/lib/ws/handlers/types";
 export function registerUsersHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
     "user.settings.updated": (message) => {
-      const repositoryIds = Array.from(new Set(message.payload.repository_ids ?? [])).sort();
       store.setState((state) => ({
         ...state,
         userSettings: {
           ...state.userSettings,
-          // Preserve workspaceId and workflowId — these are navigation state
+          // Preserve workspaceId, workflowId, and repositoryIds — these are navigation state
           // controlled by SSR and explicit user actions, not WebSocket broadcasts.
-          // Overwriting them here causes redirect loops when the broadcast
-          // arrives with a stale workspace/workflow from a previous commit.
-          repositoryIds,
+          // Overwriting them here causes redirect loops / filter resets when the broadcast
+          // arrives with a stale workspace/workflow/repo from a previous commit.
           preferredShell: message.payload.preferred_shell || null,
           defaultEditorId: message.payload.default_editor_id || null,
           enablePreviewOnClick: message.payload.enable_preview_on_click ?? false,


### PR DESCRIPTION
Display filters (Workflow and Repository) in the tasks list view were non-functional — selecting a filter had no effect.

## Changes

**Backend**
- `task_http_handlers.go`: parse `workflow_id` and `repository_id` query params
- `service_tasks.go`: propagate filter params through the service layer
- `repository/sqlite/task.go`: apply `workflow_id` and `repository_id` as SQL WHERE conditions

**Frontend**
- `kanban-api.ts` / `workspaces.ts`: forward `workflowId` and `repositoryId` to the API URL
- `tasks-page-client.tsx`: pass active filter values to `listTasksByWorkspace`
- `page.tsx`: resolve active filters from user settings on the server and pass them to the initial `listTasksByWorkspaceAction` call; hydrate `workflows.activeId` in the store via `StateHydrator` so the first client-side fetch uses the correct filters without a flash

## Validation

<img width="2492" alt="image" src="https://github.com/user-attachments/assets/868139c9-9f6f-4918-bd6e-1e2ee838c696" />

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
