### PR TITLE
feat(preview): add PR preview environments via Sprites

### DIFF
--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -1,0 +1,140 @@
+name: Preview Environment
+
+# Dual triggers — mirrors the claude-code-review.yml pattern exactly:
+#   pull_request: same-repo PRs (secrets available, safe to run on PR head)
+#   pull_request_target: fork PRs (secrets available via base repo, gated by allowlist)
+# Exactly one job runs per PR event based on event_name AND head repo identity.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  # -----------------------------------------------------------------------
+  # Deploy / update preview (same-repo PRs)
+  # Always runs for same-repo pushes that are not a close event.
+  # -----------------------------------------------------------------------
+  deploy-same-repo:
+    if: >
+      github.event.action != 'closed' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: apps/backend/go.mod
+          cache-dependency-path: apps/backend/go.sum
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "9"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install frontend dependencies
+        run: pnpm -C apps install --frozen-lockfile
+
+      - name: Deploy preview environment
+        working-directory: apps/backend
+        run: go run ./cmd/preview deploy --pr "$PR" --sha "$SHA" --repo "$REPO"
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          SPRITES_API_TOKEN: ${{ secrets.SPRITES_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # -----------------------------------------------------------------------
+  # Deploy / update preview (fork PRs, gated by allowlist)
+  # Uses pull_request_target so secrets are available.
+  # Gated by: OWNER/MEMBER/COLLABORATOR author_association,
+  #           `safe-to-test` label (maintainer opt-in), or
+  #           PREVIEW_ENV_ALLOWLIST repo variable (JSON array of logins).
+  # -----------------------------------------------------------------------
+  deploy-fork:
+    if: >
+      github.event.action != 'closed' &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+       contains(github.event.pull_request.labels.*.name, 'safe-to-test') ||
+       (vars.PREVIEW_ENV_ALLOWLIST != '' && contains(fromJSON(vars.PREVIEW_ENV_ALLOWLIST), github.event.pull_request.user.login)))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # pull_request_target checks out base by default; explicitly use PR head.
+          # Safe: the preview CLI only reads files to build artifacts and posts comments.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: apps/backend/go.mod
+          cache-dependency-path: apps/backend/go.sum
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "9"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install frontend dependencies
+        run: pnpm -C apps install --frozen-lockfile
+
+      - name: Deploy preview environment
+        working-directory: apps/backend
+        run: go run ./cmd/preview deploy --pr "$PR" --sha "$SHA" --repo "$REPO"
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          SPRITES_API_TOKEN: ${{ secrets.SPRITES_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # -----------------------------------------------------------------------
+  # Cleanup (all closed PRs — no allowlist check)
+  # The sprite must be destroyed regardless of how the PR was closed or
+  # whether a preview was ever successfully deployed. Handles gracefully
+  # if the sprite does not exist (was never deployed or already destroyed).
+  # -----------------------------------------------------------------------
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: apps/backend/go.mod
+          cache-dependency-path: apps/backend/go.sum
+
+      - name: Destroy preview environment
+        working-directory: apps/backend
+        run: go run ./cmd/preview cleanup --pr "$PR" --repo "$REPO"
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          SPRITES_API_TOKEN: ${{ secrets.SPRITES_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Deploy preview environment
         working-directory: apps/backend
-        run: go run ./cmd/preview deploy --pr "$PR" --sha "$SHA" --repo "$REPO"
+        run: go run ./cmd/preview deploy --pr "$PR" --sha "$SHA" --repo "$REPO" --skip-web-install
         env:
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
@@ -81,6 +81,9 @@ jobs:
         with:
           # pull_request_target checks out base by default; explicitly use PR head.
           # Safe: the preview CLI only reads files to build artifacts and posts comments.
+          # NOTE: The allowlist gate (OWNER/MEMBER/COLLABORATOR, safe-to-test, PREVIEW_ENV_ALLOWLIST)
+          # authorizes running the fork's cmd/preview code with SPRITES_API_TOKEN and GH_TOKEN.
+          # The safe-to-test label must be re-applied after each new push (see strip-safe-to-test job).
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -102,7 +105,7 @@ jobs:
 
       - name: Deploy preview environment
         working-directory: apps/backend
-        run: go run ./cmd/preview deploy --pr "$PR" --sha "$SHA" --repo "$REPO"
+        run: go run ./cmd/preview deploy --pr "$PR" --sha "$SHA" --repo "$REPO" --skip-web-install
         env:
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
@@ -111,13 +114,42 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # -----------------------------------------------------------------------
+  # Strip safe-to-test label on new pushes to fork PRs.
+  # Prevents a once-approved fork from running updated (potentially malicious)
+  # code on subsequent pushes without a fresh maintainer re-approval.
+  # -----------------------------------------------------------------------
+  strip-safe-to-test:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'safe-to-test',
+            });
+
+  # -----------------------------------------------------------------------
   # Cleanup (all closed PRs — no allowlist check)
   # The sprite must be destroyed regardless of how the PR was closed or
   # whether a preview was ever successfully deployed. Handles gracefully
   # if the sprite does not exist (was never deployed or already destroyed).
+  # Runs only on pull_request_target to avoid duplicate runs — both events
+  # fire `closed`, but only pull_request_target has secrets for all PRs.
   # -----------------------------------------------------------------------
   cleanup-preview:
-    if: github.event.action == 'closed'
+    if: >
+      github.event.action == 'closed' &&
+      github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -152,6 +152,7 @@ jobs:
       github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
 
     steps:

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -25,10 +25,16 @@ BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || powershell -c
 
 LDFLAGS += -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildTime=$(BUILD_TIME)
 
-.PHONY: all build build-all build-agentctl build-agentctl-linux build-acpdbg acpdbg build-mock-agent clean run dev start-debug test test-e2e test-sprites-e2e lint fmt vet help
+.PHONY: all build build-all build-agentctl build-agentctl-linux build-acpdbg acpdbg build-mock-agent build-preview clean run dev start-debug test test-e2e test-sprites-e2e lint fmt vet help
 
 ## Default target
 all: build
+
+## Build the preview CLI for deploying PR preview environments to Sprites
+build-preview:
+	@echo "Building preview..."
+	@$(MKDIR) $(BUILD_DIR)
+	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/preview ./cmd/preview
 
 ## Build the mock-agent binary for testing
 build-mock-agent:
@@ -162,6 +168,7 @@ help:
 	@echo "  build-all       Build all binaries (unified + individual services + agentctl)"
 	@echo "  build-agentctl  Build the agentctl sidecar binary (includes embedded MCP server)"
 	@echo "  build-mock-agent Build the mock-agent binary for testing"
+	@echo "  build-preview   Build the preview CLI for PR preview environments"
 	@echo "  clean         Remove build artifacts"
 	@echo "  run           Build and run the application"
 	@echo "  dev           Run in development mode (pprof enabled)"

--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -60,16 +60,13 @@ import (
 
 	// Database
 	"github.com/kandev/kandev/internal/db"
-)
 
-// defaultServerPort is the fallback HTTP port when neither the CLI flag nor
-// the config file / env var sets one. Kept in sync with the viper default in
-// internal/common/config.setDefaults.
-const defaultServerPort = 38429
+	"github.com/kandev/kandev/internal/common/ports"
+)
 
 // Command-line flags
 var (
-	flagPort     = flag.Int("port", 0, fmt.Sprintf("HTTP server port (default: %d)", defaultServerPort))
+	flagPort     = flag.Int("port", 0, fmt.Sprintf("HTTP server port (default: %d)", ports.Backend))
 	flagLogLevel = flag.String("log-level", "", "Log level: debug, info, warn, error")
 	flagHelp     = flag.Bool("help", false, "Show help message")
 	flagVersion  = flag.Bool("version", false, "Show version information")
@@ -435,7 +432,7 @@ func startGatewayAndServe(
 
 	port := cfg.Server.Port
 	if port == 0 {
-		port = defaultServerPort
+		port = ports.Backend
 	}
 	go func() {
 		log.Info("WebSocket server listening", zap.Int("port", port))
@@ -506,7 +503,7 @@ func buildHTTPServer(
 
 	port := cfg.Server.Port
 	if port == 0 {
-		port = defaultServerPort
+		port = ports.Backend
 	}
 	return &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),

--- a/apps/backend/cmd/preview/build.go
+++ b/apps/backend/cmd/preview/build.go
@@ -20,8 +20,8 @@ const goDockerImage = "golang:1.26-bookworm"
 
 // buildLinuxBinaries compiles kandev, agentctl, and mock-agent for linux/amd64.
 // Run this from apps/backend/. agentctl and mock-agent use CGO_ENABLED=0 and
-// always build natively. kandev requires CGO (SQLite); on non-linux/amd64 hosts
-// it is built inside a Docker container automatically.
+// always build natively. kandev requires CGO (SQLite) and is always built inside
+// a Docker container to target a known glibc version (Debian Bookworm = 2.36).
 func buildLinuxBinaries(ctx context.Context, outDir string) error {
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return err

--- a/apps/backend/cmd/preview/build.go
+++ b/apps/backend/cmd/preview/build.go
@@ -125,12 +125,10 @@ func packageBundle(binDir, tarPath string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	gz := gzip.NewWriter(f)
-	defer gz.Close()
 	tw := tar.NewWriter(gz)
-	defer tw.Close()
 
 	// Add binaries.
 	binEntries, err := os.ReadDir(binDir)
@@ -165,7 +163,11 @@ func packageBundle(binDir, tarPath string) error {
 		return fmt.Errorf("add public: %w", err)
 	}
 
-	return nil
+	// Close in order: tar → gzip → file (flush compressed data).
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("close tar: %w", err)
+	}
+	return gz.Close()
 }
 
 func addFileToTar(tw *tar.Writer, src, dst string, mode fs.FileMode) error {
@@ -233,7 +235,7 @@ func addDirToTar(tw *tar.Writer, srcDir, dstPrefix string) error {
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err

--- a/apps/backend/cmd/preview/build.go
+++ b/apps/backend/cmd/preview/build.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 )
 
 // appsDir is the apps/ workspace root relative to the working directory (apps/backend/).
@@ -43,20 +42,14 @@ func buildLinuxBinaries(ctx context.Context, outDir string) error {
 		}
 	}
 
-	// kandev requires CGO for SQLite. Build natively on linux/amd64; use Docker otherwise.
+	// kandev requires CGO for SQLite. Always build inside Docker so the resulting
+	// binary targets a known glibc version (Debian Bookworm = 2.36) regardless of
+	// the host OS. Sprites VMs run a compatible glibc; building natively on the
+	// CI runner (Ubuntu 24.04, glibc 2.39) would produce a binary that requires
+	// symbols unavailable in the Sprites environment.
 	kandevOut := filepath.Join(outDir, "kandev")
-	fmt.Fprintf(os.Stderr, "  go build ./cmd/kandev -> %s\n", kandevOut)
-	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
-		return buildKandevNative(ctx, kandevOut)
-	}
+	fmt.Fprintf(os.Stderr, "  go build ./cmd/kandev (docker cross-compile) -> %s\n", kandevOut)
 	return buildKandevDocker(ctx, kandevOut)
-}
-
-func buildKandevNative(ctx context.Context, out string) error {
-	cmd := exec.CommandContext(ctx, "go", "build", "-ldflags", "-s -w", "-o", out, "./cmd/kandev")
-	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=1")
-	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
-	return cmd.Run()
 }
 
 // buildKandevDocker builds kandev inside a linux/amd64 Docker container.

--- a/apps/backend/cmd/preview/build.go
+++ b/apps/backend/cmd/preview/build.go
@@ -34,7 +34,7 @@ func buildLinuxBinaries(ctx context.Context, outDir string) error {
 		{"mock-agent", "./cmd/mock-agent"},
 	} {
 		out := filepath.Join(outDir, b.name)
-		fmt.Printf("  go build %s -> %s\n", b.pkg, out)
+		fmt.Fprintf(os.Stderr, "  go build %s -> %s\n", b.pkg, out)
 		cmd := exec.CommandContext(ctx, "go", "build", "-ldflags", "-s -w", "-o", out, b.pkg)
 		cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
 		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
@@ -45,7 +45,7 @@ func buildLinuxBinaries(ctx context.Context, outDir string) error {
 
 	// kandev requires CGO for SQLite. Build natively on linux/amd64; use Docker otherwise.
 	kandevOut := filepath.Join(outDir, "kandev")
-	fmt.Printf("  go build ./cmd/kandev -> %s\n", kandevOut)
+	fmt.Fprintf(os.Stderr, "  go build ./cmd/kandev -> %s\n", kandevOut)
 	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
 		return buildKandevNative(ctx, kandevOut)
 	}
@@ -88,21 +88,48 @@ func buildKandevDocker(ctx context.Context, out string) error {
 		return fmt.Errorf("docker build kandev: %w", err)
 	}
 
-	// Move from the temp path (inside /work) to the desired output path.
+	// Copy from temp path (inside /work mount) to the desired output path.
+	// os.Rename fails with EXDEV when hostTmp and out are on different filesystems
+	// (e.g. the repo is on a regular disk and out is under os.TempDir() on tmpfs).
 	hostTmp := filepath.Join(wd, "bin", "kandev-preview-build")
-	return os.Rename(hostTmp, out)
+	defer func() { _ = os.Remove(hostTmp) }()
+	return copyFile(hostTmp, out, 0o755)
 }
 
-// buildWeb installs frontend dependencies and runs the Next.js production build.
-func buildWeb(ctx context.Context) error {
-	for _, step := range []struct {
+func copyFile(src, dst string, mode fs.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %s → %s: %w", src, dst, err)
+	}
+	return nil
+}
+
+// buildWeb runs the Next.js production build. When skipInstall is true the
+// pnpm install step is skipped (CI already runs it before invoking the CLI).
+func buildWeb(ctx context.Context, skipInstall bool) error {
+	steps := []struct {
 		desc string
 		args []string
 	}{
 		{"pnpm install", []string{"pnpm", "install", "--frozen-lockfile"}},
 		{"pnpm build web", []string{"pnpm", "--filter", "@kandev/web", "build"}},
-	} {
-		fmt.Printf("  %s\n", step.desc)
+	}
+	for _, step := range steps {
+		if skipInstall && step.desc == "pnpm install" {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "  %s\n", step.desc)
 		cmd := exec.CommandContext(ctx, step.args[0], step.args[1:]...)
 		cmd.Dir = appsDir
 		cmd.Stdout = os.Stdout
@@ -203,7 +230,7 @@ func addDirToTar(tw *tar.Writer, srcDir, dstPrefix string) error {
 			return err
 		}
 
-		// Handle symlinks by following them.
+		// Preserve symlinks as-is (Next.js standalone relies on them for node_modules).
 		if info.Mode()&fs.ModeSymlink != 0 {
 			target, err := os.Readlink(path)
 			if err != nil {

--- a/apps/backend/cmd/preview/build.go
+++ b/apps/backend/cmd/preview/build.go
@@ -60,6 +60,11 @@ func buildKandevDocker(ctx context.Context, out string) error {
 	if err != nil {
 		return err
 	}
+	// Ensure the host-side bin/ directory exists before Docker tries to write
+	// into it. `go build -o` does not create missing parent directories.
+	if err := os.MkdirAll(filepath.Join(wd, "bin"), 0o755); err != nil {
+		return fmt.Errorf("mkdir bin: %w", err)
+	}
 	// Output inside the container (relative to /work mount).
 	containerOut := "/work/bin/kandev-preview-build"
 	goCache := filepath.Join(os.Getenv("HOME"), ".cache", "go-build-linux")

--- a/apps/backend/cmd/preview/build.go
+++ b/apps/backend/cmd/preview/build.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// appsDir is the apps/ workspace root relative to the working directory (apps/backend/).
+const appsDir = ".."
+
+// goDockerImage is used to cross-compile CGO binaries on non-linux/amd64 hosts.
+const goDockerImage = "golang:1.26-bookworm"
+
+// buildLinuxBinaries compiles kandev, agentctl, and mock-agent for linux/amd64.
+// Run this from apps/backend/. agentctl and mock-agent use CGO_ENABLED=0 and
+// always build natively. kandev requires CGO (SQLite); on non-linux/amd64 hosts
+// it is built inside a Docker container automatically.
+func buildLinuxBinaries(ctx context.Context, outDir string) error {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return err
+	}
+
+	// agentctl and mock-agent don't need CGO — build natively with cross-env.
+	for _, b := range []struct{ name, pkg string }{
+		{"agentctl", "./cmd/agentctl"},
+		{"mock-agent", "./cmd/mock-agent"},
+	} {
+		out := filepath.Join(outDir, b.name)
+		fmt.Printf("  go build %s -> %s\n", b.pkg, out)
+		cmd := exec.CommandContext(ctx, "go", "build", "-ldflags", "-s -w", "-o", out, b.pkg)
+		cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("build %s: %w", b.name, err)
+		}
+	}
+
+	// kandev requires CGO for SQLite. Build natively on linux/amd64; use Docker otherwise.
+	kandevOut := filepath.Join(outDir, "kandev")
+	fmt.Printf("  go build ./cmd/kandev -> %s\n", kandevOut)
+	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
+		return buildKandevNative(ctx, kandevOut)
+	}
+	return buildKandevDocker(ctx, kandevOut)
+}
+
+func buildKandevNative(ctx context.Context, out string) error {
+	cmd := exec.CommandContext(ctx, "go", "build", "-ldflags", "-s -w", "-o", out, "./cmd/kandev")
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=1")
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
+// buildKandevDocker builds kandev inside a linux/amd64 Docker container.
+// apps/backend is mounted at /work; the output is written to /work/bin/kandev
+// then copied to the host out path.
+func buildKandevDocker(ctx context.Context, out string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	// Output inside the container (relative to /work mount).
+	containerOut := "/work/bin/kandev-preview-build"
+	goCache := filepath.Join(os.Getenv("HOME"), ".cache", "go-build-linux")
+	goModCache := filepath.Join(os.Getenv("HOME"), "go", "pkg", "mod")
+
+	cmd := exec.CommandContext(ctx, "docker", "run", "--rm",
+		"--platform", "linux/amd64",
+		"-v", wd+":/work",
+		"-v", goCache+":/root/.cache/go-build",
+		"-v", goModCache+":/go/pkg/mod",
+		"-w", "/work",
+		goDockerImage,
+		"go", "build", "-ldflags", "-s -w",
+		"-o", containerOut,
+		"./cmd/kandev",
+	)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker build kandev: %w", err)
+	}
+
+	// Move from the temp path (inside /work) to the desired output path.
+	hostTmp := filepath.Join(wd, "bin", "kandev-preview-build")
+	return os.Rename(hostTmp, out)
+}
+
+// buildWeb installs frontend dependencies and runs the Next.js production build.
+func buildWeb(ctx context.Context) error {
+	for _, step := range []struct {
+		desc string
+		args []string
+	}{
+		{"pnpm install", []string{"pnpm", "install", "--frozen-lockfile"}},
+		{"pnpm build web", []string{"pnpm", "--filter", "@kandev/web", "build"}},
+	} {
+		fmt.Printf("  %s\n", step.desc)
+		cmd := exec.CommandContext(ctx, step.args[0], step.args[1:]...)
+		cmd.Dir = appsDir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("%s: %w", step.desc, err)
+		}
+	}
+	return nil
+}
+
+// packageBundle creates a tar.gz matching the Docker container layout:
+//
+//	app/apps/backend/bin/{kandev,agentctl,mock-agent}
+//	app/apps/web/.next/standalone/           (Next.js server + node_modules)
+//	app/apps/web/.next/standalone/web/.next/static/  (static assets inside standalone)
+//	app/apps/web/.next/standalone/web/public/        (public assets inside standalone)
+func packageBundle(binDir, tarPath string) error {
+	f, err := os.Create(tarPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz := gzip.NewWriter(f)
+	defer gz.Close()
+	tw := tar.NewWriter(gz)
+	defer tw.Close()
+
+	// Add binaries.
+	binEntries, err := os.ReadDir(binDir)
+	if err != nil {
+		return fmt.Errorf("read bin dir: %w", err)
+	}
+	for _, e := range binEntries {
+		src := filepath.Join(binDir, e.Name())
+		dst := filepath.Join("app", "apps", "backend", "bin", e.Name())
+		if err := addFileToTar(tw, src, dst, 0o755); err != nil {
+			return err
+		}
+	}
+
+	// Add Next.js standalone output.
+	standaloneDir := filepath.Join(appsDir, "web", ".next", "standalone")
+	if err := addDirToTar(tw, standaloneDir, filepath.Join("app", "apps", "web", ".next", "standalone")); err != nil {
+		return fmt.Errorf("add standalone: %w", err)
+	}
+
+	// Add static assets into the standalone web dir (mirrors the Dockerfile COPY).
+	staticDir := filepath.Join(appsDir, "web", ".next", "static")
+	staticDst := filepath.Join("app", "apps", "web", ".next", "standalone", "web", ".next", "static")
+	if err := addDirToTar(tw, staticDir, staticDst); err != nil {
+		return fmt.Errorf("add static: %w", err)
+	}
+
+	// Add public directory into the standalone web dir.
+	publicDir := filepath.Join(appsDir, "web", "public")
+	publicDst := filepath.Join("app", "apps", "web", ".next", "standalone", "web", "public")
+	if err := addDirToTar(tw, publicDir, publicDst); err != nil {
+		return fmt.Errorf("add public: %w", err)
+	}
+
+	return nil
+}
+
+func addFileToTar(tw *tar.Writer, src, dst string, mode fs.FileMode) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", src, err)
+	}
+	hdr := &tar.Header{
+		Name: dst,
+		Mode: int64(mode),
+		Size: int64(len(data)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err = tw.Write(data)
+	return err
+}
+
+func addDirToTar(tw *tar.Writer, srcDir, dstPrefix string) error {
+	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		dst := filepath.Join(dstPrefix, rel)
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		// Handle symlinks by following them.
+		if info.Mode()&fs.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			hdr := &tar.Header{
+				Typeflag: tar.TypeSymlink,
+				Name:     dst,
+				Linkname: target,
+			}
+			return tw.WriteHeader(hdr)
+		}
+
+		if d.IsDir() {
+			return tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeDir,
+				Name:     dst + "/",
+				Mode:     0o755,
+			})
+		}
+
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = dst
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		_, err = io.Copy(tw, f)
+		return err
+	})
+}

--- a/apps/backend/cmd/preview/cleanup.go
+++ b/apps/backend/cmd/preview/cleanup.go
@@ -40,7 +40,7 @@ func runCleanup(ctx context.Context, args []string) int {
 	spriteName := fmt.Sprintf("kandev-pr-%d", *pr)
 
 	client := newSpriteClient(spritesToken)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	fmt.Printf("destroying sprite %s...\n", spriteName)
 	createdAt, err := destroySprite(ctx, client, spriteName)

--- a/apps/backend/cmd/preview/cleanup.go
+++ b/apps/backend/cmd/preview/cleanup.go
@@ -42,11 +42,11 @@ func runCleanup(ctx context.Context, args []string) int {
 	client := newSpriteClient(spritesToken)
 	defer func() { _ = client.Close() }()
 
-	fmt.Printf("destroying sprite %s...\n", spriteName)
-	createdAt, err := destroySprite(ctx, client, spriteName)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "preview cleanup: destroy sprite: %v\n", err)
-		// Don't fail — sprite may already be gone; still try to update comment.
+	fmt.Fprintf(os.Stderr, "destroying sprite %s...\n", spriteName)
+	createdAt, destroyErr := destroySprite(ctx, client, spriteName)
+	if destroyErr != nil {
+		fmt.Fprintf(os.Stderr, "preview cleanup: destroy sprite: %v\n", destroyErr)
+		// Continue to update the PR comment even if destroy failed.
 	}
 
 	runtime := computeRuntime(createdAt)
@@ -56,6 +56,9 @@ func runCleanup(ctx context.Context, args []string) int {
 		return 1
 	}
 
+	if destroyErr != nil {
+		return 1
+	}
 	return 0
 }
 

--- a/apps/backend/cmd/preview/cleanup.go
+++ b/apps/backend/cmd/preview/cleanup.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 )
 
 func runCleanup(ctx context.Context, args []string) int {
@@ -43,16 +42,14 @@ func runCleanup(ctx context.Context, args []string) int {
 	defer func() { _ = client.Close() }()
 
 	fmt.Fprintf(os.Stderr, "destroying sprite %s...\n", spriteName)
-	createdAt, destroyErr := destroySprite(ctx, client, spriteName)
+	_, destroyErr := destroySprite(ctx, client, spriteName)
 	if destroyErr != nil {
 		fmt.Fprintf(os.Stderr, "preview cleanup: destroy sprite: %v\n", destroyErr)
-		// Continue to update the PR comment even if destroy failed.
+		// Continue to update the PR description even if destroy failed.
 	}
 
-	runtime := computeRuntime(createdAt)
-	body := buildCleanupComment(runtime)
-	if err := upsertComment(ctx, ghToken, *repo, *pr, body); err != nil {
-		fmt.Fprintf(os.Stderr, "preview cleanup: update comment: %v\n", err)
+	if err := removeDescriptionSection(ctx, ghToken, *repo, *pr); err != nil {
+		fmt.Fprintf(os.Stderr, "preview cleanup: remove PR description section: %v\n", err)
 		return 1
 	}
 
@@ -60,11 +57,4 @@ func runCleanup(ctx context.Context, args []string) int {
 		return 1
 	}
 	return 0
-}
-
-func computeRuntime(createdAt time.Time) time.Duration {
-	if createdAt.IsZero() {
-		return 0
-	}
-	return time.Since(createdAt).Round(time.Minute)
 }

--- a/apps/backend/cmd/preview/cleanup.go
+++ b/apps/backend/cmd/preview/cleanup.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+func runCleanup(ctx context.Context, args []string) int {
+	fs := flag.NewFlagSet("cleanup", flag.ContinueOnError)
+	pr := fs.Int("pr", 0, "PR number (required)")
+	repo := fs.String("repo", envOr("GITHUB_REPOSITORY", ""), "owner/repo")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "preview cleanup: %v\n", err)
+		return 2
+	}
+	if *pr == 0 {
+		fmt.Fprintln(os.Stderr, "preview cleanup: --pr is required")
+		return 2
+	}
+	if *repo == "" {
+		fmt.Fprintln(os.Stderr, "preview cleanup: --repo or GITHUB_REPOSITORY is required")
+		return 2
+	}
+
+	spritesToken := os.Getenv("SPRITES_API_TOKEN")
+	if spritesToken == "" {
+		fmt.Fprintln(os.Stderr, "preview cleanup: SPRITES_API_TOKEN is required")
+		return 2
+	}
+	ghToken := os.Getenv("GH_TOKEN")
+	if ghToken == "" {
+		fmt.Fprintln(os.Stderr, "preview cleanup: GH_TOKEN is required")
+		return 2
+	}
+
+	spriteName := fmt.Sprintf("kandev-pr-%d", *pr)
+
+	client := newSpriteClient(spritesToken)
+	defer client.Close()
+
+	fmt.Printf("destroying sprite %s...\n", spriteName)
+	createdAt, err := destroySprite(ctx, client, spriteName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "preview cleanup: destroy sprite: %v\n", err)
+		// Don't fail — sprite may already be gone; still try to update comment.
+	}
+
+	runtime := computeRuntime(createdAt)
+	body := buildCleanupComment(runtime)
+	if err := upsertComment(ctx, ghToken, *repo, *pr, body); err != nil {
+		fmt.Fprintf(os.Stderr, "preview cleanup: update comment: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func computeRuntime(createdAt time.Time) time.Duration {
+	if createdAt.IsZero() {
+		return 0
+	}
+	return time.Since(createdAt).Round(time.Minute)
+}

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -63,9 +63,9 @@ func runDeploy(ctx context.Context, args []string) int {
 
 	fmt.Printf("preview URL: %s\n", previewURL)
 
-	body := buildDeployComment(previewURL, *sha)
-	if err := upsertComment(ctx, ghToken, *repo, *pr, body); err != nil {
-		fmt.Fprintf(os.Stderr, "preview deploy: post comment: %v\n", err)
+	section := buildDeploySection(previewURL, *sha)
+	if err := upsertDescriptionSection(ctx, ghToken, *repo, *pr, section); err != nil {
+		fmt.Fprintf(os.Stderr, "preview deploy: update PR description: %v\n", err)
 		return 1
 	}
 

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const defaultPort = 38429
+
+func runDeploy(ctx context.Context, args []string) int {
+	fs := flag.NewFlagSet("deploy", flag.ContinueOnError)
+	pr := fs.Int("pr", 0, "PR number (required)")
+	sha := fs.String("sha", "", "commit SHA to display in the comment")
+	repo := fs.String("repo", envOr("GITHUB_REPOSITORY", ""), "owner/repo")
+	port := fs.Int("port", defaultPort, "kandev backend port exposed by the sprite")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "preview deploy: %v\n", err)
+		return 2
+	}
+	if *pr == 0 {
+		fmt.Fprintln(os.Stderr, "preview deploy: --pr is required")
+		return 2
+	}
+	if *repo == "" {
+		fmt.Fprintln(os.Stderr, "preview deploy: --repo or GITHUB_REPOSITORY is required")
+		return 2
+	}
+
+	spritesToken := os.Getenv("SPRITES_API_TOKEN")
+	if spritesToken == "" {
+		fmt.Fprintln(os.Stderr, "preview deploy: SPRITES_API_TOKEN is required")
+		return 2
+	}
+	ghToken := os.Getenv("GH_TOKEN")
+	if ghToken == "" {
+		fmt.Fprintln(os.Stderr, "preview deploy: GH_TOKEN is required")
+		return 2
+	}
+
+	spriteName := fmt.Sprintf("kandev-pr-%d", *pr)
+
+	tmpDir, err := os.MkdirTemp("", "kandev-preview-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "preview deploy: mktemp: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(tmpDir)
+
+	binDir := filepath.Join(tmpDir, "bin")
+	tarPath := filepath.Join(tmpDir, "kandev-preview.tar.gz")
+
+	if err := deployArtifacts(ctx, binDir, tarPath, spritesToken, spriteName, *port); err != nil {
+		fmt.Fprintf(os.Stderr, "preview deploy: %v\n", err)
+		return 1
+	}
+
+	previewURL, err := enablePublicURL(ctx, spritesToken, spriteName, *port)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "preview deploy: enable public URL: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("preview URL: %s\n", previewURL)
+
+	body := buildDeployComment(previewURL, *sha)
+	if err := upsertComment(ctx, ghToken, *repo, *pr, body); err != nil {
+		fmt.Fprintf(os.Stderr, "preview deploy: post comment: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteName string, port int) error {
+	fmt.Println("building linux/amd64 binaries...")
+	if err := buildLinuxBinaries(ctx, binDir); err != nil {
+		return fmt.Errorf("build binaries: %w", err)
+	}
+
+	fmt.Println("building web frontend...")
+	if err := buildWeb(ctx); err != nil {
+		return fmt.Errorf("build web: %w", err)
+	}
+
+	fmt.Println("packaging bundle...")
+	if err := packageBundle(binDir, tarPath); err != nil {
+		return fmt.Errorf("package bundle: %w", err)
+	}
+
+	client := newSpriteClient(spritesToken)
+	defer client.Close()
+
+	fmt.Printf("getting or creating sprite %s...\n", spriteName)
+	sprite, err := getOrCreateSprite(ctx, client, spriteName)
+	if err != nil {
+		return fmt.Errorf("get/create sprite: %w", err)
+	}
+
+	fmt.Println("uploading bundle...")
+	if err := uploadBundle(ctx, sprite, tarPath); err != nil {
+		return fmt.Errorf("upload bundle: %w", err)
+	}
+
+	fmt.Println("extracting and configuring...")
+	if err := extractBundle(ctx, sprite); err != nil {
+		return fmt.Errorf("extract bundle: %w", err)
+	}
+
+	fmt.Println("deploying kandev service...")
+	if err := deployService(ctx, sprite, port); err != nil {
+		return fmt.Errorf("deploy service: %w", err)
+	}
+
+	return nil
+}

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/kandev/kandev/internal/common/ports"
+	sprites "github.com/superfly/sprites-go"
 )
 
 func runDeploy(ctx context.Context, args []string) int {
@@ -16,6 +17,7 @@ func runDeploy(ctx context.Context, args []string) int {
 	sha := fs.String("sha", "", "commit SHA to display in the comment")
 	repo := fs.String("repo", envOr("GITHUB_REPOSITORY", ""), "owner/repo")
 	port := fs.Int("port", ports.Backend, "kandev backend port exposed by the sprite")
+	skipWebInstall := fs.Bool("skip-web-install", false, "skip pnpm install (CI already ran it)")
 
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(os.Stderr, "preview deploy: %v\n", err)
@@ -53,14 +55,9 @@ func runDeploy(ctx context.Context, args []string) int {
 	binDir := filepath.Join(tmpDir, "bin")
 	tarPath := filepath.Join(tmpDir, "kandev-preview.tar.gz")
 
-	if err := deployArtifacts(ctx, binDir, tarPath, spritesToken, spriteName, *port); err != nil {
-		fmt.Fprintf(os.Stderr, "preview deploy: %v\n", err)
-		return 1
-	}
-
-	previewURL, err := enablePublicURL(ctx, spritesToken, spriteName, *port)
+	previewURL, err := deployArtifacts(ctx, binDir, tarPath, spritesToken, spriteName, *port, *skipWebInstall)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "preview deploy: enable public URL: %v\n", err)
+		fmt.Fprintf(os.Stderr, "preview deploy: %v\n", err)
 		return 1
 	}
 
@@ -75,45 +72,70 @@ func runDeploy(ctx context.Context, args []string) int {
 	return 0
 }
 
-func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteName string, port int) error {
-	fmt.Println("building linux/amd64 binaries...")
+// deployArtifacts builds the bundle, deploys it to the sprite, and returns the public URL.
+// Using a single client for the full flow avoids redundant auth round-trips.
+func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteName string, port int, skipWebInstall bool) (string, error) {
+	fmt.Fprintln(os.Stderr, "building linux/amd64 binaries...")
 	if err := buildLinuxBinaries(ctx, binDir); err != nil {
-		return fmt.Errorf("build binaries: %w", err)
+		return "", fmt.Errorf("build binaries: %w", err)
 	}
 
-	fmt.Println("building web frontend...")
-	if err := buildWeb(ctx); err != nil {
-		return fmt.Errorf("build web: %w", err)
+	fmt.Fprintln(os.Stderr, "building web frontend...")
+	if err := buildWeb(ctx, skipWebInstall); err != nil {
+		return "", fmt.Errorf("build web: %w", err)
 	}
 
-	fmt.Println("packaging bundle...")
+	fmt.Fprintln(os.Stderr, "packaging bundle...")
 	if err := packageBundle(binDir, tarPath); err != nil {
-		return fmt.Errorf("package bundle: %w", err)
+		return "", fmt.Errorf("package bundle: %w", err)
 	}
 
 	client := newSpriteClient(spritesToken)
 	defer func() { _ = client.Close() }()
 
-	fmt.Printf("getting or creating sprite %s...\n", spriteName)
+	fmt.Fprintf(os.Stderr, "getting or creating sprite %s...\n", spriteName)
 	sprite, err := getOrCreateSprite(ctx, client, spriteName)
 	if err != nil {
-		return fmt.Errorf("get/create sprite: %w", err)
+		return "", fmt.Errorf("get/create sprite: %w", err)
 	}
 
-	fmt.Println("uploading bundle...")
+	fmt.Fprintln(os.Stderr, "uploading bundle...")
 	if err := uploadBundle(ctx, sprite, tarPath); err != nil {
-		return fmt.Errorf("upload bundle: %w", err)
+		return "", fmt.Errorf("upload bundle: %w", err)
 	}
 
-	fmt.Println("extracting and configuring...")
+	fmt.Fprintln(os.Stderr, "extracting and configuring...")
 	if err := extractBundle(ctx, sprite); err != nil {
-		return fmt.Errorf("extract bundle: %w", err)
+		return "", fmt.Errorf("extract bundle: %w", err)
 	}
 
-	fmt.Println("deploying kandev service...")
+	fmt.Fprintln(os.Stderr, "deploying kandev service...")
 	if err := deployService(ctx, sprite, port); err != nil {
-		return fmt.Errorf("deploy service: %w", err)
+		return "", fmt.Errorf("deploy service: %w", err)
 	}
 
-	return nil
+	return enablePublicURL(ctx, client, spriteName)
+}
+
+// enablePublicURL sets the sprite's URL to public mode and returns the URL.
+// Accepts the already-open client from deployArtifacts to avoid a second auth handshake.
+func enablePublicURL(ctx context.Context, client *sprites.Client, spriteName string) (string, error) {
+	updateCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer cancel()
+
+	if err := client.UpdateURLSettings(updateCtx, spriteName, &sprites.URLSettings{Auth: "public"}); err != nil {
+		return "", fmt.Errorf("update URL settings: %w", err)
+	}
+
+	getCtx, getCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer getCancel()
+
+	sprite, err := client.GetSprite(getCtx, spriteName)
+	if err != nil {
+		return "", fmt.Errorf("get sprite URL: %w", err)
+	}
+	if sprite.URL == "" {
+		return "", fmt.Errorf("sprite %s has no URL assigned yet", spriteName)
+	}
+	return sprite.URL, nil
 }

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -105,7 +105,7 @@ func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteN
 	}
 
 	fmt.Fprintln(os.Stderr, "extracting and configuring...")
-	if err := extractBundle(ctx, sprite); err != nil {
+	if err := extractBundle(ctx, sprite, port); err != nil {
 		return "", fmt.Errorf("extract bundle: %w", err)
 	}
 
@@ -126,7 +126,7 @@ func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteN
 	// service transitions (the external URL may return 502 while the new
 	// service process is starting up).
 	fmt.Fprintln(os.Stderr, "waiting for kandev to be healthy...")
-	if err := waitForKandev(ctx, sprite); err != nil {
+	if err := waitForKandev(ctx, sprite, port); err != nil {
 		return "", fmt.Errorf("health check: %w", err)
 	}
 

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -114,6 +114,11 @@ func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteN
 		return "", fmt.Errorf("deploy service: %w", err)
 	}
 
+	fmt.Fprintln(os.Stderr, "waiting for kandev to be healthy...")
+	if err := waitForKandev(ctx, sprite); err != nil {
+		return "", fmt.Errorf("health check: %w", err)
+	}
+
 	return enablePublicURL(ctx, client, spriteName)
 }
 

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -48,7 +48,7 @@ func runDeploy(ctx context.Context, args []string) int {
 		fmt.Fprintf(os.Stderr, "preview deploy: mktemp: %v\n", err)
 		return 1
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	binDir := filepath.Join(tmpDir, "bin")
 	tarPath := filepath.Join(tmpDir, "kandev-preview.tar.gz")
@@ -92,7 +92,7 @@ func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteN
 	}
 
 	client := newSpriteClient(spritesToken)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	fmt.Printf("getting or creating sprite %s...\n", spriteName)
 	sprite, err := getOrCreateSprite(ctx, client, spriteName)

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -114,12 +114,19 @@ func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteN
 		return "", fmt.Errorf("deploy service: %w", err)
 	}
 
-	fmt.Fprintln(os.Stderr, "waiting for kandev to be healthy...")
-	if err := waitForKandev(ctx, sprite); err != nil {
+	// Enable the public URL before the health check so that hitting the URL
+	// also triggers any lazy service startup on Sprites' side.
+	previewURL, err := enablePublicURL(ctx, client, spriteName)
+	if err != nil {
+		return "", fmt.Errorf("enable public URL: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "waiting for kandev to be healthy at %s...\n", previewURL)
+	if err := waitForKandev(ctx, sprite, previewURL); err != nil {
 		return "", fmt.Errorf("health check: %w", err)
 	}
 
-	return enablePublicURL(ctx, client, spriteName)
+	return previewURL, nil
 }
 
 // enablePublicURL sets the sprite's URL to public mode and returns the URL.

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -6,16 +6,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-)
 
-const defaultPort = 38429
+	"github.com/kandev/kandev/internal/common/ports"
+)
 
 func runDeploy(ctx context.Context, args []string) int {
 	fs := flag.NewFlagSet("deploy", flag.ContinueOnError)
 	pr := fs.Int("pr", 0, "PR number (required)")
 	sha := fs.String("sha", "", "commit SHA to display in the comment")
 	repo := fs.String("repo", envOr("GITHUB_REPOSITORY", ""), "owner/repo")
-	port := fs.Int("port", defaultPort, "kandev backend port exposed by the sprite")
+	port := fs.Int("port", ports.Backend, "kandev backend port exposed by the sprite")
 
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(os.Stderr, "preview deploy: %v\n", err)

--- a/apps/backend/cmd/preview/deploy.go
+++ b/apps/backend/cmd/preview/deploy.go
@@ -109,20 +109,24 @@ func deployArtifacts(ctx context.Context, binDir, tarPath, spritesToken, spriteN
 		return "", fmt.Errorf("extract bundle: %w", err)
 	}
 
-	fmt.Fprintln(os.Stderr, "deploying kandev service...")
-	if err := deployService(ctx, sprite, port); err != nil {
-		return "", fmt.Errorf("deploy service: %w", err)
-	}
-
-	// Enable the public URL before the health check so that hitting the URL
-	// also triggers any lazy service startup on Sprites' side.
+	// Enable the public URL before deploying the service. This sets the auth
+	// mode on the sprite (not the service), so it is safe to call before the
+	// service exists. Doing it first avoids a service restart mid-health-check.
 	previewURL, err := enablePublicURL(ctx, client, spriteName)
 	if err != nil {
 		return "", fmt.Errorf("enable public URL: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "waiting for kandev to be healthy at %s...\n", previewURL)
-	if err := waitForKandev(ctx, sprite, previewURL); err != nil {
+	fmt.Fprintln(os.Stderr, "deploying kandev service...")
+	if err := deployService(ctx, sprite, port); err != nil {
+		return "", fmt.Errorf("deploy service: %w", err)
+	}
+
+	// Health check via internal localhost to avoid Sprites routing lag during
+	// service transitions (the external URL may return 502 while the new
+	// service process is starting up).
+	fmt.Fprintln(os.Stderr, "waiting for kandev to be healthy...")
+	if err := waitForKandev(ctx, sprite); err != nil {
 		return "", fmt.Errorf("health check: %w", err)
 	}
 

--- a/apps/backend/cmd/preview/github.go
+++ b/apps/backend/cmd/preview/github.go
@@ -31,39 +31,43 @@ func upsertComment(ctx context.Context, token, repo string, pr int, body string)
 }
 
 func findPreviewComment(ctx context.Context, token, repo string, pr int) (int64, error) {
-	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments?per_page=100", githubAPIBase, repo, pr)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return 0, err
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("%s/repos/%s/issues/%d/comments?per_page=100&page=%d", githubAPIBase, repo, pr, page)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return 0, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { _ = resp.Body.Close() }()
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return 0, fmt.Errorf("list comments status %d: %s", resp.StatusCode, body)
-	}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			return 0, fmt.Errorf("list comments status %d: %s", resp.StatusCode, body)
+		}
 
-	var comments []struct {
-		ID   int64  `json:"id"`
-		Body string `json:"body"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
-		return 0, err
-	}
+		var comments []struct {
+			ID   int64  `json:"id"`
+			Body string `json:"body"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
+			return 0, err
+		}
 
-	for _, c := range comments {
-		if containsMarker(c.Body) {
-			return c.ID, nil
+		for _, c := range comments {
+			if containsMarker(c.Body) {
+				return c.ID, nil
+			}
+		}
+		if len(comments) < 100 {
+			return 0, nil // last page — marker not found
 		}
 	}
-	return 0, nil
 }
 
 func containsMarker(body string) bool {
@@ -127,8 +131,13 @@ func buildDeployComment(previewURL, sha string) string {
 
 // buildCleanupComment returns the markdown body for a post-close summary comment.
 func buildCleanupComment(runtime time.Duration) string {
-	runtimeStr := "unknown"
-	if runtime > 0 {
+	var runtimeStr string
+	switch {
+	case runtime <= 0:
+		runtimeStr = "unknown"
+	case runtime < time.Minute:
+		runtimeStr = "< 1 minute"
+	default:
 		runtimeStr = fmt.Sprintf("~%d minutes", int(runtime.Minutes()))
 	}
 	return fmt.Sprintf(`%s

--- a/apps/backend/cmd/preview/github.go
+++ b/apps/backend/cmd/preview/github.go
@@ -168,4 +168,3 @@ func buildDeploySection(previewURL, sha string) string {
 > Updates automatically on each push. Destroyed when the PR is closed.`,
 		previewURL, shaDisplay)
 }
-

--- a/apps/backend/cmd/preview/github.go
+++ b/apps/backend/cmd/preview/github.go
@@ -43,7 +43,7 @@ func findPreviewComment(ctx context.Context, token, repo string, pr int) (int64,
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -97,7 +97,7 @@ func postJSON(ctx context.Context, token, method, url string, payload any) error
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)

--- a/apps/backend/cmd/preview/github.go
+++ b/apps/backend/cmd/preview/github.go
@@ -83,11 +83,17 @@ func replaceSection(body, marked string) string {
 
 // stripSection removes the entire kandev section block (markers + content)
 // including any leading blank line that we added before the section.
+// Mirrors replaceSection's orphan handling: if sectionEnd is missing, the
+// orphaned start marker (and everything after it) is stripped.
 func stripSection(body string) string {
 	start := strings.Index(body, sectionStart)
-	end := strings.Index(body, sectionEnd)
-	if start == -1 || end == -1 {
+	if start == -1 {
 		return body
+	}
+	end := strings.Index(body, sectionEnd)
+	if end == -1 || end < start {
+		// Orphaned start marker — strip from marker to end of string.
+		return strings.TrimRight(body[:start], "\n")
 	}
 	end += len(sectionEnd)
 

--- a/apps/backend/cmd/preview/github.go
+++ b/apps/backend/cmd/preview/github.go
@@ -60,11 +60,22 @@ func replaceOrAppendSection(body, section string) string {
 }
 
 // replaceSection replaces everything between our markers (inclusive) with marked.
+// If sectionEnd is missing (orphaned start marker), the orphan is stripped
+// and marked is appended to avoid duplicating sectionStart.
 func replaceSection(body, marked string) string {
 	start := strings.Index(body, sectionStart)
 	end := strings.Index(body, sectionEnd)
-	if start == -1 || end == -1 || end < start {
+	if start == -1 {
 		return body + "\n\n" + marked
+	}
+	if end == -1 || end < start {
+		// Orphaned start marker — strip from the start marker to end of string,
+		// then append the new section.
+		prefix := strings.TrimRight(body[:start], "\n")
+		if prefix == "" {
+			return marked
+		}
+		return prefix + "\n\n" + marked
 	}
 	end += len(sectionEnd)
 	return body[:start] + marked + body[end:]

--- a/apps/backend/cmd/preview/github.go
+++ b/apps/backend/cmd/preview/github.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	commentMarker = "<!-- kandev-preview -->"
+	githubAPIBase = "https://api.github.com"
+)
+
+// upsertComment finds an existing preview comment on the PR and updates it,
+// or creates a new one if none exists.
+func upsertComment(ctx context.Context, token, repo string, pr int, body string) error {
+	existing, err := findPreviewComment(ctx, token, repo, pr)
+	if err != nil {
+		return fmt.Errorf("find comment: %w", err)
+	}
+
+	if existing != 0 {
+		return updateComment(ctx, token, repo, existing, body)
+	}
+	return createComment(ctx, token, repo, pr, body)
+}
+
+func findPreviewComment(ctx context.Context, token, repo string, pr int) (int64, error) {
+	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments?per_page=100", githubAPIBase, repo, pr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("list comments status %d: %s", resp.StatusCode, body)
+	}
+
+	var comments []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
+		return 0, err
+	}
+
+	for _, c := range comments {
+		if containsMarker(c.Body) {
+			return c.ID, nil
+		}
+	}
+	return 0, nil
+}
+
+func containsMarker(body string) bool {
+	return strings.Contains(body, commentMarker)
+}
+
+func createComment(ctx context.Context, token, repo string, pr int, body string) error {
+	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", githubAPIBase, repo, pr)
+	return postJSON(ctx, token, http.MethodPost, url, map[string]string{"body": body})
+}
+
+func updateComment(ctx context.Context, token, repo string, commentID int64, body string) error {
+	url := fmt.Sprintf("%s/repos/%s/issues/comments/%d", githubAPIBase, repo, commentID)
+	return postJSON(ctx, token, http.MethodPatch, url, map[string]string{"body": body})
+}
+
+func postJSON(ctx context.Context, token, method, url string, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s %s: status %d: %s", method, url, resp.StatusCode, body)
+	}
+	return nil
+}
+
+// buildDeployComment returns the markdown body for a deploy comment.
+func buildDeployComment(previewURL, sha string) string {
+	shaDisplay := sha
+	if len(sha) > 7 {
+		shaDisplay = sha[:7]
+	}
+	return fmt.Sprintf(`%s
+### Preview Environment
+
+| | |
+|---|---|
+| **URL** | %s |
+| **Commit** | `+"`%s`"+` |
+| **Agent** | Mock agent |
+
+> Environment updates automatically on each new commit. Destroyed when the PR is closed.`,
+		commentMarker, previewURL, shaDisplay)
+}
+
+// buildCleanupComment returns the markdown body for a post-close summary comment.
+func buildCleanupComment(runtime time.Duration) string {
+	runtimeStr := "unknown"
+	if runtime > 0 {
+		runtimeStr = fmt.Sprintf("~%d minutes", int(runtime.Minutes()))
+	}
+	return fmt.Sprintf(`%s
+### Preview Environment — Closed
+
+The preview environment for this PR has been destroyed.
+
+| | |
+|---|---|
+| **Runtime** | %s |`,
+		commentMarker, runtimeStr)
+}

--- a/apps/backend/cmd/preview/github.go
+++ b/apps/backend/cmd/preview/github.go
@@ -8,79 +8,120 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 )
 
 const (
-	commentMarker = "<!-- kandev-preview -->"
+	sectionStart  = "<!-- kandev-preview-start -->"
+	sectionEnd    = "<!-- kandev-preview-end -->"
 	githubAPIBase = "https://api.github.com"
 )
 
-// upsertComment finds an existing preview comment on the PR and updates it,
-// or creates a new one if none exists.
-func upsertComment(ctx context.Context, token, repo string, pr int, body string) error {
-	existing, err := findPreviewComment(ctx, token, repo, pr)
+// upsertDescriptionSection appends (or updates) the kandev preview section at
+// the end of the PR description. Other bots may also append sections; we only
+// touch the block delimited by our own markers.
+func upsertDescriptionSection(ctx context.Context, token, repo string, pr int, section string) error {
+	body, err := getPRBody(ctx, token, repo, pr)
 	if err != nil {
-		return fmt.Errorf("find comment: %w", err)
+		return fmt.Errorf("get PR body: %w", err)
 	}
 
-	if existing != 0 {
-		return updateComment(ctx, token, repo, existing, body)
+	newBody := replaceOrAppendSection(body, section)
+	return updatePRBody(ctx, token, repo, pr, newBody)
+}
+
+// removeDescriptionSection removes the kandev preview section from the PR
+// description on cleanup. If no section is present this is a no-op.
+func removeDescriptionSection(ctx context.Context, token, repo string, pr int) error {
+	body, err := getPRBody(ctx, token, repo, pr)
+	if err != nil {
+		return fmt.Errorf("get PR body: %w", err)
 	}
-	return createComment(ctx, token, repo, pr, body)
-}
 
-func findPreviewComment(ctx context.Context, token, repo string, pr int) (int64, error) {
-	for page := 1; ; page++ {
-		url := fmt.Sprintf("%s/repos/%s/issues/%d/comments?per_page=100&page=%d", githubAPIBase, repo, pr, page)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return 0, err
-		}
-		req.Header.Set("Authorization", "Bearer "+token)
-		req.Header.Set("Accept", "application/vnd.github+json")
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return 0, err
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			return 0, fmt.Errorf("list comments status %d: %s", resp.StatusCode, body)
-		}
-
-		var comments []struct {
-			ID   int64  `json:"id"`
-			Body string `json:"body"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&comments); err != nil {
-			return 0, err
-		}
-
-		for _, c := range comments {
-			if containsMarker(c.Body) {
-				return c.ID, nil
-			}
-		}
-		if len(comments) < 100 {
-			return 0, nil // last page — marker not found
-		}
+	if !strings.Contains(body, sectionStart) {
+		return nil // nothing to remove
 	}
+
+	newBody := stripSection(body)
+	return updatePRBody(ctx, token, repo, pr, newBody)
 }
 
-func containsMarker(body string) bool {
-	return strings.Contains(body, commentMarker)
+// replaceOrAppendSection replaces an existing kandev section in body with
+// section, or appends it if none exists. Preserves any trailing newline.
+func replaceOrAppendSection(body, section string) string {
+	marked := sectionStart + "\n" + section + "\n" + sectionEnd
+	if strings.Contains(body, sectionStart) {
+		return replaceSection(body, marked)
+	}
+	sep := "\n\n"
+	if body == "" {
+		sep = ""
+	}
+	return body + sep + marked
 }
 
-func createComment(ctx context.Context, token, repo string, pr int, body string) error {
-	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", githubAPIBase, repo, pr)
-	return postJSON(ctx, token, http.MethodPost, url, map[string]string{"body": body})
+// replaceSection replaces everything between our markers (inclusive) with marked.
+func replaceSection(body, marked string) string {
+	start := strings.Index(body, sectionStart)
+	end := strings.Index(body, sectionEnd)
+	if start == -1 || end == -1 || end < start {
+		return body + "\n\n" + marked
+	}
+	end += len(sectionEnd)
+	return body[:start] + marked + body[end:]
 }
 
-func updateComment(ctx context.Context, token, repo string, commentID int64, body string) error {
-	url := fmt.Sprintf("%s/repos/%s/issues/comments/%d", githubAPIBase, repo, commentID)
+// stripSection removes the entire kandev section block (markers + content)
+// including any leading blank line that we added before the section.
+func stripSection(body string) string {
+	start := strings.Index(body, sectionStart)
+	end := strings.Index(body, sectionEnd)
+	if start == -1 || end == -1 {
+		return body
+	}
+	end += len(sectionEnd)
+
+	// Strip the blank line separator we added before the section.
+	prefix := body[:start]
+	prefix = strings.TrimRight(prefix, "\n")
+
+	suffix := body[end:]
+	if prefix == "" {
+		return strings.TrimLeft(suffix, "\n")
+	}
+	return prefix + suffix
+}
+
+func getPRBody(ctx context.Context, token, repo string, pr int) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/pulls/%d", githubAPIBase, repo, pr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("get PR status %d: %s", resp.StatusCode, b)
+	}
+
+	var result struct {
+		Body string `json:"body"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return result.Body, nil
+}
+
+func updatePRBody(ctx context.Context, token, repo string, pr int, body string) error {
+	url := fmt.Sprintf("%s/repos/%s/pulls/%d", githubAPIBase, repo, pr)
 	return postJSON(ctx, token, http.MethodPatch, url, map[string]string{"body": body})
 }
 
@@ -104,20 +145,19 @@ func postJSON(ctx context.Context, token, method, url string, payload any) error
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("%s %s: status %d: %s", method, url, resp.StatusCode, body)
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s %s: status %d: %s", method, url, resp.StatusCode, b)
 	}
 	return nil
 }
 
-// buildDeployComment returns the markdown body for a deploy comment.
-func buildDeployComment(previewURL, sha string) string {
+// buildDeploySection returns the markdown section body for a deploy update.
+func buildDeploySection(previewURL, sha string) string {
 	shaDisplay := sha
 	if len(sha) > 7 {
 		shaDisplay = sha[:7]
 	}
-	return fmt.Sprintf(`%s
-### Preview Environment
+	return fmt.Sprintf(`### Preview Environment
 
 | | |
 |---|---|
@@ -125,28 +165,7 @@ func buildDeployComment(previewURL, sha string) string {
 | **Commit** | `+"`%s`"+` |
 | **Agent** | Mock agent |
 
-> Environment updates automatically on each new commit. Destroyed when the PR is closed.`,
-		commentMarker, previewURL, shaDisplay)
+> Updates automatically on each push. Destroyed when the PR is closed.`,
+		previewURL, shaDisplay)
 }
 
-// buildCleanupComment returns the markdown body for a post-close summary comment.
-func buildCleanupComment(runtime time.Duration) string {
-	var runtimeStr string
-	switch {
-	case runtime <= 0:
-		runtimeStr = "unknown"
-	case runtime < time.Minute:
-		runtimeStr = "< 1 minute"
-	default:
-		runtimeStr = fmt.Sprintf("~%d minutes", int(runtime.Minutes()))
-	}
-	return fmt.Sprintf(`%s
-### Preview Environment — Closed
-
-The preview environment for this PR has been destroyed.
-
-| | |
-|---|---|
-| **Runtime** | %s |`,
-		commentMarker, runtimeStr)
-}

--- a/apps/backend/cmd/preview/github_test.go
+++ b/apps/backend/cmd/preview/github_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReplaceOrAppendSection_append(t *testing.T) {
+	body := "Existing PR description."
+	section := "### Preview\nURL: https://example.com"
+	got := replaceOrAppendSection(body, section)
+
+	if !strings.Contains(got, sectionStart) {
+		t.Error("expected sectionStart marker")
+	}
+	if !strings.Contains(got, sectionEnd) {
+		t.Error("expected sectionEnd marker")
+	}
+	if !strings.HasPrefix(got, body) {
+		t.Errorf("expected original body to be preserved at start; got: %q", got)
+	}
+}
+
+func TestReplaceOrAppendSection_replace(t *testing.T) {
+	old := "### Preview\nURL: https://old.example.com"
+	body := "Existing body.\n\n" + sectionStart + "\n" + old + "\n" + sectionEnd
+
+	newSection := "### Preview\nURL: https://new.example.com"
+	got := replaceOrAppendSection(body, newSection)
+
+	if strings.Contains(got, "old.example.com") {
+		t.Error("expected old section to be replaced")
+	}
+	if !strings.Contains(got, "new.example.com") {
+		t.Error("expected new section to be present")
+	}
+	// Only one start marker.
+	if strings.Count(got, sectionStart) != 1 {
+		t.Errorf("expected exactly one start marker, got %d", strings.Count(got, sectionStart))
+	}
+}
+
+func TestReplaceOrAppendSection_emptyBody(t *testing.T) {
+	section := "### Preview"
+	got := replaceOrAppendSection("", section)
+	if !strings.HasPrefix(got, sectionStart) {
+		t.Errorf("expected section at start of empty body; got: %q", got)
+	}
+}
+
+func TestStripSection(t *testing.T) {
+	section := "### Preview\nURL: https://example.com"
+	body := "My PR description.\n\n" + sectionStart + "\n" + section + "\n" + sectionEnd
+	got := stripSection(body)
+
+	if strings.Contains(got, sectionStart) || strings.Contains(got, sectionEnd) {
+		t.Error("expected section markers to be removed")
+	}
+	if !strings.Contains(got, "My PR description.") {
+		t.Error("expected original body to be preserved")
+	}
+	if strings.Contains(got, "https://example.com") {
+		t.Error("expected section content to be removed")
+	}
+}
+
+func TestStripSection_noMarker(t *testing.T) {
+	body := "No preview section here."
+	got := stripSection(body)
+	if got != body {
+		t.Errorf("expected no-op; got %q", got)
+	}
+}
+
+func TestStripSection_otherBotAppended(t *testing.T) {
+	// Simulates another bot having appended its own section after ours.
+	section := "### Preview"
+	otherBot := "<!-- other-bot-start -->\nOther bot content\n<!-- other-bot-end -->"
+	body := "PR body.\n\n" + sectionStart + "\n" + section + "\n" + sectionEnd + "\n\n" + otherBot
+	got := stripSection(body)
+
+	if strings.Contains(got, sectionStart) {
+		t.Error("expected our section to be removed")
+	}
+	if !strings.Contains(got, "other-bot-start") {
+		t.Error("expected other bot section to be preserved")
+	}
+}

--- a/apps/backend/cmd/preview/github_test.go
+++ b/apps/backend/cmd/preview/github_test.go
@@ -86,3 +86,37 @@ func TestStripSection_otherBotAppended(t *testing.T) {
 		t.Error("expected other bot section to be preserved")
 	}
 }
+
+func TestReplaceSection_orphanStart(t *testing.T) {
+	// Orphaned start marker (no end) should not produce a duplicate start marker.
+	body := "PR body.\n\n" + sectionStart + "\ntruncated content with no end"
+	newSection := "### Preview\nURL: https://new.example.com"
+	got := replaceOrAppendSection(body, newSection)
+
+	if strings.Count(got, sectionStart) != 1 {
+		t.Errorf("expected exactly one start marker, got %d: %q", strings.Count(got, sectionStart), got)
+	}
+	if !strings.Contains(got, "new.example.com") {
+		t.Error("expected new section content to be present")
+	}
+	if strings.Contains(got, "truncated content") {
+		t.Error("expected orphaned content to be removed")
+	}
+}
+
+func TestBuildDeploySection(t *testing.T) {
+	tests := []struct {
+		sha     string
+		wantSha string
+	}{
+		{"abc1234", "abc1234"},         // exactly 7: no truncation
+		{"abc1234deadbeef", "abc1234"}, // > 7: truncated to 7
+		{"abc", "abc"},                 // < 7: kept as-is
+	}
+	for _, tc := range tests {
+		got := buildDeploySection("https://example.com", tc.sha)
+		if !strings.Contains(got, "`"+tc.wantSha+"`") {
+			t.Errorf("sha=%q: expected %q in output, got: %s", tc.sha, tc.wantSha, got)
+		}
+	}
+}

--- a/apps/backend/cmd/preview/main.go
+++ b/apps/backend/cmd/preview/main.go
@@ -2,7 +2,7 @@
 //
 // Usage:
 //
-//	preview deploy  --pr N --sha S [--repo owner/repo] [--port ports.Backend]
+//	preview deploy  --pr N --sha S [--repo owner/repo] [--port 38429]
 //	preview cleanup --pr N [--repo owner/repo]
 //
 // Required environment variables:
@@ -50,7 +50,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `preview — deploy and manage PR preview environments on Sprites.dev
 
 Usage:
-  preview deploy  --pr N --sha S [--repo owner/repo] [--port ports.Backend]
+  preview deploy  --pr N --sha S [--repo owner/repo] [--port 38429]
   preview cleanup --pr N [--repo owner/repo]
 
 Environment variables:

--- a/apps/backend/cmd/preview/main.go
+++ b/apps/backend/cmd/preview/main.go
@@ -2,7 +2,7 @@
 //
 // Usage:
 //
-//	preview deploy  --pr N --sha S [--repo owner/repo] [--port 38429]
+//	preview deploy  --pr N --sha S [--repo owner/repo] [--port ports.Backend]
 //	preview cleanup --pr N [--repo owner/repo]
 //
 // Required environment variables:
@@ -50,7 +50,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `preview — deploy and manage PR preview environments on Sprites.dev
 
 Usage:
-  preview deploy  --pr N --sha S [--repo owner/repo] [--port 38429]
+  preview deploy  --pr N --sha S [--repo owner/repo] [--port ports.Backend]
   preview cleanup --pr N [--repo owner/repo]
 
 Environment variables:

--- a/apps/backend/cmd/preview/main.go
+++ b/apps/backend/cmd/preview/main.go
@@ -1,0 +1,72 @@
+// Command preview deploys and manages PR preview environments on Sprites.dev.
+//
+// Usage:
+//
+//	preview deploy  --pr N --sha S [--repo owner/repo] [--port 38429]
+//	preview cleanup --pr N [--repo owner/repo]
+//
+// Required environment variables:
+//
+//	SPRITES_API_TOKEN  Sprites.dev API token
+//	GH_TOKEN           GitHub token for posting PR comments
+//	GITHUB_REPOSITORY  Repository in owner/repo format
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	if len(os.Args) < 2 {
+		usage()
+		return 2
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	switch os.Args[1] {
+	case "deploy":
+		return runDeploy(ctx, os.Args[2:])
+	case "cleanup":
+		return runCleanup(ctx, os.Args[2:])
+	case "-h", "--help", "help":
+		usage()
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "preview: unknown subcommand %q\n\n", os.Args[1])
+		usage()
+		return 2
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `preview — deploy and manage PR preview environments on Sprites.dev
+
+Usage:
+  preview deploy  --pr N --sha S [--repo owner/repo] [--port 38429]
+  preview cleanup --pr N [--repo owner/repo]
+
+Environment variables:
+  SPRITES_API_TOKEN  Sprites.dev API token (required)
+  GH_TOKEN           GitHub token for posting PR comments (required)
+  GITHUB_REPOSITORY  GitHub repository in owner/repo format (required)
+
+Local usage:
+  cd apps/backend
+  SPRITES_API_TOKEN=xxx GH_TOKEN=xxx GITHUB_REPOSITORY=owner/repo \
+    go run ./cmd/preview deploy --pr 123 --sha abc1234`)
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -140,14 +140,21 @@ STARTSCRIPT
 chmod +x /app/start-kandev.sh`, ports.Web, backendPort, ports.Web)
 }
 
-// deployService registers (or updates) the kandev service and explicitly starts
-// it. The two-step approach (CreateService then StartService) ensures the
-// process runs on both first deploy and re-deploy:
-//   - CreateService is idempotent: creates the service config if absent, or
-//     updates it if it already exists.
-//   - StartService explicitly starts (or restarts) the process regardless of
-//     whether it was previously running or stopped.
+// deployService stops any running kandev service, registers (or updates) its
+// config, then explicitly starts it. Three-step stop → create → start ensures
+// the process is restarted on re-deploy and started on first deploy:
+//   - StopService terminates any running instance (no-op if none exists).
+//   - CreateService is idempotent: creates or updates the service config.
+//   - StartService explicitly starts the process regardless of prior state.
 func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error {
+	// Stop any running instance so StartService always spawns a fresh process.
+	// Errors here are best-effort — the service may not exist yet on first deploy.
+	stopCtx, stopCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer stopCancel()
+	if stream, err := sprite.StopService(stopCtx, "kandev"); err == nil {
+		drainStream(stream)
+	}
+
 	createCtx, createCancel := context.WithTimeout(ctx, spriteStepTimeout)
 	defer createCancel()
 
@@ -175,7 +182,7 @@ func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error 
 	}
 	_ = createStream.Close()
 
-	// Explicitly start the service so it runs immediately.
+	// Explicitly start the fresh service.
 	startCtx, startCancel := context.WithTimeout(ctx, spriteStepTimeout)
 	defer startCancel()
 
@@ -186,6 +193,18 @@ func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error 
 	defer func() { _ = startStream.Close() }()
 
 	return waitForServiceStarted(startStream)
+}
+
+// drainStream reads all events from a ServiceStream and closes it.
+// Used for informational streams where we don't need to act on the content.
+func drainStream(stream *sprites.ServiceStream) {
+	defer func() { _ = stream.Close() }()
+	for {
+		_, err := stream.Next()
+		if err != nil {
+			return
+		}
+	}
 }
 
 func waitForServiceStarted(stream *sprites.ServiceStream) error {

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -110,10 +110,14 @@ cat > /app/start-kandev.sh << 'STARTSCRIPT'
 set -e
 mkdir -p /data
 
+echo "node: $(node --version 2>&1 || echo NOT FOUND)" >&2
+echo "kandev binary: $(ls -lh /app/apps/backend/bin/kandev 2>&1)" >&2
+
 # Start Next.js web server in background.
 PORT=%d HOSTNAME=0.0.0.0 NODE_ENV=production \
   nohup node /app/apps/web/.next/standalone/web/server.js \
   > /var/log/kandev-web.log 2>&1 &
+echo "web server started (pid $!)" >&2
 
 # Start Go backend (main process — Sprites HTTPPort proxies here).
 export KANDEV_HOME_DIR=/data
@@ -121,9 +125,10 @@ export KANDEV_DOCKER_ENABLED=false
 export KANDEV_LOG_LEVEL=info
 export KANDEV_SERVER_PORT=%d
 export KANDEV_WEB_INTERNAL_URL=http://localhost:%d
+echo "starting kandev on port %d..." >&2
 exec /app/apps/backend/bin/kandev
 STARTSCRIPT
-chmod +x /app/start-kandev.sh`, ports.Web, ports.Backend, ports.Web)
+chmod +x /app/start-kandev.sh`, ports.Web, ports.Backend, ports.Web, ports.Backend)
 }
 
 // deployService registers (or re-registers) kandev as a Sprites managed service.
@@ -187,6 +192,52 @@ func drainStream(stream *sprites.ServiceStream) error {
 			return err
 		}
 	}
+}
+
+// waitForKandev polls the kandev health endpoint inside the sprite until it
+// responds or the deadline is exceeded. On failure it fetches log output for
+// diagnostics and returns a combined error.
+func waitForKandev(ctx context.Context, sprite *sprites.Sprite) error {
+	const (
+		timeout   = 60 * time.Second
+		retryWait = 3 * time.Second
+	)
+	healthURL := fmt.Sprintf("http://localhost:%d/health", ports.Backend)
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		out, err := sprite.CommandContext(checkCtx, "curl", "-sf", healthURL).Output()
+		cancel()
+
+		if err == nil && len(out) > 0 {
+			fmt.Fprintf(os.Stderr, "  kandev is healthy\n")
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(retryWait):
+		}
+	}
+
+	// Health check timed out — fetch logs to help diagnose.
+	diag := fetchSpriteLogs(ctx, sprite)
+	return fmt.Errorf("kandev did not become healthy within %v\n%s", timeout, diag)
+}
+
+// fetchSpriteLogs reads log files from the sprite for failure diagnostics.
+func fetchSpriteLogs(ctx context.Context, sprite *sprites.Sprite) string {
+	logCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	script := `echo "=== /var/log/kandev-web.log ==="; tail -50 /var/log/kandev-web.log 2>/dev/null || echo "(empty)"; echo "=== journalctl/service (last 50 lines) ==="; journalctl -u kandev --no-pager -n 50 2>/dev/null || true`
+	out, err := sprite.CommandContext(logCtx, "bash", "-c", script).CombinedOutput()
+	if err != nil {
+		return fmt.Sprintf("[log fetch error: %v]\n%s", err, string(out))
+	}
+	return string(out)
 }
 
 // destroySprite destroys the named sprite and returns its creation time for

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	sprites "github.com/superfly/sprites-go"
+)
+
+const (
+	spriteUploadTimeout = 10 * time.Minute // bundles can be large
+	spriteStepTimeout   = 2 * time.Minute
+	spriteUploadRetries = 3
+	spriteBackoffInit   = 700 * time.Millisecond
+	kandevBackendPort   = 38429
+	kandevWebPort       = 37429
+)
+
+func newSpriteClient(token string) *sprites.Client {
+	return sprites.New(token)
+}
+
+// getOrCreateSprite returns an existing sprite or creates a new one.
+// Cold/sleeping sprites wake automatically when commands are issued.
+func getOrCreateSprite(ctx context.Context, client *sprites.Client, name string) (*sprites.Sprite, error) {
+	stepCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer cancel()
+
+	sprite, err := client.GetSprite(stepCtx, name)
+	if err == nil {
+		return sprite, nil
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		return nil, fmt.Errorf("get sprite: %w", err)
+	}
+
+	createCtx, createCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer createCancel()
+
+	sprite, err = client.CreateSprite(createCtx, name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create sprite: %w", err)
+	}
+	return sprite, nil
+}
+
+// uploadBundle uploads the bundle tarball to the sprite via the Filesystem API.
+// Retries up to spriteUploadRetries times on transient errors.
+func uploadBundle(ctx context.Context, sprite *sprites.Sprite, tarPath string) error {
+	data, err := os.ReadFile(tarPath)
+	if err != nil {
+		return fmt.Errorf("read bundle: %w", err)
+	}
+
+	uploadCtx, cancel := context.WithTimeout(ctx, spriteUploadTimeout)
+	defer cancel()
+
+	backoff := spriteBackoffInit
+	var lastErr error
+	for attempt := 1; attempt <= spriteUploadRetries; attempt++ {
+		err := sprite.Filesystem().WriteFileContext(uploadCtx, "/tmp/kandev-preview.tar.gz", data, 0o644)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if attempt == spriteUploadRetries || uploadCtx.Err() != nil {
+			break
+		}
+		fmt.Printf("  upload attempt %d failed (%v), retrying in %v...\n", attempt, err, backoff)
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+	return fmt.Errorf("upload bundle after %d attempts: %w", spriteUploadRetries, lastErr)
+}
+
+// extractBundle extracts the bundle tarball and writes the startup script.
+func extractBundle(ctx context.Context, sprite *sprites.Sprite) error {
+	script := buildExtractScript()
+	stepCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer cancel()
+
+	out, err := sprite.CommandContext(stepCtx, "bash", "-c", script).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("extract bundle: %w\n%s", err, string(out))
+	}
+	return nil
+}
+
+func buildExtractScript() string {
+	return fmt.Sprintf(`set -e
+tar -xzf /tmp/kandev-preview.tar.gz -C /
+chmod +x /app/apps/backend/bin/kandev \
+         /app/apps/backend/bin/agentctl \
+         /app/apps/backend/bin/mock-agent
+ln -sf /app/apps/backend/bin/agentctl    /usr/local/bin/agentctl
+ln -sf /app/apps/backend/bin/mock-agent  /usr/local/bin/mock-agent
+mkdir -p /data /var/log
+cat > /app/start-kandev.sh << 'STARTSCRIPT'
+#!/bin/bash
+set -e
+mkdir -p /data
+
+# Start Next.js web server in background.
+PORT=%d HOSTNAME=0.0.0.0 NODE_ENV=production \
+  nohup node /app/apps/web/.next/standalone/web/server.js \
+  > /var/log/kandev-web.log 2>&1 &
+
+# Start Go backend (main process — Sprites HTTPPort proxies here).
+export KANDEV_HOME_DIR=/data
+export KANDEV_DOCKER_ENABLED=false
+export KANDEV_LOG_LEVEL=info
+export KANDEV_SERVER_PORT=%d
+export KANDEV_WEB_INTERNAL_URL=http://localhost:%d
+exec /app/apps/backend/bin/kandev
+STARTSCRIPT
+chmod +x /app/start-kandev.sh`, kandevWebPort, kandevBackendPort, kandevWebPort)
+}
+
+// deployService registers (or re-registers) kandev as a Sprites managed service.
+// Uses PUT semantics: safe to call multiple times for re-deploys.
+func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error {
+	// Stop the service first if running; ignore errors (may not exist yet).
+	stopCtx, stopCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer stopCancel()
+	if stream, err := sprite.StopService(stopCtx, "kandev"); err == nil {
+		_ = drainStream(stream)
+	}
+
+	svcCtx, svcCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer svcCancel()
+
+	stream, err := sprite.CreateService(svcCtx, "kandev", &sprites.ServiceRequest{
+		Cmd:      "/app/start-kandev.sh",
+		HTTPPort: &port,
+	})
+	if err != nil {
+		return fmt.Errorf("create service: %w", err)
+	}
+	defer stream.Close()
+
+	return waitForServiceStarted(stream)
+}
+
+func waitForServiceStarted(stream *sprites.ServiceStream) error {
+	for {
+		event, err := stream.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("service stream: %w", err)
+		}
+		switch event.Type {
+		case "started":
+			fmt.Println("  kandev service started")
+			return nil
+		case "error":
+			return fmt.Errorf("service error: %s", event.Data)
+		case "exit":
+			if event.ExitCode != nil && *event.ExitCode != 0 {
+				return fmt.Errorf("service exited with code %d", *event.ExitCode)
+			}
+		case "stdout", "stderr":
+			if event.Data != "" {
+				fmt.Printf("  [kandev] %s\n", strings.TrimRight(event.Data, "\n"))
+			}
+		}
+	}
+}
+
+func drainStream(stream *sprites.ServiceStream) error {
+	for {
+		_, err := stream.Next()
+		if errors.Is(err, io.EOF) || err != nil {
+			return err
+		}
+	}
+}
+
+// enablePublicURL sets the sprite's URL to public mode and returns the URL.
+func enablePublicURL(ctx context.Context, token, spriteName string, _ int) (string, error) {
+	client := newSpriteClient(token)
+	defer client.Close()
+
+	updateCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer cancel()
+
+	if err := client.UpdateURLSettings(updateCtx, spriteName, &sprites.URLSettings{Auth: "public"}); err != nil {
+		return "", fmt.Errorf("update URL settings: %w", err)
+	}
+
+	getCtx, getCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer getCancel()
+
+	sprite, err := client.GetSprite(getCtx, spriteName)
+	if err != nil {
+		return "", fmt.Errorf("get sprite URL: %w", err)
+	}
+	if sprite.URL == "" {
+		return "", fmt.Errorf("sprite %s has no URL assigned yet", spriteName)
+	}
+	return sprite.URL, nil
+}
+
+// destroySprite destroys the named sprite and returns its creation time for
+// runtime calculation. Returns zero time if the sprite was not found.
+func destroySprite(ctx context.Context, client *sprites.Client, name string) (time.Time, error) {
+	getCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer cancel()
+
+	sprite, err := client.GetSprite(getCtx, name)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			fmt.Printf("sprite %s not found, skipping destroy\n", name)
+			return time.Time{}, nil
+		}
+		return time.Time{}, fmt.Errorf("get sprite: %w", err)
+	}
+	createdAt := sprite.CreatedAt
+
+	destroyCtx, destroyCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer destroyCancel()
+
+	if err := sprite.Delete(destroyCtx); err != nil {
+		return createdAt, fmt.Errorf("delete sprite: %w", err)
+	}
+	fmt.Printf("sprite %s destroyed\n", name)
+	return createdAt, nil
+}

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -120,6 +120,9 @@ mkdir -p /data
 
 # Kill any agentctl orphans from previous runs.
 pkill -f agentctl || true
+# Kill any stale web (node) process — nohup'd node survives StopService since
+# it detaches from the process group, and would hold the web port on redeploy.
+pkill -f '/app/apps/web/.next/standalone/web/server.js' || true
 sleep 1
 
 # Start Next.js web server in background.

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -91,8 +91,11 @@ func extractBundle(ctx context.Context, sprite *sprites.Sprite) error {
 	defer cancel()
 
 	out, err := sprite.CommandContext(stepCtx, "bash", "-c", script).CombinedOutput()
+	if len(out) > 0 {
+		fmt.Fprintf(os.Stderr, "%s\n", string(out))
+	}
 	if err != nil {
-		return fmt.Errorf("extract bundle: %w\n%s", err, string(out))
+		return fmt.Errorf("extract bundle: %w", err)
 	}
 	return nil
 }

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -105,6 +106,11 @@ chmod +x /app/apps/backend/bin/kandev \
 ln -sf /app/apps/backend/bin/agentctl    /usr/local/bin/agentctl
 ln -sf /app/apps/backend/bin/mock-agent  /usr/local/bin/mock-agent
 mkdir -p /data /var/log
+echo "=== binary check ==="
+ldd /app/apps/backend/bin/kandev 2>&1 || true
+echo "=== binary test ==="
+(KANDEV_HOME_DIR=/data KANDEV_DOCKER_ENABLED=false timeout 2 /app/apps/backend/bin/kandev || true) 2>&1 | head -20
+echo "=== end binary check ==="
 cat > /app/start-kandev.sh << 'STARTSCRIPT'
 #!/bin/bash
 set -e
@@ -195,25 +201,31 @@ func drainStream(stream *sprites.ServiceStream) error {
 	}
 }
 
-// waitForKandev polls the kandev health endpoint inside the sprite until it
-// responds or the deadline is exceeded. On failure it fetches log output for
-// diagnostics and returns a combined error.
-func waitForKandev(ctx context.Context, sprite *sprites.Sprite) error {
+// waitForKandev polls the kandev /health endpoint via the public URL until it
+// responds with HTTP 200 or the deadline is exceeded. Hitting the public URL
+// also triggers the service to start if Sprites uses lazy-startup semantics.
+// On failure it fetches log output for diagnostics.
+func waitForKandev(ctx context.Context, sprite *sprites.Sprite, publicURL string) error {
 	const (
-		timeout   = 60 * time.Second
+		timeout   = 90 * time.Second
 		retryWait = 3 * time.Second
 	)
-	healthURL := fmt.Sprintf("http://localhost:%d/health", ports.Backend)
+	healthURL := strings.TrimRight(publicURL, "/") + "/health"
 	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: 5 * time.Second}
 
 	for time.Now().Before(deadline) {
-		checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		out, err := sprite.CommandContext(checkCtx, "curl", "-sf", healthURL).Output()
-		cancel()
-
-		if err == nil && len(out) > 0 {
-			fmt.Fprintf(os.Stderr, "  kandev is healthy\n")
-			return nil
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		if err == nil {
+			resp, err := client.Do(req)
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					fmt.Fprintf(os.Stderr, "  kandev is healthy\n")
+					return nil
+				}
+				fmt.Fprintf(os.Stderr, "  health check: HTTP %d\n", resp.StatusCode)
+			}
 		}
 
 		select {

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -152,12 +152,14 @@ func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error 
 }
 
 func waitForServiceStarted(stream *sprites.ServiceStream) error {
-	started := false
+	// "started" and "complete" are both valid success terminals for CreateService.
+	// The stream may end with EOF after either event, or EOF alone on fast starts.
+	ok := false
 	for {
 		event, err := stream.Next()
 		if errors.Is(err, io.EOF) {
-			if !started {
-				return fmt.Errorf("service stream closed before 'started' event")
+			if !ok {
+				return fmt.Errorf("service stream closed before 'started' or 'complete' event")
 			}
 			return nil
 		}
@@ -165,9 +167,9 @@ func waitForServiceStarted(stream *sprites.ServiceStream) error {
 			return fmt.Errorf("service stream: %w", err)
 		}
 		switch event.Type {
-		case "started":
+		case "started", "complete":
 			fmt.Fprintln(os.Stderr, "  kandev service started")
-			started = true
+			ok = true
 			return nil
 		case "error":
 			return fmt.Errorf("service error: %s", event.Data)

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -141,7 +141,7 @@ func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error 
 	if err != nil {
 		return fmt.Errorf("create service: %w", err)
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	return waitForServiceStarted(stream)
 }
@@ -185,7 +185,7 @@ func drainStream(stream *sprites.ServiceStream) error {
 // enablePublicURL sets the sprite's URL to public mode and returns the URL.
 func enablePublicURL(ctx context.Context, token, spriteName string, _ int) (string, error) {
 	client := newSpriteClient(token)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	updateCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
 	defer cancel()

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -125,8 +125,9 @@ export KANDEV_DOCKER_ENABLED=false
 export KANDEV_LOG_LEVEL=info
 export KANDEV_SERVER_PORT=%d
 export KANDEV_WEB_INTERNAL_URL=http://localhost:%d
+echo "ldd: $(ldd /app/apps/backend/bin/kandev 2>&1 | head -5 || echo NOT AVAILABLE)" >&2
 echo "starting kandev on port %d..." >&2
-exec /app/apps/backend/bin/kandev
+exec /app/apps/backend/bin/kandev >> /var/log/kandev.log 2>&1
 STARTSCRIPT
 chmod +x /app/start-kandev.sh`, ports.Web, ports.Backend, ports.Web, ports.Backend)
 }
@@ -232,7 +233,7 @@ func fetchSpriteLogs(ctx context.Context, sprite *sprites.Sprite) string {
 	logCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	script := `echo "=== /var/log/kandev-web.log ==="; tail -50 /var/log/kandev-web.log 2>/dev/null || echo "(empty)"; echo "=== journalctl/service (last 50 lines) ==="; journalctl -u kandev --no-pager -n 50 2>/dev/null || true`
+	script := `echo "=== /var/log/kandev.log ==="; tail -50 /var/log/kandev.log 2>/dev/null || echo "(empty)"; echo "=== /var/log/kandev-web.log ==="; tail -20 /var/log/kandev-web.log 2>/dev/null || echo "(empty)"`
 	out, err := sprite.CommandContext(logCtx, "bash", "-c", script).CombinedOutput()
 	if err != nil {
 		return fmt.Sprintf("[log fetch error: %v]\n%s", err, string(out))

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -84,8 +84,8 @@ func uploadBundle(ctx context.Context, sprite *sprites.Sprite, tarPath string) e
 }
 
 // extractBundle extracts the bundle tarball and writes the startup script.
-func extractBundle(ctx context.Context, sprite *sprites.Sprite) error {
-	script := buildExtractScript()
+func extractBundle(ctx context.Context, sprite *sprites.Sprite, port int) error {
+	script := buildExtractScript(port)
 	stepCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
 	defer cancel()
 
@@ -99,7 +99,7 @@ func extractBundle(ctx context.Context, sprite *sprites.Sprite) error {
 	return nil
 }
 
-func buildExtractScript() string {
+func buildExtractScript(backendPort int) string {
 	return fmt.Sprintf(`set -e
 tar -xzf /tmp/kandev-preview.tar.gz -C /
 chmod +x /app/apps/backend/bin/kandev \
@@ -116,7 +116,7 @@ cat > /app/start-kandev.sh << 'STARTSCRIPT'
 set -e
 mkdir -p /data
 
-# Kill any agentctl orphans from previous runs or extract-time diagnostics.
+# Kill any agentctl orphans from previous runs.
 pkill -f agentctl || true
 sleep 1
 
@@ -133,10 +133,9 @@ export KANDEV_SERVER_PORT=%d
 export KANDEV_WEB_INTERNAL_URL=http://localhost:%d
 /app/apps/backend/bin/kandev > /var/log/kandev.log 2>&1
 STARTSCRIPT
-chmod +x /app/start-kandev.sh`, ports.Web, ports.Backend, ports.Web)
+chmod +x /app/start-kandev.sh`, ports.Web, backendPort, ports.Web)
 }
 
-// deployService registers (or re-registers) kandev as a Sprites managed service.
 // deployService registers (or updates) the kandev service and explicitly starts
 // it. The two-step approach (CreateService then StartService) ensures the
 // process runs on both first deploy and re-deploy:
@@ -218,12 +217,12 @@ func waitForServiceStarted(stream *sprites.ServiceStream) error {
 // CommandContext until kandev responds or the deadline is exceeded.
 // Using the internal address (localhost) avoids Sprites routing state that
 // may lag during a service restart triggered by enablePublicURL.
-func waitForKandev(ctx context.Context, sprite *sprites.Sprite) error {
+func waitForKandev(ctx context.Context, sprite *sprites.Sprite, port int) error {
 	const (
 		timeout   = 90 * time.Second
 		retryWait = 3 * time.Second
 	)
-	healthURL := fmt.Sprintf("http://localhost:%d/health", ports.Backend)
+	healthURL := fmt.Sprintf("http://localhost:%d/health", port)
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -109,24 +108,22 @@ chmod +x /app/apps/backend/bin/kandev \
 ln -sf /app/apps/backend/bin/agentctl    /usr/local/bin/agentctl
 ln -sf /app/apps/backend/bin/mock-agent  /usr/local/bin/mock-agent
 mkdir -p /data /var/log
-echo "=== binary check ==="
+echo "=== kandev binary info ==="
 ldd /app/apps/backend/bin/kandev 2>&1 || true
-echo "=== binary test ==="
-(KANDEV_HOME_DIR=/data KANDEV_DOCKER_ENABLED=false timeout 2 /app/apps/backend/bin/kandev || true) 2>&1 | head -20
-echo "=== end binary check ==="
+echo "==========================="
 cat > /app/start-kandev.sh << 'STARTSCRIPT'
 #!/bin/bash
 set -e
 mkdir -p /data
 
-echo "node: $(node --version 2>&1 || echo NOT FOUND)" >&2
-echo "kandev binary: $(ls -lh /app/apps/backend/bin/kandev 2>&1)" >&2
+# Kill any agentctl orphans from previous runs or extract-time diagnostics.
+pkill -f agentctl || true
+sleep 1
 
 # Start Next.js web server in background.
 PORT=%d HOSTNAME=0.0.0.0 NODE_ENV=production \
   nohup node /app/apps/web/.next/standalone/web/server.js \
   > /var/log/kandev-web.log 2>&1 &
-echo "web server started (pid $!)" >&2
 
 # Start Go backend (main process — Sprites HTTPPort proxies here).
 export KANDEV_HOME_DIR=/data
@@ -134,36 +131,58 @@ export KANDEV_DOCKER_ENABLED=false
 export KANDEV_LOG_LEVEL=info
 export KANDEV_SERVER_PORT=%d
 export KANDEV_WEB_INTERNAL_URL=http://localhost:%d
-echo "ldd: $(ldd /app/apps/backend/bin/kandev 2>&1 | head -5 || echo NOT AVAILABLE)" >&2
-echo "starting kandev on port %d..." >&2
-exec /app/apps/backend/bin/kandev >> /var/log/kandev.log 2>&1
+/app/apps/backend/bin/kandev > /var/log/kandev.log 2>&1
 STARTSCRIPT
-chmod +x /app/start-kandev.sh`, ports.Web, ports.Backend, ports.Web, ports.Backend)
+chmod +x /app/start-kandev.sh`, ports.Web, ports.Backend, ports.Web)
 }
 
 // deployService registers (or re-registers) kandev as a Sprites managed service.
-// Uses PUT semantics: safe to call multiple times for re-deploys.
+// deployService registers (or updates) the kandev service and explicitly starts
+// it. The two-step approach (CreateService then StartService) ensures the
+// process runs on both first deploy and re-deploy:
+//   - CreateService is idempotent: creates the service config if absent, or
+//     updates it if it already exists.
+//   - StartService explicitly starts (or restarts) the process regardless of
+//     whether it was previously running or stopped.
 func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error {
-	// Stop the service first if running; ignore errors (may not exist yet).
-	stopCtx, stopCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer stopCancel()
-	if stream, err := sprite.StopService(stopCtx, "kandev"); err == nil {
-		_ = drainStream(stream)
-	}
+	createCtx, createCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer createCancel()
 
-	svcCtx, svcCancel := context.WithTimeout(ctx, spriteStepTimeout)
-	defer svcCancel()
-
-	stream, err := sprite.CreateService(svcCtx, "kandev", &sprites.ServiceRequest{
+	createStream, err := sprite.CreateService(createCtx, "kandev", &sprites.ServiceRequest{
 		Cmd:      "/app/start-kandev.sh",
 		HTTPPort: &port,
 	})
 	if err != nil {
 		return fmt.Errorf("create service: %w", err)
 	}
-	defer func() { _ = stream.Close() }()
+	// Drain create stream (informational only).
+	for {
+		ev, err := createStream.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			_ = createStream.Close()
+			return fmt.Errorf("create service stream: %w", err)
+		}
+		if ev.Type == "error" {
+			_ = createStream.Close()
+			return fmt.Errorf("create service error: %s", ev.Data)
+		}
+	}
+	_ = createStream.Close()
 
-	return waitForServiceStarted(stream)
+	// Explicitly start the service so it runs immediately.
+	startCtx, startCancel := context.WithTimeout(ctx, spriteStepTimeout)
+	defer startCancel()
+
+	startStream, err := sprite.StartService(startCtx, "kandev")
+	if err != nil {
+		return fmt.Errorf("start service: %w", err)
+	}
+	defer func() { _ = startStream.Close() }()
+
+	return waitForServiceStarted(startStream)
 }
 
 func waitForServiceStarted(stream *sprites.ServiceStream) error {
@@ -195,40 +214,26 @@ func waitForServiceStarted(stream *sprites.ServiceStream) error {
 	}
 }
 
-func drainStream(stream *sprites.ServiceStream) error {
-	for {
-		_, err := stream.Next()
-		if errors.Is(err, io.EOF) || err != nil {
-			return err
-		}
-	}
-}
-
-// waitForKandev polls the kandev /health endpoint via the public URL until it
-// responds with HTTP 200 or the deadline is exceeded. Hitting the public URL
-// also triggers the service to start if Sprites uses lazy-startup semantics.
-// On failure it fetches log output for diagnostics.
-func waitForKandev(ctx context.Context, sprite *sprites.Sprite, publicURL string) error {
+// waitForKandev polls the kandev /health endpoint inside the sprite via
+// CommandContext until kandev responds or the deadline is exceeded.
+// Using the internal address (localhost) avoids Sprites routing state that
+// may lag during a service restart triggered by enablePublicURL.
+func waitForKandev(ctx context.Context, sprite *sprites.Sprite) error {
 	const (
 		timeout   = 90 * time.Second
 		retryWait = 3 * time.Second
 	)
-	healthURL := strings.TrimRight(publicURL, "/") + "/health"
+	healthURL := fmt.Sprintf("http://localhost:%d/health", ports.Backend)
 	deadline := time.Now().Add(timeout)
-	client := &http.Client{Timeout: 5 * time.Second}
 
 	for time.Now().Before(deadline) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		if err == nil {
-			resp, err := client.Do(req)
-			if err == nil {
-				_ = resp.Body.Close()
-				if resp.StatusCode == http.StatusOK {
-					fmt.Fprintf(os.Stderr, "  kandev is healthy\n")
-					return nil
-				}
-				fmt.Fprintf(os.Stderr, "  health check: HTTP %d\n", resp.StatusCode)
-			}
+		checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		out, err := sprite.CommandContext(checkCtx, "curl", "-sf", healthURL).Output()
+		cancel()
+
+		if err == nil && len(out) > 0 {
+			fmt.Fprintf(os.Stderr, "  kandev is healthy\n")
+			return nil
 		}
 
 		select {

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -34,6 +34,8 @@ func getOrCreateSprite(ctx context.Context, client *sprites.Client, name string)
 	if err == nil {
 		return sprite, nil
 	}
+	// The SDK returns a plain fmt.Errorf("sprite not found: %s") for 404s —
+	// no typed error is available, so we check the message string.
 	if !strings.Contains(err.Error(), "not found") {
 		return nil, fmt.Errorf("get sprite: %w", err)
 	}
@@ -49,7 +51,7 @@ func getOrCreateSprite(ctx context.Context, client *sprites.Client, name string)
 }
 
 // uploadBundle uploads the bundle tarball to the sprite via the Filesystem API.
-// Retries up to spriteUploadRetries times on transient errors.
+// Retries up to spriteUploadRetries times on transient errors with context-aware backoff.
 func uploadBundle(ctx context.Context, sprite *sprites.Sprite, tarPath string) error {
 	data, err := os.ReadFile(tarPath)
 	if err != nil {
@@ -70,8 +72,12 @@ func uploadBundle(ctx context.Context, sprite *sprites.Sprite, tarPath string) e
 		if attempt == spriteUploadRetries || uploadCtx.Err() != nil {
 			break
 		}
-		fmt.Printf("  upload attempt %d failed (%v), retrying in %v...\n", attempt, err, backoff)
-		time.Sleep(backoff)
+		fmt.Fprintf(os.Stderr, "  upload attempt %d failed (%v), retrying in %v...\n", attempt, err, backoff)
+		select {
+		case <-uploadCtx.Done():
+			return uploadCtx.Err()
+		case <-time.After(backoff):
+		}
 		backoff *= 2
 	}
 	return fmt.Errorf("upload bundle after %d attempts: %w", spriteUploadRetries, lastErr)
@@ -146,9 +152,13 @@ func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error 
 }
 
 func waitForServiceStarted(stream *sprites.ServiceStream) error {
+	started := false
 	for {
 		event, err := stream.Next()
 		if errors.Is(err, io.EOF) {
+			if !started {
+				return fmt.Errorf("service stream closed before 'started' event")
+			}
 			return nil
 		}
 		if err != nil {
@@ -156,17 +166,20 @@ func waitForServiceStarted(stream *sprites.ServiceStream) error {
 		}
 		switch event.Type {
 		case "started":
-			fmt.Println("  kandev service started")
+			fmt.Fprintln(os.Stderr, "  kandev service started")
+			started = true
 			return nil
 		case "error":
 			return fmt.Errorf("service error: %s", event.Data)
 		case "exit":
-			if event.ExitCode != nil && *event.ExitCode != 0 {
-				return fmt.Errorf("service exited with code %d", *event.ExitCode)
+			code := -1
+			if event.ExitCode != nil {
+				code = *event.ExitCode
 			}
+			return fmt.Errorf("service exited (code %d) before 'started'", code)
 		case "stdout", "stderr":
 			if event.Data != "" {
-				fmt.Printf("  [kandev] %s\n", strings.TrimRight(event.Data, "\n"))
+				fmt.Fprintf(os.Stderr, "  [kandev] %s\n", strings.TrimRight(event.Data, "\n"))
 			}
 		}
 	}
@@ -181,31 +194,6 @@ func drainStream(stream *sprites.ServiceStream) error {
 	}
 }
 
-// enablePublicURL sets the sprite's URL to public mode and returns the URL.
-func enablePublicURL(ctx context.Context, token, spriteName string, _ int) (string, error) {
-	client := newSpriteClient(token)
-	defer func() { _ = client.Close() }()
-
-	updateCtx, cancel := context.WithTimeout(ctx, spriteStepTimeout)
-	defer cancel()
-
-	if err := client.UpdateURLSettings(updateCtx, spriteName, &sprites.URLSettings{Auth: "public"}); err != nil {
-		return "", fmt.Errorf("update URL settings: %w", err)
-	}
-
-	getCtx, getCancel := context.WithTimeout(ctx, spriteStepTimeout)
-	defer getCancel()
-
-	sprite, err := client.GetSprite(getCtx, spriteName)
-	if err != nil {
-		return "", fmt.Errorf("get sprite URL: %w", err)
-	}
-	if sprite.URL == "" {
-		return "", fmt.Errorf("sprite %s has no URL assigned yet", spriteName)
-	}
-	return sprite.URL, nil
-}
-
 // destroySprite destroys the named sprite and returns its creation time for
 // runtime calculation. Returns zero time if the sprite was not found.
 func destroySprite(ctx context.Context, client *sprites.Client, name string) (time.Time, error) {
@@ -214,8 +202,9 @@ func destroySprite(ctx context.Context, client *sprites.Client, name string) (ti
 
 	sprite, err := client.GetSprite(getCtx, name)
 	if err != nil {
+		// The SDK returns a plain fmt.Errorf("sprite not found: %s") for 404s.
 		if strings.Contains(err.Error(), "not found") {
-			fmt.Printf("sprite %s not found, skipping destroy\n", name)
+			fmt.Fprintf(os.Stderr, "sprite %s not found, skipping destroy\n", name)
 			return time.Time{}, nil
 		}
 		return time.Time{}, fmt.Errorf("get sprite: %w", err)
@@ -228,6 +217,6 @@ func destroySprite(ctx context.Context, client *sprites.Client, name string) (ti
 	if err := sprite.Delete(destroyCtx); err != nil {
 		return createdAt, fmt.Errorf("delete sprite: %w", err)
 	}
-	fmt.Printf("sprite %s destroyed\n", name)
+	fmt.Fprintf(os.Stderr, "sprite %s destroyed\n", name)
 	return createdAt, nil
 }

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -152,24 +152,21 @@ func deployService(ctx context.Context, sprite *sprites.Sprite, port int) error 
 }
 
 func waitForServiceStarted(stream *sprites.ServiceStream) error {
-	// "started" and "complete" are both valid success terminals for CreateService.
-	// The stream may end with EOF after either event, or EOF alone on fast starts.
-	ok := false
+	// CreateService returns HTTP 200 when the service is registered; the stream
+	// carries optional progress events. EOF means the server finished streaming —
+	// treat it as success unless we saw an explicit failure event first.
+	// On existing sprites the service can start fast enough that no events arrive.
 	for {
 		event, err := stream.Next()
 		if errors.Is(err, io.EOF) {
-			if !ok {
-				return fmt.Errorf("service stream closed before 'started' or 'complete' event")
-			}
 			return nil
 		}
 		if err != nil {
 			return fmt.Errorf("service stream: %w", err)
 		}
+		fmt.Fprintf(os.Stderr, "  [service] type=%s data=%q\n", event.Type, event.Data)
 		switch event.Type {
 		case "started", "complete":
-			fmt.Fprintln(os.Stderr, "  kandev service started")
-			ok = true
 			return nil
 		case "error":
 			return fmt.Errorf("service error: %s", event.Data)
@@ -179,10 +176,6 @@ func waitForServiceStarted(stream *sprites.ServiceStream) error {
 				code = *event.ExitCode
 			}
 			return fmt.Errorf("service exited (code %d) before 'started'", code)
-		case "stdout", "stderr":
-			if event.Data != "" {
-				fmt.Fprintf(os.Stderr, "  [kandev] %s\n", strings.TrimRight(event.Data, "\n"))
-			}
 		}
 	}
 }

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -107,6 +107,8 @@ chmod +x /app/apps/backend/bin/kandev \
          /app/apps/backend/bin/mock-agent
 ln -sf /app/apps/backend/bin/agentctl    /usr/local/bin/agentctl
 ln -sf /app/apps/backend/bin/mock-agent  /usr/local/bin/mock-agent
+# Reset data directory on each deploy so the DB starts fresh (preview env only).
+rm -rf /data
 mkdir -p /data /var/log
 echo "=== kandev binary info ==="
 ldd /app/apps/backend/bin/kandev 2>&1 || true

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -131,6 +131,8 @@ export KANDEV_DOCKER_ENABLED=false
 export KANDEV_LOG_LEVEL=info
 export KANDEV_SERVER_PORT=%d
 export KANDEV_WEB_INTERNAL_URL=http://localhost:%d
+# Preview mode: only register the mock agent, suppress real agent discovery.
+export KANDEV_MOCK_AGENT=only
 /app/apps/backend/bin/kandev > /var/log/kandev.log 2>&1
 STARTSCRIPT
 chmod +x /app/start-kandev.sh`, ports.Web, backendPort, ports.Web)

--- a/apps/backend/cmd/preview/sprite_ops.go
+++ b/apps/backend/cmd/preview/sprite_ops.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kandev/kandev/internal/common/ports"
 	sprites "github.com/superfly/sprites-go"
 )
 
@@ -17,8 +18,6 @@ const (
 	spriteStepTimeout   = 2 * time.Minute
 	spriteUploadRetries = 3
 	spriteBackoffInit   = 700 * time.Millisecond
-	kandevBackendPort   = 38429
-	kandevWebPort       = 37429
 )
 
 func newSpriteClient(token string) *sprites.Client {
@@ -118,7 +117,7 @@ export KANDEV_SERVER_PORT=%d
 export KANDEV_WEB_INTERNAL_URL=http://localhost:%d
 exec /app/apps/backend/bin/kandev
 STARTSCRIPT
-chmod +x /app/start-kandev.sh`, kandevWebPort, kandevBackendPort, kandevWebPort)
+chmod +x /app/start-kandev.sh`, ports.Web, ports.Backend, ports.Web)
 }
 
 // deployService registers (or re-registers) kandev as a Sprites managed service.

--- a/apps/backend/cmd/preview/sprite_ops_test.go
+++ b/apps/backend/cmd/preview/sprite_ops_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildExtractScript(t *testing.T) {
+	script := buildExtractScript(12345)
+
+	if !strings.Contains(script, "KANDEV_SERVER_PORT=12345") {
+		t.Errorf("expected KANDEV_SERVER_PORT=12345 in script, got:\n%s", script)
+	}
+	if !strings.Contains(script, "rm -rf /data") {
+		t.Errorf("expected rm -rf /data in script")
+	}
+	if !strings.Contains(script, "KANDEV_MOCK_AGENT=only") {
+		t.Errorf("expected KANDEV_MOCK_AGENT=only in script")
+	}
+}

--- a/apps/backend/internal/agent/lifecycle/types.go
+++ b/apps/backend/internal/agent/lifecycle/types.go
@@ -12,14 +12,14 @@ import (
 	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 	agentctl "github.com/kandev/kandev/internal/agentctl/client"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/common/ports"
 	"github.com/kandev/kandev/internal/task/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Default agentctl port. Clustered near the web port (37429) to avoid
-// collisions with commonly used ports (8080, 9090, 9999, etc.).
-const AgentCtlPort = 39429
+// AgentCtlPort is the default agentctl control port.
+const AgentCtlPort = ports.AgentCtl
 
 // AgentExecution represents a running agent execution
 type AgentExecution struct {

--- a/apps/backend/internal/agent/settings/controller/agent_discovery.go
+++ b/apps/backend/internal/agent/settings/controller/agent_discovery.go
@@ -270,7 +270,9 @@ func (c *Controller) updateExistingProfiles(ctx context.Context, profiles []*mod
 func (c *Controller) syncAgentFromDiscovery(ctx context.Context, result discovery.Availability) error {
 	agentConfig, ok := c.agentRegistry.Get(result.Name)
 	if !ok {
-		return fmt.Errorf("unknown agent: %s", result.Name)
+		// Agent detected on filesystem but not in registry (e.g. KANDEV_MOCK_AGENT=only
+		// suppresses real agents). Skip silently rather than aborting the entire sync.
+		return nil
 	}
 	displayName, err := c.resolveDisplayName(agentConfig, result.Name)
 	if err != nil {

--- a/apps/backend/internal/agent/settings/controller/controller_test.go
+++ b/apps/backend/internal/agent/settings/controller/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kandev/kandev/internal/agent/agents"
+	"github.com/kandev/kandev/internal/agent/discovery"
 	"github.com/kandev/kandev/internal/agent/registry"
 	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/agent/settings/modelfetcher"
@@ -497,5 +498,23 @@ func TestController_GetAgentLogo_NoLogoData(t *testing.T) {
 	_, err := ctrl.GetAgentLogo(context.Background(), "test-agent", agents.LogoLight)
 	if err != ErrLogoNotAvailable {
 		t.Errorf("GetAgentLogo() error = %v, want ErrLogoNotAvailable", err)
+	}
+}
+
+// TestSyncAgentFromDiscovery_UnknownAgentSkipped verifies that
+// syncAgentFromDiscovery returns nil (not an error) when the discovered agent
+// is not in the registry. This is the expected behaviour when
+// KANDEV_MOCK_AGENT=only suppresses all real agents: the filesystem scanner may
+// still detect installed CLIs, but they should be silently skipped rather than
+// aborting the entire profile-sync loop.
+func TestSyncAgentFromDiscovery_UnknownAgentSkipped(t *testing.T) {
+	ctrl := newTestController(map[string]agents.Agent{}) // empty registry
+
+	result := discovery.Availability{
+		Name:      "some-unregistered-agent",
+		Available: true,
+	}
+	if err := ctrl.syncAgentFromDiscovery(context.Background(), result); err != nil {
+		t.Errorf("expected nil error for unknown agent, got: %v", err)
 	}
 }

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kandev/kandev/internal/common/ports"
 	"github.com/spf13/viper"
 )
 
@@ -235,7 +236,7 @@ func detectDefaultLogFormat() string {
 func setDefaults(v *viper.Viper) {
 	// Server defaults
 	v.SetDefault("server.host", "0.0.0.0")
-	v.SetDefault("server.port", 38429)
+	v.SetDefault("server.port", ports.Backend)
 	v.SetDefault("server.readTimeout", 30)
 	v.SetDefault("server.writeTimeout", 30)
 	v.SetDefault("server.webInternalUrl", "")
@@ -274,9 +275,9 @@ func setDefaults(v *viper.Viper) {
 
 	// Agent defaults (runtime selection is now per-task based on executor type)
 	v.SetDefault("agent.standaloneHost", "localhost")
-	v.SetDefault("agent.standalonePort", 39429)
+	v.SetDefault("agent.standalonePort", ports.AgentCtl)
 	v.SetDefault("agent.mcpServerEnabled", false) // MCP is now embedded in agentctl
-	v.SetDefault("agent.mcpServerPort", 40429)
+	v.SetDefault("agent.mcpServerPort", ports.MCP)
 	v.SetDefault("agent.mcpServerUrl", "")
 
 	// Auth defaults

--- a/apps/backend/internal/common/ports/ports.go
+++ b/apps/backend/internal/common/ports/ports.go
@@ -1,0 +1,21 @@
+// Package ports defines the default service ports used by kandev.
+// These values are the single source of truth in Go; the TypeScript CLI
+// mirrors them in apps/cli/src/constants.ts.
+//
+// All four ports are clustered around 37429–40429 to avoid collisions with
+// commonly used ports (8080, 9090, 9999, etc.) while keeping them memorable.
+package ports
+
+const (
+	// Backend is the default HTTP port for the kandev Go backend.
+	Backend = 38429
+
+	// Web is the default HTTP port for the Next.js web server.
+	Web = 37429
+
+	// AgentCtl is the default control port for the agentctl sidecar.
+	AgentCtl = 39429
+
+	// MCP is the default port for the standalone MCP server.
+	MCP = 40429
+)

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -1174,44 +1174,67 @@ func (s *Service) ListRepoBranches(ctx context.Context, owner, repo string) ([]R
 var anonymousAPIBase = githubAPIBase
 
 // listRepoBranchesAnonymous calls the GitHub REST API without authentication to
-// list branches for public repositories. Returns ErrNoClient on network errors
-// and a GitHubAPIError for non-2xx responses (404, 403, etc.) so the controller
-// can map them to the appropriate HTTP status codes.
+// list branches for public repositories, following pagination via Link headers.
+// Returns ErrNoClient on network errors and a GitHubAPIError for non-2xx
+// responses (404, 403, etc.) so the controller maps them to correct HTTP codes.
 func listRepoBranchesAnonymous(ctx context.Context, owner, repo string) ([]RepoBranch, error) {
-	endpoint := fmt.Sprintf("%s/repos/%s/%s/branches?per_page=100", anonymousAPIBase, owner, repo)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, ErrNoClient
-	}
-	req.Header.Set("Accept", githubAccept)
-	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, ErrNoClient
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, &GitHubAPIError{
-			StatusCode: resp.StatusCode,
-			Endpoint:   endpoint,
-			Body:       string(body),
+	next := fmt.Sprintf("%s/repos/%s/%s/branches?per_page=100", anonymousAPIBase, owner, repo)
+	var branches []RepoBranch
+	for next != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
+		if err != nil {
+			return nil, ErrNoClient
 		}
-	}
+		req.Header.Set("Accept", githubAccept)
+		req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
 
-	var raw []struct {
-		Name string `json:"name"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
-		return nil, ErrNoClient
-	}
-	branches := make([]RepoBranch, 0, len(raw))
-	for _, b := range raw {
-		branches = append(branches, RepoBranch{Name: b.Name})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, ErrNoClient
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, &GitHubAPIError{
+				StatusCode: resp.StatusCode,
+				Endpoint:   next,
+				Body:       string(body),
+			}
+		}
+
+		var page []struct {
+			Name string `json:"name"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&page)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, ErrNoClient
+		}
+		for _, b := range page {
+			branches = append(branches, RepoBranch{Name: b.Name})
+		}
+		next = parseLinkNext(resp.Header.Get("Link"))
 	}
 	return branches, nil
+}
+
+// parseLinkNext extracts the URL for rel="next" from a GitHub Link header.
+// Returns "" if no next page is present.
+func parseLinkNext(link string) string {
+	// Format: <url>; rel="next", <url>; rel="last"
+	for part := range strings.SplitSeq(link, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		if start := strings.Index(part, "<"); start != -1 {
+			if end := strings.Index(part, ">"); end != -1 && end > start {
+				return part[start+1 : end]
+			}
+		}
+	}
+	return ""
 }
 
 // SearchUserPRs searches for PRs using a filter or custom query. Unless the

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -25,6 +26,13 @@ import (
 const (
 	AuthMethodNone = "none"
 	AuthMethodPAT  = "pat"
+)
+
+// defaultBranchMain and defaultBranchMaster are the conventional default branch
+// names sorted to the top of branch pickers.
+const (
+	defaultBranchMain   = "main"
+	defaultBranchMaster = "master"
 )
 
 // TaskDeleter deletes tasks by ID. Used for cleaning up merged PR tasks.
@@ -1189,9 +1197,9 @@ func (s *Service) ListRepoBranches(ctx context.Context, owner, repo string) ([]R
 func sortBranchesMainFirst(branches []RepoBranch) {
 	priority := func(name string) int {
 		switch name {
-		case "main":
+		case defaultBranchMain:
 			return 0
-		case "master":
+		case defaultBranchMaster:
 			return 1
 		default:
 			return 2
@@ -1210,12 +1218,18 @@ func sortBranchesMainFirst(branches []RepoBranch) {
 // Overridden in tests to point at a local httptest server.
 var anonymousAPIBase = githubAPIBase
 
+// anonymousHTTPClient is used by listRepoBranchesAnonymous. The 30 s timeout
+// prevents a slow or unresponsive GitHub API from tying up server goroutines
+// indefinitely across multi-page pagination.
+var anonymousHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 // listRepoBranchesAnonymous calls the GitHub REST API without authentication to
 // list branches for public repositories, following pagination via Link headers.
 // Returns ErrNoClient on network errors and a GitHubAPIError for non-2xx
 // responses (404, 403, etc.) so the controller maps them to correct HTTP codes.
 func listRepoBranchesAnonymous(ctx context.Context, owner, repo string) ([]RepoBranch, error) {
-	next := fmt.Sprintf("%s/repos/%s/%s/branches?per_page=100", anonymousAPIBase, owner, repo)
+	next := fmt.Sprintf("%s/repos/%s/%s/branches?per_page=100",
+		anonymousAPIBase, url.PathEscape(owner), url.PathEscape(repo))
 	var branches []RepoBranch
 	for next != "" {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
@@ -1225,7 +1239,7 @@ func listRepoBranchesAnonymous(ctx context.Context, owner, repo string) ([]RepoB
 		req.Header.Set("Accept", githubAccept)
 		req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := anonymousHTTPClient.Do(req)
 		if err != nil {
 			return nil, ErrNoClient
 		}
@@ -1246,7 +1260,7 @@ func listRepoBranchesAnonymous(ctx context.Context, owner, repo string) ([]RepoB
 		err = json.NewDecoder(resp.Body).Decode(&page)
 		_ = resp.Body.Close()
 		if err != nil {
-			return nil, ErrNoClient
+			return nil, fmt.Errorf("decode branches response: %w", err)
 		}
 		for _, b := range page {
 			branches = append(branches, RepoBranch{Name: b.Name})

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -2,7 +2,11 @@ package github
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"sync"
@@ -1153,11 +1157,61 @@ func (s *Service) SearchOrgRepos(ctx context.Context, org, query string, limit i
 }
 
 // ListRepoBranches lists branches for a repository.
+// When no authenticated client is configured, it falls back to the unauthenticated
+// GitHub API so that public repositories remain accessible without a token.
 func (s *Service) ListRepoBranches(ctx context.Context, owner, repo string) ([]RepoBranch, error) {
-	if s.client == nil {
-		return nil, fmt.Errorf("github client not available")
+	if s.client != nil {
+		branches, err := s.client.ListRepoBranches(ctx, owner, repo)
+		if err == nil || !errors.Is(err, ErrNoClient) {
+			return branches, err
+		}
 	}
-	return s.client.ListRepoBranches(ctx, owner, repo)
+	return listRepoBranchesAnonymous(ctx, owner, repo)
+}
+
+// anonymousAPIBase is the GitHub API base URL used by listRepoBranchesAnonymous.
+// Overridden in tests to point at a local httptest server.
+var anonymousAPIBase = githubAPIBase
+
+// listRepoBranchesAnonymous calls the GitHub REST API without authentication to
+// list branches for public repositories. Returns ErrNoClient on network errors
+// and a GitHubAPIError for non-2xx responses (404, 403, etc.) so the controller
+// can map them to the appropriate HTTP status codes.
+func listRepoBranchesAnonymous(ctx context.Context, owner, repo string) ([]RepoBranch, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/branches?per_page=100", anonymousAPIBase, owner, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, ErrNoClient
+	}
+	req.Header.Set("Accept", githubAccept)
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, ErrNoClient
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, &GitHubAPIError{
+			StatusCode: resp.StatusCode,
+			Endpoint:   endpoint,
+			Body:       string(body),
+		}
+	}
+
+	var raw []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, ErrNoClient
+	}
+	branches := make([]RepoBranch, 0, len(raw))
+	for _, b := range raw {
+		branches = append(branches, RepoBranch{Name: b.Name})
+	}
+	return branches, nil
 }
 
 // SearchUserPRs searches for PRs using a filter or custom query. Unless the

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1159,14 +1160,50 @@ func (s *Service) SearchOrgRepos(ctx context.Context, org, query string, limit i
 // ListRepoBranches lists branches for a repository.
 // When no authenticated client is configured, it falls back to the unauthenticated
 // GitHub API so that public repositories remain accessible without a token.
+// The result is sorted so that "main" appears first, "master" second, then all
+// remaining branches alphabetically — matching the default branch convention and
+// making the most common choices immediately visible in pickers.
 func (s *Service) ListRepoBranches(ctx context.Context, owner, repo string) ([]RepoBranch, error) {
+	var (
+		branches []RepoBranch
+		err      error
+	)
 	if s.client != nil {
-		branches, err := s.client.ListRepoBranches(ctx, owner, repo)
-		if err == nil || !errors.Is(err, ErrNoClient) {
-			return branches, err
+		branches, err = s.client.ListRepoBranches(ctx, owner, repo)
+		if err != nil && !errors.Is(err, ErrNoClient) {
+			return nil, err
 		}
 	}
-	return listRepoBranchesAnonymous(ctx, owner, repo)
+	if branches == nil {
+		branches, err = listRepoBranchesAnonymous(ctx, owner, repo)
+		if err != nil {
+			return nil, err
+		}
+	}
+	sortBranchesMainFirst(branches)
+	return branches, nil
+}
+
+// sortBranchesMainFirst sorts branches in-place: "main" first, "master" second,
+// then all remaining branches alphabetically.
+func sortBranchesMainFirst(branches []RepoBranch) {
+	priority := func(name string) int {
+		switch name {
+		case "main":
+			return 0
+		case "master":
+			return 1
+		default:
+			return 2
+		}
+	}
+	sort.SliceStable(branches, func(i, j int) bool {
+		pi, pj := priority(branches[i].Name), priority(branches[j].Name)
+		if pi != pj {
+			return pi < pj
+		}
+		return branches[i].Name < branches[j].Name
+	})
 }
 
 // anonymousAPIBase is the GitHub API base URL used by listRepoBranchesAnonymous.

--- a/apps/backend/internal/github/service_test.go
+++ b/apps/backend/internal/github/service_test.go
@@ -3,6 +3,10 @@ package github
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +18,62 @@ import (
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events/bus"
 )
+
+func TestListRepoBranches_NoopClientFallback(t *testing.T) {
+	// A fake GitHub API that returns two branches for a public repo.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/branches" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"name": "main"},
+			{"name": "develop"},
+		})
+	}))
+	defer srv.Close()
+
+	orig := anonymousAPIBase
+	anonymousAPIBase = srv.URL
+	defer func() { anonymousAPIBase = orig }()
+
+	svc := &Service{client: &NoopClient{}}
+	branches, err := svc.ListRepoBranches(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(branches))
+	}
+	if branches[0].Name != "main" || branches[1].Name != "develop" {
+		t.Errorf("unexpected branches: %+v", branches)
+	}
+}
+
+func TestListRepoBranches_NoopClientFallback_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	orig := anonymousAPIBase
+	anonymousAPIBase = srv.URL
+	defer func() { anonymousAPIBase = orig }()
+
+	svc := &Service{client: &NoopClient{}}
+	_, err := svc.ListRepoBranches(context.Background(), "owner", "private-repo")
+	if err == nil {
+		t.Fatal("expected error for private/missing repo")
+	}
+	var apiErr *GitHubAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected GitHubAPIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 status, got %d", apiErr.StatusCode)
+	}
+}
 
 func TestGetPR_NilClient(t *testing.T) {
 	svc := &Service{client: nil}

--- a/apps/backend/internal/github/service_test.go
+++ b/apps/backend/internal/github/service_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,6 +19,60 @@ import (
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events/bus"
 )
+
+func TestParseLinkNext(t *testing.T) {
+	tests := []struct {
+		link string
+		want string
+	}{
+		{
+			link: `<https://api.github.com/repos/o/r/branches?page=2>; rel="next", <https://api.github.com/repos/o/r/branches?page=3>; rel="last"`,
+			want: "https://api.github.com/repos/o/r/branches?page=2",
+		},
+		{
+			link: `<https://api.github.com/repos/o/r/branches?page=3>; rel="last"`,
+			want: "",
+		},
+		{link: "", want: ""},
+	}
+	for _, tc := range tests {
+		got := parseLinkNext(tc.link)
+		if got != tc.want {
+			t.Errorf("parseLinkNext(%q) = %q, want %q", tc.link, got, tc.want)
+		}
+	}
+}
+
+func TestListRepoBranches_Pagination(t *testing.T) {
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		if page == 1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/branches?page=2>; rel="next"`, "http://"+r.Host))
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"name": "feature-a"}})
+		} else {
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"name": "main"}})
+		}
+	}))
+	defer srv.Close()
+
+	orig := anonymousAPIBase
+	anonymousAPIBase = srv.URL
+	defer func() { anonymousAPIBase = orig }()
+
+	svc := &Service{client: &NoopClient{}}
+	branches, err := svc.ListRepoBranches(context.Background(), "owner", "repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 branches across pages, got %d", len(branches))
+	}
+	names := map[string]bool{branches[0].Name: true, branches[1].Name: true}
+	if !names["main"] || !names["feature-a"] {
+		t.Errorf("unexpected branches: %+v", branches)
+	}
+}
 
 func TestListRepoBranches_NoopClientFallback(t *testing.T) {
 	// A fake GitHub API that returns two branches for a public repo.

--- a/apps/backend/internal/github/service_test.go
+++ b/apps/backend/internal/github/service_test.go
@@ -68,9 +68,12 @@ func TestListRepoBranches_Pagination(t *testing.T) {
 	if len(branches) != 2 {
 		t.Fatalf("expected 2 branches across pages, got %d", len(branches))
 	}
-	names := map[string]bool{branches[0].Name: true, branches[1].Name: true}
-	if !names["main"] || !names["feature-a"] {
-		t.Errorf("unexpected branches: %+v", branches)
+	// main should appear first regardless of which page it was fetched from.
+	if branches[0].Name != "main" {
+		t.Errorf("expected main first, got %q; branches: %+v", branches[0].Name, branches)
+	}
+	if branches[1].Name != "feature-a" {
+		t.Errorf("expected feature-a second, got %q", branches[1].Name)
 	}
 }
 
@@ -127,6 +130,46 @@ func TestListRepoBranches_NoopClientFallback_NotFound(t *testing.T) {
 	}
 	if apiErr.StatusCode != http.StatusNotFound {
 		t.Errorf("expected 404 status, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestSortBranchesMainFirst(t *testing.T) {
+	tests := []struct {
+		input []string
+		want  []string
+	}{
+		{
+			input: []string{"feature-b", "main", "feature-a", "master"},
+			want:  []string{"main", "master", "feature-a", "feature-b"},
+		},
+		{
+			input: []string{"develop", "master"},
+			want:  []string{"master", "develop"},
+		},
+		{
+			input: []string{"feature-a", "feature-b"},
+			want:  []string{"feature-a", "feature-b"},
+		},
+		{
+			input: []string{"main"},
+			want:  []string{"main"},
+		},
+		{
+			input: []string{},
+			want:  []string{},
+		},
+	}
+	for _, tc := range tests {
+		branches := make([]RepoBranch, len(tc.input))
+		for i, n := range tc.input {
+			branches[i] = RepoBranch{Name: n}
+		}
+		sortBranchesMainFirst(branches)
+		for i, b := range branches {
+			if b.Name != tc.want[i] {
+				t.Errorf("input=%v: got[%d]=%q, want %q", tc.input, i, b.Name, tc.want[i])
+			}
+		}
 	}
 }
 

--- a/apps/backend/internal/task/service/repository_discovery.go
+++ b/apps/backend/internal/task/service/repository_discovery.go
@@ -207,40 +207,49 @@ func (s *Service) resolveAllowedLocalPath(repoPath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid repository path: %w", err)
 	}
-	safe, err := pathWithinRoots(abs, roots)
+	// Resolve symlinks before the allowlist check so that OS-level symlinks
+	// (e.g. /var -> /private/var on macOS) don't produce false negatives.
+	// normalizeRoots already resolves symlinks on the roots themselves, so both
+	// sides of the comparison are canonical after this step.
+	resolved, err := filepath.EvalSymlinks(abs)
 	if err != nil {
 		return "", err
 	}
-	// Resolve symlinks then re-validate so a symlink within a root cannot
-	// escape outside the allowed roots.
-	resolved, err := filepath.EvalSymlinks(safe)
+	safe, err := pathWithinRoots(filepath.Clean(resolved), roots)
 	if err != nil {
 		return "", err
 	}
-	resolvedSafe, err := pathWithinRoots(filepath.Clean(resolved), roots)
-	if err != nil {
-		return "", err
-	}
-	info, err := os.Stat(resolvedSafe)
+	info, err := os.Stat(safe)
 	if err != nil {
 		return "", err
 	}
 	if !info.IsDir() {
 		return "", fmt.Errorf("repository path is not a directory")
 	}
-	return resolvedSafe, nil
+	return safe, nil
 }
 
 // pathWithinRoots returns abs only when it sits inside one of the allowed
 // roots after resolving relative segments. The returned string is the
 // trusted, validated path; callers should never use the original input for
 // subsequent file operations.
+//
+// Each root is also passed through filepath.EvalSymlinks before comparison so
+// that OS-level symlinks (e.g. /var -> /private/var on macOS) do not produce
+// false negatives when abs was obtained via EvalSymlinks but the stored root
+// was not.
 func pathWithinRoots(abs string, roots []string) (string, error) {
 	for _, root := range roots {
 		if root == "" {
 			continue
 		}
-		rel, err := filepath.Rel(root, abs)
+		// Resolve symlinks on the root so both sides of the comparison are
+		// canonical. Ignore errors — if the root itself doesn't exist we skip it.
+		canonRoot := root
+		if r, err := filepath.EvalSymlinks(root); err == nil {
+			canonRoot = r
+		}
+		rel, err := filepath.Rel(canonRoot, abs)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Adds a `cmd/preview` Go CLI with `deploy` and `cleanup` subcommands that deploy a full kandev + Next.js instance to a [Sprites](https://sprites.dev) microVM for each PR
- Reviewers get a public URL to manually test changes without pulling the branch locally; mock agent is pre-configured so there are no AI costs
- `.github/workflows/preview-env.yml` triggers on PR open/sync/close with the same dual-trigger + allowlist security pattern as the code review workflow
- Sprite is destroyed on PR close; PR comment is updated with runtime summary

## How it works

1. **Build**: Compiles `kandev` (CGO, uses Docker on non-linux/amd64), `agentctl`, and `mock-agent` for linux/amd64; runs Next.js production build; packages everything into a tar.gz
2. **Deploy**: Gets or creates a Sprites microVM named `kandev-pr-{N}`; uploads the bundle; extracts and registers a managed service; activates a public URL
3. **Comment**: Upserts a PR comment with the preview URL and commit SHA (updates on each new push, URL stays stable)
4. **Cleanup**: Destroys the sprite when the PR is closed; updates the comment with runtime

## Test plan

- [x] End-to-end local test: `go run ./cmd/preview deploy --pr 706 --sha ec9637c5...` — sprite created, bundle uploaded, kandev service started, URL `https://kandev-pr-706-bwo7.sprites.app` returned, PR comment posted
- [x] Cleanup test: `go run ./cmd/preview cleanup --pr 706` — sprite destroyed, comment updated
- [ ] Open a real PR to verify the GH Actions workflow triggers automatically
- [ ] Test fork PR security: non-allowlisted fork → no deploy; add `safe-to-test` label → deploys