### PR TITLE
fix(web): gate merge button on required_reviews so it matches GitHub

### DIFF
--- a/apps/web/components/github/pr-task-icon.test.ts
+++ b/apps/web/components/github/pr-task-icon.test.ts
@@ -41,6 +41,8 @@ function makePR(overrides: Partial<TaskPR> = {}): TaskPR {
   };
 }
 
+const SKY_400 = "text-sky-400";
+
 describe("isPRReadyToMerge", () => {
   it("is true when open + approved + success + clean", () => {
     expect(
@@ -223,7 +225,22 @@ describe("getPRStatusColor", () => {
       mergeable_state: "blocked",
       pending_review_count: 1,
     });
-    expect(getPRStatusColor(pr)).toBe("text-sky-400");
+    expect(getPRStatusColor(pr)).toBe(SKY_400);
+  });
+
+  it("returns sky-400 when required_reviews is unmet but mergeable_state is clean (bug repro)", () => {
+    // The stale-snapshot bug: GitHub still reports mergeable_state="clean" while
+    // branch protection has recorded one fewer approval than required. The icon
+    // must downgrade to "awaiting review" instead of the emerald "ready to merge".
+    const pr = makePR({
+      state: "open",
+      review_state: "approved",
+      checks_state: "success",
+      mergeable_state: "clean",
+      required_reviews: 2,
+      review_count: 1,
+    });
+    expect(getPRStatusColor(pr)).toBe(SKY_400);
   });
 
   it("returns plain green when mergeable_state is empty (backfilled row)", () => {
@@ -244,7 +261,7 @@ describe("getPRStatusColor", () => {
       mergeable_state: "clean",
       pending_review_count: 2,
     });
-    expect(getPRStatusColor(pr)).toBe("text-sky-400");
+    expect(getPRStatusColor(pr)).toBe(SKY_400);
   });
 
   it("returns sky-400 when CI passed and reviewers are requested but no review state set", () => {
@@ -255,7 +272,7 @@ describe("getPRStatusColor", () => {
       mergeable_state: "blocked",
       pending_review_count: 1,
     });
-    expect(getPRStatusColor(pr)).toBe("text-sky-400");
+    expect(getPRStatusColor(pr)).toBe(SKY_400);
   });
 
   it("returns emerald when CI passed and no reviewers are required", () => {

--- a/apps/web/components/github/pr-task-icon.test.ts
+++ b/apps/web/components/github/pr-task-icon.test.ts
@@ -140,6 +140,57 @@ describe("isPRReadyToMerge", () => {
   );
 });
 
+describe("isPRReadyToMerge — required_reviews gate", () => {
+  it("is false when required_reviews is unmet even if mergeable_state is clean", () => {
+    // GitHub's stored mergeable_state can lag branch-protection state (e.g.
+    // after a dismissed approval); the required_reviews gate guarantees the
+    // button matches GitHub's merge box.
+    expect(
+      isPRReadyToMerge(
+        makePR({
+          state: "open",
+          review_state: "approved",
+          checks_state: "success",
+          mergeable_state: "clean",
+          required_reviews: 2,
+          review_count: 1,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when required_reviews equals review_count and everything else is clean", () => {
+    expect(
+      isPRReadyToMerge(
+        makePR({
+          state: "open",
+          review_state: "approved",
+          checks_state: "success",
+          mergeable_state: "clean",
+          required_reviews: 2,
+          review_count: 2,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is true when required_reviews is zero (protected branch with no approval requirement)", () => {
+    expect(
+      isPRReadyToMerge(
+        makePR({
+          state: "open",
+          review_state: "",
+          checks_state: "success",
+          mergeable_state: "clean",
+          required_reviews: 0,
+          review_count: 0,
+          pending_review_count: 0,
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("getPRStatusColor", () => {
   it("returns ready-to-merge color when all conditions are met", () => {
     const pr = makePR({
@@ -298,6 +349,23 @@ describe("isPRAwaitingReview", () => {
         }),
       ),
     ).toBe(false);
+  });
+
+  it("is true when required_reviews is unmet even with no pending reviewers", () => {
+    // 1 of 2 approvals; the second reviewer is no longer requested but branch
+    // protection still demands two approvals — surface as awaiting review.
+    expect(
+      isPRAwaitingReview(
+        makePR({
+          state: "open",
+          review_state: "approved",
+          checks_state: "success",
+          pending_review_count: 0,
+          required_reviews: 2,
+          review_count: 1,
+        }),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -24,6 +24,15 @@ export function isPRReadyToMerge(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
   if (pr.checks_state !== "success") return false;
   if (pr.mergeable_state !== "clean") return false;
+  // Branch protection's required_approving_review_count: when the recorded
+  // approval count hasn't met the required minimum, refuse to show the merge
+  // button even if GitHub's mergeable_state momentarily reports "clean" (a
+  // stale snapshot from before an approval was dismissed, or a missing
+  // refetch after a new commit invalidated approvals). The popover renders
+  // the same "K / M" pair in PRReviewRow, so the two surfaces now agree.
+  if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
+    return false;
+  }
   if (pr.review_state === "approved") return true;
   // No review process: no requested reviewers and no submitted reviews. GitHub
   // sets mergeable_state=clean when branch protection is satisfied, so this
@@ -39,6 +48,12 @@ export function isPRReadyToMerge(pr: TaskPR): boolean {
 export function isPRAwaitingReview(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
   if (pr.checks_state !== "success") return false;
+  // Required-reviewer shortfall is "awaiting review" even when no one is
+  // currently requested (e.g. the second reviewer was un-requested but
+  // protection still demands 2 approvals). Matches the popover's "1 / 2".
+  if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
+    return true;
+  }
   if (pr.review_state === "approved") return pr.pending_review_count > 0;
   return pr.review_state === "pending" || pr.pending_review_count > 0;
 }

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -24,12 +24,8 @@ export function isPRReadyToMerge(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
   if (pr.checks_state !== "success") return false;
   if (pr.mergeable_state !== "clean") return false;
-  // Branch protection's required_approving_review_count: when the recorded
-  // approval count hasn't met the required minimum, refuse to show the merge
-  // button even if GitHub's mergeable_state momentarily reports "clean" (a
-  // stale snapshot from before an approval was dismissed, or a missing
-  // refetch after a new commit invalidated approvals). The popover renders
-  // the same "K / M" pair in PRReviewRow, so the two surfaces now agree.
+  // Guard against stale mergeable_state: enforce required_reviews directly so
+  // this matches the popover's "K / M required" display.
   if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
     return false;
   }
@@ -48,9 +44,7 @@ export function isPRReadyToMerge(pr: TaskPR): boolean {
 export function isPRAwaitingReview(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
   if (pr.checks_state !== "success") return false;
-  // Required-reviewer shortfall is "awaiting review" even when no one is
-  // currently requested (e.g. the second reviewer was un-requested but
-  // protection still demands 2 approvals). Matches the popover's "1 / 2".
+  // Shortfall is "awaiting review" even when no reviewer is currently requested.
   if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
     return true;
   }

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -24,8 +24,7 @@ export function isPRReadyToMerge(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
   if (pr.checks_state !== "success") return false;
   if (pr.mergeable_state !== "clean") return false;
-  // Guard against stale mergeable_state: enforce required_reviews directly so
-  // this matches the popover's "K / M required" display.
+  // Guard against stale mergeable_state: enforce required_reviews to match GitHub's gate.
   if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
     return false;
   }


### PR DESCRIPTION
The merge button rendered green even when GitHub still considered the PR blocked — `mergeable_state` can momentarily lag branch protection (dismissed approvals, fresh-commit invalidations, partial polls), and `isPRReadyToMerge` previously trusted it alone. Both the merge button and the icon color now refuse the "ready" verdict when the recorded approval count is below `required_reviews`, mirroring the "K / M required" pair the CI popover already renders.

## Validation

- `pnpm --filter @kandev/web test -- --run components/github/pr-task-icon` — 43/43 pass (4 new regression tests covering the gate, including the bug repro)
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `make -C apps/backend test lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.