### PR TITLE
fix(web): enable Start task button when workflow provides agent override

### DIFF
--- a/apps/web/components/task-create-dialog-state.ts
+++ b/apps/web/components/task-create-dialog-state.ts
@@ -524,11 +524,22 @@ export function useDialogComputed({
   repositories,
   workflows,
 }: DialogComputedArgs): DialogComputedValues {
-  const isPassthroughProfile = useMemo(
-    () => computePassthroughProfile(fs.agentProfileId, agentProfiles),
-    [fs.agentProfileId, agentProfiles],
-  );
   const effectiveWorkflowId = fs.selectedWorkflowId ?? workflowId;
+  // Compute workflow agent lock directly from data — avoids effect timing issues.
+  const workflowAgentProfileId = (() => {
+    const wfId = effectiveWorkflowId;
+    if (!wfId) return "";
+    const wf = workflows.find((w) => w.id === wfId);
+    return wf?.agent_profile_id ?? "";
+  })();
+  const workflowAgentLocked = Boolean(workflowAgentProfileId);
+  // fs.agentProfileId lags behind the workflow override on dialog re-open
+  // (effect deps don't change), so fall back to the synchronous value.
+  const effectiveAgentProfileId = fs.agentProfileId || workflowAgentProfileId;
+  const isPassthroughProfile = useMemo(
+    () => computePassthroughProfile(effectiveAgentProfileId, agentProfiles),
+    [effectiveAgentProfileId, agentProfiles],
+  );
   const effectiveDefaultStepId = computeEffectiveStepId(
     fs.selectedWorkflowId,
     workflowId,
@@ -563,14 +574,6 @@ export function useDialogComputed({
   const { headerRepositoryOptions } = useRepositoryOptions(repositories, fs.discoveredRepositories);
   const agentProfilesLoading = open && !settingsData.agentsLoaded;
   const executorsLoading = open && !settingsData.executorsLoaded;
-  // Compute workflow agent lock directly from data — avoids effect timing issues.
-  const workflowAgentProfileId = (() => {
-    const wfId = effectiveWorkflowId;
-    if (!wfId) return "";
-    const wf = workflows.find((w) => w.id === wfId);
-    return wf?.agent_profile_id ?? "";
-  })();
-  const workflowAgentLocked = Boolean(workflowAgentProfileId);
   return {
     isPassthroughProfile,
     effectiveWorkflowId,
@@ -587,6 +590,7 @@ export function useDialogComputed({
     executorsLoading,
     workflowAgentLocked,
     workflowAgentProfileId,
+    effectiveAgentProfileId,
   };
 }
 

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -56,6 +56,8 @@ export type DialogComputedValues = {
   workflowAgentLocked: boolean;
   /** The agent_profile_id from the effective workflow (empty string if none) */
   workflowAgentProfileId: string;
+  /** User selection if any, else the workflow override; what footer/submit/passthrough should consult */
+  effectiveAgentProfileId: string;
 };
 
 export type DialogComputedArgs = {

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -415,6 +415,9 @@ function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     workflows,
   });
   const handlers = useDialogHandlers(fs, repositories);
+  // fs.agentProfileId is updated asynchronously by an effect, so it can lag
+  // behind the synchronous workflow override on dialog re-open.
+  const effectiveAgentProfileId = fs.agentProfileId || computed.workflowAgentProfileId;
   const submitHandlers = useTaskSubmitHandlers({
     isSessionMode,
     isEditMode,
@@ -430,7 +433,7 @@ function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     githubUrl: fs.githubUrl,
     githubPrHeadBranch: fs.githubPrHeadBranch,
     branch: fs.branch,
-    agentProfileId: fs.agentProfileId,
+    agentProfileId: effectiveAgentProfileId,
     executorId: fs.executorId,
     executorProfileId: fs.executorProfileId,
     editingTask,
@@ -472,6 +475,7 @@ function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     handlers,
     submitHandlers,
     handleKeyDown,
+    effectiveAgentProfileId,
     enhance: useEnhanceForDialog(fs),
   };
 }
@@ -556,7 +560,7 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
               hasDescription={fs.hasDescription}
               hasRepositorySelection={computed.hasRepositorySelection}
               branch={fs.branch}
-              agentProfileId={fs.agentProfileId}
+              agentProfileId={setup.effectiveAgentProfileId}
               workspaceId={workspaceId}
               effectiveWorkflowId={computed.effectiveWorkflowId ?? null}
               executorHint={computed.executorHint}

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -415,9 +415,6 @@ function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     workflows,
   });
   const handlers = useDialogHandlers(fs, repositories);
-  // fs.agentProfileId is updated asynchronously by an effect, so it can lag
-  // behind the synchronous workflow override on dialog re-open.
-  const effectiveAgentProfileId = fs.agentProfileId || computed.workflowAgentProfileId;
   const submitHandlers = useTaskSubmitHandlers({
     isSessionMode,
     isEditMode,
@@ -433,7 +430,7 @@ function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     githubUrl: fs.githubUrl,
     githubPrHeadBranch: fs.githubPrHeadBranch,
     branch: fs.branch,
-    agentProfileId: effectiveAgentProfileId,
+    agentProfileId: computed.effectiveAgentProfileId,
     executorId: fs.executorId,
     executorProfileId: fs.executorProfileId,
     editingTask,
@@ -475,7 +472,6 @@ function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     handlers,
     submitHandlers,
     handleKeyDown,
-    effectiveAgentProfileId,
     enhance: useEnhanceForDialog(fs),
   };
 }
@@ -560,7 +556,7 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
               hasDescription={fs.hasDescription}
               hasRepositorySelection={computed.hasRepositorySelection}
               branch={fs.branch}
-              agentProfileId={setup.effectiveAgentProfileId}
+              agentProfileId={computed.effectiveAgentProfileId}
               workspaceId={workspaceId}
               effectiveWorkflowId={computed.effectiveWorkflowId ?? null}
               executorHint={computed.executorHint}

--- a/apps/web/e2e/tests/workflow/workflow-agent-profile.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-profile.spec.ts
@@ -144,7 +144,7 @@ test.describe("Workflow agent profile", () => {
     }
   });
 
-  test("single workflow with agent override enables Start task button and shows profile", async ({
+  test("single workflow with agent override enables Start task button and submits with that profile", async ({
     testPage,
     seedData,
     apiClient,
@@ -172,7 +172,8 @@ test.describe("Workflow agent profile", () => {
       const dialog = testPage.getByTestId("create-task-dialog");
       await expect(dialog).toBeVisible();
 
-      await testPage.getByTestId("task-title-input").fill("Single Workflow Test");
+      const taskTitle = "Single Workflow Test";
+      await testPage.getByTestId("task-title-input").fill(taskTitle);
       await testPage.getByTestId("task-description-input").fill("testing single workflow");
 
       // The selector should be disabled with "Agent set by workflow" text
@@ -181,6 +182,86 @@ test.describe("Workflow agent profile", () => {
       // The agent selector should be disabled (locked by workflow)
       const agentSelector = testPage.getByTestId("agent-profile-selector");
       await expect(agentSelector).toBeDisabled({ timeout: 10_000 });
+
+      // Start task must be enabled: the workflow provides the agent even though
+      // the in-dialog agent selector is empty.
+      const startButton = testPage.getByTestId("submit-start-agent");
+      await expect(startButton).toBeEnabled({ timeout: 10_000 });
+
+      // Submit and verify the task + session are created with the workflow's profile.
+      await startButton.click();
+      await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+      let createdTaskId: string | undefined;
+      await expect
+        .poll(
+          async () => {
+            const { tasks } = await apiClient.listTasks(seedData.workspaceId);
+            const created = tasks.find((t) => t.title === taskTitle);
+            createdTaskId = created?.id;
+            return createdTaskId;
+          },
+          { timeout: 15_000 },
+        )
+        .toBeDefined();
+
+      await expect
+        .poll(
+          async () => {
+            const { sessions } = await apiClient.listTaskSessions(createdTaskId!);
+            return sessions[0]?.agent_profile_id;
+          },
+          { timeout: 15_000 },
+        )
+        .toBe(agentProfile.id);
+    } finally {
+      await apiClient.updateWorkflow(seedData.workflowId, {
+        agent_profile_id: "",
+      });
+    }
+  });
+
+  test("Start task stays enabled after closing and re-opening the dialog", async ({
+    testPage,
+    seedData,
+    apiClient,
+  }) => {
+    // Same setup: a single workflow with an agent override.
+    const { agents } = await apiClient.listAgents();
+    const agentProfile = agents.flatMap((a) => a.profiles ?? [])[0];
+    expect(agentProfile).toBeDefined();
+    await apiClient.updateWorkflow(seedData.workflowId, {
+      agent_profile_id: agentProfile.id,
+    });
+
+    try {
+      const kanban = new KanbanPage(testPage);
+      await kanban.goto();
+      await testPage.reload({ waitUntil: "networkidle" });
+
+      const startButton = testPage.getByTestId("submit-start-agent");
+      const dialog = testPage.getByTestId("create-task-dialog");
+
+      // First open: fill and confirm enabled.
+      await kanban.createTaskButton.first().click();
+      await expect(dialog).toBeVisible();
+      await testPage.getByTestId("task-title-input").fill("Reopen Test 1");
+      await testPage.getByTestId("task-description-input").fill("first open");
+      await expect(testPage.getByText("Agent set by workflow")).toBeVisible({ timeout: 10_000 });
+      await expect(startButton).toBeEnabled({ timeout: 10_000 });
+
+      // Cancel (Escape) and re-open.
+      await testPage.keyboard.press("Escape");
+      await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+      await kanban.createTaskButton.first().click();
+      await expect(dialog).toBeVisible();
+
+      // Second open: fill content; workflow override must still enable Start.
+      await testPage.getByTestId("task-title-input").fill("Reopen Test 2");
+      await testPage.getByTestId("task-description-input").fill("second open");
+      await expect(testPage.getByText("Agent set by workflow")).toBeVisible({ timeout: 10_000 });
+      await expect(startButton).toBeEnabled({ timeout: 10_000 });
     } finally {
       await apiClient.updateWorkflow(seedData.workflowId, {
         agent_profile_id: "",


### PR DESCRIPTION
The task-create dialog showed "Agent set by workflow" with the overridden profile name, yet the Start task button stayed disabled with a "Select an agent" tooltip — because the footer's disable check read `fs.agentProfileId` (populated asynchronously by an effect that doesn't re-fire on dialog re-open) instead of the synchronously-computed workflow override, so users couldn't submit a task whose agent was entirely provided by the workflow.

## Validation

- `cd apps/web && npx tsc --noEmit` — clean
- `pnpm --filter @kandev/web lint` — clean (`--max-warnings 0`)
- Extended `apps/web/e2e/tests/workflow/workflow-agent-profile.spec.ts`:
  - The "single workflow with agent override…" test now asserts Start is enabled, the dialog closes on submit, and the created session's `agent_profile_id` matches the workflow override.
  - New test "Start task stays enabled after closing and re-opening the dialog" covers the specific re-open race from the bug report.

## Possible Improvements

Low risk. `useWorkflowAgentProfileEffect` still maintains a duplicated `fs.workflowAgentProfileId` state read by `useDefaultSelectionsEffect`; a follow-up could delete the effect entirely and drive everything off the synchronously-computed value.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
