### PR TITLE
feat(web): add GitHub dashboard shortcut to command panel

### DIFF
--- a/apps/web/components/global-commands.tsx
+++ b/apps/web/components/global-commands.tsx
@@ -16,6 +16,7 @@ import {
   IconFolder,
   IconMessageCircle,
   IconSparkles,
+  IconBrandGithub,
 } from "@tabler/icons-react";
 import { useRegisterCommands } from "@/hooks/use-register-commands";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
@@ -58,6 +59,14 @@ function buildNavigationCommands(push: PushFn): CommandItem[] {
       icon: <IconChartBar className="size-3.5" />,
       keywords: ["stats", "analytics", "metrics"],
       action: () => push("/stats"),
+    },
+    {
+      id: "nav-github",
+      label: "Go to GitHub Dashboard",
+      group: "Navigation",
+      icon: <IconBrandGithub className="size-3.5" />,
+      keywords: ["github", "dashboard", "pr", "pull request", "review"],
+      action: () => push("/github"),
     },
     {
       id: "settings-agents",


### PR DESCRIPTION
## Summary

Reaching the GitHub dashboard previously required clicking the icon in the kanban header. Add a Cmd+K command panel entry so it sits alongside the other top-level navigation shortcuts (Home, Tasks, Stats, Settings).

## Validation

- \`pnpm --filter @kandev/web lint\` — clean (0 warnings).
- Manual: Cmd+K → type \"github\" → entry appears under Navigation, routes to \`/github\`.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation