### PR TITLE
fix(mobile): passthrough TUI rendering + touch-scroll (closes #1031)

### DIFF
--- a/apps/web/components/task/passthrough-terminal.tsx
+++ b/apps/web/components/task/passthrough-terminal.tsx
@@ -249,6 +249,7 @@ export function PassthroughTerminal(props: PassthroughTerminalProps) {
   });
 
   usePendingCommand(pendingCommand, isConnected, wsRef, onCommandSent);
+  useMobileTouchScroll(refs.terminalRef, refs.xtermRef, isTerminalReady);
 
   return (
     <div
@@ -298,4 +299,90 @@ function usePendingCommand(
     }, 300);
     return () => clearTimeout(timer);
   }, [pendingCommand, isConnected, wsRef, onCommandSent]);
+}
+
+/**
+ * Wires touch-drag scrolling on the xterm viewport. xterm.js handles mouse
+ * wheel natively but not touch gestures — without this hook, swiping inside
+ * the terminal on mobile bubbles up and scrolls the page instead of the
+ * terminal's scrollback. Maps vertical drag delta to `terminal.scrollLines`.
+ *
+ * Only attaches on coarse-pointer devices (mobile/tablet) so desktop xterm
+ * behaviour stays unchanged.
+ */
+function useMobileTouchScroll(
+  terminalRef: React.RefObject<HTMLDivElement | null>,
+  xtermRef: React.RefObject<Terminal | null>,
+  isTerminalReady: boolean,
+) {
+  React.useEffect(() => {
+    if (!isTerminalReady) return;
+    const el = terminalRef.current;
+    const term = xtermRef.current;
+    if (!el || !term) return;
+
+    // Skip on fine-pointer devices — desktop mouse wheel scrolling is already
+    // handled by xterm and we don't want to interfere with text selection.
+    if (typeof window !== "undefined" && window.matchMedia) {
+      const coarse = window.matchMedia("(pointer: coarse)").matches;
+      if (!coarse) return;
+    }
+
+    // Compute the row height from xterm's internal render dimensions, with
+    // graceful fallback. The internal path is the xterm 5.x layout; if the
+    // shape ever changes we fall back to a CSS-derived estimate.
+    function rowHeightPx(): number {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const internal = (term as any)?._core?._renderService?.dimensions?.css?.cell?.height;
+      if (typeof internal === "number" && internal > 0) return internal;
+      if (el && term && term.rows > 0) {
+        const measured = el.clientHeight / term.rows;
+        if (measured > 0) return measured;
+      }
+      return 16;
+    }
+
+    let startY: number | null = null;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) {
+        startY = null;
+        return;
+      }
+      startY = e.touches[0].clientY;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (startY === null || e.touches.length !== 1) return;
+      const currentY = e.touches[0].clientY;
+      const dy = startY - currentY;
+      const rh = rowHeightPx();
+      const rows = Math.trunc(dy / rh);
+      if (rows !== 0) {
+        term.scrollLines(rows);
+        // Advance the anchor by the consumed pixels so the next move computes
+        // relative to here (avoids jumpy multi-row scrolls).
+        startY = currentY + (dy - rows * rh);
+        // preventDefault keeps the browser from also scrolling the page.
+        // Requires passive: false on the listener registration below.
+        e.preventDefault();
+      }
+    };
+
+    const onTouchEnd = () => {
+      startY = null;
+    };
+
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: false });
+    el.addEventListener("touchend", onTouchEnd, { passive: true });
+    el.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
+    return () => {
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [isTerminalReady, terminalRef, xtermRef]);
 }

--- a/apps/web/components/task/task-center-panel.tsx
+++ b/apps/web/components/task/task-center-panel.tsx
@@ -52,12 +52,28 @@ function useSessionApprove(activeSessionId: string | null, activeTaskId: string 
   );
   const setTaskSession = useAppStore((state) => state.setTaskSession);
   const isAgentWorking = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
+  // Passthrough detection priority:
+  //   1. session.is_passthrough — the source of truth, set on session creation
+  //      from the agent profile's CLIPassthrough setting and persisted on the
+  //      session row. This is what `StartAgentProcess` routes on
+  //      (manager_startup.go), and what the desktop layout and other
+  //      passthrough-aware code paths already use.
+  //   2. agent_profile_snapshot.cli_passthrough — fallback for the brief
+  //      window where the snapshot is loaded but the dedicated is_passthrough
+  //      field isn't yet present on the session record. This kept legacy
+  //      behaviour working while migrations populated is_passthrough on
+  //      existing rows.
+  // Mobile previously only checked (2), which silently dropped to a chat
+  // fallback whenever the snapshot was missing from the Redux store on
+  // re-mount — even when is_passthrough was correctly populated. Desktop was
+  // immune because it checks (1) directly.
   const isPassthroughMode = useMemo(() => {
+    if (activeSession?.is_passthrough === true) return true;
     if (!activeSession?.agent_profile_snapshot) return false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const snapshot = activeSession.agent_profile_snapshot as any;
     return snapshot?.cli_passthrough === true;
-  }, [activeSession?.agent_profile_snapshot]);
+  }, [activeSession?.is_passthrough, activeSession?.agent_profile_snapshot]);
   const showApproveButton =
     !!activeSession?.review_status && activeSession.review_status !== "approved" && !isAgentWorking;
   const handleApprove = useCallback(async () => {


### PR DESCRIPTION
## Summary

Two surgical fixes for the mobile cli_passthrough UX issues reported in #1031.

### 1. `task-center-panel.tsx` — passthrough TUI silently disappears on re-mount

`isPassthroughMode` previously only consulted `agent_profile_snapshot.cli_passthrough`. When the Redux store re-hydrated a session without the full snapshot (the leaner session-list responses populate the row but omit the JSON snapshot), the memo returned `false` and the mobile chat panel rendered `TaskChatPanel` (description bubble + status banner) instead of the live `PassthroughTerminal`.

Desktop wasn't affected because `dockview-desktop-layout.tsx:250` (and `dockview-header-actions.tsx:68`, `task-page-content.tsx:133`) already reads `session.is_passthrough` directly as the source of truth — that matches what `manager_startup.go`'s `StartAgentProcess` routes on. Mobile was the only place still using only the snapshot, so the bug was mobile-only by accident, not by design.

Fix: short-circuit on `activeSession.is_passthrough === true`, fall back to the snapshot check only when that field isn't populated (e.g. legacy sessions before the column was added).

### 2. `passthrough-terminal.tsx` — terminal scrollback unreachable on mobile

xterm.js handles mouse wheel scrolling natively but doesn't wire any touch handlers. Swiping inside the terminal on mobile bubbled up the gesture and scrolled the page — meaning anything that scrolled off the top of the terminal viewport (which is most of a long-running agent session) was unreachable. The user could only see whatever fit in the current screen.

New `useMobileTouchScroll` hook attaches `touchstart` / `touchmove` / `touchend` to the terminal div, maps vertical drag delta to `Terminal.scrollLines(...)`, and only activates on `(pointer: coarse)` so desktop xterm behaviour stays identical. Row-height is sourced from xterm's internal `_core._renderService.dimensions.css.cell.height` with a measured-from-DOM fallback and a 16px constant as a last resort.

## Test plan

- [ ] Manual: open a `cli_passthrough: true` task on mobile (or Chrome devtools mobile viewport), verify TUI renders in Chat tab
- [ ] Manual: navigate to a different mobile panel (Plan / Changes / Files / Terminal) and back to Chat — TUI re-mounts, doesn't fall back to `TaskChatPanel`
- [ ] Manual: in mobile Chat tab with a TUI that has scrolled output, swipe vertically inside the terminal — scrollback scrolls, page stays put
- [ ] Manual: desktop unchanged — mouse wheel still works, text selection still works (the touch hook bails on `(pointer: fine)`)
- [ ] Automated: no existing tests for `task-center-panel.tsx` or `passthrough-terminal.tsx` — happy to add Vitest unit tests for `isPassthroughMode` and/or a Playwright spec for the mobile re-mount scenario if maintainers prefer that bar before merge

## Related

- Closes #1031
- Filed alongside #1032 (broader cli_passthrough first-class gaps); these two fixes don't depend on that work.
- Out of scope for this PR but related (planned follow-up): expose the `MobileTerminalKeybar` in the Chat tab for passthrough sessions, not just the Terminal tab. Currently the keybar's `visible` prop in `session-mobile-layout.tsx:394` is gated on `currentMobilePanel === "terminal"` only, so passthrough agents on mobile have no way to send Ctrl-C / Ctrl-D / Tab / arrows. Will file separately once this lands.
