### PR TITLE
fix: focus task name on create dialog open

### DIFF
--- a/apps/web/components/task-create-dialog-form-body.tsx
+++ b/apps/web/components/task-create-dialog-form-body.tsx
@@ -313,6 +313,12 @@ export type DialogPromptSectionProps = {
   descriptionPlaceholder?: string;
   /** Optional slot rendered above the description textarea (e.g. a tab toggle). */
   aboveDescriptionSlot?: React.ReactNode;
+  /**
+   * Whether the description textarea should grab focus on mount. Defaults to
+   * `!isTaskStarted`. Callers that render a task-name input above the
+   * description should pass `false` so the name field wins focus.
+   */
+  autoFocusDescription?: boolean;
 };
 
 // importBindings collapses the optional Jira/Linear import callbacks into the
@@ -344,19 +350,21 @@ export function DialogPromptSection({
   extraFormSlot,
   descriptionPlaceholder,
   aboveDescriptionSlot,
+  autoFocusDescription,
 }: DialogPromptSectionProps) {
   const importsEnabled = !isSessionMode && !isTaskStarted;
   const ws = workspaceId ?? null;
   const placeholder = isPassthroughProfile
     ? "Passthrough mode — prompt not supported"
     : descriptionPlaceholder;
+  const shouldAutoFocus = autoFocusDescription ?? !isTaskStarted;
   return (
     <>
       {aboveDescriptionSlot}
       <TaskFormInputs
         key={fs.openCycle}
         isSessionMode={isSessionMode}
-        autoFocus={!isTaskStarted}
+        autoFocus={shouldAutoFocus}
         initialDescription={initialDescription}
         onDescriptionChange={fs.setHasDescription}
         onKeyDown={handleKeyDown}

--- a/apps/web/components/task-create-dialog-selectors.tsx
+++ b/apps/web/components/task-create-dialog-selectors.tsx
@@ -249,9 +249,11 @@ export const InlineTaskName = memo(function InlineTaskName({
   autoFocus,
 }: InlineTaskNameProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const hasFocusedRef = useRef(false);
 
   useEffect(() => {
-    if (autoFocus && inputRef.current) {
+    if (autoFocus && !hasFocusedRef.current && inputRef.current) {
+      hasFocusedRef.current = true;
       inputRef.current.focus();
       inputRef.current.select();
     }

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -177,6 +177,7 @@ function CreateModeBody(props: DialogFormBodyProps) {
     isLocalExecutor,
   } = props;
   const showTaskName = (isCreateMode || isEditMode) && !isTaskStarted;
+  const taskNameAutoFocus = !isEditMode && !fs.useGitHubUrl;
   return (
     <>
       <RepoChipsRow
@@ -197,7 +198,7 @@ function CreateModeBody(props: DialogFormBodyProps) {
         <InlineTaskName
           value={fs.taskName}
           onChange={onTaskNameChange}
-          autoFocus={!isEditMode && !fs.useGitHubUrl}
+          autoFocus={taskNameAutoFocus}
         />
       )}
       <DialogPromptSection
@@ -215,6 +216,7 @@ function CreateModeBody(props: DialogFormBodyProps) {
         descriptionPlaceholder={props.descriptionPlaceholder}
         aboveDescriptionSlot={props.aboveDescriptionSlot}
         extraFormSlot={props.extraFormSlot}
+        autoFocusDescription={!isTaskStarted && !(showTaskName && taskNameAutoFocus)}
       />
       <CreateModeSelectors
         isTaskStarted={isTaskStarted}


### PR DESCRIPTION
On first open of the task creation dialog, focus landed on the description textarea instead of the task name input — both fields auto-focused on mount and the description (rendered later) won. The dialog now hands focus to the task name when it is visible and the description yields.

## Validation

- `make -C apps/backend test lint`
- `pnpm typecheck` / `pnpm lint` (web)
- `pnpm format`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.