### PR TITLE
fix(web): plan panel misses agent updates emitted before WS connects

### DIFF
--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -127,6 +127,21 @@ describe("usePlanPanelAutoOpen", () => {
     renderHook(() => usePlanPanelAutoOpen());
     expect(mockAddPlanPanel).not.toHaveBeenCalled();
   });
+});
+
+describe("usePlanPanelAutoOpen — eager fetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveTaskId = "task-1";
+    mockPlan = agentPlan();
+    mockLastSeen = undefined;
+    mockIsLoaded = true;
+    mockConnectionStatus = "connected";
+    mockIsRestoringLayout = false;
+    mockApi = { getPanel: mockGetPanel };
+    mockGetPanel.mockReturnValue(null);
+    mockGetTaskPlan.mockResolvedValue(null);
+  });
 
   it("eagerly fetches the plan when not yet loaded", () => {
     mockIsLoaded = false;

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -17,23 +17,25 @@ let mockConnectionStatus = "connected";
 let mockIsRestoringLayout = false;
 let mockApi: { getPanel: typeof mockGetPanel } | null = { getPanel: mockGetPanel };
 
+function buildState() {
+  return {
+    tasks: { activeTaskId: mockActiveTaskId },
+    taskPlans: {
+      byTaskId: mockActiveTaskId && mockPlan ? { [mockActiveTaskId]: mockPlan } : {},
+      loadedByTaskId: mockActiveTaskId ? { [mockActiveTaskId]: mockIsLoaded } : {},
+      lastSeenUpdatedAtByTaskId:
+        mockActiveTaskId && mockLastSeen !== undefined ? { [mockActiveTaskId]: mockLastSeen } : {},
+    },
+    connection: { status: mockConnectionStatus },
+    setTaskPlan: mockSetTaskPlan,
+    setTaskPlanLoading: mockSetTaskPlanLoading,
+    markTaskPlanSeen: mockMarkTaskPlanSeen,
+  };
+}
+
 vi.mock("@/components/state-provider", () => ({
-  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({
-      tasks: { activeTaskId: mockActiveTaskId },
-      taskPlans: {
-        byTaskId: mockActiveTaskId && mockPlan ? { [mockActiveTaskId]: mockPlan } : {},
-        loadedByTaskId: mockActiveTaskId ? { [mockActiveTaskId]: mockIsLoaded } : {},
-        lastSeenUpdatedAtByTaskId:
-          mockActiveTaskId && mockLastSeen !== undefined
-            ? { [mockActiveTaskId]: mockLastSeen }
-            : {},
-      },
-      connection: { status: mockConnectionStatus },
-      setTaskPlan: mockSetTaskPlan,
-      setTaskPlanLoading: mockSetTaskPlanLoading,
-      markTaskPlanSeen: mockMarkTaskPlanSeen,
-    }),
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(buildState()),
+  useAppStoreApi: () => ({ getState: () => buildState() }),
 }));
 
 vi.mock("@/lib/state/dockview-store", () => ({
@@ -192,6 +194,24 @@ describe("usePlanPanelAutoOpen — eager fetch", () => {
     rerender();
     rerender();
     expect(mockGetTaskPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not overwrite a WS-delivered plan when the fetch resolves with null", async () => {
+    mockIsLoaded = false;
+    mockPlan = null;
+    let resolveFn: (v: TaskPlan | null) => void = () => {};
+    mockGetTaskPlan.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+    renderHook(() => usePlanPanelAutoOpen());
+    // Simulate a WS event populating the store while the HTTP fetch is in flight.
+    mockPlan = agentPlan();
+    resolveFn(null);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSetTaskPlan).not.toHaveBeenCalled();
   });
 
   it("retries the eager fetch after WS reconnects following a failure", async () => {

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -4,10 +4,17 @@ import type { TaskPlan } from "@/lib/types/http";
 
 const mockAddPlanPanel = vi.fn();
 const mockGetPanel = vi.fn();
+const mockSetTaskPlan = vi.fn();
+const mockSetTaskPlanLoading = vi.fn();
+const mockMarkTaskPlanSeen = vi.fn();
+const mockGetTaskPlan = vi.fn();
 
 let mockActiveTaskId: string | null = "task-1";
 let mockPlan: TaskPlan | null = null;
 let mockLastSeen: string | undefined = undefined;
+let mockIsLoaded = true;
+let mockIsLoading = false;
+let mockConnectionStatus = "connected";
 let mockIsRestoringLayout = false;
 let mockApi: { getPanel: typeof mockGetPanel } | null = { getPanel: mockGetPanel };
 
@@ -17,11 +24,17 @@ vi.mock("@/components/state-provider", () => ({
       tasks: { activeTaskId: mockActiveTaskId },
       taskPlans: {
         byTaskId: mockActiveTaskId && mockPlan ? { [mockActiveTaskId]: mockPlan } : {},
+        loadedByTaskId: mockActiveTaskId ? { [mockActiveTaskId]: mockIsLoaded } : {},
+        loadingByTaskId: mockActiveTaskId ? { [mockActiveTaskId]: mockIsLoading } : {},
         lastSeenUpdatedAtByTaskId:
           mockActiveTaskId && mockLastSeen !== undefined
             ? { [mockActiveTaskId]: mockLastSeen }
             : {},
       },
+      connection: { status: mockConnectionStatus },
+      setTaskPlan: mockSetTaskPlan,
+      setTaskPlanLoading: mockSetTaskPlanLoading,
+      markTaskPlanSeen: mockMarkTaskPlanSeen,
     }),
 }));
 
@@ -32,6 +45,10 @@ vi.mock("@/lib/state/dockview-store", () => ({
       isRestoringLayout: mockIsRestoringLayout,
       addPlanPanel: mockAddPlanPanel,
     }),
+}));
+
+vi.mock("@/lib/api/domains/plan-api", () => ({
+  getTaskPlan: (...args: unknown[]) => mockGetTaskPlan(...args),
 }));
 
 import { usePlanPanelAutoOpen } from "./use-plan-panel-auto-open";
@@ -57,9 +74,13 @@ describe("usePlanPanelAutoOpen", () => {
     mockActiveTaskId = "task-1";
     mockPlan = agentPlan();
     mockLastSeen = undefined;
+    mockIsLoaded = true;
+    mockIsLoading = false;
+    mockConnectionStatus = "connected";
     mockIsRestoringLayout = false;
     mockApi = { getPanel: mockGetPanel };
     mockGetPanel.mockReturnValue(null);
+    mockGetTaskPlan.mockResolvedValue(null);
   });
 
   it("opens plan panel for unseen agent plan", () => {
@@ -107,6 +128,38 @@ describe("usePlanPanelAutoOpen", () => {
   it("does not open when plan is null", () => {
     mockPlan = null;
     renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("eagerly fetches the plan when not yet loaded", () => {
+    mockIsLoaded = false;
+    mockPlan = null;
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockGetTaskPlan).toHaveBeenCalledWith("task-1");
+    expect(mockSetTaskPlanLoading).toHaveBeenCalledWith("task-1", true);
+  });
+
+  it("does not fetch when WS is disconnected", () => {
+    mockIsLoaded = false;
+    mockConnectionStatus = "connecting";
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockGetTaskPlan).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges the plan on hydrate when the panel was restored", () => {
+    mockGetPanel.mockReturnValue({ id: "plan" });
+    mockLastSeen = undefined;
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockMarkTaskPlanSeen).toHaveBeenCalledWith("task-1");
+    expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not acknowledge a live update when lastSeen is already recorded", () => {
+    mockGetPanel.mockReturnValue({ id: "plan" });
+    mockLastSeen = TS;
+    mockPlan = agentPlan(TS_LATER);
+    renderHook(() => usePlanPanelAutoOpen());
+    expect(mockMarkTaskPlanSeen).not.toHaveBeenCalled();
     expect(mockAddPlanPanel).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -196,6 +196,41 @@ describe("usePlanPanelAutoOpen — eager fetch", () => {
     expect(mockGetTaskPlan).toHaveBeenCalledTimes(1);
   });
 
+});
+
+describe("usePlanPanelAutoOpen — race guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveTaskId = "task-1";
+    mockPlan = agentPlan();
+    mockLastSeen = undefined;
+    mockIsLoaded = true;
+    mockConnectionStatus = "connected";
+    mockIsRestoringLayout = false;
+    mockApi = { getPanel: mockGetPanel };
+    mockGetPanel.mockReturnValue(null);
+    mockGetTaskPlan.mockResolvedValue(null);
+  });
+
+  it("does not overwrite a newer WS-delivered plan with an older HTTP result", async () => {
+    mockIsLoaded = false;
+    mockPlan = null;
+    let resolveFn: (v: TaskPlan | null) => void = () => {};
+    mockGetTaskPlan.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+    renderHook(() => usePlanPanelAutoOpen());
+    // WS delivers the latest plan while the HTTP fetch is in flight.
+    mockPlan = agentPlan(TS_LATER);
+    // HTTP resolves with an older snapshot of the same plan.
+    resolveFn(agentPlan(TS));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockSetTaskPlan).not.toHaveBeenCalled();
+  });
+
   it("does not overwrite a WS-delivered plan when the fetch resolves with null", async () => {
     mockIsLoaded = false;
     mockPlan = null;

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -178,4 +178,24 @@ describe("usePlanPanelAutoOpen", () => {
     rerender();
     expect(mockGetTaskPlan).toHaveBeenCalledTimes(1);
   });
+
+  it("retries the eager fetch after WS reconnects following a failure", async () => {
+    mockIsLoaded = false;
+    mockPlan = null;
+    mockGetTaskPlan.mockRejectedValueOnce(new Error("boom"));
+    mockGetTaskPlan.mockResolvedValueOnce(null);
+
+    const { rerender } = renderHook(() => usePlanPanelAutoOpen());
+    expect(mockGetTaskPlan).toHaveBeenCalledTimes(1);
+    await new Promise((r) => setTimeout(r, 0));
+
+    // WS disconnect — clears the attempted set
+    mockConnectionStatus = "connecting";
+    rerender();
+
+    // WS reconnect — fetches again
+    mockConnectionStatus = "connected";
+    rerender();
+    expect(mockGetTaskPlan).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -13,7 +13,6 @@ let mockActiveTaskId: string | null = "task-1";
 let mockPlan: TaskPlan | null = null;
 let mockLastSeen: string | undefined = undefined;
 let mockIsLoaded = true;
-let mockIsLoading = false;
 let mockConnectionStatus = "connected";
 let mockIsRestoringLayout = false;
 let mockApi: { getPanel: typeof mockGetPanel } | null = { getPanel: mockGetPanel };
@@ -25,7 +24,6 @@ vi.mock("@/components/state-provider", () => ({
       taskPlans: {
         byTaskId: mockActiveTaskId && mockPlan ? { [mockActiveTaskId]: mockPlan } : {},
         loadedByTaskId: mockActiveTaskId ? { [mockActiveTaskId]: mockIsLoaded } : {},
-        loadingByTaskId: mockActiveTaskId ? { [mockActiveTaskId]: mockIsLoading } : {},
         lastSeenUpdatedAtByTaskId:
           mockActiveTaskId && mockLastSeen !== undefined
             ? { [mockActiveTaskId]: mockLastSeen }
@@ -75,7 +73,6 @@ describe("usePlanPanelAutoOpen", () => {
     mockPlan = agentPlan();
     mockLastSeen = undefined;
     mockIsLoaded = true;
-    mockIsLoading = false;
     mockConnectionStatus = "connected";
     mockIsRestoringLayout = false;
     mockApi = { getPanel: mockGetPanel };
@@ -161,5 +158,24 @@ describe("usePlanPanelAutoOpen", () => {
     renderHook(() => usePlanPanelAutoOpen());
     expect(mockMarkTaskPlanSeen).not.toHaveBeenCalled();
     expect(mockAddPlanPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not retry the eager fetch after a failure", async () => {
+    mockIsLoaded = false;
+    mockPlan = null;
+    let rejectFn: (err: Error) => void = () => {};
+    mockGetTaskPlan.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectFn = reject;
+        }),
+    );
+    const { rerender } = renderHook(() => usePlanPanelAutoOpen());
+    expect(mockGetTaskPlan).toHaveBeenCalledTimes(1);
+    rejectFn(new Error("boom"));
+    await new Promise((r) => setTimeout(r, 0));
+    rerender();
+    rerender();
+    expect(mockGetTaskPlan).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -195,7 +195,6 @@ describe("usePlanPanelAutoOpen — eager fetch", () => {
     rerender();
     expect(mockGetTaskPlan).toHaveBeenCalledTimes(1);
   });
-
 });
 
 describe("usePlanPanelAutoOpen — race guards", () => {

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -74,10 +74,9 @@ export function usePlanPanelAutoOpen() {
       // recorded `lastSeen` (not persisted across sessions). We can't tell
       // whether the plan was acknowledged before reload or not, so we
       // optimistically mark it seen to avoid a stale indicator flash on
-      // every reload. A plan update arriving after reload will re-arm the
-      // indicator via the live-update path (lastSeen populated, panel
-      // exists → fall through to addPlanPanel which is idempotent for an
-      // existing panel and PlanTab re-renders the indicator).
+      // every reload. When a live update arrives after the reload,
+      // `lastSeen` is defined so we don't suppress it — PlanTab reads the
+      // store directly and re-arms the indicator.
       if (lastSeen === undefined) markTaskPlanSeen(plan.task_id);
       return;
     }

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -66,8 +66,8 @@ export function usePlanPanelAutoOpen() {
       .finally(() => setTaskPlanLoading(taskId, false));
   }, [activeTaskId, connectionStatus, isLoaded, setTaskPlan, setTaskPlanLoading, storeApi]);
 
-  // Drop the attempt mark when the WS reconnects so a transient failure can
-  // be retried after recovery.
+  // Clear the attempt set on WS disconnect so that when the WS reconnects
+  // the fetch effect can retry any tasks that previously failed or were pending.
   useEffect(() => {
     if (connectionStatus === "connected") return;
     attemptedRef.current.clear();

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -34,9 +34,8 @@ export function usePlanPanelAutoOpen() {
   const addPlanPanel = useDockviewStore((s) => s.addPlanPanel);
 
   // Track tasks we've already attempted to fetch so a transient failure
-  // doesn't put us in an infinite retry loop (the in-flight `loading` flag
-  // would otherwise re-trigger the effect via dep updates). Cleared per
-  // task only on successful navigation away.
+  // doesn't put us in an infinite retry loop. Cleared on WS disconnect so a
+  // reconnect can retry any failed or not-yet-attempted tasks.
   const attemptedRef = useRef<Set<string>>(new Set());
 
   // Eagerly fetch the plan on task load. The Plan panel mounts `useTaskPlan`
@@ -53,8 +52,8 @@ export function usePlanPanelAutoOpen() {
     getTaskPlan(taskId)
       .then((fetched) => setTaskPlan(taskId, fetched))
       .catch(() => {
-        /* swallow — `useTaskPlan` retries on panel mount and on the next
-         * WS reconnect via its own connectionStatus-keyed effect. */
+        /* swallow — the disconnect/reconnect effect clears `attemptedRef`
+         * so a transient failure retries automatically after recovery. */
       })
       .finally(() => setTaskPlanLoading(taskId, false));
   }, [activeTaskId, connectionStatus, isLoaded, setTaskPlan, setTaskPlanLoading]);
@@ -71,11 +70,14 @@ export function usePlanPanelAutoOpen() {
     if (!plan || plan.created_by !== "agent") return;
     if (lastSeen === plan.updated_at) return;
     if (api.getPanel("plan")) {
-      // Page-reload case: panel restored from saved layout AND we have no
-      // recorded `lastSeen` (cold hydrate). The plan was already acknowledged
-      // before the reload — mark seen so a stale indicator doesn't flash.
-      // Live updates keep `lastSeen` populated and re-arm normally.
-      // `activeTaskId` is non-null here because `plan` was derived from it.
+      // Page-reload case: panel restored from saved layout and there is no
+      // recorded `lastSeen` (not persisted across sessions). We can't tell
+      // whether the plan was acknowledged before reload or not, so we
+      // optimistically mark it seen to avoid a stale indicator flash on
+      // every reload. A plan update arriving after reload will re-arm the
+      // indicator via the live-update path (lastSeen populated, panel
+      // exists → fall through to addPlanPanel which is idempotent for an
+      // existing panel and PlanTab re-renders the indicator).
       if (lastSeen === undefined) markTaskPlanSeen(plan.task_id);
       return;
     }

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { getTaskPlan } from "@/lib/api/domains/plan-api";
 
@@ -29,6 +29,7 @@ export function usePlanPanelAutoOpen() {
   const setTaskPlanLoading = useAppStore((s) => s.setTaskPlanLoading);
   const markTaskPlanSeen = useAppStore((s) => s.markTaskPlanSeen);
   const connectionStatus = useAppStore((s) => s.connection.status);
+  const storeApi = useAppStoreApi();
   const api = useDockviewStore((s) => s.api);
   const isRestoringLayout = useDockviewStore((s) => s.isRestoringLayout);
   const addPlanPanel = useDockviewStore((s) => s.addPlanPanel);
@@ -50,13 +51,20 @@ export function usePlanPanelAutoOpen() {
     attemptedRef.current.add(taskId);
     setTaskPlanLoading(taskId, true);
     getTaskPlan(taskId)
-      .then((fetched) => setTaskPlan(taskId, fetched))
+      .then((fetched) => {
+        // Race guard: if a WS event populated the store while our HTTP
+        // request was in flight, don't overwrite a real plan with a
+        // stale `null` (server didn't have it yet at fetch time).
+        const live = storeApi.getState().taskPlans.byTaskId[taskId];
+        if (fetched === null && live) return;
+        setTaskPlan(taskId, fetched);
+      })
       .catch(() => {
         /* swallow — the disconnect/reconnect effect clears `attemptedRef`
          * so a transient failure retries automatically after recovery. */
       })
       .finally(() => setTaskPlanLoading(taskId, false));
-  }, [activeTaskId, connectionStatus, isLoaded, setTaskPlan, setTaskPlanLoading]);
+  }, [activeTaskId, connectionStatus, isLoaded, setTaskPlan, setTaskPlanLoading, storeApi]);
 
   // Drop the attempt mark when the WS reconnects so a transient failure can
   // be retried after recovery.

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -57,13 +57,12 @@ export function usePlanPanelAutoOpen() {
     if (!api || isRestoringLayout) return;
     if (!plan || plan.created_by !== "agent") return;
     if (lastSeen === plan.updated_at) return;
-    // Page-reload case: panel restored from saved layout AND we have no
-    // recorded `lastSeen` for this task (cold hydrate). The plan was already
-    // acknowledged before the reload — mark seen so the stale-indicator
-    // doesn't flash. Live updates keep `lastSeen` populated and re-arm
-    // normally.
-    if (api.getPanel("plan") && lastSeen === undefined) {
-      if (activeTaskId) markTaskPlanSeen(activeTaskId);
+    if (api.getPanel("plan")) {
+      // Page-reload case: panel restored from saved layout AND we have no
+      // recorded `lastSeen` (cold hydrate). The plan was already acknowledged
+      // before the reload — mark seen so a stale indicator doesn't flash.
+      // Live updates keep `lastSeen` populated and re-arm normally.
+      if (lastSeen === undefined && activeTaskId) markTaskPlanSeen(activeTaskId);
       return;
     }
 

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAppStore } from "@/components/state-provider";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { getTaskPlan } from "@/lib/api/domains/plan-api";
@@ -22,9 +22,6 @@ export function usePlanPanelAutoOpen() {
   const isLoaded = useAppStore((s) =>
     activeTaskId ? (s.taskPlans.loadedByTaskId[activeTaskId] ?? false) : false,
   );
-  const isLoading = useAppStore((s) =>
-    activeTaskId ? (s.taskPlans.loadingByTaskId[activeTaskId] ?? false) : false,
-  );
   const lastSeen = useAppStore((s) =>
     activeTaskId ? s.taskPlans.lastSeenUpdatedAtByTaskId[activeTaskId] : undefined,
   );
@@ -36,22 +33,38 @@ export function usePlanPanelAutoOpen() {
   const isRestoringLayout = useDockviewStore((s) => s.isRestoringLayout);
   const addPlanPanel = useDockviewStore((s) => s.addPlanPanel);
 
+  // Track tasks we've already attempted to fetch so a transient failure
+  // doesn't put us in an infinite retry loop (the in-flight `loading` flag
+  // would otherwise re-trigger the effect via dep updates). Cleared per
+  // task only on successful navigation away.
+  const attemptedRef = useRef<Set<string>>(new Set());
+
   // Eagerly fetch the plan on task load. The Plan panel mounts `useTaskPlan`
   // only after the panel exists, so without this fetch a plan written by the
   // agent before the browser's WS connected (fast auto-start path) would never
   // populate the store and the auto-open below would never fire.
   useEffect(() => {
     if (!activeTaskId || connectionStatus !== "connected") return;
-    if (isLoaded || isLoading) return;
+    if (isLoaded) return;
+    if (attemptedRef.current.has(activeTaskId)) return;
     const taskId = activeTaskId;
+    attemptedRef.current.add(taskId);
     setTaskPlanLoading(taskId, true);
     getTaskPlan(taskId)
       .then((fetched) => setTaskPlan(taskId, fetched))
       .catch(() => {
-        /* swallow — useTaskPlan will retry once the panel mounts */
+        /* swallow — `useTaskPlan` retries on panel mount and on the next
+         * WS reconnect via its own connectionStatus-keyed effect. */
       })
       .finally(() => setTaskPlanLoading(taskId, false));
-  }, [activeTaskId, connectionStatus, isLoaded, isLoading, setTaskPlan, setTaskPlanLoading]);
+  }, [activeTaskId, connectionStatus, isLoaded, setTaskPlan, setTaskPlanLoading]);
+
+  // Drop the attempt mark when the WS reconnects so a transient failure can
+  // be retried after recovery.
+  useEffect(() => {
+    if (connectionStatus === "connected") return;
+    attemptedRef.current.clear();
+  }, [connectionStatus]);
 
   useEffect(() => {
     if (!api || isRestoringLayout) return;
@@ -62,10 +75,11 @@ export function usePlanPanelAutoOpen() {
       // recorded `lastSeen` (cold hydrate). The plan was already acknowledged
       // before the reload — mark seen so a stale indicator doesn't flash.
       // Live updates keep `lastSeen` populated and re-arm normally.
-      if (lastSeen === undefined && activeTaskId) markTaskPlanSeen(activeTaskId);
+      // `activeTaskId` is non-null here because `plan` was derived from it.
+      if (lastSeen === undefined) markTaskPlanSeen(plan.task_id);
       return;
     }
 
     addPlanPanel({ quiet: true, inCenter: true });
-  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel, activeTaskId, markTaskPlanSeen]);
+  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel, markTaskPlanSeen]);
 }

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -54,9 +54,14 @@ export function usePlanPanelAutoOpen() {
       .then((fetched) => {
         // Race guard: if a WS event populated the store while our HTTP
         // request was in flight, don't overwrite a real plan with a
-        // stale `null` (server didn't have it yet at fetch time).
+        // stale response — neither a `null` (server didn't have it yet
+        // at fetch time) nor an older non-null version (HTTP saw an
+        // earlier write than the WS event we already applied).
         const live = storeApi.getState().taskPlans.byTaskId[taskId];
-        if (fetched === null && live) return;
+        if (live) {
+          if (fetched === null) return;
+          if (Date.parse(fetched.updated_at) < Date.parse(live.updated_at)) return;
+        }
         setTaskPlan(taskId, fetched);
       })
       .catch(() => {

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useAppStore } from "@/components/state-provider";
 import { useDockviewStore } from "@/lib/state/dockview-store";
+import { getTaskPlan } from "@/lib/api/domains/plan-api";
 
 /**
  * Watches the active task's plan and opens the Plan panel quietly (without
@@ -18,19 +19,54 @@ import { useDockviewStore } from "@/lib/state/dockview-store";
 export function usePlanPanelAutoOpen() {
   const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
   const plan = useAppStore((s) => (activeTaskId ? s.taskPlans.byTaskId[activeTaskId] : null));
+  const isLoaded = useAppStore((s) =>
+    activeTaskId ? (s.taskPlans.loadedByTaskId[activeTaskId] ?? false) : false,
+  );
+  const isLoading = useAppStore((s) =>
+    activeTaskId ? (s.taskPlans.loadingByTaskId[activeTaskId] ?? false) : false,
+  );
   const lastSeen = useAppStore((s) =>
     activeTaskId ? s.taskPlans.lastSeenUpdatedAtByTaskId[activeTaskId] : undefined,
   );
+  const setTaskPlan = useAppStore((s) => s.setTaskPlan);
+  const setTaskPlanLoading = useAppStore((s) => s.setTaskPlanLoading);
+  const markTaskPlanSeen = useAppStore((s) => s.markTaskPlanSeen);
+  const connectionStatus = useAppStore((s) => s.connection.status);
   const api = useDockviewStore((s) => s.api);
   const isRestoringLayout = useDockviewStore((s) => s.isRestoringLayout);
   const addPlanPanel = useDockviewStore((s) => s.addPlanPanel);
+
+  // Eagerly fetch the plan on task load. The Plan panel mounts `useTaskPlan`
+  // only after the panel exists, so without this fetch a plan written by the
+  // agent before the browser's WS connected (fast auto-start path) would never
+  // populate the store and the auto-open below would never fire.
+  useEffect(() => {
+    if (!activeTaskId || connectionStatus !== "connected") return;
+    if (isLoaded || isLoading) return;
+    const taskId = activeTaskId;
+    setTaskPlanLoading(taskId, true);
+    getTaskPlan(taskId)
+      .then((fetched) => setTaskPlan(taskId, fetched))
+      .catch(() => {
+        /* swallow — useTaskPlan will retry once the panel mounts */
+      })
+      .finally(() => setTaskPlanLoading(taskId, false));
+  }, [activeTaskId, connectionStatus, isLoaded, isLoading, setTaskPlan, setTaskPlanLoading]);
 
   useEffect(() => {
     if (!api || isRestoringLayout) return;
     if (!plan || plan.created_by !== "agent") return;
     if (lastSeen === plan.updated_at) return;
-    if (api.getPanel("plan")) return;
+    // Page-reload case: panel restored from saved layout AND we have no
+    // recorded `lastSeen` for this task (cold hydrate). The plan was already
+    // acknowledged before the reload — mark seen so the stale-indicator
+    // doesn't flash. Live updates keep `lastSeen` populated and re-arm
+    // normally.
+    if (api.getPanel("plan") && lastSeen === undefined) {
+      if (activeTaskId) markTaskPlanSeen(activeTaskId);
+      return;
+    }
 
     addPlanPanel({ quiet: true, inCenter: true });
-  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel]);
+  }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel, activeTaskId, markTaskPlanSeen]);
 }


### PR DESCRIPTION
Agent auto-start can fire `task_plan.created` within ~100 ms of task creation — faster than the browser opens its WS — so the broadcast hits zero clients and the Plan tab never appears (`useTaskPlan` only fetches once the panel is mounted). Eagerly fetch the plan from `usePlanPanelAutoOpen` once the WS is connected, and on page-reload hydrate (panel restored from saved layout, no `lastSeen` recorded) acknowledge the plan to avoid a stale indicator flash.

## Validation

- 3× back-to-back local runs of `e2e/tests/layout/plan-panel-indicator.spec.ts` with `--retries=0`: 12/12 passing (was 0/4 before fix).
- CI-mode local run of plan-panel-indicator + pr-detail-auto-show specs combined: 8/8 passing.
- Repro confirmed by backend logs: agent emits `task_plan.created` event ~430 ms before browser WS connects.

## Possible Improvements

Low risk. Worst case the eager fetch races with the WS event and double-sets the same plan (idempotent `setTaskPlan`).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.