### PR TITLE
chore: suppress pnpm modules-purge prompt in non-interactive installs

### DIFF
--- a/apps/.npmrc
+++ b/apps/.npmrc
@@ -1,3 +1,5 @@
 # Hoist @lezer/highlight for codemirror theme packages that expect it as a peer dependency
 public-hoist-pattern[]=@lezer/*
 
+confirm-modules-purge=false
+

--- a/apps/backend/internal/common/config/config_test.go
+++ b/apps/backend/internal/common/config/config_test.go
@@ -150,9 +150,15 @@ func TestValidate_PostgresSSLMode(t *testing.T) {
 // would ship an in-progress feature to users on the next release.
 // See docs/decisions/0007-runtime-feature-flags.md.
 func TestFeatures_DefaultOff(t *testing.T) {
-	// Force a clean env so KANDEV_FEATURES_* from the host shell can't
-	// bleed in and turn a default-off check into a default-on accident.
+	// Force a clean env so KANDEV_FEATURES_* and profile-selector vars
+	// from the host shell can't bleed in and turn a default-off check
+	// into a default-on accident. Clearing the profile selectors ensures
+	// DetectEnvironment returns prod, so FeatureFlagDefaults uses the
+	// prod value ("false") rather than the dev value ("true").
 	t.Setenv("KANDEV_FEATURES_OFFICE", "")
+	t.Setenv("KANDEV_DEBUG_DEV_MODE", "")
+	t.Setenv("KANDEV_DEBUG_PPROF_ENABLED", "")
+	t.Setenv("KANDEV_E2E_MOCK", "")
 
 	dir := t.TempDir()
 	cfg, err := LoadWithPath(dir)


### PR DESCRIPTION
Running `make start-debug` (or any target that calls `install-web`) would prompt for confirmation when pnpm needed to purge and reinstall node_modules, blocking non-interactive shells and piped runs like `make start-debug | tee logs.txt`. Setting `confirm-modules-purge=false` in `apps/.npmrc` silences this globally without affecting install behaviour.

Also fixes a flaky backend test (`TestFeatures_DefaultOff`) that failed when `KANDEV_DEBUG_DEV_MODE=true` was set in the host environment, causing `DetectEnvironment()` to return `EnvDev` and seed wrong defaults.

**Validation**
- `make -C apps/backend test lint`
- `cd apps && pnpm --filter @kandev/web lint`

**Checklist**
- [ ] Tests added/updated
- [ ] Docs updated if needed