### PR TITLE
fix: remove settings topbar border

### DIFF
--- a/apps/web/components/settings/settings-layout-client.tsx
+++ b/apps/web/components/settings/settings-layout-client.tsx
@@ -22,7 +22,7 @@ export function SettingsLayoutClient({ children }: { children: React.ReactNode }
             title={title}
             backHref={backHref}
             backLabel={backLabel}
-            className="h-16"
+            className="h-16 border-b-0"
             leading={<SidebarTrigger size="lg" className="md:hidden h-10 w-10 cursor-pointer" />}
           />
           <div className="flex min-w-0 flex-1 flex-col gap-4 p-4 pt-0 mb-20">{children}</div>


### PR DESCRIPTION
Settings pages showed an extra divider from the shared top bar, adding visual noise above each page's content. The settings shell now suppresses that divider while leaving other pages untouched.

## Validation

- `make fmt`
- `make typecheck test lint`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.