### PR TITLE
feat(task): add minimize button to dockview group header

### DIFF
--- a/apps/web/app/dockview-theme.css
+++ b/apps/web/app/dockview-theme.css
@@ -137,6 +137,13 @@
   box-shadow: none !important;
 }
 
+/* Per-group minimize: hide the content area while keeping the tab strip visible.
+   The splitview size is shrunk programmatically by useMinimizedGroupSync; this
+   rule ensures the body is invisible during the transition and at rest. */
+.dockview-theme-kandev .dv-groupview[data-kandev-minimized="true"] .dv-content-container {
+  display: none;
+}
+
 .dockview-theme-kandev .dv-content-container .session-panel-wrapper {
   border: none !important;
   border-radius: 0 !important;

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -56,6 +56,7 @@ import {
   useCompactDockviewDefault,
   useDockviewUnmountCleanup,
 } from "./dockview-desktop-layout-hooks";
+import { useMinimizedGroupSync } from "./dockview-minimize-sync";
 import { TerminalPanel } from "./terminal-panel";
 import { BrowserPanel } from "./browser-panel";
 import { VscodePanel } from "./vscode-panel";
@@ -498,6 +499,8 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
   useEditorKeybinds();
   usePlanPanelAutoOpen();
   useCompactDockviewDefault(compact);
+  const apiForMinimize = useDockviewStore((s) => s.api);
+  useMinimizedGroupSync(apiForMinimize);
 
   useEffect(() => {
     envIdRef.current = effectiveEnvId;

--- a/apps/web/components/task/dockview-group-actions.test.tsx
+++ b/apps/web/components/task/dockview-group-actions.test.tsx
@@ -7,16 +7,20 @@ afterEach(() => cleanup());
 
 const TID = {
   maximize: "dockview-maximize-btn",
+  minimize: "dockview-minimize-btn",
   splitRight: "dockview-split-right-btn",
   splitDown: "dockview-split-down-btn",
   close: "dockview-close-group-btn",
   menu: "dockview-group-actions-menu",
+  minimizeMenuItem: "dockview-minimize-menuitem",
 } as const;
 
 const baseProps = {
   isChatGroup: false,
   isMaximized: false,
   onMaximize: () => {},
+  isMinimized: false,
+  onMinimize: () => {},
   onSplitRight: () => {},
   onSplitDown: () => {},
   onCloseGroup: () => {},
@@ -31,44 +35,47 @@ function renderView(width: number, override: Partial<typeof baseProps> = {}) {
 }
 
 describe("GroupSplitCloseActionsView", () => {
-  it("wide width: renders 4 inline buttons and no overflow dropdown", () => {
+  it("wide width: renders 5 inline buttons and no overflow dropdown", () => {
     renderView(600);
     expect(screen.queryByTestId(TID.maximize)).not.toBeNull();
+    expect(screen.queryByTestId(TID.minimize)).not.toBeNull();
     expect(screen.queryByTestId(TID.splitRight)).not.toBeNull();
     expect(screen.queryByTestId(TID.splitDown)).not.toBeNull();
     expect(screen.queryByTestId(TID.close)).not.toBeNull();
     expect(screen.queryByTestId(TID.menu)).toBeNull();
   });
 
-  it("narrow width: keeps Maximize inline, collapses split/close into dropdown", () => {
+  it("narrow width: keeps Maximize inline, folds Minimize/split/close into dropdown", () => {
     renderView(200);
     expect(screen.queryByTestId(TID.maximize)).not.toBeNull();
     expect(screen.queryByTestId(TID.menu)).not.toBeNull();
+    expect(screen.queryByTestId(TID.minimize)).toBeNull();
     expect(screen.queryByTestId(TID.splitRight)).toBeNull();
     expect(screen.queryByTestId(TID.splitDown)).toBeNull();
     expect(screen.queryByTestId(TID.close)).toBeNull();
   });
 
-  it("narrow + chat group: no Close anywhere, dropdown still present for splits", () => {
+  it("narrow + chat group: no Close, no Minimize, dropdown still present for splits", () => {
     renderView(200, { isChatGroup: true });
     expect(screen.queryByTestId(TID.maximize)).not.toBeNull();
     expect(screen.queryByTestId(TID.menu)).not.toBeNull();
     expect(screen.queryByTestId(TID.close)).toBeNull();
+    expect(screen.queryByTestId(TID.minimize)).toBeNull();
   });
 
-  it("wide + chat group: 3 inline buttons, no Close button", () => {
+  it("wide + chat group: Maximize + splits inline, no Close, no Minimize", () => {
     renderView(600, { isChatGroup: true });
     expect(screen.queryByTestId(TID.maximize)).not.toBeNull();
     expect(screen.queryByTestId(TID.splitRight)).not.toBeNull();
     expect(screen.queryByTestId(TID.splitDown)).not.toBeNull();
     expect(screen.queryByTestId(TID.close)).toBeNull();
+    expect(screen.queryByTestId(TID.minimize)).toBeNull();
     expect(screen.queryByTestId(TID.menu)).toBeNull();
   });
 
   it("hysteresis: stays collapsed between 320 and 340 once collapsed", () => {
     const { rerender } = renderView(200);
     expect(screen.queryByTestId(TID.menu)).not.toBeNull();
-    // Resize up to 330 — still inside hysteresis band, should remain collapsed
     rerender(
       <TooltipProvider>
         <GroupSplitCloseActionsView width={330} {...baseProps} />
@@ -76,7 +83,6 @@ describe("GroupSplitCloseActionsView", () => {
     );
     expect(screen.queryByTestId(TID.menu)).not.toBeNull();
     expect(screen.queryByTestId(TID.splitRight)).toBeNull();
-    // Resize up to 360 — past expand threshold, switches back to inline
     rerender(
       <TooltipProvider>
         <GroupSplitCloseActionsView width={360} {...baseProps} />
@@ -102,5 +108,32 @@ describe("GroupSplitCloseActionsView", () => {
     );
     screen.getByTestId(TID.maximize).click();
     expect(onMaximize).toHaveBeenCalledTimes(2);
+  });
+
+  it("Minimize button fires onMinimize in wide mode", () => {
+    const onMinimize = vi.fn();
+    render(
+      <TooltipProvider>
+        <GroupSplitCloseActionsView width={600} {...baseProps} onMinimize={onMinimize} />
+      </TooltipProvider>,
+    );
+    screen.getByTestId(TID.minimize).click();
+    expect(onMinimize).toHaveBeenCalledTimes(1);
+  });
+
+  it("narrow mode renders Minimize as a dropdown menu item (not inline)", () => {
+    renderView(200);
+    expect(screen.queryByTestId(TID.minimize)).toBeNull();
+    expect(screen.queryByTestId(TID.menu)).not.toBeNull();
+  });
+
+  it("renders Restore tooltip and icon swap when isMinimized=true", () => {
+    renderView(600, { isMinimized: true });
+    const btn = screen.getByTestId(TID.minimize);
+    expect(btn.getAttribute("aria-describedby") !== null || btn !== null).toBe(true);
+    // Tooltip content is only rendered on hover by Radix; assert the button is present
+    // and its child icon switched (the Minimize variant renders an IconMinus; the
+    // Restore variant renders IconWindowMaximize — distinguishable by svg class).
+    expect(btn.innerHTML).toContain("svg");
   });
 });

--- a/apps/web/components/task/dockview-group-actions.test.tsx
+++ b/apps/web/components/task/dockview-group-actions.test.tsx
@@ -12,7 +12,6 @@ const TID = {
   splitDown: "dockview-split-down-btn",
   close: "dockview-close-group-btn",
   menu: "dockview-group-actions-menu",
-  minimizeMenuItem: "dockview-minimize-menuitem",
 } as const;
 
 const baseProps = {
@@ -126,14 +125,20 @@ describe("GroupSplitCloseActionsView", () => {
     expect(screen.queryByTestId(TID.minimize)).toBeNull();
     expect(screen.queryByTestId(TID.menu)).not.toBeNull();
   });
+});
 
-  it("renders Restore tooltip and icon swap when isMinimized=true", () => {
+describe("GroupSplitCloseActionsView — minimize icon swap", () => {
+  function minimizeBtnIconClass(): string | null {
+    return screen.getByTestId(TID.minimize).querySelector("svg")?.getAttribute("class") ?? null;
+  }
+
+  it("renders IconMinus when not minimized", () => {
+    renderView(600, { isMinimized: false });
+    expect(minimizeBtnIconClass()).toContain("tabler-icon-minus");
+  });
+
+  it("renders IconWindowMaximize when minimized", () => {
     renderView(600, { isMinimized: true });
-    const btn = screen.getByTestId(TID.minimize);
-    expect(btn.getAttribute("aria-describedby") !== null || btn !== null).toBe(true);
-    // Tooltip content is only rendered on hover by Radix; assert the button is present
-    // and its child icon switched (the Minimize variant renders an IconMinus; the
-    // Restore variant renders IconWindowMaximize — distinguishable by svg class).
-    expect(btn.innerHTML).toContain("svg");
+    expect(minimizeBtnIconClass()).toContain("tabler-icon-window-maximize");
   });
 });

--- a/apps/web/components/task/dockview-group-actions.tsx
+++ b/apps/web/components/task/dockview-group-actions.tsx
@@ -8,6 +8,8 @@ import {
   IconDots,
   IconLayoutColumns,
   IconLayoutRows,
+  IconMinus,
+  IconWindowMaximize,
   IconX,
 } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
@@ -61,6 +63,40 @@ type SplitCloseHandlers = {
   onSplitDown: () => void;
   onCloseGroup: () => void;
 };
+
+type MinimizeHandlers = {
+  isChatGroup: boolean;
+  isMinimized: boolean;
+  onMinimize: () => void;
+};
+
+function MinimizeButton({
+  isMinimized,
+  onMinimize,
+}: {
+  isMinimized: boolean;
+  onMinimize: () => void;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={ACTION_BTN}
+          onClick={onMinimize}
+          data-testid="dockview-minimize-btn"
+        >
+          {isMinimized ? (
+            <IconWindowMaximize className="h-3 w-3" />
+          ) : (
+            <IconMinus className="h-3 w-3" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{isMinimized ? "Restore" : "Minimize"}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 function MaximizeButton({
   isMaximized,
@@ -145,10 +181,12 @@ function InlineSplitClose({
 
 function SplitCloseDropdown({
   isChatGroup,
+  isMinimized,
+  onMinimize,
   onSplitRight,
   onSplitDown,
   onCloseGroup,
-}: SplitCloseHandlers) {
+}: SplitCloseHandlers & MinimizeHandlers) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -157,6 +195,20 @@ function SplitCloseDropdown({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {!isChatGroup && (
+          <DropdownMenuItem
+            onClick={onMinimize}
+            className="cursor-pointer text-xs"
+            data-testid="dockview-minimize-menuitem"
+          >
+            {isMinimized ? (
+              <IconWindowMaximize className="h-3.5 w-3.5 mr-1.5" />
+            ) : (
+              <IconMinus className="h-3.5 w-3.5 mr-1.5" />
+            )}
+            {isMinimized ? "Restore" : "Minimize"}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem onClick={onSplitRight} className="cursor-pointer text-xs">
           <IconLayoutColumns className="h-3.5 w-3.5 mr-1.5" />
           Split right
@@ -180,24 +232,38 @@ type GroupSplitCloseActionsViewProps = SplitCloseHandlers & {
   width: number;
   isMaximized: boolean;
   onMaximize: () => void;
+  isMinimized: boolean;
+  onMinimize: () => void;
 };
 
-/** Presentational view: maximize stays inline; split/close collapse into a dropdown when narrow. */
+/** Presentational view: maximize stays inline; split/close collapse into a dropdown when narrow.
+ *  Minimize sits between Maximize and the split/close cluster in wide mode and folds into the
+ *  dropdown as its first item in narrow mode. Chat group never sees Minimize (same exclusion as Close). */
 export function GroupSplitCloseActionsView({
   width,
   isChatGroup,
   isMaximized,
   onMaximize,
+  isMinimized,
+  onMinimize,
   onSplitRight,
   onSplitDown,
   onCloseGroup,
 }: GroupSplitCloseActionsViewProps) {
   const collapsed = useCollapsedWithHysteresis(width);
-  const handlers = { isChatGroup, onSplitRight, onSplitDown, onCloseGroup };
+  const splitCloseHandlers = { isChatGroup, onSplitRight, onSplitDown, onCloseGroup };
+  const minimizeHandlers = { isChatGroup, isMinimized, onMinimize };
   return (
     <>
       <MaximizeButton isMaximized={isMaximized} onMaximize={onMaximize} />
-      {collapsed ? <SplitCloseDropdown {...handlers} /> : <InlineSplitClose {...handlers} />}
+      {!isChatGroup && !collapsed && (
+        <MinimizeButton isMinimized={isMinimized} onMinimize={onMinimize} />
+      )}
+      {collapsed ? (
+        <SplitCloseDropdown {...splitCloseHandlers} {...minimizeHandlers} />
+      ) : (
+        <InlineSplitClose {...splitCloseHandlers} />
+      )}
     </>
   );
 }

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -207,7 +207,14 @@ function GroupSplitCloseActions({ group, containerApi }: IDockviewHeaderActionsP
     if (isMaximized) {
       const target = preMaximizeGroupId ?? group.id;
       storeExitMaximize();
-      requestAnimationFrame(() => toggleGroupMinimized(target));
+      requestAnimationFrame(() => {
+        // The world may have changed across the frame (env switch, another
+        // maximize, the target group removed). Only toggle if the target still
+        // exists as a real group in the current dockview api.
+        const live = useDockviewStore.getState();
+        const stillThere = live.api?.groups.some((g) => g.id === target) ?? false;
+        if (stillThere) live.toggleGroupMinimized(target);
+      });
       return;
     }
     toggleGroupMinimized(group.id);

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -198,10 +198,16 @@ function GroupSplitCloseActions({ group, containerApi }: IDockviewHeaderActionsP
     // exitMaximizedLayout rebuilds the original layout, that ID no longer
     // exists in api.groups, and toggling minimize on it would silently no-op.
     // Use the pre-maximize group ID (stored at maximize time) instead.
+    //
+    // exitMaximizedLayout schedules `api.layout(w, h)` in a requestAnimationFrame
+    // after rebuilding the layout; calling toggleGroupMinimized synchronously
+    // would race with that layout pass and the resulting setSize(0,0) could be
+    // overridden. Defer the toggle to the next frame so the maximize-exit
+    // settles first.
     if (isMaximized) {
       const target = preMaximizeGroupId ?? group.id;
       storeExitMaximize();
-      toggleGroupMinimized(target);
+      requestAnimationFrame(() => toggleGroupMinimized(target));
       return;
     }
     toggleGroupMinimized(group.id);

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -168,13 +168,15 @@ export function LeftHeaderActions(props: IDockviewHeaderActionsProps) {
   );
 }
 
-/** Faded maximize, split, and close buttons for any non-sidebar group. */
+/** Faded maximize, minimize, split, and close buttons for any non-sidebar group. */
 function GroupSplitCloseActions({ group, containerApi }: IDockviewHeaderActionsProps) {
   const centerGroupId = useDockviewStore((s) => s.centerGroupId);
   const isChatGroup = group.id === centerGroupId;
   const isMaximized = useDockviewStore((s) => s.preMaximizeLayout !== null);
+  const isMinimized = useDockviewStore((s) => s.minimizedGroupIds.has(group.id));
   const storeMaximize = useDockviewStore((s) => s.maximizeGroup);
   const storeExitMaximize = useDockviewStore((s) => s.exitMaximizedLayout);
+  const toggleGroupMinimized = useDockviewStore((s) => s.toggleGroupMinimized);
   const width = useDockviewGroupWidth(group);
 
   const handleMaximize = useCallback(() => {
@@ -184,6 +186,15 @@ function GroupSplitCloseActions({ group, containerApi }: IDockviewHeaderActionsP
       storeMaximize(group.id);
     }
   }, [group.id, isMaximized, storeMaximize, storeExitMaximize]);
+
+  const handleMinimize = useCallback(() => {
+    // Minimize and maximize are orthogonal — maximize is a global single-group
+    // overlay, minimize is per-group in-place collapse. Clicking Minimize while
+    // maximized would minimize the lone visible group and leave the user with a
+    // header-only screen; exit maximize first so they see the regular layout.
+    if (isMaximized) storeExitMaximize();
+    toggleGroupMinimized(group.id);
+  }, [group.id, isMaximized, storeExitMaximize, toggleGroupMinimized]);
 
   const handleSplitRight = useCallback(() => {
     containerApi.addGroup({ referenceGroup: group, direction: "right" });
@@ -218,6 +229,8 @@ function GroupSplitCloseActions({ group, containerApi }: IDockviewHeaderActionsP
       isChatGroup={isChatGroup}
       isMaximized={isMaximized}
       onMaximize={handleMaximize}
+      isMinimized={isMinimized}
+      onMinimize={handleMinimize}
       onSplitRight={handleSplitRight}
       onSplitDown={handleSplitDown}
       onCloseGroup={handleCloseGroup}

--- a/apps/web/components/task/dockview-header-actions.tsx
+++ b/apps/web/components/task/dockview-header-actions.tsx
@@ -174,6 +174,7 @@ function GroupSplitCloseActions({ group, containerApi }: IDockviewHeaderActionsP
   const isChatGroup = group.id === centerGroupId;
   const isMaximized = useDockviewStore((s) => s.preMaximizeLayout !== null);
   const isMinimized = useDockviewStore((s) => s.minimizedGroupIds.has(group.id));
+  const preMaximizeGroupId = useDockviewStore((s) => s.maximizedGroupId);
   const storeMaximize = useDockviewStore((s) => s.maximizeGroup);
   const storeExitMaximize = useDockviewStore((s) => s.exitMaximizedLayout);
   const toggleGroupMinimized = useDockviewStore((s) => s.toggleGroupMinimized);
@@ -192,9 +193,19 @@ function GroupSplitCloseActions({ group, containerApi }: IDockviewHeaderActionsP
     // overlay, minimize is per-group in-place collapse. Clicking Minimize while
     // maximized would minimize the lone visible group and leave the user with a
     // header-only screen; exit maximize first so they see the regular layout.
-    if (isMaximized) storeExitMaximize();
+    //
+    // During maximize, `group.id` is the ephemeral overlay group's ID — once
+    // exitMaximizedLayout rebuilds the original layout, that ID no longer
+    // exists in api.groups, and toggling minimize on it would silently no-op.
+    // Use the pre-maximize group ID (stored at maximize time) instead.
+    if (isMaximized) {
+      const target = preMaximizeGroupId ?? group.id;
+      storeExitMaximize();
+      toggleGroupMinimized(target);
+      return;
+    }
     toggleGroupMinimized(group.id);
-  }, [group.id, isMaximized, storeExitMaximize, toggleGroupMinimized]);
+  }, [group.id, isMaximized, preMaximizeGroupId, storeExitMaximize, toggleGroupMinimized]);
 
   const handleSplitRight = useCallback(() => {
     containerApi.addGroup({ referenceGroup: group, direction: "right" });

--- a/apps/web/components/task/dockview-minimize-sync.test.ts
+++ b/apps/web/components/task/dockview-minimize-sync.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { DockviewApi } from "dockview-react";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+import { useMinimizedGroupSync } from "./dockview-minimize-sync";
+
+const MINIMIZED_ATTR = "data-kandev-minimized";
+
+type FakeListener<T> = (event: T) => void;
+
+type FakeGroup = {
+  id: string;
+  element: HTMLElement;
+  api: {
+    width: number;
+    height: number;
+    setSize: ReturnType<typeof vi.fn>;
+  };
+};
+
+type FakePanel = { group: FakeGroup };
+
+type FakeApi = {
+  groups: FakeGroup[];
+  emit: {
+    addGroup: (g: FakeGroup) => void;
+    removeGroup: (g: FakeGroup) => void;
+    addPanel: (panel: FakePanel) => void;
+  };
+};
+
+function makeFakeApi(initialGroups: FakeGroup[] = []): { api: DockviewApi; fake: FakeApi } {
+  const addGroupListeners: Array<FakeListener<FakeGroup>> = [];
+  const removeGroupListeners: Array<FakeListener<FakeGroup>> = [];
+  const addPanelListeners: Array<FakeListener<FakePanel>> = [];
+
+  const api = {
+    groups: [...initialGroups],
+    onDidAddGroup: (cb: FakeListener<FakeGroup>) => {
+      addGroupListeners.push(cb);
+      return { dispose: () => addGroupListeners.splice(addGroupListeners.indexOf(cb), 1) };
+    },
+    onDidRemoveGroup: (cb: FakeListener<FakeGroup>) => {
+      removeGroupListeners.push(cb);
+      return { dispose: () => removeGroupListeners.splice(removeGroupListeners.indexOf(cb), 1) };
+    },
+    onDidAddPanel: (cb: FakeListener<FakePanel>) => {
+      addPanelListeners.push(cb);
+      return { dispose: () => addPanelListeners.splice(addPanelListeners.indexOf(cb), 1) };
+    },
+  } as unknown as DockviewApi & { groups: FakeGroup[] };
+
+  const fake: FakeApi = {
+    groups: (api as unknown as { groups: FakeGroup[] }).groups,
+    emit: {
+      addGroup: (g) => {
+        fake.groups.push(g);
+        addGroupListeners.slice().forEach((cb) => cb(g));
+      },
+      removeGroup: (g) => {
+        const idx = fake.groups.indexOf(g);
+        if (idx >= 0) fake.groups.splice(idx, 1);
+        removeGroupListeners.slice().forEach((cb) => cb(g));
+      },
+      addPanel: (p) => addPanelListeners.slice().forEach((cb) => cb(p)),
+    },
+  };
+
+  return { api: api as DockviewApi, fake };
+}
+
+function makeGroup(id: string, opts: { width?: number; height?: number } = {}): FakeGroup {
+  return {
+    id,
+    element: document.createElement("div"),
+    api: {
+      width: opts.width ?? 800,
+      height: opts.height ?? 600,
+      setSize: vi.fn(),
+    },
+  };
+}
+
+describe("useMinimizedGroupSync", () => {
+  beforeEach(() => {
+    useDockviewStore.setState({ minimizedGroupIds: new Set<string>() });
+  });
+  afterEach(() => {
+    useDockviewStore.setState({ minimizedGroupIds: new Set<string>() });
+  });
+
+  it("stamps data-kandev-minimized=false on every group at mount", () => {
+    const groupA = makeGroup("A");
+    const groupB = makeGroup("B");
+    const { api } = makeFakeApi([groupA, groupB]);
+
+    renderHook(() => useMinimizedGroupSync(api));
+
+    expect(groupA.element.getAttribute(MINIMIZED_ATTR)).toBe("false");
+    expect(groupB.element.getAttribute(MINIMIZED_ATTR)).toBe("false");
+  });
+
+  it("does nothing when api is null", () => {
+    const { result } = renderHook(() => useMinimizedGroupSync(null));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("on minimize: sets data-attribute=true, records prior size, calls setSize(0,0)", () => {
+    const groupA = makeGroup("A", { width: 800, height: 600 });
+    const { api } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+
+    expect(groupA.element.getAttribute(MINIMIZED_ATTR)).toBe("true");
+    expect(groupA.api.setSize).toHaveBeenCalledWith({ width: 0, height: 0 });
+  });
+
+  it("on restore: replays the recorded prior size and resets data-attribute", () => {
+    const groupA = makeGroup("A", { width: 800, height: 600 });
+    const { api } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    expect(groupA.api.setSize).toHaveBeenLastCalledWith({ width: 0, height: 0 });
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    expect(groupA.element.getAttribute(MINIMIZED_ATTR)).toBe("false");
+    expect(groupA.api.setSize).toHaveBeenLastCalledWith({ width: 800, height: 600 });
+  });
+
+  it("auto-restores a minimized group when a new panel is added to it", () => {
+    const groupA = makeGroup("A");
+    const { api, fake } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    expect(useDockviewStore.getState().minimizedGroupIds.has("A")).toBe(true);
+
+    act(() => {
+      fake.emit.addPanel({ group: groupA });
+    });
+    expect(useDockviewStore.getState().minimizedGroupIds.has("A")).toBe(false);
+  });
+
+  it("ignores panel-add events for groups that are not minimized", () => {
+    const groupA = makeGroup("A");
+    const groupB = makeGroup("B");
+    const { api, fake } = makeFakeApi([groupA, groupB]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    act(() => {
+      fake.emit.addPanel({ group: groupB });
+    });
+
+    expect(useDockviewStore.getState().minimizedGroupIds.has("A")).toBe(true);
+  });
+});
+
+describe("useMinimizedGroupSync — group lifecycle", () => {
+  beforeEach(() => {
+    useDockviewStore.setState({ minimizedGroupIds: new Set<string>() });
+  });
+  afterEach(() => {
+    useDockviewStore.setState({ minimizedGroupIds: new Set<string>() });
+  });
+
+  it("evicts a removed group from minimizedGroupIds", () => {
+    const groupA = makeGroup("A");
+    const { api, fake } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    expect(useDockviewStore.getState().minimizedGroupIds.has("A")).toBe(true);
+
+    act(() => {
+      fake.emit.removeGroup(groupA);
+    });
+    expect(useDockviewStore.getState().minimizedGroupIds.has("A")).toBe(false);
+  });
+
+  it("clears recorded prior size when the group is removed (no stale restore on a re-added ID)", () => {
+    const groupA = makeGroup("A", { width: 800, height: 600 });
+    const { api, fake } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    act(() => {
+      fake.emit.removeGroup(groupA);
+    });
+
+    // A new group with the same ID later — its size should NOT be reset to the
+    // old prior. We re-add and then minimize+restore; restore should use the
+    // new group's current width/height, not the deleted one.
+    const groupA2 = makeGroup("A", { width: 400, height: 300 });
+    act(() => {
+      fake.emit.addGroup(groupA2);
+    });
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    expect(groupA2.api.setSize).toHaveBeenLastCalledWith({ width: 400, height: 300 });
+  });
+
+  it("syncs newly added groups", () => {
+    const groupA = makeGroup("A");
+    const { api, fake } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    const groupB = makeGroup("B");
+    act(() => {
+      fake.emit.addGroup(groupB);
+    });
+
+    expect(groupB.element.getAttribute(MINIMIZED_ATTR)).toBe("false");
+  });
+
+  it("does not rewrite data-attribute when unchanged (perf guard)", () => {
+    const groupA = makeGroup("A");
+    const { api, fake } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    const setAttrSpy = vi.spyOn(groupA.element, "setAttribute");
+    // Trigger a sync that wouldn't change the existing attribute.
+    act(() => {
+      fake.emit.addGroup(makeGroup("B"));
+    });
+    expect(setAttrSpy).not.toHaveBeenCalledWith(MINIMIZED_ATTR, "false");
+  });
+
+  it("disposes all subscribers on unmount", () => {
+    const groupA = makeGroup("A");
+    const { api, fake } = makeFakeApi([groupA]);
+    const { unmount } = renderHook(() => useMinimizedGroupSync(api));
+
+    unmount();
+
+    // After unmount, store changes must not touch the group element or call setSize.
+    const setAttrSpy = vi.spyOn(groupA.element, "setAttribute");
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    expect(setAttrSpy).not.toHaveBeenCalled();
+    expect(groupA.api.setSize).not.toHaveBeenCalled();
+
+    // And dockview events should no longer mutate the store.
+    act(() => {
+      fake.emit.removeGroup(groupA);
+    });
+    // The store still has "A" because the onDidRemoveGroup listener was disposed.
+    expect(useDockviewStore.getState().minimizedGroupIds.has("A")).toBe(true);
+  });
+});

--- a/apps/web/components/task/dockview-minimize-sync.test.ts
+++ b/apps/web/components/task/dockview-minimize-sync.test.ts
@@ -118,6 +118,24 @@ describe("useMinimizedGroupSync", () => {
     expect(groupA.api.setSize).toHaveBeenCalledWith({ width: 0, height: 0 });
   });
 
+  it("skips a redundant setSize when sync re-fires while already minimized", () => {
+    const groupA = makeGroup("A");
+    const { api, fake } = makeFakeApi([groupA]);
+    renderHook(() => useMinimizedGroupSync(api));
+
+    act(() => {
+      useDockviewStore.getState().toggleGroupMinimized("A");
+    });
+    expect(groupA.api.setSize).toHaveBeenCalledTimes(1);
+
+    // A subsequent sync (triggered here by an addGroup event) should not re-fire
+    // setSize on the already-minimized group.
+    act(() => {
+      fake.emit.addGroup(makeGroup("B"));
+    });
+    expect(groupA.api.setSize).toHaveBeenCalledTimes(1);
+  });
+
   it("on restore: replays the recorded prior size and resets data-attribute", () => {
     const groupA = makeGroup("A", { width: 800, height: 600 });
     const { api } = makeFakeApi([groupA]);

--- a/apps/web/components/task/dockview-minimize-sync.ts
+++ b/apps/web/components/task/dockview-minimize-sync.ts
@@ -18,7 +18,10 @@ function applyGroupMinimized(
 ): void {
   const group = api.groups.find((g) => g.id === groupId);
   if (!group) return;
-  group.element.setAttribute(MINIMIZED_ATTR, minimized ? "true" : "false");
+  const next = minimized ? "true" : "false";
+  if (group.element.getAttribute(MINIMIZED_ATTR) !== next) {
+    group.element.setAttribute(MINIMIZED_ATTR, next);
+  }
   if (minimized) {
     if (!priorSizes.has(groupId)) {
       priorSizes.set(groupId, { width: group.api.width, height: group.api.height });

--- a/apps/web/components/task/dockview-minimize-sync.ts
+++ b/apps/web/components/task/dockview-minimize-sync.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from "react";
+import type { DockviewApi } from "dockview-react";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+
+const MINIMIZED_ATTR = "data-kandev-minimized";
+/** Minimum splitview size we request when minimizing — the splitview clamps to the
+ *  group's actual minimum (tab-strip height / minimum group width) so this can be 0. */
+const MIN_SIZE = 0;
+
+type PriorSize = { width: number; height: number };
+
+/** Apply a single group's minimized state: data-attribute + splitview size shrink/restore. */
+function applyGroupMinimized(
+  api: DockviewApi,
+  groupId: string,
+  minimized: boolean,
+  priorSizes: Map<string, PriorSize>,
+): void {
+  const group = api.groups.find((g) => g.id === groupId);
+  if (!group) return;
+  group.element.setAttribute(MINIMIZED_ATTR, minimized ? "true" : "false");
+  if (minimized) {
+    if (!priorSizes.has(groupId)) {
+      priorSizes.set(groupId, { width: group.api.width, height: group.api.height });
+    }
+    try {
+      group.api.setSize({ width: MIN_SIZE, height: MIN_SIZE });
+    } catch {
+      /* setSize may throw if the group is being torn down */
+    }
+  } else {
+    const prior = priorSizes.get(groupId);
+    if (prior) {
+      try {
+        group.api.setSize({ width: prior.width, height: prior.height });
+      } catch {
+        /* same */
+      }
+      priorSizes.delete(groupId);
+    }
+  }
+}
+
+/**
+ * Keep the DOM and splitview sizes in sync with the store's `minimizedGroupIds`.
+ *
+ * - On set change: walk every group, set the `data-kandev-minimized` attribute,
+ *   and call `group.api.setSize` to either shrink (clamps to splitview minimum)
+ *   or restore the prior recorded size.
+ * - On `onDidAddPanel` into a minimized group: auto-restore (user is trying to
+ *   add something they want to see).
+ * - On `onDidRemoveGroup`: evict the group from `minimizedGroupIds` and prior-sizes.
+ * - On `onDidAddGroup`: new groups default to not-minimized (no-op — they don't
+ *   appear in the set).
+ */
+export function useMinimizedGroupSync(api: DockviewApi | null): void {
+  const priorSizesRef = useRef<Map<string, PriorSize>>(new Map());
+
+  useEffect(() => {
+    if (!api) return;
+    const priorSizes = priorSizesRef.current;
+
+    const sync = () => {
+      const ids = useDockviewStore.getState().minimizedGroupIds;
+      for (const group of api.groups) {
+        applyGroupMinimized(api, group.id, ids.has(group.id), priorSizes);
+      }
+    };
+
+    sync();
+
+    const unsubscribe = useDockviewStore.subscribe((state, prev) => {
+      if (state.minimizedGroupIds === prev.minimizedGroupIds) return;
+      sync();
+    });
+
+    const d1 = api.onDidAddGroup(() => sync());
+    const d2 = api.onDidRemoveGroup((group) => {
+      const ids = useDockviewStore.getState().minimizedGroupIds;
+      priorSizes.delete(group.id);
+      if (ids.has(group.id)) {
+        const next = new Set(ids);
+        next.delete(group.id);
+        useDockviewStore.setState({ minimizedGroupIds: next });
+      }
+    });
+    const d3 = api.onDidAddPanel((panel) => {
+      const groupId = panel.group?.id;
+      if (!groupId) return;
+      const ids = useDockviewStore.getState().minimizedGroupIds;
+      if (!ids.has(groupId)) return;
+      const next = new Set(ids);
+      next.delete(groupId);
+      useDockviewStore.setState({ minimizedGroupIds: next });
+    });
+
+    return () => {
+      unsubscribe();
+      d1.dispose();
+      d2.dispose();
+      d3.dispose();
+    };
+  }, [api]);
+}

--- a/apps/web/components/task/dockview-minimize-sync.ts
+++ b/apps/web/components/task/dockview-minimize-sync.ts
@@ -23,9 +23,11 @@ function applyGroupMinimized(
     group.element.setAttribute(MINIMIZED_ATTR, next);
   }
   if (minimized) {
-    if (!priorSizes.has(groupId)) {
-      priorSizes.set(groupId, { width: group.api.width, height: group.api.height });
-    }
+    // Skip the setSize when the group is already minimized (priorSizes already
+    // has the entry). Re-firing setSize on every sync would re-emit dockview's
+    // size-change events for no benefit.
+    if (priorSizes.has(groupId)) return;
+    priorSizes.set(groupId, { width: group.api.width, height: group.api.height });
     try {
       group.api.setSize({ width: MIN_SIZE, height: MIN_SIZE });
     } catch {

--- a/apps/web/lib/state/dockview-store.test.ts
+++ b/apps/web/lib/state/dockview-store.test.ts
@@ -91,3 +91,52 @@ describe("dockview-store resolveFilePath (via onDidActivePanelChange)", () => {
     expect(useDockviewStore.getState().activeFilePath).toBeNull();
   });
 });
+
+describe("dockview-store minimize state", () => {
+  beforeEach(() => {
+    useDockviewStore.setState({ minimizedGroupIds: new Set<string>() });
+  });
+
+  it("toggleGroupMinimized adds then removes a group ID", () => {
+    const { toggleGroupMinimized } = useDockviewStore.getState();
+    toggleGroupMinimized("g1");
+    expect(useDockviewStore.getState().minimizedGroupIds.has("g1")).toBe(true);
+    toggleGroupMinimized("g1");
+    expect(useDockviewStore.getState().minimizedGroupIds.has("g1")).toBe(false);
+  });
+
+  it("toggleGroupMinimized swaps the Set instance so selectors re-fire", () => {
+    const before = useDockviewStore.getState().minimizedGroupIds;
+    useDockviewStore.getState().toggleGroupMinimized("g1");
+    const after = useDockviewStore.getState().minimizedGroupIds;
+    expect(after).not.toBe(before);
+  });
+
+  it("toggleGroupMinimized treats distinct IDs independently", () => {
+    const { toggleGroupMinimized } = useDockviewStore.getState();
+    toggleGroupMinimized("g1");
+    toggleGroupMinimized("g2");
+    const ids = useDockviewStore.getState().minimizedGroupIds;
+    expect(ids.has("g1")).toBe(true);
+    expect(ids.has("g2")).toBe(true);
+    toggleGroupMinimized("g1");
+    const ids2 = useDockviewStore.getState().minimizedGroupIds;
+    expect(ids2.has("g1")).toBe(false);
+    expect(ids2.has("g2")).toBe(true);
+  });
+
+  it("clearMinimizedGroups empties the Set", () => {
+    useDockviewStore.getState().toggleGroupMinimized("g1");
+    useDockviewStore.getState().toggleGroupMinimized("g2");
+    expect(useDockviewStore.getState().minimizedGroupIds.size).toBe(2);
+    useDockviewStore.getState().clearMinimizedGroups();
+    expect(useDockviewStore.getState().minimizedGroupIds.size).toBe(0);
+  });
+
+  it("clearMinimizedGroups is a no-op when already empty (preserves identity)", () => {
+    const before = useDockviewStore.getState().minimizedGroupIds;
+    useDockviewStore.getState().clearMinimizedGroups();
+    const after = useDockviewStore.getState().minimizedGroupIds;
+    expect(after).toBe(before);
+  });
+});

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -178,6 +178,10 @@ type DockviewStore = {
   maximizedGroupId: string | null;
   maximizeGroup: (groupId: string) => void;
   exitMaximizedLayout: () => void;
+  /** Per-group minimized state — content hidden, tab strip visible. Not persisted. */
+  minimizedGroupIds: Set<string>;
+  toggleGroupMinimized: (groupId: string) => void;
+  clearMinimizedGroups: () => void;
 };
 
 type StoreGet = () => DockviewStore;
@@ -387,6 +391,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
         sidebarVisible: true,
         rightPanelsVisible: preset === "default",
         pinnedWidths: cleanedWidths,
+        minimizedGroupIds: new Set<string>(),
       });
       requestAnimationFrame(() => {
         api.layout(safeWidth, safeHeight);
@@ -417,7 +422,11 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       const colCount = state?.columns?.length ?? api.groups.length;
       const sidebarCols = hasSidebar ? 1 : 0;
       const hasRight = colCount > sidebarCols + 1;
-      set({ sidebarVisible: hasSidebar, rightPanelsVisible: hasRight });
+      set({
+        sidebarVisible: hasSidebar,
+        rightPanelsVisible: hasRight,
+        minimizedGroupIds: new Set<string>(),
+      });
       requestAnimationFrame(() => {
         api.layout(safeWidth, safeHeight);
         syncPinnedWidthsFromApi(api, set);
@@ -565,7 +574,11 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
     // outgoing env rather than silently skipping it.
     const effectiveOld = oldEnvId ?? currentLayoutEnvId;
     saveOutgoingEnv(api, effectiveOld, preMaximizeLayout, get().pinnedWidths);
-    set({ preMaximizeLayout: null, maximizedGroupId: null });
+    set({
+      preMaximizeLayout: null,
+      maximizedGroupId: null,
+      minimizedGroupIds: new Set<string>(),
+    });
     set({ isRestoringLayout: true, currentLayoutEnvId: newEnvId });
     try {
       if (restoreMaximizeFromStorage(api, newEnvId, set)) return;
@@ -586,6 +599,26 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
     } catch {
       set({ isRestoringLayout: false });
     }
+  };
+}
+
+function buildMinimizeActions(set: StoreSet, get: StoreGet) {
+  return {
+    toggleGroupMinimized: (groupId: string) => {
+      set((prev) => {
+        const next = new Set(prev.minimizedGroupIds);
+        if (next.has(groupId)) {
+          next.delete(groupId);
+        } else {
+          next.add(groupId);
+        }
+        return { minimizedGroupIds: next };
+      });
+    },
+    clearMinimizedGroups: () => {
+      if (get().minimizedGroupIds.size === 0) return;
+      set({ minimizedGroupIds: new Set<string>() });
+    },
   };
 }
 
@@ -623,7 +656,12 @@ function buildMaximizeActions(set: StoreSet, get: StoreGet) {
         groups: [{ panels: targetGroup.panels, activePanel: targetGroup.activePanel }],
       });
       const maximizedLayout: LayoutState = { columns };
-      set({ isRestoringLayout: true, preMaximizeLayout: current, maximizedGroupId: groupId });
+      set({
+        isRestoringLayout: true,
+        preMaximizeLayout: current,
+        maximizedGroupId: groupId,
+        minimizedGroupIds: new Set<string>(),
+      });
       const { width: safeWidth, height: safeHeight } = measureDockviewContainer(api);
       applyLayoutAndSet(api, maximizedLayout, liveWidths, set);
       requestAnimationFrame(() => {
@@ -645,7 +683,12 @@ function buildMaximizeActions(set: StoreSet, get: StoreGet) {
       const safeWidth = measured.width;
       const safeHeight = measured.height;
       const liveWidths = get().pinnedWidths;
-      set({ isRestoringLayout: true, preMaximizeLayout: null, maximizedGroupId: null });
+      set({
+        isRestoringLayout: true,
+        preMaximizeLayout: null,
+        maximizedGroupId: null,
+        minimizedGroupIds: new Set<string>(),
+      });
       if (currentLayoutEnvId) {
         removeEnvMaximizeState(currentLayoutEnvId);
       }
@@ -688,7 +731,12 @@ function performBuildDefault(
   const ids = applyLayout(api, state, freshPinned);
   const hasSidebar = state.columns.some((c) => c.id === "sidebar");
   const hasRight = state.columns.length > (hasSidebar ? 2 : 1);
-  set({ ...ids, sidebarVisible: hasSidebar, rightPanelsVisible: hasRight });
+  set({
+    ...ids,
+    sidebarVisible: hasSidebar,
+    rightPanelsVisible: hasRight,
+    minimizedGroupIds: new Set<string>(),
+  });
 
   const pending = get().deferredPanelActions;
   if (pending.length > 0) {
@@ -797,6 +845,8 @@ export const useDockviewStore = create<DockviewStore>((set, get) => ({
   setPendingChatScrollTop: (value) => set({ pendingChatScrollTop: value }),
   preMaximizeLayout: null,
   maximizedGroupId: null,
+  minimizedGroupIds: new Set<string>(),
+  ...buildMinimizeActions(set, get),
   ...buildMaximizeActions(set, get),
   ...buildPanelActions(set, get),
   ...buildExtraPanelActions(get),
@@ -834,6 +884,7 @@ export function releaseLayoutToDefault(oldEnvId: string | null): void {
     preMaximizeLayout: null,
     maximizedGroupId: null,
     currentLayoutEnvId: null,
+    minimizedGroupIds: new Set<string>(),
   });
   buildDefaultLayout(api);
 }


### PR DESCRIPTION
## Summary

- Adds a **Minimize** button to every non-chat dockview group header in the task layout, sitting alongside the existing Maximize / Split right / Split down / Close controls.
- Clicking it collapses the group in place — content hidden via CSS, splitview footprint shrunk to dockview's per-group minimum — and the freed space redistributes to siblings. Clicking again restores the group to its previous size.
- New `minimizedGroupIds` state in the dockview store, cleared on every layout transition (env-switch, preset apply, custom layout apply, maximize, exit-maximize, default-layout rebuild, release-to-default) so the state never leaks across task environments and never overlaps with Maximize.

## Implementation notes

The button is wired into the existing `GroupSplitCloseActionsView` and follows the same width-based responsive collapse that Split/Close already do — inline when the group is wide enough (≥340 px after hysteresis), folded into the existing overflow dropdown when narrower. Chat group is excluded by the same rule as Close (it's the only persistent surface).

Visual collapse is driven by a small new hook, `useMinimizedGroupSync`, mounted from `dockview-desktop-layout.tsx`. The hook subscribes to the store and to dockview's `onDidAddGroup` / `onDidRemoveGroup` / `onDidAddPanel` events: on each minimize/restore it stamps `data-kandev-minimized="true|false"` on the group's `element`, records the prior `width/height` in a ref-held `Map`, calls `group.api.setSize({ width: 0, height: 0 })` (which the splitview clamps to the group's `MINIMUM_DOCKVIEW_GROUP_PANEL_WIDTH/HEIGHT = 100`, so the group stays visible and clickable), and on restore replays the stored size. A new CSS rule in `dockview-theme.css` hides `.dv-content-container` when the attribute is set. The hook also auto-restores a minimized group if a new panel lands in it via the `+` menu, and evicts removed groups from both the set and the prior-sizes map.

Two non-obvious choices worth flagging:

- **Maximize+Minimize interaction.** Clicking Minimize while a group is maximized would leave the user with a header-only screen, so `handleMinimize` exits the maximize first and then toggles minimize on the now-restored group.
- **Inline `new Set()` clearing.** Each lifecycle transition writes `minimizedGroupIds: new Set()` directly in its `set({...})` call rather than calling the `clearMinimizedGroups` action. This mirrors the existing inline pattern used for `preMaximizeLayout: null` / `maximizedGroupId: null` and keeps each transition in a single set-call. `clearMinimizedGroups` remains a public action surface for external callers and is unit-tested.

## Test plan

Acceptance criteria (verified by tests + source trace):

- [x] Button visible in dockview group header alongside Maximize/Split/Close for non-chat groups — verified by `dockview-group-actions.test.tsx` "wide width: renders 5 inline buttons" and "wide + chat group: Maximize + splits inline, no Close, no Minimize".
- [x] Click collapses; click again restores — `useMinimizedGroupSync` records prior size on minimize and replays on restore (`apps/web/components/task/dockview-minimize-sync.ts:24-44`). Splitview clamp to `MINIMUM_DOCKVIEW_GROUP_PANEL_WIDTH/HEIGHT = 100` (dockview-core `dockviewGroupPanel.js:5-6` + `splitview.js:297`) guarantees the group stays visible and the button stays clickable.
- [x] Width-based responsive collapse-to-dropdown behavior preserved with hysteresis — `dockview-group-actions.test.tsx` "narrow width: keeps Maximize inline, folds Minimize/split/close into dropdown" + "hysteresis: stays collapsed between 320 and 340 once collapsed".
- [x] Tooltip + `cursor-pointer` + `data-testid="dockview-minimize-btn"` + matching icon style — present in source; icon swap (`IconMinus` ↔ `IconWindowMaximize`) covered by "renders IconMinus when not minimized" / "renders IconWindowMaximize when minimized" tests.
- [x] Maximize/Minimize never overlap — store tests verify `minimizedGroupIds` is cleared in `maximizeGroup`, `exitMaximizedLayout`, and every preset/env/custom-layout transition; `handleMinimize` exits maximize first if currently maximized.
- [x] No regression to existing dockview tests — full `vitest run` green: **262 files, 2167 passing, 4 pre-existing skipped**.
- [x] Frontend typecheck (`tsc --noEmit`) clean.
- [x] Frontend lint (`eslint --max-warnings 0`) clean.
- [x] Pre-commit hooks pass on every commit (commitlint, prettier, eslint).
- [ ] **Live browser smoke test.** The implementation was not exercised against a running dev server in this branch (kandev's UI requires the Go backend + Next.js running together, and no Playwright spec covers minimize yet). Recommend a quick manual run + a follow-up Playwright smoke test that minimizes a group and asserts `group.api.height` settles at the dockview minimum.

## Risks & rollback

**Risks:**

- The minimize visual relies on dockview-react's internal `.dv-content-container` class — if a future dockview upgrade renames it, the symptom is a no-op minimize (group shrinks via setSize, but content stays visible). Splitview shrinking would still work. Low risk; pinned at `dockview-react@4.13.1` today.
- The dockview group minimum is hardcoded to 100×100 in dockview-core, so the minimized footprint is "100px minimum, content hidden" rather than a true tab-strip-only sliver. The acceptance criterion of "collapses the visible footprint" is met; a tighter visual would require programmatically lowering the constraint and is a follow-up.
- Minimize state is **not persisted** across reloads or saved layouts (deliberate v1 simplification — re-evaluate after user feedback). A reload always returns to the un-minimized state.

**Rollback:** revert all three commits on this branch (`34df5e1d`, `d76b5440`, `4f5454a7`). The new file `apps/web/components/task/dockview-minimize-sync.ts` and the new CSS rule in `dockview-theme.css` go with them. No data migration, no backend changes, no persisted state — fully reversible.