### PR TITLE
feat(web): move automations entry above agents in settings sidebar

### DIFF
--- a/apps/web/components/settings/settings-app-sidebar.tsx
+++ b/apps/web/components/settings/settings-app-sidebar.tsx
@@ -325,6 +325,23 @@ export function SettingsAppSidebar() {
                 <GeneralSidebarSection pathname={pathname} />
                 <WorkspacesSidebarSection pathname={pathname} workspaces={workspaces} />
                 <IntegrationsSidebarSection pathname={pathname} />
+
+                {/* Automations */}
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={
+                      pathname.startsWith("/settings/automations") ||
+                      pathname.includes("/automations")
+                    }
+                  >
+                    <Link href="/settings/automations">
+                      <IconBolt className="h-4 w-4" />
+                      <span>Automations</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+
                 <AgentsSidebarSection pathname={pathname} agents={agents} />
 
                 {/* Prompts */}
@@ -348,22 +365,6 @@ export function SettingsAppSidebar() {
                 </SidebarMenuItem>
 
                 <ExecutorsSidebarSection pathname={pathname} executors={executors} />
-
-                {/* Automations */}
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    asChild
-                    isActive={
-                      pathname.startsWith("/settings/automations") ||
-                      pathname.includes("/automations")
-                    }
-                  >
-                    <Link href="/settings/automations">
-                      <IconBolt className="h-4 w-4" />
-                      <span>Automations</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
 
                 <SecretsSidebarSection pathname={pathname} />
 


### PR DESCRIPTION
## Summary

Automations was buried near the bottom of the settings sidebar between Executors and Secrets, where the long Agents/Executors profile sub-lists pushed it offscreen. Moving it directly under Integrations puts it in the top group of primary navigation entries so it stays visible without scrolling.

## Validation

- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated
- [ ] Linked to issue


---
_Generated by [Claude Code](https://claude.ai/code/session_012dA7nNecaDCYwzWCBs1FsV)_