### PR TITLE
feat(release): credit external contributors in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,13 @@ jobs:
 
       - name: Install git-cliff
         env:
-          # Pinned to v2.6.1. To bump, also update the sha512 below — fetch the
+          # Pinned to v2.13.1 to match git-cliff-action@v4's default runtime.
+          # To bump, also update the sha512 below — fetch the
           # new one from:
           # https://github.com/orhun/git-cliff/releases/download/<tag>/<asset>.sha512
-          CLIFF_VERSION: "2.6.1"
-          CLIFF_ASSET: "git-cliff-2.6.1-x86_64-unknown-linux-gnu.tar.gz"
-          CLIFF_SHA512: "b1e7a6b70fc794accdccd9717eff5a8bf8b507f0308da44d837d935be31b18b19db3758d1a9bb4975fbca7d01ddaae251229a753ae2cd2ecc24845cfc50d067f"
+          CLIFF_VERSION: "2.13.1"
+          CLIFF_ASSET: "git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz"
+          CLIFF_SHA512: "e716cce3a07dda41b1e370d6afbd7a59eb3d4739509fb7856aeec8da2be28c0396584e29e106141c1a1c535c1827dbc1f60417524f5cfb1da9e11f700bd00f30"
         run: |
           set -euo pipefail
           curl -sSL "https://github.com/orhun/git-cliff/releases/download/v${CLIFF_VERSION}/${CLIFF_ASSET}" -o /tmp/git-cliff.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,7 @@ jobs:
         env:
           NEXT: ${{ steps.compute.outputs.version }}
           TAG: ${{ steps.compute.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # Bump only the main package version. optionalDependencies stay
@@ -235,6 +236,7 @@ jobs:
         env:
           NEXT: ${{ steps.compute.outputs.version }}
           TAG: ${{ steps.compute.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # In dry-run we still bump + run git-cliff locally so the maintainer
           # can verify the computed version + changelog look right, but nothing
@@ -778,6 +780,7 @@ jobs:
           args: --latest --strip header
         env:
           OUTPUT: RELEASE_NOTES.md
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/download-artifact@v5
         with:

--- a/cliff.toml
+++ b/cliff.toml
@@ -17,7 +17,7 @@ body = """
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 - {{ commit.message }}\
-{% if commit.github.username and commit.github.username not in maintainers %} by @{{ commit.github.username }}{% endif %}\
+{% if commit.remote.username and commit.remote.username | lower not in maintainers %} by @{{ commit.remote.username }}{% endif %}\
 {% endfor %}
 {% endfor %}\n
 """

--- a/cliff.toml
+++ b/cliff.toml
@@ -7,6 +7,7 @@ header = """# Changelog
 All notable changes to Kandev.\n
 """
 body = """
+{# Update when team changes — must match GitHub login (lowercased). Check repo admins at https://github.com/orgs/kdlbs/people #}\
 {% set maintainers = ["carlosflorencio", "jcfs", "zeval", "nnobre"] %}\
 {% if version %}\
 ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -7,6 +7,7 @@ header = """# Changelog
 All notable changes to Kandev.\n
 """
 body = """
+{% set maintainers = ["carlosmflorencio"] %}\
 {% if version %}\
 ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
@@ -16,11 +17,16 @@ body = """
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 - {{ commit.message }}\
+{% if commit.github.username and commit.github.username not in maintainers %} by @{{ commit.github.username }}{% endif %}\
 {% endfor %}
 {% endfor %}\n
 """
 trim = true
 footer = ""
+
+[remote.github]
+owner = "kdlbs"
+repo = "kandev"
 
 [git]
 conventional_commits = true

--- a/cliff.toml
+++ b/cliff.toml
@@ -7,7 +7,7 @@ header = """# Changelog
 All notable changes to Kandev.\n
 """
 body = """
-{% set maintainers = ["carlosmflorencio"] %}\
+{% set maintainers = ["carlosflorencio", "jcfs", "zeval"] %}\
 {% if version %}\
 ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\

--- a/cliff.toml
+++ b/cliff.toml
@@ -7,7 +7,7 @@ header = """# Changelog
 All notable changes to Kandev.\n
 """
 body = """
-{% set maintainers = ["carlosflorencio", "jcfs", "zeval"] %}\
+{% set maintainers = ["carlosflorencio", "jcfs", "zeval", "nnobre"] %}\
 {% if version %}\
 ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\


### PR DESCRIPTION
GitHub release notes for kandev were anonymous — community PRs landed in the changelog with no author credit. Wire git-cliff's GitHub remote integration so each commit's PR author is resolved, and append `by @<user>` inline to bullets whose author isn't a kandev maintainer.

## Important Changes

- `cliff.toml`: added `[remote.github]` + a Tera `maintainers` allowlist (`carlosflorencio`, `jcfs`, `zeval`, `nnobre` — the four repo admins). Body template now appends ` by @<username>` per bullet for everyone else and documents where to update the maintainer list.
- `.github/workflows/release.yml`: threaded `GITHUB_TOKEN` into all three git-cliff invocations (prepare bump, dry-run summary, publish-release notes). Without the token, git-cliff can't resolve PR authors and the template degrades silently to no attribution.
- `.github/workflows/release.yml`: pinned the locally installed `git-cliff` in `prepare` and dry-run paths to `v2.13.1` so committed `CHANGELOG.md` generation uses the same `commit.remote.username` field as `git-cliff-action@v4`.

## Validation

- Checked `orhun/git-cliff-action@v4` and confirmed its default runtime is `git-cliff v2.13.1`.
- Updated the workflow's manual install pin and sha512 to `git-cliff v2.13.1` so local `prepare` generation and action-based release-note generation use the same template field semantics.
- Cross-checked the official `git-cliff v2.13.1` GitHub example, which uses `commit.remote.username`.
- Cross-checked the maintainer allowlist against `kdlbs/kandev` admin collaborators via the GitHub API.

## Possible Improvements

Low risk: worst case the GitHub API call fails and bullets render without attribution (same as today). Maintainer list is a static Tera array — any new admin needs a one-line update to `cliff.toml`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
