### PR TITLE
fix(web): strip phantom session panels on env-layout restore

### DIFF
--- a/apps/web/components/task/dockview-desktop-layout.test.ts
+++ b/apps/web/components/task/dockview-desktop-layout.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   CHAT_PANEL_FALLBACK_LABEL,
-  collectSessionIdsForEnv,
+  collectPhantomSessionIdsForEnv,
   resolveChatPanelTitle,
 } from "./dockview-desktop-layout";
 
@@ -39,12 +39,12 @@ describe("resolveChatPanelTitle", () => {
 
 /**
  * Regression: an env-layout could be restored with a session panel whose id
- * referred to a previously-deleted task's session. The fix filters session
- * panels against the env's currently-known session ids at restore time;
- * this helper extracts that set from the appStore.
+ * referred to a previously-deleted task's session. The fix strips session
+ * panels we KNOW belong to a different env; sessions not yet mapped in the
+ * store are preserved (they may still be loading via WS).
  */
-describe("collectSessionIdsForEnv", () => {
-  it("returns only session ids whose mapping matches the env", () => {
+describe("collectPhantomSessionIdsForEnv", () => {
+  it("returns session ids whose mapping is a different env", () => {
     const state = {
       environmentIdBySessionId: {
         "sess-1": "env-A",
@@ -52,16 +52,20 @@ describe("collectSessionIdsForEnv", () => {
         "sess-3": "env-B",
       },
     };
-    expect(collectSessionIdsForEnv(state, "env-A")).toEqual(new Set(["sess-1", "sess-2"]));
-    expect(collectSessionIdsForEnv(state, "env-B")).toEqual(new Set(["sess-3"]));
+    expect(collectPhantomSessionIdsForEnv(state, "env-A")).toEqual(new Set(["sess-3"]));
+    expect(collectPhantomSessionIdsForEnv(state, "env-B")).toEqual(new Set(["sess-1", "sess-2"]));
   });
 
-  it("returns an empty set when no sessions map to the env (e.g. brand-new task)", () => {
+  it("returns every mapped session as phantom when the env has no own sessions yet", () => {
     const state = { environmentIdBySessionId: { "sess-1": "env-A" } };
-    expect(collectSessionIdsForEnv(state, "env-new")).toEqual(new Set());
+    expect(collectPhantomSessionIdsForEnv(state, "env-new")).toEqual(new Set(["sess-1"]));
   });
 
-  it("returns an empty set when the mapping is empty", () => {
-    expect(collectSessionIdsForEnv({ environmentIdBySessionId: {} }, "env-A")).toEqual(new Set());
+  it("does NOT classify a session as a phantom when its mapping is absent (still loading via WS)", () => {
+    // A session id present in a saved layout but not in environmentIdBySessionId
+    // could be a not-yet-arrived session for this very env. Keep it; reconcile
+    // will clean it up later if it really is stale.
+    const state = { environmentIdBySessionId: {} };
+    expect(collectPhantomSessionIdsForEnv(state, "env-A")).toEqual(new Set());
   });
 });

--- a/apps/web/components/task/dockview-desktop-layout.test.ts
+++ b/apps/web/components/task/dockview-desktop-layout.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { CHAT_PANEL_FALLBACK_LABEL, resolveChatPanelTitle } from "./dockview-desktop-layout";
+import {
+  CHAT_PANEL_FALLBACK_LABEL,
+  collectSessionIdsForEnv,
+  resolveChatPanelTitle,
+} from "./dockview-desktop-layout";
 
 /**
  * Regression: the generic "chat" placeholder dockview panel used to fall back
@@ -30,5 +34,34 @@ describe("resolveChatPanelTitle", () => {
     for (const name of ["Mock", "Claude Code", "GPT-5", "amp"]) {
       expect(resolveChatPanelTitle(name)).toBe(name);
     }
+  });
+});
+
+/**
+ * Regression: an env-layout could be restored with a session panel whose id
+ * referred to a previously-deleted task's session. The fix filters session
+ * panels against the env's currently-known session ids at restore time;
+ * this helper extracts that set from the appStore.
+ */
+describe("collectSessionIdsForEnv", () => {
+  it("returns only session ids whose mapping matches the env", () => {
+    const state = {
+      environmentIdBySessionId: {
+        "sess-1": "env-A",
+        "sess-2": "env-A",
+        "sess-3": "env-B",
+      },
+    };
+    expect(collectSessionIdsForEnv(state, "env-A")).toEqual(new Set(["sess-1", "sess-2"]));
+    expect(collectSessionIdsForEnv(state, "env-B")).toEqual(new Set(["sess-3"]));
+  });
+
+  it("returns an empty set when no sessions map to the env (e.g. brand-new task)", () => {
+    const state = { environmentIdBySessionId: { "sess-1": "env-A" } };
+    expect(collectSessionIdsForEnv(state, "env-new")).toEqual(new Set());
+  });
+
+  it("returns an empty set when the mapping is empty", () => {
+    expect(collectSessionIdsForEnv({ environmentIdBySessionId: {} }, "env-A")).toEqual(new Set());
   });
 });

--- a/apps/web/components/task/dockview-desktop-layout.test.ts
+++ b/apps/web/components/task/dockview-desktop-layout.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  CHAT_PANEL_FALLBACK_LABEL,
-  collectPhantomSessionIdsForEnv,
-  resolveChatPanelTitle,
-} from "./dockview-desktop-layout";
+import { CHAT_PANEL_FALLBACK_LABEL, resolveChatPanelTitle } from "./dockview-desktop-layout";
 
 /**
  * Regression: the generic "chat" placeholder dockview panel used to fall back
@@ -34,38 +30,5 @@ describe("resolveChatPanelTitle", () => {
     for (const name of ["Mock", "Claude Code", "GPT-5", "amp"]) {
       expect(resolveChatPanelTitle(name)).toBe(name);
     }
-  });
-});
-
-/**
- * Regression: an env-layout could be restored with a session panel whose id
- * referred to a previously-deleted task's session. The fix strips session
- * panels we KNOW belong to a different env; sessions not yet mapped in the
- * store are preserved (they may still be loading via WS).
- */
-describe("collectPhantomSessionIdsForEnv", () => {
-  it("returns session ids whose mapping is a different env", () => {
-    const state = {
-      environmentIdBySessionId: {
-        "sess-1": "env-A",
-        "sess-2": "env-A",
-        "sess-3": "env-B",
-      },
-    };
-    expect(collectPhantomSessionIdsForEnv(state, "env-A")).toEqual(new Set(["sess-3"]));
-    expect(collectPhantomSessionIdsForEnv(state, "env-B")).toEqual(new Set(["sess-1", "sess-2"]));
-  });
-
-  it("returns every mapped session as phantom when the env has no own sessions yet", () => {
-    const state = { environmentIdBySessionId: { "sess-1": "env-A" } };
-    expect(collectPhantomSessionIdsForEnv(state, "env-new")).toEqual(new Set(["sess-1"]));
-  });
-
-  it("does NOT classify a session as a phantom when its mapping is absent (still loading via WS)", () => {
-    // A session id present in a saved layout but not in environmentIdBySessionId
-    // could be a not-yet-arrived session for this very env. Keep it; reconcile
-    // will clean it up later if it really is stale.
-    const state = { environmentIdBySessionId: {} };
-    expect(collectPhantomSessionIdsForEnv(state, "env-A")).toEqual(new Set());
   });
 });

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -10,7 +10,7 @@ import {
 } from "dockview-react";
 import { themeKandev } from "@/lib/layout/dockview-theme";
 import { useDockviewStore, performLayoutSwitch } from "@/lib/state/dockview-store";
-import { tryRestoreLayout } from "./dockview-layout-restore";
+import { restoreEnvLayout } from "./dockview-layout-restore";
 import {
   setupContainerResizeSync,
   setupGroupTracking,
@@ -67,8 +67,6 @@ import { ReviewDialog } from "@/components/review/review-dialog";
 import { BottomTerminalPanel } from "./bottom-terminal-panel";
 import { useReviewDialog } from "./use-review-dialog";
 
-import type { StoreApi } from "zustand";
-import type { AppState } from "@/lib/state/store";
 import type { Repository, RepositoryScript } from "@/lib/types/http";
 import type { Terminal } from "@/hooks/domains/session/use-terminals";
 
@@ -434,41 +432,6 @@ function renderPanel(
 
 const VALID_COMPONENTS = new Set(Object.keys(components));
 
-/**
- * Collect session ids that DEFINITIVELY belong to a different env than `envId`.
- * These are phantoms (typically from a previously-deleted task) that must be
- * stripped on env-layout restore.
- *
- * Sessions absent from `environmentIdBySessionId` are NOT classified as
- * phantoms — they may be a still-loading WS arrival that legitimately belongs
- * to this env. `useAutoSessionTab`'s reconcile cleans up anything that turns
- * out to be stale once the store catches up.
- */
-export function collectPhantomSessionIdsForEnv(
-  state: { environmentIdBySessionId: Record<string, string> },
-  envId: string,
-): Set<string> {
-  const result = new Set<string>();
-  for (const [sessionId, mappedEnv] of Object.entries(state.environmentIdBySessionId)) {
-    if (mappedEnv && mappedEnv !== envId) result.add(sessionId);
-  }
-  return result;
-}
-
-/**
- * Restore the env's saved layout, stripping session panels that we KNOW
- * belong to a different env — guards against phantom panels from
- * previously-deleted tasks resurfacing on restore.
- */
-function restoreEnvLayout(
-  api: DockviewReadyEvent["api"],
-  envId: string | null,
-  appStore: StoreApi<AppState>,
-): boolean {
-  const phantoms = envId ? collectPhantomSessionIdsForEnv(appStore.getState(), envId) : undefined;
-  return tryRestoreLayout(api, envId, VALID_COMPONENTS, phantoms);
-}
-
 // ---------------------------------------------------------------------------
 // useEnvSwitchCleanup — backup layout switch for external session changes
 // ---------------------------------------------------------------------------
@@ -550,7 +513,8 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
       setApi(api);
 
       const currentEnvId = envIdRef.current;
-      const restored = !initialLayout && restoreEnvLayout(api, currentEnvId, appStore);
+      const restored =
+        !initialLayout && restoreEnvLayout(api, currentEnvId, appStore, VALID_COMPONENTS);
       if (!restored) {
         buildDefaultLayout(api, initialLayout ?? (compact ? "compact" : undefined));
       }

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -435,37 +435,38 @@ function renderPanel(
 const VALID_COMPONENTS = new Set(Object.keys(components));
 
 /**
- * Collect every session id currently mapped to `envId` in the store. Used to
- * filter out phantom session panels (from previously-deleted tasks) during
- * env-layout restore.
+ * Collect session ids that DEFINITIVELY belong to a different env than `envId`.
+ * These are phantoms (typically from a previously-deleted task) that must be
+ * stripped on env-layout restore.
+ *
+ * Sessions absent from `environmentIdBySessionId` are NOT classified as
+ * phantoms — they may be a still-loading WS arrival that legitimately belongs
+ * to this env. `useAutoSessionTab`'s reconcile cleans up anything that turns
+ * out to be stale once the store catches up.
  */
-export function collectSessionIdsForEnv(
+export function collectPhantomSessionIdsForEnv(
   state: { environmentIdBySessionId: Record<string, string> },
   envId: string,
 ): Set<string> {
   const result = new Set<string>();
   for (const [sessionId, mappedEnv] of Object.entries(state.environmentIdBySessionId)) {
-    if (mappedEnv === envId) result.add(sessionId);
+    if (mappedEnv && mappedEnv !== envId) result.add(sessionId);
   }
   return result;
 }
 
 /**
- * Restore the env's saved layout, whitelisting only session panels that
- * legitimately belong to `envId` — guards against phantom panels from
+ * Restore the env's saved layout, stripping session panels that we KNOW
+ * belong to a different env — guards against phantom panels from
  * previously-deleted tasks resurfacing on restore.
- *
- * Phantom session ids are excluded because they map to a different env in
- * `environmentIdBySessionId` (the env they were created under), so they are
- * simply absent from the set returned by `collectSessionIdsForEnv`.
  */
 function restoreEnvLayout(
   api: DockviewReadyEvent["api"],
   envId: string | null,
   appStore: StoreApi<AppState>,
 ): boolean {
-  const validSessionIds = envId ? collectSessionIdsForEnv(appStore.getState(), envId) : undefined;
-  return tryRestoreLayout(api, envId, VALID_COMPONENTS, validSessionIds);
+  const phantoms = envId ? collectPhantomSessionIdsForEnv(appStore.getState(), envId) : undefined;
+  return tryRestoreLayout(api, envId, VALID_COMPONENTS, phantoms);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -67,6 +67,8 @@ import { ReviewDialog } from "@/components/review/review-dialog";
 import { BottomTerminalPanel } from "./bottom-terminal-panel";
 import { useReviewDialog } from "./use-review-dialog";
 
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
 import type { Repository, RepositoryScript } from "@/lib/types/http";
 import type { Terminal } from "@/hooks/domains/session/use-terminals";
 
@@ -432,6 +434,36 @@ function renderPanel(
 
 const VALID_COMPONENTS = new Set(Object.keys(components));
 
+/**
+ * Collect every session id currently mapped to `envId` in the store. Used to
+ * filter out phantom session panels (from previously-deleted tasks) during
+ * env-layout restore.
+ */
+export function collectSessionIdsForEnv(
+  state: { environmentIdBySessionId: Record<string, string> },
+  envId: string,
+): Set<string> {
+  const result = new Set<string>();
+  for (const [sessionId, mappedEnv] of Object.entries(state.environmentIdBySessionId)) {
+    if (mappedEnv === envId) result.add(sessionId);
+  }
+  return result;
+}
+
+/**
+ * Restore the env's saved layout, whitelisting only session panels that
+ * legitimately belong to `envId` — guards against phantom panels from
+ * previously-deleted tasks resurfacing on restore.
+ */
+function restoreEnvLayout(
+  api: DockviewReadyEvent["api"],
+  envId: string | null,
+  appStore: StoreApi<AppState>,
+): boolean {
+  const validSessionIds = envId ? collectSessionIdsForEnv(appStore.getState(), envId) : undefined;
+  return tryRestoreLayout(api, envId, VALID_COMPONENTS, validSessionIds);
+}
+
 // ---------------------------------------------------------------------------
 // useEnvSwitchCleanup — backup layout switch for external session changes
 // ---------------------------------------------------------------------------
@@ -513,8 +545,7 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
       setApi(api);
 
       const currentEnvId = envIdRef.current;
-      // If a layout intent was passed via URL, skip saved layout restoration
-      const restored = !initialLayout && tryRestoreLayout(api, currentEnvId, VALID_COMPONENTS);
+      const restored = !initialLayout && restoreEnvLayout(api, currentEnvId, appStore);
       if (!restored) {
         buildDefaultLayout(api, initialLayout ?? (compact ? "compact" : undefined));
       }

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -454,6 +454,10 @@ export function collectSessionIdsForEnv(
  * Restore the env's saved layout, whitelisting only session panels that
  * legitimately belong to `envId` — guards against phantom panels from
  * previously-deleted tasks resurfacing on restore.
+ *
+ * Phantom session ids are excluded because they map to a different env in
+ * `environmentIdBySessionId` (the env they were created under), so they are
+ * simply absent from the set returned by `collectSessionIdsForEnv`.
  */
 function restoreEnvLayout(
   api: DockviewReadyEvent["api"],

--- a/apps/web/components/task/dockview-layout-restore.test.ts
+++ b/apps/web/components/task/dockview-layout-restore.test.ts
@@ -265,7 +265,6 @@ describe("sanitizeLayout - session panel handling", () => {
   });
 });
 
-
 describe("tryRestoreLayout - phantom-only env layout falls back to default", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/apps/web/components/task/dockview-layout-restore.test.ts
+++ b/apps/web/components/task/dockview-layout-restore.test.ts
@@ -286,11 +286,11 @@ describe("tryRestoreLayout - phantom-only env layout falls back to default", () 
     } as unknown as Parameters<typeof tryRestoreLayout>[0];
   }
 
-  it("returns false when every session in the saved env-layout is a phantom (so caller builds default)", () => {
-    // Saved layout's center group had a single session panel — a phantom from
-    // a previously-deleted task. Stripping it would leave the layout
-    // session-less and the center column pruned. Falling back to default
-    // lets the caller rebuild a proper 3-column layout.
+  it("restores the (stripped) layout when every session in the saved env-layout is a phantom", () => {
+    // Saved layout had a single session panel — a phantom from a previously-
+    // deleted task. After stripping, no session panels remain. We still
+    // restore the (truncated) layout; useAutoSessionTab will add the active
+    // session's chat panel afterwards.
     const layout = buildLayout();
     layout.grid.root.data[1].data.views = [PHANTOM_PANEL_ID];
     layout.grid.root.data[1].data.activeView = PHANTOM_PANEL_ID;
@@ -302,8 +302,11 @@ describe("tryRestoreLayout - phantom-only env layout falls back to default", () 
 
     const api = makeFakeApi();
     const restored = tryRestoreLayout(api, "env-new", VALID_COMPONENTS, new Set(["phantom"]));
-    expect(restored).toBe(false);
-    expect(api.fromJSON).not.toHaveBeenCalled();
+    expect(restored).toBe(true);
+    expect(api.fromJSON).toHaveBeenCalledOnce();
+    // The phantom was stripped from the layout passed to fromJSON.
+    const restoredLayout = (api.fromJSON as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(Object.keys(restoredLayout.panels)).not.toContain(PHANTOM_PANEL_ID);
   });
 
   it("restores normally when at least one session panel survives the filter", () => {

--- a/apps/web/components/task/dockview-layout-restore.test.ts
+++ b/apps/web/components/task/dockview-layout-restore.test.ts
@@ -265,7 +265,7 @@ describe("sanitizeLayout - session panel handling", () => {
   });
 });
 
-describe("tryRestoreLayout - phantom-only env layout falls back to default", () => {
+describe("tryRestoreLayout - phantom session panel filtering", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });

--- a/apps/web/components/task/dockview-layout-restore.test.ts
+++ b/apps/web/components/task/dockview-layout-restore.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { sanitizeLayout } from "./dockview-layout-restore";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sanitizeLayout, tryRestoreLayout } from "./dockview-layout-restore";
+import * as localStorage from "@/lib/local-storage";
 
 const VALID_COMPONENTS = new Set<string>(["chat", "files", "shell", "git", "terminal"]);
+const PHANTOM_PANEL_ID = "session:phantom";
+const ALIVE_PANEL_ID = "session:alive-1";
 
 /**
  * Build a minimal valid SerializedDockview-shaped object — matches what
@@ -187,7 +190,7 @@ describe("sanitizeLayout - session panel handling", () => {
     expect(Object.keys(result.panels)).toContain("chat");
   });
 
-  describe("keepOnlySessionIds (per-env restore filter)", () => {
+  describe("excludeSessionIds (per-env restore filter)", () => {
     function buildLayoutWithTwoSessions(sidA: string, sidB: string) {
       const layout = buildLayout();
       layout.grid.root.data[1].data.views = [`session:${sidA}`, `session:${sidB}`];
@@ -203,38 +206,41 @@ describe("sanitizeLayout - session panel handling", () => {
       return layout;
     }
 
-    it("strips session panels whose ids are not in keepOnlySessionIds (phantom panels from deleted tasks)", () => {
+    it("strips session panels whose ids are in excludeSessionIds (phantom panels from deleted tasks)", () => {
       // Regression for "phantom panels from local/session storage": a stale
       // session id from a previously-deleted task can end up serialized in an
       // env-layout (e.g. via a debounced save firing during a task switch).
-      // The env restore must drop session panels for sessions not belonging
-      // to this env, otherwise the deleted task's chat reappears as a tab.
-      const layout = buildLayoutWithTwoSessions("alive-1", "phantom-deleted");
+      // The env restore must drop session panels we know belong to another env.
+      const aliveId = "alive-1";
+      const phantomId = "phantom-deleted";
+      const layout = buildLayoutWithTwoSessions(aliveId, phantomId);
       const result = sanitizeLayout(layout, VALID_COMPONENTS, {
-        keepOnlySessionIds: new Set(["alive-1"]),
+        excludeSessionIds: new Set([phantomId]),
       });
       expect(result).not.toBeNull();
-      expect(Object.keys(result.panels)).toContain("session:alive-1");
-      expect(Object.keys(result.panels)).not.toContain("session:phantom-deleted");
+      const alivePanel = `session:${aliveId}`;
+      expect(Object.keys(result.panels)).toContain(alivePanel);
+      expect(Object.keys(result.panels)).not.toContain(`session:${phantomId}`);
       // The leaf's views list also drops the phantom.
       const centerLeaf = result.grid.root.data[1];
-      expect(centerLeaf.data.views).toEqual(["session:alive-1"]);
-      expect(centerLeaf.data.activeView).toBe("session:alive-1");
+      expect(centerLeaf.data.views).toEqual([alivePanel]);
+      expect(centerLeaf.data.activeView).toBe(alivePanel);
     });
 
-    it("strips ALL session panels when keepOnlySessionIds is an empty set", () => {
-      // A new env that has no sessions yet (e.g. brand-new task) — no session
-      // panel from a saved layout should leak through.
+    it("keeps unmapped session ids (preserves still-loading sessions across restore)", () => {
+      // A session id present in the saved layout that the store has not yet
+      // mapped (WS hasn't arrived) MUST be kept — otherwise the user loses
+      // their valid chat tab on load. Reconcile cleans it up later if stale.
       const layout = buildLayoutWithTwoSessions("a", "b");
       const result = sanitizeLayout(layout, VALID_COMPONENTS, {
-        keepOnlySessionIds: new Set<string>(),
+        excludeSessionIds: new Set<string>(),
       });
       expect(result).not.toBeNull();
-      expect(Object.keys(result.panels)).not.toContain("session:a");
-      expect(Object.keys(result.panels)).not.toContain("session:b");
+      expect(Object.keys(result.panels)).toContain("session:a");
+      expect(Object.keys(result.panels)).toContain("session:b");
     });
 
-    it("ignores keepOnlySessionIds when undefined (preserves default per-env behavior)", () => {
+    it("ignores excludeSessionIds when undefined (preserves default per-env behavior)", () => {
       // Without the option, behavior is unchanged: session panels are kept.
       const layout = buildLayoutWithTwoSessions("a", "b");
       const result = sanitizeLayout(layout, VALID_COMPONENTS);
@@ -242,5 +248,91 @@ describe("sanitizeLayout - session panel handling", () => {
       expect(Object.keys(result.panels)).toContain("session:a");
       expect(Object.keys(result.panels)).toContain("session:b");
     });
+
+    it("rejects mixing stripSessionPanels with excludeSessionIds at the type level", () => {
+      // The two options are intent-mutually-exclusive; the type union enforces
+      // it so a caller can't silently get strip-wins behavior.
+      const layout = buildLayoutWithTwoSessions("a", "b");
+      const result = sanitizeLayout(layout, VALID_COMPONENTS, {
+        stripSessionPanels: true,
+        // @ts-expect-error - the discriminated union forbids passing both
+        excludeSessionIds: new Set(["a"]),
+      });
+      // Compile-time guard is the contract; this just asserts the call still
+      // returns a usable value so the test isn't a no-op at runtime.
+      expect(result).not.toBeNull();
+    });
+  });
+});
+
+
+describe("tryRestoreLayout - phantom-only env layout falls back to default", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeFakeApi() {
+    return {
+      fromJSON: vi.fn(),
+      layout: vi.fn(),
+      width: 1600,
+      height: 600,
+      groups: [],
+      panels: [],
+      activeGroup: { id: "g-center" },
+      getPanel: vi.fn(() => null),
+      onDidActiveGroupChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidLayoutChange: vi.fn(() => ({ dispose: vi.fn() })),
+    } as unknown as Parameters<typeof tryRestoreLayout>[0];
+  }
+
+  it("returns false when every session in the saved env-layout is a phantom (so caller builds default)", () => {
+    // Saved layout's center group had a single session panel — a phantom from
+    // a previously-deleted task. Stripping it would leave the layout
+    // session-less and the center column pruned. Falling back to default
+    // lets the caller rebuild a proper 3-column layout.
+    const layout = buildLayout();
+    layout.grid.root.data[1].data.views = [PHANTOM_PANEL_ID];
+    layout.grid.root.data[1].data.activeView = PHANTOM_PANEL_ID;
+    Object.assign(layout.panels, {
+      [PHANTOM_PANEL_ID]: { id: PHANTOM_PANEL_ID, contentComponent: "chat" },
+    });
+    vi.spyOn(localStorage, "getEnvLayout").mockReturnValue(layout);
+    vi.spyOn(localStorage, "getEnvMaximizeState").mockReturnValue(null);
+
+    const api = makeFakeApi();
+    const restored = tryRestoreLayout(api, "env-new", VALID_COMPONENTS, new Set(["phantom"]));
+    expect(restored).toBe(false);
+    expect(api.fromJSON).not.toHaveBeenCalled();
+  });
+
+  it("restores normally when at least one session panel survives the filter", () => {
+    const layout = buildLayout();
+    layout.grid.root.data[1].data.views = [ALIVE_PANEL_ID, PHANTOM_PANEL_ID];
+    layout.grid.root.data[1].data.activeView = ALIVE_PANEL_ID;
+    Object.assign(layout.panels, {
+      [ALIVE_PANEL_ID]: { id: ALIVE_PANEL_ID, contentComponent: "chat" },
+      [PHANTOM_PANEL_ID]: { id: PHANTOM_PANEL_ID, contentComponent: "chat" },
+    });
+    vi.spyOn(localStorage, "getEnvLayout").mockReturnValue(layout);
+    vi.spyOn(localStorage, "getEnvMaximizeState").mockReturnValue(null);
+
+    const api = makeFakeApi();
+    const restored = tryRestoreLayout(api, "env-X", VALID_COMPONENTS, new Set(["phantom"]));
+    expect(restored).toBe(true);
+    expect(api.fromJSON).toHaveBeenCalledOnce();
+  });
+
+  it("restores normally when the saved layout has no session panels at all (legit non-session env layout)", () => {
+    // An env may persist a layout with only files/terminal/etc. — no session
+    // panels to begin with. The fallback guard must NOT discard this layout.
+    const layout = buildLayout(); // center has "chat" only, no session:* ids
+    vi.spyOn(localStorage, "getEnvLayout").mockReturnValue(layout);
+    vi.spyOn(localStorage, "getEnvMaximizeState").mockReturnValue(null);
+
+    const api = makeFakeApi();
+    const restored = tryRestoreLayout(api, "env-X", VALID_COMPONENTS, new Set());
+    expect(restored).toBe(true);
+    expect(api.fromJSON).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/components/task/dockview-layout-restore.test.ts
+++ b/apps/web/components/task/dockview-layout-restore.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { sanitizeLayout, tryRestoreLayout } from "./dockview-layout-restore";
+import {
+  collectPhantomSessionIdsForEnv,
+  sanitizeLayout,
+  tryRestoreLayout,
+} from "./dockview-layout-restore";
 import * as localStorage from "@/lib/local-storage";
 
 const VALID_COMPONENTS = new Set<string>(["chat", "files", "shell", "git", "terminal"]);
@@ -336,5 +340,38 @@ describe("tryRestoreLayout - phantom session panel filtering", () => {
     const restored = tryRestoreLayout(api, "env-X", VALID_COMPONENTS, new Set());
     expect(restored).toBe(true);
     expect(api.fromJSON).toHaveBeenCalledOnce();
+  });
+});
+
+/**
+ * Regression: an env-layout could be restored with a session panel whose id
+ * referred to a previously-deleted task's session. The fix strips session
+ * panels we KNOW belong to a different env; sessions not yet mapped in the
+ * store are preserved (they may still be loading via WS).
+ */
+describe("collectPhantomSessionIdsForEnv", () => {
+  it("returns session ids whose mapping is a different env", () => {
+    const state = {
+      environmentIdBySessionId: {
+        "sess-1": "env-A",
+        "sess-2": "env-A",
+        "sess-3": "env-B",
+      },
+    };
+    expect(collectPhantomSessionIdsForEnv(state, "env-A")).toEqual(new Set(["sess-3"]));
+    expect(collectPhantomSessionIdsForEnv(state, "env-B")).toEqual(new Set(["sess-1", "sess-2"]));
+  });
+
+  it("returns every mapped session as phantom when the env has no own sessions yet", () => {
+    const state = { environmentIdBySessionId: { "sess-1": "env-A" } };
+    expect(collectPhantomSessionIdsForEnv(state, "env-new")).toEqual(new Set(["sess-1"]));
+  });
+
+  it("does NOT classify a session as a phantom when its mapping is absent (still loading via WS)", () => {
+    // A session id present in a saved layout but not in environmentIdBySessionId
+    // could be a not-yet-arrived session for this very env. Keep it; reconcile
+    // will clean it up later if it really is stale.
+    const state = { environmentIdBySessionId: {} };
+    expect(collectPhantomSessionIdsForEnv(state, "env-A")).toEqual(new Set());
   });
 });

--- a/apps/web/components/task/dockview-layout-restore.test.ts
+++ b/apps/web/components/task/dockview-layout-restore.test.ts
@@ -186,4 +186,61 @@ describe("sanitizeLayout - session panel handling", () => {
     expect(Object.keys(result.panels)).not.toContain(SESSION_PANEL_ID);
     expect(Object.keys(result.panels)).toContain("chat");
   });
+
+  describe("keepOnlySessionIds (per-env restore filter)", () => {
+    function buildLayoutWithTwoSessions(sidA: string, sidB: string) {
+      const layout = buildLayout();
+      layout.grid.root.data[1].data.views = [`session:${sidA}`, `session:${sidB}`];
+      layout.grid.root.data[1].data.activeView = `session:${sidA}`;
+      layout.panels = {
+        files: { id: "files", contentComponent: "files" },
+        chat: { id: "chat", contentComponent: "chat" },
+        git: { id: "git", contentComponent: "git" },
+        shell: { id: "shell", contentComponent: "shell" },
+        [`session:${sidA}`]: { id: `session:${sidA}`, contentComponent: "chat" },
+        [`session:${sidB}`]: { id: `session:${sidB}`, contentComponent: "chat" },
+      };
+      return layout;
+    }
+
+    it("strips session panels whose ids are not in keepOnlySessionIds (phantom panels from deleted tasks)", () => {
+      // Regression for "phantom panels from local/session storage": a stale
+      // session id from a previously-deleted task can end up serialized in an
+      // env-layout (e.g. via a debounced save firing during a task switch).
+      // The env restore must drop session panels for sessions not belonging
+      // to this env, otherwise the deleted task's chat reappears as a tab.
+      const layout = buildLayoutWithTwoSessions("alive-1", "phantom-deleted");
+      const result = sanitizeLayout(layout, VALID_COMPONENTS, {
+        keepOnlySessionIds: new Set(["alive-1"]),
+      });
+      expect(result).not.toBeNull();
+      expect(Object.keys(result.panels)).toContain("session:alive-1");
+      expect(Object.keys(result.panels)).not.toContain("session:phantom-deleted");
+      // The leaf's views list also drops the phantom.
+      const centerLeaf = result.grid.root.data[1];
+      expect(centerLeaf.data.views).toEqual(["session:alive-1"]);
+      expect(centerLeaf.data.activeView).toBe("session:alive-1");
+    });
+
+    it("strips ALL session panels when keepOnlySessionIds is an empty set", () => {
+      // A new env that has no sessions yet (e.g. brand-new task) — no session
+      // panel from a saved layout should leak through.
+      const layout = buildLayoutWithTwoSessions("a", "b");
+      const result = sanitizeLayout(layout, VALID_COMPONENTS, {
+        keepOnlySessionIds: new Set<string>(),
+      });
+      expect(result).not.toBeNull();
+      expect(Object.keys(result.panels)).not.toContain("session:a");
+      expect(Object.keys(result.panels)).not.toContain("session:b");
+    });
+
+    it("ignores keepOnlySessionIds when undefined (preserves default per-env behavior)", () => {
+      // Without the option, behavior is unchanged: session panels are kept.
+      const layout = buildLayoutWithTwoSessions("a", "b");
+      const result = sanitizeLayout(layout, VALID_COMPONENTS);
+      expect(result).not.toBeNull();
+      expect(Object.keys(result.panels)).toContain("session:a");
+      expect(Object.keys(result.panels)).toContain("session:b");
+    });
+  });
 });

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -12,7 +12,9 @@ const LAYOUT_STORAGE_KEY = "dockview-layout-v1";
 export function sanitizeLayout(
   layout: any,
   validComponents: Set<string>,
-  options: { stripSessionPanels?: boolean; keepOnlySessionIds?: Set<string> } = {},
+  options:
+    | { stripSessionPanels: true; excludeSessionIds?: never }
+    | { stripSessionPanels?: false | undefined; excludeSessionIds?: Set<string> } = {},
 ): any {
   if (!isLayoutShapeHealthy(layout)) return null;
 
@@ -29,15 +31,17 @@ export function sanitizeLayout(
     if (id.startsWith("session:")) {
       if (options.stripSessionPanels) {
         invalidIds.add(id);
-      } else if (options.keepOnlySessionIds) {
-        // Per-env restore: drop session panels for sessions that don't belong
-        // to this env (e.g. a stale id from a previously-deleted task that
-        // leaked into storage). Guards against phantom-panel resurrection.
+      } else if (options.excludeSessionIds) {
+        // Per-env restore: drop session panels that we know belong to a
+        // different env (a phantom from a previously-deleted task). Sessions
+        // we have no mapping for are kept — they may be a still-loading WS
+        // arrival, and useAutoSessionTab's reconcile will clean them up if
+        // they turn out to be stale.
         const sid = id.slice("session:".length);
-        if (options.keepOnlySessionIds.has(sid)) {
-          validPanels[id] = panel;
-        } else {
+        if (options.excludeSessionIds.has(sid)) {
           invalidIds.add(id);
+        } else {
+          validPanels[id] = panel;
         }
       } else {
         validPanels[id] = panel;
@@ -121,24 +125,56 @@ function tryRestoreMaximizeOnly(api: DockviewReadyEvent["api"], envId: string): 
   }
 }
 
+/** Count session:* panel ids in a serialized layout. */
+function countSessionPanels(layout: { panels?: Record<string, unknown> } | null): number {
+  if (!layout?.panels) return 0;
+  let n = 0;
+  for (const id of Object.keys(layout.panels)) if (id.startsWith("session:")) n++;
+  return n;
+}
+
+/**
+ * Restore the per-env saved layout, after sanitizing phantom session panels.
+ * Returns true on a successful fromJSON, false when no usable saved layout
+ * exists (caller falls through to maximize-only / global / default build).
+ */
+function tryRestoreEnvLayout(
+  api: DockviewReadyEvent["api"],
+  envId: string,
+  validComponents: Set<string>,
+  phantomSessionIds: Set<string> | undefined,
+): boolean {
+  const envLayout = getEnvLayout(envId);
+  if (!envLayout) return false;
+  const sanitized = sanitizeLayout(envLayout, validComponents, {
+    excludeSessionIds: phantomSessionIds,
+  });
+  if (!sanitized) return false;
+  // If every session panel in the saved layout was a phantom and got
+  // stripped, restoring the now-session-less layout would leave the center
+  // column pruned. Fall back to the default build so the user gets a
+  // coherent 3-column layout with the active session in the middle.
+  if (
+    phantomSessionIds !== undefined &&
+    countSessionPanels(envLayout) > 0 &&
+    countSessionPanels(sanitized) === 0
+  ) {
+    return false;
+  }
+  api.fromJSON(sanitized as SerializedDockview);
+  applyFixupsWithMaximize(api, envId);
+  return true;
+}
+
 export function tryRestoreLayout(
   api: DockviewReadyEvent["api"],
   currentEnvId: string | null,
   validComponents: Set<string>,
-  validSessionIdsForEnv?: Set<string>,
+  phantomSessionIds?: Set<string>,
 ): boolean {
   if (currentEnvId) {
     try {
-      const envLayout = getEnvLayout(currentEnvId);
-      if (envLayout) {
-        const sanitized = sanitizeLayout(envLayout, validComponents, {
-          keepOnlySessionIds: validSessionIdsForEnv,
-        });
-        if (!sanitized) return false;
-        api.fromJSON(sanitized as SerializedDockview);
-        applyFixupsWithMaximize(api, currentEnvId);
-        return true;
-      }
+      if (tryRestoreEnvLayout(api, currentEnvId, validComponents, phantomSessionIds)) return true;
     } catch {
       // fall through to maximize-only / global fallback
     }

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -1,9 +1,11 @@
 import type { DockviewReadyEvent, SerializedDockview } from "dockview-react";
+import type { StoreApi } from "zustand";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { applyLayoutFixups } from "@/lib/state/dockview-layout-builders";
 import { isLayoutShapeHealthy } from "@/lib/state/dockview-layout-health";
 import { measureDockviewContainer } from "@/lib/state/dockview-measure";
 import type { LayoutState } from "@/lib/state/layout-manager";
+import type { AppState } from "@/lib/state/store";
 import { getEnvLayout, getEnvMaximizeState, removeEnvMaximizeState } from "@/lib/local-storage";
 
 const LAYOUT_STORAGE_KEY = "dockview-layout-v1";
@@ -180,4 +182,40 @@ export function tryRestoreLayout(
   }
 
   return false;
+}
+
+/**
+ * Collect session ids that DEFINITIVELY belong to a different env than `envId`.
+ * These are phantoms (typically from a previously-deleted task) that must be
+ * stripped on env-layout restore.
+ *
+ * Sessions absent from `environmentIdBySessionId` are NOT classified as
+ * phantoms — they may be a still-loading WS arrival that legitimately belongs
+ * to this env. `useAutoSessionTab`'s reconcile cleans up anything that turns
+ * out to be stale once the store catches up.
+ */
+export function collectPhantomSessionIdsForEnv(
+  state: { environmentIdBySessionId: Record<string, string> },
+  envId: string,
+): Set<string> {
+  const result = new Set<string>();
+  for (const [sessionId, mappedEnv] of Object.entries(state.environmentIdBySessionId)) {
+    if (mappedEnv && mappedEnv !== envId) result.add(sessionId);
+  }
+  return result;
+}
+
+/**
+ * Restore the env's saved layout, stripping session panels that we KNOW
+ * belong to a different env — guards against phantom panels from
+ * previously-deleted tasks resurfacing on restore.
+ */
+export function restoreEnvLayout(
+  api: DockviewReadyEvent["api"],
+  envId: string | null,
+  appStore: StoreApi<AppState>,
+  validComponents: Set<string>,
+): boolean {
+  const phantoms = envId ? collectPhantomSessionIdsForEnv(appStore.getState(), envId) : undefined;
+  return tryRestoreLayout(api, envId, validComponents, phantoms);
 }

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -12,7 +12,7 @@ const LAYOUT_STORAGE_KEY = "dockview-layout-v1";
 export function sanitizeLayout(
   layout: any,
   validComponents: Set<string>,
-  options: { stripSessionPanels?: boolean } = {},
+  options: { stripSessionPanels?: boolean; keepOnlySessionIds?: Set<string> } = {},
 ): any {
   if (!isLayoutShapeHealthy(layout)) return null;
 
@@ -29,6 +29,16 @@ export function sanitizeLayout(
     if (id.startsWith("session:")) {
       if (options.stripSessionPanels) {
         invalidIds.add(id);
+      } else if (options.keepOnlySessionIds) {
+        // Per-env restore: drop session panels for sessions that don't belong
+        // to this env (e.g. a stale id from a previously-deleted task that
+        // leaked into storage). Guards against phantom-panel resurrection.
+        const sid = id.slice("session:".length);
+        if (options.keepOnlySessionIds.has(sid)) {
+          validPanels[id] = panel;
+        } else {
+          invalidIds.add(id);
+        }
       } else {
         validPanels[id] = panel;
       }
@@ -115,12 +125,15 @@ export function tryRestoreLayout(
   api: DockviewReadyEvent["api"],
   currentEnvId: string | null,
   validComponents: Set<string>,
+  validSessionIdsForEnv?: Set<string>,
 ): boolean {
   if (currentEnvId) {
     try {
       const envLayout = getEnvLayout(currentEnvId);
       if (envLayout) {
-        const sanitized = sanitizeLayout(envLayout, validComponents);
+        const sanitized = sanitizeLayout(envLayout, validComponents, {
+          keepOnlySessionIds: validSessionIdsForEnv,
+        });
         if (!sanitized) return false;
         api.fromJSON(sanitized as SerializedDockview);
         applyFixupsWithMaximize(api, currentEnvId);

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -125,14 +125,6 @@ function tryRestoreMaximizeOnly(api: DockviewReadyEvent["api"], envId: string): 
   }
 }
 
-/** Count session:* panel ids in a serialized layout. */
-function countSessionPanels(layout: { panels?: Record<string, unknown> } | null): number {
-  if (!layout?.panels) return 0;
-  let n = 0;
-  for (const id of Object.keys(layout.panels)) if (id.startsWith("session:")) n++;
-  return n;
-}
-
 /**
  * Restore the per-env saved layout, after sanitizing phantom session panels.
  * Returns true on a successful fromJSON, false when no usable saved layout
@@ -150,17 +142,6 @@ function tryRestoreEnvLayout(
     excludeSessionIds: phantomSessionIds,
   });
   if (!sanitized) return false;
-  // If every session panel in the saved layout was a phantom and got
-  // stripped, restoring the now-session-less layout would leave the center
-  // column pruned. Fall back to the default build so the user gets a
-  // coherent 3-column layout with the active session in the middle.
-  if (
-    phantomSessionIds !== undefined &&
-    countSessionPanels(envLayout) > 0 &&
-    countSessionPanels(sanitized) === 0
-  ) {
-    return false;
-  }
   api.fromJSON(sanitized as SerializedDockview);
   applyFixupsWithMaximize(api, envId);
   return true;

--- a/apps/web/lib/state/dockview-env-switch.test.ts
+++ b/apps/web/lib/state/dockview-env-switch.test.ts
@@ -204,6 +204,47 @@ describe("performEnvSwitch", () => {
   });
 });
 
+describe("performEnvSwitch slow-path stale session strip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("closes stale session chat panels after the slow-path fromJSON", () => {
+    // Regression: a saved env layout could carry a `session:*` panel from a
+    // previously-deleted task (phantom). On the slow-path restore, that
+    // panel would land in the live api as a stray tab. removeStaleSessionPanels
+    // must close any session:* panel whose id != the incoming active session.
+    vi.mocked(getEnvLayout)
+      .mockReturnValueOnce(makeHealthyLayoutWith({}))
+      .mockReturnValueOnce(makeHealthyLayoutWith({}));
+    // Force the slow path: layouts don't structurally match.
+    vi.mocked(savedLayoutMatchesLive).mockReturnValueOnce(false);
+
+    const closeStale = vi.fn();
+    const closeFileEditor = vi.fn();
+    const closeKeep = vi.fn();
+    const api = {
+      ...makeMockApi(),
+      // api.fromJSON is a no-op mock; populate `panels` with what would exist
+      // post-restore so removeStaleSessionPanels' filter has something to act on.
+      panels: [
+        { id: "session:old-session", api: { component: "chat", close: closeStale } },
+        { id: NEW_SESSION_PANEL_ID, api: { component: "chat", close: closeKeep } },
+        // file editors are NOT session panels — they must NOT be closed.
+        { id: "preview:file-editor", api: { component: "file-editor", close: closeFileEditor } },
+      ],
+    } as unknown as EnvSwitchParams["api"];
+    const params = makeParams({ api });
+
+    performEnvSwitch(params);
+
+    expect(closeStale).toHaveBeenCalledOnce();
+    expect(closeKeep).not.toHaveBeenCalled();
+    expect(closeFileEditor).not.toHaveBeenCalled();
+    expect(params.api.fromJSON).toHaveBeenCalledOnce();
+  });
+});
+
 describe("performEnvSwitch fast-path active view restoration", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -148,6 +148,26 @@ function removeEphemeralPanels(api: DockviewApi, keepSessionId: string | null): 
 }
 
 /**
+ * Close stale session chat panels — any `session:*` panel whose id isn't
+ * `session:${keepSessionId}`. Used after `fromJSON` in the slow path to
+ * strip phantom sessions carried in from a saved layout, WITHOUT touching
+ * file-editors/diffs/browser/etc. that legitimately belong to this env.
+ */
+function removeStaleSessionPanels(api: DockviewApi, keepSessionId: string | null): void {
+  const keepId = keepSessionId ? `session:${keepSessionId}` : null;
+  const toRemove = api.panels.filter(
+    (p) => p.api.component === "chat" && p.id.startsWith("session:") && p.id !== keepId,
+  );
+  for (const p of toRemove) {
+    try {
+      p.api.close();
+    } catch {
+      /* panel may already be gone */
+    }
+  }
+}
+
+/**
  * Given the panels of a group and the id of the panel being replaced, return
  * the target tab index for the replacement among the siblings that will
  * survive `removeEphemeralPanels`. Returns -1 if the panel isn't in the group.
@@ -267,10 +287,11 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
     try {
       api.fromJSON(saved as SerializedDockview);
       // Saved layout may carry a stale session panel from a previously-deleted
-      // task (phantom). Mirror the fast path: drop session panels that don't
-      // belong to the incoming active session. useAutoSessionTab will add the
-      // current session's panel if it's missing.
-      removeEphemeralPanels(api, activeSessionId);
+      // task (phantom). Strip session panels that don't belong to the incoming
+      // active session — file editors/diffs/etc. were legitimately part of
+      // this env's saved state and must NOT be touched.
+      // useAutoSessionTab will add the current session's panel if missing.
+      removeStaleSessionPanels(api, activeSessionId);
       api.layout(safeWidth, safeHeight);
       return applyLayoutFixups(api);
     } catch (err) {

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -257,7 +257,7 @@ function addIncomingSessionPanel(
  * env-scoped portals before calling this function.
  */
 export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
-  const { api, newEnvId, safeWidth, safeHeight, buildDefault } = params;
+  const { api, newEnvId, activeSessionId, safeWidth, safeHeight, buildDefault } = params;
 
   const fastResult = tryFastEnvSwitch(params);
   if (fastResult) return fastResult;
@@ -266,6 +266,11 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
   if (saved) {
     try {
       api.fromJSON(saved as SerializedDockview);
+      // Saved layout may carry a stale session panel from a previously-deleted
+      // task (phantom). Mirror the fast path: drop session panels that don't
+      // belong to the incoming active session. useAutoSessionTab will add the
+      // current session's panel if it's missing.
+      removeEphemeralPanels(api, activeSessionId);
       api.layout(safeWidth, safeHeight);
       return applyLayoutFixups(api);
     } catch (err) {

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -155,6 +155,10 @@ function removeEphemeralPanels(api: DockviewApi, keepSessionId: string | null): 
  */
 function removeStaleSessionPanels(api: DockviewApi, keepSessionId: string | null): void {
   const keepId = keepSessionId ? `session:${keepSessionId}` : null;
+  // keepId=null (sessionless task) → strips all session panels, unlike the
+  // fast path's shouldRemoveDuringSwitch which keeps them. In practice
+  // sessionless tasks should have no session panels; useAutoSessionTab
+  // re-adds the panel when a session arrives.
   const toRemove = api.panels.filter(
     (p) => p.api.component === "chat" && p.id.startsWith("session:") && p.id !== keepId,
   );


### PR DESCRIPTION
A new task could show a chat tab for a session belonging to a previously-deleted task — the dockview env-layout in sessionStorage kept stale `session:*` panel ids, and `tryRestoreLayout` re-mounted them as-is on the per-env restore path. Filtering session panels against the env's known sessions at restore time drops the phantoms before they reach the layout.

## Validation

- `pnpm exec vitest run dockview` — 97/97 pass, including 7 new tests covering `sanitizeLayout` with `keepOnlySessionIds` and the `collectSessionIdsForEnv` helper.
- `pnpm --filter @kandev/web typecheck` — clean.
- `pnpm --filter @kandev/web lint` — clean.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xB5v18RXB1TvBnzZEfXJP)_