### PR TITLE
fix(ci): install curl in universal image

### DIFF
--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -39,14 +39,14 @@ ARG PNPM_VERSION=9.15.9
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        # Tarball fetcher for the toolchain install steps below (Go,
+        # golangci-lint, rustup, yq). Not provided by the vanilla base image.
+        curl \
         # Native compile (CGO, pip wheels with C extensions, native npm modules)
         build-essential \
         pkg-config \
         python3-dev \
         libssl-dev \
-        # curl is used by the toolchain install steps below (Go, golangci-lint,
-        # rustup, yq). The vanilla base image doesn't ship it.
-        curl \
         # Useful CLI tools agents reach for. Small, broadly applicable.
         ripgrep \
         fd-find \

--- a/Dockerfile.universal
+++ b/Dockerfile.universal
@@ -44,6 +44,9 @@ RUN set -eux; \
         pkg-config \
         python3-dev \
         libssl-dev \
+        # curl is used by the toolchain install steps below (Go, golangci-lint,
+        # rustup, yq). The vanilla base image doesn't ship it.
+        curl \
         # Useful CLI tools agents reach for. Small, broadly applicable.
         ripgrep \
         fd-find \


### PR DESCRIPTION
## Summary

The v0.46.0 release failed in the new "Build & push universal container image" job — `Dockerfile.universal` calls `curl` to fetch the Go, golangci-lint, rustup, and yq tarballs, but neither the vanilla base image nor the universal image's apt install list provides curl, so the first toolchain step exited 127 (`/bin/sh: 1: curl: not found`). Adding `curl` to the universal image's apt install list unblocks the release.

## Validation

- Inspected the failed [run 25930139151](https://github.com/kdlbs/kandev/actions/runs/25930139151) — failure was at the Go install step in `Dockerfile.universal`.
- Confirmed vanilla `Dockerfile` does not install `curl` (only `git`, `gh`, `ca-certificates`, `gosu`, `tini`, `python3`, `python3-venv`, `pipx`).
- Local `docker build` not run; a new release run will exercise the fix end-to-end.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated
- [ ] Linked issue

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-910-bwo7.sprites.app |
| **Commit** | `7a2d532` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->