### PR TITLE
docs: add remote cloud environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,39 +101,9 @@ When a change is scoped to a single subtree, update the scoped `AGENTS.md` inste
 
 ---
 
-## Cursor Cloud specific instructions
+## Remote cloud environment
 
-### Runtime requirements
-
-- **Go 1.26** — install to `/usr/local/go` and ensure `PATH` includes `/usr/local/go/bin`.
-- **Node.js 24** — use `nvm install 24 && nvm use 24`.
-- **pnpm 9.15.9** — matches `packageManager` in `apps/package.json`. Install with `npm install -g pnpm@9.15.9`.
-- **golangci-lint v2** — required for `make lint-backend`. Install with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.
-- **gcc** — required for CGO (SQLite FTS5). Pre-installed on Ubuntu VMs.
-
-### Generated files before typecheck
-
-Before running `make typecheck`, you must generate two files that are gitignored:
-
-```bash
-node apps/web/scripts/generate-release-notes.mjs
-node apps/web/scripts/generate-changelog.mjs
-```
-
-Without these, `tsc` fails with missing module errors for `@/generated/release-notes.json` and `@/generated/changelog.json`.
-
-### Running dev mode
-
-`make dev` from the repo root builds the backend and starts both the Go backend (port 38429) and Next.js frontend (port 37429). The CLI launcher sets `KANDEV_DEBUG_DEV_MODE=true` which activates the `dev` profile from `profiles.yaml`, enabling mock agent and other dev conveniences. No external services (database, message queue, Docker) are needed — SQLite is embedded and the event bus runs in-memory.
-
-### Key commands
-
-All documented in the root `Makefile`:
-- `make dev` — build + start backend + web (dev mode)
-- `make test` — backend (Go) + web (vitest) + CLI tests
-- `make lint` — golangci-lint + ESLint
-- `make typecheck` — TypeScript type-checking across all apps
-- `make fmt` — format all code (run before lint to avoid false positives)
+For developing in ephemeral cloud VMs (Cursor Cloud, Codex, GitHub Codespaces, etc.), see [`docs/remote-cloud-environment.md`](docs/remote-cloud-environment.md) — covers runtime requirements, generated-file gotchas, and dev-mode setup.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,4 +101,40 @@ When a change is scoped to a single subtree, update the scoped `AGENTS.md` inste
 
 ---
 
-**Last Updated**: 2026-05-16
+## Cursor Cloud specific instructions
+
+### Runtime requirements
+
+- **Go 1.26** — install to `/usr/local/go` and ensure `PATH` includes `/usr/local/go/bin`.
+- **Node.js 24** — use `nvm install 24 && nvm use 24`.
+- **pnpm 9.15.9** — matches `packageManager` in `apps/package.json`. Install with `npm install -g pnpm@9.15.9`.
+- **golangci-lint v2** — required for `make lint-backend`. Install with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.
+- **gcc** — required for CGO (SQLite FTS5). Pre-installed on Ubuntu VMs.
+
+### Generated files before typecheck
+
+Before running `make typecheck`, you must generate two files that are gitignored:
+
+```bash
+node apps/web/scripts/generate-release-notes.mjs
+node apps/web/scripts/generate-changelog.mjs
+```
+
+Without these, `tsc` fails with missing module errors for `@/generated/release-notes.json` and `@/generated/changelog.json`.
+
+### Running dev mode
+
+`make dev` from the repo root builds the backend and starts both the Go backend (port 38429) and Next.js frontend (port 37429). The CLI launcher sets `KANDEV_DEBUG_DEV_MODE=true` which activates the `dev` profile from `profiles.yaml`, enabling mock agent and other dev conveniences. No external services (database, message queue, Docker) are needed — SQLite is embedded and the event bus runs in-memory.
+
+### Key commands
+
+All documented in the root `Makefile`:
+- `make dev` — build + start backend + web (dev mode)
+- `make test` — backend (Go) + web (vitest) + CLI tests
+- `make lint` — golangci-lint + ESLint
+- `make typecheck` — TypeScript type-checking across all apps
+- `make fmt` — format all code (run before lint to avoid false positives)
+
+---
+
+**Last Updated**: 2026-05-24

--- a/docs/remote-cloud-environment.md
+++ b/docs/remote-cloud-environment.md
@@ -1,0 +1,35 @@
+# Remote Cloud Environment Instructions
+
+Setup notes and caveats for developing Kandev in ephemeral cloud VMs (Cursor Cloud, Codex, GitHub Codespaces, or similar sandboxed environments).
+
+## Runtime requirements
+
+- **Go 1.26** — install to `/usr/local/go` and ensure `PATH` includes `/usr/local/go/bin`.
+- **Node.js 24** — use `nvm install 24 && nvm use 24`.
+- **pnpm 9.15.9** — matches `packageManager` in `apps/package.json`. Install with `npm install -g pnpm@9.15.9`.
+- **golangci-lint v2** — required for `make lint-backend`. Install with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.
+- **gcc** — required for CGO (SQLite FTS5). Pre-installed on most Ubuntu-based cloud VMs.
+
+## Generated files before typecheck
+
+Before running `make typecheck`, you must generate two files that are gitignored:
+
+```bash
+node apps/web/scripts/generate-release-notes.mjs
+node apps/web/scripts/generate-changelog.mjs
+```
+
+Without these, `tsc` fails with missing module errors for `@/generated/release-notes.json` and `@/generated/changelog.json`.
+
+## Running dev mode
+
+`make dev` from the repo root builds the backend and starts both the Go backend (port 38429) and Next.js frontend (port 37429). The CLI launcher sets `KANDEV_DEBUG_DEV_MODE=true` which activates the `dev` profile from `profiles.yaml`, enabling mock agent and other dev conveniences. No external services (database, message queue, Docker) are needed — SQLite is embedded and the event bus runs in-memory.
+
+## Key commands
+
+All documented in the root `Makefile`:
+- `make dev` — build + start backend + web (dev mode)
+- `make test` — backend (Go) + web (vitest) + CLI tests
+- `make lint` — golangci-lint + ESLint
+- `make typecheck` — TypeScript type-checking across all apps
+- `make fmt` — format all code (run before lint to avoid false positives)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add remote cloud environment instructions to `docs/remote-cloud-environment.md` (runtime requirements, generated-file gotchas, dev-mode setup) and reference it from `AGENTS.md` — keeps the main engineering guide lean while documenting cloud VM caveats in a dedicated file.

## Validation

- `make test` — 128 Go packages passed, 275 web test files (2266 tests) passed
- `make lint` — backend (golangci-lint) and web (ESLint) both passed
- `make typecheck` — passed after generating release-notes.json and changelog.json
- `make dev` — backend (port 38429) and frontend (port 37429) started successfully
- Created tasks on the kanban board to verify end-to-end functionality

[kandev-dev-environment-demo.mp4](https://cursor.com/agents/bc-bcf9774d-bb09-42d0-b7fb-d614ff75ab59/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkandev-dev-environment-demo.mp4)

![Two tasks on the Kanban board](https://cursor.com/artifacts/c/art-2a4669b4-0568-44b6-ae3c-1aa669bd37d6)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcf9774d-bb09-42d0-b7fb-d614ff75ab59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcf9774d-bb09-42d0-b7fb-d614ff75ab59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>