### PR TITLE
fix(ci): disable track_progress for labeled event in claude-review-fork

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -153,7 +153,7 @@ jobs:
           # enough for the action to post review comments. Author will be
           # github-actions[bot] on this path.
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          track_progress: true
+          track_progress: ${{ github.event.action != 'labeled' }}
           allowed_bots: "*"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `claude-review-fork` job runs when a maintainer applies the `safe-to-review` label to a fork PR (`pull_request_target` with `labeled` action). `claude-code-action@v1` does not support `track_progress: true` for that event, which caused the workflow to fail with:

> track_progress for pull_request events is only supported for actions: opened, synchronize, ready_for_review, reopened. Current action: labeled

## Change

Set `track_progress` conditionally in the fork job so it stays enabled for push-like PR events but is disabled when the trigger is `labeled`:

```yaml
track_progress: ${{ github.event.action != 'labeled' }}
```

The same-repo job is unchanged; it only runs on non-`labeled` events.

## Testing

- Workflow YAML change only; verified expression matches the intended fork vs. same-repo trigger split.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4d2353d-6510-47f9-8b48-f38b41595eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4d2353d-6510-47f9-8b48-f38b41595eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>