### PR TITLE
fix: make task move event handlers asynchronous to prevent HTTP timeouts

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -81,6 +81,7 @@ func (m *mockStepGetter) GetWorkflowAgentProfileID(_ context.Context, workflowID
 
 // mockTaskRepo implements scheduler.TaskRepository for testing.
 type mockTaskRepo struct {
+	mu            sync.Mutex
 	tasks         map[string]*v1.Task
 	updatedStates map[string]v1.TaskState
 	getTaskErr    error // if set, GetTask returns this error
@@ -94,6 +95,8 @@ func newMockTaskRepo() *mockTaskRepo {
 }
 
 func (m *mockTaskRepo) GetTask(_ context.Context, taskID string) (*v1.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.getTaskErr != nil {
 		return nil, m.getTaskErr
 	}
@@ -104,6 +107,8 @@ func (m *mockTaskRepo) GetTask(_ context.Context, taskID string) (*v1.Task, erro
 }
 
 func (m *mockTaskRepo) UpdateTaskState(_ context.Context, taskID string, state v1.TaskState) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.updatedStates[taskID] = state
 	return nil
 }
@@ -183,6 +188,8 @@ func (m *mockAgentManager) ResolveAgentProfile(_ context.Context, _ string) (*ex
 	}, nil
 }
 func (m *mockAgentManager) RestartAgentProcess(_ context.Context, agentExecutionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.restartProcessCalls = append(m.restartProcessCalls, agentExecutionID)
 	return m.restartProcessErr
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -345,11 +345,7 @@ func (s *Service) handleTaskMovedNoSession(ctx context.Context, data watcher.Tas
 		zap.String("executor_profile_id", executorProfileID),
 		zap.Bool("plan_mode", planMode))
 
-	// Launch StartTask asynchronously so the event handler returns immediately.
-	// The handleTaskMoved handler runs synchronously inside the in-memory event
-	// bus Publish call — if StartTask blocks (e.g., waiting for the agent turn),
-	// the MoveTask HTTP handler that published the event also blocks, causing the
-	// browser request to time out with ERR_EMPTY_RESPONSE.
+	// Async: event bus delivers synchronously; blocking here → HTTP timeout (see handleTaskMovedWithSession doc).
 	go func() {
 		asyncCtx := context.WithoutCancel(ctx)
 		_, err := s.StartTask(asyncCtx, task.ID, agentProfileID, "", executorProfileID, 0, task.Description, data.ToStepID, planMode, nil)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -345,17 +345,30 @@ func (s *Service) handleTaskMovedNoSession(ctx context.Context, data watcher.Tas
 		zap.String("executor_profile_id", executorProfileID),
 		zap.Bool("plan_mode", planMode))
 
-	_, err = s.StartTask(ctx, task.ID, agentProfileID, "", executorProfileID, 0, task.Description, data.ToStepID, planMode, nil)
-	if err != nil {
-		s.logger.Error("task.moved: failed to auto-start task",
-			zap.String("task_id", data.TaskID),
-			zap.Error(err))
-	}
+	// Launch StartTask asynchronously so the event handler returns immediately.
+	// The handleTaskMoved handler runs synchronously inside the in-memory event
+	// bus Publish call — if StartTask blocks (e.g., waiting for the agent turn),
+	// the MoveTask HTTP handler that published the event also blocks, causing the
+	// browser request to time out with ERR_EMPTY_RESPONSE.
+	go func() {
+		asyncCtx := context.WithoutCancel(ctx)
+		_, err := s.StartTask(asyncCtx, task.ID, agentProfileID, "", executorProfileID, 0, task.Description, data.ToStepID, planMode, nil)
+		if err != nil {
+			s.logger.Error("task.moved: failed to auto-start task",
+				zap.String("task_id", data.TaskID),
+				zap.Error(err))
+		}
+	}()
 }
 
 // handleTaskMovedWithSession handles the case where a task with an existing session
 // is moved between steps. It processes on_exit for the source step and on_enter
 // for the target step.
+//
+// The on_exit/on_enter processing is launched asynchronously because this handler
+// runs synchronously inside the in-memory event bus Publish call. If processOnEnter
+// blocks (e.g., auto_start_agent waiting for the agent turn), the MoveTask HTTP
+// handler that published the event also blocks, causing browser request timeouts.
 func (s *Service) handleTaskMovedWithSession(ctx context.Context, data watcher.TaskMovedEventData) {
 	session, err := s.repo.GetTaskSession(ctx, data.SessionID)
 	if err != nil {
@@ -365,7 +378,7 @@ func (s *Service) handleTaskMovedWithSession(ctx context.Context, data watcher.T
 		return
 	}
 
-	s.processStepExitAndEnter(ctx, data.TaskID, session, data.FromStepID, data.ToStepID, data.TaskDescription)
+	go s.processStepExitAndEnter(context.WithoutCancel(ctx), data.TaskID, session, data.FromStepID, data.ToStepID, data.TaskDescription)
 }
 
 // processStepExitAndEnter runs the on_exit → clear review → reload session → on_enter

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
@@ -156,87 +157,89 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("processes on_exit and on_enter for step transition", func(t *testing.T) {
-		repo := setupTestRepo(t)
-		seedSession(t, repo, "t1", "s1", "step1")
+		synctest.Test(t, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			seedSession(t, repo, "t1", "s1", "step1")
 
-		// Set plan_mode on the session to verify on_exit clears it
-		session, _ := repo.GetTaskSession(ctx, "s1")
-		_ = repo.UpdateTaskSession(ctx, session)
-		_ = repo.UpdateSessionMetadata(ctx, session.ID, map[string]interface{}{"plan_mode": true})
+			// Set plan_mode on the session to verify on_exit clears it
+			session, _ := repo.GetTaskSession(ctx, "s1")
+			_ = repo.UpdateTaskSession(ctx, session)
+			_ = repo.UpdateSessionMetadata(ctx, session.ID, map[string]interface{}{"plan_mode": true})
 
-		stepGetter := newMockStepGetter()
-		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
-			ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
-			Events: wfmodels.StepEvents{
-				OnExit: []wfmodels.OnExitAction{
-					{Type: wfmodels.OnExitDisablePlanMode},
+			stepGetter := newMockStepGetter()
+			stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+				ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+				Events: wfmodels.StepEvents{
+					OnExit: []wfmodels.OnExitAction{
+						{Type: wfmodels.OnExitDisablePlanMode},
+					},
 				},
-			},
-		}
-		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
-			ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
-			Events: wfmodels.StepEvents{
-				OnEnter: []wfmodels.OnEnterAction{
-					{Type: wfmodels.OnEnterEnablePlanMode},
+			}
+			stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+				ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
+				Events: wfmodels.StepEvents{
+					OnEnter: []wfmodels.OnEnterAction{
+						{Type: wfmodels.OnEnterEnablePlanMode},
+					},
 				},
-			},
-		}
+			}
 
-		svc := createTestService(repo, stepGetter, newMockTaskRepo())
-		svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
-			TaskID:          "t1",
-			SessionID:       "s1",
-			FromStepID:      "step1",
-			ToStepID:        "step2",
-			TaskDescription: "test task",
+			svc := createTestService(repo, stepGetter, newMockTaskRepo())
+			svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
+				TaskID:          "t1",
+				SessionID:       "s1",
+				FromStepID:      "step1",
+				ToStepID:        "step2",
+				TaskDescription: "test task",
+			})
+
+			synctest.Wait()
+
+			// Verify on_exit cleared plan_mode, then on_enter re-enabled it
+			updated, _ := repo.GetTaskSession(ctx, "s1")
+			if updated.Metadata == nil {
+				t.Fatal("expected metadata to be set")
+			}
+			if pm, ok := updated.Metadata["plan_mode"].(bool); !ok || !pm {
+				t.Error("expected plan_mode to be true after on_enter re-enabled it")
+			}
 		})
-
-		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
-		time.Sleep(100 * time.Millisecond)
-
-		// Verify on_exit cleared plan_mode, then on_enter re-enabled it
-		updated, _ := repo.GetTaskSession(ctx, "s1")
-		if updated.Metadata == nil {
-			t.Fatal("expected metadata to be set")
-		}
-		if pm, ok := updated.Metadata["plan_mode"].(bool); !ok || !pm {
-			t.Error("expected plan_mode to be true after on_enter re-enabled it")
-		}
 	})
 
 	t.Run("clears review status on step transition", func(t *testing.T) {
-		repo := setupTestRepo(t)
-		seedSession(t, repo, "t1", "s1", "step1")
+		synctest.Test(t, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			seedSession(t, repo, "t1", "s1", "step1")
 
-		// Set review status on the session
-		_ = repo.UpdateSessionReviewStatus(ctx, "s1", "pending")
+			// Set review status on the session
+			_ = repo.UpdateSessionReviewStatus(ctx, "s1", "pending")
 
-		stepGetter := newMockStepGetter()
-		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
-			ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
-			Events: wfmodels.StepEvents{},
-		}
-		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
-			ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
-			Events: wfmodels.StepEvents{},
-		}
+			stepGetter := newMockStepGetter()
+			stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+				ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+				Events: wfmodels.StepEvents{},
+			}
+			stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+				ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
+				Events: wfmodels.StepEvents{},
+			}
 
-		svc := createTestService(repo, stepGetter, newMockTaskRepo())
-		svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
-			TaskID:          "t1",
-			SessionID:       "s1",
-			FromStepID:      "step1",
-			ToStepID:        "step2",
-			TaskDescription: "test task",
+			svc := createTestService(repo, stepGetter, newMockTaskRepo())
+			svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
+				TaskID:          "t1",
+				SessionID:       "s1",
+				FromStepID:      "step1",
+				ToStepID:        "step2",
+				TaskDescription: "test task",
+			})
+
+			synctest.Wait()
+
+			updated, _ := repo.GetTaskSession(ctx, "s1")
+			if updated.ReviewStatus != nil && *updated.ReviewStatus != "" {
+				t.Errorf("expected review status to be cleared, got %q", *updated.ReviewStatus)
+			}
 		})
-
-		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
-		time.Sleep(100 * time.Millisecond)
-
-		updated, _ := repo.GetTaskSession(ctx, "s1")
-		if updated.ReviewStatus != nil && *updated.ReviewStatus != "" {
-			t.Errorf("expected review status to be cleared, got %q", *updated.ReviewStatus)
-		}
 	})
 
 	t.Run("queues auto-start prompt on enter", func(t *testing.T) {
@@ -306,109 +309,112 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 	})
 
 	t.Run("handles missing from-step gracefully", func(t *testing.T) {
-		repo := setupTestRepo(t)
-		seedSession(t, repo, "t1", "s1", "step1")
+		synctest.Test(t, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			seedSession(t, repo, "t1", "s1", "step1")
 
-		stepGetter := newMockStepGetter()
-		// step1 intentionally NOT in stepGetter
-		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
-			ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
-			Events: wfmodels.StepEvents{},
-		}
+			stepGetter := newMockStepGetter()
+			// step1 intentionally NOT in stepGetter
+			stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+				ID: "step2", WorkflowID: "wf1", Name: "Step 2", Position: 1,
+				Events: wfmodels.StepEvents{},
+			}
 
-		svc := createTestService(repo, stepGetter, newMockTaskRepo())
-		// Should not panic — from-step lookup failure is logged but processing continues
-		svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
-			TaskID:          "t1",
-			SessionID:       "s1",
-			FromStepID:      "nonexistent",
-			ToStepID:        "step2",
-			TaskDescription: "test task",
+			svc := createTestService(repo, stepGetter, newMockTaskRepo())
+			// Should not panic — from-step lookup failure is logged but processing continues
+			svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
+				TaskID:          "t1",
+				SessionID:       "s1",
+				FromStepID:      "nonexistent",
+				ToStepID:        "step2",
+				TaskDescription: "test task",
+			})
+
+			synctest.Wait()
 		})
-
-		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
-		time.Sleep(100 * time.Millisecond)
 	})
 
 	t.Run("handles missing to-step gracefully", func(t *testing.T) {
-		repo := setupTestRepo(t)
-		seedSession(t, repo, "t1", "s1", "step1")
+		synctest.Test(t, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			seedSession(t, repo, "t1", "s1", "step1")
 
-		stepGetter := newMockStepGetter()
-		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
-			ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
-			Events: wfmodels.StepEvents{},
-		}
-		// step2 intentionally NOT in stepGetter
+			stepGetter := newMockStepGetter()
+			stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+				ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+				Events: wfmodels.StepEvents{},
+			}
+			// step2 intentionally NOT in stepGetter
 
-		svc := createTestService(repo, stepGetter, newMockTaskRepo())
-		// Should not panic — to-step lookup failure causes early return
-		svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
-			TaskID:          "t1",
-			SessionID:       "s1",
-			FromStepID:      "step1",
-			ToStepID:        "nonexistent",
-			TaskDescription: "test task",
+			svc := createTestService(repo, stepGetter, newMockTaskRepo())
+			// Should not panic — to-step lookup failure causes early return
+			svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
+				TaskID:          "t1",
+				SessionID:       "s1",
+				FromStepID:      "step1",
+				ToStepID:        "nonexistent",
+				TaskDescription: "test task",
+			})
+
+			synctest.Wait()
 		})
-
-		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
-		time.Sleep(100 * time.Millisecond)
 	})
 
 	t.Run("reset_agent_context processed on enter", func(t *testing.T) {
-		repo := setupTestRepo(t)
-		seedSession(t, repo, "t1", "s1", "step1")
+		synctest.Test(t, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			seedSession(t, repo, "t1", "s1", "step1")
 
-		// Set agent execution ID on the session
-		session, _ := repo.GetTaskSession(ctx, "s1")
-		session.AgentExecutionID = "exec-123"
-		_ = repo.UpdateTaskSession(ctx, session)
-		_ = repo.UpdateSessionMetadata(ctx, session.ID, map[string]interface{}{"acp_session_id": "old-acp"})
+			// Set agent execution ID on the session
+			session, _ := repo.GetTaskSession(ctx, "s1")
+			session.AgentExecutionID = "exec-123"
+			_ = repo.UpdateTaskSession(ctx, session)
+			_ = repo.UpdateSessionMetadata(ctx, session.ID, map[string]interface{}{"acp_session_id": "old-acp"})
 
-		stepGetter := newMockStepGetter()
-		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
-			ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
-			Events: wfmodels.StepEvents{},
-		}
-		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
-			ID: "step2", WorkflowID: "wf1", Name: "Review", Position: 1,
-			Events: wfmodels.StepEvents{
-				OnEnter: []wfmodels.OnEnterAction{
-					{Type: wfmodels.OnEnterResetAgentContext},
-				},
-			},
-		}
-
-		agentMgr := &mockAgentManager{}
-		svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), agentMgr)
-		svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
-			TaskID:          "t1",
-			SessionID:       "s1",
-			FromStepID:      "step1",
-			ToStepID:        "step2",
-			TaskDescription: "test task",
-		})
-
-		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
-		time.Sleep(100 * time.Millisecond)
-
-		agentMgr.mu.Lock()
-		restartCalls := agentMgr.restartProcessCalls
-		agentMgr.mu.Unlock()
-		if len(restartCalls) != 1 {
-			t.Fatalf("expected 1 RestartAgentProcess call, got %d", len(restartCalls))
-		}
-		if restartCalls[0] != "exec-123" {
-			t.Errorf("expected RestartAgentProcess called with 'exec-123', got %q", restartCalls[0])
-		}
-
-		// Verify acp_session_id was cleared
-		updated, _ := repo.GetTaskSession(ctx, "s1")
-		if updated.Metadata != nil {
-			if acp, _ := updated.Metadata["acp_session_id"].(string); acp != "" {
-				t.Error("expected acp_session_id to be cleared from session metadata")
+			stepGetter := newMockStepGetter()
+			stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+				ID: "step1", WorkflowID: "wf1", Name: "Step 1", Position: 0,
+				Events: wfmodels.StepEvents{},
 			}
-		}
+			stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+				ID: "step2", WorkflowID: "wf1", Name: "Review", Position: 1,
+				Events: wfmodels.StepEvents{
+					OnEnter: []wfmodels.OnEnterAction{
+						{Type: wfmodels.OnEnterResetAgentContext},
+					},
+				},
+			}
+
+			agentMgr := &mockAgentManager{}
+			svc := createTestServiceWithAgent(repo, stepGetter, newMockTaskRepo(), agentMgr)
+			svc.handleTaskMovedWithSession(ctx, watcher.TaskMovedEventData{
+				TaskID:          "t1",
+				SessionID:       "s1",
+				FromStepID:      "step1",
+				ToStepID:        "step2",
+				TaskDescription: "test task",
+			})
+
+			synctest.Wait()
+
+			agentMgr.mu.Lock()
+			restartCalls := agentMgr.restartProcessCalls
+			agentMgr.mu.Unlock()
+			if len(restartCalls) != 1 {
+				t.Fatalf("expected 1 RestartAgentProcess call, got %d", len(restartCalls))
+			}
+			if restartCalls[0] != "exec-123" {
+				t.Errorf("expected RestartAgentProcess called with 'exec-123', got %q", restartCalls[0])
+			}
+
+			// Verify acp_session_id was cleared
+			updated, _ := repo.GetTaskSession(ctx, "s1")
+			if updated.Metadata != nil {
+				if acp, _ := updated.Metadata["acp_session_id"].(string); acp != "" {
+					t.Error("expected acp_session_id to be cleared from session metadata")
+				}
+			}
+		})
 	})
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
@@ -191,6 +191,9 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 			TaskDescription: "test task",
 		})
 
+		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
+		time.Sleep(100 * time.Millisecond)
+
 		// Verify on_exit cleared plan_mode, then on_enter re-enabled it
 		updated, _ := repo.GetTaskSession(ctx, "s1")
 		if updated.Metadata == nil {
@@ -226,6 +229,9 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 			ToStepID:        "step2",
 			TaskDescription: "test task",
 		})
+
+		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
+		time.Sleep(100 * time.Millisecond)
 
 		updated, _ := repo.GetTaskSession(ctx, "s1")
 		if updated.ReviewStatus != nil && *updated.ReviewStatus != "" {
@@ -319,6 +325,9 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 			ToStepID:        "step2",
 			TaskDescription: "test task",
 		})
+
+		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
+		time.Sleep(100 * time.Millisecond)
 	})
 
 	t.Run("handles missing to-step gracefully", func(t *testing.T) {
@@ -341,6 +350,9 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 			ToStepID:        "nonexistent",
 			TaskDescription: "test task",
 		})
+
+		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
+		time.Sleep(100 * time.Millisecond)
 	})
 
 	t.Run("reset_agent_context processed on enter", func(t *testing.T) {
@@ -377,11 +389,17 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 			TaskDescription: "test task",
 		})
 
-		if len(agentMgr.restartProcessCalls) != 1 {
-			t.Fatalf("expected 1 RestartAgentProcess call, got %d", len(agentMgr.restartProcessCalls))
+		// handleTaskMovedWithSession runs asynchronously — wait for it to complete.
+		time.Sleep(100 * time.Millisecond)
+
+		agentMgr.mu.Lock()
+		restartCalls := agentMgr.restartProcessCalls
+		agentMgr.mu.Unlock()
+		if len(restartCalls) != 1 {
+			t.Fatalf("expected 1 RestartAgentProcess call, got %d", len(restartCalls))
 		}
-		if agentMgr.restartProcessCalls[0] != "exec-123" {
-			t.Errorf("expected RestartAgentProcess called with 'exec-123', got %q", agentMgr.restartProcessCalls[0])
+		if restartCalls[0] != "exec-123" {
+			t.Errorf("expected RestartAgentProcess called with 'exec-123', got %q", restartCalls[0])
 		}
 
 		// Verify acp_session_id was cleared

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -360,7 +360,10 @@ func assertStepByName(t *testing.T, ctx context.Context, repo sessionExecutorSto
 // assertResetCalls verifies the cumulative count of RestartAgentProcess calls.
 func assertResetCalls(t *testing.T, agentMgr *mockAgentManager, expectCount int) {
 	t.Helper()
-	if got := len(agentMgr.restartProcessCalls); got != expectCount {
+	agentMgr.mu.Lock()
+	got := len(agentMgr.restartProcessCalls)
+	agentMgr.mu.Unlock()
+	if got != expectCount {
 		t.Errorf("restart calls = %d, want %d", got, expectCount)
 	}
 }


### PR DESCRIPTION
The POST /tasks/:id/move endpoint blocked for the entire duration of the agent turn (~5 minutes) because the in-memory event bus delivers events synchronously. When the orchestrator's handleTaskMoved handler triggered auto_start_agent or processStepExitAndEnter, the HTTP handler waited for the agent to complete, causing browser ERR_EMPTY_RESPONSE timeouts.

## Important Changes

- `handleTaskMovedNoSession`: wraps `StartTask` in a goroutine with `context.WithoutCancel(ctx)` so the event handler returns immediately
- `handleTaskMovedWithSession`: launches `processStepExitAndEnter` in a goroutine with `context.WithoutCancel(ctx)`
- Test updates: added `time.Sleep(100ms)` in 5 test cases to account for the now-asynchronous execution

## Validation

- `make -C apps/backend fmt` — clean
- `go test -count=1 ./internal/orchestrator/` — all pass
- `make -C apps/backend lint` — clean
- Existing e2e tests in `workflow-automation.spec.ts` already cover moveTask with auto_start_agent

## Possible Improvements

The pattern of using `time.Sleep` in tests for async goroutines could be replaced with `testing/synctest` (Go 1.24+) for deterministic timing, but 100ms is consistent with the existing `workflow_e2e_test.go` approach.

## Checklist

- [ ] Self-reviewed
- [ ] Tests updated
- [ ] Documentation updated (if applicable)
