### PR TITLE
fix(web): scope settings workflow list to current workspace

### DIFF
--- a/apps/web/app/settings/workspace/workspace-workflows-client.tsx
+++ b/apps/web/app/settings/workspace/workspace-workflows-client.tsx
@@ -504,7 +504,7 @@ function useWorkspaceWorkflowsPage(
   const router = useRouter();
   const { toast } = useToast();
   const { workflowItems, setWorkflowItems, setSavedWorkflowItems, isWorkflowDirty } =
-    useWorkflowSettings(workflows);
+    useWorkflowSettings(workflows, workspace?.id);
 
   const importExport = useWorkflowImportExport(workspace, router, toast);
   const {

--- a/apps/web/hooks/domains/settings/use-workflow-settings.test.ts
+++ b/apps/web/hooks/domains/settings/use-workflow-settings.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Workflow } from "@/lib/types/http";
+
+type StoreWorkflow = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  description?: string | null;
+};
+
+type MockState = { workflows: { items: StoreWorkflow[] } };
+
+let mockState: MockState = { workflows: { items: [] } };
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: MockState) => unknown) => selector(mockState),
+}));
+
+import { useWorkflowSettings } from "./use-workflow-settings";
+
+function setStore(items: StoreWorkflow[]) {
+  mockState = { workflows: { items } };
+}
+
+const wf = (id: string, workspaceId: string, name: string): Workflow => ({
+  id,
+  workspace_id: workspaceId,
+  name,
+  description: "",
+  created_at: "",
+  updated_at: "",
+});
+
+const NAME_A1 = "Workflow A1";
+const NAME_B1 = "Workflow B1";
+const STORE_A1: StoreWorkflow = { id: "wf-a1", workspaceId: "ws-a", name: NAME_A1 };
+const STORE_B1: StoreWorkflow = { id: "wf-b1", workspaceId: "ws-b", name: NAME_B1 };
+
+beforeEach(() => {
+  setStore([]);
+});
+
+describe("useWorkflowSettings", () => {
+  it("does not include workflows from other workspaces present in the global store", () => {
+    // Store has a workflow from workspace A (e.g. user previously visited it)
+    setStore([STORE_A1]);
+
+    // We render the settings hook for workspace B with no initial workflows
+    const { result } = renderHook(() => useWorkflowSettings([], "ws-b"));
+
+    // The leaked workflow from workspace A must not appear in B's list
+    expect(result.current.workflowItems).toHaveLength(0);
+    expect(result.current.savedWorkflowItems).toHaveLength(0);
+  });
+
+  it("adds workflows from the store that belong to the current workspace", () => {
+    setStore([STORE_A1, STORE_B1]);
+
+    const { result } = renderHook(() => useWorkflowSettings([], "ws-b"));
+
+    expect(result.current.workflowItems.map((w) => w.id)).toEqual(["wf-b1"]);
+  });
+
+  it("does not remove a workspace's workflows when an unrelated workspace's entries are added/removed in the store", () => {
+    // Initial: workspace B has one saved workflow from SSR
+    const initial = [wf("wf-b1", "ws-b", NAME_B1)];
+    setStore([STORE_B1]);
+
+    const { result, rerender } = renderHook(
+      ({ store }: { store: StoreWorkflow[] }) => {
+        setStore(store);
+        return useWorkflowSettings(initial, "ws-b");
+      },
+      { initialProps: { store: [STORE_B1] } },
+    );
+
+    expect(result.current.workflowItems.map((w) => w.id)).toEqual(["wf-b1"]);
+
+    // Workspace A workflow is added to the store (e.g. WS event from another tab)
+    act(() => {
+      rerender({ store: [STORE_B1, STORE_A1] });
+    });
+    expect(result.current.workflowItems.map((w) => w.id)).toEqual(["wf-b1"]);
+
+    // Workspace A workflow is removed from the store — must not affect B's list
+    act(() => {
+      rerender({ store: [STORE_B1] });
+    });
+    expect(result.current.workflowItems.map((w) => w.id)).toEqual(["wf-b1"]);
+  });
+
+  it("falls back to the unscoped store when no workspaceId is provided", () => {
+    setStore([STORE_A1, STORE_B1]);
+
+    const { result } = renderHook(() => useWorkflowSettings([]));
+
+    expect(result.current.workflowItems.map((w) => w.id).sort()).toEqual(["wf-a1", "wf-b1"]);
+  });
+});

--- a/apps/web/hooks/domains/settings/use-workflow-settings.test.ts
+++ b/apps/web/hooks/domains/settings/use-workflow-settings.test.ts
@@ -97,4 +97,44 @@ describe("useWorkflowSettings", () => {
 
     expect(result.current.workflowItems.map((w) => w.id).sort()).toEqual(["wf-a1", "wf-b1"]);
   });
+
+  it("syncs name updates from the store within the current workspace", () => {
+    const initial = [wf("wf-b1", "ws-b", NAME_B1)];
+    setStore([STORE_B1]);
+
+    const { result, rerender } = renderHook(
+      ({ store }: { store: StoreWorkflow[] }) => {
+        setStore(store);
+        return useWorkflowSettings(initial, "ws-b");
+      },
+      { initialProps: { store: [STORE_B1] } },
+    );
+
+    expect(result.current.workflowItems[0].name).toEqual(NAME_B1);
+
+    act(() => {
+      rerender({ store: [{ id: "wf-b1", workspaceId: "ws-b", name: "Renamed B1" }] });
+    });
+
+    expect(result.current.workflowItems[0].name).toEqual("Renamed B1");
+  });
+
+  it("starts scoping store entries once a workspaceId becomes defined", () => {
+    setStore([STORE_A1, STORE_B1]);
+
+    const { result, rerender } = renderHook(
+      ({ workspaceId }: { workspaceId?: string }) => useWorkflowSettings([], workspaceId),
+      { initialProps: { workspaceId: undefined as string | undefined } },
+    );
+
+    // No workspaceId → unscoped fallback shows both
+    expect(result.current.workflowItems.map((w) => w.id).sort()).toEqual(["wf-a1", "wf-b1"]);
+
+    act(() => {
+      rerender({ workspaceId: "ws-b" });
+    });
+
+    // Once scoped to B, A's workflow is dropped
+    expect(result.current.workflowItems.map((w) => w.id)).toEqual(["wf-b1"]);
+  });
 });

--- a/apps/web/hooks/domains/settings/use-workflow-settings.ts
+++ b/apps/web/hooks/domains/settings/use-workflow-settings.ts
@@ -7,9 +7,18 @@ import type { Workflow } from "@/lib/types/http";
 /**
  * Manages workflow list state for the settings page, synced with WS events
  * from the Zustand store. Supports local edits (dirty tracking) and temp drafts.
+ *
+ * `workspaceId` scopes the visible workflows to the current workspace so that
+ * stale entries from previously visited workspaces (still cached in the global
+ * Zustand store) don't leak into another workspace's settings page.
  */
-export function useWorkflowSettings(initialWorkflows: Workflow[]) {
+export function useWorkflowSettings(initialWorkflows: Workflow[], workspaceId?: string) {
   const storeWorkflows = useAppStore((state) => state.workflows.items);
+  const scopedStoreWorkflows = useMemo(
+    () =>
+      workspaceId ? storeWorkflows.filter((w) => w.workspaceId === workspaceId) : storeWorkflows,
+    [storeWorkflows, workspaceId],
+  );
   const [workflowItems, setWorkflowItems] = useState<Workflow[]>(initialWorkflows);
   const [savedWorkflowItems, setSavedWorkflowItems] = useState<Workflow[]>(initialWorkflows);
 
@@ -45,7 +54,7 @@ export function useWorkflowSettings(initialWorkflows: Workflow[]) {
   const prevStoreIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    const currentStoreIds = new Set(storeWorkflows.map((w) => w.id));
+    const currentStoreIds = new Set(scopedStoreWorkflows.map((w) => w.id));
     const prevStoreIds = prevStoreIdsRef.current;
 
     // IDs that were in the store last render but are gone now → actually deleted via WS.
@@ -60,7 +69,7 @@ export function useWorkflowSettings(initialWorkflows: Workflow[]) {
       const tempWorkspaceIds = new Set(
         prev.filter((w) => w.id.startsWith("temp-")).map((w) => w.workspace_id),
       );
-      return storeWorkflows
+      return scopedStoreWorkflows
         .filter((sw) => !localIds.has(sw.id) && !tempWorkspaceIds.has(sw.workspaceId))
         .map((sw) => storeItemToWorkflow(sw));
     };
@@ -72,7 +81,7 @@ export function useWorkflowSettings(initialWorkflows: Workflow[]) {
       const filtered = prev.filter((w) => !deletedIds.has(w.id));
       const updated = filtered.map((w) => {
         if (w.id.startsWith("temp-")) return w;
-        const sw = storeWorkflows.find((s) => s.id === w.id);
+        const sw = scopedStoreWorkflows.find((s) => s.id === w.id);
         if (sw && sw.name !== w.name) return { ...w, name: sw.name };
         return w;
       });
@@ -93,7 +102,7 @@ export function useWorkflowSettings(initialWorkflows: Workflow[]) {
       if (toAdd.length === 0 && filtered.length === prev.length) return prev;
       return [...toAdd, ...filtered];
     });
-  }, [storeWorkflows]);
+  }, [scopedStoreWorkflows]);
 
   const savedWorkflowsById = useMemo(() => {
     return new Map(savedWorkflowItems.map((w) => [w.id, w]));


### PR DESCRIPTION
Workflows from a previously-visited workspace leaked into a new workspace's settings page because the global Zustand store was never filtered by workspace, and "deleting" a leaked entry issued a real DELETE against the original workspace's workflow — wiping it from both. The settings hook now scopes store reads to the current workspace, so each workspace shows only its own workflows.

## Validation

- `pnpm --filter @kandev/web test --run` (622/622 passing, includes new `use-workflow-settings.test.ts`)
- `pnpm --filter @kandev/web lint` (0 warnings)
- `tsc --noEmit` (clean)

## Possible Improvements

Low risk. The hook still falls back to the unscoped store when no `workspaceId` is provided, preserving behaviour for any other (non-settings) caller. A follow-up could clear `workflows.items` on workspace switch to harden other consumers.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.