### PR TITLE
fix(backend): force fresh git status on session subscribe

### DIFF
--- a/apps/backend/cmd/kandev/helpers.go
+++ b/apps/backend/cmd/kandev/helpers.go
@@ -214,10 +214,7 @@ func tryGetLiveGitStatus(ctx context.Context, lifecycleMgr *lifecycle.Manager, s
 	// Use bounded timeout to prevent blocking session hydration if agentctl is stuck.
 	rpcCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	// Force a fresh git query rather than reading agentctl's cached status.
-	// The cache can wedge when the poll loop misses a HEAD change (paused
-	// mode, dropped tick) — every new subscriber treats itself as ground
-	// truth's request to revalidate so a stale cache self-heals on subscribe.
+	// Force fresh git query: cache can wedge when the poll loop misses a HEAD change.
 	multi, err := agentClient.GetGitStatusMultiFresh(rpcCtx)
 	if err != nil {
 		log.Debug("failed to get live git status, will fall back to DB snapshot",

--- a/apps/backend/cmd/kandev/helpers.go
+++ b/apps/backend/cmd/kandev/helpers.go
@@ -214,7 +214,11 @@ func tryGetLiveGitStatus(ctx context.Context, lifecycleMgr *lifecycle.Manager, s
 	// Use bounded timeout to prevent blocking session hydration if agentctl is stuck.
 	rpcCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	multi, err := agentClient.GetGitStatusMulti(rpcCtx)
+	// Force a fresh git query rather than reading agentctl's cached status.
+	// The cache can wedge when the poll loop misses a HEAD change (paused
+	// mode, dropped tick) — every new subscriber treats itself as ground
+	// truth's request to revalidate so a stale cache self-heals on subscribe.
+	multi, err := agentClient.GetGitStatusMultiFresh(rpcCtx)
 	if err != nil {
 		log.Debug("failed to get live git status, will fall back to DB snapshot",
 			zap.String("session_id", sessionID),

--- a/apps/backend/internal/agent/runtime/agentctl/git.go
+++ b/apps/backend/internal/agent/runtime/agentctl/git.go
@@ -571,19 +571,11 @@ type MultiRepoGitStatusResult struct {
 	Error   string             `json:"error,omitempty"`
 }
 
-// GetGitStatusMulti returns one status entry per repo (multi-repo) or a
-// single untagged entry (single-repo). Used by the session-subscribe handler
-// in the main backend to seed the frontend's per-repo state on page reload —
-// without it, the frontend never sees per-repo grouping until something else
-// (a file change, a poll) pushes a stamped notification.
-func (c *Client) GetGitStatusMulti(ctx context.Context) (*MultiRepoGitStatusResult, error) {
-	return c.getGitStatusMulti(ctx, false)
-}
-
-// GetGitStatusMultiFresh is GetGitStatusMulti with the workspace tracker's
-// cache bypassed — each repo re-runs `git status --porcelain` against the
-// worktree. Used on WS session subscribe so a new observer always sees a
-// validated snapshot rather than a possibly-stale cached one.
+// GetGitStatusMultiFresh returns one status entry per repo (multi-repo) or a
+// single untagged entry (single-repo) with the workspace tracker's cache
+// bypassed — each repo re-runs `git status --porcelain` against the worktree.
+// Used by the session-subscribe handler in the main backend so a new observer
+// always sees a validated snapshot rather than a possibly-stale cached one.
 //
 // The fresh path is read-only with respect to the cache: it returns the live
 // query but does not write the result back into the tracker's currentStatus.
@@ -591,16 +583,8 @@ func (c *Client) GetGitStatusMulti(ctx context.Context) (*MultiRepoGitStatusResu
 // race with concurrent polls. Already-subscribed observers continue to see
 // the cached stream until the poll loop catches up.
 func (c *Client) GetGitStatusMultiFresh(ctx context.Context) (*MultiRepoGitStatusResult, error) {
-	return c.getGitStatusMulti(ctx, true)
-}
-
-func (c *Client) getGitStatusMulti(ctx context.Context, fresh bool) (*MultiRepoGitStatusResult, error) {
-	path := "/api/v1/git/status/multi"
-	if fresh {
-		path += "?fresh=true"
-	}
 	var result MultiRepoGitStatusResult
-	status, err := c.fetchJSONResult(ctx, path, &result)
+	status, err := c.fetchJSONResult(ctx, "/api/v1/git/status/multi?fresh=true", &result)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/agent/runtime/agentctl/git.go
+++ b/apps/backend/internal/agent/runtime/agentctl/git.go
@@ -584,6 +584,12 @@ func (c *Client) GetGitStatusMulti(ctx context.Context) (*MultiRepoGitStatusResu
 // cache bypassed — each repo re-runs `git status --porcelain` against the
 // worktree. Used on WS session subscribe so a new observer always sees a
 // validated snapshot rather than a possibly-stale cached one.
+//
+// The fresh path is read-only with respect to the cache: it returns the live
+// query but does not write the result back into the tracker's currentStatus.
+// That's intentional — the poll loop owns the cache, and writing here would
+// race with concurrent polls. Already-subscribed observers continue to see
+// the cached stream until the poll loop catches up.
 func (c *Client) GetGitStatusMultiFresh(ctx context.Context) (*MultiRepoGitStatusResult, error) {
 	return c.getGitStatusMulti(ctx, true)
 }

--- a/apps/backend/internal/agent/runtime/agentctl/git.go
+++ b/apps/backend/internal/agent/runtime/agentctl/git.go
@@ -577,8 +577,24 @@ type MultiRepoGitStatusResult struct {
 // without it, the frontend never sees per-repo grouping until something else
 // (a file change, a poll) pushes a stamped notification.
 func (c *Client) GetGitStatusMulti(ctx context.Context) (*MultiRepoGitStatusResult, error) {
+	return c.getGitStatusMulti(ctx, false)
+}
+
+// GetGitStatusMultiFresh is GetGitStatusMulti with the workspace tracker's
+// cache bypassed — each repo re-runs `git status --porcelain` against the
+// worktree. Used on WS session subscribe so a new observer always sees a
+// validated snapshot rather than a possibly-stale cached one.
+func (c *Client) GetGitStatusMultiFresh(ctx context.Context) (*MultiRepoGitStatusResult, error) {
+	return c.getGitStatusMulti(ctx, true)
+}
+
+func (c *Client) getGitStatusMulti(ctx context.Context, fresh bool) (*MultiRepoGitStatusResult, error) {
+	path := "/api/v1/git/status/multi"
+	if fresh {
+		path += "?fresh=true"
+	}
 	var result MultiRepoGitStatusResult
-	status, err := c.fetchJSONResult(ctx, "/api/v1/git/status/multi", &result)
+	status, err := c.fetchJSONResult(ctx, path, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/agentctl/server/api/git.go
+++ b/apps/backend/internal/agentctl/server/api/git.go
@@ -1069,7 +1069,9 @@ type MultiRepoGitStatusResult struct {
 // session-subscribe handler in the main backend to seed per-repo state on
 // page reload — the legacy single GET /api/v1/git/status endpoint returns
 // only the workspace-root status, which is empty for multi-repo task roots
-// (the root isn't itself a git repo).
+// (the root isn't itself a git repo). Pass ?fresh=true to bypass the cached
+// status and run a fresh git query — used on WS subscribe so a new observer
+// always validates the cache against the live worktree.
 func (s *Server) handleGitStatusMulti(c *gin.Context) {
 	subpaths := s.procMgr.RepoSubpaths()
 	// Single-repo: fall back to the workspace-root status with an empty repo
@@ -1077,19 +1079,22 @@ func (s *Server) handleGitStatusMulti(c *gin.Context) {
 	if len(subpaths) == 0 {
 		subpaths = []string{""}
 	}
+	fresh := c.Query("fresh") == queryParamTrue
 	result := MultiRepoGitStatusResult{Success: true, Repos: make([]PerRepoGitStatus, 0, len(subpaths))}
 	for _, sub := range subpaths {
-		entry := s.collectStatusForRepo(c, sub)
+		entry := s.collectStatusForRepo(c, sub, fresh)
 		result.Repos = append(result.Repos, entry)
 	}
 	c.JSON(http.StatusOK, result)
 }
 
 // collectStatusForRepo runs the status query for a single subpath and packs
-// it into a PerRepoGitStatus. Failures land in Status.Error / Status.Success
-// so the caller can render partial results instead of erroring out the whole
-// fan-out when one repo is misconfigured.
-func (s *Server) collectStatusForRepo(c *gin.Context, sub string) PerRepoGitStatus {
+// it into a PerRepoGitStatus. When fresh is true the workspace tracker
+// re-runs `git status --porcelain` against the worktree instead of returning
+// the cached snapshot. Failures land in Status.Error / Status.Success so the
+// caller can render partial results instead of erroring out the whole fan-out
+// when one repo is misconfigured.
+func (s *Server) collectStatusForRepo(c *gin.Context, sub string, fresh bool) PerRepoGitStatus {
 	wt, wtErr := s.procMgr.GetWorkspaceTrackerFor(sub)
 	if wtErr != nil {
 		return PerRepoGitStatus{
@@ -1103,7 +1108,7 @@ func (s *Server) collectStatusForRepo(c *gin.Context, sub string) PerRepoGitStat
 			Status:         GitStatusResult{Success: false, Error: "workspace tracker not available"},
 		}
 	}
-	status, err := wt.GetCurrentGitStatus(c.Request.Context())
+	status, err := wt.GetGitStatus(c.Request.Context(), fresh)
 	if err != nil {
 		return PerRepoGitStatus{
 			RepositoryName: sub,

--- a/apps/backend/internal/agentctl/server/api/git.go
+++ b/apps/backend/internal/agentctl/server/api/git.go
@@ -1081,11 +1081,7 @@ func (s *Server) handleGitStatusMulti(c *gin.Context) {
 		subpaths = []string{""}
 	}
 	fresh := c.Query("fresh") == queryParamTrue
-	// Fan out per-repo queries in parallel. Each repo's git work is independent
-	// and runs sub-100ms on small repos, but `fresh=true` skips the cache so a
-	// serial loop over N repos would scale linearly and risk blowing past the
-	// 2s subscribe-path timeout in tryGetLiveGitStatus. Parallelism keeps the
-	// wall-clock close to the slowest single repo regardless of count.
+	// Parallel fan-out: fresh=true skips the cache, so serial scales linearly and would blow the 2s subscribe timeout for multi-repo workspaces.
 	result := MultiRepoGitStatusResult{Success: true, Repos: make([]PerRepoGitStatus, len(subpaths))}
 	ctx := c.Request.Context()
 	var wg sync.WaitGroup

--- a/apps/backend/internal/agentctl/server/api/git.go
+++ b/apps/backend/internal/agentctl/server/api/git.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -1080,11 +1081,22 @@ func (s *Server) handleGitStatusMulti(c *gin.Context) {
 		subpaths = []string{""}
 	}
 	fresh := c.Query("fresh") == queryParamTrue
-	result := MultiRepoGitStatusResult{Success: true, Repos: make([]PerRepoGitStatus, 0, len(subpaths))}
-	for _, sub := range subpaths {
-		entry := s.collectStatusForRepo(c, sub, fresh)
-		result.Repos = append(result.Repos, entry)
+	// Fan out per-repo queries in parallel. Each repo's git work is independent
+	// and runs sub-100ms on small repos, but `fresh=true` skips the cache so a
+	// serial loop over N repos would scale linearly and risk blowing past the
+	// 2s subscribe-path timeout in tryGetLiveGitStatus. Parallelism keeps the
+	// wall-clock close to the slowest single repo regardless of count.
+	result := MultiRepoGitStatusResult{Success: true, Repos: make([]PerRepoGitStatus, len(subpaths))}
+	ctx := c.Request.Context()
+	var wg sync.WaitGroup
+	for i, sub := range subpaths {
+		wg.Add(1)
+		go func(i int, sub string) {
+			defer wg.Done()
+			result.Repos[i] = s.collectStatusForRepo(ctx, sub, fresh)
+		}(i, sub)
 	}
+	wg.Wait()
 	c.JSON(http.StatusOK, result)
 }
 
@@ -1094,7 +1106,7 @@ func (s *Server) handleGitStatusMulti(c *gin.Context) {
 // the cached snapshot. Failures land in Status.Error / Status.Success so the
 // caller can render partial results instead of erroring out the whole fan-out
 // when one repo is misconfigured.
-func (s *Server) collectStatusForRepo(c *gin.Context, sub string, fresh bool) PerRepoGitStatus {
+func (s *Server) collectStatusForRepo(ctx context.Context, sub string, fresh bool) PerRepoGitStatus {
 	wt, wtErr := s.procMgr.GetWorkspaceTrackerFor(sub)
 	if wtErr != nil {
 		return PerRepoGitStatus{
@@ -1108,7 +1120,7 @@ func (s *Server) collectStatusForRepo(c *gin.Context, sub string, fresh bool) Pe
 			Status:         GitStatusResult{Success: false, Error: "workspace tracker not available"},
 		}
 	}
-	status, err := wt.GetGitStatus(c.Request.Context(), fresh)
+	status, err := wt.GetGitStatus(ctx, fresh)
 	if err != nil {
 		return PerRepoGitStatus{
 			RepositoryName: sub,

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -165,8 +165,8 @@ func TestGetGitStatus_FreshBypassesStaleCache(t *testing.T) {
 	runGit(t, repoDir, "add", ".")
 	runGit(t, repoDir, "commit", "-m", "commit v2")
 
-	// The cached read should still report tracked.txt as modified — that's
-	// the stale-cache lie the user sees in the UI.
+	// Precondition: cache must still hold the pre-commit entry — confirms the
+	// stale-cache scenario the fresh path is supposed to bypass.
 	stale, err := wt.GetGitStatus(ctx, false)
 	if err != nil {
 		t.Fatalf("stale GetGitStatus failed: %v", err)
@@ -185,6 +185,18 @@ func TestGetGitStatus_FreshBypassesStaleCache(t *testing.T) {
 	}
 	if len(fresh.Modified) != 0 {
 		t.Errorf("fresh=true should produce empty Modified; got %v", fresh.Modified)
+	}
+
+	// Contract: a fresh read MUST NOT mutate the shared cache. The poll loop
+	// owns currentStatus; subscribe-time fresh reads short-circuit it without
+	// writing back, so already-subscribed observers still see the cached
+	// stream until the poll loop catches up.
+	afterFresh, err := wt.GetGitStatus(ctx, false)
+	if err != nil {
+		t.Fatalf("post-fresh GetGitStatus failed: %v", err)
+	}
+	if _, ok := afterFresh.Files["tracked.txt"]; !ok {
+		t.Errorf("fresh=true must not overwrite the cache; expected stale entry to remain, got Files=%v", mapKeys(afterFresh.Files))
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_git_status_test.go
@@ -130,6 +130,64 @@ func TestGetGitStatus_UntrackedFileWithSpaces(t *testing.T) {
 	}
 }
 
+// TestGetGitStatus_FreshBypassesStaleCache simulates the bug class where the
+// poll loop missed a HEAD change (paused mode, dropped tick) and left
+// currentStatus.Files holding pre-commit entries. fresh=true must re-run
+// `git status --porcelain` and return ground truth, not the cached snapshot.
+func TestGetGitStatus_FreshBypassesStaleCache(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(repoDir, log)
+	ctx := context.Background()
+
+	// Commit a file so we have something to modify.
+	writeFile(t, repoDir, "tracked.txt", "v1")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "add tracked")
+
+	// Dirty the worktree and prime the cache by running an update.
+	writeFile(t, repoDir, "tracked.txt", "v2")
+	wt.updateGitStatus(ctx)
+
+	cached, err := wt.GetGitStatus(ctx, false)
+	if err != nil {
+		t.Fatalf("priming GetGitStatus failed: %v", err)
+	}
+	if _, ok := cached.Files["tracked.txt"]; !ok {
+		t.Fatalf("expected priming run to cache tracked.txt as modified; got Files=%v", mapKeys(cached.Files))
+	}
+
+	// Simulate the bug: commit the file but DO NOT refresh the tracker (this
+	// is what happens when the poll loop is paused or drops a tick at the
+	// exact moment HEAD moves).
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "commit v2")
+
+	// The cached read should still report tracked.txt as modified — that's
+	// the stale-cache lie the user sees in the UI.
+	stale, err := wt.GetGitStatus(ctx, false)
+	if err != nil {
+		t.Fatalf("stale GetGitStatus failed: %v", err)
+	}
+	if _, ok := stale.Files["tracked.txt"]; !ok {
+		t.Fatalf("expected cache to still hold pre-commit entry (test setup invalid); got Files=%v", mapKeys(stale.Files))
+	}
+
+	// fresh=true must bypass the cache and produce a clean status.
+	fresh, err := wt.GetGitStatus(ctx, true)
+	if err != nil {
+		t.Fatalf("fresh GetGitStatus failed: %v", err)
+	}
+	if len(fresh.Files) != 0 {
+		t.Errorf("fresh=true should reflect the clean worktree; got Files=%v", mapKeys(fresh.Files))
+	}
+	if len(fresh.Modified) != 0 {
+		t.Errorf("fresh=true should produce empty Modified; got %v", fresh.Modified)
+	}
+}
+
 // mapKeys returns the keys of a map for diagnostic output.
 func mapKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))


### PR DESCRIPTION
## Summary

The Changes panel was showing files as "UNSTAGED" even though the worktree was clean and the DB snapshot was clean. The 3 files reported were exactly the files committed on the PR branch — so the UI was rendering pre-commit state.

Tracked the lie to agentctl's in-memory `WorkspaceTracker.currentStatus` cache. When the poll loop misses a HEAD change (poll mode paused at the exact commit, `gitPollRunning==1` dropping a tick, or any future race), the cache freezes with stale `Files`. Every subsequent WS subscribe replays that frozen snapshot.

Strategic fix: **a new observer is the moment to revalidate.** The cache stays for ongoing notifications to already-subscribed clients, but every new subscribe forces a fresh `git status --porcelain`. This collapses the entire class of "cache wedged due to dropped signal" bugs — they all self-heal on the next subscribe.

## Changes

- `/api/v1/git/status/multi` now honors `?fresh=true` (mirrors the existing single-repo `/api/v1/git/status?fresh=true`).
- New `GetGitStatusMultiFresh` agentctl client method.
- `tryGetLiveGitStatus` (the session-subscribe hydration path in `cmd/kandev/helpers.go`) uses the fresh variant.
- Regression test in `workspace_git_status_test.go` reproduces the bug end-to-end: prime cache while dirty → commit without refreshing → cached read still shows the file → fresh=true returns the clean truth.

## What stays the same

The push side (poll loop → `notifyWorkspaceStreamGitStatus` → existing subscribers) is unchanged. It's still best-effort. It just stops being load-bearing for correctness.

## What you also get for free

- agentctl restart no longer leaves frontends with stale state on reconnect.
- The `if mode == PollModePaused { return }` early-out in `SetWorkspacePollMode` is safe again — pausing no longer freezes incorrect state forever.
- Future poll-loop bugs downgrade from "permanently wrong UI" to "briefly wrong until next subscribe".

## Test plan

- [x] `make -C apps/backend test lint` passes
- [x] New `TestGetGitStatus_FreshBypassesStaleCache` covers the regression
- [ ] Manual: reproduce the original task (UI showed 3 stale unstaged files), reload, panel clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)