### PR TITLE
refactor(worktree): drop unused flat-layout worktrees/ path

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -287,8 +287,7 @@ func startAgentInfrastructure(
 	}
 	addCleanup(worktreeCleanup)
 	log.Info("Worktree Manager initialized",
-		zap.Bool("enabled", cfg.Worktree.Enabled),
-		zap.String("base_path", cfg.Worktree.BasePath))
+		zap.Bool("enabled", cfg.Worktree.Enabled))
 
 	lifecycleMgr.SetWorkspaceInfoProvider(services.Task)
 	log.Info("Workspace info provider configured for session recovery")

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -150,7 +150,6 @@ type RepositoryDiscoveryConfig struct {
 // WorktreeConfig holds Git worktree configuration for concurrent agent execution.
 type WorktreeConfig struct {
 	Enabled             bool   `mapstructure:"enabled"`             // Enable worktree mode
-	BasePath            string `mapstructure:"basePath"`            // Base directory for worktrees (default: ~/.kandev/worktrees)
 	DefaultBranch       string `mapstructure:"defaultBranch"`       // Default base branch (default: main)
 	CleanupOnRemove     bool   `mapstructure:"cleanupOnRemove"`     // Remove worktree directory on task deletion
 	FetchTimeoutSeconds int    `mapstructure:"fetchTimeoutSeconds"` // Git fetch timeout before worktree creation
@@ -294,7 +293,6 @@ func setDefaults(v *viper.Viper) {
 
 	// Worktree defaults
 	v.SetDefault("worktree.enabled", true)
-	v.SetDefault("worktree.basePath", "")
 	v.SetDefault("worktree.defaultBranch", "main")
 	v.SetDefault("worktree.cleanupOnRemove", true)
 	v.SetDefault("worktree.fetchTimeoutSeconds", 60)

--- a/apps/backend/internal/worktree/config.go
+++ b/apps/backend/internal/worktree/config.go
@@ -15,11 +15,6 @@ type Config struct {
 	// Enabled controls whether worktree mode is active.
 	Enabled bool `mapstructure:"enabled"`
 
-	// BasePath is the base directory for worktree storage.
-	// Supports ~ expansion for home directory.
-	// Default: ~/.kandev/worktrees
-	BasePath string `mapstructure:"base_path"`
-
 	// TasksBasePath is the base directory for per-task worktree storage.
 	// Each task gets a subdirectory containing one repo worktree (future: multiple).
 	// Supports ~ expansion for home directory.
@@ -50,40 +45,11 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// SetDataDirFallback sets the BasePath from the data directory if not already configured.
-func (c *Config) SetDataDirFallback(dataDir string) {
-	if c.BasePath == "" && dataDir != "" {
-		c.BasePath = filepath.Join(dataDir, "worktrees")
-	}
-}
-
 // SetTasksBasePathFallback sets the TasksBasePath from the data directory if not already configured.
 func (c *Config) SetTasksBasePathFallback(dataDir string) {
 	if c.TasksBasePath == "" && dataDir != "" {
 		c.TasksBasePath = filepath.Join(dataDir, "tasks")
 	}
-}
-
-// ExpandedBasePath returns the base path with ~ expanded to the user's home directory.
-func (c *Config) ExpandedBasePath() (string, error) {
-	path := c.BasePath
-	if strings.HasPrefix(path, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		path = filepath.Join(home, path[2:])
-	}
-	return path, nil
-}
-
-// WorktreePath returns the full path for a worktree given a unique worktree ID.
-func (c *Config) WorktreePath(worktreeID string) (string, error) {
-	basePath, err := c.ExpandedBasePath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(basePath, worktreeID), nil
 }
 
 // ExpandedTasksBasePath returns the tasks base path with ~ expanded to the user's home directory.

--- a/apps/backend/internal/worktree/errors.go
+++ b/apps/backend/internal/worktree/errors.go
@@ -46,6 +46,12 @@ var (
 
 	// ErrGitCryptFailed is returned when git-crypt unlock fails during worktree creation.
 	ErrGitCryptFailed = errors.New("git-crypt unlock failed")
+
+	// ErrTaskDirRequired is returned when a worktree create request is missing
+	// TaskDirName or RepoName. Worktrees are always placed inside the per-task
+	// directory (~/.kandev/tasks/{taskDir}/{repo}/), so callers must populate
+	// both fields.
+	ErrTaskDirRequired = errors.New("worktree create requires TaskDirName and RepoName")
 )
 
 // containsAuthFailure checks if git output indicates an authentication failure.

--- a/apps/backend/internal/worktree/gitcrypt_test.go
+++ b/apps/backend/internal/worktree/gitcrypt_test.go
@@ -272,6 +272,8 @@ func TestCreateWorktree_GitCryptNewBranch(t *testing.T) {
 		RepositoryID:   "repo-gc",
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
+		TaskDirName:    "gc-task-1",
+		RepoName:       "repo-gc",
 	})
 	if err != nil {
 		t.Fatalf("Create() failed: %v", err)
@@ -333,6 +335,8 @@ func TestCreateWorktree_GitCryptExistingBranch(t *testing.T) {
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
 		CheckoutBranch: "feature/encrypted-branch",
+		TaskDirName:    "gc-task-2",
+		RepoName:       "repo-gc",
 	})
 	if err != nil {
 		t.Fatalf("Create() failed: %v", err)
@@ -472,6 +476,8 @@ func TestCreateWorktree_GitCryptLockedRepo(t *testing.T) {
 		RepositoryID:   "repo-gc-locked",
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
+		TaskDirName:    "gc-locked-1",
+		RepoName:       "repo-gc-locked",
 	})
 	if err != nil {
 		t.Fatalf("Create() with locked repo should succeed, got: %v", err)
@@ -561,6 +567,8 @@ func TestCreateWorktree_GitCryptWithSubmodules(t *testing.T) {
 		RepositoryID:   "repo-gc-sub",
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
+		TaskDirName:    "gc-sub-task-1",
+		RepoName:       "repo-gc-sub",
 	})
 	if err != nil {
 		t.Fatalf("Create() failed: %v", err)

--- a/apps/backend/internal/worktree/manager.go
+++ b/apps/backend/internal/worktree/manager.go
@@ -1061,59 +1061,6 @@ func (m *Manager) OnTaskDeleted(ctx context.Context, taskID string) error {
 	return m.CleanupWorktrees(ctx, worktrees)
 }
 
-// Reconcile syncs worktree state with active tasks on startup.
-func (m *Manager) Reconcile(ctx context.Context) error {
-	m.reconcileTasksDir(ctx)
-	return nil
-}
-
-// reconcileTasksDir scans ~/.kandev/tasks/ for orphaned task directories
-// whose worktrees are no longer referenced by the store.
-func (m *Manager) reconcileTasksDir(ctx context.Context) {
-	tasksBase, err := m.config.ExpandedTasksBasePath()
-	if err != nil || tasksBase == "" {
-		return
-	}
-
-	entries, err := os.ReadDir(tasksBase)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			m.logger.Debug("failed to read tasks directory for reconciliation",
-				zap.String("path", tasksBase), zap.Error(err))
-		}
-		return
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		taskDirPath := filepath.Join(tasksBase, entry.Name())
-		if m.isOrphanedTaskDir(ctx, taskDirPath) {
-			m.logger.Info("cleaning up orphaned task directory",
-				zap.String("path", taskDirPath))
-			if err := os.RemoveAll(taskDirPath); err != nil {
-				m.logger.Warn("failed to remove orphaned task directory",
-					zap.String("path", taskDirPath), zap.Error(err))
-			}
-		}
-	}
-}
-
-// isOrphanedTaskDir checks if a task directory contains no valid worktrees.
-func (m *Manager) isOrphanedTaskDir(ctx context.Context, taskDirPath string) bool {
-	subEntries, err := os.ReadDir(taskDirPath)
-	if err != nil {
-		return true // Can't read it, treat as orphaned
-	}
-	for _, sub := range subEntries {
-		if sub.IsDir() && m.IsValid(filepath.Join(taskDirPath, sub.Name())) {
-			return false // At least one valid worktree
-		}
-	}
-	return true
-}
-
 // isGitRepo checks if a path is a Git repository.
 func (m *Manager) isGitRepo(path string) bool {
 	gitDir := filepath.Join(path, ".git")

--- a/apps/backend/internal/worktree/manager.go
+++ b/apps/backend/internal/worktree/manager.go
@@ -87,15 +87,6 @@ func NewManager(cfg Config, store Store, log *logger.Logger) (*Manager, error) {
 		log = logger.Default()
 	}
 
-	// Ensure base directory exists
-	basePath, err := cfg.ExpandedBasePath()
-	if err != nil {
-		return nil, fmt.Errorf("failed to expand base path: %w", err)
-	}
-	if err := os.MkdirAll(basePath, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create worktree base directory: %w", err)
-	}
-
 	// Ensure tasks base directory exists (if configured)
 	if cfg.TasksBasePath != "" {
 		tasksBase, err := cfg.ExpandedTasksBasePath()
@@ -264,67 +255,13 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (*Worktree, err
 		return nil, fmt.Errorf("%w: %s", ErrInvalidBaseBranch, baseRef)
 	}
 
-	// Task-dir mode: place worktree inside ~/.kandev/tasks/{taskDir}/{repo}/
-	if req.TaskDirName != "" && req.RepoName != "" {
-		return m.createInTaskDir(ctx, req, baseRef)
+	// Worktrees are always placed under ~/.kandev/tasks/{taskDir}/{repo}/.
+	// Callers must populate TaskDirName and RepoName; the legacy flat layout
+	// has been removed, so a missing field is a programming error.
+	if req.TaskDirName == "" || req.RepoName == "" {
+		return nil, ErrTaskDirRequired
 	}
-
-	return m.createWorktree(ctx, req, baseRef)
-}
-
-// createWorktree performs the actual git worktree creation.
-func (m *Manager) createWorktree(ctx context.Context, req CreateRequest, baseRef string) (*Worktree, error) {
-	worktreeDirName, branchName := m.buildWorktreeNames(req)
-	startPoint := baseRef
-
-	// If a checkout branch is specified (e.g. a PR's head branch), fetch it
-	// and try to check it out directly. If the branch is already checked out
-	// in another worktree, fall back to a unique branch with a random suffix.
-	var fetchResult *FetchBranchResult
-	if req.CheckoutBranch != "" {
-		var err error
-		fetchResult, err = m.fetchBranchToLocal(ctx, req.RepositoryPath, req.CheckoutBranch)
-		if err != nil {
-			return nil, err
-		}
-		if fetchResult.StartPoint != "" {
-			startPoint = fetchResult.StartPoint
-		} else {
-			startPoint = req.CheckoutBranch
-		}
-	}
-
-	worktreePath, err := m.config.WorktreePath(worktreeDirName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get worktree path: %w", err)
-	}
-
-	worktreeID, branchName, err := m.addWorktreeForBranch(ctx, req, worktreePath, branchName, startPoint, baseRef)
-	if err != nil {
-		return nil, err
-	}
-
-	wt := m.buildWorktreeRecord(worktreeID, req, worktreePath, branchName)
-	if fetchResult != nil {
-		wt.FetchWarning = fetchResult.Warning
-		wt.FetchWarningDetail = fetchResult.WarningDetail
-	}
-
-	if err := m.persistAndCacheWorktree(ctx, wt, req, worktreePath); err != nil {
-		return nil, err
-	}
-
-	if err := m.runWorktreeSetupScript(ctx, wt, req.RepositoryPath); err != nil {
-		return nil, err
-	}
-
-	m.logger.Info("created worktree",
-		zap.String("session_id", req.SessionID),
-		zap.String("task_id", req.TaskID),
-		zap.String("path", worktreePath),
-		zap.String("branch", wt.Branch))
-
-	return wt, nil
+	return m.createInTaskDir(ctx, req, baseRef)
 }
 
 // createInTaskDir creates a worktree inside the task directory structure:
@@ -1125,53 +1062,8 @@ func (m *Manager) OnTaskDeleted(ctx context.Context, taskID string) error {
 }
 
 // Reconcile syncs worktree state with active tasks on startup.
-func (m *Manager) Reconcile(ctx context.Context, activeTasks []string) error {
-	basePath, err := m.config.ExpandedBasePath()
-	if err != nil {
-		return fmt.Errorf("failed to expand base path: %w", err)
-	}
-
-	// Create a set of active task IDs
-	activeSet := make(map[string]bool)
-	for _, taskID := range activeTasks {
-		activeSet[taskID] = true
-	}
-
-	// Scan worktree directories
-	entries, err := os.ReadDir(basePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // No worktrees directory yet
-		}
-		return fmt.Errorf("failed to read worktree directory: %w", err)
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		taskID := entry.Name()
-		worktreePath := filepath.Join(basePath, taskID)
-
-		if !activeSet[taskID] {
-			// Orphaned worktree - no matching active task
-			m.logger.Info("cleaning up orphaned worktree",
-				zap.String("task_id", taskID),
-				zap.String("path", worktreePath))
-
-			// Remove directory
-			if err := os.RemoveAll(worktreePath); err != nil {
-				m.logger.Warn("failed to remove orphaned worktree",
-					zap.String("path", worktreePath),
-					zap.Error(err))
-			}
-		}
-	}
-
-	// Also scan the tasks directory for orphaned task directories
+func (m *Manager) Reconcile(ctx context.Context) error {
 	m.reconcileTasksDir(ctx)
-
 	return nil
 }
 
@@ -1484,9 +1376,11 @@ func (m *Manager) recreate(ctx context.Context, existing *Worktree, req CreateRe
 		m.releaseRepoLock(req.RepositoryPath)
 	}()
 
-	worktreePath, err := m.config.WorktreePath(req.TaskID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get worktree path: %w", err)
+	// Reuse the original on-disk path so the worktree is recreated in the
+	// same task-dir slot it was first created in.
+	worktreePath := existing.Path
+	if worktreePath == "" {
+		return nil, fmt.Errorf("cannot recreate worktree: existing record has no path")
 	}
 
 	// Try to add worktree using existing branch

--- a/apps/backend/internal/worktree/manager_checkout_branch_test.go
+++ b/apps/backend/internal/worktree/manager_checkout_branch_test.go
@@ -30,6 +30,8 @@ func TestCreateWorktree_CheckoutBranchDirectCheckout(t *testing.T) {
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
 		CheckoutBranch: "feature/pr-branch",
+		TaskDirName:    "task-1",
+		RepoName:       "repo-1",
 	})
 	if err != nil {
 		t.Fatalf("Create() unexpected error: %v", err)
@@ -74,6 +76,8 @@ func TestCreateWorktree_CheckoutBranchFallsBackToSuffix(t *testing.T) {
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
 		CheckoutBranch: "feature/pr-branch",
+		TaskDirName:    "task-1",
+		RepoName:       "repo-1",
 	})
 	if err != nil {
 		t.Fatalf("Create() first worktree: %v", err)
@@ -91,6 +95,8 @@ func TestCreateWorktree_CheckoutBranchFallsBackToSuffix(t *testing.T) {
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
 		CheckoutBranch: "feature/pr-branch",
+		TaskDirName:    "task-2",
+		RepoName:       "repo-1",
 	})
 	if err != nil {
 		t.Fatalf("Create() second worktree: %v", err)
@@ -135,6 +141,8 @@ func TestCreateWorktree_CheckoutBranchNoFetchWarningWithRemote(t *testing.T) {
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
 		CheckoutBranch: "feature/pr-branch",
+		TaskDirName:    "task-1",
+		RepoName:       "repo-1",
 	})
 	if err != nil {
 		t.Fatalf("Create() first worktree: %v", err)
@@ -157,6 +165,8 @@ func TestCreateWorktree_CheckoutBranchNoFetchWarningWithRemote(t *testing.T) {
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
 		CheckoutBranch: "feature/pr-branch",
+		TaskDirName:    "task-2",
+		RepoName:       "repo-1",
 	})
 	if err != nil {
 		t.Fatalf("Create() second worktree: %v", err)
@@ -218,6 +228,8 @@ func TestCreateWorktree_RemoteBaseRefDoesNotSetUpstream(t *testing.T) {
 		RepositoryID:   "repo-1",
 		RepositoryPath: repoPath,
 		BaseBranch:     "origin/feature/pr-branch",
+		TaskDirName:    "task-1",
+		RepoName:       "repo-1",
 	})
 	if err != nil {
 		t.Fatalf("Create() unexpected error: %v", err)

--- a/apps/backend/internal/worktree/manager_taskdir_checkout_branch_test.go
+++ b/apps/backend/internal/worktree/manager_taskdir_checkout_branch_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestCreateInTaskDir_CheckoutBranchUsesRemoteStartPointAndUpstream(t *testing.T) {
 	cfg := newTestConfig(t)
-	cfg.TasksBasePath = cfg.BasePath
 	log := newTestLogger()
 	store := newMockStore()
 
@@ -78,7 +77,6 @@ func TestCreateInTaskDir_CheckoutBranchUsesRemoteStartPointAndUpstream(t *testin
 
 func TestCreateInTaskDir_RemoteBaseRefDoesNotSetUpstream(t *testing.T) {
 	cfg := newTestConfig(t)
-	cfg.TasksBasePath = cfg.BasePath
 	log := newTestLogger()
 	store := newMockStore()
 

--- a/apps/backend/internal/worktree/manager_test.go
+++ b/apps/backend/internal/worktree/manager_test.go
@@ -23,9 +23,9 @@ func newTestLogger() *logger.Logger {
 func newTestConfig(t *testing.T) Config {
 	tmpDir := t.TempDir()
 	return Config{
-		Enabled:      true,
-		BasePath:     tmpDir,
-		BranchPrefix: "kandev/",
+		Enabled:       true,
+		TasksBasePath: tmpDir,
+		BranchPrefix:  "kandev/",
 	}
 }
 
@@ -147,8 +147,8 @@ func TestNewManager_CustomSyncTimeouts(t *testing.T) {
 func TestNewManager_DisabledConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := Config{
-		Enabled:  false,
-		BasePath: tmpDir,
+		Enabled:       false,
+		TasksBasePath: tmpDir,
 	}
 	log := newTestLogger()
 	store := newMockStore()
@@ -178,7 +178,7 @@ func TestManager_IsValid(t *testing.T) {
 	}
 
 	// Create a mock worktree directory
-	worktreePath := filepath.Join(cfg.BasePath, "test-worktree")
+	worktreePath := filepath.Join(cfg.TasksBasePath, "test-worktree")
 	if err := os.MkdirAll(worktreePath, 0755); err != nil {
 		t.Fatalf("failed to create test dir: %v", err)
 	}

--- a/apps/backend/internal/worktree/manager_test.go
+++ b/apps/backend/internal/worktree/manager_test.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -934,6 +935,57 @@ esac
 	}
 	if !strings.Contains(err.Error(), "couldn't find remote ref") {
 		t.Fatalf("expected error to contain git output, got: %v", err)
+	}
+}
+
+// TestCreate_MissingTaskDirFields_ReturnsErrTaskDirRequired locks in the guard
+// added when the legacy flat layout was removed. Worktrees must be placed
+// inside the per-task directory; a request without TaskDirName or RepoName
+// is a programming error and must surface loudly rather than fall back.
+func TestCreate_MissingTaskDirFields_ReturnsErrTaskDirRequired(t *testing.T) {
+	cfg := newTestConfig(t)
+	mgr, err := NewManager(cfg, newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+
+	repoPath := initGitRepoForWorktreeTest(t)
+
+	cases := []struct {
+		name string
+		req  CreateRequest
+	}{
+		{
+			name: "missing RepoName",
+			req: CreateRequest{
+				TaskID: "t1", SessionID: "s1",
+				RepositoryPath: repoPath, BaseBranch: "main",
+				TaskDirName: "task-1", RepoName: "",
+			},
+		},
+		{
+			name: "missing TaskDirName",
+			req: CreateRequest{
+				TaskID: "t2", SessionID: "s2",
+				RepositoryPath: repoPath, BaseBranch: "main",
+				TaskDirName: "", RepoName: "repo-1",
+			},
+		},
+		{
+			name: "both missing",
+			req: CreateRequest{
+				TaskID: "t3", SessionID: "s3",
+				RepositoryPath: repoPath, BaseBranch: "main",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := mgr.Create(context.Background(), tc.req)
+			if !errors.Is(err, ErrTaskDirRequired) {
+				t.Fatalf("Create() err = %v, want ErrTaskDirRequired", err)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/worktree/manager_timeout_test.go
+++ b/apps/backend/internal/worktree/manager_timeout_test.go
@@ -136,6 +136,8 @@ func TestCreate_HangingRevParseReleasesRepoLock(t *testing.T) {
 		RepositoryPath:     repoPath,
 		BaseBranch:         "main",
 		PullBeforeWorktree: true,
+		TaskDirName:        "task-a",
+		RepoName:           "repo-a",
 	}
 
 	// Short caller deadline exercises ctx propagation through branchExists

--- a/apps/backend/internal/worktree/provider.go
+++ b/apps/backend/internal/worktree/provider.go
@@ -15,12 +15,10 @@ func Provide(writer, reader *sqlx.DB, cfg *config.Config, log *logger.Logger) (*
 	}
 	wtCfg := Config{
 		Enabled:             cfg.Worktree.Enabled,
-		BasePath:            cfg.Worktree.BasePath,
 		BranchPrefix:        "kandev/",
 		FetchTimeoutSeconds: cfg.Worktree.FetchTimeoutSeconds,
 		PullTimeoutSeconds:  cfg.Worktree.PullTimeoutSeconds,
 	}
-	wtCfg.SetDataDirFallback(cfg.ResolvedHomeDir())
 	wtCfg.SetTasksBasePathFallback(cfg.ResolvedHomeDir())
 	manager, err := NewManager(wtCfg, store, log)
 	if err != nil {

--- a/apps/backend/internal/worktree/submodule_test.go
+++ b/apps/backend/internal/worktree/submodule_test.go
@@ -201,6 +201,8 @@ func TestCreateWorktree_WithSubmodules(t *testing.T) {
 		RepositoryID:   "repo-sub",
 		RepositoryPath: repoPath,
 		BaseBranch:     "main",
+		TaskDirName:    "sub-task-1",
+		RepoName:       "repo-sub",
 	})
 	if err != nil {
 		t.Fatalf("Create() failed: %v", err)


### PR DESCRIPTION
## Summary

- Every worktree creation now routes through the per-task layout (`~/.kandev/tasks/{title}_{suffix}/{repo}/`); the legacy flat layout under `~/.kandev/worktrees/` has been unreachable since `applyRepositoryConfig` started populating `TaskDirName` / `RepoName` unconditionally.
- Removes the dead code that backed the flat layout: `Config.BasePath` / `WorktreePath` / `ExpandedBasePath` / `SetDataDirFallback`, `WorktreeConfig.BasePath` and its viper default, `Manager.createWorktree`, and the flat-layout branch of `Manager.Reconcile`.
- `Manager.Create` now returns a new `ErrTaskDirRequired` if `TaskDirName` or `RepoName` is missing, so any future regression surfaces loudly instead of silently falling back. `Manager.recreate` reuses the original `existing.Path` (which is already in task-dir layout) instead of recomputing a flat-layout path.
- On-disk `~/.kandev/worktrees/` is **not** touched — that's user machine state, not code.

## Test plan

- [x] `make -C apps/backend fmt`
- [x] `make -C apps/backend vet`
- [x] `make -C apps/backend test` — all packages pass; flat-layout test setups (`gitcrypt_test`, `submodule_test`, `manager_checkout_branch_test`, `manager_timeout_test`) ported to populate `TaskDirName` / `RepoName`.
- [x] `make -C apps/backend lint` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)