### PR TITLE
fix(acp): stop inventing currentModelId from AvailableModels[0]

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -1474,6 +1474,10 @@ func (a *Adapter) emitSessionModels(sessionID string, models *acp.SessionModelSt
 func (a *Adapter) emitSetModelEvent(sessionID, modelID string, cachedModels []acp.ModelInfo, cachedConfig []streams.ConfigOption) {
 	outConfig := cachedConfig
 	if len(cachedConfig) > 0 {
+		// Shallow copy: only CurrentValue (a string) is rewritten below, so
+		// sharing the inner Options slice with the caller is safe today. If a
+		// future caller mutates ConfigOption.Options in place, switch to a
+		// deep copy to avoid aliasing the caller's backing array.
 		outConfig = make([]streams.ConfigOption, len(cachedConfig))
 		copy(outConfig, cachedConfig)
 		for i := range outConfig {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -154,6 +154,12 @@ type Adapter struct {
 	// frontend mode selector can render available options.
 	availableModes []streams.SessionModeInfo
 
+	// Available config options from the most recent session creation/load.
+	// Used by emitSetModelEvent to include cached options in the convergence
+	// event emitted after SetModel succeeds so the frontend doesn't lose
+	// the options list when the model is changed.
+	availableConfigOptions []streams.ConfigOption
+
 	// Synchronization
 	mu     sync.RWMutex
 	closed bool
@@ -1416,16 +1422,21 @@ func (a *Adapter) emitSessionModels(sessionID string, models *acp.SessionModelSt
 	}
 
 	// Fallback: if the SDK didn't parse currentModelId (some agents omit it),
-	// try to resolve it from configOptions or the first available model.
+	// try to resolve it from a model-shaped configOption. We deliberately do
+	// NOT fall back to AvailableModels[0]: agents like auggie return an
+	// alphabetically-sorted list whose first entry is a pseudo-agent ("Build
+	// Analyzer"), which clobbered the profile model in the UI. When neither
+	// CurrentModelId nor a configOption surface a value, emit empty and let
+	// the frontend fall through to its profile/snapshot resolution.
 	if currentModelID == "" {
 		currentModelID = resolveCurrentModelFromConfig(configOptions)
 	}
-	if currentModelID == "" && len(models.AvailableModels) > 0 {
-		currentModelID = string(models.AvailableModels[0].ModelId)
-		a.logger.Info("currentModelId empty, using first available model as fallback",
-			zap.String("fallback_model", currentModelID),
-		)
-	}
+
+	// Cache config options so emitSetModelEvent can include them in the
+	// convergence event emitted after a successful SetModel call.
+	a.mu.Lock()
+	a.availableConfigOptions = configOptions
+	a.mu.Unlock()
 
 	a.logger.Info("emitting session_models event",
 		zap.String("session_id", sessionID),
@@ -1438,6 +1449,26 @@ func (a *Adapter) emitSessionModels(sessionID string, models *acp.SessionModelSt
 		CurrentModelID: currentModelID,
 		SessionModels:  convertSessionModels(models.AvailableModels),
 		ConfigOptions:  configOptions,
+	})
+}
+
+// emitSetModelEvent emits a session_models convergence event after SetModel
+// applies a new model. The frontend uses this to update its current-model
+// view: without it the only session_models event is the one from session/new,
+// which carries the agent's (possibly stale or empty) currentModelId.
+func (a *Adapter) emitSetModelEvent(modelID string) {
+	a.mu.RLock()
+	sessionID := a.sessionID
+	cachedModels := a.availableModels
+	cachedConfig := a.availableConfigOptions
+	a.mu.RUnlock()
+
+	a.sendUpdate(AgentEvent{
+		Type:           streams.EventTypeSessionModels,
+		SessionID:      sessionID,
+		CurrentModelID: modelID,
+		SessionModels:  convertSessionModels(cachedModels),
+		ConfigOptions:  cachedConfig,
 	})
 }
 
@@ -1520,6 +1551,7 @@ func (a *Adapter) SetModel(ctx context.Context, modelID string) error {
 	if err != nil {
 		return fmt.Errorf("set session model failed: %w", err)
 	}
+	a.emitSetModelEvent(modelID)
 	return nil
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -40,6 +40,10 @@ const (
 	contentTypeImage    = "image"
 	contentTypeAudio    = "audio"
 	contentTypeResource = "resource"
+
+	// configOptionIDModel is the well-known ConfigOption ID/Category value used
+	// by ACP agents to surface the active model as a selectable option.
+	configOptionIDModel = "model"
 )
 
 // runPromptTimeout bounds how long a synthetic run prompt can run.
@@ -1158,11 +1162,14 @@ func (a *Adapter) convertNotification(n acp.SessionNotification) *AgentEvent {
 	case u.ConfigOptionUpdate != nil:
 		configOptions := convertACPConfigOptions(u.ConfigOptionUpdate.ConfigOptions)
 		if len(configOptions) > 0 {
-			// Include cached available models so this event doesn't overwrite
-			// the model list that was set during session initialization.
-			a.mu.RLock()
+			// Refresh the cached config options so emitSetModelEvent
+			// (called from SetModel) doesn't reuse the stale snapshot from
+			// session/new. Include the cached available models so the event
+			// doesn't overwrite the model list set during session init.
+			a.mu.Lock()
 			cachedModels := a.availableModels
-			a.mu.RUnlock()
+			a.availableConfigOptions = configOptions
+			a.mu.Unlock()
 			currentModelID := resolveCurrentModelFromConfig(configOptions)
 			return &AgentEvent{
 				Type:           streams.EventTypeSessionModels,
@@ -1456,26 +1463,43 @@ func (a *Adapter) emitSessionModels(sessionID string, models *acp.SessionModelSt
 // applies a new model. The frontend uses this to update its current-model
 // view: without it the only session_models event is the one from session/new,
 // which carries the agent's (possibly stale or empty) currentModelId.
-func (a *Adapter) emitSetModelEvent(modelID string) {
-	a.mu.RLock()
-	sessionID := a.sessionID
-	cachedModels := a.availableModels
-	cachedConfig := a.availableConfigOptions
-	a.mu.RUnlock()
+//
+// Callers MUST pass the sessionID and cached state captured under the same
+// RLock used to read the connection, so concurrent session switches can't
+// route this event to the wrong session. cachedConfig is copied before mutation
+// so the model-shaped option's CurrentValue can be rewritten to match modelID
+// — this prevents a downstream consumer that reads ConfigOptions[model]
+// .CurrentValue (codex-style agents surface the current model there) from
+// disagreeing with the CurrentModelID emitted on the same event.
+func (a *Adapter) emitSetModelEvent(sessionID, modelID string, cachedModels []acp.ModelInfo, cachedConfig []streams.ConfigOption) {
+	outConfig := cachedConfig
+	if len(cachedConfig) > 0 {
+		outConfig = make([]streams.ConfigOption, len(cachedConfig))
+		copy(outConfig, cachedConfig)
+		for i := range outConfig {
+			if outConfig[i].ID == configOptionIDModel || outConfig[i].Category == configOptionIDModel {
+				outConfig[i].CurrentValue = modelID
+			}
+		}
+	}
 
+	a.logger.Info("emitting session_models convergence event after SetModel",
+		zap.String("session_id", sessionID),
+		zap.String("model_id", modelID),
+	)
 	a.sendUpdate(AgentEvent{
 		Type:           streams.EventTypeSessionModels,
 		SessionID:      sessionID,
 		CurrentModelID: modelID,
 		SessionModels:  convertSessionModels(cachedModels),
-		ConfigOptions:  cachedConfig,
+		ConfigOptions:  outConfig,
 	})
 }
 
 // resolveCurrentModelFromConfig extracts current model ID from configOptions.
 func resolveCurrentModelFromConfig(options []streams.ConfigOption) string {
 	for _, opt := range options {
-		if opt.ID == "model" || opt.Category == "model" {
+		if opt.ID == configOptionIDModel || opt.Category == configOptionIDModel {
 			return opt.CurrentValue
 		}
 	}
@@ -1517,10 +1541,14 @@ func (a *Adapter) SetMode(ctx context.Context, modeID string) error {
 // SetModel changes the agent's model via ACP session/set_model (unstable SDK method).
 // If the model ID doesn't exist in the agent's available models, the call is skipped to avoid 404.
 func (a *Adapter) SetModel(ctx context.Context, modelID string) error {
+	// Snapshot sessionID + cached state under a single RLock so the
+	// convergence event emitted on success is bound to the same session
+	// (and the same cached models/options) used to issue the RPC.
 	a.mu.RLock()
 	conn := a.acpConn
 	sessionID := a.sessionID
 	available := a.availableModels
+	cachedConfig := a.availableConfigOptions
 	a.mu.RUnlock()
 
 	if conn == nil {
@@ -1551,7 +1579,7 @@ func (a *Adapter) SetModel(ctx context.Context, modelID string) error {
 	if err != nil {
 		return fmt.Errorf("set session model failed: %w", err)
 	}
-	a.emitSetModelEvent(modelID)
+	a.emitSetModelEvent(sessionID, modelID, available, cachedConfig)
 	return nil
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
@@ -180,6 +180,9 @@ func TestConfigOptionUpdate_RefreshesCachedConfig(t *testing.T) {
 	if ev == nil {
 		t.Fatalf("expected a session_models event from ConfigOptionUpdate")
 	}
+	if ev.CurrentModelID != "fresh" {
+		t.Errorf("event CurrentModelID = %q, want %q (resolved from refreshed configOption)", ev.CurrentModelID, "fresh")
+	}
 
 	a.mu.RLock()
 	got := a.availableConfigOptions

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
@@ -103,9 +103,12 @@ func TestEmitSetModelEvent_EmitsSessionModelsWithCachedState(t *testing.T) {
 		{ModelId: "claude-opus-4-7", Name: "Opus 4.7"},
 		{ModelId: "build-analyzer", Name: "Build Analyzer"},
 	}
+	// Cover both rewrite paths: ID == "model" and Category == "model"
+	// (some agents identify the model option by category, not ID).
 	cachedConfig := []streams.ConfigOption{
 		{Type: "select", ID: "other", Name: "Other", CurrentValue: "keep-me"},
 		{Type: "select", ID: "model", Name: "Model", CurrentValue: "old-model"},
+		{Type: "select", ID: "model-cat", Category: "model", Name: "ModelCat", CurrentValue: "old-model"},
 	}
 
 	a.emitSetModelEvent("sess-1", "claude-opus-4-7", cachedModels, cachedConfig)
@@ -120,18 +123,18 @@ func TestEmitSetModelEvent_EmitsSessionModelsWithCachedState(t *testing.T) {
 	if len(ev.SessionModels) != 2 {
 		t.Errorf("SessionModels len = %d, want 2", len(ev.SessionModels))
 	}
-	if len(ev.ConfigOptions) != 2 {
-		t.Fatalf("ConfigOptions len = %d, want 2", len(ev.ConfigOptions))
+	if len(ev.ConfigOptions) != 3 {
+		t.Fatalf("ConfigOptions len = %d, want 3", len(ev.ConfigOptions))
 	}
 
-	// Model-shaped option's CurrentValue must be rewritten to the new model
-	// so consumers reading ConfigOptions[model].CurrentValue (codex-style
-	// agents surface the current model there) don't see a stale value.
+	// Both the ID-matched and Category-matched model options must have their
+	// CurrentValue rewritten to the new model so consumers reading either
+	// don't see a stale value. Non-model options are untouched.
 	for _, opt := range ev.ConfigOptions {
 		switch opt.ID {
-		case "model":
+		case "model", "model-cat":
 			if opt.CurrentValue != "claude-opus-4-7" {
-				t.Errorf("model option CurrentValue = %q, want %q", opt.CurrentValue, "claude-opus-4-7")
+				t.Errorf("option %q CurrentValue = %q, want %q", opt.ID, opt.CurrentValue, "claude-opus-4-7")
 			}
 		case "other":
 			if opt.CurrentValue != "keep-me" {
@@ -141,9 +144,8 @@ func TestEmitSetModelEvent_EmitsSessionModelsWithCachedState(t *testing.T) {
 	}
 
 	// The caller's cachedConfig must not be mutated — we copy before rewrite.
-	if cachedConfig[1].CurrentValue != "old-model" {
-		t.Errorf("caller cachedConfig was mutated: model.CurrentValue = %q, want %q",
-			cachedConfig[1].CurrentValue, "old-model")
+	if cachedConfig[1].CurrentValue != "old-model" || cachedConfig[2].CurrentValue != "old-model" {
+		t.Errorf("caller cachedConfig was mutated: got %+v", cachedConfig)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
@@ -99,18 +99,16 @@ func TestEmitSessionModels_NonEmptyCurrentIDPreserved(t *testing.T) {
 func TestEmitSetModelEvent_EmitsSessionModelsWithCachedState(t *testing.T) {
 	a := newTestAdapter()
 
-	a.mu.Lock()
-	a.sessionID = "sess-1"
-	a.availableModels = []acp.ModelInfo{
+	cachedModels := []acp.ModelInfo{
 		{ModelId: "claude-opus-4-7", Name: "Opus 4.7"},
 		{ModelId: "build-analyzer", Name: "Build Analyzer"},
 	}
-	a.availableConfigOptions = []streams.ConfigOption{
-		{Type: "select", ID: "model", Name: "Model", CurrentValue: "claude-opus-4-7"},
+	cachedConfig := []streams.ConfigOption{
+		{Type: "select", ID: "other", Name: "Other", CurrentValue: "keep-me"},
+		{Type: "select", ID: "model", Name: "Model", CurrentValue: "old-model"},
 	}
-	a.mu.Unlock()
 
-	a.emitSetModelEvent("claude-opus-4-7")
+	a.emitSetModelEvent("sess-1", "claude-opus-4-7", cachedModels, cachedConfig)
 
 	ev := findSessionModelsEvent(t, drainEvents(a))
 	if ev.SessionID != "sess-1" {
@@ -122,7 +120,72 @@ func TestEmitSetModelEvent_EmitsSessionModelsWithCachedState(t *testing.T) {
 	if len(ev.SessionModels) != 2 {
 		t.Errorf("SessionModels len = %d, want 2", len(ev.SessionModels))
 	}
-	if len(ev.ConfigOptions) != 1 || ev.ConfigOptions[0].ID != "model" {
-		t.Errorf("ConfigOptions = %+v, want one option with ID=model", ev.ConfigOptions)
+	if len(ev.ConfigOptions) != 2 {
+		t.Fatalf("ConfigOptions len = %d, want 2", len(ev.ConfigOptions))
+	}
+
+	// Model-shaped option's CurrentValue must be rewritten to the new model
+	// so consumers reading ConfigOptions[model].CurrentValue (codex-style
+	// agents surface the current model there) don't see a stale value.
+	for _, opt := range ev.ConfigOptions {
+		switch opt.ID {
+		case "model":
+			if opt.CurrentValue != "claude-opus-4-7" {
+				t.Errorf("model option CurrentValue = %q, want %q", opt.CurrentValue, "claude-opus-4-7")
+			}
+		case "other":
+			if opt.CurrentValue != "keep-me" {
+				t.Errorf("non-model option CurrentValue = %q, want %q (untouched)", opt.CurrentValue, "keep-me")
+			}
+		}
+	}
+
+	// The caller's cachedConfig must not be mutated — we copy before rewrite.
+	if cachedConfig[1].CurrentValue != "old-model" {
+		t.Errorf("caller cachedConfig was mutated: model.CurrentValue = %q, want %q",
+			cachedConfig[1].CurrentValue, "old-model")
+	}
+}
+
+// TestConfigOptionUpdate_RefreshesCachedConfig pins that an inbound
+// ConfigOptionUpdate notification refreshes the adapter's availableConfigOptions
+// cache, so a subsequent SetModel convergence event emits the latest options
+// instead of the snapshot taken at session/new.
+func TestConfigOptionUpdate_RefreshesCachedConfig(t *testing.T) {
+	a := newTestAdapter()
+
+	a.mu.Lock()
+	a.availableConfigOptions = []streams.ConfigOption{
+		{Type: "select", ID: "model", Name: "Model", CurrentValue: "stale"},
+	}
+	a.mu.Unlock()
+
+	notif := acp.SessionNotification{
+		SessionId: "sess-1",
+		Update: acp.SessionUpdate{
+			ConfigOptionUpdate: &acp.SessionConfigOptionUpdate{
+				ConfigOptions: []acp.SessionConfigOption{
+					{Select: &acp.SessionConfigOptionSelect{
+						Type:         "select",
+						Id:           "model",
+						Name:         "Model",
+						CurrentValue: "fresh",
+					}},
+				},
+			},
+		},
+	}
+
+	ev := a.convertNotification(notif)
+	if ev == nil {
+		t.Fatalf("expected a session_models event from ConfigOptionUpdate")
+	}
+
+	a.mu.RLock()
+	got := a.availableConfigOptions
+	a.mu.RUnlock()
+
+	if len(got) != 1 || got[0].CurrentValue != "fresh" {
+		t.Errorf("availableConfigOptions = %+v, want one option with CurrentValue=fresh", got)
 	}
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
@@ -1,0 +1,128 @@
+package acp
+
+import (
+	"testing"
+
+	"github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+// findSessionModelsEvent returns the first session_models event in events,
+// or fails the test if none is present.
+func findSessionModelsEvent(t *testing.T, events []AgentEvent) AgentEvent {
+	t.Helper()
+	for _, ev := range events {
+		if ev.Type == streams.EventTypeSessionModels {
+			return ev
+		}
+	}
+	t.Fatalf("no %s event emitted; got %d events", streams.EventTypeSessionModels, len(events))
+	return AgentEvent{}
+}
+
+// auggieLikeModels mimics Auggie's response: empty CurrentModelId with an
+// alphabetically-sorted list whose [0] is a pseudo-agent ("Build Analyzer").
+func auggieLikeModels() *acp.SessionModelState {
+	return &acp.SessionModelState{
+		CurrentModelId: "",
+		AvailableModels: []acp.ModelInfo{
+			{ModelId: "build-fix-gpt5-2-responses-high-200k-v1-c4-p2-agent", Name: "Build Analyzer"},
+			{ModelId: "claude-opus-4-7", Name: "Opus 4.7"},
+		},
+	}
+}
+
+// TestEmitSessionModels_EmptyCurrentIDNoFallback pins the regression: when the
+// agent returns currentModelId="" with no model-shaped configOption, the
+// adapter must NOT invent a "current" model from AvailableModels[0]. Auggie
+// returns alphabetically-sorted models whose [0] is a pseudo-agent ("Build
+// Analyzer"), so the previous fallback caused the UI to show the wrong model.
+func TestEmitSessionModels_EmptyCurrentIDNoFallback(t *testing.T) {
+	a := newTestAdapter()
+	a.emitSessionModels("sess-1", auggieLikeModels(), nil, nil)
+
+	ev := findSessionModelsEvent(t, drainEvents(a))
+	if ev.CurrentModelID != "" {
+		t.Errorf("CurrentModelID = %q, want empty (let frontend fall through to profile)", ev.CurrentModelID)
+	}
+	if len(ev.SessionModels) != 2 {
+		t.Errorf("SessionModels len = %d, want 2", len(ev.SessionModels))
+	}
+}
+
+// TestEmitSessionModels_EmptyCurrentIDFromConfigOption pins the legitimate
+// fallback that we keep: some agents expose the current model via a
+// configOption (id="model") rather than CurrentModelId.
+func TestEmitSessionModels_EmptyCurrentIDFromConfigOption(t *testing.T) {
+	a := newTestAdapter()
+	meta := map[string]any{
+		"configOptions": []any{
+			map[string]any{
+				"type":         "select",
+				"id":           "model",
+				"name":         "Model",
+				"currentValue": "claude-opus-4-7",
+			},
+		},
+	}
+	a.emitSessionModels("sess-1", auggieLikeModels(), meta, nil)
+
+	ev := findSessionModelsEvent(t, drainEvents(a))
+	if ev.CurrentModelID != "claude-opus-4-7" {
+		t.Errorf("CurrentModelID = %q, want %q", ev.CurrentModelID, "claude-opus-4-7")
+	}
+}
+
+// TestEmitSessionModels_NonEmptyCurrentIDPreserved checks the happy path:
+// when the agent populates CurrentModelId, we propagate it verbatim.
+func TestEmitSessionModels_NonEmptyCurrentIDPreserved(t *testing.T) {
+	a := newTestAdapter()
+	models := &acp.SessionModelState{
+		CurrentModelId: "claude-opus-4-7",
+		AvailableModels: []acp.ModelInfo{
+			{ModelId: "claude-opus-4-7", Name: "Opus 4.7"},
+		},
+	}
+	a.emitSessionModels("sess-1", models, nil, nil)
+
+	ev := findSessionModelsEvent(t, drainEvents(a))
+	if ev.CurrentModelID != "claude-opus-4-7" {
+		t.Errorf("CurrentModelID = %q, want %q", ev.CurrentModelID, "claude-opus-4-7")
+	}
+}
+
+// TestEmitSetModelEvent_EmitsSessionModelsWithCachedState pins that after a
+// successful SetModel call the adapter emits a session_models convergence
+// event carrying the requested model and cached available models / config
+// options. This is what corrects the frontend after the lifecycle manager
+// applies the profile model at session init.
+func TestEmitSetModelEvent_EmitsSessionModelsWithCachedState(t *testing.T) {
+	a := newTestAdapter()
+
+	a.mu.Lock()
+	a.sessionID = "sess-1"
+	a.availableModels = []acp.ModelInfo{
+		{ModelId: "claude-opus-4-7", Name: "Opus 4.7"},
+		{ModelId: "build-analyzer", Name: "Build Analyzer"},
+	}
+	a.availableConfigOptions = []streams.ConfigOption{
+		{Type: "select", ID: "model", Name: "Model", CurrentValue: "claude-opus-4-7"},
+	}
+	a.mu.Unlock()
+
+	a.emitSetModelEvent("claude-opus-4-7")
+
+	ev := findSessionModelsEvent(t, drainEvents(a))
+	if ev.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want %q", ev.SessionID, "sess-1")
+	}
+	if ev.CurrentModelID != "claude-opus-4-7" {
+		t.Errorf("CurrentModelID = %q, want %q", ev.CurrentModelID, "claude-opus-4-7")
+	}
+	if len(ev.SessionModels) != 2 {
+		t.Errorf("SessionModels len = %d, want 2", len(ev.SessionModels))
+	}
+	if len(ev.ConfigOptions) != 1 || ev.ConfigOptions[0].ID != "model" {
+		t.Errorf("ConfigOptions = %+v, want one option with ID=model", ev.ConfigOptions)
+	}
+}


### PR DESCRIPTION
## Summary

- Auggie ACP sessions showed "Build Analyzer" instead of the profile model (e.g. Opus 4.7) on every fresh load and resume.
- Root cause: `emitSessionModels` fell back to `AvailableModels[0]` when `currentModelId` was empty. Auggie returns an alphabetically-sorted list whose `[0]` is a pseudo-agent ("Build Analyzer"), and the frontend `resolveCurrentModel` precedence (`acpCurrentModel > profileModel`) let that bogus value win.
- Dropped the `AvailableModels[0]` fallback. Kept the `configOption`-based fallback (legitimate for codex-style agents).
- Added a convergence `session_models` event emitted from `SetModel` after `UnstableSetSessionModel` succeeds, so the UI updates after the lifecycle manager applies the profile model at session init (`lifecycle/session.go:339`) and after user-driven `/session/set_model` calls. Cached `configOptions` alongside `availableModels` for inclusion in that event.

## Test plan

- [x] `make -C apps/backend test` — 281 ACP tests pass, full suite green
- [x] `make -C apps/backend lint` — 0 issues
- [x] `pnpm --filter @kandev/web typecheck` — pass
- [x] `pnpm --filter @kandev/web lint` — pass
- [x] New unit tests in `session_models_test.go`:
  - empty `CurrentModelId` no longer falls back to `AvailableModels[0]` (Auggie regression)
  - empty `CurrentModelId` still resolves from a model-shaped `configOption`
  - non-empty `CurrentModelId` is preserved verbatim
  - `SetModel` emits a `session_models` event with cached models + options
- [ ] Manual: `make dev`, start an auggie task with profile model Opus 4.7, confirm selector shows "Opus 4.7" on first load and after page refresh / session resume