### PR TITLE
fix(agentctl): start per-repo workspace trackers in passthrough mode

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_subscription.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_subscription.go
@@ -75,10 +75,7 @@ type workspacePollAggregator struct {
 	pushInFlight map[string]bool
 }
 
-// workspacePushTarget bundles the mode and client for a queued push. The
-// client is captured at enqueue time rather than re-looked-up in the pusher
-// goroutine so the request always targets the agentctl instance that was
-// current when the gateway transition fired.
+// workspacePushTarget bundles the queued mode and the agentctl client captured at enqueue time.
 type workspacePushTarget struct {
 	mode   WorkspacePollMode
 	client *agentctl.Client
@@ -205,12 +202,7 @@ func (a *workspacePollAggregator) recordAndCompute(sessionID string, mode Worksp
 	return workspacePath, effective, true
 }
 
-// pushAsync queues the latest mode for a workspace and ensures exactly one
-// in-flight pusher goroutine per workspace processes the queue. Concurrent
-// callers (e.g. subscribe→focus arriving back-to-back from the gateway) all
-// converge on the same goroutine, which drains pendingPush in order until
-// empty — guaranteeing the FINAL queued mode reaches agentctl last on the
-// wire, regardless of how Go's http.Transport schedules connections.
+// pushAsync queues the latest mode and ensures exactly one pusher goroutine per workspace drains it (last-write-wins).
 func (a *workspacePollAggregator) pushAsync(execution *AgentExecution, workspacePath string, mode WorkspacePollMode) {
 	client := execution.GetAgentCtlClient()
 	if client == nil {
@@ -227,11 +219,7 @@ func (a *workspacePollAggregator) pushAsync(execution *AgentExecution, workspace
 	go a.pushLoop(workspacePath)
 }
 
-// pushLoop drains pendingPush for a single workspace, holding the in-flight
-// slot for its workspace until the queue is empty. Drops the slot under lock
-// so a concurrent pushAsync sees the released state and starts a fresh
-// goroutine if needed — no goroutine is ever simultaneously executing for
-// the same workspace, so HTTP order matches enqueue order.
+// pushLoop drains pendingPush for a workspace sequentially so HTTP order matches enqueue order.
 func (a *workspacePollAggregator) pushLoop(workspacePath string) {
 	for {
 		a.mu.Lock()

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_subscription.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_subscription.go
@@ -63,14 +63,7 @@ type workspacePollAggregator struct {
 	// known to belong to that workspace. Lets recordAndCompute iterate only
 	// sessions in the affected workspace instead of scanning all sessionModes.
 	workspaceSessions map[string]map[string]bool
-	// pendingPush holds the latest mode that still needs to be pushed for a
-	// workspace, scoped to the in-flight pusher goroutine for that workspace.
-	// Map presence + pushInFlight together implement a last-write-wins queue
-	// so concurrent transitions can't race on the wire (a subscribe→focus pair
-	// would otherwise spawn two goroutines whose HTTP order is undefined; if
-	// the slow push lands after the fast push the tracker ends up in slow mode
-	// while lastPushed claims fast — and the suppress-duplicate guard then
-	// prevents any future event from ever reconciling the divergence).
+	// Last-write-wins queue: pendingPush + pushInFlight serialize per-workspace HTTP pushes so order matches enqueue.
 	pendingPush  map[string]workspacePushTarget
 	pushInFlight map[string]bool
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_subscription.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_subscription.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 )
 
 // WorkspacePollMode mirrors process.PollMode for the lifecycle layer. Defined
@@ -61,6 +63,25 @@ type workspacePollAggregator struct {
 	// known to belong to that workspace. Lets recordAndCompute iterate only
 	// sessions in the affected workspace instead of scanning all sessionModes.
 	workspaceSessions map[string]map[string]bool
+	// pendingPush holds the latest mode that still needs to be pushed for a
+	// workspace, scoped to the in-flight pusher goroutine for that workspace.
+	// Map presence + pushInFlight together implement a last-write-wins queue
+	// so concurrent transitions can't race on the wire (a subscribe→focus pair
+	// would otherwise spawn two goroutines whose HTTP order is undefined; if
+	// the slow push lands after the fast push the tracker ends up in slow mode
+	// while lastPushed claims fast — and the suppress-duplicate guard then
+	// prevents any future event from ever reconciling the divergence).
+	pendingPush  map[string]workspacePushTarget
+	pushInFlight map[string]bool
+}
+
+// workspacePushTarget bundles the mode and client for a queued push. The
+// client is captured at enqueue time rather than re-looked-up in the pusher
+// goroutine so the request always targets the agentctl instance that was
+// current when the gateway transition fired.
+type workspacePushTarget struct {
+	mode   WorkspacePollMode
+	client *agentctl.Client
 }
 
 // newWorkspacePollAggregator wires an aggregator to the lifecycle manager.
@@ -70,6 +91,8 @@ func newWorkspacePollAggregator(mgr *Manager) *workspacePollAggregator {
 		sessionModes:      make(map[string]WorkspacePollMode),
 		lastPushed:        make(map[string]WorkspacePollMode),
 		workspaceSessions: make(map[string]map[string]bool),
+		pendingPush:       make(map[string]workspacePushTarget),
+		pushInFlight:      make(map[string]bool),
 	}
 }
 
@@ -182,23 +205,55 @@ func (a *workspacePollAggregator) recordAndCompute(sessionID string, mode Worksp
 	return workspacePath, effective, true
 }
 
-// pushAsync issues the SetWorkspacePollMode RPC to the agentctl client without
-// blocking the caller (typically the hub's session-mode goroutine).
+// pushAsync queues the latest mode for a workspace and ensures exactly one
+// in-flight pusher goroutine per workspace processes the queue. Concurrent
+// callers (e.g. subscribe→focus arriving back-to-back from the gateway) all
+// converge on the same goroutine, which drains pendingPush in order until
+// empty — guaranteeing the FINAL queued mode reaches agentctl last on the
+// wire, regardless of how Go's http.Transport schedules connections.
 func (a *workspacePollAggregator) pushAsync(execution *AgentExecution, workspacePath string, mode WorkspacePollMode) {
 	client := execution.GetAgentCtlClient()
 	if client == nil {
 		return
 	}
-	go func() {
+	a.mu.Lock()
+	a.pendingPush[workspacePath] = workspacePushTarget{mode: mode, client: client}
+	if a.pushInFlight[workspacePath] {
+		a.mu.Unlock()
+		return
+	}
+	a.pushInFlight[workspacePath] = true
+	a.mu.Unlock()
+	go a.pushLoop(workspacePath)
+}
+
+// pushLoop drains pendingPush for a single workspace, holding the in-flight
+// slot for its workspace until the queue is empty. Drops the slot under lock
+// so a concurrent pushAsync sees the released state and starts a fresh
+// goroutine if needed — no goroutine is ever simultaneously executing for
+// the same workspace, so HTTP order matches enqueue order.
+func (a *workspacePollAggregator) pushLoop(workspacePath string) {
+	for {
+		a.mu.Lock()
+		target, ok := a.pendingPush[workspacePath]
+		if !ok {
+			delete(a.pushInFlight, workspacePath)
+			a.mu.Unlock()
+			return
+		}
+		delete(a.pendingPush, workspacePath)
+		a.mu.Unlock()
+
 		ctx, cancel := context.WithTimeout(context.Background(), pushPollModeTimeout)
-		defer cancel()
-		if err := client.SetWorkspacePollMode(ctx, string(mode)); err != nil {
+		err := target.client.SetWorkspacePollMode(ctx, string(target.mode))
+		cancel()
+		if err != nil {
 			a.mgr.logger.Warn("failed to push workspace poll mode",
 				zap.String("workspace", workspacePath),
-				zap.String("mode", string(mode)),
+				zap.String("mode", string(target.mode)),
 				zap.Error(err))
 		}
-	}()
+	}
 }
 
 // FlushSessionMode resolves two races that leave agentctl in the wrong mode:

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -288,29 +289,12 @@ func parseHTTPURL(t *testing.T, raw string) (host string, port int) {
 		t.Fatalf("unexpected URL shape: %q", raw)
 	}
 	host = parts[0]
-	if _, err := fmtSscanf(parts[1], &port); err != nil {
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
 		t.Fatalf("port parse: %v", err)
 	}
 	return host, port
 }
-
-// fmtSscanf is a tiny wrapper around fmt.Sscanf kept in this file so the import
-// list stays scoped to what the test needs.
-func fmtSscanf(s string, p *int) (int, error) {
-	var n int
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return 0, &numErr{s}
-		}
-		n = n*10 + int(r-'0')
-	}
-	*p = n
-	return 1, nil
-}
-
-type numErr struct{ s string }
-
-func (e *numErr) Error() string { return "not a number: " + e.s }
 
 // TestAggregator_PushAsync_LastWriteWinsUnderRace is a regression test for the
 // race that caused multi-repo passthrough sessions to get stuck in slow mode
@@ -396,6 +380,12 @@ waitLoop:
 	defer mu.Unlock()
 	if serverSeen != "fast" {
 		t.Errorf("agentctl tracker final mode = %q, want fast (calls: %+v)", serverSeen, calls)
+	}
+	// The fix collapses back-to-back slow→fast in the pending queue when the
+	// pusher hasn't dispatched yet, so we expect at most one slow push. More
+	// than one would mean the queue stopped collapsing (a regression).
+	if n := slowCalls.Load(); n > 1 {
+		t.Errorf("slow push count = %d, want <= 1 (queue should collapse duplicates)", n)
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
@@ -296,18 +296,7 @@ func parseHTTPURL(t *testing.T, raw string) (host string, port int) {
 	return host, port
 }
 
-// TestAggregator_PushAsync_LastWriteWinsUnderRace is a regression test for the
-// race that caused multi-repo passthrough sessions to get stuck in slow mode
-// (#982 follow-up): subscribe + focus arriving back-to-back used to spawn two
-// independent goroutines whose HTTP order was undefined; with a slow request
-// landing AFTER the fast request the tracker ended up in slow mode while the
-// aggregator's lastPushed claimed fast — and the suppress-duplicate guard
-// then blocked any future event from reconciling the divergence.
-//
-// We simulate the race by making the agentctl "slow" handler block briefly,
-// firing slow then fast in quick succession, and asserting the FINAL mode
-// the server saw is "fast" (which a parallel-goroutine implementation would
-// fail because the slow push would land last and overwrite fast).
+// Regression for #982: slow-then-fast mode events must not leave the tracker stuck in slow.
 func TestAggregator_PushAsync_LastWriteWinsUnderRace(t *testing.T) {
 	type call struct {
 		Mode string

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
@@ -362,10 +362,35 @@ func TestAggregator_PushAsync_LastWriteWinsUnderRace(t *testing.T) {
 	mgr.pollAggregator.HandleSessionMode("s1", WorkspacePollModeSlow)
 	mgr.pollAggregator.HandleSessionMode("s1", WorkspacePollModeFast)
 
-	// Wait long enough for both pushes (including the artificial slowDelay)
-	// to settle. Otherwise the test could observe "fast" before the racing
-	// "slow" arrives and overwrites it — and pass even when the bug is present.
-	time.Sleep(slowDelay + 300*time.Millisecond)
+	// Wait for both pushes to land — the server records each call, so we
+	// can poll the recorded length instead of sleeping a fixed amount. The
+	// old fire-and-forget impl sent both slow and fast (2 calls); the fix
+	// may collapse slow before dispatch (1 call). Either way we wait until
+	// the pusher goroutine has drained, plus a brief settle window for any
+	// in-flight slow request to complete.
+	deadline := time.NewTimer(slowDelay + 2*time.Second)
+	defer deadline.Stop()
+waitLoop:
+	for {
+		mu.Lock()
+		n := len(calls)
+		seen := serverSeen
+		mu.Unlock()
+		// 1 call is enough only when it's already "fast" — in the buggy
+		// path a late-arriving slow can still overwrite, so wait for the
+		// drain window or until both arrived.
+		if n >= 2 || (n >= 1 && seen == "fast") {
+			break
+		}
+		select {
+		case <-deadline.C:
+			break waitLoop
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	// Add a brief settle so any racing slow push has time to overwrite if
+	// the bug is present.
+	time.Sleep(slowDelay + 100*time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_subscription_test.go
@@ -1,10 +1,16 @@
 package lifecycle
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/common/logger"
 )
 
@@ -251,6 +257,120 @@ func TestAggregator_FlushSessionMode_QueriesHubWhenWired(t *testing.T) {
 	}
 	if cachedMode != WorkspacePollModeFast {
 		t.Errorf("FlushSessionMode should update sessionModes to hub-queried mode; got %q, want fast", cachedMode)
+	}
+}
+
+// addExecutionWithClient is like addExecution but wires a real agentctl.Client
+// pointing at the supplied URL. Needed for tests that observe the HTTP RPC.
+func addExecutionWithClient(t *testing.T, mgr *Manager, sessionID, workspacePath, agentctlURL string) {
+	t.Helper()
+	host, port := parseHTTPURL(t, agentctlURL)
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	c := agentctl.NewClient(host, port, log)
+	if err := mgr.executionStore.Add(&AgentExecution{
+		ID:            "exec-" + sessionID,
+		SessionID:     sessionID,
+		WorkspacePath: workspacePath,
+		agentctl:      c,
+	}); err != nil {
+		t.Fatalf("executionStore.Add: %v", err)
+	}
+}
+
+func parseHTTPURL(t *testing.T, raw string) (host string, port int) {
+	t.Helper()
+	stripped := strings.TrimPrefix(raw, "http://")
+	parts := strings.Split(stripped, ":")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected URL shape: %q", raw)
+	}
+	host = parts[0]
+	if _, err := fmtSscanf(parts[1], &port); err != nil {
+		t.Fatalf("port parse: %v", err)
+	}
+	return host, port
+}
+
+// fmtSscanf is a tiny wrapper around fmt.Sscanf kept in this file so the import
+// list stays scoped to what the test needs.
+func fmtSscanf(s string, p *int) (int, error) {
+	var n int
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, &numErr{s}
+		}
+		n = n*10 + int(r-'0')
+	}
+	*p = n
+	return 1, nil
+}
+
+type numErr struct{ s string }
+
+func (e *numErr) Error() string { return "not a number: " + e.s }
+
+// TestAggregator_PushAsync_LastWriteWinsUnderRace is a regression test for the
+// race that caused multi-repo passthrough sessions to get stuck in slow mode
+// (#982 follow-up): subscribe + focus arriving back-to-back used to spawn two
+// independent goroutines whose HTTP order was undefined; with a slow request
+// landing AFTER the fast request the tracker ended up in slow mode while the
+// aggregator's lastPushed claimed fast — and the suppress-duplicate guard
+// then blocked any future event from reconciling the divergence.
+//
+// We simulate the race by making the agentctl "slow" handler block briefly,
+// firing slow then fast in quick succession, and asserting the FINAL mode
+// the server saw is "fast" (which a parallel-goroutine implementation would
+// fail because the slow push would land last and overwrite fast).
+func TestAggregator_PushAsync_LastWriteWinsUnderRace(t *testing.T) {
+	type call struct {
+		Mode string
+		At   time.Time
+	}
+	var (
+		mu         sync.Mutex
+		calls      []call
+		slowCalls  atomic.Int32
+		slowDelay  = 80 * time.Millisecond
+		serverSeen string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Mode string `json:"mode"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Mode == "slow" {
+			slowCalls.Add(1)
+			time.Sleep(slowDelay)
+		}
+		mu.Lock()
+		calls = append(calls, call{Mode: body.Mode, At: time.Now()})
+		serverSeen = body.Mode
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	mgr := newTestManagerForAggregator(t)
+	addExecutionWithClient(t, mgr, "s1", "/tmp/ws1", srv.URL)
+
+	// Fire subscribe (slow) then focus (fast) microseconds apart, matching
+	// what the gateway does when a page loads.
+	mgr.pollAggregator.HandleSessionMode("s1", WorkspacePollModeSlow)
+	mgr.pollAggregator.HandleSessionMode("s1", WorkspacePollModeFast)
+
+	// Wait long enough for both pushes (including the artificial slowDelay)
+	// to settle. Otherwise the test could observe "fast" before the racing
+	// "slow" arrives and overwrites it — and pass even when the bug is present.
+	time.Sleep(slowDelay + 300*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if serverSeen != "fast" {
+		t.Errorf("agentctl tracker final mode = %q, want fast (calls: %+v)", serverSeen, calls)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -108,12 +108,7 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 	// Create process manager
 	procMgr := process.NewManager(instanceCfg, m.logger)
 
-	// Start workspace trackers (root + every per-repo tracker for multi-repo
-	// roots) immediately so file-change notifications fire even without an
-	// agent running. CLI passthrough mode never goes through startAgent /
-	// startOneShot, so per-repo trackers would otherwise stay idle and the
-	// Files panel would not refresh when the user-driven agent CLI modifies
-	// files.
+	// Start root + per-repo trackers so file-change events fire even in passthrough mode.
 	procMgr.StartAllWorkspaceTrackers(context.Background())
 
 	handler := m.buildHTTPHandler(instanceCfg, procMgr)

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -108,9 +108,13 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 	// Create process manager
 	procMgr := process.NewManager(instanceCfg, m.logger)
 
-	// Start workspace tracker immediately so process output can be streamed
-	// even without an agent running (for dev server, etc.)
-	procMgr.GetWorkspaceTracker().Start(context.Background())
+	// Start workspace trackers (root + every per-repo tracker for multi-repo
+	// roots) immediately so file-change notifications fire even without an
+	// agent running. CLI passthrough mode never goes through startAgent /
+	// startOneShot, so per-repo trackers would otherwise stay idle and the
+	// Files panel would not refresh when the user-driven agent CLI modifies
+	// files.
+	procMgr.StartAllWorkspaceTrackers(context.Background())
 
 	handler := m.buildHTTPHandler(instanceCfg, procMgr)
 	httpServer := m.startHTTPServer(port, listener, handler, id)

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -232,22 +232,24 @@ func (m *Manager) GetWorkspaceTracker() *WorkspaceTracker {
 	return m.workspaceTracker
 }
 
-// StartAllWorkspaceTrackers starts the root tracker plus every per-repo tracker.
-// Idempotent: WorkspaceTracker.Start is a no-op when already started.
-//
-// For single-repo workspaces this is equivalent to
-// GetWorkspaceTracker().Start(ctx) — repoTrackers is empty. For multi-repo
-// task roots the root tracker is bare (no git index, exits immediately) and
-// only the per-repo trackers actually poll for changes — they must be started
-// here so file-change notifications fire without an agent process. Without
-// this, CLI passthrough mode (which bypasses startAgent/startOneShot) leaves
-// every per-repo tracker idle and the Files panel never receives updates.
+// StartAllWorkspaceTrackers starts root + per-repo trackers (idempotent) so file-change events fire in passthrough mode.
 func (m *Manager) StartAllWorkspaceTrackers(ctx context.Context) {
 	if m.workspaceTracker != nil {
 		m.workspaceTracker.Start(ctx)
 	}
 	for _, t := range m.repoTrackers {
 		t.Start(ctx)
+	}
+}
+
+// stopWorkspaceTrackers stops the root tracker and every per-repo tracker.
+// Idempotent: WorkspaceTracker.Stop uses sync.Once internally.
+func (m *Manager) stopWorkspaceTrackers() {
+	if m.workspaceTracker != nil {
+		m.workspaceTracker.Stop()
+	}
+	for _, t := range m.repoTrackers {
+		t.Stop()
 	}
 }
 
@@ -953,6 +955,12 @@ func (m *Manager) Stop(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Stop workspace trackers unconditionally — CreateInstance starts them
+	// before any agent process, so in passthrough mode (where Start() is
+	// never called and status stays Stopped) the early return below would
+	// otherwise skip stopShellAndProcesses and leak the tracker goroutines.
+	m.stopWorkspaceTrackers()
+
 	status := m.Status()
 	if status == StatusStopped || status == StatusStopping {
 		m.logger.Info("Stop called but already stopped/stopping", zap.String("status", string(status)))
@@ -1004,12 +1012,7 @@ func (m *Manager) stopShellAndProcesses(ctx context.Context) {
 	m.logger.Debug("workspace processes stopped")
 
 	m.logger.Debug("stopping workspace tracker")
-	if m.workspaceTracker != nil {
-		m.workspaceTracker.Stop()
-	}
-	for _, t := range m.repoTrackers {
-		t.Stop()
-	}
+	m.stopWorkspaceTrackers()
 	m.logger.Debug("workspace tracker stopped")
 }
 

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -232,6 +232,25 @@ func (m *Manager) GetWorkspaceTracker() *WorkspaceTracker {
 	return m.workspaceTracker
 }
 
+// StartAllWorkspaceTrackers starts the root tracker plus every per-repo tracker.
+// Idempotent: WorkspaceTracker.Start is a no-op when already started.
+//
+// For single-repo workspaces this is equivalent to
+// GetWorkspaceTracker().Start(ctx) — repoTrackers is empty. For multi-repo
+// task roots the root tracker is bare (no git index, exits immediately) and
+// only the per-repo trackers actually poll for changes — they must be started
+// here so file-change notifications fire without an agent process. Without
+// this, CLI passthrough mode (which bypasses startAgent/startOneShot) leaves
+// every per-repo tracker idle and the Files panel never receives updates.
+func (m *Manager) StartAllWorkspaceTrackers(ctx context.Context) {
+	if m.workspaceTracker != nil {
+		m.workspaceTracker.Start(ctx)
+	}
+	for _, t := range m.repoTrackers {
+		t.Start(ctx)
+	}
+}
+
 // SubscribeWorkspaceStream creates a single workspace stream subscriber and
 // fans it out across the root tracker plus every per-repo tracker, so the
 // caller receives events from all repositories on one channel. Use

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -242,8 +242,7 @@ func (m *Manager) StartAllWorkspaceTrackers(ctx context.Context) {
 	}
 }
 
-// stopWorkspaceTrackers stops the root tracker and every per-repo tracker.
-// Idempotent: WorkspaceTracker.Stop uses sync.Once internally.
+// stopWorkspaceTrackers stops root + per-repo trackers (idempotent via sync.Once).
 func (m *Manager) stopWorkspaceTrackers() {
 	if m.workspaceTracker != nil {
 		m.workspaceTracker.Stop()
@@ -955,10 +954,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Stop workspace trackers unconditionally — CreateInstance starts them
-	// before any agent process, so in passthrough mode (where Start() is
-	// never called and status stays Stopped) the early return below would
-	// otherwise skip stopShellAndProcesses and leak the tracker goroutines.
+	// Stop trackers before the status guard: passthrough never calls Start() so the early return below would otherwise leak them.
 	m.stopWorkspaceTrackers()
 
 	status := m.Status()

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -976,7 +976,7 @@ func (m *Manager) Stop(ctx context.Context) error {
 	return nil
 }
 
-// stopShellAndProcesses stops the shell session, VS Code, workspace processes, and workspace tracker.
+// stopShellAndProcesses stops the shell session, VS Code, and workspace processes.
 func (m *Manager) stopShellAndProcesses(ctx context.Context) {
 	// Stop VS Code server if running
 	m.logger.Debug("stopping vscode server")
@@ -1006,10 +1006,6 @@ func (m *Manager) stopShellAndProcesses(ctx context.Context) {
 		}
 	}
 	m.logger.Debug("workspace processes stopped")
-
-	m.logger.Debug("stopping workspace tracker")
-	m.stopWorkspaceTrackers()
-	m.logger.Debug("workspace tracker stopped")
 }
 
 // closeAdapterAndStdin closes the protocol adapter, the stop channel, and stdin.

--- a/apps/backend/internal/agentctl/server/process/manager_multi_repo_stream_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_multi_repo_stream_test.go
@@ -108,12 +108,7 @@ func TestManager_RepoSubpaths(t *testing.T) {
 	}
 }
 
-// Regression test for kdlbs/kandev#982: in CLI passthrough mode the agent
-// runs via the PTY-based InteractiveRunner and never goes through
-// startAgent/startOneShot, so the per-repo trackers used to stay idle and
-// file changes by the agent never produced workspace-stream notifications.
-// StartAllWorkspaceTrackers is what instance.Manager.CreateInstance now
-// calls so polling fires even without an agent subprocess.
+// Regression for #982: passthrough mode must start per-repo trackers so file-change events reach the Files panel.
 func TestManager_StartAllWorkspaceTrackers_StartsRootAndRepoTrackers(t *testing.T) {
 	taskRoot := t.TempDir()
 	for _, name := range []string{"frontend", "backend"} {
@@ -137,10 +132,7 @@ func TestManager_StartAllWorkspaceTrackers_StartsRootAndRepoTrackers(t *testing.
 		}
 	})
 
-	// Every tracker must report started. Waiting on initialScanDone proves
-	// the monitor goroutine actually ran (it closes the channel on either
-	// the first scan completing or the no-git-index early-exit), which is
-	// what makes the workspace stream subscriber receive change events.
+	// initialScanDone closes once the monitor goroutine ran — confirms Start() actually fired.
 	for i, tr := range append([]*WorkspaceTracker{mgr.workspaceTracker}, mgr.repoTrackers...) {
 		select {
 		case <-tr.initialScanDone:

--- a/apps/backend/internal/agentctl/server/process/manager_multi_repo_stream_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_multi_repo_stream_test.go
@@ -108,6 +108,51 @@ func TestManager_RepoSubpaths(t *testing.T) {
 	}
 }
 
+// Regression test for kdlbs/kandev#982: in CLI passthrough mode the agent
+// runs via the PTY-based InteractiveRunner and never goes through
+// startAgent/startOneShot, so the per-repo trackers used to stay idle and
+// file changes by the agent never produced workspace-stream notifications.
+// StartAllWorkspaceTrackers is what instance.Manager.CreateInstance now
+// calls so polling fires even without an agent subprocess.
+func TestManager_StartAllWorkspaceTrackers_StartsRootAndRepoTrackers(t *testing.T) {
+	taskRoot := t.TempDir()
+	for _, name := range []string{"frontend", "backend"} {
+		repoDir, cleanup := setupTestRepo(t)
+		t.Cleanup(cleanup)
+		if err := os.Rename(repoDir, filepath.Join(taskRoot, name)); err != nil {
+			t.Fatalf("place %s: %v", name, err)
+		}
+	}
+
+	mgr := NewManager(&config.InstanceConfig{WorkDir: taskRoot}, newTestLogger(t))
+	if len(mgr.repoTrackers) != 2 {
+		t.Fatalf("expected 2 per-repo trackers, got %d", len(mgr.repoTrackers))
+	}
+
+	mgr.StartAllWorkspaceTrackers(context.Background())
+	t.Cleanup(func() {
+		mgr.workspaceTracker.Stop()
+		for _, tr := range mgr.repoTrackers {
+			tr.Stop()
+		}
+	})
+
+	// Every tracker must report started. Waiting on initialScanDone proves
+	// the monitor goroutine actually ran (it closes the channel on either
+	// the first scan completing or the no-git-index early-exit), which is
+	// what makes the workspace stream subscriber receive change events.
+	for i, tr := range append([]*WorkspaceTracker{mgr.workspaceTracker}, mgr.repoTrackers...) {
+		select {
+		case <-tr.initialScanDone:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("tracker %d (workDir=%q) never completed initial scan — Start did not run", i, tr.workDir)
+		}
+	}
+
+	// Idempotency: a second call must not panic or double-start.
+	mgr.StartAllWorkspaceTrackers(context.Background())
+}
+
 // Verifies that SetWorkspacePollMode propagates to every per-repo tracker.
 // Without the fan-out, per-repo trackers stay at their construction-time
 // default and never receive the focus-triggered refresh that delivers a

--- a/apps/web/components/task/file-browser-apply-changes.test.ts
+++ b/apps/web/components/task/file-browser-apply-changes.test.ts
@@ -58,9 +58,7 @@ function client() {
   return {} as ReturnType<typeof import("@/lib/ws/connection").getWebSocketClient>;
 }
 
-// Polling-detected refresh events carry empty path + operation: "refresh".
-// Before the fix, applyFileChanges only refreshed root, so files added under
-// an expanded subdir never appeared in the tree (regression for #982).
+// Regression for #982: refresh events must expand all affected-repo folders, not just root.
 describe("applyFileChanges — refresh operation expands to all expanded folders", () => {
   it("refreshes every expanded folder under the affected repo on a refresh event", async () => {
     mockEmptyTree();
@@ -110,8 +108,7 @@ describe("applyFileChanges — refresh operation expands to all expanded folders
       setLoadState: vi.fn(),
     });
     await new Promise<void>((r) => setTimeout(r, 0));
-    // create event for THM_NEW — parent is "thm" (expanded), the path
-    // itself isn't expanded. Only "thm" should be refreshed.
+    // create event: parent "thm" is expanded, path itself is not — only "thm" refreshed.
     expect(requestFileTreeMock.mock.calls.map((c) => c[2]).sort()).toEqual(["thm"]);
   });
 
@@ -184,8 +181,7 @@ describe("applyFileChanges — cross-repo subtree preservation", () => {
     const reducer = setTree.mock.calls[0][0] as (prev: FileTreeNode) => FileTreeNode;
     const next = reducer(prevTree);
     const kandevNode = next.children?.find((c) => c.path === "kandev");
-    // kandev wasn't part of the refresh scope (different repo), so its
-    // existing README.md child must still be present.
+    // kandev's existing child must survive a refresh scoped to a different repo.
     expect(kandevNode?.children?.map((c) => c.path)).toEqual(["kandev/README.md"]);
     const thmNode = next.children?.find((c) => c.path === "thm");
     expect(thmNode?.children?.map((c) => c.path).sort()).toEqual([THM_NEW, THM_OLD]);

--- a/apps/web/components/task/file-browser-apply-changes.test.ts
+++ b/apps/web/components/task/file-browser-apply-changes.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FileTreeNode } from "@/lib/types/backend";
+
+const requestFileTreeMock = vi.fn();
+const getWebSocketClientMock = vi.fn(() => ({}) as unknown);
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => getWebSocketClientMock(),
+}));
+vi.mock("@/lib/ws/workspace-files", () => ({
+  requestFileTree: (...args: unknown[]) => requestFileTreeMock(...args),
+  requestFileContent: vi.fn(),
+  searchWorkspaceFiles: vi.fn(),
+}));
+
+type ApplyFileChanges = (typeof import("./file-browser-hooks"))["applyFileChanges"];
+let applyFileChanges: ApplyFileChanges;
+
+const SESSION_ID = "sess";
+const REFRESH_OP = "refresh";
+
+beforeEach(async () => {
+  vi.resetModules();
+  requestFileTreeMock.mockReset();
+  getWebSocketClientMock.mockReset().mockReturnValue({});
+  ({ applyFileChanges } = await import("./file-browser-hooks"));
+});
+
+function makeTree(): FileTreeNode {
+  return {
+    name: "",
+    path: "",
+    is_dir: true,
+    size: 0,
+    children: [
+      {
+        name: "thm",
+        path: "thm",
+        is_dir: true,
+        size: 0,
+        children: [{ name: "old.txt", path: "thm/old.txt", is_dir: false, size: 0 }],
+      },
+      { name: "kandev", path: "kandev", is_dir: true, size: 0, children: [] },
+    ],
+  };
+}
+
+function mockEmptyTree() {
+  requestFileTreeMock.mockImplementation((_client: unknown, _sid: string, folder: string) =>
+    Promise.resolve({ root: { name: folder, path: folder, is_dir: true, children: [] } }),
+  );
+}
+
+function client() {
+  return {} as ReturnType<typeof import("@/lib/ws/connection").getWebSocketClient>;
+}
+
+// Polling-detected refresh events carry empty path + operation: "refresh".
+// Before the fix, applyFileChanges only refreshed root, so files added under
+// an expanded subdir never appeared in the tree (regression for #982).
+describe("applyFileChanges — refresh operation expands to all expanded folders", () => {
+  it("refreshes every expanded folder under the affected repo on a refresh event", async () => {
+    mockEmptyTree();
+    applyFileChanges({
+      client: client(),
+      sessionId: SESSION_ID,
+      expandedPaths: new Set(["thm", "thm/rooms", "kandev"]),
+      changes: [{ path: "", operation: REFRESH_OP, repository_name: "thm" }],
+      setTree: vi.fn(),
+      setLoadState: vi.fn(),
+    });
+    await new Promise<void>((r) => setTimeout(r, 0));
+    // Root + every expanded path under "thm" (not "kandev" — different repo).
+    expect(requestFileTreeMock.mock.calls.map((c) => c[2]).sort()).toEqual([
+      "",
+      "thm",
+      "thm/rooms",
+    ]);
+  });
+
+  it("refreshes every expanded folder when repository_name is missing", async () => {
+    mockEmptyTree();
+    applyFileChanges({
+      client: client(),
+      sessionId: SESSION_ID,
+      expandedPaths: new Set(["src", "src/components"]),
+      changes: [{ path: "", operation: REFRESH_OP }],
+      setTree: vi.fn(),
+      setLoadState: vi.fn(),
+    });
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(requestFileTreeMock.mock.calls.map((c) => c[2]).sort()).toEqual([
+      "",
+      "src",
+      "src/components",
+    ]);
+  });
+
+  it("preserves the targeted-path behavior for specific operations", async () => {
+    mockEmptyTree();
+    applyFileChanges({
+      client: client(),
+      sessionId: SESSION_ID,
+      expandedPaths: new Set(["thm", "kandev"]),
+      changes: [{ path: "thm/new.txt", operation: "create" }],
+      setTree: vi.fn(),
+      setLoadState: vi.fn(),
+    });
+    await new Promise<void>((r) => setTimeout(r, 0));
+    // create event for "thm/new.txt" — parent is "thm" (expanded), the path
+    // itself isn't expanded. Only "thm" should be refreshed.
+    expect(requestFileTreeMock.mock.calls.map((c) => c[2]).sort()).toEqual(["thm"]);
+  });
+
+  it("merges fresh children into the expanded subtree", async () => {
+    requestFileTreeMock.mockImplementation((_c: unknown, _s: string, folder: string) =>
+      folder === "thm"
+        ? Promise.resolve({ root: thmChildrenAfter() })
+        : Promise.resolve({ root: rootChildrenAfter() }),
+    );
+    const setTree = vi.fn();
+    applyFileChanges({
+      client: client(),
+      sessionId: SESSION_ID,
+      expandedPaths: new Set(["thm"]),
+      changes: [{ path: "", operation: REFRESH_OP, repository_name: "thm" }],
+      setTree,
+      setLoadState: vi.fn(),
+    });
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(setTree).toHaveBeenCalled();
+    // Apply setTree's reducer to the prev tree to inspect the merged shape.
+    const reducer = setTree.mock.calls[0][0] as (prev: FileTreeNode) => FileTreeNode;
+    const next = reducer(makeTree());
+    const thmNode = next.children?.find((c) => c.path === "thm");
+    expect(thmNode?.children?.map((c) => c.path).sort()).toEqual(["thm/new.txt", "thm/old.txt"]);
+  });
+});
+
+function thmChildrenAfter(): FileTreeNode {
+  return {
+    name: "thm",
+    path: "thm",
+    is_dir: true,
+    size: 0,
+    children: [
+      { name: "old.txt", path: "thm/old.txt", is_dir: false, size: 0 },
+      { name: "new.txt", path: "thm/new.txt", is_dir: false, size: 0 },
+    ],
+  };
+}
+
+function rootChildrenAfter(): FileTreeNode {
+  return {
+    name: "",
+    path: "",
+    is_dir: true,
+    size: 0,
+    children: [
+      { name: "thm", path: "thm", is_dir: true, size: 0, children: [] },
+      { name: "kandev", path: "kandev", is_dir: true, size: 0, children: [] },
+    ],
+  };
+}

--- a/apps/web/components/task/file-browser-apply-changes.test.ts
+++ b/apps/web/components/task/file-browser-apply-changes.test.ts
@@ -18,6 +18,8 @@ let applyFileChanges: ApplyFileChanges;
 
 const SESSION_ID = "sess";
 const REFRESH_OP = "refresh";
+const THM_OLD = "thm/old.txt";
+const THM_NEW = "thm/new.txt";
 
 beforeEach(async () => {
   vi.resetModules();
@@ -38,7 +40,7 @@ function makeTree(): FileTreeNode {
         path: "thm",
         is_dir: true,
         size: 0,
-        children: [{ name: "old.txt", path: "thm/old.txt", is_dir: false, size: 0 }],
+        children: [{ name: "old.txt", path: THM_OLD, is_dir: false, size: 0 }],
       },
       { name: "kandev", path: "kandev", is_dir: true, size: 0, children: [] },
     ],
@@ -46,8 +48,9 @@ function makeTree(): FileTreeNode {
 }
 
 function mockEmptyTree() {
+  // depth=1 responses omit `children` for placeholder nodes (omitempty).
   requestFileTreeMock.mockImplementation((_client: unknown, _sid: string, folder: string) =>
-    Promise.resolve({ root: { name: folder, path: folder, is_dir: true, children: [] } }),
+    Promise.resolve({ root: { name: folder, path: folder, is_dir: true } }),
   );
 }
 
@@ -102,12 +105,12 @@ describe("applyFileChanges — refresh operation expands to all expanded folders
       client: client(),
       sessionId: SESSION_ID,
       expandedPaths: new Set(["thm", "kandev"]),
-      changes: [{ path: "thm/new.txt", operation: "create" }],
+      changes: [{ path: THM_NEW, operation: "create" }],
       setTree: vi.fn(),
       setLoadState: vi.fn(),
     });
     await new Promise<void>((r) => setTimeout(r, 0));
-    // create event for "thm/new.txt" — parent is "thm" (expanded), the path
+    // create event for THM_NEW — parent is "thm" (expanded), the path
     // itself isn't expanded. Only "thm" should be refreshed.
     expect(requestFileTreeMock.mock.calls.map((c) => c[2]).sort()).toEqual(["thm"]);
   });
@@ -133,7 +136,62 @@ describe("applyFileChanges — refresh operation expands to all expanded folders
     const reducer = setTree.mock.calls[0][0] as (prev: FileTreeNode) => FileTreeNode;
     const next = reducer(makeTree());
     const thmNode = next.children?.find((c) => c.path === "thm");
-    expect(thmNode?.children?.map((c) => c.path).sort()).toEqual(["thm/new.txt", "thm/old.txt"]);
+    expect(thmNode?.children?.map((c) => c.path).sort()).toEqual([THM_NEW, THM_OLD]);
+  });
+});
+
+// Regression: a `refresh` event scoped to one repo must NOT wipe out the
+// loaded children of unaffected sibling repos. Previously patchNode ran on
+// the root and re-matched folderUpdates.has(""), replacing the merged
+// children with the raw depth-1 server response.
+describe("applyFileChanges — cross-repo subtree preservation", () => {
+  it("preserves kandev's loaded children when refresh is scoped to thm", async () => {
+    requestFileTreeMock.mockImplementation((_c: unknown, _s: string, folder: string) => {
+      if (folder === "thm") {
+        return Promise.resolve({ root: thmChildrenAfter() });
+      }
+      return Promise.resolve({ root: rootChildrenAfter() });
+    });
+    const prevTree: FileTreeNode = {
+      name: "",
+      path: "",
+      is_dir: true,
+      size: 0,
+      children: [
+        {
+          name: "kandev",
+          path: "kandev",
+          is_dir: true,
+          size: 0,
+          children: [{ name: "README.md", path: "kandev/README.md", is_dir: false, size: 0 }],
+        },
+        {
+          name: "thm",
+          path: "thm",
+          is_dir: true,
+          size: 0,
+          children: [{ name: "old.txt", path: THM_OLD, is_dir: false, size: 0 }],
+        },
+      ],
+    };
+    const setTree = vi.fn();
+    applyFileChanges({
+      client: client(),
+      sessionId: SESSION_ID,
+      expandedPaths: new Set(["thm"]),
+      changes: [{ path: "", operation: REFRESH_OP, repository_name: "thm" }],
+      setTree,
+      setLoadState: vi.fn(),
+    });
+    await new Promise<void>((r) => setTimeout(r, 0));
+    const reducer = setTree.mock.calls[0][0] as (prev: FileTreeNode) => FileTreeNode;
+    const next = reducer(prevTree);
+    const kandevNode = next.children?.find((c) => c.path === "kandev");
+    // kandev wasn't part of the refresh scope (different repo), so its
+    // existing README.md child must still be present.
+    expect(kandevNode?.children?.map((c) => c.path)).toEqual(["kandev/README.md"]);
+    const thmNode = next.children?.find((c) => c.path === "thm");
+    expect(thmNode?.children?.map((c) => c.path).sort()).toEqual([THM_NEW, THM_OLD]);
   });
 });
 
@@ -144,21 +202,24 @@ function thmChildrenAfter(): FileTreeNode {
     is_dir: true,
     size: 0,
     children: [
-      { name: "old.txt", path: "thm/old.txt", is_dir: false, size: 0 },
-      { name: "new.txt", path: "thm/new.txt", is_dir: false, size: 0 },
+      { name: "old.txt", path: THM_OLD, is_dir: false, size: 0 },
+      { name: "new.txt", path: THM_NEW, is_dir: false, size: 0 },
     ],
   };
 }
 
 function rootChildrenAfter(): FileTreeNode {
+  // depth=1 backend responses serialize directory children as `undefined`
+  // (Children []*FileTreeNode `json:"children,omitempty"`), not as empty
+  // arrays — mergeTreeNodes relies on this to preserve nested children.
   return {
     name: "",
     path: "",
     is_dir: true,
     size: 0,
     children: [
-      { name: "thm", path: "thm", is_dir: true, size: 0, children: [] },
-      { name: "kandev", path: "kandev", is_dir: true, size: 0, children: [] },
+      { name: "thm", path: "thm", is_dir: true, size: 0 },
+      { name: "kandev", path: "kandev", is_dir: true, size: 0 },
     ],
   };
 }

--- a/apps/web/components/task/file-browser-apply-changes.test.ts
+++ b/apps/web/components/task/file-browser-apply-changes.test.ts
@@ -140,10 +140,7 @@ describe("applyFileChanges — refresh operation expands to all expanded folders
   });
 });
 
-// Regression: a `refresh` event scoped to one repo must NOT wipe out the
-// loaded children of unaffected sibling repos. Previously patchNode ran on
-// the root and re-matched folderUpdates.has(""), replacing the merged
-// children with the raw depth-1 server response.
+// Regression (#982): refresh scoped to one repo must not wipe sibling repos' loaded subtrees.
 describe("applyFileChanges — cross-repo subtree preservation", () => {
   it("preserves kandev's loaded children when refresh is scoped to thm", async () => {
     requestFileTreeMock.mockImplementation((_c: unknown, _s: string, folder: string) => {
@@ -209,9 +206,7 @@ function thmChildrenAfter(): FileTreeNode {
 }
 
 function rootChildrenAfter(): FileTreeNode {
-  // depth=1 backend responses serialize directory children as `undefined`
-  // (Children []*FileTreeNode `json:"children,omitempty"`), not as empty
-  // arrays — mergeTreeNodes relies on this to preserve nested children.
+  // depth=1 backend responses omit `children` (omitempty) — mergeTreeNodes uses absence to preserve loaded subtrees.
   return {
     name: "",
     path: "",

--- a/apps/web/components/task/file-browser-hooks.ts
+++ b/apps/web/components/task/file-browser-hooks.ts
@@ -183,7 +183,11 @@ export function applyFileChanges(ctx: {
           }
           return node.children ? { ...node, children: node.children.map(patchNode) } : node;
         };
-        return patchNode(updated);
+        // Recurse over the root's already-merged children — re-running patchNode
+        // on the root itself would re-match folderUpdates.has("") and replace
+        // the merged children with the raw depth-1 server response, discarding
+        // every preserved subtree from the merge block above.
+        return { ...updated, children: updated.children?.map(patchNode) };
       });
       setLoadState("loaded");
     } catch (error) {

--- a/apps/web/components/task/file-browser-hooks.ts
+++ b/apps/web/components/task/file-browser-hooks.ts
@@ -118,25 +118,39 @@ export function useFileBrowserSearch(sessionId: string) {
 }
 
 /** Apply incoming file changes to the tree by refreshing affected folders. */
-function applyFileChanges(ctx: {
+export function applyFileChanges(ctx: {
   client: ReturnType<typeof getWebSocketClient>;
   sessionId: string;
   expandedPaths: ReadonlySet<string>;
-  changes: Array<{ path: string }>;
+  changes: Array<{ path: string; operation?: string; repository_name?: string }>;
   setTree: React.Dispatch<React.SetStateAction<FileTreeNode | null>>;
   setLoadState: React.Dispatch<React.SetStateAction<LoadState>>;
 }) {
   const { client, sessionId, expandedPaths, changes, setTree, setLoadState } = ctx;
-  const candidates = new Set<string>();
+  const foldersToRefresh = new Set<string>();
   for (const change of changes) {
+    // Polling-detected workspace changes arrive as `refresh` events with an
+    // empty path (the tracker knows "something changed" but not which file).
+    // Refresh root plus every currently-expanded folder under the affected
+    // repo so files added inside an expanded subtree show up — without this
+    // the merge preserves the stale children and the user has to manually
+    // re-expand to see new files. repository_name is set for multi-repo
+    // task roots; scope to that repo's branch when present.
+    if (change.operation === "refresh") {
+      foldersToRefresh.add("");
+      const repo = change.repository_name;
+      for (const exp of expandedPaths) {
+        if (!repo || exp === repo || exp.startsWith(repo + "/")) {
+          foldersToRefresh.add(exp);
+        }
+      }
+      continue;
+    }
     const p = change.path;
     const lastSlash = p.lastIndexOf("/");
-    candidates.add(lastSlash === -1 ? "" : p.substring(0, lastSlash));
-    candidates.add(p);
-  }
-  const foldersToRefresh = new Set<string>();
-  for (const c of candidates) {
-    if (c === "" || expandedPaths.has(c)) foldersToRefresh.add(c);
+    const parent = lastSlash === -1 ? "" : p.substring(0, lastSlash);
+    if (parent === "" || expandedPaths.has(parent)) foldersToRefresh.add(parent);
+    if (p === "" || expandedPaths.has(p)) foldersToRefresh.add(p);
   }
   if (foldersToRefresh.size === 0) return;
 

--- a/apps/web/components/task/file-browser-hooks.ts
+++ b/apps/web/components/task/file-browser-hooks.ts
@@ -183,10 +183,7 @@ export function applyFileChanges(ctx: {
           }
           return node.children ? { ...node, children: node.children.map(patchNode) } : node;
         };
-        // Recurse over the root's already-merged children — re-running patchNode
-        // on the root itself would re-match folderUpdates.has("") and replace
-        // the merged children with the raw depth-1 server response, discarding
-        // every preserved subtree from the merge block above.
+        // Skip root: already merged above; re-matching folderUpdates.has("") here would overwrite preserved subtrees.
         return { ...updated, children: updated.children?.map(patchNode) };
       });
       setLoadState("loaded");

--- a/apps/web/components/task/file-browser-hooks.ts
+++ b/apps/web/components/task/file-browser-hooks.ts
@@ -129,13 +129,7 @@ export function applyFileChanges(ctx: {
   const { client, sessionId, expandedPaths, changes, setTree, setLoadState } = ctx;
   const foldersToRefresh = new Set<string>();
   for (const change of changes) {
-    // Polling-detected workspace changes arrive as `refresh` events with an
-    // empty path (the tracker knows "something changed" but not which file).
-    // Refresh root plus every currently-expanded folder under the affected
-    // repo so files added inside an expanded subtree show up — without this
-    // the merge preserves the stale children and the user has to manually
-    // re-expand to see new files. repository_name is set for multi-repo
-    // task roots; scope to that repo's branch when present.
+    // `refresh` events have empty path; refresh root + every expanded folder under the affected repo so new files show up.
     if (change.operation === "refresh") {
       foldersToRefresh.add("");
       const repo = change.repository_name;

--- a/apps/web/lib/types/workspace-files.ts
+++ b/apps/web/lib/types/workspace-files.ts
@@ -35,6 +35,9 @@ export type FileChangeEvent = {
   session_id: string;
   task_id: string;
   agent_id: string;
+  // Repo-scoped events (multi-repo task roots) include the subdir name so the
+  // frontend can scope the refresh to that repo's branch of the tree.
+  repository_name?: string;
 };
 
 export type FileChangeNotificationPayload = {

--- a/apps/web/lib/types/workspace-files.ts
+++ b/apps/web/lib/types/workspace-files.ts
@@ -35,8 +35,7 @@ export type FileChangeEvent = {
   session_id: string;
   task_id: string;
   agent_id: string;
-  // Repo-scoped events (multi-repo task roots) include the subdir name so the
-  // frontend can scope the refresh to that repo's branch of the tree.
+  // Set for multi-repo task roots so the frontend can scope refreshes to the right repo branch.
   repository_name?: string;
 };
 


### PR DESCRIPTION
## Summary

- Per-repo workspace trackers (multi-repo task roots) were never started in CLI passthrough mode because the agent runs via the PTY-based `InteractiveRunner` instead of agentctl's `startAgent` / `startOneShot`, which were the only callers that started them.
- The bare root tracker that `instance.Manager.CreateInstance` did start exits immediately (no git index), so polling was completely idle — file edits made by the agent never produced workspace-stream notifications and the Files panel stayed stale.
- Add `process.Manager.StartAllWorkspaceTrackers` (root + every per-repo tracker, idempotent) and call it from `instance.Manager.CreateInstance` so polling fires for every repo regardless of whether the agent runs via ACP or passthrough.

Fixes #982

## Test plan

- [x] `make build` — backend compiles
- [x] `make lint` — golangci-lint clean
- [x] `make test` — all backend tests pass
- [x] New regression test `TestManager_StartAllWorkspaceTrackers_StartsRootAndRepoTrackers` proves both the root and every per-repo tracker actually start (waits on `initialScanDone`) and that a second call is a no-op
- [ ] Manual: in a multi-repo task with a passthrough profile, watch the Files panel refresh as the agent CLI creates/edits files

🤖 Generated with [Claude Code](https://claude.com/claude-code)