### PR TITLE
fix(web): stop "Preparing workspace" flashing on step move and refresh stale chats

### DIFF
--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -390,7 +390,8 @@ export function ChatInputArea({
         mcpServers={panelState.mcpServers}
         onPlanModeChange={handlePlanModeChange}
         isAgentBusy={isAgentBusy}
-        isStarting={panelState.isStarting || isMoving}
+        isStarting={panelState.isStarting}
+        isMoving={isMoving}
         isSending={isSending}
         onCancel={handleCancelTurn}
         placeholder={placeholder}

--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -57,6 +57,7 @@ type ChatInputContainerProps = {
   onPlanModeChange: (enabled: boolean) => void;
   isAgentBusy: boolean;
   isStarting: boolean;
+  isMoving?: boolean;
   isSending: boolean;
   onCancel: () => void;
   placeholder?: string;
@@ -241,10 +242,12 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
       taskDescription,
       isAgentBusy,
       isStarting,
+      isMoving = false,
       isSending,
       isFailed = false,
       showRequestChangesTooltip = false,
     } = props;
+    const isBusyVisual = isStarting || isMoving;
 
     const p = {
       ...props,
@@ -262,6 +265,7 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
       sessionId,
       isSending,
       isStarting,
+      isMoving,
       isFailed: p.isFailed,
       needsRecovery: props.needsRecovery ?? false,
       isAgentBusy,
@@ -309,7 +313,7 @@ export const ChatInputContainer = forwardRef<ChatInputContainerHandle, ChatInput
         containerRef={s.containerRef}
         height={s.height}
         resizeHandleProps={s.resizeHandleProps}
-        isStarting={isStarting}
+        isStarting={isBusyVisual}
         isAgentBusy={isAgentBusy}
         hasClarification={s.hasClarification}
         showRequestChangesTooltip={showRequestChangesTooltip}

--- a/apps/web/components/task/chat/use-chat-input-container.ts
+++ b/apps/web/components/task/chat/use-chat-input-container.ts
@@ -16,6 +16,7 @@ type UseChatInputContainerParams = {
   sessionId: string | null;
   isSending: boolean;
   isStarting: boolean;
+  isMoving: boolean;
   isFailed: boolean;
   needsRecovery: boolean;
   isAgentBusy: boolean;
@@ -71,6 +72,7 @@ function getInputPlaceholder(
 
 function computeDerivedState(params: {
   isStarting: boolean;
+  isMoving: boolean;
   isSending: boolean;
   isFailed: boolean;
   needsRecovery: boolean;
@@ -84,7 +86,11 @@ function computeDerivedState(params: {
   hasAgentCommands: boolean;
 }) {
   const isDisabled =
-    params.isStarting || params.isSending || params.isFailed || params.needsRecovery;
+    params.isStarting ||
+    params.isMoving ||
+    params.isSending ||
+    params.isFailed ||
+    params.needsRecovery;
   const hasClarification = !!(params.pendingClarification && params.onClarificationResolved);
   const hasPendingComments = !!(
     params.pendingCommentsByFile && Object.keys(params.pendingCommentsByFile).length > 0
@@ -113,6 +119,7 @@ export function useChatInputContainer(params: UseChatInputContainerParams) {
     sessionId,
     isSending,
     isStarting,
+    isMoving,
     isFailed,
     needsRecovery,
     isAgentBusy,
@@ -181,6 +188,7 @@ export function useChatInputContainer(params: UseChatInputContainerParams) {
 
   const derived = computeDerivedState({
     isStarting,
+    isMoving,
     isSending,
     isFailed,
     needsRecovery,

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -129,7 +129,7 @@ function useTerminalStateFetch(
 // connectionStatus stuck at "connected" and no resubscribe fires. Backfill
 // whenever the tab regains visibility to recover missed messages without
 // requiring a page refresh.
-function useVisibilityBackfill(
+export function useVisibilityBackfill(
   taskSessionId: string | null,
   store: ReturnType<typeof useAppStoreApi>,
 ) {
@@ -226,6 +226,12 @@ export function useSessionMessages(taskSessionId: string | null): UseSessionMess
     });
   }, [taskSessionId, connectionStatus, messages.length, store]);
 
+  // Bool flips exactly once when a freshly-adopted session leaves STARTING,
+  // so the subscription effect re-runs then (covering the backend race where
+  // session.subscribe arrives before the session is fully constructed) without
+  // churning on every subsequent RUNNING ↔ WAITING_FOR_INPUT transition.
+  const isSessionStartingOrUnknown = taskSessionState === null || taskSessionState === "STARTING";
+
   useEffect(() => {
     if (!taskSessionId || connectionStatus !== "connected") return;
     const client = getWebSocketClient();
@@ -236,16 +242,12 @@ export function useSessionMessages(taskSessionId: string | null): UseSessionMess
     // (which may have run before the agent responded) and this subscription.
     // Without this, fast-responding agents can complete a turn before the
     // subscription is active, causing the response to never appear.
-    // taskSessionState is in deps so a freshly-adopted session that was still
-    // being constructed server-side when we subscribed re-runs subscribe+fetch
-    // once it transitions (e.g. STARTING → RUNNING), covering the backend race
-    // where an early session.subscribe arrives before the session exists.
     fetchAndStoreMessages(taskSessionId, store).catch(() => {});
 
     return () => {
       unsubscribe();
     };
-  }, [taskSessionId, connectionStatus, store, taskSessionState]);
+  }, [taskSessionId, connectionStatus, store, isSessionStartingOrUnknown]);
 
   useVisibilityBackfill(taskSessionId, store);
 

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -125,6 +125,26 @@ function useTerminalStateFetch(
   }, [taskSessionId, taskSessionState, hasAgentMessage, connectionStatus, refs]);
 }
 
+// Silent WS disconnects (NAT timeout, laptop sleep, suspended tab) leave
+// connectionStatus stuck at "connected" and no resubscribe fires. Backfill
+// whenever the tab regains visibility to recover missed messages without
+// requiring a page refresh.
+function useVisibilityBackfill(
+  taskSessionId: string | null,
+  store: ReturnType<typeof useAppStoreApi>,
+) {
+  useEffect(() => {
+    if (!taskSessionId) return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        fetchAndStoreMessages(taskSessionId, store).catch(() => {});
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [taskSessionId, store]);
+}
+
 export function useSessionMessages(taskSessionId: string | null): UseSessionMessagesReturn {
   const store = useAppStoreApi();
   const messages = useAppStore((state) =>
@@ -216,12 +236,18 @@ export function useSessionMessages(taskSessionId: string | null): UseSessionMess
     // (which may have run before the agent responded) and this subscription.
     // Without this, fast-responding agents can complete a turn before the
     // subscription is active, causing the response to never appear.
+    // taskSessionState is in deps so a freshly-adopted session that was still
+    // being constructed server-side when we subscribed re-runs subscribe+fetch
+    // once it transitions (e.g. STARTING → RUNNING), covering the backend race
+    // where an early session.subscribe arrives before the session exists.
     fetchAndStoreMessages(taskSessionId, store).catch(() => {});
 
     return () => {
       unsubscribe();
     };
-  }, [taskSessionId, connectionStatus, store]);
+  }, [taskSessionId, connectionStatus, store, taskSessionState]);
+
+  useVisibilityBackfill(taskSessionId, store);
 
   const terminalFetchRefs = useMemo(
     () => ({

--- a/apps/web/hooks/domains/session/use-visibility-backfill.test.ts
+++ b/apps/web/hooks/domains/session/use-visibility-backfill.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+
+const mockRequest = vi.fn();
+const mockSetMessages = vi.fn();
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: () => null,
+  useAppStoreApi: () => ({
+    getState: () => ({
+      messages: { bySession: {} },
+      setMessages: mockSetMessages,
+    }),
+  }),
+}));
+
+import { useVisibilityBackfill } from "./use-session-messages";
+
+function setVisibility(value: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", { configurable: true, value });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("useVisibilityBackfill", () => {
+  let store: { getState: () => unknown };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest.mockResolvedValue({ messages: [], has_more: false });
+    store = {
+      getState: () => ({ messages: { bySession: {} }, setMessages: mockSetMessages }),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("fetches when the tab becomes visible", () => {
+    renderHook(() => useVisibilityBackfill("sess-1", store as never));
+    setVisibility("visible");
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledWith(
+      "message.list",
+      expect.objectContaining({ session_id: "sess-1" }),
+      expect.any(Number),
+    );
+  });
+
+  it("does not fetch when the tab becomes hidden", () => {
+    renderHook(() => useVisibilityBackfill("sess-1", store as never));
+    setVisibility("hidden");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when sessionId is null", () => {
+    renderHook(() => useVisibilityBackfill(null, store as never));
+    setVisibility("visible");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("removes the listener on unmount", () => {
+    const { unmount } = renderHook(() => useVisibilityBackfill("sess-1", store as never));
+    unmount();
+    setVisibility("visible");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("re-registers when sessionId changes", () => {
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) => useVisibilityBackfill(id, store as never),
+      { initialProps: { id: "sess-1" } },
+    );
+    setVisibility("visible");
+    expect(mockRequest).toHaveBeenLastCalledWith(
+      "message.list",
+      expect.objectContaining({ session_id: "sess-1" }),
+      expect.any(Number),
+    );
+
+    rerender({ id: "sess-2" });
+    setVisibility("visible");
+    expect(mockRequest).toHaveBeenLastCalledWith(
+      "message.list",
+      expect.objectContaining({ session_id: "sess-2" }),
+      expect.any(Number),
+    );
+  });
+});


### PR DESCRIPTION
Two task-details chat bugs around session/workflow transitions were making the chat input misrepresent state and causing messages to silently stop updating until a page refresh.

## Important Changes

- **Chat input state split**: `isStarting` (real workspace prep) and `isMoving` (workflow step transition) are now separate props through `ChatInputContainer` → `useChatInputContainer`. `isStarting` drives only the placeholder text; `isMoving` still contributes to disabled state and the combined visual class. Previously both were OR'd into `isStarting`, which made `getInputPlaceholder` return "Preparing workspace…" for several seconds every time the user clicked "Proceed to next step", hiding the author's intended "Switching agent…" label.
- **Message subscription hardening** in `useSessionMessages`:
  - Added `taskSessionState` to the subscription effect deps so a freshly-adopted session re-runs subscribe+fetch once it transitions out of `STARTING`. This covers the race where the client sends `session.subscribe` before the server has fully constructed the new session.
  - Added a `visibilitychange` backfill hook that re-fetches messages on tab refocus, recovering from silent WS drops (NAT timeout, laptop sleep, suspended tab) where `connectionStatus` never flips and no resubscribe fires.

## Validation

- `cd apps && pnpm --filter @kandev/web lint` — clean.
- `cd apps && pnpm --filter @kandev/web test` — 432 tests pass.
- `cd apps/web && npx tsc --noEmit` — clean (only pre-existing generated-file import errors unrelated to this change).
- Manual: verified placeholder is "Switching agent…" during a step move and "Preparing workspace…" only during real task startup.

## Possible Improvements

Low risk. Visibility backfill fires an extra `message.list` WS request on every tab refocus — cheap, but if it becomes noisy we can debounce or gate it on "time since last activity".

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.