### PR TITLE
fix: keep task sidebar diff stats visible on hover

### DIFF
--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -129,7 +129,7 @@ function DiffStatsRight({ diffStats, menuOpen }: { diffStats: DiffStats; menuOpe
     <div
       className={cn(
         "shrink-0 self-center font-mono text-[11px] transition-opacity duration-100",
-        menuOpen ? "opacity-0" : "group-hover:opacity-0",
+        menuOpen && "opacity-0",
       )}
     >
       <span className="text-emerald-500">+{diffStats.additions}</span>{" "}
@@ -289,7 +289,9 @@ function TaskMenuButton({ visible }: { visible: boolean }) {
   return (
     <div
       className={cn(
-        "absolute right-1 inset-y-0 flex items-center gap-0.5 transition-opacity duration-100",
+        "absolute right-0 top-0 bottom-0 flex items-center justify-end pr-1 pl-6 rounded-r-md",
+        "bg-gradient-to-r from-transparent via-background/60 to-background",
+        "transition-opacity duration-200",
         visible ? "opacity-100" : "opacity-0 group-hover:opacity-100",
       )}
     >


### PR DESCRIPTION
Hovering a task in the sidebar previously faded the diff stats to zero so the 3-dot button could take over the right edge, hiding useful information. The stats now stay in place and a gradient overlay reveals the action button without erasing them.

## Validation

- `pnpm --filter @kandev/web run lint` — clean
- `pnpm exec tsc --noEmit` — no new errors in `apps/web/components/task/task-item.tsx`
- Manual: dark mode hover shows gradient fade over diff while 3-dot button reveals on the right; selected + sub-task rows unaffected; `menuOpen` still hides diff while popover is active.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
