### PR TITLE
fix(web): wrap long paths in Discard Changes dialog

### DIFF
--- a/apps/web/components/task/changes-panel-dialogs.tsx
+++ b/apps/web/components/task/changes-panel-dialogs.tsx
@@ -55,11 +55,12 @@ export function DiscardDialog({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Discard changes?</AlertDialogTitle>
-          <AlertDialogDescription>
+          <AlertDialogDescription className="break-words">
             {description ?? (
               <>
                 This will permanently discard all changes to{" "}
-                <span className="font-semibold">{displayFile}</span>. This action cannot be undone.
+                <span className="font-semibold [overflow-wrap:anywhere]">{displayFile}</span>. This
+                action cannot be undone.
               </>
             )}
           </AlertDialogDescription>


### PR DESCRIPTION
Long file paths could overflow the Discard Changes alert dialog horizontally, pushing the Cancel and Discard buttons outside the visible area. Adding `break-words` on the description and `overflow-wrap: anywhere` on the filename span lets long paths wrap mid-string so the dialog stays within its max width.

## Validation

- `pnpm format`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web typecheck` (no new errors)

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated
- [ ] Follows the project's code style