### PR TITLE
fix(backend): return mcp message_task once dispatched, not after target turn ends

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -266,8 +266,8 @@ func (a *lifecycleAdapter) GetSessionAuthMethods(sessionID string) []streams.Aut
 
 // PromptAgent sends a follow-up prompt to a running agent
 // Attachments (images) are passed to the agent if provided
-func (a *lifecycleAdapter) PromptAgent(ctx context.Context, agentInstanceID string, prompt string, attachments []v1.MessageAttachment) (*executor.PromptResult, error) {
-	result, err := a.mgr.PromptAgent(ctx, agentInstanceID, prompt, attachments)
+func (a *lifecycleAdapter) PromptAgent(ctx context.Context, agentInstanceID string, prompt string, attachments []v1.MessageAttachment, dispatchOnly bool) (*executor.PromptResult, error) {
+	result, err := a.mgr.PromptAgent(ctx, agentInstanceID, prompt, attachments, dispatchOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -435,8 +435,8 @@ type orchestratorWrapper struct {
 
 // PromptTask forwards directly to the orchestrator service.
 // Attachments (images) are passed through to the agent.
-func (w *orchestratorWrapper) PromptTask(ctx context.Context, taskID, taskSessionID, prompt, model string, planMode bool, attachments []v1.MessageAttachment) (*orchestrator.PromptResult, error) {
-	return w.svc.PromptTask(ctx, taskID, taskSessionID, prompt, model, planMode, attachments)
+func (w *orchestratorWrapper) PromptTask(ctx context.Context, taskID, taskSessionID, prompt, model string, planMode bool, attachments []v1.MessageAttachment, dispatchOnly bool) (*orchestrator.PromptResult, error) {
+	return w.svc.PromptTask(ctx, taskID, taskSessionID, prompt, model, planMode, attachments, dispatchOnly)
 }
 
 // ResumeTaskSession forwards to the orchestrator service, discarding the TaskExecution result.

--- a/apps/backend/internal/agent/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/lifecycle/manager_interaction.go
@@ -78,14 +78,16 @@ func fallbackAuthMethods(agentID string) []streams.AuthMethodInfo {
 	}
 }
 
-// PromptAgent sends a follow-up prompt to a running agent
-// Attachments (images) are passed to the agent if provided
-func (m *Manager) PromptAgent(ctx context.Context, executionID string, prompt string, attachments []v1.MessageAttachment) (*PromptResult, error) {
+// PromptAgent sends a follow-up prompt to a running agent.
+// Attachments (images) are passed to the agent if provided.
+// When dispatchOnly is true, returns once the prompt is accepted instead of
+// waiting for the agent's turn to complete.
+func (m *Manager) PromptAgent(ctx context.Context, executionID string, prompt string, attachments []v1.MessageAttachment, dispatchOnly bool) (*PromptResult, error) {
 	execution, exists := m.executionStore.Get(executionID)
 	if !exists {
 		return nil, fmt.Errorf("execution %q not found: %w", executionID, ErrExecutionNotFound)
 	}
-	return m.sessionManager.SendPrompt(ctx, execution, prompt, true, attachments)
+	return m.sessionManager.SendPrompt(ctx, execution, prompt, true, attachments, dispatchOnly)
 }
 
 // cancelWaitTimeout bounds how long CancelAgent waits for the in-flight SendPrompt

--- a/apps/backend/internal/agent/lifecycle/session.go
+++ b/apps/backend/internal/agent/lifecycle/session.go
@@ -406,7 +406,7 @@ func (sm *SessionManager) dispatchInitialPrompt(ctx context.Context, execution *
 		go func() {
 			promptCtx, cancel := appctx.Detached(ctx, sm.stopCh, 0)
 			defer cancel()
-			_, err := sm.SendPrompt(promptCtx, execution, effectivePrompt, false, acpAttachments)
+			_, err := sm.SendPrompt(promptCtx, execution, effectivePrompt, false, acpAttachments, false)
 			if err != nil {
 				sm.logger.Error("initial prompt failed",
 					zap.String("execution_id", execution.ID),
@@ -523,6 +523,9 @@ func (sm *SessionManager) waitForPromptDone(ctx context.Context, execution *Agen
 
 // SendPrompt sends a prompt to an agent execution and waits for completion.
 // For initial prompts, pass validateStatus=false. For follow-up prompts, pass validateStatus=true.
+// When dispatchOnly is true, returns once agentctl.Prompt has accepted the prompt
+// instead of blocking on the agent's complete event — used by the MCP message_task
+// path so the tool call doesn't hang for the duration of the target's turn.
 // Attachments (images) are passed to the agent if provided.
 // Returns the prompt result containing the stop reason and agent message.
 // Note: MarkReady is handled by handleAgentEvent(complete), not by this method.
@@ -532,13 +535,28 @@ func (sm *SessionManager) SendPrompt(
 	prompt string,
 	validateStatus bool,
 	attachments []v1.MessageAttachment,
+	dispatchOnly bool,
 ) (*PromptResult, error) {
 	if execution.agentctl == nil {
 		return nil, fmt.Errorf("execution %q has no agentctl client", execution.ID)
 	}
 
+	// Drain any stale signal left in the channel by a prior dispatch-only prompt
+	// whose completion arrived after SendPrompt returned. Without this, the next
+	// waitForPromptDone would consume the stale signal and report an immediate
+	// (wrong) completion for the new prompt.
+	select {
+	case <-execution.promptDoneCh:
+	default:
+	}
+
 	// Signal when this prompt completes so CancelAgent can wait for it.
-	defer beginPromptBarrier(execution)()
+	// In dispatch-only mode there is no in-flight wait to coordinate with, so the
+	// barrier is unused — skip it to avoid closing the channel before the agent's
+	// async processing actually finishes.
+	if !dispatchOnly {
+		defer beginPromptBarrier(execution)()
+	}
 
 	// Inject session trace context so prompt spans become children of the session span
 	if sessionSpan := trace.SpanFromContext(execution.SessionTraceContext()); sessionSpan.SpanContext().IsValid() {
@@ -591,6 +609,9 @@ func (sm *SessionManager) SendPrompt(
 				zap.String("execution_id", execution.ID))
 			retryErr := sm.retryPromptAfterReconnect(ctx, execution, effectivePrompt, attachments)
 			if retryErr == nil {
+				if dispatchOnly {
+					return &PromptResult{StopReason: PromptStopReasonDispatched}, nil
+				}
 				return sm.waitForPromptDone(ctx, execution)
 			}
 			sm.logger.Warn("prompt retry after stream reconnect failed",
@@ -601,6 +622,10 @@ func (sm *SessionManager) SendPrompt(
 			zap.String("execution_id", execution.ID),
 			zap.Error(err))
 		return nil, fmt.Errorf("failed to trigger prompt: %w", err)
+	}
+
+	if dispatchOnly {
+		return &PromptResult{StopReason: PromptStopReasonDispatched}, nil
 	}
 
 	// Wait for completion signal from handleAgentEvent(complete) or stream disconnect.

--- a/apps/backend/internal/agent/lifecycle/session_test.go
+++ b/apps/backend/internal/agent/lifecycle/session_test.go
@@ -581,6 +581,18 @@ func TestInitializeSession_LoadsExistingSession(t *testing.T) {
 	}
 }
 
+// waitForWSConnected blocks until the mock's agent stream WebSocket has accepted
+// a connection. Avoids racing the goroutine that StreamUpdates spawns to maintain
+// the WS, per CLAUDE.md preference for channel-based sync over time.Sleep.
+func waitForWSConnected(t *testing.T, mock *mockAgentServer) {
+	t.Helper()
+	select {
+	case <-mock.wsConnected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent stream did not connect within 2s")
+	}
+}
+
 // TestSendPrompt_DispatchOnlyReturnsWithoutWaiting verifies that dispatch-only
 // mode returns immediately after agentctl.Prompt succeeds, without blocking on
 // the agent's complete event. This is what message_task_kandev relies on so the
@@ -600,7 +612,7 @@ func TestSendPrompt_DispatchOnlyReturnsWithoutWaiting(t *testing.T) {
 	if err := client.StreamUpdates(ctx, func(event agentctl.AgentEvent) {}, nil, nil); err != nil {
 		t.Fatalf("failed to connect stream: %v", err)
 	}
-	time.Sleep(100 * time.Millisecond)
+	waitForWSConnected(t, mock)
 
 	execution := &AgentExecution{
 		ID:            "test-exec",
@@ -655,7 +667,7 @@ func TestSendPrompt_DrainsStaleSignalFromPriorDispatchOnly(t *testing.T) {
 	if err := client.StreamUpdates(ctx, func(event agentctl.AgentEvent) {}, nil, nil); err != nil {
 		t.Fatalf("failed to connect stream: %v", err)
 	}
-	time.Sleep(100 * time.Millisecond)
+	waitForWSConnected(t, mock)
 
 	execution := &AgentExecution{
 		ID:            "test-exec",

--- a/apps/backend/internal/agent/lifecycle/session_test.go
+++ b/apps/backend/internal/agent/lifecycle/session_test.go
@@ -580,3 +580,106 @@ func TestInitializeSession_LoadsExistingSession(t *testing.T) {
 		t.Error("did not expect agent.session.new to be called when loading existing session")
 	}
 }
+
+// TestSendPrompt_DispatchOnlyReturnsWithoutWaiting verifies that dispatch-only
+// mode returns immediately after agentctl.Prompt succeeds, without blocking on
+// the agent's complete event. This is what message_task_kandev relies on so the
+// MCP tool call doesn't hang for the duration of the target's turn.
+func TestSendPrompt_DispatchOnlyReturnsWithoutWaiting(t *testing.T) {
+	mock := newMockAgentServer(t)
+	defer mock.Close()
+
+	log := newSessionTestLogger()
+	sm := NewSessionManager(log, make(chan struct{}))
+
+	client := createTestClient(t, mock.server.URL)
+	defer client.Close()
+
+	// Stream must be connected before SendPrompt — agentctl.Prompt sends through it.
+	ctx := context.Background()
+	if err := client.StreamUpdates(ctx, func(event agentctl.AgentEvent) {}, nil, nil); err != nil {
+		t.Fatalf("failed to connect stream: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	execution := &AgentExecution{
+		ID:            "test-exec",
+		TaskID:        "test-task",
+		SessionID:     "test-session",
+		WorkspacePath: "/workspace",
+		agentctl:      client,
+		// Buffered chan but nothing will ever publish to it during this test —
+		// dispatch-only must not wait on it.
+		promptDoneCh: make(chan PromptCompletionSignal, 1),
+	}
+
+	done := make(chan struct {
+		result *PromptResult
+		err    error
+	}, 1)
+	go func() {
+		result, err := sm.SendPrompt(ctx, execution, "hello", false, nil, true)
+		done <- struct {
+			result *PromptResult
+			err    error
+		}{result, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("SendPrompt(dispatchOnly) returned error: %v", got.err)
+		}
+		if got.result == nil || got.result.StopReason != PromptStopReasonDispatched {
+			t.Fatalf("expected StopReason=%q, got %+v", PromptStopReasonDispatched, got.result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SendPrompt(dispatchOnly=true) blocked waiting for completion signal")
+	}
+}
+
+// TestSendPrompt_DrainsStaleSignalFromPriorDispatchOnly verifies that a leftover
+// completion signal from a previous dispatch-only prompt does not cause the next
+// (waiting) SendPrompt to return immediately with a stale result.
+func TestSendPrompt_DrainsStaleSignalFromPriorDispatchOnly(t *testing.T) {
+	mock := newMockAgentServer(t)
+	defer mock.Close()
+
+	log := newSessionTestLogger()
+	sm := NewSessionManager(log, make(chan struct{}))
+
+	client := createTestClient(t, mock.server.URL)
+	defer client.Close()
+
+	ctx := context.Background()
+	if err := client.StreamUpdates(ctx, func(event agentctl.AgentEvent) {}, nil, nil); err != nil {
+		t.Fatalf("failed to connect stream: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	execution := &AgentExecution{
+		ID:            "test-exec",
+		TaskID:        "test-task",
+		SessionID:     "test-session",
+		WorkspacePath: "/workspace",
+		agentctl:      client,
+		promptDoneCh:  make(chan PromptCompletionSignal, 1),
+	}
+
+	// Pre-load a stale signal as if a prior dispatch-only prompt's completion
+	// landed in the buffer after SendPrompt returned.
+	execution.promptDoneCh <- PromptCompletionSignal{StopReason: "stale"}
+
+	// Run a normal SendPrompt (waits for completion). It must drain the stale
+	// signal and block until a real signal arrives or ctx times out.
+	timeoutCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	_, err := sm.SendPrompt(timeoutCtx, execution, "hello", false, nil, false)
+	if err == nil {
+		t.Fatal("expected SendPrompt to block until ctx timeout, but it returned immediately (stale signal not drained)")
+	}
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("expected deadline exceeded error, got: %v", err)
+	}
+}

--- a/apps/backend/internal/agent/lifecycle/types.go
+++ b/apps/backend/internal/agent/lifecycle/types.go
@@ -452,3 +452,8 @@ type PromptResult struct {
 	StopReason   string // The reason the agent stopped (e.g., "end_turn")
 	AgentMessage string // The agent's accumulated response message
 }
+
+// PromptStopReasonDispatched is the StopReason returned when SendPrompt was
+// called in dispatch-only mode and returned after the agent acknowledged the
+// prompt instead of waiting for the turn to complete.
+const PromptStopReasonDispatched = "dispatched"

--- a/apps/backend/internal/integration/simulated_agent_manager_test.go
+++ b/apps/backend/internal/integration/simulated_agent_manager_test.go
@@ -288,7 +288,7 @@ func (s *SimulatedAgentManagerClient) StopAgentWithReason(ctx context.Context, a
 
 // PromptAgent sends a follow-up prompt to a running agent
 // Note: attachments parameter is accepted but not used in simulation
-func (s *SimulatedAgentManagerClient) PromptAgent(ctx context.Context, agentExecutionID string, prompt string, _ []v1.MessageAttachment) (*executor.PromptResult, error) {
+func (s *SimulatedAgentManagerClient) PromptAgent(ctx context.Context, agentExecutionID string, prompt string, _ []v1.MessageAttachment, _ bool) (*executor.PromptResult, error) {
 	s.mu.Lock()
 	execution, exists := s.instances[agentExecutionID]
 	s.mu.Unlock()

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -61,7 +61,7 @@ type EventBus interface {
 // Both methods are implemented by *orchestrator.Service.
 type SessionLauncher interface {
 	LaunchSession(ctx context.Context, req *orchestrator.LaunchSessionRequest) (*orchestrator.LaunchSessionResponse, error)
-	PromptTask(ctx context.Context, taskID, sessionID, prompt, model string, planMode bool, attachments []v1.MessageAttachment) (*orchestrator.PromptResult, error)
+	PromptTask(ctx context.Context, taskID, sessionID, prompt, model string, planMode bool, attachments []v1.MessageAttachment, dispatchOnly bool) (*orchestrator.PromptResult, error)
 	StartCreatedSession(ctx context.Context, taskID, sessionID, agentProfileID, prompt string, skipMessageRecord, planMode bool, attachments []v1.MessageAttachment) (*executor.TaskExecution, error)
 	ResumeTaskSession(ctx context.Context, taskID, sessionID string) (*executor.TaskExecution, error)
 	GetMessageQueue() *messagequeue.Service
@@ -828,8 +828,10 @@ func (h *Handlers) recordUserMessage(ctx context.Context, taskID, sessionID, pro
 
 // promptWithAutoResume sends a prompt to a session and resumes the agent
 // transparently if it has been torn down (mirrors message.add behaviour).
+// Uses dispatch-only mode so the MCP tool returns once the prompt is accepted
+// rather than blocking for the entire target turn.
 func (h *Handlers) promptWithAutoResume(ctx context.Context, taskID, sessionID, prompt string) (string, error) {
-	_, err := h.sessionLauncher.PromptTask(ctx, taskID, sessionID, prompt, "", false, nil)
+	_, err := h.sessionLauncher.PromptTask(ctx, taskID, sessionID, prompt, "", false, nil, true)
 	if err == nil {
 		return "sent", nil
 	}
@@ -844,7 +846,7 @@ func (h *Handlers) promptWithAutoResume(ctx context.Context, taskID, sessionID, 
 	if waitErr := h.taskSvc.WaitForSessionReady(ctx, sessionID); waitErr != nil {
 		return "", fmt.Errorf("session not ready after resume: %w", waitErr)
 	}
-	if _, retryErr := h.sessionLauncher.PromptTask(ctx, taskID, sessionID, prompt, "", false, nil); retryErr != nil {
+	if _, retryErr := h.sessionLauncher.PromptTask(ctx, taskID, sessionID, prompt, "", false, nil, true); retryErr != nil {
 		return "", fmt.Errorf("failed to send prompt after resume: %w", retryErr)
 	}
 	return "sent", nil

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -156,7 +156,7 @@ func (m *mockSessionLauncher) getRequest() *orchestrator.LaunchSessionRequest {
 // The following methods satisfy the SessionLauncher interface but are not used by
 // the autoStartTask tests. handleMessageTask tests use a dedicated fakeOrchestrator
 // (see message_task_test.go) that exercises these paths.
-func (m *mockSessionLauncher) PromptTask(context.Context, string, string, string, string, bool, []v1.MessageAttachment) (*orchestrator.PromptResult, error) {
+func (m *mockSessionLauncher) PromptTask(context.Context, string, string, string, string, bool, []v1.MessageAttachment, bool) (*orchestrator.PromptResult, error) {
 	return nil, nil
 }
 func (m *mockSessionLauncher) StartCreatedSession(context.Context, string, string, string, string, bool, bool, []v1.MessageAttachment) (*executor.TaskExecution, error) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -37,6 +37,7 @@ type fakeOrchestrator struct {
 
 type promptCall struct {
 	taskID, sessionID, prompt string
+	dispatchOnly              bool
 }
 type startCreatedCall struct {
 	taskID, sessionID, agentProfileID, prompt string
@@ -47,10 +48,10 @@ func (f *fakeOrchestrator) LaunchSession(context.Context, *orchestrator.LaunchSe
 	return nil, nil
 }
 
-func (f *fakeOrchestrator) PromptTask(_ context.Context, taskID, sessionID, prompt, _ string, _ bool, _ []v1.MessageAttachment) (*orchestrator.PromptResult, error) {
+func (f *fakeOrchestrator) PromptTask(_ context.Context, taskID, sessionID, prompt, _ string, _ bool, _ []v1.MessageAttachment, dispatchOnly bool) (*orchestrator.PromptResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.promptCalls = append(f.promptCalls, promptCall{taskID, sessionID, prompt})
+	f.promptCalls = append(f.promptCalls, promptCall{taskID: taskID, sessionID: sessionID, prompt: prompt, dispatchOnly: dispatchOnly})
 	if f.promptErrFirst != nil {
 		err := f.promptErrFirst
 		f.promptErrFirst = nil
@@ -212,6 +213,9 @@ func TestHandleMessageTask_WaitingForInput_PromptsAgent(t *testing.T) {
 	assert.Equal(t, task.ID, orch.promptCalls[0].taskID)
 	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
 	assert.Equal(t, "next instruction", orch.promptCalls[0].prompt)
+	// MCP message_task uses dispatch-only mode so the tool returns once the
+	// prompt is accepted instead of blocking for the entire target turn.
+	assert.True(t, orch.promptCalls[0].dispatchOnly, "MCP path must use dispatch-only mode")
 	assert.Zero(t, orch.resumeCalls)
 
 	// Prompt is recorded as a user message so it shows in the receiving task's chat.

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -342,7 +342,7 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 	}
 
 	_, err := s.PromptTask(promptCtx, queuedMsg.TaskID, queuedMsg.SessionID,
-		queuedMsg.Content, queuedMsg.Model, queuedMsg.PlanMode, attachments)
+		queuedMsg.Content, queuedMsg.Model, queuedMsg.PlanMode, attachments, false)
 	if err != nil {
 		s.logger.Error("failed to execute queued message",
 			zap.String("session_id", callerSessionID),

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -72,7 +72,7 @@ func (s *Service) handleClarificationAnswered(ctx context.Context, event *bus.Ev
 		zap.String("session_id", data.SessionID),
 		zap.Bool("rejected", data.Rejected))
 
-	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil); err != nil {
+	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil, false); err != nil {
 		if !s.retryClarificationAfterCancel(ctx, data, prompt, err) {
 			s.logger.Error("failed to resume agent with clarification answer",
 				zap.String("task_id", data.TaskID),
@@ -175,7 +175,7 @@ func (s *Service) resumeClarificationViaFallback(data clarificationAnsweredData)
 		zap.String("pending_id", data.PendingID))
 
 	ctx := context.Background()
-	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil); err != nil {
+	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil, false); err != nil {
 		if !s.retryClarificationAfterCancel(ctx, data, prompt, err) {
 			s.logger.Error("failed to resume agent via clarification watchdog fallback",
 				zap.String("task_id", data.TaskID),
@@ -214,7 +214,7 @@ func (s *Service) retryClarificationAfterCancel(ctx context.Context, data clarif
 		s.completeTurnForSession(ctx, data.SessionID)
 	}
 
-	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil); err != nil {
+	if _, err := s.PromptTask(ctx, data.TaskID, data.SessionID, prompt, "", false, nil, false); err != nil {
 		s.logger.Error("failed to resume agent after cancel in clarification recovery",
 			zap.String("task_id", data.TaskID),
 			zap.String("session_id", data.SessionID),

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -199,7 +199,7 @@ func (m *mockAgentManager) StopAgentWithReason(_ context.Context, agentExecution
 	})
 	return nil
 }
-func (m *mockAgentManager) PromptAgent(_ context.Context, executionID string, prompt string, _ []v1.MessageAttachment) (*executor.PromptResult, error) {
+func (m *mockAgentManager) PromptAgent(_ context.Context, executionID string, prompt string, _ []v1.MessageAttachment, _ bool) (*executor.PromptResult, error) {
 	m.mu.Lock()
 	first := len(m.capturedPrompts) == 0
 	m.capturedPrompts = append(m.capturedPrompts, prompt)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1086,7 +1086,7 @@ func (s *Service) autoStartStepPrompt(
 
 	const maxRetryAttempts = 5
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
-		_, err := s.PromptTask(ctx, taskID, sessionID, prompt, "", planMode, attachments)
+		_, err := s.PromptTask(ctx, taskID, sessionID, prompt, "", planMode, attachments, false)
 		if err == nil {
 			return nil
 		}

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -93,7 +93,9 @@ type AgentManagerClient interface {
 	// PromptAgent sends a prompt to a running agent
 	// Returns PromptResult indicating if the agent needs input
 	// Attachments (images) are passed to the agent if provided
-	PromptAgent(ctx context.Context, agentExecutionID string, prompt string, attachments []v1.MessageAttachment) (*PromptResult, error)
+	// When dispatchOnly is true, returns once the prompt is accepted by agentctl
+	// without waiting for the agent's turn to complete.
+	PromptAgent(ctx context.Context, agentExecutionID string, prompt string, attachments []v1.MessageAttachment, dispatchOnly bool) (*PromptResult, error)
 
 	// CancelAgent interrupts the current agent turn without terminating the process.
 	CancelAgent(ctx context.Context, sessionID string) error

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -120,7 +120,7 @@ func (e *Executor) StopByTaskID(ctx context.Context, taskID string, reason strin
 // Prompt sends a follow-up prompt to a running agent for a task
 // Returns PromptResult indicating if the agent needs input
 // Attachments (images) are passed to the agent if provided
-func (e *Executor) Prompt(ctx context.Context, taskID, sessionID string, prompt string, attachments []v1.MessageAttachment, preloadedSession ...*models.TaskSession) (*PromptResult, error) {
+func (e *Executor) Prompt(ctx context.Context, taskID, sessionID string, prompt string, attachments []v1.MessageAttachment, dispatchOnly bool, preloadedSession ...*models.TaskSession) (*PromptResult, error) {
 	var session *models.TaskSession
 	if len(preloadedSession) > 0 && preloadedSession[0] != nil {
 		session = preloadedSession[0]
@@ -144,9 +144,10 @@ func (e *Executor) Prompt(ctx context.Context, taskID, sessionID string, prompt 
 		zap.String("session_id", sessionID),
 		zap.String("agent_execution_id", executionID),
 		zap.Int("prompt_length", len(prompt)),
-		zap.Int("attachments_count", len(attachments)))
+		zap.Int("attachments_count", len(attachments)),
+		zap.Bool("dispatch_only", dispatchOnly))
 
-	result, err := e.agentManager.PromptAgent(ctx, executionID, prompt, attachments)
+	result, err := e.agentManager.PromptAgent(ctx, executionID, prompt, attachments, dispatchOnly)
 	if err != nil {
 		if errors.Is(err, lifecycle.ErrExecutionNotFound) {
 			return nil, ErrExecutionNotFound

--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -70,7 +70,7 @@ func (m *mockAgentManager) StopAgentWithReason(ctx context.Context, agentExecuti
 	return m.StopAgent(ctx, agentExecutionID, force)
 }
 
-func (m *mockAgentManager) PromptAgent(ctx context.Context, agentExecutionID string, prompt string, _ []v1.MessageAttachment) (*PromptResult, error) {
+func (m *mockAgentManager) PromptAgent(ctx context.Context, agentExecutionID string, prompt string, _ []v1.MessageAttachment, _ bool) (*PromptResult, error) {
 	return nil, nil
 }
 

--- a/apps/backend/internal/orchestrator/handlers/handlers.go
+++ b/apps/backend/internal/orchestrator/handlers/handlers.go
@@ -390,7 +390,7 @@ func (h *Handlers) wsPromptTask(ctx context.Context, msg *ws.Message) (*ws.Messa
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "prompt is required", nil)
 	}
 
-	result, err := h.service.PromptTask(ctx, req.TaskID, req.TaskSessionID, req.Prompt, req.Model, false, nil)
+	result, err := h.service.PromptTask(ctx, req.TaskID, req.TaskSessionID, req.Prompt, req.Model, false, nil, false)
 	if err != nil {
 		h.logger.Error("failed to send prompt", zap.String("task_id", req.TaskID), zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to send prompt: "+err.Error(), nil)

--- a/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
+++ b/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
@@ -68,7 +68,7 @@ func (m *mockAgentManager) StopAgentWithReason(ctx context.Context, agentExecuti
 	return m.StopAgent(ctx, agentExecutionID, force)
 }
 
-func (m *mockAgentManager) PromptAgent(ctx context.Context, agentExecutionID string, prompt string, _ []v1.MessageAttachment) (*executor.PromptResult, error) {
+func (m *mockAgentManager) PromptAgent(ctx context.Context, agentExecutionID string, prompt string, _ []v1.MessageAttachment, _ bool) (*executor.PromptResult, error) {
 	return &executor.PromptResult{StopReason: "end_turn"}, nil
 }
 

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1703,15 +1703,11 @@ func (s *Service) checkSessionPromptable(taskID, sessionID string, state models.
 // Returns the (possibly remapped) error for the caller to surface.
 func (s *Service) handlePromptError(ctx context.Context, taskID, sessionID string, previousSessionState models.TaskSessionState, err error) error {
 	if isTransientPromptError(err) && s.isSessionResetInProgress(sessionID) {
-		s.logger.Warn("prompt interrupted by in-progress session reset; retry expected",
+		s.logger.Warn("prompt deferred while session reset is in progress; retry expected",
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 		err = ErrSessionResetInProgress
-		s.logger.Warn("prompt deferred while session reset is in progress",
-			zap.String("task_id", taskID),
-			zap.String("session_id", sessionID),
-			zap.Error(err))
 	} else {
 		s.logger.Error("prompt failed",
 			zap.String("task_id", taskID),

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -837,7 +837,7 @@ func (s *Service) StartSessionForWorkflowStep(ctx context.Context, taskID, sessi
 	}
 
 	stepPlanMode := step.HasOnEnterAction(wfmodels.OnEnterEnablePlanMode)
-	_, err = s.PromptTask(ctx, taskID, sessionID, effectivePrompt, "", stepPlanMode, nil)
+	_, err = s.PromptTask(ctx, taskID, sessionID, effectivePrompt, "", stepPlanMode, nil, false)
 	if err != nil {
 		return fmt.Errorf("failed to prompt session: %w", err)
 	}
@@ -1599,14 +1599,15 @@ func (s *Service) saveArchiveCommits(ctx context.Context, sessionID string, comm
 // PromptTask sends a follow-up prompt to a running agent for a task session.
 // If planMode is true, a plan mode prefix is prepended to the prompt.
 // Attachments (images) are passed through to the agent if provided.
-func (s *Service) PromptTask(ctx context.Context, taskID, sessionID string, prompt string, model string, planMode bool, attachments []v1.MessageAttachment) (*PromptResult, error) {
+func (s *Service) PromptTask(ctx context.Context, taskID, sessionID string, prompt string, model string, planMode bool, attachments []v1.MessageAttachment, dispatchOnly bool) (*PromptResult, error) {
 	s.logger.Debug("PromptTask called",
 		zap.String("task_id", taskID),
 		zap.String("session_id", sessionID),
 		zap.Int("prompt_length", len(prompt)),
 		zap.String("requested_model", model),
 		zap.Bool("plan_mode", planMode),
-		zap.Int("attachments_count", len(attachments)))
+		zap.Int("attachments_count", len(attachments)),
+		zap.Bool("dispatch_only", dispatchOnly))
 	if sessionID == "" {
 		return nil, fmt.Errorf("session_id is required")
 	}
@@ -1620,21 +1621,8 @@ func (s *Service) PromptTask(ctx context.Context, taskID, sessionID string, prom
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session: %w", err)
 	}
-	switch session.State {
-	case models.TaskSessionStateWaitingForInput, models.TaskSessionStateCompleted:
-		// OK — session is ready for a new prompt
-	case models.TaskSessionStateRunning:
-		s.logger.Warn("rejected prompt while agent is already running",
-			zap.String("task_id", taskID),
-			zap.String("session_id", sessionID),
-			zap.String("session_state", string(session.State)))
-		return nil, fmt.Errorf("%w, please wait for completion", ErrAgentPromptInProgress)
-	default:
-		s.logger.Warn("rejected prompt: session not ready for input",
-			zap.String("task_id", taskID),
-			zap.String("session_id", sessionID),
-			zap.String("session_state", string(session.State)))
-		return nil, fmt.Errorf("%w, session is in %s state", ErrAgentPromptInProgress, session.State)
+	if err := s.checkSessionPromptable(taskID, sessionID, session.State); err != nil {
+		return nil, err
 	}
 
 	// Ensure the agent process is actually running. After a lazy backend restart,
@@ -1679,54 +1667,77 @@ func (s *Service) PromptTask(ctx context.Context, taskID, sessionID string, prom
 	// Prompts can take a long time (minutes) while the WS request may timeout in 15 seconds.
 	// We still want to log and respond, but the prompt should continue regardless.
 	promptCtx := context.WithoutCancel(ctx)
-	result, err := s.executor.Prompt(promptCtx, taskID, sessionID, effectivePrompt, attachments, session)
+	result, err := s.executor.Prompt(promptCtx, taskID, sessionID, effectivePrompt, attachments, dispatchOnly, session)
 	if err != nil {
-		expectedResetInterrupt := false
-		if isTransientPromptError(err) && s.isSessionResetInProgress(sessionID) {
-			s.logger.Warn("prompt interrupted by in-progress session reset; retry expected",
-				zap.String("task_id", taskID),
-				zap.String("session_id", sessionID),
-				zap.Error(err))
-			err = ErrSessionResetInProgress
-			expectedResetInterrupt = true
-		}
-
-		if expectedResetInterrupt {
-			s.logger.Warn("prompt deferred while session reset is in progress",
-				zap.String("task_id", taskID),
-				zap.String("session_id", sessionID),
-				zap.Error(err))
-		} else {
-			s.logger.Error("prompt failed",
-				zap.String("task_id", taskID),
-				zap.String("session_id", sessionID),
-				zap.Error(err))
-		}
-		// Revert session state so it doesn't stay stuck in RUNNING. Route through the
-		// wrapper so WS subscribers are notified — the UI relies on the
-		// session.state_changed broadcast to flip the composer/pause button out of
-		// "Agent is running". The wrapper's terminal-state guard is also correct here:
-		// if a concurrent agent-failure handler moved the session to FAILED we don't
-		// want to overwrite that with previousSessionState. Do NOT pass the preloaded
-		// `session` — the wrapper must re-read the row to see any such concurrent
-		// terminal transition; the stale pre-RUNNING snapshot would defeat the guard.
-		// allowWakeFromWaiting=false — this is a revert away from RUNNING, never a
-		// wake transition; the flag only matters when going WAITING_FOR_INPUT → RUNNING.
-		s.updateTaskSessionState(ctx, taskID, sessionID, previousSessionState, "", false)
-		// ErrCancelEscalated means the user cancelled and the lifecycle manager had to
-		// force-unblock a hung agent. That is not a "review this failure" condition —
-		// Service.CancelAgent reconciles DB state (WAITING_FOR_INPUT, cancel message,
-		// complete turn) already.
-		if !isTransientPromptError(err) && !errors.Is(err, lifecycle.ErrCancelEscalated) {
-			_ = s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateReview)
-		}
-		s.completeTurnForSession(ctx, sessionID)
-		return nil, err
+		return nil, s.handlePromptError(ctx, taskID, sessionID, previousSessionState, err)
 	}
 	return &PromptResult{
 		StopReason:   result.StopReason,
 		AgentMessage: result.AgentMessage,
 	}, nil
+}
+
+// checkSessionPromptable returns nil when the session's state accepts a new
+// prompt, or an ErrAgentPromptInProgress-wrapped error otherwise.
+func (s *Service) checkSessionPromptable(taskID, sessionID string, state models.TaskSessionState) error {
+	switch state {
+	case models.TaskSessionStateWaitingForInput, models.TaskSessionStateCompleted:
+		return nil
+	case models.TaskSessionStateRunning:
+		s.logger.Warn("rejected prompt while agent is already running",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("session_state", string(state)))
+		return fmt.Errorf("%w, please wait for completion", ErrAgentPromptInProgress)
+	default:
+		s.logger.Warn("rejected prompt: session not ready for input",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("session_state", string(state)))
+		return fmt.Errorf("%w, session is in %s state", ErrAgentPromptInProgress, state)
+	}
+}
+
+// handlePromptError reverts session state, logs the failure, transitions the
+// task to REVIEW for non-transient errors, and completes the in-flight turn.
+// Returns the (possibly remapped) error for the caller to surface.
+func (s *Service) handlePromptError(ctx context.Context, taskID, sessionID string, previousSessionState models.TaskSessionState, err error) error {
+	if isTransientPromptError(err) && s.isSessionResetInProgress(sessionID) {
+		s.logger.Warn("prompt interrupted by in-progress session reset; retry expected",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		err = ErrSessionResetInProgress
+		s.logger.Warn("prompt deferred while session reset is in progress",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+	} else {
+		s.logger.Error("prompt failed",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+	}
+	// Revert session state so it doesn't stay stuck in RUNNING. Route through the
+	// wrapper so WS subscribers are notified — the UI relies on the
+	// session.state_changed broadcast to flip the composer/pause button out of
+	// "Agent is running". The wrapper's terminal-state guard is also correct here:
+	// if a concurrent agent-failure handler moved the session to FAILED we don't
+	// want to overwrite that with previousSessionState. Do NOT pass the preloaded
+	// `session` — the wrapper must re-read the row to see any such concurrent
+	// terminal transition; the stale pre-RUNNING snapshot would defeat the guard.
+	// allowWakeFromWaiting=false — this is a revert away from RUNNING, never a
+	// wake transition; the flag only matters when going WAITING_FOR_INPUT → RUNNING.
+	s.updateTaskSessionState(ctx, taskID, sessionID, previousSessionState, "", false)
+	// ErrCancelEscalated means the user cancelled and the lifecycle manager had to
+	// force-unblock a hung agent. That is not a "review this failure" condition —
+	// Service.CancelAgent reconciles DB state (WAITING_FOR_INPUT, cancel message,
+	// complete turn) already.
+	if !isTransientPromptError(err) && !errors.Is(err, lifecycle.ErrCancelEscalated) {
+		_ = s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateReview)
+	}
+	s.completeTurnForSession(ctx, sessionID)
+	return err
 }
 
 // trySwitchModel handles model switching for a prompt. Returns (result, true, nil) if a switch was

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -63,7 +63,7 @@ func seedTaskAndSession(t *testing.T, repo *sqliterepo.Repository, taskID, sessi
 func TestPromptTask_EmptySessionID(t *testing.T) {
 	repo := setupTestRepo(t)
 	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
-	_, err := svc.PromptTask(context.Background(), "task1", "", "hello", "", false, nil)
+	_, err := svc.PromptTask(context.Background(), "task1", "", "hello", "", false, nil, false)
 	if err == nil {
 		t.Fatal("expected error for empty session_id")
 	}
@@ -75,7 +75,7 @@ func TestPromptTask_SessionAlreadyRunning(t *testing.T) {
 
 	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateRunning)
 
-	_, err := svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil)
+	_, err := svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil, false)
 	if err == nil {
 		t.Fatal("expected error when session is already RUNNING")
 	}
@@ -102,7 +102,7 @@ func TestPromptTask_TransientErrorDoesNotMoveTaskToReview(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	_, err = svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil)
+	_, err = svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil, false)
 	if err == nil {
 		t.Fatal("expected transient prompt error")
 	}
@@ -147,7 +147,7 @@ func TestPromptTask_CancelEscalatedDoesNotMoveTaskToReview(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	_, err = svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil)
+	_, err = svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil, false)
 	if err == nil {
 		t.Fatal("expected cancel-escalated error to bubble up from PromptTask")
 	}
@@ -189,7 +189,7 @@ func TestPromptTask_ExecutionNotFoundRevertsStateAndBroadcasts(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	_, err = svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil)
+	_, err = svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil, false)
 	if err == nil {
 		t.Fatal("expected error from prompt, got nil")
 	}
@@ -247,7 +247,7 @@ func TestPromptTask_PlanModeInjectsPrefix(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	_, err = svc.PromptTask(context.Background(), "task1", "session1", "update the plan", "", true, nil)
+	_, err = svc.PromptTask(context.Background(), "task1", "session1", "update the plan", "", true, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestPromptTask_NoPlanModeDoesNotInjectPrefix(t *testing.T) {
 		t.Fatalf("failed to update session: %v", err)
 	}
 
-	_, err = svc.PromptTask(context.Background(), "task1", "session1", "implement the feature", "", false, nil)
+	_, err = svc.PromptTask(context.Background(), "task1", "session1", "implement the feature", "", false, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestPromptTask_ResetInProgressReturnsSentinelError(t *testing.T) {
 	svc.setSessionResetInProgress("session1", true)
 	defer svc.setSessionResetInProgress("session1", false)
 
-	_, err := svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil)
+	_, err := svc.PromptTask(context.Background(), "task1", "session1", "hello", "", false, nil, false)
 	if !errors.Is(err, ErrSessionResetInProgress) {
 		t.Fatalf("expected ErrSessionResetInProgress, got %v", err)
 	}

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -23,7 +23,7 @@ import (
 
 // OrchestratorService defines the interface for orchestrator operations
 type OrchestratorService interface {
-	PromptTask(ctx context.Context, taskID, sessionID, prompt, model string, planMode bool, attachments []v1.MessageAttachment) (*orchestrator.PromptResult, error)
+	PromptTask(ctx context.Context, taskID, sessionID, prompt, model string, planMode bool, attachments []v1.MessageAttachment, dispatchOnly bool) (*orchestrator.PromptResult, error)
 	ResumeTaskSession(ctx context.Context, taskID, taskSessionID string) error
 	StartCreatedSession(ctx context.Context, taskID, sessionID, agentProfileID, prompt string, skipMessageRecord, planMode bool, attachments []v1.MessageAttachment) error
 	ProcessOnTurnStart(ctx context.Context, taskID, sessionID string) error
@@ -370,7 +370,7 @@ func (h *MessageHandlers) forwardMessageAsPrompt(
 		return
 	}
 
-	_, err := h.orchestrator.PromptTask(ctx, taskID, sessionID, content, model, planMode, attachments)
+	_, err := h.orchestrator.PromptTask(ctx, taskID, sessionID, content, model, planMode, attachments, false)
 	if err != nil {
 		err = h.handlePromptWithResume(ctx, taskID, sessionID, content, model, planMode, attachments, err)
 	}
@@ -419,7 +419,7 @@ func (h *MessageHandlers) handlePromptWithResume(
 			zap.Error(waitErr))
 		return waitErr
 	}
-	_, err := h.orchestrator.PromptTask(ctx, taskID, sessionID, content, model, planMode, attachments)
+	_, err := h.orchestrator.PromptTask(ctx, taskID, sessionID, content, model, planMode, attachments, false)
 	return err
 }
 


### PR DESCRIPTION
The MCP `message_task_kandev` tool was synchronously waiting for the target session's entire turn to complete before returning, even though its description advertises a fast dispatch status — for idle target sessions the call would hang for the full duration of the agent's response, with no upper bound since `waitForPromptDone` has no timeout.

## Important Changes

- Threads a `dispatchOnly` flag from the MCP handler down through `PromptTask` → `executor.Prompt` → `PromptAgent` → `SendPrompt`. When set, `SendPrompt` returns once `agentctl.Prompt` accepts the prompt instead of blocking on the agent's `complete` event.
- Drains stale completion signals from `promptDoneCh` at the start of `SendPrompt` so a leftover signal from a prior dispatch-only prompt doesn't poison the next waiting call.
- Skips `beginPromptBarrier` in dispatch-only mode — there is no in-flight wait for `CancelAgent` to coordinate with.

## Validation

- `make fmt lint` (0 issues) and `make test` across the backend.
- New `TestSendPrompt_DispatchOnlyReturnsWithoutWaiting` confirms the dispatch-only path returns within ms even when no completion signal arrives.
- New `TestSendPrompt_DrainsStaleSignalFromPriorDispatchOnly` confirms a stale signal doesn't satisfy the next waiting prompt.
- Updated `TestHandleMessageTask_WaitingForInput_PromptsAgent` asserts the MCP path passes `dispatchOnly=true`.

## Possible Improvements

Low risk. The MCP tool now returns optimistically — the prompt has been accepted by the agent process, but failures that surface only mid-turn (e.g. the agent crashing) won't propagate back to the MCP caller. They still flow through the normal event pipeline (`handleAgentReady`, REVIEW state transition), so observable behavior in the UI is unchanged.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.