### PR TITLE
fix: restore release changelog boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ All notable changes to Kandev.
 
 ### Bug Fixes
 
-- release script tags fetching
+- release script tags fetching ([986410ab](https://github.com/kdlbs/kandev/commit/986410ab2ebb1cc25e1ad046c9daae18a58cc150))
 - show repo name instead of full path in task sidebar ([#652](https://github.com/kdlbs/kandev/pull/652))
 - unstick agent session when cancel times out ([#651](https://github.com/kdlbs/kandev/pull/651))
 - anchor PR detail panel to session group on auto-open ([#646](https://github.com/kdlbs/kandev/pull/646))
@@ -1155,5 +1155,4 @@ All notable changes to Kandev.
 ### Merge
 
 - resolve conflicts with main
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,27 +16,6 @@ All notable changes to Kandev.
 - auto-open plan panel with unseen-changes indicator ([#650](https://github.com/kdlbs/kandev/pull/650))
 - add /spec for writing feature specs ([#700](https://github.com/kdlbs/kandev/pull/700))
 - support claude-acp Monitor tool and fix incremental tool_call updates ([#698](https://github.com/kdlbs/kandev/pull/698))
-- add GitHub token injection for remote executors and Docker session resume ([#654](https://github.com/kdlbs/kandev/pull/654))
-- add Ctrl+F search to session, plan, and terminal panels ([#686](https://github.com/kdlbs/kandev/pull/686))
-- configurable quick-action presets and PR branch checkout ([#689](https://github.com/kdlbs/kandev/pull/689))
-- add /github page for PRs and issues ([#687](https://github.com/kdlbs/kandev/pull/687))
-- collapse subtasks in sidebar ([#662](https://github.com/kdlbs/kandev/pull/662))
-- review uncommitted changes and add git safety rails ([#684](https://github.com/kdlbs/kandev/pull/684))
-- add issue watcher with task creation and auto-cleanup ([#672](https://github.com/kdlbs/kandev/pull/672))
-- per-launch authentication for agentctl ([#666](https://github.com/kdlbs/kandev/pull/666))
-- configurable CLI flags per agent profile ([#653](https://github.com/kdlbs/kandev/pull/653))
-- session tabs on kanban preview panel ([#648](https://github.com/kdlbs/kandev/pull/648))
-- sidebar filter UX polish — align ops, group steps by workflow ([#647](https://github.com/kdlbs/kandev/pull/647))
-- explain why Start task button is disabled via hover tooltip ([#649](https://github.com/kdlbs/kandev/pull/649))
-- add filter/group/sort and saved views to task sidebar ([#644](https://github.com/kdlbs/kandev/pull/644))
-- vscode-style preview tabs for files, diffs, and commits ([#622](https://github.com/kdlbs/kandev/pull/622))
-- add confirmation dialog before archiving tasks ([#621](https://github.com/kdlbs/kandev/pull/621))
-- introduce card multi-selection ([#573](https://github.com/kdlbs/kandev/pull/573))
-- render short tool-call output inline ([#604](https://github.com/kdlbs/kandev/pull/604))
-- associate agent profiles with workflows and steps ([#597](https://github.com/kdlbs/kandev/pull/597))
-- add start_agent and local_path params to create_task ([#505](https://github.com/kdlbs/kandev/pull/505))
-- acp-first profiles, models, and modes ([#566](https://github.com/kdlbs/kandev/pull/566))
-- add multi-select and drag-to-move for file tree and changes panel ([#490](https://github.com/kdlbs/kandev/pull/490))
 
 ### Bug Fixes
 
@@ -49,6 +28,23 @@ All notable changes to Kandev.
 - align sidebar filter toolbar height with panel headers ([#699](https://github.com/kdlbs/kandev/pull/699))
 - derive sidebar session state from most active session ([#697](https://github.com/kdlbs/kandev/pull/697))
 - auto-resume failed sessions with silent workspace-restore fallback ([#696](https://github.com/kdlbs/kandev/pull/696))
+
+## 0.37 - 2026-04-25
+
+### Features
+
+- add GitHub token injection for remote executors and Docker session resume ([#654](https://github.com/kdlbs/kandev/pull/654))
+- add Ctrl+F search to session, plan, and terminal panels ([#686](https://github.com/kdlbs/kandev/pull/686))
+- configurable quick-action presets and PR branch checkout ([#689](https://github.com/kdlbs/kandev/pull/689))
+- add /github page for PRs and issues ([#687](https://github.com/kdlbs/kandev/pull/687))
+- collapse subtasks in sidebar ([#662](https://github.com/kdlbs/kandev/pull/662))
+- review uncommitted changes and add git safety rails ([#684](https://github.com/kdlbs/kandev/pull/684))
+- add issue watcher with task creation and auto-cleanup ([#672](https://github.com/kdlbs/kandev/pull/672))
+- per-launch authentication for agentctl ([#666](https://github.com/kdlbs/kandev/pull/666))
+- configurable CLI flags per agent profile ([#653](https://github.com/kdlbs/kandev/pull/653))
+
+### Bug Fixes
+
 - ui polish — unified topbar, selector consistency, quick actions editor improvements ([#693](https://github.com/kdlbs/kandev/pull/693))
 - subtask sessions inherit agent profile from parent task ([#692](https://github.com/kdlbs/kandev/pull/692))
 - recover from stale execution ID when auto-starting agent on prepared workspace ([#690](https://github.com/kdlbs/kandev/pull/690))
@@ -62,6 +58,24 @@ All notable changes to Kandev.
 - send auto-start prompt after on_turn_complete context reset ([#669](https://github.com/kdlbs/kandev/pull/669))
 - include archived tasks in completed tasks over time chart ([#668](https://github.com/kdlbs/kandev/pull/668))
 - remove duplicate WebSocket event subscriptions ([#667](https://github.com/kdlbs/kandev/pull/667))
+
+### Refactoring
+
+- unify task.updated via single publisher and shared mapper ([#676](https://github.com/kdlbs/kandev/pull/676))
+- move system prompts from Go constants to external config files ([#673](https://github.com/kdlbs/kandev/pull/673))
+
+### Documentation
+
+- improve commit skill with mandatory verify and pre-commit check ([#691](https://github.com/kdlbs/kandev/pull/691))
+
+## 0.36 - 2026-04-20
+
+### Features
+
+- session tabs on kanban preview panel ([#648](https://github.com/kdlbs/kandev/pull/648))
+
+### Bug Fixes
+
 - prevent kanban topbar search from overlapping right buttons ([#661](https://github.com/kdlbs/kandev/pull/661))
 - enable Start task button when workflow provides agent override ([#665](https://github.com/kdlbs/kandev/pull/665))
 - default dev mode db to <repo>/.kandev-dev/data ([#664](https://github.com/kdlbs/kandev/pull/664))
@@ -72,6 +86,20 @@ All notable changes to Kandev.
 - exclude ephemeral tasks from stats page queries ([#656](https://github.com/kdlbs/kandev/pull/656))
 - add edit icon hint to utility agent rows ([#657](https://github.com/kdlbs/kandev/pull/657))
 - tighten default template prompts for commits, todos, and PR review ([#655](https://github.com/kdlbs/kandev/pull/655))
+
+## 0.35 - 2026-04-20
+
+### Features
+
+- sidebar filter UX polish — align ops, group steps by workflow ([#647](https://github.com/kdlbs/kandev/pull/647))
+- explain why Start task button is disabled via hover tooltip ([#649](https://github.com/kdlbs/kandev/pull/649))
+- add filter/group/sort and saved views to task sidebar ([#644](https://github.com/kdlbs/kandev/pull/644))
+- vscode-style preview tabs for files, diffs, and commits ([#622](https://github.com/kdlbs/kandev/pull/622))
+- add confirmation dialog before archiving tasks ([#621](https://github.com/kdlbs/kandev/pull/621))
+- introduce card multi-selection ([#573](https://github.com/kdlbs/kandev/pull/573))
+
+### Bug Fixes
+
 - release script tags fetching
 - show repo name instead of full path in task sidebar ([#652](https://github.com/kdlbs/kandev/pull/652))
 - unstick agent session when cancel times out ([#651](https://github.com/kdlbs/kandev/pull/651))
@@ -92,6 +120,25 @@ All notable changes to Kandev.
 - apply display filters in list view ([#612](https://github.com/kdlbs/kandev/pull/612))
 - isolate dev mode state when running inside a kandev task ([#617](https://github.com/kdlbs/kandev/pull/617))
 - disable multi-select mode after bulk archive or delete ([#623](https://github.com/kdlbs/kandev/pull/623))
+
+### Performance
+
+- focus-gated git polling to reduce CPU on retained worktrees ([#610](https://github.com/kdlbs/kandev/pull/610))
+
+### Documentation
+
+- add Discord link and require e2e tests for UI changes ([#630](https://github.com/kdlbs/kandev/pull/630))
+- refresh README, roadmap, and workflow templates ([#624](https://github.com/kdlbs/kandev/pull/624))
+
+## 0.34 - 2026-04-17
+
+### Features
+
+- render short tool-call output inline ([#604](https://github.com/kdlbs/kandev/pull/604))
+- associate agent profiles with workflows and steps ([#597](https://github.com/kdlbs/kandev/pull/597))
+
+### Bug Fixes
+
 - close file diff tab when uncommitted change is undone ([#618](https://github.com/kdlbs/kandev/pull/618))
 - stop killing live agents on resume race ([#619](https://github.com/kdlbs/kandev/pull/619))
 - treat skipped checks as passing and add ready-to-merge status ([#616](https://github.com/kdlbs/kandev/pull/616))
@@ -103,6 +150,16 @@ All notable changes to Kandev.
 - prevent duplicate review tasks via atomic PR reservation ([#605](https://github.com/kdlbs/kandev/pull/605))
 - stop panels from opening in the left sidebar group ([#603](https://github.com/kdlbs/kandev/pull/603))
 - align top-bar right button heights ([#601](https://github.com/kdlbs/kandev/pull/601))
+
+## 0.33 - 2026-04-16
+
+### Features
+
+- add start_agent and local_path params to create_task ([#505](https://github.com/kdlbs/kandev/pull/505))
+- acp-first profiles, models, and modes ([#566](https://github.com/kdlbs/kandev/pull/566))
+
+### Bug Fixes
+
 - improve plan comment formatting to match code review style ([#600](https://github.com/kdlbs/kandev/pull/600))
 - skip ExtraFiles liveness pipe on Windows to fix agentctl startup ([#599](https://github.com/kdlbs/kandev/pull/599))
 - disable resume and show agent selector when profile is deleted ([#578](https://github.com/kdlbs/kandev/pull/578))
@@ -122,6 +179,19 @@ All notable changes to Kandev.
 - stop vertical scroll on mobile column tabs ([#583](https://github.com/kdlbs/kandev/pull/583))
 - disable inherited git-crypt filters when repo is locked ([#577](https://github.com/kdlbs/kandev/pull/577))
 - handle locked git-crypt repos and localized git errors ([#532](https://github.com/kdlbs/kandev/pull/532))
+
+### Refactoring
+
+- re-key dockview panel state by environmentId instead of sessionId ([#491](https://github.com/kdlbs/kandev/pull/491))
+
+## 0.32 - 2026-04-13
+
+### Features
+
+- add multi-select and drag-to-move for file tree and changes panel ([#490](https://github.com/kdlbs/kandev/pull/490))
+
+### Bug Fixes
+
 - register MCP tools with _kandev suffix to match sysprompt ([#572](https://github.com/kdlbs/kandev/pull/572))
 - recalculate dockview layout after fast-path session switch ([#571](https://github.com/kdlbs/kandev/pull/571))
 - prevent worktree branches from inheriting upstream tracking ([#570](https://github.com/kdlbs/kandev/pull/570))
@@ -129,21 +199,8 @@ All notable changes to Kandev.
 - make PR Approve button look clickable ([#567](https://github.com/kdlbs/kandev/pull/567))
 - associate PRs with tasks after branch rename or PR replacement ([#565](https://github.com/kdlbs/kandev/pull/565))
 
-### Performance
-
-- focus-gated git polling to reduce CPU on retained worktrees ([#610](https://github.com/kdlbs/kandev/pull/610))
-
-### Refactoring
-
-- unify task.updated via single publisher and shared mapper ([#676](https://github.com/kdlbs/kandev/pull/676))
-- move system prompts from Go constants to external config files ([#673](https://github.com/kdlbs/kandev/pull/673))
-- re-key dockview panel state by environmentId instead of sessionId ([#491](https://github.com/kdlbs/kandev/pull/491))
-
 ### Documentation
 
-- improve commit skill with mandatory verify and pre-commit check ([#691](https://github.com/kdlbs/kandev/pull/691))
-- add Discord link and require e2e tests for UI changes ([#630](https://github.com/kdlbs/kandev/pull/630))
-- refresh README, roadmap, and workflow templates ([#624](https://github.com/kdlbs/kandev/pull/624))
 - enforce test requirements and improve agent skill resilience ([#543](https://github.com/kdlbs/kandev/pull/543))
 
 ## 0.31 - 2026-04-09

--- a/scripts/release/release-pr.sh
+++ b/scripts/release/release-pr.sh
@@ -239,7 +239,7 @@ detect_current_app_version() {
 
   while IFS= read -r tag; do
     [[ -z "$tag" ]] && continue
-    if [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
+    if [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)$ ]]; then
       local major="${BASH_REMATCH[1]}"
       local minor="${BASH_REMATCH[2]}"
       if [[ "$found" -eq 0 ]] || (( 10#$major > 10#$best_major )) || \
@@ -435,7 +435,7 @@ latest_origin_app_tag() {
     [[ -z "${ref:-}" ]] && continue
     tag="${ref#refs/tags/}"
     tag="${tag%\^\{\}}"
-    if [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
+    if [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)$ ]]; then
       local major="${BASH_REMATCH[1]}"
       local minor="${BASH_REMATCH[2]}"
       if [[ "$found" -eq 0 ]] || (( 10#$major > 10#$best_major )) || \

--- a/scripts/release/release-pr.sh
+++ b/scripts/release/release-pr.sh
@@ -47,6 +47,7 @@ CURRENT_CLI_MAJOR=0
 CURRENT_CLI_MINOR=0
 CURRENT_CLI_PATCH=0
 CURRENT_APP_TAG=""
+CURRENT_APP_TAG_FOUND=0
 CURRENT_APP_MAJOR=0
 CURRENT_APP_MINOR=0
 
@@ -232,6 +233,7 @@ detect_current_app_version() {
   local tags
   tags="$(git -C "$ROOT_DIR" tag --list 'v*')"
 
+  CURRENT_APP_TAG_FOUND=0
   local found=0
   local best_major=0
   local best_minor=0
@@ -254,6 +256,7 @@ detect_current_app_version() {
   CURRENT_APP_MAJOR="$best_major"
   CURRENT_APP_MINOR="$best_minor"
   CURRENT_APP_TAG="v${CURRENT_APP_MAJOR}.${CURRENT_APP_MINOR}"
+  CURRENT_APP_TAG_FOUND="$found"
 
   if [[ "$found" -eq 1 ]]; then
     log "Current app tag:     $(bold "$CURRENT_APP_TAG") $(dim "(latest git tag matching vM.m)")"
@@ -456,6 +459,14 @@ ensure_latest_app_tag_present() {
   [[ "$DRY_RUN" -eq 1 ]] && return 0
 
   log "Verifying latest app tag $(bold "$CURRENT_APP_TAG") is present locally..."
+  if [[ "$CURRENT_APP_TAG_FOUND" -eq 0 ]]; then
+    if latest_origin_app_tag >/dev/null 2>&1; then
+      die "No local app tag found, but origin has app tags. Fetch origin tags and retry."
+    fi
+    log_ok "No prior app tags on origin or locally"
+    return 0
+  fi
+
   local origin_app_tag
   if ! origin_app_tag="$(latest_origin_app_tag)"; then
     die "Could not determine latest app tag from origin. Refusing to generate CHANGELOG.md."

--- a/scripts/release/release-pr.sh
+++ b/scripts/release/release-pr.sh
@@ -371,7 +371,7 @@ ensure_prerequisites() {
   log_ok "Working tree is clean"
 
   log "Fetching tags from origin..."
-  run_cmd git -C "$ROOT_DIR" fetch --tags
+  run_cmd git -C "$ROOT_DIR" fetch --tags origin
   log_ok "Tags fetched"
 }
 
@@ -420,6 +420,56 @@ ensure_app_tag_available() {
     die "Tag $NEXT_APP_TAG already exists on origin."
   fi
   log_ok "Tag $(bold "$NEXT_APP_TAG") is available"
+}
+
+latest_origin_app_tag() {
+  local refs
+  refs="$(git -C "$ROOT_DIR" ls-remote --tags origin 'refs/tags/v*')"
+
+  local found=0
+  local best_major=0
+  local best_minor=0
+  local ref tag
+
+  while read -r _ ref; do
+    [[ -z "${ref:-}" ]] && continue
+    tag="${ref#refs/tags/}"
+    tag="${tag%\^\{\}}"
+    if [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
+      local major="${BASH_REMATCH[1]}"
+      local minor="${BASH_REMATCH[2]}"
+      if [[ "$found" -eq 0 ]] || (( 10#$major > 10#$best_major )) || \
+        (( 10#$major == 10#$best_major && 10#$minor > 10#$best_minor )); then
+        found=1
+        best_major="$major"
+        best_minor="$minor"
+      fi
+    fi
+  done <<<"$refs"
+
+  [[ "$found" -eq 1 ]] || return 1
+  echo "v${best_major}.${best_minor}"
+}
+
+ensure_latest_app_tag_present() {
+  [[ "$APP_SELECTED" -eq 1 ]] || return 0
+  [[ "$DRY_RUN" -eq 1 ]] && return 0
+
+  log "Verifying latest app tag $(bold "$CURRENT_APP_TAG") is present locally..."
+  local origin_app_tag
+  if ! origin_app_tag="$(latest_origin_app_tag)"; then
+    die "Could not determine latest app tag from origin. Refusing to generate CHANGELOG.md."
+  fi
+
+  if [[ "$CURRENT_APP_TAG" != "$origin_app_tag" ]]; then
+    die "Latest local app tag is $CURRENT_APP_TAG, but origin latest is $origin_app_tag. Refusing to generate CHANGELOG.md."
+  fi
+
+  if ! git -C "$ROOT_DIR" rev-parse --verify --quiet "refs/tags/$CURRENT_APP_TAG" >/dev/null; then
+    die "Latest app tag $CURRENT_APP_TAG is missing locally after fetching origin tags. Refusing to generate CHANGELOG.md."
+  fi
+
+  log_ok "Latest app tag $(bold "$CURRENT_APP_TAG") is present"
 }
 
 # -- Release plan --------------------------------------------------------------
@@ -508,6 +558,10 @@ apply_cli_release() {
 
 generate_changelog() {
   [[ "$APP_SELECTED" -eq 1 ]] || return 0
+
+  log "Refreshing origin tags before changelog generation..."
+  run_cmd git -C "$ROOT_DIR" fetch --tags origin
+  ensure_latest_app_tag_present
 
   log "Generating changelog for $(bold "$NEXT_APP_TAG")..."
   if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -705,6 +759,7 @@ main() {
   detect_current_cli_version
   detect_current_app_version
   compute_next_versions
+  ensure_latest_app_tag_present
   ensure_app_tag_available
   compute_total_steps
   print_plan

--- a/scripts/release/release-pr.sh
+++ b/scripts/release/release-pr.sh
@@ -427,7 +427,9 @@ ensure_app_tag_available() {
 
 latest_origin_app_tag() {
   local refs
-  refs="$(git -C "$ROOT_DIR" ls-remote --tags origin 'refs/tags/v*')"
+  if ! refs="$(git -C "$ROOT_DIR" ls-remote --tags origin 'refs/tags/v*')"; then
+    return 2
+  fi
 
   local found=0
   local best_major=0
@@ -460,8 +462,17 @@ ensure_latest_app_tag_present() {
 
   log "Verifying latest app tag $(bold "$CURRENT_APP_TAG") is present locally..."
   if [[ "$CURRENT_APP_TAG_FOUND" -eq 0 ]]; then
-    if latest_origin_app_tag >/dev/null 2>&1; then
+    local origin_status
+    if latest_origin_app_tag >/dev/null; then
+      origin_status=0
+    else
+      origin_status="$?"
+    fi
+    if [[ "$origin_status" -eq 0 ]]; then
       die "No local app tag found, but origin has app tags. Fetch origin tags and retry."
+    fi
+    if [[ "$origin_status" -ne 1 ]]; then
+      die "Could not reach origin to verify app tags. Check your connection and retry."
     fi
     log_ok "No prior app tags on origin or locally"
     return 0


### PR DESCRIPTION
Release changelog generation could collapse multiple historical releases when local tags were pruned by a secondary remote, making the published changelog misleading. The release PR flow now fetches and validates origin tags before changelog generation, and the changelog has the correct 0.32-0.38 release boundaries restored.

## Important Changes

- `release-pr.sh` fetches tags from `origin` explicitly to avoid multi-remote tag pruning.
- Changelog generation now refreshes and validates origin tags immediately before running `git-cliff`.

## Validation

- `bash -n scripts/release/release.sh scripts/release/release-pr.sh`
- `git diff --check`
- `git fetch --tags origin`
- `git-cliff --latest --strip header`

## Possible Improvements

Low risk: future release automation could add a regression test around multi-remote tag pruning if shell test infrastructure is introduced.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.