### PR TITLE
fix: stop changes panel from showing stale or flickering content

### DIFF
--- a/apps/backend/internal/agentctl/server/process/git.go
+++ b/apps/backend/internal/agentctl/server/process/git.go
@@ -528,6 +528,11 @@ func (g *GitOperator) Commit(ctx context.Context, message string, stageAll bool,
 		}
 
 		g.workspaceTracker.NotifyGitCommit(commit)
+		// Refresh git status so the UI's "unstaged" list clears immediately.
+		// NotifyGitCommit only updates cachedHeadSHA — without an explicit
+		// refresh, currentStatus keeps the pre-commit "modified" entries until
+		// the next poll tick (which never fires when polling is paused).
+		g.triggerRefresh()
 	}
 
 	return result, nil

--- a/apps/backend/internal/agentctl/server/process/workspace_stream.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_stream.go
@@ -1,7 +1,6 @@
 package process
 
 import (
-	"context"
 	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/types"
@@ -52,8 +51,11 @@ func (wt *WorkspaceTracker) AttachWorkspaceStreamSubscriber(sub types.WorkspaceS
 	// tryUpdateGitStatus here because its broadcast would (a) duplicate the
 	// manual replay below for this subscriber and (b) push a redundant frame
 	// to every already-attached subscriber.
+	//
+	// Use the tracker's cancellable context (not context.Background) so
+	// Stop() can kill an in-flight `git status` here without waiting it out.
 	if wt.updateMu.TryLock() {
-		if status, err := wt.getGitStatus(context.Background()); err == nil {
+		if status, err := wt.getGitStatus(wt.cancelCtx); err == nil {
 			wt.mu.Lock()
 			wt.currentStatus = status
 			wt.mu.Unlock()

--- a/apps/backend/internal/agentctl/server/process/workspace_stream.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_stream.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/types"
@@ -20,6 +21,14 @@ func (wt *WorkspaceTracker) SubscribeWorkspaceStream() types.WorkspaceStreamSubs
 // process Manager to fan out a single client subscription across multiple
 // per-repo trackers (multi-repo task roots) without giving the client a
 // channel per tracker.
+//
+// Before replaying, run a fresh git status update if the cached snapshot may be
+// stale. The cache can lag the working tree when an agent committed via its
+// own shell tool (which bypasses GitOperator) while polling was paused or in
+// slow mode, or in the brief window between a HEAD-changing operation and the
+// next poll tick. Without this refresh, the new subscriber sees the old
+// "file=modified" state and only the next poll tick (up to ~30s away in slow
+// mode, never in paused mode) corrects it.
 func (wt *WorkspaceTracker) AttachWorkspaceStreamSubscriber(sub types.WorkspaceStreamSubscriber) {
 	wt.workspaceSubMu.Lock()
 	wt.workspaceStreamSubscribers[sub] = struct{}{}
@@ -36,8 +45,22 @@ func (wt *WorkspaceTracker) AttachWorkspaceStreamSubscriber(sub types.WorkspaceS
 		return
 	}
 
-	// Replay current git status so the new subscriber doesn't have to wait for
-	// the next poll tick.
+	// Refresh the cache opportunistically before replaying. Use TryLock so a
+	// concurrent poll/refresh doesn't block the attach; in that case we fall
+	// through to replaying whatever's cached, which is still no worse than
+	// the previous behaviour. We deliberately don't go through
+	// tryUpdateGitStatus here because its broadcast would (a) duplicate the
+	// manual replay below for this subscriber and (b) push a redundant frame
+	// to every already-attached subscriber.
+	if wt.updateMu.TryLock() {
+		if status, err := wt.getGitStatus(context.Background()); err == nil {
+			wt.mu.Lock()
+			wt.currentStatus = status
+			wt.mu.Unlock()
+		}
+		wt.updateMu.Unlock()
+	}
+
 	wt.mu.RLock()
 	currentStatus := wt.currentStatus
 	wt.mu.RUnlock()
@@ -106,6 +129,10 @@ func (wt *WorkspaceTracker) notifyWorkspaceStreamGitCommit(commit *types.GitComm
 
 // NotifyGitCommit notifies all subscribers about a new git commit.
 // It also updates the cached HEAD SHA to prevent polling from re-detecting the same commit.
+// Callers that mutate the working tree are responsible for refreshing
+// currentStatus separately (see GitOperator's triggerRefresh) — keeping that
+// responsibility on the caller avoids implicit blocking inside this Notify*
+// path, which is otherwise a fast event emit.
 func (wt *WorkspaceTracker) NotifyGitCommit(commit *types.GitCommitNotification) {
 	// Update cached HEAD to the new commit SHA so polling doesn't re-detect it
 	if commit.CommitSHA != "" {

--- a/apps/backend/internal/agentctl/server/process/workspace_stream_test.go
+++ b/apps/backend/internal/agentctl/server/process/workspace_stream_test.go
@@ -1,0 +1,235 @@
+package process
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/types"
+)
+
+// TestAttachWorkspaceStreamSubscriber_RefreshesBeforeReplay verifies that a
+// new subscriber receives a *fresh* git status, not whatever stale value is
+// sitting in the tracker's currentStatus cache. This closes the bug where an
+// agent shell `git commit` (which bypasses GitOperator) leaves the cache
+// showing "file=modified", and any later subscribe replays that stale entry.
+func TestAttachWorkspaceStreamSubscriber_RefreshesBeforeReplay(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(repoDir, log)
+
+	// Plant a stale entry directly into the cache: pretend an earlier poll
+	// observed README.md as modified, but the file is actually clean on disk.
+	wt.mu.Lock()
+	wt.currentStatus = types.GitStatusUpdate{
+		Timestamp: time.Now(),
+		Branch:    "main",
+		Modified:  []string{"README.md"},
+		Files: map[string]types.FileInfo{
+			"README.md": {Path: "README.md", Status: fileStatusModified, Staged: false},
+		},
+	}
+	wt.mu.Unlock()
+
+	sub := make(types.WorkspaceStreamSubscriber, 4)
+	wt.AttachWorkspaceStreamSubscriber(sub)
+	defer wt.DetachWorkspaceStreamSubscriber(sub)
+
+	select {
+	case msg := <-sub:
+		if msg.GitStatus == nil {
+			t.Fatalf("expected GitStatus message on attach, got %+v", msg)
+		}
+		// The working tree is actually clean. With the refresh-before-replay
+		// fix in place, AttachWorkspaceStreamSubscriber re-runs git status and
+		// the replayed snapshot reflects that — Modified must be empty.
+		if len(msg.GitStatus.Modified) != 0 {
+			t.Errorf("expected fresh Modified=[], got %v (stale cache was replayed)", msg.GitStatus.Modified)
+		}
+		if _, exists := msg.GitStatus.Files["README.md"]; exists {
+			t.Errorf("expected README.md to be absent from Files, found it (stale cache was replayed)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for replayed status on subscribe")
+	}
+}
+
+// TestAttachWorkspaceStreamSubscriber_BareTrackerSkipsReplay guards against
+// the refresh hook accidentally running git status against a non-repo
+// directory (multi-repo task root). The bare tracker has gitIndexPath="" and
+// must skip both the refresh and the replay.
+func TestAttachWorkspaceStreamSubscriber_BareTrackerSkipsReplay(t *testing.T) {
+	isolateTestGitEnv(t)
+
+	dir := t.TempDir()
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(dir, log)
+	// Force bare-tracker behaviour even if NewWorkspaceTracker happened to
+	// find a git index (unlikely in a fresh TempDir, but be explicit).
+	wt.gitIndexPath = ""
+
+	sub := make(types.WorkspaceStreamSubscriber, 4)
+	wt.AttachWorkspaceStreamSubscriber(sub)
+	defer wt.DetachWorkspaceStreamSubscriber(sub)
+
+	select {
+	case msg := <-sub:
+		t.Fatalf("bare tracker should not send anything on attach, got %+v", msg)
+	case <-time.After(100 * time.Millisecond):
+		// Good — no message sent.
+	}
+}
+
+// TestGitOperator_Commit_RefreshesGitStatus verifies that GitOperator.Commit
+// refreshes currentStatus after the commit completes, matching the
+// Stage/Unstage/Discard/Push pattern. Without this, the UI's "unstaged" list
+// keeps the pre-commit entries until the next poll tick — which never fires
+// in PollModePaused.
+func TestGitOperator_Commit_RefreshesGitStatus(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(repoDir, log)
+	ctx := context.Background()
+
+	// Modify and stage a tracked file, then warm the cache so it shows the
+	// pre-commit "modified=1" state.
+	writeFile(t, repoDir, "README.md", "# Modified\n")
+	runGit(t, repoDir, "add", "README.md")
+	wt.updateGitStatus(ctx)
+
+	wt.mu.RLock()
+	preFiles := len(wt.currentStatus.Files)
+	wt.mu.RUnlock()
+	if preFiles == 0 {
+		t.Fatalf("test setup: expected cached status to show 1+ file pre-commit, got 0")
+	}
+
+	gitOp := NewGitOperator(repoDir, log, wt)
+	result, err := gitOp.Commit(ctx, "test: refresh after commit", false, false)
+	if err != nil {
+		t.Fatalf("Commit returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Commit failed: %+v", result)
+	}
+
+	// Post-commit the working tree is clean; currentStatus must reflect that.
+	wt.mu.RLock()
+	gotFiles := len(wt.currentStatus.Files)
+	gotModified := append([]string(nil), wt.currentStatus.Modified...)
+	wt.mu.RUnlock()
+
+	if gotFiles != 0 {
+		t.Errorf("expected currentStatus.Files=0 after commit, got %d", gotFiles)
+	}
+	if len(gotModified) != 0 {
+		t.Errorf("expected currentStatus.Modified=[] after commit, got %v", gotModified)
+	}
+}
+
+// TestGitOperator_Commit_BroadcastsFreshStatus verifies that an already-attached
+// stream subscriber receives a fresh status_update after a commit. This is
+// the end-to-end path the orchestrator + frontend rely on: poll-driven
+// detection of an agent's commit goes through this broadcast.
+func TestGitOperator_Commit_BroadcastsFreshStatus(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(repoDir, log)
+	ctx := context.Background()
+
+	writeFile(t, repoDir, "README.md", "# Modified\n")
+	runGit(t, repoDir, "add", "README.md")
+	wt.updateGitStatus(ctx)
+
+	sub := make(types.WorkspaceStreamSubscriber, 8)
+	wt.AttachWorkspaceStreamSubscriber(sub)
+	defer wt.DetachWorkspaceStreamSubscriber(sub)
+
+	// Drain the on-attach replay so we observe only commit-driven messages.
+	drain(t, sub)
+
+	gitOp := NewGitOperator(repoDir, log, wt)
+	if _, err := gitOp.Commit(ctx, "test: broadcast after commit", false, false); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+
+	// Expect at least one git_status broadcast carrying a clean working tree.
+	// A commit notification may also be delivered; ignore it for this test.
+	sawCleanStatus := false
+	deadline := time.After(2 * time.Second)
+	for !sawCleanStatus {
+		select {
+		case msg := <-sub:
+			if msg.GitStatus == nil {
+				continue
+			}
+			if len(msg.GitStatus.Modified) == 0 && len(msg.GitStatus.Files) == 0 {
+				sawCleanStatus = true
+			}
+		case <-deadline:
+			t.Fatal("did not observe a clean status broadcast after commit")
+		}
+	}
+}
+
+// TestAttachWorkspaceStreamSubscriber_DoesNotBroadcastToOthers guards against
+// regressions where the refresh-before-replay hook accidentally goes through
+// notifyWorkspaceStreamGitStatus. That would noise up every already-attached
+// subscriber on every new attach and double-deliver to the attaching one.
+func TestAttachWorkspaceStreamSubscriber_DoesNotBroadcastToOthers(t *testing.T) {
+	repoDir, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	log := newTestLogger(t)
+	wt := NewWorkspaceTracker(repoDir, log)
+
+	existing := make(types.WorkspaceStreamSubscriber, 8)
+	wt.AttachWorkspaceStreamSubscriber(existing)
+	defer wt.DetachWorkspaceStreamSubscriber(existing)
+	drain(t, existing)
+
+	newSub := make(types.WorkspaceStreamSubscriber, 8)
+	wt.AttachWorkspaceStreamSubscriber(newSub)
+	defer wt.DetachWorkspaceStreamSubscriber(newSub)
+
+	// The newly attached subscriber must receive exactly one replay frame.
+	select {
+	case msg := <-newSub:
+		if msg.GitStatus == nil {
+			t.Fatalf("expected GitStatus replay, got %+v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("new subscriber did not receive the replay")
+	}
+	select {
+	case msg := <-newSub:
+		t.Fatalf("new subscriber received a second frame, want one: %+v", msg)
+	case <-time.After(150 * time.Millisecond):
+		// Good — only one frame delivered.
+	}
+
+	// The pre-existing subscriber must receive nothing on this attach.
+	select {
+	case msg := <-existing:
+		t.Fatalf("existing subscriber should not receive a frame when another attaches, got %+v", msg)
+	case <-time.After(150 * time.Millisecond):
+		// Good — no noise.
+	}
+}
+
+func drain(t *testing.T, sub types.WorkspaceStreamSubscriber) {
+	t.Helper()
+	for {
+		select {
+		case <-sub:
+		case <-time.After(100 * time.Millisecond):
+			return
+		}
+	}
+}

--- a/apps/web/hooks/domains/session/use-session-changes-count.test.ts
+++ b/apps/web/hooks/domains/session/use-session-changes-count.test.ts
@@ -35,6 +35,7 @@ function setStore(opts: {
     sessionCommits: {
       byEnvironmentId: opts.commitsByEnvironmentId ?? {},
       loading: {} as Record<string, boolean>,
+      refetchTrigger: {} as Record<string, number>,
     },
     connection: { status: "disconnected" },
     setSessionCommits: vi.fn(),

--- a/apps/web/hooks/domains/session/use-session-commits.test.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.test.ts
@@ -3,15 +3,22 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 const mockRequest = vi.fn();
 // setSessionCommits is the only mock whose default behaviour matters: the
-// trigger-bump regression test asserts the old commits stay in the store
-// throughout the refetch. With a pure `vi.fn()` mock that assertion is
-// vacuous — nothing in the test ever writes to storeState, so it's
-// trivially true. Default to actually mutating storeState so the test
-// would catch a future regression that clears the store mid-refetch.
-const mockSetSessionCommits = vi.fn((sessionId: string, commits: unknown[]) => {
-  const sc = storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> };
-  sc.byEnvironmentId[sessionId] = commits;
-});
+// trigger-bump regression tests assert what the store looks like before
+// and after the refetch resolves. With a pure `vi.fn()` mock those
+// assertions would be vacuous. Mirror the real action's anti-race guard
+// (skip writes of `[]` over a populated list unless `allowEmpty` is set)
+// so the tests cover the actual end-to-end behaviour, including the
+// authoritative-empty path used after a `commits_reset` bump.
+const mockSetSessionCommits = vi.fn(
+  (sessionId: string, commits: unknown[], opts?: { allowEmpty?: boolean }) => {
+    const sc = storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> };
+    const existing = sc.byEnvironmentId[sessionId];
+    if (!opts?.allowEmpty && commits.length === 0 && existing && existing.length > 0) {
+      return;
+    }
+    sc.byEnvironmentId[sessionId] = commits;
+  },
+);
 const mockSetSessionCommitsLoading = vi.fn();
 
 vi.mock("@/lib/ws/connection", () => ({
@@ -58,9 +65,11 @@ describe("useSessionCommits", () => {
     renderHook(() => useSessionCommits("sess-1"));
 
     await waitFor(() => {
-      expect(mockSetSessionCommits).toHaveBeenCalledWith("sess-1", [
-        { commit_sha: "abc", insertions: 10, deletions: 2 },
-      ]);
+      expect(mockSetSessionCommits).toHaveBeenCalledWith(
+        "sess-1",
+        [{ commit_sha: "abc", insertions: 10, deletions: 2 }],
+        undefined,
+      );
     });
   });
 
@@ -86,9 +95,11 @@ describe("useSessionCommits", () => {
       { timeout: 4000 },
     );
     await waitFor(() => {
-      expect(mockSetSessionCommits).toHaveBeenCalledWith("sess-1", [
-        { commit_sha: "abc", insertions: 5, deletions: 1 },
-      ]);
+      expect(mockSetSessionCommits).toHaveBeenCalledWith(
+        "sess-1",
+        [{ commit_sha: "abc", insertions: 5, deletions: 1 }],
+        undefined,
+      );
     });
   });
 
@@ -206,6 +217,42 @@ describe("useSessionCommits — stale-while-revalidate on trigger bump", () => {
       const after = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> })
         .byEnvironmentId;
       expect(after["sess-1"]).toEqual([{ commit_sha: "new", insertions: 2, deletions: 1 }]);
+    });
+  });
+
+  it("accepts an authoritative empty response on trigger bump", async () => {
+    // After a `git reset` that strips every commit back to base, the refetch
+    // legitimately returns []. Without `allowEmpty: true`, the default guard
+    // in `setSessionCommits` would silently drop that response and the panel
+    // would keep showing the pre-reset commits forever.
+    storeState.sessionCommits = {
+      byEnvironmentId: {
+        "sess-1": [
+          { commit_sha: "a", insertions: 0, deletions: 0 },
+          { commit_sha: "b", insertions: 0, deletions: 0 },
+        ],
+      },
+      loading: {},
+      refetchTrigger: { "sess-1": 0 },
+    };
+    mockRequest.mockResolvedValueOnce({ commits: [], ready: true });
+
+    const { rerender } = renderHook(() => useSessionCommits("sess-1"));
+    (storeState.sessionCommits as { refetchTrigger: Record<string, number> }).refetchTrigger = {
+      "sess-1": 1,
+    };
+    rerender();
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    // The hook MUST pass `{ allowEmpty: true }` for trigger-bump refetches.
+    await waitFor(() => {
+      expect(mockSetSessionCommits).toHaveBeenCalledWith("sess-1", [], { allowEmpty: true });
+    });
+    // And the store actually accepts the empty response.
+    await waitFor(() => {
+      const after = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> })
+        .byEnvironmentId;
+      expect(after["sess-1"]).toEqual([]);
     });
   });
 });

--- a/apps/web/hooks/domains/session/use-session-commits.test.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.test.ts
@@ -154,10 +154,33 @@ describe("useSessionCommits", () => {
   });
 });
 
+// Helper: seed store with one existing commit and a deferred request so we
+// can observe the store mid-refetch (stale-while-revalidate test).
+async function seedAndDeferRefetch(sessionId: string) {
+  storeState.sessionCommits = {
+    byEnvironmentId: {
+      [sessionId]: [{ commit_sha: "old", insertions: 1, deletions: 0 }],
+    },
+    loading: {},
+    refetchTrigger: { [sessionId]: 0 },
+  };
+  let resolveRequest!: (value: unknown) => void;
+  mockRequest.mockReturnValueOnce(
+    new Promise((resolve) => {
+      resolveRequest = resolve;
+    }),
+  );
+  return resolveRequest;
+}
+
+function bumpTrigger(sessionId: string, value: number) {
+  (storeState.sessionCommits as { refetchTrigger: Record<string, number> }).refetchTrigger = {
+    [sessionId]: value,
+  };
+}
+
 // Lives in its own describe so the outer block stays under the 100-line
-// max-lines-per-function limit; the test is involved enough (deferred
-// promise, mid-refetch observation) that inlining it pushes the parent
-// describe past the cap.
+// max-lines-per-function limit.
 describe("useSessionCommits — stale-while-revalidate on trigger bump", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -169,50 +192,20 @@ describe("useSessionCommits — stale-while-revalidate on trigger bump", () => {
   });
 
   it("refetches when refetchTrigger bumps without nulling the visible list", async () => {
-    // Seed the store with existing commits. The bug we're guarding against:
-    // a bump clears the list to undefined, the hook returns `[]`, the
-    // Changes panel renders its empty state, then the new list arrives.
-    storeState.sessionCommits = {
-      byEnvironmentId: {
-        "sess-1": [{ commit_sha: "old", insertions: 1, deletions: 0 }],
-      },
-      loading: {},
-      refetchTrigger: { "sess-1": 0 },
-    };
-    // Defer the request resolution so we can observe what the store looks
-    // like while the hook is mid-refetch — that's where the flicker would
-    // happen if the hook were nulling the visible list.
-    let resolveRequest!: (value: unknown) => void;
-    mockRequest.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveRequest = resolve;
-      }),
-    );
-
+    const resolveRequest = await seedAndDeferRefetch("sess-1");
     const { rerender } = renderHook(() => useSessionCommits("sess-1"));
-    // Initial mount: commits is already populated, so no fetch should fire.
     expect(mockRequest).not.toHaveBeenCalled();
 
-    // Bump the trigger (this is what commits_reset / branch_switched do).
-    (storeState.sessionCommits as { refetchTrigger: Record<string, number> }).refetchTrigger = {
-      "sess-1": 1,
-    };
+    bumpTrigger("sess-1", 1);
     rerender();
 
-    // The hook fires the refetch but the promise is still pending. During
-    // this window the store must still hold the OLD commits — that's the
-    // whole point of stale-while-revalidate.
     await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    // During mid-refetch the store must still hold the OLD commits.
     const midRefetch = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown> })
       .byEnvironmentId;
     expect(midRefetch["sess-1"]).toEqual([{ commit_sha: "old", insertions: 1, deletions: 0 }]);
 
-    // Now resolve the request — the new commits replace the old via the
-    // (mutating) mockSetSessionCommits.
-    resolveRequest({
-      commits: [{ commit_sha: "new", insertions: 2, deletions: 1 }],
-      ready: true,
-    });
+    resolveRequest({ commits: [{ commit_sha: "new", insertions: 2, deletions: 1 }], ready: true });
     await waitFor(() => {
       const after = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> })
         .byEnvironmentId;
@@ -221,10 +214,9 @@ describe("useSessionCommits — stale-while-revalidate on trigger bump", () => {
   });
 
   it("accepts an authoritative empty response on trigger bump", async () => {
-    // After a `git reset` that strips every commit back to base, the refetch
-    // legitimately returns []. Without `allowEmpty: true`, the default guard
-    // in `setSessionCommits` would silently drop that response and the panel
-    // would keep showing the pre-reset commits forever.
+    // After a `git reset`, the refetch legitimately returns []. Without
+    // `allowEmpty: true`, the default guard in `setSessionCommits` would
+    // silently drop that response and the panel would keep showing stale data.
     storeState.sessionCommits = {
       byEnvironmentId: {
         "sess-1": [
@@ -238,21 +230,62 @@ describe("useSessionCommits — stale-while-revalidate on trigger bump", () => {
     mockRequest.mockResolvedValueOnce({ commits: [], ready: true });
 
     const { rerender } = renderHook(() => useSessionCommits("sess-1"));
-    (storeState.sessionCommits as { refetchTrigger: Record<string, number> }).refetchTrigger = {
-      "sess-1": 1,
-    };
+    bumpTrigger("sess-1", 1);
     rerender();
 
     await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
-    // The hook MUST pass `{ allowEmpty: true }` for trigger-bump refetches.
     await waitFor(() => {
       expect(mockSetSessionCommits).toHaveBeenCalledWith("sess-1", [], { allowEmpty: true });
     });
-    // And the store actually accepts the empty response.
     await waitFor(() => {
       const after = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> })
         .byEnvironmentId;
       expect(after["sess-1"]).toEqual([]);
     });
+  });
+
+  it("drops a stale response when a newer fetch already started", async () => {
+    storeState.sessionCommits = {
+      byEnvironmentId: { "sess-1": [{ commit_sha: "initial" }] },
+      loading: {},
+      refetchTrigger: { "sess-1": 0 },
+    };
+    let resolveFirst!: (value: unknown) => void;
+    let resolveSecond!: (value: unknown) => void;
+    mockRequest
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+
+    const { rerender } = renderHook(() => useSessionCommits("sess-1"));
+
+    bumpTrigger("sess-1", 1);
+    rerender();
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+
+    bumpTrigger("sess-1", 2);
+    rerender();
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+
+    resolveFirst({ commits: [{ commit_sha: "stale" }], ready: true });
+    resolveSecond({ commits: [{ commit_sha: "fresh" }], ready: true });
+
+    await waitFor(() => {
+      const after = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> })
+        .byEnvironmentId;
+      expect(after["sess-1"]).toEqual([{ commit_sha: "fresh" }]);
+    });
+
+    const winningCalls = mockSetSessionCommits.mock.calls.filter(
+      ([, commits]) => Array.isArray(commits) && commits.length > 0,
+    );
+    expect(winningCalls).toHaveLength(1);
   });
 });

--- a/apps/web/hooks/domains/session/use-session-commits.test.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.test.ts
@@ -23,6 +23,7 @@ function setStore(connectionStatus: "connected" | "disconnected" = "connected") 
     sessionCommits: {
       byEnvironmentId: {} as Record<string, unknown>,
       loading: {} as Record<string, boolean>,
+      refetchTrigger: {} as Record<string, number>,
     },
     connection: { status: connectionStatus },
     setSessionCommits: mockSetSessionCommits,
@@ -130,5 +131,47 @@ describe("useSessionCommits", () => {
   it("does not fetch when sessionId is null", () => {
     renderHook(() => useSessionCommits(null));
     expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("refetches when refetchTrigger bumps without nulling the visible list", async () => {
+    // Seed the store with existing commits so we can assert they survive the
+    // bump. The bug we're guarding against is: a bump clears the list to
+    // undefined, the hook returns `[]`, the Changes panel renders its empty
+    // state, then the new list arrives — a visible flicker.
+    storeState.sessionCommits = {
+      byEnvironmentId: {
+        "sess-1": [{ commit_sha: "old", insertions: 1, deletions: 0 }],
+      },
+      loading: {},
+      refetchTrigger: { "sess-1": 0 },
+    };
+    mockRequest.mockResolvedValueOnce({
+      commits: [{ commit_sha: "new", insertions: 2, deletions: 1 }],
+      ready: true,
+    });
+
+    const { rerender } = renderHook(() => useSessionCommits("sess-1"));
+    // Initial mount: commits is already populated, so no fetch should fire.
+    expect(mockRequest).not.toHaveBeenCalled();
+
+    // Simulate the WS handler bumping the trigger (commits_reset /
+    // branch_switched). Critically, byEnvironmentId stays populated.
+    (storeState.sessionCommits as { refetchTrigger: Record<string, number> }).refetchTrigger = {
+      "sess-1": 1,
+    };
+    rerender();
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(mockSetSessionCommits).toHaveBeenCalledWith("sess-1", [
+        { commit_sha: "new", insertions: 2, deletions: 1 },
+      ]);
+    });
+
+    // The old list must still be in the store throughout — the hook never
+    // wiped it. Without stale-while-revalidate, the panel would flicker.
+    const byEnv = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown> })
+      .byEnvironmentId;
+    expect(byEnv["sess-1"]).toEqual([{ commit_sha: "old", insertions: 1, deletions: 0 }]);
   });
 });

--- a/apps/web/hooks/domains/session/use-session-commits.test.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 const mockRequest = vi.fn();
-const mockSetSessionCommits = vi.fn();
+// setSessionCommits is the only mock whose default behaviour matters: the
+// trigger-bump regression test asserts the old commits stay in the store
+// throughout the refetch. With a pure `vi.fn()` mock that assertion is
+// vacuous — nothing in the test ever writes to storeState, so it's
+// trivially true. Default to actually mutating storeState so the test
+// would catch a future regression that clears the store mid-refetch.
+const mockSetSessionCommits = vi.fn((sessionId: string, commits: unknown[]) => {
+  const sc = storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> };
+  sc.byEnvironmentId[sessionId] = commits;
+});
 const mockSetSessionCommitsLoading = vi.fn();
 
 vi.mock("@/lib/ws/connection", () => ({
@@ -132,12 +141,26 @@ describe("useSessionCommits", () => {
     renderHook(() => useSessionCommits(null));
     expect(mockRequest).not.toHaveBeenCalled();
   });
+});
+
+// Lives in its own describe so the outer block stays under the 100-line
+// max-lines-per-function limit; the test is involved enough (deferred
+// promise, mid-refetch observation) that inlining it pushes the parent
+// describe past the cap.
+describe("useSessionCommits — stale-while-revalidate on trigger bump", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
 
   it("refetches when refetchTrigger bumps without nulling the visible list", async () => {
-    // Seed the store with existing commits so we can assert they survive the
-    // bump. The bug we're guarding against is: a bump clears the list to
-    // undefined, the hook returns `[]`, the Changes panel renders its empty
-    // state, then the new list arrives — a visible flicker.
+    // Seed the store with existing commits. The bug we're guarding against:
+    // a bump clears the list to undefined, the hook returns `[]`, the
+    // Changes panel renders its empty state, then the new list arrives.
     storeState.sessionCommits = {
       byEnvironmentId: {
         "sess-1": [{ commit_sha: "old", insertions: 1, deletions: 0 }],
@@ -145,33 +168,44 @@ describe("useSessionCommits", () => {
       loading: {},
       refetchTrigger: { "sess-1": 0 },
     };
-    mockRequest.mockResolvedValueOnce({
-      commits: [{ commit_sha: "new", insertions: 2, deletions: 1 }],
-      ready: true,
-    });
+    // Defer the request resolution so we can observe what the store looks
+    // like while the hook is mid-refetch — that's where the flicker would
+    // happen if the hook were nulling the visible list.
+    let resolveRequest!: (value: unknown) => void;
+    mockRequest.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
 
     const { rerender } = renderHook(() => useSessionCommits("sess-1"));
     // Initial mount: commits is already populated, so no fetch should fire.
     expect(mockRequest).not.toHaveBeenCalled();
 
-    // Simulate the WS handler bumping the trigger (commits_reset /
-    // branch_switched). Critically, byEnvironmentId stays populated.
+    // Bump the trigger (this is what commits_reset / branch_switched do).
     (storeState.sessionCommits as { refetchTrigger: Record<string, number> }).refetchTrigger = {
       "sess-1": 1,
     };
     rerender();
 
+    // The hook fires the refetch but the promise is still pending. During
+    // this window the store must still hold the OLD commits — that's the
+    // whole point of stale-while-revalidate.
     await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
-    await waitFor(() => {
-      expect(mockSetSessionCommits).toHaveBeenCalledWith("sess-1", [
-        { commit_sha: "new", insertions: 2, deletions: 1 },
-      ]);
-    });
-
-    // The old list must still be in the store throughout — the hook never
-    // wiped it. Without stale-while-revalidate, the panel would flicker.
-    const byEnv = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown> })
+    const midRefetch = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown> })
       .byEnvironmentId;
-    expect(byEnv["sess-1"]).toEqual([{ commit_sha: "old", insertions: 1, deletions: 0 }]);
+    expect(midRefetch["sess-1"]).toEqual([{ commit_sha: "old", insertions: 1, deletions: 0 }]);
+
+    // Now resolve the request — the new commits replace the old via the
+    // (mutating) mockSetSessionCommits.
+    resolveRequest({
+      commits: [{ commit_sha: "new", insertions: 2, deletions: 1 }],
+      ready: true,
+    });
+    await waitFor(() => {
+      const after = (storeState.sessionCommits as { byEnvironmentId: Record<string, unknown[]> })
+        .byEnvironmentId;
+      expect(after["sess-1"]).toEqual([{ commit_sha: "new", insertions: 2, deletions: 1 }]);
+    });
   });
 });

--- a/apps/web/hooks/domains/session/use-session-commits.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.ts
@@ -53,6 +53,12 @@ export function useSessionCommits(sessionId: string | null) {
   // commit_created notifications were already fired (or pushed and so
   // filtered out by the live watcher).
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Monotonic request version. Captured at fetch start; the response is only
+  // applied if the version still matches. Without this, two trigger bumps in
+  // quick succession (e.g. branch_switched → user reverts) could see the
+  // older in-flight response land after the newer one and clobber the panel
+  // with stale data. Mirrors the pattern in useCumulativeDiff.
+  const requestVersionRef = useRef(0);
 
   // `allowEmpty` is threaded into setSessionCommits's guard. Trigger-bump
   // refetches (commits_reset / branch_switched) can legitimately return [] —
@@ -71,12 +77,20 @@ export function useSessionCommits(sessionId: string | null) {
         retryTimerRef.current = null;
       }
 
+      const version = ++requestVersionRef.current;
       setSessionCommitsLoading(sessionId, true);
       try {
         const response = await client.request<{ commits?: SessionCommit[]; ready?: boolean }>(
           "session.git.commits",
           { session_id: sessionId },
         );
+
+        // Drop stale callbacks: another fetch (e.g. a later trigger bump)
+        // already started, so this response is for an older state and must
+        // not overwrite the newer one. Skips both the retry-scheduling and
+        // the setSessionCommits write so the in-flight winner stays in
+        // control of both.
+        if (version !== requestVersionRef.current) return;
 
         // Backend signals ready:false with an empty commits array when the
         // workspace execution isn't available yet (e.g. agentctl still being
@@ -100,11 +114,9 @@ export function useSessionCommits(sessionId: string | null) {
       } catch (error) {
         console.error("Failed to fetch session commits:", error);
       } finally {
-        // Keep loading:true while a retry is scheduled — the operation isn't
-        // really finished, and flipping the flag here would let consumers see
-        // `{ loading: false, commits: [] }` for the whole retry window, which is
-        // the same misleading state this hook is designed to avoid.
-        if (!retryTimerRef.current) {
+        // Same version guard as above: a stale fetch must not flip loading
+        // off — only the current in-flight call owns the loading flag.
+        if (version === requestVersionRef.current && !retryTimerRef.current) {
           setSessionCommitsLoading(sessionId, false);
         }
       }

--- a/apps/web/hooks/domains/session/use-session-commits.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.ts
@@ -3,6 +3,13 @@ import { useAppStore } from "@/components/state-provider";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import type { SessionCommit } from "@/lib/state/slices/session-runtime/types";
 
+// Sentinel ref value: forces the trigger-bumped path to fire on first mount if
+// the store already carries a non-zero refetchTrigger (e.g. a bump landed
+// before the hook mounted). Any real trigger value the store can hold is > 0,
+// so 0 reliably "looks bumped" when the store's first observed value isn't 0
+// and "looks unbumped" when it is — there's no first-render flash either way.
+const REFETCH_TRIGGER_INIT = 0;
+
 const NOT_READY_RETRY_MS = 2000;
 
 /**
@@ -33,11 +40,12 @@ export function useSessionCommits(sessionId: string | null) {
   const setSessionCommitsLoading = useAppStore((state) => state.setSessionCommitsLoading);
   const connectionStatus = useAppStore((state) => state.connection.status);
 
-  // Track whether we had commits before (to detect clears)
-  const prevCommitsRef = useRef<SessionCommit[] | undefined>(undefined);
   // Track the last refetch trigger we acted on, so a bump triggers exactly one
-  // refetch rather than re-firing on every render.
-  const prevRefetchTriggerRef = useRef<number>(refetchTrigger);
+  // refetch rather than re-firing on every render. Initialise to a sentinel
+  // (not `refetchTrigger`) so a bump that arrived before this hook mounted
+  // still drives an initial refetch — otherwise prevRef would equal the live
+  // value and `triggerBumped` would silently be false on first render.
+  const prevRefetchTriggerRef = useRef<number>(REFETCH_TRIGGER_INIT);
   // Retry timer for the not-ready case — agentctl recovers asynchronously
   // after a backend restart, so the first fetch may land before the workspace
   // execution has been ensured. Without a retry the store would be stuck on
@@ -95,8 +103,10 @@ export function useSessionCommits(sessionId: string | null) {
   }, [sessionId, setSessionCommits, setSessionCommitsLoading]);
 
   // Fetch commits when:
-  //  1. commits is undefined (initial load or after an explicit clear)
-  //  2. the refetch trigger was bumped (commits_reset / branch_switched)
+  //  1. commits is undefined (initial load — clearSessionCommits is still
+  //     called by callers that genuinely want to drop the list, e.g. session
+  //     teardown).
+  //  2. the refetch trigger was bumped (commits_reset / branch_switched).
   //
   // The trigger path replaces the old "clear then refetch from undefined"
   // pattern: it keeps the previous commits in the store so the Changes panel
@@ -107,14 +117,12 @@ export function useSessionCommits(sessionId: string | null) {
     if (!sessionId) return;
 
     const needsInitialFetch = commits === undefined;
-    const wasCleared = prevCommitsRef.current !== undefined && commits === undefined;
     const triggerBumped = refetchTrigger !== prevRefetchTriggerRef.current;
 
-    if (needsInitialFetch || wasCleared || triggerBumped) {
+    if (needsInitialFetch || triggerBumped) {
       fetchCommits();
     }
 
-    prevCommitsRef.current = commits;
     prevRefetchTriggerRef.current = refetchTrigger;
   }, [sessionId, commits, refetchTrigger, fetchCommits, connectionStatus]);
 

--- a/apps/web/hooks/domains/session/use-session-commits.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.ts
@@ -54,53 +54,63 @@ export function useSessionCommits(sessionId: string | null) {
   // filtered out by the live watcher).
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const fetchCommits = useCallback(async () => {
-    if (!sessionId) return;
+  // `allowEmpty` is threaded into setSessionCommits's guard. Trigger-bump
+  // refetches (commits_reset / branch_switched) can legitimately return [] —
+  // e.g. a `git reset` stripped every commit back to base — and the store
+  // must accept that authoritatively. Initial fetches keep the default
+  // guard so a stale empty response can't race the addSessionCommit path.
+  const fetchCommits = useCallback(
+    async (opts?: { allowEmpty?: boolean }) => {
+      if (!sessionId) return;
 
-    const client = getWebSocketClient();
-    if (!client) return;
+      const client = getWebSocketClient();
+      if (!client) return;
 
-    if (retryTimerRef.current) {
-      clearTimeout(retryTimerRef.current);
-      retryTimerRef.current = null;
-    }
-
-    setSessionCommitsLoading(sessionId, true);
-    try {
-      const response = await client.request<{ commits?: SessionCommit[]; ready?: boolean }>(
-        "session.git.commits",
-        { session_id: sessionId },
-      );
-
-      // Backend signals ready:false with an empty commits array when the
-      // workspace execution isn't available yet (e.g. agentctl still being
-      // recovered after a backend restart, or a session in WAITING_FOR_INPUT
-      // whose execution was never spawned). Don't overwrite the store with
-      // [] — that would leave commits looking "loaded but empty" forever.
-      // Schedule a retry so we eventually pick up the real list.
-      if (response?.ready === false) {
-        retryTimerRef.current = setTimeout(() => {
-          retryTimerRef.current = null;
-          fetchCommits();
-        }, NOT_READY_RETRY_MS);
-        return;
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
       }
 
-      if (response?.commits) {
-        setSessionCommits(sessionId, response.commits);
+      setSessionCommitsLoading(sessionId, true);
+      try {
+        const response = await client.request<{ commits?: SessionCommit[]; ready?: boolean }>(
+          "session.git.commits",
+          { session_id: sessionId },
+        );
+
+        // Backend signals ready:false with an empty commits array when the
+        // workspace execution isn't available yet (e.g. agentctl still being
+        // recovered after a backend restart, or a session in WAITING_FOR_INPUT
+        // whose execution was never spawned). Don't overwrite the store with
+        // [] — that would leave commits looking "loaded but empty" forever.
+        // Schedule a retry so we eventually pick up the real list. Preserve
+        // `opts` across retries so a trigger-bump fetch that gets ready:false
+        // still applies its authoritative empty response when it succeeds.
+        if (response?.ready === false) {
+          retryTimerRef.current = setTimeout(() => {
+            retryTimerRef.current = null;
+            fetchCommits(opts);
+          }, NOT_READY_RETRY_MS);
+          return;
+        }
+
+        if (response?.commits) {
+          setSessionCommits(sessionId, response.commits, opts);
+        }
+      } catch (error) {
+        console.error("Failed to fetch session commits:", error);
+      } finally {
+        // Keep loading:true while a retry is scheduled — the operation isn't
+        // really finished, and flipping the flag here would let consumers see
+        // `{ loading: false, commits: [] }` for the whole retry window, which is
+        // the same misleading state this hook is designed to avoid.
+        if (!retryTimerRef.current) {
+          setSessionCommitsLoading(sessionId, false);
+        }
       }
-    } catch (error) {
-      console.error("Failed to fetch session commits:", error);
-    } finally {
-      // Keep loading:true while a retry is scheduled — the operation isn't
-      // really finished, and flipping the flag here would let consumers see
-      // `{ loading: false, commits: [] }` for the whole retry window, which is
-      // the same misleading state this hook is designed to avoid.
-      if (!retryTimerRef.current) {
-        setSessionCommitsLoading(sessionId, false);
-      }
-    }
-  }, [sessionId, setSessionCommits, setSessionCommitsLoading]);
+    },
+    [sessionId, setSessionCommits, setSessionCommitsLoading],
+  );
 
   // Fetch commits when:
   //  1. commits is undefined (initial load — clearSessionCommits is still
@@ -119,7 +129,12 @@ export function useSessionCommits(sessionId: string | null) {
     const needsInitialFetch = commits === undefined;
     const triggerBumped = refetchTrigger !== prevRefetchTriggerRef.current;
 
-    if (needsInitialFetch || triggerBumped) {
+    if (triggerBumped) {
+      // Trigger-bump path: the backend already mutated state (reset / branch
+      // switch). An empty response is authoritative — bypass the default
+      // anti-race guard so the panel reflects the actual post-reset state.
+      fetchCommits({ allowEmpty: true });
+    } else if (needsInitialFetch) {
       fetchCommits();
     }
 

--- a/apps/web/hooks/domains/session/use-session-commits.ts
+++ b/apps/web/hooks/domains/session/use-session-commits.ts
@@ -21,12 +21,23 @@ export function useSessionCommits(sessionId: string | null) {
     const envKey = state.environmentIdBySessionId[sessionId] ?? sessionId;
     return state.sessionCommits.loading[envKey] ?? false;
   });
+  // Stale-while-revalidate trigger: bumped by commits_reset / branch_switched
+  // WS events. We refetch on change without nulling the visible list, so the
+  // Changes panel keeps showing the previous commits until the new ones land.
+  const refetchTrigger = useAppStore((state) => {
+    if (!sessionId) return 0;
+    const envKey = state.environmentIdBySessionId[sessionId] ?? sessionId;
+    return state.sessionCommits.refetchTrigger[envKey] ?? 0;
+  });
   const setSessionCommits = useAppStore((state) => state.setSessionCommits);
   const setSessionCommitsLoading = useAppStore((state) => state.setSessionCommitsLoading);
   const connectionStatus = useAppStore((state) => state.connection.status);
 
   // Track whether we had commits before (to detect clears)
   const prevCommitsRef = useRef<SessionCommit[] | undefined>(undefined);
+  // Track the last refetch trigger we acted on, so a bump triggers exactly one
+  // refetch rather than re-firing on every render.
+  const prevRefetchTriggerRef = useRef<number>(refetchTrigger);
   // Retry timer for the not-ready case — agentctl recovers asynchronously
   // after a backend restart, so the first fetch may land before the workspace
   // execution has been ensured. Without a retry the store would be stuck on
@@ -83,23 +94,29 @@ export function useSessionCommits(sessionId: string | null) {
     }
   }, [sessionId, setSessionCommits, setSessionCommitsLoading]);
 
-  // Fetch commits on mount or when commits are cleared (e.g., after reset)
+  // Fetch commits when:
+  //  1. commits is undefined (initial load or after an explicit clear)
+  //  2. the refetch trigger was bumped (commits_reset / branch_switched)
+  //
+  // The trigger path replaces the old "clear then refetch from undefined"
+  // pattern: it keeps the previous commits in the store so the Changes panel
+  // doesn't flicker through its empty state while the refetch is in flight
+  // (stale-while-revalidate, matching how useCumulativeDiff works).
   useEffect(() => {
     if (connectionStatus !== "connected") return;
     if (!sessionId) return;
 
-    // Fetch if:
-    // 1. commits is undefined (initial load or after clear)
-    // 2. commits was previously set but is now undefined (reset scenario)
-    const wasCleared = prevCommitsRef.current !== undefined && commits === undefined;
     const needsInitialFetch = commits === undefined;
+    const wasCleared = prevCommitsRef.current !== undefined && commits === undefined;
+    const triggerBumped = refetchTrigger !== prevRefetchTriggerRef.current;
 
-    if (needsInitialFetch || wasCleared) {
+    if (needsInitialFetch || wasCleared || triggerBumped) {
       fetchCommits();
     }
 
     prevCommitsRef.current = commits;
-  }, [sessionId, commits, fetchCommits, connectionStatus]);
+    prevRefetchTriggerRef.current = refetchTrigger;
+  }, [sessionId, commits, refetchTrigger, fetchCommits, connectionStatus]);
 
   // Cancel any in-flight retry on unmount, when the session changes, or when
   // the WS disconnects — a retry firing against a disconnected client would

--- a/apps/web/lib/state/slices/session-runtime/session-commits-refetch.test.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-commits-refetch.test.ts
@@ -71,3 +71,48 @@ describe("bumpSessionCommitsRefetch", () => {
     expect(triggers[SESSION]).toBeUndefined();
   });
 });
+
+describe("setSessionCommits — empty-response guard", () => {
+  let useStore: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    useStore = makeStore();
+  });
+
+  it("rejects [] over a populated list by default (race protection)", () => {
+    // The default guard protects against a stale fetch response landing
+    // after incremental commit_created notifications already populated the
+    // store. Without it, an in-flight initial fetch could clobber the live
+    // list with [].
+    useStore.getState().setSessionCommits(SESSION, [commit({ commit_sha: "abc" })]);
+
+    useStore.getState().setSessionCommits(SESSION, []);
+
+    const after = useStore.getState().sessionCommits.byEnvironmentId[SESSION];
+    expect(after).toHaveLength(1);
+    expect(after[0].commit_sha).toBe("abc");
+  });
+
+  it("accepts [] when allowEmpty:true (authoritative response after reset)", () => {
+    // After commits_reset/branch_switched, a refetch can legitimately return
+    // []. The caller opts into the empty-accepting path so the panel stops
+    // showing the pre-reset list.
+    useStore.getState().setSessionCommits(SESSION, [commit({ commit_sha: "abc" })]);
+
+    useStore.getState().setSessionCommits(SESSION, [], { allowEmpty: true });
+
+    expect(useStore.getState().sessionCommits.byEnvironmentId[SESSION]).toEqual([]);
+  });
+
+  it("writes the populated list regardless of allowEmpty", () => {
+    // Sanity: allowEmpty only changes behaviour for empty arrays. A populated
+    // list always overwrites.
+    useStore.getState().setSessionCommits(SESSION, [commit({ commit_sha: "old" })]);
+
+    useStore.getState().setSessionCommits(SESSION, [commit({ commit_sha: "new" })]);
+
+    const after = useStore.getState().sessionCommits.byEnvironmentId[SESSION];
+    expect(after).toHaveLength(1);
+    expect(after[0].commit_sha).toBe("new");
+  });
+});

--- a/apps/web/lib/state/slices/session-runtime/session-commits-refetch.test.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-commits-refetch.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { createSessionRuntimeSlice } from "./session-runtime-slice";
+import type { SessionCommit, SessionRuntimeSlice } from "./types";
+
+function makeStore() {
+  return create<SessionRuntimeSlice>()(
+    immer((set, get, store) => createSessionRuntimeSlice(set, get, store)),
+  );
+}
+
+const SESSION = "sess-1";
+
+function commit(overrides: Partial<SessionCommit>): SessionCommit {
+  return {
+    id: "id",
+    session_id: SESSION,
+    commit_sha: "sha",
+    parent_sha: "parent",
+    commit_message: "msg",
+    author_name: "test",
+    author_email: "test@test",
+    files_changed: 0,
+    insertions: 0,
+    deletions: 0,
+    committed_at: "2026-05-28T00:00:00Z",
+    created_at: "2026-05-28T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("bumpSessionCommitsRefetch", () => {
+  let useStore: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    useStore = makeStore();
+  });
+
+  it("increments the trigger counter for the session's env key", () => {
+    useStore.getState().bumpSessionCommitsRefetch(SESSION);
+    expect(useStore.getState().sessionCommits.refetchTrigger[SESSION]).toBe(1);
+
+    useStore.getState().bumpSessionCommitsRefetch(SESSION);
+    expect(useStore.getState().sessionCommits.refetchTrigger[SESSION]).toBe(2);
+  });
+
+  it("does NOT touch byEnvironmentId — visible commits stay during refetch", () => {
+    // Stale-while-revalidate is the whole point: the WS handler bumps so the
+    // hook refetches, but the panel keeps showing the previous commits until
+    // the new list arrives. If a bump cleared the list, the panel would
+    // briefly fall through to its empty state.
+    const existing = [commit({ commit_sha: "abc" }), commit({ commit_sha: "def" })];
+    useStore.getState().setSessionCommits(SESSION, existing);
+
+    useStore.getState().bumpSessionCommitsRefetch(SESSION);
+
+    expect(useStore.getState().sessionCommits.byEnvironmentId[SESSION]).toEqual(existing);
+  });
+
+  it("resolves through environmentIdBySessionId so co-environment sessions share a trigger", () => {
+    // sess-1 and sess-2 share env-foo; the trigger lives under env-foo so
+    // either session bumping it refetches both.
+    useStore.getState().registerSessionEnvironment(SESSION, "env-foo");
+    useStore.getState().registerSessionEnvironment("sess-2", "env-foo");
+
+    useStore.getState().bumpSessionCommitsRefetch(SESSION);
+
+    const triggers = useStore.getState().sessionCommits.refetchTrigger;
+    expect(triggers["env-foo"]).toBe(1);
+    expect(triggers[SESSION]).toBeUndefined();
+  });
+});

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -87,7 +87,7 @@ export const defaultSessionRuntimeState: SessionRuntimeSliceState = {
   },
   gitStatus: { byEnvironmentId: {}, byEnvironmentRepo: {} },
   environmentIdBySessionId: {},
-  sessionCommits: { byEnvironmentId: {}, loading: {} },
+  sessionCommits: { byEnvironmentId: {}, loading: {}, refetchTrigger: {} },
   contextWindow: { bySessionId: {} },
   agents: { agents: [] },
   availableCommands: { bySessionId: {} },
@@ -199,6 +199,12 @@ function buildSessionCommitActions(set: ImmerSet) {
       set((draft) => {
         const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
         delete draft.sessionCommits.byEnvironmentId[envKey];
+      }),
+    bumpSessionCommitsRefetch: (sessionId: string) =>
+      set((draft) => {
+        const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
+        const prev = draft.sessionCommits.refetchTrigger[envKey] ?? 0;
+        draft.sessionCommits.refetchTrigger[envKey] = prev + 1;
       }),
   };
 }

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -287,6 +287,7 @@ export function migrateEnvKeyedData(
   migrate(draft.sessionCommits.byEnvironmentId);
   migrate(draft.gitStatus.byEnvironmentRepo);
   migrate(draft.sessionCommits.loading);
+  migrate(draft.sessionCommits.refetchTrigger);
   migrate(draft.gitStatus.byEnvironmentId);
   migrate(draft.shell.outputs);
   migrate(draft.shell.statuses);

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -164,13 +164,20 @@ function buildSessionCommitActions(set: ImmerSet) {
     setSessionCommits: (
       sessionId: string,
       commits: Parameters<SessionRuntimeSlice["setSessionCommits"]>[1],
+      opts?: { allowEmpty?: boolean },
     ) =>
       set((draft) => {
         const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
         const existing = draft.sessionCommits.byEnvironmentId[envKey];
-        // Prevent a stale empty-array response from overwriting commits that
-        // arrived via incremental notifications while the request was in flight.
-        if (commits.length === 0 && existing && existing.length > 0) {
+        // Default guard: prevent a stale empty-array response from overwriting
+        // commits that arrived via incremental notifications while the request
+        // was in flight (race between fetch start and commit_created events).
+        //
+        // Under stale-while-revalidate, a `commits_reset` or `branch_switched`
+        // refetch can *legitimately* return [] — the backend actually has no
+        // commits. The caller must opt in to that path with `allowEmpty: true`
+        // so the panel stops showing the pre-reset list.
+        if (!opts?.allowEmpty && commits.length === 0 && existing && existing.length > 0) {
           return;
         }
         draft.sessionCommits.byEnvironmentId[envKey] = commits;

--- a/apps/web/lib/state/slices/session-runtime/types.ts
+++ b/apps/web/lib/state/slices/session-runtime/types.ts
@@ -364,7 +364,11 @@ export type SessionRuntimeSliceActions = {
   registerSessionEnvironment: (sessionId: string, environmentId: string) => void;
   setContextWindow: (sessionId: string, contextWindow: ContextWindowEntry) => void;
   // Session commit actions
-  setSessionCommits: (sessionId: string, commits: SessionCommit[]) => void;
+  setSessionCommits: (
+    sessionId: string,
+    commits: SessionCommit[],
+    opts?: { allowEmpty?: boolean },
+  ) => void;
   setSessionCommitsLoading: (sessionId: string, loading: boolean) => void;
   addSessionCommit: (sessionId: string, commit: SessionCommit) => void;
   clearSessionCommits: (sessionId: string) => void;

--- a/apps/web/lib/state/slices/session-runtime/types.ts
+++ b/apps/web/lib/state/slices/session-runtime/types.ts
@@ -133,6 +133,12 @@ export type CumulativeDiff = {
 export type SessionCommitsState = {
   byEnvironmentId: Record<string, SessionCommit[]>;
   loading: Record<string, boolean>;
+  // Stale-while-revalidate signal: bumped by WS handlers (commits_reset /
+  // branch_switched) that previously cleared `byEnvironmentId` outright.
+  // useSessionCommits watches this counter and refetches without nulling the
+  // visible list, so the Changes panel doesn't flicker through its empty
+  // state while the refetch is in flight.
+  refetchTrigger: Record<string, number>;
 };
 
 export type ContextWindowEntry = {
@@ -362,6 +368,9 @@ export type SessionRuntimeSliceActions = {
   setSessionCommitsLoading: (sessionId: string, loading: boolean) => void;
   addSessionCommit: (sessionId: string, commit: SessionCommit) => void;
   clearSessionCommits: (sessionId: string) => void;
+  // Signal a refetch without clearing the visible list — see
+  // SessionCommitsState.refetchTrigger.
+  bumpSessionCommitsRefetch: (sessionId: string) => void;
   // Available commands actions
   setAvailableCommands: (sessionId: string, commands: AvailableCommand[]) => void;
   clearAvailableCommands: (sessionId: string) => void;

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -387,7 +387,11 @@ export type AppState = {
   setGitStatus: (sessionId: string, gitStatus: GitStatusEntry) => void;
   clearGitStatus: (sessionId: string) => void;
   registerSessionEnvironment: (sessionId: string, environmentId: string) => void;
-  setSessionCommits: (sessionId: string, commits: SessionCommit[]) => void;
+  setSessionCommits: (
+    sessionId: string,
+    commits: SessionCommit[],
+    opts?: { allowEmpty?: boolean },
+  ) => void;
   setSessionCommitsLoading: (sessionId: string, loading: boolean) => void;
   addSessionCommit: (sessionId: string, commit: SessionCommit) => void;
   clearSessionCommits: (sessionId: string) => void;

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -391,6 +391,7 @@ export type AppState = {
   setSessionCommitsLoading: (sessionId: string, loading: boolean) => void;
   addSessionCommit: (sessionId: string, commit: SessionCommit) => void;
   clearSessionCommits: (sessionId: string) => void;
+  bumpSessionCommitsRefetch: (sessionId: string) => void;
   setContextWindow: (sessionId: string, contextWindow: ContextWindowEntry) => void;
   bumpAgentProfilesVersion: () => void;
   setPendingModel: (sessionId: string, modelId: string) => void;

--- a/apps/web/lib/ws/handlers/git-status.test.ts
+++ b/apps/web/lib/ws/handlers/git-status.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { create, type StoreApi } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { createSessionRuntimeSlice } from "@/lib/state/slices/session-runtime/session-runtime-slice";
+import type { SessionRuntimeSlice } from "@/lib/state/slices/session-runtime/types";
+import type { AppState } from "@/lib/state/store";
+import type { GitCommitsResetEvent, GitBranchSwitchedEvent } from "@/lib/types/git-events";
+import { registerGitStatusHandlers } from "./git-status";
+
+// invalidateCumulativeDiffCache lives in a hook module that pulls React in via
+// its imports. Stub it out so this test can run as a pure unit test against
+// the slice + handler without dragging in React.
+vi.mock("@/hooks/domains/session/use-cumulative-diff", () => ({
+  invalidateCumulativeDiffCache: vi.fn(),
+}));
+
+const SESSION = "sess-1";
+
+function makeStore() {
+  // The handler only touches sessionCommits actions and environmentIdBySessionId.
+  // We don't need the full AppState — cast through unknown so the handler
+  // signature is satisfied without standing up unrelated slices.
+  return create<SessionRuntimeSlice>()(
+    immer((set, get, store) => createSessionRuntimeSlice(set, get, store)),
+  ) as unknown as StoreApi<AppState>;
+}
+
+function gitEvent(payload: GitCommitsResetEvent | GitBranchSwitchedEvent) {
+  return {
+    id: "msg",
+    type: "notification" as const,
+    action: "session.git.event" as const,
+    timestamp: payload.timestamp,
+    payload,
+  };
+}
+
+describe("git-status WS handler — stale-while-revalidate", () => {
+  let store: StoreApi<AppState>;
+
+  beforeEach(() => {
+    store = makeStore();
+    store.getState().setSessionCommits(SESSION, [
+      {
+        id: "id",
+        session_id: SESSION,
+        commit_sha: "old",
+        parent_sha: "parent",
+        commit_message: "msg",
+        author_name: "a",
+        author_email: "a@a",
+        files_changed: 0,
+        insertions: 0,
+        deletions: 0,
+        committed_at: "2026-05-28T00:00:00Z",
+        created_at: "2026-05-28T00:00:00Z",
+      },
+    ]);
+  });
+
+  it("commits_reset bumps refetchTrigger and keeps existing commits visible", () => {
+    const handlers = registerGitStatusHandlers(store);
+    const handler = handlers["session.git.event"];
+    if (!handler) throw new Error("session.git.event handler is missing");
+
+    handler(
+      gitEvent({
+        type: "commits_reset",
+        session_id: SESSION,
+        timestamp: "2026-05-28T00:00:01Z",
+        reset: { previous_head: "old-head", current_head: "new-head", deleted_count: 1 },
+      }),
+    );
+
+    const state = store.getState();
+    // Trigger bumped — useSessionCommits will refetch.
+    expect(state.sessionCommits.refetchTrigger[SESSION]).toBe(1);
+    // Existing commits remain — this is the whole point. Clearing would make
+    // the Changes panel briefly render its empty state until the refetch
+    // resolved.
+    expect(state.sessionCommits.byEnvironmentId[SESSION]).toHaveLength(1);
+    expect(state.sessionCommits.byEnvironmentId[SESSION][0].commit_sha).toBe("old");
+  });
+
+  it("branch_switched bumps refetchTrigger and keeps existing commits visible", () => {
+    const handlers = registerGitStatusHandlers(store);
+    const handler = handlers["session.git.event"];
+    if (!handler) throw new Error("session.git.event handler is missing");
+
+    handler(
+      gitEvent({
+        type: "branch_switched",
+        session_id: SESSION,
+        timestamp: "2026-05-28T00:00:02Z",
+        branch_switch: {
+          previous_branch: "old",
+          current_branch: "new",
+          current_head: "head",
+          base_commit: "base",
+        },
+      }),
+    );
+
+    const state = store.getState();
+    expect(state.sessionCommits.refetchTrigger[SESSION]).toBe(1);
+    expect(state.sessionCommits.byEnvironmentId[SESSION]).toHaveLength(1);
+  });
+});

--- a/apps/web/lib/ws/handlers/git-status.ts
+++ b/apps/web/lib/ws/handlers/git-status.ts
@@ -97,16 +97,21 @@ const gitEventHandlers: GitEventHandlers = {
 
   commits_reset: (store, event) => {
     if (IS_DEBUG) debug("commits_reset", { sessionId: event.session_id });
-    // Clear commits to trigger refetch in useSessionCommits hook
-    store.getState().clearSessionCommits(event.session_id);
+    // Trigger a refetch without clearing the visible commits — the Changes
+    // panel would otherwise flicker through its empty state ("Your changed
+    // files will appear here") while the refetch is in flight, because
+    // useSessionCommits returns `commits ?? []` and the panel's hasAnything
+    // gate flips to false the moment commits goes undefined.
+    store.getState().bumpSessionCommitsRefetch(event.session_id);
     // Invalidate cumulative diff cache when commits are reset
     invalidateCumulativeDiffCache(resolveEnvKey(store, event.session_id));
   },
 
   branch_switched: (store, event) => {
     if (IS_DEBUG) debug("branch_switched", { sessionId: event.session_id });
-    // Clear commits to trigger refetch with new base commit
-    store.getState().clearSessionCommits(event.session_id);
+    // Stale-while-revalidate (see commits_reset above): refetch with the new
+    // base commit but keep the old list visible until the new one arrives.
+    store.getState().bumpSessionCommitsRefetch(event.session_id);
     // Invalidate cumulative diff cache when branch switches
     invalidateCumulativeDiffCache(resolveEnvKey(store, event.session_id));
   },


### PR DESCRIPTION
The Changes panel had two distinct ways to look wrong: it kept showing pre-commit "modified=1" entries until the agentctl poll caught up (never, while polling was paused), and it visibly flickered through its empty state every time the agent did a reset / amend / rebase. Fixing each at its source — the agentctl status cache, and the WS handler that wiped sessionCommits.

## Important Changes

- **Backend.** `GitOperator.Commit` now calls `triggerRefresh()` after `NotifyGitCommit`, matching the Stage/Unstage/Discard/Push pattern. `AttachWorkspaceStreamSubscriber` runs a non-broadcasting fresh refresh under `updateMu.TryLock` before replaying — covers agent shell commits that bypass `GitOperator` entirely. The non-broadcasting path is deliberate: going through `tryUpdateGitStatus` would duplicate the replay for the new subscriber and push a redundant frame to every already-attached one.
- **Frontend.** Replaced `clearSessionCommits` + refetch-from-undefined with a stale-while-revalidate `refetchTrigger` counter on `SessionCommitsState`, matching how `useCumulativeDiff` already handles invalidation. The WS handlers for `commits_reset` / `branch_switched` bump the counter instead of nulling the list, so `useSessionCommits` refetches while the previous commits stay visible — no more empty-state window.

## Validation

- \`make fmt typecheck test lint\` across backend and web (via the verify pipeline).
- New regression tests:
  - \`workspace_stream_test.go\` — fresh-before-replay, bare-tracker no-op, no spurious broadcast to existing subscribers, post-commit cache refresh, post-commit fresh broadcast.
  - \`session-commits-refetch.test.ts\` — bump increments counter, leaves \`byEnvironmentId\` untouched, resolves through env mapping.
  - \`git-status.test.ts\` (web) — \`commits_reset\` and \`branch_switched\` bump trigger and preserve existing commits.
  - One new case in \`use-session-commits.test.ts\` — refetch fires on trigger bump and the old list survives in the store throughout.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.