### PR TITLE
fix(web): make PR CI status reachable on mobile via tap-activated drawer

### DIFF
--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { StateProvider } from "@/components/state-provider";
+import { ToastProvider } from "@/components/toast-provider";
+import { PRStatusChip } from "./pr-status-chip";
+import type { AppState } from "@/lib/state/store";
+import type { TaskPR } from "@/lib/types/github";
+
+const isMobileMock = vi.fn(() => false);
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => isMobileMock(),
+}));
+
+vi.mock("@/lib/api/domains/github-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/domains/github-api")>();
+  return {
+    ...actual,
+    getPRFeedback: vi.fn().mockResolvedValue(null),
+    listWorkspaceTaskPRs: vi.fn().mockResolvedValue({ task_prs: {} }),
+  };
+});
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: vi.fn(() => null),
+}));
+
+function renderWithStore(initialState: Partial<AppState> | undefined, ui: ReactNode) {
+  return render(
+    <StateProvider initialState={initialState}>
+      <ToastProvider>
+        <TooltipProvider>{ui}</TooltipProvider>
+      </ToastProvider>
+    </StateProvider>,
+  );
+}
+
+function makePR(overrides: Partial<TaskPR> = {}): TaskPR {
+  return {
+    id: "pr-id",
+    task_id: "task-1",
+    owner: "acme",
+    repo: "demo",
+    pr_number: 42,
+    pr_url: "https://github.com/acme/demo/pull/42",
+    pr_title: "Test PR",
+    head_branch: "feat",
+    base_branch: "main",
+    author_login: "alice",
+    state: "open",
+    review_state: "approved",
+    checks_state: "success",
+    mergeable_state: "clean",
+    review_count: 1,
+    pending_review_count: 0,
+    comment_count: 0,
+    unresolved_review_threads: 0,
+    checks_total: 2,
+    checks_passing: 2,
+    additions: 0,
+    deletions: 0,
+    created_at: "",
+    merged_at: null,
+    closed_at: null,
+    last_synced_at: null,
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  isMobileMock.mockReturnValue(false);
+});
+
+afterEach(() => {
+  cleanup();
+  isMobileMock.mockReset();
+});
+
+const CHIP_TESTID = "pr-status-chip";
+const seededState: Partial<AppState> = {
+  taskPRs: { byTaskId: { "task-1": [makePR()] } },
+};
+
+describe("PRStatusChip", () => {
+  it("returns null when the task has no PR", () => {
+    renderWithStore(undefined, <PRStatusChip taskId="missing" />);
+    expect(screen.queryByTestId(CHIP_TESTID)).toBeNull();
+  });
+
+  describe("desktop branch", () => {
+    beforeEach(() => isMobileMock.mockReturnValue(false));
+
+    it("renders the chip button without a Drawer", () => {
+      renderWithStore(seededState, <PRStatusChip taskId="task-1" />);
+      const chip = screen.getByTestId(CHIP_TESTID);
+      expect(chip).toBeTruthy();
+      // The chip's HoverCard popover is hover-only on desktop; clicking the
+      // chip must not surface the mobile Drawer testid.
+      act(() => {
+        fireEvent.click(chip);
+      });
+      expect(document.querySelector("[data-testid='pr-status-chip-drawer']")).toBeNull();
+    });
+
+    it("exposes the canonical data attributes that desktop tests rely on", () => {
+      renderWithStore(seededState, <PRStatusChip taskId="task-1" />);
+      const chip = screen.getByTestId(CHIP_TESTID);
+      expect(chip.getAttribute("data-pr-number")).toBe("42");
+      expect(chip.getAttribute("data-pr-state")).toBe("open");
+      expect(chip.getAttribute("data-status")).toBe("passed");
+      expect(chip.getAttribute("data-pr-ready-to-merge")).toBe("true");
+    });
+  });
+
+  describe("mobile branch", () => {
+    beforeEach(() => isMobileMock.mockReturnValue(true));
+
+    it("renders the chip closed and opens the drawer on click", () => {
+      renderWithStore(seededState, <PRStatusChip taskId="task-1" />);
+      // Drawer must not be in the DOM before the user taps the chip — relied
+      // on by the e2e spec's `toHaveCount(0)` precondition.
+      expect(document.querySelector("[data-testid='pr-status-chip-drawer']")).toBeNull();
+
+      const chip = screen.getByTestId(CHIP_TESTID);
+      act(() => {
+        fireEvent.click(chip);
+      });
+
+      const drawer = document.querySelector("[data-testid='pr-status-chip-drawer']");
+      expect(drawer).not.toBeNull();
+      // Inner popover body + close button render inside the drawer.
+      expect(document.querySelector("[data-testid='pr-topbar-popover-inner']")).not.toBeNull();
+      expect(document.querySelector("[data-testid='pr-status-chip-drawer-close']")).not.toBeNull();
+    });
+
+    it("preserves the same data attributes as the desktop chip", () => {
+      renderWithStore(seededState, <PRStatusChip taskId="task-1" />);
+      const chip = screen.getByTestId(CHIP_TESTID);
+      expect(chip.getAttribute("data-pr-number")).toBe("42");
+      expect(chip.getAttribute("data-pr-state")).toBe("open");
+      expect(chip.getAttribute("data-status")).toBe("passed");
+      expect(chip.getAttribute("data-pr-ready-to-merge")).toBe("true");
+    });
+
+    it("reflects a failed PR with data-status='failed'", () => {
+      renderWithStore(
+        { taskPRs: { byTaskId: { "task-1": [makePR({ checks_state: "failure" })] } } },
+        <PRStatusChip taskId="task-1" />,
+      );
+      expect(screen.getByTestId(CHIP_TESTID).getAttribute("data-status")).toBe("failed");
+    });
+
+    // NOTE: vaul's close animation depends on CSS transition events that
+    // happy-dom does not fire, so the drawer never unmounts in this env.
+    // The mobile-pr-ci-chip.spec.ts e2e covers close-button dismissal in a
+    // real browser.
+
+    it("renders the no-checks empty state in the drawer when the PR has no checks", () => {
+      renderWithStore(
+        {
+          taskPRs: {
+            byTaskId: {
+              "task-1": [
+                makePR({
+                  checks_state: "",
+                  checks_total: 0,
+                  checks_passing: 0,
+                  review_state: "",
+                  mergeable_state: "",
+                }),
+              ],
+            },
+          },
+        },
+        <PRStatusChip taskId="task-1" />,
+      );
+      act(() => {
+        fireEvent.click(screen.getByTestId(CHIP_TESTID));
+      });
+      expect(document.querySelector("[data-testid='pr-checks-empty']")).not.toBeNull();
+    });
+  });
+});

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -10,7 +10,14 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@kandev/ui/hover-card";
-import { Drawer, DrawerClose, DrawerContent, DrawerHeader, DrawerTitle } from "@kandev/ui/drawer";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@kandev/ui/drawer";
 import { Button } from "@kandev/ui/button";
 import { useTaskPR } from "@/hooks/domains/github/use-task-pr";
 import { usePRFeedbackBackgroundSync } from "@/hooks/domains/github/use-pr-ci-popover";
@@ -132,13 +139,22 @@ function PRStatusChipDrawer({ pr }: { pr: TaskPR }) {
   const [open, setOpen] = useState(false);
   return (
     <Drawer open={open} onOpenChange={setOpen}>
-      <button type="button" onClick={() => setOpen(true)} {...chipButtonAttrs(pr, status)}>
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        {...chipButtonAttrs(pr, status)}
+      >
         <IconChecklist className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
         <ChipStatusGlyph status={status} />
       </button>
       <DrawerContent data-testid="pr-status-chip-drawer" className="max-h-[80vh] flex flex-col">
         <DrawerHeader className="flex flex-row items-center justify-between border-b py-2">
           <DrawerTitle className="text-sm">PR #{pr.pr_number}</DrawerTitle>
+          <DrawerDescription className="sr-only">
+            Pull request CI status, reviews, and checks summary.
+          </DrawerDescription>
           <DrawerClose asChild>
             <Button
               data-testid="pr-status-chip-drawer-close"

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -1,18 +1,22 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import {
   IconCircleCheckFilled,
   IconCircleXFilled,
   IconChecklist,
   IconLoader2,
   IconPointFilled,
+  IconX,
 } from "@tabler/icons-react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@kandev/ui/hover-card";
+import { Drawer, DrawerClose, DrawerContent, DrawerHeader, DrawerTitle } from "@kandev/ui/drawer";
+import { Button } from "@kandev/ui/button";
 import { useTaskPR } from "@/hooks/domains/github/use-task-pr";
 import { usePRFeedbackBackgroundSync } from "@/hooks/domains/github/use-pr-ci-popover";
 import { PRCIPopover } from "@/components/github/pr-ci-popover";
 import { isPRAwaitingReview, isPRReadyToMerge } from "@/components/github/pr-task-icon";
+import { useIsMobile } from "@/hooks/use-mobile";
 import type { TaskPR } from "@/lib/types/github";
 
 const HOVER_OPEN_DELAY_MS = 150;
@@ -46,8 +50,11 @@ function chipStatus(pr: TaskPR): ChipStatus {
  *   merged  → purple dot
  *   neutral → muted dot
  *
- * Hovering opens the full PRCIPopover anchored to the top edge so the card
- * expands upward (the chip sits just above the chat input).
+ * Desktop: hovering opens the full PRCIPopover anchored to the top edge so the
+ * card expands upward (the chip sits just above the chat input).
+ *
+ * Mobile: tapping opens the same popover content inside a bottom-sheet Drawer
+ * — hover is unreachable on touch devices.
  *
  * Returns null when the task has no PR yet.
  */
@@ -60,23 +67,41 @@ export function PRStatusChip({ taskId }: { taskId: string | null }) {
   return <PRStatusChipInner pr={pr} />;
 }
 
+type ChipButtonAttrs = {
+  "data-testid": "pr-status-chip";
+  "data-pr-number": number;
+  "data-pr-state": string;
+  "data-status": ChipStatus;
+  "data-pr-ready-to-merge": "true" | "false";
+  "aria-label": string;
+  className: string;
+};
+
+function chipButtonAttrs(pr: TaskPR, status: ChipStatus): ChipButtonAttrs {
+  return {
+    "data-testid": "pr-status-chip",
+    "data-pr-number": pr.pr_number,
+    "data-pr-state": pr.state,
+    "data-status": status,
+    "data-pr-ready-to-merge": isPRReadyToMerge(pr) ? "true" : "false",
+    "aria-label": `Pull request #${pr.pr_number} CI status`,
+    className: "cursor-pointer inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-xs",
+  };
+}
+
 function PRStatusChipInner({ pr }: { pr: TaskPR }) {
+  const isMobile = useIsMobile();
+  if (isMobile) return <PRStatusChipDrawer pr={pr} />;
+  return <PRStatusChipHoverCard pr={pr} />;
+}
+
+function PRStatusChipHoverCard({ pr }: { pr: TaskPR }) {
   const status = chipStatus(pr);
   const triggerRef = useRef<HTMLButtonElement>(null);
   return (
     <HoverCard openDelay={HOVER_OPEN_DELAY_MS} closeDelay={HOVER_CLOSE_DELAY_MS}>
       <HoverCardTrigger asChild>
-        <button
-          ref={triggerRef}
-          type="button"
-          data-testid="pr-status-chip"
-          data-pr-number={pr.pr_number}
-          data-pr-state={pr.state}
-          data-status={status}
-          data-pr-ready-to-merge={isPRReadyToMerge(pr) ? "true" : "false"}
-          aria-label={`Pull request #${pr.pr_number} CI status`}
-          className="cursor-pointer inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-xs"
-        >
+        <button ref={triggerRef} type="button" {...chipButtonAttrs(pr, status)}>
           <IconChecklist className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           <ChipStatusGlyph status={status} />
         </button>
@@ -99,6 +124,38 @@ function PRStatusChipInner({ pr }: { pr: TaskPR }) {
         <PRCIPopover pr={pr} enabled={true} />
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+function PRStatusChipDrawer({ pr }: { pr: TaskPR }) {
+  const status = chipStatus(pr);
+  const [open, setOpen] = useState(false);
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <button type="button" onClick={() => setOpen(true)} {...chipButtonAttrs(pr, status)}>
+        <IconChecklist className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+        <ChipStatusGlyph status={status} />
+      </button>
+      <DrawerContent data-testid="pr-status-chip-drawer" className="max-h-[80vh] flex flex-col">
+        <DrawerHeader className="flex flex-row items-center justify-between border-b py-2">
+          <DrawerTitle className="text-sm">PR #{pr.pr_number}</DrawerTitle>
+          <DrawerClose asChild>
+            <Button
+              data-testid="pr-status-chip-drawer-close"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Close PR status"
+              className="cursor-pointer"
+            >
+              <IconX className="h-4 w-4" />
+            </Button>
+          </DrawerClose>
+        </DrawerHeader>
+        <div className="flex-1 min-h-0 overflow-y-auto p-3" data-vaul-no-drag>
+          <PRCIPopover pr={pr} enabled={open} />
+        </div>
+      </DrawerContent>
+    </Drawer>
   );
 }
 

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -477,7 +477,7 @@ export class SessionPage {
     return this.page.getByTestId("pr-approve-button");
   }
 
-  // --- CI hover popover accessors (kept here so the spec stays declarative) ---
+  // --- PR CI accessors: desktop hover popover + chip + mobile chip drawer ---
 
   /** The single-PR hover popover content (visible after hovering the topbar button). */
   prTopbarPopover(): Locator {

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -484,6 +484,32 @@ export class SessionPage {
     return this.page.getByTestId("pr-topbar-popover");
   }
 
+  /** Compact PR/CI status chip rendered in the chat status bar. */
+  prStatusChip(): Locator {
+    return this.page.getByTestId("pr-status-chip");
+  }
+
+  /** Mobile bottom-sheet drawer that hosts the PR CI popover. */
+  prStatusChipDrawer(): Locator {
+    return this.page.getByTestId("pr-status-chip-drawer");
+  }
+
+  /** Close button inside the chip's mobile drawer. */
+  prStatusChipDrawerClose(): Locator {
+    return this.page.getByTestId("pr-status-chip-drawer-close");
+  }
+
+  /** PRCIPopover body when rendered inside the mobile chip drawer. */
+  prStatusChipPopoverInner(): Locator {
+    return this.prStatusChipDrawer().getByTestId("pr-topbar-popover-inner");
+  }
+
+  /** Tap the chip and wait for the mobile drawer to be visible. */
+  async tapPRStatusChip(): Promise<void> {
+    await this.prStatusChip().tap();
+    await expect(this.prStatusChipDrawer()).toBeVisible({ timeout: 5_000 });
+  }
+
   /** Multi-PR aggregate popover content. */
   prTopbarPopoverAggregate(): Locator {
     return this.page.getByTestId("pr-topbar-popover-aggregate");

--- a/apps/web/e2e/tests/pr/mobile-pr-ci-chip.spec.ts
+++ b/apps/web/e2e/tests/pr/mobile-pr-ci-chip.spec.ts
@@ -133,6 +133,7 @@ test.describe("mobile PR CI chip drawer", () => {
       .prStatusChipDrawer()
       .locator("[data-testid='pr-check-group'][data-kind='failed']");
     await expect(failedGroup).toBeVisible();
+    // 3 checks_total − 2 checks_passing = 1 in the failed bucket.
     await expect(failedGroup.getByTestId("pr-check-group-count")).toHaveText("1");
   });
 

--- a/apps/web/e2e/tests/pr/mobile-pr-ci-chip.spec.ts
+++ b/apps/web/e2e/tests/pr/mobile-pr-ci-chip.spec.ts
@@ -1,0 +1,160 @@
+// Mobile project: tap-activated PR/CI chip in the chat status bar.
+//
+// On mobile the desktop topbar PRTopbarButton is not mounted, and the chip's
+// HoverCard is unreachable by touch. The chip wraps a vaul Drawer that hosts
+// the PRCIPopover body — these specs exercise the open/close path and verify
+// the popover content renders the same surface as desktop.
+//
+// File name starts with "mobile-" so it lands in the `mobile-chrome` project
+// (Pixel 5 emulation) defined in playwright.config.ts.
+import { test, expect } from "../../fixtures/test-base";
+import type { SeedData } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+import type { ApiClient } from "../../helpers/api-client";
+
+const OWNER = "acme";
+const REPO = "demo";
+const PR_NUMBER = 99;
+const PR_URL = `https://github.com/${OWNER}/${REPO}/pull/${PR_NUMBER}`;
+
+type SeedTaskArgs = {
+  apiClient: ApiClient;
+  seedData: SeedData;
+  title: string;
+  prOverrides?: Partial<Parameters<ApiClient["mockGitHubAssociateTaskPR"]>[0]>;
+};
+
+async function seedTaskWithPR({
+  apiClient,
+  seedData,
+  title,
+  prOverrides = {},
+}: SeedTaskArgs): Promise<string> {
+  await apiClient.mockGitHubReset();
+  await apiClient.mockGitHubSetUser("test-user");
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    title,
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  await apiClient.mockGitHubAssociateTaskPR({
+    task_id: task.id,
+    owner: OWNER,
+    repo: REPO,
+    pr_number: PR_NUMBER,
+    pr_url: PR_URL,
+    pr_title: "Add mobile CI drawer",
+    head_branch: "feat/mobile-drawer",
+    base_branch: "main",
+    author_login: "test-user",
+    state: "open",
+    additions: 10,
+    deletions: 1,
+    ...prOverrides,
+  });
+  return task.id;
+}
+
+async function openTask(testPage: import("@playwright/test").Page, taskId: string) {
+  await testPage.goto(`/t/${taskId}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  return session;
+}
+
+test.describe("mobile PR CI chip drawer", () => {
+  test("tapping the chip opens the drawer with PR CI content", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const title = "Mobile CI tap-open";
+    const taskId = await seedTaskWithPR({
+      apiClient,
+      seedData,
+      title,
+      prOverrides: {
+        checks_state: "success",
+        checks_total: 4,
+        checks_passing: 4,
+        review_state: "approved",
+        review_count: 1,
+      },
+    });
+    const session = await openTask(testPage, taskId);
+
+    // Desktop topbar PR button never mounts on mobile — sanity check that we
+    // are exercising the chip path and not a leftover desktop affordance.
+    await expect(session.prTopbarButton()).toHaveCount(0);
+
+    await expect(session.prStatusChip()).toBeVisible({ timeout: 15_000 });
+    await expect(session.prStatusChipDrawer()).toHaveCount(0);
+
+    await session.tapPRStatusChip();
+
+    await expect(session.prStatusChipPopoverInner()).toBeVisible();
+    await expect(
+      session.prStatusChipDrawer().locator("[data-testid='pr-check-group'][data-kind='passed']"),
+    ).toBeVisible();
+    await expect(session.prStatusChipDrawer().getByTestId("pr-review-row")).toContainText(
+      "Approved",
+    );
+  });
+
+  test("failed PR shows failed bucket inside the drawer", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const title = "Mobile CI failed";
+    const taskId = await seedTaskWithPR({
+      apiClient,
+      seedData,
+      title,
+      prOverrides: {
+        checks_state: "failure",
+        checks_total: 3,
+        checks_passing: 2,
+      },
+    });
+    const session = await openTask(testPage, taskId);
+    await expect(session.prStatusChip()).toBeVisible({ timeout: 15_000 });
+    await session.tapPRStatusChip();
+
+    const failedGroup = session
+      .prStatusChipDrawer()
+      .locator("[data-testid='pr-check-group'][data-kind='failed']");
+    await expect(failedGroup).toBeVisible();
+    await expect(failedGroup.getByTestId("pr-check-group-count")).toHaveText("1");
+  });
+
+  test("close button dismisses the drawer", async ({ testPage, apiClient, seedData }) => {
+    test.setTimeout(120_000);
+    const title = "Mobile CI close";
+    const taskId = await seedTaskWithPR({
+      apiClient,
+      seedData,
+      title,
+      prOverrides: {
+        checks_state: "success",
+        checks_total: 1,
+        checks_passing: 1,
+      },
+    });
+    const session = await openTask(testPage, taskId);
+    await expect(session.prStatusChip()).toBeVisible({ timeout: 15_000 });
+    await session.tapPRStatusChip();
+    await expect(session.prStatusChipDrawer()).toBeVisible();
+
+    await session.prStatusChipDrawerClose().tap();
+    await expect(session.prStatusChipDrawer()).toHaveCount(0, { timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## Summary
- On mobile, the PR/CI status chip in the chat status bar was unreachable: it used a Radix `HoverCard`, and touch users have no hover.
- The desktop topbar PR button (`PRTopbarButton`) is not mounted in the mobile layout either, so the chip was the only PR/CI affordance on mobile — and it didn't work.
- This change keeps the desktop hover popover untouched and gives mobile a tap-activated vaul `Drawer` hosting the same `PRCIPopover` body (passes / failures / review / comments / merge button).

## Implementation notes
`PRStatusChip` now branches on `useIsMobile()` and renders one of two sibling components: `PRStatusChipHoverCard` (desktop — byte-equivalent to the prior implementation) or `PRStatusChipDrawer` (mobile — a vaul `Drawer` controlled by local `useState`, opened on chip tap, dismissable via close button / overlay / swipe / Escape). Both branches share a `chipButtonAttrs()` helper so all five chip `data-*` attributes (testid, pr-number, pr-state, status, ready-to-merge) stay in lockstep — no risk of selector drift between branches.

The drawer hosts `<PRCIPopover pr={pr} enabled={open} />`. The `enabled={open}` prop gates the lazy `usePRCIPopover` feedback fetch on the drawer's open state, mirroring desktop's hover-driven fetch semantics. The "Open PR details" footer button is not surfaced on mobile because `addPRPanel` is Dockview-only; a mobile-native PR detail panel is out of scope for this fix.

Chosen over alternatives: (a) mounting `PRTopbarButton` in `SessionMobileTopBar` — larger blast radius, requires a mobile PR-detail surface; (b) making the desktop button itself tap-capable — risks regressing the carefully tuned hover open/close timers. The chip is already in the mobile chat status bar; fixing it in place is the smallest viable change.

## Test plan
- [x] **Tap-activated CI surface on mobile <640px** — unit test "renders the chip closed and opens the drawer on click" mounts the chip in a mobile-mocked viewport, clicks, and asserts `pr-status-chip-drawer` + `pr-topbar-popover-inner` + `pr-status-chip-drawer-close` all appear in the DOM.
- [x] **Desktop hover popover untouched** — unit test "renders the chip button without a Drawer" confirms desktop click does NOT mount the mobile drawer; chip data-attrs preserved across both branches.
- [x] **Touch-only interaction** — mobile branch uses `onClick` + vaul `onOpenChange`; no `onMouseEnter`/`onMouseLeave` on the mobile path.
- [x] **Failed PR maps to failed bucket / data-status** — unit test "reflects a failed PR with data-status='failed'" + e2e "failed PR shows failed bucket inside the drawer".
- [x] **No-checks empty state** — unit test "renders the no-checks empty state in the drawer when the PR has no checks".
- [x] **Test-ID stability** (no regression for downstream e2e specs reading `pr-status-chip`) — explicit data-attribute assertions in both desktop and mobile unit branches.
- [x] **Full unit suite** — `pnpm --filter @kandev/web test` → 275 files / 2266 passed, 4 skipped.
- [x] **Lint + typecheck** — `pnpm --filter @kandev/web lint` and `tsc --noEmit` both clean.
- [ ] **CI runs the new `e2e/tests/pr/mobile-pr-ci-chip.spec.ts` under the `mobile-chrome` Playwright project** (Pixel 5 emulation). The spec compiles clean under tsc/eslint and follows the established mobile-spec pattern, but it requires a built Go backend + Next.js standalone (heavy fixture) that wasn't built locally for this change.
- [ ] **Manual smoke on a real device or DevTools mobile emulator** to confirm vaul touch gestures (swipe-down dismiss), drawer z-index over the mobile bottom nav, and screen-reader announcement of the drawer.

## Risks & rollback
**Risk surface is small.** Single component change (`pr-status-chip.tsx`) with the desktop branch preserved verbatim; only the chip on touch viewports gains new behavior. No API/contract changes, no migrations, no new dependencies (vaul `Drawer` is already used by `mobile-diff-sheet.tsx`). Worst credible failure modes: (1) vaul drawer fails to dismiss on some Android browser → users see a stuck modal, dismissible via Escape / overlay tap fallbacks; (2) the chip's testid leaks into a new selector someone writes — mitigated by the shared `chipButtonAttrs()` helper.

**Rollback**: revert this PR. No state to clean up.

## Known non-blocking notes
- Radix logs a `Missing 'Description'` a11y warning when the drawer opens (same omission as `mobile-diff-sheet.tsx`). Cross-cutting a11y sweep would be a good follow-up.
- Discoverability: mobile users coming from the desktop topbar PR button may not immediately realize the small chip in the chat status bar IS the equivalent. A mobile topbar PR button is a deliberate follow-up (requires a mobile PR-detail surface to back the click).