### PR TITLE
fix(web): overlay menu button on diff stats to remove wasted sidebar space

### DIFF
--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -367,8 +367,16 @@ export const TaskItem = memo(function TaskItem({
         prInfo={prInfo}
         issueInfo={issueInfo}
       />
-      {hasDiffStats && <DiffStatsRight diffStats={diffStats!} menuOpen={effectiveMenuOpen} />}
-      <TaskMenuButton visible={effectiveMenuOpen} />
+      {hasDiffStats ? (
+        <div className="relative shrink-0 self-center flex items-center">
+          <DiffStatsRight diffStats={diffStats!} menuOpen={effectiveMenuOpen} />
+          <div className="absolute inset-0 flex items-center justify-end">
+            <TaskMenuButton visible={effectiveMenuOpen} />
+          </div>
+        </div>
+      ) : (
+        <TaskMenuButton visible={effectiveMenuOpen} />
+      )}
       {showSubtaskToggle && (
         <SubtaskToggle
           taskId={taskId}


### PR DESCRIPTION
Tasks with git diff stats (e.g. `+1788 -54`) had an invisible 24 px menu button sitting to their right at all times, creating dead space after the diff counter. The 3-dot button now overlays the diff stats area via absolute positioning, so it takes no additional width — the diff stats fade out on hover and the button appears in the same space.

## Validation
- `pnpm --filter @kandev/web lint` — no warnings
- `pnpm --filter @kandev/web typecheck` — no errors

## Checklist
- [ ] Tests updated (if applicable)
- [ ] Docs updated (if applicable)

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1106-bwo7.sprites.app |
| **Commit** | `b7befb8` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->