### PR TITLE
fix: dedupe cancel-turn clicks to stop "turn cancelled" cascade

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -146,11 +146,14 @@ type mockAgentManager struct {
 	// Optional override for GetExecutionIDForSession
 	getExecutionIDForSessionFunc func(context.Context, string) (string, error)
 
-	// CancelAgent tracking. cancelAgentCalls counts every invocation; if
-	// cancelAgentBlock is non-nil, CancelAgent blocks on it before returning,
-	// letting tests stage concurrent cancel calls deterministically.
-	cancelAgentCalls atomic.Int32
-	cancelAgentBlock chan struct{}
+	// CancelAgent tracking. cancelAgentCalls counts every invocation. If
+	// cancelAgentBlock is non-nil, CancelAgent blocks on it before returning;
+	// if cancelAgentEntered is non-nil, CancelAgent does a non-blocking send
+	// on it on entry. Together they let tests stage concurrent cancel calls
+	// without sleep-based polling.
+	cancelAgentCalls   atomic.Int32
+	cancelAgentBlock   chan struct{}
+	cancelAgentEntered chan struct{}
 }
 
 type stopAgentCall struct {
@@ -210,6 +213,12 @@ func (m *mockAgentManager) PromptAgent(_ context.Context, executionID string, pr
 }
 func (m *mockAgentManager) CancelAgent(_ context.Context, _ string) error {
 	m.cancelAgentCalls.Add(1)
+	if m.cancelAgentEntered != nil {
+		select {
+		case m.cancelAgentEntered <- struct{}{}:
+		default:
+		}
+	}
 	if m.cancelAgentBlock != nil {
 		<-m.cancelAgentBlock
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -144,6 +145,12 @@ type mockAgentManager struct {
 
 	// Optional override for GetExecutionIDForSession
 	getExecutionIDForSessionFunc func(context.Context, string) (string, error)
+
+	// CancelAgent tracking. cancelAgentCalls counts every invocation; if
+	// cancelAgentBlock is non-nil, CancelAgent blocks on it before returning,
+	// letting tests stage concurrent cancel calls deterministically.
+	cancelAgentCalls atomic.Int32
+	cancelAgentBlock chan struct{}
 }
 
 type stopAgentCall struct {
@@ -201,7 +208,13 @@ func (m *mockAgentManager) PromptAgent(_ context.Context, executionID string, pr
 	}
 	return &executor.PromptResult{}, nil
 }
-func (m *mockAgentManager) CancelAgent(_ context.Context, _ string) error { return nil }
+func (m *mockAgentManager) CancelAgent(_ context.Context, _ string) error {
+	m.cancelAgentCalls.Add(1)
+	if m.cancelAgentBlock != nil {
+		<-m.cancelAgentBlock
+	}
+	return nil
+}
 func (m *mockAgentManager) RespondToPermissionBySessionID(_ context.Context, _, _, _ string, _ bool) error {
 	return nil
 }

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -262,6 +262,15 @@ type Service struct {
 	// activity before triggering fallback resume.
 	clarificationWatchdogTimeout time.Duration
 
+	// cancelInFlight tracks sessionIDs whose CancelAgent call is currently in
+	// progress. Used to deduplicate impatient retries from the UI: while the
+	// first cancel is still propagating through the agent (which can take several
+	// seconds when a long-running tool like Claude's Monitor is being torn down),
+	// the user often clicks the button repeatedly. Without this guard each click
+	// would create another "Turn cancelled by user" message and lazily start a
+	// phantom turn just to host it.
+	cancelInFlight sync.Map
+
 	// Service state
 	mu        sync.RWMutex
 	running   bool

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1832,6 +1832,20 @@ func (s *Service) RespondToPermission(ctx context.Context, sessionID, pendingID,
 func (s *Service) CancelAgent(ctx context.Context, sessionID string) error {
 	s.logger.Debug("cancelling agent turn", zap.String("session_id", sessionID))
 
+	// Deduplicate concurrent retries. The UI's cancel button has no in-flight
+	// disable, so impatient users click it multiple times while the agent is
+	// still tearing down the turn (e.g. unwinding a Claude Monitor tool can take
+	// several seconds). Without this guard each click produces a duplicate
+	// "Turn cancelled by user" message and races on turn cleanup — the second
+	// call's getActiveTurnID lazily starts a phantom turn after the first call
+	// already closed the real one.
+	if _, busy := s.cancelInFlight.LoadOrStore(sessionID, struct{}{}); busy {
+		s.logger.Debug("cancel already in flight; skipping duplicate",
+			zap.String("session_id", sessionID))
+		return nil
+	}
+	defer s.cancelInFlight.Delete(sessionID)
+
 	// Fetch session for state updates and message creation
 	session, err := s.repo.GetTaskSession(ctx, sessionID)
 	if err != nil {

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -317,8 +317,9 @@ func TestPromptTask_ResetInProgressReturnsSentinelError(t *testing.T) {
 func TestCancelAgent_DeduplicatesConcurrentCalls(t *testing.T) {
 	repo := setupTestRepo(t)
 	agentMgr := &mockAgentManager{
-		isAgentRunning:   true,
-		cancelAgentBlock: make(chan struct{}),
+		isAgentRunning:     true,
+		cancelAgentBlock:   make(chan struct{}),
+		cancelAgentEntered: make(chan struct{}, 1),
 	}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
 
@@ -331,14 +332,10 @@ func TestCancelAgent_DeduplicatesConcurrentCalls(t *testing.T) {
 	}()
 
 	// Wait for the first call to actually enter agentManager.CancelAgent so
-	// the dedupe guard is set before the duplicate calls fire.
-	deadline := time.Now().Add(2 * time.Second)
-	for agentMgr.cancelAgentCalls.Load() == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("first CancelAgent never reached agentManager")
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
+	// the dedupe guard is set before the duplicate calls fire. Channel sync
+	// (over sleep-based polling) is the project convention for tests that
+	// don't depend on real subprocess timing.
+	<-agentMgr.cancelAgentEntered
 
 	// Fire several duplicates while the first is still parked. Each must be
 	// short-circuited by the dedupe guard and return immediately.

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -305,6 +305,69 @@ func TestPromptTask_ResetInProgressReturnsSentinelError(t *testing.T) {
 	}
 }
 
+// --- CancelAgent ---
+
+// TestCancelAgent_DeduplicatesConcurrentCalls covers the impatient-user case:
+// the UI's cancel button has no in-flight disable, so users click it multiple
+// times while the agent is still tearing down a slow turn (e.g. a Claude
+// Monitor tool). Without dedupe each click reaches the lifecycle layer and
+// emits its own "Turn cancelled by user" message; phantom turns are also
+// lazily started to host those messages. We assert that only one cancel makes
+// it through to agentManager.CancelAgent while one is already in flight.
+func TestCancelAgent_DeduplicatesConcurrentCalls(t *testing.T) {
+	repo := setupTestRepo(t)
+	agentMgr := &mockAgentManager{
+		isAgentRunning:   true,
+		cancelAgentBlock: make(chan struct{}),
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateRunning)
+
+	// First call goes async and parks inside agentManager.CancelAgent.
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- svc.CancelAgent(context.Background(), "session1")
+	}()
+
+	// Wait for the first call to actually enter agentManager.CancelAgent so
+	// the dedupe guard is set before the duplicate calls fire.
+	deadline := time.Now().Add(2 * time.Second)
+	for agentMgr.cancelAgentCalls.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("first CancelAgent never reached agentManager")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Fire several duplicates while the first is still parked. Each must be
+	// short-circuited by the dedupe guard and return immediately.
+	const duplicates = 5
+	for i := 0; i < duplicates; i++ {
+		if err := svc.CancelAgent(context.Background(), "session1"); err != nil {
+			t.Fatalf("duplicate cancel %d returned error: %v", i, err)
+		}
+	}
+	if got := agentMgr.cancelAgentCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 agentManager.CancelAgent call while first is in flight, got %d", got)
+	}
+
+	// Release the first call. After it returns, the guard clears and a fresh
+	// cancel is allowed through.
+	close(agentMgr.cancelAgentBlock)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first CancelAgent returned error: %v", err)
+	}
+
+	agentMgr.cancelAgentBlock = nil // unblock subsequent calls
+	if err := svc.CancelAgent(context.Background(), "session1"); err != nil {
+		t.Fatalf("post-release CancelAgent returned error: %v", err)
+	}
+	if got := agentMgr.cancelAgentCalls.Load(); got != 2 {
+		t.Fatalf("expected 2 agentManager.CancelAgent calls after release, got %d", got)
+	}
+}
+
 // --- StartCreatedSession ---
 
 func TestStartCreatedSession_WrongTask(t *testing.T) {

--- a/apps/web/components/task/chat/chat-input-toolbar.test.tsx
+++ b/apps/web/components/task/chat/chat-input-toolbar.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("@kandev/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ChatInputToolbar } from "./chat-input-toolbar";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function renderToolbar(onCancel: () => void | Promise<void>) {
+  return render(
+    <ChatInputToolbar
+      planModeEnabled={false}
+      onPlanModeChange={() => {}}
+      sessionId="s1"
+      taskId="t1"
+      taskDescription=""
+      isAgentBusy
+      isDisabled={false}
+      isSending={false}
+      onCancel={onCancel}
+      onSubmit={() => {}}
+      minimalToolbar
+    />,
+  );
+}
+
+// The cancel button must disable itself while a cancel request is in flight.
+// Without this guard, an impatient user clicking it repeatedly while the agent
+// tears down a long-running tool (Claude Monitor, etc.) sends N cancel requests
+// to the backend, each producing a duplicate "Turn cancelled by user" message.
+describe("ChatInputToolbar cancel button", () => {
+  it("disables itself and blocks duplicate clicks while cancel is in flight", async () => {
+    const { promise, resolve } = deferred<void>();
+    const onCancel = vi.fn(() => promise);
+
+    renderToolbar(onCancel);
+
+    const button = screen.getByTestId("cancel-agent-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+    // Click is processed synchronously; React then flushes the setState that
+    // marks the button disabled. We assert post-flush.
+    await act(async () => {});
+    expect(button.disabled).toBe(true);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    // Subsequent clicks while the promise is pending must not call onCancel.
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    // Once the in-flight cancel resolves, the button re-enables for retry
+    // (rare, but possible if the first cancel returned an error).
+    await act(async () => {
+      resolve();
+      await promise;
+    });
+    expect(button.disabled).toBe(false);
+  });
+
+  it("re-enables the button if onCancel rejects", async () => {
+    const { promise, resolve } = deferred<void>();
+    const onCancel = vi.fn(() => promise.then(() => Promise.reject(new Error("network"))));
+
+    renderToolbar(onCancel);
+    const button = screen.getByTestId("cancel-agent-button") as HTMLButtonElement;
+
+    fireEvent.click(button);
+    await act(async () => {});
+    expect(button.disabled).toBe(true);
+
+    await act(async () => {
+      resolve();
+      // Allow the rejected promise to settle inside the click handler.
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(button.disabled).toBe(false);
+  });
+});

--- a/apps/web/components/task/chat/chat-input-toolbar.tsx
+++ b/apps/web/components/task/chat/chat-input-toolbar.tsx
@@ -108,8 +108,14 @@ function SubmitButton({
   // take several seconds, and without this the user clicks repeatedly and
   // each click hits the backend.
   const [isCancelling, setIsCancelling] = useState(false);
+  // Re-entrancy guard via ref: `disabled={isCancelling}` already blocks DOM
+  // clicks, but the ref makes the guard effective for any programmatic caller
+  // and keeps `isCancelling` out of the useCallback deps so the handler
+  // identity is stable across the false→true→false flips.
+  const cancellingRef = useRef(false);
   const handleCancelClick = useCallback(async () => {
-    if (isCancelling) return;
+    if (cancellingRef.current) return;
+    cancellingRef.current = true;
     setIsCancelling(true);
     try {
       await onCancel();
@@ -119,9 +125,10 @@ function SubmitButton({
       // re-enable so the user can retry.
       console.error("Failed to cancel agent turn:", error);
     } finally {
+      cancellingRef.current = false;
       setIsCancelling(false);
     }
-  }, [isCancelling, onCancel]);
+  }, [onCancel]);
   return (
     <div className="flex items-center gap-1">
       {isAgentBusy && (

--- a/apps/web/components/task/chat/chat-input-toolbar.tsx
+++ b/apps/web/components/task/chat/chat-input-toolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useRef, useState, type ReactNode } from "react";
+import { memo, useCallback, useRef, useState, type ReactNode } from "react";
 import {
   IconArrowUp,
   IconChevronsLeft,
@@ -46,7 +46,7 @@ export type ChatInputToolbarProps = {
   hasContent?: boolean;
   isDisabled: boolean;
   isSending: boolean;
-  onCancel: () => void;
+  onCancel: () => void | Promise<void>;
   onSubmit: () => void;
   submitKey?: "enter" | "cmd_enter";
   contextCount?: number;
@@ -79,7 +79,7 @@ type SubmitButtonProps = {
   isDisabled: boolean;
   isSending: boolean;
   planModeEnabled: boolean;
-  onCancel: () => void;
+  onCancel: () => void | Promise<void>;
   onSubmit: () => void;
   submitShortcut: (typeof SHORTCUTS)[keyof typeof SHORTCUTS];
 };
@@ -103,6 +103,25 @@ function SubmitButton({
   // When agent is busy and there's nothing to send, show only the cancel button.
   // When there's content to queue, show both cancel and send buttons side-by-side.
   const showSendButton = !isAgentBusy || hasContent;
+  // Track cancel-in-flight locally so impatient retries are blocked at the
+  // button itself: cancelling a long-running tool (e.g. Claude Monitor) can
+  // take several seconds, and without this the user clicks repeatedly and
+  // each click hits the backend.
+  const [isCancelling, setIsCancelling] = useState(false);
+  const handleCancelClick = useCallback(async () => {
+    if (isCancelling) return;
+    setIsCancelling(true);
+    try {
+      await onCancel();
+    } catch (error) {
+      // Parent handlers normally swallow errors, but a rejected onCancel
+      // must not propagate as an unhandled rejection — and the button must
+      // re-enable so the user can retry.
+      console.error("Failed to cancel agent turn:", error);
+    } finally {
+      setIsCancelling(false);
+    }
+  }, [isCancelling, onCancel]);
   return (
     <div className="flex items-center gap-1">
       {isAgentBusy && (
@@ -112,14 +131,19 @@ function SubmitButton({
               type="button"
               variant="secondary"
               size="icon"
-              className="h-7 w-7 rounded-full cursor-pointer bg-destructive/10 text-destructive hover:bg-destructive/20"
-              onClick={onCancel}
+              className="h-7 w-7 rounded-full cursor-pointer bg-destructive/10 text-destructive hover:bg-destructive/20 disabled:cursor-not-allowed disabled:opacity-70"
+              onClick={handleCancelClick}
+              disabled={isCancelling}
               data-testid="cancel-agent-button"
             >
-              <IconPlayerPauseFilled className="h-3.5 w-3.5" />
+              {isCancelling ? (
+                <GridSpinner className="text-destructive" />
+              ) : (
+                <IconPlayerPauseFilled className="h-3.5 w-3.5" />
+              )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Cancel agent</TooltipContent>
+          <TooltipContent>{isCancelling ? "Cancelling..." : "Cancel agent"}</TooltipContent>
         </Tooltip>
       )}
       {showSendButton && (


### PR DESCRIPTION
The cancel button had no in-flight feedback, so impatient users clicked it repeatedly while the agent tore down a slow turn (e.g. a Claude Monitor tool), and each click reached the backend and emitted its own "Turn cancelled by user" message — with the second-and-later calls also lazily creating phantom turns to host them. SubmitButton now disables itself with a spinner while the cancel is in flight, and the orchestrator deduplicates concurrent CancelAgent calls per session.

## Validation

- `make -C apps/backend fmt test lint` — all packages pass, 0 lint issues, including new `TestCancelAgent_DeduplicatesConcurrentCalls`
- `pnpm --filter @kandev/web test` — 962/962 pass, including new `chat-input-toolbar.test.tsx`
- `pnpm --filter @kandev/web exec eslint components/task/chat/chat-input-toolbar.tsx components/task/chat/chat-input-toolbar.test.tsx` — clean
- `tsc --noEmit` — no new errors (two pre-existing errors about missing generated changelog/release-notes JSON are unrelated)

## Possible Improvements

Low risk: the dedupe is per-session and short-lived (clears on `CancelAgent` return). Worst case if the backend hangs is the user can't issue a second cancel until the first settles — which is the desired behavior.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.