### PR TITLE
refactor(orchestrator): address watcher dispatch review feedback

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_jira.go
+++ b/apps/backend/internal/orchestrator/event_handlers_jira.go
@@ -22,9 +22,12 @@ type JiraService interface {
 }
 
 // SetJiraService wires the JIRA dedup helpers into the orchestrator so
-// jira-watch handlers can claim ticket slots before creating tasks.
+// jira-watch handlers can claim ticket slots before creating tasks. Also
+// (re)builds the cached JiraWatcherSource so handleNewJiraIssue can
+// dispatch without allocating per event.
 func (s *Service) SetJiraService(j JiraService) {
 	s.jiraService = j
+	s.jiraSource = NewJiraWatcherSource(j, s.logger)
 }
 
 // subscribeJiraEvents wires the JIRA event handlers onto the bus. Called from
@@ -46,8 +49,13 @@ func (s *Service) handleNewJiraIssue(ctx context.Context, event *bus.Event) erro
 	if !ok || evt == nil || evt.Issue == nil {
 		return nil
 	}
-	s.dispatchWatcherEvent(ctx, "jira",
-		NewJiraWatcherSource(s.jiraService, s.logger), evt,
+	src := s.jiraSource
+	if src == nil {
+		// SetJiraService was never called; fall back to a fail-open
+		// source so behaviour matches the pre-cache code path.
+		src = NewJiraWatcherSource(nil, s.logger)
+	}
+	s.dispatchWatcherEvent(ctx, "jira", src, evt,
 		zap.String("issue_watch_id", evt.IssueWatchID),
 		zap.String("issue_key", evt.Issue.Key))
 	return nil

--- a/apps/backend/internal/orchestrator/event_handlers_linear.go
+++ b/apps/backend/internal/orchestrator/event_handlers_linear.go
@@ -21,9 +21,12 @@ type LinearService interface {
 }
 
 // SetLinearService wires the Linear dedup helpers into the orchestrator so
-// linear-watch handlers can claim issue slots before creating tasks.
+// linear-watch handlers can claim issue slots before creating tasks. Also
+// (re)builds the cached LinearWatcherSource so handleNewLinearIssue can
+// dispatch without allocating per event.
 func (s *Service) SetLinearService(l LinearService) {
 	s.linearService = l
+	s.linearSource = NewLinearWatcherSource(l, s.logger)
 }
 
 // subscribeLinearEvents wires the Linear event handlers onto the bus.
@@ -48,8 +51,13 @@ func (s *Service) handleNewLinearIssue(ctx context.Context, event *bus.Event) er
 	if !ok || evt == nil || evt.Issue == nil {
 		return nil
 	}
-	s.dispatchWatcherEvent(ctx, "linear",
-		NewLinearWatcherSource(s.linearService, s.logger), evt,
+	src := s.linearSource
+	if src == nil {
+		// SetLinearService was never called; fall back to a fail-open
+		// source so behaviour matches the pre-cache code path.
+		src = NewLinearWatcherSource(nil, s.logger)
+	}
+	s.dispatchWatcherEvent(ctx, "linear", src, evt,
 		zap.String("issue_watch_id", evt.IssueWatchID),
 		zap.String("identifier", evt.Issue.Identifier))
 	return nil

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -265,9 +265,15 @@ type Service struct {
 
 	// Jira service for issue watch dedup operations
 	jiraService JiraService
+	// jiraSource adapts jiraService onto WatcherSource. Built once in
+	// SetJiraService so handlers don't allocate per bus event.
+	jiraSource *JiraWatcherSource
 
 	// Linear service for issue watch dedup operations
 	linearService LinearService
+	// linearSource adapts linearService onto WatcherSource. Built once in
+	// SetLinearService so handlers don't allocate per bus event.
+	linearSource *LinearWatcherSource
 
 	// Repository resolver for cloning + finding/creating repos for review tasks
 	repositoryResolver RepositoryResolver

--- a/apps/backend/internal/orchestrator/source_jira.go
+++ b/apps/backend/internal/orchestrator/source_jira.go
@@ -90,7 +90,6 @@ func (s *JiraWatcherSource) AutoStartParams(evt any) AutoStartParams {
 	return AutoStartParams{
 		AgentProfileID:    e.AgentProfileID,
 		ExecutorProfileID: e.ExecutorProfileID,
-		Prompt:            interpolateJiraPrompt(e.Prompt, e.Issue),
 		WorkflowStepID:    e.WorkflowStepID,
 	}
 }

--- a/apps/backend/internal/orchestrator/source_jira_test.go
+++ b/apps/backend/internal/orchestrator/source_jira_test.go
@@ -158,7 +158,4 @@ func TestJiraSource_AutoStartParams(t *testing.T) {
 	if p.WorkflowStepID != "step-1" {
 		t.Errorf("step id wrong: %q", p.WorkflowStepID)
 	}
-	if p.Prompt != "Pick up PROJ-1: Bug" {
-		t.Errorf("prompt should be interpolated, got %q", p.Prompt)
-	}
 }

--- a/apps/backend/internal/orchestrator/source_linear.go
+++ b/apps/backend/internal/orchestrator/source_linear.go
@@ -91,7 +91,6 @@ func (s *LinearWatcherSource) AutoStartParams(evt any) AutoStartParams {
 	return AutoStartParams{
 		AgentProfileID:    e.AgentProfileID,
 		ExecutorProfileID: e.ExecutorProfileID,
-		Prompt:            interpolateLinearPrompt(e.Prompt, e.Issue),
 		WorkflowStepID:    e.WorkflowStepID,
 	}
 }

--- a/apps/backend/internal/orchestrator/source_linear_test.go
+++ b/apps/backend/internal/orchestrator/source_linear_test.go
@@ -172,7 +172,4 @@ func TestLinearSource_AutoStartParams(t *testing.T) {
 	if p.WorkflowStepID != "step-1" {
 		t.Errorf("step id wrong: %q", p.WorkflowStepID)
 	}
-	if p.Prompt != "Work on ENG-1: Bug" {
-		t.Errorf("prompt should be interpolated, got %q", p.Prompt)
-	}
 }

--- a/apps/backend/internal/orchestrator/watcher_dispatch.go
+++ b/apps/backend/internal/orchestrator/watcher_dispatch.go
@@ -2,18 +2,11 @@ package orchestrator
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/common/logger"
-)
-
-// Log field keys repeated across coordinator log calls. Hoisted to file
-// constants so a typo would be a compile error rather than a silent log-
-// search miss.
-const (
-	logFieldSource = "source"
-	logFieldTaskID = "task_id"
 )
 
 // WatcherDispatchCoordinator owns the cross-integration pipeline that turns
@@ -30,24 +23,45 @@ const (
 // On any failure between Reserve and a successful CreateIssueTask, Release
 // is invoked so the dedup row does not strand the issue.
 type WatcherDispatchCoordinator struct {
+	// mu guards taskCreator. SetTaskCreator may be called more than once at
+	// boot (tests in particular swap creators between scenarios), and
+	// Dispatch reads from background goroutines spawned by
+	// dispatchWatcherEvent — so the field needs synchronisation.
+	mu              sync.RWMutex
 	taskCreator     IssueTaskCreator
 	startTask       taskStarter
 	shouldAutoStart func(ctx context.Context, workflowStepID string) bool
 	logger          *logger.Logger
 }
 
+// SetTaskCreator atomically updates the task creator the coordinator
+// dispatches to. Safe to call concurrently with Dispatch.
+func (c *WatcherDispatchCoordinator) SetTaskCreator(tc IssueTaskCreator) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.taskCreator = tc
+}
+
+func (c *WatcherDispatchCoordinator) getTaskCreator() IssueTaskCreator {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.taskCreator
+}
+
 // taskStarter wraps Service.StartTask so the coordinator can be tested
 // without spinning up the full orchestrator service.
 type taskStarter interface {
-	Start(ctx context.Context, taskID, workflowStepID string, params AutoStartParams) error
+	Start(ctx context.Context, taskID, workflowStepID, prompt string, params AutoStartParams) error
 }
 
 // AutoStartParams is the data a source contributes when the resulting task's
-// workflow step has auto-start enabled.
+// workflow step has auto-start enabled. The prompt is intentionally NOT
+// included here — the coordinator passes the created task's Description
+// directly so auto-start always uses the persisted task body, matching the
+// legacy createXIssueTask call sites byte-for-byte.
 type AutoStartParams struct {
 	AgentProfileID    string
 	ExecutorProfileID string
-	Prompt            string
 	WorkflowStepID    string
 }
 
@@ -90,57 +104,57 @@ func (c *WatcherDispatchCoordinator) Dispatch(ctx context.Context, src WatcherSo
 	reserved, err := src.Reserve(ctx, evt)
 	if err != nil {
 		c.logger.Error("watcher dispatch: reserve failed",
-			zap.String(logFieldSource, src.Name()), zap.Error(err))
+			zap.String("source", src.Name()), zap.Error(err))
 		return
 	}
 	if !reserved {
 		c.logger.Debug("watcher dispatch: already reserved by concurrent handler",
-			zap.String(logFieldSource, src.Name()))
+			zap.String("source", src.Name()))
 		return
 	}
 
 	req, err := src.BuildTaskRequest(evt)
 	if err != nil {
 		c.logger.Error("watcher dispatch: build task request failed",
-			zap.String(logFieldSource, src.Name()), zap.Error(err))
+			zap.String("source", src.Name()), zap.Error(err))
 		src.Release(ctx, evt)
 		return
 	}
 
-	task, err := c.taskCreator.CreateIssueTask(ctx, req)
+	task, err := c.getTaskCreator().CreateIssueTask(ctx, req)
 	if err != nil {
 		c.logger.Error("watcher dispatch: create issue task failed",
-			zap.String(logFieldSource, src.Name()), zap.Error(err))
+			zap.String("source", src.Name()), zap.Error(err))
 		src.Release(ctx, evt)
 		return
 	}
 
 	if err := src.AttachTaskID(ctx, evt, task.ID); err != nil {
 		c.logger.Error("watcher dispatch: attach task id failed",
-			zap.String(logFieldSource, src.Name()),
-			zap.String(logFieldTaskID, task.ID),
+			zap.String("source", src.Name()),
+			zap.String("task_id", task.ID),
 			zap.Error(err))
 		// Do NOT release here — matches existing Linear/Jira behaviour:
 		// attach is a best-effort step, the task is already created.
 	}
 
 	c.logger.Info("watcher dispatch: created issue task",
-		zap.String(logFieldSource, src.Name()),
-		zap.String(logFieldTaskID, task.ID))
+		zap.String("source", src.Name()),
+		zap.String("task_id", task.ID))
 
 	if !c.shouldAutoStart(ctx, req.WorkflowStepID) {
 		return
 	}
 
 	params := src.AutoStartParams(evt)
-	if err := c.startTask.Start(ctx, task.ID, req.WorkflowStepID, params); err != nil {
+	if err := c.startTask.Start(ctx, task.ID, req.WorkflowStepID, task.Description, params); err != nil {
 		c.logger.Error("watcher dispatch: auto-start failed",
-			zap.String(logFieldSource, src.Name()),
-			zap.String(logFieldTaskID, task.ID),
+			zap.String("source", src.Name()),
+			zap.String("task_id", task.ID),
 			zap.Error(err))
 		return
 	}
 	c.logger.Info("watcher dispatch: auto-started issue task",
-		zap.String(logFieldSource, src.Name()),
-		zap.String(logFieldTaskID, task.ID))
+		zap.String("source", src.Name()),
+		zap.String("task_id", task.ID))
 }

--- a/apps/backend/internal/orchestrator/watcher_dispatch_test.go
+++ b/apps/backend/internal/orchestrator/watcher_dispatch_test.go
@@ -100,16 +100,18 @@ func newTestCoordinator(t *testing.T, tc *fakeTaskCreator, autoStart bool, start
 // taskStarter is the indirection used inside Coordinator so tests can
 // inspect whether StartTask was invoked.
 type fakeTaskStarter struct {
-	called  int
-	gotID   string
-	gotStep string
-	err     error
+	called    int
+	gotID     string
+	gotStep   string
+	gotPrompt string
+	err       error
 }
 
-func (f *fakeTaskStarter) Start(_ context.Context, taskID, stepID string, _ AutoStartParams) error {
+func (f *fakeTaskStarter) Start(_ context.Context, taskID, stepID, prompt string, _ AutoStartParams) error {
 	f.called++
 	f.gotID = taskID
 	f.gotStep = stepID
+	f.gotPrompt = prompt
 	return f.err
 }
 
@@ -127,11 +129,14 @@ func TestCoordinator_Dispatch_HappyPath(t *testing.T) {
 		autoStart: AutoStartParams{
 			AgentProfileID:    "agent-1",
 			ExecutorProfileID: "exec-1",
-			Prompt:            "body",
 			WorkflowStepID:    "step-1",
 		},
 	}
-	tc := &fakeTaskCreator{}
+	// returned.Description must drive auto-start prompt; if the created
+	// task's description ever diverges from the request's (e.g. service-
+	// side normalisation), auto-start MUST use the persisted body — pin
+	// that contract here.
+	tc := &fakeTaskCreator{returned: &models.Task{ID: "task-1", Description: "persisted body"}}
 	starter := &fakeTaskStarter{}
 	c := newTestCoordinator(t, tc, true, starter)
 
@@ -152,6 +157,9 @@ func TestCoordinator_Dispatch_HappyPath(t *testing.T) {
 	}
 	if starter.gotID != "task-1" || starter.gotStep != "step-1" {
 		t.Fatalf("auto-start received wrong args: id=%s step=%s", starter.gotID, starter.gotStep)
+	}
+	if starter.gotPrompt != "persisted body" {
+		t.Fatalf("auto-start prompt must come from created task.Description, got %q", starter.gotPrompt)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/watcher_dispatch_wiring.go
+++ b/apps/backend/internal/orchestrator/watcher_dispatch_wiring.go
@@ -13,19 +13,20 @@ import (
 // orchestrator-internal types.
 type serviceTaskStarter struct{ svc *Service }
 
-func (s serviceTaskStarter) Start(ctx context.Context, taskID, workflowStepID string, p AutoStartParams) error {
+func (s serviceTaskStarter) Start(ctx context.Context, taskID, workflowStepID, prompt string, p AutoStartParams) error {
 	_, err := s.svc.StartTask(
 		ctx, taskID, p.AgentProfileID, "", p.ExecutorProfileID,
-		"", p.Prompt, workflowStepID, false, true, nil,
+		"", prompt, workflowStepID, false, true, nil,
 	)
 	return err
 }
 
 // initWatcherCoordinator builds the coordinator (once) and (always) refreshes
-// the mutable taskCreator dependency. Called from SetIssueTaskCreator, which
-// can be invoked multiple times — tests in particular may swap creators
-// between scenarios. Re-running the setter MUST update the coordinator,
-// otherwise Dispatch silently keeps the original creator.
+// the mutable taskCreator dependency via SetTaskCreator. Called from
+// SetIssueTaskCreator, which can be invoked multiple times — tests in
+// particular may swap creators between scenarios. Re-running the setter MUST
+// update the coordinator, otherwise Dispatch silently keeps the original
+// creator.
 func (s *Service) initWatcherCoordinator() {
 	if s.watcherCoordinator == nil {
 		s.watcherCoordinator = &WatcherDispatchCoordinator{
@@ -36,17 +37,16 @@ func (s *Service) initWatcherCoordinator() {
 			logger: s.logger,
 		}
 	}
-	// Always refresh: SetIssueTaskCreator may be called more than once.
-	s.watcherCoordinator.taskCreator = s.issueTaskCreator
+	s.watcherCoordinator.SetTaskCreator(s.issueTaskCreator)
 }
 
 // dispatchWatcherEvent runs the wiring guards every per-integration bus
-// handler shares — issueTaskCreator check, coordinator check, and the
-// final goroutine dispatch with cancellation detached. integration is used
-// in log message templating ("new linear issue ...", "skipping jira task ...").
-// fields are the structured log fields that identify the event in operator
-// logs; pass at least the issue_watch_id and an integration-specific
-// identifier field so a deferred / dropped event is diagnosable.
+// handler shares — issueTaskCreator check and the final goroutine dispatch
+// with cancellation detached. integration is used in log message templating
+// ("new linear issue ...", "skipping jira task ..."). fields are the
+// structured log fields that identify the event in operator logs; pass at
+// least the issue_watch_id and an integration-specific identifier field so
+// a deferred / dropped event is diagnosable.
 //
 // Lives in its own helper so per-integration handlers stay below dupl's
 // duplicate-block threshold without copy-pasting the same guards.
@@ -54,13 +54,6 @@ func (s *Service) dispatchWatcherEvent(ctx context.Context, integration string, 
 	s.logger.Info(fmt.Sprintf("new %s issue detected from watch", integration), fields...)
 	if s.issueTaskCreator == nil {
 		s.logger.Warn(fmt.Sprintf("issue task creator not configured, skipping %s task creation", integration))
-		return
-	}
-	if s.watcherCoordinator == nil {
-		// Defensive: coordinator is wired by SetIssueTaskCreator. If we got
-		// here without the creator we already returned above; this is just
-		// a belt-and-braces guard for tests that wire pieces individually.
-		s.logger.Warn(fmt.Sprintf("watcher coordinator not configured, skipping %s task dispatch", integration), fields...)
 		return
 	}
 	// Detach from cancellation but keep request-scoped values (tracing, etc.):


### PR DESCRIPTION
Follow-up to #1070 — addresses review feedback raised on that PR. Now rebased onto main (which contains the squash-merged #1070), so the diff is just the single fixup commit. Credit for the underlying refactor goes to @nlenepveu.

## Fixes

1. **Drop `AutoStartParams.Prompt`** — coordinator now passes the created `task.Description` to `taskStarter.Start`. Matches legacy `createXIssueTask` byte-for-byte and removes a silent-divergence trap if the task service ever normalises `Description`.
2. **Race on `WatcherDispatchCoordinator.taskCreator`** — guarded with `sync.RWMutex` via a new `SetTaskCreator` method; `Dispatch` reads via `getTaskCreator()`. Wiring in `initWatcherCoordinator` uses the setter.
3. **Cache `LinearWatcherSource` / `JiraWatcherSource`** on `Service` — built once in `SetLinearService` / `SetJiraService` instead of allocated per bus event.
4. **Inline `logFieldSource` / `logFieldTaskID` constants** — inconsistent with every other handler in the package.
5. **Remove unreachable `watcherCoordinator == nil` branch** in `dispatchWatcherEvent` — `issueTaskCreator` nil-check above already covers it.

## Test plan

- [x] `go build ./internal/orchestrator/...` — clean
- [x] `go vet ./internal/orchestrator/...` — clean
- [x] `go test -race -count=1 ./internal/orchestrator/` — passed (15.9s)
- [x] Updated `TestCoordinator_Dispatch_HappyPath` pins the new contract: auto-start prompt comes from the created task's `Description`, not the request.