### PR TITLE
fix: unify Kandev branding

### DIFF
--- a/apps/backend/internal/health/checks.go
+++ b/apps/backend/internal/health/checks.go
@@ -153,7 +153,7 @@ func (c *AgentChecker) Check(ctx context.Context) []Issue {
 			ID:       "no_agents",
 			Category: "agents",
 			Title:    "No AI agents detected",
-			Message:  "Install an AI coding agent (e.g. Claude Code, Codex) to start using KanDev.",
+			Message:  "Install an AI coding agent (e.g. Claude Code, Codex) to start using Kandev.",
 			Severity: SeverityWarning,
 			FixURL:   "/settings/agents",
 			FixLabel: "Configure Agents",

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -17,7 +17,7 @@ import { SidebarViewsSyncBridge } from "@/components/sidebar-views-sync-bridge";
 import { LogBufferBridge } from "@/components/log-buffer-bridge";
 
 export const metadata: Metadata = {
-  title: "KanDev - AI Kanban",
+  title: "Kandev - AI Kanban",
   description: "AI-powered workflow management for developers",
 };
 
@@ -43,7 +43,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <meta name="apple-mobile-web-app-title" content="KanDev" />
+        <meta name="apple-mobile-web-app-title" content="Kandev" />
       </head>
       <body className="antialiased font-sans">
         {apiPort || debugMode ? (

--- a/apps/web/app/manifest.json
+++ b/apps/web/app/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "KanDev",
-  "short_name": "KanDev",
+  "name": "Kandev",
+  "short_name": "Kandev",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",

--- a/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
+++ b/apps/web/app/settings/agents/[agentId]/profile-mcp-config-card.tsx
@@ -191,7 +191,7 @@ function McpServersEditor({
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="text-xs rounded-full border border-primary/50 bg-primary/10 px-2 py-1 text-primary">
-              ✓ KanDev MCP
+              ✓ Kandev MCP
             </span>
           </TooltipTrigger>
           <TooltipContent side="bottom" className="max-w-[320px] text-xs">

--- a/apps/web/app/stats/stats-page-client.tsx
+++ b/apps/web/app/stats/stats-page-client.tsx
@@ -293,7 +293,7 @@ function buildStatsSummary(
     ? `${git_stats.total_commits} commits, +${git_stats.total_insertions.toLocaleString()}/-${git_stats.total_deletions.toLocaleString()}`
     : "no git activity";
   return [
-    `*KanDev Stats — ${rangeLabel}*`,
+    `*Kandev Stats — ${rangeLabel}*`,
     `- Tasks: ${global.total_tasks} total (${global.completed_tasks} done, ${global.in_progress_tasks} in progress) · ${completion} completion`,
     `- Completed (${rangeLabel}): ${completedInRange}`,
     `- Time: ${formatDuration(global.total_duration_ms)} total · ${formatDuration(global.avg_duration_ms_per_task)} avg/task`,

--- a/apps/web/components/github/github-status.tsx
+++ b/apps/web/components/github/github-status.tsx
@@ -109,7 +109,7 @@ function TokenConfigForm({ onSuccess }: { onSuccess: () => void }) {
       <p className="text-xs text-muted-foreground">
         Create a{" "}
         <a
-          href="https://github.com/settings/tokens/new?scopes=repo,read:org&description=KanDev"
+          href="https://github.com/settings/tokens/new?scopes=repo,read:org&description=Kandev"
           target="_blank"
           rel="noopener noreferrer"
           className="underline cursor-pointer"

--- a/apps/web/components/improve-kandev-dialog-create.tsx
+++ b/apps/web/components/improve-kandev-dialog-create.tsx
@@ -267,7 +267,7 @@ function BootstrapStatusSlot({
               </button>
             </TooltipTrigger>
             <TooltipContent side="top" className="max-w-xs text-xs leading-relaxed">
-              KanDev keeps a small in-memory ring buffer of the most recent backend logs and browser
+              Kandev keeps a small in-memory ring buffer of the most recent backend logs and browser
               console events. When enabled, those logs are written to a temporary folder on your
               machine, and the file paths are appended to the task description so the agent can read
               them while investigating.

--- a/apps/web/components/improve-kandev-dialog.tsx
+++ b/apps/web/components/improve-kandev-dialog.tsx
@@ -251,7 +251,7 @@ function IntroExplanation({
   return (
     <div className="space-y-5 py-2">
       <p className="text-sm leading-relaxed text-muted-foreground">
-        KanDev is open source, and you can help make it better.
+        Kandev is open source, and you can help make it better.
       </p>
 
       <p className="text-sm leading-relaxed text-muted-foreground">

--- a/apps/web/components/kanban/kanban-header.tsx
+++ b/apps/web/components/kanban/kanban-header.tsx
@@ -109,7 +109,7 @@ function ImproveKandevTopbarButton({
             <IconStethoscope className="h-4 w-4" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>Improve KanDev</TooltipContent>
+        <TooltipContent>Improve Kandev</TooltipContent>
       </Tooltip>
       <ImproveKandevDialog
         open={open}

--- a/apps/web/components/page-topbar.tsx
+++ b/apps/web/components/page-topbar.tsx
@@ -21,7 +21,7 @@ type PageTopbarProps = {
   icon?: ReactNode;
   /** Where the back link navigates to (default: "/") */
   backHref?: string;
-  /** Label for the parent breadcrumb (default: "KanDev") */
+  /** Label for the parent breadcrumb (default: "Kandev") */
   backLabel?: string;
   /** Optional content rendered before the breadcrumb */
   leading?: ReactNode;
@@ -43,7 +43,7 @@ export const PageTopbar = forwardRef<HTMLElement, PageTopbarProps>(function Page
     subtitle,
     icon,
     backHref = "/",
-    backLabel = "KanDev",
+    backLabel = "Kandev",
     leading,
     center,
     leftActions,

--- a/apps/web/components/settings/settings-app-sidebar.tsx
+++ b/apps/web/components/settings/settings-app-sidebar.tsx
@@ -301,7 +301,7 @@ export function SettingsAppSidebar() {
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
               <Link href="/">
-                <span className="text-2xl font-bold">KanDev</span>
+                <span className="text-2xl font-bold">Kandev</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/apps/web/components/settings/settings-layout-client.tsx
+++ b/apps/web/components/settings/settings-layout-client.tsx
@@ -10,7 +10,7 @@ export function SettingsLayoutClient({ children }: { children: React.ReactNode }
   const pathname = usePathname();
   const isAgentDetail = pathname.startsWith("/settings/agents/") && pathname !== "/settings/agents";
   const backHref = isAgentDetail ? "/settings/agents" : "/";
-  const backLabel = isAgentDetail ? "Agents" : "KanDev";
+  const backLabel = isAgentDetail ? "Agents" : "Kandev";
   const title = isAgentDetail ? "Agent" : "Settings";
 
   return (

--- a/apps/web/components/settings/sprites-settings.tsx
+++ b/apps/web/components/settings/sprites-settings.tsx
@@ -193,7 +193,7 @@ export function SpritesInstancesCard({ secretId }: { secretId?: string }) {
           <div>
             <CardTitle>Running Sprites</CardTitle>
             <CardDescription>
-              Active KanDev sprites. Sprites are destroyed when agents stop.
+              Active Kandev sprites. Sprites are destroyed when agents stop.
             </CardDescription>
           </div>
           {instances.length > 0 && (

--- a/apps/web/e2e/tests/improve-kandev.spec.ts
+++ b/apps/web/e2e/tests/improve-kandev.spec.ts
@@ -89,7 +89,7 @@ test.describe("Improve Kandev dialog", () => {
     // Intro screen
     const introDialog = testPage.getByRole("dialog", { name: "Improve Kandev" });
     await expect(introDialog).toBeVisible();
-    await expect(introDialog.getByText(/KanDev is open source/)).toBeVisible();
+    await expect(introDialog.getByText(/Kandev is open source/)).toBeVisible();
     await expect(introDialog.getByText(/forks .* to your GitHub account/)).toBeVisible();
 
     const contribute = testPage.getByTestId("improve-kandev-proceed");

--- a/apps/web/hooks/domains/kanban/use-plan-actions.test.ts
+++ b/apps/web/hooks/domains/kanban/use-plan-actions.test.ts
@@ -38,7 +38,9 @@ describe("readContextFilesMeta", () => {
   const appFilePath = "src/app.ts";
   const appFileName = "app.ts";
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("returns an empty array when the session has no context files", () => {
     mockGetState.mockReturnValue({ filesBySessionId: {} });


### PR DESCRIPTION
The product branding was split between `KanDev` in live UI surfaces and `Kandev` in docs, which made the app feel inconsistent. Display copy now uses `Kandev` consistently while stable machine identifiers remain unchanged.

## Validation

- `make fmt`
- `make typecheck test lint`
- `make build-backend build-web`
- `cd apps && pnpm --filter @kandev/web e2e -- tests/improve-kandev.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Closes #856