### PR TITLE
fix(web): rank longest/quickest tasks by active duration

### DIFF
--- a/apps/web/app/stats/stats-sections.tsx
+++ b/apps/web/app/stats/stats-sections.tsx
@@ -223,7 +223,7 @@ export function WorkloadSection({ task_stats }: WorkloadSectionProps) {
       <Card className="rounded-sm">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-muted-foreground">Longest Tasks</CardTitle>
-          <p className="text-xs text-muted-foreground">Ranked by elapsed span</p>
+          <p className="text-xs text-muted-foreground">Ranked by active duration</p>
         </CardHeader>
         <CardContent>
           <TaskDurationList
@@ -240,7 +240,7 @@ export function WorkloadSection({ task_stats }: WorkloadSectionProps) {
           <CardTitle className="text-sm font-medium text-muted-foreground">
             Quickest Tasks
           </CardTitle>
-          <p className="text-xs text-muted-foreground">Ranked by elapsed span</p>
+          <p className="text-xs text-muted-foreground">Ranked by active duration</p>
         </CardHeader>
         <CardContent>
           <TaskDurationList
@@ -435,11 +435,11 @@ export function RepoLeaders({ repositoryStats }: { repositoryStats: RepositorySt
 }
 
 function TaskDurationList({ tasks, sortDirection, emptyLabel }: TaskDurationListProps) {
-  const filtered = [...tasks].filter((t) => t.active_duration_ms > 0 || t.elapsed_span_ms > 0);
+  const filtered = [...tasks].filter((t) => t.active_duration_ms > 0);
   const sorted =
     sortDirection === "desc"
-      ? filtered.sort((a, b) => b.elapsed_span_ms - a.elapsed_span_ms)
-      : filtered.sort((a, b) => a.elapsed_span_ms - b.elapsed_span_ms);
+      ? filtered.sort((a, b) => b.active_duration_ms - a.active_duration_ms)
+      : filtered.sort((a, b) => a.active_duration_ms - b.active_duration_ms);
   const top3 = sorted.slice(0, 3);
 
   return (

--- a/apps/web/app/stats/stats-sections.tsx
+++ b/apps/web/app/stats/stats-sections.tsx
@@ -436,11 +436,12 @@ export function RepoLeaders({ repositoryStats }: { repositoryStats: RepositorySt
 
 function TaskDurationList({ tasks, sortDirection, emptyLabel }: TaskDurationListProps) {
   const filtered = [...tasks].filter((t) => t.active_duration_ms > 0);
-  const sorted =
+  filtered.sort((a, b) =>
     sortDirection === "desc"
-      ? filtered.sort((a, b) => b.active_duration_ms - a.active_duration_ms)
-      : filtered.sort((a, b) => a.active_duration_ms - b.active_duration_ms);
-  const top3 = sorted.slice(0, 3);
+      ? b.active_duration_ms - a.active_duration_ms
+      : a.active_duration_ms - b.active_duration_ms,
+  );
+  const top3 = filtered.slice(0, 3);
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
The Longest/Quickest Tasks lists on the stats page were sorting by elapsed wall-clock span (first turn → last turn), so a task that was idle for days outranked one that actually consumed more agent time. Switched the sort key to active duration (sum of turn durations) so the ranking reflects real work, matching the primary number already displayed on each row.

## Validation
- `pnpm lint` (apps/web)
- Verified visually in stats page: subtitles now read "Ranked by active duration"; ordering matches the displayed primary duration

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] Self-reviewed