### PR TITLE
fix(web): task-create dialog races — locked branch chip + agent profile labels

### DIFF
--- a/apps/backend/internal/agentctl/server/process/interactive_lifecycle.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_lifecycle.go
@@ -507,7 +507,9 @@ func (r *InteractiveRunner) wait(proc *interactiveProcess) {
 	)
 
 	// Log buffer contents if process exited with error (helps debug startup failures)
-	// Use Debug level since non-zero exit is normal for killed processes (e.g., user closing terminal)
+	// Bump to Warn for early-exit failures (process died within 5s of start) — those
+	// are almost always real problems (bad CLI flag, missing binary, auth failure)
+	// rather than the expected user-closes-terminal case. Keep Debug for late exits.
 	if status == types.ProcessStatusFailed && proc.buffer != nil {
 		chunks := proc.buffer.snapshot()
 		if len(chunks) > 0 {
@@ -519,12 +521,19 @@ func (r *InteractiveRunner) wait(proc *interactiveProcess) {
 			if len(combinedOutput) > 2000 {
 				combinedOutput = combinedOutput[:2000] + "...(truncated)"
 			}
-			r.logger.Debug("interactive process output before exit",
+			lifetime := time.Since(proc.info.StartedAt)
+			fields := []zap.Field{
 				zap.String("process_id", proc.info.ID),
 				zap.String("session_id", proc.info.SessionID),
 				zap.Int("exit_code", exitCode),
+				zap.Duration("lifetime", lifetime),
 				zap.String("output", combinedOutput),
-			)
+			}
+			if lifetime < 5*time.Second {
+				r.logger.Warn("interactive process exited early — likely startup failure", fields...)
+			} else {
+				r.logger.Debug("interactive process output before exit", fields...)
+			}
 		}
 	}
 

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -280,16 +280,17 @@ func (e *Executor) launchModelSwitchAgent(ctx context.Context, taskID, sessionID
 // repository and worktree config from the existing session.
 func (e *Executor) buildSwitchModelRequest(ctx context.Context, task *models.Task, session *models.TaskSession, sessionID, newModel, prompt, acpSessionID string, execConfig executorConfig, running *models.ExecutorRunning) (*LaunchAgentRequest, error) {
 	req := &LaunchAgentRequest{
-		TaskID:          task.ID,
-		SessionID:       sessionID,
-		TaskTitle:       task.Title,
-		AgentProfileID:  session.AgentProfileID,
-		TaskDescription: prompt,
-		ModelOverride:   newModel,
-		ACPSessionID:    acpSessionID,
-		ExecutorType:    execConfig.ExecutorType,
-		Metadata:        execConfig.Metadata,
-		IsEphemeral:     task.IsEphemeral,
+		TaskID:            task.ID,
+		SessionID:         sessionID,
+		TaskTitle:         task.Title,
+		AgentProfileID:    session.AgentProfileID,
+		TaskDescription:   prompt,
+		ModelOverride:     newModel,
+		ACPSessionID:      acpSessionID,
+		ExecutorType:      execConfig.ExecutorType,
+		Metadata:          execConfig.Metadata,
+		IsEphemeral:       task.IsEphemeral,
+		TaskEnvironmentID: session.TaskEnvironmentID,
 	}
 
 	// Activate config-mode MCP tools when config_mode is set in session metadata.

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -477,13 +477,14 @@ func (e *Executor) validateAndLockResume(ctx context.Context, session *models.Ta
 // Returns the request, repository ID, executor config, existing ExecutorRunning record (may be nil), and error.
 func (e *Executor) buildResumeRequest(ctx context.Context, task *v1.Task, session *models.TaskSession, startAgent bool) (*LaunchAgentRequest, string, executorConfig, *models.ExecutorRunning, error) {
 	req := &LaunchAgentRequest{
-		TaskID:          task.ID,
-		SessionID:       session.ID,
-		TaskTitle:       task.Title,
-		AgentProfileID:  session.AgentProfileID,
-		TaskDescription: task.Description,
-		Priority:        task.Priority,
-		IsEphemeral:     task.IsEphemeral,
+		TaskID:            task.ID,
+		SessionID:         session.ID,
+		TaskTitle:         task.Title,
+		AgentProfileID:    session.AgentProfileID,
+		TaskDescription:   task.Description,
+		Priority:          task.Priority,
+		IsEphemeral:       task.IsEphemeral,
+		TaskEnvironmentID: session.TaskEnvironmentID,
 	}
 
 	metadata := map[string]interface{}{}

--- a/apps/backend/internal/orchestrator/executor/executor_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_test.go
@@ -366,6 +366,44 @@ func TestResumeSession_CancelledStateForceCleansUpStaleState(t *testing.T) {
 	}
 }
 
+// TestResumeSession_PropagatesTaskEnvironmentID is a regression test for a
+// post-restart bug where `buildResumeRequest` did not copy
+// `session.TaskEnvironmentID` onto the LaunchAgentRequest. The lifecycle's
+// in-memory ExecutionStore indexes executions by TaskEnvironmentID for the
+// shell terminal lookup (`GetByTaskEnvironmentID`); a request without the env
+// ID produced an execution tagged with TaskEnvironmentID="" so the shell
+// terminal handler hit the "task environment ... has no workspace path yet"
+// 503 fallback and stayed stuck on "Connecting terminal..." after restart.
+func TestResumeSession_PropagatesTaskEnvironmentID(t *testing.T) {
+	repo := newMockRepository()
+	setupLiveResumeTestFixture(repo)
+	repo.sessions["sess-1"].TaskEnvironmentID = "env-1"
+
+	var capturedReq *LaunchAgentRequest
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			capturedReq = req
+			return &LaunchAgentResponse{
+				AgentExecutionID: "exec-new",
+				Status:           v1.AgentStatusStarting,
+			}, nil
+		},
+		isAgentRunningForSessionFunc: func(_ context.Context, _ string) bool { return false },
+	}
+	exec := newTestExecutor(t, agentMgr, repo)
+
+	if _, err := exec.ResumeSession(context.Background(), repo.sessions["sess-1"], true); err != nil {
+		t.Fatalf("expected resume success, got: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("expected LaunchAgent to be called with a request")
+	}
+	if capturedReq.TaskEnvironmentID != "env-1" {
+		t.Errorf("TaskEnvironmentID = %q, want %q — without this the lifecycle execution is indexed under empty env_id and GetByTaskEnvironmentID never finds it",
+			capturedReq.TaskEnvironmentID, "env-1")
+	}
+}
+
 // TestResumeSession_TerminalStateSkipsLivenessProbeOnFallback covers the
 // residual path where the preemptive CleanupStaleExecutionBySessionID is not
 // enough (e.g. the first LaunchAgent still returns "already has an agent running"

--- a/apps/backend/internal/task/service/repository_discovery.go
+++ b/apps/backend/internal/task/service/repository_discovery.go
@@ -10,6 +10,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
 )
 
 type RepositoryDiscoveryConfig struct {
@@ -209,18 +213,72 @@ func (s *Service) LocalRepositoryCurrentBranch(ctx context.Context, path string)
 // local repository on disk. Used by the task-create dialog to preflight the
 // fresh-branch flow before committing to a destructive checkout.
 func (s *Service) LocalRepositoryStatus(ctx context.Context, path string) (LocalRepoStatus, error) {
+	roots := s.discoveryRoots()
+	s.logger.Info("DEBUG_BRANCH LocalRepositoryStatus entry",
+		zap.String("path", path),
+		zap.Strings("roots", roots))
 	absPath, err := s.resolveAllowedLocalPath(path)
 	if err != nil {
+		s.logger.Info("DEBUG_BRANCH resolveAllowedLocalPath failed",
+			zap.String("path", path), zap.Error(err))
 		return LocalRepoStatus{}, err
 	}
 	dirty, err := readGitDirtyFiles(ctx, absPath)
 	if err != nil {
+		s.logger.Info("DEBUG_BRANCH readGitDirtyFiles failed",
+			zap.String("absPath", absPath), zap.Error(err))
 		return LocalRepoStatus{}, err
 	}
+	branch := readGitCurrentBranchVerbose(absPath, roots, s.logger)
+	s.logger.Info("DEBUG_BRANCH LocalRepositoryStatus result",
+		zap.String("absPath", absPath),
+		zap.String("branch", branch),
+		zap.Int("dirty_count", len(dirty)))
 	return LocalRepoStatus{
-		CurrentBranch: readGitCurrentBranch(absPath, s.discoveryRoots()),
+		CurrentBranch: branch,
 		DirtyFiles:    dirty,
 	}, nil
+}
+
+// readGitCurrentBranchVerbose mirrors readGitCurrentBranch but logs which arm
+// returned the empty string. Used for the debug repro of the task-create dialog
+// "branch" placeholder; remove once the path-allowlist / detached-HEAD root
+// cause is identified.
+func readGitCurrentBranchVerbose(repoPath string, allowedRoots []string, log *logger.Logger) string {
+	if !filepath.IsAbs(repoPath) {
+		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: not absolute", zap.String("repoPath", repoPath))
+		return ""
+	}
+	cleanRepo := filepath.Clean(repoPath)
+	gitDir, err := resolveGitDirWithin(cleanRepo, allowedRoots)
+	if err != nil {
+		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: resolveGitDirWithin",
+			zap.String("cleanRepo", cleanRepo),
+			zap.Strings("allowedRoots", allowedRoots),
+			zap.Error(err))
+		return ""
+	}
+	headPath := filepath.Clean(filepath.Join(gitDir, gitHEAD))
+	log.Info("DEBUG_BRANCH readGitCurrentBranch resolved gitDir",
+		zap.String("gitDir", gitDir),
+		zap.String("headPath", headPath))
+	if !filepath.IsAbs(headPath) {
+		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: headPath not abs", zap.String("headPath", headPath))
+		return ""
+	}
+	content, err := os.ReadFile(headPath)
+	if err != nil {
+		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: ReadFile", zap.String("headPath", headPath), zap.Error(err))
+		return ""
+	}
+	trimmed := strings.TrimSpace(string(content))
+	log.Info("DEBUG_BRANCH readGitCurrentBranch HEAD content", zap.String("trimmed", trimmed))
+	ref, ok := strings.CutPrefix(trimmed, "ref: ")
+	if !ok {
+		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: detached HEAD", zap.String("trimmed", trimmed))
+		return ""
+	}
+	return strings.TrimPrefix(ref, "refs/heads/")
 }
 
 func (s *Service) resolveAllowedLocalPath(repoPath string) (string, error) {

--- a/apps/backend/internal/task/service/repository_discovery.go
+++ b/apps/backend/internal/task/service/repository_discovery.go
@@ -10,10 +10,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-
-	"go.uber.org/zap"
-
-	"github.com/kandev/kandev/internal/common/logger"
 )
 
 type RepositoryDiscoveryConfig struct {
@@ -213,72 +209,18 @@ func (s *Service) LocalRepositoryCurrentBranch(ctx context.Context, path string)
 // local repository on disk. Used by the task-create dialog to preflight the
 // fresh-branch flow before committing to a destructive checkout.
 func (s *Service) LocalRepositoryStatus(ctx context.Context, path string) (LocalRepoStatus, error) {
-	roots := s.discoveryRoots()
-	s.logger.Info("DEBUG_BRANCH LocalRepositoryStatus entry",
-		zap.String("path", path),
-		zap.Strings("roots", roots))
 	absPath, err := s.resolveAllowedLocalPath(path)
 	if err != nil {
-		s.logger.Info("DEBUG_BRANCH resolveAllowedLocalPath failed",
-			zap.String("path", path), zap.Error(err))
 		return LocalRepoStatus{}, err
 	}
 	dirty, err := readGitDirtyFiles(ctx, absPath)
 	if err != nil {
-		s.logger.Info("DEBUG_BRANCH readGitDirtyFiles failed",
-			zap.String("absPath", absPath), zap.Error(err))
 		return LocalRepoStatus{}, err
 	}
-	branch := readGitCurrentBranchVerbose(absPath, roots, s.logger)
-	s.logger.Info("DEBUG_BRANCH LocalRepositoryStatus result",
-		zap.String("absPath", absPath),
-		zap.String("branch", branch),
-		zap.Int("dirty_count", len(dirty)))
 	return LocalRepoStatus{
-		CurrentBranch: branch,
+		CurrentBranch: readGitCurrentBranch(absPath, s.discoveryRoots()),
 		DirtyFiles:    dirty,
 	}, nil
-}
-
-// readGitCurrentBranchVerbose mirrors readGitCurrentBranch but logs which arm
-// returned the empty string. Used for the debug repro of the task-create dialog
-// "branch" placeholder; remove once the path-allowlist / detached-HEAD root
-// cause is identified.
-func readGitCurrentBranchVerbose(repoPath string, allowedRoots []string, log *logger.Logger) string {
-	if !filepath.IsAbs(repoPath) {
-		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: not absolute", zap.String("repoPath", repoPath))
-		return ""
-	}
-	cleanRepo := filepath.Clean(repoPath)
-	gitDir, err := resolveGitDirWithin(cleanRepo, allowedRoots)
-	if err != nil {
-		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: resolveGitDirWithin",
-			zap.String("cleanRepo", cleanRepo),
-			zap.Strings("allowedRoots", allowedRoots),
-			zap.Error(err))
-		return ""
-	}
-	headPath := filepath.Clean(filepath.Join(gitDir, gitHEAD))
-	log.Info("DEBUG_BRANCH readGitCurrentBranch resolved gitDir",
-		zap.String("gitDir", gitDir),
-		zap.String("headPath", headPath))
-	if !filepath.IsAbs(headPath) {
-		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: headPath not abs", zap.String("headPath", headPath))
-		return ""
-	}
-	content, err := os.ReadFile(headPath)
-	if err != nil {
-		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: ReadFile", zap.String("headPath", headPath), zap.Error(err))
-		return ""
-	}
-	trimmed := strings.TrimSpace(string(content))
-	log.Info("DEBUG_BRANCH readGitCurrentBranch HEAD content", zap.String("trimmed", trimmed))
-	ref, ok := strings.CutPrefix(trimmed, "ref: ")
-	if !ok {
-		log.Info("DEBUG_BRANCH readGitCurrentBranch bail: detached HEAD", zap.String("trimmed", trimmed))
-		return ""
-	}
-	return strings.TrimPrefix(ref, "refs/heads/")
 }
 
 func (s *Service) resolveAllowedLocalPath(repoPath string) (string, error) {
@@ -552,10 +494,32 @@ func readGitCurrentBranch(repoPath string, allowedRoots []string) string {
 	}
 	trimmed := strings.TrimSpace(string(content))
 	ref, ok := strings.CutPrefix(trimmed, "ref: ")
-	if !ok {
-		return ""
+	if ok {
+		return strings.TrimPrefix(ref, "refs/heads/")
 	}
-	return strings.TrimPrefix(ref, "refs/heads/")
+	// Detached HEAD: HEAD is a raw commit SHA (no "ref: " prefix). Return the
+	// short form so the task-create dialog's locked branch chip surfaces a
+	// meaningful identifier ("a7f5558") instead of the empty placeholder.
+	// Validate it's a hex string of 40 chars to avoid leaking garbled HEAD content.
+	if isHexCommitSHA(trimmed) {
+		return trimmed[:7]
+	}
+	return ""
+}
+
+// isHexCommitSHA returns true if s is a 40-character lowercase hex string —
+// the format git writes to HEAD when detached. Anything else (truncated,
+// uppercase, with prefix) is treated as unparseable rather than echoed back.
+func isHexCommitSHA(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // readGitDirtyFiles returns the list of dirty file paths in a repository, as

--- a/apps/backend/internal/task/service/repository_discovery_test.go
+++ b/apps/backend/internal/task/service/repository_discovery_test.go
@@ -170,6 +170,44 @@ func TestReadGitDefaultBranch(t *testing.T) {
 	}
 }
 
+func TestReadGitCurrentBranchDetachedHead(t *testing.T) {
+	repoPath := canonicalTempDir(t)
+	gitDir := filepath.Join(repoPath, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir git: %v", err)
+	}
+	headPath := filepath.Join(gitDir, "HEAD")
+	roots := []string{filepath.Dir(repoPath)}
+
+	// Branch HEAD: returns the branch name.
+	if err := os.WriteFile(headPath, []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("write HEAD: %v", err)
+	}
+	if got := readGitCurrentBranch(repoPath, roots); got != "main" {
+		t.Fatalf("ref HEAD: got %q, want %q", got, "main")
+	}
+
+	// Detached HEAD with a 40-char SHA returns the short (7-char) form. This
+	// is the regression: pre-fix it returned "" and the task-create dialog's
+	// locked branch chip fell back to the "branch" placeholder.
+	const sha = "a7f5558af69cd3cc2813536b775687b9bfaf65db"
+	if err := os.WriteFile(headPath, []byte(sha+"\n"), 0o644); err != nil {
+		t.Fatalf("write detached HEAD: %v", err)
+	}
+	if got := readGitCurrentBranch(repoPath, roots); got != "a7f5558" {
+		t.Fatalf("detached HEAD: got %q, want %q", got, "a7f5558")
+	}
+
+	// Garbled HEAD content (not a valid SHA): return empty rather than
+	// echo back arbitrary bytes.
+	if err := os.WriteFile(headPath, []byte("not-a-sha\n"), 0o644); err != nil {
+		t.Fatalf("write garbled HEAD: %v", err)
+	}
+	if got := readGitCurrentBranch(repoPath, roots); got != "" {
+		t.Fatalf("garbled HEAD: got %q, want empty", got)
+	}
+}
+
 func TestResolveGitDir(t *testing.T) {
 	repoPath := t.TempDir()
 	gitDir := filepath.Join(repoPath, ".git")

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -163,10 +163,16 @@ export function useCurrentLocalBranchEffect(
   workspaceId: string | null,
   repositories: Repository[],
 ) {
-  const { repositories: rows, useGitHubUrl, setCurrentLocalBranch } = fs;
+  const {
+    repositories: rows,
+    useGitHubUrl,
+    setCurrentLocalBranch,
+    setCurrentLocalBranchLoading,
+  } = fs;
   useEffect(() => {
     if (!open || !workspaceId || useGitHubUrl || rows.length !== 1) {
       setCurrentLocalBranch("");
+      setCurrentLocalBranchLoading(false);
       return;
     }
     const row = rows[0];
@@ -177,20 +183,41 @@ export function useCurrentLocalBranchEffect(
     }
     if (!path) {
       setCurrentLocalBranch("");
+      setCurrentLocalBranchLoading(false);
       return;
     }
     let cancelled = false;
+    setCurrentLocalBranchLoading(true);
     getLocalRepositoryStatusAction(workspaceId, path)
       .then((r) => {
-        if (!cancelled) setCurrentLocalBranch(r.current_branch ?? "");
+        if (cancelled) return;
+        const branch = r.current_branch ?? "";
+        if (!branch) {
+          // Backend silently returns "" for detached HEAD or path-allowlist
+          // misses. Surface for debugging without blocking the UI.
+          console.warn("[task-create] local repo status returned no current branch", { path });
+        }
+        setCurrentLocalBranch(branch);
+        setCurrentLocalBranchLoading(false);
       })
-      .catch(() => {
-        if (!cancelled) setCurrentLocalBranch("");
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn("[task-create] failed to load local repo status", { path, err });
+        setCurrentLocalBranch("");
+        setCurrentLocalBranchLoading(false);
       });
     return () => {
       cancelled = true;
     };
-  }, [open, workspaceId, useGitHubUrl, rows, repositories, setCurrentLocalBranch]);
+  }, [
+    open,
+    workspaceId,
+    useGitHubUrl,
+    rows,
+    repositories,
+    setCurrentLocalBranch,
+    setCurrentLocalBranchLoading,
+  ]);
 }
 
 export function useDefaultSelectionsEffect(

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -170,39 +170,49 @@ export function useCurrentLocalBranchEffect(
     setCurrentLocalBranchLoading,
   } = fs;
   useEffect(() => {
+    // prettier-ignore
+    console.log("[task-create] DEBUG_BRANCH effect entry", { open, workspaceId, useGitHubUrl, rowsLength: rows.length, firstRow: rows[0] ? { localPath: rows[0].localPath, repositoryId: rows[0].repositoryId, branch: rows[0].branch } : null, repositoriesLength: repositories.length });
     if (!open || !workspaceId || useGitHubUrl || rows.length !== 1) {
+      // prettier-ignore
+      console.log("[task-create] DEBUG_BRANCH bail: gate", { open, hasWorkspace: !!workspaceId, useGitHubUrl, rowsLength: rows.length });
       setCurrentLocalBranch("");
       setCurrentLocalBranchLoading(false);
       return;
     }
     const row = rows[0];
     let path = row.localPath ?? "";
+    let pathSource: "localPath" | "repository.local_path" | "" = path ? "localPath" : "";
     if (!path && row.repositoryId) {
       const repo = repositories.find((r: Repository) => r.id === row.repositoryId);
+      // prettier-ignore
+      console.log("[task-create] DEBUG_BRANCH path lookup", { repositoryId: row.repositoryId, foundRepo: !!repo, repoLocalPath: repo?.local_path });
       path = repo?.local_path ?? "";
+      pathSource = path ? "repository.local_path" : "";
     }
     if (!path) {
+      // prettier-ignore
+      console.log("[task-create] DEBUG_BRANCH bail: no path resolved", { rowLocalPath: row.localPath, rowRepositoryId: row.repositoryId, repositoriesLength: repositories.length });
       setCurrentLocalBranch("");
       setCurrentLocalBranchLoading(false);
       return;
     }
+    console.log("[task-create] DEBUG_BRANCH calling action", { workspaceId, path, pathSource });
     let cancelled = false;
     setCurrentLocalBranchLoading(true);
     getLocalRepositoryStatusAction(workspaceId, path)
       .then((r) => {
+        console.log("[task-create] DEBUG_BRANCH action resolved", { path, cancelled, response: r });
         if (cancelled) return;
         const branch = r.current_branch ?? "";
         if (!branch) {
-          // Backend silently returns "" for detached HEAD or path-allowlist
-          // misses. Surface for debugging without blocking the UI.
-          console.warn("[task-create] local repo status returned no current branch", { path });
+          console.log("[task-create] local repo status returned no current branch", { path });
         }
         setCurrentLocalBranch(branch);
         setCurrentLocalBranchLoading(false);
       })
       .catch((err) => {
+        console.log("[task-create] DEBUG_BRANCH action rejected", { path, err });
         if (cancelled) return;
-        console.warn("[task-create] failed to load local repo status", { path, err });
         setCurrentLocalBranch("");
         setCurrentLocalBranchLoading(false);
       });

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -170,48 +170,31 @@ export function useCurrentLocalBranchEffect(
     setCurrentLocalBranchLoading,
   } = fs;
   useEffect(() => {
-    // prettier-ignore
-    console.log("[task-create] DEBUG_BRANCH effect entry", { open, workspaceId, useGitHubUrl, rowsLength: rows.length, firstRow: rows[0] ? { localPath: rows[0].localPath, repositoryId: rows[0].repositoryId, branch: rows[0].branch } : null, repositoriesLength: repositories.length });
     if (!open || !workspaceId || useGitHubUrl || rows.length !== 1) {
-      // prettier-ignore
-      console.log("[task-create] DEBUG_BRANCH bail: gate", { open, hasWorkspace: !!workspaceId, useGitHubUrl, rowsLength: rows.length });
       setCurrentLocalBranch("");
       setCurrentLocalBranchLoading(false);
       return;
     }
     const row = rows[0];
     let path = row.localPath ?? "";
-    let pathSource: "localPath" | "repository.local_path" | "" = path ? "localPath" : "";
     if (!path && row.repositoryId) {
       const repo = repositories.find((r: Repository) => r.id === row.repositoryId);
-      // prettier-ignore
-      console.log("[task-create] DEBUG_BRANCH path lookup", { repositoryId: row.repositoryId, foundRepo: !!repo, repoLocalPath: repo?.local_path });
       path = repo?.local_path ?? "";
-      pathSource = path ? "repository.local_path" : "";
     }
     if (!path) {
-      // prettier-ignore
-      console.log("[task-create] DEBUG_BRANCH bail: no path resolved", { rowLocalPath: row.localPath, rowRepositoryId: row.repositoryId, repositoriesLength: repositories.length });
       setCurrentLocalBranch("");
       setCurrentLocalBranchLoading(false);
       return;
     }
-    console.log("[task-create] DEBUG_BRANCH calling action", { workspaceId, path, pathSource });
     let cancelled = false;
     setCurrentLocalBranchLoading(true);
     getLocalRepositoryStatusAction(workspaceId, path)
       .then((r) => {
-        console.log("[task-create] DEBUG_BRANCH action resolved", { path, cancelled, response: r });
         if (cancelled) return;
-        const branch = r.current_branch ?? "";
-        if (!branch) {
-          console.log("[task-create] local repo status returned no current branch", { path });
-        }
-        setCurrentLocalBranch(branch);
+        setCurrentLocalBranch(r.current_branch ?? "");
         setCurrentLocalBranchLoading(false);
       })
-      .catch((err) => {
-        console.log("[task-create] DEBUG_BRANCH action rejected", { path, err });
+      .catch(() => {
         if (cancelled) return;
         setCurrentLocalBranch("");
         setCurrentLocalBranchLoading(false);

--- a/apps/web/components/task-create-dialog-repo-chips.test.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.test.tsx
@@ -139,6 +139,51 @@ describe("RepoChipsRow", () => {
     expect(screen.queryByTestId("repo-chips-row")).toBeNull();
   });
 
+  it("locked branch chip shows the resolved current branch when not loading", () => {
+    mockBranches.value = {
+      branches: [{ name: "feature/x", type: "local" } as Branch],
+      isLoading: false,
+    };
+    renderInProvider(
+      <RepoChipsRow
+        fs={makeFs({
+          repositories: [row({ key: "r0", repositoryId: REPO_FRONT_ID })],
+          currentLocalBranch: "feature/x",
+          currentLocalBranchLoading: false,
+        })}
+        repositories={[makeRepo(REPO_FRONT_ID, "frontend")]}
+        isTaskStarted={false}
+        workspaceId="ws-1"
+        onRowRepositoryChange={NOOP}
+        onRowBranchChange={NOOP}
+        isLocalExecutor
+      />,
+    );
+    expect(screen.getByText("feature/x")).toBeTruthy();
+  });
+
+  it("locked branch chip shows the loading placeholder while resolving", () => {
+    mockBranches.value = { branches: [], isLoading: false };
+    renderInProvider(
+      <RepoChipsRow
+        fs={makeFs({
+          repositories: [row({ key: "r0", repositoryId: REPO_FRONT_ID })],
+          currentLocalBranch: "",
+          currentLocalBranchLoading: true,
+        })}
+        repositories={[makeRepo(REPO_FRONT_ID, "frontend")]}
+        isTaskStarted={false}
+        workspaceId="ws-1"
+        onRowRepositoryChange={NOOP}
+        onRowBranchChange={NOOP}
+        isLocalExecutor
+      />,
+    );
+    // Without the loading state we'd render the generic "branch" placeholder;
+    // computeBranchPlaceholder switches to "loading…" when branchOverrideLoading is true.
+    expect(screen.getByText(/loading…/i)).toBeTruthy();
+  });
+
   it("disables Add when no more repositories are available", () => {
     renderInProvider(
       <RepoChipsRow

--- a/apps/web/components/task-create-dialog-repo-chips.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.tsx
@@ -422,6 +422,8 @@ function RepoChip({
     branchesLoading || !!branchOverrideLoading,
     branchOptions.length,
   );
+  // prettier-ignore
+  console.log("[task-create] DEBUG_BRANCH chip render", { rowKey: row.key, rowRepositoryId: row.repositoryId, rowLocalPath: row.localPath, branchLocked, branchOverride, branchOverrideLoading, branchValue, branchPlaceholder, branchOptionsCount: branchOptions.length, branchesLoading });
 
   return (
     <span

--- a/apps/web/components/task-create-dialog-repo-chips.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.tsx
@@ -172,6 +172,7 @@ function ChipsList({
           excludedRepoIds={collectUsedRepoIds(fs.repositories, row.key)}
           branchLocked={branchLocked}
           branchOverride={branchLocked ? fs.currentLocalBranch : undefined}
+          branchOverrideLoading={branchLocked ? fs.currentLocalBranchLoading : false}
           onRepositoryChange={(value) => onRowRepositoryChange(row.key, value)}
           onBranchChange={(value) => onRowBranchChange(row.key, value)}
           onRemove={() => fs.removeRepository(row.key)}
@@ -277,6 +278,13 @@ type RepoChipProps = {
    * instead of whatever the user picked under a different executor.
    */
   branchOverride?: string;
+  /**
+   * True while resolving the locked branch from disk. Lets the chip render
+   * a "Loading branch…" placeholder instead of the generic "branch" stub —
+   * which would otherwise lie to the user about an unset state in the brief
+   * window between dialog open and the local-status fetch resolving.
+   */
+  branchOverrideLoading?: boolean;
   onRepositoryChange: (value: string) => void;
   onBranchChange: (value: string) => void;
   onRemove: () => void;
@@ -386,6 +394,7 @@ function RepoChip({
   excludedRepoIds,
   branchLocked,
   branchOverride,
+  branchOverrideLoading,
   onRepositoryChange,
   onBranchChange,
   onRemove,
@@ -403,11 +412,14 @@ function RepoChip({
     repositories,
     discoveredRepositories,
   );
-  const branchValue = branchOverride ?? row.branch;
+  // Show empty (so the placeholder renders) while the locked-branch fetch is
+  // in flight; otherwise the chip would briefly display row.branch before the
+  // override lands and snap to a different value.
+  const branchValue = branchOverrideLoading ? "" : (branchOverride ?? row.branch);
   const hasRepo = !!(row.repositoryId || row.localPath);
   const branchPlaceholder = computeBranchPlaceholder(
     hasRepo,
-    branchesLoading,
+    branchesLoading || !!branchOverrideLoading,
     branchOptions.length,
   );
 

--- a/apps/web/components/task-create-dialog-repo-chips.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.tsx
@@ -422,9 +422,6 @@ function RepoChip({
     branchesLoading || !!branchOverrideLoading,
     branchOptions.length,
   );
-  // prettier-ignore
-  console.log("[task-create] DEBUG_BRANCH chip render", { rowKey: row.key, rowRepositoryId: row.repositoryId, rowLocalPath: row.localPath, branchLocked, branchOverride, branchOverrideLoading, branchValue, branchPlaceholder, branchOptionsCount: branchOptions.length, branchesLoading });
-
   return (
     <span
       className="inline-flex items-center rounded-md border border-input bg-input/20 dark:bg-input/30 pr-0.5"

--- a/apps/web/components/task-create-dialog-state.ts
+++ b/apps/web/components/task-create-dialog-state.ts
@@ -240,11 +240,14 @@ function useWorkflowAgentProfileState() {
 function useFreshBranchState() {
   const [freshBranchEnabled, setFreshBranchEnabled] = useState(false);
   const [currentLocalBranch, setCurrentLocalBranch] = useState("");
+  const [currentLocalBranchLoading, setCurrentLocalBranchLoading] = useState(false);
   return {
     freshBranchEnabled,
     setFreshBranchEnabled,
     currentLocalBranch,
     setCurrentLocalBranch,
+    currentLocalBranchLoading,
+    setCurrentLocalBranchLoading,
   };
 }
 
@@ -505,7 +508,13 @@ export function useDialogComputed({
   const executorHint = useExecutorHint(executors, fs.executorId, selectedRepoCount);
   const isLocalExecutor = useIsLocalExecutor(executors, fs.executorId);
   const { headerRepositoryOptions } = useRepositoryOptions(repositories, fs.discoveredRepositories);
-  const agentProfilesLoading = open && !settingsData.agentsLoaded;
+  // Treat the dialog as still loading agents until BOTH the agent profiles
+  // (DB rows) AND the host-utility capability probe have resolved. The
+  // backend reconciler renames profiles ("Claude" → "Claude Sonnet 4.6") only
+  // after the probe lands, so showing the selector before then surfaces stale
+  // labels missing the model badge.
+  const agentProfilesLoading =
+    open && (!settingsData.agentsLoaded || !settingsData.capabilitiesLoaded);
   const executorsLoading = open && !settingsData.executorsLoaded;
   return {
     isPassthroughProfile,
@@ -556,6 +565,7 @@ export function useTaskCreateDialogData(
   const agentProfiles = useAppStore((state) => state.agentProfiles.items);
   const executors = useAppStore((state) => state.executors.items);
   const settingsData = useAppStore((state) => state.settingsData);
+  const availableAgentsLoaded = useAppStore((state) => state.availableAgents.loaded);
   const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
 
   useSettingsData(open);
@@ -570,7 +580,11 @@ export function useTaskCreateDialogData(
     workspaceId,
     workflowId,
     defaultStepId,
-    settingsData,
+    settingsData: {
+      agentsLoaded: settingsData.agentsLoaded,
+      executorsLoaded: settingsData.executorsLoaded,
+      capabilitiesLoaded: availableAgentsLoaded,
+    },
     agentProfiles,
     workspaces,
     executors,

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -93,7 +93,11 @@ export type DialogComputedArgs = {
   workspaceId: string | null;
   workflowId: string | null;
   defaultStepId: string | null;
-  settingsData: { agentsLoaded: boolean; executorsLoaded: boolean };
+  settingsData: {
+    agentsLoaded: boolean;
+    executorsLoaded: boolean;
+    capabilitiesLoaded: boolean;
+  };
   agentProfiles: AgentProfileOption[];
   workspaces: Workspace[];
   executors: Executor[];
@@ -193,6 +197,9 @@ export type DialogFormState = {
   /** Currently checked-out branch in the selected local repo (for the disabled selector placeholder) */
   currentLocalBranch: string;
   setCurrentLocalBranch: (v: string) => void;
+  /** True while resolving currentLocalBranch — distinguishes "still loading" from "no branch on disk" */
+  currentLocalBranchLoading: boolean;
+  setCurrentLocalBranchLoading: (v: boolean) => void;
 };
 
 export type SubmitHandlersDeps = {

--- a/apps/web/hooks/domains/settings/use-settings-data.ts
+++ b/apps/web/hooks/domains/settings/use-settings-data.ts
@@ -1,15 +1,18 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAppStore } from "@/components/state-provider";
-import { listAgents, listExecutors } from "@/lib/api";
+import { listAgents, listAvailableAgents, listExecutors } from "@/lib/api";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
 
 export function useSettingsData(enabled = true) {
   const executors = useAppStore((state) => state.executors.items);
   const settingsAgents = useAppStore((state) => state.settingsAgents.items);
   const settingsData = useAppStore((state) => state.settingsData);
+  const availableAgents = useAppStore((state) => state.availableAgents);
   const setExecutors = useAppStore((state) => state.setExecutors);
   const setSettingsAgents = useAppStore((state) => state.setSettingsAgents);
   const setAgentProfiles = useAppStore((state) => state.setAgentProfiles);
+  const setAvailableAgents = useAppStore((state) => state.setAvailableAgents);
+  const setAvailableAgentsLoading = useAppStore((state) => state.setAvailableAgentsLoading);
   const setSettingsData = useAppStore((state) => state.setSettingsData);
 
   useEffect(() => {
@@ -53,5 +56,58 @@ export function useSettingsData(enabled = true) {
     setSettingsData,
     settingsAgents.length,
     settingsData.agentsLoaded,
+  ]);
+
+  // Capabilities probe — host-utility probes ACP agents in the background and
+  // the backend reconciler renames profiles from "Claude" → "Claude Sonnet 4.6"
+  // once results land. The DB write happens *after* listAgents has already
+  // returned the seeded profile.name, so without re-fetching here, the create
+  // dialog renders stale labels (agent name with no model badge) for as long as
+  // the probe takes to finish. This effect kicks the probe off and gates
+  // listAgents-staleness on its completion.
+  useEffect(() => {
+    if (!enabled) return;
+    if (availableAgents.loaded || availableAgents.loading) return;
+    setAvailableAgentsLoading(true);
+    listAvailableAgents({ cache: "no-store" })
+      .then((response) => setAvailableAgents(response.agents, response.tools ?? []))
+      .catch(() => setAvailableAgents([]));
+  }, [
+    enabled,
+    availableAgents.loaded,
+    availableAgents.loading,
+    setAvailableAgents,
+    setAvailableAgentsLoading,
+  ]);
+
+  // Re-fetch agent profiles once the host-utility probe completes. Use a ref
+  // gate so we re-fetch exactly once per `availableAgents.loaded` transition,
+  // not on every render after.
+  const reconciledRef = useRef(false);
+  useEffect(() => {
+    if (!enabled) return;
+    if (!availableAgents.loaded) return;
+    if (!settingsData.agentsLoaded) return; // Wait for the initial agents fetch first.
+    if (reconciledRef.current) return;
+    reconciledRef.current = true;
+    listAgents({ cache: "no-store" })
+      .then((response) => {
+        setSettingsAgents(response.agents);
+        setAgentProfiles(
+          response.agents.flatMap((agent) =>
+            agent.profiles.map((profile) => toAgentProfileOption(agent, profile)),
+          ),
+        );
+      })
+      .catch(() => {
+        // Best-effort reconcile; keep prior (possibly stale) profiles rather
+        // than wiping the dialog state on a transient error.
+      });
+  }, [
+    enabled,
+    availableAgents.loaded,
+    settingsData.agentsLoaded,
+    setAgentProfiles,
+    setSettingsAgents,
   ]);
 }


### PR DESCRIPTION
## Summary

Two narrow races on task-create dialog open, both surfaced when the user opens the dialog quickly after backend boot.

1. **Locked branch chip showed the generic "branch" placeholder** while `useCurrentLocalBranchEffect` was still resolving the on-disk current branch. Now shows "loading…" during the in-flight window and lands the resolved branch when the action returns. Adds `console.warn` on empty/error paths so a real backend issue (detached HEAD, path-allowlist miss) leaves a breadcrumb.

2. **Agent profile labels missing the model badge** after a fast click in. The backend reconciler renames profiles "Claude" → "Claude Sonnet 4.6" once the host-utility capability probe completes (ADR 0002), but the frontend fetched `listAgents` once and cached the seeded labels forever. `useSettingsData` now triggers the capability probe itself, gates the dialog's `agentProfilesLoading` flag on probe completion, and re-fetches `listAgents` once after `availableAgents.loaded` flips true so the dropdown picks up the reconciled labels without a manual refresh.

## Important changes

- `useCurrentLocalBranchEffect` (`task-create-dialog-effects.ts`) tracks loading via the new `currentLocalBranchLoading` flag on `DialogFormState` and warns on empty/error responses.
- `RepoChip` accepts `branchOverrideLoading` and routes it through `computeBranchPlaceholder` so the chip reads "loading…" instead of "branch" during the resolve window.
- `useSettingsData` now: (a) kicks off `listAvailableAgents` itself, (b) tracks `capabilitiesLoaded` via the existing `availableAgents.loaded` flag, (c) re-fetches `listAgents` exactly once on the loaded transition (guarded by a `useRef`).
- `DialogComputedArgs.settingsData` grows `capabilitiesLoaded`; `agentProfilesLoading` is now `!agentsLoaded || !capabilitiesLoaded`.

## Validation

- `pnpm --filter @kandev/web typecheck` — pass
- `pnpm --filter @kandev/web lint` — pass (0 warnings)
- `pnpm --filter @kandev/web test task-create-dialog-repo-chips` — 14 pass (12 existing + 2 new for locked-branch loading state)
- Pre-existing test failures in `recent-tasks.test.ts` and `jira-availability.test.ts` reproduce on `main`; unrelated to this PR.

## Possible improvements

The reconcile re-fetch is best-effort: if `listAgents` fails on the second call, we keep the (possibly stale) profiles from the first fetch rather than wiping the dropdown. Future work could add a backend WS event ("profiles reconciled") so the frontend doesn't have to poll on capability completion.

## Checklist

- [ ] Self-reviewed
- [ ] Tests added or updated
- [ ] Tested locally with `make dev`