### PR TITLE
feat(web): show grid spinner on agent tab while session is working

### DIFF
--- a/apps/web/components/task/preview-session-tabs.tsx
+++ b/apps/web/components/task/preview-session-tabs.tsx
@@ -177,7 +177,7 @@ function PreviewSessionBody({ session, taskId }: { session: TaskSession; taskId:
 }
 
 function RunningSpinner() {
-  return <GridSpinner className="text-blue-500 shrink-0 text-[12px]" />;
+  return <GridSpinner className="text-muted-foreground shrink-0 text-[12px]" />;
 }
 
 function PreviewLoadingState({ label }: { label: string }) {

--- a/apps/web/components/task/preview-session-tabs.tsx
+++ b/apps/web/components/task/preview-session-tabs.tsx
@@ -12,12 +12,13 @@ import { useSessionResumption } from "@/hooks/domains/session/use-session-resump
 import { useTaskSessions } from "@/hooks/use-task-sessions";
 import type { UseEnsureTaskSessionResult } from "@/hooks/domains/session/use-ensure-task-session";
 import type { AgentProfileOption } from "@/lib/state/slices";
-import type { TaskSession, TaskSessionState } from "@/lib/types/http";
+import type { TaskSession } from "@/lib/types/http";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { PassthroughTerminal } from "./passthrough-terminal";
 import { TaskChatPanel } from "./task-chat-panel";
 import {
   buildAgentLabelsById,
+  isSessionActive,
   pickActiveSessionId,
   resolveAgentLabelFor,
   sortSessions,
@@ -173,10 +174,6 @@ function PreviewSessionBody({ session, taskId }: { session: TaskSession; taskId:
       <TaskChatPanel onSend={handleSendMessage} sessionId={session.id} hideSessionsDropdown />
     </div>
   );
-}
-
-function isSessionActive(state: TaskSessionState): boolean {
-  return state === "RUNNING" || state === "STARTING";
 }
 
 function RunningSpinner() {

--- a/apps/web/components/task/preview-session-tabs.tsx
+++ b/apps/web/components/task/preview-session-tabs.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { IconLoader2 } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { AgentLogo } from "@/components/agent-logo";
+import { GridSpinner } from "@/components/grid-spinner";
 import { SessionTabs, type SessionTab } from "@/components/session-tabs";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
@@ -179,7 +180,7 @@ function isSessionActive(state: TaskSessionState): boolean {
 }
 
 function RunningSpinner() {
-  return <IconLoader2 className="h-3 w-3 shrink-0 text-blue-500 animate-spin" />;
+  return <GridSpinner className="text-blue-500 shrink-0 text-[12px]" />;
 }
 
 function PreviewLoadingState({ label }: { label: string }) {

--- a/apps/web/components/task/session-sort.test.ts
+++ b/apps/web/components/task/session-sort.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAgentLabelsById,
+  isSessionActive,
   pickActiveSessionId,
   resolveAgentLabelFor,
   sortSessions,
@@ -81,5 +82,25 @@ describe("pickActiveSessionId", () => {
   it("falls back to the first session when no primary exists", () => {
     const sessions = [makeSession({ id: "a" }), makeSession({ id: "b" })];
     expect(pickActiveSessionId(sessions, null)).toBe("a");
+  });
+});
+
+describe("isSessionActive", () => {
+  it("is true while the agent is starting or running", () => {
+    expect(isSessionActive("RUNNING")).toBe(true);
+    expect(isSessionActive("STARTING")).toBe(true);
+  });
+
+  it("is false for terminal and idle states", () => {
+    expect(isSessionActive("WAITING_FOR_INPUT")).toBe(false);
+    expect(isSessionActive("COMPLETED")).toBe(false);
+    expect(isSessionActive("FAILED")).toBe(false);
+    expect(isSessionActive("CANCELLED")).toBe(false);
+    expect(isSessionActive("CREATED")).toBe(false);
+  });
+
+  it("is false for null/undefined", () => {
+    expect(isSessionActive(null)).toBe(false);
+    expect(isSessionActive(undefined)).toBe(false);
   });
 });

--- a/apps/web/components/task/session-sort.ts
+++ b/apps/web/components/task/session-sort.ts
@@ -57,3 +57,7 @@ export function pickActiveSessionId(
   const primary = sessions.find((s) => s.is_primary);
   return (primary ?? sessions[0]).id;
 }
+
+export function isSessionActive(state: TaskSessionState | null | undefined): boolean {
+  return state === "RUNNING" || state === "STARTING";
+}

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -26,6 +26,7 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import type { TaskSessionState } from "@/lib/types/http";
+import { isSessionActive } from "./session-sort";
 import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 
 function isStoppable(s: TaskSessionState) {
@@ -318,7 +319,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
               </span>
             )}
             {agentName &&
-              (sessionState === "RUNNING" || sessionState === "STARTING" ? (
+              (isSessionActive(sessionState) ? (
                 <GridSpinner
                   className={`ml-1.5 shrink-0 text-[14px] text-blue-500${isActive ? "" : " opacity-50"}`}
                 />

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -321,7 +321,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
             {agentName &&
               (isSessionActive(sessionState) ? (
                 <GridSpinner
-                  className={`ml-1.5 shrink-0 text-[14px] text-blue-500${isActive ? "" : " opacity-50"}`}
+                  className={`ml-1.5 shrink-0 text-[14px] text-muted-foreground${isActive ? "" : " opacity-50"}`}
                 />
               ) : (
                 <AgentLogo

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import { IconStar } from "@tabler/icons-react";
 import { AgentLogo } from "@/components/agent-logo";
+import { GridSpinner } from "@/components/grid-spinner";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -316,13 +317,18 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
                 {sessionNumber}
               </span>
             )}
-            {agentName && (
-              <AgentLogo
-                agentName={agentName}
-                size={14}
-                className={`ml-1.5 shrink-0${isActive ? "" : " opacity-50"}`}
-              />
-            )}
+            {agentName &&
+              (sessionState === "RUNNING" || sessionState === "STARTING" ? (
+                <GridSpinner
+                  className={`ml-1.5 shrink-0 text-[14px] text-blue-500${isActive ? "" : " opacity-50"}`}
+                />
+              ) : (
+                <AgentLogo
+                  agentName={agentName}
+                  size={14}
+                  className={`ml-1.5 shrink-0${isActive ? "" : " opacity-50"}`}
+                />
+              ))}
             <DockviewDefaultTab {...props} hideClose={sessionCount <= 1} />
           </div>
         </ContextMenuTrigger>


### PR DESCRIPTION
The session tab strip didn't surface whether an agent was actively working — only the static agent logo was shown. While a session is `STARTING` or `RUNNING`, the agent logo is now replaced by the existing `GridSpinner` (also swapping out the legacy `IconLoader2` in the kanban preview tab), mirroring the spinner already used elsewhere in the chat UI so working state is visible at a glance from the tab strip.

## Validation

- Manual review of conditional rendering against `TaskSessionState` values used by `useSessionState` and the existing `isSessionActive` helper.
- Reused the existing `GridSpinner` (already covered by other tab/chat usages); CI will run lint/typecheck/e2e.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMRSUo7setbTRQY7XBb2sZ)_