### PR TITLE
fix(backend): make repository setup script failures non-fatal

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -223,8 +223,16 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 	// OnWorktreeCreated already completed the step — so surface the warning
 	// here, once Create has returned, rather than in completeCreateWorktreeStep.
 	if wt.SetupScriptWarning != "" {
-		step.Warning = wt.SetupScriptWarning
-		step.WarningDetail = wt.SetupScriptWarningDetail
+		// Don't clobber a base-branch fallback warning that
+		// completeCreateWorktreeStep may have already set — append instead so
+		// both "wrong branch" and "setup script failed" survive.
+		if step.Warning != "" {
+			step.Warning += "\n" + wt.SetupScriptWarning
+			step.WarningDetail += "\n" + wt.SetupScriptWarningDetail
+		} else {
+			step.Warning = wt.SetupScriptWarning
+			step.WarningDetail = wt.SetupScriptWarningDetail
+		}
 		reportProgress(onProgress, step, stepIdx, totalSteps)
 	}
 	// wt.FetchWarning is surfaced in the separate "Fetch PR branch" step

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree.go
@@ -218,6 +218,15 @@ func (p *WorktreePreparer) createWorktreeWithSync(
 	if !stepCompleted {
 		completeCreateWorktreeStep(&step, wt, stepIdx, totalSteps, onProgress)
 	}
+	// A failed repository setup script is non-fatal: worktree.Manager.Create
+	// keeps the worktree and records the warning, but the script runs *after*
+	// OnWorktreeCreated already completed the step — so surface the warning
+	// here, once Create has returned, rather than in completeCreateWorktreeStep.
+	if wt.SetupScriptWarning != "" {
+		step.Warning = wt.SetupScriptWarning
+		step.WarningDetail = wt.SetupScriptWarningDetail
+		reportProgress(onProgress, step, stepIdx, totalSteps)
+	}
 	// wt.FetchWarning is surfaced in the separate "Fetch PR branch" step
 	// rendered later in the pipeline. It can only be non-empty when
 	// req.CheckoutBranch != "" (it is set inside fetchBranchToLocal), so the

--- a/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_setup_failure_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/env_preparer_worktree_setup_failure_test.go
@@ -16,10 +16,11 @@ import (
 // The per-repo setup script runs inside worktree.Manager.Create() AFTER the
 // worktree directory is created (git worktree add succeeded) and the
 // OnWorktreeCreated callback has already completed the "Create worktree" step.
-// When that script fails, Create() returns an error — but the failure belongs
-// to the setup script (which streams its own step), not to worktree creation.
-// The preparer must therefore leave "Create worktree" completed rather than
-// re-marking it as failed.
+// A setup-script failure is non-fatal: Create() keeps the worktree, records a
+// warning, and returns no error, so preparation still succeeds and the agent
+// launches. The failure belongs to the setup script (which streams its own
+// step), not to worktree creation — so "Create worktree" stays completed and
+// carries the setup-script warning rather than being re-marked as failed.
 func TestWorktreePreparer_SetupScriptFailure_KeepsCreateWorktreeStepCompleted(t *testing.T) {
 	repo := initBareGitRepo(t, "single")
 
@@ -47,9 +48,10 @@ func TestWorktreePreparer_SetupScriptFailure_KeepsCreateWorktreeStepCompleted(t 
 	if err != nil {
 		t.Fatalf("prepare returned hard error: %v", err)
 	}
-	// The setup script failed, so the prepare as a whole fails.
-	if res.Success {
-		t.Fatalf("expected prepare to fail when the setup script errors")
+	// A failed setup script is non-fatal: preparation still succeeds so the
+	// agent launches (and Resume / Start-fresh keep working).
+	if !res.Success {
+		t.Fatalf("expected prepare to succeed (setup-script failures are non-fatal)")
 	}
 
 	var createStep *PrepareStep
@@ -67,5 +69,9 @@ func TestWorktreePreparer_SetupScriptFailure_KeepsCreateWorktreeStepCompleted(t 
 	}
 	if createStep.Error != "" {
 		t.Errorf(`"Create worktree" unexpectedly carries error %q`, createStep.Error)
+	}
+	// The non-fatal failure surfaces as a warning on the step instead.
+	if createStep.Warning == "" {
+		t.Errorf(`"Create worktree" should carry the setup-script warning when the script fails`)
 	}
 }

--- a/apps/backend/internal/worktree/manager_cleanup.go
+++ b/apps/backend/internal/worktree/manager_cleanup.go
@@ -93,24 +93,29 @@ func (m *Manager) removeWorktree(ctx context.Context, wt *Worktree, removeBranch
 	return nil
 }
 
-func (m *Manager) runWorktreeSetupScript(ctx context.Context, wt *Worktree, repositoryPath string) error {
+// runWorktreeSetupScript runs the repository's setup script in the freshly
+// created worktree. Setup script failures are non-fatal: the worktree is kept
+// and the failure is recorded on wt as a warning (surfaced by the env preparer)
+// so the agent can still launch. This mirrors the task-level setup script
+// behavior in runSetupScriptStep — a broken setup script must not block the task.
+func (m *Manager) runWorktreeSetupScript(ctx context.Context, wt *Worktree) {
 	if m.scriptMsgHandler == nil || m.repoProvider == nil {
-		return nil
+		return
 	}
 	if wt.RepositoryID == "" {
 		// Nothing to set up without a linked repository; upstream may not
 		// always populate this field.
-		return nil
+		return
 	}
 	repo, err := m.repoProvider.GetRepository(ctx, wt.RepositoryID)
 	if err != nil {
 		m.logger.Warn("failed to fetch repository for setup script",
 			zap.String("repository_id", wt.RepositoryID),
 			zap.Error(err))
-		return nil
+		return
 	}
 	if strings.TrimSpace(repo.SetupScript) == "" {
-		return nil
+		return
 	}
 	m.logger.Info("executing setup script for worktree",
 		zap.String("worktree_id", wt.ID),
@@ -124,37 +129,17 @@ func (m *Manager) runWorktreeSetupScript(ctx context.Context, wt *Worktree, repo
 		ScriptType:   "setup",
 	}
 	if err := m.scriptMsgHandler.ExecuteSetupScript(ctx, scriptReq); err != nil {
-		m.logger.Error("setup script failed, cleaning up worktree",
+		// Non-fatal: keep the worktree and surface a warning. The detailed
+		// script output is already streamed to the script_execution chat
+		// message; here we only record a concise, user-facing warning.
+		m.logger.Warn("setup script failed, continuing without it",
 			zap.String("worktree_id", wt.ID),
 			zap.Error(err))
-		m.cleanupWorktreeOnSetupFailure(ctx, wt, repositoryPath)
-		return fmt.Errorf("setup script failed: %w", err)
-	}
-	m.logger.Info("setup script completed successfully", zap.String("worktree_id", wt.ID))
-	return nil
-}
-
-// cleanupWorktreeOnSetupFailure removes the in-memory cache entry, deletes the worktree
-// directory, and marks the worktree as deleted in the store after a setup script failure.
-func (m *Manager) cleanupWorktreeOnSetupFailure(ctx context.Context, wt *Worktree, repositoryPath string) {
-	if wt.SessionID != "" {
-		m.mu.Lock()
-		delete(m.worktrees, cacheKey(wt.SessionID, wt.RepositoryID))
-		m.mu.Unlock()
-	}
-	if cleanupErr := m.removeWorktreeDir(ctx, wt.Path, repositoryPath); cleanupErr != nil {
-		m.logger.Warn("failed to cleanup worktree after setup failure", zap.Error(cleanupErr))
-	}
-	if m.store == nil {
+		wt.SetupScriptWarning = "Repository setup script failed; the worktree was created without it. Fix the setup script and re-run if needed."
+		wt.SetupScriptWarningDetail = err.Error()
 		return
 	}
-	now := time.Now()
-	wt.Status = StatusDeleted
-	wt.DeletedAt = &now
-	wt.UpdatedAt = now
-	if updateErr := m.store.UpdateWorktree(ctx, wt); updateErr != nil {
-		m.logger.Warn("failed to update worktree status", zap.Error(updateErr))
-	}
+	m.logger.Info("setup script completed successfully", zap.String("worktree_id", wt.ID))
 }
 
 // runWorktreeCleanupScript executes the repository cleanup script for a worktree before removal.

--- a/apps/backend/internal/worktree/manager_lifecycle.go
+++ b/apps/backend/internal/worktree/manager_lifecycle.go
@@ -252,9 +252,9 @@ func (m *Manager) createInTaskDir(ctx context.Context, req CreateRequest, baseRe
 
 	m.copyConfiguredFiles(ctx, req, wt)
 
-	if err := m.runWorktreeSetupScript(ctx, wt, req.RepositoryPath); err != nil {
-		return nil, err
-	}
+	// Setup script failures are non-fatal — runWorktreeSetupScript records a
+	// warning on wt and keeps the worktree so the agent can still launch.
+	m.runWorktreeSetupScript(ctx, wt)
 
 	m.logger.Info("created worktree in task directory",
 		zap.String("session_id", req.SessionID),

--- a/apps/backend/internal/worktree/manager_setup_script_test.go
+++ b/apps/backend/internal/worktree/manager_setup_script_test.go
@@ -1,0 +1,110 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// fakeScriptHandler simulates the script message handler. ExecuteSetupScript
+// returns setupErr so tests can drive the setup-script failure path without a
+// real task service / shell.
+type fakeScriptHandler struct {
+	setupErr  error
+	setupRuns int
+}
+
+func (f *fakeScriptHandler) ExecuteSetupScript(_ context.Context, _ ScriptExecutionRequest) error {
+	f.setupRuns++
+	return f.setupErr
+}
+
+func (f *fakeScriptHandler) ExecuteCleanupScript(_ context.Context, _ ScriptExecutionRequest) error {
+	return nil
+}
+
+func newManagerForSetupTest(t *testing.T, provider RepositoryProvider, handler ScriptMessageHandler) *Manager {
+	t.Helper()
+	cfg := newTestConfig(t)
+	mgr, err := NewManager(cfg, newMockStore(), newTestLogger())
+	if err != nil {
+		t.Fatalf("NewManager failed: %v", err)
+	}
+	if provider != nil {
+		mgr.SetRepositoryProvider(provider)
+	}
+	if handler != nil {
+		mgr.SetScriptMessageHandler(handler)
+	}
+	return mgr
+}
+
+// TestManagerCreate_SetupScriptFailure_NonFatal covers the regression where a
+// failing repository setup script aborted environment preparation (and the
+// launch) instead of being surfaced as a non-fatal warning. The worktree must
+// survive the failure and the warning must be recorded on the worktree so the
+// UI can show it without blocking the task.
+func TestManagerCreate_SetupScriptFailure_NonFatal(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	provider := &fakeRepoProvider{
+		repo: &Repository{ID: "repo-setupfail", SetupScript: "make install"},
+	}
+	handler := &fakeScriptHandler{setupErr: errors.New("script exited with code 2")}
+	mgr := newManagerForSetupTest(t, provider, handler)
+
+	wt, err := mgr.Create(context.Background(), CreateRequest{
+		TaskID:         "task-setupfail",
+		SessionID:      "session-setupfail",
+		TaskTitle:      "Setup script fails",
+		RepositoryID:   "repo-setupfail",
+		RepositoryPath: repoPath,
+		BaseBranch:     "main",
+		TaskDirName:    "task-setupfail",
+		RepoName:       "repo-setupfail",
+	})
+	if err != nil {
+		t.Fatalf("Create() should not fail when the setup script fails, got: %v", err)
+	}
+	if wt == nil {
+		t.Fatal("expected non-nil worktree after non-fatal setup failure")
+	}
+	if handler.setupRuns != 1 {
+		t.Fatalf("setup script run count = %d, want 1", handler.setupRuns)
+	}
+	// The worktree directory must survive — the agent needs it to work in.
+	if _, statErr := os.Stat(wt.Path); statErr != nil {
+		t.Fatalf("expected worktree dir to survive setup failure, stat err = %v", statErr)
+	}
+	if wt.SetupScriptWarning == "" {
+		t.Fatal("expected SetupScriptWarning to be set when the setup script fails")
+	}
+}
+
+// TestManagerCreate_SetupScriptSuccess_NoWarning guards against the warning
+// being set on the happy path.
+func TestManagerCreate_SetupScriptSuccess_NoWarning(t *testing.T) {
+	repoPath := initGitRepoForWorktreeTest(t)
+	provider := &fakeRepoProvider{
+		repo: &Repository{ID: "repo-setupok", SetupScript: "make install"},
+	}
+	handler := &fakeScriptHandler{setupErr: nil}
+	mgr := newManagerForSetupTest(t, provider, handler)
+
+	wt, err := mgr.Create(context.Background(), CreateRequest{
+		TaskID:         "task-setupok",
+		SessionID:      "session-setupok",
+		TaskTitle:      "Setup script succeeds",
+		RepositoryID:   "repo-setupok",
+		RepositoryPath: repoPath,
+		BaseBranch:     "main",
+		TaskDirName:    "task-setupok",
+		RepoName:       "repo-setupok",
+	})
+	if err != nil {
+		t.Fatalf("Create() unexpected error: %v", err)
+	}
+	if wt.SetupScriptWarning != "" {
+		t.Fatalf("expected no setup-script warning on success, got %q", wt.SetupScriptWarning)
+	}
+}

--- a/apps/backend/internal/worktree/worktree.go
+++ b/apps/backend/internal/worktree/worktree.go
@@ -84,6 +84,17 @@ type Worktree struct {
 	// detail alongside BaseBranchFallbackWarning.
 	BaseBranchFallbackDetail string `json:"base_branch_fallback_detail,omitempty"`
 
+	// SetupScriptWarning is set when the repository's setup script failed.
+	// Setup script failures are non-fatal: the worktree is kept and the agent
+	// launches normally, but the failure is surfaced as a warning so the user
+	// can fix it. Empty when the script succeeded or no script was configured.
+	SetupScriptWarning string `json:"setup_script_warning,omitempty"`
+
+	// SetupScriptWarningDetail mirrors FetchWarningDetail: a longer message
+	// describing the setup-script failure. Surfaced as collapsible detail
+	// alongside SetupScriptWarning.
+	SetupScriptWarningDetail string `json:"setup_script_warning_detail,omitempty"`
+
 	// CopiedFiles lists the relative paths of files copied from the source
 	// repo into this worktree per the repository's CopyFiles spec. Populated
 	// only on the in-memory record returned by Create — not persisted, since

--- a/apps/web/e2e/tests/session/setup-script-progress.spec.ts
+++ b/apps/web/e2e/tests/session/setup-script-progress.spec.ts
@@ -237,6 +237,79 @@ test.describe("Setup script progress UX", () => {
     }
   });
 
+  test("repository setup script failure is non-fatal — agent still launches", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    // This exercises the REPOSITORY-level setup_script (run inside
+    // worktree.Manager.Create via the script handler), which is a different
+    // path from the profile prepare_script the tests above cover. Before the
+    // fix, a non-zero exit aborted environment preparation and stopped the
+    // agent ("Environment setup failed"); the Resume / Start-fresh buttons
+    // then couldn't recover because each relaunch re-ran the same failing
+    // script. The script must now be non-fatal: the worktree is kept, the
+    // failure shows as a warning, and the agent launches normally.
+    const failingScript = [
+      "echo '[repo-setup] installing deps'",
+      "sleep 4",
+      "echo 'make: *** No rule to make target `i2nstall`.  Stop.' 1>&2",
+      "exit 2",
+    ].join("; ");
+    await apiClient.updateRepository(seedData.repositoryId, { setup_script: failingScript });
+
+    try {
+      const task = await apiClient.createTaskWithAgent(
+        seedData.workspaceId,
+        "Repo Setup Script Failure",
+        seedData.agentProfileId,
+        {
+          description: "/e2e:simple-message",
+          workflow_id: seedData.workflowId,
+          workflow_step_id: seedData.startStepId,
+          repository_ids: [seedData.repositoryId],
+          executor_profile_id: seedData.worktreeExecutorProfileId,
+        },
+      );
+
+      await testPage.goto(`/t/${task.id}`);
+      const session = new SessionPage(testPage);
+      await session.waitForLoad();
+
+      const panel = testPage.getByTestId("prepare-progress-panel");
+      await expect(panel).toBeVisible({ timeout: 15_000 });
+
+      // The failure is surfaced as a non-fatal warning, NOT the fatal `failed`
+      // state — preparation completes and the worktree survives.
+      await expect(panel).toHaveAttribute("data-status", "completed_with_warnings", {
+        timeout: 45_000,
+      });
+
+      // The failure is surfaced as a warning banner on the worktree step so
+      // the user knows the setup script didn't run — without it blocking the
+      // launch. (The full script output also streams to a separate
+      // script_execution chat message.)
+      await expect(panel.getByTestId("prepare-warning-banner")).toContainText(
+        "Repository setup script failed",
+      );
+
+      // The core regression: the agent must launch and run to completion
+      // instead of stopping. Reaching chat-idle proves the turn finished and
+      // the session is awaiting input — preparation did not abort the launch.
+      await session.waitForChatIdle();
+
+      // The "agent stopped" recovery affordances must not appear — the task
+      // continued normally.
+      await expect(session.recoveryResumeButton()).toBeHidden();
+      await expect(session.recoveryFreshButton()).toBeHidden();
+    } finally {
+      // Reset the worker-scoped seed repo so sibling specs aren't contaminated.
+      await apiClient.updateRepository(seedData.repositoryId, { setup_script: "" }).catch(() => {});
+    }
+  });
+
   test("renders collapsed on success when no setup script is configured", async ({
     testPage,
     apiClient,


### PR DESCRIPTION
When a repository setup script failed, environment preparation aborted and the agent stopped ("Environment setup failed") — and the Resume / Start-fresh buttons couldn't recover because each relaunch re-ran the same failing script. This makes the repository-level setup script non-fatal (matching the existing task/profile-level behavior) so a broken setup script surfaces as a warning and the task continues.

## Important Changes

- `runWorktreeSetupScript` no longer deletes the worktree or returns an error on a non-zero exit; it logs a warning, records `SetupScriptWarning`/`Detail` on the worktree, and lets the launch proceed.
- The worktree env preparer surfaces the warning on the "Create worktree" step, so the prepare panel shows `completed_with_warnings` instead of the fatal `failed`. The full script output still streams to the `script_execution` chat message.

## Validation

- `go test ./internal/worktree/` and `./internal/agent/runtime/lifecycle/` (new backend regression tests pass)
- `go vet`, `golangci-lint`, `gofmt` — clean
- `pnpm --filter @kandev/web typecheck` and `lint` — clean
- E2E `tests/session/setup-script-progress.spec.ts` — new test verified **red before / green after** the fix (panel goes `failed` → `completed_with_warnings`, agent launches and reaches idle)

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings