### PR TITLE
feat(web): polish chat message rendering

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -715,11 +715,13 @@
   margin-bottom: 0.25rem;
 }
 
-/* Inline code accent color */
+/* Inline code: neutral foreground on a soft muted background.
+   Linked code (a > code) drops the background and inherits the link
+   color so file references read as links, not as another code chip. */
 .markdown-body :not(pre) > code,
 .markdown-body code:not(pre code) {
   background: var(--muted);
-  color: var(--accent);
+  color: var(--foreground);
   padding: 0.1rem 0.375rem;
   border-radius: 0.25rem;
   font-size: 0.9em;
@@ -734,6 +736,19 @@
 
 .markdown-body a:hover {
   text-decoration-line: underline;
+}
+
+/* Code wrapped in a link reads as a link: no fill, link color,
+   background appears on hover for affordance. */
+.markdown-body a > code,
+.markdown-body a code:not(pre code) {
+  background: transparent;
+  color: inherit;
+}
+
+.markdown-body a:hover > code,
+.markdown-body a:hover code:not(pre code) {
+  background: var(--muted);
 }
 
 .markdown-body blockquote {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -739,15 +739,16 @@
 }
 
 /* Code wrapped in a link reads as a link: no fill, link color,
-   background appears on hover for affordance. */
-.markdown-body a > code,
-.markdown-body a code:not(pre code) {
+   background appears on hover for affordance. Scoped to exclude
+   user bubbles so they keep their primary-tinted chip styling. */
+.markdown-body:not(.markdown-body-user) a > code,
+.markdown-body:not(.markdown-body-user) a code:not(pre code) {
   background: transparent;
   color: inherit;
 }
 
-.markdown-body a:hover > code,
-.markdown-body a:hover code:not(pre code) {
+.markdown-body:not(.markdown-body-user) a:hover > code,
+.markdown-body:not(.markdown-body-user) a:hover code:not(pre code) {
   background: var(--muted);
 }
 

--- a/apps/web/components/shared/markdown-components.test.tsx
+++ b/apps/web/components/shared/markdown-components.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { markdownComponents, remarkPlugins } from "./markdown-components";
+import { markdownComponents, normalizeMarkdown, remarkPlugins } from "./markdown-components";
 
 vi.mock("@/components/shared/mermaid-block", () => ({
   MermaidBlock: ({ code }: { code: string }) => <div data-kind="mermaid">{code}</div>,
@@ -51,5 +51,93 @@ describe("markdownComponents", () => {
     expect(html).toContain("language-ts");
     expect(html).toContain("const source");
     expect(html).not.toContain('data-kind="mermaid"');
+  });
+});
+
+describe("normalizeMarkdown", () => {
+  it("splits a glued 4-backtick close", () => {
+    const input = "````go\nfunc f() {\n  ...\n}````\nprose continues here";
+    const expected = "````go\nfunc f() {\n  ...\n}\n````\nprose continues here";
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("splits a glued 3-backtick close", () => {
+    const input = "```go\nfunc f() {}```\nprose";
+    const expected = "```go\nfunc f() {}\n```\nprose";
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("leaves a valid fence (close on its own line) unchanged", () => {
+    const input = "```go\nfunc f() {}\n```\nprose";
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("leaves inline-code prose outside any fence unchanged", () => {
+    const input = "Use `code` inline in a paragraph.";
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("does not split when trailing run is shorter than opener", () => {
+    // Opens with 4, line ends with 3 — those 3 backticks would not close, so
+    // we must not split. The parser will keep gobbling, but at least we don't
+    // invent a false close.
+    const input = "````go\nfunc f() {}```\nstill code";
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("splits only the malformed fence when multiple fences appear", () => {
+    const input = ["```go", "func f() {}```", "prose", "", "```ts", "const x = 1;", "```"].join(
+      "\n",
+    );
+    const expected = [
+      "```go",
+      "func f() {}",
+      "```",
+      "prose",
+      "",
+      "```ts",
+      "const x = 1;",
+      "```",
+    ].join("\n");
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("handles up to 3 leading spaces on the opener", () => {
+    const input = "   ```go\nfunc f() {}```\nprose";
+    const expected = "   ```go\nfunc f() {}\n```\nprose";
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("returns pure prose unchanged", () => {
+    const input = "Just some paragraph text with no fences.\nSecond line.";
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("returns empty and single-line input unchanged", () => {
+    expect(normalizeMarkdown("")).toBe("");
+    expect(normalizeMarkdown("single line")).toBe("single line");
+  });
+
+  it("preserves a trailing newline if present", () => {
+    const input = "```go\nx```\nprose\n";
+    const expected = "```go\nx\n```\nprose\n";
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("renders malformed fence + prose as two code blocks plus a paragraph", () => {
+    const malformed = "```go\nfunc f() {}```\nprose continues here\n```ts\nconst x = 1;\n```";
+    const htmlRaw = renderMarkdown(malformed);
+    const htmlFixed = renderMarkdown(normalizeMarkdown(malformed));
+
+    // Without normalization the parser swallows the prose into one code node.
+    const rawBlockCount = (htmlRaw.match(/data-kind="block"/g) ?? []).length;
+    const fixedBlockCount = (htmlFixed.match(/data-kind="block"/g) ?? []).length;
+    expect(fixedBlockCount).toBeGreaterThan(rawBlockCount);
+    expect(fixedBlockCount).toBe(2);
+
+    // Prose paragraph is visible as its own node, not inside a code block.
+    expect(htmlFixed).toContain("prose continues here");
+    expect(htmlFixed).toContain("language-go");
+    expect(htmlFixed).toContain("language-ts");
   });
 });

--- a/apps/web/components/shared/markdown-components.tsx
+++ b/apps/web/components/shared/markdown-components.tsx
@@ -13,6 +13,70 @@ import { isMermaidContent } from "@/components/editors/tiptap/tiptap-mermaid-ext
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const remarkPlugins: any[] = [remarkGfm, remarkBreaks, remarkGemoji];
 
+const FENCE_OPEN_RE = /^ {0,3}(`{3,})/;
+const TRAILING_FENCE_RE = /(`{3,})\s*$/;
+
+function pureCloseLength(line: string, openCount: number): number | null {
+  const match = /^ {0,3}(`{3,})\s*$/.exec(line);
+  if (!match || match[1].length < openCount) return null;
+  return match[1].length;
+}
+
+function gluedCloseLength(line: string, openCount: number): number | null {
+  const match = TRAILING_FENCE_RE.exec(line);
+  if (!match || match[1].length < openCount) return null;
+  // Reject pure-fence lines (already handled by pureCloseLength) and lines
+  // where everything before the trailing run is whitespace only.
+  const head = line.slice(0, line.length - match[0].length).trimEnd();
+  if (head.length === 0) return null;
+  return match[1].length;
+}
+
+/**
+ * Pre-process a markdown string to repair fenced code blocks that have their
+ * closing fence glued to the last code line (`...}\`\`\`\n`prose`). Without
+ * this, CommonMark/GFM treats the glued backticks as code content, so the
+ * fence never closes and following prose gets swallowed into one huge code
+ * node. We split such lines into `<content>\n<backticks>` only when we're
+ * inside an open fence whose opener run length is ≤ the trailing run length.
+ *
+ * Pure string preprocessing, intentionally not a remark plugin.
+ */
+export function normalizeMarkdown(input: string): string {
+  if (!input || input.length === 0) return input;
+  const hadTrailingNewline = input.endsWith("\n");
+  const lines = input.split("\n");
+  const out: string[] = [];
+  let openCount: number | null = null;
+
+  for (const line of lines) {
+    if (openCount === null) {
+      const opener = FENCE_OPEN_RE.exec(line);
+      if (opener) openCount = opener[1].length;
+      out.push(line);
+      continue;
+    }
+    if (pureCloseLength(line, openCount) !== null) {
+      openCount = null;
+      out.push(line);
+      continue;
+    }
+    const glued = gluedCloseLength(line, openCount);
+    if (glued !== null) {
+      const trailingMatch = TRAILING_FENCE_RE.exec(line)!;
+      const head = line.slice(0, line.length - trailingMatch[0].length);
+      out.push(head);
+      out.push("`".repeat(glued));
+      openCount = null;
+      continue;
+    }
+    out.push(line);
+  }
+
+  const result = out.join("\n");
+  return hadTrailingNewline && !result.endsWith("\n") ? result + "\n" : result;
+}
+
 /**
  * Recursively extracts text content from React children.
  * Optimized with fast paths for common cases (string/number).

--- a/apps/web/components/task-create-dialog-selectors.tsx
+++ b/apps/web/components/task-create-dialog-selectors.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useRef, useState, memo, useCallback, useMemo } from "react";
 import { Textarea } from "@kandev/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { IconUpload } from "@tabler/icons-react";
+import { IconPaperclip } from "@tabler/icons-react";
 import { Combobox } from "./combobox";
 import { scoreBranch } from "@/lib/utils/branch-filter";
 import { BranchRefreshButton } from "./branch-refresh-button";
@@ -441,7 +441,7 @@ function AttachButton({ onClick, disabled }: { onClick: () => void; disabled?: b
             onClick={onClick}
             disabled={disabled}
           >
-            <IconUpload className="h-4 w-4" />
+            <IconPaperclip className="h-4 w-4" />
           </button>
         </TooltipTrigger>
         <TooltipContent>Attach files</TooltipContent>

--- a/apps/web/components/task/chat/chat-input-toolbar.tsx
+++ b/apps/web/components/task/chat/chat-input-toolbar.tsx
@@ -10,7 +10,7 @@ import {
   IconAt,
   IconPlugConnected,
   IconPlugConnectedX,
-  IconUpload,
+  IconPaperclip,
 } from "@tabler/icons-react";
 
 import { EnhancePromptButton } from "@/components/enhance-prompt-button";
@@ -439,7 +439,7 @@ function AttachFilesButton({ onClick }: { onClick: () => void }) {
           className="h-7 gap-1.5 px-2 cursor-pointer hover:bg-muted/40"
           onClick={onClick}
         >
-          <IconUpload className="h-4 w-4" />
+          <IconPaperclip className="h-4 w-4" />
         </Button>
       </TooltipTrigger>
       <TooltipContent>Attach files</TooltipContent>

--- a/apps/web/components/task/chat/messages/agent-plan-message.tsx
+++ b/apps/web/components/task/chat/messages/agent-plan-message.tsx
@@ -5,7 +5,11 @@ import ReactMarkdown from "react-markdown";
 import { IconMinus, IconPlus, IconMaximize } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@kandev/ui/dialog";
-import { remarkPlugins, markdownComponents } from "@/components/shared/markdown-components";
+import {
+  markdownComponents,
+  normalizeMarkdown,
+  remarkPlugins,
+} from "@/components/shared/markdown-components";
 import type { Message } from "@/lib/types/http";
 
 function parsePlanContent(text: string): { title: string; body: string } {
@@ -25,7 +29,7 @@ function PlanMarkdownBody({ text, className }: { text: string; className?: strin
       className={`markdown-body max-w-none text-sm [&>*]:my-2 [&>p]:my-2 [&>ul]:my-2 [&>ol]:my-2 ${className ?? ""}`}
     >
       <ReactMarkdown remarkPlugins={remarkPlugins} components={markdownComponents}>
-        {text}
+        {normalizeMarkdown(text)}
       </ReactMarkdown>
     </div>
   );

--- a/apps/web/components/task/chat/messages/chat-message.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.tsx
@@ -12,7 +12,11 @@ import { MessageActions } from "@/components/task/chat/messages/message-actions"
 import { useMessageNavigation } from "@/hooks/use-message-navigation";
 import { useTaskById } from "@/hooks/domains/kanban/use-task-by-id";
 import { linkToTask } from "@/lib/links";
-import { markdownComponents, remarkPlugins } from "@/components/shared/markdown-components";
+import {
+  markdownComponents,
+  normalizeMarkdown,
+  remarkPlugins,
+} from "@/components/shared/markdown-components";
 import { openImageInWindow } from "@/components/task/chat/file-attachment";
 
 type ChatMessageProps = {
@@ -82,7 +86,7 @@ function renderUserMessageBody(
     return (
       <div className="markdown-body markdown-body-user max-w-none">
         <ReactMarkdown remarkPlugins={remarkPlugins} components={markdownComponents}>
-          {content}
+          {normalizeMarkdown(content)}
         </ReactMarkdown>
       </div>
     );
@@ -340,7 +344,7 @@ function AgentMessageContent({ comment, showRaw, onToggleRaw, showRichBlocks }: 
         ) : (
           <div className="markdown-body max-w-none">
             <ReactMarkdown remarkPlugins={remarkPlugins} components={markdownComponents}>
-              {comment.content || "(empty)"}
+              {normalizeMarkdown(comment.content || "(empty)")}
             </ReactMarkdown>
             {showRichBlocks ? <RichBlocks comment={comment} /> : null}
           </div>

--- a/apps/web/components/task/chat/messages/todo-message.tsx
+++ b/apps/web/components/task/chat/messages/todo-message.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { IconListCheck } from "@tabler/icons-react";
+import { IconChevronDown, IconChevronRight, IconListCheck } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
 import type { RichMetadata, TodoMetadata, TodoSnapshot } from "@/components/task/chat/types";
@@ -35,31 +35,44 @@ function countCompleted(items: TodoItem[]): number {
 }
 
 function SnapshotHistory({ snapshots }: { snapshots: TodoSnapshot[] }) {
+  const [isOpen, setIsOpen] = useState(false);
   return (
     <div className="mt-3 pt-2 border-t border-border/30">
-      <div className="text-[10px] uppercase tracking-wide text-muted-foreground/60 mb-1.5">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted-foreground/60 hover:text-muted-foreground cursor-pointer"
+        aria-expanded={isOpen}
+      >
+        {isOpen ? (
+          <IconChevronDown className="h-3 w-3" />
+        ) : (
+          <IconChevronRight className="h-3 w-3" />
+        )}
         Earlier updates ({snapshots.length})
-      </div>
-      <div className="space-y-1 text-[11px] text-muted-foreground/80">
-        {snapshots.map((snap, i) => {
-          const items = normalizeTodos(snap.todos);
-          const done = countCompleted(items);
-          // Todos may not be ordered with completed-first, so find the first
-          // non-completed entry rather than indexing by the completed count.
-          const nextItem = items.find((t) => resolveStatus(t) !== "completed");
-          return (
-            <div key={i} className="flex items-baseline gap-2">
-              <span className="font-mono shrink-0">#{i + 1}</span>
-              <span className="shrink-0">
-                {done}/{items.length}
-              </span>
-              {nextItem && (
-                <span className="truncate text-muted-foreground/60">- {nextItem.text}</span>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      </button>
+      {isOpen && (
+        <div className="mt-1.5 space-y-1 text-[11px] text-muted-foreground/80">
+          {snapshots.map((snap, i) => {
+            const items = normalizeTodos(snap.todos);
+            const done = countCompleted(items);
+            // Todos may not be ordered with completed-first, so find the first
+            // non-completed entry rather than indexing by the completed count.
+            const nextItem = items.find((t) => resolveStatus(t) !== "completed");
+            return (
+              <div key={i} className="flex items-baseline gap-2">
+                <span className="font-mono shrink-0">#{i + 1}</span>
+                <span className="shrink-0">
+                  {done}/{items.length}
+                </span>
+                {nextItem && (
+                  <span className="truncate text-muted-foreground/60">- {nextItem.text}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/task/chat/messages/todo-message.tsx
+++ b/apps/web/components/task/chat/messages/todo-message.tsx
@@ -44,14 +44,17 @@ function SnapshotHistory({ snapshots }: { snapshots: TodoSnapshot[] }) {
         {snapshots.map((snap, i) => {
           const items = normalizeTodos(snap.todos);
           const done = countCompleted(items);
+          // Todos may not be ordered with completed-first, so find the first
+          // non-completed entry rather than indexing by the completed count.
+          const nextItem = items.find((t) => resolveStatus(t) !== "completed");
           return (
             <div key={i} className="flex items-baseline gap-2">
               <span className="font-mono shrink-0">#{i + 1}</span>
               <span className="shrink-0">
                 {done}/{items.length}
               </span>
-              {items[done] && (
-                <span className="truncate text-muted-foreground/60">- {items[done].text}</span>
+              {nextItem && (
+                <span className="truncate text-muted-foreground/60">- {nextItem.text}</span>
               )}
             </div>
           );

--- a/apps/web/components/task/chat/messages/todo-message.tsx
+++ b/apps/web/components/task/chat/messages/todo-message.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { IconListCheck } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
-import type { RichMetadata } from "@/components/task/chat/types";
+import type { RichMetadata, TodoMetadata, TodoSnapshot } from "@/components/task/chat/types";
 import { ExpandableRow } from "./expandable-row";
 import { StatusIcon, resolveStatus } from "../todo-indicator";
 
@@ -14,12 +14,51 @@ type TodoItem = {
   status?: "pending" | "in_progress" | "completed" | "failed";
 };
 
-function parseTodos(comment: Message): TodoItem[] {
-  const metadata = comment.metadata as RichMetadata | undefined;
-  const todos = metadata?.todos ?? [];
-  return todos
+function normalizeTodos(raw: TodoMetadata[]): TodoItem[] {
+  return raw
     .map((item) => (typeof item === "string" ? { text: item, done: false } : item))
     .filter((item) => item.text);
+}
+
+function parseTodos(comment: Message): TodoItem[] {
+  const metadata = comment.metadata as RichMetadata | undefined;
+  return normalizeTodos(metadata?.todos ?? []);
+}
+
+function parseSnapshots(comment: Message): TodoSnapshot[] {
+  const metadata = comment.metadata as RichMetadata | undefined;
+  return metadata?.previous_todo_snapshots ?? [];
+}
+
+function countCompleted(items: TodoItem[]): number {
+  return items.filter((t) => resolveStatus(t) === "completed").length;
+}
+
+function SnapshotHistory({ snapshots }: { snapshots: TodoSnapshot[] }) {
+  return (
+    <div className="mt-3 pt-2 border-t border-border/30">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground/60 mb-1.5">
+        Earlier updates ({snapshots.length})
+      </div>
+      <div className="space-y-1 text-[11px] text-muted-foreground/80">
+        {snapshots.map((snap, i) => {
+          const items = normalizeTodos(snap.todos);
+          const done = countCompleted(items);
+          return (
+            <div key={i} className="flex items-baseline gap-2">
+              <span className="font-mono shrink-0">#{i + 1}</span>
+              <span className="shrink-0">
+                {done}/{items.length}
+              </span>
+              {items[done] && (
+                <span className="truncate text-muted-foreground/60">- {items[done].text}</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 export function TodoMessage({
@@ -30,12 +69,14 @@ export function TodoMessage({
   defaultExpanded?: boolean;
 }) {
   const todoItems = parseTodos(comment);
+  const snapshots = parseSnapshots(comment);
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
   if (!todoItems.length) return null;
 
-  const completed = todoItems.filter((t) => resolveStatus(t) === "completed").length;
+  const completed = countCompleted(todoItems);
   const currentTask = todoItems.find((t) => resolveStatus(t) === "in_progress");
+  const totalUpdates = snapshots.length + 1;
 
   return (
     <ExpandableRow
@@ -48,6 +89,11 @@ export function TodoMessage({
           <span className="text-muted-foreground text-[11px] shrink-0">
             ({completed}/{todoItems.length})
           </span>
+          {totalUpdates > 1 && (
+            <span className="text-muted-foreground/60 text-[10px] shrink-0 bg-muted/60 px-1.5 rounded">
+              {totalUpdates}x
+            </span>
+          )}
           {currentTask && (
             <>
               <span className="text-muted-foreground/40 shrink-0">·</span>
@@ -72,6 +118,7 @@ export function TodoMessage({
             </div>
           );
         })}
+        {snapshots.length > 0 && <SnapshotHistory snapshots={snapshots} />}
       </div>
     </ExpandableRow>
   );

--- a/apps/web/components/task/chat/messages/tool-execute-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.tsx
@@ -2,6 +2,7 @@
 
 import { memo } from "react";
 import { IconCheck, IconX, IconTerminal } from "@tabler/icons-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { GridSpinner } from "@/components/grid-spinner";
 import { transformPathsInText } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
@@ -51,16 +52,28 @@ function ExecuteStatusIcon({
 }
 
 type ExecuteOutputProps = {
+  displayCommand: string;
+  isCommandLong: boolean;
   displayWorkDir: string | null;
   workDir: string | undefined;
-  hasOutput: string | undefined | false;
   output: ShellExecOutput | undefined;
 };
 
-function ExecuteOutputContent({ displayWorkDir, workDir, hasOutput, output }: ExecuteOutputProps) {
+function ExecuteOutputContent({
+  displayCommand,
+  isCommandLong,
+  displayWorkDir,
+  workDir,
+  output,
+}: ExecuteOutputProps) {
   return (
     <div className="pl-4 border-l-2 border-border/30 space-y-2">
-      {displayWorkDir && !hasOutput && (
+      {isCommandLong && (
+        <pre className="text-xs bg-muted/30 rounded p-2 whitespace-pre-wrap break-all font-mono">
+          {displayCommand}
+        </pre>
+      )}
+      {displayWorkDir && (
         <div className="text-xs text-muted-foreground">
           <span className="opacity-60">cwd:</span>{" "}
           <span className="font-mono" title={workDir}>
@@ -82,50 +95,77 @@ function ExecuteOutputContent({ displayWorkDir, workDir, hasOutput, output }: Ex
   );
 }
 
+// Threshold beyond which the command is considered "long" and worth surfacing
+// in the expanded view (the header always truncates via CSS regardless).
+const LONG_COMMAND_THRESHOLD = 60;
+
+function isExecuteSuccess(
+  status: ToolExecuteMetadata["status"],
+  output: ShellExecOutput | undefined,
+): boolean {
+  if (status !== "complete") return false;
+  return output?.exit_code === 0 || output?.exit_code === undefined;
+}
+
 function parseExecuteMetadata(comment: Message) {
   const metadata = comment.metadata as ToolExecuteMetadata | undefined;
   const status = metadata?.status;
   const shellExec = metadata?.normalized?.shell_exec;
   const output = shellExec?.output;
   const workDir = shellExec?.work_dir;
-  const hasOutput = output?.stdout || output?.stderr;
-  const hasExpandableContent = hasOutput || workDir;
-  const isSuccess =
-    status === "complete" && (output?.exit_code === 0 || output?.exit_code === undefined);
-  return { status, output, workDir, hasOutput, hasExpandableContent, isSuccess };
+  const hasOutput = !!(output?.stdout || output?.stderr);
+  const isCommandLong = (comment.content?.length ?? 0) > LONG_COMMAND_THRESHOLD;
+  const hasExpandableContent = hasOutput || !!workDir || isCommandLong;
+  const isSuccess = isExecuteSuccess(status, output);
+  return { status, output, workDir, hasOutput, isCommandLong, hasExpandableContent, isSuccess };
 }
 
 export const ToolExecuteMessage = memo(function ToolExecuteMessage({
   comment,
   worktreePath,
 }: ToolExecuteMessageProps) {
-  const { status, output, workDir, hasOutput, hasExpandableContent, isSuccess } =
+  const { status, output, workDir, isCommandLong, hasExpandableContent, isSuccess } =
     parseExecuteMetadata(comment);
   const autoExpanded = status === "running";
   const { isExpanded, handleToggle } = useExpandState(status, autoExpanded);
+  const displayCommand = transformPathsInText(comment.content, worktreePath);
   const displayWorkDir = workDir ? transformPathsInText(workDir, worktreePath) : null;
 
   return (
     <ExpandableRow
       icon={<IconTerminal className="h-4 w-4 text-muted-foreground" />}
       header={
-        <div className="flex items-center gap-2 text-xs">
-          <span className="inline-flex items-center gap-1.5">
-            <span className="font-mono text-xs text-muted-foreground">
-              {transformPathsInText(comment.content, worktreePath)}
+        <div className="flex items-center gap-2 text-xs min-w-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="font-mono text-xs text-muted-foreground truncate min-w-0 flex-1">
+                {displayCommand}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent
+              side="bottom"
+              align="start"
+              className="max-w-[min(90vw,640px)] whitespace-pre-wrap break-all font-mono text-xs"
+            >
+              {displayCommand}
+            </TooltipContent>
+          </Tooltip>
+          {!isSuccess && (
+            <span className="shrink-0">
+              <ExecuteStatusIcon status={status} exitCode={output?.exit_code} />
             </span>
-            {!isSuccess && <ExecuteStatusIcon status={status} exitCode={output?.exit_code} />}
-          </span>
+          )}
         </div>
       }
-      hasExpandableContent={!!hasExpandableContent}
+      hasExpandableContent={hasExpandableContent}
       isExpanded={isExpanded}
       onToggle={handleToggle}
     >
       <ExecuteOutputContent
+        displayCommand={displayCommand}
+        isCommandLong={isCommandLong}
         displayWorkDir={displayWorkDir}
         workDir={workDir}
-        hasOutput={hasOutput}
         output={output}
       />
     </ExpandableRow>

--- a/apps/web/components/task/chat/messages/tool-execute-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.tsx
@@ -114,42 +114,59 @@ function parseExecuteMetadata(comment: Message) {
   const output = shellExec?.output;
   const workDir = shellExec?.work_dir;
   const hasOutput = !!(output?.stdout || output?.stderr);
-  const isCommandLong = (comment.content?.length ?? 0) > LONG_COMMAND_THRESHOLD;
-  const hasExpandableContent = hasOutput || !!workDir || isCommandLong;
   const isSuccess = isExecuteSuccess(status, output);
-  return { status, output, workDir, hasOutput, isCommandLong, hasExpandableContent, isSuccess };
+  return { status, output, workDir, hasOutput, isSuccess };
+}
+
+function CommandHeader({
+  displayCommand,
+  isCommandLong,
+}: {
+  displayCommand: string;
+  isCommandLong: boolean;
+}) {
+  const className = "font-mono text-xs text-muted-foreground truncate min-w-0 flex-1 text-left";
+  if (!isCommandLong) {
+    return <span className={className}>{displayCommand}</span>;
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" className={`${className} cursor-pointer bg-transparent border-0 p-0`}>
+          {displayCommand}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        className="max-w-[min(90vw,640px)] whitespace-pre-wrap break-all font-mono text-xs"
+      >
+        {displayCommand}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 export const ToolExecuteMessage = memo(function ToolExecuteMessage({
   comment,
   worktreePath,
 }: ToolExecuteMessageProps) {
-  const { status, output, workDir, isCommandLong, hasExpandableContent, isSuccess } =
-    parseExecuteMetadata(comment);
+  const { status, output, workDir, hasOutput, isSuccess } = parseExecuteMetadata(comment);
   const autoExpanded = status === "running";
   const { isExpanded, handleToggle } = useExpandState(status, autoExpanded);
   const displayCommand = transformPathsInText(comment.content, worktreePath);
   const displayWorkDir = workDir ? transformPathsInText(workDir, worktreePath) : null;
+  // Measure after path transform so a long absolute path that gets shortened
+  // to a relative one is correctly treated as short.
+  const isCommandLong = displayCommand.length > LONG_COMMAND_THRESHOLD;
+  const hasExpandableContent = hasOutput || !!workDir || isCommandLong;
 
   return (
     <ExpandableRow
       icon={<IconTerminal className="h-4 w-4 text-muted-foreground" />}
       header={
         <div className="flex items-center gap-2 text-xs min-w-0">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="font-mono text-xs text-muted-foreground truncate min-w-0 flex-1">
-                {displayCommand}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent
-              side="bottom"
-              align="start"
-              className="max-w-[min(90vw,640px)] whitespace-pre-wrap break-all font-mono text-xs"
-            >
-              {displayCommand}
-            </TooltipContent>
-          </Tooltip>
+          <CommandHeader displayCommand={displayCommand} isCommandLong={isCommandLong} />
           {!isSuccess && (
             <span className="shrink-0">
               <ExecuteStatusIcon status={status} exitCode={output?.exit_code} />

--- a/apps/web/components/task/chat/types.ts
+++ b/apps/web/components/task/chat/types.ts
@@ -161,6 +161,11 @@ export type MessageAction = {
 
 export type TodoMetadata = { text: string; done?: boolean } | string;
 
+export type TodoSnapshot = {
+  todos: TodoMetadata[];
+  created_at: string;
+};
+
 export type ContentBlock = {
   type: string; // "text", "image", "audio", "resource_link", "resource"
   text?: string;
@@ -176,6 +181,7 @@ export type ContentBlock = {
 export type RichMetadata = {
   thinking?: string;
   todos?: TodoMetadata[];
+  previous_todo_snapshots?: TodoSnapshot[];
   diff?: unknown;
   content_blocks?: ContentBlock[];
 };

--- a/apps/web/components/task/session-dialog-shared.tsx
+++ b/apps/web/components/task/session-dialog-shared.tsx
@@ -12,7 +12,7 @@ import {
   SelectValue,
 } from "@kandev/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
-import { IconGitBranch, IconUpload } from "@tabler/icons-react";
+import { IconGitBranch, IconPaperclip } from "@tabler/icons-react";
 import { AgentLogo } from "@/components/agent-logo";
 import {
   processFile,
@@ -251,7 +251,7 @@ export function AttachButton({ onClick, disabled }: { onClick: () => void; disab
             onClick={onClick}
             disabled={disabled}
           >
-            <IconUpload className="h-4 w-4" />
+            <IconPaperclip className="h-4 w-4" />
           </button>
         </TooltipTrigger>
         <TooltipContent>Attach files</TooltipContent>

--- a/apps/web/components/task/simple/OfficeSimplePane.tsx
+++ b/apps/web/components/task/simple/OfficeSimplePane.tsx
@@ -9,7 +9,7 @@ import {
   IconPlus,
   IconRestore,
   IconTrash,
-  IconUpload,
+  IconPaperclip,
 } from "@tabler/icons-react";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
@@ -355,7 +355,7 @@ function TaskActionRow({
           className="cursor-pointer"
           onClick={() => attachInputRef.current?.click()}
         >
-          <IconUpload className="h-3.5 w-3.5 mr-1" /> Upload attachment
+          <IconPaperclip className="h-3.5 w-3.5 mr-1" /> Attach files
         </Button>
         <input
           ref={attachInputRef}

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { toast } from "sonner";
-import { IconCode, IconChevronDown, IconSend, IconUpload, IconUser } from "@tabler/icons-react";
+import { IconCode, IconChevronDown, IconSend, IconPaperclip, IconUser } from "@tabler/icons-react";
 import { AgentAvatar } from "@/app/office/components/agent-avatar";
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
@@ -345,7 +345,7 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
                 className="h-7 w-7 cursor-pointer"
                 onClick={() => fileInputRef.current?.click()}
               >
-                <IconUpload className="h-3.5 w-3.5" />
+                <IconPaperclip className="h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>Attach file</TooltipContent>

--- a/apps/web/components/task/simple/task-chat.tsx
+++ b/apps/web/components/task/simple/task-chat.tsx
@@ -348,7 +348,7 @@ function ChatInput({ taskId, taskTitle, taskDescription, onSubmitted }: ChatInpu
                 <IconPaperclip className="h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Attach file</TooltipContent>
+            <TooltipContent>Attach files</TooltipContent>
           </Tooltip>
           <EnhancePromptButton
             onClick={handleEnhance}

--- a/apps/web/hooks/use-processed-messages.test.ts
+++ b/apps/web/hooks/use-processed-messages.test.ts
@@ -5,7 +5,12 @@ import {
   type Message,
   type MessageType,
 } from "@/lib/types/http";
-import { deduplicateAgentBootResumes, isAgentBootResumeMessage } from "./use-processed-messages";
+import type { RichMetadata } from "@/components/task/chat/types";
+import {
+  collapseTodoSnapshotsPerTurn,
+  deduplicateAgentBootResumes,
+  isAgentBootResumeMessage,
+} from "./use-processed-messages";
 
 function makeMessage(
   id: string,
@@ -23,6 +28,14 @@ function makeMessage(
     metadata,
     created_at: "",
   };
+}
+
+function makeTodo(
+  id: string,
+  turnId: string | undefined,
+  todos: Array<{ text: string; done?: boolean }>,
+): Message {
+  return { ...makeMessage(id, "todo", { todos }), turn_id: turnId };
 }
 
 function bootStarted(id: string): Message {
@@ -117,5 +130,74 @@ describe("deduplicateAgentBootResumes", () => {
     const messages = [setup, bootResumed("r1"), bootResumed("r2")];
     const result = deduplicateAgentBootResumes(messages);
     expect(result.map((m) => m.id)).toEqual(["x", "r2"]);
+  });
+});
+
+describe("collapseTodoSnapshotsPerTurn", () => {
+  it("returns the list unchanged when there are no todo messages", () => {
+    const messages = [makeMessage("m1", "message", undefined, "hi")];
+    expect(collapseTodoSnapshotsPerTurn(messages)).toEqual(messages);
+  });
+
+  it("returns a single todo message unchanged", () => {
+    const todo = makeTodo("t1", "turn-1", [{ text: "step 1" }]);
+    const result = collapseTodoSnapshotsPerTurn([todo]);
+    expect(result).toEqual([todo]);
+    expect((result[0].metadata as RichMetadata).previous_todo_snapshots).toBeUndefined();
+  });
+
+  it("keeps only the latest todo per turn and attaches prior snapshots", () => {
+    const userMsg = makeMessage("u1", "message", undefined, "go");
+    const t1 = makeTodo("t1", "turn-1", [{ text: "a" }]);
+    const t2 = makeTodo("t2", "turn-1", [{ text: "a", done: true }, { text: "b" }]);
+    const t3 = makeTodo("t3", "turn-1", [
+      { text: "a", done: true },
+      { text: "b", done: true },
+      { text: "c" },
+    ]);
+    const result = collapseTodoSnapshotsPerTurn([userMsg, t1, t2, t3]);
+
+    expect(result.map((m) => m.id)).toEqual(["u1", "t3"]);
+    const meta = result[1].metadata as RichMetadata;
+    expect(meta.previous_todo_snapshots).toHaveLength(2);
+    expect(meta.previous_todo_snapshots?.[0].todos).toEqual([{ text: "a" }]);
+    expect(meta.previous_todo_snapshots?.[1].todos).toEqual([
+      { text: "a", done: true },
+      { text: "b" },
+    ]);
+    // Latest todos remain reachable on the kept message.
+    expect(meta.todos).toEqual([
+      { text: "a", done: true },
+      { text: "b", done: true },
+      { text: "c" },
+    ]);
+  });
+
+  it("collapses todos independently per turn", () => {
+    const a1 = makeTodo("a1", "turn-A", [{ text: "x" }]);
+    const a2 = makeTodo("a2", "turn-A", [{ text: "x", done: true }]);
+    const b1 = makeTodo("b1", "turn-B", [{ text: "y" }]);
+    const result = collapseTodoSnapshotsPerTurn([a1, a2, b1]);
+
+    expect(result.map((m) => m.id)).toEqual(["a2", "b1"]);
+    expect((result[0].metadata as RichMetadata).previous_todo_snapshots).toHaveLength(1);
+    expect((result[1].metadata as RichMetadata).previous_todo_snapshots).toBeUndefined();
+  });
+
+  it("preserves todo messages without a turn_id", () => {
+    const orphan = makeTodo("o1", undefined, [{ text: "orphan" }]);
+    const t1 = makeTodo("t1", "turn-1", [{ text: "a" }]);
+    const t2 = makeTodo("t2", "turn-1", [{ text: "a", done: true }]);
+    const result = collapseTodoSnapshotsPerTurn([orphan, t1, t2]);
+
+    expect(result.map((m) => m.id)).toEqual(["o1", "t2"]);
+  });
+
+  it("does not mutate input messages", () => {
+    const t1 = makeTodo("t1", "turn-1", [{ text: "a" }]);
+    const t2 = makeTodo("t2", "turn-1", [{ text: "a", done: true }]);
+    collapseTodoSnapshotsPerTurn([t1, t2]);
+    expect(t1.metadata).toEqual({ todos: [{ text: "a" }] });
+    expect(t2.metadata).toEqual({ todos: [{ text: "a", done: true }] });
   });
 });

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -210,9 +210,8 @@ function collectPriorSnapshotsByLatestId(
       todos: (message.metadata as RichMetadata | undefined)?.todos ?? [],
       created_at: message.created_at,
     };
-    const list = previousByLatestId.get(latestId) ?? [];
-    list.push(snapshot);
-    previousByLatestId.set(latestId, list);
+    if (!previousByLatestId.has(latestId)) previousByLatestId.set(latestId, []);
+    previousByLatestId.get(latestId)!.push(snapshot);
   }
   return previousByLatestId;
 }

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -6,7 +6,7 @@ import {
   type Message,
   type MessageType,
 } from "@/lib/types/http";
-import type { ToolCallMetadata } from "@/components/task/chat/types";
+import type { RichMetadata, ToolCallMetadata, TodoSnapshot } from "@/components/task/chat/types";
 import {
   findPendingClarification,
   findPendingClarificationGroup,
@@ -182,7 +182,60 @@ function filterVisibleMessages(
     return false;
   });
 
-  return deduplicateAgentBootResumes(deduplicateRecoveryMessages(filtered));
+  return collapseTodoSnapshotsPerTurn(
+    deduplicateAgentBootResumes(deduplicateRecoveryMessages(filtered)),
+  );
+}
+
+function findLatestTodoIdsByTurn(messages: Message[]): Map<string, string> {
+  const latest = new Map<string, string>();
+  for (const message of messages) {
+    if (message.type === "todo" && message.turn_id) {
+      latest.set(message.turn_id, message.id);
+    }
+  }
+  return latest;
+}
+
+function collectPriorSnapshotsByLatestId(
+  messages: Message[],
+  latestTodoIdByTurn: Map<string, string>,
+): Map<string, TodoSnapshot[]> {
+  const previousByLatestId = new Map<string, TodoSnapshot[]>();
+  for (const message of messages) {
+    if (message.type !== "todo" || !message.turn_id) continue;
+    const latestId = latestTodoIdByTurn.get(message.turn_id);
+    if (!latestId || latestId === message.id) continue;
+    const snapshot: TodoSnapshot = {
+      todos: (message.metadata as RichMetadata | undefined)?.todos ?? [],
+      created_at: message.created_at,
+    };
+    const list = previousByLatestId.get(latestId) ?? [];
+    list.push(snapshot);
+    previousByLatestId.set(latestId, list);
+  }
+  return previousByLatestId;
+}
+
+/** Some agents (Claude Opus/Sonnet) emit a fresh `todo` message every time
+ *  they update their plan, producing a long stack of "Updated Todos" rows in
+ *  the chat. Each todo message is a full snapshot of the list, so all but the
+ *  latest in a turn are strictly stale. Collapse them: keep only the latest
+ *  per `turn_id` and attach the earlier snapshots to its metadata as
+ *  `previous_todo_snapshots` so the UI can show the progression on expand. */
+export function collapseTodoSnapshotsPerTurn(messages: Message[]): Message[] {
+  const latestTodoIdByTurn = findLatestTodoIdsByTurn(messages);
+  if (latestTodoIdByTurn.size === 0) return messages;
+
+  const previousByLatestId = collectPriorSnapshotsByLatestId(messages, latestTodoIdByTurn);
+
+  return messages.flatMap((message) => {
+    if (message.type !== "todo" || !message.turn_id) return [message];
+    if (latestTodoIdByTurn.get(message.turn_id) !== message.id) return [];
+    const previous = previousByLatestId.get(message.id);
+    if (!previous || previous.length === 0) return [message];
+    return [{ ...message, metadata: { ...message.metadata, previous_todo_snapshots: previous } }];
+  });
 }
 
 function groupActivityMessages(allMessages: Message[]): RenderItem[] {


### PR DESCRIPTION
Verbose agents (Claude Opus/Sonnet, gh-heavy poller scripts) made chat hard to read: repeated TodoWrite snapshots stacked as 14+ standalone rows, long shell commands wrapped across three lines, every inline code chip wore the accent color, and the attach button shipped an upload-arrow that didn't read as "attach files." This PR collapses snapshots per turn, truncates long commands behind a tooltip, restyles inline code so links stand apart from plain chips, and swaps in a paperclip on the five attach entry points.

## Important Changes

- `collapseTodoSnapshotsPerTurn` runs in `filterVisibleMessages`: keeps only the latest todo per `turn_id` and attaches prior snapshots to its metadata as `previous_todo_snapshots` (full snapshots are strictly stale, so no signal lost).
- `TodoMessage` shows an `Nx` pill in the header when multiple updates collapsed, with an "Earlier updates" history block on expand.
- `ToolExecuteMessage` truncates the header command via CSS, wraps it in a Radix tooltip (full command wrapped, monospace), and surfaces the full command in the expanded view; the row stays expandable for commands > 60 chars even before output arrives.
- `.markdown-body` inline code now renders neutral on muted bg; `a > code` drops the fill, inherits link color, and gains the muted bg on hover. The `.markdown-body-user` override still wins for user bubbles.

## Validation

- `pnpm --filter @kandev/web typecheck` clean
- `pnpm --filter @kandev/web lint` clean (max-warnings 0)
- `pnpm --filter @kandev/web test` — 1861 passed, 4 skipped, including 6 new tests for `collapseTodoSnapshotsPerTurn` (empty, single, multi-per-turn, multi-turn isolation, no `turn_id` passthrough, no input mutation)
- `make -C apps/backend test lint` clean
- Manual: visually inspected the affected chat surfaces in a running dev instance

## Possible Improvements

Low risk; all changes are render-layer. The todo collapser keys on `turn_id` only, so todo messages without a turn (legacy or unusual agents) still render individually as before. Tool-execute's 60-char heuristic for "long command" could miss commands that are visually long due to wide glyphs, but the tooltip + CSS truncate degrade gracefully.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.