### PR TITLE
fix(onboarding): bound agent probe, add error tooltip, stop mock false errors

### DIFF
--- a/apps/backend/internal/agent/agents/mock.go
+++ b/apps/backend/internal/agent/agents/mock.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	_ "embed"
+	"os/exec"
 	"time"
 
 	"github.com/kandev/kandev/pkg/agent"
@@ -80,9 +81,20 @@ func (a *MockAgent) Logo(v LogoVariant) []byte {
 	return mockLogoLight
 }
 
-func (a *MockAgent) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
-	// Mock agent is always "available" when enabled (forced by settings controller).
-	return &DiscoveryResult{Available: true, SupportsMCP: a.supportsMCP}, nil
+func (a *MockAgent) IsInstalled(_ context.Context) (*DiscoveryResult, error) {
+	// Mock-agent is only usable when its CLI is reachable on PATH (or the
+	// caller explicitly set a binary path, e.g. E2E harness). Outside those
+	// setups the binary won't exist — return Available=false so the UI shows
+	// "Not installed" rather than probing and failing with ENOENT.
+	binary := "mock-agent"
+	if a.binaryPath != "" {
+		binary = a.binaryPath
+	}
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		return &DiscoveryResult{Available: false}, nil
+	}
+	return &DiscoveryResult{Available: true, SupportsMCP: a.supportsMCP, MatchedPath: path}, nil
 }
 
 func (a *MockAgent) BuildCommand(opts CommandOptions) Command {

--- a/apps/backend/internal/agent/agents/mock.go
+++ b/apps/backend/internal/agent/agents/mock.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"os/exec"
 	"time"
 
@@ -92,7 +93,14 @@ func (a *MockAgent) IsInstalled(_ context.Context) (*DiscoveryResult, error) {
 	}
 	path, err := exec.LookPath(binary)
 	if err != nil {
-		return &DiscoveryResult{Available: false}, nil
+		// Only "not found" is a normal state. Propagate other errors
+		// (permission denied, malformed PATH component) so bootstrapAgent
+		// surfaces them in the StatusNotInstalled Error field instead of
+		// silently masking the real cause.
+		if errors.Is(err, exec.ErrNotFound) {
+			return &DiscoveryResult{Available: false}, nil
+		}
+		return nil, err
 	}
 	return &DiscoveryResult{Available: true, SupportsMCP: a.supportsMCP, MatchedPath: path}, nil
 }

--- a/apps/backend/internal/agent/agents/mock_test.go
+++ b/apps/backend/internal/agent/agents/mock_test.go
@@ -1,6 +1,8 @@
 package agents
 
 import (
+	"context"
+	"os"
 	"testing"
 
 	"github.com/kandev/kandev/pkg/agent"
@@ -57,6 +59,41 @@ func TestMockAgent_Runtime_NoResumeFlag(t *testing.T) {
 	// ACP agents handle resume via session/load, not CLI flags.
 	if !rt.SessionConfig.ResumeFlag.IsEmpty() {
 		t.Error("expected ResumeFlag to be empty for ACP agent")
+	}
+}
+
+func TestMockAgent_IsInstalled_MissingBinary(t *testing.T) {
+	// With no `mock-agent` on PATH, IsInstalled must report not-available so
+	// the host utility skips probing (avoiding ENOENT → StatusFailed) and the
+	// UI renders "Not installed" rather than an error badge.
+	t.Setenv("PATH", "")
+	a := NewMockAgent()
+	result, err := a.IsInstalled(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Available {
+		t.Errorf("expected Available=false with empty PATH, got true")
+	}
+	if result.MatchedPath != "" {
+		t.Errorf("expected empty MatchedPath, got %q", result.MatchedPath)
+	}
+}
+
+func TestMockAgent_IsInstalled_WithBinaryPath(t *testing.T) {
+	// A non-empty binary path that actually exists should make the mock
+	// report available with MatchedPath populated.
+	a := NewMockAgent()
+	a.SetBinaryPath(os.Args[0]) // Test binary is guaranteed to exist.
+	result, err := a.IsInstalled(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Available {
+		t.Errorf("expected Available=true for existing binary path")
+	}
+	if result.MatchedPath == "" {
+		t.Errorf("expected MatchedPath to be set")
 	}
 }
 

--- a/apps/backend/internal/agent/hostutility/cache.go
+++ b/apps/backend/internal/agent/hostutility/cache.go
@@ -28,6 +28,12 @@ func (c *cache) get(agentType string) (AgentCapabilities, bool) {
 	return caps, ok
 }
 
+func (c *cache) clear(agentType string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.byType, agentType)
+}
+
 func (c *cache) all() []AgentCapabilities {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -354,6 +354,12 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 	return v.(*instance), ia, nil
 }
 
+// probeTimeout bounds a single probe attempt. Long enough to cover `npx`
+// cold-starts on moderately slow networks (Gemini / Copilot CLIs pull their
+// packages on first run), short enough that hangs surface within one
+// onboarding refresh cycle instead of leaving agents stuck in "Probing".
+const probeTimeout = 45 * time.Second
+
 // probe runs an ACP probe against the given instance and translates the result
 // into an AgentCapabilities record suitable for the cache.
 func (m *Manager) probe(ctx context.Context, inst *instance, ia agents.InferenceAgent) AgentCapabilities {
@@ -366,13 +372,16 @@ func (m *Manager) probe(ctx context.Context, inst *instance, ia agents.Inference
 			WorkDir:   inst.workDir,
 		},
 	}
-	resp, err := inst.client.Probe(ctx, req)
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	resp, err := inst.client.Probe(probeCtx, req)
 	now := time.Now()
 	if err != nil {
+		status, msg := classifyProbeError(err, probeCtx.Err())
 		return AgentCapabilities{
 			AgentType:     inst.agentType,
-			Status:        StatusFailed,
-			Error:         err.Error(),
+			Status:        status,
+			Error:         msg,
 			LastCheckedAt: now,
 		}
 	}
@@ -425,6 +434,24 @@ func (m *Manager) probe(ctx context.Context, inst *instance, ia agents.Inference
 		caps.Commands = append(caps.Commands, Command{Name: c.Name, Description: c.Description})
 	}
 	return caps
+}
+
+// classifyProbeError turns a probe transport error into a cache status.
+// Deadline exceeded on probeCtx (but not on the parent ctx) indicates a
+// hung subprocess — surface it as a timeout so the UI stops spinning.
+// Missing-binary errors from acp_executor's cmd.Start() arrive as strings
+// like `start: exec: "<name>": executable file not found in $PATH` — we
+// map them to StatusNotInstalled so the user sees the correct remediation
+// instead of a generic error badge.
+func classifyProbeError(err error, probeCtxErr error) (Status, string) {
+	if errors.Is(probeCtxErr, context.DeadlineExceeded) {
+		return StatusFailed, fmt.Sprintf("probe timed out after %s", probeTimeout)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "executable file not found") {
+		return StatusNotInstalled, msg
+	}
+	return StatusFailed, msg
 }
 
 // isAuthError is a coarse heuristic — ACP auth failures bubble up as string

--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -216,6 +216,11 @@ func (m *Manager) bootstrapAgent(ctx context.Context, ia agents.InferenceAgent) 
 	m.mu.Unlock()
 
 	caps := m.probe(ctx, inst, ia)
+	if ctx.Err() != nil {
+		// Parent context canceled (e.g. shutdown). Don't overwrite the cache
+		// with a spurious "context canceled" error — leave prior state intact.
+		return
+	}
 	m.cache.set(caps)
 	log.Info("host utility bootstrap completed",
 		zap.String("status", string(caps.Status)),
@@ -377,7 +382,7 @@ func (m *Manager) probe(ctx context.Context, inst *instance, ia agents.Inference
 	resp, err := inst.client.Probe(probeCtx, req)
 	now := time.Now()
 	if err != nil {
-		status, msg := classifyProbeError(err, probeCtx.Err())
+		status, msg := classifyProbeError(err, ctx.Err(), probeCtx.Err())
 		return AgentCapabilities{
 			AgentType:     inst.agentType,
 			Status:        status,
@@ -439,12 +444,15 @@ func (m *Manager) probe(ctx context.Context, inst *instance, ia agents.Inference
 // classifyProbeError turns a probe transport error into a cache status.
 // Deadline exceeded on probeCtx (but not on the parent ctx) indicates a
 // hung subprocess — surface it as a timeout so the UI stops spinning.
+// When the parent ctx already carries a shorter deadline, don't misattribute
+// that to our 45s probe budget.
 // Missing-binary errors from acp_executor's cmd.Start() arrive as strings
 // like `start: exec: "<name>": executable file not found in $PATH` — we
 // map them to StatusNotInstalled so the user sees the correct remediation
 // instead of a generic error badge.
-func classifyProbeError(err error, probeCtxErr error) (Status, string) {
-	if errors.Is(probeCtxErr, context.DeadlineExceeded) {
+func classifyProbeError(err error, parentCtxErr error, probeCtxErr error) (Status, string) {
+	if errors.Is(probeCtxErr, context.DeadlineExceeded) &&
+		!errors.Is(parentCtxErr, context.DeadlineExceeded) {
 		return StatusFailed, fmt.Sprintf("probe timed out after %s", probeTimeout)
 	}
 	msg := err.Error()

--- a/apps/backend/internal/agent/hostutility/manager_test.go
+++ b/apps/backend/internal/agent/hostutility/manager_test.go
@@ -1,0 +1,42 @@
+package hostutility
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestClassifyProbeError_Timeout(t *testing.T) {
+	status, msg := classifyProbeError(errors.New("probe: context deadline exceeded"), context.DeadlineExceeded)
+	if status != StatusFailed {
+		t.Errorf("expected StatusFailed for timeout, got %s", status)
+	}
+	if !strings.Contains(msg, "timed out") {
+		t.Errorf("expected timeout message, got %q", msg)
+	}
+}
+
+func TestClassifyProbeError_ExecutableNotFound(t *testing.T) {
+	// Mirrors the string format from acp_executor's cmd.Start() wrap:
+	// `start: exec: "<name>": executable file not found in $PATH`.
+	err := errors.New(`start: exec: "mock-agent": executable file not found in $PATH`)
+	status, msg := classifyProbeError(err, nil)
+	if status != StatusNotInstalled {
+		t.Errorf("expected StatusNotInstalled for missing binary, got %s", status)
+	}
+	if msg != err.Error() {
+		t.Errorf("expected original message preserved, got %q", msg)
+	}
+}
+
+func TestClassifyProbeError_Generic(t *testing.T) {
+	err := errors.New("rpc: connection refused")
+	status, msg := classifyProbeError(err, nil)
+	if status != StatusFailed {
+		t.Errorf("expected StatusFailed for generic error, got %s", status)
+	}
+	if msg != err.Error() {
+		t.Errorf("expected original message preserved, got %q", msg)
+	}
+}

--- a/apps/backend/internal/agent/hostutility/manager_test.go
+++ b/apps/backend/internal/agent/hostutility/manager_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func TestClassifyProbeError_Timeout(t *testing.T) {
-	status, msg := classifyProbeError(errors.New("probe: context deadline exceeded"), context.DeadlineExceeded)
+	status, msg := classifyProbeError(
+		errors.New("probe: context deadline exceeded"),
+		nil,
+		context.DeadlineExceeded,
+	)
 	if status != StatusFailed {
 		t.Errorf("expected StatusFailed for timeout, got %s", status)
 	}
@@ -17,11 +21,25 @@ func TestClassifyProbeError_Timeout(t *testing.T) {
 	}
 }
 
+func TestClassifyProbeError_ParentDeadlineNotAttributed(t *testing.T) {
+	// Parent context already has its own deadline that fires first; the
+	// probe shouldn't claim "timed out after 45s" when the root cause is
+	// the caller's context deadline.
+	err := errors.New("probe: context deadline exceeded")
+	status, msg := classifyProbeError(err, context.DeadlineExceeded, context.DeadlineExceeded)
+	if status != StatusFailed {
+		t.Errorf("expected StatusFailed, got %s", status)
+	}
+	if strings.Contains(msg, "timed out after") {
+		t.Errorf("expected generic failure message when parent deadline fires, got %q", msg)
+	}
+}
+
 func TestClassifyProbeError_ExecutableNotFound(t *testing.T) {
 	// Mirrors the string format from acp_executor's cmd.Start() wrap:
 	// `start: exec: "<name>": executable file not found in $PATH`.
 	err := errors.New(`start: exec: "mock-agent": executable file not found in $PATH`)
-	status, msg := classifyProbeError(err, nil)
+	status, msg := classifyProbeError(err, nil, nil)
 	if status != StatusNotInstalled {
 		t.Errorf("expected StatusNotInstalled for missing binary, got %s", status)
 	}
@@ -32,7 +50,7 @@ func TestClassifyProbeError_ExecutableNotFound(t *testing.T) {
 
 func TestClassifyProbeError_Generic(t *testing.T) {
 	err := errors.New("rpc: connection refused")
-	status, msg := classifyProbeError(err, nil)
+	status, msg := classifyProbeError(err, nil, nil)
 	if status != StatusFailed {
 		t.Errorf("expected StatusFailed for generic error, got %s", status)
 	}

--- a/apps/backend/internal/agent/hostutility/public.go
+++ b/apps/backend/internal/agent/hostutility/public.go
@@ -30,6 +30,9 @@ func (m *Manager) Get(agentType string) (AgentCapabilities, bool) {
 // new capabilities. If the warm instance is missing (never bootstrapped or
 // crashed), it is lazily recreated.
 func (m *Manager) Refresh(ctx context.Context, agentType string) (AgentCapabilities, error) {
+	// Snapshot the prior cache entry so we can restore it if the caller
+	// cancels mid-probe (see restorePriorOnCancel below).
+	prior, hadPrior := m.cache.get(agentType)
 	// Publish "probing" so callers polling the cache see in-flight state.
 	m.cache.set(AgentCapabilities{
 		AgentType:     agentType,
@@ -38,6 +41,10 @@ func (m *Manager) Refresh(ctx context.Context, agentType string) (AgentCapabilit
 	})
 	inst, ia, err := m.getInstance(ctx, agentType)
 	if err != nil {
+		if ctx.Err() != nil {
+			m.restorePriorOnCancel(agentType, prior, hadPrior)
+			return AgentCapabilities{}, ctx.Err()
+		}
 		status := StatusFailed
 		if errors.Is(err, errAgentNotInstalled) {
 			status = StatusNotInstalled
@@ -51,8 +58,23 @@ func (m *Manager) Refresh(ctx context.Context, agentType string) (AgentCapabilit
 		return AgentCapabilities{}, err
 	}
 	caps := m.probe(ctx, inst, ia)
+	if ctx.Err() != nil {
+		m.restorePriorOnCancel(agentType, prior, hadPrior)
+		return caps, ctx.Err()
+	}
 	m.cache.set(caps)
 	return caps, nil
+}
+
+// restorePriorOnCancel rolls the cache back to the pre-Refresh entry when the
+// caller cancels (e.g. browser close). Without this we'd leave StatusProbing
+// stuck or cache a spurious "context canceled" error.
+func (m *Manager) restorePriorOnCancel(agentType string, prior AgentCapabilities, hadPrior bool) {
+	if hadPrior {
+		m.cache.set(prior)
+		return
+	}
+	m.cache.clear(agentType)
 }
 
 // ExecutePrompt runs a sessionless utility prompt against the warm instance

--- a/apps/backend/internal/agent/settings/controller/agent_discovery.go
+++ b/apps/backend/internal/agent/settings/controller/agent_discovery.go
@@ -421,21 +421,9 @@ func (c *Controller) detectTools() []dto.ToolStatusDTO {
 	return []dto.ToolStatusDTO{ghTool}
 }
 
-// detectAgents runs discovery and forces mock-agent available when enabled.
+// detectAgents runs discovery. Mock-agent availability is driven by its own
+// IsInstalled() PATH check — no special override here, so a missing binary
+// shows as "Not installed" instead of a spurious error.
 func (c *Controller) detectAgents(ctx context.Context) ([]discovery.Availability, error) {
-	results, err := c.discovery.Detect(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// Force mock-agent as available when enabled (skip file-presence discovery)
-	agentConfig, ok := c.agentRegistry.Get("mock-agent")
-	if ok && agentConfig.Enabled() {
-		for i := range results {
-			if results[i].Name == "mock-agent" {
-				results[i].Available = true
-				break
-			}
-		}
-	}
-	return results, nil
+	return c.discovery.Detect(ctx)
 }

--- a/apps/web/components/onboarding/step-agents.tsx
+++ b/apps/web/components/onboarding/step-agents.tsx
@@ -70,22 +70,38 @@ function withErrorTooltip(node: ReactElement, errorMessage?: string) {
 }
 
 function StatusPill({ status, errorMessage }: { status: string; errorMessage?: string }) {
+  // tabIndex is applied when the pill gets a tooltip so keyboard users can
+  // focus the span and read the error detail (asChild passes children through
+  // as the trigger, and a bare <span> isn't focusable by default).
+  const focusableIfTooltip = errorMessage ? { tabIndex: 0 } : {};
   switch (status) {
     case "auth_required":
       return withErrorTooltip(
-        <span className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+        <span
+          {...focusableIfTooltip}
+          className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        >
           <IconLock className="h-3.5 w-3.5" />
           No auth
         </span>,
         errorMessage,
       );
     case "not_installed":
-      return (
-        <span className="flex items-center gap-1 text-xs text-muted-foreground">Not installed</span>
+      return withErrorTooltip(
+        <span
+          {...focusableIfTooltip}
+          className="flex items-center gap-1 text-xs text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        >
+          Not installed
+        </span>,
+        errorMessage,
       );
     case "failed":
       return withErrorTooltip(
-        <span className="flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
+        <span
+          {...focusableIfTooltip}
+          className="flex items-center gap-1 text-xs text-red-600 dark:text-red-400 outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+        >
           <IconAlertTriangle className="h-3.5 w-3.5" />
           Error
         </span>,

--- a/apps/web/components/onboarding/step-agents.tsx
+++ b/apps/web/components/onboarding/step-agents.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactElement } from "react";
 import {
   IconAlertTriangle,
   IconCheck,
@@ -12,6 +12,7 @@ import {
   IconLock,
 } from "@tabler/icons-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@kandev/ui/collapsible";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { AgentLogo } from "@/components/agent-logo";
 import { ProfileFormFields, type ProfileFormData } from "@/components/settings/profile-form-fields";
 import type { AvailableAgent, ToolStatus } from "@/lib/types/http";
@@ -56,25 +57,39 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-function StatusPill({ status }: { status: string }) {
+function withErrorTooltip(node: ReactElement, errorMessage?: string) {
+  if (!errorMessage) return node;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{node}</TooltipTrigger>
+      <TooltipContent className="max-w-sm whitespace-pre-wrap break-words">
+        {errorMessage}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function StatusPill({ status, errorMessage }: { status: string; errorMessage?: string }) {
   switch (status) {
     case "auth_required":
-      return (
+      return withErrorTooltip(
         <span className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
           <IconLock className="h-3.5 w-3.5" />
           No auth
-        </span>
+        </span>,
+        errorMessage,
       );
     case "not_installed":
       return (
         <span className="flex items-center gap-1 text-xs text-muted-foreground">Not installed</span>
       );
     case "failed":
-      return (
+      return withErrorTooltip(
         <span className="flex items-center gap-1 text-xs text-red-600 dark:text-red-400">
           <IconAlertTriangle className="h-3.5 w-3.5" />
           Error
-        </span>
+        </span>,
+        errorMessage,
       );
     case "probing":
       return (
@@ -130,7 +145,7 @@ function InstalledAgentRow({
               {modelName}
             </span>
           )}
-          <StatusPill status={status} />
+          <StatusPill status={status} errorMessage={agent.model_config.error} />
           <IconChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
         </button>
       </CollapsibleTrigger>

--- a/apps/web/e2e/tests/onboarding/agents-step.spec.ts
+++ b/apps/web/e2e/tests/onboarding/agents-step.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "../../fixtures/test-base";
+
+/**
+ * Regression guard for the onboarding "AI Agents" step. Specifically covers
+ * the collapsed agent row surfacing a tooltip with the probe error message
+ * on failed/auth-required states — previously the error was only visible
+ * after expanding the row.
+ */
+test.describe("Onboarding: AI Agents step", () => {
+  test("shows tooltip with error message on failed agent row", async ({ testPage }) => {
+    // Stub the available-agents response with three synthetic rows — one ok,
+    // one probing, one failed — so we don't depend on host-side probe timing.
+    await testPage.route("**/api/v1/agents/available", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          agents: [
+            buildAgent({ name: "ok-agent", display: "Ok Agent", status: "ok" }),
+            buildAgent({ name: "probing-agent", display: "Probing Agent", status: "probing" }),
+            buildAgent({
+              name: "failed-agent",
+              display: "Failed Agent",
+              status: "failed",
+              error: "probe timed out after 45s",
+            }),
+          ],
+          tools: [],
+          total: 3,
+        }),
+      }),
+    );
+
+    // The shared fixture pre-sets kandev.onboarding.completed=true; undo that
+    // so the onboarding dialog renders.
+    await testPage.addInitScript(() => {
+      localStorage.removeItem("kandev.onboarding.completed");
+    });
+
+    await testPage.goto("/");
+
+    await expect(
+      testPage.getByRole("heading", { name: "AI Agents", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // All three agent rows are listed as installed (filtered by agent.available).
+    await expect(testPage.getByText("Ok Agent")).toBeVisible();
+    await expect(testPage.getByText("Probing Agent")).toBeVisible();
+    await expect(testPage.getByText("Failed Agent")).toBeVisible();
+
+    // Ok row shows "Installed" with no error tooltip trigger.
+    await expect(testPage.getByText("Installed", { exact: true })).toBeVisible();
+
+    // Probing row shows the spinner + label.
+    await expect(testPage.getByText("Probing", { exact: true })).toBeVisible();
+
+    // Failed row shows "Error". Hovering reveals a tooltip with the message.
+    const errorLabel = testPage.getByText("Error", { exact: true });
+    await expect(errorLabel).toBeVisible();
+    await errorLabel.hover();
+    await expect(testPage.getByRole("tooltip")).toContainText("probe timed out after 45s");
+  });
+});
+
+function buildAgent(opts: {
+  name: string;
+  display: string;
+  status: "ok" | "probing" | "failed";
+  error?: string;
+}) {
+  return {
+    name: opts.name,
+    display_name: opts.display,
+    description: "",
+    install_script: "",
+    supports_mcp: false,
+    mcp_config_path: null,
+    installation_paths: [],
+    available: true,
+    matched_path: null,
+    capabilities: {
+      supports_session_resume: false,
+      supports_shell: false,
+      supports_workspace_only: false,
+    },
+    model_config: {
+      default_model: "synthetic",
+      available_models: [{ id: "synthetic", name: "synthetic" }],
+      supports_dynamic_models: true,
+      status: opts.status,
+      error: opts.error,
+    },
+    permission_settings: {},
+    passthrough_config: null,
+    updated_at: new Date().toISOString(),
+  };
+}

--- a/apps/web/e2e/tests/onboarding/agents-step.spec.ts
+++ b/apps/web/e2e/tests/onboarding/agents-step.spec.ts
@@ -39,9 +39,9 @@ test.describe("Onboarding: AI Agents step", () => {
 
     await testPage.goto("/");
 
-    await expect(
-      testPage.getByRole("heading", { name: "AI Agents", exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(testPage.getByRole("heading", { name: "AI Agents", exact: true })).toBeVisible({
+      timeout: 15_000,
+    });
 
     // All three agent rows are listed as installed (filtered by agent.available).
     await expect(testPage.getByText("Ok Agent")).toBeVisible();


### PR DESCRIPTION
## Summary

The onboarding "AI Agents" step left Gemini/Copilot stuck on "Probing" forever, showed the Mock agent as "Error" when its binary wasn't on `$PATH`, and hid probe error messages until the row was expanded. This change bounds each probe, routes missing-binary errors to the "Not installed" state, and surfaces error messages in a tooltip on the collapsed row.

## Important Changes

- `hostutility.probe` now wraps each attempt in a 45s timeout and uses a new `classifyProbeError` helper that maps `"executable file not found"` to `StatusNotInstalled` (instead of `StatusFailed`) and deadline-exceeded to a clear "probe timed out after 45s" message.
- `MockAgent.IsInstalled` checks `$PATH` (or an explicit `binaryPath`) rather than always reporting available. The force-`Available: true` override in `agent_discovery.detectAgents` is removed, so a missing `mock-agent` binary now shows "Not installed" rather than an error badge.
- `StepAgents.StatusPill` wraps the "Error" and "No auth" pills in a tooltip that shows `model_config.error`, so the probe failure reason is visible without expanding the row.

## Validation

- `go test ./internal/agent/hostutility/ ./internal/agent/agents/` (3 new `classifyProbeError` tests, 2 new `MockAgent.IsInstalled` tests)
- `go build ./...` and `go vet` on edited packages
- `pnpm lint components/onboarding/step-agents.tsx e2e/tests/onboarding/agents-step.spec.ts`
- `pnpm e2e --grep Onboarding` (new `agents-step.spec.ts` passes: stubbed agents with `ok` / `probing` / `failed` statuses, verifies the Error row's tooltip surfaces the injected error message)

## Possible Improvements

The `"executable file not found"` substring match is fragile — the canonical `exec.ErrNotFound` sentinel is lost when the error crosses the agentctl RPC boundary, so we match on string content. A future refactor that propagates typed errors through agentctl could replace this with `errors.Is`.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated
- [ ] Manual verification
