### PR TITLE
fix(logger): wire logging.outputPath from config to logger

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -133,8 +133,9 @@ func realMain() int {
 
 	// 2. Initialize logger
 	log, err := logger.NewLogger(logger.LoggingConfig{
-		Level:  cfg.Logging.Level,
-		Format: cfg.Logging.Format,
+		Level:      cfg.Logging.Level,
+		Format:     cfg.Logging.Format,
+		OutputPath: cfg.Logging.OutputPath,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)


### PR DESCRIPTION
The `logging.outputPath` setting in `config.yaml` was silently ignored because `cmd/kandev/main.go` only forwarded `Level` and `Format` to `NewLogger`, so logs always went to stdout
regardless of the configured path. Passing the field through restores the documented behavior (stdout/stderr/file path) defined in `internal/common/logger/logger.go`.

## Validation

- Set `logging.outputPath: <abs path>` in `config.yaml`, started the backend → file is created and JSON log lines are appended; nothing is written to stdout.
- Set `logging.outputPath: stdout` (and unset) → behaviour unchanged, output goes to stdout.
- `go build ./...` in `apps/backend/`.

## Possible Improvements

Low risk — three-line wiring fix touching only logger construction. No tests exist for the logger package; a small `logger_test.go` covering the `stdout` / `stderr` / file-path branches of
`NewLogger` would catch regressions like this in the future.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.