### PR TITLE
feat(editors): truncate file path in editor toolbar with hover-scroll

### DIFF
--- a/apps/web/components/editors/codemirror/codemirror-code-editor.tsx
+++ b/apps/web/components/editors/codemirror/codemirror-code-editor.tsx
@@ -3,6 +3,7 @@
 import { useRef } from "react";
 import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { Button } from "@kandev/ui/button";
+import { ScrollOnOverflow } from "@kandev/ui/scroll-on-overflow";
 import {
   IconDeviceFloppy,
   IconLoader2,
@@ -228,10 +229,12 @@ function CodeMirrorToolbar({
   return (
     <PanelHeaderBarSplit
       left={
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <span className="font-mono">{toRelativePath(path, worktreePath)}</span>
+        <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          <ScrollOnOverflow className="min-w-0 font-mono">
+            {toRelativePath(path, worktreePath)}
+          </ScrollOnOverflow>
           {isDirty && diffStats && (
-            <span className="text-xs text-yellow-500">
+            <span className="shrink-0 text-xs text-yellow-500">
               {formatDiffStats(diffStats.additions, diffStats.deletions)}
             </span>
           )}

--- a/apps/web/components/editors/monaco/monaco-editor-toolbar.tsx
+++ b/apps/web/components/editors/monaco/monaco-editor-toolbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@kandev/ui/button";
+import { ScrollOnOverflow } from "@kandev/ui/scroll-on-overflow";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import {
   IconDeviceFloppy,
@@ -68,10 +69,12 @@ function ToolbarLeft({
   diffStats: { additions: number; deletions: number } | null;
 }) {
   return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <span className="font-mono">{toRelativePath(path, worktreePath)}</span>
+    <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+      <ScrollOnOverflow className="min-w-0 font-mono">
+        {toRelativePath(path, worktreePath)}
+      </ScrollOnOverflow>
       {isDirty && diffStats && (
-        <span className="text-xs text-yellow-500">
+        <span className="shrink-0 text-xs text-yellow-500">
           {formatDiffStats(diffStats.additions, diffStats.deletions)}
         </span>
       )}


### PR DESCRIPTION
Long file paths in the Monaco and CodeMirror editor toolbars pushed the action buttons off-screen; the path now truncates inside the available space and scrolls horizontally on hover via the shared `ScrollOnOverflow` component so the full path stays reachable without breaking the toolbar layout.

## Validation

- `pnpm --filter @kandev/web exec tsc --noEmit`
- `pnpm --filter @kandev/web exec eslint components/editors/monaco/monaco-editor-toolbar.tsx components/editors/codemirror/codemirror-code-editor.tsx`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFao3tPvFHtjs7diwXRq9C)_