### PR TITLE
fix(office): unbreak new-task dialog "Create Task" button

### DIFF
--- a/apps/backend/internal/orchestrator/executor/executor_worktree_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_worktree_resume_test.go
@@ -83,4 +83,3 @@ func TestLaunchPreparedSession_SingleRepoWorktree_PersistsSubdirAsWorkspacePath(
 			env.WorkspacePath, subdir)
 	}
 }
-

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -409,6 +409,7 @@ type httpCreateTaskRequest struct {
 	ParentID          string                    `json:"parent_id,omitempty"`
 	WorkspacePath     string                    `json:"workspace_path,omitempty"`
 	BlockedBy         []string                  `json:"blocked_by,omitempty"`
+	ProjectID         string                    `json:"project_id,omitempty"`
 	// Office task-handoffs phase 5 — workspace policy. Optional; same
 	// shape as the MCP create_task_kandev fields.
 	WorkspaceMode         string `json:"workspace_mode,omitempty"`
@@ -527,6 +528,7 @@ func (h *TaskHandlers) httpCreateTask(c *gin.Context) {
 		ParentID:       body.ParentID,
 		WorkspacePath:  body.WorkspacePath,
 		BlockedBy:      body.BlockedBy,
+		ProjectID:      body.ProjectID,
 	})
 	if err != nil {
 		handleNotFound(c, h.logger, err, "task not created")

--- a/apps/backend/internal/task/handlers/task_http_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers_test.go
@@ -19,6 +19,58 @@ import (
 	"github.com/kandev/kandev/internal/task/service"
 )
 
+type captureCreateTaskRepo struct {
+	mockRepository
+	captured *models.Task
+}
+
+func (m *captureCreateTaskRepo) GetWorkspaceTaskPrefix(_ context.Context, _ string) (string, string, error) {
+	return "KAN", "wf-office", nil
+}
+
+func (m *captureCreateTaskRepo) CreateTask(_ context.Context, task *models.Task) error {
+	m.captured = task
+	return nil
+}
+
+// TestHTTPCreateTask_ProjectIDReachesOfficePath guards the wiring that broke
+// the office "New Task" dialog: when the request body sets project_id (and
+// omits workflow_id), the handler must forward it to the service so
+// isOfficeRequest() returns true and the workflow is auto-resolved. Without
+// this, requests fall through to the kanban validator with
+// "workflow_id is required for non-ephemeral tasks".
+func TestHTTPCreateTask_ProjectIDReachesOfficePath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	log := newTestLogger(t)
+
+	repo := &captureCreateTaskRepo{}
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	h := &TaskHandlers{service: svc, logger: log}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(`{
+		"workspace_id": "ws-1",
+		"title": "Analyse integrations",
+		"project_id": "proj-1",
+		"priority": "medium"
+	}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.httpCreateTask(c)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	require.NotNil(t, repo.captured, "service.CreateTask was not called")
+	assert.Equal(t, "proj-1", repo.captured.ProjectID)
+	assert.Equal(t, "wf-office", repo.captured.WorkflowID, "office workflow should be auto-resolved")
+}
+
 func newTestLogger(t *testing.T) *logger.Logger {
 	t.Helper()
 	log, err := logger.NewLogger(logger.LoggingConfig{

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { StateProvider } from "@/components/state-provider";
 import { WebSocketConnector } from "@/components/ws-connector";
 import { ToastProvider } from "@/components/toast-provider";
 import { TooltipProvider } from "@kandev/ui/tooltip";
+import { Toaster as SonnerToaster } from "@kandev/ui/sonner";
 import { CommandRegistryProvider } from "@/lib/commands/command-registry";
 import { CommandPanel } from "@/components/command-panel";
 import { GlobalCommands } from "@/components/global-commands";
@@ -70,6 +71,7 @@ export default async function RootLayout({
             <DiffWorkerPoolProvider>
               <TooltipProvider>
                 <ToastProvider>
+                  <SonnerToaster richColors position="bottom-right" />
                   <SessionFailureToastBridge />
                   <SidebarViewsSyncBridge />
                   <LogBufferBridge />

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -71,7 +71,7 @@ export default async function RootLayout({
             <DiffWorkerPoolProvider>
               <TooltipProvider>
                 <ToastProvider>
-                  <SonnerToaster richColors position="bottom-right" />
+                  <SonnerToaster richColors position="top-right" />
                   <SessionFailureToastBridge />
                   <SidebarViewsSyncBridge />
                   <LogBufferBridge />

--- a/apps/web/app/office/components/new-task-dialog.tsx
+++ b/apps/web/app/office/components/new-task-dialog.tsx
@@ -66,7 +66,7 @@ export function NewTaskDialog({
         title: draft.title.trim(),
         description: draft.description.trim() || undefined,
         parent_id: parentTaskId,
-        priority: draft.priority || undefined,
+        priority: draft.priority,
         project_id: draft.projectId || undefined,
         metadata: executionPolicy ? { ...metadata, execution_policy: executionPolicy } : metadata,
       });

--- a/apps/web/app/office/components/new-task-dialog.tsx
+++ b/apps/web/app/office/components/new-task-dialog.tsx
@@ -8,7 +8,6 @@ import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from "
 import { toast } from "sonner";
 import { useAppStore } from "@/components/state-provider";
 import { createTask } from "@/lib/api/domains/kanban-api";
-import type { OfficeMeta } from "@/lib/state/slices/office/types";
 import { useIssueDraft, type IssueDraft } from "./new-task-draft";
 import { NewTaskSelectorRow } from "./new-task-selector-row";
 import { NewTaskBottomBar } from "./new-task-bottom-bar";
@@ -19,26 +18,9 @@ import {
   type StagesDraft,
 } from "./new-task-stages";
 
-const FALLBACK_PRIORITY_VALUES: Record<string, number> = {
-  critical: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
-  none: 0,
-};
-
-function priorityToNumber(priority: string, meta: OfficeMeta | null): number {
-  if (meta) {
-    const p = meta.priorities.find((m) => m.id === priority);
-    if (p) return p.value;
-  }
-  return FALLBACK_PRIORITY_VALUES[priority] ?? 0;
-}
-
 function buildMetadata(draft: IssueDraft): Record<string, unknown> | undefined {
   const meta: Record<string, unknown> = {};
   if (draft.assigneeId) meta.assignee_agent_profile_id = draft.assigneeId;
-  if (draft.projectId) meta.project_id = draft.projectId;
   if (draft.status && draft.status !== "todo") meta.initial_status = draft.status;
   return Object.keys(meta).length > 0 ? meta : undefined;
 }
@@ -59,7 +41,6 @@ export function NewTaskDialog({
   defaultAssigneeId,
 }: NewIssueDialogProps) {
   const workspaceId = useAppStore((s) => s.workspaces.activeId);
-  const meta = useAppStore((s) => s.office.meta);
   const [submitting, setSubmitting] = useState(false);
   const [stages, setStages] = useState<StagesDraft>(EMPTY_STAGES);
 
@@ -85,7 +66,8 @@ export function NewTaskDialog({
         title: draft.title.trim(),
         description: draft.description.trim() || undefined,
         parent_id: parentTaskId,
-        priority: priorityToNumber(draft.priority, meta),
+        priority: draft.priority || undefined,
+        project_id: draft.projectId || undefined,
         metadata: executionPolicy ? { ...metadata, execution_policy: executionPolicy } : metadata,
       });
       clearDraft();
@@ -97,7 +79,7 @@ export function NewTaskDialog({
     } finally {
       setSubmitting(false);
     }
-  }, [draft, stages, workspaceId, parentTaskId, meta, clearDraft, onOpenChange]);
+  }, [draft, stages, workspaceId, parentTaskId, clearDraft, onOpenChange]);
 
   const handleDiscard = useCallback(() => {
     clearDraft();

--- a/apps/web/lib/api/domains/kanban-api.ts
+++ b/apps/web/lib/api/domains/kanban-api.ts
@@ -74,7 +74,8 @@ export async function createTask(
     attachments?: Array<{ type: string; data: string; mime_type: string; name?: string }>;
     parent_id?: string;
     workspace_path?: string;
-    priority?: number;
+    priority?: string;
+    project_id?: string;
     metadata?: Record<string, unknown>;
     /** Office task-handoffs phase 4/5 — workspace policy. */
     workspace_mode?: "inherit_parent" | "new_workspace" | "shared_group";


### PR DESCRIPTION
Office task creation silently failed when users clicked "Create Task" — the request was malformed, the backend rejected it, and no error toast appeared. Three independent bugs combined to produce zero feedback; this PR fixes all of them so the dialog actually creates tasks and surfaces failures.

## Important Changes

- **Sonner Toaster mounted at the root layout.** No `<Toaster />` was ever rendered, so every `sonner` `toast.success/error` call across the app was silently dropped (not just this dialog).
- **`project_id` is now a top-level `createTask` field.** Was being smuggled inside `metadata` where the HTTP handler never read it, so `isOfficeRequest()` returned false and the request tripped the kanban validator with "workflow_id is required for non-ephemeral tasks".
- **`priority` is sent as a string id, not a number.** Backend's `httpCreateTaskRequest.Priority` is `string`; the frontend was sending `2` (a numeric "value"), which made `c.ShouldBindJSON` fail and return 400 `invalid payload`.

## Validation

- Reproduced the original failure with `curl` against the existing backend (HTTP 400 `invalid payload`, then HTTP 400 `workflow_id is required` after fixing only the priority).
- After the fix, the same payload shape passes through the HTTP handler into the office task path (verified against a freshly-built worktree binary).
- `make -C apps/backend build` — clean
- `make -C apps/backend lint` — `0 issues`
- `go test ./internal/task/handlers/... ./internal/task/service/...` — pass
- `pnpm --filter @kandev/web typecheck` — pass
- `pnpm --filter @kandev/web lint` — pass

## Possible Improvements

The dropped-toast bug almost certainly hid other silent failures across the app; an audit of `sonner` call sites that used to "do nothing" would be worth a follow-up.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] Manually verified in browser