### PR TITLE
chore(web): add dockview session-tab debug logs to investigate wrong-panel bugs

### DIFF
--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -423,7 +423,7 @@ function ensureSiblingPanels(
   const created: string[] = [];
   for (const sid of currentSessionIds) {
     if (sid === effectiveSessionId) continue;
-    if (!api.getPanel(`session:${sid}`)) created.push(sid);
+    if (IS_DEBUG && !api.getPanel(`session:${sid}`)) created.push(sid);
     ensureSessionPanel(api, sid, siblingAnchor, true, createdSet);
   }
   return created;

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -82,7 +82,7 @@ export function setupChatPanelSafetyNet(
         // If all sessions were deleted, leave the layout empty — the user
         // can create a new session via the "+" menu.
         if (!activeSessionId) {
-          debug("setupChatPanelSafetyNet: skip recreate (no active session)");
+          if (IS_DEBUG) debug("setupChatPanelSafetyNet: skip recreate (no active session)");
           return;
         }
         // Don't recreate a panel for a session that no longer exists in the
@@ -461,7 +461,8 @@ function shouldSkipPanelEnsure(
     return true;
   }
   if (!prepareLayoutForSessionPanels(api)) {
-    debug("useAutoSessionTab: skip body (maximized - panels suppressed)", { effectiveSessionId });
+    if (IS_DEBUG)
+      debug("useAutoSessionTab: skip body (maximized - panels suppressed)", { effectiveSessionId });
     createdSet.add(effectiveSessionId);
     return true;
   }
@@ -502,7 +503,7 @@ function runAutoSessionTabEffect(
   );
 
   if (!effectiveSessionId) {
-    debug("useAutoSessionTab: no effectiveSessionId, returning");
+    if (IS_DEBUG) debug("useAutoSessionTab: no effectiveSessionId, returning");
     return;
   }
 

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type MutableRefObject } from "react";
 import type { DockviewApi, DockviewReadyEvent, AddPanelOptions } from "dockview-react";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
@@ -20,12 +20,25 @@ const debug = createDebugLogger("dockview:session-tabs");
 export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: StoreApi<AppState>) {
   return api.onDidActivePanelChange((panel) => {
     if (!panel) return;
-    if (useDockviewStore.getState().isRestoringLayout) return;
+    const isRestoring = useDockviewStore.getState().isRestoringLayout;
+    if (IS_DEBUG) {
+      debug("setupSessionTabSync: onDidActivePanelChange", {
+        panelId: panel.id,
+        isRestoring,
+        currentActiveSessionId: appStore.getState().tasks.activeSessionId,
+        currentActiveTaskId: appStore.getState().tasks.activeTaskId,
+        livePanelIds: api.panels.map((p) => p.id),
+      });
+    }
+    if (isRestoring) return;
     if (!panel.id.startsWith("session:")) return;
     const sid = panel.id.slice("session:".length);
     if (sid && sid !== appStore.getState().tasks.activeSessionId) {
       const taskId = appStore.getState().tasks.activeTaskId;
       if (taskId) {
+        if (IS_DEBUG) {
+          debug("setupSessionTabSync: setActiveSession", { taskId, newSessionId: sid });
+        }
         appStore.getState().setActiveSession(taskId, sid);
       }
     }
@@ -47,6 +60,12 @@ export function setupChatPanelSafetyNet(
     if (useDockviewStore.getState().isRestoringLayout) return;
     const isChatPanel = panel.id === "chat" || panel.id.startsWith("session:");
     if (!isChatPanel) return;
+    if (IS_DEBUG) {
+      debug("setupChatPanelSafetyNet: chat panel removed", {
+        removedPanelId: panel.id,
+        livePanelIds: api.panels.map((p) => p.id),
+      });
+    }
     // Double rAF gives dockview time to finish internal operations like
     // drag-to-split moves (remove from old group → add to new group).
     requestAnimationFrame(() => {
@@ -62,14 +81,33 @@ export function setupChatPanelSafetyNet(
         // Only recreate a panel if there's still an active session.
         // If all sessions were deleted, leave the layout empty — the user
         // can create a new session via the "+" menu.
-        if (!activeSessionId) return;
+        if (!activeSessionId) {
+          debug("setupChatPanelSafetyNet: skip recreate (no active session)");
+          return;
+        }
         // Don't recreate a panel for a session that no longer exists in the
         // store — this guards against handleDelete racing with the safety net.
         const activeTaskId = appStore.getState().tasks.activeTaskId;
         const knownSessions = activeTaskId
           ? (appStore.getState().taskSessionsByTask.itemsByTaskId[activeTaskId] ?? [])
           : [];
-        if (!knownSessions.some((s) => s.id === activeSessionId)) return;
+        if (!knownSessions.some((s) => s.id === activeSessionId)) {
+          if (IS_DEBUG) {
+            debug("setupChatPanelSafetyNet: skip recreate (session not in store)", {
+              activeSessionId,
+              activeTaskId,
+              knownSessionIds: knownSessions.map((s) => s.id),
+            });
+          }
+          return;
+        }
+        if (IS_DEBUG) {
+          debug("setupChatPanelSafetyNet: recreating session panel", {
+            activeSessionId,
+            activeTaskId,
+            anchor: sb ? "rightOfSidebar" : "auto",
+          });
+        }
         api.addPanel({
           id: `session:${activeSessionId}`,
           component: "chat",
@@ -327,6 +365,211 @@ function shouldActivateSessionPanel(args: {
   return sessionChanged && !taskChanged;
 }
 
+type AutoSessionTabRefs = {
+  sessionTabCreatedRef: MutableRefObject<Set<string>>;
+  prevTaskIdRef: MutableRefObject<string | null>;
+  prevSessionIdRef: MutableRefObject<string | null>;
+};
+
+/**
+ * Activate the newly-ensured session panel and update the center-group store
+ * entry. Returns the resolved active panel for sibling anchoring.
+ */
+function activateSessionPanel(
+  api: DockviewApi,
+  effectiveSessionId: string,
+  sessionPanelExistedBefore: boolean,
+  refs: AutoSessionTabRefs,
+  tid: string | null,
+): ReturnType<DockviewApi["getPanel"]> {
+  const activePanel = api.getPanel(`session:${effectiveSessionId}`);
+  if (!activePanel) return activePanel;
+
+  const shouldActivate = shouldActivateSessionPanel({
+    sessionPanelExistedBefore,
+    prevTaskId: refs.prevTaskIdRef.current,
+    prevSessionId: refs.prevSessionIdRef.current,
+    currentTaskId: tid,
+    currentSessionId: effectiveSessionId,
+  });
+  if (IS_DEBUG) {
+    debug("useAutoSessionTab: activation decision", {
+      effectiveSessionId,
+      shouldActivate,
+      sessionPanelExistedBefore,
+      prevTaskId: refs.prevTaskIdRef.current,
+      prevSessionId: refs.prevSessionIdRef.current,
+      currentTaskId: tid,
+      activeGroupId: activePanel.group.id,
+    });
+  }
+  if (shouldActivate) activePanel.api.setActive();
+  useDockviewStore.setState({ centerGroupId: activePanel.group.id });
+  return activePanel;
+}
+
+/**
+ * Add sibling session panels (inactive) into the same group as the active
+ * panel so they appear as tabs. Returns the list of newly-created sibling IDs
+ * for debug logging.
+ */
+function ensureSiblingPanels(
+  api: DockviewApi,
+  currentSessionIds: string[],
+  effectiveSessionId: string,
+  siblingAnchor: AddPanelOptions["position"],
+  createdSet: Set<string>,
+): string[] {
+  const created: string[] = [];
+  for (const sid of currentSessionIds) {
+    if (sid === effectiveSessionId) continue;
+    if (!api.getPanel(`session:${sid}`)) created.push(sid);
+    ensureSessionPanel(api, sid, siblingAnchor, true, createdSet);
+  }
+  return created;
+}
+
+/** Resolve the current session ID list from the store for the active task. */
+function resolveCurrentSessionIds(appStore: ReturnType<typeof useAppStoreApi>): {
+  tid: string | null;
+  currentSessionIds: string[];
+} {
+  const tid = appStore.getState().tasks.activeTaskId;
+  const currentSessions = tid
+    ? (appStore.getState().taskSessionsByTask.itemsByTaskId[tid] ?? [])
+    : [];
+  return { tid: tid ?? null, currentSessionIds: currentSessions.map((s) => s.id) };
+}
+
+/**
+ * Check early-exit conditions after reconciliation. Returns true when the
+ * caller should bail out before ensuring panels.
+ */
+function shouldSkipPanelEnsure(
+  api: DockviewApi,
+  effectiveSessionId: string,
+  currentSessionIds: string[],
+  createdSet: Set<string>,
+): boolean {
+  if (!currentSessionIds.includes(toSessionId(effectiveSessionId))) {
+    if (IS_DEBUG) {
+      debug("useAutoSessionTab: skip (session not in store yet)", {
+        effectiveSessionId,
+        currentSessionIds,
+      });
+    }
+    return true;
+  }
+  if (!prepareLayoutForSessionPanels(api)) {
+    debug("useAutoSessionTab: skip body (maximized - panels suppressed)", { effectiveSessionId });
+    createdSet.add(effectiveSessionId);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Core effect body for useAutoSessionTab — extracted to reduce complexity of
+ * the hook itself.
+ */
+function runAutoSessionTabEffect(
+  effectiveSessionId: string | null,
+  appStore: ReturnType<typeof useAppStoreApi>,
+  refs: AutoSessionTabRefs,
+): void {
+  const api = useDockviewStore.getState().api;
+  if (!api) return;
+
+  const { tid, currentSessionIds } = resolveCurrentSessionIds(appStore);
+
+  if (IS_DEBUG) {
+    debug("useAutoSessionTab: effect entry", {
+      effectiveSessionId,
+      activeTaskId: tid,
+      prevTaskId: refs.prevTaskIdRef.current,
+      prevSessionId: refs.prevSessionIdRef.current,
+      currentSessionIds,
+      livePanelIdsBefore: api.panels.map((p) => p.id),
+      createdSet: Array.from(refs.sessionTabCreatedRef.current),
+    });
+  }
+
+  reconcileRemovedSessionPanels(
+    api,
+    refs.sessionTabCreatedRef.current,
+    currentSessionIds,
+    effectiveSessionId ?? "",
+  );
+
+  if (!effectiveSessionId) {
+    debug("useAutoSessionTab: no effectiveSessionId, returning");
+    return;
+  }
+
+  if (
+    shouldSkipPanelEnsure(
+      api,
+      effectiveSessionId,
+      currentSessionIds,
+      refs.sessionTabCreatedRef.current,
+    )
+  ) {
+    return;
+  }
+
+  const initialPosition = resolveInitialPosition(api);
+  const sessionPanelExistedBefore = !!api.getPanel(`session:${effectiveSessionId}`);
+
+  if (IS_DEBUG) {
+    debug("useAutoSessionTab: ensuring active session panel", {
+      effectiveSessionId,
+      sessionPanelExistedBefore,
+      initialPosition: JSON.stringify(initialPosition),
+    });
+  }
+
+  ensureSessionPanel(
+    api,
+    effectiveSessionId,
+    initialPosition,
+    false,
+    refs.sessionTabCreatedRef.current,
+  );
+
+  const activePanel = activateSessionPanel(
+    api,
+    effectiveSessionId,
+    sessionPanelExistedBefore,
+    refs,
+    tid,
+  );
+
+  const siblingAnchor: AddPanelOptions["position"] = activePanel
+    ? { referenceGroup: activePanel.group.id }
+    : initialPosition;
+
+  const siblingsCreated = ensureSiblingPanels(
+    api,
+    currentSessionIds,
+    effectiveSessionId,
+    siblingAnchor,
+    refs.sessionTabCreatedRef.current,
+  );
+
+  if (IS_DEBUG) {
+    debug("useAutoSessionTab: effect exit", {
+      effectiveSessionId,
+      siblingsCreated,
+      livePanelIdsAfter: api.panels.map((p) => p.id),
+      activeGroupId: activePanel?.group.id ?? null,
+      liveActivePanelId: api.activePanel?.id ?? null,
+    });
+  }
+
+  refs.prevTaskIdRef.current = tid;
+  refs.prevSessionIdRef.current = effectiveSessionId;
+}
+
 /**
  * Open a dockview tab for every session of the active task and keep them in sync
  * with the store.
@@ -357,74 +600,10 @@ export function useAutoSessionTab(effectiveSessionId: string | null) {
   });
 
   useEffect(() => {
-    const api = useDockviewStore.getState().api;
-    if (!api) return;
-
-    // Re-read the current session list straight from the store so we iterate
-    // the live array (sessionIdsKey change is what gets us here).
-    const tid = appStore.getState().tasks.activeTaskId;
-    const currentSessions = tid
-      ? (appStore.getState().taskSessionsByTask.itemsByTaskId[tid] ?? [])
-      : [];
-    const currentSessionIds = currentSessions.map((s) => s.id);
-
-    // Always reconcile removed panels — even when effectiveSessionId is null
-    // (e.g. all sessions deleted) so orphaned tabs are closed.
-    reconcileRemovedSessionPanels(
-      api,
-      sessionTabCreatedRef.current,
-      currentSessionIds,
-      effectiveSessionId ?? "",
-    );
-
-    if (!effectiveSessionId) return;
-
-    // Don't create a panel for a session that no longer exists in the store —
-    // guards against a race where removeTaskSession fires before the active
-    // session is switched, which would cause the deleted session's panel to
-    // be re-created by ensureSessionPanel.
-    if (!currentSessionIds.includes(toSessionId(effectiveSessionId))) return;
-
-    if (!prepareLayoutForSessionPanels(api)) {
-      sessionTabCreatedRef.current.add(effectiveSessionId);
-      return;
-    }
-
-    const initialPosition = resolveInitialPosition(api);
-
-    // Active panel first so its group becomes the anchor for siblings.
-    const sessionPanelExistedBefore = !!api.getPanel(`session:${effectiveSessionId}`);
-    ensureSessionPanel(
-      api,
-      effectiveSessionId,
-      initialPosition,
-      false,
-      sessionTabCreatedRef.current,
-    );
-    const activePanel = api.getPanel(`session:${effectiveSessionId}`);
-    if (activePanel) {
-      const shouldActivate = shouldActivateSessionPanel({
-        sessionPanelExistedBefore,
-        prevTaskId: prevTaskIdRef.current,
-        prevSessionId: prevSessionIdRef.current,
-        currentTaskId: tid ?? null,
-        currentSessionId: effectiveSessionId,
-      });
-      if (shouldActivate) {
-        activePanel.api.setActive();
-      }
-      useDockviewStore.setState({ centerGroupId: activePanel.group.id });
-    }
-
-    const siblingAnchor: AddPanelOptions["position"] = activePanel
-      ? { referenceGroup: activePanel.group.id }
-      : initialPosition;
-
-    for (const sid of currentSessionIds) {
-      if (sid === effectiveSessionId) continue;
-      ensureSessionPanel(api, sid, siblingAnchor, true, sessionTabCreatedRef.current);
-    }
-    prevTaskIdRef.current = tid ?? null;
-    prevSessionIdRef.current = effectiveSessionId;
+    runAutoSessionTabEffect(effectiveSessionId, appStore, {
+      sessionTabCreatedRef,
+      prevTaskIdRef,
+      prevSessionIdRef,
+    });
   }, [effectiveSessionId, sessionIdsKey, appStore]);
 }

--- a/apps/web/components/task/task-select-helpers.ts
+++ b/apps/web/components/task/task-select-helpers.ts
@@ -16,6 +16,9 @@ import { INTENT_PR_REVIEW } from "@/lib/state/layout-manager";
 import { replaceTaskUrl } from "@/lib/links";
 import { launchSession } from "@/lib/services/session-launch-service";
 import { buildPrepareRequest } from "@/lib/services/session-launch-helpers";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+
+const debug = createDebugLogger("dockview:task-select");
 
 export type SwitchToSessionFn = (
   taskId: string,
@@ -65,6 +68,16 @@ export function buildSwitchToSession(
     const state = store.getState();
     const oldEnvId = oldSessionId ? (state.environmentIdBySessionId[oldSessionId] ?? null) : null;
     const newEnvId = state.environmentIdBySessionId[sessionId] ?? null;
+    if (IS_DEBUG) {
+      debug("switchToSession: entry", {
+        taskId,
+        sessionId,
+        oldSessionId: oldSessionId ?? null,
+        oldEnvId,
+        newEnvId,
+        path: newEnvId ? "performLayoutSwitch" : "releaseToDefault",
+      });
+    }
     setActiveSession(taskId, sessionId);
     if (newEnvId) {
       performLayoutSwitch(oldEnvId, newEnvId, sessionId);
@@ -77,6 +90,9 @@ export function buildSwitchToSession(
     // layout to default so the new task starts from a clean slate; when the
     // new env id arrives, useEnvSwitchCleanup will adopt it without rebuild.
     if (oldEnvId || oldSessionId !== sessionId) {
+      if (IS_DEBUG) {
+        debug("switchToSession: releasing outgoing env (no newEnvId yet)", { oldEnvId });
+      }
       releaseLayoutToDefault(oldEnvId);
     }
   };
@@ -137,6 +153,14 @@ export function selectTaskWithLayout(params: {
   const { taskId, task, store, switchToSession, loadTaskSessionsForTask } = params;
   const state = store.getState();
   const oldSessionId = state.tasks.activeSessionId;
+  if (IS_DEBUG) {
+    debug("selectTaskWithLayout: entry", {
+      taskId,
+      primarySessionId: task?.primarySessionId ?? null,
+      oldSessionId: oldSessionId ?? null,
+      prevActiveTaskId: state.tasks.activeTaskId ?? null,
+    });
+  }
   if (task?.primarySessionId) {
     const targetSessionId = resolvePreferredSessionId(
       taskId,

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -48,7 +48,7 @@
  *
  *   Other
  *     [ws:connection]         WS hook mount + status transitions
- *     [dockview:*]            layout restore / save / env-switch / session-tabs
+ *     [dockview:*]            layout restore / save / env-switch / session-tabs / task-select
  *     [messages:*]            message fetch / process / lazyload
  *     [session:env-mapping]   session → environment ID mapping
  *


### PR DESCRIPTION
Adds targeted IS_DEBUG-gated logs to the tab-switch and panel-creation code paths so the wrong-panel-on-switch bug can be reproduced and diagnosed with console output. Without these, the sequence of env switches, panel additions, and active-panel decisions is opaque.

**Validation**

- `pnpm --filter @kandev/web typecheck` — passes
- `pnpm --filter @kandev/web lint` — passes (helpers extracted to stay within complexity limits)
- `pnpm --filter @kandev/web test` — passes

**Checklist**

- [ ] Tests added/updated
- [ ] Docs updated if needed

> Note: these logs are temporary instrumentation — they will be stripped before any fix PR is opened.