### PR TITLE
fix: show human-readable title and details in permission prompts

### DIFF
--- a/apps/backend/internal/agentctl/server/acp/client.go
+++ b/apps/backend/internal/agentctl/server/acp/client.go
@@ -156,7 +156,7 @@ func (c *Client) forwardPermissionRequest(ctx context.Context, handler Permissio
 	// for tools they can't classify, which on its own is meaningless to the user.
 	description := ""
 	if p.ToolCall.Title != nil {
-		description = *p.ToolCall.Title
+		description = strings.TrimSpace(*p.ToolCall.Title)
 	}
 
 	actionType := ""
@@ -169,12 +169,14 @@ func (c *Client) forwardPermissionRequest(ctx context.Context, handler Permissio
 		title = actionType
 	}
 
-	// Build action details from raw input if available
+	// Build action details from raw input if available. The frontend de-dups
+	// description against title at render time, so always forward description
+	// when present — useful for future agents where the two may diverge.
 	actionDetails := make(map[string]any)
 	if p.ToolCall.RawInput != nil {
 		actionDetails["raw_input"] = p.ToolCall.RawInput
 	}
-	if description != "" && description != title {
+	if description != "" {
 		actionDetails["description"] = description
 	}
 

--- a/apps/backend/internal/agentctl/server/acp/client.go
+++ b/apps/backend/internal/agentctl/server/acp/client.go
@@ -150,29 +150,23 @@ func (c *Client) forwardPermissionRequest(ctx context.Context, handler Permissio
 		}
 	}
 
-	// Extract title - prefer Kind as the title, use Title as description
-	title := ""
+	// Prefer the agent's human-readable ToolCall.Title for the user-facing label
+	// (e.g. "Run bash command 'ls -la'", "Read 216 lines from foo.go"). Fall back
+	// to Kind only when no Title was provided — many agents send Kind="other"
+	// for tools they can't classify, which on its own is meaningless to the user.
 	description := ""
 	if p.ToolCall.Title != nil {
 		description = *p.ToolCall.Title
 	}
 
-	// Use Kind as the action type (e.g., "run_shell_command", "write_file")
 	actionType := ""
 	if p.ToolCall.Kind != nil {
 		actionType = string(*p.ToolCall.Kind)
-		title = actionType // Use kind as the title for cleaner display
 	}
 
-	// If no Kind, try to extract a short title from the verbose title
-	// Gemini format: "pwd [current working directory /path] (Print the current working directory.)"
-	if title == "" && description != "" {
-		// Use the first word/command as the title
-		if idx := strings.Index(description, " "); idx > 0 {
-			title = description[:idx]
-		} else {
-			title = description
-		}
+	title := description
+	if title == "" {
+		title = actionType
 	}
 
 	// Build action details from raw input if available

--- a/apps/backend/internal/agentctl/server/acp/client_test.go
+++ b/apps/backend/internal/agentctl/server/acp/client_test.go
@@ -1,8 +1,12 @@
 package acp
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
+
+	"github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/types"
 )
 
 func TestResolvePath(t *testing.T) {
@@ -76,6 +80,104 @@ func TestResolvePath(t *testing.T) {
 			}
 			if got != tt.expected {
 				t.Errorf("resolvePath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestForwardPermissionRequestTitleDerivation(t *testing.T) {
+	str := func(s string) *string { return &s }
+	kind := func(k acp.ToolKind) *acp.ToolKind { return &k }
+	allowOpt := acp.PermissionOption{OptionId: "allow", Name: "Allow", Kind: acp.PermissionOptionKindAllowOnce}
+
+	tests := []struct {
+		name           string
+		toolCall       acp.ToolCallUpdate
+		wantTitle      string
+		wantActionType string
+		wantDescInDtl  bool
+	}{
+		{
+			name: "title present, kind other -> human title wins",
+			toolCall: acp.ToolCallUpdate{
+				ToolCallId: "tc-1",
+				Title:      str("Run bash command 'ls -la'"),
+				Kind:       kind(acp.ToolKindOther),
+			},
+			wantTitle:      "Run bash command 'ls -la'",
+			wantActionType: "other",
+			wantDescInDtl:  false, // description == title, so not duplicated
+		},
+		{
+			name: "title present, kind execute -> human title still wins",
+			toolCall: acp.ToolCallUpdate{
+				ToolCallId: "tc-2",
+				Title:      str("Run bash command 'rm -rf'"),
+				Kind:       kind(acp.ToolKindExecute),
+			},
+			wantTitle:      "Run bash command 'rm -rf'",
+			wantActionType: "execute",
+			wantDescInDtl:  false,
+		},
+		{
+			name: "only kind -> kind is the title",
+			toolCall: acp.ToolCallUpdate{
+				ToolCallId: "tc-3",
+				Kind:       kind(acp.ToolKindEdit),
+			},
+			wantTitle:      "edit",
+			wantActionType: "edit",
+			wantDescInDtl:  false,
+		},
+		{
+			name: "only title, no kind",
+			toolCall: acp.ToolCallUpdate{
+				ToolCallId: "tc-4",
+				Title:      str("Reading configuration file"),
+			},
+			wantTitle:      "Reading configuration file",
+			wantActionType: "",
+			wantDescInDtl:  false,
+		},
+		{
+			name: "neither title nor kind -> both empty",
+			toolCall: acp.ToolCallUpdate{
+				ToolCallId: "tc-5",
+			},
+			wantTitle:      "",
+			wantActionType: "",
+			wantDescInDtl:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient()
+			var captured *types.PermissionRequest
+			handler := func(_ context.Context, req *types.PermissionRequest) (*types.PermissionResponse, error) {
+				captured = req
+				return &types.PermissionResponse{OptionID: "allow"}, nil
+			}
+			req := acp.RequestPermissionRequest{
+				SessionId: "sess",
+				ToolCall:  tt.toolCall,
+				Options:   []acp.PermissionOption{allowOpt},
+			}
+			if _, err := c.forwardPermissionRequest(context.Background(), handler, req); err != nil {
+				t.Fatalf("forwardPermissionRequest returned error: %v", err)
+			}
+			if captured == nil {
+				t.Fatal("handler not invoked")
+			}
+			if captured.Title != tt.wantTitle {
+				t.Errorf("Title = %q, want %q", captured.Title, tt.wantTitle)
+			}
+			if captured.ActionType != tt.wantActionType {
+				t.Errorf("ActionType = %q, want %q", captured.ActionType, tt.wantActionType)
+			}
+			_, hasDesc := captured.ActionDetails["description"]
+			if hasDesc != tt.wantDescInDtl {
+				t.Errorf("ActionDetails.description present = %v, want %v (details=%v)", hasDesc, tt.wantDescInDtl, captured.ActionDetails)
 			}
 		})
 	}

--- a/apps/backend/internal/agentctl/server/acp/client_test.go
+++ b/apps/backend/internal/agentctl/server/acp/client_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/coder/acp-go-sdk"
@@ -96,6 +97,7 @@ func TestForwardPermissionRequestTitleDerivation(t *testing.T) {
 		wantTitle      string
 		wantActionType string
 		wantDescInDtl  bool
+		wantRawInput   map[string]any
 	}{
 		{
 			name: "title present, kind other -> human title wins",
@@ -106,7 +108,7 @@ func TestForwardPermissionRequestTitleDerivation(t *testing.T) {
 			},
 			wantTitle:      "Run bash command 'ls -la'",
 			wantActionType: "other",
-			wantDescInDtl:  false, // description == title, so not duplicated
+			wantDescInDtl:  true,
 		},
 		{
 			name: "title present, kind execute -> human title still wins",
@@ -117,10 +119,10 @@ func TestForwardPermissionRequestTitleDerivation(t *testing.T) {
 			},
 			wantTitle:      "Run bash command 'rm -rf'",
 			wantActionType: "execute",
-			wantDescInDtl:  false,
+			wantDescInDtl:  true,
 		},
 		{
-			name: "only kind -> kind is the title",
+			name: "only kind -> kind is the title, no description forwarded",
 			toolCall: acp.ToolCallUpdate{
 				ToolCallId: "tc-3",
 				Kind:       kind(acp.ToolKindEdit),
@@ -137,7 +139,7 @@ func TestForwardPermissionRequestTitleDerivation(t *testing.T) {
 			},
 			wantTitle:      "Reading configuration file",
 			wantActionType: "",
-			wantDescInDtl:  false,
+			wantDescInDtl:  true,
 		},
 		{
 			name: "neither title nor kind -> both empty",
@@ -147,6 +149,30 @@ func TestForwardPermissionRequestTitleDerivation(t *testing.T) {
 			wantTitle:      "",
 			wantActionType: "",
 			wantDescInDtl:  false,
+		},
+		{
+			name: "whitespace-only title falls back to kind",
+			toolCall: acp.ToolCallUpdate{
+				ToolCallId: "tc-ws",
+				Title:      str("   "),
+				Kind:       kind(acp.ToolKindExecute),
+			},
+			wantTitle:      "execute",
+			wantActionType: "execute",
+			wantDescInDtl:  false,
+		},
+		{
+			name: "raw_input forwarded into ActionDetails",
+			toolCall: acp.ToolCallUpdate{
+				ToolCallId: "tc-6",
+				Title:      str("Run bash"),
+				Kind:       kind(acp.ToolKindExecute),
+				RawInput:   map[string]any{"command": "ls -la", "cwd": "/tmp"},
+			},
+			wantTitle:      "Run bash",
+			wantActionType: "execute",
+			wantDescInDtl:  true,
+			wantRawInput:   map[string]any{"command": "ls -la", "cwd": "/tmp"},
 		},
 	}
 
@@ -178,6 +204,15 @@ func TestForwardPermissionRequestTitleDerivation(t *testing.T) {
 			_, hasDesc := captured.ActionDetails["description"]
 			if hasDesc != tt.wantDescInDtl {
 				t.Errorf("ActionDetails.description present = %v, want %v (details=%v)", hasDesc, tt.wantDescInDtl, captured.ActionDetails)
+			}
+			if tt.wantRawInput != nil {
+				gotRaw, ok := captured.ActionDetails["raw_input"].(map[string]any)
+				if !ok {
+					t.Fatalf("ActionDetails.raw_input missing or wrong type: %#v", captured.ActionDetails["raw_input"])
+				}
+				if !reflect.DeepEqual(gotRaw, tt.wantRawInput) {
+					t.Errorf("ActionDetails.raw_input = %v, want %v", gotRaw, tt.wantRawInput)
+				}
 			}
 		})
 	}

--- a/apps/web/components/task/chat/messages/permission-action-summary.test.ts
+++ b/apps/web/components/task/chat/messages/permission-action-summary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { summarizePermissionAction } from "./permission-action-summary";
+
+describe("summarizePermissionAction", () => {
+  it("returns null when details are missing", () => {
+    expect(summarizePermissionAction(undefined, "x")).toBeNull();
+  });
+
+  it("prefers explicit description", () => {
+    expect(
+      summarizePermissionAction(
+        { description: "Run bash command 'ls -la'", raw_input: { command: "ls -la" } },
+        "other",
+      ),
+    ).toBe("Run bash command 'ls -la'");
+  });
+
+  it("falls back to raw_input.command", () => {
+    expect(summarizePermissionAction({ raw_input: { command: "rm -rf /tmp/x" } }, "execute")).toBe(
+      "rm -rf /tmp/x",
+    );
+  });
+
+  it("picks file_path from raw_input", () => {
+    expect(
+      summarizePermissionAction({ raw_input: { file_path: "/etc/hosts", limit: 5 } }, "read"),
+    ).toBe("/etc/hosts");
+  });
+
+  it("falls back to JSON when no preferred key matches", () => {
+    expect(summarizePermissionAction({ raw_input: { foo: "bar", n: 1 } }, "other")).toBe(
+      `{"foo":"bar","n":1}`,
+    );
+  });
+
+  it("skips when summary equals the title", () => {
+    expect(summarizePermissionAction({ description: "same" }, "same")).toBeNull();
+  });
+
+  it("uses legacy top-level command/path when raw_input absent", () => {
+    expect(summarizePermissionAction({ command: 'grep -r "x"' }, "other")).toBe('grep -r "x"');
+    expect(summarizePermissionAction({ path: "/foo/bar" }, "read")).toBe("/foo/bar");
+  });
+
+  it("returns null when raw_input is empty object", () => {
+    expect(summarizePermissionAction({ raw_input: {} }, "other")).toBeNull();
+  });
+
+  it("truncates very long values", () => {
+    const long = "a".repeat(500);
+    const result = summarizePermissionAction({ description: long }, "other");
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(200);
+    expect(result!.endsWith("…")).toBe(true);
+  });
+});

--- a/apps/web/components/task/chat/messages/permission-action-summary.test.ts
+++ b/apps/web/components/task/chat/messages/permission-action-summary.test.ts
@@ -6,7 +6,9 @@ describe("summarizePermissionAction", () => {
     expect(summarizePermissionAction(undefined, "x")).toBeNull();
   });
 
-  it("prefers explicit description", () => {
+  // Today the backend always sends description == title; this case covers
+  // the future-reserved path where agents send a distinct description.
+  it("prefers explicit description when it differs from title", () => {
     expect(
       summarizePermissionAction(
         { description: "Run bash command 'ls -la'", raw_input: { command: "ls -la" } },

--- a/apps/web/components/task/chat/messages/permission-action-summary.ts
+++ b/apps/web/components/task/chat/messages/permission-action-summary.ts
@@ -1,0 +1,74 @@
+import type { PermissionActionDetails } from "./use-permission-handlers";
+
+const PREFERRED_RAW_INPUT_KEYS = [
+  "command",
+  "cmd",
+  "file_path",
+  "filePath",
+  "path",
+  "url",
+  "query",
+  "pattern",
+];
+
+const MAX_LEN = 200;
+
+function truncate(value: string): string {
+  if (value.length <= MAX_LEN) return value;
+  return `${value.slice(0, MAX_LEN - 1)}…`;
+}
+
+function stringifyValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value.trim() || null;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function pickFromRawInput(raw: Record<string, unknown>): string | null {
+  for (const key of PREFERRED_RAW_INPUT_KEYS) {
+    if (key in raw) {
+      const v = stringifyValue(raw[key]);
+      if (v) return v;
+    }
+  }
+  const v = stringifyValue(raw);
+  return v && v !== "{}" ? v : null;
+}
+
+/**
+ * One-line human-readable summary of what the agent is asking permission to do,
+ * derived from action_details. Returns null when no useful detail is available
+ * (so the caller can skip rendering).
+ *
+ * Priority: explicit description > raw_input (best key) > legacy top-level
+ * command/path. Skipped when the result duplicates `title` so we don't show
+ * the same string twice.
+ */
+export function summarizePermissionAction(
+  details: PermissionActionDetails | undefined,
+  title: string,
+): string | null {
+  if (!details) return null;
+
+  const candidates: (string | null | undefined)[] = [
+    details.description,
+    details.raw_input ? pickFromRawInput(details.raw_input) : null,
+    details.command,
+    details.path,
+    details.cwd,
+  ];
+
+  for (const c of candidates) {
+    if (!c) continue;
+    const trimmed = c.trim();
+    if (!trimmed) continue;
+    if (trimmed === title.trim()) continue;
+    return truncate(trimmed);
+  }
+  return null;
+}

--- a/apps/web/components/task/chat/messages/permission-request-message.tsx
+++ b/apps/web/components/task/chat/messages/permission-request-message.tsx
@@ -4,6 +4,7 @@ import { IconAlertTriangle, IconCheck, IconX } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
 import { PermissionActionRow } from "./permission-action-row";
+import { summarizePermissionAction } from "./permission-action-summary";
 import {
   parsePermission,
   usePermissionResponseHandlers,
@@ -51,6 +52,8 @@ export function PermissionRequestMessage({ comment }: PermissionRequestMessagePr
   });
 
   const statusBadge = getPermissionStatusBadge(permissionStatus);
+  const titleText = comment.content || "Permission Required";
+  const detailSummary = summarizePermissionAction(permissionMetadata?.action_details, titleText);
 
   return (
     <div className="w-full">
@@ -74,10 +77,19 @@ export function PermissionRequestMessage({ comment }: PermissionRequestMessagePr
                   : "text-muted-foreground",
               )}
             >
-              {comment.content || "Permission Required"}
+              {titleText}
             </span>
             {statusBadge}
           </div>
+
+          {detailSummary && (
+            <div
+              className="mt-1 font-mono text-xs text-muted-foreground break-all"
+              data-testid="permission-action-detail"
+            >
+              {detailSummary}
+            </div>
+          )}
 
           {isPermissionPending && (
             <div className="mt-2">

--- a/apps/web/components/task/chat/messages/use-permission-handlers.ts
+++ b/apps/web/components/task/chat/messages/use-permission-handlers.ts
@@ -15,8 +15,9 @@ export type PermissionActionDetails = {
   command?: string;
   path?: string;
   cwd?: string;
-  // Free-form human-readable description (set by the ACP adapter when the
-  // agent provides a ToolCall.Title distinct from the displayed title).
+  // Description forwarded from ToolCall.Title. Equals the displayed title
+  // in the current backend; reserved for future use when agents send a
+  // separate description distinct from Title.
   description?: string;
   // Raw tool-call input as sent by the agent (e.g. { command: "ls -la" },
   // { file_path: "foo.go", limit: 10 }, { url: "..." }). Schema varies per

--- a/apps/web/components/task/chat/messages/use-permission-handlers.ts
+++ b/apps/web/components/task/chat/messages/use-permission-handlers.ts
@@ -11,12 +11,25 @@ export type PermissionOption = {
   kind: PermissionOptionKind;
 };
 
+export type PermissionActionDetails = {
+  command?: string;
+  path?: string;
+  cwd?: string;
+  // Free-form human-readable description (set by the ACP adapter when the
+  // agent provides a ToolCall.Title distinct from the displayed title).
+  description?: string;
+  // Raw tool-call input as sent by the agent (e.g. { command: "ls -la" },
+  // { file_path: "foo.go", limit: 10 }, { url: "..." }). Schema varies per
+  // tool; consumers should treat keys as opaque.
+  raw_input?: Record<string, unknown>;
+};
+
 export type PermissionRequestMetadata = {
   pending_id: string;
   tool_call_id: string;
   options: PermissionOption[];
   action_type: PermissionActionType;
-  action_details: { command?: string; path?: string; cwd?: string };
+  action_details: PermissionActionDetails;
   status?: "pending" | "approved" | "rejected" | "expired";
 };
 


### PR DESCRIPTION
The ACP permission card was labeling tool approvals with the `ToolCall.Kind` enum value (often `other`) instead of the agent's `ToolCall.Title`, so users saw "other / Pending Approval / Approve this action?" with no clue what action they were approving. The adapter now prefers `Title` for the user-facing label and renders a one-line summary of `action_details` (description, or a best-key from `raw_input` like command/file_path/url) so the actual command, path, or URL is visible alongside the title.

## Important Changes

- `forwardPermissionRequest` (`apps/backend/internal/agentctl/server/acp/client.go`): flip precedence — `ToolCall.Title` becomes the user-facing title; `ToolCall.Kind` stays as `ActionType` for icons/categorization only.
- Widen frontend `action_details` type with `description` and `raw_input`, and add `summarizePermissionAction` helper that picks the most informative field (description → preferred raw_input key → legacy command/path/cwd), de-duping against the title and truncating to 200 chars.
- `permission-request-message.tsx` renders the summary as a muted mono line under the title.

## Validation

- `make -C apps/backend test lint` — pass (21 ACP tests, 0 lint issues)
- `pnpm --filter @kandev/web typecheck lint test` — pass (64 message-component tests including 9 new summary cases)
- Repro via `acpdbg probe opencode-acp` with `opencode-go/kimi-k2.6` confirmed the ACP `ToolKind` enum includes `other` as an explicit fallback for unclassified tools, which is what triggered the original "other / Pending Approval" rendering.

## Possible Improvements

Low risk. The summary line is purely additive UI — if `action_details` is empty or matches the title, nothing extra renders. The widened TS type keeps legacy `command`/`path`/`cwd` so existing demo data and any agents that put fields at the top level still work.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.