### PR TITLE
feat(stats): show active time and elapsed span per task

### DIFF
--- a/apps/backend/internal/analytics/dto/dto.go
+++ b/apps/backend/internal/analytics/dto/dto.go
@@ -13,6 +13,8 @@ type TaskStatsDTO struct {
 	UserMessageCount int     `json:"user_message_count"`
 	ToolCallCount    int     `json:"tool_call_count"`
 	TotalDurationMs  int64   `json:"total_duration_ms"`
+	ActiveDurationMs int64   `json:"active_duration_ms"`
+	ElapsedSpanMs    int64   `json:"elapsed_span_ms"`
 	CreatedAt        string  `json:"created_at"`
 	CompletedAt      *string `json:"completed_at,omitempty"`
 }

--- a/apps/backend/internal/analytics/handlers/stats_handlers.go
+++ b/apps/backend/internal/analytics/handlers/stats_handlers.go
@@ -154,6 +154,8 @@ func taskStatsToDTOs(taskStats []*models.TaskStats) []dto.TaskStatsDTO {
 			UserMessageCount: ts.UserMessageCount,
 			ToolCallCount:    ts.ToolCallCount,
 			TotalDurationMs:  ts.TotalDurationMs,
+			ActiveDurationMs: ts.ActiveDurationMs,
+			ElapsedSpanMs:    ts.ElapsedSpanMs,
 			CreatedAt:        ts.CreatedAt.UTC().Format(time.RFC3339),
 		}
 		if ts.CompletedAt != nil {

--- a/apps/backend/internal/analytics/models/models.go
+++ b/apps/backend/internal/analytics/models/models.go
@@ -15,6 +15,8 @@ type TaskStats struct {
 	UserMessageCount int        `json:"user_message_count"`
 	ToolCallCount    int        `json:"tool_call_count"`
 	TotalDurationMs  int64      `json:"total_duration_ms"`
+	ActiveDurationMs int64      `json:"active_duration_ms"`
+	ElapsedSpanMs    int64      `json:"elapsed_span_ms"`
 	CreatedAt        time.Time  `json:"created_at"`
 	CompletedAt      *time.Time `json:"completed_at,omitempty"`
 }

--- a/apps/backend/internal/analytics/repository/sqlite/repository_test.go
+++ b/apps/backend/internal/analytics/repository/sqlite/repository_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -129,6 +130,15 @@ func execOrFatal(t *testing.T, dbConn *sqlx.DB, query string, args ...any) {
 	t.Helper()
 	if _, err := dbConn.Exec(query, args...); err != nil {
 		t.Fatalf("exec failed: %v", err)
+	}
+}
+
+func assertDurationAlmostEqual(t *testing.T, got, want int64, label string) {
+	t.Helper()
+	const toleranceMs = int64(2)
+	diff := int64(math.Abs(float64(got - want)))
+	if diff > toleranceMs {
+		t.Errorf("expected %s %dms (+/-%dms), got %dms", label, want, toleranceMs, got)
 	}
 }
 
@@ -370,6 +380,44 @@ func TestGetTaskStats_ExcludesEphemeralTasks(t *testing.T) {
 	if results[0].TaskID != "task-regular" {
 		t.Errorf("expected task-regular, got %s", results[0].TaskID)
 	}
+}
+
+func TestGetTaskStats_IncludesActiveAndElapsedDurations(t *testing.T) {
+	dbConn := createTestDB(t)
+	repo, err := NewWithDB(dbConn, dbConn)
+	if err != nil {
+		t.Fatalf("NewWithDB failed: %v", err)
+	}
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+
+	execOrFatal(t, dbConn, `INSERT INTO workspaces (id, name, created_at, updated_at) VALUES ('ws-1', 'Test', ?, ?)`, nowStr, nowStr)
+	execOrFatal(t, dbConn, `INSERT INTO boards (id, workspace_id, name, created_at, updated_at) VALUES ('board-1', 'ws-1', 'Board', ?, ?)`, nowStr, nowStr)
+	execOrFatal(t, dbConn, `INSERT INTO tasks (id, workspace_id, board_id, workflow_step_id, title, is_ephemeral, created_at, updated_at) VALUES ('task-1', 'ws-1', 'board-1', '', 'Task 1', 0, ?, ?)`, nowStr, nowStr)
+	execOrFatal(t, dbConn, `INSERT INTO task_sessions (id, task_id, agent_profile_id, state, started_at, updated_at) VALUES ('sess-1', 'task-1', 'agent-1', 'COMPLETED', ?, ?)`, nowStr, nowStr)
+
+	// Two 10-minute turns with a 60-minute idle gap in between.
+	execOrFatal(t, dbConn, `INSERT INTO task_session_turns (id, task_session_id, task_id, started_at, completed_at, created_at, updated_at) VALUES ('turn-1', 'sess-1', 'task-1', '2026-01-01T10:00:00Z', '2026-01-01T10:10:00Z', ?, ?)`, nowStr, nowStr)
+	execOrFatal(t, dbConn, `INSERT INTO task_session_turns (id, task_session_id, task_id, started_at, completed_at, created_at, updated_at) VALUES ('turn-2', 'sess-1', 'task-1', '2026-01-01T11:10:00Z', '2026-01-01T11:20:00Z', ?, ?)`, nowStr, nowStr)
+
+	results, err := repo.GetTaskStats(ctx, "ws-1", nil)
+	if err != nil {
+		t.Fatalf("GetTaskStats failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 task stat, got %d", len(results))
+	}
+
+	// Active duration = 20m, elapsed span = 80m.
+	const (
+		wantActiveMs  = int64(20 * 60 * 1000)
+		wantElapsedMs = int64(80 * 60 * 1000)
+	)
+	assertDurationAlmostEqual(t, results[0].ActiveDurationMs, wantActiveMs, "active duration")
+	assertDurationAlmostEqual(t, results[0].ElapsedSpanMs, wantElapsedMs, "elapsed span")
+	assertDurationAlmostEqual(t, results[0].TotalDurationMs, wantActiveMs, "total duration")
 }
 
 func TestGetDailyActivity_ExcludesEphemeralTasks(t *testing.T) {

--- a/apps/backend/internal/analytics/repository/sqlite/stats.go
+++ b/apps/backend/internal/analytics/repository/sqlite/stats.go
@@ -51,8 +51,8 @@ func (r *Repository) GetTaskStats(ctx context.Context, workspaceID string, start
 			COALESCE(session_stats.message_count, 0) as message_count,
 			COALESCE(session_stats.user_message_count, 0) as user_message_count,
 			COALESCE(session_stats.tool_call_count, 0) as tool_call_count,
-			COALESCE(turn_stats.total_duration_ms, 0) as total_duration_ms,
-			COALESCE(turn_stats.total_duration_ms, 0) as active_duration_ms,
+			COALESCE(turn_stats.active_duration_ms, 0) as total_duration_ms,
+			COALESCE(turn_stats.active_duration_ms, 0) as active_duration_ms,
 			COALESCE(turn_stats.elapsed_span_ms, 0) as elapsed_span_ms,
 			t.created_at, session_stats.last_completed_at
 		FROM tasks t
@@ -72,7 +72,7 @@ func (r *Repository) GetTaskStats(ctx context.Context, workspaceID string, start
 		) session_stats ON session_stats.task_id = t.id
 		LEFT JOIN (
 			SELECT s.task_id,
-				SUM(CASE WHEN turn.completed_at IS NOT NULL THEN %s ELSE 0 END) as total_duration_ms,
+				SUM(CASE WHEN turn.completed_at IS NOT NULL THEN %s ELSE 0 END) as active_duration_ms,
 				%s as elapsed_span_ms
 			FROM task_sessions s
 			LEFT JOIN task_session_turns turn ON turn.task_session_id = s.id
@@ -81,7 +81,11 @@ func (r *Repository) GetTaskStats(ctx context.Context, workspaceID string, start
 		) turn_stats ON turn_stats.task_id = t.id
 		WHERE t.workspace_id = ? AND t.is_ephemeral = 0 AND (? IS NULL OR t.created_at >= ?)
 		ORDER BY t.updated_at DESC
-	`, dur, dialect.DurationMs(drv, "MAX(turn.completed_at)", "MIN(turn.started_at)"))
+	`, dur, dialect.DurationMs(
+		drv,
+		"MAX(CASE WHEN turn.completed_at IS NOT NULL THEN turn.completed_at END)",
+		"MIN(CASE WHEN turn.completed_at IS NOT NULL THEN turn.started_at END)",
+	))
 
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(query),
 		startArg, startArg, startArg, startArg,

--- a/apps/backend/internal/analytics/repository/sqlite/stats.go
+++ b/apps/backend/internal/analytics/repository/sqlite/stats.go
@@ -52,6 +52,8 @@ func (r *Repository) GetTaskStats(ctx context.Context, workspaceID string, start
 			COALESCE(session_stats.user_message_count, 0) as user_message_count,
 			COALESCE(session_stats.tool_call_count, 0) as tool_call_count,
 			COALESCE(turn_stats.total_duration_ms, 0) as total_duration_ms,
+			COALESCE(turn_stats.total_duration_ms, 0) as active_duration_ms,
+			COALESCE(turn_stats.elapsed_span_ms, 0) as elapsed_span_ms,
 			t.created_at, session_stats.last_completed_at
 		FROM tasks t
 		LEFT JOIN (
@@ -70,7 +72,8 @@ func (r *Repository) GetTaskStats(ctx context.Context, workspaceID string, start
 		) session_stats ON session_stats.task_id = t.id
 		LEFT JOIN (
 			SELECT s.task_id,
-				SUM(CASE WHEN turn.completed_at IS NOT NULL THEN %s ELSE 0 END) as total_duration_ms
+				SUM(CASE WHEN turn.completed_at IS NOT NULL THEN %s ELSE 0 END) as total_duration_ms,
+				%s as elapsed_span_ms
 			FROM task_sessions s
 			LEFT JOIN task_session_turns turn ON turn.task_session_id = s.id
 			WHERE (? IS NULL OR s.started_at >= ?)
@@ -78,7 +81,7 @@ func (r *Repository) GetTaskStats(ctx context.Context, workspaceID string, start
 		) turn_stats ON turn_stats.task_id = t.id
 		WHERE t.workspace_id = ? AND t.is_ephemeral = 0 AND (? IS NULL OR t.created_at >= ?)
 		ORDER BY t.updated_at DESC
-	`, dur)
+	`, dur, dialect.DurationMs(drv, "MAX(turn.completed_at)", "MIN(turn.started_at)"))
 
 	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(query),
 		startArg, startArg, startArg, startArg,
@@ -99,16 +102,21 @@ func (r *Repository) scanTaskStats(rows *sql.Rows) ([]*models.TaskStats, error) 
 		var completedAtStr sql.NullString
 		var createdAtStr string
 		var totalDurationMs float64
+		var activeDurationMs float64
+		var elapsedSpanMs float64
 		err := rows.Scan(
 			&stat.TaskID, &stat.TaskTitle, &stat.WorkspaceID, &stat.WorkflowID, &stat.State,
 			&stat.SessionCount, &stat.TurnCount, &stat.MessageCount,
 			&stat.UserMessageCount, &stat.ToolCallCount, &totalDurationMs,
+			&activeDurationMs, &elapsedSpanMs,
 			&createdAtStr, &completedAtStr,
 		)
 		if err != nil {
 			return nil, err
 		}
 		stat.TotalDurationMs = int64(totalDurationMs)
+		stat.ActiveDurationMs = int64(activeDurationMs)
+		stat.ElapsedSpanMs = int64(elapsedSpanMs)
 		stat.CreatedAt = parseTimeString(createdAtStr)
 		if completedAtStr.Valid && completedAtStr.String != "" {
 			parsedTime := parseTimeString(completedAtStr.String)

--- a/apps/web/app/stats/stats-sections.tsx
+++ b/apps/web/app/stats/stats-sections.tsx
@@ -223,6 +223,7 @@ export function WorkloadSection({ task_stats }: WorkloadSectionProps) {
       <Card className="rounded-sm">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-muted-foreground">Longest Tasks</CardTitle>
+          <p className="text-xs text-muted-foreground">Ranked by elapsed span</p>
         </CardHeader>
         <CardContent>
           <TaskDurationList
@@ -239,6 +240,7 @@ export function WorkloadSection({ task_stats }: WorkloadSectionProps) {
           <CardTitle className="text-sm font-medium text-muted-foreground">
             Quickest Tasks
           </CardTitle>
+          <p className="text-xs text-muted-foreground">Ranked by elapsed span</p>
         </CardHeader>
         <CardContent>
           <TaskDurationList

--- a/apps/web/app/stats/stats-sections.tsx
+++ b/apps/web/app/stats/stats-sections.tsx
@@ -433,11 +433,11 @@ export function RepoLeaders({ repositoryStats }: { repositoryStats: RepositorySt
 }
 
 function TaskDurationList({ tasks, sortDirection, emptyLabel }: TaskDurationListProps) {
-  const filtered = [...tasks].filter((t) => t.total_duration_ms > 0);
+  const filtered = [...tasks].filter((t) => t.active_duration_ms > 0 || t.elapsed_span_ms > 0);
   const sorted =
     sortDirection === "desc"
-      ? filtered.sort((a, b) => b.total_duration_ms - a.total_duration_ms)
-      : filtered.sort((a, b) => a.total_duration_ms - b.total_duration_ms);
+      ? filtered.sort((a, b) => b.elapsed_span_ms - a.elapsed_span_ms)
+      : filtered.sort((a, b) => a.elapsed_span_ms - b.elapsed_span_ms);
   const top3 = sorted.slice(0, 3);
 
   return (
@@ -454,7 +454,10 @@ function TaskDurationList({ tasks, sortDirection, emptyLabel }: TaskDurationList
             </div>
           </div>
           <div className="text-sm font-medium tabular-nums text-right">
-            {formatDuration(task.total_duration_ms)}
+            <div>{formatDuration(task.active_duration_ms)}</div>
+            <div className="text-[11px] text-muted-foreground">
+              span {formatDuration(task.elapsed_span_ms)}
+            </div>
           </div>
         </div>
       ))}

--- a/apps/web/lib/types/http-agents.ts
+++ b/apps/web/lib/types/http-agents.ts
@@ -297,6 +297,8 @@ export type TaskStatsDTO = {
   user_message_count: number;
   tool_call_count: number;
   total_duration_ms: number;
+  active_duration_ms: number;
+  elapsed_span_ms: number;
   created_at: string;
   completed_at?: string;
 };


### PR DESCRIPTION
Summary
The stats page currently reports only elapsed turn duration, which makes long idle turns look like active work and confuses task effort interpretation. This change adds explicit active time and elapsed span metrics so the UI can communicate both the time spent and the total wall-clock window.

Important Changes
- extend analytics task stats model/DTO with active_duration_ms and elapsed_span_ms
- compute elapsed span in sqlite stats query using first turn start to last turn completion
- render task durations in stats UI as active time with a secondary span label
- add repository test coverage for active-vs-span behavior

Validation
- cd apps/backend && GOCACHE=/tmp/go-build go test ./internal/analytics/...
- cd apps/web && pnpm lint

Possible Improvements
- Consider adding the same dual-metric treatment to global and repository time cards for consistency.

Checklist
- [ ] Code builds locally and passes relevant checks
- [ ] Tests added/updated for behavior changes
- [ ] Documentation updated (if needed)
- [ ] Backward compatibility considered