### PR TITLE
fix(backend): drain orphaned queued messages on agent boot ready

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -109,9 +109,13 @@ func (s *Service) requeueMessage(ctx context.Context, queuedMsg *messagequeue.Qu
 // agent.ready (turn-end) so the orchestrator never has to disambiguate the
 // two with race-prone flags.
 //
-// The only job here is to flip the session to WAITING_FOR_INPUT so callers
+// Two jobs here: (1) flip the session to WAITING_FOR_INPUT so callers
 // that are gating on that state (e.g. PromptTask's waitForSessionReady after
-// ensureSessionRunning kicked off ResumeSession) can proceed. Crucially we do
+// ensureSessionRunning kicked off ResumeSession) can proceed; (2) drain any
+// orphaned queued message. Without the drain, a workflow auto-start prompt
+// queued against a session that died mid-turn (or before its first prompt)
+// would sit forever after the user resumed it — agent.ready (the usual drain
+// trigger) never fires for a turn that never completed. Crucially we do
 // NOT call processOnTurnCompleteViaEngine — there's no turn to complete, and
 // stepping the workflow off a boot signal is what caused the production
 // ping-pong bug.
@@ -159,15 +163,23 @@ func (s *Service) handleAgentBootReady(ctx context.Context, data watcher.AgentEv
 
 	// Idempotent: if the session is already WAITING_FOR_INPUT (e.g. revived
 	// from a previously launched session and the boot signal arrived faster
-	// than persistResumeState wrote STARTING), skip — there's nothing to flip
-	// and waitForSessionReady's poll will pick it up.
+	// than persistResumeState wrote STARTING), skip the flip — but still
+	// fall through to the drain below: an orphaned queued message would
+	// otherwise sit forever.
 	if session.State == models.TaskSessionStateWaitingForInput {
-		s.logger.Debug("agent.boot_ready: session already WAITING_FOR_INPUT, no-op",
+		s.logger.Debug("agent.boot_ready: session already WAITING_FOR_INPUT, skipping flip",
 			zap.String("session_id", data.SessionID))
-		return
+	} else {
+		s.setSessionWaitingForInput(ctx, data.TaskID, data.SessionID, session)
 	}
 
-	s.setSessionWaitingForInput(ctx, data.TaskID, data.SessionID, session)
+	// Drain any orphaned queued message. handleAgentReady drains on turn-end,
+	// but a session that crashed mid-turn (or never started its first turn)
+	// won't fire agent.ready — leaving e.g. workflow auto-start prompts stuck
+	// on the queue until the user manually sends another message. After the
+	// agent has booted and the session is back to WAITING_FOR_INPUT it's safe
+	// to dispatch any pending message.
+	s.drainQueuedMessageAfterTransition(ctx, data.SessionID)
 }
 
 // handleAgentReady handles turn-end ready events: the agent finished processing

--- a/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
@@ -112,11 +112,14 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 	}
 
 	// Stream-disconnected error matches isTransientPromptError → autoStartStepPrompt
-	// records the user msg, then queues on the retry path.
+	// records the user msg, then queues on the retry path. promptDone closes on
+	// the first PromptAgent call so the test can sync on it without time.Sleep.
+	firstPromptCalled := make(chan struct{})
 	agentMgr := &mockAgentManager{
 		repoForExecutionLookup: repo,
 		isAgentRunning:         true, // skip ensureSessionRunning's resume
 		promptErr:              errors.New("agent stream disconnected mid-prompt"),
+		promptDone:             firstPromptCalled,
 	}
 
 	msgCreator := &mockMessageCreator{}
@@ -151,15 +154,23 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 		t.Fatalf("handleAgentReady did not return within 3s")
 	}
 
-	// Wait for the async processOnEnter goroutine to record the user msg and
-	// queue the prompt. The transient-error path queues on the first attempt
-	// (no backoff sleeps), so this is fast.
-	deadline := time.Now().Add(3 * time.Second)
+	// Sync on PromptAgent's first call (closes firstPromptCalled). After that,
+	// the goroutine returns from PromptAgent and runs handlePromptError +
+	// autoStartStepPrompt's queue branch — a fully synchronous sequence that
+	// ends with messageQueue.QueueMessageWithMetadata. A tight poll covers
+	// the few-microsecond gap between PromptAgent returning and the queue
+	// row being committed (an unbuffered channel isn't available there).
+	select {
+	case <-firstPromptCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("PromptAgent was not called within 3s")
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if svc.messageQueue.GetStatus(ctx, sessionID).Count > 0 {
 			break
 		}
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 	}
 
 	// Verify the workflow transitioned to Merge.
@@ -200,10 +211,17 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 	// Clear the transient error so the drain's executeQueuedMessage → PromptTask
 	// → PromptAgent succeeds. Otherwise the goroutine that runs after the queue
 	// take would re-enter the same transient-retry path and re-queue the message
-	// immediately, racing the queue-empty assertion below.
+	// immediately, racing the queue-empty assertion below. Also swap in a fresh
+	// promptDone channel to signal the second PromptAgent call (the original one
+	// was already closed by Phase 1).
+	secondPromptCalled := make(chan struct{})
 	agentMgr.mu.Lock()
 	agentMgr.promptErr = nil
-	priorPromptCount := len(agentMgr.capturedPrompts)
+	agentMgr.promptDone = secondPromptCalled
+	// Reset capturedPrompts' bookkeeping so the channel re-fires; the mock's
+	// `first := len(m.capturedPrompts) == 0` guard would otherwise skip the close.
+	agentMgr.capturedPrompts = agentMgr.capturedPrompts[:0]
+	agentMgr.capturedPromptCalls = agentMgr.capturedPromptCalls[:0]
 	agentMgr.mu.Unlock()
 
 	// Simulate the resume: agentctl's ACP session has re-initialized so the
@@ -216,24 +234,12 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 
 	// drainQueuedMessageAfterTransition pops the queue synchronously and fires
 	// `go executeQueuedMessage(...)`. The goroutine creates a user message and
-	// calls PromptTask → PromptAgent. Wait for that to land, then assert the
-	// agent received the prompt.
-	deadline = time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		agentMgr.mu.Lock()
-		got := len(agentMgr.capturedPrompts)
-		agentMgr.mu.Unlock()
-		if got > priorPromptCount {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	agentMgr.mu.Lock()
-	postPromptCount := len(agentMgr.capturedPrompts)
-	agentMgr.mu.Unlock()
-	if postPromptCount <= priorPromptCount {
-		t.Fatalf("boot_ready drain did not dispatch the queued prompt: PromptAgent calls before=%d after=%d", priorPromptCount, postPromptCount)
+	// calls PromptTask → PromptAgent. The mock closes secondPromptCalled on
+	// that call, so the assertion below has a deterministic sync point.
+	select {
+	case <-secondPromptCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("boot_ready drain did not reach PromptAgent within 3s")
 	}
 
 	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 0 {

--- a/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
@@ -1,0 +1,215 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/executor"
+	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+// TestAutoStartTransientError_BootReadyDrainsOrphanedQueue is the regression
+// test for the production stuck-queue symptom on task 9378f7cf.
+//
+// Setup mirrors the production scenario verbatim:
+//   - Step "Fixup" has auto_start_agent + on_turn_complete=move_to_next.
+//   - Step "Merge" has only auto_start_agent (no on_turn_complete).
+//   - Task at Fixup, session.State=RUNNING (Fixup turn in flight).
+//   - The underlying agent stream drops mid-prompt — PromptAgent returns
+//     "agent stream disconnected", which isTransientPromptError matches.
+//
+// What happens without the boot-ready drain (the bug):
+//  1. handleAgentReady → applyEngineTransition flips state, transitions
+//     Fixup→Merge, spawns processOnEnter(Merge) in a goroutine.
+//  2. processOnEnter → autoStartStepPrompt:
+//     a. recordAutoStartMessage records the Merge prompt as a user msg.
+//     b. PromptTask → executor.Prompt → PromptAgent returns the transient
+//     error after ~5 s in production.
+//     c. handlePromptError reverts state + completeTurnForSession (this
+//     is the 5-second "ghost turn" observed in the production DB).
+//     d. autoStartStepPrompt's retry loop matches isTransientPromptError
+//     and queues the same Merge prompt with queued_by=workflow.
+//  3. The queue sits forever because:
+//     - The agent never produced an agent.ready for this prompt (the
+//     stream dropped first), so handleAgentReady's drain never fires.
+//     - The user manually resumes the session → handleAgentBootReady
+//     fires → BEFORE the fix, that handler only flipped state and
+//     returned, leaving the queue orphaned.
+//
+// With the boot-ready drain fix in handleAgentBootReady, step 3 drains the
+// queue when the session is resumed — the test asserts both halves end-to-end:
+// the duplicate is created on transient failure, then boot_ready drains it.
+func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
+	ctx := context.Background()
+	const (
+		taskID       = "task-1"
+		sessionID    = "sess-1"
+		executionID  = "exec-1"
+		fixupStepID  = "step-fixup"
+		mergeStepID  = "step-merge"
+		profile      = "profile-impl"
+		taskWorkflow = "wf1"
+	)
+
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: taskWorkflow, WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps[fixupStepID] = &wfmodels.WorkflowStep{
+		ID: fixupStepID, WorkflowID: taskWorkflow, Name: "Fixup after PR", Position: 1,
+		AgentProfileID: profile,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}},
+			OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+				{Type: wfmodels.OnTurnCompleteMoveToStep, Config: map[string]interface{}{"step_id": mergeStepID}},
+			},
+		},
+	}
+	stepGetter.steps[mergeStepID] = &wfmodels.WorkflowStep{
+		ID: mergeStepID, WorkflowID: taskWorkflow, Name: "Merge", Position: 2,
+		AgentProfileID: profile,
+		Events: wfmodels.StepEvents{
+			OnEnter: []wfmodels.OnEnterAction{{Type: wfmodels.OnEnterAutoStartAgent}},
+		},
+	}
+
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: taskID, WorkflowID: taskWorkflow, WorkflowStepID: fixupStepID,
+		Title: "Test", Description: "Test task",
+		State:     v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:               sessionID,
+		TaskID:           taskID,
+		AgentProfileID:   profile,
+		AgentExecutionID: executionID,
+		State:            models.TaskSessionStateRunning, // mid-turn for Fixup
+		IsPrimary:        true,
+		StartedAt:        now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	seedExecutorRunning(t, repo, sessionID, taskID, executionID)
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks[taskID] = &v1.Task{
+		ID: taskID, WorkflowID: taskWorkflow, State: v1.TaskStateInProgress,
+	}
+
+	// Stream-disconnected error matches isTransientPromptError → autoStartStepPrompt
+	// records the user msg, then queues on the retry path.
+	agentMgr := &mockAgentManager{
+		repoForExecutionLookup: repo,
+		isAgentRunning:         true, // skip ensureSessionRunning's resume
+		promptErr:              errors.New("agent stream disconnected mid-prompt"),
+	}
+
+	msgCreator := &mockMessageCreator{}
+
+	exec := executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	svc := &Service{
+		logger:         testLogger(),
+		repo:           repo,
+		taskRepo:       taskRepo,
+		agentManager:   agentMgr,
+		messageQueue:   messagequeue.NewServiceMemory(testLogger()),
+		executor:       exec,
+		messageCreator: msgCreator,
+	}
+	svc.SetWorkflowStepGetter(stepGetter)
+
+	// --- Phase 1: agent.ready triggers the transient-failure auto-start path ---
+
+	doneFired := make(chan struct{})
+	go func() {
+		defer close(doneFired)
+		svc.handleAgentReady(ctx, watcher.AgentEventData{
+			TaskID:           taskID,
+			SessionID:        sessionID,
+			AgentExecutionID: executionID,
+			AgentProfileID:   profile,
+		})
+	}()
+	select {
+	case <-doneFired:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("handleAgentReady did not return within 3s")
+	}
+
+	// Wait for the async processOnEnter goroutine to record the user msg and
+	// queue the prompt. The transient-error path queues on the first attempt
+	// (no backoff sleeps), so this is fast.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if svc.messageQueue.GetStatus(ctx, sessionID).Count > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Verify the workflow transitioned to Merge.
+	updatedTask, err := repo.GetTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("load task: %v", err)
+	}
+	if updatedTask.WorkflowStepID != mergeStepID {
+		t.Errorf("task step = %q, want %q", updatedTask.WorkflowStepID, mergeStepID)
+	}
+
+	// The transient-failure path records the user msg AND queues the prompt
+	// — both for the same Merge auto-start. This is the production data shape
+	// (one chat row + one queue entry, both with workflow_step_name=Merge).
+	queueStatus := svc.messageQueue.GetStatus(ctx, sessionID)
+	if queueStatus.Count != 1 {
+		t.Fatalf("expected exactly 1 queued message after transient failure, got %d", queueStatus.Count)
+	}
+	queued := queueStatus.Entries[0]
+	if queued.QueuedBy != messagequeue.QueuedByWorkflow {
+		t.Errorf("queued_by = %q, want %q", queued.QueuedBy, messagequeue.QueuedByWorkflow)
+	}
+	if name, _ := queued.Metadata["workflow_step_name"].(string); name != "Merge" {
+		t.Errorf("queued metadata workflow_step_name = %q, want Merge", name)
+	}
+	mergeUserMsgs := 0
+	for _, m := range msgCreator.userMessages {
+		if name, _ := m.metadata["workflow_step_name"].(string); name == "Merge" {
+			mergeUserMsgs++
+		}
+	}
+	if mergeUserMsgs != 1 {
+		t.Errorf("expected exactly 1 Merge user_message (from recordAutoStartMessage before PromptTask failed), got %d", mergeUserMsgs)
+	}
+
+	// --- Phase 2: user resumes the session — boot_ready must drain the queue ---
+
+	// Simulate the resume: agentctl's ACP session has re-initialized so the
+	// lifecycle manager fires events.AgentBootReady. Without the drain fix,
+	// the queue stays orphaned. With the fix, it gets drained.
+	svc.handleAgentBootReady(ctx, watcher.AgentEventData{
+		TaskID:    taskID,
+		SessionID: sessionID,
+	})
+
+	// drainQueuedMessageAfterTransition fires `go executeQueuedMessage(...)`,
+	// so the queue is taken synchronously inside handleAgentBootReady but
+	// further processing is async. Take() happens before the function
+	// returns; we can assert the queue is empty right after.
+	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 0 {
+		t.Errorf("queue not drained after boot_ready: %d messages still queued (the orphaned-queue bug is back)", got)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
@@ -197,6 +197,15 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 
 	// --- Phase 2: user resumes the session — boot_ready must drain the queue ---
 
+	// Clear the transient error so the drain's executeQueuedMessage → PromptTask
+	// → PromptAgent succeeds. Otherwise the goroutine that runs after the queue
+	// take would re-enter the same transient-retry path and re-queue the message
+	// immediately, racing the queue-empty assertion below.
+	agentMgr.mu.Lock()
+	agentMgr.promptErr = nil
+	priorPromptCount := len(agentMgr.capturedPrompts)
+	agentMgr.mu.Unlock()
+
 	// Simulate the resume: agentctl's ACP session has re-initialized so the
 	// lifecycle manager fires events.AgentBootReady. Without the drain fix,
 	// the queue stays orphaned. With the fix, it gets drained.
@@ -205,10 +214,28 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 		SessionID: sessionID,
 	})
 
-	// drainQueuedMessageAfterTransition fires `go executeQueuedMessage(...)`,
-	// so the queue is taken synchronously inside handleAgentBootReady but
-	// further processing is async. Take() happens before the function
-	// returns; we can assert the queue is empty right after.
+	// drainQueuedMessageAfterTransition pops the queue synchronously and fires
+	// `go executeQueuedMessage(...)`. The goroutine creates a user message and
+	// calls PromptTask → PromptAgent. Wait for that to land, then assert the
+	// agent received the prompt.
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		agentMgr.mu.Lock()
+		got := len(agentMgr.capturedPrompts)
+		agentMgr.mu.Unlock()
+		if got > priorPromptCount {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	agentMgr.mu.Lock()
+	postPromptCount := len(agentMgr.capturedPrompts)
+	agentMgr.mu.Unlock()
+	if postPromptCount <= priorPromptCount {
+		t.Fatalf("boot_ready drain did not dispatch the queued prompt: PromptAgent calls before=%d after=%d", priorPromptCount, postPromptCount)
+	}
+
 	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 0 {
 		t.Errorf("queue not drained after boot_ready: %d messages still queued (the orphaned-queue bug is back)", got)
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
@@ -601,3 +601,160 @@ func TestHandleAgentBootReady_DoesNotTriggerOnTurnComplete(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleAgentBootReady_DrainsOrphanedQueuedMessage reproduces the
+// production stuck-queue symptom: a workflow auto-start prompt is queued
+// against a session, the agent dies before the turn completes (so no
+// agent.ready fires to drain it), and the user resumes the session. The
+// session ends up WAITING_FOR_INPUT with the message still on the queue —
+// "1 queued" displayed in the UI forever — because handleAgentBootReady
+// only flipped state but never drained.
+//
+// After the fix, handleAgentBootReady takes the queued message and dispatches
+// it (via executeQueuedMessage in a goroutine). The unit test only asserts
+// that the queue is empty after the handler returns; the goroutine's
+// PromptTask is not exercised here (it requires a live executor).
+func TestHandleAgentBootReady_DrainsOrphanedQueuedMessage(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	cases := []struct {
+		name    string
+		startSt models.TaskSessionState
+	}{
+		{"STARTING -> WAITING_FOR_INPUT (boot completes resume)", models.TaskSessionStateStarting},
+		{"already WAITING_FOR_INPUT (boot raced persistResumeState)", models.TaskSessionStateWaitingForInput},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}); err != nil {
+				t.Fatalf("create workspace: %v", err)
+			}
+			if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}); err != nil {
+				t.Fatalf("create workflow: %v", err)
+			}
+			if err := repo.CreateTask(ctx, &models.Task{
+				ID: "task-1", WorkflowID: "wf1", WorkflowStepID: "step-merge",
+				Title: "T", Description: "D", State: v1.TaskStateInProgress,
+				CreatedAt: now, UpdatedAt: now,
+			}); err != nil {
+				t.Fatalf("create task: %v", err)
+			}
+
+			sessionID := "s1"
+			if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+				ID: sessionID, TaskID: "task-1", AgentProfileID: "profile-impl",
+				State:     tc.startSt,
+				IsPrimary: true,
+				StartedAt: now, UpdatedAt: now,
+			}); err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+
+			taskRepo := newMockTaskRepo()
+			taskRepo.tasks["task-1"] = &v1.Task{
+				ID: "task-1", WorkflowID: "wf1", State: v1.TaskStateInProgress,
+			}
+
+			log := testLogger()
+			svc := &Service{
+				logger:       log,
+				repo:         repo,
+				taskRepo:     taskRepo,
+				agentManager: &mockAgentManager{repoForExecutionLookup: repo},
+				messageQueue: messagequeue.NewServiceMemory(log),
+			}
+
+			// Seed an orphaned workflow auto-start prompt — what the production
+			// bug looked like in the DB at task 9378f7cf.
+			if _, err := svc.messageQueue.QueueMessage(
+				ctx, sessionID, "task-1", "ROLE: Merge operator. ...", "",
+				messagequeue.QueuedByWorkflow, false, nil,
+			); err != nil {
+				t.Fatalf("queue orphaned prompt: %v", err)
+			}
+			if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 1 {
+				t.Fatalf("precondition: queue count = %d, want 1", got)
+			}
+
+			svc.handleAgentBootReady(ctx, watcher.AgentEventData{
+				TaskID: "task-1", SessionID: sessionID,
+			})
+
+			if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 0 {
+				t.Errorf("queue count after boot ready = %d, want 0 (orphaned message must be drained)", got)
+			}
+
+			// Session must still end up WAITING_FOR_INPUT — the drain is
+			// additive, not a replacement for the existing flip behavior.
+			finalSess, err := repo.GetTaskSession(ctx, sessionID)
+			if err != nil {
+				t.Fatalf("load session: %v", err)
+			}
+			if finalSess.State != models.TaskSessionStateWaitingForInput {
+				t.Errorf("session.State = %q, want WAITING_FOR_INPUT", finalSess.State)
+			}
+		})
+	}
+}
+
+// TestHandleAgentBootReady_DoesNotDrainForTerminalSession guards against
+// reviving a queued message on a session that was cancelled or completed —
+// the user explicitly stopped this session, the queued prompt should NOT be
+// dispatched, and the early-return for terminal states must continue to
+// short-circuit before the drain.
+func TestHandleAgentBootReady_DoesNotDrainForTerminalSession(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	repo := setupTestRepo(t)
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID: "task-1", WorkflowID: "wf1", WorkflowStepID: "step-merge",
+		Title: "T", Description: "D", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	sessionID := "s1"
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: sessionID, TaskID: "task-1", AgentProfileID: "profile-impl",
+		State:     models.TaskSessionStateCancelled,
+		IsPrimary: true,
+		StartedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	log := testLogger()
+	svc := &Service{
+		logger:       log,
+		repo:         repo,
+		taskRepo:     newMockTaskRepo(),
+		agentManager: &mockAgentManager{repoForExecutionLookup: repo},
+		messageQueue: messagequeue.NewServiceMemory(log),
+	}
+
+	if _, err := svc.messageQueue.QueueMessage(
+		ctx, sessionID, "task-1", "stuck prompt", "",
+		messagequeue.QueuedByWorkflow, false, nil,
+	); err != nil {
+		t.Fatalf("queue prompt: %v", err)
+	}
+
+	svc.handleAgentBootReady(ctx, watcher.AgentEventData{
+		TaskID: "task-1", SessionID: sessionID,
+	})
+
+	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 1 {
+		t.Errorf("queue count after boot ready on terminal session = %d, want 1 (must not drain)", got)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_pending_move_test.go
@@ -611,9 +611,10 @@ func TestHandleAgentBootReady_DoesNotTriggerOnTurnComplete(t *testing.T) {
 // only flipped state but never drained.
 //
 // After the fix, handleAgentBootReady takes the queued message and dispatches
-// it (via executeQueuedMessage in a goroutine). The unit test only asserts
-// that the queue is empty after the handler returns; the goroutine's
-// PromptTask is not exercised here (it requires a live executor).
+// it (via executeQueuedMessage in a goroutine). The test wires a full
+// executor + seeded executors_running row so the goroutine's PromptTask
+// call lands on a working code path instead of nil-derefing s.executor
+// under -race.
 func TestHandleAgentBootReady_DrainsOrphanedQueuedMessage(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
@@ -644,14 +645,19 @@ func TestHandleAgentBootReady_DrainsOrphanedQueuedMessage(t *testing.T) {
 			}
 
 			sessionID := "s1"
+			const executionID = "exec-1"
 			if err := repo.CreateTaskSession(ctx, &models.TaskSession{
 				ID: sessionID, TaskID: "task-1", AgentProfileID: "profile-impl",
-				State:     tc.startSt,
-				IsPrimary: true,
-				StartedAt: now, UpdatedAt: now,
+				AgentExecutionID: executionID,
+				State:            tc.startSt,
+				IsPrimary:        true,
+				StartedAt:        now, UpdatedAt: now,
 			}); err != nil {
 				t.Fatalf("create session: %v", err)
 			}
+			// Seed executors_running so PromptTask -> ensureSessionRunning ->
+			// executor.GetExecutionBySession finds the agent and skips resume.
+			seedExecutorRunning(t, repo, sessionID, "task-1", executionID)
 
 			taskRepo := newMockTaskRepo()
 			taskRepo.tasks["task-1"] = &v1.Task{
@@ -659,12 +665,20 @@ func TestHandleAgentBootReady_DrainsOrphanedQueuedMessage(t *testing.T) {
 			}
 
 			log := testLogger()
+			agentMgr := &mockAgentManager{
+				repoForExecutionLookup: repo,
+				isAgentRunning:         true, // satisfy GetExecutionBySession's IsAgentRunningForSession check
+			}
 			svc := &Service{
 				logger:       log,
 				repo:         repo,
 				taskRepo:     taskRepo,
-				agentManager: &mockAgentManager{repoForExecutionLookup: repo},
+				agentManager: agentMgr,
 				messageQueue: messagequeue.NewServiceMemory(log),
+				// Wire a real executor so the executeQueuedMessage goroutine
+				// spawned by drainQueuedMessageAfterTransition can safely call
+				// PromptTask -> executor.GetExecutionBySession without nil-derefing.
+				executor: executor.NewExecutor(agentMgr, repo, log, executor.ExecutorConfig{}),
 			}
 
 			// Seed an orphaned workflow auto-start prompt — what the production


### PR DESCRIPTION
## Summary

- `handleAgentBootReady` now drains orphaned queued messages so workflow auto-start prompts don't stay stuck in the queue after the user resumes a session.
- Adds a regression test that reproduces the production scenario end-to-end (transient `PromptAgent` failure → record + queue → boot_ready → drained).

## Root cause

Pinpointed on task `9378f7cf-c8b9-420e-9517-61cfbb43a150` (the stuck-queue report). The duplicate stuck queue isn't a second `processOnEnter`, not a double `agent.ready`, not a `task.moved` race — it's a single `autoStartStepPrompt` invocation taking its **transient-error retry path**:

`apps/backend/internal/orchestrator/event_handlers_workflow.go`:
1. L1212 `recordAutoStartMessage(...)` — records the auto-start user msg first
2. L1232 `PromptTask(...)` — fails with an error matching `isTransientPromptError` (\"agent stream disconnected\" / \"use of closed network connection\")
3. L1262–1272 retry loop falls into `shouldQueueIfBusy` → `queueAutoStartPrompt(...)` → queues the same prompt with `queued_by=workflow`

The chat shows the prompt as a user message *and* the queue holds the same prompt for retry. The drain only fired from `handleAgentReady` (turn-end), but the failed prompt never reached the agent — so no `agent.ready` for that prompt ever arrives. When the user resumes the session, `handleAgentBootReady` only flipped state and returned, leaving the queue orphaned. The user sees \"1 queued\" forever.

This matches the production timeline on the reporting task exactly:
- `10:32:32.002` user msg recorded (`recordAutoStartMessage`)
- ~5s of `PromptAgent` blocked on the disconnected stream
- `10:32:37.080` turn closed (`handlePromptError` → `completeTurnForSession`)
- `10:32:37.091` queue insert (`queueAutoStartPrompt` from the transient-retry branch)

Yesterday's PR (#1087) added `flipStaleRunningToWaiting` for a different stuck-queue scenario (stale-RUNNING state, no active turn). It didn't cover the resume path.

## The fix

`handleAgentBootReady` calls `drainQueuedMessageAfterTransition` after the `WAITING_FOR_INPUT` flip, on both code paths:
- normal STARTING → WAITING flip (the textbook resume case)
- early-return path where state was already WAITING (boot signal raced `persistResumeState`)

The terminal-state short-circuit happens *before* the drain so cancelled/completed sessions don't revive their queued prompts.

## Test plan

- [x] `TestAutoStartTransientError_BootReadyDrainsOrphanedQueue` — full end-to-end reproducer: drives `handleAgentReady` with a mock `PromptAgent` that returns the transient error, verifies user msg + queue both populated, then fires `handleAgentBootReady` and asserts the queue is drained. Deterministic across 5+ runs.
- [x] `TestHandleAgentBootReady_DrainsOrphanedQueuedMessage` — covers both STARTING→WAITING and the persistResumeState-race path.
- [x] `TestHandleAgentBootReady_DoesNotDrainForTerminalSession` — guards against reviving a queue on cancelled/completed sessions.
- [x] All existing tests in `internal/orchestrator/...` pass (`go test ./internal/orchestrator/...`)
- [x] `make lint` clean (0 issues)
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)