### PR TITLE
fix(workflows): tighten default template prompts for commits, todos, and PR review

### DIFF
--- a/apps/backend/config/workflows/architecture.yml
+++ b/apps/backend/config/workflows/architecture.yml
@@ -24,6 +24,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: UNDERSTAND THE REQUIREMENTS
       If anything is unclear or ambiguous, ask the user clarifying questions using the ask_user_question_kandev tool before proceeding.
 

--- a/apps/backend/config/workflows/feature-dev.yml
+++ b/apps/backend/config/workflows/feature-dev.yml
@@ -151,6 +151,12 @@ steps:
       - Only report findings you're >=80% confident about.
 
       Do NOT report issues on code that was not modified in this branch.
+
+      STEP 4: COMMIT ANY FIXES YOU MADE
+      If you made direct fixes in STEP 3:
+      - Run `git status` to see what changed.
+      - Stage and commit the fixes with a descriptive message (e.g. `review: remove dead code` or `review: early returns in X`).
+      - Do not leave the tree dirty — QA runs next and must see a clean state.
     events:
       on_enter:
         - type: reset_agent_context

--- a/apps/backend/config/workflows/feature-dev.yml
+++ b/apps/backend/config/workflows/feature-dev.yml
@@ -25,6 +25,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: UNDERSTAND THE PROBLEM
       - If anything is unclear or ambiguous, ask the user clarifying questions using the ask_user_question_kandev tool before proceeding.
       - Identify: what problem is being solved, who benefits, what are the constraints.
@@ -62,6 +65,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: RETRIEVE THE PLAN
       Before starting, retrieve the task plan using get_task_plan_kandev with the task_id from the session context.
       Review the plan carefully, including any edits the user may have made.
@@ -85,6 +91,12 @@ steps:
       - If you hit a blocker (missing dependency, unclear requirement, test fails repeatedly): stop and ask the user.
       - If a fix requires an architectural change (new DB table, new service layer, switching libraries): stop and ask.
       - After 3 failed fix attempts on the same issue: stop, question the approach, ask the user.
+
+      STEP 4: ENSURE EVERYTHING IS COMMITTED
+      Before finishing this phase:
+      - Run `git status` to confirm there are no uncommitted or untracked changes that belong to this task.
+      - If anything is left, stage and commit it with a descriptive message.
+      - The phase is only complete when `git status` shows a clean tree on the task branch.
     events:
       on_enter:
         - type: auto_start_agent
@@ -100,6 +112,9 @@ steps:
       Review the changes made in the Work phase for quality, security, and correctness.
 
       {{task_prompt}}
+
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
       STEP 1: DETERMINE WHAT TO REVIEW
       Determine the default branch (e.g. main, master) and diff against it:
@@ -153,6 +168,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: UNDERSTAND WHAT WAS BUILT
       Read the task description and recent commits to understand what the feature should do.
       Retrieve the task plan using get_task_plan_kandev if available.
@@ -195,6 +213,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: PREPARE
       - Run formatters and linters to ensure code is clean.
       - Stage and commit any remaining changes.
@@ -232,6 +253,9 @@ steps:
       Wait for CI checks to complete and fix any failures.
 
       {{task_prompt}}
+
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
       STEP 1: FIND THE PR
       Run gh pr list --head $(git branch --show-current) to find the PR number.

--- a/apps/backend/config/workflows/plan-and-build.yml
+++ b/apps/backend/config/workflows/plan-and-build.yml
@@ -25,6 +25,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: UNDERSTAND THE REQUIREMENTS
       If anything is unclear or ambiguous, ask the user clarifying questions using the ask_user_question_kandev tool before proceeding.
 
@@ -63,6 +66,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: RETRIEVE THE PLAN
       Before starting, retrieve the task plan using get_task_plan_kandev with the task_id from the session context.
       Review the plan carefully, including any edits the user may have made.
@@ -85,6 +91,12 @@ steps:
       - If you hit a blocker (missing dependency, unclear requirement, test fails repeatedly): stop and ask the user.
       - If a fix requires an architectural change (new DB table, new service layer, switching libraries): stop and ask.
       - After 3 failed fix attempts on the same issue: stop, question the approach, ask the user.
+
+      STEP 4: ENSURE EVERYTHING IS COMMITTED
+      Before finishing this phase:
+      - Run `git status` to confirm there are no uncommitted or untracked changes that belong to this task.
+      - If anything is left, stage and commit it with a descriptive message.
+      - The phase is only complete when `git status` shows a clean tree on the task branch.
     events:
       on_enter:
         - type: auto_start_agent

--- a/apps/backend/config/workflows/pr-review.yml
+++ b/apps/backend/config/workflows/pr-review.yml
@@ -29,20 +29,27 @@ steps:
       STEP 0: CREATE A TASK LIST
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
-      STEP 1: DETERMINE WHAT TO REVIEW
+      HARD RULE — READ THIS FIRST
+      You are reviewing the PR's DIFF, not the repository. Findings are only valid on lines that were ADDED or MODIFIED in this PR. Unchanged lines in changed files, and any code in files the PR did not touch, are OFF-LIMITS even if they contain real bugs. If you cannot point to the exact added/modified line in the PR diff that triggers a finding, discard the finding.
 
-      The PR branch is checked out and the full codebase is available. You can and should read surrounding code to understand changes in context.
-      - Extract the PR number from the task description (e.g. from the GitHub URL)
-      - Run: gh pr view <number> --json headRefName,baseRefName to confirm the branch and base
-      - Run: git diff origin/<base_branch>...HEAD --name-only to get the list of changed files
-      - Run: git diff origin/<base_branch>...HEAD to see the full diff
-      - Read each changed file in full — understand the surrounding code, not just the diff
-      - Navigate related files (callers, interfaces, tests) to understand the change end-to-end
-      - Only REPORT issues on code that was modified in this PR, but USE the full codebase for context
+      STEP 1: GET THE PR DIFF AND ENUMERATE CHANGED LINES
 
-      STEP 2: REVIEW THE CHANGES
+      - Extract the PR number from the task description (e.g. from the GitHub URL).
+      - Run: gh pr view <number> --json headRefName,baseRefName,title,body to confirm branch, base, and intent.
+      - Run: gh pr diff <number> to fetch the canonical PR diff (this is what GitHub shows reviewers).
+      - For each file in the diff, list the changed hunks as (file, start_line-end_line) for the NEW side (added/modified lines only — ignore removed-only lines and unchanged context lines).
+      - Write this "changed-lines map" down at the top of your review notes. Every finding you later report must cite a (file, line) pair that falls inside this map.
 
-      Review across these layers (skip layers that don't apply):
+      STEP 2: READ FOR CONTEXT, NOT FOR FINDINGS
+
+      Context reading is allowed only to understand whether a changed line is correct. It is never a source of findings.
+      - Open each changed file and read the surrounding function / block so you understand what the added lines do.
+      - Navigate to callers, interfaces, or tests only if needed to judge a changed line.
+      - Do NOT scan unchanged code looking for issues. Do NOT review files outside the diff.
+
+      STEP 3: REVIEW THE CHANGED LINES
+
+      Walk through the changed-lines map hunk by hunk. For each hunk, consider these layers (skip layers that don't apply):
 
       Security (blockers if found):
       - No secrets, tokens, or credentials in code
@@ -75,11 +82,17 @@ steps:
       - as any / as unknown casts to dodge type errors instead of fixing types
       - Redundant validation where inputs are already parsed/typed
 
-      OUTPUT FORMAT:
+      STEP 4: SELF-CHECK EVERY FINDING BEFORE REPORTING
 
-      For each finding, provide: file:line - description, why it matters, and how to fix it.
-      Only report findings you're >=80% confident about.
+      For each candidate finding, do this check. Drop the finding if any answer is "no":
+      1. Is the cited (file, line) inside the changed-lines map from STEP 1?
+      2. Can you quote the exact added/modified line from the PR diff that triggers it? (Include that quoted line in your notes.)
+      3. Is the issue caused by this PR, not pre-existing?
+      4. Are you >=80% confident it's a real issue?
 
+      STEP 5: OUTPUT
+
+      For each finding: file:line - description, why it matters, how to fix it, and the quoted diff line.
       Use these sections (omit empty ones):
 
       BLOCKER (must fix before merge — security, data loss, broken logic):
@@ -90,8 +103,8 @@ steps:
 
       End with a verdict: Ready to merge / Ready with suggestions / Blocked
 
-      NOT A FINDING (skip these):
-      - Issues on lines or files the PR didn't modify — even if they are real bugs
+      NOT A FINDING (never report these):
+      - Any line not in the changed-lines map — even if it's a real bug
       - Pre-existing code patterns that this PR didn't introduce or change
       - Things linters, typecheckers, or CI catch (imports, types, formatting)
       - Intentional functionality changes directly related to the PR's purpose

--- a/apps/backend/config/workflows/pr-review.yml
+++ b/apps/backend/config/workflows/pr-review.yml
@@ -26,11 +26,11 @@ steps:
 
       {{task_prompt}}
 
-      STEP 0: CREATE A TASK LIST
-      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
-
       HARD RULE — READ THIS FIRST
       You are reviewing the PR's DIFF, not the repository. Findings are only valid on lines that were ADDED or MODIFIED in this PR. Unchanged lines in changed files, and any code in files the PR did not touch, are OFF-LIMITS even if they contain real bugs. If you cannot point to the exact added/modified line in the PR diff that triggers a finding, discard the finding.
+
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
       STEP 1: GET THE PR DIFF AND ENUMERATE CHANGED LINES
 

--- a/apps/backend/config/workflows/pr-review.yml
+++ b/apps/backend/config/workflows/pr-review.yml
@@ -26,6 +26,9 @@ steps:
 
       {{task_prompt}}
 
+      STEP 0: CREATE A TASK LIST
+      Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
+
       STEP 1: DETERMINE WHAT TO REVIEW
 
       The PR branch is checked out and the full codebase is available. You can and should read surrounding code to understand changes in context.


### PR DESCRIPTION
Users reported two recurring failures in the built-in workflow templates: the Work phase of `feature-dev` sometimes finished with uncommitted changes, and the PR Review phase frequently flagged lines the PR had not touched. Rework the default prompts so agents create a substep task list up front, end Work/Implementation with a clean tree, and anchor PR review findings strictly to the PR diff.

## Important Changes

- Add `STEP 0: CREATE A TASK LIST` preamble to every multi-step default prompt (`feature-dev` spec/work/review/qa/pr/ci-fixup, `plan-and-build` plan/implementation, `pr-review` review, `architecture` planning), mirroring the `feature` skill pipeline pattern.
- Add `STEP 4: ENSURE EVERYTHING IS COMMITTED` to the Work (feature-dev) and Implementation (plan-and-build) prompts — the phase is only complete when `git status` is clean.
- Rewrite the PR Review prompt: a hard "findings must cite added/modified diff lines" rule up front, explicit enumeration of the changed-lines map via `gh pr diff`, separation of context reading from finding generation, and a per-finding self-check that quotes the diff line.

## Validation

- `go test ./config/workflows/...` (loader + embed validation pass — confirms all 5 templates parse, each has one start step, `move_to_step` refs resolve, positions unique).

## Possible Improvements

Low risk — YAML-only prompt changes, no code paths touched. If an agent's todo/task tool is unavailable it will silently skip STEP 0; that's intentional ("if available") and matches the `feature` skill pattern.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.