### PR TITLE
fix: reflect stale CI failures in progress bar

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -143,6 +143,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
+      - name: Point origin at base repo for Claude fetch
+        run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Claude Code Review (GITHUB_TOKEN fallback)
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ on:
     types: [opened, synchronize, ready_for_review, reopened, labeled]
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.ref }}
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -15,7 +15,7 @@ on:
     types: [opened, synchronize, reopened, closed, labeled]
 
 concurrency:
-  group: preview-env-${{ github.event.pull_request.number || github.ref }}
+  group: preview-env-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   # Don't cancel cleanup on close — let it finish destroying the sprite.
   cancel-in-progress: ${{ github.event.action != 'closed' }}
 

--- a/apps/web/components/github/pr-ci-popover.test.ts
+++ b/apps/web/components/github/pr-ci-popover.test.ts
@@ -67,6 +67,14 @@ describe("deriveAggregateCounts", () => {
       ),
     ).toEqual({ passed: 19, failed: 0, inProgress: 1 });
   });
+
+  it("reserves in-progress segment when pending state has no populated counts yet", () => {
+    expect(deriveAggregateCounts(makePR({ checks_state: "pending" }))).toEqual({
+      passed: 0,
+      failed: 0,
+      inProgress: 1,
+    });
+  });
 });
 
 describe("hasNoChecksAtAll", () => {

--- a/apps/web/components/github/pr-ci-popover.test.ts
+++ b/apps/web/components/github/pr-ci-popover.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { deriveAggregateCounts, hasNoChecksAtAll } from "./pr-ci-popover";
+import type { TaskPR } from "@/lib/types/github";
+
+function makePR(overrides: Partial<TaskPR> = {}): TaskPR {
+  return {
+    id: "id",
+    task_id: "task",
+    owner: "o",
+    repo: "r",
+    pr_number: 1,
+    pr_url: "",
+    pr_title: "Test PR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_login: "alice",
+    state: "open",
+    review_state: "",
+    checks_state: "",
+    mergeable_state: "",
+    review_count: 0,
+    pending_review_count: 0,
+    comment_count: 0,
+    unresolved_review_threads: 0,
+    checks_total: 0,
+    checks_passing: 0,
+    additions: 0,
+    deletions: 0,
+    created_at: "",
+    merged_at: null,
+    closed_at: null,
+    last_synced_at: null,
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+describe("deriveAggregateCounts", () => {
+  it("reserves failed segment when failure state has stale all-passing counts", () => {
+    expect(
+      deriveAggregateCounts(
+        makePR({
+          checks_state: "failure",
+          checks_total: 20,
+          checks_passing: 20,
+        }),
+      ),
+    ).toEqual({ passed: 19, failed: 1, inProgress: 0 });
+  });
+
+  it("reserves failed segment when failure state has no populated counts yet", () => {
+    expect(deriveAggregateCounts(makePR({ checks_state: "failure" }))).toEqual({
+      passed: 0,
+      failed: 1,
+      inProgress: 0,
+    });
+  });
+
+  it("reserves in-progress segment when pending state has stale all-passing counts", () => {
+    expect(
+      deriveAggregateCounts(
+        makePR({
+          checks_state: "pending",
+          checks_total: 20,
+          checks_passing: 20,
+        }),
+      ),
+    ).toEqual({ passed: 19, failed: 0, inProgress: 1 });
+  });
+});
+
+describe("hasNoChecksAtAll", () => {
+  it("does not hide failed status just because aggregate counts are zero", () => {
+    expect(hasNoChecksAtAll(makePR({ checks_state: "failure" }), null, false)).toBe(false);
+  });
+
+  it("hides checks only when status and counts are empty", () => {
+    expect(hasNoChecksAtAll(makePR(), null, false)).toBe(true);
+  });
+});

--- a/apps/web/components/github/pr-ci-popover.tsx
+++ b/apps/web/components/github/pr-ci-popover.tsx
@@ -42,23 +42,41 @@ function countForBucket(counts: CountsView, kind: CheckBucket): number {
   return counts.failed;
 }
 
-function deriveAggregateCounts(pr: TaskPR): CountsView {
+export function deriveAggregateCounts(pr: TaskPR): CountsView {
   // Pre-load: if checks_total is populated, derive a coarse split using
   // checks_state to attribute the "non-passing" remainder. This is good
-  // enough for the instant render — the lazy PRFeedback fetch refines.
-  const total = pr.checks_total;
-  const passing = pr.checks_passing;
+  // enough for the instant render — the lazy PRFeedback fetch refines. When
+  // counts are stale, trust the status and reserve a visible non-passing slice.
+  const total = Math.max(0, pr.checks_total);
+  const passing = Math.min(Math.max(0, pr.checks_passing), total);
   const remaining = Math.max(0, total - passing);
   if (pr.checks_state === "failure") {
-    return { passed: passing, failed: remaining, inProgress: 0 };
+    const failed = remaining > 0 ? remaining : 1;
+    const passed = total > 0 ? Math.max(0, total - failed) : 0;
+    return { passed, failed, inProgress: 0 };
   }
   if (pr.checks_state === "pending") {
-    return { passed: passing, failed: 0, inProgress: remaining };
+    const inProgress = remaining > 0 ? remaining : 1;
+    const passed = total > 0 ? Math.max(0, total - inProgress) : 0;
+    return { passed, failed: 0, inProgress };
   }
   if (pr.checks_state === "success") {
     return { passed: total, failed: 0, inProgress: 0 };
   }
   return { passed: passing, failed: 0, inProgress: remaining };
+}
+
+export function hasNoChecksAtAll(
+  pr: TaskPR,
+  feedback: { checks?: CheckRun[] } | null,
+  isFetching: boolean,
+): boolean {
+  return (
+    !isFetching &&
+    pr.checks_state === "" &&
+    pr.checks_total === 0 &&
+    (!feedback || (feedback.checks?.length ?? 0) === 0)
+  );
 }
 
 function PRCIPopoverHeader({ pr }: { pr: TaskPR }) {
@@ -328,9 +346,7 @@ function PRChecksSection({
   const counts = precise ?? aggregateCounts;
   // "No checks at all": the lazy fetch has settled (not isFetching) and there
   // are no checks anywhere — neither in PRFeedback nor in the aggregate.
-  const noChecksAtAll =
-    !isFetching && pr.checks_total === 0 && (!feedback || (feedback.checks?.length ?? 0) === 0);
-  if (noChecksAtAll) {
+  if (hasNoChecksAtAll(pr, feedback, isFetching)) {
     return (
       <div data-testid="pr-checks-section" className="flex flex-col">
         <div data-testid="pr-checks-empty" className="px-1 py-2 text-xs text-muted-foreground">


### PR DESCRIPTION
Stale PR check aggregates could show a green CI progress bar while the rollup status was already failed. The popover now trusts the rollup status when aggregate counts are inconsistent, so failures and pending checks remain visible before live check details load.

## Validation

- `make fmt`
- `NODENV_VERSION=24.12.0 pnpm --filter @kandev/web test -- --run components/github/pr-ci-popover.test.ts lib/github/check-buckets.test.ts`
- `NODENV_VERSION=24.12.0 make typecheck`
- `NODENV_VERSION=24.12.0 make lint-web`
- `NODENV_VERSION=24.12.0 make test` (backend and web passed; existing CLI `src/release-config.test.ts` failed: `Dockerfile: PNPM_VERSION must be pinned`)
- `NODENV_VERSION=24.12.0 make lint` (existing backend goconst failure in `internal/jira/cloud_client.go`)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.