### PR TITLE
feat(ui): collapse commits and PR changes by default in changes panel

### DIFF
--- a/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
+++ b/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
@@ -30,6 +30,7 @@ import { FileListSection, CommitsSection } from "./changes-panel-timeline";
 const REPO_HEADER_TID = "changes-repo-header";
 const COMMIT_ROW_TID = "commit-row";
 const COMMITS_SECTION_TOGGLE_TID = "commits-section-collapse-toggle";
+const ARIA_EXPANDED = "aria-expanded";
 
 afterEach(cleanup);
 
@@ -142,11 +143,11 @@ describe("FileListSection — multi-repo grouping", () => {
 
     // frontend's two rows hidden, backend's one row still visible
     expect(screen.getAllByTestId("file-row")).toHaveLength(1);
-    expect(frontendHeader.getAttribute("aria-expanded")).toBe("false");
+    expect(frontendHeader.getAttribute(ARIA_EXPANDED)).toBe("false");
 
     fireEvent.click(frontendHeader);
     expect(screen.getAllByTestId("file-row")).toHaveLength(3);
-    expect(frontendHeader.getAttribute("aria-expanded")).toBe("true");
+    expect(frontendHeader.getAttribute(ARIA_EXPANDED)).toBe("true");
   });
 });
 
@@ -164,13 +165,17 @@ describe("CommitsSection", () => {
     };
   }
 
-  it("renders the commits section header with a collapse toggle", () => {
+  it("renders the commits section header collapsed by default", () => {
     render(<CommitsSection commits={[commit("abc123", "first")]} isLast />);
-    // Section is expanded by default — file changes and commit history are
-    // both first-class signals in the changes panel.
-    expect(screen.getByTestId(COMMIT_ROW_TID)).toBeTruthy();
+    // Commits section is collapsed by default; the toggle reflects that and
+    // the commit rows are not in the DOM until the user expands the section.
     const toggle = screen.getByTestId(COMMITS_SECTION_TOGGLE_TID);
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(toggle.getAttribute(ARIA_EXPANDED)).toBe("false");
+    expect(screen.queryByTestId(COMMIT_ROW_TID)).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute(ARIA_EXPANDED)).toBe("true");
+    expect(screen.getByTestId(COMMIT_ROW_TID)).toBeTruthy();
   });
 
   it("groups commits per repo when 2+ repos are present", () => {
@@ -184,6 +189,7 @@ describe("CommitsSection", () => {
         isLast
       />,
     );
+    fireEvent.click(screen.getByTestId(COMMITS_SECTION_TOGGLE_TID));
     const headers = screen.getAllByTestId("commits-repo-header");
     expect(headers).toHaveLength(2);
     expect(headers[0].textContent).toContain("frontend");
@@ -199,6 +205,7 @@ describe("CommitsSection", () => {
     // repository_name; the header still renders so the per-repo Push / PR
     // buttons live in a consistent place across single-repo and multi-repo.
     render(<CommitsSection commits={[commit("c1", "msg"), commit("c2", "msg")]} isLast />);
+    fireEvent.click(screen.getByTestId(COMMITS_SECTION_TOGGLE_TID));
     expect(screen.getAllByTestId("commits-repo-header")).toHaveLength(1);
     expect(screen.getAllByTestId(COMMIT_ROW_TID)).toHaveLength(2);
   });
@@ -221,6 +228,7 @@ describe("CommitsSection", () => {
         onRevertCommit={() => undefined}
       />,
     );
+    fireEvent.click(screen.getByTestId(COMMITS_SECTION_TOGGLE_TID));
     const rows = screen.getAllByTestId(COMMIT_ROW_TID);
     const latestByShas = rows
       .filter((r) => r.getAttribute("data-is-latest") === "true")

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -182,6 +182,7 @@ export function CommitsSection({
       label="Commits"
       count={commits.length}
       isLast={isLast}
+      defaultCollapsed
       data-testid="commits-section"
     >
       <ul data-testid="commits-list" className="space-y-0.5">
@@ -545,6 +546,7 @@ export function PRFilesSection({
       label="PR Changes"
       count={files.length}
       isLast={isLast}
+      defaultCollapsed
       data-testid="pr-changes-section"
     >
       {files.length > 0 && (

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -418,6 +418,26 @@ export class SessionPage {
     return this.changes.getByTestId("commits-section");
   }
 
+  /** Expand a collapsible section in the changes panel if currently collapsed. */
+  async expandChangesSection(testId: string): Promise<void> {
+    const toggle = this.changes.getByTestId(`${testId}-collapse-toggle`);
+    await expect(toggle).toBeVisible({ timeout: 15_000 });
+    if ((await toggle.getAttribute("aria-expanded")) === "false") {
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    }
+  }
+
+  /** Expand the commits section (collapsed by default in the changes panel). */
+  async expandCommitsSection(): Promise<void> {
+    await this.expandChangesSection("commits-section");
+  }
+
+  /** Expand the PR Changes section (collapsed by default in the changes panel). */
+  async expandPRChangesSection(): Promise<void> {
+    await this.expandChangesSection("pr-changes-section");
+  }
+
   /**
    * Types a message into the TipTap chat input and sends it.
    * Default submit key is Cmd+Enter (chatSubmitKey = "cmd_enter").

--- a/apps/web/e2e/tests/git/git-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/git/git-changes-panel.spec.ts
@@ -328,6 +328,7 @@ test.describe("Git Changes Panel", () => {
 
     // The commit should appear in the commits section
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(testPage.getByText("Add feature module")).toBeVisible({ timeout: 15_000 });
     // Verify the short SHA is displayed
     await expect(testPage.getByText(sha.slice(0, 7))).toBeVisible({ timeout: 5_000 });
@@ -372,6 +373,7 @@ test.describe("Git Changes Panel", () => {
 
     // Wait for the commit to appear
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     const commitRow = testPage.getByTestId(`commit-row-${sha.slice(0, 7)}`);
     await expect(commitRow).toBeVisible({ timeout: 10_000 });
 
@@ -444,6 +446,7 @@ test.describe("Git Changes Panel", () => {
 
     // Wait for the specific commit to appear by SHA
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     const commitRow = testPage.getByTestId(`commit-row-${sha.slice(0, 7)}`);
     await expect(commitRow).toBeVisible({ timeout: 10_000 });
 
@@ -516,6 +519,7 @@ test.describe("Git Changes Panel", () => {
 
     // Wait for both commits to appear
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("First commit")).toBeVisible({ timeout: 10_000 });
     await expect(session.changes.getByText("Second commit")).toBeVisible({ timeout: 10_000 });
 
@@ -614,6 +618,7 @@ test.describe("Git Changes Panel", () => {
 
     // Wait for the commit to appear
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     const commitRow = testPage.getByTestId(`commit-row-${sha.slice(0, 7)}`);
     await expect(commitRow).toBeVisible({ timeout: 10_000 });
 
@@ -686,6 +691,8 @@ test.describe("Git Changes Panel", () => {
 
     // The commit should appear in the UI via WebSocket update (when git status polls)
     // Note: The polling interval may mean we need to wait a bit
+    await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 30_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("External commit from another user")).toBeVisible({
       timeout: 30_000,
     });
@@ -734,6 +741,7 @@ test.describe("Git Changes Panel", () => {
 
     // Wait for the commit to appear
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("Commit that should persist")).toBeVisible({
       timeout: 10_000,
     });
@@ -751,6 +759,7 @@ test.describe("Git Changes Panel", () => {
 
     // The commit MUST still be visible after refresh
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("Commit that should persist")).toBeVisible({
       timeout: 15_000,
     });
@@ -815,6 +824,7 @@ test.describe("Git Changes Panel", () => {
 
     // Wait for all commits to appear
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("First persistent commit")).toBeVisible({
       timeout: 10_000,
     });
@@ -840,6 +850,7 @@ test.describe("Git Changes Panel", () => {
 
     // ALL commits MUST still be visible after refresh
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("First persistent commit")).toBeVisible({
       timeout: 15_000,
     });
@@ -940,6 +951,7 @@ test.describe("Git Changes Panel", () => {
 
       // After rebase, the feature commit should still be visible
       await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+      await session.expandCommitsSection();
       await expect(session.changes.getByText("Feature commit before rebase")).toBeVisible({
         timeout: 15_000,
       });
@@ -1000,6 +1012,7 @@ test.describe("Git Changes Panel", () => {
 
     // Verify both commits are visible before squash
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("First commit to squash")).toBeVisible({
       timeout: 10_000,
     });
@@ -1076,6 +1089,7 @@ test.describe("Git Changes Panel", () => {
 
     // Wait for commits to appear
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
 
     // Wait for both commits to be visible
     await expect(session.changes.getByText("Add first line")).toBeVisible({ timeout: 10_000 });
@@ -1143,13 +1157,18 @@ test.describe("Git Changes Panel", () => {
     await expect(testPage.getByTestId("unstaged-files-section")).toBeVisible({ timeout: 15_000 });
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
 
-    // Verify the unstaged file is visible
+    // Verify the unstaged file is visible (unstaged section is expanded by default)
     await expect(session.changes.getByText("collapse-unstaged.txt")).toBeVisible({
       timeout: 5_000,
     });
 
-    // Verify the commit is visible
-    await expect(session.changes.getByText("Collapse test commit")).toBeVisible({ timeout: 5_000 });
+    // Commits section is collapsed by default, so the commit text is not in the DOM
+    const commitsToggle = testPage.getByTestId("commits-section-collapse-toggle");
+    await expect(commitsToggle).toBeVisible({ timeout: 5_000 });
+    await expect(commitsToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(session.changes.getByText("Collapse test commit")).not.toBeVisible({
+      timeout: 2_000,
+    });
 
     // --- Collapse the unstaged section ---
     const unstagedToggle = testPage.getByTestId("unstaged-files-section-collapse-toggle");
@@ -1167,33 +1186,24 @@ test.describe("Git Changes Panel", () => {
     await expect(unstagedToggle).toBeVisible();
     await expect(unstagedToggle).toContainText("Unstaged");
 
-    // --- Collapse the commits section ---
-    const commitsToggle = testPage.getByTestId("commits-section-collapse-toggle");
-    await expect(commitsToggle).toBeVisible({ timeout: 5_000 });
-    await expect(commitsToggle).toHaveAttribute("aria-expanded", "true");
-    await commitsToggle.click();
-
-    // The commit should now be hidden and toggle reflects collapsed state
-    await expect(session.changes.getByText("Collapse test commit")).not.toBeVisible({
-      timeout: 5_000,
-    });
-    await expect(commitsToggle).toHaveAttribute("aria-expanded", "false");
-
     // --- Expand the unstaged section back ---
     await unstagedToggle.click();
-
-    // The unstaged file should be visible again
     await expect(session.changes.getByText("collapse-unstaged.txt")).toBeVisible({
       timeout: 5_000,
     });
     await expect(unstagedToggle).toHaveAttribute("aria-expanded", "true");
 
-    // --- Expand the commits section back ---
+    // --- Expand the commits section ---
     await commitsToggle.click();
-
-    // The commit should be visible again
     await expect(session.changes.getByText("Collapse test commit")).toBeVisible({ timeout: 5_000 });
     await expect(commitsToggle).toHaveAttribute("aria-expanded", "true");
+
+    // --- Collapse the commits section back ---
+    await commitsToggle.click();
+    await expect(session.changes.getByText("Collapse test commit")).not.toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(commitsToggle).toHaveAttribute("aria-expanded", "false");
 
     // Clean up
     git.deleteFile("collapse-unstaged.txt");
@@ -1246,6 +1256,7 @@ test.describe("Git Changes Panel", () => {
     await session.clickTab("Changes");
     await expect(session.changes).toBeVisible({ timeout: 10_000 });
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("Commit in PR")).toBeVisible({ timeout: 10_000 });
 
     // Mock a PR that contains the same commit
@@ -1277,6 +1288,7 @@ test.describe("Git Changes Panel", () => {
 
     // Unified commits section should show the commit as pushed (git-commit icon, not arrow-up)
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("Commit in PR")).toBeVisible({ timeout: 10_000 });
     const commitsList = testPage.getByTestId("commits-list");
     await expect(commitsList.locator('[data-testid^="commit-row-"]')).toHaveCount(1, {
@@ -1364,6 +1376,7 @@ test.describe("Git Changes Panel", () => {
     // Unified commits section should show at least the two commits we created.
     // Other tests in the same worker may have left additional commits in the shared e2e-repo.
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
     const commitsList = testPage.getByTestId("commits-list");
     await expect(commitsList.locator('[data-testid^="commit-row-"]').first()).toBeVisible({
       timeout: 5_000,

--- a/apps/web/e2e/tests/git/git-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/git/git-changes-panel.spec.ts
@@ -1032,6 +1032,10 @@ test.describe("Git Changes Panel", () => {
       timeout: 5_000,
     });
 
+    // CommitsSection unmounts mid-transition (when no commits and no staged
+    // files exist briefly), so it re-mounts collapsed by default — re-expand.
+    await session.expandCommitsSection();
+
     // The squashed commit should appear
     await expect(session.changes.getByText("Squashed commit")).toBeVisible({ timeout: 10_000 });
   });

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -75,6 +75,7 @@ test.describe("Changes panel focus behavior", () => {
     // Wait for the changes panel to show the commit
     await session.clickTab("Changes");
     await expect(session.changes).toBeVisible({ timeout: 10_000 });
+    await session.expandCommitsSection();
     await expect(session.changes.getByText("test commit")).toBeVisible({ timeout: 10_000 });
 
     // Switch back to chat tab — this is the tab that should be active after refresh

--- a/apps/web/e2e/tests/layout/preview-tabs.spec.ts
+++ b/apps/web/e2e/tests/layout/preview-tabs.spec.ts
@@ -289,6 +289,7 @@ test.describe.skip("Editor preview tabs", () => {
     await session.clickTab("Changes");
     await expect(session.changes).toBeVisible({ timeout: 10_000 });
     await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+    await session.expandCommitsSection();
 
     const short1 = sha1.slice(0, 7);
     const short2 = sha2.slice(0, 7);

--- a/apps/web/e2e/tests/pr/pr-detection.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-detection.spec.ts
@@ -454,6 +454,8 @@ test.describe("PR external detection", () => {
     await session.clickTab("Changes");
 
     await expect(session.prFilesSection()).toBeVisible({ timeout: 15_000 });
+    await session.expandPRChangesSection();
+    await session.expandCommitsSection();
     await expect(session.prFilesSection().getByText("feature.ts")).toBeVisible();
     await expect(session.prFilesSection().getByText("index.ts")).toBeVisible();
 

--- a/apps/web/e2e/tests/pr/pr-switcher-changes.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-switcher-changes.spec.ts
@@ -190,6 +190,8 @@ test.describe("PR switcher changes panel", () => {
 
     // --- Verify Task A PR data ---
     await expect(session.prFilesSection()).toBeVisible({ timeout: 15_000 });
+    await session.expandPRChangesSection();
+    await session.expandCommitsSection();
     await expect(session.prFilesSection().getByText("auth.go")).toBeVisible();
     await expect(session.prFilesSection().getByText("auth_test.go")).toBeVisible();
 
@@ -203,6 +205,8 @@ test.describe("PR switcher changes panel", () => {
 
     // Wait for PR data to load for Task B
     await expect(session.prFilesSection()).toBeVisible({ timeout: 15_000 });
+    await session.expandPRChangesSection();
+    await session.expandCommitsSection();
     await expect(session.prFilesSection().getByText("dashboard.tsx")).toBeVisible();
     await expect(session.prFilesSection().getByText("api.ts")).toBeVisible();
     await expect(session.prFilesSection().getByText("styles.css")).toBeVisible();
@@ -229,6 +233,8 @@ test.describe("PR switcher changes panel", () => {
     await session.clickTab("Changes");
 
     await expect(session.prFilesSection()).toBeVisible({ timeout: 15_000 });
+    await session.expandPRChangesSection();
+    await session.expandCommitsSection();
     await expect(session.prFilesSection().getByText("auth.go")).toBeVisible();
     await expect(session.prFilesSection().getByText("auth_test.go")).toBeVisible();
     await expect(session.commitsSection().getByText("fix auth token expiry")).toBeVisible();


### PR DESCRIPTION
The Commits and PR Changes sections in the changes panel were always expanded on first render, which made the panel noisy when the local working tree was the focus. Both sections now start collapsed so unstaged/staged changes lead the view, and users can toggle them open as needed.

## Validation

- `pnpm --filter @kandev/web lint` (0 warnings)
- `pnpm --filter @kandev/web test changes-panel` (33/33 passing)
- `make -C apps/backend test lint`
- E2E specs touching the commits/PR sections updated to expand the section before asserting on row content; not run locally (Playwright env required)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.