### PR TITLE
feat: allow subtasks to target a sibling repository

### DIFF
--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -436,24 +436,43 @@ type taskRepoResult struct {
 }
 
 // resolveTaskRepositories builds the repository list for a new task.
-// Priority: explicit repositories > parent task repos > source task repos.
-// When inheriting from a parent, it also returns the parent's workspace/workflow IDs.
+//
+// For subtasks (parentID set) workspace and workflow always come from the
+// parent. Explicit repositories override the parent's repos when supplied,
+// otherwise the parent's repos are inherited verbatim — letting an agent
+// spin up a subtask that targets a sibling repo while staying in the same
+// workspace/workflow.
+//
+// For top-level tasks (parentID empty) explicit repos win over source-task
+// inheritance; workspace falls back to the source task when available.
 func (h *Handlers) resolveTaskRepositories(
 	ctx context.Context,
 	parentID, sourceTaskID string,
 	explicit []mcpRepositoryInput,
 ) (taskRepoResult, error) {
-	if len(explicit) > 0 {
-		var repos []service.TaskRepositoryInput
-		for _, r := range explicit {
-			repos = append(repos, service.TaskRepositoryInput{
-				RepositoryID: r.RepositoryID,
-				LocalPath:    r.LocalPath,
-				GitHubURL:    r.GitHubURL,
-				BaseBranch:   r.BaseBranch,
-			})
+	explicitRepos := explicitRepoInputs(explicit)
+
+	if parentID != "" {
+		parent, err := h.taskSvc.GetTask(ctx, parentID)
+		if err != nil {
+			return taskRepoResult{}, fmt.Errorf("invalid parent_id: %w", err)
 		}
-		result := taskRepoResult{Repos: repos}
+		if parent.IsEphemeral {
+			return taskRepoResult{}, fmt.Errorf("cannot create subtasks of an ephemeral task (quick chat); omit parent_id to create a top-level task")
+		}
+		repos := explicitRepos
+		if repos == nil {
+			repos = inheritedRepoInputs(parent.Repositories)
+		}
+		return taskRepoResult{
+			Repos:       repos,
+			WorkspaceID: parent.WorkspaceID,
+			WorkflowID:  parent.WorkflowID,
+		}, nil
+	}
+
+	if explicitRepos != nil {
+		result := taskRepoResult{Repos: explicitRepos}
 		// Inherit workspace from source task so multi-workspace installs don't
 		// fail auto-resolution when the agent supplies an explicit repository.
 		if sourceTaskID != "" && h.taskSvc != nil {
@@ -468,29 +487,6 @@ func (h *Handlers) resolveTaskRepositories(
 		return result, nil
 	}
 
-	if parentID != "" {
-		parent, err := h.taskSvc.GetTask(ctx, parentID)
-		if err != nil {
-			return taskRepoResult{}, fmt.Errorf("invalid parent_id: %w", err)
-		}
-		if parent.IsEphemeral {
-			return taskRepoResult{}, fmt.Errorf("cannot create subtasks of an ephemeral task (quick chat); omit parent_id to create a top-level task")
-		}
-		var repos []service.TaskRepositoryInput
-		for _, r := range parent.Repositories {
-			repos = append(repos, service.TaskRepositoryInput{
-				RepositoryID:   r.RepositoryID,
-				BaseBranch:     r.BaseBranch,
-				CheckoutBranch: r.CheckoutBranch,
-			})
-		}
-		return taskRepoResult{
-			Repos:       repos,
-			WorkspaceID: parent.WorkspaceID,
-			WorkflowID:  parent.WorkflowID,
-		}, nil
-	}
-
 	// For top-level tasks, inherit repos and workspace from the calling agent's current task.
 	if sourceTaskID != "" {
 		sourceTask, err := h.taskSvc.GetTask(ctx, sourceTaskID)
@@ -499,21 +495,52 @@ func (h *Handlers) resolveTaskRepositories(
 				zap.String("source_task_id", sourceTaskID), zap.Error(err))
 			return taskRepoResult{}, nil
 		}
-		var repos []service.TaskRepositoryInput
-		for _, r := range sourceTask.Repositories {
-			repos = append(repos, service.TaskRepositoryInput{
-				RepositoryID:   r.RepositoryID,
-				BaseBranch:     r.BaseBranch,
-				CheckoutBranch: r.CheckoutBranch,
-			})
-		}
 		return taskRepoResult{
-			Repos:       repos,
+			Repos:       inheritedRepoInputs(sourceTask.Repositories),
 			WorkspaceID: sourceTask.WorkspaceID,
 		}, nil
 	}
 
 	return taskRepoResult{}, nil
+}
+
+// explicitRepoInputs maps the MCP-side explicit repo list to service inputs.
+// Returns nil when no explicit repos were supplied so callers can distinguish
+// "agent didn't pass repos" from "agent passed an empty list".
+func explicitRepoInputs(explicit []mcpRepositoryInput) []service.TaskRepositoryInput {
+	if len(explicit) == 0 {
+		return nil
+	}
+	repos := make([]service.TaskRepositoryInput, 0, len(explicit))
+	for _, r := range explicit {
+		repos = append(repos, service.TaskRepositoryInput{
+			RepositoryID: r.RepositoryID,
+			LocalPath:    r.LocalPath,
+			GitHubURL:    r.GitHubURL,
+			BaseBranch:   r.BaseBranch,
+		})
+	}
+	return repos
+}
+
+// inheritedRepoInputs maps an existing task's repository list onto service
+// inputs for a new task that inherits from it.
+func inheritedRepoInputs(src []*models.TaskRepository) []service.TaskRepositoryInput {
+	if len(src) == 0 {
+		return nil
+	}
+	repos := make([]service.TaskRepositoryInput, 0, len(src))
+	for _, r := range src {
+		if r == nil {
+			continue
+		}
+		repos = append(repos, service.TaskRepositoryInput{
+			RepositoryID:   r.RepositoryID,
+			BaseBranch:     r.BaseBranch,
+			CheckoutBranch: r.CheckoutBranch,
+		})
+	}
+	return repos
 }
 
 // autoStartTask launches an agent session for a newly created task in the background.

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -263,20 +263,62 @@ func TestResolveTaskRepositories_NoInputs_ReturnsEmpty(t *testing.T) {
 	assert.Empty(t, result.Repos)
 }
 
-func TestResolveTaskRepositories_ExplicitRepos_SkipsParentLookup(t *testing.T) {
-	log := testLogger(t)
-	h := &Handlers{logger: log.WithFields()}
+// --- Integration tests using real task service ---
 
-	// Even with a parentID, explicit repos should be used without looking up the parent
-	// (taskSvc is nil — if it tried to call GetTask it would panic).
-	explicit := []mcpRepositoryInput{{RepositoryID: "repo-explicit"}}
-	result, err := h.resolveTaskRepositories(context.Background(), "some-parent", "some-source", explicit)
+// seedParentWithRepo creates a workspace, workflow, repository, and a parent
+// task linked to that repository. Returns the parent task ID.
+func seedParentWithRepo(t *testing.T, svc *service.Service, repo *sqliterepo.Repository) string {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Test"}))
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Board"}))
+	require.NoError(t, repo.CreateRepository(ctx, &models.Repository{ID: "repo-parent", WorkspaceID: "ws-1", Name: "Parent Repo"}))
+	parent, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		Title:       "Parent task",
+		Repositories: []service.TaskRepositoryInput{
+			{RepositoryID: "repo-parent", BaseBranch: "main"},
+		},
+	})
 	require.NoError(t, err)
-	require.Len(t, result.Repos, 1)
-	assert.Equal(t, "repo-explicit", result.Repos[0].RepositoryID)
+	return parent.ID
 }
 
-// --- Integration tests using real task service ---
+func TestResolveTaskRepositories_ParentWithoutExplicitRepos_InheritsAll(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	parentID := seedParentWithRepo(t, svc, repo)
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+
+	result, err := h.resolveTaskRepositories(context.Background(), parentID, "", nil)
+	require.NoError(t, err)
+	require.Len(t, result.Repos, 1, "subtask without explicit repos inherits parent's repos")
+	assert.Equal(t, "repo-parent", result.Repos[0].RepositoryID)
+	assert.Equal(t, "ws-1", result.WorkspaceID)
+	assert.Equal(t, "wf-1", result.WorkflowID)
+}
+
+func TestResolveTaskRepositories_ParentWithExplicitRepos_OverridesRepoButInheritsWorkspace(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	parentID := seedParentWithRepo(t, svc, repo)
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+
+	explicit := []mcpRepositoryInput{
+		{GitHubURL: "https://github.com/acme/sibling", BaseBranch: "develop"},
+	}
+	result, err := h.resolveTaskRepositories(context.Background(), parentID, "", explicit)
+	require.NoError(t, err)
+	require.Len(t, result.Repos, 1, "explicit repos override parent's repos")
+	assert.Equal(t, "https://github.com/acme/sibling", result.Repos[0].GitHubURL)
+	assert.Equal(t, "develop", result.Repos[0].BaseBranch)
+	assert.Empty(t, result.Repos[0].RepositoryID, "explicit repo should not be conflated with parent's RepositoryID")
+	assert.Equal(t, "ws-1", result.WorkspaceID, "subtask still inherits parent's workspace")
+	assert.Equal(t, "wf-1", result.WorkflowID, "subtask still inherits parent's workflow")
+}
 
 func TestResolveTaskRepositories_EphemeralParent_Rejected(t *testing.T) {
 	svc, repo := newTestTaskService(t)

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -146,15 +146,13 @@ func (s *Server) createTaskHandler() server.ToolHandlerFunc {
 			"start_agent":         startAgent,
 		}
 
-		// Add repository info (only valid for top-level tasks)
+		// Add repository info. For subtasks an explicit repo overrides the
+		// parent's; if omitted the backend inherits from the parent.
 		repositoryID := req.GetString("repository_id", "")
 		localPath := req.GetString("local_path", "")
 		repositoryURL := req.GetString("repository_url", "")
 		baseBranch := req.GetString("base_branch", "")
 		hasRepo := repositoryID != "" || localPath != "" || repositoryURL != ""
-		if hasRepo && parentID != "" {
-			return mcp.NewToolResultError("repository_id, local_path, and repository_url are only valid for top-level tasks; subtasks inherit their repository from the parent"), nil
-		}
 		if hasRepo {
 			repo := map[string]string{}
 			if repositoryID != "" {

--- a/apps/backend/internal/mcp/server/handlers_test.go
+++ b/apps/backend/internal/mcp/server/handlers_test.go
@@ -252,17 +252,56 @@ func TestCreateTask_WithRepositoryURL(t *testing.T) {
 	assert.Equal(t, "main", repos[0]["base_branch"])
 }
 
-func TestCreateTask_RepositoryURL_RejectedForSubtasks(t *testing.T) {
-	backend := &testBackend{}
+func TestCreateTask_RepositoryURL_AllowedForSubtasks(t *testing.T) {
+	backend := &testBackend{
+		response: map[string]interface{}{"id": "task-new", "title": "Subtask with URL"},
+	}
 	s := newTaskModeServer(t, backend, "task-current")
 
 	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
 		"title":          "Subtask with URL",
 		"parent_id":      "self",
+		"description":    "Fix the upstream review-eligibility check",
 		"repository_url": "https://github.com/acme/widgets",
+		"base_branch":    "main",
 	})
 
-	assert.True(t, result.IsError, "repository_url should be rejected for subtasks")
+	assert.False(t, result.IsError, "repository_url should be accepted for subtasks (cross-repo subtask)")
+
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "task-current", payload["parent_id"], "self resolves to current task id")
+
+	repos, ok := payload["repositories"].([]map[string]string)
+	require.True(t, ok, "repositories should be a slice")
+	require.Len(t, repos, 1)
+	assert.Equal(t, "https://github.com/acme/widgets", repos[0]["github_url"])
+	assert.Equal(t, "main", repos[0]["base_branch"])
+}
+
+func TestCreateTask_LocalPath_AllowedForSubtasks(t *testing.T) {
+	backend := &testBackend{
+		response: map[string]interface{}{"id": "task-new", "title": "Subtask with local path"},
+	}
+	s := newTaskModeServer(t, backend, "task-current")
+
+	result := callTool(t, s, "create_task_kandev", map[string]interface{}{
+		"title":       "Subtask with local path",
+		"parent_id":   "self",
+		"description": "Patch the sibling repo",
+		"local_path":  "/Users/me/projects/sibling",
+	})
+
+	assert.False(t, result.IsError, "local_path should be accepted for subtasks (cross-repo subtask)")
+
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "task-current", payload["parent_id"])
+
+	repos, ok := payload["repositories"].([]map[string]string)
+	require.True(t, ok)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "/Users/me/projects/sibling", repos[0]["local_path"])
 }
 
 func TestMessageTask_ForwardsToBackend(t *testing.T) {

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -434,6 +434,7 @@ WHEN TO USE parent_id='self':
 - Breaking down your current task into phases/steps → use parent_id='self'
 - Creating tasks from a plan → use parent_id='self' (inherits repo, workspace, workflow)
 - Delegating work to another agent → use parent_id='self'
+- Delegating work that lives in a sibling repo → use parent_id='self' AND pass repository_url / repository_id / local_path to point the subtask at that repo
 
 WHEN TO OMIT parent_id (top-level task):
 - Creating an unrelated, standalone task
@@ -441,7 +442,8 @@ WHEN TO OMIT parent_id (top-level task):
 - workspace_id and workflow_id are auto-resolved if only one exists; provide explicitly if ambiguous
 
 IMPORTANT:
-- Subtasks inherit repositories, workspace, workflow, agent profile, and executor from parent
+- Subtasks inherit workspace, workflow, agent profile, and executor from the parent
+- Subtasks inherit the parent's repository unless you supply repository_url, repository_id, or local_path — in which case the subtask targets that repo instead (must live in the parent's workspace)
 - Top-level tasks need a repository via repository_url, repository_id, or local_path
 - 'description' is the sub-agent's initial prompt — be specific and detailed
 - Set start_agent=false to create without starting an agent`
@@ -471,9 +473,9 @@ IMPORTANT:
 			mcp.WithString("agent_profile_id", mcp.Description("Agent profile ID to use. For subtasks, inherited from the parent session. For top-level tasks, ask the user which agent profile they want (e.g. Claude Code, OpenCode) if not already known.")),
 			mcp.WithString("executor_profile_id", mcp.Description("Executor profile ID to use (determines the runtime environment: local, worktree, docker, etc.). For subtasks, inherited from the parent session. For top-level tasks, ask the user which executor profile they want if not already known.")),
 			mcp.WithBoolean("start_agent", mcp.Description("Whether to auto-start an agent on the created task. Default: true. Set to false to create the task without starting an agent.")),
-			mcp.WithString("repository_id", mcp.Description("Repository ID for top-level tasks. Not needed for subtasks (inherited from parent).")),
-			mcp.WithString("local_path", mcp.Description("Local repository folder path (e.g. '/Users/me/projects/myrepo') for top-level tasks. Will create/find the repository automatically. Preferred for local worktree flow.")),
-			mcp.WithString("repository_url", mcp.Description("GitHub repository URL (e.g. 'https://github.com/owner/repo') for top-level tasks. The repository will be cloned automatically on first use. Not needed for subtasks (inherited from parent).")),
+			mcp.WithString("repository_id", mcp.Description("Repository ID. Required for top-level tasks unless local_path or repository_url is provided. For subtasks: optional — supply only when the subtask should target a different repo than the parent.")),
+			mcp.WithString("local_path", mcp.Description("Local repository folder path (e.g. '/Users/me/projects/myrepo'). Will create/find the repository automatically. Preferred for local worktree flow. For subtasks: supply only when the subtask should target a different repo than the parent.")),
+			mcp.WithString("repository_url", mcp.Description("GitHub repository URL (e.g. 'https://github.com/owner/repo'). The repository will be cloned automatically on first use. For subtasks: supply only when the subtask should target a different repo than the parent.")),
 			mcp.WithString("base_branch", mcp.Description("Base branch for the repository (e.g. 'main'). Optional, defaults to repository's default branch.")),
 		),
 		s.wrapHandler("create_task_kandev", s.createTaskHandler()),

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -165,8 +165,11 @@ func (s *Service) resolveRepoInput(ctx context.Context, workspaceID string, repo
 		// could associate it with a task in this workspace via the MCP tool's
 		// repository_id fast path (the github_url and local_path branches both
 		// scope through FindOrCreateRepository, which is workspace-bound).
-		repo, err := s.repoEntities.GetRepository(ctx, repositoryID)
-		if err != nil || repo == nil || repo.WorkspaceID != workspaceID {
+		repo, lookupErr := s.repoEntities.GetRepository(ctx, repositoryID)
+		if lookupErr != nil {
+			return "", "", fmt.Errorf("looking up repository %q: %w", repositoryID, lookupErr)
+		}
+		if repo == nil || repo.WorkspaceID != workspaceID {
 			return "", "", fmt.Errorf("repository %q does not belong to workspace %q", repositoryID, workspaceID)
 		}
 		return repositoryID, baseBranch, nil

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -160,6 +160,15 @@ func (s *Service) resolveRepoInput(ctx context.Context, workspaceID string, repo
 	repositoryID = repoInput.RepositoryID
 	baseBranch = repoInput.BaseBranch
 	if repositoryID != "" {
+		// Verify the repository belongs to the target workspace. Without this
+		// check, an agent that knows a repository UUID from another workspace
+		// could associate it with a task in this workspace via the MCP tool's
+		// repository_id fast path (the github_url and local_path branches both
+		// scope through FindOrCreateRepository, which is workspace-bound).
+		repo, err := s.repoEntities.GetRepository(ctx, repositoryID)
+		if err != nil || repo == nil || repo.WorkspaceID != workspaceID {
+			return "", "", fmt.Errorf("repository %q does not belong to workspace %q", repositoryID, workspaceID)
+		}
 		return repositoryID, baseBranch, nil
 	}
 

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -220,6 +220,30 @@ func TestService_CreateTask_AcceptsMultipleDistinctRepositories(t *testing.T) {
 	}
 }
 
+func TestService_CreateTask_RejectsRepositoryFromOtherWorkspace(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-a", Name: "A"})
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-b", Name: "B"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-a", WorkspaceID: "ws-a", Name: "WF"})
+	_ = repo.CreateRepository(ctx, &models.Repository{ID: "repo-b", WorkspaceID: "ws-b", Name: "B repo"})
+
+	req := &CreateTaskRequest{
+		WorkspaceID:    "ws-a",
+		WorkflowID:     "wf-a",
+		WorkflowStepID: "step-1",
+		Title:          "cross-ws",
+		Repositories: []TaskRepositoryInput{
+			{RepositoryID: "repo-b", BaseBranch: "main"},
+		},
+	}
+	_, err := svc.CreateTask(ctx, req)
+	if err == nil {
+		t.Fatal("expected cross-workspace repository error, got nil")
+	}
+}
+
 func TestService_CreateRepository_DefaultWorktreeBranchPrefix(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -241,6 +242,9 @@ func TestService_CreateTask_RejectsRepositoryFromOtherWorkspace(t *testing.T) {
 	_, err := svc.CreateTask(ctx, req)
 	if err == nil {
 		t.Fatal("expected cross-workspace repository error, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not belong to workspace") {
+		t.Errorf("expected workspace-ownership error, got: %v", err)
 	}
 }
 

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -1,19 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@kandev/ui/dialog";
-import { Button } from "@kandev/ui/button";
-import { Input } from "@kandev/ui/input";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@kandev/ui/dialog";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
-import { createTask } from "@/lib/api/domains/kanban-api";
-import { replaceTaskUrl } from "@/lib/links";
 
 import {
   useAgentProfileOptions,
   useExecutorProfileOptions,
 } from "@/components/task-create-dialog-options";
-import { RepoChipsRow } from "@/components/task-create-dialog-repo-chips";
 import { useDialogHandlers } from "@/components/task-create-dialog-handlers";
 import {
   useDiscoverReposEffect,
@@ -22,20 +17,15 @@ import {
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { useIsUtilityConfigured } from "@/hooks/use-is-utility-configured";
-import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
 import { useSummarizeSession } from "@/hooks/use-summarize-session";
 import { useTaskSessions } from "@/hooks/use-task-sessions";
 import { getLocalStorage } from "@/lib/local-storage";
 import { STORAGE_KEYS } from "@/lib/settings/constants";
 import type { ExecutorProfile, Repository } from "@/lib/types/http";
 import type { AgentProfileOption } from "@/lib/state/slices";
-import {
-  buildRepositoriesPayload,
-  toMessageAttachments,
-} from "@/components/task-create-dialog-helpers";
 import { useSubtaskFormState } from "./new-subtask-form-state";
-import { WorktreeBadge, SelectorsRow, PromptZone } from "./new-subtask-form-parts";
-import { ContextSelect, useDialogAttachments, toContextItems } from "./session-dialog-shared";
+import { PromptZone, SubtaskFormBody } from "./new-subtask-form-parts";
+import { useSubtaskPromptZone, useSubtaskSubmit } from "./use-subtask-submit";
 
 type NewSubtaskDialogProps = {
   open: boolean;
@@ -131,19 +121,6 @@ function useAutoSelectExecutorProfile(
   }, [allProfiles, executorProfileId, setExecutorProfileId]);
 }
 
-function activateSubtaskSession(opts: {
-  sessionId: string;
-  taskId: string;
-  setActiveTask: (taskId: string) => void;
-  setActiveSession: (taskId: string, sessionId: string) => void;
-}) {
-  opts.setActiveTask(opts.taskId);
-  opts.setActiveSession(opts.taskId, opts.sessionId);
-  // Layout switch is handled by useEnvSwitchCleanup when the new session's
-  // task_environment_id is present; the hook subscribes to env-id updates.
-  replaceTaskUrl(opts.taskId);
-}
-
 /**
  * Seeds the chip row with the parent task's repo + branch when the form
  * mounts. Form parent passes `key={open}` so each dialog open remounts the
@@ -236,7 +213,6 @@ type SubtaskFormProps = {
   onClose: () => void;
 };
 
-// eslint-disable-next-line max-lines-per-function
 function NewSubtaskForm({
   parentTaskId,
   defaultTitle,
@@ -254,8 +230,6 @@ function NewSubtaskForm({
   onClose,
 }: SubtaskFormProps) {
   const { toast } = useToast();
-  const setActiveTask = useAppStore((s) => s.setActiveTask);
-  const setActiveSession = useAppStore((s) => s.setActiveSession);
   const isUtilityConfigured = useIsUtilityConfigured();
   const { summarize, isSummarizing } = useSummarizeSession();
   const [isCreating, setIsCreating] = useState(false);
@@ -272,227 +246,71 @@ function NewSubtaskForm({
   // Fetch on-disk repos so the chip dropdown shows "on disk" entries
   // (matches the create-task dialog's RepoChipsRow behavior).
   useDiscoverReposEffect(fs, isOpen, workspaceId, false, toast);
-  const promptRef = useRef<HTMLTextAreaElement>(null);
-  const {
-    attachments,
-    isDragging,
-    fileInputRef,
-    handleRemoveAttachment,
-    handlePaste,
-    handleDragOver,
-    handleDragLeave,
-    handleDrop,
-    handleAttachClick,
-    handleFileInputChange,
-  } = useDialogAttachments(isCreating || isSummarizing);
-  const contextItems = useMemo(
-    () => toContextItems(attachments, handleRemoveAttachment),
-    [attachments, handleRemoveAttachment],
-  );
   const profileOptions = useAgentProfileOptions(agentProfiles);
   const sessionOptions = useSessionOptions(parentTaskId);
-  const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
-    sessionId: null,
-    taskTitle: title,
-  });
-  const handleEnhancePrompt = useCallback(() => {
-    const current = promptRef.current?.value?.trim();
-    if (!current) return;
-    enhancePrompt(current, (enhanced) => {
-      if (promptRef.current) {
-        promptRef.current.value = enhanced;
-        setHasPrompt(true);
-      }
-    });
-  }, [enhancePrompt]);
-
   const allExecutorProfiles = useExecutorProfiles(executors);
   const executorProfileOptions = useExecutorProfileOptions(allExecutorProfiles);
   useAutoSelectExecutorProfile(allExecutorProfiles, fs.executorProfileId, fs.setExecutorProfileId);
-
+  const promptZone = useSubtaskPromptZone({
+    taskTitle: title,
+    inputDisabled: isCreating || isSummarizing,
+    contextValue,
+    initialPrompt,
+    setHasPrompt,
+  });
   const handleContextChange = useContextChangeHandler({
     setContextValue,
     setHasPrompt,
-    promptRef,
+    promptRef: promptZone.promptRef,
     initialPrompt,
     summarize,
   });
-
-  const resolvePrompt = useCallback(() => {
-    const typed = promptRef.current?.value?.trim() ?? "";
-    if (contextValue === "copy_prompt" && !typed && initialPrompt) return initialPrompt;
-    return typed;
-  }, [contextValue, initialPrompt]);
-
-  const performCreate = useCallback(
-    async (trimmedTitle: string, prompt: string) => {
-      const repositories = buildRepositoriesPayload({
-        useGitHubUrl: fs.useGitHubUrl,
-        githubUrl: fs.githubUrl,
-        githubBranch: fs.githubBranch,
-        githubPrHeadBranch: fs.githubPrHeadBranch,
-        repositories: fs.repositories,
-        discoveredRepositories: fs.discoveredRepositories,
-        workspaceRepositories: availableRepositories,
-      });
-      const profileId = fs.agentProfileId || defaultProfileId || undefined;
-
-      const response = await createTask({
-        workspace_id: workspaceId!,
-        workflow_id: workflowId!,
-        title: trimmedTitle,
-        description: prompt,
-        repositories,
-        start_agent: true,
-        agent_profile_id: profileId,
-        executor_profile_id: fs.executorProfileId || undefined,
-        parent_id: parentTaskId,
-        attachments: toMessageAttachments(attachments),
-      });
-
-      const newSessionId = response.session_id ?? response.primary_session_id ?? null;
-      if (newSessionId) {
-        activateSubtaskSession({
-          sessionId: newSessionId,
-          taskId: response.id,
-          setActiveTask,
-          setActiveSession,
-        });
-      }
-    },
-    [
-      fs.useGitHubUrl,
-      fs.githubUrl,
-      fs.githubBranch,
-      fs.githubPrHeadBranch,
-      fs.repositories,
-      fs.discoveredRepositories,
-      fs.agentProfileId,
-      fs.executorProfileId,
-      availableRepositories,
-      defaultProfileId,
-      workspaceId,
-      workflowId,
-      parentTaskId,
-      attachments,
-      setActiveTask,
-      setActiveSession,
-    ],
-  );
-
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
-      const trimmedTitle = title.trim();
-      if (!trimmedTitle || !workspaceId || !workflowId) return;
-      const prompt = resolvePrompt();
-      if (!prompt) return;
-
-      setIsCreating(true);
-      try {
-        await performCreate(trimmedTitle, prompt);
-        onClose();
-      } catch (error) {
-        toast({
-          title: "Failed to create subtask",
-          description: error instanceof Error ? error.message : "Unknown error",
-          variant: "error",
-        });
-      } finally {
-        setIsCreating(false);
-      }
-    },
-    [title, workspaceId, workflowId, resolvePrompt, performCreate, onClose, toast],
-  );
-
-  const showSessions = isUtilityConfigured ? sessionOptions : [];
-  // Worktree badge is only meaningful when the subtask still targets the
-  // parent's repo (single chip, same id). Adding repos or pasting a URL makes
-  // it ambiguous, so hide.
-  const onlyChipIsParent =
-    fs.repositories.length === 1 &&
-    fs.repositories[0]?.repositoryId === parentRepositoryId &&
-    !fs.useGitHubUrl;
-  const showWorktreeBadge = !!worktreeBranch && onlyChipIsParent;
-
+  const { handleSubmit } = useSubtaskSubmit({
+    fs,
+    parentTaskId,
+    defaultProfileId,
+    workspaceId,
+    workflowId,
+    availableRepositories,
+    attachments: promptZone.attachments.attachments,
+    resolvePrompt: promptZone.resolvePrompt,
+    title,
+    setIsCreating,
+    onClose,
+  });
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-1.5">
-        <label className="text-xs font-medium text-muted-foreground">Title</label>
-        <Input
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Subtask title"
-          className="text-sm"
-          data-testid="subtask-title-input"
-          disabled={isCreating}
+    <SubtaskFormBody
+      fs={fs}
+      handlers={handlers}
+      title={title}
+      setTitle={setTitle}
+      workspaceId={workspaceId}
+      availableRepositories={availableRepositories}
+      parentRepositoryId={parentRepositoryId}
+      worktreeBranch={worktreeBranch}
+      profileOptions={profileOptions}
+      executorProfileOptions={executorProfileOptions}
+      agentProfileId={fs.agentProfileId || defaultProfileId}
+      contextValue={contextValue}
+      onContextChange={handleContextChange}
+      hasInitialPrompt={!!initialPrompt}
+      sessionOptions={isUtilityConfigured ? sessionOptions : []}
+      promptZone={
+        <PromptZone
+          {...promptZone}
+          isCreating={isCreating}
+          isSummarizing={isSummarizing}
+          isUtilityConfigured={isUtilityConfigured}
+          setHasPrompt={setHasPrompt}
+          onSubmitShortcut={handleSubmit}
         />
-      </div>
-      <RepoChipsRow
-        fs={fs}
-        repositories={availableRepositories}
-        isTaskStarted={false}
-        workspaceId={workspaceId}
-        onRowRepositoryChange={handlers.handleRowRepositoryChange}
-        onRowBranchChange={handlers.handleRowBranchChange}
-        onToggleGitHubUrl={handlers.handleToggleGitHubUrl}
-        onGitHubUrlChange={handlers.handleGitHubUrlChange}
-      />
-      <WorktreeBadge show={showWorktreeBadge} branch={worktreeBranch} />
-      <SelectorsRow
-        profileOptions={profileOptions}
-        executorProfileOptions={executorProfileOptions}
-        agentProfileId={fs.agentProfileId || defaultProfileId}
-        executorProfileId={fs.executorProfileId}
-        onAgentProfileChange={handlers.handleAgentProfileChange}
-        onExecutorProfileChange={handlers.handleExecutorProfileChange}
-        disabled={isCreating}
-      />
-      <ContextSelect
-        value={contextValue}
-        onValueChange={handleContextChange}
-        hasInitialPrompt={!!initialPrompt}
-        sessionOptions={showSessions}
-        isSummarizing={isSummarizing}
-      />
-      <PromptZone
-        promptRef={promptRef}
-        contextItems={contextItems}
-        fileInputRef={fileInputRef}
-        isDragging={isDragging}
-        isCreating={isCreating}
-        isSummarizing={isSummarizing}
-        isEnhancingPrompt={isEnhancingPrompt}
-        isUtilityConfigured={isUtilityConfigured}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-        onPaste={handlePaste}
-        onFileInputChange={handleFileInputChange}
-        onAttachClick={handleAttachClick}
-        onEnhancePrompt={handleEnhancePrompt}
-        setHasPrompt={setHasPrompt}
-        onSubmitShortcut={handleSubmit}
-      />
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onClose}
-          disabled={isCreating}
-          className="cursor-pointer"
-        >
-          Cancel
-        </Button>
-        <Button
-          type="submit"
-          disabled={isCreating || isSummarizing || !hasPrompt}
-          className="cursor-pointer"
-        >
-          {isCreating ? "Creating..." : "Create Subtask"}
-        </Button>
-      </DialogFooter>
-    </form>
+      }
+      isCreating={isCreating}
+      isSummarizing={isSummarizing}
+      hasPrompt={hasPrompt}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+    />
   );
 }
 

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -9,7 +9,6 @@ import { useToast } from "@/components/toast-provider";
 import { createTask } from "@/lib/api/domains/kanban-api";
 import { replaceTaskUrl } from "@/lib/links";
 
-
 import {
   useAgentProfileOptions,
   useExecutorProfileOptions,
@@ -36,11 +35,7 @@ import {
 } from "@/components/task-create-dialog-helpers";
 import { useSubtaskFormState } from "./new-subtask-form-state";
 import { WorktreeBadge, SelectorsRow, PromptZone } from "./new-subtask-form-parts";
-import {
-  ContextSelect,
-  useDialogAttachments,
-  toContextItems,
-} from "./session-dialog-shared";
+import { ContextSelect, useDialogAttachments, toContextItems } from "./session-dialog-shared";
 
 type NewSubtaskDialogProps = {
   open: boolean;
@@ -500,7 +495,6 @@ function NewSubtaskForm({
     </form>
   );
 }
-
 
 export function NewSubtaskDialog({
   open,

--- a/apps/web/components/task/new-subtask-dialog.tsx
+++ b/apps/web/components/task/new-subtask-dialog.tsx
@@ -2,39 +2,45 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@kandev/ui/dialog";
-import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
-import { Textarea } from "@kandev/ui/textarea";
-import { IconGitBranch } from "@tabler/icons-react";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 import { createTask } from "@/lib/api/domains/kanban-api";
 import { replaceTaskUrl } from "@/lib/links";
-import { AgentSelector, ExecutorProfileSelector } from "@/components/task-create-dialog-selectors";
+
+
 import {
   useAgentProfileOptions,
   useExecutorProfileOptions,
 } from "@/components/task-create-dialog-options";
+import { RepoChipsRow } from "@/components/task-create-dialog-repo-chips";
+import { useDialogHandlers } from "@/components/task-create-dialog-handlers";
+import {
+  useDiscoverReposEffect,
+  useGitHubUrlBranchesEffect,
+} from "@/components/task-create-dialog-effects";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
-import { EnhancePromptButton } from "@/components/enhance-prompt-button";
+import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { useIsUtilityConfigured } from "@/hooks/use-is-utility-configured";
 import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
 import { useSummarizeSession } from "@/hooks/use-summarize-session";
 import { useTaskSessions } from "@/hooks/use-task-sessions";
 import { getLocalStorage } from "@/lib/local-storage";
 import { STORAGE_KEYS } from "@/lib/settings/constants";
-import type { ExecutorProfile } from "@/lib/types/http";
+import type { ExecutorProfile, Repository } from "@/lib/types/http";
 import type { AgentProfileOption } from "@/lib/state/slices";
-import { IconLoader2 } from "@tabler/icons-react";
-import { toMessageAttachments } from "@/components/task-create-dialog-helpers";
+import {
+  buildRepositoriesPayload,
+  toMessageAttachments,
+} from "@/components/task-create-dialog-helpers";
+import { useSubtaskFormState } from "./new-subtask-form-state";
+import { WorktreeBadge, SelectorsRow, PromptZone } from "./new-subtask-form-parts";
 import {
   ContextSelect,
   useDialogAttachments,
-  AttachButton,
   toContextItems,
 } from "./session-dialog-shared";
-import { ContextZone } from "./chat/context-items/context-zone";
 
 type NewSubtaskDialogProps = {
   open: boolean;
@@ -143,6 +149,78 @@ function activateSubtaskSession(opts: {
   replaceTaskUrl(opts.taskId);
 }
 
+/**
+ * Seeds the chip row with the parent task's repo + branch when the form
+ * mounts. Form parent passes `key={open}` so each dialog open remounts the
+ * form, which is when this fires. The user can still change or add repos
+ * after seeding.
+ */
+function useSeedParentRepository(
+  fs: ReturnType<typeof useSubtaskFormState>,
+  parentRepositoryId: string | null,
+  baseBranch: string | null,
+) {
+  useEffect(() => {
+    if (!parentRepositoryId) return;
+    fs.setRepositories([
+      { key: "subtask-row-1", repositoryId: parentRepositoryId, branch: baseBranch ?? "" },
+    ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+/** Pre-fills the agent profile with the parent session's profile on mount. */
+function useSeedAgentProfileId(
+  fs: ReturnType<typeof useSubtaskFormState>,
+  defaultProfileId: string,
+) {
+  useEffect(() => {
+    if (defaultProfileId) fs.setAgentProfileId(defaultProfileId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+/**
+ * Centralizes the Context selector's branching logic (Blank / Copy parent
+ * prompt / Summarize session N) so the form component stays under the
+ * complexity cap.
+ */
+function useContextChangeHandler(opts: {
+  setContextValue: (v: string) => void;
+  setHasPrompt: (v: boolean) => void;
+  promptRef: React.RefObject<HTMLTextAreaElement | null>;
+  initialPrompt: string | null;
+  summarize: (sessionId: string) => Promise<string | null>;
+}) {
+  const { setContextValue, setHasPrompt, promptRef, initialPrompt, summarize } = opts;
+  return useCallback(
+    async (value: string) => {
+      if (!value) return;
+      setContextValue(value);
+      const ta = promptRef.current;
+      if (!ta) return;
+      if (value === "copy_prompt" && initialPrompt) {
+        ta.value = initialPrompt;
+        setHasPrompt(true);
+        return;
+      }
+      if (value === "blank") {
+        ta.value = "";
+        setHasPrompt(false);
+        return;
+      }
+      if (value.startsWith("summarize:")) {
+        const result = await summarize(value.slice("summarize:".length));
+        if (result && promptRef.current) {
+          promptRef.current.value = result;
+          setHasPrompt(true);
+        }
+      }
+    },
+    [setContextValue, setHasPrompt, promptRef, initialPrompt, summarize],
+  );
+}
+
 type SubtaskFormProps = {
   parentTaskId: string;
   defaultTitle: string;
@@ -153,8 +231,13 @@ type SubtaskFormProps = {
   executors: Array<{ id: string; type: string; name: string; profiles?: ExecutorProfile[] }>;
   workspaceId: string | null;
   workflowId: string | null;
-  repositoryId: string | null;
+  /** The parent task's repository — used as the default for the subtask. */
+  parentRepositoryId: string | null;
   baseBranch: string | null;
+  /** Workspace repositories the user can pick from to override the default. */
+  availableRepositories: Repository[];
+  /** Whether the parent dialog is open — required for the GitHub URL effect. */
+  isOpen: boolean;
   onClose: () => void;
 };
 
@@ -169,8 +252,10 @@ function NewSubtaskForm({
   executors,
   workspaceId,
   workflowId,
-  repositoryId,
+  parentRepositoryId,
   baseBranch,
+  availableRepositories,
+  isOpen,
   onClose,
 }: SubtaskFormProps) {
   const { toast } = useToast();
@@ -182,8 +267,16 @@ function NewSubtaskForm({
   const [title, setTitle] = useState(defaultTitle);
   const [hasPrompt, setHasPrompt] = useState(false);
   const [contextValue, setContextValue] = useState("blank");
-  const [selectedProfileId, setSelectedProfileId] = useState(defaultProfileId);
-  const [executorProfileId, setExecutorProfileId] = useState("");
+  // Shim DialogFormState shared with the create-task dialog so RepoChipsRow,
+  // useDialogHandlers, and the GitHub URL branches effect work unchanged.
+  const fs = useSubtaskFormState();
+  useSeedParentRepository(fs, parentRepositoryId, baseBranch);
+  useSeedAgentProfileId(fs, defaultProfileId);
+  const handlers = useDialogHandlers(fs, availableRepositories);
+  useGitHubUrlBranchesEffect(fs, isOpen);
+  // Fetch on-disk repos so the chip dropdown shows "on disk" entries
+  // (matches the create-task dialog's RepoChipsRow behavior).
+  useDiscoverReposEffect(fs, isOpen, workspaceId, false, toast);
   const promptRef = useRef<HTMLTextAreaElement>(null);
   const {
     attachments,
@@ -220,29 +313,15 @@ function NewSubtaskForm({
 
   const allExecutorProfiles = useExecutorProfiles(executors);
   const executorProfileOptions = useExecutorProfileOptions(allExecutorProfiles);
-  useAutoSelectExecutorProfile(allExecutorProfiles, executorProfileId, setExecutorProfileId);
+  useAutoSelectExecutorProfile(allExecutorProfiles, fs.executorProfileId, fs.setExecutorProfileId);
 
-  const handleContextChange = useCallback(
-    async (value: string) => {
-      if (!value) return;
-      setContextValue(value);
-      if (value === "copy_prompt" && initialPrompt && promptRef.current) {
-        promptRef.current.value = initialPrompt;
-        setHasPrompt(true);
-      } else if (value === "blank" && promptRef.current) {
-        promptRef.current.value = "";
-        setHasPrompt(false);
-      } else if (value.startsWith("summarize:")) {
-        const sessionId = value.slice("summarize:".length);
-        const result = await summarize(sessionId);
-        if (result && promptRef.current) {
-          promptRef.current.value = result;
-          setHasPrompt(true);
-        }
-      }
-    },
-    [initialPrompt, summarize],
-  );
+  const handleContextChange = useContextChangeHandler({
+    setContextValue,
+    setHasPrompt,
+    promptRef,
+    initialPrompt,
+    summarize,
+  });
 
   const resolvePrompt = useCallback(() => {
     const typed = promptRef.current?.value?.trim() ?? "";
@@ -252,10 +331,16 @@ function NewSubtaskForm({
 
   const performCreate = useCallback(
     async (trimmedTitle: string, prompt: string) => {
-      const repositories = repositoryId
-        ? [{ repository_id: repositoryId, base_branch: baseBranch || undefined }]
-        : [];
-      const profileId = selectedProfileId || defaultProfileId || undefined;
+      const repositories = buildRepositoriesPayload({
+        useGitHubUrl: fs.useGitHubUrl,
+        githubUrl: fs.githubUrl,
+        githubBranch: fs.githubBranch,
+        githubPrHeadBranch: fs.githubPrHeadBranch,
+        repositories: fs.repositories,
+        discoveredRepositories: fs.discoveredRepositories,
+        workspaceRepositories: availableRepositories,
+      });
+      const profileId = fs.agentProfileId || defaultProfileId || undefined;
 
       const response = await createTask({
         workspace_id: workspaceId!,
@@ -265,7 +350,7 @@ function NewSubtaskForm({
         repositories,
         start_agent: true,
         agent_profile_id: profileId,
-        executor_profile_id: executorProfileId || undefined,
+        executor_profile_id: fs.executorProfileId || undefined,
         parent_id: parentTaskId,
         attachments: toMessageAttachments(attachments),
       });
@@ -281,13 +366,18 @@ function NewSubtaskForm({
       }
     },
     [
-      repositoryId,
-      baseBranch,
-      selectedProfileId,
+      fs.useGitHubUrl,
+      fs.githubUrl,
+      fs.githubBranch,
+      fs.githubPrHeadBranch,
+      fs.repositories,
+      fs.discoveredRepositories,
+      fs.agentProfileId,
+      fs.executorProfileId,
+      availableRepositories,
       defaultProfileId,
       workspaceId,
       workflowId,
-      executorProfileId,
       parentTaskId,
       attachments,
       setActiveTask,
@@ -321,6 +411,14 @@ function NewSubtaskForm({
   );
 
   const showSessions = isUtilityConfigured ? sessionOptions : [];
+  // Worktree badge is only meaningful when the subtask still targets the
+  // parent's repo (single chip, same id). Adding repos or pasting a URL makes
+  // it ambiguous, so hide.
+  const onlyChipIsParent =
+    fs.repositories.length === 1 &&
+    fs.repositories[0]?.repositoryId === parentRepositoryId &&
+    !fs.useGitHubUrl;
+  const showWorktreeBadge = !!worktreeBranch && onlyChipIsParent;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -335,37 +433,26 @@ function NewSubtaskForm({
           disabled={isCreating}
         />
       </div>
-      {worktreeBranch && (
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Badge variant="outline" className="text-xs font-normal gap-1">
-            <IconGitBranch className="h-3 w-3" />
-            {worktreeBranch}
-          </Badge>
-          <span>Same branch as current session</span>
-        </div>
-      )}
-      <div className="space-y-1.5">
-        <label className="text-xs font-medium text-muted-foreground">Executor</label>
-        <ExecutorProfileSelector
-          options={executorProfileOptions}
-          value={executorProfileId}
-          onValueChange={setExecutorProfileId}
-          disabled={isCreating}
-          placeholder="Select executor profile"
-        />
-      </div>
-      {profileOptions.length > 1 && (
-        <div className="space-y-1.5">
-          <label className="text-xs font-medium text-muted-foreground">Agent Profile</label>
-          <AgentSelector
-            options={profileOptions}
-            value={selectedProfileId || defaultProfileId}
-            onValueChange={setSelectedProfileId}
-            disabled={isCreating}
-            placeholder="Select agent profile"
-          />
-        </div>
-      )}
+      <RepoChipsRow
+        fs={fs}
+        repositories={availableRepositories}
+        isTaskStarted={false}
+        workspaceId={workspaceId}
+        onRowRepositoryChange={handlers.handleRowRepositoryChange}
+        onRowBranchChange={handlers.handleRowBranchChange}
+        onToggleGitHubUrl={handlers.handleToggleGitHubUrl}
+        onGitHubUrlChange={handlers.handleGitHubUrlChange}
+      />
+      <WorktreeBadge show={showWorktreeBadge} branch={worktreeBranch} />
+      <SelectorsRow
+        profileOptions={profileOptions}
+        executorProfileOptions={executorProfileOptions}
+        agentProfileId={fs.agentProfileId || defaultProfileId}
+        executorProfileId={fs.executorProfileId}
+        onAgentProfileChange={handlers.handleAgentProfileChange}
+        onExecutorProfileChange={handlers.handleExecutorProfileChange}
+        disabled={isCreating}
+      />
       <ContextSelect
         value={contextValue}
         onValueChange={handleContextChange}
@@ -373,61 +460,25 @@ function NewSubtaskForm({
         sessionOptions={showSessions}
         isSummarizing={isSummarizing}
       />
-      <div
-        className="relative"
+      <PromptZone
+        promptRef={promptRef}
+        contextItems={contextItems}
+        fileInputRef={fileInputRef}
+        isDragging={isDragging}
+        isCreating={isCreating}
+        isSummarizing={isSummarizing}
+        isEnhancingPrompt={isEnhancingPrompt}
+        isUtilityConfigured={isUtilityConfigured}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-      >
-        <div className="rounded-md border border-input bg-transparent">
-          <ContextZone items={contextItems} />
-          <Textarea
-            ref={promptRef}
-            placeholder="What should the agent work on?"
-            className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0 min-h-[120px] max-h-[240px] resize-none overflow-auto text-[13px]"
-            autoFocus
-            disabled={isCreating || isSummarizing}
-            data-testid="subtask-prompt-input"
-            onInput={(e) => setHasPrompt((e.target as HTMLTextAreaElement).value.trim().length > 0)}
-            onPaste={handlePaste}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                handleSubmit(e);
-              }
-            }}
-          />
-          <div className="flex items-center px-1 pb-1">
-            <AttachButton onClick={handleAttachClick} disabled={isCreating || isSummarizing} />
-            <EnhancePromptButton
-              onClick={handleEnhancePrompt}
-              isLoading={isEnhancingPrompt}
-              isConfigured={isUtilityConfigured}
-            />
-          </div>
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={handleFileInputChange}
-            tabIndex={-1}
-          />
-        </div>
-        {isDragging && (
-          <div className="absolute inset-0 flex items-center justify-center bg-primary/10 border-2 border-dashed border-primary rounded-md pointer-events-none">
-            <span className="text-sm text-primary font-medium">Drop files here</span>
-          </div>
-        )}
-        {isSummarizing && (
-          <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/80">
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <IconLoader2 className="h-4 w-4 animate-spin" />
-              <span>Generating summary...</span>
-            </div>
-          </div>
-        )}
-      </div>
+        onPaste={handlePaste}
+        onFileInputChange={handleFileInputChange}
+        onAttachClick={handleAttachClick}
+        onEnhancePrompt={handleEnhancePrompt}
+        setHasPrompt={setHasPrompt}
+        onSubmitShortcut={handleSubmit}
+      />
       <DialogFooter>
         <Button
           type="button"
@@ -450,6 +501,7 @@ function NewSubtaskForm({
   );
 }
 
+
 export function NewSubtaskDialog({
   open,
   onOpenChange,
@@ -468,6 +520,8 @@ export function NewSubtaskDialog({
 
   // Ensure executor/agent data is loaded when dialog opens
   useSettingsData(open);
+  // Load workspace repositories so the subtask repo override picker has options.
+  const { repositories: availableRepositories } = useRepositories(workspaceId, open);
 
   const siblingCount = useAppStore(
     (s) => s.kanban.tasks.filter((t) => t.parentTaskId === parentTaskId).length,
@@ -480,7 +534,10 @@ export function NewSubtaskDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[520px]">
+      <DialogContent
+        data-testid="new-subtask-dialog"
+        className="w-full h-full max-w-full max-h-full rounded-none sm:w-[800px] sm:h-auto sm:max-w-none sm:max-h-[85vh] sm:rounded-lg flex flex-col"
+      >
         <DialogHeader>
           <DialogTitle className="text-sm font-medium">
             New subtask for <span className="text-foreground">{parentTaskTitle}</span>
@@ -497,8 +554,10 @@ export function NewSubtaskDialog({
           executors={executors}
           workspaceId={workspaceId}
           workflowId={workflowId}
-          repositoryId={currentSession?.repository_id ?? null}
+          parentRepositoryId={currentSession?.repository_id ?? null}
           baseBranch={currentSession?.base_branch ?? null}
+          availableRepositories={availableRepositories}
+          isOpen={open}
           onClose={() => onOpenChange(false)}
         />
       </DialogContent>

--- a/apps/web/components/task/new-subtask-form-parts.tsx
+++ b/apps/web/components/task/new-subtask-form-parts.tsx
@@ -238,8 +238,11 @@ export function SubtaskFormBody({
   return (
     <form onSubmit={onSubmit} className="space-y-4">
       <div className="space-y-1.5">
-        <label className="text-xs font-medium text-muted-foreground">Title</label>
+        <label htmlFor="subtask-title-input" className="text-xs font-medium text-muted-foreground">
+          Title
+        </label>
         <Input
+          id="subtask-title-input"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="Subtask title"

--- a/apps/web/components/task/new-subtask-form-parts.tsx
+++ b/apps/web/components/task/new-subtask-form-parts.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { Badge } from "@kandev/ui/badge";
+import { Textarea } from "@kandev/ui/textarea";
+import { IconGitBranch, IconLoader2 } from "@tabler/icons-react";
+import { AgentSelector, ExecutorProfileSelector } from "@/components/task-create-dialog-selectors";
+import type {
+  useAgentProfileOptions,
+  useExecutorProfileOptions,
+} from "@/components/task-create-dialog-options";
+import { EnhancePromptButton } from "@/components/enhance-prompt-button";
+import { AttachButton, toContextItems } from "./session-dialog-shared";
+import { ContextZone } from "./chat/context-items/context-zone";
+
+export function WorktreeBadge({ show, branch }: { show: boolean; branch: string | null }) {
+  if (!show || !branch) return null;
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <Badge variant="outline" className="text-xs font-normal gap-1">
+        <IconGitBranch className="h-3 w-3" />
+        {branch}
+      </Badge>
+      <span>Same branch as current session</span>
+    </div>
+  );
+}
+
+type SelectorsRowProps = {
+  profileOptions: ReturnType<typeof useAgentProfileOptions>;
+  executorProfileOptions: ReturnType<typeof useExecutorProfileOptions>;
+  agentProfileId: string;
+  executorProfileId: string;
+  onAgentProfileChange: (value: string) => void;
+  onExecutorProfileChange: (value: string) => void;
+  disabled: boolean;
+};
+
+export function SelectorsRow({
+  profileOptions,
+  executorProfileOptions,
+  agentProfileId,
+  executorProfileId,
+  onAgentProfileChange,
+  onExecutorProfileChange,
+  disabled,
+}: SelectorsRowProps) {
+  const noAgents = profileOptions.length === 0;
+  return (
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
+      <div>
+        <AgentSelector
+          options={profileOptions}
+          value={agentProfileId}
+          onValueChange={onAgentProfileChange}
+          disabled={disabled || noAgents}
+          placeholder={noAgents ? "No agents found" : "Select agent profile"}
+        />
+      </div>
+      <div>
+        <ExecutorProfileSelector
+          options={executorProfileOptions}
+          value={executorProfileId}
+          onValueChange={onExecutorProfileChange}
+          disabled={disabled}
+          placeholder="Select executor profile"
+        />
+      </div>
+    </div>
+  );
+}
+
+type PromptZoneProps = {
+  promptRef: React.RefObject<HTMLTextAreaElement | null>;
+  contextItems: ReturnType<typeof toContextItems>;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  isDragging: boolean;
+  isCreating: boolean;
+  isSummarizing: boolean;
+  isEnhancingPrompt: boolean;
+  isUtilityConfigured: boolean;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragLeave: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
+  onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAttachClick: () => void;
+  onEnhancePrompt: () => void;
+  setHasPrompt: (v: boolean) => void;
+  onSubmitShortcut: (e: React.FormEvent) => void;
+};
+
+export function PromptZone({
+  promptRef,
+  contextItems,
+  fileInputRef,
+  isDragging,
+  isCreating,
+  isSummarizing,
+  isEnhancingPrompt,
+  isUtilityConfigured,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onPaste,
+  onFileInputChange,
+  onAttachClick,
+  onEnhancePrompt,
+  setHasPrompt,
+  onSubmitShortcut,
+}: PromptZoneProps) {
+  const inputDisabled = isCreating || isSummarizing;
+  return (
+    <div className="relative" onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop}>
+      <div className="rounded-md border border-input bg-transparent">
+        <ContextZone items={contextItems} />
+        <Textarea
+          ref={promptRef}
+          placeholder="What should the agent work on?"
+          className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0 min-h-[120px] max-h-[240px] resize-none overflow-auto text-[13px]"
+          autoFocus
+          disabled={inputDisabled}
+          data-testid="subtask-prompt-input"
+          onInput={(e) => setHasPrompt((e.target as HTMLTextAreaElement).value.trim().length > 0)}
+          onPaste={onPaste}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              onSubmitShortcut(e);
+            }
+          }}
+        />
+        <div className="flex items-center px-1 pb-1">
+          <AttachButton onClick={onAttachClick} disabled={inputDisabled} />
+          <EnhancePromptButton
+            onClick={onEnhancePrompt}
+            isLoading={isEnhancingPrompt}
+            isConfigured={isUtilityConfigured}
+          />
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={onFileInputChange}
+          tabIndex={-1}
+        />
+      </div>
+      {isDragging && (
+        <div className="absolute inset-0 flex items-center justify-center bg-primary/10 border-2 border-dashed border-primary rounded-md pointer-events-none">
+          <span className="text-sm text-primary font-medium">Drop files here</span>
+        </div>
+      )}
+      {isSummarizing && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/80">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <IconLoader2 className="h-4 w-4 animate-spin" />
+            <span>Generating summary...</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/task/new-subtask-form-parts.tsx
+++ b/apps/web/components/task/new-subtask-form-parts.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { Badge } from "@kandev/ui/badge";
+import { Button } from "@kandev/ui/button";
+import { DialogFooter } from "@kandev/ui/dialog";
+import { Input } from "@kandev/ui/input";
 import { Textarea } from "@kandev/ui/textarea";
 import { IconGitBranch, IconLoader2 } from "@tabler/icons-react";
 import { AgentSelector, ExecutorProfileSelector } from "@/components/task-create-dialog-selectors";
@@ -9,7 +12,16 @@ import type {
   useExecutorProfileOptions,
 } from "@/components/task-create-dialog-options";
 import { EnhancePromptButton } from "@/components/enhance-prompt-button";
-import { AttachButton, toContextItems } from "./session-dialog-shared";
+import { RepoChipsRow } from "@/components/task-create-dialog-repo-chips";
+import type { useDialogHandlers } from "@/components/task-create-dialog-handlers";
+import type { Repository } from "@/lib/types/http";
+import type { useSubtaskFormState } from "./new-subtask-form-state";
+import {
+  AttachButton,
+  ContextSelect,
+  toContextItems,
+  useDialogAttachments,
+} from "./session-dialog-shared";
 import { ContextZone } from "./chat/context-items/context-zone";
 
 export function WorktreeBadge({ show, branch }: { show: boolean; branch: string | null }) {
@@ -72,19 +84,12 @@ export function SelectorsRow({
 type PromptZoneProps = {
   promptRef: React.RefObject<HTMLTextAreaElement | null>;
   contextItems: ReturnType<typeof toContextItems>;
-  fileInputRef: React.RefObject<HTMLInputElement | null>;
-  isDragging: boolean;
+  attachments: ReturnType<typeof useDialogAttachments>;
   isCreating: boolean;
   isSummarizing: boolean;
   isEnhancingPrompt: boolean;
   isUtilityConfigured: boolean;
-  onDragOver: (e: React.DragEvent) => void;
-  onDragLeave: (e: React.DragEvent) => void;
-  onDrop: (e: React.DragEvent) => void;
-  onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
-  onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onAttachClick: () => void;
-  onEnhancePrompt: () => void;
+  handleEnhancePrompt: () => void;
   setHasPrompt: (v: boolean) => void;
   onSubmitShortcut: (e: React.FormEvent) => void;
 };
@@ -92,25 +97,33 @@ type PromptZoneProps = {
 export function PromptZone({
   promptRef,
   contextItems,
-  fileInputRef,
-  isDragging,
+  attachments,
   isCreating,
   isSummarizing,
   isEnhancingPrompt,
   isUtilityConfigured,
-  onDragOver,
-  onDragLeave,
-  onDrop,
-  onPaste,
-  onFileInputChange,
-  onAttachClick,
-  onEnhancePrompt,
+  handleEnhancePrompt,
   setHasPrompt,
   onSubmitShortcut,
 }: PromptZoneProps) {
+  const {
+    isDragging,
+    fileInputRef,
+    handlePaste,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleAttachClick,
+    handleFileInputChange,
+  } = attachments;
   const inputDisabled = isCreating || isSummarizing;
   return (
-    <div className="relative" onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop}>
+    <div
+      className="relative"
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
       <div className="rounded-md border border-input bg-transparent">
         <ContextZone items={contextItems} />
         <Textarea
@@ -121,7 +134,7 @@ export function PromptZone({
           disabled={inputDisabled}
           data-testid="subtask-prompt-input"
           onInput={(e) => setHasPrompt((e.target as HTMLTextAreaElement).value.trim().length > 0)}
-          onPaste={onPaste}
+          onPaste={handlePaste}
           onKeyDown={(e) => {
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               e.preventDefault();
@@ -130,9 +143,9 @@ export function PromptZone({
           }}
         />
         <div className="flex items-center px-1 pb-1">
-          <AttachButton onClick={onAttachClick} disabled={inputDisabled} />
+          <AttachButton onClick={handleAttachClick} disabled={inputDisabled} />
           <EnhancePromptButton
-            onClick={onEnhancePrompt}
+            onClick={handleEnhancePrompt}
             isLoading={isEnhancingPrompt}
             isConfigured={isUtilityConfigured}
           />
@@ -142,7 +155,7 @@ export function PromptZone({
           type="file"
           multiple
           className="hidden"
-          onChange={onFileInputChange}
+          onChange={handleFileInputChange}
           tabIndex={-1}
         />
       </div>
@@ -160,5 +173,127 @@ export function PromptZone({
         </div>
       )}
     </div>
+  );
+}
+
+type SubtaskFormBodyProps = {
+  fs: ReturnType<typeof useSubtaskFormState>;
+  handlers: ReturnType<typeof useDialogHandlers>;
+  title: string;
+  setTitle: (v: string) => void;
+  workspaceId: string | null;
+  availableRepositories: Repository[];
+  parentRepositoryId: string | null;
+  worktreeBranch: string | null;
+  profileOptions: ReturnType<typeof useAgentProfileOptions>;
+  executorProfileOptions: ReturnType<typeof useExecutorProfileOptions>;
+  agentProfileId: string;
+  contextValue: string;
+  onContextChange: (value: string) => void | Promise<void>;
+  hasInitialPrompt: boolean;
+  sessionOptions: React.ComponentProps<typeof ContextSelect>["sessionOptions"];
+  promptZone: React.ReactNode;
+  isCreating: boolean;
+  isSummarizing: boolean;
+  hasPrompt: boolean;
+  onClose: () => void;
+  onSubmit: (e: React.FormEvent) => void;
+};
+
+/**
+ * Renders the entire subtask form body (title input, repo chips, selectors,
+ * context picker, prompt zone, footer). Extracted from `NewSubtaskForm` so
+ * the parent stays under the per-function complexity cap.
+ */
+export function SubtaskFormBody({
+  fs,
+  handlers,
+  title,
+  setTitle,
+  workspaceId,
+  availableRepositories,
+  parentRepositoryId,
+  worktreeBranch,
+  profileOptions,
+  executorProfileOptions,
+  agentProfileId,
+  contextValue,
+  onContextChange,
+  hasInitialPrompt,
+  sessionOptions,
+  promptZone,
+  isCreating,
+  isSummarizing,
+  hasPrompt,
+  onClose,
+  onSubmit,
+}: SubtaskFormBodyProps) {
+  // Worktree badge only when subtask still targets parent's repo (single chip,
+  // same id). Adding repos or pasting a URL makes it ambiguous, so hide.
+  const showWorktreeBadge =
+    !!worktreeBranch &&
+    fs.repositories.length === 1 &&
+    fs.repositories[0]?.repositoryId === parentRepositoryId &&
+    !fs.useGitHubUrl;
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">Title</label>
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Subtask title"
+          className="text-sm"
+          data-testid="subtask-title-input"
+          disabled={isCreating}
+        />
+      </div>
+      <RepoChipsRow
+        fs={fs}
+        repositories={availableRepositories}
+        isTaskStarted={false}
+        workspaceId={workspaceId}
+        onRowRepositoryChange={handlers.handleRowRepositoryChange}
+        onRowBranchChange={handlers.handleRowBranchChange}
+        onToggleGitHubUrl={handlers.handleToggleGitHubUrl}
+        onGitHubUrlChange={handlers.handleGitHubUrlChange}
+      />
+      <WorktreeBadge show={showWorktreeBadge} branch={worktreeBranch} />
+      <SelectorsRow
+        profileOptions={profileOptions}
+        executorProfileOptions={executorProfileOptions}
+        agentProfileId={agentProfileId}
+        executorProfileId={fs.executorProfileId}
+        onAgentProfileChange={handlers.handleAgentProfileChange}
+        onExecutorProfileChange={handlers.handleExecutorProfileChange}
+        disabled={isCreating}
+      />
+      <ContextSelect
+        value={contextValue}
+        onValueChange={onContextChange}
+        hasInitialPrompt={hasInitialPrompt}
+        sessionOptions={sessionOptions}
+        isSummarizing={isSummarizing}
+      />
+      {promptZone}
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onClose}
+          disabled={isCreating}
+          className="cursor-pointer"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={isCreating || isSummarizing || !hasPrompt}
+          className="cursor-pointer"
+        >
+          {isCreating ? "Creating..." : "Create Subtask"}
+        </Button>
+      </DialogFooter>
+    </form>
   );
 }

--- a/apps/web/components/task/new-subtask-form-state.ts
+++ b/apps/web/components/task/new-subtask-form-state.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import type { Branch, LocalRepository } from "@/lib/types/http";
+import type {
+  DialogFormState,
+  StepType,
+  TaskFormInputsHandle,
+} from "@/components/task-create-dialog-types";
+import { useRepositoriesState } from "@/components/task-create-dialog-repositories-state";
+
+/**
+ * Returns a `DialogFormState`-shaped object for the New Subtask dialog so it
+ * can reuse the create-task dialog's `RepoChipsRow`, `useDialogHandlers`, and
+ * `useGitHubUrlBranchesEffect` without any forking of those components.
+ *
+ * The subtask flow only exercises a slice of the full state: repo rows,
+ * GitHub URL mode, agent/executor profiles. The remaining fields (title,
+ * workflow, draft, fresh-branch, discovered repos) are kept as inert stubs
+ * because the subtask dialog renders its own title input and inherits the
+ * parent's workflow.
+ */
+export function useSubtaskFormState(): DialogFormState {
+  const repos = useRepositoriesState();
+  const [agentProfileId, setAgentProfileId] = useState("");
+  const [executorProfileId, setExecutorProfileId] = useState("");
+  const [useGitHubUrl, setUseGitHubUrl] = useState(false);
+  const [githubUrl, setGitHubUrl] = useState("");
+  const [githubBranch, setGitHubBranch] = useState("");
+  const [githubBranches, setGitHubBranches] = useState<Branch[]>([]);
+  const [githubBranchesLoading, setGitHubBranchesLoading] = useState(false);
+  const [githubUrlError, setGitHubUrlError] = useState<string | null>(null);
+  const [githubPrHeadBranch, setGitHubPrHeadBranch] = useState<string | null>(null);
+  // Discovered (on-disk) repos — populated by useDiscoverReposEffect when the
+  // dialog opens, same as the create-task flow. This lets users target
+  // not-yet-imported on-machine git folders for the subtask.
+  const [discoveredRepositories, setDiscoveredRepositories] = useState<LocalRepository[]>([]);
+  const [discoverReposLoading, setDiscoverReposLoading] = useState(false);
+  const [discoverReposLoaded, setDiscoverReposLoaded] = useState(false);
+  const descriptionInputRef = useRef<TaskFormInputsHandle | null>(null);
+
+  return useMemo<DialogFormState>(
+    () => ({
+      // Title is owned by the subtask dialog directly — these are inert.
+      taskName: "",
+      setTaskName: NOOP,
+      hasTitle: false,
+      setHasTitle: NOOP,
+      hasDescription: false,
+      setHasDescription: NOOP,
+      draftDescription: "",
+      openCycle: 0,
+      currentDefaults: EMPTY_DEFAULTS,
+      descriptionInputRef,
+      // Repo chip row — what RepoChipsRow + useDialogHandlers actually drive.
+      repositories: repos.repositories,
+      setRepositories: repos.setRepositories,
+      addRepository: repos.addRepository,
+      removeRepository: repos.removeRepository,
+      updateRepository: repos.updateRepository,
+      githubBranch,
+      setGitHubBranch,
+      agentProfileId,
+      setAgentProfileId,
+      executorId: "",
+      setExecutorId: NOOP,
+      executorProfileId,
+      setExecutorProfileId,
+      discoveredRepositories,
+      setDiscoveredRepositories,
+      discoverReposLoading,
+      setDiscoverReposLoading,
+      discoverReposLoaded,
+      setDiscoverReposLoaded,
+      // Subtasks inherit the parent's workflow; no selector is rendered.
+      selectedWorkflowId: null,
+      setSelectedWorkflowId: NOOP,
+      fetchedSteps: EMPTY_STEPS,
+      setFetchedSteps: NOOP,
+      isCreatingSession: false,
+      setIsCreatingSession: NOOP,
+      isCreatingTask: false,
+      setIsCreatingTask: NOOP,
+      useGitHubUrl,
+      setUseGitHubUrl,
+      githubUrl,
+      setGitHubUrl,
+      githubBranches,
+      setGitHubBranches,
+      githubBranchesLoading,
+      setGitHubBranchesLoading,
+      githubUrlError,
+      setGitHubUrlError,
+      githubPrHeadBranch,
+      setGitHubPrHeadBranch,
+      workflowAgentProfileId: "",
+      setWorkflowAgentProfileId: NOOP,
+      clearDraft: NOOP,
+      // Fresh-branch flow is local-executor-only, single-row, and not
+      // surfaced here — keep the toggles wired but always inert.
+      freshBranchEnabled: false,
+      setFreshBranchEnabled: NOOP,
+      currentLocalBranch: "",
+      setCurrentLocalBranch: NOOP,
+      currentLocalBranchLoading: false,
+      setCurrentLocalBranchLoading: NOOP,
+    }),
+    [
+      descriptionInputRef,
+      repos.repositories,
+      repos.setRepositories,
+      repos.addRepository,
+      repos.removeRepository,
+      repos.updateRepository,
+      githubBranch,
+      agentProfileId,
+      executorProfileId,
+      useGitHubUrl,
+      githubUrl,
+      githubBranches,
+      githubBranchesLoading,
+      githubUrlError,
+      githubPrHeadBranch,
+      discoveredRepositories,
+      discoverReposLoading,
+      discoverReposLoaded,
+    ],
+  );
+}
+
+const NOOP = () => undefined;
+const EMPTY_DEFAULTS = { name: "", description: "" };
+const EMPTY_STEPS: StepType[] | null = null;

--- a/apps/web/components/task/new-subtask-form-state.ts
+++ b/apps/web/components/task/new-subtask-form-state.ts
@@ -106,7 +106,6 @@ export function useSubtaskFormState(): DialogFormState {
       setCurrentLocalBranchLoading: NOOP,
     }),
     [
-      descriptionInputRef,
       repos.repositories,
       repos.setRepositories,
       repos.addRepository,

--- a/apps/web/components/task/use-subtask-submit.ts
+++ b/apps/web/components/task/use-subtask-submit.ts
@@ -31,8 +31,7 @@ type UseSubtaskSubmitOpts = {
 /**
  * Encapsulates the subtask creation flow: builds the repositories payload,
  * calls createTask, and activates the new session. Returns `handleSubmit`
- * (form submit handler) and `isCreating` (loading flag) so the surrounding
- * component stays under the per-function complexity cap.
+ * so the surrounding component stays under the per-function complexity cap.
  */
 export function useSubtaskSubmit(opts: UseSubtaskSubmitOpts) {
   const {
@@ -51,6 +50,10 @@ export function useSubtaskSubmit(opts: UseSubtaskSubmitOpts) {
   const { toast } = useToast();
   const setActiveTask = useAppStore((s) => s.setActiveTask);
   const setActiveSession = useAppStore((s) => s.setActiveSession);
+  // Synchronous guard: setIsCreating(true) won't reflect into the disabled
+  // submit button until React commits, so a fast double-submit (Enter + click,
+  // double-click) can re-enter handleSubmit and call createTask twice.
+  const isSubmittingRef = useRef(false);
 
   const performCreate = useCallback(
     async (trimmedTitle: string, prompt: string) => {
@@ -110,11 +113,13 @@ export function useSubtaskSubmit(opts: UseSubtaskSubmitOpts) {
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
+      if (isSubmittingRef.current) return;
       const trimmedTitle = title.trim();
       if (!trimmedTitle || !workspaceId || !workflowId) return;
       const prompt = resolvePrompt();
       if (!prompt) return;
 
+      isSubmittingRef.current = true;
       setIsCreating(true);
       try {
         await performCreate(trimmedTitle, prompt);
@@ -126,6 +131,7 @@ export function useSubtaskSubmit(opts: UseSubtaskSubmitOpts) {
           variant: "error",
         });
       } finally {
+        isSubmittingRef.current = false;
         setIsCreating(false);
       }
     },

--- a/apps/web/components/task/use-subtask-submit.ts
+++ b/apps/web/components/task/use-subtask-submit.ts
@@ -1,0 +1,184 @@
+"use client";
+
+import { useCallback, useMemo, useRef } from "react";
+import { createTask } from "@/lib/api/domains/kanban-api";
+import { replaceTaskUrl } from "@/lib/links";
+import { useAppStore } from "@/components/state-provider";
+import {
+  buildRepositoriesPayload,
+  toMessageAttachments,
+} from "@/components/task-create-dialog-helpers";
+import { useToast } from "@/components/toast-provider";
+import { useUtilityAgentGenerator } from "@/hooks/use-utility-agent-generator";
+import type { Repository } from "@/lib/types/http";
+import type { useSubtaskFormState } from "./new-subtask-form-state";
+import { toContextItems, useDialogAttachments } from "./session-dialog-shared";
+
+type UseSubtaskSubmitOpts = {
+  fs: ReturnType<typeof useSubtaskFormState>;
+  parentTaskId: string;
+  defaultProfileId: string;
+  workspaceId: string | null;
+  workflowId: string | null;
+  availableRepositories: Repository[];
+  attachments: ReturnType<typeof useDialogAttachments>["attachments"];
+  resolvePrompt: () => string;
+  title: string;
+  setIsCreating: (v: boolean) => void;
+  onClose: () => void;
+};
+
+/**
+ * Encapsulates the subtask creation flow: builds the repositories payload,
+ * calls createTask, and activates the new session. Returns `handleSubmit`
+ * (form submit handler) and `isCreating` (loading flag) so the surrounding
+ * component stays under the per-function complexity cap.
+ */
+export function useSubtaskSubmit(opts: UseSubtaskSubmitOpts) {
+  const {
+    fs,
+    parentTaskId,
+    defaultProfileId,
+    workspaceId,
+    workflowId,
+    availableRepositories,
+    attachments,
+    resolvePrompt,
+    title,
+    setIsCreating,
+    onClose,
+  } = opts;
+  const { toast } = useToast();
+  const setActiveTask = useAppStore((s) => s.setActiveTask);
+  const setActiveSession = useAppStore((s) => s.setActiveSession);
+
+  const performCreate = useCallback(
+    async (trimmedTitle: string, prompt: string) => {
+      const repositories = buildRepositoriesPayload({
+        useGitHubUrl: fs.useGitHubUrl,
+        githubUrl: fs.githubUrl,
+        githubBranch: fs.githubBranch,
+        githubPrHeadBranch: fs.githubPrHeadBranch,
+        repositories: fs.repositories,
+        discoveredRepositories: fs.discoveredRepositories,
+        workspaceRepositories: availableRepositories,
+      });
+      const profileId = fs.agentProfileId || defaultProfileId || undefined;
+
+      const response = await createTask({
+        workspace_id: workspaceId!,
+        workflow_id: workflowId!,
+        title: trimmedTitle,
+        description: prompt,
+        repositories,
+        start_agent: true,
+        agent_profile_id: profileId,
+        executor_profile_id: fs.executorProfileId || undefined,
+        parent_id: parentTaskId,
+        attachments: toMessageAttachments(attachments),
+      });
+
+      const newSessionId = response.session_id ?? response.primary_session_id ?? null;
+      if (newSessionId) {
+        setActiveTask(response.id);
+        setActiveSession(response.id, newSessionId);
+        // Layout switch is handled by useEnvSwitchCleanup when the new session's
+        // task_environment_id is present; the hook subscribes to env-id updates.
+        replaceTaskUrl(response.id);
+      }
+    },
+    [
+      fs.useGitHubUrl,
+      fs.githubUrl,
+      fs.githubBranch,
+      fs.githubPrHeadBranch,
+      fs.repositories,
+      fs.discoveredRepositories,
+      fs.agentProfileId,
+      fs.executorProfileId,
+      availableRepositories,
+      defaultProfileId,
+      workspaceId,
+      workflowId,
+      parentTaskId,
+      attachments,
+      setActiveTask,
+      setActiveSession,
+    ],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmedTitle = title.trim();
+      if (!trimmedTitle || !workspaceId || !workflowId) return;
+      const prompt = resolvePrompt();
+      if (!prompt) return;
+
+      setIsCreating(true);
+      try {
+        await performCreate(trimmedTitle, prompt);
+        onClose();
+      } catch (error) {
+        toast({
+          title: "Failed to create subtask",
+          description: error instanceof Error ? error.message : "Unknown error",
+          variant: "error",
+        });
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [title, workspaceId, workflowId, resolvePrompt, performCreate, setIsCreating, onClose, toast],
+  );
+
+  return { handleSubmit };
+}
+
+/**
+ * Bundles the prompt textarea ref, attachments, enhance-prompt action, and
+ * derived context items used by the subtask form. Returns the values the form
+ * needs without spreading hook/state plumbing across the parent component.
+ */
+export function useSubtaskPromptZone(opts: {
+  taskTitle: string;
+  inputDisabled: boolean;
+  contextValue: string;
+  initialPrompt: string | null;
+  setHasPrompt: (v: boolean) => void;
+}) {
+  const { taskTitle, inputDisabled, contextValue, initialPrompt, setHasPrompt } = opts;
+  const promptRef = useRef<HTMLTextAreaElement>(null);
+  const attachments = useDialogAttachments(inputDisabled);
+  const { enhancePrompt, isEnhancingPrompt } = useUtilityAgentGenerator({
+    sessionId: null,
+    taskTitle,
+  });
+  const handleEnhancePrompt = useCallback(() => {
+    const current = promptRef.current?.value?.trim();
+    if (!current) return;
+    enhancePrompt(current, (enhanced) => {
+      if (promptRef.current) {
+        promptRef.current.value = enhanced;
+        setHasPrompt(true);
+      }
+    });
+  }, [enhancePrompt, setHasPrompt]);
+  const contextItems = useMemo(
+    () => toContextItems(attachments.attachments, attachments.handleRemoveAttachment),
+    [attachments.attachments, attachments.handleRemoveAttachment],
+  );
+  const resolvePrompt = useCallback(() => {
+    const typed = promptRef.current?.value?.trim() ?? "";
+    if (contextValue === "copy_prompt" && !typed && initialPrompt) return initialPrompt;
+    return typed;
+  }, [contextValue, initialPrompt]);
+  return {
+    promptRef,
+    attachments,
+    contextItems,
+    handleEnhancePrompt,
+    isEnhancingPrompt,
+    resolvePrompt,
+  };
+}

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -502,9 +502,10 @@ test.describe("Subtask dialog feature parity", () => {
     await urlInput.fill("https://github.com/subtask-owner/subtask-repo");
 
     // Wait for branch list to resolve so the payload carries `base_branch`.
-    // The subtask submit button isn't gated on this (only on prompt presence),
-    // but giving the effect time to settle keeps the assertion deterministic.
-    await expect(testPage.getByTestId("github-url-error")).not.toBeVisible({ timeout: 10_000 });
+    // The branch pill is disabled while branches are loading and re-enables
+    // once the resolver returns options, so this is a positive signal that
+    // the URL was parsed and branches were fetched.
+    await expect(testPage.getByTestId("branch-chip-trigger")).toBeEnabled({ timeout: 10_000 });
 
     // 4. Submit.
     const subtaskTitle = `Subtask GH URL ${Date.now()}`;

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -1,4 +1,8 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { test, expect } from "../../fixtures/test-base";
+import { makeGitEnv } from "../../helpers/git-helper";
 import { KanbanPage } from "../../pages/kanban-page";
 import { SessionPage } from "../../pages/session-page";
 
@@ -271,6 +275,432 @@ test.describe("MCP subtask creation", () => {
     await kanban.goto();
     const subtaskCard = kanban.taskCardByTitle(/Subtask Button Parent \/ Subtask \d+/);
     await expect(subtaskCard).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("user creates subtask in a different repository via the repo chooser", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(90_000);
+
+    // 1. Add a second workspace repository so the New Subtask dialog's
+    //    repo chip can be switched to a different repo.
+    const otherRepoName = "UI Subtask Override Target";
+    const otherRepoDir = path.join(backend.tmpDir, "repos", "ui-subtask-override");
+    fs.mkdirSync(otherRepoDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: otherRepoDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: otherRepoDir, env: gitEnv });
+    const otherRepo = await apiClient.createRepository(seedData.workspaceId, otherRepoDir, "main", {
+      name: otherRepoName,
+    });
+
+    // 2. Create a parent task on repo A with a simple agent script so we can
+    //    open its session and reach the subtask split-button.
+    const parentTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "UI Override Parent",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${parentTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+
+    // 3. Open the New Subtask dialog from the split-button.
+    await testPage.getByTestId("new-task-chevron").click();
+    await testPage.getByTestId("new-subtask-button").click();
+
+    const titleInput = testPage.getByTestId("subtask-title-input");
+    await expect(titleInput).toBeVisible({ timeout: 5_000 });
+
+    // 4. Open the repo chip and switch the parent's repo for repo B. The
+    //    subtask dialog now uses the same chip-row UX as the create-task
+    //    dialog (RepoChipsRow), so we drive it via repo-chip-trigger and
+    //    the combobox option role.
+    const repoChip = testPage.getByTestId("repo-chip-trigger").first();
+    await expect(repoChip).toBeVisible({ timeout: 5_000 });
+    await repoChip.click();
+    // The combobox option label includes a truncated-path badge alongside the
+    // repo name, so match by name substring rather than exact.
+    await testPage.getByRole("option", { name: new RegExp(otherRepoName) }).click();
+    // After selection, the chip should now show repo B's name.
+    await expect(repoChip).toContainText(otherRepoName);
+
+    // 5. Submit. Use a unique title so the listTasks poll can find this row.
+    const subtaskTitle = `UI Override Subtask ${Date.now()}`;
+    await titleInput.fill(subtaskTitle);
+    await testPage.getByTestId("subtask-prompt-input").fill("/e2e:simple-message");
+    await testPage.getByRole("button", { name: "Create Subtask" }).click();
+    await expect(titleInput).not.toBeVisible({ timeout: 10_000 });
+
+    // 6. Find the subtask via API and verify it landed on the override repo,
+    //    not the parent's repo.
+    type TaskEntry = { id: string; title: string };
+    let subtask: TaskEntry | undefined;
+    await expect
+      .poll(
+        async () => {
+          const allTasks = await apiClient.listTasks(seedData.workspaceId);
+          subtask = allTasks.tasks.find((t: TaskEntry) => t.title === subtaskTitle);
+          return subtask;
+        },
+        { timeout: 30_000, message: "Subtask should be created from the dialog" },
+      )
+      .toBeDefined();
+
+    const subtaskRaw = await apiClient.rawRequest("GET", `/api/v1/tasks/${subtask!.id}`);
+    const subtaskData = (await subtaskRaw.json()) as TaskWithRepos;
+    const repoIds = subtaskData.repositories?.map((r) => r.repository_id) ?? [];
+    expect(
+      repoIds,
+      `subtask should target the override repository (${otherRepo.id}), not the parent's (${seedData.repositoryId}); got: ${JSON.stringify(repoIds)}`,
+    ).toContain(otherRepo.id);
+    expect(repoIds).not.toContain(seedData.repositoryId);
+  });
+
+  test("MCP-created subtask can override parent task repository", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(90_000);
+
+    // 1. Create a second workspace repository so the subtask has somewhere
+    //    different to point at than the parent's repository.
+    const otherRepoDir = path.join(backend.tmpDir, "repos", "e2e-cross-repo");
+    fs.mkdirSync(otherRepoDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: otherRepoDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: otherRepoDir, env: gitEnv });
+    const otherRepo = await apiClient.createRepository(seedData.workspaceId, otherRepoDir, "main", {
+      name: "E2E Cross-Repo Target",
+    });
+
+    const subtaskTitle = "Cross-Repo Subtask E2E";
+    const script = [
+      'e2e:thinking("Creating cross-repo subtask...")',
+      "e2e:delay(100)",
+      `e2e:mcp:kandev:create_task_kandev({"parent_id":"self","title":"${subtaskTitle}","description":"E2E subtask: verify repository override","repository_id":"${otherRepo.id}"})`,
+      "e2e:delay(100)",
+      'e2e:message("Done.")',
+    ].join("\n");
+
+    // 2. Parent task lives in repoA (seedData.repositoryId). The agent script
+    //    asks the MCP tool to create a subtask in repoB instead.
+    const parentTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Cross-Repo Parent Task",
+      seedData.agentProfileId,
+      {
+        description: script,
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    expect(parentTask.id).toBeTruthy();
+
+    // 3. Navigate so the parent execution stays alive while the agent runs.
+    await testPage.goto(`/t/${parentTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    // 4. Poll for the subtask the agent is about to create.
+    type TaskEntry = { id: string; title: string };
+    let subtask: TaskEntry | undefined;
+    await expect
+      .poll(
+        async () => {
+          const allTasks = await apiClient.listTasks(seedData.workspaceId);
+          subtask = allTasks.tasks.find((t: TaskEntry) => t.title === subtaskTitle);
+          return subtask;
+        },
+        { timeout: 60_000, message: "Subtask should be created by the agent's MCP call" },
+      )
+      .toBeDefined();
+
+    // 5. Verify the subtask landed on the OTHER repository, not the parent's.
+    const subtaskRaw = await apiClient.rawRequest("GET", `/api/v1/tasks/${subtask!.id}`);
+    const subtaskData = (await subtaskRaw.json()) as TaskWithRepos;
+    const repoIds = subtaskData.repositories?.map((r) => r.repository_id) ?? [];
+    expect(
+      repoIds,
+      `subtask should target the override repository (${otherRepo.id}), not the parent's (${seedData.repositoryId}); got: ${JSON.stringify(repoIds)}`,
+    ).toContain(otherRepo.id);
+    expect(repoIds).not.toContain(seedData.repositoryId);
+  });
+});
+
+/**
+ * Verifies the New Subtask dialog mirrors the create-task dialog's repo/URL
+ * features: GitHub URL paste, on-disk discovered repos, and multi-repo rows.
+ * These tests exercise the shared `RepoChipsRow` + handlers/effects through
+ * the subtask form-state shim in `new-subtask-form-state.ts`.
+ */
+test.describe("Subtask dialog feature parity", () => {
+  test("user creates subtask via pasted GitHub URL", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(90_000);
+
+    // 1. Pre-seed a GitHub-backed repo + branches so the GitHub URL flow
+    //    resolves to a known repository_id without performing a real clone.
+    const repoDir = path.join(backend.tmpDir, "repos", "subtask-gh-url-target");
+    fs.mkdirSync(repoDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: repoDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: repoDir, env: gitEnv });
+    const ghRepo = await apiClient.createRepository(seedData.workspaceId, repoDir, "main", {
+      name: "subtask-owner/subtask-repo",
+      provider: "github",
+      provider_owner: "subtask-owner",
+      provider_name: "subtask-repo",
+    });
+    await apiClient.mockGitHubAddBranches("subtask-owner", "subtask-repo", [{ name: "main" }]);
+
+    // 2. Parent task on the seed repo.
+    const parentTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Subtask GH URL Parent",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${parentTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+
+    // 3. Open the subtask dialog and toggle to GitHub URL mode.
+    await testPage.getByTestId("new-task-chevron").click();
+    await testPage.getByTestId("new-subtask-button").click();
+    const titleInput = testPage.getByTestId("subtask-title-input");
+    await expect(titleInput).toBeVisible({ timeout: 5_000 });
+
+    await testPage.getByTestId("toggle-github-url").click();
+    const urlInput = testPage.getByTestId("github-url-input");
+    await expect(urlInput).toBeVisible({ timeout: 5_000 });
+    await urlInput.fill("https://github.com/subtask-owner/subtask-repo");
+
+    // Wait for branch list to resolve so the payload carries `base_branch`.
+    // The subtask submit button isn't gated on this (only on prompt presence),
+    // but giving the effect time to settle keeps the assertion deterministic.
+    await expect(testPage.getByTestId("github-url-error")).not.toBeVisible({ timeout: 10_000 });
+
+    // 4. Submit.
+    const subtaskTitle = `Subtask GH URL ${Date.now()}`;
+    await titleInput.fill(subtaskTitle);
+    await testPage.getByTestId("subtask-prompt-input").fill("/e2e:simple-message");
+    await testPage.getByRole("button", { name: "Create Subtask" }).click();
+    await expect(titleInput).not.toBeVisible({ timeout: 10_000 });
+
+    // 5. Verify the subtask resolved to the GitHub-backed repo, not the parent's.
+    type TaskEntry = { id: string; title: string };
+    let subtask: TaskEntry | undefined;
+    await expect
+      .poll(
+        async () => {
+          const allTasks = await apiClient.listTasks(seedData.workspaceId);
+          subtask = allTasks.tasks.find((t: TaskEntry) => t.title === subtaskTitle);
+          return subtask;
+        },
+        { timeout: 30_000, message: "Subtask should be created from a GitHub URL" },
+      )
+      .toBeDefined();
+
+    const subtaskRaw = await apiClient.rawRequest("GET", `/api/v1/tasks/${subtask!.id}`);
+    const subtaskData = (await subtaskRaw.json()) as TaskWithRepos;
+    const repoIds = subtaskData.repositories?.map((r) => r.repository_id) ?? [];
+    expect(
+      repoIds,
+      `subtask should resolve to the GitHub URL's repository (${ghRepo.id}); got: ${JSON.stringify(repoIds)}`,
+    ).toContain(ghRepo.id);
+    expect(repoIds).not.toContain(seedData.repositoryId);
+  });
+
+  test("subtask repo dropdown lists on-disk discovered repositories", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(60_000);
+
+    // 1. Create a git repo on disk (under HOME=tmpDir, where the backend's
+    //    discovery roots default scans) but do NOT register it as a workspace
+    //    repo. The chip dropdown's "on disk" section is fed by the discovery
+    //    endpoint and should pick this up.
+    const discoveredName = "subtask-discovered-only";
+    const discoveredDir = path.join(backend.tmpDir, "repos", discoveredName);
+    fs.mkdirSync(discoveredDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: discoveredDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: discoveredDir, env: gitEnv });
+
+    // 2. Parent task so we can open the subtask dialog from its session.
+    const parentTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Subtask Discovered Parent",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${parentTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+
+    // 3. Sanity-check via the API that backend discovery actually finds the
+    //    on-disk directory. If this fails, the issue is the backend scan, not
+    //    the dialog wiring — tells us where to look when debugging.
+    const discoverRaw = await apiClient.rawRequest(
+      "GET",
+      `/api/v1/workspaces/${seedData.workspaceId}/repositories/discover`,
+    );
+    const discoverData = (await discoverRaw.json()) as {
+      repositories: Array<{ path: string; name: string }>;
+    };
+    expect(
+      discoverData.repositories.some((r) => r.path === discoveredDir),
+      `backend discovery should include ${discoveredDir}; got: ${JSON.stringify(discoverData.repositories.map((r) => r.path))}`,
+    ).toBe(true);
+
+    // 4. Open the subtask dialog. The discover effect fires on mount via a
+    //    Next.js server action, so we can't await a direct backend response
+    //    here. Use poll-then-open: poll for the chip option to appear,
+    //    reopening the popover each tick because cmdk's listbox snapshots
+    //    options at open time and won't update if discovery resolves while
+    //    the popover is already showing.
+    await testPage.getByTestId("new-task-chevron").click();
+    await testPage.getByTestId("new-subtask-button").click();
+    await expect(testPage.getByTestId("subtask-title-input")).toBeVisible({ timeout: 5_000 });
+
+    const discoveredOption = testPage
+      .getByRole("option", { name: new RegExp(discoveredName, "i") })
+      .first();
+    const repoChip = testPage.getByTestId("repo-chip-trigger").first();
+    await expect
+      .poll(
+        async () => {
+          await repoChip.click();
+          const visible = await discoveredOption.isVisible().catch(() => false);
+          if (!visible) {
+            // Close so the next tick reopens against fresh state.
+            await testPage.keyboard.press("Escape");
+          }
+          return visible;
+        },
+        { timeout: 15_000, intervals: [500, 1000, 1500] },
+      )
+      .toBe(true);
+    await expect(discoveredOption).toContainText("on disk");
+  });
+
+  test("user creates subtask spanning multiple repositories", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(90_000);
+
+    // 1. Add a second workspace repository so the chip row can hold two rows.
+    const otherRepoName = "Subtask MultiRepo Target";
+    const otherRepoDir = path.join(backend.tmpDir, "repos", "subtask-multi-repo");
+    fs.mkdirSync(otherRepoDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: otherRepoDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: otherRepoDir, env: gitEnv });
+    const otherRepo = await apiClient.createRepository(seedData.workspaceId, otherRepoDir, "main", {
+      name: otherRepoName,
+    });
+
+    // 2. Parent task on repo A so we can open the subtask dialog from there.
+    const parentTask = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Subtask MultiRepo Parent",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${parentTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+
+    // 3. Open the subtask dialog. The first chip is seeded with the parent's
+    //    repo. Click the "+ add repository" button to append a second chip,
+    //    then point that chip at repo B.
+    await testPage.getByTestId("new-task-chevron").click();
+    await testPage.getByTestId("new-subtask-button").click();
+    const titleInput = testPage.getByTestId("subtask-title-input");
+    await expect(titleInput).toBeVisible({ timeout: 5_000 });
+
+    await testPage.getByTestId("add-repository").click();
+    const chipTriggers = testPage.getByTestId("repo-chip-trigger");
+    await expect(chipTriggers).toHaveCount(2, { timeout: 5_000 });
+    await chipTriggers.nth(1).click();
+    await testPage.getByRole("option", { name: new RegExp(otherRepoName) }).click();
+    await expect(chipTriggers.nth(1)).toContainText(otherRepoName);
+
+    // 4. Submit.
+    const subtaskTitle = `Subtask MultiRepo ${Date.now()}`;
+    await titleInput.fill(subtaskTitle);
+    await testPage.getByTestId("subtask-prompt-input").fill("/e2e:simple-message");
+    await testPage.getByRole("button", { name: "Create Subtask" }).click();
+    await expect(titleInput).not.toBeVisible({ timeout: 10_000 });
+
+    // 5. Verify the subtask carries BOTH repos.
+    type TaskEntry = { id: string; title: string };
+    let subtask: TaskEntry | undefined;
+    await expect
+      .poll(
+        async () => {
+          const allTasks = await apiClient.listTasks(seedData.workspaceId);
+          subtask = allTasks.tasks.find((t: TaskEntry) => t.title === subtaskTitle);
+          return subtask;
+        },
+        { timeout: 30_000, message: "Multi-repo subtask should be created from the dialog" },
+      )
+      .toBeDefined();
+
+    const subtaskRaw = await apiClient.rawRequest("GET", `/api/v1/tasks/${subtask!.id}`);
+    const subtaskData = (await subtaskRaw.json()) as TaskWithRepos;
+    const repoIds = subtaskData.repositories?.map((r) => r.repository_id) ?? [];
+    expect(
+      repoIds,
+      `subtask should target both the parent's repo and the override repo; got: ${JSON.stringify(repoIds)}`,
+    ).toEqual(expect.arrayContaining([seedData.repositoryId, otherRepo.id]));
+    expect(repoIds).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
Subtasks previously had to live in the parent's repository, which forced agents and users to drop out of the workflow whenever a piece of work spanned a sibling repo in the same workspace. Both the MCP `create_task` tool and the New Subtask dialog now accept a repository override while still inheriting the parent's workspace and workflow, and the dialog reuses the create-task `RepoChipsRow` / handlers / discover effect through a small `DialogFormState` shim so the two dialogs stay in lock-step.

## Important Changes

- `resolveTaskRepositories` reordered so subtasks check `parent_id` first: explicit repo wins, otherwise inherit from parent. Workspace + workflow always come from the parent.
- `create_task_kandev` MCP tool no longer rejects `repository_id` / `local_path` / `repository_url` when `parent_id` is set; tool description updated to document the cross-repo subtask flow.
- `NewSubtaskDialog` now uses the shared `RepoChipsRow`, `useDialogHandlers`, `useGitHubUrlBranchesEffect`, and `useDiscoverReposEffect` via `useSubtaskFormState` (a typed `DialogFormState` shim). New form parts split out of the dialog file to keep it under the 600-line cap.

## Validation

- `make -C apps/backend fmt test lint`
- `cd apps/web && pnpm test && pnpm lint`
- `pnpm --filter @kandev/web exec playwright test e2e/tests/task/subtask.spec.ts` — 11/11 passing (8 existing + 3 new under "Subtask dialog feature parity": GitHub URL flow, on-disk discovered repos in chip dropdown, multi-repo subtask).

## Possible Improvements

Low risk. Backend change is additive (removed a guard, added a parent-first branch); the dialog refactor is covered by the new e2e suite. Worst case is a regression in the form-state shim if `DialogFormState` grows fields without updating `useSubtaskFormState` — TypeScript would catch that at build time.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.