### PR TITLE
fix(orchestrator): drain queued message on workflow transition to non-auto-start step

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -128,6 +128,9 @@ type mockAgentManager struct {
 
 	// Prompt tracking
 	capturedPrompts []string // tracks prompts passed to PromptAgent
+	// Optional: closed once on the first PromptAgent call so tests can wait
+	// deterministically without polling. Tests opt in by initializing the channel.
+	promptDone chan struct{}
 
 	// Passthrough stdin tracking
 	passthroughStdinCalls []passthroughStdinCall
@@ -169,12 +172,21 @@ func (m *mockAgentManager) StopAgentWithReason(_ context.Context, agentExecution
 	return nil
 }
 func (m *mockAgentManager) PromptAgent(_ context.Context, _ string, prompt string, _ []v1.MessageAttachment) (*executor.PromptResult, error) {
+	m.mu.Lock()
+	first := len(m.capturedPrompts) == 0
 	m.capturedPrompts = append(m.capturedPrompts, prompt)
-	if m.promptErr != nil {
-		return nil, m.promptErr
+	promptErr := m.promptErr
+	promptResult := m.promptResult
+	doneCh := m.promptDone
+	m.mu.Unlock()
+	if first && doneCh != nil {
+		close(doneCh)
 	}
-	if m.promptResult != nil {
-		return m.promptResult, nil
+	if promptErr != nil {
+		return nil, promptErr
+	}
+	if promptResult != nil {
+		return promptResult, nil
 	}
 	return &executor.PromptResult{}, nil
 }

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -610,6 +610,7 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 	if len(step.Events.OnEnter) == 0 && !sessionSwitched {
 		s.setSessionWaitingForInput(ctx, taskID, sessionID, session)
 		s.publishSessionWaitingEvent(ctx, taskID, sessionID, step.ID, session)
+		s.drainQueuedMessageAfterTransition(ctx, sessionID)
 		return
 	}
 
@@ -702,7 +703,32 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 		}
 		s.setSessionWaitingForInput(ctx, taskID, sessionID, session)
 		s.publishSessionWaitingEvent(ctx, taskID, sessionID, step.ID, session)
+		// handleAgentReady early-returns when a workflow transition occurs (#677),
+		// so user-queued messages would otherwise stick forever on transitions to
+		// steps without auto_start_agent (e.g. Review). Drain here to match the
+		// pre-#677 behavior where handleAgentReady always drained after returning
+		// from inline processOnEnter.
+		s.drainQueuedMessageAfterTransition(ctx, sessionID)
 	}
+}
+
+// drainQueuedMessageAfterTransition takes any user-queued message and dispatches
+// it for execution. Used by processOnEnter branches that don't auto-start the
+// agent — without this, the message is orphaned because handleAgentReady skips
+// the queue when a workflow transition occurred.
+func (s *Service) drainQueuedMessageAfterTransition(ctx context.Context, sessionID string) {
+	if s.messageQueue == nil {
+		return
+	}
+	queuedMsg, ok := s.messageQueue.TakeQueued(ctx, sessionID)
+	if !ok || queuedMsg == nil {
+		return
+	}
+	s.publishQueueStatusEvent(ctx, sessionID)
+	if queuedMsg.Content == "" && len(queuedMsg.Attachments) == 0 {
+		return
+	}
+	go s.executeQueuedMessage(sessionID, queuedMsg)
 }
 
 // deliverPassthroughPrompt writes a prompt to PTY stdin and marks the session as running.

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -697,6 +697,7 @@ func (s *Service) processOnEnter(ctx context.Context, taskID string, session *mo
 						zap.Error(err))
 					s.setSessionWaitingForInput(asyncCtx, taskID, sessionID, session)
 					s.publishSessionWaitingEvent(asyncCtx, taskID, sessionID, stepID, session)
+					s.drainQueuedMessageAfterTransition(asyncCtx, sessionID)
 				}
 			}()
 			return
@@ -726,6 +727,9 @@ func (s *Service) drainQueuedMessageAfterTransition(ctx context.Context, session
 	}
 	s.publishQueueStatusEvent(ctx, sessionID)
 	if queuedMsg.Content == "" && len(queuedMsg.Attachments) == 0 {
+		s.logger.Warn("skipping empty queued message after transition",
+			zap.String("session_id", sessionID),
+			zap.String("queue_id", queuedMsg.ID))
 		return
 	}
 	go s.executeQueuedMessage(sessionID, queuedMsg)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -352,6 +353,65 @@ func TestProcessOnEnter(t *testing.T) {
 		pm, _ := updated.Metadata["plan_mode"].(bool)
 		if !pm {
 			t.Error("expected plan_mode to persist in session metadata")
+		}
+	})
+
+	// Regression: a workflow transition to a step without auto_start_agent
+	// (e.g. Review) must still drain a user-queued message. Pre-#677 the drain
+	// happened in handleAgentReady after inline processOnEnter returned;
+	// #677 made handleAgentReady early-return on transition, which orphaned
+	// the queue for any step that didn't auto-start.
+	t.Run("drains user-queued message when entering step without auto_start_agent", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+
+		// Mirror applyEngineTransition's pre-flip so processOnEnter sees the
+		// session in the same state it would in production.
+		session, _ := repo.GetTaskSession(ctx, "s1")
+		session.State = models.TaskSessionStateWaitingForInput
+		session.AgentExecutionID = "exec-1"
+		_ = repo.UpdateTaskSession(ctx, session)
+
+		agentMgr := &mockAgentManager{isAgentRunning: true}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+		svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+		if _, err := svc.messageQueue.QueueMessage(ctx, "s1", "t1", "user queued msg", "", "user", false, nil); err != nil {
+			t.Fatalf("failed to seed queued message: %v", err)
+		}
+
+		reviewStep := &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Review", Position: 1,
+			// No on_enter actions — this is the broken case before the fix.
+		}
+
+		session, _ = repo.GetTaskSession(ctx, "s1")
+		svc.processOnEnter(ctx, "t1", session, reviewStep, "task description")
+
+		// executeQueuedMessage runs in a goroutine; wait for it to call PromptAgent.
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			agentMgr.mu.Lock()
+			n := len(agentMgr.capturedPrompts)
+			agentMgr.mu.Unlock()
+			if n > 0 {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("timed out waiting for queued message to be sent to agent")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		agentMgr.mu.Lock()
+		got := agentMgr.capturedPrompts[0]
+		agentMgr.mu.Unlock()
+		if got != "user queued msg" {
+			t.Fatalf("agent received %q, want %q", got, "user queued msg")
+		}
+
+		if status := svc.messageQueue.GetStatus(ctx, "s1"); status.IsQueued {
+			t.Fatalf("expected queue to be drained, still queued: %+v", status.Message)
 		}
 	})
 

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_triggers_test.go
@@ -372,7 +372,7 @@ func TestProcessOnEnter(t *testing.T) {
 		session.AgentExecutionID = "exec-1"
 		_ = repo.UpdateTaskSession(ctx, session)
 
-		agentMgr := &mockAgentManager{isAgentRunning: true}
+		agentMgr := &mockAgentManager{isAgentRunning: true, promptDone: make(chan struct{})}
 		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
 		svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
 
@@ -388,19 +388,10 @@ func TestProcessOnEnter(t *testing.T) {
 		session, _ = repo.GetTaskSession(ctx, "s1")
 		svc.processOnEnter(ctx, "t1", session, reviewStep, "task description")
 
-		// executeQueuedMessage runs in a goroutine; wait for it to call PromptAgent.
-		deadline := time.Now().Add(2 * time.Second)
-		for {
-			agentMgr.mu.Lock()
-			n := len(agentMgr.capturedPrompts)
-			agentMgr.mu.Unlock()
-			if n > 0 {
-				break
-			}
-			if time.Now().After(deadline) {
-				t.Fatal("timed out waiting for queued message to be sent to agent")
-			}
-			time.Sleep(10 * time.Millisecond)
+		select {
+		case <-agentMgr.promptDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for queued message to be sent to agent")
 		}
 
 		agentMgr.mu.Lock()


### PR DESCRIPTION
A workflow transition to a step without `auto_start_agent` (e.g. In Progress → Review) was leaving user-queued messages stranded forever — `handleAgentReady` early-returns on transition (#677) and the new step had nothing to drain the queue. `processOnEnter`'s no-auto-start paths now drain explicitly, restoring the pre-#677 behavior for those transitions while keeping the auto-start deadlock fix intact.

## Validation

- `go test ./internal/orchestrator/... ./internal/workflow/...` (all pass, including the new regression test)
- `golangci-lint run ./...` clean across the backend
- `make fmt`

## Possible Improvements

Low risk. The `auto_start_agent` path remains unchanged — user-queued messages on those transitions still get superseded by the step's auto-start prompt, same as before. A follow-up could merge user-queued content with the auto-start prompt, but that's a separate UX decision.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.