### PR TITLE
docs: add cloud-VM caveats and Playwright install script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,13 +103,7 @@ When a change is scoped to a single subtree, update the scoped `AGENTS.md` inste
 
 ## Remote cloud environment
 
-For developing in ephemeral cloud VMs (Cursor Cloud, Codex, GitHub Codespaces, etc.), see [`docs/remote-cloud-environment.md`](docs/remote-cloud-environment.md) — covers runtime requirements, generated-file gotchas, and dev-mode setup.
-
----
-
-## Cursor Cloud specific instructions
-
-See [`docs/remote-cloud-environment.md`](docs/remote-cloud-environment.md) for runtime requirements, generated-file prerequisites, dev-mode setup, key commands, and Firecracker-specific caveats (golangci-lint PATH, Playwright io_uring workaround, known test flakes).
+For developing in ephemeral cloud VMs (Cursor Cloud, Codex, GitHub Codespaces, etc.), see [`docs/remote-cloud-environment.md`](docs/remote-cloud-environment.md) — covers runtime requirements, generated-file gotchas, dev-mode setup, key commands, and Firecracker-specific caveats.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,9 @@ Setup details are in [`docs/remote-cloud-environment.md`](docs/remote-cloud-envi
 - **Generated files before typecheck**: `make typecheck` requires two gitignored files. Run `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs` before `make typecheck` (the update script handles this automatically).
 - **`make dev`** starts both backend (`:38429`) and web (`:37429`) via the CLI launcher. No external services needed — SQLite is embedded, event bus is in-memory, mock agent is auto-registered in dev profile. First page load may be slow (~25s) due to Turbopack compilation.
 - **CLI test flake**: `src/ports.test.ts > isPortInUse > returns false within the timeout when the host black-holes packets` fails in cloud VMs due to network environment differences (192.0.2.1 behaves differently). This is a known environment-specific flake, not a code issue.
-- **Key commands** (all from repo root): `make dev` (run), `make test` (all tests), `make lint` (all linters), `make typecheck` (tsc), `make fmt` (format). See root `Makefile` for full list.
+- **Playwright browser installation**: `playwright install chromium` hangs during zip extraction in Firecracker-based cloud VMs (Node.js io_uring incompatibility). Workaround: download the zip with Playwright, then kill the stuck extraction process, manually `unzip` the archive into `~/.cache/ms-playwright/<browser>-<revision>/`, and write an `INSTALLATION_COMPLETE` marker file. The update script handles this automatically. System deps are pre-installed; if not, run `playwright install-deps chromium`.
+- **E2E tests**: require a production build first (`make build-backend && make build-web`), then `make test-e2e`. Tests use `e2e/playwright.config.ts` (not the root config). 1000+ specs.
+- **Key commands** (all from repo root): `make dev` (run), `make test` (all tests), `make lint` (all linters), `make typecheck` (tsc), `make fmt` (format), `make test-e2e` (E2E). See root `Makefile` for full list.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,4 +107,16 @@ For developing in ephemeral cloud VMs (Cursor Cloud, Codex, GitHub Codespaces, e
 
 ---
 
+## Cursor Cloud specific instructions
+
+Setup details are in [`docs/remote-cloud-environment.md`](docs/remote-cloud-environment.md). Key caveats for cloud agents:
+
+- **golangci-lint** is installed to `~/go/bin/` via `go install`. The update script ensures `~/go/bin` is on `PATH` via `~/.bashrc`, but in-session shells may need `export PATH="$PATH:$HOME/go/bin"` if the profile hasn't been sourced.
+- **Generated files before typecheck**: `make typecheck` requires two gitignored files. Run `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs` before `make typecheck` (the update script handles this automatically).
+- **`make dev`** starts both backend (`:38429`) and web (`:37429`) via the CLI launcher. No external services needed — SQLite is embedded, event bus is in-memory, mock agent is auto-registered in dev profile. First page load may be slow (~25s) due to Turbopack compilation.
+- **CLI test flake**: `src/ports.test.ts > isPortInUse > returns false within the timeout when the host black-holes packets` fails in cloud VMs due to network environment differences (192.0.2.1 behaves differently). This is a known environment-specific flake, not a code issue.
+- **Key commands** (all from repo root): `make dev` (run), `make test` (all tests), `make lint` (all linters), `make typecheck` (tsc), `make fmt` (format). See root `Makefile` for full list.
+
+---
+
 **Last Updated**: 2026-05-24

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,15 +109,7 @@ For developing in ephemeral cloud VMs (Cursor Cloud, Codex, GitHub Codespaces, e
 
 ## Cursor Cloud specific instructions
 
-Setup details are in [`docs/remote-cloud-environment.md`](docs/remote-cloud-environment.md). Key caveats for cloud agents:
-
-- **golangci-lint** is installed to `~/go/bin/` via `go install`. The update script ensures `~/go/bin` is on `PATH` via `~/.bashrc`, but in-session shells may need `export PATH="$PATH:$HOME/go/bin"` if the profile hasn't been sourced.
-- **Generated files before typecheck**: `make typecheck` requires two gitignored files. Run `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs` before `make typecheck` (the update script handles this automatically).
-- **`make dev`** starts both backend (`:38429`) and web (`:37429`) via the CLI launcher. No external services needed — SQLite is embedded, event bus is in-memory, mock agent is auto-registered in dev profile. First page load may be slow (~25s) due to Turbopack compilation.
-- **CLI test flake**: `src/ports.test.ts > isPortInUse > returns false within the timeout when the host black-holes packets` fails in cloud VMs due to network environment differences (192.0.2.1 behaves differently). This is a known environment-specific flake, not a code issue.
-- **Playwright browser installation**: `playwright install chromium` hangs during zip extraction in Firecracker-based cloud VMs (Node.js io_uring incompatibility). Workaround: download the zip with Playwright, then kill the stuck extraction process, manually `unzip` the archive into `~/.cache/ms-playwright/<browser>-<revision>/`, and write an `INSTALLATION_COMPLETE` marker file. The update script handles this automatically. System deps are pre-installed; if not, run `playwright install-deps chromium`.
-- **E2E tests**: require a production build first (`make build-backend && make build-web`), then `make test-e2e`. Tests use `e2e/playwright.config.ts` (not the root config). 1000+ specs.
-- **Key commands** (all from repo root): `make dev` (run), `make test` (all tests), `make lint` (all linters), `make typecheck` (tsc), `make fmt` (format), `make test-e2e` (E2E). See root `Makefile` for full list.
+See [`docs/remote-cloud-environment.md`](docs/remote-cloud-environment.md) for runtime requirements, generated-file prerequisites, dev-mode setup, key commands, and Firecracker-specific caveats (golangci-lint PATH, Playwright io_uring workaround, known test flakes).
 
 ---
 

--- a/docs/remote-cloud-environment.md
+++ b/docs/remote-cloud-environment.md
@@ -33,3 +33,13 @@ All documented in the root `Makefile`:
 - `make lint` — golangci-lint + ESLint
 - `make typecheck` — TypeScript type-checking across all apps
 - `make fmt` — format all code (run before lint to avoid false positives)
+- `make test-e2e` — Playwright E2E tests (requires `make build-backend && make build-web` first). Uses `e2e/playwright.config.ts`. 1000+ specs.
+
+## Firecracker / cloud-VM caveats
+
+These apply to Cursor Cloud, Codex, and similar Firecracker-backed sandboxes:
+
+- **golangci-lint PATH**: `go install` places the binary in `~/go/bin/`. Ensure `PATH` includes it (the update script appends to `~/.bashrc`, but in-session shells may need `export PATH="$PATH:$HOME/go/bin"`).
+- **First page load**: `make dev` compiles pages on first visit via Turbopack — expect ~25 s for the initial load.
+- **CLI test flake**: `src/ports.test.ts > isPortInUse > returns false within the timeout when the host black-holes packets` fails because `192.0.2.1` behaves differently inside Firecracker. This is a known environment-specific flake, not a code issue.
+- **Playwright browser installation**: `playwright install chromium` hangs during zip extraction (Node.js io_uring incompatibility with the Firecracker kernel). Workaround: `scripts/install-playwright-browsers.sh` runs the install with a timeout, then falls back to extracting the already-downloaded zips with `unzip`. The update script calls this automatically. System deps can be installed via `playwright install-deps chromium`.

--- a/scripts/install-playwright-browsers.sh
+++ b/scripts/install-playwright-browsers.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# install-playwright-browsers.sh — install Playwright chromium browser
+# with a workaround for Firecracker VMs where Node.js io_uring-based
+# zip extraction hangs indefinitely.
+#
+# Strategy: run `playwright install chromium` with a timeout. If it
+# completes, great. If it hangs (extraction stuck), kill it and
+# manually extract the already-downloaded zips with `unzip`.
+
+set -euo pipefail
+
+PW_CACHE="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+TIMEOUT_SECS=90
+
+cd "$(dirname "$0")/../apps"
+
+# Check if browsers are already fully installed
+if pnpm --filter @kandev/web exec playwright install chromium --dry-run 2>&1 | grep -q "already installed"; then
+  echo "[playwright] browsers already installed"
+  exit 0
+fi
+
+# Install system dependencies (idempotent, needs sudo)
+pnpm --filter @kandev/web exec playwright install-deps chromium 2>/dev/null || true
+
+# Attempt normal install with timeout
+rm -rf "$PW_CACHE/__dirlock"
+if timeout "$TIMEOUT_SECS" pnpm --filter @kandev/web exec playwright install chromium 2>&1; then
+  echo "[playwright] install completed normally"
+  exit 0
+fi
+
+echo "[playwright] install timed out — falling back to manual extraction"
+
+# Kill any leftover oopDownload processes
+pkill -f oopDownloadBrowserMain 2>/dev/null || true
+sleep 1
+
+# Manually extract any downloaded zips that weren't fully extracted
+for comp_dir in "$PW_CACHE"/chromium-* "$PW_CACHE"/chromium_headless_shell-* "$PW_CACHE"/ffmpeg-*; do
+  [ -d "$comp_dir" ] || continue
+  [ -f "$comp_dir/INSTALLATION_COMPLETE" ] && continue
+
+  comp_name=$(basename "$comp_dir" | sed 's/-[0-9]*$//')
+  zipfile=$(find /tmp -name "playwright-download-${comp_name}-*" -type f 2>/dev/null | sort | tail -1)
+
+  if [ -z "$zipfile" ]; then
+    echo "[playwright] no zip found for $comp_name — skipping"
+    continue
+  fi
+
+  if ! unzip -t "$zipfile" >/dev/null 2>&1; then
+    echo "[playwright] zip corrupt for $comp_name — skipping"
+    continue
+  fi
+
+  echo "[playwright] extracting $comp_name from $zipfile"
+  rm -rf "$comp_dir"
+  mkdir -p "$comp_dir"
+  (cd "$comp_dir" && unzip -q "$zipfile")
+  echo '{}' > "$comp_dir/INSTALLATION_COMPLETE"
+done
+
+echo "[playwright] manual extraction complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Firecracker/cloud-VM caveats to `docs/remote-cloud-environment.md` (golangci-lint PATH, first-load latency, CLI test flake, Playwright io_uring workaround, E2E test instructions) and a helper script for reliable Playwright browser installation in sandboxed environments.

## Important Changes

- `docs/remote-cloud-environment.md` — added "Firecracker / cloud-VM caveats" section and `make test-e2e` to key commands.
- `scripts/install-playwright-browsers.sh` — new script that runs `playwright install chromium` with a timeout, falling back to manual `unzip` extraction when Node.js io_uring hangs in Firecracker VMs.
- `AGENTS.md` — updated the existing "Remote cloud environment" pointer to reflect the new content; no Cursor-specific section (all caveats are generic).

## Validation

- `make lint` — 0 issues (backend + web)
- `make test` — backend + web pass, CLI 223/224 (1 known VM flake)
- `make typecheck` — all apps pass
- `make dev` — backend + web start, kanban board functional
- `scripts/install-playwright-browsers.sh` — tested end-to-end; Playwright lists 1056 E2E tests

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17cc5a1e-289d-49bf-9c14-d630aebb645c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17cc5a1e-289d-49bf-9c14-d630aebb645c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>