### PR TITLE
chore(web): add pnpm typecheck script

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,8 @@
     "build": "cross-env NODE_ENV=production next build",
     "start": "cross-env NODE_ENV=production next start",
     "lint": "eslint --max-warnings 0",
+    "pretypecheck": "node scripts/generate-release-notes.mjs && node scripts/generate-changelog.mjs",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "e2e": "playwright test --config e2e/playwright.config.ts",
     "e2e:ui": "playwright test --config e2e/playwright.config.ts --ui",


### PR DESCRIPTION
## Summary

\`pnpm --filter @kandev/web typecheck\` is currently a no-op — there's no \`typecheck\` script in \`apps/web/package.json\`, so pnpm prints \`None of the selected packages has a "typecheck" script\` and exits 0. CI doesn't catch the gap because \`next build\` skips \`*.test.tsx\`, and CLAUDE.md / docs reference \`pnpm typecheck\` as the canonical command. Net effect: TypeScript errors in test files can ship while tooling reports green.

This adds a real \`typecheck\` script (\`tsc --noEmit\`) with a \`pretypecheck\` hook that regenerates the same changelog / release-notes JSON files that \`prebuild\` / \`predev\` already generate, so the script works on a fresh clone.

## Validation

- \`pnpm --filter @kandev/web typecheck\` — exits 0, runs the generators, then \`tsc --noEmit\` with no errors against current main.
- \`pnpm --filter @kandev/web lint\` — unchanged.
- \`pnpm --filter @kandev/web build\` — unchanged.

## Possible Improvements

If CI grows a dedicated typecheck step (instead of relying on \`next build\`), it can now invoke this script directly. Out of scope for this PR.

## Checklist

- [ ] I have updated \`apps/backend/CLAUDE.md\` and \`apps/web/CLAUDE.md\` if architectural patterns changed
- [ ] I have added tests for new functionality
- [ ] I have updated documentation if needed