### PR TITLE
fix(backend): correct task_environments migration order for older DBs

### DIFF
--- a/apps/backend/internal/task/repository/sqlite/base.go
+++ b/apps/backend/internal/task/repository/sqlite/base.go
@@ -183,6 +183,9 @@ func (r *Repository) runMigrations() error {
 	if err := r.migrateSessionsRemoveAgentExecutionID(); err != nil {
 		return err
 	}
+	// Add task_dir_name column to task_environments for multi-repo task root layout (ignore error if already exists).
+	// Must run BEFORE migrateTaskEnvironmentsRemoveAgentExecutionID, which copies task_dir_name into the recreated table.
+	_, _ = r.db.Exec(`ALTER TABLE task_environments ADD COLUMN task_dir_name TEXT DEFAULT ''`)
 	if err := r.migrateTaskEnvironmentsRemoveAgentExecutionID(); err != nil {
 		return err
 	}
@@ -190,8 +193,6 @@ func (r *Repository) runMigrations() error {
 	_, _ = r.db.Exec(`ALTER TABLE workflows ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`)
 	// Add agent_profile_id column to workflows for per-workflow agent profile override (ignore error if already exists)
 	_, _ = r.db.Exec(`ALTER TABLE workflows ADD COLUMN agent_profile_id TEXT DEFAULT ''`)
-	// Add task_dir_name column to task_environments for multi-repo task root layout (ignore error if already exists)
-	_, _ = r.db.Exec(`ALTER TABLE task_environments ADD COLUMN task_dir_name TEXT DEFAULT ''`)
 	// Add hidden flag to workflows for system-only flows excluded from management UI (ignore error if already exists)
 	_, _ = r.db.Exec(`ALTER TABLE workflows ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0`)
 	return nil
@@ -415,7 +416,9 @@ func (r *Repository) migrateTaskEnvironmentsRemoveAgentExecutionID() error {
 		`ALTER TABLE task_environments_new RENAME TO task_environments`,
 		`CREATE INDEX IF NOT EXISTS idx_task_environments_task_id ON task_environments(task_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_task_environments_status ON task_environments(status)`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_task_environments_task_id ON task_environments(task_id)`,
+		// uniq_task_environments_task_id is created by ensureTaskEnvironmentTaskUniqueIndex
+		// AFTER healDuplicateTaskEnvironments collapses any pre-existing duplicates.
+		// Creating it here would fail on databases that still have duplicate task_id rows.
 	})
 }
 


### PR DESCRIPTION
Two ordering bugs in the SQLite migration sequence caused `failed to initialize schema` on startup for users whose database predated PR #767 (multi-repo) and PR #799 (executors_running source-of-truth), leaving them unable to launch the app after pulling main; reordering the affected migrations restores a clean upgrade path without requiring users to delete their database.

## Important Changes

- `ALTER TABLE task_environments ADD COLUMN task_dir_name` now runs **before** `migrateTaskEnvironmentsRemoveAgentExecutionID`, whose recreate INSERT references that column via `COALESCE(task_dir_name, '')` — `COALESCE` only handles NULL, not a missing column.
- The recreate migration no longer creates `uniq_task_environments_task_id` inline. The pre-existing `ensureTaskEnvironmentTaskUniqueIndex()` already handles it, and it must run **after** `healDuplicateTaskEnvironments()` so duplicate `task_id` rows are collapsed first.

## Validation

- `make -C apps/backend fmt test lint` — all green
- `cd apps && pnpm format && pnpm --filter @kandev/web lint` — clean
- Reproduced the original `no such column: task_dir_name` and `UNIQUE constraint failed: task_environments.task_id` errors on a stale local DB; both resolved after the fix and `make start-debug` boots cleanly.

## Possible Improvements

Low risk. Worth adding a regression test that seeds a pre-#767 schema (with `agent_execution_id`, no `task_dir_name`, duplicate `task_id` rows) and runs `initializeSchema` end-to-end so future re-orderings are caught in CI.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.