### PR TITLE
fix(backend): push git snapshot on session focus

### DIFF
--- a/apps/backend/internal/gateway/websocket/client.go
+++ b/apps/backend/internal/gateway/websocket/client.go
@@ -327,6 +327,12 @@ func (c *Client) handleSessionUnsubscribe(msg *ws.Message) {
 
 // handleSessionFocus handles session.focus — marks the session as actively
 // viewed by this client, lifting backend polling to fast mode for the workspace.
+//
+// Also pushes a fresh session data snapshot (git status, etc.) because the
+// session.subscribe frame is often absorbed by the sidebar's bulk subscribe
+// (ref-counted on the client) before the task-page hook can ask for it — so
+// without this, switching tasks leaves the Changes panel showing stale/empty
+// state until the next poll broadcast arrives.
 func (c *Client) handleSessionFocus(msg *ws.Message) {
 	var req SessionSubscribeRequest
 	if err := msg.ParsePayload(&req); err != nil {
@@ -344,6 +350,8 @@ func (c *Client) handleSessionFocus(msg *ws.Message) {
 		"session_id": req.SessionID,
 	})
 	c.sendMessage(resp)
+
+	c.sendSessionData(req.SessionID)
 }
 
 // handleSessionUnfocus handles session.unfocus — releases the focus mark for

--- a/apps/backend/internal/gateway/websocket/client_session_focus_test.go
+++ b/apps/backend/internal/gateway/websocket/client_session_focus_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	ws "github.com/kandev/kandev/pkg/websocket"
 )
@@ -46,10 +45,12 @@ func TestHandleSessionFocus_PushesSessionDataSnapshot(t *testing.T) {
 		t.Fatal("session data provider was not invoked on focus")
 	}
 
-	// Expect two frames: the ACK response, then the snapshot notification.
+	// handleSessionFocus is synchronous and sendMessage writes to the buffered
+	// send channel without blocking, so both frames are already queued by the
+	// time we get here. A non-blocking select fails fast if the invariant
+	// breaks in the future.
 	var sawSnapshot bool
-	deadline := time.After(500 * time.Millisecond)
-	for range 2 {
+	for i := range 2 {
 		select {
 		case data := <-c.send:
 			var m ws.Message
@@ -59,8 +60,8 @@ func TestHandleSessionFocus_PushesSessionDataSnapshot(t *testing.T) {
 			if m.Type == ws.MessageTypeNotification && m.Action == "session.git.event" {
 				sawSnapshot = true
 			}
-		case <-deadline:
-			t.Fatalf("timed out waiting for focus frames")
+		default:
+			t.Fatalf("expected focus frame %d, none in buffer", i+1)
 		}
 	}
 	if !sawSnapshot {
@@ -84,12 +85,12 @@ func TestHandleSessionFocus_NoProviderDoesNotCrash(t *testing.T) {
 	// Drain the ACK so it's clear exactly one frame was produced.
 	select {
 	case <-c.send:
-	case <-time.After(200 * time.Millisecond):
+	default:
 		t.Fatal("expected ACK frame after focus")
 	}
 	select {
 	case <-c.send:
 		t.Error("unexpected extra frame when provider is nil")
-	case <-time.After(50 * time.Millisecond):
+	default:
 	}
 }

--- a/apps/backend/internal/gateway/websocket/client_session_focus_test.go
+++ b/apps/backend/internal/gateway/websocket/client_session_focus_test.go
@@ -1,0 +1,95 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// TestHandleSessionFocus_PushesSessionDataSnapshot verifies that session.focus
+// pushes a fresh session-data snapshot to the focusing client, not just
+// session.subscribe. This closes the "sidebar bulk-subscribe absorbs the
+// task-page subscribe" gap — when the ref-counted client-side subscribe skips
+// the frame, focus is the only signal the backend still receives on task open.
+func TestHandleSessionFocus_PushesSessionDataSnapshot(t *testing.T) {
+	h := newTestHub(t)
+
+	const sessionID = "sess-focus-1"
+	snapshot, err := ws.NewNotification("session.git.event", map[string]any{
+		"session_id": sessionID,
+		"type":       "status_update",
+	})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	var provided bool
+	h.SetSessionDataProvider(func(_ context.Context, sid string) ([]*ws.Message, error) {
+		if sid != sessionID {
+			t.Errorf("provider called with sid=%q, want %q", sid, sessionID)
+		}
+		provided = true
+		return []*ws.Message{snapshot}, nil
+	})
+
+	c := newTestClient("c-focus")
+	c.hub = h
+
+	payload, _ := json.Marshal(SessionSubscribeRequest{SessionID: sessionID})
+	msg := &ws.Message{ID: "req-1", Type: ws.MessageTypeRequest, Action: "session.focus", Payload: payload}
+
+	c.handleSessionFocus(msg)
+
+	if !provided {
+		t.Fatal("session data provider was not invoked on focus")
+	}
+
+	// Expect two frames: the ACK response, then the snapshot notification.
+	var sawSnapshot bool
+	deadline := time.After(500 * time.Millisecond)
+	for range 2 {
+		select {
+		case data := <-c.send:
+			var m ws.Message
+			if err := json.Unmarshal(data, &m); err != nil {
+				t.Fatalf("decode frame: %v", err)
+			}
+			if m.Type == ws.MessageTypeNotification && m.Action == "session.git.event" {
+				sawSnapshot = true
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for focus frames")
+		}
+	}
+	if !sawSnapshot {
+		t.Error("expected a session.git.event notification after focus, got none")
+	}
+}
+
+// TestHandleSessionFocus_NoProviderDoesNotCrash guards the nil-provider path —
+// the hub ships without a provider configured in some test setups.
+func TestHandleSessionFocus_NoProviderDoesNotCrash(t *testing.T) {
+	h := newTestHub(t)
+
+	c := newTestClient("c-no-provider")
+	c.hub = h
+
+	payload, _ := json.Marshal(SessionSubscribeRequest{SessionID: "sess-x"})
+	msg := &ws.Message{ID: "req-1", Type: ws.MessageTypeRequest, Action: "session.focus", Payload: payload}
+
+	c.handleSessionFocus(msg)
+
+	// Drain the ACK so it's clear exactly one frame was produced.
+	select {
+	case <-c.send:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected ACK frame after focus")
+	}
+	select {
+	case <-c.send:
+		t.Error("unexpected extra frame when provider is nil")
+	case <-time.After(50 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
Switching tasks left the Changes panel stuck on the empty state until a page refresh, because the sidebar's bulk `session.subscribe` ref-counts the per-session subscription client-side — the task page's own subscribe call never reached the backend, so the snapshot push wired into `handleSessionSubscribe` never fired. Piggybacking the snapshot on `session.focus` (always sent 0→1 when the user opens a task) guarantees fresh git state on task switch without disturbing the existing first-subscriber optimization.

## Validation

- \`go test ./internal/gateway/websocket/...\` — 65 tests pass, including 2 new focus-handler tests.
- \`make fmt\` — clean.
- \`golangci-lint run ./...\` — no issues.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.