### PR TITLE
fix(web): mobile-layout fixes for onboarding wizard + dialog

### DIFF
--- a/apps/web/app/office/setup/close-button.tsx
+++ b/apps/web/app/office/setup/close-button.tsx
@@ -15,7 +15,7 @@ export function CloseButton({ href }: CloseButtonProps) {
       type="button"
       onClick={() => router.push(href)}
       aria-label="Cancel"
-      className="absolute -top-12 -left-12 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground hover:bg-accent hover:text-foreground cursor-pointer"
+      className="fixed top-4 right-4 z-10 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground cursor-pointer lg:absolute lg:bg-transparent lg:-top-12 lg:-left-12 lg:right-auto"
     >
       <IconX className="h-4 w-4" />
     </button>

--- a/apps/web/components/onboarding-dialog.tsx
+++ b/apps/web/components/onboarding-dialog.tsx
@@ -389,7 +389,7 @@ function StepWorkflows({
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-2 max-h-[320px] overflow-y-auto pr-1">
+      <div className="grid gap-2 max-h-[320px] overflow-y-auto">
         {defaultTemplate && <TemplateCard template={defaultTemplate} isDefault />}
         {otherTemplates.length > 0 && (
           <>

--- a/apps/web/components/onboarding-dialog.tsx
+++ b/apps/web/components/onboarding-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -508,9 +508,9 @@ function TemplateCard({
         <p className="text-xs text-muted-foreground mt-0.5">{template.description}</p>
       )}
       {steps.length > 0 && (
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground whitespace-nowrap mt-2">
+        <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-muted-foreground mt-2">
           {steps.map((s, i) => (
-            <Fragment key={s.name}>
+            <span key={s.name} className="flex items-center gap-1.5">
               {i > 0 && <span className="text-muted-foreground/40">→</span>}
               <span className="flex items-center gap-1">
                 <span
@@ -519,7 +519,7 @@ function TemplateCard({
                 />
                 {s.name}
               </span>
-            </Fragment>
+            </span>
           ))}
         </div>
       )}

--- a/apps/web/components/onboarding-dialog.tsx
+++ b/apps/web/components/onboarding-dialog.tsx
@@ -389,7 +389,7 @@ function StepWorkflows({
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-2 max-h-[320px] overflow-y-auto">
+      <div className="grid grid-cols-1 gap-2 max-h-[320px] overflow-y-auto">
         {defaultTemplate && <TemplateCard template={defaultTemplate} isDefault />}
         {otherTemplates.length > 0 && (
           <>

--- a/apps/web/components/onboarding/step-agents.tsx
+++ b/apps/web/components/onboarding/step-agents.tsx
@@ -46,7 +46,7 @@ function CopyButton({ text }: { text: string }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="p-0.5 cursor-pointer hover:text-foreground text-muted-foreground transition-colors"
+      className="p-0.5 cursor-pointer hover:text-foreground text-muted-foreground transition-colors shrink-0"
     >
       {copied ? (
         <IconCheck className="h-3 w-3 text-green-500" />
@@ -232,7 +232,7 @@ function NotInstalledItems({
               href={tool.info_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-foreground shrink-0"
+              className="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer"
             >
               <IconExternalLink className="h-3.5 w-3.5" />
             </a>

--- a/apps/web/components/onboarding/step-agents.tsx
+++ b/apps/web/components/onboarding/step-agents.tsx
@@ -269,7 +269,7 @@ export function StepAgents({
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-2 max-h-[320px] overflow-y-auto pr-1">
+      <div className="grid gap-2 max-h-[320px] overflow-y-auto">
         {installedAgents.map((agent) => (
           <InstalledAgentRow
             key={agent.name}

--- a/apps/web/components/onboarding/step-agents.tsx
+++ b/apps/web/components/onboarding/step-agents.tsx
@@ -138,9 +138,9 @@ function InstalledAgentRow({
           type="button"
           className="flex w-full items-center gap-3 rounded-lg border p-2 text-left cursor-pointer hover:bg-muted/50 transition-colors group"
         >
-          <AgentLogo agentName={agent.name} size={28} />
+          <AgentLogo agentName={agent.name} size={28} className="shrink-0" />
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium">{agent.display_name}</p>
+            <p className="text-sm font-medium truncate">{agent.display_name}</p>
           </div>
           {showModelPill && (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium truncate max-w-[120px]">
@@ -190,19 +190,21 @@ function NotInstalledItems({
           key={agent.name}
           className="flex w-full items-center gap-3 rounded-lg border border-dashed p-2"
         >
-          <AgentLogo agentName={agent.name} size={28} className="opacity-60" />
+          <AgentLogo agentName={agent.name} size={28} className="opacity-60 shrink-0" />
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-muted-foreground">{agent.display_name}</p>
+            <p className="text-sm font-medium text-muted-foreground truncate">
+              {agent.display_name}
+            </p>
             {agent.install_script && (
-              <div className="flex items-center gap-1 mt-0.5">
-                <code className="text-[10px] text-muted-foreground font-mono truncate">
+              <div className="flex items-center gap-1 mt-0.5 min-w-0">
+                <code className="text-[10px] text-muted-foreground font-mono truncate min-w-0">
                   {agent.install_script}
                 </code>
                 <CopyButton text={agent.install_script} />
               </div>
             )}
           </div>
-          <IconDownload className="h-3.5 w-3.5 text-muted-foreground" />
+          <IconDownload className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         </div>
       ))}
       {tools.map((tool) => (
@@ -212,11 +214,13 @@ function NotInstalledItems({
         >
           <IconDownload className="h-7 w-7 p-1 text-muted-foreground opacity-60 shrink-0" />
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-muted-foreground">{tool.display_name}</p>
-            <p className="text-[10px] text-muted-foreground">{tool.description}</p>
+            <p className="text-sm font-medium text-muted-foreground truncate">
+              {tool.display_name}
+            </p>
+            <p className="text-[10px] text-muted-foreground break-words">{tool.description}</p>
             {tool.install_script && (
-              <div className="flex items-center gap-1 mt-0.5">
-                <code className="text-[10px] text-muted-foreground font-mono truncate">
+              <div className="flex items-center gap-1 mt-0.5 min-w-0">
+                <code className="text-[10px] text-muted-foreground font-mono truncate min-w-0">
                   {tool.install_script}
                 </code>
                 <CopyButton text={tool.install_script} />
@@ -228,7 +232,7 @@ function NotInstalledItems({
               href={tool.info_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-foreground"
+              className="text-muted-foreground hover:text-foreground shrink-0"
             >
               <IconExternalLink className="h-3.5 w-3.5" />
             </a>
@@ -269,7 +273,7 @@ export function StepAgents({
 
   return (
     <div className="space-y-3">
-      <div className="grid gap-2 max-h-[320px] overflow-y-auto">
+      <div className="grid grid-cols-1 gap-2 max-h-[320px] overflow-y-auto">
         {installedAgents.map((agent) => (
           <InstalledAgentRow
             key={agent.name}

--- a/apps/web/e2e/helpers/layout-assertions.ts
+++ b/apps/web/e2e/helpers/layout-assertions.ts
@@ -23,10 +23,12 @@ export async function assertNoDescendantOverflowsRight(
     (node, rightArg) => {
       const limit = rightArg as number;
       const results: { tag: string; text: string; right: number }[] = [];
-      const skip = new Set(["SVG", "PATH", "CIRCLE", "RECT", "LINE", "G"]);
+      // SVG elements in HTML documents report `tagName` lowercase (per the
+      // SVG namespace) while HTML elements report uppercase, so normalize.
+      const skip = new Set(["svg", "path", "circle", "rect", "line", "g"]);
       const all = node.querySelectorAll("*");
       for (const el of all) {
-        if (skip.has(el.tagName)) continue;
+        if (skip.has(el.tagName.toLowerCase())) continue;
         const rect = el.getBoundingClientRect();
         if (rect.width === 0 || rect.height === 0) continue;
         if (rect.right > limit + 1) {

--- a/apps/web/e2e/helpers/layout-assertions.ts
+++ b/apps/web/e2e/helpers/layout-assertions.ts
@@ -1,0 +1,102 @@
+import { expect, type Locator } from "@playwright/test";
+
+// Shared layout assertions for mobile / responsive specs. Extracted because
+// both onboarding mobile specs need the same overflow + padding checks and
+// duplicating the DOM walk caused review churn.
+
+/**
+ * Asserts that no descendant of `root` has a right edge past `root`'s right
+ * edge. `label` shows up in the failure message so the offending step is
+ * identifiable.
+ */
+export async function assertNoDescendantOverflowsRight(
+  root: Locator,
+  label = "container",
+): Promise<void> {
+  const rootBox = await root.boundingBox();
+  expect(rootBox, `${label}: root has no bounding box`).not.toBeNull();
+  if (!rootBox) return;
+  const rootRight = rootBox.x + rootBox.width;
+
+  // One round-trip to keep this cheap on a deep DOM.
+  const overflowing: { tag: string; text: string; right: number }[] = await root.evaluate(
+    (node, rightArg) => {
+      const limit = rightArg as number;
+      const results: { tag: string; text: string; right: number }[] = [];
+      const skip = new Set(["SVG", "PATH", "CIRCLE", "RECT", "LINE", "G"]);
+      const all = node.querySelectorAll("*");
+      for (const el of all) {
+        if (skip.has(el.tagName)) continue;
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) continue;
+        if (rect.right > limit + 1) {
+          results.push({
+            tag: el.tagName.toLowerCase(),
+            text: (el.textContent ?? "").trim().slice(0, 80),
+            right: rect.right,
+          });
+        }
+      }
+      return results;
+    },
+    rootRight,
+  );
+
+  expect(
+    overflowing,
+    `${label}: ${overflowing.length} element(s) overflow the right edge (${rootRight.toFixed(
+      1,
+    )}). First few:\n${overflowing
+      .slice(0, 8)
+      .map((o) => `  <${o.tag}> right=${o.right.toFixed(1)} text="${o.text}"`)
+      .join("\n")}`,
+  ).toHaveLength(0);
+}
+
+/**
+ * Asserts that the first element matching `selector` inside `root` has
+ * equal left and right horizontal gaps to `root`'s edges (within 1 px of
+ * sub-pixel rounding). Useful for catching scrollbar-gutter style fixes
+ * that leave the padding asymmetric.
+ */
+export async function assertHorizontalPaddingSymmetric(
+  root: Locator,
+  selector: string,
+  label = selector,
+): Promise<void> {
+  const result = await root.evaluate((node, sel) => {
+    const rootRect = node.getBoundingClientRect();
+    const el = node.querySelector(sel as string) as HTMLElement | null;
+    if (!el) return { missing: true as const };
+    const r = el.getBoundingClientRect();
+    return {
+      missing: false as const,
+      leftGap: Math.round(r.left - rootRect.left),
+      rightGap: Math.round(rootRect.right - r.right),
+    };
+  }, selector);
+  expect(result.missing, `${label}: selector "${selector}" matched nothing`).toBe(false);
+  if (result.missing) return;
+  expect(
+    Math.abs(result.leftGap - result.rightGap),
+    `${label}: leftGap=${result.leftGap}px, rightGap=${result.rightGap}px (selector "${selector}")`,
+  ).toBeLessThanOrEqual(1);
+}
+
+/**
+ * Asserts that the document scrollWidth does not exceed clientWidth — i.e.
+ * the page is not horizontally scrollable.
+ */
+export async function assertNoDocumentHorizontalOverflow(
+  page: { evaluate: <T>(fn: () => T) => Promise<T> },
+  label = "document",
+): Promise<void> {
+  const widths = await page.evaluate(() => ({
+    scroll: document.documentElement.scrollWidth,
+    client: document.documentElement.clientWidth,
+  }));
+  expect(
+    widths.scroll,
+    `${label}: scrollWidth (${widths.scroll}) exceeds clientWidth (${widths.client})`,
+  ).toBeLessThanOrEqual(widths.client + 1);
+}

--- a/apps/web/e2e/tests/office/mobile-onboarding-dialog-rich.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding-dialog-rich.spec.ts
@@ -1,0 +1,142 @@
+import type { Locator } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+
+// Reproduces the "agents section content comes out of the modal on the right"
+// bug on Pixel-class mobile widths. The default mock-agent has a short
+// display_name and no install_script, so the regular spec can't catch the
+// overflow scenarios that real installs trigger (long display names, multi-
+// agent install_script rows, etc.). This spec intercepts the
+// /api/v1/agents/available endpoint and returns a realistic payload.
+
+const FAKE_AVAILABLE_AGENTS = {
+  agents: [
+    {
+      name: "claude-code",
+      display_name: "Claude Code (Anthropic CLI)",
+      available: true,
+      install_script: "",
+      info_url: "",
+      model_config: {
+        default_model: "claude-sonnet-4-5",
+        available_models: [{ id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5 Long Model Name" }],
+        modes: [],
+        current_mode_id: "",
+        status: "ok",
+        error: "",
+      },
+      permission_settings: {},
+      passthrough_config: null,
+    },
+    {
+      name: "codex",
+      display_name: "OpenAI Codex CLI Tool With Long Name",
+      available: false,
+      install_script: "npm install -g @openai/codex-cli-with-a-very-long-package-name",
+      info_url: "",
+      model_config: {
+        default_model: "",
+        available_models: [],
+        modes: [],
+        current_mode_id: "",
+        status: "not_installed",
+        error: "",
+      },
+      permission_settings: {},
+      passthrough_config: null,
+    },
+    {
+      name: "opencode",
+      display_name: "OpenCode",
+      available: false,
+      install_script: "curl -fsSL https://opencode.example.com/install/script.sh | sh",
+      info_url: "",
+      model_config: {
+        default_model: "",
+        available_models: [],
+        modes: [],
+        current_mode_id: "",
+        status: "not_installed",
+        error: "",
+      },
+      permission_settings: {},
+      passthrough_config: null,
+    },
+  ],
+  tools: [
+    {
+      name: "ripgrep",
+      display_name: "ripgrep",
+      description:
+        "Fast recursive search tool used by agents for codebase navigation and file lookups.",
+      available: false,
+      install_script: "brew install ripgrep",
+      info_url: "https://github.com/BurntSushi/ripgrep",
+    },
+  ],
+  total: 3,
+};
+
+test.describe("OnboardingDialog with realistic agent data — mobile layout", () => {
+  test("no content overflows the dialog on Pixel-7-class width (412)", async ({ testPage }) => {
+    await testPage.route("**/api/v1/agents/available**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(FAKE_AVAILABLE_AGENTS),
+      });
+    });
+    await testPage.addInitScript(() => {
+      localStorage.removeItem("kandev.onboarding.completed");
+    });
+    // Pixel 7 viewport. Playwright's `mobile-chrome` project ships Pixel 5
+    // (393x851); we override to Pixel 7's 412x915 here so the spec
+    // reproduces the exact width the user reports.
+    await testPage.setViewportSize({ width: 412, height: 915 });
+    await testPage.goto("/");
+
+    const dialog = testPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(testPage.getByRole("heading", { name: "AI Agents" })).toBeVisible();
+    // Wait for the agent rows to render — listAvailableAgents resolves async.
+    await expect(testPage.getByText("Claude Code (Anthropic CLI)", { exact: true })).toBeVisible();
+
+    await assertNoChildOverflowsDialog(dialog);
+  });
+});
+
+async function assertNoChildOverflowsDialog(dialog: Locator): Promise<void> {
+  const dialogBox = await dialog.boundingBox();
+  expect(dialogBox).not.toBeNull();
+  if (!dialogBox) return;
+  const dialogRight = dialogBox.x + dialogBox.width;
+
+  const overflowing = await dialog.evaluate((root, dialogRightArg) => {
+    const limit = dialogRightArg as number;
+    const results: { tag: string; text: string; right: number }[] = [];
+    const skip = new Set(["SVG", "PATH", "CIRCLE", "RECT", "LINE", "G"]);
+    const all = root.querySelectorAll("*");
+    for (const node of all) {
+      if (skip.has(node.tagName)) continue;
+      const rect = node.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) continue;
+      if (rect.right > limit + 1) {
+        results.push({
+          tag: node.tagName.toLowerCase(),
+          text: (node.textContent ?? "").trim().slice(0, 80),
+          right: rect.right,
+        });
+      }
+    }
+    return results;
+  }, dialogRight);
+
+  expect(
+    overflowing,
+    `Pixel 7 AI Agents: ${overflowing.length} element(s) overflow the dialog right edge (${dialogRight.toFixed(
+      1,
+    )}). First few:\n${overflowing
+      .slice(0, 8)
+      .map((o) => `  <${o.tag}> right=${o.right.toFixed(1)} text="${o.text}"`)
+      .join("\n")}`,
+  ).toHaveLength(0);
+}

--- a/apps/web/e2e/tests/office/mobile-onboarding-dialog-rich.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding-dialog-rich.spec.ts
@@ -1,5 +1,5 @@
-import type { Locator } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
+import { assertNoDescendantOverflowsRight } from "../../helpers/layout-assertions";
 
 // Reproduces the "agents section content comes out of the modal on the right"
 // bug on Pixel-class mobile widths. The default mock-agent has a short
@@ -77,7 +77,9 @@ const FAKE_AVAILABLE_AGENTS = {
 };
 
 test.describe("OnboardingDialog with realistic agent data — mobile layout", () => {
-  test("no content overflows the dialog on Pixel-7-class width (412)", async ({ testPage }) => {
+  test("AI Agents step does not overflow the dialog with realistic agent data (Pixel 7)", async ({
+    testPage,
+  }) => {
     await testPage.route("**/api/v1/agents/available**", async (route) => {
       await route.fulfill({
         status: 200,
@@ -100,43 +102,6 @@ test.describe("OnboardingDialog with realistic agent data — mobile layout", ()
     // Wait for the agent rows to render — listAvailableAgents resolves async.
     await expect(testPage.getByText("Claude Code (Anthropic CLI)", { exact: true })).toBeVisible();
 
-    await assertNoChildOverflowsDialog(dialog);
+    await assertNoDescendantOverflowsRight(dialog, "Pixel 7 AI Agents");
   });
 });
-
-async function assertNoChildOverflowsDialog(dialog: Locator): Promise<void> {
-  const dialogBox = await dialog.boundingBox();
-  expect(dialogBox).not.toBeNull();
-  if (!dialogBox) return;
-  const dialogRight = dialogBox.x + dialogBox.width;
-
-  const overflowing = await dialog.evaluate((root, dialogRightArg) => {
-    const limit = dialogRightArg as number;
-    const results: { tag: string; text: string; right: number }[] = [];
-    const skip = new Set(["SVG", "PATH", "CIRCLE", "RECT", "LINE", "G"]);
-    const all = root.querySelectorAll("*");
-    for (const node of all) {
-      if (skip.has(node.tagName)) continue;
-      const rect = node.getBoundingClientRect();
-      if (rect.width === 0 || rect.height === 0) continue;
-      if (rect.right > limit + 1) {
-        results.push({
-          tag: node.tagName.toLowerCase(),
-          text: (node.textContent ?? "").trim().slice(0, 80),
-          right: rect.right,
-        });
-      }
-    }
-    return results;
-  }, dialogRight);
-
-  expect(
-    overflowing,
-    `Pixel 7 AI Agents: ${overflowing.length} element(s) overflow the dialog right edge (${dialogRight.toFixed(
-      1,
-    )}). First few:\n${overflowing
-      .slice(0, 8)
-      .map((o) => `  <${o.tag}> right=${o.right.toFixed(1)} text="${o.text}"`)
-      .join("\n")}`,
-  ).toHaveLength(0);
-}

--- a/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
@@ -1,5 +1,9 @@
-import type { Locator } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
+import {
+  assertHorizontalPaddingSymmetric,
+  assertNoDescendantOverflowsRight,
+  assertNoDocumentHorizontalOverflow,
+} from "../../helpers/layout-assertions";
 
 // Runs under the mobile-chrome project (Pixel 5, viewport 393x851).
 //
@@ -22,112 +26,32 @@ test.describe("OnboardingDialog — mobile layout", () => {
     await expect(testPage.getByRole("heading", { name: "AI Agents" })).toBeVisible();
 
     // Step 0 — AI Agents
-    await assertNoHorizontalOverflow(dialog, "AI Agents");
-    await assertChildrenFitInDialog(dialog, "AI Agents");
+    await assertNoDocumentHorizontalOverflow(testPage, "AI Agents");
+    await assertNoDescendantOverflowsRight(dialog, "AI Agents");
     // Padding around the agent row must match left/right — i.e. the gap from
-    // the agent row to the dialog's left edge equals the gap from the agent
-    // row to the dialog's right edge. The `pr-1` scrollbar-gutter on the
-    // grid breaks this symmetry; the surrounding paragraphs sit at 17/17
-    // while the row sits at 17/21 (4 px wider gap on the right).
-    await assertHorizontalPaddingSymmetric(dialog, "AI Agents agent row", ".grid.gap-2 > *");
+    // the agent row to the dialog's left edge equals the gap to the right
+    // edge. The `pr-1` scrollbar-gutter on the grid used to break this:
+    // surrounding paragraphs sat at 17/17 while the row sat at 17/21.
+    await assertHorizontalPaddingSymmetric(dialog, ".grid.gap-2 > *", "AI Agents agent row");
 
     // Step 1 — Executors
     await dialog.getByRole("button", { name: /next/i }).click();
     await expect(testPage.getByRole("heading", { name: "Executors" })).toBeVisible();
-    await assertNoHorizontalOverflow(dialog, "Executors");
-    await assertChildrenFitInDialog(dialog, "Executors");
+    await assertNoDocumentHorizontalOverflow(testPage, "Executors");
+    await assertNoDescendantOverflowsRight(dialog, "Executors");
 
     // Step 2 — Agentic Workflows (the workflow step rows use whitespace-nowrap
     // by default, which is exactly the kind of layout that overflows a phone-
     // sized dialog).
     await dialog.getByRole("button", { name: /next/i }).click();
     await expect(testPage.getByRole("heading", { name: "Agentic Workflows" })).toBeVisible();
-    await assertNoHorizontalOverflow(dialog, "Agentic Workflows");
-    await assertChildrenFitInDialog(dialog, "Agentic Workflows");
+    await assertNoDocumentHorizontalOverflow(testPage, "Agentic Workflows");
+    await assertNoDescendantOverflowsRight(dialog, "Agentic Workflows");
 
     // Step 3 — Command Panel
     await dialog.getByRole("button", { name: /next/i }).click();
     await expect(testPage.getByRole("heading", { name: "Command Panel" })).toBeVisible();
-    await assertNoHorizontalOverflow(dialog, "Command Panel");
-    await assertChildrenFitInDialog(dialog, "Command Panel");
+    await assertNoDocumentHorizontalOverflow(testPage, "Command Panel");
+    await assertNoDescendantOverflowsRight(dialog, "Command Panel");
   });
 });
-
-async function assertNoHorizontalOverflow(dialog: Locator, label: string): Promise<void> {
-  const widths = await dialog.evaluate((el) => ({
-    scroll: el.scrollWidth,
-    client: el.clientWidth,
-  }));
-  expect(
-    widths.scroll,
-    `${label}: dialog scrollWidth (${widths.scroll}) exceeds clientWidth (${widths.client})`,
-  ).toBeLessThanOrEqual(widths.client + 1);
-}
-
-async function assertChildrenFitInDialog(dialog: Locator, label: string): Promise<void> {
-  const dialogBox = await dialog.boundingBox();
-  expect(dialogBox, `${label}: dialog has no bounding box`).not.toBeNull();
-  if (!dialogBox) return;
-  const dialogRight = dialogBox.x + dialogBox.width;
-
-  // Walk every visible descendant. Anything whose visible right edge exceeds
-  // the dialog right edge is "content coming out of the modal on the right".
-  // Done in one evaluate round-trip so this stays cheap on a deep DOM.
-  const overflowing: { tag: string; text: string; right: number }[] = await dialog.evaluate(
-    (root, dialogRightArg) => {
-      const limit = dialogRightArg as number;
-      const results: { tag: string; text: string; right: number }[] = [];
-      const skip = new Set(["SVG", "PATH", "CIRCLE", "RECT", "LINE", "G"]);
-      const all = root.querySelectorAll("*");
-      for (const node of all) {
-        if (skip.has(node.tagName)) continue;
-        const rect = node.getBoundingClientRect();
-        if (rect.width === 0 || rect.height === 0) continue;
-        if (rect.right > limit + 1) {
-          results.push({
-            tag: node.tagName.toLowerCase(),
-            text: (node.textContent ?? "").trim().slice(0, 80),
-            right: rect.right,
-          });
-        }
-      }
-      return results;
-    },
-    dialogRight,
-  );
-
-  expect(
-    overflowing,
-    `${label}: ${overflowing.length} element(s) overflow the dialog right edge (${dialogRight.toFixed(
-      1,
-    )}). First few:\n${overflowing
-      .slice(0, 5)
-      .map((o) => `  <${o.tag}> right=${o.right.toFixed(1)} text="${o.text}"`)
-      .join("\n")}`,
-  ).toHaveLength(0);
-}
-
-async function assertHorizontalPaddingSymmetric(
-  dialog: Locator,
-  label: string,
-  selector: string,
-): Promise<void> {
-  const result = await dialog.evaluate((root, sel) => {
-    const dialogRect = root.getBoundingClientRect();
-    const el = root.querySelector(sel as string) as HTMLElement | null;
-    if (!el) return { missing: true as const };
-    const r = el.getBoundingClientRect();
-    return {
-      missing: false as const,
-      leftGap: Math.round(r.left - dialogRect.left),
-      rightGap: Math.round(dialogRect.right - r.right),
-    };
-  }, selector);
-  expect(result.missing, `${label}: selector "${selector}" matched nothing`).toBe(false);
-  if (result.missing) return;
-  // Allow 1 px of sub-pixel rounding slack — anything more is asymmetric.
-  expect(
-    Math.abs(result.leftGap - result.rightGap),
-    `${label}: leftGap=${result.leftGap}px, rightGap=${result.rightGap}px (selector "${selector}")`,
-  ).toBeLessThanOrEqual(1);
-}

--- a/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
@@ -1,0 +1,102 @@
+import type { Locator } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+
+// Runs under the mobile-chrome project (Pixel 5, viewport 393x851).
+//
+// Covers the OnboardingDialog that opens from `/` when the
+// `kandev.onboarding.completed` localStorage flag is unset. It is distinct
+// from the office /office/setup wizard (separate spec) — this dialog has
+// four steps: AI Agents, Executors, Agentic Workflows, Command Panel.
+
+test.describe("OnboardingDialog — mobile layout", () => {
+  test("dialog and each step stay inside the viewport on Pixel 5", async ({ testPage }) => {
+    // Undo the test-base init script that pre-marks onboarding completed —
+    // otherwise the dialog never opens on `/`.
+    await testPage.addInitScript(() => {
+      localStorage.removeItem("kandev.onboarding.completed");
+    });
+    await testPage.goto("/");
+
+    const dialog = testPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(testPage.getByRole("heading", { name: "AI Agents" })).toBeVisible();
+
+    // Step 0 — AI Agents
+    await assertNoHorizontalOverflow(dialog, "AI Agents");
+    await assertChildrenFitInDialog(dialog, "AI Agents");
+
+    // Step 1 — Executors
+    await dialog.getByRole("button", { name: /next/i }).click();
+    await expect(testPage.getByRole("heading", { name: "Executors" })).toBeVisible();
+    await assertNoHorizontalOverflow(dialog, "Executors");
+    await assertChildrenFitInDialog(dialog, "Executors");
+
+    // Step 2 — Agentic Workflows (the workflow step rows use whitespace-nowrap
+    // by default, which is exactly the kind of layout that overflows a phone-
+    // sized dialog).
+    await dialog.getByRole("button", { name: /next/i }).click();
+    await expect(testPage.getByRole("heading", { name: "Agentic Workflows" })).toBeVisible();
+    await assertNoHorizontalOverflow(dialog, "Agentic Workflows");
+    await assertChildrenFitInDialog(dialog, "Agentic Workflows");
+
+    // Step 3 — Command Panel
+    await dialog.getByRole("button", { name: /next/i }).click();
+    await expect(testPage.getByRole("heading", { name: "Command Panel" })).toBeVisible();
+    await assertNoHorizontalOverflow(dialog, "Command Panel");
+    await assertChildrenFitInDialog(dialog, "Command Panel");
+  });
+});
+
+async function assertNoHorizontalOverflow(dialog: Locator, label: string): Promise<void> {
+  const widths = await dialog.evaluate((el) => ({
+    scroll: el.scrollWidth,
+    client: el.clientWidth,
+  }));
+  expect(
+    widths.scroll,
+    `${label}: dialog scrollWidth (${widths.scroll}) exceeds clientWidth (${widths.client})`,
+  ).toBeLessThanOrEqual(widths.client + 1);
+}
+
+async function assertChildrenFitInDialog(dialog: Locator, label: string): Promise<void> {
+  const dialogBox = await dialog.boundingBox();
+  expect(dialogBox, `${label}: dialog has no bounding box`).not.toBeNull();
+  if (!dialogBox) return;
+  const dialogRight = dialogBox.x + dialogBox.width;
+
+  // Walk every visible descendant. Anything whose visible right edge exceeds
+  // the dialog right edge is "content coming out of the modal on the right".
+  // Done in one evaluate round-trip so this stays cheap on a deep DOM.
+  const overflowing: { tag: string; text: string; right: number }[] = await dialog.evaluate(
+    (root, dialogRightArg) => {
+      const limit = dialogRightArg as number;
+      const results: { tag: string; text: string; right: number }[] = [];
+      const skip = new Set(["SVG", "PATH", "CIRCLE", "RECT", "LINE", "G"]);
+      const all = root.querySelectorAll("*");
+      for (const node of all) {
+        if (skip.has(node.tagName)) continue;
+        const rect = node.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) continue;
+        if (rect.right > limit + 1) {
+          results.push({
+            tag: node.tagName.toLowerCase(),
+            text: (node.textContent ?? "").trim().slice(0, 80),
+            right: rect.right,
+          });
+        }
+      }
+      return results;
+    },
+    dialogRight,
+  );
+
+  expect(
+    overflowing,
+    `${label}: ${overflowing.length} element(s) overflow the dialog right edge (${dialogRight.toFixed(
+      1,
+    )}). First few:\n${overflowing
+      .slice(0, 5)
+      .map((o) => `  <${o.tag}> right=${o.right.toFixed(1)} text="${o.text}"`)
+      .join("\n")}`,
+  ).toHaveLength(0);
+}

--- a/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
@@ -28,6 +28,11 @@ test.describe("OnboardingDialog — mobile layout", () => {
     // Step 0 — AI Agents
     await assertNoDocumentHorizontalOverflow(testPage, "AI Agents");
     await assertNoDescendantOverflowsRight(dialog, "AI Agents");
+    // The DialogTitle ("AI Agents") renders synchronously regardless of
+    // loading state — StepAgents only mounts the `.grid.gap-2` once the
+    // /api/v1/agents/available probe resolves, so wait for an actual row
+    // before asserting padding or the selector matches nothing.
+    await expect(dialog.locator(".grid.gap-2 > *").first()).toBeVisible();
     // Padding around the agent row must match left/right — i.e. the gap from
     // the agent row to the dialog's left edge equals the gap to the right
     // edge. The `pr-1` scrollbar-gutter on the grid used to break this:

--- a/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding-dialog.spec.ts
@@ -24,6 +24,12 @@ test.describe("OnboardingDialog — mobile layout", () => {
     // Step 0 — AI Agents
     await assertNoHorizontalOverflow(dialog, "AI Agents");
     await assertChildrenFitInDialog(dialog, "AI Agents");
+    // Padding around the agent row must match left/right — i.e. the gap from
+    // the agent row to the dialog's left edge equals the gap from the agent
+    // row to the dialog's right edge. The `pr-1` scrollbar-gutter on the
+    // grid breaks this symmetry; the surrounding paragraphs sit at 17/17
+    // while the row sits at 17/21 (4 px wider gap on the right).
+    await assertHorizontalPaddingSymmetric(dialog, "AI Agents agent row", ".grid.gap-2 > *");
 
     // Step 1 — Executors
     await dialog.getByRole("button", { name: /next/i }).click();
@@ -99,4 +105,29 @@ async function assertChildrenFitInDialog(dialog: Locator, label: string): Promis
       .map((o) => `  <${o.tag}> right=${o.right.toFixed(1)} text="${o.text}"`)
       .join("\n")}`,
   ).toHaveLength(0);
+}
+
+async function assertHorizontalPaddingSymmetric(
+  dialog: Locator,
+  label: string,
+  selector: string,
+): Promise<void> {
+  const result = await dialog.evaluate((root, sel) => {
+    const dialogRect = root.getBoundingClientRect();
+    const el = root.querySelector(sel as string) as HTMLElement | null;
+    if (!el) return { missing: true as const };
+    const r = el.getBoundingClientRect();
+    return {
+      missing: false as const,
+      leftGap: Math.round(r.left - dialogRect.left),
+      rightGap: Math.round(dialogRect.right - r.right),
+    };
+  }, selector);
+  expect(result.missing, `${label}: selector "${selector}" matched nothing`).toBe(false);
+  if (result.missing) return;
+  // Allow 1 px of sub-pixel rounding slack — anything more is asymmetric.
+  expect(
+    Math.abs(result.leftGap - result.rightGap),
+    `${label}: leftGap=${result.leftGap}px, rightGap=${result.rightGap}px (selector "${selector}")`,
+  ).toBeLessThanOrEqual(1);
 }

--- a/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
@@ -1,36 +1,33 @@
 import type { Locator } from "@playwright/test";
 import { test, expect } from "../../fixtures/office-fixture";
+import { assertNoDocumentHorizontalOverflow } from "../../helpers/layout-assertions";
 
 // These tests run under the mobile-chrome Playwright project (Pixel 5,
 // viewport 393x851). They catch layout regressions that a desktop viewport
 // hides: horizontal overflow and clipped-off-viewport interactive elements
 // on the office onboarding wizard.
 
+const SETUP_ROUTE = "/office/setup?mode=new";
+const STEP_0_HEADING = "Set up your Office workspace";
+const STEP_1_HEADING = "Create your coordinator agent";
+
 test.describe("Office onboarding — mobile layout", () => {
   test("setup wizard does not overflow horizontally on Pixel 5", async ({
     testPage,
     officeSeed: _,
   }) => {
-    await testPage.goto("/office/setup?mode=new");
-    await expect(
-      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
-    ).toBeVisible();
+    await testPage.goto(SETUP_ROUTE);
+    await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
 
-    const overflow = await testPage.evaluate(() => ({
-      scroll: document.documentElement.scrollWidth,
-      client: document.documentElement.clientWidth,
-    }));
-    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
+    await assertNoDocumentHorizontalOverflow(testPage, "setup wizard Step 0");
   });
 
   test("close button is fully inside the viewport on mobile", async ({
     testPage,
     officeSeed: _,
   }) => {
-    await testPage.goto("/office/setup?mode=new");
-    await expect(
-      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
-    ).toBeVisible();
+    await testPage.goto(SETUP_ROUTE);
+    await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
 
     const close = testPage.getByRole("button", { name: "Cancel" });
     const box = await close.boundingBox();
@@ -48,20 +45,12 @@ test.describe("Office onboarding — mobile layout", () => {
     testPage,
     officeSeed: _,
   }) => {
-    await testPage.goto("/office/setup?mode=new");
-    await expect(
-      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
-    ).toBeVisible();
+    await testPage.goto(SETUP_ROUTE);
+    await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
-    await expect(
-      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
-    ).toBeVisible();
+    await expect(testPage.getByRole("heading", { name: STEP_1_HEADING })).toBeVisible();
 
-    const overflow = await testPage.evaluate(() => ({
-      scroll: document.documentElement.scrollWidth,
-      client: document.documentElement.clientWidth,
-    }));
-    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
+    await assertNoDocumentHorizontalOverflow(testPage, "agent step (Step 1)");
 
     const viewport = testPage.viewportSize();
     expect(viewport).not.toBeNull();
@@ -91,13 +80,11 @@ test.describe("Office onboarding — mobile layout", () => {
     // (top of Step 1) and the Next button (bottom of Step 1) end up clipped
     // off-screen — and because the wrapper has no overflow-y-auto, the user
     // cannot scroll to reach them. The whole step becomes unusable.
-    await testPage.goto("/office/setup?mode=new");
-    await expect(
-      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
-    ).toBeVisible();
+    await testPage.goto(SETUP_ROUTE);
+    await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
     await testPage.getByRole("button", { name: /next/i }).click();
 
-    const heading = testPage.getByRole("heading", { name: "Create your coordinator agent" });
+    const heading = testPage.getByRole("heading", { name: STEP_1_HEADING });
     await expect(heading).toBeVisible();
 
     const viewport = testPage.viewportSize();
@@ -140,11 +127,9 @@ test.describe("Office onboarding — mobile layout", () => {
     testPage,
     officeSeed: _,
   }) => {
-    await testPage.goto("/office/setup?mode=new");
+    await testPage.goto(SETUP_ROUTE);
     await testPage.getByRole("button", { name: /next/i }).click();
-    await expect(
-      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
-    ).toBeVisible();
+    await expect(testPage.getByRole("heading", { name: STEP_1_HEADING })).toBeVisible();
 
     await testPage.getByTestId("agent-profile-selector").click();
     // Wait for the popover to actually mount instead of sleeping — the
@@ -155,11 +140,7 @@ test.describe("Office onboarding — mobile layout", () => {
       .first()
       .waitFor({ state: "visible" });
 
-    const overflow = await testPage.evaluate(() => ({
-      scroll: document.documentElement.scrollWidth,
-      client: document.documentElement.clientWidth,
-    }));
-    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
+    await assertNoDocumentHorizontalOverflow(testPage, "agent profile combobox open");
   });
 });
 

--- a/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
@@ -1,0 +1,171 @@
+import type { Locator } from "@playwright/test";
+import { test, expect } from "../../fixtures/office-fixture";
+
+// These tests run under the mobile-chrome Playwright project (Pixel 5,
+// viewport 393x851). They catch layout regressions that a desktop viewport
+// hides: horizontal overflow and clipped-off-viewport interactive elements
+// on the office onboarding wizard.
+
+test.describe("Office onboarding — mobile layout", () => {
+  test("setup wizard does not overflow horizontally on Pixel 5", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto("/office/setup?mode=new");
+    await expect(
+      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
+    ).toBeVisible();
+
+    const overflow = await testPage.evaluate(() => ({
+      scroll: document.documentElement.scrollWidth,
+      client: document.documentElement.clientWidth,
+    }));
+    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
+  });
+
+  test("close button is fully inside the viewport on mobile", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto("/office/setup?mode=new");
+    await expect(
+      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
+    ).toBeVisible();
+
+    const close = testPage.getByRole("button", { name: "Cancel" });
+    const box = await close.boundingBox();
+    const viewport = testPage.viewportSize();
+    expect(box).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    if (!box || !viewport) return;
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+    expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+  });
+
+  test("agent step (Step 1) fits within the viewport horizontally", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto("/office/setup?mode=new");
+    await expect(
+      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
+    ).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+    await expect(
+      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
+    ).toBeVisible();
+
+    const overflow = await testPage.evaluate(() => ({
+      scroll: document.documentElement.scrollWidth,
+      client: document.documentElement.clientWidth,
+    }));
+    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
+
+    const viewport = testPage.viewportSize();
+    expect(viewport).not.toBeNull();
+    if (!viewport) return;
+
+    // Every visible interactive control on this step must fit inside the
+    // viewport horizontally. Catches comboboxes forcing a min-width wider
+    // than the phone screen, or a row whose icon + label still exceeds it.
+    const inputs = testPage.locator("input, button, [role=combobox]");
+    const count = await inputs.count();
+    for (let i = 0; i < count; i++) {
+      const el = inputs.nth(i);
+      const box = await el.boundingBox();
+      if (!box) continue; // hidden
+      const tag = await describeElement(el);
+      expect(box.x + box.width, tag).toBeLessThanOrEqual(viewport.width + 1);
+      expect(box.x, tag).toBeGreaterThanOrEqual(-1);
+    }
+  });
+
+  test("agent step (Step 1) heading and Next button are reachable on mobile", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    // The bug we are catching: `fixed inset-0 ... flex items-center` centers
+    // content that is taller than the phone viewport, so both the step heading
+    // (top of Step 1) and the Next button (bottom of Step 1) end up clipped
+    // off-screen — and because the wrapper has no overflow-y-auto, the user
+    // cannot scroll to reach them. The whole step becomes unusable.
+    await testPage.goto("/office/setup?mode=new");
+    await expect(
+      testPage.getByRole("heading", { name: "Set up your Office workspace" }),
+    ).toBeVisible();
+    await testPage.getByRole("button", { name: /next/i }).click();
+
+    const heading = testPage.getByRole("heading", { name: "Create your coordinator agent" });
+    await expect(heading).toBeVisible();
+
+    const viewport = testPage.viewportSize();
+    expect(viewport).not.toBeNull();
+    if (!viewport) return;
+
+    // The user has to be able to reach the controls without scrolling magic.
+    // We allow scrolling, but the heading must sit inside the document
+    // (positive y) and the Next button must be reachable by scrolling the
+    // page (its bottom must be <= scrollHeight, i.e. inside the document).
+    const headingBox = await heading.boundingBox();
+    expect(headingBox).not.toBeNull();
+    if (!headingBox) return;
+    expect(
+      headingBox.y,
+      "step heading should not be clipped above the document",
+    ).toBeGreaterThanOrEqual(-1);
+
+    const next = testPage.getByRole("button", { name: /next/i });
+    const nextBox = await next.boundingBox();
+    expect(nextBox).not.toBeNull();
+    if (!nextBox) return;
+    const scrollHeight = await testPage.evaluate(() => document.documentElement.scrollHeight);
+    expect(
+      nextBox.y + nextBox.height,
+      "Next button must be reachable within the scrollable document",
+    ).toBeLessThanOrEqual(scrollHeight + 1);
+
+    // And: actually clicking Next must advance the wizard. If the wrapper
+    // is unscrollable and Next is below the viewport, Playwright's auto-
+    // scroll cannot bring it on-screen and the click times out — which is
+    // exactly the user-facing bug.
+    await next.click();
+    await expect(
+      testPage.getByRole("heading", { name: /Give your .* something to do/i }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("opening the agent profile combobox keeps the document within the viewport", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto("/office/setup?mode=new");
+    await testPage.getByRole("button", { name: /next/i }).click();
+    await expect(
+      testPage.getByRole("heading", { name: "Create your coordinator agent" }),
+    ).toBeVisible();
+
+    await testPage.getByTestId("agent-profile-selector").click();
+    await testPage.waitForTimeout(150); // let the popover position
+
+    const overflow = await testPage.evaluate(() => ({
+      scroll: document.documentElement.scrollWidth,
+      client: document.documentElement.clientWidth,
+    }));
+    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
+  });
+});
+
+async function describeElement(el: Locator): Promise<string> {
+  return el
+    .evaluate((node: Element) => {
+      const tid = node.getAttribute("data-testid");
+      if (tid) return `[data-testid="${tid}"]`;
+      const label = node.getAttribute("aria-label");
+      const text = (node.textContent ?? "").trim().slice(0, 30);
+      const id = node.id ? `#${node.id}` : "";
+      return `${node.tagName.toLowerCase()}${id}${label ? `[aria-label="${label}"]` : ""}${text ? ` "${text}"` : ""}`;
+    })
+    .catch(() => "(unknown element)");
+}

--- a/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
@@ -147,7 +147,13 @@ test.describe("Office onboarding — mobile layout", () => {
     ).toBeVisible();
 
     await testPage.getByTestId("agent-profile-selector").click();
-    await testPage.waitForTimeout(150); // let the popover position
+    // Wait for the popover to actually mount instead of sleeping — the
+    // Radix popover renders as `[data-radix-popper-content-wrapper]` and
+    // is positioned synchronously once present.
+    await testPage
+      .locator("[data-radix-popper-content-wrapper], [role=listbox]")
+      .first()
+      .waitFor({ state: "visible" });
 
     const overflow = await testPage.evaluate(() => ({
       scroll: document.documentElement.scrollWidth,


### PR DESCRIPTION
## Summary

Four mobile-layout fixes for the onboarding surfaces, each landed RED-first with a Playwright spec under the existing `mobile-chrome` project.

1. **Office setup wizard close button** (`apps/web/app/office/setup/close-button.tsx`)
   Was `absolute -top-12 -left-12`, which placed Cancel ~48 px left of the document on phones — off-screen and unreachable. Pinned to `fixed top-4 right-4 z-10` on mobile, original `-top-12 -left-12` placement restored at `lg+`.

2. **Root `OnboardingDialog` "Agentic Workflows" step** (`apps/web/components/onboarding-dialog.tsx`)
   `TemplateCard`'s step row used `whitespace-nowrap`, forcing the row to grow to ~522 px to fit `Backlog → In Progress → In Review → Done`. On a 359-px-wide dialog (Pixel 5) the card extended past the right edge. Switched the row to `flex flex-wrap` with each `arrow + step name` bundled into a single non-breaking flex item, so they wrap together on a new line when needed.

3. **Symmetric inner padding on the agent/workflow scroll grids** (`apps/web/components/onboarding/step-agents.tsx`, `apps/web/components/onboarding-dialog.tsx`)
   Both `StepAgents` and `StepWorkflows` had `overflow-y-auto pr-1` on the list grid as a scrollbar-gutter reservation. With the lists usually short enough that no scrollbar appears, the `pr-1` just left a 4 px asymmetric inset (17 left / 21 right). Dropped it so all "inner sections" sit at the same 17 / 17 inset as the surrounding paragraphs.

4. **Agent rows blowing past the dialog on Pixel 7-class viewports** (`apps/web/components/onboarding/step-agents.tsx`)
   The agents/tools grid used bare `grid gap-2` which leaves tracks as `minmax(auto, 1fr)` — `min-width: auto` on each item refuses to shrink below min-content, so realistic content (e.g. `display_name: "Claude Code (Anthropic CLI)"`, install_script tokens, model-name pill) forced the row wider than the dialog. Added `grid-cols-1` so tracks become `minmax(0, 1fr)`, plus belt-and-braces row internals — `truncate` on each display_name `<p>`, `min-w-0` on the inner flex wrapping `<code>install_script</code>` + CopyButton, and `shrink-0` on the trailing icons.

## Test plan

E2E specs (mobile-chrome project):

- `tests/office/mobile-onboarding.spec.ts` — 5 tests on the `/office/setup` wizard at Pixel 5: no horizontal document overflow, close button inside viewport, Step 1 controls within viewport, Step 1 actions reachable, agent profile popover keeps document inside viewport.
- `tests/office/mobile-onboarding-dialog.spec.ts` — walks all four steps of the root `OnboardingDialog` (AI Agents, Executors, Agentic Workflows, Command Panel), asserts no dialog scroll, no descendant overflowing the dialog right edge, and now agent-row left/right gaps match within 1 px.
- `tests/office/mobile-onboarding-dialog-rich.spec.ts` — intercepts `/api/v1/agents/available` with realistic agent + tool payload, drives the dialog at exactly 412 × 915 (Pixel 7), and asserts no descendant overflows. Pre-fix this caught 59 overflowing elements; post-fix it's 0.

## Validation

- `cd apps && pnpm --filter @kandev/web e2e -- tests/office/mobile-onboarding.spec.ts tests/office/mobile-onboarding-dialog.spec.ts tests/office/mobile-onboarding-dialog-rich.spec.ts tests/office/onboarding.spec.ts` → 18 / 18 pass (no desktop regression in the existing 11-test onboarding suite)
- `cd apps && pnpm --filter @kandev/web lint` → clean
- `cd apps && pnpm --filter @kandev/web typecheck` → clean

## Manual verification

Pixel 5 (Step 0–3 of `OnboardingDialog`), Pixel 7 with realistic agent data, Pixel 5 across all four office-wizard steps with default seeded mock agent, plus `lg+` regression check that the office wizard's close button restores to its `-top-12 -left-12` corner placement on desktop.