### PR TITLE
fix(web): preserve chat scroll position when maximizing panel

### DIFF
--- a/apps/web/e2e/tests/session/session-layout.spec.ts
+++ b/apps/web/e2e/tests/session/session-layout.spec.ts
@@ -212,11 +212,14 @@ test.describe("Session layout", () => {
     // Bug invariant: after maximize, scrollTop must NOT snap back to 0.
     // The fix preserves the user's vertical position so they remain anchored
     // somewhere mid/bottom of the conversation, not jumped to the top.
-    // We wait for the layout to settle (rAF + restore happens within ~1 frame
-    // of clearing isRestoringLayout) before sampling the final scroll value.
-    await testPage.waitForTimeout(500);
-    const restoredScrollTop = await chatListAfter.evaluate((el) => el.scrollTop);
-    expect(restoredScrollTop).toBeGreaterThan(50);
+    // Poll instead of a fixed sleep — the rAF restore lands within ~1 frame
+    // after isRestoringLayout clears.
+    await expect
+      .poll(async () => chatListAfter.evaluate((el) => el.scrollTop), {
+        timeout: 2_000,
+        message: "scroll position should be restored after maximize",
+      })
+      .toBeGreaterThan(50);
   });
 });
 

--- a/apps/web/e2e/tests/session/session-layout.spec.ts
+++ b/apps/web/e2e/tests/session/session-layout.spec.ts
@@ -158,6 +158,66 @@ test.describe("Session layout", () => {
     // Terminal should be gone (it was closed)
     await expect(session.terminal).not.toBeVisible({ timeout: 5_000 });
   });
+
+  test("maximize chat panel preserves scroll position", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // Seed a session whose script emits enough messages to overflow the chat list,
+    // so the user can be scrolled away from the bottom.
+    const script = Array.from(
+      { length: 30 },
+      (_, i) =>
+        `e2e:message("Message number ${i + 1} - lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua")`,
+    ).join("\n");
+
+    await seedTaskWithSession(testPage, apiClient, seedData, "Chat Maximize Scroll", script);
+
+    const chatList = testPage.locator(".chat-message-list:visible").first();
+    await chatList.waitFor({ state: "visible", timeout: 10_000 });
+
+    // Wait for the message list to overflow so we have room to scroll up.
+    await expect
+      .poll(async () => chatList.evaluate((el) => el.scrollHeight - el.clientHeight), {
+        timeout: 15_000,
+        message: "Waiting for chat to overflow",
+      })
+      .toBeGreaterThan(200);
+
+    // Scroll to roughly the middle so we are clearly away from the top.
+    // (Exact scrollTop won't match after maximize because the panel resizes
+    // and content reflows — we only assert the bug invariant: scroll did
+    // not snap back to 0/top.)
+    const targetScrollTop = await chatList.evaluate((el) => {
+      el.scrollTop = Math.floor((el.scrollHeight - el.clientHeight) / 2);
+      return el.scrollTop;
+    });
+    expect(targetScrollTop).toBeGreaterThan(100);
+
+    // Click maximize on the dockview group whose tab is the chat session tab.
+    // Note: the chat panel content is rendered via a portal outside `.dv-groupview`,
+    // so we identify the group by its tab (`session-tab-<id>`) instead.
+    const chatMaxBtn = testPage
+      .locator(
+        `.dv-groupview:has([data-testid^="session-tab-"]) .dv-tabs-and-actions-container [data-testid="dockview-maximize-btn"]`,
+      )
+      .first();
+    await chatMaxBtn.click();
+
+    // Re-locate after layout change (panel content may be re-mounted).
+    const chatListAfter = testPage.locator(".chat-message-list:visible").first();
+    await chatListAfter.waitFor({ state: "visible", timeout: 5_000 });
+
+    // Bug invariant: after maximize, scrollTop must NOT snap back to 0.
+    // The fix preserves the user's vertical position so they remain anchored
+    // somewhere mid/bottom of the conversation, not jumped to the top.
+    // We wait for the layout to settle (rAF + restore happens within ~1 frame
+    // of clearing isRestoringLayout) before sampling the final scroll value.
+    await testPage.waitForTimeout(500);
+    const restoredScrollTop = await chatListAfter.evaluate((el) => el.scrollTop);
+    expect(restoredScrollTop).toBeGreaterThan(50);
+  });
 });
 
 test.describe("Session tab cleanup", () => {

--- a/apps/web/lib/state/dockview-scroll-preserve.test.ts
+++ b/apps/web/lib/state/dockview-scroll-preserve.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Fake store API exposed by the mock below. Tests drive it directly to simulate
+// the dockview store's setPendingChatScrollTop / subscribe / getState surface.
+type Listener = (state: { isRestoringLayout: boolean }) => void;
+const fakeStore = {
+  isRestoringLayout: false,
+  pendingChatScrollTop: null as number | null,
+  setPendingChatScrollTop: vi.fn((v: number | null) => {
+    fakeStore.pendingChatScrollTop = v;
+  }),
+  listeners: new Set<Listener>(),
+  emit() {
+    for (const l of fakeStore.listeners) l({ isRestoringLayout: fakeStore.isRestoringLayout });
+  },
+};
+
+vi.mock("./dockview-store", () => ({
+  useDockviewStore: {
+    getState: () => fakeStore,
+    subscribe: (listener: Listener) => {
+      fakeStore.listeners.add(listener);
+      return () => fakeStore.listeners.delete(listener);
+    },
+  },
+}));
+
+import { preserveChatScrollDuringLayout } from "./dockview-scroll-preserve";
+
+function flushRaf(): Promise<void> {
+  // happy-dom's requestAnimationFrame is asynchronous; flush via a microtask
+  // followed by a 0ms timeout, which is enough for a single rAF callback.
+  return new Promise((resolve) => setTimeout(resolve, 16));
+}
+
+function makeChatList(scrollTop: number): HTMLElement {
+  const el = document.createElement("div");
+  el.className = "chat-message-list";
+  // happy-dom does not enforce overflow; assign scrollTop directly.
+  Object.defineProperty(el, "scrollTop", {
+    value: scrollTop,
+    writable: true,
+    configurable: true,
+  });
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("preserveChatScrollDuringLayout", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    fakeStore.isRestoringLayout = false;
+    fakeStore.pendingChatScrollTop = null;
+    fakeStore.listeners.clear();
+    fakeStore.setPendingChatScrollTop.mockClear();
+  });
+
+  it("captures the current scrollTop and stores it as pending", () => {
+    makeChatList(250);
+
+    preserveChatScrollDuringLayout();
+
+    expect(fakeStore.setPendingChatScrollTop).toHaveBeenCalledWith(250);
+    expect(fakeStore.pendingChatScrollTop).toBe(250);
+  });
+
+  it("uses 0 when no chat list element is present", () => {
+    preserveChatScrollDuringLayout();
+    expect(fakeStore.setPendingChatScrollTop).toHaveBeenCalledWith(0);
+  });
+
+  it("restores scrollTop and clears pending after isRestoringLayout flips to false", async () => {
+    const el = makeChatList(250);
+    fakeStore.isRestoringLayout = true;
+
+    preserveChatScrollDuringLayout();
+
+    // While restoring, the listener should not act.
+    fakeStore.emit();
+    expect(el.scrollTop).toBe(250);
+    expect(fakeStore.pendingChatScrollTop).toBe(250);
+
+    // Layout restore completes — listener fires and schedules the rAF restore.
+    el.scrollTop = 0; // simulate dockview wiping the position during rebuild
+    fakeStore.isRestoringLayout = false;
+    fakeStore.emit();
+
+    await flushRaf();
+
+    expect(el.scrollTop).toBe(250);
+    expect(fakeStore.setPendingChatScrollTop).toHaveBeenLastCalledWith(null);
+    expect(fakeStore.listeners.size).toBe(0);
+  });
+
+  it("restores against the latest .chat-message-list element (handles re-mount)", async () => {
+    const original = makeChatList(180);
+    fakeStore.isRestoringLayout = true;
+
+    preserveChatScrollDuringLayout();
+
+    // Simulate the panel being torn down and a new one mounted before restore.
+    original.remove();
+    const replacement = makeChatList(0);
+
+    fakeStore.isRestoringLayout = false;
+    fakeStore.emit();
+
+    await flushRaf();
+
+    expect(replacement.scrollTop).toBe(180);
+  });
+});

--- a/apps/web/lib/state/dockview-scroll-preserve.test.ts
+++ b/apps/web/lib/state/dockview-scroll-preserve.test.ts
@@ -109,4 +109,32 @@ describe("preserveChatScrollDuringLayout", () => {
 
     expect(replacement.scrollTop).toBe(180);
   });
+
+  it("does not fire prematurely when set() runs before isRestoringLayout becomes true", async () => {
+    // Mirrors the maximizeGroup() call sequence: caller invokes the helper while
+    // isRestoringLayout is still false, then a non-layout set() (e.g.
+    // captureLiveWidths → syncPinnedWidthsFromApi) emits to subscribers BEFORE
+    // isRestoringLayout flips to true. The helper must wait for the real
+    // false→true→false transition rather than firing on this premature emit.
+    const el = makeChatList(250);
+    preserveChatScrollDuringLayout();
+
+    // Premature emit while isRestoringLayout is still false. Must not restore.
+    fakeStore.emit();
+    expect(fakeStore.listeners.size).toBe(1);
+    expect(fakeStore.pendingChatScrollTop).toBe(250);
+
+    // Real maximize sequence: flip to true, then back to false.
+    fakeStore.isRestoringLayout = true;
+    fakeStore.emit();
+    el.scrollTop = 0; // simulate dockview wiping scroll during rebuild
+    fakeStore.isRestoringLayout = false;
+    fakeStore.emit();
+
+    await flushRaf();
+
+    expect(el.scrollTop).toBe(250);
+    expect(fakeStore.setPendingChatScrollTop).toHaveBeenLastCalledWith(null);
+    expect(fakeStore.listeners.size).toBe(0);
+  });
 });

--- a/apps/web/lib/state/dockview-scroll-preserve.ts
+++ b/apps/web/lib/state/dockview-scroll-preserve.ts
@@ -11,14 +11,22 @@ export function preserveChatScrollDuringLayout(): void {
 
   useDockviewStore.getState().setPendingChatScrollTop(savedScrollTop);
 
+  // Wait for the full isRestoringLayout transition (false → true → false).
+  // Callers may emit non-layout updates (e.g. pinnedWidths) before flipping
+  // isRestoringLayout to true; without this guard the subscriber would
+  // unsubscribe on the first false-state emit and skip the real restore.
+  let sawRestoring = useDockviewStore.getState().isRestoringLayout;
   const unsub = useDockviewStore.subscribe((state) => {
-    if (!state.isRestoringLayout) {
-      unsub();
-      requestAnimationFrame(() => {
-        const el = document.querySelector<HTMLElement>(".chat-message-list");
-        if (el) el.scrollTop = savedScrollTop;
-        useDockviewStore.getState().setPendingChatScrollTop(null);
-      });
+    if (state.isRestoringLayout) {
+      sawRestoring = true;
+      return;
     }
+    if (!sawRestoring) return;
+    unsub();
+    requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLElement>(".chat-message-list");
+      if (el) el.scrollTop = savedScrollTop;
+      useDockviewStore.getState().setPendingChatScrollTop(null);
+    });
   });
 }

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -498,6 +498,7 @@ function buildMaximizeActions(set: StoreSet, get: StoreGet) {
         get().exitMaximizedLayout();
         return;
       }
+      preserveChatScrollDuringLayout();
       const liveWidths = captureLiveWidths(api, set);
       const current = fromDockviewApi(api);
       let targetGroup: {
@@ -541,6 +542,7 @@ function buildMaximizeActions(set: StoreSet, get: StoreGet) {
     exitMaximizedLayout: () => {
       const { api, preMaximizeLayout, currentLayoutSessionId } = get();
       if (!api || !preMaximizeLayout) return;
+      preserveChatScrollDuringLayout();
       const safeWidth = api.width;
       const safeHeight = api.height;
       const liveWidths = get().pinnedWidths;

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -498,8 +498,8 @@ function buildMaximizeActions(set: StoreSet, get: StoreGet) {
         get().exitMaximizedLayout();
         return;
       }
-      preserveChatScrollDuringLayout();
       const liveWidths = captureLiveWidths(api, set);
+      preserveChatScrollDuringLayout();
       const current = fromDockviewApi(api);
       let targetGroup: {
         panels: LayoutState["columns"][0]["groups"][0]["panels"];


### PR DESCRIPTION
Maximizing the chat panel rebuilt the dockview layout and remounted the message list, snapping the chat back to scrollTop=0; wiring the existing scroll-preservation helper into the maximize/exit transitions keeps the user where they were.

## Validation

- `pnpm --filter @kandev/web exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` (640 passed)
- `pnpm --filter @kandev/web exec playwright test e2e/tests/session/session-layout.spec.ts` (6 passed, including new "maximize chat panel preserves scroll position")

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.