### PR TITLE
fix(web): use clipboard hook with HTTP fallback for stats copy

### DIFF
--- a/apps/web/app/stats/stats-page-client.tsx
+++ b/apps/web/app/stats/stats-page-client.tsx
@@ -5,9 +5,10 @@ import { Button } from "@kandev/ui/button";
 import { PageTopbar } from "@/components/page-topbar";
 import { ToggleGroup, ToggleGroupItem } from "@kandev/ui/toggle-group";
 import type { StatsResponse } from "@/lib/types/http";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { IconChartBar } from "@tabler/icons-react";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import {
   OverviewCards,
   WorkloadSection,
@@ -305,7 +306,7 @@ function buildStatsSummary(
 export function StatsPageClient({ stats, error, workspaceId, activeRange }: StatsPageClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const range = (activeRange ?? "month") as RangeKey;
   const rangeLabel = getRangeLabel(range);
   const resolvedStats = stats ?? EMPTY_STATS;
@@ -332,14 +333,8 @@ export function StatsPageClient({ stats, error, workspaceId, activeRange }: Stat
     );
   if (!stats) return <StatsEmptyState message="No stats available." />;
 
-  const handleCopyStats = async () => {
-    try {
-      await navigator.clipboard.writeText(statsSummary);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy stats summary", err);
-    }
+  const handleCopyStats = () => {
+    void copy(statsSummary);
   };
 
   const handleRangeChange = (nextRange: RangeKey) => {


### PR DESCRIPTION
The Copy Stats button on `/stats` threw `TypeError: Cannot read properties of undefined (reading 'writeText')` over HTTP on non-localhost origins, where `navigator.clipboard` is undefined (browsers gate it behind secure contexts). Switch to the existing `useCopyToClipboard` hook, which falls back to `document.execCommand("copy")` when the modern API is unavailable.

## Validation

- Read `apps/web/hooks/use-copy-to-clipboard.ts` to confirm fallback behavior.
- Pre-commit hooks (prettier, eslint on changed files) passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.