### PR TITLE
docs: add integrations banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Open source, multi-provider, no telemetry, not tied to any cloud.
 - **Session management** - Resume and review agent conversations
 - **Stats** - Track your productivity with stats on the completed tasks, agent turns, etc
 
+## Integrations
+
+<p align="center">
+  <a href="https://github.com/"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
+  <a href="https://www.atlassian.com/software/jira"><img src="https://img.shields.io/badge/Jira-0052CC?style=for-the-badge&logo=jira&logoColor=white" alt="Jira"></a>
+  <a href="https://linear.app/"><img src="https://img.shields.io/badge/Linear-5E6AD2?style=for-the-badge&logo=linear&logoColor=white" alt="Linear"></a>
+</p>
+
+Connect Kandev to the tools your team already uses — pull issues into the kanban, link tasks to PRs, and surface review activity inline.
+
 ## Supported ACP Agents
 
 | Agent | Protocol |


### PR DESCRIPTION
Surface the third-party integrations Kandev ships with (GitHub, Jira, Linear) directly in the README so visitors can see provider support at a glance instead of digging through the Features list.

## Validation

- `make -C apps/backend fmt test lint`
- `pnpm --filter @kandev/web lint test`
- Visually previewed the rendered Markdown.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.