### PR TITLE
fix(web): show skeleton in file tree header while workspace path loads

### DIFF
--- a/apps/web/components/task/file-browser-toolbar.tsx
+++ b/apps/web/components/task/file-browser-toolbar.tsx
@@ -11,6 +11,7 @@ import {
   IconPlus,
 } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { Skeleton } from "@kandev/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { PanelHeaderBarSplit } from "./panel-primitives";
 
@@ -93,9 +94,13 @@ export function FileBrowserToolbar({
             </TooltipTrigger>
             <TooltipContent>Copy workspace path</TooltipContent>
           </Tooltip>
-          <span className="min-w-0 truncate text-xs font-medium text-muted-foreground">
-            {displayPath}
-          </span>
+          {displayPath ? (
+            <span className="min-w-0 truncate text-xs font-medium text-muted-foreground">
+              {displayPath}
+            </span>
+          ) : (
+            <Skeleton className="h-3 w-32" />
+          )}
         </>
       }
       right={

--- a/apps/web/components/task/file-browser-toolbar.tsx
+++ b/apps/web/components/task/file-browser-toolbar.tsx
@@ -99,7 +99,7 @@ export function FileBrowserToolbar({
               {displayPath}
             </span>
           ) : (
-            <Skeleton className="h-3 w-32" />
+            <Skeleton className="h-3 w-24" />
           )}
         </>
       }


### PR DESCRIPTION
The file tree header sometimes rendered with no workspace folder name — only the copy button — because `displayPath` is derived from `session.worktree_path`/`repository.local_path` while the header itself is gated on tree-load state, so the two could be out of sync. Now an empty `displayPath` renders a small skeleton so the layout stays stable and the loading state is visible.

## Validation

- `make -C apps/backend fmt test lint` (clean)
- `pnpm format` / `pnpm exec tsc --noEmit` / `pnpm exec eslint --max-warnings 0` in `apps/web` (clean)

## Possible Improvements

Low risk — purely a UX patch. The underlying hydration mismatch (tree loaded before session/repository slices populate) still exists; a follow-up could investigate why `useRepository` lags behind the tree.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.