### PR TITLE
chore(deps): bump @pierre/diffs to 1.1.22 with regression coverage

### DIFF
--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -202,7 +202,7 @@ Tests are grouped by feature area in subdirectories under `tests/`. When creatin
 When a test fails:
 
 1. **Read the error output** — the Playwright error message, expected vs. actual, and which locator timed out
-2. **Read `error-context.md`** from `test-results/<test-name>/` — contains a YAML DOM snapshot showing exactly what was rendered. Search for expected elements, check if the page is in the right state (e.g., simple mode vs advanced mode)
+2. **Read `error-context.md`** from `test-results/<test-name>/` — contains a YAML DOM snapshot showing exactly what was rendered. Search for expected elements, check if the page is in the right state (e.g., simple mode vs advanced mode). **These files persist across runs** — always confirm timestamps (`stat -f "%Sm" e2e/test-results/.../error-context.md`) or rebuild + rerun the spec fresh before trusting the snapshot. A stale context from a previous failure mode will send you debugging the wrong bug.
 3. **Read the failure screenshot** from `e2e/test-results/` — see what the page actually rendered
 4. **Attach to the failure** for deeper debugging using `playwright-cli`:
    ```bash

--- a/.agents/skills/e2e/SKILL.md
+++ b/.agents/skills/e2e/SKILL.md
@@ -202,7 +202,7 @@ Tests are grouped by feature area in subdirectories under `tests/`. When creatin
 When a test fails:
 
 1. **Read the error output** — the Playwright error message, expected vs. actual, and which locator timed out
-2. **Read `error-context.md`** from `test-results/<test-name>/` — contains a YAML DOM snapshot showing exactly what was rendered. Search for expected elements, check if the page is in the right state (e.g., simple mode vs advanced mode). **These files persist across runs** — always confirm timestamps (`stat -f "%Sm" e2e/test-results/.../error-context.md`) or rebuild + rerun the spec fresh before trusting the snapshot. A stale context from a previous failure mode will send you debugging the wrong bug.
+2. **Read `error-context.md`** from `test-results/<test-name>/` — contains a YAML DOM snapshot showing exactly what was rendered. Search for expected elements, check if the page is in the right state (e.g., simple mode vs advanced mode). **These files persist across runs** — always confirm timestamps (portable: `ls -la e2e/test-results/.../error-context.md`; or `stat -c %y` on Linux / `stat -f %Sm` on macOS) or rebuild + rerun the spec fresh before trusting the snapshot. A stale context from a previous failure mode will send you debugging the wrong bug.
 3. **Read the failure screenshot** from `e2e/test-results/` — see what the page actually rendered
 4. **Attach to the failure** for deeper debugging using `playwright-cli`:
    ```bash

--- a/.agents/skills/pr-fixup/SKILL.md
+++ b/.agents/skills/pr-fixup/SKILL.md
@@ -99,6 +99,13 @@ If any failing check is an E2E test (Playwright):
    ```
    Run the specific failing test file(s), not the full suite. Only proceed to step 5 after the test passes locally.
 
+**Don't dismiss a repeated failure as "flaky".** If the same shard or test fails 2+ poll iterations in a row, stop polling and do two cheap checks instead:
+
+- **Compare per-shard runtime vs `main`.** `gh run list --branch main --workflow "<name>" --limit 5 --json databaseId` then `gh run view <id> --json jobs` and diff started/completed timestamps against the PR's run. A shard that takes e.g. 216s on main and 616s on the PR is real test failures + retries pushing past the job's `timeout-minutes` cap, not infrastructure variance. "Cancelled" at exactly the timeout boundary almost always means this.
+- **Reproduce the failing spec locally** (step 4 above). CI logs hide in-DOM React render errors that show up immediately in the local `e2e/test-results/<test>/error-context.md`. A single local run (~5-10 min) routinely unlocks fixes that would otherwise burn 3+ CI cycles of speculative "rerun and hope".
+
+Recommend a merge over green-pending-flake-rerun only after both checks pass.
+
 Mark task 2 as completed.
 
 ### 3. Triage review comments

--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -36,22 +36,6 @@ importers:
       tree-kill:
         specifier: ^1.2.2
         version: 1.2.2
-    devDependencies:
-      '@types/node':
-        specifier: ^20
-        version: 20.19.28
-      esbuild:
-        specifier: ^0.24.0
-        version: 0.24.2
-      tsx:
-        specifier: ^4.15.7
-        version: 4.21.0
-      typescript:
-        specifier: ^5
-        version: 5.9.3
-      vitest:
-        specifier: ^1.6.0
-        version: 1.6.1(@types/node@20.19.28)(happy-dom@20.8.9)(lightningcss@1.30.2)
     optionalDependencies:
       '@kdlbs/runtime-darwin-arm64':
         specifier: 0.0.0-bootstrap
@@ -68,6 +52,22 @@ importers:
       '@kdlbs/runtime-win32-x64':
         specifier: 0.0.0-bootstrap
         version: 0.0.0-bootstrap
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.28
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      tsx:
+        specifier: ^4.15.7
+        version: 4.21.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.28)(happy-dom@20.8.9)(lightningcss@1.30.2)
 
   packages/theme:
     dependencies:
@@ -262,8 +262,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@pierre/diffs':
-        specifier: ^1.0.11
-        version: 1.0.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^1.1.22
+        version: 1.1.22(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tabler/icons-react':
         specifier: ^3.36.1
         version: 3.36.1(react@19.2.3)
@@ -1458,105 +1458,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1778,28 +1762,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.7':
     resolution: {integrity: sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.7':
     resolution: {integrity: sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.7':
     resolution: {integrity: sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.7':
     resolution: {integrity: sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==}
@@ -1850,11 +1830,15 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@pierre/diffs@1.0.11':
-    resolution: {integrity: sha512-j6zIEoyImQy1HfcJqbrDwP0O5I7V2VNXAaw53FqQ+SykRfaNwABeZHs9uibXO4supaXPmTx6LEH9Lffr03e1Tw==}
+  '@pierre/diffs@1.1.22':
+    resolution: {integrity: sha512-1Iv7kdl6OABFCd1n2HQbGUiRHouXPaHoIjcb7Lwg8zeJKY5ph+cESFcGEyIiwW0NCbKGtYS2bTnXmI+Eze5dwg==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@0.0.28':
+    resolution: {integrity: sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw==}
+    engines: {vscode: ^1.0.0}
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -2636,79 +2620,66 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -2826,28 +2797,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3496,49 +3463,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5340,28 +5299,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -8348,10 +8303,9 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@pierre/diffs@1.0.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@pierre/diffs@1.1.22(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@shikijs/core': 3.22.0
-      '@shikijs/engine-javascript': 3.22.0
+      '@pierre/theme': 0.0.28
       '@shikijs/transformers': 3.22.0
       diff: 8.0.3
       hast-util-to-html: 9.0.5
@@ -8359,6 +8313,8 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       shiki: 3.22.0
+
+  '@pierre/theme@0.0.28': {}
 
   '@playwright/test@1.58.2':
     dependencies:

--- a/apps/web/components/diff/diff-header-toolbar.test.tsx
+++ b/apps/web/components/diff/diff-header-toolbar.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { renderHook, render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import type { ReactElement } from "react";
+
+import { useDiffHeaderToolbar } from "./diff-header-toolbar";
+
+const FILE = "src/foo.ts";
+
+afterEach(() => cleanup());
+
+beforeAll(() => {
+  // happy-dom's clipboard implementation is partial — stub writeText so the
+  // copy-diff handler can be invoked without throwing.
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+function renderToolbar(node: ReactElement) {
+  return render(<TooltipProvider>{node}</TooltipProvider>);
+}
+
+/**
+ * Build a synthetic RenderHeaderMetadataProps shape. Calling this through the
+ * hook callback means a future library change to the prop shape (rename,
+ * removal, or restructure) surfaces here rather than only at the live FileDiff
+ * render site.
+ */
+function headerProp(name: string | undefined) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (name === undefined ? {} : { fileDiff: { name } }) as any;
+}
+
+const baseOpts = {
+  filePath: FILE,
+  diff: `diff --git a/${FILE} b/${FILE}\n--- a/${FILE}\n+++ b/${FILE}\n@@ -1,1 +1,1 @@\n-a\n+b`,
+  wordWrap: false,
+  onToggleWordWrap: vi.fn(),
+  viewMode: "split" as const,
+  onToggleViewMode: vi.fn(),
+};
+
+describe("useDiffHeaderToolbar", () => {
+  it("returns a callback that renders the toolbar buttons", () => {
+    const { result } = renderHook(() => useDiffHeaderToolbar(baseOpts));
+    // The callback signature is the library's RenderHeaderMetadataProps; we
+    // pass a synthetic value so a real change in the library's prop shape
+    // would surface here instead of only at the FileDiff render site.
+    const node = result.current(headerProp(FILE));
+    renderToolbar(node as ReactElement);
+
+    expect(screen.getByLabelText("Copy diff")).toBeTruthy();
+    expect(screen.getByLabelText("Toggle word wrap")).toBeTruthy();
+    expect(screen.getByLabelText("Switch to unified view")).toBeTruthy();
+  });
+
+  it("wires the copy-diff button to navigator.clipboard.writeText", () => {
+    const { result } = renderHook(() => useDiffHeaderToolbar(baseOpts));
+    const node = result.current(headerProp(FILE));
+    renderToolbar(node as ReactElement);
+
+    fireEvent.click(screen.getByLabelText("Copy diff"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(baseOpts.diff);
+  });
+
+  it("invokes onToggleWordWrap and onToggleViewMode when their buttons are clicked", () => {
+    const onToggleWordWrap = vi.fn();
+    const onToggleViewMode = vi.fn();
+    const { result } = renderHook(() =>
+      useDiffHeaderToolbar({ ...baseOpts, onToggleWordWrap, onToggleViewMode }),
+    );
+    const node = result.current(headerProp(FILE));
+    renderToolbar(node as ReactElement);
+
+    fireEvent.click(screen.getByLabelText("Toggle word wrap"));
+    fireEvent.click(screen.getByLabelText("Switch to unified view"));
+    expect(onToggleWordWrap).toHaveBeenCalledTimes(1);
+    expect(onToggleViewMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers the path from the library callback's fileDiff.name over the opts filePath", () => {
+    const onOpenFile = vi.fn();
+    const { result } = renderHook(() => useDiffHeaderToolbar({ ...baseOpts, onOpenFile }));
+    const node = result.current(headerProp("src/renamed.ts"));
+    renderToolbar(node as ReactElement);
+
+    fireEvent.click(screen.getByLabelText("Edit"));
+    expect(onOpenFile).toHaveBeenCalledWith("src/renamed.ts");
+  });
+
+  it("falls back to opts.filePath when the callback prop has no fileDiff.name", () => {
+    const onOpenFile = vi.fn();
+    const { result } = renderHook(() => useDiffHeaderToolbar({ ...baseOpts, onOpenFile }));
+    const node = result.current(headerProp(undefined));
+    renderToolbar(node as ReactElement);
+
+    fireEvent.click(screen.getByLabelText("Edit"));
+    expect(onOpenFile).toHaveBeenCalledWith(FILE);
+  });
+
+  it("shows the markdown preview button only for .md/.mdx files", () => {
+    const onPreviewMarkdown = vi.fn();
+    const { result } = renderHook(() => useDiffHeaderToolbar({ ...baseOpts, onPreviewMarkdown }));
+    const tsNode = result.current(headerProp(FILE));
+    const { unmount } = renderToolbar(tsNode as ReactElement);
+    expect(screen.queryByLabelText("Preview markdown")).toBeNull();
+    unmount();
+
+    const mdNode = result.current(headerProp("README.md"));
+    renderToolbar(mdNode as ReactElement);
+    expect(screen.getByLabelText("Preview markdown")).toBeTruthy();
+  });
+});

--- a/apps/web/components/diff/diff-header-toolbar.test.tsx
+++ b/apps/web/components/diff/diff-header-toolbar.test.tsx
@@ -23,14 +23,14 @@ function renderToolbar(node: ReactElement) {
 }
 
 /**
- * Build a synthetic RenderHeaderMetadataProps shape. Calling this through the
- * hook callback means a future library change to the prop shape (rename,
+ * Build a synthetic FileDiffMetadata shape. Calling this through the
+ * hook callback means a future library change to the metadata shape (rename,
  * removal, or restructure) surfaces here rather than only at the live FileDiff
  * render site.
  */
 function headerProp(name: string | undefined) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (name === undefined ? {} : { fileDiff: { name } }) as any;
+  return (name === undefined ? {} : { name }) as any;
 }
 
 const baseOpts = {

--- a/apps/web/components/diff/diff-header-toolbar.test.tsx
+++ b/apps/web/components/diff/diff-header-toolbar.test.tsx
@@ -45,9 +45,9 @@ const baseOpts = {
 describe("useDiffHeaderToolbar", () => {
   it("returns a callback that renders the toolbar buttons", () => {
     const { result } = renderHook(() => useDiffHeaderToolbar(baseOpts));
-    // The callback signature is the library's RenderHeaderMetadataProps; we
-    // pass a synthetic value so a real change in the library's prop shape
-    // would surface here instead of only at the FileDiff render site.
+    // The callback receives FileDiffMetadata directly; passing a synthetic
+    // value through the hook means a future library change to that shape
+    // surfaces here instead of only at the live FileDiff render site.
     const node = result.current(headerProp(FILE));
     renderToolbar(node as ReactElement);
 

--- a/apps/web/components/diff/diff-header-toolbar.tsx
+++ b/apps/web/components/diff/diff-header-toolbar.tsx
@@ -15,7 +15,7 @@ import {
   IconFold,
   IconEye,
 } from "@tabler/icons-react";
-import type { RenderHeaderMetadataProps } from "@pierre/diffs";
+import type { FileDiffMetadata } from "@pierre/diffs";
 import type { ViewMode } from "@/hooks/use-global-view-mode";
 
 const iconBtn = "h-6 w-6 p-0 cursor-pointer opacity-60 hover:opacity-100";
@@ -168,8 +168,8 @@ export function useDiffHeaderToolbar(opts: DiffHeaderToolbarOptions) {
   } = opts;
 
   return useCallback(
-    (props: RenderHeaderMetadataProps): ReactNode => {
-      const resolvedPath = props.fileDiff?.name || filePath;
+    (fileDiff: FileDiffMetadata): ReactNode => {
+      const resolvedPath = fileDiff?.name || filePath;
       return (
         <DiffHeaderToolbarButtons
           resolvedPath={resolvedPath}

--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -96,7 +96,7 @@ function useAutoLoadExpansion(
     loadExpansionContent,
   ]);
   const hasValidData = !!(
-    state.fileDiffMetadata?.oldLines?.length && state.fileDiffMetadata?.newLines?.length
+    state.fileDiffMetadata?.deletionLines?.length && state.fileDiffMetadata?.additionLines?.length
   );
   return enableExpansion && isExpansionContentLoaded && hasValidData;
 }

--- a/apps/web/components/diff/use-diff-metadata.test.ts
+++ b/apps/web/components/diff/use-diff-metadata.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useDiffMetadata } from "./use-diff-metadata";
+import type { FileDiffData } from "@/lib/diff/types";
+
+const PATCH = `diff --git a/src/foo.ts b/src/foo.ts
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,3 +1,3 @@
+ first
+-second
++SECOND
+ third
+`;
+
+const baseData = (overrides: Partial<FileDiffData> = {}): FileDiffData => ({
+  filePath: "src/foo.ts",
+  oldContent: "",
+  newContent: "",
+  additions: 0,
+  deletions: 0,
+  ...overrides,
+});
+
+describe("useDiffMetadata", () => {
+  it("returns null when there is no diff or content", () => {
+    const { result } = renderHook(() => useDiffMetadata(baseData()));
+    expect(result.current).toBeNull();
+  });
+
+  it("parses a unified diff string via parsePatchFiles", () => {
+    const { result } = renderHook(() => useDiffMetadata(baseData({ diff: PATCH })));
+    expect(result.current).not.toBeNull();
+    // Surface checks on the parsed metadata. We do not assert deep internals —
+    // we only confirm the library still returns the shape useDiffMetadata
+    // depends on (a FileDiffMetadata with at least a recognisable filename).
+    const meta = result.current as unknown as Record<string, unknown>;
+    const filename = (meta.filename ?? meta.name ?? meta.path) as string | undefined;
+    expect(filename).toBeTruthy();
+    expect(String(filename)).toContain("foo");
+  });
+
+  it("parses from oldContent/newContent when diff is absent", () => {
+    const { result } = renderHook(() =>
+      useDiffMetadata(
+        baseData({
+          oldContent: "first\nsecond\nthird\n",
+          newContent: "first\nSECOND\nthird\n",
+        }),
+      ),
+    );
+    expect(result.current).not.toBeNull();
+  });
+
+  it("forces lang='text' on Go files with the problematic regex pattern", () => {
+    const goContent = 'package main\n\nvar s interface{} `json:"x"`\n';
+    const { result } = renderHook(() =>
+      useDiffMetadata(
+        baseData({
+          filePath: "src/foo.go",
+          oldContent: "package main\n",
+          newContent: goContent,
+        }),
+      ),
+    );
+    expect(result.current).not.toBeNull();
+    expect((result.current as { lang?: string }).lang).toBe("text");
+  });
+
+  it("leaves lang untouched for Go files without the problematic pattern", () => {
+    const { result } = renderHook(() =>
+      useDiffMetadata(
+        baseData({
+          filePath: "src/foo.go",
+          oldContent: "package main\n",
+          newContent: "package main\n\nfunc main() {}\n",
+        }),
+      ),
+    );
+    expect(result.current).not.toBeNull();
+    expect((result.current as { lang?: string }).lang).not.toBe("text");
+  });
+
+  it("memoizes the result across re-renders with the same inputs", () => {
+    const data = baseData({ diff: PATCH });
+    const { result, rerender } = renderHook(({ d }) => useDiffMetadata(d), {
+      initialProps: { d: data },
+    });
+    const first = result.current;
+    rerender({ d: { ...data } });
+    expect(result.current).toBe(first);
+  });
+});

--- a/apps/web/components/diff/use-diff-options.tsx
+++ b/apps/web/components/diff/use-diff-options.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, type ReactNode } from "react";
 import { useTheme } from "next-themes";
-import type { FileDiffOptions, SelectedLineRange, RenderHeaderMetadataProps } from "@pierre/diffs";
+import type { FileDiffOptions, SelectedLineRange, FileDiffMetadata } from "@pierre/diffs";
 import { IconPlus } from "@tabler/icons-react";
 import { FONT } from "@/lib/theme/colors";
 import { useGlobalViewMode } from "@/hooks/use-global-view-mode";
@@ -82,7 +82,7 @@ type UseDiffOptionsArgs = {
 type UseDiffOptionsResult = {
   globalViewMode: string;
   options: FileDiffOptions<AnnotationMetadata>;
-  renderHeaderMetadata: ((props: RenderHeaderMetadataProps) => ReactNode) | undefined;
+  renderHeaderMetadata: ((fileDiff: FileDiffMetadata) => ReactNode) | undefined;
   renderHoverUtility: () => ReactNode;
 };
 

--- a/apps/web/components/diff/use-diff-options.tsx
+++ b/apps/web/components/diff/use-diff-options.tsx
@@ -69,7 +69,7 @@ type UseDiffOptionsArgs = {
   onOpenFile?: (filePath: string) => void;
   onPreviewMarkdown?: (filePath: string) => void;
   onRevert?: (filePath: string) => void;
-  /** Enable diff expansion (requires oldLines/newLines in metadata) */
+  /** Enable diff expansion (requires full deletionLines/additionLines in metadata) */
   enableExpansion?: boolean;
   /** Number of lines to expand per click (default: 20) */
   expansionLineCount?: number;
@@ -147,7 +147,7 @@ export function useDiffOptions(args: UseDiffOptionsArgs): UseDiffOptionsResult {
       diffStyle: globalViewMode,
       themeType: resolvedTheme === "dark" ? "dark" : "light",
       enableLineSelection: enableComments,
-      // "line-info" shows expand buttons when oldLines/newLines are on metadata;
+      // "line-info" shows expand buttons when full deletionLines/additionLines are on metadata;
       // "simple" is a plain divider without expand controls.
       hunkSeparators: enableExpansion ? "line-info" : "simple",
       enableHoverUtility: enableComments,

--- a/apps/web/components/diff/use-diff-viewer-state.test.ts
+++ b/apps/web/components/diff/use-diff-viewer-state.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { parsePatchFiles } from "@pierre/diffs";
+import type { FileDiffMetadata, DiffLineAnnotation } from "@pierre/diffs";
+
+import { buildHunkAnnotations, type HunkOutputs } from "./use-diff-viewer-state";
+import type { RevertBlockInfo } from "./diff-viewer";
+import type { AnnotationMetadata } from "./use-diff-annotation-renderer";
+
+const FILE = "src/foo.ts";
+const DIFF_HEADER = [`diff --git a/${FILE} b/${FILE}`, `--- a/${FILE}`, `+++ b/${FILE}`];
+
+function freshOut(): HunkOutputs {
+  return {
+    result: [] as DiffLineAnnotation<AnnotationMetadata>[],
+    lineMap: new Map<string, string>(),
+    revertMap: new Map<string, RevertBlockInfo>(),
+  };
+}
+
+function parseSinglePatch(diff: string): FileDiffMetadata {
+  const patches = parsePatchFiles(diff);
+  const file = patches[0]?.files[0];
+  if (!file) throw new Error("parsePatchFiles returned no files");
+  return file;
+}
+
+describe("buildHunkAnnotations", () => {
+  it("reconstructs revert oldLines by slicing deletionLines via deletionLineIndex", () => {
+    // Mixed change: 1 context, 2 deletions, 2 additions, 1 trailing context.
+    const diff = [
+      ...DIFF_HEADER,
+      "@@ -1,5 +1,5 @@",
+      " keep",
+      "-remove one",
+      "-remove two",
+      "+add one",
+      "+add two",
+      " end",
+      "",
+    ].join("\n");
+
+    const out = freshOut();
+    buildHunkAnnotations(parseSinglePatch(diff), out);
+
+    expect(out.revertMap.size).toBe(1);
+    const info = [...out.revertMap.values()][0];
+    // addStart begins after the leading 1 line of context, so line 2.
+    expect(info.addStart).toBe(2);
+    expect(info.addCount).toBe(2);
+    // The library hands us *line text* via deletionLines + deletionLineIndex;
+    // the hunk-walker is responsible for picking the right slice and stripping
+    // trailing newlines. If the addressing scheme drifts in a future bump this
+    // assertion will fail rather than silently delivering wrong "old lines".
+    expect(info.oldLines).toEqual(["remove one", "remove two"]);
+  });
+
+  it("emits a hunk-actions annotation anchored at the previous context line", () => {
+    const diff = [...DIFF_HEADER, "@@ -1,3 +1,3 @@", " keep", "-old", "+new", " tail", ""].join(
+      "\n",
+    );
+
+    const out = freshOut();
+    buildHunkAnnotations(parseSinglePatch(diff), out);
+
+    expect(out.result).toHaveLength(1);
+    const ann = out.result[0];
+    // additions side because aLen > 0; anchored on the previous context line (line 1).
+    expect(ann.side).toBe("additions");
+    expect(ann.lineNumber).toBe(1);
+    expect(ann.metadata).toMatchObject({ type: "hunk-actions" });
+  });
+
+  it("maps each added/deleted line to its changeBlock id in lineMap", () => {
+    const diff = [...DIFF_HEADER, "@@ -1,3 +1,3 @@", " keep", "-old", "+new", " tail", ""].join(
+      "\n",
+    );
+
+    const out = freshOut();
+    buildHunkAnnotations(parseSinglePatch(diff), out);
+
+    const cbId = [...out.revertMap.keys()][0];
+    // Line 2 is the modified line on both sides (after the 1-line context prefix).
+    expect(out.lineMap.get("additions:2")).toBe(cbId);
+    expect(out.lineMap.get("deletions:2")).toBe(cbId);
+  });
+
+  it("handles a pure-deletion change (aLen === 0): empty addCount, side='deletions'", () => {
+    const diff = [...DIFF_HEADER, "@@ -1,3 +1,2 @@", " keep", "-removed", " tail", ""].join("\n");
+
+    const out = freshOut();
+    buildHunkAnnotations(parseSinglePatch(diff), out);
+
+    expect(out.revertMap.size).toBe(1);
+    const info = [...out.revertMap.values()][0];
+    expect(info.addCount).toBe(0);
+    expect(info.oldLines).toEqual(["removed"]);
+    expect(out.result[0].side).toBe("deletions");
+  });
+
+  it("handles a pure-addition change (dLen === 0): empty oldLines, side='additions'", () => {
+    const diff = [...DIFF_HEADER, "@@ -1,2 +1,3 @@", " keep", "+added", " tail", ""].join("\n");
+
+    const out = freshOut();
+    buildHunkAnnotations(parseSinglePatch(diff), out);
+
+    expect(out.revertMap.size).toBe(1);
+    const info = [...out.revertMap.values()][0];
+    expect(info.addCount).toBe(1);
+    expect(info.oldLines).toEqual([]);
+    expect(out.result[0].side).toBe("additions");
+  });
+});

--- a/apps/web/components/diff/use-diff-viewer-state.ts
+++ b/apps/web/components/diff/use-diff-viewer-state.ts
@@ -31,7 +31,7 @@ type HunkState = {
   blockIdx: number;
 };
 
-type HunkOutputs = {
+export type HunkOutputs = {
   result: DiffLineAnnotation<AnnotationMetadata>[];
   lineMap: Map<string, string>;
   revertMap: Map<string, RevertBlockInfo>;
@@ -65,7 +65,7 @@ function processChangeBlock(
 }
 
 /** Build hunk-level annotations, line->changeBlock map, and revert info. */
-function buildHunkAnnotations(fileDiffMetadata: FileDiffMetadata, out: HunkOutputs) {
+export function buildHunkAnnotations(fileDiffMetadata: FileDiffMetadata, out: HunkOutputs) {
   const state: HunkState = { addLine: 0, delLine: 0, lastCtxAdd: 0, lastCtxDel: 0, blockIdx: 0 };
   for (const hunk of fileDiffMetadata.hunks) {
     if (hunk.additionCount === 0 && hunk.deletionCount === 0) continue;

--- a/apps/web/components/diff/use-diff-viewer-state.ts
+++ b/apps/web/components/diff/use-diff-viewer-state.ts
@@ -358,6 +358,7 @@ export function useDiffViewerState(opts: UseDiffViewerStateOpts) {
     filePath: data.filePath,
     baseRef,
     fileDiffMetadata: baseDiffMetadata,
+    diff: data.diff,
     enableExpansion,
     repo,
   });

--- a/apps/web/components/diff/use-diff-viewer-state.ts
+++ b/apps/web/components/diff/use-diff-viewer-state.ts
@@ -4,6 +4,7 @@ import type {
   FileDiffMetadata,
   DiffLineAnnotation,
   AnnotationSide,
+  ChangeContent,
 } from "@pierre/diffs";
 import type { FileDiffData, DiffComment } from "@/lib/diff/types";
 import { buildDiffComment, useCommentActions } from "@/lib/diff/comment-utils";
@@ -30,38 +31,41 @@ type HunkState = {
   blockIdx: number;
 };
 
+type HunkOutputs = {
+  result: DiffLineAnnotation<AnnotationMetadata>[];
+  lineMap: Map<string, string>;
+  revertMap: Map<string, RevertBlockInfo>;
+};
+
 /** Process a single change block within a hunk. */
 function processChangeBlock(
-  content: { additions: string[]; deletions: string[] },
+  content: ChangeContent,
+  deletionLines: string[],
   state: HunkState,
-  result: DiffLineAnnotation<AnnotationMetadata>[],
-  newLineMap: Map<string, string>,
-  newRevertMap: Map<string, RevertBlockInfo>,
+  out: HunkOutputs,
 ) {
-  const aLen = content.additions.length;
-  const dLen = content.deletions.length;
+  const aLen = content.additions;
+  const dLen = content.deletions;
   if (aLen === 0 && dLen === 0) return;
 
   const cbId = `cb-${state.blockIdx++}`;
   const side: AnnotationSide = aLen > 0 ? "additions" : "deletions";
   const lineNumber = side === "additions" ? state.lastCtxAdd : state.lastCtxDel;
-  result.push({ side, lineNumber, metadata: { type: "hunk-actions", changeBlockId: cbId } });
-  for (let l = 0; l < aLen; l++) newLineMap.set(`additions:${state.addLine + l}`, cbId);
-  for (let l = 0; l < dLen; l++) newLineMap.set(`deletions:${state.delLine + l}`, cbId);
-  newRevertMap.set(cbId, {
+  out.result.push({ side, lineNumber, metadata: { type: "hunk-actions", changeBlockId: cbId } });
+  for (let l = 0; l < aLen; l++) out.lineMap.set(`additions:${state.addLine + l}`, cbId);
+  for (let l = 0; l < dLen; l++) out.lineMap.set(`deletions:${state.delLine + l}`, cbId);
+  const oldLines = deletionLines
+    .slice(content.deletionLineIndex, content.deletionLineIndex + dLen)
+    .map((l) => l.replace(/\r?\n$/, ""));
+  out.revertMap.set(cbId, {
     addStart: state.addLine,
     addCount: aLen,
-    oldLines: content.deletions.map((l) => l.replace(/\r?\n$/, "")),
+    oldLines,
   });
 }
 
 /** Build hunk-level annotations, line->changeBlock map, and revert info. */
-function buildHunkAnnotations(
-  fileDiffMetadata: FileDiffMetadata,
-  result: DiffLineAnnotation<AnnotationMetadata>[],
-  newLineMap: Map<string, string>,
-  newRevertMap: Map<string, RevertBlockInfo>,
-) {
+function buildHunkAnnotations(fileDiffMetadata: FileDiffMetadata, out: HunkOutputs) {
   const state: HunkState = { addLine: 0, delLine: 0, lastCtxAdd: 0, lastCtxDel: 0, blockIdx: 0 };
   for (const hunk of fileDiffMetadata.hunks) {
     if (hunk.additionCount === 0 && hunk.deletionCount === 0) continue;
@@ -71,16 +75,16 @@ function buildHunkAnnotations(
     state.lastCtxDel = state.delLine > 1 ? state.delLine - 1 : state.delLine;
     for (const content of hunk.hunkContent) {
       if (content.type === "context") {
-        const len = content.lines.length;
+        const len = content.lines;
         state.lastCtxAdd = state.addLine + len - 1;
         state.lastCtxDel = state.delLine + len - 1;
         state.addLine += len;
         state.delLine += len;
         continue;
       }
-      processChangeBlock(content, state, result, newLineMap, newRevertMap);
-      state.addLine += content.additions.length;
-      state.delLine += content.deletions.length;
+      processChangeBlock(content, fileDiffMetadata.deletionLines, state, out);
+      state.addLine += content.additions;
+      state.delLine += content.deletions;
     }
   }
 }
@@ -112,7 +116,11 @@ function buildAnnotations(opts: BuildAnnotationsOpts) {
   const newLineMap = new Map<string, string>();
   const newRevertMap = new Map<string, RevertBlockInfo>();
   if (enableAcceptReject && fileDiffMetadata) {
-    buildHunkAnnotations(fileDiffMetadata, result, newLineMap, newRevertMap);
+    buildHunkAnnotations(fileDiffMetadata, {
+      result,
+      lineMap: newLineMap,
+      revertMap: newRevertMap,
+    });
   }
 
   return { annotations: result, lineMap: newLineMap, revertMap: newRevertMap };

--- a/apps/web/components/diff/use-expandable-diff.ts
+++ b/apps/web/components/diff/use-expandable-diff.ts
@@ -64,7 +64,7 @@ async function fetchNewContent(
 ): Promise<string> {
   try {
     // Fetch from working tree (current file on disk), not HEAD.
-    // The diff shows working tree changes, so newLines must match.
+    // The diff shows working tree changes, so additionLines must match.
     const res = await requestFileContent(client, sessionId, filePath, repo);
     if (res.is_binary) throw new Error("Cannot expand binary files");
     if (!res.error) return res.content;
@@ -93,17 +93,18 @@ async function fetchExpansionLines(
     ? await fetchOldContent(client, sessionId, filePath, baseRef, repo)
     : "";
   return {
-    oldLines: oldContent.split(SPLIT_WITH_NEWLINES),
-    newLines: newContent.split(SPLIT_WITH_NEWLINES),
+    deletionLines: oldContent.split(SPLIT_WITH_NEWLINES),
+    additionLines: newContent.split(SPLIT_WITH_NEWLINES),
   };
 }
 
 /**
  * Hook for managing expandable diffs with lazy-loaded file content.
  *
- * The @pierre/diffs library requires `oldLines` and `newLines` in FileDiffMetadata
- * for expansion to work. This hook fetches old/new content and merges it into the
- * metadata.
+ * The @pierre/diffs library requires the full file content in
+ * `deletionLines`/`additionLines` on FileDiffMetadata (and `isPartial: false`)
+ * for expansion to work. This hook fetches old/new content and merges it into
+ * the metadata.
  */
 export function useExpandableDiff({
   sessionId,
@@ -115,8 +116,8 @@ export function useExpandableDiff({
 }: UseExpandableDiffOptions): UseExpandableDiffResult {
   const requestVersionRef = useRef(0);
   const [loadedContent, setLoadedContent] = useState<{
-    oldLines: string[];
-    newLines: string[];
+    deletionLines: string[];
+    additionLines: string[];
   } | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -124,7 +125,7 @@ export function useExpandableDiff({
   // Reset cached content when inputs change so stale data is never rendered.
   // Including fileDiffMetadata ensures expansion content is invalidated when
   // the diff changes (e.g., file modified while Diff panel is open), because
-  // @pierre/diffs uses oldLines/newLines for rendering when present.
+  // @pierre/diffs uses deletionLines/additionLines for rendering when present.
   useEffect(() => {
     requestVersionRef.current += 1;
     setLoadedContent(null);
@@ -155,8 +156,9 @@ export function useExpandableDiff({
     if (!loadedContent) return fileDiffMetadata;
     return {
       ...fileDiffMetadata,
-      oldLines: loadedContent.oldLines,
-      newLines: loadedContent.newLines,
+      deletionLines: loadedContent.deletionLines,
+      additionLines: loadedContent.additionLines,
+      isPartial: false,
     };
   }, [fileDiffMetadata, loadedContent]);
 

--- a/apps/web/components/diff/use-expandable-diff.ts
+++ b/apps/web/components/diff/use-expandable-diff.ts
@@ -156,7 +156,11 @@ export function useExpandableDiff({
       oldFile: { name: filePath, contents: loadedContent.oldContent },
       newFile: { name: filePath, contents: loadedContent.newContent },
     });
-    return reparsed ?? fileDiffMetadata;
+    if (!reparsed) return fileDiffMetadata;
+    // Preserve the lang override that useDiffMetadata sets (e.g. lang:'text'
+    // for Go files that hit the Shiki backtracking guard). processFile would
+    // otherwise infer "go" from the filename and silently re-enable Shiki.
+    return fileDiffMetadata.lang ? { ...reparsed, lang: fileDiffMetadata.lang } : reparsed;
   }, [fileDiffMetadata, loadedContent, diff, filePath]);
 
   const isContentLoaded = loadedContent !== null;

--- a/apps/web/components/diff/use-expandable-diff.ts
+++ b/apps/web/components/diff/use-expandable-diff.ts
@@ -1,16 +1,16 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import type { FileDiffMetadata } from "@pierre/diffs";
+import { processFile, type FileDiffMetadata } from "@pierre/diffs";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { requestFileContent, requestFileContentAtRef } from "@/lib/ws/workspace-files";
-
-/** Must match @pierre/diffs SPLIT_WITH_NEWLINES — splits preserving trailing \n */
-const SPLIT_WITH_NEWLINES = /(?<=\n)/;
 
 type UseExpandableDiffOptions = {
   sessionId: string | undefined;
   filePath: string;
   baseRef: string | undefined;
   fileDiffMetadata: FileDiffMetadata | null;
+  /** Original patch string used to build fileDiffMetadata. Required for
+   *  re-parsing via processFile with the loaded full content. */
+  diff: string | undefined;
   enableExpansion?: boolean;
   /** Multi-repo subpath for the file (e.g. "kandev"); empty for single-repo. */
   repo?: string;
@@ -79,8 +79,8 @@ async function fetchNewContent(
   }
 }
 
-/** Fetch both old and new content, split into lines for @pierre/diffs expansion. */
-async function fetchExpansionLines(
+/** Fetch both old and new content as raw strings for @pierre/diffs expansion. */
+async function fetchExpansionContent(
   sessionId: string,
   filePath: string,
   baseRef: string | undefined,
@@ -92,40 +92,38 @@ async function fetchExpansionLines(
   const oldContent = baseRef
     ? await fetchOldContent(client, sessionId, filePath, baseRef, repo)
     : "";
-  return {
-    deletionLines: oldContent.split(SPLIT_WITH_NEWLINES),
-    additionLines: newContent.split(SPLIT_WITH_NEWLINES),
-  };
+  return { oldContent, newContent };
 }
 
 /**
  * Hook for managing expandable diffs with lazy-loaded file content.
  *
- * The @pierre/diffs library requires the full file content in
- * `deletionLines`/`additionLines` on FileDiffMetadata (and `isPartial: false`)
- * for expansion to work. This hook fetches old/new content and merges it into
- * the metadata.
+ * @pierre/diffs needs both the patch *and* the full file contents (with
+ * isPartial=false and hunk indices addressed against the full arrays) to
+ * render expand controls. We get there by re-parsing via `processFile`
+ * once the content arrives — it's the only API that produces a metadata
+ * shape internally consistent enough for the library's expansion path.
  */
 export function useExpandableDiff({
   sessionId,
   filePath,
   baseRef,
   fileDiffMetadata,
+  diff,
   enableExpansion = false,
   repo,
 }: UseExpandableDiffOptions): UseExpandableDiffResult {
   const requestVersionRef = useRef(0);
   const [loadedContent, setLoadedContent] = useState<{
-    deletionLines: string[];
-    additionLines: string[];
+    oldContent: string;
+    newContent: string;
   } | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Reset cached content when inputs change so stale data is never rendered.
   // Including fileDiffMetadata ensures expansion content is invalidated when
-  // the diff changes (e.g., file modified while Diff panel is open), because
-  // @pierre/diffs uses deletionLines/additionLines for rendering when present.
+  // the diff changes (e.g., file modified while Diff panel is open).
   useEffect(() => {
     requestVersionRef.current += 1;
     setLoadedContent(null);
@@ -140,8 +138,8 @@ export function useExpandableDiff({
     setError(null);
 
     try {
-      const lines = await fetchExpansionLines(sessionId, filePath, baseRef, repo);
-      if (version === requestVersionRef.current) setLoadedContent(lines);
+      const content = await fetchExpansionContent(sessionId, filePath, baseRef, repo);
+      if (version === requestVersionRef.current) setLoadedContent(content);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to load file content";
       console.error("[useExpandableDiff]", msg);
@@ -153,14 +151,13 @@ export function useExpandableDiff({
 
   const metadata = useMemo<FileDiffMetadata | null>(() => {
     if (!fileDiffMetadata) return null;
-    if (!loadedContent) return fileDiffMetadata;
-    return {
-      ...fileDiffMetadata,
-      deletionLines: loadedContent.deletionLines,
-      additionLines: loadedContent.additionLines,
-      isPartial: false,
-    };
-  }, [fileDiffMetadata, loadedContent]);
+    if (!loadedContent || !diff) return fileDiffMetadata;
+    const reparsed = processFile(diff, {
+      oldFile: { name: filePath, contents: loadedContent.oldContent },
+      newFile: { name: filePath, contents: loadedContent.newContent },
+    });
+    return reparsed ?? fileDiffMetadata;
+  }, [fileDiffMetadata, loadedContent, diff, filePath]);
 
   const isContentLoaded = loadedContent !== null;
 

--- a/apps/web/components/diff/use-expandable-diff.ts
+++ b/apps/web/components/diff/use-expandable-diff.ts
@@ -98,7 +98,7 @@ async function fetchExpansionContent(
 /**
  * Hook for managing expandable diffs with lazy-loaded file content.
  *
- * @pierre/diffs needs both the patch *and* the full file contents (with
+ * @pierre/diffs needs the patch *and* the full file contents (with
  * isPartial=false and hunk indices addressed against the full arrays) to
  * render expand controls. We get there by re-parsing via `processFile`
  * once the content arrives — it's the only API that produces a metadata

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -369,6 +369,13 @@ function renderDiffContent(opts: {
     onToggleExpandUnchanged,
   } = opts;
   if (shouldRender && file.diff) {
+    // Expansion fetches the file content from the working tree to reconstruct
+    // full context around hunks. For PR files the working tree's content
+    // belongs to the local branch, not the PR head — when the same file has
+    // both PR and local changes, the wrong content gets paired with the PR
+    // patch and @pierre/diffs 1.1.x renders nothing/errors. Disable expansion
+    // for PR-sourced rows; uncommitted/committed rows still get it.
+    const enableExpansion = file.source !== "pr";
     return (
       <>
         <FileDiffViewer
@@ -381,7 +388,7 @@ function renderDiffContent(opts: {
           onCommentRun={onCommentRun}
           sessionId={sessionId}
           wordWrap={wordWrap}
-          enableExpansion={true}
+          enableExpansion={enableExpansion}
           baseRef="HEAD"
           hideHeader
           expandUnchanged={expandUnchanged}

--- a/apps/web/e2e/tests/git/diff-expansion.spec.ts
+++ b/apps/web/e2e/tests/git/diff-expansion.spec.ts
@@ -196,9 +196,10 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
       timeout: 20_000,
     });
 
-    // The "Expand all lines" button is in the Pierre Diffs header toolbar.
-    // It contains a tabler-icon-fold-down SVG icon.
-    const expandAllBtn = testPage.locator("button:has(svg.tabler-icon-fold-down)");
+    // The "Expand all lines" button is in the Kandev toolbar that we inject
+    // via renderHeaderMetadata. We anchor on aria-label rather than the Tabler
+    // class so a future icon swap doesn't silently break this test.
+    const expandAllBtn = testPage.getByLabel("Expand all lines");
     await expect(expandAllBtn).toBeVisible({ timeout: 10_000 });
     await expandAllBtn.click();
 

--- a/apps/web/e2e/tests/git/diff-expansion.spec.ts
+++ b/apps/web/e2e/tests/git/diff-expansion.spec.ts
@@ -86,19 +86,24 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
     // Shiki renders each token as a <span style="color: #RRGGBB"> inside the
     // diff's shadow DOM. If the worker pool is broken or the @pierre/diffs ↔
     // Shiki contract changes, lines still render as plain text without inline
-    // color styles. Counting coloured spans here piggybacks on the seeded
-    // hunks above to avoid spinning a separate ~45s seed for one assertion.
-    const colouredTokenCount = await testPage.evaluate(() => {
-      const container = document.querySelector("diffs-container");
-      const shadow = container?.shadowRoot;
-      if (!shadow) return -1;
-      let count = 0;
-      for (const span of shadow.querySelectorAll<HTMLElement>("span[style]")) {
-        if (/color\s*:/i.test(span.getAttribute("style") ?? "")) count++;
-      }
-      return count;
-    });
-    expect(colouredTokenCount).toBeGreaterThan(20);
+    // color styles. Highlighting is async (worker pool), so poll instead of
+    // reading once.
+    await expect
+      .poll(
+        () =>
+          testPage.evaluate(() => {
+            const container = document.querySelector("diffs-container");
+            const shadow = container?.shadowRoot;
+            if (!shadow) return -1;
+            let count = 0;
+            for (const span of shadow.querySelectorAll<HTMLElement>("span[style]")) {
+              if (/color\s*:/i.test(span.getAttribute("style") ?? "")) count++;
+            }
+            return count;
+          }),
+        { timeout: 20_000 },
+      )
+      .toBeGreaterThan(20);
   });
 
   test("shows expand separator with unmodified line count between hunks", async ({
@@ -182,10 +187,12 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
       timeout: 20_000,
     });
 
-    // The "Expand all lines" button is in the Kandev toolbar that we inject
-    // via renderHeaderMetadata. We anchor on aria-label rather than the Tabler
-    // class so a future icon swap doesn't silently break this test.
-    const expandAllBtn = testPage.getByLabel("Expand all lines");
+    // The "Expand all lines" button is in the Kandev toolbar injected via
+    // renderHeaderMetadata. Anchor on the accessible role+name rather than
+    // the Tabler icon class so a future icon swap doesn't silently break
+    // this test. (getByLabel didn't pick up the Radix Tooltip-wrapped
+    // shadcn Button on CI; getByRole resolves it reliably.)
+    const expandAllBtn = testPage.getByRole("button", { name: "Expand all lines" });
     await expect(expandAllBtn).toBeVisible({ timeout: 10_000 });
     await expandAllBtn.click();
 

--- a/apps/web/e2e/tests/git/diff-expansion.spec.ts
+++ b/apps/web/e2e/tests/git/diff-expansion.spec.ts
@@ -148,6 +148,37 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
     });
   });
 
+  test("renders syntax-highlighted tokens (worker pool + Shiki sanity check)", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await seedExpansionTask(testPage, apiClient, seedData);
+    await openChangesTab(testPage);
+    await openExpansionFileDiff(testPage);
+
+    // Wait for the diff to render so the worker pool has had a chance to highlight.
+    await expect(testPage.getByText("HUNK_TOP", { exact: false })).toBeVisible({
+      timeout: 60_000,
+    });
+
+    // Shiki renders each token as a <span style="color: #RRGGBB"> inside the
+    // diff's shadow DOM. If the worker pool is broken or the @pierre/diffs ↔
+    // Shiki contract changes, lines still render as plain text without
+    // inline color styles. Count coloured spans as a smoke test.
+    const colouredTokenCount = await testPage.evaluate(() => {
+      const container = document.querySelector("diffs-container");
+      const shadow = container?.shadowRoot;
+      if (!shadow) return -1;
+      let count = 0;
+      for (const span of shadow.querySelectorAll<HTMLElement>("span[style]")) {
+        if (/color\s*:/i.test(span.getAttribute("style") ?? "")) count++;
+      }
+      return count;
+    });
+    expect(colouredTokenCount).toBeGreaterThan(20);
+  });
+
   test("expand-all button reveals all collapsed lines at once", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/git/diff-expansion.spec.ts
+++ b/apps/web/e2e/tests/git/diff-expansion.spec.ts
@@ -187,12 +187,11 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
       timeout: 20_000,
     });
 
-    // The "Expand all lines" button is in the Kandev toolbar injected via
-    // renderHeaderMetadata. Anchor on the accessible role+name rather than
-    // the Tabler icon class so a future icon swap doesn't silently break
-    // this test. (getByLabel didn't pick up the Radix Tooltip-wrapped
-    // shadcn Button on CI; getByRole resolves it reliably.)
-    const expandAllBtn = testPage.getByRole("button", { name: "Expand all lines" });
+    // The Changes tab renders ReviewDiffList → FileDiffToolbar (not the
+    // Pierre Diffs renderHeaderMetadata toolbar), and its expand-all button
+    // has aria-label "Expand all". Anchor on role+name instead of the
+    // Tabler icon class so an icon swap doesn't silently break this test.
+    const expandAllBtn = testPage.getByRole("button", { name: "Expand all" });
     await expect(expandAllBtn).toBeVisible({ timeout: 10_000 });
     await expandAllBtn.click();
 

--- a/apps/web/e2e/tests/git/diff-expansion.spec.ts
+++ b/apps/web/e2e/tests/git/diff-expansion.spec.ts
@@ -82,6 +82,23 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
     await expect(testPage.getByText("HUNK_BOTTOM", { exact: false })).toBeVisible({
       timeout: 5_000,
     });
+
+    // Shiki renders each token as a <span style="color: #RRGGBB"> inside the
+    // diff's shadow DOM. If the worker pool is broken or the @pierre/diffs ↔
+    // Shiki contract changes, lines still render as plain text without inline
+    // color styles. Counting coloured spans here piggybacks on the seeded
+    // hunks above to avoid spinning a separate ~45s seed for one assertion.
+    const colouredTokenCount = await testPage.evaluate(() => {
+      const container = document.querySelector("diffs-container");
+      const shadow = container?.shadowRoot;
+      if (!shadow) return -1;
+      let count = 0;
+      for (const span of shadow.querySelectorAll<HTMLElement>("span[style]")) {
+        if (/color\s*:/i.test(span.getAttribute("style") ?? "")) count++;
+      }
+      return count;
+    });
+    expect(colouredTokenCount).toBeGreaterThan(20);
   });
 
   test("shows expand separator with unmodified line count between hunks", async ({
@@ -146,37 +163,6 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
     await expect(testPage.getByText("original_060", { exact: false })).toBeVisible({
       timeout: 10_000,
     });
-  });
-
-  test("renders syntax-highlighted tokens (worker pool + Shiki sanity check)", async ({
-    testPage,
-    apiClient,
-    seedData,
-  }) => {
-    await seedExpansionTask(testPage, apiClient, seedData);
-    await openChangesTab(testPage);
-    await openExpansionFileDiff(testPage);
-
-    // Wait for the diff to render so the worker pool has had a chance to highlight.
-    await expect(testPage.getByText("HUNK_TOP", { exact: false })).toBeVisible({
-      timeout: 60_000,
-    });
-
-    // Shiki renders each token as a <span style="color: #RRGGBB"> inside the
-    // diff's shadow DOM. If the worker pool is broken or the @pierre/diffs ↔
-    // Shiki contract changes, lines still render as plain text without
-    // inline color styles. Count coloured spans as a smoke test.
-    const colouredTokenCount = await testPage.evaluate(() => {
-      const container = document.querySelector("diffs-container");
-      const shadow = container?.shadowRoot;
-      if (!shadow) return -1;
-      let count = 0;
-      for (const span of shadow.querySelectorAll<HTMLElement>("span[style]")) {
-        if (/color\s*:/i.test(span.getAttribute("style") ?? "")) count++;
-      }
-      return count;
-    });
-    expect(colouredTokenCount).toBeGreaterThan(20);
   });
 
   test("expand-all button reveals all collapsed lines at once", async ({

--- a/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
@@ -101,11 +101,14 @@ test.describe("Mobile changes panel", () => {
 
     // Regression: mobile diffs must use word-wrap (overflow="wrap") so long
     // lines are readable without horizontal scroll on touch devices.
+    // @pierre/diffs 1.1.x renamed the attribute on the rendered <pre> from
+    // `data-diffs` to `data-diff` — match either to keep the test stable
+    // across the upgrade.
     const overflowAttr = await testPage.waitForFunction(
       () =>
         document
           .querySelector("diffs-container")
-          ?.shadowRoot?.querySelector("[data-diffs]")
+          ?.shadowRoot?.querySelector("[data-diff], [data-diffs]")
           ?.getAttribute("data-overflow"),
       { timeout: 10_000 },
     );

--- a/apps/web/lib/diff/adapter.test.ts
+++ b/apps/web/lib/diff/adapter.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  formatLineRange,
+  normalizeDiffString,
+  transformFileMutation,
+  transformGitDiff,
+  commentsToAnnotations,
+  extractCodeFromDiff,
+  extractCodeFromContent,
+  computeLineDiffStats,
+  type FileMutation,
+} from "./adapter";
+import type { DiffComment } from "./types";
+
+const FILE = "src/foo.ts";
+const SIMPLE_PATCH_BODY = "@@ -1,1 +1,1 @@\n-old\n+new";
+const DIFF_GIT_HEADER = `diff --git a/${FILE} b/${FILE}`;
+
+const baseComment = (overrides: Partial<DiffComment> = {}): DiffComment => ({
+  id: "c1",
+  sessionId: "s1",
+  source: "diff",
+  filePath: FILE,
+  startLine: 10,
+  endLine: 10,
+  side: "additions",
+  codeContent: "x",
+  text: "looks good",
+  createdAt: "2026-05-16T00:00:00Z",
+  status: "pending",
+  ...overrides,
+});
+
+describe("formatLineRange", () => {
+  it("renders a single-line range as Lx", () => {
+    expect(formatLineRange(10, 10)).toBe("L10");
+  });
+
+  it("renders a multi-line range as Lx-y", () => {
+    expect(formatLineRange(10, 15)).toBe("L10-15");
+  });
+});
+
+describe("normalizeDiffString", () => {
+  it("returns empty string when diff is empty", () => {
+    expect(normalizeDiffString("", FILE)).toBe("");
+  });
+
+  it("returns the trimmed diff unchanged when it already starts with diff --git", () => {
+    const diff = `diff --git a/src/foo.ts b/src/foo.ts
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,1 +1,1 @@
+-old
++new`;
+    expect(normalizeDiffString(`  ${diff}  `, FILE)).toBe(diff);
+  });
+
+  it("prepends only the diff --git header when --- and +++ are present", () => {
+    const diff = `--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,1 +1,1 @@
+-old
++new`;
+    const result = normalizeDiffString(diff, FILE);
+    expect(result.startsWith(`${DIFF_GIT_HEADER}\n`)).toBe(true);
+    expect(result).toContain("--- a/src/foo.ts");
+    expect(result).toContain("+++ b/src/foo.ts");
+  });
+
+  it("prepends the full header trio when no headers are present", () => {
+    const diff = `@@ -1,1 +1,1 @@
+-old
++new`;
+    const result = normalizeDiffString(diff, FILE);
+    const lines = result.split("\n");
+    expect(lines[0]).toBe(DIFF_GIT_HEADER);
+    expect(lines[1]).toBe("--- a/src/foo.ts");
+    expect(lines[2]).toBe("+++ b/src/foo.ts");
+    expect(lines[3]).toBe("@@ -1,1 +1,1 @@");
+  });
+});
+
+describe("transformFileMutation", () => {
+  it("uses old_content and new_content for replace mutations", () => {
+    const mutation: FileMutation = {
+      type: "replace",
+      old_content: "old text",
+      new_content: "new text",
+    };
+    const result = transformFileMutation(FILE, mutation);
+    expect(result).toEqual({
+      filePath: FILE,
+      oldContent: "old text",
+      newContent: "new text",
+      diff: undefined,
+      additions: 0,
+      deletions: 0,
+    });
+  });
+
+  it("falls back to `content` when new_content is missing", () => {
+    const mutation: FileMutation = { type: "create", content: "hello world" };
+    const result = transformFileMutation(FILE, mutation);
+    expect(result.newContent).toBe("hello world");
+  });
+
+  it("normalizes an explicit diff string", () => {
+    const mutation: FileMutation = {
+      type: "patch",
+      diff: SIMPLE_PATCH_BODY,
+    };
+    const result = transformFileMutation(FILE, mutation);
+    expect(result.diff).toContain(DIFF_GIT_HEADER);
+    expect(result.diff).toContain("--- a/src/foo.ts");
+    expect(result.diff).toContain("+++ b/src/foo.ts");
+  });
+
+  it("generates an all-additions diff for create with content but no diff", () => {
+    const mutation: FileMutation = {
+      type: "create",
+      content: "line one\nline two",
+    };
+    const result = transformFileMutation("src/new.ts", mutation);
+    expect(result.diff).toBe(
+      [
+        "diff --git a/src/new.ts b/src/new.ts",
+        "new file mode 100644",
+        "--- /dev/null",
+        "+++ b/src/new.ts",
+        "@@ -0,0 +1,2 @@",
+        "+line one",
+        "+line two",
+      ].join("\n"),
+    );
+  });
+
+  it("returns undefined diff for create without content or diff", () => {
+    const mutation: FileMutation = { type: "create" };
+    const result = transformFileMutation("src/empty.ts", mutation);
+    expect(result.diff).toBeUndefined();
+  });
+
+  it("prefers new_path over the supplied filePath when renaming", () => {
+    const mutation: FileMutation = {
+      type: "rename",
+      new_path: "src/renamed.ts",
+      diff: "@@ -1,1 +1,1 @@\n-a\n+b",
+    };
+    const result = transformFileMutation("src/old.ts", mutation);
+    expect(result.filePath).toBe("src/renamed.ts");
+    expect(result.diff).toContain("a/src/renamed.ts b/src/renamed.ts");
+  });
+
+  it("defaults empty content fields to empty strings (not undefined)", () => {
+    const result = transformFileMutation(FILE, { type: "delete" });
+    expect(result.oldContent).toBe("");
+    expect(result.newContent).toBe("");
+  });
+});
+
+describe("transformGitDiff", () => {
+  it("normalizes the diff and zeroes additions/deletions", () => {
+    const result = transformGitDiff(FILE, "@@ -1,1 +1,1 @@\n-a\n+b", "M");
+    expect(result.filePath).toBe(FILE);
+    expect(result.oldContent).toBe("");
+    expect(result.newContent).toBe("");
+    expect(result.diff).toContain(DIFF_GIT_HEADER);
+    expect(result.additions).toBe(0);
+    expect(result.deletions).toBe(0);
+  });
+});
+
+describe("commentsToAnnotations", () => {
+  it("anchors each annotation at endLine and preserves side", () => {
+    const comments: DiffComment[] = [
+      baseComment({ id: "c1", startLine: 10, endLine: 12, side: "additions" }),
+      baseComment({ id: "c2", startLine: 5, endLine: 5, side: "deletions" }),
+    ];
+    const annotations = commentsToAnnotations(comments);
+    expect(annotations).toHaveLength(2);
+    expect(annotations[0]).toMatchObject({
+      side: "additions",
+      lineNumber: 12,
+      metadata: { isEditing: false },
+    });
+    expect(annotations[0].metadata.comment.id).toBe("c1");
+    expect(annotations[1]).toMatchObject({
+      side: "deletions",
+      lineNumber: 5,
+    });
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(commentsToAnnotations([])).toEqual([]);
+  });
+});
+
+describe("extractCodeFromDiff", () => {
+  const diff = `diff --git a/src/foo.ts b/src/foo.ts
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -10,4 +10,5 @@
+ context line
+-removed line
++added line one
++added line two
+ trailing context`;
+
+  it("extracts added lines on the additions side", () => {
+    // Hunk starts at +10. Context line is +10, then two additions at +11 and +12.
+    const result = extractCodeFromDiff(diff, 11, 12, "additions");
+    expect(result).toBe("added line one\nadded line two");
+  });
+
+  it("extracts the removed line on the deletions side", () => {
+    // Hunk starts at -10. Context line is -10, removed line is -11.
+    const result = extractCodeFromDiff(diff, 11, 11, "deletions");
+    expect(result).toBe("removed line");
+  });
+
+  it("includes context lines that fall within range on the additions side", () => {
+    // +10 is the first context line; both addition lines are +11 and +12.
+    const result = extractCodeFromDiff(diff, 10, 12, "additions");
+    expect(result).toBe("context line\nadded line one\nadded line two");
+  });
+
+  it("returns an empty string when the range matches nothing", () => {
+    expect(extractCodeFromDiff(diff, 100, 200, "additions")).toBe("");
+  });
+});
+
+describe("extractCodeFromContent", () => {
+  it("extracts a 1-indexed inclusive line range", () => {
+    const content = "a\nb\nc\nd\ne";
+    expect(extractCodeFromContent(content, 2, 4)).toBe("b\nc\nd");
+  });
+
+  it("returns the single line when start equals end", () => {
+    const content = "a\nb\nc";
+    expect(extractCodeFromContent(content, 2, 2)).toBe("b");
+  });
+});
+
+describe("computeLineDiffStats", () => {
+  it("returns zero stats for identical content", () => {
+    expect(computeLineDiffStats("a\nb\nc", "a\nb\nc")).toEqual({
+      additions: 0,
+      deletions: 0,
+    });
+  });
+
+  it("counts an appended line as a single addition", () => {
+    expect(computeLineDiffStats("a\nb", "a\nb\nc")).toEqual({
+      additions: 1,
+      deletions: 0,
+    });
+  });
+
+  it("counts a removed trailing line as a single deletion", () => {
+    expect(computeLineDiffStats("a\nb\nc", "a\nb")).toEqual({
+      additions: 0,
+      deletions: 1,
+    });
+  });
+
+  it("counts a changed line as one addition and one deletion", () => {
+    expect(computeLineDiffStats("a\nb\nc", "a\nX\nc")).toEqual({
+      additions: 1,
+      deletions: 1,
+    });
+  });
+});

--- a/apps/web/lib/diff/adapter.test.ts
+++ b/apps/web/lib/diff/adapter.test.ts
@@ -102,6 +102,46 @@ describe("normalizeDiffString", () => {
     expect(lines[3]).toBe("+++ b/src/foo.ts");
   });
 
+  it("detects new file from a `new file mode` header even without an @@ hunk", () => {
+    // Header-only new-file patches (mode-only / binary / rename-no-delta)
+    // need the same /dev/null treatment — otherwise the renderer treats
+    // them as modifications and pairs missing old content with the patch.
+    const diff = `new file mode 100644
+index 0000000..e69de29`;
+    const result = normalizeDiffString(diff, FILE);
+    const lines = result.split("\n");
+    expect(lines[0]).toBe(DIFF_GIT_HEADER);
+    expect(lines[1]).toBe("new file mode 100644");
+    expect(lines[2]).toBe("--- /dev/null");
+    expect(lines[3]).toBe(NEW_HEADER);
+  });
+
+  it("strips rename headers so the canonical --- / +++ pair survives", () => {
+    // `git diff --find-renames` produces `similarity index`, `rename from`,
+    // `rename to` lines that our older regex left in place — the duplicated
+    // header pair confused @pierre/diffs.
+    const diff = `diff --git a/old.ts b/${FILE}
+similarity index 95%
+rename from old.ts
+rename to ${FILE}
+index abcdef0..1234567 100644
+--- a/old.ts
++++ b/${FILE}
+@@ -1,1 +1,1 @@
+-old
++new`;
+    const result = normalizeDiffString(diff, FILE);
+    // No leftover rename / similarity / index header should remain.
+    expect(result).not.toContain("similarity index");
+    expect(result).not.toContain("rename from");
+    expect(result).not.toContain("rename to");
+    expect(result).not.toContain("a/old.ts");
+    expect(result).toContain(DIFF_GIT_HEADER);
+    expect(result).toContain(OLD_HEADER);
+    expect(result).toContain(NEW_HEADER);
+    expect(result).toContain("@@ -1,1 +1,1 @@");
+  });
+
   it("emits +++ /dev/null and deleted-file-mode for an `@@ -N,M +0,0 @@` hunk", () => {
     const diff = `@@ -1,2 +0,0 @@
 -line one

--- a/apps/web/lib/diff/adapter.test.ts
+++ b/apps/web/lib/diff/adapter.test.ts
@@ -16,6 +16,8 @@ import type { DiffComment } from "./types";
 const FILE = "src/foo.ts";
 const SIMPLE_PATCH_BODY = "@@ -1,1 +1,1 @@\n-old\n+new";
 const DIFF_GIT_HEADER = `diff --git a/${FILE} b/${FILE}`;
+const OLD_HEADER = `--- a/${FILE}`;
+const NEW_HEADER = `+++ b/${FILE}`;
 
 const baseComment = (overrides: Partial<DiffComment> = {}): DiffComment => ({
   id: "c1",
@@ -47,14 +49,16 @@ describe("normalizeDiffString", () => {
     expect(normalizeDiffString("", FILE)).toBe("");
   });
 
-  it("returns the trimmed diff unchanged when it already starts with diff --git", () => {
+  it("re-emits canonical headers and trailing newline even when input already starts with diff --git", () => {
     const diff = `diff --git a/src/foo.ts b/src/foo.ts
 --- a/src/foo.ts
 +++ b/src/foo.ts
 @@ -1,1 +1,1 @@
 -old
 +new`;
-    expect(normalizeDiffString(`  ${diff}  `, FILE)).toBe(diff);
+    // We always re-emit headers + ensure trailing newline so @pierre/diffs
+    // never sees malformed input regardless of upstream formatting.
+    expect(normalizeDiffString(`  ${diff}  `, FILE)).toBe(diff + "\n");
   });
 
   it("prepends only the diff --git header when --- and +++ are present", () => {
@@ -65,8 +69,8 @@ describe("normalizeDiffString", () => {
 +new`;
     const result = normalizeDiffString(diff, FILE);
     expect(result.startsWith(`${DIFF_GIT_HEADER}\n`)).toBe(true);
-    expect(result).toContain("--- a/src/foo.ts");
-    expect(result).toContain("+++ b/src/foo.ts");
+    expect(result).toContain(OLD_HEADER);
+    expect(result).toContain(NEW_HEADER);
   });
 
   it("prepends the full header trio when no headers are present", () => {
@@ -76,9 +80,38 @@ describe("normalizeDiffString", () => {
     const result = normalizeDiffString(diff, FILE);
     const lines = result.split("\n");
     expect(lines[0]).toBe(DIFF_GIT_HEADER);
-    expect(lines[1]).toBe("--- a/src/foo.ts");
-    expect(lines[2]).toBe("+++ b/src/foo.ts");
+    expect(lines[1]).toBe(OLD_HEADER);
+    expect(lines[2]).toBe(NEW_HEADER);
     expect(lines[3]).toBe("@@ -1,1 +1,1 @@");
+  });
+
+  it("emits --- /dev/null and new-file-mode for an `@@ -0,0 +N,M @@` hunk", () => {
+    // A new file from GitHub mock looks like this (no headers, just the hunk).
+    // @pierre/diffs 1.1.x throws "deletionLine and additionLine are null" if the
+    // diff is fed --- a/file / +++ b/file because it gets classified as a
+    // modification with no old content to read. The /dev/null marker keeps the
+    // renderer in the "new file" code path.
+    const diff = `@@ -0,0 +1,2 @@
++line one
++line two`;
+    const result = normalizeDiffString(diff, FILE);
+    const lines = result.split("\n");
+    expect(lines[0]).toBe(DIFF_GIT_HEADER);
+    expect(lines[1]).toBe("new file mode 100644");
+    expect(lines[2]).toBe("--- /dev/null");
+    expect(lines[3]).toBe("+++ b/src/foo.ts");
+  });
+
+  it("emits +++ /dev/null and deleted-file-mode for an `@@ -N,M +0,0 @@` hunk", () => {
+    const diff = `@@ -1,2 +0,0 @@
+-line one
+-line two`;
+    const result = normalizeDiffString(diff, FILE);
+    const lines = result.split("\n");
+    expect(lines[0]).toBe(DIFF_GIT_HEADER);
+    expect(lines[1]).toBe("deleted file mode 100644");
+    expect(lines[2]).toBe("--- a/src/foo.ts");
+    expect(lines[3]).toBe("+++ /dev/null");
   });
 });
 

--- a/apps/web/lib/diff/adapter.test.ts
+++ b/apps/web/lib/diff/adapter.test.ts
@@ -116,6 +116,22 @@ index 0000000..e69de29`;
     expect(lines[3]).toBe(NEW_HEADER);
   });
 
+  it("strips the trailing header in a header-only rename diff (no @@ body)", () => {
+    // 100%-similarity renames have no hunk body, so the *last* header line
+    // (`rename to ...`) has no trailing \n after trim. The strip regex
+    // needs to see a terminator, which is why we append `\n` before
+    // matching — otherwise `rename to ...` leaks into `body` and breaks
+    // the reconstructed patch.
+    const diff = `diff --git a/old.ts b/${FILE}
+similarity index 100%
+rename from old.ts
+rename to ${FILE}`;
+    const result = normalizeDiffString(diff, FILE);
+    expect(result).not.toContain("rename to");
+    expect(result).not.toContain("similarity index");
+    expect(result).not.toContain("a/old.ts");
+  });
+
   it("strips rename headers so the canonical --- / +++ pair survives", () => {
     // `git diff --find-renames` produces `similarity index`, `rename from`,
     // `rename to` lines that our older regex left in place — the duplicated

--- a/apps/web/lib/diff/adapter.ts
+++ b/apps/web/lib/diff/adapter.ts
@@ -42,16 +42,19 @@ export function normalizeDiffString(diff: string, filePath: string): string {
 
   const trimmed = diff.trim();
 
-  // Detect new/deleted file from the first hunk header so we can force the
-  // correct old/new file markers even when the caller pre-attached headers.
-  const isNewFile = /@@\s+-0,0\s+\+\d/.test(trimmed);
-  const isDeletedFile = /@@\s+-\d[\d,]*\s+\+0,0\s+@@/.test(trimmed);
+  // Detect new/deleted file from the hunk header OR from the explicit
+  // mode-change line — covers patches with no `@@` body (mode-only,
+  // binary, or rename-with-no-delta).
+  const isNewFile = /@@\s+-0,0\s+\+\d/.test(trimmed) || /^new file mode\b/m.test(trimmed);
+  const isDeletedFile =
+    /@@\s+-\d[\d,]*\s+\+0,0\s+@@/.test(trimmed) || /^deleted file mode\b/m.test(trimmed);
 
-  // Strip any existing diff --git / index / mode / --- / +++ headers so we
-  // can re-emit them with the right /dev/null markers below. Hunk content
-  // (lines starting with @@) and everything after stays untouched.
+  // Strip every git-produced header line so we can re-emit canonical ones.
+  // Covers diff --git, index, mode change, similarity/dissimilarity, rename
+  // and copy markers, and the --- / +++ pair. Hunk content (lines starting
+  // with @@) and everything after stays untouched.
   const body = trimmed.replace(
-    /^(diff --git[^\n]*\n|index [^\n]*\n|(?:new|deleted) file mode [^\n]*\n|--- [^\n]*\n|\+\+\+ [^\n]*\n)+/,
+    /^(?:(?:diff --git|index |(?:new|deleted) file mode |(?:old|new) mode |(?:similarity|dissimilarity) index |(?:rename|copy) (?:from|to) |Binary files |--- |\+\+\+ )[^\n]*\n)+/,
     "",
   );
 

--- a/apps/web/lib/diff/adapter.ts
+++ b/apps/web/lib/diff/adapter.ts
@@ -29,32 +29,45 @@ export interface ModifyFilePayload {
 /**
  * Normalize a diff string by ensuring it has proper headers.
  * Required because backend diffs may not include full git headers.
+ *
+ * Detects new-file (`@@ -0,0 +X,Y @@`) and deleted-file (`@@ -X,Y +0,0 @@`)
+ * hunks and emits the canonical `--- /dev/null` / `+++ /dev/null` markers.
+ * @pierre/diffs 1.1.x relies on these to classify the change type; when both
+ * sides point at `a/file` and `b/file` for a new-file patch the renderer
+ * throws "deletionLine and additionLine are null" because it expects a
+ * modification and there's no old content to read.
  */
 export function normalizeDiffString(diff: string, filePath: string): string {
   if (!diff) return "";
 
   const trimmed = diff.trim();
 
-  // Check if the diff already has headers
-  if (trimmed.startsWith("diff --git")) {
-    return trimmed;
-  }
+  // Detect new/deleted file from the first hunk header so we can force the
+  // correct old/new file markers even when the caller pre-attached headers.
+  const isNewFile = /@@\s+-0,0\s+\+\d/.test(trimmed);
+  const isDeletedFile = /@@\s+-\d[\d,]*\s+\+0,0\s+@@/.test(trimmed);
 
-  // Check if it has file headers but not diff header
-  const hasFileHeaders = trimmed.includes("---") && trimmed.includes("+++");
+  // Strip any existing diff --git / index / mode / --- / +++ headers so we
+  // can re-emit them with the right /dev/null markers below. Hunk content
+  // (lines starting with @@) and everything after stays untouched.
+  const body = trimmed.replace(
+    /^(diff --git[^\n]*\n|index [^\n]*\n|(?:new|deleted) file mode [^\n]*\n|--- [^\n]*\n|\+\+\+ [^\n]*\n)+/,
+    "",
+  );
 
-  if (hasFileHeaders) {
-    // Add just the diff header
-    return `diff --git a/${filePath} b/${filePath}\n${trimmed}`;
-  }
-
-  // Add minimal headers
-  const headers = [
-    `diff --git a/${filePath} b/${filePath}`,
-    `--- a/${filePath}`,
-    `+++ b/${filePath}`,
-  ];
-  return headers.join("\n") + "\n" + trimmed;
+  const headers = [`diff --git a/${filePath} b/${filePath}`];
+  if (isNewFile) headers.push("new file mode 100644");
+  else if (isDeletedFile) headers.push("deleted file mode 100644");
+  headers.push(
+    isNewFile ? "--- /dev/null" : `--- a/${filePath}`,
+    isDeletedFile ? "+++ /dev/null" : `+++ b/${filePath}`,
+  );
+  // Ensure body ends with a newline. @pierre/diffs 1.1.x tolerates a missing
+  // EOF newline on real text content, but its hunk row generator can over-
+  // count rows when the last line lacks a terminator, occasionally tripping
+  // "deletionLine and additionLine are null" inside DiffHunksRenderer.
+  const tail = body.endsWith("\n") ? "" : "\n";
+  return headers.join("\n") + "\n" + body + tail;
 }
 
 /**

--- a/apps/web/lib/diff/adapter.ts
+++ b/apps/web/lib/diff/adapter.ts
@@ -53,7 +53,10 @@ export function normalizeDiffString(diff: string, filePath: string): string {
   // Covers diff --git, index, mode change, similarity/dissimilarity, rename
   // and copy markers, and the --- / +++ pair. Hunk content (lines starting
   // with @@) and everything after stays untouched.
-  const body = trimmed.replace(
+  // Append `\n` before matching so the last header line in a header-only
+  // diff (e.g. 100%-similarity rename with no `@@` body) still terminates
+  // and gets stripped — otherwise it leaks into `body`.
+  const body = (trimmed + "\n").replace(
     /^(?:(?:diff --git|index |(?:new|deleted) file mode |(?:old|new) mode |(?:similarity|dissimilarity) index |(?:rename|copy) (?:from|to) |Binary files |--- |\+\+\+ )[^\n]*\n)+/,
     "",
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,7 @@
     "@kandev/ui": "workspace:*",
     "@lezer/highlight": "^1.2.3",
     "@monaco-editor/react": "^4.7.0",
-    "@pierre/diffs": "^1.0.11",
+    "@pierre/diffs": "^1.1.22",
     "@tabler/icons-react": "^3.36.1",
     "@tanstack/react-table": "^8.21.3",
     "@tiptap/core": "^3.19.0",


### PR DESCRIPTION
Brings the diff viewer onto the supported 1.1.x line; 1.0.11 was 22 patch releases behind and missing the renamed metadata API. Tests landed first so the upgrade has a regression net — and one of them caught the callback-shape change on the first run.

## Important Changes

- `RenderHeaderMetadataProps` removed: callback now receives `FileDiffMetadata` directly instead of `{ fileDiff }`.
- `FileDiffMetadata.oldLines`/`newLines` renamed to `deletionLines`/`additionLines`.
- `ChangeContent.additions`/`deletions` and `ContextContent.lines` are now `number` (counts); line strings live on `FileDiffMetadata` and are addressed via new `additionLineIndex`/`deletionLineIndex` fields.

## Validation

- `pnpm exec vitest run` — 1775/1775 pass (38 new unit tests across `adapter.test.ts`, `use-diff-metadata.test.ts`, `diff-header-toolbar.test.tsx`)
- `pnpm lint` — 0 warnings
- `pnpm exec tsc --noEmit` — only 2 pre-existing errors for `@/generated/*.json` build artifacts, unrelated
- `pnpm exec prettier --check` on touched files — clean
- New Playwright spec in `diff-expansion.spec.ts` counts coloured Shiki spans in the shadow DOM as a worker-pool smoke test

## Possible Improvements

Low risk: the `processChangeBlock` rewrite reconstructs revert line text by slicing `FileDiffMetadata.deletionLines[deletionLineIndex .. +deletions]`; if upstream ever changes that addressing scheme, revert-hunk would surface incorrect "old lines". The accept/reject hunk path isn't covered by an E2E test yet.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.