### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,219 @@
+name: Bug report
+description: Report a reproducible problem in Kandev.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Good reports let maintainers reproduce the failure quickly.
+
+        Before posting, remove secrets, tokens, private repository URLs, private prompts, and customer data from logs or screenshots.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What broke? Keep it short and concrete.
+      placeholder: Starting a Codex task in a Docker executor fails after the agent profile is selected.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      description: Pick the closest area.
+      options:
+        - Web UI
+        - Backend API
+        - WebSocket/session streaming
+        - Agent lifecycle
+        - agentctl
+        - Executor/runtime
+        - Git/worktree operations
+        - GitHub integration
+        - Workflow/queue
+        - CLI
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Kandev version
+      description: Use the release version, commit SHA, or Docker image tag/digest.
+      placeholder: v0.4.2, 9f2c1ab, or ghcr.io/kdlbs/kandev@sha256:...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-mode
+    attributes:
+      label: Install mode
+      options:
+        - Docker Compose
+        - Docker run
+        - Kubernetes
+        - Local development
+        - Source build
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include host OS, architecture, browser, Docker/Kubernetes versions, and anything unusual about the runtime.
+      placeholder: |
+        - OS: macOS 15.4 / Ubuntu 24.04 / Windows 11 + WSL2
+        - Architecture: arm64 / amd64
+        - Browser: Chrome 124 / Firefox 125 / Safari 17
+        - Docker: 26.1.0
+        - Kubernetes: v1.30.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: kandev-config
+    attributes:
+      label: Kandev configuration
+      description: Paste relevant sanitized Kandev config. Use "N/A" if no config changes.
+      placeholder: |
+        - Executor type/profile: name shown in Kandev settings
+        - Agent profile: Codex / Claude Code / OpenCode / Amp / Copilot
+        - Model/provider: gpt-5.4 / claude-... / other
+        - Repository source: local path / GitHub clone / remote executor clone
+        - Relevant KANDEV_* env vars:
+          KANDEV_HOME_DIR=/data
+          KANDEV_WORKTREE_BASEPATH=/data/worktrees
+    validations:
+      required: true
+
+  - type: textarea
+    id: task-session
+    attributes:
+      label: Task/session context
+      description: Include IDs and workflow context if the bug happens inside a task. Use "N/A" if not task-specific.
+      placeholder: |
+        - Workspace ID:
+        - Workflow/step:
+        - Task ID:
+        - Session ID:
+        - Branch/worktree:
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List exact clicks, commands, config, and inputs needed to trigger the bug.
+      placeholder: |
+        1. Start Kandev with ...
+        2. Create workspace ...
+        3. Select executor ...
+        4. Start task ...
+        5. Observe ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: reproducibility
+    attributes:
+      label: Reproducibility
+      description: How often can you reproduce this with the steps above?
+      options:
+        - Always
+        - Often
+        - Sometimes
+        - Once
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: clean-state
+    attributes:
+      label: Clean-state check
+      description: Did you try with a fresh Kandev data directory, workspace, or browser session?
+      options:
+        - Reproduces on clean state
+        - Does not reproduce on clean state
+        - Not tried
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The task starts and agent output streams to the session panel.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: The task stays queued and backend logs show ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and artifacts
+      description: Paste relevant sanitized logs, screenshots, HAR files, or recordings. Use "No logs observed" if none exist.
+      placeholder: |
+        Backend:
+        ```text
+        ...
+        ```
+
+        Browser console:
+        ```text
+        ...
+        ```
+
+        Container/pod:
+        ```text
+        docker logs kandev
+        kubectl logs -l app=kandev
+        ```
+
+        Agent/session:
+        ```text
+        ...
+        ```
+    validations:
+      required: true
+
+  - type: input
+    id: regression
+    attributes:
+      label: Last known good version
+      description: If this used to work, provide the version, commit, date, or image tag.
+      placeholder: v0.4.1, commit abc123, or "unknown"
+
+  - type: textarea
+    id: extra-context
+    attributes:
+      label: Extra context
+      description: Add links to minimal reproduction repositories, related issues, or notes that help isolate the failure.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Before submitting
+      options:
+        - label: I can reproduce this using the steps above.
+          required: true
+        - label: I removed secrets, tokens, private repository URLs, private prompts, and customer data.
+          required: true
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Kandev documentation
+    url: https://github.com/kdlbs/kandev/tree/main/docs
+    about: Read setup, Docker, Kubernetes, workflow, and API documentation.
+  - name: Security issue
+    url: https://github.com/kdlbs/kandev/security/advisories/new
+    about: Report vulnerabilities privately instead of opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,118 @@
+name: Feature request
+description: Propose a Kandev improvement with clear user value.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for product changes, workflow improvements, and new integrations.
+
+        If something is broken or regressed, open a bug report instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user workflow is blocked or painful today?
+      placeholder: When several agents run in parallel, it is hard to tell which task owns each worktree.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior you want. Focus on outcome, not only implementation.
+      placeholder: Show the active worktree and branch next to each session, with a quick link to git status.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      description: Pick the closest area.
+      options:
+        - Web UI
+        - Backend API
+        - WebSocket/session streaming
+        - Agent lifecycle
+        - agentctl
+        - Executor/runtime
+        - Git/worktree operations
+        - GitHub integration
+        - Workflow/queue
+        - CLI
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: user-type
+    attributes:
+      label: Who needs this?
+      options:
+        - Individual developer
+        - Team using shared Kandev instance
+        - Maintainer/operator
+        - Integration/plugin author
+        - Enterprise/admin user
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Target workflow
+      description: Show where this fits in Kandev. Include executor, agent profile, workflow step, or integration details when relevant.
+      placeholder: |
+        1. User creates task from the kanban board.
+        2. User chooses an executor and agent profile.
+        3. User needs to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workaround exists today? What other designs did you consider?
+      placeholder: Today users inspect git status from the terminal, but this loses task/session context.
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true for this feature to be complete?
+      placeholder: |
+        - Users can see ...
+        - Users can do ...
+        - Existing behavior remains ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and constraints
+      description: Include security, privacy, performance, compatibility, or migration concerns.
+      placeholder: Do not expose secret env vars from executor config. Must work across relevant executor runtimes.
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link related issues, discussions, specs, mockups, or comparable open-source behavior.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked existing issues and did not find this request already tracked.
+          required: true
+        - label: This request describes user value, not only an implementation detail.
+          required: true


### PR DESCRIPTION
Open-source issue reports need enough context to reproduce failures without repeated maintainer follow-up. Adds focused bug and feature request forms that collect Kandev-specific context while avoiding executor-specific option churn.

## Validation

- `python3 -c 'import yaml, sys; [yaml.safe_load(open(f, encoding="utf-8")) for f in sys.argv[1:]]; print("ok")' .github/ISSUE_TEMPLATE/*.yml`
- `make -C apps/backend fmt`
- `pnpm format`
- App test suites not run; GitHub metadata only.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.