### PR TITLE
fix(web): honor default dockview widths on task open

### DIFF
--- a/apps/web/components/task/dockview-layout-restore.test.ts
+++ b/apps/web/components/task/dockview-layout-restore.test.ts
@@ -5,21 +5,10 @@ import {
   tryRestoreLayout,
 } from "./dockview-layout-restore";
 import * as localStorage from "@/lib/local-storage";
-import { ENV_SCOPED_DOCKVIEW_COMPONENTS } from "@/lib/state/dockview-env-scoped-components";
 
 const VALID_COMPONENTS = new Set<string>(["chat", "files", "shell", "git", "terminal"]);
 const PHANTOM_PANEL_ID = "session:phantom";
 const ALIVE_PANEL_ID = "session:alive-1";
-const PREVIEW_FILE_EDITOR_PANEL_ID = "preview:file-editor";
-const TERMINAL_DEFAULT_PANEL_ID = "terminal-default";
-const ENV_SCOPED_PANEL_ID_BY_COMPONENT: Record<string, string> = {
-  browser: "browser:http://localhost:3000",
-  "commit-detail": "preview:commit-detail",
-  "diff-viewer": "preview:file-diff",
-  "file-editor": PREVIEW_FILE_EDITOR_PANEL_ID,
-  "pr-detail": "pr-detail",
-  vscode: "vscode",
-};
 
 /**
  * Build a minimal valid SerializedDockview-shaped object — matches what
@@ -76,19 +65,6 @@ function makeFakeRestoreApi() {
     onDidActiveGroupChange: vi.fn(() => ({ dispose: vi.fn() })),
     onDidLayoutChange: vi.fn(() => ({ dispose: vi.fn() })),
   } as unknown as Parameters<typeof tryRestoreLayout>[0];
-}
-
-function restoreGlobalFallbackLayout(
-  layout: ReturnType<typeof buildLayout>,
-  components: Set<string>,
-) {
-  window.localStorage.setItem("dockview-layout-v2", JSON.stringify(layout));
-  const api = makeFakeRestoreApi();
-  const restored = tryRestoreLayout(api, null, components);
-
-  expect(restored).toBe(true);
-  expect(api.fromJSON).toHaveBeenCalledOnce();
-  return (api.fromJSON as ReturnType<typeof vi.fn>).mock.calls[0][0];
 }
 
 describe("sanitizeLayout - size validation", () => {
@@ -367,51 +343,24 @@ describe("tryRestoreLayout - phantom session panel filtering", () => {
   });
 });
 
-describe("tryRestoreLayout - global fallback env-scoped panel filtering", () => {
+describe("tryRestoreLayout - no env (task preparing)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     window.localStorage.clear();
   });
 
-  it.each(
-    [...ENV_SCOPED_DOCKVIEW_COMPONENTS].map((component) => ({
-      component,
-      panelId: ENV_SCOPED_PANEL_ID_BY_COMPONENT[component] ?? `${component}:stale`,
-    })),
-  )("strips $component panels from the no-env global fallback layout", ({ component, panelId }) => {
-    const layout = buildLayout();
-    layout.grid.root.data[1].data.views = [PHANTOM_PANEL_ID, panelId];
-    layout.grid.root.data[1].data.activeView = panelId;
-    const panels = layout.panels as Record<string, { id?: string; contentComponent: string }>;
-    delete panels.chat;
-    Object.assign(panels, {
-      [PHANTOM_PANEL_ID]: { id: PHANTOM_PANEL_ID, contentComponent: "chat" },
-      [panelId]: { id: panelId, contentComponent: component },
-    });
+  it("returns false and restores nothing when no env is known yet", () => {
+    // Regression: a null env (task preparing / session→env mapping not yet
+    // hydrated) must NOT restore the cross-env global layout — that flashed the
+    // previous task's proportions on a fresh task. onReady builds the default
+    // layout instead; the env's own layout is applied later by switchEnvLayout.
+    window.localStorage.setItem("dockview-layout-v2", JSON.stringify(buildLayout()));
+    const api = makeFakeRestoreApi();
 
-    const restoredLayout = restoreGlobalFallbackLayout(
-      layout,
-      new Set([...VALID_COMPONENTS, component]),
-    );
-    expect(Object.keys(restoredLayout.panels)).not.toContain(PHANTOM_PANEL_ID);
-    expect(Object.keys(restoredLayout.panels)).not.toContain(panelId);
-  });
+    const restored = tryRestoreLayout(api, null, VALID_COMPONENTS);
 
-  it("keeps terminal panels in the no-env global fallback layout", () => {
-    const layout = buildLayout();
-    layout.grid.root.data[1].data.views = [TERMINAL_DEFAULT_PANEL_ID];
-    layout.grid.root.data[1].data.activeView = TERMINAL_DEFAULT_PANEL_ID;
-    const panels = layout.panels as Record<string, { id?: string; contentComponent: string }>;
-    delete panels.chat;
-    Object.assign(panels, {
-      [TERMINAL_DEFAULT_PANEL_ID]: {
-        id: TERMINAL_DEFAULT_PANEL_ID,
-        contentComponent: "terminal",
-      },
-    });
-
-    const restoredLayout = restoreGlobalFallbackLayout(layout, VALID_COMPONENTS);
-    expect(Object.keys(restoredLayout.panels)).toContain(TERMINAL_DEFAULT_PANEL_ID);
+    expect(restored).toBe(false);
+    expect(api.fromJSON).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -12,9 +12,6 @@ import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debug = createDebugLogger("dockview:restore");
 
-// Mirrors LAYOUT_STORAGE_KEY in dockview-layout-setup.ts. Bump in lockstep.
-const LAYOUT_STORAGE_KEY = "dockview-layout-v2";
-
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type SanitizeLayoutOptions =
   | { stripSessionPanels: true; stripEnvScopedPanels?: boolean; excludeSessionIds?: never }
@@ -242,34 +239,19 @@ export function tryRestoreLayout(
   validComponents: Set<string>,
   phantomSessionIds?: Set<string>,
 ): boolean {
-  if (currentEnvId) {
-    try {
-      if (tryRestoreEnvLayout(api, currentEnvId, validComponents, phantomSessionIds)) return true;
-    } catch {
-      // fall through to maximize-only / global fallback
-    }
-    if (tryRestoreMaximizeOnly(api, currentEnvId)) return true;
+  // No env yet — the task is still preparing or its session→env mapping hasn't
+  // hydrated. Return false so `onReady` builds the DEFAULT layout instead of
+  // restoring a cross-env "last layout": the global layout key is shared across
+  // tasks, so restoring it here would flash the *previous* task's proportions
+  // while a fresh task prepares. The env's own saved layout is applied later by
+  // `switchEnvLayout` once the env hydrates.
+  if (!currentEnvId) return false;
+  try {
+    if (tryRestoreEnvLayout(api, currentEnvId, validComponents, phantomSessionIds)) return true;
+  } catch {
+    // fall through to maximize-only
   }
-
-  if (!currentEnvId) {
-    try {
-      const saved = localStorage.getItem(LAYOUT_STORAGE_KEY);
-      if (saved) {
-        const layout = sanitizeLayout(JSON.parse(saved), validComponents, {
-          stripSessionPanels: true,
-          stripEnvScopedPanels: true,
-        });
-        if (!layout) return false;
-        api.fromJSON(layout);
-        useDockviewStore.setState(applyLayoutFixups(api));
-        return true;
-      }
-    } catch {
-      // fall through to default-build
-    }
-  }
-
-  return false;
+  return tryRestoreMaximizeOnly(api, currentEnvId);
 }
 
 /**

--- a/apps/web/components/task/dockview-layout-setup.ts
+++ b/apps/web/components/task/dockview-layout-setup.ts
@@ -242,6 +242,11 @@ export function setupLayoutPersistence(
     try {
       const json = api.toJSON();
       const envId = envIdRef.current;
+      // Global snapshot of the last layout. NOTE: restore is per-env (see
+      // tryRestoreLayout) — this key is no longer read on load, since
+      // restoring a cross-env layout flashed the previous task's proportions
+      // while a fresh task prepared. Kept as a debounced-save checkpoint that
+      // e2e polls to know a layout change has flushed before reloading.
       localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(json));
       if (envId) {
         setEnvLayout(envId, json);

--- a/apps/web/components/task/layout-preset-selector.tsx
+++ b/apps/web/components/task/layout-preset-selector.tsx
@@ -276,7 +276,7 @@ export function LayoutPresetSelector() {
               return (
                 <DropdownMenuItem
                   key={preset.id}
-                  onClick={() => applyBuiltInPreset(preset.id)}
+                  onClick={() => applyBuiltInPreset(preset.id, true)}
                   className="cursor-pointer"
                 >
                   <Icon className="h-4 w-4 mr-2 shrink-0" />

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -70,6 +70,10 @@
  *                              build-default-{entry,done}     first paint / reset
  *                              env-switch-{resize,resize-col,done}
  *                                                              cross-task switch
+ *                              fixups-capture                 target captured vs cap in
+ *                                                              applyLayoutFixups; caller=<chain>,
+ *                                                              cols=<n>, sidebarOverCap=true means
+ *                                                              the recorded target is unreachable
  *                              container-resize               DOM ResizeObserver fired
  *                              sash-drag-end                  user-released sash
  *                              store-sync                     live widths → store pinnedWidths

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -70,6 +70,10 @@
  *                              build-default-{entry,done}     first paint / reset
  *                              env-switch-{resize,resize-col,done}
  *                                                              cross-task switch
+ *                              preset-apply / preset-post-layout
+ *                                                              layout-selector preset switch:
+ *                                                              applied widths + snapshot before
+ *                                                              and after the rAF api.layout
  *                              fixups-capture                 target captured vs cap in
  *                                                              applyLayoutFixups; caller=<chain>,
  *                                                              cols=<n>, sidebarOverCap=true means

--- a/apps/web/lib/state/dockview-env-switch-action.test.ts
+++ b/apps/web/lib/state/dockview-env-switch-action.test.ts
@@ -73,16 +73,21 @@ describe("switchEnvLayout — root fix for terminal/layout swapping", () => {
     expect(useDockviewStore.getState().currentLayoutEnvId).toBe("env-new");
   });
 
-  it("first adoption (no previous env) just records the new env", () => {
+  it("first adoption applies the env's layout without overwriting it or releasing portals", () => {
     const api = makeMockApi();
     useDockviewStore.setState({ api, currentLayoutEnvId: null });
 
     useDockviewStore.getState().switchEnvLayout(null, "env-first", "session-Y");
 
-    // First adoption keeps existing layout, no portal release on the
-    // (empty) outgoing env.
+    // No outgoing env to save/release.
     expect(panelPortalManager.releaseByEnv).not.toHaveBeenCalled();
     expect(useDockviewStore.getState().currentLayoutEnvId).toBe("env-first");
+    // Regression: the old "just adopt onReady's layout" shortcut persisted the
+    // stale global-fallback layout into the new env via setEnvLayout(newEnvId,
+    // toJSON()), overwriting any real saved layout and giving fresh tasks the
+    // previous env's proportions. First adoption must apply the env's layout
+    // (defaults here, since getEnvLayout is mocked null), never persist over it.
+    expect(setEnvLayout).not.toHaveBeenCalledWith("env-first", expect.anything());
   });
 
   it("does nothing when api is unset", () => {

--- a/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
+++ b/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
@@ -101,6 +101,19 @@ describe("applyLayoutFixups — pinned target capture", () => {
     expect(setPinnedTarget).toHaveBeenCalledWith("right", 400);
   });
 
+  it("records the side-column target for a 3-column preset without RIGHT_TOP_GROUP", () => {
+    // Regression: vscode/preview/plan presets put their side column in a group
+    // with a generated id (not RIGHT_TOP_GROUP). The target must still be
+    // captured per-env, or switching to such a task leaks the previous task's
+    // right target and snaps its side column to the wrong width.
+    mockSplitview([350, 720, 420]); // sidebar, center, vscode/preview side col
+    const api = makeApi([SIDEBAR_GROUP, CENTER_GROUP, "group-generated-7"]);
+
+    applyLayoutFixups(api);
+
+    expect(setPinnedTarget).toHaveBeenCalledWith("right", 420);
+  });
+
   it("clamps an over-cap right target down to the cap", () => {
     mockSplitview([350, 200, 1200]); // right (1200) exceeds RIGHT_CAP (1029)
     const api = makeApi([SIDEBAR_GROUP, CENTER_GROUP, RIGHT_TOP_GROUP]);

--- a/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
+++ b/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DockviewApi } from "dockview-react";
+
+// Dedicated file for `applyLayoutFixups` pinned-target capture. Mocks
+// `./layout-manager` so we can drive the splitview geometry and spy on
+// `setPinnedTarget` without standing up a real dockview instance. Kept
+// separate from `dockview-layout-builders.test.ts` (which exercises
+// `fallbackGroupPosition` against the real layout-manager constants).
+
+const SIDEBAR_CAP = 441;
+const RIGHT_CAP = 1029;
+
+vi.mock("@/lib/debug/log", () => ({
+  createDebugLogger: () => () => {},
+  IS_DEBUG: false,
+}));
+
+vi.mock("./layout-manager", () => ({
+  SIDEBAR_LOCK: "no-drop-target",
+  SIDEBAR_GROUP: "group-sidebar",
+  CENTER_GROUP: "group-center",
+  RIGHT_TOP_GROUP: "group-right-top",
+  RIGHT_BOTTOM_GROUP: "group-right-bottom",
+  LAYOUT_PINNED_MIN_PX: 180,
+  computeSidebarMaxPx: vi.fn(() => SIDEBAR_CAP),
+  computeRightMaxPx: vi.fn(() => RIGHT_CAP),
+  getRootSplitview: vi.fn(),
+  resolveGroupIds: vi.fn(() => ({
+    sidebarGroupId: "group-sidebar",
+    centerGroupId: "group-center",
+    rightTopGroupId: "group-right-top",
+    rightBottomGroupId: "group-right-bottom",
+  })),
+  setPinnedTarget: vi.fn(),
+}));
+
+import { applyLayoutFixups } from "./dockview-layout-builders";
+import { getRootSplitview, setPinnedTarget, RIGHT_TOP_GROUP } from "./layout-manager";
+
+const SIDEBAR_GROUP = "group-sidebar";
+const CENTER_GROUP = "group-center";
+const RIGHT_BOTTOM_GROUP = "group-right-bottom";
+
+function mockSplitview(sizesByIndex: number[]): void {
+  vi.mocked(getRootSplitview).mockReturnValue({
+    length: sizesByIndex.length,
+    getViewSize: (idx: number) => sizesByIndex[idx],
+  } as unknown as NonNullable<ReturnType<typeof getRootSplitview>>);
+}
+
+function makeApi(groupIds: string[]): DockviewApi {
+  const sidebarGroup = {
+    locked: undefined as unknown,
+    header: { hidden: true },
+    width: 0,
+    api: { setConstraints: vi.fn() },
+  };
+  return {
+    width: 1470,
+    groups: groupIds.map((id) => ({ id, api: { setConstraints: vi.fn() } })),
+    getPanel: (id: string) => (id === "sidebar" ? { group: sidebarGroup } : null),
+  } as unknown as DockviewApi;
+}
+
+describe("applyLayoutFixups — pinned target capture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does NOT record a right target in the 2-column fallback (center is last)", () => {
+    // Regression: global-fallback restore strips env-scoped right panels,
+    // leaving [sidebar, center]. The last splitview child is the CENTER
+    // column — its width must never be recorded as the "right" target, or it
+    // inflates the real right column and gets persisted into the env layout.
+    mockSplitview([474, 996]); // idx0 = sidebar, idx1 = center (NOT right)
+    const api = makeApi([SIDEBAR_GROUP, CENTER_GROUP]); // no right groups
+
+    applyLayoutFixups(api);
+
+    expect(setPinnedTarget).not.toHaveBeenCalledWith("right", expect.anything());
+  });
+
+  it("clamps an over-cap sidebar target down to the cap", () => {
+    // sidebar live (474) exceeds the cap (441); the constraint pins it at the
+    // cap, so the target must be clamped or enforcePinnedTargets spins forever.
+    mockSplitview([474, 996]);
+    const api = makeApi([SIDEBAR_GROUP, CENTER_GROUP]);
+
+    applyLayoutFixups(api);
+
+    expect(setPinnedTarget).toHaveBeenCalledWith("sidebar", SIDEBAR_CAP);
+  });
+
+  it("records both targets in a real 3-column layout", () => {
+    mockSplitview([350, 720, 400]); // sidebar, center, right
+    const api = makeApi([SIDEBAR_GROUP, CENTER_GROUP, RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP]);
+
+    applyLayoutFixups(api);
+
+    expect(setPinnedTarget).toHaveBeenCalledWith("sidebar", 350);
+    expect(setPinnedTarget).toHaveBeenCalledWith("right", 400);
+  });
+
+  it("clamps an over-cap right target down to the cap", () => {
+    mockSplitview([350, 200, 1200]); // right (1200) exceeds RIGHT_CAP (1029)
+    const api = makeApi([SIDEBAR_GROUP, CENTER_GROUP, RIGHT_TOP_GROUP]);
+
+    applyLayoutFixups(api);
+
+    expect(setPinnedTarget).toHaveBeenCalledWith("right", RIGHT_CAP);
+  });
+});

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -80,30 +80,33 @@ function captureSidebarTarget(api: DockviewApi, sv: any): void {
   }
 }
 
-/** Constrain the right column's groups and record its target width, clamped to
- *  the cap.
+/** Constrain the default layout's right column groups and record the side
+ *  column's target width, clamped to the cap.
  *
- *  Only records a right target when a genuine right column exists AND it is a
- *  distinct column from the center (`sv.length >= 3`). In the 2-column
- *  global-fallback restore (right panels stripped as env-scoped, only
- *  sidebar + center remain), the LAST splitview child is the CENTER column —
- *  recording its width as the "right" target inflates the real right column
- *  once the full layout materializes, and the inflated width gets persisted
- *  into the env layout, so every later open loads broken widths. */
+ *  The target is recorded whenever a distinct last column exists
+ *  (`sv.length >= 3`). It must NOT be gated on the well-known RIGHT_TOP/BOTTOM
+ *  group ids: the vscode/preview/plan presets put their side column in a group
+ *  with a generated id, so gating on those ids would skip the capture and let
+ *  the PREVIOUS task's right target leak in — switching to one of those tasks
+ *  would then snap its side column to whatever width the last task left.
+ *
+ *  `sv.length >= 3` still excludes the 2-column global-fallback restore
+ *  (sidebar + center, right panels stripped as env-scoped), where the last
+ *  splitview child is the CENTER column — recording its width as the "right"
+ *  target would inflate the real right column once the full layout materializes
+ *  and persist that into the env layout. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function captureRightTarget(api: DockviewApi, sv: any): void {
-  // Groups created from presets carry stable IDs (e.g. "group-right-top"),
-  // so this works regardless of which panels are in them.
+  // Constrain the default preset's right column groups (stable well-known IDs).
+  // Other presets' side columns aren't pinned and carry no max-width cap.
   const rightCap = computeRightMaxPx();
-  let hasRightColumn = false;
   for (const gid of [RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP]) {
     const group = api.groups.find((g) => g.id === gid);
     if (group) {
-      hasRightColumn = true;
       group.api.setConstraints({ maximumWidth: rightCap, minimumWidth: LAYOUT_PINNED_MIN_PX });
     }
   }
-  if (!hasRightColumn || !sv || sv.length < 3) return;
+  if (!sv || sv.length < 3) return;
   const liveRight = sv.getViewSize(sv.length - 1);
   if (typeof liveRight === "number" && liveRight > 0) {
     setPinnedTarget("right", Math.min(liveRight, rightCap));

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -13,9 +13,32 @@ import {
   setPinnedTarget,
 } from "./layout-manager";
 import type { LayoutGroupIds } from "./layout-manager";
+import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 // Re-export for consumers that import from this module
 export { getRootSplitview } from "./layout-manager";
+
+const debugWidths = createDebugLogger("dockview:widths");
+
+/** Best-effort caller chain for the fixups-capture debug log: pull the first
+ *  few stack frames above `applyLayoutFixups` so we can see WHICH layout path
+ *  (env-switch / restore / custom-layout / maximize) recorded a given target.
+ *  Debug-only — never called when IS_DEBUG is false. */
+function captureCallerChain(): string {
+  const stack = new Error().stack;
+  if (!stack) return "-";
+  const lines = stack.split("\n").slice(1);
+  const frames: string[] = [];
+  for (const line of lines) {
+    const m = /at (\S+)/.exec(line);
+    const name = m?.[1] ?? "";
+    if (!name || name === "captureCallerChain" || name === "applyLayoutFixups") continue;
+    const short = name.split(".").pop() ?? name;
+    frames.push(short);
+    if (frames.length >= 3) break;
+  }
+  return frames.join("<") || "-";
+}
 
 /** After fromJSON() restores a session layout, apply fixups and return group IDs.
  *
@@ -24,42 +47,89 @@ export { getRootSplitview } from "./layout-manager";
  *  the column to that target on every subsequent rebalance. */
 export function applyLayoutFixups(api: DockviewApi): LayoutGroupIds {
   const sv = getRootSplitviewImpl(api);
-  const sb = api.getPanel("sidebar");
-  if (sb) {
-    sb.group.locked = SIDEBAR_LOCK;
-    sb.group.header.hidden = false;
-    sb.group.api.setConstraints({
-      maximumWidth: computeSidebarMaxPx(),
-      minimumWidth: LAYOUT_PINNED_MIN_PX,
-    });
-    const live = sv?.getViewSize?.(0) ?? sb.group.width;
-    if (typeof live === "number" && live > 0) setPinnedTarget("sidebar", live);
-  }
+  captureSidebarTarget(api, sv);
 
   const oldChanges = api.getPanel("diff-files");
   if (oldChanges) oldChanges.api.setTitle("Changes");
   const oldFiles = api.getPanel("all-files");
   if (oldFiles) oldFiles.api.setTitle("Files");
 
-  // Constrain right column groups by their well-known IDs.
+  captureRightTarget(api, sv);
+
+  logFixupsCapture(api, sv);
+
+  return resolveGroupIds(api);
+}
+
+/** Lock + constrain the sidebar group and record its target width, clamped to
+ *  the cap. The constraint pins the column at `sidebarCap`, so a target above
+ *  it is unreachable and makes `enforcePinnedTargets` spin forever. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function captureSidebarTarget(api: DockviewApi, sv: any): void {
+  const sb = api.getPanel("sidebar");
+  if (!sb) return;
+  const sidebarCap = computeSidebarMaxPx();
+  sb.group.locked = SIDEBAR_LOCK;
+  sb.group.header.hidden = false;
+  sb.group.api.setConstraints({ maximumWidth: sidebarCap, minimumWidth: LAYOUT_PINNED_MIN_PX });
+  const live = sv?.getViewSize?.(0) ?? sb.group.width;
+  if (typeof live === "number" && live > 0) {
+    setPinnedTarget("sidebar", Math.min(live, sidebarCap));
+  }
+}
+
+/** Constrain the right column's groups and record its target width, clamped to
+ *  the cap.
+ *
+ *  Only records a right target when a genuine right column exists AND it is a
+ *  distinct column from the center (`sv.length >= 3`). In the 2-column
+ *  global-fallback restore (right panels stripped as env-scoped, only
+ *  sidebar + center remain), the LAST splitview child is the CENTER column —
+ *  recording its width as the "right" target inflates the real right column
+ *  once the full layout materializes, and the inflated width gets persisted
+ *  into the env layout, so every later open loads broken widths. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function captureRightTarget(api: DockviewApi, sv: any): void {
   // Groups created from presets carry stable IDs (e.g. "group-right-top"),
   // so this works regardless of which panels are in them.
   const rightCap = computeRightMaxPx();
+  let hasRightColumn = false;
   for (const gid of [RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP]) {
     const group = api.groups.find((g) => g.id === gid);
     if (group) {
-      group.api.setConstraints({
-        maximumWidth: rightCap,
-        minimumWidth: LAYOUT_PINNED_MIN_PX,
-      });
+      hasRightColumn = true;
+      group.api.setConstraints({ maximumWidth: rightCap, minimumWidth: LAYOUT_PINNED_MIN_PX });
     }
   }
-  if (sv && sv.length >= 2) {
-    const liveRight = sv.getViewSize(sv.length - 1);
-    if (typeof liveRight === "number" && liveRight > 0) setPinnedTarget("right", liveRight);
+  if (!hasRightColumn || !sv || sv.length < 3) return;
+  const liveRight = sv.getViewSize(sv.length - 1);
+  if (typeof liveRight === "number" && liveRight > 0) {
+    setPinnedTarget("right", Math.min(liveRight, rightCap));
   }
+}
 
-  return resolveGroupIds(api);
+/** Emit the `fixups-capture` width snapshot. Pulled out of `applyLayoutFixups`
+ *  to keep that function under the complexity limit; no-op in prod. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function logFixupsCapture(api: DockviewApi, sv: any): void {
+  if (!IS_DEBUG) return;
+  // Decisive fields: `sidebarOverCap=true` means the recorded target exceeds
+  // the cap that enforcement clamps the column to — i.e. an unreachable target
+  // that makes `enforcePinnedTargets` spin forever. `cols` shows whether the
+  // layout was complete at capture (cols<3 → no real right column). api.width
+  // vs window.innerWidth surfaces the window-fallback cap divergence.
+  const sidebarCap = computeSidebarMaxPx();
+  const innerW = typeof window !== "undefined" ? window.innerWidth : -1;
+  const liveSidebar = sv?.getViewSize?.(0);
+  const liveRight = sv && sv.length >= 2 ? sv.getViewSize(sv.length - 1) : undefined;
+  const r = (n: number | undefined): string =>
+    typeof n === "number" ? String(Math.round(n)) : "-";
+  debugWidths(
+    `fixups-capture caller=${captureCallerChain()} apiW=${api.width} innerW=${innerW} ` +
+      `cols=${sv?.length ?? 0} sidebarCap=${Math.round(sidebarCap)} liveSidebar=${r(liveSidebar)} ` +
+      `rightCap=${Math.round(computeRightMaxPx())} liveRight=${r(liveRight)} ` +
+      `sidebarOverCap=${typeof liveSidebar === "number" && liveSidebar > sidebarCap + 1}`,
+  );
 }
 
 /**

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -24,6 +24,8 @@ const debugWidths = createDebugLogger("dockview:widths");
  *  few stack frames above `applyLayoutFixups` so we can see WHICH layout path
  *  (env-switch / restore / custom-layout / maximize) recorded a given target.
  *  Debug-only — never called when IS_DEBUG is false. */
+const CALLER_CHAIN_SKIP = new Set(["captureCallerChain", "applyLayoutFixups", "logFixupsCapture"]);
+
 function captureCallerChain(): string {
   const stack = new Error().stack;
   if (!stack) return "-";
@@ -32,7 +34,7 @@ function captureCallerChain(): string {
   for (const line of lines) {
     const m = /at (\S+)/.exec(line);
     const name = m?.[1] ?? "";
-    if (!name || name === "captureCallerChain" || name === "applyLayoutFixups") continue;
+    if (!name || CALLER_CHAIN_SKIP.has(name)) continue;
     const short = name.split(".").pop() ?? name;
     frames.push(short);
     if (frames.length >= 3) break;
@@ -121,7 +123,9 @@ function logFixupsCapture(api: DockviewApi, sv: any): void {
   const sidebarCap = computeSidebarMaxPx();
   const innerW = typeof window !== "undefined" ? window.innerWidth : -1;
   const liveSidebar = sv?.getViewSize?.(0);
-  const liveRight = sv && sv.length >= 2 ? sv.getViewSize(sv.length - 1) : undefined;
+  // Threshold matches captureRightTarget (>= 3): in a 2-column layout the last
+  // child is the center, not a right column, so we don't mislabel it here.
+  const liveRight = sv && sv.length >= 3 ? sv.getViewSize(sv.length - 1) : undefined;
   const r = (n: number | undefined): string =>
     typeof n === "number" ? String(Math.round(n)) : "-";
   debugWidths(

--- a/apps/web/lib/state/dockview-store.test.ts
+++ b/apps/web/lib/state/dockview-store.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { DockviewApi } from "dockview-react";
-import { useDockviewStore } from "./dockview-store";
+import {
+  useDockviewStore,
+  resolvePresetPinnedWidths,
+  collectPinnedWidthUpdates,
+} from "./dockview-store";
 
 type ActivePanelEvent = { id: string };
 type CapturedHandlers = {
@@ -89,5 +93,111 @@ describe("dockview-store resolveFilePath (via onDidActivePanelChange)", () => {
 
     captured.active?.(undefined);
     expect(useDockviewStore.getState().activeFilePath).toBeNull();
+  });
+});
+
+describe("resolvePresetPinnedWidths", () => {
+  // sidebar + center + right, with the legacy initial caps (sidebar 350, right
+  // 450). At totalWidth 1600 the ratio (0.25) is 400 → sidebar clamps to 350,
+  // right stays 400.
+  const cols = [
+    { id: "sidebar", pinned: true, groups: [] },
+    { id: "center", groups: [] },
+    { id: "right", pinned: true, groups: [] },
+  ] as unknown as Parameters<typeof resolvePresetPinnedWidths>[1];
+
+  it("returns each pinned column's default width when resetWidths is true", () => {
+    // Explicit layout pick: drop the carried-over live widths and pass the
+    // preset's computed defaults as explicit overrides (NOT an empty map, which
+    // would let applyLayout capture a transient post-fromJSON live size).
+    const live = new Map([
+      ["sidebar", 519],
+      ["right", 900],
+    ]);
+
+    const result = resolvePresetPinnedWidths(live, cols, 1600, true);
+
+    expect(result.get("sidebar")).toBe(350); // clamped to legacy sidebar cap
+    expect(result.get("right")).toBe(400); // ratio 0.25 * 1600
+    expect(result.has("center")).toBe(false); // not pinned
+  });
+
+  it("keeps live widths for columns in the target layout when not resetting", () => {
+    const live = new Map([
+      ["sidebar", 519],
+      ["right", 900],
+    ]);
+
+    const result = resolvePresetPinnedWidths(live, cols, 1600, false);
+
+    expect(result.get("sidebar")).toBe(519);
+    expect(result.get("right")).toBe(900);
+  });
+
+  it("drops live overrides for columns absent from the target layout", () => {
+    // e.g. switching to a layout without a "right" column must not leak the
+    // old right width into the new layout.
+    const live = new Map([
+      ["sidebar", 300],
+      ["right", 900],
+    ]);
+    const noRight = [
+      { id: "sidebar", pinned: true, groups: [] },
+      { id: "center", groups: [] },
+    ] as unknown as Parameters<typeof resolvePresetPinnedWidths>[1];
+
+    const result = resolvePresetPinnedWidths(live, noRight, 1600, false);
+
+    expect(result.get("sidebar")).toBe(300);
+    expect(result.has("right")).toBe(false);
+  });
+
+  it("does not mutate the input map", () => {
+    const live = new Map([["sidebar", 300]]);
+    resolvePresetPinnedWidths(live, cols, 1600, false);
+    expect(live.get("sidebar")).toBe(300);
+  });
+});
+
+describe("collectPinnedWidthUpdates", () => {
+  const size = (i: number) => [350, 560, 560][i]; // sidebar, center, last
+
+  it("tracks sidebar + right when both are visible", () => {
+    const columns = [{ id: "sidebar" }, { id: "center" }, { id: "right" }];
+
+    const updates = collectPinnedWidthUpdates(columns, size, {
+      sidebarVisible: true,
+      rightPanelsVisible: true,
+    });
+
+    expect(updates.get("sidebar")).toBe(350);
+    expect(updates.get("right")).toBe(560);
+  });
+
+  it("does NOT track right when rightPanelsVisible is false (plan/preview/vscode)", () => {
+    // Regression: in plan mode the side column inherits files/changes panels
+    // and fromDockviewApi labels it "right". With the right column hidden, its
+    // width must NOT be captured, or it leaks into the default layout on
+    // toggle-back.
+    const columns = [{ id: "sidebar" }, { id: "center" }, { id: "right" }];
+
+    const updates = collectPinnedWidthUpdates(columns, size, {
+      sidebarVisible: true,
+      rightPanelsVisible: false,
+    });
+
+    expect(updates.has("right")).toBe(false);
+    expect(updates.get("sidebar")).toBe(350);
+  });
+
+  it("skips collapsed/transient widths <= 50px", () => {
+    const columns = [{ id: "sidebar" }, { id: "right" }];
+
+    const updates = collectPinnedWidthUpdates(columns, () => 40, {
+      sidebarVisible: true,
+      rightPanelsVisible: true,
+    });
+
+    expect(updates.size).toBe(0);
   });
 });

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -605,20 +605,20 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
       debugSwitch("envSwitch: skip (same env)", { newEnvId });
       return;
     }
-    // First adoption — onReady already built the layout; just adopt it.
-    if (!oldEnvId && !currentLayoutEnvId) {
-      set({ isRestoringLayout: true, currentLayoutEnvId: newEnvId });
-      if (restoreMaximizeFromStorage(api, newEnvId, set)) return;
-      set({ isRestoringLayout: false, currentLayoutEnvId: newEnvId });
-      try {
-        setEnvLayout(newEnvId, api.toJSON());
-      } catch {
-        /* ignore */
-      }
-      return;
-    }
-    // When oldEnvId is null but there is a live layout env (e.g. the
-    // useEnvSwitchCleanup hook fires after passing through a null state),
+    // First adoption (oldEnvId and currentLayoutEnvId both null) falls through
+    // to the general path below. We deliberately do NOT "just adopt" whatever
+    // onReady rendered: this branch only fires when onReady ran with a null
+    // env (otherwise currentLayoutEnvId would equal newEnvId and we'd have
+    // skipped above as same-env), so onReady built the cross-env GLOBAL
+    // FALLBACK layout — not this env's saved/default layout. Adopting it gave a
+    // fresh task the previous env's stale proportions instead of the defaults,
+    // and `setEnvLayout(newEnvId, api.toJSON())` even overwrote the env's real
+    // saved layout with that stale one. `performEnvSwitch` instead restores the
+    // env's saved layout (or builds defaults for a brand-new task), and
+    // `saveOutgoingEnv(null)` below is a no-op so there is nothing to lose.
+    //
+    // When oldEnvId is null but there IS a live layout env (the
+    // useEnvSwitchCleanup hook firing after passing through a null state),
     // fall back to currentLayoutEnvId so we correctly save and release the
     // outgoing env rather than silently skipping it.
     const effectiveOld = oldEnvId ?? currentLayoutEnvId;

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -18,6 +18,7 @@ import {
   getPresetLayout,
   getPresetSidebarColumn,
   applyLayout,
+  getPinnedWidth,
   getRootSplitview,
   fromDockviewApi,
   filterEphemeral,
@@ -157,7 +158,7 @@ type DockviewStore = {
   toggleRightPanels: () => void;
   setSidebarVisible: (visible: boolean) => void;
   setRightPanelsVisible: (visible: boolean) => void;
-  applyBuiltInPreset: (preset: BuiltInPreset) => void;
+  applyBuiltInPreset: (preset: BuiltInPreset, resetWidths?: boolean) => void;
   defaultPreset: BuiltInPreset;
   setDefaultPreset: (preset: BuiltInPreset) => void;
   applyCustomLayout: (layout: SavedLayoutConfig) => void;
@@ -219,6 +220,34 @@ function applyDeferredPanelActions(api: DockviewApi, actions: DeferredPanelActio
 /** Read live column widths from dockview's splitview and persist them as pinned overrides.
  *  Only syncs widths for columns identified as "sidebar" or "right" to avoid
  *  capturing plan/preview/vscode column widths as stale "right" overrides. */
+/**
+ * Build the pinnedWidths updates for a width sync, tracking a column only when
+ * it is the VISIBLE default sidebar/right.
+ *
+ * In plan/preview/vscode layouts the side column inherits merged files/changes
+ * panels and `fromDockviewApi` mislabels it "right"; storing its width as the
+ * right override would then leak into the default layout when toggling back
+ * (e.g. plan-mode off snapping the right column to the plan column's width).
+ * Mirrors the visibility guards in `trackPinnedWidths`. Widths <= 50px are
+ * treated as transient/collapsed and skipped.
+ */
+export function collectPinnedWidthUpdates(
+  columns: { id: string }[],
+  getSize: (index: number) => number,
+  visibility: { sidebarVisible: boolean; rightPanelsVisible: boolean },
+): Map<string, number> {
+  const updates = new Map<string, number>();
+  columns.forEach((col, i) => {
+    const tracked =
+      (col.id === "sidebar" && visibility.sidebarVisible) ||
+      (col.id === "right" && visibility.rightPanelsVisible);
+    if (!tracked) return;
+    const w = getSize(i);
+    if (w > 50) updates.set(col.id, w);
+  });
+  return updates;
+}
+
 function syncPinnedWidthsFromApi(api: DockviewApi, set: StoreSet): void {
   if (api.hasMaximizedGroup()) return;
   const sv = getRootSplitview(api);
@@ -226,14 +255,11 @@ function syncPinnedWidthsFromApi(api: DockviewApi, set: StoreSet): void {
   try {
     const state = fromDockviewApi(api);
     if (state.columns.length !== sv.length) return;
-    const updates = new Map<string, number>();
-    for (let i = 0; i < state.columns.length; i++) {
-      const col = state.columns[i];
-      if (col.id === "sidebar" || col.id === "right") {
-        const w = sv.getViewSize(i);
-        if (w > 50) updates.set(col.id, w);
-      }
-    }
+    const { sidebarVisible, rightPanelsVisible } = useDockviewStore.getState();
+    const updates = collectPinnedWidthUpdates(state.columns, (i) => sv.getViewSize(i), {
+      sidebarVisible,
+      rightPanelsVisible,
+    });
     if (updates.size > 0) {
       if (IS_DEBUG) {
         const pairs = Array.from(updates.entries())
@@ -253,6 +279,42 @@ function syncPinnedWidthsFromApi(api: DockviewApi, set: StoreSet): void {
 }
 
 /** Capture the live sidebar/right pixel widths into pinnedWidths before a layout rebuild. */
+/**
+ * Decide which pinned-width overrides to apply when switching to a preset.
+ *
+ * - `resetWidths` (explicit layout pick from the selector): return each pinned
+ *   column's computed DEFAULT width (ratio clamped to its initial cap). These
+ *   are passed as explicit overrides — NOT an empty map — so `applyLayout`'s
+ *   resize-to-target path is used. An empty map makes it read the
+ *   post-`fromJSON` live size instead, which is fragile: dockview can lay
+ *   `fromJSON` out at a transient narrower width, and that shrunken size would
+ *   be captured as the pinned target and then enforced, leaving the columns
+ *   too narrow.
+ * - otherwise (programmatic switch, e.g. plan-mode toggle): keep the live
+ *   widths, minus overrides for columns absent in the target layout, so the
+ *   user's current sidebar/right widths carry across the switch.
+ */
+export function resolvePresetPinnedWidths(
+  liveWidths: Map<string, number>,
+  columns: LayoutState["columns"],
+  totalWidth: number,
+  resetWidths: boolean,
+): Map<string, number> {
+  if (resetWidths) {
+    const defaults = new Map<string, number>();
+    for (const col of columns) {
+      if (col.pinned) defaults.set(col.id, getPinnedWidth(col, totalWidth, undefined));
+    }
+    return defaults;
+  }
+  const targetColumnIds = new Set(columns.map((c) => c.id));
+  const cleaned = new Map(liveWidths);
+  for (const key of cleaned.keys()) {
+    if (!targetColumnIds.has(key)) cleaned.delete(key);
+  }
+  return cleaned;
+}
+
 function captureLiveWidths(api: DockviewApi, set: StoreSet): Map<string, number> {
   if (api.hasMaximizedGroup()) {
     api.exitMaximizedGroup();
@@ -420,7 +482,7 @@ function buildVisibilityActions(set: StoreSet, get: StoreGet) {
 
 function buildPresetActions(set: StoreSet, get: StoreGet) {
   return {
-    applyBuiltInPreset: (preset: BuiltInPreset) => {
+    applyBuiltInPreset: (preset: BuiltInPreset, resetWidths = false) => {
       const { api } = get();
       if (!api) return;
       const liveWidths = captureLiveWidths(api, set);
@@ -431,13 +493,23 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       set({ isRestoringLayout: true });
       const presetState = getPresetLayout(preset);
       const state = mergeCurrentPanelsIntoPreset(api, presetState);
-      // Remove stale pinned overrides for columns absent in the target layout
-      const targetColumnIds = new Set(state.columns.map((c) => c.id));
-      const cleanedWidths = new Map(liveWidths);
-      for (const key of cleanedWidths.keys()) {
-        if (!targetColumnIds.has(key)) cleanedWidths.delete(key);
-      }
+      // resetWidths (explicit pick from the layout selector) → preset defaults;
+      // otherwise carry live widths minus columns absent in the target layout.
+      const cleanedWidths = resolvePresetPinnedWidths(
+        liveWidths,
+        state.columns,
+        safeWidth,
+        resetWidths,
+      );
       const ids = applyLayout(api, state, cleanedWidths, safeWidth, safeHeight);
+      if (IS_DEBUG) {
+        const applied =
+          [...cleanedWidths].map(([k, v]) => `${k}:${Math.round(v)}`).join(",") || "-";
+        debugWidths(
+          `preset-apply preset=${preset} reset=${resetWidths} safeW=${safeWidth} ` +
+            `applied=${applied} postApply=${formatWidthsSnapshot(snapshotColumnWidths(api))}`,
+        );
+      }
       set({
         ...ids,
         sidebarVisible: true,
@@ -446,6 +518,11 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       });
       requestAnimationFrame(() => {
         api.layout(safeWidth, safeHeight);
+        if (IS_DEBUG) {
+          debugWidths(
+            `preset-post-layout preset=${preset} ${formatWidthsSnapshot(snapshotColumnWidths(api))}`,
+          );
+        }
         enforceFromStore(api, get);
         syncPinnedWidthsFromApi(api, set);
         set({ isRestoringLayout: false });

--- a/apps/web/lib/state/layout-manager/applier.test.ts
+++ b/apps/web/lib/state/layout-manager/applier.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { DockviewApi } from "dockview-react";
-import { resolveGroupIds } from "./applier";
+import { applyLayout, resolveGroupIds } from "./applier";
+import { getPinnedTarget, clearAllPinnedTargets } from "./pinned-targets";
+import type { LayoutState } from "./types";
 import { SIDEBAR_GROUP, CENTER_GROUP, RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP } from "./constants";
 
 type MockGroup = { id: string };
@@ -67,5 +69,79 @@ describe("resolveGroupIds", () => {
     const ids = resolveGroupIds(api);
 
     expect(ids.centerGroupId).toBe(CENTER_GROUP);
+  });
+});
+
+describe("applyLayout — pinned target capture with no override", () => {
+  beforeEach(() => {
+    clearAllPinnedTargets();
+  });
+
+  it("targets the computed default, not a transient post-fromJSON live size", () => {
+    // Regression: with no pinnedWidths override (e.g. toggling plan mode off,
+    // where the right width was dropped), applyLayout must pin each column to
+    // its DEFAULT width — not whatever transient (narrower) size the splitview
+    // reports right after fromJSON. Reading the transient left the column stuck
+    // too narrow and persisted it.
+    const resizeView = vi.fn();
+    const splitview = {
+      length: 3,
+      // Transient: ~0.7x the intended widths, as seen right after fromJSON.
+      getViewSize: (idx: number) => [245, 1097, 258][idx],
+      resizeView,
+    };
+    const setConstraints = vi.fn();
+    const sidebarGroup = { locked: undefined, header: { hidden: true }, api: { setConstraints } };
+    const rightGroup = { id: RIGHT_TOP_GROUP, api: { setConstraints } };
+    const api = {
+      width: 1600,
+      height: 800,
+      fromJSON: vi.fn(),
+      groups: [{ id: SIDEBAR_GROUP }, { id: CENTER_GROUP }, rightGroup],
+      getPanel: (id: string) => {
+        if (id === "sidebar") return { group: sidebarGroup };
+        if (id === "files") return { group: rightGroup };
+        return null;
+      },
+      component: { gridview: { root: { splitview } } },
+    } as unknown as DockviewApi;
+
+    const state: LayoutState = {
+      columns: [
+        {
+          id: "sidebar",
+          pinned: true,
+          groups: [
+            {
+              id: SIDEBAR_GROUP,
+              panels: [{ id: "sidebar", component: "sidebar", title: "Sidebar" }],
+            },
+          ],
+        },
+        {
+          id: "center",
+          groups: [
+            { id: CENTER_GROUP, panels: [{ id: "chat", component: "chat", title: "Agent" }] },
+          ],
+        },
+        {
+          id: "right",
+          pinned: true,
+          groups: [
+            { id: RIGHT_TOP_GROUP, panels: [{ id: "files", component: "files", title: "Files" }] },
+          ],
+        },
+      ],
+    };
+
+    // Empty overrides → each pinned column should fall back to its default.
+    applyLayout(api, state, new Map(), 1600, 800);
+
+    // Defaults at totalWidth 1600: ratio 0.25*1600 = 400 → sidebar clamps to
+    // 350, right stays 400. NOT the transient 245 / 258.
+    expect(getPinnedTarget("sidebar")).toBe(350);
+    expect(getPinnedTarget("right")).toBe(400);
+    expect(resizeView).toHaveBeenCalledWith(0, 350);
+    expect(resizeView).toHaveBeenCalledWith(2, 400);
   });
 });

--- a/apps/web/lib/state/layout-manager/applier.ts
+++ b/apps/web/lib/state/layout-manager/applier.ts
@@ -10,6 +10,7 @@ import {
   TERMINAL_DEFAULT_ID,
 } from "./constants";
 import { computePinnedMaxPxFor, LAYOUT_PINNED_MIN_PX } from "./caps";
+import { getPinnedWidth } from "./sizing";
 import { setPinnedTarget } from "./pinned-targets";
 
 export type LayoutGroupIds = {
@@ -95,16 +96,19 @@ export function applyLayout(
   return resolveGroupIds(api);
 }
 
-/** Set the pinned target for a column. Prefers an explicit override from
- *  `pinnedWidths` over what fromJSON happened to render — fromJSON can
- *  produce a clamped value during a sidebar/right toggle (the panel's NEW
- *  group is mounted with default constraints and a transient internal
- *  rebalance can squeeze it below the serialized target before our
- *  setConstraints lifts the cap), and reading `sv.getViewSize` at that
- *  moment would silently overwrite the saved user-resized width with the
- *  clamped value (the `pane-resize-sidebar.spec.ts:41` failure mode). When
- *  the override is known we also proactively resize dockview to match so
- *  the user sees their intended width immediately.
+/** Set the pinned target for a column.
+ *
+ *  Resolve the intended width as `override ?? defaultWidth` — an explicit
+ *  user-resized width if we have one (from `pinnedWidths`), otherwise the
+ *  column's computed default. We resize dockview to that width and pin it as
+ *  the target. We deliberately do NOT fall back to reading `sv.getViewSize`:
+ *  fromJSON can produce a transient clamped/rebalanced size during a layout
+ *  switch (the panel's NEW group mounts with default constraints, or the grid
+ *  is briefly laid out at a narrower width before our setConstraints/api.layout
+ *  settle), and capturing that would pin the column too narrow and then persist
+ *  it — e.g. toggling plan mode off left the right column stuck at the
+ *  transient width instead of its default. `getViewSize` is only a last resort
+ *  when neither an override nor a default is available.
  */
 function syncPinnedColumnTarget(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -112,17 +116,19 @@ function syncPinnedColumnTarget(
   idx: number,
   columnId: "sidebar" | "right",
   override: number | undefined,
+  defaultWidth: number | undefined,
 ): void {
-  if (override !== undefined && override > 0) {
+  const target = override !== undefined && override > 0 ? override : defaultWidth;
+  if (target !== undefined && target > 0) {
     const live = sv?.getViewSize?.(idx);
-    if (typeof live === "number" && live > 0 && Math.abs(live - override) > 1) {
+    if (typeof live === "number" && live > 0 && Math.abs(live - target) > 1) {
       try {
-        sv.resizeView(idx, override);
+        sv.resizeView(idx, target);
       } catch {
         /* dockview rejects unreachable sizes — ignore */
       }
     }
-    setPinnedTarget(columnId, override);
+    setPinnedTarget(columnId, target);
     return;
   }
   const live = sv?.getViewSize?.(idx);
@@ -154,7 +160,8 @@ function configureSidebarPinned(
     minimumWidth: LAYOUT_PINNED_MIN_PX,
   });
   if (!sidebarCol) return;
-  syncPinnedColumnTarget(sv, 0, "sidebar", pinnedWidths.get("sidebar"));
+  const defaultWidth = getPinnedWidth(sidebarCol, viewportWidth, undefined);
+  syncPinnedColumnTarget(sv, 0, "sidebar", pinnedWidths.get("sidebar"), defaultWidth);
 }
 
 function configureRightPinned(
@@ -173,7 +180,8 @@ function configureRightPinned(
     const cap = col.maxWidth ?? computePinnedMaxPxFor(col.id, viewportWidth);
     applyConstraintsToAllPanelGroups(api, col, cap);
     if (col.id !== "right") continue;
-    syncPinnedColumnTarget(sv, i, "right", pinnedWidths.get("right"));
+    const defaultWidth = getPinnedWidth(col, viewportWidth, undefined);
+    syncPinnedColumnTarget(sv, i, "right", pinnedWidths.get("right"), defaultWidth);
   }
 }
 

--- a/apps/web/lib/state/layout-manager/merger.test.ts
+++ b/apps/web/lib/state/layout-manager/merger.test.ts
@@ -132,6 +132,32 @@ describe("mergePanelsIntoPreset", () => {
     expect(panelIdsIn(result, "right")).toEqual(["files", "changes"]);
   });
 
+  it("places surviving browser/vscode/pr-detail in center, files/changes in the side column", () => {
+    // Switching from a content preset (vscode/preview/etc.) back to default:
+    // main-content surfaces (browser, vscode, pr-detail) must follow the chat
+    // into the center group, not get stranded in the narrow right "tools"
+    // column. Only files/changes/terminal belong on the right.
+    const currentState = makeLayoutWithSide([{ id: SESSION_ABC, component: "chat" }], "preview", [
+      { id: "vscode", component: "vscode" },
+      { id: "browser:http://localhost:3000", component: "browser" },
+      { id: "pr-detail", component: "pr-detail" },
+      { id: "files", component: "files" },
+    ]);
+    const targetPreset = makeLayoutWithSide([{ id: "chat", component: "chat" }], "right", [
+      { id: "changes", component: "changes" },
+    ]);
+
+    const result = mergePanelsIntoPreset(currentState, targetPreset);
+
+    expect(panelIdsIn(result, "center")).toEqual([
+      SESSION_ABC,
+      "vscode",
+      "browser:http://localhost:3000",
+      "pr-detail",
+    ]);
+    expect(panelIdsIn(result, "right")).toEqual(["changes", "files"]);
+  });
+
   it("falls back to center for side extras when the target preset has no side column", () => {
     const currentState = makeLayoutWithSide([{ id: SESSION_ABC, component: "chat" }], "right", [
       { id: "files", component: "files" },

--- a/apps/web/lib/state/layout-manager/merger.ts
+++ b/apps/web/lib/state/layout-manager/merger.ts
@@ -5,11 +5,16 @@ import { fromDockviewApi } from "./serializer";
 /** Panel IDs that always come from the preset and should never be merged. */
 const PRESET_ONLY_PANELS = new Set(["sidebar"]);
 
-/** Panel IDs that, when surviving as extras, belong next to the chat in the
- *  center column rather than in the side column. The plan panel is paired
- *  with the chat conceptually, so toggling off plan mode keeps it visible
- *  in the center group rather than dumping it into the right column. */
-const CENTER_EXTRA_PANELS = new Set(["plan"]);
+/** Components that, when surviving as extras on a layout switch, belong next
+ *  to the chat/agent tabs in the CENTER column rather than the narrow side
+ *  "tools" column. These are main-content surfaces — the plan, the browser,
+ *  the VS Code editor, and PR detail — whereas files/changes/terminal are
+ *  tools that stay in the side column. Switching from the plan/vscode/preview
+ *  preset back to default must not strand these in the right column.
+ *
+ *  Matched by component (not id) because some carry dynamic ids — a browser
+ *  panel is `browser:<url>`, not a literal `browser`. */
+const CENTER_EXTRA_COMPONENTS = new Set(["plan", "browser", "vscode", "pr-detail"]);
 
 /** Collect all panels from a LayoutState, flattened. */
 function collectAllPanels(state: LayoutState): LayoutPanel[] {
@@ -76,9 +81,9 @@ export function mergePanelsIntoPreset(
   }
 
   const sessionExtras = extraPanels.filter((p) => p.id.startsWith("session:"));
-  const centerExtras = extraPanels.filter((p) => CENTER_EXTRA_PANELS.has(p.id));
+  const centerExtras = extraPanels.filter((p) => CENTER_EXTRA_COMPONENTS.has(p.component));
   const sideExtras = extraPanels.filter(
-    (p) => !p.id.startsWith("session:") && !CENTER_EXTRA_PANELS.has(p.id),
+    (p) => !p.id.startsWith("session:") && !CENTER_EXTRA_COMPONENTS.has(p.component),
   );
   const hasSessionPanels = sessionExtras.length > 0;
   const extrasColumnId = pickExtrasColumnId(targetPreset);


### PR DESCRIPTION
## Summary

Freshly created or opened tasks rendered with the wrong sidebar/right column widths (the center "chat" column crushed) and the console spun on a `[dockview:widths] enforce-restore` loop that never converged. Two independent defects in the dockview layout pipeline both pushed pinned columns away from their defaults; this fixes both so a task opens at its intended proportions.

## Important Changes

- **`applyLayoutFixups` captured pinned targets by position** (index 0 = sidebar, last = right). In the 2-column global-fallback restore the last splitview child is the *center* column, so its width was recorded as the "right" target — inflating the real right column once the full layout materialized and persisting that into the env layout. It now records a right target only when a genuine right column exists (`sv.length >= 3` and a right group present) and clamps both targets to their caps, so an unreachable target can no longer spin `enforcePinnedTargets`.
- **`switchEnvLayout`'s first-adoption branch** adopted whatever `onReady` rendered and persisted it via `setEnvLayout(newEnvId, toJSON())`. When `onReady` ran before the env hydrated, it had built the stale cross-env global-fallback layout — so fresh tasks inherited the previous env's proportions and the env's real saved layout was overwritten. First adoption now routes through `performEnvSwitch`, which restores the env's saved layout or builds defaults for a brand-new task.
- Adds a persistent `fixups-capture` debug log (`dockview:widths` namespace, no-op in prod) with `caller`/`cols`/`sidebarOverCap` fields to make future width-pipeline triage one line.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm exec vitest run lib/state/dockview lib/state/layout-manager components/task/dockview-layout-restore.test.ts components/task/dockview-session-tabs.test.ts` (133 pass)
- New regression tests in `dockview-layout-builders-fixups.test.ts` confirmed red without the fix (3/4), green with it
- Prettier check on all changed files

## Possible Improvements

A task whose env layout was persisted *while already corrupted* (pre-fix) still loads that saved value, since `performEnvSwitch` faithfully restores saved layouts. A follow-up could clamp a restored pinned column to `container − opposite − center-min` so such layouts self-heal on next open.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] Self-reviewed