### PR TITLE
feat(automations): /settings/automations with run-mode + per-automation config

### DIFF
--- a/apps/backend/cmd/kandev/e2e_reset.go
+++ b/apps/backend/cmd/kandev/e2e_reset.go
@@ -129,7 +129,12 @@ func handleE2EReset(
 			return
 		}
 
-		deletedAutomations := deleteAutomationsForReset(ctx, automationSvc, workspaceID, log)
+		deletedAutomations, autoErr := deleteAutomationsForReset(ctx, automationSvc, workspaceID)
+		if autoErr != nil {
+			log.Error("e2e reset: failed to delete automations", zap.Error(autoErr))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": autoErr.Error()})
+			return
+		}
 
 		c.JSON(http.StatusOK, gin.H{
 			"deleted_tasks":       deletedTasks,
@@ -143,17 +148,11 @@ func deleteAutomationsForReset(
 	ctx context.Context,
 	automationSvc *automation.Service,
 	workspaceID string,
-	log *logger.Logger,
-) int {
+) (int, error) {
 	if automationSvc == nil {
-		return 0
+		return 0, nil
 	}
-	n, err := automationSvc.Store().DeleteAutomationsByWorkspace(ctx, workspaceID)
-	if err != nil {
-		log.Error("e2e reset: failed to delete automations", zap.Error(err))
-		return 0
-	}
-	return n
+	return automationSvc.Store().DeleteAutomationsByWorkspace(ctx, workspaceID)
 }
 
 type e2eHiddenWorkflowRequest struct {

--- a/apps/backend/cmd/kandev/e2e_reset.go
+++ b/apps/backend/cmd/kandev/e2e_reset.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 
+	"github.com/kandev/kandev/internal/automation"
 	"github.com/kandev/kandev/internal/common/logger"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	taskservice "github.com/kandev/kandev/internal/task/service"
@@ -15,14 +17,20 @@ import (
 
 // registerE2EResetRoutes registers the E2E test-only endpoints.
 // The endpoints are available when KANDEV_MOCK_AGENT is "true" or "only" (dev/E2E modes).
-func registerE2EResetRoutes(router *gin.Engine, repo *sqliterepo.Repository, taskSvc *taskservice.Service, log *logger.Logger) {
+func registerE2EResetRoutes(
+	router *gin.Engine,
+	repo *sqliterepo.Repository,
+	taskSvc *taskservice.Service,
+	automationSvc *automation.Service,
+	log *logger.Logger,
+) {
 	mockMode := os.Getenv("KANDEV_MOCK_AGENT")
 	if mockMode != "true" && mockMode != "only" {
 		return
 	}
 
 	api := router.Group("/api/v1/e2e")
-	api.DELETE("/reset/:workspaceId", handleE2EReset(repo, taskSvc, log))
+	api.DELETE("/reset/:workspaceId", handleE2EReset(repo, taskSvc, automationSvc, log))
 	// Hidden-workflow factory: lets E2E tests cover the system-only
 	// workflow path (e.g. improve-kandev) without depending on the real
 	// bootstrap endpoint, which clones from GitHub and shells out to gh.
@@ -31,7 +39,12 @@ func registerE2EResetRoutes(router *gin.Engine, repo *sqliterepo.Repository, tas
 	log.Info("registered E2E endpoints (test-only)")
 }
 
-func handleE2EReset(repo *sqliterepo.Repository, taskSvc *taskservice.Service, log *logger.Logger) gin.HandlerFunc {
+func handleE2EReset(
+	repo *sqliterepo.Repository,
+	taskSvc *taskservice.Service,
+	automationSvc *automation.Service,
+	log *logger.Logger,
+) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		workspaceID := c.Param("workspaceId")
 
@@ -116,11 +129,31 @@ func handleE2EReset(repo *sqliterepo.Repository, taskSvc *taskservice.Service, l
 			return
 		}
 
+		deletedAutomations := deleteAutomationsForReset(ctx, automationSvc, workspaceID, log)
+
 		c.JSON(http.StatusOK, gin.H{
-			"deleted_tasks":     deletedTasks,
-			"deleted_workflows": deletedWorkflows,
+			"deleted_tasks":       deletedTasks,
+			"deleted_workflows":   deletedWorkflows,
+			"deleted_automations": deletedAutomations,
 		})
 	}
+}
+
+func deleteAutomationsForReset(
+	ctx context.Context,
+	automationSvc *automation.Service,
+	workspaceID string,
+	log *logger.Logger,
+) int {
+	if automationSvc == nil {
+		return 0
+	}
+	n, err := automationSvc.Store().DeleteAutomationsByWorkspace(ctx, workspaceID)
+	if err != nil {
+		log.Error("e2e reset: failed to delete automations", zap.Error(err))
+		return 0
+	}
+	return n
 }
 
 type e2eHiddenWorkflowRequest struct {

--- a/apps/backend/cmd/kandev/helpers.go
+++ b/apps/backend/cmd/kandev/helpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kandev/kandev/internal/agentctl/tracing"
 	analyticshandlers "github.com/kandev/kandev/internal/analytics/handlers"
 	analyticsrepository "github.com/kandev/kandev/internal/analytics/repository"
+	"github.com/kandev/kandev/internal/automation"
 	"github.com/kandev/kandev/internal/clarification"
 	"github.com/kandev/kandev/internal/common/config"
 	"github.com/kandev/kandev/internal/common/logger"
@@ -731,6 +732,11 @@ func registerSecondaryRoutes(
 		p.log.Debug("Registered Slack handlers (HTTP + WebSocket)")
 	}
 
+	if p.services.Automation != nil {
+		automation.RegisterRoutes(p.router, p.gateway.Dispatcher, p.services.Automation.Service, p.log)
+		p.log.Debug("Registered Automation handlers (HTTP + WebSocket)")
+	}
+
 	docker.RegisterDockerRoutes(p.router, p.lifecycleMgr.DockerClientProvider(), dockerTaskTitleProvider(p.taskRepo, p.log), p.log)
 	p.log.Debug("Registered Docker management handlers (HTTP)")
 
@@ -747,7 +753,11 @@ func registerSecondaryRoutes(
 
 	registerMCPAndDebugRoutes(p, workflowCtrl, clarificationStore, planService, handoffSvc)
 
-	registerE2EResetRoutes(p.router, p.taskRepo, p.taskSvc, p.log)
+	var automationSvc *automation.Service
+	if p.services.Automation != nil {
+		automationSvc = p.services.Automation.Service
+	}
+	registerE2EResetRoutes(p.router, p.taskRepo, p.taskSvc, automationSvc, p.log)
 
 	if officetestharness.Enabled() {
 		var officeAgentSvc *officeagents.AgentService

--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -467,6 +467,17 @@ func startAgentInfrastructure(
 		addCleanup(func() error { slackTrigger.Stop(); return nil })
 	}
 
+	// Wire automation service into orchestrator for trigger-based task creation.
+	// The Automation subsystem is independent of the Office feature flag — it
+	// has its own cron scheduler, GitHub poller, and webhook handler, and
+	// creates tasks via the task service directly.
+	if services.Automation != nil {
+		orchestratorSvc.SetAutomationService(services.Automation.Service)
+		services.Automation.Start(ctx)
+		addCleanup(func() error { services.Automation.Stop(); return nil })
+		log.Info("Automation scheduler and evaluator started")
+	}
+
 	return startGatewayAndServe(ctx, cfg, log, eventBus, repos, services,
 		agentSettingsController, lifecycleMgr, agentRegistry, orchestratorSvc, msgCreator, repoCloner, agentctlBinaryPath, addCleanup, runCleanups)
 }

--- a/apps/backend/cmd/kandev/orchestrator.go
+++ b/apps/backend/cmd/kandev/orchestrator.go
@@ -80,6 +80,7 @@ func provideOrchestrator(
 	orchestratorSvc := orchestrator.NewService(serviceCfg, eventBus, agentManagerClient, taskRepoAdapter, taskRepo, userSvc, secretStore, msgQueue, log)
 	taskSvc.SetExecutionStopper(orchestratorSvc)
 	taskSvc.SetGitArchiveCapture(orchestratorSvc)
+	orchestratorSvc.SetWorktreeManager(lifecycleMgr.WorktreeManager())
 
 	msgCreator := &messageCreatorAdapter{svc: taskSvc, logger: log}
 	orchestratorSvc.SetMessageCreator(msgCreator)

--- a/apps/backend/cmd/kandev/orchestrator.go
+++ b/apps/backend/cmd/kandev/orchestrator.go
@@ -256,6 +256,8 @@ func (a *reviewTaskCreatorAdapter) CreateReviewTask(ctx context.Context, req *or
 		Description:    req.Description,
 		Metadata:       req.Metadata,
 		Repositories:   repos,
+		IsEphemeral:    req.IsEphemeral,
+		Origin:         req.Origin,
 	})
 }
 

--- a/apps/backend/cmd/kandev/services.go
+++ b/apps/backend/cmd/kandev/services.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/registry"
 	agentsettingscontroller "github.com/kandev/kandev/internal/agent/settings/controller"
 	agentctlutil "github.com/kandev/kandev/internal/agentctl/server/utility"
+	"github.com/kandev/kandev/internal/automation"
 	"github.com/kandev/kandev/internal/common/config"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
@@ -103,18 +104,25 @@ func provideServices(cfg *config.Config, log *logger.Logger, repos *Repositories
 		taskSvc.SetRemoteBranchLister(githubBranchListerAdapter{svc: githubSvc})
 	}
 
+	// Initialize Automation service
+	automationComponents, automationErr := automation.Provide(dbPool.Writer(), dbPool.Reader(), eventBus, githubSvc, log)
+	if automationErr != nil {
+		log.Warn("Automation service initialization failed (non-fatal)", zap.Error(automationErr))
+	}
+
 	return &Services{
-		Task:     taskSvc,
-		User:     userSvc,
-		Editor:   editorSvc,
-		Prompts:  promptSvc,
-		Utility:  utilitySvc,
-		Workflow: workflowSvc,
-		GitHub:   githubSvc,
-		Jira:     jiraSvc,
-		Linear:   linearSvc,
-		Slack:    slackSvc,
-		Share:    shareHTTP,
+		Task:       taskSvc,
+		User:       userSvc,
+		Editor:     editorSvc,
+		Prompts:    promptSvc,
+		Utility:    utilitySvc,
+		Workflow:   workflowSvc,
+		GitHub:     githubSvc,
+		Jira:       jiraSvc,
+		Linear:     linearSvc,
+		Slack:      slackSvc,
+		Share:      shareHTTP,
+		Automation: automationComponents,
 		// Office is constructed later in initOfficeServices once all
 		// of its dependencies (config loader, task integrations, etc.) are available.
 		Office: nil,

--- a/apps/backend/cmd/kandev/types.go
+++ b/apps/backend/cmd/kandev/types.go
@@ -3,6 +3,7 @@ package main
 import (
 	settingsstore "github.com/kandev/kandev/internal/agent/settings/store"
 	analyticsrepository "github.com/kandev/kandev/internal/analytics/repository"
+	"github.com/kandev/kandev/internal/automation"
 	editorservice "github.com/kandev/kandev/internal/editors/service"
 	editorstore "github.com/kandev/kandev/internal/editors/store"
 	"github.com/kandev/kandev/internal/github"
@@ -65,4 +66,8 @@ type Services struct {
 	// WorktreeMgr is the worktree manager. Exposed so the office GC can
 	// consult it as the authoritative inventory of live worktrees.
 	WorktreeMgr *worktree.Manager
+	// Automation is the trigger-based automation subsystem (cron, GitHub PR
+	// events, webhooks). Independent of Office — has its own scheduler and
+	// creates tasks via the task service.
+	Automation *automation.Components
 }

--- a/apps/backend/internal/automation/evaluator.go
+++ b/apps/backend/internal/automation/evaluator.go
@@ -1,0 +1,253 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/github"
+)
+
+const defaultGitHubPollInterval = 60 * time.Second
+
+// GitHubEvaluator polls GitHub for events matching automation triggers.
+// It handles github_pr, github_push, and github_ci trigger types.
+type GitHubEvaluator struct {
+	svc      *Service
+	ghClient github.Client
+	logger   *logger.Logger
+
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	started bool
+}
+
+// NewGitHubEvaluator creates a new GitHub trigger evaluator.
+func NewGitHubEvaluator(svc *Service, ghClient github.Client, log *logger.Logger) *GitHubEvaluator {
+	return &GitHubEvaluator{
+		svc:      svc,
+		ghClient: ghClient,
+		logger:   log,
+	}
+}
+
+// Start begins the polling loop.
+func (e *GitHubEvaluator) Start(ctx context.Context) {
+	if e.started || e.ghClient == nil {
+		return
+	}
+	e.started = true
+	ctx, e.cancel = context.WithCancel(ctx)
+
+	e.wg.Add(1)
+	go e.loop(ctx)
+
+	e.logger.Info("automation GitHub evaluator started")
+}
+
+// Stop cancels the polling loop and waits for it to finish.
+func (e *GitHubEvaluator) Stop() {
+	if !e.started {
+		return
+	}
+	if e.cancel != nil {
+		e.cancel()
+	}
+	e.wg.Wait()
+	e.started = false
+	e.logger.Info("automation GitHub evaluator stopped")
+}
+
+func (e *GitHubEvaluator) loop(ctx context.Context) {
+	defer e.wg.Done()
+
+	e.evaluate(ctx)
+
+	ticker := time.NewTicker(defaultGitHubPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.evaluate(ctx)
+		}
+	}
+}
+
+func (e *GitHubEvaluator) evaluate(ctx context.Context) {
+	e.evaluatePRTriggers(ctx)
+	e.evaluatePushTriggers(ctx)
+	e.evaluateCITriggers(ctx)
+}
+
+func (e *GitHubEvaluator) evaluatePRTriggers(ctx context.Context) {
+	triggers, err := e.svc.Store().ListEnabledTriggersByType(ctx, TriggerTypeGitHubPR)
+	if err != nil {
+		e.logger.Error("failed to list github_pr triggers", zap.Error(err))
+		return
+	}
+	for i := range triggers {
+		t := &triggers[i]
+		e.checkPRTrigger(ctx, t)
+	}
+}
+
+func (e *GitHubEvaluator) checkPRTrigger(ctx context.Context, t *AutomationTrigger) {
+	var cfg GitHubPRTriggerConfig
+	if err := json.Unmarshal(t.Config, &cfg); err != nil {
+		e.logger.Debug("invalid github_pr trigger config",
+			zap.String("trigger_id", t.ID), zap.Error(err))
+		return
+	}
+
+	repos := cfg.Repos
+	if len(repos) == 0 {
+		return // Cannot poll without specific repos
+	}
+
+	for _, repo := range repos {
+		// Use ListReviewRequestedPRs with a custom query scoped to this repo.
+		query := fmt.Sprintf("is:pr is:open repo:%s/%s", repo.Owner, repo.Name)
+		prs, err := e.ghClient.ListReviewRequestedPRs(ctx, "", "", query)
+		if err != nil {
+			e.logger.Debug("failed to list PRs for automation trigger",
+				zap.String("repo", repo.Owner+"/"+repo.Name),
+				zap.Error(err))
+			continue
+		}
+		for _, pr := range prs {
+			if pr == nil {
+				continue
+			}
+			if cfg.ExcludeDraft && pr.Draft {
+				continue
+			}
+			if !matchesBranches(pr.BaseBranch, cfg.Branches) {
+				continue
+			}
+			if !matchesAuthors(pr.AuthorLogin, cfg.Authors) {
+				continue
+			}
+
+			dedupKey := fmt.Sprintf("pr:%s/%s#%d", repo.Owner, repo.Name, pr.Number)
+			e.firePRTrigger(ctx, t, pr, dedupKey)
+		}
+	}
+}
+
+func (e *GitHubEvaluator) firePRTrigger(ctx context.Context, t *AutomationTrigger, pr *github.PR, dedupKey string) {
+	data, _ := json.Marshal(map[string]interface{}{
+		"number":       pr.Number,
+		"title":        pr.Title,
+		"html_url":     pr.HTMLURL,
+		"author_login": pr.AuthorLogin,
+		"repo":         fmt.Sprintf("%s/%s", pr.RepoOwner, pr.RepoName),
+		"head_branch":  pr.HeadBranch,
+		"base_branch":  pr.BaseBranch,
+		"body":         pr.Body,
+		"draft":        pr.Draft,
+		"state":        pr.State,
+	})
+
+	if err := e.svc.FireTrigger(ctx, t.AutomationID, t.ID, TriggerTypeGitHubPR, data, dedupKey); err != nil {
+		e.logger.Error("failed to fire PR trigger",
+			zap.String("trigger_id", t.ID), zap.Error(err))
+	}
+}
+
+func (e *GitHubEvaluator) evaluatePushTriggers(ctx context.Context) {
+	triggers, err := e.svc.Store().ListEnabledTriggersByType(ctx, TriggerTypeGitHubPush)
+	if err != nil {
+		e.logger.Error("failed to list github_push triggers", zap.Error(err))
+		return
+	}
+	for i := range triggers {
+		t := &triggers[i]
+		e.checkPushTrigger(ctx, t)
+	}
+}
+
+func (e *GitHubEvaluator) checkPushTrigger(ctx context.Context, t *AutomationTrigger) {
+	var cfg GitHubPushTriggerConfig
+	if err := json.Unmarshal(t.Config, &cfg); err != nil {
+		return
+	}
+	// Push trigger evaluation requires comparing commit SHAs.
+	// For now, mark as evaluated; full implementation needs commit tracking.
+	now := time.Now().UTC()
+	_ = e.svc.Store().UpdateTriggerEvaluatedAt(ctx, t.ID, now)
+}
+
+func (e *GitHubEvaluator) evaluateCITriggers(ctx context.Context) {
+	triggers, err := e.svc.Store().ListEnabledTriggersByType(ctx, TriggerTypeGitHubCI)
+	if err != nil {
+		e.logger.Error("failed to list github_ci triggers", zap.Error(err))
+		return
+	}
+	for i := range triggers {
+		t := &triggers[i]
+		e.checkCITrigger(ctx, t)
+	}
+}
+
+func (e *GitHubEvaluator) checkCITrigger(ctx context.Context, t *AutomationTrigger) {
+	var cfg GitHubCITriggerConfig
+	if err := json.Unmarshal(t.Config, &cfg); err != nil {
+		return
+	}
+	// CI trigger evaluation requires tracking check run completion.
+	// For now, mark as evaluated; full implementation needs check run tracking.
+	now := time.Now().UTC()
+	_ = e.svc.Store().UpdateTriggerEvaluatedAt(ctx, t.ID, now)
+}
+
+// matchesBranches checks if a branch matches any of the filter patterns.
+// Empty filter means match all.
+func matchesBranches(branch string, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for _, f := range filters {
+		if matchGlob(f, branch) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesAuthors checks if an author matches the filter list.
+// Empty filter means match all.
+func matchesAuthors(author string, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for _, f := range filters {
+		if f == author {
+			return true
+		}
+	}
+	return false
+}
+
+// matchGlob performs simple glob matching (supports * wildcard).
+func matchGlob(pattern, s string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if pattern == s {
+		return true
+	}
+	// Handle trailing wildcard: "release/*" matches "release/v1"
+	if len(pattern) > 1 && pattern[len(pattern)-1] == '*' {
+		prefix := pattern[:len(pattern)-1]
+		return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+	}
+	return false
+}

--- a/apps/backend/internal/automation/handlers.go
+++ b/apps/backend/internal/automation/handlers.go
@@ -1,0 +1,251 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// RegisterRoutes registers HTTP and WebSocket routes for automations.
+func RegisterRoutes(router *gin.Engine, dispatcher *ws.Dispatcher, svc *Service, log *logger.Logger) {
+	registerWSHandlers(dispatcher, svc, log)
+	registerHTTPRoutes(router, svc, log)
+}
+
+func registerWSHandlers(dispatcher *ws.Dispatcher, svc *Service, log *logger.Logger) {
+	dispatcher.RegisterFunc(ws.ActionAutomationList, wsList(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationGet, wsGet(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationCreate, wsCreate(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationUpdate, wsUpdate(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationDelete, wsDelete(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationEnable, wsEnable(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationDisable, wsDisable(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationTrigger, wsManualTrigger(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationRunsList, wsListRuns(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationTriggerAdd, wsAddTrigger(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationTriggerUpdate, wsUpdateTrigger(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationTriggerDelete, wsDeleteTrigger(svc, log))
+	dispatcher.RegisterFunc(ws.ActionAutomationTriggerTypes, wsTriggerTypes())
+}
+
+func registerHTTPRoutes(router *gin.Engine, svc *Service, log *logger.Logger) {
+	wh := NewWebhookHandler(svc, log)
+	router.POST("/api/v1/automations/webhook/:id", wh.Handle)
+}
+
+// parseMap parses the WS message payload into a map.
+func parseMap(msg *ws.Message) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	err := msg.ParsePayload(&m)
+	if m == nil {
+		m = make(map[string]interface{})
+	}
+	return m, err
+}
+
+func wsList(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		workspaceID, _ := payload["workspace_id"].(string)
+		if workspaceID == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "workspace_id required", nil)
+		}
+		items, err := svc.ListAutomations(ctx, workspaceID)
+		if err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, items)
+	}
+}
+
+func wsGet(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		id, _ := payload["id"].(string)
+		if id == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "id required", nil)
+		}
+		a, err := svc.GetAutomation(ctx, id)
+		if err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		if a == nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "automation not found", nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, a)
+	}
+}
+
+func wsCreate(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		var req CreateAutomationRequest
+		if err := msg.ParsePayload(&req); err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload: "+err.Error(), nil)
+		}
+		a, err := svc.CreateAutomation(ctx, &req)
+		if err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, a)
+	}
+}
+
+func wsUpdate(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		id, _ := payload["id"].(string)
+		if id == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "id required", nil)
+		}
+		var req UpdateAutomationRequest
+		if err := msg.ParsePayload(&req); err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload: "+err.Error(), nil)
+		}
+		a, err := svc.UpdateAutomation(ctx, id, &req)
+		if err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, a)
+	}
+}
+
+func wsDelete(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		id, _ := payload["id"].(string)
+		if id == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "id required", nil)
+		}
+		if err := svc.DeleteAutomation(ctx, id); err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, map[string]bool{"deleted": true})
+	}
+}
+
+func wsEnable(svc *Service, _ *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return wsToggleEnabled(svc, true)
+}
+
+func wsDisable(svc *Service, _ *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return wsToggleEnabled(svc, false)
+}
+
+func wsToggleEnabled(svc *Service, enable bool) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		id, _ := payload["id"].(string)
+		if id == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "id required", nil)
+		}
+		var err error
+		if enable {
+			err = svc.EnableAutomation(ctx, id)
+		} else {
+			err = svc.DisableAutomation(ctx, id)
+		}
+		if err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		a, _ := svc.GetAutomation(ctx, id)
+		return ws.NewResponse(msg.ID, msg.Action, a)
+	}
+}
+
+func wsManualTrigger(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		id, _ := payload["id"].(string)
+		if id == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "id required", nil)
+		}
+		a, err := svc.GetAutomation(ctx, id)
+		if err != nil || a == nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "automation not found", nil)
+		}
+		data, _ := json.Marshal(map[string]string{"source": "manual"})
+		triggerID := ""
+		if len(a.Triggers) > 0 {
+			triggerID = a.Triggers[0].ID
+		}
+		if fireErr := svc.FireTrigger(ctx, id, triggerID, "manual", data, ""); fireErr != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, fireErr.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, map[string]bool{"triggered": true})
+	}
+}
+
+func wsListRuns(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		automationID, _ := payload["automation_id"].(string)
+		if automationID == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "automation_id required", nil)
+		}
+		limit := 50
+		if l, ok := payload["limit"].(float64); ok && l > 0 {
+			limit = int(l)
+		}
+		runs, err := svc.ListRuns(ctx, automationID, limit)
+		if err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, runs)
+	}
+}
+
+func wsAddTrigger(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		var req AddTriggerRequest
+		if err := msg.ParsePayload(&req); err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload: "+err.Error(), nil)
+		}
+		t, err := svc.AddTrigger(ctx, &req)
+		if err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, t)
+	}
+}
+
+func wsUpdateTrigger(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		id, _ := payload["id"].(string)
+		if id == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "id required", nil)
+		}
+		var req UpdateTriggerRequest
+		if err := msg.ParsePayload(&req); err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "invalid payload: "+err.Error(), nil)
+		}
+		if err := svc.UpdateTrigger(ctx, id, &req); err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, map[string]bool{"updated": true})
+	}
+}
+
+func wsDeleteTrigger(svc *Service, log *logger.Logger) func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+		payload, _ := parseMap(msg)
+		id, _ := payload["id"].(string)
+		if id == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "id required", nil)
+		}
+		if err := svc.DeleteTrigger(ctx, id); err != nil {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		}
+		return ws.NewResponse(msg.ID, msg.Action, map[string]bool{"deleted": true})
+	}
+}
+
+func wsTriggerTypes() func(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	return func(_ context.Context, msg *ws.Message) (*ws.Message, error) {
+		return ws.NewResponse(msg.ID, msg.Action, GetTriggerTypes())
+	}
+}

--- a/apps/backend/internal/automation/interpolator.go
+++ b/apps/backend/internal/automation/interpolator.go
@@ -1,0 +1,119 @@
+package automation
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// InterpolatePrompt replaces {{placeholder}} tokens in the prompt template
+// with values from the trigger data. Supports nested access via dot notation.
+func InterpolatePrompt(prompt string, triggerType TriggerType, triggerData json.RawMessage) string {
+	if prompt == "" || !strings.Contains(prompt, "{{") {
+		return prompt
+	}
+
+	// Parse trigger data into a generic map for lookups.
+	var data map[string]interface{}
+	if err := json.Unmarshal(triggerData, &data); err != nil {
+		data = make(map[string]interface{})
+	}
+
+	// Build replacer pairs from common placeholders.
+	pairs := []string{
+		"{{trigger.type}}", string(triggerType),
+		"{{trigger.timestamp}}", time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Add trigger-type-specific placeholders.
+	switch triggerType {
+	case TriggerTypeGitHubPR:
+		pairs = append(pairs, prPlaceholders(data)...)
+	case TriggerTypeGitHubPush:
+		pairs = append(pairs, pushPlaceholders(data)...)
+	case TriggerTypeGitHubCI:
+		pairs = append(pairs, ciPlaceholders(data)...)
+	case TriggerTypeWebhook:
+		pairs = append(pairs, webhookPlaceholders(data)...)
+	}
+
+	// Add generic data.* placeholders for any top-level key.
+	for k, v := range data {
+		pairs = append(pairs, fmt.Sprintf("{{data.%s}}", k), toString(v))
+	}
+
+	result := strings.NewReplacer(pairs...).Replace(prompt)
+	return stripUnresolved(result)
+}
+
+// unresolvedRe matches leftover {{placeholder}} tokens that weren't replaced.
+var unresolvedRe = regexp.MustCompile(`\{\{[a-z_.]+\}\}`)
+
+// stripUnresolved removes any remaining {{...}} placeholders so they don't
+// appear as raw text in the agent prompt.
+func stripUnresolved(s string) string {
+	return strings.TrimSpace(unresolvedRe.ReplaceAllString(s, ""))
+}
+
+func prPlaceholders(data map[string]interface{}) []string {
+	return []string{
+		"{{pr.number}}", toString(data["number"]),
+		"{{pr.title}}", toString(data["title"]),
+		"{{pr.url}}", toString(data["html_url"]),
+		"{{pr.author}}", toString(data["author_login"]),
+		"{{pr.repo}}", toString(data["repo"]),
+		"{{pr.branch}}", toString(data["head_branch"]),
+		"{{pr.base_branch}}", toString(data["base_branch"]),
+		"{{pr.body}}", toString(data["body"]),
+	}
+}
+
+func pushPlaceholders(data map[string]interface{}) []string {
+	return []string{
+		"{{push.branch}}", toString(data["branch"]),
+		"{{push.repo}}", toString(data["repo"]),
+		"{{push.sha}}", toString(data["sha"]),
+		"{{push.message}}", toString(data["message"]),
+	}
+}
+
+func ciPlaceholders(data map[string]interface{}) []string {
+	return []string{
+		"{{ci.check_name}}", toString(data["check_name"]),
+		"{{ci.conclusion}}", toString(data["conclusion"]),
+		"{{ci.repo}}", toString(data["repo"]),
+		"{{ci.url}}", toString(data["html_url"]),
+	}
+}
+
+func webhookPlaceholders(data map[string]interface{}) []string {
+	raw, _ := json.Marshal(data)
+	return []string{
+		"{{webhook.body}}", string(raw),
+	}
+}
+
+func toString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	default:
+		b, _ := json.Marshal(val)
+		return string(b)
+	}
+}

--- a/apps/backend/internal/automation/interpolator_test.go
+++ b/apps/backend/internal/automation/interpolator_test.go
@@ -1,0 +1,71 @@
+package automation
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestInterpolatePrompt_Scheduled(t *testing.T) {
+	data, _ := json.Marshal(map[string]string{"source": "scheduled", "timestamp": "2026-03-08T12:00:00Z"})
+	result := InterpolatePrompt("Run at {{trigger.timestamp}} by {{trigger.type}}", TriggerTypeScheduled, data)
+	if !strings.Contains(result, "scheduled") {
+		t.Errorf("expected trigger type in result, got %q", result)
+	}
+	// timestamp is generated at call time, just verify it's replaced
+	if strings.Contains(result, "{{trigger.timestamp}}") {
+		t.Error("expected {{trigger.timestamp}} to be replaced")
+	}
+}
+
+func TestInterpolatePrompt_PR(t *testing.T) {
+	data, _ := json.Marshal(map[string]any{
+		"number":       42,
+		"title":        "Fix the bug",
+		"html_url":     "https://github.com/org/repo/pull/42",
+		"author_login": "alice",
+		"repo":         "org/repo",
+		"head_branch":  "fix-bug",
+		"base_branch":  "main",
+	})
+	prompt := "Review PR #{{pr.number}} '{{pr.title}}' by {{pr.author}} in {{pr.repo}}"
+	result := InterpolatePrompt(prompt, TriggerTypeGitHubPR, data)
+	if !strings.Contains(result, "#42") {
+		t.Errorf("expected PR number, got %q", result)
+	}
+	if !strings.Contains(result, "Fix the bug") {
+		t.Errorf("expected PR title, got %q", result)
+	}
+	if !strings.Contains(result, "alice") {
+		t.Errorf("expected author, got %q", result)
+	}
+}
+
+func TestInterpolatePrompt_Webhook(t *testing.T) {
+	data, _ := json.Marshal(map[string]any{
+		"action": "deploy",
+		"env":    "production",
+	})
+	prompt := "Webhook received: {{webhook.body}}, action={{data.action}}"
+	result := InterpolatePrompt(prompt, TriggerTypeWebhook, data)
+	if strings.Contains(result, "{{webhook.body}}") {
+		t.Error("expected {{webhook.body}} to be replaced")
+	}
+	if !strings.Contains(result, "deploy") {
+		t.Errorf("expected 'deploy' in result, got %q", result)
+	}
+}
+
+func TestInterpolatePrompt_Empty(t *testing.T) {
+	result := InterpolatePrompt("", TriggerTypeScheduled, json.RawMessage(`{}`))
+	if result != "" {
+		t.Errorf("expected empty, got %q", result)
+	}
+}
+
+func TestInterpolatePrompt_NoPlaceholders(t *testing.T) {
+	result := InterpolatePrompt("plain text", TriggerTypeScheduled, json.RawMessage(`{}`))
+	if result != "plain text" {
+		t.Errorf("expected 'plain text', got %q", result)
+	}
+}

--- a/apps/backend/internal/automation/models.go
+++ b/apps/backend/internal/automation/models.go
@@ -1,0 +1,180 @@
+// Package automation provides a generic automation system for Kandev.
+// Automations are named rules with triggers (cron, GitHub events, webhooks)
+// that automatically create and optionally start tasks when fired.
+package automation
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/kandev/kandev/internal/github"
+)
+
+// TriggerType identifies the kind of trigger.
+type TriggerType string
+
+const (
+	TriggerTypeScheduled  TriggerType = "scheduled"
+	TriggerTypeGitHubPR   TriggerType = "github_pr"
+	TriggerTypeGitHubPush TriggerType = "github_push"
+	TriggerTypeGitHubCI   TriggerType = "github_ci"
+	TriggerTypeWebhook    TriggerType = "webhook"
+)
+
+// RunStatus tracks the outcome of a trigger firing.
+type RunStatus string
+
+const (
+	RunStatusTriggered   RunStatus = "triggered"
+	RunStatusTaskCreated RunStatus = "task_created"
+	RunStatusFailed      RunStatus = "failed"
+	RunStatusSkipped     RunStatus = "skipped"
+)
+
+// Automation is a named rule with triggers, a prompt template, and agent/executor config.
+type Automation struct {
+	ID                string     `json:"id" db:"id"`
+	WorkspaceID       string     `json:"workspace_id" db:"workspace_id"`
+	Name              string     `json:"name" db:"name"`
+	Description       string     `json:"description" db:"description"`
+	WorkflowID        string     `json:"workflow_id" db:"workflow_id"`
+	WorkflowStepID    string     `json:"workflow_step_id" db:"workflow_step_id"`
+	AgentProfileID    string     `json:"agent_profile_id" db:"agent_profile_id"`
+	ExecutorProfileID string     `json:"executor_profile_id" db:"executor_profile_id"`
+	Prompt            string     `json:"prompt" db:"prompt"`
+	TaskTitleTemplate string     `json:"task_title_template" db:"task_title_template"`
+	Enabled           bool       `json:"enabled" db:"enabled"`
+	MaxConcurrentRuns int        `json:"max_concurrent_runs" db:"max_concurrent_runs"`
+	WebhookSecret     string     `json:"-" db:"webhook_secret"`
+	LastTriggeredAt   *time.Time `json:"last_triggered_at,omitempty" db:"last_triggered_at"`
+	CreatedAt         time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at" db:"updated_at"`
+
+	// Hydrated separately, not stored in the automations table.
+	Triggers []AutomationTrigger `json:"triggers" db:"-"`
+}
+
+// AutomationTrigger is a single trigger attached to an automation.
+type AutomationTrigger struct {
+	ID              string          `json:"id" db:"id"`
+	AutomationID    string          `json:"automation_id" db:"automation_id"`
+	Type            TriggerType     `json:"type" db:"type"`
+	Config          json.RawMessage `json:"config" db:"-"`
+	ConfigJSON      string          `json:"-" db:"config"`
+	Enabled         bool            `json:"enabled" db:"enabled"`
+	LastEvaluatedAt *time.Time      `json:"last_evaluated_at,omitempty" db:"last_evaluated_at"`
+	CreatedAt       time.Time       `json:"created_at" db:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at" db:"updated_at"`
+}
+
+// AutomationRun records a single trigger firing for audit/observability.
+type AutomationRun struct {
+	ID              string          `json:"id" db:"id"`
+	AutomationID    string          `json:"automation_id" db:"automation_id"`
+	TriggerID       string          `json:"trigger_id" db:"trigger_id"`
+	TriggerType     TriggerType     `json:"trigger_type" db:"trigger_type"`
+	TaskID          string          `json:"task_id,omitempty" db:"task_id"`
+	Status          RunStatus       `json:"status" db:"status"`
+	DedupKey        string          `json:"dedup_key" db:"dedup_key"`
+	TriggerData     json.RawMessage `json:"trigger_data" db:"-"`
+	TriggerDataJSON string          `json:"-" db:"trigger_data"`
+	ErrorMessage    string          `json:"error_message,omitempty" db:"error_message"`
+	CreatedAt       time.Time       `json:"created_at" db:"created_at"`
+}
+
+// --- Trigger config types ---
+
+// ScheduledTriggerConfig holds configuration for cron-based triggers.
+type ScheduledTriggerConfig struct {
+	CronExpression string `json:"cron_expression"`
+	Timezone       string `json:"timezone,omitempty"`
+}
+
+// GitHubPRTriggerConfig filters PR events.
+type GitHubPRTriggerConfig struct {
+	Events       []string            `json:"events"`             // opened, commented, merged, review_requested, closed
+	Repos        []github.RepoFilter `json:"repos"`              // empty = all repos
+	Branches     []string            `json:"branches,omitempty"` // base branch filter
+	Authors      []string            `json:"authors,omitempty"`  // PR author filter
+	Labels       []string            `json:"labels,omitempty"`   // label filter
+	ExcludeDraft bool                `json:"exclude_draft,omitempty"`
+}
+
+// GitHubPushTriggerConfig filters push-to-branch events.
+type GitHubPushTriggerConfig struct {
+	Repos    []github.RepoFilter `json:"repos"`
+	Branches []string            `json:"branches"` // glob patterns: ["main", "release/*"]
+}
+
+// GitHubCITriggerConfig filters CI completion events.
+type GitHubCITriggerConfig struct {
+	Repos       []github.RepoFilter `json:"repos"`
+	Conclusions []string            `json:"conclusions"` // success, failure, etc.
+	CheckNames  []string            `json:"check_names,omitempty"`
+}
+
+// WebhookTriggerConfig holds configuration for webhook triggers.
+type WebhookTriggerConfig struct {
+	FilterExpression string `json:"filter_expression,omitempty"`
+}
+
+// --- Request/response DTOs ---
+
+// CreateAutomationRequest is the payload for creating an automation.
+type CreateAutomationRequest struct {
+	WorkspaceID       string              `json:"workspace_id"`
+	Name              string              `json:"name"`
+	Description       string              `json:"description"`
+	WorkflowID        string              `json:"workflow_id"`
+	WorkflowStepID    string              `json:"workflow_step_id"`
+	AgentProfileID    string              `json:"agent_profile_id"`
+	ExecutorProfileID string              `json:"executor_profile_id"`
+	Prompt            string              `json:"prompt"`
+	TaskTitleTemplate string              `json:"task_title_template"`
+	MaxConcurrentRuns int                 `json:"max_concurrent_runs"`
+	Triggers          []CreateTriggerSpec `json:"triggers"`
+}
+
+// CreateTriggerSpec defines a trigger to add during automation creation.
+type CreateTriggerSpec struct {
+	Type    TriggerType     `json:"type"`
+	Config  json.RawMessage `json:"config"`
+	Enabled bool            `json:"enabled"`
+}
+
+// UpdateAutomationRequest is the payload for updating an automation.
+type UpdateAutomationRequest struct {
+	Name              *string `json:"name,omitempty"`
+	Description       *string `json:"description,omitempty"`
+	WorkflowID        *string `json:"workflow_id,omitempty"`
+	WorkflowStepID    *string `json:"workflow_step_id,omitempty"`
+	AgentProfileID    *string `json:"agent_profile_id,omitempty"`
+	ExecutorProfileID *string `json:"executor_profile_id,omitempty"`
+	Prompt            *string `json:"prompt,omitempty"`
+	TaskTitleTemplate *string `json:"task_title_template,omitempty"`
+	Enabled           *bool   `json:"enabled,omitempty"`
+	MaxConcurrentRuns *int    `json:"max_concurrent_runs,omitempty"`
+}
+
+// AddTriggerRequest adds a trigger to an existing automation.
+type AddTriggerRequest struct {
+	AutomationID string          `json:"automation_id"`
+	Type         TriggerType     `json:"type"`
+	Config       json.RawMessage `json:"config"`
+	Enabled      bool            `json:"enabled"`
+}
+
+// UpdateTriggerRequest updates a trigger's config or enabled state.
+type UpdateTriggerRequest struct {
+	Config  *json.RawMessage `json:"config,omitempty"`
+	Enabled *bool            `json:"enabled,omitempty"`
+}
+
+// AutomationTriggeredEvent is published when a trigger fires.
+type AutomationTriggeredEvent struct {
+	AutomationID string          `json:"automation_id"`
+	TriggerID    string          `json:"trigger_id"`
+	TriggerType  TriggerType     `json:"trigger_type"`
+	TriggerData  json.RawMessage `json:"trigger_data"`
+	DedupKey     string          `json:"dedup_key"`
+}

--- a/apps/backend/internal/automation/models.go
+++ b/apps/backend/internal/automation/models.go
@@ -31,24 +31,46 @@ const (
 	RunStatusSkipped     RunStatus = "skipped"
 )
 
+// ExecutionMode controls whether an automation firing creates a visible
+// kanban task or a fire-and-forget ephemeral run.
+type ExecutionMode string
+
+const (
+	// ExecutionModeTask is the default: a trigger fires, a normal kanban
+	// task is created, the user can see/track/comment on it.
+	ExecutionModeTask ExecutionMode = "task"
+	// ExecutionModeRun is the lightweight path: a trigger fires, an
+	// ephemeral task is created so the session pipeline still works, but
+	// the task is hidden from the kanban. Only the AutomationRun row is
+	// surfaced to the user. Intended for "scheduled prompt that produces
+	// output the user just reads" use cases.
+	ExecutionModeRun ExecutionMode = "run"
+)
+
+// Valid reports whether the execution mode is a recognised value.
+func (m ExecutionMode) Valid() bool {
+	return m == ExecutionModeTask || m == ExecutionModeRun
+}
+
 // Automation is a named rule with triggers, a prompt template, and agent/executor config.
 type Automation struct {
-	ID                string     `json:"id" db:"id"`
-	WorkspaceID       string     `json:"workspace_id" db:"workspace_id"`
-	Name              string     `json:"name" db:"name"`
-	Description       string     `json:"description" db:"description"`
-	WorkflowID        string     `json:"workflow_id" db:"workflow_id"`
-	WorkflowStepID    string     `json:"workflow_step_id" db:"workflow_step_id"`
-	AgentProfileID    string     `json:"agent_profile_id" db:"agent_profile_id"`
-	ExecutorProfileID string     `json:"executor_profile_id" db:"executor_profile_id"`
-	Prompt            string     `json:"prompt" db:"prompt"`
-	TaskTitleTemplate string     `json:"task_title_template" db:"task_title_template"`
-	Enabled           bool       `json:"enabled" db:"enabled"`
-	MaxConcurrentRuns int        `json:"max_concurrent_runs" db:"max_concurrent_runs"`
-	WebhookSecret     string     `json:"-" db:"webhook_secret"`
-	LastTriggeredAt   *time.Time `json:"last_triggered_at,omitempty" db:"last_triggered_at"`
-	CreatedAt         time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt         time.Time  `json:"updated_at" db:"updated_at"`
+	ID                string        `json:"id" db:"id"`
+	WorkspaceID       string        `json:"workspace_id" db:"workspace_id"`
+	Name              string        `json:"name" db:"name"`
+	Description       string        `json:"description" db:"description"`
+	WorkflowID        string        `json:"workflow_id" db:"workflow_id"`
+	WorkflowStepID    string        `json:"workflow_step_id" db:"workflow_step_id"`
+	AgentProfileID    string        `json:"agent_profile_id" db:"agent_profile_id"`
+	ExecutorProfileID string        `json:"executor_profile_id" db:"executor_profile_id"`
+	Prompt            string        `json:"prompt" db:"prompt"`
+	TaskTitleTemplate string        `json:"task_title_template" db:"task_title_template"`
+	ExecutionMode     ExecutionMode `json:"execution_mode" db:"execution_mode"`
+	Enabled           bool          `json:"enabled" db:"enabled"`
+	MaxConcurrentRuns int           `json:"max_concurrent_runs" db:"max_concurrent_runs"`
+	WebhookSecret     string        `json:"-" db:"webhook_secret"`
+	LastTriggeredAt   *time.Time    `json:"last_triggered_at,omitempty" db:"last_triggered_at"`
+	CreatedAt         time.Time     `json:"created_at" db:"created_at"`
+	UpdatedAt         time.Time     `json:"updated_at" db:"updated_at"`
 
 	// Hydrated separately, not stored in the automations table.
 	Triggers []AutomationTrigger `json:"triggers" db:"-"`
@@ -131,6 +153,7 @@ type CreateAutomationRequest struct {
 	ExecutorProfileID string              `json:"executor_profile_id"`
 	Prompt            string              `json:"prompt"`
 	TaskTitleTemplate string              `json:"task_title_template"`
+	ExecutionMode     ExecutionMode       `json:"execution_mode"`
 	MaxConcurrentRuns int                 `json:"max_concurrent_runs"`
 	Triggers          []CreateTriggerSpec `json:"triggers"`
 }
@@ -144,16 +167,17 @@ type CreateTriggerSpec struct {
 
 // UpdateAutomationRequest is the payload for updating an automation.
 type UpdateAutomationRequest struct {
-	Name              *string `json:"name,omitempty"`
-	Description       *string `json:"description,omitempty"`
-	WorkflowID        *string `json:"workflow_id,omitempty"`
-	WorkflowStepID    *string `json:"workflow_step_id,omitempty"`
-	AgentProfileID    *string `json:"agent_profile_id,omitempty"`
-	ExecutorProfileID *string `json:"executor_profile_id,omitempty"`
-	Prompt            *string `json:"prompt,omitempty"`
-	TaskTitleTemplate *string `json:"task_title_template,omitempty"`
-	Enabled           *bool   `json:"enabled,omitempty"`
-	MaxConcurrentRuns *int    `json:"max_concurrent_runs,omitempty"`
+	Name              *string        `json:"name,omitempty"`
+	Description       *string        `json:"description,omitempty"`
+	WorkflowID        *string        `json:"workflow_id,omitempty"`
+	WorkflowStepID    *string        `json:"workflow_step_id,omitempty"`
+	AgentProfileID    *string        `json:"agent_profile_id,omitempty"`
+	ExecutorProfileID *string        `json:"executor_profile_id,omitempty"`
+	Prompt            *string        `json:"prompt,omitempty"`
+	TaskTitleTemplate *string        `json:"task_title_template,omitempty"`
+	ExecutionMode     *ExecutionMode `json:"execution_mode,omitempty"`
+	Enabled           *bool          `json:"enabled,omitempty"`
+	MaxConcurrentRuns *int           `json:"max_concurrent_runs,omitempty"`
 }
 
 // AddTriggerRequest adds a trigger to an existing automation.

--- a/apps/backend/internal/automation/models.go
+++ b/apps/backend/internal/automation/models.go
@@ -54,14 +54,19 @@ func (m ExecutionMode) Valid() bool {
 
 // Automation is a named rule with triggers, a prompt template, and agent/executor config.
 type Automation struct {
-	ID                string        `json:"id" db:"id"`
-	WorkspaceID       string        `json:"workspace_id" db:"workspace_id"`
-	Name              string        `json:"name" db:"name"`
-	Description       string        `json:"description" db:"description"`
-	WorkflowID        string        `json:"workflow_id" db:"workflow_id"`
-	WorkflowStepID    string        `json:"workflow_step_id" db:"workflow_step_id"`
-	AgentProfileID    string        `json:"agent_profile_id" db:"agent_profile_id"`
-	ExecutorProfileID string        `json:"executor_profile_id" db:"executor_profile_id"`
+	ID                string `json:"id" db:"id"`
+	WorkspaceID       string `json:"workspace_id" db:"workspace_id"`
+	Name              string `json:"name" db:"name"`
+	Description       string `json:"description" db:"description"`
+	WorkflowID        string `json:"workflow_id" db:"workflow_id"`
+	WorkflowStepID    string `json:"workflow_step_id" db:"workflow_step_id"`
+	AgentProfileID    string `json:"agent_profile_id" db:"agent_profile_id"`
+	ExecutorProfileID string `json:"executor_profile_id" db:"executor_profile_id"`
+	// RepositoryID is the explicit repository to use for trigger firings.
+	// Empty falls back to the workspace's first repository (for scheduled /
+	// webhook triggers) or the PR's repository (for github_pr triggers, which
+	// always override this field — see resolveAutomationRepository).
+	RepositoryID      string        `json:"repository_id" db:"repository_id"`
 	Prompt            string        `json:"prompt" db:"prompt"`
 	TaskTitleTemplate string        `json:"task_title_template" db:"task_title_template"`
 	ExecutionMode     ExecutionMode `json:"execution_mode" db:"execution_mode"`
@@ -151,6 +156,7 @@ type CreateAutomationRequest struct {
 	WorkflowStepID    string              `json:"workflow_step_id"`
 	AgentProfileID    string              `json:"agent_profile_id"`
 	ExecutorProfileID string              `json:"executor_profile_id"`
+	RepositoryID      string              `json:"repository_id"`
 	Prompt            string              `json:"prompt"`
 	TaskTitleTemplate string              `json:"task_title_template"`
 	ExecutionMode     ExecutionMode       `json:"execution_mode"`
@@ -173,6 +179,7 @@ type UpdateAutomationRequest struct {
 	WorkflowStepID    *string        `json:"workflow_step_id,omitempty"`
 	AgentProfileID    *string        `json:"agent_profile_id,omitempty"`
 	ExecutorProfileID *string        `json:"executor_profile_id,omitempty"`
+	RepositoryID      *string        `json:"repository_id,omitempty"`
 	Prompt            *string        `json:"prompt,omitempty"`
 	TaskTitleTemplate *string        `json:"task_title_template,omitempty"`
 	ExecutionMode     *ExecutionMode `json:"execution_mode,omitempty"`

--- a/apps/backend/internal/automation/models.go
+++ b/apps/backend/internal/automation/models.go
@@ -27,6 +27,7 @@ type RunStatus string
 const (
 	RunStatusTriggered   RunStatus = "triggered"
 	RunStatusTaskCreated RunStatus = "task_created"
+	RunStatusSucceeded   RunStatus = "succeeded"
 	RunStatusFailed      RunStatus = "failed"
 	RunStatusSkipped     RunStatus = "skipped"
 )

--- a/apps/backend/internal/automation/provider.go
+++ b/apps/backend/internal/automation/provider.go
@@ -1,0 +1,58 @@
+package automation
+
+import (
+	"context"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/github"
+)
+
+// Components holds the automation subsystem components for lifecycle management.
+type Components struct {
+	Service   *Service
+	Scheduler *CronScheduler
+	Evaluator *GitHubEvaluator
+}
+
+// Start begins background processing (scheduler + GitHub polling).
+func (c *Components) Start(ctx context.Context) {
+	c.Scheduler.Start(ctx)
+	c.Evaluator.Start(ctx)
+}
+
+// Stop gracefully shuts down background processing.
+func (c *Components) Stop() {
+	c.Scheduler.Stop()
+	c.Evaluator.Stop()
+}
+
+// Provide creates the full automation stack: store, service, scheduler, evaluator.
+func Provide(
+	writer, reader *sqlx.DB,
+	eventBus bus.EventBus,
+	ghSvc *github.Service,
+	log *logger.Logger,
+) (*Components, error) {
+	store, err := NewStore(writer, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := NewService(store, eventBus, log)
+	scheduler := NewCronScheduler(svc, log)
+
+	var ghClient github.Client
+	if ghSvc != nil {
+		ghClient = ghSvc.Client()
+	}
+	evaluator := NewGitHubEvaluator(svc, ghClient, log)
+
+	return &Components{
+		Service:   svc,
+		Scheduler: scheduler,
+		Evaluator: evaluator,
+	}, nil
+}

--- a/apps/backend/internal/automation/scheduler.go
+++ b/apps/backend/internal/automation/scheduler.go
@@ -1,0 +1,229 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+const defaultSchedulerCheckInterval = 30 * time.Second
+
+// CronScheduler evaluates scheduled triggers on a timer.
+// It checks all enabled scheduled triggers and fires those whose cron expression
+// indicates they should run based on time elapsed since last evaluation.
+type CronScheduler struct {
+	svc    *Service
+	logger *logger.Logger
+
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	started bool
+}
+
+// NewCronScheduler creates a new cron scheduler.
+func NewCronScheduler(svc *Service, log *logger.Logger) *CronScheduler {
+	return &CronScheduler{
+		svc:    svc,
+		logger: log,
+	}
+}
+
+// Start begins the scheduler loop.
+func (cs *CronScheduler) Start(ctx context.Context) {
+	if cs.started {
+		return
+	}
+	cs.started = true
+	ctx, cs.cancel = context.WithCancel(ctx)
+
+	cs.wg.Add(1)
+	go cs.loop(ctx)
+
+	cs.logger.Info("automation cron scheduler started")
+}
+
+// Stop cancels the scheduler and waits for it to finish.
+func (cs *CronScheduler) Stop() {
+	if !cs.started {
+		return
+	}
+	if cs.cancel != nil {
+		cs.cancel()
+	}
+	cs.wg.Wait()
+	cs.started = false
+	cs.logger.Info("automation cron scheduler stopped")
+}
+
+func (cs *CronScheduler) loop(ctx context.Context) {
+	defer cs.wg.Done()
+
+	// Initial check on startup.
+	cs.evaluate(ctx)
+
+	ticker := time.NewTicker(defaultSchedulerCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			cs.evaluate(ctx)
+		}
+	}
+}
+
+// evaluate checks all enabled scheduled triggers and fires those that are due.
+func (cs *CronScheduler) evaluate(ctx context.Context) {
+	triggers, err := cs.svc.Store().ListEnabledTriggersByType(ctx, TriggerTypeScheduled)
+	if err != nil {
+		cs.logger.Error("failed to list scheduled triggers", zap.Error(err))
+		return
+	}
+	if len(triggers) == 0 {
+		return
+	}
+
+	now := time.Now()
+	for i := range triggers {
+		t := &triggers[i]
+		if cs.shouldFire(t, now) {
+			cs.fire(ctx, t, now)
+		}
+	}
+}
+
+// shouldFire determines if a scheduled trigger is due based on its cron expression.
+// Uses a simplified interval-based approach: parses the cron expression to derive
+// an interval and checks if enough time has passed since last evaluation.
+func (cs *CronScheduler) shouldFire(t *AutomationTrigger, now time.Time) bool {
+	var cfg ScheduledTriggerConfig
+	if err := json.Unmarshal(t.Config, &cfg); err != nil {
+		cs.logger.Debug("invalid scheduled trigger config",
+			zap.String("trigger_id", t.ID), zap.Error(err))
+		return false
+	}
+	if cfg.CronExpression == "" {
+		return false
+	}
+
+	interval, err := parseCronInterval(cfg.CronExpression)
+	if err != nil {
+		cs.logger.Debug("unparseable cron expression",
+			zap.String("trigger_id", t.ID),
+			zap.String("expression", cfg.CronExpression),
+			zap.Error(err))
+		return false
+	}
+
+	if t.LastEvaluatedAt == nil {
+		return true
+	}
+	return now.Sub(*t.LastEvaluatedAt) >= interval
+}
+
+func (cs *CronScheduler) fire(ctx context.Context, t *AutomationTrigger, now time.Time) {
+	data, _ := json.Marshal(map[string]string{
+		"source":    "scheduled",
+		"timestamp": now.Format(time.RFC3339),
+	})
+	dedupKey := fmt.Sprintf("scheduled:%s:%d", t.ID, now.Unix()/60) // Dedup by minute
+
+	if err := cs.svc.FireTrigger(ctx, t.AutomationID, t.ID, TriggerTypeScheduled, data, dedupKey); err != nil {
+		cs.logger.Error("failed to fire scheduled trigger",
+			zap.String("trigger_id", t.ID),
+			zap.String("automation_id", t.AutomationID),
+			zap.Error(err))
+	}
+}
+
+// parseCronInterval converts common cron expressions to a duration.
+// Supports standard 5-field cron and shorthand like "@every 5m".
+func parseCronInterval(expr string) (time.Duration, error) {
+	if d, ok := parseCronShorthand(expr); ok {
+		return d, nil
+	}
+	return parseCronFields(expr)
+}
+
+func parseCronShorthand(expr string) (time.Duration, bool) {
+	// Handle @every shorthand.
+	if len(expr) > 7 && expr[:6] == "@every" {
+		d, err := time.ParseDuration(expr[7:])
+		if err == nil {
+			return d, true
+		}
+	}
+	// Common presets.
+	switch expr {
+	case "@hourly", "0 * * * *":
+		return time.Hour, true
+	case "@daily", "0 0 * * *":
+		return 24 * time.Hour, true
+	case "@weekly", "0 0 * * 0":
+		return 7 * 24 * time.Hour, true
+	}
+	return 0, false
+}
+
+func parseCronFields(expr string) (time.Duration, error) {
+	fields := splitFields(expr)
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("invalid cron expression: %s", expr)
+	}
+
+	minuteInterval := parseFieldInterval(fields[0], 60)
+	hourInterval := parseFieldInterval(fields[1], 24)
+
+	if minuteInterval > 0 && minuteInterval < 60 {
+		return time.Duration(minuteInterval) * time.Minute, nil
+	}
+	if hourInterval > 0 && hourInterval < 24 {
+		return time.Duration(hourInterval) * time.Hour, nil
+	}
+	return time.Hour, nil
+}
+
+func splitFields(expr string) []string {
+	var fields []string
+	field := ""
+	for _, c := range expr {
+		if c == ' ' || c == '\t' {
+			if field != "" {
+				fields = append(fields, field)
+				field = ""
+			}
+		} else {
+			field += string(c)
+		}
+	}
+	if field != "" {
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+// parseFieldInterval extracts the step value from a cron field (e.g., "*/5" → 5).
+func parseFieldInterval(field string, max int) int {
+	for i, c := range field {
+		if c == '/' {
+			val := 0
+			for _, d := range field[i+1:] {
+				if d >= '0' && d <= '9' {
+					val = val*10 + int(d-'0')
+				}
+			}
+			if val > 0 && val <= max {
+				return val
+			}
+		}
+	}
+	return 0
+}

--- a/apps/backend/internal/automation/scheduler.go
+++ b/apps/backend/internal/automation/scheduler.go
@@ -188,7 +188,7 @@ func parseCronFields(expr string) (time.Duration, error) {
 	if hourInterval > 0 && hourInterval < 24 {
 		return time.Duration(hourInterval) * time.Hour, nil
 	}
-	return time.Hour, nil
+	return 0, fmt.Errorf("unsupported cron expression (no step interval found): %s", expr)
 }
 
 func splitFields(expr string) []string {

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -1,0 +1,230 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+)
+
+// Service coordinates automation operations.
+type Service struct {
+	store    *Store
+	eventBus bus.EventBus
+	logger   *logger.Logger
+}
+
+// NewService creates a new automation service.
+func NewService(store *Store, eventBus bus.EventBus, log *logger.Logger) *Service {
+	return &Service{
+		store:    store,
+		eventBus: eventBus,
+		logger:   log,
+	}
+}
+
+// Store returns the underlying store (for scheduler/poller access).
+func (s *Service) Store() *Store {
+	return s.store
+}
+
+// --- Automation CRUD ---
+
+// CreateAutomation creates an automation with its initial triggers.
+func (s *Service) CreateAutomation(ctx context.Context, req *CreateAutomationRequest) (*Automation, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if req.WorkspaceID == "" {
+		return nil, fmt.Errorf("workspace_id is required")
+	}
+	if req.WorkflowID == "" {
+		return nil, fmt.Errorf("workflow_id is required")
+	}
+	if req.WorkflowStepID == "" {
+		return nil, fmt.Errorf("workflow_step_id is required")
+	}
+
+	maxRuns := req.MaxConcurrentRuns
+	if maxRuns <= 0 {
+		maxRuns = 1
+	}
+
+	a := &Automation{
+		WorkspaceID:       req.WorkspaceID,
+		Name:              req.Name,
+		Description:       req.Description,
+		WorkflowID:        req.WorkflowID,
+		WorkflowStepID:    req.WorkflowStepID,
+		AgentProfileID:    req.AgentProfileID,
+		ExecutorProfileID: req.ExecutorProfileID,
+		Prompt:            req.Prompt,
+		TaskTitleTemplate: req.TaskTitleTemplate,
+		Enabled:           true,
+		MaxConcurrentRuns: maxRuns,
+	}
+	if err := s.store.CreateAutomation(ctx, a); err != nil {
+		return nil, fmt.Errorf("create automation: %w", err)
+	}
+
+	// Create initial triggers.
+	for _, ts := range req.Triggers {
+		t := &AutomationTrigger{
+			AutomationID: a.ID,
+			Type:         ts.Type,
+			Config:       ts.Config,
+			Enabled:      ts.Enabled,
+		}
+		if err := s.store.CreateTrigger(ctx, t); err != nil {
+			s.logger.Error("failed to create trigger during automation creation",
+				zap.String("automation_id", a.ID),
+				zap.String("type", string(ts.Type)),
+				zap.Error(err))
+		}
+	}
+
+	return s.store.GetAutomation(ctx, a.ID)
+}
+
+// GetAutomation retrieves an automation by ID.
+func (s *Service) GetAutomation(ctx context.Context, id string) (*Automation, error) {
+	return s.store.GetAutomation(ctx, id)
+}
+
+// ListAutomations returns all automations for a workspace.
+func (s *Service) ListAutomations(ctx context.Context, workspaceID string) ([]*Automation, error) {
+	return s.store.ListAutomations(ctx, workspaceID)
+}
+
+// UpdateAutomation applies partial updates.
+func (s *Service) UpdateAutomation(ctx context.Context, id string, req *UpdateAutomationRequest) (*Automation, error) {
+	if err := s.store.UpdateAutomation(ctx, id, req); err != nil {
+		return nil, err
+	}
+	return s.store.GetAutomation(ctx, id)
+}
+
+// DeleteAutomation removes an automation.
+func (s *Service) DeleteAutomation(ctx context.Context, id string) error {
+	return s.store.DeleteAutomation(ctx, id)
+}
+
+// EnableAutomation sets enabled = true.
+func (s *Service) EnableAutomation(ctx context.Context, id string) error {
+	enabled := true
+	return s.store.UpdateAutomation(ctx, id, &UpdateAutomationRequest{Enabled: &enabled})
+}
+
+// DisableAutomation sets enabled = false.
+func (s *Service) DisableAutomation(ctx context.Context, id string) error {
+	enabled := false
+	return s.store.UpdateAutomation(ctx, id, &UpdateAutomationRequest{Enabled: &enabled})
+}
+
+// --- Trigger CRUD ---
+
+// AddTrigger adds a trigger to an automation.
+func (s *Service) AddTrigger(ctx context.Context, req *AddTriggerRequest) (*AutomationTrigger, error) {
+	if req.AutomationID == "" {
+		return nil, fmt.Errorf("automation_id is required")
+	}
+	t := &AutomationTrigger{
+		AutomationID: req.AutomationID,
+		Type:         req.Type,
+		Config:       req.Config,
+		Enabled:      req.Enabled,
+	}
+	if err := s.store.CreateTrigger(ctx, t); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// UpdateTrigger updates a trigger.
+func (s *Service) UpdateTrigger(ctx context.Context, id string, req *UpdateTriggerRequest) error {
+	return s.store.UpdateTrigger(ctx, id, req)
+}
+
+// DeleteTrigger removes a trigger.
+func (s *Service) DeleteTrigger(ctx context.Context, id string) error {
+	return s.store.DeleteTrigger(ctx, id)
+}
+
+// --- Run queries ---
+
+// ListRuns returns recent runs for an automation.
+func (s *Service) ListRuns(ctx context.Context, automationID string, limit int) ([]*AutomationRun, error) {
+	return s.store.ListRuns(ctx, automationID, limit)
+}
+
+// --- Trigger firing ---
+
+// FireTrigger publishes an AutomationTriggered event for the given trigger.
+// The orchestrator handles task creation in response.
+func (s *Service) FireTrigger(ctx context.Context, automationID, triggerID string, triggerType TriggerType, triggerData json.RawMessage, dedupKey string) error {
+	// Check dedup.
+	if dedupKey != "" {
+		exists, err := s.store.HasRunWithDedupKey(ctx, automationID, dedupKey)
+		if err != nil {
+			return fmt.Errorf("check dedup: %w", err)
+		}
+		if exists {
+			s.logger.Debug("skipping duplicate trigger",
+				zap.String("automation_id", automationID),
+				zap.String("dedup_key", dedupKey))
+			return nil
+		}
+	}
+
+	evt := &AutomationTriggeredEvent{
+		AutomationID: automationID,
+		TriggerID:    triggerID,
+		TriggerType:  triggerType,
+		TriggerData:  triggerData,
+		DedupKey:     dedupKey,
+	}
+
+	now := time.Now().UTC()
+	if updateErr := s.store.UpdateLastTriggered(ctx, automationID, now); updateErr != nil {
+		s.logger.Warn("failed to update last_triggered_at",
+			zap.String("automation_id", automationID), zap.Error(updateErr))
+	}
+	if updateErr := s.store.UpdateTriggerEvaluatedAt(ctx, triggerID, now); updateErr != nil {
+		s.logger.Warn("failed to update last_evaluated_at",
+			zap.String("trigger_id", triggerID), zap.Error(updateErr))
+	}
+
+	event := bus.NewEvent(events.AutomationTriggered, "automation_service", evt)
+	if err := s.eventBus.Publish(ctx, events.AutomationTriggered, event); err != nil {
+		return fmt.Errorf("publish automation triggered: %w", err)
+	}
+
+	s.logger.Info("automation trigger fired",
+		zap.String("automation_id", automationID),
+		zap.String("trigger_id", triggerID),
+		zap.String("type", string(triggerType)))
+	return nil
+}
+
+// RecordRun records a trigger run outcome.
+func (s *Service) RecordRun(ctx context.Context, run *AutomationRun) error {
+	return s.store.CreateRun(ctx, run)
+}
+
+// GetWebhookSecret returns the webhook secret for an automation.
+func (s *Service) GetWebhookSecret(ctx context.Context, id string) (string, error) {
+	a, err := s.store.GetAutomation(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if a == nil {
+		return "", fmt.Errorf("automation not found: %s", id)
+	}
+	return a.WebhookSecret, nil
+}

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -44,12 +44,6 @@ func (s *Service) CreateAutomation(ctx context.Context, req *CreateAutomationReq
 	if req.WorkspaceID == "" {
 		return nil, fmt.Errorf("workspace_id is required")
 	}
-	if req.WorkflowID == "" {
-		return nil, fmt.Errorf("workflow_id is required")
-	}
-	if req.WorkflowStepID == "" {
-		return nil, fmt.Errorf("workflow_step_id is required")
-	}
 
 	maxRuns := req.MaxConcurrentRuns
 	if maxRuns <= 0 {
@@ -59,6 +53,17 @@ func (s *Service) CreateAutomation(ctx context.Context, req *CreateAutomationReq
 	mode := req.ExecutionMode
 	if !mode.Valid() {
 		mode = ExecutionModeTask
+	}
+	// Workflow + step are required for task-mode automations (the run is
+	// surfaced on the kanban and needs a starting column). Run-mode is
+	// ephemeral and bypasses the workflow entirely.
+	if mode == ExecutionModeTask {
+		if req.WorkflowID == "" {
+			return nil, fmt.Errorf("workflow_id is required")
+		}
+		if req.WorkflowStepID == "" {
+			return nil, fmt.Errorf("workflow_step_id is required")
+		}
 	}
 	a := &Automation{
 		WorkspaceID:       req.WorkspaceID,
@@ -221,6 +226,19 @@ func (s *Service) FireTrigger(ctx context.Context, automationID, triggerID strin
 // RecordRun records a trigger run outcome.
 func (s *Service) RecordRun(ctx context.Context, run *AutomationRun) error {
 	return s.store.CreateRun(ctx, run)
+}
+
+// MarkRunFailedByTaskID transitions a still-pending run (task_created) into
+// the failed state. Used when something downstream of task creation aborts
+// the run, e.g. a permission prompt for a run-mode automation.
+func (s *Service) MarkRunFailedByTaskID(ctx context.Context, taskID, errMsg string) error {
+	return s.store.MarkRunFailedByTaskID(ctx, taskID, errMsg)
+}
+
+// MarkRunSucceededByTaskID transitions a still-pending run (task_created)
+// into the succeeded state when the launched agent finishes cleanly.
+func (s *Service) MarkRunSucceededByTaskID(ctx context.Context, taskID string) error {
+	return s.store.MarkRunSucceededByTaskID(ctx, taskID)
 }
 
 // GetWebhookSecret returns the webhook secret for an automation.

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -68,6 +68,7 @@ func (s *Service) CreateAutomation(ctx context.Context, req *CreateAutomationReq
 		WorkflowStepID:    req.WorkflowStepID,
 		AgentProfileID:    req.AgentProfileID,
 		ExecutorProfileID: req.ExecutorProfileID,
+		RepositoryID:      req.RepositoryID,
 		Prompt:            req.Prompt,
 		TaskTitleTemplate: req.TaskTitleTemplate,
 		ExecutionMode:     mode,

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -56,6 +56,10 @@ func (s *Service) CreateAutomation(ctx context.Context, req *CreateAutomationReq
 		maxRuns = 1
 	}
 
+	mode := req.ExecutionMode
+	if !mode.Valid() {
+		mode = ExecutionModeTask
+	}
 	a := &Automation{
 		WorkspaceID:       req.WorkspaceID,
 		Name:              req.Name,
@@ -66,6 +70,7 @@ func (s *Service) CreateAutomation(ctx context.Context, req *CreateAutomationReq
 		ExecutorProfileID: req.ExecutorProfileID,
 		Prompt:            req.Prompt,
 		TaskTitleTemplate: req.TaskTitleTemplate,
+		ExecutionMode:     mode,
 		Enabled:           true,
 		MaxConcurrentRuns: maxRuns,
 	}

--- a/apps/backend/internal/automation/service.go
+++ b/apps/backend/internal/automation/service.go
@@ -193,6 +193,17 @@ func (s *Service) FireTrigger(ctx context.Context, automationID, triggerID strin
 		}
 	}
 
+	// Enforce max_concurrent_runs: a run is "active" while still in
+	// task_created (succeeded/failed/skipped don't count). If at the cap,
+	// record a skipped run so the user can see the cap kicked in.
+	skipped, capErr := s.maybeSkipForConcurrencyCap(ctx, automationID, triggerID, triggerType, triggerData, dedupKey)
+	if capErr != nil {
+		return capErr
+	}
+	if skipped {
+		return nil
+	}
+
 	evt := &AutomationTriggeredEvent{
 		AutomationID: automationID,
 		TriggerID:    triggerID,
@@ -226,6 +237,43 @@ func (s *Service) FireTrigger(ctx context.Context, automationID, triggerID strin
 // RecordRun records a trigger run outcome.
 func (s *Service) RecordRun(ctx context.Context, run *AutomationRun) error {
 	return s.store.CreateRun(ctx, run)
+}
+
+// maybeSkipForConcurrencyCap enforces max_concurrent_runs. Returns (skipped,
+// err). When skipped, a "skipped" run row is persisted so the user can see
+// the cap kicked in.
+func (s *Service) maybeSkipForConcurrencyCap(ctx context.Context, automationID, triggerID string, triggerType TriggerType, triggerData json.RawMessage, dedupKey string) (bool, error) {
+	a, err := s.store.GetAutomation(ctx, automationID)
+	if err != nil || a == nil {
+		return false, nil // not our problem here; FireTrigger will hit it again downstream
+	}
+	if a.MaxConcurrentRuns <= 0 {
+		return false, nil
+	}
+	active, err := s.store.CountActiveRuns(ctx, automationID)
+	if err != nil {
+		return false, fmt.Errorf("count active runs: %w", err)
+	}
+	if active < a.MaxConcurrentRuns {
+		return false, nil
+	}
+	skipRun := &AutomationRun{
+		AutomationID: automationID,
+		TriggerID:    triggerID,
+		TriggerType:  triggerType,
+		Status:       RunStatusSkipped,
+		DedupKey:     dedupKey,
+		TriggerData:  triggerData,
+		ErrorMessage: fmt.Sprintf("max_concurrent_runs=%d reached", a.MaxConcurrentRuns),
+	}
+	if recErr := s.store.CreateRun(ctx, skipRun); recErr != nil {
+		s.logger.Warn("failed to record skipped run", zap.Error(recErr))
+	}
+	s.logger.Info("automation trigger skipped: concurrency cap reached",
+		zap.String("automation_id", automationID),
+		zap.Int("active", active),
+		zap.Int("max", a.MaxConcurrentRuns))
+	return true, nil
 }
 
 // MarkRunFailedByTaskID transitions a still-pending run (task_created) into

--- a/apps/backend/internal/automation/store.go
+++ b/apps/backend/internal/automation/store.go
@@ -1,0 +1,442 @@
+package automation
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// Store provides SQLite persistence for automations.
+type Store struct {
+	db *sqlx.DB // writer
+	ro *sqlx.DB // reader
+}
+
+// NewStore creates a new automation store and initializes the schema.
+func NewStore(writer, reader *sqlx.DB) (*Store, error) {
+	s := &Store{db: writer, ro: reader}
+	if err := s.initSchema(); err != nil {
+		return nil, fmt.Errorf("automation schema init: %w", err)
+	}
+	return s, nil
+}
+
+const createTablesSQL = `
+	CREATE TABLE IF NOT EXISTS automations (
+		id TEXT PRIMARY KEY,
+		workspace_id TEXT NOT NULL,
+		name TEXT NOT NULL,
+		description TEXT DEFAULT '',
+		workflow_id TEXT NOT NULL,
+		workflow_step_id TEXT NOT NULL,
+		agent_profile_id TEXT NOT NULL,
+		executor_profile_id TEXT NOT NULL,
+		prompt TEXT DEFAULT '',
+		enabled BOOLEAN DEFAULT 1,
+		max_concurrent_runs INTEGER DEFAULT 1,
+		webhook_secret TEXT DEFAULT '',
+		last_triggered_at DATETIME,
+		created_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS automation_triggers (
+		id TEXT PRIMARY KEY,
+		automation_id TEXT NOT NULL REFERENCES automations(id) ON DELETE CASCADE,
+		type TEXT NOT NULL,
+		config TEXT NOT NULL DEFAULT '{}',
+		enabled BOOLEAN DEFAULT 1,
+		last_evaluated_at DATETIME,
+		created_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_automation_triggers_automation ON automation_triggers(automation_id);
+
+	CREATE TABLE IF NOT EXISTS automation_runs (
+		id TEXT PRIMARY KEY,
+		automation_id TEXT NOT NULL REFERENCES automations(id) ON DELETE CASCADE,
+		trigger_id TEXT NOT NULL,
+		trigger_type TEXT NOT NULL,
+		task_id TEXT DEFAULT '',
+		status TEXT NOT NULL,
+		dedup_key TEXT DEFAULT '',
+		trigger_data TEXT NOT NULL DEFAULT '{}',
+		error_message TEXT DEFAULT '',
+		created_at DATETIME NOT NULL
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_automation_runs_automation ON automation_runs(automation_id);
+	CREATE INDEX IF NOT EXISTS idx_automation_runs_dedup ON automation_runs(automation_id, dedup_key);
+`
+
+const migrateTaskTitleSQL = `
+	ALTER TABLE automations ADD COLUMN task_title_template TEXT DEFAULT '';
+`
+
+func (s *Store) initSchema() error {
+	if _, err := s.db.Exec(createTablesSQL); err != nil {
+		return err
+	}
+	// Idempotent migration: add task_title_template column if missing.
+	s.db.Exec(migrateTaskTitleSQL) //nolint:errcheck // column may already exist
+	return nil
+}
+
+// --- Automation CRUD ---
+
+// CreateAutomation persists a new automation.
+func (s *Store) CreateAutomation(ctx context.Context, a *Automation) error {
+	if a.ID == "" {
+		a.ID = uuid.New().String()
+	}
+	if a.WebhookSecret == "" {
+		a.WebhookSecret = generateSecret()
+	}
+	now := time.Now().UTC()
+	a.CreatedAt = now
+	a.UpdatedAt = now
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO automations (id, workspace_id, name, description, workflow_id, workflow_step_id,
+			agent_profile_id, executor_profile_id, prompt, task_title_template, enabled, max_concurrent_runs,
+			webhook_secret, last_triggered_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.ID, a.WorkspaceID, a.Name, a.Description, a.WorkflowID, a.WorkflowStepID,
+		a.AgentProfileID, a.ExecutorProfileID, a.Prompt, a.TaskTitleTemplate, a.Enabled, a.MaxConcurrentRuns,
+		a.WebhookSecret, a.LastTriggeredAt, a.CreatedAt, a.UpdatedAt)
+	return err
+}
+
+// GetAutomation returns an automation by ID with its triggers hydrated.
+func (s *Store) GetAutomation(ctx context.Context, id string) (*Automation, error) {
+	var a Automation
+	err := s.ro.GetContext(ctx, &a, `SELECT * FROM automations WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	triggers, err := s.ListTriggers(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("hydrate triggers: %w", err)
+	}
+	a.Triggers = triggers
+	return &a, nil
+}
+
+// ListAutomations returns all automations for a workspace with triggers hydrated.
+func (s *Store) ListAutomations(ctx context.Context, workspaceID string) ([]*Automation, error) {
+	var automations []*Automation
+	err := s.ro.SelectContext(ctx, &automations,
+		`SELECT * FROM automations WHERE workspace_id = ? ORDER BY created_at DESC`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if len(automations) == 0 {
+		return automations, nil
+	}
+	// Batch-load triggers for all automations.
+	ids := make([]string, len(automations))
+	for i, a := range automations {
+		ids[i] = a.ID
+	}
+	triggersByAutomation, err := s.listTriggersForAutomations(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("hydrate triggers: %w", err)
+	}
+	for _, a := range automations {
+		a.Triggers = triggersByAutomation[a.ID]
+	}
+	return automations, nil
+}
+
+// ListAllEnabled returns all enabled automations (across workspaces).
+func (s *Store) ListAllEnabled(ctx context.Context) ([]*Automation, error) {
+	var automations []*Automation
+	err := s.ro.SelectContext(ctx, &automations,
+		`SELECT * FROM automations WHERE enabled = 1 ORDER BY created_at`)
+	if err != nil {
+		return nil, err
+	}
+	if len(automations) == 0 {
+		return automations, nil
+	}
+	ids := make([]string, len(automations))
+	for i, a := range automations {
+		ids[i] = a.ID
+	}
+	triggersByAutomation, err := s.listTriggersForAutomations(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("hydrate triggers: %w", err)
+	}
+	for _, a := range automations {
+		a.Triggers = triggersByAutomation[a.ID]
+	}
+	return automations, nil
+}
+
+// UpdateAutomation applies partial updates to an automation.
+func (s *Store) UpdateAutomation(ctx context.Context, id string, req *UpdateAutomationRequest) error {
+	a, err := s.GetAutomation(ctx, id)
+	if err != nil {
+		return err
+	}
+	if a == nil {
+		return fmt.Errorf("automation not found: %s", id)
+	}
+	if req.Name != nil {
+		a.Name = *req.Name
+	}
+	if req.Description != nil {
+		a.Description = *req.Description
+	}
+	if req.WorkflowID != nil {
+		a.WorkflowID = *req.WorkflowID
+	}
+	if req.WorkflowStepID != nil {
+		a.WorkflowStepID = *req.WorkflowStepID
+	}
+	if req.AgentProfileID != nil {
+		a.AgentProfileID = *req.AgentProfileID
+	}
+	if req.ExecutorProfileID != nil {
+		a.ExecutorProfileID = *req.ExecutorProfileID
+	}
+	if req.Prompt != nil {
+		a.Prompt = *req.Prompt
+	}
+	if req.Enabled != nil {
+		a.Enabled = *req.Enabled
+	}
+	if req.MaxConcurrentRuns != nil {
+		a.MaxConcurrentRuns = *req.MaxConcurrentRuns
+	}
+	if req.TaskTitleTemplate != nil {
+		a.TaskTitleTemplate = *req.TaskTitleTemplate
+	}
+	a.UpdatedAt = time.Now().UTC()
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE automations SET name = ?, description = ?, workflow_id = ?, workflow_step_id = ?,
+			agent_profile_id = ?, executor_profile_id = ?, prompt = ?, task_title_template = ?,
+			enabled = ?, max_concurrent_runs = ?, updated_at = ?
+		WHERE id = ?`,
+		a.Name, a.Description, a.WorkflowID, a.WorkflowStepID,
+		a.AgentProfileID, a.ExecutorProfileID, a.Prompt, a.TaskTitleTemplate,
+		a.Enabled, a.MaxConcurrentRuns, a.UpdatedAt, id)
+	return err
+}
+
+// DeleteAutomation removes an automation and its triggers/runs (CASCADE).
+func (s *Store) DeleteAutomation(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM automations WHERE id = ?`, id)
+	return err
+}
+
+// UpdateLastTriggered updates the last_triggered_at timestamp.
+func (s *Store) UpdateLastTriggered(ctx context.Context, id string, t time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE automations SET last_triggered_at = ?, updated_at = ? WHERE id = ?`,
+		t, time.Now().UTC(), id)
+	return err
+}
+
+// --- Trigger CRUD ---
+
+// CreateTrigger adds a trigger to an automation.
+func (s *Store) CreateTrigger(ctx context.Context, t *AutomationTrigger) error {
+	if t.ID == "" {
+		t.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	t.CreatedAt = now
+	t.UpdatedAt = now
+	t.ConfigJSON = string(t.Config)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO automation_triggers (id, automation_id, type, config, enabled, last_evaluated_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, t.AutomationID, t.Type, t.ConfigJSON, t.Enabled, t.LastEvaluatedAt, t.CreatedAt, t.UpdatedAt)
+	return err
+}
+
+// ListTriggers returns all triggers for an automation.
+func (s *Store) ListTriggers(ctx context.Context, automationID string) ([]AutomationTrigger, error) {
+	var triggers []AutomationTrigger
+	err := s.ro.SelectContext(ctx, &triggers,
+		`SELECT * FROM automation_triggers WHERE automation_id = ? ORDER BY created_at`, automationID)
+	hydrateTriggers(triggers)
+	return triggers, err
+}
+
+// hydrateTriggers converts the ConfigJSON string field to the Config json.RawMessage.
+func hydrateTriggers(triggers []AutomationTrigger) {
+	for i := range triggers {
+		triggers[i].Config = json.RawMessage(triggers[i].ConfigJSON)
+	}
+}
+
+func (s *Store) listTriggersForAutomations(ctx context.Context, automationIDs []string) (map[string][]AutomationTrigger, error) {
+	if len(automationIDs) == 0 {
+		return make(map[string][]AutomationTrigger), nil
+	}
+	query, args, err := sqlx.In(
+		`SELECT * FROM automation_triggers WHERE automation_id IN (?) ORDER BY created_at`, automationIDs)
+	if err != nil {
+		return nil, err
+	}
+	query = s.ro.Rebind(query)
+	var triggers []AutomationTrigger
+	if err := s.ro.SelectContext(ctx, &triggers, query, args...); err != nil {
+		return nil, err
+	}
+	hydrateTriggers(triggers)
+	result := make(map[string][]AutomationTrigger, len(automationIDs))
+	for i := range triggers {
+		result[triggers[i].AutomationID] = append(result[triggers[i].AutomationID], triggers[i])
+	}
+	return result, nil
+}
+
+// UpdateTrigger applies partial updates to a trigger.
+func (s *Store) UpdateTrigger(ctx context.Context, id string, req *UpdateTriggerRequest) error {
+	var t AutomationTrigger
+	err := s.ro.GetContext(ctx, &t, `SELECT * FROM automation_triggers WHERE id = ?`, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("trigger not found: %s", id)
+	}
+	if err != nil {
+		return err
+	}
+	if req.Config != nil {
+		t.ConfigJSON = string(*req.Config)
+	}
+	if req.Enabled != nil {
+		t.Enabled = *req.Enabled
+	}
+	t.UpdatedAt = time.Now().UTC()
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE automation_triggers SET config = ?, enabled = ?, updated_at = ? WHERE id = ?`,
+		t.ConfigJSON, t.Enabled, t.UpdatedAt, id)
+	return err
+}
+
+// DeleteTrigger removes a trigger.
+func (s *Store) DeleteTrigger(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM automation_triggers WHERE id = ?`, id)
+	return err
+}
+
+// UpdateTriggerEvaluatedAt sets the last_evaluated_at timestamp.
+func (s *Store) UpdateTriggerEvaluatedAt(ctx context.Context, id string, t time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE automation_triggers SET last_evaluated_at = ?, updated_at = ? WHERE id = ?`,
+		t, time.Now().UTC(), id)
+	return err
+}
+
+// ListEnabledTriggersByType returns enabled triggers of a specific type (across all enabled automations).
+func (s *Store) ListEnabledTriggersByType(ctx context.Context, triggerType TriggerType) ([]AutomationTrigger, error) {
+	var triggers []AutomationTrigger
+	err := s.ro.SelectContext(ctx, &triggers, `
+		SELECT t.* FROM automation_triggers t
+		JOIN automations a ON a.id = t.automation_id
+		WHERE t.type = ? AND t.enabled = 1 AND a.enabled = 1
+		ORDER BY t.created_at`, string(triggerType))
+	hydrateTriggers(triggers)
+	return triggers, err
+}
+
+// --- Run operations ---
+
+// CreateRun records a trigger firing.
+func (s *Store) CreateRun(ctx context.Context, r *AutomationRun) error {
+	if r.ID == "" {
+		r.ID = uuid.New().String()
+	}
+	r.CreatedAt = time.Now().UTC()
+	r.TriggerDataJSON = string(r.TriggerData)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO automation_runs (id, automation_id, trigger_id, trigger_type, task_id, status,
+			dedup_key, trigger_data, error_message, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.AutomationID, r.TriggerID, r.TriggerType, r.TaskID, r.Status,
+		r.DedupKey, r.TriggerDataJSON, r.ErrorMessage, r.CreatedAt)
+	return err
+}
+
+// ListRuns returns recent runs for an automation.
+func (s *Store) ListRuns(ctx context.Context, automationID string, limit int) ([]*AutomationRun, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var runs []*AutomationRun
+	err := s.ro.SelectContext(ctx, &runs,
+		`SELECT * FROM automation_runs WHERE automation_id = ? ORDER BY created_at DESC LIMIT ?`,
+		automationID, limit)
+	for _, r := range runs {
+		r.TriggerData = json.RawMessage(r.TriggerDataJSON)
+	}
+	return runs, err
+}
+
+// HasRunWithDedupKey checks if a run with the given dedup key already exists.
+func (s *Store) HasRunWithDedupKey(ctx context.Context, automationID, dedupKey string) (bool, error) {
+	if dedupKey == "" {
+		return false, nil
+	}
+	var count int
+	err := s.ro.GetContext(ctx, &count,
+		`SELECT COUNT(*) FROM automation_runs WHERE automation_id = ? AND dedup_key = ?`,
+		automationID, dedupKey)
+	return count > 0, err
+}
+
+// CountActiveRuns returns the number of runs with task_created status for an automation.
+func (s *Store) CountActiveRuns(ctx context.Context, automationID string) (int, error) {
+	var count int
+	err := s.ro.GetContext(ctx, &count,
+		`SELECT COUNT(*) FROM automation_runs WHERE automation_id = ? AND status = ?`,
+		automationID, string(RunStatusTaskCreated))
+	return count, err
+}
+
+// DeleteAutomationsByWorkspace removes all automations (and their triggers/runs) for a workspace.
+// Used by e2e reset.
+func (s *Store) DeleteAutomationsByWorkspace(ctx context.Context, workspaceID string) (int, error) {
+	// Get automation IDs first for cascade cleanup.
+	var ids []string
+	if err := s.ro.SelectContext(ctx, &ids,
+		`SELECT id FROM automations WHERE workspace_id = ?`, workspaceID); err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	for _, id := range ids {
+		_, _ = s.db.ExecContext(ctx, `DELETE FROM automation_triggers WHERE automation_id = ?`, id)
+		_, _ = s.db.ExecContext(ctx, `DELETE FROM automation_runs WHERE automation_id = ?`, id)
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM automations WHERE workspace_id = ?`, workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// generateSecret creates a random hex string for webhook authentication.
+func generateSecret() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return uuid.New().String()
+	}
+	return hex.EncodeToString(b)
+}

--- a/apps/backend/internal/automation/store.go
+++ b/apps/backend/internal/automation/store.go
@@ -39,7 +39,10 @@ const createTablesSQL = `
 		workflow_step_id TEXT NOT NULL,
 		agent_profile_id TEXT NOT NULL,
 		executor_profile_id TEXT NOT NULL,
+		repository_id TEXT NOT NULL DEFAULT '',
 		prompt TEXT DEFAULT '',
+		task_title_template TEXT DEFAULT '',
+		execution_mode TEXT NOT NULL DEFAULT 'task',
 		enabled BOOLEAN DEFAULT 1,
 		max_concurrent_runs INTEGER DEFAULT 1,
 		webhook_secret TEXT DEFAULT '',
@@ -78,23 +81,9 @@ const createTablesSQL = `
 	CREATE INDEX IF NOT EXISTS idx_automation_runs_dedup ON automation_runs(automation_id, dedup_key);
 `
 
-const migrateTaskTitleSQL = `
-	ALTER TABLE automations ADD COLUMN task_title_template TEXT DEFAULT '';
-`
-
-const migrateExecutionModeSQL = `
-	ALTER TABLE automations ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'task';
-`
-
 func (s *Store) initSchema() error {
-	if _, err := s.db.Exec(createTablesSQL); err != nil {
-		return err
-	}
-	// Idempotent migrations: each ALTER adds a column if missing; SQLite
-	// returns a duplicate-column error otherwise, which we swallow.
-	s.db.Exec(migrateTaskTitleSQL)     //nolint:errcheck // column may already exist
-	s.db.Exec(migrateExecutionModeSQL) //nolint:errcheck // column may already exist
-	return nil
+	_, err := s.db.Exec(createTablesSQL)
+	return err
 }
 
 // --- Automation CRUD ---
@@ -115,12 +104,14 @@ func (s *Store) CreateAutomation(ctx context.Context, a *Automation) error {
 	}
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO automations (id, workspace_id, name, description, workflow_id, workflow_step_id,
-			agent_profile_id, executor_profile_id, prompt, task_title_template, execution_mode,
+			agent_profile_id, executor_profile_id, repository_id,
+			prompt, task_title_template, execution_mode,
 			enabled, max_concurrent_runs,
 			webhook_secret, last_triggered_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ID, a.WorkspaceID, a.Name, a.Description, a.WorkflowID, a.WorkflowStepID,
-		a.AgentProfileID, a.ExecutorProfileID, a.Prompt, a.TaskTitleTemplate, string(a.ExecutionMode),
+		a.AgentProfileID, a.ExecutorProfileID, a.RepositoryID,
+		a.Prompt, a.TaskTitleTemplate, string(a.ExecutionMode),
 		a.Enabled, a.MaxConcurrentRuns,
 		a.WebhookSecret, a.LastTriggeredAt, a.CreatedAt, a.UpdatedAt)
 	return err
@@ -222,6 +213,9 @@ func (s *Store) UpdateAutomation(ctx context.Context, id string, req *UpdateAuto
 	if req.ExecutorProfileID != nil {
 		a.ExecutorProfileID = *req.ExecutorProfileID
 	}
+	if req.RepositoryID != nil {
+		a.RepositoryID = *req.RepositoryID
+	}
 	if req.Prompt != nil {
 		a.Prompt = *req.Prompt
 	}
@@ -243,11 +237,13 @@ func (s *Store) UpdateAutomation(ctx context.Context, id string, req *UpdateAuto
 	a.UpdatedAt = time.Now().UTC()
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE automations SET name = ?, description = ?, workflow_id = ?, workflow_step_id = ?,
-			agent_profile_id = ?, executor_profile_id = ?, prompt = ?, task_title_template = ?,
+			agent_profile_id = ?, executor_profile_id = ?, repository_id = ?,
+			prompt = ?, task_title_template = ?,
 			execution_mode = ?, enabled = ?, max_concurrent_runs = ?, updated_at = ?
 		WHERE id = ?`,
 		a.Name, a.Description, a.WorkflowID, a.WorkflowStepID,
-		a.AgentProfileID, a.ExecutorProfileID, a.Prompt, a.TaskTitleTemplate,
+		a.AgentProfileID, a.ExecutorProfileID, a.RepositoryID,
+		a.Prompt, a.TaskTitleTemplate,
 		string(a.ExecutionMode), a.Enabled, a.MaxConcurrentRuns, a.UpdatedAt, id)
 	return err
 }

--- a/apps/backend/internal/automation/store.go
+++ b/apps/backend/internal/automation/store.go
@@ -82,12 +82,18 @@ const migrateTaskTitleSQL = `
 	ALTER TABLE automations ADD COLUMN task_title_template TEXT DEFAULT '';
 `
 
+const migrateExecutionModeSQL = `
+	ALTER TABLE automations ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'task';
+`
+
 func (s *Store) initSchema() error {
 	if _, err := s.db.Exec(createTablesSQL); err != nil {
 		return err
 	}
-	// Idempotent migration: add task_title_template column if missing.
-	s.db.Exec(migrateTaskTitleSQL) //nolint:errcheck // column may already exist
+	// Idempotent migrations: each ALTER adds a column if missing; SQLite
+	// returns a duplicate-column error otherwise, which we swallow.
+	s.db.Exec(migrateTaskTitleSQL)     //nolint:errcheck // column may already exist
+	s.db.Exec(migrateExecutionModeSQL) //nolint:errcheck // column may already exist
 	return nil
 }
 
@@ -104,13 +110,18 @@ func (s *Store) CreateAutomation(ctx context.Context, a *Automation) error {
 	now := time.Now().UTC()
 	a.CreatedAt = now
 	a.UpdatedAt = now
+	if a.ExecutionMode == "" {
+		a.ExecutionMode = ExecutionModeTask
+	}
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO automations (id, workspace_id, name, description, workflow_id, workflow_step_id,
-			agent_profile_id, executor_profile_id, prompt, task_title_template, enabled, max_concurrent_runs,
+			agent_profile_id, executor_profile_id, prompt, task_title_template, execution_mode,
+			enabled, max_concurrent_runs,
 			webhook_secret, last_triggered_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ID, a.WorkspaceID, a.Name, a.Description, a.WorkflowID, a.WorkflowStepID,
-		a.AgentProfileID, a.ExecutorProfileID, a.Prompt, a.TaskTitleTemplate, a.Enabled, a.MaxConcurrentRuns,
+		a.AgentProfileID, a.ExecutorProfileID, a.Prompt, a.TaskTitleTemplate, string(a.ExecutionMode),
+		a.Enabled, a.MaxConcurrentRuns,
 		a.WebhookSecret, a.LastTriggeredAt, a.CreatedAt, a.UpdatedAt)
 	return err
 }
@@ -223,15 +234,21 @@ func (s *Store) UpdateAutomation(ctx context.Context, id string, req *UpdateAuto
 	if req.TaskTitleTemplate != nil {
 		a.TaskTitleTemplate = *req.TaskTitleTemplate
 	}
+	if req.ExecutionMode != nil {
+		a.ExecutionMode = *req.ExecutionMode
+	}
+	if !a.ExecutionMode.Valid() {
+		a.ExecutionMode = ExecutionModeTask
+	}
 	a.UpdatedAt = time.Now().UTC()
 	_, err = s.db.ExecContext(ctx, `
 		UPDATE automations SET name = ?, description = ?, workflow_id = ?, workflow_step_id = ?,
 			agent_profile_id = ?, executor_profile_id = ?, prompt = ?, task_title_template = ?,
-			enabled = ?, max_concurrent_runs = ?, updated_at = ?
+			execution_mode = ?, enabled = ?, max_concurrent_runs = ?, updated_at = ?
 		WHERE id = ?`,
 		a.Name, a.Description, a.WorkflowID, a.WorkflowStepID,
 		a.AgentProfileID, a.ExecutorProfileID, a.Prompt, a.TaskTitleTemplate,
-		a.Enabled, a.MaxConcurrentRuns, a.UpdatedAt, id)
+		string(a.ExecutionMode), a.Enabled, a.MaxConcurrentRuns, a.UpdatedAt, id)
 	return err
 }
 

--- a/apps/backend/internal/automation/store.go
+++ b/apps/backend/internal/automation/store.go
@@ -400,6 +400,37 @@ func (s *Store) CreateRun(ctx context.Context, r *AutomationRun) error {
 	return err
 }
 
+// MarkRunFailedByTaskID flips the most recent task_created run for a task
+// into the failed state. Used when a downstream condition (e.g. a permission
+// prompt that a run-mode automation can't answer) makes the run effectively
+// dead. No-op if no matching run is found.
+func (s *Store) MarkRunFailedByTaskID(ctx context.Context, taskID, errMsg string) error {
+	return s.updateRunTerminalStatus(ctx, taskID, RunStatusFailed, errMsg)
+}
+
+// MarkRunSucceededByTaskID flips the most recent task_created run for a task
+// into the succeeded state. Used when an automation-launched agent completes
+// without error.
+func (s *Store) MarkRunSucceededByTaskID(ctx context.Context, taskID string) error {
+	return s.updateRunTerminalStatus(ctx, taskID, RunStatusSucceeded, "")
+}
+
+// updateRunTerminalStatus is the shared implementation behind MarkRun{Failed,Succeeded}ByTaskID.
+func (s *Store) updateRunTerminalStatus(ctx context.Context, taskID string, status RunStatus, errMsg string) error {
+	if taskID == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE automation_runs SET status = ?, error_message = ?
+		WHERE id = (
+			SELECT id FROM automation_runs
+			WHERE task_id = ? AND status = ?
+			ORDER BY created_at DESC LIMIT 1
+		)`,
+		string(status), errMsg, taskID, string(RunStatusTaskCreated))
+	return err
+}
+
 // ListRuns returns recent runs for an automation.
 func (s *Store) ListRuns(ctx context.Context, automationID string, limit int) ([]*AutomationRun, error) {
 	if limit <= 0 {

--- a/apps/backend/internal/automation/store.go
+++ b/apps/backend/internal/automation/store.go
@@ -81,9 +81,24 @@ const createTablesSQL = `
 	CREATE INDEX IF NOT EXISTS idx_automation_runs_dedup ON automation_runs(automation_id, dedup_key);
 `
 
+// In-branch column additions. The canonical CREATE TABLE covers fresh
+// installs; these ALTERs cover DBs already initialised from an earlier
+// commit on this branch (the original PR #406 schema). SQLite returns a
+// duplicate-column error when the column already exists, which we swallow.
+const (
+	migrateTaskTitleSQL     = `ALTER TABLE automations ADD COLUMN task_title_template TEXT DEFAULT ''`
+	migrateExecutionModeSQL = `ALTER TABLE automations ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'task'`
+	migrateRepositoryIDSQL  = `ALTER TABLE automations ADD COLUMN repository_id TEXT NOT NULL DEFAULT ''`
+)
+
 func (s *Store) initSchema() error {
-	_, err := s.db.Exec(createTablesSQL)
-	return err
+	if _, err := s.db.Exec(createTablesSQL); err != nil {
+		return err
+	}
+	s.db.Exec(migrateTaskTitleSQL)     //nolint:errcheck // duplicate-column on existing DBs
+	s.db.Exec(migrateExecutionModeSQL) //nolint:errcheck // duplicate-column on existing DBs
+	s.db.Exec(migrateRepositoryIDSQL)  //nolint:errcheck // duplicate-column on existing DBs
+	return nil
 }
 
 // --- Automation CRUD ---

--- a/apps/backend/internal/automation/store_test.go
+++ b/apps/backend/internal/automation/store_test.go
@@ -1,0 +1,214 @@
+package automation
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func setupTestStore(t *testing.T) *Store {
+	t.Helper()
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := NewStore(db, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestCreateAndGetAutomation(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	a := &Automation{
+		WorkspaceID:       "ws-1",
+		Name:              "Test Automation",
+		Description:       "Runs on cron",
+		WorkflowID:        "wf-1",
+		WorkflowStepID:    "step-1",
+		AgentProfileID:    "agent-1",
+		ExecutorProfileID: "exec-1",
+		Prompt:            "Hello {{trigger.type}}",
+		Enabled:           true,
+		MaxConcurrentRuns: 1,
+	}
+	if err := store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	if a.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if a.WebhookSecret == "" {
+		t.Fatal("expected non-empty webhook secret")
+	}
+
+	got, err := store.GetAutomation(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected automation, got nil")
+	}
+	if got.Name != "Test Automation" {
+		t.Errorf("expected name 'Test Automation', got %q", got.Name)
+	}
+	if !got.Enabled {
+		t.Error("expected enabled = true")
+	}
+}
+
+func TestCreateAndListTriggers(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	a := &Automation{WorkspaceID: "ws-1", Name: "A", WorkflowID: "wf-1", WorkflowStepID: "s-1", Enabled: true}
+	if err := store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := json.Marshal(ScheduledTriggerConfig{CronExpression: "*/5 * * * *"})
+	t1 := &AutomationTrigger{AutomationID: a.ID, Type: TriggerTypeScheduled, Config: cfg, Enabled: true}
+	if err := store.CreateTrigger(ctx, t1); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg2, _ := json.Marshal(WebhookTriggerConfig{})
+	t2 := &AutomationTrigger{AutomationID: a.ID, Type: TriggerTypeWebhook, Config: cfg2, Enabled: true}
+	if err := store.CreateTrigger(ctx, t2); err != nil {
+		t.Fatal(err)
+	}
+
+	triggers, err := store.ListTriggers(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(triggers) != 2 {
+		t.Fatalf("expected 2 triggers, got %d", len(triggers))
+	}
+
+	// Verify trigger hydration on GetAutomation.
+	got, _ := store.GetAutomation(ctx, a.ID)
+	if len(got.Triggers) != 2 {
+		t.Fatalf("expected 2 hydrated triggers, got %d", len(got.Triggers))
+	}
+}
+
+func TestRunDeduplication(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	a := &Automation{WorkspaceID: "ws-1", Name: "A", WorkflowID: "wf-1", WorkflowStepID: "s-1", Enabled: true}
+	if err := store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	run := &AutomationRun{
+		AutomationID: a.ID,
+		TriggerID:    "t-1",
+		TriggerType:  TriggerTypeScheduled,
+		Status:       RunStatusTaskCreated,
+		DedupKey:     "scheduled:t-1:12345",
+		TriggerData:  json.RawMessage(`{}`),
+	}
+	if err := store.CreateRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, err := store.HasRunWithDedupKey(ctx, a.ID, "scheduled:t-1:12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("expected dedup key to exist")
+	}
+
+	exists, _ = store.HasRunWithDedupKey(ctx, a.ID, "other-key")
+	if exists {
+		t.Error("expected other key to not exist")
+	}
+}
+
+func TestListEnabledTriggersByType(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	a1 := &Automation{WorkspaceID: "ws-1", Name: "Enabled", WorkflowID: "wf-1", WorkflowStepID: "s-1", Enabled: true}
+	if err := store.CreateAutomation(ctx, a1); err != nil {
+		t.Fatal(err)
+	}
+	a2 := &Automation{WorkspaceID: "ws-1", Name: "Disabled", WorkflowID: "wf-1", WorkflowStepID: "s-1", Enabled: false}
+	if err := store.CreateAutomation(ctx, a2); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, _ := json.Marshal(ScheduledTriggerConfig{CronExpression: "@hourly"})
+	if err := store.CreateTrigger(ctx, &AutomationTrigger{AutomationID: a1.ID, Type: TriggerTypeScheduled, Config: cfg, Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateTrigger(ctx, &AutomationTrigger{AutomationID: a2.ID, Type: TriggerTypeScheduled, Config: cfg, Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	triggers, err := store.ListEnabledTriggersByType(ctx, TriggerTypeScheduled)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only one — from the enabled automation.
+	if len(triggers) != 1 {
+		t.Fatalf("expected 1 trigger from enabled automation, got %d", len(triggers))
+	}
+}
+
+func TestUpdateAutomation(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	a := &Automation{WorkspaceID: "ws-1", Name: "Original", WorkflowID: "wf-1", WorkflowStepID: "s-1", Enabled: true}
+	if err := store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	newName := "Updated"
+	enabled := false
+	if err := store.UpdateAutomation(ctx, a.ID, &UpdateAutomationRequest{Name: &newName, Enabled: &enabled}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := store.GetAutomation(ctx, a.ID)
+	if got.Name != "Updated" {
+		t.Errorf("expected name 'Updated', got %q", got.Name)
+	}
+	if got.Enabled {
+		t.Error("expected enabled = false")
+	}
+}
+
+func TestDeleteAutomation(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	a := &Automation{WorkspaceID: "ws-1", Name: "To Delete", WorkflowID: "wf-1", WorkflowStepID: "s-1", Enabled: true}
+	if err := store.CreateAutomation(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := json.Marshal(ScheduledTriggerConfig{CronExpression: "@hourly"})
+	if err := store.CreateTrigger(ctx, &AutomationTrigger{AutomationID: a.ID, Type: TriggerTypeScheduled, Config: cfg, Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteAutomation(ctx, a.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := store.GetAutomation(ctx, a.ID)
+	if got != nil {
+		t.Error("expected nil after delete")
+	}
+}

--- a/apps/backend/internal/automation/trigger_registry.go
+++ b/apps/backend/internal/automation/trigger_registry.go
@@ -1,0 +1,125 @@
+package automation
+
+import "encoding/json"
+
+// PlaceholderInfo describes a single {{key}} placeholder available for a trigger type.
+type PlaceholderInfo struct {
+	Key         string `json:"key"`
+	Description string `json:"description"`
+	Example     string `json:"example"`
+}
+
+// TriggerTypeInfo describes a trigger type and its associated metadata.
+// Served to clients so they can build UIs dynamically.
+type TriggerTypeInfo struct {
+	Type             TriggerType       `json:"type"`
+	Label            string            `json:"label"`
+	Description      string            `json:"description"`
+	Category         string            `json:"category"` // "schedule", "github", "webhook"
+	Enabled          bool              `json:"enabled"`
+	Placeholders     []PlaceholderInfo `json:"placeholders"`
+	DefaultPrompt    string            `json:"default_prompt"`
+	DefaultTaskTitle string            `json:"default_task_title"`
+	DefaultConfig    json.RawMessage   `json:"default_config"`
+}
+
+// Common placeholders available for every trigger type.
+var commonPlaceholders = []PlaceholderInfo{
+	{Key: "trigger.type", Description: "Trigger type (scheduled, github_pr, webhook, etc.)", Example: "scheduled"},
+	{Key: "trigger.timestamp", Description: "When the trigger fired", Example: "2026-03-08T12:00:00Z"},
+	{Key: "data.*", Description: "Access any field from trigger data", Example: "data.action"},
+}
+
+var triggerTypeRegistry = []TriggerTypeInfo{
+	{
+		Type:             TriggerTypeScheduled,
+		Label:            "Scheduled",
+		Description:      "Runs on a cron schedule",
+		Category:         "schedule",
+		Enabled:          true,
+		Placeholders:     commonPlaceholders,
+		DefaultPrompt:    "Run scheduled automation.\n\nTrigger: {{trigger.type}}",
+		DefaultTaskTitle: "",
+		DefaultConfig:    json.RawMessage(`{"cron_expression":"0 */6 * * *","timezone":"UTC"}`),
+	},
+	{
+		Type:        TriggerTypeGitHubPR,
+		Label:       "New pull requests",
+		Description: "Polls GitHub for PRs matching your filters (repo, branch, author, labels)",
+		Category:    "github",
+		Enabled:     true,
+		Placeholders: append([]PlaceholderInfo{
+			{Key: "pr.number", Description: "Pull request number", Example: "42"},
+			{Key: "pr.title", Description: "Pull request title", Example: "Fix the bug"},
+			{Key: "pr.url", Description: "Pull request URL", Example: "https://github.com/org/repo/pull/42"},
+			{Key: "pr.author", Description: "PR author login", Example: "alice"},
+			{Key: "pr.repo", Description: "Repository (owner/name)", Example: "org/repo"},
+			{Key: "pr.branch", Description: "Head branch name", Example: "fix-bug"},
+			{Key: "pr.base_branch", Description: "Base branch name", Example: "main"},
+			{Key: "pr.body", Description: "Pull request body text", Example: "Fixes #123"},
+		}, commonPlaceholders...),
+		DefaultPrompt:    "Review PR #{{pr.number}} in {{pr.repo}}: {{pr.title}}\n\n{{pr.body}}\n\nBranch: {{pr.branch}} → {{pr.base_branch}}",
+		DefaultTaskTitle: "[Auto] {{pr.repo}}#{{pr.number}} — {{pr.title}}",
+		DefaultConfig:    json.RawMessage(`{"events":["opened"],"repos":[],"exclude_draft":false}`),
+	},
+	{
+		Type:        TriggerTypeGitHubPush,
+		Label:       "Push to branch",
+		Description: "Triggers when commits are pushed to matching branches",
+		Category:    "github",
+		Enabled:     false,
+		Placeholders: append([]PlaceholderInfo{
+			{Key: "push.branch", Description: "Branch that was pushed to", Example: "main"},
+			{Key: "push.repo", Description: "Repository (owner/name)", Example: "org/repo"},
+			{Key: "push.sha", Description: "Commit SHA", Example: "abc1234"},
+			{Key: "push.message", Description: "Commit message", Example: "feat: add feature"},
+		}, commonPlaceholders...),
+		DefaultPrompt:    "Review push to {{push.branch}} in {{push.repo}}\n\nCommit: {{push.sha}}\n{{push.message}}",
+		DefaultTaskTitle: "[Auto] Push to {{push.branch}} — {{push.repo}}",
+		DefaultConfig:    json.RawMessage(`{"repos":[],"branches":["main"]}`),
+	},
+	{
+		Type:        TriggerTypeGitHubCI,
+		Label:       "CI check result",
+		Description: "Triggers when a CI check completes with matching conclusion",
+		Category:    "github",
+		Enabled:     false,
+		Placeholders: append([]PlaceholderInfo{
+			{Key: "ci.check_name", Description: "CI check/workflow name", Example: "build"},
+			{Key: "ci.conclusion", Description: "CI conclusion", Example: "failure"},
+			{Key: "ci.repo", Description: "Repository (owner/name)", Example: "org/repo"},
+			{Key: "ci.url", Description: "CI run URL", Example: "https://github.com/..."},
+		}, commonPlaceholders...),
+		DefaultPrompt:    "CI check '{{ci.check_name}}' {{ci.conclusion}} in {{ci.repo}}\n\n{{ci.url}}",
+		DefaultTaskTitle: "[Auto] CI {{ci.conclusion}} — {{ci.check_name}}",
+		DefaultConfig:    json.RawMessage(`{"repos":[],"conclusions":["failure"]}`),
+	},
+	{
+		Type:        TriggerTypeWebhook,
+		Label:       "Webhook",
+		Description: "Triggers when an HTTP POST is received at the automation's webhook URL",
+		Category:    "webhook",
+		Enabled:     true,
+		Placeholders: append([]PlaceholderInfo{
+			{Key: "webhook.body", Description: "Full webhook request body (JSON)", Example: `{"event":"deploy"}`},
+		}, commonPlaceholders...),
+		DefaultPrompt:    "Process webhook event.\n\n{{webhook.body}}",
+		DefaultTaskTitle: "",
+		DefaultConfig:    json.RawMessage(`{}`),
+	},
+}
+
+// GetTriggerTypes returns metadata for all known trigger types.
+func GetTriggerTypes() []TriggerTypeInfo {
+	return triggerTypeRegistry
+}
+
+// GetTriggerTypeInfo returns metadata for a specific trigger type, or nil if not found.
+func GetTriggerTypeInfo(t TriggerType) *TriggerTypeInfo {
+	for i := range triggerTypeRegistry {
+		if triggerTypeRegistry[i].Type == t {
+			return &triggerTypeRegistry[i]
+		}
+	}
+	return nil
+}

--- a/apps/backend/internal/automation/webhook.go
+++ b/apps/backend/internal/automation/webhook.go
@@ -1,0 +1,85 @@
+package automation
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+// WebhookHandler handles incoming webhook requests that fire automation triggers.
+type WebhookHandler struct {
+	svc    *Service
+	logger *logger.Logger
+}
+
+// NewWebhookHandler creates a new webhook handler.
+func NewWebhookHandler(svc *Service, log *logger.Logger) *WebhookHandler {
+	return &WebhookHandler{svc: svc, logger: log}
+}
+
+// Handle processes an incoming webhook POST request.
+// URL format: POST /api/v1/automations/webhook/:id?secret=<webhook_secret>
+func (h *WebhookHandler) Handle(c *gin.Context) {
+	automationID := c.Param("id")
+	if automationID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "automation id required"})
+		return
+	}
+
+	a, err := h.svc.GetAutomation(c.Request.Context(), automationID)
+	if err != nil || a == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "automation not found"})
+		return
+	}
+	if !a.Enabled {
+		c.JSON(http.StatusConflict, gin.H{"error": "automation is disabled"})
+		return
+	}
+
+	// Validate secret via query param or header.
+	secret := c.Query("secret")
+	if secret == "" {
+		secret = c.GetHeader("X-Webhook-Secret")
+	}
+	if secret != a.WebhookSecret {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook secret"})
+		return
+	}
+
+	// Read body as trigger data.
+	body, readErr := io.ReadAll(io.LimitReader(c.Request.Body, 1<<20)) // 1MB limit
+	if readErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+		return
+	}
+
+	// Ensure valid JSON; wrap raw text if needed.
+	triggerData := json.RawMessage(body)
+	if len(body) == 0 || !json.Valid(body) {
+		triggerData, _ = json.Marshal(map[string]string{"body": string(body)})
+	}
+
+	// Find the first webhook trigger for this automation.
+	triggerID := ""
+	for _, t := range a.Triggers {
+		if t.Type == TriggerTypeWebhook && t.Enabled {
+			triggerID = t.ID
+			break
+		}
+	}
+
+	if fireErr := h.svc.FireTrigger(c.Request.Context(), automationID, triggerID, TriggerTypeWebhook, triggerData, ""); fireErr != nil {
+		h.logger.Error("failed to fire webhook trigger",
+			zap.String("automation_id", automationID),
+			zap.Error(fireErr))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "trigger failed"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "triggered"})
+}

--- a/apps/backend/internal/automation/webhook.go
+++ b/apps/backend/internal/automation/webhook.go
@@ -1,6 +1,7 @@
 package automation
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -23,7 +24,7 @@ func NewWebhookHandler(svc *Service, log *logger.Logger) *WebhookHandler {
 }
 
 // Handle processes an incoming webhook POST request.
-// URL format: POST /api/v1/automations/webhook/:id?secret=<webhook_secret>
+// URL format: POST /api/v1/automations/webhook/:id  with X-Webhook-Secret header
 func (h *WebhookHandler) Handle(c *gin.Context) {
 	automationID := c.Param("id")
 	if automationID == "" {
@@ -41,13 +42,26 @@ func (h *WebhookHandler) Handle(c *gin.Context) {
 		return
 	}
 
-	// Validate secret via query param or header.
-	secret := c.Query("secret")
-	if secret == "" {
-		secret = c.GetHeader("X-Webhook-Secret")
-	}
-	if secret != a.WebhookSecret {
+	// Secret must come via header — query params would leak into URLs/logs.
+	// Compared in constant time so an attacker can't recover the secret byte
+	// by byte from timing differences.
+	secret := c.GetHeader("X-Webhook-Secret")
+	if subtle.ConstantTimeCompare([]byte(secret), []byte(a.WebhookSecret)) != 1 {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid webhook secret"})
+		return
+	}
+
+	// Find the first enabled webhook trigger for this automation. Bail out if
+	// none — firing with an empty trigger ID papers over a misconfiguration.
+	triggerID := ""
+	for _, t := range a.Triggers {
+		if t.Type == TriggerTypeWebhook && t.Enabled {
+			triggerID = t.ID
+			break
+		}
+	}
+	if triggerID == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "no enabled webhook trigger"})
 		return
 	}
 
@@ -62,15 +76,6 @@ func (h *WebhookHandler) Handle(c *gin.Context) {
 	triggerData := json.RawMessage(body)
 	if len(body) == 0 || !json.Valid(body) {
 		triggerData, _ = json.Marshal(map[string]string{"body": string(body)})
-	}
-
-	// Find the first webhook trigger for this automation.
-	triggerID := ""
-	for _, t := range a.Triggers {
-		if t.Type == TriggerTypeWebhook && t.Enabled {
-			triggerID = t.ID
-			break
-		}
 	}
 
 	if fireErr := h.svc.FireTrigger(c.Request.Context(), automationID, triggerID, TriggerTypeWebhook, triggerData, ""); fireErr != nil {

--- a/apps/backend/internal/events/types.go
+++ b/apps/backend/internal/events/types.go
@@ -204,6 +204,12 @@ const (
 	SessionPromptUsageUpdated = "session_prompt_usage.updated" // Prompt token usage updated
 )
 
+// Event types for automations
+const (
+	AutomationTriggered  = "automation.triggered"   // A trigger fired
+	AutomationRunCreated = "automation.run.created" // Run outcome recorded
+)
+
 // Event types for GitHub integration
 const (
 	GitHubPRFeedback       = "github.pr_feedback"        // PR has new feedback (UI notification only)

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -451,6 +451,10 @@ func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEv
 
 	// Clean up the agent execution (stop agentctl, release port)
 	go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
+
+	// Finalize run-mode automation runs: mark status=succeeded and reap
+	// the ephemeral worktree right away (the 24h Office GC is too late).
+	s.finalizeAutomationRunIfEphemeral(ctx, data.TaskID, data.SessionID, true, "")
 }
 
 // handleAgentFailed handles agent failure events
@@ -489,6 +493,12 @@ func (s *Service) handleAgentFailed(ctx context.Context, data watcher.AgentEvent
 	}
 
 	go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
+
+	errMsg := data.ErrorMessage
+	if errMsg == "" {
+		errMsg = "agent failed"
+	}
+	s.finalizeAutomationRunIfEphemeral(ctx, data.TaskID, data.SessionID, false, errMsg)
 }
 
 // wasResumeAttempt checks whether the session's last execution used a resume token.

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -465,6 +465,16 @@ func (s *Service) handleAgentFailed(ctx context.Context, data watcher.AgentEvent
 		zap.String("agent_execution_id", data.AgentExecutionID),
 		zap.String("error_message", data.ErrorMessage))
 
+	// Finalize run-mode automation runs first — every other branch below
+	// returns early (resume failure, session-backed recoverable failure,
+	// no-session retry), and run-mode automations need their AutomationRun
+	// flipped + worktree reaped on *every* failure path.
+	errMsg := data.ErrorMessage
+	if errMsg == "" {
+		errMsg = "agent failed"
+	}
+	s.finalizeAutomationRunIfEphemeral(ctx, data.TaskID, data.SessionID, false, errMsg)
+
 	// Check if the agent was started with a resume token AND session init hadn't completed.
 	// If init completed, this is a normal prompt failure (e.g. agent internal timeout),
 	// not a resume failure — skip the resume cleanup path.
@@ -493,12 +503,6 @@ func (s *Service) handleAgentFailed(ctx context.Context, data watcher.AgentEvent
 	}
 
 	go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
-
-	errMsg := data.ErrorMessage
-	if errMsg == "" {
-		errMsg = "agent failed"
-	}
-	s.finalizeAutomationRunIfEphemeral(ctx, data.TaskID, data.SessionID, false, errMsg)
 }
 
 // wasResumeAttempt checks whether the session's last execution used a resume token.

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -13,17 +13,27 @@ import (
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/github"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/worktree"
 )
 
 // AutomationService is the interface the orchestrator uses for automation operations.
 type AutomationService interface {
 	GetAutomation(ctx context.Context, id string) (*automation.Automation, error)
 	RecordRun(ctx context.Context, run *automation.AutomationRun) error
+	MarkRunFailedByTaskID(ctx context.Context, taskID, errMsg string) error
+	MarkRunSucceededByTaskID(ctx context.Context, taskID string) error
 }
 
 // SetAutomationService sets the automation service for handling automation triggers.
 func (s *Service) SetAutomationService(svc AutomationService) {
 	s.automationService = svc
+}
+
+// SetWorktreeManager sets the worktree manager. Used to clean up ephemeral
+// worktrees for run-mode automation tasks on completion. Nil-safe — handlers
+// skip worktree cleanup when not set.
+func (s *Service) SetWorktreeManager(mgr *worktree.Manager) {
+	s.worktreeMgr = mgr
 }
 
 // subscribeAutomationEvents subscribes to automation-related events on the event bus.
@@ -89,12 +99,20 @@ func (s *Service) createAutomationTask(ctx context.Context, evt *automation.Auto
 
 	// Run-mode automations create an ephemeral task hidden from the kanban —
 	// the user surfaces them through the AutomationRun row instead. The
-	// existing session/launch pipeline still runs against the task.
+	// existing session/launch pipeline still runs against the task. Ephemeral
+	// tasks reject a non-empty workflow_id, so we strip workflow fields in
+	// run-mode even if the automation row still carries them.
 	isRunMode := a.ExecutionMode == automation.ExecutionModeRun
+	workflowID := a.WorkflowID
+	workflowStepID := a.WorkflowStepID
+	if isRunMode {
+		workflowID = ""
+		workflowStepID = ""
+	}
 	task, taskErr := s.reviewTaskCreator.CreateReviewTask(ctx, &ReviewTaskRequest{
 		WorkspaceID:    a.WorkspaceID,
-		WorkflowID:     a.WorkflowID,
-		WorkflowStepID: a.WorkflowStepID,
+		WorkflowID:     workflowID,
+		WorkflowStepID: workflowStepID,
 		Title:          title,
 		Description:    prompt,
 		Repositories:   repositories,
@@ -137,10 +155,10 @@ func (s *Service) createAutomationTask(ctx context.Context, evt *automation.Auto
 	if !isRunMode && !s.shouldAutoStartStep(ctx, a.WorkflowStepID) {
 		return
 	}
-	s.autoStartAutomationTask(ctx, a, task)
+	s.autoStartAutomationTask(ctx, a, task, workflowStepID)
 }
 
-func (s *Service) autoStartAutomationTask(ctx context.Context, a *automation.Automation, task *models.Task) {
+func (s *Service) autoStartAutomationTask(ctx context.Context, a *automation.Automation, task *models.Task, workflowStepID string) {
 	_, err := s.StartTask(
 		ctx,
 		task.ID,
@@ -149,7 +167,7 @@ func (s *Service) autoStartAutomationTask(ctx context.Context, a *automation.Aut
 		a.ExecutorProfileID,
 		"",
 		task.Description,
-		a.WorkflowStepID,
+		workflowStepID,
 		false,
 		true,
 		nil,
@@ -374,4 +392,60 @@ func (s *Service) recordSuccessRun(ctx context.Context, evt *automation.Automati
 	if recordErr := s.automationService.RecordRun(ctx, run); recordErr != nil {
 		s.logger.Error("failed to record automation run", zap.Error(recordErr))
 	}
+}
+
+// finalizeAutomationRunIfEphemeral closes out a run-mode automation run when
+// its agent terminates. For ephemeral automation tasks it (a) flips the
+// AutomationRun row from task_created → succeeded|failed, and (b) reaps the
+// per-run worktree immediately. Regular tasks are untouched.
+func (s *Service) finalizeAutomationRunIfEphemeral(ctx context.Context, taskID, sessionID string, success bool, errMsg string) {
+	if taskID == "" {
+		return
+	}
+	task, err := s.repo.GetTask(ctx, taskID)
+	if err != nil || task == nil {
+		return
+	}
+	if !task.IsEphemeral || task.Origin != models.TaskOriginAutomationRun {
+		return
+	}
+
+	if s.automationService != nil {
+		var markErr error
+		if success {
+			markErr = s.automationService.MarkRunSucceededByTaskID(ctx, taskID)
+		} else {
+			markErr = s.automationService.MarkRunFailedByTaskID(ctx, taskID, errMsg)
+		}
+		if markErr != nil {
+			s.logger.Warn("failed to update automation run terminal status",
+				zap.String("task_id", taskID),
+				zap.Bool("success", success),
+				zap.Error(markErr))
+		}
+	}
+
+	s.reapAutomationWorktree(ctx, taskID, sessionID)
+}
+
+// reapAutomationWorktree removes the ephemeral worktree (and its branch)
+// associated with a finished run-mode automation session.
+func (s *Service) reapAutomationWorktree(ctx context.Context, taskID, sessionID string) {
+	if s.worktreeMgr == nil || sessionID == "" {
+		return
+	}
+	running, err := s.repo.GetExecutorRunningBySessionID(ctx, sessionID)
+	if err != nil || running == nil || running.WorktreeID == "" {
+		return
+	}
+	if err := s.worktreeMgr.RemoveByID(ctx, running.WorktreeID, true); err != nil {
+		s.logger.Warn("failed to reap automation worktree",
+			zap.String("task_id", taskID),
+			zap.String("worktree_id", running.WorktreeID),
+			zap.Error(err))
+		return
+	}
+	s.logger.Info("reaped ephemeral automation worktree",
+		zap.String("task_id", taskID),
+		zap.String("worktree_id", running.WorktreeID))
 }

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -87,6 +87,10 @@ func (s *Service) createAutomationTask(ctx context.Context, evt *automation.Auto
 		return
 	}
 
+	// Run-mode automations create an ephemeral task hidden from the kanban —
+	// the user surfaces them through the AutomationRun row instead. The
+	// existing session/launch pipeline still runs against the task.
+	isRunMode := a.ExecutionMode == automation.ExecutionModeRun
 	task, taskErr := s.reviewTaskCreator.CreateReviewTask(ctx, &ReviewTaskRequest{
 		WorkspaceID:    a.WorkspaceID,
 		WorkflowID:     a.WorkflowID,
@@ -101,7 +105,10 @@ func (s *Service) createAutomationTask(ctx context.Context, evt *automation.Auto
 			"trigger_type":        string(evt.TriggerType),
 			"agent_profile_id":    a.AgentProfileID,
 			"executor_profile_id": a.ExecutorProfileID,
+			"execution_mode":      string(a.ExecutionMode),
 		},
+		IsEphemeral: isRunMode,
+		Origin:      models.TaskOriginAutomationRun,
 	})
 	if taskErr != nil {
 		s.logger.Error("failed to create automation task",
@@ -121,10 +128,13 @@ func (s *Service) createAutomationTask(ctx context.Context, evt *automation.Auto
 	s.logger.Info("created automation task",
 		zap.String("task_id", task.ID),
 		zap.String("automation_id", a.ID),
+		zap.String("execution_mode", string(a.ExecutionMode)),
 		zap.String("trigger_type", string(evt.TriggerType)))
 
-	// Auto-start if the target step has auto_start_agent on_enter.
-	if !s.shouldAutoStartStep(ctx, a.WorkflowStepID) {
+	// Auto-start: always for run-mode (the user never sees the task, so no
+	// kanban drag triggers it); otherwise honour the workflow step's
+	// auto_start_agent on_enter setting.
+	if !isRunMode && !s.shouldAutoStartStep(ctx, a.WorkflowStepID) {
 		return
 	}
 	s.autoStartAutomationTask(ctx, a, task)

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -165,15 +165,49 @@ func (s *Service) autoStartAutomationTask(ctx context.Context, a *automation.Aut
 }
 
 // resolveAutomationRepository determines the repository for an automation-triggered task.
-// For github_pr triggers, it extracts repo info from the trigger data.
-// For other triggers (scheduled, webhook), it uses the automation's configured repository_id.
+// For github_pr triggers, it always extracts repo info from the trigger data —
+// the PR's own repo is the only sensible choice when responding to a PR event,
+// so an explicit RepositoryID on the automation is ignored.
+// For other triggers (scheduled, webhook), it prefers the automation's explicit
+// RepositoryID; falls back to the workspace's first repository if unset.
 func (s *Service) resolveAutomationRepository(
 	ctx context.Context, a *automation.Automation, evt *automation.AutomationTriggeredEvent,
 ) []ReviewTaskRepository {
 	if evt.TriggerType == automation.TriggerTypeGitHubPR {
 		return s.resolveGitHubPRTriggerRepository(ctx, a.WorkspaceID, evt.TriggerData)
 	}
+	if a.RepositoryID != "" {
+		return s.resolveExplicitRepository(ctx, a.RepositoryID)
+	}
 	return s.resolveWorkspaceRepository(ctx, a.WorkspaceID)
+}
+
+// resolveExplicitRepository loads the repository named by the automation's
+// RepositoryID field and produces a single ReviewTaskRepository entry. The
+// task gets pinned to the repo's default branch; the automation has no way
+// to specify a checkout branch yet.
+func (s *Service) resolveExplicitRepository(
+	ctx context.Context, repositoryID string,
+) []ReviewTaskRepository {
+	store, ok := s.repo.(repoStore)
+	if !ok {
+		return nil
+	}
+	repo, err := store.GetRepository(ctx, repositoryID)
+	if err != nil || repo == nil {
+		s.logger.Warn("failed to load explicit automation repository",
+			zap.String("repository_id", repositoryID), zap.Error(err))
+		return nil
+	}
+	baseBranch := repo.DefaultBranch
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	return []ReviewTaskRepository{{
+		RepositoryID:   repo.ID,
+		BaseBranch:     baseBranch,
+		CheckoutBranch: baseBranch,
+	}}
 }
 
 // resolveGitHubPRTriggerRepository extracts repo owner/name from PR trigger data

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -1,0 +1,333 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/automation"
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+	"github.com/kandev/kandev/internal/github"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+// AutomationService is the interface the orchestrator uses for automation operations.
+type AutomationService interface {
+	GetAutomation(ctx context.Context, id string) (*automation.Automation, error)
+	RecordRun(ctx context.Context, run *automation.AutomationRun) error
+}
+
+// SetAutomationService sets the automation service for handling automation triggers.
+func (s *Service) SetAutomationService(svc AutomationService) {
+	s.automationService = svc
+}
+
+// subscribeAutomationEvents subscribes to automation-related events on the event bus.
+func (s *Service) subscribeAutomationEvents() {
+	if s.eventBus == nil {
+		return
+	}
+	if _, err := s.eventBus.Subscribe(events.AutomationTriggered, s.handleAutomationTriggered); err != nil {
+		s.logger.Error("failed to subscribe to automation.triggered events", zap.Error(err))
+	}
+}
+
+// handleAutomationTriggered creates a task when an automation trigger fires.
+func (s *Service) handleAutomationTriggered(ctx context.Context, event *bus.Event) error {
+	evt, ok := event.Data.(*automation.AutomationTriggeredEvent)
+	if !ok {
+		return nil
+	}
+
+	s.logger.Info("automation trigger received",
+		zap.String("automation_id", evt.AutomationID),
+		zap.String("trigger_type", string(evt.TriggerType)))
+
+	if s.automationService == nil || s.reviewTaskCreator == nil {
+		s.logger.Warn("automation service or task creator not configured")
+		return nil
+	}
+
+	go s.createAutomationTask(context.Background(), evt)
+	return nil
+}
+
+func (s *Service) createAutomationTask(ctx context.Context, evt *automation.AutomationTriggeredEvent) {
+	a, err := s.automationService.GetAutomation(ctx, evt.AutomationID)
+	if err != nil || a == nil {
+		s.logger.Error("failed to load automation for trigger",
+			zap.String("automation_id", evt.AutomationID), zap.Error(err))
+		s.recordFailedRun(ctx, evt, "automation not found")
+		return
+	}
+	if !a.Enabled {
+		s.logger.Debug("automation disabled, skipping",
+			zap.String("automation_id", evt.AutomationID))
+		return
+	}
+
+	// Interpolate prompt with trigger data.
+	prompt := automation.InterpolatePrompt(a.Prompt, evt.TriggerType, evt.TriggerData)
+	if prompt == "" {
+		prompt = fmt.Sprintf("Automation '%s' triggered by %s", a.Name, evt.TriggerType)
+	}
+
+	title := s.resolveAutomationTaskTitle(a, evt)
+	repositories := s.resolveAutomationRepository(ctx, a, evt)
+	if len(repositories) == 0 {
+		errMsg := "no repository available — add a repository to the workspace"
+		s.logger.Warn("automation skipped: "+errMsg,
+			zap.String("automation_id", a.ID),
+			zap.String("workspace_id", a.WorkspaceID))
+		s.recordFailedRun(ctx, evt, errMsg)
+		return
+	}
+
+	task, taskErr := s.reviewTaskCreator.CreateReviewTask(ctx, &ReviewTaskRequest{
+		WorkspaceID:    a.WorkspaceID,
+		WorkflowID:     a.WorkflowID,
+		WorkflowStepID: a.WorkflowStepID,
+		Title:          title,
+		Description:    prompt,
+		Repositories:   repositories,
+		Metadata: map[string]interface{}{
+			"automation_id":       a.ID,
+			"automation_name":     a.Name,
+			"trigger_id":          evt.TriggerID,
+			"trigger_type":        string(evt.TriggerType),
+			"agent_profile_id":    a.AgentProfileID,
+			"executor_profile_id": a.ExecutorProfileID,
+		},
+	})
+	if taskErr != nil {
+		s.logger.Error("failed to create automation task",
+			zap.String("automation_id", a.ID), zap.Error(taskErr))
+		s.recordFailedRun(ctx, evt, taskErr.Error())
+		return
+	}
+
+	// Record successful run.
+	s.recordSuccessRun(ctx, evt, task.ID)
+
+	// Associate PR with task for github_pr triggers (same as PR Watcher).
+	if evt.TriggerType == automation.TriggerTypeGitHubPR {
+		s.associateAutomationPR(ctx, task.ID, repositories[0].RepositoryID, evt.TriggerData)
+	}
+
+	s.logger.Info("created automation task",
+		zap.String("task_id", task.ID),
+		zap.String("automation_id", a.ID),
+		zap.String("trigger_type", string(evt.TriggerType)))
+
+	// Auto-start if the target step has auto_start_agent on_enter.
+	if !s.shouldAutoStartStep(ctx, a.WorkflowStepID) {
+		return
+	}
+	s.autoStartAutomationTask(ctx, a, task)
+}
+
+func (s *Service) autoStartAutomationTask(ctx context.Context, a *automation.Automation, task *models.Task) {
+	_, err := s.StartTask(
+		ctx,
+		task.ID,
+		a.AgentProfileID,
+		"",
+		a.ExecutorProfileID,
+		"",
+		task.Description,
+		a.WorkflowStepID,
+		false,
+		true,
+		nil,
+	)
+	if err != nil {
+		s.logger.Error("failed to auto-start automation task",
+			zap.String("task_id", task.ID), zap.Error(err))
+		return
+	}
+	s.logger.Info("auto-started automation task",
+		zap.String("task_id", task.ID),
+		zap.String("automation_id", a.ID))
+}
+
+// resolveAutomationRepository determines the repository for an automation-triggered task.
+// For github_pr triggers, it extracts repo info from the trigger data.
+// For other triggers (scheduled, webhook), it uses the automation's configured repository_id.
+func (s *Service) resolveAutomationRepository(
+	ctx context.Context, a *automation.Automation, evt *automation.AutomationTriggeredEvent,
+) []ReviewTaskRepository {
+	if evt.TriggerType == automation.TriggerTypeGitHubPR {
+		return s.resolveGitHubPRTriggerRepository(ctx, a.WorkspaceID, evt.TriggerData)
+	}
+	return s.resolveWorkspaceRepository(ctx, a.WorkspaceID)
+}
+
+// resolveGitHubPRTriggerRepository extracts repo owner/name from PR trigger data
+// and resolves it via the repository resolver.
+func (s *Service) resolveGitHubPRTriggerRepository(
+	ctx context.Context, workspaceID string, triggerData json.RawMessage,
+) []ReviewTaskRepository {
+	if s.repositoryResolver == nil {
+		return nil
+	}
+	var data struct {
+		Repo       string `json:"repo"`
+		HeadBranch string `json:"head_branch"`
+		BaseBranch string `json:"base_branch"`
+	}
+	if err := json.Unmarshal(triggerData, &data); err != nil || data.Repo == "" {
+		return nil
+	}
+	parts := strings.SplitN(data.Repo, "/", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	owner, name := parts[0], parts[1]
+	repoID, baseBranch, err := s.repositoryResolver.ResolveForReview(
+		ctx, workspaceID, "github", owner, name, data.BaseBranch,
+	)
+	if err != nil || repoID == "" {
+		s.logger.Warn("failed to resolve PR trigger repository",
+			zap.String("repo", data.Repo), zap.Error(err))
+		return nil
+	}
+	return []ReviewTaskRepository{{
+		RepositoryID:   repoID,
+		BaseBranch:     baseBranch,
+		CheckoutBranch: data.HeadBranch,
+	}}
+}
+
+// resolveWorkspaceRepository looks up the workspace's first repository
+// and returns it for task creation. This mirrors how the review watch
+// auto-resolves repos — no manual selector needed.
+func (s *Service) resolveWorkspaceRepository(
+	ctx context.Context, workspaceID string,
+) []ReviewTaskRepository {
+	store, ok := s.repo.(repoStore)
+	if !ok {
+		return nil
+	}
+	repos, err := store.ListRepositories(ctx, workspaceID)
+	if err != nil {
+		s.logger.Warn("failed to list workspace repositories", zap.Error(err))
+		return nil
+	}
+	if len(repos) == 0 {
+		s.logger.Warn("workspace has no repositories",
+			zap.String("workspace_id", workspaceID))
+		return nil
+	}
+	repo := repos[0]
+	baseBranch := repo.DefaultBranch
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	return []ReviewTaskRepository{{
+		RepositoryID: repo.ID,
+		BaseBranch:   baseBranch,
+	}}
+}
+
+// resolveAutomationTaskTitle builds the task title from the automation's template or falls back to a default.
+func (s *Service) resolveAutomationTaskTitle(a *automation.Automation, evt *automation.AutomationTriggeredEvent) string {
+	if a.TaskTitleTemplate != "" {
+		title := automation.InterpolatePrompt(a.TaskTitleTemplate, evt.TriggerType, evt.TriggerData)
+		if title != "" {
+			return title
+		}
+	}
+	// Fall back to trigger type default from registry.
+	if info := automation.GetTriggerTypeInfo(evt.TriggerType); info != nil && info.DefaultTaskTitle != "" {
+		title := automation.InterpolatePrompt(info.DefaultTaskTitle, evt.TriggerType, evt.TriggerData)
+		if title != "" {
+			return title
+		}
+	}
+	return fmt.Sprintf("[Auto] %s", a.Name)
+}
+
+// associateAutomationPR links a task to a GitHub PR using trigger data.
+func (s *Service) associateAutomationPR(ctx context.Context, taskID, repositoryID string, triggerData json.RawMessage) {
+	if s.githubService == nil {
+		return
+	}
+	var data struct {
+		Number      float64 `json:"number"`
+		Title       string  `json:"title"`
+		HTMLURL     string  `json:"html_url"`
+		AuthorLogin string  `json:"author_login"`
+		Repo        string  `json:"repo"`
+		HeadBranch  string  `json:"head_branch"`
+		BaseBranch  string  `json:"base_branch"`
+		Body        string  `json:"body"`
+		Draft       bool    `json:"draft"`
+		State       string  `json:"state"`
+	}
+	if err := json.Unmarshal(triggerData, &data); err != nil || data.Repo == "" {
+		return
+	}
+	parts := strings.SplitN(data.Repo, "/", 2)
+	if len(parts) != 2 {
+		return
+	}
+	pr := &github.PR{
+		Number:      int(data.Number),
+		Title:       data.Title,
+		HTMLURL:     data.HTMLURL,
+		AuthorLogin: data.AuthorLogin,
+		RepoOwner:   parts[0],
+		RepoName:    parts[1],
+		HeadBranch:  data.HeadBranch,
+		BaseBranch:  data.BaseBranch,
+		Body:        data.Body,
+		Draft:       data.Draft,
+		State:       data.State,
+	}
+	if _, err := s.githubService.AssociatePRWithTask(ctx, taskID, repositoryID, pr); err != nil {
+		s.logger.Error("failed to associate PR with automation task",
+			zap.String("task_id", taskID),
+			zap.Int("pr_number", pr.Number),
+			zap.Error(err))
+	}
+}
+
+func (s *Service) recordFailedRun(ctx context.Context, evt *automation.AutomationTriggeredEvent, errMsg string) {
+	if s.automationService == nil {
+		return
+	}
+	run := &automation.AutomationRun{
+		AutomationID: evt.AutomationID,
+		TriggerID:    evt.TriggerID,
+		TriggerType:  evt.TriggerType,
+		Status:       automation.RunStatusFailed,
+		DedupKey:     evt.DedupKey,
+		TriggerData:  evt.TriggerData,
+		ErrorMessage: errMsg,
+	}
+	if recordErr := s.automationService.RecordRun(ctx, run); recordErr != nil {
+		s.logger.Error("failed to record automation run", zap.Error(recordErr))
+	}
+}
+
+func (s *Service) recordSuccessRun(ctx context.Context, evt *automation.AutomationTriggeredEvent, taskID string) {
+	if s.automationService == nil {
+		return
+	}
+	run := &automation.AutomationRun{
+		AutomationID: evt.AutomationID,
+		TriggerID:    evt.TriggerID,
+		TriggerType:  evt.TriggerType,
+		TaskID:       taskID,
+		Status:       automation.RunStatusTaskCreated,
+		DedupKey:     evt.DedupKey,
+		TriggerData:  evt.TriggerData,
+	}
+	if recordErr := s.automationService.RecordRun(ctx, run); recordErr != nil {
+		s.logger.Error("failed to record automation run", zap.Error(recordErr))
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -439,9 +439,11 @@ func (s *Service) failAutomationRunOnPermission(ctx context.Context, data watche
 		return
 	}
 
+	// Always cancel: the session is going to be marked failed anyway, and
+	// passing cancelled=false would let RespondToPermission set the session
+	// back to running ("approved") even though the optionID denotes rejection.
 	optionID := pickRejectOption(data.Options)
-	cancelled := optionID == ""
-	if err := s.RespondToPermission(ctx, data.TaskSessionID, data.PendingID, optionID, cancelled); err != nil {
+	if err := s.RespondToPermission(ctx, data.TaskSessionID, data.PendingID, optionID, true); err != nil {
 		s.logger.Warn("failed to auto-reject permission for run-mode automation",
 			zap.String("task_id", data.TaskID),
 			zap.String("pending_id", data.PendingID),

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -417,6 +417,56 @@ func (s *Service) handlePermissionRequest(ctx context.Context, data watcher.Perm
 				zap.String("pending_id", data.PendingID))
 		}
 	}
+
+	// Run-mode automation tasks are hidden from the kanban, so there is no UI
+	// for the user to answer a permission prompt. Auto-reject and mark the run
+	// failed so the failure shows up in the automation's Recent Runs.
+	s.failAutomationRunOnPermission(ctx, data)
+}
+
+// failAutomationRunOnPermission checks whether the permission request belongs
+// to a run-mode automation task and, if so, rejects the prompt and marks the
+// corresponding automation_run row as failed.
+func (s *Service) failAutomationRunOnPermission(ctx context.Context, data watcher.PermissionRequestData) {
+	if s.automationService == nil || data.TaskID == "" {
+		return
+	}
+	task, err := s.repo.GetTask(ctx, data.TaskID)
+	if err != nil || task == nil {
+		return
+	}
+	if !task.IsEphemeral || task.Origin != models.TaskOriginAutomationRun {
+		return
+	}
+
+	optionID := pickRejectOption(data.Options)
+	cancelled := optionID == ""
+	if err := s.RespondToPermission(ctx, data.TaskSessionID, data.PendingID, optionID, cancelled); err != nil {
+		s.logger.Warn("failed to auto-reject permission for run-mode automation",
+			zap.String("task_id", data.TaskID),
+			zap.String("pending_id", data.PendingID),
+			zap.Error(err))
+	}
+
+	errMsg := fmt.Sprintf("Permission required: %s — run-mode automations cannot answer prompts", data.Title)
+	if err := s.automationService.MarkRunFailedByTaskID(ctx, data.TaskID, errMsg); err != nil {
+		s.logger.Warn("failed to mark automation run failed after permission prompt",
+			zap.String("task_id", data.TaskID), zap.Error(err))
+	}
+}
+
+// pickRejectOption returns the first option_id with a reject-kind, or "" if
+// none was offered.
+func pickRejectOption(options []map[string]interface{}) string {
+	for _, opt := range options {
+		kind, _ := opt["kind"].(string)
+		if strings.HasPrefix(kind, "reject") {
+			if id, ok := opt["option_id"].(string); ok {
+				return id
+			}
+		}
+	}
+	return ""
 }
 
 // handleGitCommitCreated handles git commit events by forwarding them to the frontend.

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -91,6 +91,13 @@ type ReviewTaskRequest struct {
 	Description    string
 	Metadata       map[string]interface{}
 	Repositories   []ReviewTaskRepository
+	// IsEphemeral hides the task from the kanban — used by run-mode
+	// automations whose output should surface in the automation's run
+	// history rather than as a tracked task.
+	IsEphemeral bool
+	// Origin tags the task with a provenance label (see task/models.TaskOrigin*).
+	// Defaults to TaskOriginManual when empty.
+	Origin string
 }
 
 // ReviewTaskRepository associates a repository with a review task.

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/workflow/engine"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	"github.com/kandev/kandev/internal/worktree"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -269,6 +270,11 @@ type Service struct {
 
 	// Automation service for handling automation triggers
 	automationService AutomationService
+
+	// Worktree manager — used to clean up ephemeral worktrees for run-mode
+	// automation tasks immediately on completion rather than waiting for
+	// the 24h Office GC. Nil-safe.
+	worktreeMgr *worktree.Manager
 
 	// Clarification canceller — cancels pending clarifications when agent's turn completes
 	clarificationCanceller ClarificationCanceller

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -132,6 +132,7 @@ type repoStore interface {
 	ListSessionsWithBranches(ctx context.Context) ([]models.SessionBranchInfo, error)
 	GetRepository(ctx context.Context, id string) (*models.Repository, error)
 	UpdateRepository(ctx context.Context, repository *models.Repository) error
+	ListRepositories(ctx context.Context, workspaceID string) ([]*models.Repository, error)
 	GetExecutorProfile(ctx context.Context, id string) (*models.ExecutorProfile, error)
 	// Multi-repo task environment children
 	CreateTaskEnvironmentRepo(ctx context.Context, repo *models.TaskEnvironmentRepo) error
@@ -265,6 +266,9 @@ type Service struct {
 
 	// Repository resolver for cloning + finding/creating repos for review tasks
 	repositoryResolver RepositoryResolver
+
+	// Automation service for handling automation triggers
+	automationService AutomationService
 
 	// Clarification canceller — cancels pending clarifications when agent's turn completes
 	clarificationCanceller ClarificationCanceller
@@ -780,6 +784,9 @@ func (s *Service) Start(ctx context.Context) error {
 
 	// Subscribe to Linear integration events
 	s.subscribeLinearEvents()
+
+	// Subscribe to automation events
+	s.subscribeAutomationEvents()
 
 	// Subscribe to clarification events (cancel-and-resume flow)
 	s.subscribeClarificationEvents()

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -57,10 +57,11 @@ const (
 
 // Task origin values for the Origin field.
 const (
-	TaskOriginManual       = "manual"
-	TaskOriginAgentCreated = "agent_created"
-	TaskOriginRoutine      = "routine"
-	TaskOriginOnboarding   = "onboarding"
+	TaskOriginManual        = "manual"
+	TaskOriginAgentCreated  = "agent_created"
+	TaskOriginRoutine       = "routine"
+	TaskOriginOnboarding    = "onboarding"
+	TaskOriginAutomationRun = "automation_run"
 )
 
 // Task represents a task in the database

--- a/apps/backend/pkg/websocket/actions.go
+++ b/apps/backend/pkg/websocket/actions.go
@@ -461,6 +461,23 @@ const (
 	ActionOfficeRoutingSettingsUpdated = "office.routing.settings_updated"
 )
 
+// Automation actions
+const (
+	ActionAutomationList          = "automation.list"
+	ActionAutomationGet           = "automation.get"
+	ActionAutomationCreate        = "automation.create"
+	ActionAutomationUpdate        = "automation.update"
+	ActionAutomationDelete        = "automation.delete"
+	ActionAutomationEnable        = "automation.enable"
+	ActionAutomationDisable       = "automation.disable"
+	ActionAutomationTrigger       = "automation.trigger"
+	ActionAutomationRunsList      = "automation.runs.list"
+	ActionAutomationTriggerAdd    = "automation.trigger.add"
+	ActionAutomationTriggerUpdate = "automation.trigger.update"
+	ActionAutomationTriggerDelete = "automation.trigger.delete"
+	ActionAutomationTriggerTypes  = "automation.trigger_types"
+)
+
 // Error codes
 const (
 	ErrorCodeBadRequest    = "BAD_REQUEST"

--- a/apps/web/app/settings/automations/page.tsx
+++ b/apps/web/app/settings/automations/page.tsx
@@ -1,0 +1,54 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { listWorkspaces } from "@/lib/api";
+
+export default async function AutomationsTopLevelPage() {
+  const res = await listWorkspaces({ cache: "no-store" }).catch(() => ({ workspaces: [] }));
+  const workspaces = res.workspaces ?? [];
+
+  if (workspaces.length === 1) {
+    redirect(`/settings/workspace/${workspaces[0].id}/automations`);
+  }
+
+  if (workspaces.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center">
+        <p className="text-sm font-medium">No workspaces yet</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Create a workspace first, then schedule automations inside it.
+        </p>
+        <Link
+          href="/settings/workspace"
+          className="mt-4 inline-block rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 cursor-pointer"
+        >
+          Create workspace
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Automations</h2>
+        <p className="text-sm text-muted-foreground">Pick a workspace to manage its automations.</p>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {workspaces.map((ws) => (
+          <Link
+            key={ws.id}
+            href={`/settings/workspace/${ws.id}/automations`}
+            className="rounded-md border p-3 text-sm hover:bg-muted/50 cursor-pointer"
+          >
+            <div className="font-medium">{ws.name}</div>
+            {ws.description && (
+              <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                {ws.description}
+              </div>
+            )}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/settings/workspace/[id]/automations/[automationId]/page.tsx
+++ b/apps/web/app/settings/workspace/[id]/automations/[automationId]/page.tsx
@@ -1,0 +1,10 @@
+import { AutomationEditor } from "@/components/automations/automation-editor";
+
+type Props = {
+  params: Promise<{ id: string; automationId: string }>;
+};
+
+export default async function AutomationEditorPage({ params }: Props) {
+  const { id, automationId } = await params;
+  return <AutomationEditor workspaceId={id} automationId={automationId} />;
+}

--- a/apps/web/app/settings/workspace/[id]/automations/new/page.tsx
+++ b/apps/web/app/settings/workspace/[id]/automations/new/page.tsx
@@ -1,0 +1,10 @@
+import { AutomationEditor } from "@/components/automations/automation-editor";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function NewAutomationPage({ params }: Props) {
+  const { id } = await params;
+  return <AutomationEditor workspaceId={id} automationId={null} />;
+}

--- a/apps/web/app/settings/workspace/[id]/automations/page.tsx
+++ b/apps/web/app/settings/workspace/[id]/automations/page.tsx
@@ -1,0 +1,10 @@
+import { AutomationsListPage } from "@/components/automations/automations-list-page";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function AutomationsPage({ params }: Props) {
+  const { id } = await params;
+  return <AutomationsListPage workspaceId={id} />;
+}

--- a/apps/web/components/automations/automation-editor.tsx
+++ b/apps/web/components/automations/automation-editor.tsx
@@ -1,0 +1,522 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@kandev/ui/button";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import { Switch } from "@kandev/ui/switch";
+import { Separator } from "@kandev/ui/separator";
+import { IconArrowLeft, IconTrash } from "@tabler/icons-react";
+import { useAutomations } from "@/hooks/domains/settings/use-automations";
+import {
+  addTrigger,
+  updateTrigger,
+  deleteTrigger,
+  getAutomation,
+  listTriggerTypes,
+} from "@/lib/api/domains/automation-api";
+import type {
+  Automation,
+  TriggerType,
+  AutomationTrigger,
+  TriggerTypeInfo,
+  PlaceholderInfo,
+} from "@/lib/types/automation";
+import { TriggersSection } from "./triggers-section";
+import { PromptSection } from "./prompt-section";
+import { ConfigSection } from "./config-section";
+import { RunsSection } from "./runs-section";
+
+type AutomationEditorProps = {
+  workspaceId: string;
+  automationId: string | null; // null = create mode
+};
+
+type FormState = {
+  name: string;
+  description: string;
+  workflowId: string;
+  workflowStepId: string;
+  agentProfileId: string;
+  executorProfileId: string;
+  prompt: string;
+  taskTitleTemplate: string;
+  enabled: boolean;
+  maxConcurrentRuns: number;
+};
+
+type PendingTrigger = {
+  tempId: string;
+  type: TriggerType;
+  config: Record<string, unknown>;
+  enabled: boolean;
+};
+
+const DEFAULT_PROMPT = "Run scheduled automation.\n\nTrigger: {{trigger.type}}";
+
+const defaultForm: FormState = {
+  name: "",
+  description: "",
+  workflowId: "",
+  workflowStepId: "",
+  agentProfileId: "",
+  executorProfileId: "",
+  prompt: DEFAULT_PROMPT,
+  taskTitleTemplate: "",
+  enabled: true,
+  maxConcurrentRuns: 1,
+};
+
+function formFromAutomation(a: Automation): FormState {
+  return {
+    name: a.name,
+    description: a.description,
+    workflowId: a.workflow_id,
+    workflowStepId: a.workflow_step_id,
+    agentProfileId: a.agent_profile_id,
+    executorProfileId: a.executor_profile_id,
+    prompt: a.prompt || DEFAULT_PROMPT,
+    taskTitleTemplate: a.task_title_template ?? "",
+    enabled: a.enabled,
+    maxConcurrentRuns: a.max_concurrent_runs,
+  };
+}
+
+function pendingToTrigger(p: PendingTrigger): AutomationTrigger {
+  return {
+    id: p.tempId,
+    automation_id: "",
+    type: p.type,
+    config: p.config,
+    enabled: p.enabled,
+    last_evaluated_at: null,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function useTriggerActions(currentId: string | null) {
+  const [triggers, setTriggers] = useState<AutomationTrigger[]>([]);
+  const [pending, setPending] = useState<PendingTrigger[]>([]);
+
+  const handleAdd = async (type: TriggerType, config: Record<string, unknown>) => {
+    if (!currentId) {
+      setPending((prev) => [...prev, { tempId: crypto.randomUUID(), type, config, enabled: true }]);
+      return;
+    }
+    const trigger = await addTrigger({ automation_id: currentId, type, config, enabled: true });
+    setTriggers((prev) => [...prev, trigger]);
+  };
+
+  const handleUpdate = async (triggerId: string, config: Record<string, unknown>) => {
+    if (!currentId) {
+      setPending((prev) => prev.map((t) => (t.tempId === triggerId ? { ...t, config } : t)));
+      return;
+    }
+    await updateTrigger(triggerId, { config });
+    setTriggers((prev) => prev.map((t) => (t.id === triggerId ? { ...t, config } : t)));
+  };
+
+  const handleToggle = async (triggerId: string, enabled: boolean) => {
+    if (!currentId) {
+      setPending((prev) => prev.map((t) => (t.tempId === triggerId ? { ...t, enabled } : t)));
+      return;
+    }
+    await updateTrigger(triggerId, { enabled });
+    setTriggers((prev) => prev.map((t) => (t.id === triggerId ? { ...t, enabled } : t)));
+  };
+
+  const handleDelete = async (triggerId: string) => {
+    if (!currentId) {
+      setPending((prev) => prev.filter((t) => t.tempId !== triggerId));
+      return;
+    }
+    await deleteTrigger(triggerId);
+    setTriggers((prev) => prev.filter((t) => t.id !== triggerId));
+  };
+
+  const allTriggers = currentId ? triggers : pending.map(pendingToTrigger);
+  const clearPending = () => setPending([]);
+
+  return {
+    triggers,
+    setTriggers,
+    pending,
+    clearPending,
+    allTriggers,
+    handleAdd,
+    handleUpdate,
+    handleToggle,
+    handleDelete,
+  };
+}
+
+function useTriggerTypeMetadata() {
+  const [triggerTypes, setTriggerTypes] = useState<TriggerTypeInfo[]>([]);
+
+  useEffect(() => {
+    listTriggerTypes()
+      .then(setTriggerTypes)
+      .catch(() => setTriggerTypes([]));
+  }, []);
+
+  return triggerTypes;
+}
+
+/** Returns the condition type from the current triggers (the non-scheduled, non-webhook trigger). */
+function getConditionType(triggers: AutomationTrigger[]): TriggerType | null {
+  const condition = triggers.find((t) => t.type !== "scheduled" && t.type !== "webhook");
+  return condition?.type ?? null;
+}
+
+/** Checks if the prompt matches any known default prompt from the trigger types. */
+function isDefaultPrompt(prompt: string, triggerTypes: TriggerTypeInfo[]): boolean {
+  return triggerTypes.some((t) => t.default_prompt === prompt);
+}
+
+function buildCreatePayload(workspaceId: string, form: FormState, pending: PendingTrigger[]) {
+  return {
+    workspace_id: workspaceId,
+    name: form.name || "New Automation",
+    description: form.description,
+    workflow_id: form.workflowId,
+    workflow_step_id: form.workflowStepId,
+    agent_profile_id: form.agentProfileId,
+    executor_profile_id: form.executorProfileId,
+    prompt: form.prompt,
+    task_title_template: form.taskTitleTemplate,
+    max_concurrent_runs: form.maxConcurrentRuns,
+    triggers: pending.map((t) => ({ type: t.type, config: t.config, enabled: t.enabled })),
+  };
+}
+
+function buildUpdatePayload(form: FormState) {
+  return {
+    name: form.name,
+    description: form.description,
+    workflow_id: form.workflowId,
+    workflow_step_id: form.workflowStepId,
+    agent_profile_id: form.agentProfileId,
+    executor_profile_id: form.executorProfileId,
+    prompt: form.prompt,
+    task_title_template: form.taskTitleTemplate,
+    enabled: form.enabled,
+    max_concurrent_runs: form.maxConcurrentRuns,
+  };
+}
+
+function getSaveLabel(saving: boolean, isNew: boolean): string {
+  if (saving) return "Saving...";
+  return isNew ? "Create Automation" : "Save Changes";
+}
+
+function useConditionMetadata(triggers: AutomationTrigger[], triggerTypes: TriggerTypeInfo[]) {
+  const conditionType = getConditionType(triggers);
+  const activeTriggerInfo = useMemo(
+    () => triggerTypes.find((t) => t.type === (conditionType ?? "scheduled")),
+    [triggerTypes, conditionType],
+  );
+  return {
+    conditionType,
+    placeholders: activeTriggerInfo?.placeholders ?? [],
+    defaultTaskTitle: activeTriggerInfo?.default_task_title ?? "",
+    activeTriggerInfo,
+  };
+}
+
+function useAutoPromptUpdate(
+  activeTriggerInfo: TriggerTypeInfo | undefined,
+  conditionType: TriggerType | null,
+  triggerTypes: TriggerTypeInfo[],
+  setForm: React.Dispatch<React.SetStateAction<FormState>>,
+) {
+  useEffect(() => {
+    if (!activeTriggerInfo) return;
+    setForm((prev) => {
+      if (isDefaultPrompt(prev.prompt, triggerTypes) || prev.prompt === DEFAULT_PROMPT) {
+        return { ...prev, prompt: activeTriggerInfo.default_prompt };
+      }
+      return prev;
+    });
+  }, [conditionType, activeTriggerInfo, triggerTypes, setForm]);
+}
+
+export function AutomationEditor({ workspaceId, automationId }: AutomationEditorProps) {
+  const router = useRouter();
+  const { create, update, remove } = useAutomations(workspaceId);
+  const [form, setForm] = useState<FormState>(defaultForm);
+  const [saving, setSaving] = useState(false);
+  const [currentId, setCurrentId] = useState<string | null>(automationId);
+  const isNew = currentId === null;
+  const triggerActions = useTriggerActions(currentId);
+  const triggerTypes = useTriggerTypeMetadata();
+
+  const { placeholders, defaultTaskTitle, activeTriggerInfo, conditionType } = useConditionMetadata(
+    triggerActions.allTriggers,
+    triggerTypes,
+  );
+  useAutoPromptUpdate(activeTriggerInfo, conditionType, triggerTypes, setForm);
+
+  useEffect(() => {
+    if (!automationId) return;
+    getAutomation(automationId)
+      .then((a) => {
+        setForm(formFromAutomation(a));
+        triggerActions.setTriggers(a.triggers ?? []);
+      })
+      .catch(() => {
+        router.push(`/settings/workspace/${workspaceId}/automations`);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [automationId]);
+
+  const updateField = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      if (isNew) {
+        const a = await create(buildCreatePayload(workspaceId, form, triggerActions.pending));
+        setCurrentId(a.id);
+        triggerActions.setTriggers(a.triggers ?? []);
+        triggerActions.clearPending();
+        router.replace(`/settings/workspace/${workspaceId}/automations/${a.id}`);
+      } else {
+        await update(currentId, buildUpdatePayload(form));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!currentId) return;
+    await remove(currentId);
+    router.push(`/settings/workspace/${workspaceId}/automations`);
+  };
+
+  const canSave = form.name.trim().length > 0 && !!form.workflowId && !!form.workflowStepId;
+
+  return (
+    <div className="max-w-3xl space-y-6" data-testid="automation-editor">
+      <EditorHeader workspaceId={workspaceId} />
+      <div className="space-y-2">
+        <Label htmlFor="automation-name">Name</Label>
+        <Input
+          id="automation-name"
+          data-testid="automation-name-input"
+          value={form.name}
+          onChange={(e) => updateField("name", e.target.value)}
+          placeholder="Automation name"
+        />
+      </div>
+      <Separator />
+      <WhenSection
+        triggerActions={triggerActions}
+        triggerTypes={triggerTypes}
+        currentId={currentId}
+      />
+      <Separator />
+      <ThenSection
+        form={form}
+        workspaceId={workspaceId}
+        placeholders={placeholders}
+        defaultTaskTitle={defaultTaskTitle}
+        updateField={updateField}
+      />
+      <Separator />
+      <SettingsSection form={form} updateField={updateField} />
+      <Separator />
+      <RunsSection automationId={currentId} />
+      <EditorFooter
+        canSave={canSave}
+        saving={saving}
+        isNew={isNew}
+        onSave={handleSave}
+        onDelete={handleRemove}
+      />
+    </div>
+  );
+}
+
+type TriggerActionsResult = ReturnType<typeof useTriggerActions>;
+
+function WhenSection({
+  triggerActions,
+  triggerTypes,
+  currentId,
+}: {
+  triggerActions: TriggerActionsResult;
+  triggerTypes: TriggerTypeInfo[];
+  currentId: string | null;
+}) {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h3 className="text-base font-medium">When</h3>
+        <p className="text-sm text-muted-foreground">What causes this automation to run</p>
+      </div>
+      <div className="rounded-lg border bg-card p-4">
+        <TriggersSection
+          triggers={triggerActions.allTriggers}
+          automationId={currentId}
+          triggerTypes={triggerTypes}
+          onAddTrigger={triggerActions.handleAdd}
+          onUpdateTrigger={triggerActions.handleUpdate}
+          onToggleTrigger={triggerActions.handleToggle}
+          onDeleteTrigger={triggerActions.handleDelete}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ThenSection({
+  form,
+  workspaceId,
+  placeholders,
+  defaultTaskTitle,
+  updateField,
+}: {
+  form: FormState;
+  workspaceId: string;
+  placeholders: PlaceholderInfo[];
+  defaultTaskTitle: string;
+  updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div>
+        <h3 className="text-base font-medium">Then</h3>
+        <p className="text-sm text-muted-foreground">
+          A new task will be created each time this automation triggers
+        </p>
+      </div>
+      <div className="rounded-lg border bg-card p-4 space-y-4">
+        <div className="space-y-1.5">
+          <Label className="text-xs">Task title</Label>
+          <Input
+            value={form.taskTitleTemplate}
+            onChange={(e) => updateField("taskTitleTemplate", e.target.value)}
+            placeholder={defaultTaskTitle || "[Auto] automation name"}
+          />
+          <p className="text-xs text-muted-foreground">
+            Leave empty to use the default. Supports placeholders.
+          </p>
+        </div>
+        <PromptSection
+          value={form.prompt}
+          onChange={(v) => updateField("prompt", v)}
+          placeholders={placeholders}
+        />
+        <Separator />
+        <ConfigSection
+          workspaceId={workspaceId}
+          workflowId={form.workflowId}
+          workflowStepId={form.workflowStepId}
+          agentProfileId={form.agentProfileId}
+          executorProfileId={form.executorProfileId}
+          onWorkflowChange={(v) => {
+            updateField("workflowId", v);
+            updateField("workflowStepId", "");
+          }}
+          onStepChange={(v) => updateField("workflowStepId", v)}
+          onAgentProfileChange={(v) => updateField("agentProfileId", v)}
+          onExecutorProfileChange={(v) => updateField("executorProfileId", v)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function EditorHeader({ workspaceId }: { workspaceId: string }) {
+  const router = useRouter();
+  return (
+    <div className="flex items-center gap-3">
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        className="cursor-pointer"
+        onClick={() => router.push(`/settings/workspace/${workspaceId}/automations`)}
+      >
+        <IconArrowLeft className="h-4 w-4" />
+      </Button>
+      <span className="text-sm text-muted-foreground">Automations</span>
+    </div>
+  );
+}
+
+function SettingsSection({
+  form,
+  updateField,
+}: {
+  form: FormState;
+  updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <Label className="text-xs uppercase tracking-wider text-muted-foreground">Settings</Label>
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={form.enabled}
+            onCheckedChange={(v) => updateField("enabled", v)}
+            className="cursor-pointer"
+          />
+          <Label className="text-sm">Enabled</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Label className="text-sm">Max concurrent runs</Label>
+          <Input
+            type="number"
+            min={1}
+            value={form.maxConcurrentRuns}
+            onChange={(e) => updateField("maxConcurrentRuns", parseInt(e.target.value) || 1)}
+            className="w-20"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditorFooter({
+  canSave,
+  saving,
+  isNew,
+  onSave,
+  onDelete,
+}: {
+  canSave: boolean;
+  saving: boolean;
+  isNew: boolean;
+  onSave: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 pt-4">
+      <Button
+        data-testid="automation-save-button"
+        className="cursor-pointer"
+        onClick={onSave}
+        disabled={!canSave || saving}
+      >
+        {getSaveLabel(saving, isNew)}
+      </Button>
+      {!isNew && (
+        <Button
+          data-testid="automation-delete-button"
+          variant="destructive"
+          className="cursor-pointer"
+          onClick={onDelete}
+        >
+          <IconTrash className="h-4 w-4 mr-1" />
+          Delete
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/automations/automation-editor.tsx
+++ b/apps/web/components/automations/automation-editor.tsx
@@ -26,8 +26,9 @@ import type {
 } from "@/lib/types/automation";
 import { TriggersSection } from "./triggers-section";
 import { PromptSection } from "./prompt-section";
-import { ConfigSection } from "./config-section";
+import { ConfigSection, type RepositorySelection } from "./config-section";
 import { RunsSection } from "./runs-section";
+import { createRepositoryAction } from "@/app/actions/workspaces";
 
 type AutomationEditorProps = {
   workspaceId: string;
@@ -41,7 +42,10 @@ type FormState = {
   workflowStepId: string;
   agentProfileId: string;
   executorProfileId: string;
-  repositoryId: string;
+  // repositorySelection captures either a registered workspace repo (id),
+  // a discovered local repo (path — registered at save time to obtain an
+  // id), or "auto" for workspace-first fallback.
+  repositorySelection: RepositorySelection;
   prompt: string;
   taskTitleTemplate: string;
   executionMode: ExecutionMode;
@@ -65,7 +69,7 @@ const defaultForm: FormState = {
   workflowStepId: "",
   agentProfileId: "",
   executorProfileId: "",
-  repositoryId: "",
+  repositorySelection: { kind: "auto" },
   prompt: DEFAULT_PROMPT,
   taskTitleTemplate: "",
   executionMode: "task",
@@ -81,7 +85,9 @@ function formFromAutomation(a: Automation): FormState {
     workflowStepId: a.workflow_step_id,
     agentProfileId: a.agent_profile_id,
     executorProfileId: a.executor_profile_id,
-    repositoryId: a.repository_id ?? "",
+    repositorySelection: a.repository_id
+      ? { kind: "registered", id: a.repository_id }
+      : { kind: "auto" },
     prompt: a.prompt || DEFAULT_PROMPT,
     taskTitleTemplate: a.task_title_template ?? "",
     executionMode: a.execution_mode ?? "task",
@@ -182,7 +188,40 @@ function isDefaultPrompt(prompt: string, triggerTypes: TriggerTypeInfo[]): boole
   return triggerTypes.some((t) => t.default_prompt === prompt);
 }
 
-function buildCreatePayload(workspaceId: string, form: FormState, pending: PendingTrigger[]) {
+// resolveRepositoryId turns a RepositorySelection into a concrete
+// repository_id, registering a discovered local repo with the workspace
+// first when needed. Empty string for "auto" (workspace-first fallback).
+async function resolveRepositoryId(
+  workspaceId: string,
+  selection: RepositorySelection,
+): Promise<string> {
+  if (selection.kind === "auto") return "";
+  if (selection.kind === "registered") return selection.id;
+  const created = await createRepositoryAction({
+    workspace_id: workspaceId,
+    name: selection.name,
+    source_type: "local",
+    local_path: selection.path,
+    provider: "",
+    provider_repo_id: "",
+    provider_owner: "",
+    provider_name: "",
+    default_branch: selection.defaultBranch,
+    worktree_branch_prefix: "feature/",
+    pull_before_worktree: true,
+    setup_script: "",
+    cleanup_script: "",
+    dev_script: "",
+  });
+  return created.id;
+}
+
+function buildCreatePayload(
+  workspaceId: string,
+  form: FormState,
+  repositoryId: string,
+  pending: PendingTrigger[],
+) {
   return {
     workspace_id: workspaceId,
     name: form.name || "New Automation",
@@ -191,7 +230,7 @@ function buildCreatePayload(workspaceId: string, form: FormState, pending: Pendi
     workflow_step_id: form.workflowStepId,
     agent_profile_id: form.agentProfileId,
     executor_profile_id: form.executorProfileId,
-    repository_id: form.repositoryId,
+    repository_id: repositoryId,
     prompt: form.prompt,
     task_title_template: form.taskTitleTemplate,
     execution_mode: form.executionMode,
@@ -200,7 +239,59 @@ function buildCreatePayload(workspaceId: string, form: FormState, pending: Pendi
   };
 }
 
-function buildUpdatePayload(form: FormState) {
+type SaveHandlerOpts = {
+  isNew: boolean;
+  workspaceId: string;
+  form: FormState;
+  currentId: string | null;
+  create: (payload: ReturnType<typeof buildCreatePayload>) => Promise<Automation>;
+  update: (id: string, payload: ReturnType<typeof buildUpdatePayload>) => Promise<unknown>;
+  setSaving: React.Dispatch<React.SetStateAction<boolean>>;
+  setCurrentId: React.Dispatch<React.SetStateAction<string | null>>;
+  setForm: React.Dispatch<React.SetStateAction<FormState>>;
+  triggerActions: ReturnType<typeof useTriggerActions>;
+  router: ReturnType<typeof useRouter>;
+};
+
+// useSaveHandler returns the save callback for the automation editor.
+// Pulled out of AutomationEditor to keep that component under the
+// function-length lint cap; the save flow has gotten chunky now that it
+// registers discovered repos before persisting the automation.
+function useSaveHandler(opts: SaveHandlerOpts): () => Promise<void> {
+  const { isNew, workspaceId, form, currentId, create, update } = opts;
+  const { setSaving, setCurrentId, setForm, triggerActions, router } = opts;
+  return async () => {
+    setSaving(true);
+    try {
+      const repositoryId = await resolveRepositoryId(workspaceId, form.repositorySelection);
+      const promoteSelection = () => {
+        if (form.repositorySelection.kind === "discovered" && repositoryId) {
+          setForm((prev) => ({
+            ...prev,
+            repositorySelection: { kind: "registered", id: repositoryId },
+          }));
+        }
+      };
+      if (isNew) {
+        const a = await create(
+          buildCreatePayload(workspaceId, form, repositoryId, triggerActions.pending),
+        );
+        setCurrentId(a.id);
+        triggerActions.setTriggers(a.triggers ?? []);
+        triggerActions.clearPending();
+        promoteSelection();
+        router.replace(`/settings/workspace/${workspaceId}/automations/${a.id}`);
+      } else if (currentId) {
+        await update(currentId, buildUpdatePayload(form, repositoryId));
+        promoteSelection();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+}
+
+function buildUpdatePayload(form: FormState, repositoryId: string) {
   return {
     name: form.name,
     description: form.description,
@@ -208,7 +299,7 @@ function buildUpdatePayload(form: FormState) {
     workflow_step_id: form.workflowStepId,
     agent_profile_id: form.agentProfileId,
     executor_profile_id: form.executorProfileId,
-    repository_id: form.repositoryId,
+    repository_id: repositoryId,
     prompt: form.prompt,
     task_title_template: form.taskTitleTemplate,
     execution_mode: form.executionMode,
@@ -286,22 +377,19 @@ export function AutomationEditor({ workspaceId, automationId }: AutomationEditor
     setForm((prev) => ({ ...prev, [key]: value }));
   }, []);
 
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      if (isNew) {
-        const a = await create(buildCreatePayload(workspaceId, form, triggerActions.pending));
-        setCurrentId(a.id);
-        triggerActions.setTriggers(a.triggers ?? []);
-        triggerActions.clearPending();
-        router.replace(`/settings/workspace/${workspaceId}/automations/${a.id}`);
-      } else {
-        await update(currentId, buildUpdatePayload(form));
-      }
-    } finally {
-      setSaving(false);
-    }
-  };
+  const handleSave = useSaveHandler({
+    isNew,
+    workspaceId,
+    form,
+    currentId,
+    create,
+    update,
+    setSaving,
+    setCurrentId,
+    setForm,
+    triggerActions,
+    router,
+  });
 
   const handleRemove = async () => {
     if (!currentId) return;
@@ -433,7 +521,7 @@ function ThenSection({
           workflowStepId={form.workflowStepId}
           agentProfileId={form.agentProfileId}
           executorProfileId={form.executorProfileId}
-          repositoryId={form.repositoryId}
+          repositorySelection={form.repositorySelection}
           executionMode={form.executionMode}
           conditionType={conditionType}
           onWorkflowChange={(v) => {
@@ -443,7 +531,7 @@ function ThenSection({
           onStepChange={(v) => updateField("workflowStepId", v)}
           onAgentProfileChange={(v) => updateField("agentProfileId", v)}
           onExecutorProfileChange={(v) => updateField("executorProfileId", v)}
-          onRepositoryChange={(v) => updateField("repositoryId", v)}
+          onRepositoryChange={(v) => updateField("repositorySelection", v)}
           onExecutionModeChange={(v) => updateField("executionMode", v)}
         />
       </div>

--- a/apps/web/components/automations/automation-editor.tsx
+++ b/apps/web/components/automations/automation-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
@@ -286,6 +287,9 @@ function useSaveHandler(opts: SaveHandlerOpts): () => Promise<void> {
         await update(currentId, buildUpdatePayload(form, repositoryId));
         promoteSelection();
       }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to save automation: ${msg}`);
     } finally {
       setSaving(false);
     }
@@ -398,7 +402,9 @@ export function AutomationEditor({ workspaceId, automationId }: AutomationEditor
     router.push(`/settings/workspace/${workspaceId}/automations`);
   };
 
-  const canSave = form.name.trim().length > 0 && !!form.workflowId && !!form.workflowStepId;
+  const isRunMode = form.executionMode === "run";
+  const canSave =
+    form.name.trim().length > 0 && (isRunMode || (!!form.workflowId && !!form.workflowStepId));
 
   return (
     <div className="max-w-3xl space-y-6" data-testid="automation-editor">
@@ -431,7 +437,7 @@ export function AutomationEditor({ workspaceId, automationId }: AutomationEditor
       <Separator />
       <SettingsSection form={form} updateField={updateField} />
       <Separator />
-      <RunsSection automationId={currentId} />
+      <RunsSection automationId={currentId} executionMode={form.executionMode} />
       <EditorFooter
         canSave={canSave}
         saving={saving}

--- a/apps/web/components/automations/automation-editor.tsx
+++ b/apps/web/components/automations/automation-editor.tsx
@@ -22,6 +22,7 @@ import type {
   AutomationTrigger,
   TriggerTypeInfo,
   PlaceholderInfo,
+  ExecutionMode,
 } from "@/lib/types/automation";
 import { TriggersSection } from "./triggers-section";
 import { PromptSection } from "./prompt-section";
@@ -42,6 +43,7 @@ type FormState = {
   executorProfileId: string;
   prompt: string;
   taskTitleTemplate: string;
+  executionMode: ExecutionMode;
   enabled: boolean;
   maxConcurrentRuns: number;
 };
@@ -64,6 +66,7 @@ const defaultForm: FormState = {
   executorProfileId: "",
   prompt: DEFAULT_PROMPT,
   taskTitleTemplate: "",
+  executionMode: "task",
   enabled: true,
   maxConcurrentRuns: 1,
 };
@@ -78,6 +81,7 @@ function formFromAutomation(a: Automation): FormState {
     executorProfileId: a.executor_profile_id,
     prompt: a.prompt || DEFAULT_PROMPT,
     taskTitleTemplate: a.task_title_template ?? "",
+    executionMode: a.execution_mode ?? "task",
     enabled: a.enabled,
     maxConcurrentRuns: a.max_concurrent_runs,
   };
@@ -186,6 +190,7 @@ function buildCreatePayload(workspaceId: string, form: FormState, pending: Pendi
     executor_profile_id: form.executorProfileId,
     prompt: form.prompt,
     task_title_template: form.taskTitleTemplate,
+    execution_mode: form.executionMode,
     max_concurrent_runs: form.maxConcurrentRuns,
     triggers: pending.map((t) => ({ type: t.type, config: t.config, enabled: t.enabled })),
   };
@@ -201,6 +206,7 @@ function buildUpdatePayload(form: FormState) {
     executor_profile_id: form.executorProfileId,
     prompt: form.prompt,
     task_title_template: form.taskTitleTemplate,
+    execution_mode: form.executionMode,
     enabled: form.enabled,
     max_concurrent_runs: form.maxConcurrentRuns,
   };
@@ -419,6 +425,7 @@ function ThenSection({
           workflowStepId={form.workflowStepId}
           agentProfileId={form.agentProfileId}
           executorProfileId={form.executorProfileId}
+          executionMode={form.executionMode}
           onWorkflowChange={(v) => {
             updateField("workflowId", v);
             updateField("workflowStepId", "");
@@ -426,6 +433,7 @@ function ThenSection({
           onStepChange={(v) => updateField("workflowStepId", v)}
           onAgentProfileChange={(v) => updateField("agentProfileId", v)}
           onExecutorProfileChange={(v) => updateField("executorProfileId", v)}
+          onExecutionModeChange={(v) => updateField("executionMode", v)}
         />
       </div>
     </div>

--- a/apps/web/components/automations/automation-editor.tsx
+++ b/apps/web/components/automations/automation-editor.tsx
@@ -29,6 +29,7 @@ import { PromptSection } from "./prompt-section";
 import { ConfigSection, type RepositorySelection } from "./config-section";
 import { RunsSection } from "./runs-section";
 import { createRepositoryAction } from "@/app/actions/workspaces";
+import { generateUUID } from "@/lib/utils";
 
 type AutomationEditorProps = {
   workspaceId: string;
@@ -115,7 +116,7 @@ function useTriggerActions(currentId: string | null) {
 
   const handleAdd = async (type: TriggerType, config: Record<string, unknown>) => {
     if (!currentId) {
-      setPending((prev) => [...prev, { tempId: crypto.randomUUID(), type, config, enabled: true }]);
+      setPending((prev) => [...prev, { tempId: generateUUID(), type, config, enabled: true }]);
       return;
     }
     const trigger = await addTrigger({ automation_id: currentId, type, config, enabled: true });

--- a/apps/web/components/automations/automation-editor.tsx
+++ b/apps/web/components/automations/automation-editor.tsx
@@ -41,6 +41,7 @@ type FormState = {
   workflowStepId: string;
   agentProfileId: string;
   executorProfileId: string;
+  repositoryId: string;
   prompt: string;
   taskTitleTemplate: string;
   executionMode: ExecutionMode;
@@ -64,6 +65,7 @@ const defaultForm: FormState = {
   workflowStepId: "",
   agentProfileId: "",
   executorProfileId: "",
+  repositoryId: "",
   prompt: DEFAULT_PROMPT,
   taskTitleTemplate: "",
   executionMode: "task",
@@ -79,6 +81,7 @@ function formFromAutomation(a: Automation): FormState {
     workflowStepId: a.workflow_step_id,
     agentProfileId: a.agent_profile_id,
     executorProfileId: a.executor_profile_id,
+    repositoryId: a.repository_id ?? "",
     prompt: a.prompt || DEFAULT_PROMPT,
     taskTitleTemplate: a.task_title_template ?? "",
     executionMode: a.execution_mode ?? "task",
@@ -188,6 +191,7 @@ function buildCreatePayload(workspaceId: string, form: FormState, pending: Pendi
     workflow_step_id: form.workflowStepId,
     agent_profile_id: form.agentProfileId,
     executor_profile_id: form.executorProfileId,
+    repository_id: form.repositoryId,
     prompt: form.prompt,
     task_title_template: form.taskTitleTemplate,
     execution_mode: form.executionMode,
@@ -204,6 +208,7 @@ function buildUpdatePayload(form: FormState) {
     workflow_step_id: form.workflowStepId,
     agent_profile_id: form.agentProfileId,
     executor_profile_id: form.executorProfileId,
+    repository_id: form.repositoryId,
     prompt: form.prompt,
     task_title_template: form.taskTitleTemplate,
     execution_mode: form.executionMode,
@@ -331,6 +336,7 @@ export function AutomationEditor({ workspaceId, automationId }: AutomationEditor
         workspaceId={workspaceId}
         placeholders={placeholders}
         defaultTaskTitle={defaultTaskTitle}
+        conditionType={conditionType}
         updateField={updateField}
       />
       <Separator />
@@ -385,12 +391,14 @@ function ThenSection({
   workspaceId,
   placeholders,
   defaultTaskTitle,
+  conditionType,
   updateField,
 }: {
   form: FormState;
   workspaceId: string;
   placeholders: PlaceholderInfo[];
   defaultTaskTitle: string;
+  conditionType: TriggerType | null;
   updateField: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
 }) {
   return (
@@ -425,7 +433,9 @@ function ThenSection({
           workflowStepId={form.workflowStepId}
           agentProfileId={form.agentProfileId}
           executorProfileId={form.executorProfileId}
+          repositoryId={form.repositoryId}
           executionMode={form.executionMode}
+          conditionType={conditionType}
           onWorkflowChange={(v) => {
             updateField("workflowId", v);
             updateField("workflowStepId", "");
@@ -433,6 +443,7 @@ function ThenSection({
           onStepChange={(v) => updateField("workflowStepId", v)}
           onAgentProfileChange={(v) => updateField("agentProfileId", v)}
           onExecutorProfileChange={(v) => updateField("executorProfileId", v)}
+          onRepositoryChange={(v) => updateField("repositoryId", v)}
           onExecutionModeChange={(v) => updateField("executionMode", v)}
         />
       </div>

--- a/apps/web/components/automations/automation-placeholders.ts
+++ b/apps/web/components/automations/automation-placeholders.ts
@@ -1,0 +1,15 @@
+import type { ScriptPlaceholder } from "@/components/settings/profile-edit/script-editor-completions";
+import type { PlaceholderInfo } from "@/lib/types/automation";
+
+/**
+ * Converts backend PlaceholderInfo[] to ScriptPlaceholder[] for the Monaco editor.
+ * The executor_types field is empty since automation placeholders apply to all executors.
+ */
+export function toScriptPlaceholders(placeholders: PlaceholderInfo[]): ScriptPlaceholder[] {
+  return placeholders.map((p) => ({
+    key: p.key,
+    description: p.description,
+    example: p.example,
+    executor_types: [],
+  }));
+}

--- a/apps/web/components/automations/automations-list-page.tsx
+++ b/apps/web/components/automations/automations-list-page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@kandev/ui/button";
+import { Separator } from "@kandev/ui/separator";
+import { IconPlus, IconBolt } from "@tabler/icons-react";
+import { useAutomations } from "@/hooks/domains/settings/use-automations";
+import { AutomationsTable } from "./automations-table";
+
+type AutomationsListPageProps = {
+  workspaceId: string;
+};
+
+export function AutomationsListPage({ workspaceId }: AutomationsListPageProps) {
+  const router = useRouter();
+  const { items, loading, enable, disable, trigger, remove } = useAutomations(workspaceId);
+
+  const handleToggleEnabled = async (id: string, enabled: boolean) => {
+    if (enabled) {
+      await enable(id);
+    } else {
+      await disable(id);
+    }
+  };
+
+  const handleTrigger = async (id: string) => {
+    await trigger(id);
+  };
+
+  const handleDelete = async (id: string) => {
+    await remove(id);
+  };
+
+  return (
+    <div className="space-y-6" data-testid="automations-list-page">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <IconBolt className="h-5 w-5" />
+            Automations
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Create rules that automatically trigger agent tasks.
+          </p>
+        </div>
+        <Button
+          data-testid="new-automation-button"
+          className="cursor-pointer"
+          onClick={() => router.push(`/settings/workspace/${workspaceId}/automations/new`)}
+        >
+          <IconPlus className="h-4 w-4 mr-1" />
+          New Automation
+        </Button>
+      </div>
+      <Separator />
+      {loading && items.length === 0 ? (
+        <div className="py-12 text-center text-muted-foreground">Loading automations...</div>
+      ) : (
+        <AutomationsTable
+          automations={items}
+          workspaceId={workspaceId}
+          onToggleEnabled={handleToggleEnabled}
+          onTrigger={handleTrigger}
+          onDelete={handleDelete}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/automations/automations-table.tsx
+++ b/apps/web/components/automations/automations-table.tsx
@@ -106,6 +106,7 @@ export function AutomationsTable({
         <TableHeader>
           <TableRow>
             <TableHead>Name</TableHead>
+            <TableHead>Mode</TableHead>
             <TableHead>Triggers</TableHead>
             <TableHead>Enabled</TableHead>
             <TableHead>Last Triggered</TableHead>
@@ -116,7 +117,7 @@ export function AutomationsTable({
           {automations.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={5}
+                colSpan={6}
                 className="text-center text-muted-foreground py-8"
                 data-testid="automations-empty"
               >
@@ -134,6 +135,11 @@ export function AutomationsTable({
                 }
               >
                 <TableCell className="font-medium">{a.name}</TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="text-[10px]">
+                    {a.execution_mode === "run" ? "Run" : "Task"}
+                  </Badge>
+                </TableCell>
                 <TableCell>
                   <TriggerBadges triggers={a.triggers} />
                 </TableCell>

--- a/apps/web/components/automations/automations-table.tsx
+++ b/apps/web/components/automations/automations-table.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Badge } from "@kandev/ui/badge";
+import { Button } from "@kandev/ui/button";
+import { Switch } from "@kandev/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@kandev/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconPlayerPlay, IconTrash } from "@tabler/icons-react";
+import type { Automation, TriggerType } from "@/lib/types/automation";
+import { formatRelativeTime } from "./format-utils";
+
+type AutomationsTableProps = {
+  automations: Automation[];
+  workspaceId: string;
+  onToggleEnabled: (id: string, enabled: boolean) => void;
+  onTrigger: (id: string) => void;
+  onDelete: (id: string) => void;
+};
+
+const TRIGGER_BADGE_VARIANT: Record<TriggerType, string> = {
+  scheduled: "bg-blue-500/15 text-blue-400 border-blue-500/20",
+  github_pr: "bg-purple-500/15 text-purple-400 border-purple-500/20",
+  github_push: "bg-purple-500/15 text-purple-400 border-purple-500/20",
+  github_ci: "bg-purple-500/15 text-purple-400 border-purple-500/20",
+  webhook: "bg-orange-500/15 text-orange-400 border-orange-500/20",
+};
+
+const TRIGGER_LABELS: Record<TriggerType, string> = {
+  scheduled: "Scheduled",
+  github_pr: "GitHub PR",
+  github_push: "GitHub Push",
+  github_ci: "GitHub CI",
+  webhook: "Webhook",
+};
+
+function TriggerBadges({ triggers }: { triggers: Automation["triggers"] }) {
+  const items = triggers ?? [];
+  if (items.length === 0) {
+    return <span className="text-xs text-muted-foreground">None</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {items.map((t) => (
+        <Badge key={t.id} variant="outline" className={TRIGGER_BADGE_VARIANT[t.type]}>
+          {TRIGGER_LABELS[t.type]}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function RowActions({
+  id,
+  onTrigger,
+  onDelete,
+}: {
+  id: string;
+  onTrigger: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <div className="flex items-center justify-end gap-0.5">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="cursor-pointer"
+            onClick={() => onTrigger(id)}
+          >
+            <IconPlayerPlay className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Trigger manually</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="cursor-pointer"
+            onClick={() => onDelete(id)}
+          >
+            <IconTrash className="h-3.5 w-3.5 text-destructive" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Delete</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+export function AutomationsTable({
+  automations,
+  workspaceId,
+  onToggleEnabled,
+  onTrigger,
+  onDelete,
+}: AutomationsTableProps) {
+  const router = useRouter();
+
+  return (
+    <div className="rounded-md border" data-testid="automations-table">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Triggers</TableHead>
+            <TableHead>Enabled</TableHead>
+            <TableHead>Last Triggered</TableHead>
+            <TableHead className="w-[100px]" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {automations.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={5}
+                className="text-center text-muted-foreground py-8"
+                data-testid="automations-empty"
+              >
+                No automations yet
+              </TableCell>
+            </TableRow>
+          ) : (
+            automations.map((a) => (
+              <TableRow
+                key={a.id}
+                data-testid={`automation-row-${a.id}`}
+                className="cursor-pointer hover:bg-muted/50"
+                onClick={() =>
+                  router.push(`/settings/workspace/${workspaceId}/automations/${a.id}`)
+                }
+              >
+                <TableCell className="font-medium">{a.name}</TableCell>
+                <TableCell>
+                  <TriggerBadges triggers={a.triggers} />
+                </TableCell>
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <Switch
+                    data-testid={`automation-enabled-${a.id}`}
+                    size="sm"
+                    checked={a.enabled}
+                    onCheckedChange={(checked) => onToggleEnabled(a.id, checked)}
+                    className="cursor-pointer"
+                  />
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {a.last_triggered_at ? formatRelativeTime(a.last_triggered_at) : "Never"}
+                </TableCell>
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <RowActions id={a.id} onTrigger={onTrigger} onDelete={onDelete} />
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/web/components/automations/automations-table.tsx
+++ b/apps/web/components/automations/automations-table.tsx
@@ -104,7 +104,7 @@ export function AutomationsTable({
     <div className="rounded-md border" data-testid="automations-table">
       <Table>
         <TableHeader>
-          <TableRow>
+          <TableRow className="hover:bg-transparent focus-within:bg-transparent">
             <TableHead>Name</TableHead>
             <TableHead>Mode</TableHead>
             <TableHead>Triggers</TableHead>

--- a/apps/web/components/automations/config-section.tsx
+++ b/apps/web/components/automations/config-section.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { Label } from "@kandev/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
+import { useAppStore } from "@/components/state-provider";
+import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
+import { useWorkflows } from "@/hooks/use-workflows";
+import { listWorkflowSteps } from "@/lib/api/domains/workflow-api";
+
+type ConfigSectionProps = {
+  workspaceId: string;
+  workflowId: string;
+  workflowStepId: string;
+  agentProfileId: string;
+  executorProfileId: string;
+  onWorkflowChange: (id: string) => void;
+  onStepChange: (id: string) => void;
+  onAgentProfileChange: (id: string) => void;
+  onExecutorProfileChange: (id: string) => void;
+};
+
+type StepOption = { id: string; name: string };
+
+function useWorkflowSteps(workflowId: string) {
+  const [steps, setSteps] = useState<StepOption[]>([]);
+
+  useEffect(() => {
+    if (!workflowId) return;
+    let cancelled = false;
+    listWorkflowSteps(workflowId)
+      .then((response) => {
+        if (cancelled) return;
+        const sorted = [...response.steps].sort((a, b) => a.position - b.position);
+        setSteps(sorted.map((s) => ({ id: s.id, name: s.name })));
+      })
+      .catch(() => {
+        if (!cancelled) setSteps([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workflowId]);
+
+  return steps;
+}
+
+export function ConfigSection({
+  workspaceId,
+  workflowId,
+  workflowStepId,
+  agentProfileId,
+  executorProfileId,
+  onWorkflowChange,
+  onStepChange,
+  onAgentProfileChange,
+  onExecutorProfileChange,
+}: ConfigSectionProps) {
+  useSettingsData(true);
+  useWorkflows(workspaceId, true);
+
+  const workflows = useAppStore((state) => state.workflows.items);
+  const agentProfiles = useAppStore((state) => state.agentProfiles.items);
+  const executors = useAppStore((state) => state.executors.items);
+  const steps = useWorkflowSteps(workflowId);
+
+  const filteredAgentProfiles = useMemo(
+    () => agentProfiles.filter((p) => !p.cli_passthrough),
+    [agentProfiles],
+  );
+  const allExecutorProfiles = useMemo(
+    () => executors.filter((e) => e.type !== "local").flatMap((e) => e.profiles ?? []),
+    [executors],
+  );
+
+  return (
+    <div className="space-y-3">
+      <Label className="text-xs uppercase tracking-wider text-muted-foreground">
+        Configuration
+      </Label>
+      <div className="grid grid-cols-2 gap-4">
+        <SelectField
+          testId="workflow-selector"
+          label="Workflow"
+          value={workflowId}
+          onChange={onWorkflowChange}
+          placeholder="Select workflow"
+          items={workflows.map((w) => ({ id: w.id, label: w.name }))}
+        />
+        <SelectField
+          testId="workflow-step-selector"
+          label="Workflow Step"
+          value={workflowStepId}
+          onChange={onStepChange}
+          placeholder="Select step"
+          items={steps.map((s) => ({ id: s.id, label: s.name }))}
+        />
+        <SelectField
+          label="Agent Profile"
+          value={agentProfileId}
+          onChange={onAgentProfileChange}
+          placeholder="Select agent"
+          items={filteredAgentProfiles.map((p) => ({
+            id: p.id,
+            label: p.label,
+          }))}
+        />
+        <SelectField
+          label="Executor Profile"
+          value={executorProfileId}
+          onChange={onExecutorProfileChange}
+          placeholder="Select executor"
+          items={allExecutorProfiles.map((p) => ({ id: p.id, label: p.name }))}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SelectField({
+  testId,
+  label,
+  value,
+  onChange,
+  placeholder,
+  items,
+}: {
+  testId?: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  items: Array<{ id: string; label: string }>;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs">{label}</Label>
+      <Select value={value || undefined} onValueChange={onChange}>
+        <SelectTrigger data-testid={testId} className="cursor-pointer">
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map((item) => (
+            <SelectItem key={item.id} value={item.id}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/web/components/automations/config-section.tsx
+++ b/apps/web/components/automations/config-section.tsx
@@ -7,8 +7,20 @@ import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
+import { discoverRepositoriesAction } from "@/app/actions/workspaces";
 import { listWorkflowSteps } from "@/lib/api/domains/workflow-api";
+import type { LocalRepository, Repository } from "@/lib/types/http";
 import type { ExecutionMode, TriggerType } from "@/lib/types/automation";
+
+// RepositorySelection mirrors the task-create dialog's two-tier model: a
+// registered workspace repository (keyed by id) OR a filesystem-discovered
+// repo not yet registered (keyed by local path). The form holds whichever
+// the user picked; save-time logic registers the discovered repo first to
+// land an id on the automation row.
+export type RepositorySelection =
+  | { kind: "auto" }
+  | { kind: "registered"; id: string }
+  | { kind: "discovered"; path: string; name: string; defaultBranch: string };
 
 type ConfigSectionProps = {
   workspaceId: string;
@@ -16,35 +28,93 @@ type ConfigSectionProps = {
   workflowStepId: string;
   agentProfileId: string;
   executorProfileId: string;
-  repositoryId: string;
+  repositorySelection: RepositorySelection;
   executionMode: ExecutionMode;
   conditionType: TriggerType | null;
   onWorkflowChange: (id: string) => void;
   onStepChange: (id: string) => void;
   onAgentProfileChange: (id: string) => void;
   onExecutorProfileChange: (id: string) => void;
-  onRepositoryChange: (id: string) => void;
+  onRepositoryChange: (selection: RepositorySelection) => void;
   onExecutionModeChange: (mode: ExecutionMode) => void;
 };
 
 const REPO_AUTO_OPTION_ID = "__auto__";
+const DISCOVERED_PREFIX = "path:";
 
-type RepoLike = { id: string; name: string; provider_owner: string; provider_name: string };
+function selectionToOptionId(sel: RepositorySelection): string {
+  if (sel.kind === "registered") return sel.id;
+  if (sel.kind === "discovered") return DISCOVERED_PREFIX + sel.path;
+  return REPO_AUTO_OPTION_ID;
+}
 
-function buildRepositoryItems(repositories: RepoLike[]): Array<{ id: string; label: string }> {
+function buildRepositoryItems(
+  workspaceRepos: Repository[],
+  discoveredRepos: LocalRepository[],
+): Array<{ id: string; label: string }> {
+  const registeredPaths = new Set(
+    workspaceRepos
+      .map((r) => r.local_path)
+      .filter(Boolean)
+      .map((p) => p.replace(/\/+$/, "")),
+  );
   const items: Array<{ id: string; label: string }> = [
     { id: REPO_AUTO_OPTION_ID, label: "Auto — first workspace repo" },
   ];
-  for (const r of repositories) {
+  for (const r of workspaceRepos) {
     items.push({ id: r.id, label: r.name || `${r.provider_owner}/${r.provider_name}` });
   }
+  for (const r of discoveredRepos) {
+    if (registeredPaths.has(r.path.replace(/\/+$/, ""))) continue;
+    items.push({ id: DISCOVERED_PREFIX + r.path, label: `${r.name} — ${r.path}` });
+  }
   return items;
+}
+
+function pickSelectionFromOptionId(
+  optionId: string,
+  workspaceRepos: Repository[],
+  discoveredRepos: LocalRepository[],
+): RepositorySelection {
+  if (optionId === REPO_AUTO_OPTION_ID) return { kind: "auto" };
+  if (optionId.startsWith(DISCOVERED_PREFIX)) {
+    const path = optionId.slice(DISCOVERED_PREFIX.length);
+    const match = discoveredRepos.find((r) => r.path === path);
+    return {
+      kind: "discovered",
+      path,
+      name: match?.name ?? path.split("/").pop() ?? "New Repository",
+      defaultBranch: match?.default_branch ?? "",
+    };
+  }
+  const reg = workspaceRepos.find((r) => r.id === optionId);
+  return reg ? { kind: "registered", id: reg.id } : { kind: "auto" };
 }
 
 const EXECUTION_MODE_ITEMS = [
   { id: "task", label: "Task — creates a tracked kanban task" },
   { id: "run", label: "Run — fire-and-forget, hidden from kanban" },
 ];
+
+function useDiscoveredRepositories(workspaceId: string) {
+  const [items, setItems] = useState<LocalRepository[]>([]);
+  useEffect(() => {
+    if (!workspaceId) return;
+    let cancelled = false;
+    discoverRepositoriesAction(workspaceId)
+      .then((res) => {
+        if (cancelled) return;
+        setItems(res.repositories ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+  return items;
+}
 
 type StepOption = { id: string; name: string };
 
@@ -77,7 +147,7 @@ export function ConfigSection({
   workflowStepId,
   agentProfileId,
   executorProfileId,
-  repositoryId,
+  repositorySelection,
   executionMode,
   conditionType,
   onWorkflowChange,
@@ -90,6 +160,7 @@ export function ConfigSection({
   useSettingsData(true);
   useWorkflows(workspaceId, true);
   const { repositories } = useRepositories(workspaceId, true);
+  const discoveredRepos = useDiscoveredRepositories(workspaceId);
 
   const workflows = useAppStore((state) => state.workflows.items);
   const agentProfiles = useAppStore((state) => state.agentProfiles.items);
@@ -105,7 +176,10 @@ export function ConfigSection({
     [executors],
   );
   const isPRTrigger = conditionType === "github_pr";
-  const repositoryItems = useMemo(() => buildRepositoryItems(repositories), [repositories]);
+  const repositoryItems = useMemo(
+    () => buildRepositoryItems(repositories, discoveredRepos),
+    [repositories, discoveredRepos],
+  );
 
   return (
     <div className="space-y-3">
@@ -149,8 +223,10 @@ export function ConfigSection({
         <SelectField
           testId="repository-selector"
           label="Repository"
-          value={repositoryId || REPO_AUTO_OPTION_ID}
-          onChange={(v) => onRepositoryChange(v === REPO_AUTO_OPTION_ID ? "" : v)}
+          value={selectionToOptionId(repositorySelection)}
+          onChange={(v) =>
+            onRepositoryChange(pickSelectionFromOptionId(v, repositories, discoveredRepos))
+          }
           placeholder="Auto"
           items={repositoryItems}
           disabled={isPRTrigger}

--- a/apps/web/components/automations/config-section.tsx
+++ b/apps/web/components/automations/config-section.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
 import { listWorkflowSteps } from "@/lib/api/domains/workflow-api";
+import type { ExecutionMode } from "@/lib/types/automation";
 
 type ConfigSectionProps = {
   workspaceId: string;
@@ -14,10 +15,12 @@ type ConfigSectionProps = {
   workflowStepId: string;
   agentProfileId: string;
   executorProfileId: string;
+  executionMode: ExecutionMode;
   onWorkflowChange: (id: string) => void;
   onStepChange: (id: string) => void;
   onAgentProfileChange: (id: string) => void;
   onExecutorProfileChange: (id: string) => void;
+  onExecutionModeChange: (mode: ExecutionMode) => void;
 };
 
 type StepOption = { id: string; name: string };
@@ -51,10 +54,12 @@ export function ConfigSection({
   workflowStepId,
   agentProfileId,
   executorProfileId,
+  executionMode,
   onWorkflowChange,
   onStepChange,
   onAgentProfileChange,
   onExecutorProfileChange,
+  onExecutionModeChange,
 }: ConfigSectionProps) {
   useSettingsData(true);
   useWorkflows(workspaceId, true);
@@ -111,6 +116,17 @@ export function ConfigSection({
           onChange={onExecutorProfileChange}
           placeholder="Select executor"
           items={allExecutorProfiles.map((p) => ({ id: p.id, label: p.name }))}
+        />
+        <SelectField
+          testId="execution-mode-selector"
+          label="Execution Mode"
+          value={executionMode}
+          onChange={(v) => onExecutionModeChange(v as ExecutionMode)}
+          placeholder="Select mode"
+          items={[
+            { id: "task", label: "Task — creates a tracked kanban task" },
+            { id: "run", label: "Run — fire-and-forget, hidden from kanban" },
+          ]}
         />
       </div>
     </div>

--- a/apps/web/components/automations/config-section.tsx
+++ b/apps/web/components/automations/config-section.tsx
@@ -6,8 +6,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
+import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { listWorkflowSteps } from "@/lib/api/domains/workflow-api";
-import type { ExecutionMode } from "@/lib/types/automation";
+import type { ExecutionMode, TriggerType } from "@/lib/types/automation";
 
 type ConfigSectionProps = {
   workspaceId: string;
@@ -15,13 +16,35 @@ type ConfigSectionProps = {
   workflowStepId: string;
   agentProfileId: string;
   executorProfileId: string;
+  repositoryId: string;
   executionMode: ExecutionMode;
+  conditionType: TriggerType | null;
   onWorkflowChange: (id: string) => void;
   onStepChange: (id: string) => void;
   onAgentProfileChange: (id: string) => void;
   onExecutorProfileChange: (id: string) => void;
+  onRepositoryChange: (id: string) => void;
   onExecutionModeChange: (mode: ExecutionMode) => void;
 };
+
+const REPO_AUTO_OPTION_ID = "__auto__";
+
+type RepoLike = { id: string; name: string; provider_owner: string; provider_name: string };
+
+function buildRepositoryItems(repositories: RepoLike[]): Array<{ id: string; label: string }> {
+  const items: Array<{ id: string; label: string }> = [
+    { id: REPO_AUTO_OPTION_ID, label: "Auto — first workspace repo" },
+  ];
+  for (const r of repositories) {
+    items.push({ id: r.id, label: r.name || `${r.provider_owner}/${r.provider_name}` });
+  }
+  return items;
+}
+
+const EXECUTION_MODE_ITEMS = [
+  { id: "task", label: "Task — creates a tracked kanban task" },
+  { id: "run", label: "Run — fire-and-forget, hidden from kanban" },
+];
 
 type StepOption = { id: string; name: string };
 
@@ -54,15 +77,19 @@ export function ConfigSection({
   workflowStepId,
   agentProfileId,
   executorProfileId,
+  repositoryId,
   executionMode,
+  conditionType,
   onWorkflowChange,
   onStepChange,
   onAgentProfileChange,
   onExecutorProfileChange,
+  onRepositoryChange,
   onExecutionModeChange,
 }: ConfigSectionProps) {
   useSettingsData(true);
   useWorkflows(workspaceId, true);
+  const { repositories } = useRepositories(workspaceId, true);
 
   const workflows = useAppStore((state) => state.workflows.items);
   const agentProfiles = useAppStore((state) => state.agentProfiles.items);
@@ -77,6 +104,8 @@ export function ConfigSection({
     () => executors.filter((e) => e.type !== "local").flatMap((e) => e.profiles ?? []),
     [executors],
   );
+  const isPRTrigger = conditionType === "github_pr";
+  const repositoryItems = useMemo(() => buildRepositoryItems(repositories), [repositories]);
 
   return (
     <div className="space-y-3">
@@ -118,15 +147,22 @@ export function ConfigSection({
           items={allExecutorProfiles.map((p) => ({ id: p.id, label: p.name }))}
         />
         <SelectField
+          testId="repository-selector"
+          label="Repository"
+          value={repositoryId || REPO_AUTO_OPTION_ID}
+          onChange={(v) => onRepositoryChange(v === REPO_AUTO_OPTION_ID ? "" : v)}
+          placeholder="Auto"
+          items={repositoryItems}
+          disabled={isPRTrigger}
+          helpText={isPRTrigger ? "PR triggers always use the PR's own repository." : undefined}
+        />
+        <SelectField
           testId="execution-mode-selector"
           label="Execution Mode"
           value={executionMode}
           onChange={(v) => onExecutionModeChange(v as ExecutionMode)}
           placeholder="Select mode"
-          items={[
-            { id: "task", label: "Task — creates a tracked kanban task" },
-            { id: "run", label: "Run — fire-and-forget, hidden from kanban" },
-          ]}
+          items={EXECUTION_MODE_ITEMS}
         />
       </div>
     </div>
@@ -140,6 +176,8 @@ function SelectField({
   onChange,
   placeholder,
   items,
+  disabled,
+  helpText,
 }: {
   testId?: string;
   label: string;
@@ -147,11 +185,13 @@ function SelectField({
   onChange: (value: string) => void;
   placeholder: string;
   items: Array<{ id: string; label: string }>;
+  disabled?: boolean;
+  helpText?: string;
 }) {
   return (
     <div className="space-y-1.5">
       <Label className="text-xs">{label}</Label>
-      <Select value={value || undefined} onValueChange={onChange}>
+      <Select value={value || undefined} onValueChange={onChange} disabled={disabled}>
         <SelectTrigger data-testid={testId} className="cursor-pointer">
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
@@ -163,6 +203,7 @@ function SelectField({
           ))}
         </SelectContent>
       </Select>
+      {helpText && <p className="text-[10px] text-muted-foreground">{helpText}</p>}
     </div>
   );
 }

--- a/apps/web/components/automations/config-section.tsx
+++ b/apps/web/components/automations/config-section.tsx
@@ -176,6 +176,7 @@ export function ConfigSection({
     [executors],
   );
   const isPRTrigger = conditionType === "github_pr";
+  const isRunMode = executionMode === "run";
   const repositoryItems = useMemo(
     () => buildRepositoryItems(repositories, discoveredRepos),
     [repositories, discoveredRepos],
@@ -188,21 +189,23 @@ export function ConfigSection({
       </Label>
       <div className="grid grid-cols-2 gap-4">
         <SelectField
-          testId="workflow-selector"
-          label="Workflow"
-          value={workflowId}
-          onChange={onWorkflowChange}
-          placeholder="Select workflow"
-          items={workflows.map((w) => ({ id: w.id, label: w.name }))}
+          testId="execution-mode-selector"
+          label="Execution Mode"
+          value={executionMode}
+          onChange={(v) => onExecutionModeChange(v as ExecutionMode)}
+          placeholder="Select mode"
+          items={EXECUTION_MODE_ITEMS}
         />
-        <SelectField
-          testId="workflow-step-selector"
-          label="Workflow Step"
-          value={workflowStepId}
-          onChange={onStepChange}
-          placeholder="Select step"
-          items={steps.map((s) => ({ id: s.id, label: s.name }))}
-        />
+        {!isRunMode && (
+          <WorkflowFields
+            workflowId={workflowId}
+            workflowStepId={workflowStepId}
+            workflows={workflows}
+            steps={steps}
+            onWorkflowChange={onWorkflowChange}
+            onStepChange={onStepChange}
+          />
+        )}
         <SelectField
           label="Agent Profile"
           value={agentProfileId}
@@ -232,16 +235,45 @@ export function ConfigSection({
           disabled={isPRTrigger}
           helpText={isPRTrigger ? "PR triggers always use the PR's own repository." : undefined}
         />
-        <SelectField
-          testId="execution-mode-selector"
-          label="Execution Mode"
-          value={executionMode}
-          onChange={(v) => onExecutionModeChange(v as ExecutionMode)}
-          placeholder="Select mode"
-          items={EXECUTION_MODE_ITEMS}
-        />
       </div>
     </div>
+  );
+}
+
+function WorkflowFields({
+  workflowId,
+  workflowStepId,
+  workflows,
+  steps,
+  onWorkflowChange,
+  onStepChange,
+}: {
+  workflowId: string;
+  workflowStepId: string;
+  workflows: Array<{ id: string; name: string }>;
+  steps: StepOption[];
+  onWorkflowChange: (id: string) => void;
+  onStepChange: (id: string) => void;
+}) {
+  return (
+    <>
+      <SelectField
+        testId="workflow-selector"
+        label="Workflow"
+        value={workflowId}
+        onChange={onWorkflowChange}
+        placeholder="Select workflow"
+        items={workflows.map((w) => ({ id: w.id, label: w.name }))}
+      />
+      <SelectField
+        testId="workflow-step-selector"
+        label="Workflow Step"
+        value={workflowStepId}
+        onChange={onStepChange}
+        placeholder="Select step"
+        items={steps.map((s) => ({ id: s.id, label: s.name }))}
+      />
+    </>
   );
 }
 

--- a/apps/web/components/automations/format-utils.ts
+++ b/apps/web/components/automations/format-utils.ts
@@ -1,0 +1,15 @@
+export function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}

--- a/apps/web/components/automations/prompt-section.tsx
+++ b/apps/web/components/automations/prompt-section.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useMemo } from "react";
+import { Label } from "@kandev/ui/label";
+import { ScriptEditor } from "@/components/settings/profile-edit/script-editor";
+import type { PlaceholderInfo } from "@/lib/types/automation";
+import { toScriptPlaceholders } from "./automation-placeholders";
+
+type PromptSectionProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholders: PlaceholderInfo[];
+};
+
+export function PromptSection({ value, onChange, placeholders }: PromptSectionProps) {
+  const scriptPlaceholders = useMemo(() => toScriptPlaceholders(placeholders), [placeholders]);
+
+  return (
+    <div className="space-y-3">
+      <Label className="text-xs uppercase tracking-wider text-muted-foreground">Instructions</Label>
+      <ScriptEditor
+        value={value}
+        onChange={onChange}
+        language="plaintext"
+        height="160px"
+        placeholders={scriptPlaceholders}
+      />
+      {placeholders.length > 0 && (
+        <div className="text-xs text-muted-foreground space-y-1">
+          <p className="font-medium">Available placeholders:</p>
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {placeholders.map((p) => (
+              <span key={p.key} title={p.description}>
+                <code className="text-[11px]">{`{{${p.key}}}`}</code>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/automations/runs-section.tsx
+++ b/apps/web/components/automations/runs-section.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@kandev/ui/badge";
+import { Button } from "@kandev/ui/button";
+import { Label } from "@kandev/ui/label";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@kandev/ui/table";
+import { IconChevronDown, IconChevronUp, IconRefresh } from "@tabler/icons-react";
+import { useAutomationRuns } from "@/hooks/domains/settings/use-automation-runs";
+import type { RunStatus } from "@/lib/types/automation";
+import { formatRelativeTime } from "./format-utils";
+
+type RunsSectionProps = {
+  automationId: string | null;
+};
+
+const STATUS_BADGE: Record<
+  RunStatus,
+  { variant: "default" | "destructive" | "secondary" | "outline"; label: string }
+> = {
+  triggered: { variant: "secondary", label: "Triggered" },
+  task_created: { variant: "default", label: "Task Created" },
+  failed: { variant: "destructive", label: "Failed" },
+  skipped: { variant: "outline", label: "Skipped" },
+};
+
+export function RunsSection({ automationId }: RunsSectionProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { runs, loading, refresh } = useAutomationRuns(automationId);
+
+  if (!automationId) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <button
+          className="flex items-center gap-2 cursor-pointer"
+          onClick={() => setExpanded(!expanded)}
+        >
+          <Label className="text-xs uppercase tracking-wider text-muted-foreground cursor-pointer">
+            Recent Runs ({runs.length})
+          </Label>
+          {expanded ? (
+            <IconChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
+          ) : (
+            <IconChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+        </button>
+        {expanded && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="cursor-pointer"
+            onClick={refresh}
+            disabled={loading}
+          >
+            <IconRefresh className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+          </Button>
+        )}
+      </div>
+      {expanded && (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Trigger</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Task</TableHead>
+                <TableHead>Time</TableHead>
+                <TableHead>Error</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {runs.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-muted-foreground py-4">
+                    {loading ? "Loading..." : "No runs yet"}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                runs.map((run) => {
+                  const badge = STATUS_BADGE[run.status] ?? STATUS_BADGE.triggered;
+                  return (
+                    <TableRow key={run.id}>
+                      <TableCell className="text-sm">{run.trigger_type}</TableCell>
+                      <TableCell>
+                        <Badge variant={badge.variant}>{badge.label}</Badge>
+                      </TableCell>
+                      <TableCell className="text-sm font-mono">
+                        {run.task_id ? run.task_id.slice(0, 8) : "-"}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {formatRelativeTime(run.created_at)}
+                      </TableCell>
+                      <TableCell className="text-sm text-destructive max-w-[200px] truncate">
+                        {run.error_message || "-"}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/automations/runs-section.tsx
+++ b/apps/web/components/automations/runs-section.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
 import { Label } from "@kandev/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@kandev/ui/table";
 import { IconChevronDown, IconChevronUp, IconRefresh } from "@tabler/icons-react";
 import { useAutomationRuns } from "@/hooks/domains/settings/use-automation-runs";
-import type { RunStatus } from "@/lib/types/automation";
+import type { ExecutionMode, RunStatus } from "@/lib/types/automation";
 import { formatRelativeTime } from "./format-utils";
 
 type RunsSectionProps = {
   automationId: string | null;
+  executionMode: ExecutionMode;
 };
 
 const STATUS_BADGE: Record<
@@ -19,14 +21,17 @@ const STATUS_BADGE: Record<
   { variant: "default" | "destructive" | "secondary" | "outline"; label: string }
 > = {
   triggered: { variant: "secondary", label: "Triggered" },
-  task_created: { variant: "default", label: "Task Created" },
+  task_created: { variant: "secondary", label: "Running" },
+  succeeded: { variant: "default", label: "Succeeded" },
   failed: { variant: "destructive", label: "Failed" },
   skipped: { variant: "outline", label: "Skipped" },
 };
 
-export function RunsSection({ automationId }: RunsSectionProps) {
+export function RunsSection({ automationId, executionMode }: RunsSectionProps) {
   const [expanded, setExpanded] = useState(false);
   const { runs, loading, refresh } = useAutomationRuns(automationId);
+  const router = useRouter();
+  const taskClickable = executionMode !== "run";
 
   if (!automationId) return null;
 
@@ -62,7 +67,7 @@ export function RunsSection({ automationId }: RunsSectionProps) {
         <div className="rounded-md border">
           <Table>
             <TableHeader>
-              <TableRow>
+              <TableRow className="hover:bg-transparent focus-within:bg-transparent">
                 <TableHead>Trigger</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Task</TableHead>
@@ -80,8 +85,19 @@ export function RunsSection({ automationId }: RunsSectionProps) {
               ) : (
                 runs.map((run) => {
                   const badge = STATUS_BADGE[run.status] ?? STATUS_BADGE.triggered;
+                  const rowClickable = taskClickable && !!run.task_id;
                   return (
-                    <TableRow key={run.id}>
+                    <TableRow
+                      key={run.id}
+                      className={
+                        rowClickable
+                          ? "cursor-pointer hover:bg-muted/50"
+                          : "hover:bg-transparent focus-within:bg-transparent"
+                      }
+                      onClick={
+                        rowClickable ? () => router.push(`/tasks/${run.task_id}`) : undefined
+                      }
+                    >
                       <TableCell className="text-sm">{run.trigger_type}</TableCell>
                       <TableCell>
                         <Badge variant={badge.variant}>{badge.label}</Badge>

--- a/apps/web/components/automations/schedule-selector.tsx
+++ b/apps/web/components/automations/schedule-selector.tsx
@@ -55,13 +55,20 @@ export function ScheduleSelector({ config, onChange }: ScheduleSelectorProps) {
   };
 
   const handleCustomBlur = () => {
-    if (!customInput) return;
-    if (!isValidExpression(customInput)) {
+    const trimmed = customInput.trim();
+    // An empty input means "clear the schedule" — propagate so the saved
+    // config doesn't retain a stale cron expression.
+    if (trimmed === "") {
+      setError(null);
+      if (configExpr !== "") onChange({ cron_expression: "" });
+      return;
+    }
+    if (!isValidExpression(trimmed)) {
       setError("Invalid expression. Use @every with a duration, a shorthand, or a 5-field cron.");
       return;
     }
     setError(null);
-    onChange({ cron_expression: customInput });
+    onChange({ cron_expression: trimmed });
   };
 
   return (

--- a/apps/web/components/automations/schedule-selector.tsx
+++ b/apps/web/components/automations/schedule-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
@@ -39,6 +39,14 @@ export function ScheduleSelector({ config, onChange }: ScheduleSelectorProps) {
   const configExpr = (config?.cron_expression as string) ?? "";
   const [customInput, setCustomInput] = useState(configExpr);
   const [error, setError] = useState<string | null>(null);
+
+  // Re-sync the input when the saved config arrives or changes from elsewhere
+  // (e.g. async automation fetch on page reload). useState's initial value
+  // only fires at mount, so without this the input would stay empty after
+  // a deferred load.
+  useEffect(() => {
+    setCustomInput(configExpr);
+  }, [configExpr]);
 
   const handlePreset = (expression: string) => {
     setCustomInput(expression);

--- a/apps/web/components/automations/schedule-selector.tsx
+++ b/apps/web/components/automations/schedule-selector.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconInfoCircle } from "@tabler/icons-react";
+
+type ScheduleSelectorProps = {
+  config: Record<string, unknown> | null;
+  onChange: (config: Record<string, unknown>) => void;
+};
+
+const SHORTHANDS = new Set(["@hourly", "@daily", "@weekly", "0 * * * *", "0 0 * * *", "0 0 * * 0"]);
+const EVERY_RE = /^@every\s+(\d+[hms])+$/;
+const CRON_FIELD_RE = /^(\*|\*\/\d+|\d+)(\s+(\*|\*\/\d+|\d+)){4}$/;
+
+function isValidExpression(expr: string): boolean {
+  const trimmed = expr.trim();
+  if (!trimmed) return true;
+  if (SHORTHANDS.has(trimmed)) return true;
+  if (EVERY_RE.test(trimmed)) return true;
+  if (CRON_FIELD_RE.test(trimmed)) return true;
+  return false;
+}
+
+const PRESETS = [
+  { label: "5 min", expression: "@every 5m" },
+  { label: "15 min", expression: "@every 15m" },
+  { label: "30 min", expression: "@every 30m" },
+  { label: "1 hour", expression: "@hourly" },
+  { label: "6 hours", expression: "@every 6h" },
+  { label: "Daily", expression: "@daily" },
+  { label: "Weekly", expression: "@weekly" },
+] as const;
+
+export function ScheduleSelector({ config, onChange }: ScheduleSelectorProps) {
+  const configExpr = (config?.cron_expression as string) ?? "";
+  const [customInput, setCustomInput] = useState(configExpr);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePreset = (expression: string) => {
+    setCustomInput(expression);
+    setError(null);
+    onChange({ cron_expression: expression });
+  };
+
+  const handleCustomBlur = () => {
+    if (!customInput) return;
+    if (!isValidExpression(customInput)) {
+      setError("Invalid expression. Use @every with a duration, a shorthand, or a 5-field cron.");
+      return;
+    }
+    setError(null);
+    onChange({ cron_expression: customInput });
+  };
+
+  return (
+    <div className="space-y-2" data-testid="schedule-selector">
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {PRESETS.map((preset) => (
+          <Button
+            key={preset.expression}
+            data-testid={`schedule-preset-${preset.expression}`}
+            variant={configExpr === preset.expression ? "secondary" : "outline"}
+            size="sm"
+            className="cursor-pointer"
+            onClick={() => handlePreset(preset.expression)}
+          >
+            {preset.label}
+          </Button>
+        ))}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground ml-1" />
+          </TooltipTrigger>
+          <TooltipContent className="max-w-[280px]">
+            How often to check for matching events. Checked every 30 seconds by a background
+            process. Schedules persist across backend restarts.
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs text-muted-foreground">Custom interval</Label>
+        <Input
+          value={customInput}
+          onChange={(e) => {
+            setCustomInput(e.target.value);
+            if (error) setError(null);
+          }}
+          onBlur={handleCustomBlur}
+          data-testid="schedule-custom-input"
+          placeholder="@every 2h30m"
+          className={`font-mono text-sm max-w-xs ${error ? "border-destructive" : ""}`}
+        />
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <p className="text-xs text-muted-foreground">
+          Use <code className="bg-muted px-1 rounded">@every</code> with a duration (e.g.,{" "}
+          <code className="bg-muted px-1 rounded">@every 10m</code>,{" "}
+          <code className="bg-muted px-1 rounded">@every 2h30m</code>) or shorthands like{" "}
+          <code className="bg-muted px-1 rounded">@hourly</code>,{" "}
+          <code className="bg-muted px-1 rounded">@daily</code>,{" "}
+          <code className="bg-muted px-1 rounded">@weekly</code>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/automations/trigger-card.tsx
+++ b/apps/web/components/automations/trigger-card.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { Switch } from "@kandev/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import {
+  IconClock,
+  IconBrandGithub,
+  IconWebhook,
+  IconTrash,
+  IconChevronDown,
+  IconChevronUp,
+  IconInfoCircle,
+} from "@tabler/icons-react";
+import type { AutomationTrigger, TriggerType } from "@/lib/types/automation";
+import { ScheduledConfig } from "./trigger-configs/scheduled-config";
+import { GitHubPRConfig } from "./trigger-configs/github-pr-config";
+import { GitHubPushConfig } from "./trigger-configs/github-push-config";
+import { GitHubCIConfig } from "./trigger-configs/github-ci-config";
+import { WebhookConfig } from "./trigger-configs/webhook-config";
+
+type TriggerCardProps = {
+  trigger: AutomationTrigger;
+  automationId: string | null;
+  onUpdate: (config: Record<string, unknown>) => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  onDelete: () => void;
+};
+
+const TRIGGER_ICON: Record<TriggerType, typeof IconClock> = {
+  scheduled: IconClock,
+  github_pr: IconBrandGithub,
+  github_push: IconBrandGithub,
+  github_ci: IconBrandGithub,
+  webhook: IconWebhook,
+};
+
+const TRIGGER_COLOR: Record<TriggerType, string> = {
+  scheduled: "text-blue-400",
+  github_pr: "text-purple-400",
+  github_push: "text-purple-400",
+  github_ci: "text-purple-400",
+  webhook: "text-orange-400",
+};
+
+const CRON_PRESETS: Record<string, string> = {
+  "@hourly": "Every hour",
+  "0 * * * *": "Every hour",
+  "@daily": "Every day",
+  "0 0 * * *": "Every day",
+  "@weekly": "Every week",
+  "0 0 * * 0": "Every week",
+};
+
+const SIMPLE_SUMMARIES: Partial<Record<TriggerType, string>> = {
+  github_push: "Push to branch",
+  github_ci: "CI completed",
+  webhook: "Webhook",
+};
+
+const TRIGGER_INFO: Record<TriggerType, string> = {
+  scheduled: "Checked every 30 seconds. Fires when the cron schedule matches.",
+  github_pr: "Polls GitHub API on your schedule for PRs matching your filters.",
+  github_push: "Not yet implemented.",
+  github_ci: "Not yet implemented.",
+  webhook: "Fires immediately when a POST request hits the webhook URL.",
+};
+
+function getTriggerSummary(trigger: AutomationTrigger): string {
+  const simple = SIMPLE_SUMMARIES[trigger.type];
+  if (simple) return simple;
+
+  const cfg = trigger.config;
+  if (trigger.type === "scheduled") {
+    const expr = (cfg.cron_expression as string) ?? "";
+    return CRON_PRESETS[expr] ?? (expr ? `Cron: ${expr}` : "Custom schedule");
+  }
+  if (trigger.type === "github_pr") {
+    const events = (cfg.events as string[]) ?? [];
+    return events.length > 0 ? `PR: ${events.join(", ")}` : "Pull request event";
+  }
+  return trigger.type;
+}
+
+export function TriggerCard({
+  trigger,
+  automationId,
+  onUpdate,
+  onToggleEnabled,
+  onDelete,
+}: TriggerCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const Icon = TRIGGER_ICON[trigger.type];
+  const color = TRIGGER_COLOR[trigger.type];
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Icon className={`h-4 w-4 ${color} shrink-0`} />
+        <button
+          className="flex-1 text-sm text-left cursor-pointer hover:underline"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {getTriggerSummary(trigger)}
+        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          </TooltipTrigger>
+          <TooltipContent>{TRIGGER_INFO[trigger.type]}</TooltipContent>
+        </Tooltip>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="cursor-pointer"
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded ? (
+            <IconChevronUp className="h-3.5 w-3.5" />
+          ) : (
+            <IconChevronDown className="h-3.5 w-3.5" />
+          )}
+        </Button>
+        <Switch
+          size="sm"
+          checked={trigger.enabled}
+          onCheckedChange={onToggleEnabled}
+          className="cursor-pointer"
+        />
+        <Button variant="ghost" size="icon-sm" className="cursor-pointer" onClick={onDelete}>
+          <IconTrash className="h-3.5 w-3.5 text-destructive" />
+        </Button>
+      </div>
+      {expanded && (
+        <div className="px-4 pb-4 pt-1 border-t">
+          <TriggerConfigForm trigger={trigger} automationId={automationId} onUpdate={onUpdate} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TriggerConfigForm({
+  trigger,
+  automationId,
+  onUpdate,
+}: {
+  trigger: AutomationTrigger;
+  automationId: string | null;
+  onUpdate: (config: Record<string, unknown>) => void;
+}) {
+  switch (trigger.type) {
+    case "scheduled":
+      return <ScheduledConfig config={trigger.config} onUpdate={onUpdate} />;
+    case "github_pr":
+      return <GitHubPRConfig config={trigger.config} onUpdate={onUpdate} />;
+    case "github_push":
+      return <GitHubPushConfig config={trigger.config} onUpdate={onUpdate} />;
+    case "github_ci":
+      return <GitHubCIConfig config={trigger.config} onUpdate={onUpdate} />;
+    case "webhook":
+      return <WebhookConfig automationId={automationId} />;
+    default:
+      return <p className="text-sm text-muted-foreground">Unknown trigger type</p>;
+  }
+}

--- a/apps/web/components/automations/trigger-configs/github-ci-config.tsx
+++ b/apps/web/components/automations/trigger-configs/github-ci-config.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { Checkbox } from "@kandev/ui/checkbox";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+
+type GitHubCIConfigProps = {
+  config: Record<string, unknown>;
+  onUpdate: (config: Record<string, unknown>) => void;
+};
+
+const CI_CONCLUSIONS = [
+  { value: "success", label: "Success" },
+  { value: "failure", label: "Failure" },
+  { value: "cancelled", label: "Cancelled" },
+] as const;
+
+export function GitHubCIConfig({ config, onUpdate }: GitHubCIConfigProps) {
+  const conclusions = (config.conclusions as string[]) ?? [];
+  const [checkNames, setCheckNames] = useState(((config.check_names as string[]) ?? []).join(", "));
+
+  const toggleConclusion = (conclusion: string) => {
+    const next = conclusions.includes(conclusion)
+      ? conclusions.filter((c) => c !== conclusion)
+      : [...conclusions, conclusion];
+    onUpdate({ ...config, conclusions: next });
+  };
+
+  const handleCheckNamesBlur = () => {
+    const parsed = checkNames
+      .split(",")
+      .map((n) => n.trim())
+      .filter(Boolean);
+    onUpdate({ ...config, check_names: parsed });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label className="text-xs">Conclusions</Label>
+        <div className="flex flex-wrap gap-3">
+          {CI_CONCLUSIONS.map((c) => (
+            <label key={c.value} className="flex items-center gap-1.5 cursor-pointer">
+              <Checkbox
+                checked={conclusions.includes(c.value)}
+                onCheckedChange={() => toggleConclusion(c.value)}
+                className="cursor-pointer"
+              />
+              <span className="text-sm">{c.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs">Check names (comma-separated, optional)</Label>
+        <Input
+          value={checkNames}
+          onChange={(e) => setCheckNames(e.target.value)}
+          onBlur={handleCheckNamesBlur}
+          placeholder="build, test, lint"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/automations/trigger-configs/github-ci-config.tsx
+++ b/apps/web/components/automations/trigger-configs/github-ci-config.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Checkbox } from "@kandev/ui/checkbox";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
@@ -18,7 +18,11 @@ const CI_CONCLUSIONS = [
 
 export function GitHubCIConfig({ config, onUpdate }: GitHubCIConfigProps) {
   const conclusions = (config.conclusions as string[]) ?? [];
-  const [checkNames, setCheckNames] = useState(((config.check_names as string[]) ?? []).join(", "));
+  const configCheckNames = ((config.check_names as string[]) ?? []).join(", ");
+  const [checkNames, setCheckNames] = useState(configCheckNames);
+  useEffect(() => {
+    setCheckNames(configCheckNames);
+  }, [configCheckNames]);
 
   const toggleConclusion = (conclusion: string) => {
     const next = conclusions.includes(conclusion)

--- a/apps/web/components/automations/trigger-configs/github-pr-config.tsx
+++ b/apps/web/components/automations/trigger-configs/github-pr-config.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { Checkbox } from "@kandev/ui/checkbox";
+import { Label } from "@kandev/ui/label";
+import { Input } from "@kandev/ui/input";
+import { Switch } from "@kandev/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconInfoCircle } from "@tabler/icons-react";
+import { RepoFilterSelector } from "@/components/github/repo-filter-selector";
+import type { RepoFilter } from "@/lib/types/github";
+
+type GitHubPRConfigProps = {
+  config: Record<string, unknown>;
+  onUpdate: (config: Record<string, unknown>) => void;
+};
+
+const PR_EVENTS = [
+  {
+    value: "opened",
+    label: "Opened",
+    tooltip:
+      "Fires once when a new open PR is detected. Each PR number is deduped — the same PR won't trigger again.",
+  },
+] as const;
+
+export function GitHubPRConfig({ config, onUpdate }: GitHubPRConfigProps) {
+  const events = (config.events as string[]) ?? [];
+  const repos = (config.repos as RepoFilter[]) ?? [];
+  const allRepos = (config.all_repos as boolean) ?? true;
+  const [branches, setBranches] = useState(((config.branches as string[]) ?? []).join(", "));
+  const [authors, setAuthors] = useState(((config.authors as string[]) ?? []).join(", "));
+  const excludeDraft = (config.exclude_draft as boolean) ?? false;
+
+  const toggleEvent = (event: string) => {
+    const next = events.includes(event) ? events.filter((e) => e !== event) : [...events, event];
+    onUpdate({ ...config, events: next });
+  };
+
+  const handleBranchesBlur = () => {
+    const parsed = branches
+      .split(",")
+      .map((b) => b.trim())
+      .filter(Boolean);
+    onUpdate({ ...config, branches: parsed });
+  };
+
+  const handleAuthorsBlur = () => {
+    const parsed = authors
+      .split(",")
+      .map((a) => a.trim())
+      .filter(Boolean);
+    onUpdate({ ...config, authors: parsed });
+  };
+
+  return (
+    <div className="space-y-3">
+      <EventsSection events={events} onToggle={toggleEvent} />
+      <RepoFilterSelector
+        allRepos={allRepos}
+        selectedRepos={repos}
+        onAllReposChange={(checked) => {
+          onUpdate({ ...config, all_repos: checked, repos: checked ? [] : repos });
+        }}
+        onSelectedReposChange={(next) => onUpdate({ ...config, repos: next })}
+      />
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label className="text-xs">Base branches (comma-separated)</Label>
+          <Input
+            value={branches}
+            onChange={(e) => setBranches(e.target.value)}
+            onBlur={handleBranchesBlur}
+            placeholder="main, develop"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">Authors (comma-separated)</Label>
+          <Input
+            value={authors}
+            onChange={(e) => setAuthors(e.target.value)}
+            onBlur={handleAuthorsBlur}
+            placeholder="alice, bob"
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch
+          size="sm"
+          checked={excludeDraft}
+          onCheckedChange={(checked) => onUpdate({ ...config, exclude_draft: checked })}
+          className="cursor-pointer"
+        />
+        <Label className="text-xs">Exclude draft PRs</Label>
+      </div>
+    </div>
+  );
+}
+
+function EventsSection({
+  events,
+  onToggle,
+}: {
+  events: string[];
+  onToggle: (event: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs">Events</Label>
+      <div className="flex flex-wrap gap-3">
+        {PR_EVENTS.map((evt) => (
+          <label key={evt.value} className="flex items-center gap-1.5 cursor-pointer">
+            <Checkbox
+              checked={events.includes(evt.value)}
+              onCheckedChange={() => onToggle(evt.value)}
+              className="cursor-pointer"
+            />
+            <span className="text-sm">{evt.label}</span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <IconInfoCircle className="h-3 w-3 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[220px]">{evt.tooltip}</TooltipContent>
+            </Tooltip>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/automations/trigger-configs/github-pr-config.tsx
+++ b/apps/web/components/automations/trigger-configs/github-pr-config.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Checkbox } from "@kandev/ui/checkbox";
 import { Label } from "@kandev/ui/label";
 import { Input } from "@kandev/ui/input";
@@ -28,8 +28,16 @@ export function GitHubPRConfig({ config, onUpdate }: GitHubPRConfigProps) {
   const events = (config.events as string[]) ?? [];
   const repos = (config.repos as RepoFilter[]) ?? [];
   const allRepos = (config.all_repos as boolean) ?? true;
-  const [branches, setBranches] = useState(((config.branches as string[]) ?? []).join(", "));
-  const [authors, setAuthors] = useState(((config.authors as string[]) ?? []).join(", "));
+  const configBranches = ((config.branches as string[]) ?? []).join(", ");
+  const configAuthors = ((config.authors as string[]) ?? []).join(", ");
+  const [branches, setBranches] = useState(configBranches);
+  const [authors, setAuthors] = useState(configAuthors);
+  useEffect(() => {
+    setBranches(configBranches);
+  }, [configBranches]);
+  useEffect(() => {
+    setAuthors(configAuthors);
+  }, [configAuthors]);
   const excludeDraft = (config.exclude_draft as boolean) ?? false;
 
   const toggleEvent = (event: string) => {

--- a/apps/web/components/automations/trigger-configs/github-push-config.tsx
+++ b/apps/web/components/automations/trigger-configs/github-push-config.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+
+type GitHubPushConfigProps = {
+  config: Record<string, unknown>;
+  onUpdate: (config: Record<string, unknown>) => void;
+};
+
+export function GitHubPushConfig({ config, onUpdate }: GitHubPushConfigProps) {
+  const [branches, setBranches] = useState(((config.branches as string[]) ?? []).join(", "));
+
+  const handleBlur = () => {
+    const parsed = branches
+      .split(",")
+      .map((b) => b.trim())
+      .filter(Boolean);
+    onUpdate({ ...config, branches: parsed });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs">Branch patterns (comma-separated, supports globs)</Label>
+        <Input
+          value={branches}
+          onChange={(e) => setBranches(e.target.value)}
+          onBlur={handleBlur}
+          placeholder="main, release/*"
+        />
+        <p className="text-xs text-muted-foreground">
+          Triggers when code is pushed to matching branches
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/automations/trigger-configs/github-push-config.tsx
+++ b/apps/web/components/automations/trigger-configs/github-push-config.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
 
@@ -10,7 +10,11 @@ type GitHubPushConfigProps = {
 };
 
 export function GitHubPushConfig({ config, onUpdate }: GitHubPushConfigProps) {
-  const [branches, setBranches] = useState(((config.branches as string[]) ?? []).join(", "));
+  const configBranches = ((config.branches as string[]) ?? []).join(", ");
+  const [branches, setBranches] = useState(configBranches);
+  useEffect(() => {
+    setBranches(configBranches);
+  }, [configBranches]);
 
   const handleBlur = () => {
     const parsed = branches

--- a/apps/web/components/automations/trigger-configs/scheduled-config.tsx
+++ b/apps/web/components/automations/trigger-configs/scheduled-config.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+
+type ScheduledConfigProps = {
+  config: Record<string, unknown>;
+  onUpdate: (config: Record<string, unknown>) => void;
+};
+
+const PRESETS = [
+  { label: "Every hour", expression: "@hourly" },
+  { label: "Every day", expression: "@daily" },
+  { label: "Every week", expression: "@weekly" },
+] as const;
+
+export function ScheduledConfig({ config, onUpdate }: ScheduledConfigProps) {
+  const [cronExpression, setCronExpression] = useState((config.cron_expression as string) ?? "");
+
+  const handlePreset = (expression: string) => {
+    setCronExpression(expression);
+    onUpdate({ ...config, cron_expression: expression });
+  };
+
+  const handleCustomChange = (value: string) => {
+    setCronExpression(value);
+  };
+
+  const handleCustomBlur = () => {
+    onUpdate({ ...config, cron_expression: cronExpression });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        {PRESETS.map((preset) => (
+          <Button
+            key={preset.expression}
+            variant={cronExpression === preset.expression ? "secondary" : "outline"}
+            size="sm"
+            className="cursor-pointer"
+            onClick={() => handlePreset(preset.expression)}
+          >
+            {preset.label}
+          </Button>
+        ))}
+      </div>
+      <div className="space-y-1.5">
+        <Label className="text-xs">Cron expression</Label>
+        <Input
+          value={cronExpression}
+          onChange={(e) => handleCustomChange(e.target.value)}
+          onBlur={handleCustomBlur}
+          placeholder="*/5 * * * *"
+          className="font-mono text-sm"
+        />
+        <p className="text-xs text-muted-foreground">
+          Standard 5-field cron or shortcuts (@hourly, @daily, @weekly, @every 5m)
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/automations/trigger-configs/scheduled-config.tsx
+++ b/apps/web/components/automations/trigger-configs/scheduled-config.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
 import { Label } from "@kandev/ui/label";
@@ -17,7 +17,11 @@ const PRESETS = [
 ] as const;
 
 export function ScheduledConfig({ config, onUpdate }: ScheduledConfigProps) {
-  const [cronExpression, setCronExpression] = useState((config.cron_expression as string) ?? "");
+  const configExpr = (config.cron_expression as string) ?? "";
+  const [cronExpression, setCronExpression] = useState(configExpr);
+  useEffect(() => {
+    setCronExpression(configExpr);
+  }, [configExpr]);
 
   const handlePreset = (expression: string) => {
     setCronExpression(expression);

--- a/apps/web/components/automations/trigger-configs/webhook-config.tsx
+++ b/apps/web/components/automations/trigger-configs/webhook-config.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { Button } from "@kandev/ui/button";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import { Textarea } from "@kandev/ui/textarea";
+import { IconCopy, IconCheck } from "@tabler/icons-react";
+
+type WebhookConfigProps = {
+  automationId: string | null;
+};
+
+function extractKeys(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return Object.keys(parsed);
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return [];
+}
+
+export function WebhookConfig({ automationId }: WebhookConfigProps) {
+  const [copied, setCopied] = useState<"url" | null>(null);
+  const [samplePayload, setSamplePayload] = useState("");
+
+  const copyToClipboard = useCallback(async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied("url");
+    setTimeout(() => setCopied(null), 2000);
+  }, []);
+
+  const detectedKeys = useMemo(() => extractKeys(samplePayload), [samplePayload]);
+
+  if (!automationId) {
+    return (
+      <div className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Webhook URL will be available after saving the automation.
+        </p>
+        <SamplePayloadSection
+          samplePayload={samplePayload}
+          onChange={setSamplePayload}
+          detectedKeys={detectedKeys}
+        />
+      </div>
+    );
+  }
+
+  const webhookUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/api/v1/automations/webhook/${automationId}`
+      : `/api/v1/automations/webhook/${automationId}`;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label className="text-xs">Webhook URL</Label>
+        <div className="flex gap-2">
+          <Input value={webhookUrl} readOnly className="font-mono text-xs" />
+          <Button
+            variant="outline"
+            size="sm"
+            className="cursor-pointer shrink-0"
+            onClick={() => copyToClipboard(webhookUrl)}
+          >
+            {copied === "url" ? (
+              <IconCheck className="h-3.5 w-3.5" />
+            ) : (
+              <IconCopy className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Send a POST request with JSON body. Auth via{" "}
+          <code className="bg-muted px-1 rounded">X-Webhook-Secret</code> header or{" "}
+          <code className="bg-muted px-1 rounded">?secret=</code> query parameter.
+        </p>
+      </div>
+      <SamplePayloadSection
+        samplePayload={samplePayload}
+        onChange={setSamplePayload}
+        detectedKeys={detectedKeys}
+      />
+    </div>
+  );
+}
+
+function SamplePayloadSection({
+  samplePayload,
+  onChange,
+  detectedKeys,
+}: {
+  samplePayload: string;
+  onChange: (value: string) => void;
+  detectedKeys: string[];
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="space-y-1.5">
+        <Label className="text-xs">Sample payload (optional)</Label>
+        <Textarea
+          value={samplePayload}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder='{"repo": "org/app", "env": "prod"}'
+          className="font-mono text-xs min-h-[60px] resize-y"
+          rows={2}
+        />
+        <p className="text-xs text-muted-foreground">
+          Paste an example JSON body to discover available placeholders.
+        </p>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Available placeholders</Label>
+        <div className="flex flex-wrap gap-1.5">
+          <PlaceholderBadge value="webhook.body" />
+          {detectedKeys.map((key) => (
+            <PlaceholderBadge key={key} value={`data.${key}`} />
+          ))}
+          {detectedKeys.length === 0 && !samplePayload && <PlaceholderBadge value="data.*" />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PlaceholderBadge({ value }: { value: string }) {
+  return (
+    <code className="bg-muted px-1.5 py-0.5 rounded text-xs font-mono text-muted-foreground">
+      {`{{${value}}}`}
+    </code>
+  );
+}

--- a/apps/web/components/automations/trigger-picker.tsx
+++ b/apps/web/components/automations/trigger-picker.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@kandev/ui/popover";
+import { Command, CommandInput, CommandList, CommandGroup, CommandItem } from "@kandev/ui/command";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { IconPlus, IconBrandGithub, IconWebhook, IconInfoCircle } from "@tabler/icons-react";
+import type { TriggerType, TriggerTypeInfo } from "@/lib/types/automation";
+
+type TriggerPickerProps = {
+  triggerTypes: TriggerTypeInfo[];
+  onSelect: (type: TriggerType, config: Record<string, unknown>) => void;
+};
+
+type CategoryMeta = {
+  heading: string;
+  icon: typeof IconBrandGithub;
+  color: string;
+};
+
+const CATEGORY_META: Record<string, CategoryMeta> = {
+  github: { heading: "GitHub", icon: IconBrandGithub, color: "text-purple-400" },
+  webhook: { heading: "Webhook", icon: IconWebhook, color: "text-blue-400" },
+};
+
+export function TriggerPicker({ triggerTypes, onSelect }: TriggerPickerProps) {
+  const [open, setOpen] = useState(false);
+
+  // Only show condition types (not schedule — that's handled separately).
+  const conditionTypes = useMemo(
+    () => triggerTypes.filter((t) => t.category !== "schedule"),
+    [triggerTypes],
+  );
+
+  const groups = useMemo(() => {
+    const byCategory = new Map<string, TriggerTypeInfo[]>();
+    for (const t of conditionTypes) {
+      const list = byCategory.get(t.category) ?? [];
+      list.push(t);
+      byCategory.set(t.category, list);
+    }
+    return Array.from(byCategory.entries());
+  }, [conditionTypes]);
+
+  const handleSelect = (info: TriggerTypeInfo) => {
+    if (!info.enabled) return;
+    onSelect(info.type, info.default_config);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          data-testid="add-condition-button"
+          variant="ghost"
+          size="sm"
+          className="cursor-pointer text-muted-foreground"
+        >
+          <IconPlus className="h-4 w-4 mr-1" />
+          Add Condition
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search conditions..." />
+          <CommandList>
+            {groups.map(([category, items]) => {
+              const meta = CATEGORY_META[category];
+              if (!meta) return null;
+              return (
+                <PickerGroup
+                  key={category}
+                  heading={meta.heading}
+                  icon={meta.icon}
+                  color={meta.color}
+                  items={items}
+                  onSelect={handleSelect}
+                />
+              );
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function PickerGroup({
+  heading,
+  icon: Icon,
+  color,
+  items,
+  onSelect,
+}: {
+  heading: string;
+  icon: typeof IconBrandGithub;
+  color: string;
+  items: TriggerTypeInfo[];
+  onSelect: (info: TriggerTypeInfo) => void;
+}) {
+  return (
+    <CommandGroup heading={heading}>
+      {items.map((item) => (
+        <CommandItem
+          key={item.type}
+          onSelect={() => onSelect(item)}
+          disabled={!item.enabled}
+          className={!item.enabled ? "opacity-50" : "cursor-pointer"}
+        >
+          <Icon className={`h-4 w-4 mr-2 ${color}`} />
+          <span className="flex-1">
+            {item.label}
+            {!item.enabled && " (Coming soon)"}
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            </TooltipTrigger>
+            <TooltipContent side="right" className="max-w-[220px]">
+              {item.description}
+            </TooltipContent>
+          </Tooltip>
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  );
+}

--- a/apps/web/components/automations/triggers-section.tsx
+++ b/apps/web/components/automations/triggers-section.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button } from "@kandev/ui/button";
+import { Label } from "@kandev/ui/label";
+import type { AutomationTrigger, TriggerType, TriggerTypeInfo } from "@/lib/types/automation";
+import { ScheduleSelector } from "./schedule-selector";
+import { TriggerCard } from "./trigger-card";
+import { TriggerPicker } from "./trigger-picker";
+
+type TriggersSectionProps = {
+  triggers: AutomationTrigger[];
+  automationId: string | null;
+  triggerTypes: TriggerTypeInfo[];
+  onAddTrigger: (type: TriggerType, config: Record<string, unknown>) => void;
+  onUpdateTrigger: (triggerId: string, config: Record<string, unknown>) => void;
+  onToggleTrigger: (triggerId: string, enabled: boolean) => void;
+  onDeleteTrigger: (triggerId: string) => void;
+};
+
+export function TriggersSection({
+  triggers,
+  automationId,
+  triggerTypes,
+  onAddTrigger,
+  onUpdateTrigger,
+  onToggleTrigger,
+  onDeleteTrigger,
+}: TriggersSectionProps) {
+  const webhookTrigger = useMemo(() => triggers.find((t) => t.type === "webhook"), [triggers]);
+  const isWebhookMode = !!webhookTrigger;
+
+  const scheduleTrigger = useMemo(() => triggers.find((t) => t.type === "scheduled"), [triggers]);
+  const conditionTrigger = useMemo(
+    () => triggers.find((t) => t.type !== "scheduled" && t.type !== "webhook"),
+    [triggers],
+  );
+
+  const handleScheduleChange = (config: Record<string, unknown>) => {
+    if (scheduleTrigger) {
+      onUpdateTrigger(scheduleTrigger.id, config);
+    } else {
+      onAddTrigger("scheduled", config);
+    }
+  };
+
+  const handleAddWebhook = () => {
+    onAddTrigger("webhook", {});
+  };
+
+  const handleRemoveWebhook = () => {
+    if (webhookTrigger) onDeleteTrigger(webhookTrigger.id);
+  };
+
+  if (isWebhookMode) {
+    return (
+      <div className="space-y-3">
+        <TriggerCard
+          trigger={webhookTrigger}
+          automationId={automationId}
+          onUpdate={(config) => onUpdateTrigger(webhookTrigger.id, config)}
+          onToggleEnabled={(enabled) => onToggleTrigger(webhookTrigger.id, enabled)}
+          onDelete={handleRemoveWebhook}
+        />
+        <SwitchModeButton label="Switch to scheduled" onClick={handleRemoveWebhook} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <ScheduleArea scheduleTrigger={scheduleTrigger} onScheduleChange={handleScheduleChange} />
+      <ConditionArea
+        trigger={conditionTrigger}
+        automationId={automationId}
+        triggerTypes={triggerTypes}
+        onAddTrigger={onAddTrigger}
+        onUpdateTrigger={onUpdateTrigger}
+        onToggleTrigger={onToggleTrigger}
+        onDeleteTrigger={onDeleteTrigger}
+      />
+      <SwitchModeButton label="Or use a webhook instead" onClick={handleAddWebhook} />
+    </div>
+  );
+}
+
+function ScheduleArea({
+  scheduleTrigger,
+  onScheduleChange,
+}: {
+  scheduleTrigger: AutomationTrigger | undefined;
+  onScheduleChange: (config: Record<string, unknown>) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs font-medium">Schedule</Label>
+      <ScheduleSelector config={scheduleTrigger?.config ?? null} onChange={onScheduleChange} />
+    </div>
+  );
+}
+
+function ConditionArea({
+  trigger,
+  automationId,
+  triggerTypes,
+  onAddTrigger,
+  onUpdateTrigger,
+  onToggleTrigger,
+  onDeleteTrigger,
+}: {
+  trigger: AutomationTrigger | undefined;
+  automationId: string | null;
+  triggerTypes: TriggerTypeInfo[];
+  onAddTrigger: (type: TriggerType, config: Record<string, unknown>) => void;
+  onUpdateTrigger: (triggerId: string, config: Record<string, unknown>) => void;
+  onToggleTrigger: (triggerId: string, enabled: boolean) => void;
+  onDeleteTrigger: (triggerId: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs font-medium">Watch for</Label>
+      {trigger ? (
+        <div className="space-y-2">
+          <TriggerCard
+            trigger={trigger}
+            automationId={automationId}
+            onUpdate={(config) => onUpdateTrigger(trigger.id, config)}
+            onToggleEnabled={(enabled) => onToggleTrigger(trigger.id, enabled)}
+            onDelete={() => onDeleteTrigger(trigger.id)}
+          />
+        </div>
+      ) : (
+        <TriggerPicker triggerTypes={triggerTypes} onSelect={onAddTrigger} />
+      )}
+    </div>
+  );
+}
+
+function SwitchModeButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="cursor-pointer text-xs text-muted-foreground"
+      onClick={onClick}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/apps/web/components/automations/triggers-section.tsx
+++ b/apps/web/components/automations/triggers-section.tsx
@@ -45,6 +45,11 @@ export function TriggersSection({
   };
 
   const handleAddWebhook = () => {
+    // Switching to webhook mode is exclusive: any pre-existing scheduled /
+    // condition triggers must be deleted, otherwise they keep firing in the
+    // background while the UI only shows the webhook trigger.
+    if (scheduleTrigger) onDeleteTrigger(scheduleTrigger.id);
+    if (conditionTrigger) onDeleteTrigger(conditionTrigger.id);
     onAddTrigger("webhook", {});
   };
 

--- a/apps/web/components/settings/settings-app-sidebar.tsx
+++ b/apps/web/components/settings/settings-app-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   IconArrowsShuffle,
   IconTicket,
   IconPlugConnected,
+  IconBolt,
 } from "@tabler/icons-react";
 import {
   Sidebar,
@@ -112,6 +113,7 @@ function WorkspacesSidebarSection({ pathname, workspaces }: WorkspacesSidebarSec
             const workspacePath = `/settings/workspace/${workspace.id}`;
             const workflowsPath = `${workspacePath}/workflows`;
             const repositoriesPath = `${workspacePath}/repositories`;
+            const automationsPath = `${workspacePath}/automations`;
 
             return (
               <SidebarMenuSubItem key={workspace.id}>
@@ -138,6 +140,18 @@ function WorkspacesSidebarSection({ pathname, workspaces }: WorkspacesSidebarSec
                       <Link href={workflowsPath}>
                         <IconArrowsShuffle className="h-3.5 w-3.5" />
                         <span>Workflows</span>
+                      </Link>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton
+                      asChild
+                      size="sm"
+                      isActive={pathname.startsWith(automationsPath)}
+                    >
+                      <Link href={automationsPath}>
+                        <IconBolt className="h-3.5 w-3.5" />
+                        <span>Automations</span>
                       </Link>
                     </SidebarMenuSubButton>
                   </SidebarMenuSubItem>

--- a/apps/web/components/settings/settings-app-sidebar.tsx
+++ b/apps/web/components/settings/settings-app-sidebar.tsx
@@ -113,7 +113,6 @@ function WorkspacesSidebarSection({ pathname, workspaces }: WorkspacesSidebarSec
             const workspacePath = `/settings/workspace/${workspace.id}`;
             const workflowsPath = `${workspacePath}/workflows`;
             const repositoriesPath = `${workspacePath}/repositories`;
-            const automationsPath = `${workspacePath}/automations`;
 
             return (
               <SidebarMenuSubItem key={workspace.id}>
@@ -140,18 +139,6 @@ function WorkspacesSidebarSection({ pathname, workspaces }: WorkspacesSidebarSec
                       <Link href={workflowsPath}>
                         <IconArrowsShuffle className="h-3.5 w-3.5" />
                         <span>Workflows</span>
-                      </Link>
-                    </SidebarMenuSubButton>
-                  </SidebarMenuSubItem>
-                  <SidebarMenuSubItem>
-                    <SidebarMenuSubButton
-                      asChild
-                      size="sm"
-                      isActive={pathname.startsWith(automationsPath)}
-                    >
-                      <Link href={automationsPath}>
-                        <IconBolt className="h-3.5 w-3.5" />
-                        <span>Automations</span>
                       </Link>
                     </SidebarMenuSubButton>
                   </SidebarMenuSubItem>
@@ -359,6 +346,23 @@ export function SettingsAppSidebar() {
                 </SidebarMenuItem>
 
                 <ExecutorsSidebarSection pathname={pathname} executors={executors} />
+
+                {/* Automations */}
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={
+                      pathname.startsWith("/settings/automations") ||
+                      pathname.includes("/automations")
+                    }
+                  >
+                    <Link href="/settings/automations">
+                      <IconBolt className="h-4 w-4" />
+                      <span>Automations</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+
                 <SecretsSidebarSection pathname={pathname} />
 
                 {/* External MCP */}

--- a/apps/web/e2e/pages/automations-page.ts
+++ b/apps/web/e2e/pages/automations-page.ts
@@ -1,0 +1,68 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class AutomationsPage {
+  readonly listPage: Locator;
+  readonly newAutomationButton: Locator;
+  readonly table: Locator;
+  readonly emptyState: Locator;
+  readonly editor: Locator;
+  readonly nameInput: Locator;
+  readonly saveButton: Locator;
+  readonly deleteButton: Locator;
+  readonly customScheduleInput: Locator;
+  readonly addConditionButton: Locator;
+  readonly workflowSelector: Locator;
+  readonly workflowStepSelector: Locator;
+
+  constructor(
+    private page: Page,
+    private workspaceId: string,
+  ) {
+    this.listPage = page.getByTestId("automations-list-page");
+    this.newAutomationButton = page.getByTestId("new-automation-button");
+    this.table = page.getByTestId("automations-table");
+    this.emptyState = page.getByTestId("automations-empty");
+    this.editor = page.getByTestId("automation-editor");
+    this.nameInput = page.getByTestId("automation-name-input");
+    this.saveButton = page.getByTestId("automation-save-button");
+    this.deleteButton = page.getByTestId("automation-delete-button");
+    this.customScheduleInput = page.getByTestId("schedule-custom-input");
+    this.addConditionButton = page.getByTestId("add-condition-button");
+    this.workflowSelector = page.getByTestId("workflow-selector");
+    this.workflowStepSelector = page.getByTestId("workflow-step-selector");
+  }
+
+  async goto() {
+    await this.page.goto(`/settings/workspace/${this.workspaceId}/automations`);
+    await this.listPage.waitFor({ state: "visible", timeout: 15_000 });
+  }
+
+  async gotoNew() {
+    await this.page.goto(`/settings/workspace/${this.workspaceId}/automations/new`);
+    await this.editor.waitFor({ state: "visible", timeout: 15_000 });
+  }
+
+  automationRow(id: string): Locator {
+    return this.page.getByTestId(`automation-row-${id}`);
+  }
+
+  enabledSwitch(id: string): Locator {
+    return this.page.getByTestId(`automation-enabled-${id}`);
+  }
+
+  schedulePreset(expression: string): Locator {
+    return this.page.getByTestId(`schedule-preset-${expression}`);
+  }
+
+  /** Select a workflow by clicking the selector and picking an item by name. */
+  async selectWorkflow(name: string) {
+    await this.workflowSelector.click();
+    await this.page.getByRole("option", { name }).click();
+  }
+
+  /** Select a workflow step by clicking the selector and picking an item by name. */
+  async selectWorkflowStep(name: string) {
+    await this.workflowStepSelector.click();
+    await this.page.getByRole("option", { name }).click();
+  }
+}

--- a/apps/web/e2e/tests/automations-settings.spec.ts
+++ b/apps/web/e2e/tests/automations-settings.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "../fixtures/test-base";
+import { AutomationsPage } from "../pages/automations-page";
+
+test.describe("Automations settings page", () => {
+  test("list page shows empty state", async ({ testPage, seedData }) => {
+    const automations = new AutomationsPage(testPage, seedData.workspaceId);
+    await automations.goto();
+
+    await expect(automations.emptyState).toBeVisible({ timeout: 10_000 });
+    await expect(automations.emptyState).toHaveText(/No automations yet/);
+  });
+
+  test("create scheduled automation via UI", async ({ testPage, seedData }) => {
+    const automations = new AutomationsPage(testPage, seedData.workspaceId);
+    await automations.goto();
+
+    // Navigate to new automation form
+    await automations.newAutomationButton.click();
+    await expect(testPage).toHaveURL(/automations\/new/, { timeout: 10_000 });
+    await expect(automations.editor).toBeVisible();
+
+    // Fill in name
+    await automations.nameInput.fill("Daily Check");
+
+    // Select a schedule preset
+    await automations.schedulePreset("@daily").click();
+
+    // Select workflow and step
+    await automations.selectWorkflow("E2E Workflow");
+    await automations.selectWorkflowStep(seedData.steps[0].name);
+
+    // Save — button should be enabled now
+    await expect(automations.saveButton).toBeEnabled({ timeout: 5_000 });
+    await automations.saveButton.click();
+
+    // Should redirect to the edit page (URL contains automation ID)
+    await expect(testPage).toHaveURL(/automations\/[a-f0-9-]+$/, { timeout: 15_000 });
+
+    // Name should persist in the input
+    await expect(automations.nameInput).toHaveValue("Daily Check");
+  });
+
+  test("create automation with custom schedule expression", async ({ testPage, seedData }) => {
+    const automations = new AutomationsPage(testPage, seedData.workspaceId);
+    await automations.gotoNew();
+
+    await automations.nameInput.fill("Custom Schedule");
+    await automations.customScheduleInput.fill("@every 2h");
+    await automations.customScheduleInput.blur();
+
+    // Select workflow and step
+    await automations.selectWorkflow("E2E Workflow");
+    await automations.selectWorkflowStep(seedData.steps[0].name);
+
+    await expect(automations.saveButton).toBeEnabled({ timeout: 5_000 });
+    await automations.saveButton.click();
+
+    await expect(testPage).toHaveURL(/automations\/[a-f0-9-]+$/, { timeout: 15_000 });
+  });
+
+  test("schedule validation rejects invalid expression", async ({ testPage, seedData }) => {
+    const automations = new AutomationsPage(testPage, seedData.workspaceId);
+    await automations.gotoNew();
+
+    await automations.customScheduleInput.fill("invalid-cron");
+    await automations.customScheduleInput.blur();
+
+    // Should show error text
+    await expect(testPage.getByText("Invalid expression")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("edit automation name", async ({ testPage, seedData }) => {
+    const automations = new AutomationsPage(testPage, seedData.workspaceId);
+
+    // Create an automation first
+    await automations.gotoNew();
+    await automations.nameInput.fill("Original Name");
+    await automations.schedulePreset("@hourly").click();
+    await automations.selectWorkflow("E2E Workflow");
+    await automations.selectWorkflowStep(seedData.steps[0].name);
+    await expect(automations.saveButton).toBeEnabled({ timeout: 5_000 });
+    await automations.saveButton.click();
+    await expect(testPage).toHaveURL(/automations\/[a-f0-9-]+$/, { timeout: 15_000 });
+
+    // Edit the name
+    await automations.nameInput.clear();
+    await automations.nameInput.fill("Updated Name");
+    await automations.saveButton.click();
+
+    // Go back to list and verify
+    await automations.goto();
+    await expect(automations.table).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByText("Updated Name")).toBeVisible();
+  });
+
+  test("delete automation from editor", async ({ testPage, seedData }) => {
+    const automations = new AutomationsPage(testPage, seedData.workspaceId);
+
+    // Create an automation first
+    await automations.gotoNew();
+    await automations.nameInput.fill("To Be Deleted");
+    await automations.schedulePreset("@weekly").click();
+    await automations.selectWorkflow("E2E Workflow");
+    await automations.selectWorkflowStep(seedData.steps[0].name);
+    await expect(automations.saveButton).toBeEnabled({ timeout: 5_000 });
+    await automations.saveButton.click();
+    await expect(testPage).toHaveURL(/automations\/[a-f0-9-]+$/, { timeout: 15_000 });
+
+    // Delete it
+    await automations.deleteButton.click();
+
+    // Should redirect to list page
+    await expect(testPage).toHaveURL(/automations$/, { timeout: 10_000 });
+
+    // The deleted automation should not appear in the list
+    await expect(testPage.getByText("To Be Deleted")).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("enable/disable toggle on list page", async ({ testPage, seedData }) => {
+    const automations = new AutomationsPage(testPage, seedData.workspaceId);
+
+    // Create an automation
+    await automations.gotoNew();
+    await automations.nameInput.fill("Toggle Test");
+    await automations.schedulePreset("@daily").click();
+    await automations.selectWorkflow("E2E Workflow");
+    await automations.selectWorkflowStep(seedData.steps[0].name);
+    await expect(automations.saveButton).toBeEnabled({ timeout: 5_000 });
+    await automations.saveButton.click();
+    await expect(testPage).toHaveURL(/automations\/[a-f0-9-]+$/, { timeout: 15_000 });
+
+    // Go back to list
+    await automations.goto();
+    await expect(automations.table).toBeVisible({ timeout: 10_000 });
+
+    // Find the toggle — automations are enabled by default.
+    // The table row containing "Toggle Test" has a switch inside it.
+    const row = testPage.locator("tr", { hasText: "Toggle Test" });
+    const toggle = row.locator('[role="switch"]');
+    await expect(toggle).toBeChecked();
+
+    // Disable it
+    await toggle.click();
+    await expect(toggle).not.toBeChecked();
+
+    // Reload and verify it persisted
+    await testPage.reload();
+    await expect(automations.table).toBeVisible({ timeout: 10_000 });
+    const rowAfterReload = testPage.locator("tr", { hasText: "Toggle Test" });
+    const toggleAfterReload = rowAfterReload.locator('[role="switch"]');
+    await expect(toggleAfterReload).not.toBeChecked();
+  });
+});

--- a/apps/web/hooks/domains/settings/use-automation-runs.ts
+++ b/apps/web/hooks/domains/settings/use-automation-runs.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+import { listAutomationRuns } from "@/lib/api/domains/automation-api";
+import { useAppStore } from "@/components/state-provider";
+import type { AutomationRun } from "@/lib/types/automation";
+
+const EMPTY_RUNS: AutomationRun[] = [];
+
+export function useAutomationRuns(automationId: string | null) {
+  const runs = useAppStore((state) =>
+    automationId ? (state.automationRuns.byAutomationId[automationId] ?? EMPTY_RUNS) : EMPTY_RUNS,
+  );
+  const loading = useAppStore((state) =>
+    automationId ? (state.automationRuns.loading[automationId] ?? false) : false,
+  );
+  const setRuns = useAppStore((state) => state.setAutomationRuns);
+  const setRunsLoading = useAppStore((state) => state.setAutomationRunsLoading);
+
+  useEffect(() => {
+    if (!automationId || loading) return;
+    setRunsLoading(automationId, true);
+    listAutomationRuns(automationId)
+      .then((result) => {
+        setRuns(automationId, result ?? []);
+      })
+      .catch(() => {
+        setRuns(automationId, []);
+      })
+      .finally(() => {
+        setRunsLoading(automationId, false);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [automationId]);
+
+  const refresh = useCallback(() => {
+    if (!automationId) return;
+    setRunsLoading(automationId, true);
+    listAutomationRuns(automationId)
+      .then((result) => {
+        setRuns(automationId, result ?? []);
+      })
+      .catch(() => {})
+      .finally(() => {
+        setRunsLoading(automationId, false);
+      });
+  }, [automationId, setRuns, setRunsLoading]);
+
+  return { runs, loading, refresh };
+}

--- a/apps/web/hooks/domains/settings/use-automations.ts
+++ b/apps/web/hooks/domains/settings/use-automations.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+import {
+  listAutomations,
+  createAutomation,
+  updateAutomation as apiUpdateAutomation,
+  deleteAutomation,
+  enableAutomation,
+  disableAutomation,
+  triggerAutomation,
+} from "@/lib/api/domains/automation-api";
+import { useAppStore } from "@/components/state-provider";
+import type { CreateAutomationRequest, UpdateAutomationRequest } from "@/lib/types/automation";
+
+export function useAutomations(workspaceId: string | null) {
+  const items = useAppStore((state) => state.automations.items);
+  const loaded = useAppStore((state) => state.automations.loaded);
+  const loading = useAppStore((state) => state.automations.loading);
+  const setAutomations = useAppStore((state) => state.setAutomations);
+  const setLoading = useAppStore((state) => state.setAutomationsLoading);
+  const addToStore = useAppStore((state) => state.addAutomation);
+  const updateInStore = useAppStore((state) => state.updateAutomation);
+  const removeFromStore = useAppStore((state) => state.removeAutomation);
+
+  useEffect(() => {
+    if (!workspaceId || loaded || loading) return;
+    setLoading(true);
+    listAutomations(workspaceId)
+      .then((result) => {
+        setAutomations(result ?? []);
+      })
+      .catch(() => {
+        setAutomations([]);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [workspaceId, loaded, loading, setAutomations, setLoading]);
+
+  const create = useCallback(
+    async (req: CreateAutomationRequest) => {
+      const automation = await createAutomation(req);
+      addToStore(automation);
+      return automation;
+    },
+    [addToStore],
+  );
+
+  const update = useCallback(
+    async (id: string, req: UpdateAutomationRequest) => {
+      const automation = await apiUpdateAutomation(id, req);
+      updateInStore(automation);
+      return automation;
+    },
+    [updateInStore],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      await deleteAutomation(id);
+      removeFromStore(id);
+    },
+    [removeFromStore],
+  );
+
+  const enable = useCallback(
+    async (id: string) => {
+      const automation = await enableAutomation(id);
+      updateInStore(automation);
+      return automation;
+    },
+    [updateInStore],
+  );
+
+  const disable = useCallback(
+    async (id: string) => {
+      const automation = await disableAutomation(id);
+      updateInStore(automation);
+      return automation;
+    },
+    [updateInStore],
+  );
+
+  const trigger = useCallback(async (id: string) => {
+    return triggerAutomation(id);
+  }, []);
+
+  const refresh = useCallback(() => {
+    if (!workspaceId) return;
+    setLoading(true);
+    listAutomations(workspaceId)
+      .then((result) => {
+        setAutomations(result ?? []);
+      })
+      .catch(() => {})
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [workspaceId, setAutomations, setLoading]);
+
+  return { items, loaded, loading, create, update, remove, enable, disable, trigger, refresh };
+}

--- a/apps/web/hooks/domains/settings/use-automations.ts
+++ b/apps/web/hooks/domains/settings/use-automations.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import {
   listAutomations,
   createAutomation,
@@ -15,7 +15,6 @@ import type { CreateAutomationRequest, UpdateAutomationRequest } from "@/lib/typ
 
 export function useAutomations(workspaceId: string | null) {
   const items = useAppStore((state) => state.automations.items);
-  const loaded = useAppStore((state) => state.automations.loaded);
   const loading = useAppStore((state) => state.automations.loading);
   const setAutomations = useAppStore((state) => state.setAutomations);
   const setLoading = useAppStore((state) => state.setAutomationsLoading);
@@ -23,20 +22,42 @@ export function useAutomations(workspaceId: string | null) {
   const updateInStore = useAppStore((state) => state.updateAutomation);
   const removeFromStore = useAppStore((state) => state.removeAutomation);
 
+  // Track which workspace the current store contents belong to so a
+  // workspace switch refetches instead of serving stale data from the
+  // previous workspace. Also gate the response apply behind the in-flight
+  // workspace id to drop late responses that arrive after a quick switch.
+  //
+  // loadedWorkspaceRef is a ref (not state) so the effect guard on line
+  // below does not create a stale-closure problem. loadedWorkspaceId is
+  // the parallel state copy used only for the render-time `loaded` flag.
+  const loadedWorkspaceRef = useRef<string | null>(null);
+  const inFlightWorkspaceRef = useRef<string | null>(null);
+  const [loadedWorkspaceId, setLoadedWorkspaceId] = useState<string | null>(null);
+
   useEffect(() => {
-    if (!workspaceId || loaded || loading) return;
+    if (!workspaceId) return;
+    if (loadedWorkspaceRef.current === workspaceId) return;
+    inFlightWorkspaceRef.current = workspaceId;
     setLoading(true);
     listAutomations(workspaceId)
       .then((result) => {
+        if (inFlightWorkspaceRef.current !== workspaceId) return; // stale
         setAutomations(result ?? []);
+        loadedWorkspaceRef.current = workspaceId;
+        setLoadedWorkspaceId(workspaceId);
       })
       .catch(() => {
+        if (inFlightWorkspaceRef.current !== workspaceId) return;
         setAutomations([]);
+        loadedWorkspaceRef.current = workspaceId;
+        setLoadedWorkspaceId(workspaceId);
       })
       .finally(() => {
-        setLoading(false);
+        if (inFlightWorkspaceRef.current === workspaceId) {
+          setLoading(false);
+        }
       });
-  }, [workspaceId, loaded, loading, setAutomations, setLoading]);
+  }, [workspaceId, setAutomations, setLoading]);
 
   const create = useCallback(
     async (req: CreateAutomationRequest) => {
@@ -88,16 +109,20 @@ export function useAutomations(workspaceId: string | null) {
 
   const refresh = useCallback(() => {
     if (!workspaceId) return;
+    inFlightWorkspaceRef.current = workspaceId;
     setLoading(true);
     listAutomations(workspaceId)
       .then((result) => {
+        if (inFlightWorkspaceRef.current !== workspaceId) return;
         setAutomations(result ?? []);
       })
       .catch(() => {})
       .finally(() => {
-        setLoading(false);
+        if (inFlightWorkspaceRef.current === workspaceId) setLoading(false);
       });
   }, [workspaceId, setAutomations, setLoading]);
 
+  // loaded mirrors "are we on the workspace we've fetched at least once?"
+  const loaded = loadedWorkspaceId === workspaceId;
   return { items, loaded, loading, create, update, remove, enable, disable, trigger, refresh };
 }

--- a/apps/web/lib/api/domains/automation-api.ts
+++ b/apps/web/lib/api/domains/automation-api.ts
@@ -1,0 +1,83 @@
+import { getWebSocketClient } from "@/lib/ws/connection";
+import type {
+  Automation,
+  AutomationRun,
+  CreateAutomationRequest,
+  UpdateAutomationRequest,
+  AddTriggerRequest,
+  UpdateTriggerRequest,
+  AutomationTrigger,
+  TriggerTypeInfo,
+} from "@/lib/types/automation";
+
+const WS_UNAVAILABLE = "WebSocket client not available";
+
+function requireClient() {
+  const client = getWebSocketClient();
+  if (!client) throw new Error(WS_UNAVAILABLE);
+  return client;
+}
+
+export async function listAutomations(workspaceId: string): Promise<Automation[]> {
+  return requireClient().request<Automation[]>("automation.list", { workspace_id: workspaceId });
+}
+
+export async function getAutomation(id: string): Promise<Automation> {
+  return requireClient().request<Automation>("automation.get", { id });
+}
+
+export async function createAutomation(req: CreateAutomationRequest): Promise<Automation> {
+  return requireClient().request<Automation>("automation.create", req);
+}
+
+export async function updateAutomation(
+  id: string,
+  req: UpdateAutomationRequest,
+): Promise<Automation> {
+  return requireClient().request<Automation>("automation.update", { id, ...req });
+}
+
+export async function deleteAutomation(id: string): Promise<void> {
+  await requireClient().request("automation.delete", { id });
+}
+
+export async function enableAutomation(id: string): Promise<Automation> {
+  return requireClient().request<Automation>("automation.enable", { id });
+}
+
+export async function disableAutomation(id: string): Promise<Automation> {
+  return requireClient().request<Automation>("automation.disable", { id });
+}
+
+export async function triggerAutomation(id: string): Promise<{ triggered: boolean }> {
+  return requireClient().request<{ triggered: boolean }>("automation.trigger", { id });
+}
+
+export async function listAutomationRuns(
+  automationId: string,
+  limit?: number,
+): Promise<AutomationRun[]> {
+  return requireClient().request<AutomationRun[]>("automation.runs.list", {
+    automation_id: automationId,
+    ...(limit ? { limit } : {}),
+  });
+}
+
+export async function addTrigger(req: AddTriggerRequest): Promise<AutomationTrigger> {
+  return requireClient().request<AutomationTrigger>("automation.trigger.add", req);
+}
+
+export async function updateTrigger(
+  id: string,
+  req: UpdateTriggerRequest,
+): Promise<{ updated: boolean }> {
+  return requireClient().request<{ updated: boolean }>("automation.trigger.update", { id, ...req });
+}
+
+export async function deleteTrigger(id: string): Promise<{ deleted: boolean }> {
+  return requireClient().request<{ deleted: boolean }>("automation.trigger.delete", { id });
+}
+
+export async function listTriggerTypes(): Promise<TriggerTypeInfo[]> {
+  return requireClient().request<TriggerTypeInfo[]>("automation.trigger_types", {});
+}

--- a/apps/web/lib/state/default-state.ts
+++ b/apps/web/lib/state/default-state.ts
@@ -10,6 +10,7 @@ import {
   defaultLinearState,
   defaultOfficeState,
   defaultFeaturesState,
+  defaultAutomationsState,
 } from "./slices";
 
 export const defaultState = {
@@ -70,6 +71,8 @@ export const defaultState = {
   linearIssueWatches: defaultLinearState.linearIssueWatches,
   office: defaultOfficeState.office,
   features: defaultFeaturesState.features,
+  automations: defaultAutomationsState.automations,
+  automationRuns: defaultAutomationsState.automationRuns,
   previewPanel: defaultUIState.previewPanel,
   rightPanel: defaultUIState.rightPanel,
   diffs: defaultUIState.diffs,
@@ -161,6 +164,8 @@ export function mergeInitialState(initialState?: Partial<DefaultState>): Default
     },
     office: { ...defaultState.office, ...initialState.office },
     features: { ...defaultState.features, ...initialState.features },
+    automations: { ...defaultState.automations, ...initialState.automations },
+    automationRuns: { ...defaultState.automationRuns, ...initialState.automationRuns },
     previewPanel: { ...defaultState.previewPanel, ...initialState.previewPanel },
     rightPanel: { ...defaultState.rightPanel, ...initialState.rightPanel },
     diffs: { ...defaultState.diffs, ...initialState.diffs },

--- a/apps/web/lib/state/slices/automations/automations-slice.ts
+++ b/apps/web/lib/state/slices/automations/automations-slice.ts
@@ -68,7 +68,7 @@ export const createAutomationsSlice: StateCreator<
   [["zustand/immer", never]],
   [],
   AutomationsSlice
-> = (set) => ({
+> = (set, _get, _api) => ({
   ...defaultAutomationsState,
   ...createAutomationsActions(set),
   ...createRunsActions(set),

--- a/apps/web/lib/state/slices/automations/automations-slice.ts
+++ b/apps/web/lib/state/slices/automations/automations-slice.ts
@@ -1,0 +1,75 @@
+import type { StateCreator } from "zustand";
+import type { AutomationsSlice, AutomationsSliceState } from "./types";
+
+export const defaultAutomationsState: AutomationsSliceState = {
+  automations: { items: [], loaded: false, loading: false },
+  automationRuns: { byAutomationId: {}, loading: {} },
+};
+
+type ImmerSet = Parameters<
+  StateCreator<AutomationsSlice, [["zustand/immer", never]], [], AutomationsSlice>
+>[0];
+
+function createAutomationsActions(
+  set: ImmerSet,
+): Pick<
+  AutomationsSlice,
+  | "setAutomations"
+  | "setAutomationsLoading"
+  | "addAutomation"
+  | "updateAutomation"
+  | "removeAutomation"
+> {
+  return {
+    setAutomations: (items) =>
+      set((draft) => {
+        draft.automations.items = items;
+        draft.automations.loaded = true;
+      }),
+    setAutomationsLoading: (loading) =>
+      set((draft) => {
+        draft.automations.loading = loading;
+      }),
+    addAutomation: (automation) =>
+      set((draft) => {
+        draft.automations.items.unshift(automation);
+      }),
+    updateAutomation: (automation) =>
+      set((draft) => {
+        const idx = draft.automations.items.findIndex((a) => a.id === automation.id);
+        if (idx >= 0) {
+          draft.automations.items[idx] = automation;
+        }
+      }),
+    removeAutomation: (id) =>
+      set((draft) => {
+        draft.automations.items = draft.automations.items.filter((a) => a.id !== id);
+      }),
+  };
+}
+
+function createRunsActions(
+  set: ImmerSet,
+): Pick<AutomationsSlice, "setAutomationRuns" | "setAutomationRunsLoading"> {
+  return {
+    setAutomationRuns: (automationId, runs) =>
+      set((draft) => {
+        draft.automationRuns.byAutomationId[automationId] = runs;
+      }),
+    setAutomationRunsLoading: (automationId, loading) =>
+      set((draft) => {
+        draft.automationRuns.loading[automationId] = loading;
+      }),
+  };
+}
+
+export const createAutomationsSlice: StateCreator<
+  AutomationsSlice,
+  [["zustand/immer", never]],
+  [],
+  AutomationsSlice
+> = (set) => ({
+  ...defaultAutomationsState,
+  ...createAutomationsActions(set),
+  ...createRunsActions(set),
+});

--- a/apps/web/lib/state/slices/automations/index.ts
+++ b/apps/web/lib/state/slices/automations/index.ts
@@ -1,0 +1,8 @@
+export { createAutomationsSlice, defaultAutomationsState } from "./automations-slice";
+export type {
+  AutomationsSlice,
+  AutomationsSliceState,
+  AutomationsSliceActions,
+  AutomationsState,
+  AutomationRunsState,
+} from "./types";

--- a/apps/web/lib/state/slices/automations/types.ts
+++ b/apps/web/lib/state/slices/automations/types.ts
@@ -1,0 +1,29 @@
+import type { Automation, AutomationRun } from "@/lib/types/automation";
+
+export type AutomationsState = {
+  items: Automation[];
+  loaded: boolean;
+  loading: boolean;
+};
+
+export type AutomationRunsState = {
+  byAutomationId: Record<string, AutomationRun[]>;
+  loading: Record<string, boolean>;
+};
+
+export type AutomationsSliceState = {
+  automations: AutomationsState;
+  automationRuns: AutomationRunsState;
+};
+
+export type AutomationsSliceActions = {
+  setAutomations: (items: Automation[]) => void;
+  setAutomationsLoading: (loading: boolean) => void;
+  addAutomation: (automation: Automation) => void;
+  updateAutomation: (automation: Automation) => void;
+  removeAutomation: (id: string) => void;
+  setAutomationRuns: (automationId: string, runs: AutomationRun[]) => void;
+  setAutomationRunsLoading: (automationId: string, loading: boolean) => void;
+};
+
+export type AutomationsSlice = AutomationsSliceState & AutomationsSliceActions;

--- a/apps/web/lib/state/slices/index.ts
+++ b/apps/web/lib/state/slices/index.ts
@@ -13,6 +13,7 @@ export { createJiraSlice, defaultJiraState } from "./jira/jira-slice";
 export { createLinearSlice, defaultLinearState } from "./linear/linear-slice";
 export { createOfficeSlice, defaultOfficeState } from "./office/office-slice";
 export { createFeaturesSlice, defaultFeaturesState } from "./features/features-slice";
+export { createAutomationsSlice, defaultAutomationsState } from "./automations/automations-slice";
 
 // Export types
 export type { KanbanSlice, KanbanSliceState, KanbanSliceActions } from "./kanban/types";
@@ -46,6 +47,13 @@ export type {
   FeatureFlags,
   FeatureName,
 } from "./features/types";
+export type {
+  AutomationsSlice,
+  AutomationsSliceState,
+  AutomationsSliceActions,
+  AutomationsState,
+  AutomationRunsState,
+} from "./automations/types";
 
 // Re-export commonly used types from each domain
 export type {

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -22,6 +22,7 @@ import type {
 import type { SystemHealthResponse } from "@/lib/types/health";
 import type { UISliceActions as UIA } from "./slices/ui/types";
 import type * as UISliceTypes from "./slices/ui/types";
+import type { Automation, AutomationRun } from "@/lib/types/automation";
 import { mergeInitialState } from "./default-state";
 import {
   createKanbanSlice,
@@ -35,6 +36,7 @@ import {
   createLinearSlice,
   createOfficeSlice,
   createFeaturesSlice,
+  createAutomationsSlice,
   defaultKanbanState,
   defaultWorkspaceState,
   defaultSettingsState,
@@ -46,6 +48,7 @@ import {
   defaultLinearState,
   defaultOfficeState,
   defaultFeaturesState,
+  defaultAutomationsState,
   type WorkspaceState,
   type WorkflowsState,
   type ExecutorsState,
@@ -196,6 +199,10 @@ export type AppState = {
   features: (typeof defaultFeaturesState)["features"];
   setFeatures: (features: (typeof defaultFeaturesState)["features"]) => void;
 
+  // Automations slice
+  automations: (typeof defaultAutomationsState)["automations"];
+  automationRuns: (typeof defaultAutomationsState)["automationRuns"];
+
   // UI slice
   previewPanel: (typeof defaultUIState)["previewPanel"];
   rightPanel: (typeof defaultUIState)["rightPanel"];
@@ -254,6 +261,15 @@ export type AppState = {
   updateLinearIssueWatch: (watch: LinearIssueWatch) => void;
   removeLinearIssueWatch: (id: string) => void;
   resetLinearIssueWatches: () => void;
+
+  // Automations actions
+  setAutomations: (items: Automation[]) => void;
+  setAutomationsLoading: (loading: boolean) => void;
+  addAutomation: (automation: Automation) => void;
+  updateAutomation: (automation: Automation) => void;
+  removeAutomation: (id: string) => void;
+  setAutomationRuns: (automationId: string, runs: AutomationRun[]) => void;
+  setAutomationRunsLoading: (automationId: string, loading: boolean) => void;
 
   // Actions from all slices
   hydrate: (state: Partial<AppState>, options?: HydrationOptions) => void;
@@ -525,8 +541,6 @@ export type AppState = {
   setAgentRouting: (agentId: string, data: AgentRouteData | undefined) => void;
 };
 
-export type AppStore = ReturnType<typeof createAppStore>;
-
 export function createAppStore(initialState?: Partial<AppState>) {
   const merged = mergeInitialState(initialState);
 
@@ -556,6 +570,8 @@ export function createAppStore(initialState?: Partial<AppState>) {
       ...createFeaturesSlice(set as any, get as any, api as any),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...createUISlice(set as any, get as any, api as any),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...createAutomationsSlice(set as any, get as any, api as any),
       // Override state with merged initial state
       kanban: merged.kanban,
       kanbanMulti: merged.kanbanMulti,
@@ -610,6 +626,8 @@ export function createAppStore(initialState?: Partial<AppState>) {
       linearIssueWatches: merged.linearIssueWatches,
       office: merged.office,
       features: merged.features,
+      automations: merged.automations,
+      automationRuns: merged.automationRuns,
       previewPanel: merged.previewPanel,
       rightPanel: merged.rightPanel,
       diffs: merged.diffs,

--- a/apps/web/lib/types/automation.ts
+++ b/apps/web/lib/types/automation.ts
@@ -1,0 +1,144 @@
+// Automation types matching backend models in internal/automation/models.go
+
+export type TriggerType = "scheduled" | "github_pr" | "github_push" | "github_ci" | "webhook";
+
+export type RunStatus = "triggered" | "task_created" | "failed" | "skipped";
+
+export type Automation = {
+  id: string;
+  workspace_id: string;
+  name: string;
+  description: string;
+  workflow_id: string;
+  workflow_step_id: string;
+  agent_profile_id: string;
+  executor_profile_id: string;
+  prompt: string;
+  task_title_template: string;
+  enabled: boolean;
+  max_concurrent_runs: number;
+  last_triggered_at: string | null;
+  created_at: string;
+  updated_at: string;
+  triggers: AutomationTrigger[];
+};
+
+export type AutomationTrigger = {
+  id: string;
+  automation_id: string;
+  type: TriggerType;
+  config: Record<string, unknown>;
+  enabled: boolean;
+  last_evaluated_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AutomationRun = {
+  id: string;
+  automation_id: string;
+  trigger_id: string;
+  trigger_type: TriggerType;
+  task_id: string;
+  status: RunStatus;
+  dedup_key: string;
+  trigger_data: Record<string, unknown>;
+  error_message: string;
+  created_at: string;
+};
+
+// --- Trigger config types ---
+
+export type ScheduledTriggerConfig = {
+  cron_expression: string;
+  timezone?: string;
+};
+
+export type GitHubPRTriggerConfig = {
+  events: string[];
+  repos: Array<{ owner: string; name: string }>;
+  branches?: string[];
+  authors?: string[];
+  labels?: string[];
+  exclude_draft?: boolean;
+};
+
+export type GitHubPushTriggerConfig = {
+  repos: Array<{ owner: string; name: string }>;
+  branches: string[];
+};
+
+export type GitHubCITriggerConfig = {
+  repos: Array<{ owner: string; name: string }>;
+  conclusions: string[];
+  check_names?: string[];
+};
+
+export type WebhookTriggerConfig = {
+  filter_expression?: string;
+};
+
+// --- Trigger type metadata (from backend registry) ---
+
+export type PlaceholderInfo = {
+  key: string;
+  description: string;
+  example: string;
+};
+
+export type TriggerTypeInfo = {
+  type: TriggerType;
+  label: string;
+  description: string;
+  category: string;
+  enabled: boolean;
+  placeholders: PlaceholderInfo[];
+  default_prompt: string;
+  default_task_title: string;
+  default_config: Record<string, unknown>;
+};
+
+// --- Request/response DTOs ---
+
+export type CreateAutomationRequest = {
+  workspace_id: string;
+  name: string;
+  description?: string;
+  workflow_id: string;
+  workflow_step_id: string;
+  agent_profile_id: string;
+  executor_profile_id: string;
+  prompt?: string;
+  task_title_template?: string;
+  max_concurrent_runs?: number;
+  triggers?: Array<{
+    type: TriggerType;
+    config: Record<string, unknown>;
+    enabled: boolean;
+  }>;
+};
+
+export type UpdateAutomationRequest = {
+  name?: string;
+  description?: string;
+  workflow_id?: string;
+  workflow_step_id?: string;
+  agent_profile_id?: string;
+  executor_profile_id?: string;
+  prompt?: string;
+  task_title_template?: string;
+  enabled?: boolean;
+  max_concurrent_runs?: number;
+};
+
+export type AddTriggerRequest = {
+  automation_id: string;
+  type: TriggerType;
+  config: Record<string, unknown>;
+  enabled: boolean;
+};
+
+export type UpdateTriggerRequest = {
+  config?: Record<string, unknown>;
+  enabled?: boolean;
+};

--- a/apps/web/lib/types/automation.ts
+++ b/apps/web/lib/types/automation.ts
@@ -2,7 +2,7 @@
 
 export type TriggerType = "scheduled" | "github_pr" | "github_push" | "github_ci" | "webhook";
 
-export type RunStatus = "triggered" | "task_created" | "failed" | "skipped";
+export type RunStatus = "triggered" | "task_created" | "succeeded" | "failed" | "skipped";
 
 // ExecutionMode controls whether an automation firing creates a visible
 // kanban task ("task", the default) or an ephemeral run hidden from the

--- a/apps/web/lib/types/automation.ts
+++ b/apps/web/lib/types/automation.ts
@@ -4,6 +4,11 @@ export type TriggerType = "scheduled" | "github_pr" | "github_push" | "github_ci
 
 export type RunStatus = "triggered" | "task_created" | "failed" | "skipped";
 
+// ExecutionMode controls whether an automation firing creates a visible
+// kanban task ("task", the default) or an ephemeral run hidden from the
+// kanban whose output is surfaced via the automation's run history ("run").
+export type ExecutionMode = "task" | "run";
+
 export type Automation = {
   id: string;
   workspace_id: string;
@@ -15,6 +20,7 @@ export type Automation = {
   executor_profile_id: string;
   prompt: string;
   task_title_template: string;
+  execution_mode: ExecutionMode;
   enabled: boolean;
   max_concurrent_runs: number;
   last_triggered_at: string | null;
@@ -110,6 +116,7 @@ export type CreateAutomationRequest = {
   executor_profile_id: string;
   prompt?: string;
   task_title_template?: string;
+  execution_mode?: ExecutionMode;
   max_concurrent_runs?: number;
   triggers?: Array<{
     type: TriggerType;
@@ -127,6 +134,7 @@ export type UpdateAutomationRequest = {
   executor_profile_id?: string;
   prompt?: string;
   task_title_template?: string;
+  execution_mode?: ExecutionMode;
   enabled?: boolean;
   max_concurrent_runs?: number;
 };

--- a/apps/web/lib/types/automation.ts
+++ b/apps/web/lib/types/automation.ts
@@ -18,6 +18,7 @@ export type Automation = {
   workflow_step_id: string;
   agent_profile_id: string;
   executor_profile_id: string;
+  repository_id: string;
   prompt: string;
   task_title_template: string;
   execution_mode: ExecutionMode;
@@ -114,6 +115,7 @@ export type CreateAutomationRequest = {
   workflow_step_id: string;
   agent_profile_id: string;
   executor_profile_id: string;
+  repository_id?: string;
   prompt?: string;
   task_title_template?: string;
   execution_mode?: ExecutionMode;
@@ -132,6 +134,7 @@ export type UpdateAutomationRequest = {
   workflow_step_id?: string;
   agent_profile_id?: string;
   executor_profile_id?: string;
+  repository_id?: string;
   prompt?: string;
   task_title_template?: string;
   execution_mode?: ExecutionMode;

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -28,6 +28,7 @@ The office umbrella covers kandev's autonomous-agent product surface: workspaces
 | [inbox](office/inbox.md) | draft |
 | [assistant](office/assistant.md) | draft |
 | [plugins](office/plugins.md) | draft |
+| [automations-settings](office/automations-settings.md) | draft |
 | [testing](office/testing.md) | shipped |
 
 ## tasks/ — task & workflow model

--- a/docs/specs/office/automations-settings.md
+++ b/docs/specs/office/automations-settings.md
@@ -1,0 +1,121 @@
+---
+status: draft
+created: 2026-05-21
+owner: jcfs
+---
+
+# Automations in Settings
+
+## Why
+
+Users want to schedule an agent to run a prompt on a cron (e.g. "every weekday at 9am, run claude on this repo with the prompt 'check for stale branches'") without first learning Office's vocabulary — workspaces, projects, agent instances, roles, budgets, skills. Office routines already deliver this capability end-to-end, but the UI to reach them is buried inside `/office/<workspace>/routines`, behind the `KANDEV_FEATURES_OFFICE` flag and a workspace-selection flow that doesn't apply when the user just wants "a cron + a prompt".
+
+Automations-in-settings is a flat, low-ceremony entry point under `/settings/automations` that reuses the Office routines backend and the existing create-routine wizard, but hides the workspace / project / Office-agent concepts behind an auto-provisioned default workspace + assignee. Power users keep full editing access via `/office/<workspace>/routines`; new users get a "schedule a prompt" surface with no Office onboarding.
+
+## What
+
+- A new settings page at `/settings/automations` lists the user's automations as a flat table: name, schedule (human-readable cron + timezone), assignee agent type (e.g. `claude`), last run (status + relative time), next run, enabled toggle, row actions (edit, run now, delete).
+- A "New automation" button opens the existing 3-step routine create wizard with the workspace selector **hidden** and pre-filled to the default automations workspace.
+- On first use (no automations workspace exists yet), the act of opening the create wizard auto-provisions a hidden Office workspace + a default assignee Office agent without prompting the user. Provisioning is idempotent and atomic from the user's perspective: either the wizard opens with the workspace already attached, or it surfaces an error and creates nothing.
+- Automations created from settings are indistinguishable on the backend from routines created via `/office/<workspace>/routines` — they are the same `office_routines` + `office_routine_triggers` rows, scheduled by the same dispatcher, retried by the same policy. Editing the same automation from either UI yields the same result.
+- The settings UI exposes only the **schedule (cron)** trigger kind. Webhook and manual triggers remain available in the Office routines UI but are not surfaced in settings.
+- The settings UI exposes only **lightweight** routines (no task template). The agent receives the user-provided prompt and runs once per fire. Heavy routines (task-template, blockers, projects) remain available in the Office routines UI but are hidden from settings.
+- The settings UI MUST be reachable independently of the `KANDEV_FEATURES_OFFICE` flag state — when the flag is off, the rest of `/office/*` stays gated, but `/settings/automations` works and auto-provisioning treats the underlying Office subsystem as a private implementation detail.
+- An automation can be paused / resumed by toggling the row's enabled control, which flips the routine status between `active` and `paused`.
+- "Run now" on a row fires the routine immediately via the existing manual-fire endpoint and shows the launched run inline (status badge updates without page reload).
+- Editing an automation in settings opens the same wizard pre-filled. Fields surfaced: name, description (optional), assignee agent type, prompt, cron expression, timezone, enabled.
+- A link in the page header — "Need more control? Open the full automations editor" — deep-links to the corresponding `/office/<workspace>/routines` page for the auto-provisioned workspace, so power users can reach concurrency policies, catch-up policies, variables, webhook triggers, and heavy routines.
+
+## Data model
+
+No new tables. Automations-in-settings is a UI projection over existing entities from `scheduler.md`:
+
+- `office_routines` row — represents one automation. Filter for the settings list: `workspace_id = <default-automations-workspace-id> AND task_template = '' AND status != 'archived'`.
+- `office_routine_triggers` row — one schedule trigger per automation (`kind = 'schedule'`).
+- `office_routine_runs` row — execution history. Settings shows only the most recent row's `status` and `started_at` per routine.
+- `office_workspaces` row — exactly one is the default automations workspace per user, identified by a marker on the row. Field added: `office_workspaces.is_settings_default BOOL NOT NULL DEFAULT FALSE` with a partial unique index ensuring at most one default per user.
+- `office_agent_instances` row — exactly one is the default assignee for the default automations workspace, identified by `office_agent_instances.is_settings_default BOOL NOT NULL DEFAULT FALSE` with a partial unique index ensuring at most one default per workspace.
+
+The default workspace's `name` is fixed (`"Automations"`); its `display_name` is user-editable from `/office/<workspace>/routines` but the marker field is read-only. The default agent's role is `worker`, `skip_idle_wakeups = false` (since automations should fire even with no actionable tasks), `max_concurrent_sessions = 1`, `cooldown_sec = 10`.
+
+## API surface
+
+No new routes. Settings reuses the existing Office routines endpoints from `scheduler.md`:
+
+- `GET /api/office/routines?workspace_id=<default-automations-workspace-id>&task_template_empty=true` — settings list (server filter on lightweight routines).
+- `POST /api/office/routines` — create. Settings injects `workspace_id` and `assignee_agent_id` from the resolved default.
+- `PATCH /api/office/routines/:id` — toggle enabled / edit name / description / prompt / cron.
+- `DELETE /api/office/routines/:id` — delete an automation.
+- `POST /api/office/routines/:id/fire` — "Run now".
+
+One new endpoint resolves (creating if missing) the default automations workspace + assignee:
+
+- `POST /api/settings/automations/ensure-default` → `{ workspace_id, assignee_agent_id }`. Idempotent: returns the existing pair if already provisioned. Errors if the underlying Office subsystem is unavailable. Called by the settings page on first open of the create dialog (or list, whichever comes first that needs an ID).
+
+The `task_template_empty=true` filter parameter is the only addition to the existing list endpoint; everything else is the same call surface the Office routines UI uses today.
+
+## State machine
+
+Automations inherit the routine lifecycle from `scheduler.md` (`active <-> paused`, `active -> archived`). Settings exposes only `active` and `paused`; deleting an automation calls `DELETE` rather than archiving. The settings list query filters out `archived` rows but does not surface them — power users who want to archive use the Office routines UI.
+
+## Permissions
+
+- A user can manage their own automations only — the settings page filters by the user's default automations workspace, which is owned by that user.
+- The same user, when navigating to `/office/<workspace>/routines` for the default automations workspace, sees the same routines plus any heavy / webhook ones they created via the Office surface.
+- The auto-provisioned default workspace + agent cannot be deleted from settings. Deletion is reachable only via the Office workspace deletion flow (`docs/specs/workspaces/deletion.md`); doing so removes all automations.
+
+## Failure modes
+
+| Dependency / invariant | Behavior |
+|---|---|
+| `ensure-default` call fails (DB write error) | Settings page renders the list (which may be empty) and a banner: "Couldn't initialize automations. Retry." Create button is disabled until retry succeeds. |
+| Office subsystem is structurally unavailable (e.g. migration in progress) | Settings page renders the same banner; existing automation rows still display from the last successful list fetch. |
+| Default workspace marker exists but the underlying row is missing (drift) | `ensure-default` clears the stale marker and provisions a new workspace + agent. Existing automations under the missing workspace are not recoverable from settings (the user is told to use `/office/*` if they have other workspaces). |
+| User deletes the default agent via Office UI | Next `ensure-default` call re-creates a default agent. Existing automations whose `assignee_agent_id` pointed to the deleted agent are surfaced in the settings list with an "Assignee missing — edit to reassign" indicator; firing is blocked until reassigned. |
+| User toggles `KANDEV_FEATURES_OFFICE` off after creating automations | The scheduler may stop dispatching depending on how the flag gates the dispatcher (see Open questions). Settings page remains reachable and shows existing automations; UI surfaces a warning if backend reports the dispatcher is disabled. |
+| Cron expression invalid | Caught client-side and by the existing routines validator; the create / edit dialog blocks save with the existing error display. |
+| Two settings tabs open in the same browser race the "first create" | `ensure-default` is idempotent on the unique marker, so the second call returns the same pair; no duplicate workspace is created. |
+
+## Persistence guarantees
+
+Settings automations are routines — they survive restart with the same guarantees as `scheduler.md`. The default workspace + agent markers survive restart; provisioning runs exactly once per user across the lifetime of the install unless the marker is cleared by the drift-recovery path above.
+
+## Scenarios
+
+- **GIVEN** a user who has never used Office, **WHEN** they open `/settings/automations` and click "New automation" for the first time, **THEN** an Office workspace named `Automations` and a worker agent are auto-provisioned, the create wizard opens with the workspace selector hidden, and the user enters name + prompt + cron and saves. The new automation appears in the settings list immediately.
+
+- **GIVEN** the user's default automations workspace already exists, **WHEN** they open `/settings/automations`, **THEN** no new workspace is created (`ensure-default` returns the existing IDs) and the list renders the user's automations.
+
+- **GIVEN** an automation with cron `0 9 * * 1-5` in `Europe/Lisbon`, **WHEN** the scheduler tick crosses 09:00 Lisbon time on a weekday, **THEN** a lightweight routine wakeup fires for the default assignee, the agent receives the user-provided prompt, and the most-recent run status on the settings row updates to "Running" then "Done" without a page refresh.
+
+- **GIVEN** an automation in `active` status, **WHEN** the user toggles the row's enabled switch off, **THEN** a PATCH sets routine `status = 'paused'`; no further cron ticks dispatch wakeups for this automation. Toggling it back to on sets `status = 'active'` and the next cron boundary fires normally.
+
+- **GIVEN** a settings automation, **WHEN** the user clicks "Run now", **THEN** the existing `POST /api/office/routines/:id/fire` endpoint is called and the row's status badge transitions to "Running" within one WS tick.
+
+- **GIVEN** a settings automation created via the settings UI, **WHEN** the user navigates to `/office/<default-workspace>/routines`, **THEN** the same routine appears in the full Office routines list with the same `id`. Editing it from either UI persists to the same row.
+
+- **GIVEN** a user has created automations and `KANDEV_FEATURES_OFFICE` is then disabled, **WHEN** they open `/settings/automations`, **THEN** the page still loads and lists their automations. A banner indicates that automations may not fire because the Office subsystem is disabled.
+
+- **GIVEN** a heavy routine and a webhook-triggered routine in the default automations workspace (created via `/office/*`), **WHEN** the user opens `/settings/automations`, **THEN** neither appears in the settings list (filter: lightweight + schedule-trigger only). The settings list count + Office routines list count differ accordingly, which is expected.
+
+- **GIVEN** a settings automation whose assignee agent was deleted from the Office UI, **WHEN** the user opens `/settings/automations`, **THEN** the row shows "Assignee missing — edit to reassign". Firing is blocked. The next `ensure-default` call re-provisions a default agent; the user must explicitly edit existing automations to point at the new agent (no auto-reassign).
+
+- **GIVEN** an in-flight scheduler restart in the middle of a fire, **WHEN** the backend comes back up, **THEN** the routine's queued / scheduled-retry wakeup-requests are resumed per `scheduler.md` persistence guarantees and the settings row's last-run status reflects the eventual terminal state.
+
+## Out of scope
+
+- Webhook-triggered automations in the settings UI (use `/office/<workspace>/routines`).
+- Heavy automations with task templates, blockers, or projects in the settings UI.
+- Concurrency-policy / catch-up-policy / variable controls in the settings UI — defaults applied (`coalesce_if_active`, `enqueue_missed_with_cap` with cap 25).
+- Approval gates, reviewer flows, multi-agent delegation — these belong to Office proper.
+- Cost budgets, skill assignment, role configuration for the default agent.
+- A standalone "settings-only" scheduler decoupled from Office (the prior option 2; this spec is the lift-and-shift option).
+- Multi-user workspace sharing — automations are per-user via the `is_settings_default` marker.
+- Migration of existing routines created via `/office/*` into the default automations workspace.
+- Importing / exporting automations as YAML in the settings UI (configloader still works for power users).
+
+## Open questions
+
+- Does `KANDEV_FEATURES_OFFICE = false` short-circuit the scheduler dispatcher entirely, or only gate the `/office/*` routes? If the former, the "settings works even when flag is off" requirement implies decoupling the dispatcher from the UI gate. Decide before implementation.
+- Should the settings list show the most-recent run inline as a status badge (requires joining `office_routine_runs`) or only the routine's last-fired timestamp (cheaper)? Lean: status badge — matches the rest of the Kandev UI.
+- Is there value in surfacing "agent type" (claude / codex / opencode) as the settings-facing primary choice instead of "agent instance"? If yes, the default Office agent needs a mapping to the selected agent type at fire time. Lean: yes, since the entire point is to avoid Office vocabulary.

--- a/docs/specs/office/automations-settings.md
+++ b/docs/specs/office/automations-settings.md
@@ -8,114 +8,98 @@ owner: jcfs
 
 ## Why
 
-Users want to schedule an agent to run a prompt on a cron (e.g. "every weekday at 9am, run claude on this repo with the prompt 'check for stale branches'") without first learning Office's vocabulary — workspaces, projects, agent instances, roles, budgets, skills. Office routines already deliver this capability end-to-end, but the UI to reach them is buried inside `/office/<workspace>/routines`, behind the `KANDEV_FEATURES_OFFICE` flag and a workspace-selection flow that doesn't apply when the user just wants "a cron + a prompt".
+Users want to schedule an agent to run a prompt on a cron (or on a GitHub PR event, or on a webhook) without first navigating to per-workspace settings, picking the right workspace, then drilling down into a workflow. They also want two execution flavors: **tracked work** that shows up on the kanban as a real task (current default), and **fire-and-forget runs** whose output is just informational — not kanban clutter.
 
-Automations-in-settings is a flat, low-ceremony entry point under `/settings/automations` that reuses the Office routines backend and the existing create-routine wizard, but hides the workspace / project / Office-agent concepts behind an auto-provisioned default workspace + assignee. Power users keep full editing access via `/office/<workspace>/routines`; new users get a "schedule a prompt" surface with no Office onboarding.
+The Automations feature, originating in PR #406, gives kandev a standalone trigger-based subsystem (cron, GitHub PR events, webhooks) that turns triggers into Tasks. This spec extends it with two changes: (1) a per-automation `execution_mode` choice between **task** (existing behavior) and **run** (new — creates an ephemeral kanban-hidden task that surfaces only through the AutomationRun row), and (2) a flat `/settings/automations` entry point that drops the per-workspace nesting from the sidebar.
 
 ## What
 
-- A new settings page at `/settings/automations` lists the user's automations as a flat table: name, schedule (human-readable cron + timezone), assignee agent type (e.g. `claude`), last run (status + relative time), next run, enabled toggle, row actions (edit, run now, delete).
-- A "New automation" button opens the existing 3-step routine create wizard with the workspace selector **hidden** and pre-filled to the default automations workspace.
-- On first use (no automations workspace exists yet), the act of opening the create wizard auto-provisions a hidden Office workspace + a default assignee Office agent without prompting the user. Provisioning is idempotent and atomic from the user's perspective: either the wizard opens with the workspace already attached, or it surfaces an error and creates nothing.
-- Automations created from settings are indistinguishable on the backend from routines created via `/office/<workspace>/routines` — they are the same `office_routines` + `office_routine_triggers` rows, scheduled by the same dispatcher, retried by the same policy. Editing the same automation from either UI yields the same result.
-- The settings UI exposes only the **schedule (cron)** trigger kind. Webhook and manual triggers remain available in the Office routines UI but are not surfaced in settings.
-- The settings UI exposes only **lightweight** routines (no task template). The agent receives the user-provided prompt and runs once per fire. Heavy routines (task-template, blockers, projects) remain available in the Office routines UI but are hidden from settings.
-- The settings UI MUST be reachable independently of the `KANDEV_FEATURES_OFFICE` flag state — when the flag is off, the rest of `/office/*` stays gated, but `/settings/automations` works and auto-provisioning treats the underlying Office subsystem as a private implementation detail.
-- An automation can be paused / resumed by toggling the row's enabled control, which flips the routine status between `active` and `paused`.
-- "Run now" on a row fires the routine immediately via the existing manual-fire endpoint and shows the launched run inline (status badge updates without page reload).
-- Editing an automation in settings opens the same wizard pre-filled. Fields surfaced: name, description (optional), assignee agent type, prompt, cron expression, timezone, enabled.
-- A link in the page header — "Need more control? Open the full automations editor" — deep-links to the corresponding `/office/<workspace>/routines` page for the auto-provisioned workspace, so power users can reach concurrency policies, catch-up policies, variables, webhook triggers, and heavy routines.
+- Every automation has an `execution_mode` field — `task` (default) or `run`. The choice is per-automation, editable in the editor.
+- `execution_mode = task`: trigger fires → a normal kanban task is created (current PR #406 behavior). Task is visible on the kanban, commentable, reviewable, and has full lifecycle.
+- `execution_mode = run`: trigger fires → an ephemeral task is created (`is_ephemeral = true`, `origin = "automation_run"`) so the existing session pipeline still launches an agent. The kanban hides ephemeral tasks. The AutomationRun row is the surfaced artifact; the linked task is plumbing only.
+- Run-mode automations **auto-start** their agent regardless of the workflow step's `auto_start_agent` setting — the user never opens the task to drag it, so the trigger MUST be the start signal.
+- The sidebar exposes a single top-level **Automations** entry pointing at `/settings/automations`. The per-workspace `Automations` sub-link is removed (PR #406 added it; this spec drops it).
+- `/settings/automations` is a server-side router:
+  - 0 workspaces → empty state with "Create workspace" CTA.
+  - 1 workspace → redirect to `/settings/workspace/<id>/automations`.
+  - 2+ workspaces → workspace picker (grid of cards, click to enter).
+- The automations table shows the execution mode as a badge column ("Task" / "Run") so the user can scan which automations clutter the kanban and which don't.
 
 ## Data model
 
-No new tables. Automations-in-settings is a UI projection over existing entities from `scheduler.md`:
+Builds on PR #406's `internal/automation/` schema. Only one column added:
 
-- `office_routines` row — represents one automation. Filter for the settings list: `workspace_id = <default-automations-workspace-id> AND task_template = '' AND status != 'archived'`.
-- `office_routine_triggers` row — one schedule trigger per automation (`kind = 'schedule'`).
-- `office_routine_runs` row — execution history. Settings shows only the most recent row's `status` and `started_at` per routine.
-- `office_workspaces` row — exactly one is the default automations workspace per user, identified by a marker on the row. Field added: `office_workspaces.is_settings_default BOOL NOT NULL DEFAULT FALSE` with a partial unique index ensuring at most one default per user.
-- `office_agent_instances` row — exactly one is the default assignee for the default automations workspace, identified by `office_agent_instances.is_settings_default BOOL NOT NULL DEFAULT FALSE` with a partial unique index ensuring at most one default per workspace.
+```
+automations.execution_mode TEXT NOT NULL DEFAULT 'task'   -- 'task' | 'run'
+```
 
-The default workspace's `name` is fixed (`"Automations"`); its `display_name` is user-editable from `/office/<workspace>/routines` but the marker field is read-only. The default agent's role is `worker`, `skip_idle_wakeups = false` (since automations should fire even with no actionable tasks), `max_concurrent_sessions = 1`, `cooldown_sec = 10`.
+Idempotent migration in `internal/automation/store.go::migrateExecutionModeSQL` — `ALTER TABLE automations ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'task'`. SQLite swallows duplicate-column errors on re-run.
+
+The `tasks.is_ephemeral` and `tasks.origin` columns already exist (used by quick-chat). Run-mode automations set both at task-create time. New task origin constant `TaskOriginAutomationRun = "automation_run"` lives in `internal/task/models/models.go`.
+
+`automation_runs.task_id` continues to reference the created task for both modes. Run mode just means that task is hidden.
 
 ## API surface
 
-No new routes. Settings reuses the existing Office routines endpoints from `scheduler.md`:
+PR #406's WS-based API gets one new field — `execution_mode` — on:
 
-- `GET /api/office/routines?workspace_id=<default-automations-workspace-id>&task_template_empty=true` — settings list (server filter on lightweight routines).
-- `POST /api/office/routines` — create. Settings injects `workspace_id` and `assignee_agent_id` from the resolved default.
-- `PATCH /api/office/routines/:id` — toggle enabled / edit name / description / prompt / cron.
-- `DELETE /api/office/routines/:id` — delete an automation.
-- `POST /api/office/routines/:id/fire` — "Run now".
+- `automation.create` payload (input)
+- `automation.update` payload (input)
+- `automation.get` / `automation.list` responses (output)
 
-One new endpoint resolves (creating if missing) the default automations workspace + assignee:
-
-- `POST /api/settings/automations/ensure-default` → `{ workspace_id, assignee_agent_id }`. Idempotent: returns the existing pair if already provisioned. Errors if the underlying Office subsystem is unavailable. Called by the settings page on first open of the create dialog (or list, whichever comes first that needs an ID).
-
-The `task_template_empty=true` filter parameter is the only addition to the existing list endpoint; everything else is the same call surface the Office routines UI uses today.
+No new endpoints. No HTTP routes change. Sidebar deep-links to `/settings/automations` (flat).
 
 ## State machine
 
-Automations inherit the routine lifecycle from `scheduler.md` (`active <-> paused`, `active -> archived`). Settings exposes only `active` and `paused`; deleting an automation calls `DELETE` rather than archiving. The settings list query filters out `archived` rows but does not surface them — power users who want to archive use the Office routines UI.
+Automation lifecycle unchanged. Run-mode and task-mode share the trigger → AutomationRun pipeline. The only branching is in `orchestrator/event_handlers_automation.go::handleAutomationTriggered`:
+
+```
+trigger fires
+  → resolve repository
+  → CreateReviewTask(IsEphemeral=mode==run, Origin=automation_run)
+  → record AutomationRun (status=task_created, task_id set)
+  → associate PR if github_pr trigger
+  → if mode==run OR step.auto_start_agent: StartTask
+```
 
 ## Permissions
 
-- A user can manage their own automations only — the settings page filters by the user's default automations workspace, which is owned by that user.
-- The same user, when navigating to `/office/<workspace>/routines` for the default automations workspace, sees the same routines plus any heavy / webhook ones they created via the Office surface.
-- The auto-provisioned default workspace + agent cannot be deleted from settings. Deletion is reachable only via the Office workspace deletion flow (`docs/specs/workspaces/deletion.md`); doing so removes all automations.
+Inherits PR #406's model (no per-action authorization gates). The flat `/settings/automations` page is reachable by anyone with workspace-list access, since it only lists workspaces and links into the per-workspace UI.
 
 ## Failure modes
 
 | Dependency / invariant | Behavior |
 |---|---|
-| `ensure-default` call fails (DB write error) | Settings page renders the list (which may be empty) and a banner: "Couldn't initialize automations. Retry." Create button is disabled until retry succeeds. |
-| Office subsystem is structurally unavailable (e.g. migration in progress) | Settings page renders the same banner; existing automation rows still display from the last successful list fetch. |
-| Default workspace marker exists but the underlying row is missing (drift) | `ensure-default` clears the stale marker and provisions a new workspace + agent. Existing automations under the missing workspace are not recoverable from settings (the user is told to use `/office/*` if they have other workspaces). |
-| User deletes the default agent via Office UI | Next `ensure-default` call re-creates a default agent. Existing automations whose `assignee_agent_id` pointed to the deleted agent are surfaced in the settings list with an "Assignee missing — edit to reassign" indicator; firing is blocked until reassigned. |
-| User toggles `KANDEV_FEATURES_OFFICE` off after creating automations | The scheduler may stop dispatching depending on how the flag gates the dispatcher (see Open questions). Settings page remains reachable and shows existing automations; UI surfaces a warning if backend reports the dispatcher is disabled. |
-| Cron expression invalid | Caught client-side and by the existing routines validator; the create / edit dialog blocks save with the existing error display. |
-| Two settings tabs open in the same browser race the "first create" | `ensure-default` is idempotent on the unique marker, so the second call returns the same pair; no duplicate workspace is created. |
+| `listWorkspaces` fails on the flat page | Page renders the empty state (treating "couldn't load" as "no workspaces"). |
+| Run-mode automation's task starts but agent fails | AutomationRun stays at `task_created` status; task error_message reflects the failure. User sees the failed AutomationRun row. |
+| User manually drags a run-mode task on the kanban | Cannot happen — ephemeral tasks are hidden from the kanban. The "auto-start" rule fires once at trigger time; no manual recovery path. |
+| Existing automation upgraded from pre-execution_mode version | Migration sets `execution_mode = 'task'` for all existing rows. UI shows them with "Task" badge. |
+| User edits `execution_mode` from `task` to `run` on an enabled automation | Next firing uses the new mode. In-flight runs are unaffected. |
 
 ## Persistence guarantees
 
-Settings automations are routines — they survive restart with the same guarantees as `scheduler.md`. The default workspace + agent markers survive restart; provisioning runs exactly once per user across the lifetime of the install unless the marker is cleared by the drift-recovery path above.
+`automations.execution_mode` and `tasks.is_ephemeral` survive restart. Run-mode AutomationRuns and their hidden tasks persist normally. The kanban filter on `is_ephemeral` is applied at query time, not at write time — so re-marking a task non-ephemeral via direct DB update would reveal it.
 
 ## Scenarios
 
-- **GIVEN** a user who has never used Office, **WHEN** they open `/settings/automations` and click "New automation" for the first time, **THEN** an Office workspace named `Automations` and a worker agent are auto-provisioned, the create wizard opens with the workspace selector hidden, and the user enters name + prompt + cron and saves. The new automation appears in the settings list immediately.
-
-- **GIVEN** the user's default automations workspace already exists, **WHEN** they open `/settings/automations`, **THEN** no new workspace is created (`ensure-default` returns the existing IDs) and the list renders the user's automations.
-
-- **GIVEN** an automation with cron `0 9 * * 1-5` in `Europe/Lisbon`, **WHEN** the scheduler tick crosses 09:00 Lisbon time on a weekday, **THEN** a lightweight routine wakeup fires for the default assignee, the agent receives the user-provided prompt, and the most-recent run status on the settings row updates to "Running" then "Done" without a page refresh.
-
-- **GIVEN** an automation in `active` status, **WHEN** the user toggles the row's enabled switch off, **THEN** a PATCH sets routine `status = 'paused'`; no further cron ticks dispatch wakeups for this automation. Toggling it back to on sets `status = 'active'` and the next cron boundary fires normally.
-
-- **GIVEN** a settings automation, **WHEN** the user clicks "Run now", **THEN** the existing `POST /api/office/routines/:id/fire` endpoint is called and the row's status badge transitions to "Running" within one WS tick.
-
-- **GIVEN** a settings automation created via the settings UI, **WHEN** the user navigates to `/office/<default-workspace>/routines`, **THEN** the same routine appears in the full Office routines list with the same `id`. Editing it from either UI persists to the same row.
-
-- **GIVEN** a user has created automations and `KANDEV_FEATURES_OFFICE` is then disabled, **WHEN** they open `/settings/automations`, **THEN** the page still loads and lists their automations. A banner indicates that automations may not fire because the Office subsystem is disabled.
-
-- **GIVEN** a heavy routine and a webhook-triggered routine in the default automations workspace (created via `/office/*`), **WHEN** the user opens `/settings/automations`, **THEN** neither appears in the settings list (filter: lightweight + schedule-trigger only). The settings list count + Office routines list count differ accordingly, which is expected.
-
-- **GIVEN** a settings automation whose assignee agent was deleted from the Office UI, **WHEN** the user opens `/settings/automations`, **THEN** the row shows "Assignee missing — edit to reassign". Firing is blocked. The next `ensure-default` call re-provisions a default agent; the user must explicitly edit existing automations to point at the new agent (no auto-reassign).
-
-- **GIVEN** an in-flight scheduler restart in the middle of a fire, **WHEN** the backend comes back up, **THEN** the routine's queued / scheduled-retry wakeup-requests are resumed per `scheduler.md` persistence guarantees and the settings row's last-run status reflects the eventual terminal state.
+- **GIVEN** a user creates an automation with `execution_mode = "task"` and a cron trigger, **WHEN** the cron fires, **THEN** a normal kanban task appears with the rendered title; the user can click it, drag it, comment on it.
+- **GIVEN** a user creates an automation with `execution_mode = "run"` and a cron trigger, **WHEN** the cron fires, **THEN** an ephemeral task is created (not visible on the kanban), the agent starts automatically, and the AutomationRun row in the automation's history shows the result.
+- **GIVEN** a user opens `/settings/automations` in an install with one workspace, **WHEN** the page loads, **THEN** the browser redirects to `/settings/workspace/<id>/automations`.
+- **GIVEN** a user opens `/settings/automations` in an install with three workspaces, **WHEN** the page loads, **THEN** a workspace picker is shown; clicking one navigates to its automations.
+- **GIVEN** a user opens `/settings/automations` in a fresh install with zero workspaces, **WHEN** the page loads, **THEN** an empty-state card explains "create a workspace first" with a CTA.
+- **GIVEN** a user toggles an existing task-mode automation to run mode in the editor, **WHEN** the next trigger fires, **THEN** the resulting task is hidden from the kanban; previously-created tasks (from task-mode firings) remain visible.
+- **GIVEN** a run-mode automation triggered by a GitHub PR event, **WHEN** the trigger fires, **THEN** the PR is associated with the ephemeral task via `AssociatePRWithTask` exactly as in task mode.
+- **GIVEN** an upgrade from a pre-execution_mode kandev version, **WHEN** the user opens the editor for an existing automation, **THEN** the execution-mode selector defaults to "Task" (preserving previous behavior).
 
 ## Out of scope
 
-- Webhook-triggered automations in the settings UI (use `/office/<workspace>/routines`).
-- Heavy automations with task templates, blockers, or projects in the settings UI.
-- Concurrency-policy / catch-up-policy / variable controls in the settings UI — defaults applied (`coalesce_if_active`, `enqueue_missed_with_cap` with cap 25).
-- Approval gates, reviewer flows, multi-agent delegation — these belong to Office proper.
-- Cost budgets, skill assignment, role configuration for the default agent.
-- A standalone "settings-only" scheduler decoupled from Office (the prior option 2; this spec is the lift-and-shift option).
-- Multi-user workspace sharing — automations are per-user via the `is_settings_default` marker.
-- Migration of existing routines created via `/office/*` into the default automations workspace.
-- Importing / exporting automations as YAML in the settings UI (configloader still works for power users).
+- **AutomationRun-as-true-session-owner** (instead of ephemeral task). The cleaner model — make `task_sessions.task_id` nullable, add `task_sessions.automation_run_id`, route run-mode bypassing tasks entirely — was considered and explicitly deferred to a future PR. It touches ~50+ files in the orchestrator + session pipeline + WS layer + frontend state, which is out of scope here. The ephemeral-task path is the pragmatic shim.
+- **Agent-type primary picker.** PR #406's editor still picks an `agent_profile_id` (a fully configured profile), not a raw agent type (`claude` / `codex` / `opencode`). Switching to agent-type-primary requires plumbing changes in the orchestrator (which expects a profile id). Deferred.
+- **Auto-provisioned default workspace.** When no workspaces exist, the flat page shows a CTA; it does not auto-create one. Most installs already have a workspace (workspace setup is part of onboarding), so the CTA is sufficient for now.
+- **Cross-workspace automation listing** on the flat page. Multi-workspace installs see a picker, not a merged list. Merging would require a new list-all endpoint and a workspace column in the table.
+- A standalone AutomationRun detail page (showing session output for run-mode firings). Run-mode automations currently link to the linked task's detail page; since the task is hidden from the kanban it's reachable only by direct URL.
+- Webhook execution-mode override (e.g. webhook payload setting `execution_mode` per call). The execution mode is automation-level, not per-firing.
 
 ## Open questions
 
-- Does `KANDEV_FEATURES_OFFICE = false` short-circuit the scheduler dispatcher entirely, or only gate the `/office/*` routes? If the former, the "settings works even when flag is off" requirement implies decoupling the dispatcher from the UI gate. Decide before implementation.
-- Should the settings list show the most-recent run inline as a status badge (requires joining `office_routine_runs`) or only the routine's last-fired timestamp (cheaper)? Lean: status badge — matches the rest of the Kandev UI.
-- Is there value in surfacing "agent type" (claude / codex / opencode) as the settings-facing primary choice instead of "agent instance"? If yes, the default Office agent needs a mapping to the selected agent type at fire time. Lean: yes, since the entire point is to avoid Office vocabulary.
+- (none)

--- a/docs/specs/office/automations-settings.md
+++ b/docs/specs/office/automations-settings.md
@@ -15,6 +15,7 @@ The Automations feature, originating in PR #406, gives kandev a standalone trigg
 ## What
 
 - Every automation has an `execution_mode` field — `task` (default) or `run`. The choice is per-automation, editable in the editor.
+- Every automation has an optional `repository_id` field. When set, scheduled and webhook firings pin the task to that repository on its default branch. When empty, falls back to the workspace's first repository (legacy behavior). `github_pr` triggers always use the PR's own repository and ignore `repository_id`.
 - `execution_mode = task`: trigger fires → a normal kanban task is created (current PR #406 behavior). Task is visible on the kanban, commentable, reviewable, and has full lifecycle.
 - `execution_mode = run`: trigger fires → an ephemeral task is created (`is_ephemeral = true`, `origin = "automation_run"`) so the existing session pipeline still launches an agent. The kanban hides ephemeral tasks. The AutomationRun row is the surfaced artifact; the linked task is plumbing only.
 - Run-mode automations **auto-start** their agent regardless of the workflow step's `auto_start_agent` setting — the user never opens the task to drag it, so the trigger MUST be the start signal.
@@ -27,13 +28,12 @@ The Automations feature, originating in PR #406, gives kandev a standalone trigg
 
 ## Data model
 
-Builds on PR #406's `internal/automation/` schema. Only one column added:
+Builds on PR #406's `internal/automation/` schema. Two columns added (folded into the canonical `CREATE TABLE` since PR #406 itself introduces the `automations` table — no in-branch migrations are needed):
 
 ```
 automations.execution_mode TEXT NOT NULL DEFAULT 'task'   -- 'task' | 'run'
+automations.repository_id  TEXT NOT NULL DEFAULT ''       -- optional FK-by-id to repositories
 ```
-
-Idempotent migration in `internal/automation/store.go::migrateExecutionModeSQL` — `ALTER TABLE automations ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'task'`. SQLite swallows duplicate-column errors on re-run.
 
 The `tasks.is_ephemeral` and `tasks.origin` columns already exist (used by quick-chat). Run-mode automations set both at task-create time. New task origin constant `TaskOriginAutomationRun = "automation_run"` lives in `internal/task/models/models.go`.
 
@@ -41,7 +41,7 @@ The `tasks.is_ephemeral` and `tasks.origin` columns already exist (used by quick
 
 ## API surface
 
-PR #406's WS-based API gets one new field — `execution_mode` — on:
+PR #406's WS-based API gets two new fields — `execution_mode` and `repository_id` — on:
 
 - `automation.create` payload (input)
 - `automation.update` payload (input)
@@ -89,6 +89,9 @@ Inherits PR #406's model (no per-action authorization gates). The flat `/setting
 - **GIVEN** a user opens `/settings/automations` in a fresh install with zero workspaces, **WHEN** the page loads, **THEN** an empty-state card explains "create a workspace first" with a CTA.
 - **GIVEN** a user toggles an existing task-mode automation to run mode in the editor, **WHEN** the next trigger fires, **THEN** the resulting task is hidden from the kanban; previously-created tasks (from task-mode firings) remain visible.
 - **GIVEN** a run-mode automation triggered by a GitHub PR event, **WHEN** the trigger fires, **THEN** the PR is associated with the ephemeral task via `AssociatePRWithTask` exactly as in task mode.
+- **GIVEN** a scheduled automation with `repository_id` set to a specific repo, **WHEN** the cron fires, **THEN** the resulting task is pinned to that repo's default branch — regardless of whether the workspace has other repositories.
+- **GIVEN** a scheduled automation with `repository_id = ""` in a multi-repo workspace, **WHEN** the cron fires, **THEN** the task uses the workspace's first repository (legacy fallback) and a warning is logged.
+- **GIVEN** an automation with `repository_id` set and a `github_pr` trigger, **WHEN** a PR event fires, **THEN** the task uses the PR's own repository, not the configured `repository_id` — the editor disables the picker for PR triggers with a hint.
 - **GIVEN** an upgrade from a pre-execution_mode kandev version, **WHEN** the user opens the editor for an existing automation, **THEN** the execution-mode selector defaults to "Task" (preserving previous behavior).
 
 ## Out of scope

--- a/docs/specs/office/automations-settings.md
+++ b/docs/specs/office/automations-settings.md
@@ -16,6 +16,7 @@ The Automations feature, originating in PR #406, gives kandev a standalone trigg
 
 - Every automation has an `execution_mode` field — `task` (default) or `run`. The choice is per-automation, editable in the editor.
 - Every automation has an optional `repository_id` field. When set, scheduled and webhook firings pin the task to that repository on its default branch. When empty, falls back to the workspace's first repository (legacy behavior). `github_pr` triggers always use the PR's own repository and ignore `repository_id`.
+- The editor's repository picker matches the task-creation dialog's UX: lists both registered workspace repositories AND filesystem-discovered repositories under the workspace's roots. Picking a discovered repo registers it with the workspace at automation-save time (one round-trip via `createRepositoryAction`), then stores the resulting id on the automation. After the first save, the selection is promoted from `discovered` to `registered` so subsequent edits don't try to re-register.
 - `execution_mode = task`: trigger fires → a normal kanban task is created (current PR #406 behavior). Task is visible on the kanban, commentable, reviewable, and has full lifecycle.
 - `execution_mode = run`: trigger fires → an ephemeral task is created (`is_ephemeral = true`, `origin = "automation_run"`) so the existing session pipeline still launches an agent. The kanban hides ephemeral tasks. The AutomationRun row is the surfaced artifact; the linked task is plumbing only.
 - Run-mode automations **auto-start** their agent regardless of the workflow step's `auto_start_agent` setting — the user never opens the task to drag it, so the trigger MUST be the start signal.
@@ -92,6 +93,7 @@ Inherits PR #406's model (no per-action authorization gates). The flat `/setting
 - **GIVEN** a scheduled automation with `repository_id` set to a specific repo, **WHEN** the cron fires, **THEN** the resulting task is pinned to that repo's default branch — regardless of whether the workspace has other repositories.
 - **GIVEN** a scheduled automation with `repository_id = ""` in a multi-repo workspace, **WHEN** the cron fires, **THEN** the task uses the workspace's first repository (legacy fallback) and a warning is logged.
 - **GIVEN** an automation with `repository_id` set and a `github_pr` trigger, **WHEN** a PR event fires, **THEN** the task uses the PR's own repository, not the configured `repository_id` — the editor disables the picker for PR triggers with a hint.
+- **GIVEN** a user picks a discovered (not-yet-registered) repository in the editor and clicks Save, **WHEN** the save flow runs, **THEN** the discovered repo is registered with the workspace first (`createRepositoryAction`), its new id is written onto the automation, and the picker selection is promoted to `registered` so re-saving doesn't duplicate the registration.
 - **GIVEN** an upgrade from a pre-execution_mode kandev version, **WHEN** the user opens the editor for an existing automation, **THEN** the execution-mode selector defaults to "Task" (preserving previous behavior).
 
 ## Out of scope


### PR DESCRIPTION
## Summary

Adds a flat **Settings → Automations** surface that lets users wire a trigger (scheduled / GitHub PR / push / CI / webhook), a prompt, and a target agent/executor/repo into either:

- **Task** mode — visible on the kanban, follows the workflow
- **Run** mode — ephemeral, hidden from the kanban, status surfaced via the automation's Recent Runs

The bulk of the diff is the initial system + editor; the final commit is the run-mode polish loop after dogfooding.

## What's in the branch

- `feat: automation system with triggers, backend-driven metadata, and PR association` — DB model, scheduler, evaluator, trigger registry (`scheduled`, `github_pr|ci|push`, `webhook`), orchestrator handler that bridges automation events to `CreateReviewTask` + `StartTask`, settings UI, runs view, e2e
- `feat: execution_mode + flat /settings/automations` — Task vs Run mode, `tasks.is_ephemeral` + `tasks.origin = "automation_run"`
- `feat: per-automation repository picker` + `repo picker shows discovered repos too` — same two-tier UX as task creation (registered + filesystem-discovered, auto-registered on save). `github_pr` ignores the picker and uses the PR's repo
- `fix: idempotent ALTERs for in-branch columns` — schema drift safety for existing DBs
- `fix: use generateUUID in non-secure contexts` — `crypto.randomUUID` fails on plain HTTP
- `fix: polish run-mode lifecycle, validation, and editor UX` — fixes found while dogfooding

## Run-mode fixes (last commit)

- Workflow fields are no longer sent / required when `execution_mode = run` (task service rejects non-empty `workflow_id` on ephemeral tasks)
- "Create Automation" was always disabled in run-mode (`canSave` required workflow); now only requires name
- Silent save failure → now surfaced via toast
- Permission prompts on run-mode tasks no longer hang forever — auto-rejected, run flipped to `Failed` with a clear reason
- On agent completion / failure for ephemeral automation tasks: run row flips to `Succeeded` / `Failed`, worktree + branch reaped immediately instead of waiting for the 24h GC
- Trigger-config inputs (cron, branches, authors) now re-sync to the loaded automation on page reload (the `useState(prop)` initial-value bug)
- Recent Runs row clicks navigate to `/tasks/<id>` for task-mode runs; suppressed shadcn header-row hover

## Test plan

- [ ] Create a task-mode automation with a scheduled trigger, let it fire; row appears with `Running → Succeeded` and clicking the row opens the task
- [ ] Create a run-mode automation; workflow/step fields hidden; `Create Automation` enabled with just a name; agent runs and worktree is gone from `.kandev-dev/tasks/` on completion
- [ ] Run-mode automation that asks for permission to edit outside its worktree → run shows `Failed` with `Permission required: …`, session no longer hangs
- [ ] Reload an existing automation's edit page → cron expression, branches, and authors all repopulate from saved config
- [ ] Manual trigger button on the Automations list still works

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1016-bwo7.sprites.app |
| **Commit** | `fe1796a` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->