### PR TITLE
fix(web): show repo name instead of full path in task sidebar

### DIFF
--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -207,7 +207,9 @@ function useSidebarData(workspaceId: string | null) {
         repo.id,
         repo.provider_owner && repo.provider_name
           ? `${repo.provider_owner}/${repo.provider_name}`
-          : repo.local_path,
+          : repo.name ||
+            repo.local_path.split("/").filter(Boolean).pop() ||
+            repo.local_path,
       ]),
     );
     const titleById = new Map(allTasks.map((t) => [t.id, t.title]));

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -207,9 +207,7 @@ function useSidebarData(workspaceId: string | null) {
         repo.id,
         repo.provider_owner && repo.provider_name
           ? `${repo.provider_owner}/${repo.provider_name}`
-          : repo.name ||
-            repo.local_path.split("/").filter(Boolean).pop() ||
-            repo.local_path,
+          : repo.name || repo.local_path?.split("/").filter(Boolean).pop() || repo.local_path,
       ]),
     );
     const titleById = new Map(allTasks.map((t) => [t.id, t.title]));


### PR DESCRIPTION
Local-only repositories in the task sidebar were rendering as an absolute filesystem path (e.g. `/Users/.../icare-ride`) because the display fell back to `repo.local_path` whenever provider info was missing. The header now prefers `repo.name`, with a basename fallback for older repos that were saved without one, so local repos render as `icare-ride` and match the top breadcrumb.

## Validation

- Manual: verified the task sidebar now shows the short repo name for a local repo with no GitHub provider, and still shows `owner/repo` for GitHub-connected repos.
- CI will run `pnpm --filter @kandev/web lint` and Playwright e2e.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
