### PR TITLE
feat(web): persist PR-merged banner dismissal in sessionStorage

### DIFF
--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -29,6 +29,7 @@ import { usePlanActions } from "@/hooks/domains/kanban/use-plan-actions";
 import { useExecutorEnvironmentAvailability } from "@/hooks/domains/session/use-executor-environment-availability";
 import { useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useToast } from "@/components/toast-provider";
+import { markPRMergedBannerDismissed, wasPRMergedBannerDismissed } from "@/lib/local-storage";
 import type { DiffComment } from "@/lib/diff/types";
 import type { useChatPanelState } from "./use-chat-panel-state";
 
@@ -241,9 +242,14 @@ export function useChatPanelHandlers(
 
 export function PRMergedBanner({ taskId }: { taskId: string }) {
   const taskPRs = useAppStore((state) => state.taskPRs.byTaskId[taskId]);
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useState(() => wasPRMergedBannerDismissed(taskId));
   const archiveAndSwitch = useArchiveAndSwitchTask();
   const { toast } = useToast();
+
+  const handleDismiss = useCallback(() => {
+    markPRMergedBannerDismissed(taskId);
+    setDismissed(true);
+  }, [taskId]);
 
   const handleArchive = useCallback(async () => {
     try {
@@ -282,7 +288,8 @@ export function PRMergedBanner({ taskId }: { taskId: string }) {
       <button
         type="button"
         aria-label="Dismiss"
-        onClick={() => setDismissed(true)}
+        data-testid="pr-merged-dismiss-button"
+        onClick={handleDismiss}
         className="p-0.5 hover:bg-purple-500/10 rounded cursor-pointer"
       >
         <IconX className="h-3 w-3" />

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -58,6 +58,9 @@ export class SessionPage {
   prMergedArchiveButton() {
     return this.page.getByTestId("pr-merged-archive-button");
   }
+  prMergedDismissButton() {
+    return this.page.getByTestId("pr-merged-dismiss-button");
+  }
   todoIndicator() {
     return this.page.getByTestId("todo-indicator");
   }

--- a/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
@@ -237,12 +237,13 @@ test.describe("Chat status bar", () => {
     });
     await expect(session.prMergedBanner()).not.toBeVisible();
 
-    // Persists across task switch (away and back).
+    // Switch to task B and back. Task B has no merged PR so it never shows
+    // the banner — the real proof of cross-task-switch persistence is that
+    // the banner is still hidden on the return trip to task A.
     await session.taskInSidebar("Dismiss Banner Task B").first().click();
     await expect(session.chat.getByText("dismiss banner beta response").last()).toBeVisible({
       timeout: 30_000,
     });
-    await expect(session.prMergedBanner()).not.toBeVisible();
 
     await session.taskInSidebar("Dismiss Banner Task A").first().click();
     await expect(session.chat.getByText("dismiss banner alpha response").last()).toBeVisible({

--- a/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
@@ -165,6 +165,92 @@ test.describe("Chat status bar", () => {
     );
   });
 
+  test("dismissed PR merged banner stays hidden across reload and task switch", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const taskA = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Dismiss Banner Task A",
+      seedData.agentProfileId,
+      {
+        description: 'e2e:message("dismiss banner alpha response")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Dismiss Banner Task B",
+      seedData.agentProfileId,
+      {
+        description: 'e2e:message("dismiss banner beta response")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: taskA.id,
+      owner: "test-org",
+      repo: "test-repo",
+      pr_number: 404,
+      pr_url: "https://github.com/test-org/test-repo/pull/404",
+      pr_title: "Dismiss Test PR",
+      head_branch: "feature/dismiss",
+      base_branch: "main",
+      author_login: "test-user",
+      state: "merged",
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    const cardA = kanban.taskCardByTitle("Dismiss Banner Task A");
+    await expect(cardA).toBeVisible({ timeout: 30_000 });
+    await cardA.click();
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
+
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    await expect(session.chat.getByText("dismiss banner alpha response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Banner appears, then user dismisses it.
+    await expect(session.prMergedBanner()).toBeVisible({ timeout: 10_000 });
+    await session.prMergedDismissButton().click();
+    await expect(session.prMergedBanner()).not.toBeVisible();
+
+    // Persists across reload.
+    await testPage.reload();
+    await session.waitForLoad();
+    await expect(session.chat.getByText("dismiss banner alpha response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(session.prMergedBanner()).not.toBeVisible();
+
+    // Persists across task switch (away and back).
+    await session.taskInSidebar("Dismiss Banner Task B").first().click();
+    await expect(session.chat.getByText("dismiss banner beta response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(session.prMergedBanner()).not.toBeVisible();
+
+    await session.taskInSidebar("Dismiss Banner Task A").first().click();
+    await expect(session.chat.getByText("dismiss banner alpha response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(session.prMergedBanner()).not.toBeVisible();
+  });
+
   test("archive via PR banner switches to next task", async ({ testPage, apiClient, seedData }) => {
     test.setTimeout(90_000);
 

--- a/apps/web/lib/local-storage.test.ts
+++ b/apps/web/lib/local-storage.test.ts
@@ -5,8 +5,6 @@ import {
   wasPRMergedBannerDismissed,
 } from "./local-storage";
 
-const DISMISSED_KEY_PREFIX = "kandev.pr-merged-banner-dismissed.";
-
 describe("PR merged banner dismissal storage", () => {
   beforeEach(() => {
     window.sessionStorage.clear();
@@ -21,7 +19,6 @@ describe("PR merged banner dismissal storage", () => {
 
     expect(wasPRMergedBannerDismissed("task-a")).toBe(true);
     expect(wasPRMergedBannerDismissed("task-b")).toBe(false);
-    expect(window.sessionStorage.getItem(`${DISMISSED_KEY_PREFIX}task-a`)).toBe("1");
   });
 
   it("clears the dismissal flag via cleanupTaskStorage", () => {

--- a/apps/web/lib/local-storage.test.ts
+++ b/apps/web/lib/local-storage.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTaskStorage,
+  markPRMergedBannerDismissed,
+  wasPRMergedBannerDismissed,
+} from "./local-storage";
+
+const DISMISSED_KEY_PREFIX = "kandev.pr-merged-banner-dismissed.";
+
+describe("PR merged banner dismissal storage", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("returns false when no dismissal has been recorded", () => {
+    expect(wasPRMergedBannerDismissed("task-a")).toBe(false);
+  });
+
+  it("persists dismissal per task and reads it back", () => {
+    markPRMergedBannerDismissed("task-a");
+
+    expect(wasPRMergedBannerDismissed("task-a")).toBe(true);
+    expect(wasPRMergedBannerDismissed("task-b")).toBe(false);
+    expect(window.sessionStorage.getItem(`${DISMISSED_KEY_PREFIX}task-a`)).toBe("1");
+  });
+
+  it("clears the dismissal flag via cleanupTaskStorage", () => {
+    markPRMergedBannerDismissed("task-a");
+    markPRMergedBannerDismissed("task-b");
+
+    cleanupTaskStorage("task-a", []);
+
+    expect(wasPRMergedBannerDismissed("task-a")).toBe(false);
+    expect(wasPRMergedBannerDismissed("task-b")).toBe(true);
+  });
+});

--- a/apps/web/lib/local-storage.ts
+++ b/apps/web/lib/local-storage.ts
@@ -364,6 +364,28 @@ export function markPRPanelOffered(sessionId: string): void {
   }
 }
 
+// PR merged banner dismissal — per-task, survives reload + task switch within
+// the tab session, resets on tab close.
+const PR_MERGED_BANNER_DISMISSED_PREFIX = "kandev.pr-merged-banner-dismissed.";
+
+export function wasPRMergedBannerDismissed(taskId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(`${PR_MERGED_BANNER_DISMISSED_PREFIX}${taskId}`) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markPRMergedBannerDismissed(taskId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(`${PR_MERGED_BANNER_DISMISSED_PREFIX}${taskId}`, "1");
+  } catch {
+    // Ignore write failures
+  }
+}
+
 // Internal storage keys for open file tabs
 const OPEN_FILES_KEY = "kandev.openFiles";
 const ACTIVE_TAB_KEY = "kandev.activeTab";
@@ -572,6 +594,9 @@ export function cleanupTaskStorage(
 ): void {
   // Plan notification (localStorage, keyed per task inside a Record)
   setPlanLastSeen(taskId, null);
+
+  // PR merged banner dismissal (sessionStorage, keyed per task)
+  removeSessionStorage(`${PR_MERGED_BANNER_DISMISSED_PREFIX}${taskId}`);
 
   // Sidebar collapsed-subtask set (sessionStorage, array keyed by parent taskId)
   const collapsed = getStoredCollapsedSubtaskParents();


### PR DESCRIPTION
The "PR has been merged" banner above the chat input previously reappeared every time the chat-input component remounted (page refresh, task switch), forcing users to dismiss it on every visit. Dismissal now persists per task in `sessionStorage`, so the banner stays hidden across reloads and task switches within the tab and resets only on tab close.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` (full web suite, 2477 tests pass — includes new unit tests for `wasPRMergedBannerDismissed` / `markPRMergedBannerDismissed` / `cleanupTaskStorage` integration)
- `make -C apps/backend test lint`
- New Playwright e2e: dismiss → reload → switch task and back, banner stays hidden in all cases

## Possible Improvements

Low risk. The dismissal key is included in `cleanupTaskStorage` so deleted tasks don't leak storage; sessionStorage scope means worst case is the banner doesn't come back during a tab session, which matches the user's intent.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.