### PR TITLE
fix(backend): complete Create worktree step before setup script runs

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -203,6 +203,14 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 			reportProgress(onProgress, *syncStep, syncStepIndex, totalSteps)
 		}
 	}
+	// Complete the "Create worktree" step the moment the worktree dir is ready,
+	// before the per-repo setup script runs inside Create() — the setup script
+	// streams its own step, so this keeps the two from overlapping in the UI.
+	stepCompleted := false
+	createReq.OnWorktreeCreated = func(wt *worktree.Worktree) {
+		completeCreateWorktreeStep(&step, wt, stepIdx, totalSteps, onProgress)
+		stepCompleted = true
+	}
 
 	wt, err := p.worktreeMgr.Create(ctx, createReq)
 	steps = finalizeSyncStep(syncStep, syncStepIndex, totalSteps, onProgress, steps, err)
@@ -214,18 +222,29 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 		return nil, steps, stepIdx, err
 	}
 
-	completeStepSuccess(&step)
-	if wt.BaseBranchFallbackWarning != "" {
-		step.Warning = wt.BaseBranchFallbackWarning
-		step.WarningDetail = wt.BaseBranchFallbackDetail
+	// Reuse of an existing worktree skips OnWorktreeCreated, so complete the
+	// step here when the callback did not fire.
+	if !stepCompleted {
+		completeCreateWorktreeStep(&step, wt, stepIdx, totalSteps, onProgress)
 	}
 	// wt.FetchWarning is surfaced in the separate "Fetch PR branch" step
 	// rendered later in the pipeline. It can only be non-empty when
 	// req.CheckoutBranch != "" (it is set inside fetchBranchToLocal), so the
 	// two warnings always co-occur and FetchWarning is never silently dropped.
 	steps = append(steps, step)
-	reportProgress(onProgress, step, stepIdx, totalSteps)
 	return wt, steps, stepIdx + 1, nil
+}
+
+// completeCreateWorktreeStep marks the "Create worktree" step successful,
+// attaches any base-branch fallback warning carried by the worktree, and
+// reports progress.
+func completeCreateWorktreeStep(step *PrepareStep, wt *worktree.Worktree, stepIdx, totalSteps int, onProgress PrepareProgressCallback) {
+	completeStepSuccess(step)
+	if wt.BaseBranchFallbackWarning != "" {
+		step.Warning = wt.BaseBranchFallbackWarning
+		step.WarningDetail = wt.BaseBranchFallbackDetail
+	}
+	reportProgress(onProgress, *step, stepIdx, totalSteps)
 }
 
 // finalizeSyncStep closes out the optional sync step after worktree.Create returns.

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -181,22 +181,7 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 	step.Command = "git worktree add"
 	reportProgress(onProgress, step, stepIdx, totalSteps)
 
-	createReq := worktree.CreateRequest{
-		TaskID:               req.TaskID,
-		SessionID:            req.SessionID,
-		TaskTitle:            req.TaskTitle,
-		RepositoryID:         req.RepositoryID,
-		RepositoryPath:       req.RepositoryPath,
-		BaseBranch:           req.BaseBranch,
-		FallbackBaseBranch:   req.DefaultBranch,
-		CheckoutBranch:       req.CheckoutBranch,
-		PRNumber:             req.PRNumber,
-		WorktreeBranchPrefix: req.WorktreeBranchPrefix,
-		PullBeforeWorktree:   req.PullBeforeWorktree,
-		WorktreeID:           req.WorktreeID,
-		TaskDirName:          req.TaskDirName,
-		RepoName:             req.RepoName,
-	}
+	createReq := buildWorktreeCreateRequest(req)
 	if syncStep != nil {
 		createReq.OnSyncProgress = func(event worktree.SyncProgressEvent) {
 			applySyncProgressEvent(syncStep, event)
@@ -215,9 +200,15 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 	wt, err := p.worktreeMgr.Create(ctx, createReq)
 	steps = finalizeSyncStep(syncStep, syncStepIndex, totalSteps, onProgress, steps, err)
 	if err != nil {
-		completeStepError(&step, err.Error())
+		// If the callback already completed the step (worktree add succeeded,
+		// but a later phase like the setup script failed), leave it green — the
+		// failing phase owns its own step. Only attribute the error to "Create
+		// worktree" when it never completed (the creation itself failed).
+		if !stepCompleted {
+			completeStepError(&step, err.Error())
+			reportProgress(onProgress, step, stepIdx, totalSteps)
+		}
 		steps = append(steps, step)
-		reportProgress(onProgress, step, stepIdx, totalSteps)
 		p.logger.Error("worktree creation failed", zap.String("task_id", req.TaskID), zap.Error(err))
 		return nil, steps, stepIdx, err
 	}
@@ -233,6 +224,27 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 	// two warnings always co-occur and FetchWarning is never silently dropped.
 	steps = append(steps, step)
 	return wt, steps, stepIdx + 1, nil
+}
+
+// buildWorktreeCreateRequest maps an EnvPrepareRequest onto the worktree
+// manager's CreateRequest. Progress callbacks are wired by the caller.
+func buildWorktreeCreateRequest(req *EnvPrepareRequest) worktree.CreateRequest {
+	return worktree.CreateRequest{
+		TaskID:               req.TaskID,
+		SessionID:            req.SessionID,
+		TaskTitle:            req.TaskTitle,
+		RepositoryID:         req.RepositoryID,
+		RepositoryPath:       req.RepositoryPath,
+		BaseBranch:           req.BaseBranch,
+		FallbackBaseBranch:   req.DefaultBranch,
+		CheckoutBranch:       req.CheckoutBranch,
+		PRNumber:             req.PRNumber,
+		WorktreeBranchPrefix: req.WorktreeBranchPrefix,
+		PullBeforeWorktree:   req.PullBeforeWorktree,
+		WorktreeID:           req.WorktreeID,
+		TaskDirName:          req.TaskDirName,
+		RepoName:             req.RepoName,
+	}
 }
 
 // completeCreateWorktreeStep marks the "Create worktree" step successful,

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_setup_failure_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_setup_failure_test.go
@@ -1,0 +1,71 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/executor"
+	"github.com/kandev/kandev/internal/worktree"
+)
+
+// TestWorktreePreparer_SetupScriptFailure_KeepsCreateWorktreeStepCompleted
+// guards the step-attribution edge case introduced alongside the early
+// completion of the "Create worktree" step.
+//
+// The per-repo setup script runs inside worktree.Manager.Create() AFTER the
+// worktree directory is created (git worktree add succeeded) and the
+// OnWorktreeCreated callback has already completed the "Create worktree" step.
+// When that script fails, Create() returns an error — but the failure belongs
+// to the setup script (which streams its own step), not to worktree creation.
+// The preparer must therefore leave "Create worktree" completed rather than
+// re-marking it as failed.
+func TestWorktreePreparer_SetupScriptFailure_KeepsCreateWorktreeStepCompleted(t *testing.T) {
+	repo := initBareGitRepo(t, "single")
+
+	repos := map[string]*worktree.Repository{
+		"repo-single": {ID: "repo-single", SetupScript: "echo hi"},
+	}
+	preparer, _, handler := newPreparerWithScriptHandler(t, repos)
+	handler.scriptError = errors.New("setup script boom")
+
+	req := &EnvPrepareRequest{
+		TaskID:          "task-setup-fail",
+		SessionID:       "sess-setup-fail",
+		TaskTitle:       "Setup Fail",
+		ExecutorType:    executor.NameStandalone,
+		TaskDirName:     "setup-fail_fff",
+		UseWorktree:     true,
+		RepositoryID:    "repo-single",
+		RepositoryPath:  repo,
+		RepoName:        "single",
+		BaseBranch:      "main",
+		RepoSetupScript: "echo hi",
+	}
+
+	res, err := preparer.Prepare(context.Background(), req, nil)
+	if err != nil {
+		t.Fatalf("prepare returned hard error: %v", err)
+	}
+	// The setup script failed, so the prepare as a whole fails.
+	if res.Success {
+		t.Fatalf("expected prepare to fail when the setup script errors")
+	}
+
+	var createStep *PrepareStep
+	for i := range res.Steps {
+		if res.Steps[i].Name == "Create worktree" {
+			createStep = &res.Steps[i]
+		}
+	}
+	if createStep == nil {
+		t.Fatal(`no "Create worktree" step found in prepare result`)
+	}
+	if createStep.Status != PrepareStepCompleted {
+		t.Errorf(`"Create worktree" status = %q, want %q — a setup-script failure must not be attributed to worktree creation`,
+			createStep.Status, PrepareStepCompleted)
+	}
+	if createStep.Error != "" {
+		t.Errorf(`"Create worktree" unexpectedly carries error %q`, createStep.Error)
+	}
+}

--- a/apps/backend/internal/worktree/manager_lifecycle.go
+++ b/apps/backend/internal/worktree/manager_lifecycle.go
@@ -57,13 +57,9 @@ func (m *Manager) Create(ctx context.Context, req CreateRequest) (*Worktree, err
 	if req.TaskDirName == "" || req.RepoName == "" {
 		return nil, ErrTaskDirRequired
 	}
-	wt, err := m.createInTaskDir(ctx, req, baseRef)
+	wt, err := m.createInTaskDir(ctx, req, baseRef, fallbackWarning, fallbackDetail)
 	if err != nil {
 		return nil, err
-	}
-	if fallbackWarning != "" {
-		wt.BaseBranchFallbackWarning = fallbackWarning
-		wt.BaseBranchFallbackDetail = fallbackDetail
 	}
 	return wt, nil
 }
@@ -192,7 +188,7 @@ func (m *Manager) resolveBaseRefWithFallback(ctx context.Context, req *CreateReq
 // "owner/repo" don't produce a nested subdirectory — that would push the
 // worktree one level below the task root and break agentctl's sibling-based
 // multi-repo detection.
-func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRef string) (*Worktree, error) {
+func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRef, fallbackWarning, fallbackDetail string) (*Worktree, error) {
 	repoDir := SanitizeRepoDirName(req.RepoName)
 	if repoDir == "" {
 		return nil, ErrInvalidRepoName
@@ -237,6 +233,21 @@ func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRe
 
 	if err := m.persistAndCacheWorktree(ctx, wt, req, worktreePath); err != nil {
 		return nil, err
+	}
+
+	// Surface any base-branch fallback before signaling readiness so the
+	// "Create worktree" step can show the warning when completed early.
+	if fallbackWarning != "" {
+		wt.BaseBranchFallbackWarning = fallbackWarning
+		wt.BaseBranchFallbackDetail = fallbackDetail
+	}
+
+	// The worktree directory now exists and is persisted. Signal readiness
+	// before running the per-repo setup script so the env preparer can complete
+	// the "Create worktree" UI step and render the setup script as a distinct,
+	// subsequent step rather than overlapping it.
+	if req.OnWorktreeCreated != nil {
+		req.OnWorktreeCreated(wt)
 	}
 
 	m.copyConfiguredFiles(ctx, req, wt)

--- a/apps/backend/internal/worktree/manager_setup_script_order_test.go
+++ b/apps/backend/internal/worktree/manager_setup_script_order_test.go
@@ -1,0 +1,78 @@
+package worktree
+
+import (
+	"context"
+	"testing"
+)
+
+// orderRecordingScriptHandler records when the per-repo setup script runs so a
+// test can assert it relative to the OnWorktreeCreated callback.
+type orderRecordingScriptHandler struct {
+	order *[]string
+}
+
+func (h *orderRecordingScriptHandler) ExecuteSetupScript(_ context.Context, _ ScriptExecutionRequest) error {
+	*h.order = append(*h.order, "script")
+	return nil
+}
+
+func (h *orderRecordingScriptHandler) ExecuteCleanupScript(_ context.Context, _ ScriptExecutionRequest) error {
+	return nil
+}
+
+// TestManagerCreate_OnWorktreeCreatedFiresBeforeSetupScript guards the prepare
+// UI ordering. The worktree-ready signal (used by the env preparer to complete
+// the "Create worktree" step) must fire AFTER the worktree directory exists but
+// BEFORE the per-repo setup script runs — otherwise the "Create worktree" and
+// "Run repository setup script" steps render as overlapping spinners instead of
+// a sequential timeline.
+func TestManagerCreate_OnWorktreeCreatedFiresBeforeSetupScript(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+
+	var order []string
+	provider := &fakeRepoProvider{
+		repo: &Repository{ID: "repo-order", SetupScript: "echo hi"},
+	}
+	mgr := newManagerForCopyTest(t, provider)
+	mgr.SetScriptMessageHandler(&orderRecordingScriptHandler{order: &order})
+
+	req := createReqForCopyTest(repoPath, "order")
+	req.OnWorktreeCreated = func(_ *Worktree) {
+		order = append(order, "callback")
+	}
+
+	if _, err := mgr.Create(context.Background(), req); err != nil {
+		t.Fatalf("Create() unexpected error: %v", err)
+	}
+
+	want := []string{"callback", "script"}
+	if len(order) != len(want) || order[0] != want[0] || order[1] != want[1] {
+		t.Fatalf("execution order = %v, want %v", order, want)
+	}
+}
+
+// TestManagerCreate_OnWorktreeCreatedReceivesFallbackWarning verifies the
+// worktree handed to the callback already carries the base-branch fallback
+// warning, so the "Create worktree" step can surface it when completed early.
+func TestManagerCreate_OnWorktreeCreatedReceivesFallbackWarning(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+
+	mgr := newManagerForCopyTest(t, nil)
+
+	req := createReqForCopyTest(repoPath, "fallback")
+	req.BaseBranch = "does-not-exist"
+	req.FallbackBaseBranch = "main"
+
+	var warningAtCallback string
+	req.OnWorktreeCreated = func(wt *Worktree) {
+		warningAtCallback = wt.BaseBranchFallbackWarning
+	}
+
+	if _, err := mgr.Create(context.Background(), req); err != nil {
+		t.Fatalf("Create() unexpected error: %v", err)
+	}
+
+	if warningAtCallback == "" {
+		t.Fatalf("expected fallback warning to be set on worktree at callback time, got empty")
+	}
+}

--- a/apps/backend/internal/worktree/worktree.go
+++ b/apps/backend/internal/worktree/worktree.go
@@ -162,6 +162,15 @@ type CreateRequest struct {
 
 	// OnSyncProgress receives progress updates for pre-worktree branch sync.
 	OnSyncProgress SyncProgressCallback
+
+	// OnWorktreeCreated, when set, is invoked once the worktree directory has
+	// been created and persisted (git worktree add succeeded) but BEFORE the
+	// per-repo setup script runs. The env preparer uses it to complete the
+	// "Create worktree" UI step so the setup script renders as a distinct,
+	// subsequent step instead of overlapping it. The passed worktree already
+	// carries any base-branch fallback warning. Called synchronously on the
+	// Create goroutine; not invoked when an existing worktree is reused.
+	OnWorktreeCreated func(*Worktree)
 }
 
 // Validate validates the create request.


### PR DESCRIPTION
## Summary

In the task prepare UI, the "Create worktree" and "Run repository setup script" steps appeared to run concurrently — two overlapping spinners that made a strictly sequential backend flow look like a race. This completes the "Create worktree" step the moment the worktree directory is ready, so the setup script renders as a distinct, subsequent step.

The setup script already ran sequentially in the correct directory (`WorkingDir: wt.Path`); the only problem was UI step sequencing.

## Important Changes

- Added an `OnWorktreeCreated` callback to `worktree.CreateRequest`, fired inside `Manager.Create()` once the worktree dir exists and is persisted (with any base-branch fallback warning already attached) but **before** the per-repo setup script runs.
- The env preparer uses the callback to complete the "Create worktree" step early; the reuse-existing-worktree path (which skips the callback) falls back to completing the step after `Create()` returns.

## Validation

- `go test ./internal/worktree/ ./internal/agent/runtime/lifecycle/` — pass (the unrelated `TestKandevBranchCheckoutPostlude_LandsOnFeatureBranch` fails on a clean tree too, due to the sandbox git commit-signing server, not this change)
- New regression test `manager_setup_script_order_test.go`: asserts `OnWorktreeCreated` fires before the setup script (fails before fix: `order=[script]`; passes after: `[callback script]`) and that the fallback warning is present at callback time
- `go build ./...`, `gofmt -l`, `go vet` — clean
- `golangci-lint` could not run (environment Go-version mismatch); verified `createWorktreeWithSync` stays at 79 lines (under the 80-line funlen limit)

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] Self-reviewed the diff

---
_Generated by [Claude Code](https://claude.ai/code/session_011Vo1BNrwAEuXS7eQUVwH8J)_