### PR TITLE
feat(web): double-click tab to toggle maximize

### DIFF
--- a/apps/web/components/task/__tests__/use-tab-maximize.test.ts
+++ b/apps/web/components/task/__tests__/use-tab-maximize.test.ts
@@ -6,56 +6,101 @@ const SIDEBAR_GROUP_ID = "sidebar-group";
 const mockMaximizeGroup = vi.fn();
 const mockExitMaximizedLayout = vi.fn();
 
-let mockPreMaximizeLayout: object | null = null;
-let mockSidebarGroupId = SIDEBAR_GROUP_ID;
+const storeState: {
+  preMaximizeLayout: object | null;
+  sidebarGroupId: string;
+  isRestoringLayout: boolean;
+  maximizeGroup: typeof mockMaximizeGroup;
+  exitMaximizedLayout: typeof mockExitMaximizedLayout;
+} = {
+  preMaximizeLayout: null,
+  sidebarGroupId: SIDEBAR_GROUP_ID,
+  isRestoringLayout: false,
+  maximizeGroup: mockMaximizeGroup,
+  exitMaximizedLayout: mockExitMaximizedLayout,
+};
 
 vi.mock("@/lib/state/dockview-store", () => ({
-  useDockviewStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({
-      preMaximizeLayout: mockPreMaximizeLayout,
-      sidebarGroupId: mockSidebarGroupId,
-      maximizeGroup: mockMaximizeGroup,
-      exitMaximizedLayout: mockExitMaximizedLayout,
-    }),
+  useDockviewStore: Object.assign(
+    (selector: (state: typeof storeState) => unknown) => selector(storeState),
+    { getState: () => storeState },
+  ),
 }));
 
-import { useToggleGroupMaximize } from "../use-tab-maximize";
+import { useTabMaximizeOnDoubleClick } from "../use-tab-maximize";
 
-describe("useToggleGroupMaximize", () => {
+function makeApi(groupId: string | undefined) {
+  return { group: groupId === undefined ? undefined : { id: groupId } } as Parameters<
+    typeof useTabMaximizeOnDoubleClick
+  >[0];
+}
+
+function makeEvent() {
+  return {
+    stopPropagation: vi.fn(),
+    preventDefault: vi.fn(),
+  } as unknown as React.MouseEvent;
+}
+
+describe("useTabMaximizeOnDoubleClick", () => {
   beforeEach(() => {
     mockMaximizeGroup.mockClear();
     mockExitMaximizedLayout.mockClear();
-    mockPreMaximizeLayout = null;
-    mockSidebarGroupId = SIDEBAR_GROUP_ID;
+    storeState.preMaximizeLayout = null;
+    storeState.sidebarGroupId = SIDEBAR_GROUP_ID;
+    storeState.isRestoringLayout = false;
   });
 
   it("calls maximizeGroup when not currently maximized", () => {
-    const { result } = renderHook(() => useToggleGroupMaximize("group-a"));
-    result.current();
+    const { result } = renderHook(() => useTabMaximizeOnDoubleClick(makeApi("group-a")));
+    result.current(makeEvent());
     expect(mockMaximizeGroup).toHaveBeenCalledWith("group-a");
     expect(mockExitMaximizedLayout).not.toHaveBeenCalled();
   });
 
   it("calls exitMaximizedLayout when currently maximized", () => {
-    mockPreMaximizeLayout = { columns: [] };
-    const { result } = renderHook(() => useToggleGroupMaximize("group-a"));
-    result.current();
+    storeState.preMaximizeLayout = { columns: [] };
+    const { result } = renderHook(() => useTabMaximizeOnDoubleClick(makeApi("group-a")));
+    result.current(makeEvent());
     expect(mockExitMaximizedLayout).toHaveBeenCalledTimes(1);
     expect(mockMaximizeGroup).not.toHaveBeenCalled();
   });
 
   it("no-ops when groupId is the sidebar group", () => {
-    const { result } = renderHook(() => useToggleGroupMaximize(SIDEBAR_GROUP_ID));
-    result.current();
+    const { result } = renderHook(() => useTabMaximizeOnDoubleClick(makeApi(SIDEBAR_GROUP_ID)));
+    result.current(makeEvent());
     expect(mockMaximizeGroup).not.toHaveBeenCalled();
     expect(mockExitMaximizedLayout).not.toHaveBeenCalled();
   });
 
-  it("no-ops on sidebar group even when maximized state is set", () => {
-    mockPreMaximizeLayout = { columns: [] };
-    const { result } = renderHook(() => useToggleGroupMaximize(SIDEBAR_GROUP_ID));
-    result.current();
+  it("no-ops while a layout restore is in progress", () => {
+    storeState.isRestoringLayout = true;
+    const { result } = renderHook(() => useTabMaximizeOnDoubleClick(makeApi("group-a")));
+    result.current(makeEvent());
     expect(mockMaximizeGroup).not.toHaveBeenCalled();
     expect(mockExitMaximizedLayout).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when api.group is missing", () => {
+    const { result } = renderHook(() => useTabMaximizeOnDoubleClick(makeApi(undefined)));
+    result.current(makeEvent());
+    expect(mockMaximizeGroup).not.toHaveBeenCalled();
+  });
+
+  it("reads groupId fresh at call time, not from render-time closure", () => {
+    const api = makeApi("group-a");
+    const { result } = renderHook(() => useTabMaximizeOnDoubleClick(api));
+    // Simulate dockview reassigning the panel's group after layout rebuild.
+    (api.group as { id: string }).id = "group-b";
+    result.current(makeEvent());
+    expect(mockMaximizeGroup).toHaveBeenCalledWith("group-b");
+  });
+
+  it("stops the event from propagating to the underlying tab", () => {
+    const event = makeEvent();
+    const { result } = renderHook(() => useTabMaximizeOnDoubleClick(makeApi("group-a")));
+    result.current(event);
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
   });
 });

--- a/apps/web/components/task/__tests__/use-tab-maximize.test.ts
+++ b/apps/web/components/task/__tests__/use-tab-maximize.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const SIDEBAR_GROUP_ID = "sidebar-group";
+
+const mockMaximizeGroup = vi.fn();
+const mockExitMaximizedLayout = vi.fn();
+
+let mockPreMaximizeLayout: object | null = null;
+let mockSidebarGroupId = SIDEBAR_GROUP_ID;
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      preMaximizeLayout: mockPreMaximizeLayout,
+      sidebarGroupId: mockSidebarGroupId,
+      maximizeGroup: mockMaximizeGroup,
+      exitMaximizedLayout: mockExitMaximizedLayout,
+    }),
+}));
+
+import { useToggleGroupMaximize } from "../use-tab-maximize";
+
+describe("useToggleGroupMaximize", () => {
+  beforeEach(() => {
+    mockMaximizeGroup.mockClear();
+    mockExitMaximizedLayout.mockClear();
+    mockPreMaximizeLayout = null;
+    mockSidebarGroupId = SIDEBAR_GROUP_ID;
+  });
+
+  it("calls maximizeGroup when not currently maximized", () => {
+    const { result } = renderHook(() => useToggleGroupMaximize("group-a"));
+    result.current();
+    expect(mockMaximizeGroup).toHaveBeenCalledWith("group-a");
+    expect(mockExitMaximizedLayout).not.toHaveBeenCalled();
+  });
+
+  it("calls exitMaximizedLayout when currently maximized", () => {
+    mockPreMaximizeLayout = { columns: [] };
+    const { result } = renderHook(() => useToggleGroupMaximize("group-a"));
+    result.current();
+    expect(mockExitMaximizedLayout).toHaveBeenCalledTimes(1);
+    expect(mockMaximizeGroup).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when groupId is the sidebar group", () => {
+    const { result } = renderHook(() => useToggleGroupMaximize(SIDEBAR_GROUP_ID));
+    result.current();
+    expect(mockMaximizeGroup).not.toHaveBeenCalled();
+    expect(mockExitMaximizedLayout).not.toHaveBeenCalled();
+  });
+
+  it("no-ops on sidebar group even when maximized state is set", () => {
+    mockPreMaximizeLayout = { columns: [] };
+    const { result } = renderHook(() => useToggleGroupMaximize(SIDEBAR_GROUP_ID));
+    result.current();
+    expect(mockMaximizeGroup).not.toHaveBeenCalled();
+    expect(mockExitMaximizedLayout).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/changes-tab.tsx
+++ b/apps/web/components/task/changes-tab.tsx
@@ -13,6 +13,7 @@ import { useSessionGitStatus } from "@/hooks/domains/session/use-session-git-sta
 import { useSessionCommits } from "@/hooks/domains/session/use-session-commits";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { cn } from "@kandev/ui/lib/utils";
+import { useToggleGroupMaximize } from "./use-tab-maximize";
 
 /** Auto-activate the changes panel only when it lives in the right sidebar. */
 function autoActivateChangesPanel(): void {
@@ -35,6 +36,7 @@ function autoActivateChangesPanel(): void {
  */
 export function ChangesTab(props: IDockviewPanelHeaderProps) {
   const { api, containerApi } = props;
+  const toggleMaximize = useToggleGroupMaximize(api.group.id);
 
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
   const gitStatus = useSessionGitStatus(activeSessionId);
@@ -118,7 +120,10 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger className="flex h-full items-center cursor-pointer">
+      <ContextMenuTrigger
+        className="flex h-full items-center cursor-pointer select-none"
+        onDoubleClick={toggleMaximize}
+      >
         <div className={cn("relative", isFlashing && "animate-changes-flash")}>
           <DockviewDefaultTab {...props} />
           {badgeCount > 0 && (

--- a/apps/web/components/task/changes-tab.tsx
+++ b/apps/web/components/task/changes-tab.tsx
@@ -13,7 +13,7 @@ import { useSessionGitStatus } from "@/hooks/domains/session/use-session-git-sta
 import { useSessionCommits } from "@/hooks/domains/session/use-session-commits";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { cn } from "@kandev/ui/lib/utils";
-import { useToggleGroupMaximize } from "./use-tab-maximize";
+import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 
 /** Auto-activate the changes panel only when it lives in the right sidebar. */
 function autoActivateChangesPanel(): void {
@@ -36,7 +36,7 @@ function autoActivateChangesPanel(): void {
  */
 export function ChangesTab(props: IDockviewPanelHeaderProps) {
   const { api, containerApi } = props;
-  const toggleMaximize = useToggleGroupMaximize(api.group.id);
+  const onDoubleClick = useTabMaximizeOnDoubleClick(api);
 
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
   const gitStatus = useSessionGitStatus(activeSessionId);
@@ -122,7 +122,7 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
     <ContextMenu>
       <ContextMenuTrigger
         className="flex h-full items-center cursor-pointer select-none"
-        onDoubleClick={toggleMaximize}
+        onDoubleClick={onDoubleClick}
       >
         <div className={cn("relative", isFlashing && "animate-changes-flash")}>
           <DockviewDefaultTab {...props} />

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -155,7 +155,10 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps>> =
 function PermanentTab(props: IDockviewPanelHeaderProps) {
   const toggleMaximize = useToggleGroupMaximize(props.api.group.id);
   return (
-    <div className="flex h-full items-center select-none" onDoubleClick={toggleMaximize}>
+    <div
+      className="flex h-full items-center cursor-pointer select-none"
+      onDoubleClick={toggleMaximize}
+    >
       <DockviewDefaultTab {...props} hideClose />
     </div>
   );

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -42,6 +42,7 @@ import { ChangesTab } from "./changes-tab";
 import { PlanTab } from "./plan-tab";
 import { PreviewFileTab, PreviewDiffTab, PreviewCommitTab, PinnedDefaultTab } from "./preview-tab";
 import { SessionTab } from "./session-tab";
+import { useToggleGroupMaximize } from "./use-tab-maximize";
 import {
   setupSessionTabSync,
   setupChatPanelSafetyNet,
@@ -152,7 +153,12 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps>> =
 
 // --- TAB COMPONENTS ---
 function PermanentTab(props: IDockviewPanelHeaderProps) {
-  return <DockviewDefaultTab {...props} hideClose />;
+  const toggleMaximize = useToggleGroupMaximize(props.api.group.id);
+  return (
+    <div className="flex h-full items-center select-none" onDoubleClick={toggleMaximize}>
+      <DockviewDefaultTab {...props} hideClose />
+    </div>
+  );
 }
 
 /** Sync the user's default saved layout from settings into the dockview store. */

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -42,7 +42,7 @@ import { ChangesTab } from "./changes-tab";
 import { PlanTab } from "./plan-tab";
 import { PreviewFileTab, PreviewDiffTab, PreviewCommitTab, PinnedDefaultTab } from "./preview-tab";
 import { SessionTab } from "./session-tab";
-import { useToggleGroupMaximize } from "./use-tab-maximize";
+import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 import {
   setupSessionTabSync,
   setupChatPanelSafetyNet,
@@ -153,11 +153,11 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps>> =
 
 // --- TAB COMPONENTS ---
 function PermanentTab(props: IDockviewPanelHeaderProps) {
-  const toggleMaximize = useToggleGroupMaximize(props.api.group.id);
+  const onDoubleClick = useTabMaximizeOnDoubleClick(props.api);
   return (
     <div
       className="flex h-full items-center cursor-pointer select-none"
-      onDoubleClick={toggleMaximize}
+      onDoubleClick={onDoubleClick}
     >
       <DockviewDefaultTab {...props} hideClose />
     </div>

--- a/apps/web/components/task/plan-tab.test.tsx
+++ b/apps/web/components/task/plan-tab.test.tsx
@@ -27,6 +27,16 @@ vi.mock("dockview-react", () => ({
   DockviewDefaultTab: () => null,
 }));
 
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      preMaximizeLayout: null,
+      sidebarGroupId: "sidebar-group",
+      maximizeGroup: vi.fn(),
+      exitMaximizedLayout: vi.fn(),
+    }),
+}));
+
 import { PlanTab } from "./plan-tab";
 
 const TS = "2026-04-20T00:00:00Z";
@@ -46,12 +56,14 @@ function agentPlan(updated_at = TS): TaskPlan {
 
 type TabApi = {
   isActive: boolean;
+  group: { id: string };
   onDidActiveChange: (listener: (e: { isActive: boolean }) => void) => { dispose: () => void };
 };
 
 function makeApi(isActive: boolean): TabApi {
   return {
     isActive,
+    group: { id: "group-a" },
     onDidActiveChange: () => ({ dispose: () => {} }),
   };
 }

--- a/apps/web/components/task/plan-tab.test.tsx
+++ b/apps/web/components/task/plan-tab.test.tsx
@@ -27,14 +27,19 @@ vi.mock("dockview-react", () => ({
   DockviewDefaultTab: () => null,
 }));
 
+const mockDockviewState = {
+  preMaximizeLayout: null,
+  sidebarGroupId: "sidebar-group",
+  isRestoringLayout: false,
+  maximizeGroup: vi.fn(),
+  exitMaximizedLayout: vi.fn(),
+};
+
 vi.mock("@/lib/state/dockview-store", () => ({
-  useDockviewStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({
-      preMaximizeLayout: null,
-      sidebarGroupId: "sidebar-group",
-      maximizeGroup: vi.fn(),
-      exitMaximizedLayout: vi.fn(),
-    }),
+  useDockviewStore: Object.assign(
+    (selector: (state: typeof mockDockviewState) => unknown) => selector(mockDockviewState),
+    { getState: () => mockDockviewState },
+  ),
 }));
 
 import { PlanTab } from "./plan-tab";

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect } from "react";
 import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import { useAppStore } from "@/components/state-provider";
+import { useToggleGroupMaximize } from "./use-tab-maximize";
 
 /**
  * Custom tab component for the Plan panel.
@@ -11,6 +12,7 @@ import { useAppStore } from "@/components/state-provider";
  */
 export function PlanTab(props: IDockviewPanelHeaderProps) {
   const { api } = props;
+  const toggleMaximize = useToggleGroupMaximize(api.group.id);
 
   const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
   const plan = useAppStore((s) => (activeTaskId ? s.taskPlans.byTaskId[activeTaskId] : null));
@@ -39,7 +41,7 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
   const hasUnseen = plan?.created_by === "agent" && lastSeen !== plan.updated_at;
 
   return (
-    <div data-testid="plan-tab" className="relative">
+    <div data-testid="plan-tab" className="relative select-none" onDoubleClick={toggleMaximize}>
       <DockviewDefaultTab {...props} />
       {hasUnseen && (
         <span

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -41,7 +41,11 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
   const hasUnseen = plan?.created_by === "agent" && lastSeen !== plan.updated_at;
 
   return (
-    <div data-testid="plan-tab" className="relative select-none" onDoubleClick={toggleMaximize}>
+    <div
+      data-testid="plan-tab"
+      className="relative cursor-pointer select-none"
+      onDoubleClick={toggleMaximize}
+    >
       <DockviewDefaultTab {...props} />
       {hasUnseen && (
         <span

--- a/apps/web/components/task/plan-tab.tsx
+++ b/apps/web/components/task/plan-tab.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useLayoutEffect } from "react";
 import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import { useAppStore } from "@/components/state-provider";
-import { useToggleGroupMaximize } from "./use-tab-maximize";
+import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 
 /**
  * Custom tab component for the Plan panel.
@@ -12,7 +12,7 @@ import { useToggleGroupMaximize } from "./use-tab-maximize";
  */
 export function PlanTab(props: IDockviewPanelHeaderProps) {
   const { api } = props;
-  const toggleMaximize = useToggleGroupMaximize(api.group.id);
+  const onDoubleClick = useTabMaximizeOnDoubleClick(api);
 
   const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
   const plan = useAppStore((s) => (activeTaskId ? s.taskPlans.byTaskId[activeTaskId] : null));
@@ -44,7 +44,7 @@ export function PlanTab(props: IDockviewPanelHeaderProps) {
     <div
       data-testid="plan-tab"
       className="relative cursor-pointer select-none"
-      onDoubleClick={toggleMaximize}
+      onDoubleClick={onDoubleClick}
     >
       <DockviewDefaultTab {...props} />
       {hasUnseen && (

--- a/apps/web/components/task/preview-tab.test.tsx
+++ b/apps/web/components/task/preview-tab.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, screen, cleanup } from "@testing-library/react";
+
+const mockPromote = vi.fn();
+const mockMaximizeGroup = vi.fn();
+const mockExitMaximizedLayout = vi.fn();
+
+let mockPreMaximizeLayout: object | null = null;
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      promotePreviewToPinned: mockPromote,
+      preMaximizeLayout: mockPreMaximizeLayout,
+      sidebarGroupId: "sidebar-group",
+      maximizeGroup: mockMaximizeGroup,
+      exitMaximizedLayout: mockExitMaximizedLayout,
+    }),
+}));
+
+vi.mock("dockview-react", () => ({
+  DockviewDefaultTab: () => null,
+}));
+
+vi.mock("@kandev/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: () => null,
+  ContextMenuItem: () => null,
+  ContextMenuSeparator: () => null,
+}));
+
+import { PreviewFileTab } from "./preview-tab";
+
+type TabApi = {
+  id: string;
+  group: { id: string };
+};
+
+function makeProps(promoted: boolean) {
+  const api: TabApi = { id: "panel-1", group: { id: "group-a" } };
+  const containerApi = { getPanel: () => undefined, removePanel: () => {} };
+  return {
+    api,
+    containerApi,
+    params: { promoted },
+  } as unknown as React.ComponentProps<typeof PreviewFileTab>;
+}
+
+describe("PreviewTab dblclick sequencing", () => {
+  beforeEach(() => {
+    mockPromote.mockClear();
+    mockMaximizeGroup.mockClear();
+    mockExitMaximizedLayout.mockClear();
+    mockPreMaximizeLayout = null;
+  });
+  afterEach(() => cleanup());
+
+  it("first dblclick on unpinned preview promotes to pinned (no maximize)", () => {
+    render(<PreviewFileTab {...makeProps(false)} />);
+    fireEvent.doubleClick(screen.getByTestId("preview-tab-file-editor"));
+    expect(mockPromote).toHaveBeenCalledWith("file-editor");
+    expect(mockMaximizeGroup).not.toHaveBeenCalled();
+  });
+
+  it("dblclick on pinned preview maximizes (no further promote)", () => {
+    render(<PreviewFileTab {...makeProps(true)} />);
+    fireEvent.doubleClick(screen.getByTestId("preview-tab-file-editor"));
+    expect(mockPromote).not.toHaveBeenCalled();
+    expect(mockMaximizeGroup).toHaveBeenCalledWith("group-a");
+  });
+
+  it("dblclick on pinned preview while maximized restores layout", () => {
+    mockPreMaximizeLayout = { columns: [] };
+    render(<PreviewFileTab {...makeProps(true)} />);
+    fireEvent.doubleClick(screen.getByTestId("preview-tab-file-editor"));
+    expect(mockExitMaximizedLayout).toHaveBeenCalledTimes(1);
+    expect(mockMaximizeGroup).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/preview-tab.test.tsx
+++ b/apps/web/components/task/preview-tab.test.tsx
@@ -5,17 +5,20 @@ const mockPromote = vi.fn();
 const mockMaximizeGroup = vi.fn();
 const mockExitMaximizedLayout = vi.fn();
 
-let mockPreMaximizeLayout: object | null = null;
+const storeState = {
+  promotePreviewToPinned: mockPromote,
+  preMaximizeLayout: null as object | null,
+  sidebarGroupId: "sidebar-group",
+  isRestoringLayout: false,
+  maximizeGroup: mockMaximizeGroup,
+  exitMaximizedLayout: mockExitMaximizedLayout,
+};
 
 vi.mock("@/lib/state/dockview-store", () => ({
-  useDockviewStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({
-      promotePreviewToPinned: mockPromote,
-      preMaximizeLayout: mockPreMaximizeLayout,
-      sidebarGroupId: "sidebar-group",
-      maximizeGroup: mockMaximizeGroup,
-      exitMaximizedLayout: mockExitMaximizedLayout,
-    }),
+  useDockviewStore: Object.assign(
+    (selector: (state: typeof storeState) => unknown) => selector(storeState),
+    { getState: () => storeState },
+  ),
 }));
 
 vi.mock("dockview-react", () => ({
@@ -31,6 +34,8 @@ vi.mock("@kandev/ui/context-menu", () => ({
 }));
 
 import { PreviewFileTab } from "./preview-tab";
+
+const PREVIEW_TAB_TID = "preview-tab-file-editor";
 
 type TabApi = {
   id: string;
@@ -52,29 +57,38 @@ describe("PreviewTab dblclick sequencing", () => {
     mockPromote.mockClear();
     mockMaximizeGroup.mockClear();
     mockExitMaximizedLayout.mockClear();
-    mockPreMaximizeLayout = null;
+    storeState.preMaximizeLayout = null;
+    storeState.isRestoringLayout = false;
   });
   afterEach(() => cleanup());
 
   it("first dblclick on unpinned preview promotes to pinned (no maximize)", () => {
     render(<PreviewFileTab {...makeProps(false)} />);
-    fireEvent.doubleClick(screen.getByTestId("preview-tab-file-editor"));
+    fireEvent.doubleClick(screen.getByTestId(PREVIEW_TAB_TID));
     expect(mockPromote).toHaveBeenCalledWith("file-editor");
     expect(mockMaximizeGroup).not.toHaveBeenCalled();
   });
 
   it("dblclick on pinned preview maximizes (no further promote)", () => {
     render(<PreviewFileTab {...makeProps(true)} />);
-    fireEvent.doubleClick(screen.getByTestId("preview-tab-file-editor"));
+    fireEvent.doubleClick(screen.getByTestId(PREVIEW_TAB_TID));
     expect(mockPromote).not.toHaveBeenCalled();
     expect(mockMaximizeGroup).toHaveBeenCalledWith("group-a");
   });
 
   it("dblclick on pinned preview while maximized restores layout", () => {
-    mockPreMaximizeLayout = { columns: [] };
+    storeState.preMaximizeLayout = { columns: [] };
     render(<PreviewFileTab {...makeProps(true)} />);
-    fireEvent.doubleClick(screen.getByTestId("preview-tab-file-editor"));
+    fireEvent.doubleClick(screen.getByTestId(PREVIEW_TAB_TID));
     expect(mockExitMaximizedLayout).toHaveBeenCalledTimes(1);
     expect(mockMaximizeGroup).not.toHaveBeenCalled();
+  });
+
+  it("ignores dblclick while a layout restore is in progress", () => {
+    storeState.isRestoringLayout = true;
+    render(<PreviewFileTab {...makeProps(true)} />);
+    fireEvent.doubleClick(screen.getByTestId(PREVIEW_TAB_TID));
+    expect(mockMaximizeGroup).not.toHaveBeenCalled();
+    expect(mockExitMaximizedLayout).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/task/preview-tab.tsx
+++ b/apps/web/components/task/preview-tab.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import type { PreviewType } from "@/lib/state/dockview-panel-actions";
+import { useToggleGroupMaximize } from "./use-tab-maximize";
 
 /**
  * Middle-click to close any tab (preview or pinned).
@@ -61,11 +62,16 @@ function PreviewTab(props: IDockviewPanelHeaderProps & { type: PreviewType }) {
   const promote = useDockviewStore((s) => s.promotePreviewToPinned);
   const onMouseDown = useMiddleClickClose(api, containerApi);
   const { handleClose, handleCloseOthers } = useTabContextActions(api, containerApi);
+  const toggleMaximize = useToggleGroupMaximize(api.group.id);
   const isPromoted = (props.params as Record<string, unknown> | undefined)?.promoted === true;
 
   const onDoubleClick = useCallback(() => {
-    if (!isPromoted) promote(type);
-  }, [promote, type, isPromoted]);
+    if (!isPromoted) {
+      promote(type);
+      return;
+    }
+    toggleMaximize();
+  }, [promote, type, isPromoted, toggleMaximize]);
 
   const handleKeepOpen = useCallback(() => {
     promote(type);
@@ -75,7 +81,10 @@ function PreviewTab(props: IDockviewPanelHeaderProps & { type: PreviewType }) {
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
-          className={cn("flex h-full items-center cursor-pointer", !isPromoted && "italic")}
+          className={cn(
+            "flex h-full items-center cursor-pointer select-none",
+            !isPromoted && "italic",
+          )}
           onMouseDown={onMouseDown}
           onDoubleClick={onDoubleClick}
           title={isPromoted ? undefined : "Double-click to keep this tab open"}
@@ -122,11 +131,16 @@ export function PinnedDefaultTab(props: IDockviewPanelHeaderProps) {
   const { api, containerApi } = props;
   const onMouseDown = useMiddleClickClose(api, containerApi);
   const { handleClose, handleCloseOthers } = useTabContextActions(api, containerApi);
+  const toggleMaximize = useToggleGroupMaximize(api.group.id);
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div className="flex h-full items-center cursor-pointer" onMouseDown={onMouseDown}>
+        <div
+          className="flex h-full items-center cursor-pointer select-none"
+          onMouseDown={onMouseDown}
+          onDoubleClick={toggleMaximize}
+        >
           <DockviewDefaultTab {...props} />
         </div>
       </ContextMenuTrigger>

--- a/apps/web/components/task/preview-tab.tsx
+++ b/apps/web/components/task/preview-tab.tsx
@@ -12,7 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import type { PreviewType } from "@/lib/state/dockview-panel-actions";
-import { useToggleGroupMaximize } from "./use-tab-maximize";
+import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 
 /**
  * Middle-click to close any tab (preview or pinned).
@@ -62,16 +62,19 @@ function PreviewTab(props: IDockviewPanelHeaderProps & { type: PreviewType }) {
   const promote = useDockviewStore((s) => s.promotePreviewToPinned);
   const onMouseDown = useMiddleClickClose(api, containerApi);
   const { handleClose, handleCloseOthers } = useTabContextActions(api, containerApi);
-  const toggleMaximize = useToggleGroupMaximize(api.group.id);
+  const handleMaximizeDblClick = useTabMaximizeOnDoubleClick(api);
   const isPromoted = (props.params as Record<string, unknown> | undefined)?.promoted === true;
 
-  const onDoubleClick = useCallback(() => {
-    if (!isPromoted) {
-      promote(type);
-      return;
-    }
-    toggleMaximize();
-  }, [promote, type, isPromoted, toggleMaximize]);
+  const onDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (!isPromoted) {
+        promote(type);
+        return;
+      }
+      handleMaximizeDblClick(event);
+    },
+    [promote, type, isPromoted, handleMaximizeDblClick],
+  );
 
   const handleKeepOpen = useCallback(() => {
     promote(type);
@@ -131,7 +134,7 @@ export function PinnedDefaultTab(props: IDockviewPanelHeaderProps) {
   const { api, containerApi } = props;
   const onMouseDown = useMiddleClickClose(api, containerApi);
   const { handleClose, handleCloseOthers } = useTabContextActions(api, containerApi);
-  const toggleMaximize = useToggleGroupMaximize(api.group.id);
+  const onDoubleClick = useTabMaximizeOnDoubleClick(api);
 
   return (
     <ContextMenu>
@@ -139,7 +142,7 @@ export function PinnedDefaultTab(props: IDockviewPanelHeaderProps) {
         <div
           className="flex h-full items-center cursor-pointer select-none"
           onMouseDown={onMouseDown}
-          onDoubleClick={toggleMaximize}
+          onDoubleClick={onDoubleClick}
         >
           <DockviewDefaultTab {...props} />
         </div>

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -25,6 +25,7 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import type { TaskSessionState } from "@/lib/types/http";
+import { useToggleGroupMaximize } from "./use-tab-maximize";
 
 function isStoppable(s: TaskSessionState) {
   return s === "RUNNING" || s === "STARTING" || s === "WAITING_FOR_INPUT";
@@ -283,6 +284,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const { isPrimary, sessionState, taskId, agentLabel, agentName, sessionNumber, sessionCount } =
     useSessionTabState(sessionId);
   const actions = useSessionTabActions(sessionId, taskId, api, containerApi);
+  const toggleMaximize = useToggleGroupMaximize(api.group.id);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isActive, setIsActive] = useState(api.isActive);
 
@@ -301,8 +303,9 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
     <>
       <ContextMenu>
         <ContextMenuTrigger
-          className="flex h-full items-center cursor-pointer"
+          className="flex h-full items-center cursor-pointer select-none"
           data-testid={sessionId ? `session-tab-${sessionId}` : undefined}
+          onDoubleClick={toggleMaximize}
         >
           <div className="flex items-center">
             {isPrimary && showMultiSessionBadges && (

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -25,7 +25,7 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import type { TaskSessionState } from "@/lib/types/http";
-import { useToggleGroupMaximize } from "./use-tab-maximize";
+import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 
 function isStoppable(s: TaskSessionState) {
   return s === "RUNNING" || s === "STARTING" || s === "WAITING_FOR_INPUT";
@@ -284,7 +284,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const { isPrimary, sessionState, taskId, agentLabel, agentName, sessionNumber, sessionCount } =
     useSessionTabState(sessionId);
   const actions = useSessionTabActions(sessionId, taskId, api, containerApi);
-  const toggleMaximize = useToggleGroupMaximize(api.group.id);
+  const onDoubleClick = useTabMaximizeOnDoubleClick(api);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isActive, setIsActive] = useState(api.isActive);
 
@@ -305,7 +305,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
         <ContextMenuTrigger
           className="flex h-full items-center cursor-pointer select-none"
           data-testid={sessionId ? `session-tab-${sessionId}` : undefined}
-          onDoubleClick={toggleMaximize}
+          onDoubleClick={onDoubleClick}
         >
           <div className="flex items-center">
             {isPrimary && showMultiSessionBadges && (

--- a/apps/web/components/task/tab-context-menu.tsx
+++ b/apps/web/components/task/tab-context-menu.tsx
@@ -43,7 +43,7 @@ export function ContextMenuTab(props: IDockviewPanelHeaderProps) {
   return (
     <ContextMenu>
       <ContextMenuTrigger
-        className="flex h-full items-center select-none"
+        className="flex h-full items-center cursor-pointer select-none"
         onDoubleClick={toggleMaximize}
       >
         <DockviewDefaultTab {...props} />

--- a/apps/web/components/task/tab-context-menu.tsx
+++ b/apps/web/components/task/tab-context-menu.tsx
@@ -8,7 +8,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@kandev/ui/context-menu";
-import { useToggleGroupMaximize } from "./use-tab-maximize";
+import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 
 /** An item in the tab right-click context menu.
  *  Items are ephemeral — not serialized to the saved layout. */
@@ -28,7 +28,7 @@ export type TabContextMenuParams = {
  *  props.params.contextMenuItems. */
 export function ContextMenuTab(props: IDockviewPanelHeaderProps) {
   const { api, containerApi } = props;
-  const toggleMaximize = useToggleGroupMaximize(api.group.id);
+  const onDoubleClick = useTabMaximizeOnDoubleClick(api);
 
   const handleCloseOthers = useCallback(() => {
     const toClose = api.group.panels.filter(
@@ -44,7 +44,7 @@ export function ContextMenuTab(props: IDockviewPanelHeaderProps) {
     <ContextMenu>
       <ContextMenuTrigger
         className="flex h-full items-center cursor-pointer select-none"
-        onDoubleClick={toggleMaximize}
+        onDoubleClick={onDoubleClick}
       >
         <DockviewDefaultTab {...props} />
       </ContextMenuTrigger>

--- a/apps/web/components/task/tab-context-menu.tsx
+++ b/apps/web/components/task/tab-context-menu.tsx
@@ -8,6 +8,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@kandev/ui/context-menu";
+import { useToggleGroupMaximize } from "./use-tab-maximize";
 
 /** An item in the tab right-click context menu.
  *  Items are ephemeral — not serialized to the saved layout. */
@@ -27,6 +28,7 @@ export type TabContextMenuParams = {
  *  props.params.contextMenuItems. */
 export function ContextMenuTab(props: IDockviewPanelHeaderProps) {
   const { api, containerApi } = props;
+  const toggleMaximize = useToggleGroupMaximize(api.group.id);
 
   const handleCloseOthers = useCallback(() => {
     const toClose = api.group.panels.filter(
@@ -40,7 +42,10 @@ export function ContextMenuTab(props: IDockviewPanelHeaderProps) {
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger className="flex h-full items-center">
+      <ContextMenuTrigger
+        className="flex h-full items-center select-none"
+        onDoubleClick={toggleMaximize}
+      >
         <DockviewDefaultTab {...props} />
       </ContextMenuTrigger>
       <ContextMenuContent>

--- a/apps/web/components/task/use-tab-maximize.ts
+++ b/apps/web/components/task/use-tab-maximize.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useCallback } from "react";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+
+/**
+ * Returns a callback that toggles the maximize state for the given dockview
+ * group. No-ops for the sidebar group (it has no maximize button either).
+ */
+export function useToggleGroupMaximize(groupId: string): () => void {
+  const isMaximized = useDockviewStore((s) => s.preMaximizeLayout !== null);
+  const sidebarGroupId = useDockviewStore((s) => s.sidebarGroupId);
+  const maximizeGroup = useDockviewStore((s) => s.maximizeGroup);
+  const exitMaximizedLayout = useDockviewStore((s) => s.exitMaximizedLayout);
+
+  return useCallback(() => {
+    if (groupId === sidebarGroupId) return;
+    if (isMaximized) {
+      exitMaximizedLayout();
+    } else {
+      maximizeGroup(groupId);
+    }
+  }, [groupId, sidebarGroupId, isMaximized, maximizeGroup, exitMaximizedLayout]);
+}

--- a/apps/web/components/task/use-tab-maximize.ts
+++ b/apps/web/components/task/use-tab-maximize.ts
@@ -1,24 +1,37 @@
 "use client";
 
 import { useCallback } from "react";
+import type { DockviewPanelApi } from "dockview-react";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 
 /**
- * Returns a callback that toggles the maximize state for the given dockview
- * group. No-ops for the sidebar group (it has no maximize button either).
+ * Returns an `onDoubleClick` handler that toggles the maximize state for the
+ * dockview group containing the given panel. No-ops for the sidebar group
+ * (which has no maximize button either) and while the dockview store is in
+ * the middle of restoring a layout (guards against rapid double-firing on
+ * back-to-back dblclicks during the maximize/restore animation frame).
+ *
+ * Reads `api.group.id` and store state at call time rather than render time
+ * so the toggle remains correct after dockview rebuilds groups via fromJSON.
  */
-export function useToggleGroupMaximize(groupId: string): () => void {
-  const isMaximized = useDockviewStore((s) => s.preMaximizeLayout !== null);
-  const sidebarGroupId = useDockviewStore((s) => s.sidebarGroupId);
-  const maximizeGroup = useDockviewStore((s) => s.maximizeGroup);
-  const exitMaximizedLayout = useDockviewStore((s) => s.exitMaximizedLayout);
-
-  return useCallback(() => {
-    if (groupId === sidebarGroupId) return;
-    if (isMaximized) {
-      exitMaximizedLayout();
-    } else {
-      maximizeGroup(groupId);
-    }
-  }, [groupId, sidebarGroupId, isMaximized, maximizeGroup, exitMaximizedLayout]);
+export function useTabMaximizeOnDoubleClick(
+  api: Pick<DockviewPanelApi, "group">,
+): (event: React.MouseEvent) => void {
+  return useCallback(
+    (event) => {
+      event.stopPropagation();
+      event.preventDefault();
+      const groupId = api.group?.id;
+      if (!groupId) return;
+      const state = useDockviewStore.getState();
+      if (state.isRestoringLayout) return;
+      if (groupId === state.sidebarGroupId) return;
+      if (state.preMaximizeLayout) {
+        state.exitMaximizedLayout();
+      } else {
+        state.maximizeGroup(groupId);
+      }
+    },
+    [api],
+  );
 }


### PR DESCRIPTION
Power users want to maximize a dockview group without aiming for the small header button — a double-click on any tab now toggles maximize/restore. Preview tabs keep their existing promote-to-pin gesture: first double-click pins, second double-click maximizes.

## Validation

- `pnpm --filter @kandev/web exec tsc --noEmit`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` (1095/1095, includes new `use-tab-maximize.test.ts` and `preview-tab.test.tsx`)

## Possible Improvements

Low risk. The preview-tab UX shifts slightly: a fast triple-click now pins-then-maximizes instead of just pinning. Keyboard shortcut for maximize is out of scope.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.