### PR TITLE
fix: respect user-chosen agent on workflow step transitions

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -481,23 +481,10 @@ func sessionWasWorkflowSwitched(session *models.TaskSession) bool {
 // tagSessionAsWorkflowSwitched marks a session's metadata so it's recognised
 // as workflow-spawned by sessionWasWorkflowSwitched. Used by every code path
 // that ends up with a session whose agent_profile_id was decided by the
-// workflow step override rather than by the user.
+// workflow step override rather than by the user. Uses the atomic
+// SetSessionMetadataKey (json_set) so other metadata keys are preserved.
 func (s *Service) tagSessionAsWorkflowSwitched(ctx context.Context, sessionID string) {
-	session, err := s.repo.GetTaskSession(ctx, sessionID)
-	if err != nil || session == nil {
-		s.logger.Warn("failed to load session for workflow-switch tagging",
-			zap.String("session_id", sessionID), zap.Error(err))
-		return
-	}
-	if session.Metadata == nil {
-		session.Metadata = map[string]interface{}{}
-	}
-	if existing, _ := session.Metadata[models.SessionMetaKeyCreatedBy].(string); existing == models.SessionCreatedByWorkflowSwitch {
-		return
-	}
-	session.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
-	session.UpdatedAt = time.Now().UTC()
-	if err := s.repo.UpdateTaskSession(ctx, session); err != nil {
+	if err := s.repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyCreatedBy, models.SessionCreatedByWorkflowSwitch); err != nil {
 		s.logger.Warn("failed to persist workflow-switch tag",
 			zap.String("session_id", sessionID), zap.Error(err))
 	}
@@ -594,21 +581,11 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 		s.reviveReusedSession(ctx, existing)
 	}
 
-	// Tag the reused session as workflow-spawned so a later transition to a
-	// plain step knows it can revert to the task default — same rationale as
-	// the tag in createNewSessionForStep. Without this, reusing a session
-	// across two workflow overrides (X → Y → X) and then entering a plain
-	// step would leave the reused session untagged and incorrectly
-	// indistinguishable from a user-created one.
-	if existing.Metadata == nil {
-		existing.Metadata = map[string]interface{}{}
-	}
-	existing.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
-	existing.UpdatedAt = time.Now().UTC()
-	if err := s.repo.UpdateTaskSession(ctx, existing); err != nil {
-		s.logger.Warn("failed to persist workflow-switch metadata on reused session",
-			zap.String("session_id", existing.ID), zap.Error(err))
-	}
+	// Note: do not stamp created_by here. Reused sessions keep whatever tag
+	// they had when first created — workflow-spawned ones (createNewSessionForStep,
+	// StartCreatedSession, startTask) already carry the workflow_switch tag,
+	// and user-created ones must stay untagged so a later plain step doesn't
+	// silently revert their explicit profile choice to the task default.
 
 	if err := s.SetPrimarySession(ctx, existing.ID); err != nil {
 		s.logger.Warn("failed to set reused session as primary",
@@ -696,22 +673,19 @@ func (s *Service) createNewSessionForStep(ctx context.Context, taskID string, cu
 	// step (no agent_profile override) knows it's safe to revert to the task
 	// default. User-created sessions intentionally lack this tag — reverting
 	// them would override an explicit user choice.
-	if newSession.Metadata == nil {
-		newSession.Metadata = map[string]interface{}{}
-	}
-	newSession.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
+	s.tagSessionAsWorkflowSwitched(ctx, newSession.ID)
 
 	// Inherit the task environment from the old session — the workspace is shared
 	// across sessions within the same task, so the new session can reuse the
 	// existing agentctl connection and workspace files.
 	if currentSession.TaskEnvironmentID != "" && newSession.TaskEnvironmentID == "" {
 		newSession.TaskEnvironmentID = currentSession.TaskEnvironmentID
-	}
-	newSession.UpdatedAt = time.Now().UTC()
-	if err := s.repo.UpdateTaskSession(ctx, newSession); err != nil {
-		s.logger.Warn("failed to persist workflow-switch metadata on new session",
-			zap.String("session_id", newSession.ID),
-			zap.Error(err))
+		newSession.UpdatedAt = time.Now().UTC()
+		if err := s.repo.UpdateTaskSession(ctx, newSession); err != nil {
+			s.logger.Warn("failed to copy task_environment_id to new session",
+				zap.String("session_id", newSession.ID),
+				zap.Error(err))
+		}
 	}
 
 	// Transfer any queued message (e.g. a move_task_kandev hand-off prompt) and

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -466,6 +466,18 @@ func (s *Service) resolveStepAgentProfile(ctx context.Context, step *wfmodels.Wo
 	return ""
 }
 
+// sessionWasWorkflowSwitched reports whether the session was spawned by a
+// previous workflow step's agent_profile override (createNewSessionForStep)
+// rather than by the user. Used to decide whether transitioning to a step
+// with no override should revert to the task default.
+func sessionWasWorkflowSwitched(session *models.TaskSession) bool {
+	if session == nil || session.Metadata == nil {
+		return false
+	}
+	v, _ := session.Metadata[models.SessionMetaKeyCreatedBy].(string)
+	return v == models.SessionCreatedByWorkflowSwitch
+}
+
 // switchSessionForStep activates a session for the new agent profile.
 // If an existing session on this task already uses the target profile it is
 // reused (re-promoted to primary, brought out of COMPLETED if it had been
@@ -639,17 +651,26 @@ func (s *Service) createNewSessionForStep(ctx context.Context, taskID string, cu
 		return nil, fmt.Errorf("failed to get new session: %w", err)
 	}
 
+	// Tag the session as workflow-spawned so a later transition to a plain
+	// step (no agent_profile override) knows it's safe to revert to the task
+	// default. User-created sessions intentionally lack this tag — reverting
+	// them would override an explicit user choice.
+	if newSession.Metadata == nil {
+		newSession.Metadata = map[string]interface{}{}
+	}
+	newSession.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
+
 	// Inherit the task environment from the old session — the workspace is shared
 	// across sessions within the same task, so the new session can reuse the
 	// existing agentctl connection and workspace files.
 	if currentSession.TaskEnvironmentID != "" && newSession.TaskEnvironmentID == "" {
 		newSession.TaskEnvironmentID = currentSession.TaskEnvironmentID
-		newSession.UpdatedAt = time.Now().UTC()
-		if err := s.repo.UpdateTaskSession(ctx, newSession); err != nil {
-			s.logger.Warn("failed to copy task_environment_id to new session",
-				zap.String("session_id", newSession.ID),
-				zap.Error(err))
-		}
+	}
+	newSession.UpdatedAt = time.Now().UTC()
+	if err := s.repo.UpdateTaskSession(ctx, newSession); err != nil {
+		s.logger.Warn("failed to persist workflow-switch metadata on new session",
+			zap.String("session_id", newSession.ID),
+			zap.Error(err))
 	}
 
 	// Transfer any queued message (e.g. a move_task_kandev hand-off prompt) and
@@ -732,9 +753,13 @@ func (s *Service) maybySwitchSessionForProfile(
 	}
 	effectiveProfile := s.resolveStepAgentProfile(ctx, step)
 
-	// When the step has no override, fall back to the task's original agent profile
-	// so that moving to a step without an agent_profile reverts to the default.
-	if effectiveProfile == "" {
+	// When the step has no override, fall back to the task's original agent
+	// profile so that moving to a step without an agent_profile reverts to the
+	// default. Only do this when the current session was itself spawned by a
+	// previous step's override — a user-chosen session (e.g. "New Agent"
+	// button) must not be silently replaced by the task default, which would
+	// override the user's explicit choice.
+	if effectiveProfile == "" && sessionWasWorkflowSwitched(session) {
 		task, err := s.repo.GetTask(ctx, taskID)
 		if err == nil && task.Metadata != nil {
 			if pid, ok := task.Metadata[models.MetaKeyAgentProfileID].(string); ok && pid != "" {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -478,6 +478,31 @@ func sessionWasWorkflowSwitched(session *models.TaskSession) bool {
 	return v == models.SessionCreatedByWorkflowSwitch
 }
 
+// tagSessionAsWorkflowSwitched marks a session's metadata so it's recognised
+// as workflow-spawned by sessionWasWorkflowSwitched. Used by every code path
+// that ends up with a session whose agent_profile_id was decided by the
+// workflow step override rather than by the user.
+func (s *Service) tagSessionAsWorkflowSwitched(ctx context.Context, sessionID string) {
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil || session == nil {
+		s.logger.Warn("failed to load session for workflow-switch tagging",
+			zap.String("session_id", sessionID), zap.Error(err))
+		return
+	}
+	if session.Metadata == nil {
+		session.Metadata = map[string]interface{}{}
+	}
+	if existing, _ := session.Metadata[models.SessionMetaKeyCreatedBy].(string); existing == models.SessionCreatedByWorkflowSwitch {
+		return
+	}
+	session.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
+	session.UpdatedAt = time.Now().UTC()
+	if err := s.repo.UpdateTaskSession(ctx, session); err != nil {
+		s.logger.Warn("failed to persist workflow-switch tag",
+			zap.String("session_id", sessionID), zap.Error(err))
+	}
+}
+
 // switchSessionForStep activates a session for the new agent profile.
 // If an existing session on this task already uses the target profile it is
 // reused (re-promoted to primary, brought out of COMPLETED if it had been

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -569,6 +569,22 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 		s.reviveReusedSession(ctx, existing)
 	}
 
+	// Tag the reused session as workflow-spawned so a later transition to a
+	// plain step knows it can revert to the task default — same rationale as
+	// the tag in createNewSessionForStep. Without this, reusing a session
+	// across two workflow overrides (X → Y → X) and then entering a plain
+	// step would leave the reused session untagged and incorrectly
+	// indistinguishable from a user-created one.
+	if existing.Metadata == nil {
+		existing.Metadata = map[string]interface{}{}
+	}
+	existing.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
+	existing.UpdatedAt = time.Now().UTC()
+	if err := s.repo.UpdateTaskSession(ctx, existing); err != nil {
+		s.logger.Warn("failed to persist workflow-switch metadata on reused session",
+			zap.String("session_id", existing.ID), zap.Error(err))
+	}
+
 	if err := s.SetPrimarySession(ctx, existing.ID); err != nil {
 		s.logger.Warn("failed to set reused session as primary",
 			zap.String("session_id", existing.ID), zap.Error(err))

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -731,6 +731,171 @@ func TestProcessOnEnter_ProfileSwitch(t *testing.T) {
 			t.Errorf("expected 1 session, got %d", len(sessions))
 		}
 	})
+
+	// The user created the task with profile-a, then manually added a new
+	// session with profile-b ("New Agent" button). When the workflow
+	// transitions to a step with no agent_profile_id override, the user's
+	// explicit choice (profile-b) must win — we must NOT silently switch
+	// back to the task's original profile-a just because that's what
+	// task.Metadata[agent_profile_id] still says.
+	t.Run("keeps user-chosen session when step has no override", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		now := time.Now().UTC()
+
+		ws := &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}
+		_ = repo.CreateWorkspace(ctx, ws)
+		wf := &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}
+		_ = repo.CreateWorkflow(ctx, wf)
+		// Task was created with profile-a as the default agent.
+		task := &models.Task{
+			ID: "t1", WorkflowID: "wf1", WorkflowStepID: "step1",
+			Title: "Test", Description: "desc", State: v1.TaskStateInProgress,
+			Metadata:  map[string]interface{}{models.MetaKeyAgentProfileID: "profile-a"},
+			CreatedAt: now, UpdatedAt: now,
+		}
+		_ = repo.CreateTask(ctx, task)
+
+		// User clicked "New Agent" and started a profile-b session — it has
+		// no created_by metadata tag because it was user-chosen, not spawned
+		// by a workflow step override.
+		session := &models.TaskSession{
+			ID:                "s1",
+			TaskID:            "t1",
+			AgentProfileID:    "profile-b",
+			ExecutorID:        "exec-local",
+			ExecutorProfileID: "ep1",
+			State:             models.TaskSessionStateWaitingForInput,
+			IsPrimary:         true,
+			StartedAt:         now,
+			UpdatedAt:         now,
+		}
+		_ = repo.CreateTaskSession(ctx, session)
+
+		sg := newMockStepGetter()
+		step := &wfmodels.WorkflowStep{
+			ID:         "step1",
+			WorkflowID: "wf1",
+			Name:       "Review",
+			// No AgentProfileID — step has no override.
+		}
+		sg.steps["step1"] = step
+
+		svc := createTestService(repo, sg, newMockTaskRepo())
+		svc.processOnEnter(ctx, "t1", session, step, "desc")
+
+		// Critical: no new profile-a session should be spawned, and the
+		// user-chosen profile-b session must NOT be marked COMPLETED.
+		sessions, err := repo.ListTaskSessions(ctx, "t1")
+		if err != nil {
+			t.Fatalf("failed to list sessions: %v", err)
+		}
+		if len(sessions) != 1 {
+			t.Errorf("expected 1 session (no respawn), got %d", len(sessions))
+		}
+		updated, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("failed to get session: %v", err)
+		}
+		if updated.State == models.TaskSessionStateCompleted {
+			t.Error("user-chosen session must not be completed when step has no override")
+		}
+		if updated.AgentProfileID != "profile-b" {
+			t.Errorf("primary session must remain profile-b, got %q", updated.AgentProfileID)
+		}
+	})
+
+	// Inverse of the above: when the current session was spawned by a
+	// previous step's agent_profile override, transitioning to a plain step
+	// SHOULD revert to the task default.
+	t.Run("reverts to task default when current session was workflow-spawned", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		now := time.Now().UTC()
+
+		ws := &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}
+		_ = repo.CreateWorkspace(ctx, ws)
+		wf := &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}
+		_ = repo.CreateWorkflow(ctx, wf)
+		task := &models.Task{
+			ID: "t1", WorkflowID: "wf1", WorkflowStepID: "step2",
+			Title: "Test", Description: "desc", State: v1.TaskStateInProgress,
+			Metadata:  map[string]interface{}{models.MetaKeyAgentProfileID: "profile-a"},
+			CreatedAt: now, UpdatedAt: now,
+		}
+		_ = repo.CreateTask(ctx, task)
+
+		// Session was spawned by createNewSessionForStep — tagged accordingly.
+		session := &models.TaskSession{
+			ID:                "s1",
+			TaskID:            "t1",
+			AgentProfileID:    "profile-b",
+			ExecutorID:        "exec-local",
+			ExecutorProfileID: "ep1",
+			State:             models.TaskSessionStateWaitingForInput,
+			IsPrimary:         true,
+			Metadata:          map[string]interface{}{models.SessionMetaKeyCreatedBy: models.SessionCreatedByWorkflowSwitch},
+			StartedAt:         now,
+			UpdatedAt:         now,
+		}
+		_ = repo.CreateTaskSession(ctx, session)
+
+		taskRepo := newMockTaskRepo()
+		taskRepo.tasks["t1"] = &v1.Task{
+			ID: "t1", WorkspaceID: "ws1", WorkflowID: "wf1",
+			Title: "Test", Description: "desc", State: v1.TaskStateInProgress,
+		}
+
+		sg := newMockStepGetter()
+		step := &wfmodels.WorkflowStep{
+			ID:         "step2",
+			WorkflowID: "wf1",
+			Name:       "Done",
+			// No AgentProfileID — plain step.
+		}
+		sg.steps["step2"] = step
+
+		agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+		log := testLogger()
+		exec := executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{})
+		sched := scheduler.NewScheduler(queue.NewTaskQueue(100), exec, taskRepo, log, scheduler.SchedulerConfig{})
+		svc := &Service{
+			logger:             log,
+			repo:               repo,
+			workflowStepGetter: sg,
+			taskRepo:           taskRepo,
+			agentManager:       agentMgr,
+			messageQueue:       messagequeue.NewServiceMemory(log),
+			executor:           exec,
+			scheduler:          sched,
+		}
+
+		svc.processOnEnter(ctx, "t1", session, step, "desc")
+
+		oldSession, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("failed to get old session: %v", err)
+		}
+		if oldSession.State != models.TaskSessionStateCompleted {
+			t.Errorf("workflow-spawned session should be completed when reverting to default, got %s", oldSession.State)
+		}
+
+		sessions, err := repo.ListTaskSessions(ctx, "t1")
+		if err != nil {
+			t.Fatalf("failed to list sessions: %v", err)
+		}
+		var newSession *models.TaskSession
+		for _, s := range sessions {
+			if s.ID != "s1" {
+				newSession = s
+				break
+			}
+		}
+		if newSession == nil {
+			t.Fatal("expected a new session for task default profile")
+		}
+		if newSession.AgentProfileID != "profile-a" {
+			t.Errorf("expected reverted profile-a, got %q", newSession.AgentProfileID)
+		}
+	})
 }
 
 func TestSwitchSessionForStep_PreservesOldSessionOnFailure(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -882,12 +882,21 @@ func TestProcessOnEnter_ProfileSwitch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to list sessions: %v", err)
 		}
+		if len(sessions) != 2 {
+			t.Fatalf("expected exactly 2 sessions (old + reverted), got %d", len(sessions))
+		}
 		var newSession *models.TaskSession
+		profileACount := 0
 		for _, s := range sessions {
+			if s.AgentProfileID == "profile-a" {
+				profileACount++
+			}
 			if s.ID != "s1" {
 				newSession = s
-				break
 			}
+		}
+		if profileACount != 1 {
+			t.Fatalf("expected exactly one profile-a session after revert, got %d", profileACount)
 		}
 		if newSession == nil {
 			t.Fatal("expected a new session for task default profile")

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -337,10 +337,7 @@ func (s *Service) StartCreatedSession(ctx context.Context, taskID, sessionID, ag
 		// profile mutation here is invisible to maybySwitchSessionForProfile,
 		// which would treat the session as user-chosen and leave it on the
 		// override forever.
-		if session.Metadata == nil {
-			session.Metadata = map[string]interface{}{}
-		}
-		session.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
+		s.tagSessionAsWorkflowSwitched(ctx, sessionID)
 		// Re-resolve the agent profile snapshot so the tab shows the correct agent logo/name.
 		// Set a minimal snapshot first so stale data is never persisted if resolution fails.
 		session.AgentProfileSnapshot = map[string]interface{}{"id": effectiveProfileID}

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -660,6 +660,15 @@ func (s *Service) prepareSessionForStart(
 		if ensureErr != nil {
 			return "", ensureErr
 		}
+		// The office/assignee path bypasses StartCreatedSession's override
+		// mutation: the session is created directly with the assignee
+		// profile (which falls back to the step's agent_profile_id via the
+		// runner projection). If that profile differs from the caller's,
+		// the assignment was workflow-driven — tag so a later transition
+		// to a plain step knows it can revert to the task default.
+		if agentProfileID != "" && session.AgentProfileID != "" && session.AgentProfileID != agentProfileID {
+			s.tagSessionAsWorkflowSwitched(ctx, session.ID)
+		}
 		return session.ID, nil
 	}
 	return s.executor.PrepareSession(ctx, task, agentProfileID, executorID, executorProfileID, workflowStepID)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -332,6 +332,15 @@ func (s *Service) StartCreatedSession(ctx context.Context, taskID, sessionID, ag
 			zap.String("old_profile", session.AgentProfileID),
 			zap.String("new_profile", effectiveProfileID))
 		session.AgentProfileID = effectiveProfileID
+		// Tag as workflow-spawned so a later transition to a plain step can
+		// correctly revert to the task default. Without this, the in-place
+		// profile mutation here is invisible to maybySwitchSessionForProfile,
+		// which would treat the session as user-chosen and leave it on the
+		// override forever.
+		if session.Metadata == nil {
+			session.Metadata = map[string]interface{}{}
+		}
+		session.Metadata[models.SessionMetaKeyCreatedBy] = models.SessionCreatedByWorkflowSwitch
 		// Re-resolve the agent profile snapshot so the tab shows the correct agent logo/name.
 		// Set a minimal snapshot first so stale data is never persisted if resolution fails.
 		session.AgentProfileSnapshot = map[string]interface{}{"id": effectiveProfileID}
@@ -551,7 +560,9 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	// Resolve the workflow step's agent profile override.
 	// The frontend may pass the workspace default profile, but the step may
 	// require a different agent (e.g., Codex on "In Progress", Auggie on "Review").
+	callerProfileID := agentProfileID
 	agentProfileID = s.resolveEffectiveAgentProfile(ctx, taskID, workflowStepID, agentProfileID)
+	overrideApplied := agentProfileID != callerProfileID
 
 	// Fetch the task from the repository to get complete task info
 	task, err := s.scheduler.GetTask(ctx, taskID)
@@ -579,6 +590,14 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	sessionID, err := s.prepareSessionForStart(ctx, task, agentProfileID, executorID, executorProfileID, workflowStepID)
 	if err != nil {
 		return nil, err
+	}
+
+	// When the workflow step overrode the caller's profile, tag the session
+	// so maybySwitchSessionForProfile knows it can revert to the task default
+	// on a later plain-step transition. Without this tag, the session looks
+	// indistinguishable from a user-chosen one and stays on the override.
+	if overrideApplied {
+		s.tagSessionAsWorkflowSwitched(ctx, sessionID)
 	}
 
 	effectivePrompt, planModeActive := s.applyWorkflowAndPlanMode(ctx, effectivePrompt, task.ID, sessionID, workflowStepID, planMode, task.IsEphemeral)

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -45,6 +45,16 @@ const (
 	MetaKeyWorkspacePath = "workspace_path"
 )
 
+// TaskSession.Metadata key that records how the session came into existence.
+// Read by maybySwitchSessionForProfile to decide whether transitioning to a
+// step with no agent_profile override should revert to the task default
+// (workflow-spawned sessions: yes) or preserve the user's explicit choice
+// (user-created sessions: yes — they have no created_by tag).
+const (
+	SessionMetaKeyCreatedBy        = "created_by"
+	SessionCreatedByWorkflowSwitch = "workflow_switch"
+)
+
 // Task origin values for the Origin field.
 const (
 	TaskOriginManual       = "manual"

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -47,9 +47,9 @@ const (
 
 // TaskSession.Metadata key that records how the session came into existence.
 // Read by maybySwitchSessionForProfile to decide whether transitioning to a
-// step with no agent_profile override should revert to the task default
-// (workflow-spawned sessions: yes) or preserve the user's explicit choice
-// (user-created sessions: yes — they have no created_by tag).
+// step with no agent_profile override should revert to the task default:
+// workflow-spawned sessions (created_by=workflow_switch) -> yes, revert.
+// user-created sessions (no created_by tag)              -> no, preserve.
 const (
 	SessionMetaKeyCreatedBy        = "created_by"
 	SessionCreatedByWorkflowSwitch = "workflow_switch"

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -443,6 +443,11 @@ func (r *Repository) UpdateTaskSession(ctx context.Context, session *models.Task
 		return fmt.Errorf("failed to serialize repository snapshot: %w", err)
 	}
 
+	// metadata is NOT written here — callers wanting to change it must use
+	// UpdateSessionMetadata or SetSessionMetadataKey. A full-row write here
+	// would clobber metadata set via those side-channel paths since the
+	// caller's in-memory copy may be stale.
+
 	// agent_profile_id is stored as NULL when empty so the partial unique
 	// index over (task_id, agent_profile_id) ignores kanban / quick-chat rows.
 	var agentProfileID interface{}

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -1011,6 +1011,7 @@ export class ApiClient {
     title: string;
     primary_session_id?: string | null;
     state?: string;
+    workflow_step_id?: string;
     repositories?: Array<{
       id: string;
       task_id: string;

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -730,7 +730,7 @@ test.describe("Workflow agent profile switching", () => {
     const step1 = await apiClient.createWorkflowStep(workflow.id, "Step1", 0, {
       is_start_step: true,
     });
-    await apiClient.createWorkflowStep(workflow.id, "Step2", 1);
+    const step2 = await apiClient.createWorkflowStep(workflow.id, "Step2", 1);
     await apiClient.createWorkflowStep(workflow.id, "Done", 2);
 
     await apiClient.updateWorkflowStep(step1.id, {
@@ -784,7 +784,7 @@ test.describe("Workflow agent profile switching", () => {
         },
         { timeout: 30_000, message: "Waiting for task to advance to step2" },
       )
-      .not.toBe(step1.id);
+      .toBe(step2.id);
 
     // Critical assertion: no extra profileA session was spawned after the
     // user's profileB turn completed. The task must still have exactly two

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -773,22 +773,18 @@ test.describe("Workflow agent profile switching", () => {
       intent: "start",
     });
 
-    // Wait for the profileB session to complete its turn (mock agent finishes
-    // the e2e:message and emits agent.ready). The on_turn_complete handler
-    // then evaluates the transition to Step2.
+    // Wait for the on_turn_complete handler to advance the task to Step2 —
+    // a deterministic signal that the handler ran (and either spawned a new
+    // session, the bug, or correctly did not).
     await expect
       .poll(
         async () => {
-          const { sessions } = await apiClient.listTaskSessions(task.id);
-          return sessions.find((s) => s.agent_profile_id === profileB.id)?.state ?? "";
+          const t = await apiClient.getTask(task.id);
+          return t.workflow_step_id;
         },
-        { timeout: 30_000, message: "Waiting for profileB session to settle after turn" },
+        { timeout: 30_000, message: "Waiting for task to advance to step2" },
       )
-      .toMatch(/WAITING_FOR_INPUT|COMPLETED/);
-
-    // Give the on_turn_complete handler time to (incorrectly) spawn a new
-    // session if the bug is present.
-    await new Promise((r) => setTimeout(r, 2000));
+      .not.toBe(step1.id);
 
     // Critical assertion: no extra profileA session was spawned after the
     // user's profileB turn completed. The task must still have exactly two

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -798,15 +798,20 @@ test.describe("Workflow agent profile switching", () => {
       .toBe(step2.id);
 
     // The handler runs in a goroutine after the step-id write, so a buggy
-    // respawn could land a few moments after the advance is visible. Poll
-    // briefly for session-count stability before the final assertion to
-    // close that race.
-    await expect
-      .poll(async () => (await apiClient.listTaskSessions(task.id)).sessions.length, {
-        timeout: 5_000,
-        message: "Checking no extra session is spawned",
-      })
-      .toBe(2);
+    // respawn could land a few moments after the advance is visible. Sample
+    // the session count repeatedly across a short window and fail fast if
+    // it ever exceeds 2. `expect.poll(...).toBe(2)` would return on the
+    // first matching sample and miss a delayed respawn — we need to prove
+    // the count *stays* at 2.
+    const stabilityWindowMs = 3_000;
+    const stabilityStart = Date.now();
+    while (Date.now() - stabilityStart < stabilityWindowMs) {
+      const { sessions: stableSessions } = await apiClient.listTaskSessions(task.id);
+      expect(stableSessions.length, "no extra session should spawn within stability window").toBe(
+        2,
+      );
+      await new Promise((r) => setTimeout(r, 250));
+    }
 
     // Critical assertion: no extra profileA session was spawned after the
     // user's profileB turn completed. The task must still have exactly two

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -710,6 +710,96 @@ test.describe("Workflow agent profile switching", () => {
     await expect(session.primaryStarInTab("Profile A")).toBeVisible({ timeout: 30_000 });
   });
 
+  /**
+   * A user manually adds a session with a different agent (the "New Agent"
+   * button), and the active step has on_turn_complete: move_to_next with the
+   * next step having no agent override. The user's explicit profileB choice
+   * must win — we must NOT silently respawn a profileA session after each
+   * completed turn.
+   */
+  test("user-added agent session is not respawned to task default on turn complete", async ({
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(60_000);
+    const { profileA, profileB } = await createProfiles(apiClient);
+
+    // Step1: no override, auto_start + on_turn_complete → next.
+    // Step2: no override (this is the trigger condition for the bug).
+    const workflow = await apiClient.createWorkflow(seedData.workspaceId, "Respawn Regression");
+    const step1 = await apiClient.createWorkflowStep(workflow.id, "Step1", 0, {
+      is_start_step: true,
+    });
+    await apiClient.createWorkflowStep(workflow.id, "Step2", 1);
+    await apiClient.createWorkflowStep(workflow.id, "Done", 2);
+
+    await apiClient.updateWorkflowStep(step1.id, {
+      prompt: 'e2e:message("step1 done")',
+      events: {
+        on_enter: [{ type: "auto_start_agent" }],
+        on_turn_complete: [{ type: "move_to_next" }],
+      },
+    });
+    // step2 deliberately has no agent_profile_id and no on_enter.
+
+    // Task is created with profileA as the default agent.
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Respawn Regression Task",
+      profileA.id,
+      {
+        workflow_id: workflow.id,
+        workflow_step_id: step1.id,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    // Wait for the auto-started profileA session to be ready.
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return sessions.find((s) => s.agent_profile_id === profileA.id)?.state ?? "";
+        },
+        { timeout: 30_000, message: "Waiting for profileA session to be ready" },
+      )
+      .toBe("WAITING_FOR_INPUT");
+
+    // User clicks "New Agent" — launch a profileB session on the same task.
+    await apiClient.launchSession({
+      task_id: task.id,
+      agent_profile_id: profileB.id,
+      prompt: 'e2e:message("hello from B")',
+      intent: "start",
+    });
+
+    // Wait for the profileB session to complete its turn (mock agent finishes
+    // the e2e:message and emits agent.ready). The on_turn_complete handler
+    // then evaluates the transition to Step2.
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          return sessions.find((s) => s.agent_profile_id === profileB.id)?.state ?? "";
+        },
+        { timeout: 30_000, message: "Waiting for profileB session to settle after turn" },
+      )
+      .toMatch(/WAITING_FOR_INPUT|COMPLETED/);
+
+    // Give the on_turn_complete handler time to (incorrectly) spawn a new
+    // session if the bug is present.
+    await new Promise((r) => setTimeout(r, 2000));
+
+    // Critical assertion: no extra profileA session was spawned after the
+    // user's profileB turn completed. The task must still have exactly two
+    // sessions (the original profileA and the user-added profileB).
+    const { sessions } = await apiClient.listTaskSessions(task.id);
+    const profileASessions = sessions.filter((s) => s.agent_profile_id === profileA.id);
+    const profileBSessions = sessions.filter((s) => s.agent_profile_id === profileB.id);
+    expect(profileBSessions.length).toBe(1);
+    expect(profileASessions.length).toBe(1);
+  });
+
   test("reset context checkbox is disabled when step has agent profile override", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -733,8 +733,11 @@ test.describe("Workflow agent profile switching", () => {
     const step2 = await apiClient.createWorkflowStep(workflow.id, "Step2", 1);
     await apiClient.createWorkflowStep(workflow.id, "Done", 2);
 
+    // step1 has auto_start + on_turn_complete:move_to_next but NO startup
+    // prompt — a prompt would race the user's New Agent launch and could
+    // advance the task to step2 before the user-added session even exists,
+    // letting this test pass without exercising the bug path.
     await apiClient.updateWorkflowStep(step1.id, {
-      prompt: 'e2e:message("step1 done")',
       events: {
         on_enter: [{ type: "auto_start_agent" }],
         on_turn_complete: [{ type: "move_to_next" }],
@@ -754,7 +757,9 @@ test.describe("Workflow agent profile switching", () => {
       },
     );
 
-    // Wait for the auto-started profileA session to be ready.
+    // Wait for the auto-started profileA session to be ready AND confirm the
+    // task is still on step1 — without a startup prompt the only way to
+    // advance is via the user-added session's turn-complete below.
     await expect
       .poll(
         async () => {
@@ -764,6 +769,12 @@ test.describe("Workflow agent profile switching", () => {
         { timeout: 30_000, message: "Waiting for profileA session to be ready" },
       )
       .toBe("WAITING_FOR_INPUT");
+    await expect
+      .poll(async () => (await apiClient.getTask(task.id)).workflow_step_id, {
+        timeout: 5_000,
+        message: "Task should still be on step1 before New Agent",
+      })
+      .toBe(step1.id);
 
     // User clicks "New Agent" — launch a profileB session on the same task.
     await apiClient.launchSession({
@@ -785,6 +796,17 @@ test.describe("Workflow agent profile switching", () => {
         { timeout: 30_000, message: "Waiting for task to advance to step2" },
       )
       .toBe(step2.id);
+
+    // The handler runs in a goroutine after the step-id write, so a buggy
+    // respawn could land a few moments after the advance is visible. Poll
+    // briefly for session-count stability before the final assertion to
+    // close that race.
+    await expect
+      .poll(async () => (await apiClient.listTaskSessions(task.id)).sessions.length, {
+        timeout: 5_000,
+        message: "Checking no extra session is spawned",
+      })
+      .toBe(2);
 
     // Critical assertion: no extra profileA session was spawned after the
     // user's profileB turn completed. The task must still have exactly two


### PR DESCRIPTION
When the user manually added a session with a different agent ("New Agent" button) and the active step had `on_turn_complete: move_to_step`, the original agent kept getting respawned after every turn the user-chosen agent completed.

Root cause: `maybySwitchSessionForProfile` fell back to `task.Metadata["agent_profile_id"]` (the task's original agent) whenever a step had no override, overriding the user's explicit choice. The fallback now only fires when the current session itself was spawned by a previous step's override — user-created sessions are tagged so the handler can tell them apart.

## Validation

- `go test ./internal/orchestrator/...` (702 passed)
- `make lint` (0 issues)
- `pnpm --filter @kandev/web typecheck lint` (clean)
- New unit tests in `event_handlers_workflow_profile_test.go`: regression case (user-chosen session preserved) and inverse case (workflow-spawned session still reverts to task default)
- New e2e regression in `workflow-agent-switch.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.

Closes #938