### PR TITLE
fix(approvals): drop stale OpenCode permission cards (#717)

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -550,16 +550,39 @@ func (a *messageCreatorAdapter) CreateSessionMessage(ctx context.Context, taskID
 
 // CreatePermissionRequestMessage creates a message for a permission request
 func (a *messageCreatorAdapter) CreatePermissionRequestMessage(ctx context.Context, taskID, sessionID, pendingID, toolCallID, title, turnID string, options []map[string]interface{}, actionType string, actionDetails map[string]interface{}) (string, error) {
+	a.logger.Info("creating permission_request message",
+		zap.String("session_id", sessionID),
+		zap.String("pending_id", pendingID),
+		zap.String("tool_call_id", toolCallID),
+		zap.String("title", title))
+
 	// Idempotent on pending_id: some agents (OpenCode) re-emit
 	// session/request_permission for an already-resolved pending_id, which
 	// would otherwise spawn a second card whose backend pending was already
 	// consumed (issue #717).
 	if existing, err := a.svc.GetPermissionMessageByPendingID(ctx, sessionID, pendingID); err == nil && existing != nil {
-		a.logger.Debug("permission_request message already exists, skipping duplicate",
+		a.logger.Warn("permission_request message already exists with same pending_id, skipping duplicate",
 			zap.String("session_id", sessionID),
 			zap.String("pending_id", pendingID),
 			zap.String("existing_message_id", existing.ID))
 		return existing.ID, nil
+	}
+
+	// Stronger dedupe by tool_call_id. process.Manager generates a fresh
+	// nanos-suffixed pending_id on every permission forward, so a re-emit
+	// from the same ACP frame produces a different pending_id but the same
+	// tool_call_id. Without this guard the user sees a phantom card at
+	// turn end whose first click hits "pending permission not found"
+	// because agentctl already consumed the original.
+	if toolCallID != "" {
+		if existing, err := a.svc.FindPermissionMessageByToolCallID(ctx, sessionID, toolCallID); err == nil && existing != nil {
+			a.logger.Warn("permission_request message already exists for tool_call_id, skipping duplicate",
+				zap.String("session_id", sessionID),
+				zap.String("tool_call_id", toolCallID),
+				zap.String("incoming_pending_id", pendingID),
+				zap.String("existing_message_id", existing.ID))
+			return existing.ID, nil
+		}
 	}
 
 	metadata := map[string]interface{}{

--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -578,6 +578,14 @@ func (a *messageCreatorAdapter) UpdatePermissionMessage(ctx context.Context, ses
 	return a.svc.UpdatePermissionMessage(ctx, sessionID, pendingID, status)
 }
 
+// ExpirePendingPermissionsForSession sweeps any still-pending permission_request
+// messages for the session and marks them as expired. Used by the orchestrator
+// on turn complete to clean up agent-emitted permission frames that were never
+// resolved.
+func (a *messageCreatorAdapter) ExpirePendingPermissionsForSession(ctx context.Context, sessionID string) (int, error) {
+	return a.svc.ExpirePendingPermissionsForSession(ctx, sessionID)
+}
+
 // CreateClarificationRequestMessage creates a message for a clarification request.
 // This allows clarification requests to appear in the chat as messages.
 func (a *messageCreatorAdapter) CreateClarificationRequestMessage(ctx context.Context, taskID, sessionID, pendingID string, question clarification.Question, clarificationContext string) (string, error) {

--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -550,6 +550,18 @@ func (a *messageCreatorAdapter) CreateSessionMessage(ctx context.Context, taskID
 
 // CreatePermissionRequestMessage creates a message for a permission request
 func (a *messageCreatorAdapter) CreatePermissionRequestMessage(ctx context.Context, taskID, sessionID, pendingID, toolCallID, title, turnID string, options []map[string]interface{}, actionType string, actionDetails map[string]interface{}) (string, error) {
+	// Idempotent on pending_id: some agents (OpenCode) re-emit
+	// session/request_permission for an already-resolved pending_id, which
+	// would otherwise spawn a second card whose backend pending was already
+	// consumed (issue #717).
+	if existing, err := a.svc.GetPermissionMessageByPendingID(ctx, sessionID, pendingID); err == nil && existing != nil {
+		a.logger.Debug("permission_request message already exists, skipping duplicate",
+			zap.String("session_id", sessionID),
+			zap.String("pending_id", pendingID),
+			zap.String("existing_message_id", existing.ID))
+		return existing.ID, nil
+	}
+
 	metadata := map[string]interface{}{
 		"pending_id":     pendingID,
 		"tool_call_id":   toolCallID,

--- a/apps/backend/internal/agentctl/server/acp/client.go
+++ b/apps/backend/internal/agentctl/server/acp/client.go
@@ -195,9 +195,22 @@ func (c *Client) forwardPermissionRequest(ctx context.Context, handler Permissio
 
 	c.logger.Info("forwarding permission request to handler",
 		zap.String("session_id", req.SessionID),
-		zap.String("tool_call_id", req.ToolCallID))
+		zap.String("tool_call_id", req.ToolCallID),
+		zap.String("title", title),
+		zap.String("action_type", actionType))
 
 	resp, err := handler(ctx, req)
+	c.logger.Info("permission handler returned",
+		zap.String("session_id", req.SessionID),
+		zap.String("tool_call_id", req.ToolCallID),
+		zap.Bool("cancelled", resp != nil && resp.Cancelled),
+		zap.String("option_id", func() string {
+			if resp == nil {
+				return ""
+			}
+			return resp.OptionID
+		}()),
+		zap.Error(err))
 	if err != nil {
 		c.logger.Error("permission handler failed", zap.Error(err))
 		// On error, cancel the permission request

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -1803,6 +1803,12 @@ func extractPathFromTitle(title string) string {
 // Since both acpclient and adapter now use the shared types package,
 // no conversion is needed - we just forward to the handler.
 func (a *Adapter) handlePermissionRequest(ctx context.Context, req *PermissionRequest) (*PermissionResponse, error) {
+	a.logger.Info("acp adapter received permission request",
+		zap.String("session_id", req.SessionID),
+		zap.String("tool_call_id", req.ToolCallID),
+		zap.String("title", req.Title),
+		zap.String("action_type", req.ActionType))
+
 	a.mu.RLock()
 	handler := a.permissionHandler
 	fallbackSessionID := a.sessionID

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -103,6 +103,15 @@ type Adapter struct {
 	// Maps toolCallId -> NormalizedPayload so we can update with results
 	activeToolCalls map[string]*streams.NormalizedPayload
 
+	// terminalToolCalls remembers tool_call IDs that have already streamed a
+	// terminal status (completed/error/cancelled) within the current prompt.
+	// Used by handlePermissionRequest to drop ghost permission requests that
+	// arrive after the tool already finished — observed with OpenCode (issue
+	// #717), where forwarding such a request creates a permission_request
+	// message nothing later resolves. Cleared at the same boundaries as
+	// activeToolCalls.
+	terminalToolCalls map[string]bool
+
 	// Active Monitor tools, keyed by sessionID -> taskID -> toolCallID.
 	// Claude-acp's Monitor tool runs a background script that streams events
 	// back to the LLM as `<task-notification>` envelopes. We hold this map so
@@ -157,17 +166,18 @@ func NewAdapter(cfg *shared.Config, log *logger.Logger) *Adapter {
 	l := log.WithFields(zap.String("adapter", "acp"), zap.String("agent_id", cfg.AgentID))
 	ctx, cancel := context.WithCancel(context.Background())
 	a := &Adapter{
-		cfg:             cfg,
-		logger:          l,
-		agentID:         cfg.AgentID,
-		normalizer:      NewNormalizer(),
-		updatesCh:       make(chan AgentEvent, 100),
-		activeToolCalls: make(map[string]*streams.NormalizedPayload),
-		activeMonitors:  make(map[string]map[string]string),
-		pendingWakeups:  make(map[string]*pendingWakeup),
-		attachMgr:       shared.NewAttachmentManager(cfg.WorkDir, l.Zap()),
-		lifetimeCtx:     ctx,
-		lifetimeCancel:  cancel,
+		cfg:               cfg,
+		logger:            l,
+		agentID:           cfg.AgentID,
+		normalizer:        NewNormalizer(),
+		updatesCh:         make(chan AgentEvent, 100),
+		activeToolCalls:   make(map[string]*streams.NormalizedPayload),
+		terminalToolCalls: make(map[string]bool),
+		activeMonitors:    make(map[string]map[string]string),
+		pendingWakeups:    make(map[string]*pendingWakeup),
+		attachMgr:         shared.NewAttachmentManager(cfg.WorkDir, l.Zap()),
+		lifetimeCtx:       ctx,
+		lifetimeCancel:    cancel,
 	}
 	a.wakeup = newWakeupScheduler(l, a.fireWakeup)
 	return a
@@ -854,6 +864,7 @@ func (a *Adapter) cancelActiveToolCalls(sessionID string) {
 		}
 	}
 	a.activeToolCalls = preserved
+	a.terminalToolCalls = make(map[string]bool)
 	a.mu.Unlock()
 
 	for toolCallID, normalized := range toCancel {
@@ -1700,6 +1711,7 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 
 	if isTerminal {
 		delete(a.activeToolCalls, toolCallID)
+		a.terminalToolCalls[toolCallID] = true
 		// Also drop tracked Monitor: this terminal update is the
 		// agent-emitted close, so the prompt-end sweep must not re-emit a
 		// "Monitor exited" event for this same toolCallID.
@@ -1802,14 +1814,28 @@ func (a *Adapter) handlePermissionRequest(ctx context.Context, req *PermissionRe
 		sessionID = fallbackSessionID
 	}
 
+	// Drop ghost permission requests for tool calls that already finished.
+	// OpenCode (issue #717) has been observed emitting session/request_permission
+	// after streaming a terminal tool_call_update for the same tool_call_id.
+	// Forwarding it would create a permission_request message nothing later
+	// resolves; instead auto-cancel upstream so the agent can proceed.
+	a.mu.RLock()
+	_, alreadyTracked := a.activeToolCalls[req.ToolCallID]
+	terminal := a.terminalToolCalls[req.ToolCallID]
+	a.mu.RUnlock()
+
+	if terminal {
+		a.logger.Warn("dropping permission request for already-terminal tool_call",
+			zap.String("session_id", sessionID),
+			zap.String("tool_call_id", req.ToolCallID),
+			zap.String("title", req.Title))
+		return &PermissionResponse{Cancelled: true}, nil
+	}
+
 	// Only emit a synthetic tool_call event if no ToolCall notification preceded this.
 	// When a ToolCall notification exists (tracked in activeToolCalls), the message
 	// was already created by convertToolCallUpdate → handleToolCallEvent.
 	// Emitting a second tool_call for the same ID creates duplicate messages in the UI.
-	a.mu.RLock()
-	_, alreadyTracked := a.activeToolCalls[req.ToolCallID]
-	a.mu.RUnlock()
-
 	if !alreadyTracked {
 		toolCallEvent := AgentEvent{
 			Type:       streams.EventTypeToolCall,

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/permission_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/permission_test.go
@@ -1,0 +1,101 @@
+package acp
+
+import (
+	"context"
+	"testing"
+
+	acp "github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/types"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+// TestHandlePermissionRequest_ToolAlreadyTerminal_AutoCancels exercises the
+// stale-permission guard: when a session/request_permission arrives for a
+// tool_call whose terminal status was already streamed (the OpenCode bug from
+// issue #717), the adapter must auto-cancel upstream and not emit any kandev
+// event. Otherwise the orchestrator creates a permission_request message that
+// has nothing to resolve it — pending forever.
+func TestHandlePermissionRequest_ToolAlreadyTerminal_AutoCancels(t *testing.T) {
+	a := newTestAdapter()
+
+	// Seed an execute tool_call (status=pending) and stream a terminal update.
+	seedExecuteToolCall(t, a, "tc-stale")
+	completed := acp.ToolCallStatus("completed")
+	if ev := a.convertToolCallResultUpdate("session-1", &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-stale",
+		Status:     &completed,
+	}); ev == nil {
+		t.Fatalf("seed: terminal tool_call_update returned nil")
+	}
+
+	// Drain seed events so we can assert nothing new is emitted by the guard.
+	_ = drainEvents(a)
+
+	// A handler that, if invoked, fails the test — the guard must short-circuit
+	// before forwarding. Tracking whether it was called gives a clear failure
+	// when the guard regresses.
+	handlerCalled := false
+	a.SetPermissionHandler(func(_ context.Context, _ *types.PermissionRequest) (*types.PermissionResponse, error) {
+		handlerCalled = true
+		return &types.PermissionResponse{OptionID: "allow"}, nil
+	})
+
+	resp, err := a.handlePermissionRequest(context.Background(), &types.PermissionRequest{
+		SessionID:  "session-1",
+		ToolCallID: "tc-stale",
+		Title:      "Bash",
+		Options: []streams.PermissionOption{
+			{OptionID: "allow", Name: "Allow", Kind: "allow_once"},
+			{OptionID: "deny", Name: "Deny", Kind: "reject_once"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handlePermissionRequest returned error: %v", err)
+	}
+	if handlerCalled {
+		t.Fatal("permission handler was invoked for an already-terminal tool_call; guard regressed")
+	}
+	if resp == nil || !resp.Cancelled {
+		t.Fatalf("expected cancelled response, got %+v", resp)
+	}
+
+	events := drainEvents(a)
+	for _, ev := range events {
+		if ev.Type == streams.EventTypeToolCall && ev.ToolStatus == "pending_permission" {
+			t.Fatalf("guard must not emit synthetic pending_permission tool_call event, got %+v", ev)
+		}
+	}
+}
+
+// TestHandlePermissionRequest_ToolStillActive_ForwardsToHandler is the
+// happy-path counterpart: when the tool_call is still in-flight (no terminal
+// update yet), the request must reach the handler unchanged.
+func TestHandlePermissionRequest_ToolStillActive_ForwardsToHandler(t *testing.T) {
+	a := newTestAdapter()
+	seedExecuteToolCall(t, a, "tc-active")
+	_ = drainEvents(a)
+
+	handlerCalled := false
+	a.SetPermissionHandler(func(_ context.Context, _ *types.PermissionRequest) (*types.PermissionResponse, error) {
+		handlerCalled = true
+		return &types.PermissionResponse{OptionID: "allow"}, nil
+	})
+
+	resp, err := a.handlePermissionRequest(context.Background(), &types.PermissionRequest{
+		SessionID:  "session-1",
+		ToolCallID: "tc-active",
+		Title:      "Bash",
+		Options: []streams.PermissionOption{
+			{OptionID: "allow", Name: "Allow", Kind: "allow_once"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handlePermissionRequest returned error: %v", err)
+	}
+	if !handlerCalled {
+		t.Fatal("permission handler must be invoked for an active tool_call")
+	}
+	if resp == nil || resp.OptionID != "allow" {
+		t.Fatalf("expected allow response, got %+v", resp)
+	}
+}

--- a/apps/backend/internal/integration/test_server_test.go
+++ b/apps/backend/internal/integration/test_server_test.go
@@ -164,6 +164,10 @@ func (a *testMessageCreatorAdapter) UpdatePermissionMessage(ctx context.Context,
 	return a.svc.UpdatePermissionMessage(ctx, sessionID, pendingID, status)
 }
 
+func (a *testMessageCreatorAdapter) ExpirePendingPermissionsForSession(ctx context.Context, sessionID string) (int, error) {
+	return a.svc.ExpirePendingPermissionsForSession(ctx, sessionID)
+}
+
 func (a *testMessageCreatorAdapter) CreateAgentMessageStreaming(ctx context.Context, messageID, taskID, content, agentSessionID, turnID string) error {
 	_, err := a.svc.CreateMessageWithID(ctx, messageID, &taskservice.CreateMessageRequest{
 		TaskSessionID: agentSessionID,

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -316,9 +316,11 @@ func (s *Service) handleContextWindowUpdated(ctx context.Context, data watcher.C
 
 // handlePermissionRequest handles permission request events and saves as message
 func (s *Service) handlePermissionRequest(ctx context.Context, data watcher.PermissionRequestData) {
-	s.logger.Debug("handling permission request",
+	s.logger.Info("orchestrator handling permission request event",
 		zap.String("task_id", data.TaskID),
+		zap.String("session_id", data.TaskSessionID),
 		zap.String("pending_id", data.PendingID),
+		zap.String("tool_call_id", data.ToolCallID),
 		zap.String("title", data.Title))
 
 	if data.TaskSessionID == "" {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -542,6 +542,22 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 		}
 	}
 
+	// Expire any permission_request messages still showing as pending. Some
+	// agents (issue #717: OpenCode) emit a session/request_permission frame
+	// but never resolve it, leaving the user with a phantom approval card
+	// that nothing else clears.
+	if s.messageCreator != nil && payload.SessionID != "" {
+		if n, err := s.messageCreator.ExpirePendingPermissionsForSession(ctx, payload.SessionID); err != nil {
+			s.logger.Error("failed to expire pending permission messages on turn complete",
+				zap.String("session_id", payload.SessionID),
+				zap.Error(err))
+		} else if n > 0 {
+			s.logger.Info("expired pending permission messages on turn complete",
+				zap.String("session_id", payload.SessionID),
+				zap.Int("count", n))
+		}
+	}
+
 	// READY events own workflow transitions and queued prompt execution.
 	// If we're still RUNNING here, avoid racing READY by forcing WAITING/REVIEW.
 	if session != nil && session.State == models.TaskSessionStateRunning {
@@ -780,7 +796,7 @@ func (s *Service) handlePermissionCancelledEvent(ctx context.Context, payload *l
 		return
 	}
 	if err := s.messageCreator.UpdatePermissionMessage(ctx, sessionID, payload.Data.PendingID, "expired"); err != nil {
-		s.logger.Warn("failed to mark permission as expired",
+		s.logger.Error("failed to mark permission as expired",
 			zap.String("session_id", sessionID),
 			zap.String("pending_id", payload.Data.PendingID),
 			zap.Error(err))

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -73,6 +73,11 @@ type MessageCreator interface {
 	CreateSessionMessage(ctx context.Context, taskID, content, agentSessionID, messageType, turnID string, metadata map[string]interface{}, requestsInput bool) error
 	CreatePermissionRequestMessage(ctx context.Context, taskID, sessionID, pendingID, toolCallID, title, turnID string, options []map[string]interface{}, actionType string, actionDetails map[string]interface{}) (string, error)
 	UpdatePermissionMessage(ctx context.Context, sessionID, pendingID, status string) error
+	// ExpirePendingPermissionsForSession marks any still-pending
+	// permission_request messages for a session as expired. Used by the
+	// turn-complete sweep to recover from agents that emit a permission
+	// frame but never resolve it (issue #717).
+	ExpirePendingPermissionsForSession(ctx context.Context, sessionID string) (int, error)
 	// CreateAgentMessageStreaming creates a new agent message with a pre-generated ID for streaming updates
 	CreateAgentMessageStreaming(ctx context.Context, messageID, taskID, content, agentSessionID, turnID string) error
 	// AppendAgentMessage appends additional content to an existing streaming message

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1743,7 +1743,7 @@ func (s *Service) RespondToPermission(ctx context.Context, sessionID, pendingID,
 		// Permission likely expired — update message so frontend reflects this
 		if s.messageCreator != nil {
 			if updateErr := s.messageCreator.UpdatePermissionMessage(ctx, sessionID, pendingID, "expired"); updateErr != nil {
-				s.logger.Warn("failed to mark expired permission message",
+				s.logger.Error("failed to mark expired permission message",
 					zap.String("session_id", sessionID),
 					zap.String("pending_id", pendingID),
 					zap.Error(updateErr))
@@ -1761,7 +1761,7 @@ func (s *Service) RespondToPermission(ctx context.Context, sessionID, pendingID,
 	// Update the permission message with the new status
 	if s.messageCreator != nil {
 		if err := s.messageCreator.UpdatePermissionMessage(ctx, sessionID, pendingID, status); err != nil {
-			s.logger.Warn("failed to update permission message status",
+			s.logger.Error("failed to update permission message status",
 				zap.String("session_id", sessionID),
 				zap.String("pending_id", pendingID),
 				zap.String("status", status),

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -390,6 +390,10 @@ func (m *mockMessageCreator) UpdatePermissionMessage(context.Context, string, st
 	return nil
 }
 
+func (m *mockMessageCreator) ExpirePendingPermissionsForSession(context.Context, string) (int, error) {
+	return 0, nil
+}
+
 func (m *mockMessageCreator) CreateAgentMessageStreaming(context.Context, string, string, string, string, string) error {
 	return nil
 }

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -139,6 +139,9 @@ func (m *mockRepository) GetMessageByPendingID(ctx context.Context, sessionID, p
 func (m *mockRepository) FindMessageByPendingID(ctx context.Context, pendingID string) (*models.Message, error) {
 	return nil, nil
 }
+func (m *mockRepository) ExpirePendingPermissionRequestsForSession(ctx context.Context, sessionID string) ([]string, error) {
+	return nil, nil
+}
 func (m *mockRepository) UpdateMessage(ctx context.Context, message *models.Message) error {
 	return nil
 }

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -67,6 +67,11 @@ type MessageRepository interface {
 	GetMessageByPendingID(ctx context.Context, sessionID, pendingID string) (*models.Message, error)
 	FindMessageByPendingID(ctx context.Context, pendingID string) (*models.Message, error)
 	UpdateMessage(ctx context.Context, message *models.Message) error
+	// ExpirePendingPermissionRequestsForSession atomically marks every
+	// permission_request message for the session whose metadata.status is
+	// missing, empty, or "pending" as "expired". Returns the IDs of the
+	// rows that were updated.
+	ExpirePendingPermissionRequestsForSession(ctx context.Context, sessionID string) ([]string, error)
 	ListMessages(ctx context.Context, sessionID string) ([]*models.Message, error)
 	ListMessagesPaginated(ctx context.Context, sessionID string, opts models.ListMessagesOptions) ([]*models.Message, bool, error)
 	SearchMessages(ctx context.Context, sessionID string, opts models.SearchMessagesOptions) ([]*models.Message, error)

--- a/apps/backend/internal/task/repository/sqlite/message.go
+++ b/apps/backend/internal/task/repository/sqlite/message.go
@@ -332,6 +332,49 @@ func (r *Repository) FindMessageByPendingID(ctx context.Context, pendingID strin
 	return message, nil
 }
 
+// ExpirePendingPermissionRequestsForSession atomically marks every
+// permission_request message for the session whose metadata.status is NULL
+// or "pending" as "expired". Returns the IDs of rows that were updated so
+// the caller can publish message.updated events.
+//
+// The WHERE clause is what prevents the well-known race with the WS
+// approve/reject path: by the time we reach this statement, a concurrent
+// `UpdatePermissionMessage(... "approved")` may already have committed —
+// the WHERE filter sees the new "approved" status and excludes that row,
+// so this sweep can never demote a user-resolved decision back to
+// "expired".
+func (r *Repository) ExpirePendingPermissionRequestsForSession(ctx context.Context, sessionID string) ([]string, error) {
+	drv := r.db.DriverName()
+	statusExpr := dialect.JSONExtract(drv, "metadata", "status")
+	selectQuery := fmt.Sprintf(`
+		SELECT id
+		FROM task_session_messages
+		WHERE task_session_id = ?
+		  AND type = 'permission_request'
+		  AND (%s IS NULL OR %s IN ('', 'pending'))
+	`, statusExpr, statusExpr)
+
+	var ids []string
+	if err := r.db.SelectContext(ctx, &ids, r.db.Rebind(selectQuery), sessionID); err != nil {
+		return nil, fmt.Errorf("list pending permission_request messages: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	updateQuery := fmt.Sprintf(`
+		UPDATE task_session_messages
+		SET metadata = %s
+		WHERE task_session_id = ?
+		  AND type = 'permission_request'
+		  AND (%s IS NULL OR %s IN ('', 'pending'))
+	`, dialect.JSONSet(drv, "metadata", "status", "expired"), statusExpr, statusExpr)
+	if _, err := r.db.ExecContext(ctx, r.db.Rebind(updateQuery), sessionID); err != nil {
+		return nil, fmt.Errorf("expire pending permission_request messages: %w", err)
+	}
+	return ids, nil
+}
+
 // CompletePendingToolCallsForTurn marks all non-terminal tool call messages for a turn as "complete".
 // This is a safety net to ensure no tool calls remain stuck in a non-terminal state (pending,
 // running, in_progress, etc.) after a turn completes.

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -630,59 +630,45 @@ func (s *Service) FindPermissionMessageByToolCallID(ctx context.Context, session
 	return latest, nil
 }
 
-// ExpirePendingPermissionsForSession marks all permission_request messages
-// for the session that are still pending (no terminal status set) as
-// "expired", reusing UpdatePermissionMessage so each message also publishes
-// the message.updated event and cancels its related tool_call.
+// ExpirePendingPermissionsForSession atomically marks every
+// permission_request message for the session whose status is still
+// missing/"pending" as "expired", and publishes message.updated for each
+// row that flipped. Used by the orchestrator on turn complete to clean up
+// permission frames an agent emitted but never resolved (issue #717).
 //
-// Called by the orchestrator on agent turn completion to recover from agents
-// that emit permission_request frames but never resolve them — see issue
-// #717 (OpenCode ACP). Returns the number of messages transitioned.
+// The atomicity matters: the WS approve/reject path runs a separate
+// `UpdatePermissionMessage(... "approved")` and the agent's `complete`
+// notification can land while that write is in flight. A read-then-write
+// implementation here would race and overwrite "approved" with "expired",
+// leaving the FE rendering a stuck banner whose first click hits "pending
+// permission not found" because agentctl already consumed the response.
+// The repository's WHERE clause excludes any row that has already moved
+// to a terminal status, so a concurrent approve always wins the race.
 func (s *Service) ExpirePendingPermissionsForSession(ctx context.Context, sessionID string) (int, error) {
-	msgs, err := s.messages.ListMessages(ctx, sessionID)
+	expiredIDs, err := s.messages.ExpirePendingPermissionRequestsForSession(ctx, sessionID)
 	if err != nil {
 		return 0, err
 	}
-
-	expired := 0
-	for _, msg := range msgs {
-		if msg.Type != models.MessageTypePermissionRequest {
-			continue
-		}
-		if !isPendingPermissionStatus(msg.Metadata) {
-			continue
-		}
-		pendingID, _ := msg.Metadata["pending_id"].(string)
-		if pendingID == "" {
-			continue
-		}
-		if err := s.UpdatePermissionMessage(ctx, sessionID, pendingID, "expired"); err != nil {
-			s.logger.Error("failed to expire pending permission message",
+	for _, id := range expiredIDs {
+		msg, err := s.messages.GetMessage(ctx, id)
+		if err != nil || msg == nil {
+			s.logger.Warn("expired permission message not found for event publish",
 				zap.String("session_id", sessionID),
-				zap.String("pending_id", pendingID),
-				zap.String("message_id", msg.ID),
+				zap.String("message_id", id),
 				zap.Error(err))
 			continue
 		}
-		expired++
+		s.publishMessageEvent(ctx, events.MessageUpdated, msg)
+		if toolCallID, ok := msg.Metadata["tool_call_id"].(string); ok && toolCallID != "" {
+			if err := s.UpdateToolCallMessage(ctx, sessionID, toolCallID, "error", "", "", nil); err != nil {
+				s.logger.Warn("failed to cancel related tool call message after expire",
+					zap.String("tool_call_id", toolCallID),
+					zap.String("message_id", id),
+					zap.Error(err))
+			}
+		}
 	}
-	return expired, nil
-}
-
-// isPendingPermissionStatus reports whether a permission_request message's
-// metadata indicates it is still awaiting user resolution. Missing or empty
-// status counts as pending — the create path doesn't always set it.
-func isPendingPermissionStatus(metadata map[string]interface{}) bool {
-	if metadata == nil {
-		return true
-	}
-	status, _ := metadata["status"].(string)
-	switch status {
-	case "", "pending":
-		return true
-	default:
-		return false
-	}
+	return len(expiredIDs), nil
 }
 
 // UpdateClarificationMessage updates a clarification request message's status and response.

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -535,6 +535,23 @@ func (s *Service) UpdatePermissionMessage(ctx context.Context, sessionID, pendin
 	if message.Metadata == nil {
 		message.Metadata = make(map[string]interface{})
 	}
+
+	// Never demote a user-resolved permission. The turn-complete sweep races
+	// with the WS approve/reject path: if `complete` arrives before the
+	// approve write commits, the sweep can otherwise overwrite "approved"
+	// with "expired" — which is what the user sees as a stuck card whose
+	// next click hits "pending permission not found" because agentctl
+	// already consumed the response.
+	if status == "expired" {
+		current, _ := message.Metadata["status"].(string)
+		if current == "approved" || current == "rejected" {
+			s.logger.Debug("skipping expire of already-resolved permission",
+				zap.String("message_id", message.ID),
+				zap.String("pending_id", pendingID),
+				zap.String("current_status", current))
+			return nil
+		}
+	}
 	message.Metadata["status"] = status
 
 	if err := s.messages.UpdateMessage(ctx, message); err != nil {

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -600,6 +600,36 @@ func (s *Service) GetPermissionMessageByPendingID(ctx context.Context, sessionID
 	return msg, nil
 }
 
+// FindPermissionMessageByToolCallID returns the most recent
+// permission_request message for the session+tool_call_id, or (nil, nil)
+// if none exists. Used as a stronger dedupe key than pending_id when the
+// upstream layer (process.Manager) generates a fresh nanos-suffixed
+// pending_id on every forward — re-emitted permission frames for the
+// same tool_call would otherwise each get their own DB row.
+func (s *Service) FindPermissionMessageByToolCallID(ctx context.Context, sessionID, toolCallID string) (*models.Message, error) {
+	if toolCallID == "" {
+		return nil, nil
+	}
+	msgs, err := s.messages.ListMessages(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	var latest *models.Message
+	for _, msg := range msgs {
+		if msg.Type != models.MessageTypePermissionRequest {
+			continue
+		}
+		tcID, _ := msg.Metadata["tool_call_id"].(string)
+		if tcID != toolCallID {
+			continue
+		}
+		if latest == nil || msg.CreatedAt.After(latest.CreatedAt) {
+			latest = msg
+		}
+	}
+	return latest, nil
+}
+
 // ExpirePendingPermissionsForSession marks all permission_request messages
 // for the session that are still pending (no terminal status set) as
 // "expired", reusing UpdatePermissionMessage so each message also publishes

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -586,6 +586,20 @@ func (s *Service) UpdatePermissionMessage(ctx context.Context, sessionID, pendin
 	return nil
 }
 
+// GetPermissionMessageByPendingID looks up an existing permission_request
+// message by session and pending_id. Returns (nil, nil) if not found —
+// callers use this for idempotency (de-dupe re-emitted permission frames).
+func (s *Service) GetPermissionMessageByPendingID(ctx context.Context, sessionID, pendingID string) (*models.Message, error) {
+	msg, err := s.messages.GetMessageByPendingID(ctx, sessionID, pendingID)
+	if err != nil {
+		return nil, nil //nolint:nilerr // not found is the common case; treat as absence
+	}
+	if msg == nil || msg.Type != models.MessageTypePermissionRequest {
+		return nil, nil
+	}
+	return msg, nil
+}
+
 // ExpirePendingPermissionsForSession marks all permission_request messages
 // for the session that are still pending (no terminal status set) as
 // "expired", reusing UpdatePermissionMessage so each message also publishes

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -569,6 +569,61 @@ func (s *Service) UpdatePermissionMessage(ctx context.Context, sessionID, pendin
 	return nil
 }
 
+// ExpirePendingPermissionsForSession marks all permission_request messages
+// for the session that are still pending (no terminal status set) as
+// "expired", reusing UpdatePermissionMessage so each message also publishes
+// the message.updated event and cancels its related tool_call.
+//
+// Called by the orchestrator on agent turn completion to recover from agents
+// that emit permission_request frames but never resolve them — see issue
+// #717 (OpenCode ACP). Returns the number of messages transitioned.
+func (s *Service) ExpirePendingPermissionsForSession(ctx context.Context, sessionID string) (int, error) {
+	msgs, err := s.messages.ListMessages(ctx, sessionID)
+	if err != nil {
+		return 0, err
+	}
+
+	expired := 0
+	for _, msg := range msgs {
+		if msg.Type != models.MessageTypePermissionRequest {
+			continue
+		}
+		if !isPendingPermissionStatus(msg.Metadata) {
+			continue
+		}
+		pendingID, _ := msg.Metadata["pending_id"].(string)
+		if pendingID == "" {
+			continue
+		}
+		if err := s.UpdatePermissionMessage(ctx, sessionID, pendingID, "expired"); err != nil {
+			s.logger.Error("failed to expire pending permission message",
+				zap.String("session_id", sessionID),
+				zap.String("pending_id", pendingID),
+				zap.String("message_id", msg.ID),
+				zap.Error(err))
+			continue
+		}
+		expired++
+	}
+	return expired, nil
+}
+
+// isPendingPermissionStatus reports whether a permission_request message's
+// metadata indicates it is still awaiting user resolution. Missing or empty
+// status counts as pending — the create path doesn't always set it.
+func isPendingPermissionStatus(metadata map[string]interface{}) bool {
+	if metadata == nil {
+		return true
+	}
+	status, _ := metadata["status"].(string)
+	switch status {
+	case "", "pending":
+		return true
+	default:
+		return false
+	}
+}
+
 // UpdateClarificationMessage updates a clarification request message's status and response.
 // It includes retry logic to handle race conditions.
 // The answers parameter should be a slice of answer objects with question_id, selected_options, and custom_text.

--- a/apps/backend/internal/task/service/service_permissions_test.go
+++ b/apps/backend/internal/task/service/service_permissions_test.go
@@ -110,6 +110,41 @@ func TestService_UpdatePermissionMessage_ExpiredCannotDemoteApproved(t *testing.
 	}
 }
 
+// TestService_GetPermissionMessageByPendingID guards the lookup the
+// CreatePermissionRequestMessage adapter uses for idempotency. Returns the
+// matching message when present, (nil, nil) when not — and (nil, nil) for a
+// message with the same pending_id but a non-permission type, so the
+// adapter doesn't accidentally treat e.g. a tool_call message as a
+// duplicate.
+func TestService_GetPermissionMessageByPendingID(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	sessionID := setupTestSession(t, repo)
+	turnID := setupTestTurn(t, repo, sessionID, "task-123", "turn-perm-lookup")
+
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-perm", "pend-find", map[string]any{
+		"pending_id": "pend-find",
+	})
+
+	got, err := svc.GetPermissionMessageByPendingID(ctx, sessionID, "pend-find")
+	if err != nil {
+		t.Fatalf("GetPermissionMessageByPendingID: %v", err)
+	}
+	if got == nil || got.ID != "msg-perm" {
+		t.Fatalf("expected msg-perm, got %+v", got)
+	}
+
+	got, err = svc.GetPermissionMessageByPendingID(ctx, sessionID, "no-such-pending")
+	if err != nil {
+		t.Fatalf("absent lookup returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for absent pending_id, got %+v", got)
+	}
+}
+
 // TestService_ExpirePendingPermissionsForSession_NoPending is a no-op
 // fast-path: when nothing is pending, the sweep must return zero and not
 // fail.

--- a/apps/backend/internal/task/service/service_permissions_test.go
+++ b/apps/backend/internal/task/service/service_permissions_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// TestService_ExpirePendingPermissionsForSession_MarksOnlyPending guards the
+// turn-complete sweep added for issue #717: when an agent finishes its turn,
+// any permission_request messages still in pending status must transition to
+// expired so the UI stops showing approval cards. Already-resolved messages
+// (approved/rejected/expired) must not be re-touched.
+func TestService_ExpirePendingPermissionsForSession_MarksOnlyPending(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	sessionID := setupTestSession(t, repo)
+	turnID := setupTestTurn(t, repo, sessionID, "task-123", "turn-perm-1")
+
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-pending-1", "pend-1", map[string]any{
+		"pending_id": "pend-1",
+	})
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-pending-2", "pend-2", map[string]any{
+		"pending_id": "pend-2",
+		"status":     "pending",
+	})
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-approved", "pend-3", map[string]any{
+		"pending_id": "pend-3",
+		"status":     "approved",
+	})
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-rejected", "pend-4", map[string]any{
+		"pending_id": "pend-4",
+		"status":     "rejected",
+	})
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-already-expired", "pend-5", map[string]any{
+		"pending_id": "pend-5",
+		"status":     "expired",
+	})
+
+	count, err := svc.ExpirePendingPermissionsForSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("ExpirePendingPermissionsForSession: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 pending messages expired, got %d", count)
+	}
+
+	cases := []struct {
+		id   string
+		want string
+	}{
+		{"msg-pending-1", "expired"},
+		{"msg-pending-2", "expired"},
+		{"msg-approved", "approved"},
+		{"msg-rejected", "rejected"},
+		{"msg-already-expired", "expired"},
+	}
+	for _, c := range cases {
+		got, err := repo.GetMessage(ctx, c.id)
+		if err != nil {
+			t.Fatalf("GetMessage(%s): %v", c.id, err)
+		}
+		status, _ := got.Metadata["status"].(string)
+		if status != c.want {
+			t.Errorf("%s: status = %q, want %q", c.id, status, c.want)
+		}
+	}
+}
+
+// TestService_ExpirePendingPermissionsForSession_NoPending is a no-op
+// fast-path: when nothing is pending, the sweep must return zero and not
+// fail.
+func TestService_ExpirePendingPermissionsForSession_NoPending(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	sessionID := setupTestSession(t, repo)
+
+	count, err := svc.ExpirePendingPermissionsForSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("ExpirePendingPermissionsForSession: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 with no permission messages, got %d", count)
+	}
+}
+
+func mustCreatePermMsg(t *testing.T, repo interface {
+	CreateMessage(ctx context.Context, m *models.Message) error
+}, sessionID, turnID, id, _ string, metadata map[string]any) {
+	t.Helper()
+	msg := &models.Message{
+		ID:            id,
+		TaskSessionID: sessionID,
+		TaskID:        "task-123",
+		TurnID:        turnID,
+		AuthorType:    models.MessageAuthorAgent,
+		AuthorID:      "agent-123",
+		Content:       "Permission required",
+		Type:          models.MessageTypePermissionRequest,
+		Metadata:      metadata,
+	}
+	if err := repo.CreateMessage(context.Background(), msg); err != nil {
+		t.Fatalf("seed permission message %s: %v", id, err)
+	}
+}

--- a/apps/backend/internal/task/service/service_permissions_test.go
+++ b/apps/backend/internal/task/service/service_permissions_test.go
@@ -70,6 +70,46 @@ func TestService_ExpirePendingPermissionsForSession_MarksOnlyPending(t *testing.
 	}
 }
 
+// TestService_UpdatePermissionMessage_ExpiredCannotDemoteApproved guards the
+// race between the WS approve/reject path and the turn-complete sweep. If
+// `complete` lands before the approve write commits, the sweep would
+// otherwise clobber "approved" with "expired" — which the user observes as
+// a stuck banner whose next click hits "pending permission not found"
+// (agentctl already consumed the response).
+func TestService_UpdatePermissionMessage_ExpiredCannotDemoteApproved(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	sessionID := setupTestSession(t, repo)
+	turnID := setupTestTurn(t, repo, sessionID, "task-123", "turn-perm-race")
+
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-approved", "pend-A", map[string]any{
+		"pending_id": "pend-A",
+		"status":     "approved",
+	})
+	mustCreatePermMsg(t, repo, sessionID, turnID, "msg-rejected", "pend-R", map[string]any{
+		"pending_id": "pend-R",
+		"status":     "rejected",
+	})
+
+	if err := svc.UpdatePermissionMessage(ctx, sessionID, "pend-A", "expired"); err != nil {
+		t.Fatalf("UpdatePermissionMessage approved→expired: %v", err)
+	}
+	if err := svc.UpdatePermissionMessage(ctx, sessionID, "pend-R", "expired"); err != nil {
+		t.Fatalf("UpdatePermissionMessage rejected→expired: %v", err)
+	}
+
+	approved, _ := repo.GetMessage(ctx, "msg-approved")
+	if got, _ := approved.Metadata["status"].(string); got != "approved" {
+		t.Errorf("approved permission was demoted to %q", got)
+	}
+	rejected, _ := repo.GetMessage(ctx, "msg-rejected")
+	if got, _ := rejected.Metadata["status"].(string); got != "rejected" {
+		t.Errorf("rejected permission was demoted to %q", got)
+	}
+}
+
 // TestService_ExpirePendingPermissionsForSession_NoPending is a no-op
 // fast-path: when nothing is pending, the sweep must return zero and not
 // fail.

--- a/apps/web/components/task/chat/messages/tool-call-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-call-message.tsx
@@ -130,7 +130,10 @@ function parsePermission(permissionMessage: Message | undefined) {
   const permissionMetadata = permissionMessage?.metadata as PermissionRequestMetadata | undefined;
   const permissionStatus = permissionMetadata?.status;
   const isPermissionPending =
-    !!permissionMessage && permissionStatus !== "approved" && permissionStatus !== "rejected";
+    !!permissionMessage &&
+    permissionStatus !== "approved" &&
+    permissionStatus !== "rejected" &&
+    permissionStatus !== "expired";
   return { permissionMetadata, permissionStatus, isPermissionPending };
 }
 

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -37,7 +37,19 @@ function isPermissionVisible(message: Message, toolCallIds: Set<string>): boolea
   const toolCallId = metadata?.tool_call_id;
   if (toolCallId && toolCallIds.has(toolCallId)) return false;
   const status = metadata?.status;
-  if (status === "approved" || status === "denied" || status === "cancelled") return false;
+  // Backend writes status "approved" / "rejected" / "expired" (see
+  // task/service/service_messages.go). The earlier "denied" / "cancelled"
+  // values are accepted as legacy aliases — if a real resolved permission
+  // ever slips past the toolCallIds dedup, never resurface it as a fresh
+  // approve card.
+  if (
+    status === "approved" ||
+    status === "rejected" ||
+    status === "denied" ||
+    status === "expired" ||
+    status === "cancelled"
+  )
+    return false;
   return true;
 }
 

--- a/docs/specs/opencode-stale-approvals/notes.md
+++ b/docs/specs/opencode-stale-approvals/notes.md
@@ -1,0 +1,59 @@
+# Stale OpenCode permission approvals — investigation notes
+
+GH issue: https://github.com/kdlbs/kandev/issues/717
+
+## ACP frame capture
+
+Captured raw ACP wire frames between `acpdbg` and `opencode acp` (v1.14.28) on
+2026-04-27. With OpenCode's default permission policy, no
+`session/request_permission` is emitted — the agent auto-approves bash/edits
+locally. After forcing `permission: { bash: "ask" }` via a workspace
+`opencode.json`, OpenCode emits the permission flow as expected.
+
+JSONL: `/tmp/acpdbg-opencode/opencode-acp-prompt-20260427-214819.jsonl`
+
+Observed nominal frame order (per turn, single bash tool call):
+
+1. `session/update` `tool_call` — status `pending`
+2. `session/update` `tool_call_update` — status `in_progress`
+3. `session/request_permission` — JSON-RPC request awaiting reply
+4. (acpdbg auto-replies `-32601 method not found`)
+5. `session/update` `tool_call_update` — status `failed` (treated as denial)
+6. `session/update` `usage_update`, then turn ends
+
+## Finding
+
+Under happy path, OpenCode posts `session/request_permission` only **between**
+the in-progress notification and the terminal status. So the kandev adapter's
+existing dedup logic (`activeToolCalls[req.ToolCallID]` lookup) sees the entry
+present and skips emitting a synthetic `tool_call`.
+
+The reported symptom — permission cards appearing **after** the user already
+approved and the agent finished the turn — is not reproducible with `acpdbg`'s
+canned replies, but the gap is real in our flow:
+
+- `convertToolCallResultUpdate` at adapter.go:1701 deletes
+  `activeToolCalls[id]` as soon as a terminal `tool_call_update` arrives.
+- A subsequent (out-of-order or duplicate) `session/request_permission` for
+  that same tool call ID then misses the dedup branch (`alreadyTracked=false`),
+  emits a synthetic `tool_call` event with status `pending_permission`, and
+  registers a pending message that nothing later resolves.
+- `process/manager.handlePermissionRequest` blocks indefinitely on
+  `ResponseCh`. There is no turn-complete sweep for permissions analogous to
+  `clarification.Canceller`. Even if the user closes the page, the pending
+  message persists across reloads.
+- `UpdatePermissionMessage` failures from `RespondToPermission` and the cancel
+  handler are only `Warn`-logged, so silent drops never surface.
+
+## Fix scope
+
+1. Adapter guard in `acp/adapter.go:handlePermissionRequest`: track recently
+   terminal tool-call IDs; on permission request for one, auto-cancel upstream
+   and skip emitting any kandev event.
+2. Turn-complete sweep: on `agent_complete`, mark any pending
+   `permission_request` messages for the session as `expired` (mirroring
+   `ClarificationCanceller`).
+3. Bump `UpdatePermissionMessage` failure logs from `Warn` to `Error`.
+
+Both defensive and orthogonal — fix #1 prevents new ghost messages, fix #2
+recovers from any that slipped through (other agents, prior bugs, restarts).


### PR DESCRIPTION
## Summary

Closes #717. Permission approval cards from OpenCode (and any agent that emits `session/request_permission` after a tool already finished, or never resolves the request) stayed pending forever — even after the user clicked Approve and the agent moved on.

Two-part defensive fix:

- **Adapter guard** (`acp/adapter.go`): track recently-terminal `tool_call_id`s alongside `activeToolCalls`. If a `session/request_permission` arrives for an ID we've already seen finish, log a Warn, return `Cancelled` upstream, and emit no kandev event. The existing `activeToolCalls` dedup branch only covered the in-flight case.
- **Turn-complete sweep** (`orchestrator` + `task/service`): on `agent_complete`, iterate the session's `permission_request` messages whose metadata.status is empty/`pending` and route each through `UpdatePermissionMessage(..., "expired")`. Mirrors the `ClarificationCanceller` pattern so the existing message.updated event publish + related-tool_call cancel logic kicks in unchanged.
- **Log severity bump**: three call-site `Warn` logs around `UpdatePermissionMessage` failures bumped to `Error` so silent drops are visible under default log filtering.

## Investigation

`docs/specs/opencode-stale-approvals/notes.md` records a raw ACP frame capture from `acpdbg prompt opencode-acp` confirming OpenCode's normal permission ordering and the gap that lets ghost requests slip through.

## Test plan

- [x] New unit test: `TestHandlePermissionRequest_ToolAlreadyTerminal_AutoCancels` (adapter guard returns Cancelled, never invokes handler, never emits synthetic tool_call)
- [x] New unit test: `TestHandlePermissionRequest_ToolStillActive_ForwardsToHandler` (happy path still forwards)
- [x] New unit test: `TestService_ExpirePendingPermissionsForSession_MarksOnlyPending` (expires only pending, leaves approved/rejected/already-expired untouched)
- [x] New unit test: `TestService_ExpirePendingPermissionsForSession_NoPending` (no-op when no permission messages)
- [x] `make fmt vet test lint` (0 issues)
- [ ] Manual smoke: run a tool that requires permission against an OpenCode session, verify card resolves on approve and that no stale card persists after agent finishes