### PR TITLE
fix(web): restore padding on office task-creation title input

### DIFF
--- a/apps/web/app/office/components/new-task-dialog.tsx
+++ b/apps/web/app/office/components/new-task-dialog.tsx
@@ -163,7 +163,7 @@ function NewIssueDialogBody({
           placeholder="Task title"
           value={draft.title}
           onChange={(e) => updateDraft({ title: e.target.value })}
-          className="text-lg font-medium border-0 resize-none p-0 focus-visible:ring-0 min-h-[40px]"
+          className="text-lg font-medium border-0 resize-none focus-visible:ring-0 min-h-[40px]"
           rows={1}
           autoFocus
         />


### PR DESCRIPTION
The office new-task dialog's title input had `p-0` overriding the default `@kandev/ui/textarea` padding, so the placeholder and entered text sat flush against the top-left edge of the input. Removed the override so it uses the standard `px-2 py-2` and visually aligns with the description textarea below.

## Validation

- `pnpm --filter @kandev/web lint` — passes
- Manually opened the office new-task dialog and verified the title text is no longer flush against the input edge.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.