### PR TITLE
fix(agentctl): allow native ACP CLIs in probe allowlist

### DIFF
--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -1,26 +1,16 @@
 package utility
 
 import (
+	"maps"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
-func TestResolveProbeCommand_AllowsNativeACPBinaries(t *testing.T) {
+func TestResolveProbeCommand_AllowsEveryListedBinary(t *testing.T) {
 	t.Parallel()
 
-	allowed := []string{
-		"auggie",
-		"cursor-agent",
-		"kimi",
-		"kiro-cli-chat",
-		"mock-agent",
-		"npx",
-		"omp",
-		"opencode",
-		"qodercli",
-		"traecli",
-	}
-	for _, name := range allowed {
+	for _, name := range slices.Sorted(maps.Keys(allowedProbeCommands)) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if got := resolveProbeCommand(name); got != name {

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -1,6 +1,45 @@
 package utility
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveProbeCommand_AllowsNativeACPBinaries(t *testing.T) {
+	t.Parallel()
+
+	allowed := []string{
+		"auggie",
+		"cursor-agent",
+		"kimi",
+		"kiro-cli-chat",
+		"mock-agent",
+		"npx",
+		"omp",
+		"opencode",
+		"qodercli",
+		"traecli",
+	}
+	for _, name := range allowed {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveProbeCommand(name); got != name {
+				t.Fatalf("resolveProbeCommand(%q) = %q, want %q", name, got, name)
+			}
+			path := filepath.Join("/usr/local/bin", name)
+			if got := resolveProbeCommand(path); got != name {
+				t.Fatalf("resolveProbeCommand(%q) = %q, want %q", path, got, name)
+			}
+		})
+	}
+}
+
+func TestResolveProbeCommand_RejectsUnknown(t *testing.T) {
+	t.Parallel()
+	if got := resolveProbeCommand("claude"); got != "" {
+		t.Fatalf("resolveProbeCommand(claude) = %q, want empty", got)
+	}
+}
 
 func TestSanitizeInferenceChunk_DropsPiVersionBanner(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Native-binary ACP agents (cursor-acp, kimi-acp, kiro-acp, qoder-acp, trae-acp) could not be probed or used for one-shot inference because agentctl only allowed npx, opencode, auggie, and mock-agent on the CodeQL-safe exec allowlist. This extends that list so capability discovery and inference work for those CLIs.

## Validation

- `env -u GOROOT make -C apps/backend fmt`
- `env -u GOROOT make -C apps/backend test lint`
- `env -u GOROOT go test ./internal/agentctl/server/utility/... -run TestResolveProbeCommand`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)