### PR TITLE
docs: add star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,13 @@ Built with these excellent open-source projects:
 ## License
 
 [AGPL-3.0](LICENSE)
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=kdlbs%2Fkandev&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=kdlbs/kandev&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
README readers should be able to see repository growth without leaving project docs. The README now ends with a Star History chart that supports light and dark themes.

## Validation

- `make -C apps/backend fmt`
- `pnpm format`
- `pnpm --filter @kandev/web prebuild`
- `pnpm --filter @kandev/web exec tsc --noEmit`
- `pnpm --filter @kandev/web lint`
- `make -C apps/backend test lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-753-bwo7.sprites.app |
| **Commit** | `0f102e8` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->