### PR TITLE
fix(settings): toggle off default-on curated CLI flags

### DIFF
--- a/apps/backend/internal/task/repository/sqlite/base.go
+++ b/apps/backend/internal/task/repository/sqlite/base.go
@@ -659,8 +659,8 @@ func (r *Repository) backfillInitialPlanRevisions() error {
 	for _, x := range pending {
 		authorKind := x.createdBy
 		// Match CreateTaskPlan (plan.go) and the task_plan_revisions column DEFAULT 'agent'.
-		if authorKind != "user" && authorKind != "agent" {
-			authorKind = "agent"
+		if authorKind != "user" && authorKind != authorKindAgent {
+			authorKind = authorKindAgent
 		}
 		_, err := r.db.Exec(r.db.Rebind(`
 			INSERT INTO task_plan_revisions

--- a/apps/backend/internal/task/repository/sqlite/plan.go
+++ b/apps/backend/internal/task/repository/sqlite/plan.go
@@ -15,6 +15,10 @@ import (
 // every SELECT in this file (and by scanRevisionRow / scanRevisionRows).
 const revisionSelectCols = `id, task_id, revision_number, title, content, author_kind, author_name, revert_of_revision_id, created_at, updated_at`
 
+// authorKindAgent matches the task_plan_revisions.author_kind column DEFAULT
+// and is the fallback for unknown values when persisting plan history rows.
+const authorKindAgent = "agent"
+
 // CreateTaskPlan creates a new task plan.
 func (r *Repository) CreateTaskPlan(ctx context.Context, plan *models.TaskPlan) error {
 	if plan.ID == "" {
@@ -28,7 +32,7 @@ func (r *Repository) CreateTaskPlan(ctx context.Context, plan *models.TaskPlan) 
 		plan.Title = "Plan"
 	}
 	if plan.CreatedBy == "" {
-		plan.CreatedBy = "agent"
+		plan.CreatedBy = authorKindAgent
 	}
 
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
@@ -250,7 +254,7 @@ func upsertPlanHead(ctx context.Context, tx *sqlx.Tx, db *sqlx.DB, head *models.
 		head.Title = "Plan"
 	}
 	if head.CreatedBy == "" {
-		head.CreatedBy = "agent"
+		head.CreatedBy = authorKindAgent
 	}
 	if head.CreatedAt.IsZero() {
 		head.CreatedAt = now

--- a/apps/web/app/settings/agents/[agentId]/page.tsx
+++ b/apps/web/app/settings/agents/[agentId]/page.tsx
@@ -15,6 +15,7 @@ import type {
   ModelConfig,
 } from "@/lib/types/http";
 import { buildDefaultPermissions } from "@/lib/agent-permissions";
+import { seedDefaultCLIFlags } from "@/lib/cli-flags";
 import { generateUUID } from "@/lib/utils";
 import { useAppStore } from "@/components/state-provider";
 import { useAvailableAgents } from "@/hooks/domains/settings/use-available-agents";
@@ -51,7 +52,7 @@ const createDraftProfile = (
   model: defaultModel,
   ...buildDefaultPermissions(permissionSettings ?? {}),
   cli_passthrough: false,
-  cli_flags: [],
+  cli_flags: seedDefaultCLIFlags(permissionSettings ?? {}),
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
   isNew: true,

--- a/apps/web/components/settings/cli-flags-field.test.tsx
+++ b/apps/web/components/settings/cli-flags-field.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { CLIFlagsField } from "./cli-flags-field";
+import type { CLIFlag, PermissionSetting } from "@/lib/types/http";
+
+const ALLOW_INDEXING_FLAG = "--allow-indexing";
+const ALLOW_INDEXING_DESC = "Enable workspace indexing without confirmation";
+const CURATED_SWITCH_TESTID = "cli-flag-curated-enabled-allow_indexing";
+
+// Curated permission whose default is ON — mirrors auggie's --allow-indexing.
+// Reproduces the original bug: default-on switches couldn't be toggled off
+// because no entry existed in cli_flags and the toggle short-circuited.
+const allowIndexing: PermissionSetting = {
+  supported: true,
+  default: true,
+  label: "Allow indexing",
+  description: ALLOW_INDEXING_DESC,
+  apply_method: "cli_flag",
+  cli_flag: ALLOW_INDEXING_FLAG,
+};
+
+const onChange = vi.fn();
+
+beforeEach(() => {
+  onChange.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CLIFlagsField — curated toggles", () => {
+  it("renders curated switch as checked when no entry exists and default is true", () => {
+    const { getByTestId } = render(
+      <CLIFlagsField
+        flags={[]}
+        onChange={onChange}
+        permissionSettings={{ allow_indexing: allowIndexing }}
+      />,
+    );
+    expect(getByTestId(CURATED_SWITCH_TESTID).getAttribute("data-state")).toBe("checked");
+  });
+
+  it("turning a default-on curated flag OFF persists an explicit { enabled: false } entry", () => {
+    // This is the regression test for the original bug. Before the fix the
+    // toggle short-circuited (`if (!enabled) return; // nothing to turn off`)
+    // and onChange was never called, leaving the switch visually stuck ON.
+    const { getByTestId } = render(
+      <CLIFlagsField
+        flags={[]}
+        onChange={onChange}
+        permissionSettings={{ allow_indexing: allowIndexing }}
+      />,
+    );
+    fireEvent.click(getByTestId(CURATED_SWITCH_TESTID));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([
+      { flag: ALLOW_INDEXING_FLAG, description: ALLOW_INDEXING_DESC, enabled: false },
+    ]);
+  });
+
+  it("turning a default-off curated flag ON appends an { enabled: true } entry", () => {
+    const setting: PermissionSetting = { ...allowIndexing, default: false };
+    const { getByTestId } = render(
+      <CLIFlagsField
+        flags={[]}
+        onChange={onChange}
+        permissionSettings={{ allow_indexing: setting }}
+      />,
+    );
+    const sw = getByTestId(CURATED_SWITCH_TESTID);
+    expect(sw.getAttribute("data-state")).toBe("unchecked");
+    fireEvent.click(sw);
+    expect(onChange).toHaveBeenCalledWith([
+      { flag: ALLOW_INDEXING_FLAG, description: ALLOW_INDEXING_DESC, enabled: true },
+    ]);
+  });
+
+  it("toggles existing curated entry in place without duplicating it", () => {
+    const existing: CLIFlag[] = [
+      { flag: ALLOW_INDEXING_FLAG, description: "previous", enabled: true },
+    ];
+    const { getByTestId } = render(
+      <CLIFlagsField
+        flags={existing}
+        onChange={onChange}
+        permissionSettings={{ allow_indexing: allowIndexing }}
+      />,
+    );
+    fireEvent.click(getByTestId(CURATED_SWITCH_TESTID));
+    expect(onChange).toHaveBeenCalledWith([
+      { flag: ALLOW_INDEXING_FLAG, description: "previous", enabled: false },
+    ]);
+  });
+
+  it("reads switch state from the existing entry over setting.default", () => {
+    const existing: CLIFlag[] = [
+      { flag: ALLOW_INDEXING_FLAG, description: "previous", enabled: false },
+    ];
+    const { getByTestId } = render(
+      <CLIFlagsField
+        flags={existing}
+        onChange={onChange}
+        permissionSettings={{ allow_indexing: allowIndexing }}
+      />,
+    );
+    expect(getByTestId(CURATED_SWITCH_TESTID).getAttribute("data-state")).toBe("unchecked");
+  });
+});

--- a/apps/web/components/settings/cli-flags-field.tsx
+++ b/apps/web/components/settings/cli-flags-field.tsx
@@ -74,8 +74,10 @@ export function CLIFlagsField({
       onChange(flags.map((f, i) => (i === existingIdx ? { ...f, enabled } : f)));
       return;
     }
-    if (!enabled) return; // nothing to turn off
-    onChange([...flags, { flag: setting.flag, description: setting.description, enabled: true }]);
+    // No existing entry: append an explicit record. The displayed switch
+    // state derives from setting.default when absent, so we must persist
+    // the user's choice (even when turning off) to actually flip it.
+    onChange([...flags, { flag: setting.flag, description: setting.description, enabled }]);
   };
 
   const toggleAt = (index: number, enabled: boolean) => {

--- a/apps/web/lib/cli-flags.test.ts
+++ b/apps/web/lib/cli-flags.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { areCLIFlagsEqual } from "./cli-flags";
-import type { CLIFlag } from "@/lib/types/http";
+import { areCLIFlagsEqual, seedDefaultCLIFlags } from "./cli-flags";
+import type { CLIFlag, PermissionSetting } from "@/lib/types/http";
 
 const flag = (f: string, enabled = true, description = ""): CLIFlag => ({
   flag: f,
@@ -46,5 +46,63 @@ describe("areCLIFlagsEqual", () => {
     const a = [flag("--a"), flag("--b")];
     const b = [flag("--b"), flag("--a")];
     expect(areCLIFlagsEqual(a, b)).toBe(false);
+  });
+});
+
+const setting = (overrides: Partial<PermissionSetting> = {}): PermissionSetting => ({
+  supported: true,
+  default: true,
+  label: "Allow indexing",
+  description: "Enable workspace indexing without confirmation",
+  apply_method: "cli_flag",
+  cli_flag: "--allow-indexing",
+  ...overrides,
+});
+
+describe("seedDefaultCLIFlags", () => {
+  it("returns empty list when no permission settings target a CLI flag", () => {
+    expect(seedDefaultCLIFlags({})).toEqual([]);
+  });
+
+  it("seeds curated cli_flag entries with their defaults", () => {
+    const out = seedDefaultCLIFlags({ allow_indexing: setting() });
+    expect(out).toEqual([
+      {
+        description: "Enable workspace indexing without confirmation",
+        flag: "--allow-indexing",
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("skips unsupported, non-cli_flag, and missing-cli_flag entries", () => {
+    const out = seedDefaultCLIFlags({
+      unsupported: setting({ supported: false }),
+      modeBased: setting({ apply_method: "mode" }),
+      missingFlag: setting({ cli_flag: "" }),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("appends cli_flag_value to flag text when present", () => {
+    const out = seedDefaultCLIFlags({
+      allow_all: setting({ cli_flag: "--allow", cli_flag_value: "all" }),
+    });
+    expect(out[0].flag).toBe("--allow all");
+  });
+
+  it("falls back to label when description is empty", () => {
+    const out = seedDefaultCLIFlags({
+      allow_indexing: setting({ description: "" }),
+    });
+    expect(out[0].description).toBe("Allow indexing");
+  });
+
+  it("sorts results by flag text for stable order", () => {
+    const out = seedDefaultCLIFlags({
+      b: setting({ cli_flag: "--b-flag" }),
+      a: setting({ cli_flag: "--a-flag" }),
+    });
+    expect(out.map((f) => f.flag)).toEqual(["--a-flag", "--b-flag"]);
   });
 });

--- a/apps/web/lib/cli-flags.ts
+++ b/apps/web/lib/cli-flags.ts
@@ -1,4 +1,4 @@
-import type { CLIFlag } from "@/lib/types/http";
+import type { CLIFlag, PermissionSetting } from "@/lib/types/http";
 
 /**
  * Deep-equality comparison for a profile's cli_flags list. Used by the
@@ -23,4 +23,30 @@ export function areCLIFlagsEqual(
     }
   }
   return true;
+}
+
+/**
+ * Build the default cli_flags list for a new draft profile from the
+ * agent's curated PermissionSettings catalogue. Mirrors the backend
+ * seedCLIFlags in apps/backend/internal/agent/settings/controller/profile_crud.go
+ * so a draft created in the UI matches what the backend would seed when
+ * the field is omitted from a create request. Only entries that target a
+ * CLI flag are included; per-flag metadata (description, flag text,
+ * default enabled) is copied so the draft is self-contained.
+ */
+export function seedDefaultCLIFlags(
+  permissionSettings: Record<string, PermissionSetting>,
+): CLIFlag[] {
+  const out: CLIFlag[] = [];
+  for (const s of Object.values(permissionSettings)) {
+    if (!s.supported || s.apply_method !== "cli_flag" || !s.cli_flag) continue;
+    const flagText = s.cli_flag_value ? `${s.cli_flag} ${s.cli_flag_value}` : s.cli_flag;
+    out.push({
+      description: s.description || s.label,
+      flag: flagText,
+      enabled: s.default,
+    });
+  }
+  out.sort((a, b) => a.flag.localeCompare(b.flag));
+  return out;
 }


### PR DESCRIPTION
The Allow Indexing switch (and any curated default-on `cli_flag` permission) couldn't be turned off on freshly created agent profiles, leaving users with no way to opt out of the default. Toggling now persists the user's choice and new draft profiles seed defaults to match what the backend would produce.

## Important Changes

- `toggleCurated` no longer short-circuits when disabling a curated flag with no existing entry; it appends an explicit `{ enabled: false }` record so the off state is persisted.
- `seedDefaultCLIFlags` mirrors the backend's `seedCLIFlags` on the frontend so new draft profiles start with the curated CLI flags pre-populated, instead of sending `cli_flags: []` which bypassed backend default-seeding.

## Validation

- `make -C apps/backend fmt test lint`
- `cd apps && pnpm format`
- `pnpm exec tsc --noEmit` in `apps/web`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` — 618/618 passing, including 5 new component tests for the curated toggle and 6 new tests for `seedDefaultCLIFlags`

## Possible Improvements

Low risk — pure frontend draft-state change plus a tightening of the toggle handler. The backend persistence path is unchanged. Worst case is a regression in how custom (non-curated) flags interact with the curated section, which the new component tests guard against.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.