### PR TITLE
feat(web): add Share to session tab context menu

### DIFF
--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -29,6 +29,8 @@ import {
   isSessionDeletable as isDeletable,
   isSessionResumable as isResumable,
 } from "@/hooks/domains/session/use-session-actions";
+import { shareableSessionStateClient } from "@/components/task/share/share-button";
+import { ShareDialog } from "@/components/task/share/share-dialog";
 import type { TaskSessionState } from "@/lib/types/http";
 import { isSessionActive } from "./session-sort";
 import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
@@ -163,13 +165,17 @@ function DeleteSessionDialog({
 function SessionContextMenuItems({
   sessionState,
   isPrimary,
+  canShare,
   actions,
   onDelete,
+  onShare,
 }: {
   sessionState: TaskSessionState | null;
   isPrimary: boolean;
+  canShare: boolean;
   actions: ReturnType<typeof useSessionTabActions>;
   onDelete: () => void;
+  onShare: () => void;
 }) {
   return (
     <ContextMenuContent>
@@ -196,6 +202,14 @@ function SessionContextMenuItems({
           Delete
         </ContextMenuItem>
       )}
+      {canShare && (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem className="cursor-pointer" onSelect={onShare}>
+            Share
+          </ContextMenuItem>
+        </>
+      )}
       <ContextMenuSeparator />
       <ContextMenuItem className="cursor-pointer" onSelect={actions.handleCloseOthers}>
         Close Others
@@ -216,7 +230,9 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const actions = useSessionTabActions(sessionId, taskId, api, containerApi);
   const onDoubleClick = useTabMaximizeOnDoubleClick(api);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const [isActive, setIsActive] = useState(api.isActive);
+  const canShare = !!taskId && !!sessionId && shareableSessionStateClient(sessionState);
 
   useEffect(() => {
     const disposable = api.onDidActiveChange((e) => setIsActive(e.isActive));
@@ -264,8 +280,10 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
         <SessionContextMenuItems
           sessionState={sessionState}
           isPrimary={isPrimary}
+          canShare={canShare}
           actions={actions}
           onDelete={() => setConfirmDelete(true)}
+          onShare={() => setShareOpen(true)}
         />
       </ContextMenu>
       <DeleteSessionDialog
@@ -275,6 +293,14 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
         sessionCount={sessionCount}
         onConfirm={actions.handleDelete}
       />
+      {taskId && sessionId && (
+        <ShareDialog
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+          taskId={taskId}
+          sessionId={sessionId}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
Right-clicking an agent tab now offers Share alongside the existing lifecycle actions, so users can publish a session without first reaching for the small icon button above the chat input.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2t2Ex9SmdgUEocDUbrQLf)_