### PR TITLE
fix(office): bound idle-timeout task lookup with caller's context

### DIFF
--- a/apps/backend/internal/office/service/idle_timeout.go
+++ b/apps/backend/internal/office/service/idle_timeout.go
@@ -50,12 +50,16 @@ func NewIdleTimeoutManager(svc *Service, timeout time.Duration) *IdleTimeoutMana
 // OnRunFinished is called after a run is marked as finished.
 // It checks if the task is in a terminal state and, if so, starts an
 // idle timer that will clean up the execution after the timeout.
-func (m *IdleTimeoutManager) OnRunFinished(sessionID, taskID string) {
+//
+// The provided context bounds the underlying task-state lookup; pass a
+// request-scoped context where one is available so that DB stalls do
+// not block the caller indefinitely.
+func (m *IdleTimeoutManager) OnRunFinished(ctx context.Context, sessionID, taskID string) {
 	if sessionID == "" || taskID == "" {
 		return
 	}
 
-	if !m.isTaskTerminal(taskID) {
+	if !m.isTaskTerminal(ctx, taskID) {
 		return
 	}
 
@@ -77,10 +81,20 @@ func (m *IdleTimeoutManager) OnViewerDisconnected(sessionID string, taskTerminal
 	m.startTimer(sessionID)
 }
 
+// isTaskTerminalLookupTimeout bounds the repository lookup performed by
+// isTaskTerminal so that a stalled database does not block the caller's
+// request handler indefinitely.
+const isTaskTerminalLookupTimeout = 5 * time.Second
+
 // isTaskTerminal checks if the task's current state is terminal by
-// querying the office repository.
-func (m *IdleTimeoutManager) isTaskTerminal(taskID string) bool {
-	fields, err := m.svc.repo.GetTaskExecutionFields(context.Background(), taskID)
+// querying the office repository. The lookup is bounded by
+// isTaskTerminalLookupTimeout and also respects the parent ctx so it
+// is safe to call from request-scoped paths.
+func (m *IdleTimeoutManager) isTaskTerminal(ctx context.Context, taskID string) bool {
+	lookupCtx, cancel := context.WithTimeout(ctx, isTaskTerminalLookupTimeout)
+	defer cancel()
+
+	fields, err := m.svc.repo.GetTaskExecutionFields(lookupCtx, taskID)
 	if err != nil {
 		m.logger.Debug("failed to check task state for idle timeout",
 			zap.String("task_id", taskID), zap.Error(err))

--- a/apps/backend/internal/office/service/idle_timeout_test.go
+++ b/apps/backend/internal/office/service/idle_timeout_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ func TestIdleTimeout_TerminalTaskStartsTimer(t *testing.T) {
 		VALUES ('task-done', 'ws-1', 'COMPLETED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
 
 	mgr := service.NewIdleTimeoutManager(svc, 50*time.Millisecond)
-	mgr.OnRunFinished("sess-1", "task-done")
+	mgr.OnRunFinished(t.Context(), "sess-1", "task-done")
 
 	if mgr.PendingCount() != 1 {
 		t.Fatalf("expected 1 pending timer, got %d", mgr.PendingCount())
@@ -36,7 +37,7 @@ func TestIdleTimeout_ViewerConnectedCancelsTimer(t *testing.T) {
 		VALUES ('task-cancelled', 'ws-1', 'CANCELLED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
 
 	mgr := service.NewIdleTimeoutManager(svc, 1*time.Second)
-	mgr.OnRunFinished("sess-2", "task-cancelled")
+	mgr.OnRunFinished(t.Context(), "sess-2", "task-cancelled")
 
 	if mgr.PendingCount() != 1 {
 		t.Fatalf("expected 1 pending timer, got %d", mgr.PendingCount())
@@ -57,7 +58,7 @@ func TestIdleTimeout_NonTerminalTaskNoTimer(t *testing.T) {
 		VALUES ('task-progress', 'ws-1', 'IN_PROGRESS', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
 
 	mgr := service.NewIdleTimeoutManager(svc, 50*time.Millisecond)
-	mgr.OnRunFinished("sess-3", "task-progress")
+	mgr.OnRunFinished(t.Context(), "sess-3", "task-progress")
 
 	if mgr.PendingCount() != 0 {
 		t.Errorf("expected 0 pending timers for non-terminal task, got %d", mgr.PendingCount())
@@ -94,10 +95,34 @@ func TestIdleTimeout_ViewerDisconnectedNonTerminal(t *testing.T) {
 func TestIdleTimeout_EmptySessionOrTaskIgnored(t *testing.T) {
 	mgr := service.NewIdleTimeoutManager(newTestService(t), 50*time.Millisecond)
 
-	mgr.OnRunFinished("", "task-1")
-	mgr.OnRunFinished("sess-1", "")
+	mgr.OnRunFinished(t.Context(), "", "task-1")
+	mgr.OnRunFinished(t.Context(), "sess-1", "")
 
 	if mgr.PendingCount() != 0 {
 		t.Errorf("expected 0 pending timers for empty IDs, got %d", mgr.PendingCount())
+	}
+}
+
+// TestIdleTimeout_CancelledContextDoesNotStartTimer verifies that when the
+// caller's context is already cancelled, the task-state lookup short-circuits
+// and the manager does not schedule an idle timer. Without ctx propagation
+// the lookup would run against context.Background() and could block on a
+// stalled database before falsely tripping (or not tripping) the timer.
+func TestIdleTimeout_CancelledContextDoesNotStartTimer(t *testing.T) {
+	svc := newTestService(t)
+
+	svc.ExecSQL(t, `INSERT INTO tasks (id, workspace_id, state, created_at, updated_at)
+		VALUES ('task-ctx', 'ws-1', 'COMPLETED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+
+	mgr := service.NewIdleTimeoutManager(svc, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	mgr.OnRunFinished(ctx, "sess-cancelled", "task-ctx")
+
+	if mgr.PendingCount() != 0 {
+		t.Errorf("expected 0 pending timers when ctx is already cancelled, got %d",
+			mgr.PendingCount())
 	}
 }

--- a/apps/backend/internal/office/service/idle_timeout_test.go
+++ b/apps/backend/internal/office/service/idle_timeout_test.go
@@ -108,6 +108,12 @@ func TestIdleTimeout_EmptySessionOrTaskIgnored(t *testing.T) {
 // and the manager does not schedule an idle timer. Without ctx propagation
 // the lookup would run against context.Background() and could block on a
 // stalled database before falsely tripping (or not tripping) the timer.
+//
+// The elapsed-time assertion guards against a future refactor that drops
+// ctx propagation but happens to fall through some other no-timer path:
+// in that regression the lookup would either still run to completion or
+// hit the 5s isTaskTerminalLookupTimeout, both of which take far longer
+// than this bound.
 func TestIdleTimeout_CancelledContextDoesNotStartTimer(t *testing.T) {
 	svc := newTestService(t)
 
@@ -116,13 +122,18 @@ func TestIdleTimeout_CancelledContextDoesNotStartTimer(t *testing.T) {
 
 	mgr := service.NewIdleTimeoutManager(svc, 50*time.Millisecond)
 
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
+	start := time.Now()
 	mgr.OnRunFinished(ctx, "sess-cancelled", "task-ctx")
+	elapsed := time.Since(start)
 
 	if mgr.PendingCount() != 0 {
 		t.Errorf("expected 0 pending timers when ctx is already cancelled, got %d",
 			mgr.PendingCount())
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected prompt return when ctx is cancelled, elapsed=%v", elapsed)
 	}
 }


### PR DESCRIPTION
The idle timeout manager's isTaskTerminal helper queried the office repository with context.Background(), so a stalled DB call could block the calling goroutine indefinitely. The methods are not wired into a request-scoped path in production today, but once OnRunFinished gets attached to an event subscriber or websocket handler, that would translate directly into a stuck request.

Propagate a context.Context through OnRunFinished into isTaskTerminal, and bound the underlying repository call with a 5s timeout derived from the caller's context. The new TestIdleTimeout_CancelledContextDoesNotStartTimer exercises the propagation by passing an already-cancelled context and confirming no idle timer is scheduled.

Existing tests are updated to thread t.Context() through OnRunFinished. Happy-path behavior is unchanged.

There is a near-duplicate IdleTimeoutManager in internal/office/scheduler/idle_timeout.go with the same bug. Left out of this PR to keep it single-concern; happy to follow up with a matching change if you'd prefer it bundled.