### PR TITLE
fix(mcp): improve create_task_kandev repository and workspace resolution

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -84,6 +84,7 @@ func (a *lifecycleAdapter) LaunchAgent(ctx context.Context, req *executor.Launch
 		ExecutorConfig:      req.ExecutorConfig,
 		PreviousExecutionID: req.PreviousExecutionID,
 		McpMode:             req.McpMode,
+		IsEphemeral:         req.IsEphemeral,
 		SetupScript:         req.SetupScript,
 		// Worktree configuration for concurrent agent execution
 		UseWorktree:          req.UseWorktree,

--- a/apps/backend/cmd/kandev/orchestrator.go
+++ b/apps/backend/cmd/kandev/orchestrator.go
@@ -280,7 +280,11 @@ type repositoryResolverAdapter struct {
 func (a *repositoryResolverAdapter) ResolveForReview(
 	ctx context.Context, workspaceID, provider, owner, name, defaultBranch string,
 ) (string, string, error) {
-	if existing, err := a.taskSvc.GetRepositoryByProviderInfo(ctx, workspaceID, provider, owner, name); err == nil && existing != nil && existing.LocalPath != "" {
+	existing, err := a.taskSvc.GetRepositoryByProviderInfo(ctx, workspaceID, provider, owner, name)
+	if err != nil {
+		return "", "", fmt.Errorf("lookup repository by provider info: %w", err)
+	}
+	if existing != nil && existing.LocalPath != "" {
 		baseBranch := defaultBranch
 		if baseBranch == "" {
 			baseBranch = existing.DefaultBranch

--- a/apps/backend/cmd/kandev/orchestrator.go
+++ b/apps/backend/cmd/kandev/orchestrator.go
@@ -272,9 +272,25 @@ type repositoryResolverAdapter struct {
 }
 
 // ResolveForReview implements orchestrator.RepositoryResolver.
+//
+// If the workspace already has a Repository configured for the given provider
+// info with a non-empty LocalPath, that repo is reused and no clone is
+// performed. Otherwise the repo is cloned into the kandev-managed location and
+// a Repository entity is created.
 func (a *repositoryResolverAdapter) ResolveForReview(
 	ctx context.Context, workspaceID, provider, owner, name, defaultBranch string,
 ) (string, string, error) {
+	if existing, err := a.taskSvc.GetRepositoryByProviderInfo(ctx, workspaceID, provider, owner, name); err == nil && existing != nil && existing.LocalPath != "" {
+		baseBranch := defaultBranch
+		if baseBranch == "" {
+			baseBranch = existing.DefaultBranch
+		}
+		if baseBranch == "" {
+			baseBranch = a.detectAndPersistDefaultBranch(ctx, existing, existing.LocalPath)
+		}
+		return existing.ID, baseBranch, nil
+	}
+
 	cloneURL, err := repoclone.CloneURL(provider, owner, name, a.protocol)
 	if err != nil {
 		return "", "", fmt.Errorf("unsupported provider: %w", err)

--- a/apps/backend/internal/agent/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/lifecycle/manager_launch.go
@@ -167,9 +167,17 @@ func (m *Manager) launchResolveWorkspacePath(ctx context.Context, req *LaunchReq
 			return resolved, "", "", ""
 		}
 	}
-	// For tasks without repositories (e.g., quick chat), create a workspace in ~/.kandev/quick-chat/
+	// For ephemeral tasks without repositories (e.g., quick chat), create a workspace in ~/.kandev/quick-chat/
 	// These directories are cleaned up when the ephemeral task is deleted (see task service performTaskCleanup).
+	// Non-ephemeral tasks should not receive a fallback workspace — they should fail loudly
+	// if no repository is configured (the MCP handler validates this for auto-start tasks).
 	if workspacePath == "" && req.SessionID != "" && m.dataDir != "" {
+		if !req.IsEphemeral {
+			m.logger.Warn("non-ephemeral task has no workspace path; skipping quick-chat fallback",
+				zap.String("task_id", req.TaskID),
+				zap.String("session_id", req.SessionID))
+			return "", "", "", ""
+		}
 		quickChatDir := filepath.Join(m.dataDir, "quick-chat")
 		if err := os.MkdirAll(quickChatDir, 0755); err != nil {
 			m.logger.Warn("failed to create quick-chat directory, continuing without workspace",

--- a/apps/backend/internal/agent/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_launch_test.go
@@ -175,3 +175,31 @@ func TestRunEnvironmentPreparer_SkippedWithoutRepoPath(t *testing.T) {
 	require.False(t, preparer.called, "preparer should be skipped when no repository path")
 	require.Nil(t, result)
 }
+
+func TestLaunchResolveWorkspacePath_EphemeralCreatesQuickChatDir(t *testing.T) {
+	mgr := newTestManager()
+	mgr.dataDir = t.TempDir()
+
+	req := &LaunchRequest{
+		SessionID:   "session-abc",
+		IsEphemeral: true,
+	}
+
+	workspacePath, _, _, _ := mgr.launchResolveWorkspacePath(context.Background(), req)
+	require.NotEmpty(t, workspacePath, "ephemeral task should get a quick-chat workspace")
+	require.Contains(t, workspacePath, "quick-chat")
+	require.Contains(t, workspacePath, "session-abc")
+}
+
+func TestLaunchResolveWorkspacePath_NonEphemeralSkipsQuickChatDir(t *testing.T) {
+	mgr := newTestManager()
+	mgr.dataDir = t.TempDir()
+
+	req := &LaunchRequest{
+		SessionID:   "session-xyz",
+		IsEphemeral: false,
+	}
+
+	workspacePath, _, _, _ := mgr.launchResolveWorkspacePath(context.Background(), req)
+	require.Empty(t, workspacePath, "non-ephemeral task without repo should NOT get a quick-chat workspace")
+}

--- a/apps/backend/internal/agent/lifecycle/types.go
+++ b/apps/backend/internal/agent/lifecycle/types.go
@@ -263,6 +263,10 @@ type LaunchRequest struct {
 	Metadata        map[string]interface{}
 	ModelOverride   string // If set, use this model instead of the profile's model
 
+	// Ephemeral tasks (quick chat) get fallback workspace directories when no repo is configured.
+	// Non-ephemeral tasks without a workspace path will not receive a fallback directory.
+	IsEphemeral bool
+
 	// Executor configuration - determines which runtime to use
 	ExecutorType        string            // Executor type (e.g., "local", "worktree", "local_docker") - determines runtime
 	ExecutorConfig      map[string]string // Executor config (docker_host, git_token, etc.)

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -342,7 +342,9 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 
 	// Auto-resolve workspace/workflow when not provided and there's exactly one option.
 	if req.WorkspaceID == "" && h.taskSvc != nil {
-		if workspaces, wsErr := h.taskSvc.ListWorkspaces(ctx); wsErr == nil && len(workspaces) == 1 {
+		if workspaces, wsErr := h.taskSvc.ListWorkspaces(ctx); wsErr != nil {
+			h.logger.Warn("failed to auto-resolve workspace", zap.Error(wsErr))
+		} else if len(workspaces) == 1 {
 			req.WorkspaceID = workspaces[0].ID
 		}
 	}
@@ -351,7 +353,9 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 	}
 
 	if req.WorkflowID == "" && h.taskSvc != nil {
-		if workflows, wfErr := h.taskSvc.ListWorkflows(ctx, req.WorkspaceID); wfErr == nil && len(workflows) == 1 {
+		if workflows, wfErr := h.taskSvc.ListWorkflows(ctx, req.WorkspaceID); wfErr != nil {
+			h.logger.Warn("failed to auto-resolve workflow", zap.String("workspace_id", req.WorkspaceID), zap.Error(wfErr))
+		} else if len(workflows) == 1 {
 			req.WorkflowID = workflows[0].ID
 		}
 	}

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -410,7 +410,15 @@ func (h *Handlers) resolveTaskRepositories(
 				BaseBranch:   r.BaseBranch,
 			})
 		}
-		return taskRepoResult{Repos: repos}, nil
+		result := taskRepoResult{Repos: repos}
+		// Inherit workspace from source task so multi-workspace installs don't
+		// fail auto-resolution when the agent supplies an explicit repository.
+		if sourceTaskID != "" && h.taskSvc != nil {
+			if src, srcErr := h.taskSvc.GetTask(ctx, sourceTaskID); srcErr == nil {
+				result.WorkspaceID = src.WorkspaceID
+			}
+		}
+		return result, nil
 	}
 
 	if parentID != "" {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -292,6 +292,7 @@ func (h *Handlers) handleListTasks(ctx context.Context, msg *ws.Message) (*ws.Me
 type mcpRepositoryInput struct {
 	RepositoryID string `json:"repository_id"`
 	LocalPath    string `json:"local_path"`
+	GitHubURL    string `json:"github_url"`
 	BaseBranch   string `json:"base_branch"`
 }
 
@@ -339,8 +340,20 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		req.WorkflowID = resolved.WorkflowID
 	}
 
+	// Auto-resolve workspace/workflow when not provided and there's exactly one option.
+	if req.WorkspaceID == "" && h.taskSvc != nil {
+		if workspaces, wsErr := h.taskSvc.ListWorkspaces(ctx); wsErr == nil && len(workspaces) == 1 {
+			req.WorkspaceID = workspaces[0].ID
+		}
+	}
 	if req.WorkspaceID == "" {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "workspace_id is required", nil)
+	}
+
+	if req.WorkflowID == "" && h.taskSvc != nil {
+		if workflows, wfErr := h.taskSvc.ListWorkflows(ctx, req.WorkspaceID); wfErr == nil && len(workflows) == 1 {
+			req.WorkflowID = workflows[0].ID
+		}
 	}
 	if req.WorkflowID == "" {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "workflow_id is required", nil)
@@ -389,6 +402,7 @@ func (h *Handlers) resolveTaskRepositories(
 			repos = append(repos, service.TaskRepositoryInput{
 				RepositoryID: r.RepositoryID,
 				LocalPath:    r.LocalPath,
+				GitHubURL:    r.GitHubURL,
 				BaseBranch:   r.BaseBranch,
 			})
 		}
@@ -399,6 +413,9 @@ func (h *Handlers) resolveTaskRepositories(
 		parent, err := h.taskSvc.GetTask(ctx, parentID)
 		if err != nil {
 			return taskRepoResult{}, fmt.Errorf("invalid parent_id: %w", err)
+		}
+		if parent.IsEphemeral {
+			return taskRepoResult{}, fmt.Errorf("cannot create subtasks of an ephemeral task (quick chat); omit parent_id to create a top-level task")
 		}
 		var repos []service.TaskRepositoryInput
 		for _, r := range parent.Repositories {
@@ -415,11 +432,11 @@ func (h *Handlers) resolveTaskRepositories(
 		}, nil
 	}
 
-	// For top-level tasks, inherit from the calling agent's current task.
+	// For top-level tasks, inherit repos and workspace from the calling agent's current task.
 	if sourceTaskID != "" {
 		sourceTask, err := h.taskSvc.GetTask(ctx, sourceTaskID)
 		if err != nil {
-			h.logger.Warn("source task not found, skipping repo inheritance",
+			h.logger.Warn("source task not found, skipping inheritance",
 				zap.String("source_task_id", sourceTaskID), zap.Error(err))
 			return taskRepoResult{}, nil
 		}
@@ -431,7 +448,10 @@ func (h *Handlers) resolveTaskRepositories(
 				CheckoutBranch: r.CheckoutBranch,
 			})
 		}
-		return taskRepoResult{Repos: repos}, nil
+		return taskRepoResult{
+			Repos:       repos,
+			WorkspaceID: sourceTask.WorkspaceID,
+		}, nil
 	}
 
 	return taskRepoResult{}, nil

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -414,7 +414,11 @@ func (h *Handlers) resolveTaskRepositories(
 		// Inherit workspace from source task so multi-workspace installs don't
 		// fail auto-resolution when the agent supplies an explicit repository.
 		if sourceTaskID != "" && h.taskSvc != nil {
-			if src, srcErr := h.taskSvc.GetTask(ctx, sourceTaskID); srcErr == nil {
+			src, srcErr := h.taskSvc.GetTask(ctx, sourceTaskID)
+			if srcErr != nil {
+				h.logger.Warn("source task lookup failed, skipping workspace inheritance",
+					zap.String("source_task_id", sourceTaskID), zap.Error(srcErr))
+			} else {
 				result.WorkspaceID = src.WorkspaceID
 			}
 		}

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -282,6 +282,37 @@ func TestResolveTaskRepositories_EphemeralParent_Rejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "ephemeral")
 }
 
+func TestResolveTaskRepositories_ExplicitRepos_InheritsSourceWorkspace(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+
+	// Seed workspace and source task to inherit from.
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Test"}))
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Board"}))
+	_, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		Title:       "Source task",
+	})
+	require.NoError(t, err)
+	tasks, err := svc.ListTasks(ctx, "wf-1")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	sourceTaskID := tasks[0].ID
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+
+	explicit := []mcpRepositoryInput{
+		{GitHubURL: "https://github.com/acme/widgets", BaseBranch: "main"},
+	}
+	result, err := h.resolveTaskRepositories(ctx, "", sourceTaskID, explicit)
+	require.NoError(t, err)
+	require.Len(t, result.Repos, 1)
+	assert.Equal(t, "https://github.com/acme/widgets", result.Repos[0].GitHubURL)
+	assert.Equal(t, "ws-1", result.WorkspaceID, "should inherit source task workspace even with explicit repos")
+}
+
 func TestResolveTaskRepositories_SourceTask_InheritsWorkspace(t *testing.T) {
 	svc, repo := newTestTaskService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestTaskService creates a real task service with an in-memory SQLite DB for integration tests.
+// newTestTaskService creates a real task service with a temporary file-backed SQLite DB for integration tests.
 // Returns the service and the raw repo (for seeding data).
 func newTestTaskService(t *testing.T) (*service.Service, *sqliterepo.Repository) {
 	t.Helper()

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -3,16 +3,61 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/jmoiron/sqlx"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/orchestrator"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	"github.com/kandev/kandev/internal/task/service"
+	"github.com/kandev/kandev/internal/worktree"
 	ws "github.com/kandev/kandev/pkg/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newTestTaskService creates a real task service with an in-memory SQLite DB for integration tests.
+// Returns the service and the raw repo (for seeding data).
+func newTestTaskService(t *testing.T) (*service.Service, *sqliterepo.Repository) {
+	t.Helper()
+	dbConn, err := db.OpenSQLite(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	sqlxDB := sqlx.NewDb(dbConn, "sqlite3")
+	repo, cleanup, err := repository.Provide(sqlxDB, sqlxDB)
+	require.NoError(t, err)
+	_, err = worktree.NewSQLiteStore(sqlxDB, sqlxDB)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sqlxDB.Close()
+		_ = cleanup()
+	})
+
+	log, _ := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	eventBus := bus.NewMemoryEventBus(log)
+	t.Cleanup(func() { eventBus.Close() })
+	svc := service.NewService(service.Repos{
+		Workspaces:   repo,
+		Tasks:        repo,
+		TaskRepos:    repo,
+		Workflows:    repo,
+		Messages:     repo,
+		Turns:        repo,
+		Sessions:     repo,
+		GitSnapshots: repo,
+		RepoEntities: repo,
+		Executors:    repo,
+		Environments: repo,
+		Reviews:      repo,
+	}, eventBus, log, service.RepositoryDiscoveryConfig{})
+	return svc, repo
+}
 
 func TestHandleCreateTask_MissingTitle(t *testing.T) {
 	h := &Handlers{}
@@ -178,6 +223,20 @@ func TestResolveTaskRepositories_ExplicitRepos(t *testing.T) {
 	assert.Empty(t, result.WorkflowID, "workflow should not be set for explicit repos")
 }
 
+func TestResolveTaskRepositories_ExplicitGitHubURL(t *testing.T) {
+	log := testLogger(t)
+	h := &Handlers{logger: log.WithFields()}
+
+	explicit := []mcpRepositoryInput{
+		{GitHubURL: "https://github.com/acme/widgets", BaseBranch: "main"},
+	}
+	result, err := h.resolveTaskRepositories(context.Background(), "", "", explicit)
+	require.NoError(t, err)
+	require.Len(t, result.Repos, 1)
+	assert.Equal(t, "https://github.com/acme/widgets", result.Repos[0].GitHubURL)
+	assert.Equal(t, "main", result.Repos[0].BaseBranch)
+}
+
 func TestResolveTaskRepositories_NoInputs_ReturnsEmpty(t *testing.T) {
 	log := testLogger(t)
 	h := &Handlers{logger: log.WithFields()}
@@ -198,4 +257,108 @@ func TestResolveTaskRepositories_ExplicitRepos_SkipsParentLookup(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Repos, 1)
 	assert.Equal(t, "repo-explicit", result.Repos[0].RepositoryID)
+}
+
+// --- Integration tests using real task service ---
+
+func TestResolveTaskRepositories_EphemeralParent_Rejected(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+
+	// Seed workspace and ephemeral task
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Test"}))
+	task, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Quick Chat",
+		IsEphemeral: true,
+	})
+	require.NoError(t, err)
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+
+	_, err = h.resolveTaskRepositories(ctx, task.ID, "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ephemeral")
+}
+
+func TestResolveTaskRepositories_SourceTask_InheritsWorkspace(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+
+	// Seed workspace, workflow, and source task
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Test"}))
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Board"}))
+	_, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		Title:       "Source task",
+	})
+	require.NoError(t, err)
+	tasks, err := svc.ListTasks(ctx, "wf-1")
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	sourceTaskID := tasks[0].ID
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+
+	result, err := h.resolveTaskRepositories(ctx, "", sourceTaskID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "ws-1", result.WorkspaceID, "should inherit workspace from source task")
+	assert.Empty(t, result.WorkflowID, "should NOT inherit workflow from source task")
+}
+
+func TestHandleCreateTask_AutoResolvesWorkspaceAndWorkflow(t *testing.T) {
+	svc, _ := newTestTaskService(t)
+	ctx := context.Background()
+
+	// The DB is seeded with a default workspace and workflow by repository.Provide.
+	// Verify exactly 1 of each exists so auto-resolve works.
+	workspaces, wsErr := svc.ListWorkspaces(ctx)
+	require.NoError(t, wsErr)
+	require.Len(t, workspaces, 1, "should have exactly 1 default workspace")
+
+	workflows, wfErr := svc.ListWorkflows(ctx, workspaces[0].ID)
+	require.NoError(t, wfErr)
+	require.Len(t, workflows, 1, "should have exactly 1 default workflow")
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+	// No workspace_id or workflow_id provided — should auto-resolve from defaults
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"title":       "Auto-resolved task",
+		"start_agent": false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	if resp.Type == ws.MessageTypeError {
+		t.Logf("error payload: %s", string(resp.Payload))
+	}
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type, "should succeed with auto-resolved workspace and workflow")
+}
+
+func TestHandleCreateTask_AutoResolveFailsWithMultipleWorkflows(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+
+	// The DB already has 1 default workspace + 1 default workflow.
+	// Add a second workflow to make auto-resolution ambiguous.
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-extra", WorkspaceID: workspaces[0].ID, Name: "Extra Board"}))
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"title":       "Task",
+		"start_agent": false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeValidation)
 }

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -120,17 +120,22 @@ func (s *Server) createTaskHandler() server.ToolHandlerFunc {
 		// Add repository info (only valid for top-level tasks)
 		repositoryID := req.GetString("repository_id", "")
 		localPath := req.GetString("local_path", "")
+		repositoryURL := req.GetString("repository_url", "")
 		baseBranch := req.GetString("base_branch", "")
-		if (repositoryID != "" || localPath != "") && parentID != "" {
-			return mcp.NewToolResultError("repository_id and local_path are only valid for top-level tasks; subtasks inherit their repository from the parent"), nil
+		hasRepo := repositoryID != "" || localPath != "" || repositoryURL != ""
+		if hasRepo && parentID != "" {
+			return mcp.NewToolResultError("repository_id, local_path, and repository_url are only valid for top-level tasks; subtasks inherit their repository from the parent"), nil
 		}
-		if repositoryID != "" || localPath != "" {
+		if hasRepo {
 			repo := map[string]string{}
 			if repositoryID != "" {
 				repo["repository_id"] = repositoryID
 			}
 			if localPath != "" {
 				repo["local_path"] = localPath
+			}
+			if repositoryURL != "" {
+				repo["github_url"] = repositoryURL
 			}
 			if baseBranch != "" {
 				repo["base_branch"] = baseBranch

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -92,10 +92,6 @@ func (s *Server) createTaskHandler() server.ToolHandlerFunc {
 		workflowID := req.GetString("workflow_id", "")
 		workflowStepID := req.GetString("workflow_step_id", "")
 
-		if parentID == "" && (workspaceID == "" || workflowID == "") {
-			return mcp.NewToolResultError("workspace_id and workflow_id are required when creating a top-level task (no parent_id)"), nil
-		}
-
 		// Default start_agent to true if not provided
 		startAgent := true
 		if args := req.GetArguments(); args["start_agent"] != nil {

--- a/apps/backend/internal/mcp/server/handlers_test.go
+++ b/apps/backend/internal/mcp/server/handlers_test.go
@@ -237,3 +237,42 @@ func TestCreateTask_WithLocalPath(t *testing.T) {
 	require.Len(t, repos, 1)
 	assert.Equal(t, "/Users/me/projects/myrepo", repos[0]["local_path"])
 }
+
+func TestCreateTask_WithRepositoryURL(t *testing.T) {
+	backend := &testBackend{
+		response: map[string]interface{}{"id": "task-new", "title": "Task with URL"},
+	}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
+		"title":          "Task with URL",
+		"workspace_id":   "ws-1",
+		"workflow_id":    "wf-1",
+		"repository_url": "https://github.com/acme/widgets",
+		"base_branch":    "main",
+	})
+
+	assert.False(t, result.IsError)
+
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+
+	repos, ok := payload["repositories"].([]map[string]string)
+	require.True(t, ok, "repositories should be a slice")
+	require.Len(t, repos, 1)
+	assert.Equal(t, "https://github.com/acme/widgets", repos[0]["github_url"])
+	assert.Equal(t, "main", repos[0]["base_branch"])
+}
+
+func TestCreateTask_RepositoryURL_RejectedForSubtasks(t *testing.T) {
+	backend := &testBackend{}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
+		"title":          "Subtask with URL",
+		"parent_id":      "self",
+		"repository_url": "https://github.com/acme/widgets",
+	})
+
+	assert.True(t, result.IsError, "repository_url should be rejected for subtasks")
+}

--- a/apps/backend/internal/mcp/server/handlers_test.go
+++ b/apps/backend/internal/mcp/server/handlers_test.go
@@ -100,18 +100,6 @@ func TestCreateTask_ExplicitParentID(t *testing.T) {
 	assert.Equal(t, "task-abc", payload["parent_id"])
 }
 
-func TestCreateTask_NoParentID_RequiresWorkspaceAndWorkflow(t *testing.T) {
-	backend := &testBackend{}
-	s := newTaskModeServer(t, backend, "task-current")
-
-	// No parent_id and no workspace/workflow -> error
-	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
-		"title": "Standalone task",
-	})
-
-	assert.True(t, result.IsError)
-}
-
 func TestCreateTask_NoParentID_WithIDs_CreatesTopLevelTask(t *testing.T) {
 	backend := &testBackend{
 		response: map[string]interface{}{"id": "task-new", "title": "Standalone"},

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -395,11 +395,12 @@ WHEN TO USE parent_id='self':
 
 WHEN TO OMIT parent_id (top-level task):
 - Creating an unrelated, standalone task
-- Requires workspace_id, workflow_id, and repository (use repository_url, repository_id, or local_path)
+- Provide a repository via repository_url, repository_id, or local_path
+- workspace_id and workflow_id are auto-resolved if only one exists; provide explicitly if ambiguous
 
 IMPORTANT:
 - Subtasks inherit repositories, workspace, workflow, agent profile, and executor from parent
-- Top-level tasks need explicit repository via repository_url, repository_id, or local_path
+- Top-level tasks need a repository via repository_url, repository_id, or local_path
 - 'description' is the sub-agent's initial prompt — be specific and detailed
 - Set start_agent=false to create without starting an agent`
 	parentDesc := "Parent task ID for subtasks. Use 'self' to create a subtask of your current task (RECOMMENDED for plan phases, delegated work). Omit only for unrelated top-level tasks."
@@ -408,7 +409,8 @@ IMPORTANT:
 		toolDesc = `Create a new top-level task and auto-start an agent on it.
 
 IMPORTANT:
-- Requires workspace_id, workflow_id, and repository (use repository_url, repository_id, or local_path)
+- Provide a repository via repository_url, repository_id, or local_path
+- workspace_id and workflow_id are auto-resolved if only one exists; provide explicitly if ambiguous
 - 'description' is the agent's initial prompt — be specific and detailed
 - Set start_agent=false to create without starting an agent
 - Use parent_id only when delegating to a known existing task by its ID`
@@ -419,8 +421,8 @@ IMPORTANT:
 		mcp.NewTool("create_task_kandev",
 			mcp.WithDescription(toolDesc),
 			mcp.WithString("parent_id", mcp.Description(parentDesc)),
-			mcp.WithString("workspace_id", mcp.Description("The workspace ID (required for top-level tasks, inherited from parent for subtasks)")),
-			mcp.WithString("workflow_id", mcp.Description("The workflow ID (required for top-level tasks, inherited from parent for subtasks)")),
+			mcp.WithString("workspace_id", mcp.Description("The workspace ID. Auto-resolved if only one workspace exists. Inherited from parent for subtasks.")),
+			mcp.WithString("workflow_id", mcp.Description("The workflow ID. Auto-resolved if the workspace has only one workflow. Inherited from parent for subtasks.")),
 			mcp.WithString("workflow_step_id", mcp.Description("The workflow step ID (optional, auto-resolved if omitted)")),
 			mcp.WithString("title", mcp.Required(), mcp.Description("The task title")),
 			mcp.WithString("description", mcp.Description("The initial prompt for the sub-agent. This is the ONLY context the agent receives when it starts — treat it as the agent's first user message. REQUIRED for subtasks: without a description the sub-agent starts with no context and cannot do useful work. Be specific and detailed.")),

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -395,11 +395,11 @@ WHEN TO USE parent_id='self':
 
 WHEN TO OMIT parent_id (top-level task):
 - Creating an unrelated, standalone task
-- Requires workspace_id, workflow_id, and repository (use repository_id or local_path)
+- Requires workspace_id, workflow_id, and repository (use repository_url, repository_id, or local_path)
 
 IMPORTANT:
 - Subtasks inherit repositories, workspace, workflow, agent profile, and executor from parent
-- Top-level tasks need explicit repository via repository_id or local_path
+- Top-level tasks need explicit repository via repository_url, repository_id, or local_path
 - 'description' is the sub-agent's initial prompt — be specific and detailed
 - Set start_agent=false to create without starting an agent`
 	parentDesc := "Parent task ID for subtasks. Use 'self' to create a subtask of your current task (RECOMMENDED for plan phases, delegated work). Omit only for unrelated top-level tasks."
@@ -408,7 +408,7 @@ IMPORTANT:
 		toolDesc = `Create a new top-level task and auto-start an agent on it.
 
 IMPORTANT:
-- Requires workspace_id, workflow_id, and repository (use repository_id or local_path)
+- Requires workspace_id, workflow_id, and repository (use repository_url, repository_id, or local_path)
 - 'description' is the agent's initial prompt — be specific and detailed
 - Set start_agent=false to create without starting an agent
 - Use parent_id only when delegating to a known existing task by its ID`
@@ -429,6 +429,7 @@ IMPORTANT:
 			mcp.WithBoolean("start_agent", mcp.Description("Whether to auto-start an agent on the created task. Default: true. Set to false to create the task without starting an agent.")),
 			mcp.WithString("repository_id", mcp.Description("Repository ID for top-level tasks. Not needed for subtasks (inherited from parent).")),
 			mcp.WithString("local_path", mcp.Description("Local repository folder path (e.g. '/Users/me/projects/myrepo') for top-level tasks. Will create/find the repository automatically. Preferred for local worktree flow.")),
+			mcp.WithString("repository_url", mcp.Description("GitHub repository URL (e.g. 'https://github.com/owner/repo') for top-level tasks. The repository will be cloned automatically on first use. Not needed for subtasks (inherited from parent).")),
 			mcp.WithString("base_branch", mcp.Description("Base branch for the repository (e.g. 'main'). Optional, defaults to repository's default branch.")),
 		),
 		s.wrapHandler("create_task_kandev", s.createTaskHandler()),

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -238,6 +238,7 @@ type LaunchAgentRequest struct {
 	ExecutorConfig      map[string]string // Executor config (docker_host, git_token, etc.)
 	PreviousExecutionID string            // Previous execution ID for runtime reconnect
 	McpMode             string            // MCP tool mode: "config" activates config-mode tools
+	IsEphemeral         bool              // Ephemeral task (quick chat) — enables fallback workspace creation
 
 	// Setup script from executor profile (runs in execution environment before agent starts)
 	SetupScript string

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -510,6 +510,7 @@ func (e *Executor) buildLaunchAgentRequest(ctx context.Context, task *v1.Task, s
 		TaskDescription: prompt,
 		Priority:        task.Priority,
 		SessionID:       sessionID,
+		IsEphemeral:     task.IsEphemeral,
 	}
 
 	execConfig := e.resolveExecutorConfig(ctx, executorID, task.WorkspaceID, metadata)

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -289,6 +289,7 @@ func (e *Executor) buildSwitchModelRequest(ctx context.Context, task *models.Tas
 		ACPSessionID:    acpSessionID,
 		ExecutorType:    execConfig.ExecutorType,
 		Metadata:        execConfig.Metadata,
+		IsEphemeral:     task.IsEphemeral,
 	}
 
 	// Activate config-mode MCP tools when config_mode is set in session metadata.

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -417,6 +417,7 @@ func (e *Executor) buildResumeRequest(ctx context.Context, task *v1.Task, sessio
 		AgentProfileID:  session.AgentProfileID,
 		TaskDescription: task.Description,
 		Priority:        task.Priority,
+		IsEphemeral:     task.IsEphemeral,
 	}
 
 	metadata := map[string]interface{}{}

--- a/apps/backend/internal/task/service/service_resources.go
+++ b/apps/backend/internal/task/service/service_resources.go
@@ -270,6 +270,12 @@ func (s *Service) GetRepository(ctx context.Context, id string) (*models.Reposit
 	return s.repoEntities.GetRepository(ctx, id)
 }
 
+// GetRepositoryByProviderInfo looks up a repository by workspace and provider identity.
+// Returns nil (with nil error) when no matching repository exists.
+func (s *Service) GetRepositoryByProviderInfo(ctx context.Context, workspaceID, provider, owner, name string) (*models.Repository, error) {
+	return s.repoEntities.GetRepositoryByProviderInfo(ctx, workspaceID, provider, owner, name)
+}
+
 // FindOrCreateRepository looks up a repository by provider info, creating one if not found.
 // If the repository exists but has no LocalPath and the request provides one, updates LocalPath.
 func (s *Service) FindOrCreateRepository(ctx context.Context, req *FindOrCreateRepositoryRequest) (*models.Repository, error) {

--- a/apps/web/e2e/tests/pr/pr-watcher-dockview-layout.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-dockview-layout.spec.ts
@@ -1,4 +1,7 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
+import { makeGitEnv } from "../../helpers/git-helper";
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
 
@@ -22,8 +25,28 @@ test.describe("PR watcher dockview layout stability", () => {
     testPage,
     apiClient,
     seedData,
+    backend,
   }) => {
     test.setTimeout(120_000);
+
+    // --- Register the GitHub repo so the PR watcher can resolve it to a real
+    // local path (the seed repo created in test-base.ts has no provider info,
+    // and clone-from-real-GitHub fails for the mocked testorg/testrepo). ---
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    await apiClient.createRepository(seedData.workspaceId, repoDir, "main", {
+      name: "GitHub Test Repo",
+      provider: "github",
+      provider_owner: "testorg",
+      provider_name: "testrepo",
+    });
+
+    // Create the PR head branches in the local seed repo so the executor's
+    // git checkout for auto-started review tasks succeeds (in production these
+    // branches would have been fetched during clone).
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    for (const branch of ["fix/auth", "feat/dashboard", "docs/update"]) {
+      execSync(`git branch -f ${branch} main`, { cwd: repoDir, env: gitEnv });
+    }
 
     // --- Seed workflow ---
     const workflow = await apiClient.createWorkflow(

--- a/apps/web/e2e/tests/pr/pr-watcher-merged-cleanup.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-merged-cleanup.spec.ts
@@ -1,4 +1,7 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
+import { makeGitEnv } from "../../helpers/git-helper";
 import { KanbanPage } from "../../pages/kanban-page";
 
 test.describe("PR watcher merged cleanup", () => {
@@ -115,8 +118,26 @@ test.describe("PR watcher merged cleanup", () => {
     testPage,
     apiClient,
     seedData,
+    backend,
   }) => {
     test.setTimeout(120_000);
+
+    // --- Register the GitHub repo so the PR watcher can resolve it to a real
+    // local path (the seed repo created in test-base.ts has no provider info,
+    // and clone-from-real-GitHub fails for the mocked testorg/testrepo). ---
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    await apiClient.createRepository(seedData.workspaceId, repoDir, "main", {
+      name: "GitHub Test Repo",
+      provider: "github",
+      provider_owner: "testorg",
+      provider_name: "testrepo",
+    });
+
+    // Create the PR's head branch in the local seed repo so the executor's
+    // git checkout for auto-started review tasks succeeds (in production this
+    // branch would have been fetched during clone).
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git branch -f feature/reviewed main", { cwd: repoDir, env: gitEnv });
 
     // --- Setup mock GitHub ---
     await apiClient.mockGitHubReset();

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -301,7 +301,8 @@ test.describe("Subtask inheritance", () => {
 
     // 2. Create parent task via API with explicit executor_profile_id so the
     //    parent session records it. The mock agent runs the MCP script which
-    //    creates the subtask with parent_id="self".
+    //    creates the subtask with parent_id="self". A repository is required
+    //    so the parent (non-ephemeral) task gets a real workspace path.
     const parentTask = await apiClient.createTaskWithAgent(
       seedData.workspaceId,
       "Executor Inherit Parent Task",
@@ -311,6 +312,7 @@ test.describe("Subtask inheritance", () => {
         workflow_id: seedData.workflowId,
         workflow_step_id: seedData.startStepId,
         executor_profile_id: executorProfile.id,
+        repository_ids: [seedData.repositoryId],
       },
     );
     expect(parentTask.id).toBeTruthy();


### PR DESCRIPTION
Tasks created from quick-chat sessions silently ended up with empty git workspaces ("bare repo" situation) because they inherited no repository context from the ephemeral parent. This fixes the create_task_kandev MCP tool to properly handle repository URLs, auto-resolve workspace/workflow, and prevent non-ephemeral tasks from silently falling back to empty workspaces.

## Important Changes

- **`repository_url` parameter**: Agents can now provide a GitHub URL (e.g. `https://github.com/owner/repo`) directly. The service layer clones it on-demand at agent launch via the existing `FindOrCreateRepository` + `ensureRepoCloned` infrastructure.
- **Workspace auto-resolution**: Top-level tasks now inherit `workspace_id` from the source task (quick-chat's workspace). If still empty, auto-resolves when exactly 1 workspace exists.
- **Workflow auto-resolution**: When `workflow_id` is empty after inheritance, auto-resolves when the workspace has exactly 1 workflow.
- **Ephemeral parent rejection**: `parent_id` pointing to an ephemeral task (quick-chat) now returns a clear validation error instead of creating a subtask with no workflow.
- **IsEphemeral gate**: The quick-chat workspace fallback directory (`~/.kandev/quick-chat/`) is now only created for ephemeral tasks. Non-ephemeral tasks without a workspace path skip the fallback and log a warning.

## Validation

```
go test ./internal/agentctl/server/mcp/... ./internal/mcp/handlers/... ./internal/agent/lifecycle/... ./internal/orchestrator/executor/... ./internal/integration/... → 516+ pass, 0 fail
make lint → 0 issues
make fmt → clean
```

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] Breaking changes documented (if applicable)