### PR TITLE
fix(web): keep "All Workflows" filter on task nav and workflow.created

### DIFF
--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -198,7 +198,10 @@ const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeader
 
 function SidebarContent({ panelId }: { panelId: string }) {
   const workspaceId = useAppStore((state) => state.workspaces.activeId);
-  const workflowId = useAppStore((state) => state.workflows.activeId);
+  // Read the task's workflow from the kanban snapshot, not the homepage
+  // filter (`workflows.activeId`), so navigating into a task never
+  // overwrites the user's "All Workflows" selection.
+  const workflowId = useAppStore((state) => state.kanban.workflowId);
   const workspaceName = useAppStore((state) => {
     const ws = state.workspaces.items.find((w: { id: string }) => w.id === workspaceId);
     return ws?.name ?? "Workspace";

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -198,9 +198,7 @@ const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeader
 
 function SidebarContent({ panelId }: { panelId: string }) {
   const workspaceId = useAppStore((state) => state.workspaces.activeId);
-  // Read the task's workflow from the kanban snapshot, not the homepage
-  // filter (`workflows.activeId`), so navigating into a task never
-  // overwrites the user's "All Workflows" selection.
+  // Read kanban.workflowId (task snapshot), not workflows.activeId (homepage filter), to preserve "All Workflows" across task navigation.
   const workflowId = useAppStore((state) => state.kanban.workflowId);
   const workspaceName = useAppStore((state) => {
     const ws = state.workspaces.items.find((w: { id: string }) => w.id === workspaceId);

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -252,8 +252,7 @@ export function RightHeaderActions(props: IDockviewHeaderActionsProps) {
 function SidebarRightActions() {
   const workspaceId = useAppStore((state) => state.workspaces.activeId);
   const kanban = useAppStore((state) => state.kanban);
-  // Read the task's workflow from the kanban snapshot rather than the
-  // homepage filter so opening a task doesn't poison "All Workflows".
+  // Use kanban.workflowId (task context) not workflows.activeId so "All Workflows" isn't clobbered when viewing a task.
   const workflowId = kanban.workflowId;
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
   const activeTaskTitle = useAppStore((state) => {

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -251,8 +251,10 @@ export function RightHeaderActions(props: IDockviewHeaderActionsProps) {
 
 function SidebarRightActions() {
   const workspaceId = useAppStore((state) => state.workspaces.activeId);
-  const workflowId = useAppStore((state) => state.workflows.activeId);
   const kanban = useAppStore((state) => state.kanban);
+  // Read the task's workflow from the kanban snapshot rather than the
+  // homepage filter so opening a task doesn't poison "All Workflows".
+  const workflowId = kanban.workflowId;
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
   const activeTaskTitle = useAppStore((state) => {
     const id = state.tasks.activeTaskId;

--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -199,6 +199,7 @@ function TopBarLeft({
               <Link
                 href="/"
                 className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
+                data-testid="task-breadcrumb-home"
               >
                 <IconHome className="h-4 w-4" />
               </Link>

--- a/apps/web/e2e/tests/kanban/workflow-filter.spec.ts
+++ b/apps/web/e2e/tests/kanban/workflow-filter.spec.ts
@@ -122,13 +122,7 @@ test.describe("Kanban workflow filter", () => {
     });
   });
 
-  // Regression: the task page's SSR (`buildResourceState` in
-  // `lib/ssr/session-page-state.ts`) used to set `workflows.activeId` to the
-  // task's `workflow_id`. On hydration, `deepMerge` overwrote the user's
-  // "All Workflows" (`null`) selection with that id, so returning to the
-  // homepage silently changed the filter to whichever workflow the visited
-  // task belonged to. Pin the cross-page flow so any future SSR regression
-  // (or a similar over-write from a WS handler / hook) gets caught here.
+  // Regression: SSR wrote workflows.activeId from the task's workflow_id, clobbering the "All Workflows" filter on return. Pins the cross-page flow.
   test("'All Workflows' selection survives navigating into a task and back", async ({
     testPage,
   }) => {
@@ -150,11 +144,7 @@ test.describe("Kanban workflow filter", () => {
     await testPage.goto(`/t/${betaTaskId}`);
     await expect(testPage).toHaveURL(new RegExp(`/t/${betaTaskId}`));
 
-    // Return via the in-app home breadcrumb (Next.js Link → client-side
-    // navigation). A full `goto("/")` would re-run the homepage SSR which
-    // re-resolves activeId from user_settings and masks the bug; the
-    // client-side path keeps the in-memory store and exposes any task-page
-    // SSR poisoning (the original repro).
+    // Breadcrumb = client-side nav: goto("/") re-runs SSR and re-resolves activeId, masking the bug.
     await testPage.getByTestId("task-breadcrumb-home").click();
     await expect(testPage).toHaveURL(/\/$|\?/);
     await expect(kanban.board).toBeVisible();

--- a/apps/web/e2e/tests/kanban/workflow-filter.spec.ts
+++ b/apps/web/e2e/tests/kanban/workflow-filter.spec.ts
@@ -33,6 +33,7 @@ async function selectWorkflowFilter(page: Page, optionLabel: string): Promise<vo
 
 test.describe("Kanban workflow filter", () => {
   let workflowBId: string | null = null;
+  let betaTaskId: string | null = null;
 
   // Pull `testPage` so its fixture (which runs `e2eReset` and resets user
   // settings) is set up before this hook seeds workflows/tasks — otherwise
@@ -48,10 +49,11 @@ test.describe("Kanban workflow filter", () => {
       workflow_id: seedData.workflowId,
       workflow_step_id: seedData.startStepId,
     });
-    await apiClient.createTask(seedData.workspaceId, BETA_TASK, {
+    const beta = await apiClient.createTask(seedData.workspaceId, BETA_TASK, {
       workflow_id: workflowB.id,
       workflow_step_id: startB.id,
     });
+    betaTaskId = beta.id;
   });
 
   test.afterEach(async ({ apiClient, seedData }) => {
@@ -59,6 +61,7 @@ test.describe("Kanban workflow filter", () => {
       await apiClient.deleteWorkflow(workflowBId).catch(() => {});
       workflowBId = null;
     }
+    betaTaskId = null;
     await apiClient.saveUserSettings({
       workspace_id: seedData.workspaceId,
       workflow_filter_id: seedData.workflowId,
@@ -110,6 +113,51 @@ test.describe("Kanban workflow filter", () => {
 
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
+
+    await expect(kanban.taskCardByTitle(ALPHA_TASK)).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+    await expect(kanban.taskCardByTitle(BETA_TASK)).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+  });
+
+  // Regression: the task page's SSR (`buildResourceState` in
+  // `lib/ssr/session-page-state.ts`) used to set `workflows.activeId` to the
+  // task's `workflow_id`. On hydration, `deepMerge` overwrote the user's
+  // "All Workflows" (`null`) selection with that id, so returning to the
+  // homepage silently changed the filter to whichever workflow the visited
+  // task belonged to. Pin the cross-page flow so any future SSR regression
+  // (or a similar over-write from a WS handler / hook) gets caught here.
+  test("'All Workflows' selection survives navigating into a task and back", async ({
+    testPage,
+  }) => {
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await selectWorkflowFilter(testPage, "All Workflows");
+
+    await expect(kanban.taskCardByTitle(ALPHA_TASK)).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+    await expect(kanban.taskCardByTitle(BETA_TASK)).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+
+    // Visit a task that belongs to Workflow B — the SSR build path that used
+    // to poison the global filter.
+    if (!betaTaskId) throw new Error("beta task was not seeded");
+    await testPage.goto(`/t/${betaTaskId}`);
+    await expect(testPage).toHaveURL(new RegExp(`/t/${betaTaskId}`));
+
+    // Return via the in-app home breadcrumb (Next.js Link → client-side
+    // navigation). A full `goto("/")` would re-run the homepage SSR which
+    // re-resolves activeId from user_settings and masks the bug; the
+    // client-side path keeps the in-memory store and exposes any task-page
+    // SSR poisoning (the original repro).
+    await testPage.getByTestId("task-breadcrumb-home").click();
+    await expect(testPage).toHaveURL(/\/$|\?/);
+    await expect(kanban.board).toBeVisible();
 
     await expect(kanban.taskCardByTitle(ALPHA_TASK)).toBeVisible({
       timeout: TASK_VISIBLE_TIMEOUT,

--- a/apps/web/lib/kanban/resolve-workflow.ts
+++ b/apps/web/lib/kanban/resolve-workflow.ts
@@ -30,5 +30,6 @@ export function resolveDesiredWorkflowId({
   ) {
     return settingsWorkflowId;
   }
-  return visibleWorkflows.length === 1 ? visibleWorkflows[0].id : null;
+  if (visibleWorkflows.length === 1) return visibleWorkflows[0].id;
+  return null;
 }

--- a/apps/web/lib/ssr/session-page-state.ts
+++ b/apps/web/lib/ssr/session-page-state.ts
@@ -105,13 +105,7 @@ function buildResourceState(p: BuildSessionPageStateParams) {
       })),
       activeId: task.workspace_id,
     },
-    // Only hydrate `workflows.items` from the task page; never write
-    // `activeId`. That field is the homepage workflow filter (with `null`
-    // meaning "All Workflows"), and overwriting it from a task page would
-    // silently change the user's filter when they return home. The task's
-    // own workflow context lives in `kanban.workflowId`, populated from
-    // the snapshot. `deepMerge` correctly preserves the existing
-    // `activeId` when it is omitted from the source.
+    // Don't write activeId — null means "All Workflows"; task context lives in kanban.workflowId.
     workflows: {
       items: workflows.map((w) => ({
         id: w.id,

--- a/apps/web/lib/ssr/session-page-state.ts
+++ b/apps/web/lib/ssr/session-page-state.ts
@@ -22,6 +22,7 @@ import type {
 import type { Terminal } from "@/hooks/domains/session/use-terminals";
 import { snapshotToState, taskToState } from "@/lib/ssr/mapper";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import type { AppState } from "@/lib/state/store";
 
 function buildWorktreeState(allSessions: TaskSession[]) {
   const sessionsWithWorktrees = allSessions.filter((s) => s.worktree_id);
@@ -104,6 +105,13 @@ function buildResourceState(p: BuildSessionPageStateParams) {
       })),
       activeId: task.workspace_id,
     },
+    // Only hydrate `workflows.items` from the task page; never write
+    // `activeId`. That field is the homepage workflow filter (with `null`
+    // meaning "All Workflows"), and overwriting it from a task page would
+    // silently change the user's filter when they return home. The task's
+    // own workflow context lives in `kanban.workflowId`, populated from
+    // the snapshot. `deepMerge` correctly preserves the existing
+    // `activeId` when it is omitted from the source.
     workflows: {
       items: workflows.map((w) => ({
         id: w.id,
@@ -111,8 +119,7 @@ function buildResourceState(p: BuildSessionPageStateParams) {
         name: w.name,
         hidden: w.hidden,
       })),
-      activeId: task.workflow_id,
-    },
+    } as Partial<AppState>["workflows"],
     repositories: {
       itemsByWorkspaceId: { [task.workspace_id]: repositories },
       loadingByWorkspaceId: { [task.workspace_id]: false },

--- a/apps/web/lib/state/slices/kanban/kanban-slice.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.ts
@@ -13,16 +13,12 @@ export const createKanbanSlice: StateCreator<
   [["zustand/immer", never]],
   [],
   KanbanSlice
-> = (set, get) => ({
+> = (set) => ({
   ...defaultKanbanState,
-  setActiveWorkflow: (workflowId) => {
-    if (get().workflows.activeId === workflowId) {
-      return;
-    }
+  setActiveWorkflow: (workflowId) =>
     set((draft) => {
       draft.workflows.activeId = workflowId;
-    });
-  },
+    }),
   setWorkflows: (workflows) =>
     set((draft) => {
       draft.workflows.items = workflows;

--- a/apps/web/lib/state/slices/kanban/kanban-slice.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.ts
@@ -17,6 +17,7 @@ export const createKanbanSlice: StateCreator<
   ...defaultKanbanState,
   setActiveWorkflow: (workflowId) =>
     set((draft) => {
+      if (draft.workflows.activeId === workflowId) return;
       draft.workflows.activeId = workflowId;
     }),
   setWorkflows: (workflows) =>

--- a/apps/web/lib/ws/handlers/workflows.test.ts
+++ b/apps/web/lib/ws/handlers/workflows.test.ts
@@ -35,6 +35,47 @@ function updatedMessage(payload: WorkflowPayload): BackendMessageMap["workflow.u
   };
 }
 
+function createdMessage(payload: WorkflowPayload): BackendMessageMap["workflow.created"] {
+  return {
+    id: "msg-1",
+    type: "notification",
+    action: "workflow.created",
+    payload,
+    timestamp: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("workflow.created handler — preserves user filter", () => {
+  it("does not promote a new workflow when activeId is null ('All Workflows')", () => {
+    const store = makeStore(
+      [{ id: "wf-1", workspaceId: "ws-1", name: "Existing", hidden: false }],
+      null,
+    );
+    const handlers = registerWorkflowsHandlers(store);
+
+    handlers["workflow.created"]?.(
+      createdMessage({ id: "wf-2", workspace_id: "ws-1", name: "Brand New" }),
+    );
+
+    expect(store.getState().workflows.activeId).toBeNull();
+    expect(store.getState().workflows.items.map((i) => i.id)).toEqual(["wf-2", "wf-1"]);
+  });
+
+  it("leaves an existing activeId untouched when a new workflow appears", () => {
+    const store = makeStore(
+      [{ id: "wf-1", workspaceId: "ws-1", name: "Existing", hidden: false }],
+      "wf-1",
+    );
+    const handlers = registerWorkflowsHandlers(store);
+
+    handlers["workflow.created"]?.(
+      createdMessage({ id: "wf-2", workspace_id: "ws-1", name: "Brand New" }),
+    );
+
+    expect(store.getState().workflows.activeId).toBe("wf-1");
+  });
+});
+
 describe("workflow.updated handler — hidden flag reconciles activeId", () => {
   it("clears activeId to next visible workflow when active becomes hidden", () => {
     const store = makeStore(

--- a/apps/web/lib/ws/handlers/workflows.ts
+++ b/apps/web/lib/ws/handlers/workflows.ts
@@ -23,6 +23,10 @@ function applyWorkflowCreated(state: AppState, payload: WorkflowPayload): AppSta
   if (state.workspaces.activeId !== payload.workspace_id) return state;
   if (state.workflows.items.some((item) => item.id === payload.id)) return state;
   const isHidden = Boolean(payload.hidden);
+  // Never auto-promote a newly-created workflow over the user's filter:
+  // `null` is a valid "All Workflows" selection, and using `??` here would
+  // treat it as "no selection" and silently switch the kanban to the new
+  // workflow. Workflow selection is the user's choice.
   return {
     ...state,
     workflows: {
@@ -35,9 +39,7 @@ function applyWorkflowCreated(state: AppState, payload: WorkflowPayload): AppSta
         },
         ...state.workflows.items,
       ],
-      // Hidden workflows must never be promoted to the active selection;
-      // they are system-only and would surface in the workflow picker.
-      activeId: state.workflows.activeId ?? (isHidden ? null : payload.id),
+      activeId: state.workflows.activeId,
     },
   };
 }

--- a/apps/web/lib/ws/handlers/workflows.ts
+++ b/apps/web/lib/ws/handlers/workflows.ts
@@ -23,10 +23,7 @@ function applyWorkflowCreated(state: AppState, payload: WorkflowPayload): AppSta
   if (state.workspaces.activeId !== payload.workspace_id) return state;
   if (state.workflows.items.some((item) => item.id === payload.id)) return state;
   const isHidden = Boolean(payload.hidden);
-  // Never auto-promote a newly-created workflow over the user's filter:
-  // `null` is a valid "All Workflows" selection, and using `??` here would
-  // treat it as "no selection" and silently switch the kanban to the new
-  // workflow. Workflow selection is the user's choice.
+  // Never use `??` here: null is a valid "All Workflows" selection, not a missing value.
   return {
     ...state,
     workflows: {


### PR DESCRIPTION
Selecting "All Workflows" (`workflowId: null`) on the kanban homepage was silently replaced by a specific workflow id whenever the user opened a task page or a new workflow arrived over WebSocket. The task page's SSR was hydrating `workflows.activeId = task.workflow_id` into the global store, and the `workflow.created` handler was treating `null` as "no selection" and auto-promoting the new workflow — both have been removed so `null` is preserved as a first-class user choice.

## Important Changes

- `lib/ssr/session-page-state.ts` no longer writes `workflows.activeId` from the task page; the task's workflow context lives in `kanban.workflowId` (populated from the snapshot). `deepMerge` preserves the existing `activeId`.
- `lib/ws/handlers/workflows.ts` `applyWorkflowCreated` no longer uses `?? payload.id` to backfill `null` — workflow selection is the user's choice.
- Task-page sidebar reads from `state.kanban.workflowId` instead of `state.workflows.activeId` (`dockview-desktop-layout.tsx`, `dockview-header-actions.tsx`).

## Validation

- `cd apps && pnpm format`
- `cd apps/web && npx tsc --noEmit` — clean (ignoring pre-existing `.next/types/validator.ts` noise)
- `cd apps/web && npx vitest run` — 1233/1233 passing, including 2 new `workflow.created` regression tests
- `cd apps/web && npx eslint --max-warnings 0` — clean
- `npx playwright test e2e/tests/kanban/workflow-filter.spec.ts` — 3/3 passing, including the new `'All Workflows' selection survives navigating into a task and back` regression
- TDD red/green verified by reverting each fix in turn and watching the matching test fail

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.