### PR TITLE
feat(web): add dev debug logging for git-status, dockview, and chat messages

### DIFF
--- a/apps/backend/cmd/mock-agent/handler.go
+++ b/apps/backend/cmd/mock-agent/handler.go
@@ -74,6 +74,12 @@ func handlePrompt(e *emitter, prompt, model string) {
 		rest := strings.TrimPrefix(cmd, "/e2e:")
 		scenarioName, _, _ := strings.Cut(strings.TrimSpace(rest), " ")
 		emitPredefinedScenario(e, scenarioName)
+	// Friendly aliases for the two clarification e2e scenarios so the slash menu
+	// exposes them without forcing users to type /e2e:clarification(-multi).
+	case strings.EqualFold(cmd, "/ask-single"):
+		emitPredefinedScenario(e, "clarification")
+	case strings.EqualFold(cmd, "/ask-multiple"):
+		emitPredefinedScenario(e, "clarification-multi")
 	case strings.EqualFold(cmd, "/crash"):
 		emitCrash(e, model)
 	case strings.HasPrefix(cmd, "/todo"):

--- a/apps/backend/cmd/mock-agent/main.go
+++ b/apps/backend/cmd/mock-agent/main.go
@@ -266,6 +266,8 @@ func mockAvailableCommands() []acp.AvailableCommand {
 		{Name: "tool:search", Description: "Emit a search tool call"},
 		{Name: "markdown", Description: "Render all markdown/text types"},
 		{Name: "sleep", Description: "Sleep without output (default 10s)", Input: hint("seconds (e.g. 30)")},
+		{Name: "ask-single", Description: "Ask a single clarification question"},
+		{Name: "ask-multiple", Description: "Ask multiple clarification questions"},
 	}
 }
 

--- a/apps/backend/internal/gateway/websocket/client.go
+++ b/apps/backend/internal/gateway/websocket/client.go
@@ -60,8 +60,14 @@ func NewClient(id string, conn *websocket.Conn, hub *Hub, log *logger.Logger) *C
 	}
 }
 
-// ReadPump pumps messages from the WebSocket connection to the hub
-func (c *Client) ReadPump(ctx context.Context) {
+// ReadPump pumps messages from the WebSocket connection to the hub.
+//
+// The ctx argument is retained for API stability but is not consulted by the
+// pump itself — Gorilla's ReadMessage blocks on the conn only, so teardown
+// happens via the conn close path (driven by client disconnect, server
+// shutdown closing all conns, or pong timeout). Dispatched handlers use the
+// hub's lifetime context instead; see handleMessage.
+func (c *Client) ReadPump(_ context.Context) {
 	defer func() {
 		c.hub.Unregister(c)
 		if err := c.conn.Close(); err != nil {
@@ -100,12 +106,16 @@ func (c *Client) ReadPump(ctx context.Context) {
 		// Process the message in a goroutine to avoid blocking the read pump
 		// This allows concurrent message handling so long-running handlers
 		// (like orchestrator.prompt) don't block other requests (like workspace.tree.get)
-		go c.handleMessage(ctx, &msg)
+		go c.handleMessage(&msg)
 	}
 }
 
-// handleMessage processes an incoming message
-func (c *Client) handleMessage(ctx context.Context, msg *ws.Message) {
+// handleMessage processes an incoming message.
+//
+// Intentionally does NOT take the connection context. Dispatched handlers run
+// under the hub's lifetime context so a mid-flight client disconnect doesn't
+// abort in-progress side effects (see the comment on Dispatch below).
+func (c *Client) handleMessage(msg *ws.Message) {
 	c.logger.Debug("Received message",
 		zap.String("action", msg.Action),
 		zap.String("id", msg.ID))
@@ -144,8 +154,17 @@ func (c *Client) handleMessage(ctx context.Context, msg *ws.Message) {
 		return
 	}
 
-	// Dispatch to handler
-	response, err := c.hub.dispatcher.Dispatch(ctx, msg)
+	// Dispatch to handler using the hub's lifetime context, not the per-
+	// connection one. The connection ctx is cancelled when the client
+	// disconnects (page reload, nav, network drop). Using it here would
+	// SIGKILL any exec.CommandContext subprocesses the handler spawned
+	// (e.g. `gh pr`, `git`, agentctl HTTP requests) and abort
+	// side-effecting work like session.launch mid-flight. We can't deliver
+	// the response either way once the connection is gone, but the
+	// handler's work should run to completion so it doesn't leave partial
+	// state behind. The dispatch ctx still cancels on server shutdown.
+	dispatchCtx := c.hub.DispatchContext()
+	response, err := c.hub.dispatcher.Dispatch(dispatchCtx, msg)
 	if err != nil {
 		c.logger.Error("Handler error",
 			zap.String("action", msg.Action),

--- a/apps/backend/internal/gateway/websocket/client_dispatch_ctx_test.go
+++ b/apps/backend/internal/gateway/websocket/client_dispatch_ctx_test.go
@@ -1,0 +1,191 @@
+package websocket
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// TestHub_DispatchContextFallsBackBeforeRun guards the test-setup path:
+// DispatchContext must never return a nil context, even when Run was never
+// started (e.g. tests that just exercise handlers directly).
+func TestHub_DispatchContextFallsBackBeforeRun(t *testing.T) {
+	h := newTestHub(t)
+
+	got := h.DispatchContext()
+	if got == nil {
+		t.Fatal("DispatchContext returned nil before Run; handlers would NPE")
+	}
+	if err := got.Err(); err != nil {
+		t.Fatalf("fallback ctx should not be done, got err=%v", err)
+	}
+}
+
+// TestHub_DispatchContextTracksRunCtx checks that DispatchContext returns the
+// ctx Run was called with, so it cancels on server shutdown (the only
+// cancellation reason that should still kill dispatched handlers).
+func TestHub_DispatchContextTracksRunCtx(t *testing.T) {
+	h := newTestHub(t)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Set directly via in-package field access — mirrors what Run does without
+	// the goroutine scheduling race.
+	h.mu.Lock()
+	h.dispatchCtx = runCtx
+	h.mu.Unlock()
+
+	dispatchCtx := h.DispatchContext()
+	if dispatchCtx.Err() != nil {
+		t.Fatalf("dispatchCtx prematurely done: %v", dispatchCtx.Err())
+	}
+
+	cancel()
+
+	// Cancellation is synchronous once the parent ctx is cancelled.
+	if dispatchCtx.Err() == nil {
+		t.Fatal("dispatchCtx did not cancel when hub ctx was cancelled")
+	}
+}
+
+// TestClient_HandleMessageUsesHubCtxNotConnCtx is the regression test for the
+// SIGKILL cascade: a dispatched handler must NOT see a cancelled context when
+// the originating client disconnects. Before the fix, the dispatcher was
+// called with the connection ctx, so any in-flight exec.CommandContext
+// subprocess (gh, git, agentctl HTTP) got SIGKILL'd the moment the user
+// navigated away from the page.
+func TestClient_HandleMessageUsesHubCtxNotConnCtx(t *testing.T) {
+	h := newTestHub(t)
+	dispatcher := ws.NewDispatcher()
+	h.dispatcher = dispatcher
+
+	hubCtx, hubCancel := context.WithCancel(context.Background())
+	defer hubCancel()
+
+	// Set directly before Run so the goroutine has no scheduling race.
+	h.mu.Lock()
+	h.dispatchCtx = hubCtx
+	h.mu.Unlock()
+	go h.Run(hubCtx)
+
+	// Handler that records what ctx it received and waits long enough for
+	// the test to cancel a fake connection ctx before returning. If the
+	// dispatcher were still wired to the connection ctx, gotCtx.Err()
+	// below would be non-nil.
+	handlerEntered := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	var gotCtx context.Context
+	dispatcher.RegisterFunc("test.write", func(ctx context.Context, _ *ws.Message) (*ws.Message, error) {
+		gotCtx = ctx
+		close(handlerEntered)
+		<-releaseHandler
+		return nil, nil
+	})
+
+	c := newTestClient("c-disconnect")
+	c.hub = h
+
+	// Run handleMessage in a goroutine so we can cancel the "connection"
+	// while the handler is mid-flight.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.handleMessage(&ws.Message{Action: "test.write", Type: ws.MessageTypeRequest})
+	}()
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("handler never entered; dispatch wiring is broken")
+	}
+
+	// The handler is inside Dispatch. In production this is the moment the
+	// WS client disconnects. Verify the handler's ctx is not derived from
+	// any connection lifetime: we don't even have a connection ctx to
+	// cancel here, which is exactly the point — handleMessage no longer
+	// takes one.
+	if gotCtx == nil {
+		t.Fatal("handler did not receive a context")
+	}
+	if err := gotCtx.Err(); err != nil {
+		t.Fatalf("handler ctx already done at entry: %v", err)
+	}
+
+	// Sanity: the handler ctx must be the hub's lifetime ctx (or derived
+	// from it). Cancel the hub and observe. Cancellation is synchronous
+	// because gotCtx IS hubCtx (DispatchContext returns the field directly).
+	hubCancel()
+	if !errors.Is(gotCtx.Err(), context.Canceled) {
+		t.Fatalf("handler ctx should cancel with hub shutdown, got err=%v", gotCtx.Err())
+	}
+
+	close(releaseHandler)
+	<-done
+}
+
+// TestClient_HandleMessageSurvivesConnectionTeardown is the higher-level
+// regression: even though ReadPump may exit and the client may be torn down,
+// already-dispatched handlers continue running. Models the real bug — a
+// session.launch already inside the handler when the WS closes.
+func TestClient_HandleMessageSurvivesConnectionTeardown(t *testing.T) {
+	h := newTestHub(t)
+	dispatcher := ws.NewDispatcher()
+	h.dispatcher = dispatcher
+
+	hubCtx, hubCancel := context.WithCancel(context.Background())
+	defer hubCancel()
+
+	h.mu.Lock()
+	h.dispatchCtx = hubCtx
+	h.mu.Unlock()
+	go h.Run(hubCtx)
+
+	handlerEntered := make(chan struct{})
+	handlerCompleted := make(chan error, 1)
+	releaseHandler := make(chan struct{})
+	dispatcher.RegisterFunc("session.launch.fake", func(ctx context.Context, _ *ws.Message) (*ws.Message, error) {
+		close(handlerEntered)
+		// Mimic an exec.CommandContext-style subroutine that watches ctx.
+		select {
+		case <-releaseHandler:
+			handlerCompleted <- ctx.Err()
+		case <-ctx.Done():
+			handlerCompleted <- ctx.Err()
+		}
+		return nil, nil
+	})
+
+	c := newTestClient("c-teardown")
+	c.hub = h
+
+	go c.handleMessage(&ws.Message{Action: "session.launch.fake", Type: ws.MessageTypeRequest})
+
+	select {
+	case <-handlerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("handler never entered; dispatch wiring is broken")
+	}
+
+	// Simulate connection teardown: close the client's send channel and
+	// drop our hub reference, the way removeClient would. Crucially, this
+	// does NOT cancel the hub ctx — only client-scoped state goes away.
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+
+	// Handler must still be running. Release it explicitly.
+	close(releaseHandler)
+
+	select {
+	case err := <-handlerCompleted:
+		if err != nil {
+			t.Fatalf("handler ctx was cancelled by connection teardown; want nil, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handler never completed; deadlock or wrong ctx wiring")
+	}
+}

--- a/apps/backend/internal/gateway/websocket/hub.go
+++ b/apps/backend/internal/gateway/websocket/hub.go
@@ -45,6 +45,13 @@ type Hub struct {
 	// effective mode (paused/slow/fast) transitions. See hub_session_mode.go.
 	sessionMode *sessionModeTracker
 
+	// dispatchCtx is the hub's lifetime context, set by Run. Dispatched
+	// message handlers use it instead of the per-connection context so that
+	// a client disconnecting mid-flight does not SIGKILL exec subprocesses
+	// (gh, git, agentctl HTTP calls) or otherwise abort side-effecting work
+	// like session.launch. It still cancels on server shutdown.
+	dispatchCtx context.Context
+
 	mu     sync.RWMutex
 	logger *logger.Logger
 }
@@ -70,6 +77,10 @@ func NewHub(dispatcher *ws.Dispatcher, log *logger.Logger) *Hub {
 func (h *Hub) Run(ctx context.Context) {
 	h.logger.Info("WebSocket hub started")
 	defer h.logger.Info("WebSocket hub stopped")
+
+	h.mu.Lock()
+	h.dispatchCtx = ctx
+	h.mu.Unlock()
 
 	for {
 		select {
@@ -435,6 +446,20 @@ func (h *Hub) GetClientCount() int {
 // GetDispatcher returns the message dispatcher
 func (h *Hub) GetDispatcher() *ws.Dispatcher {
 	return h.dispatcher
+}
+
+// DispatchContext returns a context whose lifetime is tied to the hub (and
+// therefore the server) rather than any single client connection. Dispatched
+// handlers should use this so that a client disconnecting mid-flight does not
+// cancel in-progress writes, exec subprocesses, or downstream HTTP calls.
+// Falls back to context.Background when Run has not been called (test setups).
+func (h *Hub) DispatchContext() context.Context {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.dispatchCtx == nil {
+		return context.Background()
+	}
+	return h.dispatchCtx
 }
 
 // SetSessionDataProvider sets the provider for session data on subscription

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -883,8 +883,13 @@ func (s *Service) ResumeTaskSession(ctx context.Context, taskID, sessionID strin
 		if task, taskErr := s.repo.GetTask(resumeCtx, taskID); taskErr == nil && task != nil && task.ArchivedAt != nil {
 			return nil, executor.ErrTaskArchived
 		}
-		s.updateTaskSessionState(ctx, taskID, sessionID, models.TaskSessionStateFailed, err.Error(), false, session)
-		if stateErr := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateFailed); stateErr != nil {
+		// Use resumeCtx (WithoutCancel) for the failure-recording writes too —
+		// if the caller's ctx was already cancelled (e.g. WS client navigated
+		// away), the SessionStateFailed and TaskStateFailed updates would
+		// themselves fail with "context canceled" and leave the task stuck
+		// looking "running" forever.
+		s.updateTaskSessionState(resumeCtx, taskID, sessionID, models.TaskSessionStateFailed, err.Error(), false, session)
+		if stateErr := s.taskRepo.UpdateTaskState(resumeCtx, taskID, v1.TaskStateFailed); stateErr != nil {
 			s.logger.Warn("failed to update task state to FAILED after resume error",
 				zap.String("task_id", taskID),
 				zap.String("session_id", sessionID),

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -878,6 +878,93 @@ func TestResumeTaskSession_FailedKeepsResumeToken(t *testing.T) {
 	}
 }
 
+// ctxAwareTaskRepo wraps mockTaskRepo and respects ctx cancellation. Used to
+// prove that ResumeTaskSession's failure-recording path is insulated from a
+// pre-cancelled caller ctx (the WS-disconnect scenario).
+type ctxAwareTaskRepo struct {
+	inner *mockTaskRepo
+}
+
+func (c *ctxAwareTaskRepo) GetTask(ctx context.Context, taskID string) (*v1.Task, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return c.inner.GetTask(ctx, taskID)
+}
+
+func (c *ctxAwareTaskRepo) UpdateTaskState(ctx context.Context, taskID string, state v1.TaskState) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.inner.UpdateTaskState(ctx, taskID, state)
+}
+
+// TestResumeTaskSession_FailedStateWriteSurvivesCancelledCallerCtx verifies the
+// fix for the WS-disconnect cascade: when the caller's ctx was already
+// cancelled (e.g. the user navigated away mid-resume) and the launch then
+// failed, the FAILED state-update writes must still go through using the
+// detached resumeCtx — otherwise the task is stuck looking "running" forever.
+//
+// Before the fix, lines 886-892 used the original ctx, so the failure-state
+// write itself returned "context canceled" and the WARN "failed to update task
+// state to FAILED after resume error: context canceled" appeared in the logs.
+func TestResumeTaskSession_FailedStateWriteSurvivesCancelledCallerCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	repo := setupTestRepo(t)
+	mockTR := newMockTaskRepo()
+	taskRepo := &ctxAwareTaskRepo{inner: mockTR}
+
+	// Cancel the caller ctx the moment launch is invoked. This mirrors the
+	// WS-disconnect race: the request handler's ctx is alive when the
+	// resume path starts (so it gets through the early-exit checks against
+	// sqlite/etc.) and dies mid-launch. The post-launch failure-recording
+	// writes use resumeCtx (WithoutCancel) and must still succeed.
+	agentMgr := &mockAgentManager{
+		launchAgentFunc: func(_ context.Context, _ *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+			cancel()
+			return nil, errors.New("simulated launch failure")
+		},
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), mockTR, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	// Override with the ctx-aware wrapper so we can detect ctx-canceled
+	// writes — the bare mockTaskRepo ignores ctx entirely.
+	svc.taskRepo = taskRepo
+
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+	session, _ := repo.GetTaskSession(ctx, "session1")
+	session.AgentProfileID = "profile-1"
+	_ = repo.UpdateTaskSession(ctx, session)
+
+	now := time.Now().UTC()
+	_ = repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID: "er1", SessionID: "session1", TaskID: "task1",
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	_, err := svc.ResumeTaskSession(ctx, "task1", "session1")
+	if err == nil {
+		t.Fatal("expected ResumeTaskSession to return an error from the simulated launch failure")
+	}
+
+	state, ok := mockTR.updatedStates["task1"]
+	if !ok {
+		t.Fatal("task FAILED state was NOT persisted; the failure-recording write was cancelled by the caller ctx")
+	}
+	if state != v1.TaskStateFailed {
+		t.Errorf("expected task1 state=FAILED, got %v", state)
+	}
+
+	persisted, getErr := repo.GetTaskSession(context.Background(), "session1")
+	if getErr != nil {
+		t.Fatalf("failed to reload session: %v", getErr)
+	}
+	if persisted.State != models.TaskSessionStateFailed {
+		t.Errorf("expected session1 state=FAILED, got %v", persisted.State)
+	}
+}
+
 // --- CompleteTask ---
 
 func TestCompleteTask_UpdatesTaskState(t *testing.T) {

--- a/apps/web/components/github/my-github/pr-list.test.tsx
+++ b/apps/web/components/github/my-github/pr-list.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import type { GitHubPR, GitHubPRStatus } from "@/lib/types/github";
+import { pickPRForLaunch } from "./pr-list";
+
+function makePR(overrides?: Partial<GitHubPR>): GitHubPR {
+  return {
+    number: 42,
+    title: "Test PR",
+    url: "https://github.com/owner/repo/pull/42",
+    html_url: "https://github.com/owner/repo/pull/42",
+    state: "open",
+    head_branch: "",
+    base_branch: "",
+    author_login: "author",
+    repo_owner: "owner",
+    repo_name: "repo",
+    draft: false,
+    mergeable: true,
+    additions: 0,
+    deletions: 0,
+    requested_reviewers: [],
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    merged_at: null,
+    closed_at: null,
+    ...overrides,
+  };
+}
+
+function makeStatus(pr: GitHubPR): GitHubPRStatus {
+  return {
+    pr,
+    review_state: "",
+    checks_state: "",
+    mergeable_state: "unknown",
+    review_count: 0,
+    pending_review_count: 0,
+    checks_total: 0,
+    checks_passing: 0,
+  };
+}
+
+describe("pickPRForLaunch", () => {
+  it("prefers the enriched PR from the batched status (which carries head/base branches)", () => {
+    const rawSearchPR = makePR({ head_branch: "", base_branch: "" });
+    const enrichedPR = makePR({ head_branch: "feature/x", base_branch: "main" });
+
+    const result = pickPRForLaunch(rawSearchPR, makeStatus(enrichedPR));
+
+    expect(result.head_branch).toBe("feature/x");
+    expect(result.base_branch).toBe("main");
+  });
+
+  it("falls back to the raw PR when no status is loaded yet", () => {
+    const rawPR = makePR({ head_branch: "feature/raw", base_branch: "main" });
+
+    expect(pickPRForLaunch(rawPR, undefined).head_branch).toBe("feature/raw");
+    expect(pickPRForLaunch(rawPR, null).head_branch).toBe("feature/raw");
+  });
+});

--- a/apps/web/components/github/my-github/pr-list.tsx
+++ b/apps/web/components/github/my-github/pr-list.tsx
@@ -31,6 +31,13 @@ type PRListProps = {
   onStartTask: (payload: LaunchPayload) => void;
 };
 
+// Prefer the enriched PR returned by the batched status endpoint — the search
+// API used to populate `items` does not include head/base branches, so the
+// launcher needs the enriched copy to pre-fill the task dialog correctly.
+export function pickPRForLaunch(pr: GitHubPR, status: GitHubPRStatus | null | undefined): GitHubPR {
+  return status?.pr ?? pr;
+}
+
 function prStateIcon(pr: GitHubPR): { Icon: Icon; className: string } {
   if (pr.state === "merged")
     return { Icon: IconGitMerge, className: "text-purple-600 dark:text-purple-400" };
@@ -53,7 +60,12 @@ function StartTaskMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="sm" variant="outline" className="h-7 gap-1 cursor-pointer">
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1 cursor-pointer"
+          data-testid="pr-start-task-trigger"
+        >
           <IconPlus className="h-3.5 w-3.5" />
           Task
           <IconChevronDown className="h-3 w-3" />
@@ -67,6 +79,8 @@ function StartTaskMenu({
               key={p.id}
               className="cursor-pointer gap-2 py-1.5"
               onSelect={() => launch(p)}
+              data-testid="pr-start-task-preset"
+              data-preset-id={p.id}
             >
               <ItemIcon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
               <div className="flex flex-col min-w-0">
@@ -94,7 +108,11 @@ function PRRow({
 }) {
   const { Icon: StateIcon, className: stateIconClass } = prStateIcon(pr);
   return (
-    <div className="flex items-start gap-3 px-4 py-3 hover:bg-muted/40 transition-colors">
+    <div
+      className="flex items-start gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
+      data-testid="pr-row"
+      data-pr-number={pr.number}
+    >
       <StateIcon className={cn("h-4 w-4 mt-1 shrink-0", stateIconClass)} />
       <div className="min-w-0 flex-1">
         <Link
@@ -117,7 +135,11 @@ function PRRow({
         </div>
       </div>
       <div className="shrink-0">
-        <StartTaskMenu pr={pr} presets={presets} onStartTask={onStartTask} />
+        <StartTaskMenu
+          pr={pickPRForLaunch(pr, status)}
+          presets={presets}
+          onStartTask={onStartTask}
+        />
       </div>
     </div>
   );

--- a/apps/web/components/github/my-github/quick-task-launcher.tsx
+++ b/apps/web/components/github/my-github/quick-task-launcher.tsx
@@ -36,6 +36,10 @@ function matchRepo(repos: Repository[], owner: string, name: string): Repository
   );
 }
 
+function emptyToUndefined(value: string | undefined): string | undefined {
+  return value ? value : undefined;
+}
+
 function extractPayload(payload: LaunchPayload) {
   if (payload.kind === "pr") {
     return {
@@ -43,7 +47,7 @@ function extractPayload(payload: LaunchPayload) {
       title: payload.pr.title,
       owner: payload.pr.repo_owner,
       name: payload.pr.repo_name,
-      branch: payload.pr.head_branch,
+      branch: emptyToUndefined(payload.pr.head_branch),
     };
   }
   return {
@@ -60,6 +64,10 @@ function buildDialogState(payload: LaunchPayload, repositories: Repository[]): D
   const repo = matchRepo(repositories, data.owner, data.name);
   const description = payload.preset.prompt({ url: data.url, title: data.title });
   const title = `${payload.preset.label}: ${data.title}`;
+  // For a PR launch we want the dialog to display and check out the PR's head
+  // branch — matching the GitHub-URL-paste flow, where the branch selector
+  // auto-resolves to the PR head. Same branch for both: the chip shows it and
+  // the worktree checks it out.
   const checkoutBranch = payload.kind === "pr" ? data.branch : undefined;
   if (repo) {
     return {

--- a/apps/web/components/quick-chat/quick-chat-content.tsx
+++ b/apps/web/components/quick-chat/quick-chat-content.tsx
@@ -12,6 +12,8 @@ import {
   useChatPanelHandlers,
 } from "@/components/task/chat/chat-input-area";
 import { ClarificationInputOverlay } from "@/components/task/chat/clarification-input-overlay";
+import { ResizeHandle } from "@/components/task/chat/resize-handle";
+import { useResizableClarificationOverlay } from "@/hooks/use-resizable-clarification-overlay";
 
 type QuickChatContentProps = {
   sessionId: string;
@@ -73,6 +75,18 @@ export const QuickChatContent = memo(function QuickChatContent({
   }, [initialPrompt, taskId, handleSubmit, onInitialPromptSent]);
 
   const handleClarificationResolved = useCallback(() => setClarificationKey((k) => k + 1), []);
+  const {
+    height: clarificationHeight,
+    containerRef: clarificationContainerRef,
+    resetHeight: clarificationResetHeight,
+    resizeHandleProps: clarificationResizeProps,
+  } = useResizableClarificationOverlay();
+
+  // Reset the dragged height when the overlay closes so a fresh
+  // clarification starts auto-sized instead of inheriting a stale value.
+  useEffect(() => {
+    if (!pendingClarification) clarificationResetHeight();
+  }, [pendingClarification, clarificationResetHeight]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -93,11 +107,19 @@ export const QuickChatContent = memo(function QuickChatContent({
         />
       </div>
       {pendingClarification && (
-        <div className="flex-shrink-0 border-t border-sky-400/30 bg-card px-1">
-          <ClarificationInputOverlay
-            messages={pendingClarificationGroup}
-            onResolved={handleClarificationResolved}
-          />
+        <div className="relative flex-shrink-0 border-t border-sky-400/30 bg-card">
+          <ResizeHandle {...clarificationResizeProps} />
+          <div
+            ref={clarificationContainerRef}
+            data-testid="clarification-overlay-container"
+            className="px-1 overflow-y-auto overscroll-contain max-h-[50vh]"
+            style={clarificationHeight === null ? undefined : { height: clarificationHeight }}
+          >
+            <ClarificationInputOverlay
+              messages={pendingClarificationGroup}
+              onResolved={handleClarificationResolved}
+            />
+          </div>
         </div>
       )}
       <QueuedGhostList sessionId={panelState.resolvedSessionId} isArchived={false} />

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -99,11 +99,21 @@ export function useRepositoryAutoSelectEffect(
     } else if (repositories.length === 1) {
       pickId = repositories[0].id;
     }
-    void Promise.resolve().then(() =>
-      setRepositories([
-        pickId ? { key: "row-0", repositoryId: pickId, branch: "" } : { key: "row-0", branch: "" },
-      ]),
-    );
+    // Use the functional setter so the deferred microtask sees fresh state.
+    // Without this, a sibling effect (resetTaskForm / useLockedFieldSync) that
+    // seeds rows from `initialValues.repositoryId` synchronously races with
+    // this microtask — the microtask captured rows.length === 0 at queue time
+    // and would blindly clobber the initialValues-seeded row.
+    void Promise.resolve().then(() => {
+      setRepositories((prev) => {
+        if (prev.length > 0) return prev;
+        return [
+          pickId
+            ? { key: "row-0", repositoryId: pickId, branch: "" }
+            : { key: "row-0", branch: "" },
+        ];
+      });
+    });
   }, [open, repositories, rows, useGitHubUrl, workspaceId, setRepositories]);
 }
 
@@ -490,7 +500,7 @@ export function useTaskCreateDialogEffects(fs: DialogFormState, args: TaskCreate
   useDiscoverReposEffect(fs, open, workspaceId, repositoriesLoading, toast);
   useBranchAutoSelectEffect(fs);
   useCurrentLocalBranchEffect(fs, open, workspaceId, repositories);
-  useResetBranchOnLocalSwitchEffect(fs, isLocalExecutor);
+  useResetBranchOnLocalSwitchEffect(fs, isLocalExecutor, args.preserveBranch);
   useDefaultSelectionsEffect(fs, open, { agentProfiles, executors, workspaceDefaults }, workflows);
   useGitHubUrlBranchesEffect(fs, open);
 }
@@ -504,7 +514,11 @@ export function useTaskCreateDialogEffects(fs: DialogFormState, args: TaskCreate
 // tree. With the reset, switching to local always defaults to "current
 // branch on disk" and the user has to opt back into a different branch
 // explicitly.
-function useResetBranchOnLocalSwitchEffect(fs: DialogFormState, isLocalExecutor: boolean) {
+function useResetBranchOnLocalSwitchEffect(
+  fs: DialogFormState,
+  isLocalExecutor: boolean,
+  preserveBranch: string | undefined,
+) {
   const { repositories: rows, updateRepository } = fs;
   const wasLocalRef = useRef(isLocalExecutor);
   useEffect(() => {
@@ -512,7 +526,16 @@ function useResetBranchOnLocalSwitchEffect(fs: DialogFormState, isLocalExecutor:
     wasLocalRef.current = isLocalExecutor;
     if (!isLocalExecutor || prev) return; // only fire on false → true transition
     for (const row of rows) {
-      if (row.branch) updateRepository(row.key, { branch: "" });
+      // Preserve a branch the caller asked us to keep (e.g. the PR head branch
+      // when launching from a GitHub PR). Without this, the executor's async
+      // settle on dialog open looks like a worktree→local switch and clobbers
+      // the explicit branch choice, leaving the chip showing "current: main".
+      // Both `row.branch` and `preserveBranch` are bare branch names with no
+      // remote prefix — current callers (`initialValues.checkoutBranch` /
+      // `initialValues.branch`) never pass `origin/...` here.
+      if (row.branch && row.branch !== preserveBranch) {
+        updateRepository(row.key, { branch: "" });
+      }
     }
-  }, [isLocalExecutor, rows, updateRepository]);
+  }, [isLocalExecutor, rows, updateRepository, preserveBranch]);
 }

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { LocalRepository, Repository, Executor, Branch, Task } from "@/lib/types/http";
 import type { AgentProfileOption, WorkspaceState } from "@/lib/state/slices";
 import type {
@@ -128,6 +129,13 @@ export type TaskCreateEffectsArgs = {
    * worktree run that would trigger a destructive `git checkout` on submit.
    */
   isLocalExecutor: boolean;
+  /**
+   * Branch the caller wants preserved across the local-switch reset (e.g. the
+   * PR head branch when launching from a GitHub PR). The reset effect skips
+   * rows whose branch matches this value so the explicit caller choice isn't
+   * clobbered by the executor's async settle on mount.
+   */
+  preserveBranch?: string;
 };
 
 import type { FileAttachment } from "@/components/task/chat/file-attachment";
@@ -158,7 +166,7 @@ export type DialogFormState = {
    * order is the position the backend sees. There is no "primary" concept.
    */
   repositories: TaskRepoRow[];
-  setRepositories: (v: TaskRepoRow[]) => void;
+  setRepositories: React.Dispatch<React.SetStateAction<TaskRepoRow[]>>;
   addRepository: () => void;
   removeRepository: (key: string) => void;
   updateRepository: (key: string, patch: Partial<TaskRepoRow>) => void;
@@ -265,7 +273,7 @@ export type SubmitHandlersDeps = {
   setHasTitle: (v: boolean) => void;
   setHasDescription: (v: boolean) => void;
   setTaskName: (v: string) => void;
-  setRepositories: (v: TaskRepoRow[]) => void;
+  setRepositories: React.Dispatch<React.SetStateAction<TaskRepoRow[]>>;
   setGitHubBranch: (v: string) => void;
   setAgentProfileId: (v: string) => void;
   setExecutorId: (v: string) => void;

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -408,6 +408,7 @@ export function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     toast,
     workflows,
     isLocalExecutor: computed.isLocalExecutor,
+    preserveBranch: initialValues?.checkoutBranch || initialValues?.branch,
   });
   useLockedFieldSync(open, workflowId, initialValues, fs);
   const handlers = useDialogHandlers(fs, repositories);

--- a/apps/web/components/task/chat/clarification-input-overlay.tsx
+++ b/apps/web/components/task/chat/clarification-input-overlay.tsx
@@ -90,22 +90,23 @@ function ClarificationCard(props: CardProps) {
       data-testid="clarification-question-card"
       data-question-id={meta.questionId}
       data-question-index={String(index)}
-      className="px-4 pt-3 pb-4"
+      className="px-4 pt-1 pb-4"
     >
-      <div className="flex items-center gap-2 mb-2 text-xs text-muted-foreground">
-        <IconMessageQuestion className="h-4 w-4 text-blue-500" />
-        {total > 1 && (
-          <span data-testid="clarification-progress-chip">
-            Question {index + 1} of {total}
-          </span>
-        )}
-        {metadata.question.title && (
-          <span className="text-muted-foreground/70">
-            {total > 1 ? "· " : ""}
-            {metadata.question.title}
-          </span>
-        )}
-      </div>
+      {(total > 1 || metadata.question.title) && (
+        <div className="flex items-center gap-2 mb-2 text-xs text-muted-foreground">
+          {total > 1 && (
+            <span data-testid="clarification-progress-chip">
+              Question {index + 1} of {total}
+            </span>
+          )}
+          {metadata.question.title && (
+            <span className="text-muted-foreground/70">
+              {total > 1 ? "· " : ""}
+              {metadata.question.title}
+            </span>
+          )}
+        </div>
+      )}
       <div className="markdown-body max-w-none text-sm font-medium [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 mb-3">
         <ReactMarkdown remarkPlugins={remarkPlugins} components={markdownComponents}>
           {question.prompt}
@@ -453,8 +454,9 @@ export function ClarificationInputOverlay({
 
   return (
     <div className="relative" data-testid="clarification-overlay">
-      <div className="flex items-center justify-between gap-3 px-4 pt-3 pb-2">
-        <div className="flex items-center gap-3">
+      <div className="flex items-center justify-between gap-3 px-4 pt-2 pb-1">
+        <div className="flex items-center gap-3 min-w-0">
+          <IconMessageQuestion className="h-4 w-4 text-blue-500 flex-shrink-0" />
           {total > 1 && (
             <ClarificationStepper
               total={total}

--- a/apps/web/components/task/chat/resize-handle.tsx
+++ b/apps/web/components/task/chat/resize-handle.tsx
@@ -11,11 +11,13 @@ type ResizeHandleProps = {
 };
 
 function getHandleColor(planModeEnabled?: boolean, isAgentBusy?: boolean, isStarting?: boolean) {
-  if (isStarting) return "bg-primary/40 hover:bg-primary/70";
-  if (isAgentBusy && planModeEnabled) return "bg-violet-400/60 hover:bg-violet-400";
-  if (isAgentBusy) return "bg-primary/40 hover:bg-primary/70";
-  if (planModeEnabled) return "bg-violet-400/60 hover:bg-violet-400";
-  return "bg-border hover:bg-muted-foreground";
+  if (isStarting) return "bg-primary/70 hover:bg-primary";
+  if (isAgentBusy && planModeEnabled) return "bg-violet-400/80 hover:bg-violet-400";
+  if (isAgentBusy) return "bg-primary/70 hover:bg-primary";
+  if (planModeEnabled) return "bg-violet-400/80 hover:bg-violet-400";
+  // Resting state: muted-foreground (light gray on dark bg) at high opacity so
+  // the handle reads as a discoverable affordance, not invisible chrome.
+  return "bg-muted-foreground/60 hover:bg-muted-foreground";
 }
 
 export function ResizeHandle({
@@ -28,10 +30,11 @@ export function ResizeHandle({
   return (
     <button
       type="button"
+      aria-label="Resize"
       className={cn(
         "absolute left-1/2 top-[-1px] -translate-x-1/2 -translate-y-1/2 z-10",
-        "w-12 h-2 cursor-ns-resize",
-        "flex items-center justify-center",
+        "w-16 h-3 cursor-ns-resize",
+        "flex items-center justify-center group",
       )}
       onMouseDown={onMouseDown}
       onDoubleClick={onDoubleClick}
@@ -39,7 +42,7 @@ export function ResizeHandle({
     >
       <div
         className={cn(
-          "w-8 h-0.5 rounded-full transition-colors",
+          "w-12 h-1 rounded-full transition-all group-hover:h-1.5 group-hover:w-14",
           getHandleColor(planModeEnabled, isAgentBusy, isStarting),
         )}
       />

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -7,7 +7,7 @@ import { measureDockviewContainer } from "@/lib/state/dockview-measure";
 import type { LayoutState } from "@/lib/state/layout-manager";
 import type { AppState } from "@/lib/state/store";
 import { getEnvLayout, getEnvMaximizeState, removeEnvMaximizeState } from "@/lib/local-storage";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debug = createDebugLogger("dockview:restore");
 
@@ -29,6 +29,7 @@ function logSanitizeOutcome(
   validPanels: Record<string, any>,
   invalidIds: Set<string>,
 ): void {
+  if (!IS_DEBUG) return;
   debug("sanitizeLayout", {
     mode: describeSanitizeMode(options),
     excludeSessionCount: options.excludeSessionIds?.size ?? 0,

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -7,8 +7,40 @@ import { measureDockviewContainer } from "@/lib/state/dockview-measure";
 import type { LayoutState } from "@/lib/state/layout-manager";
 import type { AppState } from "@/lib/state/store";
 import { getEnvLayout, getEnvMaximizeState, removeEnvMaximizeState } from "@/lib/local-storage";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debug = createDebugLogger("dockview:restore");
 
 const LAYOUT_STORAGE_KEY = "dockview-layout-v1";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function describeSanitizeMode(options: {
+  stripSessionPanels?: boolean;
+  excludeSessionIds?: Set<string>;
+}): string {
+  if (options.stripSessionPanels) return "stripAllSessions";
+  if (options.excludeSessionIds) return "excludeSpecificSessions";
+  return "keepAll";
+}
+
+function logSanitizeOutcome(
+  options: { stripSessionPanels?: boolean; excludeSessionIds?: Set<string> },
+  totalPanels: Record<string, any>,
+  validPanels: Record<string, any>,
+  invalidIds: Set<string>,
+): void {
+  debug("sanitizeLayout", {
+    mode: describeSanitizeMode(options),
+    excludeSessionCount: options.excludeSessionIds?.size ?? 0,
+    excludeSessionIds: options.excludeSessionIds
+      ? Array.from(options.excludeSessionIds)
+      : undefined,
+    totalPanels: Object.keys(totalPanels).length,
+    keptPanels: Object.keys(validPanels).length,
+    strippedPanels: Array.from(invalidIds),
+  });
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function sanitizeLayout(
@@ -18,7 +50,10 @@ export function sanitizeLayout(
     | { stripSessionPanels: true; excludeSessionIds?: never }
     | { stripSessionPanels?: false | undefined; excludeSessionIds?: Set<string> } = {},
 ): any {
-  if (!isLayoutShapeHealthy(layout)) return null;
+  if (!isLayoutShapeHealthy(layout)) {
+    debug("sanitizeLayout: layout shape unhealthy, returning null");
+    return null;
+  }
 
   const invalidIds = new Set<string>();
   const validPanels: Record<string, any> = {};
@@ -55,6 +90,8 @@ export function sanitizeLayout(
     }
   }
 
+  logSanitizeOutcome(options, layout.panels, validPanels, invalidIds);
+
   if (invalidIds.size === 0) return layout;
 
   function cleanNode(node: any): any {
@@ -73,7 +110,10 @@ export function sanitizeLayout(
   }
 
   const cleanedRoot = cleanNode(layout.grid.root);
-  if (!cleanedRoot) return null;
+  if (!cleanedRoot) {
+    debug("sanitizeLayout: cleanedRoot is null after stripping, returning null");
+    return null;
+  }
 
   return {
     ...layout,
@@ -139,11 +179,29 @@ function tryRestoreEnvLayout(
   phantomSessionIds: Set<string> | undefined,
 ): boolean {
   const envLayout = getEnvLayout(envId);
-  if (!envLayout) return false;
+  if (!envLayout) {
+    debug("tryRestoreEnvLayout: no saved layout for env", { envId });
+    return false;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawPanelIds = Object.keys((envLayout as any).panels ?? {});
+  debug("tryRestoreEnvLayout: loaded saved layout", {
+    envId,
+    rawPanelCount: rawPanelIds.length,
+    rawPanelIds,
+    phantomSessionIds: phantomSessionIds ? Array.from(phantomSessionIds) : [],
+  });
   const sanitized = sanitizeLayout(envLayout, validComponents, {
     excludeSessionIds: phantomSessionIds,
   });
-  if (!sanitized) return false;
+  if (!sanitized) {
+    debug("tryRestoreEnvLayout: sanitize returned null", { envId });
+    return false;
+  }
+  debug("tryRestoreEnvLayout: calling api.fromJSON", {
+    envId,
+    sanitizedPanelIds: Object.keys(sanitized.panels),
+  });
   api.fromJSON(sanitized as SerializedDockview);
   applyFixupsWithMaximize(api, envId);
   return true;
@@ -217,5 +275,17 @@ export function restoreEnvLayout(
   validComponents: Set<string>,
 ): boolean {
   const phantoms = envId ? collectPhantomSessionIdsForEnv(appStore.getState(), envId) : undefined;
-  return tryRestoreLayout(api, envId, validComponents, phantoms);
+  debug("restoreEnvLayout: entry", {
+    envId,
+    phantomCount: phantoms?.size ?? 0,
+    phantomSessionIds: phantoms ? Array.from(phantoms) : [],
+    livePanelIdsBefore: api.panels.map((p) => p.id),
+  });
+  const result = tryRestoreLayout(api, envId, validComponents, phantoms);
+  debug("restoreEnvLayout: result", {
+    envId,
+    restored: result,
+    livePanelIdsAfter: api.panels.map((p) => p.id),
+  });
+  return result;
 }

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -184,14 +184,16 @@ function tryRestoreEnvLayout(
     debug("tryRestoreEnvLayout: no saved layout for env", { envId });
     return false;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawPanelIds = Object.keys((envLayout as any).panels ?? {});
-  debug("tryRestoreEnvLayout: loaded saved layout", {
-    envId,
-    rawPanelCount: rawPanelIds.length,
-    rawPanelIds,
-    phantomSessionIds: phantomSessionIds ? Array.from(phantomSessionIds) : [],
-  });
+  if (IS_DEBUG) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rawPanelIds = Object.keys((envLayout as any).panels ?? {});
+    debug("tryRestoreEnvLayout: loaded saved layout", {
+      envId,
+      rawPanelCount: rawPanelIds.length,
+      rawPanelIds,
+      phantomSessionIds: phantomSessionIds ? Array.from(phantomSessionIds) : [],
+    });
+  }
   const sanitized = sanitizeLayout(envLayout, validComponents, {
     excludeSessionIds: phantomSessionIds,
   });
@@ -199,10 +201,12 @@ function tryRestoreEnvLayout(
     debug("tryRestoreEnvLayout: sanitize returned null", { envId });
     return false;
   }
-  debug("tryRestoreEnvLayout: calling api.fromJSON", {
-    envId,
-    sanitizedPanelIds: Object.keys(sanitized.panels),
-  });
+  if (IS_DEBUG) {
+    debug("tryRestoreEnvLayout: calling api.fromJSON", {
+      envId,
+      sanitizedPanelIds: Object.keys(sanitized.panels),
+    });
+  }
   api.fromJSON(sanitized as SerializedDockview);
   applyFixupsWithMaximize(api, envId);
   return true;
@@ -276,17 +280,21 @@ export function restoreEnvLayout(
   validComponents: Set<string>,
 ): boolean {
   const phantoms = envId ? collectPhantomSessionIdsForEnv(appStore.getState(), envId) : undefined;
-  debug("restoreEnvLayout: entry", {
-    envId,
-    phantomCount: phantoms?.size ?? 0,
-    phantomSessionIds: phantoms ? Array.from(phantoms) : [],
-    livePanelIdsBefore: api.panels.map((p) => p.id),
-  });
+  if (IS_DEBUG) {
+    debug("restoreEnvLayout: entry", {
+      envId,
+      phantomCount: phantoms?.size ?? 0,
+      phantomSessionIds: phantoms ? Array.from(phantoms) : [],
+      livePanelIdsBefore: api.panels.map((p) => p.id),
+    });
+  }
   const result = tryRestoreLayout(api, envId, validComponents, phantoms);
-  debug("restoreEnvLayout: result", {
-    envId,
-    restored: result,
-    livePanelIdsAfter: api.panels.map((p) => p.id),
-  });
+  if (IS_DEBUG) {
+    debug("restoreEnvLayout: result", {
+      envId,
+      restored: result,
+      livePanelIdsAfter: api.panels.map((p) => p.id),
+    });
+  }
   return result;
 }

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -7,6 +7,9 @@ import { focusOrAddPanel } from "@/lib/state/dockview-layout-builders";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { wasPRPanelOffered, markPRPanelOffered } from "@/lib/local-storage";
 import { sessionId as toSessionId } from "@/lib/types/ids";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debug = createDebugLogger("dockview:session-tabs");
 
 /**
  * Sync `activeSessionId` in the store when the user clicks a session tab.
@@ -234,6 +237,8 @@ export function reconcileRemovedSessionPanels(
   keepSessionId: string,
 ): void {
   const currentIds = new Set(currentSessionIds);
+  const sessionPanels = api.panels.filter((p) => p.id.startsWith("session:"));
+  const removed: string[] = [];
   // Snapshot before iterating: closing a panel can mutate `api.panels`
   // synchronously, which would skip elements in a `for...of` over the live
   // array. Matches the pattern in `removeEphemeralPanels`.
@@ -244,11 +249,19 @@ export function reconcileRemovedSessionPanels(
     if (currentIds.has(sid)) continue;
     try {
       panel.api.close();
+      removed.push(panel.id);
     } catch {
       /* already gone */
     }
     createdSet.delete(sid);
   }
+  debug("reconcileRemovedSessionPanels", {
+    keepSessionId,
+    currentSessionIds,
+    liveSessionPanelIds: sessionPanels.map((p) => p.id),
+    removed,
+    createdSetAfter: Array.from(createdSet),
+  });
   // Drop any remaining stale entries (panel already removed externally, e.g.
   // by the right-click delete handler) so the ref stays in sync with reality.
   for (const sid of [...createdSet]) {

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -237,7 +237,6 @@ export function reconcileRemovedSessionPanels(
   keepSessionId: string,
 ): void {
   const currentIds = new Set(currentSessionIds);
-  const sessionPanels = api.panels.filter((p) => p.id.startsWith("session:"));
   const removed: string[] = [];
   // Snapshot before iterating: closing a panel can mutate `api.panels`
   // synchronously, which would skip elements in a `for...of` over the live
@@ -255,13 +254,16 @@ export function reconcileRemovedSessionPanels(
     }
     createdSet.delete(sid);
   }
-  debug("reconcileRemovedSessionPanels", {
-    keepSessionId,
-    currentSessionIds,
-    liveSessionPanelIds: sessionPanels.map((p) => p.id),
-    removed,
-    createdSetAfter: Array.from(createdSet),
-  });
+  if (process.env.NODE_ENV !== "production") {
+    const sessionPanels = api.panels.filter((p) => p.id.startsWith("session:"));
+    debug("reconcileRemovedSessionPanels", {
+      keepSessionId,
+      currentSessionIds,
+      liveSessionPanelIds: sessionPanels.map((p) => p.id),
+      removed,
+      createdSetAfter: Array.from(createdSet),
+    });
+  }
   // Drop any remaining stale entries (panel already removed externally, e.g.
   // by the right-click delete handler) so the ref stays in sync with reality.
   for (const sid of [...createdSet]) {

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -7,7 +7,7 @@ import { focusOrAddPanel } from "@/lib/state/dockview-layout-builders";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { wasPRPanelOffered, markPRPanelOffered } from "@/lib/local-storage";
 import { sessionId as toSessionId } from "@/lib/types/ids";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debug = createDebugLogger("dockview:session-tabs");
 
@@ -254,7 +254,7 @@ export function reconcileRemovedSessionPanels(
     }
     createdSet.delete(sid);
   }
-  if (process.env.NODE_ENV !== "production") {
+  if (IS_DEBUG) {
     const sessionPanels = api.panels.filter((p) => p.id.startsWith("session:"));
     debug("reconcileRemovedSessionPanels", {
       keepSessionId,

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -23,6 +23,7 @@ import {
   type WorkflowSnapshot,
 } from "@/lib/types/http";
 import type { KanbanState } from "@/lib/state/slices";
+import { resolvePreferredSessionId } from "../task-select-helpers";
 
 // Map workflow snapshot to kanban state on workspace switch.
 function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) {
@@ -453,10 +454,16 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
 
   const handleSelectTask = useCallback(
     (taskId: string) => {
-      const kanbanTasks = store.getState().kanban.tasks;
-      const task = kanbanTasks.find((t) => t.id === taskId);
+      const state = store.getState();
+      const task = state.kanban.tasks.find((t) => t.id === taskId);
       if (task?.primarySessionId) {
-        setActiveSession(taskId, task.primarySessionId);
+        const targetSessionId = resolvePreferredSessionId(
+          taskId,
+          task.primarySessionId,
+          state.tasks.lastSessionByTaskId,
+          state.environmentIdBySessionId,
+        );
+        setActiveSession(taskId, targetSessionId);
         loadTaskSessionsForTask(taskId);
         replaceTaskUrl(taskId);
         onOpenChange(false);

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -10,6 +10,8 @@ import { useIsTaskArchived } from "./task-archived-context";
 import { useChatPanelState } from "./chat/use-chat-panel-state";
 import { ChatInputArea, useSubmitHandler, useChatPanelHandlers } from "./chat/chat-input-area";
 import { ClarificationInputOverlay } from "./chat/clarification-input-overlay";
+import { ResizeHandle } from "./chat/resize-handle";
+import { useResizableClarificationOverlay } from "@/hooks/use-resizable-clarification-overlay";
 import { PanelSearchBar } from "@/components/search/panel-search-bar";
 import { SessionSearchHits } from "@/components/task/chat/session-search-hits";
 import { usePanelSearch } from "@/hooks/use-panel-search";
@@ -157,6 +159,18 @@ export const TaskChatPanel = memo(function TaskChatPanel({
   } = panelState;
   const { handleCancelTurn } = useChatPanelHandlers(resolvedSessionId, clearQueue, chatInputRef);
   const { clarificationKey, handleClarificationResolved } = useClarificationKey(agentMessageCount);
+  const {
+    height: clarificationHeight,
+    containerRef: clarificationContainerRef,
+    resetHeight: clarificationResetHeight,
+    resizeHandleProps: clarificationResizeProps,
+  } = useResizableClarificationOverlay();
+
+  // Reset the dragged height when the overlay closes so a fresh
+  // clarification starts auto-sized instead of inheriting a stale value.
+  useEffect(() => {
+    if (!pendingClarification) clarificationResetHeight();
+  }, [pendingClarification, clarificationResetHeight]);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const { loadMore } = useLazyLoadMessages(resolvedSessionId);
@@ -216,11 +230,19 @@ export const TaskChatPanel = memo(function TaskChatPanel({
         <SessionSearchOverlay search={search} agentLabel={agentLabel} agentName={agentName} />
       </PanelBody>
       {pendingClarification && !isArchived && (
-        <div className="flex-shrink-0 border-t border-sky-400/30 bg-card px-1">
-          <ClarificationInputOverlay
-            messages={pendingClarificationGroup}
-            onResolved={handleClarificationResolved}
-          />
+        <div className="relative flex-shrink-0 border-t border-sky-400/30 bg-card">
+          <ResizeHandle {...clarificationResizeProps} />
+          <div
+            ref={clarificationContainerRef}
+            data-testid="clarification-overlay-container"
+            className="px-1 overflow-y-auto overscroll-contain max-h-[50vh]"
+            style={clarificationHeight === null ? undefined : { height: clarificationHeight }}
+          >
+            <ClarificationInputOverlay
+              messages={pendingClarificationGroup}
+              onResolved={handleClarificationResolved}
+            />
+          </div>
         </div>
       )}
       <QueuedGhostList sessionId={resolvedSessionId} isArchived={isArchived} />

--- a/apps/web/components/task/task-select-helpers.test.ts
+++ b/apps/web/components/task/task-select-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { prepareAndSwitchTask, buildSwitchToSession } from "./task-select-helpers";
+import {
+  prepareAndSwitchTask,
+  buildSwitchToSession,
+  selectTaskWithLayout,
+} from "./task-select-helpers";
 
 vi.mock("@/lib/services/session-launch-service", () => ({
   launchSession: vi.fn(),
@@ -161,5 +165,122 @@ describe("buildSwitchToSession", () => {
     expect(setActiveSession).toHaveBeenCalledWith("task-new", "sess-x");
     expect(performLayoutSwitch).not.toHaveBeenCalled();
     expect(releaseLayoutToDefault).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression for "switching tasks loses the user's last-selected session":
+ *
+ *   1. Task A has sessions [primary, gpt]; user clicks the gpt tab.
+ *   2. User clicks Task B in the sidebar.
+ *   3. User clicks Task A in the sidebar — expected the gpt tab still active.
+ *
+ * Before the fix, `selectTaskWithLayout` always switched to `primarySessionId`,
+ * so step 3 set activeSessionId back to "primary". The dockview slow-path then
+ * closed the gpt panel (it didn't match activeSessionId), and the surviving
+ * sibling tab (Diff) auto-promoted to active.
+ *
+ * The fix tracks the user's last-selected session per task in
+ * `tasks.lastSessionByTaskId` and prefers it over `primarySessionId` on
+ * re-entry, as long as the session still has a known environment.
+ */
+describe("selectTaskWithLayout — last-selected session preference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeKanbanStore(args: {
+    activeSessionId: string | null;
+    envIds: Record<string, string>;
+    lastSessionByTaskId?: Record<string, string>;
+  }): StoreApi<AppState> {
+    const state = {
+      tasks: {
+        activeSessionId: args.activeSessionId,
+        lastSessionByTaskId: args.lastSessionByTaskId ?? {},
+      },
+      taskPRs: { byTaskId: {} as Record<string, unknown[]> },
+      environmentIdBySessionId: args.envIds,
+    };
+    return {
+      getState: () => state as unknown as AppState,
+      setState: vi.fn(),
+      subscribe: vi.fn(),
+    } as unknown as StoreApi<AppState>;
+  }
+
+  it("prefers the user's last-selected session over primarySessionId on re-entry", () => {
+    const TASK_ID = "task-A";
+    const PRIMARY = "sess-primary";
+    const LAST = "sess-gpt";
+    const store = makeKanbanStore({
+      activeSessionId: "sess-other-task",
+      envIds: {
+        "sess-other-task": "env-B",
+        [PRIMARY]: "env-A",
+        [LAST]: "env-A",
+      },
+      lastSessionByTaskId: { [TASK_ID]: LAST },
+    });
+    const switchToSession = vi.fn();
+
+    selectTaskWithLayout({
+      taskId: TASK_ID,
+      task: { primarySessionId: PRIMARY },
+      store,
+      switchToSession,
+      loadTaskSessionsForTask: vi.fn(async () => []),
+      setActiveTask: vi.fn(),
+      setPreparingTaskId: vi.fn(),
+    });
+
+    expect(switchToSession).toHaveBeenCalledWith(TASK_ID, LAST, "sess-other-task");
+  });
+
+  it("falls back to primarySessionId when the remembered session has no env mapping", () => {
+    const TASK_ID = "task-A";
+    const PRIMARY = "sess-primary";
+    const LAST = "sess-stale";
+    const store = makeKanbanStore({
+      activeSessionId: null,
+      envIds: { [PRIMARY]: "env-A" },
+      lastSessionByTaskId: { [TASK_ID]: LAST },
+    });
+    const switchToSession = vi.fn();
+
+    selectTaskWithLayout({
+      taskId: TASK_ID,
+      task: { primarySessionId: PRIMARY },
+      store,
+      switchToSession,
+      loadTaskSessionsForTask: vi.fn(async () => []),
+      setActiveTask: vi.fn(),
+      setPreparingTaskId: vi.fn(),
+    });
+
+    expect(switchToSession).toHaveBeenCalledWith(TASK_ID, PRIMARY, null);
+  });
+
+  it("uses primarySessionId when no last-selected session is recorded for the task", () => {
+    const TASK_ID = "task-A";
+    const PRIMARY = "sess-primary";
+    const store = makeKanbanStore({
+      activeSessionId: null,
+      envIds: { [PRIMARY]: "env-A" },
+      lastSessionByTaskId: {},
+    });
+    const switchToSession = vi.fn();
+
+    selectTaskWithLayout({
+      taskId: TASK_ID,
+      task: { primarySessionId: PRIMARY },
+      store,
+      switchToSession,
+      loadTaskSessionsForTask: vi.fn(async () => []),
+      setActiveTask: vi.fn(),
+      setPreparingTaskId: vi.fn(),
+    });
+
+    expect(switchToSession).toHaveBeenCalledWith(TASK_ID, PRIMARY, null);
   });
 });

--- a/apps/web/components/task/task-select-helpers.ts
+++ b/apps/web/components/task/task-select-helpers.ts
@@ -35,6 +35,28 @@ export function resolveLoadedSessionId(
   );
 }
 
+/**
+ * Pick the session to re-open when the user navigates back to a task.
+ *
+ * Prefers the user's last-selected session (tracked per task in
+ * `lastSessionByTaskId`) over `primarySessionId`, so opening a non-primary
+ * tab then bouncing through another task does not silently snap the user
+ * back to primary. Falls back to `primarySessionId` when the remembered
+ * session is unknown / missing an env mapping (e.g. it was deleted).
+ */
+export function resolvePreferredSessionId(
+  taskId: string,
+  primarySessionId: string,
+  lastSessionByTaskId: Record<string, string>,
+  environmentIdBySessionId: Record<string, string>,
+): string {
+  const last = lastSessionByTaskId[taskId];
+  if (last && environmentIdBySessionId[last]) {
+    return last;
+  }
+  return primarySessionId;
+}
+
 export function buildSwitchToSession(
   store: StoreApi<AppState>,
   setActiveSession: (taskId: string, sessionId: string) => void,
@@ -113,18 +135,24 @@ export function selectTaskWithLayout(params: {
   setPreparingTaskId: (id: string | null) => void;
 }): void {
   const { taskId, task, store, switchToSession, loadTaskSessionsForTask } = params;
-  const oldSessionId = store.getState().tasks.activeSessionId;
+  const state = store.getState();
+  const oldSessionId = state.tasks.activeSessionId;
   if (task?.primarySessionId) {
-    const primarySessionId = task.primarySessionId;
-    const hasEnvId = !!store.getState().environmentIdBySessionId[primarySessionId];
+    const targetSessionId = resolvePreferredSessionId(
+      taskId,
+      task.primarySessionId,
+      state.tasks.lastSessionByTaskId,
+      state.environmentIdBySessionId,
+    );
+    const hasEnvId = !!state.environmentIdBySessionId[targetSessionId];
     if (hasEnvId) {
-      switchToSession(taskId, primarySessionId, oldSessionId);
+      switchToSession(taskId, targetSessionId, oldSessionId);
       loadTaskSessionsForTask(taskId);
       replaceTaskUrl(taskId);
       return;
     }
     loadTaskSessionsForTask(taskId).then((sessions) => {
-      switchToSession(taskId, resolveLoadedSessionId(sessions, primarySessionId), oldSessionId);
+      switchToSession(taskId, resolveLoadedSessionId(sessions, targetSessionId), oldSessionId);
       replaceTaskUrl(taskId);
     });
     return;

--- a/apps/web/e2e/tests/chat/clarification-resize.spec.ts
+++ b/apps/web/e2e/tests/chat/clarification-resize.spec.ts
@@ -1,0 +1,164 @@
+import { type Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+/**
+ * Helper to create a regular task, navigate to it, and wait for idle.
+ * Mirrors clarification.spec.ts's `seedClarificationTask`, but uses a non-
+ * blocking scenario so we reach the idle input and can drive the slash
+ * commands `/ask-single` and `/ask-multiple` from inside the session.
+ */
+async function seedTaskAndWaitForIdle(
+  testPage: Page,
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+): Promise<SessionPage> {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    title,
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+
+  if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+
+  await testPage.goto(`/t/${task.id}`);
+
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await session.waitForChatIdle();
+
+  return session;
+}
+
+test.describe("Mock agent clarification slash commands", () => {
+  test.describe.configure({ retries: 1 });
+
+  // Smoke test that the /ask-single alias routes to the clarification scenario.
+  // The underlying clarification behaviour (option click, multi-question carousel,
+  // submit, etc.) is exhaustively covered by clarification.spec.ts — this only
+  // proves the alias is wired up.
+  test("/ask-single alias triggers the clarification overlay", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const session = await seedTaskAndWaitForIdle(testPage, apiClient, seedData, "Ask Single Alias");
+
+    await session.sendMessage("/ask-single");
+
+    await expect(session.clarificationOverlay()).toBeVisible({ timeout: 30_000 });
+    await session.clarificationOption("PostgreSQL").click();
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("/ask-multiple alias triggers the multi-question carousel", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const session = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "Ask Multiple Alias",
+    );
+
+    await session.sendMessage("/ask-multiple");
+
+    await expect(session.clarificationOverlay()).toBeVisible({ timeout: 30_000 });
+    await expect(session.clarificationSteps()).toHaveCount(3);
+    await expect(session.clarificationOverlay()).toContainText("Which database");
+
+    await session.clarificationOption("PostgreSQL").click();
+    await session.clarificationOption("Go").click();
+    await session.clarificationOption("Docker").click();
+
+    await session.clarificationSubmit().click();
+    await expect(session.clarificationOverlay()).not.toBeVisible({ timeout: 30_000 });
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  });
+});
+
+test.describe("Clarification overlay resizable layout", () => {
+  test("starts content-sized, drag grows the overlay, double-click resets", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // Tall viewport so the content-sized overlay has plenty of room to grow
+    // without bumping into the 50vh safety cap on the first drag.
+    await testPage.setViewportSize({ width: 1280, height: 1000 });
+
+    const session = await seedTaskAndWaitForIdle(
+      testPage,
+      apiClient,
+      seedData,
+      "Clarification Resize",
+    );
+
+    await session.sendMessage("/ask-multiple");
+    await expect(session.clarificationOverlay()).toBeVisible({ timeout: 30_000 });
+
+    const container = testPage.getByTestId("clarification-overlay-container");
+    await expect(container).toBeVisible();
+
+    const initial = await container.evaluate((el) => {
+      const computed = window.getComputedStyle(el);
+      return {
+        overflowY: computed.overflowY,
+        height: el.getBoundingClientRect().height,
+        // Inline style is what disambiguates "auto-sized" from "user-dragged".
+        inlineHeight: (el as HTMLElement).style.height,
+      };
+    });
+
+    expect(initial.overflowY).toBe("auto");
+    // Default state: no inline height → container sizes to its content.
+    expect(initial.inlineHeight).toBe("");
+    // Sanity check: content-sized overlay is at least tall enough for the
+    // question card but well under the 50vh cap.
+    expect(initial.height).toBeGreaterThan(200);
+    expect(initial.height).toBeLessThan(1000 * 0.5);
+
+    const handle = container.locator("xpath=..").locator("button[aria-label='Resize']");
+    await expect(handle).toBeVisible();
+
+    // Drag the handle upward by 120px → overlay should grow by ~120px.
+    const handleBox = await handle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    const dragDistance = 120;
+    const startX = handleBox!.x + handleBox!.width / 2;
+    const startY = handleBox!.y + handleBox!.height / 2;
+    await testPage.mouse.move(startX, startY);
+    await testPage.mouse.down();
+    await testPage.mouse.move(startX, startY - dragDistance, { steps: 10 });
+    await testPage.mouse.up();
+
+    const afterDrag = await container.evaluate((el) => ({
+      height: el.getBoundingClientRect().height,
+      inlineHeight: (el as HTMLElement).style.height,
+    }));
+    // Drag flipped the container to an explicit pixel height.
+    expect(afterDrag.inlineHeight).toMatch(/^\d+(\.\d+)?px$/);
+    // Allow ±10px tolerance for rounding / mouse event coalescing.
+    expect(afterDrag.height).toBeGreaterThan(initial.height + dragDistance - 10);
+
+    // Double-click the handle → back to auto-sized.
+    await handle.dblclick();
+    const afterReset = await container.evaluate((el) => ({
+      height: el.getBoundingClientRect().height,
+      inlineHeight: (el as HTMLElement).style.height,
+    }));
+    expect(afterReset.inlineHeight).toBe("");
+    expect(Math.abs(afterReset.height - initial.height)).toBeLessThanOrEqual(2);
+  });
+});

--- a/apps/web/e2e/tests/task/create-task-from-pr-list.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-from-pr-list.spec.ts
@@ -1,0 +1,95 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import { test, expect } from "../../fixtures/test-base";
+import { makeGitEnv } from "../../helpers/git-helper";
+
+test.describe("Create task from GitHub PR list", () => {
+  // Cold-start backend boots can race on the first test in a worker.
+  test.describe.configure({ retries: 1 });
+
+  test("starting a task from a PR pre-fills the matching repo and the PR head branch", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(60_000);
+
+    // seedData is worker-scoped, so the workspace can accumulate repos across
+    // test reruns. Use a unique owner/repo per invocation so matchRepo lands
+    // on exactly the one we just created.
+    const suffix = `${process.pid}-${Date.now()}`;
+    const ownerSlug = `owner-${suffix}`;
+    const repoSlug = `repo-${suffix}`;
+
+    // Create a real local git repo so the branch chip can enumerate branches.
+    // Both `main` and the PR head branch must exist locally — the chip lists
+    // local branches, not the GitHub mock's branches.
+    const repoDir = `${backend.tmpDir}/repos/pr-list-${suffix}`;
+    fs.mkdirSync(repoDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: repoDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: repoDir, env: gitEnv });
+    execSync("git checkout -b feature/from-pr-list", { cwd: repoDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "feature"', { cwd: repoDir, env: gitEnv });
+    execSync("git checkout main", { cwd: repoDir, env: gitEnv });
+
+    // Pre-seed a GitHub-backed repository that matches the mock PR's owner/repo.
+    // The launcher's matchRepo() looks up workspace repos by provider_owner/name.
+    await apiClient.createRepository(seedData.workspaceId, repoDir, "main", {
+      name: `${ownerSlug}/${repoSlug}`,
+      provider: "github",
+      provider_owner: ownerSlug,
+      provider_name: repoSlug,
+    });
+
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddBranches(ownerSlug, repoSlug, [
+      { name: "main" },
+      { name: "feature/from-pr-list" },
+    ]);
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 77,
+        title: "PR from GitHub page",
+        state: "open",
+        head_branch: "feature/from-pr-list",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: ownerSlug,
+        repo_name: repoSlug,
+      },
+    ]);
+
+    await testPage.goto("/github");
+
+    // Wait for the seeded PR row to render. The "Review requested" default
+    // preset matches because the mock user is the requested reviewer fallback
+    // for the seeded PR. We scope by data-pr-number to avoid catching any
+    // leftover PRs cached by previous tests.
+    const prRow = testPage.locator('[data-testid="pr-row"][data-pr-number="77"]');
+    await expect(prRow).toBeVisible({ timeout: 15_000 });
+
+    // Open the task launcher menu for this PR and choose the "Review" preset.
+    await prRow.getByTestId("pr-start-task-trigger").click();
+    await testPage.locator('[data-testid="pr-start-task-preset"][data-preset-id="review"]').click();
+
+    // The create-task dialog should open with the matching workspace repo
+    // selected and the PR head branch pre-filled in the branch chip.
+    const dialog = testPage.getByTestId("create-task-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByTestId("repo-chip-trigger").first()).toContainText(
+      `${ownerSlug}/${repoSlug}`,
+    );
+    await expect(dialog.getByTestId("branch-chip-trigger").first()).toContainText(
+      "feature/from-pr-list",
+      { timeout: 10_000 },
+    );
+
+    // The dialog title should be derived from the preset + PR title.
+    await expect(testPage.getByTestId("task-title-input")).toHaveValue(
+      /Review: PR from GitHub page/,
+    );
+  });
+});

--- a/apps/web/hooks/domains/session/use-session-git.ts
+++ b/apps/web/hooks/domains/session/use-session-git.ts
@@ -5,6 +5,7 @@ import { useSessionGitStatus, useSessionGitStatusByRepo } from "./use-session-gi
 import { useSessionCommits } from "./use-session-commits";
 import { useCumulativeDiff } from "./use-cumulative-diff";
 import { useGitOperations } from "@/hooks/use-git-operations";
+import { createDebugLogger } from "@/lib/debug/log";
 import type {
   FileInfo,
   SessionCommit,
@@ -40,6 +41,8 @@ export type GitOperationResult = RawGitOperationResult & {
 };
 
 export type { PRCreateResult };
+
+const debugDeriv = createDebugLogger("git-status:derive");
 
 export type SessionGit = {
   // Branch info
@@ -596,6 +599,17 @@ function useFileDerivations(
     () => aggregateFilesAcrossRepos(statusByRepo, gitStatus),
     [statusByRepo, gitStatus],
   );
+  useEffect(() => {
+    debugDeriv("aggregate", {
+      path: statusByRepo.length > 0 ? "multi-repo" : "single-repo-fallback",
+      statusByRepoEntries: statusByRepo.map((s) => ({
+        repo: s.repository_name,
+        files: Object.keys(s.status?.files ?? {}).length,
+      })),
+      legacyGitStatusFiles: Object.keys(gitStatus?.files ?? {}).length,
+      allFilesCount: allFiles.length,
+    });
+  }, [statusByRepo, gitStatus, allFiles]);
   const unstagedFiles = useMemo(() => allFiles.filter((f) => !f.staged), [allFiles]);
   const stagedFiles = useMemo(() => allFiles.filter((f) => f.staged), [allFiles]);
   const repoForPath = useMemo(() => {

--- a/apps/web/hooks/domains/session/use-session-git.ts
+++ b/apps/web/hooks/domains/session/use-session-git.ts
@@ -5,7 +5,7 @@ import { useSessionGitStatus, useSessionGitStatusByRepo } from "./use-session-gi
 import { useSessionCommits } from "./use-session-commits";
 import { useCumulativeDiff } from "./use-cumulative-diff";
 import { useGitOperations } from "@/hooks/use-git-operations";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 import type {
   FileInfo,
   SessionCommit,
@@ -600,7 +600,7 @@ function useFileDerivations(
     [statusByRepo, gitStatus],
   );
   useEffect(() => {
-    if (process.env.NODE_ENV === "production") return;
+    if (!IS_DEBUG) return;
     debugDeriv("aggregate", {
       path: statusByRepo.length > 0 ? "multi-repo" : "single-repo-fallback",
       statusByRepoEntries: statusByRepo.map((s) => ({

--- a/apps/web/hooks/domains/session/use-session-git.ts
+++ b/apps/web/hooks/domains/session/use-session-git.ts
@@ -600,6 +600,7 @@ function useFileDerivations(
     [statusByRepo, gitStatus],
   );
   useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
     debugDeriv("aggregate", {
       path: statusByRepo.length > 0 ? "multi-repo" : "single-repo-fallback",
       statusByRepoEntries: statusByRepo.map((s) => ({

--- a/apps/web/hooks/domains/session/use-session-messages.test.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Message } from "@/lib/types/http";
+
+const mockListTaskSessionMessages = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  listTaskSessionMessages: (...args: unknown[]) => mockListTaskSessionMessages(...args),
+}));
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => null,
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: () => null,
+  useAppStoreApi: () => null,
+}));
+
+import { taskId, sessionId } from "@/lib/types/ids";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListTaskSessionMessages.mockResolvedValue({ messages: [], has_more: false });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+import {
+  hasUserOrAgentMessage,
+  runBackfillRound,
+  autoBackfillUntilUserMessage,
+} from "./use-session-messages";
+
+function makeMessage(overrides: Partial<Message>): Message {
+  return {
+    id: "msg-1",
+    task_id: taskId("task-1"),
+    session_id: sessionId("sess-1"),
+    author_type: "user",
+    content: "hello",
+    type: "message",
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  } as Message;
+}
+
+/** Stateful store mock — prependMessages actually updates the stored messages. */
+function makeStore(options: {
+  messages?: Message[];
+  hasMore?: boolean;
+  oldestCursor?: string | null;
+}) {
+  let messages: Message[] = options.messages ?? [];
+  let meta = {
+    hasMore: options.hasMore ?? false,
+    oldestCursor: options.oldestCursor ?? null,
+    isLoading: false,
+  };
+  const prependMessages = vi.fn(
+    (
+      _sessionId: string,
+      newMsgs: Message[],
+      newMeta: { hasMore: boolean; oldestCursor: string | null },
+    ) => {
+      messages = [...newMsgs, ...messages];
+      meta = { ...meta, ...newMeta };
+    },
+  );
+  return {
+    getState: () => ({
+      messages: {
+        bySession: { "sess-1": messages },
+        metaBySession: { "sess-1": meta },
+      },
+      prependMessages,
+    }),
+    _prependMessages: prependMessages,
+  };
+}
+
+describe("hasUserOrAgentMessage", () => {
+  it("returns true for a user message", () => {
+    expect(hasUserOrAgentMessage([makeMessage({ type: "message", author_type: "user" })])).toBe(
+      true,
+    );
+  });
+
+  it("returns true for an agent message", () => {
+    expect(hasUserOrAgentMessage([makeMessage({ type: "message", author_type: "agent" })])).toBe(
+      true,
+    );
+  });
+
+  it("returns false for tool_call only", () => {
+    expect(hasUserOrAgentMessage([makeMessage({ type: "tool_call", author_type: "agent" })])).toBe(
+      false,
+    );
+  });
+
+  it("returns false for empty array", () => {
+    expect(hasUserOrAgentMessage([])).toBe(false);
+  });
+
+  it("returns true when mixed messages include a user message", () => {
+    const msgs = [
+      makeMessage({ id: "t1", type: "tool_call", author_type: "agent" }),
+      makeMessage({ id: "u1", type: "message", author_type: "user" }),
+    ];
+    expect(hasUserOrAgentMessage(msgs)).toBe(true);
+  });
+});
+
+describe("runBackfillRound", () => {
+  it("returns 'stop' when a user/agent message already exists in the store", async () => {
+    const store = makeStore({
+      messages: [makeMessage({ type: "message", author_type: "user" })],
+      hasMore: true,
+      oldestCursor: "msg-1",
+    });
+    const result = await runBackfillRound("sess-1", store as never, 0);
+    expect(result).toBe("stop");
+    expect(mockListTaskSessionMessages).not.toHaveBeenCalled();
+  });
+
+  it("returns 'stop' when hasMore is false", async () => {
+    const store = makeStore({ messages: [], hasMore: false, oldestCursor: "msg-1" });
+    const result = await runBackfillRound("sess-1", store as never, 0);
+    expect(result).toBe("stop");
+  });
+
+  it("returns 'stop' when oldestCursor is null", async () => {
+    const store = makeStore({ messages: [], hasMore: true, oldestCursor: null });
+    const result = await runBackfillRound("sess-1", store as never, 0);
+    expect(result).toBe("stop");
+  });
+
+  it("returns 'continue' and calls prependMessages when older messages are fetched", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({
+      messages: [makeMessage({ id: "old-1" })],
+      has_more: true,
+    });
+    const store = makeStore({ messages: [], hasMore: true, oldestCursor: "msg-1" });
+    const result = await runBackfillRound("sess-1", store as never, 0);
+    expect(result).toBe("continue");
+    expect(store._prependMessages).toHaveBeenCalled();
+  });
+
+  it("returns 'stop' when fetched batch is empty", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({ messages: [], has_more: true });
+    const store = makeStore({ messages: [], hasMore: true, oldestCursor: "msg-1" });
+    const result = await runBackfillRound("sess-1", store as never, 0);
+    expect(result).toBe("stop");
+  });
+
+  it("returns 'stop' on fetch error", async () => {
+    mockListTaskSessionMessages.mockRejectedValue(new Error("network error"));
+    const store = makeStore({ messages: [], hasMore: true, oldestCursor: "msg-1" });
+    const result = await runBackfillRound("sess-1", store as never, 0);
+    expect(result).toBe("stop");
+  });
+});
+
+describe("autoBackfillUntilUserMessage", () => {
+  it("stops after MAX_BACKFILL_ROUNDS (3) without finding a user/agent message", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({
+      messages: [makeMessage({ id: "t1", type: "tool_call", author_type: "agent" })],
+      has_more: true,
+    });
+    const store = makeStore({ messages: [], hasMore: true, oldestCursor: "cursor-0" });
+    await autoBackfillUntilUserMessage("sess-1", store as never);
+    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops after round 1 once a user message is prepended", async () => {
+    mockListTaskSessionMessages.mockResolvedValue({
+      messages: [makeMessage({ id: "u1", type: "message", author_type: "user" })],
+      has_more: true,
+    });
+    const store = makeStore({ messages: [], hasMore: true, oldestCursor: "cursor-0" });
+    await autoBackfillUntilUserMessage("sess-1", store as never);
+    // After round 0, prependMessages adds the user message; round 1 finds it and stops.
+    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -3,7 +3,7 @@ import { getWebSocketClient } from "@/lib/ws/connection";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import type { TaskSessionState, Message } from "@/lib/types/http";
 import { listTaskSessionMessages } from "@/lib/api";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const INITIAL_FETCH_LIMIT = 100;
 const BACKFILL_PAGE_LIMIT = 100;
@@ -74,7 +74,7 @@ async function fetchAndStoreMessages(
   debug("message.list request", requestParams);
   const response = await client.request<MessageListResponse>("message.list", requestParams, 10000);
   const fetched = [...(response.messages ?? [])].reverse();
-  if (process.env.NODE_ENV !== "production") {
+  if (IS_DEBUG) {
     const summary = summarizeMessages(fetched);
     debug("message.list response", {
       sessionId,

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -2,6 +2,47 @@ import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "rea
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import type { TaskSessionState, Message } from "@/lib/types/http";
+import { listTaskSessionMessages } from "@/lib/api";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const INITIAL_FETCH_LIMIT = 100;
+const BACKFILL_PAGE_LIMIT = 100;
+const MAX_BACKFILL_ROUNDS = 3;
+
+function hasUserOrAgentMessage(messages: Message[]): boolean {
+  return messages.some(
+    (m) => m.type === "message" && (m.author_type === "user" || m.author_type === "agent"),
+  );
+}
+
+const debug = createDebugLogger("messages:fetch");
+
+function summarizeMessages(messages: Message[]): {
+  count: number;
+  byType: Record<string, number>;
+  userMessageCount: number;
+  agentMessageCount: number;
+  oldestCreatedAt: string | null;
+  newestCreatedAt: string | null;
+} {
+  const byType: Record<string, number> = {};
+  let userMessageCount = 0;
+  let agentMessageCount = 0;
+  for (const m of messages) {
+    const t = m.type ?? "unknown";
+    byType[t] = (byType[t] ?? 0) + 1;
+    if (m.type === "message" && m.author_type === "user") userMessageCount++;
+    if (m.type === "message" && m.author_type === "agent") agentMessageCount++;
+  }
+  return {
+    count: messages.length,
+    byType,
+    userMessageCount,
+    agentMessageCount,
+    oldestCreatedAt: messages[0]?.created_at ?? null,
+    newestCreatedAt: messages[messages.length - 1]?.created_at ?? null,
+  };
+}
 
 interface UseSessionMessagesReturn {
   isLoading: boolean;
@@ -25,12 +66,30 @@ async function fetchAndStoreMessages(
     return [];
   }
 
-  const response = await client.request<MessageListResponse>(
-    "message.list",
-    { session_id: sessionId, limit: 50, sort: "desc" },
-    10000,
-  );
+  const requestParams = {
+    session_id: sessionId,
+    limit: INITIAL_FETCH_LIMIT,
+    sort: "desc" as const,
+  };
+  debug("message.list request", requestParams);
+  const response = await client.request<MessageListResponse>("message.list", requestParams, 10000);
   const fetched = [...(response.messages ?? [])].reverse();
+  const summary = summarizeMessages(fetched);
+  debug("message.list response", {
+    sessionId,
+    hasMore: response.has_more ?? false,
+    cursor: response.cursor ?? null,
+    ...summary,
+  });
+  if (fetched.length > 0 && summary.userMessageCount === 0 && summary.agentMessageCount === 0) {
+    debug("WARNING: fetched window contains no user/agent message rows", {
+      sessionId,
+      limit: requestParams.limit,
+      hasMore: response.has_more ?? false,
+      byType: summary.byType,
+      hint: "The fetch limit may be too small for this session's last turn — user prompt and agent replies live further back. Paginate or raise the limit to see them.",
+    });
+  }
   // Merge: keep WS-delivered messages that aren't in the fetch response.
   // This prevents a slow fetch (sent before messages existed) from wiping
   // messages that arrived via real-time notifications while the fetch was
@@ -50,6 +109,81 @@ async function fetchAndStoreMessages(
     oldestCursor: merged[0]?.id ?? null,
   });
   return merged;
+}
+
+/**
+ * When the initial fetch window contains no user/agent message rows (common
+ * when the latest turn produced hundreds of tool calls), the chat would render
+ * as an opaque collapsed activity group with nothing meaningful to scroll
+ * past — the lazy-load sentinel at the top of the list never fires because
+ * the user has no anchor to scroll from. Paginate backward via the same HTTP
+ * endpoint `useLazyLoadMessages` uses until we span at least one user/agent
+ * message or hit the round cap.
+ */
+type BackfillStep = "continue" | "stop";
+
+async function fetchAndPrependOlder(
+  sessionId: string,
+  store: ReturnType<typeof useAppStoreApi>,
+  oldestCursor: string,
+): Promise<number> {
+  const response = await listTaskSessionMessages(sessionId, {
+    limit: BACKFILL_PAGE_LIMIT,
+    before: oldestCursor,
+    sort: "desc",
+  });
+  const ordered = [...(response.messages ?? [])].reverse();
+  const newOldestCursor = ordered[0]?.id ?? oldestCursor;
+  store.getState().prependMessages(sessionId, ordered, {
+    hasMore: response.has_more ?? false,
+    oldestCursor: newOldestCursor,
+  });
+  return ordered.length;
+}
+
+async function runBackfillRound(
+  sessionId: string,
+  store: ReturnType<typeof useAppStoreApi>,
+  round: number,
+): Promise<BackfillStep> {
+  const meta = store.getState().messages.metaBySession[sessionId];
+  const messages = store.getState().messages.bySession[sessionId] ?? [];
+  if (hasUserOrAgentMessage(messages)) return "stop";
+  if (!meta?.hasMore || !meta.oldestCursor) {
+    debug("autoBackfill: stopping (no more older messages)", {
+      sessionId,
+      round,
+      hasMore: meta?.hasMore ?? false,
+    });
+    return "stop";
+  }
+  debug("autoBackfill: window has no user/agent message, fetching older", {
+    sessionId,
+    round,
+    currentCount: messages.length,
+    oldestCursor: meta.oldestCursor,
+  });
+  try {
+    const added = await fetchAndPrependOlder(sessionId, store, meta.oldestCursor);
+    return added === 0 ? "stop" : "continue";
+  } catch (err) {
+    debug("autoBackfill: fetch failed, stopping", { sessionId, round, err });
+    return "stop";
+  }
+}
+
+async function autoBackfillUntilUserMessage(
+  sessionId: string,
+  store: ReturnType<typeof useAppStoreApi>,
+): Promise<void> {
+  for (let round = 0; round < MAX_BACKFILL_ROUNDS; round++) {
+    const step = await runBackfillRound(sessionId, store, round);
+    if (step === "stop") return;
+  }
+  debug("autoBackfill: hit round cap without finding user/agent message", {
+    sessionId,
+    cap: MAX_BACKFILL_ROUNDS,
+  });
 }
 
 type FetchMessagesParams = {
@@ -81,6 +215,9 @@ async function doFetchMessages({
     const fetched = await fetchAndStoreMessages(taskSessionId, store);
     lastFetchedSessionIdRef.current = taskSessionId;
     if (fetched.length > 0) setIsWaitingForInitialMessages(false);
+    if (fetched.length > 0 && !hasUserOrAgentMessage(fetched)) {
+      await autoBackfillUntilUserMessage(taskSessionId, store);
+    }
   } catch (error) {
     if (onError) onError(error);
     else console.error("Failed to fetch messages:", error);
@@ -135,14 +272,46 @@ export function useVisibilityBackfill(
   store: ReturnType<typeof useAppStoreApi>,
 ) {
   useEffect(() => {
-    if (!taskSessionId) return;
+    if (!taskSessionId) {
+      debug("visibilityBackfill: skipped attaching (no sessionId)");
+      return;
+    }
+    debug("visibilityBackfill: attached", { sessionId: taskSessionId });
     const onVisible = () => {
-      if (document.visibilityState === "visible") {
-        fetchAndStoreMessages(taskSessionId, store).catch(() => {});
-      }
+      const visibilityState = document.visibilityState;
+      const state = store.getState();
+      const existingCount = state.messages.bySession[taskSessionId]?.length ?? 0;
+      const newestBefore =
+        state.messages.bySession[taskSessionId]?.slice(-1)[0]?.created_at ?? null;
+      debug("visibilityBackfill: visibilitychange fired", {
+        sessionId: taskSessionId,
+        visibilityState,
+        connectionStatus: state.connection?.status ?? "unknown",
+        existingCount,
+        newestBefore,
+      });
+      if (visibilityState !== "visible") return;
+      fetchAndStoreMessages(taskSessionId, store)
+        .then(() => {
+          const afterCount = store.getState().messages.bySession[taskSessionId]?.length ?? 0;
+          const newestAfter =
+            store.getState().messages.bySession[taskSessionId]?.slice(-1)[0]?.created_at ?? null;
+          debug("visibilityBackfill: refetch complete", {
+            sessionId: taskSessionId,
+            delta: afterCount - existingCount,
+            newestBefore,
+            newestAfter,
+          });
+        })
+        .catch((err) => {
+          debug("visibilityBackfill: refetch failed", { sessionId: taskSessionId, err });
+        });
     };
     document.addEventListener("visibilitychange", onVisible);
-    return () => document.removeEventListener("visibilitychange", onVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      debug("visibilityBackfill: detached", { sessionId: taskSessionId });
+    };
   }, [taskSessionId, store]);
 }
 
@@ -153,13 +322,24 @@ function useSessionSubscription(
   store: ReturnType<typeof useAppStoreApi>,
 ) {
   useEffect(() => {
+    debug("subscription: effect ran", {
+      sessionId: taskSessionId,
+      connectionStatus,
+      isSessionStartingOrUnknown,
+    });
     if (!taskSessionId || connectionStatus !== "connected") {
+      debug("subscription: skipped (no session or not connected)", {
+        sessionId: taskSessionId,
+        connectionStatus,
+      });
       return;
     }
     const client = getWebSocketClient();
     if (!client) {
+      debug("subscription: skipped (no ws client)", { sessionId: taskSessionId });
       return;
     }
+    debug("subscription: subscribing", { sessionId: taskSessionId });
     const unsubscribe = client.subscribeSession(taskSessionId);
 
     // Re-fetch messages after subscribing to close the gap between SSR
@@ -167,6 +347,7 @@ function useSessionSubscription(
     fetchAndStoreMessages(taskSessionId, store).catch(() => {});
 
     return () => {
+      debug("subscription: unsubscribing", { sessionId: taskSessionId });
       unsubscribe();
     };
   }, [taskSessionId, connectionStatus, store, isSessionStartingOrUnknown]);

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -9,7 +9,7 @@ const INITIAL_FETCH_LIMIT = 100;
 const BACKFILL_PAGE_LIMIT = 100;
 const MAX_BACKFILL_ROUNDS = 3;
 
-function hasUserOrAgentMessage(messages: Message[]): boolean {
+export function hasUserOrAgentMessage(messages: Message[]): boolean {
   return messages.some(
     (m) => m.type === "message" && (m.author_type === "user" || m.author_type === "agent"),
   );
@@ -74,21 +74,23 @@ async function fetchAndStoreMessages(
   debug("message.list request", requestParams);
   const response = await client.request<MessageListResponse>("message.list", requestParams, 10000);
   const fetched = [...(response.messages ?? [])].reverse();
-  const summary = summarizeMessages(fetched);
-  debug("message.list response", {
-    sessionId,
-    hasMore: response.has_more ?? false,
-    cursor: response.cursor ?? null,
-    ...summary,
-  });
-  if (fetched.length > 0 && summary.userMessageCount === 0 && summary.agentMessageCount === 0) {
-    debug("WARNING: fetched window contains no user/agent message rows", {
+  if (process.env.NODE_ENV !== "production") {
+    const summary = summarizeMessages(fetched);
+    debug("message.list response", {
       sessionId,
-      limit: requestParams.limit,
       hasMore: response.has_more ?? false,
-      byType: summary.byType,
-      hint: "The fetch limit may be too small for this session's last turn — user prompt and agent replies live further back. Paginate or raise the limit to see them.",
+      cursor: response.cursor ?? null,
+      ...summary,
     });
+    if (fetched.length > 0 && summary.userMessageCount === 0 && summary.agentMessageCount === 0) {
+      debug("WARNING: fetched window contains no user/agent message rows", {
+        sessionId,
+        limit: requestParams.limit,
+        hasMore: response.has_more ?? false,
+        byType: summary.byType,
+        hint: "The fetch limit may be too small for this session's last turn — user prompt and agent replies live further back. Paginate or raise the limit to see them.",
+      });
+    }
   }
   // Merge: keep WS-delivered messages that aren't in the fetch response.
   // This prevents a slow fetch (sent before messages existed) from wiping
@@ -120,7 +122,7 @@ async function fetchAndStoreMessages(
  * endpoint `useLazyLoadMessages` uses until we span at least one user/agent
  * message or hit the round cap.
  */
-type BackfillStep = "continue" | "stop";
+export type BackfillStep = "continue" | "stop";
 
 async function fetchAndPrependOlder(
   sessionId: string,
@@ -141,7 +143,7 @@ async function fetchAndPrependOlder(
   return ordered.length;
 }
 
-async function runBackfillRound(
+export async function runBackfillRound(
   sessionId: string,
   store: ReturnType<typeof useAppStoreApi>,
   round: number,
@@ -172,7 +174,7 @@ async function runBackfillRound(
   }
 }
 
-async function autoBackfillUntilUserMessage(
+export async function autoBackfillUntilUserMessage(
   sessionId: string,
   store: ReturnType<typeof useAppStoreApi>,
 ): Promise<void> {

--- a/apps/web/hooks/use-lazy-load-messages.ts
+++ b/apps/web/hooks/use-lazy-load-messages.ts
@@ -1,6 +1,62 @@
 import { useCallback, useEffect, useRef } from "react";
 import { listTaskSessionMessages } from "@/lib/api";
 import { useAppStore } from "@/components/state-provider";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debug = createDebugLogger("messages:lazyload");
+
+function describeSkip(args: {
+  sessionId: string | null;
+  isLoading: boolean;
+  hasMore: boolean;
+}): string {
+  if (!args.sessionId) return "no-session";
+  if (args.isLoading) return "already-loading";
+  if (!args.hasMore) return "no-more";
+  return "no-cursor";
+}
+
+type LoadMoreResponseLog = {
+  sessionId: string;
+  requestedBefore: string;
+  ordered: Array<{
+    id: string;
+    created_at: string;
+    type?: string;
+    author_type?: string;
+  }>;
+  responseHasMore: boolean;
+  newOldestCursor: string | null;
+};
+
+function logLoadMoreResponse(args: LoadMoreResponseLog) {
+  const { sessionId, requestedBefore, ordered, responseHasMore, newOldestCursor } = args;
+  const first = ordered[0];
+  debug("loadMore: response", {
+    sessionId,
+    requestedBefore,
+    fetchedCount: ordered.length,
+    responseHasMore,
+    newOldestId: newOldestCursor,
+    newOldestCreatedAt: first?.created_at ?? null,
+    newOldestType: first?.type ?? null,
+    newOldestAuthor: first?.author_type ?? null,
+  });
+  if (ordered.length === 0 && responseHasMore) {
+    debug("loadMore: WARNING empty batch with has_more=true — pagination may be stuck", {
+      sessionId,
+      before: requestedBefore,
+    });
+  }
+  if (!responseHasMore && ordered.length > 0) {
+    debug("loadMore: reached oldest — check that the first prompt is present", {
+      sessionId,
+      newOldestId: newOldestCursor,
+      newOldestAuthor: first?.author_type,
+      newOldestType: first?.type,
+    });
+  }
+}
 
 export function useLazyLoadMessages(sessionId: string | null) {
   // Use refs for values that should not trigger callback recreation
@@ -28,8 +84,16 @@ export function useLazyLoadMessages(sessionId: string | null) {
     const { hasMore, isLoading, oldestCursor } = stateRef.current;
 
     if (!sessionId || !hasMore || isLoading || !oldestCursor) {
+      debug("loadMore: skipped", {
+        sessionId,
+        reason: describeSkip({ sessionId, isLoading, hasMore }),
+        hasMore,
+        oldestCursor,
+      });
       return 0;
     }
+
+    debug("loadMore: requesting older page", { sessionId, before: oldestCursor, limit: 20 });
 
     // Update ref synchronously so concurrent calls are blocked immediately
     stateRef.current.isLoading = true;
@@ -43,6 +107,13 @@ export function useLazyLoadMessages(sessionId: string | null) {
       const orderedMessages = [...(response.messages ?? [])].reverse();
       // After reversing, orderedMessages[0] is the oldest message in this batch
       const newOldestCursor = orderedMessages[0]?.id ?? null;
+      logLoadMoreResponse({
+        sessionId,
+        requestedBefore: oldestCursor,
+        ordered: orderedMessages,
+        responseHasMore: response.has_more,
+        newOldestCursor,
+      });
       // Sync ref immediately so the next intersection callback sees correct state
       // (the useEffect sync may not have run yet between store update and next observer fire)
       stateRef.current = {
@@ -57,6 +128,7 @@ export function useLazyLoadMessages(sessionId: string | null) {
       return orderedMessages.length;
     } catch (error) {
       console.error("[useLazyLoadMessages] Error loading messages:", error);
+      debug("loadMore: error", { sessionId, error });
       stateRef.current.isLoading = false;
       setMessagesMetadata(sessionId, { isLoading: false });
       return 0;

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -11,7 +11,7 @@ import {
   findPendingClarification,
   findPendingClarificationGroup,
 } from "@/lib/utils/pending-clarification";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debug = createDebugLogger("messages:process");
 
@@ -33,7 +33,7 @@ function useDebugProcessedPipeline(args: {
 }) {
   const { sessionId, messages, visibleMessages, footerActionCount, groupedItems } = args;
   useEffect(() => {
-    if (process.env.NODE_ENV === "production") return;
+    if (!IS_DEBUG) return;
     debug("pipeline", {
       sessionId,
       input: { count: messages.length, byType: countByType(messages) },

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import {
   sessionId as toSessionId,
   taskId as toTaskId,
@@ -11,6 +11,44 @@ import {
   findPendingClarification,
   findPendingClarificationGroup,
 } from "@/lib/utils/pending-clarification";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debug = createDebugLogger("messages:process");
+
+function countByType(messages: Message[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const m of messages) {
+    const t = m.type ?? "unknown";
+    out[t] = (out[t] ?? 0) + 1;
+  }
+  return out;
+}
+
+function useDebugProcessedPipeline(args: {
+  sessionId: string | null;
+  messages: Message[];
+  visibleMessages: Message[];
+  footerActionCount: number;
+  groupedItems: RenderItem[];
+}) {
+  const { sessionId, messages, visibleMessages, footerActionCount, groupedItems } = args;
+  useEffect(() => {
+    debug("pipeline", {
+      sessionId,
+      input: { count: messages.length, byType: countByType(messages) },
+      afterFilter: { count: visibleMessages.length, byType: countByType(visibleMessages) },
+      droppedByFilter: messages.length - visibleMessages.length,
+      footerActionCount,
+      groupedItemKinds: groupedItems.reduce<Record<string, number>>((acc, item) => {
+        acc[item.type] = (acc[item.type] ?? 0) + 1;
+        return acc;
+      }, {}),
+      turnGroupSizes: groupedItems
+        .filter((i): i is TurnGroup => i.type === "turn_group")
+        .map((g) => ({ turnId: g.turnId, size: g.messages.length })),
+    });
+  }, [sessionId, messages, visibleMessages, footerActionCount, groupedItems]);
+}
 
 const ACTIVITY_MESSAGE_TYPES: Set<MessageType> = new Set([
   "thinking",
@@ -376,6 +414,14 @@ export function useProcessedMessages(
   const groupedItems = useMemo<RenderItem[]>(() => {
     return injectPrepareProgressItem(groupActivityMessages(regularMessages), resolvedSessionId);
   }, [regularMessages, resolvedSessionId]);
+
+  useDebugProcessedPipeline({
+    sessionId: resolvedSessionId,
+    messages,
+    visibleMessages,
+    footerActionCount: footerActionMessages.length,
+    groupedItems,
+  });
 
   return {
     visibleMessages,

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -33,6 +33,7 @@ function useDebugProcessedPipeline(args: {
 }) {
   const { sessionId, messages, visibleMessages, footerActionCount, groupedItems } = args;
   useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
     debug("pipeline", {
       sessionId,
       input: { count: messages.length, byType: countByType(messages) },

--- a/apps/web/hooks/use-resizable-clarification-overlay.test.ts
+++ b/apps/web/hooks/use-resizable-clarification-overlay.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useResizableClarificationOverlay } from "./use-resizable-clarification-overlay";
+
+const MIN_HEIGHT = 120;
+
+function setInnerHeight(h: number) {
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: h, writable: true });
+}
+
+// Stub getBoundingClientRect on the (detached) container ref so the hook's
+// "measure current rendered height on drag start" branch has a value to read.
+function attachContainerWithHeight(ref: React.RefObject<HTMLDivElement | null>, height: number) {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () => ({
+    height,
+    width: 800,
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 800,
+    bottom: height,
+    toJSON: () => ({}),
+  });
+  (ref as { current: HTMLDivElement }).current = el;
+}
+
+function dispatchMouseMove(clientY: number) {
+  document.dispatchEvent(new MouseEvent("mousemove", { clientY, bubbles: true }));
+}
+
+function dispatchMouseUp() {
+  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
+// Fake MouseEvent for handleMouseDown — only clientY and preventDefault are read.
+function fakeReactMouseEvent(clientY: number) {
+  return { clientY, preventDefault: () => {} } as unknown as React.MouseEvent;
+}
+
+describe("useResizableClarificationOverlay", () => {
+  beforeEach(() => {
+    setInnerHeight(1000);
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  });
+
+  afterEach(() => {
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  });
+
+  it("starts with height=null (auto-sized) and exposes a containerRef + handle props", () => {
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    expect(result.current.height).toBeNull();
+    expect(result.current.containerRef.current).toBeNull();
+    expect(typeof result.current.resizeHandleProps.onMouseDown).toBe("function");
+    expect(typeof result.current.resizeHandleProps.onDoubleClick).toBe("function");
+  });
+
+  it("drag UP from a measured 300px grows height proportionally", () => {
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    attachContainerWithHeight(result.current.containerRef, 300);
+
+    // Mouse down at y=500, drag up to y=400 (delta=100), expect height ≈ 400.
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(500)));
+    act(() => dispatchMouseMove(400));
+
+    expect(result.current.height).toBe(400);
+  });
+
+  it("clamps below MIN_HEIGHT when dragging down past it", () => {
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    attachContainerWithHeight(result.current.containerRef, 200);
+
+    // Drag down (clientY grows) 500px → would target -300, must clamp to MIN_HEIGHT.
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(200)));
+    act(() => dispatchMouseMove(700));
+
+    expect(result.current.height).toBe(MIN_HEIGHT);
+  });
+
+  it("clamps above 50% of viewport when dragging up past it", () => {
+    setInnerHeight(800); // 50% = 400 cap
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    attachContainerWithHeight(result.current.containerRef, 300);
+
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(500)));
+    act(() => dispatchMouseMove(0)); // delta=500 → 800 requested, must clamp to 400
+
+    expect(result.current.height).toBe(400);
+  });
+
+  it("does not update height after mouseup", () => {
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    attachContainerWithHeight(result.current.containerRef, 250);
+
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(500)));
+    act(() => dispatchMouseMove(450)); // delta=50 → 300
+    expect(result.current.height).toBe(300);
+
+    act(() => dispatchMouseUp());
+    act(() => dispatchMouseMove(200)); // would target 550 if still dragging
+
+    expect(result.current.height).toBe(300);
+  });
+
+  it("sets document.body cursor/userSelect during drag and restores on mouseup", () => {
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    attachContainerWithHeight(result.current.containerRef, 200);
+
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(400)));
+    expect(document.body.style.cursor).toBe("ns-resize");
+    expect(document.body.style.userSelect).toBe("none");
+
+    act(() => dispatchMouseUp());
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+  });
+
+  it("falls back to MIN_HEIGHT as the drag origin when the container ref is empty", () => {
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    // No containerRef attached → fallback path.
+
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(500)));
+    act(() => dispatchMouseMove(400)); // delta=100 → MIN_HEIGHT + 100 = 220
+
+    expect(result.current.height).toBe(MIN_HEIGHT + 100);
+  });
+
+  it("resetHeight and the handle's onDoubleClick both revert to null (auto)", () => {
+    const { result } = renderHook(() => useResizableClarificationOverlay());
+    attachContainerWithHeight(result.current.containerRef, 250);
+
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(500)));
+    act(() => dispatchMouseMove(400));
+    act(() => dispatchMouseUp());
+    // startHeight=250 + delta=100 (500→400) = 350
+    expect(result.current.height).toBe(350);
+
+    act(() => result.current.resetHeight());
+    expect(result.current.height).toBeNull();
+
+    // Drag again, then double-click resets back to auto-sized.
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(500)));
+    act(() => dispatchMouseMove(380));
+    act(() => dispatchMouseUp());
+    expect(result.current.height).not.toBeNull();
+
+    act(() => result.current.resizeHandleProps.onDoubleClick());
+    expect(result.current.height).toBeNull();
+  });
+
+  it("cleans up body cursor and stops listening on unmount mid-drag", () => {
+    const { result, unmount } = renderHook(() => useResizableClarificationOverlay());
+    attachContainerWithHeight(result.current.containerRef, 250);
+
+    act(() => result.current.resizeHandleProps.onMouseDown(fakeReactMouseEvent(500)));
+    expect(document.body.style.cursor).toBe("ns-resize");
+
+    unmount();
+
+    // Unmount mid-drag must restore body styles.
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+
+    // Listeners removed: a synthetic mousemove must not throw / update anything.
+    expect(() => dispatchMouseMove(200)).not.toThrow();
+    expect(result.current.height).toBeNull();
+  });
+});

--- a/apps/web/hooks/use-resizable-clarification-overlay.ts
+++ b/apps/web/hooks/use-resizable-clarification-overlay.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MIN_HEIGHT = 120;
+const MAX_VIEWPORT_RATIO = 0.5;
+
+function viewportHeight(): number {
+  return typeof window === "undefined" ? 800 : window.innerHeight;
+}
+
+function clampHeight(value: number): number {
+  const max = Math.round(viewportHeight() * MAX_VIEWPORT_RATIO);
+  return Math.min(Math.max(value, MIN_HEIGHT), max);
+}
+
+/**
+ * Drives the user-resizable clarification overlay.
+ *
+ * Default behaviour: the container sizes to its content (`height === null` →
+ * caller omits the inline height style). Once the user drags the resize
+ * handle, the height switches to an explicit pixel value clamped between
+ * MIN_HEIGHT and 50% of the viewport. Double-clicking the handle returns to
+ * the auto-sized default.
+ *
+ * Callers MUST invoke `resetHeight()` when the overlay closes so a fresh
+ * clarification starts with auto-sized height instead of inheriting a
+ * dragged value.
+ */
+export function useResizableClarificationOverlay() {
+  // null = auto-size to content; number = user-driven pixel height.
+  const [height, setHeight] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+  const startY = useRef(0);
+  const startHeight = useRef(0);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    // Capture the *currently rendered* height so the drag continues from
+    // wherever the overlay sits — whether it's auto-sized or already pinned.
+    const measured = containerRef.current?.getBoundingClientRect().height ?? MIN_HEIGHT;
+    isDragging.current = true;
+    startY.current = e.clientY;
+    startHeight.current = measured;
+    document.body.style.cursor = "ns-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const resetHeight = useCallback(() => setHeight(null), []);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      // Dragging the handle UP grows the overlay (it expands toward the top
+      // of the screen), so a smaller clientY → larger height.
+      const delta = startY.current - e.clientY;
+      setHeight(clampHeight(startHeight.current + delta));
+    };
+    const handleMouseUp = () => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      if (isDragging.current) {
+        isDragging.current = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      }
+    };
+  }, []);
+
+  return {
+    height,
+    containerRef,
+    resetHeight,
+    resizeHandleProps: { onMouseDown: handleMouseDown, onDoubleClick: resetHeight },
+  };
+}

--- a/apps/web/lib/debug/log.test.ts
+++ b/apps/web/lib/debug/log.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createDebugLogger } from "./log";
+
+describe("createDebugLogger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a function", () => {
+    expect(typeof createDebugLogger("test")).toBe("function");
+  });
+
+  it("prefixes output with [namespace]", () => {
+    const log = createDebugLogger("my-ns");
+    log("hello");
+    expect(console.debug).toHaveBeenCalledWith("[my-ns] hello");
+  });
+
+  it("logs plain strings as-is", () => {
+    const log = createDebugLogger("ns");
+    log("simple message");
+    expect(console.debug).toHaveBeenCalledWith("[ns] simple message");
+  });
+
+  it("flattens plain objects to key=value pairs", () => {
+    const log = createDebugLogger("ns");
+    log("msg", { a: 1, b: "hello world" });
+    expect(console.debug).toHaveBeenCalledWith('[ns] msg a=1 b="hello world"');
+  });
+
+  it("quotes values containing spaces", () => {
+    const log = createDebugLogger("ns");
+    log({ key: "value with space" });
+    expect(console.debug).toHaveBeenCalledWith('[ns] key="value with space"');
+  });
+
+  it("leaves bare values unquoted", () => {
+    const log = createDebugLogger("ns");
+    log({ key: "simple_value" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] key=simple_value");
+  });
+
+  it("formats null and undefined", () => {
+    const log = createDebugLogger("ns");
+    log({ a: null, b: undefined });
+    expect(console.debug).toHaveBeenCalledWith("[ns] a=null b=undefined");
+  });
+
+  it("formats numbers and booleans", () => {
+    const log = createDebugLogger("ns");
+    log({ count: 42, flag: true });
+    expect(console.debug).toHaveBeenCalledWith("[ns] count=42 flag=true");
+  });
+
+  it("formats Error objects with name and message", () => {
+    const log = createDebugLogger("ns");
+    log({ err: new Error("boom") });
+    expect(console.debug).toHaveBeenCalledWith('[ns] err={"name":"Error","message":"boom"}');
+  });
+
+  it("serializes nested objects as JSON", () => {
+    const log = createDebugLogger("ns");
+    log({ nested: { x: 1 } });
+    expect(console.debug).toHaveBeenCalledWith('[ns] nested={"x":1}');
+  });
+
+  it("mixes strings and objects in a single call", () => {
+    const log = createDebugLogger("ns");
+    log("prefix", { a: 1 }, "suffix");
+    expect(console.debug).toHaveBeenCalledWith("[ns] prefix a=1 suffix");
+  });
+});

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -1,16 +1,20 @@
 /**
  * Namespaced debug logger for development.
  *
- * In production (`NODE_ENV === "production"`) the factory returns a no-op
- * function. The `debug()` call itself is free, but JavaScript evaluates its
- * arguments before the call — so callers that compute expensive values (O(n)
- * maps, `.reduce()`, spread of large objects) must guard with:
+ * Active when `NODE_ENV !== "production"` (i.e. `make dev`) **or** when
+ * `NEXT_PUBLIC_KANDEV_DEBUG=true` is set at build time (i.e. `make
+ * start-debug`). In a plain production build both conditions are false and
+ * Next.js dead-code-eliminates everything.
  *
- *   if (process.env.NODE_ENV !== "production") { debug(...); }
+ * The `debug()` call itself is free, but JavaScript evaluates its arguments
+ * before the call — so callers that compute expensive values (O(n) maps,
+ * `.reduce()`, spread of large objects) must guard with the exported constant:
  *
- * Next.js inlines the `process.env.NODE_ENV` check and dead-code-eliminates
- * the entire block in production builds. Simple scalar reads (lengths,
- * boolean flags, already-computed IDs) are cheap enough to leave unguarded.
+ *   if (IS_DEBUG) { debug(...); }
+ *
+ * Next.js inlines both `process.env` checks at build time and Terser folds
+ * `IS_DEBUG` to a boolean literal, dead-code-eliminating the block in regular
+ * production builds. Simple scalar reads are cheap enough to leave unguarded.
  *
  * Output format is logfmt-ish so logs are flat and grep/copy-friendly:
  *
@@ -27,7 +31,8 @@
 
 export type DebugLogger = (...args: unknown[]) => void;
 
-const DEV = process.env.NODE_ENV !== "production";
+export const IS_DEBUG =
+  process.env.NODE_ENV !== "production" || process.env.NEXT_PUBLIC_KANDEV_DEBUG === "true";
 
 const NOOP: DebugLogger = () => {};
 
@@ -78,7 +83,7 @@ function flattenArgs(args: unknown[]): string {
 }
 
 export function createDebugLogger(namespace: string): DebugLogger {
-  if (!DEV) return NOOP;
+  if (!IS_DEBUG) return NOOP;
   const prefix = `[${namespace}]`;
   return (...args: unknown[]) => {
     console.debug(`${prefix} ${flattenArgs(args)}`);

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -1,0 +1,79 @@
+/**
+ * Namespaced debug logger for development.
+ *
+ * In production (`NODE_ENV === "production"`) the factory returns a no-op
+ * function, so debug call sites have zero runtime cost — Next.js inlines the
+ * `process.env.NODE_ENV` check at build time and tree-shakes the branch.
+ *
+ * Output format is logfmt-ish so logs are flat and grep/copy-friendly:
+ *
+ *   [namespace] message key1=value key2="value with space" key3={"nested":1}
+ *
+ * Usage:
+ *   const debug = createDebugLogger("git-status");
+ *   debug("status_update received", { sessionId, fileCount });
+ *
+ * Logs go through `console.debug`, which the log interceptor mirrors into the
+ * ring buffer (see `lib/logger/intercept.ts`), so they also end up in
+ * Improve Kandev reports without extra plumbing.
+ */
+
+export type DebugLogger = (...args: unknown[]) => void;
+
+const DEV = process.env.NODE_ENV !== "production";
+
+const NOOP: DebugLogger = () => {};
+
+const BARE_VALUE_RE = /^[A-Za-z0-9_\-:./@+]+$/;
+
+function formatValue(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") {
+    return BARE_VALUE_RE.test(value) ? value : JSON.stringify(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (value instanceof Error) {
+    return JSON.stringify({ name: value.name, message: value.message });
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  if (Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function flattenArgs(args: unknown[]): string {
+  const parts: string[] = [];
+  for (const arg of args) {
+    if (typeof arg === "string") {
+      parts.push(arg);
+      continue;
+    }
+    if (isPlainObject(arg)) {
+      for (const [key, val] of Object.entries(arg)) {
+        parts.push(`${key}=${formatValue(val)}`);
+      }
+      continue;
+    }
+    parts.push(formatValue(arg));
+  }
+  return parts.join(" ");
+}
+
+export function createDebugLogger(namespace: string): DebugLogger {
+  if (!DEV) return NOOP;
+  const prefix = `[${namespace}]`;
+  return (...args: unknown[]) => {
+    console.debug(`${prefix} ${flattenArgs(args)}`);
+  };
+}

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -2,8 +2,15 @@
  * Namespaced debug logger for development.
  *
  * In production (`NODE_ENV === "production"`) the factory returns a no-op
- * function, so debug call sites have zero runtime cost — Next.js inlines the
- * `process.env.NODE_ENV` check at build time and tree-shakes the branch.
+ * function. The `debug()` call itself is free, but JavaScript evaluates its
+ * arguments before the call — so callers that compute expensive values (O(n)
+ * maps, `.reduce()`, spread of large objects) must guard with:
+ *
+ *   if (process.env.NODE_ENV !== "production") { debug(...); }
+ *
+ * Next.js inlines the `process.env.NODE_ENV` check and dead-code-eliminates
+ * the entire block in production builds. Simple scalar reads (lengths,
+ * boolean flags, already-computed IDs) are cheap enough to leave unguarded.
  *
  * Output format is logfmt-ish so logs are flat and grep/copy-friendly:
  *

--- a/apps/web/lib/ssr/mapper.ts
+++ b/apps/web/lib/ssr/mapper.ts
@@ -89,6 +89,7 @@ export function taskToState(
       activeTaskId: task.id,
       activeSessionId: resolvedSessionId,
       pinnedSessionId: null,
+      lastSessionByTaskId: resolvedSessionId ? { [task.id]: resolvedSessionId } : {},
     },
     messages:
       resolvedSessionId && messages

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -13,6 +13,30 @@ import { applyLayoutFixups } from "./dockview-layout-builders";
 import { isLayoutShapeHealthy } from "./dockview-layout-health";
 import { fromDockviewApi, savedLayoutMatchesLive, layoutStructuresMatch } from "./layout-manager";
 import type { LayoutState, LayoutGroupIds } from "./layout-manager";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debug = createDebugLogger("dockview:env-switch");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function snapshotGridShape(node: any, depth = 0): unknown {
+  if (!node || depth > 6) return null;
+  if (node.type === "leaf") {
+    return {
+      type: "leaf",
+      groupId: node.data?.id,
+      activeView: node.data?.activeView,
+      views: node.data?.views,
+    };
+  }
+  if (node.type === "branch" && Array.isArray(node.data)) {
+    return {
+      type: "branch",
+      orientation: node.orientation,
+      children: node.data.map((c: unknown) => snapshotGridShape(c, depth + 1)),
+    };
+  }
+  return null;
+}
 
 const EPHEMERAL_COMPONENTS = new Set([
   "file-editor",
@@ -162,6 +186,11 @@ function removeStaleSessionPanels(api: DockviewApi, keepSessionId: string | null
   const toRemove = api.panels.filter(
     (p) => p.api.component === "chat" && p.id.startsWith("session:") && p.id !== keepId,
   );
+  debug("removeStaleSessionPanels", {
+    keepSessionId,
+    livePanelIds: api.panels.map((p) => p.id),
+    removingIds: toRemove.map((p) => p.id),
+  });
   for (const p of toRemove) {
     try {
       p.api.close();
@@ -208,8 +237,26 @@ function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
     structuresMatch = layoutStructuresMatch(currentLayout, getDefaultLayout());
   }
 
-  if (!structuresMatch) return null;
-  if (saved && savedLayoutHasEphemeralPanels(saved as SerializedDockview)) return null;
+  if (!structuresMatch) {
+    debug("tryFastEnvSwitch: structures do not match, falling back to slow path", {
+      newEnvId,
+      hasSaved: !!saved,
+      currentPanelIds: api.panels.map((p) => p.id),
+    });
+    return null;
+  }
+  if (saved && savedLayoutHasEphemeralPanels(saved as SerializedDockview)) {
+    debug("tryFastEnvSwitch: saved layout has ephemeral panels, falling back to slow path", {
+      newEnvId,
+    });
+    return null;
+  }
+  debug("tryFastEnvSwitch: taking fast path", {
+    newEnvId,
+    activeSessionId,
+    hasSaved: !!saved,
+    currentPanelIds: api.panels.map((p) => p.id),
+  });
 
   // Prefer the active session panel so multi-session tasks anchor the
   // incoming panel to the group the user was looking at, not whichever
@@ -281,14 +328,35 @@ function addIncomingSessionPanel(
  * env-scoped portals before calling this function.
  */
 export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
-  const { api, newEnvId, activeSessionId, safeWidth, safeHeight, buildDefault } = params;
+  const { api, oldEnvId, newEnvId, activeSessionId, safeWidth, safeHeight, buildDefault } = params;
+  debug("performEnvSwitch: entry", {
+    oldEnvId,
+    newEnvId,
+    activeSessionId,
+    livePanelIdsBefore: api.panels.map((p) => p.id),
+  });
 
   const fastResult = tryFastEnvSwitch(params);
-  if (fastResult) return fastResult;
+  if (fastResult) {
+    debug("performEnvSwitch: completed via fast path", {
+      newEnvId,
+      livePanelIdsAfter: api.panels.map((p) => p.id),
+    });
+    return fastResult;
+  }
 
   const saved = getHealthyEnvLayout(newEnvId);
   if (saved) {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const savedPanelIds = Object.keys((saved as any).panels ?? {});
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const savedShape = snapshotGridShape((saved as any).grid?.root);
+      debug("performEnvSwitch: slow path - calling api.fromJSON", {
+        newEnvId,
+        savedPanelIds,
+        savedShape,
+      });
       api.fromJSON(saved as SerializedDockview);
       // Saved layout may carry a stale session panel from a previously-deleted
       // task (phantom). Strip session panels that don't belong to the incoming
@@ -297,13 +365,23 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
       // useAutoSessionTab will add the current session's panel if missing.
       removeStaleSessionPanels(api, activeSessionId);
       api.layout(safeWidth, safeHeight);
+      debug("performEnvSwitch: completed via slow path (fromJSON)", {
+        newEnvId,
+        livePanelIdsAfter: api.panels.map((p) => p.id),
+      });
       return applyLayoutFixups(api);
     } catch (err) {
       console.warn("performEnvSwitch: fromJSON threw", err);
+      debug("performEnvSwitch: fromJSON threw, falling through to default", { newEnvId, err });
       /* fall through to default layout build */
     }
   }
+  debug("performEnvSwitch: building default layout", { newEnvId, hasSaved: !!saved });
   buildDefault(api);
   api.layout(safeWidth, safeHeight);
+  debug("performEnvSwitch: completed via default build", {
+    newEnvId,
+    livePanelIdsAfter: api.panels.map((p) => p.id),
+  });
   return applyLayoutFixups(api);
 }

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -13,7 +13,7 @@ import { applyLayoutFixups } from "./dockview-layout-builders";
 import { isLayoutShapeHealthy } from "./dockview-layout-health";
 import { fromDockviewApi, savedLayoutMatchesLive, layoutStructuresMatch } from "./layout-manager";
 import type { LayoutState, LayoutGroupIds } from "./layout-manager";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debug = createDebugLogger("dockview:env-switch");
 
@@ -186,11 +186,13 @@ function removeStaleSessionPanels(api: DockviewApi, keepSessionId: string | null
   const toRemove = api.panels.filter(
     (p) => p.api.component === "chat" && p.id.startsWith("session:") && p.id !== keepId,
   );
-  debug("removeStaleSessionPanels", {
-    keepSessionId,
-    livePanelIds: api.panels.map((p) => p.id),
-    removingIds: toRemove.map((p) => p.id),
-  });
+  if (IS_DEBUG) {
+    debug("removeStaleSessionPanels", {
+      keepSessionId,
+      livePanelIds: api.panels.map((p) => p.id),
+      removingIds: toRemove.map((p) => p.id),
+    });
+  }
   for (const p of toRemove) {
     try {
       p.api.close();
@@ -238,11 +240,13 @@ function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
   }
 
   if (!structuresMatch) {
-    debug("tryFastEnvSwitch: structures do not match, falling back to slow path", {
-      newEnvId,
-      hasSaved: !!saved,
-      currentPanelIds: api.panels.map((p) => p.id),
-    });
+    if (IS_DEBUG) {
+      debug("tryFastEnvSwitch: structures do not match, falling back to slow path", {
+        newEnvId,
+        hasSaved: !!saved,
+        currentPanelIds: api.panels.map((p) => p.id),
+      });
+    }
     return null;
   }
   if (saved && savedLayoutHasEphemeralPanels(saved as SerializedDockview)) {
@@ -251,12 +255,14 @@ function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
     });
     return null;
   }
-  debug("tryFastEnvSwitch: taking fast path", {
-    newEnvId,
-    activeSessionId,
-    hasSaved: !!saved,
-    currentPanelIds: api.panels.map((p) => p.id),
-  });
+  if (IS_DEBUG) {
+    debug("tryFastEnvSwitch: taking fast path", {
+      newEnvId,
+      activeSessionId,
+      hasSaved: !!saved,
+      currentPanelIds: api.panels.map((p) => p.id),
+    });
+  }
 
   // Prefer the active session panel so multi-session tasks anchor the
   // incoming panel to the group the user was looking at, not whichever
@@ -329,34 +335,40 @@ function addIncomingSessionPanel(
  */
 export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
   const { api, oldEnvId, newEnvId, activeSessionId, safeWidth, safeHeight, buildDefault } = params;
-  debug("performEnvSwitch: entry", {
-    oldEnvId,
-    newEnvId,
-    activeSessionId,
-    livePanelIdsBefore: api.panels.map((p) => p.id),
-  });
+  if (IS_DEBUG) {
+    debug("performEnvSwitch: entry", {
+      oldEnvId,
+      newEnvId,
+      activeSessionId,
+      livePanelIdsBefore: api.panels.map((p) => p.id),
+    });
+  }
 
   const fastResult = tryFastEnvSwitch(params);
   if (fastResult) {
-    debug("performEnvSwitch: completed via fast path", {
-      newEnvId,
-      livePanelIdsAfter: api.panels.map((p) => p.id),
-    });
+    if (IS_DEBUG) {
+      debug("performEnvSwitch: completed via fast path", {
+        newEnvId,
+        livePanelIdsAfter: api.panels.map((p) => p.id),
+      });
+    }
     return fastResult;
   }
 
   const saved = getHealthyEnvLayout(newEnvId);
   if (saved) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const savedPanelIds = Object.keys((saved as any).panels ?? {});
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const savedShape = snapshotGridShape((saved as any).grid?.root);
-      debug("performEnvSwitch: slow path - calling api.fromJSON", {
-        newEnvId,
-        savedPanelIds,
-        savedShape,
-      });
+      if (IS_DEBUG) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const savedPanelIds = Object.keys((saved as any).panels ?? {});
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const savedShape = snapshotGridShape((saved as any).grid?.root);
+        debug("performEnvSwitch: slow path - calling api.fromJSON", {
+          newEnvId,
+          savedPanelIds,
+          savedShape,
+        });
+      }
       api.fromJSON(saved as SerializedDockview);
       // Saved layout may carry a stale session panel from a previously-deleted
       // task (phantom). Strip session panels that don't belong to the incoming
@@ -365,10 +377,12 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
       // useAutoSessionTab will add the current session's panel if missing.
       removeStaleSessionPanels(api, activeSessionId);
       api.layout(safeWidth, safeHeight);
-      debug("performEnvSwitch: completed via slow path (fromJSON)", {
-        newEnvId,
-        livePanelIdsAfter: api.panels.map((p) => p.id),
-      });
+      if (IS_DEBUG) {
+        debug("performEnvSwitch: completed via slow path (fromJSON)", {
+          newEnvId,
+          livePanelIdsAfter: api.panels.map((p) => p.id),
+        });
+      }
       return applyLayoutFixups(api);
     } catch (err) {
       console.warn("performEnvSwitch: fromJSON threw", err);
@@ -379,9 +393,11 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
   debug("performEnvSwitch: building default layout", { newEnvId, hasSaved: !!saved });
   buildDefault(api);
   api.layout(safeWidth, safeHeight);
-  debug("performEnvSwitch: completed via default build", {
-    newEnvId,
-    livePanelIdsAfter: api.panels.map((p) => p.id),
-  });
+  if (IS_DEBUG) {
+    debug("performEnvSwitch: completed via default build", {
+      newEnvId,
+      livePanelIdsAfter: api.panels.map((p) => p.id),
+    });
+  }
   return applyLayoutFixups(api);
 }

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -41,6 +41,10 @@ import {
 import { preserveChatScrollDuringLayout } from "./dockview-scroll-preserve";
 import { measureDockviewContainer } from "./dockview-measure";
 import { panelPortalManager } from "@/lib/layout/panel-portal-manager";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debugSwitch = createDebugLogger("dockview:store-switch");
+const debugSave = createDebugLogger("dockview:save");
 
 const RIGHT_PANEL_IDS = new Set(["changes", "files", TERMINAL_DEFAULT_ID]);
 
@@ -469,7 +473,15 @@ function saveOutgoingEnv(
   preMaximizeLayout: LayoutState | null,
   pinnedWidths: Map<string, number>,
 ): void {
-  if (!oldEnvId) return;
+  if (!oldEnvId) {
+    debugSave("saveOutgoingEnv: skip (no oldEnvId)");
+    return;
+  }
+  debugSave("saveOutgoingEnv: entry", {
+    oldEnvId,
+    livePanelIds: api.panels.map((p) => p.id),
+    maximized: !!preMaximizeLayout,
+  });
   if (preMaximizeLayout) {
     // While maximized, `api.toJSON()` is the 2-column maximize overlay, NOT
     // the user's intended layout. Persist the pre-max layout under both keys:
@@ -513,10 +525,24 @@ function saveOutgoingEnv(
 function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
   return (oldEnvId: string | null, newEnvId: string, activeSessionId: string | null) => {
     const { api, currentLayoutEnvId, preMaximizeLayout } = get();
-    if (!api) return;
+    if (!api) {
+      debugSwitch("envSwitch: skip (no api)", { oldEnvId, newEnvId, activeSessionId });
+      return;
+    }
+    debugSwitch("envSwitch: entry", {
+      oldEnvId,
+      newEnvId,
+      activeSessionId,
+      currentLayoutEnvId,
+      maximized: !!preMaximizeLayout,
+      livePanelIds: api.panels.map((p) => p.id),
+    });
     // Same-env switch (e.g. between sessions of the same task) is a no-op.
     // The layout, terminals, and env-scoped portals already belong to this env.
-    if (currentLayoutEnvId === newEnvId) return;
+    if (currentLayoutEnvId === newEnvId) {
+      debugSwitch("envSwitch: skip (same env)", { newEnvId });
+      return;
+    }
     // First adoption — onReady already built the layout; just adopt it.
     if (!oldEnvId && !currentLayoutEnvId) {
       set({ isRestoringLayout: true, currentLayoutEnvId: newEnvId });

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -41,7 +41,7 @@ import {
 import { preserveChatScrollDuringLayout } from "./dockview-scroll-preserve";
 import { measureDockviewContainer } from "./dockview-measure";
 import { panelPortalManager } from "@/lib/layout/panel-portal-manager";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debugSwitch = createDebugLogger("dockview:store-switch");
 const debugSave = createDebugLogger("dockview:save");
@@ -477,11 +477,13 @@ function saveOutgoingEnv(
     debugSave("saveOutgoingEnv: skip (no oldEnvId)");
     return;
   }
-  debugSave("saveOutgoingEnv: entry", {
-    oldEnvId,
-    livePanelIds: api.panels.map((p) => p.id),
-    maximized: !!preMaximizeLayout,
-  });
+  if (IS_DEBUG) {
+    debugSave("saveOutgoingEnv: entry", {
+      oldEnvId,
+      livePanelIds: api.panels.map((p) => p.id),
+      maximized: !!preMaximizeLayout,
+    });
+  }
   if (preMaximizeLayout) {
     // While maximized, `api.toJSON()` is the 2-column maximize overlay, NOT
     // the user's intended layout. Persist the pre-max layout under both keys:
@@ -529,14 +531,16 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
       debugSwitch("envSwitch: skip (no api)", { oldEnvId, newEnvId, activeSessionId });
       return;
     }
-    debugSwitch("envSwitch: entry", {
-      oldEnvId,
-      newEnvId,
-      activeSessionId,
-      currentLayoutEnvId,
-      maximized: !!preMaximizeLayout,
-      livePanelIds: api.panels.map((p) => p.id),
-    });
+    if (IS_DEBUG) {
+      debugSwitch("envSwitch: entry", {
+        oldEnvId,
+        newEnvId,
+        activeSessionId,
+        currentLayoutEnvId,
+        maximized: !!preMaximizeLayout,
+        livePanelIds: api.panels.map((p) => p.id),
+      });
+    }
     // Same-env switch (e.g. between sessions of the same task) is a no-op.
     // The layout, terminals, and env-scoped portals already belong to this env.
     if (currentLayoutEnvId === newEnvId) {

--- a/apps/web/lib/state/slices/kanban/kanban-slice.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.ts
@@ -5,7 +5,12 @@ export const defaultKanbanState: KanbanSliceState = {
   kanban: { workflowId: null, steps: [], tasks: [] },
   kanbanMulti: { snapshots: {}, isLoading: false },
   workflows: { items: [], activeId: null },
-  tasks: { activeTaskId: null, activeSessionId: null, pinnedSessionId: null },
+  tasks: {
+    activeTaskId: null,
+    activeSessionId: null,
+    pinnedSessionId: null,
+    lastSessionByTaskId: {},
+  },
 };
 
 export const createKanbanSlice: StateCreator<
@@ -49,12 +54,14 @@ export const createKanbanSlice: StateCreator<
       draft.tasks.activeSessionId = sessionId;
       // User-initiated selection: pin so WS auto-replace handoff respects it.
       draft.tasks.pinnedSessionId = sessionId;
+      draft.tasks.lastSessionByTaskId[taskId] = sessionId;
     }),
   setActiveSessionAuto: (taskId, sessionId) =>
     set((draft) => {
       draft.tasks.activeTaskId = taskId;
       draft.tasks.activeSessionId = sessionId;
       // Auto-driven (WS) selection: don't touch pinnedSessionId.
+      draft.tasks.lastSessionByTaskId[taskId] = sessionId;
     }),
   clearActiveSession: () =>
     set((draft) => {

--- a/apps/web/lib/state/slices/kanban/types.ts
+++ b/apps/web/lib/state/slices/kanban/types.ts
@@ -107,6 +107,11 @@ export type TaskState = {
   // pinnedSessionId alone — and skip auto-replace when the terminating session
   // matches the pin (the user wants to stay even though the workflow moved on).
   pinnedSessionId: string | null;
+  // lastSessionByTaskId remembers the most-recent active session for each task.
+  // Unlike pinnedSessionId (single global slot, cleared on task change), this
+  // map survives task switches so navigating back to a task can restore the
+  // user's last-selected session instead of always jumping to primary.
+  lastSessionByTaskId: Record<string, string>;
 };
 
 export type KanbanSliceState = {

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -6,7 +6,7 @@ import type {
   GitStatusEntry,
   FileInfo,
 } from "./types";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debugGit = createDebugLogger("git-status:store");
 
@@ -293,7 +293,7 @@ export const createSessionRuntimeSlice: StateCreator<
       // empty key so consumers using only byEnvironmentRepo still see it.
       const repoName = gitStatus.repository_name ?? "";
       const existing = draft.gitStatus.byEnvironmentId[envKey];
-      if (process.env.NODE_ENV !== "production") {
+      if (IS_DEBUG) {
         debugGit("setGitStatus", {
           sessionId,
           envKey,

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -6,6 +6,9 @@ import type {
   GitStatusEntry,
   FileInfo,
 } from "./types";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debugGit = createDebugLogger("git-status:store");
 
 const maxProcessOutputBytes = 2 * 1024 * 1024;
 
@@ -290,6 +293,18 @@ export const createSessionRuntimeSlice: StateCreator<
       // empty key so consumers using only byEnvironmentRepo still see it.
       const repoName = gitStatus.repository_name ?? "";
       const existing = draft.gitStatus.byEnvironmentId[envKey];
+      const prevFileCount = Object.keys(existing?.files ?? {}).length;
+      const nextFileCount = Object.keys(gitStatus.files ?? {}).length;
+      debugGit("setGitStatus", {
+        sessionId,
+        envKey,
+        usingFallbackKey: envKey === sessionId,
+        repoName,
+        prevFileCount,
+        nextFileCount,
+        prevRepoKeys: Object.keys(draft.gitStatus.byEnvironmentRepo[envKey] ?? {}),
+        willOverwriteByEnv: !existing || hasGitStatusChanged(existing, gitStatus),
+      });
       if (!existing || hasGitStatusChanged(existing, gitStatus)) {
         draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
       }

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -293,18 +293,18 @@ export const createSessionRuntimeSlice: StateCreator<
       // empty key so consumers using only byEnvironmentRepo still see it.
       const repoName = gitStatus.repository_name ?? "";
       const existing = draft.gitStatus.byEnvironmentId[envKey];
-      const prevFileCount = Object.keys(existing?.files ?? {}).length;
-      const nextFileCount = Object.keys(gitStatus.files ?? {}).length;
-      debugGit("setGitStatus", {
-        sessionId,
-        envKey,
-        usingFallbackKey: envKey === sessionId,
-        repoName,
-        prevFileCount,
-        nextFileCount,
-        prevRepoKeys: Object.keys(draft.gitStatus.byEnvironmentRepo[envKey] ?? {}),
-        willOverwriteByEnv: !existing || hasGitStatusChanged(existing, gitStatus),
-      });
+      if (process.env.NODE_ENV !== "production") {
+        debugGit("setGitStatus", {
+          sessionId,
+          envKey,
+          usingFallbackKey: envKey === sessionId,
+          repoName,
+          prevFileCount: Object.keys(existing?.files ?? {}).length,
+          nextFileCount: Object.keys(gitStatus.files ?? {}).length,
+          prevRepoKeys: Object.keys(draft.gitStatus.byEnvironmentRepo[envKey] ?? {}),
+          willOverwriteByEnv: !existing || hasGitStatusChanged(existing, gitStatus),
+        });
+      }
       if (!existing || hasGitStatusChanged(existing, gitStatus)) {
         draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
       }

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -47,18 +47,20 @@ function mergeMessageFields(target: Record<string, unknown>, source: Record<stri
 function syncEnvironmentMapping(draft: any, sessionId: string, environmentId: string | undefined) {
   if (!environmentId) return;
   const previous = draft.environmentIdBySessionId[sessionId];
-  debugEnv("syncEnvironmentMapping", {
-    sessionId,
-    environmentId,
-    previous: previous ?? null,
-    changed: previous !== environmentId,
-    fallbackGitStatusFileCount: Object.keys(
-      draft.gitStatus?.byEnvironmentId?.[sessionId]?.files ?? {},
-    ).length,
-    targetGitStatusFileCount: Object.keys(
-      draft.gitStatus?.byEnvironmentId?.[environmentId]?.files ?? {},
-    ).length,
-  });
+  if (process.env.NODE_ENV !== "production") {
+    debugEnv("syncEnvironmentMapping", {
+      sessionId,
+      environmentId,
+      previous: previous ?? null,
+      changed: previous !== environmentId,
+      fallbackGitStatusFileCount: Object.keys(
+        draft.gitStatus?.byEnvironmentId?.[sessionId]?.files ?? {},
+      ).length,
+      targetGitStatusFileCount: Object.keys(
+        draft.gitStatus?.byEnvironmentId?.[environmentId]?.files ?? {},
+      ).length,
+    });
+  }
   draft.environmentIdBySessionId[sessionId] = environmentId;
   migrateEnvKeyedData(draft, sessionId, environmentId);
 }

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -2,7 +2,7 @@ import type { StateCreator } from "zustand";
 import type { TaskSession } from "@/lib/types/http";
 import type { SessionSlice, SessionSliceState } from "./types";
 import { migrateEnvKeyedData } from "@/lib/state/slices/session-runtime/session-runtime-slice";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debugEnv = createDebugLogger("session:env-mapping");
 
@@ -47,7 +47,7 @@ function mergeMessageFields(target: Record<string, unknown>, source: Record<stri
 function syncEnvironmentMapping(draft: any, sessionId: string, environmentId: string | undefined) {
   if (!environmentId) return;
   const previous = draft.environmentIdBySessionId[sessionId];
-  if (process.env.NODE_ENV !== "production") {
+  if (IS_DEBUG) {
     debugEnv("syncEnvironmentMapping", {
       sessionId,
       environmentId,

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -2,6 +2,9 @@ import type { StateCreator } from "zustand";
 import type { TaskSession } from "@/lib/types/http";
 import type { SessionSlice, SessionSliceState } from "./types";
 import { migrateEnvKeyedData } from "@/lib/state/slices/session-runtime/session-runtime-slice";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debugEnv = createDebugLogger("session:env-mapping");
 
 /** Ensure message metadata exists for a session, initializing with defaults if needed. */
 function ensureMessageMeta(
@@ -43,6 +46,19 @@ function mergeMessageFields(target: Record<string, unknown>, source: Record<stri
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function syncEnvironmentMapping(draft: any, sessionId: string, environmentId: string | undefined) {
   if (!environmentId) return;
+  const previous = draft.environmentIdBySessionId[sessionId];
+  debugEnv("syncEnvironmentMapping", {
+    sessionId,
+    environmentId,
+    previous: previous ?? null,
+    changed: previous !== environmentId,
+    fallbackGitStatusFileCount: Object.keys(
+      draft.gitStatus?.byEnvironmentId?.[sessionId]?.files ?? {},
+    ).length,
+    targetGitStatusFileCount: Object.keys(
+      draft.gitStatus?.byEnvironmentId?.[environmentId]?.files ?? {},
+    ).length,
+  });
   draft.environmentIdBySessionId[sessionId] = environmentId;
   migrateEnvKeyedData(draft, sessionId, environmentId);
 }

--- a/apps/web/lib/ws/handlers/agent-session-pure.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session-pure.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  isTerminalSessionState,
+  pickReplacementSessionId,
+  shouldAdoptNewSession,
+} from "./agent-session";
+import type { AppState } from "@/lib/state/store";
+import type { TaskSessionState } from "@/lib/types/http";
+
+function makeAppState(partial: Partial<AppState>): AppState {
+  return {
+    tasks: {
+      activeTaskId: null,
+      activeSessionId: null,
+      pinnedSessionId: null,
+      lastSessionByTaskId: {},
+    },
+    taskSessions: { items: {} },
+    taskSessionsByTask: { itemsByTaskId: {} },
+    ...partial,
+  } as unknown as AppState;
+}
+
+describe("isTerminalSessionState", () => {
+  it.each<[TaskSessionState | undefined, boolean]>([
+    ["COMPLETED", true],
+    ["FAILED", true],
+    ["CANCELLED", true],
+    ["RUNNING", false],
+    ["STARTING", false],
+    ["CREATED", false],
+    ["WAITING_FOR_INPUT", false],
+    [undefined, false],
+  ])("returns %o → %s", (input, expected) => {
+    expect(isTerminalSessionState(input)).toBe(expected);
+  });
+});
+
+describe("shouldAdoptNewSession", () => {
+  it("adopts when there is no active session for the task", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: null,
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
+    });
+    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(true);
+  });
+
+  it("adopts when active session belongs to a different task", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-other",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: { "s-other": { id: "s-other", task_id: "t-2", state: "RUNNING" } },
+      } as unknown as AppState["taskSessions"],
+    });
+    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(true);
+  });
+
+  it("adopts when active session is already terminal", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: { "s-old": { id: "s-old", task_id: "t-1", state: "COMPLETED" } },
+      } as unknown as AppState["taskSessions"],
+    });
+    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(true);
+  });
+
+  it("does NOT adopt while the current active session is still running", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
+      } as unknown as AppState["taskSessions"],
+    });
+    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(false);
+  });
+
+  it("does NOT adopt when the event is for a non-active task", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: null,
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
+    });
+    expect(shouldAdoptNewSession(state, "t-2", "STARTING")).toBe(false);
+  });
+
+  it("does NOT adopt terminal state events", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: null,
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
+    });
+    expect(shouldAdoptNewSession(state, "t-1", "COMPLETED")).toBe(false);
+  });
+});
+
+describe("pickReplacementSessionId", () => {
+  it("returns the newest non-terminal session in the per-task list", () => {
+    const state = makeAppState({
+      taskSessionsByTask: {
+        itemsByTaskId: {
+          "t-1": [
+            { id: "s-1", task_id: "t-1", state: "COMPLETED", started_at: "", updated_at: "" },
+            { id: "s-2", task_id: "t-1", state: "RUNNING", started_at: "", updated_at: "" },
+            { id: "s-3", task_id: "t-1", state: "CANCELLED", started_at: "", updated_at: "" },
+          ],
+        },
+      } as unknown as AppState["taskSessionsByTask"],
+    });
+    expect(pickReplacementSessionId(state, "t-1")).toBe("s-2");
+  });
+
+  it("returns null when all sessions are terminal", () => {
+    const state = makeAppState({
+      taskSessionsByTask: {
+        itemsByTaskId: {
+          "t-1": [
+            { id: "s-1", task_id: "t-1", state: "COMPLETED", started_at: "", updated_at: "" },
+            { id: "s-2", task_id: "t-1", state: "FAILED", started_at: "", updated_at: "" },
+          ],
+        },
+      } as unknown as AppState["taskSessionsByTask"],
+    });
+    expect(pickReplacementSessionId(state, "t-1")).toBeNull();
+  });
+
+  it("returns null when the task has no sessions tracked", () => {
+    expect(pickReplacementSessionId(makeAppState({}), "t-missing")).toBeNull();
+  });
+});

--- a/apps/web/lib/ws/handlers/agent-session.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import {
-  isTerminalSessionState,
-  pickReplacementSessionId,
-  registerTaskSessionHandlers,
-  shouldAdoptNewSession,
-} from "./agent-session";
+import { registerTaskSessionHandlers } from "./agent-session";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
-import type { TaskSessionState } from "@/lib/types/http";
 
 function makeStore(overrides: Record<string, unknown> = {}) {
   const state: Record<string, unknown> = {
-    tasks: { activeTaskId: null, activeSessionId: null, pinnedSessionId: null },
+    tasks: {
+      activeTaskId: null,
+      activeSessionId: null,
+      pinnedSessionId: null,
+      lastSessionByTaskId: {},
+    },
     taskSessions: { items: {} },
     taskSessionsByTask: { itemsByTaskId: {} },
     setTaskSession: vi.fn(),
@@ -132,118 +131,6 @@ describe("session.state_changed handler", () => {
   });
 });
 
-function makeAppState(partial: Partial<AppState>): AppState {
-  return {
-    tasks: { activeTaskId: null, activeSessionId: null, pinnedSessionId: null },
-    taskSessions: { items: {} },
-    taskSessionsByTask: { itemsByTaskId: {} },
-    ...partial,
-  } as unknown as AppState;
-}
-
-describe("isTerminalSessionState", () => {
-  it.each<[TaskSessionState | undefined, boolean]>([
-    ["COMPLETED", true],
-    ["FAILED", true],
-    ["CANCELLED", true],
-    ["RUNNING", false],
-    ["STARTING", false],
-    ["CREATED", false],
-    ["WAITING_FOR_INPUT", false],
-    [undefined, false],
-  ])("returns %o → %s", (input, expected) => {
-    expect(isTerminalSessionState(input)).toBe(expected);
-  });
-});
-
-describe("shouldAdoptNewSession", () => {
-  it("adopts when there is no active session for the task", () => {
-    const state = makeAppState({
-      tasks: { activeTaskId: "t-1", activeSessionId: null, pinnedSessionId: null },
-    });
-    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(true);
-  });
-
-  it("adopts when active session belongs to a different task", () => {
-    const state = makeAppState({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-other", pinnedSessionId: null },
-      taskSessions: {
-        items: { "s-other": { id: "s-other", task_id: "t-2", state: "RUNNING" } },
-      } as unknown as AppState["taskSessions"],
-    });
-    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(true);
-  });
-
-  it("adopts when active session is already terminal", () => {
-    const state = makeAppState({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: null },
-      taskSessions: {
-        items: { "s-old": { id: "s-old", task_id: "t-1", state: "COMPLETED" } },
-      } as unknown as AppState["taskSessions"],
-    });
-    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(true);
-  });
-
-  it("does NOT adopt while the current active session is still running", () => {
-    const state = makeAppState({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: null },
-      taskSessions: {
-        items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
-      } as unknown as AppState["taskSessions"],
-    });
-    expect(shouldAdoptNewSession(state, "t-1", "STARTING")).toBe(false);
-  });
-
-  it("does NOT adopt when the event is for a non-active task", () => {
-    const state = makeAppState({
-      tasks: { activeTaskId: "t-1", activeSessionId: null, pinnedSessionId: null },
-    });
-    expect(shouldAdoptNewSession(state, "t-2", "STARTING")).toBe(false);
-  });
-
-  it("does NOT adopt terminal state events", () => {
-    const state = makeAppState({
-      tasks: { activeTaskId: "t-1", activeSessionId: null, pinnedSessionId: null },
-    });
-    expect(shouldAdoptNewSession(state, "t-1", "COMPLETED")).toBe(false);
-  });
-});
-
-describe("pickReplacementSessionId", () => {
-  it("returns the newest non-terminal session in the per-task list", () => {
-    const state = makeAppState({
-      taskSessionsByTask: {
-        itemsByTaskId: {
-          "t-1": [
-            { id: "s-1", task_id: "t-1", state: "COMPLETED", started_at: "", updated_at: "" },
-            { id: "s-2", task_id: "t-1", state: "RUNNING", started_at: "", updated_at: "" },
-            { id: "s-3", task_id: "t-1", state: "CANCELLED", started_at: "", updated_at: "" },
-          ],
-        },
-      } as unknown as AppState["taskSessionsByTask"],
-    });
-    expect(pickReplacementSessionId(state, "t-1")).toBe("s-2");
-  });
-
-  it("returns null when all sessions are terminal", () => {
-    const state = makeAppState({
-      taskSessionsByTask: {
-        itemsByTaskId: {
-          "t-1": [
-            { id: "s-1", task_id: "t-1", state: "COMPLETED", started_at: "", updated_at: "" },
-            { id: "s-2", task_id: "t-1", state: "FAILED", started_at: "", updated_at: "" },
-          ],
-        },
-      } as unknown as AppState["taskSessionsByTask"],
-    });
-    expect(pickReplacementSessionId(state, "t-1")).toBeNull();
-  });
-
-  it("returns null when the task has no sessions tracked", () => {
-    expect(pickReplacementSessionId(makeAppState({}), "t-missing")).toBeNull();
-  });
-});
-
 describe("session.state_changed → active session switching", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -251,7 +138,12 @@ describe("session.state_changed → active session switching", () => {
 
   it("adopts a newly-created session for the active task", () => {
     const store = makeStore({
-      tasks: { activeTaskId: "t-1", activeSessionId: null, pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: null,
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
     });
     const handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
 
@@ -268,7 +160,12 @@ describe("session.state_changed → active session switching", () => {
 
   it("does not adopt a new session for a task that is not active", () => {
     const store = makeStore({
-      tasks: { activeTaskId: "other-task", activeSessionId: null, pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "other-task",
+        activeSessionId: null,
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
     });
     const handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
 
@@ -284,7 +181,12 @@ describe("session.state_changed → active session switching", () => {
 
   it("does not adopt while the current active session is still running", () => {
     const store = makeStore({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
       taskSessions: {
         items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
       },
@@ -310,7 +212,12 @@ describe("session.state_changed → active session switching", () => {
   // this path too.
   it("does not yank a pinned session on reverse event ordering (old COMPLETED, then new STARTING)", () => {
     const store = makeStore({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: "s-old" },
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: "s-old",
+        lastSessionByTaskId: {},
+      },
       taskSessions: {
         items: { "s-old": { id: "s-old", task_id: "t-1", state: "COMPLETED" } },
       },
@@ -335,7 +242,12 @@ describe("session.state_changed → active session handoff on terminal", () => {
 
   it("hands off when the current active session transitions to terminal", () => {
     const store = makeStore({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
       taskSessions: {
         items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
       },
@@ -367,7 +279,12 @@ describe("session.state_changed → active session handoff on terminal", () => {
   // to the same session that just became terminal.
   it("does not hand off when the only candidate is the terminating session itself", () => {
     const store = makeStore({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
       taskSessions: {
         items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
       },
@@ -393,7 +310,12 @@ describe("session.state_changed → active session handoff on terminal", () => {
 
   it("does not hand off when all other sessions for the task are terminal", () => {
     const store = makeStore({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
       taskSessions: {
         items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
       },
@@ -428,7 +350,12 @@ describe("session.state_changed → respects user-pinned session", () => {
     // User manually clicked s-old, so pinnedSessionId === "s-old".
     // When s-old terminates we should respect the pin and stay on it.
     const store = makeStore({
-      tasks: { activeTaskId: "t-1", activeSessionId: "s-old", pinnedSessionId: "s-old" },
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: "s-old",
+        lastSessionByTaskId: {},
+      },
       taskSessions: {
         items: { "s-old": { id: "s-old", task_id: "t-1", state: "RUNNING" } },
       },

--- a/apps/web/lib/ws/handlers/git-status.ts
+++ b/apps/web/lib/ws/handlers/git-status.ts
@@ -9,6 +9,9 @@ import type {
   GitBranchSwitchedEvent,
 } from "@/lib/types/git-events";
 import { invalidateCumulativeDiffCache } from "@/hooks/domains/session/use-cumulative-diff";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debug = createDebugLogger("git-status:ws");
 
 // Handler functions for each event type
 type GitEventHandlers = {
@@ -25,6 +28,20 @@ function resolveEnvKey(store: StoreApi<AppState>, sessionId: string): string {
 
 const gitEventHandlers: GitEventHandlers = {
   status_update: (store, event) => {
+    debug("status_update", {
+      sessionId: event.session_id,
+      repositoryName: event.status.repository_name ?? null,
+      branch: event.status.branch,
+      fileCount: Object.keys(event.status.files ?? {}).length,
+      modified: event.status.modified?.length ?? 0,
+      added: event.status.added?.length ?? 0,
+      deleted: event.status.deleted?.length ?? 0,
+      untracked: event.status.untracked?.length ?? 0,
+      ahead: event.status.ahead,
+      behind: event.status.behind,
+      envKey: resolveEnvKey(store, event.session_id),
+      envMapped: event.session_id in store.getState().environmentIdBySessionId,
+    });
     store.getState().setGitStatus(event.session_id, {
       branch: event.status.branch,
       remote_branch: event.status.remote_branch,

--- a/apps/web/lib/ws/handlers/git-status.ts
+++ b/apps/web/lib/ws/handlers/git-status.ts
@@ -28,20 +28,22 @@ function resolveEnvKey(store: StoreApi<AppState>, sessionId: string): string {
 
 const gitEventHandlers: GitEventHandlers = {
   status_update: (store, event) => {
-    debug("status_update", {
-      sessionId: event.session_id,
-      repositoryName: event.status.repository_name ?? null,
-      branch: event.status.branch,
-      fileCount: Object.keys(event.status.files ?? {}).length,
-      modified: event.status.modified?.length ?? 0,
-      added: event.status.added?.length ?? 0,
-      deleted: event.status.deleted?.length ?? 0,
-      untracked: event.status.untracked?.length ?? 0,
-      ahead: event.status.ahead,
-      behind: event.status.behind,
-      envKey: resolveEnvKey(store, event.session_id),
-      envMapped: event.session_id in store.getState().environmentIdBySessionId,
-    });
+    if (process.env.NODE_ENV !== "production") {
+      debug("status_update", {
+        sessionId: event.session_id,
+        repositoryName: event.status.repository_name ?? null,
+        branch: event.status.branch,
+        fileCount: Object.keys(event.status.files ?? {}).length,
+        modified: event.status.modified?.length ?? 0,
+        added: event.status.added?.length ?? 0,
+        deleted: event.status.deleted?.length ?? 0,
+        untracked: event.status.untracked?.length ?? 0,
+        ahead: event.status.ahead,
+        behind: event.status.behind,
+        envKey: resolveEnvKey(store, event.session_id),
+        envMapped: event.session_id in store.getState().environmentIdBySessionId,
+      });
+    }
     store.getState().setGitStatus(event.session_id, {
       branch: event.status.branch,
       remote_branch: event.status.remote_branch,

--- a/apps/web/lib/ws/handlers/git-status.ts
+++ b/apps/web/lib/ws/handlers/git-status.ts
@@ -9,7 +9,7 @@ import type {
   GitBranchSwitchedEvent,
 } from "@/lib/types/git-events";
 import { invalidateCumulativeDiffCache } from "@/hooks/domains/session/use-cumulative-diff";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debug = createDebugLogger("git-status:ws");
 
@@ -28,7 +28,7 @@ function resolveEnvKey(store: StoreApi<AppState>, sessionId: string): string {
 
 const gitEventHandlers: GitEventHandlers = {
   status_update: (store, event) => {
-    if (process.env.NODE_ENV !== "production") {
+    if (IS_DEBUG) {
       debug("status_update", {
         sessionId: event.session_id,
         repositoryName: event.status.repository_name ?? null,

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -8,6 +8,8 @@ vi.mock("@/lib/recent-tasks", () => ({
   removeRecentTask: vi.fn(),
 }));
 
+const SESS_OTHER = "sess-other";
+
 type Listener = (state: AppState) => void;
 
 /**
@@ -19,7 +21,12 @@ function makeStore(initial: Partial<AppState> = {}) {
   let state = {
     kanban: { workflowId: "wf1", steps: [], tasks: [] },
     kanbanMulti: { snapshots: {}, isLoading: false },
-    tasks: { activeTaskId: null, activeSessionId: null, pinnedSessionId: null },
+    tasks: {
+      activeTaskId: null,
+      activeSessionId: null,
+      pinnedSessionId: null,
+      lastSessionByTaskId: {},
+    },
     taskSessionsByTask: { itemsByTaskId: {}, loadedByTaskId: {}, loadingByTaskId: {} },
     environmentIdBySessionId: {},
     setActiveSession: vi.fn((taskId: string, sessionId: string | null) => {
@@ -29,6 +36,9 @@ function makeStore(initial: Partial<AppState> = {}) {
           activeTaskId: taskId,
           activeSessionId: sessionId,
           pinnedSessionId: sessionId,
+          lastSessionByTaskId: sessionId
+            ? { ...state.tasks.lastSessionByTaskId, [taskId]: sessionId }
+            : state.tasks.lastSessionByTaskId,
         },
       };
     }),
@@ -111,7 +121,12 @@ describe("task.updated primary-session focus follow", () => {
         steps: [],
         tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
       } as unknown as AppState["kanban"],
-      tasks: { activeTaskId: "t1", activeSessionId: "sess-old", pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t1",
+        activeSessionId: "sess-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
       setActiveSessionAuto,
     });
 
@@ -130,7 +145,12 @@ describe("task.updated primary-session focus follow", () => {
         steps: [],
         tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
       } as unknown as AppState["kanban"],
-      tasks: { activeTaskId: "t1", activeSessionId: "sess-other", pinnedSessionId: "sess-other" },
+      tasks: {
+        activeTaskId: "t1",
+        activeSessionId: SESS_OTHER,
+        pinnedSessionId: SESS_OTHER,
+        lastSessionByTaskId: {},
+      },
       setActiveSessionAuto,
     });
 
@@ -147,7 +167,12 @@ describe("task.updated primary-session focus follow", () => {
         steps: [],
         tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
       } as unknown as AppState["kanban"],
-      tasks: { activeTaskId: "t2", activeSessionId: "sess-old", pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t2",
+        activeSessionId: "sess-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
       setActiveSessionAuto,
     });
 
@@ -164,7 +189,12 @@ describe("task.updated primary-session focus follow", () => {
         steps: [],
         tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
       } as unknown as AppState["kanban"],
-      tasks: { activeTaskId: "t1", activeSessionId: "sess-old", pinnedSessionId: null },
+      tasks: {
+        activeTaskId: "t1",
+        activeSessionId: "sess-old",
+        pinnedSessionId: null,
+        lastSessionByTaskId: {},
+      },
       setActiveSessionAuto,
     });
 
@@ -173,11 +203,21 @@ describe("task.updated primary-session focus follow", () => {
 
     expect(setActiveSessionAuto).not.toHaveBeenCalled();
   });
+});
 
-  // Regression: even when the user happens to be sitting on the previous
-  // primary, an explicit pin on it must override primary-follow-focus —
-  // otherwise a workflow profile switch silently yanks them off the session
-  // they deliberately clicked into.
+// Regression: even when the user happens to be sitting on the previous
+// primary, an explicit pin on it must override primary-follow-focus —
+// otherwise a workflow profile switch silently yanks them off the session
+// they deliberately clicked into.
+describe("task.updated primary-session focus follow (pinning)", () => {
+  let store: ReturnType<typeof makeStore>;
+  let setActiveSessionAuto: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActiveSessionAuto = vi.fn();
+    vi.mocked(removeRecentTask).mockClear();
+  });
+
   it("does NOT follow focus when the user has pinned the previous primary", () => {
     store = makeStore({
       kanban: {
@@ -185,7 +225,12 @@ describe("task.updated primary-session focus follow", () => {
         steps: [],
         tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
       } as unknown as AppState["kanban"],
-      tasks: { activeTaskId: "t1", activeSessionId: "sess-old", pinnedSessionId: "sess-old" },
+      tasks: {
+        activeTaskId: "t1",
+        activeSessionId: "sess-old",
+        pinnedSessionId: "sess-old",
+        lastSessionByTaskId: {},
+      },
       setActiveSessionAuto,
     });
 
@@ -249,5 +294,29 @@ describe("task.deleted cleanup", () => {
 
     expect(removeRecentTask).toHaveBeenCalledTimes(1);
     expect(removeRecentTask).toHaveBeenCalledWith("t1");
+  });
+
+  it("removes the deleted task from lastSessionByTaskId", () => {
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [{ id: "t1", primarySessionId: "sess-old", workflowId: "wf1" }],
+      } as unknown as AppState["kanban"],
+      tasks: {
+        activeTaskId: null,
+        activeSessionId: null,
+        pinnedSessionId: null,
+        lastSessionByTaskId: { t1: "sess-old", t2: SESS_OTHER },
+      },
+      environmentIdBySessionId: {},
+    });
+
+    const handlers = registerTasksHandlers(store);
+    handlers["task.deleted"]!(makeDeletedMessage({ task_id: "t1", workflow_id: "wf1" }));
+
+    const state = store.getState();
+    expect(state.tasks.lastSessionByTaskId).not.toHaveProperty("t1");
+    expect(state.tasks.lastSessionByTaskId).toHaveProperty("t2", SESS_OTHER);
   });
 });

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -197,6 +197,10 @@ export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
         if (isActive) {
           next = { ...next, tasks: { ...next.tasks, activeTaskId: null, activeSessionId: null } };
         }
+        if (next.tasks.lastSessionByTaskId[deletedId]) {
+          const { [deletedId]: _, ...rest } = next.tasks.lastSessionByTaskId;
+          next = { ...next, tasks: { ...next.tasks, lastSessionByTaskId: rest } };
+        }
         return next;
       });
     },

--- a/apps/web/lib/ws/use-websocket.tsx
+++ b/apps/web/lib/ws/use-websocket.tsx
@@ -6,15 +6,20 @@ import { WebSocketClient } from "@/lib/ws/client";
 import { registerWsHandlers } from "@/lib/ws/router";
 import type { AppState } from "@/lib/state/store";
 import { setWebSocketClient } from "@/lib/ws/connection";
+import { createDebugLogger } from "@/lib/debug/log";
+
+const debug = createDebugLogger("ws:connection");
 
 export function useWebSocket(store: StoreApi<AppState>, url: string) {
   const clientRef = useRef<WebSocketClient | null>(null);
 
   useEffect(() => {
+    debug("WS hook mounting", { url });
     const client = new WebSocketClient(
       url,
       (status) => {
         const setConnectionStatus = store.getState().setConnectionStatus;
+        debug("status transition", { status, timestamp: new Date().toISOString() });
         // WS client and ConnectionState share one ConnectionStatus vocabulary,
         // so this is a 1:1 forward with an `error` message attached and a
         // `subscribeUser()` side-effect on first connect.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,16 +5,18 @@ High-level direction for the project. This is not a commitment - priorities shif
 ## Now
 
 - Stability and bug fixes across all agent integrations - current primary focus
-
-## Next
-
-- Multi-repo task support - a single task can span multiple repositories
-- Coordinator mode - have an agent coordinate sub-tasks executed by other agents
 - Improved mobile UI - polish the existing mobile view for orchestrating and reviewing from your phone
+- Office mode - new scheduler, routines, agents with skills, cost tracking
+- Remote SSH runtime - run agents on remote servers over SSH
+- GitLab integration - import issues, manage repos, trigger pipelines
 
 ## Later
 
-- Issue tracker integration - import issues from GitHub, Linear, and Jira as tasks
-- Remote SSH runtime - run agents on remote servers over SSH
 - Kubernetes operator - auto-scaling agent workloads in a cluster
 - Analytics dashboard - agent performance, cost tracking, success rates
+
+## Done
+
+- Multi-repo task support - a single task can span multiple repositories
+- Coordinator mode - have an agent coordinate sub-tasks executed by other agents
+- Issue tracker integration - import issues from GitHub, Linear, and Jira as tasks


### PR DESCRIPTION
Three recurring issues were hard to debug without visibility into the
frontend data pipeline. This PR adds a zero-cost logfmt debug logger
(dead-code-eliminated in production by Next.js) and instruments every
relevant decision point so the next occurrence leaves a clear trace in
the browser console.

## Important Changes

- **`lib/debug/log.ts`** — new `createDebugLogger(namespace)` factory;
  returns a no-op in production, logfmt `key=value` output in dev
- **git-status pipeline** — WS handler, store keying (env-id vs
  session-id fallback), env-id mapping registration, and aggregation
  path selection are all logged so the Changes-panel stale-file bug
  can be traced end-to-end
- **dockview env-switch** — save, fast/slow-path decision, `fromJSON`,
  stale-session removal, and tab-reconciliation are logged to trace
  panel leaks across task switches and spurious splits
- **chat messages** — initial fetch limit bumped 50→100; auto-backfill
  added (up to 3 rounds, 100 msgs each) until a user/agent message is
  found; lazy-load cursor progression, processed-message pipeline
  stats, and visibility-backfill (tab-refocus re-fetch for silent WS
  drops) are all logged

## Validation

- `pnpm --filter @kandev/web typecheck` — clean
- `pnpm --filter @kandev/web lint` — clean
- `make -C apps/backend test lint` — clean

## Checklist

- [ ] Tests added / updated
- [ ] Docs updated (if applicable)
- [ ] Breaking changes documented