### PR TITLE
docs: add Discord link and require e2e tests for UI changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,3 +55,4 @@ RULES
 - [ ] I have performed a self-review of my code.
 - [ ] I have manually tested my changes and they work as expected.
 - [ ] My changes have tests that cover the new functionality and edge cases.
+- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Contributions are welcome! This document covers the basics.
 
+## Community
+
+Join our [Discord](https://discord.gg/gWdCPGcFCD) to ask questions, discuss ideas, or get help with your contribution before opening a PR.
+
 ## Important
 
 You must understand the code you submit. You're welcome to use AI tools to help write code, but every PR will be reviewed by a human maintainer and the feature you're contributing should be manually tested. If you can't explain what your code does and why, it's not ready to submit.
@@ -10,7 +14,7 @@ You must understand the code you submit. You're welcome to use AI tools to help 
 
 1. **Fork and branch.** Create a feature branch from `main`.
 2. **Keep PRs focused.** One logical change per PR. Small PRs get reviewed faster.
-3. **Test your changes.** Run `make typecheck test lint` before submitting. Manually verify that your feature works end-to-end, add screenshots or recordings to the PR if it has a UI component.
+3. **Test your changes.** Run `make typecheck test lint` before submitting. Manually verify that your feature works end-to-end, and add screenshots or recordings to the PR if it has a UI component. **If your change touches any UI files (anything under `apps/web/`), you must add or update Playwright e2e tests in `apps/web/e2e/` to prevent regressions.** Run them with `make test-e2e`. See [docs/test_e2e_web.md](docs/test_e2e_web.md) for patterns and fixtures.
 
 ## Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Manage and run tasks in parallel. Orchestrate agents. Review changes. Ship value.
 
-[Workflows](docs/workflow-tips.md) | [Roadmap](docs/roadmap.md) | [Contributing](CONTRIBUTING.md) | [Architecture](docs/ARCHITECTURE.md)
+[Workflows](docs/workflow-tips.md) | [Roadmap](docs/roadmap.md) | [Contributing](CONTRIBUTING.md) | [Architecture](docs/ARCHITECTURE.md) | [Discord](https://discord.gg/gWdCPGcFCD)
 
 <p align="center">
   <img src="docs/screenshots/readme-intro.gif" alt="Kandev Demo">
@@ -183,7 +183,7 @@ There are a few similar tools in this space, and new ones appearing everyday. He
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
 
-See the [issue tracker](https://github.com/kdlbs/kandev/issues) for open tasks.
+See the [issue tracker](https://github.com/kdlbs/kandev/issues) for open tasks, or join our [Discord](https://discord.gg/gWdCPGcFCD) to chat with maintainers and other contributors.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

Contributors and users currently have no way to find the project's Discord community from the docs, and UI PRs can land without automated regression coverage. This adds the Discord invite to the two main entry points and makes Playwright e2e tests a hard requirement whenever `apps/web/` is touched.

## Important Changes

- `README.md` — Discord link added to the top nav bar and to the Contributing section.
- `CONTRIBUTING.md` — new Community section pointing to Discord, and the "Test your changes" bullet now requires adding/updating Playwright e2e tests in `apps/web/e2e/` for any change under `apps/web/`.
- `.github/pull_request_template.md` — new checklist item to enforce the e2e requirement at PR time.

## Validation

- Markdown-only changes; visually reviewed rendered output.
- No code, tests, or linters affected.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
