### PR TITLE
feat(workflows): review uncommitted changes and add git safety rails

### DIFF
--- a/apps/backend/config/workflows/feature-dev.yml
+++ b/apps/backend/config/workflows/feature-dev.yml
@@ -65,6 +65,11 @@ steps:
 
       {{task_prompt}}
 
+      GIT SAFETY (read before running any git command)
+      - NEVER run `git checkout -- .`, `git checkout .`, `git reset --hard`, `git clean -fd`, or `git stash --include-untracked`. These wipe uncommitted work.
+      - When reverting files touched by formatters/linters, ALWAYS pass explicit paths (e.g. `git checkout -- path/to/file path/to/dir/`). Never use `.` or unscoped globs.
+      - Treat any uncommitted changes you did not make as intentional user work — leave them in place. Do not revert, stash, or overwrite them.
+
       STEP 0: CREATE A TASK LIST
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
@@ -113,14 +118,26 @@ steps:
 
       {{task_prompt}}
 
+      GIT SAFETY (read before running any git command)
+      - NEVER run `git checkout -- .`, `git checkout .`, `git reset --hard`, `git clean -fd`, or `git stash --include-untracked`. These wipe uncommitted work.
+      - When reverting files touched by formatters/linters, ALWAYS pass explicit paths (e.g. `git checkout -- path/to/file path/to/dir/`). Never use `.` or unscoped globs.
+      - Treat any uncommitted changes you did not make as intentional user work — leave them in place. Do not revert, stash, or overwrite them.
+
       STEP 0: CREATE A TASK LIST
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
       STEP 1: DETERMINE WHAT TO REVIEW
-      Determine the default branch (e.g. main, master) and diff against it:
-      - Run: git remote show origin | grep 'HEAD branch' to find the default branch name
-      - Run: git diff origin/<default_branch>...HEAD --name-only to get the list of changed files
-      Read each changed file in full — understand the surrounding code, not just the diff.
+      Gather BOTH committed and uncommitted changes on this branch — uncommitted edits and untracked files are still part of the task's work and must be reviewed. Do not commit or discard them yourself.
+
+      - Run: git status --short (see uncommitted modified + untracked files)
+      - Run: git remote show origin | grep 'HEAD branch' (find the default branch name)
+      - Run: git diff origin/<default_branch>...HEAD --name-only (committed changes on branch)
+      - Run: git diff HEAD --name-only (uncommitted tracked changes)
+      - Run: git ls-files --others --exclude-standard (untracked new files)
+
+      The review scope is the UNION of those lists. Read each file from the working tree — the working tree already contains the latest state including uncommitted edits. For per-file diffs against the default branch (including uncommitted changes), use: `git diff origin/<default_branch> -- <file>` (no three-dot).
+
+      If this still yields an empty set, report that there is nothing to review and stop — do not fabricate findings.
 
       STEP 2: REVIEW THE CHANGES
       Review across these layers (skip layers that don't apply):
@@ -219,6 +236,11 @@ steps:
 
       {{task_prompt}}
 
+      GIT SAFETY (read before running any git command)
+      - NEVER run `git checkout -- .`, `git checkout .`, `git reset --hard`, `git clean -fd`, or `git stash --include-untracked`. These wipe uncommitted work.
+      - When reverting files touched by formatters/linters, ALWAYS pass explicit paths (e.g. `git checkout -- path/to/file path/to/dir/`). Never use `.` or unscoped globs.
+      - Treat any uncommitted changes you did not make as intentional user work — leave them in place. Do not revert, stash, or overwrite them.
+
       STEP 0: CREATE A TASK LIST
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
@@ -259,6 +281,11 @@ steps:
       Wait for CI checks to complete and fix any failures.
 
       {{task_prompt}}
+
+      GIT SAFETY (read before running any git command)
+      - NEVER run `git checkout -- .`, `git checkout .`, `git reset --hard`, `git clean -fd`, or `git stash --include-untracked`. These wipe uncommitted work.
+      - When reverting files touched by formatters/linters, ALWAYS pass explicit paths (e.g. `git checkout -- path/to/file path/to/dir/`). Never use `.` or unscoped globs.
+      - Treat any uncommitted changes you did not make as intentional user work — leave them in place. Do not revert, stash, or overwrite them.
 
       STEP 0: CREATE A TASK LIST
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.

--- a/apps/backend/config/workflows/feature-dev.yml
+++ b/apps/backend/config/workflows/feature-dev.yml
@@ -250,8 +250,8 @@ steps:
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 
       STEP 1: PREPARE
-      - Run formatters and linters to ensure code is clean.
-      - Stage and commit any remaining changes.
+      - Run formatters and linters. If they touch files unrelated to your task, selectively restore them with `git checkout -- <specific-paths>` (see GIT SAFETY) — never `git checkout -- .`.
+      - Stage and commit any remaining task-related changes using explicit paths — never `git add .`. Leave uncommitted or untracked files you did not create untouched; they are the user's work.
       - Push the branch to origin.
 
       STEP 2: CHECK FOR PR TEMPLATE

--- a/apps/backend/config/workflows/feature-dev.yml
+++ b/apps/backend/config/workflows/feature-dev.yml
@@ -97,11 +97,11 @@ steps:
       - If a fix requires an architectural change (new DB table, new service layer, switching libraries): stop and ask.
       - After 3 failed fix attempts on the same issue: stop, question the approach, ask the user.
 
-      STEP 4: ENSURE EVERYTHING IS COMMITTED
+      STEP 4: ENSURE YOUR OWN CHANGES ARE COMMITTED
       Before finishing this phase:
-      - Run `git status` to confirm there are no uncommitted or untracked changes that belong to this task.
-      - If anything is left, stage and commit it with a descriptive message.
-      - The phase is only complete when `git status` shows a clean tree on the task branch.
+      - Run `git status` to see what changed.
+      - Stage and commit every file YOU created or modified for this task, using explicit paths (see GIT SAFETY). Use descriptive messages.
+      - Any uncommitted or untracked changes you did not make are intentional user work — leave them as-is. Do not aim for an absolutely clean tree; aim for none of YOUR task-related edits to be uncommitted.
     events:
       on_enter:
         - type: auto_start_agent
@@ -172,8 +172,8 @@ steps:
       STEP 4: COMMIT ANY FIXES YOU MADE
       If you made direct fixes in STEP 3:
       - Run `git status` to see what changed.
-      - Stage and commit the fixes with a descriptive message (e.g. `review: remove dead code` or `review: early returns in X`).
-      - Do not leave the tree dirty — QA runs next and must see a clean state.
+      - Stage only the files YOU edited, using explicit paths (see GIT SAFETY) — never `git add .`. Commit with a descriptive message (e.g. `review: remove dead code` or `review: early returns in X`).
+      - Leave any other uncommitted or untracked files alone; they are the user's work and QA will exercise them from the working tree.
     events:
       on_enter:
         - type: reset_agent_context
@@ -190,6 +190,11 @@ steps:
       Verify the feature works end-to-end. Your goal is to find bugs, not confirm it works.
 
       {{task_prompt}}
+
+      GIT SAFETY (read before running any git command)
+      - NEVER run `git checkout -- .`, `git checkout .`, `git reset --hard`, `git clean -fd`, or `git stash --include-untracked`. These wipe uncommitted work.
+      - When reverting files touched by formatters/linters, ALWAYS pass explicit paths (e.g. `git checkout -- path/to/file path/to/dir/`). Never use `.` or unscoped globs.
+      - Treat any uncommitted changes you did not make as intentional user work — leave them in place. Do not revert, stash, or overwrite them.
 
       STEP 0: CREATE A TASK LIST
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.

--- a/apps/backend/config/workflows/plan-and-build.yml
+++ b/apps/backend/config/workflows/plan-and-build.yml
@@ -97,11 +97,11 @@ steps:
       - If a fix requires an architectural change (new DB table, new service layer, switching libraries): stop and ask.
       - After 3 failed fix attempts on the same issue: stop, question the approach, ask the user.
 
-      STEP 4: ENSURE EVERYTHING IS COMMITTED
+      STEP 4: ENSURE YOUR OWN CHANGES ARE COMMITTED
       Before finishing this phase:
-      - Run `git status` to confirm there are no uncommitted or untracked changes that belong to this task.
-      - If anything is left, stage and commit it with a descriptive message.
-      - The phase is only complete when `git status` shows a clean tree on the task branch.
+      - Run `git status` to see what changed.
+      - Stage and commit every file YOU created or modified for this task, using explicit paths (see GIT SAFETY). Use descriptive messages.
+      - Any uncommitted or untracked changes you did not make are intentional user work — leave them as-is. Do not aim for an absolutely clean tree; aim for none of YOUR task-related edits to be uncommitted.
     events:
       on_enter:
         - type: auto_start_agent

--- a/apps/backend/config/workflows/plan-and-build.yml
+++ b/apps/backend/config/workflows/plan-and-build.yml
@@ -66,6 +66,11 @@ steps:
 
       {{task_prompt}}
 
+      GIT SAFETY (read before running any git command)
+      - NEVER run `git checkout -- .`, `git checkout .`, `git reset --hard`, `git clean -fd`, or `git stash --include-untracked`. These wipe uncommitted work.
+      - When reverting files touched by formatters/linters, ALWAYS pass explicit paths (e.g. `git checkout -- path/to/file path/to/dir/`). Never use `.` or unscoped globs.
+      - Treat any uncommitted changes you did not make as intentional user work — leave them in place. Do not revert, stash, or overwrite them.
+
       STEP 0: CREATE A TASK LIST
       Before anything else, create a task list tracking the substeps below (use your todo/task tracking tool if available). Mark each task in_progress when you begin it and completed when you finish. Do not skip ahead — each step feeds the next.
 


### PR DESCRIPTION
The Review step was skipping tasks whose Work phase had not been committed yet (diffing `origin/<default>...HEAD` returned empty), and agents in later phases occasionally wiped uncommitted work with `git checkout -- .` when formatters touched unrelated files — this reworks the Review prompt to include uncommitted edits and untracked files in scope, and adds a short GIT SAFETY block to every phase that runs git commands.

## Important Changes

- Review step gathers the union of committed, uncommitted tracked, and untracked changes (from the working tree) instead of only committed commits, and no longer forces a commit before reviewing.
- GIT SAFETY block added after `{{task_prompt}}` in five steps (`feature-dev`: Work, Review, PR, CI Fixup; `plan-and-build`: Implementation) — forbids `git checkout -- .` / `git reset --hard` / `git clean -fd` / `git stash --include-untracked`, requires explicit paths when reverting formatter-touched files, and tells agents to leave unknown uncommitted changes in place.

## Validation

- `cd apps/backend && go test ./config/workflows/...` — passes (loader parses both YAMLs, template invariants hold).
- Manually diffed the updated Review STEP 1 to confirm it produces a reviewable scope even with a dirty tree.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qr7u3pduLb2Vhar6tyqzN2)_