### PR TITLE
fix: improve custom script menu readability

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "9"
+          version: "9.15.9"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/apps/backend/internal/agent/lifecycle/executor_backend.go
+++ b/apps/backend/internal/agent/lifecycle/executor_backend.go
@@ -75,6 +75,9 @@ const (
 	MetadataKeyImageTagOverride = "image_tag_override"
 	MetadataKeyContainerID      = "container_id"
 	MetadataKeySpriteName       = "sprite_name"
+	MetadataKeySpriteState      = "sprite_state"
+	MetadataKeySpriteCreatedAt  = "sprite_created_at"
+	MetadataKeyLocalPort        = "local_port"
 )
 
 // persistentMetadataKeys lists metadata keys carried forward from a previous
@@ -83,10 +86,10 @@ const (
 // are NOT copied on resume.
 var persistentMetadataKeys = map[string]bool{
 	// Sprites runtime
-	MetadataKeySpriteName: true,
-	"sprite_state":        true,
-	"sprite_created_at":   true,
-	"local_port":          true,
+	MetadataKeySpriteName:      true,
+	MetadataKeySpriteState:     true,
+	MetadataKeySpriteCreatedAt: true,
+	MetadataKeyLocalPort:       true,
 
 	// Executor type marker
 	MetadataKeyIsRemote: true,

--- a/apps/backend/internal/agent/lifecycle/executor_backend.go
+++ b/apps/backend/internal/agent/lifecycle/executor_backend.go
@@ -74,6 +74,7 @@ const (
 	MetadataKeyGitUserEmail     = "git_user_email"
 	MetadataKeyImageTagOverride = "image_tag_override"
 	MetadataKeyContainerID      = "container_id"
+	MetadataKeySpriteName       = "sprite_name"
 )
 
 // persistentMetadataKeys lists metadata keys carried forward from a previous
@@ -82,10 +83,10 @@ const (
 // are NOT copied on resume.
 var persistentMetadataKeys = map[string]bool{
 	// Sprites runtime
-	"sprite_name":       true,
-	"sprite_state":      true,
-	"sprite_created_at": true,
-	"local_port":        true,
+	MetadataKeySpriteName: true,
+	"sprite_state":        true,
+	"sprite_created_at":   true,
+	"local_port":          true,
 
 	// Executor type marker
 	MetadataKeyIsRemote: true,

--- a/apps/backend/internal/agent/lifecycle/executor_sprites.go
+++ b/apps/backend/internal/agent/lifecycle/executor_sprites.go
@@ -131,7 +131,7 @@ func (r *SpritesExecutor) CreateInstance(ctx context.Context, req *ExecutorCreat
 
 	r.logger.Info("creating sprite instance",
 		zap.String("instance_id", req.InstanceID),
-		zap.String("sprite_name", spriteName),
+		zap.String(MetadataKeySpriteName, spriteName),
 		zap.Bool("reconnect_required", reconnect))
 
 	// Step 0: Create or reconnect sprite. On reconnect-then-not-found we fall
@@ -196,7 +196,7 @@ func (r *SpritesExecutor) resolveSpriteName(req *ExecutorCreateRequest, reconnec
 	if !reconnect {
 		return spritesNamePrefix + req.InstanceID[:12]
 	}
-	if name := getMetadataString(req.Metadata, "sprite_name"); name != "" {
+	if name := getMetadataString(req.Metadata, MetadataKeySpriteName); name != "" {
 		return name
 	}
 	suffix := req.PreviousExecutionID
@@ -266,7 +266,7 @@ func spritesShouldReconnect(req *ExecutorCreateRequest) bool {
 	if req == nil {
 		return false
 	}
-	return req.PreviousExecutionID != "" || getMetadataString(req.Metadata, "sprite_name") != ""
+	return req.PreviousExecutionID != "" || getMetadataString(req.Metadata, MetadataKeySpriteName) != ""
 }
 
 func spritesAgentInstanceID(req *ExecutorCreateRequest) string {
@@ -464,7 +464,7 @@ func (r *SpritesExecutor) buildInstanceResult(
 			agentctl.WithSessionID(req.SessionID)),
 		WorkspacePath: spritesWorkspacePath,
 		Metadata: map[string]interface{}{
-			"sprite_name":            spriteName,
+			MetadataKeySpriteName:    spriteName,
 			"sprite_state":           strings.TrimSpace(sprite.Status),
 			"sprite_created_at":      sprite.CreatedAt,
 			"local_port":             localPort,

--- a/apps/backend/internal/agent/lifecycle/executor_sprites.go
+++ b/apps/backend/internal/agent/lifecycle/executor_sprites.go
@@ -184,8 +184,8 @@ func (r *SpritesExecutor) CreateInstance(ctx context.Context, req *ExecutorCreat
 
 	r.logger.Info("sprite instance ready",
 		zap.String("instance_id", req.InstanceID),
-		zap.String("sprite_name", spriteName),
-		zap.Int("local_port", localPort),
+		zap.String(MetadataKeySpriteName, spriteName),
+		zap.Int(MetadataKeyLocalPort, localPort),
 		zap.Int("instance_port", instancePort))
 
 	return r.buildInstanceResult(req, spriteName, sprite, localPort, instancePort, reusingExisting), nil
@@ -464,12 +464,12 @@ func (r *SpritesExecutor) buildInstanceResult(
 			agentctl.WithSessionID(req.SessionID)),
 		WorkspacePath: spritesWorkspacePath,
 		Metadata: map[string]interface{}{
-			MetadataKeySpriteName:    spriteName,
-			"sprite_state":           strings.TrimSpace(sprite.Status),
-			"sprite_created_at":      sprite.CreatedAt,
-			"local_port":             localPort,
-			"reuse_existing_process": reusingExisting,
-			MetadataKeyIsRemote:      true,
+			MetadataKeySpriteName:      spriteName,
+			MetadataKeySpriteState:     strings.TrimSpace(sprite.Status),
+			MetadataKeySpriteCreatedAt: sprite.CreatedAt,
+			MetadataKeyLocalPort:       localPort,
+			"reuse_existing_process":   reusingExisting,
+			MetadataKeyIsRemote:        true,
 		},
 	}
 }

--- a/apps/backend/internal/agent/lifecycle/executor_sprites_lifecycle.go
+++ b/apps/backend/internal/agent/lifecycle/executor_sprites_lifecycle.go
@@ -27,7 +27,7 @@ func (r *SpritesExecutor) StopInstance(ctx context.Context, instance *ExecutorIn
 	if instance == nil {
 		return nil
 	}
-	spriteName := getMetadataString(instance.Metadata, "sprite_name")
+	spriteName := getMetadataString(instance.Metadata, MetadataKeySpriteName)
 	if spriteName == "" {
 		return nil
 	}
@@ -49,7 +49,7 @@ func (r *SpritesExecutor) StopInstance(ctx context.Context, instance *ExecutorIn
 	// archived). Resume then re-attaches the same sandbox in seconds.
 	if !shouldRunExecutorCleanup(instance.StopReason) {
 		r.logger.Info("preserving sprite sandbox after agent stop",
-			zap.String("sprite_name", spriteName),
+			zap.String(MetadataKeySpriteName, spriteName),
 			zap.String("instance_id", instance.InstanceID),
 			zap.String("stop_reason", instance.StopReason))
 		return nil
@@ -71,7 +71,7 @@ func (r *SpritesExecutor) StopInstance(ctx context.Context, instance *ExecutorIn
 	r.runTerminalCleanupScript(ctx, sprite, instance)
 	if err := sprite.Destroy(); err != nil {
 		r.logger.Warn("failed to destroy sprite",
-			zap.String("sprite_name", spriteName),
+			zap.String(MetadataKeySpriteName, spriteName),
 			zap.Error(err))
 		return fmt.Errorf("failed to destroy sprite: %w", err)
 	}
@@ -80,7 +80,7 @@ func (r *SpritesExecutor) StopInstance(ctx context.Context, instance *ExecutorIn
 	delete(r.tokens, instance.InstanceID)
 	r.mu.Unlock()
 
-	r.logger.Info("sprite destroyed", zap.String("sprite_name", spriteName),
+	r.logger.Info("sprite destroyed", zap.String(MetadataKeySpriteName, spriteName),
 		zap.String("stop_reason", instance.StopReason))
 	return nil
 }
@@ -153,7 +153,7 @@ func (r *SpritesExecutor) GetRemoteStatus(ctx context.Context, instance *Executo
 	if instance == nil {
 		return nil, fmt.Errorf("instance is nil")
 	}
-	spriteName := strings.TrimSpace(getMetadataString(instance.Metadata, "sprite_name"))
+	spriteName := strings.TrimSpace(getMetadataString(instance.Metadata, MetadataKeySpriteName))
 	if spriteName == "" {
 		return &RemoteStatus{
 			RuntimeName:   string(r.Name()),

--- a/apps/backend/internal/agent/lifecycle/executor_sprites_network.go
+++ b/apps/backend/internal/agent/lifecycle/executor_sprites_network.go
@@ -67,7 +67,7 @@ func (r *SpritesExecutor) applyNetworkPolicy(
 	defer cancel()
 
 	r.logger.Info("applying network policy from profile",
-		zap.String("sprite_name", spriteName),
+		zap.String(MetadataKeySpriteName, spriteName),
 		zap.Int("rule_count", len(rules)))
 
 	return client.UpdateNetworkPolicy(policyCtx, spriteName, &sprites.NetworkPolicy{Rules: rules})

--- a/apps/backend/internal/agent/lifecycle/executor_sprites_network.go
+++ b/apps/backend/internal/agent/lifecycle/executor_sprites_network.go
@@ -22,7 +22,7 @@ func (r *SpritesExecutor) setupPortForwarding(
 	}
 
 	r.logger.Debug("setting up port forwarding",
-		zap.Int("local_port", localPort),
+		zap.Int(MetadataKeyLocalPort, localPort),
 		zap.Int("remote_port", remotePort))
 
 	proxyCtx, cancel := context.WithCancel(context.Background())

--- a/apps/backend/internal/agent/lifecycle/manager_environment.go
+++ b/apps/backend/internal/agent/lifecycle/manager_environment.go
@@ -117,7 +117,7 @@ func (m *Manager) DestroySandbox(ctx context.Context, sandboxID, executionID str
 	// preserve-on-stop signal and the sandbox was never destroyed.
 	instance := &ExecutorInstance{
 		InstanceID: executionID,
-		Metadata:   map[string]interface{}{"sprite_name": sandboxID},
+		Metadata:   map[string]interface{}{MetadataKeySpriteName: sandboxID},
 		StopReason: StopReasonTaskDeleted,
 	}
 	return spritesExec.StopInstance(ctx, instance, true)

--- a/apps/backend/internal/task/handlers/task_environment_handlers.go
+++ b/apps/backend/internal/task/handlers/task_environment_handlers.go
@@ -11,6 +11,8 @@ import (
 	"github.com/kandev/kandev/internal/task/service"
 )
 
+const responseKeySuccess = "success"
+
 func (h *TaskHandlers) httpGetTaskEnvironment(c *gin.Context) {
 	taskID := c.Param("id")
 	env, err := h.service.GetTaskEnvironmentByTaskID(c.Request.Context(), taskID)
@@ -73,7 +75,7 @@ func (h *TaskHandlers) httpResetTaskEnvironment(c *gin.Context) {
 	})
 	switch {
 	case err == nil:
-		c.JSON(http.StatusOK, gin.H{"success": true})
+		c.JSON(http.StatusOK, gin.H{responseKeySuccess: true})
 	case errors.Is(err, service.ErrNoEnvironment):
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 	case errors.Is(err, service.ErrSessionRunning):

--- a/apps/backend/internal/task/handlers/task_git_handlers.go
+++ b/apps/backend/internal/task/handlers/task_git_handlers.go
@@ -108,8 +108,8 @@ func (h *TaskHandlers) wsUpdateSessionFileReview(ctx context.Context, msg *ws.Me
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
-		"success": true,
-		"review":  review,
+		responseKeySuccess: true,
+		"review":           review,
 	})
 }
 
@@ -132,6 +132,6 @@ func (h *TaskHandlers) wsResetSessionFileReviews(ctx context.Context, msg *ws.Me
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
-		"success": true,
+		responseKeySuccess: true,
 	})
 }

--- a/apps/backend/internal/task/handlers/task_plan_handlers.go
+++ b/apps/backend/internal/task/handlers/task_plan_handlers.go
@@ -132,7 +132,7 @@ func (h *TaskHandlers) wsDeleteTaskPlan(ctx context.Context, msg *ws.Message) (*
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to delete task plan: "+err.Error(), nil)
 	}
 
-	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{"success": true})
+	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{responseKeySuccess: true})
 }
 
 // wsListTaskPlanRevisions returns revision metadata newest-first (no content).

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -27,7 +27,7 @@ import { useRepositoryScripts } from "@/hooks/domains/workspace/use-repository-s
 import { replaceTaskUrl } from "@/lib/links";
 import type { Task, ProcessInfo } from "@/lib/types/http";
 import type { ProcessStatusEntry } from "@/lib/state/slices";
-import { AddPanelMenuItems, MENU_ICON_CLASS, MENU_ITEM_CLASS } from "./dockview-add-panel-items";
+import { AddPanelMenuItems, MENU_ITEM_CLASS } from "./dockview-add-panel-items";
 import { NewSessionDialog } from "./new-session-dialog";
 import { NewTaskDropdown } from "./new-task-dropdown";
 import { useActiveSessionDevScript } from "./repository-scripts-menu";
@@ -450,17 +450,24 @@ function TerminalScriptsDropdown({
           <IconPlayerPlay className={HEADER_ICON_CLASS} />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-52">
+      <DropdownMenuContent align="end" className="w-[min(18rem,calc(100vw-1rem))]">
         {scripts.map((script) => (
           <DropdownMenuItem
             key={script.id}
             onClick={() => handleRunScript(script.id)}
-            className={MENU_ITEM_CLASS}
+            className={`${MENU_ITEM_CLASS} grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-2 gap-y-0 py-1.5`}
           >
-            <IconTerminal2 className={MENU_ICON_CLASS} />
-            <span className="truncate">{script.name}</span>
-            <span className="ml-auto text-muted-foreground font-mono text-[10px] truncate max-w-[120px]">
-              {script.command}
+            <IconTerminal2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span className="min-w-0 overflow-hidden">
+              <span className="block truncate leading-4" title={script.name}>
+                {script.name}
+              </span>
+              <span
+                className="mt-0.5 block truncate font-mono text-[10px] leading-3 text-muted-foreground"
+                title={script.command}
+              >
+                {script.command}
+              </span>
             </span>
           </DropdownMenuItem>
         ))}

--- a/apps/web/e2e/tests/session/dockview-repository-scripts.spec.ts
+++ b/apps/web/e2e/tests/session/dockview-repository-scripts.spec.ts
@@ -195,6 +195,74 @@ test.describe("Dockview repository scripts in + menu", () => {
     await expect(testPage.getByTestId(`run-script-${customScript.id}`)).toBeVisible();
   });
 
+  test("header run script dropdown shows reasonable script names and commands", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await apiClient.createRepositoryScript(
+      seedData.repositoryId,
+      "Windows",
+      "flutter run -d windows",
+      0,
+    );
+
+    await seedTaskWithSession(testPage, apiClient, seedData, "Readable Script Menu");
+    await testPage.getByRole("button", { name: "Run script" }).click();
+
+    const menu = testPage.locator('[data-slot="dropdown-menu-content"]:visible').first();
+    await expect(menu).toBeVisible();
+    const menuBox = await menu.boundingBox();
+    expect(menuBox?.width).toBeGreaterThanOrEqual(260);
+    expect(menuBox?.width).toBeLessThanOrEqual(320);
+
+    const item = testPage
+      .getByRole("menuitem")
+      .filter({ hasText: "Windows" })
+      .filter({ hasText: "flutter run -d windows" })
+      .first();
+    await expect(item).toBeVisible();
+
+    const clippedText = await item.evaluate((element) =>
+      Array.from(element.querySelectorAll("span"))
+        .filter((span) =>
+          ["Windows", "flutter run -d windows"].includes(span.textContent?.trim() ?? ""),
+        )
+        .filter((span) => span.scrollWidth > span.clientWidth + 1)
+        .map((span) => span.textContent?.trim()),
+    );
+    expect(clippedText).toEqual([]);
+  });
+
+  test("header run script dropdown caps long script previews", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await apiClient.createRepositoryScript(
+      seedData.repositoryId,
+      "Start desktop target",
+      "set -e\nflutter clean\nflutter pub get\nflutter run -d windows --dart-define=ENV=local",
+      0,
+    );
+
+    await seedTaskWithSession(testPage, apiClient, seedData, "Compact Script Preview");
+    await testPage.getByRole("button", { name: "Run script" }).click();
+
+    const item = testPage.getByRole("menuitem").filter({ hasText: "Start desktop target" }).first();
+    await expect(item).toBeVisible();
+
+    const metrics = await item.evaluate((element) => {
+      const spans = Array.from(element.querySelectorAll("span"));
+      return {
+        itemHeight: element.getBoundingClientRect().height,
+        tallTextNodes: spans.filter((span) => span.getClientRects().length > 1).length,
+      };
+    });
+    expect(metrics.tallTextNodes).toBe(0);
+    expect(metrics.itemHeight).toBeLessThanOrEqual(44);
+  });
+
   test("clicking Dev Server opens a terminal that runs the dev_script command", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/session/dockview-repository-scripts.spec.ts
+++ b/apps/web/e2e/tests/session/dockview-repository-scripts.spec.ts
@@ -210,7 +210,8 @@ test.describe("Dockview repository scripts in + menu", () => {
     await seedTaskWithSession(testPage, apiClient, seedData, "Readable Script Menu");
     await testPage.getByRole("button", { name: "Run script" }).click();
 
-    const menu = testPage.locator('[data-slot="dropdown-menu-content"]:visible').first();
+    const menu = testPage.locator('[data-slot="dropdown-menu-content"]:visible');
+    await expect(menu).toHaveCount(1);
     await expect(menu).toBeVisible();
     const menuBox = await menu.boundingBox();
     expect(menuBox?.width).toBeGreaterThanOrEqual(260);
@@ -219,8 +220,8 @@ test.describe("Dockview repository scripts in + menu", () => {
     const item = testPage
       .getByRole("menuitem")
       .filter({ hasText: "Windows" })
-      .filter({ hasText: "flutter run -d windows" })
-      .first();
+      .filter({ hasText: "flutter run -d windows" });
+    await expect(item).toHaveCount(1);
     await expect(item).toBeVisible();
 
     const clippedText = await item.evaluate((element) =>
@@ -249,17 +250,27 @@ test.describe("Dockview repository scripts in + menu", () => {
     await seedTaskWithSession(testPage, apiClient, seedData, "Compact Script Preview");
     await testPage.getByRole("button", { name: "Run script" }).click();
 
-    const item = testPage.getByRole("menuitem").filter({ hasText: "Start desktop target" }).first();
+    const item = testPage.getByRole("menuitem").filter({ hasText: "Start desktop target" });
+    await expect(item).toHaveCount(1);
     await expect(item).toBeVisible();
 
     const metrics = await item.evaluate((element) => {
-      const spans = Array.from(element.querySelectorAll("span"));
+      const commandSpan = Array.from(element.querySelectorAll("span")).find(
+        (span) => span.children.length === 0 && span.textContent?.includes("flutter clean"),
+      );
+      if (!commandSpan) {
+        throw new Error("Expected command preview span");
+      }
+      const style = window.getComputedStyle(commandSpan);
       return {
+        commandClientHeight: commandSpan.clientHeight,
+        commandScrollHeight: commandSpan.scrollHeight,
+        commandWhiteSpace: style.whiteSpace,
         itemHeight: element.getBoundingClientRect().height,
-        tallTextNodes: spans.filter((span) => span.getClientRects().length > 1).length,
       };
     });
-    expect(metrics.tallTextNodes).toBe(0);
+    expect(metrics.commandWhiteSpace).toBe("nowrap");
+    expect(metrics.commandScrollHeight).toBeLessThanOrEqual(metrics.commandClientHeight + 1);
     expect(metrics.itemHeight).toBeLessThanOrEqual(44);
   });
 


### PR DESCRIPTION
The run-script dropdown made short custom scripts hard to scan and let long commands stretch rows. It now uses a compact two-line preview with E2E coverage for readable names and capped command text.

## Important Changes

- Changed the terminal header script menu to a compact two-line item: script name plus command preview.
- Kept verification green by reusing existing backend response/metadata constants and aligning one E2E workflow pnpm pin.

## Validation

- `make fmt`
- `make test`
- `make typecheck`
- `make lint`
- `make build-web`
- `pnpm --filter @kandev/web e2e -- tests/session/dockview-repository-scripts.spec.ts --grep "header run script dropdown"`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.