### PR TITLE
fix(ui): restore readable boxed chat hotkey tooltip

### DIFF
--- a/apps/packages/ui/src/kbd.tsx
+++ b/apps/packages/ui/src/kbd.tsx
@@ -5,7 +5,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
     <kbd
       data-slot="kbd"
       className={cn(
-        "bg-muted text-muted-foreground [[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10 h-5 w-fit min-w-5 gap-1 rounded-xs px-1 font-sans text-[0.625rem] font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
+        "bg-muted text-muted-foreground [[data-slot=tooltip-content]_&]:border [[data-slot=tooltip-content]_&]:border-border/60 [[data-slot=tooltip-content]_&]:bg-background/70 [[data-slot=tooltip-content]_&]:text-popover-foreground dark:[[data-slot=tooltip-content]_&]:bg-background/20 h-5 w-fit min-w-5 gap-1 rounded-xs px-1 font-sans text-[0.625rem] font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
         className,
       )}
       {...props}


### PR DESCRIPTION
The chat hotkey hint became hard to read in dark mode after the top bar refresh, which made a key shortcut less discoverable during hover interactions. This restores a boxed tooltip key style with theme-aware foreground contrast so the hint remains legible across themes.

## Validation
- `git commit` pre-commit checks (Prettier for changed web/package files)

## Checklist
- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.