### PR TITLE
fix(web): use UUID fallback for attachments on non-secure contexts

### DIFF
--- a/apps/web/components/task/chat/file-attachment.test.ts
+++ b/apps/web/components/task/chat/file-attachment.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { processFile } from "./file-attachment";
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+// Minimal FileReader stub — jsdom's version is fine, but we stub for deterministic output.
+class FakeFileReader {
+  public result: string | null = null;
+  public onload: ((event: { target: { result: string } }) => void) | null = null;
+  public onerror: (() => void) | null = null;
+  readAsDataURL(file: File) {
+    // Small synthetic data URL — content doesn't matter for the id assertion.
+    const payload = "AAAA"; // 3 bytes base64
+    this.result = `data:${file.type || "application/octet-stream"};base64,${payload}`;
+    queueMicrotask(() => this.onload?.({ target: { result: this.result as string } }));
+  }
+}
+
+// Image stub — fires onload synchronously so the image branch resolves.
+class FakeImage {
+  public onload: (() => void) | null = null;
+  public onerror: (() => void) | null = null;
+  set src(_: string) {
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+describe("processFile in insecure context (HTTP, no crypto.randomUUID)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("assigns a fallback UUID to non-image attachments when crypto.randomUUID is unavailable", async () => {
+    vi.stubGlobal("crypto", {}); // simulate non-secure context
+    vi.stubGlobal("FileReader", FakeFileReader);
+
+    const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+    Object.defineProperty(file, "size", { value: 5 });
+
+    const attachment = await processFile(file);
+    expect(attachment).not.toBeNull();
+    expect(attachment!.id).toMatch(UUID_V4_REGEX);
+    expect(attachment!.isImage).toBe(false);
+    expect(attachment!.fileName).toBe("notes.txt");
+  });
+
+  it("assigns a fallback UUID to image attachments when crypto.randomUUID is unavailable", async () => {
+    vi.stubGlobal("crypto", {});
+    vi.stubGlobal("FileReader", FakeFileReader);
+    vi.stubGlobal("Image", FakeImage);
+
+    const file = new File(["img"], "shot.png", { type: "image/png" });
+    Object.defineProperty(file, "size", { value: 3 });
+
+    const attachment = await processFile(file);
+    expect(attachment).not.toBeNull();
+    expect(attachment!.id).toMatch(UUID_V4_REGEX);
+    expect(attachment!.isImage).toBe(true);
+    expect(attachment!.preview).toMatch(/^data:image\/png;base64,/);
+  });
+});

--- a/apps/web/components/task/chat/file-attachment.ts
+++ b/apps/web/components/task/chat/file-attachment.ts
@@ -3,6 +3,8 @@
  * Handles both images (with preview) and arbitrary files (code, docs, etc.).
  */
 
+import { generateUUID } from "@/lib/utils";
+
 export type FileAttachment = {
   id: string;
   data: string; // Base64-encoded content (without data: prefix)
@@ -70,7 +72,7 @@ export function processFile(file: File): Promise<FileAttachment | null> {
         const img = new Image();
         img.onload = () => {
           resolve({
-            id: crypto.randomUUID(),
+            id: generateUUID(),
             data: base64,
             mimeType,
             fileName: file.name,
@@ -83,7 +85,7 @@ export function processFile(file: File): Promise<FileAttachment | null> {
         img.src = dataUrl;
       } else {
         resolve({
-          id: crypto.randomUUID(),
+          id: generateUUID(),
           data: base64,
           mimeType,
           fileName: file.name,

--- a/apps/web/components/task/chat/image-attachment-preview.tsx
+++ b/apps/web/components/task/chat/image-attachment-preview.tsx
@@ -2,7 +2,7 @@
 
 import { memo } from "react";
 import { IconX } from "@tabler/icons-react";
-import { cn } from "@/lib/utils";
+import { cn, generateUUID } from "@/lib/utils";
 
 export type ImageAttachment = {
   id: string;
@@ -121,7 +121,7 @@ export function processImageFile(file: File): Promise<ImageAttachment | null> {
       const img = new Image();
       img.onload = () => {
         resolve({
-          id: crypto.randomUUID(),
+          id: generateUUID(),
           data: base64,
           mimeType,
           preview: dataUrl,

--- a/apps/web/hooks/domains/comments/use-plan-comments.ts
+++ b/apps/web/hooks/domains/comments/use-plan-comments.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { useCommentsStore } from "@/lib/state/slices/comments";
 import type { PlanComment } from "@/lib/state/slices/comments";
 import { isPlanComment } from "@/lib/state/slices/comments";
+import { generateUUID } from "@/lib/utils";
 
 const EMPTY_COMMENTS: PlanComment[] = [];
 
@@ -52,7 +53,7 @@ export function usePlanComments(sessionId: string | null | undefined) {
         setEditingComment(null);
         return editingCommentId;
       } else {
-        const id = crypto.randomUUID();
+        const id = generateUUID();
         const comment: PlanComment = {
           id,
           sessionId,

--- a/apps/web/lib/utils.test.ts
+++ b/apps/web/lib/utils.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractRepoName,
   formatUserHomePath,
+  generateUUID,
   getRepositoryDisplayName,
   selectPreferredBranch,
   truncateRepoPath,
 } from "./utils";
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 const TILDE_PROJECTS_APP = "~/Projects/App";
 
@@ -100,5 +103,37 @@ describe("getRepositoryDisplayName", () => {
 
   it("returns org/name for remote repositories", () => {
     expect(getRepositoryDisplayName("https://github.com/org/repo.git")).toBe("org/repo");
+  });
+});
+
+describe("generateUUID", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses crypto.randomUUID when available (secure context)", () => {
+    const stub = vi.fn(() => "11111111-1111-4111-8111-111111111111");
+    vi.stubGlobal("crypto", { randomUUID: stub });
+    expect(generateUUID()).toBe("11111111-1111-4111-8111-111111111111");
+    expect(stub).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to Math.random UUID when crypto.randomUUID is undefined (HTTP/non-secure)", () => {
+    vi.stubGlobal("crypto", {});
+    const id = generateUUID();
+    expect(id).toMatch(UUID_V4_REGEX);
+  });
+
+  it("falls back when crypto itself is undefined", () => {
+    vi.stubGlobal("crypto", undefined);
+    const id = generateUUID();
+    expect(id).toMatch(UUID_V4_REGEX);
+  });
+
+  it("produces distinct ids across calls in the fallback path", () => {
+    vi.stubGlobal("crypto", {});
+    const a = generateUUID();
+    const b = generateUUID();
+    expect(a).not.toBe(b);
   });
 });


### PR DESCRIPTION
## Summary

Self-hosted instances served over plain HTTP (e.g. Tailscale IPs) crashed when pasting or picking chat attachments because `crypto.randomUUID()` is only exposed in secure contexts. Route the 3 remaining callsites through the existing `generateUUID()` helper so the UI degrades gracefully on HTTP.

## Validation

- `pnpm --filter @kandev/web test` — 302 pass, incl. 4 new `generateUUID` cases and 2 new `processFile` insecure-context cases
- `pnpm exec eslint` on changed files — clean
- `prettier` — clean

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] Verified locally