### PR TITLE
fix(web): fetch utility agent models from capabilities cache

### DIFF
--- a/apps/web/components/settings/utility-agent-dialog.tsx
+++ b/apps/web/components/settings/utility-agent-dialog.tsx
@@ -12,6 +12,7 @@ import {
   updateUtilityAgent,
   getTemplateVariables,
   listInferenceAgents,
+  listAgentCapabilities,
   type TemplateVariable,
   type InferenceAgent,
   type InferenceModel,
@@ -177,14 +178,31 @@ export function UtilityAgentDialog({ open, onOpenChange, agent, onSuccess }: Pro
   const [inferenceAgents, setInferenceAgents] = useState<InferenceAgent[]>([]);
   const isEdit = Boolean(agent);
 
-  // Fetch template variables and inference agents
+  // Fetch template variables and inference agents with capabilities
   useEffect(() => {
     getTemplateVariables()
       .then(({ variables }) => setPlaceholders(toScriptPlaceholders(variables)))
       .catch(() => setPlaceholders([]));
 
-    listInferenceAgents()
-      .then(({ agents }) => setInferenceAgents(agents))
+    // Fetch both inference agents and capabilities, then merge
+    Promise.all([listInferenceAgents(), listAgentCapabilities()])
+      .then(([inferenceRes, capsRes]) => {
+        const capsMap = new Map(capsRes.agents.map((c) => [c.agent_type, c]));
+        const merged = inferenceRes.agents.map((agent) => {
+          const caps = capsMap.get(agent.id);
+          if (!caps?.models) return agent;
+          return {
+            ...agent,
+            models: caps.models.map((m) => ({
+              id: m.id,
+              name: m.name,
+              description: m.description ?? "",
+              is_default: m.id === caps.current_model_id,
+            })),
+          };
+        });
+        setInferenceAgents(merged);
+      })
       .catch(() => setInferenceAgents([]));
   }, []);
 
@@ -199,7 +217,7 @@ export function UtilityAgentDialog({ open, onOpenChange, agent, onSuccess }: Pro
   // Auto-select default model when agent changes
   useEffect(() => {
     if (selectedAgent && !form.model) {
-      const defaultModel = selectedAgent.models.find((m) => m.is_default);
+      const defaultModel = (selectedAgent.models ?? []).find((m) => m.is_default);
       if (defaultModel) {
         setForm((f) => ({ ...f, model: defaultModel.id }));
       }

--- a/apps/web/components/settings/utility-agent-dialog.tsx
+++ b/apps/web/components/settings/utility-agent-dialog.tsx
@@ -13,12 +13,26 @@ import {
   getTemplateVariables,
   listInferenceAgents,
   listAgentCapabilities,
+  mergeAgentsWithCapabilities,
   type TemplateVariable,
   type InferenceAgent,
   type InferenceModel,
 } from "@/lib/api/domains/utility-api";
 import { ScriptEditor } from "./profile-edit/script-editor";
 import type { ScriptPlaceholder } from "./profile-edit/script-editor-completions";
+
+/** Fetches inference agents and capabilities, merging models from capabilities. */
+async function fetchInferenceAgentsWithCapabilities(): Promise<InferenceAgent[]> {
+  // Fetch agents first; if capabilities fail, still return agents without models
+  const inferenceRes = await listInferenceAgents();
+  try {
+    const capsRes = await listAgentCapabilities();
+    return mergeAgentsWithCapabilities(inferenceRes.agents, capsRes.agents);
+  } catch {
+    // Capabilities unavailable; return agents as-is (models will be null)
+    return inferenceRes.agents;
+  }
+}
 
 type Props = {
   open: boolean;
@@ -184,25 +198,8 @@ export function UtilityAgentDialog({ open, onOpenChange, agent, onSuccess }: Pro
       .then(({ variables }) => setPlaceholders(toScriptPlaceholders(variables)))
       .catch(() => setPlaceholders([]));
 
-    // Fetch both inference agents and capabilities, then merge
-    Promise.all([listInferenceAgents(), listAgentCapabilities()])
-      .then(([inferenceRes, capsRes]) => {
-        const capsMap = new Map(capsRes.agents.map((c) => [c.agent_type, c]));
-        const merged = inferenceRes.agents.map((agent) => {
-          const caps = capsMap.get(agent.id);
-          if (!caps?.models) return agent;
-          return {
-            ...agent,
-            models: caps.models.map((m) => ({
-              id: m.id,
-              name: m.name,
-              description: m.description ?? "",
-              is_default: m.id === caps.current_model_id,
-            })),
-          };
-        });
-        setInferenceAgents(merged);
-      })
+    fetchInferenceAgentsWithCapabilities()
+      .then(setInferenceAgents)
       .catch(() => setInferenceAgents([]));
   }, []);
 

--- a/apps/web/components/settings/utility-agents-section.tsx
+++ b/apps/web/components/settings/utility-agents-section.tsx
@@ -5,11 +5,11 @@ import {
   listUtilityAgents,
   listInferenceAgents,
   listAgentCapabilities,
+  mergeAgentsWithCapabilities,
   updateUtilityAgent,
   deleteUtilityAgent,
   type UtilityAgent,
   type InferenceAgent,
-  type AgentCapabilities,
 } from "@/lib/api/domains/utility-api";
 import { fetchUserSettings, updateUserSettings } from "@/lib/api/domains/settings-api";
 import { UtilityAgentDialog } from "@/components/settings/utility-agent-dialog";
@@ -20,30 +20,6 @@ import {
   USE_DEFAULT,
 } from "@/components/settings/utility-sections";
 
-/**
- * Merges inference agents with capabilities to populate models.
- * Models come from the agent-capabilities cache, not from inference-agents.
- */
-function mergeAgentsWithCapabilities(
-  agents: InferenceAgent[],
-  capabilities: AgentCapabilities[],
-): InferenceAgent[] {
-  const capsMap = new Map(capabilities.map((c) => [c.agent_type, c]));
-  return agents.map((agent) => {
-    const caps = capsMap.get(agent.id);
-    if (!caps?.models) return agent;
-    return {
-      ...agent,
-      models: caps.models.map((m) => ({
-        id: m.id,
-        name: m.name,
-        description: m.description ?? "",
-        is_default: m.id === caps.current_model_id,
-      })),
-    };
-  });
-}
-
 function buildAllModels(inferenceAgents: InferenceAgent[]) {
   return inferenceAgents.flatMap((ia) =>
     (ia.models ?? []).map((m) => ({
@@ -53,6 +29,38 @@ function buildAllModels(inferenceAgents: InferenceAgent[]) {
       modelName: m.name,
     })),
   );
+}
+
+type FetchResult = {
+  agents: UtilityAgent[];
+  inferenceAgents: InferenceAgent[];
+  defaultAgentId: string;
+  defaultModel: string;
+};
+
+async function fetchPageData(): Promise<FetchResult> {
+  const [agentsRes, inferenceRes, settingsRes] = await Promise.all([
+    listUtilityAgents({ cache: "no-store" }),
+    listInferenceAgents(),
+    fetchUserSettings({ cache: "no-store" }),
+  ]);
+
+  // Fetch capabilities separately so a failure doesn't break the page
+  let mergedAgents: InferenceAgent[];
+  try {
+    const capsRes = await listAgentCapabilities();
+    mergedAgents = mergeAgentsWithCapabilities(inferenceRes.agents, capsRes.agents);
+  } catch {
+    // Capabilities unavailable; show agents without model details
+    mergedAgents = inferenceRes.agents;
+  }
+
+  return {
+    agents: agentsRes.agents,
+    inferenceAgents: mergedAgents,
+    defaultAgentId: settingsRes.settings.default_utility_agent_id || "",
+    defaultModel: settingsRes.settings.default_utility_model || "",
+  };
 }
 
 async function handleBuiltinChange(
@@ -83,18 +91,11 @@ export function UtilityAgentsSection() {
 
   const fetchData = useCallback(async () => {
     try {
-      const [agentsRes, inferenceRes, capsRes, settingsRes] = await Promise.all([
-        listUtilityAgents({ cache: "no-store" }),
-        listInferenceAgents(),
-        listAgentCapabilities(),
-        fetchUserSettings({ cache: "no-store" }),
-      ]);
-      setAgents(agentsRes.agents);
-      // Merge inference agents with capabilities to get models
-      const mergedAgents = mergeAgentsWithCapabilities(inferenceRes.agents, capsRes.agents);
-      setInferenceAgents(mergedAgents);
-      setDefaultAgentId(settingsRes.settings.default_utility_agent_id || "");
-      setDefaultModel(settingsRes.settings.default_utility_model || "");
+      const data = await fetchPageData();
+      setAgents(data.agents);
+      setInferenceAgents(data.inferenceAgents);
+      setDefaultAgentId(data.defaultAgentId);
+      setDefaultModel(data.defaultModel);
     } catch {
       setAgents([]);
       setInferenceAgents([]);

--- a/apps/web/components/settings/utility-agents-section.tsx
+++ b/apps/web/components/settings/utility-agents-section.tsx
@@ -4,10 +4,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   listUtilityAgents,
   listInferenceAgents,
+  listAgentCapabilities,
   updateUtilityAgent,
   deleteUtilityAgent,
   type UtilityAgent,
   type InferenceAgent,
+  type AgentCapabilities,
 } from "@/lib/api/domains/utility-api";
 import { fetchUserSettings, updateUserSettings } from "@/lib/api/domains/settings-api";
 import { UtilityAgentDialog } from "@/components/settings/utility-agent-dialog";
@@ -18,9 +20,33 @@ import {
   USE_DEFAULT,
 } from "@/components/settings/utility-sections";
 
+/**
+ * Merges inference agents with capabilities to populate models.
+ * Models come from the agent-capabilities cache, not from inference-agents.
+ */
+function mergeAgentsWithCapabilities(
+  agents: InferenceAgent[],
+  capabilities: AgentCapabilities[],
+): InferenceAgent[] {
+  const capsMap = new Map(capabilities.map((c) => [c.agent_type, c]));
+  return agents.map((agent) => {
+    const caps = capsMap.get(agent.id);
+    if (!caps?.models) return agent;
+    return {
+      ...agent,
+      models: caps.models.map((m) => ({
+        id: m.id,
+        name: m.name,
+        description: m.description ?? "",
+        is_default: m.id === caps.current_model_id,
+      })),
+    };
+  });
+}
+
 function buildAllModels(inferenceAgents: InferenceAgent[]) {
   return inferenceAgents.flatMap((ia) =>
-    ia.models.map((m) => ({
+    (ia.models ?? []).map((m) => ({
       value: `${ia.id}|${m.id}`,
       label: `${ia.display_name} / ${m.name}`,
       agentName: ia.display_name,
@@ -57,13 +83,16 @@ export function UtilityAgentsSection() {
 
   const fetchData = useCallback(async () => {
     try {
-      const [agentsRes, inferenceRes, settingsRes] = await Promise.all([
+      const [agentsRes, inferenceRes, capsRes, settingsRes] = await Promise.all([
         listUtilityAgents({ cache: "no-store" }),
         listInferenceAgents(),
+        listAgentCapabilities(),
         fetchUserSettings({ cache: "no-store" }),
       ]);
       setAgents(agentsRes.agents);
-      setInferenceAgents(inferenceRes.agents);
+      // Merge inference agents with capabilities to get models
+      const mergedAgents = mergeAgentsWithCapabilities(inferenceRes.agents, capsRes.agents);
+      setInferenceAgents(mergedAgents);
       setDefaultAgentId(settingsRes.settings.default_utility_agent_id || "");
       setDefaultModel(settingsRes.settings.default_utility_model || "");
     } catch {

--- a/apps/web/e2e/tests/settings/utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/utility-agents.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "../../fixtures/test-base";
+
+/**
+ * Verifies the Utility Agents settings page loads and renders correctly.
+ *
+ * This test catches regressions like #611 where the page crashed because
+ * the backend stopped returning models in the inference-agents response.
+ */
+test.describe("Utility Agents settings page", () => {
+  test("page loads without crashing and displays sections", async ({ testPage }) => {
+    test.setTimeout(60_000);
+
+    await testPage.goto("/settings/utility-agents");
+
+    // The page should render the main heading (exact match to avoid "Custom utility agents")
+    await expect(
+      testPage.getByRole("heading", { name: "Utility Agents", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The default model section should be visible (with agent/model selectors)
+    await expect(testPage.getByText(/Default utility agent model/i)).toBeVisible();
+
+    // The actions section should render (built-in utility agents)
+    await expect(testPage.getByRole("heading", { name: "Actions" })).toBeVisible();
+
+    // Custom utility agents section should be visible
+    await expect(testPage.getByRole("heading", { name: "Custom utility agents" })).toBeVisible();
+
+    // Verify no client-side errors by checking the page didn't crash
+    // The page should have the Add button for custom agents
+    await expect(testPage.getByRole("button", { name: /Add/i })).toBeVisible();
+  });
+
+  test("page survives reload", async ({ testPage }) => {
+    test.setTimeout(60_000);
+
+    await testPage.goto("/settings/utility-agents");
+
+    // Wait for initial load (exact match to avoid "Custom utility agents")
+    await expect(
+      testPage.getByRole("heading", { name: "Utility Agents", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Reload the page
+    await testPage.reload();
+
+    // Page should still render correctly after reload
+    await expect(
+      testPage.getByRole("heading", { name: "Utility Agents", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(testPage.getByText(/Default utility agent model/i)).toBeVisible();
+  });
+});

--- a/apps/web/lib/api/domains/utility-api.test.ts
+++ b/apps/web/lib/api/domains/utility-api.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { mergeAgentsWithCapabilities, type InferenceAgent, type AgentCapabilities } from "./utility-api";
+
+const CLAUDE_CODE = "claude-code";
+const CLAUDE_CODE_DISPLAY = "Claude Code";
+
+function agent(id: string, name: string, models: InferenceAgent["models"] = null): InferenceAgent {
+  return { id, name, display_name: name, models };
+}
+
+function caps(
+  agentType: string,
+  models?: AgentCapabilities["models"],
+  currentModelId?: string,
+): AgentCapabilities {
+  return {
+    agent_type: agentType,
+    status: "ok",
+    models,
+    current_model_id: currentModelId,
+    last_checked_at: new Date().toISOString(),
+  };
+}
+
+describe("mergeAgentsWithCapabilities", () => {
+  it("populates models from capabilities", () => {
+    const agents = [agent(CLAUDE_CODE, CLAUDE_CODE_DISPLAY)];
+    const capabilities = [
+      caps(CLAUDE_CODE, [{ id: "opus", name: "Opus" }, { id: "sonnet", name: "Sonnet" }], "sonnet"),
+    ];
+
+    const result = mergeAgentsWithCapabilities(agents, capabilities);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].models).toEqual([
+      { id: "opus", name: "Opus", description: "", is_default: false },
+      { id: "sonnet", name: "Sonnet", description: "", is_default: true },
+    ]);
+  });
+
+  it("returns agent unchanged if no matching capabilities", () => {
+    const agents = [agent("unknown-agent", "Unknown")];
+    const capabilities: AgentCapabilities[] = [];
+
+    const result = mergeAgentsWithCapabilities(agents, capabilities);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(agents[0]);
+  });
+
+  it("returns agent unchanged if capabilities have no models", () => {
+    const agents = [agent(CLAUDE_CODE, CLAUDE_CODE_DISPLAY)];
+    const capabilities = [caps(CLAUDE_CODE, undefined)];
+
+    const result = mergeAgentsWithCapabilities(agents, capabilities);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].models).toBeNull();
+  });
+
+  it("handles multiple agents with different capabilities", () => {
+    const agents = [
+      agent(CLAUDE_CODE, CLAUDE_CODE_DISPLAY),
+      agent("codex", "Codex"),
+      agent("opencode", "OpenCode"),
+    ];
+    const capabilities = [
+      caps(CLAUDE_CODE, [{ id: "opus", name: "Opus" }], "opus"),
+      caps("opencode", [{ id: "gpt4o", name: "GPT-4o" }]),
+    ];
+
+    const result = mergeAgentsWithCapabilities(agents, capabilities);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].models).toEqual([{ id: "opus", name: "Opus", description: "", is_default: true }]);
+    expect(result[1].models).toBeNull(); // no capabilities for codex
+    expect(result[2].models).toEqual([{ id: "gpt4o", name: "GPT-4o", description: "", is_default: false }]);
+  });
+
+  it("preserves model description from capabilities", () => {
+    const agents = [agent(CLAUDE_CODE, CLAUDE_CODE_DISPLAY)];
+    const capabilities = [
+      caps(CLAUDE_CODE, [{ id: "opus", name: "Opus", description: "Most capable model" }]),
+    ];
+
+    const result = mergeAgentsWithCapabilities(agents, capabilities);
+
+    expect(result[0].models?.[0].description).toBe("Most capable model");
+  });
+
+  it("sets is_default based on current_model_id match", () => {
+    const agents = [agent(CLAUDE_CODE, CLAUDE_CODE_DISPLAY)];
+    const capabilities = [
+      caps(
+        CLAUDE_CODE,
+        [{ id: "opus", name: "Opus" }, { id: "sonnet", name: "Sonnet" }, { id: "haiku", name: "Haiku" }],
+        "haiku",
+      ),
+    ];
+
+    const result = mergeAgentsWithCapabilities(agents, capabilities);
+
+    expect(result[0].models).toEqual([
+      { id: "opus", name: "Opus", description: "", is_default: false },
+      { id: "sonnet", name: "Sonnet", description: "", is_default: false },
+      { id: "haiku", name: "Haiku", description: "", is_default: true },
+    ]);
+  });
+});

--- a/apps/web/lib/api/domains/utility-api.test.ts
+++ b/apps/web/lib/api/domains/utility-api.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { mergeAgentsWithCapabilities, type InferenceAgent, type AgentCapabilities } from "./utility-api";
+import {
+  mergeAgentsWithCapabilities,
+  type InferenceAgent,
+  type AgentCapabilities,
+} from "./utility-api";
 
 const CLAUDE_CODE = "claude-code";
 const CLAUDE_CODE_DISPLAY = "Claude Code";
@@ -26,7 +30,14 @@ describe("mergeAgentsWithCapabilities", () => {
   it("populates models from capabilities", () => {
     const agents = [agent(CLAUDE_CODE, CLAUDE_CODE_DISPLAY)];
     const capabilities = [
-      caps(CLAUDE_CODE, [{ id: "opus", name: "Opus" }, { id: "sonnet", name: "Sonnet" }], "sonnet"),
+      caps(
+        CLAUDE_CODE,
+        [
+          { id: "opus", name: "Opus" },
+          { id: "sonnet", name: "Sonnet" },
+        ],
+        "sonnet",
+      ),
     ];
 
     const result = mergeAgentsWithCapabilities(agents, capabilities);
@@ -72,9 +83,13 @@ describe("mergeAgentsWithCapabilities", () => {
     const result = mergeAgentsWithCapabilities(agents, capabilities);
 
     expect(result).toHaveLength(3);
-    expect(result[0].models).toEqual([{ id: "opus", name: "Opus", description: "", is_default: true }]);
+    expect(result[0].models).toEqual([
+      { id: "opus", name: "Opus", description: "", is_default: true },
+    ]);
     expect(result[1].models).toBeNull(); // no capabilities for codex
-    expect(result[2].models).toEqual([{ id: "gpt4o", name: "GPT-4o", description: "", is_default: false }]);
+    expect(result[2].models).toEqual([
+      { id: "gpt4o", name: "GPT-4o", description: "", is_default: false },
+    ]);
   });
 
   it("preserves model description from capabilities", () => {
@@ -93,7 +108,11 @@ describe("mergeAgentsWithCapabilities", () => {
     const capabilities = [
       caps(
         CLAUDE_CODE,
-        [{ id: "opus", name: "Opus" }, { id: "sonnet", name: "Sonnet" }, { id: "haiku", name: "Haiku" }],
+        [
+          { id: "opus", name: "Opus" },
+          { id: "sonnet", name: "Sonnet" },
+          { id: "haiku", name: "Haiku" },
+        ],
         "haiku",
       ),
     ];

--- a/apps/web/lib/api/domains/utility-api.ts
+++ b/apps/web/lib/api/domains/utility-api.ts
@@ -68,6 +68,30 @@ export type AgentCapabilities = {
   last_checked_at: string;
 };
 
+/**
+ * Merges inference agents with capabilities to populate models.
+ * Models are read from the agent-capabilities cache, not from inference-agents.
+ */
+export function mergeAgentsWithCapabilities(
+  agents: InferenceAgent[],
+  capabilities: AgentCapabilities[],
+): InferenceAgent[] {
+  const capsMap = new Map(capabilities.map((c) => [c.agent_type, c]));
+  return agents.map((agent) => {
+    const caps = capsMap.get(agent.id);
+    if (!caps?.models) return agent;
+    return {
+      ...agent,
+      models: caps.models.map((m) => ({
+        id: m.id,
+        name: m.name,
+        description: m.description ?? "",
+        is_default: m.id === caps.current_model_id,
+      })),
+    };
+  });
+}
+
 export type ExecutePromptRequest = {
   utility_agent_id: string;
   session_id?: string;

--- a/apps/web/lib/api/domains/utility-api.ts
+++ b/apps/web/lib/api/domains/utility-api.ts
@@ -48,7 +48,24 @@ export type InferenceAgent = {
   id: string;
   name: string;
   display_name: string;
-  models: InferenceModel[];
+  models: InferenceModel[] | null;
+};
+
+/**
+ * AgentCapabilities represents the cached result of probing an agent type.
+ * This comes from the host utility manager via /api/v1/agent-capabilities.
+ */
+export type AgentCapabilities = {
+  agent_type: string;
+  agent_name?: string;
+  agent_version?: string;
+  status: "probing" | "ok" | "auth_required" | "not_installed" | "failed" | "not_configured";
+  error?: string;
+  models?: Array<{ id: string; name: string; description?: string }>;
+  current_model_id?: string;
+  modes?: Array<{ id: string; name: string; description?: string }>;
+  current_mode_id?: string;
+  last_checked_at: string;
 };
 
 export type ExecutePromptRequest = {
@@ -132,6 +149,16 @@ export async function listInferenceAgents(
   options?: ApiRequestOptions,
 ): Promise<{ agents: InferenceAgent[] }> {
   return fetchJson<{ agents: InferenceAgent[] }>("/api/v1/utility/inference-agents", options);
+}
+
+/**
+ * Fetches all agent capabilities from the host utility capability cache.
+ * This is the canonical source for models, modes, and other capabilities.
+ */
+export async function listAgentCapabilities(
+  options?: ApiRequestOptions,
+): Promise<{ agents: AgentCapabilities[] }> {
+  return fetchJson<{ agents: AgentCapabilities[] }>("/api/v1/agent-capabilities", options);
 }
 
 export async function executeUtilityPrompt(


### PR DESCRIPTION
The Utility Agents settings page (/settings/utility-agents) crashed with TypeError: Cannot read properties of null (reading 'map') because the backend's inference-agents endpoint no longer returns models in the response. The proper fix, as noted in the issue, is to fetch models from the agent-capabilities cache instead.

## Important Changes

- Added listAgentCapabilities() API function to fetch from /api/v1/agent-capabilities
- Added mergeAgentsWithCapabilities() to combine inference agents with capabilities data
- Updated both utility-agents-section.tsx and utility-agent-dialog.tsx to fetch and merge capabilities
- Added E2E test to verify the page loads and all sections render correctly

## Validation

- make fmt — formatting passes
- make lint — only pre-existing warning about function length
- pnpm --filter @kandev/web e2e -- tests/settings/utility-agents.spec.ts — 2 tests pass

## Checklist

- [ ] I've read AGENTS.md
- [ ] I've self-reviewed my code
- [ ] I've linked any related issues below

Closes #611
