### PR TITLE
feat: configurable CLI flags per agent profile

### DIFF
--- a/apps/backend/internal/agent/agents/agent.go
+++ b/apps/backend/internal/agent/agents/agent.go
@@ -111,6 +111,10 @@ type CommandOptions struct {
 	PermissionPolicy    string          // "autonomous", "supervised", "plan"
 	PermissionValues    map[string]bool // e.g. {"allow_indexing": true}
 	AgentType           string          // for --agent flag (e.g. "task" for subagent)
+	// CLIFlagTokens are user-configured CLI flag argv tokens derived from
+	// AgentProfile.CLIFlags (only Enabled entries, shell-tokenised). Appended
+	// verbatim to the built command by every agent's BuildCommand.
+	CLIFlagTokens []string
 }
 
 // PassthroughOptions are passed to BuildPassthroughCommand.

--- a/apps/backend/internal/agent/agents/agent.go
+++ b/apps/backend/internal/agent/agents/agent.go
@@ -180,6 +180,12 @@ func (c SessionConfig) SupportsRecovery() bool {
 	return *c.CanRecover
 }
 
+// PermissionApplyMethodCLIFlag is the PermissionSetting.ApplyMethod sentinel
+// for permission flags that map to a CLI argument on the agent subprocess.
+// A typo in any one caller (e.g. "cli-flag") silently breaks the seed and
+// filter chain across agents, so the literal lives in exactly one place.
+const PermissionApplyMethodCLIFlag = "cli_flag"
+
 // PermissionSetting defines metadata for a permission setting option.
 type PermissionSetting struct {
 	Supported    bool   `json:"supported"`

--- a/apps/backend/internal/agent/agents/auggie.go
+++ b/apps/backend/internal/agent/agents/auggie.go
@@ -151,6 +151,6 @@ func (a *Auggie) InferenceConfig() *InferenceConfig {
 var auggiePermSettings = map[string]PermissionSetting{
 	"allow_indexing": {
 		Supported: true, Default: true, Label: "Allow indexing", Description: "Enable workspace indexing without confirmation",
-		ApplyMethod: "cli_flag", CLIFlag: "--allow-indexing",
+		ApplyMethod: PermissionApplyMethodCLIFlag, CLIFlag: "--allow-indexing",
 	},
 }

--- a/apps/backend/internal/agent/agents/auggie.go
+++ b/apps/backend/internal/agent/agents/auggie.go
@@ -78,13 +78,10 @@ func (a *Auggie) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
 
 func (a *Auggie) BuildCommand(opts CommandOptions) Command {
 	// Model and mode are applied via ACP session/set_model and session/set_mode
-	// after session creation — no --model CLI flag.
-	// allow_indexing is auggie-only: apply the CLI flag if the profile enables it.
-	b := Cmd("npx", "-y", auggiePkg, "--acp")
-	if opts.PermissionValues != nil && opts.PermissionValues["allow_indexing"] {
-		b = b.Flag("--allow-indexing")
-	}
-	return b.Build()
+	// after session creation — no --model CLI flag. The --allow-indexing flag
+	// used to be applied here from PermissionValues; it now flows through
+	// AgentProfile.CLIFlags and is appended by CommandBuilder.BuildCommand.
+	return Cmd("npx", "-y", auggiePkg, "--acp").Build()
 }
 
 func (a *Auggie) Runtime() *RuntimeConfig {

--- a/apps/backend/internal/agent/agents/copilot_acp.go
+++ b/apps/backend/internal/agent/agents/copilot_acp.go
@@ -122,7 +122,7 @@ var copilotPermSettings = map[string]PermissionSetting{
 		Default:     false,
 		Label:       "Allow all tools",
 		Description: "Skip confirmation for every tool call (--allow-all-tools)",
-		ApplyMethod: "cli_flag",
+		ApplyMethod: PermissionApplyMethodCLIFlag,
 		CLIFlag:     "--allow-all-tools",
 	},
 	"allow_all_paths": {
@@ -130,7 +130,7 @@ var copilotPermSettings = map[string]PermissionSetting{
 		Default:     false,
 		Label:       "Allow all paths",
 		Description: "Allow file access outside the workspace (--allow-all-paths)",
-		ApplyMethod: "cli_flag",
+		ApplyMethod: PermissionApplyMethodCLIFlag,
 		CLIFlag:     "--allow-all-paths",
 	},
 	"allow_all_urls": {
@@ -138,7 +138,7 @@ var copilotPermSettings = map[string]PermissionSetting{
 		Default:     false,
 		Label:       "Allow all URLs",
 		Description: "Allow network access to any URL (--allow-all-urls)",
-		ApplyMethod: "cli_flag",
+		ApplyMethod: PermissionApplyMethodCLIFlag,
 		CLIFlag:     "--allow-all-urls",
 	},
 	"no_ask_user": {
@@ -146,7 +146,7 @@ var copilotPermSettings = map[string]PermissionSetting{
 		Default:     false,
 		Label:       "Disable ask_user tool",
 		Description: "Agent works autonomously without asking clarifying questions (--no-ask-user)",
-		ApplyMethod: "cli_flag",
+		ApplyMethod: PermissionApplyMethodCLIFlag,
 		CLIFlag:     "--no-ask-user",
 	},
 }

--- a/apps/backend/internal/agent/agents/copilot_acp.go
+++ b/apps/backend/internal/agent/agents/copilot_acp.go
@@ -32,7 +32,7 @@ type CopilotACP struct {
 func NewCopilotACP() *CopilotACP {
 	return &CopilotACP{
 		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
+			PermSettings: copilotPermSettings,
 			Cfg: PassthroughConfig{
 				Supported:         true,
 				Label:             "CLI Passthrough",
@@ -105,7 +105,50 @@ func (a *CopilotACP) InstallScript() string {
 }
 
 func (a *CopilotACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
+	return copilotPermSettings
+}
+
+// copilotPermSettings enumerates the GitHub Copilot CLI flags that benefit
+// from being surfaced as curated profile toggles. At profile-creation time
+// these seed the AgentProfile.CLIFlags list; the launch path then consults
+// the profile (not this map) so users can freely add/toggle/remove entries.
+//
+// The CLI's `--autopilot` flag is intentionally omitted: empirical testing
+// (see acp-debug captures) shows it does not suppress session/request_permission
+// frames. Only `--allow-all-tools` and the other `--allow-all-*` flags do.
+var copilotPermSettings = map[string]PermissionSetting{
+	"allow_all_tools": {
+		Supported:   true,
+		Default:     false,
+		Label:       "Allow all tools",
+		Description: "Skip confirmation for every tool call (--allow-all-tools)",
+		ApplyMethod: "cli_flag",
+		CLIFlag:     "--allow-all-tools",
+	},
+	"allow_all_paths": {
+		Supported:   true,
+		Default:     false,
+		Label:       "Allow all paths",
+		Description: "Allow file access outside the workspace (--allow-all-paths)",
+		ApplyMethod: "cli_flag",
+		CLIFlag:     "--allow-all-paths",
+	},
+	"allow_all_urls": {
+		Supported:   true,
+		Default:     false,
+		Label:       "Allow all URLs",
+		Description: "Allow network access to any URL (--allow-all-urls)",
+		ApplyMethod: "cli_flag",
+		CLIFlag:     "--allow-all-urls",
+	},
+	"no_ask_user": {
+		Supported:   true,
+		Default:     false,
+		Label:       "Disable ask_user tool",
+		Description: "Agent works autonomously without asking clarifying questions (--no-ask-user)",
+		ApplyMethod: "cli_flag",
+		CLIFlag:     "--no-ask-user",
+	},
 }
 
 // InferenceConfig returns configuration for one-shot inference using ACP.

--- a/apps/backend/internal/agent/agents/copilot_acp_test.go
+++ b/apps/backend/internal/agent/agents/copilot_acp_test.go
@@ -1,0 +1,51 @@
+package agents
+
+import "testing"
+
+// TestCopilotACP_PermissionSettings_Curated verifies the four curated flag
+// suggestions surfaced to the profile-creation UI. These seed new profiles
+// (all disabled by default) and are the origin of the fix for Copilot's
+// permission-prompt-every-tool-call behaviour reported by users.
+func TestCopilotACP_PermissionSettings_Curated(t *testing.T) {
+	ag := NewCopilotACP()
+	settings := ag.PermissionSettings()
+
+	wantKeys := []string{"allow_all_tools", "allow_all_paths", "allow_all_urls", "no_ask_user"}
+	for _, k := range wantKeys {
+		s, ok := settings[k]
+		if !ok {
+			t.Fatalf("missing curated setting %q", k)
+		}
+		if !s.Supported {
+			t.Errorf("%q should be Supported=true", k)
+		}
+		if s.Default {
+			t.Errorf("%q should default to Enabled=false so new profiles are safe", k)
+		}
+		if s.ApplyMethod != "cli_flag" {
+			t.Errorf("%q should apply as cli_flag, got %q", k, s.ApplyMethod)
+		}
+		if s.CLIFlag == "" {
+			t.Errorf("%q must specify a CLIFlag", k)
+		}
+	}
+}
+
+// TestCopilotACP_BuildCommand_NoCLIFlagSpecialCasing confirms BuildCommand
+// itself is flag-agnostic: the cli_flags list travels through
+// CommandBuilder.BuildCommand (in the lifecycle package) which appends the
+// tokens. This test pins the bare command so any future agent drift is loud.
+func TestCopilotACP_BuildCommand_NoCLIFlagSpecialCasing(t *testing.T) {
+	ag := NewCopilotACP()
+	cmd := ag.BuildCommand(CommandOptions{})
+	got := cmd.Args()
+	want := []string{"npx", "-y", "@github/copilot", "--acp"}
+	if len(got) != len(want) {
+		t.Fatalf("argv length mismatch\n  got:  %#v\n  want: %#v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d] mismatch: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/apps/backend/internal/agent/agents/helpers.go
+++ b/apps/backend/internal/agent/agents/helpers.go
@@ -71,7 +71,7 @@ func (b *CmdBuilder) Settings(settings map[string]PermissionSetting, values map[
 		return b
 	}
 	for settingName, setting := range settings {
-		if !setting.Supported || setting.ApplyMethod != "cli_flag" || setting.CLIFlag == "" {
+		if !setting.Supported || setting.ApplyMethod != PermissionApplyMethodCLIFlag || setting.CLIFlag == "" {
 			continue
 		}
 		value, exists := values[settingName]

--- a/apps/backend/internal/agent/lifecycle/command.go
+++ b/apps/backend/internal/agent/lifecycle/command.go
@@ -18,10 +18,16 @@ func NewCommandBuilder() *CommandBuilder {
 	return &CommandBuilder{}
 }
 
-// BuildCommand builds a Command from agent config and options.
-// Delegates to the Agent.BuildCommand method.
+// BuildCommand builds a Command from agent config and options. Delegates to
+// the Agent.BuildCommand method and then appends the user-configured CLI
+// flag tokens so every agent participates in the cli_flags feature without
+// each BuildCommand needing to remember to opt in.
 func (cb *CommandBuilder) BuildCommand(ag agents.Agent, opts agents.CommandOptions) agents.Command {
-	return ag.BuildCommand(opts)
+	cmd := ag.BuildCommand(opts)
+	if len(opts.CLIFlagTokens) == 0 {
+		return cmd
+	}
+	return cmd.With().Flag(opts.CLIFlagTokens...).Build()
 }
 
 // BuildCommandString builds a command as a single string (for standalone mode)
@@ -44,6 +50,7 @@ func (cb *CommandBuilder) BuildContinueCommandString(ag agents.Agent, opts agent
 	cmd := sessionCfg.ContinueSessionCmd.With().
 		Model(ag.Runtime().ModelFlag, opts.Model).
 		Settings(ag.PermissionSettings(), opts.PermissionValues).
+		Flag(opts.CLIFlagTokens...).
 		Build()
 
 	return strings.Join(cmd.Args(), " ")

--- a/apps/backend/internal/agent/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/lifecycle/manager_launch.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/settings/cliflags"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/task/models"
 )
@@ -77,12 +78,21 @@ func (m *Manager) buildAgentCommand(req *LaunchRequest, profileInfo *AgentProfil
 	model := ""
 	autoApprove := false
 	permissionValues := make(map[string]bool)
+	var cliFlagTokens []string
 	if profileInfo != nil {
 		model = profileInfo.Model
 		autoApprove = profileInfo.AutoApprove
 		permissionValues["auto_approve"] = profileInfo.AutoApprove
 		permissionValues["allow_indexing"] = profileInfo.AllowIndexing
 		permissionValues["dangerously_skip_permissions"] = profileInfo.DangerouslySkipPermissions
+		tokens, err := cliflags.Resolve(profileInfo.CLIFlags)
+		if err != nil {
+			m.logger.Warn("failed to resolve cli_flags for profile, launching without user-configured flags",
+				zap.String("profile_id", profileInfo.ProfileID),
+				zap.Error(err))
+		} else {
+			cliFlagTokens = tokens
+		}
 	}
 	// Allow model override from request (for dynamic model switching)
 	if req.ModelOverride != "" {
@@ -99,6 +109,7 @@ func (m *Manager) buildAgentCommand(req *LaunchRequest, profileInfo *AgentProfil
 		SessionID:        sessionID,
 		AutoApprove:      autoApprove,
 		PermissionValues: permissionValues,
+		CLIFlagTokens:    cliFlagTokens,
 	}
 	return agentCommands{
 		initial:   m.commandBuilder.BuildCommandString(agentConfig, cmdOpts),

--- a/apps/backend/internal/agent/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_launch_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/executor"
+	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 )
 
 // resumeTestAgent is a minimal agent with a BuildCommand that respects the
@@ -71,6 +72,58 @@ func TestBuildAgentCommand_ResumeFlag(t *testing.T) {
 		cmds := mgr.buildAgentCommand(req, nil, ag)
 		require.Contains(t, cmds.initial, "--resume")
 		require.Contains(t, cmds.initial, "sess-456")
+	})
+}
+
+// cliFlagTestAgent is a minimal BuildCommand that produces a stable prefix
+// so tests can assert CLI flag tokens are appended after the agent's own
+// argv by CommandBuilder.BuildCommand (not by the agent itself).
+type cliFlagTestAgent struct{ testAgent }
+
+func (a *cliFlagTestAgent) BuildCommand(_ agents.CommandOptions) agents.Command {
+	return agents.Cmd("copilot", "--acp").Build()
+}
+
+func TestBuildAgentCommand_CLIFlagsAppended(t *testing.T) {
+	mgr := newTestManager()
+	ag := &cliFlagTestAgent{}
+
+	t.Run("enabled entries reach argv, disabled do not", func(t *testing.T) {
+		profile := &AgentProfileInfo{
+			ProfileID: "p1",
+			CLIFlags: []settingsmodels.CLIFlag{
+				{Flag: "--allow-all-tools", Enabled: true},
+				{Flag: "--allow-all-paths", Enabled: false}, // must be skipped
+				{Flag: "--add-dir /shared", Enabled: true},  // must be split
+			},
+		}
+		cmds := mgr.buildAgentCommand(&LaunchRequest{}, profile, ag)
+
+		require.Contains(t, cmds.initial, "--allow-all-tools")
+		require.NotContains(t, cmds.initial, "--allow-all-paths")
+		// The tokeniser splits "--add-dir /shared" into two argv elements,
+		// not one — confirm both are present.
+		require.Contains(t, cmds.initial, "--add-dir")
+		require.Contains(t, cmds.initial, "/shared")
+	})
+
+	t.Run("malformed flag does not abort launch — falls back to empty tokens", func(t *testing.T) {
+		profile := &AgentProfileInfo{
+			ProfileID: "p2",
+			CLIFlags: []settingsmodels.CLIFlag{
+				{Flag: `--broken "unterminated`, Enabled: true},
+			},
+		}
+		cmds := mgr.buildAgentCommand(&LaunchRequest{}, profile, ag)
+		// The bad flag is dropped entirely; the launch still produces the
+		// agent's base command so a user with a typo still gets their task
+		// to run, just without the flag they intended.
+		require.Equal(t, "copilot --acp", cmds.initial)
+	})
+
+	t.Run("nil profile produces bare command", func(t *testing.T) {
+		cmds := mgr.buildAgentCommand(&LaunchRequest{}, nil, ag)
+		require.Equal(t, "copilot --acp", cmds.initial)
 	})
 }
 

--- a/apps/backend/internal/agent/lifecycle/profile_resolver.go
+++ b/apps/backend/internal/agent/lifecycle/profile_resolver.go
@@ -47,6 +47,7 @@ func (r *StoreProfileResolver) ResolveProfile(ctx context.Context, profileID str
 		AutoApprove:                profile.AutoApprove,
 		DangerouslySkipPermissions: profile.DangerouslySkipPermissions,
 		AllowIndexing:              profile.AllowIndexing,
+		CLIFlags:                   profile.CLIFlags,
 		CLIPassthrough:             profile.CLIPassthrough,
 		NativeSessionResume:        nativeSessionResume,
 		SupportsMCP:                agent.SupportsMCP,

--- a/apps/backend/internal/agent/lifecycle/types.go
+++ b/apps/backend/internal/agent/lifecycle/types.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/mcpconfig"
+	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 	agentctl "github.com/kandev/kandev/internal/agentctl/client"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/task/models"
@@ -305,10 +306,13 @@ type AgentProfileInfo struct {
 	AgentName           string // e.g., "auggie", "claude", "codex"
 	Model               string // applied via ACP session/set_model at session start
 	Mode                string // applied via ACP session/set_mode at session start (empty = use agent default)
-	AllowIndexing       bool   // auggie-only CLI flag
+	AllowIndexing       bool   // Deprecated: legacy, kept so existing call sites compile; launch path reads CLIFlags.
 	CLIPassthrough      bool
 	NativeSessionResume bool // Agent supports ACP session/load for resume
 	SupportsMCP         bool
+	// CLIFlags is the resolved user-configurable list of CLI flags for this
+	// profile. Passed verbatim to cliflags.Resolve at launch time.
+	CLIFlags []settingsmodels.CLIFlag
 
 	// Deprecated: legacy permission fields, no longer consulted by the launch
 	// path. Kept so existing call sites compile during the transition.

--- a/apps/backend/internal/agent/settings/cliflags/tokenise.go
+++ b/apps/backend/internal/agent/settings/cliflags/tokenise.go
@@ -50,18 +50,18 @@ func (s *tokeniseState) step(raw string, i int) (int, error) {
 	if s.quote != 0 {
 		return s.stepInsideQuote(raw, i, ch)
 	}
-	switch {
-	case ch == '\'' || ch == '"':
+	switch ch {
+	case '\'', '"':
 		s.quote = ch
 		s.inToken = true
-	case ch == '\\':
+	case '\\':
 		if i+1 >= len(raw) {
 			return i, fmt.Errorf("trailing backslash in flag %q", raw)
 		}
 		s.current.WriteByte(raw[i+1])
 		s.inToken = true
 		return i + 1, nil
-	case ch == ' ' || ch == '\t' || ch == '\n':
+	case ' ', '\t', '\n':
 		s.flush()
 	default:
 		s.current.WriteByte(ch)

--- a/apps/backend/internal/agent/settings/cliflags/tokenise.go
+++ b/apps/backend/internal/agent/settings/cliflags/tokenise.go
@@ -15,12 +15,18 @@ import (
 )
 
 // Tokenise returns the argv tokens for a single CLIFlag entry. An empty or
-// whitespace-only input yields no tokens. Unterminated quotes are an error
-// so the user sees the mistake at save time rather than at task start.
+// whitespace-only input yields no tokens. Unterminated quotes and trailing
+// backslashes are errors so the user sees the mistake at save time rather
+// than at task start (where a silent drop would take every other enabled
+// flag down with it via cliflags.Resolve).
 func Tokenise(raw string) ([]string, error) {
 	st := &tokeniseState{}
 	for i := 0; i < len(raw); i++ {
-		i = st.step(raw, i)
+		next, err := st.step(raw, i)
+		if err != nil {
+			return nil, err
+		}
+		i = next
 	}
 	if st.quote != 0 {
 		return nil, fmt.Errorf("unterminated %c quote in flag %q", st.quote, raw)
@@ -39,7 +45,7 @@ type tokeniseState struct {
 
 // step consumes one byte at position i and returns the next index to scan.
 // Returning an advanced index is how escape handling "skips" the next byte.
-func (s *tokeniseState) step(raw string, i int) int {
+func (s *tokeniseState) step(raw string, i int) (int, error) {
 	ch := raw[i]
 	if s.quote != 0 {
 		return s.stepInsideQuote(raw, i, ch)
@@ -48,34 +54,40 @@ func (s *tokeniseState) step(raw string, i int) int {
 	case ch == '\'' || ch == '"':
 		s.quote = ch
 		s.inToken = true
-	case ch == '\\' && i+1 < len(raw):
+	case ch == '\\':
+		if i+1 >= len(raw) {
+			return i, fmt.Errorf("trailing backslash in flag %q", raw)
+		}
 		s.current.WriteByte(raw[i+1])
 		s.inToken = true
-		return i + 1
+		return i + 1, nil
 	case ch == ' ' || ch == '\t' || ch == '\n':
 		s.flush()
 	default:
 		s.current.WriteByte(ch)
 		s.inToken = true
 	}
-	return i
+	return i, nil
 }
 
 // stepInsideQuote handles the quoted-string sub-scanner: either the quote
 // closes, a double-quote backslash-escape consumes the next byte, or a byte
 // is appended verbatim.
-func (s *tokeniseState) stepInsideQuote(raw string, i int, ch byte) int {
+func (s *tokeniseState) stepInsideQuote(raw string, i int, ch byte) (int, error) {
 	if ch == s.quote {
 		s.quote = 0
-		return i
+		return i, nil
 	}
-	if ch == '\\' && s.quote == '"' && i+1 < len(raw) {
+	if ch == '\\' && s.quote == '"' {
+		if i+1 >= len(raw) {
+			return i, fmt.Errorf("trailing backslash inside quote in flag %q", raw)
+		}
 		s.current.WriteByte(raw[i+1])
-		return i + 1
+		return i + 1, nil
 	}
 	s.current.WriteByte(ch)
 	s.inToken = true
-	return i
+	return i, nil
 }
 
 func (s *tokeniseState) flush() {

--- a/apps/backend/internal/agent/settings/cliflags/tokenise.go
+++ b/apps/backend/internal/agent/settings/cliflags/tokenise.go
@@ -1,0 +1,106 @@
+// Package cliflags converts user-authored CLI-flag strings (as stored on
+// AgentProfile.CLIFlags) into argv token slices suitable for exec.Cmd.
+//
+// The input is POSIX-ish: whitespace splits tokens, single and double quotes
+// group tokens verbatim, and backslash escapes the next byte. This matches
+// what a user would type in a shell without invoking any actual shell
+// interpretation, so the result is safe to pass directly as Args.
+package cliflags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kandev/kandev/internal/agent/settings/models"
+)
+
+// Tokenise returns the argv tokens for a single CLIFlag entry. An empty or
+// whitespace-only input yields no tokens. Unterminated quotes are an error
+// so the user sees the mistake at save time rather than at task start.
+func Tokenise(raw string) ([]string, error) {
+	st := &tokeniseState{}
+	for i := 0; i < len(raw); i++ {
+		i = st.step(raw, i)
+	}
+	if st.quote != 0 {
+		return nil, fmt.Errorf("unterminated %c quote in flag %q", st.quote, raw)
+	}
+	st.flush()
+	return st.tokens, nil
+}
+
+// tokeniseState carries the scanner state between step calls.
+type tokeniseState struct {
+	tokens  []string
+	current strings.Builder
+	inToken bool
+	quote   byte // 0, '\'', or '"'
+}
+
+// step consumes one byte at position i and returns the next index to scan.
+// Returning an advanced index is how escape handling "skips" the next byte.
+func (s *tokeniseState) step(raw string, i int) int {
+	ch := raw[i]
+	if s.quote != 0 {
+		return s.stepInsideQuote(raw, i, ch)
+	}
+	switch {
+	case ch == '\'' || ch == '"':
+		s.quote = ch
+		s.inToken = true
+	case ch == '\\' && i+1 < len(raw):
+		s.current.WriteByte(raw[i+1])
+		s.inToken = true
+		return i + 1
+	case ch == ' ' || ch == '\t' || ch == '\n':
+		s.flush()
+	default:
+		s.current.WriteByte(ch)
+		s.inToken = true
+	}
+	return i
+}
+
+// stepInsideQuote handles the quoted-string sub-scanner: either the quote
+// closes, a double-quote backslash-escape consumes the next byte, or a byte
+// is appended verbatim.
+func (s *tokeniseState) stepInsideQuote(raw string, i int, ch byte) int {
+	if ch == s.quote {
+		s.quote = 0
+		return i
+	}
+	if ch == '\\' && s.quote == '"' && i+1 < len(raw) {
+		s.current.WriteByte(raw[i+1])
+		return i + 1
+	}
+	s.current.WriteByte(ch)
+	s.inToken = true
+	return i
+}
+
+func (s *tokeniseState) flush() {
+	if !s.inToken {
+		return
+	}
+	s.tokens = append(s.tokens, s.current.String())
+	s.current.Reset()
+	s.inToken = false
+}
+
+// Resolve walks a profile's CLIFlags list and returns the concatenated argv
+// tokens for every Enabled entry. Disabled entries are skipped silently;
+// malformed entries halt the walk with an error that identifies the offender.
+func Resolve(flags []models.CLIFlag) ([]string, error) {
+	var out []string
+	for i, f := range flags {
+		if !f.Enabled {
+			continue
+		}
+		tokens, err := Tokenise(f.Flag)
+		if err != nil {
+			return nil, fmt.Errorf("cli_flags[%d]: %w", i, err)
+		}
+		out = append(out, tokens...)
+	}
+	return out, nil
+}

--- a/apps/backend/internal/agent/settings/cliflags/tokenise.go
+++ b/apps/backend/internal/agent/settings/cliflags/tokenise.go
@@ -29,7 +29,7 @@ func Tokenise(raw string) ([]string, error) {
 		i = next
 	}
 	if st.quote != 0 {
-		return nil, fmt.Errorf("unterminated %c quote in flag %q", st.quote, raw)
+		return nil, fmt.Errorf("unterminated %c quote", st.quote)
 	}
 	st.flush()
 	return st.tokens, nil
@@ -56,7 +56,7 @@ func (s *tokeniseState) step(raw string, i int) (int, error) {
 		s.inToken = true
 	case '\\':
 		if i+1 >= len(raw) {
-			return i, fmt.Errorf("trailing backslash in flag %q", raw)
+			return i, fmt.Errorf("trailing backslash")
 		}
 		s.current.WriteByte(raw[i+1])
 		s.inToken = true
@@ -80,7 +80,7 @@ func (s *tokeniseState) stepInsideQuote(raw string, i int, ch byte) (int, error)
 	}
 	if ch == '\\' && s.quote == '"' {
 		if i+1 >= len(raw) {
-			return i, fmt.Errorf("trailing backslash inside quote in flag %q", raw)
+			return i, fmt.Errorf("trailing backslash inside %c quote", s.quote)
 		}
 		s.current.WriteByte(raw[i+1])
 		return i + 1, nil

--- a/apps/backend/internal/agent/settings/cliflags/tokenise_test.go
+++ b/apps/backend/internal/agent/settings/cliflags/tokenise_test.go
@@ -28,6 +28,8 @@ func TestTokenise(t *testing.T) {
 		{name: "tabs between tokens", input: "--a\t1", want: []string{"--a", "1"}},
 		{name: "unterminated double quote", input: `--msg "hi`, wantErr: true},
 		{name: "unterminated single quote", input: `--msg 'hi`, wantErr: true},
+		{name: "trailing backslash unquoted", input: `--flag foo\`, wantErr: true},
+		{name: "trailing backslash inside dq", input: `--msg "hi\`, wantErr: true},
 		{name: "empty quoted string yields empty token", input: `--empty ""`, want: []string{"--empty", ""}},
 	}
 	for _, tc := range cases {

--- a/apps/backend/internal/agent/settings/cliflags/tokenise_test.go
+++ b/apps/backend/internal/agent/settings/cliflags/tokenise_test.go
@@ -82,6 +82,21 @@ func TestResolve_ErrorPointsToOffendingIndex(t *testing.T) {
 	}
 }
 
+// TestTokenise_ErrorsOmitRawInput confirms the error messages surface the
+// error kind and position without embedding the user-authored flag string.
+// Launch-time fallback logs these errors; raw flag content could carry
+// paths or tokens that shouldn't end up in structured logs.
+func TestTokenise_ErrorsOmitRawInput(t *testing.T) {
+	sensitive := `--config "/home/u/.secret/token`
+	_, err := Tokenise(sensitive)
+	if err == nil {
+		t.Fatal("expected error for unterminated quote")
+	}
+	if strings.Contains(err.Error(), "/home/u/.secret/token") {
+		t.Errorf("error should not echo raw flag contents, got: %v", err)
+	}
+}
+
 func TestResolve_AllDisabled_ReturnsNil(t *testing.T) {
 	flags := []models.CLIFlag{
 		{Flag: "--a", Enabled: false},

--- a/apps/backend/internal/agent/settings/cliflags/tokenise_test.go
+++ b/apps/backend/internal/agent/settings/cliflags/tokenise_test.go
@@ -1,0 +1,95 @@
+package cliflags
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/settings/models"
+)
+
+func TestTokenise(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: nil},
+		{name: "whitespace only", input: "   \t  ", want: nil},
+		{name: "single flag", input: "--allow-all-tools", want: []string{"--allow-all-tools"}},
+		{name: "flag with value", input: "--add-dir /shared", want: []string{"--add-dir", "/shared"}},
+		{name: "flag eq value", input: "--foo=bar", want: []string{"--foo=bar"}},
+		{name: "double quoted value", input: `--msg "hello world"`, want: []string{"--msg", "hello world"}},
+		{name: "single quoted value", input: `--msg 'hello world'`, want: []string{"--msg", "hello world"}},
+		{name: "escaped space", input: `--path /tmp/my\ dir`, want: []string{"--path", "/tmp/my dir"}},
+		{name: "escaped quote inside dq", input: `--json "{\"a\":1}"`, want: []string{"--json", `{"a":1}`}},
+		{name: "multiple tokens", input: "--a 1 --b 2", want: []string{"--a", "1", "--b", "2"}},
+		{name: "tabs between tokens", input: "--a\t1", want: []string{"--a", "1"}},
+		{name: "unterminated double quote", input: `--msg "hi`, wantErr: true},
+		{name: "unterminated single quote", input: `--msg 'hi`, wantErr: true},
+		{name: "empty quoted string yields empty token", input: `--empty ""`, want: []string{"--empty", ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Tokenise(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got tokens %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("tokens mismatch\n  got:  %#v\n  want: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	flags := []models.CLIFlag{
+		{Flag: "--allow-all-tools", Enabled: true},
+		{Flag: "--allow-all-paths", Enabled: false}, // should be skipped
+		{Flag: "--add-dir /shared", Enabled: true},
+		{Flag: "--max-continues 5", Enabled: true},
+	}
+	got, err := Resolve(flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"--allow-all-tools", "--add-dir", "/shared", "--max-continues", "5"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("resolved tokens mismatch\n  got:  %#v\n  want: %#v", got, want)
+	}
+}
+
+func TestResolve_ErrorPointsToOffendingIndex(t *testing.T) {
+	flags := []models.CLIFlag{
+		{Flag: "--ok", Enabled: true},
+		{Flag: `--broken "unterminated`, Enabled: true},
+	}
+	_, err := Resolve(flags)
+	if err == nil {
+		t.Fatal("expected error for unterminated quote")
+	}
+	if !strings.Contains(err.Error(), "cli_flags[1]") {
+		t.Errorf("error should identify offending index, got: %v", err)
+	}
+}
+
+func TestResolve_AllDisabled_ReturnsNil(t *testing.T) {
+	flags := []models.CLIFlag{
+		{Flag: "--a", Enabled: false},
+		{Flag: "--b", Enabled: false},
+	}
+	got, err := Resolve(flags)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil tokens, got %#v", got)
+	}
+}

--- a/apps/backend/internal/agent/settings/controller/agent_config.go
+++ b/apps/backend/internal/agent/settings/controller/agent_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/hostutility"
 	"github.com/kandev/kandev/internal/agent/mcpconfig"
+	"github.com/kandev/kandev/internal/agent/settings/cliflags"
 	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/agent/settings/models"
 	"go.uber.org/zap"
@@ -166,6 +167,7 @@ type CommandPreviewRequest struct {
 	Model              string
 	PermissionSettings map[string]bool
 	CLIPassthrough     bool
+	CLIFlags           []dto.CLIFlagDTO
 }
 
 // PreviewAgentCommand generates a preview of the CLI command that will be executed
@@ -174,6 +176,12 @@ func (c *Controller) PreviewAgentCommand(ctx context.Context, agentName string, 
 	if !ok {
 		return nil, fmt.Errorf("agent type %q not found in registry", agentName)
 	}
+
+	// Resolve the user-configured cli_flags list into argv tokens. The
+	// launch path does the same via cliflags.Resolve; mirroring it here
+	// keeps the preview faithful to what the agent subprocess will see.
+	// Tolerate malformed entries silently — the preview is informational.
+	cliFlagTokens, _ := cliflags.Resolve(cliFlagsFromDTO(req.CLIFlags))
 
 	var cmd agents.Command
 	if ptAgent, ok := agentConfig.(agents.PassthroughAgent); ok && req.CLIPassthrough {
@@ -185,7 +193,11 @@ func (c *Controller) PreviewAgentCommand(ctx context.Context, agentName string, 
 		cmd = agentConfig.BuildCommand(agents.CommandOptions{
 			Model:            req.Model,
 			PermissionValues: req.PermissionSettings,
+			CLIFlagTokens:    cliFlagTokens,
 		})
+	}
+	if len(cliFlagTokens) > 0 {
+		cmd = cmd.With().Flag(cliFlagTokens...).Build()
 	}
 
 	return &dto.CommandPreviewResponse{

--- a/apps/backend/internal/agent/settings/controller/agent_crud.go
+++ b/apps/backend/internal/agent/settings/controller/agent_crud.go
@@ -140,6 +140,11 @@ func (c *Controller) findMatchedAvailability(name string, results []discovery.Av
 func (c *Controller) createAgentProfiles(ctx context.Context, agentID, displayName string, profileReqs []CreateAgentProfileRequest, agentConfig agents.Agent) ([]*models.AgentProfile, error) {
 	profiles := make([]*models.AgentProfile, 0, len(profileReqs))
 	for _, profileReq := range profileReqs {
+		if profileReq.CLIFlags != nil {
+			if err := validateCLIFlagDTOs(profileReq.CLIFlags); err != nil {
+				return nil, err
+			}
+		}
 		cliFlags := cliFlagsFromDTO(profileReq.CLIFlags)
 		if profileReq.CLIFlags == nil {
 			cliFlags = seedCLIFlags(agentConfig)

--- a/apps/backend/internal/agent/settings/controller/agent_crud.go
+++ b/apps/backend/internal/agent/settings/controller/agent_crud.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/discovery"
 	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/agent/settings/models"
@@ -57,6 +58,10 @@ type CreateAgentProfileRequest struct {
 	Name  string
 	Model string
 	Mode  string
+	// CLIFlags is the explicit list to persist. When nil the list is seeded
+	// from the agent's curated PermissionSettings() catalogue (all disabled
+	// by default) so a fresh profile opens with the agent's suggestions.
+	CLIFlags []dto.CLIFlagDTO
 }
 
 func (c *Controller) CreateAgent(ctx context.Context, req CreateAgentRequest) (*dto.AgentDTO, error) {
@@ -95,7 +100,7 @@ func (c *Controller) CreateAgent(ctx context.Context, req CreateAgentRequest) (*
 	if err := c.repo.CreateAgent(ctx, agent); err != nil {
 		return nil, err
 	}
-	profiles, err := c.createAgentProfiles(ctx, agent.ID, displayName, req.Profiles)
+	profiles, err := c.createAgentProfiles(ctx, agent.ID, displayName, req.Profiles, agentConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -132,15 +137,20 @@ func (c *Controller) findMatchedAvailability(name string, results []discovery.Av
 	return nil, fmt.Errorf("unknown agent: %s", name)
 }
 
-func (c *Controller) createAgentProfiles(ctx context.Context, agentID, displayName string, profileReqs []CreateAgentProfileRequest) ([]*models.AgentProfile, error) {
+func (c *Controller) createAgentProfiles(ctx context.Context, agentID, displayName string, profileReqs []CreateAgentProfileRequest, agentConfig agents.Agent) ([]*models.AgentProfile, error) {
 	profiles := make([]*models.AgentProfile, 0, len(profileReqs))
 	for _, profileReq := range profileReqs {
+		cliFlags := cliFlagsFromDTO(profileReq.CLIFlags)
+		if profileReq.CLIFlags == nil {
+			cliFlags = seedCLIFlags(agentConfig)
+		}
 		profile := &models.AgentProfile{
 			AgentID:          agentID,
 			Name:             profileReq.Name,
 			AgentDisplayName: displayName,
 			Model:            profileReq.Model,
 			Mode:             profileReq.Mode,
+			CLIFlags:         cliFlags,
 		}
 		if err := c.repo.CreateAgentProfile(ctx, profile); err != nil {
 			return nil, err

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/agent/agents"
+	"github.com/kandev/kandev/internal/agent/settings/cliflags"
 	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/agent/settings/models"
 )
@@ -46,6 +47,8 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 	cliFlags := cliFlagsFromDTO(req.CLIFlags)
 	if req.CLIFlags == nil {
 		cliFlags = seedCLIFlags(agentConfig)
+	} else if err := validateCLIFlagDTOs(req.CLIFlags); err != nil {
+		return nil, err
 	}
 	profile := &models.AgentProfile{
 		AgentID:          req.AgentID,
@@ -148,12 +151,20 @@ func (c *Controller) UpdateProfile(ctx context.Context, req UpdateProfileRequest
 	return &result, nil
 }
 
-// validateCLIFlagDTOs rejects entries with an empty flag string. An empty
-// description is allowed (custom flags often don't have one).
+// validateCLIFlagDTOs rejects entries with an empty flag string or malformed
+// shell tokens (unterminated quotes, trailing backslash). Empty descriptions
+// are allowed (custom flags often don't have one). Tokenising here keeps the
+// launch path's cliflags.Resolve error branch unreachable in practice: a
+// single bad entry must not silently drop every other enabled flag at task
+// start, which is what would happen if we let it slip through to the
+// subprocess builder.
 func validateCLIFlagDTOs(in []dto.CLIFlagDTO) error {
 	for i, f := range in {
 		if strings.TrimSpace(f.Flag) == "" {
 			return fmt.Errorf("cli_flags[%d].flag is required", i)
+		}
+		if _, err := cliflags.Tokenise(f.Flag); err != nil {
+			return fmt.Errorf("cli_flags[%d]: %w", i, err)
 		}
 	}
 	return nil

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -76,7 +76,7 @@ func seedCLIFlags(agent agents.Agent) []models.CLIFlag {
 	settings := agent.PermissionSettings()
 	flags := make([]models.CLIFlag, 0, len(settings))
 	for _, s := range settings {
-		if !s.Supported || s.ApplyMethod != "cli_flag" || s.CLIFlag == "" {
+		if !s.Supported || s.ApplyMethod != agents.PermissionApplyMethodCLIFlag || s.CLIFlag == "" {
 			continue
 		}
 		flagText := s.CLIFlag

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -3,10 +3,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/agent/settings/models"
 )
@@ -18,6 +20,11 @@ type CreateProfileRequest struct {
 	Mode           string
 	AllowIndexing  bool
 	CLIPassthrough bool
+	// CLIFlags is the explicit list to persist. When nil, the profile is
+	// seeded from the agent's curated PermissionSettings() list so a fresh
+	// profile opens with the agent's recommended flags (all disabled by
+	// default unless the curated entry specifies Default: true).
+	CLIFlags []dto.CLIFlagDTO
 }
 
 func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest) (*dto.AgentProfileDTO, error) {
@@ -36,6 +43,10 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 	if err != nil {
 		return nil, err
 	}
+	cliFlags := cliFlagsFromDTO(req.CLIFlags)
+	if req.CLIFlags == nil {
+		cliFlags = seedCLIFlags(agentConfig)
+	}
 	profile := &models.AgentProfile{
 		AgentID:          req.AgentID,
 		Name:             req.Name,
@@ -44,6 +55,7 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 		Mode:             req.Mode,
 		AllowIndexing:    req.AllowIndexing,
 		CLIPassthrough:   req.CLIPassthrough,
+		CLIFlags:         cliFlags,
 		UserModified:     true,
 	}
 	if err := c.repo.CreateAgentProfile(ctx, profile); err != nil {
@@ -53,6 +65,38 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 	return &result, nil
 }
 
+// seedCLIFlags builds the default cli_flags list for a new profile from the
+// agent's curated PermissionSettings() catalogue. Only entries that target a
+// CLI flag are included; per-flag metadata (description, flag text, default
+// enabled) is copied into the row so the profile is self-contained.
+func seedCLIFlags(agent agents.Agent) []models.CLIFlag {
+	settings := agent.PermissionSettings()
+	flags := make([]models.CLIFlag, 0, len(settings))
+	for _, s := range settings {
+		if !s.Supported || s.ApplyMethod != "cli_flag" || s.CLIFlag == "" {
+			continue
+		}
+		flagText := s.CLIFlag
+		if s.CLIFlagValue != "" {
+			flagText = s.CLIFlag + " " + s.CLIFlagValue
+		}
+		flags = append(flags, models.CLIFlag{
+			Description: firstNonEmpty(s.Description, s.Label),
+			Flag:        flagText,
+			Enabled:     s.Default,
+		})
+	}
+	sort.Slice(flags, func(i, j int) bool { return flags[i].Flag < flags[j].Flag })
+	return flags
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
 type UpdateProfileRequest struct {
 	ID             string
 	Name           *string
@@ -60,6 +104,9 @@ type UpdateProfileRequest struct {
 	Mode           *string
 	AllowIndexing  *bool
 	CLIPassthrough *bool
+	// CLIFlags replaces the entire list when non-nil. Nil means "leave
+	// unchanged" — the UI always sends the full desired list on save.
+	CLIFlags *[]dto.CLIFlagDTO
 }
 
 func (c *Controller) UpdateProfile(ctx context.Context, req UpdateProfileRequest) (*dto.AgentProfileDTO, error) {
@@ -87,12 +134,29 @@ func (c *Controller) UpdateProfile(ctx context.Context, req UpdateProfileRequest
 	if req.CLIPassthrough != nil {
 		profile.CLIPassthrough = *req.CLIPassthrough
 	}
+	if req.CLIFlags != nil {
+		if err := validateCLIFlagDTOs(*req.CLIFlags); err != nil {
+			return nil, err
+		}
+		profile.CLIFlags = cliFlagsFromDTO(*req.CLIFlags)
+	}
 	profile.UserModified = true
 	if err := c.repo.UpdateAgentProfile(ctx, profile); err != nil {
 		return nil, err
 	}
 	result := toProfileDTO(profile)
 	return &result, nil
+}
+
+// validateCLIFlagDTOs rejects entries with an empty flag string. An empty
+// description is allowed (custom flags often don't have one).
+func validateCLIFlagDTOs(in []dto.CLIFlagDTO) error {
+	for i, f := range in {
+		if strings.TrimSpace(f.Flag) == "" {
+			return fmt.Errorf("cli_flags[%d].flag is required", i)
+		}
+	}
+	return nil
 }
 
 func (c *Controller) DeleteProfile(ctx context.Context, id string, force bool) (*dto.AgentProfileDTO, error) {
@@ -192,11 +256,28 @@ func toProfileDTO(profile *models.AgentProfile) dto.AgentProfileDTO {
 		Model:            profile.Model,
 		Mode:             profile.Mode,
 		AllowIndexing:    profile.AllowIndexing,
+		CLIFlags:         cliFlagsToDTO(profile.CLIFlags),
 		CLIPassthrough:   profile.CLIPassthrough,
 		UserModified:     profile.UserModified,
 		CreatedAt:        profile.CreatedAt,
 		UpdatedAt:        profile.UpdatedAt,
 	}
+}
+
+func cliFlagsToDTO(in []models.CLIFlag) []dto.CLIFlagDTO {
+	out := make([]dto.CLIFlagDTO, len(in))
+	for i, f := range in {
+		out[i] = dto.CLIFlagDTO{Description: f.Description, Flag: f.Flag, Enabled: f.Enabled}
+	}
+	return out
+}
+
+func cliFlagsFromDTO(in []dto.CLIFlagDTO) []models.CLIFlag {
+	out := make([]models.CLIFlag, len(in))
+	for i, f := range in {
+		out[i] = models.CLIFlag{Description: f.Description, Flag: f.Flag, Enabled: f.Enabled}
+	}
+	return out
 }
 
 // resolveProfileNameForModel looks up the agent by ID, fetches its model list (using cache),

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -163,8 +163,17 @@ func validateCLIFlagDTOs(in []dto.CLIFlagDTO) error {
 		if strings.TrimSpace(f.Flag) == "" {
 			return fmt.Errorf("cli_flags[%d].flag is required", i)
 		}
-		if _, err := cliflags.Tokenise(f.Flag); err != nil {
+		tokens, err := cliflags.Tokenise(f.Flag)
+		if err != nil {
 			return fmt.Errorf("cli_flags[%d]: %w", i, err)
+		}
+		// Reject entries where the primary token (the flag name itself) is
+		// empty — e.g. `""` or `''` passes TrimSpace but tokenises to a
+		// single blank argv element, which would reach the subprocess
+		// argv and likely confuse the agent. Secondary tokens can still
+		// be empty (`--empty ""` legitimately passes an empty value).
+		if len(tokens) == 0 || tokens[0] == "" {
+			return fmt.Errorf("cli_flags[%d].flag is required", i)
 		}
 	}
 	return nil

--- a/apps/backend/internal/agent/settings/controller/profile_crud_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_test.go
@@ -71,6 +71,9 @@ func TestValidateCLIFlagDTOs(t *testing.T) {
 		{name: "whitespace flag rejected", flags: []dto.CLIFlagDTO{{Flag: "   "}}, wantErr: true},
 		{name: "unterminated quote rejected", flags: []dto.CLIFlagDTO{{Flag: `--msg "hi`}}, wantErr: true},
 		{name: "trailing backslash rejected", flags: []dto.CLIFlagDTO{{Flag: `--path foo\`}}, wantErr: true},
+		{name: "double-quoted empty flag rejected", flags: []dto.CLIFlagDTO{{Flag: `""`}}, wantErr: true},
+		{name: "single-quoted empty flag rejected", flags: []dto.CLIFlagDTO{{Flag: `''`}}, wantErr: true},
+		{name: "flag with empty quoted value accepted", flags: []dto.CLIFlagDTO{{Flag: `--empty ""`}}},
 		{name: "empty list accepted", flags: []dto.CLIFlagDTO{}},
 	}
 	for _, tc := range cases {

--- a/apps/backend/internal/agent/settings/controller/profile_crud_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_test.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/agents"
+	"github.com/kandev/kandev/internal/agent/settings/dto"
+)
+
+// TestSeedCLIFlags_FromCopilot verifies that a fresh Copilot profile gets
+// the four curated CLI-flag suggestions with Enabled=false, so users see
+// them in the UI but nothing changes subprocess behaviour until opt-in.
+func TestSeedCLIFlags_FromCopilot(t *testing.T) {
+	ag := agents.NewCopilotACP()
+	flags := seedCLIFlags(ag)
+
+	wantFlags := map[string]bool{
+		"--allow-all-tools": false,
+		"--allow-all-paths": false,
+		"--allow-all-urls":  false,
+		"--no-ask-user":     false,
+	}
+	if len(flags) != len(wantFlags) {
+		t.Fatalf("expected %d seeded flags, got %d: %+v", len(wantFlags), len(flags), flags)
+	}
+	for _, f := range flags {
+		want, ok := wantFlags[f.Flag]
+		if !ok {
+			t.Errorf("unexpected seeded flag: %q", f.Flag)
+			continue
+		}
+		if f.Enabled != want {
+			t.Errorf("%q: Enabled=%v, want %v", f.Flag, f.Enabled, want)
+		}
+		if f.Description == "" {
+			t.Errorf("%q: missing Description", f.Flag)
+		}
+	}
+	// Stable ordering — flags must sort lexicographically so the UI shows
+	// them in the same order every time.
+	for i := 1; i < len(flags); i++ {
+		if flags[i-1].Flag >= flags[i].Flag {
+			t.Errorf("flags not sorted: %q >= %q", flags[i-1].Flag, flags[i].Flag)
+		}
+	}
+}
+
+// TestSeedCLIFlags_EmptyForAgentWithNoCurated handles the common case:
+// most ACP agents advertise no curated flags so new profiles get an empty
+// list and the user can still add custom flags.
+func TestSeedCLIFlags_EmptyForAgentWithNoCurated(t *testing.T) {
+	ag := agents.NewClaudeACP()
+	flags := seedCLIFlags(ag)
+	if len(flags) != 0 {
+		t.Errorf("expected no curated flags for claude-acp, got %+v", flags)
+	}
+}
+
+// TestValidateCLIFlagDTOs rejects entries whose flag text is empty or
+// whitespace only. Empty descriptions are allowed (custom flags often
+// don't have one).
+func TestValidateCLIFlagDTOs(t *testing.T) {
+	cases := []struct {
+		name    string
+		flags   []dto.CLIFlagDTO
+		wantErr bool
+	}{
+		{name: "valid", flags: []dto.CLIFlagDTO{{Flag: "--ok", Enabled: true}}},
+		{name: "valid with empty description", flags: []dto.CLIFlagDTO{{Flag: "--x"}}},
+		{name: "empty flag rejected", flags: []dto.CLIFlagDTO{{Flag: ""}}, wantErr: true},
+		{name: "whitespace flag rejected", flags: []dto.CLIFlagDTO{{Flag: "   "}}, wantErr: true},
+		{name: "empty list accepted", flags: []dto.CLIFlagDTO{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCLIFlagDTOs(tc.flags)
+			if tc.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agent/settings/controller/profile_crud_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_test.go
@@ -69,6 +69,8 @@ func TestValidateCLIFlagDTOs(t *testing.T) {
 		{name: "valid with empty description", flags: []dto.CLIFlagDTO{{Flag: "--x"}}},
 		{name: "empty flag rejected", flags: []dto.CLIFlagDTO{{Flag: ""}}, wantErr: true},
 		{name: "whitespace flag rejected", flags: []dto.CLIFlagDTO{{Flag: "   "}}, wantErr: true},
+		{name: "unterminated quote rejected", flags: []dto.CLIFlagDTO{{Flag: `--msg "hi`}}, wantErr: true},
+		{name: "trailing backslash rejected", flags: []dto.CLIFlagDTO{{Flag: `--path foo\`}}, wantErr: true},
 		{name: "empty list accepted", flags: []dto.CLIFlagDTO{}},
 	}
 	for _, tc := range cases {

--- a/apps/backend/internal/agent/settings/dto/dto.go
+++ b/apps/backend/internal/agent/settings/dto/dto.go
@@ -7,17 +7,27 @@ import (
 )
 
 type AgentProfileDTO struct {
-	ID               string    `json:"id"`
-	AgentID          string    `json:"agent_id"`
-	Name             string    `json:"name"`
-	AgentDisplayName string    `json:"agent_display_name"`
-	Model            string    `json:"model"`
-	Mode             string    `json:"mode,omitempty"`
-	AllowIndexing    bool      `json:"allow_indexing"`
-	CLIPassthrough   bool      `json:"cli_passthrough"`
-	UserModified     bool      `json:"user_modified"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID               string       `json:"id"`
+	AgentID          string       `json:"agent_id"`
+	Name             string       `json:"name"`
+	AgentDisplayName string       `json:"agent_display_name"`
+	Model            string       `json:"model"`
+	Mode             string       `json:"mode,omitempty"`
+	AllowIndexing    bool         `json:"allow_indexing"` // Deprecated: use CLIFlags. Retained for legacy clients.
+	CLIFlags         []CLIFlagDTO `json:"cli_flags"`
+	CLIPassthrough   bool         `json:"cli_passthrough"`
+	UserModified     bool         `json:"user_modified"`
+	CreatedAt        time.Time    `json:"created_at"`
+	UpdatedAt        time.Time    `json:"updated_at"`
+}
+
+// CLIFlagDTO mirrors models.CLIFlag on the wire. Each entry is one user-facing
+// CLI argument on a profile; at launch time the `flag` string is shell-split
+// and only entries with `enabled:true` reach the agent subprocess argv.
+type CLIFlagDTO struct {
+	Description string `json:"description"`
+	Flag        string `json:"flag"`
+	Enabled     bool   `json:"enabled"`
 }
 
 type TUIConfigDTO struct {

--- a/apps/backend/internal/agent/settings/handlers/handlers.go
+++ b/apps/backend/internal/agent/settings/handlers/handlers.go
@@ -122,9 +122,10 @@ type createAgentRequest struct {
 }
 
 type createAgentProfileRequest struct {
-	Name  string `json:"name"`
-	Model string `json:"model"`
-	Mode  string `json:"mode,omitempty"`
+	Name     string           `json:"name"`
+	Model    string           `json:"model"`
+	Mode     string           `json:"mode,omitempty"`
+	CLIFlags []dto.CLIFlagDTO `json:"cli_flags,omitempty"`
 }
 
 func (h *Handlers) httpCreateAgent(c *gin.Context) {
@@ -144,9 +145,10 @@ func (h *Handlers) httpCreateAgent(c *gin.Context) {
 			return
 		}
 		profiles = append(profiles, controller.CreateAgentProfileRequest{
-			Name:  profile.Name,
-			Model: profile.Model,
-			Mode:  profile.Mode,
+			Name:     profile.Name,
+			Model:    profile.Model,
+			Mode:     profile.Mode,
+			CLIFlags: profile.CLIFlags,
 		})
 	}
 	resp, err := h.controller.CreateAgent(c.Request.Context(), controller.CreateAgentRequest{

--- a/apps/backend/internal/agent/settings/handlers/handlers.go
+++ b/apps/backend/internal/agent/settings/handlers/handlers.go
@@ -415,9 +415,10 @@ func (h *Handlers) httpDeleteProfile(c *gin.Context) {
 }
 
 type commandPreviewRequest struct {
-	Model              string          `json:"model"`
-	PermissionSettings map[string]bool `json:"permission_settings"`
-	CLIPassthrough     bool            `json:"cli_passthrough"`
+	Model              string           `json:"model"`
+	PermissionSettings map[string]bool  `json:"permission_settings"`
+	CLIPassthrough     bool             `json:"cli_passthrough"`
+	CLIFlags           []dto.CLIFlagDTO `json:"cli_flags"`
 }
 
 func (h *Handlers) httpPreviewAgentCommand(c *gin.Context) {
@@ -437,6 +438,7 @@ func (h *Handlers) httpPreviewAgentCommand(c *gin.Context) {
 		Model:              body.Model,
 		PermissionSettings: body.PermissionSettings,
 		CLIPassthrough:     body.CLIPassthrough,
+		CLIFlags:           body.CLIFlags,
 	})
 	if err != nil {
 		h.logger.Error("failed to preview agent command", zap.Error(err))

--- a/apps/backend/internal/agent/settings/handlers/handlers.go
+++ b/apps/backend/internal/agent/settings/handlers/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/mcpconfig"
 	"github.com/kandev/kandev/internal/agent/settings/controller"
+	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/common/logger"
 	ws "github.com/kandev/kandev/pkg/websocket"
 	"go.uber.org/zap"
@@ -297,11 +298,12 @@ func (h *Handlers) httpUpdateProfileMcpConfig(c *gin.Context) {
 }
 
 type createProfileRequest struct {
-	Name           string `json:"name"`
-	Model          string `json:"model"`
-	Mode           string `json:"mode,omitempty"`
-	AllowIndexing  bool   `json:"allow_indexing"`
-	CLIPassthrough bool   `json:"cli_passthrough"`
+	Name           string           `json:"name"`
+	Model          string           `json:"model"`
+	Mode           string           `json:"mode,omitempty"`
+	AllowIndexing  bool             `json:"allow_indexing"`
+	CLIPassthrough bool             `json:"cli_passthrough"`
+	CLIFlags       []dto.CLIFlagDTO `json:"cli_flags,omitempty"`
 }
 
 func (h *Handlers) httpCreateProfile(c *gin.Context) {
@@ -321,6 +323,7 @@ func (h *Handlers) httpCreateProfile(c *gin.Context) {
 		Mode:           body.Mode,
 		AllowIndexing:  body.AllowIndexing,
 		CLIPassthrough: body.CLIPassthrough,
+		CLIFlags:       body.CLIFlags,
 	})
 	if err != nil {
 		h.logger.Error("failed to create profile", zap.Error(err))
@@ -337,11 +340,12 @@ func (h *Handlers) httpCreateProfile(c *gin.Context) {
 }
 
 type updateProfileRequest struct {
-	Name           *string `json:"name,omitempty"`
-	Model          *string `json:"model,omitempty"`
-	Mode           *string `json:"mode,omitempty"`
-	AllowIndexing  *bool   `json:"allow_indexing,omitempty"`
-	CLIPassthrough *bool   `json:"cli_passthrough,omitempty"`
+	Name           *string           `json:"name,omitempty"`
+	Model          *string           `json:"model,omitempty"`
+	Mode           *string           `json:"mode,omitempty"`
+	AllowIndexing  *bool             `json:"allow_indexing,omitempty"`
+	CLIPassthrough *bool             `json:"cli_passthrough,omitempty"`
+	CLIFlags       *[]dto.CLIFlagDTO `json:"cli_flags,omitempty"`
 }
 
 func (h *Handlers) httpUpdateProfile(c *gin.Context) {
@@ -361,6 +365,7 @@ func (h *Handlers) httpUpdateProfile(c *gin.Context) {
 		Mode:           body.Mode,
 		AllowIndexing:  body.AllowIndexing,
 		CLIPassthrough: body.CLIPassthrough,
+		CLIFlags:       body.CLIFlags,
 	})
 	if err != nil {
 		if err == controller.ErrAgentProfileNotFound {

--- a/apps/backend/internal/agent/settings/models/models.go
+++ b/apps/backend/internal/agent/settings/models/models.go
@@ -44,9 +44,18 @@ type AgentProfile struct {
 	// CLIPassthrough enables TUI-passthrough execution style. Orthogonal to ACP.
 	CLIPassthrough bool `json:"cli_passthrough"`
 
-	// AllowIndexing is kept as an auggie-only CLI flag (no ACP equivalent).
-	// Ignored for all other agents.
+	// AllowIndexing is retained for backward compatibility with existing
+	// auggie profiles. The launch path no longer consults it — it is read
+	// only by the legacy migration shim that seeds CLIFlags on the first
+	// post-migration read. New code should use CLIFlags instead.
 	AllowIndexing bool `json:"allow_indexing"`
+
+	// CLIFlags is the user-configurable list of CLI flags passed to the agent
+	// subprocess. At profile creation the list is seeded from the agent's
+	// PermissionSettings(); users can toggle entries on/off, remove them, or
+	// add custom entries via the settings UI. Only entries with Enabled=true
+	// reach the subprocess argv.
+	CLIFlags []CLIFlag `json:"cli_flags"`
 
 	// Deprecated legacy permission fields: retained in the DB schema so rows
 	// load cleanly, but no longer read by the launch path. ACP session modes
@@ -58,4 +67,13 @@ type AgentProfile struct {
 	CreatedAt    time.Time  `json:"created_at"`
 	UpdatedAt    time.Time  `json:"updated_at"`
 	DeletedAt    *time.Time `json:"deleted_at,omitempty"`
+}
+
+// CLIFlag is a single user-configurable CLI argument on an AgentProfile.
+// The raw Flag string is shell-tokenised at launch time: a single entry
+// like "--add-dir /shared" becomes two argv tokens.
+type CLIFlag struct {
+	Description string `json:"description"`
+	Flag        string `json:"flag"`
+	Enabled     bool   `json:"enabled"`
 }

--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -485,16 +485,18 @@ func (r *sqliteRepository) DeleteAgentProfile(ctx context.Context, id string) er
 
 func (r *sqliteRepository) GetAgentProfile(ctx context.Context, id string) (*models.AgentProfile, error) {
 	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
-		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, cli_flags, created_at, updated_at, deleted_at
-		FROM agent_profiles WHERE id = ? AND deleted_at IS NULL
+		SELECT p.id, p.agent_id, p.name, p.agent_display_name, p.model, p.mode, p.migrated_from, p.auto_approve, p.dangerously_skip_permissions, p.allow_indexing, p.cli_passthrough, p.user_modified, p.plan, p.cli_flags, p.created_at, p.updated_at, p.deleted_at, a.name AS agent_name
+		FROM agent_profiles p JOIN agents a ON a.id = p.agent_id
+		WHERE p.id = ? AND p.deleted_at IS NULL
 	`), id)
 	return scanAgentProfile(row)
 }
 
 func (r *sqliteRepository) ListAgentProfiles(ctx context.Context, agentID string) ([]*models.AgentProfile, error) {
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
-		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, cli_flags, created_at, updated_at, deleted_at
-		FROM agent_profiles WHERE agent_id = ? AND deleted_at IS NULL ORDER BY created_at DESC
+		SELECT p.id, p.agent_id, p.name, p.agent_display_name, p.model, p.mode, p.migrated_from, p.auto_approve, p.dangerously_skip_permissions, p.allow_indexing, p.cli_passthrough, p.user_modified, p.plan, p.cli_flags, p.created_at, p.updated_at, p.deleted_at, a.name AS agent_name
+		FROM agent_profiles p JOIN agents a ON a.id = p.agent_id
+		WHERE p.agent_id = ? AND p.deleted_at IS NULL ORDER BY p.created_at DESC
 	`), agentID)
 	if err != nil {
 		return nil, err
@@ -587,6 +589,7 @@ func scanAgentProfile(scanner interface {
 	var userModified int
 	var plan string // unused, kept for backwards compatibility
 	var cliFlagsRaw sql.NullString
+	var agentName string
 	if err := scanner.Scan(
 		&profile.ID,
 		&profile.AgentID,
@@ -605,6 +608,7 @@ func scanAgentProfile(scanner interface {
 		&profile.CreatedAt,
 		&profile.UpdatedAt,
 		&profile.DeletedAt,
+		&agentName,
 	); err != nil {
 		return nil, err
 	}
@@ -625,11 +629,11 @@ func scanAgentProfile(scanner interface {
 		}
 	} else {
 		// Legacy row: synthesise cli_flags from the legacy allow_indexing
-		// column. The seed runs once per row — UpdateAgentProfile persists
-		// the cli_flags JSON so subsequent reads skip this branch. The seed
-		// only emits an entry when allow_indexing is true; profiles for
-		// non-auggie agents just get an empty list.
-		profile.CLIFlags = legacyCLIFlagsBackfill(profile.AllowIndexing)
+		// column. This backfill runs in-memory on every read until the
+		// profile is saved; UpdateAgentProfile persists the cli_flags JSON
+		// so subsequent reads take the non-NULL branch above. Accepting
+		// the repeated in-memory work is worth avoiding a read-path write.
+		profile.CLIFlags = legacyCLIFlagsBackfill(agentName, profile.AllowIndexing)
 	}
 	return profile, nil
 }
@@ -637,10 +641,13 @@ func scanAgentProfile(scanner interface {
 // legacyCLIFlagsBackfill builds a cli_flags list for a profile row that
 // predates the cli_flags column. Only the auggie --allow-indexing flag
 // has ever been driven by a dedicated DB column; every other CLI flag
-// was hard-coded in the agent's BuildCommand. For all other agents the
-// migration produces an empty list.
-func legacyCLIFlagsBackfill(allowIndexing bool) []models.CLIFlag {
-	if !allowIndexing {
+// was hard-coded in the agent's BuildCommand. The agentName guard
+// prevents a legacy non-Auggie row (e.g. from a direct SQL import or an
+// erroneous API write that flipped the column default) from silently
+// injecting an unsupported --allow-indexing flag into Claude / Codex /
+// Copilot argv.
+func legacyCLIFlagsBackfill(agentName string, allowIndexing bool) []models.CLIFlag {
+	if agentName != "auggie" || !allowIndexing {
 		return []models.CLIFlag{}
 	}
 	return []models.CLIFlag{{

--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -485,18 +485,20 @@ func (r *sqliteRepository) DeleteAgentProfile(ctx context.Context, id string) er
 
 func (r *sqliteRepository) GetAgentProfile(ctx context.Context, id string) (*models.AgentProfile, error) {
 	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
-		SELECT p.id, p.agent_id, p.name, p.agent_display_name, p.model, p.mode, p.migrated_from, p.auto_approve, p.dangerously_skip_permissions, p.allow_indexing, p.cli_passthrough, p.user_modified, p.plan, p.cli_flags, p.created_at, p.updated_at, p.deleted_at, a.name AS agent_name
-		FROM agent_profiles p JOIN agents a ON a.id = p.agent_id
-		WHERE p.id = ? AND p.deleted_at IS NULL
+		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, cli_flags, created_at, updated_at, deleted_at
+		FROM agent_profiles WHERE id = ? AND deleted_at IS NULL
 	`), id)
-	return scanAgentProfile(row)
+	profile, err := scanAgentProfile(row)
+	if err != nil {
+		return nil, err
+	}
+	return r.applyLegacyBackfill(ctx, profile), nil
 }
 
 func (r *sqliteRepository) ListAgentProfiles(ctx context.Context, agentID string) ([]*models.AgentProfile, error) {
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
-		SELECT p.id, p.agent_id, p.name, p.agent_display_name, p.model, p.mode, p.migrated_from, p.auto_approve, p.dangerously_skip_permissions, p.allow_indexing, p.cli_passthrough, p.user_modified, p.plan, p.cli_flags, p.created_at, p.updated_at, p.deleted_at, a.name AS agent_name
-		FROM agent_profiles p JOIN agents a ON a.id = p.agent_id
-		WHERE p.agent_id = ? AND p.deleted_at IS NULL ORDER BY p.created_at DESC
+		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, cli_flags, created_at, updated_at, deleted_at
+		FROM agent_profiles WHERE agent_id = ? AND deleted_at IS NULL ORDER BY created_at DESC
 	`), agentID)
 	if err != nil {
 		return nil, err
@@ -511,9 +513,38 @@ func (r *sqliteRepository) ListAgentProfiles(ctx context.Context, agentID string
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, profile)
+		result = append(result, r.applyLegacyBackfill(ctx, profile))
 	}
 	return result, rows.Err()
+}
+
+// applyLegacyBackfill returns the profile with CLIFlags populated from the
+// legacy allow_indexing column for Auggie rows that predate the cli_flags
+// column. The backfill is scoped to auggie only so a legacy Claude/Codex/
+// Copilot row (possible via the column's DEFAULT 1) never gains an
+// unsupported --allow-indexing flag. scanAgentProfile leaves CLIFlags nil
+// when the stored JSON is absent; we resolve the agent name lazily via a
+// small lookup here rather than JOINing in the main SELECT (keeps the
+// read query unchanged and avoids cross-test flakiness).
+func (r *sqliteRepository) applyLegacyBackfill(ctx context.Context, profile *models.AgentProfile) *models.AgentProfile {
+	if profile == nil || profile.CLIFlags != nil {
+		return profile
+	}
+	if !profile.AllowIndexing {
+		profile.CLIFlags = []models.CLIFlag{}
+		return profile
+	}
+	agent, err := r.GetAgent(ctx, profile.AgentID)
+	if err != nil || agent == nil || agent.Name != "auggie" {
+		profile.CLIFlags = []models.CLIFlag{}
+		return profile
+	}
+	profile.CLIFlags = []models.CLIFlag{{
+		Description: "Allow workspace indexing without confirmation",
+		Flag:        "--allow-indexing",
+		Enabled:     true,
+	}}
+	return profile
 }
 
 func (r *sqliteRepository) ListTUIAgents(ctx context.Context) ([]*models.Agent, error) {
@@ -589,7 +620,6 @@ func scanAgentProfile(scanner interface {
 	var userModified int
 	var plan string // unused, kept for backwards compatibility
 	var cliFlagsRaw sql.NullString
-	var agentName string
 	if err := scanner.Scan(
 		&profile.ID,
 		&profile.AgentID,
@@ -608,7 +638,6 @@ func scanAgentProfile(scanner interface {
 		&profile.CreatedAt,
 		&profile.UpdatedAt,
 		&profile.DeletedAt,
-		&agentName,
 	); err != nil {
 		return nil, err
 	}
@@ -627,32 +656,11 @@ func scanAgentProfile(scanner interface {
 		if err := json.Unmarshal([]byte(cliFlagsRaw.String), &profile.CLIFlags); err != nil {
 			return nil, fmt.Errorf("failed to parse cli_flags for profile %s: %w", profile.ID, err)
 		}
-	} else {
-		// Legacy row: synthesise cli_flags from the legacy allow_indexing
-		// column. This backfill runs in-memory on every read until the
-		// profile is saved; UpdateAgentProfile persists the cli_flags JSON
-		// so subsequent reads take the non-NULL branch above. Accepting
-		// the repeated in-memory work is worth avoiding a read-path write.
-		profile.CLIFlags = legacyCLIFlagsBackfill(agentName, profile.AllowIndexing)
 	}
+	// When cli_flags is NULL the caller (GetAgentProfile / ListAgentProfiles)
+	// runs applyLegacyBackfill to seed the list scoped to the owning agent.
+	// Leaving CLIFlags as nil here is deliberate: non-nil vs nil discriminates
+	// "stored empty list" from "never written". applyLegacyBackfill rewrites
+	// nil → []CLIFlag{} so downstream code never sees a nil slice.
 	return profile, nil
-}
-
-// legacyCLIFlagsBackfill builds a cli_flags list for a profile row that
-// predates the cli_flags column. Only the auggie --allow-indexing flag
-// has ever been driven by a dedicated DB column; every other CLI flag
-// was hard-coded in the agent's BuildCommand. The agentName guard
-// prevents a legacy non-Auggie row (e.g. from a direct SQL import or an
-// erroneous API write that flipped the column default) from silently
-// injecting an unsupported --allow-indexing flag into Claude / Codex /
-// Copilot argv.
-func legacyCLIFlagsBackfill(agentName string, allowIndexing bool) []models.CLIFlag {
-	if agentName != "auggie" || !allowIndexing {
-		return []models.CLIFlag{}
-	}
-	return []models.CLIFlag{{
-		Description: "Allow workspace indexing without confirmation",
-		Flag:        "--allow-indexing",
-		Enabled:     true,
-	}}
 }

--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -67,6 +67,7 @@ func (r *sqliteRepository) initSchema() error {
 		cli_passthrough INTEGER NOT NULL DEFAULT 0,
 		user_modified INTEGER NOT NULL DEFAULT 0,
 		plan TEXT DEFAULT '',
+		cli_flags TEXT DEFAULT NULL,
 		created_at TIMESTAMP NOT NULL,
 		updated_at TIMESTAMP NOT NULL,
 		deleted_at TIMESTAMP,
@@ -98,6 +99,10 @@ func (r *sqliteRepository) initSchema() error {
 	// Migration: add mode and migrated_from columns on agent_profiles (idempotent)
 	_, _ = r.db.Exec(`ALTER TABLE agent_profiles ADD COLUMN mode TEXT DEFAULT NULL`)
 	_, _ = r.db.Exec(`ALTER TABLE agent_profiles ADD COLUMN migrated_from TEXT DEFAULT NULL`)
+
+	// Migration: add cli_flags column on agent_profiles (idempotent).
+	// Rows where cli_flags IS NULL are backfilled on first read — see scanAgentProfile.
+	_, _ = r.db.Exec(`ALTER TABLE agent_profiles ADD COLUMN cli_flags TEXT DEFAULT NULL`)
 
 	// Migration: drop CHECK(model != '') constraint from agent_profiles.
 	//
@@ -164,9 +169,18 @@ func (r *sqliteRepository) recreateAgentProfilesWithoutModelCheck() error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	const columns = `id, agent_id, name, agent_display_name, model, mode, migrated_from,
+	// The old table does not have cli_flags yet (the ADD COLUMN ran earlier in
+	// initSchema but on the old table, which is about to be dropped). So we
+	// include it in the copy only when it exists on the source table.
+	srcHasCLIFlags := columnExists(tx, "agent_profiles", "cli_flags")
+	srcCols := `id, agent_id, name, agent_display_name, model, mode, migrated_from,
 		auto_approve, dangerously_skip_permissions, allow_indexing,
 		cli_passthrough, user_modified, plan, created_at, updated_at, deleted_at`
+	dstCols := srcCols
+	if srcHasCLIFlags {
+		srcCols += ", cli_flags"
+		dstCols += ", cli_flags"
+	}
 
 	if _, err := tx.Exec(`CREATE TABLE agent_profiles_new (
 		id TEXT PRIMARY KEY,
@@ -182,6 +196,7 @@ func (r *sqliteRepository) recreateAgentProfilesWithoutModelCheck() error {
 		cli_passthrough INTEGER NOT NULL DEFAULT 0,
 		user_modified INTEGER NOT NULL DEFAULT 0,
 		plan TEXT DEFAULT '',
+		cli_flags TEXT DEFAULT NULL,
 		created_at TIMESTAMP NOT NULL,
 		updated_at TIMESTAMP NOT NULL,
 		deleted_at TIMESTAMP,
@@ -191,7 +206,7 @@ func (r *sqliteRepository) recreateAgentProfilesWithoutModelCheck() error {
 	}
 
 	if _, err := tx.Exec(
-		`INSERT INTO agent_profiles_new (` + columns + `) SELECT ` + columns + ` FROM agent_profiles`,
+		`INSERT INTO agent_profiles_new (` + dstCols + `) SELECT ` + srcCols + ` FROM agent_profiles`,
 	); err != nil {
 		return fmt.Errorf("copy data: %w", err)
 	}
@@ -359,13 +374,17 @@ func (r *sqliteRepository) CreateAgentProfile(ctx context.Context, profile *mode
 	now := time.Now().UTC()
 	profile.CreatedAt = now
 	profile.UpdatedAt = now
-	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
-		INSERT INTO agent_profiles (id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, created_at, updated_at, deleted_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?)
+	cliFlagsJSON, err := cliFlagsToJSON(profile.CLIFlags)
+	if err != nil {
+		return err
+	}
+	_, err = r.db.ExecContext(ctx, r.db.Rebind(`
+		INSERT INTO agent_profiles (id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, cli_flags, created_at, updated_at, deleted_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, ?)
 	`), profile.ID, profile.AgentID, profile.Name, profile.AgentDisplayName, profile.Model,
 		nullableString(profile.Mode), nullableString(profile.MigratedFrom),
 		dialect.BoolToInt(profile.AutoApprove),
-		dialect.BoolToInt(profile.DangerouslySkipPermissions), dialect.BoolToInt(profile.AllowIndexing), dialect.BoolToInt(profile.CLIPassthrough), dialect.BoolToInt(profile.UserModified), profile.CreatedAt, profile.UpdatedAt, profile.DeletedAt)
+		dialect.BoolToInt(profile.DangerouslySkipPermissions), dialect.BoolToInt(profile.AllowIndexing), dialect.BoolToInt(profile.CLIPassthrough), dialect.BoolToInt(profile.UserModified), cliFlagsJSON, profile.CreatedAt, profile.UpdatedAt, profile.DeletedAt)
 	return err
 }
 
@@ -378,16 +397,67 @@ func nullableString(s string) sql.NullString {
 	return sql.NullString{String: s, Valid: true}
 }
 
+// columnExists reports whether a column is present on a SQLite table. Used by
+// the table-recreation migration to gracefully handle databases where ALTER
+// TABLE ADD COLUMN ran but the recreation is running for the first time.
+type sqlQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func columnExists(q sqlQueryer, table, column string) bool {
+	rows, err := q.Query(`PRAGMA table_info(` + table + `)`)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false
+		}
+		if name == column {
+			return true
+		}
+	}
+	return false
+}
+
+// cliFlagsToJSON marshals the profile's CLIFlags list into a JSON string
+// suitable for the cli_flags TEXT column. Empty or nil slices serialise to
+// "[]" so we can distinguish an empty-but-known list (skip backfill) from a
+// never-written NULL (trigger backfill on read).
+func cliFlagsToJSON(flags []models.CLIFlag) (string, error) {
+	if flags == nil {
+		flags = []models.CLIFlag{}
+	}
+	data, err := json.Marshal(flags)
+	if err != nil {
+		return "", fmt.Errorf("marshal cli_flags: %w", err)
+	}
+	return string(data), nil
+}
+
 func (r *sqliteRepository) UpdateAgentProfile(ctx context.Context, profile *models.AgentProfile) error {
 	profile.UpdatedAt = time.Now().UTC()
+	cliFlagsJSON, err := cliFlagsToJSON(profile.CLIFlags)
+	if err != nil {
+		return err
+	}
 	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
 		UPDATE agent_profiles
-		SET name = ?, agent_display_name = ?, model = ?, mode = ?, migrated_from = ?, auto_approve = ?, dangerously_skip_permissions = ?, allow_indexing = ?, cli_passthrough = ?, user_modified = ?, updated_at = ?
+		SET name = ?, agent_display_name = ?, model = ?, mode = ?, migrated_from = ?, auto_approve = ?, dangerously_skip_permissions = ?, allow_indexing = ?, cli_passthrough = ?, user_modified = ?, cli_flags = ?, updated_at = ?
 		WHERE id = ? AND deleted_at IS NULL
 	`), profile.Name, profile.AgentDisplayName, profile.Model,
 		nullableString(profile.Mode), nullableString(profile.MigratedFrom),
 		dialect.BoolToInt(profile.AutoApprove),
-		dialect.BoolToInt(profile.DangerouslySkipPermissions), dialect.BoolToInt(profile.AllowIndexing), dialect.BoolToInt(profile.CLIPassthrough), dialect.BoolToInt(profile.UserModified), profile.UpdatedAt, profile.ID)
+		dialect.BoolToInt(profile.DangerouslySkipPermissions), dialect.BoolToInt(profile.AllowIndexing), dialect.BoolToInt(profile.CLIPassthrough), dialect.BoolToInt(profile.UserModified), cliFlagsJSON, profile.UpdatedAt, profile.ID)
 	if err != nil {
 		return err
 	}
@@ -415,7 +485,7 @@ func (r *sqliteRepository) DeleteAgentProfile(ctx context.Context, id string) er
 
 func (r *sqliteRepository) GetAgentProfile(ctx context.Context, id string) (*models.AgentProfile, error) {
 	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
-		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, created_at, updated_at, deleted_at
+		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, cli_flags, created_at, updated_at, deleted_at
 		FROM agent_profiles WHERE id = ? AND deleted_at IS NULL
 	`), id)
 	return scanAgentProfile(row)
@@ -423,7 +493,7 @@ func (r *sqliteRepository) GetAgentProfile(ctx context.Context, id string) (*mod
 
 func (r *sqliteRepository) ListAgentProfiles(ctx context.Context, agentID string) ([]*models.AgentProfile, error) {
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
-		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, created_at, updated_at, deleted_at
+		SELECT id, agent_id, name, agent_display_name, model, mode, migrated_from, auto_approve, dangerously_skip_permissions, allow_indexing, cli_passthrough, user_modified, plan, cli_flags, created_at, updated_at, deleted_at
 		FROM agent_profiles WHERE agent_id = ? AND deleted_at IS NULL ORDER BY created_at DESC
 	`), agentID)
 	if err != nil {
@@ -516,6 +586,7 @@ func scanAgentProfile(scanner interface {
 	var cliPassthrough int
 	var userModified int
 	var plan string // unused, kept for backwards compatibility
+	var cliFlagsRaw sql.NullString
 	if err := scanner.Scan(
 		&profile.ID,
 		&profile.AgentID,
@@ -530,6 +601,7 @@ func scanAgentProfile(scanner interface {
 		&cliPassthrough,
 		&userModified,
 		&plan,
+		&cliFlagsRaw,
 		&profile.CreatedAt,
 		&profile.UpdatedAt,
 		&profile.DeletedAt,
@@ -547,5 +619,33 @@ func scanAgentProfile(scanner interface {
 	profile.AllowIndexing = allowIndexing == 1
 	profile.CLIPassthrough = cliPassthrough == 1
 	profile.UserModified = userModified == 1
+	if cliFlagsRaw.Valid && cliFlagsRaw.String != "" {
+		if err := json.Unmarshal([]byte(cliFlagsRaw.String), &profile.CLIFlags); err != nil {
+			return nil, fmt.Errorf("failed to parse cli_flags for profile %s: %w", profile.ID, err)
+		}
+	} else {
+		// Legacy row: synthesise cli_flags from the legacy allow_indexing
+		// column. The seed runs once per row — UpdateAgentProfile persists
+		// the cli_flags JSON so subsequent reads skip this branch. The seed
+		// only emits an entry when allow_indexing is true; profiles for
+		// non-auggie agents just get an empty list.
+		profile.CLIFlags = legacyCLIFlagsBackfill(profile.AllowIndexing)
+	}
 	return profile, nil
+}
+
+// legacyCLIFlagsBackfill builds a cli_flags list for a profile row that
+// predates the cli_flags column. Only the auggie --allow-indexing flag
+// has ever been driven by a dedicated DB column; every other CLI flag
+// was hard-coded in the agent's BuildCommand. For all other agents the
+// migration produces an empty list.
+func legacyCLIFlagsBackfill(allowIndexing bool) []models.CLIFlag {
+	if !allowIndexing {
+		return []models.CLIFlag{}
+	}
+	return []models.CLIFlag{{
+		Description: "Allow workspace indexing without confirmation",
+		Flag:        "--allow-indexing",
+		Enabled:     true,
+	}}
 }

--- a/apps/backend/internal/agent/settings/store/sqlite_cliflags_test.go
+++ b/apps/backend/internal/agent/settings/store/sqlite_cliflags_test.go
@@ -1,0 +1,182 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/agent/settings/models"
+)
+
+func newFreshRepo(t *testing.T) *sqliteRepository {
+	t.Helper()
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo, err := newSQLiteRepository(db, db, false)
+	if err != nil {
+		t.Fatalf("newSQLiteRepository: %v", err)
+	}
+	return repo
+}
+
+// TestCLIFlags_RoundTrip verifies CLIFlags survive insert → read → update → read.
+func TestCLIFlags_RoundTrip(t *testing.T) {
+	repo := newFreshRepo(t)
+	ctx := context.Background()
+	if err := repo.CreateAgent(ctx, &models.Agent{Name: "copilot-acp"}); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	agent, err := repo.GetAgentByName(ctx, "copilot-acp")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+
+	profile := &models.AgentProfile{
+		AgentID:          agent.ID,
+		Name:             "default",
+		AgentDisplayName: "Copilot",
+		CLIFlags: []models.CLIFlag{
+			{Description: "allow all tools", Flag: "--allow-all-tools", Enabled: true},
+			{Description: "custom dir", Flag: "--add-dir /shared", Enabled: false},
+		},
+	}
+	if err := repo.CreateAgentProfile(ctx, profile); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+
+	got, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if len(got.CLIFlags) != 2 {
+		t.Fatalf("cli_flags length mismatch: got %d", len(got.CLIFlags))
+	}
+	if got.CLIFlags[0].Flag != "--allow-all-tools" || !got.CLIFlags[0].Enabled {
+		t.Errorf("first flag mismatch: %+v", got.CLIFlags[0])
+	}
+	if got.CLIFlags[1].Flag != "--add-dir /shared" || got.CLIFlags[1].Enabled {
+		t.Errorf("second flag mismatch: %+v", got.CLIFlags[1])
+	}
+
+	// Update: replace list entirely
+	got.CLIFlags = []models.CLIFlag{{Flag: "--no-ask-user", Enabled: true}}
+	if err := repo.UpdateAgentProfile(ctx, got); err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+	got2, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("re-get profile: %v", err)
+	}
+	if len(got2.CLIFlags) != 1 || got2.CLIFlags[0].Flag != "--no-ask-user" {
+		t.Errorf("post-update cli_flags mismatch: %+v", got2.CLIFlags)
+	}
+}
+
+// TestCLIFlags_LegacyBackfill verifies that a profile row without cli_flags
+// (i.e. created before the migration) gets a cli_flags list synthesised from
+// the legacy allow_indexing column on first read.
+func TestCLIFlags_LegacyBackfill(t *testing.T) {
+	repo := newFreshRepo(t)
+	ctx := context.Background()
+	if err := repo.CreateAgent(ctx, &models.Agent{Name: "auggie"}); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	agent, err := repo.GetAgentByName(ctx, "auggie")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+
+	// Simulate a pre-migration row: insert directly with cli_flags = NULL,
+	// allow_indexing = 1.
+	_, err = repo.db.Exec(`INSERT INTO agent_profiles
+		(id, agent_id, name, agent_display_name, model, mode, auto_approve,
+		 dangerously_skip_permissions, allow_indexing, cli_passthrough,
+		 user_modified, plan, cli_flags, created_at, updated_at)
+		VALUES ('legacy-1', ?, 'Auggie', 'Auggie', '', NULL, 0, 0, 1, 0, 0, '', NULL,
+		        datetime('now'), datetime('now'))`, agent.ID)
+	if err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	got, err := repo.GetAgentProfile(ctx, "legacy-1")
+	if err != nil {
+		t.Fatalf("get legacy profile: %v", err)
+	}
+	if len(got.CLIFlags) != 1 {
+		t.Fatalf("expected 1 backfilled flag, got %d: %+v", len(got.CLIFlags), got.CLIFlags)
+	}
+	if got.CLIFlags[0].Flag != "--allow-indexing" || !got.CLIFlags[0].Enabled {
+		t.Errorf("backfilled flag mismatch: %+v", got.CLIFlags[0])
+	}
+}
+
+// TestCLIFlags_LegacyBackfill_AllowIndexingOff seeds a legacy row with
+// allow_indexing=0 and confirms no flag is backfilled (an off toggle would
+// not have produced a CLI flag historically either).
+func TestCLIFlags_LegacyBackfill_AllowIndexingOff(t *testing.T) {
+	repo := newFreshRepo(t)
+	ctx := context.Background()
+	if err := repo.CreateAgent(ctx, &models.Agent{Name: "claude-acp"}); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	agent, err := repo.GetAgentByName(ctx, "claude-acp")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	_, err = repo.db.Exec(`INSERT INTO agent_profiles
+		(id, agent_id, name, agent_display_name, model, mode, auto_approve,
+		 dangerously_skip_permissions, allow_indexing, cli_passthrough,
+		 user_modified, plan, cli_flags, created_at, updated_at)
+		VALUES ('legacy-2', ?, 'Claude', 'Claude', '', NULL, 0, 0, 0, 0, 0, '', NULL,
+		        datetime('now'), datetime('now'))`, agent.ID)
+	if err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	got, err := repo.GetAgentProfile(ctx, "legacy-2")
+	if err != nil {
+		t.Fatalf("get legacy profile: %v", err)
+	}
+	if len(got.CLIFlags) != 0 {
+		t.Errorf("expected no backfilled flags, got %+v", got.CLIFlags)
+	}
+}
+
+// TestCLIFlags_EmptyListPersists verifies that a profile explicitly saved
+// with an empty list stays empty after a round trip (must not confuse empty
+// with "never written" and trigger a backfill).
+func TestCLIFlags_EmptyListPersists(t *testing.T) {
+	repo := newFreshRepo(t)
+	ctx := context.Background()
+	if err := repo.CreateAgent(ctx, &models.Agent{Name: "auggie"}); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	agent, err := repo.GetAgentByName(ctx, "auggie")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+
+	profile := &models.AgentProfile{
+		AgentID:          agent.ID,
+		Name:             "no flags",
+		AgentDisplayName: "Auggie",
+		AllowIndexing:    true, // legacy column set — backfill would kick in if the shim ran
+		CLIFlags:         []models.CLIFlag{},
+	}
+	if err := repo.CreateAgentProfile(ctx, profile); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.CLIFlags) != 0 {
+		t.Errorf("expected empty cli_flags, got %+v", got.CLIFlags)
+	}
+}

--- a/apps/backend/internal/agent/settings/store/sqlite_cliflags_test.go
+++ b/apps/backend/internal/agent/settings/store/sqlite_cliflags_test.go
@@ -115,6 +115,43 @@ func TestCLIFlags_LegacyBackfill(t *testing.T) {
 	}
 }
 
+// TestCLIFlags_LegacyBackfill_NonAuggieAgent ensures that a legacy profile
+// for a non-Auggie agent with allow_indexing=1 (possible via direct SQL or
+// the DEFAULT 1 column) does NOT synth a --allow-indexing flag, since only
+// Auggie has ever supported that CLI flag.
+func TestCLIFlags_LegacyBackfill_NonAuggieAgent(t *testing.T) {
+	repo := newFreshRepo(t)
+	ctx := context.Background()
+	if err := repo.CreateAgent(ctx, &models.Agent{Name: "claude-acp"}); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	agent, err := repo.GetAgentByName(ctx, "claude-acp")
+	if err != nil {
+		t.Fatalf("get agent: %v", err)
+	}
+	// Deliberately set allow_indexing=1 on a claude-acp profile — this is
+	// the scenario CodeRabbit flagged: a legacy row with the column default
+	// on a non-Auggie agent would otherwise inject --allow-indexing into
+	// Claude's argv and crash the launch.
+	_, err = repo.db.Exec(`INSERT INTO agent_profiles
+		(id, agent_id, name, agent_display_name, model, mode, auto_approve,
+		 dangerously_skip_permissions, allow_indexing, cli_passthrough,
+		 user_modified, plan, cli_flags, created_at, updated_at)
+		VALUES ('legacy-claude', ?, 'Claude', 'Claude', '', NULL, 0, 0, 1, 0, 0, '', NULL,
+		        datetime('now'), datetime('now'))`, agent.ID)
+	if err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	got, err := repo.GetAgentProfile(ctx, "legacy-claude")
+	if err != nil {
+		t.Fatalf("get legacy profile: %v", err)
+	}
+	if len(got.CLIFlags) != 0 {
+		t.Errorf("expected no backfilled flags for claude-acp, got %+v", got.CLIFlags)
+	}
+}
+
 // TestCLIFlags_LegacyBackfill_AllowIndexingOff seeds a legacy row with
 // allow_indexing=0 and confirms no flag is backfilled (an off toggle would
 // not have produced a CLI flag historically either).

--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -94,7 +94,10 @@ export async function createAgentProfileAction(
 export async function updateAgentProfileAction(
   id: string,
   payload: Partial<
-    Pick<AgentProfile, "name" | "model" | "mode" | "allow_indexing" | "cli_passthrough">
+    Pick<
+      AgentProfile,
+      "name" | "model" | "mode" | "allow_indexing" | "cli_passthrough" | "cli_flags"
+    >
   >,
 ): Promise<AgentProfile> {
   return fetchJson<AgentProfile>(`${apiBaseUrl}/api/v1/agent-profiles/${id}`, {

--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -5,6 +5,7 @@ import type {
   Agent,
   AgentProfile,
   AgentProfileMcpConfig,
+  CLIFlag,
   McpServerDef,
   ListAgentsResponse,
   ListAgentDiscoveryResponse,
@@ -49,7 +50,13 @@ export async function createAgentAction(payload: {
   name: string;
   workspace_id?: string | null;
   profiles?: Array<
-    { name: string; model: string; mode?: string; cli_passthrough: boolean } & ProfilePermissions
+    {
+      name: string;
+      model: string;
+      mode?: string;
+      cli_passthrough: boolean;
+      cli_flags?: CLIFlag[];
+    } & ProfilePermissions
   >;
 }): Promise<Agent> {
   return fetchJson<Agent>(`${apiBaseUrl}/api/v1/agents`, {
@@ -83,6 +90,7 @@ export async function createAgentProfileAction(
     model: string;
     mode?: string;
     cli_passthrough: boolean;
+    cli_flags?: CLIFlag[];
   } & ProfilePermissions,
 ): Promise<AgentProfile> {
   return fetchJson<AgentProfile>(`${apiBaseUrl}/api/v1/agents/${agentId}/profiles`, {

--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -173,6 +173,7 @@ export type CommandPreviewRequest = {
   model: string;
   permission_settings: Record<string, boolean>;
   cli_passthrough: boolean;
+  cli_flags: CLIFlag[];
 };
 
 export type CommandPreviewResponse = {

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
@@ -21,6 +21,8 @@ const draftFrom = (saved: AgentProfile, overrides: Partial<DraftProfile> = {}): 
   ...overrides,
 });
 
+const ALLOW_ALL_TOOLS_FLAG = "--allow-all-tools";
+
 describe("isProfileDirty", () => {
   it("returns false when draft equals saved", () => {
     expect(isProfileDirty(draftFrom(baseProfile), baseProfile)).toBe(false);
@@ -55,7 +57,7 @@ describe("isProfileDirty", () => {
 
   it("returns true when cli_flags list changes", () => {
     const draft = draftFrom(baseProfile, {
-      cli_flags: [{ flag: "--allow-all-tools", enabled: true, description: "" }],
+      cli_flags: [{ flag: ALLOW_ALL_TOOLS_FLAG, enabled: true, description: "" }],
     });
     expect(isProfileDirty(draft, baseProfile)).toBe(true);
   });
@@ -63,16 +65,16 @@ describe("isProfileDirty", () => {
   it("returns true when a cli_flag enabled state changes", () => {
     const saved: AgentProfile = {
       ...baseProfile,
-      cli_flags: [{ flag: "--allow-all-tools", enabled: false, description: "" }],
+      cli_flags: [{ flag: ALLOW_ALL_TOOLS_FLAG, enabled: false, description: "" }],
     };
     const draft = draftFrom(saved, {
-      cli_flags: [{ flag: "--allow-all-tools", enabled: true, description: "" }],
+      cli_flags: [{ flag: ALLOW_ALL_TOOLS_FLAG, enabled: true, description: "" }],
     });
     expect(isProfileDirty(draft, saved)).toBe(true);
   });
 
   it("returns false when cli_flags are equal", () => {
-    const flags = [{ flag: "--allow-all-tools", enabled: true, description: "desc" }];
+    const flags = [{ flag: ALLOW_ALL_TOOLS_FLAG, enabled: true, description: "desc" }];
     const saved: AgentProfile = { ...baseProfile, cli_flags: flags };
     const draft = draftFrom(saved, { cli_flags: [...flags] });
     expect(isProfileDirty(draft, saved)).toBe(false);

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
@@ -52,4 +52,29 @@ describe("isProfileDirty", () => {
   it("returns true when there is no saved profile", () => {
     expect(isProfileDirty(draftFrom(baseProfile))).toBe(true);
   });
+
+  it("returns true when cli_flags list changes", () => {
+    const draft = draftFrom(baseProfile, {
+      cli_flags: [{ flag: "--allow-all-tools", enabled: true, description: "" }],
+    });
+    expect(isProfileDirty(draft, baseProfile)).toBe(true);
+  });
+
+  it("returns true when a cli_flag enabled state changes", () => {
+    const saved: AgentProfile = {
+      ...baseProfile,
+      cli_flags: [{ flag: "--allow-all-tools", enabled: false, description: "" }],
+    };
+    const draft = draftFrom(saved, {
+      cli_flags: [{ flag: "--allow-all-tools", enabled: true, description: "" }],
+    });
+    expect(isProfileDirty(draft, saved)).toBe(true);
+  });
+
+  it("returns false when cli_flags are equal", () => {
+    const flags = [{ flag: "--allow-all-tools", enabled: true, description: "desc" }];
+    const saved: AgentProfile = { ...baseProfile, cli_flags: flags };
+    const draft = draftFrom(saved, { cli_flags: [...flags] });
+    expect(isProfileDirty(draft, saved)).toBe(false);
+  });
 });

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
@@ -10,6 +10,7 @@ const baseProfile: AgentProfile = {
   model: "mock-fast",
   mode: "default",
   allow_indexing: false,
+  cli_flags: [],
   cli_passthrough: false,
   created_at: "2026-01-01T00:00:00Z",
   updated_at: "2026-01-01T00:00:00Z",

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
@@ -13,7 +13,8 @@ import type {
   PermissionSetting,
   ModelConfig,
 } from "@/lib/types/http";
-import { permissionsToProfilePatch } from "@/lib/agent-permissions";
+import { permissionsToProfilePatch, arePermissionsDirty } from "@/lib/agent-permissions";
+import { areCLIFlagsEqual } from "@/lib/cli-flags";
 
 type DraftMcpConfig = {
   enabled: boolean;
@@ -126,6 +127,7 @@ export async function saveNewAgent(draftAgent: DraftAgent, callbacks: SaveAgentC
       mode: profile.mode,
       ...permissionsToProfilePatch(profile),
       cli_passthrough: profile.cli_passthrough ?? false,
+      cli_flags: profile.cli_flags,
     })),
   });
 
@@ -179,6 +181,7 @@ async function saveExistingProfiles(
         mode: profile.mode,
         ...permissionsToProfilePatch(profile),
         cli_passthrough: profile.cli_passthrough ?? false,
+        cli_flags: profile.cli_flags,
       });
       await saveMcpForProfile({
         draftProfile: profile,
@@ -194,6 +197,8 @@ async function saveExistingProfiles(
         model: profile.model,
         mode: profile.mode,
         ...permissionsToProfilePatch(profile),
+        cli_passthrough: profile.cli_passthrough ?? false,
+        cli_flags: profile.cli_flags,
       });
       nextProfiles.push(updatedProfile);
       continue;
@@ -251,8 +256,6 @@ export async function saveExistingAgent(
   }
 }
 
-import { arePermissionsDirty } from "@/lib/agent-permissions";
-
 export function isProfileDirty(draft: DraftProfile, saved?: AgentProfile): boolean {
   if (!saved) return true;
   return (
@@ -260,6 +263,7 @@ export function isProfileDirty(draft: DraftProfile, saved?: AgentProfile): boole
     draft.model !== saved.model ||
     (draft.mode ?? "") !== (saved.mode ?? "") ||
     arePermissionsDirty(draft, saved) ||
-    draft.cli_passthrough !== saved.cli_passthrough
+    draft.cli_passthrough !== saved.cli_passthrough ||
+    !areCLIFlagsEqual(draft.cli_flags, saved.cli_flags)
   );
 }

--- a/apps/web/app/settings/agents/[agentId]/agent-setup-parts.tsx
+++ b/apps/web/app/settings/agents/[agentId]/agent-setup-parts.tsx
@@ -120,6 +120,7 @@ export function ProfileCardItem({
             mode: profile.mode ?? "",
             allow_indexing: profile.allow_indexing ?? false,
             cli_passthrough: profile.cli_passthrough,
+            cli_flags: profile.cli_flags ?? [],
           }}
           onChange={(patch) => onProfileChange(profile.id, patch)}
           modelConfig={currentAgentModelConfig}

--- a/apps/web/app/settings/agents/[agentId]/page.tsx
+++ b/apps/web/app/settings/agents/[agentId]/page.tsx
@@ -51,6 +51,7 @@ const createDraftProfile = (
   model: defaultModel,
   ...buildDefaultPermissions(permissionSettings ?? {}),
   cli_passthrough: false,
+  cli_flags: [],
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
   isNew: true,

--- a/apps/web/app/settings/agents/[agentId]/profiles/[profileId]/command-preview-card.tsx
+++ b/apps/web/app/settings/agents/[agentId]/profiles/[profileId]/command-preview-card.tsx
@@ -6,12 +6,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
 import { Button } from "@kandev/ui/button";
 import { Skeleton } from "@kandev/ui/skeleton";
 import { previewAgentCommandAction, type CommandPreviewResponse } from "@/app/actions/agents";
+import type { CLIFlag } from "@/lib/types/http";
 
 type CommandPreviewCardProps = {
   agentName: string;
   model: string;
   permissionSettings: Record<string, boolean>;
   cliPassthrough: boolean;
+  cliFlags: CLIFlag[];
 };
 
 function CommandPreviewLoading() {
@@ -102,14 +104,15 @@ export function CommandPreviewCard({
   model,
   permissionSettings,
   cliPassthrough,
+  cliFlags,
 }: CommandPreviewCardProps) {
   const [preview, setPreview] = useState<CommandPreviewResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const settingsKey = useMemo(
-    () => JSON.stringify({ model, permissionSettings, cliPassthrough }),
-    [model, permissionSettings, cliPassthrough],
+    () => JSON.stringify({ model, permissionSettings, cliPassthrough, cliFlags }),
+    [model, permissionSettings, cliPassthrough, cliFlags],
   );
 
   useEffect(() => {
@@ -122,6 +125,7 @@ export function CommandPreviewCard({
           model,
           permission_settings: permissionSettings,
           cli_passthrough: cliPassthrough,
+          cli_flags: cliFlags,
         });
         setPreview(response);
         setError(null);
@@ -134,7 +138,7 @@ export function CommandPreviewCard({
     }, 300);
 
     return () => clearTimeout(timeoutId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- settingsKey already includes model, permissionSettings, cliPassthrough
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- settingsKey already includes model, permissionSettings, cliPassthrough, cliFlags
   }, [agentName, settingsKey]);
 
   return (

--- a/apps/web/components/onboarding-dialog.tsx
+++ b/apps/web/components/onboarding-dialog.tsx
@@ -83,6 +83,7 @@ function buildAgentSettings(
       name: string;
       model?: string | null;
       cli_passthrough?: boolean | null;
+      cli_flags?: AgentProfile["cli_flags"] | null;
     }[];
   }[],
 ): Record<string, AgentSetting> {
@@ -102,6 +103,7 @@ function buildAgentSettings(
           model: profile.model || aa.model_config.default_model,
           mode: (profile as { mode?: string }).mode ?? aa.model_config.current_mode_id ?? "",
           cli_passthrough: profile.cli_passthrough ?? false,
+          cli_flags: profile.cli_flags ?? [],
           ...perms,
         },
         dirty: false,
@@ -228,6 +230,7 @@ export function OnboardingDialog({ open, onComplete }: OnboardingDialogProps) {
             model: s.formData.model,
             ...permissionsToProfilePatch(s.formData),
             cli_passthrough: s.formData.cli_passthrough,
+            cli_flags: s.formData.cli_flags,
           }),
         ),
     );

--- a/apps/web/components/onboarding/step-agents.tsx
+++ b/apps/web/components/onboarding/step-agents.tsx
@@ -140,6 +140,7 @@ function InstalledAgentRow({
             <ProfileFormFields
               variant="compact"
               hideNameField
+              hideCustomCLIFlags
               profile={settings.formData}
               onChange={(patch) => onUpdateSetting(agent.name, patch)}
               modelConfig={agent.model_config}

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { IconTrash } from "@tabler/icons-react";
+import { areCLIFlagsEqual } from "@/lib/cli-flags";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
@@ -171,22 +172,6 @@ function useSyncAgentsToStore() {
       ),
     );
   };
-}
-
-function areCLIFlagsEqual(a: AgentProfile["cli_flags"], b: AgentProfile["cli_flags"]): boolean {
-  const left = a ?? [];
-  const right = b ?? [];
-  if (left.length !== right.length) return false;
-  for (let i = 0; i < left.length; i++) {
-    if (
-      left[i].flag !== right[i].flag ||
-      left[i].enabled !== right[i].enabled ||
-      (left[i].description ?? "") !== (right[i].description ?? "")
-    ) {
-      return false;
-    }
-  }
-  return true;
 }
 
 function useProfileEditorState(profile: AgentProfile) {

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -140,6 +140,7 @@ function ProfileSettingsCard({
             mode: draft.mode ?? "",
             allow_indexing: draft.allow_indexing,
             cli_passthrough: draft.cli_passthrough,
+            cli_flags: draft.cli_flags ?? [],
           }}
           onChange={onDraftChange}
           modelConfig={modelConfig}
@@ -172,6 +173,22 @@ function useSyncAgentsToStore() {
   };
 }
 
+function areCLIFlagsEqual(a: AgentProfile["cli_flags"], b: AgentProfile["cli_flags"]): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (
+      left[i].flag !== right[i].flag ||
+      left[i].enabled !== right[i].enabled ||
+      (left[i].description ?? "") !== (right[i].description ?? "")
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function useProfileEditorState(profile: AgentProfile) {
   const [draft, setDraft] = useState<AgentProfile>({ ...profile });
   const [savedProfile, setSavedProfile] = useState<AgentProfile>(profile);
@@ -183,7 +200,8 @@ function useProfileEditorState(profile: AgentProfile) {
       draft.model !== savedProfile.model ||
       (draft.mode ?? "") !== (savedProfile.mode ?? "") ||
       draft.allow_indexing !== savedProfile.allow_indexing ||
-      draft.cli_passthrough !== savedProfile.cli_passthrough,
+      draft.cli_passthrough !== savedProfile.cli_passthrough ||
+      !areCLIFlagsEqual(draft.cli_flags, savedProfile.cli_flags),
     [draft, savedProfile],
   );
 
@@ -236,6 +254,7 @@ function useProfileSave({
         mode: draft.mode,
         allow_indexing: draft.allow_indexing,
         cli_passthrough: draft.cli_passthrough,
+        cli_flags: draft.cli_flags,
       });
       setSavedProfile(updated);
       setDraft(updated);

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -389,6 +389,7 @@ function ProfileEditor({
           allow_indexing: draft.allow_indexing,
         }}
         cliPassthrough={draft.cli_passthrough}
+        cliFlags={draft.cli_flags ?? []}
       />
 
       <ProfileMcpConfigCard

--- a/apps/web/components/settings/cli-flags-field.tsx
+++ b/apps/web/components/settings/cli-flags-field.tsx
@@ -34,11 +34,7 @@ export function CLIFlagsField({ flags, onChange, variant = "default" }: CLIFlags
 
   return (
     <div className={isCompact ? "space-y-2" : "space-y-3"} data-testid="cli-flags-field">
-      <CLIFlagsHeader
-        total={flags.length}
-        enabled={enabledCount}
-        compact={isCompact}
-      />
+      <CLIFlagsHeader total={flags.length} enabled={enabledCount} compact={isCompact} />
       {flags.length === 0 ? (
         <p className="text-xs italic text-muted-foreground" data-testid="cli-flags-empty">
           No CLI flags configured. Add one below.

--- a/apps/web/components/settings/cli-flags-field.tsx
+++ b/apps/web/components/settings/cli-flags-field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
@@ -131,6 +131,9 @@ function CLIFlagRow({
 }
 
 function CLIFlagsAddForm({ onAdd }: { onAdd: (flag: string, description: string) => void }) {
+  const uid = useId();
+  const flagId = `${uid}-flag`;
+  const descId = `${uid}-desc`;
   const [newFlag, setNewFlag] = useState("");
   const [newDesc, setNewDesc] = useState("");
   const commit = () => {
@@ -140,36 +143,38 @@ function CLIFlagsAddForm({ onAdd }: { onAdd: (flag: string, description: string)
     setNewFlag("");
     setNewDesc("");
   };
+  const onEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && newFlag.trim() !== "") {
+      e.preventDefault();
+      commit();
+    }
+  };
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
       <div className="flex-1 space-y-1">
-        <Label className="text-xs" htmlFor="cli-flags-new-flag">
+        <Label className="text-xs" htmlFor={flagId}>
           Flag
         </Label>
         <Input
-          id="cli-flags-new-flag"
+          id={flagId}
           value={newFlag}
           onChange={(e) => setNewFlag(e.target.value)}
           placeholder="--my-flag or --key=value"
           data-testid="cli-flag-new-flag-input"
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && newFlag.trim() !== "") {
-              e.preventDefault();
-              commit();
-            }
-          }}
+          onKeyDown={onEnter}
         />
       </div>
       <div className="flex-1 space-y-1">
-        <Label className="text-xs" htmlFor="cli-flags-new-desc">
+        <Label className="text-xs" htmlFor={descId}>
           Description (optional)
         </Label>
         <Input
-          id="cli-flags-new-desc"
+          id={descId}
           value={newDesc}
           onChange={(e) => setNewDesc(e.target.value)}
           placeholder="What this flag does"
           data-testid="cli-flag-new-desc-input"
+          onKeyDown={onEnter}
         />
       </div>
       <Button

--- a/apps/web/components/settings/cli-flags-field.tsx
+++ b/apps/web/components/settings/cli-flags-field.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { IconPlus, IconTrash } from "@tabler/icons-react";
+import { Button } from "@kandev/ui/button";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import { Switch } from "@kandev/ui/switch";
+import type { CLIFlag } from "@/lib/types/http";
+
+type CLIFlagsFieldProps = {
+  flags: CLIFlag[];
+  onChange: (next: CLIFlag[]) => void;
+  variant?: "default" | "compact";
+};
+
+/**
+ * CLIFlagsField renders the unified list of user-configurable CLI flags on an
+ * agent profile. The list is seeded by the backend at profile creation with
+ * the agent's curated suggestions; the user can toggle entries, remove them,
+ * or append custom flags. Only entries with `enabled: true` reach the agent
+ * subprocess argv at task launch.
+ */
+export function CLIFlagsField({ flags, onChange, variant = "default" }: CLIFlagsFieldProps) {
+  const isCompact = variant === "compact";
+  const enabledCount = flags.filter((f) => f.enabled).length;
+
+  const toggleAt = (index: number, enabled: boolean) => {
+    onChange(flags.map((f, i) => (i === index ? { ...f, enabled } : f)));
+  };
+  const removeAt = (index: number) => onChange(flags.filter((_, i) => i !== index));
+  const appendCustom = (flag: string, description: string) =>
+    onChange([...flags, { flag, description, enabled: true }]);
+
+  return (
+    <div className={isCompact ? "space-y-2" : "space-y-3"} data-testid="cli-flags-field">
+      <CLIFlagsHeader
+        total={flags.length}
+        enabled={enabledCount}
+        compact={isCompact}
+      />
+      {flags.length === 0 ? (
+        <p className="text-xs italic text-muted-foreground" data-testid="cli-flags-empty">
+          No CLI flags configured. Add one below.
+        </p>
+      ) : (
+        <ul className="space-y-2" data-testid="cli-flags-list">
+          {flags.map((flag, index) => (
+            <CLIFlagRow
+              key={`${flag.flag}-${index}`}
+              flag={flag}
+              index={index}
+              onToggle={toggleAt}
+              onRemove={removeAt}
+            />
+          ))}
+        </ul>
+      )}
+      <CLIFlagsAddForm onAdd={appendCustom} />
+    </div>
+  );
+}
+
+function CLIFlagsHeader({
+  total,
+  enabled,
+  compact,
+}: {
+  total: number;
+  enabled: number;
+  compact: boolean;
+}) {
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <Label className={compact ? "text-xs" : undefined}>Agent CLI flags</Label>
+        {total > 0 && (
+          <span className="text-[10px] text-muted-foreground" data-testid="cli-flags-count">
+            {enabled} of {total} enabled
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Flags passed to the agent CLI on launch. Only enabled entries are applied. Use quotes for
+        values with spaces, e.g.{" "}
+        <code className="bg-muted px-1 rounded">{`--msg "hello world"`}</code>.
+      </p>
+    </>
+  );
+}
+
+function CLIFlagRow({
+  flag,
+  index,
+  onToggle,
+  onRemove,
+}: {
+  flag: CLIFlag;
+  index: number;
+  onToggle: (i: number, enabled: boolean) => void;
+  onRemove: (i: number) => void;
+}) {
+  return (
+    <li
+      className="flex items-start justify-between gap-3 rounded-md border p-3"
+      data-testid={`cli-flag-row-${index}`}
+    >
+      <div className="flex-1 min-w-0 space-y-1">
+        <code className="text-sm font-semibold break-all" data-testid={`cli-flag-text-${index}`}>
+          {flag.flag}
+        </code>
+        {flag.description && <p className="text-xs text-muted-foreground">{flag.description}</p>}
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Switch
+          checked={flag.enabled}
+          onCheckedChange={(checked) => onToggle(index, checked)}
+          data-testid={`cli-flag-enabled-${index}`}
+          aria-label={`${flag.enabled ? "Disable" : "Enable"} ${flag.flag}`}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRemove(index)}
+          className="cursor-pointer"
+          data-testid={`cli-flag-remove-${index}`}
+          aria-label={`Remove ${flag.flag}`}
+        >
+          <IconTrash className="h-4 w-4" />
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+function CLIFlagsAddForm({ onAdd }: { onAdd: (flag: string, description: string) => void }) {
+  const [newFlag, setNewFlag] = useState("");
+  const [newDesc, setNewDesc] = useState("");
+  const commit = () => {
+    const trimmed = newFlag.trim();
+    if (trimmed === "") return;
+    onAdd(trimmed, newDesc.trim());
+    setNewFlag("");
+    setNewDesc("");
+  };
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+      <div className="flex-1 space-y-1">
+        <Label className="text-xs" htmlFor="cli-flags-new-flag">
+          Flag
+        </Label>
+        <Input
+          id="cli-flags-new-flag"
+          value={newFlag}
+          onChange={(e) => setNewFlag(e.target.value)}
+          placeholder="--my-flag or --key=value"
+          data-testid="cli-flag-new-flag-input"
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && newFlag.trim() !== "") {
+              e.preventDefault();
+              commit();
+            }
+          }}
+        />
+      </div>
+      <div className="flex-1 space-y-1">
+        <Label className="text-xs" htmlFor="cli-flags-new-desc">
+          Description (optional)
+        </Label>
+        <Input
+          id="cli-flags-new-desc"
+          value={newDesc}
+          onChange={(e) => setNewDesc(e.target.value)}
+          placeholder="What this flag does"
+          data-testid="cli-flag-new-desc-input"
+        />
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={commit}
+        disabled={newFlag.trim() === ""}
+        className="cursor-pointer"
+        data-testid="cli-flag-add-button"
+      >
+        <IconPlus className="h-4 w-4 mr-1" />
+        Add
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/settings/cli-flags-field.tsx
+++ b/apps/web/components/settings/cli-flags-field.tsx
@@ -1,29 +1,82 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
 import { Switch } from "@kandev/ui/switch";
-import type { CLIFlag } from "@/lib/types/http";
+import type { CLIFlag, PermissionSetting } from "@/lib/types/http";
 
 type CLIFlagsFieldProps = {
   flags: CLIFlag[];
   onChange: (next: CLIFlag[]) => void;
+  /**
+   * The agent's curated PermissionSettings catalogue. Entries with
+   * apply_method === "cli_flag" render as labelled predefined toggles
+   * (one per setting) above the custom-flags list. The switch state is
+   * read from `flags` by matching `setting.cli_flag` to `flag.flag`.
+   */
+  permissionSettings?: Record<string, PermissionSetting>;
   variant?: "default" | "compact";
+  /**
+   * When true, the custom-flag list + Add form is hidden. Used by the
+   * onboarding flow, where users should only see the agent's curated
+   * predefined toggles and defer advanced edits to the profile page.
+   */
+  hideCustomFlags?: boolean;
+};
+
+type CuratedSetting = {
+  key: string;
+  label: string;
+  description: string;
+  flag: string;
+  default: boolean;
 };
 
 /**
- * CLIFlagsField renders the unified list of user-configurable CLI flags on an
- * agent profile. The list is seeded by the backend at profile creation with
- * the agent's curated suggestions; the user can toggle entries, remove them,
- * or append custom flags. Only entries with `enabled: true` reach the agent
- * subprocess argv at task launch.
+ * CLIFlagsField renders two distinct controls backed by the same
+ * `profile.cli_flags` list:
+ *
+ * 1. Predefined toggles — one Switch per entry in the agent's curated
+ *    PermissionSettings catalogue. Styled like the CLI Passthrough
+ *    toggle. State is read/written into cli_flags by flag-text match.
+ * 2. Custom flags — a list of user-authored entries (anything in
+ *    cli_flags whose flag text does not match a curated setting),
+ *    with an Add form for new entries.
+ *
+ * Only entries with `enabled: true` reach the agent subprocess argv at
+ * launch.
  */
-export function CLIFlagsField({ flags, onChange, variant = "default" }: CLIFlagsFieldProps) {
+export function CLIFlagsField({
+  flags,
+  onChange,
+  permissionSettings,
+  variant = "default",
+  hideCustomFlags = false,
+}: CLIFlagsFieldProps) {
   const isCompact = variant === "compact";
-  const enabledCount = flags.filter((f) => f.enabled).length;
+
+  const curated = useMemo(() => extractCuratedSettings(permissionSettings), [permissionSettings]);
+  const curatedFlagTexts = useMemo(() => new Set(curated.map((s) => s.flag)), [curated]);
+  const customFlags = useMemo(
+    () =>
+      flags
+        .map((f, i) => ({ flag: f, index: i }))
+        .filter((e) => !curatedFlagTexts.has(e.flag.flag)),
+    [flags, curatedFlagTexts],
+  );
+
+  const toggleCurated = (setting: CuratedSetting, enabled: boolean) => {
+    const existingIdx = flags.findIndex((f) => f.flag === setting.flag);
+    if (existingIdx >= 0) {
+      onChange(flags.map((f, i) => (i === existingIdx ? { ...f, enabled } : f)));
+      return;
+    }
+    if (!enabled) return; // nothing to turn off
+    onChange([...flags, { flag: setting.flag, description: setting.description, enabled: true }]);
+  };
 
   const toggleAt = (index: number, enabled: boolean) => {
     onChange(flags.map((f, i) => (i === index ? { ...f, enabled } : f)));
@@ -33,46 +86,112 @@ export function CLIFlagsField({ flags, onChange, variant = "default" }: CLIFlags
     onChange([...flags, { flag, description, enabled: true }]);
 
   return (
-    <div className={isCompact ? "space-y-2" : "space-y-3"} data-testid="cli-flags-field">
-      <CLIFlagsHeader total={flags.length} enabled={enabledCount} compact={isCompact} />
-      {flags.length === 0 ? (
-        <p className="text-xs italic text-muted-foreground" data-testid="cli-flags-empty">
-          No CLI flags configured. Add one below.
-        </p>
-      ) : (
-        <ul className="space-y-2" data-testid="cli-flags-list">
-          {flags.map((flag, index) => (
-            <CLIFlagRow
-              key={`${flag.flag}-${index}`}
-              flag={flag}
-              index={index}
-              onToggle={toggleAt}
-              onRemove={removeAt}
-            />
-          ))}
-        </ul>
+    <div className={isCompact ? "space-y-3" : "space-y-4"} data-testid="cli-flags-field">
+      {curated.length > 0 && (
+        <CuratedFlagsSection
+          curated={curated}
+          flags={flags}
+          onToggle={toggleCurated}
+          compact={isCompact}
+        />
       )}
-      <CLIFlagsAddForm onAdd={appendCustom} />
+      {!hideCustomFlags && (
+        <CustomFlagsSection
+          customFlags={customFlags}
+          onToggle={toggleAt}
+          onRemove={removeAt}
+          onAdd={appendCustom}
+          compact={isCompact}
+        />
+      )}
     </div>
   );
 }
 
-function CLIFlagsHeader({
-  total,
-  enabled,
+function extractCuratedSettings(
+  permissionSettings?: Record<string, PermissionSetting>,
+): CuratedSetting[] {
+  if (!permissionSettings) return [];
+  const out: CuratedSetting[] = [];
+  for (const [key, s] of Object.entries(permissionSettings)) {
+    if (!s.supported || s.apply_method !== "cli_flag" || !s.cli_flag) continue;
+    out.push({
+      key,
+      label: s.label,
+      description: s.description,
+      flag: s.cli_flag,
+      default: s.default,
+    });
+  }
+  // Stable order by flag text so the UI doesn't reshuffle across renders.
+  out.sort((a, b) => a.flag.localeCompare(b.flag));
+  return out;
+}
+
+function CuratedFlagsSection({
+  curated,
+  flags,
+  onToggle,
   compact,
 }: {
-  total: number;
-  enabled: number;
+  curated: CuratedSetting[];
+  flags: CLIFlag[];
+  onToggle: (setting: CuratedSetting, enabled: boolean) => void;
   compact: boolean;
 }) {
+  const labelCls = compact ? "text-xs" : undefined;
+  const switchSize = compact ? ("sm" as const) : ("default" as const);
   return (
-    <>
+    <div className="space-y-2" data-testid="cli-flags-curated">
+      {curated.map((setting) => {
+        const entry = flags.find((f) => f.flag === setting.flag);
+        const enabled = entry ? entry.enabled : setting.default;
+        return (
+          <div
+            key={setting.key}
+            className="flex items-center justify-between gap-3 rounded-md border p-3"
+            data-testid={`cli-flag-curated-${setting.key}`}
+          >
+            <div className="flex-1 min-w-0 space-y-0.5">
+              <Label className={labelCls}>{setting.label}</Label>
+              <p className="text-xs text-muted-foreground">{setting.description}</p>
+              <code className="text-[10px] text-muted-foreground/80">{setting.flag}</code>
+            </div>
+            <Switch
+              size={switchSize}
+              checked={enabled}
+              onCheckedChange={(checked) => onToggle(setting, checked)}
+              data-testid={`cli-flag-curated-enabled-${setting.key}`}
+              aria-label={`${enabled ? "Disable" : "Enable"} ${setting.label}`}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CustomFlagsSection({
+  customFlags,
+  onToggle,
+  onRemove,
+  onAdd,
+  compact,
+}: {
+  customFlags: Array<{ flag: CLIFlag; index: number }>;
+  onToggle: (index: number, enabled: boolean) => void;
+  onRemove: (index: number) => void;
+  onAdd: (flag: string, description: string) => void;
+  compact: boolean;
+}) {
+  const labelCls = compact ? "text-xs" : undefined;
+  return (
+    <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <Label className={compact ? "text-xs" : undefined}>Agent CLI flags</Label>
-        {total > 0 && (
+        <Label className={labelCls}>Agent CLI flags</Label>
+        {customFlags.length > 0 && (
           <span className="text-[10px] text-muted-foreground" data-testid="cli-flags-count">
-            {enabled} of {total} enabled
+            {customFlags.filter((e) => e.flag.enabled).length} of {customFlags.length} enabled
           </span>
         )}
       </div>
@@ -81,7 +200,26 @@ function CLIFlagsHeader({
         values with spaces, e.g.{" "}
         <code className="bg-muted px-1 rounded">{`--msg "hello world"`}</code>.
       </p>
-    </>
+
+      {customFlags.length === 0 ? (
+        <p className="text-xs italic text-muted-foreground" data-testid="cli-flags-empty">
+          No CLI flags configured. Add one below.
+        </p>
+      ) : (
+        <ul className="space-y-2" data-testid="cli-flags-list">
+          {customFlags.map(({ flag, index }) => (
+            <CLIFlagRow
+              key={`${flag.flag}-${index}`}
+              flag={flag}
+              index={index}
+              onToggle={onToggle}
+              onRemove={onRemove}
+            />
+          ))}
+        </ul>
+      )}
+      <CLIFlagsAddForm onAdd={onAdd} />
+    </div>
   );
 }
 

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -56,6 +56,12 @@ export type ProfileFormFieldsProps = {
   variant?: "default" | "compact";
   hideNameField?: boolean;
   lockPassthrough?: boolean;
+  /**
+   * When true, the custom-flag list + Add form on CLIFlagsField is
+   * hidden. Curated predefined toggles still render. Used by the
+   * onboarding flow to keep the first-run UI narrow.
+   */
+  hideCustomCLIFlags?: boolean;
 };
 
 type PermissionToggleProps = {
@@ -518,6 +524,7 @@ export function ProfileFormFields({
   variant = "default",
   hideNameField = false,
   lockPassthrough = false,
+  hideCustomCLIFlags = false,
 }: ProfileFormFieldsProps) {
   const isCompact = variant === "compact";
   const caps = useAgentCapabilities(agentName, modelConfig);
@@ -561,7 +568,9 @@ export function ProfileFormFields({
       <CLIFlagsField
         flags={profile.cli_flags}
         onChange={(next) => onChange({ cli_flags: next })}
+        permissionSettings={permissionSettings}
         variant={variant}
+        hideCustomFlags={hideCustomCLIFlags}
       />
     </div>
   );

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -25,7 +25,9 @@ import { ModeCombobox } from "@/components/settings/mode-combobox";
 import { ModelCombobox } from "@/components/settings/model-combobox";
 import { useAgentCapabilities } from "@/hooks/domains/settings/use-dynamic-models";
 import { PERMISSION_KEYS, type PermissionKey } from "@/lib/agent-permissions";
+import { CLIFlagsField } from "@/components/settings/cli-flags-field";
 import type {
+  CLIFlag,
   CommandEntry,
   ModelConfig,
   ModeEntry,
@@ -39,6 +41,7 @@ export type ProfileFormData = {
   model: string;
   mode: string;
   cli_passthrough: boolean;
+  cli_flags: CLIFlag[];
 } & Record<PermissionKey, boolean>;
 
 export type ProfileFormFieldsProps = {
@@ -553,6 +556,12 @@ export function ProfileFormFields({
         passthroughConfig={passthroughConfig}
         variant={variant}
         lockPassthrough={lockPassthrough}
+      />
+
+      <CLIFlagsField
+        flags={profile.cli_flags}
+        onChange={(next) => onChange({ cli_flags: next })}
+        variant={variant}
       />
     </div>
   );

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -90,6 +90,7 @@ function PermissionToggles({
         {PERMISSION_KEYS.map((key) => {
           const setting = permissionSettings[key];
           if (!setting?.supported) return null;
+          if (setting.apply_method === "cli_flag") return null;
           return (
             <div key={key} className="flex items-center justify-between gap-2">
               <div className="space-y-0.5">
@@ -131,6 +132,7 @@ function PermissionToggles({
       {PERMISSION_KEYS.map((key) => {
         const setting = permissionSettings[key];
         if (!setting?.supported) return null;
+        if (setting.apply_method === "cli_flag") return null;
         return (
           <div key={key} className="flex items-center justify-between rounded-md border p-3">
             <div className="space-y-1">

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -248,7 +248,10 @@ export class ApiClient {
       cli_passthrough?: boolean;
       cli_flags?: Array<{ description: string; flag: string; enabled: boolean }>;
     },
-  ): Promise<{ id: string; cli_flags: Array<{ description: string; flag: string; enabled: boolean }> }> {
+  ): Promise<{
+    id: string;
+    cli_flags: Array<{ description: string; flag: string; enabled: boolean }>;
+  }> {
     return this.request("POST", `/api/v1/agents/${agentId}/profiles`, {
       name,
       model: opts.model,
@@ -258,9 +261,7 @@ export class ApiClient {
     });
   }
 
-  async getAgentProfile(
-    profileId: string,
-  ): Promise<{
+  async getAgentProfile(profileId: string): Promise<{
     id: string;
     name: string;
     cli_flags: Array<{ description: string; flag: string; enabled: boolean }>;

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -5,7 +5,7 @@ import type {
   ListWorkflowsResponse,
   ListWorkflowStepsResponse,
 } from "../../lib/types/http";
-import type { Agent } from "../../lib/types/http-agents";
+import type { Agent, AgentProfile } from "../../lib/types/http-agents";
 
 // --- GitHub Mock Types ---
 
@@ -261,22 +261,14 @@ export class ApiClient {
     });
   }
 
-  async getAgentProfile(profileId: string): Promise<{
-    id: string;
-    name: string;
-    cli_flags: Array<{ description: string; flag: string; enabled: boolean }>;
-  }> {
+  async getAgentProfile(profileId: string): Promise<AgentProfile> {
     // The profile does not have its own GET endpoint; fetch via listAgents
     // and find the matching row. Keeps the helper surface small.
     const { agents } = await this.listAgents();
     for (const agent of agents) {
       for (const profile of agent.profiles ?? []) {
         if (profile.id === profileId) {
-          return profile as unknown as {
-            id: string;
-            name: string;
-            cli_flags: Array<{ description: string; flag: string; enabled: boolean }>;
-          };
+          return profile;
         }
       }
     }

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -246,19 +246,51 @@ export class ApiClient {
       model: string;
       mode?: string;
       cli_passthrough?: boolean;
+      cli_flags?: Array<{ description: string; flag: string; enabled: boolean }>;
     },
-  ): Promise<{ id: string }> {
+  ): Promise<{ id: string; cli_flags: Array<{ description: string; flag: string; enabled: boolean }> }> {
     return this.request("POST", `/api/v1/agents/${agentId}/profiles`, {
       name,
       model: opts.model,
       mode: opts.mode,
       cli_passthrough: opts.cli_passthrough ?? false,
+      cli_flags: opts.cli_flags,
     });
+  }
+
+  async getAgentProfile(
+    profileId: string,
+  ): Promise<{
+    id: string;
+    name: string;
+    cli_flags: Array<{ description: string; flag: string; enabled: boolean }>;
+  }> {
+    // The profile does not have its own GET endpoint; fetch via listAgents
+    // and find the matching row. Keeps the helper surface small.
+    const { agents } = await this.listAgents();
+    for (const agent of agents) {
+      for (const profile of agent.profiles ?? []) {
+        if (profile.id === profileId) {
+          return profile as unknown as {
+            id: string;
+            name: string;
+            cli_flags: Array<{ description: string; flag: string; enabled: boolean }>;
+          };
+        }
+      }
+    }
+    throw new Error(`profile ${profileId} not found`);
   }
 
   async updateAgentProfile(
     profileId: string,
-    patch: { name?: string; model?: string; mode?: string; cli_passthrough?: boolean },
+    patch: {
+      name?: string;
+      model?: string;
+      mode?: string;
+      cli_passthrough?: boolean;
+      cli_flags?: Array<{ description: string; flag: string; enabled: boolean }>;
+    },
   ): Promise<void> {
     await this.request("PATCH", `/api/v1/agent-profiles/${profileId}`, patch);
   }

--- a/apps/web/e2e/tests/settings/agent-profile-cli-flags.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-cli-flags.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from "../../fixtures/test-base";
+
+/**
+ * Verifies the unified CLI-flags feature on agent profiles:
+ *
+ * - The profile editor renders a "Agent CLI flags" section.
+ * - Users can add a custom flag via the form, save, and reload; the flag
+ *   persists in the DB (assert via the PATCH round-trip).
+ * - Toggling a flag off persists across save/reload.
+ * - Removing a flag persists across save/reload.
+ *
+ * Full argv-assembly (tokenisation + launch path) is covered by
+ * backend unit tests in apps/backend/internal/agent/lifecycle — we don't
+ * exercise a full task launch here because that's both slow and redundant.
+ */
+test.describe("Agent profile — CLI flags", () => {
+  test("cli-flags section renders on profile editor", async ({ testPage, apiClient }) => {
+    test.setTimeout(60_000);
+
+    const { agents } = await apiClient.listAgents();
+    const agent = agents[0];
+    const profileId = agent.profiles[0].id;
+
+    await testPage.goto(`/settings/agents/${agent.name}/profiles/${profileId}`);
+
+    // The CLIFlagsField component is always rendered once the profile form
+    // loads — regardless of whether the agent has curated suggestions.
+    const field = testPage.getByTestId("cli-flags-field");
+    await expect(field).toBeVisible({ timeout: 15_000 });
+
+    // Header and helper copy anchoring the section for the user.
+    await expect(field).toContainText(/Agent CLI flags/i);
+    await expect(field).toContainText(/Flags passed to the agent CLI/i);
+
+    // The Add form inputs and button are always available.
+    await expect(testPage.getByTestId("cli-flag-new-flag-input")).toBeVisible();
+    await expect(testPage.getByTestId("cli-flag-add-button")).toBeVisible();
+  });
+
+  test("adding a custom flag persists across reload", async ({ testPage, apiClient }) => {
+    test.setTimeout(90_000);
+
+    // Create a fresh profile so we don't pollute other tests' fixtures.
+    const { agents } = await apiClient.listAgents();
+    const agent = agents[0];
+    const profile = await apiClient.createAgentProfile(agent.id, "CLI flags test", {
+      model: "mock-fast",
+    });
+
+    try {
+      await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
+      await expect(testPage.getByTestId("cli-flags-field")).toBeVisible({ timeout: 15_000 });
+
+      // Add a custom flag via the UI.
+      const flagText = "--my-custom-flag=value";
+      await testPage.getByTestId("cli-flag-new-flag-input").fill(flagText);
+      await testPage.getByTestId("cli-flag-new-desc-input").fill("My custom flag for testing");
+      await testPage.getByTestId("cli-flag-add-button").click();
+
+      // The row should appear immediately, enabled by default.
+      await expect(testPage.getByTestId("cli-flags-list")).toContainText(flagText);
+      await expect(testPage.getByTestId("cli-flag-enabled-0")).toBeVisible();
+
+      // Save via the dirty-state save button; wait for unsaved badge to clear.
+      const saveButton = testPage.getByRole("button", { name: /^Save( changes)?$/i }).first();
+      await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+      await saveButton.click();
+      await expect(testPage.getByText(/unsaved changes/i)).toBeHidden({ timeout: 15_000 });
+
+      // Reload — the row must still be there.
+      await testPage.reload();
+      await expect(testPage.getByTestId("cli-flags-field")).toBeVisible({ timeout: 15_000 });
+      await expect(testPage.getByTestId("cli-flags-list")).toContainText(flagText);
+
+      // Direct DB-path verification: fetch the profile via the API and assert
+      // the cli_flags JSON contains our entry, enabled.
+      const stored = await apiClient.getAgentProfile(profile.id);
+      const found = stored.cli_flags.find((f) => f.flag === flagText);
+      expect(found, `cli_flags should include ${flagText}`).toBeDefined();
+      expect(found?.enabled).toBe(true);
+      expect(found?.description).toBe("My custom flag for testing");
+    } finally {
+      await apiClient.deleteAgentProfile(profile.id, true);
+    }
+  });
+
+  test("toggling a flag off persists across reload", async ({ testPage, apiClient }) => {
+    test.setTimeout(90_000);
+
+    const { agents } = await apiClient.listAgents();
+    const agent = agents[0];
+
+    // Seed a profile with one enabled flag via the API so the UI has
+    // something to toggle off.
+    const profile = await apiClient.createAgentProfile(agent.id, "CLI flags toggle test", {
+      model: "mock-fast",
+      cli_flags: [{ description: "toggle target", flag: "--toggle-me", enabled: true }],
+    });
+
+    try {
+      await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
+      await expect(testPage.getByTestId("cli-flags-field")).toBeVisible({ timeout: 15_000 });
+
+      // The first row should be enabled; toggle it off.
+      const toggle = testPage.getByTestId("cli-flag-enabled-0");
+      await expect(toggle).toHaveAttribute("data-state", "checked");
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("data-state", "unchecked");
+
+      const saveButton = testPage.getByRole("button", { name: /^Save( changes)?$/i }).first();
+      await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+      await saveButton.click();
+      await expect(testPage.getByText(/unsaved changes/i)).toBeHidden({ timeout: 15_000 });
+
+      // Reload and confirm the toggle remained off.
+      await testPage.reload();
+      await expect(testPage.getByTestId("cli-flag-enabled-0")).toHaveAttribute(
+        "data-state",
+        "unchecked",
+        { timeout: 15_000 },
+      );
+
+      const stored = await apiClient.getAgentProfile(profile.id);
+      const found = stored.cli_flags.find((f) => f.flag === "--toggle-me");
+      expect(found?.enabled).toBe(false);
+    } finally {
+      await apiClient.deleteAgentProfile(profile.id, true);
+    }
+  });
+
+  test("removing a flag persists across reload", async ({ testPage, apiClient }) => {
+    test.setTimeout(90_000);
+
+    const { agents } = await apiClient.listAgents();
+    const agent = agents[0];
+
+    const profile = await apiClient.createAgentProfile(agent.id, "CLI flags remove test", {
+      model: "mock-fast",
+      cli_flags: [
+        { description: "keep", flag: "--keep-me", enabled: true },
+        { description: "remove", flag: "--remove-me", enabled: true },
+      ],
+    });
+
+    try {
+      await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
+      await expect(testPage.getByTestId("cli-flags-field")).toBeVisible({ timeout: 15_000 });
+
+      // Two rows present initially.
+      await expect(testPage.getByTestId("cli-flag-row-0")).toBeVisible();
+      await expect(testPage.getByTestId("cli-flag-row-1")).toBeVisible();
+
+      // Remove the second (--remove-me).
+      await testPage.getByTestId("cli-flag-remove-1").click();
+      await expect(testPage.getByTestId("cli-flag-row-1")).toBeHidden();
+
+      const saveButton = testPage.getByRole("button", { name: /^Save( changes)?$/i }).first();
+      await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+      await saveButton.click();
+      await expect(testPage.getByText(/unsaved changes/i)).toBeHidden({ timeout: 15_000 });
+
+      await testPage.reload();
+      await expect(testPage.getByTestId("cli-flag-row-0")).toBeVisible({ timeout: 15_000 });
+      await expect(testPage.getByTestId("cli-flag-row-1")).toBeHidden();
+
+      const stored = await apiClient.getAgentProfile(profile.id);
+      expect(stored.cli_flags.map((f) => f.flag)).toEqual(["--keep-me"]);
+    } finally {
+      await apiClient.deleteAgentProfile(profile.id, true);
+    }
+  });
+});

--- a/apps/web/e2e/tests/settings/agent-profile-cli-flags.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-cli-flags.spec.ts
@@ -57,9 +57,11 @@ test.describe("Agent profile — CLI flags", () => {
       await testPage.getByTestId("cli-flag-new-desc-input").fill("My custom flag for testing");
       await testPage.getByTestId("cli-flag-add-button").click();
 
-      // The row should appear immediately, enabled by default.
+      // The row should appear immediately, enabled by default. The row's
+      // positional index depends on how many curated flags the agent seeded
+      // at profile creation, so locate the new row by its flag text rather
+      // than by position.
       await expect(testPage.getByTestId("cli-flags-list")).toContainText(flagText);
-      await expect(testPage.getByTestId("cli-flag-enabled-0")).toBeVisible();
 
       // Save via the dirty-state save button; wait for unsaved badge to clear.
       const saveButton = testPage.getByRole("button", { name: /^Save( changes)?$/i }).first();

--- a/apps/web/lib/cli-flags.test.ts
+++ b/apps/web/lib/cli-flags.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { areCLIFlagsEqual } from "./cli-flags";
+import type { CLIFlag } from "@/lib/types/http";
+
+const flag = (f: string, enabled = true, description = ""): CLIFlag => ({ flag: f, enabled, description });
+
+describe("areCLIFlagsEqual", () => {
+  it("two empty lists are equal", () => {
+    expect(areCLIFlagsEqual([], [])).toBe(true);
+  });
+
+  it("null and undefined are treated as empty", () => {
+    expect(areCLIFlagsEqual(null, undefined)).toBe(true);
+    expect(areCLIFlagsEqual(null, [])).toBe(true);
+    expect(areCLIFlagsEqual([], undefined)).toBe(true);
+  });
+
+  it("same flag same state", () => {
+    expect(areCLIFlagsEqual([flag("--x")], [flag("--x")])).toBe(true);
+  });
+
+  it("different lengths are not equal", () => {
+    expect(areCLIFlagsEqual([flag("--x")], [])).toBe(false);
+    expect(areCLIFlagsEqual([], [flag("--x")])).toBe(false);
+  });
+
+  it("same flag different enabled state", () => {
+    expect(areCLIFlagsEqual([flag("--x", true)], [flag("--x", false)])).toBe(false);
+  });
+
+  it("same flag different description", () => {
+    expect(areCLIFlagsEqual([flag("--x", true, "a")], [flag("--x", true, "b")])).toBe(false);
+  });
+
+  it("null description equals empty string description", () => {
+    const a: CLIFlag[] = [{ flag: "--x", enabled: true, description: null as unknown as string }];
+    const b: CLIFlag[] = [{ flag: "--x", enabled: true, description: "" }];
+    expect(areCLIFlagsEqual(a, b)).toBe(true);
+  });
+
+  it("order matters", () => {
+    const a = [flag("--a"), flag("--b")];
+    const b = [flag("--b"), flag("--a")];
+    expect(areCLIFlagsEqual(a, b)).toBe(false);
+  });
+});

--- a/apps/web/lib/cli-flags.test.ts
+++ b/apps/web/lib/cli-flags.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { areCLIFlagsEqual } from "./cli-flags";
 import type { CLIFlag } from "@/lib/types/http";
 
-const flag = (f: string, enabled = true, description = ""): CLIFlag => ({ flag: f, enabled, description });
+const flag = (f: string, enabled = true, description = ""): CLIFlag => ({
+  flag: f,
+  enabled,
+  description,
+});
 
 describe("areCLIFlagsEqual", () => {
   it("two empty lists are equal", () => {

--- a/apps/web/lib/cli-flags.ts
+++ b/apps/web/lib/cli-flags.ts
@@ -1,0 +1,26 @@
+import type { CLIFlag } from "@/lib/types/http";
+
+/**
+ * Deep-equality comparison for a profile's cli_flags list. Used by the
+ * profile dirty-detection paths in both the agent setup page and the
+ * per-profile editor. The list order matters — it matches the order the
+ * backend stores and the order CLIFlagsField renders.
+ */
+export function areCLIFlagsEqual(
+  a: CLIFlag[] | null | undefined,
+  b: CLIFlag[] | null | undefined,
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i++) {
+    if (
+      left[i].flag !== right[i].flag ||
+      left[i].enabled !== right[i].enabled ||
+      (left[i].description ?? "") !== (right[i].description ?? "")
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/apps/web/lib/types/http-agents.ts
+++ b/apps/web/lib/types/http-agents.ts
@@ -9,12 +9,24 @@ export type AgentProfile = {
   model: string;
   /** Optional ACP session mode applied via session/set_mode at session start. */
   mode?: string;
-  /** Auggie-only CLI flag; ignored for all other agents. */
+  /** @deprecated Use cli_flags. Retained for legacy clients. */
   allow_indexing: boolean;
+  /**
+   * User-configurable CLI flags passed to the agent subprocess. Seeded
+   * from the agent's curated suggestions at profile creation; users
+   * toggle/edit entries in the profile editor.
+   */
+  cli_flags: CLIFlag[];
   cli_passthrough: boolean;
   user_modified?: boolean;
   created_at: string;
   updated_at: string;
+};
+
+export type CLIFlag = {
+  description: string;
+  flag: string;
+  enabled: boolean;
 };
 
 export type TUIConfig = {

--- a/apps/web/lib/ws/handlers/agents.ts
+++ b/apps/web/lib/ws/handlers/agents.ts
@@ -14,6 +14,7 @@ function buildProfileEntry(profile: any) {
     auto_approve: profile.auto_approve,
     dangerously_skip_permissions: profile.dangerously_skip_permissions,
     allow_indexing: profile.allow_indexing,
+    cli_flags: profile.cli_flags ?? [],
     cli_passthrough: profile.cli_passthrough ?? false,
     plan: profile.plan,
     created_at: profile.created_at ?? "",
@@ -67,6 +68,7 @@ function handleProfileUpdated(state: AppState, profile: any): Partial<AppState> 
                   auto_approve: profile.auto_approve,
                   dangerously_skip_permissions: profile.dangerously_skip_permissions,
                   allow_indexing: profile.allow_indexing,
+                  cli_flags: profile.cli_flags ?? p.cli_flags ?? [],
                   plan: profile.plan,
                   updated_at: profile.updated_at ?? p.updated_at,
                 }


### PR DESCRIPTION
Users reported that Copilot prompts for permission on every tool call, even in autopilot mode; debugging confirmed Copilot's `--acp` ignores `session/set_mode` for permission gating but honours `--allow-all-tools` on the CLI. This PR adds a per-profile CLI-flags list so users can enable that flag (and any other agent flag) from the settings UI.

## Important Changes

- New `agent_profiles.cli_flags` TEXT column (JSON array) replaces case-by-case per-flag columns. Legacy `allow_indexing` is preserved for back-compat and back-filled into `cli_flags` on first read.
- `CommandBuilder.BuildCommand` now appends user-configured tokens once for every agent, so new agents participate automatically with no `BuildCommand` edits.
- Curated `PermissionSettings()` entries become the seed catalogue for a new profile's `cli_flags` — Copilot ships four curated suggestions, Auggie keeps its one.
- Added a quote-aware shell tokeniser in `internal/agent/settings/cliflags` so entries like `--add-dir /shared` split into two argv tokens at launch.
- Frontend gains a `CLIFlagsField` component (toggle + remove + add custom), wired into the existing profile editor.

## Validation

- `make fmt test lint` — 2904 Go tests pass, 0 lint issues.
- `pnpm --filter @kandev/web lint test` — 375 tests pass, 0 lint issues.
- `npx tsc --noEmit` in `apps/web` — clean (two pre-existing `@/generated/*` errors unrelated to this change).
- New Playwright spec `agent-profile-cli-flags.spec.ts` covers the settings-page round-trip (render, add custom, toggle, remove).
- Manual ACP probe via `acpdbg prompt copilot-acp` with `copilot --acp --allow-all-tools` produced zero `session/request_permission` frames — confirms the flag resolves the user report.

## Possible Improvements

Low risk. Each enabled `cli_flags` entry is shell-split at launch; malformed quotes fall back to the bare command with a warning log rather than failing the task. Legacy profiles that haven't been read yet still rely on the back-fill shim — if someone mass-queries the DB through a different path, they'd see `cli_flags` as NULL.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.