### PR TITLE
fix(web): use shared PageTopbar on /gitlab so the page has a header

### DIFF
--- a/apps/web/app/gitlab/gitlab-page-client.tsx
+++ b/apps/web/app/gitlab/gitlab-page-client.tsx
@@ -18,6 +18,7 @@ import { Card, CardContent } from "@kandev/ui/card";
 import { Input } from "@kandev/ui/input";
 import { Spinner } from "@kandev/ui/spinner";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@kandev/ui/tabs";
+import { PageTopbar } from "@/components/page-topbar";
 import { fetchGitLabStatus } from "@/lib/api/domains/gitlab-api";
 import { useGitLabUserIssues, useGitLabUserMRs } from "@/hooks/domains/gitlab/use-user-search";
 import type { GitLabStatus, Issue, MR } from "@/lib/types/gitlab";
@@ -242,56 +243,40 @@ export function GitLabPageClient({ workspaceId: _workspaceId }: { workspaceId?: 
   const connected = status?.authenticated || status?.token_configured;
 
   return (
-    <div className="space-y-4 p-4 md:p-6">
-      <PageHeader status={status} statusLoading={statusLoading} onRefresh={reloadStatus} />
-      {!statusLoading && !connected ? (
-        <NotConnectedNotice />
-      ) : (
-        <BrowseTabs
-          search={search}
-          setSearch={setSearch}
-          mrFilter={mrFilter}
-          setMrFilter={setMrFilter}
-          issueFilter={issueFilter}
-          setIssueFilter={setIssueFilter}
-          customQuery={customQuery}
-        />
-      )}
-    </div>
-  );
-}
-
-function PageHeader({
-  status,
-  statusLoading,
-  onRefresh,
-}: {
-  status: GitLabStatus | null;
-  statusLoading: boolean;
-  onRefresh: () => void;
-}) {
-  return (
-    <header className="flex items-center justify-between gap-3">
-      <div className="flex items-center gap-3">
-        <IconBrandGitlab className="h-5 w-5 text-orange-500" />
-        <div>
-          <h2 className="text-xl font-bold">GitLab</h2>
-          <p className="text-xs text-muted-foreground">
-            {status?.host ?? "https://gitlab.com"} · merge requests and issues
-          </p>
-        </div>
+    <div className="flex flex-col h-full">
+      <PageTopbar
+        title="GitLab"
+        subtitle={`${status?.host ?? "https://gitlab.com"} · merge requests and issues`}
+        icon={<IconBrandGitlab className="h-4 w-4" />}
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={reloadStatus}
+            disabled={statusLoading}
+            className="gap-1 cursor-pointer"
+          >
+            <IconRefresh className="h-3 w-3" />
+            Refresh
+          </Button>
+        }
+      />
+      <div className="space-y-4 p-4 md:p-6">
+        {!statusLoading && !connected ? (
+          <NotConnectedNotice />
+        ) : (
+          <BrowseTabs
+            search={search}
+            setSearch={setSearch}
+            mrFilter={mrFilter}
+            setMrFilter={setMrFilter}
+            issueFilter={issueFilter}
+            setIssueFilter={setIssueFilter}
+            customQuery={customQuery}
+          />
+        )}
       </div>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={onRefresh}
-        disabled={statusLoading}
-        className="gap-1 cursor-pointer"
-      >
-        <IconRefresh className="h-3 w-3" />
-        Refresh
-      </Button>
-    </header>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- The `/gitlab` page was rendering a custom in-file header instead of the shared `PageTopbar` used by `/github`, `/jira`, and `/linear`. As a result, `/gitlab` had no app-level breadcrumb, no home/back navigation, and no visual consistency with sibling integration pages.
- This PR swaps the custom header for `PageTopbar`, keeping the GitLab brand icon, the host-based subtitle, and the Refresh button (moved into the topbar's `actions` slot).
- Page body (`NotConnectedNotice` / `BrowseTabs`) and all surrounding behavior (status fetch, tabs, filters, search, settings deep link) are unchanged.

## Implementation notes
Single-file change in `apps/web/app/gitlab/gitlab-page-client.tsx`. The outer wrapper switched from `<div className="space-y-4 p-4 md:p-6">` to `<div className="flex flex-col h-full">` (matching `/linear`'s `PageShell` pattern, `apps/web/app/linear/linear-page-client.tsx:382`). The previous outer padding is preserved on an inner `<div>` wrapping the page body so spacing inside the page is identical to before. The local `PageHeader` helper component was deleted — it had no other callers.

Two intentional minor deltas, consistent with sibling integration pages:
- The GitLab icon no longer carries `text-orange-500` (sibling topbar icons use default color).
- `PageTopbar` hides the subtitle below the `sm:` breakpoint (`apps/web/components/page-topbar.tsx:96-99`), so mobile users no longer see the host in the topbar. `/github` and `/jira` behave identically.

## Test plan
- [x] **Acceptance: `/gitlab` renders the shared `PageTopbar` with home breadcrumb, GitLab title, and GitLab icon** — `gitlab-page-client.tsx:247-263` invokes `PageTopbar`; typecheck and lint green.
- [x] **Acceptance: GitLab icon + subtitle preserved** — `icon={<IconBrandGitlab className="h-4 w-4" />}` and `subtitle={\`${status?.host ?? "https://gitlab.com"} · merge requests and issues\`}`.
- [x] **Acceptance: Refresh button preserved in `actions` slot** — props byte-identical to the prior version.
- [x] **Acceptance: Custom `PageHeader` removed, no orphans** — `grep -n PageHeader apps/web/app/gitlab/` returns no matches.
- [x] **Acceptance: Outer layout matches sibling integration pages** — `flex flex-col h-full` matches `/linear`'s `PageShell` exactly.
- [x] **Acceptance: Existing functionality unchanged** — `reloadStatus`, status-fetch effect, `BrowseTabs`/`MRList`/`IssueList`/`FilterButtons`, search debounce, and the `NotConnectedNotice` settings deep link are untouched by the diff.
- [x] `pnpm --filter @kandev/web typecheck` — green.
- [x] `pnpm --filter @kandev/web lint` (`eslint --max-warnings 0`) — green.
- [x] `pnpm --filter @kandev/web test` — **276 test files / 2273 tests passed**, 4 skipped, 0 failed.
- [ ] **Reviewer sanity check**: load `/gitlab` in a local dev build and confirm the topbar appears with the home/back icon, the GitLab title, the Refresh button on the right, and that body spacing is unchanged. No automated browser pass was performed (see "Risks" below).

## Risks & rollback
- **Layout regression risk** — `h-full` depends on the root layout supplying a height; `/linear` already ships with this pattern under the same `app/layout.tsx`, so the risk is low. If something breaks visually, rollback is a single-file `git revert`.
- **Mobile subtitle hidden** — intentional consistency with sibling pages; if product wants the host always visible on mobile, that's a follow-up to `PageTopbar` itself, not this PR.
- **No browser-driven QA in CI environment** — the change is structurally a swap to a shared, already-shipping component, and unit/lint/typecheck are green, so the risk surface is limited to CSS layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)