### PR TITLE
feat(web): per-task color indicator in sidebar

### DIFF
--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -376,8 +376,9 @@ function SelectionBar({ isSelected, color }: { isSelected: boolean; color: TaskC
     return (
       <div
         className={cn(
-          "absolute left-0 top-0 bottom-0 w-[3px] opacity-100",
+          "absolute left-0 top-0 bottom-0 w-[3px] transition-opacity",
           TASK_COLOR_BAR_CLASS[color],
+          isSelected ? "opacity-100" : "opacity-60",
         )}
       />
     );

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -15,6 +15,8 @@ import { IssueTaskIcon } from "@/components/github/issue-task-icon";
 import { useAppStore } from "@/components/state-provider";
 import { cn } from "@/lib/utils";
 import { DEBUG_UI } from "@/lib/config";
+import { useTaskColor } from "@/hooks/use-task-color";
+import { TASK_COLOR_BAR_CLASS, type TaskColor } from "@/lib/task-colors";
 import type { TaskState, TaskSessionState } from "@/lib/types/http";
 import { shouldUseQuestionTaskIcon } from "@/lib/ui/state-icons";
 import type { SessionPollMode } from "@/lib/state/slices/session-runtime/types";
@@ -312,6 +314,7 @@ export const TaskItem = memo(function TaskItem({
   const isInProgress = computeIsInProgress(state, sessionState);
   const hasDiffStats = !!diffStats && (diffStats.additions > 0 || diffStats.deletions > 0);
   const showSubtaskToggle = !!subtaskCount && subtaskCount > 0 && !!onToggleSubtasks;
+  const taskColor = useTaskColor(taskId);
 
   return (
     <div
@@ -327,12 +330,7 @@ export const TaskItem = memo(function TaskItem({
         isSubTask ? "pl-8" : "pl-3",
       )}
     >
-      <div
-        className={cn(
-          "absolute left-0 top-0 bottom-0 w-[2px] transition-opacity",
-          isSelected ? "bg-primary opacity-100" : "opacity-0",
-        )}
-      />
+      <SelectionBar isSelected={isSelected} color={taskColor} />
       {isSubTask && (
         <span className="absolute left-3.5 top-[10px] select-none text-[11px] text-muted-foreground/30">
           ↳
@@ -372,6 +370,27 @@ export const TaskItem = memo(function TaskItem({
     </div>
   );
 });
+
+function SelectionBar({ isSelected, color }: { isSelected: boolean; color: TaskColor | null }) {
+  if (color) {
+    return (
+      <div
+        className={cn(
+          "absolute left-0 top-0 bottom-0 w-[3px] opacity-100",
+          TASK_COLOR_BAR_CLASS[color],
+        )}
+      />
+    );
+  }
+  return (
+    <div
+      className={cn(
+        "absolute left-0 top-0 bottom-0 w-[2px] bg-primary transition-opacity",
+        isSelected ? "opacity-100" : "opacity-0",
+      )}
+    />
+  );
+}
 
 function SubtaskToggle({
   taskId,

--- a/apps/web/components/task/task-switcher-context-menu.tsx
+++ b/apps/web/components/task/task-switcher-context-menu.tsx
@@ -3,8 +3,10 @@
 import { cloneElement, isValidElement, useState } from "react";
 import {
   IconArchive,
+  IconCheck,
   IconCopy,
   IconLoader,
+  IconPalette,
   IconPencil,
   IconPin,
   IconPinFilled,
@@ -15,6 +17,9 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@kandev/ui/context-menu";
 import {
@@ -22,6 +27,14 @@ import {
   type TaskMoveWorkflow,
 } from "@/components/task/task-move-context-menu";
 import { useTaskWorkflowMove } from "@/hooks/use-task-workflow-move";
+import { useSetTaskColor, useTaskColor } from "@/hooks/use-task-color";
+import {
+  TASK_COLORS,
+  TASK_COLOR_BAR_CLASS,
+  TASK_COLOR_LABEL,
+  type TaskColor,
+} from "@/lib/task-colors";
+import { cn } from "@/lib/utils";
 import type { TaskSwitcherItem } from "./task-switcher";
 
 export type StepDef = {
@@ -101,6 +114,7 @@ export function TaskItemWithContextMenu({
             Archive
           </ContextMenuItem>
         )}
+        <TaskColorMenu taskId={task.id} disabled={isDeleting} />
         {task.workflowId && (
           <TaskMoveContextMenuItems
             currentWorkflowId={task.workflowId}
@@ -152,4 +166,58 @@ function cloneWithMenuOpen(
 ): React.ReactNode {
   if (isValidElement(children)) return cloneElement(children, { menuOpen });
   return children;
+}
+
+function TaskColorMenu({ taskId, disabled }: { taskId: string; disabled?: boolean }) {
+  const currentColor = useTaskColor(taskId);
+  const setColor = useSetTaskColor();
+  return (
+    <ContextMenuSub>
+      <ContextMenuSubTrigger disabled={disabled}>
+        <IconPalette className="mr-2 h-4 w-4" />
+        Color
+        {currentColor && (
+          <span
+            className={cn(
+              "ml-2 inline-block h-2 w-2 rounded-full",
+              TASK_COLOR_BAR_CLASS[currentColor],
+            )}
+          />
+        )}
+      </ContextMenuSubTrigger>
+      <ContextMenuSubContent className="w-40">
+        {TASK_COLORS.map((color) => (
+          <TaskColorMenuItem
+            key={color}
+            color={color}
+            selected={currentColor === color}
+            onSelect={() => setColor(taskId, color)}
+          />
+        ))}
+        <ContextMenuSeparator />
+        <ContextMenuItem disabled={!currentColor} onSelect={() => setColor(taskId, null)}>
+          <span className="mr-2 inline-block h-2 w-2 rounded-full border border-muted-foreground/40" />
+          None
+        </ContextMenuItem>
+      </ContextMenuSubContent>
+    </ContextMenuSub>
+  );
+}
+
+function TaskColorMenuItem({
+  color,
+  selected,
+  onSelect,
+}: {
+  color: TaskColor;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <ContextMenuItem onSelect={onSelect}>
+      <span className={cn("mr-2 inline-block h-2 w-2 rounded-full", TASK_COLOR_BAR_CLASS[color])} />
+      {TASK_COLOR_LABEL[color]}
+      {selected && <IconCheck className="ml-auto h-3.5 w-3.5" />}
+    </ContextMenuItem>
+  );
 }

--- a/apps/web/hooks/use-task-color.ts
+++ b/apps/web/hooks/use-task-color.ts
@@ -5,16 +5,20 @@ import {
   getTaskColor,
   setTaskColor,
   TASK_COLORS_CHANGED_EVENT,
+  TASK_COLORS_STORAGE_KEY,
   type TaskColor,
 } from "@/lib/task-colors";
 
 function subscribe(cb: () => void): () => void {
   if (typeof window === "undefined") return () => {};
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === null || e.key === TASK_COLORS_STORAGE_KEY) cb();
+  };
   window.addEventListener(TASK_COLORS_CHANGED_EVENT, cb);
-  window.addEventListener("storage", cb);
+  window.addEventListener("storage", onStorage);
   return () => {
     window.removeEventListener(TASK_COLORS_CHANGED_EVENT, cb);
-    window.removeEventListener("storage", cb);
+    window.removeEventListener("storage", onStorage);
   };
 }
 

--- a/apps/web/hooks/use-task-color.ts
+++ b/apps/web/hooks/use-task-color.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  getTaskColor,
+  setTaskColor,
+  TASK_COLORS_CHANGED_EVENT,
+  type TaskColor,
+} from "@/lib/task-colors";
+
+function subscribe(cb: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(TASK_COLORS_CHANGED_EVENT, cb);
+  window.addEventListener("storage", cb);
+  return () => {
+    window.removeEventListener(TASK_COLORS_CHANGED_EVENT, cb);
+    window.removeEventListener("storage", cb);
+  };
+}
+
+const getServerSnapshot = (): TaskColor | null => null;
+
+export function useTaskColor(taskId: string | undefined): TaskColor | null {
+  const getSnapshot = useCallback(() => (taskId ? getTaskColor(taskId) : null), [taskId]);
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+export function useSetTaskColor(): (taskId: string, color: TaskColor | null) => void {
+  return useCallback((taskId, color) => setTaskColor(taskId, color), []);
+}

--- a/apps/web/lib/task-colors.test.ts
+++ b/apps/web/lib/task-colors.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __resetTaskColorsCacheForTests,
   getTaskColor,
   setTaskColor,
   TASK_COLORS_CHANGED_EVENT,
@@ -9,6 +10,7 @@ import {
 describe("task colors storage", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    __resetTaskColorsCacheForTests();
   });
 
   it("returns null when no color is stored", () => {

--- a/apps/web/lib/task-colors.test.ts
+++ b/apps/web/lib/task-colors.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getTaskColor,
+  setTaskColor,
+  TASK_COLORS_CHANGED_EVENT,
+  TASK_COLORS_STORAGE_KEY,
+} from "./task-colors";
+
+describe("task colors storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when no color is stored", () => {
+    expect(getTaskColor("task-1")).toBeNull();
+  });
+
+  it("stores and reads a color", () => {
+    setTaskColor("task-1", "blue");
+    expect(getTaskColor("task-1")).toBe("blue");
+  });
+
+  it("removes a color when set to null", () => {
+    setTaskColor("task-1", "blue");
+    setTaskColor("task-1", null);
+    expect(getTaskColor("task-1")).toBeNull();
+  });
+
+  it("ignores invalid colors loaded from storage", () => {
+    window.localStorage.setItem(
+      TASK_COLORS_STORAGE_KEY,
+      JSON.stringify({ "task-1": "fuchsia", "task-2": "red" }),
+    );
+    expect(getTaskColor("task-1")).toBeNull();
+    expect(getTaskColor("task-2")).toBe("red");
+  });
+
+  it("returns null on malformed storage", () => {
+    window.localStorage.setItem(TASK_COLORS_STORAGE_KEY, "{not json");
+    expect(getTaskColor("task-1")).toBeNull();
+  });
+
+  it("dispatches a change event when a color is set", () => {
+    const listener = vi.fn();
+    window.addEventListener(TASK_COLORS_CHANGED_EVENT, listener);
+    setTaskColor("task-1", "green");
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener(TASK_COLORS_CHANGED_EVENT, listener);
+  });
+
+  it("does not dispatch when setting the same color twice", () => {
+    setTaskColor("task-1", "green");
+    const listener = vi.fn();
+    window.addEventListener(TASK_COLORS_CHANGED_EVENT, listener);
+    setTaskColor("task-1", "green");
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(TASK_COLORS_CHANGED_EVENT, listener);
+  });
+
+  it("does not dispatch when clearing a non-existent color", () => {
+    const listener = vi.fn();
+    window.addEventListener(TASK_COLORS_CHANGED_EVENT, listener);
+    setTaskColor("task-1", null);
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(TASK_COLORS_CHANGED_EVENT, listener);
+  });
+});

--- a/apps/web/lib/task-colors.test.ts
+++ b/apps/web/lib/task-colors.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  __resetTaskColorsCacheForTests,
   getTaskColor,
   setTaskColor,
   TASK_COLORS_CHANGED_EVENT,
@@ -10,7 +9,9 @@ import {
 describe("task colors storage", () => {
   beforeEach(() => {
     window.localStorage.clear();
-    __resetTaskColorsCacheForTests();
+    // Synthesize a cross-tab storage event so the module-level cache invalidates,
+    // matching how a real browser would notify other tabs after localStorage.clear().
+    window.dispatchEvent(new StorageEvent("storage", { key: null }));
   });
 
   it("returns null when no color is stored", () => {

--- a/apps/web/lib/task-colors.ts
+++ b/apps/web/lib/task-colors.ts
@@ -1,0 +1,67 @@
+import { getLocalStorage, setLocalStorage } from "./local-storage";
+
+export const TASK_COLORS = ["red", "orange", "yellow", "green", "blue", "purple", "pink"] as const;
+
+export type TaskColor = (typeof TASK_COLORS)[number];
+
+export const TASK_COLOR_BAR_CLASS: Record<TaskColor, string> = {
+  red: "bg-red-500",
+  orange: "bg-orange-500",
+  yellow: "bg-yellow-500",
+  green: "bg-green-500",
+  blue: "bg-blue-500",
+  purple: "bg-purple-500",
+  pink: "bg-pink-500",
+};
+
+export const TASK_COLOR_LABEL: Record<TaskColor, string> = {
+  red: "Red",
+  orange: "Orange",
+  yellow: "Yellow",
+  green: "Green",
+  blue: "Blue",
+  purple: "Purple",
+  pink: "Pink",
+};
+
+export const TASK_COLORS_STORAGE_KEY = "kandev.taskColors";
+export const TASK_COLORS_CHANGED_EVENT = "kandev:task-colors-changed";
+
+function isTaskColor(value: unknown): value is TaskColor {
+  return typeof value === "string" && (TASK_COLORS as readonly string[]).includes(value);
+}
+
+function readAll(): Record<string, TaskColor> {
+  const raw = getLocalStorage<Record<string, string>>(TASK_COLORS_STORAGE_KEY, {});
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, TaskColor> = {};
+  for (const [taskId, color] of Object.entries(raw)) {
+    if (typeof taskId === "string" && isTaskColor(color)) out[taskId] = color;
+  }
+  return out;
+}
+
+function writeAll(map: Record<string, TaskColor>): void {
+  setLocalStorage(TASK_COLORS_STORAGE_KEY, map);
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(TASK_COLORS_CHANGED_EVENT));
+  }
+}
+
+export function getTaskColor(taskId: string): TaskColor | null {
+  if (!taskId) return null;
+  return readAll()[taskId] ?? null;
+}
+
+export function setTaskColor(taskId: string, color: TaskColor | null): void {
+  if (!taskId) return;
+  const all = readAll();
+  if (color === null) {
+    if (!(taskId in all)) return;
+    delete all[taskId];
+  } else {
+    if (all[taskId] === color) return;
+    all[taskId] = color;
+  }
+  writeAll(all);
+}

--- a/apps/web/lib/task-colors.ts
+++ b/apps/web/lib/task-colors.ts
@@ -78,8 +78,3 @@ export function setTaskColor(taskId: string, color: TaskColor | null): void {
     writeAll({ ...all, [taskId]: color });
   }
 }
-
-/** Test-only: clears the in-memory cache so localStorage mutations from tests are observed. */
-export function __resetTaskColorsCacheForTests(): void {
-  cachedMap = null;
-}

--- a/apps/web/lib/task-colors.ts
+++ b/apps/web/lib/task-colors.ts
@@ -31,17 +31,29 @@ function isTaskColor(value: unknown): value is TaskColor {
   return typeof value === "string" && (TASK_COLORS as readonly string[]).includes(value);
 }
 
+let cachedMap: Record<string, TaskColor> | null = null;
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === null || e.key === TASK_COLORS_STORAGE_KEY) cachedMap = null;
+  });
+}
+
 function readAll(): Record<string, TaskColor> {
+  if (cachedMap) return cachedMap;
   const raw = getLocalStorage<Record<string, string>>(TASK_COLORS_STORAGE_KEY, {});
-  if (!raw || typeof raw !== "object") return {};
   const out: Record<string, TaskColor> = {};
-  for (const [taskId, color] of Object.entries(raw)) {
-    if (typeof taskId === "string" && isTaskColor(color)) out[taskId] = color;
+  if (raw && typeof raw === "object") {
+    for (const [taskId, color] of Object.entries(raw)) {
+      if (isTaskColor(color)) out[taskId] = color;
+    }
   }
+  cachedMap = out;
   return out;
 }
 
 function writeAll(map: Record<string, TaskColor>): void {
+  cachedMap = map;
   setLocalStorage(TASK_COLORS_STORAGE_KEY, map);
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent(TASK_COLORS_CHANGED_EVENT));
@@ -58,10 +70,16 @@ export function setTaskColor(taskId: string, color: TaskColor | null): void {
   const all = readAll();
   if (color === null) {
     if (!(taskId in all)) return;
-    delete all[taskId];
+    const next = { ...all };
+    delete next[taskId];
+    writeAll(next);
   } else {
     if (all[taskId] === color) return;
-    all[taskId] = color;
+    writeAll({ ...all, [taskId]: color });
   }
-  writeAll(all);
+}
+
+/** Test-only: clears the in-memory cache so localStorage mutations from tests are observed. */
+export function __resetTaskColorsCacheForTests(): void {
+  cachedMap = null;
 }


### PR DESCRIPTION
Tasks in the left list need a quick visual marker so users can spot related items at a glance without reading titles. Adds a per-task color, persisted to localStorage, picked from the right-click context menu and rendered as a 3px left bar on the row.

## Validation

- `pnpm exec tsc --noEmit` (web) — clean (only pre-existing `@/generated/*` errors).
- `pnpm lint` — clean (`--max-warnings 0`).
- `pnpm test` — 1127/1127 vitest tests pass, including 7 new tests in `lib/task-colors.test.ts` covering get/set/clear, validation, malformed storage, and event dispatch.
- `pnpm format:check` — clean.
- `make -C apps/backend test lint` — pass.
- Manual: right-click a task → Color submenu → pick color, verify bar renders; pick None, verify it clears; reload, verify persistence.

## Possible Improvements

Low risk. The colored bar replaces the 2px selection bar when a color is set; selection is still indicated by the row's `bg-primary/10` background. Storage is per-browser (no sync across devices) by design.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.