### PR TITLE
fix(web): populate prepare progress when switching tasks client-side

### DIFF
--- a/apps/web/lib/ssr/session-page-state.ts
+++ b/apps/web/lib/ssr/session-page-state.ts
@@ -22,6 +22,8 @@ import type {
 import type { Terminal } from "@/hooks/domains/session/use-terminals";
 import { snapshotToState, taskToState } from "@/lib/ssr/mapper";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { prepareResultToSessionState } from "@/lib/state/slices/session-runtime/prepare-result";
+import type { SessionPrepareState } from "@/lib/state/slices/session-runtime/types";
 import type { AppState } from "@/lib/state/store";
 
 function buildWorktreeState(allSessions: TaskSession[]) {
@@ -160,65 +162,11 @@ function buildSessionState(p: BuildSessionPageStateParams) {
 }
 
 function buildPrepareProgressState(allSessions: TaskSession[]) {
-  const bySessionId: Record<
-    string,
-    {
-      sessionId: string;
-      status: string;
-      steps: Array<{
-        name: string;
-        command?: string;
-        status: string;
-        output?: string;
-        error?: string;
-        warning?: string;
-        warningDetail?: string;
-        startedAt?: string;
-        endedAt?: string;
-      }>;
-      errorMessage?: string;
-      durationMs?: number;
-    }
-  > = {};
+  const bySessionId: Record<string, SessionPrepareState> = {};
 
   for (const session of allSessions) {
-    const pr = session.metadata?.prepare_result as
-      | {
-          status?: string;
-          steps?: Array<{
-            name: string;
-            command?: string;
-            status: string;
-            output?: string;
-            error?: string;
-            warning?: string;
-            warning_detail?: string;
-            started_at?: string;
-            ended_at?: string;
-          }>;
-          error_message?: string;
-          duration_ms?: number;
-        }
-      | undefined;
-    if (!pr) continue;
-
-    bySessionId[session.id] = {
-      sessionId: session.id,
-      status: pr.status ?? "completed",
-      steps: (pr.steps ?? []).map((s) => ({
-        name: s.name,
-        command: s.command,
-        status: s.status,
-        output: s.output,
-        error: s.error,
-        warning: s.warning,
-        warningDetail: s.warning_detail,
-        startedAt: s.started_at,
-        endedAt: s.ended_at,
-      })),
-      errorMessage: pr.error_message,
-      durationMs: pr.duration_ms,
-    };
+    const prepareState = prepareResultToSessionState(session.id, session.metadata);
+    if (prepareState) bySessionId[session.id] = prepareState;
   }
 
   if (Object.keys(bySessionId).length === 0) return {};

--- a/apps/web/lib/state/slices/session-runtime/prepare-result.test.ts
+++ b/apps/web/lib/state/slices/session-runtime/prepare-result.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { prepareResultToSessionState } from "./prepare-result";
+
+describe("prepareResultToSessionState", () => {
+  it("returns null when metadata is missing or has no prepare_result", () => {
+    expect(prepareResultToSessionState("s1", null)).toBeNull();
+    expect(prepareResultToSessionState("s1", undefined)).toBeNull();
+    expect(prepareResultToSessionState("s1", {})).toBeNull();
+    expect(prepareResultToSessionState("s1", { other: 1 })).toBeNull();
+  });
+
+  it("maps snake_case prepare_result into camelCase SessionPrepareState", () => {
+    const result = prepareResultToSessionState("s1", {
+      prepare_result: {
+        status: "completed",
+        error_message: "boom",
+        duration_ms: 1234,
+        steps: [
+          {
+            name: "clone",
+            command: "git clone",
+            status: "ok",
+            output: "done",
+            error: "err",
+            warning: "warn",
+            warning_detail: "detail",
+            started_at: "2026-01-01T00:00:00Z",
+            ended_at: "2026-01-01T00:00:05Z",
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      sessionId: "s1",
+      status: "completed",
+      errorMessage: "boom",
+      durationMs: 1234,
+      steps: [
+        {
+          name: "clone",
+          command: "git clone",
+          status: "ok",
+          output: "done",
+          error: "err",
+          warning: "warn",
+          warningDetail: "detail",
+          startedAt: "2026-01-01T00:00:00Z",
+          endedAt: "2026-01-01T00:00:05Z",
+        },
+      ],
+    });
+  });
+
+  it("defaults status to completed and steps to empty when absent", () => {
+    const result = prepareResultToSessionState("s1", { prepare_result: {} });
+    expect(result).toEqual({
+      sessionId: "s1",
+      status: "completed",
+      errorMessage: undefined,
+      durationMs: undefined,
+      steps: [],
+    });
+  });
+});

--- a/apps/web/lib/state/slices/session-runtime/prepare-result.ts
+++ b/apps/web/lib/state/slices/session-runtime/prepare-result.ts
@@ -1,0 +1,60 @@
+import type { SessionPrepareState } from "./types";
+
+/**
+ * Raw `prepare_result` shape as stored in a session's `metadata` (snake_case,
+ * straight off the backend). Mapped into the camelCase {@link SessionPrepareState}
+ * the store and UI consume.
+ */
+type RawPrepareStep = {
+  name: string;
+  command?: string;
+  status: string;
+  output?: string;
+  error?: string;
+  warning?: string;
+  warning_detail?: string;
+  started_at?: string;
+  ended_at?: string;
+};
+
+type RawPrepareResult = {
+  status?: string;
+  steps?: RawPrepareStep[];
+  error_message?: string;
+  duration_ms?: number;
+};
+
+/**
+ * Map a session's `metadata.prepare_result` into the store's
+ * {@link SessionPrepareState}. Returns `null` when the session has no prepare
+ * result (nothing to render).
+ *
+ * Used by both the SSR page-state builder and the client-side session loader so
+ * the "Environment prepared" timeline message is populated the same way whether
+ * the page is freshly loaded or the user switches tasks client-side.
+ */
+export function prepareResultToSessionState(
+  sessionId: string,
+  metadata: Record<string, unknown> | null | undefined,
+): SessionPrepareState | null {
+  const pr = metadata?.prepare_result as RawPrepareResult | undefined;
+  if (!pr) return null;
+
+  return {
+    sessionId,
+    status: pr.status ?? "completed",
+    steps: (pr.steps ?? []).map((s) => ({
+      name: s.name,
+      command: s.command,
+      status: s.status,
+      output: s.output,
+      error: s.error,
+      warning: s.warning,
+      warningDetail: s.warning_detail,
+      startedAt: s.started_at,
+      endedAt: s.ended_at,
+    })),
+    errorMessage: pr.error_message,
+    durationMs: pr.duration_ms,
+  };
+}

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from "zustand";
 import type { TaskSession } from "@/lib/types/http";
 import type { SessionSlice, SessionSliceState } from "./types";
 import { migrateEnvKeyedData } from "@/lib/state/slices/session-runtime/session-runtime-slice";
+import { prepareResultToSessionState } from "@/lib/state/slices/session-runtime/prepare-result";
 import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const debugEnv = createDebugLogger("session:env-mapping");
@@ -63,6 +64,25 @@ function syncEnvironmentMapping(draft: any, sessionId: string, environmentId: st
   }
   draft.environmentIdBySessionId[sessionId] = environmentId;
   migrateEnvKeyedData(draft, sessionId, environmentId);
+}
+
+/**
+ * Backfill the prepare-progress slice from a session's `metadata.prepare_result`
+ * when sessions are loaded from the API (e.g. switching tasks client-side).
+ *
+ * Without this, prepare progress only ever arrives via SSR hydration or live WS
+ * events, so switching to a task whose prepare already completed (common for
+ * remote executors) showed an empty "Environment prepared" row until a full
+ * page reload re-ran SSR. Only populates when no entry exists yet so we never
+ * clobber live WS progress for an in-flight prepare.
+ *
+ * `draft` must be the combined store state (SessionSlice + SessionRuntimeSlice).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function syncPrepareProgress(draft: any, session: TaskSession) {
+  if (draft.prepareProgress.bySessionId[session.id]) return;
+  const prepareState = prepareResultToSessionState(session.id, session.metadata);
+  if (prepareState) draft.prepareProgress.bySessionId[session.id] = prepareState;
 }
 
 /** Merge an incoming session update with an existing session, preserving nullable fields. */
@@ -350,6 +370,7 @@ function buildTaskSessionActions(set: ImmerSet) {
         for (const session of merged) {
           draft.taskSessions.items[session.id] = session;
           syncEnvironmentMapping(draft, session.id, session.task_environment_id);
+          syncPrepareProgress(draft, session);
         }
       }),
     // Upsert a session from a WS event without flipping the per-task `loadedByTaskId`

--- a/apps/web/lib/state/slices/session/set-task-sessions-prepare.test.ts
+++ b/apps/web/lib/state/slices/session/set-task-sessions-prepare.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { createSessionSlice } from "./session-slice";
+import { createSessionRuntimeSlice } from "../session-runtime/session-runtime-slice";
+import type { SessionSlice } from "./types";
+import type { SessionRuntimeSlice } from "../session-runtime/types";
+import { sessionId as toSessionId, taskId as toTaskId, type TaskSession } from "@/lib/types/http";
+
+type CombinedSlice = SessionSlice & SessionRuntimeSlice;
+
+function makeStore() {
+  return create<CombinedSlice>()(
+    immer((set) => ({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(createSessionSlice as any)(set),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(createSessionRuntimeSlice as any)(set),
+    })),
+  );
+}
+
+const TASK_ID = toTaskId("task-1");
+const TS = "2026-04-20T00:00:00Z";
+
+function makeSession(id: string, metadata?: Record<string, unknown>): TaskSession {
+  return {
+    id: toSessionId(id),
+    task_id: TASK_ID,
+    state: "RUNNING",
+    started_at: TS,
+    updated_at: TS,
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+describe("setTaskSessionsForTask prepare backfill", () => {
+  it("populates prepareProgress from session metadata.prepare_result", () => {
+    const store = makeStore();
+    const session = makeSession("s1", {
+      prepare_result: {
+        status: "completed",
+        steps: [{ name: "clone", status: "ok", started_at: TS }],
+      },
+    });
+
+    store.getState().setTaskSessionsForTask(TASK_ID, [session]);
+
+    const prepare = store.getState().prepareProgress.bySessionId["s1"];
+    expect(prepare).toBeDefined();
+    expect(prepare.status).toBe("completed");
+    expect(prepare.steps).toEqual([{ name: "clone", status: "ok", startedAt: TS }]);
+  });
+
+  it("does not create an entry for sessions without prepare_result", () => {
+    const store = makeStore();
+    store.getState().setTaskSessionsForTask(TASK_ID, [makeSession("s1")]);
+    expect(store.getState().prepareProgress.bySessionId["s1"]).toBeUndefined();
+  });
+
+  it("does not clobber existing live prepare progress", () => {
+    const store = makeStore();
+    // Simulate live WS progress already in the store.
+    store.setState((draft) => {
+      draft.prepareProgress.bySessionId["s1"] = {
+        sessionId: "s1",
+        status: "running",
+        steps: [{ name: "clone", status: "running" }],
+      };
+    });
+
+    store.getState().setTaskSessionsForTask(TASK_ID, [
+      makeSession("s1", {
+        prepare_result: { status: "completed", steps: [] },
+      }),
+    ]);
+
+    // Existing (live) entry is preserved, not overwritten by stale metadata.
+    expect(store.getState().prepareProgress.bySessionId["s1"].status).toBe("running");
+  });
+});


### PR DESCRIPTION
## Summary

Switching to a task running in a remote executor showed an empty, non-expandable "Environment prepared" row until a full page reload. Prepare progress was only ever populated via SSR hydration or live WebSocket events, so a task whose prepare had already completed had no store entry after a client-side switch (which uses `history.replaceState`, not navigation). This wires the missing client-side backfill so the row is populated whether the page is freshly loaded or the task is switched in-app.

## Important Changes

- Extracted the `metadata.prepare_result` → `SessionPrepareState` mapping (previously inlined in the SSR page-state builder) into a shared `prepareResultToSessionState` helper, reused by both SSR and the store.
- `setTaskSessionsForTask` now backfills `prepareProgress.bySessionId` from each loaded session's metadata, but only when no entry already exists — so a live, in-flight prepare driven by WebSocket events is never clobbered by stale metadata.

## Validation

- `pnpm exec vitest run` for the new and existing session/session-runtime/ssr suites — 92 passed
- `pnpm exec tsc --noEmit` — clean on touched files (two pre-existing errors for missing generated JSON files in a fresh checkout are unrelated)
- `pnpm exec eslint` on all changed files — clean

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] Self-reviewed the diff

https://claude.ai/code/session_014MapZef9kNxqYiQiiJgMoi

---
_Generated by [Claude Code](https://claude.ai/code/session_014MapZef9kNxqYiQiiJgMoi)_