### PR TITLE
fix(backend): silence spurious errors during Ctrl+C shutdown

### DIFF
--- a/apps/backend/internal/agent/lifecycle/manager.go
+++ b/apps/backend/internal/agent/lifecycle/manager.go
@@ -4,6 +4,7 @@ package lifecycle
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -82,6 +83,12 @@ type Manager struct {
 	remoteStatusBySession    map[string]*RemoteStatus
 	stopCh                   chan struct{}
 	wg                       sync.WaitGroup
+	// shuttingDown is flipped true when graceful shutdown begins (see
+	// StopAllAgents) so handlers running in detached goroutines can
+	// short-circuit work that would otherwise race the teardown and log
+	// confusing errors against children that already died from the same
+	// terminal-wide SIGINT.
+	shuttingDown atomic.Bool
 
 	// pollAggregator routes hub session-mode events to agentctl. See
 	// manager_subscription.go.

--- a/apps/backend/internal/agent/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/lifecycle/manager_interaction.go
@@ -395,9 +395,18 @@ func (m *Manager) StopAgentWithReason(ctx context.Context, executionID string, r
 	if execution.agentctl != nil {
 		if !force {
 			if err := execution.agentctl.Stop(ctx); err != nil {
-				m.logger.Warn("failed to stop agent via agentctl",
-					zap.String("execution_id", executionID),
-					zap.Error(err))
+				// During shutdown agentctl typically received the same
+				// terminal-wide SIGINT and is already gone, so a failed
+				// HTTP call here is expected, not noteworthy.
+				if m.IsShuttingDown() {
+					m.logger.Debug("failed to stop agent via agentctl",
+						zap.String("execution_id", executionID),
+						zap.Error(err))
+				} else {
+					m.logger.Warn("failed to stop agent via agentctl",
+						zap.String("execution_id", executionID),
+						zap.Error(err))
+				}
 			}
 		}
 		execution.agentctl.Close()
@@ -994,9 +1003,18 @@ func (m *Manager) stopAgentViaBackend(ctx context.Context, executionID string, e
 		StopReason:           reason,
 	}
 	if err := rt.StopInstance(ctx, runtimeInstance, force); err != nil {
-		m.logger.Warn("failed to stop runtime instance, continuing with cleanup",
-			zap.String("execution_id", executionID),
-			zap.Error(err))
+		// During shutdown the runtime instance (e.g. a standalone agentctl)
+		// often already exited via the shared SIGINT, so StopInstance returns
+		// a benign 404. Only surface this at WARN outside shutdown.
+		if m.IsShuttingDown() {
+			m.logger.Debug("failed to stop runtime instance, continuing with cleanup",
+				zap.String("execution_id", executionID),
+				zap.Error(err))
+		} else {
+			m.logger.Warn("failed to stop runtime instance, continuing with cleanup",
+				zap.String("execution_id", executionID),
+				zap.Error(err))
+		}
 	}
 }
 

--- a/apps/backend/internal/agent/lifecycle/manager_lifecycle.go
+++ b/apps/backend/internal/agent/lifecycle/manager_lifecycle.go
@@ -133,6 +133,14 @@ func (m *Manager) GetRecoveredExecutions() []RecoveredExecution {
 	return result
 }
 
+// IsShuttingDown reports whether graceful shutdown has begun. Set by
+// StopAllAgents before it starts tearing down executions so concurrent
+// handlers (e.g. passthrough exit auto-restart, agentctl HTTP calls) can
+// skip or downgrade work that would otherwise race the teardown.
+func (m *Manager) IsShuttingDown() bool {
+	return m.shuttingDown.Load()
+}
+
 // Stop stops the lifecycle manager and releases resources held by executors.
 func (m *Manager) Stop() error {
 	m.logger.Info("stopping lifecycle manager")
@@ -150,6 +158,8 @@ func (m *Manager) Stop() error {
 
 // StopAllAgents attempts a graceful shutdown of all active agents concurrently.
 func (m *Manager) StopAllAgents(ctx context.Context) error {
+	m.shuttingDown.Store(true)
+
 	executions := m.executionStore.List()
 	if len(executions) == 0 {
 		return nil

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough.go
@@ -586,6 +586,12 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 
 	sessionID := execution.SessionID
 
+	if m.IsShuttingDown() {
+		m.logger.Debug("skipping passthrough auto-restart during shutdown",
+			zap.String("session_id", sessionID))
+		return
+	}
+
 	// Wait a bit for the old process to be cleaned up from the process map
 	time.Sleep(cleanupDelay)
 
@@ -622,6 +628,14 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 
 	// Delay before restart
 	time.Sleep(restartDelay)
+
+	// Shutdown may have started during the sleep; re-check before touching
+	// state that the teardown is racing to remove.
+	if m.IsShuttingDown() {
+		m.logger.Debug("skipping passthrough auto-restart during shutdown",
+			zap.String("session_id", sessionID))
+		return
+	}
 
 	// Check WebSocket is still connected after delay (use session-level tracking)
 	if !interactiveRunner.HasActiveWebSocketBySession(sessionID) {

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough.go
@@ -595,6 +595,15 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 	// Wait a bit for the old process to be cleaned up from the process map
 	time.Sleep(cleanupDelay)
 
+	// Shutdown may have started during cleanupDelay; re-check before emitting
+	// the "attempting auto-restart" log and the terminal banner, which would
+	// otherwise mislead the user during a clean shutdown.
+	if m.IsShuttingDown() {
+		m.logger.Debug("skipping passthrough auto-restart during shutdown",
+			zap.String("session_id", sessionID))
+		return
+	}
+
 	interactiveRunner := m.GetInteractiveRunner()
 	if interactiveRunner == nil {
 		m.logger.Debug("no interactive runner available for auto-restart",

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
@@ -3,8 +3,10 @@ package lifecycle
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agent/agents"
+	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
 )
 
 // mockPassthroughProfileResolver is a mock for testing passthrough verification
@@ -215,6 +217,50 @@ func TestBuildPassthroughCommand(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestManager_HandlePassthroughExit_SkipsDuringShutdown verifies that the
+// detached goroutine spawned when a passthrough child exits bails out
+// immediately once graceful shutdown has begun, instead of racing the
+// teardown and logging a spurious "failed to auto-restart passthrough
+// session" error. Regression test for the Ctrl+C-in-terminal shutdown
+// noise.
+func TestManager_HandlePassthroughExit_SkipsDuringShutdown(t *testing.T) {
+	mgr := newTestManager()
+
+	if mgr.IsShuttingDown() {
+		t.Fatal("fresh manager reports IsShuttingDown() == true")
+	}
+
+	// StopAllAgents should flip the flag even with zero executions.
+	if err := mgr.StopAllAgents(context.Background()); err != nil {
+		t.Fatalf("StopAllAgents returned error: %v", err)
+	}
+	if !mgr.IsShuttingDown() {
+		t.Fatal("StopAllAgents did not set IsShuttingDown() = true")
+	}
+
+	// The exit handler normally sleeps cleanupDelay (100ms) + restartDelay
+	// (500ms) before touching any state. If the shutdown short-circuit works,
+	// it must return well before cleanupDelay elapses.
+	execution := &AgentExecution{ID: "exec-1", SessionID: "sess-1"}
+	status := &agentctltypes.ProcessStatusUpdate{SessionID: "sess-1"}
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		mgr.handlePassthroughExit(execution, status)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+			t.Errorf("handlePassthroughExit did not short-circuit during shutdown: took %v", elapsed)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("handlePassthroughExit did not return promptly during shutdown")
 	}
 }
 

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/agents"
@@ -226,42 +227,35 @@ func TestBuildPassthroughCommand(t *testing.T) {
 // teardown and logging a spurious "failed to auto-restart passthrough
 // session" error. Regression test for the Ctrl+C-in-terminal shutdown
 // noise.
+//
+// Uses testing/synctest so the assertion is "the function returned without
+// any time advancing" — i.e. it short-circuited before the cleanupDelay
+// sleep. Under fake time, a non-short-circuit path would advance by
+// cleanupDelay (and then take the nil-runner branch in the test rig).
 func TestManager_HandlePassthroughExit_SkipsDuringShutdown(t *testing.T) {
-	mgr := newTestManager()
+	synctest.Test(t, func(t *testing.T) {
+		mgr := newTestManager()
 
-	if mgr.IsShuttingDown() {
-		t.Fatal("fresh manager reports IsShuttingDown() == true")
-	}
-
-	// StopAllAgents should flip the flag even with zero executions.
-	if err := mgr.StopAllAgents(context.Background()); err != nil {
-		t.Fatalf("StopAllAgents returned error: %v", err)
-	}
-	if !mgr.IsShuttingDown() {
-		t.Fatal("StopAllAgents did not set IsShuttingDown() = true")
-	}
-
-	// The exit handler normally sleeps cleanupDelay (100ms) + restartDelay
-	// (500ms) before touching any state. If the shutdown short-circuit works,
-	// it must return well before cleanupDelay elapses.
-	execution := &AgentExecution{ID: "exec-1", SessionID: "sess-1"}
-	status := &agentctltypes.ProcessStatusUpdate{SessionID: "sess-1"}
-
-	done := make(chan struct{})
-	start := time.Now()
-	go func() {
-		mgr.handlePassthroughExit(execution, status)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
-			t.Errorf("handlePassthroughExit did not short-circuit during shutdown: took %v", elapsed)
+		if mgr.IsShuttingDown() {
+			t.Fatal("fresh manager reports IsShuttingDown() == true")
 		}
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("handlePassthroughExit did not return promptly during shutdown")
-	}
+
+		if err := mgr.StopAllAgents(context.Background()); err != nil {
+			t.Fatalf("StopAllAgents returned error: %v", err)
+		}
+		if !mgr.IsShuttingDown() {
+			t.Fatal("StopAllAgents did not set IsShuttingDown() = true")
+		}
+
+		execution := &AgentExecution{ID: "exec-1", SessionID: "sess-1"}
+		status := &agentctltypes.ProcessStatusUpdate{SessionID: "sess-1"}
+
+		start := time.Now()
+		mgr.handlePassthroughExit(execution, status)
+		if elapsed := time.Since(start); elapsed != 0 {
+			t.Errorf("handlePassthroughExit advanced fake time by %v — did not short-circuit during shutdown", elapsed)
+		}
+	})
 }
 
 func TestManager_VerifyPassthroughEnabled(t *testing.T) {


### PR DESCRIPTION
Pressing Ctrl+C in the terminal running kandev broadcasts SIGINT to the whole process group, so `agentctl` and passthrough children die at the same instant as the backend; the graceful-shutdown code then HTTP-calls an already-dead agentctl and a detached goroutine tries to auto-restart the just-exited passthrough session, producing confusing WARN/ERROR spew (including a stack-traced ERROR) that makes the first Ctrl+C look ineffective. Single Ctrl+C now exits cleanly with no false-positive errors.

## Important Changes

- `Manager.shuttingDown atomic.Bool` + `IsShuttingDown()`, flipped at the top of `StopAllAgents`.
- `handlePassthroughExit` bails out before its cleanup/restart delays when shutting down — eliminates the spurious `failed to auto-restart passthrough session` ERROR.
- `failed to stop agent via agentctl` and `failed to stop runtime instance` downgrade to Debug during shutdown (expected when agentctl already received SIGINT); still WARN outside shutdown.

## Validation

- `go build ./...`, `go vet ./...` — clean.
- `go test ./internal/agent/lifecycle/ -run 'Passthrough|StopAllAgents|IsShuttingDown' -count=1` — pass, including new `TestManager_HandlePassthroughExit_SkipsDuringShutdown` regression test.
- Full `make test` passes except pre-existing `internal/repoclone` failure from the test env's git-signing server returning 400 (unrelated).
- `make lint` fails to start due to a pre-existing golangci-lint / Go 1.26 toolchain mismatch in this env (unrelated).

## Possible Improvements

Low risk. Behavior outside shutdown is unchanged — only the log level of two messages shifts, and only while `StopAllAgents` has flipped the flag. Worst case is an unexpected agentctl-down during normal operation being logged at Debug instead of Warn if `StopAllAgents` were ever called outside shutdown.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
