### PR TITLE
fix(web): allow delete/archive of kanban cards in All Workflows view

### DIFF
--- a/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
+++ b/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "../../fixtures/test-base";
 import { KanbanPage } from "../../pages/kanban-page";
 
+const TASK_VISIBLE_TIMEOUT = 10_000;
+
 // Regression: clicking Delete / Archive must show the confirm dialog, not navigate to the task.
 test.describe("Kanban card actions menu — delete/archive does not navigate", () => {
   test("clicking Delete in card dropdown shows confirm dialog and does not navigate", async ({
@@ -79,5 +81,80 @@ test.describe("Kanban card actions menu — delete/archive does not navigate", (
     // Preview-on-click must not have fired — URL should still be the start URL
     expect(testPage.url()).toBe(startUrl);
     await expect(testPage.getByTestId("task-preview-panel")).not.toBeVisible();
+  });
+});
+
+// Regression: in "All Workflows" swimlane view, state.kanban.workflowId is null.
+// useTaskCRUD's handleDelete/handleArchive used to early-return on that, so the
+// dialog closed but no API call ran and the task stayed on the board.
+test.describe("Kanban card actions menu — delete/archive in All Workflows view", () => {
+  // Pull `testPage` so its fixture (which resets user settings) runs before this
+  // hook seeds workflows/settings — otherwise the reset wipes them on first use.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test.beforeEach(async ({ apiClient, seedData, testPage }) => {
+    // Need a second workflow so resolveDesiredWorkflowId does not auto-select
+    // the only visible workflow when filter is null.
+    await apiClient.createWorkflow(seedData.workspaceId, "Secondary Workflow", "simple");
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: "",
+      repository_ids: [],
+    });
+  });
+
+  test("confirming Delete removes the task from the board in All Workflows view", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "All-Wf Delete Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await expect(kanban.taskCardByTitle("All-Wf Delete Task")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+
+    await kanban.openTaskActionsMenu(task.id);
+    await testPage.getByRole("menuitem", { name: "Delete" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Delete" }).click();
+
+    await expect(kanban.taskCardByTitle("All-Wf Delete Task")).not.toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+  });
+
+  test("confirming Archive removes the task from the board in All Workflows view", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "All-Wf Archive Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await expect(kanban.taskCardByTitle("All-Wf Archive Task")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+
+    await kanban.openTaskActionsMenu(task.id);
+    await testPage.getByRole("menuitem", { name: "Archive" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Archive" }).click();
+
+    await expect(kanban.taskCardByTitle("All-Wf Archive Task")).not.toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
   });
 });

--- a/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
+++ b/apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts
@@ -88,9 +88,7 @@ test.describe("Kanban card actions menu — delete/archive does not navigate", (
 // useTaskCRUD's handleDelete/handleArchive used to early-return on that, so the
 // dialog closed but no API call ran and the task stayed on the board.
 test.describe("Kanban card actions menu — delete/archive in All Workflows view", () => {
-  // Pull `testPage` so its fixture (which resets user settings) runs before this
-  // hook seeds workflows/settings — otherwise the reset wipes them on first use.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- testPage is listed to force its fixture (user-settings reset) to run before this hook's API seeding; without it the reset wipes our workflow_filter_id on first use
   test.beforeEach(async ({ apiClient, seedData, testPage }) => {
     // Need a second workflow so resolveDesiredWorkflowId does not auto-select
     // the only visible workflow when filter is null.

--- a/apps/web/hooks/use-task-crud.ts
+++ b/apps/web/hooks/use-task-crud.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+import { useAppStoreApi } from "@/components/state-provider";
 import { useTaskActions } from "@/hooks/use-task-actions";
 import type { Task } from "@/components/kanban-card";
 import type { KanbanState } from "@/lib/state/slices";
@@ -18,7 +18,6 @@ export function useTaskCRUD() {
   const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
   const [archivingTaskId, setArchivingTaskId] = useState<string | null>(null);
   const { deleteTaskById, archiveTaskById } = useTaskActions();
-  const kanban = useAppStore((state) => state.kanban);
   const store = useAppStoreApi();
 
   const handleCreate = useCallback(() => {
@@ -33,8 +32,6 @@ export function useTaskCRUD() {
 
   const handleDelete = useCallback(
     async (task: Task) => {
-      if (!kanban.workflowId) return;
-
       setDeletingTaskId(task.id);
       try {
         await deleteTaskById(task.id);
@@ -52,13 +49,11 @@ export function useTaskCRUD() {
         setDeletingTaskId(null);
       }
     },
-    [deleteTaskById, kanban.workflowId, store],
+    [deleteTaskById, store],
   );
 
   const handleArchive = useCallback(
     async (task: Task) => {
-      if (!kanban.workflowId) return;
-
       setArchivingTaskId(task.id);
       try {
         await archiveTaskById(task.id);
@@ -76,7 +71,7 @@ export function useTaskCRUD() {
         setArchivingTaskId(null);
       }
     },
-    [archiveTaskById, kanban.workflowId, store],
+    [archiveTaskById, store],
   );
 
   const handleDialogOpenChange = useCallback((open: boolean) => {


### PR DESCRIPTION
Deleting or archiving a kanban card from the All Workflows swimlane silently no-opped because `useTaskCRUD` early-returned when `kanban.workflowId` was null, leaving the dialog closing but the task still on the board. Removing the workflow guard (these operations are task-scoped, not workflow-scoped) restores the expected behaviour.

## Validation

- TDD: added two regression e2e tests in `apps/web/e2e/tests/kanban/card-menu-delete-archive.spec.ts` that fail without the fix and pass with it.
- `pnpm --filter @kandev/web e2e -- tests/kanban/card-menu-delete-archive.spec.ts` (5/5 pass).
- `pnpm --filter @kandev/web typecheck`, `pnpm --filter @kandev/web lint`, full web unit suite (1315 tests pass).
- `make -C apps/backend test lint`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.