### PR TITLE
fix(orchestrator): propagate RepositoryID so worktree setup script runs

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_environment_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_environment_test.go
@@ -368,3 +368,35 @@ func TestExtractSandboxID(t *testing.T) {
 		})
 	}
 }
+
+// TestApplyRepositoryConfig_PropagatesRepositoryID asserts that
+// applyRepositoryConfig copies RepositoryID from the resolved repoInfo onto
+// the launch request. The lifecycle layer carries this field through to the
+// worktree manager's runWorktreeSetupScript, which uses it to look up the
+// repository's setup script. When the field is empty the manager silently
+// skips the script — manifesting as "the start script is not run" for the
+// user who configured one on their repo.
+func TestApplyRepositoryConfig_PropagatesRepositoryID(t *testing.T) {
+	e := newEnvTestExecutor(t)
+	req := &LaunchAgentRequest{TaskID: "task-1"}
+	task := &v1.Task{ID: "task-1", WorkspaceID: "workspace-1", Title: "Some task"}
+	info := &repoInfo{
+		RepositoryID:   "repo-abc",
+		RepositoryPath: "/repos/myrepo",
+		BaseBranch:     "main",
+		Repository: &models.Repository{
+			ID:          "repo-abc",
+			Name:        "myrepo",
+			SetupScript: "npm install",
+		},
+	}
+	execCfg := executorConfig{ExecutorID: "exec-1", ExecutorType: string(models.ExecutorTypeLocal)}
+
+	if _, err := e.applyRepositoryConfig(req, task, info, execCfg, nil); err != nil {
+		t.Fatalf("applyRepositoryConfig: %v", err)
+	}
+
+	if req.RepositoryID != "repo-abc" {
+		t.Errorf("req.RepositoryID = %q, want %q", req.RepositoryID, "repo-abc")
+	}
+}

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -721,6 +721,7 @@ func buildRepoSpecs(allRepos []*repoInfo) []RepoSpec {
 func (e *Executor) applyRepositoryConfig(req *LaunchAgentRequest, task *v1.Task, repoInfo *repoInfo, execConfig executorConfig, metadata map[string]interface{}) (map[string]interface{}, error) {
 	if repoInfo.RepositoryPath != "" {
 		req.UseWorktree = shouldUseWorktree(execConfig.ExecutorType)
+		req.RepositoryID = repoInfo.RepositoryID
 		req.RepositoryPath = repoInfo.RepositoryPath
 		req.BaseBranch = repoInfo.BaseBranch
 		req.CheckoutBranch = repoInfo.CheckoutBranch

--- a/apps/backend/internal/orchestrator/executor/executor_worktree_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_worktree_resume_test.go
@@ -83,4 +83,3 @@ func TestLaunchPreparedSession_SingleRepoWorktree_PersistsSubdirAsWorkspacePath(
 			env.WorkspacePath, subdir)
 	}
 }
-

--- a/apps/web/e2e/tests/session/setup-script-no-duplicate.spec.ts
+++ b/apps/web/e2e/tests/session/setup-script-no-duplicate.spec.ts
@@ -80,8 +80,13 @@ test.describe("Setup script no duplicate execution", () => {
 
       expect(task.session_id).toBeTruthy();
       const { messages } = await apiClient.listSessionMessages(task.session_id!);
+      // Filter by metadata.script_type === "setup" — the chat surfaces other
+      // `script_execution` rows too (e.g. agent_boot), and counting all of
+      // them masked the bug where the setup script never ran.
       const scriptMsgs = messages.filter(
-        (m) => (m as { type?: string }).type === "script_execution",
+        (m) =>
+          (m as { type?: string }).type === "script_execution" &&
+          ((m as { metadata?: { script_type?: string } }).metadata?.script_type ?? "") === "setup",
       );
       expect(scriptMsgs).toHaveLength(1);
     } finally {


### PR DESCRIPTION
Starting a new task in a worktree never executed the repository's configured setup script: `applyRepositoryConfig` forgot to copy `RepositoryID` from the resolved `repoInfo` onto the launch request, so by the time the empty value reached `worktree.Manager.runWorktreeSetupScript` it silently no-op'd. One-line fix sets the field alongside the other repo properties.

## Validation

- New unit test `TestApplyRepositoryConfig_PropagatesRepositoryID` (fails before the fix, passes after).
- `make test` — all backend packages green, including `internal/orchestrator/...`, `internal/agent/runtime/...`, `internal/worktree/...`.
- `go vet ./...` clean; `gofmt` clean.
- Manual: started a new task in worktree mode against a repo whose Setup Script writes `/tmp/kandev-setup-marker.txt`; marker file was created with the expected content and timestamp.

## Possible Improvements

Low risk. The fix only adds an assignment; affected behavior was already covered by lifecycle/worktree tests that explicitly set `RepositoryID` — the bug was purely in the orchestrator-to-lifecycle handoff.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.