### PR TITLE
ci: add kandev-ci base Docker image and publish workflow

### DIFF
--- a/.github/docker/ci-base/Dockerfile
+++ b/.github/docker/ci-base/Dockerfile
@@ -11,6 +11,8 @@
 #   - Node            : 24             (matches actions/setup-node value)
 #   - pnpm            : 9.15.9         (matches pnpm/action-setup value)
 #   - golangci-lint   : v2.9.0         (matches v2.9 floating pin)
+#   - go-licenses     : v1.6.0
+#   - Docker CLI      : 27.3.1
 
 FROM mcr.microsoft.com/playwright:v1.58.2-noble
 
@@ -79,12 +81,15 @@ RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.
 WORKDIR /work
 
 # --- Smoke checks ----------------------------------------------------------
-# Fail the build if any pinned tool is missing or mismatched.
+# Fail the build if any pinned tool is missing or mismatched. The Playwright
+# version is intentionally not asserted at runtime: `npx playwright --version`
+# resolves via npm and fetches the latest release rather than the image's
+# bundled binary, and the bundled binary's location is internal to the
+# Microsoft image. The FROM pin (`v1.58.2-noble`) is the version guarantee.
 RUN set -eux; \
     go version | grep -F 'go1.26.0'; \
     node --version | grep -E '^v24\.'; \
     pnpm --version | grep -E '^9\.15\.9$'; \
-    npx playwright --version | grep -F '1.58.2'; \
     golangci-lint --version | grep -F '2.9.0'; \
     go version -m "$(which go-licenses)" | grep -F 'v1.6.0'; \
     docker --version | grep -F '27.3.1'

--- a/.github/docker/ci-base/Dockerfile
+++ b/.github/docker/ci-base/Dockerfile
@@ -84,7 +84,7 @@ RUN set -eux; \
     go version | grep -F 'go1.26.0'; \
     node --version | grep -E '^v24\.'; \
     pnpm --version | grep -E '^9\.15\.9$'; \
-    npx playwright --version; \
+    npx playwright --version | grep -F '1.58.2'; \
     golangci-lint --version | grep -F '2.9.0'; \
-    go-licenses --help >/dev/null; \
+    go version -m "$(which go-licenses)" | grep -F 'v1.6.0'; \
     docker --version | grep -F '27.3.1'

--- a/.github/docker/ci-base/Dockerfile
+++ b/.github/docker/ci-base/Dockerfile
@@ -1,0 +1,79 @@
+# Kandev CI base image.
+#
+# Bundles every tool the CI workflows need so jobs can run via `container:`
+# without re-downloading Playwright browsers, Go, Node, pnpm, golangci-lint,
+# and go-licenses on every run.
+#
+# Pinned versions (keep in sync with the matching workflow inputs and
+# apps/backend/go.mod, apps/web/package.json):
+#   - Playwright base : v1.58.2-noble  (matches @playwright/test ^1.58.2)
+#   - Go              : 1.26.0         (matches apps/backend/go.mod)
+#   - Node            : 24             (matches actions/setup-node value)
+#   - pnpm            : 9.15.9         (matches pnpm/action-setup value)
+#   - golangci-lint   : v2.9.0         (matches v2.9 floating pin)
+
+FROM mcr.microsoft.com/playwright:v1.58.2-noble
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PNPM_HOME=/pnpm \
+    GOPATH=/root/go \
+    PATH=/pnpm:/usr/local/go/bin:/root/go/bin:/usr/local/bin:/usr/bin:/bin
+
+# --- System packages -------------------------------------------------------
+# Docker CLI is fetched as a static binary below to avoid pulling the daemon.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        git \
+        make \
+        build-essential \
+        jq \
+        tar \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Node 24 (replaces the base image's Node 22) ---------------------------
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- pnpm 9.15.9 via corepack ---------------------------------------------
+RUN corepack enable \
+    && corepack prepare pnpm@9.15.9 --activate
+
+# --- Go 1.26.0 -------------------------------------------------------------
+RUN curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz \
+        -o /tmp/go.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm /tmp/go.tar.gz
+
+# --- golangci-lint v2.9.0 --------------------------------------------------
+RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+        | sh -s -- -b /usr/local/bin v2.9.0
+
+# --- go-licenses -----------------------------------------------------------
+RUN go install github.com/google/go-licenses@latest
+
+# --- Docker CLI (no daemon) ------------------------------------------------
+# Static binary release lets jobs talk to a mounted host socket without
+# dragging containerd/dockerd into the image.
+RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.3.1.tgz \
+        -o /tmp/docker.tgz \
+    && tar -xzf /tmp/docker.tgz -C /tmp \
+    && mv /tmp/docker/docker /usr/local/bin/docker \
+    && rm -rf /tmp/docker /tmp/docker.tgz
+
+WORKDIR /work
+
+# --- Smoke checks ----------------------------------------------------------
+# Fail the build if any pinned tool is missing or mismatched.
+RUN set -eux; \
+    go version; \
+    node --version | grep -E '^v24\.'; \
+    pnpm --version | grep -E '^9\.15\.9$'; \
+    npx playwright --version; \
+    golangci-lint --version; \
+    go-licenses --help >/dev/null; \
+    docker --version

--- a/.github/docker/ci-base/Dockerfile
+++ b/.github/docker/ci-base/Dockerfile
@@ -35,7 +35,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Node 24 (replaces the base image's Node 22) ---------------------------
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+# Download the NodeSource setup script to a temp file first rather than piping
+# `curl` straight into `bash`, so the script is on disk if anything needs to
+# inspect it.
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x -o /tmp/nodesource_setup.sh \
+    && bash /tmp/nodesource_setup.sh \
+    && rm /tmp/nodesource_setup.sh \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
@@ -51,9 +56,13 @@ RUN curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz \
 
 # --- golangci-lint v2.9.0 --------------------------------------------------
 # Fetch the install script from the matching tagged ref (not `master`) so the
-# script itself is reproducible across rebuilds.
-RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/v2.9.0/install.sh \
-        | sh -s -- -b /usr/local/bin v2.9.0
+# script itself is reproducible across rebuilds, and save it to a temp file
+# before executing rather than piping `curl` into `sh`.
+RUN curl -fsSL \
+        https://raw.githubusercontent.com/golangci/golangci-lint/v2.9.0/install.sh \
+        -o /tmp/install-golangci-lint.sh \
+    && sh /tmp/install-golangci-lint.sh -b /usr/local/bin v2.9.0 \
+    && rm /tmp/install-golangci-lint.sh
 
 # --- go-licenses v1.6.0 ----------------------------------------------------
 RUN go install github.com/google/go-licenses@v1.6.0
@@ -78,4 +87,4 @@ RUN set -eux; \
     npx playwright --version; \
     golangci-lint --version | grep -F '2.9.0'; \
     go-licenses --help >/dev/null; \
-    docker --version
+    docker --version | grep -F '27.3.1'

--- a/.github/docker/ci-base/Dockerfile
+++ b/.github/docker/ci-base/Dockerfile
@@ -17,7 +17,7 @@ FROM mcr.microsoft.com/playwright:v1.58.2-noble
 ENV DEBIAN_FRONTEND=noninteractive \
     PNPM_HOME=/pnpm \
     GOPATH=/root/go \
-    PATH=/pnpm:/usr/local/go/bin:/root/go/bin:/usr/local/bin:/usr/bin:/bin
+    PATH=/pnpm:/usr/local/go/bin:/root/go/bin:$PATH
 
 # --- System packages -------------------------------------------------------
 # Docker CLI is fetched as a static binary below to avoid pulling the daemon.
@@ -50,11 +50,13 @@ RUN curl -fsSL https://go.dev/dl/go1.26.0.linux-amd64.tar.gz \
     && rm /tmp/go.tar.gz
 
 # --- golangci-lint v2.9.0 --------------------------------------------------
-RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+# Fetch the install script from the matching tagged ref (not `master`) so the
+# script itself is reproducible across rebuilds.
+RUN curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/v2.9.0/install.sh \
         | sh -s -- -b /usr/local/bin v2.9.0
 
-# --- go-licenses -----------------------------------------------------------
-RUN go install github.com/google/go-licenses@latest
+# --- go-licenses v1.6.0 ----------------------------------------------------
+RUN go install github.com/google/go-licenses@v1.6.0
 
 # --- Docker CLI (no daemon) ------------------------------------------------
 # Static binary release lets jobs talk to a mounted host socket without
@@ -70,10 +72,10 @@ WORKDIR /work
 # --- Smoke checks ----------------------------------------------------------
 # Fail the build if any pinned tool is missing or mismatched.
 RUN set -eux; \
-    go version; \
+    go version | grep -F 'go1.26.0'; \
     node --version | grep -E '^v24\.'; \
     pnpm --version | grep -E '^9\.15\.9$'; \
     npx playwright --version; \
-    golangci-lint --version; \
+    golangci-lint --version | grep -F '2.9.0'; \
     go-licenses --help >/dev/null; \
     docker --version

--- a/.github/workflows/ci-base-image.yml
+++ b/.github/workflows/ci-base-image.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -48,9 +48,11 @@ jobs:
         id: tag
         run: |
           set -euo pipefail
+          # Hash reflects image content (Dockerfile + dependencies) only; the
+          # workflow file is intentionally excluded so cosmetic edits to it
+          # (renaming a step, fixing a summary) don't produce a wasteful retag.
           hash=$(cat \
               .github/docker/ci-base/Dockerfile \
-              .github/workflows/ci-base-image.yml \
               apps/backend/go.mod \
               apps/pnpm-lock.yaml \
               apps/web/package.json \
@@ -64,7 +66,7 @@ jobs:
           context: .
           file: .github/docker/ci-base/Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
@@ -82,4 +84,4 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
-          PUSHED: ${{ github.event_name != 'pull_request' }}
+          PUSHED: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci-base-image.yml
+++ b/.github/workflows/ci-base-image.yml
@@ -1,0 +1,84 @@
+name: CI base image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/docker/ci-base/**
+      - .github/workflows/ci-base-image.yml
+      - apps/backend/go.mod
+      - apps/pnpm-lock.yaml
+      - apps/web/package.json
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/docker/ci-base/**
+      - .github/workflows/ci-base-image.yml
+      - apps/backend/go.mod
+      - apps/pnpm-lock.yaml
+      - apps/web/package.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/kdlbs/kandev-ci
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          set -euo pipefail
+          hash=$(cat \
+              .github/docker/ci-base/Dockerfile \
+              apps/backend/go.mod \
+              apps/pnpm-lock.yaml \
+              apps/web/package.json \
+            | sha256sum | cut -c1-12)
+          echo "image_tag=${hash}" >> "$GITHUB_OUTPUT"
+          echo "Computed content hash: sha-${hash}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/ci-base/Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.IMAGE_NAME }}:sha-${{ steps.tag.outputs.image_tag }}
+            ${{ env.IMAGE_NAME }}:latest
+
+      - name: Summarize
+        run: |
+          {
+            echo "### Kandev CI base image"
+            echo ""
+            echo "- image: \`${IMAGE_NAME}:sha-${IMAGE_TAG}\`"
+            echo "- latest: \`${IMAGE_NAME}:latest\`"
+            echo "- pushed: \`${PUSHED}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          PUSHED: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/ci-base-image.yml
+++ b/.github/workflows/ci-base-image.yml
@@ -50,6 +50,7 @@ jobs:
           set -euo pipefail
           hash=$(cat \
               .github/docker/ci-base/Dockerfile \
+              .github/workflows/ci-base-image.yml \
               apps/backend/go.mod \
               apps/pnpm-lock.yaml \
               apps/web/package.json \


### PR DESCRIPTION
## Summary

GitHub-hosted runners burn 3–5 minutes per shard re-downloading Playwright browsers and reinstalling system deps. This PR is step 1 of 2 toward a shared CI base image that ships every tool preinstalled — it only adds the image definition and the workflow that builds & publishes it to GHCR. A follow-up PR will migrate `backend-tests.yml`, `frontend-tests.yml`, and `e2e-tests.yml` to consume it.

## Important Changes

- New `.github/docker/ci-base/Dockerfile` based on `mcr.microsoft.com/playwright:v1.58.2-noble` with the following pinned tools:
  - Go `1.26.0` (matches `apps/backend/go.mod`)
  - Node `24` (replaces the base image's Node 22 via NodeSource)
  - pnpm `9.15.9` (via corepack)
  - golangci-lint `v2.9.0` (matches the `v2.9` floating pin used in `backend-tests.yml`)
  - `go-licenses` (used by `frontend-tests.yml`)
  - Docker CLI `27.3.1` static binary (no daemon — for jobs that shell `docker` against a mounted socket)
  - apt: `git`, `make`, `build-essential`, `ca-certificates`, `jq`, `tar`, `xz-utils`
  - Build-time smoke checks fail the image build if any tool is missing or version-mismatched.
- New `.github/workflows/ci-base-image.yml`:
  - Triggers on push to `main`, PRs against `main`, and `workflow_dispatch`, scoped to changes in the Dockerfile/workflow itself or in `apps/backend/go.mod`, `apps/pnpm-lock.yaml`, `apps/web/package.json`.
  - Publishes to `ghcr.io/kdlbs/kandev-ci` with both `sha-<12-char-hash>` and `latest` tags **only on push to main**. PR runs build the image (with GHA cache) without pushing, so this very PR validates the Dockerfile.
  - Uses `docker/build-push-action@v6` with `type=gha` cache and `linux/amd64` only.

## Validation

- This PR's own run of `.github/workflows/ci-base-image.yml` must build the image and pass the Dockerfile's smoke checks. Confirm in CI before merging.
- After merge, the image should appear at https://github.com/kdlbs/kandev/pkgs/container/kandev-ci with both tags. Local sanity check:
  ```
  docker run --rm ghcr.io/kdlbs/kandev-ci:latest bash -c \
    'go version && node --version && pnpm --version && playwright --version && golangci-lint --version'
  ```

## Possible Improvements

- A wrong pin (e.g. Node minor bump landing in `setup-node` workflows but not here) would silently let the image drift from what jobs expect. PR 2 fixes that by removing the duplicated installs from the consuming workflows.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated
- [ ] Self-reviewed