### PR TITLE
feat(linear): enrich issue watch filters with priority, labels, creator, estimate

### DIFF
--- a/apps/backend/internal/linear/client.go
+++ b/apps/backend/internal/linear/client.go
@@ -18,6 +18,8 @@ type Client interface {
 	ListStates(ctx context.Context, teamKey string) ([]LinearWorkflowState, error)
 	SetIssueState(ctx context.Context, issueID, stateID string) error
 	ListTeams(ctx context.Context) ([]LinearTeam, error)
+	ListLabels(ctx context.Context, teamKey string) ([]LinearLabel, error)
+	ListUsers(ctx context.Context, teamKey string) ([]LinearUser, error)
 	SearchIssues(ctx context.Context, filter SearchFilter, pageToken string, maxResults int) (*SearchResult, error)
 }
 

--- a/apps/backend/internal/linear/graphql_client.go
+++ b/apps/backend/internal/linear/graphql_client.go
@@ -528,8 +528,128 @@ func buildIssueFilter(f SearchFilter) map[string]interface{} {
 	case "unassigned":
 		out["assignee"] = map[string]interface{}{"null": true}
 	}
+	if f.Priority != nil {
+		out["priority"] = map[string]interface{}{"eq": *f.Priority}
+	}
+	if len(f.LabelIDs) > 0 {
+		// `labels.some` matches issues having at least one label whose id is
+		// in the provided list — Linear's OR semantics for multi-label filter.
+		out["labels"] = map[string]interface{}{
+			"some": map[string]interface{}{
+				"id": map[string]interface{}{"in": f.LabelIDs},
+			},
+		}
+	}
+	if f.CreatorID != "" {
+		out["creator"] = map[string]interface{}{"id": map[string]interface{}{"eq": f.CreatorID}}
+	}
+	if f.EstimateMin != nil || f.EstimateMax != nil {
+		bounds := map[string]interface{}{}
+		if f.EstimateMin != nil {
+			bounds["gte"] = *f.EstimateMin
+		}
+		if f.EstimateMax != nil {
+			bounds["lte"] = *f.EstimateMax
+		}
+		out["estimate"] = bounds
+	}
 	if len(out) == 0 {
 		return nil
 	}
 	return out
+}
+
+// --- labels ---
+
+const teamLabelsQuery = `
+query TeamLabels($filter: IssueLabelFilter!) {
+	issueLabels(first: 100, filter: $filter) {
+		nodes { id name color }
+	}
+}`
+
+type labelsData struct {
+	IssueLabels struct {
+		Nodes []struct {
+			ID    string `json:"id"`
+			Name  string `json:"name"`
+			Color string `json:"color"`
+		} `json:"nodes"`
+	} `json:"issueLabels"`
+}
+
+// ListLabels returns the issue labels available for a team identified by its
+// key. Workspace-scoped labels (no team) are included by also fetching the
+// `team: null` set in a second pass when teamKey is empty.
+func (c *GraphQLClient) ListLabels(ctx context.Context, teamKey string) ([]LinearLabel, error) {
+	if teamKey == "" {
+		return nil, fmt.Errorf("teamKey required")
+	}
+	vars := map[string]interface{}{
+		"filter": map[string]interface{}{
+			"team": map[string]interface{}{"key": map[string]interface{}{"eq": teamKey}},
+		},
+	}
+	var data labelsData
+	if err := c.do(ctx, teamLabelsQuery, vars, &data); err != nil {
+		return nil, err
+	}
+	out := make([]LinearLabel, 0, len(data.IssueLabels.Nodes))
+	for _, l := range data.IssueLabels.Nodes {
+		out = append(out, LinearLabel{ID: l.ID, Name: l.Name, Color: l.Color})
+	}
+	return out, nil
+}
+
+// --- users ---
+
+const teamMembersQuery = `
+query TeamMembers($filter: UserFilter!) {
+	users(first: 100, filter: $filter, orderBy: updatedAt) {
+		nodes { id name displayName email avatarUrl }
+	}
+}`
+
+type usersData struct {
+	Users struct {
+		Nodes []struct {
+			ID          string `json:"id"`
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+			Email       string `json:"email"`
+			AvatarURL   string `json:"avatarUrl"`
+		} `json:"nodes"`
+	} `json:"users"`
+}
+
+// ListUsers returns members of the team identified by teamKey. The filter
+// uses Linear's `teamMemberships.some` to scope to that team.
+func (c *GraphQLClient) ListUsers(ctx context.Context, teamKey string) ([]LinearUser, error) {
+	if teamKey == "" {
+		return nil, fmt.Errorf("teamKey required")
+	}
+	vars := map[string]interface{}{
+		"filter": map[string]interface{}{
+			"teamMemberships": map[string]interface{}{
+				"some": map[string]interface{}{
+					"team": map[string]interface{}{"key": map[string]interface{}{"eq": teamKey}},
+				},
+			},
+		},
+	}
+	var data usersData
+	if err := c.do(ctx, teamMembersQuery, vars, &data); err != nil {
+		return nil, err
+	}
+	out := make([]LinearUser, 0, len(data.Users.Nodes))
+	for _, u := range data.Users.Nodes {
+		out = append(out, LinearUser{
+			ID:          u.ID,
+			Name:        u.Name,
+			DisplayName: u.DisplayName,
+			Email:       u.Email,
+			AvatarURL:   u.AvatarURL,
+		})
+	}
+	return out, nil
 }

--- a/apps/backend/internal/linear/graphql_client.go
+++ b/apps/backend/internal/linear/graphql_client.go
@@ -561,9 +561,16 @@ func buildIssueFilter(f SearchFilter) map[string]interface{} {
 
 // --- labels ---
 
+// Linear's GraphQL API caps `first` at 250. We don't paginate labels/users
+// because the watcher dialog renders them as a single dropdown — a workspace
+// with >250 labels or members would have UX problems regardless of how the
+// data is fetched. If this limit is hit in practice, switch to cursor-based
+// pagination here and lazy-load in the UI.
+const linearMaxPageSize = 250
+
 const teamLabelsQuery = `
-query TeamLabels($filter: IssueLabelFilter!) {
-	issueLabels(first: 100, filter: $filter) {
+query TeamLabels($filter: IssueLabelFilter!, $first: Int!) {
+	issueLabels(first: $first, filter: $filter) {
 		nodes { id name color }
 	}
 }`
@@ -589,6 +596,7 @@ func (c *GraphQLClient) ListLabels(ctx context.Context, teamKey string) ([]Linea
 		"filter": map[string]interface{}{
 			"team": map[string]interface{}{"key": map[string]interface{}{"eq": teamKey}},
 		},
+		"first": linearMaxPageSize,
 	}
 	var data labelsData
 	if err := c.do(ctx, teamLabelsQuery, vars, &data); err != nil {
@@ -604,8 +612,8 @@ func (c *GraphQLClient) ListLabels(ctx context.Context, teamKey string) ([]Linea
 // --- users ---
 
 const teamMembersQuery = `
-query TeamMembers($filter: UserFilter!) {
-	users(first: 100, filter: $filter, orderBy: updatedAt) {
+query TeamMembers($filter: UserFilter!, $first: Int!) {
+	users(first: $first, filter: $filter, orderBy: updatedAt) {
 		nodes { id name displayName email avatarUrl }
 	}
 }`
@@ -636,6 +644,7 @@ func (c *GraphQLClient) ListUsers(ctx context.Context, teamKey string) ([]Linear
 				},
 			},
 		},
+		"first": linearMaxPageSize,
 	}
 	var data usersData
 	if err := c.do(ctx, teamMembersQuery, vars, &data); err != nil {

--- a/apps/backend/internal/linear/graphql_client.go
+++ b/apps/backend/internal/linear/graphql_client.go
@@ -528,8 +528,8 @@ func buildIssueFilter(f SearchFilter) map[string]interface{} {
 	case "unassigned":
 		out["assignee"] = map[string]interface{}{"null": true}
 	}
-	if f.Priority != nil {
-		out["priority"] = map[string]interface{}{"eq": *f.Priority}
+	if len(f.Priorities) > 0 {
+		out["priority"] = map[string]interface{}{"in": f.Priorities}
 	}
 	if len(f.LabelIDs) > 0 {
 		// `labels.some` matches issues having at least one label whose id is

--- a/apps/backend/internal/linear/graphql_client_test.go
+++ b/apps/backend/internal/linear/graphql_client_test.go
@@ -256,19 +256,22 @@ func TestBuildIssueFilter_DropsEmpty(t *testing.T) {
 }
 
 func TestBuildIssueFilter_RichFilters(t *testing.T) {
-	prio := 2
 	min := 1.0
 	max := 5.0
 	got := buildIssueFilter(SearchFilter{
-		Priority:    &prio,
+		Priorities:  []int{1, 2},
 		LabelIDs:    []string{"l1", "l2"},
 		CreatorID:   "u1",
 		EstimateMin: &min,
 		EstimateMax: &max,
 	})
 	prioBlock, ok := got["priority"].(map[string]interface{})
-	if !ok || prioBlock["eq"] != 2 {
-		t.Errorf("priority filter mismatch: %+v", got["priority"])
+	if !ok {
+		t.Fatalf("missing priority filter: %+v", got)
+	}
+	prioIn, _ := prioBlock["in"].([]int)
+	if len(prioIn) != 2 || prioIn[0] != 1 || prioIn[1] != 2 {
+		t.Errorf("priority filter mismatch: %+v", prioBlock)
 	}
 	labelBlock, ok := got["labels"].(map[string]interface{})
 	if !ok {
@@ -292,10 +295,10 @@ func TestBuildIssueFilter_RichFilters(t *testing.T) {
 }
 
 func TestBuildIssueFilter_PriorityZero(t *testing.T) {
-	zero := 0
-	got := buildIssueFilter(SearchFilter{Priority: &zero})
+	got := buildIssueFilter(SearchFilter{Priorities: []int{0}})
 	prio, _ := got["priority"].(map[string]interface{})
-	if prio["eq"] != 0 {
-		t.Errorf("priority=0 should map to eq:0, got %+v", prio)
+	in, _ := prio["in"].([]int)
+	if len(in) != 1 || in[0] != 0 {
+		t.Errorf("priorities=[0] should map to in:[0] (No priority), got %+v", prio)
 	}
 }

--- a/apps/backend/internal/linear/graphql_client_test.go
+++ b/apps/backend/internal/linear/graphql_client_test.go
@@ -254,3 +254,48 @@ func TestBuildIssueFilter_DropsEmpty(t *testing.T) {
 		t.Error("expected assignee filter")
 	}
 }
+
+func TestBuildIssueFilter_RichFilters(t *testing.T) {
+	prio := 2
+	min := 1.0
+	max := 5.0
+	got := buildIssueFilter(SearchFilter{
+		Priority:    &prio,
+		LabelIDs:    []string{"l1", "l2"},
+		CreatorID:   "u1",
+		EstimateMin: &min,
+		EstimateMax: &max,
+	})
+	prioBlock, ok := got["priority"].(map[string]interface{})
+	if !ok || prioBlock["eq"] != 2 {
+		t.Errorf("priority filter mismatch: %+v", got["priority"])
+	}
+	labelBlock, ok := got["labels"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing labels filter: %+v", got)
+	}
+	some, _ := labelBlock["some"].(map[string]interface{})
+	idBlock, _ := some["id"].(map[string]interface{})
+	in, _ := idBlock["in"].([]string)
+	if len(in) != 2 || in[0] != "l1" {
+		t.Errorf("label ids mismatch: %+v", labelBlock)
+	}
+	creator, _ := got["creator"].(map[string]interface{})
+	idEq, _ := creator["id"].(map[string]interface{})
+	if idEq["eq"] != "u1" {
+		t.Errorf("creator filter mismatch: %+v", got["creator"])
+	}
+	est, ok := got["estimate"].(map[string]interface{})
+	if !ok || est["gte"] != 1.0 || est["lte"] != 5.0 {
+		t.Errorf("estimate filter mismatch: %+v", got["estimate"])
+	}
+}
+
+func TestBuildIssueFilter_PriorityZero(t *testing.T) {
+	zero := 0
+	got := buildIssueFilter(SearchFilter{Priority: &zero})
+	prio, _ := got["priority"].(map[string]interface{})
+	if prio["eq"] != 0 {
+		t.Errorf("priority=0 should map to eq:0, got %+v", prio)
+	}
+}

--- a/apps/backend/internal/linear/handlers.go
+++ b/apps/backend/internal/linear/handlers.go
@@ -36,6 +36,8 @@ func (c *Controller) RegisterHTTPRoutes(router *gin.Engine) {
 	api.POST("/config/test", c.httpTestConfig)
 	api.GET("/teams", c.httpListTeams)
 	api.GET("/states", c.httpListStates)
+	api.GET("/labels", c.httpListLabels)
+	api.GET("/users", c.httpListUsers)
 	api.GET("/issues", c.httpSearchIssues)
 	api.GET("/issues/:id", c.httpGetIssue)
 	api.POST("/issues/:id/state", c.httpSetIssueState)
@@ -125,14 +127,61 @@ func (c *Controller) httpListStates(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"states": states})
 }
 
+func (c *Controller) httpListLabels(ctx *gin.Context) {
+	teamKey := ctx.Query("team_key")
+	if teamKey == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "team_key required"})
+		return
+	}
+	labels, err := c.service.ListLabels(ctx.Request.Context(), teamKey)
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"labels": labels})
+}
+
+func (c *Controller) httpListUsers(ctx *gin.Context) {
+	teamKey := ctx.Query("team_key")
+	if teamKey == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "team_key required"})
+		return
+	}
+	users, err := c.service.ListUsers(ctx.Request.Context(), teamKey)
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, gin.H{"users": users})
+}
+
 func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 	filter := SearchFilter{
-		Query:    ctx.Query("query"),
-		TeamKey:  ctx.Query("team_key"),
-		Assigned: ctx.Query("assigned"),
+		Query:     ctx.Query("query"),
+		TeamKey:   ctx.Query("team_key"),
+		Assigned:  ctx.Query("assigned"),
+		CreatorID: ctx.Query("creator_id"),
 	}
 	if states := ctx.Query("state_ids"); states != "" {
 		filter.StateIDs = splitCSV(states)
+	}
+	if labels := ctx.Query("label_ids"); labels != "" {
+		filter.LabelIDs = splitCSV(labels)
+	}
+	if p := ctx.Query("priority"); p != "" {
+		if v, err := strconv.Atoi(p); err == nil {
+			filter.Priority = &v
+		}
+	}
+	if v := ctx.Query("estimate_min"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			filter.EstimateMin = &f
+		}
+	}
+	if v := ctx.Query("estimate_max"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			filter.EstimateMax = &f
+		}
 	}
 	pageToken := ctx.Query("page_token")
 	maxResults, _ := strconv.Atoi(ctx.Query("max_results"))

--- a/apps/backend/internal/linear/handlers.go
+++ b/apps/backend/internal/linear/handlers.go
@@ -197,15 +197,15 @@ func parseSearchNumericFilters(ctx *gin.Context, filter *SearchFilter) error {
 	}
 	if v := ctx.Query("estimate_min"); v != "" {
 		f, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return fmt.Errorf("estimate_min must be a number")
+		if err != nil || f < 0 {
+			return fmt.Errorf("estimate_min must be a non-negative number")
 		}
 		filter.EstimateMin = &f
 	}
 	if v := ctx.Query("estimate_max"); v != "" {
 		f, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return fmt.Errorf("estimate_max must be a number")
+		if err != nil || f < 0 {
+			return fmt.Errorf("estimate_max must be a non-negative number")
 		}
 		filter.EstimateMax = &f
 	}

--- a/apps/backend/internal/linear/handlers.go
+++ b/apps/backend/internal/linear/handlers.go
@@ -189,39 +189,51 @@ func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 // is rejected rather than silently dropped so callers don't accidentally widen
 // the search by typoing a number.
 func parseSearchNumericFilters(ctx *gin.Context, filter *SearchFilter) error {
-	if p := ctx.Query("priorities"); p != "" {
-		parts := splitCSV(p)
-		priorities := make([]int, 0, len(parts))
-		for _, raw := range parts {
-			v, err := strconv.Atoi(raw)
-			if err != nil || v < 0 || v > 4 {
-				return fmt.Errorf("priorities must be integers between 0 and 4")
-			}
-			priorities = append(priorities, v)
-		}
-		filter.Priorities = priorities
+	priorities, err := parseSearchPriorities(ctx.Query("priorities"))
+	if err != nil {
+		return err
 	}
-	if v := ctx.Query("estimate_min"); v != "" {
-		f, err := strconv.ParseFloat(v, 64)
-		// strconv.ParseFloat accepts "NaN", "Inf", "-Inf" without error, but
-		// json.Marshal rejects them later (turning a 400 into a 500). Filter
-		// them out here so the response stays a clean 400.
-		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < 0 {
-			return fmt.Errorf("estimate_min must be a non-negative number")
-		}
-		filter.EstimateMin = &f
+	filter.Priorities = priorities
+	if filter.EstimateMin, err = parseEstimateBound(ctx.Query("estimate_min"), "estimate_min"); err != nil {
+		return err
 	}
-	if v := ctx.Query("estimate_max"); v != "" {
-		f, err := strconv.ParseFloat(v, 64)
-		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < 0 {
-			return fmt.Errorf("estimate_max must be a non-negative number")
-		}
-		filter.EstimateMax = &f
+	if filter.EstimateMax, err = parseEstimateBound(ctx.Query("estimate_max"), "estimate_max"); err != nil {
+		return err
 	}
 	if filter.EstimateMin != nil && filter.EstimateMax != nil && *filter.EstimateMin > *filter.EstimateMax {
 		return fmt.Errorf("estimate_min cannot be greater than estimate_max")
 	}
 	return nil
+}
+
+func parseSearchPriorities(raw string) ([]int, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parts := splitCSV(raw)
+	priorities := make([]int, 0, len(parts))
+	for _, p := range parts {
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 0 || v > 4 {
+			return nil, fmt.Errorf("priorities must be integers between 0 and 4")
+		}
+		priorities = append(priorities, v)
+	}
+	return priorities, nil
+}
+
+// parseEstimateBound parses a non-negative float query param. strconv.ParseFloat
+// accepts "NaN", "Inf", "-Inf" without error, but json.Marshal rejects them
+// later (turning a 400 into a 500), so we filter them out here.
+func parseEstimateBound(raw, name string) (*float64, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < 0 {
+		return nil, fmt.Errorf("%s must be a non-negative number", name)
+	}
+	return &f, nil
 }
 
 func (c *Controller) httpGetIssue(ctx *gin.Context) {

--- a/apps/backend/internal/linear/handlers.go
+++ b/apps/backend/internal/linear/handlers.go
@@ -3,6 +3,7 @@ package linear
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -168,20 +169,9 @@ func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 	if labels := ctx.Query("label_ids"); labels != "" {
 		filter.LabelIDs = splitCSV(labels)
 	}
-	if p := ctx.Query("priority"); p != "" {
-		if v, err := strconv.Atoi(p); err == nil {
-			filter.Priority = &v
-		}
-	}
-	if v := ctx.Query("estimate_min"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil {
-			filter.EstimateMin = &f
-		}
-	}
-	if v := ctx.Query("estimate_max"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil {
-			filter.EstimateMax = &f
-		}
+	if err := parseSearchNumericFilters(ctx, &filter); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 	pageToken := ctx.Query("page_token")
 	maxResults, _ := strconv.Atoi(ctx.Query("max_results"))
@@ -191,6 +181,38 @@ func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 		return
 	}
 	ctx.JSON(http.StatusOK, result)
+}
+
+// parseSearchNumericFilters parses priority + estimate query params onto the
+// filter and returns a 400-worthy error when any are malformed. Invalid input
+// is rejected rather than silently dropped so callers don't accidentally widen
+// the search by typoing a number.
+func parseSearchNumericFilters(ctx *gin.Context, filter *SearchFilter) error {
+	if p := ctx.Query("priority"); p != "" {
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 0 || v > 4 {
+			return fmt.Errorf("priority must be an integer between 0 and 4")
+		}
+		filter.Priority = &v
+	}
+	if v := ctx.Query("estimate_min"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return fmt.Errorf("estimate_min must be a number")
+		}
+		filter.EstimateMin = &f
+	}
+	if v := ctx.Query("estimate_max"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return fmt.Errorf("estimate_max must be a number")
+		}
+		filter.EstimateMax = &f
+	}
+	if filter.EstimateMin != nil && filter.EstimateMax != nil && *filter.EstimateMin > *filter.EstimateMax {
+		return fmt.Errorf("estimate_min cannot be greater than estimate_max")
+	}
+	return nil
 }
 
 func (c *Controller) httpGetIssue(ctx *gin.Context) {

--- a/apps/backend/internal/linear/handlers.go
+++ b/apps/backend/internal/linear/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -115,9 +116,9 @@ func (c *Controller) httpListTeams(ctx *gin.Context) {
 }
 
 func (c *Controller) httpListStates(ctx *gin.Context) {
-	teamKey := ctx.Query("team_key")
+	teamKey := ctx.Query(teamKeyParam)
 	if teamKey == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "team_key required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": teamKeyRequired})
 		return
 	}
 	states, err := c.service.ListStates(ctx.Request.Context(), teamKey)
@@ -129,9 +130,9 @@ func (c *Controller) httpListStates(ctx *gin.Context) {
 }
 
 func (c *Controller) httpListLabels(ctx *gin.Context) {
-	teamKey := ctx.Query("team_key")
+	teamKey := ctx.Query(teamKeyParam)
 	if teamKey == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "team_key required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": teamKeyRequired})
 		return
 	}
 	labels, err := c.service.ListLabels(ctx.Request.Context(), teamKey)
@@ -143,9 +144,9 @@ func (c *Controller) httpListLabels(ctx *gin.Context) {
 }
 
 func (c *Controller) httpListUsers(ctx *gin.Context) {
-	teamKey := ctx.Query("team_key")
+	teamKey := ctx.Query(teamKeyParam)
 	if teamKey == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "team_key required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": teamKeyRequired})
 		return
 	}
 	users, err := c.service.ListUsers(ctx.Request.Context(), teamKey)
@@ -159,7 +160,7 @@ func (c *Controller) httpListUsers(ctx *gin.Context) {
 func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 	filter := SearchFilter{
 		Query:     ctx.Query("query"),
-		TeamKey:   ctx.Query("team_key"),
+		TeamKey:   ctx.Query(teamKeyParam),
 		Assigned:  ctx.Query("assigned"),
 		CreatorID: ctx.Query("creator_id"),
 	}
@@ -197,14 +198,17 @@ func parseSearchNumericFilters(ctx *gin.Context, filter *SearchFilter) error {
 	}
 	if v := ctx.Query("estimate_min"); v != "" {
 		f, err := strconv.ParseFloat(v, 64)
-		if err != nil || f < 0 {
+		// strconv.ParseFloat accepts "NaN", "Inf", "-Inf" without error, but
+		// json.Marshal rejects them later (turning a 400 into a 500). Filter
+		// them out here so the response stays a clean 400.
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < 0 {
 			return fmt.Errorf("estimate_min must be a non-negative number")
 		}
 		filter.EstimateMin = &f
 	}
 	if v := ctx.Query("estimate_max"); v != "" {
 		f, err := strconv.ParseFloat(v, 64)
-		if err != nil || f < 0 {
+		if err != nil || math.IsNaN(f) || math.IsInf(f, 0) || f < 0 {
 			return fmt.Errorf("estimate_max must be a non-negative number")
 		}
 		filter.EstimateMax = &f
@@ -244,6 +248,13 @@ func (c *Controller) httpSetIssueState(ctx *gin.Context) {
 // errCodeLinearNotConfigured is the wire-level code surfaced to the UI when
 // Linear has no saved credentials.
 const errCodeLinearNotConfigured = "LINEAR_NOT_CONFIGURED"
+
+// Wire-format constants for the team_key query parameter that scopes
+// per-team endpoints (states / labels / users / search).
+const (
+	teamKeyParam    = "team_key"
+	teamKeyRequired = "team_key required"
+)
 
 // writeClientError maps service-level errors to HTTP responses.
 func (c *Controller) writeClientError(ctx *gin.Context, err error) {

--- a/apps/backend/internal/linear/handlers.go
+++ b/apps/backend/internal/linear/handlers.go
@@ -189,12 +189,17 @@ func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 // is rejected rather than silently dropped so callers don't accidentally widen
 // the search by typoing a number.
 func parseSearchNumericFilters(ctx *gin.Context, filter *SearchFilter) error {
-	if p := ctx.Query("priority"); p != "" {
-		v, err := strconv.Atoi(p)
-		if err != nil || v < 0 || v > 4 {
-			return fmt.Errorf("priority must be an integer between 0 and 4")
+	if p := ctx.Query("priorities"); p != "" {
+		parts := splitCSV(p)
+		priorities := make([]int, 0, len(parts))
+		for _, raw := range parts {
+			v, err := strconv.Atoi(raw)
+			if err != nil || v < 0 || v > 4 {
+				return fmt.Errorf("priorities must be integers between 0 and 4")
+			}
+			priorities = append(priorities, v)
 		}
-		filter.Priority = &v
+		filter.Priorities = priorities
 	}
 	if v := ctx.Query("estimate_min"); v != "" {
 		f, err := strconv.ParseFloat(v, 64)

--- a/apps/backend/internal/linear/handlers_test.go
+++ b/apps/backend/internal/linear/handlers_test.go
@@ -150,6 +150,80 @@ func TestHTTPListStates_RoutesThroughService(t *testing.T) {
 	}
 }
 
+func TestHTTPListLabels_RequiresTeamKey(t *testing.T) {
+	_, router, _ := newTestController(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/linear/labels", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHTTPListLabels_RoutesThroughService(t *testing.T) {
+	ctrl, router, client := newTestController(t)
+	ctx := context.Background()
+	if err := ctrl.service.store.UpsertConfig(ctx, &LinearConfig{
+		AuthMethod: AuthMethodAPIKey,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := ctrl.service.secrets.Set(ctx, SecretKey, "linear", "tok"); err != nil {
+		t.Fatalf("set secret: %v", err)
+	}
+	var seenTeam string
+	client.listLabelsFn = func(teamKey string) ([]LinearLabel, error) {
+		seenTeam = teamKey
+		return []LinearLabel{{ID: "l1", Name: "bug"}}, nil
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/linear/labels?team_key=ENG", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if seenTeam != "ENG" {
+		t.Errorf("team key forwarded to client = %q, want ENG", seenTeam)
+	}
+}
+
+func TestHTTPListUsers_RequiresTeamKey(t *testing.T) {
+	_, router, _ := newTestController(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/linear/users", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHTTPListUsers_RoutesThroughService(t *testing.T) {
+	ctrl, router, client := newTestController(t)
+	ctx := context.Background()
+	if err := ctrl.service.store.UpsertConfig(ctx, &LinearConfig{
+		AuthMethod: AuthMethodAPIKey,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := ctrl.service.secrets.Set(ctx, SecretKey, "linear", "tok"); err != nil {
+		t.Fatalf("set secret: %v", err)
+	}
+	var seenTeam string
+	client.listUsersFn = func(teamKey string) ([]LinearUser, error) {
+		seenTeam = teamKey
+		return []LinearUser{{ID: "u1", Name: "Alice"}}, nil
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/linear/users?team_key=ENG", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if seenTeam != "ENG" {
+		t.Errorf("team key forwarded to client = %q, want ENG", seenTeam)
+	}
+}
+
 func TestHTTPSearchIssues_RejectsBadNumericParams(t *testing.T) {
 	ctrl, router, _ := newTestController(t)
 	ctx := context.Background()

--- a/apps/backend/internal/linear/handlers_test.go
+++ b/apps/backend/internal/linear/handlers_test.go
@@ -150,6 +150,38 @@ func TestHTTPListStates_RoutesThroughService(t *testing.T) {
 	}
 }
 
+func TestHTTPSearchIssues_RejectsBadNumericParams(t *testing.T) {
+	ctrl, router, _ := newTestController(t)
+	ctx := context.Background()
+	if err := ctrl.service.store.UpsertConfig(ctx, &LinearConfig{
+		AuthMethod: AuthMethodAPIKey,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := ctrl.service.secrets.Set(ctx, SecretKey, "linear", "tok"); err != nil {
+		t.Fatalf("set secret: %v", err)
+	}
+	cases := map[string]string{
+		"priority out of range":    "priority=99",
+		"estimate_min not a number": "estimate_min=abc",
+		"estimate_min NaN":          "estimate_min=NaN",
+		"estimate_min +Inf":         "estimate_min=%2BInf",
+		"estimate_max -Inf":         "estimate_max=-Inf",
+		"estimate_min negative":     "estimate_min=-1",
+		"estimate_min > max":        "estimate_min=5&estimate_max=1",
+	}
+	for name, query := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/linear/issues?"+query, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestRegisterRoutes_RegistersWSHandlers(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/apps/backend/internal/linear/handlers_test.go
+++ b/apps/backend/internal/linear/handlers_test.go
@@ -236,13 +236,15 @@ func TestHTTPSearchIssues_RejectsBadNumericParams(t *testing.T) {
 		t.Fatalf("set secret: %v", err)
 	}
 	cases := map[string]string{
-		"priority out of range":    "priority=99",
-		"estimate_min not a number": "estimate_min=abc",
-		"estimate_min NaN":          "estimate_min=NaN",
-		"estimate_min +Inf":         "estimate_min=%2BInf",
-		"estimate_max -Inf":         "estimate_max=-Inf",
-		"estimate_min negative":     "estimate_min=-1",
-		"estimate_min > max":        "estimate_min=5&estimate_max=1",
+		"priorities out of range":       "priorities=99",
+		"priorities mixed valid/invalid": "priorities=1,99",
+		"priorities not a number":        "priorities=abc",
+		"estimate_min not a number":      "estimate_min=abc",
+		"estimate_min NaN":               "estimate_min=NaN",
+		"estimate_min +Inf":              "estimate_min=%2BInf",
+		"estimate_max -Inf":              "estimate_max=-Inf",
+		"estimate_min negative":          "estimate_min=-1",
+		"estimate_min > max":             "estimate_min=5&estimate_max=1",
 	}
 	for name, query := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/apps/backend/internal/linear/handlers_test.go
+++ b/apps/backend/internal/linear/handlers_test.go
@@ -236,7 +236,7 @@ func TestHTTPSearchIssues_RejectsBadNumericParams(t *testing.T) {
 		t.Fatalf("set secret: %v", err)
 	}
 	cases := map[string]string{
-		"priorities out of range":       "priorities=99",
+		"priorities out of range":        "priorities=99",
 		"priorities mixed valid/invalid": "priorities=1,99",
 		"priorities not a number":        "priorities=abc",
 		"estimate_min not a number":      "estimate_min=abc",

--- a/apps/backend/internal/linear/mock_client.go
+++ b/apps/backend/internal/linear/mock_client.go
@@ -15,6 +15,8 @@ type MockClient struct {
 	authResult   *TestConnectionResult
 	teams        []LinearTeam
 	statesByTeam map[string][]LinearWorkflowState
+	labelsByTeam map[string][]LinearLabel
+	usersByTeam  map[string][]LinearUser
 	issues       map[string]*LinearIssue // identifier (e.g. ENG-12) → issue
 	// issueOrder preserves insertion order so SearchIssues returns a stable
 	// sequence — Go map range is randomised, which would make any future test
@@ -42,6 +44,8 @@ func NewMockClient() *MockClient {
 			OrgName:     "Mock Org",
 		},
 		statesByTeam: make(map[string][]LinearWorkflowState),
+		labelsByTeam: make(map[string][]LinearLabel),
+		usersByTeam:  make(map[string][]LinearUser),
 		issues:       make(map[string]*LinearIssue),
 	}
 }
@@ -87,6 +91,24 @@ func (m *MockClient) SetIssueState(_ context.Context, issueID, stateID string) e
 	defer m.mu.Unlock()
 	m.setStateCalls = append(m.setStateCalls, setStateCall{IssueID: issueID, StateID: stateID})
 	return nil
+}
+
+func (m *MockClient) ListLabels(_ context.Context, teamKey string) ([]LinearLabel, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	src := m.labelsByTeam[teamKey]
+	out := make([]LinearLabel, len(src))
+	copy(out, src)
+	return out, nil
+}
+
+func (m *MockClient) ListUsers(_ context.Context, teamKey string) ([]LinearUser, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	src := m.usersByTeam[teamKey]
+	out := make([]LinearUser, len(src))
+	copy(out, src)
+	return out, nil
 }
 
 func (m *MockClient) ListTeams(context.Context) ([]LinearTeam, error) {
@@ -143,6 +165,24 @@ func (m *MockClient) SetStates(teamKey string, states []LinearWorkflowState) {
 	m.statesByTeam[teamKey] = cp
 }
 
+// SetLabels replaces the labels returned by ListLabels for a team.
+func (m *MockClient) SetLabels(teamKey string, labels []LinearLabel) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]LinearLabel, len(labels))
+	copy(cp, labels)
+	m.labelsByTeam[teamKey] = cp
+}
+
+// SetUsers replaces the users returned by ListUsers for a team.
+func (m *MockClient) SetUsers(teamKey string, users []LinearUser) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]LinearUser, len(users))
+	copy(cp, users)
+	m.usersByTeam[teamKey] = cp
+}
+
 // AddIssue inserts (or replaces) an issue keyed by its Identifier.
 func (m *MockClient) AddIssue(issue *LinearIssue) {
 	m.mu.Lock()
@@ -184,6 +224,8 @@ func (m *MockClient) Reset() {
 	}
 	m.teams = nil
 	m.statesByTeam = make(map[string][]LinearWorkflowState)
+	m.labelsByTeam = make(map[string][]LinearLabel)
+	m.usersByTeam = make(map[string][]LinearUser)
 	m.issues = make(map[string]*LinearIssue)
 	m.issueOrder = nil
 	m.getError = nil

--- a/apps/backend/internal/linear/models.go
+++ b/apps/backend/internal/linear/models.go
@@ -134,10 +134,10 @@ type SearchFilter struct {
 	TeamKey  string   `json:"teamKey,omitempty"`  // restrict to one team
 	StateIDs []string `json:"stateIds,omitempty"` // restrict to specific workflow states
 	Assigned string   `json:"assigned,omitempty"` // "me" | "unassigned" | "" (any)
-	// Priority: pointer so callers can distinguish "unset" (no filter) from
-	// the literal "None" priority (0). Linear uses 0=None, 1=Urgent, 2=High,
-	// 3=Medium, 4=Low.
-	Priority *int `json:"priority,omitempty"`
+	// Priorities filters issues whose priority is in this set. Linear uses
+	// 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Empty slice means no
+	// priority filter; a slice with 0 in it includes "No priority" issues.
+	Priorities []int `json:"priorities,omitempty"`
 	// LabelIDs filters issues that have ANY of the given label UUIDs (Linear's
 	// labels filter is OR by default).
 	LabelIDs []string `json:"labelIds,omitempty"`

--- a/apps/backend/internal/linear/models.go
+++ b/apps/backend/internal/linear/models.go
@@ -104,14 +104,50 @@ type LinearTeam struct {
 	Name string `json:"name"`
 }
 
+// LinearLabel is an issue label belonging to a team. Labels are returned by
+// `GET /api/v1/linear/teams/:key/labels` and surfaced in the filter UI for
+// issue watches.
+type LinearLabel struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color,omitempty"`
+}
+
+// LinearUser is a workspace member returned by `GET /api/v1/linear/teams/:key/members`
+// (and the generic users list). Used as options in creator/assignee selectors.
+type LinearUser struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
+	Email       string `json:"email,omitempty"`
+	AvatarURL   string `json:"avatarUrl,omitempty"`
+}
+
 // SearchFilter is a structured search filter used by SearchIssues. Linear has
 // no JQL equivalent, so we expose a small set of structured fields that map
 // cleanly to GraphQL filter inputs.
+//
+// All fields are optional; an empty filter returns every issue the API key can
+// see. Watcher creation rejects fully-empty filters via filterIsEmpty.
 type SearchFilter struct {
 	Query    string   `json:"query,omitempty"`    // free-text title/description/identifier match
 	TeamKey  string   `json:"teamKey,omitempty"`  // restrict to one team
 	StateIDs []string `json:"stateIds,omitempty"` // restrict to specific workflow states
 	Assigned string   `json:"assigned,omitempty"` // "me" | "unassigned" | "" (any)
+	// Priority: pointer so callers can distinguish "unset" (no filter) from
+	// the literal "None" priority (0). Linear uses 0=None, 1=Urgent, 2=High,
+	// 3=Medium, 4=Low.
+	Priority *int `json:"priority,omitempty"`
+	// LabelIDs filters issues that have ANY of the given label UUIDs (Linear's
+	// labels filter is OR by default).
+	LabelIDs []string `json:"labelIds,omitempty"`
+	// CreatorID restricts to issues created by a specific user UUID. Empty
+	// means any creator.
+	CreatorID string `json:"creatorId,omitempty"`
+	// EstimateMin / EstimateMax bound the issue's point estimate. nil disables
+	// that bound; the two together act as a closed range.
+	EstimateMin *float64 `json:"estimateMin,omitempty"`
+	EstimateMax *float64 `json:"estimateMax,omitempty"`
 }
 
 // SearchResult is a page of issues from a search. Linear uses cursor-based

--- a/apps/backend/internal/linear/service.go
+++ b/apps/backend/internal/linear/service.go
@@ -233,6 +233,25 @@ func (s *Service) ListStates(ctx context.Context, teamKey string) ([]LinearWorkf
 	return client.ListStates(ctx, teamKey)
 }
 
+// ListLabels returns the issue labels for a team identified by its key.
+func (s *Service) ListLabels(ctx context.Context, teamKey string) ([]LinearLabel, error) {
+	client, err := s.clientFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return client.ListLabels(ctx, teamKey)
+}
+
+// ListUsers returns the members of a team identified by its key. Used to
+// populate creator / assignee selectors on the watcher filter UI.
+func (s *Service) ListUsers(ctx context.Context, teamKey string) ([]LinearUser, error) {
+	client, err := s.clientFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return client.ListUsers(ctx, teamKey)
+}
+
 // SearchIssues runs a filtered search.
 func (s *Service) SearchIssues(ctx context.Context, filter SearchFilter, pageToken string, maxResults int) (*SearchResult, error) {
 	client, err := s.clientFor(ctx)

--- a/apps/backend/internal/linear/service_issue_watch.go
+++ b/apps/backend/internal/linear/service_issue_watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -223,14 +224,27 @@ func validateFilterBounds(f SearchFilter) error {
 			return fmt.Errorf("%w: priority must be between 0 and 4", ErrInvalidConfig)
 		}
 	}
-	if f.EstimateMin != nil && *f.EstimateMin < 0 {
-		return fmt.Errorf("%w: estimateMin must be non-negative", ErrInvalidConfig)
+	if err := validateEstimateBound(f.EstimateMin, "estimateMin"); err != nil {
+		return err
 	}
-	if f.EstimateMax != nil && *f.EstimateMax < 0 {
-		return fmt.Errorf("%w: estimateMax must be non-negative", ErrInvalidConfig)
+	if err := validateEstimateBound(f.EstimateMax, "estimateMax"); err != nil {
+		return err
 	}
 	if f.EstimateMin != nil && f.EstimateMax != nil && *f.EstimateMin > *f.EstimateMax {
 		return fmt.Errorf("%w: estimateMin cannot be greater than estimateMax", ErrInvalidConfig)
+	}
+	return nil
+}
+
+// validateEstimateBound rejects NaN, ±Inf, and negative values. json.Marshal
+// fails on NaN/Inf, so without this check a malformed config would surface as a
+// 500 at watch-time instead of a clean validation error at create-time.
+func validateEstimateBound(v *float64, name string) error {
+	if v == nil {
+		return nil
+	}
+	if math.IsNaN(*v) || math.IsInf(*v, 0) || *v < 0 {
+		return fmt.Errorf("%w: %s must be a non-negative number", ErrInvalidConfig, name)
 	}
 	return nil
 }

--- a/apps/backend/internal/linear/service_issue_watch.go
+++ b/apps/backend/internal/linear/service_issue_watch.go
@@ -81,7 +81,7 @@ func (s *Service) UpdateIssueWatch(ctx context.Context, id string, req *UpdateIs
 	}
 	applyIssueWatchPatch(w, req)
 	if filterIsEmpty(w.Filter) {
-		return nil, fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, assigned, priority, labelIds, creatorId, or estimate range", ErrInvalidConfig)
+		return nil, fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, assigned, priorities, labelIds, creatorId, or estimate range", ErrInvalidConfig)
 	}
 	if err := validateFilterBounds(w.Filter); err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func validateIssueWatchCreate(req *CreateIssueWatchRequest) error {
 		return fmt.Errorf("%w: workflowId and workflowStepId required", ErrInvalidConfig)
 	}
 	if filterIsEmpty(normalizeFilter(req.Filter)) {
-		return fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, assigned, priority, labelIds, creatorId, or estimate range", ErrInvalidConfig)
+		return fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, assigned, priorities, labelIds, creatorId, or estimate range", ErrInvalidConfig)
 	}
 	if err := validateFilterBounds(req.Filter); err != nil {
 		return err
@@ -218,8 +218,10 @@ func validateIssueWatchCreate(req *CreateIssueWatchRequest) error {
 // type permits invalid values (e.g. Priority being an unconstrained int).
 // Empty / unset fields pass without check.
 func validateFilterBounds(f SearchFilter) error {
-	if f.Priority != nil && (*f.Priority < 0 || *f.Priority > 4) {
-		return fmt.Errorf("%w: priority must be between 0 and 4", ErrInvalidConfig)
+	for _, p := range f.Priorities {
+		if p < 0 || p > 4 {
+			return fmt.Errorf("%w: priority must be between 0 and 4", ErrInvalidConfig)
+		}
 	}
 	if f.EstimateMin != nil && *f.EstimateMin < 0 {
 		return fmt.Errorf("%w: estimateMin must be non-negative", ErrInvalidConfig)
@@ -250,7 +252,6 @@ func normalizeFilter(f SearchFilter) SearchFilter {
 		TeamKey:     strings.TrimSpace(f.TeamKey),
 		Assigned:    strings.TrimSpace(f.Assigned),
 		CreatorID:   strings.TrimSpace(f.CreatorID),
-		Priority:    f.Priority,
 		EstimateMin: f.EstimateMin,
 		EstimateMax: f.EstimateMax,
 	}
@@ -266,6 +267,14 @@ func normalizeFilter(f SearchFilter) SearchFilter {
 			out.LabelIDs = append(out.LabelIDs, id)
 		}
 	}
+	seenPriority := map[int]bool{}
+	for _, p := range f.Priorities {
+		if seenPriority[p] {
+			continue
+		}
+		seenPriority[p] = true
+		out.Priorities = append(out.Priorities, p)
+	}
 	return out
 }
 
@@ -274,7 +283,7 @@ func filterIsEmpty(f SearchFilter) bool {
 		f.TeamKey == "" &&
 		f.Assigned == "" &&
 		len(f.StateIDs) == 0 &&
-		f.Priority == nil &&
+		len(f.Priorities) == 0 &&
 		len(f.LabelIDs) == 0 &&
 		f.CreatorID == "" &&
 		f.EstimateMin == nil &&

--- a/apps/backend/internal/linear/service_issue_watch.go
+++ b/apps/backend/internal/linear/service_issue_watch.go
@@ -81,7 +81,7 @@ func (s *Service) UpdateIssueWatch(ctx context.Context, id string, req *UpdateIs
 	}
 	applyIssueWatchPatch(w, req)
 	if filterIsEmpty(w.Filter) {
-		return nil, fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, or assigned", ErrInvalidConfig)
+		return nil, fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, assigned, priority, labelIds, creatorId, or estimate range", ErrInvalidConfig)
 	}
 	if err := validateFilterBounds(w.Filter); err != nil {
 		return nil, err

--- a/apps/backend/internal/linear/service_issue_watch.go
+++ b/apps/backend/internal/linear/service_issue_watch.go
@@ -221,6 +221,12 @@ func validateFilterBounds(f SearchFilter) error {
 	if f.Priority != nil && (*f.Priority < 0 || *f.Priority > 4) {
 		return fmt.Errorf("%w: priority must be between 0 and 4", ErrInvalidConfig)
 	}
+	if f.EstimateMin != nil && *f.EstimateMin < 0 {
+		return fmt.Errorf("%w: estimateMin must be non-negative", ErrInvalidConfig)
+	}
+	if f.EstimateMax != nil && *f.EstimateMax < 0 {
+		return fmt.Errorf("%w: estimateMax must be non-negative", ErrInvalidConfig)
+	}
 	if f.EstimateMin != nil && f.EstimateMax != nil && *f.EstimateMin > *f.EstimateMax {
 		return fmt.Errorf("%w: estimateMin cannot be greater than estimateMax", ErrInvalidConfig)
 	}

--- a/apps/backend/internal/linear/service_issue_watch.go
+++ b/apps/backend/internal/linear/service_issue_watch.go
@@ -198,7 +198,7 @@ func validateIssueWatchCreate(req *CreateIssueWatchRequest) error {
 		return fmt.Errorf("%w: workflowId and workflowStepId required", ErrInvalidConfig)
 	}
 	if filterIsEmpty(normalizeFilter(req.Filter)) {
-		return fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, or assigned", ErrInvalidConfig)
+		return fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, assigned, priority, labelIds, creatorId, or estimate range", ErrInvalidConfig)
 	}
 	if req.PollIntervalSeconds != 0 {
 		if err := validatePollInterval(req.PollIntervalSeconds); err != nil {
@@ -221,9 +221,13 @@ func validatePollInterval(seconds int) error {
 // instead of slipping through with whitespace.
 func normalizeFilter(f SearchFilter) SearchFilter {
 	out := SearchFilter{
-		Query:    strings.TrimSpace(f.Query),
-		TeamKey:  strings.TrimSpace(f.TeamKey),
-		Assigned: strings.TrimSpace(f.Assigned),
+		Query:       strings.TrimSpace(f.Query),
+		TeamKey:     strings.TrimSpace(f.TeamKey),
+		Assigned:    strings.TrimSpace(f.Assigned),
+		CreatorID:   strings.TrimSpace(f.CreatorID),
+		Priority:    f.Priority,
+		EstimateMin: f.EstimateMin,
+		EstimateMax: f.EstimateMax,
 	}
 	for _, id := range f.StateIDs {
 		id = strings.TrimSpace(id)
@@ -231,11 +235,25 @@ func normalizeFilter(f SearchFilter) SearchFilter {
 			out.StateIDs = append(out.StateIDs, id)
 		}
 	}
+	for _, id := range f.LabelIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			out.LabelIDs = append(out.LabelIDs, id)
+		}
+	}
 	return out
 }
 
 func filterIsEmpty(f SearchFilter) bool {
-	return f.Query == "" && f.TeamKey == "" && f.Assigned == "" && len(f.StateIDs) == 0
+	return f.Query == "" &&
+		f.TeamKey == "" &&
+		f.Assigned == "" &&
+		len(f.StateIDs) == 0 &&
+		f.Priority == nil &&
+		len(f.LabelIDs) == 0 &&
+		f.CreatorID == "" &&
+		f.EstimateMin == nil &&
+		f.EstimateMax == nil
 }
 
 func applyIssueWatchPatch(w *IssueWatch, req *UpdateIssueWatchRequest) {

--- a/apps/backend/internal/linear/service_issue_watch.go
+++ b/apps/backend/internal/linear/service_issue_watch.go
@@ -83,6 +83,9 @@ func (s *Service) UpdateIssueWatch(ctx context.Context, id string, req *UpdateIs
 	if filterIsEmpty(w.Filter) {
 		return nil, fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, or assigned", ErrInvalidConfig)
 	}
+	if err := validateFilterBounds(w.Filter); err != nil {
+		return nil, err
+	}
 	if w.WorkflowID == "" || w.WorkflowStepID == "" {
 		return nil, fmt.Errorf("%w: workflowId and workflowStepId cannot be empty", ErrInvalidConfig)
 	}
@@ -200,10 +203,26 @@ func validateIssueWatchCreate(req *CreateIssueWatchRequest) error {
 	if filterIsEmpty(normalizeFilter(req.Filter)) {
 		return fmt.Errorf("%w: filter must specify at least one of query, teamKey, stateIds, assigned, priority, labelIds, creatorId, or estimate range", ErrInvalidConfig)
 	}
+	if err := validateFilterBounds(req.Filter); err != nil {
+		return err
+	}
 	if req.PollIntervalSeconds != 0 {
 		if err := validatePollInterval(req.PollIntervalSeconds); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// validateFilterBounds rejects out-of-range values for fields where the wire
+// type permits invalid values (e.g. Priority being an unconstrained int).
+// Empty / unset fields pass without check.
+func validateFilterBounds(f SearchFilter) error {
+	if f.Priority != nil && (*f.Priority < 0 || *f.Priority > 4) {
+		return fmt.Errorf("%w: priority must be between 0 and 4", ErrInvalidConfig)
+	}
+	if f.EstimateMin != nil && f.EstimateMax != nil && *f.EstimateMin > *f.EstimateMax {
+		return fmt.Errorf("%w: estimateMin cannot be greater than estimateMax", ErrInvalidConfig)
 	}
 	return nil
 }

--- a/apps/backend/internal/linear/service_issue_watch_test.go
+++ b/apps/backend/internal/linear/service_issue_watch_test.go
@@ -9,10 +9,9 @@ import (
 func TestService_CreateIssueWatch_AcceptsRichFilters(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
-	prio := 1
 	min := 1.0
 	cases := map[string]SearchFilter{
-		"priority":    {Priority: &prio},
+		"priority":    {Priorities: []int{1}},
 		"labels":      {LabelIDs: []string{"l1"}},
 		"creator":     {CreatorID: "u1"},
 		"estimateMin": {EstimateMin: &min},

--- a/apps/backend/internal/linear/service_issue_watch_test.go
+++ b/apps/backend/internal/linear/service_issue_watch_test.go
@@ -3,6 +3,7 @@ package linear
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 )
 
@@ -120,6 +121,28 @@ func TestService_UpdateIssueWatch_PartialPatch(t *testing.T) {
 	empty := SearchFilter{}
 	if _, err := f.svc.UpdateIssueWatch(ctx, created.ID, &UpdateIssueWatchRequest{Filter: &empty}); !errors.Is(err, ErrInvalidConfig) {
 		t.Errorf("expected ErrInvalidConfig for empty filter patch, got %v", err)
+	}
+}
+
+func TestValidateFilterBounds_RejectsNonFiniteAndNegativeEstimates(t *testing.T) {
+	nan := math.NaN()
+	posInf := math.Inf(1)
+	negInf := math.Inf(-1)
+	neg := -1.0
+	cases := map[string]SearchFilter{
+		"estimateMin NaN":  {EstimateMin: &nan},
+		"estimateMax NaN":  {EstimateMax: &nan},
+		"estimateMin +Inf": {EstimateMin: &posInf},
+		"estimateMax -Inf": {EstimateMax: &negInf},
+		"estimateMin < 0":  {EstimateMin: &neg},
+		"estimateMax < 0":  {EstimateMax: &neg},
+	}
+	for name, f := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := validateFilterBounds(f); !errors.Is(err, ErrInvalidConfig) {
+				t.Errorf("expected ErrInvalidConfig, got %v", err)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/linear/service_issue_watch_test.go
+++ b/apps/backend/internal/linear/service_issue_watch_test.go
@@ -6,6 +6,34 @@ import (
 	"testing"
 )
 
+func TestService_CreateIssueWatch_AcceptsRichFilters(t *testing.T) {
+	f := newSvcFixture(t)
+	ctx := context.Background()
+	prio := 1
+	min := 1.0
+	cases := map[string]SearchFilter{
+		"priority":    {Priority: &prio},
+		"labels":      {LabelIDs: []string{"l1"}},
+		"creator":     {CreatorID: "u1"},
+		"estimateMin": {EstimateMin: &min},
+	}
+	for name, filter := range cases {
+		w, err := f.svc.CreateIssueWatch(ctx, &CreateIssueWatchRequest{
+			WorkspaceID:    "ws-1",
+			WorkflowID:     "wf",
+			WorkflowStepID: "step",
+			Filter:         filter,
+		})
+		if err != nil {
+			t.Errorf("%s: create rejected: %v", name, err)
+			continue
+		}
+		if w.ID == "" {
+			t.Errorf("%s: expected ID assigned", name)
+		}
+	}
+}
+
 // withSearchResults returns a fakeClient that always returns the given issues
 // for SearchIssues, ignoring the filter.
 func (c *fakeClient) withSearchResults(issues []LinearIssue) *fakeClient {

--- a/apps/backend/internal/linear/service_test.go
+++ b/apps/backend/internal/linear/service_test.go
@@ -61,6 +61,8 @@ type fakeClient struct {
 	listStatesFn   func(teamKey string) ([]LinearWorkflowState, error)
 	transitionLog  []string
 	searchIssuesFn func(filter SearchFilter, pageToken string, max int) (*SearchResult, error)
+	listLabelsFn   func(teamKey string) ([]LinearLabel, error)
+	listUsersFn    func(teamKey string) ([]LinearUser, error)
 }
 
 func (c *fakeClient) TestAuth(_ context.Context) (*TestConnectionResult, error) {
@@ -104,6 +106,20 @@ func (c *fakeClient) SearchIssues(_ context.Context, filter SearchFilter, pageTo
 		return c.searchIssuesFn(filter, pageToken, max)
 	}
 	return &SearchResult{}, nil
+}
+
+func (c *fakeClient) ListLabels(_ context.Context, teamKey string) ([]LinearLabel, error) {
+	if c.listLabelsFn != nil {
+		return c.listLabelsFn(teamKey)
+	}
+	return nil, nil
+}
+
+func (c *fakeClient) ListUsers(_ context.Context, teamKey string) ([]LinearUser, error) {
+	if c.listUsersFn != nil {
+		return c.listUsersFn(teamKey)
+	}
+	return nil, nil
 }
 
 type svcFixture struct {

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -156,7 +156,13 @@ function FilterFields({
 
   return (
     <>
-      <TeamAndAssigneeRow form={form} setForm={setForm} teams={teams} />
+      <TeamRow form={form} setForm={setForm} teams={teams} />
+      <AssigneeAndCreatorRow
+        form={form}
+        setForm={setForm}
+        users={users}
+        loadingUsers={loadingUsers}
+      />
       <div className="space-y-1.5">
         <Label>Priority</Label>
         <p className="text-xs text-muted-foreground">
@@ -164,7 +170,6 @@ function FilterFields({
         </p>
         <PriorityMultiSelect selected={form.priorities} onToggle={togglePriority} />
       </div>
-      <CreatorRow form={form} setForm={setForm} users={users} loadingUsers={loadingUsers} />
       <div className="space-y-1.5">
         <Label>States</Label>
         <p className="text-xs text-muted-foreground">
@@ -203,7 +208,7 @@ function FilterFields({
 
 type FormSetter = React.Dispatch<React.SetStateAction<FormState>>;
 
-function TeamAndAssigneeRow({
+function TeamRow({
   form,
   setForm,
   teams,
@@ -213,17 +218,32 @@ function TeamAndAssigneeRow({
   teams: LinearTeam[];
 }) {
   return (
+    <SelectField
+      label="Team"
+      description="Restrict matches to one team."
+      value={form.teamKey}
+      onChange={(v) =>
+        setForm((p) => ({ ...p, teamKey: v, stateIds: [], labelIds: [], creatorId: "" }))
+      }
+      placeholder="(any team)"
+      items={teams.map((t) => ({ id: t.key, label: `${t.name} (${t.key})` }))}
+    />
+  );
+}
+
+function AssigneeAndCreatorRow({
+  form,
+  setForm,
+  users,
+  loadingUsers,
+}: {
+  form: FormState;
+  setForm: FormSetter;
+  users: LinearUser[];
+  loadingUsers: boolean;
+}) {
+  return (
     <div className="grid grid-cols-2 gap-4">
-      <SelectField
-        label="Team"
-        description="Restrict matches to one team."
-        value={form.teamKey}
-        onChange={(v) =>
-          setForm((p) => ({ ...p, teamKey: v, stateIds: [], labelIds: [], creatorId: "" }))
-        }
-        placeholder="(any team)"
-        items={teams.map((t) => ({ id: t.key, label: `${t.name} (${t.key})` }))}
-      />
       <SelectField
         label="Assignee"
         description="Filter by who an issue is assigned to."
@@ -236,34 +256,19 @@ function TeamAndAssigneeRow({
           { id: "unassigned", label: "Unassigned" },
         ]}
       />
+      <SelectField
+        label="Creator"
+        description="Match issues created by one user."
+        value={form.creatorId || CREATOR_ANY}
+        onChange={(v) => setForm((p) => ({ ...p, creatorId: v === CREATOR_ANY ? "" : v }))}
+        placeholder={creatorPlaceholder(form.teamKey, loadingUsers)}
+        items={[
+          { id: CREATOR_ANY, label: "(any)" },
+          ...users.map((u) => ({ id: u.id, label: userOptionLabel(u) })),
+        ]}
+        disabled={!form.teamKey || loadingUsers}
+      />
     </div>
-  );
-}
-
-function CreatorRow({
-  form,
-  setForm,
-  users,
-  loadingUsers,
-}: {
-  form: FormState;
-  setForm: FormSetter;
-  users: LinearUser[];
-  loadingUsers: boolean;
-}) {
-  return (
-    <SelectField
-      label="Creator"
-      description="Match issues created by one user."
-      value={form.creatorId || CREATOR_ANY}
-      onChange={(v) => setForm((p) => ({ ...p, creatorId: v === CREATOR_ANY ? "" : v }))}
-      placeholder={creatorPlaceholder(form.teamKey, loadingUsers)}
-      items={[
-        { id: CREATOR_ANY, label: "(any)" },
-        ...users.map((u) => ({ id: u.id, label: userOptionLabel(u) })),
-      ]}
-      disabled={!form.teamKey || loadingUsers}
-    />
   );
 }
 
@@ -553,12 +558,20 @@ export function LinearIssueWatchDialog({
             }
             disabled={workspaceLocked}
           />
+          {/* Hairlines separate the four conceptual blocks (Destination /
+              Filter / Automation / Prompt / Settings). Each block answers a
+              different question, so a consistent rhythm helps users navigate
+              the form visually instead of reading it as one long stack. */}
+          <div className="border-t border-border/60" />
           <FilterFields form={form} setForm={setForm} />
+          <div className="border-t border-border/60" />
           <AutomationFields form={form} setForm={setForm} />
+          <div className="border-t border-border/60" />
           <PromptField
             value={form.prompt}
             onChange={(v) => setForm((p) => ({ ...p, prompt: v }))}
           />
+          <div className="border-t border-border/60" />
           <SettingsFields form={form} setForm={setForm} />
         </div>
         <DialogFooter>

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Button } from "@kandev/ui/button";
 import { Switch } from "@kandev/ui/switch";
 import { Label } from "@kandev/ui/label";
 import { Input } from "@kandev/ui/input";
-import { Badge } from "@kandev/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -21,20 +20,30 @@ import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
 import { useWorkflowSteps, stepPlaceholder } from "@/hooks/use-workflow-steps";
-import { listLinearTeams, listLinearStates } from "@/lib/api/domains/linear-api";
 import {
   ScriptEditor,
   computeEditorHeight,
 } from "@/components/settings/profile-edit/script-editor";
+import { LabelMultiSelect, StateMultiSelect, useTeamsAndStates } from "./linear-issue-watch-fields";
+import { LINEAR_ISSUE_WATCH_PLACEHOLDERS } from "./linear-issue-watch-placeholders";
 import {
-  LINEAR_ISSUE_WATCH_PLACEHOLDERS,
-  DEFAULT_LINEAR_ISSUE_WATCH_PROMPT,
-} from "./linear-issue-watch-placeholders";
+  ASSIGNED_ANY,
+  CREATOR_ANY,
+  PRIORITY_ANY,
+  PRIORITY_OPTIONS,
+  type FormState,
+  buildFilterPayload,
+  creatorPlaceholder,
+  filterIsEmpty,
+  formStateFromWatch,
+  makeEmptyForm,
+  userOptionLabel,
+} from "./linear-issue-watch-form";
 import type {
   CreateLinearIssueWatchInput,
   LinearIssueWatch,
   LinearTeam,
-  LinearWorkflowState,
+  LinearUser,
   UpdateLinearIssueWatchInput,
 } from "@/lib/types/linear";
 
@@ -46,57 +55,6 @@ type Props = {
   onCreate: (req: CreateLinearIssueWatchInput) => Promise<unknown>;
   onUpdate: (id: string, req: UpdateLinearIssueWatchInput) => Promise<unknown>;
 };
-
-type FormState = {
-  workspaceId: string;
-  query: string;
-  teamKey: string;
-  stateIds: string[];
-  assigned: string;
-  workflowId: string;
-  workflowStepId: string;
-  agentProfileId: string;
-  executorProfileId: string;
-  prompt: string;
-  enabled: boolean;
-  pollInterval: number;
-};
-
-const ASSIGNED_ANY = "__any__";
-
-function makeEmptyForm(workspaceId: string): FormState {
-  return {
-    workspaceId,
-    query: "",
-    teamKey: "",
-    stateIds: [],
-    assigned: "",
-    workflowId: "",
-    workflowStepId: "",
-    agentProfileId: "",
-    executorProfileId: "",
-    prompt: DEFAULT_LINEAR_ISSUE_WATCH_PROMPT,
-    enabled: true,
-    pollInterval: 300,
-  };
-}
-
-function formStateFromWatch(w: LinearIssueWatch): FormState {
-  return {
-    workspaceId: w.workspaceId,
-    query: w.filter?.query ?? "",
-    teamKey: w.filter?.teamKey ?? "",
-    stateIds: w.filter?.stateIds ?? [],
-    assigned: w.filter?.assigned ?? "",
-    workflowId: w.workflowId,
-    workflowStepId: w.workflowStepId,
-    agentProfileId: w.agentProfileId,
-    executorProfileId: w.executorProfileId,
-    prompt: w.prompt || DEFAULT_LINEAR_ISSUE_WATCH_PROMPT,
-    enabled: w.enabled,
-    pollInterval: w.pollIntervalSeconds,
-  };
-}
 
 function useFormData(workspaceId: string) {
   useSettingsData(true);
@@ -152,100 +110,6 @@ function SelectField(props: {
   );
 }
 
-function StateMultiSelect({
-  states,
-  loading,
-  selected,
-  onToggle,
-  disabled,
-}: {
-  states: LinearWorkflowState[];
-  loading: boolean;
-  selected: string[];
-  onToggle: (id: string) => void;
-  disabled: boolean;
-}) {
-  if (disabled) {
-    return (
-      <p className="text-xs text-muted-foreground">
-        Pick a team to choose specific workflow states.
-      </p>
-    );
-  }
-  if (loading) {
-    return <p className="text-xs text-muted-foreground">Loading states…</p>;
-  }
-  if (states.length === 0) {
-    return <p className="text-xs text-muted-foreground">No workflow states available.</p>;
-  }
-  return (
-    <div className="flex flex-wrap gap-1.5">
-      {states.map((s) => {
-        const active = selected.includes(s.id);
-        return (
-          <Badge
-            key={s.id}
-            variant={active ? "default" : "outline"}
-            className="cursor-pointer"
-            onClick={() => onToggle(s.id)}
-          >
-            {s.name}
-          </Badge>
-        );
-      })}
-    </div>
-  );
-}
-
-// useTeamsAndStates loads the team list once Linear is configured, plus the
-// states for the currently-selected team. The states map is keyed by teamKey
-// so switching teams renders an empty list without us having to setState in
-// an effect — only the lookup expression changes.
-function useTeamsAndStates(teamKey: string) {
-  const [teams, setTeams] = useState<LinearTeam[]>([]);
-  const [statesByTeam, setStatesByTeam] = useState<Record<string, LinearWorkflowState[]>>({});
-  // Track which teams we've already kicked off a fetch for so the effect
-  // doesn't list `statesByTeam` as a dep (which would re-fire whenever any
-  // team's states load). A ref mutation isn't reactive, so the sole input
-  // that schedules a fetch is `teamKey`.
-  const fetchedTeams = useRef<Set<string>>(new Set());
-
-  useEffect(() => {
-    let cancelled = false;
-    listLinearTeams()
-      .then((res) => {
-        if (!cancelled) setTeams(res.teams ?? []);
-      })
-      .catch(() => {
-        if (!cancelled) setTeams([]);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!teamKey || fetchedTeams.current.has(teamKey)) return;
-    fetchedTeams.current.add(teamKey);
-    let cancelled = false;
-    listLinearStates(teamKey)
-      .then((res) => {
-        if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: res.states ?? [] }));
-      })
-      .catch(() => {
-        if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: [] }));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [teamKey]);
-
-  const states = teamKey ? (statesByTeam[teamKey] ?? []) : [];
-  // "loading" = a team is selected but we haven't received a result yet.
-  const loadingStates = !!teamKey && statesByTeam[teamKey] === undefined;
-  return { teams, states, loadingStates };
-}
-
 function FilterFields({
   form,
   setForm,
@@ -253,7 +117,8 @@ function FilterFields({
   form: FormState;
   setForm: React.Dispatch<React.SetStateAction<FormState>>;
 }) {
-  const { teams, states, loadingStates } = useTeamsAndStates(form.teamKey);
+  const { teams, states, labels, users, loadingStates, loadingLabels, loadingUsers } =
+    useTeamsAndStates(form.teamKey);
   const toggleState = useCallback(
     (id: string) =>
       setForm((p) => ({
@@ -264,31 +129,26 @@ function FilterFields({
       })),
     [setForm],
   );
+  const toggleLabel = useCallback(
+    (id: string) =>
+      setForm((p) => ({
+        ...p,
+        labelIds: p.labelIds.includes(id)
+          ? p.labelIds.filter((l) => l !== id)
+          : [...p.labelIds, id],
+      })),
+    [setForm],
+  );
 
   return (
     <>
-      <div className="grid grid-cols-2 gap-4">
-        <SelectField
-          label="Team"
-          description="Restrict matches to one team."
-          value={form.teamKey}
-          onChange={(v) => setForm((p) => ({ ...p, teamKey: v, stateIds: [] }))}
-          placeholder="(any team)"
-          items={teams.map((t) => ({ id: t.key, label: `${t.name} (${t.key})` }))}
-        />
-        <SelectField
-          label="Assignee"
-          description="Filter by who an issue is assigned to."
-          value={form.assigned || ASSIGNED_ANY}
-          onChange={(v) => setForm((p) => ({ ...p, assigned: v === ASSIGNED_ANY ? "" : v }))}
-          placeholder="(any)"
-          items={[
-            { id: ASSIGNED_ANY, label: "(any)" },
-            { id: "me", label: "Me" },
-            { id: "unassigned", label: "Unassigned" },
-          ]}
-        />
-      </div>
+      <TeamAndAssigneeRow form={form} setForm={setForm} teams={teams} />
+      <PriorityAndCreatorRow
+        form={form}
+        setForm={setForm}
+        users={users}
+        loadingUsers={loadingUsers}
+      />
       <div className="space-y-1.5">
         <Label>States</Label>
         <p className="text-xs text-muted-foreground">
@@ -303,17 +163,150 @@ function FilterFields({
         />
       </div>
       <div className="space-y-1.5">
-        <Label>Query</Label>
+        <Label>Labels</Label>
         <p className="text-xs text-muted-foreground">
-          Free-text match across title and description (optional).
+          Click to toggle. Matches issues that have ANY of the selected labels.
         </p>
-        <Input
-          value={form.query}
-          onChange={(e) => setForm((p) => ({ ...p, query: e.target.value }))}
-          placeholder="auth bug"
+        <LabelMultiSelect
+          labels={labels}
+          loading={loadingLabels}
+          selected={form.labelIds}
+          onToggle={toggleLabel}
+          disabled={!form.teamKey}
         />
       </div>
+      <EstimateRow form={form} setForm={setForm} />
+      <QueryField form={form} setForm={setForm} />
     </>
+  );
+}
+
+type FormSetter = React.Dispatch<React.SetStateAction<FormState>>;
+
+function TeamAndAssigneeRow({
+  form,
+  setForm,
+  teams,
+}: {
+  form: FormState;
+  setForm: FormSetter;
+  teams: LinearTeam[];
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <SelectField
+        label="Team"
+        description="Restrict matches to one team."
+        value={form.teamKey}
+        onChange={(v) =>
+          setForm((p) => ({ ...p, teamKey: v, stateIds: [], labelIds: [], creatorId: "" }))
+        }
+        placeholder="(any team)"
+        items={teams.map((t) => ({ id: t.key, label: `${t.name} (${t.key})` }))}
+      />
+      <SelectField
+        label="Assignee"
+        description="Filter by who an issue is assigned to."
+        value={form.assigned || ASSIGNED_ANY}
+        onChange={(v) => setForm((p) => ({ ...p, assigned: v === ASSIGNED_ANY ? "" : v }))}
+        placeholder="(any)"
+        items={[
+          { id: ASSIGNED_ANY, label: "(any)" },
+          { id: "me", label: "Me" },
+          { id: "unassigned", label: "Unassigned" },
+        ]}
+      />
+    </div>
+  );
+}
+
+function PriorityAndCreatorRow({
+  form,
+  setForm,
+  users,
+  loadingUsers,
+}: {
+  form: FormState;
+  setForm: FormSetter;
+  users: LinearUser[];
+  loadingUsers: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <SelectField
+        label="Priority"
+        description="Match issues at one priority level."
+        value={form.priority === null ? PRIORITY_ANY : String(form.priority)}
+        onChange={(v) =>
+          setForm((p) => ({ ...p, priority: v === PRIORITY_ANY ? null : Number(v) }))
+        }
+        placeholder="(any)"
+        items={PRIORITY_OPTIONS}
+      />
+      <SelectField
+        label="Creator"
+        description="Match issues created by one user."
+        value={form.creatorId || CREATOR_ANY}
+        onChange={(v) => setForm((p) => ({ ...p, creatorId: v === CREATOR_ANY ? "" : v }))}
+        placeholder={creatorPlaceholder(form.teamKey, loadingUsers)}
+        items={[
+          { id: CREATOR_ANY, label: "(any)" },
+          ...users.map((u) => ({ id: u.id, label: userOptionLabel(u) })),
+        ]}
+        disabled={!form.teamKey || loadingUsers}
+      />
+    </div>
+  );
+}
+
+function EstimateRow({ form, setForm }: { form: FormState; setForm: FormSetter }) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <div className="space-y-1.5">
+        <Label>Estimate min</Label>
+        <p className="text-xs text-muted-foreground">
+          Lower bound (points). Leave empty for no minimum.
+        </p>
+        <Input
+          type="number"
+          value={form.estimateMin}
+          onChange={(e) => setForm((p) => ({ ...p, estimateMin: e.target.value }))}
+          min={0}
+          step="0.5"
+          placeholder="e.g. 1"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label>Estimate max</Label>
+        <p className="text-xs text-muted-foreground">
+          Upper bound (points). Leave empty for no maximum.
+        </p>
+        <Input
+          type="number"
+          value={form.estimateMax}
+          onChange={(e) => setForm((p) => ({ ...p, estimateMax: e.target.value }))}
+          min={0}
+          step="0.5"
+          placeholder="e.g. 5"
+        />
+      </div>
+    </div>
+  );
+}
+
+function QueryField({ form, setForm }: { form: FormState; setForm: FormSetter }) {
+  return (
+    <div className="space-y-1.5">
+      <Label>Query</Label>
+      <p className="text-xs text-muted-foreground">
+        Free-text match across title and description (optional).
+      </p>
+      <Input
+        value={form.query}
+        onChange={(e) => setForm((p) => ({ ...p, query: e.target.value }))}
+        placeholder="auth bug"
+      />
+    </div>
   );
 }
 
@@ -481,15 +474,6 @@ function savingLabel(saving: boolean, isEdit: boolean): string {
   return isEdit ? "Update" : "Create";
 }
 
-function filterIsEmpty(form: FormState): boolean {
-  return (
-    form.query.trim() === "" &&
-    form.teamKey.trim() === "" &&
-    form.assigned.trim() === "" &&
-    form.stateIds.length === 0
-  );
-}
-
 export function LinearIssueWatchDialog({
   open,
   onOpenChange,
@@ -522,12 +506,7 @@ export function LinearIssueWatchDialog({
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      const filter = {
-        query: form.query.trim() || undefined,
-        teamKey: form.teamKey.trim() || undefined,
-        stateIds: form.stateIds.length > 0 ? form.stateIds : undefined,
-        assigned: form.assigned.trim() || undefined,
-      };
+      const filter = buildFilterPayload(form);
       const payload = {
         filter,
         workflowId: form.workflowId,

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -37,6 +37,7 @@ import {
   filterIsEmpty,
   formStateFromWatch,
   makeEmptyForm,
+  parsePriority,
   userOptionLabel,
 } from "./linear-issue-watch-form";
 import type {
@@ -237,9 +238,7 @@ function PriorityAndCreatorRow({
         label="Priority"
         description="Match issues at one priority level."
         value={form.priority === null ? PRIORITY_ANY : String(form.priority)}
-        onChange={(v) =>
-          setForm((p) => ({ ...p, priority: v === PRIORITY_ANY ? null : Number(v) }))
-        }
+        onChange={(v) => setForm((p) => ({ ...p, priority: parsePriority(v) }))}
         placeholder="(any)"
         items={PRIORITY_OPTIONS}
       />

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -24,20 +24,23 @@ import {
   ScriptEditor,
   computeEditorHeight,
 } from "@/components/settings/profile-edit/script-editor";
-import { LabelMultiSelect, StateMultiSelect, useTeamsAndStates } from "./linear-issue-watch-fields";
+import {
+  LabelMultiSelect,
+  PriorityMultiSelect,
+  StateMultiSelect,
+  useTeamsAndStates,
+} from "./linear-issue-watch-fields";
 import { LINEAR_ISSUE_WATCH_PLACEHOLDERS } from "./linear-issue-watch-placeholders";
 import {
   ASSIGNED_ANY,
   CREATOR_ANY,
-  PRIORITY_ANY,
-  PRIORITY_OPTIONS,
   type FormState,
+  type LinearPriority,
   buildFilterPayload,
   creatorPlaceholder,
   filterIsEmpty,
   formStateFromWatch,
   makeEmptyForm,
-  parsePriority,
   userOptionLabel,
 } from "./linear-issue-watch-form";
 import type {
@@ -140,16 +143,28 @@ function FilterFields({
       })),
     [setForm],
   );
+  const togglePriority = useCallback(
+    (priority: LinearPriority) =>
+      setForm((p) => ({
+        ...p,
+        priorities: p.priorities.includes(priority)
+          ? p.priorities.filter((x) => x !== priority)
+          : [...p.priorities, priority],
+      })),
+    [setForm],
+  );
 
   return (
     <>
       <TeamAndAssigneeRow form={form} setForm={setForm} teams={teams} />
-      <PriorityAndCreatorRow
-        form={form}
-        setForm={setForm}
-        users={users}
-        loadingUsers={loadingUsers}
-      />
+      <div className="space-y-1.5">
+        <Label>Priority</Label>
+        <p className="text-xs text-muted-foreground">
+          Click to toggle. Matches issues at ANY of the selected priorities.
+        </p>
+        <PriorityMultiSelect selected={form.priorities} onToggle={togglePriority} />
+      </div>
+      <CreatorRow form={form} setForm={setForm} users={users} loadingUsers={loadingUsers} />
       <div className="space-y-1.5">
         <Label>States</Label>
         <p className="text-xs text-muted-foreground">
@@ -225,7 +240,7 @@ function TeamAndAssigneeRow({
   );
 }
 
-function PriorityAndCreatorRow({
+function CreatorRow({
   form,
   setForm,
   users,
@@ -237,28 +252,18 @@ function PriorityAndCreatorRow({
   loadingUsers: boolean;
 }) {
   return (
-    <div className="grid grid-cols-2 gap-4">
-      <SelectField
-        label="Priority"
-        description="Match issues at one priority level."
-        value={form.priority === null ? PRIORITY_ANY : String(form.priority)}
-        onChange={(v) => setForm((p) => ({ ...p, priority: parsePriority(v) }))}
-        placeholder="(any)"
-        items={PRIORITY_OPTIONS}
-      />
-      <SelectField
-        label="Creator"
-        description="Match issues created by one user."
-        value={form.creatorId || CREATOR_ANY}
-        onChange={(v) => setForm((p) => ({ ...p, creatorId: v === CREATOR_ANY ? "" : v }))}
-        placeholder={creatorPlaceholder(form.teamKey, loadingUsers)}
-        items={[
-          { id: CREATOR_ANY, label: "(any)" },
-          ...users.map((u) => ({ id: u.id, label: userOptionLabel(u) })),
-        ]}
-        disabled={!form.teamKey || loadingUsers}
-      />
-    </div>
+    <SelectField
+      label="Creator"
+      description="Match issues created by one user."
+      value={form.creatorId || CREATOR_ANY}
+      onChange={(v) => setForm((p) => ({ ...p, creatorId: v === CREATOR_ANY ? "" : v }))}
+      placeholder={creatorPlaceholder(form.teamKey, loadingUsers)}
+      items={[
+        { id: CREATOR_ANY, label: "(any)" },
+        ...users.map((u) => ({ id: u.id, label: userOptionLabel(u) })),
+      ]}
+      disabled={!form.teamKey || loadingUsers}
+    />
   );
 }
 

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Button } from "@kandev/ui/button";
+import { Separator } from "@kandev/ui/separator";
 import { Switch } from "@kandev/ui/switch";
 import { Label } from "@kandev/ui/label";
 import { Input } from "@kandev/ui/input";
@@ -558,20 +559,20 @@ export function LinearIssueWatchDialog({
             }
             disabled={workspaceLocked}
           />
-          {/* Hairlines separate the four conceptual blocks (Destination /
+          {/* Hairlines separate the five conceptual blocks (Destination /
               Filter / Automation / Prompt / Settings). Each block answers a
               different question, so a consistent rhythm helps users navigate
               the form visually instead of reading it as one long stack. */}
-          <div className="border-t border-border/60" />
+          <Separator />
           <FilterFields form={form} setForm={setForm} />
-          <div className="border-t border-border/60" />
+          <Separator />
           <AutomationFields form={form} setForm={setForm} />
-          <div className="border-t border-border/60" />
+          <Separator />
           <PromptField
             value={form.prompt}
             onChange={(v) => setForm((p) => ({ ...p, prompt: v }))}
           />
-          <div className="border-t border-border/60" />
+          <Separator />
           <SettingsFields form={form} setForm={setForm} />
         </div>
         <DialogFooter>

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -153,7 +153,9 @@ function FilterFields({
       <div className="space-y-1.5">
         <Label>States</Label>
         <p className="text-xs text-muted-foreground">
-          Click states to toggle. Empty matches every state on the team.
+          {form.teamKey
+            ? "Click states to toggle. Empty matches every state on the team."
+            : "Pick a team to choose specific workflow states."}
         </p>
         <StateMultiSelect
           states={states}
@@ -166,7 +168,9 @@ function FilterFields({
       <div className="space-y-1.5">
         <Label>Labels</Label>
         <p className="text-xs text-muted-foreground">
-          Click to toggle. Matches issues that have ANY of the selected labels.
+          {form.teamKey
+            ? "Click to toggle. Matches ANY of the selected labels."
+            : "Pick a team to choose specific labels."}
         </p>
         <LabelMultiSelect
           labels={labels}
@@ -263,9 +267,7 @@ function EstimateRow({ form, setForm }: { form: FormState; setForm: FormSetter }
     <div className="grid grid-cols-2 gap-4">
       <div className="space-y-1.5">
         <Label>Estimate min</Label>
-        <p className="text-xs text-muted-foreground">
-          Lower bound (points). Leave empty for no minimum.
-        </p>
+        <p className="text-xs text-muted-foreground">Lower bound in points (optional).</p>
         <Input
           type="number"
           value={form.estimateMin}
@@ -277,9 +279,7 @@ function EstimateRow({ form, setForm }: { form: FormState; setForm: FormSetter }
       </div>
       <div className="space-y-1.5">
         <Label>Estimate max</Label>
-        <p className="text-xs text-muted-foreground">
-          Upper bound (points). Leave empty for no maximum.
-        </p>
+        <p className="text-xs text-muted-foreground">Upper bound in points (optional).</p>
         <Input
           type="number"
           value={form.estimateMax}

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -37,11 +37,15 @@ export function useTeamsAndStates(teamKey: string) {
   }, []);
 
   useEffect(() => {
-    if (!teamKey || fetchedTeams.current.has(teamKey)) return;
+    // Capture the Set once so cleanup uses the exact instance the effect
+    // body added to (ref.current is stable across renders, but eslint can't
+    // prove that — so we assign to a local).
+    const fetched = fetchedTeams.current;
+    if (!teamKey || fetched.has(teamKey)) return;
     // Mark in-flight so concurrent renders don't double-fetch; clear on
     // failure so a subsequent remount can retry instead of being stuck with
     // an empty cached entry.
-    fetchedTeams.current.add(teamKey);
+    fetched.add(teamKey);
     let cancelled = false;
     let anyFailed = false;
     const markFailed = () => {
@@ -73,13 +77,18 @@ export function useTeamsAndStates(teamKey: string) {
           if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: [] }));
         }),
     ]).finally(() => {
-      // Clear the marker on failure OR cancellation so a remount can retry
-      // — leaving it set would permanently strand the team's data as
-      // whatever partial result the previous effect left behind.
-      if (anyFailed || cancelled) fetchedTeams.current.delete(teamKey);
+      // If a fetch failed (and we didn't cancel), drop the marker so the
+      // next visit to this team can retry. Success-path marker stays so
+      // cached data is reused.
+      if (anyFailed) fetched.delete(teamKey);
     });
     return () => {
       cancelled = true;
+      // Drop the marker on cleanup so rapid team switches (A → B → A)
+      // re-fetch on return. The fetch promise's late-arriving `if
+      // (!cancelled)` guard already prevents stale writes; without this
+      // delete the team could otherwise be stranded mid-load.
+      fetched.delete(teamKey);
     };
   }, [teamKey]);
 

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -73,7 +73,10 @@ export function useTeamsAndStates(teamKey: string) {
           if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: [] }));
         }),
     ]).finally(() => {
-      if (anyFailed) fetchedTeams.current.delete(teamKey);
+      // Clear the marker on failure OR cancellation so a remount can retry
+      // — leaving it set would permanently strand the team's data as
+      // whatever partial result the previous effect left behind.
+      if (anyFailed || cancelled) fetchedTeams.current.delete(teamKey);
     });
     return () => {
       cancelled = true;

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -8,6 +8,7 @@ import {
   listLinearTeams,
   listLinearUsers,
 } from "@/lib/api/domains/linear-api";
+import { PRIORITY_OPTIONS, type LinearPriority } from "./linear-issue-watch-form";
 import type { LinearLabel, LinearTeam, LinearUser, LinearWorkflowState } from "@/lib/types/linear";
 
 // useTeamsAndStates loads the team list once Linear is configured, plus the
@@ -141,6 +142,33 @@ export function StateMultiSelect({
             className="cursor-pointer"
           >
             <Badge variant={active ? "default" : "outline"}>{s.name}</Badge>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function PriorityMultiSelect({
+  selected,
+  onToggle,
+}: {
+  selected: LinearPriority[];
+  onToggle: (p: LinearPriority) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {PRIORITY_OPTIONS.map((opt) => {
+        const active = selected.includes(opt.value);
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onToggle(opt.value)}
+            aria-pressed={active}
+            className="cursor-pointer"
+          >
+            <Badge variant={active ? "default" : "outline"}>{opt.label}</Badge>
           </button>
         );
       })}

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -38,29 +38,43 @@ export function useTeamsAndStates(teamKey: string) {
 
   useEffect(() => {
     if (!teamKey || fetchedTeams.current.has(teamKey)) return;
+    // Mark in-flight so concurrent renders don't double-fetch; clear on
+    // failure so a subsequent remount can retry instead of being stuck with
+    // an empty cached entry.
     fetchedTeams.current.add(teamKey);
     let cancelled = false;
-    listLinearStates(teamKey)
-      .then((res) => {
-        if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: res.states ?? [] }));
-      })
-      .catch(() => {
-        if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: [] }));
-      });
-    listLinearLabels(teamKey)
-      .then((res) => {
-        if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: res.labels ?? [] }));
-      })
-      .catch(() => {
-        if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: [] }));
-      });
-    listLinearUsers(teamKey)
-      .then((res) => {
-        if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: res.users ?? [] }));
-      })
-      .catch(() => {
-        if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: [] }));
-      });
+    let anyFailed = false;
+    const markFailed = () => {
+      anyFailed = true;
+    };
+    Promise.allSettled([
+      listLinearStates(teamKey)
+        .then((res) => {
+          if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: res.states ?? [] }));
+        })
+        .catch(() => {
+          markFailed();
+          if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: [] }));
+        }),
+      listLinearLabels(teamKey)
+        .then((res) => {
+          if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: res.labels ?? [] }));
+        })
+        .catch(() => {
+          markFailed();
+          if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: [] }));
+        }),
+      listLinearUsers(teamKey)
+        .then((res) => {
+          if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: res.users ?? [] }));
+        })
+        .catch(() => {
+          markFailed();
+          if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: [] }));
+        }),
+    ]).finally(() => {
+      if (anyFailed) fetchedTeams.current.delete(teamKey);
+    });
     return () => {
       cancelled = true;
     };
@@ -106,14 +120,15 @@ export function StateMultiSelect({
       {states.map((s) => {
         const active = selected.includes(s.id);
         return (
-          <Badge
+          <button
             key={s.id}
-            variant={active ? "default" : "outline"}
-            className="cursor-pointer"
+            type="button"
             onClick={() => onToggle(s.id)}
+            aria-pressed={active}
+            className="cursor-pointer"
           >
-            {s.name}
-          </Badge>
+            <Badge variant={active ? "default" : "outline"}>{s.name}</Badge>
+          </button>
         );
       })}
     </div>
@@ -147,14 +162,15 @@ export function LabelMultiSelect({
       {labels.map((l) => {
         const active = selected.includes(l.id);
         return (
-          <Badge
+          <button
             key={l.id}
-            variant={active ? "default" : "outline"}
-            className="cursor-pointer"
+            type="button"
             onClick={() => onToggle(l.id)}
+            aria-pressed={active}
+            className="cursor-pointer"
           >
-            {l.name}
-          </Badge>
+            <Badge variant={active ? "default" : "outline"}>{l.name}</Badge>
+          </button>
         );
       })}
     </div>

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Badge } from "@kandev/ui/badge";
+import {
+  listLinearLabels,
+  listLinearStates,
+  listLinearTeams,
+  listLinearUsers,
+} from "@/lib/api/domains/linear-api";
+import type { LinearLabel, LinearTeam, LinearUser, LinearWorkflowState } from "@/lib/types/linear";
+
+// useTeamsAndStates loads the team list once Linear is configured, plus the
+// states, labels, and users for the currently-selected team. Each per-team
+// dataset is cached so switching teams renders an empty list (or the cached
+// list) without us having to setState in an effect — only the lookup
+// expression changes.
+export function useTeamsAndStates(teamKey: string) {
+  const [teams, setTeams] = useState<LinearTeam[]>([]);
+  const [statesByTeam, setStatesByTeam] = useState<Record<string, LinearWorkflowState[]>>({});
+  const [labelsByTeam, setLabelsByTeam] = useState<Record<string, LinearLabel[]>>({});
+  const [usersByTeam, setUsersByTeam] = useState<Record<string, LinearUser[]>>({});
+  const fetchedTeams = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    listLinearTeams()
+      .then((res) => {
+        if (!cancelled) setTeams(res.teams ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setTeams([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!teamKey || fetchedTeams.current.has(teamKey)) return;
+    fetchedTeams.current.add(teamKey);
+    let cancelled = false;
+    listLinearStates(teamKey)
+      .then((res) => {
+        if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: res.states ?? [] }));
+      })
+      .catch(() => {
+        if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: [] }));
+      });
+    listLinearLabels(teamKey)
+      .then((res) => {
+        if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: res.labels ?? [] }));
+      })
+      .catch(() => {
+        if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: [] }));
+      });
+    listLinearUsers(teamKey)
+      .then((res) => {
+        if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: res.users ?? [] }));
+      })
+      .catch(() => {
+        if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: [] }));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [teamKey]);
+
+  const states = teamKey ? (statesByTeam[teamKey] ?? []) : [];
+  const labels = teamKey ? (labelsByTeam[teamKey] ?? []) : [];
+  const users = teamKey ? (usersByTeam[teamKey] ?? []) : [];
+  const loadingStates = !!teamKey && statesByTeam[teamKey] === undefined;
+  const loadingLabels = !!teamKey && labelsByTeam[teamKey] === undefined;
+  const loadingUsers = !!teamKey && usersByTeam[teamKey] === undefined;
+  return { teams, states, labels, users, loadingStates, loadingLabels, loadingUsers };
+}
+
+export function StateMultiSelect({
+  states,
+  loading,
+  selected,
+  onToggle,
+  disabled,
+}: {
+  states: LinearWorkflowState[];
+  loading: boolean;
+  selected: string[];
+  onToggle: (id: string) => void;
+  disabled: boolean;
+}) {
+  if (disabled) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Pick a team to choose specific workflow states.
+      </p>
+    );
+  }
+  if (loading) {
+    return <p className="text-xs text-muted-foreground">Loading states…</p>;
+  }
+  if (states.length === 0) {
+    return <p className="text-xs text-muted-foreground">No workflow states available.</p>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {states.map((s) => {
+        const active = selected.includes(s.id);
+        return (
+          <Badge
+            key={s.id}
+            variant={active ? "default" : "outline"}
+            className="cursor-pointer"
+            onClick={() => onToggle(s.id)}
+          >
+            {s.name}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
+export function LabelMultiSelect({
+  labels,
+  loading,
+  selected,
+  onToggle,
+  disabled,
+}: {
+  labels: LinearLabel[];
+  loading: boolean;
+  selected: string[];
+  onToggle: (id: string) => void;
+  disabled: boolean;
+}) {
+  if (disabled) {
+    return <p className="text-xs text-muted-foreground">Pick a team to choose specific labels.</p>;
+  }
+  if (loading) {
+    return <p className="text-xs text-muted-foreground">Loading labels…</p>;
+  }
+  if (labels.length === 0) {
+    return <p className="text-xs text-muted-foreground">No labels available for this team.</p>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {labels.map((l) => {
+        const active = selected.includes(l.id);
+        return (
+          <Badge
+            key={l.id}
+            variant={active ? "default" : "outline"}
+            className="cursor-pointer"
+            onClick={() => onToggle(l.id)}
+          >
+            {l.name}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -48,6 +48,7 @@ export function useTeamsAndStates(teamKey: string) {
     fetched.add(teamKey);
     let cancelled = false;
     let anyFailed = false;
+    let loaded = false;
     const markFailed = () => {
       anyFailed = true;
     };
@@ -77,6 +78,9 @@ export function useTeamsAndStates(teamKey: string) {
           if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: [] }));
         }),
     ]).finally(() => {
+      // Track full success so cleanup can keep the cache marker — otherwise
+      // every cleanup wipes it and the next visit refetches.
+      loaded = !cancelled && !anyFailed;
       // If a fetch failed (and we didn't cancel), drop the marker so the
       // next visit to this team can retry. Success-path marker stays so
       // cached data is reused.
@@ -84,11 +88,10 @@ export function useTeamsAndStates(teamKey: string) {
     });
     return () => {
       cancelled = true;
-      // Drop the marker on cleanup so rapid team switches (A → B → A)
-      // re-fetch on return. The fetch promise's late-arriving `if
-      // (!cancelled)` guard already prevents stale writes; without this
-      // delete the team could otherwise be stranded mid-load.
-      fetched.delete(teamKey);
+      // Drop the marker on cleanup ONLY when the fetch hadn't completed
+      // successfully — that handles the rapid-switch (A→B→A) case without
+      // also evicting a healthy cache after a normal team change.
+      if (!loaded) fetched.delete(teamKey);
     };
   }, [teamKey]);
 

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -115,11 +115,9 @@ export function StateMultiSelect({
   disabled: boolean;
 }) {
   if (disabled) {
-    return (
-      <p className="text-xs text-muted-foreground">
-        Pick a team to choose specific workflow states.
-      </p>
-    );
+    // Caller's row description already explains the disabled state — render
+    // nothing here to avoid duplicate prose.
+    return null;
   }
   if (loading) {
     return <p className="text-xs text-muted-foreground">Loading states…</p>;
@@ -161,7 +159,9 @@ export function LabelMultiSelect({
   disabled: boolean;
 }) {
   if (disabled) {
-    return <p className="text-xs text-muted-foreground">Pick a team to choose specific labels.</p>;
+    // Caller's row description already explains the disabled state — render
+    // nothing here to avoid duplicate prose.
+    return null;
   }
   if (loading) {
     return <p className="text-xs text-muted-foreground">Loading labels…</p>;

--- a/apps/web/components/linear/linear-issue-watch-form.ts
+++ b/apps/web/components/linear/linear-issue-watch-form.ts
@@ -16,13 +16,15 @@ export const PRIORITY_OPTIONS: { id: string; label: string }[] = [
   { id: "4", label: "Low" },
 ];
 
-export type FormState = {
+export type LinearPriority = 0 | 1 | 2 | 3 | 4;
+
+export interface FormState {
   workspaceId: string;
   query: string;
   teamKey: string;
   stateIds: string[];
   assigned: string;
-  priority: number | null;
+  priority: LinearPriority | null;
   labelIds: string[];
   creatorId: string;
   estimateMin: string;
@@ -34,7 +36,7 @@ export type FormState = {
   prompt: string;
   enabled: boolean;
   pollInterval: number;
-};
+}
 
 export function makeEmptyForm(workspaceId: string): FormState {
   return {
@@ -83,6 +85,13 @@ export function formStateFromWatch(w: LinearIssueWatch): FormState {
     enabled: w.enabled,
     pollInterval: w.pollIntervalSeconds,
   };
+}
+
+export function parsePriority(raw: string): LinearPriority | null {
+  if (raw === PRIORITY_ANY) return null;
+  const n = Number(raw);
+  if (n === 0 || n === 1 || n === 2 || n === 3 || n === 4) return n;
+  return null;
 }
 
 export function parseEstimate(raw: string): number | undefined {

--- a/apps/web/components/linear/linear-issue-watch-form.ts
+++ b/apps/web/components/linear/linear-issue-watch-form.ts
@@ -89,7 +89,8 @@ export function parseEstimate(raw: string): number | undefined {
   const t = raw.trim();
   if (t === "") return undefined;
   const n = Number(t);
-  return Number.isFinite(n) ? n : undefined;
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return n;
 }
 
 export function filterIsEmpty(form: FormState): boolean {

--- a/apps/web/components/linear/linear-issue-watch-form.ts
+++ b/apps/web/components/linear/linear-issue-watch-form.ts
@@ -1,0 +1,133 @@
+import type { LinearIssueWatch, LinearSearchFilter, LinearUser } from "@/lib/types/linear";
+import { DEFAULT_LINEAR_ISSUE_WATCH_PROMPT } from "./linear-issue-watch-placeholders";
+
+export const ASSIGNED_ANY = "__any__";
+export const PRIORITY_ANY = "__any__";
+export const CREATOR_ANY = "__any__";
+
+// Linear priorities: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Encoded as
+// strings for use as Select values; converted back at the form boundary.
+export const PRIORITY_OPTIONS: { id: string; label: string }[] = [
+  { id: PRIORITY_ANY, label: "(any)" },
+  { id: "0", label: "No priority" },
+  { id: "1", label: "Urgent" },
+  { id: "2", label: "High" },
+  { id: "3", label: "Medium" },
+  { id: "4", label: "Low" },
+];
+
+export type FormState = {
+  workspaceId: string;
+  query: string;
+  teamKey: string;
+  stateIds: string[];
+  assigned: string;
+  priority: number | null;
+  labelIds: string[];
+  creatorId: string;
+  estimateMin: string;
+  estimateMax: string;
+  workflowId: string;
+  workflowStepId: string;
+  agentProfileId: string;
+  executorProfileId: string;
+  prompt: string;
+  enabled: boolean;
+  pollInterval: number;
+};
+
+export function makeEmptyForm(workspaceId: string): FormState {
+  return {
+    workspaceId,
+    query: "",
+    teamKey: "",
+    stateIds: [],
+    assigned: "",
+    priority: null,
+    labelIds: [],
+    creatorId: "",
+    estimateMin: "",
+    estimateMax: "",
+    workflowId: "",
+    workflowStepId: "",
+    agentProfileId: "",
+    executorProfileId: "",
+    prompt: DEFAULT_LINEAR_ISSUE_WATCH_PROMPT,
+    enabled: true,
+    pollInterval: 300,
+  };
+}
+
+function estimateString(v: number | null | undefined): string {
+  return v === undefined || v === null ? "" : String(v);
+}
+
+export function formStateFromWatch(w: LinearIssueWatch): FormState {
+  const f: LinearSearchFilter = w.filter ?? {};
+  return {
+    workspaceId: w.workspaceId,
+    query: f.query ?? "",
+    teamKey: f.teamKey ?? "",
+    stateIds: f.stateIds ?? [],
+    assigned: f.assigned ?? "",
+    priority: f.priority ?? null,
+    labelIds: f.labelIds ?? [],
+    creatorId: f.creatorId ?? "",
+    estimateMin: estimateString(f.estimateMin),
+    estimateMax: estimateString(f.estimateMax),
+    workflowId: w.workflowId,
+    workflowStepId: w.workflowStepId,
+    agentProfileId: w.agentProfileId,
+    executorProfileId: w.executorProfileId,
+    prompt: w.prompt || DEFAULT_LINEAR_ISSUE_WATCH_PROMPT,
+    enabled: w.enabled,
+    pollInterval: w.pollIntervalSeconds,
+  };
+}
+
+export function parseEstimate(raw: string): number | undefined {
+  const t = raw.trim();
+  if (t === "") return undefined;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function filterIsEmpty(form: FormState): boolean {
+  return (
+    form.query.trim() === "" &&
+    form.teamKey.trim() === "" &&
+    form.assigned.trim() === "" &&
+    form.stateIds.length === 0 &&
+    form.priority === null &&
+    form.labelIds.length === 0 &&
+    form.creatorId.trim() === "" &&
+    parseEstimate(form.estimateMin) === undefined &&
+    parseEstimate(form.estimateMax) === undefined
+  );
+}
+
+export function buildFilterPayload(form: FormState): LinearSearchFilter {
+  return {
+    query: form.query.trim() || undefined,
+    teamKey: form.teamKey.trim() || undefined,
+    stateIds: form.stateIds.length > 0 ? form.stateIds : undefined,
+    assigned: form.assigned.trim() || undefined,
+    priority: form.priority ?? undefined,
+    labelIds: form.labelIds.length > 0 ? form.labelIds : undefined,
+    creatorId: form.creatorId.trim() || undefined,
+    estimateMin: parseEstimate(form.estimateMin),
+    estimateMax: parseEstimate(form.estimateMax),
+  };
+}
+
+export function userOptionLabel(u: LinearUser): string {
+  const name = u.displayName?.trim() || u.name?.trim() || u.email?.trim() || u.id;
+  if (u.email && u.email !== name) return `${name} (${u.email})`;
+  return name;
+}
+
+export function creatorPlaceholder(teamKey: string, loadingUsers: boolean): string {
+  if (loadingUsers) return "Loading…";
+  if (!teamKey) return "Pick a team first";
+  return "(any)";
+}

--- a/apps/web/components/linear/linear-issue-watch-form.ts
+++ b/apps/web/components/linear/linear-issue-watch-form.ts
@@ -2,21 +2,19 @@ import type { LinearIssueWatch, LinearSearchFilter, LinearUser } from "@/lib/typ
 import { DEFAULT_LINEAR_ISSUE_WATCH_PROMPT } from "./linear-issue-watch-placeholders";
 
 export const ASSIGNED_ANY = "__any__";
-export const PRIORITY_ANY = "__any__";
 export const CREATOR_ANY = "__any__";
 
-// Linear priorities: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Encoded as
-// strings for use as Select values; converted back at the form boundary.
-export const PRIORITY_OPTIONS: { id: string; label: string }[] = [
-  { id: PRIORITY_ANY, label: "(any)" },
-  { id: "0", label: "No priority" },
-  { id: "1", label: "Urgent" },
-  { id: "2", label: "High" },
-  { id: "3", label: "Medium" },
-  { id: "4", label: "Low" },
-];
-
 export type LinearPriority = 0 | 1 | 2 | 3 | 4;
+
+// Linear priorities: 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Rendered as
+// toggle chips, mirroring the States and Labels multi-selects.
+export const PRIORITY_OPTIONS: { value: LinearPriority; label: string }[] = [
+  { value: 1, label: "Urgent" },
+  { value: 2, label: "High" },
+  { value: 3, label: "Medium" },
+  { value: 4, label: "Low" },
+  { value: 0, label: "No priority" },
+];
 
 export interface FormState {
   workspaceId: string;
@@ -24,7 +22,7 @@ export interface FormState {
   teamKey: string;
   stateIds: string[];
   assigned: string;
-  priority: LinearPriority | null;
+  priorities: LinearPriority[];
   labelIds: string[];
   creatorId: string;
   estimateMin: string;
@@ -45,7 +43,7 @@ export function makeEmptyForm(workspaceId: string): FormState {
     teamKey: "",
     stateIds: [],
     assigned: "",
-    priority: null,
+    priorities: [],
     labelIds: [],
     creatorId: "",
     estimateMin: "",
@@ -72,7 +70,7 @@ export function formStateFromWatch(w: LinearIssueWatch): FormState {
     teamKey: f.teamKey ?? "",
     stateIds: f.stateIds ?? [],
     assigned: f.assigned ?? "",
-    priority: f.priority ?? null,
+    priorities: f.priorities ?? [],
     labelIds: f.labelIds ?? [],
     creatorId: f.creatorId ?? "",
     estimateMin: estimateString(f.estimateMin),
@@ -85,13 +83,6 @@ export function formStateFromWatch(w: LinearIssueWatch): FormState {
     enabled: w.enabled,
     pollInterval: w.pollIntervalSeconds,
   };
-}
-
-export function parsePriority(raw: string): LinearPriority | null {
-  if (raw === PRIORITY_ANY) return null;
-  const n = Number(raw);
-  if (n === 0 || n === 1 || n === 2 || n === 3 || n === 4) return n;
-  return null;
 }
 
 export function parseEstimate(raw: string): number | undefined {
@@ -107,7 +98,7 @@ export function filterIsEmpty(form: FormState): boolean {
     form.teamKey.trim() === "" &&
     form.assigned.trim() === "" &&
     form.stateIds.length === 0 &&
-    form.priority === null &&
+    form.priorities.length === 0 &&
     form.labelIds.length === 0 &&
     form.creatorId.trim() === "" &&
     parseEstimate(form.estimateMin) === undefined &&
@@ -121,7 +112,7 @@ export function buildFilterPayload(form: FormState): LinearSearchFilter {
     teamKey: form.teamKey.trim() || undefined,
     stateIds: form.stateIds.length > 0 ? form.stateIds : undefined,
     assigned: form.assigned.trim() || undefined,
-    priority: form.priority ?? undefined,
+    priorities: form.priorities.length > 0 ? form.priorities : undefined,
     labelIds: form.labelIds.length > 0 ? form.labelIds : undefined,
     creatorId: form.creatorId.trim() || undefined,
     estimateMin: parseEstimate(form.estimateMin),

--- a/apps/web/lib/api/domains/linear-api.ts
+++ b/apps/web/lib/api/domains/linear-api.ts
@@ -77,23 +77,37 @@ export async function getLinearIssue(identifier: string, options?: ApiRequestOpt
   return fetchJson<LinearIssue>(`/api/v1/linear/issues/${encodeURIComponent(identifier)}`, options);
 }
 
+function buildSearchIssuesQuery(
+  params: LinearSearchFilter & { pageToken?: string; maxResults?: number },
+): string {
+  // Mapping table keeps the function flat — the complexity linter complains
+  // about a long chain of ifs, but a `[wire, value]` array reads as a single
+  // pass over the fields.
+  const entries: [string, string | undefined][] = [
+    ["query", params.query],
+    ["team_key", params.teamKey],
+    ["assigned", params.assigned],
+    ["creator_id", params.creatorId],
+    ["state_ids", params.stateIds?.length ? params.stateIds.join(",") : undefined],
+    ["label_ids", params.labelIds?.length ? params.labelIds.join(",") : undefined],
+    ["priorities", params.priorities?.length ? params.priorities.join(",") : undefined],
+    ["estimate_min", params.estimateMin !== undefined ? String(params.estimateMin) : undefined],
+    ["estimate_max", params.estimateMax !== undefined ? String(params.estimateMax) : undefined],
+    ["page_token", params.pageToken],
+    ["max_results", params.maxResults ? String(params.maxResults) : undefined],
+  ];
+  const search = new URLSearchParams();
+  for (const [key, value] of entries) {
+    if (value) search.set(key, value);
+  }
+  return search.toString();
+}
+
 export async function searchLinearIssues(
   params: LinearSearchFilter & { pageToken?: string; maxResults?: number },
   options?: ApiRequestOptions,
 ) {
-  const search = new URLSearchParams();
-  if (params.query) search.set("query", params.query);
-  if (params.teamKey) search.set("team_key", params.teamKey);
-  if (params.stateIds?.length) search.set("state_ids", params.stateIds.join(","));
-  if (params.assigned) search.set("assigned", params.assigned);
-  if (params.labelIds?.length) search.set("label_ids", params.labelIds.join(","));
-  if (params.priority !== undefined) search.set("priority", String(params.priority));
-  if (params.creatorId) search.set("creator_id", params.creatorId);
-  if (params.estimateMin !== undefined) search.set("estimate_min", String(params.estimateMin));
-  if (params.estimateMax !== undefined) search.set("estimate_max", String(params.estimateMax));
-  if (params.pageToken) search.set("page_token", params.pageToken);
-  if (params.maxResults) search.set("max_results", String(params.maxResults));
-  const qs = search.toString();
+  const qs = buildSearchIssuesQuery(params);
   return fetchJson<LinearSearchResult>(`/api/v1/linear/issues${qs ? `?${qs}` : ""}`, options);
 }
 

--- a/apps/web/lib/api/domains/linear-api.ts
+++ b/apps/web/lib/api/domains/linear-api.ts
@@ -4,9 +4,11 @@ import type {
   LinearConfig,
   LinearIssue,
   LinearIssueWatch,
+  LinearLabel,
   LinearSearchFilter,
   LinearSearchResult,
   LinearTeam,
+  LinearUser,
   LinearWorkflowState,
   SetLinearConfigRequest,
   TestLinearConnectionResult,
@@ -57,6 +59,20 @@ export async function listLinearStates(teamKey: string, options?: ApiRequestOpti
   );
 }
 
+export async function listLinearLabels(teamKey: string, options?: ApiRequestOptions) {
+  return fetchJson<{ labels: LinearLabel[] }>(
+    `/api/v1/linear/labels?team_key=${encodeURIComponent(teamKey)}`,
+    options,
+  );
+}
+
+export async function listLinearUsers(teamKey: string, options?: ApiRequestOptions) {
+  return fetchJson<{ users: LinearUser[] }>(
+    `/api/v1/linear/users?team_key=${encodeURIComponent(teamKey)}`,
+    options,
+  );
+}
+
 export async function getLinearIssue(identifier: string, options?: ApiRequestOptions) {
   return fetchJson<LinearIssue>(`/api/v1/linear/issues/${encodeURIComponent(identifier)}`, options);
 }
@@ -70,6 +86,11 @@ export async function searchLinearIssues(
   if (params.teamKey) search.set("team_key", params.teamKey);
   if (params.stateIds?.length) search.set("state_ids", params.stateIds.join(","));
   if (params.assigned) search.set("assigned", params.assigned);
+  if (params.labelIds?.length) search.set("label_ids", params.labelIds.join(","));
+  if (params.priority !== undefined) search.set("priority", String(params.priority));
+  if (params.creatorId) search.set("creator_id", params.creatorId);
+  if (params.estimateMin !== undefined) search.set("estimate_min", String(params.estimateMin));
+  if (params.estimateMax !== undefined) search.set("estimate_max", String(params.estimateMax));
   if (params.pageToken) search.set("page_token", params.pageToken);
   if (params.maxResults) search.set("max_results", String(params.maxResults));
   const qs = search.toString();

--- a/apps/web/lib/types/linear.ts
+++ b/apps/web/lib/types/linear.ts
@@ -96,7 +96,7 @@ export interface LinearSearchFilter {
   /** "me" | "unassigned" | "" (any) */
   assigned?: string;
   /** 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Omit for no priority filter. */
-  priority?: number;
+  priority?: 0 | 1 | 2 | 3 | 4;
   /** Issue labels (OR semantics — match any). */
   labelIds?: string[];
   /** Filter by issue creator UUID. */

--- a/apps/web/lib/types/linear.ts
+++ b/apps/web/lib/types/linear.ts
@@ -95,8 +95,8 @@ export interface LinearSearchFilter {
   stateIds?: string[];
   /** "me" | "unassigned" | "" (any) */
   assigned?: string;
-  /** 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Omit for no priority filter. */
-  priority?: 0 | 1 | 2 | 3 | 4;
+  /** Priorities to include (OR). 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. */
+  priorities?: (0 | 1 | 2 | 3 | 4)[];
   /** Issue labels (OR semantics — match any). */
   labelIds?: string[];
   /** Filter by issue creator UUID. */

--- a/apps/web/lib/types/linear.ts
+++ b/apps/web/lib/types/linear.ts
@@ -75,12 +75,36 @@ export interface LinearTeam {
   name: string;
 }
 
+export interface LinearLabel {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+export interface LinearUser {
+  id: string;
+  name: string;
+  displayName?: string;
+  email?: string;
+  avatarUrl?: string;
+}
+
 export interface LinearSearchFilter {
   query?: string;
   teamKey?: string;
   stateIds?: string[];
   /** "me" | "unassigned" | "" (any) */
   assigned?: string;
+  /** 0=None, 1=Urgent, 2=High, 3=Medium, 4=Low. Omit for no priority filter. */
+  priority?: number;
+  /** Issue labels (OR semantics — match any). */
+  labelIds?: string[];
+  /** Filter by issue creator UUID. */
+  creatorId?: string;
+  /** Inclusive lower bound on point estimate. */
+  estimateMin?: number;
+  /** Inclusive upper bound on point estimate. */
+  estimateMax?: number;
 }
 
 export interface LinearSearchResult {


### PR DESCRIPTION
## Summary

Brings Linear issue-watch filters closer to feature-parity with Linear's GraphQL filter surface. Users can scope auto-run watchers by:

- **Priority** — multi-select chips (Urgent / High / Medium / Low / No priority), matches Linear's own filter UI
- **Labels** — multi-select from the team's labels (OR semantics)
- **Creator** — single user from the team's members
- **Estimate** — min/max point range (non-negative; NaN/Inf rejected with 400)
- Existing team / states / assignee / query filters unchanged

## Changes

**Backend (`internal/linear`)**
- Extend `SearchFilter` with `Priorities []int`, `LabelIDs`, `CreatorID`, `EstimateMin/Max`
- Map new fields in `buildIssueFilter()` to Linear's `IssueFilter` GraphQL input (`priority: { in }`, `labels.some.id.in`, `creator.id.eq`, `estimate.gte/lte`)
- Add `ListLabels` / `ListUsers` on the `Client` interface, implemented for `GraphQLClient` (capped at 250 — Linear's max page size) and `MockClient`
- Expose them over HTTP: `GET /api/v1/linear/labels?team_key=…`, `GET /api/v1/linear/users?team_key=…`
- Surface the new fields in `GET /api/v1/linear/issues` query params (`priorities`, `label_ids`, `creator_id`, `estimate_min`, `estimate_max`) with strict validation: each priority ∈ [0,4], estimates non-negative & finite (rejects NaN / ±Inf), min ≤ max
- `filterIsEmpty` / `normalizeFilter` updated so watches with only one of the new filters are accepted; bounds validated at both create and update paths
- Tests: `buildIssueFilter` rich-payload mapping (incl. `Priorities=[0]` for "No priority" only), watch creation with each new filter, handler tests for `/labels`, `/users`, and 400 cases for malformed numerics

**Frontend**
- Extend `LinearSearchFilter` (priorities typed `(0|1|2|3|4)[]`) and add `LinearLabel` / `LinearUser` types
- API helpers: `listLinearLabels`, `listLinearUsers`; `searchLinearIssues` carries the new params via a flat table-driven query builder
- Watcher dialog adds Priority chip strip, Labels chips, Creator select, Estimate min/max fields — all alongside the existing controls; labels/users fetched per team and cached, with the in-flight marker cleared on cancellation/failure so remounts can retry and successful loads stay cached
- Toggle chips rendered as `<button aria-pressed>` so keyboard users can navigate and screen readers announce state
- Split helpers into `linear-issue-watch-form.ts` (state shape + parsers) and `linear-issue-watch-fields.tsx` (multi-selects + team data hook) to keep the dialog under file/function size limits

Filter persistence is forward-compatible: `SearchFilter` is stored as JSON in `search_filter`, so existing watches that pre-date this change load unchanged.

## Test plan

- [x] `go test ./internal/linear/...` — passes (new tests for rich filter mapping, watch creation, handler 400/200 paths)
- [x] `pnpm --filter @kandev/web typecheck` — passes
- [x] `pnpm --filter @kandev/web lint` — passes (warnings = 0)
- [x] `pnpm --filter @kandev/web test` — 1968 passed
- [x] `gofmt` / `go vet` clean on `internal/linear`
- [x] Manual smoke on local dev instance: dialog renders all new fields, 400 returned for bad numerics, valid filters round-trip through create/update