### PR TITLE
feat(task): auto-fill task name from PR title when pasting a PR URL

### DIFF
--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -189,6 +189,8 @@ describe("useBranchAutoSelectEffect", () => {
   });
 });
 
+const PR_1_TITLE = "PR #1: first";
+
 type AutoFillFake = Pick<DialogFormState, "taskName" | "setTaskName" | "setHasTitle">;
 function makeAutoFillFs(overrides: Partial<AutoFillFake> = {}): DialogFormState {
   return {
@@ -244,7 +246,7 @@ describe("useAutoFillTaskNameFromPR", () => {
       return useAutoFillTaskNameFromPR(fs);
     });
     result.current(1, "first");
-    expect(currentName).toBe("PR #1: first");
+    expect(currentName).toBe(PR_1_TITLE);
 
     rerender();
     result.current(2, "second");
@@ -265,7 +267,7 @@ describe("useAutoFillTaskNameFromPR", () => {
       return useAutoFillTaskNameFromPR(fs);
     });
     result.current(1, "first");
-    expect(currentName).toBe("PR #1: first");
+    expect(currentName).toBe(PR_1_TITLE);
 
     // User edits the title manually.
     currentName = "my edits";
@@ -276,5 +278,42 @@ describe("useAutoFillTaskNameFromPR", () => {
     // edit is preserved.
     expect(fs.setTaskName).toHaveBeenCalledTimes(1);
     expect(currentName).toBe("my edits");
+  });
+
+  it("clears the sentinel when taskName resets to empty, preventing a re-typed auto-fill from being overwritten", () => {
+    // Regression guard for the mounted-across-open/close edge case:
+    // after a dialog reset clears taskName, the user manually types the same
+    // text that was previously auto-filled. A second PR paste must NOT
+    // overwrite it because the sentinel was cleared on the empty transition.
+    let currentName = "";
+    const fs = makeAutoFillFs({
+      taskName: currentName,
+      setTaskName: vi.fn((v: string) => {
+        currentName = v;
+      }),
+    });
+    const { result, rerender } = renderHook(() => {
+      fs.taskName = currentName;
+      return useAutoFillTaskNameFromPR(fs);
+    });
+    result.current(1, "first");
+    expect(currentName).toBe(PR_1_TITLE);
+
+    // Simulate React flushing the setTaskName state update back into the hook
+    // so the ref-mirror effect sees taskName = PR_1_TITLE.
+    rerender();
+
+    // Dialog resets taskName to empty (sentinel should clear).
+    currentName = "";
+    rerender();
+
+    // User re-types the exact previously auto-filled value.
+    currentName = PR_1_TITLE;
+    rerender();
+
+    // A second paste with a different PR should NOT overwrite.
+    result.current(2, "second");
+    expect(fs.setTaskName).toHaveBeenCalledTimes(1); // only the first auto-fill
+    expect(currentName).toBe(PR_1_TITLE);
   });
 });

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import {
+  useAutoFillTaskNameFromPR,
   useBranchAutoSelectEffect,
   useWorkflowAgentProfileEffect,
 } from "./task-create-dialog-effects";
@@ -185,5 +186,95 @@ describe("useBranchAutoSelectEffect", () => {
     });
     renderHook(() => useBranchAutoSelectEffect(fs));
     expect(fs.setGitHubBranch).not.toHaveBeenCalled();
+  });
+});
+
+type AutoFillFake = Pick<DialogFormState, "taskName" | "setTaskName" | "setHasTitle">;
+function makeAutoFillFs(overrides: Partial<AutoFillFake> = {}): DialogFormState {
+  return {
+    taskName: "",
+    setTaskName: vi.fn(),
+    setHasTitle: vi.fn(),
+    ...overrides,
+  } as unknown as DialogFormState;
+}
+
+describe("useAutoFillTaskNameFromPR", () => {
+  it("fills the task name with 'PR #N: <title>' when the title is empty", () => {
+    const fs = makeAutoFillFs({ taskName: "" });
+    const { result } = renderHook(() => useAutoFillTaskNameFromPR(fs));
+    result.current(971, "feat/omp-acp-agent");
+    expect(fs.setTaskName).toHaveBeenCalledWith("PR #971: feat/omp-acp-agent");
+    expect(fs.setHasTitle).toHaveBeenCalledWith(true);
+  });
+
+  it("fills when the title contains only whitespace", () => {
+    // Regression guard: hasTitle treats whitespace-only as empty, so the
+    // auto-fill check must too — otherwise pasting a PR URL after typing a
+    // stray space would silently keep the spaces.
+    const fs = makeAutoFillFs({ taskName: "   " });
+    const { result } = renderHook(() => useAutoFillTaskNameFromPR(fs));
+    result.current(7, "fix");
+    expect(fs.setTaskName).toHaveBeenCalledWith("PR #7: fix");
+  });
+
+  it("does NOT overwrite a title the user typed themselves", () => {
+    const fs = makeAutoFillFs({ taskName: "my custom title" });
+    const { result } = renderHook(() => useAutoFillTaskNameFromPR(fs));
+    result.current(42, "something");
+    expect(fs.setTaskName).not.toHaveBeenCalled();
+    expect(fs.setHasTitle).not.toHaveBeenCalled();
+  });
+
+  it("replaces a previously auto-filled title when a different PR URL is pasted", () => {
+    // Re-paste flow: the user pastes PR #1 (autofills "PR #1: foo"), then
+    // realizes wrong URL and pastes PR #2. Without the lastAutoFilled-ref
+    // tracking, the second paste would see a non-empty title and bail.
+    let currentName = "";
+    const fs = makeAutoFillFs({
+      taskName: currentName,
+      setTaskName: vi.fn((v: string) => {
+        currentName = v;
+      }),
+    });
+    const { result, rerender } = renderHook(() => {
+      // Re-read taskName from the closure on every render so the ref-mirror
+      // effect sees the latest value.
+      fs.taskName = currentName;
+      return useAutoFillTaskNameFromPR(fs);
+    });
+    result.current(1, "first");
+    expect(currentName).toBe("PR #1: first");
+
+    rerender();
+    result.current(2, "second");
+    expect(currentName).toBe("PR #2: second");
+    expect(fs.setTaskName).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT replace once the user edits the auto-filled title", () => {
+    let currentName = "";
+    const fs = makeAutoFillFs({
+      taskName: currentName,
+      setTaskName: vi.fn((v: string) => {
+        currentName = v;
+      }),
+    });
+    const { result, rerender } = renderHook(() => {
+      fs.taskName = currentName;
+      return useAutoFillTaskNameFromPR(fs);
+    });
+    result.current(1, "first");
+    expect(currentName).toBe("PR #1: first");
+
+    // User edits the title manually.
+    currentName = "my edits";
+    rerender();
+
+    result.current(2, "second");
+    // Setter is still only called once (the initial auto-fill); the manual
+    // edit is preserved.
+    expect(fs.setTaskName).toHaveBeenCalledTimes(1);
+    expect(currentName).toBe("my edits");
   });
 });

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -411,9 +411,14 @@ function parseGitHubUrl(url: string): { owner: string; repo: string; prNumber?: 
 /**
  * Returns a callback that auto-fills the task name with `PR #N: <title>` when
  * a PR URL is pasted, leaving anything the user typed themselves alone. The
- * callback is stable across renders and reads the latest taskName via a ref,
- * so the fetch effect doesn't need to list taskName as a dep (which would
- * re-fire the branches/PR fetch on every keystroke in the title input).
+ * callback reads the latest taskName via a ref so the fetch effect doesn't
+ * need to list taskName as a dep (which would re-fire the branches/PR fetch on
+ * every keystroke in the title input).
+ *
+ * NOTE: Callers must omit the returned callback from `useEffect` dependency
+ * arrays — including it causes the fetch to re-fire on every keystroke,
+ * defeating the purpose of the ref. The call site uses
+ * `eslint-disable react-hooks/exhaustive-deps` intentionally.
  */
 export function useAutoFillTaskNameFromPR(fs: DialogFormState) {
   const { taskName, setTaskName, setHasTitle } = fs;
@@ -421,6 +426,9 @@ export function useAutoFillTaskNameFromPR(fs: DialogFormState) {
   const taskNameRef = useRef(taskName);
   useEffect(() => {
     taskNameRef.current = taskName;
+    if (!taskName.trim()) {
+      lastAutoFilledTitleRef.current = "";
+    }
   }, [taskName]);
   return (prNumber: number, prTitle: string) => {
     const next = `PR #${prNumber}: ${prTitle}`;

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -408,6 +408,31 @@ function parseGitHubUrl(url: string): { owner: string; repo: string; prNumber?: 
   return { owner: match[1], repo: match[2] };
 }
 
+/**
+ * Returns a callback that auto-fills the task name with `PR #N: <title>` when
+ * a PR URL is pasted, leaving anything the user typed themselves alone. The
+ * callback is stable across renders and reads the latest taskName via a ref,
+ * so the fetch effect doesn't need to list taskName as a dep (which would
+ * re-fire the branches/PR fetch on every keystroke in the title input).
+ */
+export function useAutoFillTaskNameFromPR(fs: DialogFormState) {
+  const { taskName, setTaskName, setHasTitle } = fs;
+  const lastAutoFilledTitleRef = useRef("");
+  const taskNameRef = useRef(taskName);
+  useEffect(() => {
+    taskNameRef.current = taskName;
+  }, [taskName]);
+  return (prNumber: number, prTitle: string) => {
+    const next = `PR #${prNumber}: ${prTitle}`;
+    const current = taskNameRef.current;
+    if (!current.trim() || current === lastAutoFilledTitleRef.current) {
+      lastAutoFilledTitleRef.current = next;
+      setTaskName(next);
+      setHasTitle(true);
+    }
+  };
+}
+
 export function useGitHubUrlBranchesEffect(fs: DialogFormState, open: boolean) {
   const {
     useGitHubUrl,
@@ -418,6 +443,7 @@ export function useGitHubUrlBranchesEffect(fs: DialogFormState, open: boolean) {
     setGitHubPrHeadBranch,
     setGitHubPrBaseBranch,
   } = fs;
+  const autoFillTitle = useAutoFillTaskNameFromPR(fs);
   useEffect(() => {
     if (!open || !useGitHubUrl) {
       setGitHubBranchesLoading(false);
@@ -464,6 +490,7 @@ export function useGitHubUrlBranchesEffect(fs: DialogFormState, open: boolean) {
         if (prInfo) {
           setGitHubPrHeadBranch(prInfo.head_branch);
           setGitHubPrBaseBranch(prInfo.base_branch);
+          autoFillTitle(prInfo.number, prInfo.title);
         }
       })
       .catch((err) => {
@@ -488,6 +515,10 @@ export function useGitHubUrlBranchesEffect(fs: DialogFormState, open: boolean) {
       clearTimeout(timeoutId);
       controller.abort();
     };
+    // autoFillTitle is intentionally omitted: it's a fresh closure each render
+    // but reads the latest taskName via ref, so excluding it keeps the fetch
+    // from re-firing on every keystroke.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     open,
     useGitHubUrl,


### PR DESCRIPTION
When a GitHub PR URL is pasted into the task creation dialog, the task name field
is now auto-filled with `PR #N: <title>`, matching the format the PR watcher uses
when it creates tasks automatically.

**Important Changes**
- `useAutoFillTaskNameFromPR` hook reads the latest task name via ref to avoid
  re-triggering the branch/PR fetch on every keystroke
- Auto-fill only fires when the name is empty or still holds the previously
  auto-filled value, so user edits are always preserved
- Repo-only URLs (no `/pull/N`) are unaffected

**Validation**
- `pnpm --filter @kandev/web typecheck` — passed
- `pnpm --filter @kandev/web lint` — passed
- `pnpm --filter @kandev/web test -- task-create-dialog-effects` — 16 tests passed (5 new)

**Checklist**
- [ ] Tests added/updated
- [ ] No breaking changes

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1027-bwo7.sprites.app |
| **Commit** | `498f157` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->