### PR TITLE
fix: ux consistency on archiving and deleting tasks

### DIFF
--- a/apps/web/app/tasks/columns.tsx
+++ b/apps/web/app/tasks/columns.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import type { Row, ColumnDef } from "@tanstack/react-table";
 import type { Task, Workflow, WorkflowStep, Repository } from "@/lib/types/http";
 import Link from "next/link";
@@ -8,6 +9,8 @@ import { Button } from "@kandev/ui/button";
 import { Badge } from "@kandev/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { formatDistanceToNow } from "date-fns";
+import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
+import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
 
 type TaskWithResolution = Task & {
   workflowName?: string;
@@ -66,6 +69,8 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
   const task = row.original;
   const isDeleting = ctx.deletingTaskId === task.id;
   const isArchived = !!task.archived_at;
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
   return (
     <div className="flex items-center justify-end gap-0.5">
       {!isArchived && (
@@ -77,7 +82,7 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
               className="cursor-pointer h-7 w-7 p-0"
               onClick={(e) => {
                 e.stopPropagation();
-                ctx.onArchive(task.id);
+                setShowArchiveConfirm(true);
               }}
             >
               <IconArchive className="h-3.5 w-3.5 text-muted-foreground" />
@@ -95,7 +100,7 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
             disabled={isDeleting}
             onClick={(e) => {
               e.stopPropagation();
-              ctx.onDelete(task.id);
+              setShowDeleteConfirm(true);
             }}
           >
             {isDeleting ? (
@@ -107,6 +112,19 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
         </TooltipTrigger>
         <TooltipContent>Delete</TooltipContent>
       </Tooltip>
+      <TaskDeleteConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        taskTitle={task.title}
+        isDeleting={isDeleting}
+        onConfirm={() => ctx.onDelete(task.id)}
+      />
+      <TaskArchiveConfirmDialog
+        open={showArchiveConfirm}
+        onOpenChange={setShowArchiveConfirm}
+        taskTitle={task.title}
+        onConfirm={() => ctx.onArchive(task.id)}
+      />
     </div>
   );
 }

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -100,7 +100,6 @@ function useTaskOperations({
       setDeletingTaskId(taskId);
       try {
         await deleteTask(taskId);
-        toast({ title: "Task deleted", description: "The task has been deleted successfully." });
         fetchTasks();
       } catch (err) {
         toast({

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -13,16 +13,7 @@ import {
 import { Checkbox } from "@kandev/ui/checkbox";
 import { Card, CardContent } from "@kandev/ui/card";
 import { Badge } from "@kandev/ui/badge";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@kandev/ui/alert-dialog";
+import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -41,7 +32,7 @@ import { needsAction } from "@/lib/utils/needs-action";
 import { useAppStore } from "@/components/state-provider";
 import { PRTaskIcon } from "@/components/github/pr-task-icon";
 import { RemoteCloudTooltip } from "@/components/task/remote-cloud-tooltip";
-import { ArchiveConfirmDialog } from "@/components/task/archive-confirm-dialog";
+import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
 
 export interface Task {
   id: string;
@@ -114,6 +105,7 @@ function KanbanCardBody({
               {task.title}
             </p>
             <PRTaskIcon taskId={task.id} />
+
           </div>
         </div>
         {task.isRemoteExecutor && (
@@ -122,6 +114,7 @@ function KanbanCardBody({
             sessionId={task.primarySessionId ?? null}
             fallbackName={task.primaryExecutorName ?? task.primaryExecutorType}
           />
+
         )}
         {actions}
       </div>
@@ -131,7 +124,9 @@ function KanbanCardBody({
         </p>
       )}
       <KanbanCardBadges task={task} />
+
     </>
+
   );
 }
 
@@ -154,6 +149,7 @@ function KanbanCardBadges({ task }: { task: Task }) {
       {task.parentTaskId && (
         <Badge variant="outline" className="text-xs h-5 gap-1 max-w-[160px]">
           <IconSubtask className="h-3 w-3 shrink-0" />
+
           <span className="truncate">{parentTitle ?? "Subtask"}</span>
         </Badge>
       )}
@@ -165,6 +161,7 @@ function KanbanCardBadges({ task }: { task: Task }) {
       {task.reviewStatus === "pending" && task.state !== "IN_PROGRESS" && (
         <div className="flex items-center gap-1 text-amber-700 dark:text-amber-600">
           <IconAlertCircle className="h-3.5 w-3.5" />
+
           <span className="text-[10px] font-medium">Approval Required</span>
         </div>
       )}
@@ -189,6 +186,7 @@ function KanbanCardLayout({
     <Card size="sm" className={cn("w-full py-0", className)}>
       <CardContent className="px-2 py-1">
         <KanbanCardBody task={task} repoName={repositoryName ?? null} />
+
       </CardContent>
     </Card>
   );
@@ -240,6 +238,7 @@ function KanbanCardActions({
           title="Open full page"
         >
           <IconArrowsMaximize className="h-4 w-4" />
+
         </button>
       )}
       <KanbanCardMenu
@@ -254,51 +253,11 @@ function KanbanCardActions({
         onMove={onMove}
         steps={steps}
       />
+
     </div>
   );
 }
 
-function DeleteConfirmDialog({
-  open,
-  onOpenChange,
-  taskTitle,
-  isDeleting,
-  onConfirm,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  taskTitle: string;
-  isDeleting?: boolean;
-  onConfirm: () => void;
-}) {
-  return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete task</AlertDialogTitle>
-          <AlertDialogDescription>
-            Are you sure you want to delete &quot;{taskTitle}&quot;? This action cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            disabled={isDeleting}
-            className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            onClick={() => {
-              if (isDeleting) return;
-              onConfirm();
-              onOpenChange(false);
-            }}
-          >
-            {isDeleting ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
-}
 
 function MoveToSubmenu({
   task,
@@ -403,7 +362,8 @@ function KanbanCardMenu(props: KanbanCardMenuProps) {
                 setShowArchiveConfirm(true);
               }}
             >
-              {isArchiving ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {isArchiving ? <IconLoader className="mr-2 h-4 w-4 animate-spin" />
+ : null}
               Archive
             </DropdownMenuItem>
           )}
@@ -420,14 +380,14 @@ function KanbanCardMenu(props: KanbanCardMenuProps) {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <DeleteConfirmDialog
+      <TaskDeleteConfirmDialog
         open={showDeleteConfirm}
         onOpenChange={setShowDeleteConfirm}
         taskTitle={task.title}
         isDeleting={isDeleting}
         onConfirm={() => onDelete?.(task)}
       />
-      <ArchiveConfirmDialog
+      <TaskArchiveConfirmDialog
         open={showArchiveConfirm}
         onOpenChange={setShowArchiveConfirm}
         taskTitle={task.title}

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -105,7 +105,6 @@ function KanbanCardBody({
               {task.title}
             </p>
             <PRTaskIcon taskId={task.id} />
-
           </div>
         </div>
         {task.isRemoteExecutor && (
@@ -114,7 +113,6 @@ function KanbanCardBody({
             sessionId={task.primarySessionId ?? null}
             fallbackName={task.primaryExecutorName ?? task.primaryExecutorType}
           />
-
         )}
         {actions}
       </div>
@@ -124,9 +122,7 @@ function KanbanCardBody({
         </p>
       )}
       <KanbanCardBadges task={task} />
-
     </>
-
   );
 }
 
@@ -149,7 +145,6 @@ function KanbanCardBadges({ task }: { task: Task }) {
       {task.parentTaskId && (
         <Badge variant="outline" className="text-xs h-5 gap-1 max-w-[160px]">
           <IconSubtask className="h-3 w-3 shrink-0" />
-
           <span className="truncate">{parentTitle ?? "Subtask"}</span>
         </Badge>
       )}
@@ -161,7 +156,6 @@ function KanbanCardBadges({ task }: { task: Task }) {
       {task.reviewStatus === "pending" && task.state !== "IN_PROGRESS" && (
         <div className="flex items-center gap-1 text-amber-700 dark:text-amber-600">
           <IconAlertCircle className="h-3.5 w-3.5" />
-
           <span className="text-[10px] font-medium">Approval Required</span>
         </div>
       )}
@@ -186,7 +180,6 @@ function KanbanCardLayout({
     <Card size="sm" className={cn("w-full py-0", className)}>
       <CardContent className="px-2 py-1">
         <KanbanCardBody task={task} repoName={repositoryName ?? null} />
-
       </CardContent>
     </Card>
   );
@@ -238,7 +231,6 @@ function KanbanCardActions({
           title="Open full page"
         >
           <IconArrowsMaximize className="h-4 w-4" />
-
         </button>
       )}
       <KanbanCardMenu
@@ -253,11 +245,9 @@ function KanbanCardActions({
         onMove={onMove}
         steps={steps}
       />
-
     </div>
   );
 }
-
 
 function MoveToSubmenu({
   task,

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -352,8 +352,7 @@ function KanbanCardMenu(props: KanbanCardMenuProps) {
                 setShowArchiveConfirm(true);
               }}
             >
-              {isArchiving ? <IconLoader className="mr-2 h-4 w-4 animate-spin" />
- : null}
+              {isArchiving ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}
               Archive
             </DropdownMenuItem>
           )}

--- a/apps/web/components/kanban/graph2-task-pipeline.tsx
+++ b/apps/web/components/kanban/graph2-task-pipeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo } from "react";
-import { IconDots, IconTrash } from "@tabler/icons-react";
+import { useMemo, useState } from "react";
+import { IconArchive, IconDots, IconTrash } from "@tabler/icons-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,6 +9,8 @@ import {
   DropdownMenuTrigger,
 } from "@kandev/ui/dropdown-menu";
 import { cn } from "@kandev/ui/lib/utils";
+import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
+import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
 import { needsAction } from "@/lib/utils/needs-action";
 import { Graph2StepNode } from "./graph2-step-node";
 import { Graph2Connector } from "./graph2-connector";
@@ -40,8 +42,10 @@ export type Graph2TaskPipelineProps = {
   onPreviewTask: (task: Task) => void;
   onOpenTask: (task: Task) => void;
   onDeleteTask: (task: Task) => void;
+  onArchiveTask?: (task: Task) => void;
   isMoving?: boolean;
   isDeleting?: boolean;
+  isArchiving?: boolean;
 };
 
 function getStepPhase(index: number, currentStepIndex: number): "past" | "current" | "future" {
@@ -97,7 +101,9 @@ function PipelineStepNodes({
               onPreviewTask={onPreviewTask}
               isMoving={isMoving}
             />
-            {connectorType && <Graph2Connector type={connectorType} />}
+
+            {connectorType && <Graph2Connector type={connectorType} />
+}
           </div>
         );
       })}
@@ -112,9 +118,13 @@ export function Graph2TaskPipeline({
   onPreviewTask,
   onOpenTask,
   onDeleteTask,
+  onArchiveTask,
   isMoving,
   isDeleting,
+  isArchiving,
 }: Graph2TaskPipelineProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
   const currentStepIndex = useMemo(
     () => steps.findIndex((s) => s.id === task.workflowStepId),
     [steps, task.workflowStepId],
@@ -172,8 +182,18 @@ export function Graph2TaskPipeline({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-[160px]">
+            {onArchiveTask && (
+              <DropdownMenuItem
+                onClick={() => setShowArchiveConfirm(true)}
+                disabled={isArchiving}
+                className="cursor-pointer"
+              >
+                <IconArchive className="h-3.5 w-3.5 mr-2" />
+                Archive task
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
-              onClick={() => onDeleteTask(task)}
+              onClick={() => setShowDeleteConfirm(true)}
               disabled={isDeleting}
               className="text-destructive focus:text-destructive cursor-pointer"
             >
@@ -182,6 +202,22 @@ export function Graph2TaskPipeline({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+
+        <TaskDeleteConfirmDialog
+          open={showDeleteConfirm}
+          onOpenChange={setShowDeleteConfirm}
+          taskTitle={task.title}
+          isDeleting={isDeleting}
+          onConfirm={() => onDeleteTask(task)}
+        />
+        <TaskArchiveConfirmDialog
+          open={showArchiveConfirm}
+          onOpenChange={setShowArchiveConfirm}
+          taskTitle={task.title}
+          isArchiving={isArchiving}
+          onConfirm={() => onArchiveTask?.(task)}
+        />
+
       </div>
     </div>
   );

--- a/apps/web/components/kanban/graph2-task-pipeline.tsx
+++ b/apps/web/components/kanban/graph2-task-pipeline.tsx
@@ -102,8 +102,7 @@ function PipelineStepNodes({
               isMoving={isMoving}
             />
 
-            {connectorType && <Graph2Connector type={connectorType} />
-}
+            {connectorType && <Graph2Connector type={connectorType} />}
           </div>
         );
       })}
@@ -117,7 +116,10 @@ function TaskActions({
   onArchiveTask,
   isDeleting,
   isArchiving,
-}: Pick<Graph2TaskPipelineProps, "task" | "onDeleteTask" | "onArchiveTask" | "isDeleting" | "isArchiving">) {
+}: Pick<
+  Graph2TaskPipelineProps,
+  "task" | "onDeleteTask" | "onArchiveTask" | "isDeleting" | "isArchiving"
+>) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
 

--- a/apps/web/components/kanban/graph2-task-pipeline.tsx
+++ b/apps/web/components/kanban/graph2-task-pipeline.tsx
@@ -111,6 +111,66 @@ function PipelineStepNodes({
   );
 }
 
+function TaskActions({
+  task,
+  onDeleteTask,
+  onArchiveTask,
+  isDeleting,
+  isArchiving,
+}: Pick<Graph2TaskPipelineProps, "task" | "onDeleteTask" | "onArchiveTask" | "isDeleting" | "isArchiving">) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="shrink-0 h-7 w-7 flex items-center justify-center rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
+          >
+            <IconDots className="h-3.5 w-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-[160px]">
+          {onArchiveTask && (
+            <DropdownMenuItem
+              onClick={() => setShowArchiveConfirm(true)}
+              disabled={isArchiving}
+              className="cursor-pointer"
+            >
+              <IconArchive className="h-3.5 w-3.5 mr-2" />
+              Archive task
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            onClick={() => setShowDeleteConfirm(true)}
+            disabled={isDeleting}
+            className="text-destructive focus:text-destructive cursor-pointer"
+          >
+            <IconTrash className="h-3.5 w-3.5 mr-2" />
+            Delete task
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <TaskDeleteConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={setShowDeleteConfirm}
+        taskTitle={task.title}
+        isDeleting={isDeleting}
+        onConfirm={() => onDeleteTask(task)}
+      />
+      <TaskArchiveConfirmDialog
+        open={showArchiveConfirm}
+        onOpenChange={setShowArchiveConfirm}
+        taskTitle={task.title}
+        isArchiving={isArchiving}
+        onConfirm={() => onArchiveTask?.(task)}
+      />
+    </>
+  );
+}
+
 export function Graph2TaskPipeline({
   task,
   steps,
@@ -123,13 +183,10 @@ export function Graph2TaskPipeline({
   isDeleting,
   isArchiving,
 }: Graph2TaskPipelineProps) {
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
   const currentStepIndex = useMemo(
     () => steps.findIndex((s) => s.id === task.workflowStepId),
     [steps, task.workflowStepId],
   );
-
   const hasAction = needsAction(task);
   const sessionCount = task.sessionCount ?? 0;
 
@@ -162,7 +219,6 @@ export function Graph2TaskPipeline({
             )}
           </div>
         </button>
-
         <PipelineStepNodes
           steps={steps}
           currentStepIndex={currentStepIndex}
@@ -171,53 +227,13 @@ export function Graph2TaskPipeline({
           onPreviewTask={onPreviewTask}
           isMoving={isMoving}
         />
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="shrink-0 h-7 w-7 flex items-center justify-center rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent/60 transition-colors cursor-pointer"
-            >
-              <IconDots className="h-3.5 w-3.5" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-[160px]">
-            {onArchiveTask && (
-              <DropdownMenuItem
-                onClick={() => setShowArchiveConfirm(true)}
-                disabled={isArchiving}
-                className="cursor-pointer"
-              >
-                <IconArchive className="h-3.5 w-3.5 mr-2" />
-                Archive task
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuItem
-              onClick={() => setShowDeleteConfirm(true)}
-              disabled={isDeleting}
-              className="text-destructive focus:text-destructive cursor-pointer"
-            >
-              <IconTrash className="h-3.5 w-3.5 mr-2" />
-              Delete task
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <TaskDeleteConfirmDialog
-          open={showDeleteConfirm}
-          onOpenChange={setShowDeleteConfirm}
-          taskTitle={task.title}
+        <TaskActions
+          task={task}
+          onDeleteTask={onDeleteTask}
+          onArchiveTask={onArchiveTask}
           isDeleting={isDeleting}
-          onConfirm={() => onDeleteTask(task)}
-        />
-        <TaskArchiveConfirmDialog
-          open={showArchiveConfirm}
-          onOpenChange={setShowArchiveConfirm}
-          taskTitle={task.title}
           isArchiving={isArchiving}
-          onConfirm={() => onArchiveTask?.(task)}
         />
-
       </div>
     </div>
   );

--- a/apps/web/components/kanban/swimlane-graph2-content.tsx
+++ b/apps/web/components/kanban/swimlane-graph2-content.tsx
@@ -12,8 +12,10 @@ export function SwimlaneGraph2Content({
   onPreviewTask,
   onOpenTask,
   onDeleteTask,
+  onArchiveTask,
   onMoveError,
   deletingTaskId,
+  archivingTaskId,
 }: ViewContentProps) {
   const { moveTask } = useSwimlaneMove(workflowId, {
     onMoveError,
@@ -60,8 +62,10 @@ export function SwimlaneGraph2Content({
             onPreviewTask={onPreviewTask}
             onOpenTask={onOpenTask}
             onDeleteTask={onDeleteTask}
+            onArchiveTask={onArchiveTask}
             isMoving={movingTaskId === task.id}
             isDeleting={deletingTaskId === task.id}
+            isArchiving={archivingTaskId === task.id}
           />
         ))}
       </div>

--- a/apps/web/components/kanban/task-multi-select-toolbar.tsx
+++ b/apps/web/components/kanban/task-multi-select-toolbar.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { IconLoader, IconTrash, IconArchive, IconChevronRight, IconX } from "@tabler/icons-react";
+import { IconTrash, IconArchive, IconChevronRight, IconX } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@kandev/ui/alert-dialog";
+import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
+import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,6 +23,42 @@ interface TaskMultiSelectToolbarProps {
   onBulkDelete: () => Promise<void>;
   onBulkArchive: () => Promise<void>;
   onBulkMove: (targetStepId: string) => Promise<void>;
+}
+
+function BulkArchiveDialog({
+  count,
+  isProcessing,
+  onConfirm,
+}: {
+  count: number;
+  isProcessing: boolean;
+  onConfirm: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        className="cursor-pointer gap-1.5"
+        disabled={isProcessing}
+        onClick={() => setOpen(true)}
+        data-testid="bulk-archive-button"
+      >
+        <IconArchive className="h-4 w-4" />
+        Archive {count}
+      </Button>
+      <TaskArchiveConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        isBulkOperation
+        count={count}
+        isArchiving={isProcessing}
+        onConfirm={onConfirm}
+      />
+    </>
+  );
 }
 
 function BulkDeleteDialog({
@@ -57,32 +85,15 @@ function BulkDeleteDialog({
         <IconTrash className="h-4 w-4" />
         Delete {count}
       </Button>
-      <AlertDialog open={open} onOpenChange={setOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete {count} tasks</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete {count} task{count !== 1 ? "s" : ""}? This action
-              cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={isProcessing}
-              className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={() => {
-                onConfirm();
-                setOpen(false);
-              }}
-              data-testid="bulk-delete-confirm"
-            >
-              {isProcessing ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <TaskDeleteConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        isBulkOperation
+        count={count}
+        isDeleting={isProcessing}
+        onConfirm={onConfirm}
+        confirmTestId="bulk-delete-confirm"
+      />
     </>
   );
 }
@@ -143,17 +154,11 @@ export function TaskMultiSelectToolbar({
         </DropdownMenu>
       )}
 
-      <Button
-        size="sm"
-        variant="outline"
-        className="cursor-pointer gap-1.5"
-        disabled={isProcessing}
-        onClick={() => onBulkArchive()}
-        data-testid="bulk-archive-button"
-      >
-        <IconArchive className="h-4 w-4" />
-        Archive {count}
-      </Button>
+      <BulkArchiveDialog
+        count={count}
+        isProcessing={isProcessing}
+        onConfirm={() => onBulkArchive()}
+      />
 
       <BulkDeleteDialog
         count={count}

--- a/apps/web/components/kanban/task-multi-select-toolbar.tsx
+++ b/apps/web/components/kanban/task-multi-select-toolbar.tsx
@@ -56,6 +56,7 @@ function BulkArchiveDialog({
         count={count}
         isArchiving={isProcessing}
         onConfirm={onConfirm}
+        confirmTestId="bulk-archive-confirm"
       />
     </>
   );

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -7,7 +7,7 @@ import { Button } from "@kandev/ui/button";
 import { TaskSwitcher } from "../task-switcher";
 import { WorkspaceSwitcher } from "../workspace-switcher";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
-import { ArchiveConfirmDialog } from "../archive-confirm-dialog";
+import { TaskArchiveConfirmDialog } from "../task-archive-confirm-dialog";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { replaceTaskUrl } from "@/lib/links";
 import { fetchWorkflowSnapshot, listWorkflows } from "@/lib/api";
@@ -467,7 +467,7 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
         onSuccess={handleTaskCreated}
       />
 
-      <ArchiveConfirmDialog
+      <TaskArchiveConfirmDialog
         open={archivingTask !== null}
         onOpenChange={(open) => {
           if (!open) setArchivingTask(null);

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -20,6 +20,7 @@ type TaskArchiveConfirmDialogProps = {
   count?: number;
   isArchiving?: boolean;
   onConfirm: () => void;
+  confirmTestId?: string;
 };
 
 export function TaskArchiveConfirmDialog({
@@ -30,6 +31,7 @@ export function TaskArchiveConfirmDialog({
   count,
   isArchiving,
   onConfirm,
+  confirmTestId,
 }: TaskArchiveConfirmDialogProps) {
   const label = isBulkOperation ? `task${(count ?? 0) !== 1 ? "s" : ""}` : "task";
   const title = isBulkOperation ? `Archive ${count} ${label}?` : "Archive task?";
@@ -56,6 +58,7 @@ export function TaskArchiveConfirmDialog({
           <AlertDialogAction
             disabled={isArchiving}
             className="cursor-pointer"
+            data-testid={confirmTestId}
             onClick={(e) => {
               e.preventDefault();
               if (isArchiving) return;

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -33,10 +33,11 @@ export function TaskArchiveConfirmDialog({
   onConfirm,
   confirmTestId,
 }: TaskArchiveConfirmDialogProps) {
-  const label = isBulkOperation ? `task${(count ?? 0) !== 1 ? "s" : ""}` : "task";
-  const title = isBulkOperation ? `Archive ${count} ${label}?` : "Archive task?";
+  const safeCount = count ?? 0;
+  const label = isBulkOperation ? `task${safeCount !== 1 ? "s" : ""}` : "task";
+  const title = isBulkOperation ? `Archive ${safeCount} ${label}?` : "Archive task?";
   const firstLine = isBulkOperation
-    ? `Are you sure you want to archive ${count} ${label}?`
+    ? `Are you sure you want to archive ${safeCount} ${label}?`
     : `Are you sure you want to archive "${taskTitle}"?`;
 
   return (
@@ -59,10 +60,10 @@ export function TaskArchiveConfirmDialog({
             disabled={isArchiving}
             className="cursor-pointer"
             data-testid={confirmTestId}
-            onClick={(e) => {
-              e.preventDefault();
+            onClick={() => {
               if (isArchiving) return;
               onConfirm();
+              onOpenChange(false);
             }}
           >
             {isArchiving ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -12,29 +12,39 @@ import {
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
 
-type ArchiveConfirmDialogProps = {
+type TaskArchiveConfirmDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  taskTitle: string;
+  taskTitle?: string;
+  isBulkOperation?: boolean;
+  count?: number;
   isArchiving?: boolean;
   onConfirm: () => void;
 };
 
-export function ArchiveConfirmDialog({
+export function TaskArchiveConfirmDialog({
   open,
   onOpenChange,
   taskTitle,
+  isBulkOperation,
+  count,
   isArchiving,
   onConfirm,
-}: ArchiveConfirmDialogProps) {
+}: TaskArchiveConfirmDialogProps) {
+  const label = isBulkOperation ? `task${(count ?? 0) !== 1 ? "s" : ""}` : "task";
+  const title = isBulkOperation ? `Archive ${count} ${label}?` : "Archive task?";
+  const firstLine = isBulkOperation
+    ? `Are you sure you want to archive ${count} ${label}?`
+    : `Are you sure you want to archive "${taskTitle}"?`;
+
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent onClick={(e) => e.stopPropagation()}>
         <AlertDialogHeader>
-          <AlertDialogTitle>Archive task?</AlertDialogTitle>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription asChild>
             <div>
-              <p>Are you sure you want to archive &quot;{taskTitle}&quot;?</p>
+              <p>{firstLine}</p>
               <p className="mt-2">
                 This will delete the task&apos;s worktree and stop any running agent sessions.
               </p>

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -1,0 +1,64 @@
+import { IconLoader } from "@tabler/icons-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@kandev/ui/alert-dialog";
+
+export function TaskDeleteConfirmDialog({
+  open,
+  onOpenChange,
+  taskTitle,
+  isBulkOperation,
+  count,
+  isDeleting,
+  onConfirm,
+  confirmTestId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  taskTitle?: string;
+  isBulkOperation?: boolean;
+  count?: number;
+  isDeleting?: boolean;
+  onConfirm: () => void;
+  confirmTestId?: string;
+}) {
+  const label = isBulkOperation ? `task${(count ?? 0) !== 1 ? "s" : ""}` : "task";
+  const title = isBulkOperation ? `Delete ${count} ${label}` : "Delete task";
+  const description = isBulkOperation
+    ? `Are you sure you want to delete ${count} ${label}? This action cannot be undone.`
+    : `Are you sure you want to delete "${taskTitle}"? This action cannot be undone.`;
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isDeleting}
+            className="cursor-pointer bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            data-testid={confirmTestId}
+            onClick={() => {
+              if (isDeleting) return;
+              onConfirm();
+              onOpenChange(false);
+            }}
+          >
+            {isDeleting ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -29,10 +29,11 @@ export function TaskDeleteConfirmDialog({
   onConfirm: () => void;
   confirmTestId?: string;
 }) {
-  const label = isBulkOperation ? `task${(count ?? 0) !== 1 ? "s" : ""}` : "task";
-  const title = isBulkOperation ? `Delete ${count} ${label}` : "Delete task";
+  const safeCount = count ?? 0;
+  const label = isBulkOperation ? `task${safeCount !== 1 ? "s" : ""}` : "task";
+  const title = isBulkOperation ? `Delete ${safeCount} ${label}` : "Delete task";
   const description = isBulkOperation
-    ? `Are you sure you want to delete ${count} ${label}? This action cannot be undone.`
+    ? `Are you sure you want to delete ${safeCount} ${label}? This action cannot be undone.`
     : `Are you sure you want to delete "${taskTitle}"? This action cannot be undone.`;
 
   return (

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -8,7 +8,7 @@ import type { GitStatusEntry } from "@/lib/state/slices/session-runtime/types";
 import { TaskSwitcher } from "./task-switcher";
 import type { TaskSwitcherItem } from "./task-switcher";
 import { TaskRenameDialog } from "./task-rename-dialog";
-import { ArchiveConfirmDialog } from "./archive-confirm-dialog";
+import { TaskArchiveConfirmDialog } from "./task-archive-confirm-dialog";
 import { Button } from "@kandev/ui/button";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { IconPlus } from "@tabler/icons-react";
@@ -662,7 +662,7 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
         currentTitle={renamingTask?.title ?? ""}
         onSubmit={handleRenameSubmit}
       />
-      <ArchiveConfirmDialog
+      <TaskArchiveConfirmDialog
         open={archivingTask !== null}
         onOpenChange={(open) => {
           if (!open) setArchivingTask(null);

--- a/apps/web/e2e/pages/kanban-page.ts
+++ b/apps/web/e2e/pages/kanban-page.ts
@@ -9,6 +9,7 @@ export class KanbanPage {
   readonly bulkMoveButton: Locator;
   readonly bulkClearButton: Locator;
   readonly bulkDeleteConfirm: Locator;
+  readonly bulkArchiveConfirm: Locator;
 
   readonly multiSelectToggle: Locator;
 
@@ -22,6 +23,7 @@ export class KanbanPage {
     this.bulkMoveButton = page.getByTestId("bulk-move-button");
     this.bulkClearButton = page.getByTestId("bulk-clear-selection");
     this.bulkDeleteConfirm = page.getByTestId("bulk-delete-confirm");
+    this.bulkArchiveConfirm = page.getByTestId("bulk-archive-confirm");
   }
 
   async goto() {

--- a/apps/web/e2e/tests/kanban/task-multi-select.spec.ts
+++ b/apps/web/e2e/tests/kanban/task-multi-select.spec.ts
@@ -111,6 +111,7 @@ test.describe("Multi-select bulk actions", () => {
     await kanban.selectTask(t2.id);
 
     await kanban.bulkArchiveButton.click();
+    await kanban.bulkArchiveConfirm.click();
 
     await expect(kanban.taskCard(t1.id)).not.toBeVisible({ timeout: 10000 });
     await expect(kanban.taskCard(t2.id)).not.toBeVisible();
@@ -142,6 +143,7 @@ test.describe("Multi-select bulk actions", () => {
     await expect(testPage.locator('[data-multi-select-active="true"]').first()).toBeVisible();
 
     await kanban.bulkArchiveButton.click();
+    await kanban.bulkArchiveConfirm.click();
     await expect(kanban.taskCard(t1.id)).not.toBeVisible({ timeout: 10000 });
     await expect(kanban.taskCard(t2.id)).not.toBeVisible();
 


### PR DESCRIPTION
Deleting and archiving tasks behaved differently across Kanban, Pipeline, and List views — Kanban had a confirmation dialog, the others acted immediately. All three views now gate both actions behind consistent confirmation dialogs.

## Changes

- Extracted `TaskDeleteConfirmDialog` and `TaskArchiveConfirmDialog` as shared components used across all views
- Added archive confirmation to Pipeline and List views (previously missing entirely)
- Added archive option in Pipeline view
- Bulk delete and bulk archive in the multi-select toolbar now also go through the same dialogs
- `isBulkOperation` + `count` props handle bulk copy internally — callers just pass the count
- Removed the "Tasks successfully deleted" success toast. It only showed in the List view. I don't think it's relevant.

## Validation

https://github.com/user-attachments/assets/8874d319-9403-4207-9770-421613487eff

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
