### PR TITLE
fix(web): add delete confirmation dialog in task sidebar and mobile sheet

### DIFF
--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -396,14 +396,60 @@ async function selectTaskWithoutPrimarySession(taskId: string, opts: SelectTaskO
   onOpenChange(false);
 }
 
+function useSheetDeleteActions(
+  store: ReturnType<typeof useAppStoreApi>,
+  removeTaskFromBoard: ReturnType<typeof useTaskRemoval>["removeTaskFromBoard"],
+) {
+  const { deleteTaskById } = useTaskActions();
+  const [deletingTask, setDeletingTask] = useState<{ id: string; title: string } | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDeleteTask = useCallback(
+    (taskId: string) => {
+      const task = store.getState().kanban.tasks.find((t) => t.id === taskId);
+      setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
+    },
+    [store],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deletingTask || isDeleting) return;
+    const taskId = deletingTask.id;
+    setIsDeleting(true);
+    // Capture active state before the async API call — the WS "task.deleted"
+    // handler may clear activeTaskId/activeSessionId before removeTaskFromBoard runs.
+    const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
+      store.getState().tasks;
+    try {
+      await deleteTaskById(taskId);
+      await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
+    } catch (error) {
+      console.error("Failed to delete task:", error);
+    } finally {
+      setIsDeleting(false);
+      setDeletingTask(null);
+    }
+  }, [deletingTask, isDeleting, deleteTaskById, removeTaskFromBoard, store]);
+
+  const deletingTaskId = isDeleting ? (deletingTask?.id ?? null) : null;
+
+  return {
+    deletingTaskId,
+    deletingTask,
+    setDeletingTask,
+    isDeleting,
+    handleDeleteTask,
+    handleDeleteConfirm,
+  };
+}
+
 export function useSheetActions(workspaceId: string | null, onOpenChange: (open: boolean) => void) {
   const setActiveTask = useAppStore((state) => state.setActiveTask);
   const setActiveSession = useAppStore((state) => state.setActiveSession);
   const store = useAppStoreApi();
-  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
-  const { deleteTaskById } = useTaskActions();
   const archiveAndSwitch = useArchiveAndSwitchTask();
   const { removeTaskFromBoard, loadTaskSessionsForTask } = useTaskRemoval({ store });
+  const deleteActions = useSheetDeleteActions(store, removeTaskFromBoard);
 
   const handleSelectTask = useCallback(
     (taskId: string) => {
@@ -450,23 +496,6 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
     }
   }, [archivingTask, archiveAndSwitch]);
 
-  const handleDeleteTask = useCallback(
-    async (taskId: string) => {
-      setDeletingTaskId(taskId);
-      // Capture active state before the async API call — the WS "task.deleted"
-      // handler may clear activeTaskId/activeSessionId before removeTaskFromBoard runs.
-      const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
-        store.getState().tasks;
-      try {
-        await deleteTaskById(taskId);
-        await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
-      } finally {
-        setDeletingTaskId(null);
-      }
-    },
-    [deleteTaskById, removeTaskFromBoard, store],
-  );
-
   const { handleWorkspaceChange, handleTaskCreated } = useWorkspaceAndTaskCreatedActions({
     workspaceId,
     store,
@@ -477,15 +506,14 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
   });
 
   return {
-    deletingTaskId,
     handleSelectTask,
     handleArchiveTask,
-    handleDeleteTask,
     handleWorkspaceChange,
     handleTaskCreated,
     archivingTask,
     setArchivingTask,
     isArchiving,
     handleArchiveConfirm,
+    ...deleteActions,
   };
 }

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -12,6 +12,7 @@ import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-pr
 import { WorkspaceSwitcher } from "../workspace-switcher";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
 import { TaskArchiveConfirmDialog } from "../task-archive-confirm-dialog";
+import { TaskDeleteConfirmDialog } from "../task-delete-confirm-dialog";
 import { useSheetData, useSheetActions } from "./session-task-switcher-sheet-hooks";
 
 type SessionTaskSwitcherSheetProps = {
@@ -137,6 +138,15 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
         taskTitle={actions.archivingTask?.title ?? ""}
         isArchiving={actions.isArchiving}
         onConfirm={actions.handleArchiveConfirm}
+      />
+      <TaskDeleteConfirmDialog
+        open={actions.deletingTask !== null}
+        onOpenChange={(open) => {
+          if (!open) actions.setDeletingTask(null);
+        }}
+        taskTitle={actions.deletingTask?.title ?? ""}
+        isDeleting={actions.isDeleting}
+        onConfirm={actions.handleDeleteConfirm}
       />
     </Sheet>
   );

--- a/apps/web/components/task/task-session-sidebar-dialogs.tsx
+++ b/apps/web/components/task/task-session-sidebar-dialogs.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { TaskRenameDialog } from "./task-rename-dialog";
+import { TaskArchiveConfirmDialog } from "./task-archive-confirm-dialog";
+import { TaskDeleteConfirmDialog } from "./task-delete-confirm-dialog";
+
+type Target = { id: string; title: string } | null;
+
+export type SidebarDialogsActions = {
+  renamingTask: Target;
+  setRenamingTask: (next: Target) => void;
+  handleRenameSubmit: (newTitle: string) => Promise<void> | void;
+  archivingTask: Target;
+  setArchivingTask: (next: Target) => void;
+  isArchiving: boolean;
+  handleArchiveConfirm: () => Promise<void> | void;
+  deletingTask: Target;
+  setDeletingTask: (next: Target) => void;
+  isDeleting: boolean;
+  handleDeleteConfirm: () => Promise<void> | void;
+};
+
+export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) {
+  const {
+    renamingTask,
+    setRenamingTask,
+    handleRenameSubmit,
+    archivingTask,
+    setArchivingTask,
+    isArchiving,
+    handleArchiveConfirm,
+    deletingTask,
+    setDeletingTask,
+    isDeleting,
+    handleDeleteConfirm,
+  } = actions;
+  return (
+    <>
+      <TaskRenameDialog
+        open={renamingTask !== null}
+        onOpenChange={(open) => {
+          if (!open) setRenamingTask(null);
+        }}
+        currentTitle={renamingTask?.title ?? ""}
+        onSubmit={handleRenameSubmit}
+      />
+      <TaskArchiveConfirmDialog
+        open={archivingTask !== null}
+        onOpenChange={(open) => {
+          if (!open) setArchivingTask(null);
+        }}
+        taskTitle={archivingTask?.title ?? ""}
+        isArchiving={isArchiving}
+        onConfirm={handleArchiveConfirm}
+      />
+      <TaskDeleteConfirmDialog
+        open={deletingTask !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletingTask(null);
+        }}
+        taskTitle={deletingTask?.title ?? ""}
+        isDeleting={isDeleting}
+        onConfirm={handleDeleteConfirm}
+      />
+    </>
+  );
+}

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -15,8 +15,7 @@ import { TaskSwitcher } from "./task-switcher";
 import { applyView } from "@/lib/sidebar/apply-view";
 import { SidebarFilterBar } from "./sidebar-filter/sidebar-filter-bar";
 import { MOCK_ITEMS, MOCK_SIDEBAR } from "./sidebar-mock-data";
-import { TaskRenameDialog } from "./task-rename-dialog";
-import { TaskArchiveConfirmDialog } from "./task-archive-confirm-dialog";
+import { SidebarDialogs } from "./task-session-sidebar-dialogs";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { useAllWorkflowSnapshots } from "@/hooks/domains/kanban/use-all-workflow-snapshots";
@@ -447,12 +446,56 @@ function useArchiveActions(store: StoreApi) {
   return { archivingTask, setArchivingTask, isArchiving, handleArchiveTask, handleArchiveConfirm };
 }
 
+function useDeleteActions(
+  store: StoreApi,
+  removeTaskFromBoard: ReturnType<typeof useTaskRemoval>["removeTaskFromBoard"],
+) {
+  const { deleteTaskById } = useTaskActions();
+  const [deletingTask, setDeletingTask] = useState<{ id: string; title: string } | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDeleteTask = useCallback(
+    (taskId: string) => {
+      const task = findTaskInSnapshots(store.getState().kanbanMulti.snapshots, taskId);
+      setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
+    },
+    [store],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deletingTask || isDeleting) return;
+    const taskId = deletingTask.id;
+    setIsDeleting(true);
+    const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
+      store.getState().tasks;
+    try {
+      await deleteTaskById(taskId);
+      await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
+    } catch (error) {
+      console.error("Failed to delete task:", error);
+    } finally {
+      setIsDeleting(false);
+      setDeletingTask(null);
+    }
+  }, [deletingTask, isDeleting, deleteTaskById, removeTaskFromBoard, store]);
+
+  const deletingTaskId = isDeleting ? (deletingTask?.id ?? null) : null;
+
+  return {
+    deletingTask,
+    setDeletingTask,
+    deletingTaskId,
+    isDeleting,
+    handleDeleteTask,
+    handleDeleteConfirm,
+  };
+}
+
 function useSidebarActions(store: StoreApi) {
   const setActiveTask = useAppStore((state) => state.setActiveTask);
   const setActiveSession = useAppStore((state) => state.setActiveSession);
-  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
   const [preparingTaskId, setPreparingTaskId] = useState<string | null>(null);
-  const { deleteTaskById, renameTaskById } = useTaskActions();
+  const { renameTaskById } = useTaskActions();
   const { removeTaskFromBoard, loadTaskSessionsForTask } = useTaskRemoval({
     store,
     useLayoutSwitch: true,
@@ -480,21 +523,7 @@ function useSidebarActions(store: StoreApi) {
   );
 
   const archiveActions = useArchiveActions(store);
-
-  const handleDeleteTask = useCallback(
-    async (taskId: string) => {
-      setDeletingTaskId(taskId);
-      const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
-        store.getState().tasks;
-      try {
-        await deleteTaskById(taskId);
-        await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
-      } finally {
-        setDeletingTaskId(null);
-      }
-    },
-    [deleteTaskById, removeTaskFromBoard, store],
-  );
+  const deleteActions = useDeleteActions(store, removeTaskFromBoard);
 
   const [renamingTask, setRenamingTask] = useState<{ id: string; title: string } | null>(null);
 
@@ -518,16 +547,15 @@ function useSidebarActions(store: StoreApi) {
   const handleMoveToStep = useMoveToStep(store);
 
   return {
-    deletingTaskId,
     preparingTaskId,
     handleSelectTask,
-    handleDeleteTask,
     handleMoveToStep,
     renamingTask,
     setRenamingTask,
     handleRenameTask,
     handleRenameSubmit,
     ...archiveActions,
+    ...deleteActions,
   };
 }
 
@@ -575,14 +603,7 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
     handleArchiveTask,
     handleDeleteTask,
     handleMoveToStep,
-    renamingTask,
-    setRenamingTask,
     handleRenameTask,
-    handleRenameSubmit,
-    archivingTask,
-    setArchivingTask,
-    isArchiving,
-    handleArchiveConfirm,
   } = sidebarActions;
 
   const displayTasks = useMemo(() => {
@@ -631,23 +652,7 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
           totalTaskCount={displayTasks.length}
         />
       </PanelBody>
-      <TaskRenameDialog
-        open={renamingTask !== null}
-        onOpenChange={(open) => {
-          if (!open) setRenamingTask(null);
-        }}
-        currentTitle={renamingTask?.title ?? ""}
-        onSubmit={handleRenameSubmit}
-      />
-      <TaskArchiveConfirmDialog
-        open={archivingTask !== null}
-        onOpenChange={(open) => {
-          if (!open) setArchivingTask(null);
-        }}
-        taskTitle={archivingTask?.title ?? ""}
-        isArchiving={isArchiving}
-        onConfirm={handleArchiveConfirm}
-      />
+      <SidebarDialogs actions={sidebarActions} />
     </PanelRoot>
   );
 });

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -405,10 +405,15 @@ export class SessionPage {
 
   /**
    * Delete a task via the sidebar context menu.
-   * Hovers to reveal the menu trigger, opens it, and clicks "Delete".
+   * Hovers to reveal the menu trigger, opens it, clicks "Delete",
+   * and confirms the delete dialog.
    */
   async deleteTaskInSidebar(title: string): Promise<void> {
     await this.openSidebarMenuAndClick(title, "Delete");
+    const confirmButton = this.page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Delete" });
+    await confirmButton.click();
   }
 
   /**
@@ -430,11 +435,7 @@ export class SessionPage {
    * Retries the full open-click sequence if the menu gets detached by a
    * React re-render (e.g. WS-driven sidebar update) between open and click.
    */
-  private async openSidebarMenuAndClick(
-    title: string,
-    itemName: string,
-    retries = 3,
-  ): Promise<void> {
+  async openSidebarMenuAndClick(title: string, itemName: string, retries = 3): Promise<void> {
     const taskRow = this.sidebar.locator('[role="button"]').filter({ hasText: title });
     for (let attempt = 0; attempt < retries; attempt++) {
       try {

--- a/apps/web/e2e/tests/task/sidebar-delete-confirm.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-delete-confirm.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { SessionPage } from "../../pages/session-page";
+
+/**
+ * Regression: deleting a task from the task-details sidebar must show a confirm
+ * dialog (mirroring the archive flow). Delete is permanent, so silently firing
+ * deleteTaskById on the first menu click is a footgun.
+ */
+test.describe("Task sidebar — delete shows confirmation", () => {
+  test("clicking Delete in sidebar menu shows confirm dialog and does not delete until confirmed", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(60_000);
+
+    await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Sidebar Delete Confirm Task",
+      seedData.agentProfileId,
+      {
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    // Second task so the sidebar still has something to switch to after delete.
+    await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Sidebar Delete Survivor Task",
+      seedData.agentProfileId,
+      {
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    const target = kanban.taskCardByTitle("Sidebar Delete Confirm Task");
+    await expect(target).toBeVisible({ timeout: 30_000 });
+    await target.click();
+
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    await expect(session.taskInSidebar("Sidebar Delete Confirm Task")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Open the sidebar menu and click Delete — dialog should appear, task should still exist.
+    await session.openSidebarMenuAndClick("Sidebar Delete Confirm Task", "Delete");
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Sidebar Delete Confirm Task");
+
+    // Cancel — the task must still be there.
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    await expect(session.taskInSidebar("Sidebar Delete Confirm Task")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Reopen and confirm — now it should disappear.
+    await session.openSidebarMenuAndClick("Sidebar Delete Confirm Task", "Delete");
+    await expect(testPage.getByRole("alertdialog")).toBeVisible();
+    await testPage.getByRole("alertdialog").getByRole("button", { name: "Delete" }).click();
+
+    await expect(session.taskInSidebar("Sidebar Delete Confirm Task")).not.toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});


### PR DESCRIPTION
Deleting a task from the sidebar context menu fired `deleteTaskById` immediately with no confirmation, even though archive — a weaker, reversible operation — already showed a confirm dialog. This wires the existing `TaskDeleteConfirmDialog` into the desktop task-details sidebar and mobile task sheet, mirroring the archive flow exactly and giving permanent deletes appropriate friction.

## Important Changes

- New `useDeleteActions` hook in `task-session-sidebar.tsx` (mirrors `useArchiveActions`) gates delete behind a confirm dialog.
- New `useSheetDeleteActions` hook for the mobile sheet, same pattern.
- Extracted rename + archive + delete dialogs into `task-session-sidebar-dialogs.tsx` to keep the sidebar file under the 600-line lint cap.
- `SessionPage.deleteTaskInSidebar()` page-object helper updated to click through the confirm step (mirrors `archiveTaskInSidebar`).

## Validation

- `pnpm --filter @kandev/web typecheck` — pass
- `pnpm --filter @kandev/web lint` — pass
- `pnpm --filter @kandev/web test` — 1892 tests pass
- New E2E regression spec: `e2e/tests/task/sidebar-delete-confirm.spec.ts` — cancel preserves task, confirm deletes it

## Checklist

- [ ] Tests added/updated
- [ ] No regressions introduced
- [ ] Docs/specs updated if needed