### PR TITLE
ci: pass GITHUB_TOKEN to claude-code-action to bypass OIDC exchange

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,6 +41,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the Claude GitHub App's OIDC -> installation-token exchange,
+          # which 401s on pull_request_target from forks. GITHUB_TOKEN inherits
+          # pull-requests: write from the permissions block above, which is
+          # enough for the action to post review comments.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           allowed_bots: "*"
           prompt: |


### PR DESCRIPTION
After #628 enabled the review on `pull_request_target`, fork PRs hit `App token exchange failed: 401 Unauthorized - Invalid OIDC token` because the action's default flow exchanges the workflow's OIDC token for a Claude GitHub App installation token, and that exchange rejects the claims produced for fork PRs. Supplying `github_token` makes the action skip the exchange and use the workflow's own `GITHUB_TOKEN`, which already has `pull-requests: write` from the existing `permissions` block — enough for it to post review comments.

## Validation

- Verified the failing run on PR #627 shows the OIDC exchange step as the failure point (`Exchanging OIDC token for app token...` → 401, 3 retries).
- Per the action's FAQ, providing `github_token` is the documented way to opt out of the Claude GitHub App path.
- End-to-end only testable post-merge: re-trigger the Claude Code Review job on a fork PR (e.g. #627) and confirm the OIDC exchange lines no longer appear and a review comment is posted.

## Possible Improvements

Low risk: scoped to the review workflow. If the action ever changes its default auth behavior when `github_token` is set, we may need to revisit — the `permissions:` block still controls the actual token scope.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
