### PR TITLE
fix(backend): list remote branches for provider-backed workspace repos

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -322,6 +322,13 @@ func startAgentInfrastructure(
 	log.Info("Repository cloner configured",
 		zap.String("base_path", cfg.RepoClone.BasePath))
 
+	// Let the task service treat the cloner's base path as an implicit
+	// allow-listed root. Without this, deploys that put the clone base
+	// outside HOME (e.g. KANDEV_REPOCLONE_BASEPATH=/data/repos in a
+	// container) fail the discoveryRoots() allow-list check and local
+	// branch listing returns nothing.
+	services.Task.SetRepoCloneLocation(repoCloner)
+
 	// ============================================
 	// ORCHESTRATOR
 	// ============================================

--- a/apps/backend/cmd/kandev/services.go
+++ b/apps/backend/cmd/kandev/services.go
@@ -93,6 +93,14 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 	linearSvc := initLinearService(dbPool, eventBus, repos.Secrets, log)
 	slackSvc := initSlackService(dbPool, repos.Secrets, log)
 
+	// Plumb GitHub branch listing into the task service so provider-backed
+	// ("Remote") repos serve branches from the GitHub API rather than relying
+	// on a local clone that may not exist yet (or ever - some executors clone
+	// inside their own container).
+	if githubSvc != nil {
+		taskSvc.SetRemoteBranchLister(githubBranchListerAdapter{svc: githubSvc})
+	}
+
 	return &Services{
 		Task:     taskSvc,
 		User:     userSvc,
@@ -378,4 +386,25 @@ func buildAgentProfileMatcher(repos *Repositories) wfmodels.AgentProfileMatcher 
 		}
 		return ""
 	}
+}
+
+// githubBranchListerAdapter bridges github.Service to the task service's
+// RemoteBranchLister interface. It maps github.RepoBranch into the task
+// service's Branch shape with Type="remote" so the dialog renders branches
+// the same way URL-mode does - bare names without an "origin/" prefix, since
+// there is no checked-out clone whose tracking config could disambiguate.
+type githubBranchListerAdapter struct {
+	svc *github.Service
+}
+
+func (a githubBranchListerAdapter) ListRepoBranches(ctx context.Context, owner, repo string) ([]taskservice.Branch, error) {
+	remote, err := a.svc.ListRepoBranches(ctx, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]taskservice.Branch, 0, len(remote))
+	for _, b := range remote {
+		out = append(out, taskservice.Branch{Name: b.Name, Type: "remote"})
+	}
+	return out, nil
 }

--- a/apps/backend/internal/task/service/repository_discovery.go
+++ b/apps/backend/internal/task/service/repository_discovery.go
@@ -58,6 +58,11 @@ var ErrPathNotAllowed = errors.New("path is not within an allowed root")
 // gitHEAD is the HEAD git ref.
 const gitHEAD = "HEAD"
 
+// sourceTypeLocal is the Repository.SourceType value for on-machine repos
+// (a path the user discovered or added manually). Provider-backed repos use
+// other values like "provider".
+const sourceTypeLocal = "local"
+
 func (s *Service) DiscoverLocalRepositories(ctx context.Context, root string) (RepositoryDiscoveryResult, error) {
 	roots := s.discoveryRoots()
 	if root != "" {
@@ -201,15 +206,22 @@ func (s *Service) ListBranchesWithCurrent(ctx context.Context, repoID, path stri
 // source_type (i.e. is provider-backed), and the provider has a registered
 // remote lister. The local-path arm of ListBranches stays untouched; this
 // only widens the answer for the existing repository-id arm.
+//
+// Errors from GetRepository propagate with handled=true so callers
+// short-circuit instead of falling through to resolveBranchListingPath,
+// which would re-issue the same DB lookup. Repo-not-found falls through.
 func (s *Service) listRemoteBranchesIfApplicable(ctx context.Context, repoID string) ([]Branch, bool, error) {
 	if repoID == "" || s.remoteBranchLister == nil {
 		return nil, false, nil
 	}
 	repo, err := s.repoEntities.GetRepository(ctx, repoID)
-	if err != nil || repo == nil {
-		return nil, false, err
+	if err != nil {
+		return nil, true, err
 	}
-	if repo.SourceType == "local" || repo.ProviderOwner == "" || repo.ProviderName == "" {
+	if repo == nil {
+		return nil, false, nil
+	}
+	if repo.SourceType == sourceTypeLocal || repo.ProviderOwner == "" || repo.ProviderName == "" {
 		return nil, false, nil
 	}
 	branches, err := s.remoteBranchLister.ListRepoBranches(ctx, repo.ProviderOwner, repo.ProviderName)

--- a/apps/backend/internal/task/service/repository_discovery.go
+++ b/apps/backend/internal/task/service/repository_discovery.go
@@ -149,7 +149,16 @@ type BranchListResult struct {
 // (by id, path resolved from the DB row) or an on-machine folder (by path
 // directly). Exactly one of `repoID` or `path` should be set; the caller
 // (the HTTP handler) validates that.
+//
+// For provider-backed workspace repos (the "Remote" badge in the UI), the
+// branches come from the remote API rather than a local clone. This makes
+// the picker work the moment a URL is added - before the orchestrator's
+// async clone finishes, and even when no clone ever happens because the
+// chosen executor runs the agent in a container that clones on its own.
 func (s *Service) ListBranches(ctx context.Context, repoID, path string) ([]Branch, error) {
+	if remote, ok, err := s.listRemoteBranchesIfApplicable(ctx, repoID); ok {
+		return remote, err
+	}
 	resolved, err := s.resolveBranchListingPath(ctx, repoID, path)
 	if err != nil {
 		return nil, err
@@ -160,6 +169,14 @@ func (s *Service) ListBranches(ctx context.Context, repoID, path string) ([]Bran
 // ListBranchesWithCurrent is ListBranches plus the current-branch readout.
 // One method so the handler resolves the path once instead of twice.
 func (s *Service) ListBranchesWithCurrent(ctx context.Context, repoID, path string) (BranchListResult, error) {
+	if remote, ok, err := s.listRemoteBranchesIfApplicable(ctx, repoID); ok {
+		if err != nil {
+			return BranchListResult{}, err
+		}
+		// No CurrentBranch for remote: there's no working tree to check.
+		// The dialog falls back to its preferred-default-branch heuristic.
+		return BranchListResult{Branches: remote}, nil
+	}
 	resolved, err := s.resolveBranchListingPath(ctx, repoID, path)
 	if err != nil {
 		return BranchListResult{}, err
@@ -174,6 +191,29 @@ func (s *Service) ListBranchesWithCurrent(ctx context.Context, repoID, path stri
 		Branches:      branches,
 		CurrentBranch: readGitCurrentBranch(resolved, s.discoveryRoots()),
 	}, nil
+}
+
+// listRemoteBranchesIfApplicable returns (branches, true, err) when the repo
+// should be answered from a remote provider, and (_, false, _) when the
+// caller should fall through to the local-path code path.
+//
+// "Applicable" means: a repository id is supplied, the repo has a non-local
+// source_type (i.e. is provider-backed), and the provider has a registered
+// remote lister. The local-path arm of ListBranches stays untouched; this
+// only widens the answer for the existing repository-id arm.
+func (s *Service) listRemoteBranchesIfApplicable(ctx context.Context, repoID string) ([]Branch, bool, error) {
+	if repoID == "" || s.remoteBranchLister == nil {
+		return nil, false, nil
+	}
+	repo, err := s.repoEntities.GetRepository(ctx, repoID)
+	if err != nil || repo == nil {
+		return nil, false, err
+	}
+	if repo.SourceType == "local" || repo.ProviderOwner == "" || repo.ProviderName == "" {
+		return nil, false, nil
+	}
+	branches, err := s.remoteBranchLister.ListRepoBranches(ctx, repo.ProviderOwner, repo.ProviderName)
+	return branches, true, err
 }
 
 // resolveBranchListingPath turns the request inputs into a validated
@@ -292,14 +332,24 @@ func pathWithinRoots(abs string, roots []string) (string, error) {
 }
 
 func (s *Service) discoveryRoots() []string {
+	var roots []string
 	if len(s.discoveryConfig.Roots) > 0 {
-		return normalizeRoots(s.discoveryConfig.Roots)
+		roots = append(roots, s.discoveryConfig.Roots...)
+	} else if home, err := os.UserHomeDir(); err == nil {
+		roots = append(roots, home)
 	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return []string{}
+	// The orchestrator clones provider-backed repos into a configurable base
+	// path. When that base path sits outside HOME (e.g. /data/repos in a
+	// container deployment) it would otherwise be rejected by the allow-list
+	// and local branch listing would silently return nothing. Adding it here
+	// keeps the allow-list narrow while still covering kandev's own clone
+	// destination.
+	if s.repoCloneLocation != nil {
+		if base, err := s.repoCloneLocation.ExpandedBasePath(); err == nil && base != "" {
+			roots = append(roots, base)
+		}
 	}
-	return []string{filepath.Clean(homeDir)}
+	return normalizeRoots(roots)
 }
 
 func (s *Service) discoveryMaxDepth() int {

--- a/apps/backend/internal/task/service/repository_discovery_test.go
+++ b/apps/backend/internal/task/service/repository_discovery_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/repository"
 )
 
@@ -636,4 +637,180 @@ func newDiscoveryService(t *testing.T, root string) *Service {
 		Roots:    []string{root},
 		MaxDepth: 6,
 	})
+}
+
+// --- listRemoteBranchesIfApplicable + discoveryRoots routing ---
+
+// stubRemoteLister captures the call args and returns canned branches/err.
+type stubRemoteLister struct {
+	branches []Branch
+	err      error
+	calls    int
+}
+
+func (s *stubRemoteLister) ListRepoBranches(_ context.Context, _, _ string) ([]Branch, error) {
+	s.calls++
+	return s.branches, s.err
+}
+
+// stubRepoErrors embeds a real RepositoryEntityRepository and overrides
+// GetRepository to return a forced error - lets us cover the DB-error
+// branch without standing up a broken sqlite.
+type stubRepoErrors struct {
+	repository.RepositoryEntityRepository
+	getErr error
+}
+
+func (s *stubRepoErrors) GetRepository(_ context.Context, _ string) (*models.Repository, error) {
+	return nil, s.getErr
+}
+
+func TestListBranches_RoutesProviderRepoToRemoteLister(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	mustCreateRepo(t, repo, &models.Repository{
+		ID:            "remote-1",
+		WorkspaceID:   "ws-1",
+		Name:          "owner/repo",
+		SourceType:    "provider",
+		Provider:      "github",
+		ProviderOwner: "owner",
+		ProviderName:  "repo",
+	})
+	lister := &stubRemoteLister{branches: []Branch{{Name: "main", Type: "remote"}, {Name: "develop", Type: "remote"}}}
+	svc.SetRemoteBranchLister(lister)
+
+	got, err := svc.ListBranches(ctx, "remote-1", "")
+	if err != nil {
+		t.Fatalf("ListBranches: %v", err)
+	}
+	if lister.calls != 1 {
+		t.Fatalf("remote lister calls = %d, want 1", lister.calls)
+	}
+	if len(got) != 2 || got[0].Name != "main" || got[1].Name != "develop" {
+		t.Fatalf("unexpected branches: %+v", got)
+	}
+}
+
+func TestListBranches_FallsThroughWhenNoRemoteListerWired(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	mustCreateRepo(t, repo, &models.Repository{
+		ID: "remote-2", WorkspaceID: "ws-1", Name: "o/r",
+		SourceType: "provider", Provider: "github", ProviderOwner: "o", ProviderName: "r",
+	})
+	// No SetRemoteBranchLister call. listRemoteBranchesIfApplicable should
+	// return ok=false and the call falls through to the local-path arm,
+	// which errors out on empty local_path.
+	_, err := svc.ListBranches(ctx, "remote-2", "")
+	if err == nil {
+		t.Fatal("expected local-path error when remote lister unwired")
+	}
+}
+
+func TestListBranches_FallsThroughForLocalSourceType(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	mustCreateRepo(t, repo, &models.Repository{
+		ID: "local-1", WorkspaceID: "ws-1", Name: "local",
+		SourceType: sourceTypeLocal, Provider: "github", ProviderOwner: "o", ProviderName: "r",
+	})
+	lister := &stubRemoteLister{branches: []Branch{{Name: "main"}}}
+	svc.SetRemoteBranchLister(lister)
+
+	// Local source-type repos must use the local-path arm even with provider
+	// info populated. local_path is empty here, so we expect an error - what
+	// matters for the test is that the remote lister is never consulted.
+	_, _ = svc.ListBranches(ctx, "local-1", "")
+	if lister.calls != 0 {
+		t.Fatalf("remote lister called for source_type=local: calls = %d", lister.calls)
+	}
+}
+
+func TestListBranches_FallsThroughOnMissingProviderInfo(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	mustCreateRepo(t, repo, &models.Repository{
+		ID: "remote-3", WorkspaceID: "ws-1", Name: "no-owner",
+		SourceType: "provider", Provider: "github", ProviderOwner: "", ProviderName: "repo",
+	})
+	lister := &stubRemoteLister{branches: []Branch{{Name: "main"}}}
+	svc.SetRemoteBranchLister(lister)
+
+	_, _ = svc.ListBranches(ctx, "remote-3", "")
+	if lister.calls != 0 {
+		t.Fatalf("remote lister called for repo with no owner: calls = %d", lister.calls)
+	}
+}
+
+func TestListBranches_PropagatesRemoteListerError(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "ws"}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	mustCreateRepo(t, repo, &models.Repository{
+		ID: "remote-4", WorkspaceID: "ws-1", Name: "o/r",
+		SourceType: "provider", Provider: "github", ProviderOwner: "o", ProviderName: "r",
+	})
+	wantErr := errors.New("rate limited")
+	svc.SetRemoteBranchLister(&stubRemoteLister{err: wantErr})
+
+	if _, err := svc.ListBranches(ctx, "remote-4", ""); !errors.Is(err, wantErr) {
+		t.Fatalf("ListBranches err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestListBranches_PropagatesGetRepositoryError(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	wrapped := &stubRepoErrors{RepositoryEntityRepository: repo, getErr: errors.New("db down")}
+	// Swap repoEntities for the wrapper to force the error path. Direct field
+	// access stays inside the package, which is fine for a white-box test.
+	svc.repoEntities = wrapped
+	svc.SetRemoteBranchLister(&stubRemoteLister{})
+
+	_, err := svc.ListBranches(context.Background(), "repo-id", "")
+	if err == nil || err.Error() != "db down" {
+		t.Fatalf("ListBranches err = %v, want db down", err)
+	}
+}
+
+// --- discoveryRoots extension ---
+
+type stubCloneLocation struct{ path string }
+
+func (s stubCloneLocation) ExpandedBasePath() (string, error) { return s.path, nil }
+
+func TestDiscoveryRoots_IncludesCloneBasePath(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	cloneDir := t.TempDir()
+	svc.SetRepoCloneLocation(stubCloneLocation{path: cloneDir})
+
+	roots := svc.discoveryRoots()
+	normalizedClone := filepath.Clean(cloneDir)
+	for _, r := range roots {
+		if r == normalizedClone {
+			return
+		}
+	}
+	t.Fatalf("clone base path %q missing from discoveryRoots %v", normalizedClone, roots)
+}
+
+func mustCreateRepo(t *testing.T, repo repository.RepositoryEntityRepository, r *models.Repository) {
+	t.Helper()
+	if err := repo.CreateRepository(context.Background(), r); err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
 }

--- a/apps/backend/internal/task/service/service.go
+++ b/apps/backend/internal/task/service/service.go
@@ -136,6 +136,8 @@ type Service struct {
 	startStepResolver   StartStepResolver
 	quickChatDir        string // Directory for quick-chat workspaces (e.g., ~/.kandev/quick-chat)
 	branchFetcher       *branchFetcher
+	remoteBranchLister  RemoteBranchLister
+	repoCloneLocation   RepoCloneLocation
 }
 
 // NewService creates a new task service
@@ -195,4 +197,33 @@ func (s *Service) SetStartStepResolver(resolver StartStepResolver) {
 // When set, ephemeral task cleanup will delete the session directory under this path.
 func (s *Service) SetQuickChatDir(dir string) {
 	s.quickChatDir = dir
+}
+
+// RemoteBranchLister fetches branches from a provider's remote (e.g. GitHub
+// API) without needing a local clone. Used by ListBranches so a repo that is
+// registered as remote ("Remote" badge in the UI) can serve branches before
+// before, or even without, the orchestrator finishing its clone.
+type RemoteBranchLister interface {
+	ListRepoBranches(ctx context.Context, owner, repo string) ([]Branch, error)
+}
+
+// SetRemoteBranchLister wires the remote branch source. Currently only GitHub
+// is plumbed; other providers can be added by extending the adapter.
+func (s *Service) SetRemoteBranchLister(lister RemoteBranchLister) {
+	s.remoteBranchLister = lister
+}
+
+// RepoCloneLocation reports the base path the orchestrator clones repos into
+// (e.g. ~/.kandev/repos or KANDEV_REPOCLONE_BASEPATH). Listing local branches
+// for a cloned repo requires that path to be allow-listed by
+// discoveryRoots(); without this hook clones to a custom basepath silently
+// fall outside the allow-list and branch listing returns no results.
+type RepoCloneLocation interface {
+	ExpandedBasePath() (string, error)
+}
+
+// SetRepoCloneLocation wires the cloner so its base path is treated as an
+// implicit discovery root.
+func (s *Service) SetRepoCloneLocation(loc RepoCloneLocation) {
+	s.repoCloneLocation = loc
 }

--- a/apps/backend/internal/task/service/service.go
+++ b/apps/backend/internal/task/service/service.go
@@ -202,7 +202,7 @@ func (s *Service) SetQuickChatDir(dir string) {
 // RemoteBranchLister fetches branches from a provider's remote (e.g. GitHub
 // API) without needing a local clone. Used by ListBranches so a repo that is
 // registered as remote ("Remote" badge in the UI) can serve branches before
-// before, or even without, the orchestrator finishing its clone.
+// or even without the orchestrator finishing its clone.
 type RemoteBranchLister interface {
 	ListRepoBranches(ctx context.Context, owner, repo string) ([]Branch, error)
 }

--- a/apps/web/components/task-create-dialog-pill.tsx
+++ b/apps/web/components/task-create-dialog-pill.tsx
@@ -282,7 +282,10 @@ export function branchToOption(b: Branch): PillOption {
   // from local branches with the same short name (e.g. "main" vs "origin/main").
   // Without the prefix, the dropdown shows two indistinguishable rows.
   const display = b.type === "remote" && b.remote ? `${b.remote}/${b.name}` : b.name;
-  const badge = b.type === "local" ? "local" : (b.remote ?? "remote");
+  // `||` (not `??`) so an empty-string `remote` falls back too. Provider-backed
+  // workspace repos (URL-added) list branches without a tracking remote, so the
+  // backend sends `remote: ""`; `??` would render an invisible empty badge.
+  const badge = b.type === "local" ? "local" : b.remote || "remote";
   return {
     value: display,
     label: display,

--- a/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
@@ -115,5 +115,8 @@ test.describe("Create-task URL flow - branches after reopen", () => {
 async function selectWorktreeExecutor(page: import("@playwright/test").Page): Promise<void> {
   const selector = page.getByTestId("executor-profile-selector");
   await selector.click();
-  await page.getByRole("option", { name: /Worktree/i }).first().click();
+  await page
+    .getByRole("option", { name: /Worktree/i })
+    .first()
+    .click();
 }

--- a/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+
+// Regression test for the user-reported bug:
+//
+//   1. Open the create-task dialog, switch to GitHub URL mode, enter a URL.
+//   2. Submit the task - the URL flow registers the repo in the workspace as
+//      a remote (provider-backed) repository, without a local clone.
+//   3. Reopen the dialog - the repo now appears in the workspace dropdown.
+//      Pre-fix: picking it showed "no branches" with the
+//      "No branches available for this repository." tooltip, because the
+//      backend tried to list branches from an empty local_path and the
+//      frontend cached the failure as a successful (empty) load.
+//
+// Fix: branch listing for a provider-backed repo now goes through the
+// GitHub API (mocked in e2e) instead of the local clone. The local clone is
+// only consulted when source_type=local. This test deliberately uses a fake
+// owner/repo so the orchestrator's background `gh repo clone` fails - that
+// keeps local_path empty, proving the remote-first path is what's serving
+// the branches.
+test.describe("Create-task URL flow - branches after reopen", () => {
+  test.describe.configure({ retries: 1 });
+
+  test("repo added via GitHub URL still lists branches when re-picked from the workspace dropdown", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(60_000);
+
+    // Fake owner/repo so the background clone in the orchestrator fails with
+    // 404 and local_path stays empty. The bug only repros when local listing
+    // can't help - that's the path the fix has to keep working.
+    const owner = "kandev-e2e-no-such-owner";
+    const repo = "kandev-e2e-no-such-repo";
+    const repoFullName = `${owner}/${repo}`;
+    const taskTitle = "URL repo reopen bug";
+
+    await apiClient.mockGitHubAddBranches(owner, repo, [
+      { name: "main" },
+      { name: "develop" },
+      { name: "feature/test" },
+    ]);
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    // ── First open: enter URL, submit task ──
+    await kanban.createTaskButton.first().click();
+    const dialog = testPage.getByTestId("create-task-dialog");
+    await expect(dialog).toBeVisible();
+
+    await testPage.getByTestId("toggle-github-url").click();
+    await testPage.getByTestId("github-url-input").fill(`https://github.com/${repoFullName}`);
+
+    await testPage.getByTestId("task-title-input").fill(taskTitle);
+    await testPage.getByTestId("task-description-input").fill("/e2e:simple-message");
+
+    const startBtn = testPage.getByTestId("submit-start-agent");
+    await expect(startBtn).toBeEnabled({ timeout: 15_000 });
+    await startBtn.click();
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // Wait for the workspace to surface the URL-added repo so the second
+    // dialog open sees it in the dropdown.
+    await expect
+      .poll(
+        async () => {
+          const res = await apiClient.rawRequest(
+            "GET",
+            `/api/v1/workspaces/${seedData.workspaceId}/repositories`,
+          );
+          const body = (await res.json()) as { repositories?: Array<{ name: string }> };
+          return (body.repositories ?? []).some((r) => r.name === repoFullName);
+        },
+        { timeout: 15_000, intervals: [200, 500, 1000] },
+      )
+      .toBe(true);
+
+    // ── Second open: pick the same repo from the workspace dropdown ──
+    await kanban.createTaskButton.first().click();
+    await expect(dialog).toBeVisible();
+
+    await testPage.getByTestId("repo-chip-trigger").first().click();
+    await testPage
+      .getByRole("option", { name: new RegExp(`^${repoFullName}\\b`) })
+      .first()
+      .click();
+
+    // The branch chip is now populated from the mocked GitHub branches even
+    // though local_path is empty. Asserting against the chip's current text
+    // tolerates whichever default branch the autoselect heuristic picks
+    // (main > master > develop); the dropdown contents are what proves the
+    // full list arrived.
+    const branchChip = testPage.getByTestId("branch-chip-trigger").first();
+    await expect(branchChip).toBeEnabled({ timeout: 10_000 });
+    await expect(branchChip).toContainText("main", { timeout: 10_000 });
+
+    // Open the dropdown and verify every mocked branch is selectable.
+    await branchChip.click();
+    for (const name of ["main", "develop", "feature/test"]) {
+      await expect(testPage.getByRole("option", { name: new RegExp(`^${name}$`) })).toBeVisible({
+        timeout: 5_000,
+      });
+    }
+  });
+});

--- a/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
@@ -45,7 +45,7 @@ test.describe("Create-task URL flow - branches after reopen", () => {
     const kanban = new KanbanPage(testPage);
     await kanban.goto();
 
-    // ── First open: enter URL, submit task ──
+    // ── First open: enter URL, pick worktree executor, submit task ──
     await kanban.createTaskButton.first().click();
     const dialog = testPage.getByTestId("create-task-dialog");
     await expect(dialog).toBeVisible();
@@ -55,6 +55,8 @@ test.describe("Create-task URL flow - branches after reopen", () => {
 
     await testPage.getByTestId("task-title-input").fill(taskTitle);
     await testPage.getByTestId("task-description-input").fill("/e2e:simple-message");
+
+    await selectWorktreeExecutor(testPage);
 
     const startBtn = testPage.getByTestId("submit-start-agent");
     await expect(startBtn).toBeEnabled({ timeout: 15_000 });
@@ -81,27 +83,37 @@ test.describe("Create-task URL flow - branches after reopen", () => {
     await kanban.createTaskButton.first().click();
     await expect(dialog).toBeVisible();
 
+    await selectWorktreeExecutor(testPage);
+
     await testPage.getByTestId("repo-chip-trigger").first().click();
     await testPage
       .getByRole("option", { name: new RegExp(`^${repoFullName}\\b`) })
       .first()
       .click();
 
-    // The branch chip is now populated from the mocked GitHub branches even
-    // though local_path is empty. Asserting against the chip's current text
-    // tolerates whichever default branch the autoselect heuristic picks
-    // (main > master > develop); the dropdown contents are what proves the
-    // full list arrived.
+    // The branch chip should become enabled once the remote-branch fetch
+    // resolves. Pre-fix this never happened: the listing returned an error
+    // and the chip stayed disabled with the "no branches" tooltip.
     const branchChip = testPage.getByTestId("branch-chip-trigger").first();
     await expect(branchChip).toBeEnabled({ timeout: 10_000 });
-    await expect(branchChip).toContainText("main", { timeout: 10_000 });
 
-    // Open the dropdown and verify every mocked branch is selectable.
+    // Open the dropdown and verify every mocked branch is present. Substring
+    // name matching (string, not regex) tolerates the "remote" badge that the
+    // pill renders alongside the branch name in the option's accessible name.
     await branchChip.click();
     for (const name of ["main", "develop", "feature/test"]) {
-      await expect(testPage.getByRole("option", { name: new RegExp(`^${name}$`) })).toBeVisible({
-        timeout: 5_000,
-      });
+      await expect(testPage.getByRole("option", { name })).toBeVisible({ timeout: 5_000 });
     }
   });
 });
+
+// Pin the executor on every dialog open. This test runs in a shard alongside
+// create-task-branch-selector specs that leave local-executor profiles
+// behind, and a stale local default trips the local-executor's
+// currentLocalBranch autoselect race. Worktree is the cleanest neutral
+// choice and exercises the same remote-branch-listing path.
+async function selectWorktreeExecutor(page: import("@playwright/test").Page): Promise<void> {
+  const selector = page.getByTestId("executor-profile-selector");
+  await selector.click();
+  await page.getByRole("option", { name: /Worktree/i }).first().click();
+}


### PR DESCRIPTION
## Summary

A repo added via the create-task dialog's GitHub URL mode is stored as a remote (provider-backed) workspace repo with no local_path, but branch listing was hard-wired to the local clone - so reopening the dialog and re-picking the repo showed "no branches available for this repository." even though the URL flow itself had just listed branches fine. Branch listing now follows the source: provider-backed repos answer from the GitHub API, local repos answer from disk.

## Important Changes

- `internal/task/service`: `ListBranches` / `ListBranchesWithCurrent` short-circuit to a `RemoteBranchLister` when the repo has provider info and `source_type != "local"`. New `RepoCloneLocation` setter folds the cloner's base path into `discoveryRoots()` so KANDEV_REPOCLONE_BASEPATH outside HOME (e.g. `/data/repos` in a container deploy) still passes the allow-list for local listing.
- `cmd/kandev`: `githubBranchListerAdapter` bridges `github.Service.ListRepoBranches` into the task service. Wired in `services.go`; cloner is registered as the clone-location in `main.go`.
- New e2e: `apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts` reproduces the user's flow (URL submit then reopen then re-pick) and asserts the branch chip is enabled with the mocked branches. Uses a fake owner/repo so the orchestrator's background clone fails - proving the remote-first path is what's serving branches.

## Validation

- `make -C apps/backend build`
- `go test ./internal/task/... ./cmd/...` (397 pass)
- `go test ./internal/task/service/...` (121 pass)
- `npx tsc --noEmit -p apps/web` (no errors)
- `pnpm e2e e2e/tests/task/create-task-url-reopen-no-branches.spec.ts e2e/tests/task/create-task-github-url.spec.ts e2e/tests/task/create-task-branch-selector.spec.ts` (26 pass)

## Possible Improvements

The remote path currently has no fallback to the local clone if the GitHub API call fails (network blip, mock missing). For a repo that is both provider-backed AND cloned, surfacing local branches when remote is unreachable might be friendlier than returning an error - punted for now to keep this PR scoped.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works