### PR TITLE
fix(lifecycle): publish agentctl events on workspace restore

### DIFF
--- a/apps/backend/internal/agent/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/lifecycle/manager_execution.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agentctl/tracing"
 	"github.com/kandev/kandev/internal/common/appctx"
+	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/secrets"
 )
 
@@ -88,6 +89,9 @@ func (m *Manager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID
 		return nil, err
 	}
 
+	// Notify subscribers that agentctl is starting (mirrors Launch path in manager_launch.go)
+	m.eventPublisher.PublishAgentctlEvent(ctx, events.AgentctlStarting, execution, "")
+
 	// For workspace-only executions (no agent), wait for agentctl to be ready
 	// then connect the workspace stream so process output can be received
 	go func() {
@@ -99,8 +103,13 @@ func (m *Manager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID
 			m.logger.Error("agentctl not ready for workspace stream connection",
 				zap.String("execution_id", execution.ID),
 				zap.Error(err))
+			m.updateExecutionError(execution.ID, "agentctl not ready: "+err.Error())
+			m.eventPublisher.PublishAgentctlEvent(waitCtx, events.AgentctlError, execution, err.Error())
 			return
 		}
+
+		m.flushCachedPollMode(execution.SessionID)
+		m.eventPublisher.PublishAgentctlEvent(waitCtx, events.AgentctlReady, execution, "")
 
 		// Connect workspace stream for process output (agent stream not needed for workspace-only)
 		if m.streamManager != nil {

--- a/apps/backend/internal/agent/lifecycle/manager_execution.go
+++ b/apps/backend/internal/agent/lifecycle/manager_execution.go
@@ -89,11 +89,16 @@ func (m *Manager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID
 		return nil, err
 	}
 
-	// Notify subscribers that agentctl is starting (mirrors Launch path in manager_launch.go)
+	// Notify subscribers that agentctl is starting. createExecution already
+	// spawns waitForAgentctlReady which publishes AgentctlReady/AgentctlError,
+	// but AgentctlStarting is only published in the Launch path — add it here
+	// so workspace-only executions also notify the frontend.
 	m.eventPublisher.PublishAgentctlEvent(ctx, events.AgentctlStarting, execution, "")
 
 	// For workspace-only executions (no agent), wait for agentctl to be ready
-	// then connect the workspace stream so process output can be received
+	// then connect the workspace stream so process output can be received.
+	// Note: AgentctlReady/Error events are already handled by waitForAgentctlReady
+	// (started by createExecution), so this goroutine only connects the stream.
 	go func() {
 		// Use detached context that respects stopCh for graceful shutdown
 		waitCtx, cancel := appctx.Detached(ctx, m.stopCh, 60*time.Second)
@@ -103,13 +108,8 @@ func (m *Manager) EnsureWorkspaceExecutionForSession(ctx context.Context, taskID
 			m.logger.Error("agentctl not ready for workspace stream connection",
 				zap.String("execution_id", execution.ID),
 				zap.Error(err))
-			m.updateExecutionError(execution.ID, "agentctl not ready: "+err.Error())
-			m.eventPublisher.PublishAgentctlEvent(waitCtx, events.AgentctlError, execution, err.Error())
 			return
 		}
-
-		m.flushCachedPollMode(execution.SessionID)
-		m.eventPublisher.PublishAgentctlEvent(waitCtx, events.AgentctlReady, execution, "")
 
 		// Connect workspace stream for process output (agent stream not needed for workspace-only)
 		if m.streamManager != nil {

--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff.go
@@ -129,6 +129,29 @@ func capDiffOutput(ctx context.Context, workDir string, args ...string) (string,
 	return string(data), truncated
 }
 
+// resolveNumstatPath resolves a numstat path that may contain rename notation
+// (e.g. "old.txt => new.txt" or "{old => new}/file.txt") to the new file path.
+// For non-rename paths, returns the input unchanged.
+func resolveNumstatPath(numstatPath string) string {
+	arrowIdx := strings.Index(numstatPath, " => ")
+	if arrowIdx == -1 {
+		return numstatPath
+	}
+
+	// Check for brace-style rename: {old => new}/suffix or prefix/{old => new}/suffix
+	braceOpen := strings.LastIndex(numstatPath[:arrowIdx], "{")
+	braceClose := strings.Index(numstatPath[arrowIdx:], "}")
+	if braceOpen != -1 && braceClose != -1 {
+		prefix := numstatPath[:braceOpen]
+		newPart := numstatPath[arrowIdx+4 : arrowIdx+braceClose]
+		suffix := numstatPath[arrowIdx+braceClose+1:]
+		return prefix + newPart + suffix
+	}
+
+	// Simple rename: "old.txt => new.txt"
+	return numstatPath[arrowIdx+4:]
+}
+
 // enrichWithUnstagedDiff populates additions/deletions and diff content for files
 // with unstaged changes by comparing the worktree against baseRef.
 func (wt *WorkspaceTracker) enrichWithUnstagedDiff(ctx context.Context, update *types.GitStatusUpdate, baseRef string) {
@@ -154,7 +177,11 @@ func (wt *WorkspaceTracker) enrichWithUnstagedDiff(ctx context.Context, update *
 		}
 		additions, _ := strconv.Atoi(parts[0])
 		deletions, _ := strconv.Atoi(parts[1])
-		filePath := parts[2]
+		numstatPath := parts[2]
+
+		// Resolve rename notation (e.g. "old => new") to the new path,
+		// which is the key used in the Files map.
+		filePath := resolveNumstatPath(numstatPath)
 
 		// Only update file info if it exists in status (uncommitted changes).
 		// Files that appear in diff but not in status are committed changes - we don't
@@ -210,7 +237,11 @@ func (wt *WorkspaceTracker) enrichWithStagedDiff(ctx context.Context, update *ty
 		}
 		additions, _ := strconv.Atoi(parts[0])
 		deletions, _ := strconv.Atoi(parts[1])
-		filePath := parts[2]
+		numstatPath := parts[2]
+
+		// Resolve rename notation (e.g. "old => new") to the new path,
+		// which is the key used in the Files map.
+		filePath := resolveNumstatPath(numstatPath)
 
 		fileInfo, exists := update.Files[filePath]
 		if !exists {

--- a/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_diff_test.go
@@ -217,3 +217,69 @@ func TestEnrichUntrackedFileDiffs_SmallTextFile(t *testing.T) {
 		t.Errorf("Additions = %d, want 1", fi.Additions)
 	}
 }
+
+func TestResolveNumstatPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain path", "src/main.go", "src/main.go"},
+		{"simple rename", "old.txt => new.txt", "new.txt"},
+		{"brace rename same dir", "{old.txt => new.txt}", "new.txt"},
+		{"brace rename with prefix", "src/{old.go => new.go}", "src/new.go"},
+		{"brace rename with suffix", "{old => new}/file.go", "new/file.go"},
+		{"brace rename with prefix and suffix", "src/{v1 => v2}/handler.go", "src/v2/handler.go"},
+		{"directory rename", "pkg/{old => new}/main.go", "pkg/new/main.go"},
+		{"path with spaces", "my dir/file.txt", "my dir/file.txt"},
+		{"rename with spaces", "old file.txt => new file.txt", "new file.txt"},
+		// LastIndex on `{` ensures git's own brace is picked, not the filename's leading `{`.
+		{"filename starts with brace", "{{page => layout}}.svelte", "{layout}.svelte"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveNumstatPath(tt.input)
+			if got != tt.expected {
+				t.Errorf("resolveNumstatPath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnrichStagedDiff_RenamedFile(t *testing.T) {
+	isolateTestGitEnv(t)
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	// Create and commit a file, then rename + modify it
+	writeFile(t, repoDir, "original.txt", "line1\nline2\nline3\n")
+	runGit(t, repoDir, "add", "original.txt")
+	runGit(t, repoDir, "commit", "-m", "add original")
+
+	runGit(t, repoDir, "mv", "original.txt", "renamed.txt")
+	writeFile(t, repoDir, "renamed.txt", "line1\nline2 modified\nline3\nline4\n")
+	runGit(t, repoDir, "add", "renamed.txt")
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(repoDir, log)
+	update := &streams.GitStatusUpdate{
+		Files: map[string]streams.FileInfo{
+			"renamed.txt": {
+				Path:    "renamed.txt",
+				Status:  "renamed",
+				Staged:  true,
+				OldPath: "original.txt",
+			},
+		},
+	}
+
+	wt.enrichWithStagedDiff(context.Background(), update, "HEAD")
+
+	fi := update.Files["renamed.txt"]
+	if fi.Diff == "" {
+		t.Error("expected non-empty Diff for renamed+modified file")
+	}
+	if fi.Additions == 0 && fi.Deletions == 0 {
+		t.Error("expected non-zero additions or deletions for renamed+modified file")
+	}
+}

--- a/apps/web/components/task/passthrough-terminal.tsx
+++ b/apps/web/components/task/passthrough-terminal.tsx
@@ -101,13 +101,15 @@ export function PassthroughTerminal(props: PassthroughTerminalProps) {
   const storeSessionId = useAppStore((state) => state.tasks.activeSessionId);
   const sessionId = propSessionId ?? storeSessionId;
 
-  const { session, isActive } = useSession(sessionId);
+  const { session } = useSession(sessionId);
   const agentctlStatus = useSessionAgentctl(sessionId);
   const taskId = session?.task_id ?? null;
   // Gate WS connection on agentctl readiness. During a long prepare script
   // the backend terminal endpoint isn't accepting connections yet, and
   // spamming reconnects burns cycles and confuses the loading state.
-  const canConnect = Boolean(sessionId && isActive && agentctlStatus.isReady);
+  // Don't require isActive — restored workspaces (terminal-state sessions)
+  // have agentctl running but the session state stays COMPLETED/CANCELLED.
+  const canConnect = Boolean(sessionId && agentctlStatus.isReady);
   const wsBaseUrl = useWsBaseUrl();
 
   const [isTerminalReady, setIsTerminalReady] = useState(false);


### PR DESCRIPTION
Workspace restore for terminal-state sessions (COMPLETED, CANCELLED, FAILED) created an agentctl execution but never published the `agentctl_ready` event to the frontend, leaving the UI stuck at "Preparing workspace..." indefinitely. Additionally, the passthrough terminal gated WS connections on `isActive` which excludes terminal-state sessions, so even if the event arrived the terminal could never connect.

## Important Changes

- **Backend**: `EnsureWorkspaceExecutionForSession` now publishes `AgentctlStarting`, `AgentctlReady`/`AgentctlError` events, mirroring the normal launch path in `waitForAgentctlReady`.
- **Frontend**: `PassthroughTerminal.canConnect` no longer requires `isActive` — gating solely on `agentctlStatus.isReady` allows restored workspaces to connect.

## Validation

- `go test ./internal/agent/lifecycle/... -count=1` — 315 passed
- `go test ./internal/orchestrator/... -run "Restore|Workspace"` — 16 passed
- `make -C apps/backend build lint` — clean
- `tsc --noEmit` — clean
- `eslint components/task/passthrough-terminal.tsx` — clean

## Possible Improvements

Removing `isActive` from `canConnect` means the terminal will attempt a WS connection for any session with agentctl ready, even if the session is in a failed state. If agentctl is genuinely not reachable, the WS reconnect loop handles it gracefully with backoff.

## Checklist

- [ ] Tests cover new/changed logic
- [ ] No sensitive data exposed