### PR TITLE
fix(web): collapse repeated "Resumed agent" boot messages into the last one

### DIFF
--- a/apps/web/e2e/tests/session/session-resume-dedup.spec.ts
+++ b/apps/web/e2e/tests/session/session-resume-dedup.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { SessionPage } from "../../pages/session-page";
+import type { Page } from "@playwright/test";
+
+async function openTaskSession(page: Page, title: string): Promise<SessionPage> {
+  const kanban = new KanbanPage(page);
+  await kanban.goto();
+
+  const card = kanban.taskCardByTitle(title);
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await card.click();
+  await expect(page).toHaveURL(/\/t\//, { timeout: 15_000 });
+
+  const session = new SessionPage(page);
+  await session.waitForLoad();
+  return session;
+}
+
+test.describe("Session resume boot-message dedup", () => {
+  // Test restarts the backend multiple times — can be flaky under CI load.
+  test.describe.configure({ retries: 1 });
+
+  test("only the most recent 'Resumed agent' boot message is visible", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(180_000);
+
+    // 1. Create the task and wait for the initial agent turn to finish.
+    await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Resume Dedup Task",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    const session = await openTaskSession(testPage, "Resume Dedup Task");
+    await expect(session.chat.getByText("simple mock response", { exact: false })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(session.idleInput()).toBeVisible({ timeout: 15_000 });
+
+    // 2. Initial "Started agent Mock" row should be visible exactly once.
+    await expect(session.chat.getByText("Started agent Mock", { exact: false })).toHaveCount(1, {
+      timeout: 15_000,
+    });
+
+    // 3. Restart the backend three times to produce three "Resumed agent" boot
+    //    messages. The first two must be hidden by the dedup; only the third
+    //    (most recent) should remain visible.
+    for (let i = 0; i < 3; i++) {
+      await backend.restart();
+      await testPage.reload();
+      await session.waitForLoad();
+      // Auto-resume + agent turn completion can be slow under CI load.
+      await expect(session.idleInput()).toBeVisible({ timeout: 60_000 });
+      await expect(session.chat.getByText("Resumed agent Mock", { exact: false })).toBeVisible({
+        timeout: 30_000,
+      });
+    }
+
+    // 4. Key assertion: despite three resumes, only the last "Resumed agent"
+    //    row should be rendered.
+    await expect(session.chat.getByText("Resumed agent Mock", { exact: false })).toHaveCount(1);
+
+    // 5. The original "Started agent" row must still be present — dedup must
+    //    not affect non-resuming boot messages.
+    await expect(session.chat.getByText("Started agent Mock", { exact: false })).toHaveCount(1);
+
+    // 6. Agent interaction still works after dedup.
+    await session.sendMessage("/e2e:simple-message");
+    await expect(
+      session.chat.getByText("simple mock response", { exact: false }).nth(1),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/apps/web/e2e/tests/session/session-resume-dedup.spec.ts
+++ b/apps/web/e2e/tests/session/session-resume-dedup.spec.ts
@@ -69,11 +69,15 @@ test.describe("Session resume boot-message dedup", () => {
 
     // 4. Key assertion: despite three resumes, only the last "Resumed agent"
     //    row should be rendered.
-    await expect(session.chat.getByText("Resumed agent Mock", { exact: false })).toHaveCount(1);
+    await expect(session.chat.getByText("Resumed agent Mock", { exact: false })).toHaveCount(1, {
+      timeout: 15_000,
+    });
 
     // 5. The original "Started agent" row must still be present — dedup must
     //    not affect non-resuming boot messages.
-    await expect(session.chat.getByText("Started agent Mock", { exact: false })).toHaveCount(1);
+    await expect(session.chat.getByText("Started agent Mock", { exact: false })).toHaveCount(1, {
+      timeout: 15_000,
+    });
 
     // 6. Agent interaction still works after dedup.
     await session.sendMessage("/e2e:simple-message");

--- a/apps/web/hooks/use-processed-messages.test.ts
+++ b/apps/web/hooks/use-processed-messages.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import type { Message, MessageType } from "@/lib/types/http";
+import { deduplicateAgentBootResumes, isAgentBootResumeMessage } from "./use-processed-messages";
+
+function makeMessage(
+  id: string,
+  type: MessageType,
+  metadata?: Record<string, unknown>,
+  content = "",
+): Message {
+  return {
+    id,
+    session_id: "s1",
+    task_id: "t1",
+    author_type: "agent",
+    content,
+    type,
+    metadata,
+    created_at: "",
+  };
+}
+
+function bootStarted(id: string): Message {
+  return makeMessage(id, "script_execution", {
+    script_type: "agent_boot",
+    agent_name: "Mock",
+    is_resuming: false,
+    status: "exited",
+  });
+}
+
+function bootResumed(id: string): Message {
+  return makeMessage(id, "script_execution", {
+    script_type: "agent_boot",
+    agent_name: "Mock",
+    is_resuming: true,
+    status: "exited",
+  });
+}
+
+describe("isAgentBootResumeMessage", () => {
+  it("returns true for script_execution agent_boot with is_resuming=true", () => {
+    expect(isAgentBootResumeMessage(bootResumed("r1"))).toBe(true);
+  });
+
+  it("returns false for a Started (non-resuming) agent_boot", () => {
+    expect(isAgentBootResumeMessage(bootStarted("s1"))).toBe(false);
+  });
+
+  it("returns false for a setup/cleanup script", () => {
+    const setup = makeMessage("x", "script_execution", {
+      script_type: "setup",
+      is_resuming: true,
+    });
+    expect(isAgentBootResumeMessage(setup)).toBe(false);
+  });
+
+  it("returns false for unrelated message types", () => {
+    expect(isAgentBootResumeMessage(makeMessage("m1", "message"))).toBe(false);
+  });
+
+  it("returns false when metadata is missing", () => {
+    const msg = makeMessage("x", "script_execution");
+    expect(isAgentBootResumeMessage(msg)).toBe(false);
+  });
+});
+
+describe("deduplicateAgentBootResumes", () => {
+  it("returns the list unchanged when there are no resume messages", () => {
+    const messages = [bootStarted("s1"), makeMessage("m1", "message", undefined, "hi")];
+    expect(deduplicateAgentBootResumes(messages)).toEqual(messages);
+  });
+
+  it("returns the list unchanged when there is exactly one resume message", () => {
+    const messages = [
+      bootStarted("s1"),
+      makeMessage("m1", "message", undefined, "hi"),
+      bootResumed("r1"),
+    ];
+    expect(deduplicateAgentBootResumes(messages)).toEqual(messages);
+  });
+
+  it("keeps only the last resume message when multiple exist", () => {
+    const messages = [bootResumed("r1"), bootResumed("r2"), bootResumed("r3")];
+    const result = deduplicateAgentBootResumes(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("r3");
+  });
+
+  it("preserves Started and non-boot messages while deduping resumes", () => {
+    const started = bootStarted("s1");
+    const userMsg = makeMessage("m1", "message", undefined, "hello");
+    const r1 = bootResumed("r1");
+    const r2 = bootResumed("r2");
+    const agentMsg = makeMessage("m2", "message", undefined, "reply");
+    const r3 = bootResumed("r3");
+
+    const result = deduplicateAgentBootResumes([started, userMsg, r1, r2, agentMsg, r3]);
+
+    expect(result.map((m) => m.id)).toEqual(["s1", "m1", "m2", "r3"]);
+  });
+
+  it("does not touch setup/cleanup script executions", () => {
+    const setup = makeMessage("x", "script_execution", {
+      script_type: "setup",
+      status: "exited",
+    });
+    const messages = [setup, bootResumed("r1"), bootResumed("r2")];
+    const result = deduplicateAgentBootResumes(messages);
+    expect(result.map((m) => m.id)).toEqual(["x", "r2"]);
+  });
+});

--- a/apps/web/hooks/use-processed-messages.test.ts
+++ b/apps/web/hooks/use-processed-messages.test.ts
@@ -66,6 +66,10 @@ describe("isAgentBootResumeMessage", () => {
 });
 
 describe("deduplicateAgentBootResumes", () => {
+  it("returns an empty list unchanged", () => {
+    expect(deduplicateAgentBootResumes([])).toEqual([]);
+  });
+
   it("returns the list unchanged when there are no resume messages", () => {
     const messages = [bootStarted("s1"), makeMessage("m1", "message", undefined, "hi")];
     expect(deduplicateAgentBootResumes(messages)).toEqual(messages);

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -133,6 +133,27 @@ function deduplicateRecoveryMessages(messages: Message[]): Message[] {
   });
 }
 
+export function isAgentBootResumeMessage(message: Message): boolean {
+  if (message.type !== "script_execution") return false;
+  const meta = message.metadata as { script_type?: string; is_resuming?: boolean } | undefined;
+  return meta?.script_type === "agent_boot" && meta?.is_resuming === true;
+}
+
+/** A resumed session may produce many "Resumed agent …" boot messages over its
+ *  lifetime (every backend restart emits one). They all convey the same info;
+ *  keep only the most recent and drop the rest. */
+export function deduplicateAgentBootResumes(messages: Message[]): Message[] {
+  let lastResumeIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (isAgentBootResumeMessage(messages[i])) {
+      lastResumeIdx = i;
+      break;
+    }
+  }
+  if (lastResumeIdx === -1) return messages;
+  return messages.filter((msg, i) => !isAgentBootResumeMessage(msg) || i === lastResumeIdx);
+}
+
 function filterVisibleMessages(
   messages: Message[],
   toolCallIds: Set<string>,
@@ -154,7 +175,7 @@ function filterVisibleMessages(
     return false;
   });
 
-  return deduplicateRecoveryMessages(filtered);
+  return deduplicateAgentBootResumes(deduplicateRecoveryMessages(filtered));
 }
 
 function groupActivityMessages(allMessages: Message[]): RenderItem[] {

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -141,7 +141,9 @@ export function isAgentBootResumeMessage(message: Message): boolean {
 
 /** A resumed session may produce many "Resumed agent …" boot messages over its
  *  lifetime (every backend restart emits one). They all convey the same info;
- *  keep only the most recent and drop the rest. */
+ *  keep only the most recent and drop the rest — unconditionally, even if user
+ *  messages occurred between them (unlike `deduplicateRecoveryMessages`). The
+ *  underlying DB rows are untouched; this only affects the rendered chat. */
 export function deduplicateAgentBootResumes(messages: Message[]): Message[] {
   let lastResumeIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Sessions that have been resumed multiple times stack up identical "Resumed agent …" boot rows in the chat view, drowning out real activity. Only the most recent resume is useful — earlier ones are now hidden, leaving the original "Started agent" row intact.

## Validation

- `pnpm --filter @kandev/web test` — 306 tests pass, including 10 new cases covering the predicate and dedup behaviour (no resumes, single resume, multiple resumes, Started + Resumed mix, setup-script guard).
- `pnpm --filter @kandev/web lint` — clean.
- `npx tsc --noEmit` on changed files — no new errors.
- New e2e `apps/web/e2e/tests/session/session-resume-dedup.spec.ts` restarts the backend three times and asserts only one "Resumed agent Mock" row remains visible while the original "Started agent Mock" row is preserved.

## Possible Improvements

Low risk — purely a presentation filter; the messages are still persisted so the audit trail is intact. Worst case, a genuinely useful earlier resume row (e.g. with distinct failure context) gets hidden; mitigated by keeping the most recent one, which is where a currently-running "Resuming…" spinner lives.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.