### PR TITLE
feat(web): add tree view for changes panel

### DIFF
--- a/apps/backend/internal/user/controller/controller.go
+++ b/apps/backend/internal/user/controller/controller.go
@@ -67,6 +67,7 @@ func (c *Controller) UpdateUserSettings(ctx context.Context, req dto.UpdateUserS
 		TerminalLinkBehavior:        req.TerminalLinkBehavior,
 		TerminalFontFamily:          req.TerminalFontFamily,
 		TerminalFontSize:            req.TerminalFontSize,
+		ChangesPanelLayout:          req.ChangesPanelLayout,
 	})
 	if err != nil {
 		return dto.UserSettingsResponse{}, err

--- a/apps/backend/internal/user/dto/dto.go
+++ b/apps/backend/internal/user/dto/dto.go
@@ -38,6 +38,7 @@ type UserSettingsDTO struct {
 	TerminalLinkBehavior        string                            `json:"terminal_link_behavior"`
 	TerminalFontFamily          string                            `json:"terminal_font_family"`
 	TerminalFontSize            int                               `json:"terminal_font_size"`
+	ChangesPanelLayout          string                            `json:"changes_panel_layout"`
 	UpdatedAt                   string                            `json:"updated_at"`
 }
 
@@ -80,6 +81,7 @@ type UpdateUserSettingsRequest struct {
 	TerminalLinkBehavior        *string                            `json:"terminal_link_behavior,omitempty"`
 	TerminalFontFamily          *string                            `json:"terminal_font_family,omitempty"`
 	TerminalFontSize            *int                               `json:"terminal_font_size,omitempty"`
+	ChangesPanelLayout          *string                            `json:"changes_panel_layout,omitempty"`
 }
 
 func FromUser(user *models.User) UserDTO {
@@ -117,6 +119,7 @@ func FromUserSettings(settings *models.UserSettings) UserSettingsDTO {
 		TerminalLinkBehavior:        settings.TerminalLinkBehavior,
 		TerminalFontFamily:          settings.TerminalFontFamily,
 		TerminalFontSize:            settings.TerminalFontSize,
+		ChangesPanelLayout:          settings.ChangesPanelLayout,
 		UpdatedAt:                   settings.UpdatedAt.Format(time.RFC3339),
 	}
 }

--- a/apps/backend/internal/user/models/models.go
+++ b/apps/backend/internal/user/models/models.go
@@ -37,6 +37,7 @@ type UserSettings struct {
 	TerminalLinkBehavior        string                            `json:"terminal_link_behavior"`   // "new_tab" | "browser_panel"
 	TerminalFontFamily          string                            `json:"terminal_font_family"`
 	TerminalFontSize            int                               `json:"terminal_font_size"`
+	ChangesPanelLayout          string                            `json:"changes_panel_layout"` // "flat" | "tree"
 	CreatedAt                   time.Time                         `json:"created_at"`
 	UpdatedAt                   time.Time                         `json:"updated_at"`
 }

--- a/apps/backend/internal/user/service/service.go
+++ b/apps/backend/internal/user/service/service.go
@@ -52,6 +52,7 @@ type UpdateUserSettingsRequest struct {
 	TerminalLinkBehavior        *string
 	TerminalFontFamily          *string
 	TerminalFontSize            *int
+	ChangesPanelLayout          *string
 }
 
 func NewService(repo store.Repository, eventBus bus.EventBus, log *logger.Logger) *Service {
@@ -174,6 +175,9 @@ func applyBasicSettings(settings *models.UserSettings, req *UpdateUserSettingsRe
 	if err := applyTerminalLinkBehavior(settings, req.TerminalLinkBehavior); err != nil {
 		return err
 	}
+	if err := applyChangesPanelLayout(settings, req.ChangesPanelLayout); err != nil {
+		return err
+	}
 	if req.TerminalFontFamily != nil {
 		settings.TerminalFontFamily = strings.TrimSpace(*req.TerminalFontFamily)
 	}
@@ -196,6 +200,18 @@ func applyTerminalLinkBehavior(settings *models.UserSettings, value *string) err
 		return errors.New("terminal_link_behavior must be 'new_tab' or 'browser_panel'")
 	}
 	settings.TerminalLinkBehavior = v
+	return nil
+}
+
+func applyChangesPanelLayout(settings *models.UserSettings, value *string) error {
+	if value == nil {
+		return nil
+	}
+	v := strings.TrimSpace(*value)
+	if v != "flat" && v != "tree" {
+		return errors.New("changes_panel_layout must be 'flat' or 'tree'")
+	}
+	settings.ChangesPanelLayout = v
 	return nil
 }
 
@@ -310,6 +326,7 @@ func (s *Service) publishUserSettingsEvent(ctx context.Context, settings *models
 		"terminal_link_behavior":          settings.TerminalLinkBehavior,
 		"terminal_font_family":            settings.TerminalFontFamily,
 		"terminal_font_size":              settings.TerminalFontSize,
+		"changes_panel_layout":            settings.ChangesPanelLayout,
 		"updated_at":                      settings.UpdatedAt.Format(time.RFC3339),
 	}
 	if err := s.eventBus.Publish(ctx, events.UserSettingsUpdated, bus.NewEvent(events.UserSettingsUpdated, "user-service", data)); err != nil {

--- a/apps/backend/internal/user/service/service_test.go
+++ b/apps/backend/internal/user/service/service_test.go
@@ -134,6 +134,60 @@ func TestApplyBasicSettings_TerminalFontFamily(t *testing.T) {
 	})
 }
 
+func TestApplyChangesPanelLayout(t *testing.T) {
+	t.Run("nil leaves settings unchanged", func(t *testing.T) {
+		settings := &models.UserSettings{ChangesPanelLayout: "tree"}
+		req := &UpdateUserSettingsRequest{}
+		if err := applyBasicSettings(settings, req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if settings.ChangesPanelLayout != "tree" {
+			t.Fatalf("expected ChangesPanelLayout=tree, got %s", settings.ChangesPanelLayout)
+		}
+	})
+
+	t.Run("sets tree when provided", func(t *testing.T) {
+		settings := &models.UserSettings{}
+		req := &UpdateUserSettingsRequest{ChangesPanelLayout: ptr("tree")}
+		if err := applyBasicSettings(settings, req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if settings.ChangesPanelLayout != "tree" {
+			t.Fatalf("expected ChangesPanelLayout=tree, got %s", settings.ChangesPanelLayout)
+		}
+	})
+
+	t.Run("sets flat when provided", func(t *testing.T) {
+		settings := &models.UserSettings{ChangesPanelLayout: "tree"}
+		req := &UpdateUserSettingsRequest{ChangesPanelLayout: ptr("flat")}
+		if err := applyBasicSettings(settings, req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if settings.ChangesPanelLayout != "flat" {
+			t.Fatalf("expected ChangesPanelLayout=flat, got %s", settings.ChangesPanelLayout)
+		}
+	})
+
+	t.Run("rejects invalid value", func(t *testing.T) {
+		settings := &models.UserSettings{}
+		req := &UpdateUserSettingsRequest{ChangesPanelLayout: ptr("grid")}
+		if err := applyBasicSettings(settings, req); err == nil {
+			t.Fatal("expected error for invalid layout, got nil")
+		}
+	})
+
+	t.Run("trims whitespace before validation", func(t *testing.T) {
+		settings := &models.UserSettings{}
+		req := &UpdateUserSettingsRequest{ChangesPanelLayout: ptr("  tree  ")}
+		if err := applyBasicSettings(settings, req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if settings.ChangesPanelLayout != "tree" {
+			t.Fatalf("expected ChangesPanelLayout=tree, got %q", settings.ChangesPanelLayout)
+		}
+	})
+}
+
 func TestApplyBasicSettings_TerminalFontSize(t *testing.T) {
 	t.Run("nil leaves settings unchanged", func(t *testing.T) {
 		settings := &models.UserSettings{TerminalFontSize: 14}

--- a/apps/backend/internal/user/store/sqlite.go
+++ b/apps/backend/internal/user/store/sqlite.go
@@ -161,6 +161,7 @@ func (r *sqliteRepository) UpsertUserSettings(ctx context.Context, settings *mod
 		"terminal_link_behavior":          settings.TerminalLinkBehavior,
 		"terminal_font_family":            settings.TerminalFontFamily,
 		"terminal_font_size":              settings.TerminalFontSize,
+		"changes_panel_layout":            settings.ChangesPanelLayout,
 	})
 	if err != nil {
 		return err
@@ -205,6 +206,7 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 		settings.ChatSubmitKey = "cmd_enter"
 		settings.KeyboardShortcuts = map[string]interface{}{}
 		settings.TerminalLinkBehavior = "new_tab"
+		settings.ChangesPanelLayout = "flat"
 		settings.SidebarViews = []models.SidebarView{}
 		return settings, nil
 	}
@@ -232,6 +234,7 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 		TerminalLinkBehavior        string                            `json:"terminal_link_behavior"`
 		TerminalFontFamily          string                            `json:"terminal_font_family"`
 		TerminalFontSize            int                               `json:"terminal_font_size"`
+		ChangesPanelLayout          string                            `json:"changes_panel_layout"`
 	}
 	if err := json.Unmarshal([]byte(settingsRaw), &payload); err != nil {
 		return nil, err
@@ -291,5 +294,10 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 	}
 	settings.TerminalFontFamily = payload.TerminalFontFamily
 	settings.TerminalFontSize = payload.TerminalFontSize
+	if payload.ChangesPanelLayout != "" {
+		settings.ChangesPanelLayout = payload.ChangesPanelLayout
+	} else {
+		settings.ChangesPanelLayout = "flat"
+	}
 	return settings, nil
 }

--- a/apps/backend/internal/user/store/sqlite.go
+++ b/apps/backend/internal/user/store/sqlite.go
@@ -294,8 +294,8 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 	}
 	settings.TerminalFontFamily = payload.TerminalFontFamily
 	settings.TerminalFontSize = payload.TerminalFontSize
-	if payload.ChangesPanelLayout != "" {
-		settings.ChangesPanelLayout = payload.ChangesPanelLayout
+	if payload.ChangesPanelLayout == "tree" {
+		settings.ChangesPanelLayout = "tree"
 	} else {
 		settings.ChangesPanelLayout = "flat"
 	}

--- a/apps/web/components/settings/editors-settings-state.tsx
+++ b/apps/web/components/settings/editors-settings-state.tsx
@@ -244,6 +244,7 @@ function buildUserSettingsFromResponse(
     terminalLinkBehavior: parseTerminalLinkBehavior(s.terminal_link_behavior),
     terminalFontFamily: s.terminal_font_family || null,
     terminalFontSize: s.terminal_font_size || null,
+    changesPanelLayout: s.changes_panel_layout === "tree" ? ("tree" as const) : ("flat" as const),
     ...mapEditorSettingsFields(s),
   };
 }

--- a/apps/web/components/settings/general-settings.tsx
+++ b/apps/web/components/settings/general-settings.tsx
@@ -8,6 +8,7 @@ import {
   IconServer,
   IconKeyboard,
   IconTerminal2,
+  IconGitBranch,
 } from "@tabler/icons-react";
 import { Badge } from "@kandev/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
@@ -109,6 +110,61 @@ function ChatSubmitKeyCard() {
             {userSettings.chatSubmitKey === "cmd_enter"
               ? "Press Cmd/Ctrl+Enter to send messages. Press Enter for newlines."
               : "Press Enter to send messages. Press Shift+Enter for newlines."}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ChangesPanelLayoutCard() {
+  const userSettings = useAppStore((state) => state.userSettings);
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const storeApi = useAppStoreApi();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleChange = async (value: "flat" | "tree") => {
+    if (isSaving) return;
+    setIsSaving(true);
+    const current = storeApi.getState().userSettings;
+    const previous = current.changesPanelLayout;
+    try {
+      setUserSettings({ ...current, changesPanelLayout: value });
+      await updateUserSettings({
+        workspace_id: current.workspaceId || "",
+        repository_ids: current.repositoryIds || [],
+        changes_panel_layout: value,
+      });
+    } catch {
+      setUserSettings({ ...storeApi.getState().userSettings, changesPanelLayout: previous });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Changes Panel Layout</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <Label htmlFor="changes-panel-layout">File list view</Label>
+          <Select
+            value={userSettings.changesPanelLayout}
+            onValueChange={(v) => handleChange(v as "flat" | "tree")}
+            disabled={isSaving}
+          >
+            <SelectTrigger id="changes-panel-layout" data-testid="changes-panel-layout-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="flat">Flat list</SelectItem>
+              <SelectItem value="tree">Tree</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Display changed files as a flat list with full paths, or as a folder tree.
           </p>
         </div>
       </CardContent>
@@ -446,6 +502,16 @@ export function GeneralSettings() {
         description="Configure chat input behavior"
       >
         <ChatSubmitKeyCard />
+      </SettingsSection>
+
+      <Separator />
+
+      <SettingsSection
+        icon={<IconGitBranch className="h-5 w-5" />}
+        title="Changes Panel"
+        description="Customize how changed files are displayed"
+      >
+        <ChangesPanelLayoutCard />
       </SettingsSection>
 
       <Separator />

--- a/apps/web/components/settings/general-settings.tsx
+++ b/apps/web/components/settings/general-settings.tsx
@@ -155,7 +155,11 @@ function ChangesPanelLayoutCard() {
             onValueChange={(v) => handleChange(v as "flat" | "tree")}
             disabled={isSaving}
           >
-            <SelectTrigger id="changes-panel-layout" data-testid="changes-panel-layout-select">
+            <SelectTrigger
+              id="changes-panel-layout"
+              data-testid="changes-panel-layout-select"
+              className="cursor-pointer"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/apps/web/components/task/changes-panel-file-row.tsx
+++ b/apps/web/components/task/changes-panel-file-row.tsx
@@ -14,8 +14,8 @@ import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { LineStat } from "@/components/diff-stat";
 import { FileIcon } from "@/components/ui/file-icon";
-import type { FileInfo } from "@/lib/state/store";
 import { FileStatusIcon } from "./file-status-icon";
+import type { ChangedFile } from "./changes-panel-helpers";
 import type { OpenDiffOptions } from "./changes-diff-target";
 
 const splitPath = (path: string) => {
@@ -25,17 +25,6 @@ const splitPath = (path: string) => {
     folder: path.slice(0, lastSlash),
     file: path.slice(lastSlash + 1),
   };
-};
-
-type ChangedFile = {
-  path: string;
-  status: FileInfo["status"];
-  staged: boolean;
-  plus: number | undefined;
-  minus: number | undefined;
-  oldPath: string | undefined;
-  /** Multi-repo: name of the repo this file lives in. Empty for single-repo. */
-  repositoryName?: string;
 };
 
 type FileRowProps = {

--- a/apps/web/components/task/changes-panel-file-row.tsx
+++ b/apps/web/components/task/changes-panel-file-row.tsx
@@ -52,6 +52,10 @@ type FileRowProps = {
   onUnstage: (path: string, repo?: string) => void;
   onDiscard: (path: string, repo?: string) => void;
   onEditFile: (path: string) => void;
+  /** Tree mode: skip the folder prefix in the label (depth is implied by indent). */
+  hideFolderPrefix?: boolean;
+  /** Tree mode: left padding in pixels driven by depth. */
+  indentPx?: number;
 };
 
 export function FileRow({
@@ -65,8 +69,11 @@ export function FileRow({
   onUnstage,
   onDiscard,
   onEditFile,
+  hideFolderPrefix,
+  indentPx,
 }: FileRowProps) {
   const { folder, file: name } = splitPath(file.path);
+  const showFolder = !hideFolderPrefix && folder;
 
   const handleClick = (e: React.MouseEvent) => {
     if (e.button === 2) return;
@@ -94,7 +101,10 @@ export function FileRow({
       )}
       onClick={handleClick}
     >
-      <div className="flex items-center gap-2 min-w-0">
+      <div
+        className="flex items-center gap-2 min-w-0"
+        style={indentPx ? { paddingLeft: indentPx } : undefined}
+      >
         <StageButton
           isPending={isPending}
           staged={file.staged}
@@ -105,7 +115,7 @@ export function FileRow({
         />
         <button type="button" className="min-w-0 text-left cursor-pointer" title={file.path}>
           <p className="flex text-foreground text-xs min-w-0">
-            {folder && (
+            {showFolder && (
               <span className="text-foreground/60 truncate min-w-0 [flex-shrink:9999]">
                 {folder}/
               </span>

--- a/apps/web/components/task/changes-panel-file-row.tsx
+++ b/apps/web/components/task/changes-panel-file-row.tsx
@@ -13,6 +13,7 @@ import { Button } from "@kandev/ui/button";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { LineStat } from "@/components/diff-stat";
+import { FileIcon } from "@/components/ui/file-icon";
 import type { FileInfo } from "@/lib/state/store";
 import { FileStatusIcon } from "./file-status-icon";
 import type { OpenDiffOptions } from "./changes-diff-target";
@@ -52,8 +53,13 @@ type FileRowProps = {
   onUnstage: (path: string, repo?: string) => void;
   onDiscard: (path: string, repo?: string) => void;
   onEditFile: (path: string) => void;
-  /** Tree mode: skip the folder prefix in the label (depth is implied by indent). */
-  hideFolderPrefix?: boolean;
+  /**
+   * Tree mode: skip the folder prefix, swap the left-side stage button for a
+   * filetype icon, and surface the stage action only on row hover (VS Code-
+   * style). The Unstaged / Staged section split keeps the staged state
+   * visually obvious even without the always-on left chip.
+   */
+  treeMode?: boolean;
   /** Tree mode: left padding in pixels driven by depth. */
   indentPx?: number;
 };
@@ -69,11 +75,11 @@ export function FileRow({
   onUnstage,
   onDiscard,
   onEditFile,
-  hideFolderPrefix,
+  treeMode,
   indentPx,
 }: FileRowProps) {
   const { folder, file: name } = splitPath(file.path);
-  const showFolder = !hideFolderPrefix && folder;
+  const showFolder = !treeMode && folder;
 
   const handleClick = (e: React.MouseEvent) => {
     if (e.button === 2) return;
@@ -105,14 +111,18 @@ export function FileRow({
         className="flex items-center gap-2 min-w-0"
         style={indentPx ? { paddingLeft: indentPx } : undefined}
       >
-        <StageButton
-          isPending={isPending}
-          staged={file.staged}
-          path={file.path}
-          repo={file.repositoryName}
-          onStage={onStage}
-          onUnstage={onUnstage}
-        />
+        {treeMode ? (
+          <FileIcon fileName={name} className="size-4 shrink-0" />
+        ) : (
+          <StageButton
+            isPending={isPending}
+            staged={file.staged}
+            path={file.path}
+            repo={file.repositoryName}
+            onStage={onStage}
+            onUnstage={onUnstage}
+          />
+        )}
         <button type="button" className="min-w-0 text-left cursor-pointer" title={file.path}>
           <p className="flex text-foreground text-xs min-w-0">
             {showFolder && (
@@ -130,6 +140,18 @@ export function FileRow({
           repo={file.repositoryName}
           onDiscard={onDiscard}
           onEditFile={onEditFile}
+          stageButton={
+            treeMode ? (
+              <StageButton
+                isPending={isPending}
+                staged={file.staged}
+                path={file.path}
+                repo={file.repositoryName}
+                onStage={onStage}
+                onUnstage={onUnstage}
+              />
+            ) : null
+          }
         />
         <LineStat added={file.plus} removed={file.minus} />
         <FileStatusIcon status={file.status} />
@@ -196,11 +218,14 @@ function FileRowActions({
   repo,
   onDiscard,
   onEditFile,
+  stageButton,
 }: {
   path: string;
   repo?: string;
   onDiscard: (path: string, repo?: string) => void;
   onEditFile: (path: string) => void;
+  /** Tree mode: stage/unstage control rendered alongside the other hover actions. */
+  stageButton?: React.ReactNode;
 }) {
   return (
     <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
@@ -234,6 +259,7 @@ function FileRowActions({
         </TooltipTrigger>
         <TooltipContent>Edit</TooltipContent>
       </Tooltip>
+      {stageButton}
     </div>
   );
 }

--- a/apps/web/components/task/changes-panel-repo-groups.tsx
+++ b/apps/web/components/task/changes-panel-repo-groups.tsx
@@ -11,16 +11,7 @@ import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { CommitRow, type CommitItem } from "./commit-row";
 import { groupByRepositoryName } from "@/lib/group-by-repo";
-
-type ChangedFile = {
-  path: string;
-  status: import("@/lib/state/store").FileInfo["status"];
-  staged: boolean;
-  plus: number | undefined;
-  minus: number | undefined;
-  oldPath: string | undefined;
-  repositoryName?: string;
-};
+import type { ChangedFile } from "./changes-panel-helpers";
 
 export type RepoGroup = ReturnType<typeof groupByRepositoryName<ChangedFile>>[number];
 

--- a/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
+++ b/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
@@ -25,6 +25,12 @@ vi.mock("@/hooks/use-multi-select", () => ({
   }),
 }));
 
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (
+    selector: (state: { userSettings: { changesPanelLayout: "flat" | "tree" } }) => unknown,
+  ) => selector({ userSettings: { changesPanelLayout: "flat" } }),
+}));
+
 import { FileListSection, CommitsSection } from "./changes-panel-timeline";
 
 const REPO_HEADER_TID = "changes-repo-header";

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -329,6 +329,7 @@ function FileListBody(props: FileListBodyProps) {
             onUnstage={props.onUnstage}
             onDiscard={props.onDiscard}
             variant={variant}
+            multiSelect={multiSelect}
           />
         ) : (
           groups.map((group) => (
@@ -350,6 +351,7 @@ function FileListBody(props: FileListBodyProps) {
               secondaryLabel={props.secondaryLabel}
               onRepoAction={props.onRepoAction}
               onRepoSecondaryAction={props.onRepoSecondaryAction}
+              multiSelect={multiSelect}
             />
           ))
         )}

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -336,7 +336,6 @@ type FileListBranchProps = FileListBodyProps & {
   collapsedRepos: Set<string>;
   toggleRepo: (name: string) => void;
 };
-
 function TreeFileListBody(props: FileListBranchProps) {
   const {
     variant,

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -7,7 +7,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { FileInfo } from "@/lib/state/store";
 import { useDockviewStore } from "@/lib/state/dockview-store";
+import { useAppStore } from "@/components/state-provider";
 import { FileRow, BulkActionBar } from "./changes-panel-file-row";
+import { ChangesTree, RepoTreeGroup } from "./changes-panel-tree";
 import { type CommitItem } from "./commit-row";
 import { groupByRepositoryName, isSingleRepoGroup } from "@/lib/group-by-repo";
 import {
@@ -279,6 +281,7 @@ function FileListBody(props: FileListBodyProps) {
   // in two repos will light up both rows. Matches existing routing limit noted
   // in FileRowProps comments.
   const activeFilePath = useDockviewStore((s) => s.activeFilePath);
+  const layout = useAppStore((s) => s.userSettings.changesPanelLayout);
   const groups = useMemo(() => groupByRepositoryName(files, (f) => f.repositoryName), [files]);
   // Per-repo collapsed state: keyed by repositoryName. Default expanded;
   // setting an entry to true collapses that group. Persists across re-renders
@@ -312,6 +315,47 @@ function FileListBody(props: FileListBodyProps) {
   // Single-repo: drop the per-repo sub-header. The action buttons (Stage all
   // / Commit / Unstage all) move up to the section header — see FileListSection.
   const isSingleRepo = isSingleRepoGroup(groups);
+
+  if (layout === "tree") {
+    return (
+      <div tabIndex={-1} onKeyDown={props.onKeyDown}>
+        {isSingleRepo ? (
+          <ChangesTree
+            files={groups[0].items}
+            pendingStageFiles={pendingStageFiles}
+            onOpenDiff={props.onOpenDiff}
+            onEditFile={props.onEditFile}
+            onStage={props.onStage}
+            onUnstage={props.onUnstage}
+            onDiscard={props.onDiscard}
+            variant={variant}
+          />
+        ) : (
+          groups.map((group) => (
+            <RepoTreeGroup
+              key={group.repositoryName || "__no_repo__"}
+              variant={variant}
+              repositoryName={group.repositoryName}
+              displayName={props.repoDisplayName?.(group.repositoryName)}
+              files={group.items}
+              pendingStageFiles={pendingStageFiles}
+              collapsed={collapsedRepos.has(group.repositoryName)}
+              onToggle={() => toggleRepo(group.repositoryName)}
+              onOpenDiff={props.onOpenDiff}
+              onEditFile={props.onEditFile}
+              onStage={props.onStage}
+              onUnstage={props.onUnstage}
+              onDiscard={props.onDiscard}
+              primaryLabel={props.primaryLabel}
+              secondaryLabel={props.secondaryLabel}
+              onRepoAction={props.onRepoAction}
+              onRepoSecondaryAction={props.onRepoSecondaryAction}
+            />
+          ))
+        )}
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -10,6 +10,7 @@ import { useDockviewStore } from "@/lib/state/dockview-store";
 import { useAppStore } from "@/components/state-provider";
 import { FileRow, BulkActionBar } from "./changes-panel-file-row";
 import { ChangesTree, RepoTreeGroup } from "./changes-panel-tree";
+import type { ChangedFile } from "./changes-panel-helpers";
 import { type CommitItem } from "./commit-row";
 import { groupByRepositoryName, isSingleRepoGroup } from "@/lib/group-by-repo";
 import {
@@ -22,17 +23,6 @@ import { PRFilesGroupedList } from "./changes-panel-pr-files";
 import type { OpenDiffOptions } from "./changes-diff-target";
 
 // --- Timeline visual components ---
-
-type ChangedFile = {
-  path: string;
-  status: FileInfo["status"];
-  staged: boolean;
-  plus: number | undefined;
-  minus: number | undefined;
-  oldPath: string | undefined;
-  /** Repository this file belongs to in multi-repo workspaces; empty for single-repo. */
-  repositoryName?: string;
-};
 
 // Per-repo grouping is shared with the Review dialog — see @/lib/group-by-repo.
 
@@ -276,7 +266,7 @@ type FileListBodyProps = {
 };
 
 function FileListBody(props: FileListBodyProps) {
-  const { variant, files, pendingStageFiles, multiSelect } = props;
+  const { files, pendingStageFiles, multiSelect } = props;
   // Multi-repo nuance: activeFilePath carries the path but not repo; same path
   // in two repos will light up both rows. Matches existing routing limit noted
   // in FileRowProps comments.
@@ -318,47 +308,91 @@ function FileListBody(props: FileListBodyProps) {
 
   if (layout === "tree") {
     return (
-      <div tabIndex={-1} onKeyDown={props.onKeyDown}>
-        {isSingleRepo ? (
-          <ChangesTree
-            files={groups[0].items}
+      <TreeFileListBody
+        {...props}
+        groups={groups}
+        isSingleRepo={isSingleRepo}
+        collapsedRepos={collapsedRepos}
+        toggleRepo={toggleRepo}
+      />
+    );
+  }
+
+  return (
+    <FlatFileListBody
+      {...props}
+      groups={groups}
+      isSingleRepo={isSingleRepo}
+      collapsedRepos={collapsedRepos}
+      toggleRepo={toggleRepo}
+      renderRow={renderRow}
+    />
+  );
+}
+
+type FileListBranchProps = FileListBodyProps & {
+  groups: ReturnType<typeof groupByRepositoryName<ChangedFile>>;
+  isSingleRepo: boolean;
+  collapsedRepos: Set<string>;
+  toggleRepo: (name: string) => void;
+};
+
+function TreeFileListBody(props: FileListBranchProps) {
+  const {
+    variant,
+    groups,
+    isSingleRepo,
+    collapsedRepos,
+    toggleRepo,
+    pendingStageFiles,
+    multiSelect,
+  } = props;
+  return (
+    <div tabIndex={-1} onKeyDown={props.onKeyDown}>
+      {isSingleRepo ? (
+        <ChangesTree
+          files={groups[0].items}
+          pendingStageFiles={pendingStageFiles}
+          onOpenDiff={props.onOpenDiff}
+          onEditFile={props.onEditFile}
+          onStage={props.onStage}
+          onUnstage={props.onUnstage}
+          onDiscard={props.onDiscard}
+          variant={variant}
+          multiSelect={multiSelect}
+        />
+      ) : (
+        groups.map((group) => (
+          <RepoTreeGroup
+            key={group.repositoryName || "__no_repo__"}
+            variant={variant}
+            repositoryName={group.repositoryName}
+            displayName={props.repoDisplayName?.(group.repositoryName)}
+            files={group.items}
             pendingStageFiles={pendingStageFiles}
+            collapsed={collapsedRepos.has(group.repositoryName)}
+            onToggle={() => toggleRepo(group.repositoryName)}
             onOpenDiff={props.onOpenDiff}
             onEditFile={props.onEditFile}
             onStage={props.onStage}
             onUnstage={props.onUnstage}
             onDiscard={props.onDiscard}
-            variant={variant}
+            primaryLabel={props.primaryLabel}
+            secondaryLabel={props.secondaryLabel}
+            onRepoAction={props.onRepoAction}
+            onRepoSecondaryAction={props.onRepoSecondaryAction}
             multiSelect={multiSelect}
           />
-        ) : (
-          groups.map((group) => (
-            <RepoTreeGroup
-              key={group.repositoryName || "__no_repo__"}
-              variant={variant}
-              repositoryName={group.repositoryName}
-              displayName={props.repoDisplayName?.(group.repositoryName)}
-              files={group.items}
-              pendingStageFiles={pendingStageFiles}
-              collapsed={collapsedRepos.has(group.repositoryName)}
-              onToggle={() => toggleRepo(group.repositoryName)}
-              onOpenDiff={props.onOpenDiff}
-              onEditFile={props.onEditFile}
-              onStage={props.onStage}
-              onUnstage={props.onUnstage}
-              onDiscard={props.onDiscard}
-              primaryLabel={props.primaryLabel}
-              secondaryLabel={props.secondaryLabel}
-              onRepoAction={props.onRepoAction}
-              onRepoSecondaryAction={props.onRepoSecondaryAction}
-              multiSelect={multiSelect}
-            />
-          ))
-        )}
-      </div>
-    );
-  }
+        ))
+      )}
+    </div>
+  );
+}
 
+function FlatFileListBody(
+  props: FileListBranchProps & { renderRow: (file: ChangedFile) => React.ReactNode },
+) {
+  const { variant, groups, isSingleRepo, collapsedRepos, toggleRepo, renderRow } = props;
   return (
     <div>
       <ul

--- a/apps/web/components/task/changes-panel-tree.test.tsx
+++ b/apps/web/components/task/changes-panel-tree.test.tsx
@@ -10,15 +10,6 @@ vi.mock("./changes-panel-file-row", () => ({
   ),
 }));
 
-vi.mock("@/hooks/use-multi-select", () => ({
-  useMultiSelect: () => ({
-    selectedPaths: new Set<string>(),
-    isSelected: () => false,
-    handleClick: vi.fn(),
-    clearSelection: vi.fn(),
-  }),
-}));
-
 vi.mock("@/lib/state/dockview-store", () => ({
   useDockviewStore: () => null,
 }));
@@ -29,6 +20,15 @@ afterEach(cleanup);
 
 type Props = ComponentProps<typeof ChangesTree>;
 
+const stubMultiSelect: Props["multiSelect"] = {
+  selectedPaths: new Set<string>(),
+  isSelected: () => false,
+  handleClick: vi.fn(() => false),
+  clearSelection: vi.fn(),
+  selectAll: vi.fn(),
+  setSelectedPaths: vi.fn(),
+};
+
 const baseProps: Omit<Props, "files" | "variant"> = {
   pendingStageFiles: new Set(),
   onOpenDiff: vi.fn(),
@@ -36,6 +36,7 @@ const baseProps: Omit<Props, "files" | "variant"> = {
   onStage: vi.fn(),
   onUnstage: vi.fn(),
   onDiscard: vi.fn(),
+  multiSelect: stubMultiSelect,
 };
 
 function file(path: string): Props["files"][number] {
@@ -49,19 +50,23 @@ function file(path: string): Props["files"][number] {
   };
 }
 
+const APPS_WEB_DIR = "tree-dir-apps-web";
+const FOO_TS = "apps/web/foo.ts";
+const BAR_TS = "apps/web/bar.ts";
+
 describe("ChangesTree", () => {
   it("renders folders as dir rows and files as file rows", () => {
     render(
       <ChangesTree
         {...baseProps}
         variant="unstaged"
-        files={[file("apps/web/foo.ts"), file("apps/web/bar.ts"), file("README.md")]}
+        files={[file(FOO_TS), file(BAR_TS), file("README.md")]}
       />,
     );
     // Two file rows under apps/web plus README at root.
     expect(screen.getAllByTestId("file-row")).toHaveLength(3);
     // A directory row exists for "apps/web" (chain-collapsed).
-    const dir = screen.getByTestId("tree-dir-apps-web");
+    const dir = screen.getByTestId(APPS_WEB_DIR);
     expect(dir.textContent).toContain("apps/web");
   });
 
@@ -73,15 +78,30 @@ describe("ChangesTree", () => {
   });
 
   it("hides children when a folder is collapsed", () => {
+    render(<ChangesTree {...baseProps} variant="unstaged" files={[file(FOO_TS), file(BAR_TS)]} />);
+    expect(screen.getAllByTestId("file-row")).toHaveLength(2);
+    fireEvent.click(screen.getByTestId(APPS_WEB_DIR));
+    expect(screen.queryAllByTestId("file-row")).toHaveLength(0);
+  });
+
+  it("uses the parent multiSelect (not an internal one) so bulk actions stay wired", () => {
+    // Regression: tree mode used to instantiate its own useMultiSelect, which
+    // left the section-level BulkActionBar blind to tree selections. Verify
+    // the prop is consulted by checking that isSelected/handleClick come from
+    // the supplied object.
+    const isSelected = vi.fn(() => true);
+    const handleClick = vi.fn(() => false);
     render(
       <ChangesTree
         {...baseProps}
+        multiSelect={{ ...stubMultiSelect, isSelected, handleClick }}
         variant="unstaged"
-        files={[file("apps/web/foo.ts"), file("apps/web/bar.ts")]}
+        files={[file(FOO_TS)]}
       />,
     );
-    expect(screen.getAllByTestId("file-row")).toHaveLength(2);
-    fireEvent.click(screen.getByTestId("tree-dir-apps-web"));
-    expect(screen.queryAllByTestId("file-row")).toHaveLength(0);
+    // Our FileRow mock surfaces isSelected via a data attribute when wired.
+    // Even without the attribute, the spy proves the parent's hook ran for
+    // this file's path during render.
+    expect(isSelected).toHaveBeenCalledWith(FOO_TS);
   });
 });

--- a/apps/web/components/task/changes-panel-tree.test.tsx
+++ b/apps/web/components/task/changes-panel-tree.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ComponentProps } from "react";
+
+vi.mock("./changes-panel-file-row", () => ({
+  FileRow: ({ file, indentPx }: { file: { path: string }; indentPx?: number }) => (
+    <li data-testid="file-row" data-indent={indentPx ?? 0}>
+      {file.path}
+    </li>
+  ),
+}));
+
+vi.mock("@/hooks/use-multi-select", () => ({
+  useMultiSelect: () => ({
+    selectedPaths: new Set<string>(),
+    isSelected: () => false,
+    handleClick: vi.fn(),
+    clearSelection: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: () => null,
+}));
+
+import { ChangesTree } from "./changes-panel-tree";
+
+afterEach(cleanup);
+
+type Props = ComponentProps<typeof ChangesTree>;
+
+const baseProps: Omit<Props, "files" | "variant"> = {
+  pendingStageFiles: new Set(),
+  onOpenDiff: vi.fn(),
+  onEditFile: vi.fn(),
+  onStage: vi.fn(),
+  onUnstage: vi.fn(),
+  onDiscard: vi.fn(),
+};
+
+function file(path: string): Props["files"][number] {
+  return {
+    path,
+    status: "modified",
+    staged: false,
+    plus: 1,
+    minus: 0,
+    oldPath: undefined,
+  };
+}
+
+describe("ChangesTree", () => {
+  it("renders folders as dir rows and files as file rows", () => {
+    render(
+      <ChangesTree
+        {...baseProps}
+        variant="unstaged"
+        files={[file("apps/web/foo.ts"), file("apps/web/bar.ts"), file("README.md")]}
+      />,
+    );
+    // Two file rows under apps/web plus README at root.
+    expect(screen.getAllByTestId("file-row")).toHaveLength(3);
+    // A directory row exists for "apps/web" (chain-collapsed).
+    const dir = screen.getByTestId("tree-dir-apps-web");
+    expect(dir.textContent).toContain("apps/web");
+  });
+
+  it("collapses a single-child dir chain into one row", () => {
+    render(<ChangesTree {...baseProps} variant="unstaged" files={[file("a/b/c/file.ts")]} />);
+    // The chain a/b/c renders as a single dir row keyed by the deepest path.
+    const dir = screen.getByTestId("tree-dir-a-b-c");
+    expect(dir.textContent).toContain("a/b/c");
+  });
+
+  it("hides children when a folder is collapsed", () => {
+    render(
+      <ChangesTree
+        {...baseProps}
+        variant="unstaged"
+        files={[file("apps/web/foo.ts"), file("apps/web/bar.ts")]}
+      />,
+    );
+    expect(screen.getAllByTestId("file-row")).toHaveLength(2);
+    fireEvent.click(screen.getByTestId("tree-dir-apps-web"));
+    expect(screen.queryAllByTestId("file-row")).toHaveLength(0);
+  });
+});

--- a/apps/web/components/task/changes-panel-tree.tsx
+++ b/apps/web/components/task/changes-panel-tree.tsx
@@ -3,10 +3,9 @@
 import { useMemo } from "react";
 import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
-import { cn } from "@/lib/utils";
 import { useTree, type VisibleRow } from "@/hooks/use-tree";
 import { useDockviewStore } from "@/lib/state/dockview-store";
-import { useMultiSelect } from "@/hooks/use-multi-select";
+import type { useMultiSelect } from "@/hooks/use-multi-select";
 import { FileRow } from "./changes-panel-file-row";
 import type { FileInfo } from "@/lib/state/store";
 import type { OpenDiffOptions } from "./changes-diff-target";
@@ -80,6 +79,9 @@ type ChangesTreeProps = {
   onUnstage: (path: string, repo?: string) => void;
   onDiscard: (path: string, repo?: string) => void;
   variant: "unstaged" | "staged";
+  /** Shared with the parent FileListSection so the BulkActionBar reflects
+   *  selections made in tree mode. */
+  multiSelect: ReturnType<typeof useMultiSelect>;
 };
 
 export function ChangesTree({
@@ -91,6 +93,7 @@ export function ChangesTree({
   onUnstage,
   onDiscard,
   variant,
+  multiSelect,
 }: ChangesTreeProps) {
   const tree = useMemo(() => buildChangesTree(files), [files]);
   const { visibleRows, toggle } = useTree<TreeNode>({
@@ -102,8 +105,6 @@ export function ChangesTree({
     chainCollapse: true,
   });
 
-  const filePaths = useMemo(() => files.map((f) => f.path), [files]);
-  const multiSelect = useMultiSelect({ items: filePaths });
   const activeFilePath = useDockviewStore((s) => s.activeFilePath);
 
   return (
@@ -150,6 +151,7 @@ type RepoTreeGroupProps = {
   secondaryLabel?: string;
   onRepoAction?: (repo: string) => void;
   onRepoSecondaryAction?: (repo: string) => void;
+  multiSelect: ReturnType<typeof useMultiSelect>;
 };
 
 export function RepoTreeGroup(props: RepoTreeGroupProps) {
@@ -225,6 +227,7 @@ export function RepoTreeGroup(props: RepoTreeGroupProps) {
           onUnstage={props.onUnstage}
           onDiscard={props.onDiscard}
           variant={variant}
+          multiSelect={props.multiSelect}
         />
       )}
     </div>
@@ -236,9 +239,7 @@ function TreeDirRow({ row, onToggle }: { row: VisibleRow<TreeNode>; onToggle: ()
     <li>
       <button
         type="button"
-        className={cn(
-          "flex items-center w-full gap-1 px-1 py-0.5 -mx-1 rounded-md hover:bg-muted/60 cursor-pointer text-xs text-foreground/70",
-        )}
+        className="flex items-center w-full gap-1 px-1 py-0.5 -mx-1 rounded-md hover:bg-muted/60 cursor-pointer text-xs text-foreground/70"
         style={{ paddingLeft: row.depth * 12 + 4 }}
         onClick={onToggle}
         data-testid={`tree-dir-${row.path.replace(/[/\\]/g, "-")}`}

--- a/apps/web/components/task/changes-panel-tree.tsx
+++ b/apps/web/components/task/changes-panel-tree.tsx
@@ -1,24 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { useTree, type VisibleRow } from "@/hooks/use-tree";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import type { useMultiSelect } from "@/hooks/use-multi-select";
 import { FileRow } from "./changes-panel-file-row";
-import type { FileInfo } from "@/lib/state/store";
+import type { ChangedFile } from "./changes-panel-helpers";
 import type { OpenDiffOptions } from "./changes-diff-target";
-
-type ChangedFile = {
-  path: string;
-  status: FileInfo["status"];
-  staged: boolean;
-  plus: number | undefined;
-  minus: number | undefined;
-  oldPath: string | undefined;
-  repositoryName?: string;
-};
 
 type TreeNode = {
   name: string;
@@ -70,6 +60,20 @@ const GET_PATH = (n: TreeNode) => n.path;
 const GET_CHILDREN = (n: TreeNode) => n.children;
 const IS_DIR = (n: TreeNode) => n.isDir;
 
+function collectDirPaths(nodes: TreeNode[]): string[] {
+  const out: string[] = [];
+  const walk = (list: TreeNode[]) => {
+    for (const n of list) {
+      if (n.isDir) {
+        out.push(n.path);
+        if (n.children) walk(n.children);
+      }
+    }
+  };
+  walk(nodes);
+  return out;
+}
+
 type ChangesTreeProps = {
   files: ChangedFile[];
   pendingStageFiles: Set<string>;
@@ -96,7 +100,7 @@ export function ChangesTree({
   multiSelect,
 }: ChangesTreeProps) {
   const tree = useMemo(() => buildChangesTree(files), [files]);
-  const { visibleRows, toggle } = useTree<TreeNode>({
+  const { visibleRows, toggle, setExpanded } = useTree<TreeNode>({
     nodes: tree,
     getPath: GET_PATH,
     getChildren: GET_CHILDREN,
@@ -104,6 +108,23 @@ export function ChangesTree({
     defaultExpanded: "all",
     chainCollapse: true,
   });
+
+  // Auto-expand directories the user hasn't seen yet (e.g. new dirs that
+  // appear mid-task as the agent edits more files). Existing dirs keep
+  // whatever collapsed/expanded state the user set; only first-time dirs
+  // are forced open.
+  const seenDirPathsRef = useRef<Set<string>>(new Set(collectDirPaths(tree)));
+  useEffect(() => {
+    const current = collectDirPaths(tree);
+    const newDirs = current.filter((p) => !seenDirPathsRef.current.has(p));
+    if (newDirs.length === 0) return;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (const p of newDirs) next.add(p);
+      return next;
+    });
+    for (const p of newDirs) seenDirPathsRef.current.add(p);
+  }, [tree, setExpanded]);
 
   const activeFilePath = useDockviewStore((s) => s.activeFilePath);
 

--- a/apps/web/components/task/changes-panel-tree.tsx
+++ b/apps/web/components/task/changes-panel-tree.tsx
@@ -125,7 +125,7 @@ export function ChangesTree({
             onUnstage={onUnstage}
             onDiscard={onDiscard}
             onEditFile={onEditFile}
-            hideFolderPrefix
+            treeMode
             indentPx={row.depth * 12}
           />
         ),

--- a/apps/web/components/task/changes-panel-tree.tsx
+++ b/apps/web/components/task/changes-panel-tree.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useMemo } from "react";
+import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
+import { Button } from "@kandev/ui/button";
+import { cn } from "@/lib/utils";
+import { useTree, type VisibleRow } from "@/hooks/use-tree";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+import { useMultiSelect } from "@/hooks/use-multi-select";
+import { FileRow } from "./changes-panel-file-row";
+import type { FileInfo } from "@/lib/state/store";
+import type { OpenDiffOptions } from "./changes-diff-target";
+
+type ChangedFile = {
+  path: string;
+  status: FileInfo["status"];
+  staged: boolean;
+  plus: number | undefined;
+  minus: number | undefined;
+  oldPath: string | undefined;
+  repositoryName?: string;
+};
+
+type TreeNode = {
+  name: string;
+  path: string;
+  isDir: boolean;
+  children?: TreeNode[];
+  file?: ChangedFile;
+};
+
+/**
+ * Build a hierarchical tree from a flat list of changed files. Single-child
+ * directory chains stay separate nodes — useTree's `chainCollapse` merges them
+ * into one row at render time.
+ */
+function buildChangesTree(files: ChangedFile[]): TreeNode[] {
+  const root: TreeNode = { name: "", path: "", isDir: true, children: [] };
+  for (const file of files) {
+    const parts = file.path.split("/");
+    let current = root;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const isLast = i === parts.length - 1;
+      const partPath = parts.slice(0, i + 1).join("/");
+      if (isLast) {
+        current.children!.push({ name: part, path: file.path, isDir: false, file });
+      } else {
+        let child = current.children!.find((c) => c.isDir && c.name === part);
+        if (!child) {
+          child = { name: part, path: partPath, isDir: true, children: [] };
+          current.children!.push(child);
+        }
+        current = child;
+      }
+    }
+  }
+  return sortNodes(root.children ?? []);
+}
+
+function sortNodes(nodes: TreeNode[]): TreeNode[] {
+  return nodes
+    .sort((a, b) => {
+      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    })
+    .map((n) => (n.isDir && n.children ? { ...n, children: sortNodes(n.children) } : n));
+}
+
+const GET_PATH = (n: TreeNode) => n.path;
+const GET_CHILDREN = (n: TreeNode) => n.children;
+const IS_DIR = (n: TreeNode) => n.isDir;
+
+type ChangesTreeProps = {
+  files: ChangedFile[];
+  pendingStageFiles: Set<string>;
+  onOpenDiff: (path: string, options?: OpenDiffOptions) => void;
+  onEditFile: (path: string) => void;
+  onStage: (path: string, repo?: string) => void;
+  onUnstage: (path: string, repo?: string) => void;
+  onDiscard: (path: string, repo?: string) => void;
+  variant: "unstaged" | "staged";
+};
+
+export function ChangesTree({
+  files,
+  pendingStageFiles,
+  onOpenDiff,
+  onEditFile,
+  onStage,
+  onUnstage,
+  onDiscard,
+  variant,
+}: ChangesTreeProps) {
+  const tree = useMemo(() => buildChangesTree(files), [files]);
+  const { visibleRows, toggle } = useTree<TreeNode>({
+    nodes: tree,
+    getPath: GET_PATH,
+    getChildren: GET_CHILDREN,
+    isDir: IS_DIR,
+    defaultExpanded: "all",
+    chainCollapse: true,
+  });
+
+  const filePaths = useMemo(() => files.map((f) => f.path), [files]);
+  const multiSelect = useMultiSelect({ items: filePaths });
+  const activeFilePath = useDockviewStore((s) => s.activeFilePath);
+
+  return (
+    <ul data-testid={`${variant}-file-tree`} className="space-y-0.5">
+      {visibleRows.map((row) =>
+        row.isDir ? (
+          <TreeDirRow key={row.path} row={row} onToggle={() => toggle(row.path)} />
+        ) : (
+          <FileRow
+            key={`${row.node.file?.repositoryName ?? ""}:${row.path}`}
+            file={row.node.file!}
+            isPending={pendingStageFiles.has(`${row.node.file?.repositoryName ?? ""}::${row.path}`)}
+            isSelected={multiSelect.isSelected(row.path)}
+            isActive={row.path === activeFilePath}
+            onSelect={multiSelect.handleClick}
+            onOpenDiff={onOpenDiff}
+            onStage={onStage}
+            onUnstage={onUnstage}
+            onDiscard={onDiscard}
+            onEditFile={onEditFile}
+            hideFolderPrefix
+            indentPx={row.depth * 12}
+          />
+        ),
+      )}
+    </ul>
+  );
+}
+
+type RepoTreeGroupProps = {
+  variant: "unstaged" | "staged";
+  repositoryName: string;
+  displayName?: string;
+  files: ChangedFile[];
+  pendingStageFiles: Set<string>;
+  collapsed: boolean;
+  onToggle: () => void;
+  onOpenDiff: (path: string, options?: OpenDiffOptions) => void;
+  onEditFile: (path: string) => void;
+  onStage: (path: string, repo?: string) => void;
+  onUnstage: (path: string, repo?: string) => void;
+  onDiscard: (path: string, repo?: string) => void;
+  primaryLabel: string;
+  secondaryLabel?: string;
+  onRepoAction?: (repo: string) => void;
+  onRepoSecondaryAction?: (repo: string) => void;
+};
+
+export function RepoTreeGroup(props: RepoTreeGroupProps) {
+  const {
+    variant,
+    repositoryName,
+    displayName,
+    files,
+    pendingStageFiles,
+    collapsed,
+    onToggle,
+    primaryLabel,
+    secondaryLabel,
+    onRepoAction,
+    onRepoSecondaryAction,
+  } = props;
+  const label = displayName || repositoryName || "Repository";
+  const stop = (e: React.MouseEvent) => e.stopPropagation();
+  return (
+    <div data-testid="changes-repo-group" data-repository-name={repositoryName || ""}>
+      <div className="flex items-center justify-between gap-2 px-1 py-0.5">
+        <button
+          type="button"
+          className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground/80 uppercase tracking-wide cursor-pointer hover:text-foreground/80 min-w-0"
+          data-testid="changes-repo-header"
+          aria-expanded={!collapsed}
+          onClick={onToggle}
+        >
+          {collapsed ? (
+            <IconChevronRight className="h-3 w-3 text-muted-foreground/50 shrink-0" />
+          ) : (
+            <IconChevronDown className="h-3 w-3 text-muted-foreground/50 shrink-0" />
+          )}
+          <span className="truncate">{label}</span>
+          <span className="text-muted-foreground/50 normal-case tracking-normal">
+            {files.length}
+          </span>
+        </button>
+        {(onRepoAction || onRepoSecondaryAction) && (
+          <div className="flex items-center gap-1" onClick={stop}>
+            {onRepoAction && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-5 text-[10px] px-1.5 cursor-pointer"
+                data-testid="repo-group-action"
+                onClick={() => onRepoAction(repositoryName)}
+              >
+                {primaryLabel}
+              </Button>
+            )}
+            {onRepoSecondaryAction && secondaryLabel && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-5 text-[10px] px-1.5 cursor-pointer text-muted-foreground"
+                data-testid="repo-group-secondary-action"
+                onClick={() => onRepoSecondaryAction(repositoryName)}
+              >
+                {secondaryLabel}
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+      {!collapsed && (
+        <ChangesTree
+          files={files}
+          pendingStageFiles={pendingStageFiles}
+          onOpenDiff={props.onOpenDiff}
+          onEditFile={props.onEditFile}
+          onStage={props.onStage}
+          onUnstage={props.onUnstage}
+          onDiscard={props.onDiscard}
+          variant={variant}
+        />
+      )}
+    </div>
+  );
+}
+
+function TreeDirRow({ row, onToggle }: { row: VisibleRow<TreeNode>; onToggle: () => void }) {
+  return (
+    <li>
+      <button
+        type="button"
+        className={cn(
+          "flex items-center w-full gap-1 px-1 py-0.5 -mx-1 rounded-md hover:bg-muted/60 cursor-pointer text-xs text-foreground/70",
+        )}
+        style={{ paddingLeft: row.depth * 12 + 4 }}
+        onClick={onToggle}
+        data-testid={`tree-dir-${row.path.replace(/[/\\]/g, "-")}`}
+      >
+        {row.isExpanded ? (
+          <IconChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <IconChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="truncate">{row.displayName}</span>
+      </button>
+    </li>
+  );
+}

--- a/apps/web/hooks/use-user-display-settings.ts
+++ b/apps/web/hooks/use-user-display-settings.ts
@@ -51,6 +51,7 @@ function carryForwardSettings(current: DisplaySettings) {
     sidebarViews: current.sidebarViews ?? [],
     defaultUtilityAgentId: current.defaultUtilityAgentId ?? null,
     keyboardShortcuts: current.keyboardShortcuts ?? {},
+    changesPanelLayout: current.changesPanelLayout ?? "flat",
     ...carryForwardTerminalSettings(current),
   };
 }

--- a/apps/web/lib/api/domains/settings-api.ts
+++ b/apps/web/lib/api/domains/settings-api.ts
@@ -51,6 +51,7 @@ export async function updateUserSettings(
     terminal_link_behavior?: "new_tab" | "browser_panel";
     terminal_font_family?: string;
     terminal_font_size?: number;
+    changes_panel_layout?: "flat" | "tree";
   },
   options?: ApiRequestOptions,
 ) {

--- a/apps/web/lib/ssr/user-settings.test.ts
+++ b/apps/web/lib/ssr/user-settings.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildCoreFields, mapUserSettingsResponse } from "./user-settings";
+import {
+  buildCoreFields,
+  mapUserSettingsResponse,
+  parseChangesPanelLayout,
+} from "./user-settings";
 
 describe("buildCoreFields", () => {
   it("maps terminal_font_family to terminalFontFamily", () => {
@@ -83,5 +87,23 @@ describe("mapUserSettingsResponse", () => {
   it("returns null terminalFontFamily when response is null", () => {
     const result = mapUserSettingsResponse(null);
     expect(result.terminalFontFamily).toBeNull();
+  });
+
+  it("defaults changesPanelLayout to flat when response is null", () => {
+    const result = mapUserSettingsResponse(null);
+    expect(result.changesPanelLayout).toBe("flat");
+  });
+});
+
+describe("parseChangesPanelLayout", () => {
+  it('returns "tree" for "tree"', () => {
+    expect(parseChangesPanelLayout("tree")).toBe("tree");
+  });
+
+  it('returns "flat" for "flat", undefined, or unknown values', () => {
+    expect(parseChangesPanelLayout("flat")).toBe("flat");
+    expect(parseChangesPanelLayout(undefined)).toBe("flat");
+    expect(parseChangesPanelLayout("grid")).toBe("flat");
+    expect(parseChangesPanelLayout("")).toBe("flat");
   });
 });

--- a/apps/web/lib/ssr/user-settings.test.ts
+++ b/apps/web/lib/ssr/user-settings.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  buildCoreFields,
-  mapUserSettingsResponse,
-  parseChangesPanelLayout,
-} from "./user-settings";
+import { buildCoreFields, mapUserSettingsResponse, parseChangesPanelLayout } from "./user-settings";
 
 describe("buildCoreFields", () => {
   it("maps terminal_font_family to terminalFontFamily", () => {

--- a/apps/web/lib/ssr/user-settings.ts
+++ b/apps/web/lib/ssr/user-settings.ts
@@ -8,11 +8,16 @@ export function parseTerminalLinkBehavior(value: string | undefined): "new_tab" 
   return value === "browser_panel" ? "browser_panel" : "new_tab";
 }
 
+export function parseChangesPanelLayout(value: string | undefined): "flat" | "tree" {
+  return value === "tree" ? "tree" : "flat";
+}
+
 function buildTerminalFields(s: UserSettingsData) {
   return {
     terminalLinkBehavior: parseTerminalLinkBehavior(s.terminal_link_behavior),
     terminalFontFamily: s.terminal_font_family || null,
     terminalFontSize: s.terminal_font_size || null,
+    changesPanelLayout: parseChangesPanelLayout(s.changes_panel_layout),
   };
 }
 
@@ -85,6 +90,7 @@ export function mapUserSettingsResponse(response: UserSettingsResponse | null) {
       terminalLinkBehavior: "new_tab" as const,
       terminalFontFamily: null,
       terminalFontSize: null,
+      changesPanelLayout: "flat" as const,
       ...buildLspFields(undefined),
       loaded: false,
     };

--- a/apps/web/lib/state/slices/settings/settings-slice.ts
+++ b/apps/web/lib/state/slices/settings/settings-slice.ts
@@ -43,6 +43,7 @@ export const defaultSettingsState: SettingsSliceState = {
     keyboardShortcuts: {},
     terminalFontFamily: null,
     terminalFontSize: null,
+    changesPanelLayout: "flat",
     loaded: false,
   },
 };

--- a/apps/web/lib/state/slices/settings/types.ts
+++ b/apps/web/lib/state/slices/settings/types.ts
@@ -155,6 +155,7 @@ export type UserSettingsState = {
   terminalLinkBehavior: "new_tab" | "browser_panel";
   terminalFontFamily: string | null;
   terminalFontSize: number | null;
+  changesPanelLayout: "flat" | "tree";
   loaded: boolean;
 };
 

--- a/apps/web/lib/types/backend.ts
+++ b/apps/web/lib/types/backend.ts
@@ -381,6 +381,7 @@ export type UserSettingsUpdatedPayload = {
   default_utility_agent_id?: string;
   keyboard_shortcuts?: Record<string, { key: string; modifiers?: Record<string, boolean> }>;
   terminal_link_behavior?: string;
+  changes_panel_layout?: "flat" | "tree";
   updated_at?: string;
 };
 

--- a/apps/web/lib/types/http.ts
+++ b/apps/web/lib/types/http.ts
@@ -430,6 +430,7 @@ export type UserSettings = {
   terminal_link_behavior?: string;
   terminal_font_family?: string;
   terminal_font_size?: number;
+  changes_panel_layout?: "flat" | "tree";
   updated_at: string;
 };
 

--- a/apps/web/lib/ws/handlers/users.ts
+++ b/apps/web/lib/ws/handlers/users.ts
@@ -30,6 +30,7 @@ export function registerUsersHandlers(store: StoreApi<AppState>): WsHandlers {
             message.payload.terminal_link_behavior === "browser_panel"
               ? "browser_panel"
               : "new_tab",
+          changesPanelLayout: message.payload.changes_panel_layout === "tree" ? "tree" : "flat",
           loaded: true,
         },
       }));


### PR DESCRIPTION
The flat Changes panel buries shared path prefixes and forces users to read long paths to locate files; this adds an optional folder tree view so changes can be browsed by directory instead.

## Important Changes

- New user setting `changes_panel_layout` (`flat` | `tree`, default `flat`) wired end-to-end through `models.UserSettings` → DTO → service (with validation) → SQLite store → frontend store, SSR mapper, and `user.settings.updated` WS handler.
- Tree rendering reuses the existing `useTree` hook with `chainCollapse: true` so single-child directory chains render as one row.

## Validation

- `go test ./internal/user/...` (user package green; other backend failures pre-existed and are git-signing related to the sandbox)
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` (253 files / 2090 tests pass)
- Added `changes-panel-tree.test.tsx` covering folder/file rendering, single-child chain collapsing, and collapse/expand behaviour.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrKKD5kYkNCNdSxsqHMJ2w)_