### PR TITLE
ci: skip Playwright CDN download for e2e-containers job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -209,9 +209,11 @@ jobs:
     needs: build
     # This job intentionally runs on the host ubuntu runner (NOT the kandev-ci
     # container image): the containers project needs direct access to the
-    # host Docker daemon, and docker/setup-buildx style steps + the
-    # docker-in-container UX are awkward inside a container job. We recover
-    # some of the setup cost via the pnpm-store and Playwright caches below.
+    # host Docker daemon, and a docker-in-docker setup would break the tests'
+    # host-style bind mounts (paths under os.tmpdir() inside a runner container
+    # wouldn't exist on the host where the docker daemon resolves them).
+    # We still avoid the slow `playwright install --with-deps` step by copying
+    # browsers out of the kandev-ci image — see the extract step below.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -243,37 +245,43 @@ jobs:
           key: pnpm-${{ runner.os }}-${{ hashFiles('apps/pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ runner.os }}-
 
-      # Derive the Playwright version from apps/web/package.json at runtime so
-      # the cache key below auto-busts on every @playwright/test bump. The
-      # previous hardcoded `1.58.2` suffix would have silently served stale
-      # browser binaries until manually updated.
-      - name: Resolve Playwright version
-        id: pw
-        shell: bash
-        run: |
-          set -euo pipefail
-          raw=$(node -p "require('./apps/web/package.json').devDependencies['@playwright/test']")
-          version=$(printf '%s' "$raw" | sed -E 's/^[^0-9]*//; s/[^0-9.].*$//')
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Playwright version: ${version}"
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
-
       - name: Install dependencies
         working-directory: apps
         run: pnpm install --frozen-lockfile
 
-      # `--with-deps` runs apt-get install on every invocation (~20–30s), so
-      # skip the step entirely when the cache restored the browser binaries.
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      # Required for the docker pull below to succeed even if the kandev-ci
+      # package is private on GHCR. The `e2e` / `e2e-report` jobs above don't
+      # need this because GitHub's `container:` integration handles auth
+      # implicitly using GITHUB_TOKEN.
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Skip the Playwright CDN download (~7 min and an outage-prone path) by
+      # copying the prebaked chromium out of the kandev-ci image, which is
+      # `FROM mcr.microsoft.com/playwright:...` and already ships the matching
+      # browser at /ms-playwright. Pinning to :latest matches the other e2e
+      # jobs that use the same image via `container:`.
+      - name: Extract Playwright browsers from kandev-ci image
+        run: |
+          set -euo pipefail
+          docker pull ghcr.io/kdlbs/kandev-ci:latest
+          mkdir -p /tmp/ms-playwright
+          docker run --rm \
+            -v /tmp/ms-playwright:/dest \
+            ghcr.io/kdlbs/kandev-ci:latest \
+            cp -a /ms-playwright/. /dest/
+          echo "PLAYWRIGHT_BROWSERS_PATH=/tmp/ms-playwright" >> "$GITHUB_ENV"
+
+      # Browser binaries come from the image above; this only installs the
+      # apt-level shared libs chromium links against. Fast (~20–30s) and avoids
+      # any CDN dependency.
+      - name: Install Playwright system deps
         working-directory: apps/web
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install-deps chromium
 
       - name: Download backend build
         uses: actions/download-artifact@v5


### PR DESCRIPTION
## Summary

The `e2e-containers` shards have been spending ~7 minutes each on `playwright install --with-deps chromium`, which is both slow and increasingly flaky as GitHub's path to the Playwright CDN keeps degrading. Pull the prebaked Chromium out of the kandev-ci image (which is `FROM mcr.microsoft.com/playwright:...` and already ships the matching browser at `/ms-playwright`) and just install the apt-level libs.

## Important Changes

- Drops the Playwright version-resolution + `actions/cache` + `playwright install --with-deps` steps from the `e2e-containers` job.
- Adds a GHCR login + `docker pull` + `cp -a /ms-playwright/.` step that exports `PLAYWRIGHT_BROWSERS_PATH=/tmp/ms-playwright`.
- Still runs `npx playwright install-deps chromium` (apt only, no CDN dependency) since this job stays on the host runner — DooD would silently break the host-style bind mounts in `apps/web/e2e/helpers/ssh.ts`.

## Validation

- YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-tests.yml'))"`).
- End-to-end behavior verified by the CI run this PR triggers — the change is workflow-only.

## Possible Improvements

If `kandev-ci:latest` ever drifts off `mcr.microsoft.com/playwright:vX.Y.Z-noble` while `@playwright/test` stays pinned to a different version, browser/runner mismatch could surface. The same risk applies to the existing `e2e` shards that already consume the image via `container:`, so we're not adding net new exposure.

## Checklist

- [ ] Tests added / updated
- [ ] Docs updated
- [ ] Manual verification done