### PR TITLE
feat(image): publish universal image flavor with toolchains + customize docs

### DIFF
--- a/.agents/skills/pr-fixup/SKILL.md
+++ b/.agents/skills/pr-fixup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-fixup
-description: Wait for CI checks and automated reviews (CodeRabbit, Greptile, Claude) on a PR, fix failures and address comments, then push.
+description: Wait for CI checks and automated reviews (CodeRabbit, Greptile, Claude, cubic) on a PR, fix failures and address comments, then push.
 ---
 
 # PR Fixup
@@ -28,7 +28,7 @@ Create these tasks immediately (use your task/todo tracking tool if available):
 
 1. **Gather PR state** — Fetch checks, comments, and review status
 2. **Wait for CI checks** — Poll until all checks resolve
-3. **Wait for automated reviews** — Poll for CodeRabbit and Greptile
+3. **Wait for automated reviews** — Poll for CodeRabbit, Greptile, Claude, and cubic
 4. **Fix failing CI checks** — Read logs, fix issues, run E2E tests locally if needed
 5. **Triage review comments** — Classify each comment as valid, already addressed, nitpick, or wrong
 6. **Address each comment** — Fix or reply with reasoning
@@ -75,12 +75,13 @@ Mark task 2 as completed.
 
 Mark task 3 as in_progress.
 
-Check if CodeRabbit, Greptile, and Claude have posted or are generating reviews.
+Check if CodeRabbit, Greptile, Claude, and cubic have posted or are generating reviews.
 
 **Bot usernames** (`gh pr view --json comments` uses GraphQL and returns `author.login` **without** the `[bot]` suffix; `gh api /.../reviews` and `/.../issues/<n>/comments` use REST and return `user.login` **with** the suffix — filters below use whichever form the invoked endpoint returns):
 - CodeRabbit: `coderabbitai[bot]`
 - Greptile: `greptile-apps[bot]`
 - Claude: `claude[bot]` on same-repo PRs (posts a real review with inline comments via the Claude GitHub App), or `github-actions[bot]` on fork PRs (posts findings as issue comments via `GITHUB_TOKEN`; identify by body markers — tracker starts with `**Claude finished `, findings comment starts with `## Code Review`).
+- cubic (cubic.dev): `cubic-dev-ai[bot]` (posts reviews via the GitHub review API, similar to Greptile; has its own `cubic · AI code reviewer` check).
 
 **CodeRabbit — stop waiting if:**
 - A comment contains `<!-- rate limited by coderabbit.ai -->` — rate-limited, won't review.
@@ -93,6 +94,10 @@ Check if CodeRabbit, Greptile, and Claude have posted or are generating reviews.
 - A review from `claude[bot]` exists (same-repo PR, App-authenticated path — has inline review comments).
 - An issue comment from `github-actions[bot]` whose body starts with `**Claude finished ` or `## Code Review` exists (fork PR, `GITHUB_TOKEN` fallback path — findings are issue comments, no GitHub Review object).
 - The `claude-review` check in `gh pr checks` has completed (regardless of conclusion).
+
+**cubic — stop waiting if any of these holds:**
+- A review from `cubic-dev-ai[bot]` exists (posts via the GitHub review API).
+- The `cubic · AI code reviewer` check in `gh pr checks` has completed (regardless of conclusion).
 
 **Keep polling if:**
 - A bot hasn't commented yet AND `gh pr checks` shows its check is still `pending`.
@@ -107,6 +112,8 @@ gh api repos/:owner/:repo/pulls/<number>/reviews --jq '.[] | select(.user.login 
 gh api repos/:owner/:repo/pulls/<number>/reviews --jq '.[] | select(.user.login == "claude[bot]") | {user: .user.login, state: .state}'
 # Claude — fork PRs: issue comments from github-actions[bot] (match by body marker)
 gh pr view <number> --json comments --jq '.comments[] | select(.author.login == "github-actions" and ((.body | startswith("**Claude finished ")) or (.body | startswith("## Code Review")))) | {author: .author.login, body_start: (.body[0:80])}'
+# cubic posts reviews (with inline review comments)
+gh api repos/:owner/:repo/pulls/<number>/reviews --jq '.[] | select(.user.login == "cubic-dev-ai[bot]") | {user: .user.login, state: .state}'
 ```
 
 Mark task 3 as completed.
@@ -145,7 +152,7 @@ Mark task 4 as completed.
 
 Mark task 5 as in_progress.
 
-Fetch all review comments — human reviewers, CodeRabbit, Greptile, and Claude:
+Fetch all review comments — human reviewers, CodeRabbit, Greptile, Claude, and cubic:
 
 ```bash
 gh pr view <number> --json reviews,comments

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,20 +438,17 @@ jobs:
     permissions:
       contents: read
       packages: write    # push to GHCR
+    # Build flow: push to a per-run staging tag, gate on size against the
+    # staging tag, then `buildx imagetools create` to promote the same
+    # manifest to the user-facing tags. The promote step is metadata-only -
+    # no rebuild, no new bytes - so this costs us one extra registry call
+    # in exchange for never publishing an oversized image as :universal.
+    env:
+      STAGING_IMAGE: ghcr.io/kdlbs/kandev:universal-staging-${{ needs.prepare.outputs.tag }}-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.tag }}
-
-      - name: Docker meta (universal)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/kdlbs/kandev
-          tags: |
-            type=raw,value=${{ needs.prepare.outputs.version }}-universal
-            type=raw,value=${{ needs.prepare.outputs.tag }}-universal
-            type=raw,value=universal
 
       - uses: docker/setup-buildx-action@v3
 
@@ -465,9 +462,9 @@ jobs:
       # Build universal on top of the vanilla image we just pushed. Passing
       # the exact `:vX.Y.Z` tag (not `:latest`) keeps the pair coherent:
       # universal-of-vX.Y.Z always rests on vanilla-vX.Y.Z, even if a later
-      # release moves `:latest`.
-      - name: Build and push (universal)
-        id: build
+      # release moves `:latest`. The tag pushed here is the staging tag;
+      # final tags are applied below only if the size gate passes.
+      - name: Build and push (staging tag)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -476,25 +473,25 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BASE_IMAGE=ghcr.io/kdlbs/kandev:${{ needs.prepare.outputs.tag }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.STAGING_IMAGE }}
           cache-from: type=gha,scope=universal
           cache-to: type=gha,mode=max,scope=universal
 
-      # Universal size gate. Fails the release if compressed image exceeds
-      # the ceiling - forces deliberate decisions about scope creep. Bump
-      # this number in the same PR that adds the dependency that pushed
-      # over the line, with a one-sentence justification in the commit msg.
+      # Universal size gate. Inspects the staging tag - the image is in
+      # GHCR but under a per-run tag no user pulls. Failing the gate aborts
+      # before promotion, so the user-facing :universal / :vX.Y.Z-universal
+      # tags never move to an oversized image. Bump MAX_COMPRESSED_BYTES
+      # deliberately when adding scope, with a one-sentence justification
+      # in the commit msg.
       - name: Enforce size budget
         env:
-          IMAGE: ghcr.io/kdlbs/kandev:${{ needs.prepare.outputs.tag }}-universal
           MAX_COMPRESSED_BYTES: "2684354560"   # 2.5 GiB
         run: |
           set -euo pipefail
           # Inspect the multi-arch manifest and sum compressed layer sizes
           # for linux/amd64. amd64 is the bigger of the two arches in
           # practice, so gating on it gives us a single-number signal.
-          docker buildx imagetools inspect "$IMAGE" --raw \
+          docker buildx imagetools inspect "$STAGING_IMAGE" --raw \
               > /tmp/index.json
           AMD64_DIGEST="$(jq -r '
               .manifests[]
@@ -506,9 +503,23 @@ jobs:
           TOTAL="$(jq '[.layers[].size] | add' /tmp/manifest.json)"
           echo "Universal image (amd64) compressed size: $TOTAL bytes (max: $MAX_COMPRESSED_BYTES)"
           if [ "$TOTAL" -gt "$MAX_COMPRESSED_BYTES" ]; then
-            echo "::error::Universal image exceeds compressed-size budget. See docs/images.md inclusion policy." >&2
+            echo "::error::Universal image exceeds compressed-size budget. Staging tag $STAGING_IMAGE will not be promoted. See docs/images.md inclusion policy." >&2
             exit 1
           fi
+
+      # Promote: `buildx imagetools create` retargets an existing manifest
+      # list to new tag(s) without rebuilding or re-uploading layers. Multi-
+      # arch is preserved. Only runs if the size gate passed (default step
+      # ordering); if any earlier step failed, the user-facing tags stay at
+      # whatever they pointed to before this run.
+      - name: Promote staging to final tags
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "ghcr.io/kdlbs/kandev:${{ needs.prepare.outputs.version }}-universal" \
+            --tag "ghcr.io/kdlbs/kandev:${{ needs.prepare.outputs.tag }}-universal" \
+            --tag "ghcr.io/kdlbs/kandev:universal" \
+            "$STAGING_IMAGE"
 
   publish-release:
     name: Publish GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,7 +482,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=universal
 
       # Universal size gate. Fails the release if compressed image exceeds
-      # the ceiling — forces deliberate decisions about scope creep. Bump
+      # the ceiling - forces deliberate decisions about scope creep. Bump
       # this number in the same PR that adds the dependency that pushed
       # over the line, with a one-sentence justification in the commit msg.
       - name: Enforce size budget

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,6 +443,15 @@ jobs:
     # manifest to the user-facing tags. The promote step is metadata-only -
     # no rebuild, no new bytes - so this costs us one extra registry call
     # in exchange for never publishing an oversized image as :universal.
+    #
+    # Tradeoff: staging tags accumulate in GHCR over time (one per release
+    # run). Auto-cleanup isn't safe here - `imagetools create` produces a
+    # byte-identical manifest list when retagging a single source, so the
+    # staging tag and the promoted user-facing tags share the same package
+    # version in GHCR. Deleting the version to drop the staging tag would
+    # also drop :universal / :vX.Y.Z-universal. A separate cleanup workflow
+    # filtering for versions whose ONLY tags match `universal-staging-*`
+    # would be the correct way to address this if it becomes a problem.
     env:
       STAGING_IMAGE: ghcr.io/kdlbs/kandev:universal-staging-${{ needs.prepare.outputs.tag }}-${{ github.run_id }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -512,7 +512,10 @@ jobs:
 
   publish-release:
     name: Publish GitHub release
-    needs: [prepare, build-bundles]
+    # docker-universal is included so its size gate (and any build failure)
+    # blocks the release. Without this, publish-release runs in parallel with
+    # docker-universal and an oversized universal image still ships a release.
+    needs: [prepare, build-bundles, docker-universal]
     if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,6 +430,86 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  docker-universal:
+    name: Build & push universal container image
+    needs: [prepare, docker]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write    # push to GHCR
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Docker meta (universal)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/kdlbs/kandev
+          tags: |
+            type=raw,value=${{ needs.prepare.outputs.version }}-universal
+            type=raw,value=${{ needs.prepare.outputs.tag }}-universal
+            type=raw,value=universal
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build universal on top of the vanilla image we just pushed. Passing
+      # the exact `:vX.Y.Z` tag (not `:latest`) keeps the pair coherent:
+      # universal-of-vX.Y.Z always rests on vanilla-vX.Y.Z, even if a later
+      # release moves `:latest`.
+      - name: Build and push (universal)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.universal
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BASE_IMAGE=ghcr.io/kdlbs/kandev:${{ needs.prepare.outputs.tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=universal
+          cache-to: type=gha,mode=max,scope=universal
+
+      # Universal size gate. Fails the release if compressed image exceeds
+      # the ceiling — forces deliberate decisions about scope creep. Bump
+      # this number in the same PR that adds the dependency that pushed
+      # over the line, with a one-sentence justification in the commit msg.
+      - name: Enforce size budget
+        env:
+          IMAGE: ghcr.io/kdlbs/kandev:${{ needs.prepare.outputs.tag }}-universal
+          MAX_COMPRESSED_BYTES: "2684354560"   # 2.5 GiB
+        run: |
+          set -euo pipefail
+          # Inspect the multi-arch manifest and sum compressed layer sizes
+          # for linux/amd64. amd64 is the bigger of the two arches in
+          # practice, so gating on it gives us a single-number signal.
+          docker buildx imagetools inspect "$IMAGE" --raw \
+              > /tmp/index.json
+          AMD64_DIGEST="$(jq -r '
+              .manifests[]
+              | select(.platform.architecture == "amd64" and .platform.os == "linux")
+              | .digest
+            ' /tmp/index.json)"
+          docker buildx imagetools inspect "ghcr.io/kdlbs/kandev@${AMD64_DIGEST}" --raw \
+              > /tmp/manifest.json
+          TOTAL="$(jq '[.layers[].size] | add' /tmp/manifest.json)"
+          echo "Universal image (amd64) compressed size: $TOTAL bytes (max: $MAX_COMPRESSED_BYTES)"
+          if [ "$TOTAL" -gt "$MAX_COMPRESSED_BYTES" ]; then
+            echo "::error::Universal image exceeds compressed-size budget. See docs/images.md inclusion policy." >&2
+            exit 1
+          fi
+
   publish-release:
     name: Publish GitHub release
     needs: [prepare, build-bundles]

--- a/.github/workflows/universal-rebuild.yml
+++ b/.github/workflows/universal-rebuild.yml
@@ -72,3 +72,29 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=universal
           cache-to: type=gha,mode=max,scope=universal
+
+      # Same size gate as release.yml's docker-universal job. A base-image
+      # update that adds significant weight (e.g. a new Debian dep pulled by
+      # apt security updates) would otherwise silently push an oversized
+      # `:universal` tag. Keep this MAX in sync with release.yml.
+      - name: Enforce size budget
+        env:
+          IMAGE: ghcr.io/kdlbs/kandev:universal
+          MAX_COMPRESSED_BYTES: "2684354560"   # 2.5 GiB
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "$IMAGE" --raw \
+              > /tmp/index.json
+          AMD64_DIGEST="$(jq -r '
+              .manifests[]
+              | select(.platform.architecture == "amd64" and .platform.os == "linux")
+              | .digest
+            ' /tmp/index.json)"
+          docker buildx imagetools inspect "ghcr.io/kdlbs/kandev@${AMD64_DIGEST}" --raw \
+              > /tmp/manifest.json
+          TOTAL="$(jq '[.layers[].size] | add' /tmp/manifest.json)"
+          echo "Universal image (amd64) compressed size: $TOTAL bytes (max: $MAX_COMPRESSED_BYTES)"
+          if [ "$TOTAL" -gt "$MAX_COMPRESSED_BYTES" ]; then
+            echo "::error::Universal weekly rebuild exceeds compressed-size budget. See docs/images.md inclusion policy." >&2
+            exit 1
+          fi

--- a/.github/workflows/universal-rebuild.yml
+++ b/.github/workflows/universal-rebuild.yml
@@ -9,6 +9,13 @@ name: universal-rebuild
 # - Does NOT push `:vX.Y.Z-universal`. Those are immutable per release;
 #   only the floating `:universal` and the dated weekly tags move here.
 #
+# Build flow mirrors release.yml's docker-universal: push to a per-run
+# staging tag, gate on size against the staging tag, then promote the
+# manifest to the user-facing tags via `buildx imagetools create`. The
+# promote step is metadata-only - no rebuild, no extra layer upload - so
+# a failed size gate aborts before `:universal` ever points at an
+# oversized image (the previous week's tag remains live).
+#
 # Manual trigger is also wired up so a maintainer can force a rebuild
 # after a known CVE without waiting for the cron.
 
@@ -29,21 +36,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      STAGING_IMAGE: ghcr.io/kdlbs/kandev:universal-staging-weekly-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Compute date tag
         id: date
         run: echo "tag=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/kdlbs/kandev
-          tags: |
-            type=raw,value=universal
-            type=raw,value=universal-weekly-${{ steps.date.outputs.tag }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -58,7 +58,7 @@ jobs:
       # weekly is to pick up any base-image moves. Use --pull so the
       # current :latest is freshly fetched, not whatever's in BuildKit's
       # cache from a previous run.
-      - name: Build and push
+      - name: Build and push (staging tag)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -68,22 +68,20 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BASE_IMAGE=ghcr.io/kdlbs/kandev:latest
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.STAGING_IMAGE }}
           cache-from: type=gha,scope=universal
           cache-to: type=gha,mode=max,scope=universal
 
       # Same size gate as release.yml's docker-universal job. A base-image
       # update that adds significant weight (e.g. a new Debian dep pulled by
-      # apt security updates) would otherwise silently push an oversized
-      # `:universal` tag. Keep this MAX in sync with release.yml.
+      # apt security updates) is caught here before :universal is promoted.
+      # Keep MAX in sync with release.yml.
       - name: Enforce size budget
         env:
-          IMAGE: ghcr.io/kdlbs/kandev:universal
           MAX_COMPRESSED_BYTES: "2684354560"   # 2.5 GiB
         run: |
           set -euo pipefail
-          docker buildx imagetools inspect "$IMAGE" --raw \
+          docker buildx imagetools inspect "$STAGING_IMAGE" --raw \
               > /tmp/index.json
           AMD64_DIGEST="$(jq -r '
               .manifests[]
@@ -95,6 +93,16 @@ jobs:
           TOTAL="$(jq '[.layers[].size] | add' /tmp/manifest.json)"
           echo "Universal image (amd64) compressed size: $TOTAL bytes (max: $MAX_COMPRESSED_BYTES)"
           if [ "$TOTAL" -gt "$MAX_COMPRESSED_BYTES" ]; then
-            echo "::error::Universal weekly rebuild exceeds compressed-size budget. See docs/images.md inclusion policy." >&2
+            echo "::error::Universal weekly rebuild exceeds compressed-size budget. Staging tag $STAGING_IMAGE will not be promoted; previous :universal remains live. See docs/images.md inclusion policy." >&2
             exit 1
           fi
+
+      # Promote: metadata-only retag from staging to the user-facing tags.
+      # If any earlier step fails, the previous :universal stays in place.
+      - name: Promote staging to final tags
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "ghcr.io/kdlbs/kandev:universal" \
+            --tag "ghcr.io/kdlbs/kandev:universal-weekly-${{ steps.date.outputs.tag }}" \
+            "$STAGING_IMAGE"

--- a/.github/workflows/universal-rebuild.yml
+++ b/.github/workflows/universal-rebuild.yml
@@ -1,0 +1,74 @@
+name: universal-rebuild
+
+# Weekly rebuild of the universal image on top of the current :latest
+# vanilla image, so apt security updates flow into universal even when
+# kandev itself hasn't been re-released.
+#
+# - Pushes a moving `:universal-weekly-YYYYMMDD` tag plus refreshes
+#   `:universal` (the "latest universal" alias).
+# - Does NOT push `:vX.Y.Z-universal`. Those are immutable per release;
+#   only the floating `:universal` and the dated weekly tags move here.
+#
+# Manual trigger is also wired up so a maintainer can force a rebuild
+# after a known CVE without waiting for the cron.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC. Picks up the previous week's Debian security
+    # patches without colliding with most weekday release work.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild:
+    name: Rebuild universal on top of :latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute date tag
+        id: date
+        run: echo "tag=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/kdlbs/kandev
+          tags: |
+            type=raw,value=universal
+            type=raw,value=universal-weekly-${{ steps.date.outputs.tag }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Rebuild against :latest deliberately — the whole point of the
+      # weekly is to pick up any base-image moves. Use --pull so the
+      # current :latest is freshly fetched, not whatever's in BuildKit's
+      # cache from a previous run.
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.universal
+          push: true
+          pull: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            BASE_IMAGE=ghcr.io/kdlbs/kandev:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=universal
+          cache-to: type=gha,mode=max,scope=universal

--- a/.github/workflows/universal-rebuild.yml
+++ b/.github/workflows/universal-rebuild.yml
@@ -54,7 +54,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Rebuild against :latest deliberately — the whole point of the
+      # Rebuild against :latest deliberately - the whole point of the
       # weekly is to pick up any base-image moves. Use --pull so the
       # current :latest is freshly fetched, not whatever's in BuildKit's
       # cache from a previous run.

--- a/.github/workflows/universal-rebuild.yml
+++ b/.github/workflows/universal-rebuild.yml
@@ -16,6 +16,13 @@ name: universal-rebuild
 # a failed size gate aborts before `:universal` ever points at an
 # oversized image (the previous week's tag remains live).
 #
+# Tradeoff: staging tags (one per weekly run) accumulate in GHCR. See the
+# comment in release.yml's docker-universal job for why per-run cleanup
+# isn't safe (shared manifest digest with promoted tags). A separate
+# cleanup workflow filtering for `universal-staging-*` versions whose
+# only tag matches is the right escape hatch if accumulation becomes a
+# problem; ~52 stale tags/year is acceptable in the meantime.
+#
 # Manual trigger is also wired up so a maintainer can force a rebuild
 # after a known CVE without waiting for the cron.
 

--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -1,0 +1,138 @@
+# Kandev Universal Dockerfile
+#
+# Extends the vanilla kandev image with language toolchains and developer
+# tools so agents can build/test code in the most common stacks without
+# extra setup. Built and published alongside vanilla in the release
+# workflow. Inclusion policy: see docs/images.md.
+#
+# Build:
+#   docker build -f Dockerfile.universal -t kandev:latest-universal .
+#
+# Run (drop-in replacement for the vanilla image):
+#   docker run -p 38429:38429 -v kandev-data:/data ghcr.io/kdlbs/kandev:latest-universal
+#
+# The BASE_IMAGE arg lets the release workflow point at a freshly built
+# vanilla image inside the same run (so universal-of-X.Y.Z is built on top
+# of vanilla-X.Y.Z, not on whatever :latest happens to be).
+
+ARG BASE_IMAGE=ghcr.io/kdlbs/kandev:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Pinned versions. Bump these deliberately; CI's size gate will catch growth.
+#
+# PLAYWRIGHT_VERSION pins the apt deps list. When this moves, the apt-get
+# install line below may need to add/drop packages — check the upstream list
+# at https://github.com/microsoft/playwright/blob/v<version>/packages/playwright-core/src/server/registry/nativeDeps.ts
+# or run `npx playwright@<version> install-deps --dry-run` to diff.
+ARG GO_VERSION=1.26.0
+ARG GOLANGCI_LINT_VERSION=1.62.0
+ARG PLAYWRIGHT_VERSION=1.48.0
+ARG PNPM_VERSION=9.15.9
+
+# Single RUN to minimize image layers and clean apt lists in the same layer.
+# Tools grouped by purpose; comments explain the why for each cluster so
+# future maintainers can prune deliberately rather than guess.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        # Native compile (CGO, pip wheels with C extensions, native npm modules)
+        build-essential \
+        pkg-config \
+        python3-dev \
+        libssl-dev \
+        # Useful CLI tools agents reach for. Small, broadly applicable.
+        ripgrep \
+        fd-find \
+        jq \
+        # Playwright Chromium runtime deps. Browsers themselves are NOT
+        # preinstalled — users run `pnpm exec playwright install chromium`
+        # once and the download persists at ~/.cache/ms-playwright on the PV.
+        # This list mirrors `npx playwright@${PLAYWRIGHT_VERSION} install-deps chromium`.
+        libnss3 \
+        libnspr4 \
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
+        libcups2 \
+        libdrm2 \
+        libxkbcommon0 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxfixes3 \
+        libxrandr2 \
+        libgbm1 \
+        libpango-1.0-0 \
+        libcairo2 \
+        libasound2 \
+        fonts-liberation \
+        fonts-noto-color-emoji \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+# Go toolchain — tarball install to /usr/local/go (the standard layout the
+# go.dev installer creates). Add to PATH below.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+        amd64) goarch=amd64 ;; \
+        arm64) goarch=arm64 ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${goarch}.tar.gz" -o /tmp/go.tar.gz; \
+    tar -C /usr/local -xzf /tmp/go.tar.gz; \
+    rm /tmp/go.tar.gz
+
+# golangci-lint — prebuilt binary, no compilation needed.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+        amd64) lintarch=amd64 ;; \
+        arm64) lintarch=arm64 ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}.tar.gz" \
+        | tar -xz -C /tmp; \
+    mv "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}/golangci-lint" /usr/local/bin/; \
+    rm -rf "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}"
+
+# Rust toolchain via rustup. RUSTUP_HOME/CARGO_HOME live in /usr/local so the
+# install is system-wide and read-only for non-root users at runtime —
+# matching the rest of the image. Users wanting per-user toolchain components
+# can still `rustup install` to ~/.rustup-user via overrides.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo
+RUN set -eux; \
+    curl -fsSL https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --no-modify-path --profile minimal; \
+    chmod -R a+rX "$RUSTUP_HOME" "$CARGO_HOME"
+
+# pnpm via corepack — install system-wide so users don't need
+# `corepack enable` themselves. Drops shims into /usr/local/bin.
+RUN set -eux; \
+    corepack enable; \
+    corepack prepare "pnpm@${PNPM_VERSION}" --activate
+
+# fd is installed as `fdfind` on Debian to avoid clashing with the legacy
+# fd package — symlink so agents calling plain `fd` still work.
+RUN ln -s /usr/bin/fdfind /usr/local/bin/fd
+
+# yq is not in Debian stable; install the prebuilt binary from upstream
+# (Mike Farah's yq, the Go implementation — the one most scripts assume).
+ARG YQ_VERSION=4.44.3
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${arch}" \
+        -o /usr/local/bin/yq; \
+    chmod +x /usr/local/bin/yq
+
+# Extend PATH with Go's bin (toolchain + $GOPATH/bin once users `go install`)
+# and cargo's bin. PATH order: keep agent CLI dir (/data/.npm-global/bin)
+# first so user-installed agents win over any same-named system tool, and
+# Cargo/Go after the existing system paths.
+ENV PATH=/data/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/usr/local/cargo/bin
+
+# Drop back to the unprivileged user. Matches the vanilla image's runtime
+# user; the docker-entrypoint.sh in the base image handles root → kandev
+# privilege drop via gosu for users who run the container as root.
+USER kandev

--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -9,7 +9,7 @@
 #   docker build -f Dockerfile.universal -t kandev:latest-universal .
 #
 # Run (drop-in replacement for the vanilla image):
-#   docker run -p 38429:38429 -v kandev-data:/data ghcr.io/kdlbs/kandev:latest-universal
+#   docker run -p 38429:38429 -v kandev-data:/data ghcr.io/kdlbs/kandev:universal
 #
 # The BASE_IMAGE arg lets the release workflow point at a freshly built
 # vanilla image inside the same run (so universal-of-X.Y.Z is built on top
@@ -22,13 +22,15 @@ USER root
 
 # Pinned versions. Bump these deliberately; CI's size gate will catch growth.
 #
-# PLAYWRIGHT_VERSION pins the apt deps list. When this moves, the apt-get
-# install line below may need to add/drop packages — check the upstream list
-# at https://github.com/microsoft/playwright/blob/v<version>/packages/playwright-core/src/server/registry/nativeDeps.ts
-# or run `npx playwright@<version> install-deps --dry-run` to diff.
+# The Playwright Chromium apt deps below are hand-derived against Playwright
+# 1.48.0. When that target moves, the apt-get install line may need to
+# add/drop packages — check the upstream list at
+# https://github.com/microsoft/playwright/blob/v<version>/packages/playwright-core/src/server/registry/nativeDeps.ts
+# or run `npx playwright@<version> install-deps --dry-run` to diff. (Tracked
+# only via this comment, not an ARG, since the apt package names are hardcoded
+# below and a build-arg override would silently disagree with what's installed.)
 ARG GO_VERSION=1.26.0
 ARG GOLANGCI_LINT_VERSION=1.62.0
-ARG PLAYWRIGHT_VERSION=1.48.0
 ARG PNPM_VERSION=9.15.9
 
 # Single RUN to minimize image layers and clean apt lists in the same layer.
@@ -49,7 +51,7 @@ RUN set -eux; \
         # Playwright Chromium runtime deps. Browsers themselves are NOT
         # preinstalled — users run `pnpm exec playwright install chromium`
         # once and the download persists at ~/.cache/ms-playwright on the PV.
-        # This list mirrors `npx playwright@${PLAYWRIGHT_VERSION} install-deps chromium`.
+        # This list mirrors `npx playwright@1.48.0 install-deps chromium`.
         libnss3 \
         libnspr4 \
         libatk1.0-0 \
@@ -72,6 +74,12 @@ RUN set -eux; \
 
 # Go toolchain — tarball install to /usr/local/go (the standard layout the
 # go.dev installer creates). Add to PATH below.
+#
+# Integrity: go.dev publishes a per-tarball `.sha256` file (a bare hex hash,
+# no filename), fetched alongside the tarball and verified before extraction.
+# This is TOFU on first fetch; if the go.dev CDN itself is compromised both
+# files are bad. Strongest available option without bumping the hash inline
+# every Go release.
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
@@ -80,10 +88,16 @@ RUN set -eux; \
         *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
     esac; \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${goarch}.tar.gz" -o /tmp/go.tar.gz; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${goarch}.tar.gz.sha256" -o /tmp/go.tar.gz.sha256; \
+    echo "$(cat /tmp/go.tar.gz.sha256)  /tmp/go.tar.gz" | sha256sum -c -; \
     tar -C /usr/local -xzf /tmp/go.tar.gz; \
-    rm /tmp/go.tar.gz
+    rm /tmp/go.tar.gz /tmp/go.tar.gz.sha256
 
 # golangci-lint — prebuilt binary, no compilation needed.
+# Integrity: each release publishes a single `*-checksums.txt` file with
+# `<sha256>  <filename>` lines for every artifact. Grep for our tarball,
+# pipe to `sha256sum -c -`. Download into /tmp and cd there so the relative
+# filename in the checksum line resolves.
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
@@ -91,10 +105,14 @@ RUN set -eux; \
         arm64) lintarch=arm64 ;; \
         *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}.tar.gz" \
-        | tar -xz -C /tmp; \
+    tarball="golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}.tar.gz"; \
+    base="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}"; \
+    curl -fsSL "${base}/${tarball}" -o "/tmp/${tarball}"; \
+    curl -fsSL "${base}/golangci-lint-${GOLANGCI_LINT_VERSION}-checksums.txt" -o /tmp/golangci-lint-checksums.txt; \
+    (cd /tmp && grep "  ${tarball}$" golangci-lint-checksums.txt | sha256sum -c -); \
+    tar -xz -C /tmp -f "/tmp/${tarball}"; \
     mv "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}/golangci-lint" /usr/local/bin/; \
-    rm -rf "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}"
+    rm -rf "/tmp/${tarball}" "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}" /tmp/golangci-lint-checksums.txt
 
 # Rust toolchain via rustup. RUSTUP_HOME/CARGO_HOME live in /usr/local so the
 # install is system-wide and read-only for non-root users at runtime —
@@ -119,18 +137,34 @@ RUN ln -s /usr/bin/fdfind /usr/local/bin/fd
 
 # yq is not in Debian stable; install the prebuilt binary from upstream
 # (Mike Farah's yq, the Go implementation — the one most scripts assume).
+#
+# Integrity: mikefarah/yq publishes a `checksums` file with one row per
+# artifact and multiple hash columns, plus a `checksums_hashes_order` file
+# that lists which hash algorithm corresponds to each column. We compute the
+# SHA-256 column index dynamically (defensive against upstream reordering)
+# and verify the binary against that column before installing.
 ARG YQ_VERSION=4.44.3
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
-    curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${arch}" \
-        -o /usr/local/bin/yq; \
-    chmod +x /usr/local/bin/yq
+    target="yq_linux_${arch}"; \
+    base="https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}"; \
+    curl -fsSL "${base}/checksums" -o /tmp/yq-checksums; \
+    curl -fsSL "${base}/checksums_hashes_order" -o /tmp/yq-hashes-order; \
+    sha256_col="$(awk '/^SHA-256$/ {print NR + 1; exit}' /tmp/yq-hashes-order)"; \
+    if [ -z "$sha256_col" ]; then echo "SHA-256 not in upstream checksums_hashes_order" >&2; exit 1; fi; \
+    expected="$(awk -v t="$target" -v c="$sha256_col" '$1==t {print $c}' /tmp/yq-checksums)"; \
+    if [ -z "$expected" ]; then echo "no checksum row for $target" >&2; exit 1; fi; \
+    curl -fsSL "${base}/${target}" -o /usr/local/bin/yq; \
+    echo "${expected}  /usr/local/bin/yq" | sha256sum -c -; \
+    chmod +x /usr/local/bin/yq; \
+    rm /tmp/yq-checksums /tmp/yq-hashes-order
 
-# Extend PATH with Go's bin (toolchain + $GOPATH/bin once users `go install`)
-# and cargo's bin. PATH order: keep agent CLI dir (/data/.npm-global/bin)
-# first so user-installed agents win over any same-named system tool, and
-# Cargo/Go after the existing system paths.
-ENV PATH=/data/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/usr/local/cargo/bin
+# Append Go's bin (toolchain + $GOPATH/bin once users `go install`) and
+# cargo's bin to whatever PATH the base image set. Appending rather than
+# hardcoding the full list keeps the agent CLI dir (/data/.npm-global/bin)
+# first — as the base image already arranges — and stays correct if the
+# base image's PATH ever changes.
+ENV PATH=$PATH:/usr/local/go/bin:/usr/local/cargo/bin
 
 # Drop back to the unprivileged user. Matches the vanilla image's runtime
 # user; the docker-entrypoint.sh in the base image handles root → kandev

--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -116,19 +116,36 @@ RUN set -eux; \
 
 # Rust toolchain via rustup. RUSTUP_HOME/CARGO_HOME live in /usr/local so the
 # install is system-wide and read-only for non-root users at runtime -
-# matching the rest of the image. Users wanting per-user toolchain components
-# can still `rustup install` to ~/.rustup-user via overrides.
+# matching the rest of the image. Users who need writable per-user state
+# (e.g. `cargo install <tool>`, `rustup toolchain install nightly`) should
+# override CARGO_HOME and RUSTUP_HOME to a path on the PV, e.g.:
+#   CARGO_HOME=~/.cargo RUSTUP_HOME=~/.rustup cargo install <tool>
 #
 # `--profile minimal` keeps the install lean (rustc + cargo + rust-std); we
 # then explicitly add clippy and rustfmt, which agents working on Rust
 # projects almost always reach for. `--profile default` would also work but
 # pulls in rust-docs which we don't need.
+#
+# Integrity: download rustup-init for our arch and verify its SHA-256
+# against the upstream .sha256 sidecar before executing - matches the
+# pattern used for Go/golangci-lint/yq above, rather than `curl | sh`.
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo
 RUN set -eux; \
-    curl -fsSL https://sh.rustup.rs \
-        | sh -s -- -y --default-toolchain stable --no-modify-path --profile minimal; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+        amd64) triplet=x86_64-unknown-linux-gnu ;; \
+        arm64) triplet=aarch64-unknown-linux-gnu ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    base="https://static.rust-lang.org/rustup/dist/${triplet}"; \
+    curl -fsSL "${base}/rustup-init" -o /tmp/rustup-init; \
+    curl -fsSL "${base}/rustup-init.sha256" -o /tmp/rustup-init.sha256; \
+    (cd /tmp && sha256sum -c rustup-init.sha256); \
+    chmod +x /tmp/rustup-init; \
+    /tmp/rustup-init -y --default-toolchain stable --no-modify-path --profile minimal; \
     /usr/local/cargo/bin/rustup component add --toolchain stable clippy rustfmt; \
+    rm /tmp/rustup-init /tmp/rustup-init.sha256; \
     chmod -R a+rX "$RUSTUP_HOME" "$CARGO_HOME"
 
 # pnpm via corepack - install system-wide so users don't need

--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -118,11 +118,17 @@ RUN set -eux; \
 # install is system-wide and read-only for non-root users at runtime -
 # matching the rest of the image. Users wanting per-user toolchain components
 # can still `rustup install` to ~/.rustup-user via overrides.
+#
+# `--profile minimal` keeps the install lean (rustc + cargo + rust-std); we
+# then explicitly add clippy and rustfmt, which agents working on Rust
+# projects almost always reach for. `--profile default` would also work but
+# pulls in rust-docs which we don't need.
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo
 RUN set -eux; \
     curl -fsSL https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable --no-modify-path --profile minimal; \
+    /usr/local/cargo/bin/rustup component add --toolchain stable clippy rustfmt; \
     chmod -R a+rX "$RUSTUP_HOME" "$CARGO_HOME"
 
 # pnpm via corepack - install system-wide so users don't need
@@ -154,16 +160,21 @@ RUN set -eux; \
     if [ -z "$sha256_col" ]; then echo "SHA-256 not in upstream checksums_hashes_order" >&2; exit 1; fi; \
     expected="$(awk -v t="$target" -v c="$sha256_col" '$1==t {print $c}' /tmp/yq-checksums)"; \
     if [ -z "$expected" ]; then echo "no checksum row for $target" >&2; exit 1; fi; \
-    curl -fsSL "${base}/${target}" -o /usr/local/bin/yq; \
-    echo "${expected}  /usr/local/bin/yq" | sha256sum -c -; \
+    curl -fsSL "${base}/${target}" -o /tmp/yq; \
+    echo "${expected}  /tmp/yq" | sha256sum -c -; \
+    mv /tmp/yq /usr/local/bin/yq; \
     chmod +x /usr/local/bin/yq; \
     rm /tmp/yq-checksums /tmp/yq-hashes-order
 
-# Append Go's bin (toolchain + $GOPATH/bin once users `go install`) and
-# cargo's bin to whatever PATH the base image set. Appending rather than
-# hardcoding the full list keeps the agent CLI dir (/data/.npm-global/bin)
-# first - as the base image already arranges - and stays correct if the
-# base image's PATH ever changes.
+# Append Go's toolchain bin and cargo's bin to whatever PATH the base image
+# set. Appending rather than hardcoding the full list keeps the agent CLI
+# dir (/data/.npm-global/bin) first - as the base image already arranges -
+# and stays correct if the base image's PATH ever changes.
+#
+# Note: $GOPATH/bin (defaults to ~/go/bin, i.e. /data/home/go/bin in this
+# image) is NOT added here - it's user-specific and lives on the PV. Users
+# who `go install` tools and want them on PATH should add it to their shell
+# profile (e.g. `export PATH=$PATH:$(go env GOPATH)/bin`).
 ENV PATH=$PATH:/usr/local/go/bin:/usr/local/cargo/bin
 
 # Drop back to the unprivileged user. Matches the vanilla image's runtime

--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -24,7 +24,7 @@ USER root
 #
 # The Playwright Chromium apt deps below are hand-derived against Playwright
 # 1.48.0. When that target moves, the apt-get install line may need to
-# add/drop packages — check the upstream list at
+# add/drop packages - check the upstream list at
 # https://github.com/microsoft/playwright/blob/v<version>/packages/playwright-core/src/server/registry/nativeDeps.ts
 # or run `npx playwright@<version> install-deps --dry-run` to diff. (Tracked
 # only via this comment, not an ARG, since the apt package names are hardcoded
@@ -49,7 +49,7 @@ RUN set -eux; \
         fd-find \
         jq \
         # Playwright Chromium runtime deps. Browsers themselves are NOT
-        # preinstalled — users run `pnpm exec playwright install chromium`
+        # preinstalled - users run `pnpm exec playwright install chromium`
         # once and the download persists at ~/.cache/ms-playwright on the PV.
         # This list mirrors `npx playwright@1.48.0 install-deps chromium`.
         libnss3 \
@@ -72,7 +72,7 @@ RUN set -eux; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
-# Go toolchain — tarball install to /usr/local/go (the standard layout the
+# Go toolchain - tarball install to /usr/local/go (the standard layout the
 # go.dev installer creates). Add to PATH below.
 #
 # Integrity: go.dev publishes a per-tarball `.sha256` file (a bare hex hash,
@@ -93,7 +93,7 @@ RUN set -eux; \
     tar -C /usr/local -xzf /tmp/go.tar.gz; \
     rm /tmp/go.tar.gz /tmp/go.tar.gz.sha256
 
-# golangci-lint — prebuilt binary, no compilation needed.
+# golangci-lint - prebuilt binary, no compilation needed.
 # Integrity: each release publishes a single `*-checksums.txt` file with
 # `<sha256>  <filename>` lines for every artifact. Grep for our tarball,
 # pipe to `sha256sum -c -`. Download into /tmp and cd there so the relative
@@ -115,7 +115,7 @@ RUN set -eux; \
     rm -rf "/tmp/${tarball}" "/tmp/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-${lintarch}" /tmp/golangci-lint-checksums.txt
 
 # Rust toolchain via rustup. RUSTUP_HOME/CARGO_HOME live in /usr/local so the
-# install is system-wide and read-only for non-root users at runtime —
+# install is system-wide and read-only for non-root users at runtime -
 # matching the rest of the image. Users wanting per-user toolchain components
 # can still `rustup install` to ~/.rustup-user via overrides.
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -125,18 +125,18 @@ RUN set -eux; \
         | sh -s -- -y --default-toolchain stable --no-modify-path --profile minimal; \
     chmod -R a+rX "$RUSTUP_HOME" "$CARGO_HOME"
 
-# pnpm via corepack — install system-wide so users don't need
+# pnpm via corepack - install system-wide so users don't need
 # `corepack enable` themselves. Drops shims into /usr/local/bin.
 RUN set -eux; \
     corepack enable; \
     corepack prepare "pnpm@${PNPM_VERSION}" --activate
 
 # fd is installed as `fdfind` on Debian to avoid clashing with the legacy
-# fd package — symlink so agents calling plain `fd` still work.
+# fd package - symlink so agents calling plain `fd` still work.
 RUN ln -s /usr/bin/fdfind /usr/local/bin/fd
 
 # yq is not in Debian stable; install the prebuilt binary from upstream
-# (Mike Farah's yq, the Go implementation — the one most scripts assume).
+# (Mike Farah's yq, the Go implementation - the one most scripts assume).
 #
 # Integrity: mikefarah/yq publishes a `checksums` file with one row per
 # artifact and multiple hash columns, plus a `checksums_hashes_order` file
@@ -162,7 +162,7 @@ RUN set -eux; \
 # Append Go's bin (toolchain + $GOPATH/bin once users `go install`) and
 # cargo's bin to whatever PATH the base image set. Appending rather than
 # hardcoding the full list keeps the agent CLI dir (/data/.npm-global/bin)
-# first — as the base image already arranges — and stays correct if the
+# first - as the base image already arranges - and stays correct if the
 # base image's PATH ever changes.
 ENV PATH=$PATH:/usr/local/go/bin:/usr/local/cargo/bin
 

--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -150,6 +150,12 @@ RUN set -eux; \
 
 # pnpm via corepack - install system-wide so users don't need
 # `corepack enable` themselves. Drops shims into /usr/local/bin.
+#
+# No separate sha256 step: corepack downloads from registry.npmjs.org and
+# verifies the tarball against the registry's `integrity` field (SHA-512)
+# before activating. The other tools above pin upstream `.sha256` sidecars
+# because they're served from CDNs that don't expose package integrity at
+# the API level; npm does. Decision is deliberate, not an oversight.
 RUN set -eux; \
     corepack enable; \
     corepack prepare "pnpm@${PNPM_VERSION}" --activate

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -27,7 +27,7 @@ docker pull ghcr.io/kdlbs/kandev:0.9.0
 Two flavors are published. The default vanilla image is smallest and bundles npm-installable agent CLIs only. The `:universal` image (~1.4 GB) adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs — pick this if your agents work on Go/Rust/Python projects or drive headless browsers.
 
 ```bash
-docker pull ghcr.io/kdlbs/kandev:latest-universal
+docker pull ghcr.io/kdlbs/kandev:universal
 ```
 
 See [`images.md`](./images.md) for the full comparison, inclusion policy, and recipes for deriving your own image.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -22,6 +22,16 @@ docker pull ghcr.io/kdlbs/kandev:latest
 docker pull ghcr.io/kdlbs/kandev:0.9.0
 ```
 
+### Choosing your image: vanilla vs. universal
+
+Two flavors are published. The default vanilla image is smallest and bundles npm-installable agent CLIs only. The `:universal` image (~1.4 GB) adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs — pick this if your agents work on Go/Rust/Python projects or drive headless browsers.
+
+```bash
+docker pull ghcr.io/kdlbs/kandev:latest-universal
+```
+
+See [`images.md`](./images.md) for the full comparison, inclusion policy, and recipes for deriving your own image.
+
 ## Building from Source
 
 From the repository root:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -24,7 +24,7 @@ docker pull ghcr.io/kdlbs/kandev:0.9.0
 
 ### Choosing your image: vanilla vs. universal
 
-Two flavors are published. The default vanilla image is smallest and bundles npm-installable agent CLIs only. The `:universal` image (~1.4 GB) adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs — pick this if your agents work on Go/Rust/Python projects or drive headless browsers.
+Two flavors are published. The default vanilla image is smallest and bundles npm-installable agent CLIs only. The `:universal` image (~1.4 GB) adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs - pick this if your agents work on Go/Rust/Python projects or drive headless browsers.
 
 ```bash
 docker pull ghcr.io/kdlbs/kandev:universal

--- a/docs/images.md
+++ b/docs/images.md
@@ -107,20 +107,21 @@ USER kandev
 
 ### Recipe: preinstall a specific agent CLI version
 
-The Settings → Agents *Install* button calls `npm install -g` at runtime. If you want a fixed version baked into the image (so every container starts with it), do it at build time:
+The Settings → Agents *Install* button calls `npm install -g` at runtime. If you want a fixed version baked into the image (so every container starts with it), do it at build time - and install **outside** `/data`, otherwise the named volume mounted at `/data` will shadow your install on every container after the first one is created:
 
 ```dockerfile
 FROM ghcr.io/kdlbs/kandev:0.45.0
 
 USER root
-ENV NPM_CONFIG_PREFIX=/data/.npm-global
-RUN mkdir -p /data/.npm-global \
- && npm install -g @anthropic-ai/claude-code@1.2.3 \
- && chown -R kandev:kandev /data/.npm-global
+# Install to /usr/local (NOT /data/.npm-global, which is on the named volume
+# and only seeded on first volume creation). /usr/local/bin is already on
+# PATH after /data/.npm-global/bin, so a user-installed runtime version
+# would still win if anyone adds one later.
+RUN npm install -g --prefix /usr/local @anthropic-ai/claude-code@1.2.3
 USER kandev
 ```
 
-Note: at runtime kandev users will see the agent as already installed, but baking it in means the version is tied to your image rather than to user choice.
+Note: kandev users will see the agent as already installed on the agents page. Baking it in means the version is tied to your image rather than to user choice - if a user runtime-installs a different version, that one wins (because the runtime path `/data/.npm-global/bin` precedes `/usr/local/bin` on `$PATH`).
 
 ## What if I need something that doesn't fit any of these patterns?
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,13 +1,13 @@
 # Choosing a Kandev Image
 
-Kandev publishes two container image flavors to GitHub Container Registry. Both are functionally identical kandev — same backend, same web UI, same persistence model. They differ only in what *else* is preinstalled in the image.
+Kandev publishes two container image flavors to GitHub Container Registry. Both are functionally identical kandev - same backend, same web UI, same persistence model. They differ only in what *else* is preinstalled in the image.
 
 | Tag                                     | Size (compressed) | Contents                                                                 | Pick when…                                                                                                       |
 |-----------------------------------------|-------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
 | `ghcr.io/kdlbs/kandev:X.Y.Z`            | ~600 MB           | kandev + Node 24 + npm + git + gh + python3 + pipx                       | You only need npm-installable agent CLIs (claude-code, codex, …) and want the smallest possible footprint.       |
 | `ghcr.io/kdlbs/kandev:X.Y.Z-universal`  | ~1.4 GB           | vanilla **+** language toolchains, build tools, Playwright Chromium deps | Your agents work on Go / Rust / Python projects, run native test suites, or drive headless browsers.             |
 
-`:latest` aliases the vanilla image; `:universal` aliases the latest universal. **Tag pinning is strongly recommended in production** — `:latest` moves and we don't promise it stays the same forever.
+`:latest` aliases the vanilla image; `:universal` aliases the latest universal. **Tag pinning is strongly recommended in production** - `:latest` moves and we don't promise it stays the same forever.
 
 ## What's in `:universal` (and what's not)
 
@@ -17,11 +17,11 @@ Kandev publishes two container image flavors to GitHub Container Registry. Both 
 
 **Linters and developer CLIs:** `golangci-lint`, `ripgrep`, `fd`, `jq`, `yq`.
 
-**Playwright Chromium system libraries** (browsers themselves are *not* preinstalled — see below).
+**Playwright Chromium system libraries** (browsers themselves are *not* preinstalled - see below).
 
 **Not included:**
 
-- **JDKs / .NET / Mono** — out of scope in v1; if these matter to your workflow, derive your own image (see *Customizing your image* below).
+- **JDKs / .NET / Mono** - out of scope in v1; if these matter to your workflow, derive your own image (see *Customizing your image* below).
 - **Playwright browsers** (`chromium`, `firefox`, `webkit`). Run `pnpm exec playwright install chromium` (or whichever browsers you need) once after the container starts. Downloads land at `~/.cache/ms-playwright`, which lives on the PV under `HOME=/data/home` and survives pod restarts. This keeps universal under 1.5 GB; it adds a one-time setup command per agent that wants browsers.
 - **Database servers** (Postgres, MySQL, Redis). Use a sidecar or external service.
 - **Kandev's own test dependencies beyond what's listed above.** Universal *is* enough to run kandev's backend Go tests, but the Playwright e2e suite needs the user to `pnpm install` and run `playwright install` first, same as on a fresh dev machine.
@@ -35,7 +35,7 @@ We add a tool to universal when **all four** of these hold:
 3. It adds less than 200 MB to the installed image.
 4. It doesn't carry a license that conflicts with redistributing the image.
 
-We **decline** additions that fail any of these. The escape hatch is always *derive your own image* — see below.
+We **decline** additions that fail any of these. The escape hatch is always *derive your own image* - see below.
 
 ## Switching between flavors
 
@@ -57,7 +57,7 @@ All your data (database, worktrees, npm globals, agent auth state) carries over 
 
 ## Customizing your image
 
-Universal is opinionated. If you need something it doesn't include — a JDK, a private apt repository, a specific Node version, your company's CA cert — **derive your own image** from whichever base fits.
+Universal is opinionated. If you need something it doesn't include - a JDK, a private apt repository, a specific Node version, your company's CA cert - **derive your own image** from whichever base fits.
 
 The pattern: a tiny Dockerfile that does `FROM ghcr.io/kdlbs/kandev:X.Y.Z` (or `…:X.Y.Z-universal`), drops back to root, installs what you need, drops back to `kandev`. Build it, push it to a registry you control, point your deployment at it.
 
@@ -137,7 +137,7 @@ The repository also contains the source Dockerfiles (`Dockerfile` and `Dockerfil
 # Vanilla
 docker build -t kandev:dev .
 
-# Universal (depends on a vanilla base — build vanilla first if you want a
+# Universal (depends on a vanilla base - build vanilla first if you want a
 # fully-from-source universal, or let BASE_IMAGE default to the published one)
 docker build -f Dockerfile.universal --build-arg BASE_IMAGE=kandev:dev -t kandev:dev-universal .
 ```

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,145 @@
+# Choosing a Kandev Image
+
+Kandev publishes two container image flavors to GitHub Container Registry. Both are functionally identical kandev — same backend, same web UI, same persistence model. They differ only in what *else* is preinstalled in the image.
+
+| Tag                                     | Size (compressed) | Contents                                                                 | Pick when…                                                                                                       |
+|-----------------------------------------|-------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+| `ghcr.io/kdlbs/kandev:X.Y.Z`            | ~600 MB           | kandev + Node 24 + npm + git + gh + python3 + pipx                       | You only need npm-installable agent CLIs (claude-code, codex, …) and want the smallest possible footprint.       |
+| `ghcr.io/kdlbs/kandev:X.Y.Z-universal`  | ~1.4 GB           | vanilla **+** language toolchains, build tools, Playwright Chromium deps | Your agents work on Go / Rust / Python projects, run native test suites, or drive headless browsers.             |
+
+`:latest` aliases the vanilla image; `:universal` aliases the latest universal. **Tag pinning is strongly recommended in production** — `:latest` moves and we don't promise it stays the same forever.
+
+## What's in `:universal` (and what's not)
+
+**Language toolchains:** Go (latest stable), Rust (rustup, stable default toolchain), pnpm (preinstalled via corepack so `pnpm` is on `$PATH` for everyone).
+
+**Build essentials:** `build-essential` (gcc, g++, make, libc-dev), `pkg-config`, `python3-dev`, `libssl-dev`. These cover CGO compilation, native Python pip wheels, and native Node modules.
+
+**Linters and developer CLIs:** `golangci-lint`, `ripgrep`, `fd`, `jq`, `yq`.
+
+**Playwright Chromium system libraries** (browsers themselves are *not* preinstalled — see below).
+
+**Not included:**
+
+- **JDKs / .NET / Mono** — out of scope in v1; if these matter to your workflow, derive your own image (see *Customizing your image* below).
+- **Playwright browsers** (`chromium`, `firefox`, `webkit`). Run `pnpm exec playwright install chromium` (or whichever browsers you need) once after the container starts. Downloads land at `~/.cache/ms-playwright`, which lives on the PV under `HOME=/data/home` and survives pod restarts. This keeps universal under 1.5 GB; it adds a one-time setup command per agent that wants browsers.
+- **Database servers** (Postgres, MySQL, Redis). Use a sidecar or external service.
+- **Kandev's own test dependencies beyond what's listed above.** Universal *is* enough to run kandev's backend Go tests, but the Playwright e2e suite needs the user to `pnpm install` and run `playwright install` first, same as on a fresh dev machine.
+
+## Inclusion policy
+
+We add a tool to universal when **all four** of these hold:
+
+1. It's commonly needed by agent-driven dev workflows (Go/Rust/Python/Node project work).
+2. It's reasonably available in apt or a well-maintained prebuilt binary.
+3. It adds less than 200 MB to the installed image.
+4. It doesn't carry a license that conflicts with redistributing the image.
+
+We **decline** additions that fail any of these. The escape hatch is always *derive your own image* — see below.
+
+## Switching between flavors
+
+There is no migration. Both images mount `/data` the same way and use the same database schema. To switch a running deployment:
+
+**Docker:**
+```bash
+docker pull ghcr.io/kdlbs/kandev:X.Y.Z-universal
+docker stop kandev && docker rm kandev
+docker run -p 38429:38429 -v kandev-data:/data ghcr.io/kdlbs/kandev:X.Y.Z-universal
+```
+
+**Kubernetes:**
+```bash
+kubectl set image deployment/kandev kandev=ghcr.io/kdlbs/kandev:X.Y.Z-universal
+```
+
+All your data (database, worktrees, npm globals, agent auth state) carries over because it lives on the PV, not in the image.
+
+## Customizing your image
+
+Universal is opinionated. If you need something it doesn't include — a JDK, a private apt repository, a specific Node version, your company's CA cert — **derive your own image** from whichever base fits.
+
+The pattern: a tiny Dockerfile that does `FROM ghcr.io/kdlbs/kandev:X.Y.Z` (or `…:X.Y.Z-universal`), drops back to root, installs what you need, drops back to `kandev`. Build it, push it to a registry you control, point your deployment at it.
+
+### Recipe: add a JDK on top of universal
+
+```dockerfile
+FROM ghcr.io/kdlbs/kandev:0.45.0-universal
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openjdk-21-jdk-headless \
+    && rm -rf /var/lib/apt/lists/*
+USER kandev
+```
+
+```bash
+docker build -t my-registry.example.com/kandev:0.45.0-jdk .
+docker push my-registry.example.com/kandev:0.45.0-jdk
+kubectl set image deployment/kandev kandev=my-registry.example.com/kandev:0.45.0-jdk
+```
+
+### Recipe: lightweight extras on top of vanilla
+
+If universal is too big for you but you need a couple of specific tools:
+
+```dockerfile
+FROM ghcr.io/kdlbs/kandev:0.45.0
+
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        make \
+        rsync \
+    && rm -rf /var/lib/apt/lists/*
+USER kandev
+```
+
+### Recipe: bake a corporate CA cert
+
+```dockerfile
+FROM ghcr.io/kdlbs/kandev:0.45.0-universal
+
+USER root
+COPY corporate-ca.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+USER kandev
+```
+
+### Recipe: preinstall a specific agent CLI version
+
+The Settings → Agents *Install* button calls `npm install -g` at runtime. If you want a fixed version baked into the image (so every container starts with it), do it at build time:
+
+```dockerfile
+FROM ghcr.io/kdlbs/kandev:0.45.0
+
+USER root
+ENV NPM_CONFIG_PREFIX=/data/.npm-global
+RUN mkdir -p /data/.npm-global \
+ && npm install -g @anthropic-ai/claude-code@1.2.3 \
+ && chown -R kandev:kandev /data/.npm-global
+USER kandev
+```
+
+Note: at runtime kandev users will see the agent as already installed, but baking it in means the version is tied to your image rather than to user choice.
+
+## What if I need something that doesn't fit any of these patterns?
+
+Two reasonable paths:
+
+1. **Open an issue** suggesting an addition to universal. Cite (a) the workflow that needs it, (b) the installed size, (c) whether it's apt-available or needs a prebuilt binary. We'll evaluate against the inclusion policy.
+2. **Just maintain your own derived image.** This is what most teams end up doing for org-specific needs (corporate CAs, internal tools, JDK pinning). It's a 10-line Dockerfile and a 2-line CI step.
+
+## A note on building locally
+
+The repository also contains the source Dockerfiles (`Dockerfile` and `Dockerfile.universal`). You can build either locally:
+
+```bash
+# Vanilla
+docker build -t kandev:dev .
+
+# Universal (depends on a vanilla base — build vanilla first if you want a
+# fully-from-source universal, or let BASE_IMAGE default to the published one)
+docker build -f Dockerfile.universal --build-arg BASE_IMAGE=kandev:dev -t kandev:dev-universal .
+```
+
+In CI we always build vanilla first and pass its tag as `BASE_IMAGE` to the universal build, so a single release run produces a matched `vX.Y.Z` + `vX.Y.Z-universal` pair.

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -40,7 +40,7 @@ image: ghcr.io/kdlbs/kandev:latest
 
 ### Choosing your image: vanilla vs. universal
 
-Kandev publishes two flavors: the default vanilla image (smallest, npm-installable agent CLIs only) and a `:universal` image (~1.4 GB) that adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs — useful when your agents work on Go/Rust/Python projects or drive headless browsers.
+Kandev publishes two flavors: the default vanilla image (smallest, npm-installable agent CLIs only) and a `:universal` image (~1.4 GB) that adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs - useful when your agents work on Go/Rust/Python projects or drive headless browsers.
 
 ```yaml
 image: ghcr.io/kdlbs/kandev:universal
@@ -90,7 +90,7 @@ No extra configuration is needed. The frontend automatically uses `window.locati
 
 The kandev image ships with `git`, `gh` (GitHub CLI), `node`, and `npm`, but **does not bundle the coding-agent CLIs** (`claude-code`, `codex`, `auggie`, etc.) — agent choice is per-user, and bundling all of them would bloat the image significantly.
 
-> Looking to add tools *beyond* agent CLIs — language toolchains, build tools, internal CLIs? See [`images.md`](./images.md) for the universal-image option and recipes for deriving your own image.
+> Looking to add tools *beyond* agent CLIs - language toolchains, build tools, internal CLIs? See [`images.md`](./images.md) for the universal-image option and recipes for deriving your own image.
 
 To install an agent inside the running pod, open **Settings → Agents** in the UI and click **Install** on the agent card under "Available to Install". The backend runs the agent's hard-coded install script (`npm install -g <pkg>`) and rescans on success.
 

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -43,7 +43,7 @@ image: ghcr.io/kdlbs/kandev:latest
 Kandev publishes two flavors: the default vanilla image (smallest, npm-installable agent CLIs only) and a `:universal` image (~1.4 GB) that adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs — useful when your agents work on Go/Rust/Python projects or drive headless browsers.
 
 ```yaml
-image: ghcr.io/kdlbs/kandev:latest-universal
+image: ghcr.io/kdlbs/kandev:universal
 ```
 
 See [`images.md`](./images.md) for the full comparison, inclusion policy, and recipes for deriving your own image when you need something neither flavor includes.

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -38,6 +38,16 @@ Or reference it in your K8s deployment:
 image: ghcr.io/kdlbs/kandev:latest
 ```
 
+### Choosing your image: vanilla vs. universal
+
+Kandev publishes two flavors: the default vanilla image (smallest, npm-installable agent CLIs only) and a `:universal` image (~1.4 GB) that adds language toolchains (Go, Rust, build-essential), linters, and Playwright Chromium system libs — useful when your agents work on Go/Rust/Python projects or drive headless browsers.
+
+```yaml
+image: ghcr.io/kdlbs/kandev:latest-universal
+```
+
+See [`images.md`](./images.md) for the full comparison, inclusion policy, and recipes for deriving your own image when you need something neither flavor includes.
+
 ## Deploying to Kubernetes
 
 ### Quick Start
@@ -79,6 +89,8 @@ No extra configuration is needed. The frontend automatically uses `window.locati
 ## Installing Agent CLIs
 
 The kandev image ships with `git`, `gh` (GitHub CLI), `node`, and `npm`, but **does not bundle the coding-agent CLIs** (`claude-code`, `codex`, `auggie`, etc.) — agent choice is per-user, and bundling all of them would bloat the image significantly.
+
+> Looking to add tools *beyond* agent CLIs — language toolchains, build tools, internal CLIs? See [`images.md`](./images.md) for the universal-image option and recipes for deriving your own image.
 
 To install an agent inside the running pod, open **Settings → Agents** in the UI and click **Install** on the agent card under "Available to Install". The backend runs the agent's hard-coded install script (`npm install -g <pkg>`) and rescans on success.
 


### PR DESCRIPTION
## Summary

Introduces a second published container image flavor — `ghcr.io/kdlbs/kandev:X.Y.Z-universal` — alongside the existing vanilla image. Pattern modeled on `openai/codex-universal` and GitHub Actions runner images: one minimal, one batteries-included.

Today the only kandev image is the small vanilla one (~600 MB). Anything beyond npm-installable agent CLIs requires either ephemeral `kubectl exec apt-get install` (lost on restart) or a custom derived image. Universal covers the common "agents working on real Go/Rust/Python/Playwright projects" case out of the box.

## What's in `:universal` vs vanilla

| | Vanilla | Universal |
|---|---|---|
| Size (compressed, target) | ~600 MB | ~1.4 GB |
| Node 24 + npm + git + gh + python3 + pipx | ✅ | ✅ |
| Go (latest stable) + golangci-lint | — | ✅ |
| Rust (rustup, stable toolchain) | — | ✅ |
| `build-essential`, `pkg-config`, `python3-dev`, `libssl-dev` | — | ✅ |
| `ripgrep`, `fd`, `jq`, `yq`, `pnpm` (via corepack) | — | ✅ |
| Playwright Chromium **system libs** (browsers themselves: not preinstalled) | — | ✅ |

Both share the same `/data` volume layout and DB schema, so switching between them is `kubectl set image` / `docker pull` with zero migration.

## Inclusion policy

`docs/images.md` codifies a four-rule policy so universal doesn't drift into a kitchen sink: an addition must be (a) commonly needed by agent-driven dev workflows, (b) apt-available or a well-maintained prebuilt binary, (c) <200 MB installed, (d) license-compatible with redistribution. JDK/.NET/Mono/DB servers are explicitly out — the escape hatch is "derive your own image", with worked recipes in the doc (JDK on top of universal, lightweight extras on top of vanilla, corporate CA cert, pinned agent CLI).

## CI changes

- **`.github/workflows/release.yml`** — new `docker-universal` job after the existing `docker:` job. Builds universal with `BASE_IMAGE=ghcr.io/kdlbs/kandev:${{ needs.prepare.outputs.tag }}`, so universal-of-vX.Y.Z always rests on vanilla-vX.Y.Z (not on whatever `:latest` happens to be when the universal step runs).
- **Size-gate guard** (same job): inspects the multi-arch manifest, sums amd64 compressed layer sizes, fails the release if >2.5 GiB. Forces additions to be deliberate — bumping the ceiling needs a one-line commit-message justification.
- **`.github/workflows/universal-rebuild.yml`** — new weekly workflow (`cron: "0 6 * * 1"` + `workflow_dispatch`). Rebuilds universal on top of the current `:latest` so apt security updates flow into universal between releases. Pushes the floating `:universal` + dated `:universal-weekly-YYYYMMDD` tags only — immutable `:vX.Y.Z-universal` tags are never re-pushed.

## Docs

- New `docs/images.md` — the canonical doc: flavor comparison, inclusion policy, switching guide, four customize-your-image recipes.
- `docs/k8s.md` and `docs/docker.md` get short "Choosing your image" sections + a pointer in the Agent CLIs section so users looking for "how do I add Go/JDK/etc." find the right answer.

## Needs a human pass before first release

The Dockerfile pins tool versions to plausible-but-unverified values at the cutoff. Before triggering the first release that actually builds this, please sanity-check against upstream release pages:

- Go `1.26.0`, golangci-lint `1.62.0`, Playwright `1.48.0`, pnpm `9.15.9`, yq `4.44.3`.
- Playwright apt deps list is hand-derived from upstream's Chromium list. Running `npx playwright@1.48.0 install-deps chromium --dry-run` once gives the authoritative diff.
- 2.5 GiB size ceiling is a guess; adjust after the first real build if needed.

## Test plan

- [ ] Workflow YAMLs parse cleanly (verified locally via `js-yaml`).
- [ ] Trigger a dry-run release (`workflow_dispatch` with `dry_run=true`) — sanity-check that the new `docker-universal` job graph reads correctly in the run view (it won't actually fire, since `if: ${{ !inputs.dry_run }}`, but the planning DAG should show it gated downstream of `docker`).
- [ ] Trigger a real `patch` release on a throwaway version — confirm both `:vX.Y.Z` and `:vX.Y.Z-universal` show up in GHCR, the size-gate output prints a sensible byte count, and the floating `:universal` tag points at the new digest.
- [ ] After at least one release exists, run `universal-rebuild` manually (`workflow_dispatch`) and confirm it pushes `:universal-weekly-YYYYMMDD` and refreshes `:universal` without touching `:vX.Y.Z-universal`.
- [ ] Smoke-test the published universal image: `docker run --rm ghcr.io/kdlbs/kandev:vX.Y.Z-universal bash -lc 'go version && rustc --version && pnpm --version && golangci-lint --version && yq --version && fd --version && rg --version'`.
- [ ] Verify Playwright deps cover Chromium runtime: `docker run --rm ghcr.io/kdlbs/kandev:vX.Y.Z-universal bash -lc 'npx -y playwright@1.48.0 install chromium && npx -y playwright@1.48.0 install-deps chromium --dry-run'` (the `install-deps --dry-run` should report nothing missing).
- [ ] Confirm the two doc pointers render correctly in the rendered GitHub view (k8s.md, docker.md → images.md).