### PR TITLE
fix(vcs): default the commit dialog's stage-all checkbox to unchecked

### DIFF
--- a/apps/web/components/task/mobile/session-mobile-top-bar-git-controls.tsx
+++ b/apps/web/components/task/mobile/session-mobile-top-bar-git-controls.tsx
@@ -98,13 +98,13 @@ function useCommitDialogForm(
 ) {
   const [commitMessage, setCommitMessage] = useState("");
   const [commitBody, setCommitBody] = useState("");
-  const [stageAll, setStageAll] = useState(true);
+  const [stageAll, setStageAll] = useState(false);
 
   const handleOpen = (isOpen: boolean) => {
     if (isOpen) {
       setCommitMessage("");
       setCommitBody("");
-      setStageAll(true);
+      setStageAll(false);
     }
     onOpenChange(isOpen);
   };

--- a/apps/web/components/vcs/vcs-dialogs.tsx
+++ b/apps/web/components/vcs/vcs-dialogs.tsx
@@ -61,15 +61,15 @@ type FileSummary = { count: number; additions: number; deletions: number };
 
 /**
  * Counts files for the commit dialog summary.
- * - When `stageAll=true` (the default), include every file (staged + unstaged)
- *   because the commit op stages them all before committing.
- * - When `stageAll=false`, count only staged files — those are the only files
- *   the commit will actually include. Counting all here would over-state what
- *   the commit produces and surprise the user post-commit.
+ * - When `stageAll=true`, include every file (staged + unstaged) because the
+ *   commit op stages them all before committing.
+ * - When `stageAll=false` (the default), count only staged files — those are
+ *   the only files the commit will actually include. Counting all here would
+ *   over-state what the commit produces and surprise the user post-commit.
  */
 function computeFileSummary(
   files: Record<string, FileInfo> | undefined,
-  stageAll: boolean = true,
+  stageAll: boolean = false,
 ): FileSummary {
   if (!files) return { count: 0, additions: 0, deletions: 0 };
   const considered = (Object.values(files) as FileInfo[]).filter((f) => stageAll || f.staged);
@@ -337,12 +337,12 @@ function useCommitDialogState(): UseCommitDialogReturn {
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState("");
   const [body, setBody] = useState("");
-  const [stageAll, setStageAll] = useState(true);
+  const [stageAll, setStageAll] = useState(false);
   const [repo, setRepo] = useState("");
   const openDialog = useCallback((nextRepo?: string) => {
     setMessage("");
     setBody("");
-    setStageAll(true);
+    setStageAll(false);
     // Defensive: callers binding `openDialog` directly to onClick can leak the
     // React MouseEvent into nextRepo. Only accept actual repo strings.
     setRepo(typeof nextRepo === "string" ? nextRepo : "");


### PR DESCRIPTION
The commit dialog opened with "Stage all changes before committing" pre-checked, so a user who had carefully staged a subset of files could quietly include everything else when they hit Commit. Defaulting it off makes the dialog respect whatever was already staged; users who want the old behavior can opt in per commit.

## Validation

- `make -C apps/backend test lint`
- `pnpm --filter @kandev/web typecheck lint`
- `pnpm --filter @kandev/web format`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.