### PR TITLE
feat: surface subagent task tool calls as cards in task chat

### DIFF
--- a/.agents/skills/acp-debug/SKILL.md
+++ b/.agents/skills/acp-debug/SKILL.md
@@ -29,10 +29,16 @@ test -x apps/backend/bin/acpdbg || make -C apps/backend build-acpdbg
 acpdbg list                                            # enumerate registered ACP agents
 acpdbg probe <agent>                                   # initialize + session/new + close
 acpdbg probe --exec "<cmd> [args...]"                  # probe an arbitrary binary not in the registry
-acpdbg prompt <agent> --prompt "..." [--model M] [--mode M]
-acpdbg session-load <agent> --session-id <id>
+acpdbg prompt --prompt "..." [--model M] [--mode M] <agent>
+acpdbg session-load --session-id <id> <agent>
 acpdbg matrix                                          # probe every ACP agent in parallel
 ```
+
+> **Flags MUST come before the positional `<agent>`.** The CLI uses Go's stdlib
+> `flag` parser, which stops at the first non-flag token — so any flag placed
+> *after* `<agent>` is silently ignored (`probe`/`matrix`, e.g. a dropped
+> `--timeout`) or errors (`prompt` → `--prompt is required`). Always write
+> `acpdbg prompt --prompt "..." --timeout 240s <agent>`, not `acpdbg prompt <agent> --prompt ...`.
 
 **Shared flags** (apply to every sub-command):
 - `--out DIR` — JSONL output directory (default `./acp-debug/`)
@@ -49,9 +55,9 @@ acpdbg matrix                                          # probe every ACP agent i
 ### 1. Pick the sub-command that matches the user's intent
 
 - "what models does X have" / "does X support modes" → `acpdbg probe X`
-- "test a prompt against X" → `acpdbg prompt X --prompt "..."`
+- "test a prompt against X" → `acpdbg prompt --prompt "..." X`
 - "compare all agents" / "run the matrix" → `acpdbg matrix`
-- "resume session <id>" → `acpdbg session-load X --session-id <id>`
+- "resume session <id>" → `acpdbg session-load --session-id <id> X`
 - "try this random binary" → `acpdbg probe --exec "path/to/bin --acp"`
 
 ### 2. Run the command

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -216,4 +216,4 @@ When you hit a limit, extract a helper function. Prefer composition over growing
 - `internal/agentctl/AGENTS.md` — agentctl server route groups, adapter model, ACP protocol
 - `internal/agentctl/server/api/AGENTS.md` — reverse-proxy body rewriting (`Accept-Encoding`), iframe-blocking header stripping
 - `internal/integrations/AGENTS.md` — playbook for adding a new third-party integration (Jira/Linear pattern)
-- `cmd/mock-agent/AGENTS.md` — predefined `/e2e:<name>` scenarios vs inline `e2e:...` scripts; recipe for adding a scenario to reproduce agent-output rendering bugs locally
+- `cmd/mock-agent/AGENTS.md` — predefined `/e2e:<name>` scenarios vs inline `e2e:...` scripts, recipe for adding a scenario, and the rebuild-before-e2e requirement

--- a/apps/backend/cmd/mock-agent/AGENTS.md
+++ b/apps/backend/cmd/mock-agent/AGENTS.md
@@ -12,7 +12,7 @@ Friendly aliases live in `handler.go` next to the dispatcher: `/ask-single`, `/a
 
 **2. Inline scripts — `e2e:<directive>(...)`**
 
-`script.go` parses prompts starting with `e2e:` (no leading slash) as multi-line scripts. Supported directives include `e2e:message(...)`, `e2e:thinking(...)`, `e2e:tool_use("Name", {...})`, `e2e:tool_result(...)`, `e2e:delay(ms)`, and the MCP-flavoured `e2e:mcp:kandev:<tool>({...})`. Comments start with `#`, blank lines are ignored. Tests live in `script_test.go`.
+`script.go` parses prompts starting with `e2e:` (no leading slash) as multi-line scripts. Supported directives include `e2e:message(...)`, `e2e:thinking(...)`, `e2e:tool_use("Name", {...})`, `e2e:tool_result(...)`, `e2e:delay(ms)`, the Monitor-flavoured `e2e:monitor_start/event/end`, and the MCP-flavoured `e2e:mcp:kandev:<tool>({...})`. Comments start with `#`, blank lines are ignored. Tests live in `script_test.go`.
 
 Use predefined scenarios for anything you want to trigger from the slash menu or replay across sessions; use inline scripts for ad-hoc shapes inside a single E2E spec or manual session.
 
@@ -33,8 +33,22 @@ This avoids burning real-agent tokens, gives you a deterministic payload to iter
 - `e.text(s)` / `e.thought(s)` — plain agent message vs reasoning channel.
 - `e.startTool(id, title, kind, input, locs...)` / `e.completeTool(id, output)` — paired tool-call lifecycle.
 - `e.plan(entries)` — ACP plan updates.
-- `e.startMonitorTool(id, taskID, command)` / `e.emitMonitorEvent(taskID, body)` / `e.endMonitorTool(id)` — reproduces the two-frame Monitor wire pattern the kandev ACP adapter recognises. Use these instead of building raw `SessionNotification`s when you need to test the Monitor recogniser path; they embed the correct `_meta.claudeCode.toolName=Monitor` shape.
+- `e.startMonitorTool(id, taskID, command)` / `e.emitMonitorEvent(taskID, body)` / `e.endMonitorTool(id)` — reproduces the two-frame Monitor wire pattern the kandev ACP adapter recognises.
+- `e.startSubagentTool(...)` / `e.completeSubagentTool(...)` — claude-style subagent (Task) frames with the `_meta.claudeCode` Agent marker and result metrics.
 - `e.requestPermission(...)` — interactive permission flow for scenarios that need an Allow/Reject decision.
+
+### Emitting `_meta`-tagged tool calls
+
+The acp-go-sdk has no `WithStartMeta`/`WithUpdateMeta`. To reproduce claude-agent-acp's `_meta.claudeCode.*` wire shape (`Monitor`, `Agent`-subagent), set `tc.Meta` via a local option closure — see `startMonitorTool` / `startSubagentTool` in `emitter.go`. Use these instead of building raw `SessionNotification`s when you need to exercise the adapter's `_meta` recognisers.
+
+## Rebuild before running e2e (easy to miss)
+
+The web e2e suite runs the **prebuilt host binary** `apps/backend/bin/mock-agent` (resolved via `PATH`); the `containers` project additionally uses `bin/mock-agent-linux-amd64`. `global-setup.ts` only checks the binary **exists**, not that it's current — so a stale binary silently runs the OLD behavior and your new scenario/edit won't take effect. After changing anything under `cmd/mock-agent`:
+
+```bash
+make -C apps/backend build-mock-agent          # host binary (default suite)
+make -C apps/backend build-mock-agent-linux    # only for the `containers` project
+```
 
 ## Tests
 

--- a/apps/backend/cmd/mock-agent/emitter.go
+++ b/apps/backend/cmd/mock-agent/emitter.go
@@ -174,6 +174,87 @@ func (e *emitter) endMonitorTool(id acp.ToolCallId) {
 	})
 }
 
+// subagent meta keys/values claude-agent-acp uses under
+// `_meta.claudeCode.toolResponse`. Pulled out so goconst stays happy.
+const (
+	subagentKeyStatus       = "status"
+	subagentStatusCompleted = "completed"
+)
+
+// subagentClaudeMeta builds the `_meta.claudeCode.toolName=Agent` payload that
+// claude-agent-acp tags subagent (Task) tool_call notifications with. The
+// kandev ACP adapter recognizes subagents by this marker.
+func subagentClaudeMeta() any {
+	return map[string]any{"claudeCode": map[string]any{"toolName": "Agent"}}
+}
+
+// subagentResult describes the result metadata claude-agent-acp reports for a
+// finished subagent under `_meta.claudeCode.toolResponse`.
+type subagentResult struct {
+	agentID      string
+	subagentType string
+	durationMs   int64
+	totalTokens  int64
+	toolUseCount int
+}
+
+// subagentClaudeMetaWithResponse embeds a `toolResponse` block mirroring the
+// real claude-agent-acp completion frame so the kandev adapter's
+// EnrichSubagentResult populates every metric the UI renders.
+func subagentClaudeMetaWithResponse(r subagentResult) any {
+	return map[string]any{
+		"claudeCode": map[string]any{
+			"toolName": "Agent",
+			"toolResponse": map[string]any{
+				"agentId":           r.agentID,
+				"agentType":         r.subagentType,
+				subagentKeyStatus:   subagentStatusCompleted,
+				"totalDurationMs":   r.durationMs,
+				"totalTokens":       r.totalTokens,
+				"totalToolUseCount": r.toolUseCount,
+			},
+		},
+	}
+}
+
+// startSubagentTool emits the initial subagent tool_call (status=pending) in
+// claude-agent-acp's wire shape: title "Task", kind Other, the Agent meta
+// marker, and rawInput carrying description/prompt/subagent_type.
+func (e *emitter) startSubagentTool(id acp.ToolCallId, description, prompt, subagentType string) {
+	withStartMeta := func(meta any) acp.ToolCallStartOpt {
+		return func(tc *acp.SessionUpdateToolCall) { tc.Meta = toMetaMap(meta) }
+	}
+	_ = e.conn.SessionUpdate(e.ctx, acp.SessionNotification{
+		SessionId: e.sid,
+		Update: acp.StartToolCall(id, "Task",
+			acp.WithStartKind(acp.ToolKindOther),
+			acp.WithStartStatus(acp.ToolCallStatusPending),
+			acp.WithStartRawInput(map[string]any{
+				clarificationDescKey:   description,
+				clarificationPromptKey: prompt,
+				"subagent_type":        subagentType,
+			}),
+			withStartMeta(subagentClaudeMeta()),
+		),
+	})
+}
+
+// completeSubagentTool emits the terminal subagent tool_call_update with the
+// result text and the `toolResponse` metadata block.
+func (e *emitter) completeSubagentTool(id acp.ToolCallId, resultText string, r subagentResult) {
+	withUpdateMeta := func(meta any) acp.ToolCallUpdateOpt {
+		return func(tu *acp.SessionToolCallUpdate) { tu.Meta = toMetaMap(meta) }
+	}
+	_ = e.conn.SessionUpdate(e.ctx, acp.SessionNotification{
+		SessionId: e.sid,
+		Update: acp.UpdateToolCall(id,
+			acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+			acp.WithUpdateRawOutput(resultText),
+			withUpdateMeta(subagentClaudeMetaWithResponse(r)),
+		),
+	})
+}
+
 // requestPermission asks the client for permission to proceed with a tool call.
 // Returns true if permission was granted, false otherwise.
 func (e *emitter) requestPermission(toolCallID acp.ToolCallId, title string, kind acp.ToolKind, input any) bool {

--- a/apps/backend/cmd/mock-agent/emitter.go
+++ b/apps/backend/cmd/mock-agent/emitter.go
@@ -179,6 +179,9 @@ func (e *emitter) endMonitorTool(id acp.ToolCallId) {
 const (
 	subagentKeyStatus       = "status"
 	subagentStatusCompleted = "completed"
+	subagentKeyDescription  = "description"
+	subagentKeyPrompt       = "prompt"
+	subagentKeySubagentType = "subagent_type"
 )
 
 // subagentClaudeMeta builds the `_meta.claudeCode.toolName=Agent` payload that
@@ -230,9 +233,9 @@ func (e *emitter) startSubagentTool(id acp.ToolCallId, description, prompt, suba
 			acp.WithStartKind(acp.ToolKindOther),
 			acp.WithStartStatus(acp.ToolCallStatusPending),
 			acp.WithStartRawInput(map[string]any{
-				clarificationDescKey:   description,
-				clarificationPromptKey: prompt,
-				"subagent_type":        subagentType,
+				subagentKeyDescription:  description,
+				subagentKeyPrompt:       prompt,
+				subagentKeySubagentType: subagentType,
 			}),
 			withStartMeta(subagentClaudeMeta()),
 		),

--- a/apps/backend/cmd/mock-agent/emitter.go
+++ b/apps/backend/cmd/mock-agent/emitter.go
@@ -258,6 +258,45 @@ func (e *emitter) completeSubagentTool(id acp.ToolCallId, resultText string, r s
 	})
 }
 
+// subagentChildMeta tags a tool call as a subagent's internal call via
+// `_meta.claudeCode.parentToolUseId`, mirroring claude-agent-acp so the kandev
+// adapter nests it under the parent Task card.
+func subagentChildMeta(parentToolUseID acp.ToolCallId) any {
+	return map[string]any{"claudeCode": map[string]any{"parentToolUseId": string(parentToolUseID)}}
+}
+
+// startChildTool emits a tool_call attributed to a parent subagent (Task).
+func (e *emitter) startChildTool(id, parent acp.ToolCallId, title string, kind acp.ToolKind, input any) {
+	withStartMeta := func(meta any) acp.ToolCallStartOpt {
+		return func(tc *acp.SessionUpdateToolCall) { tc.Meta = toMetaMap(meta) }
+	}
+	_ = e.conn.SessionUpdate(e.ctx, acp.SessionNotification{
+		SessionId: e.sid,
+		Update: acp.StartToolCall(id, title,
+			acp.WithStartKind(kind),
+			acp.WithStartStatus(acp.ToolCallStatusPending),
+			acp.WithStartRawInput(input),
+			withStartMeta(subagentChildMeta(parent)),
+		),
+	})
+}
+
+// completeChildTool completes a subagent child tool call, keeping the parent
+// attribution on the terminal frame too.
+func (e *emitter) completeChildTool(id, parent acp.ToolCallId, output any) {
+	withUpdateMeta := func(meta any) acp.ToolCallUpdateOpt {
+		return func(tu *acp.SessionToolCallUpdate) { tu.Meta = toMetaMap(meta) }
+	}
+	_ = e.conn.SessionUpdate(e.ctx, acp.SessionNotification{
+		SessionId: e.sid,
+		Update: acp.UpdateToolCall(id,
+			acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+			acp.WithUpdateRawOutput(output),
+			withUpdateMeta(subagentChildMeta(parent)),
+		),
+	})
+}
+
 // requestPermission asks the client for permission to proceed with a tool call.
 // Returns true if permission was granted, false otherwise.
 func (e *emitter) requestPermission(toolCallID acp.ToolCallId, title string, kind acp.ToolKind, input any) bool {

--- a/apps/backend/cmd/mock-agent/scenarios.go
+++ b/apps/backend/cmd/mock-agent/scenarios.go
@@ -206,6 +206,14 @@ func scenarioSubagent(e *emitter) {
 	fixedDelay(50)
 	e.text("Subagent working on the task...")
 
+	// A tool call the subagent runs internally, attributed to the Task via
+	// `_meta.claudeCode.parentToolUseId` so it nests under the subagent card.
+	childToolID := nextToolID()
+	e.startChildTool(childToolID, taskToolID, "sleep 30", acp.ToolKindExecute,
+		map[string]any{"command": "sleep 30"})
+	fixedDelay(50)
+	e.completeChildTool(childToolID, taskToolID, map[string]any{"output": ""})
+
 	fixedDelay(50)
 	e.completeSubagentTool(taskToolID, "E2E subagent completed", subagentResult{
 		agentID:      "agent_e2e_0001",

--- a/apps/backend/cmd/mock-agent/scenarios.go
+++ b/apps/backend/cmd/mock-agent/scenarios.go
@@ -190,22 +190,30 @@ func scenarioError(e *emitter) {
 	e.text("E2E test error: simulated failure")
 }
 
-// scenarioSubagent: subagent with child messages and fixed delays.
+// scenarioSubagent: a claude-style subagent (Task) tool call carrying the
+// `_meta.claudeCode` Agent marker and a toolResponse with full result metrics,
+// so the kandev adapter normalizes it to a subagent_task payload and the UI
+// renders the subagent card with metadata chips.
 func scenarioSubagent(e *emitter) {
 	taskToolID := nextToolID()
 	fixedDelay(50)
 
-	e.startTool(taskToolID, "E2E subagent test", acp.ToolKindOther,
-		map[string]any{
-			"description": "E2E subagent test",
-			"prompt":      "Run e2e subagent scenario",
-		})
+	e.startSubagentTool(taskToolID,
+		"Explore the codebase",
+		"Find all files and summarize the project structure",
+		"general-purpose")
 
 	fixedDelay(50)
 	e.text("Subagent working on the task...")
 
 	fixedDelay(50)
-	e.completeTool(taskToolID, map[string]any{"result": "E2E subagent completed"})
+	e.completeSubagentTool(taskToolID, "E2E subagent completed", subagentResult{
+		agentID:      "agent_e2e_0001",
+		subagentType: "general-purpose",
+		durationMs:   2200,
+		totalTokens:  9987,
+		toolUseCount: 3,
+	})
 
 	fixedDelay(50)
 	e.text("Subagent scenario complete.")

--- a/apps/backend/cmd/mock-agent/sequences.go
+++ b/apps/backend/cmd/mock-agent/sequences.go
@@ -121,16 +121,16 @@ func emitCodeSearch(e *emitter, model string) {
 	e.completeTool(toolID, map[string]any{"matches": strings.Join(results, "\n")})
 }
 
-// emitSubagent emits a Task tool call with child tool calls.
+// emitSubagent emits a claude-style subagent (Task) tool call plus a sibling
+// search tool call.
 func emitSubagent(e *emitter, model string) {
 	taskToolID := nextToolID()
 	randomDelay(model)
 
-	e.startTool(taskToolID, "Explore codebase", acp.ToolKindOther,
-		map[string]any{
-			"description": "Explore codebase",
-			"prompt":      "Find all files and summarize the project structure",
-		})
+	e.startSubagentTool(taskToolID,
+		"Explore codebase",
+		"Find all files and summarize the project structure",
+		"general-purpose")
 
 	randomDelay(model)
 	e.thought("Exploring the project structure...")
@@ -140,7 +140,7 @@ func emitSubagent(e *emitter, model string) {
 	e.text(fmt.Sprintf("Found %d files. The project structure looks well-organized.", len(paths)))
 	randomDelay(model)
 
-	// Child glob tool call
+	// Sibling glob tool call (subagents do not nest over ACP)
 	childToolID := nextToolID()
 	e.startTool(childToolID, "Glob **/*", acp.ToolKindSearch,
 		map[string]any{"pattern": "**/*"})
@@ -150,9 +150,15 @@ func emitSubagent(e *emitter, model string) {
 
 	e.text("Project structure analysis complete.")
 	randomDelay(model)
-	e.completeTool(taskToolID, map[string]any{
-		"result": fmt.Sprintf("Subagent completed: Found %d files across the project.", len(paths)),
-	})
+	e.completeSubagentTool(taskToolID,
+		fmt.Sprintf("Subagent completed: Found %d files across the project.", len(paths)),
+		subagentResult{
+			agentID:      "agent_dev_0001",
+			subagentType: "general-purpose",
+			durationMs:   1850,
+			totalTokens:  7421,
+			toolUseCount: 1,
+		})
 }
 
 // emitTodo emits a TodoWrite tool call.

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -59,6 +59,18 @@ Env knobs (all optional): `KANDEV_DEBUG_ACP_MAX_FILES` (default 200), `KANDEV_DE
 
 `claude-agent-acp` tags certain tool calls with `_meta.claudeCode.toolName` (e.g. `Monitor`, `ScheduleWakeup`, `Agent` for subagents) and may carry results in `_meta.claudeCode.toolResponse`. These are normalized into typed `streams.NormalizedPayload` kinds in `server/adapter/transport/acp/`. The established pattern is **one file per recognized tool** (`monitor.go`, `wakeup.go`, `subagent.go`), each with a defensive untyped-map recognizer (`recognize*`/`is*Meta`/`extract*`), a typed payload, and a sibling `*_test.go`. `convertToolCallUpdate` stashes `title`/`Meta` into the normalizer args; result enrichment happens in `convertToolCallResultUpdate`. To add another claude-acp meta-tool, copy that shape — don't inline detection in `adapter.go`. Detection can also be cross-agent: subagent recognition keys off Claude's `_meta`, OpenCode's tool `title`, and Cursor's `rawInput._toolName`.
 
+### Subagent tool-call nesting: what each agent emits
+
+Kandev renders subagents (the `Task` tool) as cards and *wants* to nest each subagent's internal tool calls under its card (via `parent_tool_call_id`, see `tool-subagent-message.tsx`). Reality differs per agent — verified from captured `~/.kandev/logs/acp/` frames of a "spawn 3 subagents that each run `sleep 30`" prompt:
+
+| Agent | Subagent-internal tool calls | Nestable? |
+|---|---|---|
+| **Claude** | emitted **flat on the parent session**, **no `parentToolCallId`** | No — children present but unlinked |
+| **Cursor** | **not emitted over ACP at all** (Task `tool_call_update` carries only `{durationMs, isBackground}`) | No — no child data exists |
+| **OpenCode** | emitted into a **separate child ACP session** (the `metadata.sessionId` we store as `SubagentTaskPayload.ChildSessionID`) | Only by merging that child session — they never reach the parent stream |
+
+Implications: a `parentToolCallId` field (whether upstream-provided or heuristically inferred) only helps the Claude/Cursor flat-stream case. **OpenCode needs a child-session merge** — fold the child session's tool calls into the card using the stored `child_session_id`. No timing heuristic can attribute flat parent-stream calls when multiple subagents run in parallel.
+
 ## Further scoped notes
 
 - `server/api/AGENTS.md` — reverse-proxy body rewriting (`Accept-Encoding`) and iframe-blocking header stripping.

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -65,11 +65,11 @@ Kandev renders subagents (the `Task` tool) as cards and *wants* to nest each sub
 
 | Agent | Subagent-internal tool calls | Nestable? |
 |---|---|---|
-| **Claude** | emitted **flat on the parent session**, **no `parentToolCallId`** | No — children present but unlinked |
+| **Claude** | emitted on the parent session, each tagged with **`_meta.claudeCode.parentToolUseId`** = the parent Task tool_call's id | **Yes** — `parentToolUseID()` reads it in `adapter_tools.go` and sets `AgentEvent.ParentToolCallID`, which becomes the message's `parent_tool_call_id` and nests under the card |
 | **Cursor** | **not emitted over ACP at all** (Task `tool_call_update` carries only `{durationMs, isBackground}`) | No — no child data exists |
-| **OpenCode** | emitted into a **separate child ACP session** (the `metadata.sessionId` we store as `SubagentTaskPayload.ChildSessionID`) | Only by merging that child session — they never reach the parent stream |
+| **OpenCode** | emitted into a **separate child ACP session** (the `metadata.sessionId` we store as `SubagentTaskPayload.ChildSessionID`) | Not yet — they never reach the parent stream; would require merging that child session via the stored `child_session_id` |
 
-Implications: a `parentToolCallId` field (whether upstream-provided or heuristically inferred) only helps the Claude/Cursor flat-stream case. **OpenCode needs a child-session merge** — fold the child session's tool calls into the card using the stored `child_session_id`. No timing heuristic can attribute flat parent-stream calls when multiple subagents run in parallel.
+Claude is the one that works today: `claude-agent-acp` (since PR #341) sets `_meta.claudeCode.parentToolUseId` on a subagent's internal calls, and its value already equals the parent Task tool_call id — so it maps straight onto our `parent_tool_call_id`. Cursor exposes nothing to nest. OpenCode needs a kandev-side child-session merge. (Top-level `parentToolCallId` is NOT in the ACP schema — `_meta` is the spec-compliant carrier.)
 
 ## Further scoped notes
 

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -53,6 +53,10 @@ Env knobs (all optional): `KANDEV_DEBUG_ACP_MAX_FILES` (default 200), `KANDEV_DE
 
 **PRIVACY / PERF:** frames carry the full prompt, file, and tool-call content. Keep this strictly behind the debug flag and local-dev-scoped — never enable in a shared/production deployment. When agentctl runs inside a Docker executor the files land *inside the container*, so this is meant for standalone/dev.
 
+### Recognizing claude-acp meta-tagged tools
+
+`claude-agent-acp` tags certain tool calls with `_meta.claudeCode.toolName` (e.g. `Monitor`, `ScheduleWakeup`, `Agent` for subagents) and may carry results in `_meta.claudeCode.toolResponse`. These are normalized into typed `streams.NormalizedPayload` kinds in `server/adapter/transport/acp/`. The established pattern is **one file per recognized tool** (`monitor.go`, `wakeup.go`, `subagent.go`), each with a defensive untyped-map recognizer (`recognize*`/`is*Meta`/`extract*`), a typed payload, and a sibling `*_test.go`. `convertToolCallUpdate` stashes `title`/`Meta` into the normalizer args; result enrichment happens in `convertToolCallResultUpdate`. To add another claude-acp meta-tool, copy that shape — don't inline detection in `adapter.go`. Detection can also be cross-agent: subagent recognition keys off Claude's `_meta`, OpenCode's tool `title`, and Cursor's `rawInput._toolName`.
+
 ## Further scoped notes
 
 - `server/api/AGENTS.md` — reverse-proxy body rewriting (`Accept-Encoding`) and iframe-blocking header stripping.

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -35,6 +35,8 @@ Protocol adapters in `server/adapter/transport/` normalize different agent CLIs:
 - `process.Manager` owns subprocess, wires stdio to adapter
 - Factory pattern in `server/adapter/factory.go` selects adapter by agent type
 
+The `acp` transport is split by concern across `adapter_*.go` files: `adapter.go` (core/lifecycle), `adapter_session.go` (initialize/new/load/resume), `adapter_prompt.go` (prompt/cancel), `adapter_updates.go` (`session/update` notification fan-out), `adapter_tools.go` (`convertToolCallUpdate` / `convertToolCallResultUpdate` → normalized payloads), `adapter_permissions.go`, and `adapter_helpers.go`. Tool-call conversion lives in `adapter_tools.go`, not `adapter.go`.
+
 ## ACP Protocol
 
 JSON-RPC 2.0 over stdin/stdout between agentctl and agent process. Requests: `initialize`, `session/new`, `session/load`, `session/prompt`, `session/cancel`. Notifications: `session/update` with types `message_chunk`, `tool_call`, `tool_update`, `complete`, `error`, `permission_request`, `context_window`.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
@@ -137,6 +137,7 @@ func (a *Adapter) convertToolCallUpdate(sessionID string, tc *acp.SessionUpdateT
 		Type:              streams.EventTypeToolCall,
 		SessionID:         sessionID,
 		ToolCallID:        toolCallID,
+		ParentToolCallID:  parentToolUseID(tc.Meta),
 		ToolName:          toolKind, // Kind is effectively the tool name
 		ToolTitle:         tc.Title,
 		ToolStatus:        status,
@@ -286,6 +287,7 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 		Type:              streams.EventTypeToolUpdate,
 		SessionID:         sessionID,
 		ToolCallID:        toolCallID,
+		ParentToolCallID:  parentToolUseID(tcu.Meta),
 		ToolTitle:         title,
 		ToolStatus:        status,
 		NormalizedPayload: payload,

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
@@ -104,6 +104,13 @@ func (a *Adapter) convertToolCallUpdate(sessionID string, tc *acp.SessionUpdateT
 		args["raw_input"] = tc.RawInput
 	}
 
+	// Title + meta let the normalizer detect subagent (Task) tool calls
+	// (OpenCode keys off title, Claude off `_meta.claudeCode.toolName`).
+	args[argKeyTitle] = tc.Title
+	if tc.Meta != nil {
+		args[argKeyMeta] = tc.Meta
+	}
+
 	toolKind := string(tc.Kind)
 	normalizedPayload := a.normalizer.NormalizeToolCall(toolKind, args)
 
@@ -200,6 +207,12 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	// view rather than getting clobbered by the rawOutput string.
 	if tcu.RawOutput != nil && payload != nil && !isTrackedMonitorTerminal {
 		a.normalizer.NormalizeToolResult(payload, tcu.RawOutput)
+	}
+
+	// Subagent (Task) result metadata is split across meta (Claude) and
+	// rawOutput (OpenCode/Cursor); enrich the stored payload from both.
+	if payload != nil && payload.Kind() == streams.ToolKindSubagentTask {
+		a.normalizer.EnrichSubagentResult(payload, tcu.Meta, tcu.RawOutput)
 	}
 
 	// Seed the Monitor view AFTER NormalizeToolResult so we overwrite the

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -27,6 +27,11 @@ const (
 	toolStatusError      = "error"
 	toolStatusInProgress = "in_progress"
 	toolStatusCancelled  = "cancelled"
+
+	// args map keys the adapter stashes so the normalizer can detect subagent
+	// (Task) tool calls without changing NormalizeToolCall's signature.
+	argKeyTitle = "title"
+	argKeyMeta  = "meta"
 )
 
 // DetectToolOperationType determines the specific tool operation type from ACP tool data.
@@ -75,6 +80,12 @@ func NewNormalizer() *Normalizer {
 
 // NormalizeToolCall converts ACP tool call data to NormalizedPayload.
 func (n *Normalizer) NormalizeToolCall(toolName string, args map[string]any) *streams.NormalizedPayload {
+	// Subagent (Task) tool calls are detected from meta/title/rawInput before
+	// the kind switch — they otherwise fall through to normalizeGeneric.
+	if payload, ok := n.normalizeSubagent(args); ok {
+		return payload
+	}
+
 	// ACP uses "kind" field to identify tool type
 	kind, _ := args["kind"].(string)
 	if kind == "" {
@@ -265,6 +276,20 @@ func (n *Normalizer) UpdatePayloadInput(payload *streams.NormalizedPayload, rawI
 			rf.FilePath = path
 		}
 	}
+
+	// Subagent (Task) calls send description/prompt/subagent_type in a later
+	// tool_call_update rawInput (Claude/OpenCode); fill empty fields only.
+	if sa := payload.SubagentTask(); sa != nil {
+		if v := shared.GetString(inputMap, subagentKeyDescription); v != "" && sa.Description == "" {
+			sa.Description = v
+		}
+		if v := shared.GetString(inputMap, subagentKeyPrompt); v != "" && sa.Prompt == "" {
+			sa.Prompt = v
+		}
+		if v := shared.GetString(inputMap, subagentKeySubagentTyp); v != "" && sa.SubagentType == "" {
+			sa.SubagentType = v
+		}
+	}
 }
 
 // normalizeEdit converts ACP edit tool data.
@@ -383,6 +408,35 @@ func (n *Normalizer) normalizeCodeSearch(toolName string, args map[string]any) *
 // normalizeGeneric wraps unknown tools as generic.
 func (n *Normalizer) normalizeGeneric(toolName string, args map[string]any) *streams.NormalizedPayload {
 	return streams.NewGeneric(toolName, args)
+}
+
+// normalizeSubagent recognizes subagent (Task) tool calls from the meta, title,
+// and rawInput the adapter stashes in args. Returns (payload, true) when the
+// call spawns a subagent; the initial call usually has empty description/prompt
+// /subagent_type — those arrive incrementally via UpdatePayloadInput.
+func (n *Normalizer) normalizeSubagent(args map[string]any) (*streams.NormalizedPayload, bool) {
+	meta, _ := args[argKeyMeta].(map[string]any)
+	title, _ := args[argKeyTitle].(string)
+	rawInput := args["raw_input"]
+	desc, prompt, subagentType, ok := recognizeSubagent(meta, title, rawInput)
+	if !ok {
+		return nil, false
+	}
+	return streams.NewSubagentTask(desc, prompt, subagentType), true
+}
+
+// EnrichSubagentResult fills the result fields of a subagent payload from a
+// completion tool_call_update. Claude's result lives in meta, OpenCode's and
+// Cursor's in rawOutput — so this takes both. No-op for non-subagent payloads.
+func (n *Normalizer) EnrichSubagentResult(payload *streams.NormalizedPayload, meta map[string]any, rawOutput any) {
+	if payload == nil || payload.Kind() != streams.ToolKindSubagentTask {
+		return
+	}
+	res, ok := extractSubagentResult(meta, rawOutput)
+	if !ok {
+		return
+	}
+	applySubagentResult(payload.SubagentTask(), res)
 }
 
 // --- Helper functions ---

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -286,7 +286,7 @@ func (n *Normalizer) UpdatePayloadInput(payload *streams.NormalizedPayload, rawI
 		if v := shared.GetString(inputMap, subagentKeyPrompt); v != "" && sa.Prompt == "" {
 			sa.Prompt = v
 		}
-		if v := shared.GetString(inputMap, subagentKeySubagentTyp); v != "" && sa.SubagentType == "" {
+		if v := shared.GetString(inputMap, subagentKeySubagentType); v != "" && sa.SubagentType == "" {
 			sa.SubagentType = v
 		}
 	}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -407,7 +407,17 @@ func (n *Normalizer) normalizeCodeSearch(toolName string, args map[string]any) *
 
 // normalizeGeneric wraps unknown tools as generic.
 func (n *Normalizer) normalizeGeneric(toolName string, args map[string]any) *streams.NormalizedPayload {
-	return streams.NewGeneric(toolName, args)
+	// Exclude the adapter-injected subagent-detection keys (title/meta) so
+	// internal routing data — notably the raw `_meta.claudeCode` map — never
+	// leaks into the generic payload shipped to the client.
+	input := make(map[string]any, len(args))
+	for k, v := range args {
+		if k == argKeyTitle || k == argKeyMeta {
+			continue
+		}
+		input[k] = v
+	}
+	return streams.NewGeneric(toolName, input)
 }
 
 // normalizeSubagent recognizes subagent (Task) tool calls from the meta, title,

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
@@ -57,6 +57,36 @@ func TestACPNormalization(t *testing.T) {
 	}
 }
 
+// TestNormalizeGeneric_ExcludesAdapterKeys verifies the adapter-injected
+// title/meta subagent-detection keys don't leak into a generic (unrecognized)
+// tool's client payload — only the real tool args should reach GenericPayload.Input.
+func TestNormalizeGeneric_ExcludesAdapterKeys(t *testing.T) {
+	n := NewNormalizer()
+	args := map[string]any{
+		"kind":      "other",
+		"raw_input": map[string]any{"foo": "bar"},
+		argKeyTitle: "SomeTool",
+		argKeyMeta:  map[string]any{"claudeCode": map[string]any{"toolName": "SomeTool"}},
+	}
+	payload := n.NormalizeToolCall("SomeTool", args)
+	if payload.Kind() != streams.ToolKindGeneric {
+		t.Fatalf("Kind = %q, want generic", payload.Kind())
+	}
+	input, ok := payload.Generic().Input.(map[string]any)
+	if !ok {
+		t.Fatalf("Generic().Input is not a map: %T", payload.Generic().Input)
+	}
+	if _, present := input[argKeyTitle]; present {
+		t.Errorf("generic input leaked adapter key %q", argKeyTitle)
+	}
+	if _, present := input[argKeyMeta]; present {
+		t.Errorf("generic input leaked adapter key %q", argKeyMeta)
+	}
+	if _, present := input["raw_input"]; !present {
+		t.Error("generic input dropped raw_input")
+	}
+}
+
 // TestDetectToolOperationType tests the ACP tool type detection function.
 func TestDetectToolOperationType(t *testing.T) {
 	tests := []struct {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
@@ -1,0 +1,229 @@
+package acp
+
+import (
+	"strings"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+// Subagent (Task) tool detection constants. These are the wire-level tool
+// identifiers three real agents use to spawn a child agent ("subagent"):
+//   - Claude-acp tags it via `_meta.claudeCode.toolName == "Agent"`.
+//   - OpenCode reports tool title == "task" (case-insensitive).
+//   - Cursor reports `rawInput._toolName == "task"` (title "Task: Subagent task").
+const (
+	subagentClaudeToolName = "Agent"
+	subagentTaskName       = "task"
+)
+
+// rawInput field keys carrying subagent invocation details. These arrive on a
+// later tool_call_update for Claude/OpenCode; the initial tool_call is empty.
+const (
+	subagentKeyDescription = "description"
+	subagentKeyPrompt      = "prompt"
+	subagentKeySubagentTyp = "subagent_type"
+	subagentKeyToolName    = "_toolName"
+)
+
+// SubagentTaskResult holds the result metadata extracted from a completion
+// tool_call_update. Each agent provides a different subset; absent fields stay
+// zero-valued.
+type SubagentTaskResult struct {
+	Status         string
+	AgentID        string
+	SubagentType   string
+	Model          string
+	ChildSessionID string
+	DurationMs     int64
+	TotalTokens    int64
+	ToolUseCount   int
+}
+
+// recognizeSubagent reports whether a tool call spawns a subagent (Task) and
+// pulls description/prompt/subagent_type out of rawInput when present. The
+// detection mirrors monitor.go: defensive over untyped maps, no logging.
+//
+// A tool call is a subagent if ANY of:
+//   - Claude:   meta.claudeCode.toolName == "Agent"
+//   - OpenCode: title == "task" (case-insensitive)
+//   - Cursor:   rawInput._toolName == "task"
+//
+// The Claude "Monitor"/"ScheduleWakeup" tool names are deliberately NOT matched
+// here so their dedicated handling stays intact.
+func recognizeSubagent(meta map[string]any, title string, rawInput any) (description, prompt, subagentType string, ok bool) {
+	if !isSubagentSignal(meta, title, rawInput) {
+		return "", "", "", false
+	}
+	description, prompt, subagentType = subagentInputFields(rawInput)
+	return description, prompt, subagentType, true
+}
+
+// isSubagentSignal implements the three detection rules.
+func isSubagentSignal(meta map[string]any, title string, rawInput any) bool {
+	if isClaudeAgentMeta(meta) {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(title), subagentTaskName) {
+		return true
+	}
+	if input, ok := rawInput.(map[string]any); ok {
+		if name, _ := input[subagentKeyToolName].(string); strings.EqualFold(name, subagentTaskName) {
+			return true
+		}
+	}
+	return false
+}
+
+// isClaudeAgentMeta returns true when `_meta.claudeCode.toolName == "Agent"`.
+func isClaudeAgentMeta(meta map[string]any) bool {
+	if meta == nil {
+		return false
+	}
+	cc, ok := meta["claudeCode"].(map[string]any)
+	if !ok {
+		return false
+	}
+	name, _ := cc["toolName"].(string)
+	return name == subagentClaudeToolName
+}
+
+// subagentInputFields pulls description/prompt/subagent_type from a tool call's
+// rawInput. Any may be empty (the initial tool_call carries none of them).
+func subagentInputFields(rawInput any) (description, prompt, subagentType string) {
+	input, ok := rawInput.(map[string]any)
+	if !ok {
+		return "", "", ""
+	}
+	description, _ = input[subagentKeyDescription].(string)
+	prompt, _ = input[subagentKeyPrompt].(string)
+	subagentType, _ = input[subagentKeySubagentTyp].(string)
+	return description, prompt, subagentType
+}
+
+// extractSubagentResult reads the per-agent result shapes off a completion
+// tool_call_update. Returns ok=false when neither meta nor rawOutput carries
+// any recognizable result fields.
+//
+// Shapes:
+//   - Claude:   meta.claudeCode.toolResponse = {agentId, agentType, status,
+//     totalDurationMs, totalTokens, totalToolUseCount}
+//   - OpenCode: rawOutput.metadata = {sessionId, parentSessionId,
+//     model:{providerID, modelID}}
+//   - Cursor:   rawOutput = {durationMs, isBackground}
+func extractSubagentResult(meta map[string]any, rawOutput any) (res SubagentTaskResult, ok bool) {
+	if claudeSubagentResponse(meta, &res) {
+		ok = true
+	}
+	if out, isMap := rawOutput.(map[string]any); isMap {
+		if openCodeSubagentMetadata(out, &res) {
+			ok = true
+		}
+		if cursorSubagentResult(out, &res) {
+			ok = true
+		}
+	}
+	return res, ok
+}
+
+// claudeSubagentResponse reads `_meta.claudeCode.toolResponse` into res.
+func claudeSubagentResponse(meta map[string]any, res *SubagentTaskResult) bool {
+	if meta == nil {
+		return false
+	}
+	cc, ok := meta["claudeCode"].(map[string]any)
+	if !ok {
+		return false
+	}
+	resp, ok := cc["toolResponse"].(map[string]any)
+	if !ok {
+		return false
+	}
+	res.AgentID, _ = resp["agentId"].(string)
+	res.SubagentType, _ = resp["agentType"].(string)
+	res.Status, _ = resp["status"].(string)
+	res.DurationMs = asInt64(resp["totalDurationMs"])
+	res.TotalTokens = asInt64(resp["totalTokens"])
+	res.ToolUseCount = int(asInt64(resp["totalToolUseCount"]))
+	return true
+}
+
+// openCodeSubagentMetadata reads OpenCode's `rawOutput.metadata` into res and
+// composes Model as "providerID/modelID".
+func openCodeSubagentMetadata(out map[string]any, res *SubagentTaskResult) bool {
+	md, ok := out["metadata"].(map[string]any)
+	if !ok {
+		return false
+	}
+	found := false
+	if sid, _ := md["sessionId"].(string); sid != "" {
+		res.ChildSessionID = sid
+		found = true
+	}
+	if model, ok := md["model"].(map[string]any); ok {
+		provider, _ := model["providerID"].(string)
+		modelID, _ := model["modelID"].(string)
+		if provider != "" || modelID != "" {
+			res.Model = provider + "/" + modelID
+			found = true
+		}
+	}
+	return found
+}
+
+// cursorSubagentResult reads Cursor's flat `rawOutput.durationMs` into res.
+// Returns false when no Cursor-shaped field is present so it doesn't claim
+// unrelated rawOutput maps.
+func cursorSubagentResult(out map[string]any, res *SubagentTaskResult) bool {
+	dur, present := out["durationMs"]
+	if !present {
+		return false
+	}
+	res.DurationMs = asInt64(dur)
+	return true
+}
+
+// asInt64 coerces JSON-decoded numbers (float64 most commonly) to int64.
+func asInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	}
+	return 0
+}
+
+// applySubagentResult writes the extracted result fields onto a subagent
+// payload, only filling fields the result actually provides (so we never
+// blank out values already learned from rawInput, e.g. SubagentType).
+func applySubagentResult(p *streams.SubagentTaskPayload, res SubagentTaskResult) {
+	if p == nil {
+		return
+	}
+	if res.Status != "" {
+		p.Status = res.Status
+	}
+	if res.AgentID != "" {
+		p.AgentID = res.AgentID
+	}
+	if res.SubagentType != "" && p.SubagentType == "" {
+		p.SubagentType = res.SubagentType
+	}
+	if res.Model != "" {
+		p.Model = res.Model
+	}
+	if res.ChildSessionID != "" {
+		p.ChildSessionID = res.ChildSessionID
+	}
+	if res.DurationMs != 0 {
+		p.DurationMs = res.DurationMs
+	}
+	if res.TotalTokens != 0 {
+		p.TotalTokens = res.TotalTokens
+	}
+	if res.ToolUseCount != 0 {
+		p.ToolUseCount = res.ToolUseCount
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
@@ -77,6 +77,23 @@ func isSubagentSignal(meta map[string]any, title string, rawInput any) bool {
 	return false
 }
 
+// parentToolUseID returns `_meta.claudeCode.parentToolUseId` — the tool-call id
+// of the subagent (Task) that issued this tool call. claude-agent-acp sets it
+// on a subagent's internal tool calls (Bash/Read/…) and leaves it empty for
+// top-level calls. Its value equals the parent Task tool_call's id, so it maps
+// directly onto our `parent_tool_call_id` for nesting under the subagent card.
+func parentToolUseID(meta map[string]any) string {
+	if meta == nil {
+		return ""
+	}
+	cc, ok := meta["claudeCode"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := cc["parentToolUseId"].(string)
+	return id
+}
+
 // isClaudeAgentMeta returns true when `_meta.claudeCode.toolName == "Agent"`.
 func isClaudeAgentMeta(meta map[string]any) bool {
 	if meta == nil {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
@@ -37,6 +37,9 @@ type SubagentTaskResult struct {
 	DurationMs     int64
 	TotalTokens    int64
 	ToolUseCount   int
+	// ToolUseCountKnown distinguishes a reported zero from "not reported" — the
+	// agent supplied totalToolUseCount (possibly 0) vs the field being absent.
+	ToolUseCountKnown bool
 }
 
 // recognizeSubagent reports whether a tool call spawns a subagent (Task) and
@@ -143,7 +146,10 @@ func claudeSubagentResponse(meta map[string]any, res *SubagentTaskResult) bool {
 	res.Status, _ = resp["status"].(string)
 	res.DurationMs = asInt64(resp["totalDurationMs"])
 	res.TotalTokens = asInt64(resp["totalTokens"])
-	res.ToolUseCount = int(asInt64(resp["totalToolUseCount"]))
+	if count, present := resp["totalToolUseCount"]; present {
+		res.ToolUseCount = int(asInt64(count))
+		res.ToolUseCountKnown = true
+	}
 	return true
 }
 
@@ -162,8 +168,15 @@ func openCodeSubagentMetadata(out map[string]any, res *SubagentTaskResult) bool 
 	if model, ok := md["model"].(map[string]any); ok {
 		provider, _ := model["providerID"].(string)
 		modelID, _ := model["modelID"].(string)
-		if provider != "" || modelID != "" {
+		switch {
+		case provider != "" && modelID != "":
 			res.Model = provider + "/" + modelID
+			found = true
+		case provider != "":
+			res.Model = provider
+			found = true
+		case modelID != "":
+			res.Model = modelID
 			found = true
 		}
 	}
@@ -223,7 +236,8 @@ func applySubagentResult(p *streams.SubagentTaskPayload, res SubagentTaskResult)
 	if res.TotalTokens != 0 {
 		p.TotalTokens = res.TotalTokens
 	}
-	if res.ToolUseCount != 0 {
-		p.ToolUseCount = res.ToolUseCount
+	if res.ToolUseCountKnown {
+		count := res.ToolUseCount
+		p.ToolUseCount = &count
 	}
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent.go
@@ -19,10 +19,10 @@ const (
 // rawInput field keys carrying subagent invocation details. These arrive on a
 // later tool_call_update for Claude/OpenCode; the initial tool_call is empty.
 const (
-	subagentKeyDescription = "description"
-	subagentKeyPrompt      = "prompt"
-	subagentKeySubagentTyp = "subagent_type"
-	subagentKeyToolName    = "_toolName"
+	subagentKeyDescription  = "description"
+	subagentKeyPrompt       = "prompt"
+	subagentKeySubagentType = "subagent_type"
+	subagentKeyToolName     = "_toolName"
 )
 
 // SubagentTaskResult holds the result metadata extracted from a completion
@@ -99,7 +99,7 @@ func subagentInputFields(rawInput any) (description, prompt, subagentType string
 	}
 	description, _ = input[subagentKeyDescription].(string)
 	prompt, _ = input[subagentKeyPrompt].(string)
-	subagentType, _ = input[subagentKeySubagentTyp].(string)
+	subagentType, _ = input[subagentKeySubagentType].(string)
 	return description, prompt, subagentType
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent_test.go
@@ -1,0 +1,302 @@
+package acp
+
+import (
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+// --- recognizeSubagent ---
+
+// claudeAgentMeta builds the `_meta.claudeCode.toolName=Agent` payload
+// Claude-acp attaches to subagent (Task) tool_call notifications.
+func claudeAgentMeta() map[string]any {
+	return map[string]any{"claudeCode": map[string]any{"toolName": "Agent"}}
+}
+
+func subagentRawInput() map[string]any {
+	return map[string]any{
+		"description":   "Investigate flaky test",
+		"prompt":        "Find the root cause of the flaky test in foo_test.go",
+		"subagent_type": "general-purpose",
+	}
+}
+
+func TestRecognizeSubagent_ClaudeInitialEmpty(t *testing.T) {
+	desc, prompt, st, ok := recognizeSubagent(claudeAgentMeta(), "", nil)
+	if !ok {
+		t.Fatal("expected Claude Agent meta to be recognized as subagent")
+	}
+	if desc != "" || prompt != "" || st != "" {
+		t.Errorf("expected empty fields on initial call, got (%q,%q,%q)", desc, prompt, st)
+	}
+}
+
+func TestRecognizeSubagent_ClaudeWithInput(t *testing.T) {
+	desc, prompt, st, ok := recognizeSubagent(claudeAgentMeta(), "", subagentRawInput())
+	if !ok {
+		t.Fatal("expected recognition")
+	}
+	if desc != "Investigate flaky test" || st != "general-purpose" {
+		t.Errorf("got (%q,%q,%q)", desc, prompt, st)
+	}
+	if prompt == "" {
+		t.Errorf("expected prompt to be populated")
+	}
+}
+
+func TestRecognizeSubagent_OpenCodeTitle(t *testing.T) {
+	desc, _, st, ok := recognizeSubagent(nil, "task", nil)
+	if !ok {
+		t.Fatal("expected OpenCode title=task to be recognized")
+	}
+	if desc != "" || st != "" {
+		t.Errorf("expected empty fields on initial OpenCode call, got (%q,%q)", desc, st)
+	}
+}
+
+func TestRecognizeSubagent_OpenCodeTitleCaseInsensitive(t *testing.T) {
+	if _, _, _, ok := recognizeSubagent(nil, "Task", nil); !ok {
+		t.Fatal("expected case-insensitive match on title 'Task'")
+	}
+	if _, _, _, ok := recognizeSubagent(nil, "TASK", nil); !ok {
+		t.Fatal("expected case-insensitive match on title 'TASK'")
+	}
+}
+
+func TestRecognizeSubagent_OpenCodeWithInput(t *testing.T) {
+	desc, prompt, st, ok := recognizeSubagent(nil, "task", subagentRawInput())
+	if !ok {
+		t.Fatal("expected recognition")
+	}
+	if desc != "Investigate flaky test" || prompt == "" || st != "general-purpose" {
+		t.Errorf("got (%q,%q,%q)", desc, prompt, st)
+	}
+}
+
+func TestRecognizeSubagent_CursorToolName(t *testing.T) {
+	rawInput := map[string]any{"_toolName": "task"}
+	_, _, _, ok := recognizeSubagent(nil, "Task: Subagent task", rawInput)
+	if !ok {
+		t.Fatal("expected Cursor rawInput._toolName=task to be recognized")
+	}
+}
+
+func TestRecognizeSubagent_NegativeMonitor(t *testing.T) {
+	meta := map[string]any{"claudeCode": map[string]any{"toolName": "Monitor"}}
+	if _, _, _, ok := recognizeSubagent(meta, "Monitor foo", nil); ok {
+		t.Error("Monitor meta must NOT be recognized as subagent")
+	}
+}
+
+func TestRecognizeSubagent_NegativeScheduleWakeup(t *testing.T) {
+	meta := map[string]any{"claudeCode": map[string]any{"toolName": "ScheduleWakeup"}}
+	if _, _, _, ok := recognizeSubagent(meta, "", nil); ok {
+		t.Error("ScheduleWakeup meta must NOT be recognized as subagent")
+	}
+}
+
+func TestRecognizeSubagent_NegativePlainBash(t *testing.T) {
+	if _, _, _, ok := recognizeSubagent(nil, "Bash", map[string]any{"command": "ls"}); ok {
+		t.Error("plain bash must NOT be recognized as subagent")
+	}
+}
+
+func TestRecognizeSubagent_NegativeEmpty(t *testing.T) {
+	if _, _, _, ok := recognizeSubagent(nil, "", nil); ok {
+		t.Error("empty inputs must NOT be recognized as subagent")
+	}
+}
+
+// --- extractSubagentResult ---
+
+func claudeResultMeta() map[string]any {
+	return map[string]any{"claudeCode": map[string]any{"toolResponse": map[string]any{
+		"agentId":           "agent_abc",
+		"agentType":         "general-purpose",
+		"status":            "completed",
+		"totalDurationMs":   float64(12345),
+		"totalTokens":       float64(6789),
+		"totalToolUseCount": float64(11),
+	}}}
+}
+
+func TestExtractSubagentResult_Claude(t *testing.T) {
+	res, ok := extractSubagentResult(claudeResultMeta(), nil)
+	if !ok {
+		t.Fatal("expected Claude result to be extracted")
+	}
+	if res.AgentID != "agent_abc" {
+		t.Errorf("AgentID = %q", res.AgentID)
+	}
+	if res.SubagentType != "general-purpose" {
+		t.Errorf("SubagentType = %q", res.SubagentType)
+	}
+	if res.Status != "completed" {
+		t.Errorf("Status = %q", res.Status)
+	}
+	if res.DurationMs != 12345 {
+		t.Errorf("DurationMs = %d", res.DurationMs)
+	}
+	if res.TotalTokens != 6789 {
+		t.Errorf("TotalTokens = %d", res.TotalTokens)
+	}
+	if res.ToolUseCount != 11 {
+		t.Errorf("ToolUseCount = %d", res.ToolUseCount)
+	}
+}
+
+func TestExtractSubagentResult_OpenCode(t *testing.T) {
+	rawOutput := map[string]any{"metadata": map[string]any{
+		"sessionId":       "ses_child",
+		"parentSessionId": "ses_parent",
+		"model": map[string]any{
+			"providerID": "opencode",
+			"modelID":    "big-pickle",
+		},
+	}}
+	res, ok := extractSubagentResult(nil, rawOutput)
+	if !ok {
+		t.Fatal("expected OpenCode result to be extracted")
+	}
+	if res.ChildSessionID != "ses_child" {
+		t.Errorf("ChildSessionID = %q", res.ChildSessionID)
+	}
+	if res.Model != "opencode/big-pickle" {
+		t.Errorf("Model = %q, want opencode/big-pickle", res.Model)
+	}
+}
+
+func TestExtractSubagentResult_Cursor(t *testing.T) {
+	rawOutput := map[string]any{"durationMs": float64(4200), "isBackground": false}
+	res, ok := extractSubagentResult(nil, rawOutput)
+	if !ok {
+		t.Fatal("expected Cursor result to be extracted")
+	}
+	if res.DurationMs != 4200 {
+		t.Errorf("DurationMs = %d", res.DurationMs)
+	}
+}
+
+func TestExtractSubagentResult_Empty(t *testing.T) {
+	if _, ok := extractSubagentResult(nil, nil); ok {
+		t.Error("expected no result from empty inputs")
+	}
+}
+
+// --- Subagent (Task) normalization ---
+
+func TestNormalizeToolCall_ClaudeSubagent(t *testing.T) {
+	n := NewNormalizer()
+	args := map[string]any{
+		"meta": map[string]any{"claudeCode": map[string]any{"toolName": "Agent"}},
+	}
+	payload := n.NormalizeToolCall("Agent", args)
+	if payload.Kind() != streams.ToolKindSubagentTask {
+		t.Fatalf("Kind = %q, want subagent_task", payload.Kind())
+	}
+}
+
+func TestNormalizeToolCall_OpenCodeSubagent(t *testing.T) {
+	n := NewNormalizer()
+	args := map[string]any{"title": "task"}
+	payload := n.NormalizeToolCall("", args)
+	if payload.Kind() != streams.ToolKindSubagentTask {
+		t.Fatalf("Kind = %q, want subagent_task", payload.Kind())
+	}
+}
+
+func TestNormalizeToolCall_CursorSubagent(t *testing.T) {
+	n := NewNormalizer()
+	args := map[string]any{
+		"title":     "Task: Subagent task",
+		"raw_input": map[string]any{"_toolName": "task"},
+	}
+	payload := n.NormalizeToolCall("", args)
+	if payload.Kind() != streams.ToolKindSubagentTask {
+		t.Fatalf("Kind = %q, want subagent_task", payload.Kind())
+	}
+}
+
+func TestNormalizeToolCall_PlainBashNotSubagent(t *testing.T) {
+	n := NewNormalizer()
+	args := map[string]any{
+		"meta":      map[string]any{"claudeCode": map[string]any{"toolName": "Bash"}},
+		"raw_input": map[string]any{"command": "ls"},
+	}
+	payload := n.NormalizeToolCall("bash", args)
+	if payload.Kind() == streams.ToolKindSubagentTask {
+		t.Fatal("plain bash must not normalize as subagent")
+	}
+}
+
+func TestUpdatePayloadInput_FillsSubagentFields(t *testing.T) {
+	n := NewNormalizer()
+	payload := streams.NewSubagentTask("", "", "")
+	n.UpdatePayloadInput(payload, map[string]any{
+		"description":   "Investigate flaky test",
+		"prompt":        "Find the root cause",
+		"subagent_type": "general-purpose",
+	})
+	sa := payload.SubagentTask()
+	if sa.Description != "Investigate flaky test" {
+		t.Errorf("Description = %q", sa.Description)
+	}
+	if sa.Prompt != "Find the root cause" {
+		t.Errorf("Prompt = %q", sa.Prompt)
+	}
+	if sa.SubagentType != "general-purpose" {
+		t.Errorf("SubagentType = %q", sa.SubagentType)
+	}
+}
+
+func TestEnrichSubagentResult_Claude(t *testing.T) {
+	n := NewNormalizer()
+	payload := streams.NewSubagentTask("Investigate", "do it", "")
+	meta := map[string]any{"claudeCode": map[string]any{"toolResponse": map[string]any{
+		"agentId":           "agent_abc",
+		"agentType":         "general-purpose",
+		"status":            "completed",
+		"totalDurationMs":   float64(12345),
+		"totalTokens":       float64(6789),
+		"totalToolUseCount": float64(11),
+	}}}
+	n.EnrichSubagentResult(payload, meta, nil)
+	sa := payload.SubagentTask()
+	if sa.Status != "completed" || sa.AgentID != "agent_abc" {
+		t.Errorf("status/agentId = %q/%q", sa.Status, sa.AgentID)
+	}
+	if sa.DurationMs != 12345 || sa.TotalTokens != 6789 || sa.ToolUseCount != 11 {
+		t.Errorf("metrics = %d/%d/%d", sa.DurationMs, sa.TotalTokens, sa.ToolUseCount)
+	}
+	if sa.SubagentType != "general-purpose" {
+		t.Errorf("SubagentType = %q", sa.SubagentType)
+	}
+}
+
+func TestEnrichSubagentResult_OpenCode(t *testing.T) {
+	n := NewNormalizer()
+	payload := streams.NewSubagentTask("Investigate", "do it", "general-purpose")
+	rawOutput := map[string]any{"metadata": map[string]any{
+		"sessionId":       "ses_child",
+		"parentSessionId": "ses_parent",
+		"model":           map[string]any{"providerID": "opencode", "modelID": "big-pickle"},
+	}}
+	n.EnrichSubagentResult(payload, nil, rawOutput)
+	sa := payload.SubagentTask()
+	if sa.ChildSessionID != "ses_child" {
+		t.Errorf("ChildSessionID = %q", sa.ChildSessionID)
+	}
+	if sa.Model != "opencode/big-pickle" {
+		t.Errorf("Model = %q", sa.Model)
+	}
+}
+
+func TestEnrichSubagentResult_Cursor(t *testing.T) {
+	n := NewNormalizer()
+	payload := streams.NewSubagentTask("", "", "")
+	n.EnrichSubagentResult(payload, nil, map[string]any{"durationMs": float64(4200), "isBackground": false})
+	if payload.SubagentTask().DurationMs != 4200 {
+		t.Errorf("DurationMs = %d", payload.SubagentTask().DurationMs)
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent_test.go
@@ -252,6 +252,26 @@ func TestUpdatePayloadInput_FillsSubagentFields(t *testing.T) {
 	}
 }
 
+func TestParentToolUseID(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta map[string]any
+		want string
+	}{
+		{"present", map[string]any{"claudeCode": map[string]any{"parentToolUseId": "toolu_parent"}}, "toolu_parent"},
+		{"absent (top-level call)", map[string]any{"claudeCode": map[string]any{"toolName": "Bash"}}, ""},
+		{"nil meta", nil, ""},
+		{"no claudeCode", map[string]any{"other": 1}, ""},
+		{"wrong type", map[string]any{"claudeCode": map[string]any{"parentToolUseId": 123}}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parentToolUseID(tc.meta); got != tc.want {
+				t.Errorf("parentToolUseID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEnrichSubagentResult_Claude(t *testing.T) {
 	n := NewNormalizer()
 	payload := streams.NewSubagentTask("Investigate", "do it", "")

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/subagent_test.go
@@ -1,6 +1,8 @@
 package acp
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
@@ -266,11 +268,57 @@ func TestEnrichSubagentResult_Claude(t *testing.T) {
 	if sa.Status != "completed" || sa.AgentID != "agent_abc" {
 		t.Errorf("status/agentId = %q/%q", sa.Status, sa.AgentID)
 	}
-	if sa.DurationMs != 12345 || sa.TotalTokens != 6789 || sa.ToolUseCount != 11 {
-		t.Errorf("metrics = %d/%d/%d", sa.DurationMs, sa.TotalTokens, sa.ToolUseCount)
+	if sa.ToolUseCount == nil || *sa.ToolUseCount != 11 {
+		t.Errorf("ToolUseCount = %v, want 11", sa.ToolUseCount)
+	}
+	if sa.DurationMs != 12345 || sa.TotalTokens != 6789 {
+		t.Errorf("metrics = %d/%d", sa.DurationMs, sa.TotalTokens)
 	}
 	if sa.SubagentType != "general-purpose" {
 		t.Errorf("SubagentType = %q", sa.SubagentType)
+	}
+}
+
+// A completed subagent that ran zero tools must serialize tool_use_count: 0
+// (not drop it), so the UI can render the "0 tools" chip. Regression test for
+// the omitempty + non-zero-guard bug.
+func TestEnrichSubagentResult_ClaudeZeroToolUses(t *testing.T) {
+	n := NewNormalizer()
+	payload := streams.NewSubagentTask("Investigate", "do it", "")
+	meta := map[string]any{"claudeCode": map[string]any{"toolResponse": map[string]any{
+		"status":            "completed",
+		"totalToolUseCount": float64(0),
+	}}}
+	n.EnrichSubagentResult(payload, meta, nil)
+	sa := payload.SubagentTask()
+	if sa.ToolUseCount == nil || *sa.ToolUseCount != 0 {
+		t.Fatalf("ToolUseCount = %v, want a non-nil pointer to 0", sa.ToolUseCount)
+	}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"tool_use_count":0`) {
+		t.Errorf("expected tool_use_count:0 in JSON, got %s", out)
+	}
+}
+
+// Agents that don't report a tool count (OpenCode/Cursor) must leave the field
+// omitted, not emit a misleading "0 tools".
+func TestEnrichSubagentResult_OmitsUnknownToolUseCount(t *testing.T) {
+	n := NewNormalizer()
+	payload := streams.NewSubagentTask("Investigate", "do it", "general-purpose")
+	out := map[string]any{"metadata": map[string]any{"sessionId": "child_1"}}
+	n.EnrichSubagentResult(payload, nil, out)
+	if payload.SubagentTask().ToolUseCount != nil {
+		t.Errorf("ToolUseCount = %v, want nil (unknown)", payload.SubagentTask().ToolUseCount)
+	}
+	j, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(j), "tool_use_count") {
+		t.Errorf("did not expect tool_use_count in JSON, got %s", j)
 	}
 }
 
@@ -289,6 +337,30 @@ func TestEnrichSubagentResult_OpenCode(t *testing.T) {
 	}
 	if sa.Model != "opencode/big-pickle" {
 		t.Errorf("Model = %q", sa.Model)
+	}
+}
+
+// Model must not carry a leading/trailing slash when only one of
+// providerID/modelID is present.
+func TestEnrichSubagentResult_OpenCodePartialModel(t *testing.T) {
+	for _, tc := range []struct {
+		name, provider, modelID, want string
+	}{
+		{"modelOnly", "", "big-pickle", "big-pickle"},
+		{"providerOnly", "opencode", "", "opencode"},
+		{"both", "opencode", "big-pickle", "opencode/big-pickle"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := NewNormalizer()
+			payload := streams.NewSubagentTask("d", "p", "general-purpose")
+			rawOutput := map[string]any{"metadata": map[string]any{
+				"model": map[string]any{"providerID": tc.provider, "modelID": tc.modelID},
+			}}
+			n.EnrichSubagentResult(payload, nil, rawOutput)
+			if got := payload.SubagentTask().Model; got != tc.want {
+				t.Errorf("Model = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/agentctl/types/streams/tool_payload.go
+++ b/apps/backend/internal/agentctl/types/streams/tool_payload.go
@@ -253,7 +253,10 @@ type SubagentTaskPayload struct {
 	ChildSessionID string `json:"child_session_id,omitempty"`
 	DurationMs     int64  `json:"duration_ms,omitempty"`
 	TotalTokens    int64  `json:"total_tokens,omitempty"`
-	ToolUseCount   int    `json:"tool_use_count,omitempty"`
+	// ToolUseCount is a pointer so a genuine zero ("0 tools" for a completed
+	// subagent) serializes, while agents that don't report it (OpenCode,
+	// Cursor) stay omitted rather than surfacing a misleading "0 tools" chip.
+	ToolUseCount *int `json:"tool_use_count,omitempty"`
 }
 
 // ShowPlanPayload contains normalized data for plan display operations.

--- a/apps/backend/internal/agentctl/types/streams/tool_payload.go
+++ b/apps/backend/internal/agentctl/types/streams/tool_payload.go
@@ -247,11 +247,13 @@ type SubagentTaskPayload struct {
 	SubagentType string `json:"subagent_type"`
 
 	// Result fields (populated from tool_use_result on completion)
-	Status       string `json:"status,omitempty"`
-	AgentID      string `json:"agent_id,omitempty"`
-	DurationMs   int64  `json:"duration_ms,omitempty"`
-	TotalTokens  int64  `json:"total_tokens,omitempty"`
-	ToolUseCount int    `json:"tool_use_count,omitempty"`
+	Status         string `json:"status,omitempty"`
+	AgentID        string `json:"agent_id,omitempty"`
+	Model          string `json:"model,omitempty"`
+	ChildSessionID string `json:"child_session_id,omitempty"`
+	DurationMs     int64  `json:"duration_ms,omitempty"`
+	TotalTokens    int64  `json:"total_tokens,omitempty"`
+	ToolUseCount   int    `json:"tool_use_count,omitempty"`
 }
 
 // ShowPlanPayload contains normalized data for plan display operations.

--- a/apps/backend/internal/agentctl/types/streams/tool_payload.go
+++ b/apps/backend/internal/agentctl/types/streams/tool_payload.go
@@ -349,3 +349,17 @@ func NewGeneric(name string, input any) *NormalizedPayload {
 		},
 	}
 }
+
+// NewSubagentTask creates a NormalizedPayload for subagent (Task) tool calls.
+// Result fields (status, agent id, metrics, …) are filled later from the
+// completion tool_call_update via the ACP normalizer's EnrichSubagentResult.
+func NewSubagentTask(description, prompt, subagentType string) *NormalizedPayload {
+	return &NormalizedPayload{
+		kind: ToolKindSubagentTask,
+		subagentTask: &SubagentTaskPayload{
+			Description:  description,
+			Prompt:       prompt,
+			SubagentType: subagentType,
+		},
+	}
+}

--- a/apps/web/components/task/chat/messages/subagent-meta-row.tsx
+++ b/apps/web/components/task/chat/messages/subagent-meta-row.tsx
@@ -1,0 +1,30 @@
+import { Badge } from "@kandev/ui/badge";
+import type { SubagentTaskPayload } from "@/components/task/chat/types";
+import { subagentMetaChips } from "@/components/task/chat/messages/subagent-meta";
+
+/**
+ * Compact row of metadata chips (duration, tokens, tools, model, ids) rendered
+ * under a completed subagent's header. Renders nothing when no metric fields
+ * are present, so the card degrades gracefully across agents.
+ */
+export function SubagentMetaRow({ subagentTask }: { subagentTask?: SubagentTaskPayload }) {
+  const chips = subagentMetaChips(subagentTask);
+  if (chips.length === 0) return null;
+  return (
+    <div
+      data-testid="subagent-meta"
+      className="flex flex-wrap items-center gap-1.5 mt-1 ml-7 text-muted-foreground"
+    >
+      {chips.map((chip) => (
+        <Badge
+          key={chip.label}
+          variant="secondary"
+          data-testid={`subagent-meta-${chip.label}`}
+          className="font-mono text-[10px] font-normal"
+        >
+          {chip.value}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/task/chat/messages/subagent-meta.test.ts
+++ b/apps/web/components/task/chat/messages/subagent-meta.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { subagentMetaChips } from "./subagent-meta";
+import type { SubagentTaskPayload } from "@/components/task/chat/types";
+
+describe("subagentMetaChips", () => {
+  it("returns empty list for undefined payload", () => {
+    expect(subagentMetaChips(undefined)).toEqual([]);
+  });
+
+  it("returns empty list when no metric fields are present", () => {
+    const payload: SubagentTaskPayload = { description: "do work", subagent_type: "general" };
+    expect(subagentMetaChips(payload)).toEqual([]);
+  });
+
+  it("formats a full Claude payload", () => {
+    const payload: SubagentTaskPayload = {
+      subagent_type: "general-purpose",
+      agent_id: "agent_0123456789abcdef",
+      duration_ms: 2200,
+      total_tokens: 9987,
+      tool_use_count: 0,
+      status: "complete",
+    };
+    expect(subagentMetaChips(payload)).toEqual([
+      { label: "duration", value: "2.2s" },
+      { label: "tokens", value: "9,987 tokens" },
+      { label: "tools", value: "0 tools" },
+      { label: "agent", value: "agent_012345…" },
+    ]);
+  });
+
+  it("formats an OpenCode payload", () => {
+    const payload: SubagentTaskPayload = {
+      subagent_type: "task",
+      model: "opencode/big-pickle",
+      child_session_id: "sess_abcdef0123456789",
+    };
+    expect(subagentMetaChips(payload)).toEqual([
+      { label: "model", value: "opencode/big-pickle" },
+      { label: "session", value: "sess_abcdef0…" },
+    ]);
+  });
+
+  it("formats a Cursor payload (duration only)", () => {
+    const payload: SubagentTaskPayload = { subagent_type: "task", duration_ms: 850 };
+    expect(subagentMetaChips(payload)).toEqual([{ label: "duration", value: "850ms" }]);
+  });
+
+  it("singularizes a single tool use", () => {
+    expect(subagentMetaChips({ tool_use_count: 1 })).toEqual([{ label: "tools", value: "1 tool" }]);
+  });
+
+  it("skips zero/negative duration and zero tokens but keeps zero tools", () => {
+    const payload: SubagentTaskPayload = { duration_ms: 0, total_tokens: 0, tool_use_count: 0 };
+    expect(subagentMetaChips(payload)).toEqual([{ label: "tools", value: "0 tools" }]);
+  });
+
+  it("does not truncate short ids", () => {
+    expect(subagentMetaChips({ agent_id: "short" })).toEqual([{ label: "agent", value: "short" }]);
+  });
+});

--- a/apps/web/components/task/chat/messages/subagent-meta.ts
+++ b/apps/web/components/task/chat/messages/subagent-meta.ts
@@ -1,0 +1,61 @@
+import type { SubagentTaskPayload } from "@/components/task/chat/types";
+
+export type SubagentMetaChip = {
+  label: string;
+  value: string;
+};
+
+const MAX_ID_LENGTH = 12;
+
+function truncateId(value: string): string {
+  if (value.length <= MAX_ID_LENGTH) return value;
+  return `${value.slice(0, MAX_ID_LENGTH)}…`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatTokens(tokens: number): string {
+  return `${tokens.toLocaleString("en-US")} tokens`;
+}
+
+function formatTools(count: number): string {
+  return `${count} tool${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Turns a SubagentTaskPayload into an ordered list of display chips. Different
+ * agents populate different subsets (Claude: agent_id/tokens/duration/
+ * tool_use_count; OpenCode: model/child_session_id; Cursor: duration_ms only),
+ * so each field is only included when meaningfully present. Duration and tokens
+ * are skipped when zero; tool_use_count is shown even at zero since "0 tools"
+ * is meaningful for a completed subagent.
+ */
+export function subagentMetaChips(payload: SubagentTaskPayload | undefined): SubagentMetaChip[] {
+  if (!payload) return [];
+
+  const chips: SubagentMetaChip[] = [];
+
+  if (typeof payload.duration_ms === "number" && payload.duration_ms > 0) {
+    chips.push({ label: "duration", value: formatDuration(payload.duration_ms) });
+  }
+  if (typeof payload.total_tokens === "number" && payload.total_tokens > 0) {
+    chips.push({ label: "tokens", value: formatTokens(payload.total_tokens) });
+  }
+  if (typeof payload.tool_use_count === "number") {
+    chips.push({ label: "tools", value: formatTools(payload.tool_use_count) });
+  }
+  if (payload.model) {
+    chips.push({ label: "model", value: payload.model });
+  }
+  if (payload.agent_id) {
+    chips.push({ label: "agent", value: truncateId(payload.agent_id) });
+  }
+  if (payload.child_session_id) {
+    chips.push({ label: "session", value: truncateId(payload.child_session_id) });
+  }
+
+  return chips;
+}

--- a/apps/web/components/task/chat/messages/tool-subagent-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-subagent-message.tsx
@@ -6,6 +6,7 @@ import { GridSpinner } from "@/components/grid-spinner";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/types/http";
 import type { ToolCallMetadata } from "@/components/task/chat/types";
+import { SubagentMetaRow } from "@/components/task/chat/messages/subagent-meta-row";
 
 type ToolSubagentMessageProps = {
   comment: Message;
@@ -59,10 +60,16 @@ function SubagentHeader({
       ) : (
         <IconChevronRight className="h-3.5 w-3.5 text-muted-foreground/60 flex-shrink-0" />
       )}
-      <span className="bg-muted text-muted-foreground text-[10px] px-1.5 rounded font-medium uppercase tracking-wide">
+      <span
+        data-testid="subagent-type"
+        className="bg-muted text-muted-foreground text-[10px] px-1.5 rounded font-medium uppercase tracking-wide"
+      >
         {subagentType}
       </span>
-      <span className="font-mono text-xs truncate text-muted-foreground inline-flex items-center gap-1.5">
+      <span
+        data-testid="subagent-description"
+        className="font-mono text-xs truncate text-muted-foreground inline-flex items-center gap-1.5"
+      >
         {description}
         {isActive && <GridSpinner className="text-muted-foreground shrink-0" />}
       </span>
@@ -75,10 +82,13 @@ function SubagentHeader({
   );
 }
 
+const NESTED_BORDER = "ml-2 pl-4 border-l-2 border-border/30 mt-1";
+
 type SubagentContentProps = {
   isExpanded: boolean;
   childMessages: Message[];
   isActive: boolean;
+  prompt?: string;
   renderChild: (message: Message) => React.ReactNode;
 };
 
@@ -86,12 +96,13 @@ function SubagentContent({
   isExpanded,
   childMessages,
   isActive,
+  prompt,
   renderChild,
 }: SubagentContentProps) {
   if (!isExpanded) return null;
   if (childMessages.length > 0) {
     return (
-      <div className="ml-2 pl-4 border-l-2 border-border/30 mt-1 space-y-2">
+      <div className={cn(NESTED_BORDER, "space-y-2")}>
         {childMessages.map((child) => (
           <div key={child.id}>{renderChild(child)}</div>
         ))}
@@ -100,8 +111,15 @@ function SubagentContent({
   }
   if (isActive) {
     return (
-      <div className="ml-2 pl-4 border-l-2 border-border/30 mt-1">
+      <div className={NESTED_BORDER}>
         <span className="text-xs text-muted-foreground italic">Subagent working...</span>
+      </div>
+    );
+  }
+  if (prompt) {
+    return (
+      <div className={NESTED_BORDER}>
+        <p className="text-xs text-muted-foreground whitespace-pre-wrap break-words">{prompt}</p>
       </div>
     );
   }
@@ -127,6 +145,8 @@ export const ToolSubagentMessage = memo(function ToolSubagentMessage({
   const childCount = childMessages.length;
 
   const isActive = status === "running";
+  const showMeta = !isActive;
+  const prompt = childCount === 0 ? subagentTask?.prompt : undefined;
 
   // Track manual override state - null means "use auto behavior"
   const [manualExpandState, setManualExpandState] = useState<boolean | null>(null);
@@ -142,7 +162,7 @@ export const ToolSubagentMessage = memo(function ToolSubagentMessage({
   }, [autoExpanded]);
 
   return (
-    <div className="w-full">
+    <div className="w-full" data-testid="subagent-card">
       <SubagentHeader
         isExpanded={isExpanded}
         subagentType={subagentType}
@@ -151,10 +171,12 @@ export const ToolSubagentMessage = memo(function ToolSubagentMessage({
         childCount={childCount}
         onToggle={handleToggle}
       />
+      {showMeta && <SubagentMetaRow subagentTask={subagentTask} />}
       <SubagentContent
         isExpanded={isExpanded}
         childMessages={childMessages}
         isActive={isActive}
+        prompt={prompt}
         renderChild={renderChild}
       />
     </div>

--- a/apps/web/components/task/chat/messages/tool-subagent-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-subagent-message.tsx
@@ -74,7 +74,10 @@ function SubagentHeader({
         {isActive && <GridSpinner className="text-muted-foreground shrink-0" />}
       </span>
       {childCount > 0 && (
-        <span className="text-muted-foreground/60 text-xs px-1.5 rounded min-w-[20px] text-center font-mono">
+        <span
+          data-testid="subagent-child-count"
+          className="text-muted-foreground/60 text-xs px-1.5 rounded min-w-[20px] text-center font-mono"
+        >
           {childCount} tool call{childCount !== 1 ? "s" : ""}
         </span>
       )}

--- a/apps/web/components/task/chat/types.ts
+++ b/apps/web/components/task/chat/types.ts
@@ -4,6 +4,13 @@ export type SubagentTaskPayload = {
   description?: string;
   prompt?: string;
   subagent_type?: string;
+  status?: string; // result lifecycle, e.g. "complete" | "error"
+  agent_id?: string; // Claude
+  model?: string; // OpenCode, e.g. "opencode/big-pickle"
+  child_session_id?: string; // OpenCode child session
+  duration_ms?: number; // Claude (totalDurationMs) + Cursor (durationMs)
+  total_tokens?: number; // Claude
+  tool_use_count?: number; // Claude
 };
 
 export type GenericPayload = {

--- a/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
@@ -37,25 +37,16 @@ test.describe("Mobile subagent card", () => {
     const card = cards.first();
     await expect(card).toBeVisible();
 
-    await expect(session.chat.locator('[data-testid="subagent-type"]').first()).toContainText(
-      "general-purpose",
+    // Scope chip queries to the single card (strict mode catches duplicates).
+    await expect(card.locator('[data-testid="subagent-type"]')).toContainText("general-purpose");
+    await expect(card.locator('[data-testid="subagent-description"]')).toContainText(
+      "Explore the codebase",
     );
-    await expect(
-      session.chat.locator('[data-testid="subagent-description"]').first(),
-    ).toContainText("Explore the codebase");
 
-    await expect(session.chat.locator('[data-testid="subagent-meta"]').first()).toBeVisible();
-    await expect(
-      session.chat.locator('[data-testid="subagent-meta-duration"]').first(),
-    ).toContainText("2.2s");
-    await expect(
-      session.chat.locator('[data-testid="subagent-meta-tokens"]').first(),
-    ).toContainText("9,987");
-    await expect(session.chat.locator('[data-testid="subagent-meta-tools"]').first()).toContainText(
-      "3 tools",
-    );
-    await expect(session.chat.locator('[data-testid="subagent-meta-agent"]').first()).toContainText(
-      "agent_e2e",
-    );
+    await expect(card.locator('[data-testid="subagent-meta"]')).toBeVisible();
+    await expect(card.locator('[data-testid="subagent-meta-duration"]')).toContainText("2.2s");
+    await expect(card.locator('[data-testid="subagent-meta-tokens"]')).toContainText("9,987");
+    await expect(card.locator('[data-testid="subagent-meta-tools"]')).toContainText("3 tools");
+    await expect(card.locator('[data-testid="subagent-meta-agent"]')).toContainText("agent_e2e");
   });
 });

--- a/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
@@ -48,5 +48,8 @@ test.describe("Mobile subagent card", () => {
     await expect(card.locator('[data-testid="subagent-meta-tokens"]')).toContainText("9,987");
     await expect(card.locator('[data-testid="subagent-meta-tools"]')).toContainText("3 tools");
     await expect(card.locator('[data-testid="subagent-meta-agent"]')).toContainText("agent_e2e");
+
+    // The subagent's internal tool call nests under its card (parentToolUseId).
+    await expect(card.locator('[data-testid="subagent-child-count"]')).toContainText("1 tool call");
   });
 });

--- a/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+// Mobile (Pixel 5) coverage for the subagent card — same `/e2e:subagent`
+// scenario as the desktop spec. Filename matches /mobile-.*\.spec\.ts/ so the
+// `mobile-chrome` project picks it up. Asserts the card is visible and usable
+// (type badge, description, and metadata chips all readable) at mobile width.
+
+test.describe("Mobile subagent card", () => {
+  test("renders type badge, description, and metadata chips at mobile width", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(60_000);
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Mobile subagent card",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:subagent",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 30_000 });
+
+    const card = session.chat.locator('[data-testid="subagent-card"]').first();
+    await expect(card).toBeVisible();
+
+    await expect(session.chat.locator('[data-testid="subagent-type"]').first()).toContainText(
+      "general-purpose",
+    );
+    await expect(
+      session.chat.locator('[data-testid="subagent-description"]').first(),
+    ).toContainText("Explore the codebase");
+
+    await expect(session.chat.locator('[data-testid="subagent-meta"]').first()).toBeVisible();
+    await expect(
+      session.chat.locator('[data-testid="subagent-meta-duration"]').first(),
+    ).toContainText("2.2s");
+    await expect(
+      session.chat.locator('[data-testid="subagent-meta-tokens"]').first(),
+    ).toContainText("9,987");
+    await expect(session.chat.locator('[data-testid="subagent-meta-tools"]').first()).toContainText(
+      "3 tools",
+    );
+    await expect(session.chat.locator('[data-testid="subagent-meta-agent"]').first()).toContainText(
+      "agent_e2e",
+    );
+  });
+});

--- a/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
@@ -31,7 +31,10 @@ test.describe("Mobile subagent card", () => {
     await session.waitForLoad();
     await session.waitForChatIdle({ timeout: 30_000 });
 
-    const card = session.chat.locator('[data-testid="subagent-card"]').first();
+    // Assert exactly one card so a duplicate render fails rather than hiding behind .first().
+    const cards = session.chat.locator('[data-testid="subagent-card"]');
+    await expect(cards).toHaveCount(1);
+    const card = cards.first();
     await expect(card).toBeVisible();
 
     await expect(session.chat.locator('[data-testid="subagent-type"]').first()).toContainText(

--- a/apps/web/e2e/tests/chat/subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/subagent.spec.ts
@@ -42,28 +42,20 @@ test.describe("Subagent card", () => {
     const card = cards.first();
     await expect(card).toBeVisible();
 
-    // Type badge and description (visible while collapsed).
-    await expect(session.chat.locator('[data-testid="subagent-type"]').first()).toContainText(
-      "general-purpose",
+    // Type badge and description (visible while collapsed). Scope chip queries
+    // to the single card so Playwright strict mode catches duplicates instead
+    // of silently selecting the first match.
+    await expect(card.locator('[data-testid="subagent-type"]')).toContainText("general-purpose");
+    await expect(card.locator('[data-testid="subagent-description"]')).toContainText(
+      "Explore the codebase",
     );
-    await expect(
-      session.chat.locator('[data-testid="subagent-description"]').first(),
-    ).toContainText("Explore the codebase");
 
     // Metadata row of chips surfaces the completed subagent's metrics.
-    await expect(session.chat.locator('[data-testid="subagent-meta"]').first()).toBeVisible();
-    await expect(
-      session.chat.locator('[data-testid="subagent-meta-duration"]').first(),
-    ).toContainText("2.2s");
-    await expect(
-      session.chat.locator('[data-testid="subagent-meta-tokens"]').first(),
-    ).toContainText("9,987");
-    await expect(session.chat.locator('[data-testid="subagent-meta-tools"]').first()).toContainText(
-      "3 tools",
-    );
+    await expect(card.locator('[data-testid="subagent-meta"]')).toBeVisible();
+    await expect(card.locator('[data-testid="subagent-meta-duration"]')).toContainText("2.2s");
+    await expect(card.locator('[data-testid="subagent-meta-tokens"]')).toContainText("9,987");
+    await expect(card.locator('[data-testid="subagent-meta-tools"]')).toContainText("3 tools");
     // The agent id is truncated with an ellipsis, so assert on a substring.
-    await expect(session.chat.locator('[data-testid="subagent-meta-agent"]').first()).toContainText(
-      "agent_e2e",
-    );
+    await expect(card.locator('[data-testid="subagent-meta-agent"]')).toContainText("agent_e2e");
   });
 });

--- a/apps/web/e2e/tests/chat/subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/subagent.spec.ts
@@ -57,5 +57,12 @@ test.describe("Subagent card", () => {
     await expect(card.locator('[data-testid="subagent-meta-tools"]')).toContainText("3 tools");
     // The agent id is truncated with an ellipsis, so assert on a substring.
     await expect(card.locator('[data-testid="subagent-meta-agent"]')).toContainText("agent_e2e");
+
+    // The subagent's internal tool call is nested UNDER its card (the mock emits
+    // a child carrying `_meta.claudeCode.parentToolUseId`), not as a flat sibling.
+    await expect(card.locator('[data-testid="subagent-child-count"]')).toContainText("1 tool call");
+    // Expand the card and confirm the child (sleep 30) renders inside it.
+    await card.getByRole("button").first().click();
+    await expect(card).toContainText("sleep 30");
   });
 });

--- a/apps/web/e2e/tests/chat/subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/subagent.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+// Drives the mock-agent's `subagent` scenario (triggered by the `/e2e:subagent`
+// directive). The scenario emits a claude-style subagent (Task) tool call with
+// full result metadata, which the kandev adapter normalizes to a subagent_task
+// payload. This file asserts the dedicated subagent card renders in the chat
+// with its type badge, description, and metadata chips. The card auto-collapses
+// once the subagent completes, so the badge/description/meta row are visible
+// without expanding.
+
+test.describe("Subagent card", () => {
+  test("renders type badge, description, and metadata chips on completion", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(60_000);
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Subagent card",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:subagent",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 30_000 });
+
+    // The dedicated subagent card renders, not the generic tool_call row.
+    const card = session.chat.locator('[data-testid="subagent-card"]').first();
+    await expect(card).toBeVisible();
+
+    // Type badge and description (visible while collapsed).
+    await expect(session.chat.locator('[data-testid="subagent-type"]').first()).toContainText(
+      "general-purpose",
+    );
+    await expect(
+      session.chat.locator('[data-testid="subagent-description"]').first(),
+    ).toContainText("Explore the codebase");
+
+    // Metadata row of chips surfaces the completed subagent's metrics.
+    await expect(session.chat.locator('[data-testid="subagent-meta"]').first()).toBeVisible();
+    await expect(
+      session.chat.locator('[data-testid="subagent-meta-duration"]').first(),
+    ).toContainText("2.2s");
+    await expect(
+      session.chat.locator('[data-testid="subagent-meta-tokens"]').first(),
+    ).toContainText("9,987");
+    await expect(session.chat.locator('[data-testid="subagent-meta-tools"]').first()).toContainText(
+      "3 tools",
+    );
+    // The agent id is truncated with an ellipsis, so assert on a substring.
+    await expect(session.chat.locator('[data-testid="subagent-meta-agent"]').first()).toContainText(
+      "agent_e2e",
+    );
+  });
+});

--- a/apps/web/e2e/tests/chat/subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/subagent.spec.ts
@@ -35,7 +35,11 @@ test.describe("Subagent card", () => {
     await session.waitForChatIdle({ timeout: 30_000 });
 
     // The dedicated subagent card renders, not the generic tool_call row.
-    const card = session.chat.locator('[data-testid="subagent-card"]').first();
+    // Assert exactly one so an accidental duplicate render fails the test
+    // rather than being masked by .first().
+    const cards = session.chat.locator('[data-testid="subagent-card"]');
+    await expect(cards).toHaveCount(1);
+    const card = cards.first();
     await expect(card).toBeVisible();
 
     // Type badge and description (visible while collapsed).


### PR DESCRIPTION
Agents that spawn subagents (the Task tool) previously surfaced as opaque generic tool calls in the task-details chat, so users couldn't see what was delegated or how it went. Subagent spawns from Claude, OpenCode, and Cursor are now detected, normalized, and rendered as a dedicated card showing the subagent type, description, and per-agent result metadata (duration, tokens, tool-use count, model, agent id).

## Important Changes

- New `acp/subagent.go` recognizer + extractor in the agentctl ACP adapter, following the existing `monitor.go`/`wakeup.go` `_meta.claudeCode` pattern; detection is cross-agent (Claude `_meta`, OpenCode tool `title`, Cursor `rawInput._toolName`). This activates the previously-orphaned `SubagentTaskPayload` scaffolding, extended with `model` and `child_session_id`.
- Frontend renders a subagent card with a graceful per-agent metadata chip row; the mock agent emits a claude-style subagent via `/e2e:subagent` so the path is exercised in tests.
- Codex has no subagent tool over ACP, so its "spawning" narration is correctly left as plain text (no card).

## Validation

- Backend: `go test ./internal/agentctl/... ./cmd/mock-agent/...` (1027 pass); `golangci-lint` clean on new code.
- Frontend: `pnpm --filter @kandev/web typecheck`, `test` (formatter unit tests), and `lint` all clean.
- E2E: `apps/web/e2e/tests/chat/{subagent,mobile-subagent}.spec.ts` pass on chromium + mobile-chrome.

## Possible Improvements

Low risk. Detection parses untyped wire maps defensively; an agent that changes its subagent wire shape would fall back to a generic tool card rather than break.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.