### PR TITLE
fix(web): align sidebar filter toolbar height with panel headers

### DIFF
--- a/apps/web/components/task/sidebar-filter/sidebar-filter-bar.tsx
+++ b/apps/web/components/task/sidebar-filter/sidebar-filter-bar.tsx
@@ -41,7 +41,10 @@ export function SidebarFilterBar() {
   useRegisterCommands(commands);
 
   return (
-    <div data-testid="sidebar-filter-bar" className="flex items-center gap-1 border-b px-2 py-1">
+    <div
+      data-testid="sidebar-filter-bar"
+      className="flex h-[30px] shrink-0 items-center gap-1 border-b border-border bg-card px-2"
+    >
       <SidebarViewChips />
       <SidebarFilterPopover
         open={open}


### PR DESCRIPTION
The left sidebar filter toolbar was visibly taller than the center diff viewer and the right Changes panel header, breaking the horizontal alignment of the panel headers row. Replacing `py-1` with the same fixed `h-[30px]` used by `PanelHeaderBar` (plus matching `border-border bg-card`) restores a consistent strip height across all three panels.

## Validation

- `pnpm typecheck` (no new errors)
- `pnpm lint --max-warnings 0`
- `pnpm format`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.