### PR TITLE
feat(agentctl): add Azure Repos PR creation

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -5,13 +5,15 @@ description: Commit, push, and create a PR. Default is ready-for-review with aut
 
 # PR
 
-> **Host detection:** This skill works on both GitHub and GitLab repositories. Detect the host before step 4 by inspecting `git remote get-url origin`:
+> **Host detection:** This skill works on GitHub, GitLab, and Azure Repos. Detect the host before step 4 by inspecting `git remote get-url origin`:
+> - URL contains `dev.azure.com`, `visualstudio.com`, or `ssh.dev.azure.com` → use the **Azure Repos flow** below.
 > - URL contains `github.com` (or any host you have configured for GitHub) → use the **GitHub flow** below.
 > - URL contains `gitlab` (e.g. `gitlab.com`, `gitlab.acme.corp`) → use the **GitLab flow** at the bottom of this file.
 > - For self-managed hosts, the user's repository configuration determines the host.
 >
 > **GitHub tool selection:** The GitHub flow uses `gh` CLI by default. If `gh` is unavailable or fails, use any available GitHub tools in the environment (e.g. MCP GitHub tools).
 > **GitLab tool selection:** The GitLab flow prefers `glab` CLI when available; otherwise it shells `curl` against the REST v4 API using `$GITLAB_TOKEN` (which the agent runtime injects from the user's secrets store).
+> **Azure Repos tool selection:** The Azure flow prefers `az repos pr create` with the Azure DevOps extension. Auth can come from an existing `az login` session or `AZURE_DEVOPS_EXT_PAT`.
 
 ## Available skills
 
@@ -71,6 +73,36 @@ description: Commit, push, and create a PR. Default is ready-for-review with aut
    - Tell the user to drag and drop the image files from `.pr-assets/` into the PR description on GitHub for the images to render
 
 7. **Return the PR URL** when done.
+
+## Azure Repos flow
+
+When `git remote get-url origin` points at Azure Repos, the steps are the same up through **Push** (1–3). For step 4, create an Azure Repos pull request instead of a GitHub PR. **Skip steps 5 and 6** — `/pr-fixup` and the PR asset upload flow are GitHub-specific.
+
+Prefer the Azure CLI when it is on `PATH`:
+
+```bash
+# If needed once per machine / shell:
+# az extension add --name azure-devops
+# export AZURE_DEVOPS_EXT_PAT=...   # optional when az login is not already configured
+
+SOURCE_BRANCH="$(git branch --show-current)"
+TARGET_BRANCH="${TARGET_BRANCH:-}"   # leave empty to let Azure use the repo default branch
+
+az repos pr create \
+  ${TARGET_BRANCH:+--target-branch "$TARGET_BRANCH"} \
+  --source-branch "$SOURCE_BRANCH" \
+  --title "type: description" \
+  --description "$(cat <<'EOF'
+<filled PR template>
+EOF
+)" \
+  --draft ${DRAFT:-false}
+```
+
+Notes:
+- Azure DevOps CLI auto-detects organization / project / repository from the current repo in most cases, so you usually do **not** need to pass `--organization`, `--project`, or `--repository` explicitly.
+- If auto-detect fails (common with unusual remotes or older CLI setups), derive them from the remote and retry with explicit flags.
+- Return the PR URL and stop.
 
 ## GitLab flow (Merge Requests)
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -87,6 +87,8 @@ Prefer the Azure CLI when it is on `PATH`:
 
 SOURCE_BRANCH="$(git branch --show-current)"
 TARGET_BRANCH="${TARGET_BRANCH:-}"   # leave empty to let Azure use the repo default branch
+DRAFT_FLAG=""
+[ "${DRAFT:-false}" = "true" ] && DRAFT_FLAG="--draft"
 
 az repos pr create \
   ${TARGET_BRANCH:+--target-branch "$TARGET_BRANCH"} \
@@ -96,7 +98,7 @@ az repos pr create \
 <filled PR template>
 EOF
 )" \
-  --draft ${DRAFT:-false}
+  ${DRAFT_FLAG:+$DRAFT_FLAG}
 ```
 
 Notes:

--- a/apps/backend/internal/agent/handlers/git_handlers.go
+++ b/apps/backend/internal/agent/handlers/git_handlers.go
@@ -73,6 +73,10 @@ func (h *GitHandlers) SetOnPRCreated(cb PRCreatedCallback) {
 	h.onPRCreated = cb
 }
 
+func isGitHubPRURL(prURL string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(prURL)), "/pull/")
+}
+
 // SetOnGitOperationFailed sets a callback invoked when a git operation fails.
 func (h *GitHandlers) SetOnGitOperationFailed(cb GitOperationFailedCallback) {
 	h.onGitOperationFailed = cb
@@ -562,7 +566,7 @@ func (h *GitHandlers) wsCreatePR(ctx context.Context, msg *ws.Message) (*ws.Mess
 	// flows through so the orchestrator can scope the resulting TaskPR /
 	// PRWatch rows to the per-task repository_id.
 	// Use a timeout-bound context so a stuck callback doesn't leak the goroutine.
-	if result.Success && result.PRURL != "" && h.onPRCreated != nil {
+	if result.Success && result.PRURL != "" && h.onPRCreated != nil && isGitHubPRURL(result.PRURL) {
 		execution, ok := h.lifecycleMgr.GetExecutionBySessionID(req.SessionID)
 		if ok && execution.TaskID != "" {
 			sessionID := req.SessionID

--- a/apps/backend/internal/agent/handlers/git_handlers.go
+++ b/apps/backend/internal/agent/handlers/git_handlers.go
@@ -73,6 +73,9 @@ func (h *GitHandlers) SetOnPRCreated(cb PRCreatedCallback) {
 	h.onPRCreated = cb
 }
 
+// isGitHubPRURL reports whether prURL is a GitHub pull request link. Azure Repos
+// (/pullrequest/) and GitLab (/-/merge_requests/) are excluded so onPRCreated only
+// wires GitHub TaskPR / PRWatch rows (Azure association is a separate follow-up).
 func isGitHubPRURL(prURL string) bool {
 	return strings.Contains(strings.ToLower(strings.TrimSpace(prURL)), "/pull/")
 }

--- a/apps/backend/internal/agent/handlers/git_handlers_test.go
+++ b/apps/backend/internal/agent/handlers/git_handlers_test.go
@@ -120,6 +120,27 @@ func TestRegisterGitHandlers(t *testing.T) {
 	}
 }
 
+func TestIsGitHubPRURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "github", url: "https://github.com/acme/widgets/pull/42", want: true},
+		{name: "github enterprise", url: "https://github.acme.corp/acme/widgets/pull/42", want: true},
+		{name: "azure repos", url: "https://dev.azure.com/acme/project/_git/widgets/pullrequest/42", want: false},
+		{name: "gitlab", url: "https://gitlab.com/acme/widgets/-/merge_requests/42", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGitHubPRURL(tt.url); got != tt.want {
+				t.Fatalf("isGitHubPRURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNotifyGitOperationFailed_NilResult(t *testing.T) {
 	log := newTestLogger()
 	called := false

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -9,10 +9,21 @@ agentctl exposes these route groups (see `server/api/`):
 - `/instances/*` - Multi-instance management
 - `/processes/*` - Agent subprocess management (start/stop)
 - `/agent/configure`, `/agent/stream` - Agent configuration and event streaming
-- `/git/*` - Git operations (status, commit, push, pull, rebase, stage, etc.)
+- `/git/*` - Git operations (status, commit, push, pull, rebase, stage, create PR, etc.)
 - `/shell/*` - Shell session management
 - `/workspace/*` - File operations, search, tree
 - `/vscode/*` - VS Code integration proxy
+
+## Pull request creation (`server/process/git_pr_providers.go`)
+
+`GitOperator.CreatePR` picks a host CLI from `origin`:
+
+| Remote host | CLI | Notes |
+|-------------|-----|-------|
+| `dev.azure.com`, `ssh.dev.azure.com`, `*.visualstudio.com` | `az repos pr create` | Requires `az` on `PATH` and `azure-devops` extension. Auth: `az login` or `AZURE_DEVOPS_EXT_PAT`. |
+| Everything else (today) | `gh pr create` | GitLab agentctl routing is not implemented yet — use the `/pr` skill `glab` flow. |
+
+Azure PR URLs are returned to the client but do not trigger backend `onPRCreated` / TaskPR linkage (GitHub-only today).
 
 ## Adapter Model
 

--- a/apps/backend/internal/agentctl/server/process/git.go
+++ b/apps/backend/internal/agentctl/server/process/git.go
@@ -994,8 +994,14 @@ func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch stri
 	switch detectPRProvider(remoteURL) {
 	case prProviderAzureRepos:
 		return g.createAzureReposPR(ctx, result, remoteURL, branch, title, body, baseBranch, draft)
-	default:
+	case prProviderGitHub:
 		return g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
+	default:
+		result.Error = fmt.Sprintf(
+			"unsupported git remote for PR creation: %s (GitHub and Azure Repos are supported)",
+			redactRemoteURL(remoteURL),
+		)
+		return result, nil
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/process/git.go
+++ b/apps/backend/internal/agentctl/server/process/git.go
@@ -959,7 +959,7 @@ type PRCreateResult struct {
 	Error   string `json:"error,omitempty"`
 }
 
-// CreatePR creates a pull request using the gh CLI.
+// CreatePR creates a pull request using the repository host's CLI.
 // It first pushes the current branch to the remote, then creates the PR.
 func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch string, draft bool) (*PRCreateResult, error) {
 	if !g.tryLock("create-pr") {
@@ -969,7 +969,6 @@ func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch stri
 
 	result := &PRCreateResult{}
 
-	// Get current branch name for --head flag
 	branch, err := g.getCurrentBranch(ctx)
 	if err != nil {
 		result.Error = fmt.Sprintf("failed to get current branch: %s", err.Error())
@@ -977,7 +976,13 @@ func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch stri
 	}
 	g.logger.Debug("current branch", zap.String("branch", branch))
 
-	// First, push the branch to remote (with --set-upstream in case it's a new branch)
+	remoteURL, err := g.getOriginRemoteURL(ctx)
+	if err != nil {
+		result.Error = err.Error()
+		return result, nil
+	}
+	g.logger.Debug("origin remote", zap.String("remote", remoteURL))
+
 	pushOutput, err := g.runGitCommand(ctx, "push", "--set-upstream", "origin", "HEAD")
 	if err != nil {
 		result.Error = fmt.Sprintf("failed to push branch: %s", pushOutput)
@@ -986,57 +991,12 @@ func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch stri
 	}
 	g.logger.Debug("pushed branch to remote", zap.String("output", pushOutput))
 
-	// Now create the PR
-	// Use --head to explicitly specify the branch (helps gh in worktree scenarios)
-	args := []string{"pr", "create", "--title", title, "--body", body, "--head", branch}
-
-	// Strip remote prefix (e.g., "origin/main" -> "main") since gh expects just the branch name
-	cleanBaseBranch := strings.TrimPrefix(baseBranch, "origin/")
-	if cleanBaseBranch != "" {
-		args = append(args, "--base", cleanBaseBranch)
+	switch detectPRProvider(remoteURL) {
+	case prProviderAzureRepos:
+		return g.createAzureReposPR(ctx, result, remoteURL, branch, title, body, baseBranch, draft)
+	default:
+		return g.createGitHubPR(ctx, result, branch, title, body, baseBranch, draft)
 	}
-
-	if draft {
-		args = append(args, "--draft")
-	}
-
-	cmd := exec.CommandContext(ctx, "gh", args...)
-	cmd.Dir = g.workDir
-
-	// Clear GIT_DIR and GIT_WORK_TREE to ensure gh uses the worktree's .git file
-	// and correctly detects the current branch. Inherited env vars can confuse gh
-	// when running from a worktree.
-	env := filterGitEnv(os.Environ())
-	cmd.Env = env
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	g.logger.Debug("executing gh command",
-		zap.Strings("args", args),
-		zap.String("workDir", g.workDir))
-
-	err = cmd.Run()
-	output := stdout.String()
-	if stderr.Len() > 0 {
-		if output != "" {
-			output += "\n"
-		}
-		output += stderr.String()
-	}
-	result.Output = output
-
-	if err != nil {
-		result.Error = fmt.Sprintf("%s: %s", err.Error(), strings.TrimSpace(stderr.String()))
-		return result, nil
-	}
-
-	// Extract PR URL from output (gh pr create outputs the URL on success)
-	result.PRURL = strings.TrimSpace(stdout.String())
-	result.Success = true
-	g.logger.Info("PR created", zap.String("url", result.PRURL))
-	return result, nil
 }
 
 // parseStatSummary parses a git --shortstat / --stat summary line like

--- a/apps/backend/internal/agentctl/server/process/git.go
+++ b/apps/backend/internal/agentctl/server/process/git.go
@@ -981,7 +981,7 @@ func (g *GitOperator) CreatePR(ctx context.Context, title, body, baseBranch stri
 		result.Error = err.Error()
 		return result, nil
 	}
-	g.logger.Debug("origin remote", zap.String("remote", remoteURL))
+	g.logger.Debug("origin remote", zap.String("remote", redactRemoteURL(remoteURL)))
 
 	pushOutput, err := g.runGitCommand(ctx, "push", "--set-upstream", "origin", "HEAD")
 	if err != nil {

--- a/apps/backend/internal/agentctl/server/process/git_pr_providers.go
+++ b/apps/backend/internal/agentctl/server/process/git_pr_providers.go
@@ -24,6 +24,7 @@ const (
 	repositoryFlagBody                   = "--body"
 	repositoryFlagDescription            = "--description"
 	repositoryFlagHead                   = "--head"
+	redactedLogValue                     = "[REDACTED]"
 )
 
 type azureRepoInfo struct {
@@ -40,10 +41,18 @@ type azurePRCreateResponse struct {
 }
 
 func detectPRProvider(remoteURL string) prProvider {
-	if isAzureReposHost(remoteHostFromURL(remoteURL)) {
+	host := remoteHostFromURL(remoteURL)
+	if isAzureReposHost(host) {
 		return prProviderAzureRepos
 	}
-	return prProviderGitHub
+	if isGitHubHost(host) {
+		return prProviderGitHub
+	}
+	return ""
+}
+
+func isGitHubHost(host string) bool {
+	return host == "github.com" || strings.HasSuffix(host, ".github.com")
 }
 
 func isAzureReposHost(host string) bool {
@@ -85,39 +94,26 @@ func remoteHostFromURL(remoteURL string) string {
 	return strings.ToLower(host)
 }
 
-// extractJSONObject returns the first balanced {...} object in output. Some az
-// versions prefix stdout with status text before the JSON payload.
-func extractJSONObject(output string) (string, bool) {
-	start := strings.Index(output, "{")
-	if start < 0 {
-		return "", false
+func parseAzurePRCreateResponse(stdoutOutput string) (azurePRCreateResponse, error) {
+	trimmed := strings.TrimSpace(stdoutOutput)
+	var response azurePRCreateResponse
+	if err := json.Unmarshal([]byte(trimmed), &response); err == nil {
+		return response, nil
 	}
 
-	depth := 0
-	for i := start; i < len(output); i++ {
-		switch output[i] {
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return output[start : i+1], true
-			}
+	// az may prefix stdout with status lines; parse JSON lines so braces inside
+	// string values do not confuse a naive brace balancer.
+	lines := strings.Split(trimmed, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(line), &response); err == nil {
+			return response, nil
 		}
 	}
-	return "", false
-}
-
-func parseAzurePRCreateResponse(stdoutOutput string) (azurePRCreateResponse, error) {
-	jsonPayload, ok := extractJSONObject(stdoutOutput)
-	if !ok {
-		return azurePRCreateResponse{}, fmt.Errorf("no JSON object in output")
-	}
-	var response azurePRCreateResponse
-	if err := json.Unmarshal([]byte(jsonPayload), &response); err != nil {
-		return azurePRCreateResponse{}, err
-	}
-	return response, nil
+	return azurePRCreateResponse{}, fmt.Errorf("no JSON object in output")
 }
 
 func parseAzureRepoInfo(remoteURL string) (*azureRepoInfo, error) {
@@ -268,7 +264,7 @@ func sanitizeRepositoryArgs(args []string) []string {
 	redactNext := false
 	for _, arg := range args {
 		if redactNext {
-			sanitized = append(sanitized, "[REDACTED]")
+			sanitized = append(sanitized, redactedLogValue)
 			redactNext = false
 			continue
 		}
@@ -281,11 +277,11 @@ func sanitizeRepositoryArgs(args []string) []string {
 
 		switch {
 		case strings.HasPrefix(arg, repositoryFlagTitle+"="):
-			sanitized = append(sanitized, repositoryFlagTitle+"=[REDACTED]")
+			sanitized = append(sanitized, repositoryFlagTitle+"="+redactedLogValue)
 		case strings.HasPrefix(arg, repositoryFlagBody+"="):
-			sanitized = append(sanitized, repositoryFlagBody+"=[REDACTED]")
+			sanitized = append(sanitized, repositoryFlagBody+"="+redactedLogValue)
 		case strings.HasPrefix(arg, repositoryFlagDescription+"="):
-			sanitized = append(sanitized, repositoryFlagDescription+"=[REDACTED]")
+			sanitized = append(sanitized, repositoryFlagDescription+"="+redactedLogValue)
 		default:
 			sanitized = append(sanitized, arg)
 		}

--- a/apps/backend/internal/agentctl/server/process/git_pr_providers.go
+++ b/apps/backend/internal/agentctl/server/process/git_pr_providers.go
@@ -101,8 +101,15 @@ func parseAzurePRCreateResponse(stdoutOutput string) (azurePRCreateResponse, err
 		return response, nil
 	}
 
-	// az may prefix stdout with status lines; parse JSON lines so braces inside
-	// string values do not confuse a naive brace balancer.
+	// az may prefix stdout with status text; decode the first JSON value (incl. pretty-printed).
+	if start := strings.Index(trimmed, "{"); start >= 0 {
+		dec := json.NewDecoder(strings.NewReader(trimmed[start:]))
+		if err := dec.Decode(&response); err == nil {
+			return response, nil
+		}
+	}
+
+	// Some az versions emit single-line JSON after status lines.
 	lines := strings.Split(trimmed, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := strings.TrimSpace(lines[i])

--- a/apps/backend/internal/agentctl/server/process/git_pr_providers.go
+++ b/apps/backend/internal/agentctl/server/process/git_pr_providers.go
@@ -40,13 +40,84 @@ type azurePRCreateResponse struct {
 }
 
 func detectPRProvider(remoteURL string) prProvider {
-	lower := strings.ToLower(strings.TrimSpace(remoteURL))
-	if strings.Contains(lower, "dev.azure.com") ||
-		strings.Contains(lower, "ssh.dev.azure.com") ||
-		strings.Contains(lower, "visualstudio.com") {
+	if isAzureReposHost(remoteHostFromURL(remoteURL)) {
 		return prProviderAzureRepos
 	}
 	return prProviderGitHub
+}
+
+func isAzureReposHost(host string) bool {
+	switch host {
+	case "dev.azure.com", "ssh.dev.azure.com":
+		return true
+	default:
+		return strings.HasSuffix(host, ".visualstudio.com")
+	}
+}
+
+// remoteHostFromURL returns the lowercase hostname from an origin remote URL.
+func remoteHostFromURL(remoteURL string) string {
+	trimmed := strings.TrimSpace(remoteURL)
+	if trimmed == "" {
+		return ""
+	}
+
+	if strings.Contains(trimmed, "://") {
+		parsed, err := url.Parse(trimmed)
+		if err == nil && parsed.Host != "" {
+			host := parsed.Hostname()
+			return strings.ToLower(host)
+		}
+	}
+
+	rest := strings.TrimPrefix(trimmed, "ssh://")
+	if _, after, ok := strings.Cut(rest, "@"); ok {
+		rest = after
+	}
+	hostPort, _, ok := strings.Cut(rest, ":")
+	if !ok {
+		hostPort, _, _ = strings.Cut(rest, "/")
+	}
+	host := hostPort
+	if idx := strings.Index(host, ":"); idx >= 0 {
+		host = host[:idx]
+	}
+	return strings.ToLower(host)
+}
+
+// extractJSONObject returns the first balanced {...} object in output. Some az
+// versions prefix stdout with status text before the JSON payload.
+func extractJSONObject(output string) (string, bool) {
+	start := strings.Index(output, "{")
+	if start < 0 {
+		return "", false
+	}
+
+	depth := 0
+	for i := start; i < len(output); i++ {
+		switch output[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return output[start : i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+func parseAzurePRCreateResponse(stdoutOutput string) (azurePRCreateResponse, error) {
+	jsonPayload, ok := extractJSONObject(stdoutOutput)
+	if !ok {
+		return azurePRCreateResponse{}, fmt.Errorf("no JSON object in output")
+	}
+	var response azurePRCreateResponse
+	if err := json.Unmarshal([]byte(jsonPayload), &response); err != nil {
+		return azurePRCreateResponse{}, err
+	}
+	return response, nil
 }
 
 func parseAzureRepoInfo(remoteURL string) (*azureRepoInfo, error) {
@@ -323,6 +394,11 @@ func (g *GitOperator) createAzureReposPR(
 	remoteURL, branch, title, body, baseBranch string,
 	draft bool,
 ) (*PRCreateResult, error) {
+	if _, err := exec.LookPath("az"); err != nil {
+		result.Error = "Azure CLI (az) is not on PATH; install it and run: az extension add --name azure-devops"
+		return result, nil
+	}
+
 	info, err := parseAzureRepoInfo(remoteURL)
 	if err != nil {
 		result.Error = err.Error()
@@ -355,8 +431,8 @@ func (g *GitOperator) createAzureReposPR(
 		return result, nil
 	}
 
-	var response azurePRCreateResponse
-	if err := json.Unmarshal([]byte(stdoutOutput), &response); err != nil {
+	response, err := parseAzurePRCreateResponse(stdoutOutput)
+	if err != nil {
 		result.Error = fmt.Sprintf("failed to parse Azure Repos PR output: %v", err)
 		return result, nil
 	}

--- a/apps/backend/internal/agentctl/server/process/git_pr_providers.go
+++ b/apps/backend/internal/agentctl/server/process/git_pr_providers.go
@@ -1,0 +1,300 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+type prProvider string
+
+const (
+	prProviderGitHub     prProvider = "github"
+	prProviderAzureRepos prProvider = "azure_repos"
+	prCreateSubcommand              = "create"
+)
+
+type azureRepoInfo struct {
+	OrganizationURL string
+	Project         string
+	Repository      string
+}
+
+type azurePRCreateResponse struct {
+	PullRequestID int `json:"pullRequestId"`
+	Repository    struct {
+		RemoteURL string `json:"remoteUrl"`
+	} `json:"repository"`
+}
+
+func detectPRProvider(remoteURL string) prProvider {
+	lower := strings.ToLower(strings.TrimSpace(remoteURL))
+	if strings.Contains(lower, "dev.azure.com") ||
+		strings.Contains(lower, "ssh.dev.azure.com") ||
+		strings.Contains(lower, "visualstudio.com") {
+		return prProviderAzureRepos
+	}
+	return prProviderGitHub
+}
+
+func parseAzureRepoInfo(remoteURL string) (*azureRepoInfo, error) {
+	trimmed := strings.TrimSpace(remoteURL)
+	switch {
+	case strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://"):
+		return parseAzureHTTPRemote(trimmed)
+	case strings.HasPrefix(trimmed, "ssh://"):
+		return parseAzureSSHRemote(trimmed)
+	case strings.Contains(trimmed, "@") && strings.Contains(trimmed, ":"):
+		return parseAzureSCPRemote(trimmed)
+	default:
+		return nil, fmt.Errorf("unsupported Azure Repos remote URL: %s", remoteURL)
+	}
+}
+
+func parseAzureHTTPRemote(remoteURL string) (*azureRepoInfo, error) {
+	trimmed := strings.TrimSpace(remoteURL)
+	withoutScheme := strings.TrimPrefix(trimmed, "https://")
+	withoutScheme = strings.TrimPrefix(withoutScheme, "http://")
+
+	hostAndPath := withoutScheme
+	if _, after, ok := strings.Cut(hostAndPath, "@"); ok {
+		hostAndPath = after
+	}
+
+	host, path, ok := strings.Cut(hostAndPath, "/")
+	if !ok {
+		return nil, fmt.Errorf("missing repository path in Azure Repos URL: %s", remoteURL)
+	}
+
+	segments := splitRemotePath(path)
+	if len(segments) < 3 {
+		return nil, fmt.Errorf("invalid Azure Repos URL path: %s", remoteURL)
+	}
+
+	lowerHost := strings.ToLower(host)
+	scheme := "https://"
+	switch {
+	case strings.Contains(lowerHost, "dev.azure.com"):
+		if len(segments) < 4 || segments[2] != "_git" {
+			return nil, fmt.Errorf("invalid Azure Repos dev.azure.com URL: %s", remoteURL)
+		}
+		return &azureRepoInfo{
+			OrganizationURL: scheme + host + "/" + segments[0],
+			Project:         segments[1],
+			Repository:      trimGitSuffix(segments[3]),
+		}, nil
+	case strings.Contains(lowerHost, "visualstudio.com"):
+		if len(segments) < 3 || segments[1] != "_git" {
+			return nil, fmt.Errorf("invalid Azure Repos visualstudio.com URL: %s", remoteURL)
+		}
+		return &azureRepoInfo{
+			OrganizationURL: scheme + host,
+			Project:         segments[0],
+			Repository:      trimGitSuffix(segments[2]),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported Azure Repos host: %s", host)
+	}
+}
+
+func parseAzureSSHRemote(remoteURL string) (*azureRepoInfo, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(remoteURL), "ssh://")
+	if _, after, ok := strings.Cut(trimmed, "@"); ok {
+		trimmed = after
+	}
+	hostPort, path, ok := strings.Cut(trimmed, "/")
+	if !ok {
+		return nil, fmt.Errorf("missing repository path in Azure Repos SSH URL: %s", remoteURL)
+	}
+	return parseAzureSSHParts(hostPort, path, remoteURL)
+}
+
+func parseAzureSCPRemote(remoteURL string) (*azureRepoInfo, error) {
+	trimmed := strings.TrimSpace(remoteURL)
+	if _, after, ok := strings.Cut(trimmed, "@"); ok {
+		trimmed = after
+	}
+	hostPort, path, ok := strings.Cut(trimmed, ":")
+	if !ok {
+		return nil, fmt.Errorf("missing repository path in Azure Repos SCP URL: %s", remoteURL)
+	}
+	return parseAzureSSHParts(hostPort, path, remoteURL)
+}
+
+func parseAzureSSHParts(hostPort, path, rawURL string) (*azureRepoInfo, error) {
+	host := hostPort
+	if idx := strings.Index(host, ":"); idx >= 0 {
+		host = host[:idx]
+	}
+	segments := splitRemotePath(path)
+	if len(segments) < 4 || segments[0] != "v3" {
+		return nil, fmt.Errorf("invalid Azure Repos SSH path: %s", rawURL)
+	}
+
+	org := segments[1]
+	project := segments[2]
+	repo := trimGitSuffix(segments[3])
+	lowerHost := strings.ToLower(host)
+
+	switch {
+	case strings.Contains(lowerHost, "ssh.dev.azure.com"):
+		return &azureRepoInfo{
+			OrganizationURL: "https://dev.azure.com/" + org,
+			Project:         project,
+			Repository:      repo,
+		}, nil
+	case strings.Contains(lowerHost, "visualstudio.com"):
+		return &azureRepoInfo{
+			OrganizationURL: "https://" + org + ".visualstudio.com",
+			Project:         project,
+			Repository:      repo,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported Azure Repos SSH host: %s", host)
+	}
+}
+
+func splitRemotePath(path string) []string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		segments = append(segments, part)
+	}
+	return segments
+}
+
+func trimGitSuffix(name string) string {
+	return strings.TrimSuffix(name, ".git")
+}
+
+func cleanBaseBranch(baseBranch string) string {
+	return strings.TrimPrefix(strings.TrimSpace(baseBranch), "origin/")
+}
+
+func (g *GitOperator) getOriginRemoteURL(ctx context.Context) (string, error) {
+	output, err := g.runGitCommand(ctx, "remote", "get-url", "origin")
+	if err != nil {
+		return "", fmt.Errorf("failed to get origin remote URL: %w", err)
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func (g *GitOperator) runRepositoryCommand(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = g.workDir
+	cmd.Env = filterGitEnv(os.Environ())
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	g.logger.Debug("executing repository command",
+		zap.String("command", name),
+		zap.Strings("args", args),
+		zap.String("workDir", g.workDir))
+
+	err := cmd.Run()
+	output := strings.TrimSpace(stdout.String())
+	stderrOutput := strings.TrimSpace(stderr.String())
+	if stderrOutput != "" {
+		if output != "" {
+			output += "\n"
+		}
+		output += stderrOutput
+	}
+	if err != nil {
+		return output, fmt.Errorf("%w: %s", err, strings.TrimSpace(output))
+	}
+	return output, nil
+}
+
+func (g *GitOperator) createGitHubPR(
+	ctx context.Context,
+	result *PRCreateResult,
+	branch, title, body, baseBranch string,
+	draft bool,
+) (*PRCreateResult, error) {
+	args := []string{"pr", prCreateSubcommand, "--title", title, "--body", body, "--head", branch}
+	if cleanBase := cleanBaseBranch(baseBranch); cleanBase != "" {
+		args = append(args, "--base", cleanBase)
+	}
+	if draft {
+		args = append(args, "--draft")
+	}
+
+	output, err := g.runRepositoryCommand(ctx, "gh", args...)
+	result.Output = output
+	if err != nil {
+		result.Error = err.Error()
+		return result, nil
+	}
+
+	result.PRURL = strings.TrimSpace(output)
+	result.Success = true
+	g.logger.Info("PR created", zap.String("url", result.PRURL))
+	return result, nil
+}
+
+func (g *GitOperator) createAzureReposPR(
+	ctx context.Context,
+	result *PRCreateResult,
+	remoteURL, branch, title, body, baseBranch string,
+	draft bool,
+) (*PRCreateResult, error) {
+	info, err := parseAzureRepoInfo(remoteURL)
+	if err != nil {
+		result.Error = err.Error()
+		return result, nil
+	}
+
+	args := []string{
+		"repos", "pr", prCreateSubcommand,
+		"--organization", info.OrganizationURL,
+		"--project", info.Project,
+		"--repository", info.Repository,
+		"--source-branch", branch,
+	}
+	if cleanBase := cleanBaseBranch(baseBranch); cleanBase != "" {
+		args = append(args, "--target-branch", cleanBase)
+	}
+	args = append(args,
+		"--title", title,
+		"--description", body,
+	)
+	if draft {
+		args = append(args, "--draft", "true")
+	}
+	args = append(args, "-o", "json")
+
+	output, err := g.runRepositoryCommand(ctx, "az", args...)
+	result.Output = output
+	if err != nil {
+		result.Error = err.Error()
+		return result, nil
+	}
+
+	var response azurePRCreateResponse
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		result.Error = fmt.Sprintf("failed to parse Azure Repos PR output: %v", err)
+		return result, nil
+	}
+	if response.PullRequestID <= 0 || strings.TrimSpace(response.Repository.RemoteURL) == "" {
+		result.Error = "Azure Repos PR output did not include a pull request URL"
+		return result, nil
+	}
+
+	result.PRURL = strings.TrimRight(response.Repository.RemoteURL, "/") + "/pullrequest/" + strconv.Itoa(response.PullRequestID)
+	result.Success = true
+	g.logger.Info("PR created", zap.String("url", result.PRURL))
+	return result, nil
+}

--- a/apps/backend/internal/agentctl/server/process/git_pr_providers.go
+++ b/apps/backend/internal/agentctl/server/process/git_pr_providers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -16,9 +17,13 @@ import (
 type prProvider string
 
 const (
-	prProviderGitHub     prProvider = "github"
-	prProviderAzureRepos prProvider = "azure_repos"
-	prCreateSubcommand              = "create"
+	prProviderGitHub          prProvider = "github"
+	prProviderAzureRepos      prProvider = "azure_repos"
+	prCreateSubcommand                   = "create"
+	repositoryFlagTitle                  = "--title"
+	repositoryFlagBody                   = "--body"
+	repositoryFlagDescription            = "--description"
+	repositoryFlagHead                   = "--head"
 )
 
 type azureRepoInfo struct {
@@ -181,6 +186,75 @@ func cleanBaseBranch(baseBranch string) string {
 	return strings.TrimPrefix(strings.TrimSpace(baseBranch), "origin/")
 }
 
+func sanitizeRepositoryArgs(args []string) []string {
+	redactedFlags := map[string]struct{}{
+		repositoryFlagTitle:       {},
+		repositoryFlagBody:        {},
+		repositoryFlagDescription: {},
+	}
+
+	sanitized := make([]string, 0, len(args))
+	redactNext := false
+	for _, arg := range args {
+		if redactNext {
+			sanitized = append(sanitized, "[REDACTED]")
+			redactNext = false
+			continue
+		}
+
+		if _, ok := redactedFlags[arg]; ok {
+			sanitized = append(sanitized, arg)
+			redactNext = true
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(arg, repositoryFlagTitle+"="):
+			sanitized = append(sanitized, repositoryFlagTitle+"=[REDACTED]")
+		case strings.HasPrefix(arg, repositoryFlagBody+"="):
+			sanitized = append(sanitized, repositoryFlagBody+"=[REDACTED]")
+		case strings.HasPrefix(arg, repositoryFlagDescription+"="):
+			sanitized = append(sanitized, repositoryFlagDescription+"=[REDACTED]")
+		default:
+			sanitized = append(sanitized, arg)
+		}
+	}
+
+	return sanitized
+}
+
+func combineCommandOutput(stdout, stderr string) string {
+	parts := make([]string, 0, 2)
+	if trimmedStdout := strings.TrimSpace(stdout); trimmedStdout != "" {
+		parts = append(parts, trimmedStdout)
+	}
+	if trimmedStderr := strings.TrimSpace(stderr); trimmedStderr != "" {
+		parts = append(parts, trimmedStderr)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func redactRemoteURL(remoteURL string) string {
+	trimmed := strings.TrimSpace(remoteURL)
+	if trimmed == "" {
+		return ""
+	}
+
+	if strings.Contains(trimmed, "://") {
+		parsed, err := url.Parse(trimmed)
+		if err == nil {
+			parsed.User = nil
+			return parsed.String()
+		}
+	}
+
+	if before, after, ok := strings.Cut(trimmed, "@"); ok && before != "" && strings.Contains(after, ":") {
+		return after
+	}
+
+	return trimmed
+}
+
 func (g *GitOperator) getOriginRemoteURL(ctx context.Context) (string, error) {
 	output, err := g.runGitCommand(ctx, "remote", "get-url", "origin")
 	if err != nil {
@@ -189,7 +263,7 @@ func (g *GitOperator) getOriginRemoteURL(ctx context.Context) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
-func (g *GitOperator) runRepositoryCommand(ctx context.Context, name string, args ...string) (string, error) {
+func (g *GitOperator) runRepositoryCommand(ctx context.Context, name string, args ...string) (string, string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = g.workDir
 	cmd.Env = filterGitEnv(os.Environ())
@@ -200,22 +274,20 @@ func (g *GitOperator) runRepositoryCommand(ctx context.Context, name string, arg
 
 	g.logger.Debug("executing repository command",
 		zap.String("command", name),
-		zap.Strings("args", args),
+		zap.Strings("args", sanitizeRepositoryArgs(args)),
 		zap.String("workDir", g.workDir))
 
 	err := cmd.Run()
-	output := strings.TrimSpace(stdout.String())
+	stdoutOutput := strings.TrimSpace(stdout.String())
 	stderrOutput := strings.TrimSpace(stderr.String())
-	if stderrOutput != "" {
-		if output != "" {
-			output += "\n"
-		}
-		output += stderrOutput
-	}
 	if err != nil {
-		return output, fmt.Errorf("%w: %s", err, strings.TrimSpace(output))
+		combined := combineCommandOutput(stdoutOutput, stderrOutput)
+		if combined == "" {
+			combined = err.Error()
+		}
+		return stdoutOutput, stderrOutput, fmt.Errorf("%w: %s", err, combined)
 	}
-	return output, nil
+	return stdoutOutput, stderrOutput, nil
 }
 
 func (g *GitOperator) createGitHubPR(
@@ -224,7 +296,7 @@ func (g *GitOperator) createGitHubPR(
 	branch, title, body, baseBranch string,
 	draft bool,
 ) (*PRCreateResult, error) {
-	args := []string{"pr", prCreateSubcommand, "--title", title, "--body", body, "--head", branch}
+	args := []string{"pr", prCreateSubcommand, repositoryFlagTitle, title, repositoryFlagBody, body, repositoryFlagHead, branch}
 	if cleanBase := cleanBaseBranch(baseBranch); cleanBase != "" {
 		args = append(args, "--base", cleanBase)
 	}
@@ -232,14 +304,14 @@ func (g *GitOperator) createGitHubPR(
 		args = append(args, "--draft")
 	}
 
-	output, err := g.runRepositoryCommand(ctx, "gh", args...)
-	result.Output = output
+	stdoutOutput, stderrOutput, err := g.runRepositoryCommand(ctx, "gh", args...)
+	result.Output = combineCommandOutput(stdoutOutput, stderrOutput)
 	if err != nil {
 		result.Error = err.Error()
 		return result, nil
 	}
 
-	result.PRURL = strings.TrimSpace(output)
+	result.PRURL = strings.TrimSpace(stdoutOutput)
 	result.Success = true
 	g.logger.Info("PR created", zap.String("url", result.PRURL))
 	return result, nil
@@ -268,23 +340,23 @@ func (g *GitOperator) createAzureReposPR(
 		args = append(args, "--target-branch", cleanBase)
 	}
 	args = append(args,
-		"--title", title,
-		"--description", body,
+		repositoryFlagTitle, title,
+		repositoryFlagDescription, body,
 	)
 	if draft {
 		args = append(args, "--draft", "true")
 	}
 	args = append(args, "-o", "json")
 
-	output, err := g.runRepositoryCommand(ctx, "az", args...)
-	result.Output = output
+	stdoutOutput, stderrOutput, err := g.runRepositoryCommand(ctx, "az", args...)
+	result.Output = combineCommandOutput(stdoutOutput, stderrOutput)
 	if err != nil {
 		result.Error = err.Error()
 		return result, nil
 	}
 
 	var response azurePRCreateResponse
-	if err := json.Unmarshal([]byte(output), &response); err != nil {
+	if err := json.Unmarshal([]byte(stdoutOutput), &response); err != nil {
 		result.Error = fmt.Sprintf("failed to parse Azure Repos PR output: %v", err)
 		return result, nil
 	}

--- a/apps/backend/internal/agentctl/server/process/git_test.go
+++ b/apps/backend/internal/agentctl/server/process/git_test.go
@@ -173,6 +173,11 @@ func TestDetectPRProvider(t *testing.T) {
 	}{
 		{name: "azure https", remote: "https://dev.azure.com/acme/platform/_git/widgets", want: prProviderAzureRepos},
 		{name: "azure ssh", remote: "git@ssh.dev.azure.com:v3/acme/platform/widgets", want: prProviderAzureRepos},
+		{
+			name:   "azure ssh url scheme",
+			remote: "ssh://ssh.dev.azure.com:22/v3/acme/platform/widgets",
+			want:   prProviderAzureRepos,
+		},
 		{name: "visualstudio", remote: "https://acme.visualstudio.com/platform/_git/widgets", want: prProviderAzureRepos},
 		{name: "github", remote: "https://github.com/acme/widgets.git", want: prProviderGitHub},
 		{
@@ -199,6 +204,11 @@ func TestRemoteHostFromURL(t *testing.T) {
 	}{
 		{name: "https", remote: "https://dev.azure.com/acme/platform/_git/widgets", want: "dev.azure.com"},
 		{name: "scp", remote: "git@ssh.dev.azure.com:v3/acme/platform/widgets", want: "ssh.dev.azure.com"},
+		{
+			name:   "ssh url scheme",
+			remote: "ssh://ssh.dev.azure.com:22/v3/acme/platform/widgets",
+			want:   "ssh.dev.azure.com",
+		},
 		{name: "github", remote: "https://github.com/acme/widgets.git", want: "github.com"},
 	}
 
@@ -211,17 +221,9 @@ func TestRemoteHostFromURL(t *testing.T) {
 	}
 }
 
-func TestExtractJSONObject(t *testing.T) {
+func TestParseAzurePRCreateResponse(t *testing.T) {
 	payload := `{"pullRequestId":42,"repository":{"remoteUrl":"https://dev.azure.com/acme/platform/_git/widgets"}}`
 	stdout := "Creating pull request...\n" + payload
-
-	got, ok := extractJSONObject(stdout)
-	if !ok {
-		t.Fatal("extractJSONObject() = false")
-	}
-	if got != payload {
-		t.Fatalf("extractJSONObject() = %q, want %q", got, payload)
-	}
 
 	response, err := parseAzurePRCreateResponse(stdout)
 	if err != nil {
@@ -229,6 +231,19 @@ func TestExtractJSONObject(t *testing.T) {
 	}
 	if response.PullRequestID != 42 {
 		t.Fatalf("PullRequestID = %d, want 42", response.PullRequestID)
+	}
+}
+
+func TestParseAzurePRCreateResponse_bracesInString(t *testing.T) {
+	// Braces inside JSON string values must not break line-based parsing.
+	stdout := "status line\n" + `{"pullRequestId":7,"repository":{"remoteUrl":"https://dev.azure.com/o/p/_git/r","note":"} not end"}}`
+
+	response, err := parseAzurePRCreateResponse(stdout)
+	if err != nil {
+		t.Fatalf("parseAzurePRCreateResponse() error = %v", err)
+	}
+	if response.PullRequestID != 7 {
+		t.Fatalf("PullRequestID = %d, want 7", response.PullRequestID)
 	}
 }
 
@@ -257,6 +272,13 @@ func TestParseAzureRepoInfo(t *testing.T) {
 		{
 			name:     "azure ssh",
 			remote:   "git@ssh.dev.azure.com:v3/acme/platform/widgets",
+			wantOrg:  "https://dev.azure.com/acme",
+			wantProj: "platform",
+			wantRepo: "widgets",
+		},
+		{
+			name:     "azure ssh url scheme",
+			remote:   "ssh://ssh.dev.azure.com:22/v3/acme/platform/widgets",
 			wantOrg:  "https://dev.azure.com/acme",
 			wantProj: "platform",
 			wantRepo: "widgets",

--- a/apps/backend/internal/agentctl/server/process/git_test.go
+++ b/apps/backend/internal/agentctl/server/process/git_test.go
@@ -234,6 +234,18 @@ func TestParseAzurePRCreateResponse(t *testing.T) {
 	}
 }
 
+func TestParseAzurePRCreateResponse_multilineJSON(t *testing.T) {
+	stdout := "Creating pull request...\n{\n  \"pullRequestId\": 9,\n  \"repository\": {\n    \"remoteUrl\": \"https://dev.azure.com/acme/platform/_git/widgets\"\n  }\n}\n"
+
+	response, err := parseAzurePRCreateResponse(stdout)
+	if err != nil {
+		t.Fatalf("parseAzurePRCreateResponse() error = %v", err)
+	}
+	if response.PullRequestID != 9 {
+		t.Fatalf("PullRequestID = %d, want 9", response.PullRequestID)
+	}
+}
+
 func TestParseAzurePRCreateResponse_bracesInString(t *testing.T) {
 	// Braces inside JSON string values must not break line-based parsing.
 	stdout := "status line\n" + `{"pullRequestId":7,"repository":{"remoteUrl":"https://dev.azure.com/o/p/_git/r","note":"} not end"}}`

--- a/apps/backend/internal/agentctl/server/process/git_test.go
+++ b/apps/backend/internal/agentctl/server/process/git_test.go
@@ -113,7 +113,7 @@ func TestGitOperatorCreatePR_UsesAzureCLIForAzureRepos(t *testing.T) {
 	scriptDir := t.TempDir()
 	azArgsPath := filepath.Join(scriptDir, "az-args.txt")
 	writeExecutable(t, filepath.Join(scriptDir, "git"), fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"remote\" ] && [ \"$2\" = \"get-url\" ] && [ \"$3\" = \"origin\" ]; then\n  printf '%s\\n' 'git@ssh.dev.azure.com:v3/acme/platform/widgets'\n  exit 0\nfi\nexec %q \"$@\"\n", "%s", realGit))
-	writeExecutable(t, filepath.Join(scriptDir, "az"), fmt.Sprintf("#!/bin/sh\nprintf '%s\\n' \"$@\" > %q\nprintf '%s\\n' 'WARNING: preview command group' >&2\ncat <<'EOF'\n{\"pullRequestId\":42,\"repository\":{\"remoteUrl\":\"https://dev.azure.com/acme/platform/_git/widgets\"}}\nEOF\n", "%s", azArgsPath, "%s"))
+	writeExecutable(t, filepath.Join(scriptDir, "az"), fmt.Sprintf("#!/bin/sh\nprintf '%s\\n' \"$@\" > %q\nprintf '%s\\n' 'WARNING: preview command group' >&2\nprintf 'Creating pull request...\\n'\ncat <<'EOF'\n{\"pullRequestId\":42,\"repository\":{\"remoteUrl\":\"https://dev.azure.com/acme/platform/_git/widgets\"}}\nEOF\n", "%s", azArgsPath, "%s"))
 	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	gitOp := NewGitOperator(repoDir, log, nil)
@@ -162,6 +162,73 @@ func writeExecutable(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
 		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func TestDetectPRProvider(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote string
+		want   prProvider
+	}{
+		{name: "azure https", remote: "https://dev.azure.com/acme/platform/_git/widgets", want: prProviderAzureRepos},
+		{name: "azure ssh", remote: "git@ssh.dev.azure.com:v3/acme/platform/widgets", want: prProviderAzureRepos},
+		{name: "visualstudio", remote: "https://acme.visualstudio.com/platform/_git/widgets", want: prProviderAzureRepos},
+		{name: "github", remote: "https://github.com/acme/widgets.git", want: prProviderGitHub},
+		{
+			name:   "github path must not match azure substring",
+			remote: "git@github.com:acme/dev.azure.com-docs.git",
+			want:   prProviderGitHub,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectPRProvider(tt.remote); got != tt.want {
+				t.Fatalf("detectPRProvider(%q) = %q, want %q", tt.remote, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteHostFromURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{name: "https", remote: "https://dev.azure.com/acme/platform/_git/widgets", want: "dev.azure.com"},
+		{name: "scp", remote: "git@ssh.dev.azure.com:v3/acme/platform/widgets", want: "ssh.dev.azure.com"},
+		{name: "github", remote: "https://github.com/acme/widgets.git", want: "github.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remoteHostFromURL(tt.remote); got != tt.want {
+				t.Fatalf("remoteHostFromURL(%q) = %q, want %q", tt.remote, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractJSONObject(t *testing.T) {
+	payload := `{"pullRequestId":42,"repository":{"remoteUrl":"https://dev.azure.com/acme/platform/_git/widgets"}}`
+	stdout := "Creating pull request...\n" + payload
+
+	got, ok := extractJSONObject(stdout)
+	if !ok {
+		t.Fatal("extractJSONObject() = false")
+	}
+	if got != payload {
+		t.Fatalf("extractJSONObject() = %q, want %q", got, payload)
+	}
+
+	response, err := parseAzurePRCreateResponse(stdout)
+	if err != nil {
+		t.Fatalf("parseAzurePRCreateResponse() error = %v", err)
+	}
+	if response.PullRequestID != 42 {
+		t.Fatalf("PullRequestID = %d, want 42", response.PullRequestID)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/process/git_test.go
+++ b/apps/backend/internal/agentctl/server/process/git_test.go
@@ -2,8 +2,11 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -86,4 +89,135 @@ func TestParseCommitDiff_PathsWithSpaces(t *testing.T) {
 		}
 		t.Errorf("expected Files to contain key %q, got keys: %v", expectedPath, keys)
 	}
+}
+
+func TestGitOperatorCreatePR_UsesAzureCLIForAzureRepos(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell wrapper test is Unix-only")
+	}
+
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	runGit(t, repoDir, "checkout", "-b", "feature/azure-pr")
+	writeFile(t, repoDir, "azure.txt", "azure repos\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "add azure change")
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find git: %v", err)
+	}
+
+	scriptDir := t.TempDir()
+	azArgsPath := filepath.Join(scriptDir, "az-args.txt")
+	writeExecutable(t, filepath.Join(scriptDir, "git"), fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"remote\" ] && [ \"$2\" = \"get-url\" ] && [ \"$3\" = \"origin\" ]; then\n  printf '%s\\n' 'git@ssh.dev.azure.com:v3/acme/platform/widgets'\n  exit 0\nfi\nexec %q \"$@\"\n", "%s", realGit))
+	writeExecutable(t, filepath.Join(scriptDir, "az"), fmt.Sprintf("#!/bin/sh\nprintf '%s\\n' \"$@\" > %q\ncat <<'EOF'\n{\"pullRequestId\":42,\"repository\":{\"remoteUrl\":\"https://dev.azure.com/acme/platform/_git/widgets\"}}\nEOF\n", "%s", azArgsPath))
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	gitOp := NewGitOperator(repoDir, log, nil)
+	result, err := gitOp.CreatePR(context.Background(), "Add Azure support", "PR body", "origin/main", true)
+	if err != nil {
+		t.Fatalf("CreatePR returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("CreatePR failed: %+v", result)
+	}
+
+	if got, want := result.PRURL, "https://dev.azure.com/acme/platform/_git/widgets/pullrequest/42"; got != want {
+		t.Fatalf("PRURL = %q, want %q", got, want)
+	}
+
+	gotArgs := readScriptArgs(t, azArgsPath)
+	wantArgs := []string{
+		"repos",
+		"pr",
+		"create",
+		"--organization",
+		"https://dev.azure.com/acme",
+		"--project",
+		"platform",
+		"--repository",
+		"widgets",
+		"--source-branch",
+		"feature/azure-pr",
+		"--target-branch",
+		"main",
+		"--title",
+		"Add Azure support",
+		"--description",
+		"PR body",
+		"--draft",
+		"true",
+		"-o",
+		"json",
+	}
+	if strings.Join(gotArgs, "\n") != strings.Join(wantArgs, "\n") {
+		t.Fatalf("az args mismatch\n got: %q\nwant: %q", gotArgs, wantArgs)
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func TestParseAzureRepoInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		remote   string
+		wantOrg  string
+		wantProj string
+		wantRepo string
+	}{
+		{
+			name:     "dev azure https",
+			remote:   "https://dev.azure.com/acme/platform/_git/widgets.git",
+			wantOrg:  "https://dev.azure.com/acme",
+			wantProj: "platform",
+			wantRepo: "widgets",
+		},
+		{
+			name:     "visualstudio https",
+			remote:   "https://acme.visualstudio.com/platform/_git/widgets",
+			wantOrg:  "https://acme.visualstudio.com",
+			wantProj: "platform",
+			wantRepo: "widgets",
+		},
+		{
+			name:     "azure ssh",
+			remote:   "git@ssh.dev.azure.com:v3/acme/platform/widgets",
+			wantOrg:  "https://dev.azure.com/acme",
+			wantProj: "platform",
+			wantRepo: "widgets",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := parseAzureRepoInfo(tt.remote)
+			if err != nil {
+				t.Fatalf("parseAzureRepoInfo(%q) error = %v", tt.remote, err)
+			}
+			if info.OrganizationURL != tt.wantOrg || info.Project != tt.wantProj || info.Repository != tt.wantRepo {
+				t.Fatalf("parseAzureRepoInfo(%q) = %+v, want org=%q project=%q repo=%q", tt.remote, info, tt.wantOrg, tt.wantProj, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func readScriptArgs(t *testing.T, path string) []string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	trimmed := strings.TrimSpace(string(content))
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
 }

--- a/apps/backend/internal/agentctl/server/process/git_test.go
+++ b/apps/backend/internal/agentctl/server/process/git_test.go
@@ -113,7 +113,7 @@ func TestGitOperatorCreatePR_UsesAzureCLIForAzureRepos(t *testing.T) {
 	scriptDir := t.TempDir()
 	azArgsPath := filepath.Join(scriptDir, "az-args.txt")
 	writeExecutable(t, filepath.Join(scriptDir, "git"), fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"remote\" ] && [ \"$2\" = \"get-url\" ] && [ \"$3\" = \"origin\" ]; then\n  printf '%s\\n' 'git@ssh.dev.azure.com:v3/acme/platform/widgets'\n  exit 0\nfi\nexec %q \"$@\"\n", "%s", realGit))
-	writeExecutable(t, filepath.Join(scriptDir, "az"), fmt.Sprintf("#!/bin/sh\nprintf '%s\\n' \"$@\" > %q\ncat <<'EOF'\n{\"pullRequestId\":42,\"repository\":{\"remoteUrl\":\"https://dev.azure.com/acme/platform/_git/widgets\"}}\nEOF\n", "%s", azArgsPath))
+	writeExecutable(t, filepath.Join(scriptDir, "az"), fmt.Sprintf("#!/bin/sh\nprintf '%s\\n' \"$@\" > %q\nprintf '%s\\n' 'WARNING: preview command group' >&2\ncat <<'EOF'\n{\"pullRequestId\":42,\"repository\":{\"remoteUrl\":\"https://dev.azure.com/acme/platform/_git/widgets\"}}\nEOF\n", "%s", azArgsPath, "%s"))
 	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	gitOp := NewGitOperator(repoDir, log, nil)
@@ -204,6 +204,67 @@ func TestParseAzureRepoInfo(t *testing.T) {
 			}
 			if info.OrganizationURL != tt.wantOrg || info.Project != tt.wantProj || info.Repository != tt.wantRepo {
 				t.Fatalf("parseAzureRepoInfo(%q) = %+v, want org=%q project=%q repo=%q", tt.remote, info, tt.wantOrg, tt.wantProj, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestSanitizeRepositoryArgs(t *testing.T) {
+	got := sanitizeRepositoryArgs([]string{
+		"pr",
+		"create",
+		"--title",
+		"real title",
+		"--body=secret body",
+		"--description",
+		"secret description",
+		"--head",
+		"feature/branch",
+	})
+
+	want := []string{
+		"pr",
+		"create",
+		"--title",
+		"[REDACTED]",
+		"--body=[REDACTED]",
+		"--description",
+		"[REDACTED]",
+		"--head",
+		"feature/branch",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("sanitizeRepositoryArgs() = %q, want %q", got, want)
+	}
+}
+
+func TestRedactRemoteURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "https credentials",
+			url:  "https://token:x-oauth-basic@github.com/acme/widgets.git",
+			want: "https://github.com/acme/widgets.git",
+		},
+		{
+			name: "scp style",
+			url:  "git@ssh.dev.azure.com:v3/acme/platform/widgets",
+			want: "ssh.dev.azure.com:v3/acme/platform/widgets",
+		},
+		{
+			name: "plain https",
+			url:  "https://dev.azure.com/acme/platform/_git/widgets",
+			want: "https://dev.azure.com/acme/platform/_git/widgets",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactRemoteURL(tt.url); got != tt.want {
+				t.Fatalf("redactRemoteURL(%q) = %q, want %q", tt.url, got, tt.want)
 			}
 		})
 	}

--- a/docs/remote-cloud-environment.md
+++ b/docs/remote-cloud-environment.md
@@ -9,6 +9,11 @@ Setup notes and caveats for developing Kandev in ephemeral cloud VMs (Cursor Clo
 - **pnpm 9.15.9** — matches `packageManager` in `apps/package.json`. Install with `npm install -g pnpm@9.15.9`.
 - **golangci-lint v2** — required for `make lint-backend`. Install with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.
 - **gcc** — required for CGO (SQLite FTS5). Pre-installed on most Ubuntu-based cloud VMs.
+- **Azure Repos PR creation (optional)** — only needed when testing `worktree.create_pr` against Azure remotes:
+  - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) (`az`) on `PATH`
+  - DevOps extension: `az extension add --name azure-devops`
+  - Auth: `az login` or `export AZURE_DEVOPS_EXT_PAT=<pat>`
+  - GitHub PR creation still uses `gh` (see host table in `apps/backend/internal/agentctl/AGENTS.md`).
 
 ## Generated files before typecheck
 


### PR DESCRIPTION
Add Azure Repos pull request creation to the agentctl git flow so Azure-hosted repos no longer fail on the GitHub-only `gh pr create` path. This teaches the PR creation path to detect Azure remotes, call `az repos pr create`, and avoid routing Azure PR URLs through GitHub association callbacks.

## Important Changes
- detect Azure Repos remotes from HTTPS and SSH origin URLs
- create Azure pull requests with `az repos pr create` and map the JSON response back to a browser PR URL
- keep GitHub PR association callbacks limited to GitHub-style `/pull/` URLs
- document the Azure Repos branch of the `/pr` skill

## Validation
- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps/backend && go test ./internal/agentctl/server/process ./internal/agent/handlers`

## Checklist
- [ ] Tests added/updated for the change
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Related issues
- Original task title: `Add support for azure repos. Currently there is only support for github and gitlab for creating PR`
