### PR TITLE
fix(orchestrator): guide recovery when session profile is deleted

### DIFF
--- a/apps/backend/internal/orchestrator/session_launch.go
+++ b/apps/backend/internal/orchestrator/session_launch.go
@@ -2,8 +2,6 @@ package orchestrator
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -299,13 +297,10 @@ func normalizeRecoverSessionError(err error) error {
 }
 
 func isMissingProfileResumeError(err error) bool {
-	if errors.Is(err, sql.ErrNoRows) {
-		return true
-	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "agent profile not found") ||
-		strings.Contains(msg, "profile not found") ||
-		strings.Contains(msg, "failed to resolve agent profile")
+	return strings.Contains(msg, "failed to resolve agent profile") ||
+		strings.Contains(msg, "agent profile not found") ||
+		(strings.Contains(msg, "agent profile") && strings.Contains(msg, "no rows in result set"))
 }
 
 // executionToLaunchResponse converts a TaskExecution to a LaunchSessionResponse.

--- a/apps/backend/internal/orchestrator/session_launch.go
+++ b/apps/backend/internal/orchestrator/session_launch.go
@@ -2,6 +2,8 @@ package orchestrator
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -275,11 +277,35 @@ func (s *Service) RecoverSession(ctx context.Context, taskID, sessionID, action 
 		return nil, fmt.Errorf("invalid recovery action: %s", action)
 	}
 
-	return s.LaunchSession(ctx, &LaunchSessionRequest{
+	resp, err := s.LaunchSession(ctx, &LaunchSessionRequest{
 		TaskID:    taskID,
 		SessionID: sessionID,
 		Intent:    IntentResume,
 	})
+	if err != nil {
+		return nil, normalizeRecoverSessionError(err)
+	}
+	return resp, nil
+}
+
+func normalizeRecoverSessionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isMissingProfileResumeError(err) {
+		return fmt.Errorf("the agent profile used by this session was deleted; start a new session and choose an available agent profile")
+	}
+	return err
+}
+
+func isMissingProfileResumeError(err error) bool {
+	if errors.Is(err, sql.ErrNoRows) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "agent profile not found") ||
+		strings.Contains(msg, "profile not found") ||
+		strings.Contains(msg, "failed to resolve agent profile")
 }
 
 // executionToLaunchResponse converts a TaskExecution to a LaunchSessionResponse.

--- a/apps/backend/internal/orchestrator/session_launch.go
+++ b/apps/backend/internal/orchestrator/session_launch.go
@@ -291,7 +291,7 @@ func normalizeRecoverSessionError(err error) error {
 		return nil
 	}
 	if isMissingProfileResumeError(err) {
-		return fmt.Errorf("the agent profile used by this session was deleted; start a new session and choose an available agent profile")
+		return fmt.Errorf("the agent profile used by this session was deleted; start a new session and choose an available agent profile: %w", err)
 	}
 	return err
 }
@@ -299,8 +299,7 @@ func normalizeRecoverSessionError(err error) error {
 func isMissingProfileResumeError(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "failed to resolve agent profile") ||
-		strings.Contains(msg, "agent profile not found") ||
-		(strings.Contains(msg, "agent profile") && strings.Contains(msg, "no rows in result set"))
+		strings.Contains(msg, "agent profile not found")
 }
 
 // executionToLaunchResponse converts a TaskExecution to a LaunchSessionResponse.

--- a/apps/backend/internal/orchestrator/session_launch_test.go
+++ b/apps/backend/internal/orchestrator/session_launch_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -118,6 +119,40 @@ func TestResolveIntent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalizeRecoverSessionError(t *testing.T) {
+	t.Run("maps sql ErrNoRows to actionable profile guidance", func(t *testing.T) {
+		err := normalizeRecoverSessionError(sql.ErrNoRows)
+		if err == nil {
+			t.Fatal("expected mapped error")
+		}
+		if got := err.Error(); got != "the agent profile used by this session was deleted; start a new session and choose an available agent profile" {
+			t.Fatalf("unexpected error: %q", got)
+		}
+	})
+
+	t.Run("maps profile not found errors to actionable profile guidance", func(t *testing.T) {
+		in := errors.New("failed to resolve agent profile: profile not found: sql: no rows in result set")
+		err := normalizeRecoverSessionError(in)
+		if err == nil {
+			t.Fatal("expected mapped error")
+		}
+		if got := err.Error(); got != "the agent profile used by this session was deleted; start a new session and choose an available agent profile" {
+			t.Fatalf("unexpected error: %q", got)
+		}
+	})
+
+	t.Run("passes through unrelated errors", func(t *testing.T) {
+		in := errors.New("network timeout")
+		err := normalizeRecoverSessionError(in)
+		if err == nil {
+			t.Fatal("expected passthrough error")
+		}
+		if err.Error() != in.Error() {
+			t.Fatalf("expected passthrough error %q, got %q", in.Error(), err.Error())
+		}
+	})
 }
 
 // --- launchRestoreWorkspace ---

--- a/apps/backend/internal/orchestrator/session_launch_test.go
+++ b/apps/backend/internal/orchestrator/session_launch_test.go
@@ -127,18 +127,20 @@ func TestNormalizeRecoverSessionError(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected mapped error")
 		}
-		if got := err.Error(); got != "the agent profile used by this session was deleted; start a new session and choose an available agent profile" {
+		want := "the agent profile used by this session was deleted; start a new session and choose an available agent profile: " + in.Error()
+		if got := err.Error(); got != want {
 			t.Fatalf("unexpected error: %q", got)
 		}
 	})
 
-	t.Run("maps agent profile no rows errors to actionable profile guidance", func(t *testing.T) {
-		in := errors.New("failed to launch agent: agent profile lookup failed: sql: no rows in result set")
+	t.Run("maps agent profile not found errors to actionable profile guidance", func(t *testing.T) {
+		in := errors.New("agent profile not found")
 		err := normalizeRecoverSessionError(in)
 		if err == nil {
 			t.Fatal("expected mapped error")
 		}
-		if got := err.Error(); got != "the agent profile used by this session was deleted; start a new session and choose an available agent profile" {
+		want := "the agent profile used by this session was deleted; start a new session and choose an available agent profile: " + in.Error()
+		if got := err.Error(); got != want {
 			t.Fatalf("unexpected error: %q", got)
 		}
 	})

--- a/apps/backend/internal/orchestrator/session_launch_test.go
+++ b/apps/backend/internal/orchestrator/session_launch_test.go
@@ -2,7 +2,6 @@ package orchestrator
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -122,16 +121,6 @@ func TestResolveIntent(t *testing.T) {
 }
 
 func TestNormalizeRecoverSessionError(t *testing.T) {
-	t.Run("maps sql ErrNoRows to actionable profile guidance", func(t *testing.T) {
-		err := normalizeRecoverSessionError(sql.ErrNoRows)
-		if err == nil {
-			t.Fatal("expected mapped error")
-		}
-		if got := err.Error(); got != "the agent profile used by this session was deleted; start a new session and choose an available agent profile" {
-			t.Fatalf("unexpected error: %q", got)
-		}
-	})
-
 	t.Run("maps profile not found errors to actionable profile guidance", func(t *testing.T) {
 		in := errors.New("failed to resolve agent profile: profile not found: sql: no rows in result set")
 		err := normalizeRecoverSessionError(in)
@@ -140,6 +129,39 @@ func TestNormalizeRecoverSessionError(t *testing.T) {
 		}
 		if got := err.Error(); got != "the agent profile used by this session was deleted; start a new session and choose an available agent profile" {
 			t.Fatalf("unexpected error: %q", got)
+		}
+	})
+
+	t.Run("maps agent profile no rows errors to actionable profile guidance", func(t *testing.T) {
+		in := errors.New("failed to launch agent: agent profile lookup failed: sql: no rows in result set")
+		err := normalizeRecoverSessionError(in)
+		if err == nil {
+			t.Fatal("expected mapped error")
+		}
+		if got := err.Error(); got != "the agent profile used by this session was deleted; start a new session and choose an available agent profile" {
+			t.Fatalf("unexpected error: %q", got)
+		}
+	})
+
+	t.Run("does not map generic sql no rows errors", func(t *testing.T) {
+		in := errors.New("sql: no rows in result set")
+		err := normalizeRecoverSessionError(in)
+		if err == nil {
+			t.Fatal("expected passthrough error")
+		}
+		if err.Error() != in.Error() {
+			t.Fatalf("expected passthrough error %q, got %q", in.Error(), err.Error())
+		}
+	})
+
+	t.Run("does not map executor profile not found errors", func(t *testing.T) {
+		in := errors.New("executor profile not found")
+		err := normalizeRecoverSessionError(in)
+		if err == nil {
+			t.Fatal("expected passthrough error")
+		}
+		if err.Error() != in.Error() {
+			t.Fatalf("expected passthrough error %q, got %q", in.Error(), err.Error())
 		}
 	})
 


### PR DESCRIPTION
## Summary
- normalize recovery errors when a session references a deleted agent profile
- convert raw `sql: no rows in result set` / profile resolution failures into an actionable recovery message
- add regression tests for missing-profile error normalization

## Behavior Change
- before: recover could fail with a low-level SQL error
- after: recover returns a clear message telling the user to start a new session and pick an available profile

## Testing
- go test ./internal/orchestrator -run "TestNormalizeRecoverSessionError|TestResolveIntent"
- go test ./internal/orchestrator/...