### PR TITLE
fix: add border to task name input in create dialog

### DIFF
--- a/apps/web/components/task-create-dialog-selectors.tsx
+++ b/apps/web/components/task-create-dialog-selectors.tsx
@@ -265,7 +265,7 @@ export const InlineTaskName = memo(function InlineTaskName({
       onChange={(e) => onChange(e.target.value)}
       placeholder="Task name"
       data-testid="task-title-input"
-      className="w-full bg-transparent border border-input outline-none focus:ring-0 text-sm font-medium rounded-md px-3 py-2 transition-colors placeholder:text-muted-foreground/70"
+      className="w-full bg-transparent border border-input outline-none focus-visible:border-ring focus-visible:ring-ring/35 focus-visible:ring-[2px] text-sm font-medium rounded-md px-3 py-2 transition-colors placeholder:text-muted-foreground/70"
     />
   );
 });

--- a/apps/web/components/task-create-dialog-selectors.tsx
+++ b/apps/web/components/task-create-dialog-selectors.tsx
@@ -265,7 +265,7 @@ export const InlineTaskName = memo(function InlineTaskName({
       onChange={(e) => onChange(e.target.value)}
       placeholder="Task name"
       data-testid="task-title-input"
-      className="w-full bg-transparent border-none outline-none focus:ring-0 text-sm font-medium rounded-md px-2 py-1 -mx-2 hover:bg-muted/30 focus:bg-muted/30 transition-colors placeholder:text-muted-foreground/70"
+      className="w-full bg-transparent border border-input outline-none focus:ring-0 text-sm font-medium rounded-md px-3 py-2 transition-colors placeholder:text-muted-foreground/70"
     />
   );
 });


### PR DESCRIPTION
The task name input in the create-task dialog rendered borderless against the surrounding form, making it visually inconsistent with the bordered description box; matching its style improves form alignment and affordance.

## Validation

- `make -C apps/backend fmt test lint`
- `pnpm format`
- `npx tsc --noEmit` in `apps/web`
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.