### PR TITLE
fix(loginpty): drain PTY before close on natural child exit

### DIFF
--- a/apps/backend/internal/agent/loginpty/manager.go
+++ b/apps/backend/internal/agent/loginpty/manager.go
@@ -168,11 +168,17 @@ loop:
 			// TestStart_RunsCommandAndExits on CI). Windows ConPTY does NOT
 			// deliver EOF on child exit, so if readLoop is still blocked after
 			// the grace window we close to unblock it.
+			drain := time.NewTimer(500 * time.Millisecond)
 			select {
 			case <-sess.readDone:
-			case <-time.After(500 * time.Millisecond):
-				sess.stop()
+				drain.Stop()
+			case <-drain.C:
 			}
+			// Always close the PTY (idempotent). On the natural-exit
+			// happy path readLoop has already returned by here, so
+			// this only releases the master fd; on the timeout path
+			// it also unblocks a stuck Windows ConPTY Read.
+			sess.stop()
 			break loop
 		case <-idle.C:
 			sess.log.Info("login session idle timeout — terminating")

--- a/apps/backend/internal/agent/loginpty/manager.go
+++ b/apps/backend/internal/agent/loginpty/manager.go
@@ -159,13 +159,20 @@ loop:
 	for {
 		select {
 		case info = <-exited:
-			// Natural child exit. On Windows ConPTY, the underlying handle does
-			// NOT return EOF when the child process terminates, so the readLoop
-			// would block on Read until something closes the PTY. Closing here
-			// unblocks it so the readDone wait below resolves promptly. On Unix
-			// the master already saw EOF from the slave close — this is just an
-			// extra (idempotent) Close that the windowsPTY sync.Once also guards.
-			sess.stop()
+			// Natural child exit. Give readLoop a chance to drain the child's
+			// final output before closing the PTY out from under it. On Unix
+			// the master returns EIO/EOF on next Read once the slave is closed
+			// by child exit — but closing eagerly races with the in-flight
+			// Read, which then returns "file already closed" before delivering
+			// the child's last bytes (this is what flaked
+			// TestStart_RunsCommandAndExits on CI). Windows ConPTY does NOT
+			// deliver EOF on child exit, so if readLoop is still blocked after
+			// the grace window we close to unblock it.
+			select {
+			case <-sess.readDone:
+			case <-time.After(500 * time.Millisecond):
+				sess.stop()
+			}
 			break loop
 		case <-idle.C:
 			sess.log.Info("login session idle timeout — terminating")


### PR DESCRIPTION
## Summary

- CI run [26257243477](https://github.com/kdlbs/kandev/actions/runs/26257243477) flaked on `TestStart_RunsCommandAndExits` (`internal/agent/loginpty`) with `expected 'hello' in output, got ""`.
- Root cause: `Manager.supervise` called `sess.stop()` (which closes the PTY master fd) immediately on natural child exit, racing with `readLoop`'s in-flight `pty.Read()`. Go's poller cancels the blocked Read with `"file already closed"` before the kernel's buffered bytes are delivered, so the child's last output is dropped.
- Fix: wait up to 500ms for `readLoop` to drain naturally (Unix master returns EIO once the slave is closed). Only force-close if drainage doesn't complete in time, preserving the Windows ConPTY path where EOF is never delivered on child exit.

## Test plan

- [x] `go test -race -count=50 -run TestStart_RunsCommandAndExits ./internal/agent/loginpty/` — all green
- [x] `GOMAXPROCS=1 go test -race -count=30 ./internal/agent/loginpty/` — all green (CPU-constrained mimic of CI)
- [x] `gofmt`, `go vet`, `golangci-lint` clean on the package
- [ ] Backend Tests CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)