### PR TITLE
fix: refine workbench action button layout

### DIFF
--- a/apps/web/app/dockview-theme.css
+++ b/apps/web/app/dockview-theme.css
@@ -179,7 +179,6 @@
 
 .dockview-theme-kandev .dv-left-actions-container button,
 .dockview-theme-kandev .dv-right-actions-container button {
-  border-radius: 5px;
   cursor: pointer;
 }
 

--- a/apps/web/components/kanban/kanban-header.tsx
+++ b/apps/web/components/kanban/kanban-header.tsx
@@ -190,8 +190,8 @@ function HomeLeftActions({ workspaceId }: { workspaceId?: string }) {
           Stats
         </Link>
       </Button>
-      <IntegrationsMenu workspaceId={workspaceId} />
       <ImproveKandevTopbarButton workspaceId={workspaceId} />
+      <IntegrationsMenu workspaceId={workspaceId} />
     </>
   );
 }
@@ -199,8 +199,8 @@ function HomeLeftActions({ workspaceId }: { workspaceId?: string }) {
 function WorkspaceLeftActions({ workspaceId }: { workspaceId?: string }) {
   return (
     <>
-      <IntegrationsMenu workspaceId={workspaceId} />
       <ImproveKandevTopbarButton workspaceId={workspaceId} />
+      <IntegrationsMenu workspaceId={workspaceId} />
     </>
   );
 }

--- a/apps/web/components/task/dockview-group-actions.tsx
+++ b/apps/web/components/task/dockview-group-actions.tsx
@@ -19,7 +19,7 @@ import {
 } from "@kandev/ui/dropdown-menu";
 
 const ACTION_BTN =
-  "h-5 w-5 inline-flex items-center justify-center text-muted-foreground/50 hover:text-foreground transition-colors cursor-pointer";
+  "h-5 w-5 inline-flex items-center justify-center rounded-[5px] text-muted-foreground/50 hover:text-foreground transition-colors cursor-pointer";
 
 /** Width thresholds for collapsing split/close into a dropdown. Hysteresis avoids toggle flicker. */
 const COLLAPSE_WIDTH = 320;

--- a/apps/web/components/task/new-task-dropdown.tsx
+++ b/apps/web/components/task/new-task-dropdown.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { IconPlus, IconSubtask, IconChevronDown } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
+import { ButtonGroup } from "@kandev/ui/button-group";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -39,12 +40,13 @@ export function NewTaskDropdown({
 
   return (
     <>
-      <div className="flex items-center">
+      <ButtonGroup>
         <Button
           size="sm"
           variant="outline"
-          className={`h-6 gap-1 cursor-pointer ${activeTaskId ? "rounded-r-none border-r-0" : ""}`}
+          className="h-6 gap-1 cursor-pointer"
           onClick={() => setShowTaskDialog(true)}
+          data-testid="new-task-primary"
         >
           <IconPlus className="h-3.5 w-3.5" />
           Task
@@ -55,7 +57,7 @@ export function NewTaskDropdown({
               <Button
                 size="sm"
                 variant="outline"
-                className="-ml-px h-6 rounded-l-none px-1 cursor-pointer"
+                className="h-6 px-1 cursor-pointer"
                 data-testid="new-task-chevron"
               >
                 <IconChevronDown className="h-3 w-3" />
@@ -73,7 +75,7 @@ export function NewTaskDropdown({
             </DropdownMenuContent>
           </DropdownMenu>
         )}
-      </div>
+      </ButtonGroup>
       <TaskCreateDialog
         open={showTaskDialog}
         onOpenChange={setShowTaskDialog}

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -70,8 +70,14 @@ test.describe("Subtask basics", () => {
     await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
 
     // Open the Task split-button chevron and click "New Subtask"
+    const primary = testPage.getByTestId("new-task-primary");
     const chevron = testPage.getByTestId("new-task-chevron");
+    await expect(primary).toBeVisible({ timeout: 5_000 });
     await expect(chevron).toBeVisible({ timeout: 5_000 });
+    await expect(primary).toHaveCSS("border-top-right-radius", "0px");
+    await expect(primary).toHaveCSS("border-bottom-right-radius", "0px");
+    await expect(chevron).toHaveCSS("border-top-left-radius", "0px");
+    await expect(chevron).toHaveCSS("border-bottom-left-radius", "0px");
     await chevron.click();
     await testPage.getByTestId("new-subtask-button").click();
 


### PR DESCRIPTION
Workbench action chrome had two small ordering and shape issues that made common controls feel inconsistent. The task split button now renders as one flush control in dockview, and the kanban topbar places Improve Kandev before integrations.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm --filter @kandev/web exec playwright test --config e2e/playwright.config.ts tests/task/subtask.spec.ts --project=chromium -g "create subtask from sidebar header button"`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.