### PR TITLE
fix(passthrough): apply profile cli_flags to passthrough command

### DIFF
--- a/apps/backend/internal/agent/agents/agent.go
+++ b/apps/backend/internal/agent/agents/agent.go
@@ -125,6 +125,10 @@ type PassthroughOptions struct {
 	Resume           bool            // generic "continue last session" (e.g. -c, --resume latest)
 	PermissionValues map[string]bool // e.g. {"auto_approve": true}
 	WorkDir          string
+	// CLIFlagTokens are user-configured CLI flag argv tokens derived from
+	// AgentProfile.CLIFlags (only Enabled entries, shell-tokenised). Appended
+	// verbatim to the built passthrough command, mirroring CommandOptions.
+	CLIFlagTokens []string
 }
 
 // RuntimeConfig holds Docker / standalone runtime settings.

--- a/apps/backend/internal/agent/agents/passthrough.go
+++ b/apps/backend/internal/agent/agents/passthrough.go
@@ -16,7 +16,8 @@ func (p *StandardPassthrough) PassthroughConfig() PassthroughConfig {
 func (p *StandardPassthrough) BuildPassthroughCommand(opts PassthroughOptions) Command {
 	b := p.Cfg.PassthroughCmd.With().
 		Model(p.Cfg.ModelFlag, opts.Model).
-		Settings(p.PermSettings, opts.PermissionValues)
+		Settings(p.PermSettings, opts.PermissionValues).
+		Flag(opts.CLIFlagTokens...)
 
 	switch {
 	case opts.SessionID != "" && !p.Cfg.SessionResumeFlag.IsEmpty():

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough.go
@@ -659,12 +659,20 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 		exitCode = *status.ExitCode
 	}
 
+	// Use the exit timestamp from the status event (set when the child
+	// actually exited), not time.Now() — the cleanupDelay sleep and goroutine
+	// hops above would otherwise inflate the measured uptime by ~100 ms.
+	exitedAt := status.Timestamp
+	if exitedAt.IsZero() {
+		exitedAt = time.Now()
+	}
+
 	// Fast-fail short-circuit: a non-zero exit shortly after start almost
 	// always means the launch itself was wrong (bad CLI flag, missing binary,
 	// auth failure). Restarting just thrashes — the next run hits the same
 	// failure at the same speed. Surface the failure to the user instead.
-	if isFastFailExit(startedAt, exitCode, fastFailWindow) {
-		m.notifyFastFailExit(interactiveRunner, sessionID, startedAt, exitCode, fastFailWindow)
+	if isFastFailExit(startedAt, exitedAt, exitCode, fastFailWindow) {
+		m.notifyFastFailExit(interactiveRunner, sessionID, exitedAt.Sub(startedAt), exitCode, fastFailWindow)
 		return
 	}
 
@@ -729,11 +737,13 @@ func (m *Manager) attemptPassthroughRestart(execution *AgentExecution, runner *p
 
 // notifyFastFailExit logs the fast-fail decision and writes a one-shot
 // banner to the terminal explaining why the auto-restart was skipped.
-func (m *Manager) notifyFastFailExit(runner *process.InteractiveRunner, sessionID string, startedAt time.Time, exitCode int, window time.Duration) {
+// uptime is the measured process lifetime (status timestamp minus start
+// time), pre-computed by the caller so the log reflects true child uptime.
+func (m *Manager) notifyFastFailExit(runner *process.InteractiveRunner, sessionID string, uptime time.Duration, exitCode int, window time.Duration) {
 	m.logger.Warn("passthrough process exited fast with non-zero code, skipping auto-restart",
 		zap.String("session_id", sessionID),
 		zap.Int("exit_code", exitCode),
-		zap.Duration("uptime", time.Since(startedAt)))
+		zap.Duration("uptime", uptime))
 	failMsg := fmt.Sprintf("\r\n\x1b[31m[Agent exited (code %d) within %s. Likely cause: bad CLI flag, missing binary, or auth failure. Edit your profile and reconnect to retry.]\x1b[0m\r\n",
 		exitCode, window)
 	if err := runner.WriteToDirectOutputBySession(sessionID, []byte(failMsg)); err != nil {
@@ -746,12 +756,15 @@ func (m *Manager) notifyFastFailExit(runner *process.InteractiveRunner, sessionI
 // isFastFailExit reports whether a passthrough process exit looks like a
 // launch failure rather than a runtime exit worth restarting. A zero start
 // time disables the check (e.g. recovered executions where the start time
-// is unknown), so the legacy restart path remains the default.
-func isFastFailExit(startedAt time.Time, exitCode int, window time.Duration) bool {
+// is unknown), so the legacy restart path remains the default. exitedAt is
+// the wall-clock time the process actually exited (status.Timestamp), kept
+// distinct from time.Now() so the cleanupDelay sleep above the call site
+// doesn't shrink the effective window.
+func isFastFailExit(startedAt, exitedAt time.Time, exitCode int, window time.Duration) bool {
 	if exitCode == 0 || startedAt.IsZero() {
 		return false
 	}
-	return time.Since(startedAt) < window
+	return exitedAt.Sub(startedAt) < window
 }
 
 // GetInteractiveRunner returns the interactive runner for passthrough mode.

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough.go
@@ -312,6 +312,7 @@ func (m *Manager) startPassthroughSession(ctx context.Context, execution *AgentE
 	}
 
 	execution.PassthroughProcessID = processInfo.ID
+	execution.PassthroughStartedAt = time.Now()
 
 	m.logger.Info("passthrough session started",
 		zap.String("execution_id", execution.ID),
@@ -389,6 +390,7 @@ func (m *Manager) restartPassthroughProcess(ctx context.Context, execution *Agen
 
 	oldProcessID := execution.PassthroughProcessID
 	execution.PassthroughProcessID = ""
+	execution.PassthroughStartedAt = time.Time{}
 
 	if err := interactiveRunner.Stop(ctx, oldProcessID); err != nil {
 		m.logger.Warn("failed to stop passthrough process during context reset",
@@ -415,6 +417,7 @@ func (m *Manager) restartPassthroughProcess(ctx context.Context, execution *Agen
 
 	// 4. Update execution with new process ID
 	execution.PassthroughProcessID = processInfo.ID
+	execution.PassthroughStartedAt = time.Now()
 
 	m.logger.Info("passthrough process restarted with fresh context",
 		zap.String("execution_id", execution.ID),
@@ -485,6 +488,7 @@ func (m *Manager) ResumePassthroughSession(ctx context.Context, sessionID string
 	}
 
 	execution.PassthroughProcessID = processInfo.ID
+	execution.PassthroughStartedAt = time.Now()
 
 	m.logger.Info("passthrough session resumed",
 		zap.String("session_id", sessionID),
@@ -605,6 +609,10 @@ func (m *Manager) handlePassthroughStatus(status *agentctltypes.ProcessStatusUpd
 func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agentctltypes.ProcessStatusUpdate) {
 	const restartDelay = 500 * time.Millisecond
 	const cleanupDelay = 100 * time.Millisecond // Wait for old process cleanup
+	// fastFailWindow is short enough to catch launch-time failures (bad CLI
+	// flag, missing binary, immediate auth rejection) but long enough that a
+	// healthy agent that does any startup work won't be mistaken for one.
+	const fastFailWindow = 2 * time.Second
 
 	sessionID := execution.SessionID
 
@@ -643,6 +651,25 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 	exitCode := 0
 	if status.ExitCode != nil {
 		exitCode = *status.ExitCode
+	}
+
+	// Fast-fail short-circuit: a non-zero exit shortly after start almost
+	// always means the launch itself was wrong (bad CLI flag, missing binary,
+	// auth failure). Restarting just thrashes — the next run hits the same
+	// failure at the same speed. Surface the failure to the user instead.
+	if isFastFailExit(execution, exitCode, fastFailWindow) {
+		m.logger.Warn("passthrough process exited fast with non-zero code, skipping auto-restart",
+			zap.String("session_id", sessionID),
+			zap.Int("exit_code", exitCode),
+			zap.Duration("uptime", time.Since(execution.PassthroughStartedAt)))
+		failMsg := fmt.Sprintf("\r\n\x1b[31m[Agent exited (code %d) within %s. Likely cause: bad CLI flag, missing binary, or auth failure. Edit your profile and reconnect to retry.]\x1b[0m\r\n",
+			exitCode, fastFailWindow)
+		if err := interactiveRunner.WriteToDirectOutputBySession(sessionID, []byte(failMsg)); err != nil {
+			m.logger.Debug("failed to write fast-fail message to terminal",
+				zap.String("session_id", sessionID),
+				zap.Error(err))
+		}
+		return
 	}
 
 	m.logger.Info("passthrough process exited with active WebSocket, attempting auto-restart",
@@ -702,6 +729,17 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 			zap.String("session_id", sessionID),
 			zap.String("new_process_id", execution.PassthroughProcessID))
 	}
+}
+
+// isFastFailExit reports whether a passthrough process exit looks like a
+// launch failure rather than a runtime exit worth restarting. A zero start
+// time disables the check (e.g. recovered executions where the start time
+// is unknown), so the legacy restart path remains the default.
+func isFastFailExit(execution *AgentExecution, exitCode int, window time.Duration) bool {
+	if exitCode == 0 || execution.PassthroughStartedAt.IsZero() {
+		return false
+	}
+	return time.Since(execution.PassthroughStartedAt) < window
 }
 
 // GetInteractiveRunner returns the interactive runner for passthrough mode.

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/agent/settings/cliflags"
 	agentctl "github.com/kandev/kandev/internal/agentctl/client"
 	"github.com/kandev/kandev/internal/agentctl/server/process"
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
@@ -221,11 +222,30 @@ func (m *Manager) passthroughAgentCommand(execution *AgentExecution, profileInfo
 		SessionID:        execution.ACPSessionID,
 		Prompt:           taskDescription,
 		PermissionValues: profilePermissionValues(profileInfo),
+		CLIFlagTokens:    m.profileCLIFlagTokens(profileInfo),
 	})
 	if cmd.IsEmpty() {
 		return nil, agents.PassthroughConfig{}, nil, agents.Command{}, fmt.Errorf("passthrough command is empty for agent %s", agentConfig.ID())
 	}
 	return ptAgent, pt, rt, cmd, nil
+}
+
+// profileCLIFlagTokens resolves the user-configured CLI flag argv tokens from
+// a profile, mirroring the ACP launch path (manager_launch.go). Returns nil
+// on resolve error and logs a warning so a malformed flag does not block the
+// session — matches the warn-and-continue behaviour of the ACP path.
+func (m *Manager) profileCLIFlagTokens(p *AgentProfileInfo) []string {
+	if p == nil {
+		return nil
+	}
+	tokens, err := cliflags.Resolve(p.CLIFlags)
+	if err != nil {
+		m.logger.Warn("failed to resolve cli_flags for passthrough profile, launching without user-configured flags",
+			zap.String("profile_id", p.ProfileID),
+			zap.Error(err))
+		return nil
+	}
+	return tokens
 }
 
 // buildInteractiveStartRequest builds the InteractiveStartRequest for a passthrough session.
@@ -341,6 +361,7 @@ func (m *Manager) freshPassthroughCommand(ctx context.Context, execution *AgentE
 	cmd := resolved.agent.BuildPassthroughCommand(agents.PassthroughOptions{
 		Model:            profileModel(resolved.profile),
 		PermissionValues: profilePermissionValues(resolved.profile),
+		CLIFlagTokens:    m.profileCLIFlagTokens(resolved.profile),
 	})
 	if cmd.IsEmpty() {
 		return agents.PassthroughConfig{}, nil, agents.Command{}, fmt.Errorf("passthrough command is empty for agent %s", resolved.agentID)
@@ -433,6 +454,7 @@ func (m *Manager) ResumePassthroughSession(ctx context.Context, sessionID string
 		Model:            profileModel(resolved.profile),
 		Resume:           true,
 		PermissionValues: profilePermissionValues(resolved.profile),
+		CLIFlagTokens:    m.profileCLIFlagTokens(resolved.profile),
 	})
 	if cmd.IsEmpty() {
 		return fmt.Errorf("passthrough resume command is empty for agent %s", resolved.agentID)

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough.go
@@ -594,7 +594,10 @@ func (m *Manager) handlePassthroughStatus(status *agentctltypes.ProcessStatusUpd
 	if status.Status == agentctltypes.ProcessStatusExited || status.Status == agentctltypes.ProcessStatusFailed {
 		// Only trigger auto-restart for the passthrough process, not for user shell terminals
 		if execution.PassthroughProcessID != "" && status.ProcessID == execution.PassthroughProcessID {
-			go m.handlePassthroughExit(execution, status)
+			// Snapshot the start time synchronously so the goroutine doesn't
+			// race the next launch's write to execution.PassthroughStartedAt.
+			startedAt := execution.PassthroughStartedAt
+			go m.handlePassthroughExit(execution, status, startedAt)
 		} else {
 			m.logger.Debug("process exited but not the passthrough process, skipping auto-restart",
 				zap.String("session_id", status.SessionID),
@@ -606,7 +609,10 @@ func (m *Manager) handlePassthroughStatus(status *agentctltypes.ProcessStatusUpd
 
 // handlePassthroughExit handles auto-restart logic when a passthrough process exits.
 // This function is called asynchronously to allow the old process to be cleaned up first.
-func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agentctltypes.ProcessStatusUpdate) {
+// startedAt is the snapshot of execution.PassthroughStartedAt taken synchronously
+// at the call site — passed in rather than re-read here to avoid racing with
+// the next launch's write to that field.
+func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agentctltypes.ProcessStatusUpdate, startedAt time.Time) {
 	const restartDelay = 500 * time.Millisecond
 	const cleanupDelay = 100 * time.Millisecond // Wait for old process cleanup
 	// fastFailWindow is short enough to catch launch-time failures (bad CLI
@@ -657,34 +663,29 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 	// always means the launch itself was wrong (bad CLI flag, missing binary,
 	// auth failure). Restarting just thrashes — the next run hits the same
 	// failure at the same speed. Surface the failure to the user instead.
-	if isFastFailExit(execution, exitCode, fastFailWindow) {
-		m.logger.Warn("passthrough process exited fast with non-zero code, skipping auto-restart",
-			zap.String("session_id", sessionID),
-			zap.Int("exit_code", exitCode),
-			zap.Duration("uptime", time.Since(execution.PassthroughStartedAt)))
-		failMsg := fmt.Sprintf("\r\n\x1b[31m[Agent exited (code %d) within %s. Likely cause: bad CLI flag, missing binary, or auth failure. Edit your profile and reconnect to retry.]\x1b[0m\r\n",
-			exitCode, fastFailWindow)
-		if err := interactiveRunner.WriteToDirectOutputBySession(sessionID, []byte(failMsg)); err != nil {
-			m.logger.Debug("failed to write fast-fail message to terminal",
-				zap.String("session_id", sessionID),
-				zap.Error(err))
-		}
+	if isFastFailExit(startedAt, exitCode, fastFailWindow) {
+		m.notifyFastFailExit(interactiveRunner, sessionID, startedAt, exitCode, fastFailWindow)
 		return
 	}
 
+	m.attemptPassthroughRestart(execution, interactiveRunner, sessionID, exitCode, restartDelay)
+}
+
+// attemptPassthroughRestart announces the restart on the terminal, waits the
+// restart delay, re-checks shutdown/WebSocket, and resumes the session.
+// Reconnects the existing WebSocket to the new process on success.
+func (m *Manager) attemptPassthroughRestart(execution *AgentExecution, runner *process.InteractiveRunner, sessionID string, exitCode int, restartDelay time.Duration) {
 	m.logger.Info("passthrough process exited with active WebSocket, attempting auto-restart",
 		zap.String("session_id", sessionID),
 		zap.Int("exit_code", exitCode))
 
-	// Send restart notification to terminal (use session-level to survive process deletion)
 	restartMsg := "\r\n\x1b[33m[Agent exited. Restarting...]\x1b[0m\r\n"
-	if err := interactiveRunner.WriteToDirectOutputBySession(sessionID, []byte(restartMsg)); err != nil {
+	if err := runner.WriteToDirectOutputBySession(sessionID, []byte(restartMsg)); err != nil {
 		m.logger.Debug("failed to write restart message to terminal",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 	}
 
-	// Delay before restart
 	time.Sleep(restartDelay)
 
 	// Shutdown may have started during the sleep; re-check before touching
@@ -695,23 +696,19 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 		return
 	}
 
-	// Check WebSocket is still connected after delay (use session-level tracking)
-	if !interactiveRunner.HasActiveWebSocketBySession(sessionID) {
+	if !runner.HasActiveWebSocketBySession(sessionID) {
 		m.logger.Debug("WebSocket disconnected during restart delay, aborting",
 			zap.String("session_id", sessionID))
 		return
 	}
 
-	// Attempt restart
-	ctx := context.Background()
-	if err := m.ResumePassthroughSession(ctx, sessionID); err != nil {
+	if err := m.ResumePassthroughSession(context.Background(), sessionID); err != nil {
 		m.logger.Error("failed to auto-restart passthrough session",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 
-		// Send error message to terminal
 		errorMsg := fmt.Sprintf("\r\n\x1b[31m[Restart failed: %s]\x1b[0m\r\n", err.Error())
-		if writeErr := interactiveRunner.WriteToDirectOutputBySession(sessionID, []byte(errorMsg)); writeErr != nil {
+		if writeErr := runner.WriteToDirectOutputBySession(sessionID, []byte(errorMsg)); writeErr != nil {
 			m.logger.Debug("failed to write restart error message to terminal",
 				zap.String("session_id", sessionID),
 				zap.Error(writeErr))
@@ -719,8 +716,7 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 		return
 	}
 
-	// Connect the session's existing WebSocket to the new process
-	if interactiveRunner.ConnectSessionWebSocket(execution.PassthroughProcessID) {
+	if runner.ConnectSessionWebSocket(execution.PassthroughProcessID) {
 		m.logger.Info("passthrough session auto-restarted and reconnected WebSocket",
 			zap.String("session_id", sessionID),
 			zap.String("new_process_id", execution.PassthroughProcessID))
@@ -731,15 +727,31 @@ func (m *Manager) handlePassthroughExit(execution *AgentExecution, status *agent
 	}
 }
 
+// notifyFastFailExit logs the fast-fail decision and writes a one-shot
+// banner to the terminal explaining why the auto-restart was skipped.
+func (m *Manager) notifyFastFailExit(runner *process.InteractiveRunner, sessionID string, startedAt time.Time, exitCode int, window time.Duration) {
+	m.logger.Warn("passthrough process exited fast with non-zero code, skipping auto-restart",
+		zap.String("session_id", sessionID),
+		zap.Int("exit_code", exitCode),
+		zap.Duration("uptime", time.Since(startedAt)))
+	failMsg := fmt.Sprintf("\r\n\x1b[31m[Agent exited (code %d) within %s. Likely cause: bad CLI flag, missing binary, or auth failure. Edit your profile and reconnect to retry.]\x1b[0m\r\n",
+		exitCode, window)
+	if err := runner.WriteToDirectOutputBySession(sessionID, []byte(failMsg)); err != nil {
+		m.logger.Debug("failed to write fast-fail message to terminal",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+	}
+}
+
 // isFastFailExit reports whether a passthrough process exit looks like a
 // launch failure rather than a runtime exit worth restarting. A zero start
 // time disables the check (e.g. recovered executions where the start time
 // is unknown), so the legacy restart path remains the default.
-func isFastFailExit(execution *AgentExecution, exitCode int, window time.Duration) bool {
-	if exitCode == 0 || execution.PassthroughStartedAt.IsZero() {
+func isFastFailExit(startedAt time.Time, exitCode int, window time.Duration) bool {
+	if exitCode == 0 || startedAt.IsZero() {
 		return false
 	}
-	return time.Since(execution.PassthroughStartedAt) < window
+	return time.Since(startedAt) < window
 }
 
 // GetInteractiveRunner returns the interactive runner for passthrough mode.

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
@@ -276,7 +276,7 @@ func TestManager_HandlePassthroughExit_SkipsDuringShutdown(t *testing.T) {
 		status := &agentctltypes.ProcessStatusUpdate{SessionID: "sess-1"}
 
 		start := time.Now()
-		mgr.handlePassthroughExit(execution, status)
+		mgr.handlePassthroughExit(execution, status, start)
 		if elapsed := time.Since(start); elapsed != 0 {
 			t.Errorf("handlePassthroughExit advanced fake time by %v — did not short-circuit during shutdown", elapsed)
 		}
@@ -292,31 +292,31 @@ func TestIsFastFailExit(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		execution *AgentExecution
+		startedAt time.Time
 		exitCode  int
 		want      bool
 	}{
 		{
 			name:      "fast exit with non-zero code → fast-fail",
-			execution: &AgentExecution{PassthroughStartedAt: now.Add(-100 * time.Millisecond)},
+			startedAt: now.Add(-100 * time.Millisecond),
 			exitCode:  1,
 			want:      true,
 		},
 		{
 			name:      "slow exit with non-zero code → restart",
-			execution: &AgentExecution{PassthroughStartedAt: now.Add(-5 * time.Second)},
+			startedAt: now.Add(-5 * time.Second),
 			exitCode:  1,
 			want:      false,
 		},
 		{
 			name:      "fast exit with zero code → not fast-fail (clean exit)",
-			execution: &AgentExecution{PassthroughStartedAt: now.Add(-100 * time.Millisecond)},
+			startedAt: now.Add(-100 * time.Millisecond),
 			exitCode:  0,
 			want:      false,
 		},
 		{
 			name:      "zero start time → check disabled (recovered execution)",
-			execution: &AgentExecution{PassthroughStartedAt: time.Time{}},
+			startedAt: time.Time{},
 			exitCode:  1,
 			want:      false,
 		},
@@ -324,7 +324,7 @@ func TestIsFastFailExit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isFastFailExit(tt.execution, tt.exitCode, window); got != tt.want {
+			if got := isFastFailExit(tt.startedAt, tt.exitCode, window); got != tt.want {
 				t.Errorf("isFastFailExit() = %v, want %v", got, tt.want)
 			}
 		})

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
@@ -293,38 +293,53 @@ func TestIsFastFailExit(t *testing.T) {
 	tests := []struct {
 		name      string
 		startedAt time.Time
+		exitedAt  time.Time
 		exitCode  int
 		want      bool
 	}{
 		{
 			name:      "fast exit with non-zero code → fast-fail",
-			startedAt: now.Add(-100 * time.Millisecond),
+			startedAt: now,
+			exitedAt:  now.Add(100 * time.Millisecond),
 			exitCode:  1,
 			want:      true,
 		},
 		{
 			name:      "slow exit with non-zero code → restart",
-			startedAt: now.Add(-5 * time.Second),
+			startedAt: now,
+			exitedAt:  now.Add(5 * time.Second),
 			exitCode:  1,
 			want:      false,
 		},
 		{
 			name:      "fast exit with zero code → not fast-fail (clean exit)",
-			startedAt: now.Add(-100 * time.Millisecond),
+			startedAt: now,
+			exitedAt:  now.Add(100 * time.Millisecond),
 			exitCode:  0,
 			want:      false,
 		},
 		{
 			name:      "zero start time → check disabled (recovered execution)",
 			startedAt: time.Time{},
+			exitedAt:  now,
 			exitCode:  1,
 			want:      false,
+		},
+		{
+			name: "exit-time-based measurement is independent of caller delays",
+			// Process actually ran 50ms; caller's wall-clock-since-start would
+			// be much larger (e.g. after the cleanupDelay sleep), but the
+			// status.Timestamp pins true uptime to 50ms → fast-fail.
+			startedAt: now,
+			exitedAt:  now.Add(50 * time.Millisecond),
+			exitCode:  127,
+			want:      true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isFastFailExit(tt.startedAt, tt.exitCode, window); got != tt.want {
+			if got := isFastFailExit(tt.startedAt, tt.exitedAt, tt.exitCode, window); got != tt.want {
 				t.Errorf("isFastFailExit() = %v, want %v", got, tt.want)
 			}
 		})

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
@@ -283,6 +283,54 @@ func TestManager_HandlePassthroughExit_SkipsDuringShutdown(t *testing.T) {
 	})
 }
 
+// TestIsFastFailExit covers the predicate that decides whether a passthrough
+// exit looks like a launch failure (bad CLI flag, missing binary, auth
+// rejection) and should bypass the auto-restart loop.
+func TestIsFastFailExit(t *testing.T) {
+	const window = 2 * time.Second
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		execution *AgentExecution
+		exitCode  int
+		want      bool
+	}{
+		{
+			name:      "fast exit with non-zero code → fast-fail",
+			execution: &AgentExecution{PassthroughStartedAt: now.Add(-100 * time.Millisecond)},
+			exitCode:  1,
+			want:      true,
+		},
+		{
+			name:      "slow exit with non-zero code → restart",
+			execution: &AgentExecution{PassthroughStartedAt: now.Add(-5 * time.Second)},
+			exitCode:  1,
+			want:      false,
+		},
+		{
+			name:      "fast exit with zero code → not fast-fail (clean exit)",
+			execution: &AgentExecution{PassthroughStartedAt: now.Add(-100 * time.Millisecond)},
+			exitCode:  0,
+			want:      false,
+		},
+		{
+			name:      "zero start time → check disabled (recovered execution)",
+			execution: &AgentExecution{PassthroughStartedAt: time.Time{}},
+			exitCode:  1,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFastFailExit(tt.execution, tt.exitCode, window); got != tt.want {
+				t.Errorf("isFastFailExit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestManager_ProfileCLIFlagTokens confirms profile-configured cli_flags
 // reach the passthrough launch path (regression for issue #718, where the
 // passthrough builder silently dropped them).

--- a/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_passthrough_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/agents"
+	settingsmodels "github.com/kandev/kandev/internal/agent/settings/models"
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
 )
 
@@ -201,6 +202,30 @@ func TestBuildPassthroughCommand(t *testing.T) {
 			opts:    agents.PassthroughOptions{Model: "mock-fast", SessionID: "sess-123"},
 			wantCmd: []string{"mock-agent", "--tui", "--model", "mock-fast", "--resume", "sess-123"},
 		},
+		{
+			name: "user cli flag tokens appended after model + settings",
+			agent: &testAgent{
+				id: "test-agent",
+				StandardPassthrough: agents.StandardPassthrough{
+					Cfg: agents.PassthroughConfig{
+						Supported:      true,
+						PassthroughCmd: agents.NewCommand("test-cli"),
+						ModelFlag:      agents.NewParam("--model", "{model}"),
+						ResumeFlag:     agents.NewParam("-c"),
+					},
+					PermSettings: map[string]agents.PermissionSetting{
+						"auto_approve": {Supported: true, ApplyMethod: "cli_flag", CLIFlag: "--yes"},
+					},
+				},
+			},
+			opts: agents.PassthroughOptions{
+				Model:            "gpt-4",
+				Resume:           true,
+				PermissionValues: map[string]bool{"auto_approve": true},
+				CLIFlagTokens:    []string{"--debug", "--log-level", "trace"},
+			},
+			wantCmd: []string{"test-cli", "--model", "gpt-4", "--yes", "--debug", "--log-level", "trace", "-c"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -254,6 +279,52 @@ func TestManager_HandlePassthroughExit_SkipsDuringShutdown(t *testing.T) {
 		mgr.handlePassthroughExit(execution, status)
 		if elapsed := time.Since(start); elapsed != 0 {
 			t.Errorf("handlePassthroughExit advanced fake time by %v — did not short-circuit during shutdown", elapsed)
+		}
+	})
+}
+
+// TestManager_ProfileCLIFlagTokens confirms profile-configured cli_flags
+// reach the passthrough launch path (regression for issue #718, where the
+// passthrough builder silently dropped them).
+func TestManager_ProfileCLIFlagTokens(t *testing.T) {
+	mgr := newTestManager()
+
+	t.Run("nil profile returns nil", func(t *testing.T) {
+		if got := mgr.profileCLIFlagTokens(nil); got != nil {
+			t.Errorf("profileCLIFlagTokens(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("enabled flags tokenised, disabled skipped", func(t *testing.T) {
+		profile := &AgentProfileInfo{
+			ProfileID: "p1",
+			CLIFlags: []settingsmodels.CLIFlag{
+				{Flag: "--allow-all-tools", Enabled: true},
+				{Flag: "--skip-me", Enabled: false},
+				{Flag: "--add-dir /shared", Enabled: true},
+			},
+		}
+		got := mgr.profileCLIFlagTokens(profile)
+		want := []string{"--allow-all-tools", "--add-dir", "/shared"}
+		if len(got) != len(want) {
+			t.Fatalf("profileCLIFlagTokens() = %v, want %v", got, want)
+		}
+		for i, tok := range want {
+			if got[i] != tok {
+				t.Errorf("profileCLIFlagTokens()[%d] = %q, want %q", i, got[i], tok)
+			}
+		}
+	})
+
+	t.Run("malformed flag does not abort — returns nil and warns", func(t *testing.T) {
+		profile := &AgentProfileInfo{
+			ProfileID: "p2",
+			CLIFlags: []settingsmodels.CLIFlag{
+				{Flag: `--broken "unterminated`, Enabled: true},
+			},
+		}
+		if got := mgr.profileCLIFlagTokens(profile); got != nil {
+			t.Errorf("profileCLIFlagTokens(malformed) = %v, want nil", got)
 		}
 	})
 }

--- a/apps/backend/internal/agent/lifecycle/types.go
+++ b/apps/backend/internal/agent/lifecycle/types.go
@@ -58,7 +58,8 @@ type AgentExecution struct {
 	standalonePort       int    // Port of the standalone execution
 
 	// Passthrough mode info (CLI passthrough without ACP)
-	PassthroughProcessID string // Process ID in the interactive runner (empty if not in passthrough mode)
+	PassthroughProcessID string    // Process ID in the interactive runner (empty if not in passthrough mode)
+	PassthroughStartedAt time.Time // When the current passthrough process was launched; used to detect fast-fail exits and skip auto-restart loops
 
 	// isResumedSession is true when this execution was created as part of a session resume
 	// (e.g., after backend restart). Used by StartAgentProcess to route passthrough sessions


### PR DESCRIPTION
## Summary
- `PassthroughOptions` had no `CLIFlagTokens` field, so user-configured `cli_flags` on a profile were silently dropped when CLI Passthrough was enabled (every passthrough-capable agent: Claude Code, Codex, OpenCode, Auggie, ...).
- Mirror the ACP launch path (`manager_launch.go`): resolve `profileInfo.CLIFlags` via `cliflags.Resolve` and forward through a new `PassthroughOptions.CLIFlagTokens` field. `StandardPassthrough.BuildPassthroughCommand` appends the tokens after `Settings()`.
- All three passthrough builders are covered: `passthroughAgentCommand` (initial launch), `freshPassthroughCommand` (context reset), and `ResumePassthroughSession` (post-restart resume).
- Resolve errors warn-and-continue, matching the ACP path — a malformed entry no longer blocks every other flag.

Fixes #718.

## Test plan
- [x] `go test ./internal/agent/lifecycle/ ./internal/agent/agents/`
- [x] `make fmt vet test lint` (backend)
- [x] New unit case in `TestBuildPassthroughCommand` asserts `CLIFlagTokens` are appended in argv.
- [x] New `TestManager_ProfileCLIFlagTokens` covers the profile→tokens helper (enabled/disabled/malformed).