### PR TITLE
feat(filters): add 'Has PR' task sidebar filter

### DIFF
--- a/apps/web/components/task/sidebar-filter/filter-dimension-registry.ts
+++ b/apps/web/components/task/sidebar-filter/filter-dimension-registry.ts
@@ -53,6 +53,14 @@ export const DIMENSION_METAS: DimensionMeta[] = [
     defaultValue: true,
   },
   {
+    dimension: "hasPR",
+    label: "Has PR",
+    valueKind: "boolean",
+    ops: ["is", "is_not"],
+    defaultOp: "is",
+    defaultValue: true,
+  },
+  {
     dimension: "state",
     label: "State",
     valueKind: "enum",

--- a/apps/web/lib/sidebar/apply-view.test.ts
+++ b/apps/web/lib/sidebar/apply-view.test.ts
@@ -21,6 +21,26 @@ describe("applyFilters — basics", () => {
   });
 });
 
+describe("applyFilters — hasPR", () => {
+  it("filters by hasPR is true (task with linked PR)", () => {
+    const tasks = [task({ id: "a", prInfo: { number: 1, state: "Open" } }), task({ id: "b" })];
+    const out = applyFilters(tasks, [C({ dimension: "hasPR", op: "is", value: true })]);
+    expect(out.map((t) => t.id)).toEqual(["a"]);
+  });
+
+  it("filters by hasPR is false (task without linked PR)", () => {
+    const tasks = [task({ id: "a", prInfo: { number: 1, state: "Open" } }), task({ id: "b" })];
+    const out = applyFilters(tasks, [C({ dimension: "hasPR", op: "is", value: false })]);
+    expect(out.map((t) => t.id)).toEqual(["b"]);
+  });
+
+  it("supports is_not negation on hasPR", () => {
+    const tasks = [task({ id: "a", prInfo: { number: 1, state: "Open" } }), task({ id: "b" })];
+    const out = applyFilters(tasks, [C({ dimension: "hasPR", op: "is_not", value: true })]);
+    expect(out.map((t) => t.id)).toEqual(["b"]);
+  });
+});
+
 describe("applyFilters — per-dimension", () => {
   it("filters by isPRReview is true (watcher-created task)", () => {
     const tasks = [task({ id: "a", isPRReview: true }), task({ id: "b" })];

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -46,6 +46,7 @@ const dimensionExtractors: Record<FilterDimension, DimensionExtractor> = {
     const ds = t.diffStats;
     return !!ds && (ds.additions > 0 || ds.deletions > 0);
   },
+  hasPR: (t) => !!t.prInfo,
   isPRReview: (t) => t.isPRReview === true,
   isIssueWatch: (t) => t.isIssueWatch === true,
   titleMatch: (t) => t.title ?? "",

--- a/apps/web/lib/state/slices/ui/sidebar-view-types.ts
+++ b/apps/web/lib/state/slices/ui/sidebar-view-types.ts
@@ -6,6 +6,7 @@ export type FilterDimension =
   | "executorType"
   | "repository"
   | "hasDiff"
+  | "hasPR"
   | "isPRReview"
   | "isIssueWatch"
   | "titleMatch";


### PR DESCRIPTION
Users had no way to narrow the task sidebar to tasks with a linked GitHub PR — the existing `PR review` filter only matches watcher-created tasks, not regular tasks that have since acquired a PR. Adds a new boolean `Has PR` filter that toggles tasks based on whether `prInfo` is present on the sidebar item.

## Validation

- `pnpm --filter @kandev/web test` — 621/621 pass, including 3 new tests covering `is true`, `is false`, and `is_not` cases for `hasPR`
- `pnpm format`, `pnpm lint --max-warnings 0`, `tsc --noEmit` — clean

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.