### PR TITLE
fix(backend): send auto-start prompt after on_turn_complete context reset

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -602,8 +602,26 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 		// auto_start_agent enters queueAutoStartPromptIfRunning → queues the
 		// prompt instead of sending it, and PromptTask rejects the drained
 		// queued message because DB state still reads RUNNING.
-		s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateWaitingForInput, "", false, session)
-		session.State = models.TaskSessionStateWaitingForInput
+		//
+		// Skip the flip when:
+		//   - the session was not RUNNING/STARTING (e.g. CREATED, where
+		//     resetAgentContext early-returns true without restarting and
+		//     autoStartStepPrompt routes the prompt through StartCreatedSession);
+		//   - the session is passthrough AND we're about to call
+		//     autoStartPassthroughPrompt below (the agent is actively
+		//     processing the PTY stdin write, not idle).
+		//
+		// We use updateTaskSessionState directly rather than
+		// setSessionWaitingForInput because the latter also flips the task to
+		// TaskStateReview, which would be wrong here — auto_start_agent will
+		// run next and should leave the task as IN_PROGRESS.
+		canFlip := (session.State == models.TaskSessionStateRunning ||
+			session.State == models.TaskSessionStateStarting) &&
+			!(isPassthrough && step.HasOnEnterAction(wfmodels.OnEnterAutoStartAgent))
+		if canFlip {
+			s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateWaitingForInput, "", false, session)
+			session.State = models.TaskSessionStateWaitingForInput
+		}
 	}
 
 	hasAutoStart := false

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -594,34 +594,7 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 			s.publishSessionWaitingEvent(ctx, taskID, sessionID, step.ID, session)
 			return
 		}
-		// When processOnEnter runs from an on_turn_complete engine transition,
-		// the in-memory session was loaded at the start of handleAgentReady
-		// before the turn finished — its State is still RUNNING. After a
-		// successful reset the agent is idle, so mark the session
-		// WAITING_FOR_INPUT in both DB and memory. Without this, a subsequent
-		// auto_start_agent enters queueAutoStartPromptIfRunning → queues the
-		// prompt instead of sending it, and PromptTask rejects the drained
-		// queued message because DB state still reads RUNNING.
-		//
-		// Skip the flip when:
-		//   - the session was not RUNNING/STARTING (e.g. CREATED, where
-		//     resetAgentContext early-returns true without restarting and
-		//     autoStartStepPrompt routes the prompt through StartCreatedSession);
-		//   - the session is passthrough AND we're about to call
-		//     autoStartPassthroughPrompt below (the agent is actively
-		//     processing the PTY stdin write, not idle).
-		//
-		// We use updateTaskSessionState directly rather than
-		// setSessionWaitingForInput because the latter also flips the task to
-		// TaskStateReview, which would be wrong here — auto_start_agent will
-		// run next and should leave the task as IN_PROGRESS.
-		canFlip := (session.State == models.TaskSessionStateRunning ||
-			session.State == models.TaskSessionStateStarting) &&
-			!(isPassthrough && step.HasOnEnterAction(wfmodels.OnEnterAutoStartAgent))
-		if canFlip {
-			s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateWaitingForInput, "", false, session)
-			session.State = models.TaskSessionStateWaitingForInput
-		}
+		s.markIdleAfterReset(ctx, taskID, sessionID, session, step, isPassthrough)
 	}
 
 	hasAutoStart := false
@@ -862,6 +835,43 @@ func (s *Service) queueAutoStartPrompt(
 	}
 	s.publishQueueStatusEvent(ctx, sessionID)
 	return nil
+}
+
+// markIdleAfterReset flips a freshly-reset session to WAITING_FOR_INPUT so a
+// following auto_start_agent sends the prompt directly instead of queueing
+// against a stale RUNNING state. processOnEnter runs from handleAgentReady,
+// which loads the session before the turn finishes — the in-memory pointer
+// still reads RUNNING even though the agent is now idle. Without this flip,
+// queueAutoStartPromptIfRunning queues the message and PromptTask later
+// rejects the drained queued send because the DB row also still reads RUNNING.
+//
+// Skip the flip when:
+//   - state was not RUNNING/STARTING (e.g. CREATED, where resetAgentContext
+//     early-returns true without restarting and autoStartStepPrompt routes
+//     the prompt through StartCreatedSession);
+//   - the session is passthrough AND auto_start_agent will write to PTY stdin
+//     next (the agent is actively processing, not idle).
+//
+// Uses updateTaskSessionState directly rather than setSessionWaitingForInput
+// because the helper would also flip the task to TaskStateReview, which would
+// be wrong here — auto_start_agent runs next and should leave the task as
+// IN_PROGRESS.
+func (s *Service) markIdleAfterReset(
+	ctx context.Context,
+	taskID, sessionID string,
+	session *models.TaskSession,
+	step *wfmodels.WorkflowStep,
+	isPassthrough bool,
+) {
+	if session.State != models.TaskSessionStateRunning &&
+		session.State != models.TaskSessionStateStarting {
+		return
+	}
+	if isPassthrough && step.HasOnEnterAction(wfmodels.OnEnterAutoStartAgent) {
+		return
+	}
+	s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateWaitingForInput, "", false, session)
+	session.State = models.TaskSessionStateWaitingForInput
 }
 
 // resetAgentContext restarts the agent subprocess with a fresh ACP session, clearing

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -594,6 +594,16 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 			s.publishSessionWaitingEvent(ctx, taskID, sessionID, step.ID, session)
 			return
 		}
+		// When processOnEnter runs from an on_turn_complete engine transition,
+		// the in-memory session was loaded at the start of handleAgentReady
+		// before the turn finished — its State is still RUNNING. After a
+		// successful reset the agent is idle, so mark the session
+		// WAITING_FOR_INPUT in both DB and memory. Without this, a subsequent
+		// auto_start_agent enters queueAutoStartPromptIfRunning → queues the
+		// prompt instead of sending it, and PromptTask rejects the drained
+		// queued message because DB state still reads RUNNING.
+		s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateWaitingForInput, "", false, session)
+		session.State = models.TaskSessionStateWaitingForInput
 	}
 
 	hasAutoStart := false

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
@@ -785,4 +785,42 @@ func TestProcessOnEnterResetAgentContext(t *testing.T) {
 			t.Errorf("expected 1 RestartAgentProcess call, got %d", len(agentMgr.restartProcessCalls))
 		}
 	})
+
+	// Regression: passthrough sessions handle auto_start_agent by writing to
+	// PTY stdin via autoStartPassthroughPrompt — the agent is actively
+	// processing immediately after, not idle. We must NOT flip the session to
+	// WAITING_FOR_INPUT, otherwise WS subscribers see "ready for input" while
+	// the agent is mid-prompt.
+	t.Run("reset_agent_context preserves running state for passthrough+auto_start", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1") // RUNNING
+
+		session, _ := repo.GetTaskSession(ctx, "s1")
+		session.AgentExecutionID = "exec-pt"
+		_ = repo.UpdateTaskSession(ctx, session)
+
+		agentMgr := &mockAgentManager{isPassthrough: true}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+
+		step := &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Review Step",
+			Events: wfmodels.StepEvents{
+				OnEnter: []wfmodels.OnEnterAction{
+					{Type: wfmodels.OnEnterResetAgentContext},
+					{Type: wfmodels.OnEnterAutoStartAgent},
+				},
+			},
+		}
+
+		session, _ = repo.GetTaskSession(ctx, "s1")
+		svc.processOnEnter(ctx, "t1", session, step, "review task")
+
+		if session.State == models.TaskSessionStateWaitingForInput {
+			t.Errorf("in-memory session.State should NOT be WAITING_FOR_INPUT for passthrough+auto_start, got %q", session.State)
+		}
+		updated, _ := repo.GetTaskSession(ctx, "s1")
+		if updated.State == models.TaskSessionStateWaitingForInput {
+			t.Errorf("DB session.State should NOT be WAITING_FOR_INPUT for passthrough+auto_start, got %q", updated.State)
+		}
+	})
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
@@ -815,12 +815,15 @@ func TestProcessOnEnterResetAgentContext(t *testing.T) {
 		session, _ = repo.GetTaskSession(ctx, "s1")
 		svc.processOnEnter(ctx, "t1", session, step, "review task")
 
-		if session.State == models.TaskSessionStateWaitingForInput {
-			t.Errorf("in-memory session.State should NOT be WAITING_FOR_INPUT for passthrough+auto_start, got %q", session.State)
+		// Positive assertion: pin the expected state to RUNNING so any other
+		// unintended mutation (COMPLETED, FAILED, etc.) also fails the test,
+		// not just an erroneous flip to WAITING_FOR_INPUT.
+		if session.State != models.TaskSessionStateRunning {
+			t.Errorf("in-memory session.State should remain RUNNING for passthrough+auto_start, got %q", session.State)
 		}
 		updated, _ := repo.GetTaskSession(ctx, "s1")
-		if updated.State == models.TaskSessionStateWaitingForInput {
-			t.Errorf("DB session.State should NOT be WAITING_FOR_INPUT for passthrough+auto_start, got %q", updated.State)
+		if updated.State != models.TaskSessionStateRunning {
+			t.Errorf("DB session.State should remain RUNNING for passthrough+auto_start, got %q", updated.State)
 		}
 	})
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
@@ -729,4 +729,60 @@ func TestProcessOnEnterResetAgentContext(t *testing.T) {
 			t.Fatalf("expected session state %q, got %q", models.TaskSessionStateWaitingForInput, updated.State)
 		}
 	})
+
+	// Regression: on_turn_complete auto-transition enters processOnEnter with an
+	// in-memory session still marked RUNNING (loaded at the start of
+	// handleAgentReady before the turn finished). After reset_agent_context we
+	// must flip the session to WAITING_FOR_INPUT — otherwise a following
+	// auto_start_agent hits queueAutoStartPromptIfRunning (sees State=RUNNING)
+	// and queues the prompt instead of sending it, and PromptTask rejects the
+	// drained queued message for the same reason. The agent then sits idle
+	// until the user cancels. Both the in-memory pointer and the DB must be
+	// updated.
+	t.Run("reset_agent_context flips session to WAITING_FOR_INPUT for a running session", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1") // seeds session.State = RUNNING
+
+		session, _ := repo.GetTaskSession(ctx, "s1")
+		session.AgentExecutionID = "exec-abc"
+		session.Metadata = map[string]interface{}{"acp_session_id": "old-acp"}
+		_ = repo.UpdateTaskSession(ctx, session)
+
+		agentMgr := &mockAgentManager{}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+
+		step := &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Review Step",
+			Events: wfmodels.StepEvents{
+				OnEnter: []wfmodels.OnEnterAction{
+					{Type: wfmodels.OnEnterResetAgentContext},
+				},
+			},
+		}
+
+		session, _ = repo.GetTaskSession(ctx, "s1")
+		if session.State != models.TaskSessionStateRunning {
+			t.Fatalf("precondition: seed should start session as RUNNING, got %q", session.State)
+		}
+
+		svc.processOnEnter(ctx, "t1", session, step, "review task")
+
+		// In-memory session must also be updated — queueAutoStartPromptIfRunning
+		// (further down in processOnEnter when auto_start_agent is present)
+		// checks the pointer, not the DB.
+		if session.State != models.TaskSessionStateWaitingForInput {
+			t.Errorf("in-memory session.State: want %q, got %q",
+				models.TaskSessionStateWaitingForInput, session.State)
+		}
+
+		updated, _ := repo.GetTaskSession(ctx, "s1")
+		if updated.State != models.TaskSessionStateWaitingForInput {
+			t.Errorf("DB session.State: want %q, got %q",
+				models.TaskSessionStateWaitingForInput, updated.State)
+		}
+
+		if len(agentMgr.restartProcessCalls) != 1 {
+			t.Errorf("expected 1 RestartAgentProcess call, got %d", len(agentMgr.restartProcessCalls))
+		}
+	})
 }

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	"github.com/kandev/kandev/internal/workflow/engine"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
@@ -112,15 +114,22 @@ var workflowTestCases = []workflowTestCase{
 			// Agent finishes at Backlog → In Progress (auto_start queues)
 			{Trigger: engine.TriggerOnTurnComplete, ExpectStep: "In Progress",
 				ExpectTransitioned: true, ExpectQueued: true, ExpectResets: 0},
-			// Agent finishes at In Progress → New Context (reset + auto_start)
+			// Agent finishes at In Progress → New Context (reset + auto_start).
+			// After reset_agent_context, processOnEnter flips session state to
+			// WAITING_FOR_INPUT so auto_start sends directly instead of queueing
+			// against a stale RUNNING state. PromptTask then attempts the send —
+			// in this mock environment the executor has no running record for
+			// the session, so the send fails and autoStartStepPrompt's error
+			// path leaves the session at WAITING_FOR_INPUT. Crucially, the
+			// message is NOT sitting in the queue.
 			{Trigger: engine.TriggerOnTurnComplete, SetRunning: true, ExpectStep: "New Context",
-				ExpectTransitioned: true, ExpectQueued: true, ExpectResets: 1},
+				ExpectTransitioned: true, ExpectQueued: false, ExpectResets: 1},
 			// Agent starts at New Context → on_turn_start → back to In Progress
 			{Trigger: engine.TriggerOnTurnStart, SetRunning: true, ExpectStep: "In Progress",
 				ExpectTransitioned: true, ExpectQueued: false, ExpectResets: 1},
-			// Agent finishes at In Progress → New Context again
+			// Agent finishes at In Progress → New Context again (same reset + auto_start path)
 			{Trigger: engine.TriggerOnTurnComplete, SetRunning: true, ExpectStep: "New Context",
-				ExpectTransitioned: true, ExpectQueued: true, ExpectResets: 2},
+				ExpectTransitioned: true, ExpectQueued: false, ExpectResets: 2},
 			// Agent finishes at New Context → New Step (reset, no auto_start)
 			{Trigger: engine.TriggerOnTurnComplete, SetRunning: true, ExpectStep: "New Step",
 				ExpectTransitioned: true, ExpectQueued: false, ExpectResets: 3},
@@ -283,7 +292,7 @@ func buildWorkflowFromJSON(t *testing.T, jsonStr string) (*mockStepGetter, map[s
 }
 
 // createEngineService creates a Service with the workflow engine initialized.
-func createEngineService(t *testing.T, repo sessionExecutorStore, sg *mockStepGetter, agentMgr *mockAgentManager) *Service {
+func createEngineService(t *testing.T, repo *sqliterepo.Repository, sg *mockStepGetter, agentMgr *mockAgentManager) *Service {
 	t.Helper()
 	log := testLogger()
 	svc := &Service{
@@ -292,6 +301,7 @@ func createEngineService(t *testing.T, repo sessionExecutorStore, sg *mockStepGe
 		taskRepo:     newMockTaskRepo(),
 		agentManager: agentMgr,
 		messageQueue: messagequeue.NewService(log),
+		executor:     executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{}),
 	}
 	svc.SetWorkflowStepGetter(sg)
 	return svc


### PR DESCRIPTION
When a workflow step auto-transitioned via `on_turn_complete` into a target whose `on_enter` combined `reset_agent_context` with `auto_start_agent` (e.g. `feature-dev.yml`'s Review step), the new step's prompt was never delivered — the agent sat idle on a fresh ACP session until the user cancelled.

## Important Changes

- `processOnEnter` now explicitly flips the session to `WAITING_FOR_INPUT` (DB + in-memory pointer) right after a successful `resetAgentContext`. `handleAgentReady` had loaded the session before the turn finished, so its `State` was still `RUNNING`; `queueAutoStartPromptIfRunning` then queued the prompt instead of sending it, and the drain path lost the message to a race with the `AgentReady` event the reset itself publishes. Flipping the state makes the subsequent `autoStartStepPrompt` → `PromptTask` send the prompt directly, matching the working manual-move path which already reloads the session from the DB.

## Validation

- `make fmt` · `go vet ./...` · `go test ./internal/orchestrator/... -count=1` — all green.
- Added a regression subtest in `TestProcessOnEnterResetAgentContext` asserting that after `reset_agent_context` against a `RUNNING` session, both the in-memory pointer and the DB row read `WAITING_FOR_INPUT`.
- Updated the two `TestWorkflowE2E/five_step_full_lifecycle` events (`reset + auto_start`) whose `ExpectQueued: true` was pinning the old buggy queue-then-drain behavior; they now assert the direct-send path. Wired up a real `executor.Executor` in `createEngineService` so the E2E runner can exercise `PromptTask`.

## Possible Improvements

Low risk. The behavior change only affects on_turn_complete transitions that hit a context reset; the manual-move and non-reset paths are unchanged. Worth a follow-up to ensure no other entry points rely on the "running session auto-queues" side-effect — a quick grep of `queueAutoStartPromptIfRunning` callers suggests `processOnEnter` is the sole surface.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

https://claude.ai/code/session_01LgzXiKnhN7NJgGgHNKTrQv