### PR TITLE
feat(web): collapsible queue chip with animated panel

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -470,7 +470,9 @@
   .chat-input-running,
   .chat-input-running-plan,
   .chat-input-starting,
-  .search-flash {
+  .search-flash,
+  .animate-queue-open,
+  .animate-queue-close {
     animation: none;
   }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1427,3 +1427,33 @@
     background-color: transparent;
   }
 }
+
+/* Queue panel collapsible — animate height + opacity using the Radix
+ * Collapsible CSS variable. Used by QueueAffordance so opening/closing the
+ * queued-messages panel feels intentional rather than popping. */
+@keyframes queue-panel-open {
+  from {
+    height: 0;
+    opacity: 0;
+  }
+  to {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+}
+@keyframes queue-panel-close {
+  from {
+    height: var(--radix-collapsible-content-height);
+    opacity: 1;
+  }
+  to {
+    height: 0;
+    opacity: 0;
+  }
+}
+.animate-queue-open {
+  animation: queue-panel-open 220ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+.animate-queue-close {
+  animation: queue-panel-close 180ms cubic-bezier(0.32, 0.72, 0, 1);
+}

--- a/apps/web/components/quick-chat/quick-chat-content.tsx
+++ b/apps/web/components/quick-chat/quick-chat-content.tsx
@@ -3,7 +3,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { type ChatInputContainerHandle } from "@/components/task/chat/chat-input-container";
-import { QueuedGhostList } from "@/components/task/chat/queued-ghost-list";
 import { MessageList } from "@/components/task/chat/message-list";
 import { useChatPanelState } from "@/components/task/chat/use-chat-panel-state";
 import {
@@ -100,7 +99,6 @@ export const QuickChatContent = memo(function QuickChatContent({
           />
         </div>
       )}
-      <QueuedGhostList sessionId={panelState.resolvedSessionId} isArchived={false} />
       <ChatInputArea
         chatInputRef={chatInputRef}
         clarificationKey={clarificationKey}

--- a/apps/web/components/quick-chat/quick-chat-content.tsx
+++ b/apps/web/components/quick-chat/quick-chat-content.tsx
@@ -30,12 +30,7 @@ function useQuickChatState(sessionId: string) {
     onOpenFileAtLine: undefined,
   });
   const { isSending, handleSubmit } = useSubmitHandler(panelState, undefined);
-  const { clearQueue } = panelState;
-  const { handleCancelTurn } = useChatPanelHandlers(
-    panelState.resolvedSessionId,
-    clearQueue,
-    chatInputRef,
-  );
+  const { handleCancelTurn } = useChatPanelHandlers(panelState.resolvedSessionId, chatInputRef);
 
   return {
     chatInputRef,

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -184,7 +184,6 @@ export function useSubmitHandler(
 
 export function useChatPanelHandlers(
   resolvedSessionId: string | null,
-  clearQueue: () => Promise<void>,
   chatInputRef: React.RefObject<ChatInputContainerHandle | null>,
 ) {
   const handleCancelTurn = useCallback(async () => {
@@ -197,18 +196,6 @@ export function useChatPanelHandlers(
       console.error("Failed to cancel agent turn:", error);
     }
   }, [resolvedSessionId]);
-
-  const handleClearQueue = useCallback(async () => {
-    try {
-      await clearQueue();
-    } catch (error) {
-      console.error("Failed to clear queue:", error);
-    }
-  }, [clearQueue]);
-
-  const handleQueueEditComplete = useCallback(() => {
-    chatInputRef.current?.focusInput();
-  }, [chatInputRef]);
 
   const keyboardShortcuts = useAppStore((s) => s.userSettings.keyboardShortcuts);
   useKeyboardShortcut(
@@ -232,7 +219,7 @@ export function useChatPanelHandlers(
     { enabled: true, preventDefault: false },
   );
 
-  return { handleCancelTurn, handleClearQueue, handleQueueEditComplete };
+  return { handleCancelTurn };
 }
 
 function PRMergedBanner({ taskId }: { taskId: string }) {

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -17,6 +17,7 @@ import {
   type ChatInputContainerHandle,
   type MessageAttachment,
 } from "@/components/task/chat/chat-input-container";
+import { QueueAffordance } from "@/components/task/chat/queued-ghost-list";
 import {
   formatReviewCommentsAsMarkdown,
   formatPRFeedbackAsMarkdown,
@@ -64,6 +65,28 @@ function resolveInputPlaceholder(
   if (activeDocumentType === "file") return "Continue working on the file...";
   if (planModeEnabled) return "Continue working on the plan...";
   return "Continue working on the task...";
+}
+
+type PlaceholderArgs = {
+  override: string | undefined;
+  isMoving: boolean;
+  isAgentBusy: boolean;
+  activeDocumentType: string | undefined;
+  planModeEnabled: boolean;
+  hasClarification: boolean;
+  needsRecovery: boolean;
+};
+
+function pickInputPlaceholder(a: PlaceholderArgs): string {
+  if (a.isMoving) return "Switching agent...";
+  if (a.override) return a.override;
+  return resolveInputPlaceholder(
+    a.isAgentBusy,
+    a.activeDocumentType,
+    a.planModeEnabled,
+    a.hasClarification,
+    a.needsRecovery,
+  );
 }
 
 export function useSubmitHandler(
@@ -347,6 +370,34 @@ function useExecutorUnavailable(taskId: string | null, sessionId: string | null)
   };
 }
 
+function useChatInputDerived(
+  panelState: ReturnType<typeof useChatPanelState>,
+  chatInputRef: React.RefObject<ChatInputContainerHandle | null>,
+  placeholderOverride: string | undefined,
+) {
+  const { resolvedSessionId, taskId, isAgentBusy, needsRecovery, planModeEnabled, activeDocument } =
+    panelState;
+  const planActions = usePlanActions({
+    resolvedSessionId,
+    taskId,
+    planModeEnabled,
+    handlePlanModeChange: panelState.handlePlanModeChange,
+    chatInputRef,
+  });
+  const hasClarification = !!panelState.pendingClarification;
+  const executor = useExecutorUnavailable(taskId, resolvedSessionId);
+  const placeholder = pickInputPlaceholder({
+    override: placeholderOverride,
+    isMoving: planActions.isMoving,
+    isAgentBusy,
+    activeDocumentType: activeDocument?.type,
+    planModeEnabled,
+    hasClarification,
+    needsRecovery,
+  });
+  return { planActions, executor, placeholder };
+}
+
 export function ChatInputArea({
   chatInputRef,
   clarificationKey,
@@ -362,35 +413,14 @@ export function ChatInputArea({
   hidePlanMode,
   placeholderOverride,
 }: ChatInputAreaProps) {
-  const {
-    resolvedSessionId,
-    taskId,
-    isAgentBusy,
-    needsRecovery,
-    planModeEnabled,
-    activeDocument,
-    handlePlanModeChange,
-    todoItems,
-  } = panelState;
-  const { implementPlanHandler, proceedStepName, proceed, isMoving } = usePlanActions({
-    resolvedSessionId,
-    taskId,
-    planModeEnabled,
-    handlePlanModeChange,
+  const { resolvedSessionId, taskId, isAgentBusy, needsRecovery, planModeEnabled, todoItems } =
+    panelState;
+  const { planActions, executor, placeholder } = useChatInputDerived(
+    panelState,
     chatInputRef,
-  });
-  const hasClarification = !!panelState.pendingClarification;
-  const executor = useExecutorUnavailable(taskId, resolvedSessionId);
-  const placeholder = isMoving
-    ? "Switching agent..."
-    : (placeholderOverride ??
-      resolveInputPlaceholder(
-        isAgentBusy,
-        activeDocument?.type,
-        planModeEnabled,
-        hasClarification,
-        needsRecovery,
-      ));
+    placeholderOverride,
+  );
+  const { implementPlanHandler, proceedStepName, proceed, isMoving } = planActions;
   return (
     <div className="bg-card flex-shrink-0 px-2 pb-2 pt-1">
       <ChatStatusBar
@@ -401,49 +431,51 @@ export function ChatInputArea({
         isAgentBusy={isAgentBusy}
         isMoving={isMoving}
       />
-      <ChatInputContainer
-        ref={chatInputRef}
-        key={clarificationKey}
-        onSubmit={handleSubmit}
-        sessionId={resolvedSessionId}
-        taskId={taskId}
-        taskTitle={panelState.task?.title}
-        taskDescription={panelState.taskDescription ?? ""}
-        planModeEnabled={planModeEnabled}
-        planModeAvailable={panelState.planModeAvailable}
-        mcpServers={panelState.mcpServers}
-        onPlanModeChange={handlePlanModeChange}
-        isAgentBusy={isAgentBusy}
-        isStarting={panelState.isStarting}
-        isPreparingEnvironment={panelState.isPreparingEnvironment}
-        isMoving={isMoving}
-        isSending={isSending}
-        onCancel={handleCancelTurn}
-        placeholder={placeholder}
-        pendingClarification={panelState.pendingClarification}
-        onClarificationResolved={onClarificationResolved}
-        showRequestChangesTooltip={showRequestChangesTooltip}
-        onRequestChangesTooltipDismiss={onRequestChangesTooltipDismiss}
-        pendingCommentsByFile={panelState.pendingCommentsByFile}
-        hasContextComments={
-          panelState.planComments.length > 0 || panelState.pendingPRFeedback.length > 0
-        }
-        submitKey={panelState.chatSubmitKey}
-        hasAgentCommands={!!(panelState.agentCommands && panelState.agentCommands.length > 0)}
-        isFailed={panelState.isFailed}
-        needsRecovery={needsRecovery}
-        executorUnavailable={executor.unavailable}
-        executorUnavailableReason={executor.reason}
-        contextItems={panelState.contextItems}
-        planContextEnabled={panelState.planContextEnabled}
-        contextFiles={panelState.contextFiles}
-        onToggleContextFile={panelState.handleToggleContextFile}
-        onAddContextFile={panelState.handleAddContextFile}
-        onImplementPlan={implementPlanHandler}
-        hideSessionsDropdown={hideSessionsDropdown}
-        minimalToolbar={minimalToolbar}
-        hidePlanMode={hidePlanMode}
-      />
+      <QueueAffordance sessionId={resolvedSessionId}>
+        <ChatInputContainer
+          ref={chatInputRef}
+          key={clarificationKey}
+          onSubmit={handleSubmit}
+          sessionId={resolvedSessionId}
+          taskId={taskId}
+          taskTitle={panelState.task?.title}
+          taskDescription={panelState.taskDescription ?? ""}
+          planModeEnabled={planModeEnabled}
+          planModeAvailable={panelState.planModeAvailable}
+          mcpServers={panelState.mcpServers}
+          onPlanModeChange={panelState.handlePlanModeChange}
+          isAgentBusy={isAgentBusy}
+          isStarting={panelState.isStarting}
+          isPreparingEnvironment={panelState.isPreparingEnvironment}
+          isMoving={isMoving}
+          isSending={isSending}
+          onCancel={handleCancelTurn}
+          placeholder={placeholder}
+          pendingClarification={panelState.pendingClarification}
+          onClarificationResolved={onClarificationResolved}
+          showRequestChangesTooltip={showRequestChangesTooltip}
+          onRequestChangesTooltipDismiss={onRequestChangesTooltipDismiss}
+          pendingCommentsByFile={panelState.pendingCommentsByFile}
+          hasContextComments={
+            panelState.planComments.length > 0 || panelState.pendingPRFeedback.length > 0
+          }
+          submitKey={panelState.chatSubmitKey}
+          hasAgentCommands={!!(panelState.agentCommands && panelState.agentCommands.length > 0)}
+          isFailed={panelState.isFailed}
+          needsRecovery={needsRecovery}
+          executorUnavailable={executor.unavailable}
+          executorUnavailableReason={executor.reason}
+          contextItems={panelState.contextItems}
+          planContextEnabled={panelState.planContextEnabled}
+          contextFiles={panelState.contextFiles}
+          onToggleContextFile={panelState.handleToggleContextFile}
+          onAddContextFile={panelState.handleAddContextFile}
+          onImplementPlan={implementPlanHandler}
+          hideSessionsDropdown={hideSessionsDropdown}
+          minimalToolbar={minimalToolbar}
+          hidePlanMode={hidePlanMode}
+        />
+      </QueueAffordance>
     </div>
   );
 }

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -79,7 +79,9 @@ type PlaceholderArgs = {
 
 function pickInputPlaceholder(a: PlaceholderArgs): string {
   if (a.isMoving) return "Switching agent...";
-  if (a.override) return a.override;
+  // Preserve the prior `??` semantics: an explicit "" override (caller wants
+  // no placeholder text) must NOT fall through to the resolver default.
+  if (a.override !== undefined) return a.override;
   return resolveInputPlaceholder(
     a.isAgentBusy,
     a.activeDocumentType,

--- a/apps/web/components/task/chat/messages/chat-message.tsx
+++ b/apps/web/components/task/chat/messages/chat-message.tsx
@@ -1,17 +1,14 @@
 "use client";
 
 import { memo, useState, useCallback } from "react";
-import Link from "next/link";
 import ReactMarkdown from "react-markdown";
-import { IconWand, IconMessageDots, IconFile, IconRobot } from "@tabler/icons-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconWand, IconMessageDots, IconFile } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
 import { RichBlocks } from "@/components/task/chat/messages/rich-blocks";
 import { MessageActions } from "@/components/task/chat/messages/message-actions";
 import { useMessageNavigation } from "@/hooks/use-message-navigation";
-import { useTaskById } from "@/hooks/domains/kanban/use-task-by-id";
-import { linkToTask } from "@/lib/links";
+import { SenderTaskBadge, type SenderTaskInfo } from "./sender-task-badge";
 import {
   markdownComponents,
   normalizeMarkdown,
@@ -118,13 +115,6 @@ type UserMessageMetadata = {
   sender_session_id?: string;
 };
 
-type SenderTaskInfo = {
-  id: string;
-  // Snapshot title captured when the message was sent. May differ from the
-  // task's current title; used as a fallback when the live task isn't loaded.
-  snapshotTitle: string;
-};
-
 function parseUserMessageMetadata(comment: Message) {
   const metadata = comment.metadata as UserMessageMetadata | undefined;
   const imageAttachments = (metadata?.attachments || []).filter((att) => att.type === "image");
@@ -149,57 +139,6 @@ function parseUserMessageMetadata(comment: Message) {
     hasAttachments,
     senderTask,
   };
-}
-
-const SENDER_TITLE_MAX = 24;
-
-function truncateTitle(title: string): string {
-  if (title.length <= SENDER_TITLE_MAX) return title;
-  return title.slice(0, SENDER_TITLE_MAX - 1).trimEnd() + "…";
-}
-
-function SenderTaskBadge({ sender }: { sender: SenderTaskInfo }) {
-  // Live-resolve the sender task from the loaded kanban state so the badge
-  // reflects renames. When the sender task isn't loaded (cross-workspace,
-  // archived, etc.) we fall back to the snapshot title and render a static,
-  // non-clickable greyed-out badge — the source URL only works when we have
-  // routing context.
-  const liveTask = useTaskById(sender.id);
-  const fullTitle = liveTask?.title || sender.snapshotTitle || "(unknown task)";
-  const truncated = truncateTitle(fullTitle);
-
-  const inner = (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full bg-purple-500/20 px-2.5 py-1 text-xs font-medium text-purple-300",
-        liveTask && "cursor-pointer hover:bg-purple-500/30 transition-colors",
-        !liveTask && "opacity-60",
-      )}
-      data-testid="sender-task-badge"
-      data-sender-task-id={sender.id}
-    >
-      <IconRobot size={14} /> {truncated}
-    </span>
-  );
-
-  const wrapped = liveTask ? (
-    <Link href={linkToTask(sender.id)} aria-label={`Open source task ${fullTitle}`}>
-      {inner}
-    </Link>
-  ) : (
-    inner
-  );
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>{wrapped}</TooltipTrigger>
-        <TooltipContent>
-          From agent in task <span className="font-semibold">&ldquo;{fullTitle}&rdquo;</span>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
 }
 
 function UserContextBadges({

--- a/apps/web/components/task/chat/messages/sender-task-badge.tsx
+++ b/apps/web/components/task/chat/messages/sender-task-badge.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { IconRobot } from "@tabler/icons-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useTaskById } from "@/hooks/domains/kanban/use-task-by-id";
+import { linkToTask } from "@/lib/links";
+
+export type SenderTaskInfo = {
+  id: string;
+  /** Title captured when the message was queued/sent. Survives the sender
+   * task being renamed, archived, or unloaded from the live kanban state. */
+  snapshotTitle: string;
+};
+
+const SENDER_TITLE_MAX = 24;
+
+function truncateTitle(title: string): string {
+  if (title.length <= SENDER_TITLE_MAX) return title;
+  return title.slice(0, SENDER_TITLE_MAX - 1).trimEnd() + "…";
+}
+
+type SenderTaskBadgeProps = {
+  sender: SenderTaskInfo;
+  /** Optional override for the badge size — defaults to "sm" (chat bubbles). */
+  size?: "xs" | "sm";
+};
+
+/**
+ * Renders a purple "From {task}" badge for inter-task agent messages. The badge
+ * live-resolves the sender task title from the kanban store so renames flow
+ * through; when the source task isn't loaded (cross-workspace, archived) it
+ * falls back to the snapshot title and renders un-linked + dimmed.
+ *
+ * Used by chat-message rows AND by the queued-ghost row so a queued inter-task
+ * prompt shows the same provenance affordance as the final delivered message.
+ */
+export function SenderTaskBadge({ sender, size = "sm" }: SenderTaskBadgeProps) {
+  const liveTask = useTaskById(sender.id);
+  const fullTitle = liveTask?.title || sender.snapshotTitle || "(unknown task)";
+  const truncated = truncateTitle(fullTitle);
+
+  const sizeClass =
+    size === "xs" ? "gap-1 px-1.5 py-0.5 text-[10px]" : "gap-1.5 px-2.5 py-1 text-xs font-medium";
+  const iconSize = size === "xs" ? 10 : 14;
+
+  const inner = (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full bg-purple-500/20 text-purple-300",
+        sizeClass,
+        liveTask && "cursor-pointer hover:bg-purple-500/30 transition-colors",
+        !liveTask && "opacity-60",
+      )}
+      data-testid="sender-task-badge"
+      data-sender-task-id={sender.id}
+    >
+      <IconRobot size={iconSize} /> {truncated}
+    </span>
+  );
+
+  const wrapped = liveTask ? (
+    <Link href={linkToTask(sender.id)} aria-label={`Open source task ${fullTitle}`}>
+      {inner}
+    </Link>
+  ) : (
+    inner
+  );
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{wrapped}</TooltipTrigger>
+        <TooltipContent>
+          From agent in task <span className="font-semibold">&ldquo;{fullTitle}&rdquo;</span>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/components/task/chat/queued-ghost-list.test.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.test.tsx
@@ -99,8 +99,7 @@ describe("QueueAffordance", () => {
     render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
     const chip = screen.getByTestId(CHIP_ID);
     expect(chip.textContent).toContain("2 queued");
-    expect(chip.getAttribute("data-open")).toBe("false");
-    expect(chip.getAttribute("aria-expanded")).toBe("false");
+    expect(chip.getAttribute("aria-label")).toContain("click to expand");
     expect(screen.queryByTestId(PANEL_ID)).toBeNull();
   });
 

--- a/apps/web/components/task/chat/queued-ghost-list.test.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.test.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { QueuedMessage } from "@/lib/state/slices/session/types";
+
+const useQueueMock = vi.fn();
+
+vi.mock("@/hooks/domains/session/use-queue", () => ({
+  useQueue: (sessionId: string | null) => useQueueMock(sessionId),
+}));
+
+vi.mock("@kandev/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+// Mock Radix Collapsible because the real primitive pulls in a React global the
+// jsdom test environment doesn't provide. We just need open/closed behavior to
+// drive the assertions — the close-animation path is exercised in E2E.
+vi.mock("@kandev/ui/collapsible", () => {
+  const Collapsible = ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div data-collapsible-open="true">{children}</div> : null;
+  const CollapsibleContent = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return { Collapsible, CollapsibleContent };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { QueueAffordance } from "./queued-ghost-list";
+
+const SESSION_ID = "sess-1";
+const CHIP_ID = "queue-chip";
+const PANEL_ID = "queued-ghost-list";
+
+function entry(overrides: Partial<QueuedMessage> = {}): QueuedMessage {
+  return {
+    id: "q-1",
+    session_id: "sess-1",
+    task_id: "task-1",
+    content: "hello world",
+    plan_mode: false,
+    queued_at: "2026-05-18T00:00:00Z",
+    queued_by: "user-1",
+    ...overrides,
+  };
+}
+
+function queueState(entries: QueuedMessage[], extra: Partial<ReturnType<typeof baseState>> = {}) {
+  return { ...baseState(entries), ...extra };
+}
+
+function baseState(entries: QueuedMessage[]) {
+  return {
+    entries,
+    count: entries.length,
+    max: 10,
+    isFull: false,
+    isLoading: false,
+    queue: vi.fn(async () => {}),
+    clearAll: vi.fn(async () => {}),
+    editEntry: vi.fn(async () => {}),
+    removeEntry: vi.fn(async () => {}),
+    refetch: vi.fn(async () => {}),
+  };
+}
+
+const CHILD = <div data-testid="child-marker">input</div>;
+
+beforeEach(() => {
+  useQueueMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("QueueAffordance", () => {
+  it("renders only children when there are no queued entries", () => {
+    useQueueMock.mockReturnValue(queueState([]));
+    render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    expect(screen.getByTestId("child-marker")).toBeTruthy();
+    expect(screen.queryByTestId(CHIP_ID)).toBeNull();
+    expect(screen.queryByTestId(PANEL_ID)).toBeNull();
+  });
+
+  it("renders only children when sessionId is null", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    render(<QueueAffordance sessionId={null}>{CHILD}</QueueAffordance>);
+    expect(screen.getByTestId("child-marker")).toBeTruthy();
+    expect(screen.queryByTestId(CHIP_ID)).toBeNull();
+  });
+
+  it("shows a collapsed chip with the queue count when entries exist", () => {
+    useQueueMock.mockReturnValue(queueState([entry(), entry({ id: "q-2", content: "second" })]));
+    render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    const chip = screen.getByTestId(CHIP_ID);
+    expect(chip.textContent).toContain("2 queued");
+    expect(chip.getAttribute("data-open")).toBe("false");
+    expect(chip.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByTestId(PANEL_ID)).toBeNull();
+  });
+
+  it("marks the chip as full when isFull is true", () => {
+    useQueueMock.mockReturnValue(queueState([entry()], { isFull: true, max: 1 }));
+    render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    const chip = screen.getByTestId(CHIP_ID);
+    expect(chip.getAttribute("data-full")).toBe("true");
+    expect(chip.textContent).toContain("full");
+  });
+
+  it("clicking the chip swaps it for the expanded panel", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    fireEvent.click(screen.getByTestId(CHIP_ID));
+    expect(screen.getByTestId(PANEL_ID)).toBeTruthy();
+    // While the panel is open the chip is hidden — its info is duplicated in
+    // the panel header, so we collapse via the X close button or Escape.
+    expect(screen.queryByTestId(CHIP_ID)).toBeNull();
+  });
+
+  it("clicking the X close button in the panel collapses the panel", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    fireEvent.click(screen.getByTestId(CHIP_ID));
+    fireEvent.click(screen.getByTestId("queue-close"));
+    expect(screen.queryByTestId(PANEL_ID)).toBeNull();
+  });
+
+  it("Escape collapses an open panel", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    fireEvent.click(screen.getByTestId(CHIP_ID));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId(PANEL_ID)).toBeNull();
+  });
+
+  it("auto-collapses the panel when the queue drains to zero", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    const { rerender } = render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    fireEvent.click(screen.getByTestId(CHIP_ID));
+    expect(screen.getByTestId(PANEL_ID)).toBeTruthy();
+    useQueueMock.mockReturnValue(queueState([]));
+    rerender(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    expect(screen.queryByTestId(PANEL_ID)).toBeNull();
+    expect(screen.queryByTestId(CHIP_ID)).toBeNull();
+  });
+
+  it("auto-collapses the panel when sessionId changes", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    const { rerender } = render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    fireEvent.click(screen.getByTestId(CHIP_ID));
+    expect(screen.getByTestId(PANEL_ID)).toBeTruthy();
+    rerender(<QueueAffordance sessionId="sess-2">{CHILD}</QueueAffordance>);
+    expect(screen.queryByTestId(PANEL_ID)).toBeNull();
+  });
+
+  it("clear-all button invokes clearAll from the queue hook", () => {
+    const state = queueState([entry()]);
+    useQueueMock.mockReturnValue(state);
+    render(<QueueAffordance sessionId={SESSION_ID}>{CHILD}</QueueAffordance>);
+    fireEvent.click(screen.getByTestId(CHIP_ID));
+    fireEvent.click(screen.getByTestId("queue-clear-all"));
+    expect(state.clearAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/components/task/chat/queued-ghost-list.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.tsx
@@ -1,32 +1,86 @@
 "use client";
 
-import { useCallback } from "react";
-import { IconLayoutList, IconTrash } from "@tabler/icons-react";
+import { useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { IconLayoutList, IconTrash, IconX } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { Button } from "@kandev/ui";
+import { Collapsible, CollapsibleContent } from "@kandev/ui/collapsible";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useQueue } from "@/hooks/domains/session/use-queue";
 import { QueuedGhostMessage } from "./queued-ghost-message";
 import type { QueuedMessage } from "@/lib/state/slices/session/types";
 
-type QueuedGhostListProps = {
-  sessionId: string | null;
-  isArchived: boolean;
-};
+const HEAD_PREVIEW_MAX = 80;
 
-/** Inter-task messages flow through dispatchTaskMessage with queued_by="agent".
- *  We disable edit on those so a user can't rewrite another task's prompt mid-flight. */
+/** Inter-task entries are dispatched with queued_by="agent" and stay read-only. */
 function canUserEditEntry(entry: QueuedMessage): boolean {
   return entry.queued_by !== "agent";
 }
 
+function stripSystemTags(text: string): string {
+  return text.replace(/<kandev-system>[\s\S]*?<\/kandev-system>/g, "").trim();
+}
+
+function headPreviewText(entries: QueuedMessage[]): string {
+  const first = entries[0];
+  if (!first) return "";
+  const clean = stripSystemTags(first.content);
+  if (clean.length <= HEAD_PREVIEW_MAX) return clean;
+  return clean.slice(0, HEAD_PREVIEW_MAX).trimEnd() + "…";
+}
+
+function useEscToClose(open: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const t = e.target;
+      // Don't hijack Esc while the user is editing inside the queue textarea or
+      // any other input on the page (clarification overlay, etc.).
+      if (t instanceof HTMLElement && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+}
+
+type QueueAffordanceProps = {
+  sessionId: string | null;
+  children: ReactNode;
+};
+
 /**
- * Renders the per-session FIFO queue as a stack of ghost messages plus a small
- * "n/max queued · clear all" pill above the chat input. Drained entries
- * disappear automatically when message.queue.status_changed lands.
+ * Wraps the chat input with the per-session queue affordance:
+ * - When there are no queued entries, just renders `children` (the input).
+ * - Otherwise a small floating "n queued" chip sits over the input frame and
+ *   clicking it expands a panel above the input. Drained or session-switched
+ *   queues auto-collapse.
  */
-export function QueuedGhostList({ sessionId, isArchived }: QueuedGhostListProps) {
+export function QueueAffordance({ sessionId, children }: QueueAffordanceProps) {
   const { entries, count, max, isFull, clearAll, editEntry, removeEntry } = useQueue(sessionId);
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Reset disclosure on session switch or full drain using render-phase state
+  // adjustment (React docs: "Adjusting some state when a prop changes"). This
+  // avoids the cascading-render anti-pattern of doing it inside useEffect.
+  const entryCount = entries.length;
+  const [lastSession, setLastSession] = useState(sessionId);
+  const [lastEntryCount, setLastEntryCount] = useState(entryCount);
+  if (sessionId !== lastSession) {
+    setLastSession(sessionId);
+    setIsOpen(false);
+  }
+  if (entryCount !== lastEntryCount) {
+    setLastEntryCount(entryCount);
+    if (entryCount === 0) setIsOpen(false);
+  }
+
+  const close = useCallback(() => setIsOpen(false), []);
+  useEscToClose(isOpen, close);
 
   const handleSave = useCallback(
     async (entryId: string, content: string) => {
@@ -47,21 +101,151 @@ export function QueuedGhostList({ sessionId, isArchived }: QueuedGhostListProps)
     [removeEntry],
   );
 
-  if (isArchived || !sessionId || entries.length === 0) {
-    return null;
-  }
+  const handleClear = useCallback(() => {
+    clearAll().catch((err) => {
+      console.error("Failed to clear queued messages:", err);
+      toast.error("Failed to clear queued messages.");
+    });
+  }, [clearAll]);
+
+  if (!sessionId || entryCount === 0) return <>{children}</>;
 
   return (
-    <div className="flex-shrink-0 space-y-1.5 bg-card px-3 pt-1.5 pb-1">
-      <QueueCountPill count={count} max={max} isFull={isFull} onClear={clearAll} />
-      <div className="space-y-1.5" data-testid="queued-ghost-list">
-        {entries.map((entry) => (
+    <>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleContent
+          className={cn(
+            "overflow-hidden",
+            "data-[state=open]:animate-queue-open data-[state=closed]:animate-queue-close",
+          )}
+        >
+          <QueuePanel
+            entries={entries}
+            count={count}
+            max={max}
+            isFull={isFull}
+            onClose={close}
+            onClear={handleClear}
+            onSave={handleSave}
+            onRemove={handleRemove}
+          />
+        </CollapsibleContent>
+      </Collapsible>
+      {!isOpen && (
+        <div className="flex items-center px-1 pb-1 animate-in fade-in-0 slide-in-from-bottom-1 duration-150">
+          <QueueChip
+            count={count}
+            isFull={isFull}
+            isOpen={isOpen}
+            previewText={headPreviewText(entries)}
+            onToggle={() => setIsOpen((v) => !v)}
+          />
+        </div>
+      )}
+      {children}
+    </>
+  );
+}
+
+type QueueChipProps = {
+  count: number;
+  isFull: boolean;
+  isOpen: boolean;
+  previewText: string;
+  onToggle: () => void;
+};
+
+function chipPalette(isOpen: boolean, isFull: boolean): string {
+  if (isOpen) {
+    return "text-blue-600 dark:text-blue-300 border-blue-500/50 bg-blue-500/10";
+  }
+  if (isFull) {
+    return "text-amber-600 dark:text-amber-400 border-amber-500/40 hover:bg-amber-500/10";
+  }
+  return "text-muted-foreground border-border hover:text-foreground hover:border-border/80";
+}
+
+function QueueChip({ count, isFull, isOpen, previewText, onToggle }: QueueChipProps) {
+  const button = (
+    <button
+      type="button"
+      data-testid="queue-chip"
+      data-open={isOpen ? "true" : "false"}
+      data-full={isFull ? "true" : "false"}
+      aria-expanded={isOpen}
+      aria-controls="queue-panel"
+      aria-label={`${count} queued message${count === 1 ? "" : "s"}`}
+      onClick={onToggle}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5",
+        "text-[11px] font-medium cursor-pointer transition-colors",
+        chipPalette(isOpen, isFull),
+      )}
+    >
+      <IconLayoutList className="h-3 w-3" />
+      <span>{count} queued</span>
+      {isFull && <span className="opacity-80">· full</span>}
+    </button>
+  );
+  if (!previewText || isOpen) return button;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side="top" align="start" className="max-w-[280px]">
+        <span className="line-clamp-2">{previewText}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+type QueuePanelProps = {
+  entries: QueuedMessage[];
+  count: number;
+  max: number;
+  isFull: boolean;
+  onClose: () => void;
+  onClear: () => void;
+  onSave: (entryId: string, content: string) => Promise<void>;
+  onRemove: (entryId: string) => Promise<void>;
+};
+
+function QueuePanel({
+  entries,
+  count,
+  max,
+  isFull,
+  onClose,
+  onClear,
+  onSave,
+  onRemove,
+}: QueuePanelProps) {
+  return (
+    <div
+      id="queue-panel"
+      role="region"
+      aria-label="Queued messages"
+      data-testid="queued-ghost-list"
+      className={cn(
+        "flex-shrink-0 px-3 pt-1.5 pb-1 border-t border-border/40",
+        "animate-in slide-in-from-bottom-2 fade-in-0 duration-200",
+      )}
+    >
+      <QueuePanelHeader
+        count={count}
+        max={max}
+        isFull={isFull}
+        onClear={onClear}
+        onClose={onClose}
+      />
+      <div className="space-y-1.5">
+        {entries.map((entry, index) => (
           <QueuedGhostMessage
             key={entry.id}
             entry={entry}
+            index={index}
             canEdit={canUserEditEntry(entry)}
-            onSave={(content) => handleSave(entry.id, content)}
-            onRemove={() => handleRemove(entry.id)}
+            onSave={(content) => onSave(entry.id, content)}
+            onRemove={() => onRemove(entry.id)}
           />
         ))}
       </div>
@@ -69,42 +253,48 @@ export function QueuedGhostList({ sessionId, isArchived }: QueuedGhostListProps)
   );
 }
 
-type QueueCountPillProps = {
+type QueuePanelHeaderProps = {
   count: number;
   max: number;
   isFull: boolean;
-  onClear: () => Promise<void>;
+  onClear: () => void;
+  onClose: () => void;
 };
 
-function QueueCountPill({ count, max, isFull, onClear }: QueueCountPillProps) {
-  const handleClear = useCallback(() => {
-    onClear().catch((err) => {
-      console.error("Failed to clear queued messages:", err);
-      toast.error("Failed to clear queued messages.");
-    });
-  }, [onClear]);
+function QueuePanelHeader({ count, max, isFull, onClear, onClose }: QueuePanelHeaderProps) {
+  const capacityText = max > 0 ? `${count} of ${max}` : `${count}`;
   return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <span
-        className={cn(
-          "inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5",
-          isFull && "text-amber-600 dark:text-amber-400",
-        )}
-      >
-        <IconLayoutList className="h-3 w-3" />
-        {max > 0 ? `${count}/${max} queued` : `${count} queued`}
-        {isFull ? " · full" : ""}
-      </span>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-6 cursor-pointer px-2 text-xs text-muted-foreground hover:text-foreground"
-        onClick={handleClear}
-        title="Clear all queued messages"
-      >
-        <IconTrash className="mr-1 h-3 w-3" />
-        Clear all
-      </Button>
+    <div className="flex items-center justify-between gap-3 py-1">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <IconLayoutList className="h-3.5 w-3.5" />
+        <span className="uppercase tracking-wide">Queued</span>
+        <span className={cn(isFull && "text-amber-600 dark:text-amber-400")}>
+          {capacityText}
+          {isFull ? " · full" : ""}
+        </span>
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-1.5 text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+          onClick={onClear}
+          title="Clear all queued messages"
+          data-testid="queue-clear-all"
+        >
+          <IconTrash className="mr-1 h-3 w-3" />
+          Clear all
+        </Button>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Collapse queued messages"
+          data-testid="queue-close"
+          className="text-muted-foreground hover:text-foreground cursor-pointer rounded p-1"
+        >
+          <IconX className="h-3.5 w-3.5" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/task/chat/queued-ghost-list.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.tsx
@@ -8,6 +8,7 @@ import { Button } from "@kandev/ui";
 import { Collapsible, CollapsibleContent } from "@kandev/ui/collapsible";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { stripSystemTags } from "@/lib/utils/system-tags";
 import { useQueue } from "@/hooks/domains/session/use-queue";
 import { QueuedGhostMessage } from "./queued-ghost-message";
 import type { QueuedMessage } from "@/lib/state/slices/session/types";
@@ -19,10 +20,6 @@ function canUserEditEntry(entry: QueuedMessage): boolean {
   return entry.queued_by !== "agent";
 }
 
-function stripSystemTags(text: string): string {
-  return text.replace(/<kandev-system>[\s\S]*?<\/kandev-system>/g, "").trim();
-}
-
 function headPreviewText(entries: QueuedMessage[]): string {
   const first = entries[0];
   if (!first) return "";
@@ -31,15 +28,24 @@ function headPreviewText(entries: QueuedMessage[]): string {
   return clean.slice(0, HEAD_PREVIEW_MAX).trimEnd() + "…";
 }
 
+function isEditableTarget(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  // contentEditable covers the TipTap chat editor and any rich-text surface.
+  // `el.isContentEditable` walks up the contenteditable inheritance chain.
+  return el.isContentEditable;
+}
+
 function useEscToClose(open: boolean, onClose: () => void): void {
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      const t = e.target;
-      // Don't hijack Esc while the user is editing inside the queue textarea or
-      // any other input on the page (clarification overlay, etc.).
-      if (t instanceof HTMLElement && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+      // Don't hijack Esc while the user is editing inside any input control on
+      // the page (queue textarea, TipTap chat editor, native input/select, or
+      // the clarification overlay).
+      if (isEditableTarget(e.target)) return;
       e.preventDefault();
       onClose();
     };
@@ -132,11 +138,10 @@ export function QueueAffordance({ sessionId, children }: QueueAffordanceProps) {
         </CollapsibleContent>
       </Collapsible>
       {!isOpen && (
-        <div className="flex items-center px-1 pb-1 animate-in fade-in-0 slide-in-from-bottom-1 duration-150">
+        <div className="flex items-center px-1 pb-1 animate-in fade-in-0 slide-in-from-bottom-1 duration-150 motion-reduce:animate-none">
           <QueueChip
             count={count}
             isFull={isFull}
-            isOpen={isOpen}
             previewText={headPreviewText(entries)}
             onToggle={() => setIsOpen((v) => !v)}
           />
@@ -150,36 +155,34 @@ export function QueueAffordance({ sessionId, children }: QueueAffordanceProps) {
 type QueueChipProps = {
   count: number;
   isFull: boolean;
-  isOpen: boolean;
   previewText: string;
   onToggle: () => void;
 };
 
-function chipPalette(isOpen: boolean, isFull: boolean): string {
-  if (isOpen) {
-    return "text-blue-600 dark:text-blue-300 border-blue-500/50 bg-blue-500/10";
-  }
+function chipPalette(isFull: boolean): string {
   if (isFull) {
     return "text-amber-600 dark:text-amber-400 border-amber-500/40 hover:bg-amber-500/10";
   }
   return "text-muted-foreground border-border hover:text-foreground hover:border-border/80";
 }
 
-function QueueChip({ count, isFull, isOpen, previewText, onToggle }: QueueChipProps) {
+function QueueChip({ count, isFull, previewText, onToggle }: QueueChipProps) {
+  // aria-expanded/aria-controls are intentionally omitted: the chip and the
+  // expanded panel are mutually exclusive in the DOM (clicking the chip swaps
+  // it for the panel header, which carries its own collapse controls). Pointing
+  // aria-controls at an element that isn't currently mounted would be a worse
+  // a11y signal than the descriptive aria-label below.
   const button = (
     <button
       type="button"
       data-testid="queue-chip"
-      data-open={isOpen ? "true" : "false"}
       data-full={isFull ? "true" : "false"}
-      aria-expanded={isOpen}
-      aria-controls="queue-panel"
-      aria-label={`${count} queued message${count === 1 ? "" : "s"}`}
+      aria-label={`${count} queued message${count === 1 ? "" : "s"}, click to expand`}
       onClick={onToggle}
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5",
         "text-[11px] font-medium cursor-pointer transition-colors",
-        chipPalette(isOpen, isFull),
+        chipPalette(isFull),
       )}
     >
       <IconLayoutList className="h-3 w-3" />
@@ -187,7 +190,7 @@ function QueueChip({ count, isFull, isOpen, previewText, onToggle }: QueueChipPr
       {isFull && <span className="opacity-80">· full</span>}
     </button>
   );
-  if (!previewText || isOpen) return button;
+  if (!previewText) return button;
   return (
     <Tooltip>
       <TooltipTrigger asChild>{button}</TooltipTrigger>

--- a/apps/web/components/task/chat/queued-ghost-message.tsx
+++ b/apps/web/components/task/chat/queued-ghost-message.tsx
@@ -3,7 +3,8 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import {
   IconCheck,
-  IconClock,
+  IconChevronDown,
+  IconChevronUp,
   IconEdit,
   IconFile,
   IconRobot,
@@ -13,10 +14,13 @@ import {
 import { toast } from "sonner";
 import { Button } from "@kandev/ui";
 import { Textarea } from "@kandev/ui/textarea";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { QueueEntryNotFoundError } from "@/lib/api/domains/queue-api";
 import { openImageInWindow } from "@/components/task/chat/file-attachment";
+import {
+  SenderTaskBadge,
+  type SenderTaskInfo,
+} from "@/components/task/chat/messages/sender-task-badge";
 import type { QueuedMessage } from "@/lib/state/slices/session/types";
 
 type QueuedAttachment = NonNullable<QueuedMessage["attachments"]>[number];
@@ -104,24 +108,29 @@ function senderLabel(entry: QueuedMessage): string {
   return "You";
 }
 
-type SenderChipProps = { entry: QueuedMessage };
+type SenderIconProps = { entry: QueuedMessage };
 
-function SenderChip({ entry }: SenderChipProps) {
+function SenderIcon({ entry }: SenderIconProps) {
   const kind = senderKindOf(entry);
   const Icon = kind === "agent" ? IconRobot : IconUser;
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
-        kind === "agent"
-          ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-          : "bg-primary/10 text-primary",
-      )}
-    >
-      <Icon className="h-3 w-3" />
-      {senderLabel(entry)}
-    </span>
-  );
+  const tone =
+    kind === "agent" ? "text-amber-500 dark:text-amber-400" : "text-blue-500 dark:text-blue-300";
+  return <Icon className={cn("h-3.5 w-3.5 flex-shrink-0", tone)} aria-label={senderLabel(entry)} />;
+}
+
+/**
+ * Returns the inter-task sender info when this entry was queued by another
+ * task's agent (queued_by="agent" + sender_task_id in metadata). User-typed
+ * entries have no SenderTaskInfo — they render with just the IconUser cue.
+ */
+function getSenderTaskInfo(entry: QueuedMessage): SenderTaskInfo | null {
+  if (senderKindOf(entry) !== "agent") return null;
+  const meta = entry.metadata as
+    | { sender_task_id?: string; sender_task_title?: string }
+    | undefined;
+  const id = meta?.sender_task_id;
+  if (typeof id !== "string" || id.length === 0) return null;
+  return { id, snapshotTitle: meta?.sender_task_title ?? "" };
 }
 
 type EditViewProps = {
@@ -153,7 +162,7 @@ function EditView({
     }
   };
   return (
-    <div className="space-y-2 p-2">
+    <div className="space-y-2 py-2">
       <AttachmentRow attachments={attachments} interactive={false} />
       <Textarea
         ref={textareaRef}
@@ -197,35 +206,68 @@ function EditView({
 
 type DisplayViewProps = {
   entry: QueuedMessage;
+  positionLabel: string;
   canEdit: boolean;
   onStartEdit: () => void;
   onRemove: () => void;
 };
 
-function DisplayView({ entry, canEdit, onStartEdit, onRemove }: DisplayViewProps) {
+/** Rough threshold above which we offer a per-row expand toggle. Two lines of
+ * the row's text width fit ~80 chars; anything longer is likely clamped. */
+const EXPAND_THRESHOLD = 80;
+
+function DisplayView({ entry, positionLabel, canEdit, onStartEdit, onRemove }: DisplayViewProps) {
   const visible = stripSystemTags(entry.content);
-  const display = visible.length > 200 ? visible.slice(0, 200) + "..." : visible;
   const attachments = (entry.attachments ?? []) as QueuedAttachment[];
+  const senderTask = getSenderTaskInfo(entry);
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = visible.length > EXPAND_THRESHOLD;
   return (
-    <div className="flex items-start gap-2 px-3 py-2">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="mt-0.5 flex items-center gap-1 text-muted-foreground">
-            <IconClock className="h-3.5 w-3.5" />
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top">Will run on the next turn</TooltipContent>
-      </Tooltip>
+    <div className="group flex items-start gap-2 py-1.5">
+      <span className="flex items-center gap-1.5 mt-0.5 text-muted-foreground">
+        <span
+          aria-label={`Position ${positionLabel}`}
+          className="font-mono text-[10px] tabular-nums"
+        >
+          {positionLabel}
+        </span>
+        {!senderTask && <SenderIcon entry={entry} />}
+      </span>
       <div className="flex-1 min-w-0 space-y-1">
-        <SenderChip entry={entry} />
-        <AttachmentRow attachments={attachments} interactive={true} />
-        {display && (
-          <div className="text-sm text-foreground/80 whitespace-pre-wrap break-words">
-            {display}
+        {senderTask && <SenderTaskBadge sender={senderTask} size="xs" />}
+        {visible && (
+          <div
+            data-testid="queue-entry-text"
+            data-expanded={expanded ? "true" : "false"}
+            className={cn(
+              "text-sm text-foreground/80 whitespace-pre-wrap break-words overflow-hidden",
+              "transition-[max-height] duration-200 ease-out",
+              expanded ? "max-h-[40rem]" : "max-h-[2.75rem]",
+            )}
+          >
+            {visible}
           </div>
         )}
+        <AttachmentRow attachments={attachments} interactive={true} />
       </div>
-      <div className="flex items-center gap-0.5 flex-shrink-0">
+      <div className="flex items-center gap-0.5 flex-shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+        {canExpand && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 w-6 cursor-pointer p-0 text-muted-foreground hover:text-foreground"
+            onClick={() => setExpanded((v) => !v)}
+            title={expanded ? "Collapse message" : "Expand message"}
+            data-testid="queue-entry-expand"
+            aria-expanded={expanded}
+          >
+            {expanded ? (
+              <IconChevronUp className="h-3.5 w-3.5" />
+            ) : (
+              <IconChevronDown className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        )}
         {canEdit && (
           <>
             <Button
@@ -255,6 +297,8 @@ function DisplayView({ entry, canEdit, onStartEdit, onRemove }: DisplayViewProps
 
 type QueuedGhostMessageProps = {
   entry: QueuedMessage;
+  /** Zero-based render position; combined with entry.position to label the row. */
+  index?: number;
   /**
    * Edit is only allowed when the caller's identity (currentUserId) matches the
    * entry's queued_by. Inter-task entries are visible but read-only.
@@ -267,7 +311,7 @@ type QueuedGhostMessageProps = {
 };
 
 export const QueuedGhostMessage = forwardRef<QueuedGhostMessageHandle, QueuedGhostMessageProps>(
-  function QueuedGhostMessage({ entry, canEdit, onSave, onRemove, onEditComplete }, ref) {
+  function QueuedGhostMessage({ entry, index, canEdit, onSave, onRemove, onEditComplete }, ref) {
     const [editing, setEditing] = useState(false);
     const [value, setValue] = useState(entry.content);
     const [saving, setSaving] = useState(false);
@@ -328,11 +372,14 @@ export const QueuedGhostMessage = forwardRef<QueuedGhostMessageHandle, QueuedGho
       }
     }, [value, entry.content, onSave, onEditComplete]);
 
+    const positionNumber = entry.position ?? (index ?? 0) + 1;
+    const positionLabel = `#${positionNumber}`;
+
     return (
       <div
         className={cn(
-          "rounded-md border-l-2 bg-muted/40 text-sm",
-          senderKindOf(entry) === "agent" ? "border-amber-400/60" : "border-primary/40",
+          "rounded-md border border-border/60 bg-background/40 px-2 text-sm",
+          "hover:border-border transition-colors",
         )}
       >
         {editing ? (
@@ -348,6 +395,7 @@ export const QueuedGhostMessage = forwardRef<QueuedGhostMessageHandle, QueuedGho
         ) : (
           <DisplayView
             entry={entry}
+            positionLabel={positionLabel}
             canEdit={canEdit}
             onStartEdit={startEdit}
             onRemove={onRemove}

--- a/apps/web/components/task/chat/queued-ghost-message.tsx
+++ b/apps/web/components/task/chat/queued-ghost-message.tsx
@@ -11,6 +11,7 @@ import {
   IconUser,
   IconX,
 } from "@tabler/icons-react";
+import ReactMarkdown from "react-markdown";
 import { toast } from "sonner";
 import { Button } from "@kandev/ui";
 import { Textarea } from "@kandev/ui/textarea";
@@ -21,6 +22,7 @@ import {
   SenderTaskBadge,
   type SenderTaskInfo,
 } from "@/components/task/chat/messages/sender-task-badge";
+import { markdownComponents, remarkPlugins } from "@/components/shared/markdown-components";
 import type { QueuedMessage } from "@/lib/state/slices/session/types";
 
 type QueuedAttachment = NonNullable<QueuedMessage["attachments"]>[number];
@@ -240,12 +242,15 @@ function DisplayView({ entry, positionLabel, canEdit, onStartEdit, onRemove }: D
             data-testid="queue-entry-text"
             data-expanded={expanded ? "true" : "false"}
             className={cn(
-              "text-sm text-foreground/80 whitespace-pre-wrap break-words overflow-hidden",
+              "markdown-body max-w-none text-sm text-foreground/80 break-words overflow-hidden",
+              "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
               "transition-[max-height] duration-200 ease-out",
               expanded ? "max-h-[40rem]" : "max-h-[2.75rem]",
             )}
           >
-            {visible}
+            <ReactMarkdown remarkPlugins={remarkPlugins} components={markdownComponents}>
+              {visible}
+            </ReactMarkdown>
           </div>
         )}
         <AttachmentRow attachments={attachments} interactive={true} />

--- a/apps/web/components/task/chat/queued-ghost-message.tsx
+++ b/apps/web/components/task/chat/queued-ghost-message.tsx
@@ -7,6 +7,7 @@ import {
   IconChevronUp,
   IconEdit,
   IconFile,
+  IconInfoCircle,
   IconRobot,
   IconUser,
   IconX,
@@ -17,6 +18,7 @@ import { Button } from "@kandev/ui";
 import { Textarea } from "@kandev/ui/textarea";
 import { cn } from "@/lib/utils";
 import { QueueEntryNotFoundError } from "@/lib/api/domains/queue-api";
+import { stripSystemTags } from "@/lib/utils/system-tags";
 import { openImageInWindow } from "@/components/task/chat/file-attachment";
 import {
   SenderTaskBadge,
@@ -80,11 +82,6 @@ function AttachmentRow({ attachments, interactive }: AttachmentRowProps) {
   );
 }
 
-/** Strip internal <kandev-system>...</kandev-system> blocks from display text. */
-function stripSystemTags(text: string): string {
-  return text.replace(/<kandev-system>[\s\S]*?<\/kandev-system>/g, "").trim();
-}
-
 /** Imperative handle for the ghost row, used by chat input "edit last queued" affordance. */
 export type QueuedGhostMessageHandle = {
   startEdit: () => void;
@@ -112,11 +109,18 @@ function senderLabel(entry: QueuedMessage): string {
 
 type SenderIconProps = { entry: QueuedMessage };
 
+function senderIconFor(kind: SenderKind): { Icon: typeof IconUser; tone: string } {
+  if (kind === "agent") {
+    return { Icon: IconRobot, tone: "text-amber-500 dark:text-amber-400" };
+  }
+  if (kind === "system") {
+    return { Icon: IconInfoCircle, tone: "text-muted-foreground" };
+  }
+  return { Icon: IconUser, tone: "text-blue-500 dark:text-blue-300" };
+}
+
 function SenderIcon({ entry }: SenderIconProps) {
-  const kind = senderKindOf(entry);
-  const Icon = kind === "agent" ? IconRobot : IconUser;
-  const tone =
-    kind === "agent" ? "text-amber-500 dark:text-amber-400" : "text-blue-500 dark:text-blue-300";
+  const { Icon, tone } = senderIconFor(senderKindOf(entry));
   return <Icon className={cn("h-3.5 w-3.5 flex-shrink-0", tone)} aria-label={senderLabel(entry)} />;
 }
 
@@ -215,15 +219,21 @@ type DisplayViewProps = {
 };
 
 /** Rough threshold above which we offer a per-row expand toggle. Two lines of
- * the row's text width fit ~80 chars; anything longer is likely clamped. */
+ * the row's text width fit ~80 chars OR any explicit newline implies overflow,
+ * so we use either signal to surface the chevron — short multi-line messages
+ * (lists, code blocks) would otherwise be silently truncated. */
 const EXPAND_THRESHOLD = 80;
+
+function shouldOfferExpand(text: string): boolean {
+  return text.length > EXPAND_THRESHOLD || text.includes("\n");
+}
 
 function DisplayView({ entry, positionLabel, canEdit, onStartEdit, onRemove }: DisplayViewProps) {
   const visible = stripSystemTags(entry.content);
   const attachments = (entry.attachments ?? []) as QueuedAttachment[];
   const senderTask = getSenderTaskInfo(entry);
   const [expanded, setExpanded] = useState(false);
-  const canExpand = visible.length > EXPAND_THRESHOLD;
+  const canExpand = shouldOfferExpand(visible);
   return (
     <div className="group flex items-start gap-2 py-1.5">
       <span className="flex items-center gap-1.5 mt-0.5 text-muted-foreground">
@@ -244,7 +254,7 @@ function DisplayView({ entry, positionLabel, canEdit, onStartEdit, onRemove }: D
             className={cn(
               "markdown-body max-w-none text-sm text-foreground/80 break-words overflow-hidden",
               "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-              "transition-[max-height] duration-200 ease-out",
+              "transition-[max-height] duration-200 ease-out motion-reduce:transition-none",
               expanded ? "max-h-[40rem]" : "max-h-[2.75rem]",
             )}
           >
@@ -255,7 +265,15 @@ function DisplayView({ entry, positionLabel, canEdit, onStartEdit, onRemove }: D
         )}
         <AttachmentRow attachments={attachments} interactive={true} />
       </div>
-      <div className="flex items-center gap-0.5 flex-shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+      <div
+        className={cn(
+          "flex items-center gap-0.5 flex-shrink-0 transition-opacity",
+          // Hover-reveal on devices that support hover (desktop); always
+          // visible on touch surfaces where there's no hover affordance.
+          "opacity-0 group-hover:opacity-100 focus-within:opacity-100",
+          "[@media(hover:none)]:opacity-100",
+        )}
+      >
         {canExpand && (
           <Button
             variant="ghost"

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -150,11 +150,10 @@ export const TaskChatPanel = memo(function TaskChatPanel({
     permissionsByToolCallId,
     childrenByParentToolCallId,
     agentMessageCount,
-    clearQueue,
     pendingClarification,
     pendingClarificationGroup,
   } = panelState;
-  const { handleCancelTurn } = useChatPanelHandlers(resolvedSessionId, clearQueue, chatInputRef);
+  const { handleCancelTurn } = useChatPanelHandlers(resolvedSessionId, chatInputRef);
   const { clarificationKey, handleClarificationResolved } = useClarificationKey(agentMessageCount);
 
   const panelRef = useRef<HTMLDivElement>(null);

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, memo } from "react";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { type ChatInputContainerHandle } from "@/components/task/chat/chat-input-container";
-import { QueuedGhostList } from "@/components/task/chat/queued-ghost-list";
 import { MessageList } from "@/components/task/chat/message-list";
 import { useIsTaskArchived } from "./task-archived-context";
 import { useChatPanelState } from "./chat/use-chat-panel-state";
@@ -223,7 +222,6 @@ export const TaskChatPanel = memo(function TaskChatPanel({
           />
         </div>
       )}
-      <QueuedGhostList sessionId={resolvedSessionId} isArchived={isArchived} />
       {isArchived ? (
         <div className="bg-muted/50 flex-shrink-0 px-4 py-3 text-center text-sm text-muted-foreground border-t">
           This task is archived and read-only.

--- a/apps/web/e2e/tests/chat/message-queue.spec.ts
+++ b/apps/web/e2e/tests/chat/message-queue.spec.ts
@@ -114,7 +114,8 @@ test.describe("Quick chat queue", () => {
     // Collapsed-by-default chip is the new queued-message indicator.
     const chip = dialog.getByTestId("queue-chip");
     await expect(chip).toBeVisible({ timeout: 10_000 });
-    await expect(chip).toHaveAttribute("data-open", "false");
+    // The chip is only rendered while the queue panel is collapsed, so its
+    // mere presence implies the closed state — no data-open assertion needed.
 
     // Wait for the first (slow) response to complete.
     await expect(dialog.getByText("Slow response complete", { exact: false })).toBeVisible({

--- a/apps/web/e2e/tests/chat/message-queue.spec.ts
+++ b/apps/web/e2e/tests/chat/message-queue.spec.ts
@@ -37,6 +37,18 @@ async function typeWhileBusy(page: Page, editor: Locator, text: string): Promise
 // Quick Chat queue tests
 // ---------------------------------------------------------------------------
 
+/**
+ * Open the collapsed queue panel by clicking the floating chip. The chip
+ * appears above the chat input once at least one message is queued; the
+ * panel only mounts after a click (collapsed by default).
+ */
+async function openQueuePanel(scope: Locator | Page): Promise<void> {
+  const chip = scope.getByTestId("queue-chip");
+  await expect(chip).toBeVisible({ timeout: 10_000 });
+  await chip.click();
+  await expect(scope.getByTestId("queued-ghost-list")).toBeVisible({ timeout: 5_000 });
+}
+
 async function openQuickChatWithAgent(page: Page): Promise<Locator> {
   await page.goto("/");
   await page.waitForLoadState("networkidle");
@@ -99,9 +111,10 @@ test.describe("Quick chat queue", () => {
     await typeWhileBusy(testPage, editor, "hello world");
     await testPage.keyboard.press(`${modifier}+Enter`);
 
-    // Verify the queued message indicator with cancel button appears.
-    const cancelBtn = dialog.getByTitle("Remove queued message");
-    await expect(cancelBtn).toBeVisible({ timeout: 10_000 });
+    // Collapsed-by-default chip is the new queued-message indicator.
+    const chip = dialog.getByTestId("queue-chip");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await expect(chip).toHaveAttribute("data-open", "false");
 
     // Wait for the first (slow) response to complete.
     await expect(dialog.getByText("Slow response complete", { exact: false })).toBeVisible({
@@ -148,9 +161,8 @@ test.describe("Quick chat queue", () => {
     // Click the submit button (not keyboard shortcut) to queue the message.
     await submitBtn.click();
 
-    // Verify the queued message indicator with cancel button appears.
-    const cancelBtn = dialog.getByTitle("Remove queued message");
-    await expect(cancelBtn).toBeVisible({ timeout: 10_000 });
+    // Verify the collapsed chip appears as the queued-message indicator.
+    await expect(dialog.getByTestId("queue-chip")).toBeVisible({ timeout: 10_000 });
 
     // Verify the cancel-agent button is also visible alongside submit.
     const cancelAgentBtn = dialog.getByTestId("cancel-agent-button");
@@ -232,8 +244,12 @@ test.describe("Task session queue", () => {
     // Click the submit button to queue the message.
     await submitBtn.click();
 
-    // Verify the queued message indicator appears.
-    await expect(testPage.getByTitle("Remove queued message")).toBeVisible({ timeout: 10_000 });
+    // Collapsed chip is the queued-message indicator on the task session page.
+    await expect(testPage.getByTestId("queue-chip")).toBeVisible({ timeout: 10_000 });
+
+    // Expand once so we can verify the per-entry Remove control is present.
+    await openQueuePanel(testPage);
+    await expect(testPage.getByTitle("Remove queued message")).toBeVisible({ timeout: 5_000 });
 
     // Wait for the queued message to auto-execute and agent to become idle.
     await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
@@ -266,7 +282,9 @@ test.describe("Task session queue", () => {
     await expect(submitBtn).toBeVisible({ timeout: 5_000 });
     await submitBtn.click();
 
-    // Verify the queued indicator appears, then click edit.
+    // Expand the collapsed queue panel to reveal the per-entry Edit affordance.
+    await openQueuePanel(testPage);
+
     const editBtn = testPage.getByTitle("Edit queued message");
     await expect(editBtn).toBeVisible({ timeout: 10_000 });
     await editBtn.click();
@@ -339,6 +357,9 @@ test.describe("Task session queue", () => {
     // Click the submit button to queue the message.
     await submitBtn.click();
 
+    // Expand the chip first; the panel is collapsed by default.
+    await openQueuePanel(testPage);
+
     // Verify the queued ghost list shows clean text (no system tags).
     const queueIndicator = testPage.getByTestId("queued-ghost-list");
     await expect(queueIndicator).toBeVisible({ timeout: 10_000 });
@@ -346,5 +367,113 @@ test.describe("Task session queue", () => {
 
     // Wait for agent to finish processing.
     await expect(session.planModeInput()).toBeVisible({ timeout: 30_000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue affordance — chip & panel behavior
+// ---------------------------------------------------------------------------
+
+test.describe("Queue affordance", () => {
+  test.describe.configure({ retries: 1 });
+
+  test("queue chip stays collapsed by default and toggles via panel close button", async ({
+    testPage,
+  }) => {
+    test.setTimeout(90_000);
+
+    const dialog = await openQuickChatWithAgent(testPage);
+
+    // Send a slow command so the agent stays busy long enough to queue.
+    const editor = dialog.locator(".tiptap.ProseMirror");
+    await editor.click();
+    await editor.fill("/slow 10s");
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await editor.press(`${modifier}+Enter`);
+
+    await expect(testPage.getByRole("status", { name: /Agent is (starting|running)/ })).toBeVisible(
+      { timeout: 15_000 },
+    );
+    await testPage.waitForTimeout(500);
+
+    await typeWhileBusy(testPage, editor, "first queued");
+    await testPage.keyboard.press(`${modifier}+Enter`);
+
+    // Chip is present and collapsed by default.
+    const chip = dialog.getByTestId("queue-chip");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await expect(chip).toContainText("queued");
+    await expect(dialog.getByTestId("queued-ghost-list")).not.toBeVisible();
+
+    // Clicking the chip expands the panel; the chip itself unmounts because the
+    // panel header carries the same affordance.
+    await chip.click();
+    await expect(dialog.getByTestId("queued-ghost-list")).toBeVisible({ timeout: 5_000 });
+    await expect(dialog.getByTestId("queue-chip")).not.toBeVisible();
+
+    // The panel header's X button collapses back to the chip.
+    await dialog.getByTestId("queue-close").click();
+    await expect(dialog.getByTestId("queued-ghost-list")).not.toBeVisible();
+    await expect(dialog.getByTestId("queue-chip")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("Escape collapses an open queue panel", async ({ testPage }) => {
+    test.setTimeout(90_000);
+
+    const dialog = await openQuickChatWithAgent(testPage);
+
+    const editor = dialog.locator(".tiptap.ProseMirror");
+    await editor.click();
+    await editor.fill("/slow 10s");
+    const modifier = process.platform === "darwin" ? "Meta" : "Control";
+    await editor.press(`${modifier}+Enter`);
+
+    await expect(testPage.getByRole("status", { name: /Agent is (starting|running)/ })).toBeVisible(
+      { timeout: 15_000 },
+    );
+    await testPage.waitForTimeout(500);
+
+    await typeWhileBusy(testPage, editor, "queued for esc");
+    await testPage.keyboard.press(`${modifier}+Enter`);
+
+    await openQueuePanel(dialog);
+    // Move focus out of the editor so Escape isn't swallowed by the textarea guard.
+    await dialog.getByTestId("queue-close").focus();
+    await testPage.keyboard.press("Escape");
+
+    await expect(dialog.getByTestId("queued-ghost-list")).not.toBeVisible({ timeout: 5_000 });
+    await expect(dialog.getByTestId("queue-chip")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("clear-all from the panel empties the queue and hides the chip", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const session = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "Queue clear-all test",
+    );
+
+    await session.sendMessage("/slow 10s");
+    await expect(session.agentStatus()).toBeVisible({ timeout: 15_000 });
+    await testPage.waitForTimeout(500);
+
+    const editor = testPage.locator(".tiptap.ProseMirror").first();
+    await typeWhileBusy(testPage, editor, "to be cleared");
+    const submitBtn = testPage.getByTestId("submit-message-button");
+    await expect(submitBtn).toBeVisible({ timeout: 5_000 });
+    await submitBtn.click();
+
+    await openQueuePanel(testPage);
+    await testPage.getByTestId("queue-clear-all").click();
+
+    // Panel and chip both disappear once the queue is empty.
+    await expect(testPage.getByTestId("queued-ghost-list")).not.toBeVisible({ timeout: 5_000 });
+    await expect(testPage.getByTestId("queue-chip")).not.toBeVisible({ timeout: 5_000 });
   });
 });

--- a/apps/web/lib/utils/system-tags.ts
+++ b/apps/web/lib/utils/system-tags.ts
@@ -1,0 +1,9 @@
+/**
+ * Strip internal `<kandev-system>...</kandev-system>` blocks from a message
+ * body. These wrap context the backend injects but never wants surfaced to the
+ * user (e.g. ambient task IDs, MCP session info). Used by the chat message
+ * renderer and the queued-message preview so both consistently hide them.
+ */
+export function stripSystemTags(text: string): string {
+  return text.replace(/<kandev-system>[\s\S]*?<\/kandev-system>/g, "").trim();
+}


### PR DESCRIPTION
The queued-message stack used to permanently sit above the chat input, visually loud and always claiming space. Collapses it into a small "N queued" chip in flow above the input that expands a panel with the same Radix Collapsible animation language as the rest of the surface; inter-task entries now show the purple SenderTaskBadge so provenance matches the delivered messages.

## Important Changes

- `QueueAffordance` owns the chip + panel and is mounted inside `ChatInputArea` — `task-chat-panel.tsx` and `quick-chat-content.tsx` no longer render the queue list directly.
- `SenderTaskBadge` extracted to `messages/sender-task-badge.tsx` with an `xs`/`sm` size prop, reused by both chat bubbles and queue rows.
- Panel animates via custom `queue-panel-open` / `queue-panel-close` keyframes (height + opacity, driven by `--radix-collapsible-content-height`). Per-row content has a chevron that animates `max-height` between a 2-line preview and the full text.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` — 1921 passed (incl. 10 new `QueueAffordance` unit tests)
- Manual smoke: queue 2 messages while `/slow 10s` runs, toggle chip, expand/collapse individual rows, clear-all, watch drain → chip disappears.

## Possible Improvements

Low risk. The `max-h-[40rem]` upper bound on expanded rows can clip very long messages (>~40rem); acceptable since per-entry edit still shows the full textarea, but a measured height or `grid-template-rows: 1fr` swap is the cleaner long-term fix.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.