### PR TITLE
fix(web): close kanban preview when opening the edit dialog

### DIFF
--- a/apps/web/components/kanban-board.tsx
+++ b/apps/web/components/kanban-board.tsx
@@ -260,13 +260,16 @@ function useKanbanBoardSetup(
     onOpenTask,
   });
   // Close the preview panel (if open) before showing the edit dialog so the
-  // task content doesn't render alongside the dialog.
+  // task content doesn't render alongside the dialog. Destructure `handleEdit`
+  // so the dep array tracks the stable callback rather than the freshly-built
+  // `hooks` wrapper object.
+  const { handleEdit } = hooks;
   const handleEditWithCleanup = useCallback(
     (task: Task) => {
       onBeforeEdit?.();
-      hooks.handleEdit(task);
+      handleEdit(task);
     },
-    [onBeforeEdit, hooks],
+    [onBeforeEdit, handleEdit],
   );
 
   const multiSelect = useTaskMultiSelect(kanban.workflowId);

--- a/apps/web/components/kanban-board.tsx
+++ b/apps/web/components/kanban-board.tsx
@@ -136,12 +136,7 @@ function useKanbanBoardStore() {
 interface KanbanBoardProps {
   onPreviewTask?: (task: Task) => void;
   onOpenTask?: (task: Task) => void;
-  /**
-   * Fired just before the edit dialog opens. The kanban preview panel
-   * subscribes to this to close itself — otherwise the dialog renders on top
-   * of the preview, leaving the task content visible behind the dialog and
-   * making the page look broken ("everything out of place").
-   */
+  /** Fired before the edit dialog opens so the preview panel can close itself. */
   onBeforeEdit?: () => void;
 }
 
@@ -259,10 +254,7 @@ function useKanbanBoardSetup(
     onPreviewTask,
     onOpenTask,
   });
-  // Close the preview panel (if open) before showing the edit dialog so the
-  // task content doesn't render alongside the dialog. Destructure `handleEdit`
-  // so the dep array tracks the stable callback rather than the freshly-built
-  // `hooks` wrapper object.
+  // Close preview before the edit dialog opens; destructure for stable useCallback dep.
   const { handleEdit } = hooks;
   const handleEditWithCleanup = useCallback(
     (task: Task) => {

--- a/apps/web/components/kanban-board.tsx
+++ b/apps/web/components/kanban-board.tsx
@@ -136,6 +136,13 @@ function useKanbanBoardStore() {
 interface KanbanBoardProps {
   onPreviewTask?: (task: Task) => void;
   onOpenTask?: (task: Task) => void;
+  /**
+   * Fired just before the edit dialog opens. The kanban preview panel
+   * subscribes to this to close itself — otherwise the dialog renders on top
+   * of the preview, leaving the task content visible behind the dialog and
+   * making the page look broken ("everything out of place").
+   */
+  onBeforeEdit?: () => void;
 }
 
 function useKanbanBoardHooks(
@@ -227,6 +234,7 @@ function useMultiSelectDerived(
 function useKanbanBoardSetup(
   onPreviewTask: KanbanBoardProps["onPreviewTask"],
   onOpenTask: KanbanBoardProps["onOpenTask"],
+  onBeforeEdit: KanbanBoardProps["onBeforeEdit"],
 ) {
   const router = useRouter();
   const { isMobile } = useResponsiveBreakpoint();
@@ -251,6 +259,15 @@ function useKanbanBoardSetup(
     onPreviewTask,
     onOpenTask,
   });
+  // Close the preview panel (if open) before showing the edit dialog so the
+  // task content doesn't render alongside the dialog.
+  const handleEditWithCleanup = useCallback(
+    (task: Task) => {
+      onBeforeEdit?.();
+      hooks.handleEdit(task);
+    },
+    [onBeforeEdit, hooks],
+  );
 
   const multiSelect = useTaskMultiSelect(kanban.workflowId);
   const { isMultiSelectMode, toggleSelect } = multiSelect;
@@ -299,6 +316,7 @@ function useKanbanBoardSetup(
     searchQuery,
     setSearchQuery,
     ...hooks,
+    handleEdit: handleEditWithCleanup,
     ...automation,
     handleOpenTask,
     handleCardClick: handleCardClickOrSelect,
@@ -310,8 +328,8 @@ function useKanbanBoardSetup(
   };
 }
 
-export function KanbanBoard({ onPreviewTask, onOpenTask }: KanbanBoardProps = {}) {
-  const s = useKanbanBoardSetup(onPreviewTask, onOpenTask);
+export function KanbanBoard({ onPreviewTask, onOpenTask, onBeforeEdit }: KanbanBoardProps = {}) {
+  const s = useKanbanBoardSetup(onPreviewTask, onOpenTask, onBeforeEdit);
 
   if (!s.isMounted) {
     return <div className="h-dvh w-full bg-background" />;

--- a/apps/web/components/kanban-card-menu-items.tsx
+++ b/apps/web/components/kanban-card-menu-items.tsx
@@ -360,6 +360,9 @@ function ContextEntry({ entry }: { entry: KanbanCardMenuEntry }) {
       data-testid={entry.testId}
       disabled={entry.disabled}
       className={entry.destructive ? "text-destructive focus:text-destructive" : undefined}
+      // Same React-portal-bubbling guard as DropdownEntry: without this the
+      // click leaks to the underlying card and triggers a task-page navigate.
+      onClick={(event) => event.stopPropagation()}
       onSelect={() => {
         if (!entry.disabled) entry.onSelect?.();
       }}
@@ -402,6 +405,10 @@ function DropdownEntry({ entry }: { entry: KanbanCardMenuEntry }) {
       data-testid={entry.testId}
       disabled={entry.disabled}
       className={entry.destructive ? "text-destructive focus:text-destructive" : undefined}
+      // React events bubble through the React tree even from a portal, so
+      // without this the click propagates up to the kanban card's onClick
+      // and navigates to the task page right after Archive / Delete fire.
+      onClick={(event) => event.stopPropagation()}
       onSelect={(event) => {
         event.stopPropagation();
         if (!entry.disabled) entry.onSelect?.();

--- a/apps/web/components/kanban-card-menu-items.tsx
+++ b/apps/web/components/kanban-card-menu-items.tsx
@@ -360,8 +360,7 @@ function ContextEntry({ entry }: { entry: KanbanCardMenuEntry }) {
       data-testid={entry.testId}
       disabled={entry.disabled}
       className={entry.destructive ? "text-destructive focus:text-destructive" : undefined}
-      // Same React-portal-bubbling guard as DropdownEntry: without this the
-      // click leaks to the underlying card and triggers a task-page navigate.
+      // React events bubble through the React tree even from a portal — stop here so the card's onClick doesn't navigate.
       onClick={(event) => event.stopPropagation()}
       onSelect={() => {
         if (!entry.disabled) entry.onSelect?.();
@@ -405,9 +404,7 @@ function DropdownEntry({ entry }: { entry: KanbanCardMenuEntry }) {
       data-testid={entry.testId}
       disabled={entry.disabled}
       className={entry.destructive ? "text-destructive focus:text-destructive" : undefined}
-      // React events bubble through the React tree even from a portal, so
-      // without this the click propagates up to the kanban card's onClick
-      // and navigates to the task page right after Archive / Delete fire.
+      // React events bubble through the React tree even from a portal — stop here so the card's onClick doesn't navigate.
       onClick={(event) => event.stopPropagation()}
       onSelect={(event) => {
         event.stopPropagation();

--- a/apps/web/components/kanban-with-preview.tsx
+++ b/apps/web/components/kanban-with-preview.tsx
@@ -316,7 +316,11 @@ function FloatingPreviewLayout({
   return (
     <>
       <div className="flex-1 overflow-hidden" style={{ width: `${kanbanWidth}px` }}>
-        <KanbanBoard onPreviewTask={onPreviewTask} onOpenTask={onNavigateToTask} />
+        <KanbanBoard
+          onPreviewTask={onPreviewTask}
+          onOpenTask={onNavigateToTask}
+          onBeforeEdit={onClose}
+        />
       </div>
       <div
         className="fixed inset-0 bg-black/30 z-30"
@@ -362,7 +366,11 @@ function InlinePreviewLayout({
   return (
     <div className="flex-1 flex overflow-hidden">
       <div className="overflow-hidden" style={{ width: `${kanbanWidth}px` }}>
-        <KanbanBoard onPreviewTask={onPreviewTask} onOpenTask={onNavigateToTask} />
+        <KanbanBoard
+          onPreviewTask={onPreviewTask}
+          onOpenTask={onNavigateToTask}
+          onBeforeEdit={onClose}
+        />
       </div>
       {isOpen && (
         <div


### PR DESCRIPTION
Editing a backlog task from the kanban dropdown left the page in a broken state — both because the preview panel rendered alongside the dialog, and because clicking Archive or Delete bubbled up through React's portal tree to the underlying card's onClick and navigated to the task page instead of opening a confirm dialog.

## Root cause

Two distinct bugs surfacing through the same dropdown menu:

1. **Preview / dialog overlap.** The kanban preview panel renders at z-40; the dialog overlay at z-50. The overlap has existed since the preview was introduced in commit `84252719` (2026-01-15), but `backdrop-blur-xs` on the dialog overlay masked it. PR #761 ("feat: refine workbench chrome", 2026-05-01) dropped the blur in favour of `bg-background/70`, which makes the preview content clearly visible behind the dialog — "everything out of place".
2. **Click leaks through the React tree from a portal.** React's synthetic events bubble through the React tree even when the source element is rendered in a portal, so clicking a `DropdownMenuItem` propagated up to the `Card`'s `onClick` and triggered `router.push(linkToTask(id))`. Edit happened to look fine because its `Dialog` mounted at the board level; Archive / Delete navigated away before their confirm dialog could render.

## Fix

- `kanban-board.tsx` + `kanban-with-preview.tsx`: new `onBeforeEdit` callback fires before the edit dialog opens; the preview panel uses it to call `close()`.
- `kanban-card-menu-items.tsx`: `onClick={(e) => e.stopPropagation()}` on each `DropdownMenuItem` and `ContextMenuItem` stops the synthetic click from reaching the card.

## Validation

- `pnpm format`, `pnpm typecheck`, `pnpm test` (1290/1290), `pnpm lint --max-warnings 0`
- Playwright repro against a running backend: clicking Edit / Archive / Delete on a backlog card now keeps the URL on `/?workspaceId=…` and opens the dialog cleanly. Before the fix, Archive and Delete navigated straight to `/t/<id>`.
- All 10 E2E shards green in CI.

## Possible Improvements

Low risk and surface-level. The `onBeforeEdit` prop is optional so other `KanbanBoard` callers (e.g. the mobile sheet flow) keep their previous behaviour; the `stopPropagation` on menu items is the standard guard for portal-rendered children inside clickable parents.