### PR TITLE
fix(orchestrator): keep task and session state in sync on tool-event wake

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -487,7 +487,25 @@ func (s *Service) setSessionWaitingForInput(ctx context.Context, taskID, session
 }
 
 func (s *Service) setSessionRunning(ctx context.Context, taskID, sessionID string, preloadedSession ...*models.TaskSession) {
-	s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateRunning, "", true, preloadedSession...)
+	// Resolve session up front so we can guard the task write against terminal
+	// states. updateTaskSessionState silently no-ops for terminal sessions, so
+	// without this guard a buffered tool event arriving after a CANCELLED /
+	// FAILED / COMPLETED session would still clobber tasks.state to IN_PROGRESS.
+	var session *models.TaskSession
+	if len(preloadedSession) > 0 && preloadedSession[0] != nil {
+		session = preloadedSession[0]
+	} else {
+		var err error
+		session, err = s.repo.GetTaskSession(ctx, sessionID)
+		if err != nil {
+			return
+		}
+	}
+	if isTerminalSessionState(session.State) {
+		return
+	}
+
+	s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateRunning, "", true, session)
 
 	if err := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
 		s.logger.Error("failed to update task state to IN_PROGRESS",

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -221,10 +221,12 @@ func (s *Service) handleToolCallEvent(ctx context.Context, payload *lifecycle.Ag
 				zap.String("tool_call_id", payload.Data.ToolCallID))
 		}
 
-		// Allow tool calls to wake session from WAITING_FOR_INPUT
-		// This ensures that when user responds to a clarification and the agent continues,
-		// the session properly transitions to RUNNING
-		s.updateTaskSessionState(ctx, payload.TaskID, payload.SessionID, models.TaskSessionStateRunning, "", true)
+		// Allow tool calls to wake session from WAITING_FOR_INPUT.
+		// Use setSessionRunning (not updateTaskSessionState) so the task is
+		// flipped to IN_PROGRESS in lockstep — otherwise an out-of-turn tool
+		// event (e.g. a Monitor watcher firing after on_turn_complete moved
+		// the task to REVIEW) leaves session=RUNNING with task=REVIEW.
+		s.setSessionRunning(ctx, payload.TaskID, payload.SessionID)
 	}
 }
 
@@ -331,11 +333,12 @@ func (s *Service) handleToolUpdateEvent(ctx context.Context, payload *lifecycle.
 				zap.Error(err))
 		}
 
-		// Update session state for completion events
-		// Allow tool completions to wake session from WAITING_FOR_INPUT
+		// Update session state for completion events.
+		// Use setSessionRunning so the task flips to IN_PROGRESS alongside —
+		// see comment in handleToolCallEvent for the REVIEW/RUNNING split bug.
 		if payload.Data.ToolStatus == agentEventComplete || payload.Data.ToolStatus == agentEventCompleted ||
 			payload.Data.ToolStatus == "success" || payload.Data.ToolStatus == agentEventError || payload.Data.ToolStatus == agentEventFailed {
-			s.updateTaskSessionState(ctx, payload.TaskID, payload.SessionID, models.TaskSessionStateRunning, "", true)
+			s.setSessionRunning(ctx, payload.TaskID, payload.SessionID)
 		}
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -181,5 +181,32 @@ func TestToolEventsWakeSessionAndTaskTogether(t *testing.T) {
 			require.Equal(t, v1.TaskStateInProgress, taskRepo.updatedStates["t1"],
 				"task must move to IN_PROGRESS in lockstep — leaving it at REVIEW is the bug")
 		})
+
+		t.Run(tc.name+" does not clobber terminal session", func(t *testing.T) {
+			// Inverse edge case: a buffered tool event arriving after the
+			// session is already terminal must NOT silently flip tasks.state
+			// to IN_PROGRESS while the session itself stays terminal.
+			repo := setupTestRepo(t)
+			seedSession(t, repo, "t1", "s1", "step1")
+
+			session, err := repo.GetTaskSession(ctx, "s1")
+			require.NoError(t, err)
+			session.State = models.TaskSessionStateCancelled
+			require.NoError(t, repo.UpdateTaskSession(ctx, session))
+
+			taskRepo := newMockTaskRepo()
+			svc := createTestService(repo, newMockStepGetter(), taskRepo)
+			svc.messageCreator = &mockMessageCreator{}
+
+			tc.fire(svc)
+
+			updatedSession, err := repo.GetTaskSession(ctx, "s1")
+			require.NoError(t, err)
+			require.Equal(t, models.TaskSessionStateCancelled, updatedSession.State,
+				"terminal session must not be revived by a stale tool event")
+			_, taskWritten := taskRepo.updatedStates["t1"]
+			require.False(t, taskWritten,
+				"task state must not be clobbered when session is terminal")
+		})
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kandev/kandev/internal/agent/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // recordingEventBus records published events for assertions.
@@ -113,4 +115,71 @@ func TestHandleSessionModeEvent(t *testing.T) {
 
 		require.Empty(t, eb.events)
 	})
+}
+
+// TestToolEventsWakeSessionAndTaskTogether locks in the fix for the
+// REVIEW + RUNNING split: when an out-of-turn tool event (e.g. a Monitor
+// watcher firing after on_turn_complete moved the task to REVIEW) wakes
+// the session from WAITING_FOR_INPUT, the task must flip to IN_PROGRESS
+// in lockstep instead of being left at REVIEW.
+func TestToolEventsWakeSessionAndTaskTogether(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		fire func(*Service)
+	}{
+		{
+			name: "tool_call event",
+			fire: func(svc *Service) {
+				svc.handleToolCallEvent(ctx, &lifecycle.AgentStreamEventPayload{
+					TaskID:    "t1",
+					SessionID: "s1",
+					Data: &lifecycle.AgentStreamEventData{
+						ToolCallID: "tc1",
+						ToolStatus: "running",
+					},
+				})
+			},
+		},
+		{
+			name: "tool_update completion event",
+			fire: func(svc *Service) {
+				svc.handleToolUpdateEvent(ctx, &lifecycle.AgentStreamEventPayload{
+					TaskID:    "t1",
+					SessionID: "s1",
+					Data: &lifecycle.AgentStreamEventData{
+						ToolCallID: "tc1",
+						ToolStatus: agentEventComplete,
+					},
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			seedSession(t, repo, "t1", "s1", "step1")
+
+			// Simulate post-on_turn_complete state: session WAITING, task REVIEW.
+			session, err := repo.GetTaskSession(ctx, "s1")
+			require.NoError(t, err)
+			session.State = models.TaskSessionStateWaitingForInput
+			require.NoError(t, repo.UpdateTaskSession(ctx, session))
+
+			taskRepo := newMockTaskRepo()
+			svc := createTestService(repo, newMockStepGetter(), taskRepo)
+			svc.messageCreator = &mockMessageCreator{}
+
+			tc.fire(svc)
+
+			updatedSession, err := repo.GetTaskSession(ctx, "s1")
+			require.NoError(t, err)
+			require.Equal(t, models.TaskSessionStateRunning, updatedSession.State,
+				"session should be woken to RUNNING")
+			require.Equal(t, v1.TaskStateInProgress, taskRepo.updatedStates["t1"],
+				"task must move to IN_PROGRESS in lockstep — leaving it at REVIEW is the bug")
+		})
+	}
 }


### PR DESCRIPTION
Out-of-turn tool events (e.g. a `Monitor` watcher firing after `on_turn_complete` had already moved the task to `REVIEW`) used to wake `task_sessions.state` to `RUNNING` without touching `tasks.state`, leaving the task parked in `REVIEW` and surfacing as a task that "always works, never leaves state". Fix: `handleToolCallEvent` and `handleToolUpdateEvent` now use `setSessionRunning` so the task flips to `IN_PROGRESS` in lockstep.

## Validation

- `go test ./internal/orchestrator/ -count=1` (full package + new `TestToolEventsWakeSessionAndTaskTogether` regression test, which fails on the pre-fix code)
- `make -C apps/backend test lint` (full backend, 0 lint issues)
- `pnpm format`, `pnpm --filter @kandev/web lint`, `tsc --noEmit` (clean)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.