### PR TITLE
fix(backend): use official cursor CLI install command in InstallScript()

### DIFF
--- a/apps/backend/internal/agent/agents/cursor_acp.go
+++ b/apps/backend/internal/agent/agents/cursor_acp.go
@@ -100,7 +100,7 @@ func (a *CursorACP) Runtime() *RuntimeConfig {
 func (a *CursorACP) RemoteAuth() *RemoteAuth { return nil }
 
 func (a *CursorACP) InstallScript() string {
-	return "Install Cursor CLI from https://cursor.com/cli"
+	return "curl https://cursor.com/install -fsS | bash"
 }
 
 func (a *CursorACP) PermissionSettings() map[string]PermissionSetting {

--- a/apps/backend/internal/agent/agents/new_acp_agents_test.go
+++ b/apps/backend/internal/agent/agents/new_acp_agents_test.go
@@ -28,6 +28,7 @@ type acpAgentSpec struct {
 	inferenceArgv   []string // InferenceConfig.Command
 	passthroughArgv []string // PassthroughCmd (zero-args allowed)
 	installViaNpm   bool     // InstallScript starts with "npm install -g"
+	installScript   string   // expected InstallScript() value (empty = unchecked)
 }
 
 var newACPAgentSpecs = []struct {
@@ -75,6 +76,7 @@ var newACPAgentSpecs = []struct {
 		inferenceArgv:   []string{"cursor-agent", "acp"},
 		passthroughArgv: []string{"cursor-agent"},
 		installViaNpm:   false,
+		installScript:   "curl https://cursor.com/install -fsS | bash",
 	}},
 	{func() Agent { return NewKimiACP() }, acpAgentSpec{
 		id: "kimi-acp", displayName: "Kimi", detectBinaries: []string{"kimi"},
@@ -179,6 +181,9 @@ func TestNewACPAgents_InstallScript(t *testing.T) {
 			}
 			if !tc.spec.installViaNpm && hasNpm {
 				t.Errorf("InstallScript() should NOT use npm for native-binary agent: %q", got)
+			}
+			if tc.spec.installScript != "" && got != tc.spec.installScript {
+				t.Errorf("InstallScript() = %q, want %q", got, tc.spec.installScript)
 			}
 			// The primary detection binary must be referenced somewhere
 			// actionable — either argv (native binaries) or InstallScript


### PR DESCRIPTION
**Summary**
The Cursor ACP agent's `InstallScript()` returned a non-executable hint string (`"Install Cursor CLI from https://cursor.com/cli"`). In remote environments this string is executed as a shell command, causing the error `sh: 1: Install: not found`. Changed it to the official bash install command from Cursor's documentation so remote setup works correctly.

**Validation**
- `go test ./internal/agent/agents/ -count=1`
- `go test ./internal/agent/settings/controller/ -count=1`
- `golangci-lint run --new-from-rev=HEAD~1 ./internal/agent/agents/...`

**Checklist**
- [x] I have tested the changes locally.
- [x] I have reviewed the code for quality and maintainability.
- [x] I have updated relevant documentation (if applicable).
- [x] I have added tests for new functionality (if applicable).