### PR TITLE
feat(cli): make --port the user-facing port flag

### DIFF
--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -58,6 +58,10 @@ describe("parseArgs", () => {
   it("throws ParseError on a non-integer port value", () => {
     expect(() => parseArgs(["--port=3000.5"])).toThrow(/--port value must be an integer/);
   });
+
+  it.each(["0", "-1", "65536"])("throws ParseError on out-of-range port %s", (val) => {
+    expect(() => parseArgs([`--port=${val}`])).toThrow(/--port value must be an integer between/);
+  });
 });
 
 describe("resolvePorts", () => {
@@ -118,6 +122,12 @@ describe("resolvePorts", () => {
     expect(() =>
       resolvePorts({ command: "run" }, { KANDEV_PORT: "3000.5" } as NodeJS.ProcessEnv),
     ).toThrow(/KANDEV_PORT must be an integer/);
+  });
+
+  it.each(["0", "-1", "65536"])("throws ParseError when KANDEV_PORT is out-of-range %s", (val) => {
+    expect(() =>
+      resolvePorts({ command: "run" }, { KANDEV_PORT: val } as NodeJS.ProcessEnv),
+    ).toThrow(/KANDEV_PORT must be an integer between/);
   });
 });
 

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -129,6 +129,17 @@ describe("resolvePorts", () => {
       resolvePorts({ command: "run" }, { KANDEV_PORT: val } as NodeJS.ProcessEnv),
     ).toThrow(/KANDEV_PORT must be an integer between/);
   });
+
+  it("KANDEV_WEB_PORT sets the web port", () => {
+    const r = resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
+    expect(r.webPort).toBe(8080);
+  });
+
+  it("throws ParseError when KANDEV_WEB_PORT is out of range", () => {
+    expect(() =>
+      resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "0" } as NodeJS.ProcessEnv),
+    ).toThrow(/KANDEV_WEB_PORT must be an integer between/);
+  });
 });
 
 describe("deprecationReplacement", () => {

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -60,18 +60,12 @@ describe("parseArgs", () => {
 
 describe("resolvePorts", () => {
   it("maps --port to backend port for run/start", () => {
-    const r = resolvePorts(
-      { command: "start", port: 3447 },
-      {} as NodeJS.ProcessEnv,
-    );
+    const r = resolvePorts({ command: "start", port: 3447 }, {} as NodeJS.ProcessEnv);
     expect(r).toEqual({ backendPort: 3447, webPort: undefined });
   });
 
   it("maps --port to web port for dev", () => {
-    const r = resolvePorts(
-      { command: "dev", port: 3000 },
-      {} as NodeJS.ProcessEnv,
-    );
+    const r = resolvePorts({ command: "dev", port: 3000 }, {} as NodeJS.ProcessEnv);
     expect(r).toEqual({ backendPort: undefined, webPort: 3000 });
   });
 
@@ -89,10 +83,10 @@ describe("resolvePorts", () => {
   });
 
   it("KANDEV_BACKEND_PORT wins over KANDEV_PORT", () => {
-    const r = resolvePorts(
-      { command: "run" },
-      { KANDEV_PORT: "5555", KANDEV_BACKEND_PORT: "6666" } as NodeJS.ProcessEnv,
-    );
+    const r = resolvePorts({ command: "run" }, {
+      KANDEV_PORT: "5555",
+      KANDEV_BACKEND_PORT: "6666",
+    } as NodeJS.ProcessEnv);
     expect(r.backendPort).toBe(6666);
   });
 

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -52,7 +52,11 @@ describe("parseArgs", () => {
   });
 
   it("throws ParseError on a non-numeric port value", () => {
-    expect(() => parseArgs(["--port=abc"])).toThrow(/--port value must be a number/);
+    expect(() => parseArgs(["--port=abc"])).toThrow(/--port value must be an integer/);
+  });
+
+  it("throws ParseError on a non-integer port value", () => {
+    expect(() => parseArgs(["--port=3000.5"])).toThrow(/--port value must be an integer/);
   });
 });
 
@@ -107,7 +111,13 @@ describe("resolvePorts", () => {
   it("throws ParseError when KANDEV_BACKEND_PORT is not a number", () => {
     expect(() =>
       resolvePorts({ command: "run" }, { KANDEV_BACKEND_PORT: "nope" } as NodeJS.ProcessEnv),
-    ).toThrow(/KANDEV_BACKEND_PORT must be a number/);
+    ).toThrow(/KANDEV_BACKEND_PORT must be an integer/);
+  });
+
+  it("throws ParseError when KANDEV_PORT is a float", () => {
+    expect(() =>
+      resolvePorts({ command: "run" }, { KANDEV_PORT: "3000.5" } as NodeJS.ProcessEnv),
+    ).toThrow(/KANDEV_PORT must be an integer/);
   });
 });
 

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -130,9 +130,14 @@ describe("resolvePorts", () => {
     ).toThrow(/KANDEV_PORT must be an integer between/);
   });
 
-  it("KANDEV_WEB_PORT sets the web port", () => {
+  it("KANDEV_WEB_PORT sets the web port in dev", () => {
     const r = resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
     expect(r.webPort).toBe(8080);
+  });
+
+  it("KANDEV_WEB_PORT sets the internal web port in run/start (backend stays undefined)", () => {
+    const r = resolvePorts({ command: "run" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
+    expect(r).toEqual({ backendPort: undefined, webPort: 8080 });
   });
 
   it("throws ParseError when KANDEV_WEB_PORT is out of range", () => {

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -62,6 +62,10 @@ describe("parseArgs", () => {
   it.each(["0", "-1", "65536"])("throws ParseError on out-of-range port %s", (val) => {
     expect(() => parseArgs([`--port=${val}`])).toThrow(/--port value must be an integer between/);
   });
+
+  it("throws ParseError on empty --version=", () => {
+    expect(() => parseArgs(["--version="])).toThrow(/--version requires a value/);
+  });
 });
 
 describe("resolvePorts", () => {
@@ -159,6 +163,15 @@ describe("resolvePorts", () => {
       resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "0" } as NodeJS.ProcessEnv),
     ).toThrow(/KANDEV_WEB_PORT must be an integer between/);
   });
+
+  it.each(["KANDEV_PORT", "KANDEV_BACKEND_PORT", "KANDEV_WEB_PORT"])(
+    "throws ParseError when %s is set to empty string (not silently ignored)",
+    (name) => {
+      expect(() => resolvePorts({ command: "run" }, { [name]: "" } as NodeJS.ProcessEnv)).toThrow(
+        new RegExp(`${name} must be an integer`),
+      );
+    },
+  );
 });
 
 describe("deprecationReplacement", () => {

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -96,6 +96,20 @@ describe("resolvePorts", () => {
     expect(r.backendPort).toBe(6666);
   });
 
+  it("--port wins over KANDEV_BACKEND_PORT (explicit CLI > env var)", () => {
+    const r = resolvePorts({ command: "start", port: 3000 }, {
+      KANDEV_BACKEND_PORT: "4000",
+    } as NodeJS.ProcessEnv);
+    expect(r.backendPort).toBe(3000);
+  });
+
+  it("--port wins over KANDEV_WEB_PORT in dev (explicit CLI > env var)", () => {
+    const r = resolvePorts({ command: "dev", port: 3000 }, {
+      KANDEV_WEB_PORT: "4000",
+    } as NodeJS.ProcessEnv);
+    expect(r.webPort).toBe(3000);
+  });
+
   it("KANDEV_PORT routes to web port for dev", () => {
     const r = resolvePorts({ command: "dev" }, { KANDEV_PORT: "9000" } as NodeJS.ProcessEnv);
     expect(r).toEqual({ backendPort: undefined, webPort: 9000 });

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _resetWarnedFlagsForTest, parseArgs, resolvePorts } from "./args";
+
+describe("parseArgs", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetWarnedFlagsForTest();
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it("defaults to the run command with no args", () => {
+    const { options, showHelp } = parseArgs([]);
+    expect(options.command).toBe("run");
+    expect(showHelp).toBe(false);
+  });
+
+  it("parses --port and --port=<n>", () => {
+    expect(parseArgs(["--port", "3000"]).options.port).toBe(3000);
+    expect(parseArgs(["--port=3000"]).options.port).toBe(3000);
+  });
+
+  it("parses --web-internal-port (the renamed advanced flag) without warning", () => {
+    expect(parseArgs(["--web-internal-port", "12345"]).options.webPort).toBe(12345);
+    expect(parseArgs(["--web-internal-port=12345"]).options.webPort).toBe(12345);
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits a deprecation warning for --backend-port but still parses it", () => {
+    const { options } = parseArgs(["--backend-port", "3447"]);
+    expect(options.backendPort).toBe(3447);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--backend-port is deprecated; use --port"),
+    );
+  });
+
+  it("emits a deprecation warning for --web-port pointing at --web-internal-port", () => {
+    const { options } = parseArgs(["--web-port=8080"]);
+    expect(options.webPort).toBe(8080);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--web-port is deprecated; use --web-internal-port"),
+    );
+  });
+
+  it("warns about each deprecated flag at most once per process", () => {
+    parseArgs(["--backend-port=1", "--backend-port=2"]);
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports --help via showHelp without exiting", () => {
+    const { showHelp } = parseArgs(["--help"]);
+    expect(showHelp).toBe(true);
+  });
+});
+
+describe("resolvePorts", () => {
+  it("maps --port to backend port for run/start", () => {
+    const r = resolvePorts(
+      { command: "start", port: 3447 },
+      {} as NodeJS.ProcessEnv,
+    );
+    expect(r).toEqual({ backendPort: 3447, webPort: undefined });
+  });
+
+  it("maps --port to web port for dev", () => {
+    const r = resolvePorts(
+      { command: "dev", port: 3000 },
+      {} as NodeJS.ProcessEnv,
+    );
+    expect(r).toEqual({ backendPort: undefined, webPort: 3000 });
+  });
+
+  it("explicit --backend-port wins over --port in start mode", () => {
+    const r = resolvePorts(
+      { command: "start", port: 3000, backendPort: 4000 },
+      {} as NodeJS.ProcessEnv,
+    );
+    expect(r.backendPort).toBe(4000);
+  });
+
+  it("falls back to KANDEV_PORT when no flag is given", () => {
+    const r = resolvePorts({ command: "run" }, { KANDEV_PORT: "5555" } as NodeJS.ProcessEnv);
+    expect(r.backendPort).toBe(5555);
+  });
+
+  it("KANDEV_BACKEND_PORT wins over KANDEV_PORT", () => {
+    const r = resolvePorts(
+      { command: "run" },
+      { KANDEV_PORT: "5555", KANDEV_BACKEND_PORT: "6666" } as NodeJS.ProcessEnv,
+    );
+    expect(r.backendPort).toBe(6666);
+  });
+
+  it("KANDEV_PORT routes to web port for dev", () => {
+    const r = resolvePorts({ command: "dev" }, { KANDEV_PORT: "9000" } as NodeJS.ProcessEnv);
+    expect(r).toEqual({ backendPort: undefined, webPort: 9000 });
+  });
+
+  it("returns undefined for both ports when nothing is set", () => {
+    const r = resolvePorts({ command: "run" }, {} as NodeJS.ProcessEnv);
+    expect(r).toEqual({ backendPort: undefined, webPort: undefined });
+  });
+});

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -1,23 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { _resetWarnedFlagsForTest, parseArgs, resolvePorts } from "./args";
+import { deprecationReplacement, parseArgs, ParseError, resolvePorts } from "./args";
 
 describe("parseArgs", () => {
-  let stderrSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    _resetWarnedFlagsForTest();
-    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-  });
-
-  afterEach(() => {
-    stderrSpy.mockRestore();
-  });
-
   it("defaults to the run command with no args", () => {
-    const { options, showHelp } = parseArgs([]);
+    const { options, showHelp, deprecatedFlags } = parseArgs([]);
     expect(options.command).toBe("run");
     expect(showHelp).toBe(false);
+    expect(deprecatedFlags).toEqual([]);
   });
 
   it("parses --port and --port=<n>", () => {
@@ -25,36 +15,44 @@ describe("parseArgs", () => {
     expect(parseArgs(["--port=3000"]).options.port).toBe(3000);
   });
 
-  it("parses --web-internal-port (the renamed advanced flag) without warning", () => {
-    expect(parseArgs(["--web-internal-port", "12345"]).options.webPort).toBe(12345);
-    expect(parseArgs(["--web-internal-port=12345"]).options.webPort).toBe(12345);
-    expect(stderrSpy).not.toHaveBeenCalled();
+  it("parses --web-internal-port (the renamed advanced flag) without a deprecation note", () => {
+    const r = parseArgs(["--web-internal-port", "12345"]);
+    expect(r.options.webPort).toBe(12345);
+    expect(r.deprecatedFlags).toEqual([]);
   });
 
-  it("emits a deprecation warning for --backend-port but still parses it", () => {
-    const { options } = parseArgs(["--backend-port", "3447"]);
-    expect(options.backendPort).toBe(3447);
-    expect(stderrSpy).toHaveBeenCalledWith(
-      expect.stringContaining("--backend-port is deprecated; use --port"),
-    );
+  it("records --backend-port as deprecated but still parses it", () => {
+    const r = parseArgs(["--backend-port", "3447"]);
+    expect(r.options.backendPort).toBe(3447);
+    expect(r.deprecatedFlags).toEqual(["--backend-port"]);
   });
 
-  it("emits a deprecation warning for --web-port pointing at --web-internal-port", () => {
-    const { options } = parseArgs(["--web-port=8080"]);
-    expect(options.webPort).toBe(8080);
-    expect(stderrSpy).toHaveBeenCalledWith(
-      expect.stringContaining("--web-port is deprecated; use --web-internal-port"),
-    );
+  it("records --web-port as deprecated", () => {
+    const r = parseArgs(["--web-port=8080"]);
+    expect(r.options.webPort).toBe(8080);
+    expect(r.deprecatedFlags).toEqual(["--web-port"]);
   });
 
-  it("warns about each deprecated flag at most once per process", () => {
-    parseArgs(["--backend-port=1", "--backend-port=2"]);
-    expect(stderrSpy).toHaveBeenCalledTimes(1);
+  it("dedupes deprecated flags across repeats", () => {
+    const r = parseArgs(["--backend-port=1", "--backend-port=2"]);
+    expect(r.deprecatedFlags).toEqual(["--backend-port"]);
   });
 
   it("reports --help via showHelp without exiting", () => {
-    const { showHelp } = parseArgs(["--help"]);
-    expect(showHelp).toBe(true);
+    expect(parseArgs(["--help"]).showHelp).toBe(true);
+  });
+
+  it("throws ParseError when a value-taking flag has no value", () => {
+    expect(() => parseArgs(["--port"])).toThrow(ParseError);
+    expect(() => parseArgs(["--port"])).toThrow(/--port requires a value/);
+  });
+
+  it("throws ParseError when the next token is another flag", () => {
+    expect(() => parseArgs(["--port", "--debug"])).toThrow(/--port requires a value/);
+  });
+
+  it("throws ParseError on a non-numeric port value", () => {
+    expect(() => parseArgs(["--port=abc"])).toThrow(/--port value must be a number/);
   });
 });
 
@@ -98,5 +96,21 @@ describe("resolvePorts", () => {
   it("returns undefined for both ports when nothing is set", () => {
     const r = resolvePorts({ command: "run" }, {} as NodeJS.ProcessEnv);
     expect(r).toEqual({ backendPort: undefined, webPort: undefined });
+  });
+});
+
+describe("deprecationReplacement", () => {
+  it("points --backend-port at --port for run/start", () => {
+    expect(deprecationReplacement("--backend-port", "run")).toBe("--port");
+    expect(deprecationReplacement("--backend-port", "start")).toBe("--port");
+  });
+
+  it("points --backend-port at the env var in dev (since --port maps to web there)", () => {
+    expect(deprecationReplacement("--backend-port", "dev")).toBe("KANDEV_BACKEND_PORT");
+  });
+
+  it("points --web-port at --web-internal-port", () => {
+    expect(deprecationReplacement("--web-port", "run")).toBe("--web-internal-port");
+    expect(deprecationReplacement("--web-port", "dev")).toBe("--web-internal-port");
   });
 });

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -98,9 +98,14 @@ describe("resolvePorts", () => {
     expect(r.backendPort).toBe(5555);
   });
 
-  it("KANDEV_WEB_PORT sets the internal web port", () => {
+  it("KANDEV_WEB_PORT sets the internal web port in dev", () => {
     const r = resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
     expect(r.webPort).toBe(8080);
+  });
+
+  it("KANDEV_WEB_PORT sets the internal web port in run/start (backend stays undefined)", () => {
+    const r = resolvePorts({ command: "run" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
+    expect(r).toEqual({ backendPort: undefined, webPort: 8080 });
   });
 
   it("--port maps to backend in every command (including dev)", () => {

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -97,6 +97,18 @@ describe("resolvePorts", () => {
     const r = resolvePorts({ command: "run" }, {} as NodeJS.ProcessEnv);
     expect(r).toEqual({ backendPort: undefined, webPort: undefined });
   });
+
+  it("throws ParseError when KANDEV_PORT is not a number", () => {
+    expect(() =>
+      resolvePorts({ command: "run" }, { KANDEV_PORT: "abc" } as NodeJS.ProcessEnv),
+    ).toThrow(ParseError);
+  });
+
+  it("throws ParseError when KANDEV_BACKEND_PORT is not a number", () => {
+    expect(() =>
+      resolvePorts({ command: "run" }, { KANDEV_BACKEND_PORT: "nope" } as NodeJS.ProcessEnv),
+    ).toThrow(/KANDEV_BACKEND_PORT must be a number/);
+  });
 });
 
 describe("deprecationReplacement", () => {

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { deprecationReplacement, parseArgs, ParseError, resolvePorts } from "./args";
+import { parseArgs, ParseError, resolvePorts } from "./args";
 
 describe("parseArgs", () => {
   it("defaults to the run command with no args", () => {
@@ -10,21 +10,20 @@ describe("parseArgs", () => {
     expect(deprecatedFlags).toEqual([]);
   });
 
-  it("parses --port and --port=<n>", () => {
-    expect(parseArgs(["--port", "3000"]).options.port).toBe(3000);
-    expect(parseArgs(["--port=3000"]).options.port).toBe(3000);
+  it("parses --port and --port=<n> as the backend port", () => {
+    expect(parseArgs(["--port", "3000"]).options.backendPort).toBe(3000);
+    expect(parseArgs(["--port=3000"]).options.backendPort).toBe(3000);
   });
 
-  it("parses --web-internal-port (the renamed advanced flag) without a deprecation note", () => {
+  it("parses --backend-port the same as --port (no deprecation note)", () => {
+    expect(parseArgs(["--backend-port=3447"]).options.backendPort).toBe(3447);
+    expect(parseArgs(["--backend-port=3447"]).deprecatedFlags).toEqual([]);
+  });
+
+  it("parses --web-internal-port without a deprecation note", () => {
     const r = parseArgs(["--web-internal-port", "12345"]);
     expect(r.options.webPort).toBe(12345);
     expect(r.deprecatedFlags).toEqual([]);
-  });
-
-  it("records --backend-port as deprecated but still parses it", () => {
-    const r = parseArgs(["--backend-port", "3447"]);
-    expect(r.options.backendPort).toBe(3447);
-    expect(r.deprecatedFlags).toEqual(["--backend-port"]);
   });
 
   it("records --web-port as deprecated", () => {
@@ -34,8 +33,8 @@ describe("parseArgs", () => {
   });
 
   it("dedupes deprecated flags across repeats", () => {
-    const r = parseArgs(["--backend-port=1", "--backend-port=2"]);
-    expect(r.deprecatedFlags).toEqual(["--backend-port"]);
+    const r = parseArgs(["--web-port=1", "--web-port=2"]);
+    expect(r.deprecatedFlags).toEqual(["--web-port"]);
   });
 
   it("reports --help via showHelp without exiting", () => {
@@ -63,36 +62,30 @@ describe("parseArgs", () => {
     expect(() => parseArgs([`--port=${val}`])).toThrow(/--port value must be an integer between/);
   });
 
+  it("throws ParseError on empty --port=", () => {
+    expect(() => parseArgs(["--port="])).toThrow(/--port value must be an integer/);
+  });
+
   it("throws ParseError on empty --version=", () => {
     expect(() => parseArgs(["--version="])).toThrow(/--version requires a value/);
   });
 });
 
 describe("resolvePorts", () => {
-  it("maps --port to backend port for run/start", () => {
-    const r = resolvePorts({ command: "start", port: 3447 }, {} as NodeJS.ProcessEnv);
-    expect(r).toEqual({ backendPort: 3447, webPort: undefined });
+  it("returns undefined for both ports when nothing is set", () => {
+    const r = resolvePorts({ command: "run" }, {} as NodeJS.ProcessEnv);
+    expect(r).toEqual({ backendPort: undefined, webPort: undefined });
   });
 
-  it("maps --port to web port for dev", () => {
-    const r = resolvePorts({ command: "dev", port: 3000 }, {} as NodeJS.ProcessEnv);
-    expect(r).toEqual({ backendPort: undefined, webPort: 3000 });
+  it("CLI backendPort wins over env vars", () => {
+    const r = resolvePorts({ command: "start", backendPort: 3000 }, {
+      KANDEV_BACKEND_PORT: "4000",
+      KANDEV_PORT: "5000",
+    } as NodeJS.ProcessEnv);
+    expect(r.backendPort).toBe(3000);
   });
 
-  it("explicit --backend-port wins over --port in start mode", () => {
-    const r = resolvePorts(
-      { command: "start", port: 3000, backendPort: 4000 },
-      {} as NodeJS.ProcessEnv,
-    );
-    expect(r.backendPort).toBe(4000);
-  });
-
-  it("falls back to KANDEV_PORT when no flag is given", () => {
-    const r = resolvePorts({ command: "run" }, { KANDEV_PORT: "5555" } as NodeJS.ProcessEnv);
-    expect(r.backendPort).toBe(5555);
-  });
-
-  it("KANDEV_BACKEND_PORT wins over KANDEV_PORT", () => {
+  it("KANDEV_BACKEND_PORT wins over KANDEV_PORT (more specific env wins)", () => {
     const r = resolvePorts({ command: "run" }, {
       KANDEV_PORT: "5555",
       KANDEV_BACKEND_PORT: "6666",
@@ -100,40 +93,25 @@ describe("resolvePorts", () => {
     expect(r.backendPort).toBe(6666);
   });
 
-  it("--port wins over KANDEV_BACKEND_PORT (explicit CLI > env var)", () => {
-    const r = resolvePorts({ command: "start", port: 3000 }, {
-      KANDEV_BACKEND_PORT: "4000",
-    } as NodeJS.ProcessEnv);
-    expect(r.backendPort).toBe(3000);
+  it("falls back to KANDEV_PORT when KANDEV_BACKEND_PORT is not set", () => {
+    const r = resolvePorts({ command: "run" }, { KANDEV_PORT: "5555" } as NodeJS.ProcessEnv);
+    expect(r.backendPort).toBe(5555);
   });
 
-  it("--port wins over KANDEV_WEB_PORT in dev (explicit CLI > env var)", () => {
-    const r = resolvePorts({ command: "dev", port: 3000 }, {
-      KANDEV_WEB_PORT: "4000",
-    } as NodeJS.ProcessEnv);
-    expect(r.webPort).toBe(3000);
+  it("KANDEV_WEB_PORT sets the internal web port", () => {
+    const r = resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
+    expect(r.webPort).toBe(8080);
   });
 
-  it("KANDEV_PORT routes to web port for dev", () => {
-    const r = resolvePorts({ command: "dev" }, { KANDEV_PORT: "9000" } as NodeJS.ProcessEnv);
-    expect(r).toEqual({ backendPort: undefined, webPort: 9000 });
-  });
-
-  it("returns undefined for both ports when nothing is set", () => {
-    const r = resolvePorts({ command: "run" }, {} as NodeJS.ProcessEnv);
-    expect(r).toEqual({ backendPort: undefined, webPort: undefined });
+  it("--port maps to backend in every command (including dev)", () => {
+    const r = resolvePorts({ command: "dev", backendPort: 3447 }, {} as NodeJS.ProcessEnv);
+    expect(r).toEqual({ backendPort: 3447, webPort: undefined });
   });
 
   it("throws ParseError when KANDEV_PORT is not a number", () => {
     expect(() =>
       resolvePorts({ command: "run" }, { KANDEV_PORT: "abc" } as NodeJS.ProcessEnv),
     ).toThrow(ParseError);
-  });
-
-  it("throws ParseError when KANDEV_BACKEND_PORT is not a number", () => {
-    expect(() =>
-      resolvePorts({ command: "run" }, { KANDEV_BACKEND_PORT: "nope" } as NodeJS.ProcessEnv),
-    ).toThrow(/KANDEV_BACKEND_PORT must be an integer/);
   });
 
   it("throws ParseError when KANDEV_PORT is a float", () => {
@@ -148,44 +126,12 @@ describe("resolvePorts", () => {
     ).toThrow(/KANDEV_PORT must be an integer between/);
   });
 
-  it("KANDEV_WEB_PORT sets the web port in dev", () => {
-    const r = resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
-    expect(r.webPort).toBe(8080);
-  });
-
-  it("KANDEV_WEB_PORT sets the internal web port in run/start (backend stays undefined)", () => {
-    const r = resolvePorts({ command: "run" }, { KANDEV_WEB_PORT: "8080" } as NodeJS.ProcessEnv);
-    expect(r).toEqual({ backendPort: undefined, webPort: 8080 });
-  });
-
-  it("throws ParseError when KANDEV_WEB_PORT is out of range", () => {
-    expect(() =>
-      resolvePorts({ command: "dev" }, { KANDEV_WEB_PORT: "0" } as NodeJS.ProcessEnv),
-    ).toThrow(/KANDEV_WEB_PORT must be an integer between/);
-  });
-
   it.each(["KANDEV_PORT", "KANDEV_BACKEND_PORT", "KANDEV_WEB_PORT"])(
-    "throws ParseError when %s is set to empty string (not silently ignored)",
+    "throws ParseError when %s is set to empty string",
     (name) => {
       expect(() => resolvePorts({ command: "run" }, { [name]: "" } as NodeJS.ProcessEnv)).toThrow(
         new RegExp(`${name} must be an integer`),
       );
     },
   );
-});
-
-describe("deprecationReplacement", () => {
-  it("points --backend-port at --port for run/start", () => {
-    expect(deprecationReplacement("--backend-port", "run")).toBe("--port");
-    expect(deprecationReplacement("--backend-port", "start")).toBe("--port");
-  });
-
-  it("points --backend-port at the env var in dev (since --port maps to web there)", () => {
-    expect(deprecationReplacement("--backend-port", "dev")).toBe("KANDEV_BACKEND_PORT");
-  });
-
-  it("points --web-port at --web-internal-port", () => {
-    expect(deprecationReplacement("--web-port", "run")).toBe("--web-internal-port");
-    expect(deprecationReplacement("--web-port", "dev")).toBe("--web-internal-port");
-  });
 });

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -122,19 +122,23 @@ export type ResolvedPorts = {
   webPort?: number;
 };
 
-// `--port` (and KANDEV_PORT) maps to the public front door: backend in run/start (proxied), web in dev (HMR direct). Explicit per-process flags still win.
+// `--port` (and KANDEV_PORT) maps to the public front door: backend in run/start (proxied), web in dev (HMR direct).
+// Precedence: explicit per-process CLI flag > generic CLI flag (--port) > explicit env var > generic env var (KANDEV_PORT).
+// Explicit CLI always beats env, so a stray KANDEV_BACKEND_PORT can't silently override --port.
 export function resolvePorts(options: CliOptions, env: NodeJS.ProcessEnv): ResolvedPorts {
-  const publicPort = options.port ?? envPort(env, "KANDEV_PORT");
-  let backendPort = options.backendPort ?? envPort(env, "KANDEV_BACKEND_PORT");
-  let webPort = options.webPort ?? envPort(env, "KANDEV_WEB_PORT");
-  if (publicPort !== undefined) {
-    if (options.command === "dev") {
-      webPort = webPort ?? publicPort;
-    } else {
-      backendPort = backendPort ?? publicPort;
-    }
+  const genericCli = options.port;
+  const genericEnv = envPort(env, "KANDEV_PORT");
+  if (options.command === "dev") {
+    return {
+      backendPort: options.backendPort ?? envPort(env, "KANDEV_BACKEND_PORT"),
+      webPort: options.webPort ?? genericCli ?? envPort(env, "KANDEV_WEB_PORT") ?? genericEnv,
+    };
   }
-  return { backendPort, webPort };
+  return {
+    backendPort:
+      options.backendPort ?? genericCli ?? envPort(env, "KANDEV_BACKEND_PORT") ?? genericEnv,
+    webPort: options.webPort ?? envPort(env, "KANDEV_WEB_PORT"),
+  };
 }
 
 function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -3,7 +3,6 @@ export type Command = "run" | "dev" | "start";
 export type CliOptions = {
   command: Command;
   version?: string;
-  port?: number;
   backendPort?: number;
   webPort?: number;
   verbose?: boolean;
@@ -13,7 +12,7 @@ export type CliOptions = {
 export type ParseResult = {
   options: CliOptions;
   showHelp: boolean;
-  /** Deprecated flags seen on the command line. cli.ts emits warnings after parsing so they can be command-aware. */
+  /** Deprecated flags seen on the command line. cli.ts emits warnings after parsing. */
   deprecatedFlags: string[];
 };
 
@@ -51,24 +50,15 @@ export function parseArgs(argv: string[]): ParseResult {
       opts.command = "dev";
       continue;
     }
-    if (arg === "--port") {
-      opts.port = parsePort(takeValue(argv, i, "--port"), "--port");
+    // --port is an alias for --backend-port (the user-facing port in run/start).
+    if (arg === "--port" || arg === "--backend-port") {
+      opts.backendPort = parsePort(takeValue(argv, i, arg), arg);
       i += 1;
       continue;
     }
-    if (arg.startsWith("--port=")) {
-      opts.port = parsePort(arg.split("=")[1], "--port");
-      continue;
-    }
-    if (arg === "--backend-port") {
-      opts.backendPort = parsePort(takeValue(argv, i, "--backend-port"), "--backend-port");
-      noteDeprecated("--backend-port");
-      i += 1;
-      continue;
-    }
-    if (arg.startsWith("--backend-port=")) {
-      opts.backendPort = parsePort(arg.split("=")[1], "--backend-port");
-      noteDeprecated("--backend-port");
+    if (arg.startsWith("--port=") || arg.startsWith("--backend-port=")) {
+      const flag = arg.startsWith("--port=") ? "--port" : "--backend-port";
+      opts.backendPort = parsePort(arg.slice(flag.length + 1), flag);
       continue;
     }
     if (arg === "--web-internal-port") {
@@ -77,7 +67,7 @@ export function parseArgs(argv: string[]): ParseResult {
       continue;
     }
     if (arg.startsWith("--web-internal-port=")) {
-      opts.webPort = parsePort(arg.split("=")[1], "--web-internal-port");
+      opts.webPort = parsePort(arg.slice("--web-internal-port=".length), "--web-internal-port");
       continue;
     }
     if (arg === "--web-port") {
@@ -87,7 +77,7 @@ export function parseArgs(argv: string[]): ParseResult {
       continue;
     }
     if (arg.startsWith("--web-port=")) {
-      opts.webPort = parsePort(arg.split("=")[1], "--web-port");
+      opts.webPort = parsePort(arg.slice("--web-port=".length), "--web-port");
       noteDeprecated("--web-port");
       continue;
     }
@@ -113,7 +103,7 @@ function takeValue(argv: string[], i: number, flag: string): string {
 
 function parsePort(raw: string, flag: string): number {
   const n = Number(raw);
-  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+  if (raw === "" || !Number.isInteger(n) || n < 1 || n > 65535) {
     throw new ParseError(`${flag} value must be an integer between 1 and 65535, got "${raw}"`);
   }
   return n;
@@ -124,19 +114,11 @@ export type ResolvedPorts = {
   webPort?: number;
 };
 
-// Precedence: explicit CLI > --port > explicit env var > KANDEV_PORT; explicit CLI always beats env.
+// CLI flags beat env vars; KANDEV_PORT is an alias for KANDEV_BACKEND_PORT.
 export function resolvePorts(options: CliOptions, env: NodeJS.ProcessEnv): ResolvedPorts {
-  const genericCli = options.port;
-  const genericEnv = envPort(env, "KANDEV_PORT");
-  if (options.command === "dev") {
-    return {
-      backendPort: options.backendPort ?? envPort(env, "KANDEV_BACKEND_PORT"),
-      webPort: options.webPort ?? genericCli ?? envPort(env, "KANDEV_WEB_PORT") ?? genericEnv,
-    };
-  }
   return {
     backendPort:
-      options.backendPort ?? genericCli ?? envPort(env, "KANDEV_BACKEND_PORT") ?? genericEnv,
+      options.backendPort ?? envPort(env, "KANDEV_BACKEND_PORT") ?? envPort(env, "KANDEV_PORT"),
     webPort: options.webPort ?? envPort(env, "KANDEV_WEB_PORT"),
   };
 }
@@ -149,15 +131,4 @@ function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {
     throw new ParseError(`${name} must be an integer between 1 and 65535, got "${val}"`);
   }
   return n;
-}
-
-// In dev, --port maps to web, so --backend-port → KANDEV_BACKEND_PORT (not --port).
-export function deprecationReplacement(flag: string, command: Command): string {
-  if (flag === "--backend-port") {
-    return command === "dev" ? "KANDEV_BACKEND_PORT" : "--port";
-  }
-  if (flag === "--web-port") {
-    return "--web-internal-port";
-  }
-  return "--port";
 }

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -42,7 +42,9 @@ export function parseArgs(argv: string[]): ParseResult {
       continue;
     }
     if (arg.startsWith("--version=")) {
-      opts.version = arg.split("=")[1];
+      const value = arg.slice("--version=".length);
+      if (value.length === 0) throw new ParseError("--version requires a value");
+      opts.version = value;
       continue;
     }
     if (arg === "--dev") {
@@ -141,9 +143,9 @@ export function resolvePorts(options: CliOptions, env: NodeJS.ProcessEnv): Resol
 
 function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {
   const val = env[name];
-  if (!val) return undefined;
+  if (val === undefined) return undefined;
   const n = Number(val);
-  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+  if (val === "" || !Number.isInteger(n) || n < 1 || n > 65535) {
     throw new ParseError(`${name} must be an integer between 1 and 65535, got "${val}"`);
   }
   return n;

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -139,12 +139,13 @@ export function resolvePorts(options: CliOptions, env: NodeJS.ProcessEnv): Resol
 
 function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {
   const val = env[name];
-  return val ? Number(val) : undefined;
+  if (!val) return undefined;
+  const n = Number(val);
+  if (!Number.isFinite(n)) throw new ParseError(`${name} must be a number, got "${val}"`);
+  return n;
 }
 
-// Returns the suggested replacement for a deprecated flag, given the active command.
-// `--port` maps to backend in run/start and to web in dev — so for dev users who
-// explicitly used `--backend-port`, the right pointer is the env var, not `--port`.
+// In dev, --port maps to web, so --backend-port → KANDEV_BACKEND_PORT (not --port).
 export function deprecationReplacement(flag: string, command: Command): string {
   if (flag === "--backend-port") {
     return command === "dev" ? "KANDEV_BACKEND_PORT" : "--port";

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -1,0 +1,148 @@
+/**
+ * Pure CLI argument parsing + port resolution.
+ *
+ * Kept free of side effects (other than a one-shot stderr deprecation note)
+ * so it can be unit-tested without spawning the launcher.
+ */
+
+export type Command = "run" | "dev" | "start";
+
+export type CliOptions = {
+  command: Command;
+  version?: string;
+  port?: number;
+  backendPort?: number;
+  webPort?: number;
+  verbose?: boolean;
+  debug?: boolean;
+};
+
+export type ParseResult = {
+  options: CliOptions;
+  showHelp: boolean;
+};
+
+export function parseArgs(argv: string[]): ParseResult {
+  const opts: CliOptions = { command: "run" };
+  let showHelp = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      showHelp = true;
+      continue;
+    }
+    if (arg === "dev" || arg === "run" || arg === "start") {
+      opts.command = arg;
+      continue;
+    }
+    if (arg === "--version") {
+      opts.version = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--version=")) {
+      opts.version = arg.split("=")[1];
+      continue;
+    }
+    if (arg === "--dev") {
+      opts.command = "dev";
+      continue;
+    }
+    if (arg === "--port") {
+      opts.port = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--port=")) {
+      opts.port = Number(arg.split("=")[1]);
+      continue;
+    }
+    if (arg === "--backend-port") {
+      opts.backendPort = Number(argv[i + 1]);
+      warnDeprecatedFlag("--backend-port", "--port");
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--backend-port=")) {
+      opts.backendPort = Number(arg.split("=")[1]);
+      warnDeprecatedFlag("--backend-port", "--port");
+      continue;
+    }
+    if (arg === "--web-internal-port") {
+      opts.webPort = Number(argv[i + 1]);
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--web-internal-port=")) {
+      opts.webPort = Number(arg.split("=")[1]);
+      continue;
+    }
+    if (arg === "--web-port") {
+      opts.webPort = Number(argv[i + 1]);
+      warnDeprecatedFlag("--web-port", "--web-internal-port");
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--web-port=")) {
+      opts.webPort = Number(arg.split("=")[1]);
+      warnDeprecatedFlag("--web-port", "--web-internal-port");
+      continue;
+    }
+    if (arg === "--verbose" || arg === "-v") {
+      opts.verbose = true;
+      continue;
+    }
+    if (arg === "--debug") {
+      opts.debug = true;
+      continue;
+    }
+  }
+  return { options: opts, showHelp };
+}
+
+export type ResolvedPorts = {
+  backendPort?: number;
+  webPort?: number;
+};
+
+/**
+ * Resolves backend/web ports from CLI options + env, applying the rule that
+ * `--port` (and KANDEV_PORT) maps to whichever process is the public front
+ * door for the chosen command:
+ *
+ * - start / run → backend port (the Go server reverse-proxies Next.js)
+ * - dev         → web port (browser hits Next dev directly for HMR)
+ *
+ * Explicit `--backend-port` / `--web-port` (and their *_PORT env vars)
+ * always take precedence over the generic `--port`.
+ */
+export function resolvePorts(options: CliOptions, env: NodeJS.ProcessEnv): ResolvedPorts {
+  const publicPort = options.port ?? envPort(env, "KANDEV_PORT");
+  let backendPort = options.backendPort ?? envPort(env, "KANDEV_BACKEND_PORT");
+  let webPort = options.webPort ?? envPort(env, "KANDEV_WEB_PORT");
+  if (publicPort !== undefined) {
+    if (options.command === "dev") {
+      webPort = webPort ?? publicPort;
+    } else {
+      backendPort = backendPort ?? publicPort;
+    }
+  }
+  return { backendPort, webPort };
+}
+
+function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {
+  const val = env[name];
+  return val ? Number(val) : undefined;
+}
+
+const warnedFlags = new Set<string>();
+function warnDeprecatedFlag(oldFlag: string, newFlag: string): void {
+  if (warnedFlags.has(oldFlag)) return;
+  warnedFlags.add(oldFlag);
+  process.stderr.write(`[kandev] ${oldFlag} is deprecated; use ${newFlag}\n`);
+}
+
+// Test-only: resets the dedup set between cases.
+export function _resetWarnedFlagsForTest(): void {
+  warnedFlags.clear();
+}

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -122,9 +122,7 @@ export type ResolvedPorts = {
   webPort?: number;
 };
 
-// `--port` (and KANDEV_PORT) maps to the public front door: backend in run/start (proxied), web in dev (HMR direct).
-// Precedence: explicit per-process CLI flag > generic CLI flag (--port) > explicit env var > generic env var (KANDEV_PORT).
-// Explicit CLI always beats env, so a stray KANDEV_BACKEND_PORT can't silently override --port.
+// Precedence: explicit CLI > --port > explicit env var > KANDEV_PORT; explicit CLI always beats env.
 export function resolvePorts(options: CliOptions, env: NodeJS.ProcessEnv): ResolvedPorts {
   const genericCli = options.port;
   const genericEnv = envPort(env, "KANDEV_PORT");

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -111,8 +111,8 @@ function takeValue(argv: string[], i: number, flag: string): string {
 
 function parsePort(raw: string, flag: string): number {
   const n = Number(raw);
-  if (!Number.isFinite(n)) {
-    throw new ParseError(`${flag} value must be a number, got "${raw}"`);
+  if (!Number.isInteger(n)) {
+    throw new ParseError(`${flag} value must be an integer, got "${raw}"`);
   }
   return n;
 }
@@ -141,7 +141,7 @@ function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {
   const val = env[name];
   if (!val) return undefined;
   const n = Number(val);
-  if (!Number.isFinite(n)) throw new ParseError(`${name} must be a number, got "${val}"`);
+  if (!Number.isInteger(n)) throw new ParseError(`${name} must be an integer, got "${val}"`);
   return n;
 }
 

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -1,10 +1,3 @@
-/**
- * Pure CLI argument parsing + port resolution.
- *
- * Kept free of side effects (other than a one-shot stderr deprecation note)
- * so it can be unit-tested without spawning the launcher.
- */
-
 export type Command = "run" | "dev" | "start";
 
 export type CliOptions = {
@@ -20,11 +13,19 @@ export type CliOptions = {
 export type ParseResult = {
   options: CliOptions;
   showHelp: boolean;
+  /** Deprecated flags seen on the command line. cli.ts emits warnings after parsing so they can be command-aware. */
+  deprecatedFlags: string[];
 };
+
+export class ParseError extends Error {}
 
 export function parseArgs(argv: string[]): ParseResult {
   const opts: CliOptions = { command: "run" };
   let showHelp = false;
+  const deprecatedFlags: string[] = [];
+  const noteDeprecated = (flag: string) => {
+    if (!deprecatedFlags.includes(flag)) deprecatedFlags.push(flag);
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--help" || arg === "-h") {
@@ -36,7 +37,7 @@ export function parseArgs(argv: string[]): ParseResult {
       continue;
     }
     if (arg === "--version") {
-      opts.version = argv[i + 1];
+      opts.version = takeValue(argv, i, "--version");
       i += 1;
       continue;
     }
@@ -49,43 +50,43 @@ export function parseArgs(argv: string[]): ParseResult {
       continue;
     }
     if (arg === "--port") {
-      opts.port = Number(argv[i + 1]);
+      opts.port = parsePort(takeValue(argv, i, "--port"), "--port");
       i += 1;
       continue;
     }
     if (arg.startsWith("--port=")) {
-      opts.port = Number(arg.split("=")[1]);
+      opts.port = parsePort(arg.split("=")[1], "--port");
       continue;
     }
     if (arg === "--backend-port") {
-      opts.backendPort = Number(argv[i + 1]);
-      warnDeprecatedFlag("--backend-port", "--port");
+      opts.backendPort = parsePort(takeValue(argv, i, "--backend-port"), "--backend-port");
+      noteDeprecated("--backend-port");
       i += 1;
       continue;
     }
     if (arg.startsWith("--backend-port=")) {
-      opts.backendPort = Number(arg.split("=")[1]);
-      warnDeprecatedFlag("--backend-port", "--port");
+      opts.backendPort = parsePort(arg.split("=")[1], "--backend-port");
+      noteDeprecated("--backend-port");
       continue;
     }
     if (arg === "--web-internal-port") {
-      opts.webPort = Number(argv[i + 1]);
+      opts.webPort = parsePort(takeValue(argv, i, "--web-internal-port"), "--web-internal-port");
       i += 1;
       continue;
     }
     if (arg.startsWith("--web-internal-port=")) {
-      opts.webPort = Number(arg.split("=")[1]);
+      opts.webPort = parsePort(arg.split("=")[1], "--web-internal-port");
       continue;
     }
     if (arg === "--web-port") {
-      opts.webPort = Number(argv[i + 1]);
-      warnDeprecatedFlag("--web-port", "--web-internal-port");
+      opts.webPort = parsePort(takeValue(argv, i, "--web-port"), "--web-port");
+      noteDeprecated("--web-port");
       i += 1;
       continue;
     }
     if (arg.startsWith("--web-port=")) {
-      opts.webPort = Number(arg.split("=")[1]);
-      warnDeprecatedFlag("--web-port", "--web-internal-port");
+      opts.webPort = parsePort(arg.split("=")[1], "--web-port");
+      noteDeprecated("--web-port");
       continue;
     }
     if (arg === "--verbose" || arg === "-v") {
@@ -97,7 +98,23 @@ export function parseArgs(argv: string[]): ParseResult {
       continue;
     }
   }
-  return { options: opts, showHelp };
+  return { options: opts, showHelp, deprecatedFlags };
+}
+
+function takeValue(argv: string[], i: number, flag: string): string {
+  const v = argv[i + 1];
+  if (v === undefined || v.startsWith("-")) {
+    throw new ParseError(`${flag} requires a value`);
+  }
+  return v;
+}
+
+function parsePort(raw: string, flag: string): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new ParseError(`${flag} value must be a number, got "${raw}"`);
+  }
+  return n;
 }
 
 export type ResolvedPorts = {
@@ -105,17 +122,7 @@ export type ResolvedPorts = {
   webPort?: number;
 };
 
-/**
- * Resolves backend/web ports from CLI options + env, applying the rule that
- * `--port` (and KANDEV_PORT) maps to whichever process is the public front
- * door for the chosen command:
- *
- * - start / run → backend port (the Go server reverse-proxies Next.js)
- * - dev         → web port (browser hits Next dev directly for HMR)
- *
- * Explicit `--backend-port` / `--web-port` (and their *_PORT env vars)
- * always take precedence over the generic `--port`.
- */
+// `--port` (and KANDEV_PORT) maps to the public front door: backend in run/start (proxied), web in dev (HMR direct). Explicit per-process flags still win.
 export function resolvePorts(options: CliOptions, env: NodeJS.ProcessEnv): ResolvedPorts {
   const publicPort = options.port ?? envPort(env, "KANDEV_PORT");
   let backendPort = options.backendPort ?? envPort(env, "KANDEV_BACKEND_PORT");
@@ -135,14 +142,15 @@ function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {
   return val ? Number(val) : undefined;
 }
 
-const warnedFlags = new Set<string>();
-function warnDeprecatedFlag(oldFlag: string, newFlag: string): void {
-  if (warnedFlags.has(oldFlag)) return;
-  warnedFlags.add(oldFlag);
-  process.stderr.write(`[kandev] ${oldFlag} is deprecated; use ${newFlag}\n`);
-}
-
-// Test-only: resets the dedup set between cases.
-export function _resetWarnedFlagsForTest(): void {
-  warnedFlags.clear();
+// Returns the suggested replacement for a deprecated flag, given the active command.
+// `--port` maps to backend in run/start and to web in dev — so for dev users who
+// explicitly used `--backend-port`, the right pointer is the env var, not `--port`.
+export function deprecationReplacement(flag: string, command: Command): string {
+  if (flag === "--backend-port") {
+    return command === "dev" ? "KANDEV_BACKEND_PORT" : "--port";
+  }
+  if (flag === "--web-port") {
+    return "--web-internal-port";
+  }
+  return "--port";
 }

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -111,8 +111,8 @@ function takeValue(argv: string[], i: number, flag: string): string {
 
 function parsePort(raw: string, flag: string): number {
   const n = Number(raw);
-  if (!Number.isInteger(n)) {
-    throw new ParseError(`${flag} value must be an integer, got "${raw}"`);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new ParseError(`${flag} value must be an integer between 1 and 65535, got "${raw}"`);
   }
   return n;
 }
@@ -141,7 +141,9 @@ function envPort(env: NodeJS.ProcessEnv, name: string): number | undefined {
   const val = env[name];
   if (!val) return undefined;
   const n = Number(val);
-  if (!Number.isInteger(n)) throw new ParseError(`${name} must be an integer, got "${val}"`);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new ParseError(`${name} must be an integer between 1 and 65535, got "${val}"`);
+  }
   return n;
 }
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 
 import pkg from "../package.json";
-import { deprecationReplacement, parseArgs, ParseError, resolvePorts } from "./args";
+import { parseArgs, ParseError, resolvePorts } from "./args";
 import { runDev } from "./dev";
 import { runRelease } from "./run";
 import { runStart } from "./start";
@@ -35,21 +35,19 @@ Options:
   run              Use release bundles (default).
   --dev            Alias for "dev".
   --version        Release tag to install (default: latest).
-  --port           Port to open kandev on (or KANDEV_PORT env var). In start/run
-                   this is the backend port (front door); in dev it is the Next
-                   dev server port.
+  --port           Port for the Go backend (the URL kandev opens on in
+                   start/run). Alias for --backend-port. Also reads
+                   KANDEV_PORT or KANDEV_BACKEND_PORT.
   --verbose, -v    Show info logs from backend + web.
   --debug          Show debug logs + agent message dumps.
   --help, -h       Show help.
 
 Advanced:
-  --backend-port       Sets the Go backend port directly. Deprecated alias for
-                       --port in run/start. Also reads KANDEV_BACKEND_PORT.
-  --web-internal-port  Override the Next.js port. In run/start the backend
-                       reverse-proxies to it; in dev it is the URL the browser
-                       opens (same effect as --port). Also reads KANDEV_WEB_PORT.
-  --web-port           Deprecated alias for --web-internal-port. Misleading name
-                       because in run/start the public URL is on the backend port.
+  --backend-port       Same as --port.
+  --web-internal-port  Override the internal Next.js port. The Go backend
+                       reverse-proxies to it; users hit the backend port.
+                       Also reads KANDEV_WEB_PORT.
+  --web-port           Deprecated alias for --web-internal-port.
 `);
 }
 
@@ -84,8 +82,7 @@ async function main(): Promise<void> {
   }
 
   for (const flag of deprecatedFlags) {
-    const replacement = deprecationReplacement(flag, options.command);
-    process.stderr.write(`[kandev] ${flag} is deprecated; use ${replacement}\n`);
+    process.stderr.write(`[kandev] ${flag} is deprecated; use --web-internal-port\n`);
   }
 
   const resolved = resolvePorts(options, process.env);

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 
 import pkg from "../package.json";
-import { parseArgs, resolvePorts } from "./args";
+import { deprecationReplacement, parseArgs, ParseError, resolvePorts } from "./args";
 import { runDev } from "./dev";
 import { runRelease } from "./run";
 import { runStart } from "./start";
@@ -43,13 +43,13 @@ Options:
   --help, -h       Show help.
 
 Advanced:
-  --backend-port       Deprecated alias for --port (start/run). Sets the Go
-                       backend port directly. Also reads KANDEV_BACKEND_PORT.
-  --web-internal-port  Override the internal Next.js port (start/run only). The
-                       Go backend reverse-proxies to it; users never hit it
-                       directly. Also reads KANDEV_WEB_PORT.
+  --backend-port       Sets the Go backend port directly. Deprecated alias for
+                       --port in run/start. Also reads KANDEV_BACKEND_PORT.
+  --web-internal-port  Override the Next.js port. In run/start the backend
+                       reverse-proxies to it; in dev it is the URL the browser
+                       opens (same effect as --port). Also reads KANDEV_WEB_PORT.
   --web-port           Deprecated alias for --web-internal-port. Misleading name
-                       because the public URL is on the backend port.
+                       because in run/start the public URL is on the backend port.
 `);
 }
 
@@ -77,10 +77,15 @@ function findRepoRoot(startDir: string): string | null {
 }
 
 async function main(): Promise<void> {
-  const { options, showHelp } = parseArgs(process.argv.slice(2));
+  const { options, showHelp, deprecatedFlags } = parseArgs(process.argv.slice(2));
   if (showHelp) {
     printHelp();
     return;
+  }
+
+  for (const flag of deprecatedFlags) {
+    const replacement = deprecationReplacement(flag, options.command);
+    process.stderr.write(`[kandev] ${flag} is deprecated; use ${replacement}\n`);
   }
 
   const resolved = resolvePorts(options, process.env);
@@ -122,6 +127,11 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
+  if (err instanceof ParseError) {
+    console.error(`[kandev] ${err.message}`);
+    console.error("[kandev] run --help for usage");
+    process.exit(2);
+  }
   console.error(`[kandev] ${err instanceof Error ? err.message : String(err)}`);
   process.exit(1);
 });

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -2,32 +2,22 @@ import path from "node:path";
 import fs from "node:fs";
 
 import pkg from "../package.json";
+import { parseArgs, resolvePorts } from "./args";
 import { runDev } from "./dev";
 import { runRelease } from "./run";
 import { runStart } from "./start";
 import { ensureValidPort } from "./ports";
 import { maybePromptForUpdate } from "./update";
 
-type Command = "run" | "dev" | "start";
-
-type CliOptions = {
-  command: Command;
-  version?: string;
-  backendPort?: number;
-  webPort?: number;
-  verbose?: boolean;
-  debug?: boolean;
-};
-
 function printHelp() {
   console.log(`kandev launcher
 
 Usage:
-  kandev run [--version <tag>] [--backend-port <port>] [--web-port <port>] [--verbose] [--debug]
-  kandev dev [--backend-port <port>] [--web-port <port>]
-  kandev start [--backend-port <port>] [--web-port <port>] [--verbose] [--debug]
-  kandev [--version <tag>] [--backend-port <port>] [--web-port <port>] [--verbose] [--debug]
-  kandev --dev [--backend-port <port>] [--web-port <port>]
+  kandev run [--version <tag>] [--port <port>] [--verbose] [--debug]
+  kandev dev [--port <port>]
+  kandev start [--port <port>] [--verbose] [--debug]
+  kandev [--version <tag>] [--port <port>] [--verbose] [--debug]
+  kandev --dev [--port <port>]
 
 Examples:
   kandev
@@ -36,81 +26,31 @@ Examples:
   kandev dev
   kandev start
   kandev --version v0.1.0
-  kandev --backend-port 18080 --web-port 13000
+  kandev --port 3000
   kandev --debug
 
 Options:
-  dev             Use local repo for dev (make dev + next dev) if available.
-  start           Use local production build (make build + next start).
-  run             Use release bundles (default).
+  dev              Use local repo for dev (make dev + next dev) if available.
+  start            Use local production build (make build + next start).
+  run              Use release bundles (default).
   --dev            Alias for "dev".
   --version        Release tag to install (default: latest).
-  --backend-port   Override backend port (or KANDEV_BACKEND_PORT env var).
-  --web-port       Override web port (or KANDEV_WEB_PORT env var).
+  --port           Port to open kandev on (or KANDEV_PORT env var). In start/run
+                   this is the backend port (front door); in dev it is the Next
+                   dev server port.
   --verbose, -v    Show info logs from backend + web.
   --debug          Show debug logs + agent message dumps.
   --help, -h       Show help.
+
+Advanced:
+  --backend-port       Deprecated alias for --port (start/run). Sets the Go
+                       backend port directly. Also reads KANDEV_BACKEND_PORT.
+  --web-internal-port  Override the internal Next.js port (start/run only). The
+                       Go backend reverse-proxies to it; users never hit it
+                       directly. Also reads KANDEV_WEB_PORT.
+  --web-port           Deprecated alias for --web-internal-port. Misleading name
+                       because the public URL is on the backend port.
 `);
-}
-
-function parseArgs(argv: string[]): CliOptions {
-  const opts: CliOptions = { command: "run" };
-  for (let i = 0; i < argv.length; i += 1) {
-    const arg = argv[i];
-    if (arg === "--help" || arg === "-h") {
-      printHelp();
-      process.exit(0);
-    }
-    if (arg === "dev" || arg === "run" || arg === "start") {
-      opts.command = arg;
-      continue;
-    }
-    if (arg === "--version") {
-      opts.version = argv[i + 1];
-      i += 1;
-      continue;
-    }
-    if (arg.startsWith("--version=")) {
-      opts.version = arg.split("=")[1];
-      continue;
-    }
-    if (arg === "--dev") {
-      opts.command = "dev";
-      continue;
-    }
-    if (arg === "--backend-port") {
-      opts.backendPort = Number(argv[i + 1]);
-      i += 1;
-      continue;
-    }
-    if (arg.startsWith("--backend-port=")) {
-      opts.backendPort = Number(arg.split("=")[1]);
-      continue;
-    }
-    if (arg === "--web-port") {
-      opts.webPort = Number(argv[i + 1]);
-      i += 1;
-      continue;
-    }
-    if (arg.startsWith("--web-port=")) {
-      opts.webPort = Number(arg.split("=")[1]);
-      continue;
-    }
-    if (arg === "--verbose" || arg === "-v") {
-      opts.verbose = true;
-      continue;
-    }
-    if (arg === "--debug") {
-      opts.debug = true;
-      continue;
-    }
-  }
-  return opts;
-}
-
-function envPort(name: string): number | undefined {
-  const val = process.env[name];
-  return val ? Number(val) : undefined;
 }
 
 function findRepoRoot(startDir: string): string | null {
@@ -137,14 +77,17 @@ function findRepoRoot(startDir: string): string | null {
 }
 
 async function main(): Promise<void> {
-  const raw = parseArgs(process.argv.slice(2));
-  const backendPort = ensureValidPort(
-    raw.backendPort ?? envPort("KANDEV_BACKEND_PORT"),
-    "backend port",
-  );
-  const webPort = ensureValidPort(raw.webPort ?? envPort("KANDEV_WEB_PORT"), "web port");
+  const { options, showHelp } = parseArgs(process.argv.slice(2));
+  if (showHelp) {
+    printHelp();
+    return;
+  }
 
-  if (raw.command === "dev") {
+  const resolved = resolvePorts(options, process.env);
+  const backendPort = ensureValidPort(resolved.backendPort, "backend port");
+  const webPort = ensureValidPort(resolved.webPort, "web port");
+
+  if (options.command === "dev") {
     const repoRoot = findRepoRoot(process.cwd());
     if (!repoRoot) {
       throw new Error("Unable to locate repo root for dev. Run from the repo.");
@@ -153,22 +96,28 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (raw.command === "start") {
+  if (options.command === "start") {
     const repoRoot = findRepoRoot(process.cwd());
     if (!repoRoot) {
       throw new Error("Unable to locate repo root for start. Run from the repo.");
     }
-    await runStart({ repoRoot, backendPort, webPort, verbose: raw.verbose, debug: raw.debug });
+    await runStart({
+      repoRoot,
+      backendPort,
+      webPort,
+      verbose: options.verbose,
+      debug: options.debug,
+    });
     return;
   }
 
   await maybePromptForUpdate(pkg.version, process.argv.slice(2));
   await runRelease({
-    version: raw.version,
+    version: options.version,
     backendPort,
     webPort,
-    verbose: raw.verbose,
-    debug: raw.debug,
+    verbose: options.verbose,
+    debug: options.debug,
   });
 }
 

--- a/apps/cli/src/dev.ts
+++ b/apps/cli/src/dev.ts
@@ -27,10 +27,12 @@ export async function runDev({ repoRoot, backendPort, webPort }: DevOptions): Pr
   const webEnv = buildWebEnv({ ports, debug: true });
   const logLevel =
     process.env.KANDEV_LOGGING_LEVEL?.trim() || process.env.KANDEV_LOG_LEVEL?.trim() || "info";
+  const webUrl = `http://localhost:${ports.webPort}`;
 
   logStartupInfo({
     header: "dev mode: using local repo",
     ports,
+    publicUrl: webUrl,
     dbPath,
     logLevel,
   });
@@ -52,7 +54,6 @@ export async function runDev({ repoRoot, backendPort, webPort }: DevOptions): Pr
   await waitForHealth(ports.backendUrl, backendProc, healthTimeoutMs);
   console.log(`[kandev] backend ready at ${ports.backendUrl}`);
 
-  const webUrl = `http://localhost:${ports.webPort}`;
   console.log("[kandev] starting web...");
   const webProc = launchWebApp({
     command: "pnpm",
@@ -63,7 +64,7 @@ export async function runDev({ repoRoot, backendPort, webPort }: DevOptions): Pr
     label: "web",
   });
   await waitForUrlReady(webUrl, webProc, healthTimeoutMs);
-  console.log(`[kandev] web ready at ${webUrl}`);
+  console.log(`[kandev] open: ${webUrl}`);
   openBrowser(webUrl);
 }
 

--- a/apps/cli/src/dev.ts
+++ b/apps/cli/src/dev.ts
@@ -32,7 +32,6 @@ export async function runDev({ repoRoot, backendPort, webPort }: DevOptions): Pr
   logStartupInfo({
     header: "dev mode: using local repo",
     ports,
-    publicUrl: webUrl,
     dbPath,
     logLevel,
   });

--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -252,7 +252,6 @@ function launchReleaseApps(prepared: PreparedRelease): {
       agentctlPort: prepared.agentctlPort,
       backendUrl: prepared.backendUrl,
     },
-    publicUrl: prepared.backendUrl,
     dbPath: prepared.dbPath,
     logLevel: prepared.logLevel,
   });

--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -252,6 +252,7 @@ function launchReleaseApps(prepared: PreparedRelease): {
       agentctlPort: prepared.agentctlPort,
       backendUrl: prepared.backendUrl,
     },
+    publicUrl: prepared.backendUrl,
     dbPath: prepared.dbPath,
     logLevel: prepared.logLevel,
   });
@@ -318,6 +319,6 @@ export async function runRelease({
     quiet: !prepared.showOutput,
   });
   await waitForUrlReady(webUrl, webProc, healthTimeoutMs);
-  console.log("[kandev] ready at " + prepared.backendUrl);
+  console.log("[kandev] open: " + prepared.backendUrl);
   openBrowser(prepared.backendUrl);
 }

--- a/apps/cli/src/shared.ts
+++ b/apps/cli/src/shared.ts
@@ -123,8 +123,8 @@ export function logStartupInfo(options: StartupInfoOptions): void {
   const backendUrl = ports.backendUrl;
   const webUrl = `http://localhost:${ports.webPort}`;
   console.log(`[kandev] ${header}`);
-  console.log("[kandev] backend (api):", backendUrl);
-  console.log("[kandev] web (internal):", webUrl);
+  console.log("[kandev] backend:", backendUrl);
+  console.log("[kandev] web:", webUrl);
   console.log("[kandev] agentctl port:", ports.agentctlPort);
   console.log("[kandev] mcp url:", `${backendUrl}/mcp`);
   if (dbPath) {

--- a/apps/cli/src/shared.ts
+++ b/apps/cli/src/shared.ts
@@ -109,8 +109,6 @@ export type StartupInfoOptions = {
   /** Mode header line, e.g. "dev mode: using local repo" or "release: v0.0.12 (github latest)" */
   header: string;
   ports: PortConfig;
-  /** The user-facing URL — the one the browser will open. */
-  publicUrl: string;
   /** Database file path */
   dbPath?: string;
   /** Log level being used */
@@ -121,17 +119,12 @@ export type StartupInfoOptions = {
  * Logs a unified startup info block to the console.
  */
 export function logStartupInfo(options: StartupInfoOptions): void {
-  const { header, ports, publicUrl, dbPath, logLevel } = options;
+  const { header, ports, dbPath, logLevel } = options;
   const backendUrl = ports.backendUrl;
   const webUrl = `http://localhost:${ports.webPort}`;
   console.log(`[kandev] ${header}`);
-  console.log("[kandev] open:", publicUrl);
-  if (backendUrl !== publicUrl) {
-    console.log("[kandev] backend (api):", backendUrl);
-  }
-  if (webUrl !== publicUrl) {
-    console.log("[kandev] web (internal):", webUrl);
-  }
+  console.log("[kandev] backend (api):", backendUrl);
+  console.log("[kandev] web (internal):", webUrl);
   console.log("[kandev] agentctl port:", ports.agentctlPort);
   console.log("[kandev] mcp url:", `${backendUrl}/mcp`);
   if (dbPath) {

--- a/apps/cli/src/shared.ts
+++ b/apps/cli/src/shared.ts
@@ -109,6 +109,8 @@ export type StartupInfoOptions = {
   /** Mode header line, e.g. "dev mode: using local repo" or "release: v0.0.12 (github latest)" */
   header: string;
   ports: PortConfig;
+  /** The user-facing URL — the one the browser will open. */
+  publicUrl: string;
   /** Database file path */
   dbPath?: string;
   /** Log level being used */
@@ -119,11 +121,19 @@ export type StartupInfoOptions = {
  * Logs a unified startup info block to the console.
  */
 export function logStartupInfo(options: StartupInfoOptions): void {
-  const { header, ports, dbPath, logLevel } = options;
+  const { header, ports, publicUrl, dbPath, logLevel } = options;
+  const backendUrl = ports.backendUrl;
+  const webUrl = `http://localhost:${ports.webPort}`;
   console.log(`[kandev] ${header}`);
-  console.log("[kandev] url: http://localhost:" + ports.backendPort);
+  console.log("[kandev] open:", publicUrl);
+  if (backendUrl !== publicUrl) {
+    console.log("[kandev] backend (api):", backendUrl);
+  }
+  if (webUrl !== publicUrl) {
+    console.log("[kandev] web (internal):", webUrl);
+  }
   console.log("[kandev] agentctl port:", ports.agentctlPort);
-  console.log("[kandev] mcp url:", `http://localhost:${ports.backendPort}/mcp`);
+  console.log("[kandev] mcp url:", `${backendUrl}/mcp`);
   if (dbPath) {
     console.log("[kandev] db path:", dbPath);
   }

--- a/apps/cli/src/start.ts
+++ b/apps/cli/src/start.ts
@@ -170,7 +170,6 @@ export async function runStart({
   logStartupInfo({
     header: "start mode: using local build",
     ports,
-    publicUrl: ports.backendUrl,
     dbPath,
     logLevel,
   });

--- a/apps/cli/src/start.ts
+++ b/apps/cli/src/start.ts
@@ -170,6 +170,7 @@ export async function runStart({
   logStartupInfo({
     header: "start mode: using local build",
     ports,
+    publicUrl: ports.backendUrl,
     dbPath,
     logLevel,
   });
@@ -207,6 +208,6 @@ export async function runStart({
   });
 
   await waitForUrlReady(webUrl, webProc, healthTimeoutMs);
-  console.log("[kandev] ready at " + ports.backendUrl);
+  console.log("[kandev] open: " + ports.backendUrl);
   openBrowser(ports.backendUrl);
 }


### PR DESCRIPTION
## Summary

`--web-port` looked broken because it controls an internal Next.js port, not the URL users open. In `start` / `run`, the Go backend reverse-proxies all non-API requests to Next.js (`apps/backend/cmd/kandev/helpers.go`), so the URL the browser opens is always the **backend** port. `--web-port` only changes the proxy target, which users never hit directly.

This PR makes the obvious flag (`--port`) do the obvious thing:

- **`--port` is a plain alias for `--backend-port`** in every command. Always sets the Go backend port — the URL kandev opens on in `start` / `run`. Counterintuitive name (`--backend-port`) is no longer the only option.
- **`KANDEV_PORT`** is a plain alias for `KANDEV_BACKEND_PORT` (env-var fallback).
- **`--web-port` → `--web-internal-port`**: rename to reflect what it actually controls. Old `--web-port` still works and emits a one-time stderr deprecation note.
- **Validation hardened**: missing values, non-numeric/non-integer/out-of-range port values, and empty env vars (`KANDEV_PORT=`) now throw a `ParseError` naming the flag/env var instead of leaking generic NaN errors from `ensureValidPort`.
- **Startup logs**: replace ambiguous `[kandev] url:` / `ready at` with labelled `backend:` / `web:` URLs in the startup block, plus a single post-readiness `[kandev] open:` line that's the actionable signal.

Code split: arg parsing + port resolution moved into a pure `apps/cli/src/args.ts` module with unit tests. No backend changes — the existing reverse proxy already does the right thing.

## Test plan

- [x] `pnpm exec tsc -p tsconfig.json --noEmit` clean
- [x] `pnpm exec vitest run` — 117 passed (28 new in `args.test.ts`)
- [x] Local smoke: `node apps/cli/dist/cli.js start --port 2345` → `backend: http://localhost:2345`, browser opens 2345
- [x] `--backend-port 2345` still works identically
- [x] `--port` alone (no value) → clear ParseError, exit 2, suggests `--help`
- [ ] After publish: `npx kandev start --port 3447` opens `http://localhost:3447`