### PR TITLE
fix(web): close file diff tab when uncommitted change is undone

### DIFF
--- a/apps/web/components/task/task-changes-panel.test.ts
+++ b/apps/web/components/task/task-changes-panel.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { shouldCloseFileDiffPanel } from "./task-changes-panel";
+
+const PATH = "src/foo.ts";
+
+describe("shouldCloseFileDiffPanel", () => {
+  it("returns false when gitStatus is undefined (not loaded yet)", () => {
+    expect(shouldCloseFileDiffPanel(undefined, PATH)).toBe(false);
+  });
+
+  it("returns true when gitStatus.files is undefined (loaded, no changes)", () => {
+    expect(shouldCloseFileDiffPanel({}, PATH)).toBe(true);
+  });
+
+  it("returns true when the file is missing from gitStatus.files (discarded)", () => {
+    expect(shouldCloseFileDiffPanel({ files: {} }, PATH)).toBe(true);
+  });
+
+  it("returns false when the file has a non-empty uncommitted diff", () => {
+    const gitStatus = { files: { [PATH]: { diff: "@@ -1 +1 @@\n-a\n+b\n" } } };
+    expect(shouldCloseFileDiffPanel(gitStatus, PATH)).toBe(false);
+  });
+
+  it("returns true when the file entry exists but diff is an empty string", () => {
+    const gitStatus = { files: { [PATH]: { diff: "" } } };
+    expect(shouldCloseFileDiffPanel(gitStatus, PATH)).toBe(true);
+  });
+
+  it("returns true when the file entry exists but diff is undefined", () => {
+    const gitStatus = { files: { [PATH]: {} } };
+    expect(shouldCloseFileDiffPanel(gitStatus, PATH)).toBe(true);
+  });
+
+  it("is not affected by unrelated files in gitStatus.files", () => {
+    const gitStatus = { files: { "other/file.ts": { diff: "diff content" } } };
+    expect(shouldCloseFileDiffPanel(gitStatus, PATH)).toBe(true);
+  });
+});

--- a/apps/web/components/task/task-changes-panel.tsx
+++ b/apps/web/components/task/task-changes-panel.tsx
@@ -106,6 +106,25 @@ function addPRFiles(fileMap: Map<string, ReviewFile>, files: PRDiffFile[]) {
   }
 }
 
+/**
+ * Returns true when a file-mode diff panel should auto-close because its file
+ * no longer has an uncommitted diff. File-mode diff tabs are only opened from
+ * the Changes panel's uncommitted file list, so losing that entry means the
+ * tab's reason for existence is gone — even if the file still appears in
+ * cumulative or PR diffs.
+ *
+ * Returns false while `gitStatus` is undefined to avoid a false-close during
+ * initial load.
+ */
+export function shouldCloseFileDiffPanel(
+  gitStatus: { files?: Record<string, { diff?: string }> } | undefined,
+  filePath: string,
+): boolean {
+  if (!gitStatus) return false;
+  const entry = gitStatus.files?.[filePath];
+  return !entry?.diff;
+}
+
 /** Merge PR + uncommitted + committed files into a single sorted list */
 function mergeReviewFiles(
   gitStatus: ReturnType<typeof useSessionGitStatus>,
@@ -208,6 +227,7 @@ function useChangesData(selectedDiff: SelectedDiff | null, onClearSelected: () =
     totalCommentCount,
     fileRefs,
     cumulativeLoading,
+    gitStatus,
   };
 }
 
@@ -326,6 +346,40 @@ function useChangesActions(activeSessionId: string | null | undefined, allFiles:
   };
 }
 
+function useAutoCloseWhenEmpty(opts: {
+  mode: "all" | "file";
+  filePath: string | undefined;
+  gitStatus: { files?: Record<string, { diff?: string }> } | undefined;
+  visibleCount: number;
+  onBecameEmpty: (() => void) | undefined;
+}) {
+  const { mode, filePath, gitStatus, visibleCount, onBecameEmpty } = opts;
+  const prevVisibleCountRef = useRef<number | null>(null);
+  const prevFileSeenRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!onBecameEmpty) return;
+
+    if (mode === "file" && filePath) {
+      // File-mode: close when the file no longer has an uncommitted diff,
+      // regardless of whether it still appears in PR/cumulative diff sources.
+      const shouldClose = shouldCloseFileDiffPanel(gitStatus, filePath);
+      if (prevFileSeenRef.current && shouldClose) {
+        onBecameEmpty();
+        return;
+      }
+      if (!shouldClose) prevFileSeenRef.current = true;
+      return;
+    }
+
+    const prevCount = prevVisibleCountRef.current;
+    if (prevCount !== null && prevCount > 0 && visibleCount === 0) {
+      onBecameEmpty();
+    }
+    prevVisibleCountRef.current = visibleCount;
+  }, [mode, filePath, gitStatus, onBecameEmpty, visibleCount]);
+}
+
 const TaskChangesPanel = memo(function TaskChangesPanel({
   mode = "all",
   filePath,
@@ -346,6 +400,7 @@ const TaskChangesPanel = memo(function TaskChangesPanel({
     totalCommentCount,
     fileRefs,
     cumulativeLoading,
+    gitStatus,
   } = useChangesData(selectedDiff, onClearSelected);
   const visibleFiles = useMemo(() => {
     if (mode === "file" && filePath) {
@@ -382,16 +437,13 @@ const TaskChangesPanel = memo(function TaskChangesPanel({
   );
   const totalCount = visibleFiles.length;
   const progressPercent = totalCount > 0 ? (reviewedCount / totalCount) * 100 : 0;
-  const prevVisibleCountRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!onBecameEmpty) return;
-    const prevCount = prevVisibleCountRef.current;
-    if (prevCount !== null && prevCount > 0 && visibleFiles.length === 0) {
-      onBecameEmpty();
-    }
-    prevVisibleCountRef.current = visibleFiles.length;
-  }, [onBecameEmpty, visibleFiles.length]);
+  useAutoCloseWhenEmpty({
+    mode,
+    filePath,
+    gitStatus,
+    visibleCount: visibleFiles.length,
+    onBecameEmpty,
+  });
 
   if (isArchived) return <ArchivedPanelPlaceholder />;
 

--- a/apps/web/components/task/task-changes-panel.tsx
+++ b/apps/web/components/task/task-changes-panel.tsx
@@ -106,16 +106,7 @@ function addPRFiles(fileMap: Map<string, ReviewFile>, files: PRDiffFile[]) {
   }
 }
 
-/**
- * Returns true when a file-mode diff panel should auto-close because its file
- * no longer has an uncommitted diff. File-mode diff tabs are only opened from
- * the Changes panel's uncommitted file list, so losing that entry means the
- * tab's reason for existence is gone — even if the file still appears in
- * cumulative or PR diffs.
- *
- * Returns false while `gitStatus` is undefined to avoid a false-close during
- * initial load.
- */
+// Returns true only after gitStatus loads and the file's uncommitted diff is gone.
 export function shouldCloseFileDiffPanel(
   gitStatus: { files?: Record<string, { diff?: string }> } | undefined,
   filePath: string,

--- a/apps/web/e2e/tests/git/diff-update.spec.ts
+++ b/apps/web/e2e/tests/git/diff-update.spec.ts
@@ -212,11 +212,7 @@ test.describe("Diff update on file change", () => {
     apiClient,
     seedData,
   }) => {
-    // Regression: when a file has BOTH a committed version and an uncommitted
-    // diff, clicking the hunk-level Undo button reverts the unstaged change.
-    // The file must disappear from the right Changes panel AND the
-    // `Diff [filename]` center tab must auto-close, because the tab's reason
-    // for existence (an uncommitted diff for that file) is gone.
+    // Regression: Undo must close the diff tab even when PR/cumulative diffs keep the file visible.
     await seedDiffUpdateTask(testPage, apiClient, seedData);
     await openChangesTab(testPage);
     await openFileDiff(testPage, "diff_update_test.txt");
@@ -224,17 +220,13 @@ test.describe("Diff update on file change", () => {
     const diffTab = testPage.locator(".dv-default-tab", { hasText: "diff_update_test.txt" });
     await expect(diffTab).toBeVisible({ timeout: 10_000 });
 
-    // Confirm the diff content loaded before interacting.
     const diffsContainer = getDiffsContainer(testPage);
     await expect(diffsContainer).toBeVisible({ timeout: 15_000 });
     await expect(diffsContainer.getByText("FIRST_MODIFICATION", { exact: true })).toBeVisible({
       timeout: 15_000,
     });
 
-    // The Undo button lives inside `[data-undo-btn]` wrappers with
-    // `opacity: 0; pointer-events: none` until a change line is hovered.
-    // `dispatchEvent('click')` fires the React click handler without relying
-    // on the hover/pointer-events state.
+    // Button is CSS-hidden until hover; dispatchEvent bypasses pointer-events:none.
     const undoBtn = diffsContainer.locator("[data-undo-btn] button").first();
     await expect(undoBtn).toHaveCount(1, { timeout: 10_000 });
     await undoBtn.dispatchEvent("click");

--- a/apps/web/e2e/tests/git/diff-update.spec.ts
+++ b/apps/web/e2e/tests/git/diff-update.spec.ts
@@ -231,12 +231,13 @@ test.describe("Diff update on file change", () => {
       timeout: 15_000,
     });
 
-    // The Undo button is rendered inside `[data-undo-btn]` wrappers with
-    // opacity/pointerEvents toggled on hover via JS. `force: true` bypasses
-    // the actionability checks so we don't depend on the hover timing.
+    // The Undo button lives inside `[data-undo-btn]` wrappers with
+    // `opacity: 0; pointer-events: none` until a change line is hovered.
+    // `dispatchEvent('click')` fires the React click handler without relying
+    // on the hover/pointer-events state.
     const undoBtn = diffsContainer.locator("[data-undo-btn] button").first();
     await expect(undoBtn).toHaveCount(1, { timeout: 10_000 });
-    await undoBtn.click({ force: true });
+    await undoBtn.dispatchEvent("click");
 
     // The Diff tab should close automatically.
     await expect(diffTab).toHaveCount(0, { timeout: 15_000 });

--- a/apps/web/e2e/tests/git/diff-update.spec.ts
+++ b/apps/web/e2e/tests/git/diff-update.spec.ts
@@ -206,6 +206,41 @@ test.describe("Diff update on file change", () => {
       timeout: 15_000,
     });
   });
+
+  test("diff panel closes when uncommitted change is undone via hunk Undo", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // Regression: when a file has BOTH a committed version and an uncommitted
+    // diff, clicking the hunk-level Undo button reverts the unstaged change.
+    // The file must disappear from the right Changes panel AND the
+    // `Diff [filename]` center tab must auto-close, because the tab's reason
+    // for existence (an uncommitted diff for that file) is gone.
+    await seedDiffUpdateTask(testPage, apiClient, seedData);
+    await openChangesTab(testPage);
+    await openFileDiff(testPage, "diff_update_test.txt");
+
+    const diffTab = testPage.locator(".dv-default-tab", { hasText: "diff_update_test.txt" });
+    await expect(diffTab).toBeVisible({ timeout: 10_000 });
+
+    // Confirm the diff content loaded before interacting.
+    const diffsContainer = getDiffsContainer(testPage);
+    await expect(diffsContainer).toBeVisible({ timeout: 15_000 });
+    await expect(diffsContainer.getByText("FIRST_MODIFICATION", { exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // The Undo button is rendered inside `[data-undo-btn]` wrappers with
+    // opacity/pointerEvents toggled on hover via JS. `force: true` bypasses
+    // the actionability checks so we don't depend on the hover timing.
+    const undoBtn = diffsContainer.locator("[data-undo-btn] button").first();
+    await expect(undoBtn).toHaveCount(1, { timeout: 10_000 });
+    await undoBtn.click({ force: true });
+
+    // The Diff tab should close automatically.
+    await expect(diffTab).toHaveCount(0, { timeout: 15_000 });
+  });
 });
 
 test.describe("Untracked file diff update", () => {


### PR DESCRIPTION
Clicking the hunk-level Undo button on a `Diff [filename]` tab would leave the tab open when the same file had both committed (PR/cumulative) and uncommitted changes — the existing auto-close depended on `visibleFiles.length === 0`, but the file still appeared via other diff sources. File-mode diff tabs are only opened from the Changes panel's uncommitted list, so they now close when that contract is broken.

## Important Changes

- Extract pure `shouldCloseFileDiffPanel(gitStatus, filePath)` predicate, independent of committed/PR diff state.
- Split auto-close into a dedicated `useAutoCloseWhenEmpty` hook; all-mode behavior unchanged, file-mode uses a "was present" latch to avoid false-closing during initial load.

## Validation

- `pnpm --filter @kandev/web test` — 267 unit tests pass, including 7 new cases for `shouldCloseFileDiffPanel`.
- `pnpm --filter @kandev/web lint` — clean.
- `pnpm exec tsc --noEmit` — no new errors on touched files (4 pre-existing errors in unrelated files remain).
- New Playwright regression test in `e2e/tests/git/diff-update.spec.ts` exercising the committed + uncommitted state via the existing `/e2e:diff-update-setup` scenario.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.