### PR TITLE
fix(web): show CLI-passthrough profiles in watcher dialogs (closes #1107)

### DIFF
--- a/apps/web/components/cli-mode-icon.tsx
+++ b/apps/web/components/cli-mode-icon.tsx
@@ -1,0 +1,14 @@
+import { IconTerminal2 } from "@tabler/icons-react";
+
+// Marks an agent profile that runs in CLI passthrough mode — the prompt is
+// auto-injected into a raw terminal rather than sent as a structured request.
+// Shown next to passthrough profiles in the manual create dialog and the
+// Linear/Jira/GitHub watcher dialogs so the two paths stay visually consistent.
+export function CliModeIcon({ className }: { className?: string }) {
+  return (
+    <IconTerminal2
+      className={className ?? "size-3.5 text-muted-foreground"}
+      title="CLI mode — your prompt will be auto-injected into the terminal"
+    />
+  );
+}

--- a/apps/web/components/github/issue-watch-dialog.tsx
+++ b/apps/web/components/github/issue-watch-dialog.tsx
@@ -15,8 +15,9 @@ import {
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Textarea } from "@kandev/ui/textarea";
-import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
+import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
+import { CliModeIcon } from "@/components/cli-mode-icon";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
@@ -306,7 +307,7 @@ function IssueAutomationFields({
           items={agentProfiles.map((p) => ({
             id: p.id,
             label: p.label,
-            cliPassthrough: p.cli_passthrough,
+            icon: p.cli_passthrough ? <CliModeIcon /> : undefined,
           }))}
         />
         <SelectField
@@ -499,7 +500,7 @@ export function IssueWatchDialog({
   );
 }
 
-type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
+type SelectFieldItem = { id: string; label: string; icon?: React.ReactNode };
 
 function SelectField(props: {
   label: string;
@@ -525,15 +526,14 @@ function SelectField(props: {
         <SelectContent>
           {props.items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              <span className="flex items-center gap-1.5">
-                <span>{item.label}</span>
-                {item.cliPassthrough && (
-                  <IconTerminal2
-                    className="size-3.5 text-muted-foreground"
-                    title="CLI mode — your prompt will be auto-injected into the terminal"
-                  />
-                )}
-              </span>
+              {item.icon ? (
+                <span className="flex items-center gap-1.5">
+                  <span>{item.label}</span>
+                  {item.icon}
+                </span>
+              ) : (
+                item.label
+              )}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/components/github/issue-watch-dialog.tsx
+++ b/apps/web/components/github/issue-watch-dialog.tsx
@@ -15,7 +15,7 @@ import {
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Textarea } from "@kandev/ui/textarea";
-import { IconInfoCircle } from "@tabler/icons-react";
+import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
@@ -138,12 +138,7 @@ function useWatchFormData(workspaceId: string) {
     [executors],
   );
 
-  const filteredAgentProfiles = useMemo(
-    () => agentProfiles.filter((p) => !p.cli_passthrough),
-    [agentProfiles],
-  );
-
-  return { workflows, agentProfiles: filteredAgentProfiles, allExecutorProfiles };
+  return { workflows, agentProfiles, allExecutorProfiles };
 }
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
@@ -308,7 +303,11 @@ function IssueAutomationFields({
           value={form.agentProfileId}
           onChange={(v) => setForm((prev) => ({ ...prev, agentProfileId: v }))}
           placeholder="Select agent profile"
-          items={agentProfiles.map((p) => ({ id: p.id, label: p.label }))}
+          items={agentProfiles.map((p) => ({
+            id: p.id,
+            label: p.label,
+            cliPassthrough: p.cli_passthrough,
+          }))}
         />
         <SelectField
           label="Executor Profile"
@@ -500,13 +499,15 @@ export function IssueWatchDialog({
   );
 }
 
+type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
+
 function SelectField(props: {
   label: string;
   description?: string;
   value: string;
   onChange: (v: string) => void;
   placeholder: string;
-  items: { id: string; label: string }[];
+  items: SelectFieldItem[];
   disabled?: boolean;
 }) {
   return (
@@ -524,7 +525,15 @@ function SelectField(props: {
         <SelectContent>
           {props.items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              {item.label}
+              <span className="flex items-center gap-1.5">
+                <span>{item.label}</span>
+                {item.cliPassthrough && (
+                  <IconTerminal2
+                    className="size-3.5 text-muted-foreground"
+                    title="CLI mode — your prompt will be auto-injected into the terminal"
+                  />
+                )}
+              </span>
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/components/github/review-watch-dialog.tsx
+++ b/apps/web/components/github/review-watch-dialog.tsx
@@ -15,8 +15,9 @@ import {
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Textarea } from "@kandev/ui/textarea";
-import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
+import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
+import { CliModeIcon } from "@/components/cli-mode-icon";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
@@ -122,7 +123,7 @@ const CLEANUP_POLICY_OPTIONS: Array<{ id: CleanupPolicy; label: string; descript
 
 // --- Generic select field with description ---
 
-type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
+type SelectFieldItem = { id: string; label: string; icon?: React.ReactNode };
 
 type SelectFieldProps = {
   label: string;
@@ -154,15 +155,14 @@ function SelectField({
         <SelectContent>
           {items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              <span className="flex items-center gap-1.5">
-                <span>{item.label}</span>
-                {item.cliPassthrough && (
-                  <IconTerminal2
-                    className="size-3.5 text-muted-foreground"
-                    title="CLI mode — your prompt will be auto-injected into the terminal"
-                  />
-                )}
-              </span>
+              {item.icon ? (
+                <span className="flex items-center gap-1.5">
+                  <span>{item.label}</span>
+                  {item.icon}
+                </span>
+              ) : (
+                item.label
+              )}
             </SelectItem>
           ))}
         </SelectContent>
@@ -448,7 +448,7 @@ function ProfileFields({
         items={agentProfiles.map((p) => ({
           id: p.id,
           label: p.label,
-          cliPassthrough: p.cli_passthrough,
+          icon: p.cli_passthrough ? <CliModeIcon /> : undefined,
         }))}
       />
       <div className="space-y-1.5">

--- a/apps/web/components/github/review-watch-dialog.tsx
+++ b/apps/web/components/github/review-watch-dialog.tsx
@@ -15,7 +15,7 @@ import {
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Textarea } from "@kandev/ui/textarea";
-import { IconInfoCircle } from "@tabler/icons-react";
+import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
@@ -122,13 +122,15 @@ const CLEANUP_POLICY_OPTIONS: Array<{ id: CleanupPolicy; label: string; descript
 
 // --- Generic select field with description ---
 
+type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
+
 type SelectFieldProps = {
   label: string;
   description?: string;
   value: string;
   onChange: (value: string) => void;
   placeholder: string;
-  items: Array<{ id: string; label: string }>;
+  items: SelectFieldItem[];
   disabled?: boolean;
 };
 
@@ -152,7 +154,15 @@ function SelectField({
         <SelectContent>
           {items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              {item.label}
+              <span className="flex items-center gap-1.5">
+                <span>{item.label}</span>
+                {item.cliPassthrough && (
+                  <IconTerminal2
+                    className="size-3.5 text-muted-foreground"
+                    title="CLI mode — your prompt will be auto-injected into the terminal"
+                  />
+                )}
+              </span>
             </SelectItem>
           ))}
         </SelectContent>
@@ -202,13 +212,7 @@ function useWatchFormData(workspaceId: string) {
     [executors],
   );
 
-  // Filter out passthrough/TUI profiles — they don't accept initial prompts
-  const filteredAgentProfiles = useMemo(
-    () => agentProfiles.filter((p) => !p.cli_passthrough),
-    [agentProfiles],
-  );
-
-  return { workflows, agentProfiles: filteredAgentProfiles, allExecutorProfiles };
+  return { workflows, agentProfiles, allExecutorProfiles };
 }
 
 // --- Section header ---
@@ -430,7 +434,7 @@ function ProfileFields({
 }: {
   form: FormState;
   setForm: React.Dispatch<React.SetStateAction<FormState>>;
-  agentProfiles: Array<{ id: string; label: string }>;
+  agentProfiles: Array<{ id: string; label: string; cli_passthrough?: boolean }>;
   executorProfiles: Array<{ id: string; name: string }>;
 }) {
   return (
@@ -441,7 +445,11 @@ function ProfileFields({
         value={form.agentProfileId}
         onChange={(v) => setForm((prev) => ({ ...prev, agentProfileId: v }))}
         placeholder="Select agent profile"
-        items={agentProfiles.map((p) => ({ id: p.id, label: p.label }))}
+        items={agentProfiles.map((p) => ({
+          id: p.id,
+          label: p.label,
+          cliPassthrough: p.cli_passthrough,
+        }))}
       />
       <div className="space-y-1.5">
         <div className="flex items-center gap-1.5">

--- a/apps/web/components/jira/jira-issue-watch-dialog.tsx
+++ b/apps/web/components/jira/jira-issue-watch-dialog.tsx
@@ -15,8 +15,9 @@ import {
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Textarea } from "@kandev/ui/textarea";
-import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
+import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
+import { CliModeIcon } from "@/components/cli-mode-icon";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
@@ -108,7 +109,7 @@ function useFormData(workspaceId: string) {
   return { workflows, agentProfiles, allExecutorProfiles };
 }
 
-type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
+type SelectFieldItem = { id: string; label: string; icon?: React.ReactNode };
 
 function SelectField(props: {
   label: string;
@@ -134,15 +135,14 @@ function SelectField(props: {
         <SelectContent>
           {props.items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              <span className="flex items-center gap-1.5">
-                <span>{item.label}</span>
-                {item.cliPassthrough && (
-                  <IconTerminal2
-                    className="size-3.5 text-muted-foreground"
-                    title="CLI mode — your prompt will be auto-injected into the terminal"
-                  />
-                )}
-              </span>
+              {item.icon ? (
+                <span className="flex items-center gap-1.5">
+                  <span>{item.label}</span>
+                  {item.icon}
+                </span>
+              ) : (
+                item.label
+              )}
             </SelectItem>
           ))}
         </SelectContent>
@@ -311,7 +311,7 @@ function AutomationFields({
           items={agentProfiles.map((p) => ({
             id: p.id,
             label: p.label,
-            cliPassthrough: p.cli_passthrough,
+            icon: p.cli_passthrough ? <CliModeIcon /> : undefined,
           }))}
         />
         <SelectField

--- a/apps/web/components/jira/jira-issue-watch-dialog.tsx
+++ b/apps/web/components/jira/jira-issue-watch-dialog.tsx
@@ -15,7 +15,7 @@ import {
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Textarea } from "@kandev/ui/textarea";
-import { IconInfoCircle } from "@tabler/icons-react";
+import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
@@ -105,12 +105,10 @@ function useFormData(workspaceId: string) {
         .flatMap((e) => e.profiles ?? []),
     [executors],
   );
-  const filteredAgentProfiles = useMemo(
-    () => agentProfiles.filter((p) => !p.cli_passthrough),
-    [agentProfiles],
-  );
-  return { workflows, agentProfiles: filteredAgentProfiles, allExecutorProfiles };
+  return { workflows, agentProfiles, allExecutorProfiles };
 }
+
+type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
 
 function SelectField(props: {
   label: string;
@@ -118,7 +116,7 @@ function SelectField(props: {
   value: string;
   onChange: (v: string) => void;
   placeholder: string;
-  items: { id: string; label: string }[];
+  items: SelectFieldItem[];
   disabled?: boolean;
 }) {
   return (
@@ -136,7 +134,15 @@ function SelectField(props: {
         <SelectContent>
           {props.items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              {item.label}
+              <span className="flex items-center gap-1.5">
+                <span>{item.label}</span>
+                {item.cliPassthrough && (
+                  <IconTerminal2
+                    className="size-3.5 text-muted-foreground"
+                    title="CLI mode — your prompt will be auto-injected into the terminal"
+                  />
+                )}
+              </span>
             </SelectItem>
           ))}
         </SelectContent>
@@ -302,7 +308,11 @@ function AutomationFields({
           value={form.agentProfileId}
           onChange={(v) => setForm((p) => ({ ...p, agentProfileId: v }))}
           placeholder="(use step default)"
-          items={agentProfiles.map((p) => ({ id: p.id, label: p.label }))}
+          items={agentProfiles.map((p) => ({
+            id: p.id,
+            label: p.label,
+            cliPassthrough: p.cli_passthrough,
+          }))}
         />
         <SelectField
           label="Executor Profile"

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -15,8 +15,9 @@ import {
   DialogFooter,
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
-import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
+import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
+import { CliModeIcon } from "@/components/cli-mode-icon";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
 import { useWorkflows } from "@/hooks/use-workflows";
@@ -78,7 +79,7 @@ function useFormData(workspaceId: string) {
   return { workflows, agentProfiles, allExecutorProfiles };
 }
 
-type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
+type SelectFieldItem = { id: string; label: string; icon?: React.ReactNode };
 
 function SelectField(props: {
   label: string;
@@ -104,15 +105,14 @@ function SelectField(props: {
         <SelectContent>
           {props.items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              <span className="flex items-center gap-1.5">
-                <span>{item.label}</span>
-                {item.cliPassthrough && (
-                  <IconTerminal2
-                    className="size-3.5 text-muted-foreground"
-                    title="CLI mode — your prompt will be auto-injected into the terminal"
-                  />
-                )}
-              </span>
+              {item.icon ? (
+                <span className="flex items-center gap-1.5">
+                  <span>{item.label}</span>
+                  {item.icon}
+                </span>
+              ) : (
+                item.label
+              )}
             </SelectItem>
           ))}
         </SelectContent>
@@ -436,7 +436,7 @@ function AutomationFields({
           items={agentProfiles.map((p) => ({
             id: p.id,
             label: p.label,
-            cliPassthrough: p.cli_passthrough,
+            icon: p.cli_passthrough ? <CliModeIcon /> : undefined,
           }))}
         />
         <SelectField

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -15,7 +15,7 @@ import {
   DialogFooter,
 } from "@kandev/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
-import { IconInfoCircle } from "@tabler/icons-react";
+import { IconInfoCircle, IconTerminal2 } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
@@ -75,12 +75,10 @@ function useFormData(workspaceId: string) {
         .flatMap((e) => e.profiles ?? []),
     [executors],
   );
-  const filteredAgentProfiles = useMemo(
-    () => agentProfiles.filter((p) => !p.cli_passthrough),
-    [agentProfiles],
-  );
-  return { workflows, agentProfiles: filteredAgentProfiles, allExecutorProfiles };
+  return { workflows, agentProfiles, allExecutorProfiles };
 }
+
+type SelectFieldItem = { id: string; label: string; cliPassthrough?: boolean };
 
 function SelectField(props: {
   label: string;
@@ -88,7 +86,7 @@ function SelectField(props: {
   value: string;
   onChange: (v: string) => void;
   placeholder: string;
-  items: { id: string; label: string }[];
+  items: SelectFieldItem[];
   disabled?: boolean;
 }) {
   return (
@@ -106,7 +104,15 @@ function SelectField(props: {
         <SelectContent>
           {props.items.map((item) => (
             <SelectItem key={item.id} value={item.id}>
-              {item.label}
+              <span className="flex items-center gap-1.5">
+                <span>{item.label}</span>
+                {item.cliPassthrough && (
+                  <IconTerminal2
+                    className="size-3.5 text-muted-foreground"
+                    title="CLI mode — your prompt will be auto-injected into the terminal"
+                  />
+                )}
+              </span>
             </SelectItem>
           ))}
         </SelectContent>
@@ -427,7 +433,11 @@ function AutomationFields({
           value={form.agentProfileId}
           onChange={(v) => setForm((p) => ({ ...p, agentProfileId: v }))}
           placeholder="(use step default)"
-          items={agentProfiles.map((p) => ({ id: p.id, label: p.label }))}
+          items={agentProfiles.map((p) => ({
+            id: p.id,
+            label: p.label,
+            cliPassthrough: p.cli_passthrough,
+          }))}
         />
         <SelectField
           label="Executor Profile"

--- a/apps/web/e2e/tests/integrations/linear-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/linear-settings.spec.ts
@@ -98,4 +98,41 @@ test.describe("Linear settings", () => {
     await expect(settings.secretInput).toHaveValue("");
     await expect(settings.statusBanner).toHaveCount(0);
   });
+
+  // Regression test for #1107: passthrough profiles were silently filtered
+  // out of the watcher dialog after #805 — once #923 made auto-start viable,
+  // this filter became stale and hid Claude Code / Codex / Copilot CLI from
+  // the Agent Profile selector. The dropdown must now list them.
+  test("watcher dialog lists CLI-passthrough agent profiles", async ({ testPage, apiClient }) => {
+    await apiClient.setLinearConfig({ secret: "lin_api_xxx" });
+    await apiClient.waitForIntegrationAuthHealthy("linear");
+
+    const { agents } = await apiClient.listAgents();
+    if (agents.length === 0) throw new Error("no agents registered in this e2e profile");
+    const passthroughName = "Watcher CLI Passthrough";
+    await apiClient.createAgentProfile(agents[0].id, passthroughName, {
+      model: "mock-fast",
+      cli_passthrough: true,
+    });
+
+    await testPage.goto("/settings/integrations/linear");
+    await testPage.getByRole("button", { name: /new watcher/i }).click();
+
+    const dialog = testPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Reach the Agent Profile combobox via its <label> parent so we don't
+    // collide with the other comboboxes (workspace / workflow / executor)
+    // rendered in the same dialog.
+    const trigger = dialog
+      .getByText("Agent Profile", { exact: true })
+      .locator("xpath=..")
+      .getByRole("combobox");
+    await trigger.click();
+
+    // Radix portals the listbox to the document root, so search the page (not
+    // the dialog) for the option. Substring match on the profile name handles
+    // the "<agent> • <profile>" label format.
+    await expect(testPage.getByRole("option", { name: new RegExp(passthroughName) })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary

- Drops the stale `!p.cli_passthrough` filter in the Linear, Jira, GitHub-issue, and GitHub-review watcher dialogs so Claude Code, Codex CLI, Copilot CLI, Auggie, etc. are once again selectable as the watcher Agent Profile.
- Mirrors the manual create dialog's UX hint: passthrough profiles now render with an `IconTerminal2` and a "CLI mode — your prompt will be auto-injected into the terminal" tooltip in the dropdown, so users still see which profiles run in CLI mode.
- Adds a Playwright regression in `apps/web/e2e/tests/integrations/linear-settings.spec.ts` that creates a `cli_passthrough` profile, opens the Linear watcher dialog, and asserts it appears in the Agent Profile selector.

## Why this filter is stale

- **2026-05-05** — #805 introduced the filter when Linear watchers shipped: passthrough sessions had no way to auto-start unattended at that point, so they were intentionally hidden from watcher selectors.
- **2026-05-25** — #923 (`feat(cli-mode): auto-inject task prompt + dynamic submit sequence + passthrough UX fixes`) added prompt auto-injection into the PTY. Passthrough sessions now run end-to-end from a watcher event — the prompt lands in the terminal and the agent runs.
- The watcher dialogs were never updated. The manual `task-create` dialog (`useAgentProfileOptions` at `apps/web/components/task-create-dialog-options.tsx`) already treats passthrough as first-class; this PR aligns the four watcher dialogs with that behavior.

Closes #1107.

## Test plan

- [x] `pnpm exec prettier --check` on the touched files
- [x] `pnpm --filter @kandev/web typecheck`
- [x] `pnpm --filter @kandev/web lint`
- [x] `pnpm --filter @kandev/web test` (Vitest)
- [x] `pnpm e2e tests/integrations/linear-settings.spec.ts` — all 6 tests pass, including the new regression
- [ ] CI green