### PR TITLE
fix(office): stop the backoff timer in channel relay when context is cancelled

### DIFF
--- a/apps/backend/internal/office/channels/relay.go
+++ b/apps/backend/internal/office/channels/relay.go
@@ -112,7 +112,13 @@ func (r *ChannelRelay) sendWithRetry(
 			select {
 			case <-timer.C:
 			case <-ctx.Done():
-				timer.Stop()
+				// Stop() returns false if the timer already fired between
+				// the select winning and Stop running; drain timer.C in
+				// that case so the buffered value does not strand on the
+				// channel.
+				if !timer.Stop() {
+					<-timer.C
+				}
 				return ctx.Err()
 			}
 		}

--- a/apps/backend/internal/office/channels/relay.go
+++ b/apps/backend/internal/office/channels/relay.go
@@ -105,9 +105,14 @@ func (r *ChannelRelay) sendWithRetry(
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			delay := time.Duration(1<<uint(attempt-1)) * time.Second
+			// Use NewTimer rather than time.After so a context cancellation
+			// during the backoff stops the underlying timer immediately
+			// instead of leaving it pinned in the runtime until it fires.
+			timer := time.NewTimer(delay)
 			select {
-			case <-time.After(delay):
+			case <-timer.C:
 			case <-ctx.Done():
+				timer.Stop()
 				return ctx.Err()
 			}
 		}

--- a/apps/backend/internal/office/service/channel_relay.go
+++ b/apps/backend/internal/office/service/channel_relay.go
@@ -107,7 +107,13 @@ func (r *ChannelRelay) sendWithRetry(
 			select {
 			case <-timer.C:
 			case <-ctx.Done():
-				timer.Stop()
+				// Stop() returns false if the timer already fired between
+				// the select winning and Stop running; drain timer.C in
+				// that case so the buffered value does not strand on the
+				// channel.
+				if !timer.Stop() {
+					<-timer.C
+				}
 				return ctx.Err()
 			}
 		}

--- a/apps/backend/internal/office/service/channel_relay.go
+++ b/apps/backend/internal/office/service/channel_relay.go
@@ -100,9 +100,14 @@ func (r *ChannelRelay) sendWithRetry(
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			delay := time.Duration(1<<uint(attempt-1)) * time.Second
+			// Use NewTimer rather than time.After so a context cancellation
+			// during the backoff stops the underlying timer immediately
+			// instead of leaving it pinned in the runtime until it fires.
+			timer := time.NewTimer(delay)
 			select {
-			case <-time.After(delay):
+			case <-timer.C:
 			case <-ctx.Done():
+				timer.Stop()
 				return ctx.Err()
 			}
 		}

--- a/apps/backend/internal/office/service/channel_relay_test.go
+++ b/apps/backend/internal/office/service/channel_relay_test.go
@@ -178,6 +178,14 @@ func TestRelayComment_TelegramPayload(t *testing.T) {
 // caller's context while sendWithRetry is sleeping between attempts
 // causes the function to return promptly with ctx.Err(), without
 // waiting for the backoff timer to fire.
+//
+// Scope note: this is a regression test for the cancellation contract,
+// not a direct probe of the timer.Stop() change in the same commit.
+// The pre-fix time.After path also returned promptly on cancel; what
+// it leaked was a runtime timer-heap slot, which is not observable
+// from user code without synctest or runtime instrumentation. The
+// timer.Stop() change rests on the canonical Go pattern, verified by
+// inspection.
 func TestRelayComment_CancelDuringBackoff(t *testing.T) {
 	svc := newTestService(t)
 

--- a/apps/backend/internal/office/service/channel_relay_test.go
+++ b/apps/backend/internal/office/service/channel_relay_test.go
@@ -3,10 +3,12 @@ package service_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/office/models"
 	"github.com/kandev/kandev/internal/office/service"
@@ -169,6 +171,55 @@ func TestRelayComment_TelegramPayload(t *testing.T) {
 	}
 	if receivedBody["text"] != "Hello from agent!" {
 		t.Errorf("text = %q, want %q", receivedBody["text"], "Hello from agent!")
+	}
+}
+
+// TestRelayComment_CancelDuringBackoff verifies that cancelling the
+// caller's context while sendWithRetry is sleeping between attempts
+// causes the function to return promptly with ctx.Err(), without
+// waiting for the backoff timer to fire.
+func TestRelayComment_CancelDuringBackoff(t *testing.T) {
+	svc := newTestService(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	config := `{"webhook_url":"` + ts.URL + `"}`
+	channel, _ := setupChannelForRelay(t, svc, "webhook", config)
+
+	relay := service.NewChannelRelayWithClient(svc, ts.Client())
+
+	comment := &models.TaskComment{
+		ID:             "c-cancel",
+		TaskID:         channel.TaskID,
+		AuthorType:     "agent",
+		AuthorID:       "some-agent",
+		Body:           "Cancel me",
+		ReplyChannelID: channel.ID,
+	}
+
+	// The first attempt fires immediately and fails; the second attempt
+	// waits 1s. Cancelling at 100ms should land us inside that backoff
+	// window so sendWithRetry returns ctx.Err() rather than waiting it out.
+	ctx, cancel := context.WithCancel(t.Context())
+	time.AfterFunc(100*time.Millisecond, cancel)
+
+	start := time.Now()
+	err := relay.RelayComment(ctx, comment)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after context cancel, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// Allow generous slack for slow CI; the key signal is that we did not
+	// sit through the full 1s backoff.
+	if elapsed > 800*time.Millisecond {
+		t.Errorf("expected prompt return after cancel, elapsed=%v", elapsed)
 	}
 }
 

--- a/apps/backend/internal/office/service/channel_relay_test.go
+++ b/apps/backend/internal/office/service/channel_relay_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -189,8 +190,15 @@ func TestRelayComment_TelegramPayload(t *testing.T) {
 func TestRelayComment_CancelDuringBackoff(t *testing.T) {
 	svc := newTestService(t)
 
+	// Signal once when the first HTTP attempt lands; the test then cancels
+	// the context so we deterministically land inside the backoff sleep
+	// between attempt 1 and attempt 2 rather than relying on a wall-clock
+	// delay (which can flake under loaded CI).
+	firstAttemptDone := make(chan struct{})
+	var once sync.Once
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
+		once.Do(func() { close(firstAttemptDone) })
 	}))
 	defer ts.Close()
 
@@ -208,11 +216,11 @@ func TestRelayComment_CancelDuringBackoff(t *testing.T) {
 		ReplyChannelID: channel.ID,
 	}
 
-	// The first attempt fires immediately and fails; the second attempt
-	// waits 1s. Cancelling at 100ms should land us inside that backoff
-	// window so sendWithRetry returns ctx.Err() rather than waiting it out.
-	ctx, cancel := context.WithCancel(t.Context())
-	time.AfterFunc(100*time.Millisecond, cancel)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-firstAttemptDone
+		cancel()
+	}()
 
 	start := time.Now()
 	err := relay.RelayComment(ctx, comment)


### PR DESCRIPTION
sendWithRetry used time.After for its exponential backoff sleep, so a cancelled context returned promptly but left the underlying timer pinned in the Go runtime until it fired. Under repeated retry-then-cancel churn that is a slow goroutine drip and a wasted timer wheel slot per cancellation.

Switch to time.NewTimer with a Stop() on the cancellation branch so the runtime can collect the timer immediately. Behavior on the happy path and on full-retry-exhaustion is unchanged.

Adds TestRelayComment_CancelDuringBackoff to verify the function still returns promptly with context.Canceled and does not sit through the full backoff window.