### PR TITLE
fix(cli): include node bin dir in service unit PATH for fnm/nvm/asdf/volta/mise

### DIFF
--- a/apps/cli/src/service/templates.test.ts
+++ b/apps/cli/src/service/templates.test.ts
@@ -116,6 +116,26 @@ describe("renderSystemdUnit", () => {
     );
   });
 
+  it("does not prepend '.' when nodePath has no POSIX separator (Windows-style or bare filename)", () => {
+    // path.dirname('C:\\...\\node.exe') === '.' on POSIX. Without the
+    // isAbsolute guard, this would put CWD first in the daemon's PATH —
+    // a privilege-escalation footgun the systemd unit must not introduce.
+    const unit = renderSystemdUnit({
+      launcher: {
+        nodePath: 'C:\\Program Files\\node "Node"\\node.exe',
+        cliEntry: "/home/alice/cli.js",
+        kind: "unknown",
+      },
+      homeDir: "/home/alice/.kandev",
+      logDir: "/home/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(unit).not.toMatch(/^Environment=PATH=\.:/m);
+    expect(unit).toContain(
+      "Environment=PATH=/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+    );
+  });
+
   it("quotes ExecStart paths that contain spaces", () => {
     const unit = renderSystemdUnit({
       launcher: {
@@ -175,6 +195,40 @@ describe("renderLaunchdPlist", () => {
       mode: "user",
     });
     // /opt/homebrew/bin already first in LAUNCHD_PATH — must not be doubled.
+    expect(plist).toContain(
+      "<key>PATH</key>\n      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>",
+    );
+  });
+
+  it("prepends node bin dir for system-mode LaunchDaemons too", () => {
+    const plist = renderLaunchdPlist({
+      launcher: {
+        nodePath: "/Users/alice/.volta/tools/image/node/24.14.0/bin/node",
+        cliEntry: "/Users/alice/.volta/tools/image/packages/kandev/bin/cli.js",
+        kind: "npm",
+      },
+      homeDir: "/Library/Application Support/kandev",
+      logDir: "/Library/Logs/kandev",
+      mode: "system",
+      systemUser: "_kandev",
+    });
+    expect(plist).toContain(
+      "<key>PATH</key>\n      <string>/Users/alice/.volta/tools/image/node/24.14.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>",
+    );
+  });
+
+  it("does not prepend '.' to plist PATH when nodePath has no POSIX separator", () => {
+    const plist = renderLaunchdPlist({
+      launcher: {
+        nodePath: "C:\\Program Files\\node\\node.exe",
+        cliEntry: "/home/alice/cli.js",
+        kind: "unknown",
+      },
+      homeDir: "/Users/alice/.kandev",
+      logDir: "/Users/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(plist).not.toMatch(/<key>PATH<\/key>\s*<string>\.:/);
     expect(plist).toContain(
       "<key>PATH</key>\n      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>",
     );

--- a/apps/cli/src/service/templates.test.ts
+++ b/apps/cli/src/service/templates.test.ts
@@ -17,6 +17,14 @@ const BREW_LAUNCHER: LauncherInfo = {
   version: "0.49.0",
 };
 
+// Versioned bin dir typical of per-user node managers (fnm/nvm/asdf/volta/mise).
+const FNM_LAUNCHER: LauncherInfo = {
+  nodePath: "/home/alice/.local/share/fnm/node-versions/v24.14.0/installation/bin/node",
+  cliEntry:
+    "/home/alice/.local/share/fnm/node-versions/v24.14.0/installation/lib/node_modules/kandev/bin/cli.js",
+  kind: "npm",
+};
+
 describe("renderSystemdUnit", () => {
   it("renders a user unit with absolute paths and --headless", () => {
     const unit = renderSystemdUnit({
@@ -69,6 +77,45 @@ describe("renderSystemdUnit", () => {
     expect(unit).toContain("Environment=KANDEV_SERVER_PORT=9000");
   });
 
+  it("prepends launcher node bin dir to PATH so npx-based agents resolve under fnm/nvm/asdf/volta/mise", () => {
+    const unit = renderSystemdUnit({
+      launcher: FNM_LAUNCHER,
+      homeDir: "/home/alice/.kandev",
+      logDir: "/home/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(unit).toContain(
+      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.14.0/installation/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+    );
+  });
+
+  it("does not duplicate node bin dir when it is already on the system PATH", () => {
+    const unit = renderSystemdUnit({
+      launcher: NPM_LAUNCHER,
+      homeDir: "/home/alice/.kandev",
+      logDir: "/home/alice/.kandev/logs",
+      mode: "user",
+    });
+    // /usr/local/bin already in SYSTEMD_PATH — dirname(nodePath) must not double it.
+    expect(unit).toContain(
+      "Environment=PATH=/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+    );
+    expect(unit).not.toContain("/usr/local/bin:/usr/local/bin");
+  });
+
+  it("prepends node bin dir for system-mode units too", () => {
+    const unit = renderSystemdUnit({
+      launcher: FNM_LAUNCHER,
+      homeDir: "/var/lib/kandev",
+      logDir: "/var/lib/kandev/logs",
+      mode: "system",
+      systemUser: "alice",
+    });
+    expect(unit).toContain(
+      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.14.0/installation/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+    );
+  });
+
   it("quotes ExecStart paths that contain spaces", () => {
     const unit = renderSystemdUnit({
       launcher: {
@@ -102,6 +149,35 @@ describe("renderLaunchdPlist", () => {
     expect(plist).toContain("<string>/Users/alice/.kandev/logs/service.err</string>");
     expect(plist).toContain("KANDEV_HOME_DIR");
     expect(plist).not.toContain("KANDEV_BUNDLE_DIR");
+  });
+
+  it("prepends launcher node bin dir to PATH for plists too (fnm/nvm/asdf/volta/mise)", () => {
+    const plist = renderLaunchdPlist({
+      launcher: {
+        nodePath: "/Users/alice/.volta/tools/image/node/24.14.0/bin/node",
+        cliEntry: "/Users/alice/.volta/tools/image/packages/kandev/bin/cli.js",
+        kind: "npm",
+      },
+      homeDir: "/Users/alice/.kandev",
+      logDir: "/Users/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(plist).toContain(
+      "<key>PATH</key>\n      <string>/Users/alice/.volta/tools/image/node/24.14.0/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>",
+    );
+  });
+
+  it("does not duplicate node bin dir in plist PATH when already present", () => {
+    const plist = renderLaunchdPlist({
+      launcher: BREW_LAUNCHER,
+      homeDir: "/Users/alice/.kandev",
+      logDir: "/Users/alice/.kandev/logs",
+      mode: "user",
+    });
+    // /opt/homebrew/bin already first in LAUNCHD_PATH — must not be doubled.
+    expect(plist).toContain(
+      "<key>PATH</key>\n      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>",
+    );
   });
 
   it("escapes XML special characters in paths", () => {

--- a/apps/cli/src/service/templates.ts
+++ b/apps/cli/src/service/templates.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import type { LauncherInfo } from "./paths";
 
 export type UnitInputs = {
@@ -19,6 +21,18 @@ export type UnitInputs = {
 const SYSTEMD_PATH =
   "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin";
 const LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+
+// Prepend the launcher node's bin dir so `npm`/`npx` resolve under per-user
+// node managers (fnm, nvm, asdf, volta, mise), where node lives in a versioned
+// subdirectory not covered by the system PATH. ExecStart already points at this
+// node, so its parent dir is exactly where the matching npm/npx live — without
+// this, npx-based ACP agents (claude, codex, opencode) fail to spawn.
+function pathWithNodeBinDir(basePath: string, nodePath: string): string {
+  const nodeBinDir = path.dirname(nodePath);
+  const parts = basePath.split(":");
+  if (parts.includes(nodeBinDir)) return basePath;
+  return `${nodeBinDir}:${basePath}`;
+}
 
 /**
  * Marker substring baked into every unit/plist kandev writes. Used to safely
@@ -45,7 +59,7 @@ export function renderSystemdUnit(input: UnitInputs): string {
   const env: string[] = [
     envLine("KANDEV_HOME_DIR", input.homeDir),
     envLine("KANDEV_LOG_LEVEL", "info"),
-    envLine("PATH", SYSTEMD_PATH),
+    envLine("PATH", pathWithNodeBinDir(SYSTEMD_PATH, input.launcher.nodePath)),
   ];
   if (input.port !== undefined) {
     env.push(envLine("KANDEV_SERVER_PORT", String(input.port)));
@@ -94,7 +108,7 @@ export function renderLaunchdPlist(input: UnitInputs): string {
   const envEntries: Array<[string, string]> = [
     ["KANDEV_HOME_DIR", input.homeDir],
     ["KANDEV_LOG_LEVEL", "info"],
-    ["PATH", LAUNCHD_PATH],
+    ["PATH", pathWithNodeBinDir(LAUNCHD_PATH, input.launcher.nodePath)],
   ];
   if (input.port !== undefined) {
     envEntries.push(["KANDEV_SERVER_PORT", String(input.port)]);

--- a/apps/cli/src/service/templates.ts
+++ b/apps/cli/src/service/templates.ts
@@ -27,8 +27,16 @@ const LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
 // subdirectory not covered by the system PATH. ExecStart already points at this
 // node, so its parent dir is exactly where the matching npm/npx live — without
 // this, npx-based ACP agents (claude, codex, opencode) fail to spawn.
+//
+// The isAbsolute guard exists because `path.dirname` on POSIX returns `'.'`
+// for a path with no `/` separator (e.g. a Windows-style `C:\…\node.exe`
+// passed through). Prepending `.` would put CWD ahead of system dirs in the
+// daemon's PATH — a privilege-escalation footgun. Production callers always
+// pass `process.execPath` (absolute on Linux/macOS), so the guard only kicks
+// in for non-POSIX or relative inputs from future callers / tests.
 function pathWithNodeBinDir(basePath: string, nodePath: string): string {
   const nodeBinDir = path.dirname(nodePath);
+  if (!path.isAbsolute(nodeBinDir)) return basePath;
   const parts = basePath.split(":");
   if (parts.includes(nodeBinDir)) return basePath;
   return `${nodeBinDir}:${basePath}`;


### PR DESCRIPTION
## Summary

Fixes #996. `kandev service install` generates units with a hard-coded system-only PATH. Under per-user node managers (fnm, nvm, asdf, volta, mise), node lives in a versioned subdirectory not on that PATH, so the daemon could `exec` node (`ExecStart` resolves the absolute path via `captureLauncher()`) but could **not** `exec npx`. Every ACP agent built with `npx -y <bridge-pkg>` — Claude (`@agentclientprotocol/claude-agent-acp`), Codex, OpenCode, etc. — failed at spawn time with `peer disconnected before response`.

Implements **option 1** from the issue: prepend `path.dirname(launcher.nodePath)` to the unit's PATH for both systemd and launchd. That's exactly the bin dir containing the matching `npm`/`npx` for whichever node was used to install the service, with no manager-specific knowledge.

A small `pathWithNodeBinDir()` helper dedups when the node bin dir is already in the base PATH (e.g. `/usr/local/bin/node` doesn't double `/usr/local/bin`).

System-mode units get the same prepend — if the operator installed via fnm under `sudo`, the captured node lives there and `ExecStart` still points at it.

Caveat noted in the issue: this pins to a node-version-specific dir. Survives node upgrades only if the user re-runs `kandev service install` after switching versions. That's acceptable; a stale-unit nudge is orthogonal.

## Test plan
- [x] `vitest run src/service/templates.test.ts` — 17 tests pass (5 new):
  - fnm-style launcher → PATH starts with the versioned node bin dir (systemd + launchd)
  - npm/brew launcher already on system PATH → no duplication
  - system-mode unit also gets the prepend
- [x] Existing PATH-related tests unchanged (dedup keeps `NPM_LAUNCHER` / `BREW_LAUNCHER` output identical to before).
- [ ] Manual: `fnm use 24.14.0 && npm i -g kandev && kandev service install`, restart, verify probe for `claude-acp` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)