### PR TITLE
fix(release): build kandev binary with -tags fts5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,15 +360,28 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-mingw-w64-x86-64
 
+      # The `fts5` build tag is REQUIRED on the kandev binary. The office
+      # task search migrations create a `tasks_fts` virtual table using
+      # `USING fts5(...)`; without the tag, mattn/go-sqlite3 lacks the
+      # module and any subsequent boot against a DB that already has the
+      # virtual table fails with "no such module: fts5" during schema init.
+      # See issue #1006 for the regression this prevents.
+      #
+      # Version ldflags mirror apps/backend/Makefile so `kandev --version`
+      # reports the released tag instead of the build-time default "dev".
       - name: Build backend binaries
         env:
           CC: ${{ matrix.cc || '' }}
+          KANDEV_VERSION: ${{ needs.prepare.outputs.tag }}
         run: |
           cd apps/backend
           mkdir -p bin
           EXT=${{ matrix.goos == 'windows' && '.exe' || '' }}
-          go build -o bin/kandev${EXT} ./cmd/kandev
-          go build -o bin/agentctl${EXT} ./cmd/agentctl
+          COMMIT=$(git rev-parse --short HEAD)
+          BUILD_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          LDFLAGS="-s -w -X main.Version=${KANDEV_VERSION} -X main.Commit=${COMMIT} -X main.BuildTime=${BUILD_TIME}"
+          go build -tags fts5 -ldflags "${LDFLAGS}" -o bin/kandev${EXT} ./cmd/kandev
+          go build -ldflags "${LDFLAGS}" -o bin/agentctl${EXT} ./cmd/agentctl
 
       # Cross-compile a linux/amd64 agentctl regardless of the host platform.
       # Remote executors (local Docker, remote Docker, Sprites) bind-mount this

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,6 +380,9 @@ jobs:
           COMMIT=$(git rev-parse --short HEAD)
           BUILD_TIME=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           LDFLAGS="-s -w -X main.Version=${KANDEV_VERSION} -X main.Commit=${COMMIT} -X main.BuildTime=${BUILD_TIME}"
+          # Export to subsequent steps so the cross-compiled agentctl helper
+          # below gets the same version metadata (matches Makefile parity).
+          echo "LDFLAGS=${LDFLAGS}" >> "${GITHUB_ENV}"
           go build -tags fts5 -ldflags "${LDFLAGS}" -o bin/kandev${EXT} ./cmd/kandev
           go build -ldflags "${LDFLAGS}" -o bin/agentctl${EXT} ./cmd/agentctl
 
@@ -392,7 +395,7 @@ jobs:
       - name: Build linux/amd64 agentctl helper
         run: |
           cd apps/backend
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 CC= go build -o bin/agentctl-linux-amd64 ./cmd/agentctl
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 CC= go build -ldflags "${LDFLAGS}" -o bin/agentctl-linux-amd64 ./cmd/agentctl
 
       - name: Package bundle
         run: |


### PR DESCRIPTION
## Summary

- v0.50.0 introduced the `tasks_fts` FTS5 virtual table + sync triggers (#914) and added `-tags fts5` to `apps/backend/Makefile`, but **not** to `.github/workflows/release.yml`. The published binary therefore ships without the SQLite fts5 module.
- Fresh installs are unaffected — `migrateTaskFTS` swallows the "module not available" error and search falls back to LIKE. But any DB that an FTS5-enabled build has already touched contains `tasks_fts` + triggers that reference it, and the non-FTS5 release binary fails schema init on the next DML against `tasks` with `no such module: fts5`.
- This patch adds `-tags fts5` to the release-workflow `kandev` build and propagates the standard version ldflags from the Makefile so `kandev --version` reports the released tag instead of the build-time default `dev`.

Fixes #1006.

## Test plan

- [ ] CI builds the release artifacts cleanly on linux/darwin/windows
- [ ] After release, reproduce the bug scenario from #1006: run a local FTS5-enabled `make start`, then `npx kandev@latest start` against the same `~/.kandev/data/kandev.db` — boot should succeed
- [ ] `kandev --version` on the released binary reports the tag (not `dev`)