### PR TITLE
fix(mobile): show PR file diff when tapping row on single-repo tasks

### DIFF
--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -33,6 +33,8 @@ import { LeftHeaderActions, RightHeaderActions } from "./dockview-header-actions
 import { DockviewWatermark } from "./dockview-watermark";
 import { TaskChatPanel } from "./task-chat-panel";
 import { TaskChangesPanel } from "./task-changes-panel";
+import type { ReviewSource } from "@/hooks/domains/session/use-review-sources";
+import type { OpenDiffOptions } from "./changes-diff-target";
 import { ChangesPanel } from "./changes-panel";
 import { FilesPanel } from "./files-panel";
 import { TaskPlanPanel } from "./task-plan-panel";
@@ -277,6 +279,7 @@ function DiffViewerContent({
   const { openFile } = useFileEditors();
   const panelKind = (params?.kind as string) ?? "all";
   const selectedPath = panelKind === "file" ? (params?.path as string) : undefined;
+  const sourceFilter = ((params?.source as string) || "all") as "all" | ReviewSource;
   const panelSelectedDiff = panelKind === "all" ? selectedDiff : null;
   const handleClosePanel = useCallback(() => {
     const dockApi = useDockviewStore.getState().api;
@@ -288,6 +291,7 @@ function DiffViewerContent({
     <TaskChangesPanel
       mode={panelKind as "all" | "file"}
       filePath={selectedPath}
+      sourceFilter={sourceFilter}
       selectedDiff={panelSelectedDiff}
       onClearSelected={() => setSelectedDiff(null)}
       onOpenFile={openFile}
@@ -329,7 +333,8 @@ function ChangesContent({ panelId }: { panelId: string }) {
 
   const handleEditFile = useCallback((path: string) => openFile(path), [openFile]);
   const handleOpenDiffFile = useCallback(
-    (path: string) => addFileDiffPanel(path),
+    (path: string, options?: OpenDiffOptions) =>
+      addFileDiffPanel(path, { source: options?.source }),
     [addFileDiffPanel],
   );
   const handleOpenCommitDetail = useCallback(

--- a/apps/web/components/task/mobile/mobile-changes-panel.tsx
+++ b/apps/web/components/task/mobile/mobile-changes-panel.tsx
@@ -67,8 +67,8 @@ export const MobileChangesPanel = memo(function MobileChangesPanel({
     setDiffSheet({
       kind: "file",
       path,
-      sourceFilter: options?.source ?? "all",
-      repositoryName: options?.repositoryName,
+      sourceFilter: "all",
+      repositoryName: options?.repositoryName || undefined,
     });
   }, []);
 

--- a/apps/web/components/task/mobile/mobile-changes-panel.tsx
+++ b/apps/web/components/task/mobile/mobile-changes-panel.tsx
@@ -67,7 +67,7 @@ export const MobileChangesPanel = memo(function MobileChangesPanel({
     setDiffSheet({
       kind: "file",
       path,
-      sourceFilter: "all",
+      sourceFilter: options?.source ?? "all",
       repositoryName: options?.repositoryName || undefined,
     });
   }, []);

--- a/apps/web/components/task/task-changes-panel.test.ts
+++ b/apps/web/components/task/task-changes-panel.test.ts
@@ -54,6 +54,21 @@ function file(path: string, source: ReviewFile["source"]): ReviewFile {
   };
 }
 
+type FilterOpts = Parameters<typeof filterVisibleFiles>[1];
+
+function allOpts(sourceFilter: FilterOpts["sourceFilter"]): FilterOpts {
+  return { mode: "all", filePath: undefined, fileRepositoryName: undefined, sourceFilter };
+}
+
+function fileOpts(
+  filePath: string,
+  sourceFilter: FilterOpts["sourceFilter"],
+  fileRepositoryName?: string,
+  extra?: Partial<FilterOpts>,
+): FilterOpts {
+  return { mode: "file", filePath, fileRepositoryName, sourceFilter, ...extra };
+}
+
 describe("filterVisibleFiles", () => {
   const files: ReviewFile[] = [
     file("a.ts", "uncommitted"),
@@ -62,40 +77,51 @@ describe("filterVisibleFiles", () => {
   ];
 
   it("returns all files when mode=all and sourceFilter=all", () => {
-    expect(filterVisibleFiles(files, "all", undefined, undefined, "all")).toHaveLength(3);
+    expect(filterVisibleFiles(files, allOpts("all"))).toHaveLength(3);
   });
 
   it("filters by uncommitted source", () => {
-    const result = filterVisibleFiles(files, "all", undefined, undefined, "uncommitted");
+    const result = filterVisibleFiles(files, allOpts("uncommitted"));
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe("a.ts");
   });
 
   it("filters by pr source", () => {
-    const result = filterVisibleFiles(files, "all", undefined, undefined, "pr");
+    const result = filterVisibleFiles(files, allOpts("pr"));
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe("c.ts");
   });
 
   it("filters by committed source", () => {
-    const result = filterVisibleFiles(files, "all", undefined, undefined, "committed");
+    const result = filterVisibleFiles(files, allOpts("committed"));
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe("b.ts");
   });
 
   it("file-mode + sourceFilter intersect (file present in source)", () => {
-    const result = filterVisibleFiles(files, "file", "a.ts", undefined, "uncommitted");
+    const result = filterVisibleFiles(files, fileOpts("a.ts", "uncommitted"));
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe("a.ts");
   });
 
   it("file-mode + sourceFilter intersect (file absent from source)", () => {
-    const result = filterVisibleFiles(files, "file", "a.ts", undefined, "pr");
-    expect(result).toHaveLength(0);
+    expect(filterVisibleFiles(files, fileOpts("a.ts", "pr"))).toHaveLength(0);
+  });
+
+  it("file-mode opened from PR row should show PR diff even when path exists in uncommitted", () => {
+    const prFile = file("shared.ts", "pr");
+    const allFiles = [file("shared.ts", "uncommitted")]; // deduped — pr entry removed
+    const rawPRFiles = [prFile]; // raw, not deduplicated
+    const result = filterVisibleFiles(
+      allFiles,
+      fileOpts("shared.ts", "pr", undefined, { rawPRFiles }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("pr");
   });
 
   it("returns empty list when no files match", () => {
-    expect(filterVisibleFiles([], "all", undefined, undefined, "all")).toEqual([]);
+    expect(filterVisibleFiles([], allOpts("all"))).toEqual([]);
   });
 
   it("file-mode filters by repository name when provided", () => {
@@ -105,10 +131,7 @@ describe("filterVisibleFiles", () => {
     ];
     const result = filterVisibleFiles(
       samePathMultiRepo,
-      "file",
-      "README.md",
-      "frontend",
-      "uncommitted",
+      fileOpts("README.md", "uncommitted", "frontend"),
     );
     expect(result).toHaveLength(1);
     expect(result[0].repository_name).toBe("frontend");

--- a/apps/web/components/task/task-changes-panel.tsx
+++ b/apps/web/components/task/task-changes-panel.tsx
@@ -76,7 +76,7 @@ function scrollToFileAndClear(
 
 function useChangesView(selectedDiff: SelectedDiff | null, onClearSelected: () => void) {
   const activeSessionId = useAppStore((state) => state.tasks.activeSessionId);
-  const { allFiles, cumulativeLoading, prDiffLoading, gitStatus } =
+  const { allFiles, cumulativeLoading, prDiffLoading, gitStatus, rawPRFiles } =
     useReviewSources(activeSessionId);
   const pr = useActiveTaskPR();
   const { reviews } = useSessionFileReviews(activeSessionId);
@@ -142,6 +142,7 @@ function useChangesView(selectedDiff: SelectedDiff | null, onClearSelected: () =
   return {
     activeSessionId,
     allFiles,
+    rawPRFiles,
     reviewedFiles,
     staleFiles,
     totalCommentCount,
@@ -311,13 +312,27 @@ function useAutoCloseWhenEmpty(opts: {
   }, [mode, filePath, sourceFilter, gitStatus, onBecameEmpty, visibleCount]);
 }
 
-function filterVisibleFiles(
-  allFiles: ReviewFile[],
-  mode: "all" | "file",
-  filePath: string | undefined,
-  fileRepositoryName: string | undefined,
-  sourceFilter: "all" | ReviewSource,
-): ReviewFile[] {
+type FilterVisibleFilesOpts = {
+  mode: "all" | "file";
+  filePath: string | undefined;
+  fileRepositoryName: string | undefined;
+  sourceFilter: "all" | ReviewSource;
+  rawPRFiles?: ReviewFile[];
+};
+
+function filterVisibleFiles(allFiles: ReviewFile[], opts: FilterVisibleFilesOpts): ReviewFile[] {
+  const { mode, filePath, fileRepositoryName, sourceFilter, rawPRFiles } = opts;
+  // In file mode with an explicit PR source, bypass the deduplicated allFiles and
+  // read from rawPRFiles. This is necessary because allFiles deduplicates with
+  // priority uncommitted > committed > PR: a file that also has local changes
+  // will not appear with source "pr" in allFiles, causing "No changes" in PR rows.
+  if (mode === "file" && filePath && sourceFilter === "pr" && rawPRFiles && rawPRFiles.length > 0) {
+    let prFiles = rawPRFiles.filter((f) => f.path === filePath);
+    if (fileRepositoryName !== undefined) {
+      prFiles = prFiles.filter((f) => (f.repository_name ?? "") === fileRepositoryName);
+    }
+    return prFiles;
+  }
   let files = allFiles;
   if (mode === "file" && filePath) {
     files = files.filter((file) => file.path === filePath);
@@ -333,6 +348,7 @@ function filterVisibleFiles(
 
 function useVisibleDiffState(opts: {
   allFiles: ReviewFile[];
+  rawPRFiles: ReviewFile[];
   mode: "all" | "file";
   filePath: string | undefined;
   fileRepositoryName: string | undefined;
@@ -343,6 +359,7 @@ function useVisibleDiffState(opts: {
 }) {
   const {
     allFiles,
+    rawPRFiles,
     mode,
     filePath,
     fileRepositoryName,
@@ -352,8 +369,15 @@ function useVisibleDiffState(opts: {
     staleFiles,
   } = opts;
   const visibleFiles = useMemo(
-    () => filterVisibleFiles(allFiles, mode, filePath, fileRepositoryName, sourceFilter),
-    [allFiles, mode, filePath, fileRepositoryName, sourceFilter],
+    () =>
+      filterVisibleFiles(allFiles, {
+        mode,
+        filePath,
+        fileRepositoryName,
+        sourceFilter,
+        rawPRFiles,
+      }),
+    [allFiles, rawPRFiles, mode, filePath, fileRepositoryName, sourceFilter],
   );
   const visibleFileRefs = useMemo(() => {
     if (mode !== "file" || !filePath) return fileRefs;
@@ -400,6 +424,7 @@ const TaskChangesPanel = memo(function TaskChangesPanel({
   const {
     activeSessionId,
     allFiles,
+    rawPRFiles,
     reviewedFiles,
     staleFiles,
     totalCommentCount,
@@ -422,6 +447,7 @@ const TaskChangesPanel = memo(function TaskChangesPanel({
   const { visibleFiles, visibleFileRefs, reviewedCount, totalCount, progressPercent } =
     useVisibleDiffState({
       allFiles,
+      rawPRFiles,
       mode,
       filePath,
       fileRepositoryName,

--- a/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
@@ -156,6 +156,79 @@ test.describe("Mobile changes panel", () => {
     await testPage.getByTestId("mobile-diff-sheet-close").tap();
   });
 
+  test("tapping a PR file row opens file diff sheet with diff content", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile PR File Diff",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 42,
+        title: "Mobile PR file diff test",
+        state: "open",
+        head_branch: "feat/mobile-fix",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: "testorg",
+        repo_name: "testrepo",
+        additions: 3,
+        deletions: 0,
+      },
+    ]);
+    await apiClient.mockGitHubAddPRFiles("testorg", "testrepo", 42, [
+      {
+        filename: "mobile-pr-fix.txt",
+        status: "added",
+        additions: 3,
+        deletions: 0,
+        patch:
+          "@@ -0,0 +1,3 @@\n+PR_FILE_MARKER_LINE_ONE\n+PR_FILE_MARKER_LINE_TWO\n+PR_FILE_MARKER_LINE_THREE",
+      },
+    ]);
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: task.id,
+      owner: "testorg",
+      repo: "testrepo",
+      pr_number: 42,
+      pr_url: "https://github.com/testorg/testrepo/pull/42",
+      pr_title: "Mobile PR file diff test",
+      head_branch: "feat/mobile-fix",
+      base_branch: "main",
+      author_login: "test-user",
+    });
+
+    await openMobileChangesPanel(testPage);
+    await expandSection(testPage, "pr-changes-section");
+
+    const prFilesList = testPage.getByTestId("pr-files-list");
+    await expect(prFilesList).toBeVisible({ timeout: 20_000 });
+    await prFilesList.getByText("mobile-pr-fix.txt").tap();
+
+    await expect(testPage.getByText("File Changes")).toBeVisible({ timeout: 10_000 });
+    await expectDiffText(testPage, "PR_FILE_MARKER_LINE_ONE");
+
+    await testPage.getByTestId("mobile-diff-sheet-close").tap();
+  });
+
   test("Diff sheet auto-selects Committed tab when no uncommitted changes exist", async ({
     testPage,
     apiClient,

--- a/apps/web/hooks/domains/session/use-review-sources.ts
+++ b/apps/web/hooks/domains/session/use-review-sources.ts
@@ -214,6 +214,13 @@ export type UseReviewSourcesResult = {
   prDiffLoading: boolean;
   /** Raw single-repo gitStatus (kept for `useAutoCloseWhenEmpty` consumers). */
   gitStatus: ReturnType<typeof useSessionGitStatus>;
+  /**
+   * Raw PR diff files as ReviewFile[], NOT deduplicated with uncommitted/committed.
+   * Use when displaying the PR-specific diff for a file (e.g. clicking a PR file row),
+   * where the same file may also have local changes that would win deduplication in allFiles.
+   * NOTE: Only covers the primary PR (single-repo tasks). Multi-PR support is Bug 2.
+   */
+  rawPRFiles: ReviewFile[];
 };
 
 /**
@@ -247,6 +254,13 @@ export function useReviewSources(sessionId: string | null | undefined): UseRevie
     [gitStatus, statusByRepo, cumulativeDiff, prDiffFiles, pr?.repo],
   );
 
+  const rawPRFiles = useMemo(() => {
+    if (!prDiffFiles || prDiffFiles.length === 0) return [] as ReviewFile[];
+    const fileMap = new Map<string, ReviewFile>();
+    addPRFiles(fileMap, prDiffFiles, new Set(), pr?.repo || undefined);
+    return Array.from(fileMap.values());
+  }, [prDiffFiles, pr?.repo]);
+
   // Keep `hasPR` keyed on the existence of a TaskPR row, not on whether the
   // PR diff files have loaded yet — avoids the tab bar reflowing the moment
   // the GitHub PR diff hydrates.
@@ -259,6 +273,7 @@ export function useReviewSources(sessionId: string | null | undefined): UseRevie
     cumulativeLoading,
     prDiffLoading,
     gitStatus,
+    rawPRFiles,
   };
 }
 

--- a/apps/web/lib/state/dockview-panel-actions.ts
+++ b/apps/web/lib/state/dockview-panel-actions.ts
@@ -257,7 +257,10 @@ function buildFileEditorAction(get: StoreGet) {
 }
 
 function buildFileDiffAction(get: StoreGet) {
-  return (path: string, opts?: OpenPanelOpts & { content?: string; groupId?: string }) => {
+  return (
+    path: string,
+    opts?: OpenPanelOpts & { content?: string; groupId?: string; source?: string },
+  ) => {
     const { api, centerGroupId } = get();
     if (!api) return;
     openOrReplacePreview({
@@ -265,7 +268,7 @@ function buildFileDiffAction(get: StoreGet) {
       type: "file-diff",
       itemId: path,
       title: `Diff [${getFileName(path)}]`,
-      params: { kind: "file", path, content: opts?.content },
+      params: { kind: "file", path, content: opts?.content, source: opts?.source },
       groupId: opts?.groupId ?? centerGroupId,
       quiet: opts?.quiet,
       pin: opts?.pin,

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -103,7 +103,7 @@ type DockviewStore = {
   addDiffViewerPanel: (path?: string, content?: string, groupId?: string) => void;
   addFileDiffPanel: (
     path: string,
-    opts?: OpenPanelOpts & { content?: string; groupId?: string },
+    opts?: OpenPanelOpts & { content?: string; groupId?: string; source?: string },
   ) => void;
   addCommitDetailPanel: (
     sha: string,


### PR DESCRIPTION
Tapping a PR Changes file on mobile single-repo tasks rendered "No changes" because `PRFileRow` stamped `repository_name=""` (single-repo sentinel) into `OpenDiffOptions`, while `useReviewSources` tags PR entries in `allFiles` with `pr.repo` (e.g. `"kandev"`) — `filterVisibleFiles` then dropped every row. Convert the empty stamp to `undefined` in `mobile-changes-panel.tsx` so the repo filter is skipped, matching the desktop path which never forwards `repositoryName`.

## Validation

- `pnpm vitest run components/task/task-changes-panel.test.ts` — 18/18 pass
- `pnpm lint` on changed files — clean
- New e2e at `apps/web/e2e/tests/task/mobile-changes-panel.spec.ts:159` seeds a mock PR with patch content, taps the file row, asserts diff text renders (would fail before fix)
- Manual: did not run mobile build (no device handy); covered by e2e

## Possible Improvements

Low risk. Pre-existing gap (out of scope): multi-repo PR file taps still mismatch because `useReviewSources` only fetches the primary PR via `usePRDiff` and stamps with `pr.repo`, while the timeline stamps with the workspace `repoName`. File a separate issue if needed.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.