### PR TITLE
feat(tasks): don't cascade archive/delete to subtasks by default

### DIFF
--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -97,6 +97,9 @@ func (m *mockRepository) ListChildren(_ context.Context, _ string) ([]*models.Ta
 func (m *mockRepository) ListChildrenIncludingArchived(_ context.Context, _ string) ([]*models.Task, error) {
 	return nil, nil
 }
+func (m *mockRepository) ReparentDirectChildren(_ context.Context, _, _ string) error {
+	return nil
+}
 func (m *mockRepository) ListSiblings(_ context.Context, _ string) ([]*models.Task, error) {
 	return nil, nil
 }

--- a/apps/backend/internal/task/handlers/task_handlers.go
+++ b/apps/backend/internal/task/handlers/task_handlers.go
@@ -21,6 +21,10 @@ type handlerRepo interface {
 	DeleteSessionFileReviews(ctx context.Context, sessionID string) error
 	ListTurnsBySession(ctx context.Context, sessionID string) ([]*models.Turn, error)
 	CountToolCallMessagesBySession(ctx context.Context, sessionIDs []string) (map[string]int, error)
+	// ListChildren returns the direct, non-archived, non-ephemeral
+	// subtasks of parentID. Used by httpTaskSubtaskCount to drive the
+	// "Also archive/delete subtasks" checkbox in the frontend dialog.
+	ListChildren(ctx context.Context, parentID string) ([]*models.Task, error)
 }
 
 type TaskHandlers struct {
@@ -91,6 +95,7 @@ func (h *TaskHandlers) registerHTTP(router *gin.Engine) {
 	api.DELETE("/tasks/:id", h.httpDeleteTask)
 	api.POST("/tasks/:id/archive", h.httpArchiveTask)
 	api.POST("/tasks/:id/unarchive", h.httpUnarchiveTask)
+	api.GET("/tasks/:id/subtask-count", h.httpTaskSubtaskCount)
 
 	api.POST("/tasks/bulk-move", h.httpBulkMoveTasks)
 	api.GET("/workflows/:id/task-count", h.httpGetWorkflowTaskCount)

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -940,11 +940,12 @@ func (h *TaskHandlers) httpDeleteTask(c *gin.Context) {
 	deleteCtx, cancel := context.WithTimeout(context.Background(), constants.TaskDeleteTimeout)
 	defer cancel()
 	taskID := c.Param("id")
+	cascade := cascadeQueryParam(c)
 	// Office task-handoffs phase 6: route through HandoffService.DeleteTaskTree
 	// when wired so descendant runs are cancelled, group memberships are
 	// released with reason=deleted, and the cleanup state machine fires.
 	if h.handoffSvc != nil {
-		if _, err := h.handoffSvc.DeleteTaskTree(deleteCtx, taskID); err != nil {
+		if _, err := h.handoffSvc.DeleteTaskTree(deleteCtx, taskID, cascade); err != nil {
 			handleNotFound(c, h.logger, err, "task not deleted")
 			return
 		}
@@ -960,13 +961,14 @@ func (h *TaskHandlers) httpDeleteTask(c *gin.Context) {
 
 func (h *TaskHandlers) httpArchiveTask(c *gin.Context) {
 	taskID := c.Param("id")
+	cascade := cascadeQueryParam(c)
 	// Office task-handoffs phase 6: when a HandoffService is wired,
 	// archive the whole subtree under a single cascade ID so
 	// descendants get tagged for scoped unarchive AND workspace-group
 	// memberships are released. When HandoffService is unconfigured
 	// (legacy / tests) fall back to the single-task path.
 	if h.handoffSvc != nil {
-		if _, err := h.handoffSvc.ArchiveTaskTree(c.Request.Context(), taskID); err != nil {
+		if _, err := h.handoffSvc.ArchiveTaskTree(c.Request.Context(), taskID, cascade); err != nil {
 			handleNotFound(c, h.logger, err, "task not archived")
 			return
 		}
@@ -978,6 +980,26 @@ func (h *TaskHandlers) httpArchiveTask(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, dto.SuccessResponse{Success: true})
+}
+
+// cascadeQueryParam returns whether the archive/delete request asked to
+// cascade into subtasks. Default is false — subtasks are preserved
+// unless the client explicitly opts in via ?cascade=true.
+func cascadeQueryParam(c *gin.Context) bool {
+	return strings.EqualFold(c.Query("cascade"), "true")
+}
+
+// httpTaskSubtaskCount returns the count of direct, non-archived,
+// non-ephemeral subtasks for a task. Used by the frontend's archive /
+// delete confirmation dialogs to decide whether to render the
+// "Also archive/delete subtasks" checkbox.
+func (h *TaskHandlers) httpTaskSubtaskCount(c *gin.Context) {
+	children, err := h.repo.ListChildren(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"count": len(children)})
 }
 
 // httpUnarchiveTask routes through HandoffService.UnarchiveTaskTree so

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -994,9 +994,15 @@ func cascadeQueryParam(c *gin.Context) bool {
 // delete confirmation dialogs to decide whether to render the
 // "Also archive/delete subtasks" checkbox.
 func (h *TaskHandlers) httpTaskSubtaskCount(c *gin.Context) {
-	children, err := h.repo.ListChildren(c.Request.Context(), c.Param("id"))
+	taskID := c.Param("id")
+	children, err := h.repo.ListChildren(c.Request.Context(), taskID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		// Don't surface the raw repo error to the client — it can leak
+		// driver / SQL details. Log the full reason server-side, return
+		// a generic 500 to the caller.
+		h.logger.Error("failed to list direct subtasks",
+			zap.String("task_id", taskID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to count subtasks"})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"count": len(children)})

--- a/apps/backend/internal/task/handlers/task_http_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers_test.go
@@ -84,6 +84,74 @@ func newTestLogger(t *testing.T) *logger.Logger {
 	return log
 }
 
+// subtaskCountRepo lets the subtask-count handler test drive
+// ListChildren to specific values / errors without standing up a real
+// SQLite repo.
+type subtaskCountRepo struct {
+	mockRepository
+	children []*models.Task
+	err      error
+}
+
+func (r *subtaskCountRepo) ListChildren(_ context.Context, _ string) ([]*models.Task, error) {
+	return r.children, r.err
+}
+
+func (r *subtaskCountRepo) CountToolCallMessagesBySession(
+	_ context.Context, _ []string,
+) (map[string]int, error) {
+	return nil, nil
+}
+
+func TestHTTPTaskSubtaskCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	log := newTestLogger(t)
+
+	t.Run("returns count for task with subtasks", func(t *testing.T) {
+		repo := &subtaskCountRepo{children: []*models.Task{{ID: "c1"}, {ID: "c2"}, {ID: "c3"}}}
+		h := &TaskHandlers{repo: repo, logger: log}
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodGet, "/tasks/root/subtask-count", nil)
+		c.Params = gin.Params{{Key: "id", Value: "root"}}
+
+		h.httpTaskSubtaskCount(c)
+
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		assert.JSONEq(t, `{"count":3}`, rec.Body.String())
+	})
+
+	t.Run("returns zero for task with no subtasks", func(t *testing.T) {
+		repo := &subtaskCountRepo{children: nil}
+		h := &TaskHandlers{repo: repo, logger: log}
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodGet, "/tasks/root/subtask-count", nil)
+		c.Params = gin.Params{{Key: "id", Value: "root"}}
+
+		h.httpTaskSubtaskCount(c)
+
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		assert.JSONEq(t, `{"count":0}`, rec.Body.String())
+	})
+
+	t.Run("returns 500 with a generic error on repo failure", func(t *testing.T) {
+		repo := &subtaskCountRepo{err: errors.New("sql: connection refused: postgres://user@host/db")}
+		h := &TaskHandlers{repo: repo, logger: log}
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodGet, "/tasks/root/subtask-count", nil)
+		c.Params = gin.Params{{Key: "id", Value: "root"}}
+
+		h.httpTaskSubtaskCount(c)
+
+		require.Equal(t, http.StatusInternalServerError, rec.Code)
+		// Must NOT leak the raw error (would expose DSN / driver details).
+		assert.NotContains(t, rec.Body.String(), "postgres://")
+		assert.Contains(t, rec.Body.String(), "failed to count subtasks")
+	})
+}
+
 func TestHandleSelectedMoveError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	log := newTestLogger(t)

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -49,6 +49,12 @@ type TaskRepository interface {
 	// including archived ones. Used by the office task-handoffs unarchive
 	// cascade (phase 6) to walk a previously-archived descendant tree.
 	ListChildrenIncludingArchived(ctx context.Context, parentID string) ([]*models.Task, error)
+	// ReparentDirectChildren updates every row whose parent_id matches
+	// oldParentID, replacing it with newParentID. Used by no-cascade
+	// delete so direct children of a deleted task become roots
+	// (newParentID="") instead of dangling pointers. Affects archived
+	// and active rows alike.
+	ReparentDirectChildren(ctx context.Context, oldParentID, newParentID string) error
 	// ListSiblings returns non-archived, non-ephemeral sibling tasks for taskID.
 	// A task is a sibling of taskID when it shares a non-empty parent_id and
 	// the same workspace_id, and is not taskID itself. Root tasks (empty

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -320,6 +320,21 @@ func (r *Repository) ListChildrenIncludingArchived(ctx context.Context, parentID
 	return r.scanTasks(rows)
 }
 
+// ReparentDirectChildren swaps the parent_id of every row matching
+// oldParentID (archived or not) to newParentID. Used by no-cascade
+// delete so the soon-to-be-orphaned direct children become roots
+// instead of pointing at a row that's about to vanish.
+func (r *Repository) ReparentDirectChildren(ctx context.Context, oldParentID, newParentID string) error {
+	if oldParentID == "" {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE tasks SET parent_id = ?, updated_at = ?
+		WHERE parent_id = ?
+	`), newParentID, time.Now().UTC(), oldParentID)
+	return err
+}
+
 // ListSiblings returns non-archived, non-ephemeral sibling tasks. A task
 // is a sibling when parent_id matches AND the parent_id is non-empty AND
 // the workspace matches. Root tasks (empty parent_id) deliberately return

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -257,40 +257,9 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 	cascadeID := uuid.New().String()
 	out := &CascadeOutcome{CascadeID: cascadeID}
 
-	var all []string
-	if cascade {
-		// Delete must walk archived descendants too: a parent with
-		// already-archived children must remove every row, not just the
-		// non-archived ones (post-review #4).
-		descendants, err := s.collectTaskTreeIncludingArchived(ctx, rootID)
-		if err != nil {
-			return nil, err
-		}
-		all = descendants
-	} else {
-		// Reparent direct children (archived or not) to root so the
-		// soon-deleted parent_id pointer doesn't dangle. This MUST
-		// succeed before we touch the parent row — continuing past a
-		// reparent error would leave children pointing at a row we're
-		// about to delete, exactly the dangling-pointer state the
-		// no-cascade path is designed to avoid.
-		//
-		// Capture the affected children BEFORE the update so we can
-		// publish task.updated for each one after the row change — WS
-		// clients (kanban, sidebar) cache parent_id and would otherwise
-		// keep displaying the children nested under the deleted parent
-		// until a full reload.
-		children, err := s.tasks.ListChildrenIncludingArchived(ctx, rootID)
-		if err != nil {
-			return nil, fmt.Errorf("list direct children of %s: %w", rootID, err)
-		}
-		if err := s.tasks.ReparentDirectChildren(ctx, rootID, ""); err != nil {
-			return nil, fmt.Errorf("reparent direct children of %s: %w", rootID, err)
-		}
-		for _, c := range children {
-			s.publishUpdatedTask(ctx, c.ID)
-		}
-		all = []string{rootID}
+	all, err := s.resolveDeleteSet(ctx, rootID, cascade)
+	if err != nil {
+		return nil, err
 	}
 
 	s.cancelActiveRuns(ctx, all, "task tree deleted")
@@ -423,6 +392,42 @@ func (s *HandoffService) UnarchiveTaskTree(ctx context.Context, rootID string) (
 		s.restoreCleanedGroups(ctx, ids)
 	}
 	return out, nil
+}
+
+// resolveDeleteSet returns the set of task IDs DeleteTaskTree should
+// remove. When cascade is true that's the full descendant tree
+// (including archived rows). When cascade is false it's just rootID,
+// and the helper first reparents direct children to root so the
+// soon-deleted parent_id pointer doesn't dangle, then publishes a
+// task.updated event for each reparented child so WS-driven clients
+// refresh their cached parent_id.
+func (s *HandoffService) resolveDeleteSet(ctx context.Context, rootID string, cascade bool) ([]string, error) {
+	if cascade {
+		// Delete must walk archived descendants too: a parent with
+		// already-archived children must remove every row, not just
+		// the non-archived ones (post-review #4).
+		return s.collectTaskTreeIncludingArchived(ctx, rootID)
+	}
+	// Capture the affected children BEFORE the update so we can
+	// publish task.updated for each one after the row change —
+	// clients (kanban, sidebar) cache parent_id and would otherwise
+	// keep displaying the children nested under the deleted parent
+	// until a full reload.
+	children, err := s.tasks.ListChildrenIncludingArchived(ctx, rootID)
+	if err != nil {
+		return nil, fmt.Errorf("list direct children of %s: %w", rootID, err)
+	}
+	// Reparent MUST succeed before we touch the parent row —
+	// continuing past a reparent error would leave children pointing
+	// at a row we're about to delete, exactly the dangling-pointer
+	// state the no-cascade path is designed to avoid.
+	if err := s.tasks.ReparentDirectChildren(ctx, rootID, ""); err != nil {
+		return nil, fmt.Errorf("reparent direct children of %s: %w", rootID, err)
+	}
+	for _, c := range children {
+		s.publishUpdatedTask(ctx, c.ID)
+	}
+	return []string{rootID}, nil
 }
 
 // collectTaskTree returns rootID followed by every NON-ARCHIVED

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -274,8 +274,21 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 		// reparent error would leave children pointing at a row we're
 		// about to delete, exactly the dangling-pointer state the
 		// no-cascade path is designed to avoid.
+		//
+		// Capture the affected children BEFORE the update so we can
+		// publish task.updated for each one after the row change — WS
+		// clients (kanban, sidebar) cache parent_id and would otherwise
+		// keep displaying the children nested under the deleted parent
+		// until a full reload.
+		children, err := s.tasks.ListChildrenIncludingArchived(ctx, rootID)
+		if err != nil {
+			return nil, fmt.Errorf("list direct children of %s: %w", rootID, err)
+		}
 		if err := s.tasks.ReparentDirectChildren(ctx, rootID, ""); err != nil {
 			return nil, fmt.Errorf("reparent direct children of %s: %w", rootID, err)
+		}
+		for _, c := range children {
+			s.publishUpdatedTask(ctx, c.ID)
 		}
 		all = []string{rootID}
 	}

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -149,6 +149,9 @@ type CascadeOutcome struct {
 // a single cascade ID. Already-archived descendants are skipped so the
 // later UnarchiveTaskTree restores exactly what this cascade owned.
 //
+// When cascade=false, only rootID is archived; descendants are left
+// alone (used when subtasks might still be in progress).
+//
 // Steps (in order):
 //  1. Collect the descendant set (BFS over parent_id).
 //  2. Cancel active sessions / runs for every task in the set before
@@ -158,7 +161,7 @@ type CascadeOutcome struct {
 //  4. Release workspace-group membership for the tasks this cascade
 //     archived, stamping the cascade ID on the released row.
 //  5. Evaluate cleanup once per affected group.
-func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string) (*CascadeOutcome, error) {
+func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string, cascade bool) (*CascadeOutcome, error) {
 	if rootID == "" {
 		return nil, errors.New("rootID is required")
 	}
@@ -168,9 +171,15 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string) (*C
 	cascadeID := uuid.New().String()
 	out := &CascadeOutcome{CascadeID: cascadeID}
 
-	all, err := s.collectTaskTree(ctx, rootID)
-	if err != nil {
-		return nil, err
+	var all []string
+	if cascade {
+		descendants, err := s.collectTaskTree(ctx, rootID)
+		if err != nil {
+			return nil, err
+		}
+		all = descendants
+	} else {
+		all = []string{rootID}
 	}
 
 	// Cancel active runs first. Failures are logged and skipped — a
@@ -227,13 +236,18 @@ func (s *HandoffService) ArchiveTaskTree(ctx context.Context, rootID string) (*C
 // memberships with reason=deleted, and removes every task row. Unlike
 // archive, delete is permanent — there is no Undelete cascade.
 //
+// When cascade=false, only rootID is deleted; its direct children are
+// reparented to root (parent_id="") before the row is removed so the
+// orphaned subtasks stay queryable instead of holding a dangling
+// pointer.
+//
 // Group memberships are released with reason=deleted so the cleanup
 // evaluation runs the same path archive does (last active member gone
 // → cleanup_pending → optionally cleaned). Tasks the user manually
 // archived but not deleted before this cascade are still removed
 // because deletion is unconditional; the cascade ID is stamped only
 // for symmetry with archive.
-func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string) (*CascadeOutcome, error) {
+func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, cascade bool) (*CascadeOutcome, error) {
 	if rootID == "" {
 		return nil, errors.New("rootID is required")
 	}
@@ -243,12 +257,26 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string) (*Ca
 	cascadeID := uuid.New().String()
 	out := &CascadeOutcome{CascadeID: cascadeID}
 
-	// Delete must walk archived descendants too: a parent with
-	// already-archived children must remove every row, not just the
-	// non-archived ones (post-review #4).
-	all, err := s.collectTaskTreeIncludingArchived(ctx, rootID)
-	if err != nil {
-		return nil, err
+	var all []string
+	if cascade {
+		// Delete must walk archived descendants too: a parent with
+		// already-archived children must remove every row, not just the
+		// non-archived ones (post-review #4).
+		descendants, err := s.collectTaskTreeIncludingArchived(ctx, rootID)
+		if err != nil {
+			return nil, err
+		}
+		all = descendants
+	} else {
+		// Reparent direct children (archived or not) to root so the
+		// soon-deleted parent_id pointer doesn't dangle. Best-effort:
+		// log and continue so the user's delete intent still goes
+		// through if the reparent fails.
+		if err := s.tasks.ReparentDirectChildren(ctx, rootID, ""); err != nil {
+			s.logf().Warn("reparent direct children before delete",
+				zap.String("task_id", rootID), zap.Error(err))
+		}
+		all = []string{rootID}
 	}
 
 	s.cancelActiveRuns(ctx, all, "task tree deleted")

--- a/apps/backend/internal/task/service/handoff_cascade.go
+++ b/apps/backend/internal/task/service/handoff_cascade.go
@@ -269,12 +269,13 @@ func (s *HandoffService) DeleteTaskTree(ctx context.Context, rootID string, casc
 		all = descendants
 	} else {
 		// Reparent direct children (archived or not) to root so the
-		// soon-deleted parent_id pointer doesn't dangle. Best-effort:
-		// log and continue so the user's delete intent still goes
-		// through if the reparent fails.
+		// soon-deleted parent_id pointer doesn't dangle. This MUST
+		// succeed before we touch the parent row — continuing past a
+		// reparent error would leave children pointing at a row we're
+		// about to delete, exactly the dangling-pointer state the
+		// no-cascade path is designed to avoid.
 		if err := s.tasks.ReparentDirectChildren(ctx, rootID, ""); err != nil {
-			s.logf().Warn("reparent direct children before delete",
-				zap.String("task_id", rootID), zap.Error(err))
+			return nil, fmt.Errorf("reparent direct children of %s: %w", rootID, err)
 		}
 		all = []string{rootID}
 	}

--- a/apps/backend/internal/task/service/handoff_cascade_archive_column_regression_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_archive_column_regression_test.go
@@ -44,7 +44,7 @@ func TestArchiveTaskTree_FreshTask_PreservesCascadeColumn(t *testing.T) {
 	// that condition precisely.
 	handoff := NewHandoffService(repo, repo, nil, nil, nil, nil)
 
-	outcome, err := handoff.ArchiveTaskTree(ctx, task.ID)
+	outcome, err := handoff.ArchiveTaskTree(ctx, task.ID, true)
 	if err != nil {
 		t.Fatalf("ArchiveTaskTree returned error (this would surface as 500 from httpArchiveTask): %v", err)
 	}

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -746,6 +747,41 @@ func TestArchiveTaskTree_NoCascade_LeavesChildrenActive(t *testing.T) {
 			t.Errorf("%s should remain active, got archived_at=%v", id, child.ArchivedAt)
 		}
 	}
+}
+
+// TestDeleteTaskTree_NoCascade_ReparentFailureAborts pins the safety
+// invariant: when the no-cascade reparent step fails we MUST refuse to
+// delete the parent. Continuing past a reparent error would leave
+// children pointing at a row we're about to remove — exactly the
+// dangling pointer the no-cascade path is designed to prevent.
+func TestDeleteTaskTree_NoCascade_ReparentFailureAborts(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	tasks.addTask("c1", "root", "ws-1")
+	groups := newCascadeWSGroupRepo()
+	tr := &fakeReparentErrRepo{fakeDeleteRepo: &fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)}}
+	svc := NewHandoffService(tr, nil, nil, nil, groups, nil)
+
+	_, err := svc.DeleteTaskTree(context.Background(), "root", false)
+	if err == nil {
+		t.Fatal("expected error from failed reparent, got nil")
+	}
+	if _, exists := tasks.tasks["root"]; !exists {
+		t.Error("root should NOT be deleted when reparent fails")
+	}
+	if _, exists := tasks.tasks["c1"]; !exists {
+		t.Error("c1 should still exist")
+	}
+}
+
+// fakeReparentErrRepo overrides ReparentDirectChildren to simulate a DB
+// failure so the no-cascade abort path can be exercised in tests.
+type fakeReparentErrRepo struct {
+	*fakeDeleteRepo
+}
+
+func (r *fakeReparentErrRepo) ReparentDirectChildren(_ context.Context, _, _ string) error {
+	return errors.New("simulated DB failure")
 }
 
 // TestDeleteTaskTree_NoCascade_ReparentsDirectChildren verifies the

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -159,7 +159,7 @@ func TestArchiveTaskTree_StampsCascadeAcrossDescendants(t *testing.T) {
 	groups := newCascadeWSGroupRepo()
 	svc := newCascadeService(t, tasks, groups)
 
-	out, err := svc.ArchiveTaskTree(context.Background(), "root")
+	out, err := svc.ArchiveTaskTree(context.Background(), "root", true)
 	if err != nil {
 		t.Fatalf("archive: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestUnarchiveTaskTree_LeavesPriorlyArchivedDescendantsAlone(t *testing.T) {
 	groups := newCascadeWSGroupRepo()
 	svc := newCascadeService(t, tasks, groups)
 
-	archive, err := svc.ArchiveTaskTree(context.Background(), "root")
+	archive, err := svc.ArchiveTaskTree(context.Background(), "root", true)
 	if err != nil {
 		t.Fatalf("archive: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestArchiveTaskTree_ReleasesGroupMemberships(t *testing.T) {
 	}
 	svc := newCascadeService(t, tasks, groups)
 
-	out, err := svc.ArchiveTaskTree(context.Background(), "root")
+	out, err := svc.ArchiveTaskTree(context.Background(), "root", true)
 	if err != nil {
 		t.Fatalf("archive: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestDeleteTaskTree_IncludesArchivedDescendants(t *testing.T) {
 	tr := &fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)}
 	svc := NewHandoffService(tr, nil, nil, nil, groups, nil)
 
-	out, err := svc.DeleteTaskTree(context.Background(), "root")
+	out, err := svc.DeleteTaskTree(context.Background(), "root", true)
 	if err != nil {
 		t.Fatalf("delete: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestDeleteTaskTree_RemovesAllAndCancelsRuns(t *testing.T) {
 	canceller := &fakeRunCanceller{}
 	svc.SetRunCanceller(canceller)
 
-	out, err := svc.DeleteTaskTree(context.Background(), "root")
+	out, err := svc.DeleteTaskTree(context.Background(), "root", true)
 	if err != nil {
 		t.Fatalf("delete: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestArchiveTaskTree_CancelsRunsBeforeArchive(t *testing.T) {
 	canceller := &fakeRunCanceller{}
 	svc.SetRunCanceller(canceller)
 
-	if _, err := svc.ArchiveTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.ArchiveTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("archive: %v", err)
 	}
 	if len(canceller.calls) != 2 {
@@ -466,7 +466,7 @@ func TestArchiveTaskTree_RaceFree(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _ = svc.ArchiveTaskTree(context.Background(), "root")
+			_, _ = svc.ArchiveTaskTree(context.Background(), "root", true)
 		}()
 	}
 	wg.Wait()
@@ -524,7 +524,7 @@ func TestArchiveTaskTree_PublishesTaskUpdatedPerTask(t *testing.T) {
 	pub := &fakeEventPublisher{}
 	svc.SetTaskEventPublisher(pub)
 
-	if _, err := svc.ArchiveTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.ArchiveTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("archive: %v", err)
 	}
 
@@ -564,7 +564,7 @@ func TestDeleteTaskTree_PublishesTaskDeletedPerTask(t *testing.T) {
 	pub := &fakeEventPublisher{}
 	svc.SetTaskEventPublisher(pub)
 
-	if _, err := svc.DeleteTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.DeleteTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 
@@ -596,10 +596,10 @@ func TestCascade_NilEventPublisher_NoCrash(t *testing.T) {
 	svc := NewHandoffService(tr, nil, nil, nil, groups, nil)
 	// Intentionally NOT calling SetTaskEventPublisher.
 
-	if _, err := svc.ArchiveTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.ArchiveTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("archive with nil publisher: %v", err)
 	}
-	if _, err := svc.DeleteTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.DeleteTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("delete with nil publisher: %v", err)
 	}
 }
@@ -640,7 +640,7 @@ func TestArchiveTaskTree_InvokesResourceCleanerPerTask(t *testing.T) {
 	cleaner := &fakeResourceCleaner{}
 	svc.SetTaskResourceCleaner(cleaner)
 
-	if _, err := svc.ArchiveTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.ArchiveTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("archive: %v", err)
 	}
 
@@ -675,7 +675,7 @@ func TestDeleteTaskTree_InvokesResourceCleanerPerTask(t *testing.T) {
 	cleaner := &fakeResourceCleaner{}
 	svc.SetTaskResourceCleaner(cleaner)
 
-	if _, err := svc.DeleteTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.DeleteTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 
@@ -709,10 +709,84 @@ func TestCascade_NilResourceCleaner_NoCrash(t *testing.T) {
 	svc := NewHandoffService(tr, nil, nil, nil, groups, nil)
 	// Intentionally NOT calling SetTaskResourceCleaner.
 
-	if _, err := svc.ArchiveTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.ArchiveTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("archive with nil cleaner: %v", err)
 	}
-	if _, err := svc.DeleteTaskTree(context.Background(), "root"); err != nil {
+	if _, err := svc.DeleteTaskTree(context.Background(), "root", true); err != nil {
 		t.Fatalf("delete with nil cleaner: %v", err)
+	}
+}
+
+// TestArchiveTaskTree_NoCascade_LeavesChildrenActive pins the new
+// default: archiving a parent must NOT touch its subtasks unless the
+// caller explicitly opts in. The subtasks might still be in progress
+// and the user just wanted the parent off the board.
+func TestArchiveTaskTree_NoCascade_LeavesChildrenActive(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	tasks.addTask("c1", "root", "ws-1")
+	tasks.addTask("c2", "root", "ws-1")
+	groups := newCascadeWSGroupRepo()
+	svc := newCascadeService(t, tasks, groups)
+
+	out, err := svc.ArchiveTaskTree(context.Background(), "root", false)
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if len(out.ArchivedTaskIDs) != 1 || out.ArchivedTaskIDs[0] != "root" {
+		t.Errorf("ArchivedTaskIDs = %v, want [root]", out.ArchivedTaskIDs)
+	}
+	rootRow, _ := tasks.GetTask(context.Background(), "root")
+	if rootRow.ArchivedAt == nil {
+		t.Error("root should be archived")
+	}
+	for _, id := range []string{"c1", "c2"} {
+		child, _ := tasks.GetTask(context.Background(), id)
+		if child.ArchivedAt != nil {
+			t.Errorf("%s should remain active, got archived_at=%v", id, child.ArchivedAt)
+		}
+	}
+}
+
+// TestDeleteTaskTree_NoCascade_ReparentsDirectChildren verifies the
+// orphaning step: when the user deletes a parent without cascade, the
+// direct subtasks have their parent_id cleared so the deleted-row
+// pointer doesn't dangle. The subtask rows themselves survive.
+func TestDeleteTaskTree_NoCascade_ReparentsDirectChildren(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	tasks.addTask("c1", "root", "ws-1")
+	tasks.addTask("c2", "root", "ws-1")
+	tasks.addTask("g1", "c1", "ws-1") // grandchild — should NOT be reparented
+	groups := newCascadeWSGroupRepo()
+	tr := &fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)}
+	svc := NewHandoffService(tr, nil, nil, nil, groups, nil)
+
+	out, err := svc.DeleteTaskTree(context.Background(), "root", false)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(out.ArchivedTaskIDs) != 1 || out.ArchivedTaskIDs[0] != "root" {
+		t.Errorf("ArchivedTaskIDs = %v, want [root]", out.ArchivedTaskIDs)
+	}
+	if _, exists := tasks.tasks["root"]; exists {
+		t.Error("root should be removed")
+	}
+	for _, id := range []string{"c1", "c2"} {
+		child, ok := tasks.tasks[id]
+		if !ok {
+			t.Errorf("%s should NOT be deleted (cascade=false)", id)
+			continue
+		}
+		if child.ParentID != "" {
+			t.Errorf("%s.parent_id = %q, want empty (reparented to root)", id, child.ParentID)
+		}
+	}
+	g1, ok := tasks.tasks["g1"]
+	if !ok {
+		t.Fatal("g1 should not be deleted")
+	}
+	if g1.ParentID != "c1" {
+		t.Errorf("g1.parent_id = %q, want c1 (only direct children of root are reparented)", g1.ParentID)
 	}
 }

--- a/apps/backend/internal/task/service/handoff_cascade_test.go
+++ b/apps/backend/internal/task/service/handoff_cascade_test.go
@@ -749,6 +749,43 @@ func TestArchiveTaskTree_NoCascade_LeavesChildrenActive(t *testing.T) {
 	}
 }
 
+// TestDeleteTaskTree_NoCascade_PublishesUpdatedForReparentedChildren
+// pins the WS-event contract for the reparent step: after children are
+// reparented to root, the bus must carry one task.updated per child so
+// WS-driven clients refresh their cached parent_id pointers. Without
+// the publish, the kanban / sidebar would keep displaying the children
+// nested under the (now-deleted) parent until a manual reload.
+func TestDeleteTaskTree_NoCascade_PublishesUpdatedForReparentedChildren(t *testing.T) {
+	tasks := newFakeTaskRepo()
+	tasks.addTask("root", "", "ws-1")
+	tasks.addTask("c1", "root", "ws-1")
+	tasks.addTask("c2", "root", "ws-1")
+	groups := newCascadeWSGroupRepo()
+	tr := &fakeDeleteRepo{fakeCascadeRepo: newCascadeRepo(tasks)}
+	svc := NewHandoffService(tr, nil, nil, nil, groups, nil)
+	pub := &fakeEventPublisher{}
+	svc.SetTaskEventPublisher(pub)
+
+	if _, err := svc.DeleteTaskTree(context.Background(), "root", false); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	// We expect one update per direct child (c1, c2). The deleted root
+	// goes via PublishTaskDeleted, not PublishTaskUpdated.
+	want := map[string]bool{"c1": true, "c2": true}
+	for _, id := range pub.updated {
+		delete(want, id)
+	}
+	if len(want) > 0 {
+		t.Errorf("missing PublishTaskUpdated for reparented children: %v", want)
+	}
+	if len(pub.deleted) != 1 || pub.deleted[0] != "root" {
+		t.Errorf("expected exactly one task.deleted for root, got %v", pub.deleted)
+	}
+}
+
 // TestDeleteTaskTree_NoCascade_ReparentFailureAborts pins the safety
 // invariant: when the no-cascade reparent step fails we MUST refuse to
 // delete the parent. Continuing past a reparent error would leave

--- a/apps/backend/internal/task/service/handoff_workspace_test.go
+++ b/apps/backend/internal/task/service/handoff_workspace_test.go
@@ -237,6 +237,26 @@ func (f *fakeTaskRepo) ListChildren(_ context.Context, parentID string) ([]*mode
 	return out, nil
 }
 
+// ReparentDirectChildren mirrors the sqlite impl: every child of
+// oldParentID is updated to point at newParentID. Used by the
+// no-cascade delete tests to verify children are orphaned to root
+// rather than left dangling.
+func (f *fakeTaskRepo) ReparentDirectChildren(_ context.Context, oldParentID, newParentID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ids := f.children[oldParentID]
+	delete(f.children, oldParentID)
+	for _, id := range ids {
+		if t, ok := f.tasks[id]; ok {
+			t.ParentID = newParentID
+		}
+		if newParentID != "" {
+			f.children[newParentID] = append(f.children[newParentID], id)
+		}
+	}
+	return nil
+}
+
 func (f *fakeTaskRepo) ListChildrenIncludingArchived(_ context.Context, parentID string) ([]*models.Task, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -276,6 +296,9 @@ func (r *phase4TaskRepo) ListChildren(ctx context.Context, parentID string) ([]*
 }
 func (r *phase4TaskRepo) ListChildrenIncludingArchived(ctx context.Context, parentID string) ([]*models.Task, error) {
 	return r.base.ListChildrenIncludingArchived(ctx, parentID)
+}
+func (r *phase4TaskRepo) ReparentDirectChildren(ctx context.Context, oldParentID, newParentID string) error {
+	return r.base.ReparentDirectChildren(ctx, oldParentID, newParentID)
 }
 
 // All other TaskRepository methods panic — the AttachWorkspacePolicy

--- a/apps/web/app/tasks/columns.tsx
+++ b/apps/web/app/tasks/columns.tsx
@@ -23,8 +23,8 @@ interface ColumnsConfig {
   workflows: Workflow[];
   steps: WorkflowStep[];
   repositories: Repository[];
-  onArchive: (taskId: string) => void;
-  onDelete: (taskId: string) => void;
+  onArchive: (taskId: string, opts?: { cascade?: boolean }) => void;
+  onDelete: (taskId: string, opts?: { cascade?: boolean }) => void;
   deletingTaskId: string | null;
 }
 
@@ -61,8 +61,8 @@ function TitleCell({
 }
 
 type ActionsCtx = {
-  onArchive: (id: string) => void;
-  onDelete: (id: string) => void;
+  onArchive: (id: string, opts?: { cascade?: boolean }) => void;
+  onDelete: (id: string, opts?: { cascade?: boolean }) => void;
   deletingTaskId: string | null;
 };
 
@@ -117,14 +117,16 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
         open={showDeleteConfirm}
         onOpenChange={setShowDeleteConfirm}
         taskTitle={task.title}
+        taskId={task.id}
         isDeleting={isDeleting}
-        onConfirm={() => ctx.onDelete(task.id)}
+        onConfirm={({ cascade }) => ctx.onDelete(task.id, { cascade })}
       />
       <TaskArchiveConfirmDialog
         open={showArchiveConfirm}
         onOpenChange={setShowArchiveConfirm}
         taskTitle={task.title}
-        onConfirm={() => ctx.onArchive(task.id)}
+        taskId={task.id}
+        onConfirm={({ cascade }) => ctx.onArchive(task.id, { cascade })}
       />
     </div>
   );

--- a/apps/web/app/tasks/tasks-page-client.tsx
+++ b/apps/web/app/tasks/tasks-page-client.tsx
@@ -87,9 +87,9 @@ function useTaskOperations({
   ]);
 
   const handleArchive = useCallback(
-    async (taskId: string) => {
+    async (taskId: string, opts?: { cascade?: boolean }) => {
       try {
-        await archiveTask(taskId);
+        await archiveTask(taskId, opts);
         toast({ title: "Task archived", description: "The task has been archived successfully." });
         fetchTasks();
       } catch (err) {
@@ -104,10 +104,10 @@ function useTaskOperations({
   );
 
   const handleDelete = useCallback(
-    async (taskId: string) => {
+    async (taskId: string, opts?: { cascade?: boolean }) => {
       setDeletingTaskId(taskId);
       try {
-        await deleteTask(taskId);
+        await deleteTask(taskId, opts);
         fetchTasks();
       } catch (err) {
         toast({

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -61,8 +61,8 @@ interface KanbanCardProps {
   repositoryNames?: string[];
   onClick?: (task: Task) => void;
   onEdit?: (task: Task) => void;
-  onDelete?: (task: Task) => void;
-  onArchive?: (task: Task) => void;
+  onDelete?: (task: Task, opts?: { cascade?: boolean }) => void;
+  onArchive?: (task: Task, opts?: { cascade?: boolean }) => void;
   onOpenFullPage?: (task: Task) => void;
   onMove?: (task: Task, targetStepId: string) => void;
   steps?: WorkflowStep[];
@@ -249,15 +249,17 @@ export function KanbanCard({
         open={showDeleteConfirm}
         onOpenChange={setShowDeleteConfirm}
         taskTitle={task.title}
+        taskId={task.id}
         isDeleting={isDeleting}
-        onConfirm={() => onDelete?.(task)}
+        onConfirm={({ cascade }) => onDelete?.(task, { cascade })}
       />
       <TaskArchiveConfirmDialog
         open={showArchiveConfirm}
         onOpenChange={setShowArchiveConfirm}
         taskTitle={task.title}
+        taskId={task.id}
         isArchiving={isArchiving}
-        onConfirm={() => onArchive?.(task)}
+        onConfirm={({ cascade }) => onArchive?.(task, { cascade })}
       />
     </>
   );

--- a/apps/web/components/kanban/graph2-task-pipeline.tsx
+++ b/apps/web/components/kanban/graph2-task-pipeline.tsx
@@ -43,8 +43,8 @@ export type Graph2TaskPipelineProps = {
   onMoveTask: (task: Task, targetStepId: string) => void;
   onPreviewTask: (task: Task) => void;
   onOpenTask: (task: Task) => void;
-  onDeleteTask: (task: Task) => void;
-  onArchiveTask?: (task: Task) => void;
+  onDeleteTask: (task: Task, opts?: { cascade?: boolean }) => void;
+  onArchiveTask?: (task: Task, opts?: { cascade?: boolean }) => void;
   isMoving?: boolean;
   isDeleting?: boolean;
   isArchiving?: boolean;
@@ -164,15 +164,17 @@ function TaskActions({
         open={showDeleteConfirm}
         onOpenChange={setShowDeleteConfirm}
         taskTitle={task.title}
+        taskId={task.id}
         isDeleting={isDeleting}
-        onConfirm={() => onDeleteTask(task)}
+        onConfirm={({ cascade }) => onDeleteTask(task, { cascade })}
       />
       <TaskArchiveConfirmDialog
         open={showArchiveConfirm}
         onOpenChange={setShowArchiveConfirm}
         taskTitle={task.title}
+        taskId={task.id}
         isArchiving={isArchiving}
-        onConfirm={() => onArchiveTask?.(task)}
+        onConfirm={({ cascade }) => onArchiveTask?.(task, { cascade })}
       />
     </>
   );

--- a/apps/web/components/kanban/task-multi-select-toolbar.tsx
+++ b/apps/web/components/kanban/task-multi-select-toolbar.tsx
@@ -20,19 +20,21 @@ interface TaskMultiSelectToolbarProps {
   isProcessing: boolean;
   canMove?: boolean;
   onClearSelection: () => void;
-  onBulkDelete: () => Promise<void>;
-  onBulkArchive: () => Promise<void>;
+  onBulkDelete: (opts?: { cascade?: boolean }) => Promise<void>;
+  onBulkArchive: (opts?: { cascade?: boolean }) => Promise<void>;
   onBulkMove: (targetStepId: string) => Promise<void>;
 }
 
 function BulkArchiveDialog({
   count,
+  taskIds,
   isProcessing,
   onConfirm,
 }: {
   count: number;
+  taskIds: string[];
   isProcessing: boolean;
-  onConfirm: () => void;
+  onConfirm: (opts: { cascade: boolean }) => void;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -54,6 +56,7 @@ function BulkArchiveDialog({
         onOpenChange={setOpen}
         isBulkOperation
         count={count}
+        taskIds={taskIds}
         isArchiving={isProcessing}
         onConfirm={onConfirm}
         confirmTestId="bulk-archive-confirm"
@@ -64,12 +67,14 @@ function BulkArchiveDialog({
 
 function BulkDeleteDialog({
   count,
+  taskIds,
   isProcessing,
   onConfirm,
 }: {
   count: number;
+  taskIds: string[];
   isProcessing: boolean;
-  onConfirm: () => void;
+  onConfirm: (opts: { cascade: boolean }) => void;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -91,6 +96,7 @@ function BulkDeleteDialog({
         onOpenChange={setOpen}
         isBulkOperation
         count={count}
+        taskIds={taskIds}
         isDeleting={isProcessing}
         onConfirm={onConfirm}
         confirmTestId="bulk-delete-confirm"
@@ -157,14 +163,16 @@ export function TaskMultiSelectToolbar({
 
       <BulkArchiveDialog
         count={count}
+        taskIds={[...selectedIds]}
         isProcessing={isProcessing}
-        onConfirm={() => onBulkArchive()}
+        onConfirm={({ cascade }) => onBulkArchive({ cascade })}
       />
 
       <BulkDeleteDialog
         count={count}
+        taskIds={[...selectedIds]}
         isProcessing={isProcessing}
-        onConfirm={() => onBulkDelete()}
+        onConfirm={({ cascade }) => onBulkDelete({ cascade })}
       />
 
       <Button

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -413,24 +413,27 @@ function useSheetDeleteActions(
     [store],
   );
 
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!deletingTask || isDeleting) return;
-    const taskId = deletingTask.id;
-    setIsDeleting(true);
-    // Capture active state before the async API call — the WS "task.deleted"
-    // handler may clear activeTaskId/activeSessionId before removeTaskFromBoard runs.
-    const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
-      store.getState().tasks;
-    try {
-      await deleteTaskById(taskId);
-      await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
-    } catch (error) {
-      console.error("Failed to delete task:", error);
-    } finally {
-      setIsDeleting(false);
-      setDeletingTask(null);
-    }
-  }, [deletingTask, isDeleting, deleteTaskById, removeTaskFromBoard, store]);
+  const handleDeleteConfirm = useCallback(
+    async (opts?: { cascade?: boolean }) => {
+      if (!deletingTask || isDeleting) return;
+      const taskId = deletingTask.id;
+      setIsDeleting(true);
+      // Capture active state before the async API call — the WS "task.deleted"
+      // handler may clear activeTaskId/activeSessionId before removeTaskFromBoard runs.
+      const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
+        store.getState().tasks;
+      try {
+        await deleteTaskById(taskId, opts);
+        await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
+      } catch (error) {
+        console.error("Failed to delete task:", error);
+      } finally {
+        setIsDeleting(false);
+        setDeletingTask(null);
+      }
+    },
+    [deletingTask, isDeleting, deleteTaskById, removeTaskFromBoard, store],
+  );
 
   const deletingTaskId = isDeleting ? (deletingTask?.id ?? null) : null;
 
@@ -490,18 +493,21 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
     [store],
   );
 
-  const handleArchiveConfirm = useCallback(async () => {
-    if (!archivingTask) return;
-    setIsArchiving(true);
-    try {
-      await archiveAndSwitch(archivingTask.id);
-    } catch (error) {
-      console.error("Failed to archive task:", error);
-    } finally {
-      setIsArchiving(false);
-      setArchivingTask(null);
-    }
-  }, [archivingTask, archiveAndSwitch]);
+  const handleArchiveConfirm = useCallback(
+    async (opts?: { cascade?: boolean }) => {
+      if (!archivingTask) return;
+      setIsArchiving(true);
+      try {
+        await archiveAndSwitch(archivingTask.id, opts);
+      } catch (error) {
+        console.error("Failed to archive task:", error);
+      } finally {
+        setIsArchiving(false);
+        setArchivingTask(null);
+      }
+    },
+    [archivingTask, archiveAndSwitch],
+  );
 
   const { handleWorkspaceChange, handleTaskCreated } = useWorkspaceAndTaskCreatedActions({
     workspaceId,

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -148,8 +148,9 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
           if (!open) actions.setArchivingTask(null);
         }}
         taskTitle={actions.archivingTask?.title ?? ""}
+        taskId={actions.archivingTask?.id}
         isArchiving={actions.isArchiving}
-        onConfirm={actions.handleArchiveConfirm}
+        onConfirm={({ cascade }) => actions.handleArchiveConfirm({ cascade })}
       />
       <TaskDeleteConfirmDialog
         open={actions.deletingTask !== null}
@@ -157,8 +158,9 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
           if (!open) actions.setDeletingTask(null);
         }}
         taskTitle={actions.deletingTask?.title ?? ""}
+        taskId={actions.deletingTask?.id}
         isDeleting={actions.isDeleting}
-        onConfirm={actions.handleDeleteConfirm}
+        onConfirm={({ cascade }) => actions.handleDeleteConfirm({ cascade })}
       />
     </Sheet>
   );

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { IconLoader } from "@tabler/icons-react";
 import {
   AlertDialog,
@@ -11,6 +12,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
+import { Checkbox } from "@kandev/ui/checkbox";
+import { getSubtaskCount } from "@/lib/api";
 
 type TaskArchiveConfirmDialogProps = {
   open: boolean;
@@ -19,7 +22,9 @@ type TaskArchiveConfirmDialogProps = {
   isBulkOperation?: boolean;
   count?: number;
   isArchiving?: boolean;
-  onConfirm: () => void;
+  taskId?: string;
+  taskIds?: string[];
+  onConfirm: (opts: { cascade: boolean }) => void;
   confirmTestId?: string;
 };
 
@@ -30,6 +35,8 @@ export function TaskArchiveConfirmDialog({
   isBulkOperation,
   count,
   isArchiving,
+  taskId,
+  taskIds,
   onConfirm,
   confirmTestId,
 }: TaskArchiveConfirmDialogProps) {
@@ -40,8 +47,16 @@ export function TaskArchiveConfirmDialog({
     ? `Are you sure you want to archive ${safeCount} ${label}?`
     : `Are you sure you want to archive "${taskTitle}"?`;
 
+  const [cascade, setCascade] = useState(false);
+  const subtaskCount = useSubtaskCount(open, taskId, taskIds);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setCascade(false);
+    onOpenChange(next);
+  };
+
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent onClick={(e) => e.stopPropagation()}>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
@@ -54,6 +69,22 @@ export function TaskArchiveConfirmDialog({
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
+        {subtaskCount > 0 && (
+          <label className="flex items-start gap-2 text-sm cursor-pointer">
+            <Checkbox
+              checked={cascade}
+              onCheckedChange={(v) => setCascade(v === true)}
+              disabled={isArchiving}
+              data-testid="archive-cascade-checkbox"
+            />
+            <span>
+              Also archive {subtaskCount} subtask{subtaskCount === 1 ? "" : "s"}
+              <span className="block text-xs text-muted-foreground">
+                Subtasks stay active unless you tick this. They may still be in progress.
+              </span>
+            </span>
+          </label>
+        )}
         <AlertDialogFooter>
           <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
           <AlertDialogAction
@@ -62,8 +93,8 @@ export function TaskArchiveConfirmDialog({
             data-testid={confirmTestId}
             onClick={() => {
               if (isArchiving) return;
-              onConfirm();
-              onOpenChange(false);
+              onConfirm({ cascade });
+              handleOpenChange(false);
             }}
           >
             {isArchiving ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}
@@ -73,4 +104,30 @@ export function TaskArchiveConfirmDialog({
       </AlertDialogContent>
     </AlertDialog>
   );
+}
+
+// useSubtaskCount fetches the subtask count for the dialog when it
+// opens. Returns 0 while loading, when the request fails, or when no
+// task identifier is supplied — in all of those cases the checkbox
+// stays hidden, matching the pre-cascade-toggle behavior.
+function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string[]): number {
+  const [total, setTotal] = useState(0);
+  useEffect(() => {
+    if (!open) return;
+    const ids = taskIds ?? (taskId ? [taskId] : []);
+    if (ids.length === 0) return;
+    let cancelled = false;
+    Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 }))))
+      .then((results) => {
+        if (cancelled) return;
+        setTotal(results.reduce((sum, r) => sum + r.count, 0));
+      })
+      .catch(() => {
+        // swallow — leaves total at its prior value (0 on first run)
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, taskId, taskIds]);
+  return open ? total : 0;
 }

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { IconLoader } from "@tabler/icons-react";
 import {
   AlertDialog,
@@ -13,7 +13,7 @@ import {
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
 import { Checkbox } from "@kandev/ui/checkbox";
-import { getSubtaskCount } from "@/lib/api";
+import { useSubtaskCount } from "@/hooks/use-subtask-count";
 
 type TaskArchiveConfirmDialogProps = {
   open: boolean;
@@ -104,30 +104,4 @@ export function TaskArchiveConfirmDialog({
       </AlertDialogContent>
     </AlertDialog>
   );
-}
-
-// useSubtaskCount fetches the subtask count for the dialog when it
-// opens. Returns 0 while loading, when the request fails, or when no
-// task identifier is supplied — in all of those cases the checkbox
-// stays hidden, matching the pre-cascade-toggle behavior.
-function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string[]): number {
-  const [total, setTotal] = useState(0);
-  useEffect(() => {
-    if (!open) return;
-    const ids = taskIds ?? (taskId ? [taskId] : []);
-    if (ids.length === 0) return;
-    let cancelled = false;
-    Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 }))))
-      .then((results) => {
-        if (cancelled) return;
-        setTotal(results.reduce((sum, r) => sum + r.count, 0));
-      })
-      .catch(() => {
-        // swallow — leaves total at its prior value (0 on first run)
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, taskId, taskIds]);
-  return open ? total : 0;
 }

--- a/apps/web/components/task/task-delete-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/re
 
 const mockGetSubtaskCount = vi.fn();
 
-vi.mock("@/lib/api/domains/kanban-api", () => ({
+vi.mock("@/lib/api", () => ({
   getSubtaskCount: (...args: unknown[]) => mockGetSubtaskCount(...args),
 }));
 

--- a/apps/web/components/task/task-delete-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
+
+const mockGetSubtaskCount = vi.fn();
+
+vi.mock("@/lib/api/domains/kanban-api", () => ({
+  getSubtaskCount: (...args: unknown[]) => mockGetSubtaskCount(...args),
+}));
+
+import { TaskDeleteConfirmDialog } from "./task-delete-confirm-dialog";
+
+beforeEach(() => {
+  mockGetSubtaskCount.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("TaskDeleteConfirmDialog", () => {
+  it("hides the cascade checkbox when the task has no subtasks", async () => {
+    mockGetSubtaskCount.mockResolvedValue({ count: 0 });
+    const onConfirm = vi.fn();
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        onConfirm={onConfirm}
+        confirmTestId="confirm"
+      />,
+    );
+    await waitFor(() => expect(mockGetSubtaskCount).toHaveBeenCalledWith("task-1"));
+    expect(screen.queryByTestId("delete-cascade-checkbox")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("confirm"));
+    expect(onConfirm).toHaveBeenCalledWith({ cascade: false });
+  });
+
+  it("shows the cascade checkbox when the task has subtasks; defaults to unchecked", async () => {
+    mockGetSubtaskCount.mockResolvedValue({ count: 3 });
+    const onConfirm = vi.fn();
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        onConfirm={onConfirm}
+        confirmTestId="confirm"
+      />,
+    );
+    await screen.findByTestId("delete-cascade-checkbox");
+    expect(screen.getByText(/Also delete 3 subtasks/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("confirm"));
+    expect(onConfirm).toHaveBeenCalledWith({ cascade: false });
+  });
+
+  it("propagates cascade=true when the user ticks the checkbox", async () => {
+    mockGetSubtaskCount.mockResolvedValue({ count: 2 });
+    const onConfirm = vi.fn();
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        onConfirm={onConfirm}
+        confirmTestId="confirm"
+      />,
+    );
+    const checkbox = await screen.findByTestId("delete-cascade-checkbox");
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByTestId("confirm"));
+    expect(onConfirm).toHaveBeenCalledWith({ cascade: true });
+  });
+
+  it("sums subtask counts across taskIds for bulk delete", async () => {
+    mockGetSubtaskCount.mockImplementation((id: string) =>
+      Promise.resolve({ count: id === "a" ? 2 : 5 }),
+    );
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        isBulkOperation
+        count={2}
+        taskIds={["a", "b"]}
+        onConfirm={() => {}}
+      />,
+    );
+    await screen.findByText(/Also delete 7 subtasks/i);
+  });
+});

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { IconLoader } from "@tabler/icons-react";
 import {
   AlertDialog,
@@ -9,6 +12,21 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
+import { Checkbox } from "@kandev/ui/checkbox";
+import { getSubtaskCount } from "@/lib/api";
+
+type TaskDeleteConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  taskTitle?: string;
+  isBulkOperation?: boolean;
+  count?: number;
+  isDeleting?: boolean;
+  taskId?: string;
+  taskIds?: string[];
+  onConfirm: (opts: { cascade: boolean }) => void;
+  confirmTestId?: string;
+};
 
 export function TaskDeleteConfirmDialog({
   open,
@@ -17,18 +35,11 @@ export function TaskDeleteConfirmDialog({
   isBulkOperation,
   count,
   isDeleting,
+  taskId,
+  taskIds,
   onConfirm,
   confirmTestId,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  taskTitle?: string;
-  isBulkOperation?: boolean;
-  count?: number;
-  isDeleting?: boolean;
-  onConfirm: () => void;
-  confirmTestId?: string;
-}) {
+}: TaskDeleteConfirmDialogProps) {
   const safeCount = count ?? 0;
   const label = isBulkOperation ? `task${safeCount !== 1 ? "s" : ""}` : "task";
   const title = isBulkOperation ? `Delete ${safeCount} ${label}` : "Delete task";
@@ -36,13 +47,37 @@ export function TaskDeleteConfirmDialog({
     ? `Are you sure you want to delete ${safeCount} ${label}? This action cannot be undone.`
     : `Are you sure you want to delete "${taskTitle}"? This action cannot be undone.`;
 
+  const [cascade, setCascade] = useState(false);
+  const subtaskCount = useSubtaskCount(open, taskId, taskIds);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setCascade(false);
+    onOpenChange(next);
+  };
+
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent onClick={(e) => e.stopPropagation()}>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
+        {subtaskCount > 0 && (
+          <label className="flex items-start gap-2 text-sm cursor-pointer">
+            <Checkbox
+              checked={cascade}
+              onCheckedChange={(v) => setCascade(v === true)}
+              disabled={isDeleting}
+              data-testid="delete-cascade-checkbox"
+            />
+            <span>
+              Also delete {subtaskCount} subtask{subtaskCount === 1 ? "" : "s"}
+              <span className="block text-xs text-muted-foreground">
+                Subtasks become root tasks unless you tick this. They may still be in progress.
+              </span>
+            </span>
+          </label>
+        )}
         <AlertDialogFooter>
           <AlertDialogCancel className="cursor-pointer">Cancel</AlertDialogCancel>
           <AlertDialogAction
@@ -51,8 +86,8 @@ export function TaskDeleteConfirmDialog({
             data-testid={confirmTestId}
             onClick={() => {
               if (isDeleting) return;
-              onConfirm();
-              onOpenChange(false);
+              onConfirm({ cascade });
+              handleOpenChange(false);
             }}
           >
             {isDeleting ? <IconLoader className="mr-2 h-4 w-4 animate-spin" /> : null}
@@ -62,4 +97,26 @@ export function TaskDeleteConfirmDialog({
       </AlertDialogContent>
     </AlertDialog>
   );
+}
+
+function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string[]): number {
+  const [total, setTotal] = useState(0);
+  useEffect(() => {
+    if (!open) return;
+    const ids = taskIds ?? (taskId ? [taskId] : []);
+    if (ids.length === 0) return;
+    let cancelled = false;
+    Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 }))))
+      .then((results) => {
+        if (cancelled) return;
+        setTotal(results.reduce((sum, r) => sum + r.count, 0));
+      })
+      .catch(() => {
+        // swallow — leaves total at its prior value (0 on first run)
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, taskId, taskIds]);
+  return open ? total : 0;
 }

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { IconLoader } from "@tabler/icons-react";
 import {
   AlertDialog,
@@ -13,7 +13,7 @@ import {
   AlertDialogTitle,
 } from "@kandev/ui/alert-dialog";
 import { Checkbox } from "@kandev/ui/checkbox";
-import { getSubtaskCount } from "@/lib/api";
+import { useSubtaskCount } from "@/hooks/use-subtask-count";
 
 type TaskDeleteConfirmDialogProps = {
   open: boolean;
@@ -97,26 +97,4 @@ export function TaskDeleteConfirmDialog({
       </AlertDialogContent>
     </AlertDialog>
   );
-}
-
-function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string[]): number {
-  const [total, setTotal] = useState(0);
-  useEffect(() => {
-    if (!open) return;
-    const ids = taskIds ?? (taskId ? [taskId] : []);
-    if (ids.length === 0) return;
-    let cancelled = false;
-    Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 }))))
-      .then((results) => {
-        if (cancelled) return;
-        setTotal(results.reduce((sum, r) => sum + r.count, 0));
-      })
-      .catch(() => {
-        // swallow — leaves total at its prior value (0 on first run)
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, taskId, taskIds]);
-  return open ? total : 0;
 }

--- a/apps/web/components/task/task-session-sidebar-dialogs.tsx
+++ b/apps/web/components/task/task-session-sidebar-dialogs.tsx
@@ -13,11 +13,11 @@ export type SidebarDialogsActions = {
   archivingTask: Target;
   setArchivingTask: (next: Target) => void;
   isArchiving: boolean;
-  handleArchiveConfirm: () => Promise<void> | void;
+  handleArchiveConfirm: (opts: { cascade: boolean }) => Promise<void> | void;
   deletingTask: Target;
   setDeletingTask: (next: Target) => void;
   isDeleting: boolean;
-  handleDeleteConfirm: () => Promise<void> | void;
+  handleDeleteConfirm: (opts: { cascade: boolean }) => Promise<void> | void;
 };
 
 export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) {
@@ -50,6 +50,7 @@ export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) 
           if (!open) setArchivingTask(null);
         }}
         taskTitle={archivingTask?.title ?? ""}
+        taskId={archivingTask?.id}
         isArchiving={isArchiving}
         onConfirm={handleArchiveConfirm}
       />
@@ -59,6 +60,7 @@ export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) 
           if (!open) setDeletingTask(null);
         }}
         taskTitle={deletingTask?.title ?? ""}
+        taskId={deletingTask?.id}
         isDeleting={isDeleting}
         onConfirm={handleDeleteConfirm}
       />

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -430,18 +430,21 @@ function useArchiveActions(store: StoreApi) {
     [store],
   );
 
-  const handleArchiveConfirm = useCallback(async () => {
-    if (!archivingTask) return;
-    setIsArchiving(true);
-    try {
-      await archiveAndSwitch(archivingTask.id);
-    } catch (error) {
-      console.error("Failed to archive task:", error);
-    } finally {
-      setIsArchiving(false);
-      setArchivingTask(null);
-    }
-  }, [archivingTask, archiveAndSwitch]);
+  const handleArchiveConfirm = useCallback(
+    async (opts: { cascade: boolean }) => {
+      if (!archivingTask) return;
+      setIsArchiving(true);
+      try {
+        await archiveAndSwitch(archivingTask.id, opts);
+      } catch (error) {
+        console.error("Failed to archive task:", error);
+      } finally {
+        setIsArchiving(false);
+        setArchivingTask(null);
+      }
+    },
+    [archivingTask, archiveAndSwitch],
+  );
 
   return { archivingTask, setArchivingTask, isArchiving, handleArchiveTask, handleArchiveConfirm };
 }
@@ -462,22 +465,25 @@ function useDeleteActions(
     [store],
   );
 
-  const handleDeleteConfirm = useCallback(async () => {
-    if (!deletingTask || isDeleting) return;
-    const taskId = deletingTask.id;
-    setIsDeleting(true);
-    const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
-      store.getState().tasks;
-    try {
-      await deleteTaskById(taskId);
-      await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
-    } catch (error) {
-      console.error("Failed to delete task:", error);
-    } finally {
-      setIsDeleting(false);
-      setDeletingTask(null);
-    }
-  }, [deletingTask, isDeleting, deleteTaskById, removeTaskFromBoard, store]);
+  const handleDeleteConfirm = useCallback(
+    async (opts: { cascade: boolean }) => {
+      if (!deletingTask || isDeleting) return;
+      const taskId = deletingTask.id;
+      setIsDeleting(true);
+      const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
+        store.getState().tasks;
+      try {
+        await deleteTaskById(taskId, opts);
+        await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
+      } catch (error) {
+        console.error("Failed to delete task:", error);
+      } finally {
+        setIsDeleting(false);
+        setDeletingTask(null);
+      }
+    },
+    [deletingTask, isDeleting, deleteTaskById, removeTaskFromBoard, store],
+  );
 
   const deletingTaskId = isDeleting ? (deletingTask?.id ?? null) : null;
 

--- a/apps/web/e2e/tests/kanban/cascade-subtasks-toggle.spec.ts
+++ b/apps/web/e2e/tests/kanban/cascade-subtasks-toggle.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+
+const VISIBLE_TIMEOUT = 10_000;
+
+// E2E coverage for the no-cascade-by-default archive / delete behaviour:
+// the confirmation dialog must expose an opt-in checkbox when the task
+// has live subtasks, default to unchecked (subtasks preserved), and
+// propagate the choice to the backend.
+test.describe("Kanban card archive — cascade subtasks toggle", () => {
+  test("renders the cascade checkbox only when the task has subtasks", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const lonely = await apiClient.createTask(seedData.workspaceId, "No-Subtasks Parent", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCard(lonely.id)).toBeVisible({ timeout: VISIBLE_TIMEOUT });
+
+    await kanban.openTaskActionsMenu(lonely.id);
+    await testPage.getByRole("menuitem", { name: "Archive" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    // No subtasks → no checkbox.
+    await expect(testPage.getByTestId("archive-cascade-checkbox")).toHaveCount(0);
+  });
+
+  test("archiving the parent without ticking the box leaves subtasks on the board", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const parent = await apiClient.createTask(seedData.workspaceId, "Parent Keep Subs", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Survivor Subtask A", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      parent_id: parent.id,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Survivor Subtask B", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      parent_id: parent.id,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCardByTitle("Parent Keep Subs")).toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+
+    await kanban.openTaskActionsMenu(parent.id);
+    await testPage.getByRole("menuitem", { name: "Archive" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    // Checkbox is present, displays the count, and is unchecked by default.
+    const cascade = testPage.getByTestId("archive-cascade-checkbox");
+    await expect(cascade).toBeVisible();
+    await expect(dialog).toContainText("Also archive 2 subtasks");
+    await expect(cascade).not.toBeChecked();
+
+    await dialog.getByRole("button", { name: "Archive" }).click();
+
+    // Parent leaves the board, subtasks stay.
+    await expect(kanban.taskCardByTitle("Parent Keep Subs")).not.toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+    await expect(kanban.taskCardByTitle("Survivor Subtask A")).toBeVisible();
+    await expect(kanban.taskCardByTitle("Survivor Subtask B")).toBeVisible();
+  });
+
+  test("ticking the cascade checkbox archives subtasks too", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const parent = await apiClient.createTask(seedData.workspaceId, "Parent Cascade Subs", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Doomed Subtask A", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      parent_id: parent.id,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Doomed Subtask B", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      parent_id: parent.id,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCardByTitle("Parent Cascade Subs")).toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+
+    await kanban.openTaskActionsMenu(parent.id);
+    await testPage.getByRole("menuitem", { name: "Archive" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    const cascade = testPage.getByTestId("archive-cascade-checkbox");
+    await expect(cascade).toBeVisible();
+    await cascade.click();
+    await expect(cascade).toBeChecked();
+
+    await dialog.getByRole("button", { name: "Archive" }).click();
+
+    await expect(kanban.taskCardByTitle("Parent Cascade Subs")).not.toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+    await expect(kanban.taskCardByTitle("Doomed Subtask A")).not.toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+    await expect(kanban.taskCardByTitle("Doomed Subtask B")).not.toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+  });
+});
+
+test.describe("Kanban card delete — cascade subtasks toggle", () => {
+  test("deleting the parent without ticking the box reparents subtasks to root", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const parent = await apiClient.createTask(seedData.workspaceId, "Parent Delete Keep", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Orphaned Subtask", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      parent_id: parent.id,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCardByTitle("Parent Delete Keep")).toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+
+    await kanban.openTaskActionsMenu(parent.id);
+    await testPage.getByRole("menuitem", { name: "Delete" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    const cascade = testPage.getByTestId("delete-cascade-checkbox");
+    await expect(cascade).toBeVisible();
+    await expect(dialog).toContainText("Also delete 1 subtask");
+    await expect(cascade).not.toBeChecked();
+
+    await dialog.getByRole("button", { name: "Delete" }).click();
+
+    // Parent is gone, child survives (now reparented to root with no
+    // subtask badge — the badge requires a live parent on the board).
+    await expect(kanban.taskCardByTitle("Parent Delete Keep")).not.toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+    const survivor = kanban.taskCardByTitle("Orphaned Subtask");
+    await expect(survivor).toBeVisible();
+    await expect(survivor.getByText("Parent Delete Keep")).not.toBeVisible();
+  });
+
+  test("ticking the cascade checkbox deletes subtasks too", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const parent = await apiClient.createTask(seedData.workspaceId, "Parent Delete Cascade", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await apiClient.createTask(seedData.workspaceId, "Cascaded Doomed Subtask", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      parent_id: parent.id,
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCardByTitle("Parent Delete Cascade")).toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+
+    await kanban.openTaskActionsMenu(parent.id);
+    await testPage.getByRole("menuitem", { name: "Delete" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    const cascade = testPage.getByTestId("delete-cascade-checkbox");
+    await expect(cascade).toBeVisible();
+    await cascade.click();
+    await expect(cascade).toBeChecked();
+
+    await dialog.getByRole("button", { name: "Delete" }).click();
+
+    await expect(kanban.taskCardByTitle("Parent Delete Cascade")).not.toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+    await expect(kanban.taskCardByTitle("Cascaded Doomed Subtask")).not.toBeVisible({
+      timeout: VISIBLE_TIMEOUT,
+    });
+  });
+});

--- a/apps/web/hooks/use-subtask-count.test.ts
+++ b/apps/web/hooks/use-subtask-count.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const mockGetSubtaskCount = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  getSubtaskCount: (...args: unknown[]) => mockGetSubtaskCount(...args),
+}));
+
+import { useSubtaskCount } from "./use-subtask-count";
+
+beforeEach(() => {
+  mockGetSubtaskCount.mockReset();
+});
+
+describe("useSubtaskCount", () => {
+  it("returns 0 when the dialog is closed", () => {
+    const { result } = renderHook(() => useSubtaskCount(false, "task-1"));
+    expect(result.current).toBe(0);
+    expect(mockGetSubtaskCount).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 while the fetch is in flight, then the resolved total", async () => {
+    let resolveFetch: (v: { count: number }) => void = () => {};
+    mockGetSubtaskCount.mockReturnValue(
+      new Promise<{ count: number }>((res) => {
+        resolveFetch = res;
+      }),
+    );
+    const { result } = renderHook(() => useSubtaskCount(true, "task-1"));
+    expect(result.current).toBe(0);
+    resolveFetch({ count: 7 });
+    await waitFor(() => expect(result.current).toBe(7));
+  });
+
+  it("returns 0 immediately when reopened for a different task until the fetch lands", async () => {
+    mockGetSubtaskCount.mockImplementation((id: string) =>
+      Promise.resolve({ count: id === "a" ? 3 : 0 }),
+    );
+    const { result, rerender } = renderHook(
+      ({ open, taskId }: { open: boolean; taskId: string }) => useSubtaskCount(open, taskId),
+      { initialProps: { open: true, taskId: "a" } },
+    );
+    await waitFor(() => expect(result.current).toBe(3));
+
+    rerender({ open: false, taskId: "a" });
+    expect(result.current).toBe(0);
+
+    // Reopen for a different task — should return 0 until the new
+    // fetch resolves (no stale 3 flashing through).
+    rerender({ open: true, taskId: "b" });
+    expect(result.current).toBe(0);
+    await waitFor(() => expect(result.current).toBe(0));
+  });
+
+  it("sums counts across multiple task ids for bulk operations", async () => {
+    mockGetSubtaskCount.mockImplementation((id: string) =>
+      Promise.resolve({ count: id === "a" ? 2 : 5 }),
+    );
+    const { result } = renderHook(() => useSubtaskCount(true, undefined, ["a", "b"]));
+    await waitFor(() => expect(result.current).toBe(7));
+  });
+});

--- a/apps/web/hooks/use-subtask-count.ts
+++ b/apps/web/hooks/use-subtask-count.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { getSubtaskCount } from "@/lib/api";
+
+// useSubtaskCount fetches the subtask count for an archive / delete
+// confirmation dialog when it opens. Returns 0 while the request for
+// the current set of ids is still in flight (or fails, or no ids were
+// supplied) — in all of those cases the dialog's cascade checkbox
+// stays hidden.
+//
+// The hook keys the stored count by a stable string of the requested
+// ids. When the caller passes a different task (e.g. the dialog is
+// closed and reopened for another row) the stale count is no longer
+// returned, preventing the "Also archive 3 subtasks" label from
+// flashing for a task that actually has 0. This also lets us depend on
+// the joined string instead of the taskIds array — unstable array
+// references (the multi-select toolbar spreads `selectedIds` on every
+// render) no longer fan out a new Promise.all on every render.
+export function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string[]): number {
+  const idsKey = taskIds?.join(",") ?? taskId ?? "";
+  const [{ key, total }, setResult] = useState<{ key: string; total: number }>({
+    key: "",
+    total: 0,
+  });
+  useEffect(() => {
+    if (!open || !idsKey) return;
+    const ids = taskIds ?? (taskId ? [taskId] : []);
+    let cancelled = false;
+    Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 }))))
+      .then((results) => {
+        if (cancelled) return;
+        setResult({ key: idsKey, total: results.reduce((sum, r) => sum + r.count, 0) });
+      })
+      .catch(() => {
+        // swallow — leaves prior result untouched; the stale-key gate
+        // below still suppresses any leftover total.
+      });
+    return () => {
+      cancelled = true;
+    };
+    // taskId / taskIds intentionally excluded — idsKey is their stable summary.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, idsKey]);
+  return open && key === idsKey ? total : 0;
+}

--- a/apps/web/hooks/use-subtask-count.ts
+++ b/apps/web/hooks/use-subtask-count.ts
@@ -7,22 +7,28 @@ import { getSubtaskCount } from "@/lib/api";
 // supplied) — in all of those cases the dialog's cascade checkbox
 // stays hidden.
 //
-// The hook keys the stored count by a stable string of the requested
-// ids. When the caller passes a different task (e.g. the dialog is
-// closed and reopened for another row) the stale count is no longer
-// returned, preventing the "Also archive 3 subtasks" label from
-// flashing for a task that actually has 0. This also lets us depend on
-// the joined string instead of the taskIds array — unstable array
-// references (the multi-select toolbar spreads `selectedIds` on every
-// render) no longer fan out a new Promise.all on every render.
+// The stored count is keyed by a stable string of the requested ids
+// AND only returned while the dialog reports `open=true`. Closing the
+// dialog clears the cache, so reopening — even for the same task —
+// shows 0 until the fresh fetch lands. This avoids a stale count from
+// a previous opening flashing before the new request resolves and
+// stops the bulk toolbar's per-render `[...selectedIds]` from fanning
+// out a new Promise.all on every render.
 export function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string[]): number {
   const idsKey = taskIds?.join(",") ?? taskId ?? "";
-  const [{ key, total }, setResult] = useState<{ key: string; total: number }>({
+  const [result, setResult] = useState<{ key: string; total: number }>({
     key: "",
     total: 0,
   });
   useEffect(() => {
-    if (!open || !idsKey) return;
+    if (!open) {
+      // Clear so the next open starts from a known-empty state —
+      // this is what gates stale counts from leaking across separate
+      // dialog openings for the same id.
+      setResult({ key: "", total: 0 });
+      return;
+    }
+    if (!idsKey) return;
     const ids = taskIds ?? (taskId ? [taskId] : []);
     let cancelled = false;
     Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 }))))
@@ -31,8 +37,8 @@ export function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string
         setResult({ key: idsKey, total: results.reduce((sum, r) => sum + r.count, 0) });
       })
       .catch(() => {
-        // swallow — leaves prior result untouched; the stale-key gate
-        // below still suppresses any leftover total.
+        // swallow — leaves prior result untouched; the key gate below
+        // still suppresses any leftover total.
       });
     return () => {
       cancelled = true;
@@ -40,5 +46,5 @@ export function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string
     // taskId / taskIds intentionally excluded — idsKey is their stable summary.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, idsKey]);
-  return open && key === idsKey ? total : 0;
+  return open && result.key === idsKey ? result.total : 0;
 }

--- a/apps/web/hooks/use-subtask-count.ts
+++ b/apps/web/hooks/use-subtask-count.ts
@@ -31,15 +31,14 @@ export function useSubtaskCount(open: boolean, taskId?: string, taskIds?: string
     if (!idsKey) return;
     const ids = taskIds ?? (taskId ? [taskId] : []);
     let cancelled = false;
-    Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 }))))
-      .then((results) => {
+    // Per-id .catch already maps every failure to { count: 0 }, so
+    // Promise.all never rejects — no outer .catch needed.
+    Promise.all(ids.map((id) => getSubtaskCount(id).catch(() => ({ count: 0 })))).then(
+      (results) => {
         if (cancelled) return;
         setResult({ key: idsKey, total: results.reduce((sum, r) => sum + r.count, 0) });
-      })
-      .catch(() => {
-        // swallow — leaves prior result untouched; the key gate below
-        // still suppresses any leftover total.
-      });
+      },
+    );
     return () => {
       cancelled = true;
     };

--- a/apps/web/hooks/use-task-actions.ts
+++ b/apps/web/hooks/use-task-actions.ts
@@ -10,12 +10,12 @@ export function useTaskActions() {
     return moveTask(taskId, payload);
   }, []);
 
-  const deleteTaskById = useCallback(async (taskId: string) => {
-    return deleteTask(taskId);
+  const deleteTaskById = useCallback(async (taskId: string, opts?: { cascade?: boolean }) => {
+    return deleteTask(taskId, opts);
   }, []);
 
-  const archiveTaskById = useCallback(async (taskId: string) => {
-    return archiveTask(taskId);
+  const archiveTaskById = useCallback(async (taskId: string, opts?: { cascade?: boolean }) => {
+    return archiveTask(taskId, opts);
   }, []);
 
   const renameTaskById = useCallback(async (taskId: string, title: string) => {
@@ -38,10 +38,10 @@ export function useArchiveAndSwitchTask(opts?: { useLayoutSwitch?: boolean }) {
   });
 
   return useCallback(
-    async (taskId: string) => {
+    async (taskId: string, opts?: { cascade?: boolean }) => {
       const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
         store.getState().tasks;
-      await archiveTaskById(taskId);
+      await archiveTaskById(taskId, opts);
       await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
     },
     [archiveTaskById, removeTaskFromBoard, store],

--- a/apps/web/hooks/use-task-crud.ts
+++ b/apps/web/hooks/use-task-crud.ts
@@ -31,10 +31,10 @@ export function useTaskCRUD() {
   }, []);
 
   const handleDelete = useCallback(
-    async (task: Task) => {
+    async (task: Task, opts?: { cascade?: boolean }) => {
       setDeletingTaskId(task.id);
       try {
-        await deleteTaskById(task.id);
+        await deleteTaskById(task.id, opts);
 
         // Update UI AFTER successful delete
         store.getState().hydrate({
@@ -53,10 +53,10 @@ export function useTaskCRUD() {
   );
 
   const handleArchive = useCallback(
-    async (task: Task) => {
+    async (task: Task, opts?: { cascade?: boolean }) => {
       setArchivingTaskId(task.id);
       try {
-        await archiveTaskById(task.id);
+        await archiveTaskById(task.id, opts);
 
         // Update UI AFTER successful archive - remove from kanban view
         store.getState().hydrate({

--- a/apps/web/hooks/use-task-multi-select.ts
+++ b/apps/web/hooks/use-task-multi-select.ts
@@ -107,53 +107,39 @@ function useBulkOperations({
   applyMoveInStore: (ids: Set<string>, stepId: string) => void;
   getWorkflowIdForTask: (id: string) => string | null;
 }) {
-  const bulkDelete = useCallback(async () => {
-    const ids = selectedIdsRef.current;
-    if (!ids || ids.size === 0) return;
-    setIsDeleting(true);
-    try {
-      const idList = [...ids];
-      const results = await Promise.allSettled(idList.map((id) => deleteTaskById(id)));
-      const succeeded = new Set(idList.filter((_, i) => results[i].status === "fulfilled"));
-      removeTasksFromStore(succeeded);
-      const failed = new Set(idList.filter((_, i) => results[i].status === "rejected"));
-      setSelectedIds(failed);
-      if (failed.size === 0) setIsMultiSelectEnabled(false);
-    } finally {
-      setIsDeleting(false);
-    }
-  }, [
-    deleteTaskById,
-    removeTasksFromStore,
-    selectedIdsRef,
-    setIsDeleting,
-    setIsMultiSelectEnabled,
-    setSelectedIds,
-  ]);
+  const runBulk = useCallback(
+    async (
+      per: (id: string, opts?: { cascade?: boolean }) => Promise<void>,
+      setBusy: (v: boolean) => void,
+      opts?: { cascade?: boolean },
+    ) => {
+      const ids = selectedIdsRef.current;
+      if (!ids || ids.size === 0) return;
+      setBusy(true);
+      try {
+        const idList = [...ids];
+        const results = await Promise.allSettled(idList.map((id) => per(id, opts)));
+        const succeeded = new Set(idList.filter((_, i) => results[i].status === "fulfilled"));
+        removeTasksFromStore(succeeded);
+        const failed = new Set(idList.filter((_, i) => results[i].status === "rejected"));
+        setSelectedIds(failed);
+        if (failed.size === 0) setIsMultiSelectEnabled(false);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [removeTasksFromStore, selectedIdsRef, setIsMultiSelectEnabled, setSelectedIds],
+  );
 
-  const bulkArchive = useCallback(async () => {
-    const ids = selectedIdsRef.current;
-    if (!ids || ids.size === 0) return;
-    setIsArchiving(true);
-    try {
-      const idList = [...ids];
-      const results = await Promise.allSettled(idList.map((id) => archiveTaskById(id)));
-      const succeeded = new Set(idList.filter((_, i) => results[i].status === "fulfilled"));
-      removeTasksFromStore(succeeded);
-      const failed = new Set(idList.filter((_, i) => results[i].status === "rejected"));
-      setSelectedIds(failed);
-      if (failed.size === 0) setIsMultiSelectEnabled(false);
-    } finally {
-      setIsArchiving(false);
-    }
-  }, [
-    archiveTaskById,
-    removeTasksFromStore,
-    selectedIdsRef,
-    setIsArchiving,
-    setIsMultiSelectEnabled,
-    setSelectedIds,
-  ]);
+  const bulkDelete = useCallback(
+    (opts?: { cascade?: boolean }) => runBulk(deleteTaskById, setIsDeleting, opts),
+    [runBulk, deleteTaskById, setIsDeleting],
+  );
+
+  const bulkArchive = useCallback(
+    (opts?: { cascade?: boolean }) => runBulk(archiveTaskById, setIsArchiving, opts),
+    [runBulk, archiveTaskById, setIsArchiving],
+  );
 
   const bulkMove = useCallback(
     async (targetStepId: string) => {

--- a/apps/web/lib/api/domains/kanban-api.ts
+++ b/apps/web/lib/api/domains/kanban-api.ts
@@ -111,8 +111,13 @@ export async function updateTask(
   });
 }
 
-export async function deleteTask(taskId: string, options?: ApiRequestOptions) {
-  return fetchJson<void>(`/api/v1/tasks/${taskId}`, {
+export async function deleteTask(
+  taskId: string,
+  params?: { cascade?: boolean },
+  options?: ApiRequestOptions,
+) {
+  const query = params?.cascade ? "?cascade=true" : "";
+  return fetchJson<void>(`/api/v1/tasks/${taskId}${query}`, {
     ...options,
     init: { method: "DELETE", ...(options?.init ?? {}) },
   });
@@ -143,11 +148,20 @@ export async function fetchTask(taskId: string, options?: ApiRequestOptions) {
   return fetchJson<Task>(`/api/v1/tasks/${taskId}`, options);
 }
 
-export async function archiveTask(taskId: string, options?: ApiRequestOptions) {
-  return fetchJson<void>(`/api/v1/tasks/${taskId}/archive`, {
+export async function archiveTask(
+  taskId: string,
+  params?: { cascade?: boolean },
+  options?: ApiRequestOptions,
+) {
+  const query = params?.cascade ? "?cascade=true" : "";
+  return fetchJson<void>(`/api/v1/tasks/${taskId}/archive${query}`, {
     ...options,
     init: { method: "POST", ...(options?.init ?? {}) },
   });
+}
+
+export async function getSubtaskCount(taskId: string, options?: ApiRequestOptions) {
+  return fetchJson<{ count: number }>(`/api/v1/tasks/${taskId}/subtask-count`, options);
 }
 
 export async function listTasksByWorkspace(


### PR DESCRIPTION
Archiving or deleting a parent task used to cascade unconditionally into every descendant, killing in-progress subtask sessions the user never intended to touch. The confirmation dialog now exposes an opt-in "Also archive/delete subtasks" checkbox (unchecked by default), so cascading is now a deliberate choice.

## Important Changes

- Backend cascade is now opt-in: `?cascade=true` on `POST /tasks/:id/archive` and `DELETE /tasks/:id`. Default is `false`. `HandoffService.ArchiveTaskTree` / `DeleteTaskTree` gained a `cascade bool` arg.
- Delete-without-cascade reparents direct children to root (`parent_id=""`) via a new `TaskRepository.ReparentDirectChildren` so the deleted parent's pointer doesn't dangle.
- New `GET /tasks/:id/subtask-count` endpoint drives the dialog's conditional checkbox — the checkbox only renders when the task actually has direct, non-archived subtasks.

## Validation

- `make -C apps/backend test` — 534 task-package tests pass, full suite green.
- `make -C apps/backend lint` — 0 issues.
- `pnpm --filter @kandev/web test` — 2098 tests pass (4 new dialog tests covering checkbox visibility, default state, cascade propagation, and bulk sum).
- `pnpm --filter @kandev/web typecheck` / `lint` — clean.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.