### PR TITLE
fix(web): scope pending-permission scan to current turn

### DIFF
--- a/apps/web/e2e/tests/chat/permission-approval.spec.ts
+++ b/apps/web/e2e/tests/chat/permission-approval.spec.ts
@@ -97,7 +97,11 @@ test.describe("Permission approval persistence", () => {
     await expect(session.permissionApproveButtons()).toHaveCount(1, { timeout: 30_000 });
 
     // Sidebar swaps the running spinner for the amber pending-permission icon.
-    const sidebarItem = session.sidebarTaskItem(taskTitle).first();
+    // No `.first()` — `e2eReset` runs before every test (and every retry), so
+    // the worker workspace has exactly one task with this title; if a duplicate
+    // ever appears, strict locator resolution should fail the test rather than
+    // silently picking one row.
+    const sidebarItem = session.sidebarTaskItem(taskTitle);
     await expect(sidebarItem.getByTestId("task-state-pending-permission")).toBeVisible({
       timeout: 10_000,
     });

--- a/apps/web/e2e/tests/chat/permission-approval.spec.ts
+++ b/apps/web/e2e/tests/chat/permission-approval.spec.ts
@@ -7,15 +7,18 @@ import { SessionPage } from "../../pages/session-page";
 /**
  * Seed a task that runs the multi-permission scenario, then navigate to it.
  * The mock agent will request three permissions in sequence and block on each.
+ * Returns the SessionPage plus the task so callers can correlate with the
+ * sidebar (which keys off the task title).
  */
 async function seedMultiPermissionTask(
   testPage: Page,
   apiClient: ApiClient,
   seedData: SeedData,
-): Promise<SessionPage> {
+  title = "Multi-permission approval",
+): Promise<{ session: SessionPage; task: Awaited<ReturnType<ApiClient["createTaskWithAgent"]>> }> {
   const task = await apiClient.createTaskWithAgent(
     seedData.workspaceId,
-    "Multi-permission approval",
+    title,
     seedData.agentProfileId,
     {
       description: "/e2e:multi-permission",
@@ -32,7 +35,7 @@ async function seedMultiPermissionTask(
   const session = new SessionPage(testPage);
   await session.waitForLoad();
 
-  return session;
+  return { session, task };
 }
 
 test.describe("Permission approval persistence", () => {
@@ -54,7 +57,7 @@ test.describe("Permission approval persistence", () => {
     apiClient,
     seedData,
   }) => {
-    const session = await seedMultiPermissionTask(testPage, apiClient, seedData);
+    const { session } = await seedMultiPermissionTask(testPage, apiClient, seedData);
 
     // Approve all three permission prompts as they appear. Each click unblocks
     // the agent which then emits the next prompt; the previous one's button
@@ -88,22 +91,7 @@ test.describe("Permission approval persistence", () => {
     seedData,
   }) => {
     const taskTitle = "Sidebar pending permission";
-    const task = await apiClient.createTaskWithAgent(
-      seedData.workspaceId,
-      taskTitle,
-      seedData.agentProfileId,
-      {
-        description: "/e2e:multi-permission",
-        workflow_id: seedData.workflowId,
-        workflow_step_id: seedData.startStepId,
-        repository_ids: [seedData.repositoryId],
-      },
-    );
-    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
-
-    await testPage.goto(`/t/${task.id}`);
-    const session = new SessionPage(testPage);
-    await session.waitForLoad();
+    const { session } = await seedMultiPermissionTask(testPage, apiClient, seedData, taskTitle);
 
     // First permission prompt blocks the agent.
     await expect(session.permissionApproveButtons()).toHaveCount(1, { timeout: 30_000 });

--- a/apps/web/e2e/tests/chat/permission-approval.spec.ts
+++ b/apps/web/e2e/tests/chat/permission-approval.spec.ts
@@ -4,6 +4,12 @@ import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { SessionPage } from "../../pages/session-page";
 
+// Matches the number of permission prompts emitted by the mock-agent
+// `/e2e:multi-permission` scenario (apps/backend/cmd/mock-agent/scenarios.go).
+// Both approval loops below depend on this — bump together if the scenario
+// changes.
+const MULTI_PERMISSION_COUNT = 3;
+
 /**
  * Seed a task that runs the multi-permission scenario, then navigate to it.
  * The mock agent will request three permissions in sequence and block on each.
@@ -59,11 +65,11 @@ test.describe("Permission approval persistence", () => {
   }) => {
     const { session } = await seedMultiPermissionTask(testPage, apiClient, seedData);
 
-    // Approve all three permission prompts as they appear. Each click unblocks
+    // Approve all permission prompts as they appear. Each click unblocks
     // the agent which then emits the next prompt; the previous one's button
     // detaches before the next one mounts, so wait for the count to be back
     // at 1 between clicks.
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < MULTI_PERMISSION_COUNT; i++) {
       await expect(session.permissionApproveButtons()).toHaveCount(1, { timeout: 30_000 });
       await session.permissionApproveButtons().first().click();
     }
@@ -107,8 +113,8 @@ test.describe("Permission approval persistence", () => {
     });
     await expect(sidebarItem.getByTestId("task-state-running")).toHaveCount(0);
 
-    // Approve all three prompts; once the agent's turn ends, the icon is gone.
-    for (let i = 0; i < 3; i++) {
+    // Approve all prompts; once the agent's turn ends, the icon is gone.
+    for (let i = 0; i < MULTI_PERMISSION_COUNT; i++) {
       await expect(session.permissionApproveButtons()).toHaveCount(1, { timeout: 30_000 });
       await session.permissionApproveButtons().first().click();
     }

--- a/apps/web/e2e/tests/chat/permission-approval.spec.ts
+++ b/apps/web/e2e/tests/chat/permission-approval.spec.ts
@@ -13,15 +13,15 @@ const MULTI_PERMISSION_COUNT = 3;
 /**
  * Seed a task that runs the multi-permission scenario, then navigate to it.
  * The mock agent will request three permissions in sequence and block on each.
- * Returns the SessionPage plus the task so callers can correlate with the
- * sidebar (which keys off the task title).
+ * The sidebar test passes a custom `title` so it can query the sidebar row by
+ * title text.
  */
 async function seedMultiPermissionTask(
   testPage: Page,
   apiClient: ApiClient,
   seedData: SeedData,
   title = "Multi-permission approval",
-): Promise<{ session: SessionPage; task: Awaited<ReturnType<ApiClient["createTaskWithAgent"]>> }> {
+): Promise<SessionPage> {
   const task = await apiClient.createTaskWithAgent(
     seedData.workspaceId,
     title,
@@ -41,7 +41,7 @@ async function seedMultiPermissionTask(
   const session = new SessionPage(testPage);
   await session.waitForLoad();
 
-  return { session, task };
+  return session;
 }
 
 test.describe("Permission approval persistence", () => {
@@ -63,7 +63,7 @@ test.describe("Permission approval persistence", () => {
     apiClient,
     seedData,
   }) => {
-    const { session } = await seedMultiPermissionTask(testPage, apiClient, seedData);
+    const session = await seedMultiPermissionTask(testPage, apiClient, seedData);
 
     // Approve all permission prompts as they appear. Each click unblocks
     // the agent which then emits the next prompt; the previous one's button
@@ -97,7 +97,7 @@ test.describe("Permission approval persistence", () => {
     seedData,
   }) => {
     const taskTitle = "Sidebar pending permission";
-    const { session } = await seedMultiPermissionTask(testPage, apiClient, seedData, taskTitle);
+    const session = await seedMultiPermissionTask(testPage, apiClient, seedData, taskTitle);
 
     // First permission prompt blocks the agent.
     await expect(session.permissionApproveButtons()).toHaveCount(1, { timeout: 30_000 });

--- a/apps/web/e2e/tests/chat/permission-approval.spec.ts
+++ b/apps/web/e2e/tests/chat/permission-approval.spec.ts
@@ -78,4 +78,49 @@ test.describe("Permission approval persistence", () => {
     await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
     await expect(session.permissionActionRows()).toHaveCount(0);
   });
+
+  // While an agent is blocked on a permission_request, the sidebar entry for
+  // that task swaps the running spinner for the amber pending-permission icon
+  // (introduced in #882). The icon goes away once the prompt is resolved.
+  test("sidebar shows pending-permission icon while a permission prompt is open", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const taskTitle = "Sidebar pending permission";
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      taskTitle,
+      seedData.agentProfileId,
+      {
+        description: "/e2e:multi-permission",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    // First permission prompt blocks the agent.
+    await expect(session.permissionApproveButtons()).toHaveCount(1, { timeout: 30_000 });
+
+    // Sidebar swaps the running spinner for the amber pending-permission icon.
+    const sidebarItem = session.sidebarTaskItem(taskTitle).first();
+    await expect(sidebarItem.getByTestId("task-state-pending-permission")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(sidebarItem.getByTestId("task-state-running")).toHaveCount(0);
+
+    // Approve all three prompts; once the agent's turn ends, the icon is gone.
+    for (let i = 0; i < 3; i++) {
+      await expect(session.permissionApproveButtons()).toHaveCount(1, { timeout: 30_000 });
+      await session.permissionApproveButtons().first().click();
+    }
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await expect(sidebarItem.getByTestId("task-state-pending-permission")).toHaveCount(0);
+  });
 });

--- a/apps/web/lib/utils/pending-clarification.test.ts
+++ b/apps/web/lib/utils/pending-clarification.test.ts
@@ -183,4 +183,94 @@ describe("hasPendingPermissionRequest", () => {
     expect(hasPendingPermissionRequest(null)).toBe(false);
     expect(hasPendingPermissionRequest(undefined)).toBe(false);
   });
+
+  // Mixed-state: only the latest permission_request drives the UI. A stale
+  // pending row left behind by an earlier crash followed by a newer approved
+  // one must not light the amber icon — the agent is no longer blocked on
+  // the old row.
+  it("returns false when an older permission is still pending but a newer one is approved", () => {
+    expect(
+      hasPendingPermissionRequest([
+        message({ id: "old", type: "permission_request", metadata: { status: "pending" } }),
+        message({ id: "new", type: "permission_request", metadata: { status: "approved" } }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns true when the latest permission is pending and earlier ones are resolved", () => {
+    expect(
+      hasPendingPermissionRequest([
+        message({ id: "a", type: "permission_request", metadata: { status: "approved" } }),
+        message({ id: "b", type: "permission_request", metadata: { status: "rejected" } }),
+        message({ id: "c", type: "permission_request", metadata: { status: "pending" } }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when all permission requests are resolved regardless of order", () => {
+    expect(
+      hasPendingPermissionRequest([
+        message({ id: "a", type: "permission_request", metadata: { status: "approved" } }),
+        message({ id: "b", type: "permission_request", metadata: { status: "rejected" } }),
+        message({ id: "c", type: "permission_request", metadata: { status: "expired" } }),
+      ]),
+    ).toBe(false);
+  });
+});
+
+// Turn-scoped boundary: walking back across a different turn_id ends the
+// scan, so a pending row from a previous (crashed) turn must not leak into
+// the current turn's indicator.
+describe("hasPendingPermissionRequest — turn scoping", () => {
+  it("ignores a pending permission from a previous turn", () => {
+    expect(
+      hasPendingPermissionRequest([
+        message({
+          id: "old",
+          turn_id: "t1",
+          type: "permission_request",
+          metadata: { status: "pending" },
+        }),
+        message({ id: "current", turn_id: "t2", type: "message", content: "hi" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("detects a pending permission in the current turn", () => {
+    expect(
+      hasPendingPermissionRequest([
+        message({
+          id: "stale",
+          turn_id: "t1",
+          type: "permission_request",
+          metadata: { status: "pending" },
+        }),
+        message({
+          id: "active",
+          turn_id: "t2",
+          type: "permission_request",
+          metadata: { status: "pending" },
+        }),
+      ]),
+    ).toBe(true);
+  });
+
+  it("stops at the turn boundary even when an older turn has a pending permission", () => {
+    expect(
+      hasPendingPermissionRequest([
+        message({
+          id: "old-pending",
+          turn_id: "t1",
+          type: "permission_request",
+          metadata: { status: "pending" },
+        }),
+        message({
+          id: "new-approved",
+          turn_id: "t2",
+          type: "permission_request",
+          metadata: { status: "approved" },
+        }),
+      ]),
+    ).toBe(false);
+  });
 });

--- a/apps/web/lib/utils/pending-clarification.test.ts
+++ b/apps/web/lib/utils/pending-clarification.test.ts
@@ -273,4 +273,15 @@ describe("hasPendingPermissionRequest — turn scoping", () => {
       ]),
     ).toBe(false);
   });
+
+  // A legacy permission_request with no turn_id, sitting in a session whose
+  // latest message *does* have a turn_id, must not bypass the boundary.
+  it("ignores a legacy null-turn_id pending permission when a turn is active", () => {
+    expect(
+      hasPendingPermissionRequest([
+        message({ id: "legacy", type: "permission_request", metadata: { status: "pending" } }),
+        message({ id: "current", turn_id: "t2", type: "message", content: "hi" }),
+      ]),
+    ).toBe(false);
+  });
 });

--- a/apps/web/lib/utils/pending-clarification.ts
+++ b/apps/web/lib/utils/pending-clarification.ts
@@ -69,19 +69,20 @@ export function isPendingPermissionMessage(message: Message): boolean {
 //     it sees — only the latest one drives the UI. A stale pending row left
 //     behind by an earlier crash followed by a newer approved one must not
 //     light up the amber icon (the agent is no longer blocked on the old row).
-//   - Honours turn boundaries: walking back across a different turn_id ends
-//     the scan, so old turns' permissions can never leak into the indicator
-//     and the scan stays bounded by the current turn size (typically 5–50
-//     messages) regardless of total session length.
-//   - When messages have no turn_id (older data / non-turn-scoped messages),
-//     boundary enforcement is disabled and we fall back to plain latest-only
-//     semantics.
+//   - Honours turn boundaries: when the latest message has a turn_id, walking
+//     back to any row that doesn't share it ends the scan (including legacy
+//     rows with null/undefined turn_id). Old turns' permissions can never
+//     leak into the indicator and the scan stays bounded by the current turn
+//     size (typically 5–50 messages) regardless of total session length.
+//   - When the latest message itself has no turn_id (entirely pre-turn-scope
+//     data), boundary enforcement is disabled and we fall back to plain
+//     latest-only semantics across the whole array.
 export function hasPendingPermissionRequest(messages?: readonly Message[] | null): boolean {
   if (!messages?.length) return false;
   const latestTurnId = messages[messages.length - 1].turn_id;
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
-    if (latestTurnId && m.turn_id && m.turn_id !== latestTurnId) break;
+    if (latestTurnId && m.turn_id !== latestTurnId) break;
     if (m.type !== "permission_request") continue;
     return isPendingPermissionMessage(m);
   }

--- a/apps/web/lib/utils/pending-clarification.ts
+++ b/apps/web/lib/utils/pending-clarification.ts
@@ -63,10 +63,27 @@ export function isPendingPermissionMessage(message: Message): boolean {
   return !metadata?.status || metadata.status === "pending";
 }
 
+// hasPendingPermissionRequest reports whether the *current turn* is blocked
+// on a permission_request. Scope:
+//   - Scans backwards from the end and stops at the first permission_request
+//     it sees — only the latest one drives the UI. A stale pending row left
+//     behind by an earlier crash followed by a newer approved one must not
+//     light up the amber icon (the agent is no longer blocked on the old row).
+//   - Honours turn boundaries: walking back across a different turn_id ends
+//     the scan, so old turns' permissions can never leak into the indicator
+//     and the scan stays bounded by the current turn size (typically 5–50
+//     messages) regardless of total session length.
+//   - When messages have no turn_id (older data / non-turn-scoped messages),
+//     boundary enforcement is disabled and we fall back to plain latest-only
+//     semantics.
 export function hasPendingPermissionRequest(messages?: readonly Message[] | null): boolean {
-  if (!messages) return false;
+  if (!messages?.length) return false;
+  const latestTurnId = messages[messages.length - 1].turn_id;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (isPendingPermissionMessage(messages[i])) return true;
+    const m = messages[i];
+    if (latestTurnId && m.turn_id && m.turn_id !== latestTurnId) break;
+    if (m.type !== "permission_request") continue;
+    return isPendingPermissionMessage(m);
   }
   return false;
 }


### PR DESCRIPTION
Stale pending permission_request rows from earlier turns could light the sidebar's amber icon even after the agent's newer requests were approved, and the scan walked the full message list on every render. Limiting the check to the latest permission_request within the current turn_id fixes the false positive and keeps the cost bounded by turn size.

## Important Changes

- `hasPendingPermissionRequest` now returns the state of the *latest* permission_request found while walking back from the end, and stops at the first turn_id boundary it crosses.
- When messages have no turn_id, boundary enforcement is disabled and the function falls back to latest-only semantics so older non-turn-scoped data still works.

## Validation

- `make fmt`
- `make typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test -- run lib/utils/pending-clarification.test.ts` (1337 unit tests pass, +6 turn-scoping / latest-only cases)
- `pnpm --filter @kandev/web e2e -- tests/chat/permission-approval.spec.ts` (2/2 pass, new `sidebar shows pending-permission icon while a permission prompt is open` exercises the mock-agent `/e2e:multi-permission` scenario end-to-end)

## Possible Improvements

Low risk. The sibling `hasPendingClarification` still does a full-history scan with order-independent semantics; the same turn-scoping pattern could be applied there in a follow-up if the same false-positive class shows up for clarifications.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.