### PR TITLE
docs: refresh README, roadmap, and workflow templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Open source, multi-provider, no telemetry, not tied to any cloud.
 - **Parallel task execution** – start and manage multiple tasks from different sources simultaneously, boosting productivity with AI agents
 - **Integrated workspace** - Built-in terminal, code editor with LSP, git changes panel, embedded vscode and chat in one IDE-like view
 - **Kanban task management** - Drag-and-drop boards, columns, and workflow automation
-- **Agentic workflows** - Multi-step pipelines that chain agents through automated task routing. See [docs/workflows.md](docs/workflow-tips.md)
+- **Agentic workflows** - Multi-step pipelines that mix-and-match agents per step - for example, Claude Code Opus to design a plan, GitHub Copilot Sonnet to implement it, and Codex GPT 5.4 to review the changes. See [docs/workflows.md](docs/workflow-tips.md)
+- **Sub-tasks** - Agents can spawn sub-tasks that resume from the parent task's session. Useful for splitting a task that has grown too big, or producing several PRs from the same starting point.
 - **CLI passthrough** - Drop into raw agent CLI mode for direct terminal interaction with any supported agent, leverage the full power of their TUIs
 - **Workspace isolation** - Git worktrees prevent concurrent agents from conflicting
 - **Flexible runtimes** - Run agents as local processes, in isolated Docker containers or in remote executors like sprites.dev

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,18 +4,19 @@ High-level direction for the project. This is not a commitment - priorities shif
 
 ## Now
 
-- Stability and bug fixes across all agent integrations
+- Stability and bug fixes across all agent integrations - current primary focus
 - Improved plan mode - richer plan editing, version history, plan diffs
 
 ## Next
 
-- Github integration - link tasks to GitHub issues, PRs
-- Workflow templates sharing - import/export workflows
+- Multi-repo task support - a single task can span multiple repositories
+- Coordinator mode - have an agent coordinate sub-tasks executed by other agents
 - Mobile-friendly UI - orchestrate and review from your phone
-- Remote SSH runtime - run agents on remote servers over SSH
-- Linear / Jira integration - sync tasks and workflows with popular project management tools
 
 ## Later
 
+- GitHub integration - link tasks to GitHub issues, PRs
+- Linear / Jira integration - sync tasks and workflows with popular project management tools
+- Remote SSH runtime - run agents on remote servers over SSH
 - Kubernetes operator - auto-scaling agent workloads in a cluster
 - Analytics dashboard - agent performance, cost tracking, success rates

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,6 @@ High-level direction for the project. This is not a commitment - priorities shif
 ## Now
 
 - Stability and bug fixes across all agent integrations - current primary focus
-- Improved plan mode - richer plan editing, version history, plan diffs
 
 ## Next
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,8 +15,7 @@ High-level direction for the project. This is not a commitment - priorities shif
 
 ## Later
 
-- GitHub integration - link tasks to GitHub issues, PRs
-- Linear / Jira integration - sync tasks and workflows with popular project management tools
+- Issue tracker integration - import issues from GitHub, Linear, and Jira as tasks
 - Remote SSH runtime - run agents on remote servers over SSH
 - Kubernetes operator - auto-scaling agent workloads in a cluster
 - Analytics dashboard - agent performance, cost tracking, success rates

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ High-level direction for the project. This is not a commitment - priorities shif
 
 - Multi-repo task support - a single task can span multiple repositories
 - Coordinator mode - have an agent coordinate sub-tasks executed by other agents
-- Mobile-friendly UI - orchestrate and review from your phone
+- Improved mobile UI - polish the existing mobile view for orchestrating and reviewing from your phone
 
 ## Later
 

--- a/docs/workflow-tips.md
+++ b/docs/workflow-tips.md
@@ -1,6 +1,6 @@
 # Workflows
 
-Kandev ships with four workflow templates. Each defines a sequence of steps with automated transitions - agents start, stop, and move between steps based on events like entering a step, sending a message, or an agent completing its turn.
+Kandev ships with five workflow templates. Each defines a sequence of steps with automated transitions - agents start, stop, and move between steps based on events like entering a step, sending a message, or an agent completing its turn.
 
 You can use these as-is or **create custom workflows** tailored to you or your team.
 
@@ -66,6 +66,30 @@ Focused on design and architecture. The agent creates technical designs for you 
 - Evaluating approaches before committing to implementation
 - Cross-team architectural proposals
 - Breaking down large projects into implementable pieces
+
+---
+
+### Feature Dev
+
+Full development lifecycle with quality gates between phases - spec, implementation with TDD, automated review, QA, draft PR, and CI fixup. Each phase runs a fresh agent turn so context stays focused on the task at hand.
+
+**Steps:** Todo → Spec → Work → Review → QA → PR → CI Fixup → Done
+
+| Step | What happens |
+|:------:|-------------|
+| **Todo** | Tasks ready to be picked up. |
+| **Spec** | Agent analyzes the task, explores the codebase, proposes approaches, and saves a detailed plan via MCP tool. Runs in plan mode and stops for your review - you can edit the plan in the UI before moving on. |
+| **Work** | Agent retrieves the plan (including edits), acknowledges modifications, and implements using a TDD loop - failing test → minimum code → refactor → commit, one behavior at a time. |
+| **Review** | Agent context is reset, then a fresh review pass checks the diff for security, correctness, performance, and code quality. Fixes trivial issues directly; reports the rest with file:line. |
+| **QA** | Agent verifies the feature end-to-end - traces wiring, runs the happy path, tries to break it with boundary values and error paths, and checks test coverage. |
+| **PR** | Agent runs formatters/linters, commits and pushes remaining changes, picks up the repo's PR template if present, and creates a draft PR. |
+| **CI Fixup** | Agent polls CI, fetches failed logs, fixes lint/test/type errors, pushes, and re-polls until checks go green. |
+| **Done** | Final state. |
+
+**When to use it:**
+- Features that need quality gates between phases
+- Changes that warrant a dedicated review + QA pass before the PR goes up
+- When you want a single task to carry a feature from idea to mergeable PR
 
 ---
 


### PR DESCRIPTION
README and roadmap were behind reality - mix-and-match agents per workflow step and sub-tasks were undocumented, and the roadmap still listed shipped work and long-tail integrations as near-term priorities. The workflow templates doc was also missing `Feature Dev`, bringing the shipped template count to five.

## Validation

- Docs-only change; verified by re-reading both files and cross-checking the workflow template set against `apps/backend/config/workflows/*.yml` (kanban, plan-and-build, architecture, pr-review, feature-dev).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.