### PR TITLE
fix(backend): keep cancelled office turns promptable instead of parking IDLE

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -691,13 +691,7 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	// executor backend. The conversation is preserved via acp_session_id; the
 	// next run recreates everything and reloads. Kanban / quick-chat retains
 	// the warm WAITING_FOR_INPUT model below.
-	//
-	// stop_reason "cancelled" is excluded from the office path: a user-initiated
-	// cancel is not the "between scheduled runs" intent IDLE represents. The
-	// cancel handler (Service.CancelAgent) already drives the session to
-	// WAITING_FOR_INPUT and records the cancel message — letting the office
-	// branch overwrite that with IDLE would leave the session unpromptable
-	// (checkSessionPromptable rejects IDLE) until the next scheduler wakeup.
+	// stop_reason "cancelled" skips the office IDLE path: CancelAgent already wrote WAITING_FOR_INPUT; overwriting with IDLE would make the session unpromptable.
 	stopReason := extractStopReason(payload)
 	if session != nil && s.handleOfficeTurnComplete(ctx, payload.TaskID, payload.SessionID, session, stopReason) {
 		return
@@ -737,12 +731,7 @@ const stopReasonCancelled = "cancelled"
 // terminal-state guard short-circuits (mirrors completeAndStopSession).
 // Returns true when the session was handled as office (caller must not fall
 // through to the kanban WAITING_FOR_INPUT path).
-//
-// stopReason is the agent's reported turn-end reason. When it is "cancelled"
-// (user-initiated turn cancel), this handler returns false so the caller falls
-// through to the kanban setSessionWaitingForInput path — IDLE would leave the
-// session unpromptable for the user's expected follow-up. All other reasons
-// (end_turn, error, empty) keep the original office park-to-IDLE behavior.
+// stopReason "cancelled" returns false (skip IDLE); all other reasons keep the office park-to-IDLE path.
 func (s *Service) handleOfficeTurnComplete(
 	ctx context.Context, taskID, sessionID string, session *models.TaskSession, stopReason string,
 ) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -715,11 +715,8 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	s.setSessionWaitingForInput(ctx, payload.TaskID, payload.SessionID, session)
 }
 
-// extractStopReason reads the `stop_reason` field from the agent complete event's
-// nested data map. Returns "" when the payload doesn't carry one (older agents,
-// non-ACP paths, or events whose data shape isn't a map). The literal "cancelled"
-// is the ACP-adapter signal for a user-initiated cancel — kept in sync with
-// lifecycle.handleCompleteEventSignal which reads the same field.
+// extractStopReason returns the stop_reason string from the ACP complete event; "" if absent or not a map.
+// Kept in sync with the same read in lifecycle/manager_events.go (handleCompleteEventSignal).
 func extractStopReason(payload *lifecycle.AgentStreamEventPayload) string {
 	if payload == nil || payload.Data == nil {
 		return ""
@@ -732,11 +729,7 @@ func extractStopReason(payload *lifecycle.AgentStreamEventPayload) string {
 	return sr
 }
 
-// stopReasonCancelled is the ACP stop_reason value the adapter emits when the
-// agent acknowledges a user-initiated cancel. Mirrors the literal read at
-// internal/agent/runtime/lifecycle/manager_events.go (handleCompleteEventSignal
-// and handleCompleteEvent). Kept here as a local constant to avoid importing a
-// lifecycle internal just for the string.
+// Mirrors the "cancelled" literal in lifecycle/manager_events.go — not extracted to avoid cross-package coupling.
 const stopReasonCancelled = "cancelled"
 
 // handleOfficeTurnComplete fires the fire-and-forget shutdown flow for office

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -686,12 +686,7 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 		s.captureGitStatusSnapshotWithRetry(ctx, payload.SessionID)
 	}
 
-	// Office sessions follow the fire-and-forget shutdown flow: every turn
-	// completion drops the session to IDLE and tears down the agent process +
-	// executor backend. The conversation is preserved via acp_session_id; the
-	// next run recreates everything and reloads. Kanban / quick-chat retains
-	// the warm WAITING_FOR_INPUT model below.
-	// stop_reason "cancelled" skips the office IDLE path: CancelAgent already wrote WAITING_FOR_INPUT; overwriting with IDLE would make the session unpromptable.
+	// Office sessions park at IDLE between scheduler runs; cancelled turns skip that path so the session stays promptable.
 	stopReason := extractStopReason(payload)
 	if session != nil && s.handleOfficeTurnComplete(ctx, payload.TaskID, payload.SessionID, session, stopReason) {
 		return
@@ -709,8 +704,7 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	s.setSessionWaitingForInput(ctx, payload.TaskID, payload.SessionID, session)
 }
 
-// extractStopReason returns the stop_reason string from the ACP complete event; "" if absent or not a map.
-// Kept in sync with the same read in lifecycle/manager_events.go (handleCompleteEventSignal).
+// Mirrors the same read in lifecycle/manager_events.go.
 func extractStopReason(payload *lifecycle.AgentStreamEventPayload) string {
 	if payload == nil || payload.Data == nil {
 		return ""
@@ -726,12 +720,7 @@ func extractStopReason(payload *lifecycle.AgentStreamEventPayload) string {
 // Mirrors the "cancelled" literal in lifecycle/manager_events.go — not extracted to avoid cross-package coupling.
 const stopReasonCancelled = "cancelled"
 
-// handleOfficeTurnComplete fires the fire-and-forget shutdown flow for office
-// sessions: state flips to IDLE *before* StopAgent so the workflow handler's
-// terminal-state guard short-circuits (mirrors completeAndStopSession).
-// Returns true when the session was handled as office (caller must not fall
-// through to the kanban WAITING_FOR_INPUT path).
-// stopReason "cancelled" returns false (skip IDLE); all other reasons keep the office park-to-IDLE path.
+// Returns true when handled as office (state→IDLE + StopAgent); stopReason "cancelled" returns false to keep the session promptable.
 func (s *Service) handleOfficeTurnComplete(
 	ctx context.Context, taskID, sessionID string, session *models.TaskSession, stopReason string,
 ) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -691,7 +691,15 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	// executor backend. The conversation is preserved via acp_session_id; the
 	// next run recreates everything and reloads. Kanban / quick-chat retains
 	// the warm WAITING_FOR_INPUT model below.
-	if session != nil && s.handleOfficeTurnComplete(ctx, payload.TaskID, payload.SessionID, session) {
+	//
+	// stop_reason "cancelled" is excluded from the office path: a user-initiated
+	// cancel is not the "between scheduled runs" intent IDLE represents. The
+	// cancel handler (Service.CancelAgent) already drives the session to
+	// WAITING_FOR_INPUT and records the cancel message — letting the office
+	// branch overwrite that with IDLE would leave the session unpromptable
+	// (checkSessionPromptable rejects IDLE) until the next scheduler wakeup.
+	stopReason := extractStopReason(payload)
+	if session != nil && s.handleOfficeTurnComplete(ctx, payload.TaskID, payload.SessionID, session, stopReason) {
 		return
 	}
 
@@ -707,19 +715,57 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	s.setSessionWaitingForInput(ctx, payload.TaskID, payload.SessionID, session)
 }
 
+// extractStopReason reads the `stop_reason` field from the agent complete event's
+// nested data map. Returns "" when the payload doesn't carry one (older agents,
+// non-ACP paths, or events whose data shape isn't a map). The literal "cancelled"
+// is the ACP-adapter signal for a user-initiated cancel — kept in sync with
+// lifecycle.handleCompleteEventSignal which reads the same field.
+func extractStopReason(payload *lifecycle.AgentStreamEventPayload) string {
+	if payload == nil || payload.Data == nil {
+		return ""
+	}
+	data, ok := payload.Data.Data.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	sr, _ := data["stop_reason"].(string)
+	return sr
+}
+
+// stopReasonCancelled is the ACP stop_reason value the adapter emits when the
+// agent acknowledges a user-initiated cancel. Mirrors the literal read at
+// internal/agent/runtime/lifecycle/manager_events.go (handleCompleteEventSignal
+// and handleCompleteEvent). Kept here as a local constant to avoid importing a
+// lifecycle internal just for the string.
+const stopReasonCancelled = "cancelled"
+
 // handleOfficeTurnComplete fires the fire-and-forget shutdown flow for office
 // sessions: state flips to IDLE *before* StopAgent so the workflow handler's
 // terminal-state guard short-circuits (mirrors completeAndStopSession).
 // Returns true when the session was handled as office (caller must not fall
 // through to the kanban WAITING_FOR_INPUT path).
+//
+// stopReason is the agent's reported turn-end reason. When it is "cancelled"
+// (user-initiated turn cancel), this handler returns false so the caller falls
+// through to the kanban setSessionWaitingForInput path — IDLE would leave the
+// session unpromptable for the user's expected follow-up. All other reasons
+// (end_turn, error, empty) keep the original office park-to-IDLE behavior.
 func (s *Service) handleOfficeTurnComplete(
-	ctx context.Context, taskID, sessionID string, session *models.TaskSession,
+	ctx context.Context, taskID, sessionID string, session *models.TaskSession, stopReason string,
 ) bool {
 	if session == nil || session.AgentProfileID == "" {
 		return false
 	}
 	task, err := s.repo.GetTask(ctx, taskID)
 	if err != nil || task == nil || task.AssigneeAgentProfileID == "" {
+		return false
+	}
+
+	if stopReason == stopReasonCancelled {
+		s.logger.Info("office turn cancelled by user — skipping IDLE flip, deferring to cancel handler",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("stop_reason", stopReason))
 		return false
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -284,14 +284,7 @@ func TestSetSessionRunning_WritesOnTransition(t *testing.T) {
 	require.Equal(t, v1.TaskStateInProgress, taskRepo.updatedStates["t1"])
 }
 
-// TestHandleCompleteStreamEvent_CancelledOfficeSessionLandsWaitingForInput
-// pins the call-site wiring for the office cancel-IDLE fix: when the agent
-// complete payload carries stop_reason="cancelled" on an office-style session
-// (task with AssigneeAgentProfileID + session with AgentProfileID), the
-// office IDLE branch must be skipped and the handler must fall through to
-// setSessionWaitingForInput so the user can immediately send a follow-up
-// prompt. Without this wiring the user sees "session is in IDLE state" on
-// the next message (checkSessionPromptable rejects IDLE).
+// Pins the call-site wiring: cancelled office turn must NOT leave the session at IDLE.
 func TestHandleCompleteStreamEvent_CancelledOfficeSessionLandsWaitingForInput(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -299,10 +292,7 @@ func TestHandleCompleteStreamEvent_CancelledOfficeSessionLandsWaitingForInput(t 
 	mgr := &mockAgentManager{}
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
 
-	// Drive the office session to WAITING_FOR_INPUT first — this mirrors what
-	// Service.CancelAgent does after agentManager.CancelAgent returns; the
-	// office complete-event handler arrives slightly later and must NOT
-	// clobber it back to IDLE just because session.AgentProfileID is set.
+	// Mirror Service.CancelAgent's pre-emptive WAITING_FOR_INPUT write.
 	session, err := repo.GetTaskSession(ctx, "s-cancel-flow")
 	require.NoError(t, err)
 	session.State = models.TaskSessionStateWaitingForInput
@@ -334,9 +324,7 @@ func TestHandleCompleteStreamEvent_CancelledOfficeSessionLandsWaitingForInput(t 
 		"cancelled office turn must not tear down the agent process — Service.CancelAgent owns lifecycle for user cancels")
 }
 
-// TestHandleCompleteStreamEvent_NaturalOfficeCompleteStillIdle is the inverse
-// guard: a natural turn completion (no stop_reason, or "end_turn") on an office
-// session still parks the session in IDLE and tears down the agent process.
+// Inverse guard: a natural end_turn completion on an office session still parks IDLE + StopAgent.
 func TestHandleCompleteStreamEvent_NaturalOfficeCompleteStillIdle(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -284,6 +284,90 @@ func TestSetSessionRunning_WritesOnTransition(t *testing.T) {
 	require.Equal(t, v1.TaskStateInProgress, taskRepo.updatedStates["t1"])
 }
 
+// TestHandleCompleteStreamEvent_CancelledOfficeSessionLandsWaitingForInput
+// pins the call-site wiring for the office cancel-IDLE fix: when the agent
+// complete payload carries stop_reason="cancelled" on an office-style session
+// (task with AssigneeAgentProfileID + session with AgentProfileID), the
+// office IDLE branch must be skipped and the handler must fall through to
+// setSessionWaitingForInput so the user can immediately send a follow-up
+// prompt. Without this wiring the user sees "session is in IDLE state" on
+// the next message (checkSessionPromptable rejects IDLE).
+func TestHandleCompleteStreamEvent_CancelledOfficeSessionLandsWaitingForInput(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedOfficeSession(t, repo, "t-cancel-flow", "s-cancel-flow", "exec-cancel-flow")
+	mgr := &mockAgentManager{}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
+
+	// Drive the office session to WAITING_FOR_INPUT first — this mirrors what
+	// Service.CancelAgent does after agentManager.CancelAgent returns; the
+	// office complete-event handler arrives slightly later and must NOT
+	// clobber it back to IDLE just because session.AgentProfileID is set.
+	session, err := repo.GetTaskSession(ctx, "s-cancel-flow")
+	require.NoError(t, err)
+	session.State = models.TaskSessionStateWaitingForInput
+	require.NoError(t, repo.UpdateTaskSession(ctx, session))
+
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    "t-cancel-flow",
+		SessionID: "s-cancel-flow",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: agentEventComplete,
+			Data: map[string]interface{}{
+				"stop_reason": "cancelled",
+			},
+		},
+	}
+
+	svc.handleCompleteStreamEvent(ctx, payload)
+
+	got, err := repo.GetTaskSession(ctx, "s-cancel-flow")
+	require.NoError(t, err)
+	require.NotEqual(t, models.TaskSessionStateIdle, got.State,
+		"cancelled office turn must not leave the session IDLE — PromptTask would reject the user's next message")
+	require.Equal(t, models.TaskSessionStateWaitingForInput, got.State,
+		"cancelled office turn must fall through to setSessionWaitingForInput")
+	mgr.mu.Lock()
+	stopCalls := len(mgr.stopAgentArgs)
+	mgr.mu.Unlock()
+	require.Zero(t, stopCalls,
+		"cancelled office turn must not tear down the agent process — Service.CancelAgent owns lifecycle for user cancels")
+}
+
+// TestHandleCompleteStreamEvent_NaturalOfficeCompleteStillIdle is the inverse
+// guard: a natural turn completion (no stop_reason, or "end_turn") on an office
+// session still parks the session in IDLE and tears down the agent process.
+func TestHandleCompleteStreamEvent_NaturalOfficeCompleteStillIdle(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedOfficeSession(t, repo, "t-natural", "s-natural", "exec-natural")
+	mgr := &mockAgentManager{}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
+
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:    "t-natural",
+		SessionID: "s-natural",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: agentEventComplete,
+			Data: map[string]interface{}{
+				"stop_reason": "end_turn",
+			},
+		},
+	}
+
+	svc.handleCompleteStreamEvent(ctx, payload)
+
+	got, err := repo.GetTaskSession(ctx, "s-natural")
+	require.NoError(t, err)
+	require.Equal(t, models.TaskSessionStateIdle, got.State,
+		"natural office turn completion must still park the session in IDLE")
+	mgr.mu.Lock()
+	stopCalls := len(mgr.stopAgentArgs)
+	mgr.mu.Unlock()
+	require.Equal(t, 1, stopCalls,
+		"natural office turn completion must still call StopAgent to tear down the executor")
+}
+
 // TestSetSessionWaitingForInput_WritesOnTransition is the symmetric counterpart
 // to TestSetSessionRunning_WritesOnTransition: when the session is NOT already
 // WAITING_FOR_INPUT, setSessionWaitingForInput MUST still fire the task write.

--- a/apps/backend/internal/orchestrator/office_turn_complete_test.go
+++ b/apps/backend/internal/orchestrator/office_turn_complete_test.go
@@ -190,11 +190,7 @@ func TestHandleOfficeTurnComplete_NoExecutionStillIdle(t *testing.T) {
 	}
 }
 
-// TestHandleOfficeTurnComplete_CancelStopReasonSkipsIdleAndTeardown pins the
-// fix for "session is in IDLE state" after a user cancel on an office task:
-// the cancel-triggered complete event must not park the session at IDLE
-// (which checkSessionPromptable rejects), and must not tear down the agent
-// process — Service.CancelAgent owns reconciling state to WAITING_FOR_INPUT.
+// Pins the cancel-on-office fix: handler returns false on stop_reason="cancelled" and skips StopAgent.
 func TestHandleOfficeTurnComplete_CancelStopReasonSkipsIdleAndTeardown(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -224,10 +220,7 @@ func TestHandleOfficeTurnComplete_CancelStopReasonSkipsIdleAndTeardown(t *testin
 	}
 }
 
-// TestHandleOfficeTurnComplete_OtherStopReasonsStillIdle pins that the new
-// cancelled-skip branch only triggers on the literal "cancelled" stop reason.
-// Any other reason (empty, end_turn, error, …) must keep the original
-// park-to-IDLE + StopAgent behavior so the office scheduler keeps working.
+// Only the literal "cancelled" triggers the skip branch; all other stop_reasons still IDLE + StopAgent.
 func TestHandleOfficeTurnComplete_OtherStopReasonsStillIdle(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/apps/backend/internal/orchestrator/office_turn_complete_test.go
+++ b/apps/backend/internal/orchestrator/office_turn_complete_test.go
@@ -105,7 +105,7 @@ func TestHandleOfficeTurnComplete_SetsIdleAndStopsAgent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get session: %v", err)
 	}
-	handled := svc.handleOfficeTurnComplete(ctx, "t-office", "s-office", session)
+	handled := svc.handleOfficeTurnComplete(ctx, "t-office", "s-office", session, "")
 	if !handled {
 		t.Fatal("expected office turn complete to claim the event")
 	}
@@ -136,7 +136,7 @@ func TestHandleOfficeTurnComplete_KanbanFallthrough(t *testing.T) {
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
 
 	session, _ := repo.GetTaskSession(ctx, "sess-kanban")
-	handled := svc.handleOfficeTurnComplete(ctx, "task-kanban", "sess-kanban", session)
+	handled := svc.handleOfficeTurnComplete(ctx, "task-kanban", "sess-kanban", session, "")
 	if handled {
 		t.Error("kanban session should not be claimed by office turn-complete")
 	}
@@ -155,7 +155,7 @@ func TestHandleOfficeTurnComplete_StopAgentFailureStillIdle(t *testing.T) {
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
 
 	session, _ := repo.GetTaskSession(ctx, "s-stop-fail")
-	if !svc.handleOfficeTurnComplete(ctx, "t-stop-fail", "s-stop-fail", session) {
+	if !svc.handleOfficeTurnComplete(ctx, "t-stop-fail", "s-stop-fail", session, "") {
 		t.Fatal("expected handler to claim the event")
 	}
 
@@ -179,7 +179,7 @@ func TestHandleOfficeTurnComplete_NoExecutionStillIdle(t *testing.T) {
 	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
 
 	session, _ := repo.GetTaskSession(ctx, "s-no-exec")
-	svc.handleOfficeTurnComplete(ctx, "t-no-exec", "s-no-exec", session)
+	svc.handleOfficeTurnComplete(ctx, "t-no-exec", "s-no-exec", session, "")
 
 	got, _ := repo.GetTaskSession(ctx, "s-no-exec")
 	if got.State != models.TaskSessionStateIdle {
@@ -187,5 +187,83 @@ func TestHandleOfficeTurnComplete_NoExecutionStillIdle(t *testing.T) {
 	}
 	if len(mgr.stopAgentArgs) != 0 {
 		t.Errorf("expected no StopAgent (no execution_id), got %d", len(mgr.stopAgentArgs))
+	}
+}
+
+// TestHandleOfficeTurnComplete_CancelStopReasonSkipsIdleAndTeardown pins the
+// fix for "session is in IDLE state" after a user cancel on an office task:
+// the cancel-triggered complete event must not park the session at IDLE
+// (which checkSessionPromptable rejects), and must not tear down the agent
+// process — Service.CancelAgent owns reconciling state to WAITING_FOR_INPUT.
+func TestHandleOfficeTurnComplete_CancelStopReasonSkipsIdleAndTeardown(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedOfficeSession(t, repo, "t-cancel", "s-cancel", "exec-cancel")
+	mgr := &mockAgentManager{}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
+
+	session, err := repo.GetTaskSession(ctx, "s-cancel")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+
+	handled := svc.handleOfficeTurnComplete(ctx, "t-cancel", "s-cancel", session, "cancelled")
+	if handled {
+		t.Fatal("cancelled office turn must NOT be claimed; caller has to fall through to setSessionWaitingForInput")
+	}
+
+	got, err := repo.GetTaskSession(ctx, "s-cancel")
+	if err != nil {
+		t.Fatalf("re-read session: %v", err)
+	}
+	if got.State != models.TaskSessionStateRunning {
+		t.Errorf("state must remain as seeded (RUNNING) when handler bails out; got %q", got.State)
+	}
+	if len(mgr.stopAgentArgs) != 0 {
+		t.Errorf("StopAgent must not be called on cancelled office turn; got %d calls", len(mgr.stopAgentArgs))
+	}
+}
+
+// TestHandleOfficeTurnComplete_OtherStopReasonsStillIdle pins that the new
+// cancelled-skip branch only triggers on the literal "cancelled" stop reason.
+// Any other reason (empty, end_turn, error, …) must keep the original
+// park-to-IDLE + StopAgent behavior so the office scheduler keeps working.
+func TestHandleOfficeTurnComplete_OtherStopReasonsStillIdle(t *testing.T) {
+	cases := []struct {
+		name       string
+		stopReason string
+	}{
+		{"empty", ""},
+		{"end_turn", "end_turn"},
+		{"error", "error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := setupTestRepo(t)
+			taskID := "t-" + tc.name
+			sessionID := "s-" + tc.name
+			seedOfficeSession(t, repo, taskID, sessionID, "exec-"+tc.name)
+			mgr := &mockAgentManager{}
+			svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
+
+			session, err := repo.GetTaskSession(ctx, sessionID)
+			if err != nil {
+				t.Fatalf("get session: %v", err)
+			}
+
+			if !svc.handleOfficeTurnComplete(ctx, taskID, sessionID, session, tc.stopReason) {
+				t.Fatalf("stop_reason %q: handler must still claim non-cancelled office turn", tc.stopReason)
+			}
+
+			got, _ := repo.GetTaskSession(ctx, sessionID)
+			if got.State != models.TaskSessionStateIdle {
+				t.Errorf("stop_reason %q: state got %q, want IDLE", tc.stopReason, got.State)
+			}
+			if len(mgr.stopAgentArgs) != 1 {
+				t.Errorf("stop_reason %q: expected 1 StopAgent call, got %d", tc.stopReason, len(mgr.stopAgentArgs))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- When a user cancels an in-flight office agent turn, the agent's `complete` stream event was arriving *after* `Service.CancelAgent` had already set the session to `WAITING_FOR_INPUT`, and the office handler was overwriting it with `IDLE` — causing every follow-up prompt to be rejected with `"session is in IDLE state"`.
- Fix: read `stop_reason` from the `agent.complete` payload; when it is `"cancelled"`, skip the office IDLE flip and let the caller fall through to the normal `setSessionWaitingForInput` path (which is idempotent if cancel already wrote it).
- No behaviour change for natural completions (`end_turn`, `error`, empty reason) — those still park the session in IDLE and tear down the executor process as before.

## Implementation notes

`handleCompleteStreamEvent` now calls `extractStopReason(payload)` (a small helper that safely reads `payload.Data.Data.(map[string]interface{})["stop_reason"]`) and forwards the value to `handleOfficeTurnComplete`. Inside that function, an early `if stopReason == stopReasonCancelled { return false }` fires after the office-detection guards but before the IDLE write, so the function bails out and the caller falls through to `setSessionWaitingForInput`.

The agent subprocess is intentionally **not** torn down on cancel — `Service.CancelAgent` owns the subprocess lifecycle for user-initiated cancels, matching how kanban cancels work. The local constant `stopReasonCancelled = "cancelled"` mirrors the literal already read in `lifecycle/manager_events.go`; extracting it to a shared package would cross a package boundary not worth the coupling for one string.

## Test plan

- [x] `TestHandleOfficeTurnComplete_CancelStopReasonSkipsIdleAndTeardown` — direct unit test: `stopReason="cancelled"` returns `false`, state stays `RUNNING` (handler bails before writing), `StopAgent` not called.
- [x] `TestHandleOfficeTurnComplete_OtherStopReasonsStillIdle` — table-driven (`""`, `"end_turn"`, `"error"`): all still return `true`, write IDLE, call `StopAgent` once.
- [x] `TestHandleCompleteStreamEvent_CancelledOfficeSessionLandsWaitingForInput` — full call-site path test: `handleCompleteStreamEvent` with `stop_reason="cancelled"` on an office session results in `WAITING_FOR_INPUT`, not `IDLE`, and no `StopAgent`.
- [x] `TestHandleCompleteStreamEvent_NaturalOfficeCompleteStillIdle` — inverse guard: `stop_reason="end_turn"` still writes `IDLE` and calls `StopAgent`.
- [x] Existing tests updated to pass empty `stopReason` (4 call sites in `office_turn_complete_test.go`) — all expectations preserved.
- [ ] CI: `make -C apps/backend test` + `make -C apps/backend lint`

## Risks & rollback

**Office scheduler**: a user-cancelled session now lands in `WAITING_FOR_INPUT` instead of `IDLE`. The scheduler only keys on `IDLE` for wakeup decisions, so user-cancelled sessions are correctly ignored on the next pass (the user is actively engaged). No scheduler regression expected.

**Agent subprocess**: stays alive after cancel on office sessions (matches kanban semantics). The user typically follows up within seconds; `cleanupAgentExecution` fires on eventual termination regardless.

**Rollback**: revert the single commit on this branch. The new tests will fail on revert, which is intentional — they serve as the regression guard.