### PR TITLE
fix: prevent inline code from rendering diagrams

### DIFF
--- a/apps/web/components/shared/markdown-components.test.tsx
+++ b/apps/web/components/shared/markdown-components.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
@@ -8,7 +9,7 @@ vi.mock("@/components/shared/mermaid-block", () => ({
 }));
 
 vi.mock("@/components/task/chat/messages/code-block", () => ({
-  CodeBlock: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  CodeBlock: ({ children, className }: { children: ReactNode; className?: string }) => (
     <pre data-kind="block" className={className}>
       <code>{children}</code>
     </pre>
@@ -16,9 +17,7 @@ vi.mock("@/components/task/chat/messages/code-block", () => ({
 }));
 
 vi.mock("@/components/task/chat/messages/inline-code", () => ({
-  InlineCode: ({ children }: { children: React.ReactNode }) => (
-    <code data-kind="inline">{children}</code>
-  ),
+  InlineCode: ({ children }: { children: ReactNode }) => <code data-kind="inline">{children}</code>,
 }));
 
 function renderMarkdown(source: string): string {
@@ -43,5 +42,14 @@ describe("markdownComponents", () => {
 
     expect(html).toContain('data-kind="mermaid"');
     expect(html).toContain("graph LR");
+  });
+
+  it("renders non-mermaid fenced code as a code block", () => {
+    const html = renderMarkdown("```ts\nconst source = 'kanban';\n```");
+
+    expect(html).toContain('data-kind="block"');
+    expect(html).toContain("language-ts");
+    expect(html).toContain("const source");
+    expect(html).not.toContain('data-kind="mermaid"');
   });
 });

--- a/apps/web/components/shared/markdown-components.test.tsx
+++ b/apps/web/components/shared/markdown-components.test.tsx
@@ -1,0 +1,47 @@
+import ReactMarkdown from "react-markdown";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { markdownComponents, remarkPlugins } from "./markdown-components";
+
+vi.mock("@/components/shared/mermaid-block", () => ({
+  MermaidBlock: ({ code }: { code: string }) => <div data-kind="mermaid">{code}</div>,
+}));
+
+vi.mock("@/components/task/chat/messages/code-block", () => ({
+  CodeBlock: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <pre data-kind="block" className={className}>
+      <code>{children}</code>
+    </pre>
+  ),
+}));
+
+vi.mock("@/components/task/chat/messages/inline-code", () => ({
+  InlineCode: ({ children }: { children: React.ReactNode }) => (
+    <code data-kind="inline">{children}</code>
+  ),
+}));
+
+function renderMarkdown(source: string): string {
+  return renderToStaticMarkup(
+    <ReactMarkdown remarkPlugins={remarkPlugins} components={markdownComponents}>
+      {source}
+    </ReactMarkdown>,
+  );
+}
+
+describe("markdownComponents", () => {
+  it("keeps mermaid keywords in inline code as inline code", () => {
+    const html = renderMarkdown("Metadata comes from `kanban`, `kanbanMulti`, repositories.");
+
+    expect(html).toContain('data-kind="inline"');
+    expect(html).toContain("kanban");
+    expect(html).not.toContain('data-kind="mermaid"');
+  });
+
+  it("renders fenced mermaid code as a mermaid block", () => {
+    const html = renderMarkdown("```mermaid\ngraph LR\nA-->B\n```");
+
+    expect(html).toContain('data-kind="mermaid"');
+    expect(html).toContain("graph LR");
+  });
+});

--- a/apps/web/components/shared/markdown-components.tsx
+++ b/apps/web/components/shared/markdown-components.tsx
@@ -45,7 +45,7 @@ type MarkdownCodeProps = {
 };
 
 function isBlockCode(rawContent: string, hasLanguage: boolean): boolean {
-  return hasLanguage || rawContent.endsWith("\n") || rawContent.includes("\n");
+  return hasLanguage || rawContent.includes("\n");
 }
 
 /**

--- a/apps/web/components/shared/markdown-components.tsx
+++ b/apps/web/components/shared/markdown-components.tsx
@@ -39,6 +39,24 @@ export function getTextContent(children: ReactNode): string {
   return "";
 }
 
+type MarkdownCodeNode = {
+  type?: string;
+};
+
+type MarkdownCodeProps = {
+  className?: string;
+  children?: ReactNode;
+  node?: MarkdownCodeNode;
+};
+
+function isBlockCode(
+  node: MarkdownCodeNode | undefined,
+  hasLanguage: boolean,
+  content: string,
+): boolean {
+  return node?.type === "code" || hasLanguage || content.includes("\n");
+}
+
 /**
  * Shared markdown component overrides for ReactMarkdown.
  * Element styles (headings, lists, inline code, etc.) are handled by
@@ -46,15 +64,15 @@ export function getTextContent(children: ReactNode): string {
  * (code routing, link target, table overflow wrapper) remain here.
  */
 export const markdownComponents = {
-  code: ({ className, children }: { className?: string; children?: ReactNode }) => {
+  code: ({ className, children, node }: MarkdownCodeProps) => {
     const content = getTextContent(children).replace(/\n$/, "");
     const lang = className?.replace("language-", "") ?? null;
-    if (isMermaidContent(lang, content)) {
+    const hasLanguage = className?.startsWith("language-") ?? false;
+    const isBlock = isBlockCode(node, hasLanguage, content);
+    if (isBlock && isMermaidContent(lang, content)) {
       return <MermaidBlock code={content} />;
     }
-    const hasLanguage = className?.startsWith("language-");
-    const hasNewlines = content.includes("\n");
-    if (hasLanguage || hasNewlines) {
+    if (isBlock) {
       return <CodeBlock className={className}>{content}</CodeBlock>;
     }
     return <InlineCode>{content}</InlineCode>;

--- a/apps/web/components/shared/markdown-components.tsx
+++ b/apps/web/components/shared/markdown-components.tsx
@@ -39,22 +39,13 @@ export function getTextContent(children: ReactNode): string {
   return "";
 }
 
-type MarkdownCodeNode = {
-  type?: string;
-};
-
 type MarkdownCodeProps = {
   className?: string;
   children?: ReactNode;
-  node?: MarkdownCodeNode;
 };
 
-function isBlockCode(
-  node: MarkdownCodeNode | undefined,
-  hasLanguage: boolean,
-  content: string,
-): boolean {
-  return node?.type === "code" || hasLanguage || content.includes("\n");
+function isBlockCode(rawContent: string, hasLanguage: boolean): boolean {
+  return hasLanguage || rawContent.endsWith("\n") || rawContent.includes("\n");
 }
 
 /**
@@ -64,11 +55,12 @@ function isBlockCode(
  * (code routing, link target, table overflow wrapper) remain here.
  */
 export const markdownComponents = {
-  code: ({ className, children, node }: MarkdownCodeProps) => {
-    const content = getTextContent(children).replace(/\n$/, "");
+  code: ({ className, children }: MarkdownCodeProps) => {
+    const rawContent = getTextContent(children);
+    const content = rawContent.replace(/\n$/, "");
     const lang = className?.replace("language-", "") ?? null;
     const hasLanguage = className?.startsWith("language-") ?? false;
-    const isBlock = isBlockCode(node, hasLanguage, content);
+    const isBlock = isBlockCode(rawContent, hasLanguage);
     if (isBlock && isMermaidContent(lang, content)) {
       return <MermaidBlock code={content} />;
     }


### PR DESCRIPTION
Inline Mermaid keywords in chat text were being interpreted as diagrams, which made ordinary metadata names trigger render errors. Markdown rendering now only routes block code through Mermaid detection, leaving inline code stable while preserving fenced diagram support.

## Validation

- `make fmt`
- `pnpm --filter @kandev/web run prebuild`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.