### PR TITLE
fix: inherit parent workspace for subtasks (UI + MCP)

### DIFF
--- a/apps/backend/internal/orchestrator/handoff_inheritance_test.go
+++ b/apps/backend/internal/orchestrator/handoff_inheritance_test.go
@@ -67,6 +67,49 @@ func TestInheritFromParentEnvironment_FallsBackToGroupEnv(t *testing.T) {
 	}
 }
 
+// RC1 regression: inherited-environment propagation must run on the direct
+// start path (prepareSessionForStart), not only PrepareTaskSession. MCP-created
+// subtasks auto-start through startTask, which prepares the session via
+// prepareSessionForStart. Without propagation there, an inherit_parent subtask
+// would provision a fresh worktree instead of reusing the parent's.
+func TestPrepareSessionForStart_PropagatesInheritedEnvironment(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), newMockTaskRepo(), &mockAgentManager{repoForExecutionLookup: repo})
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	ws := &models.Workspace{ID: "ws1", Name: "WS", CreatedAt: now, UpdatedAt: now}
+	_ = repo.CreateWorkspace(ctx, ws)
+	wf := &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}
+	_ = repo.CreateWorkflow(ctx, wf)
+	parent := &models.Task{ID: "parent", WorkspaceID: "ws1", WorkflowID: "wf1", Title: "P", State: v1.TaskStateInProgress, CreatedAt: now, UpdatedAt: now}
+	_ = repo.CreateTask(ctx, parent)
+	child := &models.Task{ID: "child", ParentID: "parent", WorkspaceID: "ws1", WorkflowID: "wf1", Title: "C", State: v1.TaskStateInProgress, CreatedAt: now, UpdatedAt: now}
+	_ = repo.CreateTask(ctx, child)
+	_ = repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "ps1", TaskID: "parent", State: models.TaskSessionStateRunning,
+		IsPrimary: true, TaskEnvironmentID: "env-parent", StartedAt: now, UpdatedAt: now,
+	})
+
+	childTask := &v1.Task{
+		ID:       "child",
+		ParentID: "parent",
+		Metadata: map[string]interface{}{"workspace": map[string]interface{}{"mode": "inherit_parent"}},
+	}
+	sessionID, err := svc.prepareSessionForStart(ctx, childTask, "profile-1", "exec-1", "", "")
+	if err != nil {
+		t.Fatalf("prepareSessionForStart: %v", err)
+	}
+
+	got, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil || got == nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.TaskEnvironmentID != "env-parent" {
+		t.Errorf("TaskEnvironmentID = %q, want env-parent (inherited via start path)", got.TaskEnvironmentID)
+	}
+}
+
 // When the parent has a primary session with an env, that takes
 // precedence over the group fallback.
 func TestInheritFromParentEnvironment_ParentSessionWins(t *testing.T) {

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -161,6 +161,8 @@ func (s *Service) PrepareTaskSession(ctx context.Context, taskID string, agentPr
 
 	// Create session entry in database. Office tasks route through
 	// EnsureSessionForAgent so runs + advanced-mode reuse one row.
+	// prepareSessionForStart also propagates any inherited workspace
+	// environment (inherit_parent / shared_group) onto the new session.
 	sessionID, err := s.prepareSessionForStart(ctx, task, agentProfileID, executorID, executorProfileID, workflowStepID)
 	if err != nil {
 		s.logger.Error("failed to prepare session",
@@ -168,15 +170,6 @@ func (s *Service) PrepareTaskSession(ctx context.Context, taskID string, agentPr
 			zap.Error(err))
 		return "", err
 	}
-
-	// Office task-handoffs phase 4: when this task's workspace policy says
-	// inherit_parent, propagate the parent task's primary-session
-	// TaskEnvironmentID to the new session so executor lookup binds to the
-	// existing materialized environment instead of provisioning a fresh one.
-	// shared_group is handled the same way once the group has been
-	// materialized by an earlier launch — we look up the group's
-	// MaterializedEnvironmentID via the same propagation hook.
-	s.propagateInheritedEnvironment(ctx, task, sessionID)
 
 	// Notify the frontend that a new CREATED session exists. The start path
 	// transitions through updateTaskSessionState which broadcasts; the prepare
@@ -621,11 +614,32 @@ func (s *Service) isOfficeTask(ctx context.Context, taskID string) bool {
 	return err == nil && dbTask != nil && dbTask.AssigneeAgentProfileID != ""
 }
 
-// prepareSessionForStart picks the right session-creation path for the task:
+// prepareSessionForStart creates the session for a launch and propagates any
+// inherited workspace environment onto it.
+//
+// The propagation (inherit_parent / shared_group) lives here rather than only
+// in PrepareTaskSession so every launch entry point inherits consistently —
+// including the direct start path (startTask), which MCP-created subtasks reach
+// via auto-start. Without this, an inherit_parent subtask launched through
+// startTask would provision a fresh worktree instead of reusing the parent's.
+// propagateInheritedEnvironment is a no-op for tasks without a workspace policy.
+func (s *Service) prepareSessionForStart(
+	ctx context.Context, task *v1.Task,
+	agentProfileID, executorID, executorProfileID, workflowStepID string,
+) (string, error) {
+	sessionID, err := s.createStartSession(ctx, task, agentProfileID, executorID, executorProfileID, workflowStepID)
+	if err != nil {
+		return "", err
+	}
+	s.propagateInheritedEnvironment(ctx, task, sessionID)
+	return sessionID, nil
+}
+
+// createStartSession picks the right session-creation path for the task:
 // office tasks with an assignee use the per-(task, agent) EnsureSessionForAgent
 // (so runs reuse one row across turns); kanban / quick-chat fall through to
 // the per-launch PrepareSession used since day one.
-func (s *Service) prepareSessionForStart(
+func (s *Service) createStartSession(
 	ctx context.Context, task *v1.Task,
 	agentProfileID, executorID, executorProfileID, workflowStepID string,
 ) (string, error) {

--- a/apps/backend/internal/task/service/service_child_task_test.go
+++ b/apps/backend/internal/task/service/service_child_task_test.go
@@ -79,6 +79,99 @@ func TestCreateChildTask_OverridesWorkflow(t *testing.T) {
 	}
 }
 
+func TestCreateTask_Subtask_InheritsParentRepositories(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	if err := repo.CreateRepository(ctx, &models.Repository{ID: "repo-x", WorkspaceID: "ws-1", Name: "Repo"}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	parent, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Parent",
+		ProjectID:   "proj-1",
+		Repositories: []TaskRepositoryInput{{
+			RepositoryID:   "repo-x",
+			BaseBranch:     "main",
+			CheckoutBranch: "feature/parent",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	// Child created without explicit repositories — mirrors the UI inherit_parent
+	// flow, which omits repositories expecting the backend to inherit them.
+	child, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Child",
+		ParentID:    parent.ID,
+		ProjectID:   "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	childRepos, err := repo.ListTaskRepositories(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("ListTaskRepositories: %v", err)
+	}
+	if len(childRepos) != 1 {
+		t.Fatalf("child repos = %d, want 1 inherited from parent", len(childRepos))
+	}
+	if childRepos[0].RepositoryID != "repo-x" {
+		t.Errorf("repository_id = %q, want repo-x", childRepos[0].RepositoryID)
+	}
+	if childRepos[0].BaseBranch != "main" {
+		t.Errorf("base_branch = %q, want inherited main", childRepos[0].BaseBranch)
+	}
+	// CheckoutBranch is dropped: two worktrees can't share a working branch.
+	if childRepos[0].CheckoutBranch != "" {
+		t.Errorf("checkout_branch = %q, want empty (dropped on inherit)", childRepos[0].CheckoutBranch)
+	}
+}
+
+func TestCreateTask_Subtask_ExplicitRepositoriesNotOverridden(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"repo-a", "repo-b"} {
+		if err := repo.CreateRepository(ctx, &models.Repository{ID: id, WorkspaceID: "ws-1", Name: id}); err != nil {
+			t.Fatalf("CreateRepository %s: %v", id, err)
+		}
+	}
+
+	parent, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID:  "ws-1",
+		Title:        "Parent",
+		ProjectID:    "proj-1",
+		Repositories: []TaskRepositoryInput{{RepositoryID: "repo-a", BaseBranch: "main"}},
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	child, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID:  "ws-1",
+		Title:        "Child",
+		ParentID:     parent.ID,
+		ProjectID:    "proj-1",
+		Repositories: []TaskRepositoryInput{{RepositoryID: "repo-b", BaseBranch: "dev"}},
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	childRepos, err := repo.ListTaskRepositories(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("ListTaskRepositories: %v", err)
+	}
+	if len(childRepos) != 1 || childRepos[0].RepositoryID != "repo-b" {
+		t.Fatalf("child repos = %+v, want only explicit repo-b", childRepos)
+	}
+}
+
 func TestCreateChildTask_RequiresParent(t *testing.T) {
 	svc, _ := setupOfficeTest(t)
 	_, err := svc.CreateChildTask(context.Background(), nil, ChildTaskSpec{Title: "X"})

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -58,7 +58,9 @@ func (s *Service) CreateTask(ctx context.Context, req *CreateTaskRequest) (*mode
 	// an inherit_parent subtask resolves a repo at launch and can reuse the
 	// parent's worktree (the UI omits repositories expecting this). Mirrors the
 	// MCP create_task path so UI- and agent-created subtasks behave identically.
-	s.inheritParentRepositories(ctx, req)
+	if err := s.inheritParentRepositories(ctx, req); err != nil {
+		return nil, err
+	}
 
 	// For office tasks, resolve workflow from workspace
 	if isOfficeRequest(req) && req.WorkflowID == "" {
@@ -108,22 +110,26 @@ func (s *Service) CreateTask(ctx context.Context, req *CreateTaskRequest) (*mode
 }
 
 // inheritParentRepositories fills req.Repositories from the parent task when a
-// subtask is created without explicit repositories. RepositoryID and BaseBranch
-// carry over; CheckoutBranch is dropped on purpose because two worktrees can't
-// share a working branch, so the subtask branches off the same base as the
-// parent. Mirrors the MCP create_task path (mcp/handlers.inheritedRepoInputs)
-// so UI- and agent-created subtasks behave identically. A subtask with no
-// repositories can't establish a worktree, which is what blocked inherit_parent
-// from reusing the parent's worktree on the HTTP path.
-func (s *Service) inheritParentRepositories(ctx context.Context, req *CreateTaskRequest) {
+// subtask is created without explicit repositories. This applies to any
+// repo-less subtask (not only inherit_parent ones), matching the MCP
+// create_task path (mcp/handlers.inheritedRepoInputs) so UI- and agent-created
+// subtasks behave identically — the UI's new_workspace mode always sends repos,
+// so in practice only inherit_parent reaches here empty. RepositoryID and
+// BaseBranch carry over; CheckoutBranch is dropped on purpose because two
+// worktrees can't share a working branch, so the subtask branches off the same
+// base as the parent.
+//
+// A lookup failure is returned rather than swallowed: a subtask silently
+// created with no repositories can't establish a worktree, which would
+// reintroduce the exact fresh-worktree bug this inheritance is meant to fix —
+// failing fast surfaces the problem at creation time instead.
+func (s *Service) inheritParentRepositories(ctx context.Context, req *CreateTaskRequest) error {
 	if req.ParentID == "" || len(req.Repositories) > 0 {
-		return
+		return nil
 	}
 	parentRepos, err := s.taskRepos.ListTaskRepositories(ctx, req.ParentID)
 	if err != nil {
-		s.logger.Warn("failed to list parent repositories for subtask inheritance",
-			zap.String("parent_id", req.ParentID), zap.Error(err))
-		return
+		return fmt.Errorf("list parent repositories for subtask inheritance: %w", err)
 	}
 	inherited := make([]TaskRepositoryInput, 0, len(parentRepos))
 	for _, r := range parentRepos {
@@ -138,6 +144,7 @@ func (s *Service) inheritParentRepositories(ctx context.Context, req *CreateTask
 	if len(inherited) > 0 {
 		req.Repositories = inherited
 	}
+	return nil
 }
 
 // validateCreateTaskRequest validates constraints for task creation.

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -54,6 +54,12 @@ func (s *Service) CreateTask(ctx context.Context, req *CreateTaskRequest) (*mode
 		return nil, err
 	}
 
+	// Subtasks created without explicit repositories inherit the parent's, so
+	// an inherit_parent subtask resolves a repo at launch and can reuse the
+	// parent's worktree (the UI omits repositories expecting this). Mirrors the
+	// MCP create_task path so UI- and agent-created subtasks behave identically.
+	s.inheritParentRepositories(ctx, req)
+
 	// For office tasks, resolve workflow from workspace
 	if isOfficeRequest(req) && req.WorkflowID == "" {
 		if err := s.resolveOfficeWorkflow(ctx, req); err != nil {
@@ -99,6 +105,39 @@ func (s *Service) CreateTask(ctx context.Context, req *CreateTaskRequest) (*mode
 	s.logger.Info("task created", zap.String("task_id", task.ID), zap.String("title", task.Title))
 
 	return task, nil
+}
+
+// inheritParentRepositories fills req.Repositories from the parent task when a
+// subtask is created without explicit repositories. RepositoryID and BaseBranch
+// carry over; CheckoutBranch is dropped on purpose because two worktrees can't
+// share a working branch, so the subtask branches off the same base as the
+// parent. Mirrors the MCP create_task path (mcp/handlers.inheritedRepoInputs)
+// so UI- and agent-created subtasks behave identically. A subtask with no
+// repositories can't establish a worktree, which is what blocked inherit_parent
+// from reusing the parent's worktree on the HTTP path.
+func (s *Service) inheritParentRepositories(ctx context.Context, req *CreateTaskRequest) {
+	if req.ParentID == "" || len(req.Repositories) > 0 {
+		return
+	}
+	parentRepos, err := s.taskRepos.ListTaskRepositories(ctx, req.ParentID)
+	if err != nil {
+		s.logger.Warn("failed to list parent repositories for subtask inheritance",
+			zap.String("parent_id", req.ParentID), zap.Error(err))
+		return
+	}
+	inherited := make([]TaskRepositoryInput, 0, len(parentRepos))
+	for _, r := range parentRepos {
+		if r == nil || r.RepositoryID == "" {
+			continue
+		}
+		inherited = append(inherited, TaskRepositoryInput{
+			RepositoryID: r.RepositoryID,
+			BaseBranch:   r.BaseBranch,
+		})
+	}
+	if len(inherited) > 0 {
+		req.Repositories = inherited
+	}
 }
 
 // validateCreateTaskRequest validates constraints for task creation.

--- a/apps/web/components/task/new-subtask-form-parts.tsx
+++ b/apps/web/components/task/new-subtask-form-parts.tsx
@@ -45,6 +45,12 @@ type SelectorsRowProps = {
   onAgentProfileChange: (value: string) => void;
   onExecutorProfileChange: (value: string) => void;
   disabled: boolean;
+  /**
+   * When true, hide the executor-profile selector. The subtask reuses the
+   * parent's materialized environment (inherit_parent), so choosing an
+   * executor would be meaningless — the parent's executor is always used.
+   */
+  hideExecutor: boolean;
 };
 
 export function SelectorsRow({
@@ -55,10 +61,11 @@ export function SelectorsRow({
   onAgentProfileChange,
   onExecutorProfileChange,
   disabled,
+  hideExecutor,
 }: SelectorsRowProps) {
   const noAgents = profileOptions.length === 0;
   return (
-    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
+    <div className={"grid gap-4 grid-cols-1" + (hideExecutor ? "" : " sm:grid-cols-2")}>
       <div>
         <AgentSelector
           options={profileOptions}
@@ -68,15 +75,17 @@ export function SelectorsRow({
           placeholder={noAgents ? "No agents found" : "Select agent profile"}
         />
       </div>
-      <div>
-        <ExecutorProfileSelector
-          options={executorProfileOptions}
-          value={executorProfileId}
-          onValueChange={onExecutorProfileChange}
-          disabled={disabled}
-          placeholder="Select executor profile"
-        />
-      </div>
+      {!hideExecutor && (
+        <div>
+          <ExecutorProfileSelector
+            options={executorProfileOptions}
+            value={executorProfileId}
+            onValueChange={onExecutorProfileChange}
+            disabled={disabled}
+            placeholder="Select executor profile"
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -344,6 +353,21 @@ function WorkspaceModeOption({
   );
 }
 
+// Worktree badge shows only when the subtask still targets the parent's repo
+// (single chip, same id). Adding repos or pasting a URL makes it ambiguous.
+function shouldShowWorktreeBadge(
+  fs: ReturnType<typeof useSubtaskFormState>,
+  worktreeBranch: string | null,
+  parentRepositoryId: string | null,
+): boolean {
+  return (
+    !!worktreeBranch &&
+    fs.repositories.length === 1 &&
+    fs.repositories[0]?.repositoryId === parentRepositoryId &&
+    !fs.useGitHubUrl
+  );
+}
+
 /**
  * Renders the entire subtask form body (title input, repo chips, selectors,
  * context picker, prompt zone, footer). Extracted from `NewSubtaskForm` so
@@ -374,13 +398,7 @@ export function SubtaskFormBody({
   onClose,
   onSubmit,
 }: SubtaskFormBodyProps) {
-  // Worktree badge only when subtask still targets parent's repo (single chip,
-  // same id). Adding repos or pasting a URL makes it ambiguous, so hide.
-  const showWorktreeBadge =
-    !!worktreeBranch &&
-    fs.repositories.length === 1 &&
-    fs.repositories[0]?.repositoryId === parentRepositoryId &&
-    !fs.useGitHubUrl;
+  const showWorktreeBadge = shouldShowWorktreeBadge(fs, worktreeBranch, parentRepositoryId);
   const inheritParent = workspaceMode === "inherit_parent";
   return (
     <form onSubmit={onSubmit} className="space-y-4">
@@ -421,6 +439,7 @@ export function SubtaskFormBody({
         onAgentProfileChange={handlers.handleAgentProfileChange}
         onExecutorProfileChange={handlers.handleExecutorProfileChange}
         disabled={isCreating}
+        hideExecutor={inheritParent}
       />
       <ContextSelect
         value={contextValue}

--- a/apps/web/components/task/use-subtask-submit.ts
+++ b/apps/web/components/task/use-subtask-submit.ts
@@ -83,7 +83,10 @@ export function useSubtaskSubmit(opts: UseSubtaskSubmitOpts) {
         repositories,
         start_agent: true,
         agent_profile_id: fs.agentProfileId || defaultProfileId || undefined,
-        executor_profile_id: fs.executorProfileId || undefined,
+        // inherit_parent reuses the parent's materialized environment, so the
+        // executor is inherited too — never send a chosen executor profile.
+        executor_profile_id:
+          workspaceMode === "inherit_parent" ? undefined : fs.executorProfileId || undefined,
         parent_id: parentTaskId,
         attachments: toMessageAttachments(attachments),
         workspace_mode: workspaceMode,


### PR DESCRIPTION
Subtasks created with "inherit parent workspace" were spinning up a brand-new worktree and `/tasks` folder instead of reusing the parent's materialized environment; now both the UI and MCP creation paths bind the child to the parent's workspace and the executor choice is hidden when it would be meaningless.

## Important Changes

- Moved `propagateInheritedEnvironment` into `prepareSessionForStart` so every launch entry point inherits — previously only `PrepareTaskSession` did, leaving the direct start path (MCP auto-start) to provision a fresh worktree.
- Service `CreateTask` now inherits the parent's repositories when a subtask supplies none (UI omits them by design), mirroring the MCP path — a repo-less child could never establish or reuse a worktree.
- Subtask dialog hides the executor-profile selector and omits `executor_profile_id` under `inherit_parent`, since the parent's executor is always reused.

## Validation

- `go test ./internal/task/service/ ./internal/orchestrator/ ./internal/mcp/... ./internal/task/handlers/...` (pass)
- `go build ./...`, `go vet`, `golangci-lint run` (clean)
- `pnpm --filter @kandev/web typecheck` + `eslint` on changed files (clean)
- New regression tests: start-path env propagation; subtask repo inheritance (inherits base branch, drops checkout branch, explicit repos not overridden)
- Not run: live browser / e2e of the end-to-end worktree-reuse flow (needs a running instance with a launched parent task)

## Possible Improvements

Low risk. Edge case left as-is: via MCP, passing a *different* executor profile alongside `inherit_parent` trips the executor-type-mismatch guard and skips reuse.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (\`apps/web/\`), I have added or updated Playwright e2e tests in \`apps/web/e2e/\` and verified them with \`make test-e2e\`.