### PR TITLE
fix: show sent message in chat without waiting for ws broadcast

### DIFF
--- a/apps/web/hooks/domains/comments/use-run-comment.test.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.test.ts
@@ -9,6 +9,7 @@ import type { DiffComment, PlanComment } from "@/lib/state/slices/comments";
 const mockRequest = vi.fn();
 const mockAppendToQueue = vi.fn();
 const mockMarkCommentsSent = vi.fn();
+const mockAddMessage = vi.fn();
 const mockGetWebSocketClient = vi.fn(() => ({ request: mockRequest }));
 let mockStoreState: Record<string, unknown> = {};
 
@@ -49,6 +50,7 @@ function makeStoreState(sessionState: string, planMode = false) {
     chatInput: {
       planModeBySessionId: { "sess-1": planMode },
     },
+    addMessage: mockAddMessage,
   };
 }
 
@@ -147,6 +149,44 @@ describe("useRunComment — idle agent sends directly", () => {
     ).rejects.toThrow("WS timeout");
 
     expect(mockMarkCommentsSent).not.toHaveBeenCalled();
+  });
+
+  // Regression: comments sent via "Run" sometimes did not appear in the chat
+  // until a page refresh, because the hook depended entirely on the
+  // session.message.added broadcast — which can be missed if the client's
+  // session subscription is briefly absent or its send buffer drops.
+  // The message returned in the message.add response must be added to the
+  // store optimistically; addMessage is idempotent so a later broadcast for
+  // the same id is a no-op.
+  it("adds returned message to the store so chat updates without waiting for broadcast", async () => {
+    const returnedMessage = {
+      id: "msg-42",
+      session_id: "sess-1",
+      task_id: "task-1",
+      author_type: "user",
+      content: "[diff] fix this",
+      type: "message",
+      created_at: "2026-05-08T00:00:00Z",
+    };
+    mockRequest.mockResolvedValueOnce(returnedMessage);
+    const { result } = renderCommentHook();
+
+    await act(async () => {
+      await result.current.runComment(makeDiffComment());
+    });
+
+    expect(mockAddMessage).toHaveBeenCalledWith(returnedMessage);
+  });
+
+  it("does not call addMessage when message.add returns no message", async () => {
+    mockRequest.mockResolvedValueOnce(undefined);
+    const { result } = renderCommentHook();
+
+    await act(async () => {
+      await result.current.runComment(makeDiffComment());
+    });
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/hooks/domains/comments/use-run-comment.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.ts
@@ -135,7 +135,7 @@ export function useRunComment({ sessionId, taskId }: UseRunCommentParams) {
             10000,
           );
           if (created && created.id && created.session_id) {
-            state.addMessage(created);
+            storeApi.getState().addMessage(created);
           }
         }
 

--- a/apps/web/hooks/domains/comments/use-run-comment.ts
+++ b/apps/web/hooks/domains/comments/use-run-comment.ts
@@ -15,6 +15,7 @@ import type {
   FileEditorComment,
   PRFeedbackComment,
 } from "@/lib/state/slices/comments";
+import type { Message } from "@/lib/types/http";
 
 /**
  * Format a single comment into markdown suitable for sending to the agent.
@@ -125,11 +126,17 @@ export function useRunComment({ sessionId, taskId }: UseRunCommentParams) {
         } else {
           const client = getWebSocketClient();
           if (!client) throw new Error("WebSocket client unavailable");
-          await client.request(
+          // Add the returned message to the store directly so the chat updates
+          // even if the session.message.added broadcast is missed (subscription
+          // gap, dropped frame, etc.). addMessage is idempotent on id.
+          const created = await client.request<Message | undefined>(
             "message.add",
             buildMessagePayload(sessionId, taskId, content, planModeEnabled, comment),
             10000,
           );
+          if (created && created.id && created.session_id) {
+            state.addMessage(created);
+          }
         }
 
         markCommentsSent([comment.id]);

--- a/apps/web/hooks/use-message-handler.ts
+++ b/apps/web/hooks/use-message-handler.ts
@@ -1,12 +1,13 @@
 import { useCallback } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
+import { useAppStoreApi } from "@/components/state-provider";
 import { useQueue } from "./domains/session/use-queue";
 import type { MessageAttachment } from "@/components/task/chat/chat-input-container";
 import type { ActiveDocument } from "@/lib/state/slices/ui/types";
 import type { PlanComment } from "@/lib/state/slices/comments";
 import { toBlockquote } from "@/lib/state/slices/comments/format";
 import type { ContextFile } from "@/lib/state/context-files-store";
-import type { CustomPrompt } from "@/lib/types/http";
+import type { CustomPrompt, Message } from "@/lib/types/http";
 
 function buildDocumentContext(
   activeDocument: ActiveDocument | null,
@@ -92,9 +93,9 @@ type SendMessagePayload = {
   contextFilesMeta?: Array<{ path: string; name: string }>;
 };
 
-async function sendMessageRequest(payload: SendMessagePayload): Promise<void> {
+async function sendMessageRequest(payload: SendMessagePayload): Promise<Message | undefined> {
   const client = getWebSocketClient();
-  if (!client) return;
+  if (!client) return undefined;
 
   const {
     taskId,
@@ -108,7 +109,7 @@ async function sendMessageRequest(payload: SendMessagePayload): Promise<void> {
   } = payload;
   const hasAttachments = attachments && attachments.length > 0;
 
-  await client.request(
+  return client.request<Message | undefined>(
     "message.add",
     {
       task_id: taskId,
@@ -137,6 +138,7 @@ export function useMessageHandler({
   prompts = [],
 }: UseMessageHandlerParams) {
   const { queue } = useQueue(resolvedSessionId);
+  const storeApi = useAppStoreApi();
 
   const buildFinalMessage = useCallback(
     (message: string, inlineMentions?: ContextFile[]) => {
@@ -182,7 +184,10 @@ export function useMessageHandler({
         return;
       }
 
-      await sendMessageRequest({
+      // Add the returned message to the store directly so the chat updates
+      // even if the session.message.added broadcast is missed (subscription
+      // gap, dropped frame, etc.). addMessage is idempotent on id.
+      const created = await sendMessageRequest({
         taskId,
         resolvedSessionId,
         finalMessage,
@@ -192,6 +197,9 @@ export function useMessageHandler({
         attachments,
         contextFilesMeta,
       });
+      if (created && created.id && created.session_id) {
+        storeApi.getState().addMessage(created);
+      }
     },
     [
       resolvedSessionId,
@@ -202,6 +210,7 @@ export function useMessageHandler({
       isAgentBusy,
       queue,
       buildFinalMessage,
+      storeApi,
     ],
   );
 


### PR DESCRIPTION
Comments sent via "Run" on a diff/file (and messages from the main chat input) sometimes failed to appear in the chat until the page was refreshed, because the UI relied entirely on the `session.message.added` WS broadcast — which can be missed during a brief subscription gap or dropped frame, even though the message was persisted server-side. Now the message returned by the `message.add` request is added to the store directly; `addMessage` is idempotent on `id`, so a later broadcast for the same message is a no-op.

## Validation

- `cd apps && pnpm --filter @kandev/web test` — 1233 passed (added 2 regression tests in `use-run-comment.test.ts`)
- `cd apps && pnpm --filter @kandev/web lint` — clean

## Possible Improvements

Low risk. The optimistic add is gated on a non-empty `id` and `session_id` from the response; idempotency in `addMessage` already deduplicates against the broadcast.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.