### PR TITLE
feat(share): add public share links via GitHub Gists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ apps/backend/
 │   │   ├── handlers/     # Task event handlers
 │   │   ├── models/       # Task, Session, Executor, Message models
 │   │   ├── repository/   # Database access (SQLite)
-│   │   └── service/      # Task business logic
+│   │   ├── service/      # Task business logic
+│   │   └── share/        # Public share links: snapshot builder, gist backend, service, redaction
 │   ├── office/           # Autonomous agent management (Office feature)
 │   │   ├── agents/       # Agent instance CRUD + auth guards
 │   │   ├── approvals/    # Approval requests and decisions

--- a/apps/backend/cmd/kandev/helpers.go
+++ b/apps/backend/cmd/kandev/helpers.go
@@ -643,6 +643,10 @@ func registerTaskRoutes(p routeParams, planService *taskservice.PlanService, han
 	taskhandlers.RegisterProcessRoutes(p.router, p.taskSvc, p.lifecycleMgr, p.log)
 	analyticshandlers.RegisterStatsRoutes(p.router, p.analyticsRepo, p.log)
 	agenthandlers.RegisterShellRoutes(p.router, p.lifecycleMgr, p.log)
+	if p.services.Share != nil {
+		p.services.Share.RegisterRoutes(p.router)
+		p.log.Debug("Registered Public Share Links handlers (HTTP)")
+	}
 	p.log.Debug("Registered Task Service handlers (HTTP + WebSocket)")
 }
 

--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -279,7 +279,7 @@ func startServices( //nolint:cyclop
 		return false
 	}
 
-	services, agentSettingsController, err := provideServices(cfg, log, repos, dbPool, eventBus, agentRegistry)
+	services, agentSettingsController, err := provideServices(cfg, log, repos, dbPool, eventBus, agentRegistry, Version)
 	if err != nil {
 		log.Error("Failed to initialize services", zap.Error(err))
 		return false

--- a/apps/backend/cmd/kandev/services.go
+++ b/apps/backend/cmd/kandev/services.go
@@ -25,13 +25,14 @@ import (
 	"github.com/kandev/kandev/internal/slack"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
 	taskservice "github.com/kandev/kandev/internal/task/service"
+	"github.com/kandev/kandev/internal/task/share"
 	userservice "github.com/kandev/kandev/internal/user/service"
 	utilityservice "github.com/kandev/kandev/internal/utility/service"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	workflowservice "github.com/kandev/kandev/internal/workflow/service"
 )
 
-func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories, dbPool *db.Pool, eventBus bus.EventBus, agentRegistry *registry.Registry) (*Services, *agentsettingscontroller.Controller, error) {
+func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories, dbPool *db.Pool, eventBus bus.EventBus, agentRegistry *registry.Registry, version string) (*Services, *agentsettingscontroller.Controller, error) {
 	// Load custom TUI agents from DB into registry before discovery
 	loadCustomTUIAgents(context.Background(), repos, agentRegistry, log)
 
@@ -92,6 +93,7 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 	jiraSvc := initJiraService(dbPool, eventBus, repos.Secrets, log)
 	linearSvc := initLinearService(dbPool, eventBus, repos.Secrets, log)
 	slackSvc := initSlackService(dbPool, repos.Secrets, log)
+	shareHTTP := initShareHandlers(dbPool, repos.Task, githubSvc, log, version)
 
 	// Plumb GitHub branch listing into the task service so provider-backed
 	// ("Remote") repos serve branches from the GitHub API rather than relying
@@ -112,6 +114,7 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 		Jira:     jiraSvc,
 		Linear:   linearSvc,
 		Slack:    slackSvc,
+		Share:    shareHTTP,
 		// Office is constructed later in initOfficeServices once all
 		// of its dependencies (config loader, task integrations, etc.) are available.
 		Office: nil,
@@ -261,6 +264,32 @@ func initLinearService(dbPool *db.Pool, eventBus bus.EventBus, secretsStore secr
 		log.Warn("Linear service initialization failed (non-fatal)", zap.Error(err))
 	}
 	return svc
+}
+
+// initShareHandlers wires up the public-share-links HTTP surface. Failures
+// are non-fatal: the rest of the backend boots without the share endpoints.
+// The github.Client may be nil; CreateShare will fail at the IsAuthenticated
+// probe with a 412 in that case.
+func initShareHandlers(
+	dbPool *db.Pool,
+	taskRepo share.TaskReader,
+	githubSvc *github.Service,
+	log *logger.Logger,
+	version string,
+) *share.HTTPHandlers {
+	var ghClient github.Client
+	if githubSvc != nil {
+		ghClient = githubSvc.Client()
+	}
+	if ghClient == nil {
+		ghClient = &github.NoopClient{}
+	}
+	h, _, err := share.Provide(dbPool.Writer(), dbPool.Reader(), taskRepo, ghClient, log, share.Config{KandevVersion: version})
+	if err != nil {
+		log.Warn("Share handlers initialization failed (non-fatal)", zap.Error(err))
+		return nil
+	}
+	return h
 }
 
 // initSlackService wires up the Slack integration. Failures are non-fatal.

--- a/apps/backend/cmd/kandev/types.go
+++ b/apps/backend/cmd/kandev/types.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kandev/kandev/internal/slack"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	taskservice "github.com/kandev/kandev/internal/task/service"
+	"github.com/kandev/kandev/internal/task/share"
 	userservice "github.com/kandev/kandev/internal/user/service"
 	userstore "github.com/kandev/kandev/internal/user/store"
 	utilityservice "github.com/kandev/kandev/internal/utility/service"
@@ -54,6 +55,7 @@ type Services struct {
 	Jira         *jira.Service
 	Linear       *linear.Service
 	Slack        *slack.Service
+	Share        *share.HTTPHandlers
 	Office       *officeservice.Service
 	OfficeSvcs   *office.Services
 	// OrchScheduler is the office SchedulerIntegration constructed by

--- a/apps/backend/internal/github/client.go
+++ b/apps/backend/internal/github/client.go
@@ -90,4 +90,12 @@ type Client interface {
 
 	// GetIssueState returns the state of a single issue ("open" or "closed").
 	GetIssueState(ctx context.Context, owner, repo string, number int) (string, error)
+
+	// CreateGist creates a new gist on the authenticated user's account.
+	// Set Public=false to create a secret (unlisted) gist.
+	CreateGist(ctx context.Context, in CreateGistInput) (*GistResponse, error)
+
+	// DeleteGist deletes a gist by ID. A 404 is wrapped in *GitHubAPIError
+	// so callers can distinguish "already gone" from transport failures.
+	DeleteGist(ctx context.Context, gistID string) error
 }

--- a/apps/backend/internal/github/controller_test.go
+++ b/apps/backend/internal/github/controller_test.go
@@ -99,6 +99,10 @@ func (s *stubClient) GetIssueState(context.Context, string, string, int) (string
 func (s *stubClient) GetPRStatus(context.Context, string, string, int) (*PRStatus, error) {
 	return nil, nil
 }
+func (s *stubClient) CreateGist(context.Context, CreateGistInput) (*GistResponse, error) {
+	return nil, nil
+}
+func (s *stubClient) DeleteGist(context.Context, string) error { return nil }
 
 func newControllerTestLogger() *logger.Logger {
 	log, _ := logger.NewLogger(logger.LoggingConfig{

--- a/apps/backend/internal/github/gh_client.go
+++ b/apps/backend/internal/github/gh_client.go
@@ -731,6 +731,19 @@ func (c *GHClient) DeleteGist(ctx context.Context, gistID string) error {
 	}
 	_, err := c.run(ctx, "api", "gists/"+gistID, "-X", "DELETE")
 	if err != nil {
+		// gh exits non-zero for HTTP errors; stderr contains the status
+		// line (e.g. "HTTP 404: Not Found"). Promote 404 to *GitHubAPIError
+		// so share.IsAlreadyGone matches consistently — PATClient.delete()
+		// already returns a typed error for the same case, and the share
+		// service uses errors.As to detect "gist already revoked upstream"
+		// and treat it as a soft success rather than a 502.
+		if strings.Contains(err.Error(), "HTTP 404") {
+			return &GitHubAPIError{
+				StatusCode: http.StatusNotFound,
+				Endpoint:   "/gists/" + gistID,
+				Body:       err.Error(),
+			}
+		}
 		return fmt.Errorf("delete gist %s: %w", gistID, err)
 	}
 	return nil

--- a/apps/backend/internal/github/gh_client.go
+++ b/apps/backend/internal/github/gh_client.go
@@ -736,8 +736,10 @@ func (c *GHClient) DeleteGist(ctx context.Context, gistID string) error {
 		// so share.IsAlreadyGone matches consistently — PATClient.delete()
 		// already returns a typed error for the same case, and the share
 		// service uses errors.As to detect "gist already revoked upstream"
-		// and treat it as a soft success rather than a 502.
-		if strings.Contains(err.Error(), "HTTP 404") {
+		// and treat it as a soft success rather than a 502. Use isNotFoundErr
+		// so every gh-CLI 404 format ("HTTP 404", "404 Not Found", "status: 404")
+		// is recognised, not just the most common one.
+		if isNotFoundErr(err) {
 			return &GitHubAPIError{
 				StatusCode: http.StatusNotFound,
 				Endpoint:   "/gists/" + gistID,

--- a/apps/backend/internal/github/gh_client.go
+++ b/apps/backend/internal/github/gh_client.go
@@ -692,6 +692,50 @@ func (c *GHClient) ListRepoBranches(ctx context.Context, owner, repo string) ([]
 	return branches, nil
 }
 
+func (c *GHClient) CreateGist(ctx context.Context, in CreateGistInput) (*GistResponse, error) {
+	payload := struct {
+		Description string                 `json:"description,omitempty"`
+		Public      bool                   `json:"public"`
+		Files       map[string]gistFileDTO `json:"files"`
+	}{
+		Description: in.Description,
+		Public:      in.Public,
+		Files:       make(map[string]gistFileDTO, len(in.Files)),
+	}
+	for name, f := range in.Files {
+		payload.Files[name] = gistFileDTO(f)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal gist payload: %w", err)
+	}
+	args := []string{"api", "gists",
+		"-X", "POST",
+		"-H", "Accept: " + githubAccept,
+		"--input", "-",
+	}
+	out, err := c.runWithStdin(ctx, body, args...)
+	if err != nil {
+		return nil, fmt.Errorf("create gist: %w", err)
+	}
+	var resp GistResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return nil, fmt.Errorf("decode gist response: %w", err)
+	}
+	return &resp, nil
+}
+
+func (c *GHClient) DeleteGist(ctx context.Context, gistID string) error {
+	if gistID == "" {
+		return fmt.Errorf("delete gist: empty id")
+	}
+	_, err := c.run(ctx, "api", "gists/"+gistID, "-X", "DELETE")
+	if err != nil {
+		return fmt.Errorf("delete gist %s: %w", gistID, err)
+	}
+	return nil
+}
+
 const ghCLITimeout = 30 * time.Second
 
 // withDefaultGHTimeout applies a 30s timeout if the context has no deadline.
@@ -709,6 +753,23 @@ func (c *GHClient) run(ctx context.Context, args ...string) (string, error) {
 	ctx, cancel := withDefaultGHTimeout(ctx)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		c.inspectRateStderr(args, stderr.String())
+		return stdout.String(), fmt.Errorf("gh %s: %w: %s", args[0], err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+// runWithStdin is like run but pipes stdin into the gh CLI process.
+// Useful for `gh api --input -` calls where the body comes from JSON.
+func (c *GHClient) runWithStdin(ctx context.Context, stdin []byte, args ...string) (string, error) {
+	ctx, cancel := withDefaultGHTimeout(ctx)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Stdin = bytes.NewReader(stdin)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/apps/backend/internal/github/gists.go
+++ b/apps/backend/internal/github/gists.go
@@ -1,0 +1,22 @@
+package github
+
+import "time"
+
+// CreateGistInput is the payload for CreateGist.
+type CreateGistInput struct {
+	Description string
+	Public      bool
+	Files       map[string]GistFile
+}
+
+// GistFile is a single file entry inside a gist.
+type GistFile struct {
+	Content string
+}
+
+// GistResponse is the subset of the GitHub gist API response we care about.
+type GistResponse struct {
+	ID        string    `json:"id"`
+	HTMLURL   string    `json:"html_url"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/apps/backend/internal/github/mock_client.go
+++ b/apps/backend/internal/github/mock_client.go
@@ -74,6 +74,19 @@ type MockClient struct {
 	submittedReviews []submittedReview
 	mergedPRs        []mergedPR
 	mergeMethods     map[repoKey]RepoMergeMethods
+	gists            map[string]mockGist
+	deletedGists     []string
+	nextGistID       int
+}
+
+// mockGist captures a gist that was created via the mock client so tests
+// can inspect what would have been uploaded.
+type mockGist struct {
+	ID          string
+	Description string
+	Public      bool
+	Files       map[string]GistFile
+	HTMLURL     string
 }
 
 // NewMockClient creates a new MockClient with default values.
@@ -91,6 +104,7 @@ func NewMockClient() *MockClient {
 		files:         make(map[prKey][]PRFile),
 		commits:       make(map[prKey][]PRCommitInfo),
 		mergeMethods:  make(map[repoKey]RepoMergeMethods),
+		gists:         make(map[string]mockGist),
 	}
 }
 
@@ -311,6 +325,65 @@ func (m *MockClient) MergePR(_ context.Context, owner, repo string, number int, 
 	return nil
 }
 
+func (m *MockClient) CreateGist(_ context.Context, in CreateGistInput) (*GistResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextGistID++
+	id := fmt.Sprintf("mock-gist-%d", m.nextGistID)
+	htmlURL := "https://gist.github.com/" + m.user + "/" + id
+	files := make(map[string]GistFile, len(in.Files))
+	for k, v := range in.Files {
+		files[k] = v
+	}
+	m.gists[id] = mockGist{
+		ID:          id,
+		Description: in.Description,
+		Public:      in.Public,
+		Files:       files,
+		HTMLURL:     htmlURL,
+	}
+	return &GistResponse{
+		ID:        id,
+		HTMLURL:   htmlURL,
+		CreatedAt: time.Now().UTC(),
+	}, nil
+}
+
+func (m *MockClient) DeleteGist(_ context.Context, gistID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.gists[gistID]; !ok {
+		return &GitHubAPIError{
+			StatusCode: 404,
+			Endpoint:   "/gists/" + gistID,
+			Body:       "gist not found",
+		}
+	}
+	delete(m.gists, gistID)
+	m.deletedGists = append(m.deletedGists, gistID)
+	return nil
+}
+
+// Gists returns all currently-stored gists for test inspection.
+func (m *MockClient) Gists() map[string]mockGist {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make(map[string]mockGist, len(m.gists))
+	for k, v := range m.gists {
+		out[k] = v
+	}
+	return out
+}
+
+// DeletedGists returns the IDs of gists that were deleted, in call order.
+func (m *MockClient) DeletedGists() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]string, len(m.deletedGists))
+	copy(out, m.deletedGists)
+	return out
+}
+
 // --- Setter methods for HTTP control endpoints ---
 
 // SetUser sets the authenticated username.
@@ -451,6 +524,9 @@ func (m *MockClient) Reset() {
 	m.submittedReviews = nil
 	m.mergedPRs = nil
 	m.mergeMethods = make(map[repoKey]RepoMergeMethods)
+	m.gists = make(map[string]mockGist)
+	m.deletedGists = nil
+	m.nextGistID = 0
 }
 
 // SubmittedReviews returns all recorded SubmitReview calls.

--- a/apps/backend/internal/github/mock_client_test.go
+++ b/apps/backend/internal/github/mock_client_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -190,6 +191,54 @@ func TestMockClient_SubmitReview(t *testing.T) {
 	}
 	if reviews[0].Event != "APPROVE" || reviews[0].Body != "LGTM" {
 		t.Fatalf("unexpected review: %+v", reviews[0])
+	}
+}
+
+func TestMockClient_CreateAndDeleteGist(t *testing.T) {
+	m := NewMockClient()
+	ctx := context.Background()
+
+	resp, err := m.CreateGist(ctx, CreateGistInput{
+		Description: "snapshot",
+		Public:      false,
+		Files: map[string]GistFile{
+			"snapshot.json": {Content: `{"x":1}`},
+			"README.md":     {Content: "hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateGist error: %v", err)
+	}
+	if resp.ID == "" || resp.HTMLURL == "" {
+		t.Fatalf("expected non-empty id/url, got %+v", resp)
+	}
+
+	gists := m.Gists()
+	g, ok := gists[resp.ID]
+	if !ok {
+		t.Fatalf("gist %s not stored", resp.ID)
+	}
+	if g.Public {
+		t.Fatal("gist should default to secret (Public=false)")
+	}
+	if _, ok := g.Files["snapshot.json"]; !ok {
+		t.Fatal("snapshot.json missing from stored gist")
+	}
+
+	if err := m.DeleteGist(ctx, resp.ID); err != nil {
+		t.Fatalf("DeleteGist error: %v", err)
+	}
+	if _, ok := m.Gists()[resp.ID]; ok {
+		t.Fatal("gist still present after delete")
+	}
+	if got := m.DeletedGists(); len(got) != 1 || got[0] != resp.ID {
+		t.Fatalf("expected DeletedGists=[%q], got %v", resp.ID, got)
+	}
+
+	err = m.DeleteGist(ctx, resp.ID)
+	var apiErr *GitHubAPIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 404 {
+		t.Fatalf("expected 404 GitHubAPIError on second delete, got %v", err)
 	}
 }
 

--- a/apps/backend/internal/github/noop_client.go
+++ b/apps/backend/internal/github/noop_client.go
@@ -108,3 +108,11 @@ func (c *NoopClient) SearchPRsPaged(context.Context, string, string, int, int) (
 func (c *NoopClient) GetIssueState(context.Context, string, string, int) (string, error) {
 	return "", ErrNoClient
 }
+
+func (c *NoopClient) CreateGist(context.Context, CreateGistInput) (*GistResponse, error) {
+	return nil, ErrNoClient
+}
+
+func (c *NoopClient) DeleteGist(context.Context, string) error {
+	return ErrNoClient
+}

--- a/apps/backend/internal/github/pat_client.go
+++ b/apps/backend/internal/github/pat_client.go
@@ -487,6 +487,42 @@ func (c *PATClient) MergePR(ctx context.Context, owner, repo string, number int,
 	return c.put(ctx, endpoint, jsonBody)
 }
 
+func (c *PATClient) CreateGist(ctx context.Context, in CreateGistInput) (*GistResponse, error) {
+	payload := struct {
+		Description string                 `json:"description,omitempty"`
+		Public      bool                   `json:"public"`
+		Files       map[string]gistFileDTO `json:"files"`
+	}{
+		Description: in.Description,
+		Public:      in.Public,
+		Files:       make(map[string]gistFileDTO, len(in.Files)),
+	}
+	for name, f := range in.Files {
+		payload.Files[name] = gistFileDTO(f)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal gist payload: %w", err)
+	}
+	var resp GistResponse
+	if err := c.postJSON(ctx, "/gists", body, &resp); err != nil {
+		return nil, fmt.Errorf("create gist: %w", err)
+	}
+	return &resp, nil
+}
+
+func (c *PATClient) DeleteGist(ctx context.Context, gistID string) error {
+	if gistID == "" {
+		return fmt.Errorf("delete gist: empty id")
+	}
+	return c.delete(ctx, "/gists/"+gistID)
+}
+
+// gistFileDTO mirrors the GitHub API's per-file body shape.
+type gistFileDTO struct {
+	Content string `json:"content"`
+}
+
 // post makes an authenticated HTTP POST to the GitHub API.
 // Errors on non-2xx are returned as plain `fmt.Errorf` (not `*GitHubAPIError`),
 // so callers cannot recover the HTTP status via `errors.As`. Use `put` (or
@@ -512,6 +548,60 @@ func (c *PATClient) post(ctx context.Context, endpoint string, body []byte) erro
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		c.maybeMarkRateExhaustedFromBody(endpoint, resp.StatusCode, respBody)
 		return fmt.Errorf("GitHub API POST %s returned %d: %s", endpoint, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// postJSON sends a POST and decodes the response body into result.
+// 2xx with no body returns nil; 4xx/5xx returns a *GitHubAPIError.
+func (c *PATClient) postJSON(ctx context.Context, endpoint string, body []byte, result interface{}) error {
+	u := githubAPIBase + endpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	c.setGitHubHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request POST %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	c.recordRateHeaders(resp, endpoint)
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		c.maybeMarkRateExhaustedFromBody(endpoint, resp.StatusCode, respBody)
+		return &GitHubAPIError{StatusCode: resp.StatusCode, Endpoint: endpoint, Body: string(respBody)}
+	}
+	if result == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(result)
+}
+
+// delete sends a DELETE request. 2xx and 404 both return nil-or-typed-error per caller intent.
+// Here we return a typed error on any non-2xx so callers can inspect for 404.
+func (c *PATClient) delete(ctx context.Context, endpoint string) error {
+	u := githubAPIBase + endpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return err
+	}
+	c.setGitHubHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request DELETE %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	c.recordRateHeaders(resp, endpoint)
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		c.maybeMarkRateExhaustedFromBody(endpoint, resp.StatusCode, respBody)
+		return &GitHubAPIError{StatusCode: resp.StatusCode, Endpoint: endpoint, Body: string(respBody)}
 	}
 	return nil
 }

--- a/apps/backend/internal/task/share/backend.go
+++ b/apps/backend/internal/task/share/backend.go
@@ -1,0 +1,44 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/kandev/kandev/internal/github"
+)
+
+// ErrSnapshotTooLarge is returned when a snapshot exceeds the backend's
+// per-file size cap. The HTTP handler maps this to 413.
+var ErrSnapshotTooLarge = errors.New("snapshot exceeds maximum size")
+
+// Backend is the contract every storage backend must implement. The snapshot
+// has already been redacted by the caller; the backend is responsible only
+// for transport and persistence.
+type Backend interface {
+	// Name returns the backend identifier persisted in task_shares.backend.
+	Name() string
+
+	// Upload publishes the snapshot and returns the backend-specific
+	// identifier (e.g. gist ID) and the public URL where it can be viewed.
+	Upload(ctx context.Context, snap *Snapshot) (externalID, externalURL string, err error)
+
+	// Delete removes a previously-uploaded snapshot. Backends MAY return a
+	// "not found" error which the service detects via IsAlreadyGone.
+	Delete(ctx context.Context, externalID string) error
+}
+
+// IsAlreadyGone reports whether err signals the backend resource no longer
+// exists. The service uses this to treat repeated revoke calls as success.
+// Currently scoped to GitHub-API 404s but the helper lives here so future
+// backends can extend it without leaking package boundaries.
+func IsAlreadyGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *github.GitHubAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusNotFound
+	}
+	return false
+}

--- a/apps/backend/internal/task/share/builder.go
+++ b/apps/backend/internal/task/share/builder.go
@@ -1,0 +1,249 @@
+package share
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kandev/kandev/internal/sysprompt"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// ErrSessionNotShareable is returned when BuildSnapshot is asked to snapshot
+// a session that has not produced any conversation yet (CREATED / STARTING).
+// The HTTP handler maps this to 409.
+var ErrSessionNotShareable = errors.New("session has no shareable content yet")
+
+// TaskReader is the narrow slice of the task repository BuildSnapshot needs.
+// Keeping it small lets us stub it in unit tests without pulling in the full
+// task repo interface.
+type TaskReader interface {
+	GetTask(ctx context.Context, id string) (*models.Task, error)
+	GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error)
+	ListMessages(ctx context.Context, sessionID string) ([]*models.Message, error)
+}
+
+// BuildSnapshot loads the task, session, and messages for the given session
+// and returns a redacted snapshot. The kandevVersion is recorded in the
+// snapshot for forward debugging but is otherwise opaque.
+//
+// Sessions in CREATED or STARTING state are rejected because they predate
+// any agent output. Every other state — RUNNING, IDLE, WAITING_FOR_INPUT,
+// COMPLETED, FAILED, CANCELLED — produces a valid snapshot of whatever
+// conversation has happened so far.
+func BuildSnapshot(ctx context.Context, repo TaskReader, taskSessionID, kandevVersion string) (*Snapshot, error) {
+	session, err := repo.GetTaskSession(ctx, taskSessionID)
+	if err != nil {
+		return nil, fmt.Errorf("load session: %w", err)
+	}
+	if session == nil {
+		return nil, fmt.Errorf("load session: %w", ErrSessionNotShareable)
+	}
+	if !isShareableState(session.State) {
+		return nil, ErrSessionNotShareable
+	}
+
+	task, err := repo.GetTask(ctx, session.TaskID)
+	if err != nil {
+		return nil, fmt.Errorf("load task: %w", err)
+	}
+
+	messages, err := repo.ListMessages(ctx, taskSessionID)
+	if err != nil {
+		return nil, fmt.Errorf("load messages: %w", err)
+	}
+
+	red := NewRedactor(workspaceRootFor(session))
+	snap := &Snapshot{
+		Version:       SnapshotVersion,
+		KandevVersion: kandevVersion,
+		ExportedAt:    time.Now().UTC(),
+		Task:          taskMeta(task),
+		Session:       sessionMeta(session),
+		Messages:      mapMessages(messages, red),
+	}
+	snap.Redaction.AppliedRules = red.Applied()
+	return snap, nil
+}
+
+// isShareableState mirrors the frontend gate: any session that has
+// progressed past the pre-history states (CREATED, STARTING) is fair game.
+func isShareableState(s models.TaskSessionState) bool {
+	switch s {
+	case models.TaskSessionStateCreated, models.TaskSessionStateStarting:
+		return false
+	}
+	return true
+}
+
+func taskMeta(t *models.Task) TaskMeta {
+	if t == nil {
+		return TaskMeta{}
+	}
+	return TaskMeta{
+		Title:        t.Title,
+		WorkflowStep: t.WorkflowStepID,
+	}
+}
+
+func sessionMeta(s *models.TaskSession) SessionMeta {
+	return SessionMeta{
+		AgentType:    snapshotString(s.AgentProfileSnapshot, "agent_type"),
+		Model:        snapshotString(s.AgentProfileSnapshot, "model"),
+		ExecutorType: snapshotString(s.ExecutorSnapshot, "type"),
+		StartedAt:    s.StartedAt,
+		CompletedAt:  s.CompletedAt,
+	}
+}
+
+// workspaceRootFor picks the most-specific filesystem root we can use to
+// rewrite absolute paths into repo-relative form. Prefers the active
+// worktree path, falls back to the session's workspace path.
+func workspaceRootFor(s *models.TaskSession) string {
+	for _, w := range s.Worktrees {
+		if w != nil && w.WorktreePath != "" {
+			return w.WorktreePath
+		}
+	}
+	return s.WorkspacePath
+}
+
+// snapshotString extracts a string field from one of the *Snapshot map
+// metadata fields stored on TaskSession. Returns "" if the field is missing
+// or is not a string.
+func snapshotString(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// mapMessages converts the live message rows into snapshot Messages.
+// Hidden system content (wrapped in <kandev-system>) is stripped per the
+// existing Message.ToAPI() convention before redaction.
+func mapMessages(in []*models.Message, red *Redactor) []Message {
+	out := make([]Message, 0, len(in))
+	for _, m := range in {
+		role := roleForAuthor(m.AuthorType, m.Type)
+		blocks := blocksForMessage(m, red)
+		if len(blocks) == 0 {
+			continue
+		}
+		out = append(out, Message{
+			Role:   role,
+			Ts:     m.CreatedAt,
+			Blocks: blocks,
+		})
+	}
+	return out
+}
+
+func roleForAuthor(author models.MessageAuthorType, mt models.MessageType) string {
+	switch author {
+	case models.MessageAuthorUser:
+		return roleUser
+	case models.MessageAuthorAgent:
+		return roleAssistant
+	}
+	if mt == models.MessageTypeStatus || mt == models.MessageTypeLog || mt == models.MessageTypeError {
+		return roleSystem
+	}
+	return roleSystem
+}
+
+// blocksForMessage decides whether a Message is shareable conversation
+// content and converts it into the snapshot Blocks for that role. We
+// whitelist what gets through rather than blacklist noise — that way new
+// internal message types (tool_search, agent_plan, todo, mock-agent stderr
+// captures, …) don't quietly leak into shared snapshots.
+//
+// What gets through:
+//   - User messages of any type → text block (the user's intent is always
+//     part of the conversation, even if the runtime tagged it oddly).
+//   - Agent messages with no explicit type, "message", or "content"
+//     → text block (regular agent prose).
+//   - Agent messages whose type starts with "tool_" (tool_call, tool_edit,
+//     tool_read, tool_execute, tool_search, …) → collapsed tool block.
+//
+// Everything else — status, progress, log, error, thinking, agent_plan,
+// todo, permission_request, clarification_request, script_execution, plus
+// any future type we don't recognise — is dropped.
+func blocksForMessage(m *models.Message, red *Redactor) []Block {
+	if m.AuthorType == models.MessageAuthorUser {
+		return textBlockOrNil(red, m.Content)
+	}
+	t := string(m.Type)
+	if t == "" || t == string(models.MessageTypeMessage) || t == string(models.MessageTypeContent) {
+		return textBlockOrNil(red, m.Content)
+	}
+	if strings.HasPrefix(t, "tool_") {
+		return []Block{toolCallBlock(m, red)}
+	}
+	return nil
+}
+
+// textBlockOrNil returns a single text block, or nil if the content is empty
+// after trimming. System-injected blocks wrapped in <kandev-system> tags
+// (the system prompt the runtime prepends to user turns) are stripped first
+// — those carry implementation details that should never appear in a public
+// share. After stripping, if nothing is left we drop the message entirely.
+func textBlockOrNil(red *Redactor, content string) []Block {
+	stripped := sysprompt.StripSystemContent(content)
+	text := strings.TrimSpace(stripped)
+	if text == "" {
+		return nil
+	}
+	return []Block{{Kind: blockKindText, Text: red.String(text)}}
+}
+
+// toolCallBlock builds a "tool_call" Block from a tool-call message. The
+// message Content carries a human-readable summary; the Args, when present
+// in Metadata, are redacted as a top-level JSON object so RuleEnvVars fires
+// for shell payloads.
+func toolCallBlock(m *models.Message, red *Redactor) Block {
+	b := Block{
+		Kind:     blockKindToolCall,
+		Text:     red.String(strings.TrimSpace(m.Content)),
+		ToolName: metaString(m.Metadata, "tool_name"),
+	}
+	if raw, ok := metaJSON(m.Metadata, "args"); ok {
+		b.Args = red.JSON(raw)
+	}
+	return b
+}
+
+func metaString(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key]; ok {
+		s, _ := v.(string)
+		return s
+	}
+	return ""
+}
+
+// metaJSON marshals an arbitrary metadata value back to a JSON RawMessage so
+// it can be redacted via Redactor.JSON. Returns ok=false if the key is missing.
+func metaJSON(m map[string]interface{}, key string) (json.RawMessage, bool) {
+	if m == nil {
+		return nil, false
+	}
+	v, ok := m[key]
+	if !ok {
+		return nil, false
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, false
+	}
+	return raw, true
+}

--- a/apps/backend/internal/task/share/builder.go
+++ b/apps/backend/internal/task/share/builder.go
@@ -217,12 +217,37 @@ func toolCallBlock(m *models.Message, red *Redactor) Block {
 	b := Block{
 		Kind:     blockKindToolCall,
 		Text:     red.String(strings.TrimSpace(m.Content)),
-		ToolName: metaString(m.Metadata, "tool_name"),
+		ToolName: toolNameFor(m),
 	}
-	if raw, ok := metaJSON(m.Metadata, "args"); ok {
+	if raw, ok := toolArgsFor(m); ok {
 		b.Args = red.JSON(raw)
 	}
 	return b
+}
+
+// toolNameFor picks the tool label. Production messages don't carry a
+// "tool_name" metadata key — service_messages.go writes the normalized
+// *streams.NormalizedPayload under metadata["normalized"] and the tool kind
+// ends up on Message.Type ("tool_read", "tool_execute", …). Strip the
+// "tool_" prefix from Type to get a useful label ("read", "execute", "edit").
+// The debug-fixture replay path *does* set metadata["tool_name"], so prefer
+// that when present for backward compatibility.
+func toolNameFor(m *models.Message) string {
+	if name := metaString(m.Metadata, "tool_name"); name != "" {
+		return name
+	}
+	return strings.TrimPrefix(string(m.Type), "tool_")
+}
+
+// toolArgsFor picks the args JSON payload. Production stores the typed tool
+// payload under metadata["normalized"]; the debug-fixture replay path stores
+// it under metadata["args"]. Prefer "args" so existing fixtures keep their
+// shape, fall back to "normalized" so real shares have something to redact.
+func toolArgsFor(m *models.Message) (json.RawMessage, bool) {
+	if raw, ok := metaJSON(m.Metadata, "args"); ok {
+		return raw, true
+	}
+	return metaJSON(m.Metadata, "normalized")
 }
 
 func metaString(m map[string]interface{}, key string) string {

--- a/apps/backend/internal/task/share/builder.go
+++ b/apps/backend/internal/task/share/builder.go
@@ -56,7 +56,7 @@ func BuildSnapshot(ctx context.Context, repo TaskReader, taskSessionID, kandevVe
 		return nil, fmt.Errorf("load messages: %w", err)
 	}
 
-	red := NewRedactor(workspaceRootFor(session))
+	red := NewRedactor(workspaceRootsFor(session)...)
 	snap := &Snapshot{
 		Version:       SnapshotVersion,
 		KandevVersion: kandevVersion,
@@ -99,16 +99,21 @@ func sessionMeta(s *models.TaskSession) SessionMeta {
 	}
 }
 
-// workspaceRootFor picks the most-specific filesystem root we can use to
-// rewrite absolute paths into repo-relative form. Prefers the active
-// worktree path, falls back to the session's workspace path.
-func workspaceRootFor(s *models.TaskSession) string {
+// workspaceRootsFor returns every filesystem root the redactor should rewrite
+// to repo-relative form. Multi-repo sessions carry multiple worktrees, so we
+// emit each WorktreePath plus the session's WorkspacePath fallback — the
+// redactor sorts them longest-first internally to handle nested roots.
+func workspaceRootsFor(s *models.TaskSession) []string {
+	roots := make([]string, 0, len(s.Worktrees)+1)
 	for _, w := range s.Worktrees {
 		if w != nil && w.WorktreePath != "" {
-			return w.WorktreePath
+			roots = append(roots, w.WorktreePath)
 		}
 	}
-	return s.WorkspacePath
+	if s.WorkspacePath != "" {
+		roots = append(roots, s.WorkspacePath)
+	}
+	return roots
 }
 
 // snapshotString extracts a string field from one of the *Snapshot map

--- a/apps/backend/internal/task/share/builder_test.go
+++ b/apps/backend/internal/task/share/builder_test.go
@@ -190,6 +190,62 @@ func TestBuildSnapshot_RedactsToolCallEnvAndPaths(t *testing.T) {
 	}
 }
 
+// TestBuildSnapshot_ToolCall_ProductionMetadataShape exercises the metadata
+// shape that real sessions produce: no "tool_name" key, args under
+// metadata["normalized"] as the NormalizedPayload JSON, message Type set to
+// "tool_<kind>". The earlier shape ("tool_name"/"args" keys) only exists in
+// the debug fixture loader.
+func TestBuildSnapshot_ToolCall_ProductionMetadataShape(t *testing.T) {
+	t.Parallel()
+	completed := time.Now().UTC()
+	r := &stubReader{
+		task: &models.Task{ID: "t-1", Title: "Real session"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt: completed, CompletedAt: &completed,
+			WorkspacePath: "/workspace/proj",
+		},
+		messages: []*models.Message{
+			{
+				ID: "m-1", TaskSessionID: "s-1", AuthorType: models.MessageAuthorAgent,
+				Type:    models.MessageTypeToolRead,
+				Content: "read /workspace/proj/src/main.go",
+				Metadata: map[string]interface{}{
+					"normalized": map[string]interface{}{
+						"kind": "read_file",
+						"read_file": map[string]interface{}{
+							"path": "/workspace/proj/src/main.go",
+						},
+					},
+				},
+				CreatedAt: completed,
+			},
+		},
+	}
+	snap, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	b := snap.Messages[0].Blocks[0]
+	if b.Kind != blockKindToolCall {
+		t.Fatalf("expected tool_call block, got %q", b.Kind)
+	}
+	// "tool_" prefix stripped from m.Type to produce a useful label.
+	if b.ToolName != "read" {
+		t.Fatalf("expected ToolName=read, got %q", b.ToolName)
+	}
+	// Args populated from metadata["normalized"] and redacted.
+	if len(b.Args) == 0 {
+		t.Fatalf("expected Args populated from normalized payload, got empty")
+	}
+	if strings.Contains(string(b.Args), "/workspace/proj") {
+		t.Fatalf("expected abs-path redacted in args, got %s", string(b.Args))
+	}
+	if strings.Contains(b.Text, "/workspace/proj") {
+		t.Fatalf("expected abs-path redacted in text, got %q", b.Text)
+	}
+}
+
 func TestBuildSnapshot_FiltersNoiseTypes(t *testing.T) {
 	t.Parallel()
 	completed := time.Now().UTC()

--- a/apps/backend/internal/task/share/builder_test.go
+++ b/apps/backend/internal/task/share/builder_test.go
@@ -1,0 +1,333 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// stubReader implements TaskReader for unit tests.
+type stubReader struct {
+	task     *models.Task
+	session  *models.TaskSession
+	messages []*models.Message
+}
+
+func (s *stubReader) GetTask(_ context.Context, _ string) (*models.Task, error) {
+	return s.task, nil
+}
+func (s *stubReader) GetTaskSession(_ context.Context, _ string) (*models.TaskSession, error) {
+	return s.session, nil
+}
+func (s *stubReader) ListMessages(_ context.Context, _ string) ([]*models.Message, error) {
+	return s.messages, nil
+}
+
+func TestBuildSnapshot_AllowsRunningAndOtherPostStartStates(t *testing.T) {
+	t.Parallel()
+	for _, state := range []models.TaskSessionState{
+		models.TaskSessionStateRunning,
+		models.TaskSessionStateIdle,
+		models.TaskSessionStateWaitingForInput,
+		models.TaskSessionStateCompleted,
+		models.TaskSessionStateFailed,
+		models.TaskSessionStateCancelled,
+	} {
+		state := state
+		t.Run(string(state), func(t *testing.T) {
+			r := &stubReader{
+				task:    &models.Task{ID: "t-1", Title: "Hi"},
+				session: &models.TaskSession{ID: "s-1", TaskID: "t-1", State: state},
+				messages: []*models.Message{
+					{ID: "m-1", AuthorType: models.MessageAuthorUser, Type: models.MessageTypeMessage, Content: "hi"},
+				},
+			}
+			snap, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+			if err != nil {
+				t.Fatalf("state %q: unexpected error: %v", state, err)
+			}
+			if snap == nil || len(snap.Messages) == 0 {
+				t.Fatalf("state %q: expected non-empty snapshot", state)
+			}
+		})
+	}
+}
+
+func TestBuildSnapshot_RejectsPreHistoryStates(t *testing.T) {
+	t.Parallel()
+	for _, state := range []models.TaskSessionState{
+		models.TaskSessionStateCreated,
+		models.TaskSessionStateStarting,
+	} {
+		state := state
+		t.Run(string(state), func(t *testing.T) {
+			r := &stubReader{
+				task:    &models.Task{ID: "t-1", Title: "Hi"},
+				session: &models.TaskSession{ID: "s-1", TaskID: "t-1", State: state},
+			}
+			_, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+			if !errors.Is(err, ErrSessionNotShareable) {
+				t.Fatalf("state %q: expected ErrSessionNotShareable, got %v", state, err)
+			}
+		})
+	}
+}
+
+func TestBuildSnapshot_BuildsBasicConversation(t *testing.T) {
+	t.Parallel()
+	completed := time.Now().UTC()
+	r := &stubReader{
+		task: &models.Task{ID: "t-1", Title: "Investigate flaky test", WorkflowStepID: "step-debug"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt:   completed.Add(-time.Minute),
+			CompletedAt: &completed,
+			AgentProfileSnapshot: map[string]interface{}{
+				"agent_type": "claude-acp",
+				"model":      "claude-opus-4-7",
+			},
+			ExecutorSnapshot: map[string]interface{}{"type": "local_docker"},
+			WorkspacePath:    "/Users/foo/proj",
+		},
+		messages: []*models.Message{
+			{
+				ID: "m-1", TaskSessionID: "s-1", AuthorType: models.MessageAuthorUser,
+				Type: models.MessageTypeMessage, Content: "Hello",
+				CreatedAt: completed.Add(-30 * time.Second),
+			},
+			{
+				ID: "m-2", TaskSessionID: "s-1", AuthorType: models.MessageAuthorAgent,
+				Type: models.MessageTypeContent, Content: "Hi there",
+				CreatedAt: completed.Add(-25 * time.Second),
+			},
+		},
+	}
+	snap, err := BuildSnapshot(context.Background(), r, "s-1", "v-test")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if snap.Version != SnapshotVersion {
+		t.Fatalf("expected version %d, got %d", SnapshotVersion, snap.Version)
+	}
+	if snap.Task.Title != "Investigate flaky test" {
+		t.Fatalf("task.title = %q", snap.Task.Title)
+	}
+	if snap.Session.AgentType != "claude-acp" || snap.Session.Model != "claude-opus-4-7" || snap.Session.ExecutorType != "local_docker" {
+		t.Fatalf("session metadata not populated: %+v", snap.Session)
+	}
+	if len(snap.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(snap.Messages))
+	}
+	if snap.Messages[0].Role != roleUser || snap.Messages[1].Role != roleAssistant {
+		t.Fatalf("roles wrong: %v", snap.Messages)
+	}
+	if snap.Messages[0].Blocks[0].Kind != blockKindText {
+		t.Fatalf("expected text block, got %q", snap.Messages[0].Blocks[0].Kind)
+	}
+}
+
+func TestBuildSnapshot_RedactsToolCallEnvAndPaths(t *testing.T) {
+	t.Parallel()
+	completed := time.Now().UTC()
+	r := &stubReader{
+		task: &models.Task{ID: "t-1", Title: "Shell run"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt: completed, CompletedAt: &completed,
+			WorkspacePath: "/Users/foo/proj",
+		},
+		messages: []*models.Message{
+			{
+				ID: "m-1", TaskSessionID: "s-1", AuthorType: models.MessageAuthorAgent,
+				Type:    models.MessageTypeToolExecute,
+				Content: "ran ls in /Users/foo/proj/src",
+				Metadata: map[string]interface{}{
+					"tool_name": "shell",
+					"args": map[string]interface{}{
+						"cmd": "ls",
+						"env": map[string]interface{}{"SECRET": "abc"},
+					},
+				},
+				CreatedAt: completed,
+			},
+		},
+	}
+	snap, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(snap.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(snap.Messages))
+	}
+	b := snap.Messages[0].Blocks[0]
+	if b.Kind != blockKindToolCall {
+		t.Fatalf("expected tool_call block, got %q", b.Kind)
+	}
+	if strings.Contains(b.Text, "/Users/foo/proj") {
+		t.Fatalf("expected workspace root rewritten, got %q", b.Text)
+	}
+	if strings.Contains(string(b.Args), "SECRET") {
+		t.Fatalf("env should be redacted from args, got %s", string(b.Args))
+	}
+	if !strings.Contains(string(b.Args), `"cmd":"ls"`) {
+		t.Fatalf("cmd preserved expected, got %s", string(b.Args))
+	}
+	got := snap.Redaction.AppliedRules
+	wantHas := map[string]bool{RuleEnvVars: false, RuleAbsPath: false}
+	for _, r := range got {
+		if _, ok := wantHas[r]; ok {
+			wantHas[r] = true
+		}
+	}
+	for k, present := range wantHas {
+		if !present {
+			t.Fatalf("expected applied rule %q, got %v", k, got)
+		}
+	}
+}
+
+func TestBuildSnapshot_FiltersNoiseTypes(t *testing.T) {
+	t.Parallel()
+	completed := time.Now().UTC()
+	r := &stubReader{
+		task: &models.Task{ID: "t-1", Title: "T"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt: completed, CompletedAt: &completed,
+		},
+		messages: []*models.Message{
+			// Agent noise types — must all be dropped.
+			{ID: "n-1", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeLog, Content: "mock-agent: registered ACP MCP server kandev at http://localhost:41027/sse", CreatedAt: completed},
+			{ID: "n-2", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeStatus, Content: "started", CreatedAt: completed},
+			{ID: "n-3", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeError, Content: "boom", CreatedAt: completed},
+			{ID: "n-4", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeThinking, Content: "hmm", CreatedAt: completed},
+			{ID: "n-5", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeAgentPlan, Content: "plan", CreatedAt: completed},
+			{ID: "n-6", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeTodo, Content: "todo list", CreatedAt: completed},
+			{ID: "n-7", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeScriptExecution, Content: "script", CreatedAt: completed},
+			{ID: "n-8", AuthorType: models.MessageAuthorAgent, Type: "completely_unknown_type", Content: "future leak", CreatedAt: completed},
+			// Legit content — must survive.
+			{ID: "ok-1", AuthorType: models.MessageAuthorUser, Type: models.MessageTypeMessage, Content: "real question", CreatedAt: completed},
+			{ID: "ok-2", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeMessage, Content: "real answer", CreatedAt: completed},
+			{ID: "ok-3", AuthorType: models.MessageAuthorAgent, Type: "tool_search", Content: "Search for \"import \"", Metadata: map[string]interface{}{"tool_name": "grep"}, CreatedAt: completed},
+		},
+	}
+	snap, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(snap.Messages) != 3 {
+		t.Fatalf("expected only 3 surviving messages (user prose, agent prose, tool_search pill), got %d:\n%+v", len(snap.Messages), snap.Messages)
+	}
+	// Make sure none of the noise content leaked in.
+	for _, m := range snap.Messages {
+		for _, b := range m.Blocks {
+			if strings.Contains(b.Text, "mock-agent:") {
+				t.Fatal("mock-agent log line leaked into snapshot")
+			}
+			if strings.Contains(b.Text, "hmm") || strings.Contains(b.Text, "todo list") {
+				t.Fatalf("internal type leaked: %q", b.Text)
+			}
+		}
+	}
+	// tool_search must produce a tool_call block, not text.
+	last := snap.Messages[len(snap.Messages)-1]
+	if last.Blocks[0].Kind != blockKindToolCall {
+		t.Fatalf("tool_search should render as tool_call block, got kind=%q", last.Blocks[0].Kind)
+	}
+}
+
+func TestBuildSnapshot_StripsKandevSystemBlocks(t *testing.T) {
+	t.Parallel()
+	completed := time.Now().UTC()
+	r := &stubReader{
+		task: &models.Task{ID: "t-1", Title: "T"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt: completed, CompletedAt: &completed,
+		},
+		messages: []*models.Message{
+			// First-turn prompt with system context wrapper — only the
+			// visible bit "real question" should survive.
+			{
+				ID: "u-1", AuthorType: models.MessageAuthorUser, Type: models.MessageTypeMessage,
+				Content:   "<kandev-system>\nMCP context goes here\nMore secret stuff\n</kandev-system>\nreal question",
+				CreatedAt: completed,
+			},
+			// Pure system payload — should be dropped entirely after stripping.
+			{
+				ID: "u-2", AuthorType: models.MessageAuthorUser, Type: models.MessageTypeMessage,
+				Content:   "<kandev-system>only system stuff</kandev-system>",
+				CreatedAt: completed,
+			},
+		},
+	}
+	snap, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(snap.Messages) != 1 {
+		t.Fatalf("expected 1 surviving message after system strip, got %d", len(snap.Messages))
+	}
+	body := snap.Messages[0].Blocks[0].Text
+	if strings.Contains(body, "kandev-system") || strings.Contains(body, "MCP context") || strings.Contains(body, "secret stuff") {
+		t.Fatalf("system content leaked into snapshot: %q", body)
+	}
+	if body != "real question" {
+		t.Fatalf("expected only the visible bit to remain, got %q", body)
+	}
+}
+
+func TestBuildSnapshot_UserMessageWithUnusualTypeStillIncluded(t *testing.T) {
+	t.Parallel()
+	completed := time.Now().UTC()
+	r := &stubReader{
+		task: &models.Task{ID: "t-1", Title: "T"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt: completed, CompletedAt: &completed,
+		},
+		messages: []*models.Message{
+			// A user message tagged with a weird type still represents the
+			// user's intent — keep it.
+			{ID: "u-1", AuthorType: models.MessageAuthorUser, Type: "some_weird_type", Content: "important question", CreatedAt: completed},
+		},
+	}
+	snap, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(snap.Messages) != 1 {
+		t.Fatalf("expected 1 user message, got %d", len(snap.Messages))
+	}
+	if snap.Messages[0].Role != roleUser {
+		t.Fatalf("expected user role, got %q", snap.Messages[0].Role)
+	}
+}
+
+func TestBuildSnapshot_SkipsStatusAndEmptyMessages(t *testing.T) {
+	t.Parallel()
+	completed := time.Now().UTC()
+	r := &stubReader{
+		task: &models.Task{ID: "t-1", Title: "T"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt: completed, CompletedAt: &completed,
+		},
+		messages: []*models.Message{
+			{ID: "m-1", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeStatus, Content: "started", CreatedAt: completed},
+			{ID: "m-2", AuthorType: models.MessageAuthorAgent, Type: models.MessageTypeMessage, Content: "  ", CreatedAt: completed},
+			{ID: "m-3", AuthorType: models.MessageAuthorUser, Type: models.MessageTypeMessage, Content: "hi", CreatedAt: completed},
+		},
+	}
+	snap, err := BuildSnapshot(context.Background(), r, "s-1", "v")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(snap.Messages) != 1 || snap.Messages[0].Role != roleUser {
+		t.Fatalf("expected 1 user message after pruning, got %+v", snap.Messages)
+	}
+}

--- a/apps/backend/internal/task/share/gist_backend.go
+++ b/apps/backend/internal/task/share/gist_backend.go
@@ -1,0 +1,161 @@
+package share
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/kandev/kandev/internal/github"
+)
+
+// GistMaxBytes is a conservative cap on a single snapshot.json file. GitHub
+// caps individual gist files at 100 MiB but 10 MiB is plenty for any
+// reasonable conversation and avoids accidentally pushing huge payloads.
+const GistMaxBytes = 10 * 1024 * 1024
+
+// GistBackend uploads snapshots to GitHub Gists on the authenticated user's
+// account. Created gists are always secret (unlisted); anyone with the URL
+// can view them but they are not crawled.
+type GistBackend struct {
+	client github.Client
+}
+
+// NewGistBackend returns a Backend that uses the given github.Client.
+func NewGistBackend(client github.Client) *GistBackend {
+	return &GistBackend{client: client}
+}
+
+// Name implements Backend.
+func (b *GistBackend) Name() string { return BackendGitHubGist }
+
+// Upload marshals the snapshot to JSON, builds the rendered share.html and
+// a README, then creates a secret gist with all three. The returned URL is
+// the rendered view served via gistpreview.github.io — that's the link
+// users share. The gist itself is preserved in the database via the
+// externalID so we can still delete it on revoke.
+func (b *GistBackend) Upload(ctx context.Context, snap *Snapshot) (string, string, error) {
+	body, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return "", "", fmt.Errorf("marshal snapshot: %w", err)
+	}
+	if len(body) > GistMaxBytes {
+		return "", "", fmt.Errorf("%w: %d bytes > %d", ErrSnapshotTooLarge, len(body), GistMaxBytes)
+	}
+	resp, err := b.client.CreateGist(ctx, github.CreateGistInput{
+		Description: gistDescription(snap),
+		Public:      false,
+		Files: map[string]github.GistFile{
+			// share.html sorts first alphabetically in the gist file list,
+			// which puts the rendered view at the top of the gist page too.
+			"share.html":    {Content: BuildShareHTML(snap)},
+			"snapshot.json": {Content: string(body)},
+			// README is built with empty renderedURL — the user's primary
+			// link goes to the rendered view; the README is a fallback for
+			// folks who land on the gist directly.
+			"README.md": {Content: BuildGistREADME(snap, "")},
+		},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("create gist: %w", err)
+	}
+	rendered := renderedURLForGist(resp.HTMLURL)
+	if rendered == "" {
+		// Fall back to the raw gist URL if we couldn't parse a gist ID —
+		// not pretty, but at least the user has a working link.
+		rendered = resp.HTMLURL
+	}
+	return resp.ID, rendered, nil
+}
+
+// renderedURLForGist returns the public rendering URL we hand to the user
+// for a given gist. We route through gistpreview.github.io, a static
+// GitHub-Pages site that fetches the gist via the public API and renders
+// an HTML file client-side. We use it instead of raw.githack.com so
+// visitors don't hit the "One more step" anti-phishing interstitial.
+//
+// Critically: we append "/share.html" to the URL because gistpreview's
+// file-picker logic picks the first iterated file unless one is named
+// "index.html". Our gists contain README.md, share.html, snapshot.json —
+// without the explicit suffix, gistpreview picks README.md (alphabetical
+// first), renders it raw, and the page appears unstyled. The explicit
+// filename pins it to share.html.
+//
+//	https://gist.github.com/<owner>/<id>  →  https://gistpreview.github.io/?<id>/share.html
+//	https://gist.github.com/<id>          →  https://gistpreview.github.io/?<id>/share.html
+//
+// Returns "" if the URL doesn't look like a gist URL — callers fall back
+// to whatever was stored.
+func renderedURLForGist(gistHTMLURL string) string {
+	id := gistIDFromGistHTMLURL(gistHTMLURL)
+	if id == "" {
+		return ""
+	}
+	return gistpreviewURL(id)
+}
+
+// gistpreviewURL builds the gistpreview.github.io URL for a gist id,
+// explicitly pinning the file to share.html.
+func gistpreviewURL(gistID string) string {
+	return "https://gistpreview.github.io/?" + gistID + "/share.html"
+}
+
+// gistIDFromGistHTMLURL extracts the gist ID from a github.com gist URL.
+// Returns "" for anything that doesn't match the expected shape.
+func gistIDFromGistHTMLURL(gistHTMLURL string) string {
+	const prefix = "https://gist.github.com/"
+	if !strings.HasPrefix(gistHTMLURL, prefix) {
+		return ""
+	}
+	rest := strings.Trim(strings.TrimPrefix(gistHTMLURL, prefix), "/")
+	if rest == "" {
+		return ""
+	}
+	// "<owner>/<id>" or "<id>" — the ID is always the last segment.
+	parts := strings.Split(rest, "/")
+	return parts[len(parts)-1]
+}
+
+// gistIDFromGithackURL pulls the gist ID out of a stored raw.githack URL
+// (legacy rows that were written before the gistpreview switchover).
+// Returns "" for anything that doesn't match.
+func gistIDFromGithackURL(url string) string {
+	const prefix = "https://gist.githack.com/"
+	if !strings.HasPrefix(url, prefix) {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(url, prefix), "/")
+	if len(parts) < 2 || parts[1] == "" {
+		return ""
+	}
+	return parts[1]
+}
+
+// Delete removes the gist. A 404 from GitHub is returned to the caller as-is
+// so the service can treat it as "already gone".
+func (b *GistBackend) Delete(ctx context.Context, externalID string) error {
+	if err := b.client.DeleteGist(ctx, externalID); err != nil {
+		var apiErr *github.GitHubAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return err
+		}
+		return fmt.Errorf("delete gist %s: %w", externalID, err)
+	}
+	return nil
+}
+
+func gistDescription(snap *Snapshot) string {
+	if snap == nil || snap.Task.Title == "" {
+		return "kandev task share"
+	}
+	return "kandev share: " + snap.Task.Title
+}
+
+func nonEmpty(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/apps/backend/internal/task/share/gist_backend_test.go
+++ b/apps/backend/internal/task/share/gist_backend_test.go
@@ -1,0 +1,128 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/github"
+)
+
+func sampleSnapshot() *Snapshot {
+	completed := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	return &Snapshot{
+		Version:    SnapshotVersion,
+		ExportedAt: completed,
+		Task:       TaskMeta{Title: "Fix flaky test"},
+		Session: SessionMeta{
+			AgentType:    "claude-acp",
+			Model:        "claude-opus-4-7",
+			ExecutorType: "local_docker",
+			StartedAt:    completed.Add(-time.Minute),
+			CompletedAt:  &completed,
+		},
+		Messages: []Message{
+			{Role: "user", Ts: completed, Blocks: []Block{{Kind: "text", Text: "hi"}}},
+		},
+		Redaction: RedactionLog{AppliedRules: []string{}},
+	}
+}
+
+func TestGistBackend_Upload_CreatesSecretGistWithExpectedFiles(t *testing.T) {
+	t.Parallel()
+	mock := github.NewMockClient()
+	b := NewGistBackend(mock)
+
+	id, url, err := b.Upload(context.Background(), sampleSnapshot())
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if id == "" || url == "" {
+		t.Fatalf("expected non-empty id/url, got %q / %q", id, url)
+	}
+
+	// The returned URL is the rendered gistpreview.github.io viewer URL,
+	// NOT the raw gist URL — that's what the user shares.
+	if !strings.HasPrefix(url, "https://gistpreview.github.io/?") {
+		t.Fatalf("expected gistpreview.github.io URL, got %q", url)
+	}
+
+	gists := mock.Gists()
+	g, ok := gists[id]
+	if !ok {
+		t.Fatalf("gist %s not stored on mock", id)
+	}
+	if g.Public {
+		t.Fatal("backend should always create secret gists (Public=false)")
+	}
+	for _, name := range []string{"snapshot.json", "README.md", "share.html"} {
+		if _, ok := g.Files[name]; !ok {
+			t.Fatalf("missing %s in gist files", name)
+		}
+	}
+	if !strings.Contains(g.Files["snapshot.json"].Content, `"title": "Fix flaky test"`) {
+		t.Fatalf("snapshot.json does not contain task title: %s", g.Files["snapshot.json"].Content)
+	}
+	if !strings.Contains(g.Files["README.md"].Content, "# Fix flaky test") {
+		t.Fatal("README.md missing task title heading")
+	}
+	if !strings.Contains(g.Files["share.html"].Content, "<!doctype html>") {
+		t.Fatal("share.html missing doctype")
+	}
+	if !strings.Contains(g.Files["share.html"].Content, "Fix flaky test") {
+		t.Fatal("share.html missing task title")
+	}
+}
+
+func TestGistBackend_Upload_RejectsOversizedSnapshot(t *testing.T) {
+	t.Parallel()
+	mock := github.NewMockClient()
+	b := NewGistBackend(mock)
+
+	snap := sampleSnapshot()
+	big := strings.Repeat("x", GistMaxBytes+1)
+	snap.Messages = []Message{{Role: "user", Blocks: []Block{{Kind: "text", Text: big}}}}
+
+	_, _, err := b.Upload(context.Background(), snap)
+	if err == nil {
+		t.Fatal("expected ErrSnapshotTooLarge, got nil")
+	}
+	if !errors.Is(err, ErrSnapshotTooLarge) {
+		t.Fatalf("expected ErrSnapshotTooLarge, got %v", err)
+	}
+	if len(mock.Gists()) != 0 {
+		t.Fatalf("no gist should have been created, got %d", len(mock.Gists()))
+	}
+}
+
+func TestGistBackend_Delete_Success(t *testing.T) {
+	t.Parallel()
+	mock := github.NewMockClient()
+	b := NewGistBackend(mock)
+	id, _, err := b.Upload(context.Background(), sampleSnapshot())
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := b.Delete(context.Background(), id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := mock.DeletedGists(); len(got) != 1 || got[0] != id {
+		t.Fatalf("expected DeletedGists=[%q], got %v", id, got)
+	}
+}
+
+func TestGistBackend_Delete_PassesThroughNotFoundForCallerInspection(t *testing.T) {
+	t.Parallel()
+	mock := github.NewMockClient()
+	b := NewGistBackend(mock)
+
+	err := b.Delete(context.Background(), "missing-id")
+	if err == nil {
+		t.Fatal("expected error for missing gist")
+	}
+	if !IsAlreadyGone(err) {
+		t.Fatalf("expected IsAlreadyGone to be true, got err=%v", err)
+	}
+}

--- a/apps/backend/internal/task/share/gist_css.go
+++ b/apps/backend/internal/task/share/gist_css.go
@@ -1,0 +1,386 @@
+package share
+
+// shareCSS is the inlined stylesheet for the rendered share.html page.
+// Self-contained — no @import, no external fonts — so the page renders
+// identically on a fresh CDN with no network outside itself.
+//
+// Color tokens mirror kandev's dark-mode palette
+// (apps/packages/theme/src/globals.css). We use the same oklch() values
+// so the share page reads as part of the product rather than a separate
+// site. oklch() has full support in current Chrome/Safari/Firefox.
+//
+// Layout: classic chat. User bubbles right-aligned with the primary
+// (purple) fill; assistant content left-aligned in the card surface;
+// system messages centered and de-emphasised. Tool calls render inline
+// as collapsed pills inside the assistant bubble. Diffs are full-width
+// code blocks with per-line tinting for adds/dels/hunks.
+const shareCSS = `
+:root {
+  color-scheme: dark;
+
+  /* — Kandev dark-mode tokens (oklch, ported from globals.css) — */
+  --bg: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --border-strong: oklch(1 0 0 / 18%);
+  --primary: oklch(0.59 0.2 277);
+  --primary-foreground: oklch(0.96 0.02 272);
+  --accent: oklch(0.62 0.18 276);
+  --accent-strong: oklch(0.79 0.1 275);
+  --success: oklch(0.68 0.12 150);
+  --destructive: oklch(0.704 0.191 22.216);
+
+  /* — Derived semantic aliases used in the share layout — */
+  --text: var(--foreground);
+  --text-dim: var(--muted-foreground);
+  --text-faint: oklch(0.55 0 0);
+  --surface: var(--card);
+  --surface-2: oklch(0.235 0 0);
+
+  --diff-add-bg: color-mix(in oklab, var(--success) 14%, transparent);
+  --diff-add-text: oklch(0.85 0.14 150);
+  --diff-del-bg: color-mix(in oklab, var(--destructive) 14%, transparent);
+  --diff-del-text: oklch(0.82 0.16 22);
+  --diff-hunk: var(--accent-strong);
+
+  --radius: 0.375rem;
+  --radius-lg: 0.625rem;
+  --radius-xl: 0.875rem;
+
+  --mono: "Geist Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --sans: "Figtree", "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a { color: var(--accent-strong); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code, pre { font-family: var(--mono); }
+::selection { background: var(--primary); color: var(--primary-foreground); }
+
+/* ─── Hero ─────────────────────────────────────────────────────── */
+
+.hero {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 56px 24px 28px;
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-dim);
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+.brand a { color: var(--text); font-weight: 600; letter-spacing: -0.01em; }
+.brand-sep { color: var(--text-faint); }
+.brand-tag { color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.08em; font-size: 11px; }
+
+.hero h1 {
+  margin: 0 0 18px;
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+}
+
+.badges { display: flex; flex-wrap: wrap; gap: 6px; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 12px;
+  font-family: var(--mono);
+}
+
+.redaction {
+  margin: 16px 0 0;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.redaction code {
+  padding: 1px 6px;
+  background: var(--surface);
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+/* ─── Conversation ────────────────────────────────────────────── */
+
+.conv {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.group {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.group-user { flex-direction: row-reverse; }
+.group-assistant { flex-direction: row; }
+.group-system { justify-content: center; }
+
+.avatar {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  margin-bottom: 4px;
+}
+
+.group-user .avatar {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+.group-system .avatar { display: none; }
+
+.bubble {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+.group-assistant .bubble {
+  border-bottom-left-radius: var(--radius);
+  flex: 1;
+}
+.group-user .bubble {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-color: var(--primary);
+  border-bottom-right-radius: var(--radius);
+  max-width: 75%;
+}
+.group-system .bubble {
+  background: transparent;
+  border-style: dashed;
+  color: var(--text-dim);
+  font-size: 13px;
+  max-width: 480px;
+  text-align: center;
+}
+
+/* Role label sits above the content. Hidden inside user bubbles since
+   the right-alignment + color already convey "you said this." */
+.role {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-faint);
+  margin: -2px 0 -4px;
+}
+.group-user .role { display: none; }
+.group-assistant .role { color: var(--accent-strong); }
+
+/* ─── Text inside bubbles ─────────────────────────────────────── */
+
+.text > * { margin: 0; }
+.text > * + * { margin-top: 8px; }
+.text p { line-height: 1.6; }
+.group-user .text { font-size: 15px; }
+
+code.inline {
+  background: color-mix(in oklab, var(--foreground) 8%, transparent);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+.group-user code.inline {
+  background: color-mix(in oklab, white 22%, transparent);
+  color: var(--primary-foreground);
+}
+
+pre.code {
+  margin: 4px 0;
+  padding: 12px 14px;
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  overflow-x: auto;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text);
+}
+.group-user pre.code {
+  background: color-mix(in oklab, black 25%, transparent);
+  border-color: color-mix(in oklab, white 14%, transparent);
+  color: var(--primary-foreground);
+}
+
+/* ─── Tool call / result pills ────────────────────────────────── */
+
+.tool {
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklab, var(--foreground) 3%, transparent);
+  overflow: hidden;
+}
+.tool > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 7px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-dim);
+  user-select: none;
+}
+.tool > summary::-webkit-details-marker { display: none; }
+.tool > summary:hover { background: color-mix(in oklab, var(--foreground) 4%, transparent); }
+
+.tool-icon { font-size: 13px; }
+.tool-name {
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.tool-summary {
+  flex: 1;
+  color: var(--text-faint);
+  font-family: var(--mono);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.tool-chev {
+  color: var(--text-faint);
+  font-size: 10px;
+  transition: transform 0.15s ease;
+}
+.tool[open] > summary .tool-chev { transform: rotate(90deg); }
+
+.args, .output {
+  margin: 0;
+  padding: 12px 14px;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+  font-size: 12.5px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--text);
+}
+
+/* ─── Diff blocks ─────────────────────────────────────────────── */
+
+.diff {
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  overflow: hidden;
+}
+.diff-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--text-dim);
+  background: var(--surface-2);
+}
+.diff-head code { color: var(--text); font-size: 12px; }
+.diff-body {
+  margin: 0;
+  padding: 8px 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+.diff-body > span {
+  display: block;
+  padding: 0 14px;
+  white-space: pre;
+}
+.diff-add { background: var(--diff-add-bg); color: var(--diff-add-text); }
+.diff-del { background: var(--diff-del-bg); color: var(--diff-del-text); }
+.diff-hunk { color: var(--diff-hunk); }
+.diff-file { color: var(--text-faint); }
+
+/* ─── Misc ────────────────────────────────────────────────────── */
+
+.empty {
+  text-align: center;
+  color: var(--text-faint);
+  padding: 48px 0;
+}
+
+.page-footer {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-faint);
+}
+.cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: var(--radius);
+  background: var(--primary);
+  color: var(--primary-foreground) !important;
+  font-weight: 500;
+}
+.cta:hover { text-decoration: none; background: var(--accent); }
+.foot-sep { color: var(--text-faint); }
+.foot-link { color: var(--text-dim); }
+.foot-version { color: var(--text-faint); font-family: var(--mono); font-size: 12px; }
+
+/* ─── Mobile ──────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .hero { padding: 32px 16px 20px; }
+  .hero h1 { font-size: 22px; }
+  .conv { padding: 20px 12px; gap: 18px; }
+  .group { gap: 8px; }
+  .avatar { width: 26px; height: 26px; font-size: 14px; }
+  .bubble { padding: 10px 12px; border-radius: var(--radius-lg); }
+  .group-user .bubble { max-width: 85%; }
+}
+`

--- a/apps/backend/internal/task/share/gist_html.go
+++ b/apps/backend/internal/task/share/gist_html.go
@@ -1,0 +1,241 @@
+package share
+
+import (
+	"fmt"
+	"html"
+	"strings"
+)
+
+// kandevRepoURL is the public GitHub repo for the project — used in the
+// share page's "Try kandev" CTA and brand link. Pointing at the repo
+// instead of a marketing site signals "this is open source, here's the
+// code" which is the actual value proposition for the audience that
+// receives a shared task.
+const kandevRepoURL = "https://github.com/kdlbs/kandev"
+
+// BuildShareHTML produces a self-contained styled HTML page that renders
+// the snapshot as a real chat conversation: user bubbles right-aligned,
+// assistant content left-aligned, consecutive same-role messages fused
+// into one block, and tool calls collapsed inline rather than rendered
+// as their own messages.
+func BuildShareHTML(snap *Snapshot) string {
+	if snap == nil {
+		return "<!doctype html><title>kandev share</title>"
+	}
+	var b strings.Builder
+	b.WriteString("<!doctype html>\n<html lang=\"en\">\n")
+	writeHTMLHead(&b, snap)
+	b.WriteString("<body>\n")
+	// Inline the stylesheet at the top of <body> rather than in <head> so it
+	// survives renderers (notably gistpreview.github.io) that copy only the
+	// body content into their own page — dropping <head> and any <style> tags
+	// in it. <style> in <body> is non-conforming HTML but every browser
+	// applies it without complaint, and it's the standard workaround for
+	// gist-rendering services. We ALSO keep a <style> in head so direct
+	// raw-HTML viewers still get the styles via the normal path; the
+	// duplicate is harmless (CSS rules are idempotent).
+	b.WriteString("<style>")
+	b.WriteString(shareCSS)
+	b.WriteString("</style>\n")
+	writeHTMLHero(&b, snap)
+	b.WriteString("<main class=\"conv\">\n")
+	writeHTMLConversation(&b, snap.Messages)
+	b.WriteString("</main>\n")
+	writeHTMLFooter(&b, snap)
+	b.WriteString("</body>\n</html>\n")
+	return b.String()
+}
+
+func writeHTMLHead(b *strings.Builder, snap *Snapshot) {
+	title := html.EscapeString(nonEmpty(snap.Task.Title, "Untitled task"))
+	fmt.Fprintf(b, "<head>\n<meta charset=\"utf-8\">\n")
+	fmt.Fprintf(b, "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n")
+	fmt.Fprintf(b, "<title>%s — kandev share</title>\n", title)
+	fmt.Fprintf(b, "<meta name=\"description\" content=\"%s\">\n", title)
+	b.WriteString("<style>")
+	b.WriteString(shareCSS)
+	b.WriteString("</style>\n</head>\n")
+}
+
+func writeHTMLHero(b *strings.Builder, snap *Snapshot) {
+	title := html.EscapeString(nonEmpty(snap.Task.Title, "Untitled task"))
+	b.WriteString("<header class=\"hero\">\n")
+	b.WriteString("<div class=\"brand\"><a href=\"" + kandevRepoURL + "\" target=\"_blank\" rel=\"noopener\">kandev</a>")
+	b.WriteString("<span class=\"brand-sep\">·</span><span class=\"brand-tag\">shared task</span></div>\n")
+	fmt.Fprintf(b, "<h1>%s</h1>\n", title)
+	b.WriteString("<div class=\"badges\">")
+	writeHTMLBadge(b, snap.Session.AgentType)
+	writeHTMLBadge(b, snap.Session.Model)
+	writeHTMLBadge(b, snap.Session.ExecutorType)
+	writeHTMLBadge(b, fmt.Sprintf("%d messages", len(snap.Messages)))
+	if completed := formatPtrTime(snap.Session.CompletedAt); completed != "" {
+		writeHTMLBadge(b, completed)
+	}
+	b.WriteString("</div>\n")
+	if len(snap.Redaction.AppliedRules) > 0 {
+		fmt.Fprintf(b, "<p class=\"redaction\">🛡️ Redacted: <code>%s</code></p>\n",
+			html.EscapeString(strings.Join(snap.Redaction.AppliedRules, ", ")))
+	}
+	b.WriteString("</header>\n")
+}
+
+func writeHTMLBadge(b *strings.Builder, text string) {
+	if text == "" {
+		return
+	}
+	fmt.Fprintf(b, "<span class=\"badge\">%s</span>", html.EscapeString(text))
+}
+
+// messageGroup is a run of consecutive messages sharing the same role.
+// Blocks from every member are flattened in order so the whole run renders
+// inside a single bubble.
+type messageGroup struct {
+	role   string
+	blocks []Block
+}
+
+// groupMessages collapses consecutive same-role messages so the renderer
+// can draw one bubble per group. Empty messages (no blocks) are dropped
+// rather than producing empty groups.
+func groupMessages(messages []Message) []messageGroup {
+	var groups []messageGroup
+	for _, m := range messages {
+		if len(m.Blocks) == 0 {
+			continue
+		}
+		if n := len(groups); n > 0 && groups[n-1].role == m.Role {
+			groups[n-1].blocks = append(groups[n-1].blocks, m.Blocks...)
+			continue
+		}
+		groups = append(groups, messageGroup{
+			role:   m.Role,
+			blocks: append([]Block(nil), m.Blocks...),
+		})
+	}
+	return groups
+}
+
+func writeHTMLConversation(b *strings.Builder, messages []Message) {
+	groups := groupMessages(messages)
+	if len(groups) == 0 {
+		b.WriteString("<p class=\"empty\">No messages.</p>\n")
+		return
+	}
+	for _, g := range groups {
+		writeHTMLGroup(b, g)
+	}
+}
+
+func writeHTMLGroup(b *strings.Builder, g messageGroup) {
+	cls, label, icon := messageRoleAttrs(g.role)
+	fmt.Fprintf(b, "<section class=\"group group-%s\">\n", cls)
+	fmt.Fprintf(b, "<div class=\"avatar\" aria-hidden=\"true\">%s</div>\n", icon)
+	b.WriteString("<div class=\"bubble\">\n")
+	fmt.Fprintf(b, "<div class=\"role\">%s</div>\n", html.EscapeString(label))
+	for _, block := range g.blocks {
+		writeHTMLBlock(b, block)
+	}
+	b.WriteString("</div>\n</section>\n")
+}
+
+func messageRoleAttrs(role string) (cls, label, icon string) {
+	switch role {
+	case roleUser:
+		return "user", "You", "🧑"
+	case roleAssistant:
+		return "assistant", "Assistant", "🤖"
+	case roleSystem:
+		return "system", "System", "⚙️"
+	}
+	return "other", role, "•"
+}
+
+func writeHTMLBlock(b *strings.Builder, block Block) {
+	switch block.Kind {
+	case blockKindText:
+		writeHTMLText(b, block.Text)
+	case blockKindToolCall:
+		writeHTMLToolCall(b, block)
+	case blockKindToolResult:
+		writeHTMLToolResult(b, block)
+	case blockKindDiff:
+		writeHTMLDiff(b, block)
+	}
+}
+
+func writeHTMLToolCall(b *strings.Builder, block Block) {
+	name := html.EscapeString(nonEmpty(block.ToolName, "tool"))
+	summary := html.EscapeString(strings.TrimSpace(block.Text))
+	// Closed by default — tool calls are noise unless the reader cares.
+	b.WriteString("<details class=\"tool tool-call\">\n<summary>")
+	b.WriteString("<span class=\"tool-icon\">🔧</span>")
+	fmt.Fprintf(b, "<span class=\"tool-name\">%s</span>", name)
+	if summary != "" {
+		fmt.Fprintf(b, "<span class=\"tool-summary\">%s</span>", summary)
+	}
+	b.WriteString("<span class=\"tool-chev\" aria-hidden=\"true\">▸</span>")
+	b.WriteString("</summary>\n")
+	if len(block.Args) > 0 {
+		fmt.Fprintf(b, "<pre class=\"args\"><code>%s</code></pre>\n",
+			html.EscapeString(prettyJSON(block.Args)))
+	}
+	b.WriteString("</details>\n")
+}
+
+func writeHTMLToolResult(b *strings.Builder, block Block) {
+	out := strings.TrimRight(block.Output, "\n")
+	if strings.TrimSpace(out) == "" {
+		return
+	}
+	label := "Tool output"
+	if block.Truncated {
+		label += " (truncated)"
+	}
+	b.WriteString("<details class=\"tool tool-result\">\n<summary>")
+	b.WriteString("<span class=\"tool-icon\">📤</span>")
+	fmt.Fprintf(b, "<span class=\"tool-name\">%s</span>", html.EscapeString(label))
+	b.WriteString("<span class=\"tool-chev\" aria-hidden=\"true\">▸</span>")
+	b.WriteString("</summary>\n")
+	fmt.Fprintf(b, "<pre class=\"output\"><code>%s</code></pre>\n", html.EscapeString(out))
+	b.WriteString("</details>\n")
+}
+
+func writeHTMLDiff(b *strings.Builder, block Block) {
+	if strings.TrimSpace(block.UnifiedDiff) == "" {
+		return
+	}
+	path := html.EscapeString(nonEmpty(block.Path, "diff"))
+	fmt.Fprintf(b, "<div class=\"diff\">\n<div class=\"diff-head\"><span class=\"tool-icon\">📝</span>")
+	fmt.Fprintf(b, "<code>%s</code></div>\n<pre class=\"diff-body\">", path)
+	for _, line := range strings.Split(strings.TrimRight(block.UnifiedDiff, "\n"), "\n") {
+		writeHTMLDiffLine(b, line)
+	}
+	b.WriteString("</pre>\n</div>\n")
+}
+
+func writeHTMLDiffLine(b *strings.Builder, line string) {
+	cls := "diff-ctx"
+	switch {
+	case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
+		cls = "diff-file"
+	case strings.HasPrefix(line, "@@"):
+		cls = "diff-hunk"
+	case strings.HasPrefix(line, "+"):
+		cls = "diff-add"
+	case strings.HasPrefix(line, "-"):
+		cls = "diff-del"
+	}
+	fmt.Fprintf(b, "<span class=\"%s\">%s</span>\n", cls, html.EscapeString(line))
+}
+
+func writeHTMLFooter(b *strings.Builder, snap *Snapshot) {
+	b.WriteString("<footer class=\"page-footer\">\n")
+	b.WriteString("<a href=\"" + kandevRepoURL + "\" target=\"_blank\" rel=\"noopener\" class=\"cta\">Try kandev on GitHub →</a>\n")
+	b.WriteString("<span class=\"foot-sep\">·</span>\n")
+	b.WriteString("<a href=\"snapshot.json\" class=\"foot-link\">snapshot.json</a>\n")
+	if snap.KandevVersion != "" {
+		fmt.Fprintf(b, "<span class=\"foot-sep\">·</span>\n<span class=\"foot-version\">kandev %s</span>\n",
+			html.EscapeString(snap.KandevVersion))
+	}
+	b.WriteString("</footer>\n")
+}

--- a/apps/backend/internal/task/share/gist_html_test.go
+++ b/apps/backend/internal/task/share/gist_html_test.go
@@ -1,0 +1,220 @@
+package share
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildShareHTML_RendersChatLayout(t *testing.T) {
+	t.Parallel()
+	completed := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	snap := &Snapshot{
+		Version:    SnapshotVersion,
+		ExportedAt: completed,
+		Task:       TaskMeta{Title: "Investigate <flaky> test"},
+		Session: SessionMeta{
+			AgentType:    "claude-acp",
+			Model:        "claude-opus-4-7",
+			ExecutorType: "local_docker",
+			StartedAt:    completed.Add(-time.Minute),
+			CompletedAt:  &completed,
+		},
+		Messages: []Message{
+			{Role: roleUser, Ts: completed, Blocks: []Block{{Kind: blockKindText, Text: "why is X flaky?"}}},
+			{Role: roleAssistant, Ts: completed, Blocks: []Block{{Kind: blockKindText, Text: "Looking into it."}}},
+			{Role: roleAssistant, Ts: completed, Blocks: []Block{
+				{Kind: blockKindToolCall, ToolName: "shell", Text: "ran tests",
+					Args: json.RawMessage(`{"cmd":"go test ./..."}`)},
+			}},
+			{Role: roleAssistant, Ts: completed, Blocks: []Block{
+				{Kind: blockKindToolResult, Output: "FAIL pkg/foo TestX"},
+				{Kind: blockKindText, Text: "Found it. Use `t.Cleanup`."},
+				{Kind: blockKindDiff, Path: "src/x.go",
+					UnifiedDiff: "--- a/x.go\n+++ b/x.go\n@@ -1,1 +1,1 @@\n-old\n+new\n context\n"},
+			}},
+		},
+		Redaction: RedactionLog{AppliedRules: []string{RuleAbsPath}},
+	}
+
+	doc := BuildShareHTML(snap)
+
+	assertContains(t, doc, "<!doctype html>")
+	assertContains(t, doc, "<title>Investigate &lt;flaky&gt; test — kandev share</title>")
+	assertContains(t, doc, "<style>")
+	if strings.Contains(doc, "<flaky>") {
+		t.Fatal("unescaped angle brackets leaked into HTML")
+	}
+
+	assertContains(t, doc, ">claude-acp<")
+	assertContains(t, doc, ">4 messages<")
+	assertContains(t, doc, "abs-path")
+}
+
+func TestBuildShareHTML_GroupsConsecutiveAssistantMessages(t *testing.T) {
+	t.Parallel()
+	snap := &Snapshot{
+		Task: TaskMeta{Title: "T"},
+		Messages: []Message{
+			{Role: roleUser, Blocks: []Block{{Kind: blockKindText, Text: "hi"}}},
+			{Role: roleAssistant, Blocks: []Block{{Kind: blockKindText, Text: "a1"}}},
+			{Role: roleAssistant, Blocks: []Block{{Kind: blockKindToolCall, ToolName: "shell"}}},
+			{Role: roleAssistant, Blocks: []Block{{Kind: blockKindText, Text: "a2"}}},
+			{Role: roleUser, Blocks: []Block{{Kind: blockKindText, Text: "ok"}}},
+		},
+	}
+	doc := BuildShareHTML(snap)
+	// 3 groups expected: user, assistant (merged 3 messages), user — so 3 sections.
+	if got := strings.Count(doc, `<section class="group `); got != 3 {
+		t.Fatalf("expected 3 groups, got %d in:\n%s", got, doc)
+	}
+	// User-right + assistant-left CSS classes both present.
+	assertContains(t, doc, "group-user")
+	assertContains(t, doc, "group-assistant")
+}
+
+func TestBuildShareHTML_ToolCallIsCollapsedByDefault(t *testing.T) {
+	t.Parallel()
+	snap := &Snapshot{
+		Task: TaskMeta{Title: "T"},
+		Messages: []Message{
+			{Role: roleAssistant, Blocks: []Block{
+				{Kind: blockKindToolCall, ToolName: "shell", Text: "go test",
+					Args: json.RawMessage(`{"cmd":"go test"}`)},
+			}},
+		},
+	}
+	doc := BuildShareHTML(snap)
+	// `<details>` without `open` is closed by default.
+	if strings.Contains(doc, "<details class=\"tool tool-call\" open") {
+		t.Fatal("tool call must not be open by default")
+	}
+	assertContains(t, doc, "<details class=\"tool tool-call\">")
+	assertContains(t, doc, ">shell<")
+	assertContains(t, doc, "go test")
+}
+
+func TestBuildShareHTML_DiffLineClasses(t *testing.T) {
+	t.Parallel()
+	snap := &Snapshot{
+		Task: TaskMeta{Title: "T"},
+		Messages: []Message{
+			{Role: roleAssistant, Blocks: []Block{
+				{Kind: blockKindDiff, Path: "src/x.go",
+					UnifiedDiff: "--- a\n+++ b\n@@ -1,1 +1,1 @@\n-old\n+new\n ctx\n"},
+			}},
+		},
+	}
+	doc := BuildShareHTML(snap)
+	for _, cls := range []string{"diff-add", "diff-del", "diff-hunk", "diff-file", "diff-ctx"} {
+		if !strings.Contains(doc, `class="`+cls+`"`) {
+			t.Fatalf("missing class %q in diff: %s", cls, doc)
+		}
+	}
+}
+
+func TestBuildShareHTML_InlineBackticksAndFencedCode(t *testing.T) {
+	t.Parallel()
+	snap := &Snapshot{
+		Task: TaskMeta{Title: "T"},
+		Messages: []Message{
+			{Role: roleAssistant, Blocks: []Block{
+				{Kind: blockKindText, Text: "Use `t.Cleanup` to dispose.\n\n```go\nfunc TestX(t *testing.T) { t.Cleanup(cleanup) }\n```\n\nDone."},
+			}},
+		},
+	}
+	doc := BuildShareHTML(snap)
+	assertContains(t, doc, `<code class="inline">t.Cleanup</code>`)
+	assertContains(t, doc, `<pre class="code lang-go"><code>`)
+	assertContains(t, doc, "func TestX(t *testing.T)")
+	assertContains(t, doc, "<p>Done.</p>")
+}
+
+func TestBuildShareHTML_EmptyMessagesShowsPlaceholder(t *testing.T) {
+	t.Parallel()
+	doc := BuildShareHTML(&Snapshot{Task: TaskMeta{Title: "Empty"}})
+	assertContains(t, doc, `class="empty"`)
+	assertContains(t, doc, "No messages.")
+}
+
+func TestBuildShareHTML_NilSafe(t *testing.T) {
+	t.Parallel()
+	if got := BuildShareHTML(nil); got == "" {
+		t.Fatal("nil snapshot should produce a placeholder document")
+	}
+}
+
+func TestGroupMessages_RunsFusedAcrossEmptyMessages(t *testing.T) {
+	t.Parallel()
+	groups := groupMessages([]Message{
+		{Role: roleAssistant, Blocks: []Block{{Kind: blockKindText, Text: "a"}}},
+		{Role: roleAssistant, Blocks: []Block{}}, // dropped (empty)
+		{Role: roleAssistant, Blocks: []Block{{Kind: blockKindText, Text: "b"}}},
+	})
+	if len(groups) != 1 || len(groups[0].blocks) != 2 {
+		t.Fatalf("expected 1 group with 2 blocks, got %+v", groups)
+	}
+}
+
+func TestInlineFormat_UnmatchedBacktickIsRendered(t *testing.T) {
+	t.Parallel()
+	got := inlineFormat("an unmatched ` here")
+	if !strings.Contains(got, "`") {
+		t.Fatalf("expected unmatched backtick preserved, got %q", got)
+	}
+}
+
+func TestSanitiseLang_StripsUnsafe(t *testing.T) {
+	t.Parallel()
+	if got := sanitiseLang("GO-1.21"); got != "go-121" {
+		t.Fatalf("got %q", got)
+	}
+	if got := sanitiseLang("<script>"); got != "script" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRenderedURLForGist(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"authenticated_gist", "https://gist.github.com/jane/abc123", "https://gistpreview.github.io/?abc123/share.html"},
+		{"anonymous_gist", "https://gist.github.com/abc123", "https://gistpreview.github.io/?abc123/share.html"},
+		{"wrong_host", "https://example.com/jane/abc123", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderedURLForGist(tc.input); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGistIDFromGithackURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"valid_legacy_url", "https://gist.githack.com/jane/abc123/raw/share.html", "abc123"},
+		{"wrong_host", "https://example.com/jane/abc123/raw/share.html", ""},
+		{"too_short", "https://gist.githack.com/jane", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gistIDFromGithackURL(tc.input); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/task/share/gist_html_text.go
+++ b/apps/backend/internal/task/share/gist_html_text.go
@@ -1,0 +1,148 @@
+package share
+
+import (
+	"fmt"
+	"html"
+	"strings"
+)
+
+// writeHTMLText renders prose with minimal inline-markdown support: fenced
+// code blocks (```lang … ```) become <pre><code class="lang-X"> blocks,
+// and inline `code` spans become <code> tags. Anything else is escaped and
+// wrapped in <p>. We intentionally stop short of a full markdown parser —
+// the snapshot is plain agent output, not a publishing surface.
+func writeHTMLText(b *strings.Builder, text string) {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return
+	}
+	b.WriteString("<div class=\"text\">\n")
+	for _, segment := range splitFencedCodeBlocks(t) {
+		if segment.fenced {
+			writeFencedCode(b, segment.lang, segment.body)
+			continue
+		}
+		writeProse(b, segment.body)
+	}
+	b.WriteString("</div>\n")
+}
+
+// textSegment is either a fenced code block or a run of prose paragraphs.
+type textSegment struct {
+	fenced bool
+	lang   string
+	body   string
+}
+
+// splitFencedCodeBlocks walks `text` line by line and pulls fenced code
+// blocks out as standalone segments so the surrounding prose can render
+// as paragraphs. Recognises only the triple-backtick form; tilde fences
+// and indent-based code blocks aren't worth the complexity here.
+func splitFencedCodeBlocks(text string) []textSegment {
+	var out []textSegment
+	var prose []string
+	var code []string
+	inFence := false
+	lang := ""
+	flushProse := func() {
+		if len(prose) > 0 {
+			out = append(out, textSegment{body: strings.Join(prose, "\n")})
+			prose = nil
+		}
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "```") {
+			if inFence {
+				out = append(out, textSegment{fenced: true, lang: lang, body: strings.Join(code, "\n")})
+				code = nil
+				lang = ""
+				inFence = false
+				continue
+			}
+			flushProse()
+			lang = strings.TrimSpace(strings.TrimPrefix(line, "```"))
+			inFence = true
+			continue
+		}
+		if inFence {
+			code = append(code, line)
+		} else {
+			prose = append(prose, line)
+		}
+	}
+	if inFence { // unterminated fence — render what we got so we don't drop content
+		out = append(out, textSegment{fenced: true, lang: lang, body: strings.Join(code, "\n")})
+	}
+	flushProse()
+	return out
+}
+
+func writeFencedCode(b *strings.Builder, lang, body string) {
+	body = strings.TrimRight(body, "\n")
+	cls := "code"
+	if lang != "" {
+		cls = "code lang-" + sanitiseLang(lang)
+	}
+	fmt.Fprintf(b, "<pre class=\"%s\"><code>%s</code></pre>\n", cls, html.EscapeString(body))
+}
+
+// sanitiseLang keeps language tags to a safe character set so they can go
+// into a class attribute without escaping. Anything outside [a-z0-9-_] is
+// dropped.
+func sanitiseLang(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// writeProse renders a prose run as paragraphs split on blank lines, with
+// inline backtick spans converted to <code>. Soft newlines inside a
+// paragraph become <br>.
+func writeProse(b *strings.Builder, text string) {
+	text = strings.Trim(text, "\n")
+	if text == "" {
+		return
+	}
+	for _, para := range strings.Split(text, "\n\n") {
+		para = strings.TrimSpace(para)
+		if para == "" {
+			continue
+		}
+		fmt.Fprintf(b, "<p>%s</p>\n", inlineFormat(para))
+	}
+}
+
+// inlineFormat handles inline `code` and preserves soft line breaks as <br>.
+// Everything else is HTML-escaped.
+func inlineFormat(s string) string {
+	var b strings.Builder
+	for {
+		i := strings.Index(s, "`")
+		if i < 0 {
+			b.WriteString(htmlEscapeMultiline(s))
+			return b.String()
+		}
+		b.WriteString(htmlEscapeMultiline(s[:i]))
+		rest := s[i+1:]
+		end := strings.Index(rest, "`")
+		if end < 0 {
+			// Unmatched backtick — render the rest as-is so we don't drop chars.
+			b.WriteString(htmlEscapeMultiline(s[i:]))
+			return b.String()
+		}
+		fmt.Fprintf(&b, "<code class=\"inline\">%s</code>", html.EscapeString(rest[:end]))
+		s = rest[end+1:]
+	}
+}
+
+// htmlEscapeMultiline escapes for HTML while preserving soft line breaks as
+// <br> tags so paragraph internals keep their shape.
+func htmlEscapeMultiline(s string) string {
+	return strings.ReplaceAll(html.EscapeString(s), "\n", "<br>")
+}

--- a/apps/backend/internal/task/share/gist_markdown.go
+++ b/apps/backend/internal/task/share/gist_markdown.go
@@ -170,7 +170,7 @@ func writeText(b *strings.Builder, text, role string) bool {
 }
 
 func writeToolCall(b *strings.Builder, block Block) bool {
-	name := nonEmpty(block.ToolName, "tool")
+	name := escapeHTML(nonEmpty(block.ToolName, "tool"))
 	summary := strings.TrimSpace(block.Text)
 	if summary != "" {
 		fmt.Fprintf(b, "<details>\n<summary>🔧 <strong>%s</strong> — %s</summary>\n\n", name, escapeHTML(summary))
@@ -178,7 +178,11 @@ func writeToolCall(b *strings.Builder, block Block) bool {
 		fmt.Fprintf(b, "<details>\n<summary>🔧 <strong>%s</strong></summary>\n\n", name)
 	}
 	if len(block.Args) > 0 {
-		fmt.Fprintf(b, "```json\n%s\n```\n", prettyJSON(block.Args))
+		// Render via an HTML <pre> rather than a triple-backtick fence so a
+		// JSON arg containing literal ``` sequences (commands, code snippets)
+		// can't break out of the code block and corrupt downstream rendering.
+		fmt.Fprintf(b, "<pre><code class=\"language-json\">%s</code></pre>\n",
+			escapeHTML(prettyJSON(block.Args)))
 	}
 	b.WriteString("\n</details>\n\n")
 	return true
@@ -192,8 +196,10 @@ func writeToolResult(b *strings.Builder, block Block) bool {
 	if block.Truncated {
 		label += " <em>(truncated)</em>"
 	}
-	fmt.Fprintf(b, "<details>\n<summary>%s</summary>\n\n```\n%s\n```\n\n</details>\n\n",
-		label, strings.TrimRight(block.Output, "\n"))
+	// HTML <pre> avoids the triple-backtick collision when the tool output
+	// itself contains a code fence.
+	fmt.Fprintf(b, "<details>\n<summary>%s</summary>\n\n<pre><code>%s</code></pre>\n\n</details>\n\n",
+		label, escapeHTML(strings.TrimRight(block.Output, "\n")))
 	return true
 }
 

--- a/apps/backend/internal/task/share/gist_markdown.go
+++ b/apps/backend/internal/task/share/gist_markdown.go
@@ -1,0 +1,252 @@
+package share
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// BuildGistREADME renders the README that appears at the top of the gist
+// page on github.com. The primary user-facing rendering is share.html (served
+// via raw.githack.com); the README is mostly a "go to the pretty view"
+// pointer plus a markdown fallback for anyone who lands on the gist directly.
+// renderedURL is the raw.githack.com link to share.html; pass "" if it's not
+// known yet (the README is regenerated post-upload with the real link).
+func BuildGistREADME(snap *Snapshot, renderedURL string) string {
+	if snap == nil {
+		return "# kandev share\n"
+	}
+	var b strings.Builder
+	writeHero(&b, snap)
+	writeRenderedCTA(&b, renderedURL)
+	writeMetaDetails(&b, snap)
+	writeRedactionNote(&b, snap)
+	b.WriteString("---\n\n")
+	writeConversation(&b, snap.Messages)
+	writeFooter(&b, snap)
+	return b.String()
+}
+
+// writeRenderedCTA injects a prominent link to the styled HTML view so
+// visitors who land on the raw gist know where to go.
+func writeRenderedCTA(b *strings.Builder, renderedURL string) {
+	if renderedURL == "" {
+		b.WriteString("> 📖 **Open `share.html`** for the rendered conversation.\n\n")
+		return
+	}
+	fmt.Fprintf(b, "> ✨ **[Open the rendered view →](%s)** for a properly styled conversation.\n\n", renderedURL)
+}
+
+func writeHero(b *strings.Builder, snap *Snapshot) {
+	fmt.Fprintf(b, "# %s\n\n", nonEmpty(snap.Task.Title, "Untitled task"))
+	// Compact badge line: short, dense, scannable.
+	badges := []string{}
+	if v := snap.Session.AgentType; v != "" {
+		badges = append(badges, fmt.Sprintf("<kbd>%s</kbd>", v))
+	}
+	if v := snap.Session.Model; v != "" {
+		badges = append(badges, fmt.Sprintf("<kbd>%s</kbd>", v))
+	}
+	if v := snap.Session.ExecutorType; v != "" {
+		badges = append(badges, fmt.Sprintf("<kbd>%s</kbd>", v))
+	}
+	badges = append(badges, fmt.Sprintf("<kbd>%d messages</kbd>", len(snap.Messages)))
+	fmt.Fprintf(b, "<sub>%s</sub>\n\n", strings.Join(badges, " · "))
+	// Pitch line — also doubles as marketing.
+	b.WriteString("> 🚀 Shared from **[kandev](https://github.com/kdlbs/kandev)** — the open-source agentic dev environment.\n\n")
+}
+
+func writeMetaDetails(b *strings.Builder, snap *Snapshot) {
+	rows := []struct{ k, v string }{
+		{"Agent", snap.Session.AgentType},
+		{"Model", snap.Session.Model},
+		{"Executor", snap.Session.ExecutorType},
+		{"Started", formatTime(snap.Session.StartedAt)},
+		{"Completed", formatPtrTime(snap.Session.CompletedAt)},
+		{"Workflow step", snap.Task.WorkflowStep},
+	}
+	written := 0
+	b.WriteString("<details>\n<summary>📊 Session details</summary>\n\n")
+	b.WriteString("|   |   |\n|---|---|\n")
+	for _, r := range rows {
+		if r.v == "" {
+			continue
+		}
+		fmt.Fprintf(b, "| **%s** | %s |\n", r.k, r.v)
+		written++
+	}
+	if written == 0 {
+		b.WriteString("| _no metadata_ | |\n")
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writeRedactionNote(b *strings.Builder, snap *Snapshot) {
+	if len(snap.Redaction.AppliedRules) == 0 {
+		return
+	}
+	parts := make([]string, len(snap.Redaction.AppliedRules))
+	for i, r := range snap.Redaction.AppliedRules {
+		parts[i] = "`" + r + "`"
+	}
+	fmt.Fprintf(b, "> 🛡️ **Redacted before publish:** %s\n\n", strings.Join(parts, ", "))
+}
+
+func writeConversation(b *strings.Builder, messages []Message) {
+	if len(messages) == 0 {
+		b.WriteString("_(No messages.)_\n\n")
+		return
+	}
+	for i, msg := range messages {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		writeMessage(b, msg)
+	}
+}
+
+func writeMessage(b *strings.Builder, msg Message) {
+	fmt.Fprintf(b, "### %s\n\n", messageHeading(msg.Role))
+	wroteAny := false
+	for _, block := range msg.Blocks {
+		if writeBlock(b, block, msg.Role) {
+			wroteAny = true
+		}
+	}
+	if !wroteAny {
+		b.WriteString("_(empty)_\n\n")
+	}
+}
+
+func messageHeading(role string) string {
+	switch role {
+	case roleUser:
+		return "🧑 User"
+	case roleAssistant:
+		return "🤖 Assistant"
+	case roleSystem:
+		return "⚙️ System"
+	}
+	return role
+}
+
+// writeBlock writes a single block. Returns true if it produced any output —
+// callers use this to detect "all blocks were empty" so they can show a
+// placeholder instead of a bare heading.
+func writeBlock(b *strings.Builder, block Block, role string) bool {
+	switch block.Kind {
+	case blockKindText:
+		return writeText(b, block.Text, role)
+	case blockKindToolCall:
+		return writeToolCall(b, block)
+	case blockKindToolResult:
+		return writeToolResult(b, block)
+	case blockKindDiff:
+		return writeDiff(b, block)
+	}
+	return false
+}
+
+// writeText renders prose. User text is wrapped in a blockquote so the
+// reader gets a visual accent that distinguishes the question from the
+// agent's answer; assistant text is rendered as plain markdown so its
+// own headings/lists/code blocks survive the round trip.
+func writeText(b *strings.Builder, text, role string) bool {
+	t := strings.TrimSpace(text)
+	if t == "" {
+		return false
+	}
+	if role == roleUser {
+		for _, line := range strings.Split(t, "\n") {
+			fmt.Fprintf(b, "> %s\n", line)
+		}
+		b.WriteString("\n")
+		return true
+	}
+	b.WriteString(t)
+	b.WriteString("\n\n")
+	return true
+}
+
+func writeToolCall(b *strings.Builder, block Block) bool {
+	name := nonEmpty(block.ToolName, "tool")
+	summary := strings.TrimSpace(block.Text)
+	if summary != "" {
+		fmt.Fprintf(b, "<details>\n<summary>🔧 <strong>%s</strong> — %s</summary>\n\n", name, escapeHTML(summary))
+	} else {
+		fmt.Fprintf(b, "<details>\n<summary>🔧 <strong>%s</strong></summary>\n\n", name)
+	}
+	if len(block.Args) > 0 {
+		fmt.Fprintf(b, "```json\n%s\n```\n", prettyJSON(block.Args))
+	}
+	b.WriteString("\n</details>\n\n")
+	return true
+}
+
+func writeToolResult(b *strings.Builder, block Block) bool {
+	if strings.TrimSpace(block.Output) == "" {
+		return false
+	}
+	label := "📤 Tool output"
+	if block.Truncated {
+		label += " <em>(truncated)</em>"
+	}
+	fmt.Fprintf(b, "<details>\n<summary>%s</summary>\n\n```\n%s\n```\n\n</details>\n\n",
+		label, strings.TrimRight(block.Output, "\n"))
+	return true
+}
+
+func writeDiff(b *strings.Builder, block Block) bool {
+	if strings.TrimSpace(block.UnifiedDiff) == "" {
+		return false
+	}
+	path := nonEmpty(block.Path, "diff")
+	fmt.Fprintf(b, "**📝 `%s`**\n\n```diff\n%s\n```\n\n", path, strings.TrimRight(block.UnifiedDiff, "\n"))
+	return true
+}
+
+func writeFooter(b *strings.Builder, snap *Snapshot) {
+	b.WriteString("\n---\n\n")
+	b.WriteString("<sub>📦 Raw export: [`snapshot.json`](#file-snapshot-json) · ")
+	b.WriteString("Built with [kandev](https://github.com/kdlbs/kandev)")
+	if snap.KandevVersion != "" {
+		fmt.Fprintf(b, " %s", snap.KandevVersion)
+	}
+	b.WriteString("</sub>\n")
+}
+
+// escapeHTML escapes characters that would break out of a <summary> tag.
+// Markdown inside HTML is mostly inert, so this is enough.
+func escapeHTML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02 15:04 UTC")
+}
+
+func formatPtrTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return formatTime(*t)
+}
+
+func prettyJSON(raw json.RawMessage) string {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return string(raw)
+	}
+	return string(out)
+}

--- a/apps/backend/internal/task/share/gist_markdown_test.go
+++ b/apps/backend/internal/task/share/gist_markdown_test.go
@@ -1,0 +1,88 @@
+package share
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildGistREADME_FullConversation(t *testing.T) {
+	t.Parallel()
+	completed := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	snap := &Snapshot{
+		Version:    SnapshotVersion,
+		ExportedAt: completed,
+		Task:       TaskMeta{Title: "Investigate flaky test"},
+		Session: SessionMeta{
+			AgentType:    "claude-acp",
+			Model:        "claude-opus-4-7",
+			ExecutorType: "local_docker",
+			StartedAt:    completed.Add(-time.Minute),
+			CompletedAt:  &completed,
+		},
+		Messages: []Message{
+			{Role: roleUser, Ts: completed, Blocks: []Block{{Kind: blockKindText, Text: "why is X flaky?"}}},
+			{
+				Role: roleAssistant, Ts: completed,
+				Blocks: []Block{
+					{Kind: blockKindText, Text: "Looking into it."},
+					{
+						Kind:     blockKindToolCall,
+						ToolName: "shell",
+						Text:     "ran tests",
+						Args:     json.RawMessage(`{"cmd":"go test ./..."}`),
+					},
+					{Kind: blockKindToolResult, Output: "FAIL pkg/foo TestX"},
+					{
+						Kind:        blockKindDiff,
+						Path:        "src/x.go",
+						UnifiedDiff: "--- a\n+++ b\n@@\n-old\n+new\n",
+					},
+				},
+			},
+		},
+		Redaction: RedactionLog{AppliedRules: []string{RuleAbsPath}},
+	}
+
+	md := BuildGistREADME(snap, "https://gistpreview.github.io/?mock-gist-1/share.html")
+	assertContains(t, md, "# Investigate flaky test")
+	assertContains(t, md, "<kbd>claude-acp</kbd>")
+	assertContains(t, md, "<kbd>claude-opus-4-7</kbd>")
+	assertContains(t, md, "<kbd>local_docker</kbd>")
+	assertContains(t, md, "📊 Session details")
+	assertContains(t, md, "| **Agent** | claude-acp |")
+	assertContains(t, md, "Redacted before publish:")
+	assertContains(t, md, "🧑 User")
+	// User text is wrapped in a blockquote for visual accent.
+	assertContains(t, md, "> why is X flaky?")
+	assertContains(t, md, "🤖 Assistant")
+	assertContains(t, md, "🔧 <strong>shell</strong>")
+	assertContains(t, md, "```json")
+	assertContains(t, md, `"cmd": "go test ./..."`)
+	assertContains(t, md, "📤 Tool output")
+	assertContains(t, md, "FAIL pkg/foo TestX")
+	assertContains(t, md, "**📝 `src/x.go`**")
+	assertContains(t, md, "```diff")
+	assertContains(t, md, "snapshot.json")
+	assertContains(t, md, "github.com/kdlbs/kandev")
+}
+
+func TestBuildGistREADME_NilAndEmpty(t *testing.T) {
+	t.Parallel()
+	if got := BuildGistREADME(nil, ""); got == "" {
+		t.Fatal("nil snapshot should still produce a non-empty README")
+	}
+	empty := &Snapshot{Task: TaskMeta{Title: "Untitled"}}
+	got := BuildGistREADME(empty, "https://gistpreview.github.io/?g1/share.html")
+	if !strings.Contains(got, "_(No messages.)_") {
+		t.Fatalf("expected empty-messages placeholder, got: %s", got)
+	}
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("expected output to contain %q\n--- output ---\n%s", needle, haystack)
+	}
+}

--- a/apps/backend/internal/task/share/gist_markdown_test.go
+++ b/apps/backend/internal/task/share/gist_markdown_test.go
@@ -58,7 +58,9 @@ func TestBuildGistREADME_FullConversation(t *testing.T) {
 	assertContains(t, md, "> why is X flaky?")
 	assertContains(t, md, "🤖 Assistant")
 	assertContains(t, md, "🔧 <strong>shell</strong>")
-	assertContains(t, md, "```json")
+	// Tool args and output render via HTML <pre><code> rather than a
+	// triple-backtick fence so payloads containing ``` can't break out.
+	assertContains(t, md, `<pre><code class="language-json">`)
 	assertContains(t, md, `"cmd": "go test ./..."`)
 	assertContains(t, md, "📤 Tool output")
 	assertContains(t, md, "FAIL pkg/foo TestX")

--- a/apps/backend/internal/task/share/http.go
+++ b/apps/backend/internal/task/share/http.go
@@ -1,0 +1,227 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/github"
+)
+
+// HTTPHandlers wires the share endpoints. RegisterRoutes is the public entry
+// point used by cmd/kandev.
+type HTTPHandlers struct {
+	svc      *Service
+	ghClient github.Client
+	log      *logger.Logger
+}
+
+// NewHTTPHandlers returns handlers that delegate to the share Service. The
+// github.Client is used only for the upfront IsAuthenticated probe so we
+// can return a precondition-failed error instead of letting Upload fail.
+func NewHTTPHandlers(svc *Service, ghClient github.Client, log *logger.Logger) *HTTPHandlers {
+	return &HTTPHandlers{svc: svc, ghClient: ghClient, log: log}
+}
+
+// RegisterRoutes wires the share endpoints onto the given gin engine under
+// the /api/v1 prefix.
+func (h *HTTPHandlers) RegisterRoutes(router *gin.Engine) {
+	api := router.Group("/api/v1")
+	api.POST("/tasks/:id/sessions/:sessionId/shares", h.httpCreate)
+	api.GET("/tasks/:id/sessions/:sessionId/shares", h.httpList)
+	api.DELETE("/shares/:shareId", h.httpRevoke)
+}
+
+// Response payloads. Kept on this file so the contract lives next to the
+// handlers; the frontend share-api.ts must match these shapes.
+type shareResponse struct {
+	ID                string `json:"id"`
+	URL               string `json:"url"`
+	CreatedAt         string `json:"created_at"`
+	RevokedAt         string `json:"revoked_at,omitempty"`
+	SnapshotSizeBytes int64  `json:"snapshot_size_bytes"`
+}
+
+type listSharesResponse struct {
+	Shares []shareResponse `json:"shares"`
+}
+
+type errorBody struct {
+	Error string `json:"error"`
+	Code  string `json:"code,omitempty"`
+}
+
+func toShareResponse(s *Share) shareResponse {
+	out := shareResponse{
+		ID:                s.ID,
+		URL:               displayURL(s.ExternalURL),
+		CreatedAt:         s.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
+		SnapshotSizeBytes: s.SnapshotSizeBytes,
+	}
+	if s.RevokedAt != nil {
+		out.RevokedAt = s.RevokedAt.UTC().Format("2006-01-02T15:04:05.000Z")
+	}
+	return out
+}
+
+// displayURL returns the URL we want clients to use when opening a share.
+// We always prefer the gistpreview.github.io rendered view (the static
+// renderer pulls the gist's first HTML file via the GitHub API). Three
+// stored formats are normalised on the way out:
+//
+//   - bare gist URL (https://gist.github.com/<owner>/<id>) — old rows
+//     written before share.html landed in the gist
+//   - raw.githack URL (https://gist.githack.com/<owner>/<id>/raw/share.html)
+//     — rows written during the brief raw.githack window
+//   - already a gistpreview URL — passthrough
+//
+// Anything we don't recognise is returned unchanged.
+func displayURL(stored string) string {
+	if stored == "" {
+		return ""
+	}
+	// Already a gistpreview URL — if the caller pinned share.html, keep it;
+	// otherwise re-pin it so gistpreview doesn't fall back to README.md.
+	const previewPrefix = "https://gistpreview.github.io/?"
+	if strings.HasPrefix(stored, previewPrefix) {
+		id := strings.TrimPrefix(stored, previewPrefix)
+		if i := strings.Index(id, "/"); i >= 0 {
+			id = id[:i]
+		}
+		return gistpreviewURL(id)
+	}
+	if rendered := renderedURLForGist(stored); rendered != "" {
+		return rendered
+	}
+	if id := gistIDFromGithackURL(stored); id != "" {
+		return gistpreviewURL(id)
+	}
+	return stored
+}
+
+// httpCreate handles POST /api/v1/tasks/:id/sessions/:sessionId/shares.
+// Query string dry_run=true returns the snapshot inline without uploading.
+func (h *HTTPHandlers) httpCreate(c *gin.Context) {
+	sessionID := c.Param("sessionId")
+	if sessionID == "" {
+		c.JSON(http.StatusBadRequest, errorBody{Error: "session id is required"})
+		return
+	}
+	ctx := c.Request.Context()
+
+	if strings.EqualFold(c.Query("dry_run"), "true") {
+		snap, err := h.svc.PreviewSnapshot(ctx, sessionID)
+		if mapped, status := mapShareError(err); mapped != nil {
+			c.JSON(status, mapped)
+			return
+		}
+		c.JSON(http.StatusOK, snap)
+		return
+	}
+
+	if err := h.requireGitHubAuth(ctx); err != nil {
+		c.JSON(http.StatusPreconditionFailed, errorBody{
+			Error: err.Error(),
+			Code:  "github_credential_missing",
+		})
+		return
+	}
+
+	share, err := h.svc.CreateShare(ctx, sessionID)
+	if mapped, status := mapShareError(err); mapped != nil {
+		h.logServerError(err, "create share failed", sessionID)
+		c.JSON(status, mapped)
+		return
+	}
+	c.JSON(http.StatusCreated, toShareResponse(share))
+}
+
+// httpList returns every share row for the session, including revoked.
+func (h *HTTPHandlers) httpList(c *gin.Context) {
+	sessionID := c.Param("sessionId")
+	if sessionID == "" {
+		c.JSON(http.StatusBadRequest, errorBody{Error: "session id is required"})
+		return
+	}
+	rows, err := h.svc.ListBySession(c.Request.Context(), sessionID)
+	if err != nil {
+		h.logServerError(err, "list shares failed", sessionID)
+		c.JSON(http.StatusInternalServerError, errorBody{Error: "failed to list shares"})
+		return
+	}
+	out := listSharesResponse{Shares: make([]shareResponse, 0, len(rows))}
+	for _, r := range rows {
+		out.Shares = append(out.Shares, toShareResponse(r))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// httpRevoke handles DELETE /api/v1/shares/:shareId.
+func (h *HTTPHandlers) httpRevoke(c *gin.Context) {
+	shareID := c.Param("shareId")
+	if shareID == "" {
+		c.JSON(http.StatusBadRequest, errorBody{Error: "share id is required"})
+		return
+	}
+	if err := h.svc.RevokeShare(c.Request.Context(), shareID); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.JSON(http.StatusNotFound, errorBody{Error: "share not found"})
+			return
+		}
+		h.logServerError(err, "revoke share failed", shareID)
+		c.JSON(http.StatusBadGateway, errorBody{
+			Error: err.Error(),
+			Code:  "gist_revoke_failed",
+		})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// requireGitHubAuth returns nil when the client reports an authenticated
+// session, or an explanatory error otherwise. A transport-layer failure is
+// logged and treated as "not authenticated" so the user still sees a clean
+// 412 with a CTA, not a 5xx.
+func (h *HTTPHandlers) requireGitHubAuth(ctx context.Context) error {
+	if h.ghClient == nil {
+		return errors.New("github client is not configured")
+	}
+	ok, err := h.ghClient.IsAuthenticated(ctx)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("connect a GitHub account to share tasks publicly")
+	}
+	return nil
+}
+
+// mapShareError translates a service error into the response body + status
+// code. Returns (nil, 0) when err is nil. The status table is part of the
+// public contract; keep it in sync with docs/specs/public-share-links/spec.md.
+func mapShareError(err error) (*errorBody, int) {
+	if err == nil {
+		return nil, 0
+	}
+	switch {
+	case errors.Is(err, ErrSessionNotShareable):
+		return &errorBody{Error: "session has no shareable content yet", Code: "session_not_shareable"}, http.StatusConflict
+	case errors.Is(err, ErrNotFound):
+		return &errorBody{Error: "session or task not found"}, http.StatusNotFound
+	case errors.Is(err, ErrSnapshotTooLarge):
+		return &errorBody{Error: err.Error(), Code: "snapshot_too_large"}, http.StatusRequestEntityTooLarge
+	}
+	return &errorBody{Error: err.Error(), Code: "gist_upload_failed"}, http.StatusBadGateway
+}
+
+func (h *HTTPHandlers) logServerError(err error, msg, ref string) {
+	if h.log == nil {
+		return
+	}
+	h.log.Warn(msg, zap.String("ref", ref), zap.Error(err))
+}

--- a/apps/backend/internal/task/share/http_test.go
+++ b/apps/backend/internal/task/share/http_test.go
@@ -1,0 +1,298 @@
+package share
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/kandev/kandev/internal/github"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+// stubGHAuth lets tests toggle the IsAuthenticated response without owning
+// the full Client interface.
+type stubGHAuth struct {
+	authed bool
+}
+
+func (s *stubGHAuth) IsAuthenticated(context.Context) (bool, error) { return s.authed, nil }
+
+// embedNoop fills the rest of the Client surface with the noop implementation
+// so we don't have to re-implement 30 methods just for a handler test.
+type embedNoop struct {
+	*stubGHAuth
+	*github.NoopClient
+}
+
+func (e *embedNoop) IsAuthenticated(ctx context.Context) (bool, error) {
+	return e.stubGHAuth.IsAuthenticated(ctx)
+}
+
+func newHandlersForTest(t *testing.T, reader TaskReader, backend Backend, authed bool) (*HTTPHandlers, *Service) {
+	t.Helper()
+	repo := newTestRepo(t)
+	svc := New(repo, reader, backend, nil, "v-test")
+	gh := &embedNoop{stubGHAuth: &stubGHAuth{authed: authed}, NoopClient: &github.NoopClient{}}
+	return NewHTTPHandlers(svc, gh, nil), svc
+}
+
+func newGinRouter(h *HTTPHandlers) *gin.Engine {
+	r := gin.New()
+	h.RegisterRoutes(r)
+	return r
+}
+
+func TestHTTP_Create_HappyPath(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	// Real GistBackend returns the gistpreview.github.io rendered URL —
+	// match that shape so the test mirrors production.
+	backend := &mockBackend{nextID: "gist-x", nextURL: "https://gistpreview.github.io/?gist-x/share.html"}
+	handlers, _ := newHandlersForTest(t, reader, backend, true)
+	router := newGinRouter(handlers)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/t-1/sessions/s-1/shares", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body shareResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.URL != "https://gistpreview.github.io/?gist-x/share.html" {
+		t.Fatalf("unexpected url: %s", body.URL)
+	}
+}
+
+func TestHTTP_Create_RejectsCreatedSessionWith409(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	reader.session.State = models.TaskSessionStateCreated
+	backend := &mockBackend{}
+	handlers, _ := newHandlersForTest(t, reader, backend, true)
+	router := newGinRouter(handlers)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/t-1/sessions/s-1/shares", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body errorBody
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body.Code != "session_not_shareable" {
+		t.Fatalf("expected code session_not_shareable, got %q", body.Code)
+	}
+}
+
+func TestHTTP_Create_BlocksWhenGitHubUnauthenticated(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	backend := &mockBackend{}
+	handlers, _ := newHandlersForTest(t, reader, backend, false)
+	router := newGinRouter(handlers)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/t-1/sessions/s-1/shares", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("want 412, got %d", rec.Code)
+	}
+	var body errorBody
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body.Code != "github_credential_missing" {
+		t.Fatalf("expected code github_credential_missing, got %q", body.Code)
+	}
+}
+
+func TestHTTP_Create_DryRunReturnsSnapshotWithoutUpload(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	backend := &mockBackend{}
+	// Auth check is skipped for dry-run; flip authed to false to prove that.
+	handlers, _ := newHandlersForTest(t, reader, backend, false)
+	router := newGinRouter(handlers)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks/t-1/sessions/s-1/shares?dry_run=true", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var snap Snapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snap.Task.Title == "" {
+		t.Fatalf("expected non-empty snapshot, got %+v", snap)
+	}
+	if backend.uploads != 0 {
+		t.Fatalf("dry-run must not call backend Upload, got %d uploads", backend.uploads)
+	}
+}
+
+func TestHTTP_List_ReturnsSharesNewestFirst(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	backend := &mockBackend{nextID: "gist-a"}
+	handlers, svc := newHandlersForTest(t, reader, backend, true)
+	router := newGinRouter(handlers)
+
+	if _, err := svc.CreateShare(context.Background(), "s-1"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/t-1/sessions/s-1/shares", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var body listSharesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Shares) != 1 {
+		t.Fatalf("expected 1 share, got %d", len(body.Shares))
+	}
+}
+
+func TestHTTP_Revoke_Success(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	backend := &mockBackend{nextID: "gist-z"}
+	handlers, svc := newHandlersForTest(t, reader, backend, true)
+	router := newGinRouter(handlers)
+
+	share, err := svc.CreateShare(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/shares/"+share.ID, nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(backend.deletes) != 1 {
+		t.Fatalf("expected 1 backend delete, got %d", len(backend.deletes))
+	}
+}
+
+func TestDisplayURL_NormalizesAllFormats(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			"bare_gist_url_old_share",
+			"https://gist.github.com/jane/abc123",
+			"https://gistpreview.github.io/?abc123/share.html",
+		},
+		{
+			"legacy_githack_url_gets_rewritten",
+			"https://gist.githack.com/jane/abc123/raw/share.html",
+			"https://gistpreview.github.io/?abc123/share.html",
+		},
+		{
+			"already_gistpreview_with_share_html_passthrough",
+			"https://gistpreview.github.io/?abc123/share.html",
+			"https://gistpreview.github.io/?abc123/share.html",
+		},
+		{
+			"older_gistpreview_without_filename_repinned",
+			"https://gistpreview.github.io/?abc123",
+			"https://gistpreview.github.io/?abc123/share.html",
+		},
+		{
+			"empty_string",
+			"",
+			"",
+		},
+		{
+			"unknown_url_passthrough",
+			"https://example.com/foo",
+			"https://example.com/foo",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := displayURL(tc.input); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHTTP_List_NormalizesLegacyURLsOnDisplay(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	backend := &mockBackend{}
+	handlers, svc := newHandlersForTest(t, reader, backend, true)
+	router := newGinRouter(handlers)
+
+	// Seed two legacy rows from earlier URL formats — the API should
+	// surface both as gistpreview URLs.
+	for _, row := range []*Share{
+		{ID: "old-1", TaskSessionID: "s-1", Backend: BackendGitHubGist, ExternalID: "abc123",
+			ExternalURL: "https://gist.github.com/jane/abc123"},
+		{ID: "old-2", TaskSessionID: "s-1", Backend: BackendGitHubGist, ExternalID: "def456",
+			ExternalURL: "https://gist.githack.com/jane/def456/raw/share.html"},
+	} {
+		if err := svc.repo.Create(context.Background(), row); err != nil {
+			t.Fatalf("seed %s: %v", row.ID, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tasks/t-1/sessions/s-1/shares", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	var body listSharesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Shares) != 2 {
+		t.Fatalf("expected 2 shares, got %d", len(body.Shares))
+	}
+	for _, s := range body.Shares {
+		if !strings.HasPrefix(s.URL, "https://gistpreview.github.io/?") {
+			t.Fatalf("expected gistpreview URL, got %q", s.URL)
+		}
+	}
+}
+
+func TestHTTP_Revoke_NotFound(t *testing.T) {
+	t.Parallel()
+	reader := completedSession()
+	backend := &mockBackend{}
+	handlers, _ := newHandlersForTest(t, reader, backend, true)
+	router := newGinRouter(handlers)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/shares/does-not-exist", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rec.Code)
+	}
+}

--- a/apps/backend/internal/task/share/provider.go
+++ b/apps/backend/internal/task/share/provider.go
@@ -1,0 +1,39 @@
+package share
+
+import (
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/github"
+)
+
+// Config is the boot-time configuration for the share package. KandevVersion
+// is the version string recorded in every snapshot so downstream tools can
+// detect schema drift.
+type Config struct {
+	KandevVersion string
+}
+
+// Provide wires the share package's repository, service, and HTTP handlers.
+// The taskReader is typically *sqliterepo.Repository from the task package;
+// only the three methods on TaskReader are used. The github.Client may be
+// nil, in which case CreateShare will fail at the IsAuthenticated probe.
+// Cleanup is a no-op; the repository does not own its database connection.
+func Provide(
+	writer, reader *sqlx.DB,
+	taskReader TaskReader,
+	ghClient github.Client,
+	log *logger.Logger,
+	cfg Config,
+) (*HTTPHandlers, func() error, error) {
+	repo, err := NewRepository(writer, reader, log)
+	if err != nil {
+		return nil, nil, fmt.Errorf("share: provide repository: %w", err)
+	}
+	backend := NewGistBackend(ghClient)
+	svc := New(repo, taskReader, backend, log, cfg.KandevVersion)
+	h := NewHTTPHandlers(svc, ghClient, log)
+	return h, func() error { return repo.Close() }, nil
+}

--- a/apps/backend/internal/task/share/provider.go
+++ b/apps/backend/internal/task/share/provider.go
@@ -35,5 +35,9 @@ func Provide(
 	backend := NewGistBackend(ghClient)
 	svc := New(repo, taskReader, backend, log, cfg.KandevVersion)
 	h := NewHTTPHandlers(svc, ghClient, log)
-	return h, func() error { return repo.Close() }, nil
+	// Cleanup is a true no-op — the repository doesn't own its database
+	// connection (the pool is owned by cmd/kandev), and Repository.Close()
+	// reflects that by returning nil. Returning an inline noop here keeps
+	// the contract obvious to readers without needing to chase Close.
+	return h, func() error { return nil }, nil
 }

--- a/apps/backend/internal/task/share/redaction.go
+++ b/apps/backend/internal/task/share/redaction.go
@@ -49,17 +49,31 @@ var envFileRe = regexp.MustCompile(`(^|/)\.env(\..+)?$`)
 // Construct with NewRedactor; reuse across one snapshot build (it accumulates
 // the applied-rule set).
 type Redactor struct {
-	workspaceRoot string
-	applied       map[string]struct{}
+	// workspaceRoots are sorted longest-first so a root that is a prefix of
+	// another (e.g. "/workspace" vs "/workspace/repo1") gets matched after the
+	// more specific one.
+	workspaceRoots []string
+	applied        map[string]struct{}
 }
 
-// NewRedactor returns a Redactor that rewrites absolute paths under
-// workspaceRoot to repo-relative paths. workspaceRoot may be empty, in
-// which case the abs-path rule is skipped.
-func NewRedactor(workspaceRoot string) *Redactor {
+// NewRedactor returns a Redactor that rewrites absolute paths under any of
+// workspaceRoots to repo-relative paths. Passing no roots (or only empty
+// strings) skips the abs-path rule. Multiple roots are supported so multi-repo
+// sessions don't leak paths from secondary worktrees.
+func NewRedactor(workspaceRoots ...string) *Redactor {
+	roots := make([]string, 0, len(workspaceRoots))
+	for _, root := range workspaceRoots {
+		trimmed := strings.TrimRight(root, "/")
+		if trimmed != "" {
+			roots = append(roots, trimmed)
+		}
+	}
+	sort.Slice(roots, func(i, j int) bool {
+		return len(roots[i]) > len(roots[j])
+	})
 	return &Redactor{
-		workspaceRoot: strings.TrimRight(workspaceRoot, "/"),
-		applied:       make(map[string]struct{}),
+		workspaceRoots: roots,
+		applied:        make(map[string]struct{}),
 	}
 }
 
@@ -76,26 +90,23 @@ func (r *Redactor) String(s string) string {
 			r.record(rule.name)
 		}
 	}
-	if r.workspaceRoot != "" {
+	for _, root := range r.workspaceRoots {
 		// Split on the workspace root WITH a trailing slash so a sibling
 		// directory sharing the root as a bare prefix doesn't match. e.g.
 		// workspaceRoot="/home/user/proj" must not match "/home/user/proj2/x.ts".
 		// The separator already carries the slash, so rejoining is a plain concat.
-		root := r.workspaceRoot + "/"
-		if strings.Contains(out, root) {
-			parts := strings.Split(out, root)
-			var b strings.Builder
-			b.WriteString(parts[0])
-			changed := false
-			for _, part := range parts[1:] {
-				changed = true
-				b.WriteString(part)
-			}
-			if changed {
-				out = b.String()
-				r.record(RuleAbsPath)
-			}
+		sep := root + "/"
+		if !strings.Contains(out, sep) {
+			continue
 		}
+		parts := strings.Split(out, sep)
+		var b strings.Builder
+		b.WriteString(parts[0])
+		for _, part := range parts[1:] {
+			b.WriteString(part)
+		}
+		out = b.String()
+		r.record(RuleAbsPath)
 	}
 	return out
 }

--- a/apps/backend/internal/task/share/redaction.go
+++ b/apps/backend/internal/task/share/redaction.go
@@ -49,11 +49,14 @@ var envFileRe = regexp.MustCompile(`(^|/)\.env(\..+)?$`)
 // Construct with NewRedactor; reuse across one snapshot build (it accumulates
 // the applied-rule set).
 type Redactor struct {
-	// workspaceRoots are sorted longest-first so a root that is a prefix of
-	// another (e.g. "/workspace" vs "/workspace/repo1") gets matched after the
-	// more specific one.
-	workspaceRoots []string
-	applied        map[string]struct{}
+	// rootPatterns matches each workspace root followed by either a path
+	// separator (so "/workspace/src/x.ts" → "src/x.ts") or a word boundary
+	// (so a standalone "/workspace" from `pwd` output is also stripped). The
+	// word-boundary alternative prevents sibling dirs like "/workspace2"
+	// from matching. Patterns are sorted longest-root-first so a nested root
+	// (e.g. "/workspace/repo1") gets matched before its parent.
+	rootPatterns []*regexp.Regexp
+	applied      map[string]struct{}
 }
 
 // NewRedactor returns a Redactor that rewrites absolute paths under any of
@@ -71,9 +74,13 @@ func NewRedactor(workspaceRoots ...string) *Redactor {
 	sort.Slice(roots, func(i, j int) bool {
 		return len(roots[i]) > len(roots[j])
 	})
+	patterns := make([]*regexp.Regexp, 0, len(roots))
+	for _, root := range roots {
+		patterns = append(patterns, regexp.MustCompile(regexp.QuoteMeta(root)+`(?:/|\b)`))
+	}
 	return &Redactor{
-		workspaceRoots: roots,
-		applied:        make(map[string]struct{}),
+		rootPatterns: patterns,
+		applied:      make(map[string]struct{}),
 	}
 }
 
@@ -90,22 +97,11 @@ func (r *Redactor) String(s string) string {
 			r.record(rule.name)
 		}
 	}
-	for _, root := range r.workspaceRoots {
-		// Split on the workspace root WITH a trailing slash so a sibling
-		// directory sharing the root as a bare prefix doesn't match. e.g.
-		// workspaceRoot="/home/user/proj" must not match "/home/user/proj2/x.ts".
-		// The separator already carries the slash, so rejoining is a plain concat.
-		sep := root + "/"
-		if !strings.Contains(out, sep) {
+	for _, re := range r.rootPatterns {
+		if !re.MatchString(out) {
 			continue
 		}
-		parts := strings.Split(out, sep)
-		var b strings.Builder
-		b.WriteString(parts[0])
-		for _, part := range parts[1:] {
-			b.WriteString(part)
-		}
-		out = b.String()
+		out = re.ReplaceAllString(out, "")
 		r.record(RuleAbsPath)
 	}
 	return out

--- a/apps/backend/internal/task/share/redaction.go
+++ b/apps/backend/internal/task/share/redaction.go
@@ -49,15 +49,25 @@ var envFileRe = regexp.MustCompile(`(^|/)\.env(\..+)?$`)
 // Construct with NewRedactor; reuse across one snapshot build (it accumulates
 // the applied-rule set).
 type Redactor struct {
-	// rootPatterns matches each workspace root followed by either a path
-	// separator (so "/workspace/src/x.ts" → "src/x.ts") or a word boundary
-	// (so a standalone "/workspace" from `pwd` output is also stripped). The
-	// word-boundary alternative prevents sibling dirs like "/workspace2"
-	// from matching. Patterns are sorted longest-root-first so a nested root
-	// (e.g. "/workspace/repo1") gets matched before its parent.
+	// roots are the workspace prefixes to rewrite, sorted longest-first so a
+	// nested root (e.g. "/workspace/repo1") gets matched before its parent.
+	// rootPatterns is the parallel slice of compiled matchers.
+	roots        []string
 	rootPatterns []*regexp.Regexp
 	applied      map[string]struct{}
 }
+
+// rootBoundary matches the characters that may follow a workspace root WITHOUT
+// extending it into a sibling path. We accept:
+//   - "/" — path separator (the common "rewrite to repo-relative" case)
+//   - end-of-string anchor `$` — bare root at the tail of a string
+//   - whitespace — bare root in the middle of prose, `pwd` output, …
+//
+// We explicitly do NOT use `\b` here: `\b` fires on any word↔non-word transition
+// so "/workspace.bak" or "/workspace-old" would falsely match. Restricting to
+// `/`, EOS, or whitespace keeps every realistic case while never corrupting
+// sibling paths that differ only in punctuation.
+const rootBoundary = `(/|\s|$)`
 
 // NewRedactor returns a Redactor that rewrites absolute paths under any of
 // workspaceRoots to repo-relative paths. Passing no roots (or only empty
@@ -76,9 +86,10 @@ func NewRedactor(workspaceRoots ...string) *Redactor {
 	})
 	patterns := make([]*regexp.Regexp, 0, len(roots))
 	for _, root := range roots {
-		patterns = append(patterns, regexp.MustCompile(regexp.QuoteMeta(root)+`(?:/|\b)`))
+		patterns = append(patterns, regexp.MustCompile(regexp.QuoteMeta(root)+rootBoundary))
 	}
 	return &Redactor{
+		roots:        roots,
 		rootPatterns: patterns,
 		applied:      make(map[string]struct{}),
 	}
@@ -97,11 +108,22 @@ func (r *Redactor) String(s string) string {
 			r.record(rule.name)
 		}
 	}
-	for _, re := range r.rootPatterns {
+	for i, re := range r.rootPatterns {
 		if !re.MatchString(out) {
 			continue
 		}
-		out = re.ReplaceAllString(out, "")
+		// Strip root + path separator entirely so paths become repo-relative;
+		// for whitespace/EOS boundaries, preserve the boundary char so prose
+		// like "cd /workspace && ls" loses only the root, not the surrounding
+		// space.
+		rootLen := len(r.roots[i])
+		out = re.ReplaceAllStringFunc(out, func(match string) string {
+			boundary := match[rootLen:]
+			if boundary == "/" {
+				return ""
+			}
+			return boundary
+		})
 		r.record(RuleAbsPath)
 	}
 	return out

--- a/apps/backend/internal/task/share/redaction.go
+++ b/apps/backend/internal/task/share/redaction.go
@@ -76,21 +76,25 @@ func (r *Redactor) String(s string) string {
 			r.record(rule.name)
 		}
 	}
-	if r.workspaceRoot != "" && strings.Contains(out, r.workspaceRoot) {
-		// Replace every occurrence of the workspace root with a relative form.
-		// We split on the root and rejoin so each suffix has its leading slash
-		// trimmed independently.
-		parts := strings.Split(out, r.workspaceRoot)
-		var b strings.Builder
-		b.WriteString(parts[0])
-		changed := false
-		for _, part := range parts[1:] {
-			changed = true
-			b.WriteString(strings.TrimPrefix(part, "/"))
-		}
-		if changed {
-			out = b.String()
-			r.record(RuleAbsPath)
+	if r.workspaceRoot != "" {
+		// Split on the workspace root WITH a trailing slash so a sibling
+		// directory sharing the root as a bare prefix doesn't match. e.g.
+		// workspaceRoot="/home/user/proj" must not match "/home/user/proj2/x.ts".
+		// The separator already carries the slash, so rejoining is a plain concat.
+		root := r.workspaceRoot + "/"
+		if strings.Contains(out, root) {
+			parts := strings.Split(out, root)
+			var b strings.Builder
+			b.WriteString(parts[0])
+			changed := false
+			for _, part := range parts[1:] {
+				changed = true
+				b.WriteString(part)
+			}
+			if changed {
+				out = b.String()
+				r.record(RuleAbsPath)
+			}
 		}
 	}
 	return out

--- a/apps/backend/internal/task/share/redaction.go
+++ b/apps/backend/internal/task/share/redaction.go
@@ -1,0 +1,179 @@
+package share
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Rule names recorded in Snapshot.Redaction.AppliedRules.
+const (
+	RuleAbsPath         = "abs-path"
+	RuleSecretSK        = "secret-sk"
+	RuleSecretGHP       = "secret-ghp"
+	RuleSecretGHO       = "secret-gho"
+	RuleSecretGitHubPAT = "secret-github-pat"
+	RuleSecretAWS       = "secret-aws"
+	RuleEnvFile         = "env-file"
+	RuleEnvVars         = "env-vars"
+
+	redactedPlaceholder = "[redacted]"
+	envFilePlaceholder  = "[redacted: .env contents]"
+)
+
+// secretRule pairs a regex with the rule name recorded when it fires.
+type secretRule struct {
+	name string
+	re   *regexp.Regexp
+}
+
+// secretRules covers the obvious "looks like a credential" shapes we strip
+// from any user-visible string in the snapshot. These are intentionally
+// narrow — they catch unambiguous formats without trying to find every
+// possible secret. Adding new rules: keep them anchored and high-precision.
+var secretRules = []secretRule{
+	{RuleSecretSK, regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`)},
+	{RuleSecretGHP, regexp.MustCompile(`ghp_[A-Za-z0-9]{36,}`)},
+	{RuleSecretGHO, regexp.MustCompile(`gho_[A-Za-z0-9]{36,}`)},
+	{RuleSecretGitHubPAT, regexp.MustCompile(`github_pat_[A-Za-z0-9_]{36,}`)},
+	{RuleSecretAWS, regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+}
+
+// envFileRe matches paths that look like a dotenv file: ".env", ".env.local",
+// ".env.production", etc. Used by RedactToolResult to scrub file contents.
+var envFileRe = regexp.MustCompile(`(^|/)\.env(\..+)?$`)
+
+// Redactor applies the snapshot redaction rules and records which ones fired.
+// Construct with NewRedactor; reuse across one snapshot build (it accumulates
+// the applied-rule set).
+type Redactor struct {
+	workspaceRoot string
+	applied       map[string]struct{}
+}
+
+// NewRedactor returns a Redactor that rewrites absolute paths under
+// workspaceRoot to repo-relative paths. workspaceRoot may be empty, in
+// which case the abs-path rule is skipped.
+func NewRedactor(workspaceRoot string) *Redactor {
+	return &Redactor{
+		workspaceRoot: strings.TrimRight(workspaceRoot, "/"),
+		applied:       make(map[string]struct{}),
+	}
+}
+
+// String applies the secret and absolute-path rules to s and returns the
+// redacted result. Safe for nil receivers (returns s unchanged).
+func (r *Redactor) String(s string) string {
+	if r == nil || s == "" {
+		return s
+	}
+	out := s
+	for _, rule := range secretRules {
+		if rule.re.MatchString(out) {
+			out = rule.re.ReplaceAllString(out, redactedPlaceholder)
+			r.record(rule.name)
+		}
+	}
+	if r.workspaceRoot != "" && strings.Contains(out, r.workspaceRoot) {
+		// Replace every occurrence of the workspace root with a relative form.
+		// We split on the root and rejoin so each suffix has its leading slash
+		// trimmed independently.
+		parts := strings.Split(out, r.workspaceRoot)
+		var b strings.Builder
+		b.WriteString(parts[0])
+		changed := false
+		for _, part := range parts[1:] {
+			changed = true
+			b.WriteString(strings.TrimPrefix(part, "/"))
+		}
+		if changed {
+			out = b.String()
+			r.record(RuleAbsPath)
+		}
+	}
+	return out
+}
+
+// JSON walks raw, applies String() to every string leaf, and drops any
+// top-level "env" field (RuleEnvVars). Returns the re-marshaled bytes.
+// If raw is not valid JSON, it is passed through String() as a fallback.
+func (r *Redactor) JSON(raw json.RawMessage) json.RawMessage {
+	if r == nil || len(raw) == 0 {
+		return raw
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return json.RawMessage(r.String(string(raw)))
+	}
+	v = r.walk(v, true)
+	out, err := json.Marshal(v)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// walk recursively redacts every string leaf in v. isRoot controls whether
+// the "env" key is dropped — we only drop env at the top level of a tool-call
+// args object so we don't accidentally erase legitimate nested fields named
+// "env" deep in a payload.
+func (r *Redactor) walk(v any, isRoot bool) any {
+	switch t := v.(type) {
+	case string:
+		return r.String(t)
+	case []any:
+		for i, item := range t {
+			t[i] = r.walk(item, false)
+		}
+		return t
+	case map[string]any:
+		if isRoot {
+			if _, ok := t["env"]; ok {
+				delete(t, "env")
+				r.record(RuleEnvVars)
+			}
+		}
+		for k, item := range t {
+			t[k] = r.walk(item, false)
+		}
+		return t
+	}
+	return v
+}
+
+// RedactToolResult scrubs a tool-call result string. If the paired tool-call
+// args reference a .env-style file, the entire output is replaced with a
+// placeholder and the env-file rule is recorded.
+func (r *Redactor) RedactToolResult(output string, argPath string) string {
+	if r == nil {
+		return output
+	}
+	if argPath != "" && envFileRe.MatchString(filepath.ToSlash(argPath)) {
+		r.record(RuleEnvFile)
+		return envFilePlaceholder
+	}
+	return r.String(output)
+}
+
+// Applied returns the set of redaction rules that fired, sorted lexically
+// so the snapshot output is deterministic.
+func (r *Redactor) Applied() []string {
+	if r == nil || len(r.applied) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(r.applied))
+	for k := range r.applied {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (r *Redactor) record(name string) {
+	if r == nil {
+		return
+	}
+	r.applied[name] = struct{}{}
+}

--- a/apps/backend/internal/task/share/redaction_test.go
+++ b/apps/backend/internal/task/share/redaction_test.go
@@ -113,6 +113,32 @@ func TestRedactor_AbsPath_EmptyRootSkipsRule(t *testing.T) {
 	}
 }
 
+func TestRedactor_AbsPath_MultipleRootsRewriteIndependently(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("/Users/foo/repo-a", "/Users/foo/repo-b")
+	in := "touched /Users/foo/repo-a/src/x.ts and /Users/foo/repo-b/lib/y.go"
+	want := "touched src/x.ts and lib/y.go"
+	got := r.String(in)
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleAbsPath})
+}
+
+func TestRedactor_AbsPath_NestedRootsPreferLongest(t *testing.T) {
+	t.Parallel()
+	// If the longer root is processed first the inner path stays clean;
+	// if the shorter root won, "/workspace" would strip down to "repo1/src/x.ts"
+	// while a sibling "/workspace-other" must still not match.
+	r := NewRedactor("/workspace", "/workspace/repo1")
+	got := r.String("a:/workspace/repo1/src/x.ts b:/workspace/other.md")
+	want := "a:src/x.ts b:other.md"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleAbsPath})
+}
+
 func TestRedactor_JSON_DropsTopLevelEnvField(t *testing.T) {
 	t.Parallel()
 	r := NewRedactor("")

--- a/apps/backend/internal/task/share/redaction_test.go
+++ b/apps/backend/internal/task/share/redaction_test.go
@@ -1,0 +1,212 @@
+package share
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRedactor_StringSecretRules(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		input      string
+		wantRules  []string
+		mustNotHas string // substring that must not appear in output
+	}{
+		{
+			name:       "sk_token",
+			input:      "key=sk-abcdefghijklmnopqrstuv0123456789 done",
+			wantRules:  []string{RuleSecretSK},
+			mustNotHas: "sk-abcdefghijklmnopqrstuv0123456789",
+		},
+		{
+			name:       "ghp_token",
+			input:      "GH_TOKEN=ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+			wantRules:  []string{RuleSecretGHP},
+			mustNotHas: "ghp_1234567890",
+		},
+		{
+			name:       "gho_token",
+			input:      "Authorization: bearer gho_1234567890abcdefghijklmnopqrstuvwxyz",
+			wantRules:  []string{RuleSecretGHO},
+			mustNotHas: "gho_1234567890",
+		},
+		{
+			name:       "github_pat_token",
+			input:      "pat=github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789xyz",
+			wantRules:  []string{RuleSecretGitHubPAT},
+			mustNotHas: "github_pat_11ABCDEFG",
+		},
+		{
+			name:       "aws_key",
+			input:      "aws AKIAIOSFODNN7EXAMPLE rest",
+			wantRules:  []string{RuleSecretAWS},
+			mustNotHas: "AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			name:      "no_secret",
+			input:     "just a normal string with no juicy bits",
+			wantRules: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewRedactor("")
+			got := r.String(tc.input)
+			if tc.mustNotHas != "" && strings.Contains(got, tc.mustNotHas) {
+				t.Fatalf("expected %q to be removed, got output: %q", tc.mustNotHas, got)
+			}
+			assertRulesEqual(t, r.Applied(), tc.wantRules)
+		})
+	}
+}
+
+func TestRedactor_AbsPath_RewritesToRelative(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("/Users/foo/proj")
+	got := r.String("opened /Users/foo/proj/src/x.ts for editing")
+	want := "opened src/x.ts for editing"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleAbsPath})
+}
+
+func TestRedactor_AbsPath_NoMatchLeavesUnchanged(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("/Users/foo/proj")
+	got := r.String("nothing to redact here")
+	if got != "nothing to redact here" {
+		t.Fatalf("unexpected mutation: %q", got)
+	}
+	assertRulesEqual(t, r.Applied(), nil)
+}
+
+func TestRedactor_AbsPath_EmptyRootSkipsRule(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("")
+	in := "see /Users/foo/proj/src/x.ts"
+	got := r.String(in)
+	if got != in {
+		t.Fatalf("expected pass-through with empty root, got %q", got)
+	}
+	if len(r.Applied()) != 0 {
+		t.Fatalf("expected no rules applied, got %v", r.Applied())
+	}
+}
+
+func TestRedactor_JSON_DropsTopLevelEnvField(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("")
+	in := json.RawMessage(`{"cmd":"ls","env":{"SECRET":"abc"}}`)
+	out := r.JSON(in)
+
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output not valid json: %v (%s)", err, string(out))
+	}
+	if _, present := got["env"]; present {
+		t.Fatalf("env field should have been dropped, got %v", got)
+	}
+	if got["cmd"] != "ls" {
+		t.Fatalf("cmd should be preserved, got %v", got)
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleEnvVars})
+}
+
+func TestRedactor_JSON_RedactsNestedStringSecrets(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("")
+	in := json.RawMessage(`{"cmd":"curl","headers":["Authorization: token ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"]}`)
+	out := r.JSON(in)
+	if strings.Contains(string(out), "ghp_AAAA") {
+		t.Fatalf("expected ghp_ token to be redacted in nested string, got %s", string(out))
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleSecretGHP})
+}
+
+func TestRedactor_JSON_InvalidJSONFallsBackToStringRedaction(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("")
+	in := json.RawMessage(`not-json sk-abcdefghijklmnopqrstuv0123456789`)
+	out := r.JSON(in)
+	if strings.Contains(string(out), "sk-abcdefghij") {
+		t.Fatalf("expected fallback to redact secret, got %s", string(out))
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleSecretSK})
+}
+
+func TestRedactor_RedactToolResult_EnvFileScrubbed(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("")
+	output := "DATABASE_URL=postgres://user:pass@host/db\nAPI_KEY=12345\n"
+	got := r.RedactToolResult(output, ".env.production")
+	if got != envFilePlaceholder {
+		t.Fatalf("expected env-file placeholder, got %q", got)
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleEnvFile})
+}
+
+func TestRedactor_RedactToolResult_NonEnvFileStillRedactsSecrets(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("")
+	output := "token=ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	got := r.RedactToolResult(output, "src/main.go")
+	if strings.Contains(got, "ghp_AAAA") {
+		t.Fatalf("expected token to be redacted in non-env-file output, got %q", got)
+	}
+	assertRulesEqual(t, r.Applied(), []string{RuleSecretGHP})
+}
+
+func TestRedactor_NilSafe(t *testing.T) {
+	t.Parallel()
+	var r *Redactor // nil
+	if got := r.String("hello"); got != "hello" {
+		t.Fatalf("nil receiver should pass through, got %q", got)
+	}
+	if got := r.RedactToolResult("hello", ".env"); got != "hello" {
+		t.Fatalf("nil receiver should pass through, got %q", got)
+	}
+	if got := r.Applied(); len(got) != 0 {
+		t.Fatalf("nil receiver should report no rules, got %v", got)
+	}
+}
+
+func TestRedactor_Applied_ReturnsSortedDistinct(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("/Users/foo/proj")
+	r.String("token ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA in /Users/foo/proj/x.ts")
+	r.String("again ghp_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB and /Users/foo/proj/y.ts")
+	got := r.Applied()
+	want := []string{RuleAbsPath, RuleSecretGHP}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func assertRulesEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	gotSet := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		gotSet[g] = struct{}{}
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, w := range want {
+		wantSet[w] = struct{}{}
+	}
+	for w := range wantSet {
+		if _, ok := gotSet[w]; !ok {
+			t.Fatalf("expected rule %q to be applied; got %v", w, got)
+		}
+	}
+	for g := range gotSet {
+		if _, ok := wantSet[g]; !ok {
+			t.Fatalf("unexpected extra rule %q applied; got %v want %v", g, got, want)
+		}
+	}
+}

--- a/apps/backend/internal/task/share/redaction_test.go
+++ b/apps/backend/internal/task/share/redaction_test.go
@@ -125,6 +125,30 @@ func TestRedactor_AbsPath_MultipleRootsRewriteIndependently(t *testing.T) {
 	assertRulesEqual(t, r.Applied(), []string{RuleAbsPath})
 }
 
+func TestRedactor_AbsPath_StandaloneRootStripped(t *testing.T) {
+	t.Parallel()
+	// Bare root (e.g. `pwd` output, quoted paths, end of sentence) used to
+	// leak through because the matcher only handled `root + "/"`. Now we
+	// also strip the root when it appears at a word boundary.
+	r := NewRedactor("/workspace")
+	cases := map[string]string{
+		"cwd: /workspace":          "cwd: ",
+		"cd /workspace && ls":      "cd  && ls",
+		"path=\"/workspace\" done": "path=\"\" done",
+	}
+	for in, want := range cases {
+		got := r.String(in)
+		if got != want {
+			t.Errorf("input %q: got %q, want %q", in, got, want)
+		}
+	}
+	// Sibling dir must still be left alone.
+	siblingIn := "see /workspace2/file.ts"
+	if got := r.String(siblingIn); got != siblingIn {
+		t.Errorf("sibling path corrupted: got %q, want %q", got, siblingIn)
+	}
+}
+
 func TestRedactor_AbsPath_NestedRootsPreferLongest(t *testing.T) {
 	t.Parallel()
 	// If the longer root is processed first the inner path stays clean;

--- a/apps/backend/internal/task/share/redaction_test.go
+++ b/apps/backend/internal/task/share/redaction_test.go
@@ -77,6 +77,19 @@ func TestRedactor_AbsPath_RewritesToRelative(t *testing.T) {
 	assertRulesEqual(t, r.Applied(), []string{RuleAbsPath})
 }
 
+func TestRedactor_AbsPath_SiblingDirNotCorrupted(t *testing.T) {
+	t.Parallel()
+	r := NewRedactor("/Users/foo/proj")
+	in := "opened /Users/foo/proj2/src/x.ts"
+	got := r.String(in)
+	if got != in {
+		t.Fatalf("sibling path should be unchanged, got %q", got)
+	}
+	if len(r.Applied()) != 0 {
+		t.Fatalf("abs-path rule should not fire for sibling dir, got %v", r.Applied())
+	}
+}
+
 func TestRedactor_AbsPath_NoMatchLeavesUnchanged(t *testing.T) {
 	t.Parallel()
 	r := NewRedactor("/Users/foo/proj")

--- a/apps/backend/internal/task/share/redaction_test.go
+++ b/apps/backend/internal/task/share/redaction_test.go
@@ -127,25 +127,40 @@ func TestRedactor_AbsPath_MultipleRootsRewriteIndependently(t *testing.T) {
 
 func TestRedactor_AbsPath_StandaloneRootStripped(t *testing.T) {
 	t.Parallel()
-	// Bare root (e.g. `pwd` output, quoted paths, end of sentence) used to
-	// leak through because the matcher only handled `root + "/"`. Now we
-	// also strip the root when it appears at a word boundary.
-	r := NewRedactor("/workspace")
+	// Bare root (e.g. `pwd` output, end of sentence, mid-prose whitespace)
+	// used to leak through because the matcher only handled `root + "/"`.
+	// Now we accept "/", whitespace, or end-of-string as the boundary.
 	cases := map[string]string{
 		"cwd: /workspace":          "cwd: ",
 		"cd /workspace && ls":      "cd  && ls",
-		"path=\"/workspace\" done": "path=\"\" done",
+		"line1\n/workspace\nline2": "line1\n\nline2",
 	}
 	for in, want := range cases {
+		r := NewRedactor("/workspace")
 		got := r.String(in)
 		if got != want {
 			t.Errorf("input %q: got %q, want %q", in, got, want)
 		}
 	}
-	// Sibling dir must still be left alone.
-	siblingIn := "see /workspace2/file.ts"
-	if got := r.String(siblingIn); got != siblingIn {
-		t.Errorf("sibling path corrupted: got %q, want %q", got, siblingIn)
+}
+
+func TestRedactor_AbsPath_SiblingsWithPunctuationNotCorrupted(t *testing.T) {
+	t.Parallel()
+	// Sibling paths that extend the root via punctuation (".", "-", "_") used
+	// to false-match a `\b` matcher because `\b` fires on word→non-word
+	// transitions. The current regex restricts the boundary to "/", whitespace,
+	// or end-of-string so these stay intact.
+	r := NewRedactor("/workspace")
+	siblings := []string{
+		"see /workspace2/file.ts",
+		"see /workspace.bak/file.ts",
+		"see /workspace-old/file.ts",
+		"see /workspace_alt/file.ts",
+	}
+	for _, in := range siblings {
+		if got := r.String(in); got != in {
+			t.Errorf("sibling path corrupted: in=%q got=%q", in, got)
+		}
 	}
 }
 

--- a/apps/backend/internal/task/share/repository.go
+++ b/apps/backend/internal/task/share/repository.go
@@ -1,0 +1,183 @@
+package share
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/db"
+)
+
+// Backend identifiers persisted in task_shares.backend.
+const (
+	BackendGitHubGist = "github_gist"
+)
+
+// ErrNotFound is returned when a share row cannot be located.
+var ErrNotFound = errors.New("share not found")
+
+// Share is the persisted representation of a published share link. The
+// snapshot payload itself lives at ExternalURL; only metadata is stored
+// locally.
+type Share struct {
+	ID                string
+	TaskSessionID     string
+	Backend           string
+	ExternalID        string
+	ExternalURL       string
+	SnapshotSizeBytes int64
+	CreatedAt         time.Time
+	RevokedAt         *time.Time
+	ViewCount         int
+}
+
+// IsRevoked returns true when the share has been revoked.
+func (s *Share) IsRevoked() bool { return s.RevokedAt != nil }
+
+// Repository persists Share rows in SQLite.
+type Repository struct {
+	writer *sqlx.DB
+	reader *sqlx.DB
+	log    *logger.Logger
+}
+
+// NewRepository creates a share repository and applies its migration. The
+// caller owns the database connections; Close is a no-op.
+func NewRepository(writer, reader *sqlx.DB, log *logger.Logger) (*Repository, error) {
+	r := &Repository{writer: writer, reader: reader, log: log}
+	if err := r.initSchema(); err != nil {
+		return nil, fmt.Errorf("share repo: init schema: %w", err)
+	}
+	return r, nil
+}
+
+// Close is a no-op; the database connections are not owned by this repo.
+func (r *Repository) Close() error { return nil }
+
+func (r *Repository) initSchema() error {
+	mig := db.NewMigrateLogger(r.writer, r.log)
+	mig.Apply("table.task_shares", `CREATE TABLE IF NOT EXISTS task_shares (
+		id                  TEXT PRIMARY KEY,
+		task_session_id     TEXT NOT NULL,
+		backend             TEXT NOT NULL,
+		external_id         TEXT NOT NULL,
+		external_url        TEXT NOT NULL,
+		snapshot_size_bytes INTEGER NOT NULL,
+		created_at          DATETIME NOT NULL,
+		revoked_at          DATETIME NULL,
+		view_count          INTEGER NOT NULL DEFAULT 0
+	)`)
+	mig.Apply("index.task_shares_session",
+		`CREATE INDEX IF NOT EXISTS idx_task_shares_session ON task_shares(task_session_id)`)
+	return nil
+}
+
+// Create inserts a new share row. ID, Backend, ExternalID, ExternalURL, and
+// TaskSessionID must be set by the caller. CreatedAt defaults to time.Now()
+// (UTC) if zero.
+func (r *Repository) Create(ctx context.Context, s *Share) error {
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = time.Now().UTC()
+	}
+	_, err := r.writer.ExecContext(ctx, `INSERT INTO task_shares
+		(id, task_session_id, backend, external_id, external_url, snapshot_size_bytes, created_at, view_count)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		s.ID, s.TaskSessionID, s.Backend, s.ExternalID, s.ExternalURL,
+		s.SnapshotSizeBytes, s.CreatedAt, s.ViewCount,
+	)
+	if err != nil {
+		return fmt.Errorf("insert task_share: %w", err)
+	}
+	return nil
+}
+
+// GetByID returns the share with the given ID, or ErrNotFound.
+func (r *Repository) GetByID(ctx context.Context, id string) (*Share, error) {
+	row := r.reader.QueryRowxContext(ctx, `SELECT
+		id, task_session_id, backend, external_id, external_url,
+		snapshot_size_bytes, created_at, revoked_at, view_count
+		FROM task_shares WHERE id = ?`, id)
+	return scanShareRow(row)
+}
+
+// ListByTaskSession returns every share row for a session ordered by creation
+// time (newest first), including revoked rows.
+func (r *Repository) ListByTaskSession(ctx context.Context, sessionID string) ([]*Share, error) {
+	rows, err := r.reader.QueryxContext(ctx, `SELECT
+		id, task_session_id, backend, external_id, external_url,
+		snapshot_size_bytes, created_at, revoked_at, view_count
+		FROM task_shares
+		WHERE task_session_id = ?
+		ORDER BY created_at DESC`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("list task_shares: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []*Share
+	for rows.Next() {
+		s, err := scanShareRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// MarkRevoked sets revoked_at on the share row. If the row is already revoked,
+// the existing revoked_at is preserved.
+func (r *Repository) MarkRevoked(ctx context.Context, id string, at time.Time) error {
+	res, err := r.writer.ExecContext(ctx,
+		`UPDATE task_shares SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
+		at.UTC(), id,
+	)
+	if err != nil {
+		return fmt.Errorf("update task_share revoked_at: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if affected == 0 {
+		// Either missing or already revoked. Distinguish so the caller can
+		// return a clean 404 vs treating the second call as a no-op.
+		existing, getErr := r.GetByID(ctx, id)
+		if errors.Is(getErr, ErrNotFound) {
+			return ErrNotFound
+		}
+		if getErr != nil {
+			return getErr
+		}
+		_ = existing // already revoked — caller treats this as success.
+	}
+	return nil
+}
+
+// scanShareRow is shared between QueryRowx and Queryx callers.
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanShareRow(row rowScanner) (*Share, error) {
+	var s Share
+	var revokedAt sql.NullTime
+	if err := row.Scan(
+		&s.ID, &s.TaskSessionID, &s.Backend, &s.ExternalID, &s.ExternalURL,
+		&s.SnapshotSizeBytes, &s.CreatedAt, &revokedAt, &s.ViewCount,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("scan task_share: %w", err)
+	}
+	if revokedAt.Valid {
+		t := revokedAt.Time
+		s.RevokedAt = &t
+	}
+	return &s, nil
+}

--- a/apps/backend/internal/task/share/repository_test.go
+++ b/apps/backend/internal/task/share/repository_test.go
@@ -1,0 +1,146 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/db"
+)
+
+func newTestRepo(t *testing.T) *Repository {
+	t.Helper()
+	tmp := t.TempDir()
+	rawDB, err := db.OpenSQLite(filepath.Join(tmp, "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = rawDB.Close() })
+	sqlxDB := sqlx.NewDb(rawDB, "sqlite3")
+	repo, err := NewRepository(sqlxDB, sqlxDB, nil)
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+	return repo
+}
+
+func TestRepository_CreateAndGet(t *testing.T) {
+	t.Parallel()
+	r := newTestRepo(t)
+	ctx := context.Background()
+
+	in := &Share{
+		ID:                "s-1",
+		TaskSessionID:     "sess-1",
+		Backend:           BackendGitHubGist,
+		ExternalID:        "abc123",
+		ExternalURL:       "https://gist.github.com/u/abc123",
+		SnapshotSizeBytes: 1024,
+	}
+	if err := r.Create(ctx, in); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := r.GetByID(ctx, "s-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ID != in.ID || got.ExternalURL != in.ExternalURL || got.Backend != BackendGitHubGist {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Fatal("CreatedAt should default to non-zero")
+	}
+	if got.RevokedAt != nil {
+		t.Fatalf("RevokedAt should be nil on fresh row, got %v", got.RevokedAt)
+	}
+}
+
+func TestRepository_GetByID_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newTestRepo(t)
+	_, err := r.GetByID(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRepository_ListByTaskSession_FiltersAndOrders(t *testing.T) {
+	t.Parallel()
+	r := newTestRepo(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	rows := []*Share{
+		{ID: "s-a", TaskSessionID: "sess-1", Backend: BackendGitHubGist, ExternalID: "a", ExternalURL: "u/a", CreatedAt: now.Add(-2 * time.Hour)},
+		{ID: "s-b", TaskSessionID: "sess-1", Backend: BackendGitHubGist, ExternalID: "b", ExternalURL: "u/b", CreatedAt: now.Add(-1 * time.Hour)},
+		{ID: "s-c", TaskSessionID: "sess-2", Backend: BackendGitHubGist, ExternalID: "c", ExternalURL: "u/c", CreatedAt: now},
+	}
+	for _, row := range rows {
+		if err := r.Create(ctx, row); err != nil {
+			t.Fatalf("create %s: %v", row.ID, err)
+		}
+	}
+
+	got, err := r.ListByTaskSession(ctx, "sess-1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows for sess-1, got %d", len(got))
+	}
+	if got[0].ID != "s-b" || got[1].ID != "s-a" {
+		t.Fatalf("expected newest-first ordering, got %s,%s", got[0].ID, got[1].ID)
+	}
+}
+
+func TestRepository_MarkRevoked(t *testing.T) {
+	t.Parallel()
+	r := newTestRepo(t)
+	ctx := context.Background()
+
+	if err := r.Create(ctx, &Share{
+		ID: "s-1", TaskSessionID: "sess-1", Backend: BackendGitHubGist,
+		ExternalID: "x", ExternalURL: "u/x",
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	revokedAt := time.Now().UTC()
+	if err := r.MarkRevoked(ctx, "s-1", revokedAt); err != nil {
+		t.Fatalf("first revoke: %v", err)
+	}
+
+	got, err := r.GetByID(ctx, "s-1")
+	if err != nil {
+		t.Fatalf("get after revoke: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Fatal("expected RevokedAt to be set")
+	}
+
+	// Second revoke is idempotent: returns nil and leaves the timestamp untouched.
+	priorTs := *got.RevokedAt
+	if err := r.MarkRevoked(ctx, "s-1", revokedAt.Add(time.Hour)); err != nil {
+		t.Fatalf("second revoke should be idempotent, got %v", err)
+	}
+	got2, err := r.GetByID(ctx, "s-1")
+	if err != nil {
+		t.Fatalf("get after second revoke: %v", err)
+	}
+	if !got2.RevokedAt.Equal(priorTs) {
+		t.Fatalf("revoked_at changed: was %v, now %v", priorTs, got2.RevokedAt)
+	}
+}
+
+func TestRepository_MarkRevoked_NotFound(t *testing.T) {
+	t.Parallel()
+	r := newTestRepo(t)
+	err := r.MarkRevoked(context.Background(), "missing", time.Now())
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/apps/backend/internal/task/share/service.go
+++ b/apps/backend/internal/task/share/service.go
@@ -1,0 +1,128 @@
+package share
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// Service coordinates snapshot construction, backend upload, and persistence.
+type Service struct {
+	repo      *Repository
+	taskRepo  TaskReader
+	backend   Backend
+	log       *logger.Logger
+	kandevVer string
+}
+
+// New constructs a Service. All arguments are required.
+func New(repo *Repository, taskRepo TaskReader, backend Backend, log *logger.Logger, kandevVer string) *Service {
+	return &Service{
+		repo:      repo,
+		taskRepo:  taskRepo,
+		backend:   backend,
+		log:       log,
+		kandevVer: kandevVer,
+	}
+}
+
+// PreviewSnapshot builds and returns the redacted snapshot that would be
+// uploaded for the given session, without uploading or persisting anything.
+// Returns ErrSessionNotCompleted if the session is not yet completed.
+func (s *Service) PreviewSnapshot(ctx context.Context, taskSessionID string) (*Snapshot, error) {
+	return BuildSnapshot(ctx, s.taskRepo, taskSessionID, s.kandevVer)
+}
+
+// CreateShare builds a snapshot, uploads it via the configured backend, and
+// records the row in the repository.
+func (s *Service) CreateShare(ctx context.Context, taskSessionID string) (*Share, error) {
+	snap, err := BuildSnapshot(ctx, s.taskRepo, taskSessionID, s.kandevVer)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(snap)
+	if err != nil {
+		return nil, fmt.Errorf("marshal snapshot: %w", err)
+	}
+	extID, extURL, err := s.backend.Upload(ctx, snap)
+	if err != nil {
+		return nil, fmt.Errorf("upload snapshot: %w", err)
+	}
+	row := &Share{
+		ID:                uuid.New().String(),
+		TaskSessionID:     taskSessionID,
+		Backend:           s.backend.Name(),
+		ExternalID:        extID,
+		ExternalURL:       extURL,
+		SnapshotSizeBytes: int64(len(body)),
+		CreatedAt:         time.Now().UTC(),
+	}
+	if err := s.repo.Create(ctx, row); err != nil {
+		// The gist exists on GitHub but we failed to persist the row.
+		// Best-effort: try to clean up the orphaned gist; log if that
+		// also fails so the user can manually delete it.
+		if delErr := s.backend.Delete(ctx, extID); delErr != nil {
+			s.logWarn("orphaned gist after row insert failed",
+				zap.String("gist_id", extID), zap.Error(delErr))
+		}
+		return nil, fmt.Errorf("persist share: %w", err)
+	}
+	return row, nil
+}
+
+// RevokeShare deletes the underlying gist and marks the row revoked. A
+// 404 from the gist backend (gist already deleted on GitHub) is treated
+// as success, logged at INFO, and still marks the row revoked.
+func (s *Service) RevokeShare(ctx context.Context, shareID string) error {
+	row, err := s.repo.GetByID(ctx, shareID)
+	if err != nil {
+		return err
+	}
+	if row.IsRevoked() {
+		return nil
+	}
+	if delErr := s.backend.Delete(ctx, row.ExternalID); delErr != nil {
+		if !IsAlreadyGone(delErr) {
+			return fmt.Errorf("delete from backend: %w", delErr)
+		}
+		s.logInfo("gist already gone on upstream; marking share revoked anyway",
+			zap.String("share_id", shareID),
+			zap.String("external_id", row.ExternalID))
+	}
+	if err := s.repo.MarkRevoked(ctx, shareID, time.Now().UTC()); err != nil {
+		// Repository failure after a successful upstream delete leaves an
+		// inconsistent row. Surface the error so the caller can retry.
+		return fmt.Errorf("mark revoked: %w", err)
+	}
+	return nil
+}
+
+// ListBySession returns every share row for a session (including revoked).
+func (s *Service) ListBySession(ctx context.Context, taskSessionID string) ([]*Share, error) {
+	return s.repo.ListByTaskSession(ctx, taskSessionID)
+}
+
+// GetByID exposes repo.GetByID for handlers that need to inspect a row.
+func (s *Service) GetByID(ctx context.Context, shareID string) (*Share, error) {
+	return s.repo.GetByID(ctx, shareID)
+}
+
+func (s *Service) logInfo(msg string, fields ...zap.Field) {
+	if s.log == nil {
+		return
+	}
+	s.log.Info(msg, fields...)
+}
+
+func (s *Service) logWarn(msg string, fields ...zap.Field) {
+	if s.log == nil {
+		return
+	}
+	s.log.Warn(msg, fields...)
+}

--- a/apps/backend/internal/task/share/service.go
+++ b/apps/backend/internal/task/share/service.go
@@ -46,7 +46,9 @@ func (s *Service) CreateShare(ctx context.Context, taskSessionID string) (*Share
 	if err != nil {
 		return nil, err
 	}
-	body, err := json.Marshal(snap)
+	// Use the same indented marshal as the gist backend so the size we
+	// surface to the UI matches the bytes actually uploaded to GitHub.
+	body, err := json.MarshalIndent(snap, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal snapshot: %w", err)
 	}

--- a/apps/backend/internal/task/share/service_test.go
+++ b/apps/backend/internal/task/share/service_test.go
@@ -1,0 +1,259 @@
+package share
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/github"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// mockBackend records uploads and supports configurable upload/delete errors.
+type mockBackend struct {
+	uploads   int
+	deletes   []string
+	uploadErr error
+	deleteErr error
+	nextID    string
+	nextURL   string
+}
+
+func (m *mockBackend) Name() string { return BackendGitHubGist }
+
+func (m *mockBackend) Upload(_ context.Context, _ *Snapshot) (string, string, error) {
+	if m.uploadErr != nil {
+		return "", "", m.uploadErr
+	}
+	m.uploads++
+	id := m.nextID
+	if id == "" {
+		id = "gist-1"
+	}
+	url := m.nextURL
+	if url == "" {
+		url = "https://gist.github.com/u/" + id
+	}
+	return id, url, nil
+}
+
+func (m *mockBackend) Delete(_ context.Context, id string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.deletes = append(m.deletes, id)
+	return nil
+}
+
+func completedSession() *stubReader {
+	completed := time.Now().UTC()
+	return &stubReader{
+		task: &models.Task{ID: "t-1", Title: "test task"},
+		session: &models.TaskSession{
+			ID: "s-1", TaskID: "t-1", State: models.TaskSessionStateCompleted,
+			StartedAt: completed.Add(-time.Minute), CompletedAt: &completed,
+		},
+		messages: []*models.Message{
+			{ID: "m-1", AuthorType: models.MessageAuthorUser, Type: models.MessageTypeMessage, Content: "hi", CreatedAt: completed},
+		},
+	}
+}
+
+func TestService_CreateShare_HappyPath(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	mock := &mockBackend{nextID: "abc", nextURL: "https://gist.github.com/u/abc"}
+	svc := New(repo, completedSession(), mock, nil, "test-version")
+
+	share, err := svc.CreateShare(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if share.ExternalID != "abc" || share.ExternalURL != "https://gist.github.com/u/abc" {
+		t.Fatalf("unexpected share: %+v", share)
+	}
+	if share.SnapshotSizeBytes <= 0 {
+		t.Fatalf("expected non-zero snapshot size, got %d", share.SnapshotSizeBytes)
+	}
+	got, err := repo.GetByID(context.Background(), share.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ID != share.ID {
+		t.Fatalf("row missing after create")
+	}
+}
+
+func TestService_CreateShare_RejectsPreHistorySession(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	reader := completedSession()
+	reader.session.State = models.TaskSessionStateCreated
+	mock := &mockBackend{}
+	svc := New(repo, reader, mock, nil, "v")
+
+	_, err := svc.CreateShare(context.Background(), "s-1")
+	if !errors.Is(err, ErrSessionNotShareable) {
+		t.Fatalf("expected ErrSessionNotShareable, got %v", err)
+	}
+	if mock.uploads != 0 {
+		t.Fatalf("backend should not be called when session is pre-history")
+	}
+}
+
+func TestService_CreateShare_AllowsRunningSession(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	reader := completedSession()
+	reader.session.State = models.TaskSessionStateRunning
+	mock := &mockBackend{nextID: "g1"}
+	svc := New(repo, reader, mock, nil, "v")
+
+	share, err := svc.CreateShare(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("running session should be shareable, got %v", err)
+	}
+	if share.ExternalID != "g1" {
+		t.Fatalf("expected backend to be called, got share %+v", share)
+	}
+}
+
+func TestService_CreateShare_BackendErrorLeavesNoRow(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	mock := &mockBackend{uploadErr: errors.New("gateway down")}
+	svc := New(repo, completedSession(), mock, nil, "v")
+
+	_, err := svc.CreateShare(context.Background(), "s-1")
+	if err == nil {
+		t.Fatal("expected upload error")
+	}
+	if !strings.Contains(err.Error(), "gateway down") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rows, err := repo.ListByTaskSession(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected zero rows after backend failure, got %d", len(rows))
+	}
+}
+
+func TestService_RevokeShare_DeletesAndMarksRevoked(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	mock := &mockBackend{nextID: "abc"}
+	svc := New(repo, completedSession(), mock, nil, "v")
+
+	share, err := svc.CreateShare(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := svc.RevokeShare(context.Background(), share.ID); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if len(mock.deletes) != 1 || mock.deletes[0] != "abc" {
+		t.Fatalf("expected backend Delete(abc), got %v", mock.deletes)
+	}
+	got, err := repo.GetByID(context.Background(), share.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Fatal("expected RevokedAt to be set")
+	}
+}
+
+func TestService_RevokeShare_IsIdempotentOnSecondCall(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	mock := &mockBackend{nextID: "abc"}
+	svc := New(repo, completedSession(), mock, nil, "v")
+
+	share, err := svc.CreateShare(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := svc.RevokeShare(context.Background(), share.ID); err != nil {
+		t.Fatalf("first revoke: %v", err)
+	}
+	if err := svc.RevokeShare(context.Background(), share.ID); err != nil {
+		t.Fatalf("second revoke should be a no-op, got %v", err)
+	}
+	// Backend Delete should only have been called once; the second revoke
+	// short-circuits because IsRevoked() is true.
+	if len(mock.deletes) != 1 {
+		t.Fatalf("expected 1 delete call, got %d", len(mock.deletes))
+	}
+}
+
+func TestService_RevokeShare_SurvivesUpstream404(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	mock := &mockBackend{nextID: "abc"}
+	svc := New(repo, completedSession(), mock, nil, "v")
+
+	share, err := svc.CreateShare(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	mock.deleteErr = &github.GitHubAPIError{StatusCode: http.StatusNotFound, Endpoint: "/gists/abc"}
+
+	if err := svc.RevokeShare(context.Background(), share.ID); err != nil {
+		t.Fatalf("revoke should swallow 404, got %v", err)
+	}
+	got, err := repo.GetByID(context.Background(), share.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Fatal("revoked_at should still be set after upstream 404")
+	}
+}
+
+func TestService_RevokeShare_PropagatesOtherBackendErrors(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	mock := &mockBackend{nextID: "abc"}
+	svc := New(repo, completedSession(), mock, nil, "v")
+
+	share, err := svc.CreateShare(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	mock.deleteErr = errors.New("network down")
+
+	err = svc.RevokeShare(context.Background(), share.ID)
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("expected propagated error, got %v", err)
+	}
+	got, err := repo.GetByID(context.Background(), share.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.RevokedAt != nil {
+		t.Fatal("row should NOT be marked revoked when backend delete failed for a non-404 reason")
+	}
+}
+
+func TestService_PreviewSnapshot_ReturnsRedactedWithoutUpload(t *testing.T) {
+	t.Parallel()
+	repo := newTestRepo(t)
+	mock := &mockBackend{}
+	svc := New(repo, completedSession(), mock, nil, "v")
+
+	snap, err := svc.PreviewSnapshot(context.Background(), "s-1")
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if snap == nil || snap.Task.Title == "" {
+		t.Fatalf("expected non-empty snapshot, got %+v", snap)
+	}
+	if mock.uploads != 0 {
+		t.Fatalf("preview must not call backend Upload")
+	}
+}

--- a/apps/backend/internal/task/share/snapshot.go
+++ b/apps/backend/internal/task/share/snapshot.go
@@ -1,0 +1,81 @@
+// Package share builds, persists, and uploads frozen snapshots of completed
+// task sessions to public locations (currently: GitHub Gists).
+package share
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// SnapshotVersion is the current snapshot schema version. Bump when the
+// JSON shape changes in a non-backwards-compatible way.
+const SnapshotVersion = 1
+
+// Snapshot is a self-contained, frozen JSON representation of a completed
+// task session. It MUST NOT contain foreign keys to live kandev rows; it is
+// designed to survive deletion of the underlying task, session, or workspace.
+type Snapshot struct {
+	Version       int          `json:"version"`
+	KandevVersion string       `json:"kandev_version,omitempty"`
+	ExportedAt    time.Time    `json:"exported_at"`
+	Task          TaskMeta     `json:"task"`
+	Session       SessionMeta  `json:"session"`
+	Messages      []Message    `json:"messages"`
+	Redaction     RedactionLog `json:"redaction"`
+}
+
+// TaskMeta is the durable bit of the task captured at export time.
+type TaskMeta struct {
+	Title        string `json:"title"`
+	WorkflowStep string `json:"workflow_step,omitempty"`
+}
+
+// SessionMeta is the durable bit of the session captured at export time.
+type SessionMeta struct {
+	AgentType    string     `json:"agent_type,omitempty"`
+	Model        string     `json:"model,omitempty"`
+	ExecutorType string     `json:"executor_type,omitempty"`
+	StartedAt    time.Time  `json:"started_at"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+}
+
+// Message is a single message in the conversation, broken into typed blocks.
+type Message struct {
+	Role   string    `json:"role"` // "user" | "assistant" | "system"
+	Ts     time.Time `json:"ts"`
+	Blocks []Block   `json:"blocks"`
+}
+
+// Block is a single content unit inside a message. Only the fields relevant
+// to the block kind are populated; everything else is omitted.
+type Block struct {
+	Kind        string          `json:"kind"`                   // "text" | "tool_call" | "tool_result" | "diff"
+	Text        string          `json:"text,omitempty"`         // for "text"
+	ToolName    string          `json:"tool_name,omitempty"`    // for "tool_call"
+	Args        json.RawMessage `json:"args,omitempty"`         // for "tool_call" (already redacted)
+	Output      string          `json:"output,omitempty"`       // for "tool_result" (already redacted)
+	Truncated   bool            `json:"truncated,omitempty"`    // for "tool_result"
+	Path        string          `json:"path,omitempty"`         // for "diff"
+	UnifiedDiff string          `json:"unified_diff,omitempty"` // for "diff"
+}
+
+// RedactionLog records which redaction rules were triggered while building
+// the snapshot. It is part of the snapshot so a reader can tell at a glance
+// whether sensitive data was likely scrubbed.
+type RedactionLog struct {
+	AppliedRules []string `json:"applied_rules"`
+}
+
+// Block kind constants — kept private to discourage callers from constructing
+// raw Blocks; use the Map* helpers in builder.go.
+const (
+	blockKindText       = "text"
+	blockKindToolCall   = "tool_call"
+	blockKindToolResult = "tool_result"
+	blockKindDiff       = "diff"
+
+	// Role constants used in Snapshot.Messages.
+	roleUser      = "user"
+	roleAssistant = "assistant"
+	roleSystem    = "system"
+)

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -6,6 +6,7 @@ import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { TodoIndicator } from "./todo-indicator";
 import { PRStatusChip } from "@/components/github/pr-status-chip";
+import { ShareButton, shareableSessionStateClient } from "@/components/task/share/share-button";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 import { useMessageHandler, buildTaskMentionsContext } from "@/hooks/use-message-handler";
@@ -299,6 +300,8 @@ type TodoDisplayItem = {
 function ChatStatusBar({
   todoItems,
   taskId,
+  sessionId,
+  sessionState,
   nextStepName,
   onProceed,
   isAgentBusy,
@@ -306,6 +309,8 @@ function ChatStatusBar({
 }: {
   todoItems: TodoDisplayItem[];
   taskId: string | null;
+  sessionId: string | null;
+  sessionState: string | null;
   nextStepName: string | null;
   onProceed: () => void;
   isAgentBusy: boolean;
@@ -313,6 +318,7 @@ function ChatStatusBar({
 }) {
   const showTodos = todoItems.length > 0;
   const showProceed = !!nextStepName && !isAgentBusy;
+  const canShare = !!taskId && !!sessionId && shareableSessionStateClient(sessionState);
   // PRMergedBanner returns null internally when not applicable
   return (
     <div
@@ -322,6 +328,11 @@ function ChatStatusBar({
       {showTodos && <TodoIndicator todos={todoItems} />}
       <PRStatusChip taskId={taskId} />
       {taskId && <PRMergedBanner key={taskId} taskId={taskId} />}
+      {canShare && taskId && sessionId && (
+        <div className="ml-auto">
+          <ShareButton taskId={taskId} sessionId={sessionId} iconOnly />
+        </div>
+      )}
       {showProceed && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -329,7 +340,7 @@ function ChatStatusBar({
               type="button"
               variant="outline"
               size="sm"
-              className="ml-auto h-6 gap-1 px-2.5 text-xs cursor-pointer text-primary"
+              className={`${canShare ? "" : "ml-auto "}h-6 gap-1 px-2.5 text-xs cursor-pointer text-primary`}
               onClick={onProceed}
               disabled={isMoving}
               data-testid="proceed-next-step"
@@ -432,6 +443,8 @@ export function ChatInputArea({
       <ChatStatusBar
         todoItems={todoItems}
         taskId={taskId}
+        sessionId={resolvedSessionId}
+        sessionState={panelState.session?.state ?? null}
         nextStepName={proceedStepName}
         onProceed={proceed}
         isAgentBusy={isAgentBusy}

--- a/apps/web/components/task/share/share-button.tsx
+++ b/apps/web/components/task/share/share-button.tsx
@@ -58,7 +58,7 @@ export function ShareButton({ taskId, sessionId, iconOnly = false }: Props) {
     <>
       <Tooltip>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
-        <TooltipContent>Share this completed task with a public link</TooltipContent>
+        <TooltipContent>Share this task conversation as a public link</TooltipContent>
       </Tooltip>
       <ShareDialog open={open} onOpenChange={setOpen} taskId={taskId} sessionId={sessionId} />
     </>

--- a/apps/web/components/task/share/share-button.tsx
+++ b/apps/web/components/task/share/share-button.tsx
@@ -15,16 +15,32 @@ type Props = {
   iconOnly?: boolean;
 };
 
+// Matches the ghost-style action buttons in the dockview header bar so the
+// share entry point sits flush with the maximize/split/browser icons.
+const TOP_BAR_BUTTON_CLASS =
+  "h-6 w-6 p-0 cursor-pointer text-muted-foreground hover:bg-muted/70 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring";
+
 /**
  * Renders the "Share" entry point. Callers are responsible for gating
- * visibility on `session.state === "COMPLETED"`. Keeping that check at the
- * call site lets us hide the button entirely (rather than disabling it)
- * for in-progress tasks, which avoids visual noise.
+ * visibility on `session.state` via {@link shareableSessionStateClient};
+ * keeping that check at the call site lets us hide the button entirely
+ * (rather than disabling it) for unshareable sessions.
  */
 export function ShareButton({ taskId, sessionId, iconOnly = false }: Props) {
   const [open, setOpen] = useState(false);
 
-  const button = (
+  const button = iconOnly ? (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={() => setOpen(true)}
+      className={TOP_BAR_BUTTON_CLASS}
+      aria-label="Share this task"
+      data-testid="share-task-button"
+    >
+      <IconShare className="h-3.5 w-3.5" />
+    </Button>
+  ) : (
     <Button
       variant="outline"
       size="sm"
@@ -34,7 +50,7 @@ export function ShareButton({ taskId, sessionId, iconOnly = false }: Props) {
       data-testid="share-task-button"
     >
       <IconShare className="h-3.5 w-3.5" />
-      {!iconOnly && <span className="ml-1">Share</span>}
+      <span className="ml-1">Share</span>
     </Button>
   );
 
@@ -47,4 +63,14 @@ export function ShareButton({ taskId, sessionId, iconOnly = false }: Props) {
       <ShareDialog open={open} onOpenChange={setOpen} taskId={taskId} sessionId={sessionId} />
     </>
   );
+}
+
+// shareableSessionStateClient gates the Share entry point. Sessions that
+// haven't produced any conversation yet (CREATED / STARTING) have nothing
+// worth publishing; everything else — RUNNING, IDLE, WAITING_FOR_INPUT,
+// COMPLETED, FAILED, CANCELLED — gets the button. Backend enforces the
+// same rule (see internal/task/share/builder.go).
+export function shareableSessionStateClient(state?: string | null): boolean {
+  if (!state) return false;
+  return state !== "CREATED" && state !== "STARTING";
 }

--- a/apps/web/components/task/share/share-button.tsx
+++ b/apps/web/components/task/share/share-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { IconShare } from "@tabler/icons-react";
+
+import { Button } from "@kandev/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+
+import { ShareDialog } from "./share-dialog";
+
+type Props = {
+  taskId: string;
+  sessionId: string;
+  /** When true, render as an icon-only button suited for top bars. */
+  iconOnly?: boolean;
+};
+
+/**
+ * Renders the "Share" entry point. Callers are responsible for gating
+ * visibility on `session.state === "COMPLETED"`. Keeping that check at the
+ * call site lets us hide the button entirely (rather than disabling it)
+ * for in-progress tasks, which avoids visual noise.
+ */
+export function ShareButton({ taskId, sessionId, iconOnly = false }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const button = (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => setOpen(true)}
+      className="cursor-pointer"
+      aria-label="Share this task"
+      data-testid="share-task-button"
+    >
+      <IconShare className="h-3.5 w-3.5" />
+      {!iconOnly && <span className="ml-1">Share</span>}
+    </Button>
+  );
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent>Share this completed task with a public link</TooltipContent>
+      </Tooltip>
+      <ShareDialog open={open} onOpenChange={setOpen} taskId={taskId} sessionId={sessionId} />
+    </>
+  );
+}

--- a/apps/web/components/task/share/share-dialog.test.tsx
+++ b/apps/web/components/task/share/share-dialog.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+const previewShareMock = vi.fn();
+const createShareMock = vi.fn();
+const revokeShareMock = vi.fn();
+const listSharesMock = vi.fn();
+
+vi.mock("@/lib/api/domains/share-api", () => ({
+  previewShare: (...args: unknown[]) => previewShareMock(...args),
+  createShare: (...args: unknown[]) => createShareMock(...args),
+  revokeShare: (...args: unknown[]) => revokeShareMock(...args),
+  listShares: (...args: unknown[]) => listSharesMock(...args),
+}));
+
+import { ShareDialog } from "./share-dialog";
+
+const SAMPLE_SNAPSHOT = {
+  version: 1,
+  exported_at: "2026-05-21T12:00:00.000Z",
+  task: { title: "Investigate flake" },
+  session: {
+    agent_type: "claude-acp",
+    model: "claude-opus-4-7",
+    executor_type: "local_docker",
+    started_at: "2026-05-21T11:55:00.000Z",
+    completed_at: "2026-05-21T12:00:00.000Z",
+  },
+  messages: [
+    { role: "user" as const, ts: "now", blocks: [{ kind: "text" as const, text: "hello" }] },
+  ],
+  redaction: { applied_rules: ["abs-path"] },
+};
+
+beforeEach(() => {
+  previewShareMock.mockReset();
+  createShareMock.mockReset();
+  revokeShareMock.mockReset();
+  listSharesMock.mockReset();
+  listSharesMock.mockResolvedValue({ shares: [] });
+});
+
+describe("ShareDialog", () => {
+  it("loads the preview and shows the warning + publish button", async () => {
+    previewShareMock.mockResolvedValueOnce(SAMPLE_SNAPSHOT);
+    render(<ShareDialog open={true} onOpenChange={() => {}} taskId="t-1" sessionId="sess-1" />);
+
+    await waitFor(() => expect(previewShareMock).toHaveBeenCalled());
+    expect(await screen.findByText(/Anyone with this link can view/i)).toBeTruthy();
+    expect(await screen.findByRole("button", { name: /Publish to GitHub Gist/i })).toBeTruthy();
+    // Message body and redaction summary render.
+    expect(screen.getByText(/hello/)).toBeTruthy();
+    expect(screen.getByText(/Redacted: abs-path/)).toBeTruthy();
+  });
+
+  it("publishes on click and shows the URL with a copy button", async () => {
+    previewShareMock.mockResolvedValueOnce(SAMPLE_SNAPSHOT);
+    createShareMock.mockResolvedValueOnce({
+      id: "s-x",
+      url: "https://gist.github.com/u/abc",
+      created_at: "2026-05-21T12:00:00.000Z",
+      snapshot_size_bytes: 200,
+    });
+    render(<ShareDialog open={true} onOpenChange={() => {}} taskId="t-1" sessionId="sess-1" />);
+
+    const publishBtn = await screen.findByRole("button", { name: /Publish to GitHub Gist/i });
+    fireEvent.click(publishBtn);
+
+    await waitFor(() => expect(createShareMock).toHaveBeenCalledWith("t-1", "sess-1"));
+    expect(await screen.findByText(/https:\/\/gist\.github\.com\/u\/abc/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Copy/i })).toBeTruthy();
+  });
+
+  it("shows the error state when preview fails and offers retry", async () => {
+    previewShareMock.mockRejectedValueOnce(new Error("connect a GitHub account"));
+    render(<ShareDialog open={true} onOpenChange={() => {}} taskId="t-1" sessionId="sess-1" />);
+
+    expect(await screen.findByText(/connect a GitHub account/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Try again/i })).toBeTruthy();
+  });
+
+  it("renders an existing-shares row when listShares returns a share", async () => {
+    previewShareMock.mockResolvedValueOnce(SAMPLE_SNAPSHOT);
+    listSharesMock.mockResolvedValueOnce({
+      shares: [
+        {
+          id: "s-old",
+          url: "https://gist.github.com/u/old",
+          created_at: "2026-05-20T12:00:00.000Z",
+          snapshot_size_bytes: 100,
+        },
+      ],
+    });
+    render(<ShareDialog open={true} onOpenChange={() => {}} taskId="t-1" sessionId="sess-1" />);
+
+    expect(await screen.findByText(/Active shares for this session/)).toBeTruthy();
+    expect(screen.getByText(/https:\/\/gist\.github\.com\/u\/old/)).toBeTruthy();
+  });
+});

--- a/apps/web/components/task/share/share-dialog.tsx
+++ b/apps/web/components/task/share/share-dialog.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { IconAlertTriangle, IconCopy, IconExternalLink } from "@tabler/icons-react";
+
+import { Alert, AlertDescription } from "@kandev/ui/alert";
+import { Button } from "@kandev/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@kandev/ui/dialog";
+
+import {
+  createShare,
+  previewShare,
+  type Share,
+  type SnapshotPreview,
+} from "@/lib/api/domains/share-api";
+import { useShares } from "@/hooks/domains/session/use-shares";
+
+import { ShareList } from "./share-list";
+import { ShareSnapshotPreview } from "./share-snapshot-preview";
+
+type DialogState =
+  | { kind: "loading" }
+  | { kind: "preview"; snapshot: SnapshotPreview }
+  | { kind: "publishing"; snapshot: SnapshotPreview }
+  | { kind: "published"; share: Share }
+  | { kind: "error"; message: string };
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  taskId: string;
+  sessionId: string;
+};
+
+export function ShareDialog({ open, onOpenChange, taskId, sessionId }: Props) {
+  const [state, setState] = useState<DialogState>({ kind: "loading" });
+  const { shares, refresh } = useShares(open ? taskId : null, open ? sessionId : null);
+
+  const loadPreview = useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      const snapshot = await previewShare(taskId, sessionId);
+      setState({ kind: "preview", snapshot });
+    } catch (e) {
+      setState({
+        kind: "error",
+        message: e instanceof Error ? e.message : "Failed to load preview.",
+      });
+    }
+  }, [taskId, sessionId]);
+
+  useEffect(() => {
+    if (!open) return;
+    // Defer to a microtask so setState runs outside the synchronous effect
+    // body (react-hooks/set-state-in-effect).
+    void Promise.resolve().then(() => loadPreview());
+  }, [open, loadPreview]);
+
+  const handlePublish = useCallback(
+    async (snapshot: SnapshotPreview) => {
+      setState({ kind: "publishing", snapshot });
+      try {
+        const share = await createShare(taskId, sessionId);
+        setState({ kind: "published", share });
+        void refresh();
+      } catch (e) {
+        setState({
+          kind: "error",
+          message: e instanceof Error ? e.message : "Failed to publish share.",
+        });
+      }
+    },
+    [taskId, sessionId, refresh],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] w-full max-w-[min(640px,92vw)] flex-col gap-3 overflow-hidden sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Share this task</DialogTitle>
+          <DialogDescription>
+            Publish a redacted snapshot of this completed task as a secret GitHub Gist on your
+            account.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody
+          state={state}
+          shares={shares}
+          onPublish={handlePublish}
+          onRevoked={refresh}
+          onRetry={loadPreview}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type BodyProps = {
+  state: DialogState;
+  shares: Share[];
+  onPublish: (snapshot: SnapshotPreview) => void;
+  onRevoked: () => void;
+  onRetry: () => void;
+  onClose: () => void;
+};
+
+function DialogBody({ state, shares, onPublish, onRevoked, onRetry, onClose }: BodyProps) {
+  if (state.kind === "loading") {
+    return <p className="text-sm text-muted-foreground">Building preview…</p>;
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="flex flex-col gap-2">
+        <Alert variant="destructive">
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} className="cursor-pointer">
+            Close
+          </Button>
+          <Button onClick={onRetry} className="cursor-pointer">
+            Try again
+          </Button>
+        </DialogFooter>
+      </div>
+    );
+  }
+  if (state.kind === "published") {
+    return (
+      <PublishedState share={state.share} shares={shares} onRevoked={onRevoked} onClose={onClose} />
+    );
+  }
+  const snapshot = state.snapshot;
+  const isPublishing = state.kind === "publishing";
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-3 overflow-hidden">
+      <Alert>
+        <IconAlertTriangle className="h-4 w-4" />
+        <AlertDescription>
+          Anyone with this link can view this conversation. Review the preview carefully before
+          publishing — once published, the snapshot is uploaded to GitHub Gist on your account.
+        </AlertDescription>
+      </Alert>
+      <div className="flex min-w-0 flex-1 flex-col gap-3 overflow-y-auto pr-1">
+        <ShareList shares={shares} onRevoked={onRevoked} />
+        <ShareSnapshotPreview snapshot={snapshot} />
+      </div>
+      <DialogFooter>
+        <Button
+          variant="outline"
+          onClick={onClose}
+          disabled={isPublishing}
+          className="cursor-pointer"
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={() => onPublish(snapshot)}
+          disabled={isPublishing}
+          className="cursor-pointer"
+        >
+          {isPublishing ? "Publishing…" : "Publish to GitHub Gist"}
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}
+
+function PublishedState({
+  share,
+  shares,
+  onRevoked,
+  onClose,
+}: {
+  share: Share;
+  shares: Share[];
+  onRevoked: () => void;
+  onClose: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(share.url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-3 overflow-hidden">
+      <Alert>
+        <AlertDescription>
+          Published. Anyone with this link can view the conversation.
+        </AlertDescription>
+      </Alert>
+      <div className="flex min-w-0 items-center gap-2 rounded border bg-muted/30 p-2">
+        <a
+          href={share.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex min-w-0 flex-1 items-center gap-1 text-sm text-primary hover:underline cursor-pointer"
+        >
+          <IconExternalLink className="h-3 w-3 flex-shrink-0" />
+          <span className="min-w-0 flex-1 truncate" title={share.url}>
+            {share.url}
+          </span>
+        </a>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleCopy}
+          className="flex-shrink-0 cursor-pointer"
+        >
+          <IconCopy className="h-3 w-3" />
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </div>
+      <div className="min-w-0 flex-1 overflow-y-auto pr-1">
+        <ShareList shares={shares} onRevoked={onRevoked} />
+      </div>
+      <DialogFooter>
+        <Button onClick={onClose} className="cursor-pointer">
+          Done
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/apps/web/components/task/share/share-list.tsx
+++ b/apps/web/components/task/share/share-list.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { IconExternalLink, IconTrash } from "@tabler/icons-react";
+
+import { Button } from "@kandev/ui/button";
+
+import { revokeShare, type Share } from "@/lib/api/domains/share-api";
+
+type Props = {
+  shares: Share[];
+  onRevoked: () => void;
+};
+
+/**
+ * Renders the list of active (non-revoked) shares with a per-row revoke
+ * button. Revoke is optimistic: the API call fires; on success we call
+ * onRevoked() so the parent can refresh from the source of truth.
+ */
+export function ShareList({ shares, onRevoked }: Props) {
+  const active = shares.filter((s) => !s.revoked_at);
+  if (active.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 rounded border bg-muted/30 p-3">
+      <div className="text-xs font-medium text-muted-foreground">
+        Active shares for this session
+      </div>
+      <ul className="flex flex-col gap-1.5">
+        {active.map((share) => (
+          <ShareRow key={share.id} share={share} onRevoked={onRevoked} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ShareRow({ share, onRevoked }: { share: Share; onRevoked: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const handleRevoke = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      await revokeShare(share.id);
+      onRevoked();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to revoke share.");
+      setBusy(false);
+    }
+  };
+
+  return (
+    <li className="flex min-w-0 items-center justify-between gap-2 text-sm">
+      <a
+        href={share.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex min-w-0 flex-1 items-center gap-1 text-primary hover:underline cursor-pointer"
+      >
+        <IconExternalLink className="h-3 w-3 flex-shrink-0" />
+        <span className="min-w-0 flex-1 truncate" title={share.url}>
+          {share.url}
+        </span>
+      </a>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={handleRevoke}
+        disabled={busy}
+        className="flex-shrink-0 cursor-pointer"
+        aria-label="Revoke share"
+      >
+        <IconTrash className="h-3 w-3" />
+        {busy ? "Revoking…" : "Revoke"}
+      </Button>
+      {err && <span className="text-xs text-destructive">{err}</span>}
+    </li>
+  );
+}

--- a/apps/web/components/task/share/share-list.tsx
+++ b/apps/web/components/task/share/share-list.tsx
@@ -47,34 +47,40 @@ function ShareRow({ share, onRevoked }: { share: Share; onRevoked: () => void })
       onRevoked();
     } catch (e) {
       setErr(e instanceof Error ? e.message : "Failed to revoke share.");
+    } finally {
+      // Always clear busy — on success the row usually unmounts via the
+      // parent's refresh, but if it stays rendered (e.g. error path or a
+      // not-yet-reflected list) we don't want it stuck in "Revoking…".
       setBusy(false);
     }
   };
 
   return (
-    <li className="flex min-w-0 items-center justify-between gap-2 text-sm">
-      <a
-        href={share.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex min-w-0 flex-1 items-center gap-1 text-primary hover:underline cursor-pointer"
-      >
-        <IconExternalLink className="h-3 w-3 flex-shrink-0" />
-        <span className="min-w-0 flex-1 truncate" title={share.url}>
-          {share.url}
-        </span>
-      </a>
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={handleRevoke}
-        disabled={busy}
-        className="flex-shrink-0 cursor-pointer"
-        aria-label="Revoke share"
-      >
-        <IconTrash className="h-3 w-3" />
-        {busy ? "Revoking…" : "Revoke"}
-      </Button>
+    <li className="flex min-w-0 flex-col gap-1">
+      <div className="flex min-w-0 items-center justify-between gap-2 text-sm">
+        <a
+          href={share.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex min-w-0 flex-1 items-center gap-1 text-primary hover:underline cursor-pointer"
+        >
+          <IconExternalLink className="h-3 w-3 flex-shrink-0" />
+          <span className="min-w-0 flex-1 truncate" title={share.url}>
+            {share.url}
+          </span>
+        </a>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleRevoke}
+          disabled={busy}
+          className="flex-shrink-0 cursor-pointer"
+          aria-label="Revoke share"
+        >
+          <IconTrash className="h-3 w-3" />
+          {busy ? "Revoking…" : "Revoke"}
+        </Button>
+      </div>
       {err && <span className="text-xs text-destructive">{err}</span>}
     </li>
   );

--- a/apps/web/components/task/share/share-snapshot-preview.tsx
+++ b/apps/web/components/task/share/share-snapshot-preview.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Badge } from "@kandev/ui/badge";
+import { ScrollArea } from "@kandev/ui/scroll-area";
+
+import type { SnapshotPreview, SnapshotPreviewMessage } from "@/lib/api/domains/share-api";
+
+type Props = {
+  snapshot: SnapshotPreview;
+};
+
+// Long conversations would blow up the dialog. Cap what we render in the
+// preview to the first + last few messages; the published gist still has
+// the complete snapshot.
+const PREVIEW_HEAD = 8;
+const PREVIEW_TAIL = 8;
+
+/**
+ * Renders the redacted snapshot as a read-only preview. Intentionally not
+ * reusing NativeMessageList: the snapshot does not have the live Zustand
+ * shape the rich renderer expects, and a stripped-down view makes "this is
+ * exactly what will be published" easy to verify at a glance.
+ */
+export function ShareSnapshotPreview({ snapshot }: Props) {
+  const slices = previewSlices(snapshot.messages);
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        {snapshot.session.agent_type && (
+          <Badge variant="outline">{snapshot.session.agent_type}</Badge>
+        )}
+        {snapshot.session.model && <Badge variant="outline">{snapshot.session.model}</Badge>}
+        {snapshot.session.executor_type && (
+          <Badge variant="outline">{snapshot.session.executor_type}</Badge>
+        )}
+        <span>{snapshot.messages.length} messages</span>
+        {snapshot.redaction.applied_rules.length > 0 && (
+          <span>Redacted: {snapshot.redaction.applied_rules.join(", ")}</span>
+        )}
+      </div>
+      <ScrollArea className="h-72 rounded border bg-muted/30">
+        <div className="flex flex-col gap-3 p-3">
+          {snapshot.messages.length === 0 && (
+            <p className="text-sm text-muted-foreground italic">
+              This conversation has no shareable content.
+            </p>
+          )}
+          {slices.head.map((msg, idx) => (
+            <PreviewMessage key={`h-${idx}`} message={msg} />
+          ))}
+          {slices.hiddenCount > 0 && (
+            <p className="text-center text-xs text-muted-foreground italic py-1">
+              … {slices.hiddenCount} more message{slices.hiddenCount === 1 ? "" : "s"} hidden in
+              this preview (still included in the share) …
+            </p>
+          )}
+          {slices.tail.map((msg, idx) => (
+            <PreviewMessage key={`t-${idx}`} message={msg} />
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+// previewSlices splits the messages into a head + tail with a hidden count
+// in between when the conversation exceeds the per-section caps. Short
+// conversations come back as the full head with empty tail / zero hidden.
+function previewSlices(messages: SnapshotPreviewMessage[]): {
+  head: SnapshotPreviewMessage[];
+  tail: SnapshotPreviewMessage[];
+  hiddenCount: number;
+} {
+  if (messages.length <= PREVIEW_HEAD + PREVIEW_TAIL) {
+    return { head: messages, tail: [], hiddenCount: 0 };
+  }
+  return {
+    head: messages.slice(0, PREVIEW_HEAD),
+    tail: messages.slice(messages.length - PREVIEW_TAIL),
+    hiddenCount: messages.length - PREVIEW_HEAD - PREVIEW_TAIL,
+  };
+}
+
+function PreviewMessage({ message }: { message: SnapshotPreviewMessage }) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1 rounded border border-border/60 bg-background p-2">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {message.role}
+      </div>
+      <div className="flex min-w-0 flex-col gap-1">
+        {message.blocks.map((block, i) => (
+          <PreviewBlock key={i} block={block} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PreviewBlock({ block }: { block: SnapshotPreviewMessage["blocks"][number] }) {
+  if (block.kind === "text") {
+    return <p className="whitespace-pre-wrap break-words text-sm">{block.text}</p>;
+  }
+  if (block.kind === "tool_call") {
+    return (
+      <div className="min-w-0 rounded bg-muted/60 p-1.5 text-xs">
+        <div className="truncate font-mono" title={block.tool_name || "tool"}>
+          {block.tool_name || "tool"}
+        </div>
+        {block.text && (
+          <p className="truncate text-muted-foreground" title={block.text}>
+            {block.text}
+          </p>
+        )}
+      </div>
+    );
+  }
+  if (block.kind === "tool_result") {
+    return (
+      <pre className="max-w-full overflow-x-auto rounded bg-muted/60 p-1.5 text-xs">
+        <code>{block.output}</code>
+      </pre>
+    );
+  }
+  if (block.kind === "diff") {
+    return (
+      <div className="min-w-0 rounded bg-muted/60 p-1.5 text-xs">
+        <div className="truncate font-mono" title={block.path}>
+          {block.path}
+        </div>
+        <pre className="max-w-full overflow-x-auto whitespace-pre">
+          <code>{block.unified_diff}</code>
+        </pre>
+      </div>
+    );
+  }
+  return null;
+}

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -231,7 +231,7 @@ export const TaskChatPanel = memo(function TaskChatPanel({
         <SessionSearchOverlay search={search} agentLabel={agentLabel} agentName={agentName} />
       </PanelBody>
       <ClarificationSection
-        pendingClarification={pendingClarification}
+        pendingClarification={Boolean(pendingClarification)}
         isArchived={isArchived}
         containerRef={clarificationContainerRef}
         resizeProps={clarificationResizeProps}

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, memo } from "react";
-import { PanelRoot, PanelBody } from "./panel-primitives";
+import { useCallback, useEffect, useMemo, useRef, useState, memo, type RefObject } from "react";
+import { PanelRoot, PanelBody, PanelHeaderBarSplit } from "./panel-primitives";
+import { ShareButton } from "@/components/task/share/share-button";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { type ChatInputContainerHandle } from "@/components/task/chat/chat-input-container";
 import { MessageList } from "@/components/task/chat/message-list";
@@ -17,6 +18,7 @@ import { usePanelSearch } from "@/hooks/use-panel-search";
 import { useSessionSearch } from "@/hooks/domains/session/use-session-search";
 import { useLazyLoadMessages } from "@/hooks/use-lazy-load-messages";
 import { useAppStore } from "@/components/state-provider";
+import type { Message } from "@/lib/types/http";
 
 function useClarificationKey(agentMessageCount: number) {
   const lastCountRef = useRef(agentMessageCount);
@@ -185,20 +187,16 @@ export const TaskChatPanel = memo(function TaskChatPanel({
   // plan/terminal panels), so clicking a message leaves focus on <body>. Make
   // the panel root itself focusable and route non-interactive clicks to it so
   // Ctrl+F can detect focus within the session panel.
-  const handlePanelMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLElement | null;
-    if (!target) return;
-    // Exclude `tabindex="-1"` so we don't match PanelRoot itself (which is
-    // marked focus-receivable but shouldn't short-circuit this handler).
-    if (
-      target.closest(
-        "input, textarea, select, button, a, [contenteditable], [tabindex]:not([tabindex='-1'])",
-      )
-    ) {
-      return;
-    }
-    panelRef.current?.focus({ preventScroll: true });
-  }, []);
+  const handlePanelMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => routePanelMouseDown(e, panelRef),
+    [],
+  );
+
+  const sessionState = session?.state ?? null;
+  const shareIds =
+    taskId && resolvedSessionId && shareableSessionStateClient(sessionState)
+      ? { taskId, sessionId: resolvedSessionId }
+      : null;
 
   return (
     <PanelRoot
@@ -209,6 +207,11 @@ export const TaskChatPanel = memo(function TaskChatPanel({
       onMouseDown={handlePanelMouseDown}
       className="outline-none"
     >
+      {shareIds && (
+        <PanelHeaderBarSplit
+          right={<ShareButton taskId={shareIds.taskId} sessionId={shareIds.sessionId} iconOnly />}
+        />
+      )}
       <PanelBody padding={false} className="relative">
         <MessageList
           items={groupedItems}
@@ -227,40 +230,143 @@ export const TaskChatPanel = memo(function TaskChatPanel({
         />
         <SessionSearchOverlay search={search} agentLabel={agentLabel} agentName={agentName} />
       </PanelBody>
-      {pendingClarification && !isArchived && (
-        <div className="relative flex-shrink-0 border-t border-sky-400/30 bg-card">
-          <ResizeHandle {...clarificationResizeProps} />
-          <div
-            ref={clarificationContainerRef}
-            data-testid="clarification-overlay-container"
-            className="px-1 overflow-y-scroll overscroll-contain max-h-[50vh]"
-            style={clarificationHeight === null ? undefined : { height: clarificationHeight }}
-          >
-            <ClarificationInputOverlay
-              messages={pendingClarificationGroup}
-              onResolved={handleClarificationResolved}
-            />
-          </div>
-        </div>
-      )}
-      {isArchived ? (
-        <div className="bg-muted/50 flex-shrink-0 px-4 py-3 text-center text-sm text-muted-foreground border-t">
-          This task is archived and read-only.
-        </div>
-      ) : (
-        <ChatInputArea
-          chatInputRef={chatInputRef}
-          clarificationKey={clarificationKey}
-          onClarificationResolved={handleClarificationResolved}
-          handleSubmit={handleSubmit}
-          handleCancelTurn={handleCancelTurn}
-          showRequestChangesTooltip={showRequestChangesTooltip}
-          onRequestChangesTooltipDismiss={onRequestChangesTooltipDismiss}
-          panelState={panelState}
-          isSending={isSending}
-          hideSessionsDropdown={hideSessionsDropdown}
-        />
-      )}
+      <ClarificationSection
+        pendingClarification={pendingClarification}
+        isArchived={isArchived}
+        containerRef={clarificationContainerRef}
+        resizeProps={clarificationResizeProps}
+        height={clarificationHeight}
+        messages={pendingClarificationGroup}
+        onResolved={handleClarificationResolved}
+      />
+      <ChatFooter
+        isArchived={isArchived}
+        chatInputRef={chatInputRef}
+        clarificationKey={clarificationKey}
+        onClarificationResolved={handleClarificationResolved}
+        handleSubmit={handleSubmit}
+        handleCancelTurn={handleCancelTurn}
+        showRequestChangesTooltip={showRequestChangesTooltip}
+        onRequestChangesTooltipDismiss={onRequestChangesTooltipDismiss}
+        panelState={panelState}
+        isSending={isSending}
+        hideSessionsDropdown={hideSessionsDropdown}
+      />
     </PanelRoot>
   );
 });
+
+type ClarificationSectionProps = {
+  pendingClarification: boolean;
+  isArchived: boolean;
+  containerRef: RefObject<HTMLDivElement | null>;
+  resizeProps: { onMouseDown: (e: React.MouseEvent) => void; onDoubleClick: () => void };
+  height: number | null;
+  messages: readonly Message[] | null | undefined;
+  onResolved: () => void;
+};
+
+function ClarificationSection({
+  pendingClarification,
+  isArchived,
+  containerRef,
+  resizeProps,
+  height,
+  messages,
+  onResolved,
+}: ClarificationSectionProps) {
+  if (!pendingClarification || isArchived) return null;
+  return (
+    <div className="relative flex-shrink-0 border-t border-sky-400/30 bg-card">
+      <ResizeHandle {...resizeProps} />
+      <div
+        ref={containerRef}
+        data-testid="clarification-overlay-container"
+        className="px-1 overflow-y-scroll overscroll-contain max-h-[50vh]"
+        style={height === null ? undefined : { height }}
+      >
+        <ClarificationInputOverlay messages={messages} onResolved={onResolved} />
+      </div>
+    </div>
+  );
+}
+
+type ChatFooterProps = {
+  isArchived: boolean;
+  chatInputRef: RefObject<
+    import("@/components/task/chat/chat-input-container").ChatInputContainerHandle | null
+  >;
+  clarificationKey: number;
+  onClarificationResolved: () => void;
+  handleSubmit: ReturnType<typeof useSubmitHandler>["handleSubmit"];
+  handleCancelTurn: () => Promise<void>;
+  showRequestChangesTooltip: boolean;
+  onRequestChangesTooltipDismiss?: () => void;
+  panelState: ReturnType<typeof useChatPanelState>;
+  isSending: boolean;
+  hideSessionsDropdown?: boolean;
+};
+
+function ChatFooter({
+  isArchived,
+  chatInputRef,
+  clarificationKey,
+  onClarificationResolved,
+  handleSubmit,
+  handleCancelTurn,
+  showRequestChangesTooltip,
+  onRequestChangesTooltipDismiss,
+  panelState,
+  isSending,
+  hideSessionsDropdown,
+}: ChatFooterProps) {
+  if (isArchived) {
+    return (
+      <div className="bg-muted/50 flex-shrink-0 px-4 py-3 text-center text-sm text-muted-foreground border-t">
+        This task is archived and read-only.
+      </div>
+    );
+  }
+  return (
+    <ChatInputArea
+      chatInputRef={chatInputRef}
+      clarificationKey={clarificationKey}
+      onClarificationResolved={onClarificationResolved}
+      handleSubmit={handleSubmit}
+      handleCancelTurn={handleCancelTurn}
+      showRequestChangesTooltip={showRequestChangesTooltip}
+      onRequestChangesTooltipDismiss={onRequestChangesTooltipDismiss}
+      panelState={panelState}
+      isSending={isSending}
+      hideSessionsDropdown={hideSessionsDropdown}
+    />
+  );
+}
+
+// routePanelMouseDown routes non-interactive clicks to the panel root so that
+// Ctrl+F can detect focus within the session panel. Extracted to keep
+// TaskChatPanel's cyclomatic complexity within limits.
+const interactiveSelector =
+  "input, textarea, select, button, a, [contenteditable], [tabindex]:not([tabindex='-1'])";
+
+function routePanelMouseDown(
+  e: React.MouseEvent<HTMLDivElement>,
+  ref: React.RefObject<HTMLDivElement | null>,
+): void {
+  const target = e.target as HTMLElement | null;
+  if (!target) return;
+  // Exclude `tabindex="-1"` so we don't match PanelRoot itself (which is
+  // marked focus-receivable but shouldn't short-circuit this handler).
+  if (target.closest(interactiveSelector)) return;
+  ref.current?.focus({ preventScroll: true });
+}
+
+// shareableSessionStateClient gates the Share entry point. Sessions that
+// haven't produced any conversation yet (CREATED / STARTING) have nothing
+// worth publishing; everything else — RUNNING, IDLE, WAITING_FOR_INPUT,
+// COMPLETED, FAILED, CANCELLED — gets the button. Backend enforces the
+// same rule (see internal/task/share/builder.go).
+function shareableSessionStateClient(state?: string | null): boolean {
+  if (!state) return false;
+  return state !== "CREATED" && state !== "STARTING";
+}

--- a/apps/web/components/task/task-chat-panel.tsx
+++ b/apps/web/components/task/task-chat-panel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, memo, type RefObject } from "react";
-import { PanelRoot, PanelBody, PanelHeaderBarSplit } from "./panel-primitives";
-import { ShareButton } from "@/components/task/share/share-button";
+import { PanelRoot, PanelBody } from "./panel-primitives";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { type ChatInputContainerHandle } from "@/components/task/chat/chat-input-container";
 import { MessageList } from "@/components/task/chat/message-list";
@@ -192,12 +191,6 @@ export const TaskChatPanel = memo(function TaskChatPanel({
     [],
   );
 
-  const sessionState = session?.state ?? null;
-  const shareIds =
-    taskId && resolvedSessionId && shareableSessionStateClient(sessionState)
-      ? { taskId, sessionId: resolvedSessionId }
-      : null;
-
   return (
     <PanelRoot
       ref={panelRef}
@@ -207,11 +200,6 @@ export const TaskChatPanel = memo(function TaskChatPanel({
       onMouseDown={handlePanelMouseDown}
       className="outline-none"
     >
-      {shareIds && (
-        <PanelHeaderBarSplit
-          right={<ShareButton taskId={shareIds.taskId} sessionId={shareIds.sessionId} iconOnly />}
-        />
-      )}
       <PanelBody padding={false} className="relative">
         <MessageList
           items={groupedItems}
@@ -359,14 +347,4 @@ function routePanelMouseDown(
   // marked focus-receivable but shouldn't short-circuit this handler).
   if (target.closest(interactiveSelector)) return;
   ref.current?.focus({ preventScroll: true });
-}
-
-// shareableSessionStateClient gates the Share entry point. Sessions that
-// haven't produced any conversation yet (CREATED / STARTING) have nothing
-// worth publishing; everything else — RUNNING, IDLE, WAITING_FOR_INPUT,
-// COMPLETED, FAILED, CANCELLED — gets the button. Backend enforces the
-// same rule (see internal/task/share/builder.go).
-function shareableSessionStateClient(state?: string | null): boolean {
-  if (!state) return false;
-  return state !== "CREATED" && state !== "STARTING";
 }

--- a/apps/web/hooks/domains/session/use-shares.test.tsx
+++ b/apps/web/hooks/domains/session/use-shares.test.tsx
@@ -27,8 +27,10 @@ describe("useShares", () => {
     });
     const { result } = renderHook(() => useShares("t-1", "sess-1"));
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.shares).toHaveLength(1);
+    // Wait on the actual async outcome (shares populated) rather than
+    // isLoading flipping false, which can be true on the initial render
+    // before the effect resolves.
+    await waitFor(() => expect(result.current.shares).toHaveLength(1));
     expect(result.current.shares[0]?.id).toBe("s-1");
     expect(listSharesMock).toHaveBeenCalledWith("t-1", "sess-1");
   });
@@ -59,7 +61,7 @@ describe("useShares", () => {
       ],
     });
     const { result } = renderHook(() => useShares("t-1", "sess-1"));
-    await waitFor(() => expect(result.current.shares).toEqual([]));
+    await waitFor(() => expect(listSharesMock).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       await result.current.refresh();

--- a/apps/web/hooks/domains/session/use-shares.test.tsx
+++ b/apps/web/hooks/domains/session/use-shares.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+const listSharesMock = vi.fn();
+
+vi.mock("@/lib/api/domains/share-api", () => ({
+  listShares: (...args: unknown[]) => listSharesMock(...args),
+}));
+
+import { useShares } from "./use-shares";
+
+beforeEach(() => {
+  listSharesMock.mockReset();
+});
+
+describe("useShares", () => {
+  it("loads shares on mount and exposes them", async () => {
+    listSharesMock.mockResolvedValueOnce({
+      shares: [
+        {
+          id: "s-1",
+          url: "https://gist.github.com/u/a",
+          created_at: "2026-05-21T12:00:00.000Z",
+          snapshot_size_bytes: 100,
+        },
+      ],
+    });
+    const { result } = renderHook(() => useShares("t-1", "sess-1"));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.shares).toHaveLength(1);
+    expect(result.current.shares[0]?.id).toBe("s-1");
+    expect(listSharesMock).toHaveBeenCalledWith("t-1", "sess-1");
+  });
+
+  it("does not call listShares when ids are missing", async () => {
+    const { result } = renderHook(() => useShares(null, "sess-1"));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(listSharesMock).not.toHaveBeenCalled();
+    expect(result.current.shares).toEqual([]);
+  });
+
+  it("captures errors from the API", async () => {
+    listSharesMock.mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useShares("t-1", "sess-1"));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("boom");
+  });
+
+  it("refresh() re-fetches and updates state", async () => {
+    listSharesMock.mockResolvedValueOnce({ shares: [] }).mockResolvedValueOnce({
+      shares: [
+        {
+          id: "s-1",
+          url: "u",
+          created_at: "now",
+          snapshot_size_bytes: 1,
+        },
+      ],
+    });
+    const { result } = renderHook(() => useShares("t-1", "sess-1"));
+    await waitFor(() => expect(result.current.shares).toEqual([]));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.shares).toHaveLength(1);
+    expect(listSharesMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/hooks/domains/session/use-shares.ts
+++ b/apps/web/hooks/domains/session/use-shares.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { listShares, type Share } from "@/lib/api/domains/share-api";
+
+export type UseSharesResult = {
+  shares: Share[];
+  isLoading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+};
+
+/**
+ * Loads the list of share rows for a (taskId, sessionId) pair and exposes a
+ * manual refresh callback. Local component state only — shares are a
+ * low-frequency surface so we deliberately do NOT keep them in the Zustand
+ * store. The dialog calls refresh() after create/revoke to re-sync.
+ */
+export function useShares(taskId: string | null, sessionId: string | null): UseSharesResult {
+  const [shares, setShares] = useState<Share[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!taskId || !sessionId) {
+      setShares([]);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const resp = await listShares(taskId, sessionId);
+      setShares(resp.shares ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [taskId, sessionId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { shares, isLoading, error, refresh };
+}

--- a/apps/web/hooks/domains/session/use-shares.ts
+++ b/apps/web/hooks/domains/session/use-shares.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useState } from "react";
 
 import { listShares, type Share } from "@/lib/api/domains/share-api";
 
-export type UseSharesResult = {
+export interface UseSharesResult {
   shares: Share[];
   isLoading: boolean;
   error: Error | null;
   refresh: () => Promise<void>;
-};
+}
 
 /**
  * Loads the list of share rows for a (taskId, sessionId) pair and exposes a
@@ -22,7 +22,11 @@ export function useShares(taskId: string | null, sessionId: string | null): UseS
 
   const refresh = useCallback(async () => {
     if (!taskId || !sessionId) {
+      // Reset everything when no session is selected so a stale error from
+      // a previous session doesn't keep showing in the UI.
       setShares([]);
+      setError(null);
+      setIsLoading(false);
       return;
     }
     setIsLoading(true);

--- a/apps/web/lib/api/domains/share-api.test.ts
+++ b/apps/web/lib/api/domains/share-api.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/config", () => ({
+  getBackendConfig: () => ({ apiBaseUrl: "http://api.test" }),
+}));
+
+import {
+  createShare,
+  previewShare,
+  listShares,
+  revokeShare,
+  type Share,
+  type SnapshotPreview,
+} from "./share-api";
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+const fetchSpy = vi.fn<[FetchInput, FetchInit?], Promise<Response>>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function lastCall(): { url: string; init: FetchInit | undefined } {
+  const call = fetchSpy.mock.calls.at(-1);
+  if (!call) throw new Error("expected fetch to have been called");
+  return { url: String(call[0]), init: call[1] };
+}
+
+describe("createShare", () => {
+  it("POSTs to the nested task/session shares URL", async () => {
+    const share: Share = {
+      id: "s-1",
+      url: "https://gist.github.com/u/abc",
+      created_at: "2026-05-21T12:00:00.000Z",
+      snapshot_size_bytes: 1024,
+    };
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify(share), { status: 201 }));
+
+    const got = await createShare("t-1", "sess-1");
+
+    expect(got).toEqual(share);
+    const { url, init } = lastCall();
+    expect(url).toBe("http://api.test/api/v1/tasks/t-1/sessions/sess-1/shares");
+    expect(init?.method).toBe("POST");
+  });
+
+  it("url-encodes task and session ids", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 201 }));
+    await createShare("task/with/slashes", "sess-1");
+    expect(lastCall().url).toBe(
+      "http://api.test/api/v1/tasks/task%2Fwith%2Fslashes/sessions/sess-1/shares",
+    );
+  });
+});
+
+describe("previewShare", () => {
+  it("appends dry_run=true so the backend returns the snapshot inline", async () => {
+    const snap: SnapshotPreview = {
+      version: 1,
+      exported_at: "2026-05-21T12:00:00.000Z",
+      task: { title: "Hi" },
+      session: { started_at: "2026-05-21T11:00:00.000Z" },
+      messages: [],
+      redaction: { applied_rules: [] },
+    };
+    fetchSpy.mockResolvedValueOnce(jsonResponse(snap));
+
+    const got = await previewShare("t-1", "sess-1");
+
+    expect(got.task.title).toBe("Hi");
+    const { url, init } = lastCall();
+    expect(url).toBe("http://api.test/api/v1/tasks/t-1/sessions/sess-1/shares?dry_run=true");
+    expect(init?.method).toBe("POST");
+  });
+});
+
+describe("listShares", () => {
+  it("GETs the shares for a session", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ shares: [] }));
+    const got = await listShares("t-1", "sess-1");
+    expect(got).toEqual({ shares: [] });
+    const { url, init } = lastCall();
+    expect(url).toBe("http://api.test/api/v1/tasks/t-1/sessions/sess-1/shares");
+    expect(init?.method ?? "GET").toBe("GET");
+  });
+});
+
+describe("revokeShare", () => {
+  it("DELETEs by share id", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await revokeShare("s-1");
+    const { url, init } = lastCall();
+    expect(url).toBe("http://api.test/api/v1/shares/s-1");
+    expect(init?.method).toBe("DELETE");
+  });
+
+  it("propagates ApiError on non-2xx", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "missing" }), { status: 404 }),
+    );
+    await expect(revokeShare("s-1")).rejects.toThrow(/missing/);
+  });
+});

--- a/apps/web/lib/api/domains/share-api.ts
+++ b/apps/web/lib/api/domains/share-api.ts
@@ -1,0 +1,93 @@
+import { fetchJson, type ApiRequestOptions } from "../client";
+
+export type Share = {
+  id: string;
+  url: string;
+  created_at: string;
+  revoked_at?: string;
+  snapshot_size_bytes: number;
+};
+
+export type ListSharesResponse = {
+  shares: Share[];
+};
+
+// SnapshotPreview is the redacted snapshot returned by ?dry_run=true. The
+// shape mirrors share.Snapshot in the Go backend; only the fields the
+// preview UI renders today are typed here. Everything else is left as
+// unknown so the contract is the backend's responsibility to keep stable.
+export type SnapshotPreviewMessage = {
+  role: "user" | "assistant" | "system";
+  ts: string;
+  blocks: Array<{
+    kind: "text" | "tool_call" | "tool_result" | "diff";
+    text?: string;
+    tool_name?: string;
+    args?: unknown;
+    output?: string;
+    truncated?: boolean;
+    path?: string;
+    unified_diff?: string;
+  }>;
+};
+
+export type SnapshotPreview = {
+  version: number;
+  exported_at: string;
+  task: { title: string; workflow_step?: string };
+  session: {
+    agent_type?: string;
+    model?: string;
+    executor_type?: string;
+    started_at: string;
+    completed_at?: string;
+  };
+  messages: SnapshotPreviewMessage[];
+  redaction: { applied_rules: string[] };
+};
+
+export async function createShare(
+  taskId: string,
+  sessionId: string,
+  options?: ApiRequestOptions,
+): Promise<Share> {
+  return fetchJson<Share>(
+    `/api/v1/tasks/${encodeURIComponent(taskId)}/sessions/${encodeURIComponent(sessionId)}/shares`,
+    {
+      ...options,
+      init: { method: "POST", ...(options?.init ?? {}) },
+    },
+  );
+}
+
+export async function previewShare(
+  taskId: string,
+  sessionId: string,
+  options?: ApiRequestOptions,
+): Promise<SnapshotPreview> {
+  return fetchJson<SnapshotPreview>(
+    `/api/v1/tasks/${encodeURIComponent(taskId)}/sessions/${encodeURIComponent(sessionId)}/shares?dry_run=true`,
+    {
+      ...options,
+      init: { method: "POST", ...(options?.init ?? {}) },
+    },
+  );
+}
+
+export async function listShares(
+  taskId: string,
+  sessionId: string,
+  options?: ApiRequestOptions,
+): Promise<ListSharesResponse> {
+  return fetchJson<ListSharesResponse>(
+    `/api/v1/tasks/${encodeURIComponent(taskId)}/sessions/${encodeURIComponent(sessionId)}/shares`,
+    options,
+  );
+}
+
+export async function revokeShare(shareId: string, options?: ApiRequestOptions): Promise<void> {
+  await fetchJson<void>(`/api/v1/shares/${encodeURIComponent(shareId)}`, {
+    ...options,
+    init: { method: "DELETE", ...(options?.init ?? {}) },
+  });
+}

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -93,6 +93,7 @@ Subscription quota tracking and per-agent cheap-model profile routing.
 |---|---|
 | [improve-kandev](improve-kandev/spec.md) | draft |
 | [homebrew-core](homebrew-core/spec.md) | draft |
+| [public-share-links](public-share-links/spec.md) | draft |
 
 ---
 

--- a/docs/specs/public-share-links/spec.md
+++ b/docs/specs/public-share-links/spec.md
@@ -162,7 +162,7 @@ GET    /api/v1/tasks/:taskId/sessions/:sessionId/shares
 DELETE /api/v1/shares/:shareId
        -> 204
        Revokes a share: deletes the gist and marks the row revoked.
-```go
+```
 
 Internal Go surface:
 
@@ -183,7 +183,7 @@ type Backend interface {
     Upload(ctx context.Context, snap *Snapshot) (externalID, externalURL string, err error)
     Delete(ctx context.Context, externalID string) error
 }
-```text
+```
 
 ### Share URL format
 

--- a/docs/specs/public-share-links/spec.md
+++ b/docs/specs/public-share-links/spec.md
@@ -23,9 +23,13 @@ blob can be re-posted to the hosted service without code changes.
 
 ## What
 
-- A "Share" button appears in the task header **only when the session has
-  completed**. For an in-progress, queued, or failed session the button is
-  hidden.
+- A "Share" button appears in the chat panel header for any session past
+  the pre-history states (`CREATED` / `STARTING`). The button is hidden
+  while the session is still warming up — there is nothing worth
+  publishing yet — and visible for every other state (`RUNNING`, `IDLE`,
+  `WAITING_FOR_INPUT`, `COMPLETED`, `FAILED`, `CANCELLED`). Users can
+  share an in-progress conversation if they want to; the backend mirrors
+  this rule (see Failure modes).
 - Clicking Share opens a dialog with a **mandatory preview-and-confirm step**:
   the dialog renders the redacted snapshot in a read-only viewer that reuses
   the existing session message components, plus a visible warning that anyone
@@ -65,7 +69,7 @@ published. The frozen snapshot itself lives on the gist, not in the
 kandev DB; the table only records the metadata needed to manage and
 revoke shares.
 
-```
+```text
 task_shares
   id                  TEXT       PRIMARY KEY (uuid)
   task_session_id     TEXT       NOT NULL  -- soft reference; no FK constraint
@@ -97,7 +101,7 @@ URL is opened), and `README.md` (fallback for users who land on the gist
 directly). The JSON schema is the durable contract; the HTML and README
 are derived from it.
 
-```
+```text
 Snapshot
   version          int       -- 1
   kandev_version   string    -- version that produced the snapshot
@@ -136,7 +140,7 @@ HTTP surface. kandev's HTTP layer has no per-request user middleware
 today — authorisation is "this kandev instance can reach this task in its
 local store", same as every other task endpoint.
 
-```
+```http
 POST   /api/v1/tasks/:taskId/sessions/:sessionId/shares
        -> 201 { id, url, created_at, snapshot_size_bytes, revoked_at? }
        Builds and uploads a snapshot. Idempotency is not provided in v0;
@@ -158,7 +162,7 @@ GET    /api/v1/tasks/:taskId/sessions/:sessionId/shares
 DELETE /api/v1/shares/:shareId
        -> 204
        Revokes a share: deletes the gist and marks the row revoked.
-```
+```go
 
 Internal Go surface:
 
@@ -179,7 +183,7 @@ type Backend interface {
     Upload(ctx context.Context, snap *Snapshot) (externalID, externalURL string, err error)
     Delete(ctx context.Context, externalID string) error
 }
-```
+```text
 
 ### Share URL format
 
@@ -205,7 +209,7 @@ gistpreview-with-share.html form on every response.
 
 A share row has two states:
 
-```
+```text
 created --[user clicks Revoke OR DELETE /api/shares/:id]--> revoked
 ```
 
@@ -355,5 +359,3 @@ There is no "draft" or "scheduled" state; publish is synchronous.
   with no kandev row).
 - Embedding rich workspace context (file tree, repo HEAD SHA, agent
   config). v0 captures only what is needed to render the conversation.
-- Backporting to in-progress sessions. Only completed sessions can be
-  shared in v0.

--- a/docs/specs/public-share-links/spec.md
+++ b/docs/specs/public-share-links/spec.md
@@ -1,0 +1,359 @@
+---
+status: draft
+created: 2026-05-21
+owner: Kandev
+---
+
+# Public Share Links (v0)
+
+## Why
+
+When a user finishes a noteworthy task — an interesting bug-fix transcript, a
+clean refactor walkthrough, a teaching example — they have no way to send it
+to a teammate or post it externally without screenshotting message by message.
+A one-click "Share" that produces a stable public URL turns every completed
+task into a shareable artifact, drives word-of-mouth growth, and gives users
+a portable record of work they cared about.
+
+v0 ships with zero new server infrastructure: the snapshot is uploaded to a
+**secret-by-default GitHub Gist** on the user's own account, and the gist URL
+*is* the share link. A future v1 will introduce a hosted `share.kandev.com`
+service; the snapshot format produced in v0 is forward-compatible so the same
+blob can be re-posted to the hosted service without code changes.
+
+## What
+
+- A "Share" button appears in the task header **only when the session has
+  completed**. For an in-progress, queued, or failed session the button is
+  hidden.
+- Clicking Share opens a dialog with a **mandatory preview-and-confirm step**:
+  the dialog renders the redacted snapshot in a read-only viewer that reuses
+  the existing session message components, plus a visible warning that anyone
+  with the link will be able to view the conversation.
+- The user only publishes by clicking an explicit confirm button in the
+  dialog ("Publish to GitHub Gist"). The dialog never auto-publishes on open.
+- On publish, kandev builds a **frozen snapshot** of the session and uploads
+  it as a secret GitHub Gist on the user's authenticated GitHub account. The
+  dialog then shows the gist URL with a "Copy" button.
+- A snapshot is self-contained: it survives the underlying task, session, or
+  workspace being deleted from kandev. It MUST NOT contain foreign keys to
+  live kandev rows.
+- Every snapshot passes through a redaction pass before being uploaded:
+  - Absolute paths under the session's worktree root are rewritten to
+    repo-relative paths (`/Users/foo/proj/src/x.ts` → `src/x.ts`).
+  - Known secret shapes are stripped:
+    `sk-[a-zA-Z0-9]{20,}`, `ghp_[A-Za-z0-9]{36,}`, `gho_[A-Za-z0-9]{36,}`,
+    `github_pat_[A-Za-z0-9_]{36,}`, `AKIA[0-9A-Z]{16}`.
+  - The contents of any `.env*` file read or written via tool calls are
+    replaced with the placeholder `"[redacted: .env contents]"`.
+  - The `env` field on shell tool-call payloads is dropped entirely.
+- A list of "Active shares for this session" is reachable from the task
+  details surface, with a per-row **Revoke** action that deletes the gist
+  and marks the share row revoked.
+- Revoke is best-effort: if the gist is already gone on GitHub, the local
+  row is still marked revoked.
+- The Share button and the publish flow require an authenticated GitHub
+  user account on kandev (the same OAuth/PAT credential that powers the
+  existing GitHub integration). If GitHub credentials are missing, the
+  Share button surfaces a blocking error referencing the GitHub settings
+  page rather than opening the dialog.
+
+## Data model
+
+A new SQLite table `task_shares` records every share that has been
+published. The frozen snapshot itself lives on the gist, not in the
+kandev DB; the table only records the metadata needed to manage and
+revoke shares.
+
+```
+task_shares
+  id                  TEXT       PRIMARY KEY (uuid)
+  task_session_id     TEXT       NOT NULL  -- soft reference; no FK constraint
+  backend             TEXT       NOT NULL  -- "github_gist" in v0
+  external_id         TEXT       NOT NULL  -- gist ID
+  external_url        TEXT       NOT NULL  -- public gist URL (the share link)
+  snapshot_size_bytes INTEGER    NOT NULL
+  created_at          TIMESTAMP  NOT NULL
+  revoked_at          TIMESTAMP  NULL
+  view_count          INTEGER    NOT NULL DEFAULT 0
+```
+
+Notes:
+- `task_session_id` is a soft reference. Deleting the task does not cascade.
+  Lookups by `task_session_id` filter out rows whose session no longer
+  exists.
+- `backend` is reserved for forward-compat: v1 will add `"hosted"`. The
+  controller MUST reject unknown backends.
+- `view_count` is present on the schema for v1 but is always `0` in v0 (the
+  gist host tracks its own views; we do not poll for them).
+- The migration is applied through the standard `db.MigrateLogger.Apply`
+  pattern documented in CLAUDE.md.
+
+### Snapshot document
+
+The snapshot uploaded to the gist is `snapshot.json` (machine-readable
+contract), `share.html` (the kandev-styled rendering shown when the share
+URL is opened), and `README.md` (fallback for users who land on the gist
+directly). The JSON schema is the durable contract; the HTML and README
+are derived from it.
+
+```
+Snapshot
+  version          int       -- 1
+  kandev_version   string    -- version that produced the snapshot
+  exported_at      timestamp
+  task
+    title          string
+    workflow_step  string|null
+  session
+    agent_type     string    -- e.g. "claude-acp"
+    model          string|null
+    executor_type  string    -- "local_pc" | "local_docker" | "sprites" | ...
+    started_at     timestamp
+    completed_at   timestamp
+  messages: array of Message
+    Message
+      role         "user" | "assistant" | "system"
+      ts           timestamp
+      blocks: array of Block
+        Block      one of: TextBlock | ToolCallBlock | ToolResultBlock | DiffBlock
+  redaction
+    applied_rules  array<string>  -- e.g. ["abs-path", "secret-sk", "env-vars"]
+```
+
+Block shapes are intentionally narrow: a TextBlock carries `text`; a
+ToolCallBlock carries `name`, `args` (already redacted); a ToolResultBlock
+carries `output` (already redacted) and a boolean `truncated`; a DiffBlock
+carries `path` (repo-relative) and `unified_diff`.
+
+The snapshot has no references back into kandev's database, no agent IDs,
+no user IDs. It is intentionally portable.
+
+## API surface
+
+Endpoints live under the `/api/v1` prefix to match the rest of the kandev
+HTTP surface. kandev's HTTP layer has no per-request user middleware
+today — authorisation is "this kandev instance can reach this task in its
+local store", same as every other task endpoint.
+
+```
+POST   /api/v1/tasks/:taskId/sessions/:sessionId/shares
+       -> 201 { id, url, created_at, snapshot_size_bytes, revoked_at? }
+       Builds and uploads a snapshot. Idempotency is not provided in v0;
+       calling twice creates two gists.
+
+POST   /api/v1/tasks/:taskId/sessions/:sessionId/shares?dry_run=true
+       -> 200 <Snapshot JSON>
+       Returns the redacted snapshot that would be uploaded, without
+       calling the gist backend or persisting a row. Used by the modal
+       preview so the user sees exactly what will be published.
+
+GET    /api/v1/tasks/:taskId/sessions/:sessionId/shares
+       -> 200 { shares: [{ id, url, created_at, revoked_at, snapshot_size_bytes }] }
+       Lists every share row (including revoked) for the session. The
+       `url` field is always normalised to the current rendering URL
+       (gistpreview.github.io/?<id>/share.html) regardless of what's
+       stored.
+
+DELETE /api/v1/shares/:shareId
+       -> 204
+       Revokes a share: deletes the gist and marks the row revoked.
+```
+
+Internal Go surface:
+
+```go
+// internal/task/share
+type Snapshot struct{ /* shape above */ }
+type Service struct{ /* unexported */ }
+
+func BuildSnapshot(ctx context.Context, repo TaskReader, taskSessionID, kandevVersion string) (*Snapshot, error)
+
+func (s *Service) CreateShare(ctx context.Context, taskSessionID string) (*Share, error)
+func (s *Service) RevokeShare(ctx context.Context, shareID string) error
+func (s *Service) ListBySession(ctx context.Context, taskSessionID string) ([]*Share, error)
+func (s *Service) PreviewSnapshot(ctx context.Context, taskSessionID string) (*Snapshot, error)
+
+type Backend interface {
+    Name() string
+    Upload(ctx context.Context, snap *Snapshot) (externalID, externalURL string, err error)
+    Delete(ctx context.Context, externalID string) error
+}
+```
+
+### Share URL format
+
+The user-facing share URL routes through **gistpreview.github.io** — a
+static GitHub-Pages renderer that fetches the gist via the GitHub API and
+injects the HTML client-side. We use it instead of raw.githack.com because
+raw.githack shows a "One more step" anti-phishing interstitial on HTML
+files served from gists.
+
+Format: `https://gistpreview.github.io/?<gist_id>/share.html`
+
+The `/share.html` suffix is required: gistpreview's file picker defaults
+to the first iterated file (alphabetically `README.md` in our gists), so
+without an explicit filename the page renders raw markdown instead of the
+styled HTML.
+
+`displayURL` on the API layer normalises every legacy URL format
+(`gist.github.com/<owner>/<id>`, `gist.githack.com/<owner>/<id>/raw/share.html`,
+or a gistpreview URL missing the filename) to the canonical
+gistpreview-with-share.html form on every response.
+
+## State machine
+
+A share row has two states:
+
+```
+created --[user clicks Revoke OR DELETE /api/shares/:id]--> revoked
+```
+
+- `created` (`revoked_at IS NULL`): the gist is live; anyone with the URL
+  can view it.
+- `revoked` (`revoked_at IS NOT NULL`): the row is preserved for audit, but
+  the gist has been deleted and the URL returns 404.
+
+There is no "draft" or "scheduled" state; publish is synchronous.
+
+## Permissions
+
+- kandev's HTTP layer has no per-request user identity today; the
+  authorisation contract for share endpoints is the same as for every
+  other task endpoint — "this kandev instance can see this task in its
+  local store." If/when kandev grows multi-user, the same row filter that
+  scopes tasks scopes shares.
+- The GitHub credential used for the upload is the credential bound to
+  the running kandev instance. Shares are owned by that GitHub account,
+  not by a kandev service account.
+- No "team share" or "delegate to another user" surface in v0.
+
+## Failure modes
+
+- **Session has no shareable content yet** (state is `CREATED` or
+  `STARTING` — i.e., the agent hasn't run) when POSTing a share → API
+  returns `409 Conflict` with `code: "session_not_shareable"`. The Share
+  button is hidden in the UI for these states; the server enforces it as
+  the source of truth. Every other state (`RUNNING`, `IDLE`,
+  `WAITING_FOR_INPUT`, `COMPLETED`, `FAILED`, `CANCELLED`) is allowed —
+  users can share an in-progress conversation if they want to.
+- **No GitHub credential** on the kandev instance → API returns
+  `412 Precondition Failed` with `code: "github_credential_missing"`.
+  The UI surfaces a CTA to the GitHub settings page.
+- **GitHub API failure during upload** (network, rate limit, 5xx) → API
+  returns `502 Bad Gateway` with the upstream message. No row is
+  written. The user can retry; no partial state is left behind.
+- **Snapshot exceeds the gist size limit** (GitHub caps individual files
+  at 100 MiB; we set an internal soft cap of 10 MiB on `snapshot.json` to
+  stay well within practical limits) → API returns `413 Payload Too Large`
+  with `code: "snapshot_too_large"`. No upload is attempted.
+- **Revoke when the gist no longer exists on GitHub** (manually deleted by
+  the user from gist.github.com) → the row is still marked revoked and
+  the endpoint returns `204`. The discrepancy is logged at INFO level.
+- **Revoke when the GitHub credential has been removed** → the local row
+  is still marked revoked (so the share disappears from the UI list); a
+  warning is logged that the upstream gist may still exist. The user is
+  surfaced a non-blocking notice in the UI suggesting they delete the
+  gist manually from github.com.
+- **Redaction regex failure** (panic in a regex) → MUST NOT happen; the
+  redaction code is covered by tests for each rule. As a defense in depth,
+  any panic in the redaction pipeline aborts the publish with
+  `500 Internal Server Error` and no upload occurs.
+
+## Persistence guarantees
+
+- `task_shares` rows survive kandev restarts (standard SQLite durability).
+- The snapshot uploaded to the gist is **frozen at publish time** — later
+  edits to the task or session do not change what is on the gist. The
+  only way to update a published snapshot is to publish a new one.
+- No background workers, queues, or schedulers are introduced by this
+  feature. Publish and revoke are synchronous request handlers.
+- If kandev crashes mid-publish (between gist upload and DB insert), the
+  gist will exist on GitHub but no `task_shares` row will reference it.
+  The user can recover by deleting the gist manually from github.com.
+  v0 does not attempt to reconcile orphaned gists.
+
+## Scenarios
+
+- **GIVEN** a session past the pre-history states (anything other than
+  `CREATED` / `STARTING`), **WHEN** the task chat panel renders, **THEN**
+  a Share button is visible in the panel header.
+
+- **GIVEN** a session in `CREATED` or `STARTING` state, **WHEN** the task
+  chat panel renders, **THEN** the Share button is not visible.
+
+- **GIVEN** the Share dialog opens for a shareable session, **THEN**
+  the preview shows the redacted snapshot in head+tail form (first 8 +
+  last 8 messages, with a "…N hidden in this preview…" indicator when
+  the session is longer), the warning Alert is shown, and the publish
+  button is enabled.
+
+- **GIVEN** the preview dialog is open, **WHEN** the user clicks "Publish
+  to GitHub Gist", **THEN** kandev uploads a secret gist containing
+  `snapshot.json`, `share.html`, and `README.md`, inserts a `task_shares`
+  row, and the dialog displays the gistpreview URL with a copy button.
+
+- **GIVEN** an active share row, **WHEN** the user clicks Revoke, **THEN**
+  the gist is deleted from GitHub, the row is updated with `revoked_at`,
+  and the row disappears from the active-shares list.
+
+- **GIVEN** an active share row whose gist was manually deleted on
+  github.com, **WHEN** the user clicks Revoke, **THEN** the row is still
+  marked revoked, the API returns 204, and an INFO log records the
+  upstream 404.
+
+- **GIVEN** a snapshot that contains an absolute path under the session's
+  worktree root, **WHEN** the snapshot is built, **THEN** the path appears
+  in the snapshot as repo-relative and the `redaction.applied_rules` list
+  contains `"abs-path"`.
+
+- **GIVEN** a tool call argument containing the substring
+  `sk-abcdefghijklmnopqrstuv0123456789`, **WHEN** the snapshot is built,
+  **THEN** that substring is replaced with `[redacted]` in the snapshot
+  and `redaction.applied_rules` contains `"secret-sk"`.
+
+- **GIVEN** a shell tool call payload with a populated `env` field,
+  **WHEN** the snapshot is built, **THEN** the `env` field is omitted from
+  the snapshot payload.
+
+- **GIVEN** a message whose content is wrapped in `<kandev-system>` tags
+  (system-injected prompt context), **WHEN** the snapshot is built,
+  **THEN** the wrapped portion is stripped from the snapshot via the
+  shared `sysprompt.StripSystemContent` helper.
+
+- **GIVEN** an internal agent message of type `log`, `status`, `progress`,
+  `error`, `thinking`, `agent_plan`, `todo`, `permission_request`,
+  `clarification_request`, or `script_execution`, **WHEN** the snapshot
+  is built, **THEN** the message is dropped — only user messages, plain
+  agent prose (`message`/`content`/no type), and `tool_*` types make it
+  into the share.
+
+- **GIVEN** the user has not authenticated GitHub on their kandev account,
+  **WHEN** they click Share, **THEN** the dialog does not open; an inline
+  error references the GitHub settings page.
+
+- **GIVEN** a `snapshot.json` larger than the 10 MiB soft cap, **WHEN**
+  the user clicks Publish, **THEN** the request returns 413, no gist is
+  created, and the dialog shows a "snapshot too large" message.
+
+- **GIVEN** the GitHub gist API returns a 5xx during upload, **WHEN** the
+  user clicks Publish, **THEN** the request returns 502, no
+  `task_shares` row is written, and the dialog shows a retryable error.
+
+## Out of scope
+
+- The hosted `share.kandev.com` service. v0 is bring-your-own-store via
+  gist. v1 introduces hosting.
+- Editing or re-uploading a snapshot after publish. The only update path
+  in v0 is "publish a new share".
+- Accurate view count tracking. The schema reserves the column for v1 but
+  v0 always reports `0`.
+- Snapshot expiry policy / auto-revoke. Shares live until the user
+  explicitly revokes them or deletes the gist on GitHub directly.
+- Team / org / multi-user shares. v0 is per-user, owner-only.
+- Reconciliation of orphaned gists (where a crash leaves a gist on GitHub
+  with no kandev row).
+- Embedding rich workspace context (file tree, repo HEAD SHA, agent
+  config). v0 captures only what is needed to render the conversation.
+- Backporting to in-progress sessions. Only completed sessions can be
+  shared in v0.


### PR DESCRIPTION
A new "Share" entry in the chat panel header lets a user publish the current session's conversation as a secret GitHub Gist on their own account, so they can hand a styled, redacted snapshot to a teammate or post it externally without screenshotting. The share URL routes through gistpreview.github.io to render `share.html` as a kandev-themed page; `snapshot.json` rides along as the machine-readable companion for the future hosted-share service.

## Important Changes

- New `internal/task/share/` package owns the entire feature surface: snapshot builder + redactor, gist backend, `task_shares` SQLite table, HTTP handlers wired under `/api/v1/`. Provider is mounted in `cmd/kandev` alongside the other integration services.
- `github.Client` interface grows `CreateGist` / `DeleteGist`, with implementations in `pat_client.go`, `gh_client.go`, plus stubs in `noop_client.go` / `mock_client.go` / controller-test stub.
- Snapshots strip `<kandev-system>` blocks via the existing `sysprompt.StripSystemContent` helper and run a redaction pass (absolute paths → repo-relative, `sk-…` / `ghp_…` / `gho_…` / `github_pat_…` / `AKIA…` shapes, `.env*` contents, top-level shell `env` field). Message-type filtering whitelists user prose and `tool_*` types so internal noise (log/status/error/thinking/agent_plan/todo/permission_request/script_execution/etc.) never leaks into a share.
- Share URLs are normalised on every response to `gistpreview.github.io/?<id>/share.html` regardless of the legacy URL format stored in the DB; the explicit filename is required so gistpreview picks `share.html` rather than `README.md` (its file-picker defaults to the first iterated file).
- Spec at `docs/specs/public-share-links/spec.md`.

## Validation

- `make -C apps/backend test lint` — all green
- `pnpm --filter @kandev/web typecheck lint test` — all green; new tests for share-api, useShares hook, ShareDialog, plus backend unit tests for redaction (per rule), snapshot builder, repository CRUD, service create/revoke with mocked backend, gist backend with mock GitHub client, and HTTP handlers
- Manual: published & viewed a share end-to-end via gistpreview.github.io

## Possible Improvements

Snapshot size is currently bounded only by the 10 MiB hard cap on the gist `snapshot.json` — sessions much larger than that 413 with `snapshot_too_large`. Backend doesn't truncate or paginate yet; that's the v1 hosted-service story. Risk: low for typical sessions.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.