### PR TITLE
fix(web): apply initialValues when TaskCreateDialog mounts already-open

### DIFF
--- a/apps/web/components/task-create-dialog-state.ts
+++ b/apps/web/components/task-create-dialog-state.ts
@@ -255,7 +255,9 @@ function useFormStateValues(
 ) {
   // openCycle increments each time dialog opens - used in key to force TaskFormInputs remount
   const [openCycle, setOpenCycle] = useState(0);
-  const prevOpenRef = useRef(open);
+  // Start as false so a fresh mount with open=true is detected as a rising edge
+  // (callers like QuickTaskLauncher conditionally mount the dialog already-open).
+  const prevOpenRef = useRef(false);
 
   // currentDefaults stores the loaded draft/initial values for this open cycle
   const [currentDefaults, setCurrentDefaults] = useState<{ name: string; description: string }>({


### PR DESCRIPTION
## Summary

Actions on `/github` (PR/issue presets) started empty tasks because `QuickTaskLauncher` conditionally mounts `TaskCreateDialog` with `open={true}`, and the dialog's rising-edge effect initialized `prevOpenRef` to the current `open` value — so `wasOpen` matched on first mount and the block that seeds title/description/repo/branch from `initialValues` was skipped. Initializing the ref to `false` restores rising-edge detection for both mount patterns.

## Validation

- \`pnpm format\` — clean
- \`pnpm --filter @kandev/web lint\` — 0 warnings
- \`tsc --noEmit\` in \`apps/web\` — 0 errors
- \`pnpm --filter @kandev/web test\` — 520/520 passing

## Possible Improvements

Low risk: other callers (\`NewTaskButton\`, \`TasksPageClient\`, etc.) mount with \`open={false}\` and transition to \`true\`; \`wasOpen\` is still \`false\` on that transition, so behavior is unchanged.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes