### PR TITLE
fix(web): make mermaid sanitizer quote-aware and detect parens in bracket labels

### DIFF
--- a/apps/web/components/shared/mermaid-utils.test.ts
+++ b/apps/web/components/shared/mermaid-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeMermaidCode } from "./mermaid-utils";
+
+describe("sanitizeMermaidCode", () => {
+  it("leaves a pre-quoted bracket label with parens inside untouched", () => {
+    const input = `D --> E["router.push('/github')"]`;
+    expect(sanitizeMermaidCode(input)).toBe(input);
+  });
+
+  it("quotes a bracket label containing slashes alongside a pre-quoted neighbour", () => {
+    const input = `A[plain] --> B[Types 'github' / 'pr' / 'dashboard']\nD --> E["router.push('/github')"]`;
+    const out = sanitizeMermaidCode(input);
+    expect(out).toContain(`B["Types 'github' / 'pr' / 'dashboard'"]`);
+    expect(out).toContain(`E["router.push('/github')"]`);
+  });
+
+  it("leaves an init directive with single quotes untouched", () => {
+    const input = `%%{init: {'theme': 'neutral'}}%%`;
+    expect(sanitizeMermaidCode(input)).toBe(input);
+  });
+
+  it("quotes a bracket label containing parens", () => {
+    const input = `Action[reorderSidebarViews(activeId, overId)]`;
+    expect(sanitizeMermaidCode(input)).toBe(`Action["reorderSidebarViews(activeId, overId)"]`);
+  });
+
+  it("quotes a bracket label containing arrow `->`", () => {
+    const input = `SSR[fetchUserSettings -> mapUserSettingsResponse]`;
+    expect(sanitizeMermaidCode(input)).toBe(`SSR["fetchUserSettings -> mapUserSettingsResponse"]`);
+  });
+
+  it("quotes a standalone stadium node containing `/`", () => {
+    const input = `X(/api/v1)`;
+    expect(sanitizeMermaidCode(input)).toBe(`X("/api/v1")`);
+  });
+
+  it("quotes an edge label containing `/`", () => {
+    const input = `A -->|/path/to/x| B`;
+    expect(sanitizeMermaidCode(input)).toBe(`A -->|"/path/to/x"| B`);
+  });
+
+  it("leaves a plain stadium node alone", () => {
+    const input = `Y(plain text)`;
+    expect(sanitizeMermaidCode(input)).toBe(input);
+  });
+
+  it("does not corrupt parens inside a bracket label after the bracket pass quotes it", () => {
+    // Pass 1 wraps `[fetch(/api/x)]` -> `["fetch(/api/x)"]`. Pass 3 must skip the
+    // newly-quoted region rather than re-wrapping `(/api/x)` and producing nested quotes.
+    const input = `Z[fetch(/api/x)]`;
+    expect(sanitizeMermaidCode(input)).toBe(`Z["fetch(/api/x)"]`);
+  });
+
+  it("renders the full reported case 1 diagram without nested quotes", () => {
+    const input = [
+      `%%{init: {'theme': 'neutral'}}%%`,
+      `flowchart TD`,
+      `    A[User opens Cmd+K panel] --> B[Types 'github' / 'pr' / 'dashboard']`,
+      `    D --> E["router.push('/github')"]`,
+    ].join("\n");
+    const out = sanitizeMermaidCode(input);
+    expect(out).not.toContain(`("'`);
+    expect(out).toContain(`E["router.push('/github')"]`);
+    expect(out).toContain(`B["Types 'github' / 'pr' / 'dashboard'"]`);
+  });
+});

--- a/apps/web/components/shared/mermaid-utils.test.ts
+++ b/apps/web/components/shared/mermaid-utils.test.ts
@@ -63,4 +63,21 @@ describe("sanitizeMermaidCode", () => {
     expect(out).toContain(`E["router.push('/github')"]`);
     expect(out).toContain(`B["Types 'github' / 'pr' / 'dashboard'"]`);
   });
+
+  it("quotes a stadium node next to a bracket-with-parens on the same line", () => {
+    // Pass 1 quotes `[fn(x)]` (parens inside bracket). Pass 3 must still quote
+    // the adjacent stadium `(/api/v1)` — the new quoted range from pass 1 must
+    // not leak past its actual close and suppress the unrelated stadium node.
+    const input = `A[fn(x)] --> B(/api/v1)`;
+    expect(sanitizeMermaidCode(input)).toBe(`A["fn(x)"] --> B("/api/v1")`);
+  });
+
+  it("does not let an unterminated quote leak across lines", () => {
+    // Line 1 has a stray `"` with no closing pair on the same line. The newline
+    // guard in findQuotedRanges discards that opener instead of pairing it with
+    // a `"` on a later line, so the bracket label on line 2 still gets quoted.
+    const input = `%% stray " comment\nB[/api/x]`;
+    const out = sanitizeMermaidCode(input);
+    expect(out).toContain(`B["/api/x"]`);
+  });
 });

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -83,7 +83,7 @@ export function sanitizeMermaidCode(code: string): string {
   let quoted = findQuotedRanges(code);
   let result = code.replace(/(\[+)([^\]"]+?)(\]+)/g, (match, open, text, close, offset) => {
     if (inAnyRange(offset, quoted)) return match;
-    if (BRACKET_TRIGGER_RE.test(text) && !text.startsWith('"')) {
+    if (BRACKET_TRIGGER_RE.test(text)) {
       return `${open}"${text}"${close}`;
     }
     return match;
@@ -93,7 +93,7 @@ export function sanitizeMermaidCode(code: string): string {
   quoted = findQuotedRanges(result);
   result = result.replace(/\|([^|"]+?)\|/g, (match, text, offset) => {
     if (inAnyRange(offset, quoted)) return match;
-    if (SPECIAL_CHARS_RE.test(text) && !text.startsWith('"')) {
+    if (SPECIAL_CHARS_RE.test(text)) {
       return `|"${text}"|`;
     }
     return match;
@@ -107,7 +107,7 @@ export function sanitizeMermaidCode(code: string): string {
     if (/^(subgraph|end|graph|flowchart|sequenceDiagram)\b/.test(text.trim())) {
       return match;
     }
-    if (SPECIAL_CHARS_RE.test(text) && !text.startsWith('"')) {
+    if (SPECIAL_CHARS_RE.test(text)) {
       return `${open}"${text}"${close}`;
     }
     return match;

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -40,26 +40,59 @@ export function getSvgDimensions(container: HTMLElement): { w: number; h: number
 const SPECIAL_CHARS_RE = /[$#&/\\<>{}]/;
 
 /**
+ * Bracket-pass trigger: parens are mermaid grammar metachars (stadium-shape
+ * opener) and break parsing when they appear inside `[...]` labels, so they
+ * force quoting in bracket labels even though they're legal in standalone
+ * `(...)` stadium nodes.
+ */
+const BRACKET_TRIGGER_RE = /[$#&/\\<>{}()]/;
+
+/** Index ranges of every top-level `"..."` span (start = opening `"`, end = closing `"`). */
+function findQuotedRanges(s: string): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  let i = 0;
+  while (i < s.length) {
+    if (s[i] === '"' && s[i - 1] !== "\\") {
+      const start = i;
+      i++;
+      while (i < s.length && !(s[i] === '"' && s[i - 1] !== "\\")) i++;
+      out.push([start, i]);
+    }
+    i++;
+  }
+  return out;
+}
+
+const inAnyRange = (offset: number, ranges: Array<[number, number]>): boolean =>
+  ranges.some(([a, b]) => offset >= a && offset <= b);
+
+/**
  * Preprocesses mermaid code to quote text containing special characters.
  * Mermaid requires quotes around text with special chars like $, /, etc.
  *
  * Handles:
- * - Node labels: A[text] -> A["text"] if text contains special chars
+ * - Node labels: A[text] -> A["text"] if text contains special chars or parens
  * - Edge labels: -->|text| -> -->|"text"| if text contains special chars
- * - Subgraph titles: subgraph text -> subgraph "text" if text contains special chars
+ * - Stadium nodes: (text) -> ("text") if text contains special chars
+ *
+ * Skips any region already inside a user-supplied `"..."` label so we never
+ * inject nested quotes into pre-quoted content.
  */
 export function sanitizeMermaidCode(code: string): string {
-  // Quote node labels: [text] or (text) or {text} or ([text]) or [[text]] etc.
-  // Match brackets that aren't already quoted
-  let result = code.replace(/(\[+)([^\]"]+?)(\]+)/g, (match, open, text, close) => {
-    if (SPECIAL_CHARS_RE.test(text) && !text.startsWith('"')) {
+  // Quote node labels: [text] or [[text]] etc. Match brackets that aren't already quoted.
+  let quoted = findQuotedRanges(code);
+  let result = code.replace(/(\[+)([^\]"]+?)(\]+)/g, (match, open, text, close, offset) => {
+    if (inAnyRange(offset, quoted)) return match;
+    if (BRACKET_TRIGGER_RE.test(text) && !text.startsWith('"')) {
       return `${open}"${text}"${close}`;
     }
     return match;
   });
 
   // Quote edge labels: |text|
-  result = result.replace(/\|([^|"]+?)\|/g, (match, text) => {
+  quoted = findQuotedRanges(result);
+  result = result.replace(/\|([^|"]+?)\|/g, (match, text, offset) => {
+    if (inAnyRange(offset, quoted)) return match;
     if (SPECIAL_CHARS_RE.test(text) && !text.startsWith('"')) {
       return `|"${text}"|`;
     }
@@ -67,7 +100,9 @@ export function sanitizeMermaidCode(code: string): string {
   });
 
   // Quote parentheses labels: (text) for stadium/circle nodes
-  result = result.replace(/(\(+)([^)"]+?)(\)+)/g, (match, open, text, close) => {
+  quoted = findQuotedRanges(result);
+  result = result.replace(/(\(+)([^)"]+?)(\)+)/g, (match, open, text, close, offset) => {
+    if (inAnyRange(offset, quoted)) return match;
     // Skip if it looks like a subgraph or keyword
     if (/^(subgraph|end|graph|flowchart|sequenceDiagram)\b/.test(text.trim())) {
       return match;

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -47,7 +47,11 @@ const SPECIAL_CHARS_RE = /[$#&/\\<>{}]/;
  */
 const BRACKET_TRIGGER_RE = /[$#&/\\<>{}()]/;
 
-/** Index ranges of every top-level `"..."` span (start = opening `"`, end = closing `"`). */
+/**
+ * Index ranges of every top-level `"..."` span (start = opening `"`, end = closing `"`).
+ * Scan stops at newline so an unterminated `"` on one line cannot pair with a
+ * `"` on a later line and silently suppress sanitization of unrelated content.
+ */
 function findQuotedRanges(s: string): Array<[number, number]> {
   const out: Array<[number, number]> = [];
   let i = 0;
@@ -55,8 +59,8 @@ function findQuotedRanges(s: string): Array<[number, number]> {
     if (s[i] === '"' && s[i - 1] !== "\\") {
       const start = i;
       i++;
-      while (i < s.length && !(s[i] === '"' && s[i - 1] !== "\\")) i++;
-      out.push([start, i]);
+      while (i < s.length && s[i] !== "\n" && !(s[i] === '"' && s[i - 1] !== "\\")) i++;
+      if (i < s.length && s[i] === '"') out.push([start, i]);
     }
     i++;
   }


### PR DESCRIPTION
Two diagrams failed to render because `sanitizeMermaidCode` corrupted already-quoted labels by re-wrapping inner parens (`["router.push('/github')"]` → nested `"`), and because `(`/`)` were missing from the bracket-pass trigger set so labels like `Action[reorderSidebarViews(activeId, overId)]` parsed as a stadium-shape opener.

## Important Changes

- Skip any region inside an existing `"..."` span; ranges are recomputed between passes so quoting introduced by an earlier pass is honored by later ones.
- New `BRACKET_TRIGGER_RE` adds `(`/`)` to the bracket-pass trigger only — standalone stadium nodes `X(text)` keep their existing behavior.

## Validation

- `pnpm --filter @kandev/web test mermaid-utils` → 10 tests pass (both reported failures + regressions for stadium nodes, edge labels, init directives).
- `pnpm --filter @kandev/web exec eslint components/shared/mermaid-utils.ts components/shared/mermaid-utils.test.ts` → clean.

## Possible Improvements

Low risk. Sanitizer is still regex-based; future cross-pass bugs could justify gating it behind `mermaid.parse()` pre-flight or replacing it with a single-pass tokenizer.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.