### PR TITLE
fix: suppress spurious task-failed toasts on resume and reconnect

### DIFF
--- a/apps/backend/internal/agent/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/lifecycle/manager_launch.go
@@ -491,7 +491,61 @@ func (m *Manager) Launch(ctx context.Context, req *LaunchRequest) (*AgentExecuti
 	if err != nil {
 		return nil, err
 	}
-	return v.(*AgentExecution), nil
+	execution := v.(*AgentExecution)
+	// If this Launch call joined a workspace-only ensure peer's singleflight
+	// slot (EnsureWorkspaceExecutionForSession / GetOrEnsureExecution), the
+	// returned execution has no AgentCommand and the orchestrator's subsequent
+	// StartAgentProcess() would fail with "no agent command configured".
+	// Promote it in place so the agent subprocess can start against the
+	// existing agentctl instance.
+	if execution.AgentCommand == "" {
+		if err := m.promoteWorkspaceExecution(ctx, execution, req); err != nil {
+			return nil, err
+		}
+	}
+	return execution, nil
+}
+
+// promoteWorkspaceExecution populates the agent command fields on a
+// workspace-only execution so a subsequent StartAgentProcess() can configure
+// and start the agent subprocess. Concurrent promoters serialize through a
+// dedicated singleflight key so they don't race on the shared AgentExecution
+// pointer.
+func (m *Manager) promoteWorkspaceExecution(ctx context.Context, execution *AgentExecution, req *LaunchRequest) error {
+	_, err, _ := m.ensureExecutionGroup.Do("promote:"+req.SessionID, func() (interface{}, error) {
+		// Re-check after acquiring the slot — a peer Launch may have already
+		// promoted while we were waiting.
+		if execution.AgentCommand != "" {
+			return nil, nil
+		}
+		agentTypeName, profileInfo, err := m.resolveAgentProfile(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		agentConfig, ok := m.registry.Get(agentTypeName)
+		if !ok {
+			return nil, fmt.Errorf("agent type %q not found in registry", agentTypeName)
+		}
+		if !agentConfig.Enabled() {
+			return nil, fmt.Errorf("agent type %q is disabled", agentTypeName)
+		}
+		cmds := m.buildAgentCommand(req, profileInfo, agentConfig)
+		execution.AgentCommand = cmds.initial
+		execution.ContinueCommand = cmds.continue_
+		if req.ACPSessionID != "" && execution.ACPSessionID == "" {
+			execution.ACPSessionID = req.ACPSessionID
+		}
+		if req.PreviousExecutionID != "" {
+			execution.isResumedSession = true
+		}
+		m.logger.Info("promoted workspace-only execution to agent execution",
+			zap.String("execution_id", execution.ID),
+			zap.String("session_id", req.SessionID),
+			zap.String("agent_profile_id", req.AgentProfileID),
+			zap.Bool("resume", req.ACPSessionID != ""))
+		return nil, nil
+	})
+	return err
 }
 
 // launchInternal is the body of Launch run inside the per-session singleflight
@@ -517,9 +571,15 @@ func (m *Manager) launchInternal(ctx context.Context, req *LaunchRequest) (*Agen
 		return nil, fmt.Errorf("agent type %q is disabled", agentTypeName)
 	}
 
-	// 3. Check if session already has an agent running
+	// 3. Check if session already has an agent running. A workspace-only
+	// execution created by EnsureWorkspaceExecutionForSession /
+	// GetOrEnsureExecution has no AgentCommand — return it so the outer Launch
+	// can promote it instead of erroring as if a real agent were running.
 	if req.SessionID != "" {
 		if existingExecution, exists := m.executionStore.GetBySessionID(req.SessionID); exists {
+			if existingExecution.AgentCommand == "" {
+				return existingExecution, nil
+			}
 			return nil, fmt.Errorf("session %q already has an agent running (execution: %s)", req.SessionID, existingExecution.ID)
 		}
 	}

--- a/apps/backend/internal/agent/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/lifecycle/manager_launch_test.go
@@ -207,6 +207,70 @@ func TestLaunchResolveWorkspacePath_NonEphemeralSkipsQuickChatDir(t *testing.T) 
 	require.Empty(t, workspacePath, "non-ephemeral task without repo should NOT get a quick-chat workspace")
 }
 
+// TestLaunch_PromotesWorkspaceOnlyExecution verifies that when Launch finds an
+// existing workspace-only execution in the store (created by a peer
+// EnsureWorkspaceExecutionForSession / GetOrEnsureExecution call), it promotes
+// it in place by populating AgentCommand instead of returning an
+// "already has an agent running" error. This regression test covers the
+// singleflight-collision bug that surfaced as "Task failed to start" toasts on
+// backend restart, where a workspace-only execution was returned to the resume
+// path and StartAgentProcess() then failed with "no agent command configured".
+func TestLaunch_PromotesWorkspaceOnlyExecution(t *testing.T) {
+	mgr := newTestManager()
+
+	// Inject a workspace-only execution: AgentCommand is intentionally empty,
+	// matching what createExecution produces when called from
+	// ensureWorkspaceExecutionLocked.
+	existing := &AgentExecution{
+		ID:             "exec-workspace-only",
+		SessionID:      "session-1",
+		TaskID:         "task-1",
+		AgentProfileID: "profile-1",
+	}
+	require.NoError(t, mgr.executionStore.Add(existing))
+
+	req := &LaunchRequest{
+		TaskID:              "task-1",
+		SessionID:           "session-1",
+		AgentProfileID:      "profile-1",
+		ACPSessionID:        "acp-session-abc",
+		PreviousExecutionID: "exec-prev",
+	}
+
+	got, err := mgr.Launch(context.Background(), req)
+	require.NoError(t, err)
+	require.Same(t, existing, got, "Launch must reuse the workspace-only execution, not create a new one")
+	require.NotEmpty(t, got.AgentCommand, "AgentCommand must be populated by promotion")
+	require.Equal(t, "acp-session-abc", got.ACPSessionID, "ACPSessionID must be carried over from the request")
+	require.True(t, got.isResumedSession, "isResumedSession must be set when PreviousExecutionID is non-empty")
+}
+
+// TestLaunch_RejectsWhenAgentAlreadyRunning verifies the original "already has
+// an agent running" guard still fires when the existing execution is a real
+// agent-equipped one (AgentCommand populated), preventing duplicate launches.
+func TestLaunch_RejectsWhenAgentAlreadyRunning(t *testing.T) {
+	mgr := newTestManager()
+
+	existing := &AgentExecution{
+		ID:             "exec-running",
+		SessionID:      "session-2",
+		TaskID:         "task-2",
+		AgentProfileID: "profile-2",
+		AgentCommand:   "auggie --acp",
+	}
+	require.NoError(t, mgr.executionStore.Add(existing))
+
+	req := &LaunchRequest{
+		TaskID:         "task-2",
+		SessionID:      "session-2",
+		AgentProfileID: "profile-2",
+	}
+
+	_, err := mgr.Launch(context.Background(), req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already has an agent running")
+}
+
 // TestLaunch_RaceRollback exercises the race window between the step-3 duplicate
 // session pre-check and the step-8 executionStore.Add in Launch. A barrier inside
 // CreateInstance keeps the goroutine in the race window; the test injects a

--- a/apps/backend/internal/agent/lifecycle/streams.go
+++ b/apps/backend/internal/agent/lifecycle/streams.go
@@ -200,7 +200,24 @@ func (sm *StreamManager) connectWorkspaceStream(execution *AgentExecution, ready
 	// Ensure we signal ready even on failure (so callers don't hang)
 	defer signalReady()
 
+	// Idempotency guard: if a workspace stream is already attached, another
+	// goroutine has connected it (e.g. workspace-only ensure followed by full
+	// launch promotion). Treat as success and exit cleanly.
+	if execution.GetWorkspaceStream() != nil {
+		sm.logger.Debug("workspace stream already attached, skipping connect",
+			zap.String("instance_id", execution.ID))
+		return
+	}
+
 	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// Re-check before each retry in case another goroutine connected meanwhile.
+		if execution.GetWorkspaceStream() != nil {
+			sm.logger.Debug("workspace stream attached during retry, exiting",
+				zap.String("instance_id", execution.ID),
+				zap.Int("attempt", attempt))
+			return
+		}
+
 		callbacks := sm.buildWorkspaceCallbacks(execution)
 
 		ws, err := execution.agentctl.StreamWorkspace(ctx, callbacks)

--- a/apps/backend/internal/agent/lifecycle/streams_test.go
+++ b/apps/backend/internal/agent/lifecycle/streams_test.go
@@ -1,0 +1,46 @@
+package lifecycle
+
+import (
+	"testing"
+	"time"
+
+	agentctl "github.com/kandev/kandev/internal/agentctl/client"
+)
+
+// TestConnectWorkspaceStream_IdempotentWhenAlreadyAttached is the regression
+// test for the workspace-stream double-connect race. Two paths can call
+// connectWorkspaceStream for the same execution (e.g. workspace-only ensure
+// followed by full-launch promotion). The second call previously hit
+// "workspace stream already connected" and burned 5 retries before logging
+// a terminal ERROR. The fix short-circuits when a stream is already attached.
+func TestConnectWorkspaceStream_IdempotentWhenAlreadyAttached(t *testing.T) {
+	sm := NewStreamManager(newTestLogger(), StreamCallbacks{}, nil)
+
+	execution := &AgentExecution{ID: "exec-1", SessionID: "sess-1"}
+	// Pre-attach a non-nil workspace stream — simulates another goroutine
+	// having already connected before this call.
+	execution.SetWorkspaceStream(&agentctl.WorkspaceStream{})
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		sm.connectWorkspaceStream(execution, ready)
+		close(done)
+	}()
+
+	// Should return effectively immediately (well under the 1s first-retry
+	// backoff). 500ms gives ample headroom on slow CI without masking a
+	// regression that would burn through the full 5-retry loop.
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("connectWorkspaceStream did not exit early when stream was already attached")
+	}
+
+	// ready must be closed (deferred signalReady runs even on early exit).
+	select {
+	case <-ready:
+	default:
+		t.Error("ready channel was not closed on early-exit path")
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -639,10 +639,21 @@ func (s *Service) handleRecoverableFailure(ctx context.Context, data watcher.Age
 
 // handleAgentStartFailed is called by the executor when StartAgentProcess fails.
 // It detects auth errors and routes them through the recoverable failure path so
-// the frontend shows login guidance instead of a terminal failure.
+// the frontend shows login guidance instead of a terminal failure. When the
+// failure occurred during a background session resume (fromResume=true) and is
+// not an auth error, it sets the suppressToast flag so the default FAILED
+// transition does not surface a user-facing toast for a transient bootstrap
+// error on focus / auto-resume.
 // Returns true if the failure was handled (caller should skip default FAILED logic).
-func (s *Service) handleAgentStartFailed(ctx context.Context, taskID, sessionID, agentExecutionID string, err error) bool {
+func (s *Service) handleAgentStartFailed(ctx context.Context, taskID, sessionID, agentExecutionID string, err error, fromResume bool) bool {
 	if !isAuthError(err.Error()) {
+		if fromResume {
+			s.logger.Info("suppressing toast for resume bootstrap failure",
+				zap.String("task_id", taskID),
+				zap.String("session_id", sessionID),
+				zap.Error(err))
+			s.suppressToast.Store(sessionID, true)
+		}
 		return false
 	}
 	s.logger.Info("agent start failure is auth error, treating as recoverable",

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -1287,6 +1287,58 @@ func TestHandleRecoverableFailure(t *testing.T) {
 	})
 }
 
+func TestHandleAgentStartFailed(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-auth resume failure sets suppressToast and returns false", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+		handled := svc.handleAgentStartFailed(ctx, "t1", "s1", "exec-1",
+			fmt.Errorf("ACP initialize handshake failed"), true)
+
+		if handled {
+			t.Error("expected handled=false so default FAILED transition runs")
+		}
+		v, ok := svc.suppressToast.Load("s1")
+		if !ok || v.(bool) != true {
+			t.Errorf("expected suppressToast[s1]=true, got ok=%v val=%v", ok, v)
+		}
+	})
+
+	t.Run("non-auth fresh-start failure does not set suppressToast", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+		handled := svc.handleAgentStartFailed(ctx, "t1", "s1", "exec-1",
+			fmt.Errorf("ACP initialize handshake failed"), false)
+
+		if handled {
+			t.Error("expected handled=false")
+		}
+		if _, ok := svc.suppressToast.Load("s1"); ok {
+			t.Error("expected suppressToast NOT set for fresh-start failure")
+		}
+	})
+
+	t.Run("auth error returns true regardless of fromResume", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		taskRepo := newMockTaskRepo()
+		agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+		svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+
+		handled := svc.handleAgentStartFailed(ctx, "t1", "s1", "exec-1",
+			fmt.Errorf("authentication required: please log in"), true)
+
+		if !handled {
+			t.Error("expected handled=true for auth errors")
+		}
+	})
+}
+
 func TestHandleResumeFailure(t *testing.T) {
 	ctx := context.Background()
 

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -382,10 +382,13 @@ type TaskStateChangeFunc func(ctx context.Context, taskID string, state v1.TaskS
 type SessionStateChangeFunc func(ctx context.Context, taskID, sessionID string, state models.TaskSessionState, errorMessage string) error
 
 // AgentStartFailedFunc is called when the agent process fails to start.
-// It receives the task/session/execution IDs and the error. If the callback
-// returns true, it has handled the failure (e.g., as a recoverable auth error)
-// and the executor should skip its default FAILED state updates.
-type AgentStartFailedFunc func(ctx context.Context, taskID, sessionID, agentExecutionID string, err error) (handled bool)
+// It receives the task/session/execution IDs and the error. fromResume is true
+// when the failure occurred during a background session resume (rather than a
+// user-initiated start), letting the orchestrator suppress user-facing toasts
+// for transient bootstrap errors. If the callback returns true, it has handled
+// the failure (e.g., as a recoverable auth error) and the executor should skip
+// its default FAILED state updates.
+type AgentStartFailedFunc func(ctx context.Context, taskID, sessionID, agentExecutionID string, err error, fromResume bool) (handled bool)
 
 // LaunchFailedFunc is called when session launch fails before the agent starts.
 // Useful for creating user-facing status messages tied to launch errors.

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -41,10 +41,14 @@ func isContainerizedExecutor(executorType string) bool {
 }
 
 // runAgentProcessAsync starts the agent subprocess in a background goroutine.
-// On error it marks both the session and task as FAILED.
+// On error it marks the session as FAILED. The task is also marked FAILED only
+// when escalateTaskOnFailure is true; resume callers pass false so a transient
+// background bootstrap error does not destructively overwrite the task's
+// existing state (e.g. REVIEW). fromResume is forwarded to onAgentStartFailed
+// so the orchestrator can suppress user-facing toasts on background recovery.
 // On success it calls onSuccess with a non-cancellable context derived from ctx.
 // ctx is used with WithoutCancel so trace spans are preserved without inheriting cancellation.
-func (e *Executor) runAgentProcessAsync(ctx context.Context, taskID, sessionID, agentExecutionID string, onSuccess func(context.Context)) {
+func (e *Executor) runAgentProcessAsync(ctx context.Context, taskID, sessionID, agentExecutionID string, onSuccess func(context.Context), escalateTaskOnFailure, fromResume bool) {
 	go func() {
 		startCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
 		defer cancel()
@@ -56,8 +60,9 @@ func (e *Executor) runAgentProcessAsync(ctx context.Context, taskID, sessionID, 
 				zap.String("session_id", sessionID),
 				zap.String("agent_execution_id", agentExecutionID),
 				zap.Error(err))
-			// Let the orchestrator handle auth errors as recoverable failures.
-			if e.onAgentStartFailed != nil && e.onAgentStartFailed(updateCtx, taskID, sessionID, agentExecutionID, err) {
+			// Let the orchestrator handle auth errors as recoverable failures
+			// and (for resume) suppress the toast before the session is marked FAILED.
+			if e.onAgentStartFailed != nil && e.onAgentStartFailed(updateCtx, taskID, sessionID, agentExecutionID, err, fromResume) {
 				return
 			}
 			if updateErr := e.updateSessionState(updateCtx, taskID, sessionID, models.TaskSessionStateFailed, err.Error()); updateErr != nil {
@@ -65,10 +70,12 @@ func (e *Executor) runAgentProcessAsync(ctx context.Context, taskID, sessionID, 
 					zap.String("session_id", sessionID),
 					zap.Error(updateErr))
 			}
-			if updateErr := e.updateTaskState(updateCtx, taskID, v1.TaskStateFailed); updateErr != nil {
-				e.logger.Warn("failed to mark task as failed after start error",
-					zap.String("task_id", taskID),
-					zap.Error(updateErr))
+			if escalateTaskOnFailure {
+				if updateErr := e.updateTaskState(updateCtx, taskID, v1.TaskStateFailed); updateErr != nil {
+					e.logger.Warn("failed to mark task as failed after start error",
+						zap.String("task_id", taskID),
+						zap.Error(updateErr))
+				}
 			}
 			// Clean up the execution environment (e.g., destroy remote Sprites instance).
 			// Use force=true since the agent process never fully started.
@@ -92,7 +99,7 @@ func (e *Executor) startAgentProcessAsync(ctx context.Context, taskID, sessionID
 				zap.String("task_id", taskID),
 				zap.Error(updateErr))
 		}
-	})
+	}, true, false)
 }
 
 // updateTaskState updates a task's state, using the callback if set for event publishing,

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -694,5 +694,5 @@ func (e *Executor) startAgentProcessOnResume(ctx context.Context, taskID string,
 			zap.String("task_id", taskID),
 			zap.String("session_id", session.ID),
 			zap.String("session_state", string(session.State)))
-	})
+	}, false, true)
 }

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -672,13 +672,16 @@ verified:
 
 // runAgentProcessAsyncFailureFixture builds an Executor configured to fail
 // StartAgentProcess, with task/session-state-change recorders for assertions.
+// stopCh is closed when StopAgent is invoked — since the failure path calls
+// StopAgent last, blocking on stopCh provides a happens-before barrier for all
+// other recorded fields, removing the need for atomicity or polling.
 type runAgentProcessAsyncFailureFixture struct {
 	exec              *Executor
-	taskStateUpdates  *atomicSlice
-	sessionFailedSeen *atomic.Bool
-	startFailedCalls  *atomic.Int32
-	lastFromResume    *atomic.Bool
-	stopCalled        *atomic.Bool
+	taskStateUpdates  []string
+	sessionFailedSeen bool
+	startFailedCalls  int
+	lastFromResume    bool
+	stopCh            chan struct{}
 }
 
 func newRunAgentProcessAsyncFailureFixture(t *testing.T) *runAgentProcessAsyncFailureFixture {
@@ -687,39 +690,44 @@ func newRunAgentProcessAsyncFailureFixture(t *testing.T) *runAgentProcessAsyncFa
 	repo.sessions["session-123"] = &models.TaskSession{
 		ID: "session-123", TaskID: "task-123", State: models.TaskSessionStateStarting,
 	}
-	stopCalled := &atomic.Bool{}
+	f := &runAgentProcessAsyncFailureFixture{stopCh: make(chan struct{})}
 	agentManager := &mockAgentManager{
 		startAgentProcessFunc: func(ctx context.Context, agentExecutionID string) error {
 			return fmt.Errorf("ACP initialize handshake failed: context deadline exceeded")
 		},
 		stopAgentFunc: func(ctx context.Context, agentExecutionID string, force bool) error {
-			stopCalled.Store(true)
+			close(f.stopCh)
 			return nil
 		},
 	}
-	exec := newTestExecutor(t, agentManager, repo)
-	taskUpdates := &atomicSlice{}
-	sessionFailed := &atomic.Bool{}
-	startFailedCalls := &atomic.Int32{}
-	lastFromResume := &atomic.Bool{}
-	exec.SetOnTaskStateChange(func(ctx context.Context, taskID string, state v1.TaskState) error {
-		taskUpdates.append(string(state))
+	f.exec = newTestExecutor(t, agentManager, repo)
+	f.exec.SetOnTaskStateChange(func(ctx context.Context, taskID string, state v1.TaskState) error {
+		f.taskStateUpdates = append(f.taskStateUpdates, string(state))
 		return nil
 	})
-	exec.SetOnSessionStateChange(func(ctx context.Context, taskID, sessionID string, state models.TaskSessionState, errorMessage string) error {
+	f.exec.SetOnSessionStateChange(func(ctx context.Context, taskID, sessionID string, state models.TaskSessionState, errorMessage string) error {
 		if state == models.TaskSessionStateFailed {
-			sessionFailed.Store(true)
+			f.sessionFailedSeen = true
 		}
 		return repo.UpdateTaskSessionState(ctx, sessionID, state, errorMessage)
 	})
-	exec.SetOnAgentStartFailed(func(ctx context.Context, taskID, sessionID, agentExecutionID string, err error, fromResume bool) bool {
-		startFailedCalls.Add(1)
-		lastFromResume.Store(fromResume)
+	f.exec.SetOnAgentStartFailed(func(ctx context.Context, taskID, sessionID, agentExecutionID string, err error, fromResume bool) bool {
+		f.startFailedCalls++
+		f.lastFromResume = fromResume
 		return false
 	})
-	return &runAgentProcessAsyncFailureFixture{
-		exec: exec, taskStateUpdates: taskUpdates, sessionFailedSeen: sessionFailed,
-		startFailedCalls: startFailedCalls, lastFromResume: lastFromResume, stopCalled: stopCalled,
+	return f
+}
+
+// awaitStop blocks until the failure-path goroutine calls StopAgent.
+// Closing stopCh is the last side-effect, so all other field writes are
+// guaranteed visible by the channel-receive happens-before edge.
+func (f *runAgentProcessAsyncFailureFixture) awaitStop(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.stopCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for StopAgent to be called")
 	}
 }
 
@@ -728,17 +736,17 @@ func TestRunAgentProcessAsync_ResumeDoesNotEscalateTaskState(t *testing.T) {
 	f.exec.runAgentProcessAsync(context.Background(), "task-123", "session-123", "exec-456",
 		func(ctx context.Context) { t.Error("onSuccess should not run on failure") },
 		false, true) // resume path: no escalation, fromResume=true
-	waitFor(t, func() bool { return f.stopCalled.Load() }, 5*time.Second, "StopAgent called")
-	if !f.sessionFailedSeen.Load() {
+	f.awaitStop(t)
+	if !f.sessionFailedSeen {
 		t.Error("expected session state FAILED")
 	}
-	if got := f.taskStateUpdates.snapshot(); len(got) != 0 {
-		t.Errorf("expected no task state updates on resume failure, got %v", got)
+	if len(f.taskStateUpdates) != 0 {
+		t.Errorf("expected no task state updates on resume failure, got %v", f.taskStateUpdates)
 	}
-	if f.startFailedCalls.Load() != 1 {
-		t.Errorf("expected onAgentStartFailed called once, got %d", f.startFailedCalls.Load())
+	if f.startFailedCalls != 1 {
+		t.Errorf("expected onAgentStartFailed called once, got %d", f.startFailedCalls)
 	}
-	if !f.lastFromResume.Load() {
+	if !f.lastFromResume {
 		t.Error("expected fromResume=true to be propagated to onAgentStartFailed")
 	}
 }
@@ -748,52 +756,15 @@ func TestRunAgentProcessAsync_FreshStartEscalatesTaskState(t *testing.T) {
 	f.exec.runAgentProcessAsync(context.Background(), "task-123", "session-123", "exec-456",
 		func(ctx context.Context) { t.Error("onSuccess should not run on failure") },
 		true, false) // fresh-start path: escalate, fromResume=false
-	waitFor(t, func() bool { return f.stopCalled.Load() }, 5*time.Second, "StopAgent called")
-	if !f.sessionFailedSeen.Load() {
+	f.awaitStop(t)
+	if !f.sessionFailedSeen {
 		t.Error("expected session state FAILED")
 	}
-	got := f.taskStateUpdates.snapshot()
-	if len(got) != 1 || got[0] != string(v1.TaskStateFailed) {
-		t.Errorf("expected fresh-start failure to set task state FAILED, got %v", got)
+	if len(f.taskStateUpdates) != 1 || f.taskStateUpdates[0] != string(v1.TaskStateFailed) {
+		t.Errorf("expected fresh-start failure to set task state FAILED, got %v", f.taskStateUpdates)
 	}
-	if f.lastFromResume.Load() {
+	if f.lastFromResume {
 		t.Error("expected fromResume=false on fresh-start path")
-	}
-}
-
-// atomicSlice is a tiny thread-safe slice used by the fixture above.
-type atomicSlice struct {
-	mu   sync.Mutex
-	vals []string
-}
-
-func (a *atomicSlice) append(v string) {
-	a.mu.Lock()
-	a.vals = append(a.vals, v)
-	a.mu.Unlock()
-}
-func (a *atomicSlice) snapshot() []string {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	out := make([]string, len(a.vals))
-	copy(out, a.vals)
-	return out
-}
-
-func waitFor(t *testing.T, cond func() bool, timeout time.Duration, what string) {
-	t.Helper()
-	deadline := time.After(timeout)
-	tick := time.NewTicker(10 * time.Millisecond)
-	defer tick.Stop()
-	for {
-		select {
-		case <-deadline:
-			t.Fatalf("timed out waiting for %s", what)
-		case <-tick.C:
-			if cond() {
-				return
-			}
-		}
 	}
 }
 

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -633,11 +633,12 @@ func TestRunAgentProcessAsync_CleansUpOnStartFailure(t *testing.T) {
 		return repo.UpdateTaskState(ctx, taskID, state)
 	})
 
-	// Use runAgentProcessAsync with a no-op onSuccess that should never be called
+	// Use runAgentProcessAsync with a no-op onSuccess that should never be called.
+	// escalateTaskOnFailure=true mirrors the fresh-start path.
 	exec.runAgentProcessAsync(context.Background(), "task-123", "session-123", "exec-456", func(ctx context.Context) {
 		t.Error("onSuccess should not be called when StartAgentProcess fails")
 		close(done)
-	})
+	}, true, false)
 
 	// Wait for the async goroutine to finish
 	deadline := time.After(5 * time.Second)
@@ -666,6 +667,133 @@ verified:
 	session := repo.sessions["session-123"]
 	if session.State != models.TaskSessionStateFailed {
 		t.Errorf("expected session state FAILED, got %s", session.State)
+	}
+}
+
+// runAgentProcessAsyncFailureFixture builds an Executor configured to fail
+// StartAgentProcess, with task/session-state-change recorders for assertions.
+type runAgentProcessAsyncFailureFixture struct {
+	exec              *Executor
+	taskStateUpdates  *atomicSlice
+	sessionFailedSeen *atomic.Bool
+	startFailedCalls  *atomic.Int32
+	lastFromResume    *atomic.Bool
+	stopCalled        *atomic.Bool
+}
+
+func newRunAgentProcessAsyncFailureFixture(t *testing.T) *runAgentProcessAsyncFailureFixture {
+	t.Helper()
+	repo := newMockRepository()
+	repo.sessions["session-123"] = &models.TaskSession{
+		ID: "session-123", TaskID: "task-123", State: models.TaskSessionStateStarting,
+	}
+	stopCalled := &atomic.Bool{}
+	agentManager := &mockAgentManager{
+		startAgentProcessFunc: func(ctx context.Context, agentExecutionID string) error {
+			return fmt.Errorf("ACP initialize handshake failed: context deadline exceeded")
+		},
+		stopAgentFunc: func(ctx context.Context, agentExecutionID string, force bool) error {
+			stopCalled.Store(true)
+			return nil
+		},
+	}
+	exec := newTestExecutor(t, agentManager, repo)
+	taskUpdates := &atomicSlice{}
+	sessionFailed := &atomic.Bool{}
+	startFailedCalls := &atomic.Int32{}
+	lastFromResume := &atomic.Bool{}
+	exec.SetOnTaskStateChange(func(ctx context.Context, taskID string, state v1.TaskState) error {
+		taskUpdates.append(string(state))
+		return nil
+	})
+	exec.SetOnSessionStateChange(func(ctx context.Context, taskID, sessionID string, state models.TaskSessionState, errorMessage string) error {
+		if state == models.TaskSessionStateFailed {
+			sessionFailed.Store(true)
+		}
+		return repo.UpdateTaskSessionState(ctx, sessionID, state, errorMessage)
+	})
+	exec.SetOnAgentStartFailed(func(ctx context.Context, taskID, sessionID, agentExecutionID string, err error, fromResume bool) bool {
+		startFailedCalls.Add(1)
+		lastFromResume.Store(fromResume)
+		return false
+	})
+	return &runAgentProcessAsyncFailureFixture{
+		exec: exec, taskStateUpdates: taskUpdates, sessionFailedSeen: sessionFailed,
+		startFailedCalls: startFailedCalls, lastFromResume: lastFromResume, stopCalled: stopCalled,
+	}
+}
+
+func TestRunAgentProcessAsync_ResumeDoesNotEscalateTaskState(t *testing.T) {
+	f := newRunAgentProcessAsyncFailureFixture(t)
+	f.exec.runAgentProcessAsync(context.Background(), "task-123", "session-123", "exec-456",
+		func(ctx context.Context) { t.Error("onSuccess should not run on failure") },
+		false, true) // resume path: no escalation, fromResume=true
+	waitFor(t, func() bool { return f.stopCalled.Load() }, 5*time.Second, "StopAgent called")
+	if !f.sessionFailedSeen.Load() {
+		t.Error("expected session state FAILED")
+	}
+	if got := f.taskStateUpdates.snapshot(); len(got) != 0 {
+		t.Errorf("expected no task state updates on resume failure, got %v", got)
+	}
+	if f.startFailedCalls.Load() != 1 {
+		t.Errorf("expected onAgentStartFailed called once, got %d", f.startFailedCalls.Load())
+	}
+	if !f.lastFromResume.Load() {
+		t.Error("expected fromResume=true to be propagated to onAgentStartFailed")
+	}
+}
+
+func TestRunAgentProcessAsync_FreshStartEscalatesTaskState(t *testing.T) {
+	f := newRunAgentProcessAsyncFailureFixture(t)
+	f.exec.runAgentProcessAsync(context.Background(), "task-123", "session-123", "exec-456",
+		func(ctx context.Context) { t.Error("onSuccess should not run on failure") },
+		true, false) // fresh-start path: escalate, fromResume=false
+	waitFor(t, func() bool { return f.stopCalled.Load() }, 5*time.Second, "StopAgent called")
+	if !f.sessionFailedSeen.Load() {
+		t.Error("expected session state FAILED")
+	}
+	got := f.taskStateUpdates.snapshot()
+	if len(got) != 1 || got[0] != string(v1.TaskStateFailed) {
+		t.Errorf("expected fresh-start failure to set task state FAILED, got %v", got)
+	}
+	if f.lastFromResume.Load() {
+		t.Error("expected fromResume=false on fresh-start path")
+	}
+}
+
+// atomicSlice is a tiny thread-safe slice used by the fixture above.
+type atomicSlice struct {
+	mu   sync.Mutex
+	vals []string
+}
+
+func (a *atomicSlice) append(v string) {
+	a.mu.Lock()
+	a.vals = append(a.vals, v)
+	a.mu.Unlock()
+}
+func (a *atomicSlice) snapshot() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, len(a.vals))
+	copy(out, a.vals)
+	return out
+}
+
+func waitFor(t *testing.T, cond func() bool, timeout time.Duration, what string) {
+	t.Helper()
+	deadline := time.After(timeout)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", what)
+		case <-tick.C:
+			if cond() {
+				return
+			}
+		}
 	}
 }
 

--- a/apps/web/lib/ws/handlers/agent-session.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session.test.ts
@@ -90,7 +90,10 @@ describe("session.state_changed handler", () => {
     expect(store.getState().setSessionFailureNotification).not.toHaveBeenCalled();
   });
 
-  it("sets failure notification for unknown session (first event)", () => {
+  it("does not set failure notification for unknown session (snapshot replay)", () => {
+    // When a session is replayed on reconnect/page-load, it lands in the FE
+    // store for the first time already in FAILED state. This is not a real
+    // transition we just observed, so no toast should fire.
     store = makeStore();
     handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
 
@@ -103,11 +106,7 @@ describe("session.state_changed handler", () => {
       }),
     );
 
-    expect(store.getState().setSessionFailureNotification).toHaveBeenCalledWith({
-      sessionId: "s-new",
-      taskId: "t-1",
-      message: "timeout",
-    });
+    expect(store.getState().setSessionFailureNotification).not.toHaveBeenCalled();
   });
 
   it("respects suppress_toast flag", () => {

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -228,6 +228,39 @@ function handleAgentctlReady(store: StoreApi<AppState>, payload: any): void {
   }
 }
 
+interface SessionFailureContext {
+  taskId: string;
+  sessionId: string;
+  newState: TaskSessionState | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: any;
+  previousState: TaskSessionState | undefined;
+}
+
+/** Emits a session-failure notification for FAILED transitions, honoring suppress_toast and replay guards. */
+function maybeNotifySessionFailure(store: StoreApi<AppState>, ctx: SessionFailureContext): void {
+  const { taskId, sessionId, newState, payload, previousState } = ctx;
+  if (newState !== "FAILED") return;
+
+  // Only toast on observed transitions (previousState present and not FAILED).
+  // If previousState is undefined we're learning about this session for the
+  // first time — that's a snapshot of an already-failed session being replayed
+  // by the backend (e.g. on page load / WS reconnect), not a fresh failure.
+  if (
+    payload.suppress_toast === true ||
+    previousState === undefined ||
+    previousState === "FAILED"
+  ) {
+    return;
+  }
+
+  store.getState().setSessionFailureNotification({
+    sessionId,
+    taskId,
+    message: payload.error_message ? String(payload.error_message) : "Session failed unexpectedly",
+  });
+}
+
 export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
     "message.queue.status_changed": (message) => {
@@ -271,19 +304,13 @@ export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandle
 
       maybeAdoptSessionOnTransition(store, taskId, sessionId, newState, !!existingSession);
 
-      if (
-        newState === "FAILED" &&
-        payload.suppress_toast !== true &&
-        existingSession?.state !== "FAILED" // replay guard; hook dedup is the second layer
-      ) {
-        store.getState().setSessionFailureNotification({
-          sessionId,
-          taskId,
-          message: payload.error_message
-            ? String(payload.error_message)
-            : "Session failed unexpectedly",
-        });
-      }
+      maybeNotifySessionFailure(store, {
+        taskId,
+        sessionId,
+        newState,
+        payload,
+        previousState: existingSession?.state,
+      });
     },
     "session.agentctl_starting": (message) => {
       const payload = message.payload;


### PR DESCRIPTION
After backend restart, several overlapping races in the auto-resume path produced "Task failed to start" toasts even when nothing the user did had failed. This change collapses the races and gates the toast so only fresh, user-initiated launch failures notify.

## Important Changes

- Promote workspace-only executions to full agent launches in-place instead of creating a parallel execution that races with focused-tab ensure logic.
- Gate `task.state` escalation to `FAILED` on resume paths — the session is still marked FAILED but the task stays in REVIEW.
- Add `suppress_toast` on background-resume FAILED `state_changed` events so the frontend can skip notifying for non-user-initiated failures.
- Make `connectWorkspaceStream` idempotent — short-circuit when a workspace stream is already attached so promotion doesn't burn 5 retries on the "workspace stream already connected" error.
- Tighten the frontend toast guard to fire only on observed transitions (previousState present and not FAILED), preventing snapshot replays of already-failed sessions on page load from toasting.

## Validation

- `make -C apps/backend fmt test lint` — all green
- `pnpm --filter @kandev/web test` — 1050/1050 pass
- `pnpm --filter @kandev/web lint` — 0 warnings
- New unit tests:
  - `TestConnectWorkspaceStream_IdempotentWhenAlreadyAttached` — regression for the double-connect retry loop
  - Updated `agent-session.test.ts` — verifies no toast on snapshot replay (unknown previousState) and toast on real FAILED transition
  - Backend tests for `runAgentProcessAsync` escalation gating and `fromResume` callback plumbing

## Possible Improvements

Low risk. Worst case the toast misses a genuine launch-failure during a focused fresh start; mitigated because fresh-start failures still escalate the task and toast as before. Auth-error UX is unchanged.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.