### PR TITLE
fix(executor): persist worktree subdir as workspace_path

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -962,35 +961,27 @@ func (e *Executor) injectHandoverIfNeeded(ctx context.Context, taskID, currentSe
 }
 
 // computeWorkspacePath derives the env's workspace_path from the launch
-// request and response. Used for both create and update branches of
-// persistTaskEnvironment so the rule lives in exactly one place — without
-// this, the update branch silently leaves workspace_path empty, which
-// produces ErrSessionWorkspaceNotReady forever in the env terminal handler.
+// request and response. The value must mirror the agent process cwd
+// (cfg.WorkDir set from execution.WorkspacePath in utility.go) so that ACP
+// session/load on cold start finds the jsonl saved under the same
+// sanitized-cwd folder on hot start. Collapsing single-repo worktree paths
+// to the task root via filepath.Dir would diverge hot vs cold cwd and break
+// resume with -32002 Resource not found.
 //
-// In task-directory mode the desired value is always the task root that holds
-// every per-repo worktree as a sibling. The legacy single-repo path passes
-// resp.WorktreePath as that repo's subdir, so the parent is the task root.
-// The multi-repo path on the lifecycle adapter mirrors agentctl's WorkDir
-// (already the task root) into resp.WorktreePath, so it must be used as-is —
-// applying filepath.Dir would walk up one level too far and point at the
-// /tasks holder instead.
+// resp.WorktreePath here already mirrors what executor_standalone.go writes
+// into metadata["worktree_path"] (= req.WorkspacePath from the env preparer),
+// which is also what becomes cmd.Dir of the agent process. So persisting it
+// as-is keeps a single source of truth.
 func computeWorkspacePath(req *LaunchAgentRequest, resp *LaunchAgentResponse) string {
-	workspacePath := resp.WorktreePath
-	if workspacePath == "" {
-		workspacePath = req.RepositoryPath
+	if resp.WorktreePath != "" {
+		return resp.WorktreePath
+	}
+	if req.RepositoryPath != "" {
+		return req.RepositoryPath
 	}
 	// Quick-chat sessions have no worktree/repo but the lifecycle manager
 	// creates a workspace directory — use it as fallback.
-	if workspacePath == "" && resp.WorkspacePath != "" {
-		workspacePath = resp.WorkspacePath
-	}
-	if req.TaskDirName == "" || resp.WorktreePath == "" {
-		return workspacePath
-	}
-	if len(resp.Worktrees) > 1 {
-		return resp.WorktreePath
-	}
-	return filepath.Dir(resp.WorktreePath)
+	return resp.WorkspacePath
 }
 
 // persistTaskEnvironment creates or updates the task environment record after a successful launch.

--- a/apps/backend/internal/orchestrator/executor/executor_execute_workspace_path_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute_workspace_path_test.go
@@ -3,16 +3,19 @@ package executor
 import "testing"
 
 // Pinpointed tests for computeWorkspacePath. The persisted workspace_path
-// becomes agentctl's WorkDir on cold start (GetOrEnsureExecution); pointing it
-// at the wrong directory disables the per-repo tracker fan-out and silently
-// drops the Changes panel back to single-repo mode.
+// becomes agentctl's WorkDir on cold start (GetOrEnsureExecution); it must
+// mirror the agent process cwd used on hot start (= cfg.WorkDir, which is
+// metadata["worktree_path"] = req.WorkspacePath from the env preparer).
+// Otherwise ACP session/load on resume fails with -32002 because the agent's
+// jsonl was saved under a different sanitised-cwd folder.
 func TestResolveTaskEnvWorkspacePath(t *testing.T) {
 	t.Parallel()
 	t.Run("multi-repo keeps task root", func(t *testing.T) {
 		req := &LaunchAgentRequest{TaskDirName: "do-nothing_mvo"}
 		resp := &LaunchAgentResponse{
-			// Lifecycle adapter mirrors agentctl WorkDir (task root) into
-			// the legacy WorktreePath field for multi-repo launches.
+			// Multi-repo preparer sets WorkspacePath to filepath.Dir(worktrees[0].WorktreePath)
+			// = task root; executor_standalone copies that into metadata["worktree_path"],
+			// and the lifecycle adapter surfaces it back as resp.WorktreePath.
 			WorktreePath: "/tmp/tasks/do-nothing_mvo",
 			Worktrees: []RepoWorktreeResult{
 				{WorktreePath: "/tmp/tasks/do-nothing_mvo/kandev"},
@@ -24,13 +27,16 @@ func TestResolveTaskEnvWorkspacePath(t *testing.T) {
 		}
 	})
 
-	t.Run("single-repo derives task root from repo subdir", func(t *testing.T) {
+	t.Run("single-repo keeps repo subdir", func(t *testing.T) {
+		// Single-repo preparer sets WorkspacePath = wt.Path (with repo subdir);
+		// the agent process starts at that cwd. Persisting it as-is keeps create
+		// and resume cwd in sync so ACP session/load finds the saved jsonl.
 		req := &LaunchAgentRequest{TaskDirName: "fix-thing_abc"}
 		resp := &LaunchAgentResponse{
 			WorktreePath: "/tmp/tasks/fix-thing_abc/kandev",
 		}
-		if got := computeWorkspacePath(req, resp); got != "/tmp/tasks/fix-thing_abc" {
-			t.Fatalf("single-repo: want /tmp/tasks/fix-thing_abc, got %q", got)
+		if got := computeWorkspacePath(req, resp); got != "/tmp/tasks/fix-thing_abc/kandev" {
+			t.Fatalf("single-repo: want /tmp/tasks/fix-thing_abc/kandev, got %q", got)
 		}
 	})
 

--- a/apps/backend/internal/orchestrator/executor/executor_multi_repo_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_multi_repo_test.go
@@ -55,6 +55,9 @@ func TestLaunchPreparedSession_MultiRepo_PopulatesRequestRepositories(t *testing
 			captured = req
 			return &LaunchAgentResponse{
 				AgentExecutionID: "exec-1",
+				// Multi-repo: top-level WorktreePath mirrors agentctl's WorkDir
+				// (= task root), per executor_standalone.go:147 + lifecycle adapter.
+				WorktreePath: "/tasks/x",
 				Worktrees: []RepoWorktreeResult{
 					{RepositoryID: "repo-front", WorktreeID: "wt-front", WorktreeBranch: "feat/x-1", WorktreePath: "/tasks/x/frontend"},
 					{RepositoryID: "repo-back", WorktreeID: "wt-back", WorktreeBranch: "feat/x-2", WorktreePath: "/tasks/x/backend"},
@@ -108,7 +111,10 @@ func TestLaunchPreparedSession_MultiRepo_PersistsPerRepoEnvironmentAndWorktreeRo
 			return &LaunchAgentResponse{
 				AgentExecutionID: "exec-2",
 				WorktreeID:       "wt-front", // legacy mirror of Worktrees[0]
-				WorktreePath:     "/tasks/x/frontend",
+				// Multi-repo: top-level WorktreePath = task root, matching how
+				// executor_standalone.go:147 writes metadata["worktree_path"] from
+				// req.WorkspacePath (set to task root by the multi-repo preparer).
+				WorktreePath: "/tasks/x",
 				Worktrees: []RepoWorktreeResult{
 					{RepositoryID: "repo-front", WorktreeID: "wt-front", WorktreeBranch: "feat/x-1", WorktreePath: "/tasks/x/frontend"},
 					{RepositoryID: "repo-back", WorktreeID: "wt-back", WorktreeBranch: "feat/x-2", WorktreePath: "/tasks/x/backend"},

--- a/apps/backend/internal/orchestrator/executor/executor_worktree_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_worktree_resume_test.go
@@ -1,0 +1,86 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// TestLaunchPreparedSession_SingleRepoWorktree_PersistsSubdirAsWorkspacePath is
+// the regression guard for the -32002 Resource not found bug on session/load
+// after backend restart for single-repo Worktree tasks. Before the fix,
+// computeWorkspacePath collapsed resp.WorktreePath via filepath.Dir and
+// wrote the task root as workspace_path, while the hot-start agent cwd was
+// the repo subdir. On cold start the persisted (parent) workspace_path
+// became the new cwd → SDK sanitized to a different folder and missed the
+// agent's jsonl. After the fix, workspace_path == worktree_path (the subdir),
+// matching the hot-start cwd.
+func TestLaunchPreparedSession_SingleRepoWorktree_PersistsSubdirAsWorkspacePath(t *testing.T) {
+	repo := newMockRepository()
+	taskID := "task-wt-single-1"
+	sessionID := "session-wt-single-1"
+	repo.repositories["repo-only"] = &models.Repository{
+		ID: "repo-only", Name: "only", LocalPath: "/repos/only", WorktreeBranchPrefix: "feat/",
+	}
+	repo.taskRepositories["tr-only"] = &models.TaskRepository{
+		ID: "tr-only", TaskID: taskID, RepositoryID: "repo-only", Position: 0, BaseBranch: "main",
+	}
+	repo.sessions[sessionID] = &models.TaskSession{
+		ID:             sessionID,
+		TaskID:         taskID,
+		AgentProfileID: "profile-123",
+		State:          models.TaskSessionStateCreated,
+		StartedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	const subdir = "/home/u/.kandev/tasks/test-task_abc/repo-only"
+
+	agentManager := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+			// Single-repo Worktree preparer returns wt.Path (subdir with repo
+			// folder), executor_standalone.go:147 mirrors it into
+			// metadata["worktree_path"], the lifecycle adapter surfaces it as
+			// resp.WorktreePath.
+			return &LaunchAgentResponse{
+				AgentExecutionID: "exec-1",
+				WorktreeID:       "wt-1",
+				WorktreePath:     subdir,
+				WorktreeBranch:   "feat/test",
+				PrepareResult: &lifecycle.EnvPrepareResult{
+					Success:    true,
+					WorktreeID: "wt-1",
+				},
+			}, nil
+		},
+	}
+	exec := newTestExecutor(t, agentManager, repo)
+
+	task := &v1.Task{ID: taskID, WorkspaceID: "ws-1", Title: "SingleRepoWorktree"}
+	if _, err := exec.LaunchPreparedSession(context.Background(), task, sessionID, LaunchOptions{
+		AgentProfileID: "profile-123",
+		StartAgent:     false,
+	}); err != nil {
+		t.Fatalf("LaunchPreparedSession: %v", err)
+	}
+
+	if len(repo.taskEnvironments) != 1 {
+		t.Fatalf("expected 1 task_environment, got %d", len(repo.taskEnvironments))
+	}
+	var env *models.TaskEnvironment
+	for _, e := range repo.taskEnvironments {
+		env = e
+	}
+	if env.WorktreePath != subdir {
+		t.Errorf("worktree_path = %q, want %q", env.WorktreePath, subdir)
+	}
+	if env.WorkspacePath != subdir {
+		t.Errorf("workspace_path = %q, want %q (== worktree_path so process cwd matches between hot and cold start)",
+			env.WorkspacePath, subdir)
+	}
+}
+

--- a/apps/backend/internal/task/repository/sqlite/base.go
+++ b/apps/backend/internal/task/repository/sqlite/base.go
@@ -656,25 +656,29 @@ func (r *Repository) findOrphanedTasks() ([]backfillRow, error) {
 // trigger ErrSessionWorkspaceNotReady forever in GetOrEnsureExecutionForEnvironment
 // and leave shell terminals stuck on "Connecting terminal...".
 //
-// Two worktree layouts produce two different workspace_path values, mirroring
-// the create branch in orchestrator/executor/executor_execute.go's
-// computeWorkspacePath:
+// It also repairs rows where workspace_path was the task-root parent of
+// worktree_path — a pre-fix value left by the legacy computeWorkspacePath
+// that collapsed single-repo worktree paths via filepath.Dir. After the fix,
+// workspace_path must equal worktree_path (the agent process cwd) so ACP
+// session/load on cold start hits the same sanitized-cwd jsonl folder the
+// agent wrote on hot start. Without this repair, existing single-repo
+// Worktree tasks keep failing with -32002 after upgrade.
 //
-//   - Plain worktree (.../.kandev/worktrees/<name>) — workspace_path = worktree_path
-//   - Task-dir mode (.../.kandev/tasks/<name>/<repo>) — workspace_path = Dir(worktree_path)
-//
-// The pattern lookup is hardcoded to the kandev path layout — anything that
-// doesn't match either pattern falls back to worktree_path (the common-case
-// plain-worktree assumption) and is logged for manual review.
-//
-// Idempotent — only touches rows where workspace_path is empty.
+// Idempotent — once workspace_path == worktree_path nothing more is changed.
 func (r *Repository) healTaskEnvironmentWorkspacePaths() error {
+	// substr(...) prefix match is safer than LIKE here: paths may contain
+	// "_" or "%", both of which are LIKE wildcards in SQLite.
 	rows, err := r.db.Query(`
 		SELECT id, worktree_path
 		  FROM task_environments
 		 WHERE executor_type = 'worktree'
-		   AND COALESCE(workspace_path, '') = ''
 		   AND COALESCE(worktree_path, '') != ''
+		   AND COALESCE(workspace_path, '') != worktree_path
+		   AND (
+		         COALESCE(workspace_path, '') = ''
+		         OR (length(workspace_path) < length(worktree_path)
+		             AND substr(worktree_path, 1, length(workspace_path)) = workspace_path)
+		       )
 	`)
 	if err != nil {
 		return fmt.Errorf("heal workspace_path: query: %w", err)
@@ -699,35 +703,14 @@ func (r *Repository) healTaskEnvironmentWorkspacePaths() error {
 	}
 
 	for _, hr := range pending {
-		ws := healedWorkspacePath(hr.worktreePath)
 		if _, err := r.db.Exec(
 			`UPDATE task_environments SET workspace_path = ?, updated_at = datetime('now') WHERE id = ?`,
-			ws, hr.id,
+			hr.worktreePath, hr.id,
 		); err != nil {
 			return fmt.Errorf("heal workspace_path: update %s: %w", hr.id, err)
 		}
 	}
 	return nil
-}
-
-// healedWorkspacePath derives workspace_path from worktree_path using the
-// kandev layout rules. Mirrors computeWorkspacePath in the orchestrator so
-// the heal lands the same value the create branch would.
-func healedWorkspacePath(worktreePath string) string {
-	if worktreePath == "" {
-		return ""
-	}
-	// Task-dir mode places the worktree at <root>/.kandev/tasks/<name>/<repo>.
-	// The workspace is the per-task root one level up from the repo subdir.
-	// Detect via the segment .kandev/tasks/ in the path.
-	if strings.Contains(worktreePath, "/.kandev/tasks/") {
-		parent := worktreePath[:strings.LastIndex(worktreePath, "/")]
-		if parent != "" {
-			return parent
-		}
-	}
-	// Plain worktree mode: workspace_path == worktree_path.
-	return worktreePath
 }
 
 // healDuplicateTaskEnvironments collapses rows where a single task has more

--- a/apps/backend/internal/task/repository/sqlite/heal_test.go
+++ b/apps/backend/internal/task/repository/sqlite/heal_test.go
@@ -102,10 +102,12 @@ func TestHealTaskEnvironmentWorkspacePaths_BackfillsEmpty(t *testing.T) {
 	}
 }
 
-// TestHealTaskEnvironmentWorkspacePaths_LeavesPopulatedAlone — a row that
-// already has a workspace_path must not be touched. Otherwise the heal could
-// stamp on task-dir-mode envs whose workspace_path is the worktree's parent.
-func TestHealTaskEnvironmentWorkspacePaths_LeavesPopulatedAlone(t *testing.T) {
+// TestHealTaskEnvironmentWorkspacePaths_RepairsCollapsedParent — a row where
+// workspace_path was the task-root parent of worktree_path (the pre-fix value
+// left by legacy computeWorkspacePath's filepath.Dir) must be repaired:
+// workspace_path becomes worktree_path so ACP session/load finds the agent's
+// saved jsonl on cold start.
+func TestHealTaskEnvironmentWorkspacePaths_RepairsCollapsedParent(t *testing.T) {
 	repo := newRepoForHealTests(t)
 	insertTask(t, repo.db, "task-B")
 	insertEnv(t, repo.db, &models.TaskEnvironment{
@@ -113,7 +115,7 @@ func TestHealTaskEnvironmentWorkspacePaths_LeavesPopulatedAlone(t *testing.T) {
 		TaskID:        "task-B",
 		ExecutorType:  "worktree",
 		WorktreePath:  "/home/user/.kandev/tasks/foo_abc/repo",
-		WorkspacePath: "/home/user/.kandev/tasks/foo_abc",
+		WorkspacePath: "/home/user/.kandev/tasks/foo_abc", // legacy collapsed parent
 	})
 
 	if err := repo.healTaskEnvironmentWorkspacePaths(); err != nil {
@@ -124,16 +126,41 @@ func TestHealTaskEnvironmentWorkspacePaths_LeavesPopulatedAlone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get env: %v", err)
 	}
-	if got.WorkspacePath != "/home/user/.kandev/tasks/foo_abc" {
+	if got.WorkspacePath != "/home/user/.kandev/tasks/foo_abc/repo" {
+		t.Errorf("workspace_path = %q, want repaired to worktree_path subdir", got.WorkspacePath)
+	}
+}
+
+// TestHealTaskEnvironmentWorkspacePaths_LeavesAlreadyCorrectAlone — a row that
+// already has workspace_path == worktree_path must not be touched.
+func TestHealTaskEnvironmentWorkspacePaths_LeavesAlreadyCorrectAlone(t *testing.T) {
+	repo := newRepoForHealTests(t)
+	insertTask(t, repo.db, "task-B2")
+	insertEnv(t, repo.db, &models.TaskEnvironment{
+		ID:            "env-B2",
+		TaskID:        "task-B2",
+		ExecutorType:  "worktree",
+		WorktreePath:  "/home/user/.kandev/tasks/foo_abc/repo",
+		WorkspacePath: "/home/user/.kandev/tasks/foo_abc/repo",
+	})
+
+	if err := repo.healTaskEnvironmentWorkspacePaths(); err != nil {
+		t.Fatalf("heal: %v", err)
+	}
+
+	got, err := repo.GetTaskEnvironment(context.Background(), "env-B2")
+	if err != nil {
+		t.Fatalf("get env: %v", err)
+	}
+	if got.WorkspacePath != "/home/user/.kandev/tasks/foo_abc/repo" {
 		t.Errorf("workspace_path = %q, must not be overwritten", got.WorkspacePath)
 	}
 }
 
 // TestHealTaskEnvironmentWorkspacePaths_TaskDirMode — task-dir-mode envs
 // place the worktree at <root>/.kandev/tasks/<name>/<repo>; workspace_path
-// must be the per-task root (Dir of worktree_path), not the repo subdir.
-// The naive heal would have stamped worktree_path here and corrupted the
-// row in a different way.
+// must equal worktree_path (the repo subdir), matching the agent process cwd
+// so ACP session/load on cold start hits the same sanitised-cwd folder.
 func TestHealTaskEnvironmentWorkspacePaths_TaskDirMode(t *testing.T) {
 	repo := newRepoForHealTests(t)
 	insertTask(t, repo.db, "task-T")
@@ -152,8 +179,8 @@ func TestHealTaskEnvironmentWorkspacePaths_TaskDirMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get env: %v", err)
 	}
-	if got.WorkspacePath != "/home/u/.kandev/tasks/fix-something_abc" {
-		t.Errorf("workspace_path = %q, want task root (parent of worktree_path)", got.WorkspacePath)
+	if got.WorkspacePath != "/home/u/.kandev/tasks/fix-something_abc/kandev" {
+		t.Errorf("workspace_path = %q, want worktree_path (subdir) — process cwd parity", got.WorkspacePath)
 	}
 }
 


### PR DESCRIPTION
Single-repo Worktree tasks failed ACP session/load with -32002 Resource not found after backend restart — specifically, Claude Code could no longer locate the current session's `*.jsonl` file. The agent process started at the repo subdir on hot start, but computeWorkspacePath collapsed resp.WorktreePath via filepath.Dir and persisted the task root as workspace_path. On cold start the agent then started at that task root, so Claude Code sanitized a different folder and could not find the saved jsonl.

Persist resp.WorktreePath as-is for all branches. It already mirrors the agent's cmd.Dir (executor_standalone writes metadata["worktree_path"] = req.WorkspacePath from the preparer): subdir for single-repo, task root for multi-repo. Multi-repo behaviour and the per-repo tracker fan-out invariant are unchanged.

Extend healTaskEnvironmentWorkspacePaths to also repair existing rows where workspace_path is the task-root parent of worktree_path, so upgraded installs heal their single-repo Worktree envs on the next backend start and old sessions can resume. The heal query uses a substr(...) prefix match — paths may contain "_" or "%", both of which are LIKE wildcards in SQLite.

## Validation

- `go vet ./internal/orchestrator/executor/...`
- `go test -run "Workspace|Worktree" ./internal/orchestrator/executor/...` — regression test `TestLaunchPreparedSession_SingleRepoWorktree_PersistsSubdirAsWorkspacePath` passes

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
