### PR TITLE
fix(web): preserve session-tab grouping when restoring contaminated layout

### DIFF
--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DockviewApi } from "dockview-react";
-import { reconcileRemovedSessionPanels } from "./dockview-session-tabs";
+import {
+  findSessionAnchorGroupId,
+  reconcileRemovedSessionPanels,
+} from "./dockview-session-tabs";
 
 type FakePanel = {
   id: string;
@@ -148,5 +151,31 @@ describe("reconcileRemovedSessionPanels", () => {
 
     expect(createdSet.has("already-removed")).toBe(false);
     expect(createdSet.has(KEEP)).toBe(true);
+  });
+});
+
+describe("findSessionAnchorGroupId", () => {
+  function makeApiWithPanel(panelId: string, groupId: string): DockviewApi {
+    return {
+      getPanel: (id: string) => (id === panelId ? { id, group: { id: groupId } } : null),
+    } as unknown as DockviewApi;
+  }
+
+  it("returns the group id of a pr-detail anchor panel", () => {
+    // Regression: when a saved layout's session was sanitized away (page load)
+    // or replaced (env switch) but pr-detail remained, the new session would
+    // be added as a right-of-sidebar split instead of joining pr-detail's
+    // group — pulling pr-detail out of the user's grouping with the agent.
+    const api = makeApiWithPanel("pr-detail", "saved-center-group");
+
+    expect(findSessionAnchorGroupId(api)).toBe("saved-center-group");
+  });
+
+  it("returns null when no anchor panel exists", () => {
+    const api = {
+      getPanel: () => null,
+    } as unknown as DockviewApi;
+
+    expect(findSessionAnchorGroupId(api)).toBeNull();
   });
 });

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DockviewApi } from "dockview-react";
-import {
-  findSessionAnchorGroupId,
-  reconcileRemovedSessionPanels,
-} from "./dockview-session-tabs";
+import { findSessionAnchorGroupId, reconcileRemovedSessionPanels } from "./dockview-session-tabs";
 
 type FakePanel = {
   id: string;
@@ -155,9 +152,11 @@ describe("reconcileRemovedSessionPanels", () => {
 });
 
 describe("findSessionAnchorGroupId", () => {
-  function makeApiWithPanel(panelId: string, groupId: string): DockviewApi {
+  function makeApiWithPanels(panels: Array<{ id: string; groupId: string }>): DockviewApi {
+    const enriched = panels.map((p) => ({ id: p.id, group: { id: p.groupId } }));
     return {
-      getPanel: (id: string) => (id === panelId ? { id, group: { id: groupId } } : null),
+      panels: enriched,
+      getPanel: (id: string) => enriched.find((p) => p.id === id) ?? null,
     } as unknown as DockviewApi;
   }
 
@@ -166,15 +165,23 @@ describe("findSessionAnchorGroupId", () => {
     // or replaced (env switch) but pr-detail remained, the new session would
     // be added as a right-of-sidebar split instead of joining pr-detail's
     // group — pulling pr-detail out of the user's grouping with the agent.
-    const api = makeApiWithPanel("pr-detail", "saved-center-group");
+    const api = makeApiWithPanels([{ id: "pr-detail", groupId: "saved-center-group" }]);
 
     expect(findSessionAnchorGroupId(api)).toBe("saved-center-group");
   });
 
+  it("matches keyed pr-detail panels used by multi-repo PR flows", () => {
+    // Multi-repo tasks open one PR tab per PR with id `pr-detail|owner/repo/N`
+    // (see addPRPanel in dockview-panel-actions.ts). Without prefix matching,
+    // findSessionAnchorGroupId would miss them and the new session would land
+    // as a right-of-sidebar split — losing the user's PR/session grouping.
+    const api = makeApiWithPanels([{ id: "pr-detail|owner/repo/123", groupId: "keyed-pr-group" }]);
+
+    expect(findSessionAnchorGroupId(api)).toBe("keyed-pr-group");
+  });
+
   it("returns null when no anchor panel exists", () => {
-    const api = {
-      getPanel: () => null,
-    } as unknown as DockviewApi;
+    const api = makeApiWithPanels([]);
 
     expect(findSessionAnchorGroupId(api)).toBeNull();
   });

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -250,6 +250,12 @@ function resolveInitialPosition(api: DockviewApi): AddPanelOptions["position"] {
   const centerGroupExists = centerGroupId && api.groups.some((g) => g.id === centerGroupId);
   if (centerGroupExists) return { referenceGroup: centerGroupId };
   const anchorGroupId = findSessionAnchorGroupId(api);
+  // index:0 matches the project's session-on-the-left convention (agent tab
+  // first, pr-detail/etc. to the right). Worth noting: if a user had
+  // rearranged a previous layout to put pr-detail first, that ordering is
+  // lost here — but the alternative (appending) would put the agent tab
+  // to the right of pr-detail, which contradicts the default placement
+  // every other code path produces. Pick the consistent default.
   if (anchorGroupId) return { referenceGroup: anchorGroupId, index: 0 };
   const sb = api.getPanel("sidebar");
   if (sb) return { direction: "right" as const, referencePanel: "sidebar" };

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -227,10 +227,30 @@ export function useAutoPRPanel() {
   }, [taskId, hasPR, hasApi, sessionId]);
 }
 
+/**
+ * Panels that are added co-tabbed with a session panel (see `useAutoPRPanel`).
+ * When a saved layout's session was stripped (phantom-session sanitize on
+ * page load, or stale removal during env switch), these siblings end up alone
+ * in a group with no session. Prefer joining that group when adding the new
+ * active session — without this fallback we'd add the session as a fresh
+ * split next to the sidebar, breaking the user's grouping.
+ */
+const SESSION_ANCHOR_PANEL_IDS = ["pr-detail"];
+
+export function findSessionAnchorGroupId(api: DockviewApi): string | null {
+  for (const id of SESSION_ANCHOR_PANEL_IDS) {
+    const panel = api.getPanel(id);
+    if (panel) return panel.group.id;
+  }
+  return null;
+}
+
 function resolveInitialPosition(api: DockviewApi): AddPanelOptions["position"] {
   const { centerGroupId } = useDockviewStore.getState();
   const centerGroupExists = centerGroupId && api.groups.some((g) => g.id === centerGroupId);
   if (centerGroupExists) return { referenceGroup: centerGroupId };
+  const anchorGroupId = findSessionAnchorGroupId(api);
+  if (anchorGroupId) return { referenceGroup: anchorGroupId, index: 0 };
   const sb = api.getPanel("sidebar");
   if (sb) return { direction: "right" as const, referencePanel: "sidebar" };
   return undefined;

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -234,13 +234,20 @@ export function useAutoPRPanel() {
  * in a group with no session. Prefer joining that group when adding the new
  * active session — without this fallback we'd add the session as a fresh
  * split next to the sidebar, breaking the user's grouping.
+ *
+ * Each entry matches either the bare id (e.g. `pr-detail`) or a keyed
+ * variant `<id>|<key>` (multi-repo PR panels use `pr-detail|owner/repo/N`,
+ * see `addPRPanel` in dockview-panel-actions.ts).
  */
 const SESSION_ANCHOR_PANEL_IDS = ["pr-detail"];
 
 export function findSessionAnchorGroupId(api: DockviewApi): string | null {
   for (const id of SESSION_ANCHOR_PANEL_IDS) {
-    const panel = api.getPanel(id);
-    if (panel) return panel.group.id;
+    const exact = api.getPanel(id);
+    if (exact) return exact.group.id;
+    const keyedPrefix = `${id}|`;
+    const keyed = api.panels.find((p) => p.id.startsWith(keyedPrefix));
+    if (keyed) return keyed.group.id;
   }
   return null;
 }

--- a/apps/web/lib/state/dockview-env-switch.test.ts
+++ b/apps/web/lib/state/dockview-env-switch.test.ts
@@ -274,10 +274,7 @@ describe("performEnvSwitch slow-path stale session strip", () => {
     };
     const api = {
       ...makeMockApi(),
-      panels: [
-        stale,
-        { id: "pr-detail", api: { component: "pr-detail" }, group: { id: groupId } },
-      ],
+      panels: [stale, { id: "pr-detail", api: { component: "pr-detail" }, group: { id: groupId } }],
       groups: [{ id: groupId }],
       // The active session panel does NOT exist yet — that's the whole point;
       // the fromJSON restore only brought back the phantom.
@@ -305,9 +302,7 @@ describe("performEnvSwitch slow-path stale session strip", () => {
 
     const closeStale = vi.fn();
     const groupId = "g1";
-    const groupPanels = [
-      { id: "session:phantom", api: { component: "chat", close: closeStale } },
-    ];
+    const groupPanels = [{ id: "session:phantom", api: { component: "chat", close: closeStale } }];
     const stale = { ...groupPanels[0], group: { id: groupId, panels: groupPanels } };
     const api = {
       ...makeMockApi(),

--- a/apps/web/lib/state/dockview-env-switch.test.ts
+++ b/apps/web/lib/state/dockview-env-switch.test.ts
@@ -212,7 +212,7 @@ describe("performEnvSwitch slow-path stale session strip", () => {
   it("closes stale session chat panels after the slow-path fromJSON", () => {
     // Regression: a saved env layout could carry a `session:*` panel from a
     // previously-deleted task (phantom). On the slow-path restore, that
-    // panel would land in the live api as a stray tab. removeStaleSessionPanels
+    // panel would land in the live api as a stray tab. replaceStaleSessionPanels
     // must close any session:* panel whose id != the incoming active session.
     vi.mocked(getEnvLayout)
       .mockReturnValueOnce(makeHealthyLayoutWith({}))
@@ -226,13 +226,16 @@ describe("performEnvSwitch slow-path stale session strip", () => {
     const api = {
       ...makeMockApi(),
       // api.fromJSON is a no-op mock; populate `panels` with what would exist
-      // post-restore so removeStaleSessionPanels' filter has something to act on.
+      // post-restore so replaceStaleSessionPanels' filter has something to act on.
       panels: [
         { id: "session:old-session", api: { component: "chat", close: closeStale } },
         { id: NEW_SESSION_PANEL_ID, api: { component: "chat", close: closeKeep } },
         // file editors are NOT session panels — they must NOT be closed.
         { id: "preview:file-editor", api: { component: "file-editor", close: closeFileEditor } },
       ],
+      getPanel: vi.fn((id: string) =>
+        id === NEW_SESSION_PANEL_ID ? { id: NEW_SESSION_PANEL_ID } : null,
+      ),
     } as unknown as EnvSwitchParams["api"];
     const params = makeParams({ api });
 
@@ -242,6 +245,80 @@ describe("performEnvSwitch slow-path stale session strip", () => {
     expect(closeKeep).not.toHaveBeenCalled();
     expect(closeFileEditor).not.toHaveBeenCalled();
     expect(params.api.fromJSON).toHaveBeenCalledOnce();
+    // Keep panel already existed, so no addPanel.
+    expect(params.api.addPanel).not.toHaveBeenCalled();
+  });
+
+  it("anchors the new session to the stale session's group and tab index", () => {
+    // Regression: when the saved layout had a phantom session co-tabbed with
+    // pr-detail (or other siblings the user dragged into the chat group),
+    // simply closing the phantom orphaned the siblings. The new active session
+    // would then land as a fresh split next to the sidebar — pulling pr-detail
+    // out of the user's grouping. The replacement must land in the phantom's
+    // exact (group, index) so siblings stay tabbed with the agent.
+    vi.mocked(getEnvLayout)
+      .mockReturnValueOnce(makeHealthyLayoutWith({}))
+      .mockReturnValueOnce(makeHealthyLayoutWith({}));
+    vi.mocked(savedLayoutMatchesLive).mockReturnValueOnce(false);
+
+    const closeStale = vi.fn();
+    const stalePanelId = "session:phantom-from-other-env";
+    const groupId = "saved-center-group";
+    const groupPanels = [
+      { id: stalePanelId, api: { component: "chat", close: closeStale } },
+      { id: "pr-detail", api: { component: "pr-detail", close: vi.fn() } },
+    ];
+    const stale = {
+      ...groupPanels[0],
+      group: { id: groupId, panels: groupPanels },
+    };
+    const api = {
+      ...makeMockApi(),
+      panels: [
+        stale,
+        { id: "pr-detail", api: { component: "pr-detail" }, group: { id: groupId } },
+      ],
+      groups: [{ id: groupId }],
+      // The active session panel does NOT exist yet — that's the whole point;
+      // the fromJSON restore only brought back the phantom.
+      getPanel: vi.fn(() => null),
+    } as unknown as EnvSwitchParams["api"];
+    const params = makeParams({ api });
+
+    performEnvSwitch(params);
+
+    expect(api.addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: NEW_SESSION_PANEL_ID,
+        component: "chat",
+        position: { referenceGroup: groupId, index: 0 },
+      }),
+    );
+    expect(closeStale).toHaveBeenCalledOnce();
+  });
+
+  it("skips addPanel when there is no active session (sessionless task)", () => {
+    vi.mocked(getEnvLayout)
+      .mockReturnValueOnce(makeHealthyLayoutWith({}))
+      .mockReturnValueOnce(makeHealthyLayoutWith({}));
+    vi.mocked(savedLayoutMatchesLive).mockReturnValueOnce(false);
+
+    const closeStale = vi.fn();
+    const groupId = "g1";
+    const groupPanels = [
+      { id: "session:phantom", api: { component: "chat", close: closeStale } },
+    ];
+    const stale = { ...groupPanels[0], group: { id: groupId, panels: groupPanels } };
+    const api = {
+      ...makeMockApi(),
+      panels: [stale],
+      groups: [{ id: groupId }],
+    } as unknown as EnvSwitchParams["api"];
+
+    performEnvSwitch(makeParams({ api, activeSessionId: null }));
+
+    expect(closeStale).toHaveBeenCalledOnce();
+    expect(api.addPanel).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -172,28 +172,54 @@ function removeEphemeralPanels(api: DockviewApi, keepSessionId: string | null): 
 }
 
 /**
- * Close stale session chat panels — any `session:*` panel whose id isn't
- * `session:${keepSessionId}`. Used after `fromJSON` in the slow path to
- * strip phantom sessions carried in from a saved layout, WITHOUT touching
- * file-editors/diffs/browser/etc. that legitimately belong to this env.
+ * Replace stale session chat panels with the incoming active session.
+ *
+ * A "stale" session is any `session:*` panel whose id isn't
+ * `session:${keepSessionId}` — typically a phantom carried in from a saved
+ * layout whose session belongs to a different env (or has been deleted).
+ *
+ * Before closing the first stale panel, add the active session at the same
+ * (group, tab-index). This preserves the user's grouping when the stale was
+ * co-tabbed with non-session siblings (pr-detail, dragged file-editors,
+ * etc.) — without it, the siblings would be orphaned in a group with no
+ * session, and `useAutoSessionTab` would later add the active session as a
+ * fresh split next to the sidebar.
+ *
+ * File-editors/diffs/browser/etc. are NEVER touched here — they
+ * legitimately belong to this env's saved state.
  */
-function removeStaleSessionPanels(api: DockviewApi, keepSessionId: string | null): void {
+function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: string | null): void {
   const keepId = keepSessionId ? `session:${keepSessionId}` : null;
   // keepId=null (sessionless task) → strips all session panels, unlike the
   // fast path's shouldRemoveDuringSwitch which keeps them. In practice
   // sessionless tasks should have no session panels; useAutoSessionTab
   // re-adds the panel when a session arrives.
-  const toRemove = api.panels.filter(
+  const stale = api.panels.filter(
     (p) => p.api.component === "chat" && p.id.startsWith("session:") && p.id !== keepId,
   );
+
+  // Anchor the active session to the first stale's (group, index) so co-tabbed
+  // siblings (pr-detail etc.) stay grouped with the agent tab. Skipped when:
+  //   - no keepSessionId (sessionless task)
+  //   - the active session panel already exists in the layout
+  //   - the stale's group is missing from the live api (defensive)
+  if (keepSessionId && keepId && !api.getPanel(keepId) && stale.length > 0) {
+    const first = stale[0];
+    const groupId = first.group.id;
+    if (api.groups.some((g) => g.id === groupId)) {
+      const idx = first.group.panels.findIndex((p) => p.id === first.id);
+      addIncomingSessionPanel(api, keepSessionId, groupId, idx);
+    }
+  }
+
   if (IS_DEBUG) {
-    debug("removeStaleSessionPanels", {
+    debug("replaceStaleSessionPanels", {
       keepSessionId,
       livePanelIds: api.panels.map((p) => p.id),
-      removingIds: toRemove.map((p) => p.id),
+      removingIds: stale.map((p) => p.id),
     });
   }
-  for (const p of toRemove) {
+  for (const p of stale) {
     try {
       p.api.close();
     } catch {
@@ -371,11 +397,13 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
       }
       api.fromJSON(saved as SerializedDockview);
       // Saved layout may carry a stale session panel from a previously-deleted
-      // task (phantom). Strip session panels that don't belong to the incoming
-      // active session — file editors/diffs/etc. were legitimately part of
-      // this env's saved state and must NOT be touched.
-      // useAutoSessionTab will add the current session's panel if missing.
-      removeStaleSessionPanels(api, activeSessionId);
+      // task (phantom). Replace stale session panels with the incoming active
+      // session in the same (group, tab-index), then close the stale ones —
+      // preserves grouping with co-tabbed siblings (pr-detail, dragged file
+      // editors, etc.). File editors/diffs/etc. on their own are legitimately
+      // part of this env's saved state and must NOT be touched.
+      // useAutoSessionTab will still no-op if the panel was just added here.
+      replaceStaleSessionPanels(api, activeSessionId);
       api.layout(safeWidth, safeHeight);
       if (IS_DEBUG) {
         debug("performEnvSwitch: completed via slow path (fromJSON)", {

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -209,7 +209,7 @@ function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: string | nul
   // only the first stale's group keeps its siblings. Sessions in other
   // groups still close, orphaning anything co-tabbed with them. One active
   // session can only re-anchor one group.
-  if (keepSessionId && keepId && !api.getPanel(keepId) && stale.length > 0) {
+  if (keepSessionId && !api.getPanel(`session:${keepSessionId}`) && stale.length > 0) {
     const first = stale[0];
     const groupId = first.group.id;
     if (api.groups.some((g) => g.id === groupId)) {

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -203,6 +203,12 @@ function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: string | nul
   //   - no keepSessionId (sessionless task)
   //   - the active session panel already exists in the layout
   //   - the stale's group is missing from the live api (defensive)
+  //
+  // Limitation: if the saved layout had stale sessions in multiple groups
+  // (rare — requires multi-session contamination across env boundaries),
+  // only the first stale's group keeps its siblings. Sessions in other
+  // groups still close, orphaning anything co-tabbed with them. One active
+  // session can only re-anchor one group.
   if (keepSessionId && keepId && !api.getPanel(keepId) && stale.length > 0) {
     const first = stale[0];
     const groupId = first.group.id;


### PR DESCRIPTION
Switching tasks could leave the PR detail panel orphaned in its own split because the env-switch slow path stripped phantom session panels (carried in from a cross-env layout save) without re-anchoring the new active session to their group — the agent tab then landed at right-of-sidebar, pulling co-tabbed siblings out of the user's grouping.

## Important Changes

- `replaceStaleSessionPanels` (env-switch slow path): add the active session at the first stale's `(group, tab-index)` before closing it — preserves group membership AND tab order.
- `resolveInitialPosition` (used by `useAutoSessionTab`): when `centerGroupId` is stale, fall back to a group containing a `pr-detail` anchor before right-of-sidebar — covers the page-load `sanitizeLayout` path and `reconcileRemovedSessionPanels` where `(group, index)` precision is already lost.

## Validation

- `pnpm --filter @kandev/web test` (260 files, 2145 tests pass; 5 new tests for the new behaviour)
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Possible Improvements

Low risk: restore-side defensive fix. The root cause is `saveOutgoingEnv` persisting a session panel under the wrong env key when the session was added before the env switch fired — a save-side filter would prevent contamination at the source.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Egaawi2yd9FDBxBagAweHK)_