### PR TITLE
feat(web): show executor-specific cleanup details in task delete/archive dialog

### DIFF
--- a/apps/web/app/tasks/columns.tsx
+++ b/apps/web/app/tasks/columns.tsx
@@ -118,6 +118,7 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
         onOpenChange={setShowDeleteConfirm}
         taskTitle={task.title}
         taskId={task.id}
+        executorType={task.primary_executor_type}
         isDeleting={isDeleting}
         onConfirm={({ cascade }) => ctx.onDelete(task.id, { cascade })}
       />
@@ -126,6 +127,7 @@ function ActionsCell({ row, ctx }: { row: Row<TaskWithResolution>; ctx: ActionsC
         onOpenChange={setShowArchiveConfirm}
         taskTitle={task.title}
         taskId={task.id}
+        executorType={task.primary_executor_type}
         onConfirm={({ cascade }) => ctx.onArchive(task.id, { cascade })}
       />
     </div>

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -250,6 +250,7 @@ export function KanbanCard({
         onOpenChange={setShowDeleteConfirm}
         taskTitle={task.title}
         taskId={task.id}
+        executorType={task.primaryExecutorType}
         isDeleting={isDeleting}
         onConfirm={({ cascade }) => onDelete?.(task, { cascade })}
       />
@@ -258,6 +259,7 @@ export function KanbanCard({
         onOpenChange={setShowArchiveConfirm}
         taskTitle={task.title}
         taskId={task.id}
+        executorType={task.primaryExecutorType}
         isArchiving={isArchiving}
         onConfirm={({ cascade }) => onArchive?.(task, { cascade })}
       />

--- a/apps/web/components/kanban/graph2-task-pipeline.tsx
+++ b/apps/web/components/kanban/graph2-task-pipeline.tsx
@@ -165,6 +165,7 @@ function TaskActions({
         onOpenChange={setShowDeleteConfirm}
         taskTitle={task.title}
         taskId={task.id}
+        executorType={task.primaryExecutorType}
         isDeleting={isDeleting}
         onConfirm={({ cascade }) => onDeleteTask(task, { cascade })}
       />
@@ -173,6 +174,7 @@ function TaskActions({
         onOpenChange={setShowArchiveConfirm}
         taskTitle={task.title}
         taskId={task.id}
+        executorType={task.primaryExecutorType}
         isArchiving={isArchiving}
         onConfirm={({ cascade }) => onArchiveTask?.(task, { cascade })}
       />

--- a/apps/web/components/kanban/task-multi-select-toolbar.tsx
+++ b/apps/web/components/kanban/task-multi-select-toolbar.tsx
@@ -42,16 +42,17 @@ function useBulkExecutorTypes(taskIds: string[]): Array<string | null | undefine
 function BulkArchiveDialog({
   count,
   taskIds,
+  executorTypes,
   isProcessing,
   onConfirm,
 }: {
   count: number;
   taskIds: string[];
+  executorTypes: Array<string | null | undefined>;
   isProcessing: boolean;
   onConfirm: (opts: { cascade: boolean }) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const executorTypes = useBulkExecutorTypes(taskIds);
 
   return (
     <>
@@ -84,16 +85,17 @@ function BulkArchiveDialog({
 function BulkDeleteDialog({
   count,
   taskIds,
+  executorTypes,
   isProcessing,
   onConfirm,
 }: {
   count: number;
   taskIds: string[];
+  executorTypes: Array<string | null | undefined>;
   isProcessing: boolean;
   onConfirm: (opts: { cascade: boolean }) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const executorTypes = useBulkExecutorTypes(taskIds);
 
   return (
     <>
@@ -133,6 +135,9 @@ export function TaskMultiSelectToolbar({
   onBulkArchive,
   onBulkMove,
 }: TaskMultiSelectToolbarProps) {
+  const taskIds = useMemo(() => [...selectedIds], [selectedIds]);
+  const executorTypes = useBulkExecutorTypes(taskIds);
+
   if (selectedIds.size === 0) return null;
 
   const count = selectedIds.size;
@@ -181,14 +186,16 @@ export function TaskMultiSelectToolbar({
 
       <BulkArchiveDialog
         count={count}
-        taskIds={[...selectedIds]}
+        taskIds={taskIds}
+        executorTypes={executorTypes}
         isProcessing={isProcessing}
         onConfirm={({ cascade }) => onBulkArchive({ cascade })}
       />
 
       <BulkDeleteDialog
         count={count}
-        taskIds={[...selectedIds]}
+        taskIds={taskIds}
+        executorTypes={executorTypes}
         isProcessing={isProcessing}
         onConfirm={({ cascade }) => onBulkDelete({ cascade })}
       />

--- a/apps/web/components/kanban/task-multi-select-toolbar.tsx
+++ b/apps/web/components/kanban/task-multi-select-toolbar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { IconTrash, IconArchive, IconChevronRight, IconX } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-dialog";
 import { TaskArchiveConfirmDialog } from "@/components/task/task-archive-confirm-dialog";
+import { useAppStore } from "@/components/state-provider";
+import { findTaskInSnapshots } from "@/lib/kanban/find-task";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,6 +27,18 @@ interface TaskMultiSelectToolbarProps {
   onBulkMove: (targetStepId: string) => Promise<void>;
 }
 
+function useBulkExecutorTypes(taskIds: string[]): Array<string | null | undefined> {
+  const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
+  const fallbackTasks = useAppStore((state) => state.kanban.tasks);
+  return useMemo(
+    () =>
+      taskIds.map(
+        (id) => findTaskInSnapshots(id, snapshots, fallbackTasks)?.primaryExecutorType ?? null,
+      ),
+    [taskIds, snapshots, fallbackTasks],
+  );
+}
+
 function BulkArchiveDialog({
   count,
   taskIds,
@@ -37,6 +51,7 @@ function BulkArchiveDialog({
   onConfirm: (opts: { cascade: boolean }) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const executorTypes = useBulkExecutorTypes(taskIds);
 
   return (
     <>
@@ -57,6 +72,7 @@ function BulkArchiveDialog({
         isBulkOperation
         count={count}
         taskIds={taskIds}
+        executorTypes={executorTypes}
         isArchiving={isProcessing}
         onConfirm={onConfirm}
         confirmTestId="bulk-archive-confirm"
@@ -77,6 +93,7 @@ function BulkDeleteDialog({
   onConfirm: (opts: { cascade: boolean }) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const executorTypes = useBulkExecutorTypes(taskIds);
 
   return (
     <>
@@ -97,6 +114,7 @@ function BulkDeleteDialog({
         isBulkOperation
         count={count}
         taskIds={taskIds}
+        executorTypes={executorTypes}
         isDeleting={isProcessing}
         onConfirm={onConfirm}
         confirmTestId="bulk-delete-confirm"

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -438,14 +438,22 @@ function useSheetDeleteActions(
   removeTaskFromBoard: ReturnType<typeof useTaskRemoval>["removeTaskFromBoard"],
 ) {
   const { deleteTaskById } = useTaskActions();
-  const [deletingTask, setDeletingTask] = useState<{ id: string; title: string } | null>(null);
+  const [deletingTask, setDeletingTask] = useState<{
+    id: string;
+    title: string;
+    executorType?: string | null;
+  } | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
   const handleDeleteTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
       const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
-      setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
+      setDeletingTask({
+        id: taskId,
+        title: task?.title ?? "this task",
+        executorType: task?.primaryExecutorType,
+      });
     },
     [store],
   );
@@ -519,14 +527,22 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
     [loadTaskSessionsForTask, setActiveSession, setActiveTask, store, onOpenChange],
   );
 
-  const [archivingTask, setArchivingTask] = useState<{ id: string; title: string } | null>(null);
+  const [archivingTask, setArchivingTask] = useState<{
+    id: string;
+    title: string;
+    executorType?: string | null;
+  } | null>(null);
   const [isArchiving, setIsArchiving] = useState(false);
 
   const handleArchiveTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
       const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
-      setArchivingTask({ id: taskId, title: task?.title ?? "this task" });
+      setArchivingTask({
+        id: taskId,
+        title: task?.title ?? "this task",
+        executorType: task?.primaryExecutorType,
+      });
     },
     [store],
   );

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -159,6 +159,7 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
         }}
         taskTitle={actions.archivingTask?.title ?? ""}
         taskId={actions.archivingTask?.id}
+        executorType={actions.archivingTask?.executorType}
         isArchiving={actions.isArchiving}
         onConfirm={({ cascade }) => actions.handleArchiveConfirm({ cascade })}
       />
@@ -169,6 +170,7 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
         }}
         taskTitle={actions.deletingTask?.title ?? ""}
         taskId={actions.deletingTask?.id}
+        executorType={actions.deletingTask?.executorType}
         isDeleting={actions.isDeleting}
         onConfirm={({ cascade }) => actions.handleDeleteConfirm({ cascade })}
       />

--- a/apps/web/components/task/task-archive-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+const mockGetSubtaskCount = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  getSubtaskCount: (...args: unknown[]) => mockGetSubtaskCount(...args),
+}));
+
+import { TaskArchiveConfirmDialog } from "./task-archive-confirm-dialog";
+
+beforeEach(() => {
+  mockGetSubtaskCount.mockReset();
+  mockGetSubtaskCount.mockResolvedValue({ count: 0 });
+});
+
+afterEach(cleanup);
+
+describe("TaskArchiveConfirmDialog cleanup copy", () => {
+  it("renders local-executor reassurance about untouched repo", () => {
+    render(
+      <TaskArchiveConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        executorType="local"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/directly in your repo/i)).toBeTruthy();
+  });
+
+  it("renders worktree-executor copy about worktree + branch removal", () => {
+    render(
+      <TaskArchiveConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        executorType="worktree"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/worktree and its branch will be deleted/i)).toBeTruthy();
+  });
+
+  it("warns about sandbox destruction for sprites executor", () => {
+    render(
+      <TaskArchiveConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        executorType="sprites"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Sprites cloud sandbox/i)).toBeTruthy();
+    expect(screen.getByText(/uncommitted work/i)).toBeTruthy();
+  });
+
+  it("describes Docker container removal for local_docker", () => {
+    render(
+      <TaskArchiveConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        executorType="local_docker"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Docker container/i)).toBeTruthy();
+  });
+
+  it("renders grouped copy for bulk archive", () => {
+    render(
+      <TaskArchiveConfirmDialog
+        open
+        onOpenChange={() => {}}
+        isBulkOperation
+        count={3}
+        taskIds={["a", "b", "c"]}
+        executorTypes={["sprites", "worktree", "worktree"]}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/2 worktrees/i)).toBeTruthy();
+    expect(screen.getByText(/1 Sprites sandbox/i)).toBeTruthy();
+  });
+
+  it("no longer renders the old hardcoded worktree line for non-worktree executors", () => {
+    render(
+      <TaskArchiveConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        executorType="local"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByText(
+        /This will delete the task's worktree and stop any running agent sessions/,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/web/components/task/task-archive-confirm-dialog.tsx
+++ b/apps/web/components/task/task-archive-confirm-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@kandev/ui/alert-dialog";
 import { Checkbox } from "@kandev/ui/checkbox";
 import { useSubtaskCount } from "@/hooks/use-subtask-count";
+import { getCleanupSummary, getBulkCleanupSummary } from "./task-cleanup-summary";
 
 type TaskArchiveConfirmDialogProps = {
   open: boolean;
@@ -24,6 +25,10 @@ type TaskArchiveConfirmDialogProps = {
   isArchiving?: boolean;
   taskId?: string;
   taskIds?: string[];
+  /** Executor type of the task being archived (single). */
+  executorType?: string | null;
+  /** Executor types of the tasks being archived (bulk). */
+  executorTypes?: Array<string | null | undefined>;
   onConfirm: (opts: { cascade: boolean }) => void;
   confirmTestId?: string;
 };
@@ -37,6 +42,8 @@ export function TaskArchiveConfirmDialog({
   isArchiving,
   taskId,
   taskIds,
+  executorType,
+  executorTypes,
   onConfirm,
   confirmTestId,
 }: TaskArchiveConfirmDialogProps) {
@@ -46,6 +53,9 @@ export function TaskArchiveConfirmDialog({
   const firstLine = isBulkOperation
     ? `Are you sure you want to archive ${safeCount} ${label}?`
     : `Are you sure you want to archive "${taskTitle}"?`;
+  const cleanup = isBulkOperation
+    ? getBulkCleanupSummary(executorTypes ?? [])
+    : getCleanupSummary(executorType);
 
   const [cascade, setCascade] = useState(false);
   const subtaskCount = useSubtaskCount(open, taskId, taskIds);
@@ -63,9 +73,11 @@ export function TaskArchiveConfirmDialog({
           <AlertDialogDescription asChild>
             <div>
               <p>{firstLine}</p>
-              <p className="mt-2">
-                This will delete the task&apos;s worktree and stop any running agent sessions.
-              </p>
+              {cleanup.lines.map((line, i) => (
+                <p key={i} className="mt-2" data-testid="cleanup-line">
+                  {line}
+                </p>
+              ))}
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/apps/web/components/task/task-cleanup-summary.test.ts
+++ b/apps/web/components/task/task-cleanup-summary.test.ts
@@ -83,6 +83,18 @@ describe("getBulkCleanupSummary", () => {
     expect(lines.some((l) => /3 worktrees/.test(l))).toBe(true);
   });
 
+  it("groups remote_docker tasks with their own line", () => {
+    const { lines } = getBulkCleanupSummary(["remote_docker", "remote_docker"]);
+    expect(lines.some((l) => /2 remote Docker containers/.test(l))).toBe(true);
+  });
+
+  it("groups ssh tasks with best-effort wording", () => {
+    const { lines } = getBulkCleanupSummary(["ssh", "ssh"]);
+    expect(lines.some((l) => /2 remote task directories/.test(l) && /best-effort/.test(l))).toBe(
+      true,
+    );
+  });
+
   it("emits worktree/container/sandbox lines before the local-reassurance line", () => {
     const { lines } = getBulkCleanupSummary(["local", "worktree"]);
     const worktreeIdx = lines.findIndex((l) => /worktree/i.test(l));

--- a/apps/web/components/task/task-cleanup-summary.test.ts
+++ b/apps/web/components/task/task-cleanup-summary.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { getCleanupSummary, getBulkCleanupSummary } from "./task-cleanup-summary";
+
+const AGENT_STOP_LINE = "Any running agent sessions will be stopped.";
+
+describe("getCleanupSummary (single task)", () => {
+  it("reassures the user that local executor leaves the repo untouched", () => {
+    const { lines } = getCleanupSummary("local");
+    expect(lines[0]).toMatch(/directly in your repo/i);
+    expect(lines[0]).toMatch(/not touched/i);
+  });
+
+  it("describes worktree deletion + branch removal", () => {
+    const { lines } = getCleanupSummary("worktree");
+    expect(lines[0]).toMatch(/worktree/i);
+    expect(lines[0]).toMatch(/branch/i);
+    expect(lines[0]).toMatch(/not affected/i);
+  });
+
+  it("describes local_docker container removal", () => {
+    const { lines } = getCleanupSummary("local_docker");
+    expect(lines[0]).toMatch(/Docker container/i);
+    expect(lines[0]).toMatch(/removed/i);
+  });
+
+  it("describes remote_docker container removal", () => {
+    const { lines } = getCleanupSummary("remote_docker");
+    expect(lines[0]).toMatch(/remote Docker container/i);
+  });
+
+  it("warns that sprites sandbox destruction loses uncommitted work", () => {
+    const { lines } = getCleanupSummary("sprites");
+    expect(lines[0]).toMatch(/Sprites/i);
+    expect(lines[0]).toMatch(/uncommitted work/i);
+  });
+
+  it("describes ssh remote directory removal as best-effort", () => {
+    const { lines } = getCleanupSummary("ssh");
+    expect(lines[0]).toMatch(/remote/i);
+    expect(lines[0]).toMatch(/best-effort/i);
+  });
+
+  it("always appends the agent-session-stop line", () => {
+    expect(getCleanupSummary("local").lines).toContain(AGENT_STOP_LINE);
+    expect(getCleanupSummary("worktree").lines).toContain(AGENT_STOP_LINE);
+  });
+
+  it("falls back to a generic line when executor type is unknown or missing", () => {
+    expect(getCleanupSummary(undefined).lines).toEqual([AGENT_STOP_LINE]);
+    expect(getCleanupSummary(null).lines).toEqual([AGENT_STOP_LINE]);
+    expect(getCleanupSummary("totally-made-up").lines).toEqual([AGENT_STOP_LINE]);
+  });
+
+  it("is case-insensitive for executor type", () => {
+    expect(getCleanupSummary("WORKTREE").lines[0]).toMatch(/worktree/i);
+    expect(getCleanupSummary("Local").lines[0]).toMatch(/directly in your repo/i);
+  });
+});
+
+describe("getBulkCleanupSummary", () => {
+  it("groups by executor type and counts each group", () => {
+    const { lines } = getBulkCleanupSummary([
+      "worktree",
+      "worktree",
+      "local_docker",
+      "local",
+      "sprites",
+    ]);
+    expect(lines.some((l) => /2 worktrees/.test(l) && /branches/.test(l))).toBe(true);
+    expect(lines.some((l) => /1 Docker container/.test(l))).toBe(true);
+    expect(lines.some((l) => /1 local task/.test(l) && /won't be touched/.test(l))).toBe(true);
+    expect(lines.some((l) => /1 Sprites sandbox/.test(l))).toBe(true);
+  });
+
+  it("uses singular wording for groups of size one", () => {
+    const { lines } = getBulkCleanupSummary(["worktree", "local_docker"]);
+    expect(lines.some((l) => /1 worktree\b/.test(l))).toBe(true);
+    expect(lines.some((l) => /1 Docker container\b/.test(l))).toBe(true);
+  });
+
+  it("uses plural wording for groups of size > 1", () => {
+    const { lines } = getBulkCleanupSummary(["worktree", "worktree", "worktree"]);
+    expect(lines.some((l) => /3 worktrees/.test(l))).toBe(true);
+  });
+
+  it("emits worktree/container/sandbox lines before the local-reassurance line", () => {
+    const { lines } = getBulkCleanupSummary(["local", "worktree"]);
+    const worktreeIdx = lines.findIndex((l) => /worktree/i.test(l));
+    const localIdx = lines.findIndex((l) => /local task/i.test(l));
+    expect(worktreeIdx).toBeGreaterThanOrEqual(0);
+    expect(localIdx).toBeGreaterThan(worktreeIdx);
+  });
+
+  it("always appends the agent-session-stop line", () => {
+    const { lines } = getBulkCleanupSummary(["worktree"]);
+    expect(lines[lines.length - 1]).toBe(AGENT_STOP_LINE);
+  });
+
+  it("ignores unknown / mock executor types in the grouped output", () => {
+    const { lines } = getBulkCleanupSummary(["worktree", undefined, "mock_remote", "what"]);
+    expect(lines.some((l) => /worktree/i.test(l))).toBe(true);
+    expect(lines.some((l) => /mock/i.test(l))).toBe(false);
+    expect(lines.some((l) => /what/i.test(l))).toBe(false);
+  });
+
+  it("returns only the generic line for an empty input", () => {
+    expect(getBulkCleanupSummary([]).lines).toEqual([AGENT_STOP_LINE]);
+  });
+});

--- a/apps/web/components/task/task-cleanup-summary.ts
+++ b/apps/web/components/task/task-cleanup-summary.ts
@@ -1,21 +1,10 @@
-/**
- * Builds the per-executor "what will be cleaned up" lines shown in the
- * task delete/archive confirmation dialogs. The text describes which
- * resources are torn down (worktree / container / sandbox / remote dir)
- * and — importantly for the local executor — what is NOT touched.
- *
- * Executor types match `models.ExecutorType` in the Go backend
- * (apps/backend/internal/task/models/models.go).
- */
+// Executor types match models.ExecutorType in apps/backend/internal/task/models/models.go.
 
 export type CleanupSummary = {
-  /** Lines to render under the dialog description, in order. */
   lines: string[];
 };
 
-// `mock_remote` is a test-only executor and intentionally not listed here:
-// it should never surface user-facing copy, and `normalize()` returns null
-// for unknown keys so it falls through to the generic line.
+// mock_remote is test-only — intentionally absent so it falls through to GENERIC_LINE.
 type KnownExecutor = "local" | "worktree" | "local_docker" | "remote_docker" | "sprites" | "ssh";
 
 const SINGLE: Record<KnownExecutor, string> = {
@@ -68,28 +57,26 @@ export function getBulkCleanupSummary(
 ): CleanupSummary {
   if (executorTypes.length === 0) return { lines: [GENERIC_LINE] };
 
-  const counts = new Map<KnownExecutor | "unknown", number>();
+  const counts = new Map<KnownExecutor, number>();
   for (const t of executorTypes) {
     const known = normalize(t);
-    const key = known ?? "unknown";
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (!known) continue;
+    counts.set(known, (counts.get(known) ?? 0) + 1);
   }
 
-  const order: Array<KnownExecutor | "unknown"> = [
+  const order: KnownExecutor[] = [
     "worktree",
     "local_docker",
     "remote_docker",
     "sprites",
     "ssh",
     "local",
-    "unknown",
   ];
 
   const lines: string[] = [];
   for (const key of order) {
     const count = counts.get(key);
     if (!count) continue;
-    if (key === "unknown") continue;
     const fmt = PLURAL[key];
     if (fmt) lines.push(fmt(count));
   }

--- a/apps/web/components/task/task-cleanup-summary.ts
+++ b/apps/web/components/task/task-cleanup-summary.ts
@@ -13,18 +13,13 @@ export type CleanupSummary = {
   lines: string[];
 };
 
-type KnownExecutor =
-  | "local"
-  | "worktree"
-  | "local_docker"
-  | "remote_docker"
-  | "sprites"
-  | "ssh"
-  | "mock_remote";
+// `mock_remote` is a test-only executor and intentionally not listed here:
+// it should never surface user-facing copy, and `normalize()` returns null
+// for unknown keys so it falls through to the generic line.
+type KnownExecutor = "local" | "worktree" | "local_docker" | "remote_docker" | "sprites" | "ssh";
 
 const SINGLE: Record<KnownExecutor, string> = {
-  local:
-    "The agent ran directly in your repo — your files, branch, and folder are not touched. Only the agent session will be stopped.",
+  local: "The agent ran directly in your repo — your files, branch, and folder are not touched.",
   worktree:
     "The task's git worktree and its branch will be deleted. Your main repo and other branches are not affected.",
   local_docker:
@@ -33,7 +28,6 @@ const SINGLE: Record<KnownExecutor, string> = {
   sprites:
     "The Sprites cloud sandbox for this task will be destroyed. Any uncommitted work inside it will be lost.",
   ssh: "The task directory on the remote host will be removed (best-effort). Your local repo is not touched.",
-  mock_remote: "The mock remote environment will be cleaned up.",
 };
 
 const GENERIC_LINE = "Any running agent sessions will be stopped.";
@@ -88,7 +82,6 @@ export function getBulkCleanupSummary(
     "sprites",
     "ssh",
     "local",
-    "mock_remote",
     "unknown",
   ];
 
@@ -96,7 +89,7 @@ export function getBulkCleanupSummary(
   for (const key of order) {
     const count = counts.get(key);
     if (!count) continue;
-    if (key === "unknown" || key === "mock_remote") continue;
+    if (key === "unknown") continue;
     const fmt = PLURAL[key];
     if (fmt) lines.push(fmt(count));
   }

--- a/apps/web/components/task/task-cleanup-summary.ts
+++ b/apps/web/components/task/task-cleanup-summary.ts
@@ -1,0 +1,105 @@
+/**
+ * Builds the per-executor "what will be cleaned up" lines shown in the
+ * task delete/archive confirmation dialogs. The text describes which
+ * resources are torn down (worktree / container / sandbox / remote dir)
+ * and — importantly for the local executor — what is NOT touched.
+ *
+ * Executor types match `models.ExecutorType` in the Go backend
+ * (apps/backend/internal/task/models/models.go).
+ */
+
+export type CleanupSummary = {
+  /** Lines to render under the dialog description, in order. */
+  lines: string[];
+};
+
+type KnownExecutor =
+  | "local"
+  | "worktree"
+  | "local_docker"
+  | "remote_docker"
+  | "sprites"
+  | "ssh"
+  | "mock_remote";
+
+const SINGLE: Record<KnownExecutor, string> = {
+  local:
+    "The agent ran directly in your repo — your files, branch, and folder are not touched. Only the agent session will be stopped.",
+  worktree:
+    "The task's git worktree and its branch will be deleted. Your main repo and other branches are not affected.",
+  local_docker:
+    "The Docker container running this task will be stopped and removed. Your host repo is not touched.",
+  remote_docker: "The remote Docker container running this task will be stopped and removed.",
+  sprites:
+    "The Sprites cloud sandbox for this task will be destroyed. Any uncommitted work inside it will be lost.",
+  ssh: "The task directory on the remote host will be removed (best-effort). Your local repo is not touched.",
+  mock_remote: "The mock remote environment will be cleaned up.",
+};
+
+const GENERIC_LINE = "Any running agent sessions will be stopped.";
+
+function normalize(executorType: string | null | undefined): KnownExecutor | null {
+  if (!executorType) return null;
+  const key = executorType.toLowerCase();
+  if (key in SINGLE) return key as KnownExecutor;
+  return null;
+}
+
+/** Single-task variant. */
+export function getCleanupSummary(executorType: string | null | undefined): CleanupSummary {
+  const known = normalize(executorType);
+  if (!known) return { lines: [GENERIC_LINE] };
+  return { lines: [SINGLE[known], GENERIC_LINE] };
+}
+
+const PLURAL: Partial<Record<KnownExecutor, (n: number) => string>> = {
+  local: (n) => `${n} local ${pl(n, "task", "tasks")} — your repo folders won't be touched.`,
+  worktree: (n) =>
+    `${n} ${pl(n, "worktree", "worktrees")} and ${pl(n, "its branch", "their branches")} will be deleted.`,
+  local_docker: (n) => `${n} Docker ${pl(n, "container", "containers")} will be removed.`,
+  remote_docker: (n) => `${n} remote Docker ${pl(n, "container", "containers")} will be removed.`,
+  sprites: (n) =>
+    `${n} Sprites ${pl(n, "sandbox", "sandboxes")} will be destroyed (uncommitted work lost).`,
+  ssh: (n) =>
+    `${n} remote task ${pl(n, "directory", "directories")} will be removed (best-effort).`,
+};
+
+function pl(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
+}
+
+/** Bulk variant — groups N tasks by executor type and emits one line per group. */
+export function getBulkCleanupSummary(
+  executorTypes: Array<string | null | undefined>,
+): CleanupSummary {
+  if (executorTypes.length === 0) return { lines: [GENERIC_LINE] };
+
+  const counts = new Map<KnownExecutor | "unknown", number>();
+  for (const t of executorTypes) {
+    const known = normalize(t);
+    const key = known ?? "unknown";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const order: Array<KnownExecutor | "unknown"> = [
+    "worktree",
+    "local_docker",
+    "remote_docker",
+    "sprites",
+    "ssh",
+    "local",
+    "mock_remote",
+    "unknown",
+  ];
+
+  const lines: string[] = [];
+  for (const key of order) {
+    const count = counts.get(key);
+    if (!count) continue;
+    if (key === "unknown" || key === "mock_remote") continue;
+    const fmt = PLURAL[key];
+    if (fmt) lines.push(fmt(count));
+  }
+  lines.push(GENERIC_LINE);
+  return { lines };
+}

--- a/apps/web/components/task/task-delete-confirm-dialog.test.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.test.tsx
@@ -92,3 +92,67 @@ describe("TaskDeleteConfirmDialog", () => {
     await screen.findByText(/Also delete 7 subtasks/i);
   });
 });
+
+describe("TaskDeleteConfirmDialog executor cleanup copy", () => {
+  it("local reassures repo is untouched", async () => {
+    mockGetSubtaskCount.mockResolvedValue({ count: 0 });
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        executorType="local"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/directly in your repo/i)).toBeTruthy();
+    expect(screen.getByText(/not touched/i)).toBeTruthy();
+  });
+
+  it("worktree describes worktree+branch removal", async () => {
+    mockGetSubtaskCount.mockResolvedValue({ count: 0 });
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        executorType="worktree"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/worktree and its branch will be deleted/i)).toBeTruthy();
+  });
+
+  it("groups bulk delete copy by executor type", async () => {
+    mockGetSubtaskCount.mockResolvedValue({ count: 0 });
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        isBulkOperation
+        count={3}
+        taskIds={["a", "b", "c"]}
+        executorTypes={["worktree", "worktree", "local"]}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/2 worktrees/i)).toBeTruthy();
+    expect(screen.getByText(/1 local task/i)).toBeTruthy();
+  });
+
+  it("falls back to a generic message when no executorType is provided", async () => {
+    mockGetSubtaskCount.mockResolvedValue({ count: 0 });
+    render(
+      <TaskDeleteConfirmDialog
+        open
+        onOpenChange={() => {}}
+        taskTitle="My task"
+        taskId="task-1"
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Any running agent sessions will be stopped/i)).toBeTruthy();
+  });
+});

--- a/apps/web/components/task/task-delete-confirm-dialog.tsx
+++ b/apps/web/components/task/task-delete-confirm-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@kandev/ui/alert-dialog";
 import { Checkbox } from "@kandev/ui/checkbox";
 import { useSubtaskCount } from "@/hooks/use-subtask-count";
+import { getCleanupSummary, getBulkCleanupSummary } from "./task-cleanup-summary";
 
 type TaskDeleteConfirmDialogProps = {
   open: boolean;
@@ -24,6 +25,10 @@ type TaskDeleteConfirmDialogProps = {
   isDeleting?: boolean;
   taskId?: string;
   taskIds?: string[];
+  /** Executor type of the task being deleted (single). */
+  executorType?: string | null;
+  /** Executor types of the tasks being deleted (bulk). */
+  executorTypes?: Array<string | null | undefined>;
   onConfirm: (opts: { cascade: boolean }) => void;
   confirmTestId?: string;
 };
@@ -37,6 +42,8 @@ export function TaskDeleteConfirmDialog({
   isDeleting,
   taskId,
   taskIds,
+  executorType,
+  executorTypes,
   onConfirm,
   confirmTestId,
 }: TaskDeleteConfirmDialogProps) {
@@ -46,6 +53,9 @@ export function TaskDeleteConfirmDialog({
   const description = isBulkOperation
     ? `Are you sure you want to delete ${safeCount} ${label}? This action cannot be undone.`
     : `Are you sure you want to delete "${taskTitle}"? This action cannot be undone.`;
+  const cleanup = isBulkOperation
+    ? getBulkCleanupSummary(executorTypes ?? [])
+    : getCleanupSummary(executorType);
 
   const [cascade, setCascade] = useState(false);
   const subtaskCount = useSubtaskCount(open, taskId, taskIds);
@@ -60,7 +70,16 @@ export function TaskDeleteConfirmDialog({
       <AlertDialogContent onClick={(e) => e.stopPropagation()}>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{description}</AlertDialogDescription>
+          <AlertDialogDescription asChild>
+            <div>
+              <p>{description}</p>
+              {cleanup.lines.map((line, i) => (
+                <p key={i} className="mt-2" data-testid="cleanup-line">
+                  {line}
+                </p>
+              ))}
+            </div>
+          </AlertDialogDescription>
         </AlertDialogHeader>
         {subtaskCount > 0 && (
           <label className="flex items-start gap-2 text-sm cursor-pointer">

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -367,8 +367,16 @@ export const TaskItem = memo(function TaskItem({
         prInfo={prInfo}
         issueInfo={issueInfo}
       />
-      {hasDiffStats && <DiffStatsRight diffStats={diffStats!} menuOpen={effectiveMenuOpen} />}
-      <TaskMenuButton visible={effectiveMenuOpen} />
+      {hasDiffStats ? (
+        <div className="relative shrink-0 self-center flex items-center">
+          <DiffStatsRight diffStats={diffStats!} menuOpen={effectiveMenuOpen} />
+          <div className="absolute inset-0 flex items-center justify-end">
+            <TaskMenuButton visible={effectiveMenuOpen} />
+          </div>
+        </div>
+      ) : (
+        <TaskMenuButton visible={effectiveMenuOpen} />
+      )}
       {showSubtaskToggle && (
         <SubtaskToggle
           taskId={taskId}

--- a/apps/web/components/task/task-session-sidebar-dialogs.tsx
+++ b/apps/web/components/task/task-session-sidebar-dialogs.tsx
@@ -4,7 +4,7 @@ import { TaskRenameDialog } from "./task-rename-dialog";
 import { TaskArchiveConfirmDialog } from "./task-archive-confirm-dialog";
 import { TaskDeleteConfirmDialog } from "./task-delete-confirm-dialog";
 
-type Target = { id: string; title: string } | null;
+type Target = { id: string; title: string; executorType?: string | null } | null;
 
 export type SidebarDialogsActions = {
   renamingTask: Target;
@@ -51,6 +51,7 @@ export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) 
         }}
         taskTitle={archivingTask?.title ?? ""}
         taskId={archivingTask?.id}
+        executorType={archivingTask?.executorType}
         isArchiving={isArchiving}
         onConfirm={handleArchiveConfirm}
       />
@@ -61,6 +62,7 @@ export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) 
         }}
         taskTitle={deletingTask?.title ?? ""}
         taskId={deletingTask?.id}
+        executorType={deletingTask?.executorType}
         isDeleting={isDeleting}
         onConfirm={handleDeleteConfirm}
       />

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -359,14 +359,22 @@ function useMoveToStep(store: StoreApi) {
 
 function useArchiveActions(store: StoreApi) {
   const archiveAndSwitch = useArchiveAndSwitchTask({ useLayoutSwitch: true });
-  const [archivingTask, setArchivingTask] = useState<{ id: string; title: string } | null>(null);
+  const [archivingTask, setArchivingTask] = useState<{
+    id: string;
+    title: string;
+    executorType?: string | null;
+  } | null>(null);
   const [isArchiving, setIsArchiving] = useState(false);
 
   const handleArchiveTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
       const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
-      setArchivingTask({ id: taskId, title: task?.title ?? "this task" });
+      setArchivingTask({
+        id: taskId,
+        title: task?.title ?? "this task",
+        executorType: task?.primaryExecutorType,
+      });
     },
     [store],
   );
@@ -395,14 +403,22 @@ function useDeleteActions(
   removeTaskFromBoard: ReturnType<typeof useTaskRemoval>["removeTaskFromBoard"],
 ) {
   const { deleteTaskById } = useTaskActions();
-  const [deletingTask, setDeletingTask] = useState<{ id: string; title: string } | null>(null);
+  const [deletingTask, setDeletingTask] = useState<{
+    id: string;
+    title: string;
+    executorType?: string | null;
+  } | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
   const handleDeleteTask = useCallback(
     (taskId: string) => {
       const state = store.getState();
       const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
-      setDeletingTask({ id: taskId, title: task?.title ?? "this task" });
+      setDeletingTask({
+        id: taskId,
+        title: task?.title ?? "this task",
+        executorType: task?.primaryExecutorType,
+      });
     },
     [store],
   );


### PR DESCRIPTION
## Summary

The archive/delete confirmation dialog used to say "this will delete the task's worktree and stop any running agent sessions" — a line that's wrong for every executor that isn't `worktree` (local doesn't touch a worktree at all; docker/sprites/ssh tear down a container/sandbox/remote dir instead). This PR replaces that copy with an executor-aware breakdown so users know exactly what's about to be cleaned up, and — importantly for the `local` executor — that their repo, branch, and folder are not touched.

## Important Changes

- New helper `apps/web/components/task/task-cleanup-summary.ts` with `getCleanupSummary(executorType)` and `getBulkCleanupSummary(executorTypes[])`. Knows the 7 executor types from `models.ExecutorType`.
- Both dialogs accept `executorType` / `executorTypes` props and render one cleanup line per executor; falls back to a generic line when the executor is unknown.
- Bulk delete/archive (multi-select toolbar) groups counts by executor type — e.g. *"2 worktrees and their branches will be deleted. 1 local task — your repo folders won't be touched."*
- Call sites updated: sidebar, mobile sheet, kanban-card, graph2 pipeline, tasks table; the multi-select toolbar resolves executor types from the kanban store.

## Validation

- `pnpm --filter @kandev/web typecheck` — clean
- `pnpm --filter @kandev/web lint` — clean (0 errors, 0 warnings)
- `pnpm --filter @kandev/web exec vitest run` — 2409 passed, 4 skipped
- 22 new unit tests cover per-executor copy, bulk grouping, fallback, and case-insensitivity (`task-cleanup-summary.test.ts` + dialog tests)

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] Manual smoke check