### PR TITLE
fix(backend): persist kandev-system wrap on first task prompt

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -16,7 +16,6 @@ import (
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/common/appctx"
 	"github.com/kandev/kandev/internal/common/logger"
-	"github.com/kandev/kandev/internal/sysprompt"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -189,12 +188,6 @@ func (sm *SessionManager) getResumeContextPrompt(agentConfig agents.Agent, taskS
 	}
 
 	return resumePrompt
-}
-
-// injectKandevContext prepends the Kandev system prompt and session context to the user's prompt.
-// This provides consistent guidance to the agent about using Kandev tools and the current session IDs.
-func (sm *SessionManager) injectKandevContext(taskID, sessionID, prompt string) string {
-	return sysprompt.InjectKandevContext(taskID, sessionID, prompt)
 }
 
 // loadSession loads an existing session via ACP session/load
@@ -398,8 +391,9 @@ func convertAttachments(attachments []MessageAttachment) []v1.MessageAttachment 
 func (sm *SessionManager) dispatchInitialPrompt(ctx context.Context, execution *AgentExecution, agentConfig agents.Agent, taskDescription string, attachments []MessageAttachment, markReady func(executionID string) error) {
 	switch {
 	case taskDescription != "" || len(attachments) > 0:
-		promptWithContext := sm.injectKandevContext(execution.TaskID, execution.SessionID, taskDescription)
-		effectivePrompt := sm.getResumeContextPrompt(agentConfig, execution.SessionID, promptWithContext)
+		// The orchestrator wrapped the prompt with the Kandev system block
+		// before handing it to the runtime; do not re-wrap here.
+		effectivePrompt := sm.getResumeContextPrompt(agentConfig, execution.SessionID, taskDescription)
 		if effectivePrompt != taskDescription {
 			sm.logger.Info("injecting resume context into initial prompt",
 				zap.String("execution_id", execution.ID),
@@ -440,21 +434,22 @@ func (sm *SessionManager) dispatchInitialPrompt(ctx context.Context, execution *
 }
 
 // buildEffectivePrompt applies resume context injection if needed, returning the effective prompt to send.
+// The Kandev MCP system block is intentionally NOT re-injected here — it is
+// only attached to the very first prompt of a task at the orchestrator layer.
+// On resume, the agent CLI's restored conversation already contains it.
 func (sm *SessionManager) buildEffectivePrompt(execution *AgentExecution, prompt string) string {
 	if !execution.needsResumeContext || execution.resumeContextInjected {
 		return prompt
 	}
-	// Inject Kandev context for resumed sessions (first prompt in this execution)
-	promptWithContext := sm.injectKandevContext(execution.TaskID, execution.SessionID, prompt)
-	effectivePrompt := promptWithContext
+	effectivePrompt := prompt
 	if sm.historyManager != nil {
-		resumePrompt, err := sm.historyManager.GenerateResumeContext(execution.SessionID, promptWithContext)
+		resumePrompt, err := sm.historyManager.GenerateResumeContext(execution.SessionID, prompt)
 		switch {
 		case err != nil:
 			sm.logger.Warn("failed to generate resume context for follow-up prompt",
 				zap.String("execution_id", execution.ID),
 				zap.Error(err))
-		case resumePrompt != promptWithContext:
+		case resumePrompt != prompt:
 			effectivePrompt = resumePrompt
 			sm.logger.Info("injecting resume context into follow-up prompt",
 				zap.String("execution_id", execution.ID),

--- a/apps/backend/internal/agent/runtime/lifecycle/session_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session_test.go
@@ -695,3 +695,33 @@ func TestSendPrompt_DrainsStaleSignalFromPriorDispatchOnly(t *testing.T) {
 		t.Fatalf("expected deadline exceeded error, got: %v", err)
 	}
 }
+
+// TestBuildEffectivePrompt_DoesNotInjectKandevContextOnResume verifies the
+// lifecycle layer no longer wraps follow-up prompts with the Kandev system
+// block. The orchestrator wraps the first prompt only; on resume the agent
+// CLI's restored conversation already contains it.
+func TestBuildEffectivePrompt_DoesNotInjectKandevContextOnResume(t *testing.T) {
+	log := newSessionTestLogger()
+	sm := NewSessionManager(log, make(chan struct{}))
+
+	execution := &AgentExecution{
+		ID:                 "test-exec",
+		TaskID:             "test-task",
+		SessionID:          "test-session",
+		needsResumeContext: true,
+	}
+
+	got := sm.buildEffectivePrompt(execution, "follow-up message")
+	if strings.Contains(got, "<kandev-system>") {
+		t.Fatalf("expected no <kandev-system> wrap on resumed prompt, got %q", got)
+	}
+	if !execution.resumeContextInjected {
+		t.Fatal("expected resumeContextInjected to be set after first call")
+	}
+
+	// Second call must be a no-op pass-through.
+	got2 := sm.buildEffectivePrompt(execution, "another message")
+	if got2 != "another message" {
+		t.Fatalf("expected pass-through on second call, got %q", got2)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1094,8 +1094,10 @@ func (s *Service) autoStartStepPrompt(
 	// before persisting (and before passing downstream) so the DB row matches
 	// what the agent receives. StartCreatedSession's wrap is idempotent
 	// (HasKandevContext guard) so the pre-wrap doesn't double.
+	// The HasKandevContext check on `prompt` also guards against any future
+	// caller that ever pre-wraps before reaching here (none today).
 	recordedPrompt := prompt
-	if session.State == models.TaskSessionStateCreated && (prompt != "" || len(attachments) > 0) {
+	if session.State == models.TaskSessionStateCreated && (prompt != "" || len(attachments) > 0) && !sysprompt.HasKandevContext(prompt) {
 		recordedPrompt = sysprompt.InjectKandevContext(taskID, sessionID, prompt)
 	}
 	s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/workflow/engine"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
@@ -1087,8 +1088,17 @@ func (s *Service) autoStartStepPrompt(
 		}
 	}
 
-	// Record a user message so the auto-start prompt is visible in chat history.
-	s.recordAutoStartMessage(ctx, taskID, sessionID, prompt, planMode)
+	// Record a user message so the auto-start prompt is visible in chat
+	// history. For CREATED sessions the agent has not started yet, so this is
+	// the first prompt of the task — wrap with the Kandev MCP system block
+	// before persisting (and before passing downstream) so the DB row matches
+	// what the agent receives. StartCreatedSession's wrap is idempotent
+	// (HasKandevContext guard) so the pre-wrap doesn't double.
+	recordedPrompt := prompt
+	if session.State == models.TaskSessionStateCreated && (prompt != "" || len(attachments) > 0) {
+		recordedPrompt = sysprompt.InjectKandevContext(taskID, sessionID, prompt)
+	}
+	s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode)
 
 	// If the session is in CREATED state, the agent was never started (e.g. workspace-only
 	// preparation from a blocked auto-start). PromptTask will reject CREATED sessions,
@@ -1099,7 +1109,7 @@ func (s *Service) autoStartStepPrompt(
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.String("step_name", stepName))
-		_, err := s.StartCreatedSession(ctx, taskID, sessionID, session.AgentProfileID, prompt, true, planMode, attachments)
+		_, err := s.StartCreatedSession(ctx, taskID, sessionID, session.AgentProfileID, recordedPrompt, true, planMode, attachments)
 		if err != nil {
 			requeueTaken()
 		}

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -366,7 +366,7 @@ func (e *Executor) LaunchPreparedSession(ctx context.Context, task *v1.Task, ses
 	startAgent := opts.StartAgent
 	// Serialise concurrent launches for the same session. Two callers reach
 	// this path on every task: PrepareTaskSession spawns a background launch
-	// (workspace only) the moment a session is created, and StartTaskWithSession
+	// (workspace only) the moment a session is created, and StartCreatedSession
 	// is called when the agent is actually started (auto-start, user click).
 	// Without this lock both run env-prep + executionStore.Add in parallel and
 	// the second one fails at register with "already has an agent running

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -1148,7 +1148,7 @@ func TestPersistResumeState_SetsStartingState(t *testing.T) {
 }
 
 // Regression: PrepareTaskSession launches the workspace in a background
-// goroutine while StartTaskWithSession runs a foreground launch when the
+// goroutine while StartCreatedSession runs a foreground launch when the
 // agent is started. Both call LaunchPreparedSession on the same session.
 // Without per-session serialisation the two launches both reach
 // agentManager.LaunchAgent and the second one errors with

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -90,7 +90,7 @@ func (s *Service) EnqueueTask(ctx context.Context, task *v1.Task) error {
 
 // PrepareTaskSession creates a session entry without launching the agent.
 // This allows the WS handler to return the session ID immediately while workspace setup
-// continues in the background. Use StartTaskWithSession to continue with agent launch.
+// continues in the background. Use StartCreatedSession to continue with agent launch.
 // When launchWorkspace is true, workspace infrastructure (agentctl) is launched asynchronously;
 // the frontend receives preparation progress via executor.prepare.progress WS events.
 func (s *Service) PrepareTaskSession(ctx context.Context, taskID string, agentProfileID string, executorID string, executorProfileID string, workflowStepID string, launchWorkspace bool) (string, error) {
@@ -209,81 +209,6 @@ func (s *Service) PrepareTaskSession(ctx context.Context, taskID string, agentPr
 		zap.String("session_id", sessionID))
 
 	return sessionID, nil
-}
-
-// StartTaskWithSession starts agent execution for a task using a pre-created session.
-// This is used after PrepareTaskSession to continue with the agent launch.
-// If planMode is true and the workflow step doesn't already apply plan mode,
-// default plan mode instructions are injected into the prompt.
-func (s *Service) StartTaskWithSession(ctx context.Context, taskID string, sessionID string, agentProfileID string, executorID string, executorProfileID string, priority string, prompt string, workflowStepID string, planMode bool) (*executor.TaskExecution, error) {
-	s.logger.Debug("starting task with existing session",
-		zap.String("task_id", taskID),
-		zap.String("session_id", sessionID),
-		zap.String("agent_profile_id", agentProfileID),
-		zap.Bool("plan_mode", planMode))
-
-	// Process on_turn_start before launching the agent.
-	// If the target step has a different agent profile, executeStepTransition will switch
-	// the session — so we need to pick up the new session afterwards.
-	if session, err := s.repo.GetTaskSession(ctx, sessionID); err == nil {
-		s.processOnTurnStartViaEngine(ctx, taskID, session)
-	}
-
-	// Re-read the session — on_turn_start may have switched it (agent profile change).
-	reloadedSession, reloadErr := s.repo.GetTaskSession(ctx, sessionID)
-	if reloadErr != nil {
-		return nil, fmt.Errorf("failed to reload session after on_turn_start: %w", reloadErr)
-	}
-	if reloadedSession.State == models.TaskSessionStateCompleted {
-		activeSession, activeErr := s.repo.GetActiveTaskSessionByTaskID(ctx, taskID)
-		if activeErr != nil || activeSession == nil {
-			return nil, fmt.Errorf("session was switched during on_turn_start but no active session found: %w", activeErr)
-		}
-		sessionID = activeSession.ID
-		agentProfileID = activeSession.AgentProfileID
-		executorID = activeSession.ExecutorID
-	}
-
-	if err := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateScheduling); err != nil {
-		s.logger.Warn("failed to update task state to SCHEDULING",
-			zap.String("task_id", taskID),
-			zap.Error(err))
-	}
-
-	task, err := s.scheduler.GetTask(ctx, taskID)
-	if err != nil {
-		return nil, err
-	}
-
-	if priority != "" {
-		task.Priority = priority
-	}
-
-	effectivePrompt := prompt
-	if effectivePrompt == "" {
-		effectivePrompt = task.Description
-	}
-
-	effectivePrompt, planModeActive := s.applyWorkflowAndPlanMode(ctx, effectivePrompt, task.ID, sessionID, workflowStepID, planMode, task.IsEphemeral)
-
-	execution, err := s.executor.LaunchPreparedSession(ctx, task, sessionID, executor.LaunchOptions{AgentProfileID: agentProfileID, ExecutorID: executorID, Prompt: effectivePrompt, WorkflowStepID: workflowStepID, StartAgent: true})
-	if err != nil {
-		return nil, err
-	}
-
-	if execution.SessionID != "" {
-		s.recordInitialMessage(ctx, taskID, execution.SessionID, effectivePrompt, planModeActive, nil)
-
-		if planModeActive {
-			sess, sessErr := s.repo.GetTaskSession(ctx, execution.SessionID)
-			if sessErr == nil {
-				s.setSessionPlanMode(ctx, sess, true)
-			}
-		}
-	}
-	go s.ensureSessionPRWatch(context.Background(), taskID, execution.SessionID, execution.WorktreeBranch)
-
-	return execution, nil
 }
 
 // StartCreatedSession starts agent execution for a task using a session that is in CREATED state.
@@ -417,8 +342,10 @@ func (s *Service) StartCreatedSession(ctx context.Context, taskID, sessionID, ag
 
 	// Wrap the first prompt with the Kandev MCP system block. See the
 	// matching block in startTask for the rationale (DB stores wrapped form;
-	// Message.ToAPI strips for display).
-	if effectivePrompt != "" || len(attachments) > 0 {
+	// Message.ToAPI strips for display). Idempotent — upstream call sites that
+	// record the user message themselves (wsAddMessage on CREATED sessions)
+	// wrap first, and the HasKandevContext guard prevents a second wrap here.
+	if (effectivePrompt != "" || len(attachments) > 0) && !sysprompt.HasKandevContext(effectivePrompt) {
 		effectivePrompt = sysprompt.InjectKandevContext(taskID, sessionID, effectivePrompt)
 	}
 
@@ -603,7 +530,11 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	// <kandev-system> block for the UI bubble and exposes it via raw_content.
 	// Only the first launch carries this wrap — follow-up prompts and resumes
 	// rely on the agent CLI's conversation history retaining it.
-	if effectivePrompt != "" || len(attachments) > 0 {
+	// Idempotent: upstream call sites (wsAddMessage on CREATED sessions,
+	// recordAutoStartMessage) wrap before recording the user message so the DB
+	// row carries the block; the HasKandevContext guard makes this orchestrator
+	// pass a no-op in those cases instead of double-wrapping.
+	if (effectivePrompt != "" || len(attachments) > 0) && !sysprompt.HasKandevContext(effectivePrompt) {
 		effectivePrompt = sysprompt.InjectKandevContext(task.ID, sessionID, effectivePrompt)
 	}
 

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -415,6 +415,13 @@ func (s *Service) StartCreatedSession(ctx context.Context, taskID, sessionID, ag
 		effectivePrompt = sysprompt.InjectConfigContext(sessionID, effectivePrompt)
 	}
 
+	// Wrap the first prompt with the Kandev MCP system block. See the
+	// matching block in startTask for the rationale (DB stores wrapped form;
+	// Message.ToAPI strips for display).
+	if effectivePrompt != "" || len(attachments) > 0 {
+		effectivePrompt = sysprompt.InjectKandevContext(taskID, sessionID, effectivePrompt)
+	}
+
 	executorID := session.ExecutorID
 
 	execution, err := s.executor.LaunchPreparedSession(ctx, task, sessionID, executor.LaunchOptions{AgentProfileID: effectiveProfileID, ExecutorID: executorID, Prompt: effectivePrompt, StartAgent: true, Attachments: attachments})
@@ -588,6 +595,16 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	if cm, ok := task.Metadata["config_mode"].(bool); ok && cm {
 		configMode = true
 		effectivePrompt = sysprompt.InjectConfigContext(sessionID, effectivePrompt)
+	}
+
+	// Wrap the first prompt with the Kandev MCP system block (task/session IDs +
+	// tool list). Done at the orchestrator layer so recordInitialMessage persists
+	// the wrapped form to task_session_messages; Message.ToAPI strips the
+	// <kandev-system> block for the UI bubble and exposes it via raw_content.
+	// Only the first launch carries this wrap — follow-up prompts and resumes
+	// rely on the agent CLI's conversation history retaining it.
+	if effectivePrompt != "" || len(attachments) > 0 {
+		effectivePrompt = sysprompt.InjectKandevContext(task.ID, sessionID, effectivePrompt)
 	}
 
 	// Office tasks restrict the MCP toolset: kanban tools (move/update/list

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -578,6 +578,101 @@ func TestPostLaunchCreated_PlanMode_SetsMetadata(t *testing.T) {
 	}
 }
 
+// --- StartCreatedSession: Kandev system prompt wrap on first launch ---
+
+// TestStartCreatedSession_WrapsFirstPromptWithKandevSystemBlock verifies that
+// the recorded user message persists the <kandev-system> wrap that the
+// orchestrator now injects in startTask / StartCreatedSession. The wrap must
+// be in the raw row so the chat UI can show it under "Show formatted" and the
+// agent CLI's first ACP prompt includes the MCP tools list and task/session
+// IDs. Regression guard for the case the user reported: "tasks I create from
+// the kanban mode don't have the kandev system prompt."
+func TestStartCreatedSession_WrapsFirstPromptWithKandevSystemBlock(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCreated)
+	// Seed executors_running so LaunchPreparedSession takes the fast path
+	// (startAgentOnExistingWorkspace) and never reaches the real LaunchAgent.
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{
+		ID:          "task1",
+		Title:       "Test Task",
+		Description: "Original task description",
+		State:       v1.TaskStateInProgress,
+	}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+	mc := &mockMessageCreator{}
+	svc.messageCreator = mc
+
+	_, err := svc.StartCreatedSession(ctx, "task1", "session1", "profile1", "Build me a feature", false, false, nil)
+	if err != nil {
+		t.Fatalf("StartCreatedSession failed: %v", err)
+	}
+
+	if len(mc.userMessages) != 1 {
+		t.Fatalf("expected 1 user message recorded, got %d", len(mc.userMessages))
+	}
+	content := mc.userMessages[0].content
+
+	// The wrap is the outermost layer; the user's typed text must still be inside it.
+	if !strings.Contains(content, "<kandev-system>") {
+		t.Errorf("expected <kandev-system> opening tag in recorded content, got %q", content)
+	}
+	if !strings.Contains(content, "</kandev-system>") {
+		t.Errorf("expected </kandev-system> closing tag in recorded content, got %q", content)
+	}
+	if !strings.Contains(content, "Build me a feature") {
+		t.Errorf("expected user text preserved in recorded content, got %q", content)
+	}
+	// The wrap must carry the task and session IDs so the agent can call the
+	// kandev MCP tools without re-discovering its own identifiers.
+	if !strings.Contains(content, "Kandev Task ID: task1") {
+		t.Errorf("expected Kandev Task ID in wrap, got %q", content)
+	}
+	if !strings.Contains(content, "Kandev Session ID: session1") {
+		t.Errorf("expected Kandev Session ID in wrap, got %q", content)
+	}
+	// The MCP tool list is the whole point of the wrap — guard a representative one.
+	if !strings.Contains(content, "ask_user_question_kandev") {
+		t.Errorf("expected ask_user_question_kandev tool in wrap, got %q", content)
+	}
+}
+
+// TestStartCreatedSession_EmptyPromptSkipsWrap verifies the orchestrator does
+// not synthesize a <kandev-system>-only message when the user has nothing to
+// say yet. recordInitialMessage already skips empty prompts, but wrapping
+// "" would defeat that guard and pollute the chat with a tag-only row.
+func TestStartCreatedSession_EmptyPromptSkipsWrap(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCreated)
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+
+	taskRepo := newMockTaskRepo()
+	// No description on the task and no prompt from the caller — startTask's
+	// `effectivePrompt == ""` branch must short-circuit before InjectKandevContext.
+	taskRepo.tasks["task1"] = &v1.Task{ID: "task1", Title: "Empty", State: v1.TaskStateInProgress}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+	mc := &mockMessageCreator{}
+	svc.messageCreator = mc
+
+	_, err := svc.StartCreatedSession(ctx, "task1", "session1", "profile1", "", false, false, nil)
+	if err != nil {
+		t.Fatalf("StartCreatedSession failed: %v", err)
+	}
+
+	// No user message should be recorded — wrapping an empty prompt would
+	// produce a tag-only row.
+	if len(mc.userMessages) != 0 {
+		t.Fatalf("expected 0 user messages for empty prompt, got %d (content=%q)",
+			len(mc.userMessages), mc.userMessages[0].content)
+	}
+}
+
 // --- ResumeTaskSession ---
 
 func TestResumeTaskSession_WrongTask(t *testing.T) {

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/queue"
 	"github.com/kandev/kandev/internal/orchestrator/scheduler"
+	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/models"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
@@ -638,6 +639,58 @@ func TestStartCreatedSession_WrapsFirstPromptWithKandevSystemBlock(t *testing.T)
 	// The MCP tool list is the whole point of the wrap — guard a representative one.
 	if !strings.Contains(content, "ask_user_question_kandev") {
 		t.Errorf("expected ask_user_question_kandev tool in wrap, got %q", content)
+	}
+}
+
+// TestStartCreatedSession_DoesNotDoubleWrapPreWrappedPrompt verifies the
+// idempotency guard on the orchestrator's wrap step. Upstream call sites
+// (wsAddMessage on CREATED sessions, recordAutoStartMessage) wrap before
+// recording the user message so the DB row carries the <kandev-system>
+// block. When the wrapped content is later passed through StartCreatedSession,
+// the orchestrator must NOT wrap it a second time — otherwise the agent
+// receives nested system blocks and the strip pipeline behaves unpredictably.
+func TestStartCreatedSession_DoesNotDoubleWrapPreWrappedPrompt(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCreated)
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{
+		ID:    "task1",
+		Title: "Test Task",
+		State: v1.TaskStateInProgress,
+	}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, agentMgr)
+	mc := &mockMessageCreator{}
+	svc.messageCreator = mc
+
+	// Simulate an upstream caller (e.g. wsAddMessage) that has already wrapped.
+	preWrapped := sysprompt.InjectKandevContext("task1", "session1", "Build me a feature")
+
+	_, err := svc.StartCreatedSession(ctx, "task1", "session1", "profile1", preWrapped, false, false, nil)
+	if err != nil {
+		t.Fatalf("StartCreatedSession failed: %v", err)
+	}
+
+	if len(mc.userMessages) != 1 {
+		t.Fatalf("expected 1 user message recorded, got %d", len(mc.userMessages))
+	}
+	content := mc.userMessages[0].content
+
+	// Exactly one opening tag and one closing tag — not nested.
+	openCount := strings.Count(content, "<kandev-system>")
+	closeCount := strings.Count(content, "</kandev-system>")
+	if openCount != 1 {
+		t.Errorf("expected exactly 1 <kandev-system> tag, got %d in %q", openCount, content)
+	}
+	if closeCount != 1 {
+		t.Errorf("expected exactly 1 </kandev-system> tag, got %d in %q", closeCount, content)
+	}
+	// The user's text is preserved.
+	if !strings.Contains(content, "Build me a feature") {
+		t.Errorf("expected user text preserved, got %q", content)
 	}
 }
 

--- a/apps/backend/internal/sysprompt/sysprompt.go
+++ b/apps/backend/internal/sysprompt/sysprompt.go
@@ -58,8 +58,17 @@ const kandevContextMarker = "KANDEV MCP TOOLS"
 // system block produced by [InjectKandevContext]. Use this to gate a wrap at
 // any call site so the same prompt never gets double-wrapped on its way down
 // to the agent or the DB.
+//
+// The marker is matched only inside a <kandev-system>...</kandev-system>
+// block — a user message body that happens to mention "KANDEV MCP TOOLS"
+// would not falsely signal that the wrap is already applied.
 func HasKandevContext(text string) bool {
-	return strings.Contains(text, kandevContextMarker)
+	for _, block := range systemTagRegex.FindAllString(text, -1) {
+		if strings.Contains(block, kandevContextMarker) {
+			return true
+		}
+	}
+	return false
 }
 
 // PlanMode returns the system prompt prepended when plan mode is enabled.

--- a/apps/backend/internal/sysprompt/sysprompt.go
+++ b/apps/backend/internal/sysprompt/sysprompt.go
@@ -47,6 +47,21 @@ func HasSystemContent(text string) bool {
 	return systemTagRegex.MatchString(text)
 }
 
+// kandevContextMarker is a stable string from kandev-context.md that lets
+// callers detect a prompt that has already been wrapped with the Kandev MCP
+// system block. Used by [HasKandevContext] to make the wrap step idempotent
+// across the multiple call sites that record first-turn prompts (WS handler,
+// workflow auto-start, orchestrator).
+const kandevContextMarker = "KANDEV MCP TOOLS"
+
+// HasKandevContext reports whether the prompt already contains the Kandev MCP
+// system block produced by [InjectKandevContext]. Use this to gate a wrap at
+// any call site so the same prompt never gets double-wrapped on its way down
+// to the agent or the DB.
+func HasKandevContext(text string) bool {
+	return strings.Contains(text, kandevContextMarker)
+}
+
 // PlanMode returns the system prompt prepended when plan mode is enabled.
 // It instructs agents to collaborate on the plan without implementing changes.
 func PlanMode() string { return prompts.Get("plan-mode") }

--- a/apps/backend/internal/sysprompt/sysprompt_test.go
+++ b/apps/backend/internal/sysprompt/sysprompt_test.go
@@ -121,6 +121,23 @@ func TestInjectKandevContext_SystemContentStrippable(t *testing.T) {
 	assert.Equal(t, "Do something", stripped)
 }
 
+func TestHasKandevContext_DetectsInjectedWrap(t *testing.T) {
+	// Any prompt produced by InjectKandevContext must be detectable so call
+	// sites can make the wrap step idempotent.
+	wrapped := InjectKandevContext("task-abc", "session-xyz", "Do something")
+	assert.True(t, HasKandevContext(wrapped))
+
+	// A bare user message has no marker.
+	assert.False(t, HasKandevContext("Do something"))
+
+	// A different <kandev-system> block (e.g. active-document context from
+	// the frontend) must NOT trigger a false positive — otherwise the
+	// orchestrator's idempotency guard would skip the real kandev-context
+	// wrap.
+	other := Wrap("ACTIVE DOCUMENT: some file") + "\n\nuser text"
+	assert.False(t, HasKandevContext(other))
+}
+
 // --- StripSystemContent tests ---
 
 func TestStripSystemContent_NoTags(t *testing.T) {

--- a/apps/backend/internal/sysprompt/sysprompt_test.go
+++ b/apps/backend/internal/sysprompt/sysprompt_test.go
@@ -136,6 +136,14 @@ func TestHasKandevContext_DetectsInjectedWrap(t *testing.T) {
 	// wrap.
 	other := Wrap("ACTIVE DOCUMENT: some file") + "\n\nuser text"
 	assert.False(t, HasKandevContext(other))
+
+	// A user message body that happens to mention the marker phrase must
+	// NOT short-circuit the wrap — only an actual <kandev-system> block
+	// containing the marker counts. Without the regex scope, "how do I use
+	// the KANDEV MCP TOOLS?" would falsely register as already wrapped and
+	// the first-turn injection would be skipped.
+	userMentions := "how do I use the KANDEV MCP TOOLS?"
+	assert.False(t, HasKandevContext(userMentions))
 }
 
 // --- StripSystemContent tests ---

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -223,8 +223,10 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 	// reveals it). The orchestrator's wrap in StartCreatedSession is
 	// idempotent (HasKandevContext guard), so passing the wrapped content
 	// through dispatchPromptAsync does not double-wrap downstream.
+	// HasKandevContext also guards this call: any upstream caller that ever
+	// pre-wraps the content (none today) won't get double-wrapped here.
 	storedContent := req.Content
-	if isCreatedSession && (req.Content != "" || len(req.Attachments) > 0) {
+	if isCreatedSession && (req.Content != "" || len(req.Attachments) > 0) && !sysprompt.HasKandevContext(req.Content) {
 		storedContent = sysprompt.InjectKandevContext(req.TaskID, req.TaskSessionID, req.Content)
 		req.Content = storedContent
 	}

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -223,10 +223,14 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 	// reveals it). The orchestrator's wrap in StartCreatedSession is
 	// idempotent (HasKandevContext guard), so passing the wrapped content
 	// through dispatchPromptAsync does not double-wrap downstream.
-	// HasKandevContext also guards this call: any upstream caller that ever
-	// pre-wraps the content (none today) won't get double-wrapped here.
+	// NOTE: req.Content is user-controlled — do NOT guard this wrap on
+	// HasKandevContext. A malicious or naive client could craft a body
+	// containing a fake "<kandev-system>KANDEV MCP TOOLS</kandev-system>"
+	// block and bypass server-side injection of the canonical task/session/
+	// tool context. Wrap unconditionally; the orchestrator's own guard sees
+	// our wrap downstream and skips its second pass.
 	storedContent := req.Content
-	if isCreatedSession && (req.Content != "" || len(req.Attachments) > 0) && !sysprompt.HasKandevContext(req.Content) {
+	if isCreatedSession && (req.Content != "" || len(req.Attachments) > 0) {
 		storedContent = sysprompt.InjectKandevContext(req.TaskID, req.TaskSessionID, req.Content)
 		req.Content = storedContent
 	}

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/orchestrator"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/sysprompt"
 	"github.com/kandev/kandev/internal/task/dto"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
@@ -216,10 +217,22 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 		WithAttachments(req.Attachments).
 		WithContextFiles(req.ContextFiles)
 
+	// First message on a CREATED session is the kanban "type in chat to start
+	// the agent" path. Wrap with the Kandev MCP system block before persisting
+	// so the DB row matches what the agent receives (and "Show formatted"
+	// reveals it). The orchestrator's wrap in StartCreatedSession is
+	// idempotent (HasKandevContext guard), so passing the wrapped content
+	// through dispatchPromptAsync does not double-wrap downstream.
+	storedContent := req.Content
+	if isCreatedSession && (req.Content != "" || len(req.Attachments) > 0) {
+		storedContent = sysprompt.InjectKandevContext(req.TaskID, req.TaskSessionID, req.Content)
+		req.Content = storedContent
+	}
+
 	message, err := h.service.CreateMessage(ctx, &service.CreateMessageRequest{
 		TaskSessionID: req.TaskSessionID,
 		TaskID:        req.TaskID,
-		Content:       req.Content,
+		Content:       storedContent,
 		AuthorType:    "user",
 		AuthorID:      req.AuthorID,
 		Metadata:      meta.ToMap(),

--- a/apps/web/e2e/tests/chat/kandev-system-wrap.spec.ts
+++ b/apps/web/e2e/tests/chat/kandev-system-wrap.spec.ts
@@ -63,6 +63,12 @@ test.describe("Kandev system prompt wrap on first launch", () => {
     const raw = recorded.raw_content ?? "";
     expect(raw).toContain("<kandev-system>");
     expect(raw).toContain("</kandev-system>");
+    // Exactly-once: if any future call site (wsAddMessage, recordAutoStartMessage,
+    // StartCreatedSession) lost its idempotency guard and double-wrapped, the
+    // backend unit test catches it but the agent-facing boundary needs its own
+    // assertion too — nested <kandev-system> blocks break the strip regex.
+    expect((raw.match(/<kandev-system>/g) ?? []).length).toBe(1);
+    expect((raw.match(/<\/kandev-system>/g) ?? []).length).toBe(1);
     expect(raw).toContain(`Kandev Task ID: ${task.id}`);
     expect(raw).toContain(`Kandev Session ID: ${task.session_id}`);
     // Guard one representative MCP tool from kandev-context.md — if the

--- a/apps/web/e2e/tests/chat/kandev-system-wrap.spec.ts
+++ b/apps/web/e2e/tests/chat/kandev-system-wrap.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+
+/**
+ * Regression coverage for the Kandev MCP system block (kandev-context.md)
+ * that the orchestrator wraps around the FIRST prompt of every task launch.
+ *
+ * Contract:
+ *  - The wrap (<kandev-system>...</kandev-system>) is stored on the user
+ *    message row so the chat UI can reveal it under "Show formatted" and
+ *    so the audit trail records exactly what the agent saw.
+ *  - The visible `content` is the user's original text — the wrap is
+ *    stripped server-side via Message.ToAPI.
+ *  - The wrap carries the task ID, session ID, and the MCP tools list
+ *    (ask_user_question_kandev, create_task_plan_kandev, …) so the agent
+ *    can act on the kandev platform without re-discovering its identifiers.
+ *  - Wrap is applied ONCE on the first prompt. Follow-up prompts and
+ *    resumes do not re-wrap (covered by backend lifecycle tests).
+ */
+
+async function waitForUserMessage(
+  apiClient: ApiClient,
+  sessionId: string,
+  timeoutMs = 20_000,
+): Promise<{ content: string; raw_content?: string; metadata?: Record<string, unknown> }> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { messages } = await apiClient.listSessionMessages(sessionId);
+    const user = messages.find((m) => m.author_type === "user");
+    if (user) return user;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`No user message recorded on session ${sessionId} within ${timeoutMs}ms`);
+}
+
+test.describe("Kandev system prompt wrap on first launch", () => {
+  test("kanban task records the wrap in raw_content and strips it from content", async ({
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Wrap-on-launch regression",
+      seedData.agentProfileId,
+      {
+        description: 'e2e:message("ack")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+
+    const recorded = await waitForUserMessage(apiClient, task.session_id);
+
+    // Visible bubble text — what the UI shows under the default "formatted" view.
+    expect(recorded.content).not.toContain("<kandev-system>");
+    expect(recorded.content).toContain('e2e:message("ack")');
+
+    // raw_content carries the wrap. Message.ToAPI only sets raw_content when
+    // hidden system blocks are present, so its presence is itself a signal
+    // that the wrap reached the DB.
+    const raw = recorded.raw_content ?? "";
+    expect(raw).toContain("<kandev-system>");
+    expect(raw).toContain("</kandev-system>");
+    expect(raw).toContain(`Kandev Task ID: ${task.id}`);
+    expect(raw).toContain(`Kandev Session ID: ${task.session_id}`);
+    // Guard one representative MCP tool from kandev-context.md — if the
+    // template drifts the test will fail loudly rather than silently passing
+    // an empty wrap.
+    expect(raw).toContain("ask_user_question_kandev");
+    expect(raw).toContain("create_task_plan_kandev");
+    // The user's text must survive inside the wrapped form.
+    expect(raw).toContain('e2e:message("ack")');
+
+    // metadata.has_hidden_prompts drives the UI's "Show formatted" toggle.
+    expect(recorded.metadata?.has_hidden_prompts).toBe(true);
+  });
+});


### PR DESCRIPTION
The Kandev MCP system block (task/session IDs + tool list) was being added inside the agent runtime lifecycle layer, so it reached the agent but was never stored on the user-message row — users clicking "Show formatted" in the chat saw the same stripped text as the bubble, and the audit trail had no record of what the agent was actually told on first turn. Moving the wrap up to the orchestrator records it on the message row while Message.ToAPI keeps the bubble clean.

## Important Changes

- Wrap is now applied in `orchestrator/task_operations.go` (`startTask`, `StartCreatedSession`) before `recordInitialMessage`, so `task_session_messages.content` carries the `<kandev-system>…</kandev-system>` block. The chat UI continues to display the stripped text; `raw_content` + `metadata.has_hidden_prompts` drive the "Show formatted" toggle.
- The duplicate injection in `agent/runtime/lifecycle/session.go` (`dispatchInitialPrompt`, `buildEffectivePrompt`) is removed. The lifecycle no longer touches the kandev-system wrap. Resumes pass through verbatim — the agent CLI's restored conversation already contains the original wrap, so re-injecting was redundant and inconsistent.
- Empty prompts still skip the wrap (the `effectivePrompt != "" || len(attachments) > 0` guard preserves the existing empty-message no-op).

## Validation

- `make -C apps/backend fmt lint test` — all affected packages pass; pre-existing `TestFeatures_DefaultOff` failure on `main` is unrelated.
- `pnpm --filter @kandev/web typecheck lint` — clean.
- New backend tests:
  - `TestStartCreatedSession_WrapsFirstPromptWithKandevSystemBlock` — recorded user message contains the wrap with task ID, session ID, and `ask_user_question_kandev`.
  - `TestStartCreatedSession_EmptyPromptSkipsWrap` — empty prompt yields no recorded message.
  - `TestBuildEffectivePrompt_DoesNotInjectKandevContextOnResume` — resumed prompts pass through without `<kandev-system>`.
- New e2e test `apps/web/e2e/tests/chat/kandev-system-wrap.spec.ts` — full kanban launch asserts `content` is stripped, `raw_content` carries the wrap with live IDs and the MCP tool list, and `metadata.has_hidden_prompts` is `true`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.