### PR TITLE
feat(web): move queued chip into chat status bar row

### DIFF
--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { IconArrowRight, IconGitMerge, IconX } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
@@ -306,6 +306,7 @@ function ChatStatusBar({
   onProceed,
   isAgentBusy,
   isMoving,
+  queueChip,
 }: {
   todoItems: TodoDisplayItem[];
   taskId: string | null;
@@ -315,6 +316,7 @@ function ChatStatusBar({
   onProceed: () => void;
   isAgentBusy: boolean;
   isMoving: boolean;
+  queueChip?: ReactNode;
 }) {
   const showTodos = todoItems.length > 0;
   const showProceed = !!nextStepName && !isAgentBusy;
@@ -327,6 +329,7 @@ function ChatStatusBar({
     >
       {showTodos && <TodoIndicator todos={todoItems} />}
       <PRStatusChip taskId={taskId} />
+      {queueChip}
       {taskId && <PRMergedBanner key={taskId} taskId={taskId} />}
       {canShare && taskId && sessionId && (
         <div className="ml-auto">
@@ -440,17 +443,22 @@ export function ChatInputArea({
   const { implementPlanHandler, proceedStepName, proceed, isMoving } = planActions;
   return (
     <div className="bg-card flex-shrink-0 px-2 pb-2 pt-1">
-      <ChatStatusBar
-        todoItems={todoItems}
-        taskId={taskId}
+      <QueueAffordance
         sessionId={resolvedSessionId}
-        sessionState={panelState.session?.state ?? null}
-        nextStepName={proceedStepName}
-        onProceed={proceed}
-        isAgentBusy={isAgentBusy}
-        isMoving={isMoving}
-      />
-      <QueueAffordance sessionId={resolvedSessionId}>
+        renderStatusBar={(queueChip) => (
+          <ChatStatusBar
+            todoItems={todoItems}
+            taskId={taskId}
+            sessionId={resolvedSessionId}
+            sessionState={panelState.session?.state ?? null}
+            nextStepName={proceedStepName}
+            onProceed={proceed}
+            isAgentBusy={isAgentBusy}
+            isMoving={isMoving}
+            queueChip={queueChip}
+          />
+        )}
+      >
         <ChatInputContainer
           ref={chatInputRef}
           key={clarificationKey}

--- a/apps/web/components/task/chat/queued-ghost-list.test.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.test.tsx
@@ -165,7 +165,54 @@ describe("QueueAffordance", () => {
     fireEvent.click(screen.getByTestId("queue-clear-all"));
     expect(state.clearAll).toHaveBeenCalledTimes(1);
   });
+});
 
+describe("QueueAffordance — renderStatusBar prop", () => {
+  it("calls renderStatusBar with null when there are no queued entries", () => {
+    useQueueMock.mockReturnValue(queueState([]));
+    const renderStatusBar = vi.fn(() => <div data-testid="status-bar-slot" />);
+    render(
+      <QueueAffordance sessionId={SESSION_ID} renderStatusBar={renderStatusBar}>
+        {CHILD}
+      </QueueAffordance>,
+    );
+    expect(renderStatusBar).toHaveBeenCalledWith(null);
+    expect(screen.getByTestId("status-bar-slot")).toBeTruthy();
+  });
+
+  it("calls renderStatusBar with a chip node when entries exist and panel is closed", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    const renderStatusBar = vi.fn((chip) => <div data-testid="status-bar-slot">{chip}</div>);
+    render(
+      <QueueAffordance sessionId={SESSION_ID} renderStatusBar={renderStatusBar}>
+        {CHILD}
+      </QueueAffordance>,
+    );
+    const callArg = renderStatusBar.mock.calls[0][0];
+    expect(callArg).not.toBeNull();
+    // The chip lives inside the caller-supplied slot, not as a separate
+    // inline element above the input.
+    const slot = screen.getByTestId("status-bar-slot");
+    expect(slot.contains(screen.getByTestId(CHIP_ID))).toBe(true);
+  });
+
+  it("calls renderStatusBar with null when entries exist and the panel is open", () => {
+    useQueueMock.mockReturnValue(queueState([entry()]));
+    const renderStatusBar = vi.fn((chip) => <div data-testid="status-bar-slot">{chip}</div>);
+    render(
+      <QueueAffordance sessionId={SESSION_ID} renderStatusBar={renderStatusBar}>
+        {CHILD}
+      </QueueAffordance>,
+    );
+    // Open the panel — the chip should drop out of the status bar.
+    fireEvent.click(screen.getByTestId(CHIP_ID));
+    expect(screen.getByTestId(PANEL_ID)).toBeTruthy();
+    const lastCall = renderStatusBar.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBeNull();
+  });
+});
+
+describe("QueueAffordance — workflow entries", () => {
   it("workflow queued entries are read-only", () => {
     useQueueMock.mockReturnValue(
       queueState([

--- a/apps/web/components/task/chat/queued-ghost-list.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.tsx
@@ -136,6 +136,7 @@ export function QueueAffordance({ sessionId, children, renderStatusBar }: QueueA
   if (!hasEntries) {
     return (
       <>
+        {/* Call renderStatusBar even with null so the status bar stays mounted when the queue is empty. */}
         {renderStatusBar?.(null)}
         {children}
       </>

--- a/apps/web/components/task/chat/queued-ghost-list.tsx
+++ b/apps/web/components/task/chat/queued-ghost-list.tsx
@@ -57,16 +57,24 @@ function useEscToClose(open: boolean, onClose: () => void): void {
 type QueueAffordanceProps = {
   sessionId: string | null;
   children: ReactNode;
+  /**
+   * Optional render slot for placing the chip inside an external row (e.g. the
+   * chat status bar). The callback receives the chip node (or `null` when no
+   * chip should be shown) and returns the row markup. When omitted, the chip
+   * falls back to rendering inline above the input.
+   */
+  renderStatusBar?: (queueChip: ReactNode) => ReactNode;
 };
 
 /**
  * Wraps the chat input with the per-session queue affordance:
  * - When there are no queued entries, just renders `children` (the input).
- * - Otherwise a small floating "n queued" chip sits over the input frame and
- *   clicking it expands a panel above the input. Drained or session-switched
- *   queues auto-collapse.
+ * - Otherwise a small "n queued" chip is exposed (either inline above the
+ *   input, or via `renderStatusBar` into a caller-controlled row); clicking
+ *   it expands a panel above the input. Drained or session-switched queues
+ *   auto-collapse.
  */
-export function QueueAffordance({ sessionId, children }: QueueAffordanceProps) {
+export function QueueAffordance({ sessionId, children, renderStatusBar }: QueueAffordanceProps) {
   const { entries, count, max, isFull, clearAll, editEntry, removeEntry } = useQueue(sessionId);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -114,10 +122,29 @@ export function QueueAffordance({ sessionId, children }: QueueAffordanceProps) {
     });
   }, [clearAll]);
 
-  if (!sessionId || entryCount === 0) return <>{children}</>;
+  const hasEntries = !!sessionId && entryCount > 0;
+  const chipNode =
+    hasEntries && !isOpen ? (
+      <QueueChip
+        count={count}
+        isFull={isFull}
+        previewText={headPreviewText(entries)}
+        onToggle={() => setIsOpen((v) => !v)}
+      />
+    ) : null;
+
+  if (!hasEntries) {
+    return (
+      <>
+        {renderStatusBar?.(null)}
+        {children}
+      </>
+    );
+  }
 
   return (
     <>
+      {renderStatusBar?.(chipNode)}
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CollapsibleContent
           className={cn(
@@ -137,14 +164,9 @@ export function QueueAffordance({ sessionId, children }: QueueAffordanceProps) {
           />
         </CollapsibleContent>
       </Collapsible>
-      {!isOpen && (
+      {!renderStatusBar && chipNode && (
         <div className="flex items-center px-1 pb-1 animate-in fade-in-0 slide-in-from-bottom-1 duration-150 motion-reduce:animate-none">
-          <QueueChip
-            count={count}
-            isFull={isFull}
-            previewText={headPreviewText(entries)}
-            onToggle={() => setIsOpen((v) => !v)}
-          />
+          {chipNode}
         </div>
       )}
       {children}
@@ -161,9 +183,9 @@ type QueueChipProps = {
 
 function chipPalette(isFull: boolean): string {
   if (isFull) {
-    return "text-amber-600 dark:text-amber-400 border-amber-500/40 hover:bg-amber-500/10";
+    return "text-amber-600 dark:text-amber-400 border-amber-500/60 hover:bg-amber-500/10";
   }
-  return "text-muted-foreground border-border hover:text-foreground hover:border-border/80";
+  return "text-muted-foreground border-muted-foreground/40 hover:text-foreground hover:border-muted-foreground/60";
 }
 
 function QueueChip({ count, isFull, previewText, onToggle }: QueueChipProps) {


### PR DESCRIPTION
Promotes the per-session queue chip from its own row above the chat input into the existing status bar row alongside the todo, PR, and share controls — and gives it a stronger border so it reads as an actionable chip instead of a faint label.

## Important Changes

- `QueueAffordance` now accepts an optional `renderStatusBar?: (queueChip) => ReactNode` render-prop. When provided, the chip is projected into the caller-supplied row; when omitted, behavior falls back to the prior inline-above-input layout (keeps existing tests passing).
- `ChatStatusBar` gains a `queueChip?: ReactNode` prop, rendered between `PRStatusChip` and `PRMergedBanner` so it sits with the other left-aligned chips and leaves the `ml-auto` share button intact.
- Chip border bumped from `border-border` → `border-muted-foreground/40` (hover `/60`); full-state from `/40` → `/60`.

## Validation

- \`pnpm --filter @kandev/web typecheck\`
- \`pnpm --filter @kandev/web test components/task/chat/queued-ghost-list.test.tsx\` (11/11 pass)
- Full \`/verify\` pipeline: format / typecheck / test / lint all green

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Updated docs (if applicable)