### PR TITLE
docs: note IS_DEBUG runs under vitest in debug-logs skill

### DIFF
--- a/.agents/skills/debug-logs/SKILL.md
+++ b/.agents/skills/debug-logs/SKILL.md
@@ -48,6 +48,7 @@ Key properties:
 - **Register the namespace** in the cheat-sheet docblock at the top of `lib/debug/log.ts`. Future agents triage by reading that list — an unregistered namespace is invisible.
 - **One log per event**, not per render frame. The factory is no-op in prod but allocates a closure per call in dev — still cheap, but per-render-frame logs spam the console and slow devtools.
 - **Guard expensive arg computation** with `if (IS_DEBUG) { ... }`. The `debug()` call itself is free, but JS evaluates args first.
+- **`IS_DEBUG` is true under vitest** (`NODE_ENV === "test"` ≠ `"production"`), so persistent debug branches *execute in tests*. If a debug line — or a helper it calls (e.g. a `formatXSnapshot`) — reaches into a module that a test `vi.mock`s, that mock must export every symbol the debug path touches, or the log throws `No "<symbol>" export is defined on the "..." mock` and turns a green suite red. Adding a `debug()` call to a code path covered by a partial-mock test is enough to trigger this. Fix by completing the mock (add the missing export) or by keeping the debug helper's transitive deps minimal.
 
 ### ✅ Correct — flat primitives as a single object arg
 


### PR DESCRIPTION
## Summary

The debug-logs skill documents that `createDebugLogger`/`IS_DEBUG` is "active when NODE_ENV !== production" but never connects that to test runs. Because vitest sets `NODE_ENV=test`, persistent debug branches execute during tests — so adding a `debug()` call (or a helper it transitively calls) into a code path covered by a partial `vi.mock` can crash with `No "<symbol>" export is defined on the "..." mock` and turn a green suite red. This adds a Conventions bullet capturing that gotcha so future debug-log work doesn't get bitten.

## Validation

Documentation-only change to `.agents/skills/debug-logs/SKILL.md`; no code affected.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] Self-reviewed

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1137-bwo7.sprites.app |
| **Commit** | `0762aa4` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->