### PR TITLE
docs(skills): capture commit + pr-fixup learnings from #935

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -37,6 +37,7 @@ type: lowercase description
 - Include PR/issue number when relevant: `feat: add release notes (#295)`
 - Breaking changes: add `!` after type: `feat!: remove legacy API`
 - Keep the first line under 72 characters
+- **Body lines must be ≤100 characters** (commitlint `body-max-line-length`). Hard-wrap bullet points before committing; long URLs or prose lines that exceed 100 chars will fail the hook with `body's lines must not be longer than 100 characters`. If a HEREDOC body fails, re-wrap and create a *new* commit — do not amend.
 
 ## Examples
 

--- a/.agents/skills/pr-fixup/SKILL.md
+++ b/.agents/skills/pr-fixup/SKILL.md
@@ -245,6 +245,12 @@ After the push, CI restarts and bots may re-review. Delegate to `pr-poller` agai
 - If new review comments appeared after the push → loop back to task 3.
 - If the poller hit its cap (`recommendation:` mentions "timed out") → surface the remaining pending items to the user and stop.
 
+**Force-push (rebase) can re-open previously resolved inline threads.** GitHub treats the new commit's diff as a fresh review surface, so threads you already replied-to-and-resolved may come back unresolved with their original bodies. Before re-fixing, fetch the comments and check the body — if the issue is already addressed in the new tip, reply "Already fixed in `<sha>`" and resolve again rather than re-implementing.
+
+**Mergeable status lags after a force-push.** `gh pr view --json mergeable` can show `CONFLICTING` / `mergeStateStatus: DIRTY` for ~5-10s while GitHub recomputes against the new tip. Wait briefly before deciding there's a real conflict, and confirm with `git fetch origin main && git diff --name-only HEAD origin/main` locally.
+
+**Polling that times out is often a "main moved" signal.** A 20-min E2E window is long enough for `main` to ship one or two PRs. Before the next iteration, run `git fetch origin main && git log HEAD..origin/main --oneline` — a non-empty result means a rebase is coming. Rebase, force-push, and re-poll once rather than chasing flaky test reruns.
+
 Cap re-check loops at **3 iterations** to prevent runaway sessions. After 3, surface the remaining state to the user and stop.
 
 Mark task 6 as completed.


### PR DESCRIPTION
Long PRs that go through CodeRabbit/Greptile/Claude/cubic and burn through E2E retries surface predictable friction (reopened review threads after force-push, mergeable-status lag, main moving mid-poll, commitlint body limits). Recording the patterns once so future `/commit` and `/pr-fixup` runs don't rediscover them.

## Important Changes

- `commit` skill rules: document the commitlint `body-max-line-length: 100` constraint. Bulleted bodies hit it routinely; the fix is hard-wrapping and re-committing (not amending).
- `pr-fixup` Step 6: add three pragmatic notes — force-pushes can reopen previously-resolved inline threads, `gh pr view --json mergeable` lags ~5-10s after a push, and a 20-min poll cap is often "main has shipped" rather than "test flake".

## Validation

- Skill files only; no code touched. No CI relevance beyond markdown.
- Reviewed both SKILL.md files after edit for prettiness.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-943-bwo7.sprites.app |
| **Commit** | `984405a` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->