### PR TITLE
feat(web): show relative times in remote cloud status tooltip

### DIFF
--- a/apps/web/components/task/remote-cloud-tooltip.test.tsx
+++ b/apps/web/components/task/remote-cloud-tooltip.test.tsx
@@ -38,3 +38,27 @@ describe("RemoteCloudTooltip executor icon", () => {
     expect(screen.getByTestId("executor-status-cloud-icon")).toBeTruthy();
   });
 });
+
+describe("RemoteCloudTooltip relative timestamps", () => {
+  it("renders created and last-check times as relative values", () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+    render(
+      <RemoteCloudTooltip
+        taskId="task-1"
+        executorType="sprites"
+        fallbackName="Sprites.dev"
+        status={{
+          remote_name: "kandev-da7d150f-585",
+          remote_state: "running",
+          remote_created_at: twoHoursAgo,
+          remote_checked_at: fiveMinutesAgo,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Created: 2h ago")).toBeTruthy();
+    expect(screen.getByText("Last check: 5m ago")).toBeTruthy();
+  });
+});

--- a/apps/web/components/task/remote-cloud-tooltip.tsx
+++ b/apps/web/components/task/remote-cloud-tooltip.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { getExecutorStatusIcon } from "@/lib/executor-icons";
+import { formatRelativeTime } from "@/lib/utils";
 
 type RemoteStatusData = {
   remote_name?: string;
@@ -37,7 +38,7 @@ function formatTimestamp(value?: string): string | null {
   if (!value) return null;
   const d = new Date(value);
   if (Number.isNaN(d.getTime())) return null;
-  return d.toLocaleString();
+  return formatRelativeTime(value);
 }
 
 function RemoteCloudStatusContent({


### PR DESCRIPTION
## Summary

The remote cloud status tooltip showed absolute locale timestamps for "Created" and "Last check", which are hard to scan at a glance. This switches both to relative times (e.g. "2h ago", "just now") so the executor's freshness is immediately legible.

## Important Changes

- `formatTimestamp` in `remote-cloud-tooltip.tsx` now delegates to the existing `formatRelativeTime` helper from `lib/utils.ts`, keeping its `null`/invalid-date guards.

## Validation

- `pnpm exec vitest run components/task/remote-cloud-tooltip.test.tsx` — 3 passed (added a test asserting relative rendering for Created/Last check)
- `pnpm exec eslint --max-warnings 0` on the changed files — clean

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] Self-reviewed the diff

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXuSd2NLV4UjPiFen3yc1h)_