### PR TITLE
chore(web): drop redundant hover tooltip on tool execute command

### DIFF
--- a/apps/web/components/task/chat/messages/tool-execute-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-execute-message.tsx
@@ -2,7 +2,6 @@
 
 import { memo } from "react";
 import { IconCheck, IconX, IconTerminal } from "@tabler/icons-react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { GridSpinner } from "@/components/grid-spinner";
 import { transformPathsInText } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
@@ -110,22 +109,10 @@ function parseExecuteMetadata(comment: Message) {
 }
 
 function CommandHeader({ displayCommand }: { displayCommand: string }) {
-  const className = "font-mono text-xs text-muted-foreground truncate min-w-0 flex-1 text-left";
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span className={className} tabIndex={0}>
-          {displayCommand}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent
-        side="bottom"
-        align="start"
-        className="max-w-[min(90vw,640px)] whitespace-pre-wrap break-all font-mono text-xs"
-      >
-        {displayCommand}
-      </TooltipContent>
-    </Tooltip>
+    <span className="font-mono text-xs text-muted-foreground truncate min-w-0 flex-1 text-left">
+      {displayCommand}
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

Now that every tool execute row is expandable to reveal the full command (#1086), the hover tooltip on the command header is redundant — clicking the row already shows the full text in the expanded `<pre>` block. Drop the `Tooltip` wrapper and unused imports.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated
- [ ] Changelog entry added