### PR TITLE
fix: group sidebar tasks by real state

### DIFF
--- a/apps/web/lib/sidebar/apply-view.test.ts
+++ b/apps/web/lib/sidebar/apply-view.test.ts
@@ -274,6 +274,7 @@ describe("applyGroup", () => {
     const tasks = [
       task({ id: "done", state: "COMPLETED", sessionState: "COMPLETED" }),
       task({ id: "review", state: "REVIEW", sessionState: "WAITING_FOR_INPUT" }),
+      task({ id: "not-started", sessionState: "IDLE" }),
     ];
     const groupsByKey = new Map(applyGroup(tasks, "state").groups.map((g) => [g.key, g]));
 
@@ -281,6 +282,8 @@ describe("applyGroup", () => {
     expect(groupsByKey.get("COMPLETED")?.tasks.map((t) => t.id)).toEqual(["done"]);
     expect(groupsByKey.get("REVIEW")?.label).toBe("Review");
     expect(groupsByKey.get("REVIEW")?.tasks.map((t) => t.id)).toEqual(["review"]);
+    expect(groupsByKey.get("__not_started__")?.label).toBe("Not started");
+    expect(groupsByKey.get("__not_started__")?.tasks.map((t) => t.id)).toEqual(["not-started"]);
   });
 
   it("buckets missing group-key value into Unassigned", () => {

--- a/apps/web/lib/sidebar/apply-view.test.ts
+++ b/apps/web/lib/sidebar/apply-view.test.ts
@@ -270,6 +270,19 @@ describe("applyGroup", () => {
     expect(applyGroup(tasks, "executorType").groups).toHaveLength(2);
   });
 
+  it("groups by real task state instead of the action bucket", () => {
+    const tasks = [
+      task({ id: "done", state: "COMPLETED", sessionState: "COMPLETED" }),
+      task({ id: "review", state: "REVIEW", sessionState: "WAITING_FOR_INPUT" }),
+    ];
+    const groupsByKey = new Map(applyGroup(tasks, "state").groups.map((g) => [g.key, g]));
+
+    expect(groupsByKey.get("COMPLETED")?.label).toBe("Completed");
+    expect(groupsByKey.get("COMPLETED")?.tasks.map((t) => t.id)).toEqual(["done"]);
+    expect(groupsByKey.get("REVIEW")?.label).toBe("Review");
+    expect(groupsByKey.get("REVIEW")?.tasks.map((t) => t.id)).toEqual(["review"]);
+  });
+
   it("buckets missing group-key value into Unassigned", () => {
     const tasks = [task({ id: "a", workflowId: "wf1" }), task({ id: "b" })];
     const out = applyGroup(tasks, "workflow");

--- a/apps/web/lib/sidebar/apply-view.test.ts
+++ b/apps/web/lib/sidebar/apply-view.test.ts
@@ -217,6 +217,54 @@ describe("applySort", () => {
   });
 });
 
+describe("applyGroup — state", () => {
+  it("groups by real task state instead of the action bucket", () => {
+    const tasks = [
+      task({ id: "done", state: "COMPLETED", sessionState: "COMPLETED" }),
+      task({ id: "review", state: "REVIEW", sessionState: "WAITING_FOR_INPUT" }),
+      task({ id: "not-started", sessionState: "IDLE" }),
+    ];
+    const groupsByKey = new Map(applyGroup(tasks, "state").groups.map((g) => [g.key, g]));
+
+    expect(groupsByKey.get("COMPLETED")?.label).toBe("Completed");
+    expect(groupsByKey.get("COMPLETED")?.tasks.map((t) => t.id)).toEqual(["done"]);
+    expect(groupsByKey.get("REVIEW")?.label).toBe("Review");
+    expect(groupsByKey.get("REVIEW")?.tasks.map((t) => t.id)).toEqual(["review"]);
+    expect(groupsByKey.get("__not_started__")?.label).toBe("Not started");
+    expect(groupsByKey.get("__not_started__")?.tasks.map((t) => t.id)).toEqual(["not-started"]);
+  });
+
+  it("sorts state groups by canonical status order", () => {
+    const tasks = [
+      task({ id: "cancelled", state: "CANCELLED" }),
+      task({ id: "completed", state: "COMPLETED" }),
+      task({ id: "failed", state: "FAILED" }),
+      task({ id: "blocked", state: "BLOCKED" }),
+      task({ id: "review", state: "REVIEW" }),
+      task({ id: "waiting", state: "WAITING_FOR_INPUT" }),
+      task({ id: "progress", state: "IN_PROGRESS" }),
+      task({ id: "todo", state: "TODO" }),
+      task({ id: "scheduling", state: "SCHEDULING" }),
+      task({ id: "created", state: "CREATED" }),
+      task({ id: "not-started" }),
+    ];
+
+    expect(applyGroup(tasks, "state").groups.map((g) => g.key)).toEqual([
+      "__not_started__",
+      "CREATED",
+      "SCHEDULING",
+      "TODO",
+      "IN_PROGRESS",
+      "WAITING_FOR_INPUT",
+      "REVIEW",
+      "BLOCKED",
+      "FAILED",
+      "COMPLETED",
+      "CANCELLED",
+    ]);
+  });
+});
+
 describe("applyGroup", () => {
   it("wraps all tasks in single pseudo-group when group=none", () => {
     const tasks = [task({ id: "a" }), task({ id: "b" })];
@@ -268,22 +316,6 @@ describe("applyGroup", () => {
     expect(applyGroup(tasks, "workflow").groups).toHaveLength(2);
     expect(applyGroup(tasks, "workflowStep").groups).toHaveLength(2);
     expect(applyGroup(tasks, "executorType").groups).toHaveLength(2);
-  });
-
-  it("groups by real task state instead of the action bucket", () => {
-    const tasks = [
-      task({ id: "done", state: "COMPLETED", sessionState: "COMPLETED" }),
-      task({ id: "review", state: "REVIEW", sessionState: "WAITING_FOR_INPUT" }),
-      task({ id: "not-started", sessionState: "IDLE" }),
-    ];
-    const groupsByKey = new Map(applyGroup(tasks, "state").groups.map((g) => [g.key, g]));
-
-    expect(groupsByKey.get("COMPLETED")?.label).toBe("Completed");
-    expect(groupsByKey.get("COMPLETED")?.tasks.map((t) => t.id)).toEqual(["done"]);
-    expect(groupsByKey.get("REVIEW")?.label).toBe("Review");
-    expect(groupsByKey.get("REVIEW")?.tasks.map((t) => t.id)).toEqual(["review"]);
-    expect(groupsByKey.get("__not_started__")?.label).toBe("Not started");
-    expect(groupsByKey.get("__not_started__")?.tasks.map((t) => t.id)).toEqual(["not-started"]);
   });
 
   it("buckets missing group-key value into Unassigned", () => {

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -44,6 +44,7 @@ function getStateBucket(task: TaskSwitcherItem): TaskBucket {
 
 const dimensionExtractors: Record<FilterDimension, DimensionExtractor> = {
   archived: (t) => t.isArchived === true,
+  // State filters intentionally use the action buckets exposed by the filter UI.
   state: (t) => getStateBucket(t),
   workflow: (t) => t.workflowId,
   workflowStep: (t) => t.workflowStepId,
@@ -183,6 +184,7 @@ const groupExtractors: Record<Exclude<GroupKey, "none">, GroupExtractor> = {
     }
     return { key: "__unassigned__", label: UNASSIGNED_LABEL };
   },
+  // State groups use persisted task states so headings match task status labels.
   state: getTaskStateGroup,
 };
 

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -152,11 +152,27 @@ export function applySort(
 
 const UNASSIGNED_LABEL = "Unassigned";
 const MULTI_REPO_LABEL = "Multi-repo";
+const NOT_STARTED_STATE_GROUP_KEY = "__not_started__";
+
+const STATE_GROUP_ORDER: Record<string, number> = {
+  [NOT_STARTED_STATE_GROUP_KEY]: 0,
+  CREATED: 1,
+  SCHEDULING: 2,
+  TODO: 3,
+  IN_PROGRESS: 4,
+  WAITING_FOR_INPUT: 5,
+  REVIEW: 6,
+  BLOCKED: 7,
+  FAILED: 8,
+  COMPLETED: 9,
+  CANCELLED: 10,
+};
 
 type GroupExtractor = (task: TaskSwitcherItem) => { key: string; label: string };
 
 function getTaskStateGroup(task: TaskSwitcherItem): { key: string; label: string } {
-  if (!task.state) return { key: "__not_started__", label: formatTaskStateLabel(undefined) };
+  if (!task.state)
+    return { key: NOT_STARTED_STATE_GROUP_KEY, label: formatTaskStateLabel(undefined) };
   return { key: task.state, label: formatTaskStateLabel(task.state) };
 }
 
@@ -234,6 +250,7 @@ export function applyGroup(tasks: TaskSwitcherItem[], groupKey: GroupKey): Group
     mergeSingleRepoUnassigned(groups);
     sortRepoGroups(groups);
   }
+  if (groupKey === "state") sortStateGroups(groups);
   return { groups, subTasksByParentId };
 }
 
@@ -253,6 +270,14 @@ function sortRepoGroups(groups: SidebarGroup[]): void {
     if (b.key === "__multi__") return 1;
     if (a.key === "__unassigned__") return 1;
     if (b.key === "__unassigned__") return -1;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+function sortStateGroups(groups: SidebarGroup[]): void {
+  groups.sort((a, b) => {
+    const order = (STATE_GROUP_ORDER[a.key] ?? 99) - (STATE_GROUP_ORDER[b.key] ?? 99);
+    if (order !== 0) return order;
     return a.label.localeCompare(b.label);
   });
 }

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -1,6 +1,7 @@
 import { classifyTask, type TaskBucket } from "@/components/task/task-classify";
 import type { TaskSwitcherItem } from "@/components/task/task-switcher";
 import { getExecutorLabel } from "@/lib/executor-icons";
+import { formatTaskStateLabel } from "@/lib/ui/state-labels";
 import type {
   FilterClause,
   FilterDimension,
@@ -153,6 +154,11 @@ const MULTI_REPO_LABEL = "Multi-repo";
 
 type GroupExtractor = (task: TaskSwitcherItem) => { key: string; label: string };
 
+function getTaskStateGroup(task: TaskSwitcherItem): { key: string; label: string } {
+  if (!task.state) return { key: "__not_started__", label: formatTaskStateLabel(undefined) };
+  return { key: task.state, label: formatTaskStateLabel(task.state) };
+}
+
 const groupExtractors: Record<Exclude<GroupKey, "none">, GroupExtractor> = {
   repository: (t) => {
     if (t.repositories && t.repositories.length > 1) {
@@ -177,10 +183,7 @@ const groupExtractors: Record<Exclude<GroupKey, "none">, GroupExtractor> = {
     }
     return { key: "__unassigned__", label: UNASSIGNED_LABEL };
   },
-  state: (t) => {
-    const bucket = getStateBucket(t);
-    return { key: bucket, label: bucket };
-  },
+  state: getTaskStateGroup,
 };
 
 function separateSubtasks(tasks: TaskSwitcherItem[]): {


### PR DESCRIPTION
Task sidebar grouping mixed workflow status with action buckets, so completed tasks could appear under review. Group-by-state now uses persisted task state labels while sort/filter bucket behavior stays unchanged.

## Validation

- `make fmt`
- `PATH=/home/zeval/.nodenv/versions/24.12.0/bin:$PATH make typecheck`
- `PATH=/tmp/kandev-pr-bin:/home/zeval/.nodenv/versions/24.12.0/bin:$PATH make test lint`

Closes #1072

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.