### PR TITLE
fix(orchestrator): stop killing live agents on resume race

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -16,15 +16,21 @@ import (
 
 // mockAgentManager implements AgentManagerClient for testing
 type mockAgentManager struct {
-	launchAgentFunc              func(ctx context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error)
-	startAgentProcessFunc        func(ctx context.Context, agentExecutionID string) error
-	stopAgentFunc                func(ctx context.Context, agentExecutionID string, force bool) error
-	resolveAgentProfileFunc      func(ctx context.Context, profileID string) (*AgentProfileInfo, error)
-	setExecutionDescriptionFunc  func(ctx context.Context, agentExecutionID string, description string) error
-	getExecutionIDForSessionFunc func(ctx context.Context, sessionID string) (string, error)
+	launchAgentFunc                  func(ctx context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error)
+	startAgentProcessFunc            func(ctx context.Context, agentExecutionID string) error
+	stopAgentFunc                    func(ctx context.Context, agentExecutionID string, force bool) error
+	resolveAgentProfileFunc          func(ctx context.Context, profileID string) (*AgentProfileInfo, error)
+	setExecutionDescriptionFunc      func(ctx context.Context, agentExecutionID string, description string) error
+	getExecutionIDForSessionFunc     func(ctx context.Context, sessionID string) (string, error)
+	isAgentRunningForSessionFunc     func(ctx context.Context, sessionID string) bool
+	cleanupStaleExecutionFunc        func(ctx context.Context, sessionID string) error
+	launchAgentCallCount             int
+	cleanupStaleExecutionCallCount   int
+	isAgentRunningForSessionCallArgs []string
 }
 
 func (m *mockAgentManager) LaunchAgent(ctx context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+	m.launchAgentCallCount++
 	if m.launchAgentFunc != nil {
 		return m.launchAgentFunc(ctx, req)
 	}
@@ -88,6 +94,10 @@ func (m *mockAgentManager) SetSessionModelBySessionID(ctx context.Context, sessi
 }
 
 func (m *mockAgentManager) IsAgentRunningForSession(ctx context.Context, sessionID string) bool {
+	m.isAgentRunningForSessionCallArgs = append(m.isAgentRunningForSessionCallArgs, sessionID)
+	if m.isAgentRunningForSessionFunc != nil {
+		return m.isAgentRunningForSessionFunc(ctx, sessionID)
+	}
 	return false
 }
 
@@ -111,6 +121,10 @@ func (m *mockAgentManager) GetRemoteRuntimeStatusBySession(ctx context.Context, 
 func (m *mockAgentManager) PollRemoteStatusForRecords(ctx context.Context, records []RemoteStatusPollRequest) {
 }
 func (m *mockAgentManager) CleanupStaleExecutionBySessionID(ctx context.Context, sessionID string) error {
+	m.cleanupStaleExecutionCallCount++
+	if m.cleanupStaleExecutionFunc != nil {
+		return m.cleanupStaleExecutionFunc(ctx, sessionID)
+	}
 	return nil
 }
 func (m *mockAgentManager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID, sessionID string) error {

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -11,11 +11,14 @@ import (
 	"go.uber.org/zap"
 )
 
-// isStaleExecutionError checks if an error from LaunchAgent indicates a stale
-// execution in the lifecycle manager's in-memory store. This happens when
-// PrepareTaskSession registered an execution but the agent was never started,
-// or the agent exited without proper cleanup.
-func isStaleExecutionError(err error) bool {
+// isAgentAlreadyRunningError checks whether LaunchAgent refused because the
+// lifecycle manager's in-memory store already has an execution for this session.
+// The error is ambiguous on its own — it fires both when the execution is live
+// (a concurrent resume raced us) and when it is stale (PrepareTaskSession
+// registered an execution but the agent was never started, or the agent exited
+// without proper cleanup). Callers must probe IsAgentRunningForSession to
+// distinguish live from stale before deciding to clean up.
+func isAgentAlreadyRunningError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "already has an agent running")
 }
 
@@ -232,11 +235,17 @@ func (e *Executor) ResumeSession(ctx context.Context, session *models.TaskSessio
 	req.Env = e.applyPreferredShellEnv(ctx, req.ExecutorType, req.Env)
 
 	resp, err := e.agentManager.LaunchAgent(ctx, req)
-	if err != nil && isStaleExecutionError(err) {
-		// The lifecycle manager's in-memory store has a stale execution (agent not actually
-		// running). This happens when PrepareTaskSession registered an execution but the
-		// agent was never started, or the agent exited without cleanup. Clean up the stale
-		// entry and retry.
+	if err != nil && isAgentAlreadyRunningError(err) {
+		// "already has an agent running" fires both for live executions (a concurrent
+		// resume raced us) and stale ones (agent never started or exited without
+		// cleanup). Probe liveness before deciding what to do — otherwise we'd kill a
+		// healthy agent mid-prompt.
+		if e.agentManager.IsAgentRunningForSession(ctx, session.ID) {
+			e.logger.Info("resume race: agent already running for session, returning ErrExecutionAlreadyRunning",
+				zap.String("task_id", task.ID),
+				zap.String("session_id", session.ID))
+			return nil, ErrExecutionAlreadyRunning
+		}
 		e.logger.Info("cleaning up stale execution and retrying launch",
 			zap.String("task_id", task.ID),
 			zap.String("session_id", session.ID))

--- a/apps/backend/internal/orchestrator/executor/executor_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_test.go
@@ -3,11 +3,13 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/lifecycle"
 	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 func TestResumeSession_RejectsArchivedTask(t *testing.T) {
@@ -186,4 +188,105 @@ func TestBuildExecutorRunning(t *testing.T) {
 			t.Errorf("ResumeToken = %q, want empty", running.ResumeToken)
 		}
 	})
+}
+
+// setupLiveResumeTestFixture seeds a repo + task + session + executor-running
+// record suitable for exercising the ResumeSession launch path.
+func setupLiveResumeTestFixture(repo *mockRepository) {
+	now := time.Now().UTC()
+	repo.tasks["task-1"] = &models.Task{
+		ID:        "task-1",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	repo.sessions["sess-1"] = &models.TaskSession{
+		ID:             "sess-1",
+		TaskID:         "task-1",
+		AgentProfileID: "profile-1",
+		State:          models.TaskSessionStateWaitingForInput,
+	}
+	repo.executorsRunning["sess-1"] = &models.ExecutorRunning{
+		ID:          "sess-1",
+		SessionID:   "sess-1",
+		TaskID:      "task-1",
+		ResumeToken: "token-abc",
+	}
+}
+
+// TestResumeSession_LiveAgentReturnsAlreadyRunning ensures that when LaunchAgent
+// reports "already has an agent running" and the lifecycle manager confirms the
+// agent is actually alive (via IsAgentRunningForSession), ResumeSession returns
+// ErrExecutionAlreadyRunning instead of killing the live subprocess.
+// Regression test for the resume race that killed active agents mid-stream.
+func TestResumeSession_LiveAgentReturnsAlreadyRunning(t *testing.T) {
+	repo := newMockRepository()
+	setupLiveResumeTestFixture(repo)
+
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			return nil, fmt.Errorf("session %q already has an agent running (execution: %s)", req.SessionID, "exec-live")
+		},
+		isAgentRunningForSessionFunc: func(_ context.Context, _ string) bool {
+			return true
+		},
+	}
+	exec := newTestExecutor(t, agentMgr, repo)
+
+	_, err := exec.ResumeSession(context.Background(), repo.sessions["sess-1"], true)
+
+	if !errors.Is(err, ErrExecutionAlreadyRunning) {
+		t.Fatalf("expected ErrExecutionAlreadyRunning, got: %v", err)
+	}
+	if agentMgr.cleanupStaleExecutionCallCount != 0 {
+		t.Errorf("expected no stale-cleanup call on live agent, got %d", agentMgr.cleanupStaleExecutionCallCount)
+	}
+	if agentMgr.launchAgentCallCount != 1 {
+		t.Errorf("expected LaunchAgent called once, got %d", agentMgr.launchAgentCallCount)
+	}
+	if len(agentMgr.isAgentRunningForSessionCallArgs) != 1 || agentMgr.isAgentRunningForSessionCallArgs[0] != "sess-1" {
+		t.Errorf("expected IsAgentRunningForSession called once with sess-1, got %v", agentMgr.isAgentRunningForSessionCallArgs)
+	}
+}
+
+// TestResumeSession_StaleExecutionCleansUpAndRetries ensures the pre-existing
+// stale-cleanup path still works when LaunchAgent reports "already has an agent
+// running" but the lifecycle manager confirms no live agent exists.
+func TestResumeSession_StaleExecutionCleansUpAndRetries(t *testing.T) {
+	repo := newMockRepository()
+	setupLiveResumeTestFixture(repo)
+
+	var launchCalls int
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			launchCalls++
+			if launchCalls == 1 {
+				return nil, fmt.Errorf("session %q already has an agent running (execution: %s)", req.SessionID, "exec-stale")
+			}
+			return &LaunchAgentResponse{
+				AgentExecutionID: "exec-new",
+				Status:           v1.AgentStatusStarting,
+			}, nil
+		},
+		isAgentRunningForSessionFunc: func(_ context.Context, _ string) bool {
+			return false
+		},
+	}
+	exec := newTestExecutor(t, agentMgr, repo)
+
+	execution, err := exec.ResumeSession(context.Background(), repo.sessions["sess-1"], true)
+	if err != nil {
+		t.Fatalf("expected success after stale cleanup + retry, got: %v", err)
+	}
+	if execution == nil {
+		t.Fatal("expected a non-nil execution after retry")
+	}
+	if execution.AgentExecutionID != "exec-new" {
+		t.Errorf("expected AgentExecutionID=exec-new, got %q", execution.AgentExecutionID)
+	}
+	if agentMgr.cleanupStaleExecutionCallCount != 1 {
+		t.Errorf("expected stale-cleanup called once, got %d", agentMgr.cleanupStaleExecutionCallCount)
+	}
+	if agentMgr.launchAgentCallCount != 2 {
+		t.Errorf("expected LaunchAgent called twice, got %d", agentMgr.launchAgentCallCount)
+	}
 }

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1487,14 +1487,13 @@ func (s *Service) PromptTask(ctx context.Context, taskID, sessionID string, prom
 				zap.String("session_id", sessionID),
 				zap.Error(err))
 		}
-		// Revert session state so it doesn't stay stuck in RUNNING.
-		// Use repo directly to bypass state machine guards that block transitions from terminal states.
-		if revertErr := s.repo.UpdateTaskSessionState(ctx, sessionID, previousSessionState, ""); revertErr != nil {
-			s.logger.Error("failed to revert session state after prompt error",
-				zap.String("session_id", sessionID),
-				zap.String("target_state", string(previousSessionState)),
-				zap.Error(revertErr))
-		}
+		// Revert session state so it doesn't stay stuck in RUNNING. Route through the
+		// wrapper so WS subscribers are notified — the UI relies on the
+		// session.state_changed broadcast to flip the composer/pause button out of
+		// "Agent is running". The wrapper's terminal-state guard is also correct here:
+		// if a concurrent agent-failure handler moved the session to FAILED we don't
+		// want to overwrite that with previousSessionState.
+		s.updateTaskSessionState(ctx, taskID, sessionID, previousSessionState, "", true)
 		if !isTransientPromptError(err) {
 			_ = s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateReview)
 		}

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1495,7 +1495,9 @@ func (s *Service) PromptTask(ctx context.Context, taskID, sessionID string, prom
 		// want to overwrite that with previousSessionState. Do NOT pass the preloaded
 		// `session` — the wrapper must re-read the row to see any such concurrent
 		// terminal transition; the stale pre-RUNNING snapshot would defeat the guard.
-		s.updateTaskSessionState(ctx, taskID, sessionID, previousSessionState, "", true)
+		// allowWakeFromWaiting=false — this is a revert away from RUNNING, never a
+		// wake transition; the flag only matters when going WAITING_FOR_INPUT → RUNNING.
+		s.updateTaskSessionState(ctx, taskID, sessionID, previousSessionState, "", false)
 		if !isTransientPromptError(err) {
 			_ = s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateReview)
 		}

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1492,7 +1492,9 @@ func (s *Service) PromptTask(ctx context.Context, taskID, sessionID string, prom
 		// session.state_changed broadcast to flip the composer/pause button out of
 		// "Agent is running". The wrapper's terminal-state guard is also correct here:
 		// if a concurrent agent-failure handler moved the session to FAILED we don't
-		// want to overwrite that with previousSessionState.
+		// want to overwrite that with previousSessionState. Do NOT pass the preloaded
+		// `session` — the wrapper must re-read the row to see any such concurrent
+		// terminal transition; the stale pre-RUNNING snapshot would defeat the guard.
 		s.updateTaskSessionState(ctx, taskID, sessionID, previousSessionState, "", true)
 		if !isTransientPromptError(err) {
 			_ = s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateReview)

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -10,7 +10,9 @@ import (
 
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 
+	"github.com/kandev/kandev/internal/agent/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/orchestrator/dto"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/queue"
@@ -114,6 +116,72 @@ func TestPromptTask_TransientErrorDoesNotMoveTaskToReview(t *testing.T) {
 	}
 	if updated.State != models.TaskSessionStateWaitingForInput {
 		t.Fatalf("expected session state %q, got %q", models.TaskSessionStateWaitingForInput, updated.State)
+	}
+}
+
+// TestPromptTask_ExecutionNotFoundRevertsStateAndBroadcasts ensures that when
+// Prompt returns executor.ErrExecutionNotFound, PromptTask reverts the session
+// state via the broadcasting wrapper (not a direct repo write), so the WS
+// subscribers receive session.state_changed and the UI can unstick the
+// "Agent is running" composer/pause button.
+// Regression test for the stuck-UI bug after a prompt failure.
+func TestPromptTask_ExecutionNotFoundRevertsStateAndBroadcasts(t *testing.T) {
+	repo := setupTestRepo(t)
+	taskRepo := newMockTaskRepo()
+	agentMgr := &mockAgentManager{
+		isAgentRunning: true,
+		promptErr:      fmt.Errorf("wrapped: %w", lifecycle.ErrExecutionNotFound),
+	}
+	eb := &recordingEventBus{}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	svc.eventBus = eb
+
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+	session, err := repo.GetTaskSession(context.Background(), "session1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	session.AgentExecutionID = "exec-1"
+	if err := repo.UpdateTaskSession(context.Background(), session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+
+	_, err = svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil)
+	if err == nil {
+		t.Fatal("expected error from prompt, got nil")
+	}
+	if !errors.Is(err, executor.ErrExecutionNotFound) {
+		t.Fatalf("expected ErrExecutionNotFound bubbled up, got: %v", err)
+	}
+
+	updated, err := repo.GetTaskSession(context.Background(), "session1")
+	if err != nil {
+		t.Fatalf("failed to reload session: %v", err)
+	}
+	if updated.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("expected session state WAITING_FOR_INPUT after revert, got %q", updated.State)
+	}
+
+	var sawRevert bool
+	for _, evt := range eb.events {
+		if evt.subject != events.TaskSessionStateChanged {
+			continue
+		}
+		payload, ok := evt.event.Data.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		oldState, _ := payload["old_state"].(string)
+		newState, _ := payload["new_state"].(string)
+		sessID, _ := payload["session_id"].(string)
+		if sessID == "session1" && oldState == string(models.TaskSessionStateRunning) && newState == string(models.TaskSessionStateWaitingForInput) {
+			sawRevert = true
+			break
+		}
+	}
+	if !sawRevert {
+		t.Fatalf("expected TaskSessionStateChanged RUNNING→WAITING_FOR_INPUT broadcast after prompt failure, got events: %+v", eb.events)
 	}
 }
 


### PR DESCRIPTION
A second `session.launch {intent:"resume"}` arriving for an actively-streaming session misclassified the live execution as stale and killed the agent subprocess mid-prompt (`peer disconnected before response`); a follow-on revert then wrote session state directly to the repo, bypassing the WS broadcast so the UI stayed stuck on "Agent is running". Both paths now do the right thing: the resume probes liveness before cleanup, and the post-error revert goes through the broadcasting wrapper.

## Important Changes

- `executor_resume.go`: before the stale-cleanup, probe `IsAgentRunningForSession`. If the agent is alive, return `ErrExecutionAlreadyRunning` (callers already treat this as idempotent success). Only clean up when the in-memory store is actually stale. Renamed `isStaleExecutionError` → `isAgentAlreadyRunningError` with a corrected doc comment — the old name actively misled readers into the bug.
- `task_operations.go`: the post-prompt-error state revert now routes through `s.updateTaskSessionState` instead of `s.repo.UpdateTaskSessionState`, so WS subscribers get `session.state_changed` (UI unsticks) and concurrent terminal transitions (e.g. agent-failure → FAILED) are correctly honored by the wrapper's terminal-state guard.

## Validation

- `go test ./internal/orchestrator/... ./internal/agent/lifecycle/...` — green.
- `go test ./...` — green except for `internal/repoclone/TestClone_PreservesNonDefaultRemoteBranches`, which fails in this sandbox due to the commit-signing service returning HTTP 400 (environmental, unrelated to this change).
- 2 new regression tests for the resume race (`TestResumeSession_LiveAgentReturnsAlreadyRunning`, `TestResumeSession_StaleExecutionCleansUpAndRetries`).
- 1 new regression test for the revert broadcast (`TestPromptTask_ExecutionNotFoundRevertsStateAndBroadcasts`) — asserts both session row reverts to `WAITING_FOR_INPUT` and a `TaskSessionStateChanged` event with `old_state=RUNNING, new_state=WAITING_FOR_INPUT` is published.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.