### PR TITLE
fix(kanban): stop stuck spinner by writing task.state=REVIEW on engine on_turn_complete

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1828,9 +1828,20 @@ func (s *Service) applyEngineTransition(
 	// Flip to WAITING_FOR_INPUT so that autoStartStepPrompt in processOnEnter sends
 	// the prompt directly instead of queueing it — the queue would never be drained
 	// because handleAgentReady already returned.
+	//
+	// Mirror setSessionWaitingForInput's task-state side effect: write
+	// tasks.state = REVIEW so the kanban card drops out of IN_PROGRESS. Without
+	// this, an engine-driven on_turn_complete transition would persist the
+	// new workflow step + flip the session but leave tasks.state stale at
+	// IN_PROGRESS, leaving the spinner spinning in the new column even though
+	// the agent has paused. If the target step's on_enter starts another agent,
+	// setSessionRunning will flip tasks.state back to IN_PROGRESS — the
+	// REVIEW write is a safe intermediate that any active-running follow-up
+	// will overwrite.
 	if session.State == models.TaskSessionStateRunning || session.State == models.TaskSessionStateStarting {
 		s.updateTaskSessionState(ctx, taskID, session.ID, models.TaskSessionStateWaitingForInput, "", false, session)
 		session.State = models.TaskSessionStateWaitingForInput
+		s.writeTaskReviewState(ctx, taskID)
 	}
 
 	// Launch processOnEnter asynchronously to avoid blocking the stream reader goroutine.

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/task/models"
@@ -406,5 +408,58 @@ func assertSessionState(t *testing.T, ctx context.Context, repo sessionExecutorS
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Regression for #985: an on_turn_complete engine transition flips the
+// session to WAITING_FOR_INPUT and moves the task to the next step, but the
+// pre-fix code path forgot to write tasks.state = REVIEW. That left the
+// kanban card stuck in IN_PROGRESS — with a spinning loader — even though
+// the agent had paused and the card had already moved into the "Review"
+// column. Mirrors what setSessionWaitingForInput (the non-engine path)
+// has always done via writeTaskReviewState.
+//
+// The chosen transition is "New Step" → "Done": "Done" has no on_enter, so
+// no follow-up action can mask the missing write (e.g. auto_start_agent
+// would otherwise overwrite tasks.state back to IN_PROGRESS via
+// setSessionRunning).
+func TestProcessOnTurnCompleteViaEngine_WritesTaskStateReview(t *testing.T) {
+	ctx := context.Background()
+
+	sg, nameToID := buildWorkflowFromJSON(t, developmentWorkflowJSON)
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", nameToID["New Step"])
+	setSessionExecID(t, repo, "s1", "exec-1")
+	setSessionState(t, ctx, repo, "s1", models.TaskSessionStateRunning)
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	taskRepo := newMockTaskRepo()
+	svc := createEngineService(t, repo, sg, agentMgr)
+	svc.taskRepo = taskRepo
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+
+	transitioned := svc.processOnTurnCompleteViaEngine(ctx, "t1", session)
+	if !transitioned {
+		t.Fatalf("expected a transition from New Step → Done, got none")
+	}
+
+	// processOnEnter launches asynchronously; the task-state write happens
+	// synchronously inside applyEngineTransition so it's already visible,
+	// but give the engine path a tick to settle in case anything else races.
+	time.Sleep(100 * time.Millisecond)
+
+	assertStepByName(t, ctx, repo, "s1", "Done", nameToID)
+	assertSessionState(t, ctx, repo, "s1", models.TaskSessionStateWaitingForInput)
+
+	got, ok := taskRepo.updatedStates["t1"]
+	if !ok {
+		t.Fatalf("expected tasks.state to be updated, but UpdateTaskState was never called")
+	}
+	if got != v1.TaskStateReview {
+		t.Errorf("tasks.state = %q, want %q (the kanban card would still show the spinner)", got, v1.TaskStateReview)
 	}
 }

--- a/apps/backend/internal/orchestrator/workflow_e2e_test.go
+++ b/apps/backend/internal/orchestrator/workflow_e2e_test.go
@@ -447,11 +447,10 @@ func TestProcessOnTurnCompleteViaEngine_WritesTaskStateReview(t *testing.T) {
 		t.Fatalf("expected a transition from New Step → Done, got none")
 	}
 
-	// processOnEnter launches asynchronously; the task-state write happens
-	// synchronously inside applyEngineTransition so it's already visible,
-	// but give the engine path a tick to settle in case anything else races.
-	time.Sleep(100 * time.Millisecond)
-
+	// writeTaskReviewState and ApplyTransition both run synchronously inside
+	// applyEngineTransition (before processOnEnter's goroutine), so the
+	// task-state and step assertions need no async wait. assertSessionState
+	// has its own polling loop for the WAITING_FOR_INPUT flip.
 	assertStepByName(t, ctx, repo, "s1", "Done", nameToID)
 	assertSessionState(t, ctx, repo, "s1", models.TaskSessionStateWaitingForInput)
 

--- a/apps/web/components/kanban-card-content.tsx
+++ b/apps/web/components/kanban-card-content.tsx
@@ -17,7 +17,11 @@ import {
 import { useAppStore } from "@/components/state-provider";
 import { RemoteCloudTooltip } from "@/components/task/remote-cloud-tooltip";
 import { useTaskPendingClarification } from "@/hooks/use-task-pending-clarification";
-import { getTaskStateIcon, shouldUseQuestionTaskIcon } from "@/lib/ui/state-icons";
+import {
+  getTaskStateIcon,
+  shouldShowTaskRunningSpinner,
+  shouldUseQuestionTaskIcon,
+} from "@/lib/ui/state-icons";
 import { cn } from "@/lib/utils";
 import { needsAction } from "@/lib/utils/needs-action";
 import type { Task } from "@/components/kanban-card";
@@ -188,14 +192,14 @@ function KanbanCardActions({
   const effectiveMenuOpen = menuOpen || Boolean(isDeleting) || Boolean(isArchiving);
   const hasPendingClarificationRequest = useTaskPendingClarification(task.primarySessionId);
   const showQuestionIcon = shouldUseQuestionTaskIcon(task.state, hasPendingClarificationRequest);
+  const showRunningSpinner = shouldShowTaskRunningSpinner(task.state, task.primarySessionState);
   const statusIcon = getTaskStateIcon(task.state, "h-4 w-4", hasPendingClarificationRequest);
   const hasKnownSession =
     Boolean(task.primarySessionId) || Boolean(task.sessionCount && task.sessionCount > 0);
 
   return (
     <div className="flex items-center gap-2">
-      {(task.state === "IN_PROGRESS" || task.state === "SCHEDULING" || showQuestionIcon) &&
-        statusIcon}
+      {(showRunningSpinner || showQuestionIcon) && statusIcon}
       {showMaximizeButton && onOpenFullPage && hasKnownSession && (
         <button
           type="button"

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -27,6 +27,12 @@ export interface Task {
   repositories?: Array<{ id: string; repository_id: string; position: number }>;
   sessionCount?: number | null;
   primarySessionId?: string | null;
+  /**
+   * Primary session's runtime state. Decoupled from `state` (the workflow
+   * column). Used to suppress the running-spinner when the agent has already
+   * finished — the workflow may leave the task in IN_PROGRESS for review.
+   */
+  primarySessionState?: string | null;
   reviewStatus?: "pending" | "approved" | "changes_requested" | "rejected" | null;
   primaryExecutorId?: string | null;
   primaryExecutorType?: string | null;

--- a/apps/web/lib/ui/state-icons.test.tsx
+++ b/apps/web/lib/ui/state-icons.test.tsx
@@ -23,12 +23,13 @@ describe("getTaskStateIcon", () => {
 });
 
 describe("shouldShowTaskRunningSpinner", () => {
-  it("returns false for terminal task states", () => {
+  it("returns false for non-loading task states regardless of session state", () => {
     expect(shouldShowTaskRunningSpinner("COMPLETED")).toBe(false);
     expect(shouldShowTaskRunningSpinner("FAILED")).toBe(false);
     expect(shouldShowTaskRunningSpinner("CANCELLED")).toBe(false);
     expect(shouldShowTaskRunningSpinner("REVIEW")).toBe(false);
     expect(shouldShowTaskRunningSpinner("TODO")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("REVIEW", "RUNNING")).toBe(false);
   });
 
   it("returns true for SCHEDULING with no primary session yet", () => {
@@ -37,21 +38,31 @@ describe("shouldShowTaskRunningSpinner", () => {
     expect(shouldShowTaskRunningSpinner("SCHEDULING", undefined)).toBe(true);
   });
 
-  it("returns true for IN_PROGRESS with a non-terminal primary session", () => {
+  it("returns true for IN_PROGRESS when the primary session is actively running", () => {
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "RUNNING")).toBe(true);
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "STARTING")).toBe(true);
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "CREATED")).toBe(true);
+  });
+
+  it("returns true for IN_PROGRESS when no primary session is attached yet", () => {
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", undefined)).toBe(true);
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", null)).toBe(true);
   });
 
-  it("suppresses the spinner when the primary session has reached a terminal state", () => {
-    // The repro from issue #985: agent finishes (session → COMPLETED) but the
+  it("suppresses the spinner when the primary session is terminal", () => {
+    // Repro from issue #985: agent finishes (session → COMPLETED) but the
     // workflow leaves the task in IN_PROGRESS for review/manual move. The
     // spinner must not keep spinning forever.
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "COMPLETED")).toBe(false);
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "FAILED")).toBe(false);
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "CANCELLED")).toBe(false);
     expect(shouldShowTaskRunningSpinner("SCHEDULING", "COMPLETED")).toBe(false);
+  });
+
+  it("suppresses the spinner when the primary session is paused (waiting/idle)", () => {
+    // Same desync class, paused branch: agent stopped to wait for input or
+    // was torn down (office IDLE). The spinner is misleading.
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "WAITING_FOR_INPUT")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "IDLE")).toBe(false);
   });
 });

--- a/apps/web/lib/ui/state-icons.test.tsx
+++ b/apps/web/lib/ui/state-icons.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { isValidElement, type ReactNode } from "react";
 import { IconCheck, IconMessageQuestion } from "@tabler/icons-react";
-import { getTaskStateIcon } from "./state-icons";
+import { getTaskStateIcon, shouldShowTaskRunningSpinner } from "./state-icons";
 
 function iconType(node: ReactNode) {
   if (!isValidElement(node)) throw new Error("Expected React element");
@@ -19,5 +19,39 @@ describe("getTaskStateIcon", () => {
 
   it("keeps review task state as the review check without pending clarification", () => {
     expect(iconType(getTaskStateIcon("REVIEW", undefined, false))).toBe(IconCheck);
+  });
+});
+
+describe("shouldShowTaskRunningSpinner", () => {
+  it("returns false for terminal task states", () => {
+    expect(shouldShowTaskRunningSpinner("COMPLETED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("FAILED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("CANCELLED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("REVIEW")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("TODO")).toBe(false);
+  });
+
+  it("returns true for SCHEDULING with no primary session yet", () => {
+    expect(shouldShowTaskRunningSpinner("SCHEDULING")).toBe(true);
+    expect(shouldShowTaskRunningSpinner("SCHEDULING", null)).toBe(true);
+    expect(shouldShowTaskRunningSpinner("SCHEDULING", undefined)).toBe(true);
+  });
+
+  it("returns true for IN_PROGRESS with a non-terminal primary session", () => {
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "RUNNING")).toBe(true);
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "STARTING")).toBe(true);
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "CREATED")).toBe(true);
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", undefined)).toBe(true);
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", null)).toBe(true);
+  });
+
+  it("suppresses the spinner when the primary session has reached a terminal state", () => {
+    // The repro from issue #985: agent finishes (session → COMPLETED) but the
+    // workflow leaves the task in IN_PROGRESS for review/manual move. The
+    // spinner must not keep spinning forever.
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "COMPLETED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "FAILED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "CANCELLED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("SCHEDULING", "COMPLETED")).toBe(false);
   });
 });

--- a/apps/web/lib/ui/state-icons.tsx
+++ b/apps/web/lib/ui/state-icons.tsx
@@ -72,6 +72,32 @@ export function shouldUseQuestionTaskIcon(
   return isWaitingForInputState(state) || hasPendingClarification;
 }
 
+const TERMINAL_SESSION_STATES: ReadonlySet<string> = new Set<TaskSessionState>([
+  "COMPLETED",
+  "FAILED",
+  "CANCELLED",
+]);
+
+export function isTerminalSessionState(state?: string | null): boolean {
+  return Boolean(state) && TERMINAL_SESSION_STATES.has(state as string);
+}
+
+/**
+ * Returns true when the kanban card should show the spinning loader for an
+ * in-progress task. The task state can stay in IN_PROGRESS after the agent's
+ * session has reached a terminal state (the workflow leaves the card in its
+ * current column until the user — or a transition action — moves it). In
+ * that case the spinner is misleading, so suppress it whenever the primary
+ * session is in a terminal state.
+ */
+export function shouldShowTaskRunningSpinner(
+  taskState?: TaskState,
+  primarySessionState?: string | null,
+): boolean {
+  if (taskState !== "IN_PROGRESS" && taskState !== "SCHEDULING") return false;
+  return !isTerminalSessionState(primarySessionState);
+}
+
 export function shouldUsePermissionTaskIcon(hasPendingPermission = false): boolean {
   return hasPendingPermission;
 }

--- a/apps/web/lib/ui/state-icons.tsx
+++ b/apps/web/lib/ui/state-icons.tsx
@@ -72,30 +72,34 @@ export function shouldUseQuestionTaskIcon(
   return isWaitingForInputState(state) || hasPendingClarification;
 }
 
-const TERMINAL_SESSION_STATES: ReadonlySet<string> = new Set<TaskSessionState>([
-  "COMPLETED",
-  "FAILED",
-  "CANCELLED",
+// Session states where the agent is actively running work. Anything outside
+// this set (WAITING_FOR_INPUT, IDLE, COMPLETED, FAILED, CANCELLED) is paused
+// or terminal and must not drive the spinner — even when the task is still
+// in the IN_PROGRESS workflow column.
+const ACTIVE_SESSION_STATES: ReadonlySet<string> = new Set<TaskSessionState>([
+  "CREATED",
+  "STARTING",
+  "RUNNING",
 ]);
-
-export function isTerminalSessionState(state?: string | null): boolean {
-  return Boolean(state) && TERMINAL_SESSION_STATES.has(state as string);
-}
 
 /**
  * Returns true when the kanban card should show the spinning loader for an
- * in-progress task. The task state can stay in IN_PROGRESS after the agent's
- * session has reached a terminal state (the workflow leaves the card in its
- * current column until the user — or a transition action — moves it). In
- * that case the spinner is misleading, so suppress it whenever the primary
- * session is in a terminal state.
+ * in-progress task. The task workflow state and the primary session's runtime
+ * state are decoupled — the workflow can keep a task in `IN_PROGRESS` after
+ * the agent has finished, errored, or paused waiting for input — so we gate
+ * the spinner on the primary session being actively running.
+ *
+ * When no primary session is attached yet (task just created / scheduling),
+ * we still show the spinner so users see the imminent work; otherwise we
+ * require an active session state.
  */
 export function shouldShowTaskRunningSpinner(
   taskState?: TaskState,
   primarySessionState?: string | null,
 ): boolean {
   if (taskState !== "IN_PROGRESS" && taskState !== "SCHEDULING") return false;
-  return !isTerminalSessionState(primarySessionState);
+  if (!primarySessionState) return true;
+  return ACTIVE_SESSION_STATES.has(primarySessionState);
 }
 
 export function shouldUsePermissionTaskIcon(hasPendingPermission = false): boolean {


### PR DESCRIPTION
## Summary

Issue #985 has **two** root causes — one backend, one frontend. Both fixed here.

### Backend bug (the actual root cause)

When the workflow engine's `on_turn_complete` action moves a task to the next step, `applyEngineTransition` persists the new `workflow_step_id` and flips the session to `WAITING_FOR_INPUT` — but **forgets to write `tasks.state = REVIEW`**. The non-engine path (`setSessionWaitingForInput → writeTaskReviewState` in `event_handlers_streaming.go:546`) has always done this; the engine path silently dropped it.

Result: `tasks.workflow_step_id` points to "Review", `task_sessions.state` is `WAITING_FOR_INPUT`, but `tasks.state` stays `IN_PROGRESS`. The kanban card sits in the Review column with the blue spinner spinning forever. Confirmed reproducible on a live database (task `1cf3eccf-…` had `tasks.state=IN_PROGRESS` while session was `WAITING_FOR_INPUT` and step was "Review").

Fix: mirror the non-engine path — call `s.writeTaskReviewState(ctx, taskID)` inside the `RUNNING/STARTING → WAITING_FOR_INPUT` branch of `applyEngineTransition`. Added `TestProcessOnTurnCompleteViaEngine_WritesTaskStateReview` in `workflow_e2e_test.go` that fails on the pre-fix code and passes after.

### Frontend defense-in-depth

The kanban card spinner was gated only on `task.state ∈ {IN_PROGRESS, SCHEDULING}`. Even after the backend fix, a future state-sync drift could leave the spinner running. Added `shouldShowTaskRunningSpinner(taskState, primarySessionState)` in `apps/web/lib/ui/state-icons.tsx` that requires the primary session to be in an *active* state (`CREATED`/`STARTING`/`RUNNING`) — or no session yet — before showing the spinner. `WAITING_FOR_INPUT`, `IDLE`, and terminal states now reliably suppress it.

Fixes #985.

## Test plan

- [x] `pnpm --filter @kandev/web typecheck` — passes.
- [x] `pnpm --filter @kandev/web test` — 2046 passing tests, including new spinner-gating matrix (active / paused / terminal).
- [x] `pnpm --filter @kandev/web lint` — clean.
- [x] `go test ./internal/orchestrator/...` — all pass, including new regression test which fails without the backend fix.
- [x] `make -C apps/backend lint fmt` — clean.
- [ ] Manual: after a kanban task's agent finishes a turn (or pauses for input), card moves to the next column without the spinner; survives server restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)