### PR TITLE
feat(web): explain why Start task button is disabled via hover tooltip

### DIFF
--- a/apps/web/components/task-create-dialog-footer.test.ts
+++ b/apps/web/components/task-create-dialog-footer.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { computeDisabledReason } from "./task-create-dialog-footer";
-import type { TaskCreateDialogFooterProps } from "./task-create-dialog-footer";
+import {
+  computeDisabledReason,
+  REASON_TITLE,
+  REASON_REPO,
+  REASON_BRANCH,
+  REASON_WORKSPACE,
+  REASON_WORKFLOW,
+  REASON_AGENT,
+  REASON_DESCRIPTION,
+} from "./task-create-dialog-footer";
+import type { ButtonKind, TaskCreateDialogFooterProps } from "./task-create-dialog-footer";
 
-const REASON_TITLE = "Add a task title";
-const REASON_REPO = "Select a repository";
-const REASON_BRANCH = "Select a branch";
-const REASON_WORKSPACE = "Select a workspace";
-const REASON_WORKFLOW = "Select a workflow";
-const REASON_AGENT = "Select an agent";
-const REASON_DESCRIPTION = "Add a session description";
-const KIND_START = "start-task" as const;
-const KIND_UPDATE = "update" as const;
-const KIND_DEFAULT = "default" as const;
+const KIND_START: ButtonKind = "start-task";
+const KIND_UPDATE: ButtonKind = "update";
+const KIND_DEFAULT: ButtonKind = "default";
 
 function makeProps(
   overrides: Partial<TaskCreateDialogFooterProps> = {},
@@ -140,6 +142,23 @@ describe("computeDisabledReason (default)", () => {
     expect(
       computeDisabledReason(
         makeProps({ isSessionMode: true, hasDescription: false, isPassthroughProfile: true }),
+        KIND_DEFAULT,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores base reasons in session mode to match DefaultSubmitButton disabled logic", () => {
+    // In session mode the default button is only disabled by !agentProfileId or
+    // missing description — NOT by missing title/repo/branch/workspace/workflow.
+    // The tooltip must not contradict that state.
+    expect(
+      computeDisabledReason(
+        makeProps({
+          isSessionMode: true,
+          hasTitle: false,
+          hasRepositorySelection: false,
+          branch: "",
+        }),
         KIND_DEFAULT,
       ),
     ).toBeNull();

--- a/apps/web/components/task-create-dialog-footer.test.ts
+++ b/apps/web/components/task-create-dialog-footer.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { computeDisabledReason } from "./task-create-dialog-footer";
+import type { TaskCreateDialogFooterProps } from "./task-create-dialog-footer";
+
+const REASON_TITLE = "Add a task title";
+const REASON_REPO = "Select a repository";
+const REASON_BRANCH = "Select a branch";
+const REASON_WORKSPACE = "Select a workspace";
+const REASON_WORKFLOW = "Select a workflow";
+const REASON_AGENT = "Select an agent";
+const KIND_START = "start-task" as const;
+const KIND_UPDATE = "update" as const;
+const KIND_DEFAULT = "default" as const;
+
+function makeProps(
+  overrides: Partial<TaskCreateDialogFooterProps> = {},
+): TaskCreateDialogFooterProps {
+  return {
+    isSessionMode: false,
+    isCreateMode: true,
+    isEditMode: false,
+    isTaskStarted: false,
+    isPassthroughProfile: false,
+    isCreatingSession: false,
+    isCreatingTask: false,
+    hasTitle: true,
+    hasDescription: true,
+    hasRepositorySelection: true,
+    branch: "main",
+    agentProfileId: "agent-1",
+    workspaceId: "ws-1",
+    effectiveWorkflowId: "wf-1",
+    executorHint: null,
+    onCancel: () => {},
+    onUpdateWithoutAgent: () => {},
+    onCreateWithoutAgent: () => {},
+    onCreateWithPlanMode: () => {},
+    ...overrides,
+  };
+}
+
+describe("computeDisabledReason (start-task)", () => {
+  it("returns null when nothing is missing", () => {
+    expect(computeDisabledReason(makeProps(), KIND_START)).toBeNull();
+  });
+
+  it("returns null while a submission is in flight", () => {
+    expect(
+      computeDisabledReason(makeProps({ isCreatingTask: true, hasTitle: false }), KIND_START),
+    ).toBeNull();
+  });
+
+  it("flags missing title first", () => {
+    expect(
+      computeDisabledReason(
+        makeProps({ hasTitle: false, hasRepositorySelection: false }),
+        KIND_START,
+      ),
+    ).toBe(REASON_TITLE);
+  });
+
+  it("flags missing repository selection", () => {
+    expect(
+      computeDisabledReason(makeProps({ hasRepositorySelection: false }), KIND_START),
+    ).toBe(REASON_REPO);
+  });
+
+  it("flags missing branch", () => {
+    expect(computeDisabledReason(makeProps({ branch: "" }), KIND_START)).toBe(REASON_BRANCH);
+  });
+
+  it("flags missing workspace in create mode", () => {
+    expect(computeDisabledReason(makeProps({ workspaceId: null }), KIND_START)).toBe(
+      REASON_WORKSPACE,
+    );
+  });
+
+  it("flags missing workflow in create mode", () => {
+    expect(computeDisabledReason(makeProps({ effectiveWorkflowId: null }), KIND_START)).toBe(
+      REASON_WORKFLOW,
+    );
+  });
+
+  it("ignores missing workspace/workflow outside create mode", () => {
+    expect(
+      computeDisabledReason(
+        makeProps({ isCreateMode: false, isEditMode: true, workspaceId: null }),
+        KIND_START,
+      ),
+    ).toBeNull();
+  });
+
+  it("flags missing agent profile for start-task button", () => {
+    expect(computeDisabledReason(makeProps({ agentProfileId: "" }), KIND_START)).toBe(
+      REASON_AGENT,
+    );
+  });
+});
+
+describe("computeDisabledReason (update)", () => {
+  it("only flags missing title for the update button", () => {
+    expect(
+      computeDisabledReason(
+        makeProps({ hasTitle: false, hasRepositorySelection: false, agentProfileId: "" }),
+        KIND_UPDATE,
+      ),
+    ).toBe(REASON_TITLE);
+  });
+
+  it("returns null for update when title is present, even with other gaps", () => {
+    expect(
+      computeDisabledReason(
+        makeProps({ hasRepositorySelection: false, agentProfileId: "" }),
+        KIND_UPDATE,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("computeDisabledReason (default)", () => {
+  it("does not require agent outside session mode", () => {
+    expect(computeDisabledReason(makeProps({ agentProfileId: "" }), KIND_DEFAULT)).toBeNull();
+  });
+
+  it("requires agent in session mode", () => {
+    expect(
+      computeDisabledReason(
+        makeProps({ isSessionMode: true, agentProfileId: "" }),
+        KIND_DEFAULT,
+      ),
+    ).toBe(REASON_AGENT);
+  });
+});

--- a/apps/web/components/task-create-dialog-footer.test.ts
+++ b/apps/web/components/task-create-dialog-footer.test.ts
@@ -8,6 +8,7 @@ const REASON_BRANCH = "Select a branch";
 const REASON_WORKSPACE = "Select a workspace";
 const REASON_WORKFLOW = "Select a workflow";
 const REASON_AGENT = "Select an agent";
+const REASON_DESCRIPTION = "Add a session description";
 const KIND_START = "start-task" as const;
 const KIND_UPDATE = "update" as const;
 const KIND_DEFAULT = "default" as const;
@@ -60,9 +61,9 @@ describe("computeDisabledReason (start-task)", () => {
   });
 
   it("flags missing repository selection", () => {
-    expect(
-      computeDisabledReason(makeProps({ hasRepositorySelection: false }), KIND_START),
-    ).toBe(REASON_REPO);
+    expect(computeDisabledReason(makeProps({ hasRepositorySelection: false }), KIND_START)).toBe(
+      REASON_REPO,
+    );
   });
 
   it("flags missing branch", () => {
@@ -91,9 +92,7 @@ describe("computeDisabledReason (start-task)", () => {
   });
 
   it("flags missing agent profile for start-task button", () => {
-    expect(computeDisabledReason(makeProps({ agentProfileId: "" }), KIND_START)).toBe(
-      REASON_AGENT,
-    );
+    expect(computeDisabledReason(makeProps({ agentProfileId: "" }), KIND_START)).toBe(REASON_AGENT);
   });
 });
 
@@ -124,10 +123,25 @@ describe("computeDisabledReason (default)", () => {
 
   it("requires agent in session mode", () => {
     expect(
+      computeDisabledReason(makeProps({ isSessionMode: true, agentProfileId: "" }), KIND_DEFAULT),
+    ).toBe(REASON_AGENT);
+  });
+
+  it("flags missing session description in session mode", () => {
+    expect(
       computeDisabledReason(
-        makeProps({ isSessionMode: true, agentProfileId: "" }),
+        makeProps({ isSessionMode: true, hasDescription: false }),
         KIND_DEFAULT,
       ),
-    ).toBe(REASON_AGENT);
+    ).toBe(REASON_DESCRIPTION);
+  });
+
+  it("does not flag missing description for passthrough profiles", () => {
+    expect(
+      computeDisabledReason(
+        makeProps({ isSessionMode: true, hasDescription: false, isPassthroughProfile: true }),
+        KIND_DEFAULT,
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/web/components/task-create-dialog-footer.tsx
+++ b/apps/web/components/task-create-dialog-footer.tsx
@@ -250,21 +250,15 @@ function computeBaseDisabled(props: TaskCreateDialogFooterProps) {
   );
 }
 
-type ButtonKind = "update" | "start-task" | "default";
+export type ButtonKind = "update" | "start-task" | "default";
 
-const REASON_TITLE = "Add a task title";
-const REASON_REPO = "Select a repository";
-const REASON_BRANCH = "Select a branch";
-const REASON_WORKSPACE = "Select a workspace";
-const REASON_WORKFLOW = "Select a workflow";
-const REASON_AGENT = "Select an agent";
-const REASON_DESCRIPTION = "Add a session description";
-
-function requiresAgent(kind: ButtonKind, props: TaskCreateDialogFooterProps): boolean {
-  if (kind === "start-task") return true;
-  if (kind === "default" && props.isSessionMode) return true;
-  return false;
-}
+export const REASON_TITLE = "Add a task title";
+export const REASON_REPO = "Select a repository";
+export const REASON_BRANCH = "Select a branch";
+export const REASON_WORKSPACE = "Select a workspace";
+export const REASON_WORKFLOW = "Select a workflow";
+export const REASON_AGENT = "Select an agent";
+export const REASON_DESCRIPTION = "Add a session description";
 
 function baseReason(props: TaskCreateDialogFooterProps): string | null {
   if (!props.hasTitle) return REASON_TITLE;
@@ -276,7 +270,13 @@ function baseReason(props: TaskCreateDialogFooterProps): string | null {
 }
 
 function missingSessionDescription(props: TaskCreateDialogFooterProps): boolean {
-  return props.isSessionMode && !props.hasDescription && !props.isPassthroughProfile;
+  return !props.hasDescription && !props.isPassthroughProfile;
+}
+
+function sessionDefaultReason(props: TaskCreateDialogFooterProps): string | null {
+  if (!props.agentProfileId) return REASON_AGENT;
+  if (missingSessionDescription(props)) return REASON_DESCRIPTION;
+  return null;
 }
 
 export function computeDisabledReason(
@@ -285,10 +285,10 @@ export function computeDisabledReason(
 ): string | null {
   if (props.isCreatingTask) return null;
   if (kind === "update") return props.hasTitle ? null : REASON_TITLE;
+  if (kind === "default" && props.isSessionMode) return sessionDefaultReason(props);
   const base = baseReason(props);
   if (base) return base;
-  if (requiresAgent(kind, props) && !props.agentProfileId) return REASON_AGENT;
-  if (kind === "default" && missingSessionDescription(props)) return REASON_DESCRIPTION;
+  if (kind === "start-task" && !props.agentProfileId) return REASON_AGENT;
   return null;
 }
 

--- a/apps/web/components/task-create-dialog-footer.tsx
+++ b/apps/web/components/task-create-dialog-footer.tsx
@@ -250,6 +250,51 @@ function computeBaseDisabled(props: TaskCreateDialogFooterProps) {
   );
 }
 
+type ButtonKind = "update" | "start-task" | "default";
+
+const REASON_TITLE = "Add a task title";
+const REASON_REPO = "Select a repository";
+const REASON_BRANCH = "Select a branch";
+const REASON_WORKSPACE = "Select a workspace";
+const REASON_WORKFLOW = "Select a workflow";
+const REASON_AGENT = "Select an agent";
+
+function requiresAgent(kind: ButtonKind, props: TaskCreateDialogFooterProps): boolean {
+  if (kind === "start-task") return true;
+  if (kind === "default" && props.isSessionMode) return true;
+  return false;
+}
+
+function baseReason(props: TaskCreateDialogFooterProps): string | null {
+  if (!props.hasTitle) return REASON_TITLE;
+  if (!props.hasRepositorySelection) return REASON_REPO;
+  if (!props.branch) return REASON_BRANCH;
+  if (props.isCreateMode && !props.workspaceId) return REASON_WORKSPACE;
+  if (props.isCreateMode && !props.effectiveWorkflowId) return REASON_WORKFLOW;
+  return null;
+}
+
+export function computeDisabledReason(
+  props: TaskCreateDialogFooterProps,
+  kind: ButtonKind,
+): string | null {
+  if (props.isCreatingTask) return null;
+  if (kind === "update") return props.hasTitle ? null : REASON_TITLE;
+  const base = baseReason(props);
+  if (base) return base;
+  if (requiresAgent(kind, props) && !props.agentProfileId) return REASON_AGENT;
+  return null;
+}
+
+function resolveButtonKind(
+  props: TaskCreateDialogFooterProps,
+  showStartTask: boolean,
+): ButtonKind {
+  if (props.isTaskStarted) return "update";
+  if (showStartTask) return "start-task";
+  return "default";
+}
+
 function computeFooterState(props: TaskCreateDialogFooterProps) {
   const showStartTask =
     (props.isCreateMode && (props.hasDescription || props.isPassthroughProfile)) ||
@@ -258,7 +303,9 @@ function computeFooterState(props: TaskCreateDialogFooterProps) {
   const splitDisabled = altDisabled || !props.agentProfileId;
   const defaultDisabled = props.isSessionMode ? !props.agentProfileId : altDisabled;
 
-  return { showStartTask, splitDisabled, altDisabled, defaultDisabled };
+  const disabledReason = computeDisabledReason(props, resolveButtonKind(props, showStartTask));
+
+  return { showStartTask, splitDisabled, altDisabled, defaultDisabled, disabledReason };
 }
 
 export const TaskCreateDialogFooter = memo(function TaskCreateDialogFooter(
@@ -280,7 +327,8 @@ export const TaskCreateDialogFooter = memo(function TaskCreateDialogFooter(
     onCreateWithoutAgent,
     onCreateWithPlanMode,
   } = props;
-  const { showStartTask, splitDisabled, altDisabled, defaultDisabled } = computeFooterState(props);
+  const { showStartTask, splitDisabled, altDisabled, defaultDisabled, disabledReason } =
+    computeFooterState(props);
 
   return (
     <>
@@ -300,42 +348,50 @@ export const TaskCreateDialogFooter = memo(function TaskCreateDialogFooter(
           Cancel
         </Button>
       </DialogClose>
-      <KeyboardShortcutTooltip shortcut={SHORTCUTS.SUBMIT}>
-        {(() => {
-          if (isTaskStarted) {
+      <KeyboardShortcutTooltip
+        shortcut={SHORTCUTS.SUBMIT}
+        description={disabledReason ?? undefined}
+      >
+        <span
+          className="inline-flex w-full sm:w-auto"
+          data-testid="submit-start-agent-wrapper"
+        >
+          {(() => {
+            if (isTaskStarted) {
+              return (
+                <UpdateButton
+                  isCreatingTask={isCreatingTask}
+                  hasTitle={hasTitle}
+                  onUpdate={onUpdateWithoutAgent}
+                />
+              );
+            }
+            if (showStartTask) {
+              return (
+                <StartTaskSplitButton
+                  isCreatingTask={isCreatingTask}
+                  disabled={splitDisabled}
+                  altDisabled={altDisabled}
+                  isEditMode={isEditMode}
+                  onAltAction={isEditMode ? onUpdateWithoutAgent : onCreateWithoutAgent}
+                  onPlanModeAction={onCreateWithPlanMode}
+                />
+              );
+            }
             return (
-              <UpdateButton
+              <DefaultSubmitButton
+                isCreatingSession={isCreatingSession}
                 isCreatingTask={isCreatingTask}
-                hasTitle={hasTitle}
-                onUpdate={onUpdateWithoutAgent}
-              />
-            );
-          }
-          if (showStartTask) {
-            return (
-              <StartTaskSplitButton
-                isCreatingTask={isCreatingTask}
-                disabled={splitDisabled}
-                altDisabled={altDisabled}
+                isSessionMode={isSessionMode}
+                isCreateMode={isCreateMode}
                 isEditMode={isEditMode}
-                onAltAction={isEditMode ? onUpdateWithoutAgent : onCreateWithoutAgent}
-                onPlanModeAction={onCreateWithPlanMode}
+                hasDescription={hasDescription}
+                isPassthroughProfile={isPassthroughProfile}
+                disabled={defaultDisabled}
               />
             );
-          }
-          return (
-            <DefaultSubmitButton
-              isCreatingSession={isCreatingSession}
-              isCreatingTask={isCreatingTask}
-              isSessionMode={isSessionMode}
-              isCreateMode={isCreateMode}
-              isEditMode={isEditMode}
-              hasDescription={hasDescription}
-              isPassthroughProfile={isPassthroughProfile}
-              disabled={defaultDisabled}
-            />
-          );
-        })()}
+          })()}
+        </span>
       </KeyboardShortcutTooltip>
     </>
   );

--- a/apps/web/components/task-create-dialog-footer.tsx
+++ b/apps/web/components/task-create-dialog-footer.tsx
@@ -258,6 +258,7 @@ const REASON_BRANCH = "Select a branch";
 const REASON_WORKSPACE = "Select a workspace";
 const REASON_WORKFLOW = "Select a workflow";
 const REASON_AGENT = "Select an agent";
+const REASON_DESCRIPTION = "Add a session description";
 
 function requiresAgent(kind: ButtonKind, props: TaskCreateDialogFooterProps): boolean {
   if (kind === "start-task") return true;
@@ -274,6 +275,10 @@ function baseReason(props: TaskCreateDialogFooterProps): string | null {
   return null;
 }
 
+function missingSessionDescription(props: TaskCreateDialogFooterProps): boolean {
+  return props.isSessionMode && !props.hasDescription && !props.isPassthroughProfile;
+}
+
 export function computeDisabledReason(
   props: TaskCreateDialogFooterProps,
   kind: ButtonKind,
@@ -283,13 +288,11 @@ export function computeDisabledReason(
   const base = baseReason(props);
   if (base) return base;
   if (requiresAgent(kind, props) && !props.agentProfileId) return REASON_AGENT;
+  if (kind === "default" && missingSessionDescription(props)) return REASON_DESCRIPTION;
   return null;
 }
 
-function resolveButtonKind(
-  props: TaskCreateDialogFooterProps,
-  showStartTask: boolean,
-): ButtonKind {
+function resolveButtonKind(props: TaskCreateDialogFooterProps, showStartTask: boolean): ButtonKind {
   if (props.isTaskStarted) return "update";
   if (showStartTask) return "start-task";
   return "default";
@@ -352,10 +355,7 @@ export const TaskCreateDialogFooter = memo(function TaskCreateDialogFooter(
         shortcut={SHORTCUTS.SUBMIT}
         description={disabledReason ?? undefined}
       >
-        <span
-          className="inline-flex w-full sm:w-auto"
-          data-testid="submit-start-agent-wrapper"
-        >
+        <span className="inline-flex w-full sm:w-auto" data-testid="submit-start-agent-wrapper">
           {(() => {
             if (isTaskStarted) {
               return (

--- a/apps/web/e2e/tests/task/create-task-disabled-tooltip.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-disabled-tooltip.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+
+const START_AGENT_TEST_ID = "submit-start-agent";
+const WRAPPER_TEST_ID = "submit-start-agent-wrapper";
+const START_ENABLED_TIMEOUT = 30_000;
+
+test.describe("Create task button: disabled-reason tooltip", () => {
+  test("shows 'Add a task title' when title is empty", async ({ testPage }) => {
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.createTaskButton.first().click();
+    const dialog = testPage.getByTestId("create-task-dialog");
+    await expect(dialog).toBeVisible();
+
+    // Leave title empty; fill description so the split button renders (showStartTask)
+    await testPage.getByTestId("task-description-input").fill("some description");
+
+    const startBtn = testPage.getByTestId(START_AGENT_TEST_ID);
+    await expect(startBtn).toBeDisabled();
+
+    // Hover the wrapper span (disabled button has pointer-events-none, tooltip
+    // won't fire on the button itself — hover the span that wraps it).
+    await testPage.getByTestId(WRAPPER_TEST_ID).hover();
+    await expect(testPage.getByRole("tooltip")).toContainText("Add a task title", {
+      timeout: 5_000,
+    });
+  });
+
+  test("tooltip omits any disabled reason once the form is valid", async ({ testPage }) => {
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.createTaskButton.first().click();
+    const dialog = testPage.getByTestId("create-task-dialog");
+    await expect(dialog).toBeVisible();
+
+    await testPage.getByTestId("task-title-input").fill("Valid Task");
+    await testPage.getByTestId("task-description-input").fill("doing a thing");
+
+    const startBtn = testPage.getByTestId(START_AGENT_TEST_ID);
+    await expect(startBtn).toBeEnabled({ timeout: START_ENABLED_TIMEOUT });
+
+    // Hover still shows the keyboard shortcut tooltip, but none of the
+    // disabled-reason strings should appear.
+    await testPage.getByTestId(WRAPPER_TEST_ID).hover();
+    const tooltip = testPage.getByRole("tooltip");
+    await expect(tooltip).toBeVisible({ timeout: 5_000 });
+    await expect(tooltip).not.toContainText("Add a task title");
+    await expect(tooltip).not.toContainText("Select a repository");
+    await expect(tooltip).not.toContainText("Select a branch");
+    await expect(tooltip).not.toContainText("Select an agent");
+  });
+
+  test("shows 'Add a task title' after clearing a previously-filled title", async ({
+    testPage,
+  }) => {
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.createTaskButton.first().click();
+    const dialog = testPage.getByTestId("create-task-dialog");
+    await expect(dialog).toBeVisible();
+
+    const titleInput = testPage.getByTestId("task-title-input");
+    await titleInput.fill("Temp Title");
+    await testPage.getByTestId("task-description-input").fill("description text");
+
+    const startBtn = testPage.getByTestId(START_AGENT_TEST_ID);
+    await expect(startBtn).toBeEnabled({ timeout: START_ENABLED_TIMEOUT });
+
+    await titleInput.fill("");
+    await expect(startBtn).toBeDisabled();
+
+    await testPage.getByTestId(WRAPPER_TEST_ID).hover();
+    await expect(testPage.getByRole("tooltip")).toContainText("Add a task title", {
+      timeout: 5_000,
+    });
+  });
+});


### PR DESCRIPTION
Users with a disabled "Start task" button had no feedback on which field was missing, leading them to guess at phantom requirements (one user assumed `gh` CLI was required for a GitLab repo). Hovering the disabled button now surfaces the actual missing field so users can self-diagnose.

## Validation

- `pnpm lint` — 0 warnings
- `pnpm test` — 417 passed (incl. 13 new tests for `computeDisabledReason`)
- `npx tsc --noEmit` — no new type errors on changed files
- New e2e test `apps/web/e2e/tests/task/create-task-disabled-tooltip.spec.ts` covering empty title, valid form (no reason), and cleared title

## Possible Improvements

Low risk: the tooltip wraps the split button in a `<span>` inside `TooltipTrigger asChild` — if Radix behavior changes and blocks the hover target, the wrapper testid (`submit-start-agent-wrapper`) gives e2e coverage to catch regressions.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.