### PR TITLE
fix(web): mobile task switcher sheet skeleton while snapshot loads

### DIFF
--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -87,7 +87,7 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
   const gitStatusByEnvId = useAppStore((state) => state.gitStatus.byEnvironmentId);
   const envIdBySessionId = useAppStore((state) => state.environmentIdBySessionId);
   const messagesBySession = useAppStore((state) => state.messages.bySession);
-  const { tasks } = useTasks(workflowId);
+  const { tasks, isLoading: tasksLoading } = useTasks(workflowId);
   const steps = useAppStore((state) => state.kanban.steps);
   const workspaces = useAppStore((state) => state.workspaces.items);
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
@@ -157,7 +157,10 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
     selectedTaskId,
     steps,
     workspaces,
-    kanbanIsLoading,
+    // Sheet should show a skeleton while the workflow snapshot hydrates the
+    // kanban slice — without this it briefly (or permanently, on fetch error)
+    // shows "No tasks yet." even when tasks exist server-side.
+    tasksLoading: tasksLoading || kanbanIsLoading,
     tasksWithRepositories,
     dialogSteps,
   };

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -91,7 +91,6 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
   const steps = useAppStore((state) => state.kanban.steps);
   const workspaces = useAppStore((state) => state.workspaces.items);
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
-  const kanbanIsLoading = useAppStore((state) => state.kanban.isLoading ?? false);
 
   const selectedTaskId = useMemo(() => {
     if (activeSessionId) return sessionsById[activeSessionId]?.task_id ?? activeTaskId;
@@ -160,7 +159,7 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
     // Sheet should show a skeleton while the workflow snapshot hydrates the
     // kanban slice — without this it briefly (or permanently, on fetch error)
     // shows "No tasks yet." even when tasks exist server-side.
-    tasksLoading: tasksLoading || kanbanIsLoading,
+    tasksLoading,
     tasksWithRepositories,
     dialogSteps,
   };

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -156,9 +156,7 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
     selectedTaskId,
     steps,
     workspaces,
-    // Sheet should show a skeleton while the workflow snapshot hydrates the
-    // kanban slice — without this it briefly (or permanently, on fetch error)
-    // shows "No tasks yet." even when tasks exist server-side.
+    // Skeleton while snapshot hydrates kanban — otherwise shows "No tasks yet." even when tasks exist.
     tasksLoading,
     tasksWithRepositories,
     dialogSteps,

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -114,7 +114,7 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
             onArchiveTask={actions.handleArchiveTask}
             onDeleteTask={actions.handleDeleteTask}
             deletingTaskId={actions.deletingTaskId}
-            isLoading={data.kanbanIsLoading}
+            isLoading={data.tasksLoading}
           />
         </div>
       </SheetContent>

--- a/apps/web/hooks/use-tasks.test.ts
+++ b/apps/web/hooks/use-tasks.test.ts
@@ -22,7 +22,13 @@ vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (s: MockState) => unknown) => selector(mockState),
   useAppStoreApi: () => ({
     getState: () => mockState,
-    setState: (updater: (s: MockState) => MockState) => mockSetState(updater(mockState)),
+    setState: (updater: (s: MockState) => MockState) => {
+      // Apply the updater so useWorkflowSnapshot's isLoading transitions are
+      // visible to subsequent reads in the same render cycle. Without this
+      // the mock would silently swallow side effects.
+      mockState = updater(mockState);
+      mockSetState(mockState);
+    },
   }),
 }));
 

--- a/apps/web/hooks/use-tasks.test.ts
+++ b/apps/web/hooks/use-tasks.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const mockHydrate = vi.fn();
+const mockSetState = vi.fn();
+const mockFetchWorkflowSnapshot = vi.fn();
+
+type Task = { id: string; title: string };
+type MockState = {
+  connection: { status: string };
+  kanban: { workflowId: string | null; tasks: Task[]; steps: unknown[]; isLoading?: boolean };
+  hydrate: typeof mockHydrate;
+};
+
+let mockState: MockState = {
+  connection: { status: "connected" },
+  kanban: { workflowId: null, tasks: [], steps: [] },
+  hydrate: mockHydrate,
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: MockState) => unknown) => selector(mockState),
+  useAppStoreApi: () => ({
+    getState: () => mockState,
+    setState: (updater: (s: MockState) => MockState) => mockSetState(updater(mockState)),
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchWorkflowSnapshot: (...args: unknown[]) => mockFetchWorkflowSnapshot(...args),
+}));
+
+vi.mock("@/lib/ssr/mapper", () => ({
+  snapshotToState: (snapshot: unknown) => ({ snapshot }),
+}));
+
+import { useTasks } from "./use-tasks";
+
+function setMockState(patch: Partial<MockState["kanban"]> & { workflowId?: string | null }) {
+  mockState = {
+    ...mockState,
+    kanban: { ...mockState.kanban, ...patch },
+  };
+}
+
+describe("useTasks — loading and matching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Never resolves so we observe pre-resolution loading state.
+    mockFetchWorkflowSnapshot.mockReturnValue(new Promise(() => {}));
+    mockState = {
+      connection: { status: "connected" },
+      kanban: { workflowId: null, tasks: [], steps: [], isLoading: false },
+      hydrate: mockHydrate,
+    };
+  });
+
+  it("returns empty list and not-loading when workflowId is null", () => {
+    const { result } = renderHook(() => useTasks(null));
+    expect(result.current.tasks).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("reports loading once useWorkflowSnapshot has flipped kanban.isLoading", () => {
+    setMockState({ workflowId: null, isLoading: true });
+    const { result } = renderHook(() => useTasks("wf-1"));
+    expect(result.current.tasks).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("does not report loading when fetch has settled but workflowId mismatches", () => {
+    // Simulates a failed snapshot fetch — `kanban.isLoading` is back to false
+    // and `kanban.workflowId` never advanced to the requested id. Caller
+    // shows the empty-state UI rather than an infinite skeleton.
+    setMockState({ workflowId: null, isLoading: false });
+    const { result } = renderHook(() => useTasks("wf-1"));
+    expect(result.current.tasks).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("returns tasks and not-loading once kanban.workflowId matches", () => {
+    setMockState({
+      workflowId: "wf-1",
+      tasks: [
+        { id: "t1", title: "One" },
+        { id: "t2", title: "Two" },
+      ],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useTasks("wf-1"));
+    expect(result.current.tasks).toHaveLength(2);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("filters out tasks that belong to a different workflow snapshot", () => {
+    setMockState({
+      workflowId: "wf-other",
+      tasks: [{ id: "t1", title: "One" }],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useTasks("wf-1"));
+    expect(result.current.tasks).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("respects kanban.isLoading even when workflowId already matches", () => {
+    setMockState({
+      workflowId: "wf-1",
+      tasks: [{ id: "t1", title: "One" }],
+      isLoading: true,
+    });
+    const { result } = renderHook(() => useTasks("wf-1"));
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/apps/web/hooks/use-tasks.ts
+++ b/apps/web/hooks/use-tasks.ts
@@ -6,14 +6,17 @@ export function useTasks(workflowId: string | null) {
   useWorkflowSnapshot(workflowId);
 
   const kanbanWorkflowId = useAppStore((state) => state.kanban.workflowId);
+  const kanbanIsLoading = useAppStore((state) => state.kanban.isLoading ?? false);
   const tasks = useAppStore((state) => state.kanban.tasks);
 
-  const workflowTasks = useMemo(() => {
-    if (!workflowId || kanbanWorkflowId !== workflowId) {
-      return [];
-    }
-    return tasks;
-  }, [workflowId, kanbanWorkflowId, tasks]);
+  const matchesActive = !!workflowId && kanbanWorkflowId === workflowId;
+  const workflowTasks = useMemo(() => (matchesActive ? tasks : []), [matchesActive, tasks]);
 
-  return { tasks: workflowTasks };
+  // Skeleton shows only while a snapshot fetch is actively in flight. Once the
+  // fetch settles (success or failure) `kanban.isLoading` drops to false, so
+  // a failed fetch falls back to the empty-state UI rather than spinning
+  // forever. See `useWorkflowSnapshot` for the in-flight signal.
+  const isLoading = !!workflowId && kanbanIsLoading;
+
+  return { tasks: workflowTasks, isLoading };
 }

--- a/apps/web/hooks/use-tasks.ts
+++ b/apps/web/hooks/use-tasks.ts
@@ -12,10 +12,7 @@ export function useTasks(workflowId: string | null) {
   const matchesActive = !!workflowId && kanbanWorkflowId === workflowId;
   const workflowTasks = useMemo(() => (matchesActive ? tasks : []), [matchesActive, tasks]);
 
-  // Skeleton shows only while a snapshot fetch is actively in flight. Once the
-  // fetch settles (success or failure) `kanban.isLoading` drops to false, so
-  // a failed fetch falls back to the empty-state UI rather than spinning
-  // forever. See `useWorkflowSnapshot` for the in-flight signal.
+  // Loading only while a snapshot fetch is in-flight; settles to false on success/error to avoid an infinite skeleton.
   const isLoading = !!workflowId && kanbanIsLoading;
 
   return { tasks: workflowTasks, isLoading };

--- a/apps/web/hooks/use-workflow-snapshot.test.ts
+++ b/apps/web/hooks/use-workflow-snapshot.test.ts
@@ -95,4 +95,31 @@ describe("useWorkflowSnapshot — kanban.isLoading", () => {
     expect(mockFetchWorkflowSnapshot).not.toHaveBeenCalled();
     expect(mockState.kanban.isLoading).toBe(false);
   });
+
+  it("does not clear isLoading when an old fetch settles after workflowId changes", async () => {
+    // First fetch never settles synchronously — we resolve it manually
+    // *after* re-rendering with a new workflowId, simulating the race where
+    // the user switches workflows mid-fetch.
+    let resolveFirst!: (snapshot: { steps: unknown[]; tasks: unknown[] }) => void;
+    const firstFetch = new Promise<{ steps: unknown[]; tasks: unknown[] }>((r) => {
+      resolveFirst = r;
+    });
+    const secondFetch = new Promise<{ steps: unknown[]; tasks: unknown[] }>(() => {});
+    mockFetchWorkflowSnapshot.mockReturnValueOnce(firstFetch).mockReturnValueOnce(secondFetch);
+
+    const { rerender } = renderHook(({ id }: { id: string | null }) => useWorkflowSnapshot(id), {
+      initialProps: { id: "wf-1" as string | null },
+    });
+    expect(mockState.kanban.isLoading).toBe(true);
+
+    // User switches to wf-2 before wf-1 finishes loading
+    rerender({ id: "wf-2" });
+    expect(mockState.kanban.isLoading).toBe(true);
+
+    // Old fetch lands now; its `.finally` must not clear the flag the new
+    // effect just set.
+    resolveFirst({ steps: [], tasks: [] });
+    await waitFor(() => expect(mockHydrate).not.toHaveBeenCalled());
+    expect(mockState.kanban.isLoading).toBe(true);
+  });
 });

--- a/apps/web/hooks/use-workflow-snapshot.test.ts
+++ b/apps/web/hooks/use-workflow-snapshot.test.ts
@@ -127,10 +127,13 @@ describe("useWorkflowSnapshot — kanban.isLoading", () => {
     rerender({ id: "wf-2" });
     expect(mockState.kanban.isLoading).toBe(true);
 
-    // Old fetch lands now; its `.finally` must not clear the flag the new
-    // effect just set.
+    // Old fetch lands now; flush its .then/.finally microtask chain so we
+    // can assert the negatives without relying on waitFor (which would
+    // resolve immediately for never-true assertions).
     resolveFirst({ steps: [], tasks: [] });
-    await waitFor(() => expect(mockHydrate).not.toHaveBeenCalled());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockHydrate).not.toHaveBeenCalled();
     expect(mockState.kanban.isLoading).toBe(true);
   });
 });

--- a/apps/web/hooks/use-workflow-snapshot.test.ts
+++ b/apps/web/hooks/use-workflow-snapshot.test.ts
@@ -90,6 +90,17 @@ describe("useWorkflowSnapshot — kanban.isLoading", () => {
     expect(mockState.kanban.isLoading).toBe(false);
   });
 
+  it("does not clear isLoading on settle when it didn't raise the flag (already-hydrated re-fetch)", async () => {
+    // Mimic a workspace switch having set isLoading=true after the snapshot
+    // hydrated for this workflowId. A silent re-fetch (e.g. WS reconnect)
+    // must not collapse that skeleton.
+    resetState({ workflowId: "wf-1", isLoading: true });
+    mockFetchWorkflowSnapshot.mockResolvedValue({ steps: [], tasks: [] });
+    renderHook(() => useWorkflowSnapshot("wf-1"));
+    await waitFor(() => expect(mockHydrate).toHaveBeenCalled());
+    expect(mockState.kanban.isLoading).toBe(true);
+  });
+
   it("does nothing when workflowId is null", () => {
     renderHook(() => useWorkflowSnapshot(null));
     expect(mockFetchWorkflowSnapshot).not.toHaveBeenCalled();

--- a/apps/web/hooks/use-workflow-snapshot.test.ts
+++ b/apps/web/hooks/use-workflow-snapshot.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const mockHydrate = vi.fn();
+const mockFetchWorkflowSnapshot = vi.fn();
+const mockSetState = vi.fn();
+
+type MockKanban = {
+  workflowId: string | null;
+  tasks: unknown[];
+  steps: unknown[];
+  isLoading?: boolean;
+};
+type MockState = {
+  connection: { status: string };
+  kanban: MockKanban;
+  hydrate: typeof mockHydrate;
+};
+
+let mockState: MockState = {
+  connection: { status: "connected" },
+  kanban: { workflowId: null, tasks: [], steps: [], isLoading: false },
+  hydrate: mockHydrate,
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: MockState) => unknown) => selector(mockState),
+  useAppStoreApi: () => ({
+    getState: () => mockState,
+    setState: (updater: (s: MockState) => MockState) => {
+      const next = updater(mockState);
+      mockSetState(next);
+      mockState = next;
+    },
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchWorkflowSnapshot: (...args: unknown[]) => mockFetchWorkflowSnapshot(...args),
+}));
+
+vi.mock("@/lib/ssr/mapper", () => ({
+  snapshotToState: (snapshot: unknown) => ({ snapshot }),
+}));
+
+import { useWorkflowSnapshot } from "./use-workflow-snapshot";
+
+function resetState(kanban: Partial<MockKanban> = {}) {
+  vi.clearAllMocks();
+  mockState = {
+    connection: { status: "connected" },
+    kanban: {
+      workflowId: null,
+      tasks: [],
+      steps: [],
+      isLoading: false,
+      ...kanban,
+    },
+    hydrate: mockHydrate,
+  };
+}
+
+describe("useWorkflowSnapshot — kanban.isLoading", () => {
+  beforeEach(() => resetState());
+
+  it("flips isLoading true while a fetch for an un-hydrated workflow is in flight", () => {
+    mockFetchWorkflowSnapshot.mockReturnValue(new Promise(() => {}));
+    renderHook(() => useWorkflowSnapshot("wf-1"));
+    expect(mockState.kanban.isLoading).toBe(true);
+  });
+
+  it("flips isLoading back to false after the fetch resolves", async () => {
+    mockFetchWorkflowSnapshot.mockResolvedValue({ steps: [], tasks: [] });
+    renderHook(() => useWorkflowSnapshot("wf-1"));
+    await waitFor(() => expect(mockHydrate).toHaveBeenCalled());
+    await waitFor(() => expect(mockState.kanban.isLoading).toBe(false));
+  });
+
+  it("flips isLoading back to false after the fetch rejects", async () => {
+    mockFetchWorkflowSnapshot.mockRejectedValue(new Error("nope"));
+    renderHook(() => useWorkflowSnapshot("wf-1"));
+    await waitFor(() => expect(mockState.kanban.isLoading).toBe(false));
+    expect(mockHydrate).not.toHaveBeenCalled();
+  });
+
+  it("does not flip isLoading true if the requested workflow is already hydrated", () => {
+    resetState({ workflowId: "wf-1", isLoading: false });
+    mockFetchWorkflowSnapshot.mockReturnValue(new Promise(() => {}));
+    renderHook(() => useWorkflowSnapshot("wf-1"));
+    expect(mockState.kanban.isLoading).toBe(false);
+  });
+
+  it("does nothing when workflowId is null", () => {
+    renderHook(() => useWorkflowSnapshot(null));
+    expect(mockFetchWorkflowSnapshot).not.toHaveBeenCalled();
+    expect(mockState.kanban.isLoading).toBe(false);
+  });
+});

--- a/apps/web/hooks/use-workflow-snapshot.ts
+++ b/apps/web/hooks/use-workflow-snapshot.ts
@@ -20,8 +20,9 @@ export function useWorkflowSnapshot(workflowId: string | null) {
         store.getState().hydrate(snapshotToState(snapshot));
       })
       .catch((error) => {
-        // Surface the failure so users see it rather than an indefinite empty
-        // list. Retry happens on WS reconnect.
+        // Suppress noise from a superseded fetch — only the active effect
+        // should surface the failure. Retry happens on WS reconnect.
+        if (cancelled) return;
         console.warn("[useWorkflowSnapshot] failed to load snapshot:", error);
       })
       .finally(() => {

--- a/apps/web/hooks/use-workflow-snapshot.ts
+++ b/apps/web/hooks/use-workflow-snapshot.ts
@@ -25,9 +25,11 @@ export function useWorkflowSnapshot(workflowId: string | null) {
         console.warn("[useWorkflowSnapshot] failed to load snapshot:", error);
       })
       .finally(() => {
-        // Always settle the loading flag, even after unmount — otherwise the
-        // sheet/sidebar can be stuck on a skeleton if the component unmounted
-        // mid-fetch.
+        // Skip when the effect was superseded — otherwise an in-flight fetch
+        // for an old workflowId would clear the loading flag the new effect
+        // just set, briefly flashing the empty-state UI. The next effect's
+        // finally settles isLoading for the active workflow.
+        if (cancelled) return;
         store.setState((state) => ({ ...state, kanban: { ...state.kanban, isLoading: false } }));
       });
     return () => {

--- a/apps/web/hooks/use-workflow-snapshot.ts
+++ b/apps/web/hooks/use-workflow-snapshot.ts
@@ -10,8 +10,8 @@ export function useWorkflowSnapshot(workflowId: string | null) {
   useEffect(() => {
     if (!workflowId) return;
     let cancelled = false;
-    const alreadyHydrated = store.getState().kanban.workflowId === workflowId;
-    if (!alreadyHydrated) {
+    const setLoading = store.getState().kanban.workflowId !== workflowId;
+    if (setLoading) {
       store.setState((state) => ({ ...state, kanban: { ...state.kanban, isLoading: true } }));
     }
     fetchWorkflowSnapshot(workflowId, { cache: "no-store" })
@@ -25,11 +25,11 @@ export function useWorkflowSnapshot(workflowId: string | null) {
         console.warn("[useWorkflowSnapshot] failed to load snapshot:", error);
       })
       .finally(() => {
-        // Skip when the effect was superseded — otherwise an in-flight fetch
-        // for an old workflowId would clear the loading flag the new effect
-        // just set, briefly flashing the empty-state UI. The next effect's
-        // finally settles isLoading for the active workflow.
-        if (cancelled) return;
+        // Only clear what this effect set. Skipping when cancelled avoids
+        // collapsing the new effect's skeleton; skipping when !setLoading
+        // avoids stomping on a flag a concurrent caller (e.g. workspace
+        // switch) raised independently.
+        if (cancelled || !setLoading) return;
         store.setState((state) => ({ ...state, kanban: { ...state.kanban, isLoading: false } }));
       });
     return () => {

--- a/apps/web/hooks/use-workflow-snapshot.ts
+++ b/apps/web/hooks/use-workflow-snapshot.ts
@@ -9,12 +9,29 @@ export function useWorkflowSnapshot(workflowId: string | null) {
 
   useEffect(() => {
     if (!workflowId) return;
+    let cancelled = false;
+    const alreadyHydrated = store.getState().kanban.workflowId === workflowId;
+    if (!alreadyHydrated) {
+      store.setState((state) => ({ ...state, kanban: { ...state.kanban, isLoading: true } }));
+    }
     fetchWorkflowSnapshot(workflowId, { cache: "no-store" })
       .then((snapshot) => {
+        if (cancelled) return;
         store.getState().hydrate(snapshotToState(snapshot));
       })
-      .catch(() => {
-        // Ignore snapshot errors — will retry on WS reconnect.
+      .catch((error) => {
+        // Surface the failure so users see it rather than an indefinite empty
+        // list. Retry happens on WS reconnect.
+        console.warn("[useWorkflowSnapshot] failed to load snapshot:", error);
+      })
+      .finally(() => {
+        // Always settle the loading flag, even after unmount — otherwise the
+        // sheet/sidebar can be stuck on a skeleton if the component unmounted
+        // mid-fetch.
+        store.setState((state) => ({ ...state, kanban: { ...state.kanban, isLoading: false } }));
       });
+    return () => {
+      cancelled = true;
+    };
   }, [workflowId, store, connectionStatus]);
 }

--- a/apps/web/hooks/use-workflow-snapshot.ts
+++ b/apps/web/hooks/use-workflow-snapshot.ts
@@ -20,16 +20,12 @@ export function useWorkflowSnapshot(workflowId: string | null) {
         store.getState().hydrate(snapshotToState(snapshot));
       })
       .catch((error) => {
-        // Suppress noise from a superseded fetch — only the active effect
-        // should surface the failure. Retry happens on WS reconnect.
+        // Suppress superseded-fetch noise; retry happens on WS reconnect.
         if (cancelled) return;
         console.warn("[useWorkflowSnapshot] failed to load snapshot:", error);
       })
       .finally(() => {
-        // Only clear what this effect set. Skipping when cancelled avoids
-        // collapsing the new effect's skeleton; skipping when !setLoading
-        // avoids stomping on a flag a concurrent caller (e.g. workspace
-        // switch) raised independently.
+        // Only clear the flag this effect raised; skip when cancelled or when a concurrent caller owns it.
         if (cancelled || !setLoading) return;
         store.setState((state) => ({ ...state, kanban: { ...state.kanban, isLoading: false } }));
       });


### PR DESCRIPTION
## Summary
- Mobile task page sheet showed "No tasks yet." instead of a loading state when the workflow snapshot hadn't hydrated `state.kanban` (and stayed that way silently on fetch failure).
- `useWorkflowSnapshot` now flips `kanban.isLoading=true` while a fetch for an un-hydrated workflow is in flight and back to `false` on settle (cancel-safe). Errors surface via `console.warn` instead of the prior swallow.
- `useTasks` returns `{ tasks, isLoading }`; sheet's `useSheetData` exposes `tasksLoading` and feeds it into the existing `TaskSwitcher` skeleton.

## Test plan
- [x] `pnpm vitest run hooks/use-tasks.test.ts hooks/use-workflow-snapshot.test.ts` — 11 new tests, all pass
- [x] Full `pnpm --filter @kandev/web test` — 1242 / 1242 pass
- [x] `tsc --noEmit` clean
- [x] `pnpm --filter @kandev/web lint` clean
- [ ] Manual mobile-viewport repro: open `/t/[taskId]` directly, tap hamburger → sheet should skeleton then list, not "No tasks yet."
- [ ] Manual mobile-viewport repro with snapshot endpoint stubbed to 5xx → empty-state copy + console warning, no infinite skeleton