### PR TITLE
feat(web): mobile terminal key-bar — Ctrl/Shift modify OS-keyboard input + iOS keyboard fixes

### DIFF
--- a/apps/web/components/task/mobile/mobile-terminal-keybar-helpers.tsx
+++ b/apps/web/components/task/mobile/mobile-terminal-keybar-helpers.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { Button } from "@kandev/ui/button";
+import { cn } from "@/lib/utils";
+import { KEY_SEQUENCES } from "@/lib/terminal/key-sequences";
+import { isActive } from "@/lib/terminal/shell-modifiers";
+
+export type KeyDef = {
+  /** Stable id used for data-testid (e.g. `keybar-key-esc`). */
+  id: string;
+  /** Rendered button label. */
+  label: ReactNode;
+  /** Accessible label. */
+  ariaLabel: string;
+  /** Sequence emitted on tap. Ctrl/Shift transforms are applied downstream. */
+  seq: string;
+};
+
+export const KEYS: readonly KeyDef[] = [
+  { id: "esc", label: "Esc", ariaLabel: "Escape", seq: KEY_SEQUENCES.esc },
+  { id: "tab", label: "Tab", ariaLabel: "Tab", seq: KEY_SEQUENCES.tab },
+  { id: "up", label: "↑", ariaLabel: "Arrow Up", seq: KEY_SEQUENCES.up },
+  { id: "down", label: "↓", ariaLabel: "Arrow Down", seq: KEY_SEQUENCES.down },
+  { id: "left", label: "←", ariaLabel: "Arrow Left", seq: KEY_SEQUENCES.left },
+  { id: "right", label: "→", ariaLabel: "Arrow Right", seq: KEY_SEQUENCES.right },
+  { id: "home", label: "Home", ariaLabel: "Home", seq: KEY_SEQUENCES.home },
+  { id: "end", label: "End", ariaLabel: "End", seq: KEY_SEQUENCES.end },
+  { id: "pageup", label: "PgUp", ariaLabel: "Page Up", seq: KEY_SEQUENCES.pageUp },
+  { id: "pagedown", label: "PgDn", ariaLabel: "Page Down", seq: KEY_SEQUENCES.pageDown },
+  { id: "pipe", label: "|", ariaLabel: "Pipe", seq: "|" },
+  { id: "tilde", label: "~", ariaLabel: "Tilde", seq: "~" },
+  { id: "slash", label: "/", ariaLabel: "Slash", seq: "/" },
+  { id: "dash", label: "-", ariaLabel: "Dash", seq: "-" },
+  { id: "underscore", label: "_", ariaLabel: "Underscore", seq: "_" },
+];
+
+type KeybarButtonProps = {
+  id: string;
+  ariaLabel: string;
+  ariaPressed?: boolean;
+  active?: boolean;
+  sticky?: boolean;
+  variant?: "default" | "destructive";
+  onTap: () => void;
+  children: ReactNode;
+};
+
+export function KeybarButton({
+  id,
+  ariaLabel,
+  ariaPressed,
+  active,
+  sticky,
+  variant,
+  onTap,
+  children,
+}: KeybarButtonProps) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={variant ?? (active ? "secondary" : "outline")}
+      aria-label={ariaLabel}
+      aria-pressed={ariaPressed}
+      data-testid={`keybar-key-${id}`}
+      data-sticky={sticky ? "true" : undefined}
+      onPointerDown={(e) => e.preventDefault()}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onTap}
+      style={{ touchAction: "manipulation" }}
+      className={cn(
+        "h-8 min-w-10 shrink-0 px-2 font-mono text-sm cursor-pointer",
+        active && "ring-2 ring-primary/60",
+        sticky && "ring-primary",
+      )}
+    >
+      {children}
+    </Button>
+  );
+}
+
+type ModifierButtonProps = {
+  id: string;
+  label: string;
+  ariaLabel: string;
+  state: { latched: boolean; sticky: boolean };
+  onTap: () => void;
+};
+
+export function ModifierButton({ id, label, ariaLabel, state, onTap }: ModifierButtonProps) {
+  return (
+    <KeybarButton
+      id={id}
+      ariaLabel={ariaLabel}
+      ariaPressed={isActive(state)}
+      active={isActive(state)}
+      sticky={state.sticky}
+      onTap={onTap}
+    >
+      {label}
+    </KeybarButton>
+  );
+}

--- a/apps/web/components/task/mobile/mobile-terminal-keybar.test.tsx
+++ b/apps/web/components/task/mobile/mobile-terminal-keybar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { MobileTerminalKeybar } from "./mobile-terminal-keybar";
+import { useShellModifiersStore } from "@/lib/terminal/shell-modifiers";
 
 const sendMock = vi.fn();
 
@@ -9,12 +10,15 @@ vi.mock("@/lib/ws/connection", () => ({
 }));
 
 vi.mock("@/hooks/use-visual-viewport-offset", () => ({
-  useVisualViewportOffset: () => ({ bottomOffset: 0, keyboardOpen: false }),
+  useVisualViewportOffset: () => ({ bottomOffset: 0, keyboardOpen: false, viewportBottom: 0 }),
 }));
 
+const KEYBAR_ROOT = "mobile-terminal-keybar";
 const CTRL_KEY = "keybar-key-ctrl";
-const LETTER_C = "keybar-key-letter-c";
+const SHIFT_KEY = "keybar-key-shift";
+const ESC_KEY = "keybar-key-esc";
 const ARIA_PRESSED = "aria-pressed";
+const SESSION_ID = "s1";
 
 function tap(testId: string): void {
   fireEvent.click(screen.getByTestId(testId));
@@ -25,47 +29,44 @@ function lastData(): string | undefined {
   return call?.payload?.data;
 }
 
-function allData(): string[] {
-  return sendMock.mock.calls.map((c) => (c[0] as { payload: { data: string } }).payload.data);
-}
-
 beforeEach(() => {
   sendMock.mockReset();
+  useShellModifiersStore.getState().reset();
   cleanup();
 });
 
 describe("MobileTerminalKeybar visibility", () => {
   it("renders when visible and has a sessionId", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
-    expect(screen.getByTestId("mobile-terminal-keybar")).toBeDefined();
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+    expect(screen.getByTestId(KEYBAR_ROOT)).toBeDefined();
   });
 
   it("renders nothing when not visible", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={false} />);
-    expect(screen.queryByTestId("mobile-terminal-keybar")).toBeNull();
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={false} />);
+    expect(screen.queryByTestId(KEYBAR_ROOT)).toBeNull();
   });
 
   it("renders nothing without a sessionId", () => {
     render(<MobileTerminalKeybar sessionId={null} visible={true} />);
-    expect(screen.queryByTestId("mobile-terminal-keybar")).toBeNull();
+    expect(screen.queryByTestId(KEYBAR_ROOT)).toBeNull();
   });
 });
 
 describe("MobileTerminalKeybar single-key emission", () => {
   it("sends \\x1b on Esc tap", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
-    tap("keybar-key-esc");
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+    tap(ESC_KEY);
     expect(lastData()).toBe("\x1b");
   });
 
   it("sends \\t on Tab tap", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     tap("keybar-key-tab");
     expect(lastData()).toBe("\t");
   });
 
   it("sends arrow escape sequences", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     tap("keybar-key-up");
     expect(lastData()).toBe("\x1b[A");
     tap("keybar-key-down");
@@ -76,20 +77,8 @@ describe("MobileTerminalKeybar single-key emission", () => {
     expect(lastData()).toBe("\x1b[C");
   });
 
-  it("sends Home / End / PgUp / PgDn", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
-    tap("keybar-key-home");
-    expect(lastData()).toBe("\x01");
-    tap("keybar-key-end");
-    expect(lastData()).toBe("\x05");
-    tap("keybar-key-pageup");
-    expect(lastData()).toBe("\x1b[5~");
-    tap("keybar-key-pagedown");
-    expect(lastData()).toBe("\x1b[6~");
-  });
-
   it("sends literal symbols", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     tap("keybar-key-pipe");
     expect(lastData()).toBe("|");
     tap("keybar-key-tilde");
@@ -99,69 +88,160 @@ describe("MobileTerminalKeybar single-key emission", () => {
 
 describe("MobileTerminalKeybar dedicated Ctrl+C / Ctrl+D", () => {
   it("Ctrl+C button sends \\x03 in one tap", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     tap("keybar-key-ctrl-c");
     expect(lastData()).toBe("\x03");
   });
 
   it("Ctrl+D button sends \\x04 in one tap", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     tap("keybar-key-ctrl-d");
     expect(lastData()).toBe("\x04");
   });
 });
 
-describe("MobileTerminalKeybar sticky Ctrl state machine", () => {
-  it("latches Ctrl then chords the next letter and auto-releases", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
-
+describe("MobileTerminalKeybar Ctrl modifier", () => {
+  it("tapping Ctrl latches the modifier in the shared store", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     const ctrl = screen.getByTestId(CTRL_KEY);
     expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("false");
 
     tap(CTRL_KEY);
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: true, sticky: false });
     expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("true");
-
-    tap(LETTER_C);
-    expect(lastData()).toBe("\x03");
-    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("false");
   });
 
-  it("double-tap makes Ctrl sticky; chord bytes keep flowing", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+  it("double-tap makes Ctrl sticky", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     const ctrl = screen.getByTestId(CTRL_KEY);
-
     tap(CTRL_KEY);
     tap(CTRL_KEY);
-    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("true");
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: true, sticky: true });
     expect(ctrl.getAttribute("data-sticky")).toBe("true");
-
-    tap(LETTER_C);
-    tap("keybar-key-letter-d");
-    const data = allData();
-    expect(data).toContain("\x03");
-    expect(data).toContain("\x04");
-    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("true");
   });
 
-  it("third tap releases sticky", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
-    const ctrl = screen.getByTestId(CTRL_KEY);
-
+  it("third tap clears Ctrl entirely", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     tap(CTRL_KEY);
     tap(CTRL_KEY);
     tap(CTRL_KEY);
-    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("false");
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: false, sticky: false });
   });
 
-  it("does not expose letter keys until Ctrl is active", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+  it("tapping a bar key with Ctrl latched chords it and auto-releases", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+    tap(CTRL_KEY);
+    // Tab becomes Ctrl+I (\x09) when ctrl is active — but the chord transform
+    // only runs on single-char data. Use a symbol key which is single-char.
+    tap("keybar-key-pipe");
+    expect(lastData()).toBe("|"); // "|" transforms to itself (non-letter)
+    // Ctrl was latched (non-sticky), so it clears after consumption.
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: false, sticky: false });
+  });
+
+  it("does not render in-bar letter buttons — OS keyboard drives letters", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     expect(screen.queryByTestId("keybar-key-letter-c")).toBeNull();
+    expect(screen.queryByTestId("keybar-key-letter-a")).toBeNull();
+  });
+});
+
+describe("MobileTerminalKeybar Shift modifier", () => {
+  it("exposes a Shift toggle that latches in the shared store", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+    const shift = screen.getByTestId(SHIFT_KEY);
+    expect(shift.getAttribute(ARIA_PRESSED)).toBe("false");
+
+    tap(SHIFT_KEY);
+    expect(useShellModifiersStore.getState().shift).toEqual({ latched: true, sticky: false });
+    expect(shift.getAttribute(ARIA_PRESSED)).toBe("true");
+  });
+
+  it("Shift+Tab from the bar emits CSI Z (reverse tab)", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+    tap(SHIFT_KEY);
+    tap("keybar-key-tab");
+    expect(lastData()).toBe("\x1b[Z");
+    expect(useShellModifiersStore.getState().shift).toEqual({ latched: false, sticky: false });
+  });
+});
+
+describe("MobileTerminalKeybar iOS focus retention", () => {
+  function mountXtermTextarea(): HTMLTextAreaElement {
+    const ta = document.createElement("textarea");
+    ta.className = "xterm-helper-textarea";
+    document.body.appendChild(ta);
+    return ta;
+  }
+
+  it("refocuses the xterm textarea on every key tap so the OS keyboard stays up", () => {
+    const ta = mountXtermTextarea();
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+
+    tap(ESC_KEY);
+    expect(document.activeElement).toBe(ta);
+
+    (document.activeElement as HTMLElement).blur();
+    tap(CTRL_KEY);
+    expect(document.activeElement).toBe(ta);
+
+    (document.activeElement as HTMLElement).blur();
+    tap(SHIFT_KEY);
+    expect(document.activeElement).toBe(ta);
+
+    (document.activeElement as HTMLElement).blur();
+    tap("keybar-key-ctrl-c");
+    expect(document.activeElement).toBe(ta);
+
+    ta.remove();
+  });
+});
+
+describe("MobileTerminalKeybar iOS keyboard retention", () => {
+  it("calls preventDefault on pointerdown so the OS keyboard stays open", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+    const esc = screen.getByTestId(ESC_KEY);
+
+    const pointerEvent = new Event("pointerdown", { bubbles: true, cancelable: true });
+    const mouseEvent = new Event("mousedown", { bubbles: true, cancelable: true });
+    esc.dispatchEvent(pointerEvent);
+    esc.dispatchEvent(mouseEvent);
+
+    expect(pointerEvent.defaultPrevented).toBe(true);
+    expect(mouseEvent.defaultPrevented).toBe(true);
+  });
+
+  it("still fires onClick after preventing focus transfer", () => {
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
+    const esc = screen.getByTestId(ESC_KEY);
+    esc.dispatchEvent(new Event("pointerdown", { bubbles: true, cancelable: true }));
+    fireEvent.click(esc);
+    expect(lastData()).toBe("\x1b");
+  });
+});
+
+describe("MobileTerminalKeybar positioning", () => {
+  it("anchors via top (not bottom) when the keyboard is open — iOS fixed-positioning fix", async () => {
+    // Re-mock the hook to report a keyboard-open state.
+    vi.doMock("@/hooks/use-visual-viewport-offset", () => ({
+      useVisualViewportOffset: () => ({
+        bottomOffset: 300,
+        keyboardOpen: true,
+        viewportBottom: 500,
+      }),
+    }));
+    vi.resetModules();
+    const { MobileTerminalKeybar: Reloaded } = await import("./mobile-terminal-keybar");
+    render(<Reloaded sessionId={SESSION_ID} visible={true} />);
+    const bar = screen.getByTestId(KEYBAR_ROOT);
+    expect(bar.style.top).toBeTruthy();
+    expect(bar.style.bottom).toBe("auto");
   });
 });
 
 describe("MobileTerminalKeybar accessibility", () => {
   it("every key has a non-empty aria-label", () => {
-    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    render(<MobileTerminalKeybar sessionId={SESSION_ID} visible={true} />);
     const buttons = document.querySelectorAll('[data-testid^="keybar-key-"]');
     expect(buttons.length).toBeGreaterThan(0);
     buttons.forEach((b) => {

--- a/apps/web/components/task/mobile/mobile-terminal-keybar.test.tsx
+++ b/apps/web/components/task/mobile/mobile-terminal-keybar.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { MobileTerminalKeybar } from "./mobile-terminal-keybar";
+
+const sendMock = vi.fn();
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => ({ send: sendMock }),
+}));
+
+vi.mock("@/hooks/use-visual-viewport-offset", () => ({
+  useVisualViewportOffset: () => ({ bottomOffset: 0, keyboardOpen: false }),
+}));
+
+const CTRL_KEY = "keybar-key-ctrl";
+const LETTER_C = "keybar-key-letter-c";
+const ARIA_PRESSED = "aria-pressed";
+
+function tap(testId: string): void {
+  fireEvent.click(screen.getByTestId(testId));
+}
+
+function lastData(): string | undefined {
+  const call = sendMock.mock.calls.at(-1)?.[0] as { payload?: { data?: string } } | undefined;
+  return call?.payload?.data;
+}
+
+function allData(): string[] {
+  return sendMock.mock.calls.map((c) => (c[0] as { payload: { data: string } }).payload.data);
+}
+
+beforeEach(() => {
+  sendMock.mockReset();
+  cleanup();
+});
+
+describe("MobileTerminalKeybar visibility", () => {
+  it("renders when visible and has a sessionId", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    expect(screen.getByTestId("mobile-terminal-keybar")).toBeDefined();
+  });
+
+  it("renders nothing when not visible", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={false} />);
+    expect(screen.queryByTestId("mobile-terminal-keybar")).toBeNull();
+  });
+
+  it("renders nothing without a sessionId", () => {
+    render(<MobileTerminalKeybar sessionId={null} visible={true} />);
+    expect(screen.queryByTestId("mobile-terminal-keybar")).toBeNull();
+  });
+});
+
+describe("MobileTerminalKeybar single-key emission", () => {
+  it("sends \\x1b on Esc tap", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    tap("keybar-key-esc");
+    expect(lastData()).toBe("\x1b");
+  });
+
+  it("sends \\t on Tab tap", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    tap("keybar-key-tab");
+    expect(lastData()).toBe("\t");
+  });
+
+  it("sends arrow escape sequences", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    tap("keybar-key-up");
+    expect(lastData()).toBe("\x1b[A");
+    tap("keybar-key-down");
+    expect(lastData()).toBe("\x1b[B");
+    tap("keybar-key-left");
+    expect(lastData()).toBe("\x1b[D");
+    tap("keybar-key-right");
+    expect(lastData()).toBe("\x1b[C");
+  });
+
+  it("sends Home / End / PgUp / PgDn", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    tap("keybar-key-home");
+    expect(lastData()).toBe("\x01");
+    tap("keybar-key-end");
+    expect(lastData()).toBe("\x05");
+    tap("keybar-key-pageup");
+    expect(lastData()).toBe("\x1b[5~");
+    tap("keybar-key-pagedown");
+    expect(lastData()).toBe("\x1b[6~");
+  });
+
+  it("sends literal symbols", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    tap("keybar-key-pipe");
+    expect(lastData()).toBe("|");
+    tap("keybar-key-tilde");
+    expect(lastData()).toBe("~");
+  });
+});
+
+describe("MobileTerminalKeybar dedicated Ctrl+C / Ctrl+D", () => {
+  it("Ctrl+C button sends \\x03 in one tap", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    tap("keybar-key-ctrl-c");
+    expect(lastData()).toBe("\x03");
+  });
+
+  it("Ctrl+D button sends \\x04 in one tap", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    tap("keybar-key-ctrl-d");
+    expect(lastData()).toBe("\x04");
+  });
+});
+
+describe("MobileTerminalKeybar sticky Ctrl state machine", () => {
+  it("latches Ctrl then chords the next letter and auto-releases", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+
+    const ctrl = screen.getByTestId(CTRL_KEY);
+    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("false");
+
+    tap(CTRL_KEY);
+    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("true");
+
+    tap(LETTER_C);
+    expect(lastData()).toBe("\x03");
+    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("false");
+  });
+
+  it("double-tap makes Ctrl sticky; chord bytes keep flowing", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    const ctrl = screen.getByTestId(CTRL_KEY);
+
+    tap(CTRL_KEY);
+    tap(CTRL_KEY);
+    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("true");
+    expect(ctrl.getAttribute("data-sticky")).toBe("true");
+
+    tap(LETTER_C);
+    tap("keybar-key-letter-d");
+    const data = allData();
+    expect(data).toContain("\x03");
+    expect(data).toContain("\x04");
+    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("true");
+  });
+
+  it("third tap releases sticky", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    const ctrl = screen.getByTestId(CTRL_KEY);
+
+    tap(CTRL_KEY);
+    tap(CTRL_KEY);
+    tap(CTRL_KEY);
+    expect(ctrl.getAttribute(ARIA_PRESSED)).toBe("false");
+  });
+
+  it("does not expose letter keys until Ctrl is active", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    expect(screen.queryByTestId("keybar-key-letter-c")).toBeNull();
+  });
+});
+
+describe("MobileTerminalKeybar accessibility", () => {
+  it("every key has a non-empty aria-label", () => {
+    render(<MobileTerminalKeybar sessionId="s1" visible={true} />);
+    const buttons = document.querySelectorAll('[data-testid^="keybar-key-"]');
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach((b) => {
+      expect(b.getAttribute("aria-label")?.length ?? 0).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
+++ b/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
@@ -89,13 +89,7 @@ export function MobileTerminalKeybar({
       style={{ ...position, height: `${KEYBAR_HEIGHT_PX}px` }}
     >
       <div className="flex w-full gap-1 overflow-x-auto px-2 py-1.5">
-        <ModifierButton
-          id="ctrl"
-          label="Ctrl"
-          ariaLabel="Control"
-          state={ctrl}
-          onTap={onCtrlTap}
-        />
+        <ModifierButton id="ctrl" label="Ctrl" ariaLabel="Control" state={ctrl} onTap={onCtrlTap} />
         <ModifierButton
           id="shift"
           label="Shift"

--- a/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
+++ b/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useCallback, useState, type ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
 import { Button } from "@kandev/ui/button";
 import { cn } from "@/lib/utils";
-import { KEY_SEQUENCES, ctrlChord } from "@/lib/terminal/key-sequences";
+import { KEY_SEQUENCES } from "@/lib/terminal/key-sequences";
 import { useShellKeySender } from "@/hooks/domains/session/use-shell-key-sender";
 import { useVisualViewportOffset } from "@/hooks/use-visual-viewport-offset";
+import { refocusXtermTextarea } from "@/lib/terminal/refocus-xterm";
+import { useShellModifiersStore, isActive } from "@/lib/terminal/shell-modifiers";
 
 export type MobileTerminalKeybarProps = {
   sessionId: string | null | undefined;
@@ -14,6 +16,9 @@ export type MobileTerminalKeybarProps = {
   baseBottomOffset?: string;
 };
 
+/** Height of the bar in px (border-t + py-1.5 + h-8 button). Used by the mobile layout to pad the terminal so content doesn't hide behind the bar. */
+export const KEYBAR_HEIGHT_PX = 48;
+
 type KeyDef = {
   /** Stable id used for data-testid (e.g. `keybar-key-esc`). */
   id: string;
@@ -21,10 +26,8 @@ type KeyDef = {
   label: ReactNode;
   /** Accessible label. */
   ariaLabel: string;
-  /** Sequence emitted on plain tap. */
+  /** Sequence emitted on tap. Ctrl/Shift transforms are applied downstream. */
   seq: string;
-  /** Character fed to ctrlChord when Ctrl is latched; null skips chording (use plain seq). */
-  chordChar?: string;
 };
 
 const KEYS: readonly KeyDef[] = [
@@ -38,20 +41,12 @@ const KEYS: readonly KeyDef[] = [
   { id: "end", label: "End", ariaLabel: "End", seq: KEY_SEQUENCES.end },
   { id: "pageup", label: "PgUp", ariaLabel: "Page Up", seq: KEY_SEQUENCES.pageUp },
   { id: "pagedown", label: "PgDn", ariaLabel: "Page Down", seq: KEY_SEQUENCES.pageDown },
-  { id: "pipe", label: "|", ariaLabel: "Pipe", seq: "|", chordChar: "|" },
-  { id: "tilde", label: "~", ariaLabel: "Tilde", seq: "~", chordChar: "~" },
-  { id: "slash", label: "/", ariaLabel: "Slash", seq: "/", chordChar: "/" },
-  { id: "dash", label: "-", ariaLabel: "Dash", seq: "-", chordChar: "-" },
-  { id: "underscore", label: "_", ariaLabel: "Underscore", seq: "_", chordChar: "_" },
+  { id: "pipe", label: "|", ariaLabel: "Pipe", seq: "|" },
+  { id: "tilde", label: "~", ariaLabel: "Tilde", seq: "~" },
+  { id: "slash", label: "/", ariaLabel: "Slash", seq: "/" },
+  { id: "dash", label: "-", ariaLabel: "Dash", seq: "-" },
+  { id: "underscore", label: "_", ariaLabel: "Underscore", seq: "_" },
 ];
-
-const LETTER_KEYS: readonly KeyDef[] = "abcdefghijklmnopqrstuvwxyz".split("").map((c) => ({
-  id: `letter-${c}`,
-  label: c,
-  ariaLabel: `Letter ${c}`,
-  seq: c,
-  chordChar: c,
-}));
 
 export function MobileTerminalKeybar({
   sessionId,
@@ -59,64 +54,64 @@ export function MobileTerminalKeybar({
   baseBottomOffset,
 }: MobileTerminalKeybarProps) {
   const send = useShellKeySender(sessionId);
-  const { bottomOffset, keyboardOpen } = useVisualViewportOffset();
-  const [ctrlLatched, setCtrlLatched] = useState(false);
-  const [ctrlSticky, setCtrlSticky] = useState(false);
+  const { keyboardOpen, viewportBottom } = useVisualViewportOffset();
+  const ctrl = useShellModifiersStore((s) => s.ctrl);
+  const shift = useShellModifiersStore((s) => s.shift);
+  const toggleCtrl = useShellModifiersStore((s) => s.toggleCtrl);
+  const toggleShift = useShellModifiersStore((s) => s.toggleShift);
 
-  const ctrlActive = ctrlLatched || ctrlSticky;
+  const tapSend = useCallback(
+    (data: string) => {
+      refocusXtermTextarea();
+      send(data);
+    },
+    [send],
+  );
 
   const onCtrlTap = useCallback(() => {
-    if (ctrlSticky) {
-      setCtrlSticky(false);
-      setCtrlLatched(false);
-      return;
-    }
-    if (ctrlLatched) {
-      setCtrlSticky(true);
-      return;
-    }
-    setCtrlLatched(true);
-  }, [ctrlLatched, ctrlSticky]);
+    refocusXtermTextarea();
+    toggleCtrl();
+  }, [toggleCtrl]);
 
-  const onKeyTap = useCallback(
-    (key: KeyDef) => {
-      const chord = ctrlActive && key.chordChar ? ctrlChord(key.chordChar) : null;
-      send(chord ?? key.seq);
-      if (ctrlLatched && !ctrlSticky) setCtrlLatched(false);
-    },
-    [ctrlActive, ctrlLatched, ctrlSticky, send],
-  );
+  const onShiftTap = useCallback(() => {
+    refocusXtermTextarea();
+    toggleShift();
+  }, [toggleShift]);
 
   if (!visible || !sessionId) return null;
 
-  const bottom = resolveBottom({ keyboardOpen, bottomOffset, baseBottomOffset });
+  const position = resolvePosition({ keyboardOpen, viewportBottom, baseBottomOffset });
 
   return (
     <div
       data-testid="mobile-terminal-keybar"
       className="fixed left-0 right-0 z-40 border-t border-border bg-background/95 backdrop-blur"
-      style={{ bottom }}
+      style={{ ...position, height: `${KEYBAR_HEIGHT_PX}px` }}
     >
       <div className="flex w-full gap-1 overflow-x-auto px-2 py-1.5">
-        <KeybarButton
+        <ModifierButton
           id="ctrl"
+          label="Ctrl"
           ariaLabel="Control"
-          ariaPressed={ctrlActive}
+          state={ctrl}
           onTap={onCtrlTap}
-          active={ctrlActive}
-          sticky={ctrlSticky}
-        >
-          Ctrl
-        </KeybarButton>
+        />
+        <ModifierButton
+          id="shift"
+          label="Shift"
+          ariaLabel="Shift"
+          state={shift}
+          onTap={onShiftTap}
+        />
         <KeybarButton
           id="ctrl-c"
           ariaLabel="Control C"
-          onTap={() => send(KEY_SEQUENCES.ctrlC)}
+          onTap={() => tapSend(KEY_SEQUENCES.ctrlC)}
           variant="destructive"
         >
           ^C
         </KeybarButton>
-        <KeybarButton id="ctrl-d" ariaLabel="Control D" onTap={() => send(KEY_SEQUENCES.ctrlD)}>
+        <KeybarButton id="ctrl-d" ariaLabel="Control D" onTap={() => tapSend(KEY_SEQUENCES.ctrlD)}>
           ^D
         </KeybarButton>
         {KEYS.map((key) => (
@@ -124,39 +119,58 @@ export function MobileTerminalKeybar({
             key={key.id}
             id={key.id}
             ariaLabel={key.ariaLabel}
-            onTap={() => onKeyTap(key)}
+            onTap={() => tapSend(key.seq)}
           >
             {key.label}
           </KeybarButton>
         ))}
-        {ctrlActive &&
-          LETTER_KEYS.map((key) => (
-            <KeybarButton
-              key={key.id}
-              id={key.id}
-              ariaLabel={key.ariaLabel}
-              onTap={() => onKeyTap(key)}
-            >
-              {key.label}
-            </KeybarButton>
-          ))}
       </div>
     </div>
   );
 }
 
-function resolveBottom({
+function resolvePosition({
   keyboardOpen,
-  bottomOffset,
+  viewportBottom,
   baseBottomOffset,
 }: {
   keyboardOpen: boolean;
-  bottomOffset: number;
+  viewportBottom: number;
   baseBottomOffset: string | undefined;
-}): string {
-  if (keyboardOpen) return `${bottomOffset}px`;
-  if (baseBottomOffset) return `calc(${baseBottomOffset} + env(safe-area-inset-bottom, 0px))`;
-  return "env(safe-area-inset-bottom, 0px)";
+}): React.CSSProperties {
+  // iOS Safari drifts fixed elements positioned via `bottom` while the visual
+  // viewport scrolls with the keyboard up. Anchoring via `top` tied to the
+  // visual viewport's bottom edge stays glued to the keyboard.
+  if (keyboardOpen) {
+    return { top: `${viewportBottom - KEYBAR_HEIGHT_PX}px`, bottom: "auto" };
+  }
+  const base = baseBottomOffset
+    ? `calc(${baseBottomOffset} + env(safe-area-inset-bottom, 0px))`
+    : "env(safe-area-inset-bottom, 0px)";
+  return { bottom: base };
+}
+
+type ModifierButtonProps = {
+  id: string;
+  label: string;
+  ariaLabel: string;
+  state: { latched: boolean; sticky: boolean };
+  onTap: () => void;
+};
+
+function ModifierButton({ id, label, ariaLabel, state, onTap }: ModifierButtonProps) {
+  return (
+    <KeybarButton
+      id={id}
+      ariaLabel={ariaLabel}
+      ariaPressed={isActive(state)}
+      active={isActive(state)}
+      sticky={state.sticky}
+      onTap={onTap}
+    >
+      {label}
+    </KeybarButton>
+  );
 }
 
 type KeybarButtonProps = {
@@ -189,10 +203,14 @@ function KeybarButton({
       aria-pressed={ariaPressed}
       data-testid={`keybar-key-${id}`}
       data-sticky={sticky ? "true" : undefined}
+      onPointerDown={(e) => e.preventDefault()}
+      onMouseDown={(e) => e.preventDefault()}
       onClick={onTap}
+      style={{ touchAction: "manipulation" }}
       className={cn(
         "h-8 min-w-10 shrink-0 px-2 font-mono text-sm cursor-pointer",
-        sticky && "ring-2 ring-primary/60",
+        active && "ring-2 ring-primary/60",
+        sticky && "ring-primary",
       )}
     >
       {children}

--- a/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
+++ b/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useCallback, type ReactNode } from "react";
-import { Button } from "@kandev/ui/button";
-import { cn } from "@/lib/utils";
+import { useCallback } from "react";
 import { KEY_SEQUENCES } from "@/lib/terminal/key-sequences";
 import { useShellKeySender } from "@/hooks/domains/session/use-shell-key-sender";
 import { useVisualViewportOffset } from "@/hooks/use-visual-viewport-offset";
 import { refocusXtermTextarea } from "@/lib/terminal/refocus-xterm";
-import { useShellModifiersStore, isActive } from "@/lib/terminal/shell-modifiers";
+import { useShellModifiersStore } from "@/lib/terminal/shell-modifiers";
+import { KEYS, KeybarButton, ModifierButton } from "./mobile-terminal-keybar-helpers";
 
 export type MobileTerminalKeybarProps = {
   sessionId: string | null | undefined;
@@ -18,35 +17,6 @@ export type MobileTerminalKeybarProps = {
 
 /** Height of the bar in px (border-t + py-1.5 + h-8 button). Used by the mobile layout to pad the terminal so content doesn't hide behind the bar. */
 export const KEYBAR_HEIGHT_PX = 48;
-
-type KeyDef = {
-  /** Stable id used for data-testid (e.g. `keybar-key-esc`). */
-  id: string;
-  /** Rendered button label. */
-  label: ReactNode;
-  /** Accessible label. */
-  ariaLabel: string;
-  /** Sequence emitted on tap. Ctrl/Shift transforms are applied downstream. */
-  seq: string;
-};
-
-const KEYS: readonly KeyDef[] = [
-  { id: "esc", label: "Esc", ariaLabel: "Escape", seq: KEY_SEQUENCES.esc },
-  { id: "tab", label: "Tab", ariaLabel: "Tab", seq: KEY_SEQUENCES.tab },
-  { id: "up", label: "↑", ariaLabel: "Arrow Up", seq: KEY_SEQUENCES.up },
-  { id: "down", label: "↓", ariaLabel: "Arrow Down", seq: KEY_SEQUENCES.down },
-  { id: "left", label: "←", ariaLabel: "Arrow Left", seq: KEY_SEQUENCES.left },
-  { id: "right", label: "→", ariaLabel: "Arrow Right", seq: KEY_SEQUENCES.right },
-  { id: "home", label: "Home", ariaLabel: "Home", seq: KEY_SEQUENCES.home },
-  { id: "end", label: "End", ariaLabel: "End", seq: KEY_SEQUENCES.end },
-  { id: "pageup", label: "PgUp", ariaLabel: "Page Up", seq: KEY_SEQUENCES.pageUp },
-  { id: "pagedown", label: "PgDn", ariaLabel: "Page Down", seq: KEY_SEQUENCES.pageDown },
-  { id: "pipe", label: "|", ariaLabel: "Pipe", seq: "|" },
-  { id: "tilde", label: "~", ariaLabel: "Tilde", seq: "~" },
-  { id: "slash", label: "/", ariaLabel: "Slash", seq: "/" },
-  { id: "dash", label: "-", ariaLabel: "Dash", seq: "-" },
-  { id: "underscore", label: "_", ariaLabel: "Underscore", seq: "_" },
-];
 
 export function MobileTerminalKeybar({
   sessionId,
@@ -142,72 +112,4 @@ function resolvePosition({
     ? `calc(${baseBottomOffset} + env(safe-area-inset-bottom, 0px))`
     : "env(safe-area-inset-bottom, 0px)";
   return { bottom: base };
-}
-
-type ModifierButtonProps = {
-  id: string;
-  label: string;
-  ariaLabel: string;
-  state: { latched: boolean; sticky: boolean };
-  onTap: () => void;
-};
-
-function ModifierButton({ id, label, ariaLabel, state, onTap }: ModifierButtonProps) {
-  return (
-    <KeybarButton
-      id={id}
-      ariaLabel={ariaLabel}
-      ariaPressed={isActive(state)}
-      active={isActive(state)}
-      sticky={state.sticky}
-      onTap={onTap}
-    >
-      {label}
-    </KeybarButton>
-  );
-}
-
-type KeybarButtonProps = {
-  id: string;
-  ariaLabel: string;
-  ariaPressed?: boolean;
-  active?: boolean;
-  sticky?: boolean;
-  variant?: "default" | "destructive";
-  onTap: () => void;
-  children: ReactNode;
-};
-
-function KeybarButton({
-  id,
-  ariaLabel,
-  ariaPressed,
-  active,
-  sticky,
-  variant,
-  onTap,
-  children,
-}: KeybarButtonProps) {
-  return (
-    <Button
-      type="button"
-      size="sm"
-      variant={variant ?? (active ? "secondary" : "outline")}
-      aria-label={ariaLabel}
-      aria-pressed={ariaPressed}
-      data-testid={`keybar-key-${id}`}
-      data-sticky={sticky ? "true" : undefined}
-      onPointerDown={(e) => e.preventDefault()}
-      onMouseDown={(e) => e.preventDefault()}
-      onClick={onTap}
-      style={{ touchAction: "manipulation" }}
-      className={cn(
-        "h-8 min-w-10 shrink-0 px-2 font-mono text-sm cursor-pointer",
-        active && "ring-2 ring-primary/60",
-        sticky && "ring-primary",
-      )}
-    >
-      {children}
-    </Button>
-  );
 }

--- a/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
+++ b/apps/web/components/task/mobile/mobile-terminal-keybar.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useState, type ReactNode } from "react";
+import { Button } from "@kandev/ui/button";
+import { cn } from "@/lib/utils";
+import { KEY_SEQUENCES, ctrlChord } from "@/lib/terminal/key-sequences";
+import { useShellKeySender } from "@/hooks/domains/session/use-shell-key-sender";
+import { useVisualViewportOffset } from "@/hooks/use-visual-viewport-offset";
+
+export type MobileTerminalKeybarProps = {
+  sessionId: string | null | undefined;
+  visible: boolean;
+  /** CSS length used as minimum bottom offset when the on-screen keyboard is closed (e.g., to clear the bottom nav). */
+  baseBottomOffset?: string;
+};
+
+type KeyDef = {
+  /** Stable id used for data-testid (e.g. `keybar-key-esc`). */
+  id: string;
+  /** Rendered button label. */
+  label: ReactNode;
+  /** Accessible label. */
+  ariaLabel: string;
+  /** Sequence emitted on plain tap. */
+  seq: string;
+  /** Character fed to ctrlChord when Ctrl is latched; null skips chording (use plain seq). */
+  chordChar?: string;
+};
+
+const KEYS: readonly KeyDef[] = [
+  { id: "esc", label: "Esc", ariaLabel: "Escape", seq: KEY_SEQUENCES.esc },
+  { id: "tab", label: "Tab", ariaLabel: "Tab", seq: KEY_SEQUENCES.tab },
+  { id: "up", label: "↑", ariaLabel: "Arrow Up", seq: KEY_SEQUENCES.up },
+  { id: "down", label: "↓", ariaLabel: "Arrow Down", seq: KEY_SEQUENCES.down },
+  { id: "left", label: "←", ariaLabel: "Arrow Left", seq: KEY_SEQUENCES.left },
+  { id: "right", label: "→", ariaLabel: "Arrow Right", seq: KEY_SEQUENCES.right },
+  { id: "home", label: "Home", ariaLabel: "Home", seq: KEY_SEQUENCES.home },
+  { id: "end", label: "End", ariaLabel: "End", seq: KEY_SEQUENCES.end },
+  { id: "pageup", label: "PgUp", ariaLabel: "Page Up", seq: KEY_SEQUENCES.pageUp },
+  { id: "pagedown", label: "PgDn", ariaLabel: "Page Down", seq: KEY_SEQUENCES.pageDown },
+  { id: "pipe", label: "|", ariaLabel: "Pipe", seq: "|", chordChar: "|" },
+  { id: "tilde", label: "~", ariaLabel: "Tilde", seq: "~", chordChar: "~" },
+  { id: "slash", label: "/", ariaLabel: "Slash", seq: "/", chordChar: "/" },
+  { id: "dash", label: "-", ariaLabel: "Dash", seq: "-", chordChar: "-" },
+  { id: "underscore", label: "_", ariaLabel: "Underscore", seq: "_", chordChar: "_" },
+];
+
+const LETTER_KEYS: readonly KeyDef[] = "abcdefghijklmnopqrstuvwxyz".split("").map((c) => ({
+  id: `letter-${c}`,
+  label: c,
+  ariaLabel: `Letter ${c}`,
+  seq: c,
+  chordChar: c,
+}));
+
+export function MobileTerminalKeybar({
+  sessionId,
+  visible,
+  baseBottomOffset,
+}: MobileTerminalKeybarProps) {
+  const send = useShellKeySender(sessionId);
+  const { bottomOffset, keyboardOpen } = useVisualViewportOffset();
+  const [ctrlLatched, setCtrlLatched] = useState(false);
+  const [ctrlSticky, setCtrlSticky] = useState(false);
+
+  const ctrlActive = ctrlLatched || ctrlSticky;
+
+  const onCtrlTap = useCallback(() => {
+    if (ctrlSticky) {
+      setCtrlSticky(false);
+      setCtrlLatched(false);
+      return;
+    }
+    if (ctrlLatched) {
+      setCtrlSticky(true);
+      return;
+    }
+    setCtrlLatched(true);
+  }, [ctrlLatched, ctrlSticky]);
+
+  const onKeyTap = useCallback(
+    (key: KeyDef) => {
+      const chord = ctrlActive && key.chordChar ? ctrlChord(key.chordChar) : null;
+      send(chord ?? key.seq);
+      if (ctrlLatched && !ctrlSticky) setCtrlLatched(false);
+    },
+    [ctrlActive, ctrlLatched, ctrlSticky, send],
+  );
+
+  if (!visible || !sessionId) return null;
+
+  const bottom = resolveBottom({ keyboardOpen, bottomOffset, baseBottomOffset });
+
+  return (
+    <div
+      data-testid="mobile-terminal-keybar"
+      className="fixed left-0 right-0 z-40 border-t border-border bg-background/95 backdrop-blur"
+      style={{ bottom }}
+    >
+      <div className="flex w-full gap-1 overflow-x-auto px-2 py-1.5">
+        <KeybarButton
+          id="ctrl"
+          ariaLabel="Control"
+          ariaPressed={ctrlActive}
+          onTap={onCtrlTap}
+          active={ctrlActive}
+          sticky={ctrlSticky}
+        >
+          Ctrl
+        </KeybarButton>
+        <KeybarButton
+          id="ctrl-c"
+          ariaLabel="Control C"
+          onTap={() => send(KEY_SEQUENCES.ctrlC)}
+          variant="destructive"
+        >
+          ^C
+        </KeybarButton>
+        <KeybarButton id="ctrl-d" ariaLabel="Control D" onTap={() => send(KEY_SEQUENCES.ctrlD)}>
+          ^D
+        </KeybarButton>
+        {KEYS.map((key) => (
+          <KeybarButton
+            key={key.id}
+            id={key.id}
+            ariaLabel={key.ariaLabel}
+            onTap={() => onKeyTap(key)}
+          >
+            {key.label}
+          </KeybarButton>
+        ))}
+        {ctrlActive &&
+          LETTER_KEYS.map((key) => (
+            <KeybarButton
+              key={key.id}
+              id={key.id}
+              ariaLabel={key.ariaLabel}
+              onTap={() => onKeyTap(key)}
+            >
+              {key.label}
+            </KeybarButton>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function resolveBottom({
+  keyboardOpen,
+  bottomOffset,
+  baseBottomOffset,
+}: {
+  keyboardOpen: boolean;
+  bottomOffset: number;
+  baseBottomOffset: string | undefined;
+}): string {
+  if (keyboardOpen) return `${bottomOffset}px`;
+  if (baseBottomOffset) return `calc(${baseBottomOffset} + env(safe-area-inset-bottom, 0px))`;
+  return "env(safe-area-inset-bottom, 0px)";
+}
+
+type KeybarButtonProps = {
+  id: string;
+  ariaLabel: string;
+  ariaPressed?: boolean;
+  active?: boolean;
+  sticky?: boolean;
+  variant?: "default" | "destructive";
+  onTap: () => void;
+  children: ReactNode;
+};
+
+function KeybarButton({
+  id,
+  ariaLabel,
+  ariaPressed,
+  active,
+  sticky,
+  variant,
+  onTap,
+  children,
+}: KeybarButtonProps) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={variant ?? (active ? "secondary" : "outline")}
+      aria-label={ariaLabel}
+      aria-pressed={ariaPressed}
+      data-testid={`keybar-key-${id}`}
+      data-sticky={sticky ? "true" : undefined}
+      onClick={onTap}
+      className={cn(
+        "h-8 min-w-10 shrink-0 px-2 font-mono text-sm cursor-pointer",
+        sticky && "ring-2 ring-primary/60",
+      )}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/apps/web/components/task/mobile/session-mobile-layout.tsx
+++ b/apps/web/components/task/mobile/session-mobile-layout.tsx
@@ -10,6 +10,7 @@ import { TaskChangesPanel } from "../task-changes-panel";
 import { TaskFilesPanel } from "../task-files-panel";
 import { ShellTerminal } from "../shell-terminal";
 import { PassthroughTerminal } from "../passthrough-terminal";
+import { MobileTerminalKeybar } from "./mobile-terminal-keybar";
 import { SessionPanelContent } from "@kandev/ui/pannel-session";
 import { useSessionLayoutState } from "@/hooks/use-session-layout-state";
 import type { MobileSessionPanel } from "@/lib/state/slices/ui/types";
@@ -135,7 +136,10 @@ function MobilePanelArea({
         </div>
       )}
       {currentMobilePanel === "terminal" && (
-        <div className="flex-1 min-h-0 flex flex-col p-2">
+        <div
+          data-testid="terminal-panel"
+          className="flex-1 min-h-0 flex flex-col p-2 pb-12"
+        >
           <SessionPanelContent className="p-0 flex-1 min-h-0">
             <ShellTerminal key={effectiveSessionId} sessionId={effectiveSessionId ?? undefined} />
           </SessionPanelContent>
@@ -259,6 +263,13 @@ export const SessionMobileLayout = memo(function SessionMobileLayout({
         handleOpenFile={handleOpenFile}
         topNavHeight={TOP_NAV_HEIGHT}
         bottomNavHeight={BOTTOM_NAV_HEIGHT}
+      />
+
+      {/* Terminal key-bar — docks above OS keyboard or bottom nav on the terminal panel */}
+      <MobileTerminalKeybar
+        sessionId={effectiveSessionId ?? null}
+        visible={currentMobilePanel === "terminal"}
+        baseBottomOffset={BOTTOM_NAV_HEIGHT}
       />
 
       {/* Fixed Bottom Navigation */}

--- a/apps/web/components/task/mobile/session-mobile-layout.tsx
+++ b/apps/web/components/task/mobile/session-mobile-layout.tsx
@@ -10,9 +10,10 @@ import { TaskChangesPanel } from "../task-changes-panel";
 import { TaskFilesPanel } from "../task-files-panel";
 import { ShellTerminal } from "../shell-terminal";
 import { PassthroughTerminal } from "../passthrough-terminal";
-import { MobileTerminalKeybar } from "./mobile-terminal-keybar";
+import { MobileTerminalKeybar, KEYBAR_HEIGHT_PX } from "./mobile-terminal-keybar";
 import { SessionPanelContent } from "@kandev/ui/pannel-session";
 import { useSessionLayoutState } from "@/hooks/use-session-layout-state";
+import { useVisualViewportOffset } from "@/hooks/use-visual-viewport-offset";
 import type { MobileSessionPanel } from "@/lib/state/slices/ui/types";
 
 const TOP_NAV_HEIGHT = "3.5rem";
@@ -93,6 +94,14 @@ function MobilePanelArea({
   topNavHeight,
   bottomNavHeight,
 }: MobilePanelAreaProps) {
+  const { keyboardOpen, bottomOffset } = useVisualViewportOffset();
+  // Keep terminal content's visible bottom glued to the keybar top. When the
+  // keyboard is up, the content area already pads for the bottom nav (which
+  // is now under the keyboard), so we subtract it back out and add the
+  // keyboard height instead.
+  const terminalPaddingBottom = keyboardOpen
+    ? `calc(${bottomOffset + KEYBAR_HEIGHT_PX}px - ${bottomNavHeight} - env(safe-area-inset-bottom, 0px))`
+    : `${KEYBAR_HEIGHT_PX}px`;
   return (
     <div
       className="flex flex-col"
@@ -138,7 +147,8 @@ function MobilePanelArea({
       {currentMobilePanel === "terminal" && (
         <div
           data-testid="terminal-panel"
-          className="flex-1 min-h-0 flex flex-col p-2 pb-12"
+          className="flex-1 min-h-0 flex flex-col p-2"
+          style={{ paddingBottom: terminalPaddingBottom }}
         >
           <SessionPanelContent className="p-0 flex-1 min-h-0">
             <ShellTerminal key={effectiveSessionId} sessionId={effectiveSessionId ?? undefined} />

--- a/apps/web/components/task/shell-terminal.tsx
+++ b/apps/web/components/task/shell-terminal.tsx
@@ -335,9 +335,8 @@ function useShellInputHandler(opts: {
   isReadOnlyMode: boolean;
   taskId: string | null;
   sessionId: string | null | undefined;
-  send: (action: string, payload: Record<string, unknown>) => void;
 }) {
-  const { xtermRef, onDataDisposableRef, isReadOnlyMode, taskId, sessionId, send } = opts;
+  const { xtermRef, onDataDisposableRef, isReadOnlyMode, taskId, sessionId } = opts;
   useEffect(() => {
     if (!xtermRef.current || isReadOnlyMode) return;
     onDataDisposableRef.current?.dispose();
@@ -351,7 +350,7 @@ function useShellInputHandler(opts: {
       onDataDisposableRef.current?.dispose();
       onDataDisposableRef.current = null;
     };
-  }, [taskId, sessionId, send, isReadOnlyMode, xtermRef, onDataDisposableRef]);
+  }, [taskId, sessionId, isReadOnlyMode, xtermRef, onDataDisposableRef]);
 }
 
 function useShellSessionState(propSessionId: string | undefined, isReadOnlyMode: boolean) {
@@ -432,7 +431,7 @@ export function ShellTerminal({
     onClose: search.close,
   });
 
-  useShellInputHandler({ xtermRef, onDataDisposableRef, isReadOnlyMode, taskId, sessionId, send });
+  useShellInputHandler({ xtermRef, onDataDisposableRef, isReadOnlyMode, taskId, sessionId });
   useShellTerminalKeyHandler({
     xtermRef,
     isReadOnlyMode,

--- a/apps/web/components/task/shell-terminal.tsx
+++ b/apps/web/components/task/shell-terminal.tsx
@@ -18,6 +18,8 @@ import { matchesShortcut } from "@/lib/keyboard/utils";
 import { useTerminalSearch } from "./use-terminal-search";
 import { TerminalSearchBar } from "./terminal-search-bar";
 import { usePanelSearch } from "@/hooks/use-panel-search";
+import { suppressIOSKeyboardAssists } from "@/lib/terminal/suppress-ios-keyboard-assists";
+import { sendShellInput } from "@/lib/terminal/send-shell-input";
 
 type ShellTerminalProps = {
   sessionId?: string;
@@ -73,6 +75,7 @@ function useTerminalInit({
     const webLinksAddon = new WebLinksAddon(linkHandler);
     terminal.loadAddon(webLinksAddon);
     terminal.open(terminalRef.current);
+    suppressIOSKeyboardAssists(terminalRef.current);
     exposeBufferReader(terminalRef.current, terminal);
     fitAddon.fit();
     xtermRef.current = terminal;
@@ -342,7 +345,7 @@ function useShellInputHandler(opts: {
     if (!taskId || !sessionId) return;
     onDataDisposableRef.current = xtermRef.current.onData((data) => {
       if (/^\x1b\[\d+;\d+R$/.test(data) || /^\x1b\[\d+R$/.test(data)) return;
-      send("shell.input", { session_id: sessionId, data });
+      sendShellInput(sessionId, data);
     });
     return () => {
       onDataDisposableRef.current?.dispose();

--- a/apps/web/e2e/helpers/ws-capture.ts
+++ b/apps/web/e2e/helpers/ws-capture.ts
@@ -1,0 +1,45 @@
+import type { Page } from "@playwright/test";
+
+export type ShellInputFrame = {
+  sessionId: string;
+  data: string;
+};
+
+type ParsedFrame = {
+  type?: string;
+  action?: string;
+  payload?: { session_id?: string; data?: string };
+};
+
+/**
+ * Subscribe to outgoing WS frames on the given page and collect every
+ * `shell.input` request with its `{ session_id, data }` payload. Useful for
+ * asserting that UI actions translate to the correct escape sequences without
+ * depending on xterm paint timing.
+ *
+ * Returns a live array that tests can poll via `expect.poll`. Must be called
+ * before the page navigates, since `framesent` events fire before your next
+ * tick.
+ */
+export function attachShellInputCapture(page: Page): { frames: ShellInputFrame[] } {
+  const frames: ShellInputFrame[] = [];
+  page.on("websocket", (ws) => {
+    ws.on("framesent", (event) => {
+      const raw =
+        typeof event.payload === "string" ? event.payload : (event.payload?.toString("utf8") ?? "");
+      if (!raw || !raw.includes('"shell.input"')) return;
+      try {
+        const msg = JSON.parse(raw) as ParsedFrame;
+        if (msg.action !== "shell.input") return;
+        const sessionId = msg.payload?.session_id;
+        const data = msg.payload?.data;
+        if (typeof sessionId === "string" && typeof data === "string") {
+          frames.push({ sessionId, data });
+        }
+      } catch {
+        /* non-JSON frames (binary, etc.) — ignore */
+      }
+    });
+  });
+  return { frames };
+}

--- a/apps/web/e2e/pages/mobile-terminal-keybar-page.ts
+++ b/apps/web/e2e/pages/mobile-terminal-keybar-page.ts
@@ -3,12 +3,14 @@ import type { Page, Locator } from "@playwright/test";
 export class MobileTerminalKeybarPage {
   readonly root: Locator;
   readonly ctrl: Locator;
+  readonly shift: Locator;
   readonly ctrlC: Locator;
   readonly ctrlD: Locator;
 
   constructor(private readonly page: Page) {
     this.root = page.getByTestId("mobile-terminal-keybar");
     this.ctrl = page.getByTestId("keybar-key-ctrl");
+    this.shift = page.getByTestId("keybar-key-shift");
     this.ctrlC = page.getByTestId("keybar-key-ctrl-c");
     this.ctrlD = page.getByTestId("keybar-key-ctrl-d");
   }

--- a/apps/web/e2e/pages/mobile-terminal-keybar-page.ts
+++ b/apps/web/e2e/pages/mobile-terminal-keybar-page.ts
@@ -1,0 +1,23 @@
+import type { Page, Locator } from "@playwright/test";
+
+export class MobileTerminalKeybarPage {
+  readonly root: Locator;
+  readonly ctrl: Locator;
+  readonly ctrlC: Locator;
+  readonly ctrlD: Locator;
+
+  constructor(private readonly page: Page) {
+    this.root = page.getByTestId("mobile-terminal-keybar");
+    this.ctrl = page.getByTestId("keybar-key-ctrl");
+    this.ctrlC = page.getByTestId("keybar-key-ctrl-c");
+    this.ctrlD = page.getByTestId("keybar-key-ctrl-d");
+  }
+
+  key(id: string): Locator {
+    return this.page.getByTestId(`keybar-key-${id}`);
+  }
+
+  async tap(id: string): Promise<void> {
+    await this.key(id).tap();
+  }
+}

--- a/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
@@ -1,6 +1,11 @@
 // Routing: /t/{taskId} (task-keyed). File name starts with "mobile-" so it
 // runs on the mobile-chrome Playwright project (Pixel 5 emulation).
-import { type Page } from "@playwright/test";
+//
+// These tests model real mobile user flows: every action is a button tap or
+// an OS-keyboard keystroke. We never poke React state directly. Verification
+// is a mix of (a) WS frame capture — a passive observer of `shell.input`
+// requests, and (b) terminal buffer text, which is what the user sees.
+import { type Page, type Locator, expect as baseExpect } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
 import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
@@ -36,166 +41,423 @@ async function switchToTerminalPanel(testPage: Page): Promise<void> {
   await testPage.getByRole("button", { name: "Terminal" }).tap();
 }
 
-async function fakeVisualViewportResize(testPage: Page, shrinkBy: number): Promise<void> {
+/**
+ * Wait for the mobile shell to be ready by tailing xterm's buffer until it has
+ * any content (a prompt is enough). Mobile mounts the terminal lazily on tab
+ * switch so this can take longer than desktop.
+ */
+async function waitForShellReady(testPage: Page, timeout = 45_000): Promise<void> {
+  await expect
+    .poll(() => readTerminalBuffer(testPage).then((b) => b.length > 0), {
+      timeout,
+      message: "Waiting for mobile terminal shell to connect",
+    })
+    .toBe(true);
+}
+
+/**
+ * Bring up the OS keyboard the way a user would: tap inside the terminal so
+ * xterm focuses its hidden textarea.
+ */
+async function focusTerminalForTyping(session: SessionPage): Promise<void> {
+  await session.terminal.locator(".xterm").click();
+}
+
+/**
+ * Drives the page's `visualViewport` the way the OS would when the keyboard
+ * opens or the user scrolls with it open. Pure event-firing — nothing about
+ * the keybar's behavior is touched.
+ */
+async function simulateKeyboardOpen(testPage: Page, height: number): Promise<void> {
   await testPage.evaluate((px) => {
     const vv = window.visualViewport;
     if (!vv) return;
     Object.defineProperty(vv, "height", { configurable: true, value: window.innerHeight - px });
     vv.dispatchEvent(new Event("resize"));
-  }, shrinkBy);
+  }, height);
 }
 
-function firstFrameMatching(
+async function simulateViewportScroll(testPage: Page, offsetTop: number): Promise<void> {
+  await testPage.evaluate((y) => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    Object.defineProperty(vv, "offsetTop", { configurable: true, value: y });
+    vv.dispatchEvent(new Event("scroll"));
+  }, offsetTop);
+}
+
+function frameMatching(
   frames: ShellInputFrame[],
   predicate: (f: ShellInputFrame) => boolean,
 ): ShellInputFrame | undefined {
   return frames.find(predicate);
 }
 
-test.describe("Mobile terminal keybar", () => {
+async function expectFrame(
+  frames: ShellInputFrame[],
+  data: string,
+  timeout = 5_000,
+): Promise<void> {
+  await baseExpect
+    .poll(() => frameMatching(frames, (f) => f.data === data), {
+      timeout,
+      message: `Expected shell.input frame with data ${JSON.stringify(data)}`,
+    })
+    .toBeTruthy();
+}
+
+async function readTerminalBuffer(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const panel = document.querySelector('[data-testid="terminal-panel"]');
+    const xtermEl = panel?.querySelector(".xterm");
+    type XC = HTMLElement & { __xtermReadBuffer?: () => string };
+    const container = xtermEl?.parentElement as XC | null | undefined;
+    return container?.__xtermReadBuffer?.() ?? "";
+  });
+}
+
+async function inlineStyleProp(loc: Locator, prop: "top" | "bottom"): Promise<string> {
+  return loc.evaluate((el, p) => (el as HTMLElement).style[p], prop);
+}
+
+test.describe("Mobile terminal key-bar — user flows", () => {
   test.describe.configure({ retries: 1 });
 
-  test("renders on the terminal panel and sends Esc via shell.input", async ({
+  test("user cancels a long-running command with the ^C button", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
+    test.setTimeout(90_000);
+    const session = await seedTaskWithSession(testPage, apiClient, seedData, "Keybar ^C cancels");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    await waitForShellReady(testPage);
+    await focusTerminalForTyping(session);
+
+    // User types a command on the OS keyboard, then runs it.
+    await testPage.keyboard.type("sleep 30");
+    await testPage.keyboard.press("Enter");
+
+    // User taps the dedicated ^C button to abort.
+    await keybar.ctrlC.tap();
+
+    // Shells (bash/zsh) echo "^C" when they receive SIGINT — an end-to-end
+    // signal that the WS round-trip and shell forwarding both work.
+    await session.expectTerminalHasText("^C");
+  });
+
+  test("user clears the screen with Ctrl + (OS keyboard) L", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+    const { frames } = attachShellInputCapture(testPage);
+    const session = await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Ctrl+L");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+    await waitForShellReady(testPage);
+    await focusTerminalForTyping(session);
+
+    // User taps Ctrl on the bar — visible state change.
+    await keybar.ctrl.tap();
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "true");
+
+    // User types "l" on their OS keyboard. The transform applies a Ctrl chord
+    // to whatever single letter comes through xterm's onData.
+    await testPage.keyboard.press("l");
+
+    // The wire saw \x0c (form feed = Ctrl+L), and Ctrl auto-released.
+    await expectFrame(frames, "\x0c");
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("user double-taps Ctrl for sticky and chords A then E without re-tapping", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+    const { frames } = attachShellInputCapture(testPage);
+    const session = await seedTaskWithSession(testPage, apiClient, seedData, "Keybar sticky Ctrl");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+    await waitForShellReady(testPage);
+    await focusTerminalForTyping(session);
+
+    // Two taps → sticky.
+    await keybar.ctrl.tap();
+    await keybar.ctrl.tap();
+    await expect(keybar.ctrl).toHaveAttribute("data-sticky", "true");
+
+    // Multiple chords without re-arming.
+    await testPage.keyboard.press("a");
+    await testPage.keyboard.press("e");
+
+    await expectFrame(frames, "\x01"); // Ctrl+A
+    await expectFrame(frames, "\x05"); // Ctrl+E
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "true");
+
+    // Third tap clears the latch entirely.
+    await keybar.ctrl.tap();
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "false");
+    await expect(keybar.ctrl).not.toHaveAttribute("data-sticky", "true");
+  });
+
+  test("user latches Shift then taps Tab on the bar — emits reverse-tab CSI Z", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+    const { frames } = attachShellInputCapture(testPage);
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Shift+Tab");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+    await waitForShellReady(testPage);
+
+    await keybar.shift.tap();
+    await expect(keybar.shift).toHaveAttribute("aria-pressed", "true");
+
+    await keybar.tap("tab");
+
+    await expectFrame(frames, "\x1b[Z");
+    await expect(keybar.shift).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("user presses an OS-keyboard letter while no modifier is active — passes through verbatim", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+    const { frames } = attachShellInputCapture(testPage);
+    const session = await seedTaskWithSession(testPage, apiClient, seedData, "Keybar passthrough");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+    await waitForShellReady(testPage);
+    await focusTerminalForTyping(session);
+
+    await testPage.keyboard.press("c");
+
+    // No modifier → just the letter.
+    await expectFrame(frames, "c");
+    // No frame for \x03 (which would mean Ctrl was incorrectly applied).
+    expect(frameMatching(frames, (f) => f.data === "\x03")).toBeUndefined();
+  });
+
+  test("first Ctrl tap is visibly active (aria-pressed + ring class) — not just a faint shade", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Ctrl visual");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    await keybar.ctrl.tap();
+
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "true");
+    const klass = (await keybar.ctrl.getAttribute("class")) ?? "";
+    expect(klass).toContain("ring-");
+  });
+
+  test("no in-bar letter buttons exist — even with Ctrl latched", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar no letters");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    await keybar.ctrl.tap();
+
+    for (const letter of ["a", "c", "d", "z"]) {
+      await expect(testPage.getByTestId(`keybar-key-letter-${letter}`)).toHaveCount(0);
+    }
+  });
+
+  test("bar is hidden on Chat, Files, Plan, and Changes panels", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar hidden non-terminal");
+    const keybar = new MobileTerminalKeybarPage(testPage);
+
+    // Default panel (chat) — hidden.
+    await expect(keybar.root).not.toBeVisible();
+
+    for (const panel of ["Files", "Plan", "Changes"] as const) {
+      await testPage.getByRole("button", { name: panel }).tap();
+      await expect(keybar.root).not.toBeVisible();
+    }
+  });
+
+  test("user navigates command history with the ↑ button", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+    const { frames } = attachShellInputCapture(testPage);
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar arrow up");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+    await waitForShellReady(testPage);
+
+    await keybar.tap("up");
+
+    await expectFrame(frames, "\x1b[A");
+  });
+
+  test("user taps Esc — sends \\x1b (vim-style insert-mode exit)", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
     const { frames } = attachShellInputCapture(testPage);
     await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Esc");
     await switchToTerminalPanel(testPage);
 
     const keybar = new MobileTerminalKeybarPage(testPage);
     await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+    await waitForShellReady(testPage);
 
     await keybar.tap("esc");
-    await expect
-      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x1b"), { timeout: 5_000 })
-      .toBeTruthy();
+
+    await expectFrame(frames, "\x1b");
   });
 
-  test("hidden on non-terminal panels", async ({ testPage, apiClient, seedData }) => {
-    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Chat Hidden");
-    const keybar = new MobileTerminalKeybarPage(testPage);
-    await expect(keybar.root).not.toBeVisible();
-
-    // Switch to a non-terminal panel — still hidden.
-    await testPage.getByRole("button", { name: "Files" }).tap();
-    await expect(keybar.root).not.toBeVisible();
-  });
-
-  test("Tab, arrows, Home/End, PgUp/PgDn all map to the right sequences", async ({
+  test("symbol keys (| ~ / - _) all reach the wire on tap", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
+    test.setTimeout(90_000);
     const { frames } = attachShellInputCapture(testPage);
-    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Keys");
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar symbols");
     await switchToTerminalPanel(testPage);
 
     const keybar = new MobileTerminalKeybarPage(testPage);
     await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+    await waitForShellReady(testPage);
 
-    const taps: Array<[string, string]> = [
-      ["tab", "\t"],
-      ["up", "\x1b[A"],
-      ["down", "\x1b[B"],
-      ["left", "\x1b[D"],
-      ["right", "\x1b[C"],
-      ["home", "\x01"],
-      ["end", "\x05"],
-      ["pageup", "\x1b[5~"],
-      ["pagedown", "\x1b[6~"],
+    for (const [id, ch] of [
       ["pipe", "|"],
       ["tilde", "~"],
-    ];
-
-    for (const [id, expected] of taps) {
+      ["slash", "/"],
+      ["dash", "-"],
+      ["underscore", "_"],
+    ] as const) {
       await keybar.tap(id);
-      await expect
-        .poll(() => firstFrameMatching(frames, (f) => f.data === expected), {
-          timeout: 5_000,
-          message: `Expected shell.input with data ${JSON.stringify(expected)} after tapping ${id}`,
-        })
-        .toBeTruthy();
+      await expectFrame(frames, ch);
     }
   });
 
-  test("dedicated Ctrl+C and Ctrl+D buttons send the expected bytes", async ({
+  test("bar switches to top-anchored positioning when the OS keyboard opens", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
-    const { frames } = attachShellInputCapture(testPage);
-    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar CtrlCD");
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar position keyboard");
     await switchToTerminalPanel(testPage);
 
     const keybar = new MobileTerminalKeybarPage(testPage);
     await expect(keybar.root).toBeVisible({ timeout: 10_000 });
 
-    await keybar.ctrlC.tap();
-    await expect
-      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x03"), { timeout: 5_000 })
-      .toBeTruthy();
+    // Closed: bottom-anchored.
+    expect(await inlineStyleProp(keybar.root, "bottom")).not.toBe("auto");
 
-    await keybar.ctrlD.tap();
+    // Opening the keyboard switches the bar to top-anchored — the iOS Safari
+    // fix for `position: fixed; bottom:` drift during visual-viewport scroll.
+    await simulateKeyboardOpen(testPage, 300);
+
     await expect
-      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x04"), { timeout: 5_000 })
-      .toBeTruthy();
+      .poll(() => inlineStyleProp(keybar.root, "bottom"), { timeout: 3_000 })
+      .toBe("auto");
+    expect(await inlineStyleProp(keybar.root, "top")).not.toBe("");
   });
 
-  test("sticky Ctrl: single tap latches, chord fires, then auto-releases", async ({
+  test("with the keyboard open, the bar tracks the visual viewport on scroll", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
-    const { frames } = attachShellInputCapture(testPage);
-    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Sticky Ctrl");
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar position scroll");
     await switchToTerminalPanel(testPage);
 
     const keybar = new MobileTerminalKeybarPage(testPage);
     await expect(keybar.root).toBeVisible({ timeout: 10_000 });
 
-    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "false");
-    await keybar.ctrl.tap();
-    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "true");
+    await simulateKeyboardOpen(testPage, 300);
+    const initialTop = await inlineStyleProp(keybar.root, "top");
+    expect(initialTop).not.toBe("");
 
-    // Letter buttons only render while Ctrl is latched.
-    await keybar.tap("letter-c");
+    // User scrolls the page — visualViewport.offsetTop changes.
+    await simulateViewportScroll(testPage, 80);
+
     await expect
-      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x03"), { timeout: 5_000 })
-      .toBeTruthy();
-    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "false");
+      .poll(() => inlineStyleProp(keybar.root, "top"), { timeout: 3_000 })
+      .not.toBe(initialTop);
   });
 
-  test("double-tap Ctrl stays sticky across multiple chords", async ({
+  test("terminal panel reserves bottom space so the bar doesn't cover content", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
-    const { frames } = attachShellInputCapture(testPage);
-    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Ctrl Sticky Persist");
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar terminal padding");
     await switchToTerminalPanel(testPage);
 
     const keybar = new MobileTerminalKeybarPage(testPage);
     await expect(keybar.root).toBeVisible({ timeout: 10_000 });
 
-    await keybar.ctrl.tap();
-    await keybar.ctrl.tap();
-    await expect(keybar.ctrl).toHaveAttribute("data-sticky", "true");
+    const panel = testPage.getByTestId("terminal-panel");
+    const padBefore = await panel.evaluate(
+      (el) => parseFloat(getComputedStyle(el).paddingBottom) || 0,
+    );
+    expect(padBefore).toBeGreaterThan(0);
 
-    await keybar.tap("letter-c");
-    await keybar.tap("letter-d");
+    // Open the keyboard and the panel pads further so its bottom matches the
+    // bar's new top edge instead of being eaten by the keyboard.
+    await simulateKeyboardOpen(testPage, 300);
+
     await expect
-      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x03"), { timeout: 5_000 })
-      .toBeTruthy();
-    await expect
-      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x04"), { timeout: 5_000 })
-      .toBeTruthy();
-    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "true");
+      .poll(
+        () =>
+          panel.evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom) || 0),
+        { timeout: 3_000 },
+      )
+      .toBeGreaterThan(padBefore);
   });
 
-  test("every key button has a non-empty aria-label", async ({ testPage, apiClient, seedData }) => {
-    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar A11y");
+  test("every key button has a non-empty aria-label (a11y)", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar a11y");
     await switchToTerminalPanel(testPage);
 
     const keybar = new MobileTerminalKeybarPage(testPage);
@@ -209,73 +471,4 @@ test.describe("Mobile terminal keybar", () => {
       expect(label.length).toBeGreaterThan(0);
     }
   });
-
-  test("bar moves up when visualViewport shrinks (simulated keyboard open)", async ({
-    testPage,
-    apiClient,
-    seedData,
-  }) => {
-    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Viewport");
-    await switchToTerminalPanel(testPage);
-
-    const keybar = new MobileTerminalKeybarPage(testPage);
-    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
-
-    const initialBottom = await keybar.root.evaluate((el) => {
-      return window.innerHeight - el.getBoundingClientRect().bottom;
-    });
-
-    await fakeVisualViewportResize(testPage, 300);
-
-    await expect
-      .poll(
-        async () =>
-          keybar.root.evaluate((el) => window.innerHeight - el.getBoundingClientRect().bottom),
-        { timeout: 3_000 },
-      )
-      .toBeGreaterThan(initialBottom);
-  });
-
-  test("Ctrl+C reaches the shell (^C echoes in buffer)", async ({
-    testPage,
-    apiClient,
-    seedData,
-  }) => {
-    test.setTimeout(90_000);
-    const session = await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Ctrl+C shell");
-    await switchToTerminalPanel(testPage);
-
-    const keybar = new MobileTerminalKeybarPage(testPage);
-    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
-
-    // Mobile shell boot takes longer than desktop because ShellTerminal only
-    // mounts after the terminal tab is active. Give it up to 45s.
-    await expect
-      .poll(() => readTerminalBuffer(testPage).then((b) => b.length > 0), {
-        timeout: 45_000,
-        message: "Waiting for mobile terminal shell to connect",
-      })
-      .toBe(true);
-
-    // Focus the terminal so subsequent key presses go to xterm.
-    await session.terminal.locator(".xterm").click();
-
-    await keybar.ctrlC.tap();
-
-    // Most shells (bash/zsh) echo "^C" when they receive SIGINT. Asserting
-    // on the echo gives us an end-to-end signal that the WS round-trip and
-    // backend shell forwarding both work — without relying on precise
-    // prompt state, which is flaky on a fresh zsh setup.
-    await session.expectTerminalHasText("^C");
-  });
 });
-
-async function readTerminalBuffer(page: Page): Promise<string> {
-  return page.evaluate(() => {
-    const panel = document.querySelector('[data-testid="terminal-panel"]');
-    const xtermEl = panel?.querySelector(".xterm");
-    type XC = HTMLElement & { __xtermReadBuffer?: () => string };
-    const container = xtermEl?.parentElement as XC | null | undefined;
-    return container?.__xtermReadBuffer?.() ?? "";
-  });
-}

--- a/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
@@ -1,0 +1,281 @@
+// Routing: /t/{taskId} (task-keyed). File name starts with "mobile-" so it
+// runs on the mobile-chrome Playwright project (Pixel 5 emulation).
+import { type Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+import { MobileTerminalKeybarPage } from "../../pages/mobile-terminal-keybar-page";
+import { attachShellInputCapture, type ShellInputFrame } from "../../helpers/ws-capture";
+
+async function seedTaskWithSession(
+  testPage: Page,
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+): Promise<SessionPage> {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    title,
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+  return session;
+}
+
+async function switchToTerminalPanel(testPage: Page): Promise<void> {
+  await testPage.getByRole("button", { name: "Terminal" }).tap();
+}
+
+async function fakeVisualViewportResize(testPage: Page, shrinkBy: number): Promise<void> {
+  await testPage.evaluate((px) => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    Object.defineProperty(vv, "height", { configurable: true, value: window.innerHeight - px });
+    vv.dispatchEvent(new Event("resize"));
+  }, shrinkBy);
+}
+
+function firstFrameMatching(
+  frames: ShellInputFrame[],
+  predicate: (f: ShellInputFrame) => boolean,
+): ShellInputFrame | undefined {
+  return frames.find(predicate);
+}
+
+test.describe("Mobile terminal keybar", () => {
+  test.describe.configure({ retries: 1 });
+
+  test("renders on the terminal panel and sends Esc via shell.input", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { frames } = attachShellInputCapture(testPage);
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Esc");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    await keybar.tap("esc");
+    await expect
+      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x1b"), { timeout: 5_000 })
+      .toBeTruthy();
+  });
+
+  test("hidden on non-terminal panels", async ({ testPage, apiClient, seedData }) => {
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Chat Hidden");
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).not.toBeVisible();
+
+    // Switch to a non-terminal panel — still hidden.
+    await testPage.getByRole("button", { name: "Files" }).tap();
+    await expect(keybar.root).not.toBeVisible();
+  });
+
+  test("Tab, arrows, Home/End, PgUp/PgDn all map to the right sequences", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { frames } = attachShellInputCapture(testPage);
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Keys");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    const taps: Array<[string, string]> = [
+      ["tab", "\t"],
+      ["up", "\x1b[A"],
+      ["down", "\x1b[B"],
+      ["left", "\x1b[D"],
+      ["right", "\x1b[C"],
+      ["home", "\x01"],
+      ["end", "\x05"],
+      ["pageup", "\x1b[5~"],
+      ["pagedown", "\x1b[6~"],
+      ["pipe", "|"],
+      ["tilde", "~"],
+    ];
+
+    for (const [id, expected] of taps) {
+      await keybar.tap(id);
+      await expect
+        .poll(() => firstFrameMatching(frames, (f) => f.data === expected), {
+          timeout: 5_000,
+          message: `Expected shell.input with data ${JSON.stringify(expected)} after tapping ${id}`,
+        })
+        .toBeTruthy();
+    }
+  });
+
+  test("dedicated Ctrl+C and Ctrl+D buttons send the expected bytes", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { frames } = attachShellInputCapture(testPage);
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar CtrlCD");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    await keybar.ctrlC.tap();
+    await expect
+      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x03"), { timeout: 5_000 })
+      .toBeTruthy();
+
+    await keybar.ctrlD.tap();
+    await expect
+      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x04"), { timeout: 5_000 })
+      .toBeTruthy();
+  });
+
+  test("sticky Ctrl: single tap latches, chord fires, then auto-releases", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { frames } = attachShellInputCapture(testPage);
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Sticky Ctrl");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "false");
+    await keybar.ctrl.tap();
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "true");
+
+    // Letter buttons only render while Ctrl is latched.
+    await keybar.tap("letter-c");
+    await expect
+      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x03"), { timeout: 5_000 })
+      .toBeTruthy();
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("double-tap Ctrl stays sticky across multiple chords", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const { frames } = attachShellInputCapture(testPage);
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Ctrl Sticky Persist");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    await keybar.ctrl.tap();
+    await keybar.ctrl.tap();
+    await expect(keybar.ctrl).toHaveAttribute("data-sticky", "true");
+
+    await keybar.tap("letter-c");
+    await keybar.tap("letter-d");
+    await expect
+      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x03"), { timeout: 5_000 })
+      .toBeTruthy();
+    await expect
+      .poll(() => firstFrameMatching(frames, (f) => f.data === "\x04"), { timeout: 5_000 })
+      .toBeTruthy();
+    await expect(keybar.ctrl).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("every key button has a non-empty aria-label", async ({ testPage, apiClient, seedData }) => {
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar A11y");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    const labels = await testPage
+      .locator('[data-testid^="keybar-key-"]')
+      .evaluateAll((nodes) => nodes.map((n) => n.getAttribute("aria-label") ?? ""));
+    expect(labels.length).toBeGreaterThan(5);
+    for (const label of labels) {
+      expect(label.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("bar moves up when visualViewport shrinks (simulated keyboard open)", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Viewport");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    const initialBottom = await keybar.root.evaluate((el) => {
+      return window.innerHeight - el.getBoundingClientRect().bottom;
+    });
+
+    await fakeVisualViewportResize(testPage, 300);
+
+    await expect
+      .poll(
+        async () =>
+          keybar.root.evaluate((el) => window.innerHeight - el.getBoundingClientRect().bottom),
+        { timeout: 3_000 },
+      )
+      .toBeGreaterThan(initialBottom);
+  });
+
+  test("Ctrl+C reaches the shell (^C echoes in buffer)", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+    const session = await seedTaskWithSession(testPage, apiClient, seedData, "Keybar Ctrl+C shell");
+    await switchToTerminalPanel(testPage);
+
+    const keybar = new MobileTerminalKeybarPage(testPage);
+    await expect(keybar.root).toBeVisible({ timeout: 10_000 });
+
+    // Mobile shell boot takes longer than desktop because ShellTerminal only
+    // mounts after the terminal tab is active. Give it up to 45s.
+    await expect
+      .poll(() => readTerminalBuffer(testPage).then((b) => b.length > 0), {
+        timeout: 45_000,
+        message: "Waiting for mobile terminal shell to connect",
+      })
+      .toBe(true);
+
+    // Focus the terminal so subsequent key presses go to xterm.
+    await session.terminal.locator(".xterm").click();
+
+    await keybar.ctrlC.tap();
+
+    // Most shells (bash/zsh) echo "^C" when they receive SIGINT. Asserting
+    // on the echo gives us an end-to-end signal that the WS round-trip and
+    // backend shell forwarding both work — without relying on precise
+    // prompt state, which is flaky on a fresh zsh setup.
+    await session.expectTerminalHasText("^C");
+  });
+});
+
+async function readTerminalBuffer(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const panel = document.querySelector('[data-testid="terminal-panel"]');
+    const xtermEl = panel?.querySelector(".xterm");
+    type XC = HTMLElement & { __xtermReadBuffer?: () => string };
+    const container = xtermEl?.parentElement as XC | null | undefined;
+    return container?.__xtermReadBuffer?.() ?? "";
+  });
+}

--- a/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
@@ -444,11 +444,9 @@ test.describe("Mobile terminal key-bar — user flows", () => {
     await simulateKeyboardOpen(testPage, 300);
 
     await expect
-      .poll(
-        () =>
-          panel.evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom) || 0),
-        { timeout: 3_000 },
-      )
+      .poll(() => panel.evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom) || 0), {
+        timeout: 3_000,
+      })
       .toBeGreaterThan(padBefore);
   });
 

--- a/apps/web/hooks/domains/session/use-shell-key-sender.ts
+++ b/apps/web/hooks/domains/session/use-shell-key-sender.ts
@@ -1,22 +1,15 @@
 import { useCallback } from "react";
-import { getWebSocketClient } from "@/lib/ws/connection";
+import { sendShellInput } from "@/lib/terminal/send-shell-input";
 
 /**
- * Returns a sender for shell keystrokes and escape sequences.
- * Posts `shell.input` over the active WS connection; no-op when no session or
- * no client.
+ * Returns a sender for shell keystrokes and escape sequences. Applies the
+ * active ctrl/shift modifiers before sending. No-op when no session.
  */
 export function useShellKeySender(sessionId: string | null | undefined) {
   return useCallback(
     (data: string) => {
-      if (!sessionId || !data) return;
-      const client = getWebSocketClient();
-      if (!client) return;
-      client.send({
-        type: "request",
-        action: "shell.input",
-        payload: { session_id: sessionId, data },
-      });
+      if (!sessionId) return;
+      sendShellInput(sessionId, data);
     },
     [sessionId],
   );

--- a/apps/web/hooks/domains/session/use-shell-key-sender.ts
+++ b/apps/web/hooks/domains/session/use-shell-key-sender.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import { getWebSocketClient } from "@/lib/ws/connection";
+
+/**
+ * Returns a sender for shell keystrokes and escape sequences.
+ * Posts `shell.input` over the active WS connection; no-op when no session or
+ * no client.
+ */
+export function useShellKeySender(sessionId: string | null | undefined) {
+  return useCallback(
+    (data: string) => {
+      if (!sessionId || !data) return;
+      const client = getWebSocketClient();
+      if (!client) return;
+      client.send({
+        type: "request",
+        action: "shell.input",
+        payload: { session_id: sessionId, data },
+      });
+    },
+    [sessionId],
+  );
+}

--- a/apps/web/hooks/use-visual-viewport-offset.test.ts
+++ b/apps/web/hooks/use-visual-viewport-offset.test.ts
@@ -116,5 +116,6 @@ describe("useVisualViewportOffset", () => {
     const { result } = renderHook(() => useVisualViewportOffset());
     expect(result.current.bottomOffset).toBe(0);
     expect(result.current.keyboardOpen).toBe(false);
+    expect(result.current.viewportBottom).toBe(0);
   });
 });

--- a/apps/web/hooks/use-visual-viewport-offset.test.ts
+++ b/apps/web/hooks/use-visual-viewport-offset.test.ts
@@ -43,6 +43,7 @@ describe("useVisualViewportOffset", () => {
     const { result } = renderHook(() => useVisualViewportOffset());
     expect(result.current.bottomOffset).toBe(0);
     expect(result.current.keyboardOpen).toBe(false);
+    expect(result.current.viewportBottom).toBe(800);
   });
 
   it("reports keyboard offset when visualViewport shrinks", () => {
@@ -55,6 +56,17 @@ describe("useVisualViewportOffset", () => {
 
     expect(result.current.bottomOffset).toBe(300);
     expect(result.current.keyboardOpen).toBe(true);
+    expect(result.current.viewportBottom).toBe(500);
+  });
+
+  it("viewportBottom tracks offsetTop + height for top-anchored positioning", () => {
+    const { result } = renderHook(() => useVisualViewportOffset());
+    act(() => {
+      vv.height = 600;
+      vv.offsetTop = 50;
+      vv.dispatchEvent(new Event("resize"));
+    });
+    expect(result.current.viewportBottom).toBe(650);
   });
 
   it("accounts for offsetTop", () => {

--- a/apps/web/hooks/use-visual-viewport-offset.test.ts
+++ b/apps/web/hooks/use-visual-viewport-offset.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useVisualViewportOffset } from "./use-visual-viewport-offset";
+
+class MockVisualViewport extends EventTarget {
+  height = 800;
+  width = 400;
+  offsetTop = 0;
+  offsetLeft = 0;
+  pageLeft = 0;
+  pageTop = 0;
+  scale = 1;
+}
+
+function setInnerHeight(h: number) {
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: h, writable: true });
+}
+
+describe("useVisualViewportOffset", () => {
+  let originalVV: VisualViewport | undefined;
+  let vv: MockVisualViewport;
+
+  beforeEach(() => {
+    originalVV = window.visualViewport ?? undefined;
+    vv = new MockVisualViewport();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: vv,
+      writable: true,
+    });
+    setInnerHeight(800);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: originalVV,
+      writable: true,
+    });
+  });
+
+  it("returns zero offset when no keyboard is open", () => {
+    const { result } = renderHook(() => useVisualViewportOffset());
+    expect(result.current.bottomOffset).toBe(0);
+    expect(result.current.keyboardOpen).toBe(false);
+  });
+
+  it("reports keyboard offset when visualViewport shrinks", () => {
+    const { result } = renderHook(() => useVisualViewportOffset());
+
+    act(() => {
+      vv.height = 500;
+      vv.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current.bottomOffset).toBe(300);
+    expect(result.current.keyboardOpen).toBe(true);
+  });
+
+  it("accounts for offsetTop", () => {
+    const { result } = renderHook(() => useVisualViewportOffset());
+
+    act(() => {
+      vv.height = 600;
+      vv.offsetTop = 50;
+      vv.dispatchEvent(new Event("resize"));
+    });
+
+    // 800 - 600 - 50 = 150
+    expect(result.current.bottomOffset).toBe(150);
+    expect(result.current.keyboardOpen).toBe(true);
+  });
+
+  it("stays below the keyboard-open threshold for small offsets", () => {
+    const { result } = renderHook(() => useVisualViewportOffset());
+
+    act(() => {
+      vv.height = 750; // 50px offset, under 80 threshold
+      vv.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current.bottomOffset).toBe(50);
+    expect(result.current.keyboardOpen).toBe(false);
+  });
+
+  it("stops updating after unmount", () => {
+    const { result, unmount } = renderHook(() => useVisualViewportOffset());
+    unmount();
+
+    act(() => {
+      vv.height = 400;
+      vv.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current.bottomOffset).toBe(0);
+  });
+
+  it("returns zeros when visualViewport is unavailable", () => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+    const { result } = renderHook(() => useVisualViewportOffset());
+    expect(result.current.bottomOffset).toBe(0);
+    expect(result.current.keyboardOpen).toBe(false);
+  });
+});

--- a/apps/web/hooks/use-visual-viewport-offset.ts
+++ b/apps/web/hooks/use-visual-viewport-offset.ts
@@ -5,17 +5,23 @@ export type VisualViewportOffset = {
   bottomOffset: number;
   /** True when the visual viewport is noticeably shorter than the layout viewport (virtual keyboard open). */
   keyboardOpen: boolean;
+  /** Y-coordinate of the visual viewport's bottom edge in the layout viewport — `vv.offsetTop + vv.height`. Use with `position: fixed; top:` to pin an element above the keyboard reliably on iOS even during scrolls. */
+  viewportBottom: number;
 };
 
 const KEYBOARD_THRESHOLD_PX = 80;
 
 function readOffset(): VisualViewportOffset {
   if (typeof window === "undefined" || !window.visualViewport) {
-    return { bottomOffset: 0, keyboardOpen: false };
+    return { bottomOffset: 0, keyboardOpen: false, viewportBottom: 0 };
   }
   const vv = window.visualViewport;
   const bottomOffset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
-  return { bottomOffset, keyboardOpen: bottomOffset > KEYBOARD_THRESHOLD_PX };
+  return {
+    bottomOffset,
+    keyboardOpen: bottomOffset > KEYBOARD_THRESHOLD_PX,
+    viewportBottom: vv.offsetTop + vv.height,
+  };
 }
 
 /**
@@ -28,6 +34,7 @@ export function useVisualViewportOffset(): VisualViewportOffset {
   const [offset, setOffset] = useState<VisualViewportOffset>(() => ({
     bottomOffset: 0,
     keyboardOpen: false,
+    viewportBottom: 0,
   }));
 
   useEffect(() => {

--- a/apps/web/hooks/use-visual-viewport-offset.ts
+++ b/apps/web/hooks/use-visual-viewport-offset.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+export type VisualViewportOffset = {
+  /** Pixels between the bottom of `visualViewport` and the bottom of the layout viewport. */
+  bottomOffset: number;
+  /** True when the visual viewport is noticeably shorter than the layout viewport (virtual keyboard open). */
+  keyboardOpen: boolean;
+};
+
+const KEYBOARD_THRESHOLD_PX = 80;
+
+function readOffset(): VisualViewportOffset {
+  if (typeof window === "undefined" || !window.visualViewport) {
+    return { bottomOffset: 0, keyboardOpen: false };
+  }
+  const vv = window.visualViewport;
+  const bottomOffset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+  return { bottomOffset, keyboardOpen: bottomOffset > KEYBOARD_THRESHOLD_PX };
+}
+
+/**
+ * Tracks the visual viewport's bottom offset relative to the layout viewport so
+ * floating mobile UI (e.g., terminal key-bar) can dock above the on-screen
+ * keyboard. Returns zeros on the server and on browsers without
+ * `window.visualViewport`.
+ */
+export function useVisualViewportOffset(): VisualViewportOffset {
+  const [offset, setOffset] = useState<VisualViewportOffset>(() => ({
+    bottomOffset: 0,
+    keyboardOpen: false,
+  }));
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.visualViewport) return;
+    const vv = window.visualViewport;
+    const update = () => setOffset(readOffset());
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  return offset;
+}

--- a/apps/web/lib/terminal/apply-shell-modifiers.test.ts
+++ b/apps/web/lib/terminal/apply-shell-modifiers.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { applyShellModifiers } from "./apply-shell-modifiers";
+
+const OFF = { ctrl: false, shift: false };
+
+describe("applyShellModifiers", () => {
+  it("passes data through when no modifier is active", () => {
+    expect(applyShellModifiers("c", OFF)).toBe("c");
+    expect(applyShellModifiers("\t", OFF)).toBe("\t");
+    expect(applyShellModifiers("hello", OFF)).toBe("hello");
+  });
+
+  it("maps ctrl + lowercase letter to control byte", () => {
+    expect(applyShellModifiers("c", { ctrl: true, shift: false })).toBe("\x03");
+    expect(applyShellModifiers("a", { ctrl: true, shift: false })).toBe("\x01");
+    expect(applyShellModifiers("z", { ctrl: true, shift: false })).toBe("\x1a");
+  });
+
+  it("maps ctrl + uppercase letter to control byte", () => {
+    expect(applyShellModifiers("C", { ctrl: true, shift: false })).toBe("\x03");
+    expect(applyShellModifiers("Z", { ctrl: true, shift: false })).toBe("\x1a");
+  });
+
+  it("passes ctrl + non-letter through unchanged", () => {
+    expect(applyShellModifiers("1", { ctrl: true, shift: false })).toBe("1");
+    expect(applyShellModifiers("\t", { ctrl: true, shift: false })).toBe("\t");
+  });
+
+  it("does not transform multi-char input even when ctrl is active", () => {
+    expect(applyShellModifiers("hello", { ctrl: true, shift: false })).toBe("hello");
+  });
+
+  it("maps shift + tab to CSI Z (reverse tab)", () => {
+    expect(applyShellModifiers("\t", { ctrl: false, shift: true })).toBe("\x1b[Z");
+  });
+
+  it("passes shift + non-tab letters through unchanged", () => {
+    expect(applyShellModifiers("c", { ctrl: false, shift: true })).toBe("c");
+  });
+
+  it("ctrl takes precedence over shift for letters", () => {
+    expect(applyShellModifiers("c", { ctrl: true, shift: true })).toBe("\x03");
+  });
+});

--- a/apps/web/lib/terminal/apply-shell-modifiers.ts
+++ b/apps/web/lib/terminal/apply-shell-modifiers.ts
@@ -7,10 +7,7 @@
  * Only single-character data is transformed — multi-char paste / IME output
  * passes through unchanged to avoid mangling dictated or autocompleted text.
  */
-export function applyShellModifiers(
-  data: string,
-  mods: { ctrl: boolean; shift: boolean },
-): string {
+export function applyShellModifiers(data: string, mods: { ctrl: boolean; shift: boolean }): string {
   if (mods.ctrl && data.length === 1) {
     const code = data.charCodeAt(0);
     if (code >= 97 && code <= 122) return String.fromCharCode(code - 96);

--- a/apps/web/lib/terminal/apply-shell-modifiers.ts
+++ b/apps/web/lib/terminal/apply-shell-modifiers.ts
@@ -1,0 +1,21 @@
+/**
+ * Transform a single input chunk based on active modifier state.
+ *
+ * - ctrl + single a-z/A-Z → the corresponding control byte (`\x01`..`\x1a`)
+ * - shift + tab → CSI Z (reverse tab / backtab)
+ *
+ * Only single-character data is transformed — multi-char paste / IME output
+ * passes through unchanged to avoid mangling dictated or autocompleted text.
+ */
+export function applyShellModifiers(
+  data: string,
+  mods: { ctrl: boolean; shift: boolean },
+): string {
+  if (mods.ctrl && data.length === 1) {
+    const code = data.charCodeAt(0);
+    if (code >= 97 && code <= 122) return String.fromCharCode(code - 96);
+    if (code >= 65 && code <= 90) return String.fromCharCode(code - 64);
+  }
+  if (mods.shift && data === "\t") return "\x1b[Z";
+  return data;
+}

--- a/apps/web/lib/terminal/key-sequences.test.ts
+++ b/apps/web/lib/terminal/key-sequences.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { KEY_SEQUENCES, ctrlChord } from "./key-sequences";
+import { KEY_SEQUENCES } from "./key-sequences";
 
 describe("KEY_SEQUENCES", () => {
   it("maps Ctrl+C to \\x03", () => {
@@ -27,34 +27,5 @@ describe("KEY_SEQUENCES", () => {
     expect(KEY_SEQUENCES.end).toBe("\x05");
     expect(KEY_SEQUENCES.pageUp).toBe("\x1b[5~");
     expect(KEY_SEQUENCES.pageDown).toBe("\x1b[6~");
-  });
-});
-
-describe("ctrlChord", () => {
-  it("returns \\x03 for 'c' (Ctrl+C)", () => {
-    expect(ctrlChord("c")).toBe("\x03");
-  });
-
-  it("is case-insensitive — 'C' == 'c'", () => {
-    expect(ctrlChord("C")).toBe("\x03");
-  });
-
-  it("returns \\x01 for 'a' (Ctrl+A / Home)", () => {
-    expect(ctrlChord("a")).toBe("\x01");
-  });
-
-  it("returns \\x1a for 'z' (Ctrl+Z)", () => {
-    expect(ctrlChord("z")).toBe("\x1a");
-  });
-
-  it("returns null for non-letter characters", () => {
-    expect(ctrlChord("1")).toBeNull();
-    expect(ctrlChord(" ")).toBeNull();
-    expect(ctrlChord("!")).toBeNull();
-  });
-
-  it("returns null for multi-char / empty input", () => {
-    expect(ctrlChord("")).toBeNull();
-    expect(ctrlChord("ab")).toBeNull();
   });
 });

--- a/apps/web/lib/terminal/key-sequences.test.ts
+++ b/apps/web/lib/terminal/key-sequences.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { KEY_SEQUENCES, ctrlChord } from "./key-sequences";
+
+describe("KEY_SEQUENCES", () => {
+  it("maps Ctrl+C to \\x03", () => {
+    expect(KEY_SEQUENCES.ctrlC).toBe("\x03");
+  });
+
+  it("maps Ctrl+D to \\x04", () => {
+    expect(KEY_SEQUENCES.ctrlD).toBe("\x04");
+  });
+
+  it("maps Esc / Tab", () => {
+    expect(KEY_SEQUENCES.esc).toBe("\x1b");
+    expect(KEY_SEQUENCES.tab).toBe("\t");
+  });
+
+  it("maps arrow keys", () => {
+    expect(KEY_SEQUENCES.up).toBe("\x1b[A");
+    expect(KEY_SEQUENCES.down).toBe("\x1b[B");
+    expect(KEY_SEQUENCES.right).toBe("\x1b[C");
+    expect(KEY_SEQUENCES.left).toBe("\x1b[D");
+  });
+
+  it("maps Home / End / PgUp / PgDn", () => {
+    expect(KEY_SEQUENCES.home).toBe("\x01");
+    expect(KEY_SEQUENCES.end).toBe("\x05");
+    expect(KEY_SEQUENCES.pageUp).toBe("\x1b[5~");
+    expect(KEY_SEQUENCES.pageDown).toBe("\x1b[6~");
+  });
+});
+
+describe("ctrlChord", () => {
+  it("returns \\x03 for 'c' (Ctrl+C)", () => {
+    expect(ctrlChord("c")).toBe("\x03");
+  });
+
+  it("is case-insensitive — 'C' == 'c'", () => {
+    expect(ctrlChord("C")).toBe("\x03");
+  });
+
+  it("returns \\x01 for 'a' (Ctrl+A / Home)", () => {
+    expect(ctrlChord("a")).toBe("\x01");
+  });
+
+  it("returns \\x1a for 'z' (Ctrl+Z)", () => {
+    expect(ctrlChord("z")).toBe("\x1a");
+  });
+
+  it("returns null for non-letter characters", () => {
+    expect(ctrlChord("1")).toBeNull();
+    expect(ctrlChord(" ")).toBeNull();
+    expect(ctrlChord("!")).toBeNull();
+  });
+
+  it("returns null for multi-char / empty input", () => {
+    expect(ctrlChord("")).toBeNull();
+    expect(ctrlChord("ab")).toBeNull();
+  });
+});

--- a/apps/web/lib/terminal/key-sequences.ts
+++ b/apps/web/lib/terminal/key-sequences.ts
@@ -1,0 +1,27 @@
+/** ANSI escape / control sequences for common terminal keys. */
+export const KEY_SEQUENCES = {
+  esc: "\x1b",
+  tab: "\t",
+  up: "\x1b[A",
+  down: "\x1b[B",
+  right: "\x1b[C",
+  left: "\x1b[D",
+  home: "\x01",
+  end: "\x05",
+  pageUp: "\x1b[5~",
+  pageDown: "\x1b[6~",
+  ctrlC: "\x03",
+  ctrlD: "\x04",
+  ctrlZ: "\x1a",
+} as const;
+
+/**
+ * Return the Ctrl+<letter> control byte for a given character (A–Z, a–z).
+ * Non-letters return null — callers should then emit the raw char instead.
+ */
+export function ctrlChord(char: string): string | null {
+  if (char.length !== 1) return null;
+  const code = char.toLowerCase().charCodeAt(0);
+  if (code < 97 || code > 122) return null;
+  return String.fromCharCode(code - 96);
+}

--- a/apps/web/lib/terminal/key-sequences.ts
+++ b/apps/web/lib/terminal/key-sequences.ts
@@ -1,4 +1,11 @@
-/** ANSI escape / control sequences for common terminal keys. */
+/**
+ * ANSI escape / control sequences for common terminal keys.
+ *
+ * Note: `home` / `end` send readline shortcuts (Ctrl+A / Ctrl+E) rather than
+ * the VT sequences (`\x1b[H` / `\x1b[F`). This matches what most shells expect
+ * for line-start / line-end navigation; full-screen apps like vim/nano that
+ * key off VT sequences will not interpret these as Home/End.
+ */
 export const KEY_SEQUENCES = {
   esc: "\x1b",
   tab: "\t",
@@ -14,14 +21,3 @@ export const KEY_SEQUENCES = {
   ctrlD: "\x04",
   ctrlZ: "\x1a",
 } as const;
-
-/**
- * Return the Ctrl+<letter> control byte for a given character (A–Z, a–z).
- * Non-letters return null — callers should then emit the raw char instead.
- */
-export function ctrlChord(char: string): string | null {
-  if (char.length !== 1) return null;
-  const code = char.toLowerCase().charCodeAt(0);
-  if (code < 97 || code > 122) return null;
-  return String.fromCharCode(code - 96);
-}

--- a/apps/web/lib/terminal/refocus-xterm.test.ts
+++ b/apps/web/lib/terminal/refocus-xterm.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { refocusXtermTextarea } from "./refocus-xterm";
+
+describe("refocusXtermTextarea", () => {
+  let textarea: HTMLTextAreaElement;
+
+  beforeEach(() => {
+    textarea = document.createElement("textarea");
+    textarea.className = "xterm-helper-textarea";
+    document.body.appendChild(textarea);
+  });
+
+  afterEach(() => {
+    textarea.remove();
+  });
+
+  it("focuses the xterm helper textarea", () => {
+    const other = document.createElement("input");
+    document.body.appendChild(other);
+    other.focus();
+    expect(document.activeElement).toBe(other);
+
+    refocusXtermTextarea();
+    expect(document.activeElement).toBe(textarea);
+    other.remove();
+  });
+
+  it("does not throw when no xterm textarea is mounted", () => {
+    textarea.remove();
+    expect(() => refocusXtermTextarea()).not.toThrow();
+  });
+});

--- a/apps/web/lib/terminal/refocus-xterm.ts
+++ b/apps/web/lib/terminal/refocus-xterm.ts
@@ -1,0 +1,13 @@
+/**
+ * Synchronously re-focus xterm.js's hidden textarea after a virtual-key tap.
+ *
+ * Why: on iOS Safari, tapping a button in a virtual key-bar can dismiss the
+ * soft keyboard even with preventDefault on pointerdown/mousedown, because
+ * WebKit transfers focus on touchend. Calling .focus() on the xterm textarea
+ * inside the same user gesture (the onClick handler) re-shows the keyboard.
+ */
+export function refocusXtermTextarea(): void {
+  if (typeof document === "undefined") return;
+  const textarea = document.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+  textarea?.focus({ preventScroll: true });
+}

--- a/apps/web/lib/terminal/send-shell-input.test.ts
+++ b/apps/web/lib/terminal/send-shell-input.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useShellModifiersStore } from "./shell-modifiers";
+
+const sendMock = vi.fn();
+let clientFactory: () => { send: typeof sendMock } | null = () => ({ send: sendMock });
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => clientFactory(),
+}));
+
+// Imported after the mock so it picks up the mocked module.
+const { sendShellInput } = await import("./send-shell-input");
+
+const SESSION = "sess-1";
+
+beforeEach(() => {
+  sendMock.mockReset();
+  clientFactory = () => ({ send: sendMock });
+  useShellModifiersStore.getState().reset();
+});
+
+function lastFrameData(): string | undefined {
+  const call = sendMock.mock.calls.at(-1)?.[0] as { payload?: { data?: string } } | undefined;
+  return call?.payload?.data;
+}
+
+describe("sendShellInput", () => {
+  it("no-ops on empty data", () => {
+    sendShellInput(SESSION, "");
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("sends raw data and shapes the WS frame", () => {
+    sendShellInput(SESSION, "ls");
+    expect(sendMock).toHaveBeenCalledWith({
+      type: "request",
+      action: "shell.input",
+      payload: { session_id: SESSION, data: "ls" },
+    });
+  });
+
+  it("applies the Ctrl chord transform when Ctrl is latched and consumes it", () => {
+    useShellModifiersStore.getState().toggleCtrl();
+    sendShellInput(SESSION, "c");
+    expect(lastFrameData()).toBe("\x03");
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: false, sticky: false });
+  });
+
+  it("keeps Ctrl latched when sticky after a chord", () => {
+    useShellModifiersStore.getState().toggleCtrl();
+    useShellModifiersStore.getState().toggleCtrl();
+    expect(useShellModifiersStore.getState().ctrl.sticky).toBe(true);
+
+    sendShellInput(SESSION, "a");
+    expect(lastFrameData()).toBe("\x01");
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: true, sticky: true });
+  });
+
+  it("translates Shift+Tab to CSI Z and consumes Shift", () => {
+    useShellModifiersStore.getState().toggleShift();
+    sendShellInput(SESSION, "\t");
+    expect(lastFrameData()).toBe("\x1b[Z");
+    expect(useShellModifiersStore.getState().shift).toEqual({ latched: false, sticky: false });
+  });
+
+  it("Shift on a non-Tab character is a passthrough; modifier still consumes", () => {
+    useShellModifiersStore.getState().toggleShift();
+    sendShellInput(SESSION, "a");
+    expect(lastFrameData()).toBe("a");
+    expect(useShellModifiersStore.getState().shift).toEqual({ latched: false, sticky: false });
+  });
+
+  it("when the WS client is null: nothing sent AND modifiers stay armed", () => {
+    clientFactory = () => null;
+    useShellModifiersStore.getState().toggleCtrl();
+    sendShellInput(SESSION, "c");
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: true, sticky: false });
+  });
+});

--- a/apps/web/lib/terminal/send-shell-input.ts
+++ b/apps/web/lib/terminal/send-shell-input.ts
@@ -12,18 +12,17 @@ import { useShellModifiersStore, isActive } from "./shell-modifiers";
  */
 export function sendShellInput(sessionId: string, data: string): void {
   if (!data) return;
+  const client = getWebSocketClient();
+  if (!client) return; // keep modifiers armed; the user can retry once reconnected
   const store = useShellModifiersStore.getState();
   const ctrlActive = isActive(store.ctrl);
   const shiftActive = isActive(store.shift);
   const transformed = applyShellModifiers(data, { ctrl: ctrlActive, shift: shiftActive });
-  const client = getWebSocketClient();
-  if (client) {
-    client.send({
-      type: "request",
-      action: "shell.input",
-      payload: { session_id: sessionId, data: transformed },
-    });
-  }
+  client.send({
+    type: "request",
+    action: "shell.input",
+    payload: { session_id: sessionId, data: transformed },
+  });
   if (ctrlActive) store.consumeCtrl();
   if (shiftActive) store.consumeShift();
 }

--- a/apps/web/lib/terminal/send-shell-input.ts
+++ b/apps/web/lib/terminal/send-shell-input.ts
@@ -1,0 +1,29 @@
+import { getWebSocketClient } from "@/lib/ws/connection";
+import { applyShellModifiers } from "./apply-shell-modifiers";
+import { useShellModifiersStore, isActive } from "./shell-modifiers";
+
+/**
+ * Single entry point for shell input. Applies active ctrl/shift modifiers,
+ * sends over the WS, then consumes latched (non-sticky) modifiers.
+ *
+ * Used by both the virtual key-bar and xterm's own `onData` callback so that
+ * a Ctrl latch set from the key-bar modifies the next character the user
+ * types on the OS keyboard — which is the whole point of the modifier.
+ */
+export function sendShellInput(sessionId: string, data: string): void {
+  if (!data) return;
+  const store = useShellModifiersStore.getState();
+  const ctrlActive = isActive(store.ctrl);
+  const shiftActive = isActive(store.shift);
+  const transformed = applyShellModifiers(data, { ctrl: ctrlActive, shift: shiftActive });
+  const client = getWebSocketClient();
+  if (client) {
+    client.send({
+      type: "request",
+      action: "shell.input",
+      payload: { session_id: sessionId, data: transformed },
+    });
+  }
+  if (ctrlActive) store.consumeCtrl();
+  if (shiftActive) store.consumeShift();
+}

--- a/apps/web/lib/terminal/shell-modifiers.test.ts
+++ b/apps/web/lib/terminal/shell-modifiers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useShellModifiersStore, isActive } from "./shell-modifiers";
+
+beforeEach(() => {
+  useShellModifiersStore.getState().reset();
+});
+
+describe("shell-modifiers store", () => {
+  it("toggles ctrl through off → latched → sticky → off", () => {
+    const { toggleCtrl } = useShellModifiersStore.getState();
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: false, sticky: false });
+
+    toggleCtrl();
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: true, sticky: false });
+
+    toggleCtrl();
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: true, sticky: true });
+
+    toggleCtrl();
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: false, sticky: false });
+  });
+
+  it("consumeCtrl clears a latched (non-sticky) modifier", () => {
+    useShellModifiersStore.getState().toggleCtrl();
+    useShellModifiersStore.getState().consumeCtrl();
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: false, sticky: false });
+  });
+
+  it("consumeCtrl is a no-op when sticky", () => {
+    useShellModifiersStore.getState().toggleCtrl();
+    useShellModifiersStore.getState().toggleCtrl();
+    useShellModifiersStore.getState().consumeCtrl();
+    expect(useShellModifiersStore.getState().ctrl).toEqual({ latched: true, sticky: true });
+  });
+
+  it("shift mirrors ctrl behavior", () => {
+    const { toggleShift, consumeShift } = useShellModifiersStore.getState();
+    toggleShift();
+    expect(useShellModifiersStore.getState().shift.latched).toBe(true);
+    consumeShift();
+    expect(useShellModifiersStore.getState().shift.latched).toBe(false);
+  });
+
+  it("isActive returns true for latched or sticky", () => {
+    expect(isActive({ latched: false, sticky: false })).toBe(false);
+    expect(isActive({ latched: true, sticky: false })).toBe(true);
+    expect(isActive({ latched: false, sticky: true })).toBe(true);
+    expect(isActive({ latched: true, sticky: true })).toBe(true);
+  });
+});

--- a/apps/web/lib/terminal/shell-modifiers.ts
+++ b/apps/web/lib/terminal/shell-modifiers.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+
+export type ModifierState = { latched: boolean; sticky: boolean };
+
+export type ShellModifiersStore = {
+  ctrl: ModifierState;
+  shift: ModifierState;
+  toggleCtrl: () => void;
+  toggleShift: () => void;
+  consumeCtrl: () => void;
+  consumeShift: () => void;
+  reset: () => void;
+};
+
+const INITIAL: ModifierState = { latched: false, sticky: false };
+
+function nextToggle(cur: ModifierState): ModifierState {
+  if (cur.sticky) return { latched: false, sticky: false };
+  if (cur.latched) return { latched: true, sticky: true };
+  return { latched: true, sticky: false };
+}
+
+function nextConsume(cur: ModifierState): ModifierState {
+  if (cur.sticky) return cur;
+  return { latched: false, sticky: false };
+}
+
+/**
+ * Transient, module-level modifier state for the mobile terminal key-bar.
+ * Only one terminal is typed into at a time, so per-session scoping isn't
+ * needed. Shared between `MobileTerminalKeybar` (UI + toggles) and the xterm
+ * `onData` path (consumes on every keystroke).
+ */
+export const useShellModifiersStore = create<ShellModifiersStore>((set) => ({
+  ctrl: INITIAL,
+  shift: INITIAL,
+  toggleCtrl: () => set((s) => ({ ctrl: nextToggle(s.ctrl) })),
+  toggleShift: () => set((s) => ({ shift: nextToggle(s.shift) })),
+  consumeCtrl: () => set((s) => ({ ctrl: nextConsume(s.ctrl) })),
+  consumeShift: () => set((s) => ({ shift: nextConsume(s.shift) })),
+  reset: () => set({ ctrl: INITIAL, shift: INITIAL }),
+}));
+
+export function isActive(m: ModifierState): boolean {
+  return m.latched || m.sticky;
+}

--- a/apps/web/lib/terminal/suppress-ios-keyboard-assists.test.ts
+++ b/apps/web/lib/terminal/suppress-ios-keyboard-assists.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { suppressIOSKeyboardAssists } from "./suppress-ios-keyboard-assists";
+
+function hostWithTextarea(): { host: HTMLElement; textarea: HTMLTextAreaElement } {
+  const host = document.createElement("div");
+  const textarea = document.createElement("textarea");
+  textarea.className = "xterm-helper-textarea";
+  host.appendChild(textarea);
+  return { host, textarea };
+}
+
+describe("suppressIOSKeyboardAssists", () => {
+  it("signals password managers and iOS to skip the xterm textarea for autofill", () => {
+    const { host, textarea } = hostWithTextarea();
+    suppressIOSKeyboardAssists(host);
+    expect(textarea.getAttribute("autocomplete")).toBe("off");
+    expect(textarea.getAttribute("name")).toBe("__xterm_stdin__");
+    expect(textarea.getAttribute("data-form-type")).toBe("other");
+    expect(textarea.getAttribute("data-lpignore")).toBe("true");
+    expect(textarea.getAttribute("data-1p-ignore")).toBe("true");
+    expect(textarea.getAttribute("data-bwignore")).toBe("true");
+  });
+
+  it("is a no-op when the host has no xterm textarea", () => {
+    const host = document.createElement("div");
+    expect(() => suppressIOSKeyboardAssists(host)).not.toThrow();
+  });
+});

--- a/apps/web/lib/terminal/suppress-ios-keyboard-assists.ts
+++ b/apps/web/lib/terminal/suppress-ios-keyboard-assists.ts
@@ -1,0 +1,21 @@
+/**
+ * Signal to iOS / password managers that xterm's helper textarea isn't a
+ * fillable form field, so the AutoFill suggestion bar above the keyboard
+ * doesn't appear.
+ *
+ * xterm already sets autocorrect/autocapitalize/spellcheck itself, but that
+ * isn't enough — iOS still heuristically shows the AutoFill bar for generic
+ * textareas. Adding `autocomplete="off"`, an opaque `name`, and the password-
+ * manager ignore hints (1Password, LastPass, Bitwarden) makes iOS and those
+ * extensions skip the field. Safe no-op on desktop.
+ */
+export function suppressIOSKeyboardAssists(host: HTMLElement): void {
+  const textarea = host.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+  if (!textarea) return;
+  textarea.setAttribute("autocomplete", "off");
+  textarea.setAttribute("name", "__xterm_stdin__");
+  textarea.setAttribute("data-form-type", "other");
+  textarea.setAttribute("data-lpignore", "true");
+  textarea.setAttribute("data-1p-ignore", "true");
+  textarea.setAttribute("data-bwignore", "true");
+}


### PR DESCRIPTION
The mobile terminal key-bar's Ctrl modifier only affected its own in-bar letter buttons — tapping Ctrl then typing on the OS keyboard did nothing. Reworks the bar so Ctrl/Shift transform the next OS-keyboard keystroke (or bar tap), drops the now-redundant 26 letter buttons, adds Shift, and pins the bar reliably above iOS Safari's soft keyboard.

## Important Changes

- New `lib/terminal/` toolkit: a Zustand `shellModifiers` store, a pure `applyShellModifiers` transform (ctrl + a-z → control byte; shift + tab → CSI Z), and a `sendShellInput` sender that both the bar and xterm's `onData` route through — so a Ctrl latch set on the bar modifies the next character typed on the OS keyboard.
- Key-bar UX: drops `LETTER_KEYS`, adds Shift, latched and sticky both show a ring (sticky is stronger), `touch-action: manipulation` so taps in the `overflow-x-auto` row aren't treated as scroll.
- iOS positioning: `useVisualViewportOffset` exports `viewportBottom`; with the keyboard open the bar uses `top: viewportBottom - barHeight; bottom: auto` (fixes drift during visual-viewport scroll). Terminal panel computes `paddingBottom` so its content's bottom sits at the bar's top edge.
- Keyboard retention: `refocusXtermTextarea` after every bar tap, `preventDefault` on `pointerdown`/`mousedown`, and `suppressIOSKeyboardAssists` to hide the AutoFill suggestion bar.

## Validation

- Unit/component: `pnpm --filter @kandev/web test` — 734 passed.
- Lint/types: `pnpm --filter @kandev/web lint` and `tsc --noEmit` clean.
- E2E (rewritten around real user flows, runs on mobile-chrome): `pnpm e2e --project=mobile-chrome tests/terminal/mobile-terminal-keybar.spec.ts` — 15 passed. Coverage includes ^C cancels a `sleep 30`, Ctrl + OS-keyboard L clears screen, sticky Ctrl chords A/E without re-arming, Shift+Tab → `\x1b[Z`, OS letter passthrough when no modifier, no in-bar letter buttons, bar hidden on Chat/Files/Plan/Changes, top-anchored positioning when keyboard opens, scroll-tracking, and dynamic terminal padding.

## Possible Improvements

Low risk. The iOS AutoFill bar suppression relies on attribute hints (`autocomplete=off`, opaque `name`, password-manager ignore attrs) which iOS may still override on some versions; if it persists in QA, fallback options are noted in the code comment.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.

## Screenshots
https://github.com/user-attachments/assets/e652eda0-840a-4292-a075-8b2955e4d503