### PR TITLE
feat(web): prettify Kandev MCP tool titles in chat

### DIFF
--- a/apps/web/components/task/chat/messages/tool-call-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-call-message.tsx
@@ -13,6 +13,7 @@ import {
 } from "@tabler/icons-react";
 import { GridSpinner } from "@/components/grid-spinner";
 import { cn, transformPathsInText } from "@/lib/utils";
+import { prettifyToolTitle } from "@/lib/pretty-tool-title";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import type { Message } from "@/lib/types/http";
 import type { ToolCallMetadata } from "@/components/task/chat/types";
@@ -267,7 +268,7 @@ export const ToolCallMessage = memo(function ToolCallMessage({
 
   const metadata = comment.metadata as ToolCallMetadata | undefined;
   const rawTitle = metadata?.title ?? comment.content ?? "Tool call";
-  const title = transformPathsInText(rawTitle, worktreePath);
+  const title = transformPathsInText(prettifyToolTitle(rawTitle), worktreePath);
 
   const formattedOutput = hasOutput && !inlineOutput ? formatToolOutput(output) : null;
 

--- a/apps/web/e2e/tests/settings/config-management.spec.ts
+++ b/apps/web/e2e/tests/settings/config-management.spec.ts
@@ -52,8 +52,8 @@ test.describe("Config-mode MCP — workflow management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Done listing");
-    await expect(page.chat.getByText("list_workspaces_kandev")).toBeVisible({ timeout: 10_000 });
-    await expect(page.chat.getByText("list_workflows_kandev")).toBeVisible({ timeout: 10_000 });
+    await expect(page.chat.getByText("Kandev: List Workspaces")).toBeVisible({ timeout: 10_000 });
+    await expect(page.chat.getByText("Kandev: List Workflows")).toBeVisible({ timeout: 10_000 });
   });
 
   test("agent can create and list workflow steps", async ({ testPage, apiClient, seedData }) => {
@@ -254,8 +254,8 @@ test.describe("Config-mode MCP — agent management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Agents listed");
-    await expect(page.chat.getByText("list_agents_kandev")).toBeVisible({ timeout: 10_000 });
-    await expect(page.chat.getByText("list_agent_profiles_kandev")).toBeVisible({
+    await expect(page.chat.getByText("Kandev: List Agents")).toBeVisible({ timeout: 10_000 });
+    await expect(page.chat.getByText("Kandev: List Agent Profiles")).toBeVisible({
       timeout: 10_000,
     });
   });
@@ -403,8 +403,8 @@ test.describe("Config-mode MCP — MCP server configuration", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "MCP config updated");
-    await expect(page.chat.getByText("get_mcp_config_kandev")).toBeVisible({ timeout: 10_000 });
-    await expect(page.chat.getByText("update_mcp_config_kandev")).toBeVisible({ timeout: 10_000 });
+    await expect(page.chat.getByText("Kandev: Get MCP Config")).toBeVisible({ timeout: 10_000 });
+    await expect(page.chat.getByText("Kandev: Update MCP Config")).toBeVisible({ timeout: 10_000 });
 
     // Verify via API
     const config = await apiClient.getAgentProfileMcpConfig(seedData.agentProfileId);
@@ -436,7 +436,9 @@ test.describe("Config-mode MCP — task management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Tasks listed");
-    await expect(page.chat.getByText("list_tasks_kandev").first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.chat.getByText("Kandev: List Tasks").first()).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
   test("agent can move a task to a different step", async ({ testPage, apiClient, seedData }) => {
@@ -532,7 +534,7 @@ test.describe("Config-mode MCP — executor management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Executors listed");
-    await expect(page.chat.getByText("list_executors_kandev", { exact: true })).toBeVisible({
+    await expect(page.chat.getByText("Kandev: List Executors", { exact: true })).toBeVisible({
       timeout: 10_000,
     });
   });

--- a/apps/web/e2e/tests/settings/config-management.spec.ts
+++ b/apps/web/e2e/tests/settings/config-management.spec.ts
@@ -34,6 +34,19 @@ async function runAndWait(
   return page;
 }
 
+/**
+ * After a turn completes, consecutive tool calls collapse into a "{N} tool
+ * call(s)" group header. Click each header so the per-tool-call titles below
+ * are rendered and assertions can target them.
+ */
+async function expandToolCallGroups(page: SessionPage) {
+  const headers = page.chat.getByRole("button", { name: /\d+ tool calls?$/ });
+  const count = await headers.count();
+  for (let i = 0; i < count; i++) {
+    await headers.nth(i).click();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Workflow management
 // ---------------------------------------------------------------------------
@@ -52,6 +65,7 @@ test.describe("Config-mode MCP — workflow management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Done listing");
+    await expandToolCallGroups(page);
     await expect(page.chat.getByText("Kandev: List Workspaces")).toBeVisible({ timeout: 10_000 });
     await expect(page.chat.getByText("Kandev: List Workflows")).toBeVisible({ timeout: 10_000 });
   });
@@ -254,6 +268,7 @@ test.describe("Config-mode MCP — agent management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Agents listed");
+    await expandToolCallGroups(page);
     await expect(page.chat.getByText("Kandev: List Agents")).toBeVisible({ timeout: 10_000 });
     await expect(page.chat.getByText("Kandev: List Agent Profiles")).toBeVisible({
       timeout: 10_000,
@@ -403,6 +418,7 @@ test.describe("Config-mode MCP — MCP server configuration", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "MCP config updated");
+    await expandToolCallGroups(page);
     await expect(page.chat.getByText("Kandev: Get MCP Config")).toBeVisible({ timeout: 10_000 });
     await expect(page.chat.getByText("Kandev: Update MCP Config")).toBeVisible({ timeout: 10_000 });
 
@@ -436,6 +452,7 @@ test.describe("Config-mode MCP — task management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Tasks listed");
+    await expandToolCallGroups(page);
     await expect(page.chat.getByText("Kandev: List Tasks").first()).toBeVisible({
       timeout: 10_000,
     });
@@ -534,6 +551,7 @@ test.describe("Config-mode MCP — executor management", () => {
     );
 
     const page = await runAndWait(testPage, session.task_id, "Executors listed");
+    await expandToolCallGroups(page);
     await expect(page.chat.getByText("Kandev: List Executors", { exact: true })).toBeVisible({
       timeout: 10_000,
     });

--- a/apps/web/lib/pretty-tool-title.test.ts
+++ b/apps/web/lib/pretty-tool-title.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { prettifyToolTitle } from "./pretty-tool-title";
+import { EXTERNAL_MCP_TOOL_GROUPS } from "./settings/external-mcp-tools";
+
+describe("prettifyToolTitle", () => {
+  it("converts a kandev tool name to Title Case with brand prefix", () => {
+    expect(prettifyToolTitle("create_task_kandev")).toBe("Kandev: Create Task");
+    expect(prettifyToolTitle("list_workflow_steps_kandev")).toBe("Kandev: List Workflow Steps");
+    expect(prettifyToolTitle("ask_user_question_kandev")).toBe("Kandev: Ask User Question");
+    expect(prettifyToolTitle("move_task_kandev")).toBe("Kandev: Move Task");
+  });
+
+  it("uppercases known acronyms", () => {
+    expect(prettifyToolTitle("update_mcp_config_kandev")).toBe("Kandev: Update MCP Config");
+    expect(prettifyToolTitle("get_mcp_config_kandev")).toBe("Kandev: Get MCP Config");
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(prettifyToolTitle("  create_task_kandev  ")).toBe("Kandev: Create Task");
+  });
+
+  it("leaves non-kandev MCP tool names unchanged", () => {
+    expect(prettifyToolTitle("mcp__github__list_issues")).toBe("mcp__github__list_issues");
+    expect(prettifyToolTitle("Read")).toBe("Read");
+    expect(prettifyToolTitle("Bash")).toBe("Bash");
+  });
+
+  it("leaves Claude-supplied human titles unchanged", () => {
+    expect(prettifyToolTitle("Reading file foo.ts")).toBe("Reading file foo.ts");
+    expect(prettifyToolTitle("Running `git status`")).toBe("Running `git status`");
+  });
+
+  it("does not match strings that merely contain _kandev mid-name", () => {
+    expect(prettifyToolTitle("create_kandev_task")).toBe("create_kandev_task");
+    expect(prettifyToolTitle("kandev_create_task")).toBe("kandev_create_task");
+  });
+
+  it("does not match uppercased or hyphenated variants", () => {
+    expect(prettifyToolTitle("CREATE_TASK_KANDEV")).toBe("CREATE_TASK_KANDEV");
+    expect(prettifyToolTitle("create-task-kandev")).toBe("create-task-kandev");
+  });
+
+  it("returns empty input unchanged", () => {
+    expect(prettifyToolTitle("")).toBe("");
+  });
+
+  it("prettifies every tool name in the external MCP catalog", () => {
+    const names = EXTERNAL_MCP_TOOL_GROUPS.flatMap((g) => g.tools.map((t) => t.name));
+    for (const name of names) {
+      const out = prettifyToolTitle(name);
+      expect(out.startsWith("Kandev: ")).toBe(true);
+      expect(out).not.toMatch(/_/);
+    }
+  });
+});

--- a/apps/web/lib/pretty-tool-title.test.ts
+++ b/apps/web/lib/pretty-tool-title.test.ts
@@ -15,8 +15,9 @@ describe("prettifyToolTitle", () => {
     expect(prettifyToolTitle("get_mcp_config_kandev")).toBe("Kandev: Get MCP Config");
   });
 
-  it("trims surrounding whitespace before matching", () => {
+  it("trims surrounding whitespace, both for matches and pass-through", () => {
     expect(prettifyToolTitle("  create_task_kandev  ")).toBe("Kandev: Create Task");
+    expect(prettifyToolTitle("  Reading foo.ts  ")).toBe("Reading foo.ts");
   });
 
   it("leaves non-kandev MCP tool names unchanged", () => {

--- a/apps/web/lib/pretty-tool-title.test.ts
+++ b/apps/web/lib/pretty-tool-title.test.ts
@@ -26,6 +26,14 @@ describe("prettifyToolTitle", () => {
     expect(prettifyToolTitle("Bash")).toBe("Bash");
   });
 
+  it("strips namespace prefixes used by different agents", () => {
+    // Codex passes `<server>/<tool>`.
+    expect(prettifyToolTitle("kandev/get_task_plan_kandev")).toBe("Kandev: Get Task Plan");
+    expect(prettifyToolTitle("kandev/update_mcp_config_kandev")).toBe("Kandev: Update MCP Config");
+    // Claude-style `mcp__<server>__<tool>` prefix.
+    expect(prettifyToolTitle("mcp__kandev__create_task_kandev")).toBe("Kandev: Create Task");
+  });
+
   it("leaves Claude-supplied human titles unchanged", () => {
     expect(prettifyToolTitle("Reading file foo.ts")).toBe("Reading file foo.ts");
     expect(prettifyToolTitle("Running `git status`")).toBe("Running `git status`");

--- a/apps/web/lib/pretty-tool-title.ts
+++ b/apps/web/lib/pretty-tool-title.ts
@@ -4,7 +4,7 @@ const ACRONYMS = new Set(["mcp", "id", "url", "api", "ui", "vs", "ide", "cli"]);
 export function prettifyToolTitle(raw: string): string {
   if (!raw) return raw;
   const trimmed = raw.trim();
-  if (!KANDEV_TOOL_RE.test(trimmed)) return raw;
+  if (!KANDEV_TOOL_RE.test(trimmed)) return trimmed;
   const stem = trimmed.slice(0, -"_kandev".length);
   const words = stem
     .split("_")

--- a/apps/web/lib/pretty-tool-title.ts
+++ b/apps/web/lib/pretty-tool-title.ts
@@ -1,0 +1,14 @@
+const KANDEV_TOOL_RE = /^[a-z][a-z0-9_]*_kandev$/;
+const ACRONYMS = new Set(["mcp", "id", "url", "api", "ui", "vs", "ide", "cli"]);
+
+export function prettifyToolTitle(raw: string): string {
+  if (!raw) return raw;
+  const trimmed = raw.trim();
+  if (!KANDEV_TOOL_RE.test(trimmed)) return raw;
+  const stem = trimmed.slice(0, -"_kandev".length);
+  const words = stem
+    .split("_")
+    .filter(Boolean)
+    .map((w) => (ACRONYMS.has(w) ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1)));
+  return `Kandev: ${words.join(" ")}`;
+}

--- a/apps/web/lib/pretty-tool-title.ts
+++ b/apps/web/lib/pretty-tool-title.ts
@@ -1,11 +1,16 @@
 const KANDEV_TOOL_RE = /^[a-z][a-z0-9_]*_kandev$/;
+// Different agents prefix MCP tools differently: Claude Code passes the bare
+// tool name, Codex passes `<server>/<tool>`, others may use `mcp__<server>__`.
+const NAMESPACE_SEP = /\/|__/;
 const ACRONYMS = new Set(["mcp"]);
 
 export function prettifyToolTitle(raw: string): string {
   if (!raw) return raw;
   const trimmed = raw.trim();
-  if (!KANDEV_TOOL_RE.test(trimmed)) return trimmed;
-  const stem = trimmed.slice(0, -"_kandev".length);
+  const segments = trimmed.split(NAMESPACE_SEP);
+  const tail = segments[segments.length - 1];
+  if (!KANDEV_TOOL_RE.test(tail)) return trimmed;
+  const stem = tail.slice(0, -"_kandev".length);
   const words = stem
     .split("_")
     .filter(Boolean)

--- a/apps/web/lib/pretty-tool-title.ts
+++ b/apps/web/lib/pretty-tool-title.ts
@@ -1,5 +1,5 @@
 const KANDEV_TOOL_RE = /^[a-z][a-z0-9_]*_kandev$/;
-const ACRONYMS = new Set(["mcp", "id", "url", "api", "ui", "vs", "ide", "cli"]);
+const ACRONYMS = new Set(["mcp"]);
 
 export function prettifyToolTitle(raw: string): string {
   if (!raw) return raw;


### PR DESCRIPTION
Tool calls to Kandev MCP tools rendered as raw underscored names (e.g. `create_task_kandev`) in the chat UI; now display as "Kandev: Create Task" so users can read what the agent is doing without parsing snake_case.

## Validation

- `pnpm --filter @kandev/web exec vitest run lib/pretty-tool-title.test.ts` — 9/9 pass (happy path, acronym preservation, all 29 catalog tools, negative cases: non-kandev MCP, hyphens, mid-name `_kandev`, free-form titles)
- `pnpm --filter @kandev/web lint` — clean (`--max-warnings 0`)
- `tsc --noEmit` — no new errors on touched files
- Manual: still pending — needs a Kandev session calling e.g. `list_workspaces_kandev` to confirm "Kandev: List Workspaces" renders

## Possible Improvements

Low risk — pure display transform, regex-gated to `*_kandev`. Worst case: a future Kandev tool that doesn't follow the `*_kandev` suffix would silently bypass prettification (catalog test would catch the convention break).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.