### PR TITLE
fix: clear kanban snapshots when active workspace changes

### DIFF
--- a/apps/web/components/kanban-display-dropdown.tsx
+++ b/apps/web/components/kanban-display-dropdown.tsx
@@ -41,12 +41,16 @@ function WorkspaceSection({
         value={activeWorkspaceId ?? ""}
         onValueChange={(value) => onWorkspaceChange(value || null)}
       >
-        <SelectTrigger className="w-full border-border">
+        <SelectTrigger className="w-full border-border" data-testid="workspace-select-trigger">
           <SelectValue placeholder="Select workspace" />
         </SelectTrigger>
         <SelectContent>
           {workspaces.map((workspace: Workspace) => (
-            <SelectItem key={workspace.id} value={workspace.id}>
+            <SelectItem
+              key={workspace.id}
+              value={workspace.id}
+              data-testid={`workspace-select-item-${workspace.id}`}
+            >
               {workspace.name}
             </SelectItem>
           ))}

--- a/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
+++ b/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
@@ -1,14 +1,4 @@
-/**
- * Regression test: switching the active workspace must not leak tasks from
- * the previous workspace into the task sidebar.
- *
- * Bug: useAllWorkflowSnapshots accumulated kanbanMulti.snapshots across
- * workspace switches. The sidebar merges tasks from every snapshot; cross-
- * workspace tasks had a repositoryId that didn't match the current workspace
- * repo map, so they rendered under the "Unassigned" group.
- *
- * Fix: clearKanbanMulti() is called when workspaceId changes.
- */
+// Switching the active workspace must not leak tasks from the previous workspace into the sidebar.
 import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
@@ -34,7 +24,9 @@ test.describe("Sidebar — cross-workspace isolation", () => {
     const workspaceB = await apiClient.createWorkspace("Workspace B");
     const workflowB = await apiClient.createWorkflow(workspaceB.id, "Workflow B", "simple");
     const { steps: stepsB } = await apiClient.listWorkflowSteps(workflowB.id);
-    const startStepB = stepsB.sort((a, b) => a.position - b.position).find((s) => s.is_start_step);
+    const startStepB = [...stepsB]
+      .sort((a, b) => a.position - b.position)
+      .find((s) => s.is_start_step);
     if (!startStepB) throw new Error("workspace B workflow has no start step");
 
     const repoBDir = path.join(backend.tmpDir, "repos", "e2e-repo-b");

--- a/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
+++ b/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression test: switching the active workspace must not leak tasks from
+ * the previous workspace into the task sidebar.
+ *
+ * Bug: useAllWorkflowSnapshots accumulated kanbanMulti.snapshots across
+ * workspace switches. The sidebar merges tasks from every snapshot; cross-
+ * workspace tasks had a repositoryId that didn't match the current workspace
+ * repo map, so they rendered under the "Unassigned" group.
+ *
+ * Fix: clearKanbanMulti() is called when workspaceId changes.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { SessionPage } from "../../pages/session-page";
+
+test.describe("Sidebar — cross-workspace isolation", () => {
+  test("tasks from the previous workspace do not leak into the sidebar after switching", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    // --- Seed workspace A artifacts ---
+    const taskA = await apiClient.createTask(seedData.workspaceId, "Workspace A Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    // --- Create workspace B with its own workflow, repo, and task ---
+    const workspaceB = await apiClient.createWorkspace("Workspace B");
+    const workflowB = await apiClient.createWorkflow(workspaceB.id, "Workflow B", "simple");
+    const { steps: stepsB } = await apiClient.listWorkflowSteps(workflowB.id);
+    const startStepB = stepsB.sort((a, b) => a.position - b.position).find((s) => s.is_start_step);
+    if (!startStepB) throw new Error("workspace B workflow has no start step");
+
+    const repoBDir = path.join(backend.tmpDir, "repos", "e2e-repo-b");
+    fs.mkdirSync(repoBDir, { recursive: true });
+    const gitEnv = {
+      ...process.env,
+      HOME: backend.tmpDir,
+      GIT_AUTHOR_NAME: "E2E Test",
+      GIT_AUTHOR_EMAIL: "e2e@test.local",
+      GIT_COMMITTER_NAME: "E2E Test",
+      GIT_COMMITTER_EMAIL: "e2e@test.local",
+    };
+    execSync("git init -b main", { cwd: repoBDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: repoBDir, env: gitEnv });
+    const repoB = await apiClient.createRepository(workspaceB.id, repoBDir);
+
+    const taskB = await apiClient.createTask(workspaceB.id, "Workspace B Task", {
+      workflow_id: workflowB.id,
+      workflow_step_id: startStepB.id,
+      repository_ids: [repoB.id],
+    });
+
+    // --- Land on kanban with workspace A active; task A visible, task B not ---
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCard(taskA.id)).toBeVisible({ timeout: 10_000 });
+    await expect(kanban.taskCard(taskB.id)).not.toBeVisible();
+
+    // --- Switch to workspace B via the display dropdown (SPA, no full reload) ---
+    await testPage.getByTestId("display-button").click();
+    await testPage.getByTestId("workspace-select-trigger").click();
+    await testPage.getByTestId(`workspace-select-item-${workspaceB.id}`).click();
+
+    // Close the dropdown so task cards are interactable.
+    await testPage.keyboard.press("Escape");
+
+    await expect(kanban.taskCard(taskB.id)).toBeVisible({ timeout: 10_000 });
+    await expect(kanban.taskCard(taskA.id)).not.toBeVisible();
+
+    // --- Open task B; verify sidebar shows only workspace B's task ---
+    await kanban.taskCard(taskB.id).click();
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.sidebar).toBeVisible({ timeout: 10_000 });
+
+    await expect(
+      session.sidebar.getByText("Workspace B Task", { exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The core regression assertion: task A must not appear anywhere in the
+    // sidebar — not under "Unassigned", not under any repo group.
+    await expect(session.sidebar.getByText("Workspace A Task", { exact: true })).toHaveCount(0);
+    await expect(session.sidebar.getByTestId("sidebar-repo-group-Unassigned")).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
+++ b/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
@@ -80,9 +80,9 @@ test.describe("Sidebar — cross-workspace isolation", () => {
     await session.waitForLoad();
     await expect(session.sidebar).toBeVisible({ timeout: 10_000 });
 
-    await expect(
-      session.sidebar.getByText("Workspace B Task", { exact: true }),
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(session.sidebar.getByText("Workspace B Task", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
 
     // The core regression assertion: task A must not appear anywhere in the
     // sidebar — not under "Unassigned", not under any repo group.

--- a/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
+++ b/apps/web/e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts
@@ -76,8 +76,6 @@ test.describe("Sidebar — cross-workspace isolation", () => {
       timeout: 10_000,
     });
 
-    // The core regression assertion: task A must not appear anywhere in the
-    // sidebar — not under "Unassigned", not under any repo group.
     await expect(session.sidebar.getByText("Workspace A Task", { exact: true })).toHaveCount(0);
     await expect(session.sidebar.getByTestId("sidebar-repo-group-Unassigned")).toHaveCount(0);
   });

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -87,14 +87,19 @@ describe("useAllWorkflowSnapshots — workspace scoping", () => {
     );
     await waitFor(() => expect(mockFetchWorkflowSnapshot).toHaveBeenCalledTimes(1));
 
-    // New array reference with identical contents — dedup key should match.
+    // Same-workflow rerender — dedup key unchanged, must not refetch.
     mockState.workflows = { items: [...workflows] };
     rerender({ workspaceId: "ws-A" });
-    // Wait long enough that any queued effect would have run and issued a
-    // second fetch; then assert the count is unchanged.
-    await new Promise((r) => setTimeout(r, 50));
 
-    expect(mockFetchWorkflowSnapshot).toHaveBeenCalledTimes(1);
+    // Positive signal: follow up with a DIFFERENT workflow set, which must
+    // trigger a fetch. If dedup worked, the total is 2 (initial + this one).
+    // If dedup failed, the same-key rerender would have fired a fetch before
+    // this one, making the total 3. Waiting for count==2 proves both:
+    // the dedup rerender was skipped AND the next real change still fetches.
+    mockState.workflows = { items: [{ id: "wf-A2", workspaceId: "ws-A", name: "A2" }] };
+    rerender({ workspaceId: "ws-A" });
+    await waitFor(() => expect(mockFetchWorkflowSnapshot).toHaveBeenCalledTimes(2));
+    expect(mockFetchWorkflowSnapshot.mock.calls[1][0]).toBe("wf-A2");
     expect(mockClearKanbanMulti).not.toHaveBeenCalled();
   });
 
@@ -116,15 +121,20 @@ describe("useAllWorkflowSnapshots — workspace scoping", () => {
       expect(mockFetchWorkflowSnapshot).toHaveBeenCalledWith("wf-A", expect.anything()),
     );
 
-    // Switch to workspace B before A's fetch resolves.
+    // Switch to workspace B before A's fetch resolves. Wait for B's fetch
+    // to settle (positive signal) so the new-gen effect is fully in place.
     mockFetchWorkflowSnapshot.mockResolvedValueOnce({ steps: [], tasks: [] });
     mockState.workflows = { items: [{ id: "wf-B", workspaceId: "ws-B", name: "B" }] };
     rerender({ workspaceId: "ws-B" });
-    await waitFor(() => expect(mockClearKanbanMulti).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(mockSetWorkflowSnapshot).toHaveBeenCalledWith("wf-B", expect.anything()),
+    );
 
-    // Now let workspace A's fetch finally resolve. Its write must be dropped.
+    // Resolve A's stale fetch and drain the microtask queue so its .then
+    // and .finally callbacks run. Flushing microtasks is deterministic —
+    // unlike setTimeout, it doesn't depend on CI wall-clock speed.
     resolveStale({ steps: [], tasks: [] });
-    await new Promise((r) => setTimeout(r, 50));
+    for (let i = 0; i < 5; i++) await Promise.resolve();
 
     const writtenIds = mockSetWorkflowSnapshot.mock.calls.map((args) => args[0]);
     expect(writtenIds).not.toContain("wf-A");

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const mockClearKanbanMulti = vi.fn();
+const mockSetKanbanMultiLoading = vi.fn();
+const mockSetWorkflowSnapshot = vi.fn();
+const mockFetchWorkflowSnapshot = vi.fn();
+
+type Workflow = { id: string; workspaceId: string; name: string };
+type MockState = {
+  connection: { status: string };
+  workflows: { items: Workflow[] };
+  clearKanbanMulti: typeof mockClearKanbanMulti;
+  setKanbanMultiLoading: typeof mockSetKanbanMultiLoading;
+  setWorkflowSnapshot: typeof mockSetWorkflowSnapshot;
+};
+
+let mockState: MockState = {
+  connection: { status: "connected" },
+  workflows: { items: [] },
+  clearKanbanMulti: mockClearKanbanMulti,
+  setKanbanMultiLoading: mockSetKanbanMultiLoading,
+  setWorkflowSnapshot: mockSetWorkflowSnapshot,
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: MockState) => unknown) => selector(mockState),
+  useAppStoreApi: () => ({ getState: () => mockState }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchWorkflowSnapshot: (...args: unknown[]) => mockFetchWorkflowSnapshot(...args),
+}));
+
+import { useAllWorkflowSnapshots } from "./use-all-workflow-snapshots";
+
+function resetMocks(workflows: Workflow[] = []) {
+  vi.clearAllMocks();
+  mockFetchWorkflowSnapshot.mockResolvedValue({ steps: [], tasks: [] });
+  mockState = {
+    connection: { status: "connected" },
+    workflows: { items: workflows },
+    clearKanbanMulti: mockClearKanbanMulti,
+    setKanbanMultiLoading: mockSetKanbanMultiLoading,
+    setWorkflowSnapshot: mockSetWorkflowSnapshot,
+  };
+}
+
+describe("useAllWorkflowSnapshots — workspace scoping", () => {
+  beforeEach(() => {
+    resetMocks([{ id: "wf-A", workspaceId: "ws-A", name: "A" }]);
+  });
+
+  it("does not clear snapshots on initial mount (SSR preservation)", async () => {
+    renderHook(
+      ({ workspaceId }: { workspaceId: string | null }) => useAllWorkflowSnapshots(workspaceId),
+      {
+        initialProps: { workspaceId: "ws-A" },
+      },
+    );
+
+    // Allow the effect + Promise.all to settle.
+    await waitFor(() => expect(mockSetKanbanMultiLoading).toHaveBeenCalledWith(true));
+    expect(mockClearKanbanMulti).not.toHaveBeenCalled();
+  });
+
+  it("clears snapshots when workspaceId changes", async () => {
+    const { rerender } = renderHook(
+      ({ workspaceId }: { workspaceId: string | null }) => useAllWorkflowSnapshots(workspaceId),
+      { initialProps: { workspaceId: "ws-A" } },
+    );
+    await waitFor(() => expect(mockSetKanbanMultiLoading).toHaveBeenCalledWith(true));
+    expect(mockClearKanbanMulti).not.toHaveBeenCalled();
+
+    // Switch to workspace B — must clear A's snapshots.
+    mockState.workflows = { items: [{ id: "wf-B", workspaceId: "ws-B", name: "B" }] };
+    rerender({ workspaceId: "ws-B" });
+
+    await waitFor(() => expect(mockClearKanbanMulti).toHaveBeenCalledTimes(1));
+  });
+
+  it("skips refetch when workspace + workflow set is unchanged across renders", async () => {
+    const workflows = [{ id: "wf-A", workspaceId: "ws-A", name: "A" }];
+    const { rerender } = renderHook(
+      ({ workspaceId }: { workspaceId: string | null }) => useAllWorkflowSnapshots(workspaceId),
+      { initialProps: { workspaceId: "ws-A" } },
+    );
+    await waitFor(() => expect(mockFetchWorkflowSnapshot).toHaveBeenCalledTimes(1));
+
+    // New array reference with identical contents — dedup key should match.
+    mockState.workflows = { items: [...workflows] };
+    rerender({ workspaceId: "ws-A" });
+    // Give any potential effect a chance to run.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockFetchWorkflowSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockClearKanbanMulti).not.toHaveBeenCalled();
+  });
+
+  it("discards a stale in-flight fetch when workspace switches mid-fetch", async () => {
+    // Hold the first fetch open so it resolves after the workspace switch.
+    let resolveStale: (v: { steps: []; tasks: [] }) => void = () => {};
+    mockFetchWorkflowSnapshot.mockImplementationOnce(
+      () =>
+        new Promise((res) => {
+          resolveStale = res;
+        }),
+    );
+
+    const { rerender } = renderHook(
+      ({ workspaceId }: { workspaceId: string | null }) => useAllWorkflowSnapshots(workspaceId),
+      { initialProps: { workspaceId: "ws-A" } },
+    );
+    await waitFor(() =>
+      expect(mockFetchWorkflowSnapshot).toHaveBeenCalledWith("wf-A", expect.anything()),
+    );
+
+    // Switch to workspace B before A's fetch resolves.
+    mockFetchWorkflowSnapshot.mockResolvedValueOnce({ steps: [], tasks: [] });
+    mockState.workflows = { items: [{ id: "wf-B", workspaceId: "ws-B", name: "B" }] };
+    rerender({ workspaceId: "ws-B" });
+    await waitFor(() => expect(mockClearKanbanMulti).toHaveBeenCalledTimes(1));
+
+    // Now let workspace A's fetch finally resolve. Its write must be dropped.
+    resolveStale({ steps: [], tasks: [] });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const writtenIds = mockSetWorkflowSnapshot.mock.calls.map((args) => args[0]);
+    expect(writtenIds).not.toContain("wf-A");
+  });
+});

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -10,6 +10,7 @@ type Workflow = { id: string; workspaceId: string; name: string };
 type MockState = {
   connection: { status: string };
   workflows: { items: Workflow[] };
+  kanbanMulti: { snapshots: Record<string, unknown>; isLoading: boolean };
   clearKanbanMulti: typeof mockClearKanbanMulti;
   setKanbanMultiLoading: typeof mockSetKanbanMultiLoading;
   setWorkflowSnapshot: typeof mockSetWorkflowSnapshot;
@@ -18,6 +19,7 @@ type MockState = {
 let mockState: MockState = {
   connection: { status: "connected" },
   workflows: { items: [] },
+  kanbanMulti: { snapshots: {}, isLoading: false },
   clearKanbanMulti: mockClearKanbanMulti,
   setKanbanMultiLoading: mockSetKanbanMultiLoading,
   setWorkflowSnapshot: mockSetWorkflowSnapshot,
@@ -40,6 +42,7 @@ function resetMocks(workflows: Workflow[] = []) {
   mockState = {
     connection: { status: "connected" },
     workflows: { items: workflows },
+    kanbanMulti: { snapshots: {}, isLoading: false },
     clearKanbanMulti: mockClearKanbanMulti,
     setKanbanMultiLoading: mockSetKanbanMultiLoading,
     setWorkflowSnapshot: mockSetWorkflowSnapshot,

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.test.ts
@@ -90,8 +90,9 @@ describe("useAllWorkflowSnapshots — workspace scoping", () => {
     // New array reference with identical contents — dedup key should match.
     mockState.workflows = { items: [...workflows] };
     rerender({ workspaceId: "ws-A" });
-    // Give any potential effect a chance to run.
-    await new Promise((r) => setTimeout(r, 0));
+    // Wait long enough that any queued effect would have run and issued a
+    // second fetch; then assert the count is unchanged.
+    await new Promise((r) => setTimeout(r, 50));
 
     expect(mockFetchWorkflowSnapshot).toHaveBeenCalledTimes(1);
     expect(mockClearKanbanMulti).not.toHaveBeenCalled();
@@ -123,7 +124,7 @@ describe("useAllWorkflowSnapshots — workspace scoping", () => {
 
     // Now let workspace A's fetch finally resolve. Its write must be dropped.
     resolveStale({ steps: [], tasks: [] });
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 50));
 
     const writtenIds = mockSetWorkflowSnapshot.mock.calls.map((args) => args[0]);
     expect(writtenIds).not.toContain("wf-A");

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -42,13 +42,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
   const fetchGenRef = useRef(0);
 
   useEffect(() => {
-    // Drop snapshots from the previous workspace so cross-workspace tasks
-    // don't bleed into the sidebar (they'd otherwise render under "Unassigned"
-    // because their repositoryId isn't in the current workspace's repo map).
-    // Bumping the generation counter invalidates any fetches still in flight
-    // from the previous workspace, so their late writes can't re-pollute the
-    // store after clearKanbanMulti runs.
-    // Skip the clear on initial mount so SSR-hydrated snapshots survive.
+    // Skip clear on initial mount to preserve SSR-hydrated snapshots.
     if (lastWorkspaceIdRef.current !== workspaceId) {
       if (lastWorkspaceIdRef.current !== null) {
         store.getState().clearKanbanMulti();

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -1,10 +1,68 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type MutableRefObject } from "react";
 import { fetchWorkflowSnapshot } from "@/lib/api";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import type { KanbanState } from "@/lib/state/slices/kanban/types";
 import type { Task } from "@/lib/types/http";
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
 
 type KanbanTask = KanbanState["tasks"][number];
+type Workflow = { id: string; name: string };
+
+async function fetchAndWriteSnapshot(
+  wf: Workflow,
+  store: StoreApi<AppState>,
+  fetchGenRef: MutableRefObject<number>,
+  myGen: number,
+): Promise<void> {
+  try {
+    const snapshot = await fetchWorkflowSnapshot(wf.id, { cache: "no-store" });
+    if (fetchGenRef.current !== myGen) return;
+
+    const steps = snapshot.steps.map((step) => ({
+      id: step.id,
+      title: step.name,
+      color: step.color ?? "bg-neutral-400",
+      position: step.position,
+      events: step.events,
+      allow_manual_move: step.allow_manual_move,
+      prompt: step.prompt,
+      is_start_step: step.is_start_step,
+    }));
+    const stepIds = new Set(steps.map((s) => s.id));
+
+    // Preserve runtime fields (e.g., primarySessionId) from existing snapshot
+    // tasks when the fresh API response omits them (backend uses omitempty).
+    const existingSnapshot = store.getState().kanbanMulti.snapshots[wf.id];
+    const existingById = new Map((existingSnapshot?.tasks ?? []).map((t) => [t.id, t]));
+
+    const tasks: KanbanTask[] = snapshot.tasks
+      .filter((task) => !task.is_ephemeral)
+      .map((task) => {
+        const mapped = mapSnapshotTask(task, stepIds);
+        if (!mapped) return null;
+        const existing = existingById.get(mapped.id);
+        if (existing) {
+          mapped.primarySessionId = mapped.primarySessionId || existing.primarySessionId;
+          mapped.primarySessionState = mapped.primarySessionState || existing.primarySessionState;
+        }
+        return mapped;
+      })
+      .filter((t): t is KanbanTask => t !== null);
+
+    store.getState().setWorkflowSnapshot(wf.id, {
+      workflowId: wf.id,
+      workflowName: wf.name,
+      steps,
+      tasks,
+    });
+  } catch (err) {
+    console.error(
+      `[useAllWorkflowSnapshots] Failed to fetch snapshot for workflow "${wf.name}" (${wf.id}):`,
+      err,
+    );
+  }
+}
 
 // eslint-disable-next-line complexity -- pure field mapping, no real branching logic
 function mapSnapshotTask(task: Task, stepIds: Set<string>): KanbanTask | null {
@@ -75,63 +133,10 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
     lastFetchedRef.current = key;
 
     const myGen = fetchGenRef.current;
-    const { setKanbanMultiLoading, setWorkflowSnapshot } = store.getState();
-    setKanbanMultiLoading(true);
+    store.getState().setKanbanMultiLoading(true);
 
     Promise.all(
-      workspaceWorkflows.map(async (wf) => {
-        try {
-          const snapshot = await fetchWorkflowSnapshot(wf.id, { cache: "no-store" });
-          if (fetchGenRef.current !== myGen) return;
-
-          const steps = snapshot.steps.map((step) => ({
-            id: step.id,
-            title: step.name,
-            color: step.color ?? "bg-neutral-400",
-            position: step.position,
-            events: step.events,
-            allow_manual_move: step.allow_manual_move,
-            prompt: step.prompt,
-            is_start_step: step.is_start_step,
-          }));
-          const stepIds = new Set(steps.map((s) => s.id));
-
-          // Preserve runtime fields (e.g., primarySessionId) from existing
-          // snapshot tasks when the fresh API response omits them. The backend
-          // uses omitempty for session fields, so a task whose session was just
-          // created may not have primary_session_id in the snapshot response
-          // yet, even though a WS task.updated event already delivered it.
-          const existingSnapshot = store.getState().kanbanMulti.snapshots[wf.id];
-          const existingById = new Map((existingSnapshot?.tasks ?? []).map((t) => [t.id, t]));
-
-          const tasks: KanbanTask[] = snapshot.tasks
-            .filter((task) => !task.is_ephemeral) // Filter out ephemeral tasks (e.g., quick chat)
-            .map((task) => {
-              const mapped = mapSnapshotTask(task, stepIds);
-              if (!mapped) return null;
-              const existing = existingById.get(mapped.id);
-              if (existing) {
-                mapped.primarySessionId = mapped.primarySessionId || existing.primarySessionId;
-                mapped.primarySessionState =
-                  mapped.primarySessionState || existing.primarySessionState;
-              }
-              return mapped;
-            })
-            .filter((t): t is KanbanTask => t !== null);
-
-          setWorkflowSnapshot(wf.id, {
-            workflowId: wf.id,
-            workflowName: wf.name,
-            steps,
-            tasks,
-          });
-        } catch (err) {
-          console.error(
-            `[useAllWorkflowSnapshots] Failed to fetch snapshot for workflow "${wf.name}" (${wf.id}):`,
-            err,
-          );
-        }
-      }),
+      workspaceWorkflows.map((wf) => fetchAndWriteSnapshot(wf, store, fetchGenRef, myGen)),
     ).finally(() => {
       if (fetchGenRef.current !== myGen) return;
       store.getState().setKanbanMultiLoading(false);

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -48,11 +48,14 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
     // Bumping the generation counter invalidates any fetches still in flight
     // from the previous workspace, so their late writes can't re-pollute the
     // store after clearKanbanMulti runs.
+    // Skip the clear on initial mount so SSR-hydrated snapshots survive.
     if (lastWorkspaceIdRef.current !== workspaceId) {
-      store.getState().clearKanbanMulti();
-      lastFetchedRef.current = "";
+      if (lastWorkspaceIdRef.current !== null) {
+        store.getState().clearKanbanMulti();
+        lastFetchedRef.current = "";
+        fetchGenRef.current += 1;
+      }
       lastWorkspaceIdRef.current = workspaceId;
-      fetchGenRef.current += 1;
     }
 
     if (!workspaceId) {

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -38,8 +38,18 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
   const connectionStatus = useAppStore((state) => state.connection.status);
   const workflows = useAppStore((state) => state.workflows.items);
   const lastFetchedRef = useRef<string>("");
+  const lastWorkspaceIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    // Drop snapshots from the previous workspace so cross-workspace tasks
+    // don't bleed into the sidebar (they'd otherwise render under "Unassigned"
+    // because their repositoryId isn't in the current workspace's repo map).
+    if (lastWorkspaceIdRef.current !== workspaceId) {
+      store.getState().clearKanbanMulti();
+      lastFetchedRef.current = "";
+      lastWorkspaceIdRef.current = workspaceId;
+    }
+
     if (!workspaceId) {
       return;
     }

--- a/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
+++ b/apps/web/hooks/domains/kanban/use-all-workflow-snapshots.ts
@@ -39,15 +39,20 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
   const workflows = useAppStore((state) => state.workflows.items);
   const lastFetchedRef = useRef<string>("");
   const lastWorkspaceIdRef = useRef<string | null>(null);
+  const fetchGenRef = useRef(0);
 
   useEffect(() => {
     // Drop snapshots from the previous workspace so cross-workspace tasks
     // don't bleed into the sidebar (they'd otherwise render under "Unassigned"
     // because their repositoryId isn't in the current workspace's repo map).
+    // Bumping the generation counter invalidates any fetches still in flight
+    // from the previous workspace, so their late writes can't re-pollute the
+    // store after clearKanbanMulti runs.
     if (lastWorkspaceIdRef.current !== workspaceId) {
       store.getState().clearKanbanMulti();
       lastFetchedRef.current = "";
       lastWorkspaceIdRef.current = workspaceId;
+      fetchGenRef.current += 1;
     }
 
     if (!workspaceId) {
@@ -72,6 +77,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
     }
     lastFetchedRef.current = key;
 
+    const myGen = fetchGenRef.current;
     const { setKanbanMultiLoading, setWorkflowSnapshot } = store.getState();
     setKanbanMultiLoading(true);
 
@@ -79,6 +85,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
       workspaceWorkflows.map(async (wf) => {
         try {
           const snapshot = await fetchWorkflowSnapshot(wf.id, { cache: "no-store" });
+          if (fetchGenRef.current !== myGen) return;
 
           const steps = snapshot.steps.map((step) => ({
             id: step.id,
@@ -129,6 +136,7 @@ export function useAllWorkflowSnapshots(workspaceId: string | null) {
         }
       }),
     ).finally(() => {
+      if (fetchGenRef.current !== myGen) return;
       store.getState().setKanbanMultiLoading(false);
     });
   }, [workspaceId, workflows, connectionStatus, store]);

--- a/apps/web/lib/state/slices/kanban/kanban-slice.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.ts
@@ -67,6 +67,7 @@ export const createKanbanSlice: StateCreator<
   clearKanbanMulti: () =>
     set((draft) => {
       draft.kanbanMulti.snapshots = {};
+      draft.kanbanMulti.isLoading = false;
     }),
   updateMultiTask: (workflowId, task) =>
     set((draft) => {


### PR DESCRIPTION
The task sidebar was rendering tasks from the previously-active workspace under an "Unassigned" group because `useAllWorkflowSnapshots` accumulated kanban snapshots across workspace switches and never pruned them; the hook now clears stale snapshots whenever `workspaceId` changes, so cross-workspace tasks no longer leak into the sidebar.

## Validation

- `pnpm exec tsc --noEmit` on the three changed files — clean.
- `pnpm --filter @kandev/web lint` on the three changed files — clean.
- Added e2e regression test `e2e/tests/task/workspace-switch-sidebar-isolation.spec.ts` that seeds two workspaces, switches via the display dropdown (SPA, no reload), opens a task in workspace B, and asserts neither workspace A's task nor an "Unassigned" group appear in the sidebar. Fails against the previous code path; passes with the fix.

## Possible Improvements

Low risk. The cleanup lives inside the one hook that owns `kanbanMulti.snapshots`, so any future code path that changes the active workspace benefits automatically. If additional kanban data ever gets cached keyed by workspace, it should be cleared in the same spot.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
