### PR TITLE
fix: ignore pi version banner in utility inference output

### DIFF
--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -128,8 +129,12 @@ func (e *ACPInferenceExecutor) executeACPSession(
 
 	updateHandler := func(n acp.SessionNotification) {
 		if n.Update.AgentMessageChunk != nil && n.Update.AgentMessageChunk.Content.Text != nil {
+			chunk := sanitizeInferenceChunk(n.Update.AgentMessageChunk.Content.Text.Text)
+			if chunk == "" {
+				return
+			}
 			mu.Lock()
-			responseText.WriteString(n.Update.AgentMessageChunk.Content.Text.Text)
+			responseText.WriteString(chunk)
 			mu.Unlock()
 		}
 	}
@@ -494,4 +499,27 @@ func buildACPCommand(cfg *InferenceConfigDTO, model string) []string {
 	}
 
 	return args
+}
+
+var piVersionBannerLineRE = regexp.MustCompile(`^\s*pi v\d+\.\d+\.\d+\s*$`)
+
+// sanitizeInferenceChunk removes known non-content banner lines emitted by
+// some CLIs (e.g. pi-acp printing "pi vX.Y.Z") so utility outputs like
+// commit-message generation only contain model response content.
+func sanitizeInferenceChunk(chunk string) string {
+	if chunk == "" {
+		return ""
+	}
+	lines := strings.Split(chunk, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if piVersionBannerLineRE.MatchString(line) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	return strings.Join(kept, "\n")
 }

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -506,6 +506,8 @@ var piVersionBannerLineRE = regexp.MustCompile(`^\s*pi v\d+\.\d+\.\d+\s*$`)
 // sanitizeInferenceChunk removes known non-content banner lines emitted by
 // some CLIs (e.g. pi-acp printing "pi vX.Y.Z") so utility outputs like
 // commit-message generation only contain model response content.
+// Note: pi-acp is always launched via "npx" (see PiACP.InferenceConfig),
+// so "npx" is the allowedProbeCommand entry that gates execution here.
 func sanitizeInferenceChunk(chunk string) string {
 	if chunk == "" {
 		return ""

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -30,3 +30,41 @@ func TestSanitizeInferenceChunk_RemovesBannerLineFromMultilineChunk(t *testing.T
 		t.Fatalf("sanitizeInferenceChunk() = %q, want %q", got, want)
 	}
 }
+
+func TestSanitizeInferenceChunk_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeInferenceChunk("")
+	if got != "" {
+		t.Fatalf("sanitizeInferenceChunk() = %q, want empty string", got)
+	}
+}
+
+func TestSanitizeInferenceChunk_BannerWithWhitespace(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeInferenceChunk("  pi v0.74.0  ")
+	if got != "" {
+		t.Fatalf("sanitizeInferenceChunk() = %q, want empty string", got)
+	}
+}
+
+func TestSanitizeInferenceChunk_RemovesBannerLineAtEnd(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeInferenceChunk("fix: tighten prompt parsing\npi v0.74.0")
+	want := "fix: tighten prompt parsing"
+	if got != want {
+		t.Fatalf("sanitizeInferenceChunk() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeInferenceChunk_RemovesMultipleBannerLines(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeInferenceChunk("pi v0.74.0\nfix: tighten prompt parsing\npi v1.0.0")
+	want := "fix: tighten prompt parsing"
+	if got != want {
+		t.Fatalf("sanitizeInferenceChunk() = %q, want %q", got, want)
+	}
+}

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -1,0 +1,32 @@
+package utility
+
+import "testing"
+
+func TestSanitizeInferenceChunk_DropsPiVersionBanner(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeInferenceChunk("pi v0.74.0")
+	if got != "" {
+		t.Fatalf("sanitizeInferenceChunk() = %q, want empty string", got)
+	}
+}
+
+func TestSanitizeInferenceChunk_PreservesNormalText(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeInferenceChunk("fix: avoid duplicate commit message generation")
+	want := "fix: avoid duplicate commit message generation"
+	if got != want {
+		t.Fatalf("sanitizeInferenceChunk() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeInferenceChunk_RemovesBannerLineFromMultilineChunk(t *testing.T) {
+	t.Parallel()
+
+	got := sanitizeInferenceChunk("pi v0.74.0\nfix: tighten prompt parsing")
+	want := "fix: tighten prompt parsing"
+	if got != want {
+		t.Fatalf("sanitizeInferenceChunk() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Pi ACP startup banner text (`pi v0.74.0`) was being treated as model output in utility inference, which polluted commit-message generation input/output; utility response aggregation now filters banner-only lines so commit creation uses only intended generated text.

## Validation- Added regression tests in `apps/backend/internal/agentctl/server/utility/acp_executor_test.go`:
 - `TestSanitizeInferenceChunk_DropsPiVersionBanner`
 - `TestSanitizeInferenceChunk_PreservesNormalText`
 - `TestSanitizeInferenceChunk_RemovesBannerLineFromMultilineChunk`
- Attempted to run backend tests:
 - `cd apps/backend && go test -v ./internal/agentctl/server/utility -run TestSanitizeInferenceChunk`
 - Could not execute in this environment (`go: command not found`).
- Attempted repo verification commands:
 - `make fmt`
 - Could not execute in this environment (`make: command not found`).

## Possible ImprovementsLow risk: the filter is intentionally narrow (`pi vX.Y.Z` full-line), but we could centralize “non-content chunk” sanitization for other agent banners if more variants appear.

## Checklist- [x] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files `apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.