### PR TITLE
fix(agent): honor session passthrough snapshot when starting agent process

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -93,6 +93,7 @@ func (a *lifecycleAdapter) LaunchAgent(ctx context.Context, req *executor.Launch
 		PreviousExecutionID: req.PreviousExecutionID,
 		McpMode:             req.McpMode,
 		IsEphemeral:         req.IsEphemeral,
+		IsPassthrough:       req.IsPassthrough,
 		SetupScript:         req.SetupScript,
 		// Worktree configuration for concurrent agent execution
 		UseWorktree:          req.UseWorktree,

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch.go
@@ -725,6 +725,7 @@ func (m *Manager) promoteWorkspaceExecution(ctx context.Context, execution *Agen
 		if req.PreviousExecutionID != "" {
 			execution.isResumedSession = true
 		}
+		execution.IsPassthrough = req.IsPassthrough
 		m.logger.Info("promoted workspace-only execution to agent execution",
 			zap.String("execution_id", execution.ID),
 			zap.String("session_id", req.SessionID),
@@ -853,6 +854,7 @@ func (m *Manager) buildExecutionFromInstance(
 	if req.PreviousExecutionID != "" {
 		execution.isResumedSession = true
 	}
+	execution.IsPassthrough = req.IsPassthrough
 	cmds := m.buildAgentCommand(req, profileInfo, agentConfig)
 	execution.AgentCommand = cmds.initial
 	execution.ContinueCommand = cmds.continue_

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -17,7 +17,7 @@ import (
 
 // startPassthroughExecution dispatches a passthrough-routed execution to the
 // resume or fresh launch path. profileInfo may be nil — see routePassthrough's
-// contract. Extracted so StartAgentProcess stays under the nestif budget.
+// contract.
 func (m *Manager) startPassthroughExecution(ctx context.Context, execution *AgentExecution, profileInfo *AgentProfileInfo) error {
 	if execution.isResumedSession {
 		// Resume reuses the launched session id; ResumePassthroughSession does

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -24,16 +24,29 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) err
 		return fmt.Errorf("execution %q not found", executionID)
 	}
 
-	// Check if this execution should use passthrough mode
+	// Decide passthrough vs ACP. The session-creation snapshot
+	// (execution.IsPassthrough, sourced from TaskSession.IsPassthrough) is
+	// the source of truth: a profile that toggles CLIPassthrough after the
+	// session was created must not strand existing sessions in the wrong
+	// launch path (issue #981). Non-session launches (e.g. the low-level
+	// controller.LaunchAgent path) leave IsPassthrough false and fall back to
+	// live profile resolution so first-time launches still pick the current
+	// mode.
 	if execution.AgentProfileID != "" && m.profileResolver != nil {
 		profileInfo, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
-		if err == nil && profileInfo.CLIPassthrough {
-			// On resume (e.g., after backend restart), use the resume command path
-			// so the agent receives resume flags (-c / --resume).
-			if execution.isResumedSession {
-				return m.ResumePassthroughSession(ctx, execution.SessionID)
+		if err == nil {
+			isPassthrough := execution.IsPassthrough
+			if !isPassthrough && execution.SessionID == "" {
+				isPassthrough = profileInfo.CLIPassthrough
 			}
-			return m.startPassthroughSession(ctx, execution, profileInfo)
+			if isPassthrough {
+				// On resume (e.g., after backend restart), use the resume command path
+				// so the agent receives resume flags (-c / --resume).
+				if execution.isResumedSession {
+					return m.ResumePassthroughSession(ctx, execution.SessionID)
+				}
+				return m.startPassthroughSession(ctx, execution, profileInfo)
+			}
 		}
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -15,6 +15,30 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 )
 
+// startPassthroughExecution dispatches a passthrough-routed execution to the
+// resume or fresh launch path. profileInfo may be nil — see routePassthrough's
+// contract. Extracted so StartAgentProcess stays under the nestif budget.
+func (m *Manager) startPassthroughExecution(ctx context.Context, execution *AgentExecution, profileInfo *AgentProfileInfo) error {
+	if execution.isResumedSession {
+		// Resume reuses the launched session id; ResumePassthroughSession does
+		// its own profile lookup for command building.
+		return m.ResumePassthroughSession(ctx, execution.SessionID)
+	}
+	if profileInfo == nil {
+		// Snapshot-driven routing leaves profileInfo nil so we resolve fresh
+		// here for command building.
+		if execution.AgentProfileID == "" || m.profileResolver == nil {
+			return fmt.Errorf("execution %q is passthrough but has no resolvable profile", execution.ID)
+		}
+		resolved, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
+		if err != nil {
+			return fmt.Errorf("resolve profile for passthrough execution %q: %w", execution.ID, err)
+		}
+		profileInfo = resolved
+	}
+	return m.startPassthroughSession(ctx, execution, profileInfo)
+}
+
 // routePassthrough decides whether an execution should launch on the passthrough
 // PTY path or the ACP path. The session-creation snapshot
 // (execution.IsPassthrough) is authoritative for session-backed launches.
@@ -68,27 +92,8 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) err
 	// transient resolve error must not silently route a passthrough session
 	// to ACP — the resume branch routes on the snapshot alone, and the fresh
 	// branch surfaces the resolve error explicitly.
-	isPassthrough, profileInfo := m.routePassthrough(ctx, execution)
-	if isPassthrough {
-		if execution.isResumedSession {
-			// Resume reuses the launched session id; ResumePassthroughSession
-			// does its own profile lookup for command building.
-			return m.ResumePassthroughSession(ctx, execution.SessionID)
-		}
-		// profileInfo is only pre-populated when routing already resolved it
-		// (sessionless fallback). Snapshot-driven routing leaves it nil so we
-		// resolve fresh here for command building.
-		if profileInfo == nil {
-			if execution.AgentProfileID == "" || m.profileResolver == nil {
-				return fmt.Errorf("execution %q is passthrough but has no resolvable profile", executionID)
-			}
-			resolved, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
-			if err != nil {
-				return fmt.Errorf("resolve profile for passthrough execution %q: %w", executionID, err)
-			}
-			profileInfo = resolved
-		}
-		return m.startPassthroughSession(ctx, execution, profileInfo)
+	if isPassthrough, profileInfo := m.routePassthrough(ctx, execution); isPassthrough {
+		return m.startPassthroughExecution(ctx, execution, profileInfo)
 	}
 
 	if execution.agentctl == nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -15,6 +15,27 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 )
 
+// routePassthrough decides whether an execution should launch on the passthrough
+// PTY path or the ACP path. The session-creation snapshot
+// (execution.IsPassthrough) is authoritative for session-backed launches.
+// Sessionless launches (legacy controller.LaunchAgent) fall back to live profile
+// state so first-time launches reflect the current mode. A profile resolve
+// failure on the fallback path is treated as "not passthrough" — callers that
+// need profile info for command building handle the resolve error themselves.
+func (m *Manager) routePassthrough(ctx context.Context, execution *AgentExecution) bool {
+	if execution.IsPassthrough {
+		return true
+	}
+	if execution.SessionID != "" || execution.AgentProfileID == "" || m.profileResolver == nil {
+		return false
+	}
+	profileInfo, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
+	if err != nil || profileInfo == nil {
+		return false
+	}
+	return profileInfo.CLIPassthrough
+}
+
 // StartAgentProcess configures and starts the agent subprocess for an execution.
 // This must be called after Launch() to actually start the agent (e.g., auggie, codex).
 // The command is built internally based on the execution's agent profile.
@@ -28,26 +49,31 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) err
 	// (execution.IsPassthrough, sourced from TaskSession.IsPassthrough) is
 	// the source of truth: a profile that toggles CLIPassthrough after the
 	// session was created must not strand existing sessions in the wrong
-	// launch path (issue #981). Non-session launches (e.g. the low-level
+	// launch path. Non-session launches (e.g. the low-level
 	// controller.LaunchAgent path) leave IsPassthrough false and fall back to
 	// live profile resolution so first-time launches still pick the current
 	// mode.
-	if execution.AgentProfileID != "" && m.profileResolver != nil {
-		profileInfo, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
-		if err == nil {
-			isPassthrough := execution.IsPassthrough
-			if !isPassthrough && execution.SessionID == "" {
-				isPassthrough = profileInfo.CLIPassthrough
-			}
-			if isPassthrough {
-				// On resume (e.g., after backend restart), use the resume command path
-				// so the agent receives resume flags (-c / --resume).
-				if execution.isResumedSession {
-					return m.ResumePassthroughSession(ctx, execution.SessionID)
-				}
-				return m.startPassthroughSession(ctx, execution, profileInfo)
-			}
+	//
+	// Profile resolution is needed only for *command building* in the
+	// non-resume passthrough path; it is not part of the routing decision. A
+	// transient resolve error must not silently route a passthrough session
+	// to ACP — the resume branch routes on the snapshot alone, and the fresh
+	// branch surfaces the resolve error explicitly.
+	isPassthrough := m.routePassthrough(ctx, execution)
+	if isPassthrough {
+		if execution.isResumedSession {
+			// Resume reuses the launched session id; ResumePassthroughSession
+			// does its own profile lookup for command building.
+			return m.ResumePassthroughSession(ctx, execution.SessionID)
 		}
+		if execution.AgentProfileID == "" || m.profileResolver == nil {
+			return fmt.Errorf("execution %q is passthrough but has no resolvable profile", executionID)
+		}
+		profileInfo, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
+		if err != nil {
+			return fmt.Errorf("resolve profile for passthrough execution %q: %w", executionID, err)
+		}
+		return m.startPassthroughSession(ctx, execution, profileInfo)
 	}
 
 	if execution.agentctl == nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup.go
@@ -22,18 +22,27 @@ import (
 // state so first-time launches reflect the current mode. A profile resolve
 // failure on the fallback path is treated as "not passthrough" — callers that
 // need profile info for command building handle the resolve error themselves.
-func (m *Manager) routePassthrough(ctx context.Context, execution *AgentExecution) bool {
+//
+// When the sessionless fallback path resolved the profile, the resolved
+// *AgentProfileInfo is returned so the caller can reuse it for command building
+// without a second round-trip. Snapshot-driven routing returns nil for the
+// profile because the caller must resolve fresh — the snapshot deliberately
+// outlives any particular live profile state.
+func (m *Manager) routePassthrough(ctx context.Context, execution *AgentExecution) (bool, *AgentProfileInfo) {
 	if execution.IsPassthrough {
-		return true
+		return true, nil
 	}
 	if execution.SessionID != "" || execution.AgentProfileID == "" || m.profileResolver == nil {
-		return false
+		return false, nil
 	}
 	profileInfo, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
 	if err != nil || profileInfo == nil {
-		return false
+		return false, nil
 	}
-	return profileInfo.CLIPassthrough
+	if !profileInfo.CLIPassthrough {
+		return false, nil
+	}
+	return true, profileInfo
 }
 
 // StartAgentProcess configures and starts the agent subprocess for an execution.
@@ -59,19 +68,25 @@ func (m *Manager) StartAgentProcess(ctx context.Context, executionID string) err
 	// transient resolve error must not silently route a passthrough session
 	// to ACP — the resume branch routes on the snapshot alone, and the fresh
 	// branch surfaces the resolve error explicitly.
-	isPassthrough := m.routePassthrough(ctx, execution)
+	isPassthrough, profileInfo := m.routePassthrough(ctx, execution)
 	if isPassthrough {
 		if execution.isResumedSession {
 			// Resume reuses the launched session id; ResumePassthroughSession
 			// does its own profile lookup for command building.
 			return m.ResumePassthroughSession(ctx, execution.SessionID)
 		}
-		if execution.AgentProfileID == "" || m.profileResolver == nil {
-			return fmt.Errorf("execution %q is passthrough but has no resolvable profile", executionID)
-		}
-		profileInfo, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
-		if err != nil {
-			return fmt.Errorf("resolve profile for passthrough execution %q: %w", executionID, err)
+		// profileInfo is only pre-populated when routing already resolved it
+		// (sessionless fallback). Snapshot-driven routing leaves it nil so we
+		// resolve fresh here for command building.
+		if profileInfo == nil {
+			if execution.AgentProfileID == "" || m.profileResolver == nil {
+				return fmt.Errorf("execution %q is passthrough but has no resolvable profile", executionID)
+			}
+			resolved, err := m.profileResolver.ResolveProfile(ctx, execution.AgentProfileID)
+			if err != nil {
+				return fmt.Errorf("resolve profile for passthrough execution %q: %w", executionID, err)
+			}
+			profileInfo = resolved
 		}
 		return m.startPassthroughSession(ctx, execution, profileInfo)
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
@@ -43,7 +43,9 @@ func TestStartAgentProcess_NonPassthrough_NoAgentctl(t *testing.T) {
 		SessionID:      "sess-1",
 		AgentProfileID: "profile-1",
 	}
-	mgr.executionStore.Add(execution)
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
 
 	err := mgr.StartAgentProcess(context.Background(), "exec-1")
 	if err == nil {
@@ -62,9 +64,12 @@ func TestStartAgentProcess_Passthrough_NotResumed(t *testing.T) {
 		ID:               "exec-1",
 		SessionID:        "sess-1",
 		AgentProfileID:   "profile-1",
+		IsPassthrough:    true,
 		isResumedSession: false,
 	}
-	mgr.executionStore.Add(execution)
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
 
 	err := mgr.StartAgentProcess(context.Background(), "exec-1")
 	if err == nil {
@@ -84,9 +89,12 @@ func TestStartAgentProcess_Passthrough_Resumed(t *testing.T) {
 		ID:               "exec-1",
 		SessionID:        "sess-1",
 		AgentProfileID:   "profile-1",
+		IsPassthrough:    true,
 		isResumedSession: true,
 	}
-	mgr.executionStore.Add(execution)
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
 
 	err := mgr.StartAgentProcess(context.Background(), "exec-1")
 	if err == nil {
@@ -100,5 +108,89 @@ func TestStartAgentProcess_Passthrough_Resumed(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "for passthrough mode") {
 		t.Errorf("expected ResumePassthroughSession path (no 'for passthrough mode' suffix), got: %v", err)
+	}
+}
+
+// Issue #981: a session created in agent (ACP) mode must keep using the ACP
+// launch path even after its profile has been toggled to CLIPassthrough — the
+// session-snapshot wins so existing sessions don't get stranded.
+func TestStartAgentProcess_AgentSession_IgnoresProfileToggleToPassthrough(t *testing.T) {
+	mgr := newTestManager()
+	// Profile currently advertises passthrough — simulates the post-toggle state.
+	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: true}
+
+	execution := &AgentExecution{
+		ID:             "exec-1",
+		SessionID:      "sess-1",
+		AgentProfileID: "profile-1",
+		// Session snapshot: false (session was created when profile was ACP).
+		IsPassthrough: false,
+	}
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	err := mgr.StartAgentProcess(context.Background(), "exec-1")
+	if err == nil {
+		t.Fatal("expected error (no agentctl client)")
+	}
+	// We must hit the ACP path, which errors on the missing agentctl client.
+	// Passthrough errors look like "interactive runner not available [...]"
+	// — seeing that here would mean the snapshot was ignored.
+	if !strings.Contains(err.Error(), "no agentctl client") {
+		t.Errorf("expected ACP path to fail on missing agentctl client, got: %v", err)
+	}
+}
+
+// Mirror of the bug fix in the opposite direction: a session created in
+// passthrough mode must keep using the passthrough path even if the profile
+// is later toggled back to ACP.
+func TestStartAgentProcess_PassthroughSession_IgnoresProfileToggleToAgent(t *testing.T) {
+	mgr := newTestManager()
+	// Profile currently advertises ACP — simulates a toggle away from passthrough.
+	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: false}
+
+	execution := &AgentExecution{
+		ID:             "exec-1",
+		SessionID:      "sess-1",
+		AgentProfileID: "profile-1",
+		// Session snapshot: true (session was created when profile was passthrough).
+		IsPassthrough: true,
+	}
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	err := mgr.StartAgentProcess(context.Background(), "exec-1")
+	if err == nil {
+		t.Fatal("expected error (no interactive runner)")
+	}
+	if !strings.Contains(err.Error(), "interactive runner not available") {
+		t.Errorf("expected passthrough path to fail on missing interactive runner, got: %v", err)
+	}
+}
+
+// Sessionless launches (e.g. the legacy controller.LaunchAgent path that
+// doesn't carry a SessionID) still fall back to live profile resolution so
+// first-time launches reflect the current mode.
+func TestStartAgentProcess_NoSession_FallsBackToLiveProfile(t *testing.T) {
+	mgr := newTestManager()
+	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: true}
+
+	execution := &AgentExecution{
+		ID:             "exec-1",
+		AgentProfileID: "profile-1",
+		// No SessionID, no snapshot → use live profile state.
+	}
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	err := mgr.StartAgentProcess(context.Background(), "exec-1")
+	if err == nil {
+		t.Fatal("expected error (no interactive runner)")
+	}
+	if !strings.Contains(err.Error(), "interactive runner not available") {
+		t.Errorf("expected passthrough path via live fallback, got: %v", err)
 	}
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
@@ -2,16 +2,23 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
 
 // mockAgentProfileResolver returns a profile pointing to the mock-agent.
+// When err is non-nil, ResolveProfile returns that error and a nil profile —
+// simulating transient DB hiccups, network failures, or deleted profiles.
 type mockAgentProfileResolver struct {
 	cliPassthrough bool
+	err            error
 }
 
 func (m *mockAgentProfileResolver) ResolveProfile(_ context.Context, profileID string) (*AgentProfileInfo, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	return &AgentProfileInfo{
 		ProfileID:      profileID,
 		ProfileName:    "Test Profile",
@@ -111,8 +118,8 @@ func TestStartAgentProcess_Passthrough_Resumed(t *testing.T) {
 	}
 }
 
-// Issue #981: a session created in agent (ACP) mode must keep using the ACP
-// launch path even after its profile has been toggled to CLIPassthrough — the
+// A session created in agent (ACP) mode must keep using the ACP launch path
+// even after its profile has been toggled to CLIPassthrough — the
 // session-snapshot wins so existing sessions don't get stranded.
 func TestStartAgentProcess_AgentSession_IgnoresProfileToggleToPassthrough(t *testing.T) {
 	mgr := newTestManager()
@@ -167,6 +174,66 @@ func TestStartAgentProcess_PassthroughSession_IgnoresProfileToggleToAgent(t *tes
 	}
 	if !strings.Contains(err.Error(), "interactive runner not available") {
 		t.Errorf("expected passthrough path to fail on missing interactive runner, got: %v", err)
+	}
+}
+
+// When ResolveProfile errors on a passthrough resume, the routing decision
+// must still honor the snapshot and stay on the passthrough branch. The
+// downstream command builder may then surface the resolve error explicitly —
+// what matters is that we do NOT silently fall through to the ACP path (the
+// bug that would otherwise strand the session in the wrong launch mode).
+func TestStartAgentProcess_PassthroughResume_SurvivesProfileResolveError(t *testing.T) {
+	mgr := newTestManager()
+	mgr.profileResolver = &mockAgentProfileResolver{err: errors.New("transient DB error")}
+
+	execution := &AgentExecution{
+		ID:               "exec-1",
+		SessionID:        "sess-1",
+		AgentProfileID:   "profile-1",
+		IsPassthrough:    true,
+		isResumedSession: true,
+	}
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	err := mgr.StartAgentProcess(context.Background(), "exec-1")
+	if err == nil {
+		t.Fatal("expected error from the passthrough branch")
+	}
+	// ACP-path "no agentctl client" error would mean the snapshot was
+	// ignored and routing silently picked the wrong branch.
+	if strings.Contains(err.Error(), "no agentctl client") {
+		t.Errorf("snapshot must keep us on the passthrough branch, got ACP error: %v", err)
+	}
+}
+
+// A fresh passthrough launch (not a resume) needs the profile for command
+// building, so a profile-resolve error must surface as an explicit error
+// rather than silently falling through to ACP.
+func TestStartAgentProcess_FreshPassthrough_SurfacesProfileResolveError(t *testing.T) {
+	mgr := newTestManager()
+	mgr.profileResolver = &mockAgentProfileResolver{err: errors.New("transient DB error")}
+
+	execution := &AgentExecution{
+		ID:             "exec-1",
+		SessionID:      "sess-1",
+		AgentProfileID: "profile-1",
+		IsPassthrough:  true,
+	}
+	if err := mgr.executionStore.Add(execution); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	err := mgr.StartAgentProcess(context.Background(), "exec-1")
+	if err == nil {
+		t.Fatal("expected profile-resolve error to surface")
+	}
+	if !strings.Contains(err.Error(), "resolve profile") {
+		t.Errorf("expected resolve-profile error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "agentctl client") {
+		t.Errorf("snapshot must keep us on the passthrough branch, got ACP error: %v", err)
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -63,7 +63,7 @@ type AgentExecution struct {
 	// time (TaskSession.IsPassthrough snapshot). StartAgentProcess uses this
 	// instead of re-resolving the live profile so a profile that toggles
 	// CLIPassthrough after the session was created cannot strand existing
-	// sessions in the wrong launch path. See issue #981.
+	// sessions in the wrong launch path.
 	IsPassthrough bool
 
 	// Passthrough mode info (CLI passthrough without ACP)
@@ -348,7 +348,7 @@ type LaunchRequest struct {
 	// path so a profile that toggles CLIPassthrough after the session was
 	// created does not strand the session in the wrong mode. Non-session
 	// launches (e.g. the low-level controller.LaunchAgent path) leave this
-	// false and fall back to live profile resolution. See issue #981.
+	// false and fall back to live profile resolution.
 	IsPassthrough bool
 
 	// Executor configuration - determines which runtime to use

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -59,6 +59,13 @@ type AgentExecution struct {
 	standaloneInstanceID string // Instance ID in standalone agentctl
 	standalonePort       int    // Port of the standalone execution
 
+	// IsPassthrough captures the session's mode as decided at session-creation
+	// time (TaskSession.IsPassthrough snapshot). StartAgentProcess uses this
+	// instead of re-resolving the live profile so a profile that toggles
+	// CLIPassthrough after the session was created cannot strand existing
+	// sessions in the wrong launch path. See issue #981.
+	IsPassthrough bool
+
 	// Passthrough mode info (CLI passthrough without ACP)
 	PassthroughProcessID string    // Process ID in the interactive runner (empty if not in passthrough mode)
 	PassthroughStartedAt time.Time // When the current passthrough process was launched; used to detect fast-fail exits and skip auto-restart loops
@@ -334,6 +341,15 @@ type LaunchRequest struct {
 	// Ephemeral tasks (quick chat) get fallback workspace directories when no repo is configured.
 	// Non-ephemeral tasks without a workspace path will not receive a fallback directory.
 	IsEphemeral bool
+
+	// IsPassthrough is the session's mode snapshot taken when the session was
+	// created (TaskSession.IsPassthrough). When the launch request originates
+	// from an existing session, this is the source of truth for the launch
+	// path so a profile that toggles CLIPassthrough after the session was
+	// created does not strand the session in the wrong mode. Non-session
+	// launches (e.g. the low-level controller.LaunchAgent path) leave this
+	// false and fall back to live profile resolution. See issue #981.
+	IsPassthrough bool
 
 	// Executor configuration - determines which runtime to use
 	ExecutorType        string            // Executor type (e.g., "local", "worktree", "local_docker") - determines runtime

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -261,6 +261,15 @@ type LaunchAgentRequest struct {
 	IsEphemeral         bool              // Ephemeral task (quick chat) — enables fallback workspace creation
 	WorkspacePath       string            // Optional host folder for repo-less tasks (overrides scratch fallback)
 
+	// IsPassthrough is the session's mode snapshot (TaskSession.IsPassthrough)
+	// at session-creation time. Forwarded to the lifecycle manager so
+	// StartAgentProcess routes to the passthrough vs ACP path based on the
+	// session's original mode, not on live profile state — preventing
+	// existing sessions from getting stranded when a profile's
+	// CLIPassthrough flag is toggled after the session was created
+	// (issue #981).
+	IsPassthrough bool
+
 	// Setup script from executor profile (runs in execution environment before agent starts)
 	SetupScript string
 

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -266,8 +266,7 @@ type LaunchAgentRequest struct {
 	// StartAgentProcess routes to the passthrough vs ACP path based on the
 	// session's original mode, not on live profile state — preventing
 	// existing sessions from getting stranded when a profile's
-	// CLIPassthrough flag is toggled after the session was created
-	// (issue #981).
+	// CLIPassthrough flag is toggled after the session was created.
 	IsPassthrough bool
 
 	// Setup script from executor profile (runs in execution environment before agent starts)

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -613,6 +613,7 @@ func (e *Executor) buildLaunchAgentRequest(ctx context.Context, task *v1.Task, s
 		SessionID:         sessionID,
 		TaskEnvironmentID: session.TaskEnvironmentID,
 		IsEphemeral:       task.IsEphemeral,
+		IsPassthrough:     session.IsPassthrough,
 		WorkspacePath:     session.WorkspacePath,
 	}
 

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -295,6 +295,7 @@ func (e *Executor) buildSwitchModelRequest(ctx context.Context, task *models.Tas
 		ExecutorType:      execConfig.ExecutorType,
 		Metadata:          execConfig.Metadata,
 		IsEphemeral:       task.IsEphemeral,
+		IsPassthrough:     session.IsPassthrough,
 		TaskEnvironmentID: session.TaskEnvironmentID,
 	}
 

--- a/apps/backend/internal/orchestrator/executor/executor_resume.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume.go
@@ -500,6 +500,7 @@ func (e *Executor) buildResumeRequest(ctx context.Context, task *v1.Task, sessio
 		TaskDescription:   task.Description,
 		Priority:          task.Priority,
 		IsEphemeral:       task.IsEphemeral,
+		IsPassthrough:     session.IsPassthrough,
 		TaskEnvironmentID: session.TaskEnvironmentID,
 	}
 

--- a/apps/backend/internal/orchestrator/executor/executor_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_test.go
@@ -229,14 +229,10 @@ func TestResumeSession_CancelledStateForceCleansUpStaleState(t *testing.T) {
 	}
 }
 
-// TestResumeSession_PropagatesIsPassthrough is a regression test for issue
-// #981: when a user toggles a profile's CLIPassthrough flag and restarts the
-// server, sessions created in the original mode used to silently re-resolve
-// the live profile and pick the new (wrong) launch path, leaving them stuck
-// in "starting". The fix snapshots the session's IsPassthrough at session-
-// creation time and propagates it through the resume request so the lifecycle
-// manager honors the session's original mode regardless of post-create profile
-// toggles.
+// TestResumeSession_PropagatesIsPassthrough verifies the session's IsPassthrough
+// snapshot taken at session-creation time is carried through the resume request
+// to the lifecycle manager, so a profile that toggles CLIPassthrough after the
+// session was created cannot strand existing sessions in the wrong launch path.
 func TestResumeSession_PropagatesIsPassthrough(t *testing.T) {
 	cases := []struct {
 		name             string

--- a/apps/backend/internal/orchestrator/executor/executor_resume_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_resume_test.go
@@ -229,6 +229,55 @@ func TestResumeSession_CancelledStateForceCleansUpStaleState(t *testing.T) {
 	}
 }
 
+// TestResumeSession_PropagatesIsPassthrough is a regression test for issue
+// #981: when a user toggles a profile's CLIPassthrough flag and restarts the
+// server, sessions created in the original mode used to silently re-resolve
+// the live profile and pick the new (wrong) launch path, leaving them stuck
+// in "starting". The fix snapshots the session's IsPassthrough at session-
+// creation time and propagates it through the resume request so the lifecycle
+// manager honors the session's original mode regardless of post-create profile
+// toggles.
+func TestResumeSession_PropagatesIsPassthrough(t *testing.T) {
+	cases := []struct {
+		name             string
+		sessionIsPasstru bool
+	}{
+		{name: "agent_session_keeps_acp", sessionIsPasstru: false},
+		{name: "passthrough_session_keeps_passthrough", sessionIsPasstru: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newMockRepository()
+			setupLiveResumeTestFixture(repo)
+			repo.sessions["sess-1"].IsPassthrough = tc.sessionIsPasstru
+
+			var capturedReq *LaunchAgentRequest
+			agentMgr := &mockAgentManager{
+				launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+					capturedReq = req
+					return &LaunchAgentResponse{
+						AgentExecutionID: "exec-new",
+						Status:           v1.AgentStatusStarting,
+					}, nil
+				},
+				isAgentRunningForSessionFunc: func(_ context.Context, _ string) bool { return false },
+			}
+			exec := newTestExecutor(t, agentMgr, repo)
+
+			if _, err := exec.ResumeSession(context.Background(), repo.sessions["sess-1"], true); err != nil {
+				t.Fatalf("expected resume success, got: %v", err)
+			}
+			if capturedReq == nil {
+				t.Fatal("expected LaunchAgent to be called with a request")
+			}
+			if capturedReq.IsPassthrough != tc.sessionIsPasstru {
+				t.Errorf("IsPassthrough = %v, want %v — without this the lifecycle manager would re-resolve live profile state and ignore the session's mode at creation time",
+					capturedReq.IsPassthrough, tc.sessionIsPasstru)
+			}
+		})
+	}
+}
+
 // TestResumeSession_PropagatesTaskEnvironmentID is a regression test for a
 // post-restart bug where `buildResumeRequest` did not copy
 // `session.TaskEnvironmentID` onto the LaunchAgentRequest. The lifecycle's

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -222,6 +222,65 @@ func TestLaunchPreparedSession_Success(t *testing.T) {
 	}
 }
 
+// TestLaunchPreparedSession_PropagatesIsPassthrough mirrors
+// TestResumeSession_PropagatesIsPassthrough for the initial-launch path: the
+// session's IsPassthrough snapshot must reach the LaunchAgentRequest so the
+// lifecycle manager picks the right launch path. Without this guarantee, a
+// profile that toggles CLIPassthrough after the session was prepared would
+// re-route the session to the wrong mode at start time.
+func TestLaunchPreparedSession_PropagatesIsPassthrough(t *testing.T) {
+	cases := []struct {
+		name             string
+		sessionIsPasstru bool
+	}{
+		{name: "agent_session_keeps_acp", sessionIsPasstru: false},
+		{name: "passthrough_session_keeps_passthrough", sessionIsPasstru: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newMockRepository()
+			session := &models.TaskSession{
+				ID:             "session-pt",
+				TaskID:         "task-pt",
+				AgentProfileID: "profile-pt",
+				IsPassthrough:  tc.sessionIsPasstru,
+				State:          models.TaskSessionStateCreated,
+				StartedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+			}
+			repo.sessions[session.ID] = session
+
+			var capturedReq *LaunchAgentRequest
+			agentManager := &mockAgentManager{
+				launchAgentFunc: func(_ context.Context, req *LaunchAgentRequest) (*LaunchAgentResponse, error) {
+					capturedReq = req
+					return &LaunchAgentResponse{
+						AgentExecutionID: "exec-pt",
+						Status:           v1.AgentStatusStarting,
+					}, nil
+				},
+			}
+			exec := newTestExecutor(t, agentManager, repo)
+
+			task := &v1.Task{ID: "task-pt", WorkspaceID: "ws-pt", Title: "passthrough test"}
+			if _, err := exec.LaunchPreparedSession(context.Background(), task, session.ID, LaunchOptions{
+				AgentProfileID: "profile-pt",
+				Prompt:         "go",
+				StartAgent:     true,
+			}); err != nil {
+				t.Fatalf("LaunchPreparedSession: %v", err)
+			}
+			if capturedReq == nil {
+				t.Fatal("expected LaunchAgent to be called")
+			}
+			if capturedReq.IsPassthrough != tc.sessionIsPasstru {
+				t.Errorf("IsPassthrough = %v, want %v — without this the lifecycle manager would re-resolve live profile state and ignore the session's mode at creation time",
+					capturedReq.IsPassthrough, tc.sessionIsPasstru)
+			}
+		})
+	}
+}
+
 func TestAssignLaunchTaskEnvironmentID(t *testing.T) {
 	t.Run("reuses existing task environment", func(t *testing.T) {
 		session := &models.TaskSession{ID: "session-1"}


### PR DESCRIPTION
## Summary
- Snapshot `session.IsPassthrough` onto the launch request and forward it through the orchestrator/lifecycle stack so `StartAgentProcess` no longer re-resolves the live profile each launch.
- An existing session keeps the mode it was created with even when its profile's `cli_passthrough` flag is toggled later (issue #981). Sessionless launches (legacy `controller.LaunchAgent`) still fall back to live profile resolution so first-time launches reflect the current mode.

Fixes #981.

## Why this broke
Tasks created in agent (ACP) mode were stuck in "starting" after the user toggled the profile's CLI passthrough flag, restarted, and reopened kandev. `StartAgentProcess` always consulted the live profile, so the post-toggle value routed a session prepared for ACP into the passthrough launch path (and vice versa) — the PTY/agentctl plumbing did not match the session's prepared state, so it never reached RUNNING.

## Test plan
- [x] `make -C apps/backend lint` clean
- [x] `make -C apps/backend test` green (focused: `internal/agent/runtime/lifecycle/`, `internal/orchestrator/...`, `cmd/kandev/`)
- [x] New unit tests: `TestStartAgentProcess_AgentSession_IgnoresProfileToggleToPassthrough`, `TestStartAgentProcess_PassthroughSession_IgnoresProfileToggleToAgent`, `TestStartAgentProcess_NoSession_FallsBackToLiveProfile`, `TestResumeSession_PropagatesIsPassthrough`
- [ ] Manual repro of the issue steps (start in agent mode → toggle to passthrough → restart → reopen) — should resume in ACP rather than stalling