### PR TITLE
fix(web): contain kanban card badges within card width

### DIFF
--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -141,9 +141,9 @@ function KanbanCardBadges({ task }: { task: Task }) {
   if (!showRow) return null;
 
   return (
-    <div className="flex items-center justify-end gap-2 mt-1">
+    <div className="flex flex-wrap items-center justify-end gap-2 mt-1 min-w-0">
       {task.parentTaskId && (
-        <Badge variant="outline" className="text-xs h-5 gap-1 max-w-[160px]">
+        <Badge variant="outline" className="text-xs h-5 gap-1 max-w-[160px] min-w-0">
           <IconSubtask className="h-3 w-3 shrink-0" />
           <span className="truncate">{parentTitle ?? "Subtask"}</span>
         </Badge>


### PR DESCRIPTION
## Summary

Kanban task card badges (parent task name, session count, review status) overflowed the card's right edge when the dockview panel was narrow. Card uses `overflow-visible`, the badges row had no `flex-wrap`, and the parent badge had no `min-w-0` — so they painted past the card boundary instead of wrapping or truncating. Now they wrap to a new line and shrink to fit.

## Validation

- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` (678 passed)
- `pnpm exec tsc --noEmit` (no new errors)

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if applicable)
- [ ] Self-reviewed the diff