### PR TITLE
fix(mobile): honor is_passthrough when snapshot missing (closes #1031)

### DIFF
--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import type { StoreApi } from "zustand";
 import { useStore } from "zustand";
 import type { AppState, StoreProviderProps } from "@/lib/state/store";
@@ -8,8 +8,20 @@ import { createAppStore } from "@/lib/state/store";
 
 const StoreContext = createContext<StoreApi<AppState> | null>(null);
 
+type E2EWindow = Window & {
+  __KANDEV_E2E_EXPOSE_STORE__?: boolean;
+  __KANDEV_E2E_STORE__?: StoreApi<AppState>;
+};
+
 export function StateProvider({ children, initialState }: StoreProviderProps) {
   const [store] = useState(() => createAppStore(initialState));
+
+  useEffect(() => {
+    const win = window as E2EWindow;
+    if (win.__KANDEV_E2E_EXPOSE_STORE__) {
+      win.__KANDEV_E2E_STORE__ = store;
+    }
+  }, [store]);
 
   return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>;
 }

--- a/apps/web/components/task/task-center-panel.tsx
+++ b/apps/web/components/task/task-center-panel.tsx
@@ -53,10 +53,7 @@ function useSessionApprove(activeSessionId: string | null, activeTaskId: string 
   );
   const setTaskSession = useAppStore((state) => state.setTaskSession);
   const isAgentWorking = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
-  const isPassthroughMode = useMemo(
-    () => isPassthroughSession(activeSession),
-    [activeSession],
-  );
+  const isPassthroughMode = useMemo(() => isPassthroughSession(activeSession), [activeSession]);
   const showApproveButton =
     !!activeSession?.review_status && activeSession.review_status !== "approved" && !isAgentWorking;
   const handleApprove = useCallback(async () => {

--- a/apps/web/components/task/task-center-panel.tsx
+++ b/apps/web/components/task/task-center-panel.tsx
@@ -27,6 +27,7 @@ import {
   getActiveTabForSession,
   setActiveTabForSession,
 } from "@/lib/local-storage";
+import { isPassthroughSession } from "@/lib/session/is-passthrough-session";
 import { useSessionGitStatus } from "@/hooks/domains/session/use-session-git-status";
 import { useSessionCommits } from "@/hooks/domains/session/use-session-commits";
 import { calculateHash } from "@/lib/utils/file-diff";
@@ -52,12 +53,10 @@ function useSessionApprove(activeSessionId: string | null, activeTaskId: string 
   );
   const setTaskSession = useAppStore((state) => state.setTaskSession);
   const isAgentWorking = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
-  const isPassthroughMode = useMemo(() => {
-    if (!activeSession?.agent_profile_snapshot) return false;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const snapshot = activeSession.agent_profile_snapshot as any;
-    return snapshot?.cli_passthrough === true;
-  }, [activeSession?.agent_profile_snapshot]);
+  const isPassthroughMode = useMemo(
+    () => isPassthroughSession(activeSession),
+    [activeSession],
+  );
   const showApproveButton =
     !!activeSession?.review_status && activeSession.review_status !== "approved" && !isAgentWorking;
   const handleApprove = useCallback(async () => {

--- a/apps/web/e2e/fixtures/test-base.ts
+++ b/apps/web/e2e/fixtures/test-base.ts
@@ -244,6 +244,7 @@ async function setupPage(page: Page, backend: BackendContext, seedData: SeedData
       // Set the window global that getBackendConfig() reads for API/WS connections
       // (e2e tests run frontend and backend on separate ports, like dev mode)
       window.__KANDEV_API_PORT = backendPort;
+      window.__KANDEV_E2E_EXPOSE_STORE__ = true;
 
       // Replace native Notification with a capture stub so e2e runs never
       // pop OS-level toasts on the developer's machine. Tests that want to

--- a/apps/web/e2e/helpers/session-store.ts
+++ b/apps/web/e2e/helpers/session-store.ts
@@ -1,0 +1,35 @@
+import type { Page } from "@playwright/test";
+
+type E2EStoreWindow = Window & {
+  __KANDEV_E2E_STORE__?: {
+    getState: () => {
+      taskSessions: { items: Record<string, Record<string, unknown>> };
+      setTaskSession: (session: Record<string, unknown>) => void;
+    };
+  };
+};
+
+/**
+ * Simulate a lean session-list / partial WS update: keep is_passthrough but drop
+ * agent_profile_snapshot from the client store.
+ */
+export async function stripSessionProfileSnapshot(
+  page: Page,
+  sessionId: string,
+): Promise<void> {
+  await page.evaluate((sid) => {
+    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+    if (!store) {
+      throw new Error("E2E store bridge missing — is __KANDEV_E2E_EXPOSE_STORE__ set?");
+    }
+    const session = store.getState().taskSessions.items[sid];
+    if (!session) {
+      throw new Error(`Session ${sid} not found in store`);
+    }
+    store.getState().setTaskSession({
+      ...session,
+      is_passthrough: true,
+      agent_profile_snapshot: undefined,
+    });
+  }, sessionId);
+}

--- a/apps/web/e2e/helpers/session-store.ts
+++ b/apps/web/e2e/helpers/session-store.ts
@@ -4,32 +4,41 @@ type E2EStoreWindow = Window & {
   __KANDEV_E2E_STORE__?: {
     getState: () => {
       taskSessions: { items: Record<string, Record<string, unknown>> };
-      setTaskSession: (session: Record<string, unknown>) => void;
     };
+    setState: (
+      updater: (state: {
+        taskSessions: { items: Record<string, Record<string, unknown>> };
+      }) => void,
+    ) => void;
   };
 };
 
 /**
- * Simulate a lean session-list / partial WS update: keep is_passthrough but drop
- * agent_profile_snapshot from the client store.
+ * Simulate a lean session-list / partial WS update: preserve `is_passthrough`
+ * but drop `agent_profile_snapshot` from the client store.
+ *
+ * Uses `setState` directly so we bypass `mergeTaskSession`'s nullish-coalescing
+ * guard on `agent_profile_snapshot` (see session-slice.ts).
  */
-export async function stripSessionProfileSnapshot(
-  page: Page,
-  sessionId: string,
-): Promise<void> {
+export async function stripSessionProfileSnapshot(page: Page, sessionId: string): Promise<void> {
   await page.evaluate((sid) => {
     const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
     if (!store) {
       throw new Error("E2E store bridge missing — is __KANDEV_E2E_EXPOSE_STORE__ set?");
     }
-    const session = store.getState().taskSessions.items[sid];
-    if (!session) {
-      throw new Error(`Session ${sid} not found in store`);
-    }
-    store.getState().setTaskSession({
-      ...session,
-      is_passthrough: true,
-      agent_profile_snapshot: undefined,
+    store.setState((state) => {
+      const session = state.taskSessions.items[sid];
+      if (!session) {
+        throw new Error(`Session ${sid} not found in store`);
+      }
+      state.taskSessions.items[sid] = {
+        ...session,
+        agent_profile_snapshot: undefined,
+      };
     });
+    const updated = store.getState().taskSessions.items[sid];
+    if (updated?.agent_profile_snapshot !== undefined) {
+      throw new Error("Failed to strip agent_profile_snapshot from session store");
+    }
   }, sessionId);
 }

--- a/apps/web/e2e/tests/terminal/mobile-passthrough-rendering.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-passthrough-rendering.spec.ts
@@ -17,7 +17,6 @@ async function createTUIProfile(apiClient: ApiClient, name: string) {
   }
   return apiClient.createAgentProfile(mockAgent.id, name, {
     model: "mock-fast",
-    auto_approve: true,
     cli_passthrough: true,
   });
 }

--- a/apps/web/e2e/tests/terminal/mobile-passthrough-rendering.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-passthrough-rendering.spec.ts
@@ -1,0 +1,70 @@
+// Routing: /t/{taskId}. File name starts with "mobile-" so it runs on the
+// mobile-chrome Playwright project (Pixel 5 emulation).
+//
+// Regression for #1031: mobile Chat tab must render PassthroughTerminal when
+// session.is_passthrough is set even if agent_profile_snapshot is absent from
+// the client store (lean list responses / partial WS state_changed events).
+import { test, expect } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+import { stripSessionProfileSnapshot } from "../../helpers/session-store";
+
+async function createTUIProfile(apiClient: ApiClient, name: string) {
+  const { agents } = await apiClient.listAgents();
+  const mockAgent = agents.find((a) => a.name === "mock-agent");
+  if (!mockAgent) {
+    throw new Error(`mock-agent not found (got ${agents.map((a) => a.name).join(", ")})`);
+  }
+  return apiClient.createAgentProfile(mockAgent.id, name, {
+    model: "mock-fast",
+    auto_approve: true,
+    cli_passthrough: true,
+  });
+}
+
+test.describe("Mobile passthrough rendering", () => {
+  test("keeps PassthroughTerminal on Chat when snapshot is stripped from store", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const profile = await createTUIProfile(apiClient, "Mobile Passthrough");
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile Passthrough Task",
+      profile.id,
+      {
+        description: "hello from mobile passthrough e2e",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    const sessionId = task.session_id;
+    if (!sessionId) {
+      throw new Error("createTaskWithAgent did not return session_id");
+    }
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+
+    await session.waitForPassthroughLoad();
+    await session.waitForPassthroughLoaded();
+    await session.expectPassthroughHasText("Mock Agent");
+
+    await stripSessionProfileSnapshot(testPage, sessionId);
+
+    // Switch away from Chat and back — mirrors the user flow that re-evaluates
+    // isPassthroughMode from the (now snapshot-less) session row.
+    await testPage.getByRole("button", { name: "Plan" }).tap();
+    await testPage.getByRole("button", { name: "Chat" }).tap();
+
+    await expect(session.passthroughTerminal).toBeVisible({ timeout: 15_000 });
+    await expect(session.chat).toBeHidden();
+    await session.expectPassthroughHasText("Mock Agent");
+  });
+});

--- a/apps/web/hooks/use-session-layout-state.ts
+++ b/apps/web/hooks/use-session-layout-state.ts
@@ -63,10 +63,7 @@ export function useSessionLayoutState(options: UseSessionLayoutStateOptions = {}
   // --- Agent state ---
   const isAgentWorking = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
 
-  const isPassthroughMode = useMemo(
-    () => isPassthroughSession(activeSession),
-    [activeSession],
-  );
+  const isPassthroughMode = useMemo(() => isPassthroughSession(activeSession), [activeSession]);
 
   const { selectedDiff, handleSelectDiff, handleClearSelectedDiff } = useSelectedDiffState();
   const { openFileRequest, handleOpenFile, handleFileOpenHandled } = useOpenFileRequestState();

--- a/apps/web/hooks/use-session-layout-state.ts
+++ b/apps/web/hooks/use-session-layout-state.ts
@@ -7,6 +7,7 @@ import { getPlanLastSeen } from "@/lib/local-storage";
 import { executeApprove } from "@/lib/services/session-approve";
 import type { OpenFileTab } from "@/lib/types/backend";
 import type { MobileSessionPanel } from "@/lib/state/slices/ui/types";
+import { isPassthroughSession } from "@/lib/session/is-passthrough-session";
 
 export type SelectedDiff = {
   path: string;
@@ -62,22 +63,10 @@ export function useSessionLayoutState(options: UseSessionLayoutStateOptions = {}
   // --- Agent state ---
   const isAgentWorking = activeSession?.state === "STARTING" || activeSession?.state === "RUNNING";
 
-  // session.is_passthrough is the source of truth — matches StartAgentProcess
-  // routing in manager_startup.go and what dockview-desktop-layout.tsx reads.
-  // Honor any explicit value (including false) over the snapshot fallback.
-  // The snapshot path remains for legacy rows pre-dating the column and for
-  // the brief window when a state_changed WS event updates is_passthrough
-  // before the full session has been hydrated (see ws/handlers/agent-session.ts
-  // where snapshot writes are guarded by a truthy check while is_passthrough
-  // writes are guarded by !== undefined — partial events can land one without
-  // the other).
-  const isPassthroughMode = useMemo(() => {
-    if (activeSession?.is_passthrough !== undefined) return activeSession.is_passthrough;
-    if (!activeSession?.agent_profile_snapshot) return false;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const snapshot = activeSession.agent_profile_snapshot as any;
-    return snapshot?.cli_passthrough === true;
-  }, [activeSession?.is_passthrough, activeSession?.agent_profile_snapshot]);
+  const isPassthroughMode = useMemo(
+    () => isPassthroughSession(activeSession),
+    [activeSession],
+  );
 
   const { selectedDiff, handleSelectDiff, handleClearSelectedDiff } = useSelectedDiffState();
   const { openFileRequest, handleOpenFile, handleFileOpenHandled } = useOpenFileRequestState();

--- a/apps/web/lib/session/is-passthrough-session.test.ts
+++ b/apps/web/lib/session/is-passthrough-session.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isPassthroughSession } from "./is-passthrough-session";
+
+describe("isPassthroughSession", () => {
+  it("returns true when is_passthrough is true even without a snapshot", () => {
+    expect(isPassthroughSession({ is_passthrough: true })).toBe(true);
+  });
+
+  it("returns false when is_passthrough is false even if snapshot says passthrough", () => {
+    expect(
+      isPassthroughSession({
+        is_passthrough: false,
+        agent_profile_snapshot: { cli_passthrough: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to snapshot.cli_passthrough when is_passthrough is undefined", () => {
+    expect(
+      isPassthroughSession({
+        agent_profile_snapshot: { cli_passthrough: true },
+      }),
+    ).toBe(true);
+    expect(
+      isPassthroughSession({
+        agent_profile_snapshot: { cli_passthrough: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when session is missing or has no passthrough signals", () => {
+    expect(isPassthroughSession(null)).toBe(false);
+    expect(isPassthroughSession(undefined)).toBe(false);
+    expect(isPassthroughSession({})).toBe(false);
+    expect(isPassthroughSession({ agent_profile_snapshot: null })).toBe(false);
+  });
+});

--- a/apps/web/lib/session/is-passthrough-session.ts
+++ b/apps/web/lib/session/is-passthrough-session.ts
@@ -1,0 +1,21 @@
+import type { TaskSession } from "@/lib/types/http";
+
+type PassthroughSessionInput = Pick<TaskSession, "is_passthrough" | "agent_profile_snapshot">;
+
+/**
+ * Whether a session should render the passthrough (PTY/xterm) UI instead of chat.
+ *
+ * `is_passthrough` is authoritative — it matches backend routing in
+ * `StartAgentProcess` and what desktop layouts read directly. The snapshot
+ * fallback covers legacy rows and the brief window when a `state_changed` WS
+ * event updates `is_passthrough` before the full session is hydrated (see
+ * `ws/handlers/agent-session.ts`: snapshot writes are truthy-guarded while
+ * `is_passthrough` writes use `!== undefined`).
+ */
+export function isPassthroughSession(
+  session: PassthroughSessionInput | null | undefined,
+): boolean {
+  if (session?.is_passthrough !== undefined) return session.is_passthrough;
+  const snapshot = session?.agent_profile_snapshot as { cli_passthrough?: boolean } | undefined;
+  return snapshot?.cli_passthrough === true;
+}

--- a/apps/web/lib/session/is-passthrough-session.ts
+++ b/apps/web/lib/session/is-passthrough-session.ts
@@ -12,9 +12,7 @@ type PassthroughSessionInput = Pick<TaskSession, "is_passthrough" | "agent_profi
  * `ws/handlers/agent-session.ts`: snapshot writes are truthy-guarded while
  * `is_passthrough` writes use `!== undefined`).
  */
-export function isPassthroughSession(
-  session: PassthroughSessionInput | null | undefined,
-): boolean {
+export function isPassthroughSession(session: PassthroughSessionInput | null | undefined): boolean {
   if (session?.is_passthrough !== undefined) return session.is_passthrough;
   const snapshot = session?.agent_profile_snapshot as { cli_passthrough?: boolean } | undefined;
   return snapshot?.cli_passthrough === true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Stacked on [#1034](https://github.com/kdlbs/kandev/pull/1034)** — improvements on top of the external contributor's fix for #1031.

Adds helper extraction, unit + E2E tests, tablet parity, and CI/review fixes while preserving the contributor's core `is_passthrough`-first logic.

## Changes (on top of #1034)

- **`isPassthroughSession()`** — shared helper replacing inline memo in `use-session-layout-state.ts`
- **`task-center-panel.tsx`** — tablet layout parity via same helper
- **Unit tests** — precedence rules for `is_passthrough` vs snapshot fallback
- **E2E** — `mobile-passthrough-rendering.spec.ts` with real snapshot strip via `store.setState`
- **E2E infra** — store bridge for test-only store access
- **CI** — Prettier formatting; complexity lint fix

## Merge plan

Merge this PR into #1034 first, then merge #1034 into `main`.

## Test plan

- [x] Unit tests, lint, Prettier
- [x] E2E `mobile-passthrough-rendering.spec.ts`

## Related

- Builds on #1034
- Closes #1031 (via stacked merge into #1034)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fc61d39-ff54-49af-9a65-1e24f30a4480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fc61d39-ff54-49af-9a65-1e24f30a4480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>