### PR TITLE
fix: sanitize multi-repo worktree dirs and polish task-create chip dropdown

### DIFF
--- a/apps/backend/internal/worktree/config.go
+++ b/apps/backend/internal/worktree/config.go
@@ -116,8 +116,7 @@ func SanitizeForBranch(title string, maxLen int) string {
 	result = sb.String()
 
 	// Remove consecutive hyphens
-	re := regexp.MustCompile(`-+`)
-	result = re.ReplaceAllString(result, "-")
+	result = repoDirHyphenRun.ReplaceAllString(result, "-")
 
 	// Remove leading and trailing hyphens
 	result = strings.Trim(result, "-")
@@ -188,6 +187,12 @@ func SmallSuffix(maxLen int) string {
 // This guards against names like "owner/repo" producing nested subdirectories
 // when used as the worktree directory under a multi-repo task root — the
 // extra path level breaks sibling-repo detection in agentctl.
+//
+// Limitation: distinct names that differ only in unsafe characters (e.g.
+// "acme/widget-config" and "acme-widget-config") collapse to the same
+// segment. Two such repos in one task would collide on `git worktree add`.
+// Acceptable in practice — provider repos (the common case) are uniquely
+// identified by owner/name and won't collide with each other.
 func SanitizeRepoDirName(name string) string {
 	if name == "" {
 		return ""

--- a/apps/backend/internal/worktree/config.go
+++ b/apps/backend/internal/worktree/config.go
@@ -179,6 +179,37 @@ func SmallSuffix(maxLen int) string {
 	return string(buf)
 }
 
+// SanitizeRepoDirName converts a repository display name into a single,
+// filesystem-safe path segment. Path separators and other unsafe characters
+// are replaced with hyphens, runs of hyphens are collapsed, and surrounding
+// hyphens/dots are trimmed. Returns an empty string when the input has no
+// usable characters.
+//
+// This guards against names like "owner/repo" producing nested subdirectories
+// when used as the worktree directory under a multi-repo task root — the
+// extra path level breaks sibling-repo detection in agentctl.
+func SanitizeRepoDirName(name string) string {
+	if name == "" {
+		return ""
+	}
+	var sb strings.Builder
+	sb.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			sb.WriteRune(r)
+		case r == '_', r == '.', r == '-':
+			sb.WriteRune(r)
+		default:
+			sb.WriteRune('-')
+		}
+	}
+	result := repoDirHyphenRun.ReplaceAllString(sb.String(), "-")
+	return strings.Trim(result, "-.")
+}
+
+var repoDirHyphenRun = regexp.MustCompile(`-+`)
+
 // SemanticWorktreeName generates a semantic worktree directory name from a task title.
 // Format: {sanitizedTitle}_{suffix} e.g. fix-login-bug_ab12cd34
 // The title is truncated to 20 characters before adding the suffix.

--- a/apps/backend/internal/worktree/config_test.go
+++ b/apps/backend/internal/worktree/config_test.go
@@ -1,0 +1,29 @@
+package worktree
+
+import "testing"
+
+func TestSanitizeRepoDirName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"widget-config", "widget-config"},
+		{"acme/widget-config", "acme-widget-config"},
+		{"acme/widget", "acme-widget"},
+		{"owner\\repo", "owner-repo"},
+		{"weird:name space", "weird-name-space"},
+		{"with..dots", "with..dots"},
+		{"trailing/", "trailing"},
+		{"/leading", "leading"},
+		{"a//b", "a-b"},
+		{"-a-b-", "a-b"},
+		{".hidden", "hidden"},
+		{"!@#$%", ""},
+		{"", ""},
+		{"under_score.dot-dash", "under_score.dot-dash"},
+	}
+	for _, c := range cases {
+		if got := SanitizeRepoDirName(c.in); got != c.want {
+			t.Errorf("SanitizeRepoDirName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/apps/backend/internal/worktree/errors.go
+++ b/apps/backend/internal/worktree/errors.go
@@ -52,6 +52,11 @@ var (
 	// directory (~/.kandev/tasks/{taskDir}/{repo}/), so callers must populate
 	// both fields.
 	ErrTaskDirRequired = errors.New("worktree create requires TaskDirName and RepoName")
+
+	// ErrInvalidRepoName is returned when RepoName is set but contains no
+	// characters that survive sanitization (e.g. "!@#$%"), so it cannot be
+	// used as a directory segment.
+	ErrInvalidRepoName = errors.New("repo name has no usable characters after sanitization")
 )
 
 // containsAuthFailure checks if git output indicates an authentication failure.

--- a/apps/backend/internal/worktree/manager.go
+++ b/apps/backend/internal/worktree/manager.go
@@ -290,8 +290,17 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (*Worktree, err
 
 // createInTaskDir creates a worktree inside the task directory structure:
 // ~/.kandev/tasks/{taskDirName}/{repoName}/
+//
+// RepoName is sanitized to a single path segment so display names like
+// "owner/repo" don't produce a nested subdirectory — that would push the
+// worktree one level below the task root and break agentctl's sibling-based
+// multi-repo detection.
 func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRef string) (*Worktree, error) {
-	worktreePath, err := m.config.TaskWorktreePath(req.TaskDirName, req.RepoName)
+	repoDir := SanitizeRepoDirName(req.RepoName)
+	if repoDir == "" {
+		return nil, ErrTaskDirRequired
+	}
+	worktreePath, err := m.config.TaskWorktreePath(req.TaskDirName, repoDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get task worktree path: %w", err)
 	}

--- a/apps/backend/internal/worktree/manager.go
+++ b/apps/backend/internal/worktree/manager.go
@@ -298,7 +298,7 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (*Worktree, err
 func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRef string) (*Worktree, error) {
 	repoDir := SanitizeRepoDirName(req.RepoName)
 	if repoDir == "" {
-		return nil, ErrTaskDirRequired
+		return nil, ErrInvalidRepoName
 	}
 	worktreePath, err := m.config.TaskWorktreePath(req.TaskDirName, repoDir)
 	if err != nil {

--- a/apps/backend/internal/worktree/manager_taskdir_checkout_branch_test.go
+++ b/apps/backend/internal/worktree/manager_taskdir_checkout_branch_test.go
@@ -3,6 +3,7 @@ package worktree
 import (
 	"context"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -107,5 +108,55 @@ func TestCreateInTaskDir_RemoteBaseRefDoesNotSetUpstream(t *testing.T) {
 	cmd.Dir = wt.Path
 	if out, err := cmd.CombinedOutput(); err == nil {
 		t.Fatalf("expected no upstream for new task branch, but got %q", strings.TrimSpace(string(out)))
+	}
+}
+
+// Org-prefixed RepoName ("owner/repo") used to nest the worktree one level
+// below the task root, breaking agentctl's sibling-based multi-repo detection.
+// The worktree directory must sit directly under the task root so two repos
+// (clean + org-prefixed) end up as siblings.
+func TestCreateInTaskDir_OrgPrefixedRepoNameLandsAsSibling(t *testing.T) {
+	cfg := newTestConfig(t)
+	store := newMockStore()
+	mgr, err := NewManager(cfg, store, newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	repoA := initGitRepoWithRemote(t)
+	repoB := initGitRepoWithRemote(t)
+	const taskDir = "test-task"
+
+	wtA, err := mgr.Create(context.Background(), CreateRequest{
+		TaskID: "t-1", SessionID: "s-1", TaskTitle: "T",
+		RepositoryID:   "repo-a",
+		RepositoryPath: repoA,
+		BaseBranch:     "main",
+		TaskDirName:    taskDir,
+		RepoName:       "arthur",
+	})
+	if err != nil {
+		t.Fatalf("Create A: %v", err)
+	}
+
+	wtB, err := mgr.Create(context.Background(), CreateRequest{
+		TaskID: "t-1", SessionID: "s-1", TaskTitle: "T",
+		RepositoryID:   "repo-b",
+		RepositoryPath: repoB,
+		BaseBranch:     "main",
+		TaskDirName:    taskDir,
+		RepoName:       "acme/widget-config",
+	})
+	if err != nil {
+		t.Fatalf("Create B: %v", err)
+	}
+
+	parentA := filepath.Dir(wtA.Path)
+	parentB := filepath.Dir(wtB.Path)
+	if parentA != parentB {
+		t.Fatalf("worktrees not siblings: A parent %q vs B parent %q", parentA, parentB)
+	}
+	if base := filepath.Base(wtB.Path); base != "acme-widget-config" {
+		t.Errorf("repo B dir = %q, want %q", base, "acme-widget-config")
 	}
 }

--- a/apps/web/components/task-create-dialog-options.tsx
+++ b/apps/web/components/task-create-dialog-options.tsx
@@ -48,13 +48,15 @@ export function useRepositoryOptions(
         renderLabel: () => (
           <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
             <span className="shrink-0">{repo.name}</span>
-            <Badge
-              variant="secondary"
-              className="text-xs text-muted-foreground max-w-[140px] min-w-0 truncate ml-auto"
-              title={formatUserHomePath(repo.local_path)}
-            >
-              {truncateRepoPath(repo.local_path, 24)}
-            </Badge>
+            {repo.local_path ? (
+              <Badge
+                variant="secondary"
+                className="text-xs text-muted-foreground max-w-[140px] min-w-0 truncate ml-auto"
+                title={formatUserHomePath(repo.local_path)}
+              >
+                {truncateRepoPath(repo.local_path, 24)}
+              </Badge>
+            ) : null}
           </span>
         ),
       })),

--- a/apps/web/components/task-create-dialog-pill.tsx
+++ b/apps/web/components/task-create-dialog-pill.tsx
@@ -206,7 +206,7 @@ export function Pill({
       <PopoverTrigger asChild>
         {tooltip ? <TooltipTrigger asChild>{triggerButton}</TooltipTrigger> : triggerButton}
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="start" portal={false}>
+      <PopoverContent className="w-[360px] p-0" align="start" portal={false}>
         <Command filter={filter}>
           <div className="flex items-center gap-1 px-2 pt-1">
             <CommandInput placeholder={searchPlaceholder} className="h-9 flex-1" />

--- a/apps/web/components/task-create-dialog-repo-chips.test.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.test.tsx
@@ -273,7 +273,7 @@ describe("RepoChipsRow", () => {
     );
     fireEvent.click(screen.getByTestId("repo-chip-trigger"));
     expect(screen.getByText("frontend")).toBeTruthy();
-    expect(screen.getByText("projects/local-project")).toBeTruthy();
+    expect(screen.getByText("~/projects/local-project")).toBeTruthy();
     expect(screen.queryByText("frontend-dup")).toBeNull();
   });
 
@@ -299,7 +299,7 @@ describe("RepoChipsRow", () => {
       />,
     );
     fireEvent.click(screen.getByTestId("repo-chip-trigger"));
-    fireEvent.click(screen.getByText("projects/local-project"));
+    fireEvent.click(screen.getByText("~/projects/local-project"));
     expect(onRowRepositoryChange).toHaveBeenCalledWith("r0", "/home/me/projects/local-project");
   });
 

--- a/apps/web/components/task-create-dialog-repo-chips.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.tsx
@@ -10,6 +10,7 @@ import type { LocalRepository, Repository } from "@/lib/types/http";
 import type { DialogFormState, TaskRepoRow } from "@/components/task-create-dialog-types";
 import { autoSelectBranch } from "@/components/task-create-dialog-helpers";
 import { scoreBranch } from "@/lib/utils/branch-filter";
+import { scoreRepo } from "@/lib/utils/repo-filter";
 import {
   Pill,
   sortBranches,
@@ -634,16 +635,4 @@ function leafSegment(path: string): string {
   const cleaned = path.replace(/\\/g, "/").replace(/\/+$/g, "");
   const idx = cleaned.lastIndexOf("/");
   return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
-}
-
-// Repo dropdown wraps scoreBranch but drops weak subsequence-only matches.
-// scoreBranch's last-resort fuzzy fallback makes sense for branch names
-// (typos, partial fragments) but for repo paths it surfaces nonsense — e.g.
-// "arthur" scoring against "playground/fun/thm/.../lxd-alpine-builder"
-// because a-r-t-h-u-r appears in order across path segments. Substring,
-// prefix, and word-boundary hits all score >= 0.45, so a 0.4 floor keeps
-// real matches while filtering the long-path coincidences.
-function scoreRepo(value: string, search: string, keywords?: string[]): number {
-  const score = scoreBranch(value, search, keywords);
-  return score >= 0.4 ? score : 0;
 }

--- a/apps/web/components/task-create-dialog-repo-chips.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo } from "react";
 import { IconPlus, IconX, IconCode, IconGitBranch, IconGitFork } from "@tabler/icons-react";
 import { cn, formatUserHomePath } from "@/lib/utils";
+import { Badge } from "@kandev/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useBranches, type BranchSource } from "@/hooks/domains/workspace/use-repository-branches";
 import type { LocalRepository, Repository } from "@/lib/types/http";
@@ -461,11 +462,19 @@ function useRepoChipData({
 
   const repoOptions: PillOption[] = useMemo(
     () => [
-      ...filteredRepos.map((r) => ({ value: r.id, label: r.name })),
+      ...filteredRepos.map((r) => ({
+        value: r.id,
+        label: r.name,
+        keywords: [r.name, r.local_path, formatUserHomePath(r.local_path)].filter(
+          (s): s is string => !!s,
+        ),
+        renderLabel: () => renderWorkspaceRepoOption(r),
+      })),
       ...filteredDiscovered.map((r) => ({
         value: r.path,
-        label: shortRepoPath(r.path),
-        keywords: [r.path],
+        label: leafSegment(r.path),
+        keywords: [r.path, formatUserHomePath(r.path)],
+        renderLabel: () => renderDiscoveredRepoOption(r.path),
       })),
     ],
     [filteredRepos, filteredDiscovered],
@@ -546,6 +555,7 @@ function RepoChip({
         emptyMessage="No repositories"
         testId="repo-chip-trigger"
         tooltip={repoTooltip}
+        filter={scoreRepo}
         flat
       />
       <Pill
@@ -593,9 +603,47 @@ function normalizeRepoPath(path: string): string {
   return path.replace(/\\/g, "/").replace(/\/+$/g, "");
 }
 
-function shortRepoPath(path: string): string {
-  // Show the trailing folder name with one parent for context (e.g. "myorg/myrepo").
-  const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
-  if (parts.length <= 1) return path;
-  return parts.slice(-2).join("/");
+function renderWorkspaceRepoOption(repo: Repository) {
+  const display = repo.local_path ? formatUserHomePath(repo.local_path) : "";
+  return (
+    <span className="flex min-w-0 flex-1 flex-col overflow-hidden" title={display || repo.name}>
+      <span className="truncate">{repo.name}</span>
+      {display ? (
+        <span className="truncate text-[11px] text-muted-foreground">{display}</span>
+      ) : null}
+    </span>
+  );
+}
+
+function renderDiscoveredRepoOption(path: string) {
+  const display = formatUserHomePath(path);
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden" title={display}>
+      <span className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <span className="truncate">{leafSegment(path)}</span>
+        <span className="truncate text-[11px] text-muted-foreground">{display}</span>
+      </span>
+      <Badge variant="outline" className="text-[10px] text-muted-foreground shrink-0">
+        on disk
+      </Badge>
+    </span>
+  );
+}
+
+function leafSegment(path: string): string {
+  const cleaned = path.replace(/\\/g, "/").replace(/\/+$/g, "");
+  const idx = cleaned.lastIndexOf("/");
+  return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
+}
+
+// Repo dropdown wraps scoreBranch but drops weak subsequence-only matches.
+// scoreBranch's last-resort fuzzy fallback makes sense for branch names
+// (typos, partial fragments) but for repo paths it surfaces nonsense — e.g.
+// "arthur" scoring against "playground/fun/thm/.../lxd-alpine-builder"
+// because a-r-t-h-u-r appears in order across path segments. Substring,
+// prefix, and word-boundary hits all score >= 0.45, so a 0.4 floor keeps
+// real matches while filtering the long-path coincidences.
+function scoreRepo(value: string, search: string, keywords?: string[]): number {
+  const score = scoreBranch(value, search, keywords);
+  return score >= 0.4 ? score : 0;
 }

--- a/apps/web/lib/utils/repo-filter.test.ts
+++ b/apps/web/lib/utils/repo-filter.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { scoreRepo } from "./repo-filter";
+
+describe("scoreRepo", () => {
+  it("returns a positive score for an exact keyword match", () => {
+    expect(scoreRepo("uuid-123", "arthur", ["arthur"])).toBeGreaterThan(0);
+  });
+
+  it("returns a positive score for a substring/segment hit on the value", () => {
+    expect(scoreRepo("acme/widget-config", "widget")).toBeGreaterThan(0);
+  });
+
+  it("floors weak subsequence-only matches that scoreBranch would surface", () => {
+    // a-r-t-h-u-r appears in order across the path but no segment contains
+    // "arthur" — exactly the false positive scoreRepo is designed to kill.
+    expect(scoreRepo("playground/fun/thm/gameserver/lxd-alpine-builder", "arthur")).toBe(0);
+  });
+
+  it("returns a positive score when the search prefixes the value's leaf", () => {
+    expect(scoreRepo("playground/sky/arthur", "arth")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 when nothing in value or keywords resembles the search", () => {
+    expect(scoreRepo("playground/foo", "completely-unrelated", ["foo"])).toBe(0);
+  });
+});

--- a/apps/web/lib/utils/repo-filter.ts
+++ b/apps/web/lib/utils/repo-filter.ts
@@ -1,0 +1,16 @@
+import { scoreBranch } from "./branch-filter";
+
+// scoreRepo wraps scoreBranch but drops weak subsequence-only matches.
+//
+// scoreBranch's fuzzy fallback returns small non-zero scores when search
+// characters appear in order across an arbitrary haystack — useful for
+// branch typos, but noisy for repo paths. A query like "arthur" was
+// matching long paths like "playground/fun/thm/.../lxd-alpine-builder"
+// because a-r-t-h-u-r appears in order across path segments.
+//
+// scoreBranch awards >= 0.45 for any substring/prefix/word-boundary hit,
+// so a 0.4 floor preserves real matches while filtering coincidences.
+export function scoreRepo(value: string, search: string, keywords?: string[]): number {
+  const score = scoreBranch(value, search, keywords);
+  return score >= 0.4 ? score : 0;
+}


### PR DESCRIPTION
Org-prefixed repository names like \`owner/repo\` were being used verbatim as worktree subdirectories, nesting one level too deep so the agentctl multi-repo detection scoped the Files panel to a single repo, and the task-create chip dropdown surfaced workspace repos as bare names with a fuzzy-match list that included unrelated paths. Both issues are now fixed: worktrees land as siblings under the task root, and the dropdown shows readable name + path rows with a strict path-aware filter.

## Important Changes

- \`worktree.SanitizeRepoDirName\` collapses path-unsafe characters in \`RepoName\` to a single segment so \`scanRepositorySubdirs\` sees every repo as a sibling.
- Repo chip dropdown popover widened (288 → 360 px), rows stack name + full path, and a \`scoreRepo\` wrapper floors weak fuzzy matches from \`scoreBranch\` so \`arthur\` no longer matches \`lxd-alpine-builder\`.

## Validation

- \`go test ./internal/worktree/... ./internal/agent/lifecycle/... ./internal/orchestrator/...\`
- \`make -C apps/backend fmt lint\`
- \`pnpm --filter @kandev/web exec tsc --noEmit\`
- \`pnpm --filter @kandev/web lint -- components/task-create-dialog-repo-chips.tsx components/task-create-dialog-pill.tsx components/task-create-dialog-options.tsx\`
- \`pnpm --filter @kandev/web test\` — 1050 tests pass

## Possible Improvements

Low risk. Workspace repos with no \`local_path\` (provider-imported, never cloned) still appear in the dropdown but render as bare names — could follow up by hiding them when the chosen executor needs a local checkout.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.