### PR TITLE
ci: enable claude review on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,21 +1,39 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    # Run when any of:
+    #   - PR is from the same repo (trusted, secrets already available)
+    #   - PR author is OWNER/MEMBER/COLLABORATOR of this repo
+    #   - PR has the `safe-to-review` label (maintainer opt-in)
+    #   - PR author is on the CLAUDE_REVIEW_ALLOWLIST repo variable
+    #     (set in Settings -> Secrets and variables -> Actions -> Variables,
+    #      value is a JSON array string, e.g. ["alice","bob"])
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      contains(github.event.pull_request.labels.*.name, 'safe-to-review') ||
+      (vars.CLAUDE_REVIEW_ALLOWLIST != '' && contains(fromJSON(vars.CLAUDE_REVIEW_ALLOWLIST), github.event.pull_request.user.login))
     permissions:
       contents: read
       pull-requests: write
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head
         uses: actions/checkout@v4
         with:
+          # pull_request_target defaults to the base ref; explicitly check out
+          # the PR head so the review runs against the contributor's changes.
+          # Safe because the workflow never executes scripts from the PR;
+          # claude-code-action only reads files and posts comments.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Summary

The Claude code-review workflow was failing on fork PRs (e.g. #627) because GitHub does not expose repository secrets to `pull_request` workflows triggered from forks, so `CLAUDE_CODE_OAUTH_TOKEN` was empty and the action failed to authenticate within ~26s. This switches the review workflow to `pull_request_target` with an explicit allow-list so external contributions can receive automated review while keeping secret access gated.

## Important Changes

- `.github/workflows/claude-code-review.yml` trigger changed from `pull_request` to `pull_request_target`.
- Added an `if:` gate — the review only runs when any of these is true:
  - PR is from the same repo (already had secret access)
  - PR author is `OWNER` / `MEMBER` / `COLLABORATOR`
  - PR has the `safe-to-review` label (maintainer opt-in)
  - PR author is listed in the `CLAUDE_REVIEW_ALLOWLIST` repo variable (JSON array string, editable in the Actions Variables UI with no PR)
- `actions/checkout` pinned to `github.event.pull_request.head.sha` on the head repo, since `pull_request_target` defaults to the base ref.

Safe because the workflow never executes PR-supplied scripts: `claude-code-action` is invoked with `--allowedTools` restricted to `mcp__github_inline_comment__create_inline_comment` and `Bash(gh pr comment/diff/view:*)` — it only reads files and posts comments.

## Validation

- YAML syntax verified locally; file renders cleanly.
- Full end-to-end validation requires repo setup that isn't in this PR:
  1. Create repo variable `CLAUDE_REVIEW_ALLOWLIST` (Settings → Secrets and variables → Actions → Variables) with a JSON array value (e.g. `["fmmagalhaes"]`).
  2. Create the `safe-to-review` label.
  3. On the next fork PR, confirm: skipped without label/allowlist match; runs and posts review when label is added; runs automatically when author is in the allowlist; same-repo PRs continue to run unconditionally.

## Possible Improvements

- `pull_request_target` always carries supply-chain risk if the workflow ever starts executing PR-supplied code (installs, scripts, builds). Future edits to this workflow must preserve the "reads files and posts comments only" invariant.
- If the allowlist grows beyond ~10 names, consider moving it from a repo variable to a checked-in file read via a pre-step.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
