### PR TITLE
feat(web): pin tasks and drag-to-reorder in sidebar

### DIFF
--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -7,6 +7,8 @@ import { Button } from "@kandev/ui/button";
 import { TaskSwitcher } from "../task-switcher";
 import type { TaskSwitcherItem } from "../task-switcher";
 import { applyView } from "@/lib/sidebar/apply-view";
+import { useEffectiveSidebarView } from "@/hooks/domains/sidebar/use-effective-sidebar-view";
+import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-prefs";
 import { WorkspaceSwitcher } from "../workspace-switcher";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
 import { TaskArchiveConfirmDialog } from "../task-archive-confirm-dialog";
@@ -411,12 +413,13 @@ function MobileTaskList({
   deletingTaskId: string | null;
   isLoading?: boolean;
 }) {
-  const sidebarSlice = useAppStore((s) => s.sidebarViews);
-  const view = useMemo(() => {
-    const active = sidebarSlice.views.find((v) => v.id === sidebarSlice.activeViewId);
-    return active ?? sidebarSlice.views[0];
-  }, [sidebarSlice]);
-  const grouped = useMemo(() => applyView(tasks, view), [tasks, view]);
+  const view = useEffectiveSidebarView();
+  const { pinnedTaskIds, orderedTaskIds, togglePinnedTask, handleReorderGroup } =
+    useSidebarTaskPrefs();
+  const grouped = useMemo(
+    () => applyView(tasks, view, { pinnedTaskIds, orderedTaskIds }),
+    [tasks, view, pinnedTaskIds, orderedTaskIds],
+  );
   return (
     <TaskSwitcher
       grouped={grouped}
@@ -425,6 +428,9 @@ function MobileTaskList({
       onSelectTask={onSelectTask}
       onArchiveTask={onArchiveTask}
       onDeleteTask={onDeleteTask}
+      onTogglePin={togglePinnedTask}
+      onReorderGroup={handleReorderGroup}
+      pinnedTaskIds={pinnedTaskIds}
       deletingTaskId={deletingTaskId}
       isLoading={isLoading}
       totalTaskCount={tasks.length}

--- a/apps/web/components/task/sidebar-filter/sort-picker.tsx
+++ b/apps/web/components/task/sidebar-filter/sort-picker.tsx
@@ -10,6 +10,7 @@ const SORT_OPTIONS: Array<{ key: SortKey; label: string }> = [
   { key: "updatedAt", label: "Updated" },
   { key: "createdAt", label: "Created" },
   { key: "title", label: "Title" },
+  { key: "custom", label: "Custom" },
 ];
 
 type Props = {
@@ -18,6 +19,9 @@ type Props = {
 };
 
 export function SortPicker({ value, onChange }: Props) {
+  // Direction has no meaning for the custom sort — its order is the user's
+  // drag, not an asc/desc field. Hide the toggle to avoid surprising flips.
+  const isCustom = value.key === "custom";
   return (
     <div className="flex items-center gap-1.5">
       <Select value={value.key} onValueChange={(v) => onChange({ ...value, key: v as SortKey })}>
@@ -32,24 +36,26 @@ export function SortPicker({ value, onChange }: Props) {
           ))}
         </SelectContent>
       </Select>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-7 cursor-pointer"
-        onClick={() =>
-          onChange({ ...value, direction: value.direction === "asc" ? "desc" : "asc" })
-        }
-        data-testid="sort-direction-toggle"
-        data-direction={value.direction}
-        aria-label={`Sort direction ${value.direction}`}
-      >
-        {value.direction === "asc" ? (
-          <IconArrowUp className="h-3.5 w-3.5" />
-        ) : (
-          <IconArrowDown className="h-3.5 w-3.5" />
-        )}
-      </Button>
+      {!isCustom && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 cursor-pointer"
+          onClick={() =>
+            onChange({ ...value, direction: value.direction === "asc" ? "desc" : "asc" })
+          }
+          data-testid="sort-direction-toggle"
+          data-direction={value.direction}
+          aria-label={`Sort direction ${value.direction}`}
+        >
+          {value.direction === "asc" ? (
+            <IconArrowUp className="h-3.5 w-3.5" />
+          ) : (
+            <IconArrowDown className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -8,6 +8,7 @@ import {
   IconDots,
   IconGitPullRequest,
   IconMessageQuestion,
+  IconPinFilled,
 } from "@tabler/icons-react";
 import { PRTaskIcon } from "@/components/github/pr-task-icon";
 import { IssueTaskIcon } from "@/components/github/issue-task-icon";
@@ -55,6 +56,7 @@ type TaskItemProps = {
   repositories?: string[];
   prInfo?: { number: number; state: string };
   issueInfo?: { url: string; number: number };
+  isPinned?: boolean;
 };
 
 function formatRelativeTime(dateString: string): string {
@@ -221,6 +223,7 @@ function TaskItemContent({
   remoteExecutorName,
   primarySessionId,
   isArchived,
+  isPinned,
   repositories,
   updatedAt,
   prInfo,
@@ -234,6 +237,7 @@ function TaskItemContent({
   remoteExecutorName?: string;
   primarySessionId?: string | null;
   isArchived?: boolean;
+  isPinned?: boolean;
   repositories?: string[];
   updatedAt?: string;
   prInfo?: { number: number; state: string };
@@ -246,6 +250,12 @@ function TaskItemContent({
     >
       <span className="flex items-center gap-1 min-w-0 text-[13px] font-medium text-foreground leading-tight">
         <ScrollOnOverflow className="min-w-0">{title}</ScrollOnOverflow>
+        {isPinned && (
+          <IconPinFilled
+            data-testid="task-pinned-icon"
+            className="h-3 w-3 shrink-0 text-muted-foreground/60"
+          />
+        )}
         <TaskPRIcon taskId={taskId} prInfo={prInfo} />
         {issueInfo && <IssueTaskIcon issueInfo={issueInfo} />}
         {isRemoteExecutor && (
@@ -296,6 +306,7 @@ export const TaskItem = memo(function TaskItem({
   repositories,
   prInfo,
   issueInfo,
+  isPinned,
 }: TaskItemProps) {
   const effectiveMenuOpen = menuOpen || isDeleting === true;
   const isInProgress = computeIsInProgress(state, sessionState);
@@ -341,6 +352,7 @@ export const TaskItem = memo(function TaskItem({
         remoteExecutorName={remoteExecutorName}
         primarySessionId={primarySessionId}
         isArchived={isArchived}
+        isPinned={isPinned}
         repositories={repositories}
         updatedAt={updatedAt}
         prInfo={prInfo}

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -20,6 +20,8 @@ import { TaskArchiveConfirmDialog } from "./task-archive-confirm-dialog";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useAllWorkflowSnapshots } from "@/hooks/domains/kanban/use-all-workflow-snapshots";
+import { useEffectiveSidebarView } from "@/hooks/domains/sidebar/use-effective-sidebar-view";
+import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-prefs";
 import { useTaskActions, useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useTaskRemoval } from "@/hooks/use-task-removal";
 import { buildSwitchToSession, selectTaskWithLayout } from "./task-select-helpers";
@@ -508,17 +510,6 @@ function useBulkGitStatusSubscription(primarySessionIds: string[]) {
   }, [primarySessionIds, connectionStatus, activeSessionId]);
 }
 
-function useEffectiveSidebarView() {
-  const sidebarSlice = useAppStore((state) => state.sidebarViews);
-  return useMemo(() => {
-    const active = sidebarSlice.views.find((v) => v.id === sidebarSlice.activeViewId);
-    if (!active) return sidebarSlice.views[0];
-    const d = sidebarSlice.draft;
-    if (!d || d.baseViewId !== active.id) return active;
-    return { ...active, filters: d.filters, sort: d.sort, group: d.group };
-  }, [sidebarSlice.views, sidebarSlice.activeViewId, sidebarSlice.draft]);
-}
-
 export const TaskSessionSidebar = memo(function TaskSessionSidebar({
   workspaceId,
 }: TaskSessionSidebarProps) {
@@ -539,6 +530,7 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
 
   useBulkGitStatusSubscription(primarySessionIds);
 
+  const sidebarActions = useSidebarActions(store);
   const {
     deletingTaskId,
     preparingTaskId,
@@ -554,7 +546,7 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
     setArchivingTask,
     isArchiving,
     handleArchiveConfirm,
-  } = useSidebarActions(store);
+  } = sidebarActions;
 
   const displayTasks = useMemo(() => {
     if (MOCK_SIDEBAR) return MOCK_ITEMS;
@@ -568,10 +560,12 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
   const toggleSidebarGroupCollapsed = useAppStore((state) => state.toggleSidebarGroupCollapsed);
   const collapsedSubtaskParents = useAppStore((state) => state.collapsedSubtaskParents);
   const toggleSubtaskCollapsed = useAppStore((state) => state.toggleSubtaskCollapsed);
+  const { pinnedTaskIds, orderedTaskIds, togglePinnedTask, handleReorderGroup } =
+    useSidebarTaskPrefs();
   const effectiveView = useEffectiveSidebarView();
   const grouped = useMemo(
-    () => applyView(displayTasks, effectiveView),
-    [displayTasks, effectiveView],
+    () => applyView(displayTasks, effectiveView, { pinnedTaskIds, orderedTaskIds }),
+    [displayTasks, effectiveView, pinnedTaskIds, orderedTaskIds],
   );
 
   return (
@@ -593,6 +587,9 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
           onArchiveTask={handleArchiveTask}
           onDeleteTask={handleDeleteTask}
           onMoveToStep={handleMoveToStep}
+          onTogglePin={togglePinnedTask}
+          onReorderGroup={handleReorderGroup}
+          pinnedTaskIds={pinnedTaskIds}
           deletingTaskId={deletingTaskId}
           isLoading={isLoadingWorkflow}
           totalTaskCount={displayTasks.length}

--- a/apps/web/components/task/task-switcher-context-menu.tsx
+++ b/apps/web/components/task/task-switcher-context-menu.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { cloneElement, isValidElement, useState } from "react";
+import {
+  IconArchive,
+  IconCopy,
+  IconLoader,
+  IconPencil,
+  IconPin,
+  IconPinFilled,
+  IconTrash,
+} from "@tabler/icons-react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@kandev/ui/context-menu";
+import {
+  TaskMoveContextMenuItems,
+  type TaskMoveWorkflow,
+} from "@/components/task/task-move-context-menu";
+import { useTaskWorkflowMove } from "@/hooks/use-task-workflow-move";
+import type { TaskSwitcherItem } from "./task-switcher";
+
+export type StepDef = {
+  id: string;
+  title: string;
+  color?: string;
+  events?: { on_enter?: Array<{ type: string; config?: Record<string, unknown> }> };
+};
+
+type ContextMenuProps = {
+  task: TaskSwitcherItem;
+  workflows?: TaskMoveWorkflow[];
+  stepsByWorkflowId?: Record<string, StepDef[]>;
+  steps?: StepDef[];
+  children: React.ReactElement<{ menuOpen?: boolean }>;
+  onRenameTask?: (taskId: string, currentTitle: string) => void;
+  onArchiveTask?: (taskId: string) => void;
+  onDeleteTask?: (taskId: string) => void;
+  onMoveToStep?: (taskId: string, workflowId: string, targetStepId: string) => void;
+  onTogglePin?: (taskId: string) => void;
+  isPinned?: boolean;
+  isDeleting?: boolean;
+};
+
+export function TaskItemWithContextMenu({
+  task,
+  workflows,
+  stepsByWorkflowId,
+  steps,
+  children,
+  onRenameTask,
+  onArchiveTask,
+  onDeleteTask,
+  onMoveToStep,
+  onTogglePin,
+  isPinned,
+  isDeleting,
+}: ContextMenuProps) {
+  const [contextOpen, setContextOpen] = useState(false);
+  const [menuKey, setMenuKey] = useState(0);
+  const moveTasks = useTaskWorkflowMove();
+  const menuOpen = contextOpen || isDeleting === true;
+  const closeMenu = () => {
+    setContextOpen(false);
+    setMenuKey((k) => k + 1);
+  };
+
+  return (
+    <ContextMenu key={menuKey} onOpenChange={setContextOpen}>
+      <ContextMenuTrigger asChild>
+        <div>{cloneWithMenuOpen(children, menuOpen)}</div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        {onTogglePin && (
+          <ContextMenuItem disabled={isDeleting} onSelect={() => onTogglePin(task.id)}>
+            {isPinned ? (
+              <IconPinFilled className="mr-2 h-4 w-4" />
+            ) : (
+              <IconPin className="mr-2 h-4 w-4" />
+            )}
+            {isPinned ? "Unpin" : "Pin"}
+          </ContextMenuItem>
+        )}
+        {onRenameTask && (
+          <ContextMenuItem disabled={isDeleting} onSelect={() => onRenameTask(task.id, task.title)}>
+            <IconPencil className="mr-2 h-4 w-4" />
+            Rename
+          </ContextMenuItem>
+        )}
+        <ContextMenuItem disabled>
+          <IconCopy className="mr-2 h-4 w-4" />
+          Duplicate
+        </ContextMenuItem>
+        {onArchiveTask && (
+          <ContextMenuItem disabled={isDeleting} onSelect={() => onArchiveTask(task.id)}>
+            <IconArchive className="mr-2 h-4 w-4" />
+            Archive
+          </ContextMenuItem>
+        )}
+        {task.workflowId && (
+          <TaskMoveContextMenuItems
+            currentWorkflowId={task.workflowId}
+            currentStepId={task.workflowStepId}
+            workflows={workflows ?? []}
+            stepsByWorkflowId={stepsByWorkflowId ?? (steps ? { [task.workflowId]: steps } : {})}
+            disabled={isDeleting || task.isArchived}
+            onMoveToStep={
+              onMoveToStep
+                ? (stepId) => {
+                    closeMenu();
+                    onMoveToStep(task.id, task.workflowId!, stepId);
+                  }
+                : undefined
+            }
+            onSendToWorkflow={(workflowId, stepId) => {
+              closeMenu();
+              void moveTasks([task.id], workflowId, stepId).catch(() => {
+                // useTaskWorkflowMove already shows the failure toast.
+              });
+            }}
+          />
+        )}
+        {onDeleteTask && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+              variant="destructive"
+              disabled={isDeleting}
+              onSelect={() => onDeleteTask(task.id)}
+            >
+              {isDeleting ? (
+                <IconLoader className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <IconTrash className="mr-2 h-4 w-4" />
+              )}
+              Delete
+            </ContextMenuItem>
+          </>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+function cloneWithMenuOpen(
+  children: React.ReactElement<{ menuOpen?: boolean }>,
+  menuOpen: boolean,
+): React.ReactNode {
+  if (isValidElement(children)) return cloneElement(children, { menuOpen });
+  return children;
+}

--- a/apps/web/components/task/task-switcher.tsx
+++ b/apps/web/components/task/task-switcher.tsx
@@ -1,30 +1,30 @@
 "use client";
 
-import { cloneElement, isValidElement, memo, useState } from "react";
+import { memo, useCallback, useMemo } from "react";
+import { IconChevronDown } from "@tabler/icons-react";
 import {
-  IconChevronDown,
-  IconPencil,
-  IconCopy,
-  IconArchive,
-  IconTrash,
-  IconLoader,
-} from "@tabler/icons-react";
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuTrigger,
-} from "@kandev/ui/context-menu";
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { TaskState, TaskSessionState } from "@/lib/types/http";
 import { cn } from "@/lib/utils";
 import { TaskItem } from "./task-item";
+import { TaskItemWithContextMenu, type StepDef } from "./task-switcher-context-menu";
 import type { GroupedSidebarList, SidebarGroup } from "@/lib/sidebar/apply-view";
-import {
-  TaskMoveContextMenuItems,
-  type TaskMoveWorkflow,
-} from "@/components/task/task-move-context-menu";
-import { useTaskWorkflowMove } from "@/hooks/use-task-workflow-move";
+import { type TaskMoveWorkflow } from "@/components/task/task-move-context-menu";
+
+const DRAG_ACTIVATION_DISTANCE = 8;
 
 export type TaskSwitcherItem = {
   id: string;
@@ -55,13 +55,6 @@ export type TaskSwitcherItem = {
   issueInfo?: { url: string; number: number };
 };
 
-type StepDef = {
-  id: string;
-  title: string;
-  color?: string;
-  events?: { on_enter?: Array<{ type: string; config?: Record<string, unknown> }> };
-};
-
 type TaskSwitcherProps = {
   grouped: GroupedSidebarList;
   workflows?: TaskMoveWorkflow[];
@@ -77,6 +70,9 @@ type TaskSwitcherProps = {
   onArchiveTask?: (taskId: string) => void;
   onDeleteTask?: (taskId: string) => void;
   onMoveToStep?: (taskId: string, workflowId: string, targetStepId: string) => void;
+  onTogglePin?: (taskId: string) => void;
+  onReorderGroup?: (groupTaskIds: string[]) => void;
+  pinnedTaskIds?: string[];
   deletingTaskId?: string | null;
   isLoading?: boolean;
   totalTaskCount?: number;
@@ -148,6 +144,8 @@ type TaskRowProps = {
   onArchiveTask?: (taskId: string) => void;
   onDeleteTask?: (taskId: string) => void;
   onMoveToStep?: (taskId: string, workflowId: string, targetStepId: string) => void;
+  onTogglePin?: (taskId: string) => void;
+  isPinned?: boolean;
   deletingTaskId?: string | null;
 };
 
@@ -164,6 +162,8 @@ function TaskRow({
   onArchiveTask,
   onDeleteTask,
   onMoveToStep,
+  onTogglePin,
+  isPinned,
   deletingTaskId,
 }: TaskRowProps) {
   const isSelected = task.id === selectedTaskId || task.id === activeTaskId;
@@ -178,6 +178,8 @@ function TaskRow({
       onArchiveTask={onArchiveTask}
       onDeleteTask={onDeleteTask}
       onMoveToStep={onMoveToStep}
+      onTogglePin={onTogglePin}
+      isPinned={isPinned}
       isDeleting={deletingTaskId === task.id}
     >
       <TaskItem
@@ -203,8 +205,165 @@ function TaskRow({
         onToggleSubtasks={subtaskToggle?.onToggleSubtasks}
         onClick={() => onSelectTask(task.id)}
         isDeleting={deletingTaskId === task.id}
+        isPinned={isPinned}
       />
     </TaskItemWithContextMenu>
+  );
+}
+
+function SortableTaskBlock({
+  taskId,
+  parent,
+  subTasks,
+}: {
+  taskId: string;
+  parent: React.ReactNode;
+  subTasks?: React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: taskId,
+  });
+  const sortableAttributes = {
+    ...attributes,
+    role: undefined,
+    "aria-roledescription": undefined,
+  };
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+  // setNodeRef stays on the outer wrapper so the CSS transform applies to
+  // the parent row + its subtasks together. Drag listeners only attach to
+  // the parent row's wrapper, so a pointer-down on a subtask row does NOT
+  // trigger a drag of the parent block.
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-testid="sortable-task-block"
+      data-task-id={taskId}
+      className={cn(isDragging && "z-50")}
+    >
+      <div
+        {...sortableAttributes}
+        {...listeners}
+        // Strip dnd-kit's default tabIndex={0}: only PointerSensor is wired,
+        // so keyboard tab stops here lead nowhere. If KeyboardSensor is
+        // added later, drop this override.
+        tabIndex={undefined}
+        data-testid="sortable-task-handle"
+        className="cursor-grab active:cursor-grabbing"
+      >
+        {parent}
+      </div>
+      {subTasks}
+    </div>
+  );
+}
+
+type GroupSectionProps = {
+  group: SidebarGroup;
+  subTasksByParentId: Map<string, TaskSwitcherItem[]>;
+  workflows?: TaskMoveWorkflow[];
+  stepsByWorkflowId?: Record<string, StepDef[]>;
+  activeTaskId: string | null;
+  selectedTaskId: string | null;
+  isCollapsed: boolean;
+  onToggleCollapsed: () => void;
+  collapsedSubtaskParentIds?: string[];
+  onToggleSubtasks?: (parentTaskId: string) => void;
+  showHeader: boolean;
+  onSelectTask: (taskId: string) => void;
+  onRenameTask?: (taskId: string, currentTitle: string) => void;
+  onArchiveTask?: (taskId: string) => void;
+  onDeleteTask?: (taskId: string) => void;
+  onMoveToStep?: (taskId: string, workflowId: string, targetStepId: string) => void;
+  onTogglePin?: (taskId: string) => void;
+  onReorderGroup?: (groupTaskIds: string[]) => void;
+  pinnedSet: Set<string>;
+  deletingTaskId?: string | null;
+};
+
+function useGroupDnd(
+  groupTasks: TaskSwitcherItem[],
+  onReorderGroup?: (groupTaskIds: string[]) => void,
+) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
+  );
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (!onReorderGroup) return;
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const ids = groupTasks.map((t) => t.id);
+      const oldIndex = ids.indexOf(String(active.id));
+      const newIndex = ids.indexOf(String(over.id));
+      if (oldIndex < 0 || newIndex < 0) return;
+      onReorderGroup(arrayMove(ids, oldIndex, newIndex));
+    },
+    [groupTasks, onReorderGroup],
+  );
+  const sortableIds = useMemo(() => groupTasks.map((t) => t.id), [groupTasks]);
+  return { sensors, handleDragEnd, sortableIds };
+}
+
+function GroupTaskList({
+  group,
+  subTasksByParentId,
+  collapsedSubs,
+  onToggleSubtasks,
+  pinnedSet,
+  rowProps,
+}: {
+  group: SidebarGroup;
+  subTasksByParentId: Map<string, TaskSwitcherItem[]>;
+  collapsedSubs: Set<string>;
+  onToggleSubtasks?: (parentTaskId: string) => void;
+  pinnedSet: Set<string>;
+  rowProps: Omit<TaskRowProps, "task" | "subtaskToggle" | "isPinned" | "isSubTask">;
+}) {
+  return (
+    <>
+      {group.tasks.map((task) => {
+        const subs = subTasksByParentId.get(task.id);
+        const hasSubs = !!subs?.length;
+        const subsHidden = hasSubs && !!onToggleSubtasks && collapsedSubs.has(task.id);
+        const toggleInfo: SubtaskToggleInfo | undefined =
+          hasSubs && onToggleSubtasks
+            ? {
+                subtaskCount: subs!.length,
+                subtasksCollapsed: subsHidden,
+                onToggleSubtasks: () => onToggleSubtasks(task.id),
+              }
+            : undefined;
+        return (
+          <SortableTaskBlock
+            key={task.id}
+            taskId={task.id}
+            parent={
+              <TaskRow
+                task={task}
+                subtaskToggle={toggleInfo}
+                isPinned={pinnedSet.has(task.id)}
+                {...rowProps}
+              />
+            }
+            subTasks={
+              !subsHidden &&
+              subs?.map((sub) => (
+                // Subtasks aren't independently sortable or pinnable — pinning
+                // would show an icon but `floatPinnedToTop` only operates on
+                // root tasks, so the row wouldn't move. Drop both props to
+                // avoid the misleading no-op menu item.
+                <TaskRow key={sub.id} task={sub} isSubTask {...rowProps} onTogglePin={undefined} />
+              ))
+            }
+          />
+        );
+      })}
+    </>
   );
 }
 
@@ -225,26 +384,11 @@ function GroupSection({
   onArchiveTask,
   onDeleteTask,
   onMoveToStep,
+  onTogglePin,
+  onReorderGroup,
+  pinnedSet,
   deletingTaskId,
-}: {
-  group: SidebarGroup;
-  subTasksByParentId: Map<string, TaskSwitcherItem[]>;
-  workflows?: TaskMoveWorkflow[];
-  stepsByWorkflowId?: Record<string, StepDef[]>;
-  activeTaskId: string | null;
-  selectedTaskId: string | null;
-  isCollapsed: boolean;
-  onToggleCollapsed: () => void;
-  collapsedSubtaskParentIds?: string[];
-  onToggleSubtasks?: (parentTaskId: string) => void;
-  showHeader: boolean;
-  onSelectTask: (taskId: string) => void;
-  onRenameTask?: (taskId: string, currentTitle: string) => void;
-  onArchiveTask?: (taskId: string) => void;
-  onDeleteTask?: (taskId: string) => void;
-  onMoveToStep?: (taskId: string, workflowId: string, targetStepId: string) => void;
-  deletingTaskId?: string | null;
-}) {
+}: GroupSectionProps) {
   const totalCount = group.tasks.reduce(
     (sum, t) => sum + 1 + (subTasksByParentId.get(t.id)?.length ?? 0),
     0,
@@ -260,8 +404,10 @@ function GroupSection({
     onArchiveTask,
     onDeleteTask,
     onMoveToStep,
+    onTogglePin,
     deletingTaskId,
   };
+  const { sensors, handleDragEnd, sortableIds } = useGroupDnd(group.tasks, onReorderGroup);
 
   return (
     <div>
@@ -274,136 +420,22 @@ function GroupSection({
           onToggle={onToggleCollapsed}
         />
       )}
-      {!isCollapsed &&
-        group.tasks.map((task) => {
-          const subs = subTasksByParentId.get(task.id);
-          const hasSubs = !!subs?.length;
-          const subsHidden = hasSubs && !!onToggleSubtasks && collapsedSubs.has(task.id);
-          const toggleInfo: SubtaskToggleInfo | undefined =
-            hasSubs && onToggleSubtasks
-              ? {
-                  subtaskCount: subs!.length,
-                  subtasksCollapsed: subsHidden,
-                  onToggleSubtasks: () => onToggleSubtasks(task.id),
-                }
-              : undefined;
-          return (
-            <div key={task.id}>
-              <TaskRow task={task} subtaskToggle={toggleInfo} {...rowProps} />
-              {!subsHidden &&
-                subs?.map((sub) => <TaskRow key={sub.id} task={sub} isSubTask {...rowProps} />)}
-            </div>
-          );
-        })}
+      {!isCollapsed && (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+            <GroupTaskList
+              group={group}
+              subTasksByParentId={subTasksByParentId}
+              collapsedSubs={collapsedSubs}
+              onToggleSubtasks={onToggleSubtasks}
+              pinnedSet={pinnedSet}
+              rowProps={rowProps}
+            />
+          </SortableContext>
+        </DndContext>
+      )}
     </div>
   );
-}
-
-function TaskItemWithContextMenu({
-  task,
-  workflows,
-  stepsByWorkflowId,
-  steps,
-  children,
-  onRenameTask,
-  onArchiveTask,
-  onDeleteTask,
-  onMoveToStep,
-  isDeleting,
-}: {
-  task: TaskSwitcherItem;
-  workflows?: TaskMoveWorkflow[];
-  stepsByWorkflowId?: Record<string, StepDef[]>;
-  steps?: StepDef[];
-  children: React.ReactElement<{ menuOpen?: boolean }>;
-  onRenameTask?: (taskId: string, currentTitle: string) => void;
-  onArchiveTask?: (taskId: string) => void;
-  onDeleteTask?: (taskId: string) => void;
-  onMoveToStep?: (taskId: string, workflowId: string, targetStepId: string) => void;
-  isDeleting?: boolean;
-}) {
-  const [contextOpen, setContextOpen] = useState(false);
-  const [menuKey, setMenuKey] = useState(0);
-  const moveTasks = useTaskWorkflowMove();
-  const menuOpen = contextOpen || isDeleting === true;
-  const closeMenu = () => {
-    setContextOpen(false);
-    setMenuKey((k) => k + 1);
-  };
-
-  return (
-    <ContextMenu key={menuKey} onOpenChange={setContextOpen}>
-      <ContextMenuTrigger asChild>
-        <div>{cloneWithMenuOpen(children, menuOpen)}</div>
-      </ContextMenuTrigger>
-      <ContextMenuContent className="w-48">
-        {onRenameTask && (
-          <ContextMenuItem disabled={isDeleting} onClick={() => onRenameTask(task.id, task.title)}>
-            <IconPencil className="mr-2 h-4 w-4" />
-            Rename
-          </ContextMenuItem>
-        )}
-        <ContextMenuItem disabled>
-          <IconCopy className="mr-2 h-4 w-4" />
-          Duplicate
-        </ContextMenuItem>
-        {onArchiveTask && (
-          <ContextMenuItem disabled={isDeleting} onClick={() => onArchiveTask(task.id)}>
-            <IconArchive className="mr-2 h-4 w-4" />
-            Archive
-          </ContextMenuItem>
-        )}
-        {task.workflowId && (
-          <TaskMoveContextMenuItems
-            currentWorkflowId={task.workflowId}
-            currentStepId={task.workflowStepId}
-            workflows={workflows ?? []}
-            stepsByWorkflowId={stepsByWorkflowId ?? (steps ? { [task.workflowId]: steps } : {})}
-            disabled={isDeleting || task.isArchived}
-            onMoveToStep={
-              onMoveToStep
-                ? (stepId) => {
-                    closeMenu();
-                    onMoveToStep(task.id, task.workflowId!, stepId);
-                  }
-                : undefined
-            }
-            onSendToWorkflow={(workflowId, stepId) => {
-              closeMenu();
-              void moveTasks([task.id], workflowId, stepId).catch(() => {
-                // useTaskWorkflowMove already shows the failure toast.
-              });
-            }}
-          />
-        )}
-        {onDeleteTask && (
-          <>
-            <ContextMenuSeparator />
-            <ContextMenuItem
-              variant="destructive"
-              disabled={isDeleting}
-              onClick={() => onDeleteTask(task.id)}
-            >
-              {isDeleting ? (
-                <IconLoader className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <IconTrash className="mr-2 h-4 w-4" />
-              )}
-              Delete
-            </ContextMenuItem>
-          </>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
-  );
-}
-
-function cloneWithMenuOpen(
-  children: React.ReactElement<{ menuOpen?: boolean }>,
-  menuOpen: boolean,
-): React.ReactNode {
-  if (isValidElement(children)) return cloneElement(children, { menuOpen });
-  return children;
 }
 
 export const TaskSwitcher = memo(function TaskSwitcher({
@@ -421,10 +453,14 @@ export const TaskSwitcher = memo(function TaskSwitcher({
   onArchiveTask,
   onDeleteTask,
   onMoveToStep,
+  onTogglePin,
+  onReorderGroup,
+  pinnedTaskIds,
   deletingTaskId,
   isLoading = false,
   totalTaskCount,
 }: TaskSwitcherProps) {
+  const pinnedSet = useMemo(() => new Set(pinnedTaskIds ?? []), [pinnedTaskIds]);
   if (isLoading) return <TaskSwitcherSkeleton />;
   const totalTasks = totalTaskCount ?? grouped.groups.reduce((sum, g) => sum + g.tasks.length, 0);
   if (totalTasks === 0) {
@@ -457,6 +493,9 @@ export const TaskSwitcher = memo(function TaskSwitcher({
           onArchiveTask={onArchiveTask}
           onDeleteTask={onDeleteTask}
           onMoveToStep={onMoveToStep}
+          onTogglePin={onTogglePin}
+          onReorderGroup={onReorderGroup}
+          pinnedSet={pinnedSet}
           deletingTaskId={deletingTaskId}
         />
       ))}

--- a/apps/web/hooks/domains/sidebar/use-effective-sidebar-view.ts
+++ b/apps/web/hooks/domains/sidebar/use-effective-sidebar-view.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { useAppStore } from "@/components/state-provider";
+
+/**
+ * Active sidebar view merged with any in-flight draft. Used by both desktop
+ * and mobile sidebars so a draft (e.g. sort flipped to "custom" by a drag)
+ * actually drives `applyView` and not just the sort picker.
+ */
+export function useEffectiveSidebarView() {
+  const sidebarSlice = useAppStore((state) => state.sidebarViews);
+  return useMemo(() => {
+    const active = sidebarSlice.views.find((v) => v.id === sidebarSlice.activeViewId);
+    if (!active) return sidebarSlice.views[0];
+    const d = sidebarSlice.draft;
+    if (!d || d.baseViewId !== active.id) return active;
+    return { ...active, filters: d.filters, sort: d.sort, group: d.group };
+  }, [sidebarSlice.views, sidebarSlice.activeViewId, sidebarSlice.draft]);
+}

--- a/apps/web/hooks/domains/sidebar/use-sidebar-task-prefs.ts
+++ b/apps/web/hooks/domains/sidebar/use-sidebar-task-prefs.ts
@@ -1,0 +1,37 @@
+import { useCallback } from "react";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+import { mergeGroupOrder } from "@/lib/sidebar/apply-view";
+
+/**
+ * Read sidebar pin/order prefs and expose drag/pin handlers.
+ *
+ * `handleReorderGroup` records the new order *and* flips the active sort to
+ * "Custom" via the view draft — read draft-first so subsequent drags don't
+ * try to re-set custom on top of an already-custom draft. Both desktop and
+ * mobile sidebars use this hook to stay in sync.
+ */
+export function useSidebarTaskPrefs() {
+  const store = useAppStoreApi();
+  const pinnedTaskIds = useAppStore((s) => s.sidebarTaskPrefs.pinnedTaskIds);
+  const orderedTaskIds = useAppStore((s) => s.sidebarTaskPrefs.orderedTaskIds);
+  const togglePinnedTask = useAppStore((s) => s.togglePinnedTask);
+  const setSidebarTaskOrder = useAppStore((s) => s.setSidebarTaskOrder);
+  const updateSidebarDraft = useAppStore((s) => s.updateSidebarDraft);
+
+  const handleReorderGroup = useCallback(
+    (groupTaskIds: string[]) => {
+      const state = store.getState();
+      const current = state.sidebarTaskPrefs.orderedTaskIds;
+      setSidebarTaskOrder(mergeGroupOrder(current, groupTaskIds));
+      const sliceState = state.sidebarViews;
+      const baseSort =
+        sliceState.draft?.sort ??
+        sliceState.views.find((v) => v.id === sliceState.activeViewId)?.sort;
+      if (!baseSort || baseSort.key === "custom") return;
+      updateSidebarDraft({ sort: { key: "custom", direction: baseSort.direction } });
+    },
+    [store, setSidebarTaskOrder, updateSidebarDraft],
+  );
+
+  return { pinnedTaskIds, orderedTaskIds, togglePinnedTask, handleReorderGroup };
+}

--- a/apps/web/lib/local-storage.ts
+++ b/apps/web/lib/local-storage.ts
@@ -634,6 +634,17 @@ export function cleanupTaskStorage(
     setStoredCollapsedSubtaskParents(collapsed.filter((id) => id !== taskId));
   }
 
+  // Sidebar pin + manual-order arrays. Strip the deleted task so the lists
+  // don't grow unboundedly across reloads.
+  const pinned = getStoredPinnedTaskIds();
+  if (pinned.includes(taskId)) {
+    setStoredPinnedTaskIds(pinned.filter((id) => id !== taskId));
+  }
+  const ordered = getStoredOrderedTaskIds();
+  if (ordered.includes(taskId)) {
+    setStoredOrderedTaskIds(ordered.filter((id) => id !== taskId));
+  }
+
   // Env-keyed storage — dockview layout + maximize live under task envs.
   for (const envId of envIds) {
     removeEnvMaximizeState(envId);
@@ -693,6 +704,33 @@ export function setStoredSidebarDraft<T>(draft: T): void {
 
 export function removeStoredSidebarDraft(): void {
   removeLocalStorage(SIDEBAR_DRAFT_KEY);
+}
+
+// --- Sidebar task prefs: pin + manual order (localStorage, global) ---
+
+const SIDEBAR_PINNED_TASKS_KEY = "kandev.sidebar.pinnedTaskIds";
+const SIDEBAR_TASK_ORDER_KEY = "kandev.sidebar.orderedTaskIds";
+
+function readStringArray(key: string): string[] {
+  const raw = getLocalStorage<string[]>(key, []) as unknown;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((id): id is string => typeof id === "string");
+}
+
+export function getStoredPinnedTaskIds(): string[] {
+  return readStringArray(SIDEBAR_PINNED_TASKS_KEY);
+}
+
+export function setStoredPinnedTaskIds(ids: string[]): void {
+  setLocalStorage(SIDEBAR_PINNED_TASKS_KEY, ids);
+}
+
+export function getStoredOrderedTaskIds(): string[] {
+  return readStringArray(SIDEBAR_TASK_ORDER_KEY);
+}
+
+export function setStoredOrderedTaskIds(ids: string[]): void {
+  setLocalStorage(SIDEBAR_TASK_ORDER_KEY, ids);
 }
 
 // --- Sidebar collapsed subtask parents (sessionStorage, tab-scoped) ---

--- a/apps/web/lib/sidebar/apply-view.test.ts
+++ b/apps/web/lib/sidebar/apply-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { TaskSwitcherItem } from "@/components/task/task-switcher";
-import { applyFilters, applyGroup, applySort, applyView } from "./apply-view";
+import { applyFilters, applyGroup, applySort, applyView, mergeGroupOrder } from "./apply-view";
 import type { FilterClause, SidebarView } from "@/lib/state/slices/ui/sidebar-view-types";
 import { DEFAULT_VIEW } from "@/lib/state/slices/ui/sidebar-view-builtins";
 
@@ -318,6 +318,197 @@ describe("applyView (integration)", () => {
     const out = applyView(tasks, view);
     expect(out.groups).toHaveLength(1);
     expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["c", "b"]);
+  });
+});
+
+describe("applyView — pinned tasks", () => {
+  const titleAscView: SidebarView = {
+    id: "v",
+    name: "v",
+    filters: [],
+    sort: { key: "title", direction: "asc" },
+    group: "none",
+    collapsedGroups: [],
+  };
+
+  it("floats pinned tasks to top of group regardless of sort", () => {
+    const tasks = [
+      task({ id: "a", title: "Alpha" }),
+      task({ id: "b", title: "Beta" }),
+      task({ id: "c", title: "Gamma" }),
+    ];
+    const out = applyView(tasks, titleAscView, { pinnedTaskIds: ["c"], orderedTaskIds: [] });
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("preserves pin order among pinned tasks", () => {
+    const tasks = [
+      task({ id: "a", title: "Alpha" }),
+      task({ id: "b", title: "Beta" }),
+      task({ id: "c", title: "Gamma" }),
+    ];
+    const out = applyView(tasks, titleAscView, { pinnedTaskIds: ["c", "a"], orderedTaskIds: [] });
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("noop when no tasks are pinned", () => {
+    const tasks = [task({ id: "a", title: "Alpha" }), task({ id: "b", title: "Beta" })];
+    const out = applyView(tasks, titleAscView, { pinnedTaskIds: [], orderedTaskIds: [] });
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["a", "b"]);
+  });
+
+  it("applies pin per-group when grouping is active", () => {
+    const view: SidebarView = { ...titleAscView, group: "workflow" };
+    const tasks = [
+      task({ id: "a", title: "Alpha", workflowId: "w1", workflowName: "W1" }),
+      task({ id: "b", title: "Beta", workflowId: "w1", workflowName: "W1" }),
+      task({ id: "c", title: "Gamma", workflowId: "w2", workflowName: "W2" }),
+      task({ id: "d", title: "Delta", workflowId: "w2", workflowName: "W2" }),
+    ];
+    const out = applyView(tasks, view, { pinnedTaskIds: ["b", "d"], orderedTaskIds: [] });
+    const w1 = out.groups.find((g) => g.label === "W1");
+    const w2 = out.groups.find((g) => g.label === "W2");
+    expect(w1?.tasks.map((t) => t.id)).toEqual(["b", "a"]);
+    expect(w2?.tasks.map((t) => t.id)).toEqual(["d", "c"]);
+  });
+
+  it("subtasks remain anchored to parent regardless of pin", () => {
+    const tasks = [
+      task({ id: "p1", title: "P1" }),
+      task({ id: "c1", title: "C1", parentTaskId: "p1" }),
+      task({ id: "p2", title: "P2" }),
+    ];
+    const out = applyView(tasks, titleAscView, { pinnedTaskIds: ["p2"], orderedTaskIds: [] });
+    // root tasks: p2 pinned first, then p1
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["p2", "p1"]);
+    // subtasks unchanged
+    expect(out.subTasksByParentId.get("p1")?.map((t) => t.id)).toEqual(["c1"]);
+  });
+});
+
+describe("applyView — custom sort", () => {
+  const customView: SidebarView = {
+    id: "v",
+    name: "v",
+    filters: [],
+    sort: { key: "custom", direction: "asc" },
+    group: "none",
+    collapsedGroups: [],
+  };
+
+  it("orders tasks by index in orderedTaskIds", () => {
+    const tasks = [
+      task({ id: "a", title: "Alpha" }),
+      task({ id: "b", title: "Beta" }),
+      task({ id: "c", title: "Gamma" }),
+    ];
+    const out = applyView(tasks, customView, {
+      pinnedTaskIds: [],
+      orderedTaskIds: ["c", "a", "b"],
+    });
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("places tasks not in orderedTaskIds after listed ones, newest createdAt first", () => {
+    const tasks = [
+      task({ id: "a", title: "Alpha", createdAt: "2026-01-01" }),
+      task({ id: "b", title: "Beta", createdAt: "2026-04-01" }),
+      task({ id: "c", title: "Gamma", createdAt: "2026-02-01" }),
+    ];
+    const out = applyView(tasks, customView, { pinnedTaskIds: [], orderedTaskIds: ["c"] });
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("pinned tasks still float to top within the custom sort", () => {
+    const tasks = [
+      task({ id: "a", title: "Alpha" }),
+      task({ id: "b", title: "Beta" }),
+      task({ id: "c", title: "Gamma" }),
+    ];
+    const out = applyView(tasks, customView, {
+      pinnedTaskIds: ["b"],
+      orderedTaskIds: ["c", "a", "b"],
+    });
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("direction=desc on custom sort does NOT reverse the manual order", () => {
+    const descView: SidebarView = { ...customView, sort: { key: "custom", direction: "desc" } };
+    const tasks = [
+      task({ id: "a", title: "Alpha" }),
+      task({ id: "b", title: "Beta" }),
+      task({ id: "c", title: "Gamma" }),
+    ];
+    const out = applyView(tasks, descView, {
+      pinnedTaskIds: [],
+      orderedTaskIds: ["c", "a", "b"],
+    });
+    // Same as direction=asc — the manual order is intentional, direction does not flip it
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("reordering a parent moves it but its subtasks stay anchored beneath it", () => {
+    const tasks = [
+      task({ id: "p1", title: "P1", createdAt: "2026-01-01" }),
+      task({ id: "p2", title: "P2", createdAt: "2026-01-02" }),
+      task({ id: "p3", title: "P3", createdAt: "2026-01-03" }),
+      task({ id: "c1", title: "C1", parentTaskId: "p1", createdAt: "2026-02-01" }),
+      task({ id: "c2", title: "C2", parentTaskId: "p1", createdAt: "2026-02-02" }),
+    ];
+    // Simulates a drag of P3 to the front: handleReorderGroup writes only
+    // root IDs into orderedTaskIds.
+    const out = applyView(tasks, customView, {
+      pinnedTaskIds: [],
+      orderedTaskIds: ["p3", "p1", "p2"],
+    });
+    // Root order matches the drag.
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["p3", "p1", "p2"]);
+    // Subtasks stay attached to p1 — they're never in orderedTaskIds and they
+    // never appear in group.tasks, so dragging the parent doesn't separate
+    // them or reorder them relative to each other.
+    expect(out.subTasksByParentId.get("p1")?.map((t) => t.id)).toEqual(["c2", "c1"]);
+    expect(out.subTasksByParentId.get("p2")).toBeUndefined();
+    expect(out.subTasksByParentId.get("p3")).toBeUndefined();
+  });
+
+  it("non-custom sorts ignore orderedTaskIds", () => {
+    const titleView: SidebarView = { ...customView, sort: { key: "title", direction: "asc" } };
+    const tasks = [
+      task({ id: "a", title: "Alpha" }),
+      task({ id: "b", title: "Beta" }),
+      task({ id: "c", title: "Gamma" }),
+    ];
+    const out = applyView(tasks, titleView, {
+      pinnedTaskIds: [],
+      orderedTaskIds: ["c", "b", "a"],
+    });
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("mergeGroupOrder", () => {
+  it("appends when no group items are in current", () => {
+    expect(mergeGroupOrder([], ["a", "b"])).toEqual(["a", "b"]);
+    expect(mergeGroupOrder(["x", "y"], ["a", "b"])).toEqual(["x", "y", "a", "b"]);
+  });
+
+  it("anchors at the first occurrence of any group item", () => {
+    expect(mergeGroupOrder(["x", "a", "y", "b"], ["b", "a"])).toEqual(["x", "b", "a", "y"]);
+  });
+
+  it("does not move other-group tasks on a repeated drag in the same group", () => {
+    // First drag: group A reordered. Second drag: group A reordered again.
+    // The relative order of A vs B (and the position of A's section) must stay stable.
+    const afterFirst = mergeGroupOrder([], ["a1", "a2", "a3"]);
+    expect(afterFirst).toEqual(["a1", "a2", "a3"]);
+    const afterSecondGroupB = mergeGroupOrder(afterFirst, ["b1", "b2"]);
+    expect(afterSecondGroupB).toEqual(["a1", "a2", "a3", "b1", "b2"]);
+    // Now drag A again — A must NOT move to the end (the original bug).
+    const afterThirdGroupA = mergeGroupOrder(afterSecondGroupB, ["a3", "a1", "a2"]);
+    expect(afterThirdGroupA).toEqual(["a3", "a1", "a2", "b1", "b2"]);
+    // And dragging B again must keep A first.
+    const afterFourthGroupB = mergeGroupOrder(afterThirdGroupA, ["b2", "b1"]);
+    expect(afterFourthGroupB).toEqual(["a3", "a1", "a2", "b2", "b1"]);
   });
 });
 

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -23,6 +23,11 @@ export type GroupedSidebarList = {
   subTasksByParentId: Map<string, TaskSwitcherItem[]>;
 };
 
+export type SidebarTaskPrefs = {
+  pinnedTaskIds: string[];
+  orderedTaskIds: string[];
+};
+
 type DimensionExtractor = (task: TaskSwitcherItem) => FilterValue | undefined;
 
 const STATE_BUCKET_ORDER: Record<TaskBucket, number> = {
@@ -93,7 +98,9 @@ export function applyFilters(
   return tasks.filter((task) => clauses.every((clause) => evaluateClause(task, clause)));
 }
 
-const SORT_COMPARATORS: Record<SortKey, (a: TaskSwitcherItem, b: TaskSwitcherItem) => number> = {
+type SortComparator = (a: TaskSwitcherItem, b: TaskSwitcherItem) => number;
+
+const SORT_COMPARATORS: Record<Exclude<SortKey, "custom">, SortComparator> = {
   state: (a, b) => {
     const bucket = STATE_BUCKET_ORDER[getStateBucket(a)] - STATE_BUCKET_ORDER[getStateBucket(b)];
     if (bucket !== 0) return bucket;
@@ -105,9 +112,32 @@ const SORT_COMPARATORS: Record<SortKey, (a: TaskSwitcherItem, b: TaskSwitcherIte
   title: (a, b) => (a.title ?? "").localeCompare(b.title ?? ""),
 };
 
-export function applySort(tasks: TaskSwitcherItem[], spec: SortSpec): TaskSwitcherItem[] {
-  const cmp = SORT_COMPARATORS[spec.key];
-  const sign = spec.direction === "desc" ? -1 : 1;
+function customComparator(orderedTaskIds: string[]): SortComparator {
+  const order = new Map<string, number>();
+  for (let i = 0; i < orderedTaskIds.length; i++) order.set(orderedTaskIds[i], i);
+  return (a, b) => {
+    const ai = order.get(a.id);
+    const bi = order.get(b.id);
+    if (ai !== undefined && bi !== undefined) return ai - bi;
+    if (ai !== undefined) return -1;
+    if (bi !== undefined) return 1;
+    // Fallback for tasks the user hasn't placed yet: newest createdAt first.
+    return (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+  };
+}
+
+export function applySort(
+  tasks: TaskSwitcherItem[],
+  spec: SortSpec,
+  orderedTaskIds: string[] = [],
+): TaskSwitcherItem[] {
+  const cmp: SortComparator =
+    spec.key === "custom" ? customComparator(orderedTaskIds) : SORT_COMPARATORS[spec.key];
+  // "Custom" is a manual order — reversing it on direction=desc would flip
+  // the user's drag, which has no intuitive meaning. The picker hides the
+  // direction toggle for custom; this guard keeps the data layer consistent
+  // even if a stored view ends up with desc direction.
+  const sign = spec.key !== "custom" && spec.direction === "desc" ? -1 : 1;
   const withIndex = tasks.map((t, i) => ({ t, i }));
   withIndex.sort((a, b) => {
     const primary = cmp(a.t, b.t) * sign;
@@ -221,10 +251,80 @@ function sortRepoGroups(groups: SidebarGroup[]): void {
   });
 }
 
-export function applyView(tasks: TaskSwitcherItem[], view: SidebarView): GroupedSidebarList {
+/**
+ * Float pinned tasks to the top within a group, preserving the order the user
+ * pinned them in. The active sort still determines the order of unpinned
+ * tasks (and acts as a tiebreaker among pinned tasks not in pinIndex).
+ */
+function floatPinnedToTop(
+  tasks: TaskSwitcherItem[],
+  pinnedSet: Set<string>,
+  pinIndex: Map<string, number>,
+): TaskSwitcherItem[] {
+  if (pinnedSet.size === 0) return tasks;
+  const withSortIndex = tasks.map((t, i) => ({ t, sortIdx: i }));
+  withSortIndex.sort((a, b) => {
+    const ap = pinnedSet.has(a.t.id);
+    const bp = pinnedSet.has(b.t.id);
+    if (ap !== bp) return ap ? -1 : 1;
+    if (ap && bp) {
+      const ai = pinIndex.get(a.t.id) ?? 0;
+      const bi = pinIndex.get(b.t.id) ?? 0;
+      if (ai !== bi) return ai - bi;
+    }
+    return a.sortIdx - b.sortIdx;
+  });
+  return withSortIndex.map((x) => x.t);
+}
+
+/**
+ * Splice a group's reordered task IDs back into the global manual-order list,
+ * preserving the position of *other* groups. Without an anchor, repeatedly
+ * appending the dragged group to the end shuffles section headers (the next
+ * `applyGroup` pass keys section order off first encounter, so the dragged
+ * group always ends up last).
+ *
+ * Anchor: index of the first existing group task in `current`. If the group
+ * is being placed for the first time (`firstIdx === -1`), append at the end —
+ * subsequent drags will pin its position via the anchor.
+ */
+export function mergeGroupOrder(current: string[], groupTaskIds: string[]): string[] {
+  const groupSet = new Set(groupTaskIds);
+  let firstIdx = -1;
+  for (let i = 0; i < current.length; i++) {
+    if (groupSet.has(current[i])) {
+      firstIdx = i;
+      break;
+    }
+  }
+  const remaining = current.filter((id) => !groupSet.has(id));
+  if (firstIdx === -1) return [...remaining, ...groupTaskIds];
+  // Items before `firstIdx` in `current` are all non-group (firstIdx is the
+  // first group occurrence), so translation to `remaining` is identity.
+  return [...remaining.slice(0, firstIdx), ...groupTaskIds, ...remaining.slice(firstIdx)];
+}
+
+function buildIndex(ids: string[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (let i = 0; i < ids.length; i++) m.set(ids[i], i);
+  return m;
+}
+
+export function applyView(
+  tasks: TaskSwitcherItem[],
+  view: SidebarView,
+  prefs?: SidebarTaskPrefs,
+): GroupedSidebarList {
   const filtered = applyFilters(tasks, view.filters);
-  const sorted = applySort(filtered, view.sort);
-  return applyGroup(sorted, view.group);
+  const sorted = applySort(filtered, view.sort, prefs?.orderedTaskIds);
+  const grouped = applyGroup(sorted, view.group);
+  if (!prefs || prefs.pinnedTaskIds.length === 0) return grouped;
+  const pinnedSet = new Set(prefs.pinnedTaskIds);
+  const pinIndex = buildIndex(prefs.pinnedTaskIds);
+  for (const group of grouped.groups) {
+    group.tasks = floatPinnedToTop(group.tasks, pinnedSet, pinIndex);
+  }
+  return grouped;
 }
 
 export function opIsNegative(op: FilterOp): boolean {

--- a/apps/web/lib/state/default-state.ts
+++ b/apps/web/lib/state/default-state.ts
@@ -81,6 +81,7 @@ export const defaultState = {
   sidebarViews: defaultUIState.sidebarViews,
   collapsedSubtaskParents: defaultUIState.collapsedSubtaskParents,
   kanbanPreviewedTaskId: defaultUIState.kanbanPreviewedTaskId,
+  sidebarTaskPrefs: defaultUIState.sidebarTaskPrefs,
 };
 
 export type DefaultState = typeof defaultState;

--- a/apps/web/lib/state/slices/ui/sidebar-task-prefs-actions.ts
+++ b/apps/web/lib/state/slices/ui/sidebar-task-prefs-actions.ts
@@ -1,0 +1,36 @@
+import { setStoredOrderedTaskIds, setStoredPinnedTaskIds } from "@/lib/local-storage";
+import type { UISlice } from "./types";
+
+type ImmerSet = (recipe: (draft: UISlice) => void, shouldReplace?: false | undefined) => void;
+
+export function buildSidebarTaskPrefsActions(set: ImmerSet) {
+  return {
+    togglePinnedTask: (taskId: string) =>
+      set((draft) => {
+        const list = draft.sidebarTaskPrefs.pinnedTaskIds;
+        const idx = list.indexOf(taskId);
+        if (idx === -1) list.push(taskId);
+        else list.splice(idx, 1);
+        setStoredPinnedTaskIds(list);
+      }),
+    setSidebarTaskOrder: (orderedTaskIds: string[]) =>
+      set((draft) => {
+        draft.sidebarTaskPrefs.orderedTaskIds = orderedTaskIds;
+        setStoredOrderedTaskIds(orderedTaskIds);
+      }),
+    removeTaskFromSidebarPrefs: (taskId: string) =>
+      set((draft) => {
+        const prefs = draft.sidebarTaskPrefs;
+        const pinIdx = prefs.pinnedTaskIds.indexOf(taskId);
+        if (pinIdx !== -1) {
+          prefs.pinnedTaskIds.splice(pinIdx, 1);
+          setStoredPinnedTaskIds(prefs.pinnedTaskIds);
+        }
+        const orderIdx = prefs.orderedTaskIds.indexOf(taskId);
+        if (orderIdx !== -1) {
+          prefs.orderedTaskIds.splice(orderIdx, 1);
+          setStoredOrderedTaskIds(prefs.orderedTaskIds);
+        }
+      }),
+  };
+}

--- a/apps/web/lib/state/slices/ui/sidebar-view-types.ts
+++ b/apps/web/lib/state/slices/ui/sidebar-view-types.ts
@@ -22,7 +22,7 @@ export type FilterClause = {
   value: FilterValue;
 };
 
-export type SortKey = "state" | "updatedAt" | "createdAt" | "title";
+export type SortKey = "state" | "updatedAt" | "createdAt" | "title" | "custom";
 export type SortDirection = "asc" | "desc";
 export type SortSpec = { key: SortKey; direction: SortDirection };
 

--- a/apps/web/lib/state/slices/ui/types.ts
+++ b/apps/web/lib/state/slices/ui/types.ts
@@ -100,6 +100,13 @@ export type BottomTerminalState = {
   pendingCommand: string | null;
 };
 
+export type SidebarTaskPrefsState = {
+  /** Pinned task IDs in display order (first ID renders highest within its group). */
+  pinnedTaskIds: string[];
+  /** Manual order. Tasks not present fall back to the active sort. */
+  orderedTaskIds: string[];
+};
+
 export type UISliceState = {
   previewPanel: PreviewPanelState;
   rightPanel: RightPanelState;
@@ -119,6 +126,8 @@ export type UISliceState = {
   collapsedSubtaskParents: string[];
   /** Task ID currently shown in the kanban preview side-panel, or null if closed. */
   kanbanPreviewedTaskId: string | null;
+  /** Sidebar pin + manual-order. Per-browser, persisted to localStorage. */
+  sidebarTaskPrefs: SidebarTaskPrefsState;
 };
 
 export type UISliceActions = {
@@ -171,6 +180,14 @@ export type UISliceActions = {
   clearSidebarSyncError: () => void;
   migrateLocalViewsToBackend: () => void;
   setKanbanPreviewedTaskId: (taskId: string | null) => void;
+  togglePinnedTask: (taskId: string) => void;
+  setSidebarTaskOrder: (orderedTaskIds: string[]) => void;
+  /**
+   * Drop a task ID from both pinned and ordered arrays in-memory and persist.
+   * Called on task deletion so the in-memory state doesn't out-of-date the
+   * already-cleaned localStorage and silently re-write the deleted ID back.
+   */
+  removeTaskFromSidebarPrefs: (taskId: string) => void;
 };
 
 export type { SidebarView, SidebarViewDraft };

--- a/apps/web/lib/state/slices/ui/ui-slice.test.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.test.ts
@@ -73,6 +73,76 @@ describe("toggleSubtaskCollapsed", () => {
   });
 });
 
+describe("sidebar task prefs (pin + manual order)", () => {
+  const PINNED_KEY = "kandev.sidebar.pinnedTaskIds";
+  const ORDER_KEY = "kandev.sidebar.orderedTaskIds";
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("hydrates pinned + ordered from localStorage", () => {
+    window.localStorage.setItem(PINNED_KEY, JSON.stringify(["t1"]));
+    window.localStorage.setItem(ORDER_KEY, JSON.stringify(["t2", "t1"]));
+    const store = makeStore();
+    expect(store.getState().sidebarTaskPrefs.pinnedTaskIds).toEqual(["t1"]);
+    expect(store.getState().sidebarTaskPrefs.orderedTaskIds).toEqual(["t2", "t1"]);
+  });
+
+  it("togglePinnedTask adds, removes, and persists", () => {
+    const store = makeStore();
+    store.getState().togglePinnedTask("t1");
+    expect(store.getState().sidebarTaskPrefs.pinnedTaskIds).toEqual(["t1"]);
+    expect(JSON.parse(window.localStorage.getItem(PINNED_KEY) ?? "null")).toEqual(["t1"]);
+
+    store.getState().togglePinnedTask("t2");
+    expect(store.getState().sidebarTaskPrefs.pinnedTaskIds).toEqual(["t1", "t2"]);
+
+    store.getState().togglePinnedTask("t1");
+    expect(store.getState().sidebarTaskPrefs.pinnedTaskIds).toEqual(["t2"]);
+    expect(JSON.parse(window.localStorage.getItem(PINNED_KEY) ?? "null")).toEqual(["t2"]);
+  });
+
+  it("setSidebarTaskOrder replaces and persists", () => {
+    const store = makeStore();
+    store.getState().setSidebarTaskOrder(["a", "b", "c"]);
+    expect(store.getState().sidebarTaskPrefs.orderedTaskIds).toEqual(["a", "b", "c"]);
+    expect(JSON.parse(window.localStorage.getItem(ORDER_KEY) ?? "null")).toEqual(["a", "b", "c"]);
+
+    store.getState().setSidebarTaskOrder(["c", "a"]);
+    expect(store.getState().sidebarTaskPrefs.orderedTaskIds).toEqual(["c", "a"]);
+    expect(JSON.parse(window.localStorage.getItem(ORDER_KEY) ?? "null")).toEqual(["c", "a"]);
+  });
+
+  it("removeTaskFromSidebarPrefs strips the id from both arrays and persists", () => {
+    const store = makeStore();
+    store.getState().togglePinnedTask("t1");
+    store.getState().togglePinnedTask("t2");
+    store.getState().setSidebarTaskOrder(["t1", "t2", "t3"]);
+
+    store.getState().removeTaskFromSidebarPrefs("t1");
+
+    expect(store.getState().sidebarTaskPrefs.pinnedTaskIds).toEqual(["t2"]);
+    expect(store.getState().sidebarTaskPrefs.orderedTaskIds).toEqual(["t2", "t3"]);
+    expect(JSON.parse(window.localStorage.getItem(PINNED_KEY) ?? "null")).toEqual(["t2"]);
+    expect(JSON.parse(window.localStorage.getItem(ORDER_KEY) ?? "null")).toEqual(["t2", "t3"]);
+
+    // Subsequent togglePinnedTask must NOT bring "t1" back from a stale draft.
+    store.getState().togglePinnedTask("t3");
+    expect(store.getState().sidebarTaskPrefs.pinnedTaskIds).toEqual(["t2", "t3"]);
+    expect(JSON.parse(window.localStorage.getItem(PINNED_KEY) ?? "null")).toEqual(["t2", "t3"]);
+  });
+
+  it("removeTaskFromSidebarPrefs is a no-op for unknown ids", () => {
+    const store = makeStore();
+    store.getState().togglePinnedTask("t1");
+    const before = window.localStorage.getItem(PINNED_KEY);
+    store.getState().removeTaskFromSidebarPrefs("ghost");
+    expect(store.getState().sidebarTaskPrefs.pinnedTaskIds).toEqual(["t1"]);
+    expect(window.localStorage.getItem(PINNED_KEY)).toBe(before);
+  });
+});
+
 describe("reorderSidebarViews", () => {
   beforeEach(() => {
     window.localStorage.clear();

--- a/apps/web/lib/state/slices/ui/ui-slice.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.ts
@@ -2,6 +2,8 @@ import type { StateCreator } from "zustand";
 import { updateUserSettings } from "@/lib/api/domains/settings-api";
 import {
   getStoredCollapsedSubtaskParents,
+  getStoredOrderedTaskIds,
+  getStoredPinnedTaskIds,
   getStoredSidebarActiveViewId,
   getStoredSidebarDraft,
   getStoredSidebarUserViews,
@@ -12,6 +14,7 @@ import {
   setStoredSidebarDraft,
   setStoredSidebarUserViews,
 } from "@/lib/local-storage";
+import { buildSidebarTaskPrefsActions } from "./sidebar-task-prefs-actions";
 import { DEFAULT_ACTIVE_VIEW_ID, DEFAULT_VIEW } from "./sidebar-view-builtins";
 import type {
   FilterClause,
@@ -48,7 +51,13 @@ export const KNOWN_DIMENSIONS = new Set<string>([
   "titleMatch",
 ]);
 
-export const KNOWN_SORT_KEYS = new Set<string>(["state", "updatedAt", "createdAt", "title"]);
+export const KNOWN_SORT_KEYS = new Set<string>([
+  "state",
+  "updatedAt",
+  "createdAt",
+  "title",
+  "custom",
+]);
 
 // Drops clauses whose dimension is no longer known (e.g. renamed or removed in an upgrade),
 // and resets stale sort keys, so the popover does not crash when rendering stored views.
@@ -110,6 +119,7 @@ export const defaultUIState: UISliceState = {
   sidebarViews: loadSidebarState(),
   collapsedSubtaskParents: [],
   kanbanPreviewedTaskId: null,
+  sidebarTaskPrefs: { pinnedTaskIds: [], orderedTaskIds: [] },
 };
 
 type ImmerSet = Parameters<typeof createUISlice>[0];
@@ -510,11 +520,16 @@ export const createUISlice: StateCreator<UISlice, [["zustand/immer", never]], []
   // Hydrate from sessionStorage at slice creation (runs in the browser, after
   // the default static state) so tests and SSR both see a fresh read.
   collapsedSubtaskParents: getStoredCollapsedSubtaskParents(),
+  sidebarTaskPrefs: {
+    pinnedTaskIds: getStoredPinnedTaskIds(),
+    orderedTaskIds: getStoredOrderedTaskIds(),
+  },
   ...buildPreviewActions(set),
   ...buildMobileActions(set),
   ...buildBottomTerminalActions(set),
   ...buildConfigChatActions(set),
   ...buildSidebarViewActions(set, get),
+  ...buildSidebarTaskPrefsActions(set),
   ...buildCollapsedSubtaskActions(set, get),
   ...buildSystemHealthActions(set),
   setRightPanelActiveTab: (sessionId, tab) =>

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -240,6 +240,7 @@ export type AppState = {
   sidebarViews: (typeof defaultUIState)["sidebarViews"];
   collapsedSubtaskParents: (typeof defaultUIState)["collapsedSubtaskParents"];
   kanbanPreviewedTaskId: (typeof defaultUIState)["kanbanPreviewedTaskId"];
+  sidebarTaskPrefs: (typeof defaultUIState)["sidebarTaskPrefs"];
 
   // GitHub actions
   setGitHubStatus: (status: GitHubStatus | null) => void;
@@ -498,6 +499,9 @@ export type AppState = {
   clearSidebarSyncError: UIA["clearSidebarSyncError"];
   migrateLocalViewsToBackend: UIA["migrateLocalViewsToBackend"];
   setKanbanPreviewedTaskId: UIA["setKanbanPreviewedTaskId"];
+  togglePinnedTask: UIA["togglePinnedTask"];
+  setSidebarTaskOrder: UIA["setSidebarTaskOrder"];
+  removeTaskFromSidebarPrefs: UIA["removeTaskFromSidebarPrefs"];
 };
 
 export type AppStore = ReturnType<typeof createAppStore>;

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -42,6 +42,7 @@ function makeStore(initial: Partial<AppState> = {}) {
         },
       };
     }),
+    removeTaskFromSidebarPrefs: vi.fn(),
     ...initial,
   } as unknown as AppState;
 

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -179,6 +179,10 @@ export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
         ),
       );
       cleanupTaskStorage(deletedId, sessionIds, envIds);
+      // Keep the in-memory sidebar pin/order arrays in sync — without this,
+      // a later togglePinnedTask / setSidebarTaskOrder would persist the
+      // stale state (still containing the deleted ID) back to localStorage.
+      currentState.removeTaskFromSidebarPrefs(deletedId);
       for (const sid of sessionIds) {
         useContextFilesStore.getState().clearSession(sid);
       }


### PR DESCRIPTION
Tasks in the sidebar gain a pin (floats to top of group) and drag-to-reorder, so users can keep their most-used work above the noise without changing workflow steps. Manual order surfaces as a new "Custom" sort, persisted per-browser in localStorage.

## Important Changes

- New `"custom"` sort key. Manual order is no longer a silent override — it's the active sort, so users can switch back to Status/Updated/etc. without losing the saved order.
- Drag end writes a draft sort change so it shows up in the picker like any other view edit; the user can save or discard.
- Pin floats within the existing group (independent of sort), so grouping still bucketizes tasks the same way.

## Validation

- `pnpm lint` (apps/web) — 0 warnings
- `pnpm exec tsc --noEmit` (apps/web) — clean
- `pnpm test` (apps/web) — 1100 tests pass, including new cases for pin floating, custom sort fallback, and slice persistence
- Manual verification deferred to reviewer (no e2e added in this PR)

## Possible Improvements

Low risk. Two things to watch: localStorage `orderedTaskIds` can accumulate IDs from other workspaces (cleaned only on task delete, not on workspace remove), and dnd-kit on touch is untuned — mobile drag is functional but not polished.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.