### PR TITLE
fix(homebrew): clear rubocop offenses on formula

### DIFF
--- a/Formula/kandev.rb
+++ b/Formula/kandev.rb
@@ -14,7 +14,7 @@ class Kandev < Formula
   depends_on "pnpm" => :build
   depends_on "node"
 
-  uses_from_macos "rsync"  => :build
+  uses_from_macos "rsync" => :build
   uses_from_macos "sqlite"
 
   def install
@@ -64,7 +64,7 @@ class Kandev < Formula
                 libexec/"bin/kandev")
     begin
       deadline = Time.now + 60
-      until system("curl", "-sf", "-o", "/dev/null",
+      until system("curl", "-sf", "-o", File::NULL,
                    "http://127.0.0.1:#{port}/api/v1/system/health")
         raise "kandev backend did not start within 60s" if Time.now > deadline
 


### PR DESCRIPTION
Mirror two style fixes already applied to the upstream homebrew-core PR (Homebrew/homebrew-core#283241), so the in-repo reference formula stays in sync with what's actually being submitted upstream.

- `Layout/ExtraSpacing`: double space before `=>` in `uses_from_macos "rsync"`
- `Style/FileNull`: use `File::NULL` instead of `"/dev/null"` in the test block

Both surfaced by `brew style` in homebrew-core CI, both autocorrectable.

## Validation

- Diff is two lines.
- No functional change; styling only.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.