### PR TITLE
fix(web): show tasks from all workflows in the mobile task-switcher sheet

### DIFF
--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -23,7 +23,7 @@ import {
   type WorkflowSnapshot,
 } from "@/lib/types/http";
 import type { KanbanState } from "@/lib/state/slices";
-import { resolvePreferredSessionId } from "../task-select-helpers";
+import { findTaskInSnapshots, resolvePreferredSessionId } from "../task-select-helpers";
 
 // Map workflow snapshot to kanban state on workspace switch.
 function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) {
@@ -74,21 +74,6 @@ function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) 
       updatedAt: task.updated_at,
     })),
   };
-}
-
-// Lookup a task across all loaded workflow snapshots, falling back to the
-// active kanban slice. The mobile sheet now lists tasks from every workspace
-// workflow, so action callbacks (select / archive / delete) can no longer
-// assume the target lives in `state.kanban.tasks`.
-function findTaskAcrossWorkflows(
-  state: ReturnType<ReturnType<typeof useAppStoreApi>["getState"]>,
-  taskId: string,
-): KanbanState["tasks"][number] | undefined {
-  for (const snapshot of Object.values(state.kanbanMulti.snapshots)) {
-    const found = snapshot.tasks.find((t) => t.id === taskId);
-    if (found) return found;
-  }
-  return state.kanban.tasks.find((t) => t.id === taskId);
 }
 
 function sortByUpdatedAtDesc<T extends { updated_at?: string | null }>(items: T[]): T[] {
@@ -158,7 +143,6 @@ export function useSheetData(workspaceId: string | null) {
   const gitStatusByEnvId = useAppStore((state) => state.gitStatus.byEnvironmentId);
   const envIdBySessionId = useAppStore((state) => state.environmentIdBySessionId);
   const messagesBySession = useAppStore((state) => state.messages.bySession);
-  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
   const {
     allTasks,
     allSteps,
@@ -181,9 +165,7 @@ export function useSheetData(workspaceId: string | null) {
       repositoryPathsById: new Map(
         repositories.map((repo: Repository) => [repo.id, repo.local_path]),
       ),
-      workflowNameById: new Map(
-        Object.entries(snapshots).map(([wfId, snap]) => [wfId, snap.workflowName]),
-      ),
+      workflowNameById: new Map(workflows.map((w) => [w.id, w.name])),
       stepTitleById: new Map(allSteps.map((s) => [s.id, s.title])),
       sessionsByTaskId,
       gitStatusByEnvId,
@@ -195,7 +177,7 @@ export function useSheetData(workspaceId: string | null) {
     repositoriesByWorkspace,
     allTasks,
     allSteps,
-    snapshots,
+    workflows,
     workspaceId,
     sessionsByTaskId,
     gitStatusByEnvId,
@@ -461,7 +443,8 @@ function useSheetDeleteActions(
 
   const handleDeleteTask = useCallback(
     (taskId: string) => {
-      const task = findTaskAcrossWorkflows(store.getState(), taskId);
+      const state = store.getState();
+      const task = findTaskInSnapshots(state.kanbanMulti.snapshots, taskId, state.kanban.tasks);
       setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],
@@ -509,7 +492,7 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
   const handleSelectTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
-      const task = findTaskAcrossWorkflows(state, taskId);
+      const task = findTaskInSnapshots(state.kanbanMulti.snapshots, taskId, state.kanban.tasks);
       if (task?.primarySessionId) {
         const targetSessionId = resolvePreferredSessionId(
           taskId,
@@ -538,7 +521,8 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
 
   const handleArchiveTask = useCallback(
     (taskId: string) => {
-      const task = findTaskAcrossWorkflows(store.getState(), taskId);
+      const state = store.getState();
+      const task = findTaskInSnapshots(state.kanbanMulti.snapshots, taskId, state.kanban.tasks);
       setArchivingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -23,7 +23,8 @@ import {
   type WorkflowSnapshot,
 } from "@/lib/types/http";
 import type { KanbanState } from "@/lib/state/slices";
-import { findTaskInSnapshots, resolvePreferredSessionId } from "../task-select-helpers";
+import { findTaskInSnapshots } from "@/lib/kanban/find-task";
+import { resolvePreferredSessionId } from "../task-select-helpers";
 
 // Map workflow snapshot to kanban state on workspace switch.
 function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) {
@@ -199,7 +200,6 @@ export function useSheetData(workspaceId: string | null) {
   return {
     activeTaskId,
     selectedTaskId,
-    steps,
     workspaces,
     workflows,
     stepsByWorkflowId,
@@ -444,7 +444,7 @@ function useSheetDeleteActions(
   const handleDeleteTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
-      const task = findTaskInSnapshots(state.kanbanMulti.snapshots, taskId, state.kanban.tasks);
+      const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
       setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],
@@ -492,7 +492,7 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
   const handleSelectTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
-      const task = findTaskInSnapshots(state.kanbanMulti.snapshots, taskId, state.kanban.tasks);
+      const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
       if (task?.primarySessionId) {
         const targetSessionId = resolvePreferredSessionId(
           taskId,
@@ -522,7 +522,7 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
   const handleArchiveTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
-      const task = findTaskInSnapshots(state.kanbanMulti.snapshots, taskId, state.kanban.tasks);
+      const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
       setArchivingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -6,7 +6,7 @@ import { replaceTaskUrl } from "@/lib/links";
 import { fetchWorkflowSnapshot, listWorkflows } from "@/lib/api";
 import { launchSession } from "@/lib/services/session-launch-service";
 import { buildPrepareRequest } from "@/lib/services/session-launch-helpers";
-import { useTasks } from "@/hooks/use-tasks";
+import { useWorkspaceSidebarTasks } from "@/hooks/domains/kanban/use-workspace-sidebar-tasks";
 import { useTaskActions, useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useTaskRemoval } from "@/hooks/use-task-removal";
 import { getSessionInfoForTask } from "@/lib/utils/session-info";
@@ -76,6 +76,21 @@ function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) 
   };
 }
 
+// Lookup a task across all loaded workflow snapshots, falling back to the
+// active kanban slice. The mobile sheet now lists tasks from every workspace
+// workflow, so action callbacks (select / archive / delete) can no longer
+// assume the target lives in `state.kanban.tasks`.
+function findTaskAcrossWorkflows(
+  state: ReturnType<ReturnType<typeof useAppStoreApi>["getState"]>,
+  taskId: string,
+): KanbanState["tasks"][number] | undefined {
+  for (const snapshot of Object.values(state.kanbanMulti.snapshots)) {
+    const found = snapshot.tasks.find((t) => t.id === taskId);
+    if (found) return found;
+  }
+  return state.kanban.tasks.find((t) => t.id === taskId);
+}
+
 function sortByUpdatedAtDesc<T extends { updated_at?: string | null }>(items: T[]): T[] {
   return [...items].sort((a, b) => {
     const aDate = a.updated_at ? new Date(a.updated_at).getTime() : 0;
@@ -84,7 +99,58 @@ function sortByUpdatedAtDesc<T extends { updated_at?: string | null }>(items: T[
   });
 }
 
-export function useSheetData(workspaceId: string | null, workflowId: string | null) {
+type SheetItemCtx = {
+  repositoryPathsById: Map<string, string | undefined>;
+  workflowNameById: Map<string, string>;
+  stepTitleById: Map<string, string>;
+  sessionsByTaskId: Parameters<typeof getSessionInfoForTask>[1];
+  gitStatusByEnvId: Parameters<typeof getSessionInfoForTask>[2];
+  envIdBySessionId: Parameters<typeof getSessionInfoForTask>[3];
+  messagesBySession: Parameters<typeof hasPendingClarificationForSession>[0];
+};
+
+function toSheetItem(
+  task: KanbanState["tasks"][number] & { _workflowId: string },
+  ctx: SheetItemCtx,
+) {
+  const sessionInfo = getSessionInfoForTask(
+    task.id,
+    ctx.sessionsByTaskId,
+    ctx.gitStatusByEnvId,
+    ctx.envIdBySessionId,
+  );
+  return {
+    id: task.id,
+    title: task.title,
+    state: task.state as TaskState | undefined,
+    sessionState:
+      sessionInfo.sessionState ?? (task.primarySessionState as TaskSessionState | undefined),
+    description: task.description,
+    workflowId: task._workflowId,
+    workflowName: ctx.workflowNameById.get(task._workflowId),
+    workflowStepId: task.workflowStepId,
+    workflowStepTitle: ctx.stepTitleById.get(task.workflowStepId),
+    repositoryPath: task.repositoryId
+      ? ctx.repositoryPathsById.get(toRepositoryId(task.repositoryId))
+      : undefined,
+    diffStats: sessionInfo.diffStats,
+    updatedAt: sessionInfo.updatedAt ?? task.updatedAt,
+    isRemoteExecutor: task.isRemoteExecutor,
+    remoteExecutorType: task.primaryExecutorType ?? undefined,
+    remoteExecutorName: task.primaryExecutorName ?? undefined,
+    primarySessionId: task.primarySessionId ?? null,
+    hasPendingClarification: hasPendingClarificationForSession(
+      ctx.messagesBySession,
+      task.primarySessionId,
+    ),
+    hasPendingPermission: hasPendingPermissionForSession(
+      ctx.messagesBySession,
+      task.primarySessionId,
+    ),
+  };
+}
+
+export function useSheetData(workspaceId: string | null) {
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
   const activeSessionId = useAppStore((state) => state.tasks.activeSessionId);
   const sessionsById = useAppStore((state) => state.taskSessions.items);
@@ -92,7 +158,14 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
   const gitStatusByEnvId = useAppStore((state) => state.gitStatus.byEnvironmentId);
   const envIdBySessionId = useAppStore((state) => state.environmentIdBySessionId);
   const messagesBySession = useAppStore((state) => state.messages.bySession);
-  const { tasks, isLoading: tasksLoading } = useTasks(workflowId);
+  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
+  const {
+    allTasks,
+    allSteps,
+    stepsByWorkflowId,
+    workflows,
+    isLoading: tasksLoading,
+  } = useWorkspaceSidebarTasks(workspaceId);
   const steps = useAppStore((state) => state.kanban.steps);
   const workspaces = useAppStore((state) => state.workspaces.items);
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
@@ -104,46 +177,25 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
 
   const tasksWithRepositories = useMemo(() => {
     const repositories = workspaceId ? (repositoriesByWorkspace[workspaceId] ?? []) : [];
-    const repositoryPathsById = new Map(
-      repositories.map((repo: Repository) => [repo.id, repo.local_path]),
-    );
-    return tasks.map((task: KanbanState["tasks"][number]) => {
-      const sessionInfo = getSessionInfoForTask(
-        task.id,
-        sessionsByTaskId,
-        gitStatusByEnvId,
-        envIdBySessionId,
-      );
-      return {
-        id: task.id,
-        title: task.title,
-        state: task.state as TaskState | undefined,
-        sessionState:
-          sessionInfo.sessionState ?? (task.primarySessionState as TaskSessionState | undefined),
-        description: task.description,
-        workflowStepId: task.workflowStepId,
-        repositoryPath: task.repositoryId
-          ? repositoryPathsById.get(toRepositoryId(task.repositoryId))
-          : undefined,
-        diffStats: sessionInfo.diffStats,
-        updatedAt: sessionInfo.updatedAt ?? task.updatedAt,
-        isRemoteExecutor: task.isRemoteExecutor,
-        remoteExecutorType: task.primaryExecutorType ?? undefined,
-        remoteExecutorName: task.primaryExecutorName ?? undefined,
-        primarySessionId: task.primarySessionId ?? null,
-        hasPendingClarification: hasPendingClarificationForSession(
-          messagesBySession,
-          task.primarySessionId,
-        ),
-        hasPendingPermission: hasPendingPermissionForSession(
-          messagesBySession,
-          task.primarySessionId,
-        ),
-      };
-    });
+    const ctx: SheetItemCtx = {
+      repositoryPathsById: new Map(
+        repositories.map((repo: Repository) => [repo.id, repo.local_path]),
+      ),
+      workflowNameById: new Map(
+        Object.entries(snapshots).map(([wfId, snap]) => [wfId, snap.workflowName]),
+      ),
+      stepTitleById: new Map(allSteps.map((s) => [s.id, s.title])),
+      sessionsByTaskId,
+      gitStatusByEnvId,
+      envIdBySessionId,
+      messagesBySession,
+    };
+    return allTasks.map((task) => toSheetItem(task, ctx));
   }, [
     repositoriesByWorkspace,
-    tasks,
+    allTasks,
+    allSteps,
+    snapshots,
     workspaceId,
     sessionsByTaskId,
     gitStatusByEnvId,
@@ -167,7 +219,9 @@ export function useSheetData(workspaceId: string | null, workflowId: string | nu
     selectedTaskId,
     steps,
     workspaces,
-    // Skeleton while snapshot hydrates kanban — otherwise shows "No tasks yet." even when tasks exist.
+    workflows,
+    stepsByWorkflowId,
+    // Skeleton while the first snapshot fetch is in flight — otherwise shows "No tasks yet." even when tasks exist.
     tasksLoading,
     tasksWithRepositories,
     dialogSteps,
@@ -407,7 +461,7 @@ function useSheetDeleteActions(
 
   const handleDeleteTask = useCallback(
     (taskId: string) => {
-      const task = store.getState().kanban.tasks.find((t) => t.id === taskId);
+      const task = findTaskAcrossWorkflows(store.getState(), taskId);
       setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],
@@ -455,7 +509,7 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
   const handleSelectTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
-      const task = state.kanban.tasks.find((t) => t.id === taskId);
+      const task = findTaskAcrossWorkflows(state, taskId);
       if (task?.primarySessionId) {
         const targetSessionId = resolvePreferredSessionId(
           taskId,
@@ -484,7 +538,7 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
 
   const handleArchiveTask = useCallback(
     (taskId: string) => {
-      const task = store.getState().kanban.tasks.find((t) => t.id === taskId);
+      const task = findTaskAcrossWorkflows(store.getState(), taskId);
       setArchivingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -6,6 +6,8 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { Button } from "@kandev/ui/button";
 import { TaskSwitcher } from "../task-switcher";
 import type { TaskSwitcherItem } from "../task-switcher";
+import type { StepDef } from "../task-switcher-context-menu";
+import type { TaskMoveWorkflow } from "../task-move-context-menu";
 import { applyView } from "@/lib/sidebar/apply-view";
 import { useEffectiveSidebarView } from "@/hooks/domains/sidebar/use-effective-sidebar-view";
 import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-prefs";
@@ -24,6 +26,8 @@ type SessionTaskSwitcherSheetProps = {
 
 function MobileTaskList({
   tasks,
+  workflows,
+  stepsByWorkflowId,
   activeTaskId,
   selectedTaskId,
   onSelectTask,
@@ -33,6 +37,8 @@ function MobileTaskList({
   isLoading,
 }: {
   tasks: TaskSwitcherItem[];
+  workflows: TaskMoveWorkflow[];
+  stepsByWorkflowId: Record<string, StepDef[]>;
   activeTaskId: string | null;
   selectedTaskId: string | null;
   onSelectTask: (taskId: string) => void;
@@ -62,6 +68,8 @@ function MobileTaskList({
   return (
     <TaskSwitcher
       grouped={grouped}
+      workflows={workflows}
+      stepsByWorkflowId={stepsByWorkflowId}
       activeTaskId={activeTaskId}
       selectedTaskId={selectedTaskId}
       onSelectTask={onSelectTask}
@@ -85,7 +93,7 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
   workflowId,
 }: SessionTaskSwitcherSheetProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const data = useSheetData(workspaceId, workflowId);
+  const data = useSheetData(workspaceId);
   const actions = useSheetActions(workspaceId, onOpenChange);
 
   return (
@@ -120,6 +128,8 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
         <div className="flex-1 min-h-0 overflow-y-auto p-2">
           <MobileTaskList
             tasks={data.tasksWithRepositories}
+            workflows={data.workflows}
+            stepsByWorkflowId={data.stepsByWorkflowId}
             activeTaskId={data.activeTaskId}
             selectedTaskId={data.selectedTaskId}
             onSelectTask={actions.handleSelectTask}

--- a/apps/web/components/task/task-select-helpers.ts
+++ b/apps/web/components/task/task-select-helpers.ts
@@ -7,7 +7,6 @@
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import type { TaskSession } from "@/lib/types/http";
-import type { KanbanState } from "@/lib/state/slices";
 import {
   performLayoutSwitch,
   releaseLayoutToDefault,
@@ -26,25 +25,6 @@ export type SwitchToSessionFn = (
   sessionId: string,
   oldSessionId: string | null | undefined,
 ) => void;
-
-/**
- * Find a task across every loaded workflow snapshot, with an optional
- * fallback to the active `kanban.tasks` slice. The desktop sidebar uses the
- * snapshot-only path (snapshots are guaranteed loaded); the mobile sheet
- * passes `kanban.tasks` so it can still locate tasks that arrived via WS
- * before the snapshot fetch resolved.
- */
-export function findTaskInSnapshots(
-  snapshots: Record<string, { tasks: KanbanState["tasks"] }>,
-  taskId: string,
-  fallbackTasks?: KanbanState["tasks"],
-): KanbanState["tasks"][number] | undefined {
-  for (const snapshot of Object.values(snapshots)) {
-    const found = snapshot.tasks.find((t) => t.id === taskId);
-    if (found) return found;
-  }
-  return fallbackTasks?.find((t) => t.id === taskId);
-}
 
 export function resolveLoadedSessionId(
   sessions: TaskSession[],

--- a/apps/web/components/task/task-select-helpers.ts
+++ b/apps/web/components/task/task-select-helpers.ts
@@ -7,6 +7,7 @@
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import type { TaskSession } from "@/lib/types/http";
+import type { KanbanState } from "@/lib/state/slices";
 import {
   performLayoutSwitch,
   releaseLayoutToDefault,
@@ -25,6 +26,25 @@ export type SwitchToSessionFn = (
   sessionId: string,
   oldSessionId: string | null | undefined,
 ) => void;
+
+/**
+ * Find a task across every loaded workflow snapshot, with an optional
+ * fallback to the active `kanban.tasks` slice. The desktop sidebar uses the
+ * snapshot-only path (snapshots are guaranteed loaded); the mobile sheet
+ * passes `kanban.tasks` so it can still locate tasks that arrived via WS
+ * before the snapshot fetch resolved.
+ */
+export function findTaskInSnapshots(
+  snapshots: Record<string, { tasks: KanbanState["tasks"] }>,
+  taskId: string,
+  fallbackTasks?: KanbanState["tasks"],
+): KanbanState["tasks"][number] | undefined {
+  for (const snapshot of Object.values(snapshots)) {
+    const found = snapshot.tasks.find((t) => t.id === taskId);
+    if (found) return found;
+  }
+  return fallbackTasks?.find((t) => t.id === taskId);
+}
 
 export function resolveLoadedSessionId(
   sessions: TaskSession[],

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -18,7 +18,7 @@ import { MOCK_ITEMS, MOCK_SIDEBAR } from "./sidebar-mock-data";
 import { SidebarDialogs } from "./task-session-sidebar-dialogs";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
-import { useAllWorkflowSnapshots } from "@/hooks/domains/kanban/use-all-workflow-snapshots";
+import { useWorkspaceSidebarTasks } from "@/hooks/domains/kanban/use-workspace-sidebar-tasks";
 import { useEffectiveSidebarView } from "@/hooks/domains/sidebar/use-effective-sidebar-view";
 import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-prefs";
 import { useTaskActions, useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
@@ -33,7 +33,6 @@ import {
   hasPendingClarificationForSession,
   hasPendingPermissionForSession,
 } from "@/lib/utils/pending-clarification";
-import { aggregateSidebarTasks } from "./task-session-sidebar-aggregate";
 
 /**
  * Stabilize a derived array of primary session IDs so the reference only
@@ -223,51 +222,6 @@ function buildArchivedItem(s: ReturnType<typeof useArchivedTaskState>): SidebarI
   };
 }
 
-// Restrict snapshots and the active-kanban fallback to the current workspace.
-// Snapshots can briefly persist from a previously-active workspace (SSR
-// hydration on first sidebar mount, in-flight task.created WS events that
-// raced the workspace switch, etc.), and those would otherwise leak into
-// the sidebar after switching workspaces.
-function useScopedAggregation(workspaceId: string | null) {
-  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
-  const workflows = useAppStore((state) => state.workflows.items);
-  const activeKanbanWorkflowId = useAppStore((state) => state.kanban.workflowId);
-  const activeKanbanTasks = useAppStore((state) => state.kanban.tasks);
-  const activeKanbanSteps = useAppStore((state) => state.kanban.steps);
-
-  const workspaceWorkflowIds = useMemo(
-    () =>
-      new Set(
-        workflows.filter((w) => !workspaceId || w.workspaceId === workspaceId).map((w) => w.id),
-      ),
-    [workflows, workspaceId],
-  );
-  const scopedSnapshots = useMemo(() => {
-    const result: typeof snapshots = {};
-    for (const [wfId, snap] of Object.entries(snapshots)) {
-      if (workspaceWorkflowIds.has(wfId)) result[wfId] = snap;
-    }
-    return result;
-  }, [snapshots, workspaceWorkflowIds]);
-  const fallbackWorkflowId =
-    activeKanbanWorkflowId && workspaceWorkflowIds.has(activeKanbanWorkflowId)
-      ? activeKanbanWorkflowId
-      : null;
-
-  const aggregated = useMemo(
-    () =>
-      aggregateSidebarTasks(
-        scopedSnapshots,
-        fallbackWorkflowId,
-        activeKanbanTasks,
-        activeKanbanSteps,
-      ),
-    [scopedSnapshots, fallbackWorkflowId, activeKanbanTasks, activeKanbanSteps],
-  );
-
-  return { aggregated, scopedSnapshots, snapshots };
-}
-
 function useSidebarData(workspaceId: string | null) {
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
   const activeSessionId = useAppStore((state) => state.tasks.activeSessionId);
@@ -275,8 +229,7 @@ function useSidebarData(workspaceId: string | null) {
   const sessionsByTaskId = useAppStore((state) => state.taskSessionsByTask.itemsByTaskId);
   const gitStatusByEnvId = useAppStore((state) => state.gitStatus.byEnvironmentId);
   const envIdBySessionId = useAppStore((state) => state.environmentIdBySessionId);
-  const workflows = useAppStore((state) => state.workflows.items);
-  const isMultiLoading = useAppStore((state) => state.kanbanMulti.isLoading);
+  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
   const taskPRsByTaskId = useAppStore((state) => state.taskPRs.byTaskId);
   const messagesBySession = useAppStore((state) => state.messages.bySession);
@@ -287,10 +240,13 @@ function useSidebarData(workspaceId: string | null) {
     return activeTaskId;
   }, [activeSessionId, activeTaskId, sessionsById]);
 
-  const { aggregated, scopedSnapshots, snapshots } = useScopedAggregation(workspaceId);
-  const { allTasks, allSteps, stepsByWorkflowId } = aggregated;
-
-  const isLoadingWorkflow = isMultiLoading && Object.keys(snapshots).length === 0;
+  const {
+    allTasks,
+    allSteps,
+    stepsByWorkflowId,
+    workflows,
+    isLoading: isLoadingWorkflow,
+  } = useWorkspaceSidebarTasks(workspaceId);
 
   const tasksWithRepositories = useMemo(() => {
     const repositories = workspaceId ? (repositoriesByWorkspace[workspaceId] ?? []) : [];
@@ -304,7 +260,7 @@ function useSidebarData(workspaceId: string | null) {
     );
     const titleById = new Map(allTasks.map((t) => [t.id, t.title]));
     const workflowNameById = new Map(
-      Object.entries(scopedSnapshots).map(([wfId, snap]) => [wfId, snap.workflowName]),
+      Object.entries(snapshots).map(([wfId, snap]) => [wfId, snap.workflowName]),
     );
     const stepTitleById = new Map(allSteps.map((s) => [s.id, s.title]));
     const mapCtx = {
@@ -331,7 +287,7 @@ function useSidebarData(workspaceId: string | null) {
     repositoriesByWorkspace,
     allTasks,
     allSteps,
-    scopedSnapshots,
+    snapshots,
     workspaceId,
     sessionsByTaskId,
     gitStatusByEnvId,
@@ -353,9 +309,7 @@ function useSidebarData(workspaceId: string | null) {
     isLoadingWorkflow,
     tasksWithRepositories,
     primarySessionIds,
-    workflows: workflows
-      .filter((workflow) => !workspaceId || workflow.workspaceId === workspaceId)
-      .map((workflow) => ({ id: workflow.id, name: workflow.name, hidden: workflow.hidden })),
+    workflows,
   };
 }
 
@@ -595,7 +549,6 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
   workspaceId,
 }: TaskSessionSidebarProps) {
   const store = useAppStoreApi();
-  useAllWorkflowSnapshots(workspaceId);
   useRepositories(workspaceId);
   useWorkspacePRs(workspaceId);
 

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -23,11 +23,8 @@ import { useEffectiveSidebarView } from "@/hooks/domains/sidebar/use-effective-s
 import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-prefs";
 import { useTaskActions, useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useTaskRemoval } from "@/hooks/use-task-removal";
-import {
-  buildSwitchToSession,
-  findTaskInSnapshots,
-  selectTaskWithLayout,
-} from "./task-select-helpers";
+import { findTaskInSnapshots } from "@/lib/kanban/find-task";
+import { buildSwitchToSession, selectTaskWithLayout } from "./task-select-helpers";
 import { getSessionInfoForTask } from "@/lib/utils/session-info";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { useArchivedTaskState } from "./task-archived-context";
@@ -367,7 +364,7 @@ function useArchiveActions(store: StoreApi) {
 
   const handleArchiveTask = useCallback(
     (taskId: string) => {
-      const task = findTaskInSnapshots(store.getState().kanbanMulti.snapshots, taskId);
+      const task = findTaskInSnapshots(taskId, store.getState().kanbanMulti.snapshots);
       setArchivingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],
@@ -399,7 +396,7 @@ function useDeleteActions(
 
   const handleDeleteTask = useCallback(
     (taskId: string) => {
-      const task = findTaskInSnapshots(store.getState().kanbanMulti.snapshots, taskId);
+      const task = findTaskInSnapshots(taskId, store.getState().kanbanMulti.snapshots);
       setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],
@@ -451,10 +448,10 @@ function useSidebarActions(store: StoreApi) {
 
   const handleSelectTask = useCallback(
     (taskId: string) => {
-      const task = findTaskInSnapshots(store.getState().kanbanMulti.snapshots, taskId);
+      const task = findTaskInSnapshots(taskId, store.getState().kanbanMulti.snapshots);
       selectTaskWithLayout({
         taskId,
-        task,
+        task: task ?? undefined,
         store,
         switchToSession,
         loadTaskSessionsForTask,

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -364,7 +364,8 @@ function useArchiveActions(store: StoreApi) {
 
   const handleArchiveTask = useCallback(
     (taskId: string) => {
-      const task = findTaskInSnapshots(taskId, store.getState().kanbanMulti.snapshots);
+      const state = store.getState();
+      const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
       setArchivingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],
@@ -396,7 +397,8 @@ function useDeleteActions(
 
   const handleDeleteTask = useCallback(
     (taskId: string) => {
-      const task = findTaskInSnapshots(taskId, store.getState().kanbanMulti.snapshots);
+      const state = store.getState();
+      const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
       setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
     },
     [store],
@@ -448,7 +450,8 @@ function useSidebarActions(store: StoreApi) {
 
   const handleSelectTask = useCallback(
     (taskId: string) => {
-      const task = findTaskInSnapshots(taskId, store.getState().kanbanMulti.snapshots);
+      const state = store.getState();
+      const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
       selectTaskWithLayout({
         taskId,
         task: task ?? undefined,

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -23,7 +23,11 @@ import { useEffectiveSidebarView } from "@/hooks/domains/sidebar/use-effective-s
 import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-prefs";
 import { useTaskActions, useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useTaskRemoval } from "@/hooks/use-task-removal";
-import { buildSwitchToSession, selectTaskWithLayout } from "./task-select-helpers";
+import {
+  buildSwitchToSession,
+  findTaskInSnapshots,
+  selectTaskWithLayout,
+} from "./task-select-helpers";
 import { getSessionInfoForTask } from "@/lib/utils/session-info";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { useArchivedTaskState } from "./task-archived-context";
@@ -52,18 +56,6 @@ function useStablePrimarySessionIds(
     [allTasks],
   );
   return useMemo(() => (key ? key.split("\0") : []), [key]);
-}
-
-/** Find a task across all workflow snapshots */
-function findTaskInSnapshots(
-  snapshots: Record<string, { tasks: KanbanState["tasks"] }>,
-  taskId: string,
-): KanbanState["tasks"][number] | undefined {
-  for (const snapshot of Object.values(snapshots)) {
-    const task = snapshot.tasks.find((t: KanbanState["tasks"][number]) => t.id === taskId);
-    if (task) return task;
-  }
-  return undefined;
 }
 
 /** Look up git status directly via primarySessionId, bypassing the session list. */
@@ -229,7 +221,6 @@ function useSidebarData(workspaceId: string | null) {
   const sessionsByTaskId = useAppStore((state) => state.taskSessionsByTask.itemsByTaskId);
   const gitStatusByEnvId = useAppStore((state) => state.gitStatus.byEnvironmentId);
   const envIdBySessionId = useAppStore((state) => state.environmentIdBySessionId);
-  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
   const taskPRsByTaskId = useAppStore((state) => state.taskPRs.byTaskId);
   const messagesBySession = useAppStore((state) => state.messages.bySession);
@@ -259,9 +250,7 @@ function useSidebarData(workspaceId: string | null) {
       ]),
     );
     const titleById = new Map(allTasks.map((t) => [t.id, t.title]));
-    const workflowNameById = new Map(
-      Object.entries(snapshots).map(([wfId, snap]) => [wfId, snap.workflowName]),
-    );
+    const workflowNameById = new Map(workflows.map((w) => [w.id, w.name]));
     const stepTitleById = new Map(allSteps.map((s) => [s.id, s.title]));
     const mapCtx = {
       sessionsByTaskId,
@@ -287,7 +276,7 @@ function useSidebarData(workspaceId: string | null) {
     repositoriesByWorkspace,
     allTasks,
     allSteps,
-    snapshots,
+    workflows,
     workspaceId,
     sessionsByTaskId,
     gitStatusByEnvId,

--- a/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.test.ts
+++ b/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.test.ts
@@ -104,6 +104,28 @@ describe("useWorkspaceSidebarTasks", () => {
     expect(result.current.workflows.map((w) => w.id)).toEqual(["wf-A", "wf-B"]);
   });
 
+  it("returns an empty scope when workspaceId is null (no cross-workspace leak)", () => {
+    setMockState({
+      workflows: {
+        items: [
+          { id: "wf-A", workspaceId: "ws-1", name: "Alpha" },
+          { id: "wf-B", workspaceId: "ws-2", name: "Beta" },
+        ],
+      },
+      kanbanMulti: {
+        snapshots: {
+          "wf-A": makeSnapshot("wf-A", "Alpha", ["t-a1"]),
+          "wf-B": makeSnapshot("wf-B", "Beta", ["t-b1"]),
+        },
+        isLoading: false,
+      },
+    });
+
+    const { result } = renderHook(() => useWorkspaceSidebarTasks(null));
+    expect(result.current.allTasks).toEqual([]);
+    expect(result.current.workflows).toEqual([]);
+  });
+
   it("filters out snapshots from other workspaces (stale hydration)", () => {
     setMockState({
       workflows: {
@@ -142,6 +164,17 @@ describe("useWorkspaceSidebarTasks", () => {
     const { result } = renderHook(() => useWorkspaceSidebarTasks("ws-1"));
     expect(result.current.allTasks.map((t) => t.id)).toEqual(["t-a1"]);
     expect(result.current.allTasks[0]._workflowId).toBe("wf-A");
+  });
+});
+
+describe("useWorkspaceSidebarTasks — loading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState = {
+      kanbanMulti: { snapshots: {}, isLoading: false },
+      workflows: { items: [] },
+      kanban: { workflowId: null, tasks: [], steps: [] },
+    };
   });
 
   it("reports loading only on the first fetch, not on refreshes", () => {

--- a/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.test.ts
+++ b/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const mockUseAllWorkflowSnapshots = vi.fn();
+
+type Snapshot = {
+  workflowId: string;
+  workflowName: string;
+  steps: Array<{ id: string; title: string; color: string; position: number }>;
+  tasks: Array<{ id: string; workflowStepId: string; title: string; position: number }>;
+};
+
+type MockState = {
+  kanbanMulti: {
+    snapshots: Record<string, Snapshot>;
+    isLoading: boolean;
+  };
+  workflows: { items: Array<{ id: string; workspaceId: string; name: string; hidden?: boolean }> };
+  kanban: {
+    workflowId: string | null;
+    tasks: Array<{ id: string; workflowStepId: string; title: string; position: number }>;
+    steps: Array<{ id: string; title: string; color: string; position: number }>;
+  };
+};
+
+let mockState: MockState = {
+  kanbanMulti: { snapshots: {}, isLoading: false },
+  workflows: { items: [] },
+  kanban: { workflowId: null, tasks: [], steps: [] },
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: MockState) => unknown) => selector(mockState),
+  useAppStoreApi: () => ({ getState: () => mockState }),
+}));
+
+vi.mock("@/hooks/domains/kanban/use-all-workflow-snapshots", () => ({
+  useAllWorkflowSnapshots: (workspaceId: string | null) => mockUseAllWorkflowSnapshots(workspaceId),
+}));
+
+import { useWorkspaceSidebarTasks } from "./use-workspace-sidebar-tasks";
+
+function setMockState(patch: Partial<MockState>) {
+  mockState = {
+    kanbanMulti: { ...mockState.kanbanMulti, ...(patch.kanbanMulti ?? {}) },
+    workflows: { ...mockState.workflows, ...(patch.workflows ?? {}) },
+    kanban: { ...mockState.kanban, ...(patch.kanban ?? {}) },
+  };
+}
+
+function makeSnapshot(
+  workflowId: string,
+  workflowName: string,
+  taskIds: string[],
+  stepId = "step-1",
+): Snapshot {
+  return {
+    workflowId,
+    workflowName,
+    steps: [{ id: stepId, title: "Step 1", color: "bg-blue-500", position: 0 }],
+    tasks: taskIds.map((id, i) => ({ id, workflowStepId: stepId, title: id, position: i })),
+  };
+}
+
+describe("useWorkspaceSidebarTasks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState = {
+      kanbanMulti: { snapshots: {}, isLoading: false },
+      workflows: { items: [] },
+      kanban: { workflowId: null, tasks: [], steps: [] },
+    };
+  });
+
+  it("fires useAllWorkflowSnapshots with the workspaceId", () => {
+    renderHook(() => useWorkspaceSidebarTasks("ws-1"));
+    expect(mockUseAllWorkflowSnapshots).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("aggregates tasks from every workflow snapshot scoped to the workspace", () => {
+    setMockState({
+      workflows: {
+        items: [
+          { id: "wf-A", workspaceId: "ws-1", name: "Alpha" },
+          { id: "wf-B", workspaceId: "ws-1", name: "Beta" },
+        ],
+      },
+      kanbanMulti: {
+        snapshots: {
+          "wf-A": makeSnapshot("wf-A", "Alpha", ["t-a1", "t-a2"]),
+          "wf-B": makeSnapshot("wf-B", "Beta", ["t-b1"]),
+        },
+        isLoading: false,
+      },
+    });
+
+    const { result } = renderHook(() => useWorkspaceSidebarTasks("ws-1"));
+    const ids = result.current.allTasks.map((t) => t.id);
+    expect(ids).toEqual(["t-a1", "t-a2", "t-b1"]);
+    // Tagged with their workflow so downstream UI can group.
+    expect(result.current.allTasks[0]._workflowId).toBe("wf-A");
+    expect(result.current.allTasks[2]._workflowId).toBe("wf-B");
+    expect(Object.keys(result.current.stepsByWorkflowId).sort()).toEqual(["wf-A", "wf-B"]);
+    expect(result.current.workflows.map((w) => w.id)).toEqual(["wf-A", "wf-B"]);
+  });
+
+  it("filters out snapshots from other workspaces (stale hydration)", () => {
+    setMockState({
+      workflows: {
+        items: [
+          { id: "wf-A", workspaceId: "ws-1", name: "Alpha" },
+          { id: "wf-X", workspaceId: "ws-other", name: "Stale" },
+        ],
+      },
+      kanbanMulti: {
+        snapshots: {
+          "wf-A": makeSnapshot("wf-A", "Alpha", ["t-a1"]),
+          "wf-X": makeSnapshot("wf-X", "Stale", ["t-x1"]),
+        },
+        isLoading: false,
+      },
+    });
+
+    const { result } = renderHook(() => useWorkspaceSidebarTasks("ws-1"));
+    expect(result.current.allTasks.map((t) => t.id)).toEqual(["t-a1"]);
+    expect(result.current.workflows.map((w) => w.id)).toEqual(["wf-A"]);
+  });
+
+  it("falls back to the active kanban slice for tasks not yet in snapshots", () => {
+    // Snapshot for wf-A hasn't loaded yet, but the page-level useTasks call
+    // already populated `kanban.tasks` for the current workflow.
+    setMockState({
+      workflows: { items: [{ id: "wf-A", workspaceId: "ws-1", name: "Alpha" }] },
+      kanbanMulti: { snapshots: {}, isLoading: false },
+      kanban: {
+        workflowId: "wf-A",
+        tasks: [{ id: "t-a1", workflowStepId: "step-1", title: "A1", position: 0 }],
+        steps: [{ id: "step-1", title: "Step 1", color: "bg-blue-500", position: 0 }],
+      },
+    });
+
+    const { result } = renderHook(() => useWorkspaceSidebarTasks("ws-1"));
+    expect(result.current.allTasks.map((t) => t.id)).toEqual(["t-a1"]);
+    expect(result.current.allTasks[0]._workflowId).toBe("wf-A");
+  });
+
+  it("reports loading only on the first fetch, not on refreshes", () => {
+    setMockState({
+      workflows: { items: [{ id: "wf-A", workspaceId: "ws-1", name: "Alpha" }] },
+      kanbanMulti: { snapshots: {}, isLoading: true },
+    });
+    expect(renderHook(() => useWorkspaceSidebarTasks("ws-1")).result.current.isLoading).toBe(true);
+
+    setMockState({
+      kanbanMulti: {
+        snapshots: { "wf-A": makeSnapshot("wf-A", "Alpha", ["t-a1"]) },
+        isLoading: true,
+      },
+    });
+    expect(renderHook(() => useWorkspaceSidebarTasks("ws-1")).result.current.isLoading).toBe(false);
+  });
+});

--- a/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.ts
+++ b/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.ts
@@ -31,12 +31,13 @@ export function useWorkspaceSidebarTasks(workspaceId: string | null): WorkspaceS
   const activeKanbanTasks = useAppStore((state) => state.kanban.tasks);
   const activeKanbanSteps = useAppStore((state) => state.kanban.steps);
 
-  const workspaceWorkflowIds = useMemo(
-    () =>
-      new Set(
-        workflows.filter((w) => !workspaceId || w.workspaceId === workspaceId).map((w) => w.id),
-      ),
+  const filteredWorkflows = useMemo(
+    () => (!workspaceId ? workflows : workflows.filter((w) => w.workspaceId === workspaceId)),
     [workflows, workspaceId],
+  );
+  const workspaceWorkflowIds = useMemo(
+    () => new Set(filteredWorkflows.map((w) => w.id)),
+    [filteredWorkflows],
   );
 
   const scopedSnapshots = useMemo(() => {
@@ -64,11 +65,8 @@ export function useWorkspaceSidebarTasks(workspaceId: string | null): WorkspaceS
   );
 
   const workspaceWorkflows = useMemo<TaskMoveWorkflow[]>(
-    () =>
-      workflows
-        .filter((w) => !workspaceId || w.workspaceId === workspaceId)
-        .map((w) => ({ id: w.id, name: w.name, hidden: w.hidden })),
-    [workflows, workspaceId],
+    () => filteredWorkflows.map((w) => ({ id: w.id, name: w.name, hidden: w.hidden })),
+    [filteredWorkflows],
   );
 
   // Only flash a skeleton on the very first fetch (no snapshots yet); refreshes

--- a/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.ts
+++ b/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.ts
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { useAppStore } from "@/components/state-provider";
+import { useAllWorkflowSnapshots } from "@/hooks/domains/kanban/use-all-workflow-snapshots";
+import {
+  aggregateSidebarTasks,
+  type AggregatedSidebarTasks,
+} from "@/components/task/task-session-sidebar-aggregate";
+import type { TaskMoveWorkflow } from "@/components/task/task-move-context-menu";
+
+export type WorkspaceSidebarTasksResult = AggregatedSidebarTasks & {
+  workflows: TaskMoveWorkflow[];
+  isLoading: boolean;
+};
+
+/**
+ * Shared data source for the desktop sidebar and the mobile task-switcher sheet.
+ *
+ * Fires `useAllWorkflowSnapshots` to populate `kanbanMulti.snapshots` for every
+ * workflow in the workspace, then aggregates them (with a fallback to the
+ * single active `kanban` slice for tasks that arrived via WS before their
+ * snapshot resolved). Snapshots from other workspaces are filtered out so a
+ * stale hydration doesn't leak across workspace switches.
+ */
+export function useWorkspaceSidebarTasks(workspaceId: string | null): WorkspaceSidebarTasksResult {
+  useAllWorkflowSnapshots(workspaceId);
+
+  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
+  const isMultiLoading = useAppStore((state) => state.kanbanMulti.isLoading);
+  const workflows = useAppStore((state) => state.workflows.items);
+  const activeKanbanWorkflowId = useAppStore((state) => state.kanban.workflowId);
+  const activeKanbanTasks = useAppStore((state) => state.kanban.tasks);
+  const activeKanbanSteps = useAppStore((state) => state.kanban.steps);
+
+  const workspaceWorkflowIds = useMemo(
+    () =>
+      new Set(
+        workflows.filter((w) => !workspaceId || w.workspaceId === workspaceId).map((w) => w.id),
+      ),
+    [workflows, workspaceId],
+  );
+
+  const scopedSnapshots = useMemo(() => {
+    const result: typeof snapshots = {};
+    for (const [wfId, snap] of Object.entries(snapshots)) {
+      if (workspaceWorkflowIds.has(wfId)) result[wfId] = snap;
+    }
+    return result;
+  }, [snapshots, workspaceWorkflowIds]);
+
+  const fallbackWorkflowId =
+    activeKanbanWorkflowId && workspaceWorkflowIds.has(activeKanbanWorkflowId)
+      ? activeKanbanWorkflowId
+      : null;
+
+  const aggregated = useMemo(
+    () =>
+      aggregateSidebarTasks(
+        scopedSnapshots,
+        fallbackWorkflowId,
+        activeKanbanTasks,
+        activeKanbanSteps,
+      ),
+    [scopedSnapshots, fallbackWorkflowId, activeKanbanTasks, activeKanbanSteps],
+  );
+
+  const workspaceWorkflows = useMemo<TaskMoveWorkflow[]>(
+    () =>
+      workflows
+        .filter((w) => !workspaceId || w.workspaceId === workspaceId)
+        .map((w) => ({ id: w.id, name: w.name, hidden: w.hidden })),
+    [workflows, workspaceId],
+  );
+
+  // Only flash a skeleton on the very first fetch (no snapshots yet); refreshes
+  // shouldn't blow away the existing list.
+  const isLoading = isMultiLoading && Object.keys(scopedSnapshots).length === 0;
+
+  return {
+    ...aggregated,
+    workflows: workspaceWorkflows,
+    isLoading,
+  };
+}

--- a/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.ts
+++ b/apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.ts
@@ -31,8 +31,11 @@ export function useWorkspaceSidebarTasks(workspaceId: string | null): WorkspaceS
   const activeKanbanTasks = useAppStore((state) => state.kanban.tasks);
   const activeKanbanSteps = useAppStore((state) => state.kanban.steps);
 
+  // While `workspaceId` is unresolved (initial SSR / pre-hydration), return an
+  // empty scope rather than every workflow in the store — otherwise snapshots
+  // from previously-active workspaces would briefly bleed into the sidebar.
   const filteredWorkflows = useMemo(
-    () => (!workspaceId ? workflows : workflows.filter((w) => w.workspaceId === workspaceId)),
+    () => (workspaceId ? workflows.filter((w) => w.workspaceId === workspaceId) : []),
     [workflows, workspaceId],
   );
   const workspaceWorkflowIds = useMemo(

--- a/apps/web/lib/kanban/find-task.test.ts
+++ b/apps/web/lib/kanban/find-task.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { findTaskInSnapshots } from "./find-task";
+import type { KanbanState } from "@/lib/state/slices";
+
+type Task = KanbanState["tasks"][number];
+
+function task(id: string): Task {
+  return { id, workflowStepId: "s", title: id, position: 0 };
+}
+
+describe("findTaskInSnapshots", () => {
+  it("finds a task in a snapshot", () => {
+    const snap = { tasks: [task("t1"), task("t2")] };
+    expect(findTaskInSnapshots("t2", { wf: snap })?.id).toBe("t2");
+  });
+
+  it("searches across every loaded snapshot", () => {
+    const snaps = { wfA: { tasks: [task("t1")] }, wfB: { tasks: [task("t2")] } };
+    expect(findTaskInSnapshots("t2", snaps)?.id).toBe("t2");
+  });
+
+  it("falls back to fallbackTasks when no snapshot matches", () => {
+    expect(findTaskInSnapshots("t-new", {}, [task("t-new")])?.id).toBe("t-new");
+  });
+
+  it("prefers a snapshot match over fallbackTasks", () => {
+    // If both exist, the snapshot version wins so the mobile sheet doesn't
+    // surface a stale active-kanban entry over a fresher multi-snapshot one.
+    const snap = { tasks: [{ ...task("t1"), title: "from-snapshot" }] };
+    const fallback = [{ ...task("t1"), title: "from-fallback" }];
+    expect(findTaskInSnapshots("t1", { wf: snap }, fallback)?.title).toBe("from-snapshot");
+  });
+
+  it("returns null when the task is missing from snapshots and fallback", () => {
+    expect(findTaskInSnapshots("missing", { wf: { tasks: [task("t1")] } })).toBeNull();
+    expect(findTaskInSnapshots("missing", {}, [task("t1")])).toBeNull();
+  });
+});

--- a/apps/web/lib/kanban/find-task.ts
+++ b/apps/web/lib/kanban/find-task.ts
@@ -2,13 +2,7 @@ import type { KanbanState } from "@/lib/state/slices";
 
 type Task = KanbanState["tasks"][number];
 
-// findTaskInSnapshots searches the multi-workflow snapshot map for a task by id.
-// Used by callers that need to resolve cross-workflow tasks (e.g. PR-review
-// boards, multi-workflow swimlanes) which do not live in `kanban.tasks`.
-//
-// `fallbackTasks` is consulted when no snapshot matches — the mobile sheet
-// passes `state.kanban.tasks` here so it can still locate tasks that arrived
-// via WS before the snapshot fetch resolved.
+// `fallbackTasks` is consulted when no snapshot matches (e.g. WS-arrived tasks before their snapshot lands).
 export function findTaskInSnapshots(
   taskId: string,
   snapshots: Record<string, { tasks: KanbanState["tasks"] }>,

--- a/apps/web/lib/kanban/find-task.ts
+++ b/apps/web/lib/kanban/find-task.ts
@@ -5,13 +5,18 @@ type Task = KanbanState["tasks"][number];
 // findTaskInSnapshots searches the multi-workflow snapshot map for a task by id.
 // Used by callers that need to resolve cross-workflow tasks (e.g. PR-review
 // boards, multi-workflow swimlanes) which do not live in `kanban.tasks`.
+//
+// `fallbackTasks` is consulted when no snapshot matches — the mobile sheet
+// passes `state.kanban.tasks` here so it can still locate tasks that arrived
+// via WS before the snapshot fetch resolved.
 export function findTaskInSnapshots(
   taskId: string,
   snapshots: Record<string, { tasks: KanbanState["tasks"] }>,
+  fallbackTasks?: KanbanState["tasks"],
 ): Task | null {
   for (const snapshot of Object.values(snapshots)) {
     const found = snapshot.tasks.find((t) => t.id === taskId);
     if (found) return found;
   }
-  return null;
+  return fallbackTasks?.find((t) => t.id === taskId) ?? null;
 }


### PR DESCRIPTION
On a fresh load of `/t/[id]` on mobile, the top-right menu opened a "Tasks" sheet that was empty — the mobile sheet read tasks via `useTasks(workflowId)`, which gated on `kanban.workflowId === workflowId` and returned `[]` whenever the kanban slice did not yet mirror the requested workflow (a race against the snapshot fetch, or a silent fetch failure). The mobile sheet now uses the same `kanbanMulti.snapshots` data source as the desktop sidebar, so tasks from every workspace workflow show up immediately and stay visible across workflow/workspace switches.

## Important Changes

- New shared hook `useWorkspaceSidebarTasks(workspaceId)` (`apps/web/hooks/domains/kanban/use-workspace-sidebar-tasks.ts`) — encapsulates `useAllWorkflowSnapshots` + the per-workspace aggregation with active-kanban fallback that previously lived only in the desktop sidebar.
- Desktop sidebar (`task-session-sidebar.tsx`) delegates to the new hook (its old `useScopedAggregation` is gone; behavior unchanged).
- Mobile sheet (`session-task-switcher-sheet-hooks.ts` + `session-task-switcher-sheet.tsx`) uses the new hook, passes `workflows` + `stepsByWorkflowId` to `TaskSwitcher` so grouping kicks in, and looks up action targets via a small `findTaskAcrossWorkflows` helper (snapshots first, active-kanban fallback) because the task list can now span workflows.

## Validation

- `pnpm --filter @kandev/web typecheck` — clean
- `pnpm --filter @kandev/web lint` — clean (0 warnings)
- `pnpm --filter @kandev/web test` — 2121 tests pass (incl. 5 new tests for `useWorkspaceSidebarTasks` covering scoping, cross-workspace filtering, active-kanban fallback, and first-fetch-only loading)
- `make -C apps/backend test lint` — passes (no backend changes)

## Possible Improvements

Low risk — mobile data path now matches a battle-tested desktop one. Main thing to watch: optimistic `handleTaskCreated` in the mobile sheet still upserts only into the active `kanban` slice, so a task created from another workflow's view relies on the aggregator's active-kanban fallback to surface in the list until the WS round-trip lands a fresh snapshot.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.