### PR TITLE
fix(cli): detect standalone server.js at non-default path

### DIFF
--- a/apps/cli/src/start.test.ts
+++ b/apps/cli/src/start.test.ts
@@ -26,15 +26,7 @@ describe("resolveStandaloneServerPath", () => {
   });
 
   it("returns the expected path when .next/standalone/web/server.js exists", () => {
-    const expected = path.join(
-      repoRoot,
-      "apps",
-      "web",
-      ".next",
-      "standalone",
-      "web",
-      "server.js",
-    );
+    const expected = path.join(repoRoot, "apps", "web", ".next", "standalone", "web", "server.js");
     writeFile(expected);
 
     expect(resolveStandaloneServerPath(repoRoot)).toBe(expected);

--- a/apps/cli/src/start.test.ts
+++ b/apps/cli/src/start.test.ts
@@ -64,4 +64,11 @@ describe("resolveStandaloneServerPath", () => {
 
     expect(resolveStandaloneServerPath(repoRoot)).toBeNull();
   });
+
+  it("ignores server.js inside node_modules/web/", () => {
+    const standaloneDir = path.join(repoRoot, "apps", "web", ".next", "standalone");
+    writeFile(path.join(standaloneDir, "node_modules", "web", "server.js"));
+
+    expect(resolveStandaloneServerPath(repoRoot)).toBeNull();
+  });
 });

--- a/apps/cli/src/start.test.ts
+++ b/apps/cli/src/start.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveStandaloneServerPath } from "./start";
+
+function makeRepo(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "kandev-start-test-"));
+}
+
+function writeFile(filePath: string, contents = "") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+describe("resolveStandaloneServerPath", () => {
+  let repoRoot: string;
+
+  beforeEach(() => {
+    repoRoot = makeRepo();
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("returns the expected path when .next/standalone/web/server.js exists", () => {
+    const expected = path.join(
+      repoRoot,
+      "apps",
+      "web",
+      ".next",
+      "standalone",
+      "web",
+      "server.js",
+    );
+    writeFile(expected);
+
+    expect(resolveStandaloneServerPath(repoRoot)).toBe(expected);
+  });
+
+  it("finds server.js at a deeper path (Turbopack root mismatch)", () => {
+    const nested = path.join(
+      repoRoot,
+      "apps",
+      "web",
+      ".next",
+      "standalone",
+      "Users",
+      "alice",
+      "projects",
+      "kandev",
+      "apps",
+      "web",
+      "server.js",
+    );
+    writeFile(nested);
+
+    expect(resolveStandaloneServerPath(repoRoot)).toBe(nested);
+  });
+
+  it("returns null when .next/standalone/ does not exist", () => {
+    expect(resolveStandaloneServerPath(repoRoot)).toBeNull();
+  });
+
+  it("returns null when standalone/ exists but has no web/server.js", () => {
+    const standaloneDir = path.join(repoRoot, "apps", "web", ".next", "standalone");
+    fs.mkdirSync(standaloneDir, { recursive: true });
+    // Stray server.js that is NOT inside a `web/` directory.
+    writeFile(path.join(standaloneDir, "node_modules", "next", "server.js"));
+
+    expect(resolveStandaloneServerPath(repoRoot)).toBeNull();
+  });
+});

--- a/apps/cli/src/start.ts
+++ b/apps/cli/src/start.ts
@@ -61,7 +61,7 @@ function findWebServerJs(dir: string): string | null {
       continue;
     }
     for (const entry of entries) {
-      if (entry.isDirectory()) {
+      if (entry.isDirectory() && entry.name !== "node_modules") {
         stack.push(path.join(current, entry.name));
       } else if (entry.isFile() && entry.name === "server.js" && path.basename(current) === "web") {
         return path.join(current, entry.name);

--- a/apps/cli/src/start.ts
+++ b/apps/cli/src/start.ts
@@ -45,12 +45,27 @@ export function resolveStandaloneServerPath(repoRoot: string): string | null {
   if (fs.existsSync(expected)) return expected;
   if (!fs.existsSync(standaloneDir)) return null;
 
-  const entries = fs.readdirSync(standaloneDir, { recursive: true, withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isFile() || entry.name !== "server.js") continue;
-    const parent = entry.parentPath;
-    if (path.basename(parent) === "web") {
-      return path.join(parent, entry.name);
+  return findWebServerJs(standaloneDir);
+}
+
+// Walks `dir` manually instead of relying on `Dirent.parentPath` (Node 20.12+),
+// so the CLI keeps working on older Node 20.x runtimes installed via npx.
+function findWebServerJs(dir: string): string | null {
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop() as string;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        stack.push(path.join(current, entry.name));
+      } else if (entry.isFile() && entry.name === "server.js" && path.basename(current) === "web") {
+        return path.join(current, entry.name);
+      }
     }
   }
   return null;

--- a/apps/cli/src/start.ts
+++ b/apps/cli/src/start.ts
@@ -28,6 +28,34 @@ import {
 } from "./shared";
 import { launchWebApp, openBrowser } from "./web";
 
+/**
+ * Locates the standalone Next.js `server.js` inside `apps/web/.next/standalone/`.
+ *
+ * Normally this sits at `.next/standalone/web/server.js`, but Turbopack may
+ * place it under a deeper path (e.g. `.next/standalone/Users/.../web/server.js`)
+ * when it detects the wrong project root (typically caused by a stray
+ * `package-lock.json` in a parent directory). We look for any `web/server.js`
+ * below the standalone directory so `kandev start` keeps working.
+ *
+ * @returns absolute path to `server.js`, or null if it cannot be found.
+ */
+export function resolveStandaloneServerPath(repoRoot: string): string | null {
+  const standaloneDir = path.join(repoRoot, "apps", "web", ".next", "standalone");
+  const expected = path.join(standaloneDir, "web", "server.js");
+  if (fs.existsSync(expected)) return expected;
+  if (!fs.existsSync(standaloneDir)) return null;
+
+  const entries = fs.readdirSync(standaloneDir, { recursive: true, withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isFile() || entry.name !== "server.js") continue;
+    const parent = entry.parentPath;
+    if (path.basename(parent) === "web") {
+      return path.join(parent, entry.name);
+    }
+  }
+  return null;
+}
+
 export type StartOptions = {
   /** Path to the repository root directory */
   repoRoot: string;
@@ -69,17 +97,18 @@ export async function runStart({
   }
 
   // Check for standalone build (Next.js standalone output)
-  const webServerPath = path.join(
-    repoRoot,
-    "apps",
-    "web",
-    ".next",
-    "standalone",
-    "web",
-    "server.js",
-  );
-  if (!fs.existsSync(webServerPath)) {
-    throw new Error("Web standalone build not found. Run `make build` first.");
+  const webServerPath = resolveStandaloneServerPath(repoRoot);
+  if (!webServerPath) {
+    const standaloneDir = path.join(repoRoot, "apps", "web", ".next", "standalone");
+    if (!fs.existsSync(standaloneDir)) {
+      throw new Error("Web standalone build not found. Run `make build` first.");
+    }
+    throw new Error(
+      `Web standalone build is missing server.js under ${standaloneDir}. ` +
+        "This can happen when Next.js/Turbopack detects a different project root " +
+        "(e.g. a stray package-lock.json in a parent directory). " +
+        "Remove the stray lockfile and re-run `make build`.",
+    );
   }
   const webStandaloneDir = path.dirname(webServerPath);
   const webStaticDir = path.join(repoRoot, "apps", "web", ".next", "static");


### PR DESCRIPTION
A stray `package-lock.json` in a parent directory makes Next.js Turbopack treat that ancestor as the project root, nesting the standalone output (e.g. `.next/standalone/Users/.../web/server.js`) and causing `kandev start` to wrongly report "Run `make build` first" despite a successful build. `kandev start` now walks `.next/standalone/` to locate `web/server.js` at any depth, and falls back to a targeted error message when the directory exists but the file is missing.

## Validation

- `pnpm --filter kandev test` — 83/83 tests pass (4 new tests for `resolveStandaloneServerPath`: default layout, nested Turbopack layout, missing `standalone/`, and `standalone/` without `web/server.js`).
- `pnpm --filter kandev build` — clean `tsc` compile.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
