### PR TITLE
feat(task): auto-select repo default branch when attaching a repository

### DIFF
--- a/apps/web/components/task-create-dialog-helpers.multi-repo.test.ts
+++ b/apps/web/components/task-create-dialog-helpers.multi-repo.test.ts
@@ -191,6 +191,48 @@ describe("buildRepositoriesPayload — local executor branch split (edge cases)"
   });
 });
 
+describe("buildRepositoriesPayload — non-local executor uses repo default_branch as base", () => {
+  it("workspace repo with non-main default_branch: base_branch reflects the repo default", () => {
+    // The autoselect in the chip pre-fills row.branch with default_branch (via
+    // preferredDefaultBranch). By the time submit runs, row.branch already holds
+    // the default. This test verifies the submit payload mirrors that value.
+    const payload = buildRepositoriesPayload({
+      useGitHubUrl: false,
+      githubUrl: "",
+      githubBranch: "",
+      githubPrHeadBranch: null,
+      repositories: [{ key: "r0", repositoryId: "repo-1", branch: "develop" }],
+      discoveredRepositories: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      workspaceRepositories: [{ id: "repo-1", default_branch: "develop" }] as any,
+      isLocalExecutor: false,
+    });
+    expect(payload).toEqual([
+      { repository_id: "repo-1", base_branch: "develop", checkout_branch: undefined },
+    ]);
+  });
+
+  it("workspace repo with empty default_branch falls back to hardcoded autoselect", () => {
+    // When default_branch is unset (legacy repos not yet probed by backend),
+    // the chip falls back to localStorage / main / master. row.branch ends up
+    // as whatever that fallback picks. Payload just mirrors row.branch.
+    const payload = buildRepositoriesPayload({
+      useGitHubUrl: false,
+      githubUrl: "",
+      githubBranch: "",
+      githubPrHeadBranch: null,
+      repositories: [{ key: "r0", repositoryId: "repo-1", branch: "main" }],
+      discoveredRepositories: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      workspaceRepositories: [{ id: "repo-1", default_branch: "" }] as any,
+      isLocalExecutor: false,
+    });
+    expect(payload).toEqual([
+      { repository_id: "repo-1", base_branch: "main", checkout_branch: undefined },
+    ]);
+  });
+});
+
 describe("buildRepositoriesPayload — single-row and URL mode", () => {
   it("URL mode produces a single github_url entry and ignores the rows", () => {
     const payload = buildRepositoriesPayload({

--- a/apps/web/components/task-create-dialog-repo-chips.test.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.test.tsx
@@ -344,6 +344,63 @@ describe("RepoChipsRow", () => {
     });
   });
 
+  it("non-local-executor row autoselects the repo's default_branch", () => {
+    // When a workspace repo has default_branch="develop" and the row has no branch
+    // yet, the chip must call onBranchChange("develop") — not "main" from the
+    // hardcoded fallback. This verifies the ChipsList computes repoDefaultBranch
+    // and passes it as preferredDefaultBranch to RepoChip.
+    mockBranches.value = {
+      branches: [
+        { name: "main", type: "local" } as Branch,
+        { name: "develop", type: "local" } as Branch,
+      ],
+      isLoading: false,
+    };
+    const onRowBranchChange = vi.fn();
+    const repoWithDevelopDefault: Repository = {
+      ...makeRepo(REPO_FRONT_ID, "frontend"),
+      default_branch: "develop",
+    };
+    renderInProvider(
+      <RepoChipsRow
+        fs={makeFs({ repositories: [row({ key: "r0", repositoryId: REPO_FRONT_ID })] })}
+        repositories={[repoWithDevelopDefault]}
+        isTaskStarted={false}
+        workspaceId="ws-1"
+        onRowRepositoryChange={NOOP}
+        onRowBranchChange={onRowBranchChange}
+        isLocalExecutor={false}
+      />,
+    );
+    expect(onRowBranchChange).toHaveBeenCalledWith("r0", "develop");
+    mockBranches.value = { branches: [], isLoading: false };
+  });
+
+  it("non-local-executor row with empty default_branch falls back to main", () => {
+    mockBranches.value = {
+      branches: [{ name: "main", type: "local" } as Branch],
+      isLoading: false,
+    };
+    const onRowBranchChange = vi.fn();
+    const repoNoDefault: Repository = {
+      ...makeRepo(REPO_FRONT_ID, "frontend"),
+      default_branch: "",
+    };
+    renderInProvider(
+      <RepoChipsRow
+        fs={makeFs({ repositories: [row({ key: "r0", repositoryId: REPO_FRONT_ID })] })}
+        repositories={[repoNoDefault]}
+        isTaskStarted={false}
+        workspaceId="ws-1"
+        onRowRepositoryChange={NOOP}
+        onRowBranchChange={onRowBranchChange}
+        isLocalExecutor={false}
+      />,
+    );
+    expect(onRowBranchChange).toHaveBeenCalledWith("r0", "main");
+    mockBranches.value = { branches: [], isLoading: false };
+  });
+
   // Regression: remote branches must keep their "origin/" prefix so users
   // can distinguish a local "main" from "origin/main". A prior rewrite
   // dropped the prefix, producing two indistinguishable rows.

--- a/apps/web/components/task-create-dialog-repo-chips.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.tsx
@@ -280,32 +280,38 @@ function ChipsList({
 }) {
   return (
     <>
-      {fs.repositories.map((row) => (
-        <RepoChip
-          key={row.key}
-          row={row}
-          workspaceId={workspaceId}
-          repositories={repositories}
-          discoveredRepositories={fs.discoveredRepositories}
-          excludedRepoIds={collectUsedRepoIds(fs.repositories, row.key)}
-          branchLocked={branchLocked}
-          // For local-executor rows, seed row.branch with the workspace's
-          // current branch via this prop. Non-local rows leave it undefined
-          // and fall back to the existing last-used / preferred-default
-          // autoselect path.
-          preferredDefaultBranch={isLocalExecutor ? fs.currentLocalBranch : undefined}
-          preferredDefaultBranchLoading={isLocalExecutor ? fs.currentLocalBranchLoading : false}
-          branchPrefix={computeBranchPrefix({
-            isLocalExecutor,
-            rowBranch: row.branch,
-            currentLocalBranch: fs.currentLocalBranch,
-            freshBranchEnabled: !!fs.freshBranchEnabled,
-          })}
-          onRepositoryChange={(value) => onRowRepositoryChange(row.key, value)}
-          onBranchChange={(value) => onRowBranchChange(row.key, value)}
-          onRemove={() => fs.removeRepository(row.key)}
-        />
-      ))}
+      {fs.repositories.map((row) => {
+        const repoDefaultBranch = isLocalExecutor
+          ? undefined
+          : repositories.find((r) => r.id === row.repositoryId)?.default_branch ||
+            fs.discoveredRepositories.find((d) => d.path === row.localPath)?.default_branch ||
+            undefined;
+        return (
+          <RepoChip
+            key={row.key}
+            row={row}
+            workspaceId={workspaceId}
+            repositories={repositories}
+            discoveredRepositories={fs.discoveredRepositories}
+            excludedRepoIds={collectUsedRepoIds(fs.repositories, row.key)}
+            branchLocked={branchLocked}
+            // For local-executor rows, seed row.branch with the workspace's current branch.
+            // For non-local rows, use the repo's default_branch so newly attached repos
+            // start on the correct integration branch instead of last-used or hardcoded main/master.
+            preferredDefaultBranch={isLocalExecutor ? fs.currentLocalBranch : repoDefaultBranch}
+            preferredDefaultBranchLoading={isLocalExecutor ? fs.currentLocalBranchLoading : false}
+            branchPrefix={computeBranchPrefix({
+              isLocalExecutor,
+              rowBranch: row.branch,
+              currentLocalBranch: fs.currentLocalBranch,
+              freshBranchEnabled: !!fs.freshBranchEnabled,
+            })}
+            onRepositoryChange={(value) => onRowRepositoryChange(row.key, value)}
+            onBranchChange={(value) => onRowBranchChange(row.key, value)}
+            onRemove={() => fs.removeRepository(row.key)}
+          />
+        );
+      })}
       {freshBranchToggle}
       <Tooltip>
         <TooltipTrigger asChild>


### PR DESCRIPTION
When a user attaches a workspace repository to a task, the branch chip previously defaulted to the last-used branch from localStorage or a hardcoded preference (main → master), ignoring the repository's actual default branch. This caused wrong branch selection when a repo's integration branch differs from main (e.g. `development`, `trunk`). The chip now seeds from `repo.default_branch` for non-local-executor rows, so the correct integration branch is pre-selected immediately.

## Important Changes

- `ChipsList` in `task-create-dialog-repo-chips.tsx` computes `repoDefaultBranch` per row from workspace repos or discovered repos and passes it as `preferredDefaultBranch` to `RepoChip`
- Priority chain: `repo.default_branch` → localStorage last-used → hardcoded main/master
- Local executor rows unchanged (`currentLocalBranch` still wins)
- Edit mode safe: existing `row.branch` guard prevents overwriting an already-set branch on dialog open

## Validation

- `pnpm vitest run task-create-dialog-repo-chips task-create-dialog-helpers.multi-repo` — 31 tests pass
- `pnpm --filter @kandev/web typecheck` — clean

## Checklist

- [ ] Tests added/updated
- [ ] No breaking changes
- [ ] Self-reviewed