### PR TITLE
feat(github): mobile-friendly /github page with sidebar drawer

### DIFF
--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -2,8 +2,10 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { IconBrandGithub } from "@tabler/icons-react";
+import { IconBrandGithub, IconMenu2 } from "@tabler/icons-react";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
+import { Button } from "@kandev/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { PageTopbar } from "@/components/page-topbar";
 import { useGitHubStatus } from "@/hooks/domains/github/use-github-status";
 import { usePRKeyToTasks } from "@/hooks/domains/github/use-pr-key-to-tasks";
@@ -50,12 +52,27 @@ type GitHubPageClientProps = {
   repositories: Repository[];
 };
 
-function PageHeader() {
+function PageHeader({ onOpenMobileSidebar }: { onOpenMobileSidebar?: () => void }) {
   return (
     <PageTopbar
       title="GitHub"
       subtitle="Pull requests and issues across your repos."
       icon={<IconBrandGithub className="h-4 w-4" />}
+      actions={
+        onOpenMobileSidebar && (
+          <Button
+            variant="outline"
+            size="icon-lg"
+            onClick={onOpenMobileSidebar}
+            className="md:hidden cursor-pointer"
+            data-testid="github-mobile-menu-button"
+            aria-label="Open GitHub filters"
+          >
+            <IconMenu2 className="h-4 w-4" />
+            <span className="sr-only">Open GitHub filters</span>
+          </Button>
+        )
+      }
     />
   );
 }
@@ -295,7 +312,10 @@ function AuthenticatedLayout({
   useAllWorkflowSnapshots(workspaceId ?? null);
   return (
     <div className="flex-1 flex min-h-0">
-      <aside className="w-60 border-r overflow-y-auto shrink-0">
+      <aside
+        className="hidden md:flex md:flex-col w-60 border-r overflow-y-auto shrink-0"
+        data-testid="github-presets-sidebar-inline"
+      >
         <PresetsSidebar
           selected={selection}
           onSelect={state.onSelect}
@@ -354,6 +374,7 @@ export function GitHubPageClient({
 }: GitHubPageClientProps) {
   const { status, loaded } = useGitHubStatus();
   const [launchPayload, setLaunchPayload] = useState<LaunchPayload | null>(null);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const state = useGitHubPageState();
   const { presets: storedPresets } = useGitHubActionPresets(workspaceId ?? null);
   const prPresets = useMemo(() => resolvePRPresets(storedPresets), [storedPresets]);
@@ -366,10 +387,25 @@ export function GitHubPageClient({
   const onStartTask = useCallback((payload: LaunchPayload) => setLaunchPayload(payload), []);
   const onCloseLaunch = useCallback(() => setLaunchPayload(null), []);
   const authed = !!status?.authenticated;
+  const onOpenMobileSidebar = useCallback(() => setMobileSidebarOpen(true), []);
+  // Close the mobile sheet after any sidebar selection. KindToggle clicks also
+  // route through onSelect — closing on every selection is acceptable UX since
+  // the user always wants to see the list after picking a kind or preset.
+  const onMobileSidebarSelect = useCallback(
+    (s: Parameters<typeof state.onSelect>[0]) => {
+      state.onSelect(s);
+      setMobileSidebarOpen(false);
+    },
+    [state],
+  );
+  const onMobileSaveCurrent = useCallback(() => {
+    setMobileSidebarOpen(false);
+    state.onOpenSaveDialog();
+  }, [state]);
 
   return (
     <div className="h-screen w-full flex flex-col bg-background">
-      <PageHeader />
+      <PageHeader onOpenMobileSidebar={loaded && authed ? onOpenMobileSidebar : undefined} />
       {!loaded && <div className="p-6 text-sm text-muted-foreground">Checking GitHub status…</div>}
       {loaded && !authed && (
         <div className="p-6 max-w-2xl">
@@ -385,6 +421,27 @@ export function GitHubPageClient({
           onStartTask={onStartTask}
         />
       )}
+      <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+        <SheetContent
+          side="right"
+          className="w-full sm:max-w-sm overflow-y-auto p-0"
+          data-testid="github-mobile-sidebar"
+        >
+          <SheetHeader className="px-4 pt-4 pb-2">
+            <SheetTitle>Filters</SheetTitle>
+          </SheetHeader>
+          <PresetsSidebar
+            selected={state.selection}
+            onSelect={onMobileSidebarSelect}
+            savedPresets={state.savedPresets}
+            onDeleteSaved={state.onDeleteSaved}
+            canSaveCurrent={state.canSaveCurrent}
+            onSaveCurrent={onMobileSaveCurrent}
+            prPresets={state.resolvedPrPresets}
+            issuePresets={state.resolvedIssuePresets}
+          />
+        </SheetContent>
+      </Sheet>
       <QuickTaskLauncher
         workspaceId={workspaceId ?? null}
         workflows={workflows}

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -69,7 +69,6 @@ function PageHeader({ onOpenMobileSidebar }: { onOpenMobileSidebar?: () => void 
             aria-label="Open GitHub filters"
           >
             <IconMenu2 className="h-4 w-4" />
-            <span className="sr-only">Open GitHub filters</span>
           </Button>
         )
       }
@@ -391,17 +390,16 @@ export function GitHubPageClient({
   // Close the mobile sheet after any sidebar selection. KindToggle clicks also
   // route through onSelect — closing on every selection is acceptable UX since
   // the user always wants to see the list after picking a kind or preset.
-  const onMobileSidebarSelect = useCallback(
-    (s: Parameters<typeof state.onSelect>[0]) => {
-      state.onSelect(s);
-      setMobileSidebarOpen(false);
-    },
-    [state],
-  );
-  const onMobileSaveCurrent = useCallback(() => {
+  // No useCallback: `state` is a fresh object every render, so memoizing
+  // these handlers would be deceptive — they'd still be new refs each pass.
+  const onMobileSidebarSelect = (s: Parameters<typeof state.onSelect>[0]) => {
+    state.onSelect(s);
+    setMobileSidebarOpen(false);
+  };
+  const onMobileSaveCurrent = () => {
     setMobileSidebarOpen(false);
     state.onOpenSaveDialog();
-  }, [state]);
+  };
 
   return (
     <div className="h-screen w-full flex flex-col bg-background">

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -24,6 +24,39 @@ type ListToolbarProps = {
   onRefresh: () => void;
 };
 
+function RefreshControls({
+  loading,
+  lastFetchedAt,
+  onRefresh,
+  showUpdatedPrefix,
+}: {
+  loading: boolean;
+  lastFetchedAt: Date | null;
+  onRefresh: () => void;
+  showUpdatedPrefix: boolean;
+}) {
+  return (
+    <>
+      {lastFetchedAt && !loading && (
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {showUpdatedPrefix ? "Updated " : ""}
+          {formatRelativeTime(lastFetchedAt.toISOString())}
+        </span>
+      )}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 cursor-pointer"
+        onClick={onRefresh}
+        disabled={loading}
+        title="Refresh"
+      >
+        <IconRefresh className={cn("h-4 w-4", loading && "animate-spin")} />
+      </Button>
+    </>
+  );
+}
+
 export function ListToolbar({
   title,
   count,
@@ -41,16 +74,28 @@ export function ListToolbar({
   const selectValue = repoFilter || ALL_REPOS;
   const dirty = customQuery !== committedQuery;
   return (
-    <div className="px-6 py-2.5 border-b shrink-0 flex items-center gap-3 flex-wrap">
-      <div className="flex items-baseline gap-2 min-w-0">
-        <h2 className="text-sm font-semibold truncate">{title}</h2>
-        <span className="text-xs text-muted-foreground tabular-nums">{loading ? "…" : count}</span>
+    <div className="px-4 sm:px-6 py-2.5 border-b shrink-0 flex flex-col md:flex-row md:items-center md:flex-wrap gap-2 md:gap-3">
+      <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-baseline gap-2 min-w-0 flex-1 md:flex-initial">
+          <h2 className="text-sm font-semibold truncate">{title}</h2>
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {loading ? "…" : count}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 md:hidden">
+          <RefreshControls
+            loading={loading}
+            lastFetchedAt={lastFetchedAt}
+            onRefresh={onRefresh}
+            showUpdatedPrefix={false}
+          />
+        </div>
       </div>
       <Select
         value={selectValue}
         onValueChange={(v) => onRepoFilterChange(v === ALL_REPOS ? "" : v)}
       >
-        <SelectTrigger className="w-[220px] h-8 cursor-pointer">
+        <SelectTrigger className="w-full md:w-[220px] h-8 cursor-pointer">
           <SelectValue placeholder="All repos" />
         </SelectTrigger>
         <SelectContent>
@@ -64,7 +109,7 @@ export function ListToolbar({
           ))}
         </SelectContent>
       </Select>
-      <div className="flex-1 min-w-[240px] relative">
+      <div className="w-full md:flex-1 md:min-w-[240px] relative">
         <Input
           value={customQuery}
           onChange={(e) => onCustomQueryChange(e.target.value)}
@@ -81,27 +126,18 @@ export function ListToolbar({
           className="h-8 pr-20"
         />
         {dirty && (
-          <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] uppercase tracking-wider text-muted-foreground hidden sm:inline">
             Press Enter
           </span>
         )}
       </div>
-      <div className="flex items-center gap-2 ml-auto">
-        {lastFetchedAt && !loading && (
-          <span className="text-xs text-muted-foreground whitespace-nowrap">
-            Updated {formatRelativeTime(lastFetchedAt.toISOString())}
-          </span>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 cursor-pointer"
-          onClick={onRefresh}
-          disabled={loading}
-          title="Refresh"
-        >
-          <IconRefresh className={cn("h-4 w-4", loading && "animate-spin")} />
-        </Button>
+      <div className="hidden md:flex items-center gap-2 md:ml-auto">
+        <RefreshControls
+          loading={loading}
+          lastFetchedAt={lastFetchedAt}
+          onRefresh={onRefresh}
+          showUpdatedPrefix
+        />
       </div>
     </div>
   );

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -77,7 +77,9 @@ export function ListToolbar({
     <div className="px-4 sm:px-6 py-2.5 border-b shrink-0 flex flex-col md:flex-row md:items-center md:flex-wrap gap-2 md:gap-3">
       <div className="flex items-center gap-2 min-w-0">
         <div className="flex items-baseline gap-2 min-w-0 flex-1 md:flex-initial">
-          <h2 className="text-sm font-semibold truncate">{title}</h2>
+          <h2 className="text-sm font-semibold truncate" data-testid="github-list-toolbar-title">
+            {title}
+          </h2>
           <span className="text-xs text-muted-foreground tabular-nums">
             {loading ? "…" : count}
           </span>

--- a/apps/web/e2e/pages/mobile-github-page.ts
+++ b/apps/web/e2e/pages/mobile-github-page.ts
@@ -1,0 +1,26 @@
+import { type Locator, type Page } from "@playwright/test";
+
+export class MobileGitHubPage {
+  readonly mobileMenuButton: Locator;
+  readonly mobileSidebar: Locator;
+  readonly inlineSidebar: Locator;
+  readonly toolbarTitle: Locator;
+
+  constructor(private page: Page) {
+    this.mobileMenuButton = page.getByTestId("github-mobile-menu-button");
+    this.mobileSidebar = page.getByTestId("github-mobile-sidebar");
+    this.inlineSidebar = page.getByTestId("github-presets-sidebar-inline");
+    this.toolbarTitle = page.locator("h2.text-sm.font-semibold").first();
+  }
+
+  async goto() {
+    await this.page.goto("/github");
+    // PageTopbar renders the "GitHub" breadcrumb — wait for it so the auth
+    // status fetch has resolved and the actions slot is mounted.
+    await this.page.getByText("GitHub", { exact: true }).first().waitFor({ state: "visible" });
+  }
+
+  presetByLabel(label: string): Locator {
+    return this.mobileSidebar.getByRole("button", { name: label });
+  }
+}

--- a/apps/web/e2e/pages/mobile-github-page.ts
+++ b/apps/web/e2e/pages/mobile-github-page.ts
@@ -15,9 +15,10 @@ export class MobileGitHubPage {
 
   async goto() {
     await this.page.goto("/github");
-    // PageTopbar renders the "GitHub" breadcrumb — wait for it so the auth
-    // status fetch has resolved and the actions slot is mounted.
-    await this.page.getByText("GitHub", { exact: true }).first().waitFor({ state: "visible" });
+    // The hamburger only mounts once auth has resolved on a mobile viewport —
+    // waiting on it is deterministic and avoids the ambiguity of matching
+    // "GitHub" text (which appears in the breadcrumb AND breadcrumb link aria).
+    await this.mobileMenuButton.waitFor({ state: "visible" });
   }
 
   presetByLabel(label: string): Locator {

--- a/apps/web/e2e/pages/mobile-github-page.ts
+++ b/apps/web/e2e/pages/mobile-github-page.ts
@@ -10,7 +10,7 @@ export class MobileGitHubPage {
     this.mobileMenuButton = page.getByTestId("github-mobile-menu-button");
     this.mobileSidebar = page.getByTestId("github-mobile-sidebar");
     this.inlineSidebar = page.getByTestId("github-presets-sidebar-inline");
-    this.toolbarTitle = page.locator("h2.text-sm.font-semibold").first();
+    this.toolbarTitle = page.getByTestId("github-list-toolbar-title");
   }
 
   async goto() {

--- a/apps/web/e2e/tests/github/mobile-github-sidebar.spec.ts
+++ b/apps/web/e2e/tests/github/mobile-github-sidebar.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "../../fixtures/test-base";
+import { MobileGitHubPage } from "../../pages/mobile-github-page";
+
+test.describe("Mobile /github sidebar", () => {
+  test("hamburger opens sheet and selecting a preset updates the toolbar", async ({
+    testPage,
+    apiClient,
+  }) => {
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 200,
+        title: "Mobile sidebar PR",
+        state: "open",
+        head_branch: "feat/mobile",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: "testorg",
+        repo_name: "testrepo",
+      },
+    ]);
+
+    const page = new MobileGitHubPage(testPage);
+    await page.goto();
+
+    // On a mobile viewport the inline desktop sidebar is hidden and the
+    // hamburger menu button is visible.
+    await expect(page.mobileMenuButton).toBeVisible();
+    await expect(page.inlineSidebar).toBeHidden();
+
+    // Default selection is the first PR preset.
+    await expect(page.toolbarTitle).toContainText("Review requested");
+
+    // Sheet is closed initially.
+    await expect(page.mobileSidebar).toBeHidden();
+
+    // Open the drawer.
+    await page.mobileMenuButton.tap();
+    await expect(page.mobileSidebar).toBeVisible();
+
+    // Tap a different preset → the drawer closes and the toolbar title
+    // reflects the new selection.
+    await page.presetByLabel("Mentions").tap();
+    await expect(page.mobileSidebar).toBeHidden();
+    await expect(page.toolbarTitle).toContainText("Mentions");
+  });
+});


### PR DESCRIPTION
## Summary
- The `/github` page rendered its 240px preset sidebar as a fixed inline `<aside>` at every viewport, leaving phones with almost no room for the PR/issue list and a `ListToolbar` whose 220px repo `Select` and 240px custom-query `Input` wrapped awkwardly.
- Below the Tailwind `md` breakpoint the inline aside is now hidden and a hamburger button in the page topbar opens the same `PresetsSidebar` inside a right-side `Sheet`, mirroring the existing kanban mobile pattern.
- `ListToolbar` reflows on narrow viewports: title + count + refresh stack on one row at the top, repo filter and custom-query input each become full-width below. Desktop layout is unchanged.

## Implementation notes
Used pure-CSS responsiveness rather than a JS `useIsMobile` check (`hidden md:flex` on the inline aside, `md:hidden` on the hamburger). The `Sheet` is always mounted but only opens when the mobile-only button is tapped, so there's no hydration mismatch and no FOUC. Selecting any item in the drawer — including the PR↔Issues kind toggle — closes it, which is a pragmatic UX trade-off (the user always wants to see the resulting list); the alternative of distinguishing kind-toggle clicks from preset clicks was rejected as over-engineered for v1.

The "Save current query" action wires through a wrapper that closes the `Sheet` first and then opens the existing `SavePresetDialog`, avoiding any stacked-overlay focus-trap conflict. The `RefreshControls` block in `ListToolbar` is extracted into a small inner helper to keep the mobile (in-line with title) and desktop (right-anchored) layouts DRY without tripping the duplicate-blocks lint rule.

## Test plan
- [x] Mobile (Pixel 5): hamburger visible, inline aside hidden — covered by `apps/web/e2e/tests/github/mobile-github-sidebar.spec.ts`.
- [x] Mobile: tap hamburger → Sheet opens; tap a preset → Sheet closes and toolbar title updates — same spec.
- [x] Mobile: PR/Issues kind toggle closes the drawer and switches the preset list — verified visually with a temporary screenshot spec (cleaned up before commit).
- [x] Mobile: "Save current query" closes the Sheet before opening `SavePresetDialog` (no stacking) — verified visually.
- [x] Mobile: long PR titles truncate with ellipsis; "Task ▼" launcher stays tappable — verified visually.
- [x] Desktop: inline 240px sidebar still renders, hamburger hidden, no regression — covered by `apps/web/e2e/tests/github/pr-list-task-indicator.spec.ts` (existing) and verified visually.
- [x] `pnpm --filter @kandev/web typecheck` — green.
- [x] `pnpm --filter @kandev/web lint` — 0 warnings.
- [x] `pnpm --filter @kandev/web test` — 263 files / 2179 tests pass / 4 skipped.
- [x] `pnpm exec playwright test tests/github/` — both specs green (chromium + mobile-chrome).
- [ ] CI to re-run the full E2E matrix.

## Risks & rollback
Changes are confined to three frontend files plus two new test files — no backend, API, schema, or dependency changes. The mobile experience is gated behind a `<md` media query, so desktop users see no change. Rollback is a single `git revert` of the two commits on this branch.