### PR TITLE
test(web): add e2e tests for tasks list view filters (#612)

### DIFF
--- a/apps/web/components/kanban-display-dropdown.tsx
+++ b/apps/web/components/kanban-display-dropdown.tsx
@@ -72,7 +72,7 @@ function WorkflowSection({
         value={activeWorkflowId ?? "all"}
         onValueChange={(value) => onWorkflowChange(value === "all" ? null : value)}
       >
-        <SelectTrigger className="w-full border-border">
+        <SelectTrigger data-testid="display-workflow-filter" className="w-full border-border">
           <SelectValue placeholder="Select workflow" />
         </SelectTrigger>
         <SelectContent>
@@ -107,7 +107,7 @@ function RepositorySection({
         onValueChange={(value) => onRepositoryChange(value as string | "all")}
         disabled={repositories.length === 0}
       >
-        <SelectTrigger className="w-full border-border">
+        <SelectTrigger data-testid="display-repository-filter" className="w-full border-border">
           <SelectValue
             placeholder={getRepositoryPlaceholder(repositoriesLoading, repositories.length === 0)}
           />
@@ -147,7 +147,7 @@ export function KanbanDisplayDropdown() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" className="cursor-pointer">
+        <Button variant="outline" data-testid="display-button" className="cursor-pointer">
           <IconAdjustmentsHorizontal className="h-4 w-4 mr-2" />
           Display
         </Button>

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -410,6 +410,7 @@ export class ApiClient {
     enable_preview_on_click?: boolean;
     workspace_id?: string;
     workflow_filter_id?: string;
+    repository_ids?: string[];
     terminal_link_behavior?: "new_tab" | "browser_panel";
     terminal_font_family?: string;
     terminal_font_size?: number;

--- a/apps/web/e2e/tests/task/task-list-filters.spec.ts
+++ b/apps/web/e2e/tests/task/task-list-filters.spec.ts
@@ -3,8 +3,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
 import type { Page } from "@playwright/test";
+import type { WorkflowStep } from "../../../lib/types/http";
 
 const TASK_VISIBLE_TIMEOUT = 10_000;
+
+function findStartStep(steps: WorkflowStep[]): WorkflowStep {
+  return steps.find((s) => s.is_start_step) ?? steps[0];
+}
 
 async function gotoTasksPage(page: Page): Promise<void> {
   await page.goto("/tasks");
@@ -85,13 +90,9 @@ test.describe("Task list display filters", () => {
     apiClient,
     seedData,
   }) => {
-    const workflowB = await apiClient.createWorkflow(
-      seedData.workspaceId,
-      "Workflow B",
-      "simple",
-    );
+    const workflowB = await apiClient.createWorkflow(seedData.workspaceId, "Workflow B", "simple");
     const stepsB = (await apiClient.listWorkflowSteps(workflowB.id)).steps;
-    const startB = stepsB.find((s) => s.is_start_step) ?? stepsB[0];
+    const startB = findStartStep(stepsB);
 
     await apiClient.createTask(seedData.workspaceId, "Alpha task", {
       workflow_id: seedData.workflowId,
@@ -119,13 +120,9 @@ test.describe("Task list display filters", () => {
     apiClient,
     seedData,
   }) => {
-    const workflowB = await apiClient.createWorkflow(
-      seedData.workspaceId,
-      "Workflow B",
-      "simple",
-    );
+    const workflowB = await apiClient.createWorkflow(seedData.workspaceId, "Workflow B", "simple");
     const stepsB = (await apiClient.listWorkflowSteps(workflowB.id)).steps;
-    const startB = stepsB.find((s) => s.is_start_step) ?? stepsB[0];
+    const startB = findStartStep(stepsB);
 
     await apiClient.createTask(seedData.workspaceId, "Alpha task", {
       workflow_id: seedData.workflowId,
@@ -240,13 +237,9 @@ test.describe("Task list display filters", () => {
     seedData,
     backend,
   }) => {
-    const workflowB = await apiClient.createWorkflow(
-      seedData.workspaceId,
-      "Workflow B",
-      "simple",
-    );
+    const workflowB = await apiClient.createWorkflow(seedData.workspaceId, "Workflow B", "simple");
     const stepsB = (await apiClient.listWorkflowSteps(workflowB.id)).steps;
-    const startB = stepsB.find((s) => s.is_start_step) ?? stepsB[0];
+    const startB = findStartStep(stepsB);
     const repoName = "Repo Filter T5";
     const repoPath = await createLocalRepo(backend.tmpDir, "e2e-repo-filter-t5");
     const otherRepo = await apiClient.createRepository(seedData.workspaceId, repoPath, "main", {

--- a/apps/web/e2e/tests/task/task-list-filters.spec.ts
+++ b/apps/web/e2e/tests/task/task-list-filters.spec.ts
@@ -13,7 +13,9 @@ function findStartStep(steps: WorkflowStep[]): WorkflowStep {
 
 async function gotoTasksPage(page: Page): Promise<void> {
   await page.goto("/tasks");
-  await page.waitForLoadState("networkidle");
+  // Wait for a header landmark instead of networkidle — persistent WebSocket
+  // connections can keep the network "active" and make networkidle unreliable.
+  await page.getByTestId("display-button").waitFor();
 }
 
 async function pickListboxOption(page: Page, optionLabel: string): Promise<void> {

--- a/apps/web/e2e/tests/task/task-list-filters.spec.ts
+++ b/apps/web/e2e/tests/task/task-list-filters.spec.ts
@@ -1,0 +1,290 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { test, expect } from "../../fixtures/test-base";
+import type { Page } from "@playwright/test";
+
+const TASK_VISIBLE_TIMEOUT = 10_000;
+
+async function gotoTasksPage(page: Page): Promise<void> {
+  await page.goto("/tasks");
+  await page.waitForLoadState("networkidle");
+}
+
+async function pickListboxOption(page: Page, optionLabel: string): Promise<void> {
+  // Radix Select renders the currently-selected item twice (once in the trigger
+  // for SelectValue display, once in the listbox). Scope to the listbox so we
+  // click the real option.
+  const listbox = page.getByRole("listbox");
+  await listbox.getByRole("option", { name: optionLabel, exact: true }).click();
+  // Wait for the Select to fully unmount — until then Radix's pointer-events
+  // overlay intercepts subsequent clicks on the <html> element.
+  await expect(listbox).toHaveCount(0);
+}
+
+async function closeDisplayDropdown(page: Page): Promise<void> {
+  // The Display DropdownMenu does NOT auto-close when an inner Select option
+  // is picked. Click the trigger to toggle closed. Radix leaves a brief
+  // pointer-events overlay on <html> after the inner Select closes, so use
+  // force: true to bypass Playwright's interception check.
+  const trigger = page.getByTestId("display-button");
+  if ((await trigger.getAttribute("data-state")) === "open") {
+    await trigger.click({ force: true });
+  }
+  await expect(trigger).not.toHaveAttribute("data-state", "open");
+  // Wait for the menu portal to fully unmount before any subsequent open;
+  // otherwise re-clicking the trigger lands while Radix is mid-cleanup and
+  // the menu content fails to render.
+  await expect(page.getByRole("menu")).toHaveCount(0);
+}
+
+async function selectWorkflowFilter(page: Page, optionLabel: string): Promise<void> {
+  await page.getByTestId("display-button").click();
+  await page.getByTestId("display-workflow-filter").click();
+  await pickListboxOption(page, optionLabel);
+  await closeDisplayDropdown(page);
+}
+
+async function selectRepositoryFilter(page: Page, optionLabel: string): Promise<void> {
+  await page.getByTestId("display-button").click();
+  await page.getByTestId("display-repository-filter").click();
+  await pickListboxOption(page, optionLabel);
+  await closeDisplayDropdown(page);
+}
+
+async function createLocalRepo(tmpDir: string, name: string): Promise<string> {
+  const repoDir = path.join(tmpDir, "repos", name);
+  fs.mkdirSync(repoDir, { recursive: true });
+  const gitEnv = {
+    ...process.env,
+    HOME: tmpDir,
+    GIT_AUTHOR_NAME: "E2E Test",
+    GIT_AUTHOR_EMAIL: "e2e@test.local",
+    GIT_COMMITTER_NAME: "E2E Test",
+    GIT_COMMITTER_EMAIL: "e2e@test.local",
+  };
+  execSync("git init -b main", { cwd: repoDir, env: gitEnv });
+  execSync('git commit --allow-empty -m "init"', { cwd: repoDir, env: gitEnv });
+  return repoDir;
+}
+
+test.describe("Task list display filters", () => {
+  // The testPage fixture resets workflow_filter_id between tests but not
+  // repository_ids — clear it so a leftover repo filter doesn't hide tasks
+  // in subsequent test files (e.g. task-list.spec.ts).
+  test.afterEach(async ({ apiClient, seedData }) => {
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: seedData.workflowId,
+      repository_ids: [],
+    });
+  });
+
+  test("workflow filter narrows the list to the selected workflow", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const workflowB = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Workflow B",
+      "simple",
+    );
+    const stepsB = (await apiClient.listWorkflowSteps(workflowB.id)).steps;
+    const startB = stepsB.find((s) => s.is_start_step) ?? stepsB[0];
+
+    await apiClient.createTask(seedData.workspaceId, "Alpha task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Beta task", {
+      workflow_id: workflowB.id,
+      workflow_step_id: startB.id,
+    });
+
+    await gotoTasksPage(testPage);
+
+    // testPage fixture pre-selects seedData.workflowId — only Alpha is visible initially.
+    await expect(testPage.getByText("Alpha task")).toBeVisible({ timeout: TASK_VISIBLE_TIMEOUT });
+    await expect(testPage.getByText("Beta task")).not.toBeVisible();
+
+    await selectWorkflowFilter(testPage, "Workflow B");
+
+    await expect(testPage.getByText("Beta task")).toBeVisible({ timeout: TASK_VISIBLE_TIMEOUT });
+    await expect(testPage.getByText("Alpha task")).not.toBeVisible();
+  });
+
+  test("'All Workflows' shows tasks from every workflow", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const workflowB = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Workflow B",
+      "simple",
+    );
+    const stepsB = (await apiClient.listWorkflowSteps(workflowB.id)).steps;
+    const startB = stepsB.find((s) => s.is_start_step) ?? stepsB[0];
+
+    await apiClient.createTask(seedData.workspaceId, "Alpha task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Beta task", {
+      workflow_id: workflowB.id,
+      workflow_step_id: startB.id,
+    });
+
+    await gotoTasksPage(testPage);
+    await expect(testPage.getByText("Alpha task")).toBeVisible({ timeout: TASK_VISIBLE_TIMEOUT });
+    await expect(testPage.getByText("Beta task")).not.toBeVisible();
+
+    await selectWorkflowFilter(testPage, "All Workflows");
+
+    await expect(testPage.getByText("Alpha task")).toBeVisible({ timeout: TASK_VISIBLE_TIMEOUT });
+    await expect(testPage.getByText("Beta task")).toBeVisible({ timeout: TASK_VISIBLE_TIMEOUT });
+  });
+
+  test("repository filter narrows the list to the selected repository", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    // Repository names are unique per test because the e2e reset endpoint
+    // doesn't clear repositories — they persist across tests in the worker.
+    const repoName = "Repo Filter T3";
+    const repoPath = await createLocalRepo(backend.tmpDir, "e2e-repo-filter-t3");
+    const otherRepo = await apiClient.createRepository(seedData.workspaceId, repoPath, "main", {
+      name: repoName,
+    });
+
+    await apiClient.createTask(seedData.workspaceId, "Task on seed repo", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+    await apiClient.createTask(seedData.workspaceId, "Task on other repo", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [otherRepo.id],
+    });
+    await apiClient.createTask(seedData.workspaceId, "Task with no repo", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    await gotoTasksPage(testPage);
+    await expect(testPage.getByText("Task on seed repo")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+    await expect(testPage.getByText("Task on other repo")).toBeVisible();
+    await expect(testPage.getByText("Task with no repo")).toBeVisible();
+
+    await selectRepositoryFilter(testPage, repoName);
+
+    await expect(testPage.getByText("Task on other repo")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+    await expect(testPage.getByText("Task on seed repo")).not.toBeVisible();
+    await expect(testPage.getByText("Task with no repo")).not.toBeVisible();
+  });
+
+  test("'All repositories' restores tasks across all repositories", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const repoName = "Repo Filter T4";
+    const repoPath = await createLocalRepo(backend.tmpDir, "e2e-repo-filter-t4");
+    const otherRepo = await apiClient.createRepository(seedData.workspaceId, repoPath, "main", {
+      name: repoName,
+    });
+
+    await apiClient.createTask(seedData.workspaceId, "Task on seed repo", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+    await apiClient.createTask(seedData.workspaceId, "Task on other repo", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [otherRepo.id],
+    });
+    await apiClient.createTask(seedData.workspaceId, "Task with no repo", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    await gotoTasksPage(testPage);
+    await selectRepositoryFilter(testPage, repoName);
+    await expect(testPage.getByText("Task on seed repo")).not.toBeVisible();
+    await expect(testPage.getByText("Task on other repo")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+
+    await selectRepositoryFilter(testPage, "All repositories");
+
+    await expect(testPage.getByText("Task on seed repo")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+    await expect(testPage.getByText("Task on other repo")).toBeVisible();
+    await expect(testPage.getByText("Task with no repo")).toBeVisible();
+  });
+
+  test("workflow + repository filters combine", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const workflowB = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Workflow B",
+      "simple",
+    );
+    const stepsB = (await apiClient.listWorkflowSteps(workflowB.id)).steps;
+    const startB = stepsB.find((s) => s.is_start_step) ?? stepsB[0];
+    const repoName = "Repo Filter T5";
+    const repoPath = await createLocalRepo(backend.tmpDir, "e2e-repo-filter-t5");
+    const otherRepo = await apiClient.createRepository(seedData.workspaceId, repoPath, "main", {
+      name: repoName,
+    });
+
+    // Only t1 matches workflow=seed AND repo=seed.
+    await apiClient.createTask(seedData.workspaceId, "T1 wf-A repo-1", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+    await apiClient.createTask(seedData.workspaceId, "T2 wf-A repo-2", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [otherRepo.id],
+    });
+    await apiClient.createTask(seedData.workspaceId, "T3 wf-B repo-1", {
+      workflow_id: workflowB.id,
+      workflow_step_id: startB.id,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    await gotoTasksPage(testPage);
+    // Initial: workflow=seed, repo=all → T1 + T2.
+    await expect(testPage.getByText("T1 wf-A repo-1")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+    await expect(testPage.getByText("T2 wf-A repo-2")).toBeVisible();
+    await expect(testPage.getByText("T3 wf-B repo-1")).not.toBeVisible();
+
+    await selectRepositoryFilter(testPage, "E2E Repo");
+
+    // Workflow=seed AND repo=seed → only T1.
+    await expect(testPage.getByText("T1 wf-A repo-1")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+    await expect(testPage.getByText("T2 wf-A repo-2")).not.toBeVisible();
+    await expect(testPage.getByText("T3 wf-B repo-1")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Adds Playwright e2e coverage for the workflow and repository display filters in the tasks list view that shipped without e2e tests in #612.

## Summary

- 5 new e2e tests in `apps/web/e2e/tests/task/task-list-filters.spec.ts` exercising the Display dropdown end-to-end:
  - workflow filter narrows the list to the selected workflow
  - "All Workflows" shows tasks from every workflow
  - repository filter narrows the list to the selected repository
  - "All repositories" restores tasks across all repositories
  - workflow + repository filters combine
- Three `data-testid` attributes added to `KanbanDisplayDropdown` (`display-button`, `display-workflow-filter`, `display-repository-filter`) so the dropdown trigger and the inner Selects can be targeted reliably (the existing label-based pattern from `utility-agents.spec.ts` does not work here because Radix `DropdownMenuLabel` is not a `<label>`).
- Extended `ApiClient.saveUserSettings` typing with `repository_ids?: string[]` so the new spec's `afterEach` can clear the leaked repository filter before subsequent test files run (the `testPage` fixture already resets `workflow_filter_id` but not `repository_ids`).

## Test plan

- [x] `pnpm exec playwright test e2e/tests/task/task-list-filters.spec.ts` — all 5 pass
- [x] `pnpm exec playwright test e2e/tests/task/task-list-filters.spec.ts e2e/tests/task/task-list.spec.ts` — confirms no leakage into the existing `task-list` spec
- [x] `pnpm exec eslint --max-warnings 0` on the three changed files passes