### PR TITLE
fix(docker): use API version negotiation instead of hardcoded 1.41

### DIFF
--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -263,7 +263,7 @@ func setDefaults(v *viper.Viper) {
 	// Docker defaults — platform-aware host and volume path
 	v.SetDefault("docker.enabled", true) // Docker runtime enabled by default if Docker is available
 	v.SetDefault("docker.host", DefaultDockerHost())
-	v.SetDefault("docker.apiVersion", "1.41")
+	v.SetDefault("docker.apiVersion", "") // Empty = auto-negotiate with daemon
 	v.SetDefault("docker.tlsVerify", false)
 	v.SetDefault("docker.defaultNetwork", "kandev-network")
 	v.SetDefault("docker.volumeBasePath", defaultDockerVolumePath())


### PR DESCRIPTION
Docker builds fail on newer Docker daemons that dropped support for API version 1.41 (Docker 20.10), requiring at least 1.44 (Docker 24.0+). This changes the default API version to empty string so the Docker client auto-negotiates a compatible version using the already-configured WithAPIVersionNegotiation() option.

## Validation

- go build ./... passes
- Verified Docker client initialization code already has WithAPIVersionNegotiation() which activates when API version is empty

## Checklist

- [ ] Tests passing
- [ ] Linting passing
- [ ] Documentation updated (if applicable)
