### PR TITLE
fix(sprites): use bash for prepare scripts and fix pnpm install in sprites env

### DIFF
--- a/apps/backend/internal/agent/lifecycle/default_scripts.go
+++ b/apps/backend/internal/agent/lifecycle/default_scripts.go
@@ -86,7 +86,7 @@ git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 {{github.auth_setup}}
 
 # ---- Install pnpm globally ----
-curl -fsSL https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linux-x64 -o /usr/local/bin/pnpm
+curl -fsSL https://github.com/pnpm/pnpm/releases/download/v10.32.1/pnpm-linux-x64 -o /usr/local/bin/pnpm
 chmod +x /usr/local/bin/pnpm
 
 # ---- Git identity ----

--- a/apps/backend/internal/agent/lifecycle/default_scripts.go
+++ b/apps/backend/internal/agent/lifecycle/default_scripts.go
@@ -86,7 +86,8 @@ git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 {{github.auth_setup}}
 
 # ---- Install pnpm globally ----
-npm install -g pnpm > /dev/null 2>&1
+curl -fsSL https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linux-x64 -o /usr/local/bin/pnpm
+chmod +x /usr/local/bin/pnpm
 
 # ---- Git identity ----
 {{git.identity_setup}}

--- a/apps/backend/internal/agent/lifecycle/env_preparer_local.go
+++ b/apps/backend/internal/agent/lifecycle/env_preparer_local.go
@@ -135,7 +135,7 @@ const setupScriptStreamInterval = 100 * time.Millisecond
 // streaming combined stdout/stderr to onOutput (if non-nil) as it runs.
 // Returns the full accumulated output (trimmed) and any execution error.
 func runSetupScript(ctx context.Context, script, workDir string, env map[string]string, onOutput func(current string)) (string, error) {
-	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	cmd := exec.CommandContext(ctx, "bash", "-c", script)
 	if workDir != "" {
 		cmd.Dir = workDir
 	}

--- a/apps/backend/internal/agent/lifecycle/executor_sprites_operations.go
+++ b/apps/backend/internal/agent/lifecycle/executor_sprites_operations.go
@@ -77,7 +77,7 @@ func (r *SpritesExecutor) runPrepareScript(
 	defer cancel()
 
 	r.logger.Debug("running prepare script")
-	cmd := sprite.CommandContext(stepCtx, "sh", "-c", script)
+	cmd := sprite.CommandContext(stepCtx, "bash", "-c", script)
 	cmd.Env = r.buildSpriteEnv(req.Env)
 
 	stdout, err := cmd.StdoutPipe()

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -24,7 +24,7 @@
     "vitest": "^1.6.0"
   },
   "scripts": {
-    "dev": "tsx src/cli.ts",
+    "dev": "unset npm_config_prefix && tsx src/cli.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/cli.js",
     "test": "vitest run",

--- a/apps/web/components/github/my-github/use-saved-presets.test.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.test.ts
@@ -1,11 +1,28 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { readStorage, type SavedPreset } from "./use-saved-presets";
 
 const STORAGE_KEY = "kandev:github-presets:v1";
 
+// happy-dom's localStorage Proxy does not expose methods across VM contexts;
+// stub globalThis.localStorage with a minimal in-memory implementation.
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(store)) delete store[key];
+  },
+};
+vi.stubGlobal("localStorage", localStorageMock);
+
 function set(raw: string | null) {
-  if (raw === null) window.localStorage.removeItem(STORAGE_KEY);
-  else window.localStorage.setItem(STORAGE_KEY, raw);
+  if (raw === null) localStorageMock.removeItem(STORAGE_KEY);
+  else localStorageMock.setItem(STORAGE_KEY, raw);
 }
 
 const valid: SavedPreset = {
@@ -19,7 +36,7 @@ const valid: SavedPreset = {
 
 describe("readStorage", () => {
   beforeEach(() => {
-    window.localStorage.clear();
+    localStorageMock.removeItem(STORAGE_KEY);
   });
 
   it("returns empty array when no value is stored", () => {


### PR DESCRIPTION
In Sprites executor environments, NVM is installed at `/.sprite/languages/node/nvm/nvm.sh` and gets sourced during pnpm script execution. This conflicts with `npm_config_prefix`, which pnpm injects into every script's environment, causing `make dev` and `make start` to fail with exit code 11.

## Important Changes

- `executor_sprites_operations.go`, `env_preparer_local.go`: switch prepare script execution from `sh -c` to `bash -c` so scripts with `#!/bin/bash` shebangs run as intended instead of falling back to POSIX sh (dash on Ubuntu)
- `default_scripts.go`: replace `npm install -g pnpm` with a direct `curl` download of the pnpm binary — avoids triggering npm's script runner and the NVM conflict during environment setup
- `apps/cli/package.json`: unset `npm_config_prefix` inside the CLI `dev` script so NVM does not reject it when pnpm injects it at script startup

## Validation

- `make -C apps/backend fmt test lint` — all pass
- `pnpm --filter @kandev/web lint typecheck` — 0 errors

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated if needed