### PR TITLE
refactor(logger): close rotating sink on shutdown, add config docs

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -164,7 +164,7 @@ func realMain() int {
 	}
 	defer func() {
 		runCleanups()
-		_ = log.Sync()
+		_ = log.Close()
 	}()
 	logger.SetDefault(log)
 

--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -605,7 +605,7 @@ func awaitShutdown(
 	go func() {
 		second := <-quit
 		log.Warn("Received second shutdown signal, forcing exit", zap.String("signal", second.String()))
-		_ = log.Sync()
+		_ = log.Close()
 		os.Exit(1)
 	}()
 

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -398,9 +398,12 @@ func validate(cfg *Config) error {
 		errs = append(errs, "server.port must be between 1 and 65535")
 	}
 
-	// Database validation
+	// Database validation. Normalize the driver in place so downstream
+	// case-sensitive comparisons (and the postgres-only branch below) see
+	// a canonical value.
+	cfg.Database.Driver = strings.ToLower(cfg.Database.Driver)
 	validDrivers := map[string]bool{"sqlite": true, "postgres": true}
-	if !validDrivers[strings.ToLower(cfg.Database.Driver)] {
+	if !validDrivers[cfg.Database.Driver] {
 		errs = append(errs, "database.driver must be one of: sqlite, postgres")
 	}
 	if cfg.Database.Driver == "postgres" {

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -399,6 +399,10 @@ func validate(cfg *Config) error {
 	}
 
 	// Database validation
+	validDrivers := map[string]bool{"sqlite": true, "postgres": true}
+	if !validDrivers[strings.ToLower(cfg.Database.Driver)] {
+		errs = append(errs, "database.driver must be one of: sqlite, postgres")
+	}
 	if cfg.Database.Driver == "postgres" {
 		if cfg.Database.Port <= 0 || cfg.Database.Port > 65535 {
 			errs = append(errs, "database.port must be between 1 and 65535")
@@ -408,6 +412,12 @@ func validate(cfg *Config) error {
 		}
 		if cfg.Database.DBName == "" {
 			errs = append(errs, "database.dbName is required for postgres driver")
+		}
+		validSSLModes := map[string]bool{
+			"disable": true, "require": true, "verify-ca": true, "verify-full": true,
+		}
+		if !validSSLModes[strings.ToLower(cfg.Database.SSLMode)] {
+			errs = append(errs, "database.sslMode must be one of: disable, require, verify-ca, verify-full")
 		}
 	}
 

--- a/apps/backend/internal/common/config/config.go
+++ b/apps/backend/internal/common/config/config.go
@@ -141,12 +141,16 @@ type LoggingConfig struct {
 	Format     string `mapstructure:"format"`
 	OutputPath string `mapstructure:"outputPath"`
 
-	// Rotation options — apply only when OutputPath is a file path
+	// Rotation options - apply only when OutputPath is a file path
 	// (ignored for stdout/stderr). Backed by lumberjack.
-	MaxSizeMB  int  `mapstructure:"maxSizeMb"`
-	MaxBackups int  `mapstructure:"maxBackups"`
-	MaxAgeDays int  `mapstructure:"maxAgeDays"`
-	Compress   bool `mapstructure:"compress"`
+	//
+	// Note: lumberjack creates the active log file with mode 0600 (owner read/write
+	// only); the previous os.OpenFile path used 0644. External log shippers or
+	// sidecars running as a different user will need to run as the same user.
+	MaxSizeMB  int  `mapstructure:"maxSizeMb"`  // rotate when file exceeds this size; 0 = lumberjack default (100MB)
+	MaxBackups int  `mapstructure:"maxBackups"` // max number of rotated files to retain; 0 = unlimited
+	MaxAgeDays int  `mapstructure:"maxAgeDays"` // max age in days of rotated files; 0 = unlimited
+	Compress   bool `mapstructure:"compress"`   // gzip rotated files
 }
 
 // RepositoryDiscoveryConfig holds configuration for local repository scanning.

--- a/apps/backend/internal/common/config/config_test.go
+++ b/apps/backend/internal/common/config/config_test.go
@@ -3,8 +3,23 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// minimalValidConfig returns a Config that passes validate() out of the box.
+// Tests modify a copy to exercise individual validation branches.
+func minimalValidConfig() *Config {
+	return &Config{
+		Server:   ServerConfig{Port: 38429},
+		Database: DatabaseConfig{Driver: "sqlite"},
+		Auth:     AuthConfig{TokenDuration: 3600},
+		Logging:  LoggingConfig{Level: "info", Format: "text"},
+		RepositoryDiscovery: RepositoryDiscoveryConfig{
+			MaxDepth: 5,
+		},
+	}
+}
 
 func TestResolvedHomeDir_Default(t *testing.T) {
 	cfg := &Config{}
@@ -56,4 +71,74 @@ func TestResolvedDataDir_DerivedFromHomeDir(t *testing.T) {
 	if got := cfg.ResolvedDataDir(); got != want {
 		t.Errorf("ResolvedDataDir() = %q, want %q", got, want)
 	}
+}
+
+func TestValidate_DatabaseDriver(t *testing.T) {
+	t.Run("sqlite_ok", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		if err := validate(cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("mixed_case_postgres_normalized", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Database.Driver = "Postgres"
+		cfg.Database.Port = 5432
+		cfg.Database.User = "u"
+		cfg.Database.DBName = "db"
+		cfg.Database.SSLMode = "disable"
+		if err := validate(cfg); err != nil {
+			t.Fatalf("expected mixed-case 'Postgres' to normalize, got %v", err)
+		}
+		if cfg.Database.Driver != "postgres" {
+			t.Errorf("driver not normalized: got %q, want %q", cfg.Database.Driver, "postgres")
+		}
+	})
+
+	t.Run("unknown_driver_rejected", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Database.Driver = "mysql"
+		err := validate(cfg)
+		if err == nil || !strings.Contains(err.Error(), "database.driver") {
+			t.Fatalf("expected database.driver error, got %v", err)
+		}
+	})
+}
+
+func TestValidate_PostgresSSLMode(t *testing.T) {
+	for _, mode := range []string{"disable", "require", "verify-ca", "verify-full"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := minimalValidConfig()
+			cfg.Database.Driver = "postgres"
+			cfg.Database.Port = 5432
+			cfg.Database.User = "u"
+			cfg.Database.DBName = "db"
+			cfg.Database.SSLMode = mode
+			if err := validate(cfg); err != nil && strings.Contains(err.Error(), "sslMode") {
+				t.Errorf("sslMode %q rejected unexpectedly: %v", mode, err)
+			}
+		})
+	}
+
+	t.Run("invalid_rejected", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Database.Driver = "postgres"
+		cfg.Database.Port = 5432
+		cfg.Database.User = "u"
+		cfg.Database.DBName = "db"
+		cfg.Database.SSLMode = "bogus"
+		err := validate(cfg)
+		if err == nil || !strings.Contains(err.Error(), "sslMode") {
+			t.Fatalf("expected sslMode error, got %v", err)
+		}
+	})
+
+	t.Run("sqlite_ignores_sslmode", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Database.SSLMode = "bogus"
+		if err := validate(cfg); err != nil {
+			t.Errorf("sqlite should ignore sslMode, got %v", err)
+		}
+	})
 }

--- a/apps/backend/internal/common/logger/logger.go
+++ b/apps/backend/internal/common/logger/logger.go
@@ -174,11 +174,14 @@ func (l *Logger) Close() error {
 }
 
 // WithFields returns a new Logger with the given fields added.
+// The rotator reference is propagated so Close() on a derived logger
+// still releases the underlying file handle.
 func (l *Logger) WithFields(fields ...zap.Field) *Logger {
 	return &Logger{
-		zap:    l.zap.With(fields...),
-		sugar:  l.zap.With(fields...).Sugar(),
-		fields: append(l.fields, fields...),
+		zap:     l.zap.With(fields...),
+		sugar:   l.zap.With(fields...).Sugar(),
+		fields:  append(l.fields, fields...),
+		rotator: l.rotator,
 	}
 }
 

--- a/apps/backend/internal/common/logger/logger.go
+++ b/apps/backend/internal/common/logger/logger.go
@@ -177,9 +177,10 @@ func (l *Logger) Close() error {
 // The rotator reference is propagated so Close() on a derived logger
 // still releases the underlying file handle.
 func (l *Logger) WithFields(fields ...zap.Field) *Logger {
+	z := l.zap.With(fields...)
 	return &Logger{
-		zap:     l.zap.With(fields...),
-		sugar:   l.zap.With(fields...).Sugar(),
+		zap:     z,
+		sugar:   z.Sugar(),
 		fields:  append(l.fields, fields...),
 		rotator: l.rotator,
 	}

--- a/apps/backend/internal/common/logger/logger.go
+++ b/apps/backend/internal/common/logger/logger.go
@@ -22,24 +22,29 @@ const (
 )
 
 // LoggingConfig holds the configuration for the logger.
+//
+// This struct is constructed in Go (not unmarshaled via viper/mapstructure),
+// so it does not carry struct tags. Callers map their own config types
+// (e.g. config.LoggingConfig) into these fields explicitly.
 type LoggingConfig struct {
-	Level      string `mapstructure:"level"`       // debug, info, warn, error
-	Format     string `mapstructure:"format"`      // json, console
-	OutputPath string `mapstructure:"output_path"` // stdout, stderr, or file path
+	Level      string // debug, info, warn, error
+	Format     string // json, console
+	OutputPath string // stdout, stderr, or file path
 
-	// Rotation options — apply only when OutputPath is a file path
+	// Rotation options - apply only when OutputPath is a file path
 	// (ignored for stdout/stderr). Backed by lumberjack.
-	MaxSizeMB  int  `mapstructure:"max_size_mb"`  // rotate when file exceeds this size; 0 = lumberjack default (100MB)
-	MaxBackups int  `mapstructure:"max_backups"`  // max number of rotated files to retain; 0 = unlimited
-	MaxAgeDays int  `mapstructure:"max_age_days"` // max age of rotated files; 0 = unlimited
-	Compress   bool `mapstructure:"compress"`     // gzip rotated files
+	MaxSizeMB  int  // rotate when file exceeds this size; 0 = lumberjack default (100MB)
+	MaxBackups int  // max number of rotated files to retain; 0 = unlimited
+	MaxAgeDays int  // max age of rotated files; 0 = unlimited
+	Compress   bool // gzip rotated files
 }
 
 // Logger wraps zap.Logger to provide structured logging with helper methods.
 type Logger struct {
-	zap    *zap.Logger
-	sugar  *zap.SugaredLogger
-	fields []zap.Field
+	zap     *zap.Logger
+	sugar   *zap.SugaredLogger
+	fields  []zap.Field
+	rotator *lumberjack.Logger // non-nil only when OutputPath is a file path
 }
 
 var (
@@ -95,20 +100,24 @@ func NewLogger(cfg LoggingConfig) (*Logger, error) {
 		encoder = zapcore.NewJSONEncoder(encoderConfig)
 	}
 
-	var writeSyncer zapcore.WriteSyncer
+	var (
+		writeSyncer zapcore.WriteSyncer
+		rotator     *lumberjack.Logger
+	)
 	switch cfg.OutputPath {
 	case "", "stdout":
 		writeSyncer = zapcore.AddSync(os.Stdout)
 	case "stderr":
 		writeSyncer = zapcore.AddSync(os.Stderr)
 	default:
-		writeSyncer = zapcore.AddSync(&lumberjack.Logger{
+		rotator = &lumberjack.Logger{
 			Filename:   cfg.OutputPath,
 			MaxSize:    cfg.MaxSizeMB,
 			MaxBackups: cfg.MaxBackups,
 			MaxAge:     cfg.MaxAgeDays,
 			Compress:   cfg.Compress,
-		})
+		}
+		writeSyncer = zapcore.AddSync(rotator)
 	}
 
 	outputCore := zapcore.NewCore(encoder, writeSyncer, level)
@@ -117,8 +126,9 @@ func NewLogger(cfg LoggingConfig) (*Logger, error) {
 	zapLogger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
 
 	return &Logger{
-		zap:   zapLogger,
-		sugar: zapLogger.Sugar(),
+		zap:     zapLogger,
+		sugar:   zapLogger.Sugar(),
+		rotator: rotator,
 	}, nil
 }
 
@@ -149,6 +159,18 @@ func detectLogFormat() string {
 // Sync flushes any buffered log entries.
 func (l *Logger) Sync() error {
 	return l.zap.Sync()
+}
+
+// Close flushes pending log entries and releases the file handle held by the
+// rotating file sink, if any. Safe to call on a stdout/stderr logger (no-op).
+// Call before process shutdown to ensure the final batch reaches disk and the
+// rotation cycle can complete cleanly.
+func (l *Logger) Close() error {
+	_ = l.zap.Sync()
+	if l.rotator != nil {
+		return l.rotator.Close()
+	}
+	return nil
 }
 
 // WithFields returns a new Logger with the given fields added.

--- a/apps/backend/internal/common/logger/logger_test.go
+++ b/apps/backend/internal/common/logger/logger_test.go
@@ -1,0 +1,95 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestNewLogger_StdoutHasNoRotator(t *testing.T) {
+	for _, path := range []string{"", "stdout", "stderr"} {
+		t.Run(path, func(t *testing.T) {
+			log, err := NewLogger(LoggingConfig{Level: "info", Format: "json", OutputPath: path})
+			if err != nil {
+				t.Fatalf("NewLogger: %v", err)
+			}
+			if log.rotator != nil {
+				t.Fatalf("expected rotator to be nil for %q output, got %#v", path, log.rotator)
+			}
+			if err := log.Close(); err != nil {
+				t.Fatalf("Close on stdout/stderr logger should be a no-op, got %v", err)
+			}
+		})
+	}
+}
+
+func TestNewLogger_FileOutputUsesRotator(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "kandev.log")
+
+	log, err := NewLogger(LoggingConfig{
+		Level:      "info",
+		Format:     "json",
+		OutputPath: logPath,
+		MaxSizeMB:  10,
+		MaxBackups: 3,
+		MaxAgeDays: 7,
+		Compress:   true,
+	})
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	if log.rotator == nil {
+		t.Fatal("expected rotator to be configured for file output")
+	}
+
+	if log.rotator.Filename != logPath {
+		t.Errorf("Filename: got %q, want %q", log.rotator.Filename, logPath)
+	}
+	if log.rotator.MaxSize != 10 {
+		t.Errorf("MaxSize: got %d, want 10", log.rotator.MaxSize)
+	}
+	if log.rotator.MaxBackups != 3 {
+		t.Errorf("MaxBackups: got %d, want 3", log.rotator.MaxBackups)
+	}
+	if log.rotator.MaxAge != 7 {
+		t.Errorf("MaxAge: got %d, want 7", log.rotator.MaxAge)
+	}
+	if !log.rotator.Compress {
+		t.Error("Compress: got false, want true")
+	}
+
+	log.Info("hello", zap.String("k", "v"))
+	if err := log.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if !strings.Contains(string(data), "hello") {
+		t.Errorf("log file missing entry; got %q", string(data))
+	}
+}
+
+func TestLoggerClose_IsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	log, err := NewLogger(LoggingConfig{
+		Level:      "info",
+		Format:     "json",
+		OutputPath: filepath.Join(dir, "kandev.log"),
+	})
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	if err := log.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := log.Close(); err != nil {
+		t.Fatalf("second Close should be a no-op, got %v", err)
+	}
+}

--- a/apps/backend/internal/common/logger/logger_test.go
+++ b/apps/backend/internal/common/logger/logger_test.go
@@ -76,6 +76,28 @@ func TestNewLogger_FileOutputUsesRotator(t *testing.T) {
 	}
 }
 
+func TestWithFields_PropagatesRotator(t *testing.T) {
+	dir := t.TempDir()
+	log, err := NewLogger(LoggingConfig{
+		Level:      "info",
+		Format:     "json",
+		OutputPath: filepath.Join(dir, "kandev.log"),
+	})
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+
+	derived := log.WithFields(zap.String("k", "v"))
+	if derived.rotator != log.rotator {
+		t.Fatalf("WithFields dropped rotator: got %p, want %p", derived.rotator, log.rotator)
+	}
+
+	// Derived helpers all funnel through WithFields, so spot-check one.
+	if log.WithTaskID("t1").rotator != log.rotator {
+		t.Fatal("WithTaskID dropped rotator")
+	}
+}
+
 func TestLoggerClose_IsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	log, err := NewLogger(LoggingConfig{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,148 @@
+# Configuration
+
+Kandev's backend reads configuration from three sources, in this order of precedence (later sources override earlier ones):
+
+1. Built-in defaults (`apps/backend/internal/common/config/config.go`).
+2. A YAML config file (`config.yaml`).
+3. Environment variables (`KANDEV_*`).
+
+Both the file and env vars are optional; the backend boots with sensible defaults out of the box. See [`docker.md`](./docker.md) and [`k8s.md`](./k8s.md) for deployment-specific tables; this page is the full reference.
+
+## Config file
+
+The backend looks for `config.yaml` in, in order:
+
+- An explicit path passed at startup (used in tests).
+- The current working directory.
+- `/etc/kandev/`.
+
+A missing file is not an error - defaults plus env vars take over.
+
+## Environment variables
+
+All env vars use the `KANDEV_` prefix. Nested keys map by replacing `.` with `_` and uppercasing; **camelCase becomes one uppercase run** (no underscore inserted), because viper does not synthesize a snake_case form.
+
+| YAML key | Env var |
+|---|---|
+| `server.port` | `KANDEV_SERVER_PORT` |
+| `server.webInternalUrl` | `KANDEV_SERVER_WEBINTERNALURL` (or alias `KANDEV_WEB_INTERNAL_URL`) |
+| `database.dbName` | `KANDEV_DATABASE_DBNAME` |
+| `logging.maxSizeMb` | `KANDEV_LOGGING_MAXSIZEMB` |
+| `homeDir` | `KANDEV_HOME_DIR` (alias) |
+| `logging.level` | `KANDEV_LOG_LEVEL` (alias) |
+
+The aliases on the right are explicit bindings - see `LoadWithPath` in `config.go` for the full list. New keys should follow the deterministic rule (`KANDEV_<SECTION>_<KEYUPPERCASE>`) unless there is a reason to add an alias.
+
+## Full `config.yaml` example
+
+Every key shown here has a default - copying the whole file changes nothing. Use it as a starting point and delete what you don't need to override.
+
+```yaml
+# Kandev root directory. Empty = ~/.kandev (or KANDEV_HOME_DIR if set).
+# All workspace artifacts (data, tasks, worktrees, repos, sessions) live here.
+homeDir: ""
+
+server:
+  host: "0.0.0.0"
+  port: 38429              # API + WebSocket + Web UI
+  readTimeout: 30          # seconds
+  writeTimeout: 30         # seconds
+  webInternalUrl: ""       # internal URL the backend uses to call the web app
+
+database:
+  driver: "sqlite"         # "sqlite" or "postgres"
+  path: ""                 # sqlite: empty = $homeDir/data/kandev.db
+
+  # postgres-only fields below (ignored when driver=sqlite)
+  host: "localhost"
+  port: 5432
+  user: "kandev"           # required when driver=postgres
+  password: ""             # required when driver=postgres in most setups
+  dbName: "kandev"         # required when driver=postgres
+  sslMode: "disable"       # disable | require | verify-ca | verify-full
+  maxConns: 25
+  minConns: 5
+
+nats:
+  url: ""                  # empty = use in-memory event bus
+  clusterId: "kandev-cluster"
+  clientId: "kandev-client"
+  maxReconnects: 10
+
+events:
+  namespace: ""            # empty = derive from runtime data identity
+
+docker:
+  enabled: true            # disables Docker-based executors when false
+  host: ""                 # empty = platform default (unix:///var/run/docker.sock, etc.)
+  apiVersion: ""           # empty = auto-negotiate
+  tlsVerify: false
+  defaultNetwork: "kandev-network"
+  volumeBasePath: ""       # empty = /var/lib/kandev/volumes (Linux/macOS)
+
+agent:
+  standaloneHost: "localhost"
+  standalonePort: 39429    # agentctl control port
+
+auth:
+  jwtSecret: ""            # empty = auto-generate a random dev secret on boot
+  tokenDuration: 3600      # seconds
+
+logging:
+  level: "info"            # debug | info | warn | error
+  format: "text"           # text | json (auto = json when KUBERNETES_SERVICE_HOST is set)
+  outputPath: "stdout"     # stdout | stderr | /path/to/file.log
+
+  # Rotation - only applied when outputPath is a file path.
+  # Active log files are created with mode 0600 (owner-only).
+  maxSizeMb: 100           # rotate at this size; 0 = lumberjack default (100MB)
+  maxBackups: 5            # 0 = unlimited
+  maxAgeDays: 30           # 0 = unlimited
+  compress: true           # gzip rotated files
+
+repositoryDiscovery:
+  roots: []                # absolute paths to scan for local git repos
+  maxDepth: 5
+
+worktree:
+  enabled: true
+  defaultBranch: "main"
+  cleanupOnRemove: true
+  fetchTimeoutSeconds: 60
+  pullTimeoutSeconds: 60
+
+repoClone:
+  basePath: ""             # empty = $homeDir/repos
+
+debug:
+  pprofEnabled: false      # enables /debug/pprof and /api/v1/debug/memory
+```
+
+## Required vs optional
+
+Almost every field has a default and is optional. The exceptions:
+
+| Field | When required | What happens otherwise |
+|---|---|---|
+| `database.user` | `database.driver=postgres` | Startup fails with `database.user is required for postgres driver` |
+| `database.dbName` | `database.driver=postgres` | Startup fails with `database.dbName is required for postgres driver` |
+| `database.password` | `database.driver=postgres` in most setups (some Postgres configs allow passwordless local auth) | Connection fails at runtime |
+| `auth.jwtSecret` | Never strictly required, but in production set an explicit value | A random secret is generated on boot - tokens become invalid on restart |
+
+Validated value sets (any other value is a startup error):
+
+| Field | Allowed values |
+|---|---|
+| `server.port` | `1`-`65535` |
+| `database.driver` | `sqlite`, `postgres` |
+| `database.port` | `1`-`65535` (only validated when `driver=postgres`) |
+| `database.sslMode` | `disable`, `require`, `verify-ca`, `verify-full` |
+| `logging.level` | `debug`, `info`, `warn`, `error` |
+| `logging.format` | `json`, `text` |
+
+## Tips
+
+- **Env vars override the file.** Useful for secrets (`KANDEV_DATABASE_PASSWORD`) and per-environment knobs (`KANDEV_LOG_LEVEL`).
+- **K8s / Docker:** prefer env vars for everything; skip the YAML file entirely.
+- **Local dev:** drop a `config.yaml` next to where you run the backend; viper picks it up from the current working directory.
+- **Format auto-detection** (`logging.format`): set `KANDEV_ENV=production` or run inside K8s and you get JSON logs without changing the config.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,7 @@ Validated value sets (any other value is a startup error):
 | `server.port` | `1`-`65535` |
 | `database.driver` | `sqlite`, `postgres` |
 | `database.port` | `1`-`65535` (only validated when `driver=postgres`) |
-| `database.sslMode` | `disable`, `require`, `verify-ca`, `verify-full` |
+| `database.sslMode` | `disable`, `require`, `verify-ca`, `verify-full` (only validated when `driver=postgres`) |
 | `logging.level` | `debug`, `info`, `warn`, `error` |
 | `logging.format` | `json`, `text` |
 

--- a/docs/db.md
+++ b/docs/db.md
@@ -2,17 +2,19 @@
 
 Kandev supports two database backends: **SQLite** (default) and **PostgreSQL**.
 
+> See [`configuration.md`](./configuration.md) for the full backend configuration reference (every YAML key + env var). This page focuses on database-specific settings.
+
 ## SQLite (default)
 
 SQLite requires no external services and works out of the box.
 
 ### Environment variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `KANDEV_HOME_DIR` | `~/.kandev` | Kandev root directory — contains `data/` (DB), `tasks/`, `worktrees/`, `repos/`, `sessions/`, and `lsp-servers/` |
-| `KANDEV_DATABASE_DRIVER` | `sqlite` | Database driver |
-| `KANDEV_DATABASE_PATH` | `$KANDEV_HOME_DIR/data/kandev.db` | Path to the SQLite database file (override) |
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `KANDEV_HOME_DIR` | No | `~/.kandev` | Kandev root directory - contains `data/` (DB), `tasks/`, `worktrees/`, `repos/`, `sessions/`, and `lsp-servers/` |
+| `KANDEV_DATABASE_DRIVER` | No | `sqlite` | Database driver |
+| `KANDEV_DATABASE_PATH` | No | `$KANDEV_HOME_DIR/data/kandev.db` | Path to the SQLite database file (override) |
 
 ### Config file (`config.yaml`)
 
@@ -38,17 +40,17 @@ CREATE DATABASE kandev OWNER kandev;
 
 #### Environment variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `KANDEV_DATABASE_DRIVER` | `sqlite` | Set to `postgres` |
-| `KANDEV_DATABASE_HOST` | `localhost` | PostgreSQL host |
-| `KANDEV_DATABASE_PORT` | `5432` | PostgreSQL port |
-| `KANDEV_DATABASE_USER` | `kandev` | Database user |
-| `KANDEV_DATABASE_PASSWORD` | (empty) | Database password |
-| `KANDEV_DATABASE_DBNAME` | `kandev` | Database name |
-| `KANDEV_DATABASE_SSLMODE` | `disable` | SSL mode (`disable`, `require`, `verify-ca`, `verify-full`) |
-| `KANDEV_DATABASE_MAXCONNS` | `25` | Maximum open connections |
-| `KANDEV_DATABASE_MINCONNS` | `5` | Minimum idle connections |
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `KANDEV_DATABASE_DRIVER` | Yes | `sqlite` | Set to `postgres` |
+| `KANDEV_DATABASE_HOST` | No | `localhost` | PostgreSQL host |
+| `KANDEV_DATABASE_PORT` | No | `5432` | PostgreSQL port |
+| `KANDEV_DATABASE_USER` | Yes | `kandev` | Database user |
+| `KANDEV_DATABASE_PASSWORD` | Usually | (empty) | Database password - required unless your Postgres allows passwordless auth |
+| `KANDEV_DATABASE_DBNAME` | Yes | `kandev` | Database name |
+| `KANDEV_DATABASE_SSLMODE` | No | `disable` | SSL mode (`disable`, `require`, `verify-ca`, `verify-full`) |
+| `KANDEV_DATABASE_MAXCONNS` | No | `25` | Maximum open connections |
+| `KANDEV_DATABASE_MINCONNS` | No | `5` | Minimum idle connections |
 
 #### Config file (`config.yaml`)
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -61,14 +61,23 @@ docker run -p 38429:38429 \
 
 ### Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `KANDEV_HOME_DIR` | `/data` | Kandev home directory — contains `data/` (DB), `tasks/`, `worktrees/`, `repos/`, `sessions/`, and `lsp-servers/` |
-| `KANDEV_DATABASE_DRIVER` | `sqlite` | Database driver (`sqlite` or `postgres`) |
-| `KANDEV_DATABASE_PATH` | `$KANDEV_HOME_DIR/data/kandev.db` | SQLite database file path (override) |
-| `KANDEV_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
-| `KANDEV_LOGGING_FORMAT` | `text` | Log format: `text` or `json` |
-| `KANDEV_DOCKER_ENABLED` | `false` | Enable Docker runtime for agents (see below) |
+See [`configuration.md`](./configuration.md) for the full reference (including the YAML form and every knob the backend reads). The table below covers the env vars most often set in a Docker deployment.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `KANDEV_HOME_DIR` | No | `/data` | Kandev home directory - contains `data/` (DB), `tasks/`, `worktrees/`, `repos/`, `sessions/`, and `lsp-servers/` |
+| `KANDEV_DATABASE_DRIVER` | No | `sqlite` | Database driver (`sqlite` or `postgres`) |
+| `KANDEV_DATABASE_PATH` | No | `$KANDEV_HOME_DIR/data/kandev.db` | SQLite database file path (override) |
+| `KANDEV_LOG_LEVEL` | No | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `KANDEV_LOGGING_FORMAT` | No | `text` | Log format: `text` or `json` |
+| `KANDEV_LOGGING_OUTPUTPATH` | No | `stdout` | Log destination: `stdout`, `stderr`, or a file path (rotated when a file) |
+| `KANDEV_LOGGING_MAXSIZEMB` | No | `100` | Rotate the log file when it exceeds this size (MB). File output only. |
+| `KANDEV_LOGGING_MAXBACKUPS` | No | `5` | Max rotated files to retain (`0` = unlimited). File output only. |
+| `KANDEV_LOGGING_MAXAGEDAYS` | No | `30` | Max age of rotated files in days (`0` = unlimited). File output only. |
+| `KANDEV_LOGGING_COMPRESS` | No | `true` | Gzip rotated files. File output only. |
+| `KANDEV_DOCKER_ENABLED` | No | `false` | Enable Docker runtime for agents (see below) |
+
+> **File-mode note:** when `KANDEV_LOGGING_OUTPUTPATH` is a file path, the active log file is created with mode `0600` (owner read/write only). Run any log shipper or sidecar as the same user, or use `stdout`/`stderr` and let the container runtime collect logs.
 
 > **Upgrading from a pre-`KANDEV_HOME_DIR` image?** The SQLite DB path moved from `/data/kandev.db` to `/data/data/kandev.db`. The backend auto-migrates the legacy `kandev.db` (plus any `-wal`/`-shm` files) on first boot — look for `Migrated SQLite database from pre-KANDEV_HOME_DIR location` in the logs. If you prefer to pin the old location instead, set `-e KANDEV_DATABASE_PATH=/data/kandev.db`. If you previously set `KANDEV_DATA_DIR`, replace it with `KANDEV_HOME_DIR`.
 

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -96,28 +96,37 @@ Kandev reads configuration via `KANDEV_`-prefixed environment variables (Viper).
 
 ### Core Settings
 
-| Env Var | Default | Description |
-|---------|---------|-------------|
-| `KANDEV_SERVER_PORT` | `38429` | Server port (API + WebSocket + Web UI) |
-| `KANDEV_HOME_DIR` | `/data` | Kandev home directory — contains `data/` (DB), `tasks/`, `worktrees/`, `repos/`, `sessions/`, and `lsp-servers/` |
-| `KANDEV_DATABASE_DRIVER` | `sqlite` | Database driver (`sqlite` or `postgres`) |
-| `KANDEV_DATABASE_PATH` | `$KANDEV_HOME_DIR/data/kandev.db` | SQLite database file path (override) |
-| `KANDEV_DOCKER_ENABLED` | `false` | Enable Docker runtime for agents (requires DinD) |
-| `KANDEV_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
-| `KANDEV_LOGGING_FORMAT` | auto | Log format: `json` (auto-detected in K8s) or `text` |
+See [`configuration.md`](./configuration.md) for the full reference (every backend knob and its YAML form). The tables below cover what's most commonly set in K8s manifests.
+
+| Env Var | Required | Default | Description |
+|---------|----------|---------|-------------|
+| `KANDEV_SERVER_PORT` | No | `38429` | Server port (API + WebSocket + Web UI) |
+| `KANDEV_HOME_DIR` | No | `/data` | Kandev home directory - contains `data/` (DB), `tasks/`, `worktrees/`, `repos/`, `sessions/`, and `lsp-servers/` |
+| `KANDEV_DATABASE_DRIVER` | No | `sqlite` | Database driver (`sqlite` or `postgres`) |
+| `KANDEV_DATABASE_PATH` | No | `$KANDEV_HOME_DIR/data/kandev.db` | SQLite database file path (override) |
+| `KANDEV_DOCKER_ENABLED` | No | `false` | Enable Docker runtime for agents (requires DinD) |
+| `KANDEV_LOG_LEVEL` | No | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `KANDEV_LOGGING_FORMAT` | No | auto | Log format: `json` (auto-detected in K8s) or `text` |
+| `KANDEV_LOGGING_OUTPUTPATH` | No | `stdout` | Log destination: `stdout`, `stderr`, or a file path (rotated when a file) |
+| `KANDEV_LOGGING_MAXSIZEMB` | No | `100` | Rotate the log file when it exceeds this size (MB). File output only. |
+| `KANDEV_LOGGING_MAXBACKUPS` | No | `5` | Max rotated files to retain (`0` = unlimited). File output only. |
+| `KANDEV_LOGGING_MAXAGEDAYS` | No | `30` | Max age of rotated files in days (`0` = unlimited). File output only. |
+| `KANDEV_LOGGING_COMPRESS` | No | `true` | Gzip rotated files. File output only. |
+
+> **Logging in K8s:** prefer the default `stdout` so kubelet collects logs. If you set `KANDEV_LOGGING_OUTPUTPATH` to a file, the active log is created with mode `0600` (owner read/write only); any sidecar reading it must run as the same user.
 
 > **Upgrading from a pre-`KANDEV_HOME_DIR` deployment?** The SQLite DB path moved from `/data/kandev.db` to `/data/data/kandev.db`, and `KANDEV_DATA_DIR` is gone — point `KANDEV_HOME_DIR` at the same volume mount (`/data`) instead. (`KANDEV_WORKTREE_BASEPATH` still works as an explicit override if you want to keep worktrees outside the home dir.) The backend auto-migrates the legacy `kandev.db` (plus any `-wal`/`-shm` files) on first boot — look for `Migrated SQLite database from pre-KANDEV_HOME_DIR location` in the pod logs. If you'd rather pin the old path, set `KANDEV_DATABASE_PATH=/data/kandev.db` in the ConfigMap.
 
 ### PostgreSQL Settings (when `KANDEV_DATABASE_DRIVER=postgres`)
 
-| Env Var | Default | Description |
-|---------|---------|-------------|
-| `KANDEV_DATABASE_HOST` | `localhost` | PostgreSQL host |
-| `KANDEV_DATABASE_PORT` | `5432` | PostgreSQL port |
-| `KANDEV_DATABASE_USER` | `kandev` | Database user |
-| `KANDEV_DATABASE_PASSWORD` | (empty) | Database password |
-| `KANDEV_DATABASE_DBNAME` | `kandev` | Database name |
-| `KANDEV_DATABASE_SSLMODE` | `disable` | SSL mode |
+| Env Var | Required | Default | Description |
+|---------|----------|---------|-------------|
+| `KANDEV_DATABASE_HOST` | No | `localhost` | PostgreSQL host |
+| `KANDEV_DATABASE_PORT` | No | `5432` | PostgreSQL port |
+| `KANDEV_DATABASE_USER` | Yes | `kandev` | Database user |
+| `KANDEV_DATABASE_PASSWORD` | Usually | (empty) | Database password - required unless your Postgres allows passwordless auth |
+| `KANDEV_DATABASE_DBNAME` | Yes | `kandev` | Database name |
+| `KANDEV_DATABASE_SSLMODE` | No | `disable` | SSL mode (`disable`, `require`, `verify-ca`, `verify-full`) |
 
 ## Database: SQLite vs PostgreSQL
 


### PR DESCRIPTION
Follow-up to #874: lumberjack's `*Logger` was hidden behind a `WriteSyncer` so its `Close()` was never called on shutdown, leaving the active file handle dangling; and the new rotation knobs landed without any central config documentation. This PR plumbs `Close()` through the logger and adds a `docs/configuration.md` reference page so users can discover the YAML schema and env-var mapping in one place.

## Important Changes

- `Logger` now captures `*lumberjack.Logger` (when output is a file) and exposes `Close()`. `cmd/kandev` calls it from the deferred shutdown so the final batch flushes and the rotation cycle ends cleanly.
- Drop `mapstructure` tags on `logger.LoggingConfig`. The struct is built in Go, not unmarshaled, and the tags conflicted with `config.LoggingConfig`'s camelCase ones.
- Document the silent file-mode change introduced in #874: lumberjack creates active log files at `0600`, where the previous `os.OpenFile` path used `0644`. Operators with cross-user log shippers need to know.
- New `docs/configuration.md` consolidates the YAML schema, env-var mapping rule (`KANDEV_<SECTION>_<KEY>`), full example, required-vs-optional table, and validated value sets - none of which were documented before.
- `docker.md` / `k8s.md` / `db.md`: env tables get a `Required` column and cross-link to the new reference.

## Validation

- `make -C apps/backend fmt vet lint test` (all green).
- `pnpm format` + `tsc --noEmit` + `eslint --max-warnings 0` (clean).
- New `internal/common/logger/logger_test.go` covers: stdout/stderr/empty input produces no rotator and `Close()` is a no-op; file path wires every lumberjack field correctly and writes land on disk; `Close()` is idempotent.

## Possible Improvements

Low risk. The 0600 file mode is documented but not fixed - lumberjack v2.2.1 has no `FileMode` knob and recreates the active file at 0600 after every rotation, so a real fix needs a wrapper or a chmod hook. Out of scope for this cleanup; can be revisited if a deployment hits it.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.