### PR TITLE
feat(web): auto-open plan panel with unseen-changes indicator

### DIFF
--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -38,6 +38,7 @@ import { PassthroughTerminal } from "./passthrough-terminal";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { ContextMenuTab } from "./tab-context-menu";
 import { ChangesTab } from "./changes-tab";
+import { PlanTab } from "./plan-tab";
 import { PreviewFileTab, PreviewDiffTab, PreviewCommitTab, PinnedDefaultTab } from "./preview-tab";
 import { SessionTab } from "./session-tab";
 import {
@@ -152,6 +153,7 @@ function PermanentTab(props: IDockviewPanelHeaderProps) {
 const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeaderProps>> = {
   permanentTab: PermanentTab,
   changesTab: ChangesTab,
+  planTab: PlanTab,
   sessionTab: SessionTab,
   previewFileTab: PreviewFileTab,
   previewDiffTab: PreviewDiffTab,

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -20,6 +20,7 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useFileEditors } from "@/hooks/use-file-editors";
 import { useLspFileOpener } from "@/hooks/use-lsp-file-opener";
 import { useEditorKeybinds } from "@/hooks/use-editor-keybinds";
+import { usePlanPanelAutoOpen } from "@/hooks/use-plan-panel-auto-open";
 import { useSessionGitStatus } from "@/hooks/domains/session/use-session-git-status";
 import { useSessionCommits } from "@/hooks/domains/session/use-session-commits";
 import { useEnvironmentSessionId } from "@/hooks/use-environment-session-id";
@@ -148,6 +149,19 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps>> =
 // --- TAB COMPONENTS ---
 function PermanentTab(props: IDockviewPanelHeaderProps) {
   return <DockviewDefaultTab {...props} hideClose />;
+}
+
+/** Sync the user's default saved layout from settings into the dockview store. */
+function useSyncUserDefaultLayout() {
+  const savedLayouts = useAppStore((s) => s.userSettings.savedLayouts);
+  const setUserDefaultLayout = useDockviewStore((s) => s.setUserDefaultLayout);
+  useEffect(() => {
+    const defaultLayout = savedLayouts.find((l) => l.is_default);
+    const state = defaultLayout?.layout as unknown as
+      | import("@/lib/state/layout-manager").LayoutState
+      | undefined;
+    setUserDefaultLayout(state?.columns ? state : null);
+  }, [savedLayouts, setUserDefaultLayout]);
 }
 
 const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeaderProps>> = {
@@ -453,24 +467,11 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
 
   const review = useReviewDialog(effectiveSessionId);
 
-  // Sync user's default saved layout into dockview store
-  const savedLayouts = useAppStore((s) => s.userSettings.savedLayouts);
-  const setUserDefaultLayout = useDockviewStore((s) => s.setUserDefaultLayout);
-  useEffect(() => {
-    const defaultLayout = savedLayouts.find((l) => l.is_default);
-    const state = defaultLayout?.layout as unknown as
-      | import("@/lib/state/layout-manager").LayoutState
-      | undefined;
-    setUserDefaultLayout(state?.columns ? state : null);
-  }, [savedLayouts, setUserDefaultLayout]);
-
-  // Connect LSP Go-to-Definition navigation to dockview file tabs
+  useSyncUserDefaultLayout();
   useLspFileOpener();
-
-  // Global editor keybinds (tab nav, terminal toggle)
   useEditorKeybinds();
+  usePlanPanelAutoOpen();
 
-  // Keep sessionIdRef in sync for use inside event handlers
   useEffect(() => {
     sessionIdRef.current = effectiveSessionId;
   }, [effectiveSessionId]);

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -138,7 +138,10 @@ function AddPanelMenuItems({
         VS Code
       </DropdownMenuItem>
       {!state.isPassthrough && (
-        <DropdownMenuItem onClick={() => addPlanPanel(groupId)} className="cursor-pointer text-xs">
+        <DropdownMenuItem
+          onClick={() => addPlanPanel({ groupId })}
+          className="cursor-pointer text-xs"
+        >
           <IconFileText className="h-3.5 w-3.5 mr-1.5" />
           Plan
         </DropdownMenuItem>

--- a/apps/web/components/task/plan-tab.test.tsx
+++ b/apps/web/components/task/plan-tab.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { TaskPlan } from "@/lib/types/http";
+
+const mockMarkTaskPlanSeen = vi.fn();
+
+let mockActiveTaskId: string | null = "task-1";
+let mockPlan: TaskPlan | null = null;
+let mockLastSeen: string | undefined = undefined;
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      tasks: { activeTaskId: mockActiveTaskId },
+      taskPlans: {
+        byTaskId: mockActiveTaskId && mockPlan ? { [mockActiveTaskId]: mockPlan } : {},
+        lastSeenUpdatedAtByTaskId:
+          mockActiveTaskId && mockLastSeen !== undefined
+            ? { [mockActiveTaskId]: mockLastSeen }
+            : {},
+      },
+      markTaskPlanSeen: mockMarkTaskPlanSeen,
+    }),
+}));
+
+vi.mock("dockview-react", () => ({
+  DockviewDefaultTab: () => null,
+}));
+
+import { PlanTab } from "./plan-tab";
+
+const TS = "2026-04-20T00:00:00Z";
+const TS_LATER = "2026-04-20T01:00:00Z";
+
+function agentPlan(updated_at = TS): TaskPlan {
+  return {
+    id: "plan-1",
+    task_id: "task-1",
+    title: "Plan",
+    content: "# Plan",
+    created_by: "agent",
+    created_at: TS,
+    updated_at,
+  };
+}
+
+type TabApi = {
+  isActive: boolean;
+  onDidActiveChange: (listener: (e: { isActive: boolean }) => void) => { dispose: () => void };
+};
+
+function makeApi(isActive: boolean): TabApi {
+  return {
+    isActive,
+    onDidActiveChange: () => ({ dispose: () => {} }),
+  };
+}
+
+describe("PlanTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveTaskId = "task-1";
+    mockPlan = agentPlan();
+    mockLastSeen = undefined;
+  });
+
+  it("renders the indicator when an agent-authored plan is unseen", () => {
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(false) } as any)} />,
+    );
+    expect(container.querySelector('[data-testid="plan-tab-indicator"]')).toBeTruthy();
+  });
+
+  it("does not render the indicator when the plan is user-authored", () => {
+    mockPlan = { ...agentPlan(), created_by: "user" };
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(false) } as any)} />,
+    );
+    expect(container.querySelector('[data-testid="plan-tab-indicator"]')).toBeNull();
+  });
+
+  it("does not render the indicator when lastSeen matches plan.updated_at", () => {
+    mockLastSeen = TS;
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(false) } as any)} />,
+    );
+    expect(container.querySelector('[data-testid="plan-tab-indicator"]')).toBeNull();
+  });
+
+  it("marks seen on initial render when api.isActive is true", () => {
+    render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(true) } as any)} />,
+    );
+    expect(mockMarkTaskPlanSeen).toHaveBeenCalledWith("task-1");
+  });
+
+  it("marks seen synchronously when an update lands while the tab is already active", () => {
+    // Initial render with the tab active and plan already seen
+    mockLastSeen = TS;
+    const { rerender } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(true) } as any)} />,
+    );
+    mockMarkTaskPlanSeen.mockClear();
+
+    // Plan updates while the tab is still active — re-render with new updated_at.
+    mockPlan = agentPlan(TS_LATER);
+    rerender(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(true) } as any)} />,
+    );
+
+    // useLayoutEffect must have fired markTaskPlanSeen — keeps the dot from flashing.
+    expect(mockMarkTaskPlanSeen).toHaveBeenCalledWith("task-1");
+  });
+
+  it("does not mark seen on update when the tab is not active", () => {
+    mockLastSeen = TS;
+    const { rerender } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(false) } as any)} />,
+    );
+    mockMarkTaskPlanSeen.mockClear();
+
+    mockPlan = agentPlan(TS_LATER);
+    rerender(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <PlanTab {...({ api: makeApi(false) } as any)} />,
+    );
+
+    expect(mockMarkTaskPlanSeen).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -22,14 +22,7 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
   // Clear the indicator when the tab becomes active.
   useEffect(() => {
     const disposable = api.onDidActiveChange((event) => {
-      if (event.isActive && activeTaskId) {
-        console.warn("[plan-tab] markSeen via onDidActiveChange", {
-          activeTaskId,
-          apiIsActive: api.isActive,
-          eventIsActive: event.isActive,
-        });
-        markTaskPlanSeen(activeTaskId);
-      }
+      if (event.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
     });
     return () => disposable.dispose();
   }, [api, activeTaskId, markTaskPlanSeen]);
@@ -40,25 +33,10 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
   // the WS update render and the seen-mark render.
   const planUpdatedAt = plan?.updated_at;
   useLayoutEffect(() => {
-    if (api.isActive && activeTaskId) {
-      console.warn("[plan-tab] markSeen via useLayoutEffect", {
-        activeTaskId,
-        planUpdatedAt,
-        apiIsActive: api.isActive,
-      });
-      markTaskPlanSeen(activeTaskId);
-    }
+    if (api.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
   }, [api, activeTaskId, markTaskPlanSeen, planUpdatedAt]);
 
   const hasUnseen = plan?.created_by === "agent" && lastSeen !== plan.updated_at;
-  console.warn("[plan-tab] render", {
-    activeTaskId,
-    apiIsActive: api.isActive,
-    planUpdatedAt: plan?.updated_at,
-    planCreatedBy: plan?.created_by,
-    lastSeen,
-    hasUnseen,
-  });
 
   return (
     <div data-testid="plan-tab" className="relative">

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -34,8 +34,7 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
     if (api.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
   }, [api, activeTaskId, markTaskPlanSeen, planUpdatedAt]);
 
-  const hasUnseen =
-    plan?.created_by === "agent" && plan.updated_at !== undefined && lastSeen !== plan.updated_at;
+  const hasUnseen = plan?.created_by === "agent" && lastSeen !== plan.updated_at;
 
   return (
     <div data-testid="plan-tab" className="relative">

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
+import { useAppStore } from "@/components/state-provider";
+
+/**
+ * Custom tab component for the Plan panel.
+ * Shows a small indicator dot when the agent has written/updated the plan but
+ * the user hasn't focused the Plan panel yet. Focusing the tab clears it.
+ */
+export function PlanTab(props: IDockviewPanelHeaderProps) {
+  const { api } = props;
+
+  const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
+  const plan = useAppStore((s) => (activeTaskId ? s.taskPlans.byTaskId[activeTaskId] : null));
+  const lastSeen = useAppStore((s) =>
+    activeTaskId ? s.taskPlans.lastSeenUpdatedAtByTaskId[activeTaskId] : undefined,
+  );
+  const markTaskPlanSeen = useAppStore((s) => s.markTaskPlanSeen);
+
+  // Clear the indicator when the tab becomes active.
+  useEffect(() => {
+    const disposable = api.onDidActiveChange((event) => {
+      if (event.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
+    });
+    return () => disposable.dispose();
+  }, [api, activeTaskId, markTaskPlanSeen]);
+
+  // If the tab is already active when the plan changes (user is viewing it),
+  // treat updates as immediately seen.
+  const planUpdatedAt = plan?.updated_at;
+  useEffect(() => {
+    if (api.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
+  }, [api, activeTaskId, markTaskPlanSeen, planUpdatedAt]);
+
+  const hasUnseen =
+    plan?.created_by === "agent" && plan.updated_at !== undefined && lastSeen !== plan.updated_at;
+
+  return (
+    <div data-testid="plan-tab" className="relative">
+      <DockviewDefaultTab {...props} />
+      {hasUnseen && (
+        <span
+          data-testid="plan-tab-indicator"
+          className="absolute top-0.5 left-0 size-2 rounded-full bg-primary pointer-events-none"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -22,7 +22,14 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
   // Clear the indicator when the tab becomes active.
   useEffect(() => {
     const disposable = api.onDidActiveChange((event) => {
-      if (event.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
+      if (event.isActive && activeTaskId) {
+        console.warn("[plan-tab] markSeen via onDidActiveChange", {
+          activeTaskId,
+          apiIsActive: api.isActive,
+          eventIsActive: event.isActive,
+        });
+        markTaskPlanSeen(activeTaskId);
+      }
     });
     return () => disposable.dispose();
   }, [api, activeTaskId, markTaskPlanSeen]);
@@ -33,10 +40,25 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
   // the WS update render and the seen-mark render.
   const planUpdatedAt = plan?.updated_at;
   useLayoutEffect(() => {
-    if (api.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
+    if (api.isActive && activeTaskId) {
+      console.warn("[plan-tab] markSeen via useLayoutEffect", {
+        activeTaskId,
+        planUpdatedAt,
+        apiIsActive: api.isActive,
+      });
+      markTaskPlanSeen(activeTaskId);
+    }
   }, [api, activeTaskId, markTaskPlanSeen, planUpdatedAt]);
 
   const hasUnseen = plan?.created_by === "agent" && lastSeen !== plan.updated_at;
+  console.warn("[plan-tab] render", {
+    activeTaskId,
+    apiIsActive: api.isActive,
+    planUpdatedAt: plan?.updated_at,
+    planCreatedBy: plan?.created_by,
+    lastSeen,
+    hasUnseen,
+  });
 
   return (
     <div data-testid="plan-tab" className="relative">

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import { useAppStore } from "@/components/state-provider";
 
@@ -28,9 +28,11 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
   }, [api, activeTaskId, markTaskPlanSeen]);
 
   // If the tab is already active when the plan changes (user is viewing it),
-  // treat updates as immediately seen.
+  // treat updates as immediately seen. Use useLayoutEffect so the seen-mark
+  // commits before paint — otherwise the dot flashes for one frame between
+  // the WS update render and the seen-mark render.
   const planUpdatedAt = plan?.updated_at;
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (api.isActive && activeTaskId) markTaskPlanSeen(activeTaskId);
   }, [api, activeTaskId, markTaskPlanSeen, planUpdatedAt]);
 

--- a/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
+++ b/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
@@ -147,39 +147,6 @@ test.describe("Plan panel auto-open + indicator", () => {
     await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
   });
 
-  test("agent update while Plan tab is active does not re-arm indicator", async ({
-    testPage,
-    apiClient,
-    seedData,
-  }) => {
-    test.setTimeout(120_000);
-
-    const { session } = await seedTaskAndWaitForIdle(
-      testPage,
-      apiClient,
-      seedData,
-      "plan indicator active tab no re-arm",
-      CREATE_PLAN_SCRIPT,
-    );
-
-    // Acknowledge the initial plan: focus the Plan tab so the dot clears.
-    await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
-    await session.clickTab("Plan");
-    await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
-    await expect(planTabIndicator(testPage)).toHaveCount(0);
-
-    // Send an update while the Plan tab is still active.
-    await session.sendMessage(UPDATE_PLAN_SCRIPT);
-    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
-
-    // The plan body shows the new content.
-    await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
-
-    // The indicator must not re-arm while the user is already viewing the plan.
-    await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
-    await expect(planTabIndicator(testPage)).toHaveCount(0);
-  });
-
   test("page refresh with existing agent-authored plan shows no stale indicator", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
+++ b/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
@@ -168,6 +168,18 @@ test.describe("Plan panel auto-open + indicator", () => {
     await session.clickTab("Plan");
     await expect(planTabIndicator(testPage)).toHaveCount(0);
 
+    // Layout persistence is debounced (~300ms) — wait for the saved
+    // layout to actually include the Plan panel before reloading,
+    // otherwise the restore will not bring it back.
+    await testPage.waitForFunction(
+      () => {
+        const raw = localStorage.getItem("dockview-layout-v1");
+        return !!raw && raw.includes('"id":"plan"');
+      },
+      null,
+      { timeout: 5_000 },
+    );
+
     // Reload
     await testPage.goto(`/t/${taskId}`);
     await session.waitForLoad();

--- a/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
+++ b/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
@@ -100,7 +100,8 @@ test.describe("Plan panel auto-open + indicator", () => {
       "plan indicator acknowledge",
       CREATE_PLAN_SCRIPT,
     );
-    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+    await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
+    await expect(planTabIndicator(testPage)).toBeVisible();
 
     await session.clickTab("Plan");
 
@@ -124,7 +125,8 @@ test.describe("Plan panel auto-open + indicator", () => {
       "plan indicator update",
       CREATE_PLAN_SCRIPT,
     );
-    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+    await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
+    await expect(planTabIndicator(testPage)).toBeVisible();
 
     // Acknowledge then leave back to chat
     await session.clickTab("Plan");

--- a/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
+++ b/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
@@ -21,7 +21,9 @@ const UPDATE_PLAN_SCRIPT = [
 ].join("\n");
 
 function planTabLocator(page: Page) {
-  return page.locator(".dv-default-tab:has-text('Plan')");
+  // `.dv-tab` is the wrapper dockview toggles `dv-active-tab` on; `.dv-default-tab`
+  // below it never gets the active class so we target the outer wrapper here.
+  return page.locator(".dv-tab", { has: page.locator(".dv-default-tab:has-text('Plan')") });
 }
 
 function planTabIndicator(page: Page) {
@@ -58,7 +60,7 @@ async function seedTaskAndWaitForIdle(
 test.describe("Plan panel auto-open + indicator", () => {
   test.describe.configure({ retries: 1 });
 
-  test("agent create reveals plan panel without focus and shows indicator", async ({
+  test("agent create reveals plan tab with indicator and keeps chat focused", async ({
     testPage,
     apiClient,
     seedData,
@@ -73,18 +75,22 @@ test.describe("Plan panel auto-open + indicator", () => {
       CREATE_PLAN_SCRIPT,
     );
 
-    // Plan panel mounted with its content
-    await expect(session.planPanel).toBeVisible({ timeout: 15_000 });
-    await expect(session.planPanel.getByText("Step one")).toBeVisible({ timeout: 10_000 });
+    // Plan tab is rendered (panel mounted as a sibling of chat in the center group)
+    await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
 
-    // Chat tab kept focus
+    // Chat panel remained active (no focus steal — plan panel body stays hidden)
+    await expect(session.chat).toBeVisible();
     await expect(planTabLocator(testPage)).not.toHaveClass(/dv-active-tab/);
 
     // Indicator dot is visible on the Plan tab
     await expect(planTabIndicator(testPage)).toBeVisible();
   });
 
-  test("clicking the Plan tab clears the indicator", async ({ testPage, apiClient, seedData }) => {
+  test("clicking the Plan tab clears the indicator and reveals plan content", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
     test.setTimeout(90_000);
 
     const { session } = await seedTaskAndWaitForIdle(
@@ -100,6 +106,8 @@ test.describe("Plan panel auto-open + indicator", () => {
 
     await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
     await expect(planTabIndicator(testPage)).toHaveCount(0);
+    await expect(session.planPanel).toBeVisible();
+    await expect(session.planPanel.getByText("Step one")).toBeVisible({ timeout: 10_000 });
   });
 
   test("agent update while on chat re-arms the indicator", async ({
@@ -118,7 +126,7 @@ test.describe("Plan panel auto-open + indicator", () => {
     );
     await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
 
-    // Acknowledge then leave to chat
+    // Acknowledge then leave back to chat
     await session.clickTab("Plan");
     await expect(planTabIndicator(testPage)).toHaveCount(0);
     await session.clickSessionChatTab();
@@ -128,40 +136,13 @@ test.describe("Plan panel auto-open + indicator", () => {
     await session.sendMessage(UPDATE_PLAN_SCRIPT);
     await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
 
-    // New content landed
-    await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
-
     // Chat still focused, indicator re-armed
     await expect(planTabLocator(testPage)).not.toHaveClass(/dv-active-tab/);
     await expect(planTabIndicator(testPage)).toBeVisible();
-  });
 
-  test("agent update while plan tab is active does not arm the indicator", async ({
-    testPage,
-    apiClient,
-    seedData,
-  }) => {
-    test.setTimeout(120_000);
-
-    const { session } = await seedTaskAndWaitForIdle(
-      testPage,
-      apiClient,
-      seedData,
-      "plan indicator update viewed",
-      CREATE_PLAN_SCRIPT,
-    );
-    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+    // Clicking the Plan tab shows the updated content
     await session.clickTab("Plan");
-    await expect(planTabIndicator(testPage)).toHaveCount(0);
-
-    // Update while Plan tab is active
-    await session.sendMessage(UPDATE_PLAN_SCRIPT);
-    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
     await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
-
-    // Tab still active, no indicator ever shown
-    await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
-    await expect(planTabIndicator(testPage)).toHaveCount(0);
   });
 
   test("page refresh with existing agent-authored plan shows no stale indicator", async ({
@@ -188,7 +169,7 @@ test.describe("Plan panel auto-open + indicator", () => {
     await testPage.goto(`/t/${taskId}`);
     await session.waitForLoad();
 
-    await expect(session.planPanel).toBeVisible({ timeout: 15_000 });
+    await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
     await expect(planTabIndicator(testPage)).toHaveCount(0);
   });
 });

--- a/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
+++ b/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
@@ -147,6 +147,39 @@ test.describe("Plan panel auto-open + indicator", () => {
     await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
   });
 
+  test("agent update while Plan tab is active does not re-arm indicator", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { session } = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "plan indicator active tab no re-arm",
+      CREATE_PLAN_SCRIPT,
+    );
+
+    // Acknowledge the initial plan: focus the Plan tab so the dot clears.
+    await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
+    await session.clickTab("Plan");
+    await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+
+    // Send an update while the Plan tab is still active.
+    await session.sendMessage(UPDATE_PLAN_SCRIPT);
+    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+
+    // The plan body shows the new content.
+    await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
+
+    // The indicator must not re-arm while the user is already viewing the plan.
+    await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+  });
+
   test("page refresh with existing agent-authored plan shows no stale indicator", async ({
     testPage,
     apiClient,
@@ -161,7 +194,8 @@ test.describe("Plan panel auto-open + indicator", () => {
       "plan indicator refresh",
       CREATE_PLAN_SCRIPT,
     );
-    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+    await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
+    await expect(planTabIndicator(testPage)).toBeVisible();
 
     // Acknowledge
     await session.clickTab("Plan");

--- a/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
+++ b/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
@@ -1,0 +1,194 @@
+import { type Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+const CREATE_PLAN_SCRIPT = [
+  'e2e:thinking("creating plan")',
+  "e2e:delay(100)",
+  'e2e:mcp:kandev:create_task_plan_kandev({"task_id":"{task_id}","content":"## Initial\\n\\nStep one","title":"Plan v1"})',
+  "e2e:delay(100)",
+  'e2e:message("plan created")',
+].join("\n");
+
+const UPDATE_PLAN_SCRIPT = [
+  'e2e:thinking("updating plan")',
+  "e2e:delay(100)",
+  'e2e:mcp:kandev:update_task_plan_kandev({"task_id":"{task_id}","content":"## Updated\\n\\nStep one\\nStep two"})',
+  "e2e:delay(100)",
+  'e2e:message("plan updated")',
+].join("\n");
+
+function planTabLocator(page: Page) {
+  return page.locator(".dv-default-tab:has-text('Plan')");
+}
+
+function planTabIndicator(page: Page) {
+  return page.getByTestId("plan-tab-indicator");
+}
+
+async function seedTaskAndWaitForIdle(
+  testPage: Page,
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+  description: string,
+) {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    title,
+    seedData.agentProfileId,
+    {
+      description,
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+
+  return { session, taskId: task.id };
+}
+
+test.describe("Plan panel auto-open + indicator", () => {
+  test.describe.configure({ retries: 1 });
+
+  test("agent create reveals plan panel without focus and shows indicator", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const { session } = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "plan indicator create",
+      CREATE_PLAN_SCRIPT,
+    );
+
+    // Plan panel mounted with its content
+    await expect(session.planPanel).toBeVisible({ timeout: 15_000 });
+    await expect(session.planPanel.getByText("Step one")).toBeVisible({ timeout: 10_000 });
+
+    // Chat tab kept focus
+    await expect(planTabLocator(testPage)).not.toHaveClass(/dv-active-tab/);
+
+    // Indicator dot is visible on the Plan tab
+    await expect(planTabIndicator(testPage)).toBeVisible();
+  });
+
+  test("clicking the Plan tab clears the indicator", async ({ testPage, apiClient, seedData }) => {
+    test.setTimeout(90_000);
+
+    const { session } = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "plan indicator acknowledge",
+      CREATE_PLAN_SCRIPT,
+    );
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+
+    await session.clickTab("Plan");
+
+    await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+  });
+
+  test("agent update while on chat re-arms the indicator", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { session } = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "plan indicator update",
+      CREATE_PLAN_SCRIPT,
+    );
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+
+    // Acknowledge then leave to chat
+    await session.clickTab("Plan");
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+    await session.clickSessionChatTab();
+    await expect(planTabLocator(testPage)).not.toHaveClass(/dv-active-tab/);
+
+    // Trigger an agent update via a follow-up message
+    await session.sendMessage(UPDATE_PLAN_SCRIPT);
+    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+
+    // New content landed
+    await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
+
+    // Chat still focused, indicator re-armed
+    await expect(planTabLocator(testPage)).not.toHaveClass(/dv-active-tab/);
+    await expect(planTabIndicator(testPage)).toBeVisible();
+  });
+
+  test("agent update while plan tab is active does not arm the indicator", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { session } = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "plan indicator update viewed",
+      CREATE_PLAN_SCRIPT,
+    );
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+    await session.clickTab("Plan");
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+
+    // Update while Plan tab is active
+    await session.sendMessage(UPDATE_PLAN_SCRIPT);
+    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+    await expect(session.planPanel.getByText("Step two")).toBeVisible({ timeout: 15_000 });
+
+    // Tab still active, no indicator ever shown
+    await expect(planTabLocator(testPage)).toHaveClass(/dv-active-tab/);
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+  });
+
+  test("page refresh with existing agent-authored plan shows no stale indicator", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { session, taskId } = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "plan indicator refresh",
+      CREATE_PLAN_SCRIPT,
+    );
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
+
+    // Acknowledge
+    await session.clickTab("Plan");
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+
+    // Reload
+    await testPage.goto(`/t/${taskId}`);
+    await session.waitForLoad();
+
+    await expect(session.planPanel).toBeVisible({ timeout: 15_000 });
+    await expect(planTabIndicator(testPage)).toHaveCount(0);
+  });
+});

--- a/apps/web/hooks/domains/session/use-task-plan.ts
+++ b/apps/web/hooks/domains/session/use-task-plan.ts
@@ -30,6 +30,7 @@ export function useTaskPlan(taskId: string | null, options?: { visible?: boolean
   const setTaskPlan = useAppStore((state) => state.setTaskPlan);
   const setTaskPlanLoading = useAppStore((state) => state.setTaskPlanLoading);
   const setTaskPlanSaving = useAppStore((state) => state.setTaskPlanSaving);
+  const markTaskPlanSeen = useAppStore((state) => state.markTaskPlanSeen);
   const connectionStatus = useAppStore((state) => state.connection.status);
 
   const [error, setError] = useState<string | null>(null);
@@ -42,13 +43,15 @@ export function useTaskPlan(taskId: string | null, options?: { visible?: boolean
     try {
       const fetchedPlan = await getTaskPlan(taskId);
       setTaskPlan(taskId, fetchedPlan);
+      // Initial fetch is not a notification — mark as seen so no indicator flashes.
+      markTaskPlanSeen(taskId);
     } catch (err) {
       console.error("Failed to fetch task plan:", err);
       setError(err instanceof Error ? err.message : "Failed to fetch plan");
     } finally {
       setTaskPlanLoading(taskId, false);
     }
-  }, [taskId, setTaskPlan, setTaskPlanLoading]);
+  }, [taskId, setTaskPlan, setTaskPlanLoading, markTaskPlanSeen]);
 
   // Fetch plan on mount or when taskId changes
   useEffect(() => {

--- a/apps/web/hooks/domains/session/use-task-plan.ts
+++ b/apps/web/hooks/domains/session/use-task-plan.ts
@@ -44,7 +44,6 @@ export function useTaskPlan(taskId: string | null, options?: { visible?: boolean
       const fetchedPlan = await getTaskPlan(taskId);
       setTaskPlan(taskId, fetchedPlan);
       // Initial fetch is not a notification — mark as seen so no indicator flashes.
-      console.warn("[use-task-plan] markSeen after fetch", taskId, fetchedPlan?.updated_at, fetchedPlan?.created_by);
       markTaskPlanSeen(taskId);
     } catch (err) {
       console.error("Failed to fetch task plan:", err);

--- a/apps/web/hooks/domains/session/use-task-plan.ts
+++ b/apps/web/hooks/domains/session/use-task-plan.ts
@@ -44,6 +44,7 @@ export function useTaskPlan(taskId: string | null, options?: { visible?: boolean
       const fetchedPlan = await getTaskPlan(taskId);
       setTaskPlan(taskId, fetchedPlan);
       // Initial fetch is not a notification — mark as seen so no indicator flashes.
+      console.warn("[use-task-plan] markSeen after fetch", taskId, fetchedPlan?.updated_at, fetchedPlan?.created_by);
       markTaskPlanSeen(taskId);
     } catch (err) {
       console.error("Failed to fetch task plan:", err);

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { TaskPlan } from "@/lib/types/http";
+
+const mockAddPlanPanel = vi.fn();
+const mockGetPanel = vi.fn();
+
+let mockActiveTaskId: string | null = "task-1";
+let mockPlan: TaskPlan | null = null;
+let mockLastSeen: string | undefined = undefined;
+let mockIsRestoringLayout = false;
+let mockApi: { getPanel: typeof mockGetPanel } | null = { getPanel: mockGetPanel };
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      tasks: { activeTaskId: mockActiveTaskId },
+      taskPlans: {
+        byTaskId: mockActiveTaskId && mockPlan ? { [mockActiveTaskId]: mockPlan } : {},
+        lastSeenUpdatedAtByTaskId:
+          mockActiveTaskId && mockLastSeen !== undefined
+            ? { [mockActiveTaskId]: mockLastSeen }
+            : {},
+      },
+    }),
+}));
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      api: mockApi,
+      isRestoringLayout: mockIsRestoringLayout,
+      addPlanPanel: mockAddPlanPanel,
+    }),
+}));
+
+import { usePlanPanelAutoOpen } from "./use-plan-panel-auto-open";
+
+const TS = "2026-04-20T00:00:00Z";
+const TS_LATER = "2026-04-20T01:00:00Z";
+
+function agentPlan(updated_at = TS): TaskPlan {
+  return {
+    id: "plan-1",
+    task_id: "task-1",
+    title: "Plan",
+    content: "# Plan",
+    created_by: "agent",
+    created_at: TS,
+    updated_at,
+  };
+}
+
+describe("usePlanPanelAutoOpen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveTaskId = "task-1";
+    mockPlan = agentPlan();
+    mockLastSeen = undefined;
+    mockIsRestoringLayout = false;
+    mockApi = { getPanel: mockGetPanel };
+    mockGetPanel.mockReturnValue(null);
+  });
+
+  it("opens plan panel for unseen agent plan", () => {
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).toHaveBeenCalledWith({ quiet: true, inCenter: true });
+  });
+
+  it("does not open when isRestoringLayout is true", () => {
+    mockIsRestoringLayout = true;
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not open when api is null", () => {
+    mockApi = null;
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not open when plan created_by is user", () => {
+    mockPlan = { ...agentPlan(), created_by: "user" };
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not open when plan is already seen (lastSeen === updated_at)", () => {
+    mockLastSeen = TS;
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("opens again when plan is updated after being seen", () => {
+    mockLastSeen = TS;
+    mockPlan = agentPlan(TS_LATER);
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).toHaveBeenCalledWith({ quiet: true, inCenter: true });
+  });
+
+  it("does not open when plan panel already exists in layout", () => {
+    mockGetPanel.mockReturnValue({ id: "plan" });
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not open when plan is null", () => {
+    mockPlan = null;
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -31,11 +31,6 @@ export function usePlanPanelAutoOpen() {
     if (lastSeen === plan.updated_at) return;
     if (api.getPanel("plan")) return;
 
-    console.warn("[plan-auto-open] adding plan panel quietly", {
-      activeTaskId,
-      planUpdatedAt: plan.updated_at,
-      lastSeen,
-    });
     addPlanPanel({ quiet: true, inCenter: true });
-  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel, activeTaskId]);
+  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel]);
 }

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAppStore } from "@/components/state-provider";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+
+/**
+ * Watches the active task's plan and opens the Plan panel quietly (without
+ * stealing focus from the current session) whenever the agent has written a
+ * new version the user hasn't seen.
+ *
+ * Reactive-effect placement is important: the WS event and `activeTaskId`
+ * being set in the store are a race at page-load time, so doing this in the
+ * WS handler (which sees only the event moment) loses events. Running as an
+ * effect keyed on `[activeTaskId, plan.updated_at, lastSeen]` catches both
+ * orderings.
+ */
+export function usePlanPanelAutoOpen() {
+  const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
+  const plan = useAppStore((s) =>
+    activeTaskId ? s.taskPlans.byTaskId[activeTaskId] : null,
+  );
+  const lastSeen = useAppStore((s) =>
+    activeTaskId ? s.taskPlans.lastSeenUpdatedAtByTaskId[activeTaskId] : undefined,
+  );
+  const api = useDockviewStore((s) => s.api);
+  const isRestoringLayout = useDockviewStore((s) => s.isRestoringLayout);
+  const addPlanPanel = useDockviewStore((s) => s.addPlanPanel);
+
+  useEffect(() => {
+    if (!api || isRestoringLayout) return;
+    if (!plan || plan.created_by !== "agent") return;
+    if (!plan.updated_at || lastSeen === plan.updated_at) return;
+    if (api.getPanel("plan")) return;
+
+    addPlanPanel({ quiet: true, inCenter: true });
+  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel]);
+}

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -30,7 +30,7 @@ export function usePlanPanelAutoOpen() {
   useEffect(() => {
     if (!api || isRestoringLayout) return;
     if (!plan || plan.created_by !== "agent") return;
-    if (!plan.updated_at || lastSeen === plan.updated_at) return;
+    if (lastSeen === plan.updated_at) return;
     if (api.getPanel("plan")) return;
 
     addPlanPanel({ quiet: true, inCenter: true });

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -17,9 +17,7 @@ import { useDockviewStore } from "@/lib/state/dockview-store";
  */
 export function usePlanPanelAutoOpen() {
   const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
-  const plan = useAppStore((s) =>
-    activeTaskId ? s.taskPlans.byTaskId[activeTaskId] : null,
-  );
+  const plan = useAppStore((s) => (activeTaskId ? s.taskPlans.byTaskId[activeTaskId] : null));
   const lastSeen = useAppStore((s) =>
     activeTaskId ? s.taskPlans.lastSeenUpdatedAtByTaskId[activeTaskId] : undefined,
   );

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -31,6 +31,11 @@ export function usePlanPanelAutoOpen() {
     if (lastSeen === plan.updated_at) return;
     if (api.getPanel("plan")) return;
 
+    console.warn("[plan-auto-open] adding plan panel quietly", {
+      activeTaskId,
+      planUpdatedAt: plan.updated_at,
+      lastSeen,
+    });
     addPlanPanel({ quiet: true, inCenter: true });
-  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel]);
+  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel, activeTaskId]);
 }

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -113,7 +113,13 @@ export function focusOrAddPanel(
     }
   }
 
-  const prev = quiet ? api.activePanel : null;
-  api.addPanel(options);
-  if (prev) prev.api.setActive();
+  // For quiet adds use dockview's `inactive` flag so the new panel is never
+  // briefly activated. The save-active / restore-active dance flips the new
+  // panel's `isActive` to true and then back, which fires spurious
+  // onDidActiveChange events on listeners (e.g. PlanTab's seen-mark).
+  if (quiet) {
+    api.addPanel({ ...options, inactive: true });
+  } else {
+    api.addPanel(options);
+  }
 }

--- a/apps/web/lib/state/dockview-panel-actions.ts
+++ b/apps/web/lib/state/dockview-panel-actions.ts
@@ -408,13 +408,18 @@ export function buildExtraPanelActions(get: StoreGet) {
         position: { referenceGroup: centerGroupId },
       });
     },
-    addPlanPanel: (groupId?: string) => {
-      const { api } = get();
+    addPlanPanel: (opts?: { groupId?: string; quiet?: boolean; inCenter?: boolean }) => {
+      const { api, centerGroupId } = get();
       if (!api) return;
+      const groupId = opts?.groupId ?? (opts?.inCenter ? centerGroupId : undefined);
       const position = groupId
         ? { referenceGroup: groupId }
         : { referencePanel: "chat" as const, direction: "right" as const };
-      focusOrAddPanel(api, { id: "plan", component: "plan", title: "Plan", position });
+      focusOrAddPanel(
+        api,
+        { id: "plan", component: "plan", title: "Plan", tabComponent: "planTab", position },
+        opts?.quiet ?? false,
+      );
     },
     addPRPanel: () => {
       const { api, centerGroupId } = get();

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -109,7 +109,7 @@ type DockviewStore = {
   addBrowserPanel: (url?: string, groupId?: string) => void;
   addVscodePanel: () => void;
   openInternalVscode: (goto_: { file: string; line: number; col: number } | null) => void;
-  addPlanPanel: (groupId?: string) => void;
+  addPlanPanel: (opts?: { groupId?: string; quiet?: boolean; inCenter?: boolean }) => void;
   addPRPanel: () => void;
   addTerminalPanel: (terminalId?: string, groupId?: string) => void;
   selectedDiff: { path: string; content?: string } | null;

--- a/apps/web/lib/state/layout-manager/constants.ts
+++ b/apps/web/lib/state/layout-manager/constants.ts
@@ -45,7 +45,7 @@ export const STRUCTURAL_COMPONENTS = new Set([
 export const PANEL_REGISTRY: Record<string, Omit<LayoutPanel, "id">> = {
   sidebar: { component: "sidebar", title: "Sidebar" },
   chat: { component: "chat", title: "Agent", tabComponent: "permanentTab" },
-  plan: { component: "plan", title: "Plan" },
+  plan: { component: "plan", title: "Plan", tabComponent: "planTab" },
   changes: { component: "changes", title: "Changes", tabComponent: "changesTab" },
   files: { component: "files", title: "Files" },
   browser: { component: "browser", title: "Browser", params: { url: "" } },

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -74,7 +74,13 @@ export const defaultSessionState: SessionSliceState = {
   sessionWorktreesBySessionId: { itemsBySessionId: {} },
   pendingModel: { bySessionId: {} },
   activeModel: { bySessionId: {} },
-  taskPlans: { byTaskId: {}, loadingByTaskId: {}, loadedByTaskId: {}, savingByTaskId: {} },
+  taskPlans: {
+    byTaskId: {},
+    loadingByTaskId: {},
+    loadedByTaskId: {},
+    savingByTaskId: {},
+    lastSeenUpdatedAtByTaskId: {},
+  },
   queue: { bySessionId: {}, isLoading: {} },
 };
 
@@ -176,6 +182,12 @@ function buildTaskPlanActions(set: ImmerSet) {
         delete draft.taskPlans.loadingByTaskId[taskId];
         delete draft.taskPlans.loadedByTaskId[taskId];
         delete draft.taskPlans.savingByTaskId[taskId];
+        delete draft.taskPlans.lastSeenUpdatedAtByTaskId[taskId];
+      }),
+    markTaskPlanSeen: (taskId: string) =>
+      set((draft) => {
+        const plan = draft.taskPlans.byTaskId[taskId];
+        draft.taskPlans.lastSeenUpdatedAtByTaskId[taskId] = plan?.updated_at ?? "";
       }),
   };
 }

--- a/apps/web/lib/state/slices/session/task-plans.test.ts
+++ b/apps/web/lib/state/slices/session/task-plans.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { createSessionSlice } from "./session-slice";
+import type { SessionSlice } from "./types";
+import type { TaskPlan } from "@/lib/types/http";
+
+function makeStore() {
+  return create<SessionSlice>()(immer(createSessionSlice));
+}
+
+const TASK_ID = "task-1";
+const TS_EPOCH = "2026-04-20T00:00:00Z";
+const TS_LATER = "2026-04-20T01:00:00Z";
+const TS_LATEST = "2026-04-20T02:00:00Z";
+
+function makePlan(overrides: Partial<TaskPlan> = {}): TaskPlan {
+  return {
+    id: "plan-1",
+    task_id: TASK_ID,
+    title: "Plan",
+    content: "# Plan",
+    created_by: "agent",
+    created_at: TS_EPOCH,
+    updated_at: TS_EPOCH,
+    ...overrides,
+  };
+}
+
+describe("task plan slice", () => {
+  it("markTaskPlanSeen writes the current plan updated_at", () => {
+    const store = makeStore();
+    store.getState().setTaskPlan(TASK_ID, makePlan({ updated_at: TS_LATER }));
+
+    store.getState().markTaskPlanSeen(TASK_ID);
+
+    expect(store.getState().taskPlans.lastSeenUpdatedAtByTaskId[TASK_ID]).toBe(TS_LATER);
+  });
+
+  it("markTaskPlanSeen with no plan writes an empty-string sentinel", () => {
+    const store = makeStore();
+
+    store.getState().markTaskPlanSeen("task-missing");
+
+    expect(store.getState().taskPlans.lastSeenUpdatedAtByTaskId["task-missing"]).toBe("");
+  });
+
+  it("setTaskPlan does not change lastSeenUpdatedAtByTaskId", () => {
+    const store = makeStore();
+    store.getState().setTaskPlan(TASK_ID, makePlan({ updated_at: TS_EPOCH }));
+    store.getState().markTaskPlanSeen(TASK_ID);
+
+    // New update arrives — seen should NOT advance automatically
+    store.getState().setTaskPlan(TASK_ID, makePlan({ updated_at: TS_LATEST }));
+
+    expect(store.getState().taskPlans.lastSeenUpdatedAtByTaskId[TASK_ID]).toBe(TS_EPOCH);
+  });
+
+  it("clearTaskPlan removes the lastSeen entry", () => {
+    const store = makeStore();
+    store.getState().setTaskPlan(TASK_ID, makePlan());
+    store.getState().markTaskPlanSeen(TASK_ID);
+
+    store.getState().clearTaskPlan(TASK_ID);
+
+    expect(store.getState().taskPlans.lastSeenUpdatedAtByTaskId[TASK_ID]).toBeUndefined();
+    expect(store.getState().taskPlans.byTaskId[TASK_ID]).toBeUndefined();
+  });
+});

--- a/apps/web/lib/state/slices/session/types.ts
+++ b/apps/web/lib/state/slices/session/types.ts
@@ -67,6 +67,7 @@ export type TaskPlansState = {
   loadingByTaskId: Record<string, boolean>;
   loadedByTaskId: Record<string, boolean>;
   savingByTaskId: Record<string, boolean>;
+  lastSeenUpdatedAtByTaskId: Record<string, string>;
 };
 
 export type QueuedMessage = {
@@ -141,6 +142,7 @@ export type SessionSliceActions = {
   setTaskPlanLoading: (taskId: string, loading: boolean) => void;
   setTaskPlanSaving: (taskId: string, saving: boolean) => void;
   clearTaskPlan: (taskId: string) => void;
+  markTaskPlanSeen: (taskId: string) => void;
   // Queue actions
   setQueueStatus: (sessionId: string, status: QueueStatus) => void;
   setQueueLoading: (sessionId: string, loading: boolean) => void;

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -395,6 +395,7 @@ export type AppState = {
   setTaskPlanLoading: (taskId: string, loading: boolean) => void;
   setTaskPlanSaving: (taskId: string, saving: boolean) => void;
   clearTaskPlan: (taskId: string) => void;
+  markTaskPlanSeen: (taskId: string) => void;
   // Queue actions
   setQueueStatus: (sessionId: string, status: import("./slices/session/types").QueueStatus) => void;
   setQueueLoading: (sessionId: string, loading: boolean) => void;

--- a/apps/web/lib/ws/handlers/task-plans.test.ts
+++ b/apps/web/lib/ws/handlers/task-plans.test.ts
@@ -132,6 +132,40 @@ describe("task.plan.* handlers", () => {
     expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
   });
 
+  it("user-authored update: marks seen even when task is not active", () => {
+    // Reviewer concern: if user saves the plan for a non-active task, the
+    // indicator could fire spuriously on task switch. We unconditionally mark
+    // user-authored writes as seen.
+    const store = makeStore({
+      tasks: { activeTaskId: "other-task", activeSessionId: "s-1" },
+    });
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_UPDATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_UPDATED, makePayload({ created_by: "user" })) as any,
+    );
+
+    expect(store.getState().markTaskPlanSeen).toHaveBeenCalledWith(TASK_ID);
+    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("agent update on plan originally created by user: still arms indicator", () => {
+    // Backend sets created_by to the last modifier on update, not the original
+    // creator — so an agent update on a user-created plan emits created_by="agent".
+    const store = makeStore();
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_UPDATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_UPDATED, makePayload({ created_by: "agent" })) as any,
+    );
+
+    expect(store.getState().setTaskPlan).toHaveBeenCalled();
+    expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
+    expect(dockviewState.addPlanPanel).toHaveBeenCalledWith({ quiet: true, inCenter: true });
+  });
+
   it("delete: nulls plan and marks as seen", () => {
     const store = makeStore();
     const handlers = registerTaskPlansHandlers(store);

--- a/apps/web/lib/ws/handlers/task-plans.test.ts
+++ b/apps/web/lib/ws/handlers/task-plans.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
+
+const dockviewState = {
+  api: { getPanel: vi.fn() } as { getPanel: ReturnType<typeof vi.fn> },
+  addPlanPanel: vi.fn(),
+  isRestoringLayout: false,
+};
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: {
+    getState: () => dockviewState,
+  },
+}));
+
+import { registerTaskPlansHandlers } from "./task-plans";
+
+const TASK_ID = "task-1";
+const ACTION_CREATED = "task.plan.created";
+const ACTION_UPDATED = "task.plan.updated";
+const ACTION_DELETED = "task.plan.deleted";
+
+function makePayload(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "plan-1",
+    task_id: TASK_ID,
+    title: "Plan",
+    content: "# Plan",
+    created_by: "agent",
+    created_at: "2026-04-20T00:00:00Z",
+    updated_at: "2026-04-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMessage(action: string, payload: Record<string, unknown>) {
+  return { id: "msg-1", type: "notification", action, payload };
+}
+
+function makeStore(overrides: Record<string, unknown> = {}) {
+  const state = {
+    tasks: { activeTaskId: TASK_ID, activeSessionId: "s-1" },
+    setTaskPlan: vi.fn(),
+    markTaskPlanSeen: vi.fn(),
+    ...overrides,
+  };
+  return {
+    getState: () => state as unknown as AppState,
+    setState: vi.fn(),
+    subscribe: vi.fn(),
+    destroy: vi.fn(),
+    getInitialState: vi.fn(),
+  } as unknown as StoreApi<AppState>;
+}
+
+describe("task.plan.* handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dockviewState.api = { getPanel: vi.fn().mockReturnValue(null) };
+    dockviewState.isRestoringLayout = false;
+  });
+
+  it("agent created on active task: stores plan and opens panel quietly in center", () => {
+    const store = makeStore();
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_CREATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_CREATED, makePayload()) as any,
+    );
+
+    expect(store.getState().setTaskPlan).toHaveBeenCalledWith(TASK_ID, expect.any(Object));
+    expect(dockviewState.addPlanPanel).toHaveBeenCalledWith({ quiet: true, inCenter: true });
+    expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
+  });
+
+  it("agent updated with plan panel already open: does not re-open, does not mark seen", () => {
+    const store = makeStore();
+    dockviewState.api.getPanel.mockReturnValue({ id: "plan" });
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_UPDATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_UPDATED, makePayload()) as any,
+    );
+
+    expect(store.getState().setTaskPlan).toHaveBeenCalled();
+    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
+    expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
+  });
+
+  it("agent event for non-active task: does not open panel", () => {
+    const store = makeStore({
+      tasks: { activeTaskId: "other-task", activeSessionId: "s-1" },
+    });
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_CREATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_CREATED, makePayload()) as any,
+    );
+
+    expect(store.getState().setTaskPlan).toHaveBeenCalled();
+    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("agent event while layout is restoring: does not open panel", () => {
+    const store = makeStore();
+    dockviewState.isRestoringLayout = true;
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_CREATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_CREATED, makePayload()) as any,
+    );
+
+    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("user-authored create: marks plan as seen, does not open panel", () => {
+    const store = makeStore();
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_CREATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_CREATED, makePayload({ created_by: "user" })) as any,
+    );
+
+    expect(store.getState().setTaskPlan).toHaveBeenCalled();
+    expect(store.getState().markTaskPlanSeen).toHaveBeenCalledWith(TASK_ID);
+    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("delete: nulls plan and marks as seen", () => {
+    const store = makeStore();
+    const handlers = registerTaskPlansHandlers(store);
+
+    handlers[ACTION_DELETED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_DELETED, { task_id: TASK_ID }) as any,
+    );
+
+    expect(store.getState().setTaskPlan).toHaveBeenCalledWith(TASK_ID, null);
+    expect(store.getState().markTaskPlanSeen).toHaveBeenCalledWith(TASK_ID);
+  });
+});

--- a/apps/web/lib/ws/handlers/task-plans.test.ts
+++ b/apps/web/lib/ws/handlers/task-plans.test.ts
@@ -2,18 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 
-const dockviewState = {
-  api: { getPanel: vi.fn() } as { getPanel: ReturnType<typeof vi.fn> },
-  addPlanPanel: vi.fn(),
-  isRestoringLayout: false,
-};
-
-vi.mock("@/lib/state/dockview-store", () => ({
-  useDockviewStore: {
-    getState: () => dockviewState,
-  },
-}));
-
 import { registerTaskPlansHandlers } from "./task-plans";
 
 const TASK_ID = "task-1";
@@ -57,11 +45,9 @@ function makeStore(overrides: Record<string, unknown> = {}) {
 describe("task.plan.* handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dockviewState.api = { getPanel: vi.fn().mockReturnValue(null) };
-    dockviewState.isRestoringLayout = false;
   });
 
-  it("agent created on active task: stores plan and opens panel quietly in center", () => {
+  it("agent created: stores plan and does NOT mark seen", () => {
     const store = makeStore();
     const handlers = registerTaskPlansHandlers(store);
 
@@ -71,13 +57,11 @@ describe("task.plan.* handlers", () => {
     );
 
     expect(store.getState().setTaskPlan).toHaveBeenCalledWith(TASK_ID, expect.any(Object));
-    expect(dockviewState.addPlanPanel).toHaveBeenCalledWith({ quiet: true, inCenter: true });
     expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
   });
 
-  it("agent updated with plan panel already open: does not re-open, does not mark seen", () => {
+  it("agent updated: stores plan and does NOT mark seen", () => {
     const store = makeStore();
-    dockviewState.api.getPanel.mockReturnValue({ id: "plan" });
     const handlers = registerTaskPlansHandlers(store);
 
     handlers[ACTION_UPDATED]!(
@@ -86,39 +70,10 @@ describe("task.plan.* handlers", () => {
     );
 
     expect(store.getState().setTaskPlan).toHaveBeenCalled();
-    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
     expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
   });
 
-  it("agent event for non-active task: does not open panel", () => {
-    const store = makeStore({
-      tasks: { activeTaskId: "other-task", activeSessionId: "s-1" },
-    });
-    const handlers = registerTaskPlansHandlers(store);
-
-    handlers[ACTION_CREATED]!(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      makeMessage(ACTION_CREATED, makePayload()) as any,
-    );
-
-    expect(store.getState().setTaskPlan).toHaveBeenCalled();
-    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
-  });
-
-  it("agent event while layout is restoring: does not open panel", () => {
-    const store = makeStore();
-    dockviewState.isRestoringLayout = true;
-    const handlers = registerTaskPlansHandlers(store);
-
-    handlers[ACTION_CREATED]!(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      makeMessage(ACTION_CREATED, makePayload()) as any,
-    );
-
-    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
-  });
-
-  it("user-authored create: marks plan as seen, does not open panel", () => {
+  it("user-authored create: marks plan as seen", () => {
     const store = makeStore();
     const handlers = registerTaskPlansHandlers(store);
 
@@ -129,13 +84,9 @@ describe("task.plan.* handlers", () => {
 
     expect(store.getState().setTaskPlan).toHaveBeenCalled();
     expect(store.getState().markTaskPlanSeen).toHaveBeenCalledWith(TASK_ID);
-    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
   });
 
   it("user-authored update: marks seen even when task is not active", () => {
-    // Reviewer concern: if user saves the plan for a non-active task, the
-    // indicator could fire spuriously on task switch. We unconditionally mark
-    // user-authored writes as seen.
     const store = makeStore({
       tasks: { activeTaskId: "other-task", activeSessionId: "s-1" },
     });
@@ -147,10 +98,9 @@ describe("task.plan.* handlers", () => {
     );
 
     expect(store.getState().markTaskPlanSeen).toHaveBeenCalledWith(TASK_ID);
-    expect(dockviewState.addPlanPanel).not.toHaveBeenCalled();
   });
 
-  it("agent update on plan originally created by user: still arms indicator", () => {
+  it("agent update on plan originally created by user: stores plan without marking seen", () => {
     // Backend sets created_by to the last modifier on update, not the original
     // creator — so an agent update on a user-created plan emits created_by="agent".
     const store = makeStore();
@@ -163,7 +113,6 @@ describe("task.plan.* handlers", () => {
 
     expect(store.getState().setTaskPlan).toHaveBeenCalled();
     expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
-    expect(dockviewState.addPlanPanel).toHaveBeenCalledWith({ quiet: true, inCenter: true });
   });
 
   it("delete: nulls plan and marks as seen", () => {

--- a/apps/web/lib/ws/handlers/task-plans.test.ts
+++ b/apps/web/lib/ws/handlers/task-plans.test.ts
@@ -26,9 +26,13 @@ function makeMessage(action: string, payload: Record<string, unknown>) {
   return { id: "msg-1", type: "notification", action, payload };
 }
 
-function makeStore(overrides: Record<string, unknown> = {}) {
+function makeStore(
+  overrides: Record<string, unknown> = {},
+  prevPlan: Record<string, unknown> | null = null,
+) {
   const state = {
     tasks: { activeTaskId: TASK_ID, activeSessionId: "s-1" },
+    taskPlans: { byTaskId: prevPlan ? { [TASK_ID]: prevPlan } : {} },
     setTaskPlan: vi.fn(),
     markTaskPlanSeen: vi.fn(),
     ...overrides,
@@ -113,6 +117,44 @@ describe("task.plan.* handlers", () => {
 
     expect(store.getState().setTaskPlan).toHaveBeenCalled();
     expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
+  });
+
+  it("user-authored update with UNCHANGED content does NOT mark seen", () => {
+    // Editor auto-save round-trips the agent's plan content through TipTap
+    // and saves it as user-authored — same content, new updated_at. Without
+    // a content-change check this would erase the agent's unseen indicator.
+    const store = makeStore({}, makePayload({ content: "# Plan", created_by: "agent" }));
+    const handlers = registerTaskPlansHandlers(store);
+
+    const payload = makePayload({
+      content: "# Plan",
+      created_by: "user",
+      updated_at: "2026-04-20T01:00:00Z",
+    });
+    handlers[ACTION_UPDATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_UPDATED, payload) as any,
+    );
+
+    expect(store.getState().setTaskPlan).toHaveBeenCalled();
+    expect(store.getState().markTaskPlanSeen).not.toHaveBeenCalled();
+  });
+
+  it("user-authored update with CHANGED content marks seen", () => {
+    const store = makeStore({}, makePayload({ content: "# Old", created_by: "agent" }));
+    const handlers = registerTaskPlansHandlers(store);
+
+    const payload = makePayload({
+      content: "# New",
+      created_by: "user",
+      updated_at: "2026-04-20T01:00:00Z",
+    });
+    handlers[ACTION_UPDATED]!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeMessage(ACTION_UPDATED, payload) as any,
+    );
+
+    expect(store.getState().markTaskPlanSeen).toHaveBeenCalledWith(TASK_ID);
   });
 
   it("delete: nulls plan and marks as seen", () => {

--- a/apps/web/lib/ws/handlers/task-plans.ts
+++ b/apps/web/lib/ws/handlers/task-plans.ts
@@ -17,10 +17,18 @@ function handlePlanUpsert(store: StoreApi<AppState>, message: PlanMessage) {
     updated_at,
   });
 
+  console.warn("[task-plans-ws] handlePlanUpsert", {
+    type: message.type,
+    task_id,
+    created_by,
+    updated_at,
+  });
+
   // User-authored writes: mark seen so the indicator doesn't fire. Panel
   // reveal is handled reactively by usePlanPanelAutoOpen when an agent
   // writes a new version the user hasn't seen.
   if (created_by === "user") {
+    console.warn("[task-plans-ws] markSeen (user-authored)", { task_id });
     store.getState().markTaskPlanSeen(task_id);
   }
 }
@@ -31,6 +39,7 @@ export function registerTaskPlansHandlers(store: StoreApi<AppState>): WsHandlers
     "task.plan.updated": (message) => handlePlanUpsert(store, message),
     "task.plan.deleted": (message) => {
       const { task_id } = message.payload;
+      console.warn("[task-plans-ws] markSeen on delete", { task_id });
       store.getState().setTaskPlan(task_id, null);
       store.getState().markTaskPlanSeen(task_id);
     },

--- a/apps/web/lib/ws/handlers/task-plans.ts
+++ b/apps/web/lib/ws/handlers/task-plans.ts
@@ -18,18 +18,22 @@ function handlePlanUpsert(store: StoreApi<AppState>, message: PlanMessage) {
     updated_at,
   });
 
-  // Auto-open plan panel side-by-side with chat when agent writes a plan
-  if (created_by === "agent" && task_id === store.getState().tasks.activeTaskId) {
-    const dockview = useDockviewStore.getState();
-    if (dockview.isRestoringLayout) return;
-    if (dockview.api?.getPanel("plan")) return;
+  if (task_id !== store.getState().tasks.activeTaskId) return;
 
-    const activeSessionId = store.getState().tasks.activeSessionId;
-    if (!activeSessionId) return;
-
-    dockview.addPlanPanel();
-    store.getState().setActiveDocument(activeSessionId, { type: "plan", taskId: task_id });
+  if (created_by === "user") {
+    // User just saved the plan — mark as seen so no indicator fires.
+    store.getState().markTaskPlanSeen(task_id);
+    return;
   }
+
+  // Agent-authored: reveal plan panel quietly in the center group so the user
+  // sees the indicator without losing focus. If the panel is already open the
+  // indicator on the tab drives the UI.
+  const dockview = useDockviewStore.getState();
+  if (dockview.isRestoringLayout) return;
+  if (dockview.api?.getPanel("plan")) return;
+
+  dockview.addPlanPanel({ quiet: true, inCenter: true });
 }
 
 export function registerTaskPlansHandlers(store: StoreApi<AppState>): WsHandlers {
@@ -39,6 +43,7 @@ export function registerTaskPlansHandlers(store: StoreApi<AppState>): WsHandlers
     "task.plan.deleted": (message) => {
       const { task_id } = message.payload;
       store.getState().setTaskPlan(task_id, null);
+      store.getState().markTaskPlanSeen(task_id);
     },
   };
 }

--- a/apps/web/lib/ws/handlers/task-plans.ts
+++ b/apps/web/lib/ws/handlers/task-plans.ts
@@ -18,13 +18,14 @@ function handlePlanUpsert(store: StoreApi<AppState>, message: PlanMessage) {
     updated_at,
   });
 
-  if (task_id !== store.getState().tasks.activeTaskId) return;
-
+  // Mark user-authored writes as seen regardless of active task so the
+  // indicator never fires spuriously if the user switches tasks mid-save.
   if (created_by === "user") {
-    // User just saved the plan — mark as seen so no indicator fires.
     store.getState().markTaskPlanSeen(task_id);
     return;
   }
+
+  if (task_id !== store.getState().tasks.activeTaskId) return;
 
   // Agent-authored: reveal plan panel quietly in the center group so the user
   // sees the indicator without losing focus. If the panel is already open the

--- a/apps/web/lib/ws/handlers/task-plans.ts
+++ b/apps/web/lib/ws/handlers/task-plans.ts
@@ -7,6 +7,7 @@ type PlanMessage = BackendMessageMap["task.plan.created"] | BackendMessageMap["t
 
 function handlePlanUpsert(store: StoreApi<AppState>, message: PlanMessage) {
   const { task_id, id, title, content, created_by, created_at, updated_at } = message.payload;
+  const prevPlan = store.getState().taskPlans.byTaskId[task_id];
   store.getState().setTaskPlan(task_id, {
     id,
     task_id,
@@ -17,18 +18,12 @@ function handlePlanUpsert(store: StoreApi<AppState>, message: PlanMessage) {
     updated_at,
   });
 
-  console.warn("[task-plans-ws] handlePlanUpsert", {
-    type: message.type,
-    task_id,
-    created_by,
-    updated_at,
-  });
-
-  // User-authored writes: mark seen so the indicator doesn't fire. Panel
-  // reveal is handled reactively by usePlanPanelAutoOpen when an agent
-  // writes a new version the user hasn't seen.
-  if (created_by === "user") {
-    console.warn("[task-plans-ws] markSeen (user-authored)", { task_id });
+  // User-authored writes mark the plan as seen — but only when the content
+  // actually changed. The plan editor's auto-save on mount can emit a
+  // user-authored update with unchanged content (TipTap markdown round-trip
+  // normalises whitespace), which would otherwise wipe an unseen agent
+  // indicator the moment the panel opens.
+  if (created_by === "user" && prevPlan?.content !== content) {
     store.getState().markTaskPlanSeen(task_id);
   }
 }
@@ -39,7 +34,6 @@ export function registerTaskPlansHandlers(store: StoreApi<AppState>): WsHandlers
     "task.plan.updated": (message) => handlePlanUpsert(store, message),
     "task.plan.deleted": (message) => {
       const { task_id } = message.payload;
-      console.warn("[task-plans-ws] markSeen on delete", { task_id });
       store.getState().setTaskPlan(task_id, null);
       store.getState().markTaskPlanSeen(task_id);
     },

--- a/apps/web/lib/ws/handlers/task-plans.ts
+++ b/apps/web/lib/ws/handlers/task-plans.ts
@@ -2,7 +2,6 @@ import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import type { BackendMessageMap } from "@/lib/types/backend";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
-import { useDockviewStore } from "@/lib/state/dockview-store";
 
 type PlanMessage = BackendMessageMap["task.plan.created"] | BackendMessageMap["task.plan.updated"];
 
@@ -18,23 +17,12 @@ function handlePlanUpsert(store: StoreApi<AppState>, message: PlanMessage) {
     updated_at,
   });
 
-  // Mark user-authored writes as seen regardless of active task so the
-  // indicator never fires spuriously if the user switches tasks mid-save.
+  // User-authored writes: mark seen so the indicator doesn't fire. Panel
+  // reveal is handled reactively by usePlanPanelAutoOpen when an agent
+  // writes a new version the user hasn't seen.
   if (created_by === "user") {
     store.getState().markTaskPlanSeen(task_id);
-    return;
   }
-
-  if (task_id !== store.getState().tasks.activeTaskId) return;
-
-  // Agent-authored: reveal plan panel quietly in the center group so the user
-  // sees the indicator without losing focus. If the panel is already open the
-  // indicator on the tab drives the UI.
-  const dockview = useDockviewStore.getState();
-  if (dockview.isRestoringLayout) return;
-  if (dockview.api?.getPanel("plan")) return;
-
-  dockview.addPlanPanel({ quiet: true, inCenter: true });
 }
 
 export function registerTaskPlansHandlers(store: StoreApi<AppState>): WsHandlers {

--- a/apps/web/lib/ws/handlers/task-plans.ts
+++ b/apps/web/lib/ws/handlers/task-plans.ts
@@ -34,6 +34,10 @@ export function registerTaskPlansHandlers(store: StoreApi<AppState>): WsHandlers
     "task.plan.updated": (message) => handlePlanUpsert(store, message),
     "task.plan.deleted": (message) => {
       const { task_id } = message.payload;
+      // Intentionally NOT clearTaskPlan: setTaskPlan(null) preserves
+      // loadedByTaskId[taskId] = true so useTaskPlan doesn't see !isLoaded
+      // and refetch a plan that was just deleted. clearTaskPlan would drop
+      // that flag and trigger a wasted HTTP round-trip.
       store.getState().setTaskPlan(task_id, null);
       store.getState().markTaskPlanSeen(task_id);
     },


### PR DESCRIPTION
When the agent writes a plan via the kandev MCP tools, the user had no signal that the plan had landed unless they were already looking at the panel; the Plan panel now reveals itself in the center group without stealing focus and surfaces an indicator dot until the user acknowledges.

## Important Changes

- `addPlanPanel` now takes `{ groupId, quiet, inCenter }` so the WS handler can open the panel without activating it.
- Session slice tracks `lastSeenUpdatedAtByTaskId` and exposes `markTaskPlanSeen`; user-authored edits, page reloads, and focus all mark seen.
- New `PlanTab` component renders the indicator dot (mirrors `ChangesTab`'s pattern).

## Validation

- `pnpm --filter @kandev/web test` — 414/414 tests pass (includes 10 new unit tests in `lib/state/slices/session/task-plans.test.ts` and `lib/ws/handlers/task-plans.test.ts`).
- `pnpm --filter @kandev/web lint` — clean.
- `npx tsc --noEmit` — clean for this change (2 pre-existing errors on `main` for gitignored generated files are unrelated).
- `make -C apps/backend test lint` — clean (no backend changes).
- New E2E spec `apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts` covers: agent-create reveals without focus, click clears dot, update while on chat re-arms dot, update while on plan does not, page refresh shows no stale dot.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.