### PR TITLE
fix(orchestrator): stop duplicating workflow auto-start prompt on boot-ready drain

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -329,8 +329,14 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 		}
 	}
 
-	// Create user message for the queued message (so it appears in chat history)
-	if s.messageCreator != nil {
+	// Create user message for the queued message (so it appears in chat history).
+	// Skip when the queued metadata is tagged user_message_recorded — that means
+	// autoStartStepPrompt already inserted the chat row via recordAutoStartMessage
+	// before queueing (the post-recordAutoStartMessage retry branches). Recording
+	// here would produce the duplicate user message observed when a workflow
+	// auto-start failed transiently and the queue drained on boot_ready.
+	alreadyRecorded, _ := queuedMsg.Metadata[metaKeyUserMessageRecorded].(bool)
+	if s.messageCreator != nil && !alreadyRecorded {
 		turnID := s.getActiveTurnID(queuedMsg.SessionID)
 		if turnID == "" {
 			// Start a new turn if needed
@@ -352,6 +358,10 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 				zap.Error(err))
 			// Continue anyway - the prompt should still be sent
 		}
+	} else if alreadyRecorded {
+		s.logger.Debug("skipping CreateUserMessage for queued workflow auto-start; already recorded before queueing",
+			zap.String("session_id", queuedMsg.SessionID),
+			zap.String("queue_id", queuedMsg.ID))
 	}
 
 	// Process on_turn_start before sending the queued prompt, just like

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -358,7 +358,7 @@ func (s *Service) executeQueuedMessage(callerSessionID string, queuedMsg *messag
 				zap.Error(err))
 			// Continue anyway - the prompt should still be sent
 		}
-	} else if alreadyRecorded {
+	} else if s.messageCreator != nil && alreadyRecorded {
 		s.logger.Debug("skipping CreateUserMessage for queued workflow auto-start; already recorded before queueing",
 			zap.String("session_id", queuedMsg.SessionID),
 			zap.String("queue_id", queuedMsg.ID))

--- a/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_duplicate_autostart_test.go
@@ -233,9 +233,11 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 	})
 
 	// drainQueuedMessageAfterTransition pops the queue synchronously and fires
-	// `go executeQueuedMessage(...)`. The goroutine creates a user message and
-	// calls PromptTask → PromptAgent. The mock closes secondPromptCalled on
-	// that call, so the assertion below has a deterministic sync point.
+	// `go executeQueuedMessage(...)`. With the user_message_recorded flag set
+	// at queue time (see autoStartStepPrompt's retry branch), the goroutine
+	// SKIPS its CreateUserMessage and just calls PromptTask → PromptAgent.
+	// The mock closes secondPromptCalled on that call, so the assertion below
+	// has a deterministic sync point.
 	select {
 	case <-secondPromptCalled:
 	case <-time.After(3 * time.Second):
@@ -244,5 +246,19 @@ func TestAutoStartTransientError_BootReadyDrainsOrphanedQueue(t *testing.T) {
 
 	if got := svc.messageQueue.GetStatus(ctx, sessionID).Count; got != 0 {
 		t.Errorf("queue not drained after boot_ready: %d messages still queued (the orphaned-queue bug is back)", got)
+	}
+
+	// After the drain: exactly ONE Merge user message must exist. Phase 1
+	// inserted it via recordAutoStartMessage; Phase 2 (executeQueuedMessage)
+	// must not double-insert. Without the user_message_recorded flag, this
+	// would be 2 — the symptom reported on the ACP-removal task.
+	mergeUserMsgsAfterDrain := 0
+	for _, m := range msgCreator.userMessages {
+		if name, _ := m.metadata["workflow_step_name"].(string); name == "Merge" {
+			mergeUserMsgsAfterDrain++
+		}
+	}
+	if mergeUserMsgsAfterDrain != 1 {
+		t.Errorf("expected exactly 1 Merge user_message after boot_ready drain, got %d (duplicate-prompt bug is back)", mergeUserMsgsAfterDrain)
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_queue_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_queue_test.go
@@ -50,6 +50,58 @@ func TestExecuteQueuedMessage_RequeuesWhenResetInProgress(t *testing.T) {
 	}
 }
 
+// TestExecuteQueuedMessage_SkipsUserMessageWhenAlreadyRecorded pins the
+// duplicate-prompt fix: when a queued workflow auto-start carries
+// metadata[user_message_recorded]=true (set by autoStartStepPrompt's
+// post-recordAutoStartMessage retry branches), executeQueuedMessage must NOT
+// call CreateUserMessage. Without this guard, the boot_ready drain produces
+// the second identical "Merge"-step user row observed on the ACP-removal task.
+func TestExecuteQueuedMessage_SkipsUserMessageWhenAlreadyRecorded(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+
+	session, err := repo.GetTaskSession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+	session.State = models.TaskSessionStateWaitingForInput
+	session.AgentExecutionID = "exec-1"
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+
+	taskRepo := newMockTaskRepo()
+	agentMgr := &mockAgentManager{isAgentRunning: true, repoForExecutionLookup: repo}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+	seedExecutorRunning(t, repo, "s1", "t1", "exec-1")
+
+	mc := &mockMessageCreator{}
+	svc.messageCreator = mc
+
+	queuedMsg := &messagequeue.QueuedMessage{
+		ID:        "q1",
+		SessionID: "s1",
+		TaskID:    "t1",
+		Content:   "merge it",
+		QueuedBy:  messagequeue.QueuedByWorkflow,
+		Metadata: map[string]interface{}{
+			"workflow_step_name":       "Merge",
+			metaKeyUserMessageRecorded: true,
+		},
+	}
+
+	svc.executeQueuedMessage("s1", queuedMsg)
+
+	if len(mc.userMessages) != 0 {
+		t.Fatalf("expected 0 user messages (already recorded before queueing), got %d", len(mc.userMessages))
+	}
+	if len(agentMgr.capturedPrompts) != 1 {
+		t.Fatalf("expected the prompt to still reach PromptAgent, captured=%d", len(agentMgr.capturedPrompts))
+	}
+}
+
 func TestExecuteQueuedMessage_StoresAttachmentsInUserMessageMetadata(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1126,6 +1126,13 @@ func (s *Service) autoStartPassthroughPrompt(
 	return nil
 }
 
+// metaKeyUserMessageRecorded marks a queued workflow auto-start message
+// whose chat-history user row was already inserted by recordAutoStartMessage
+// before the prompt was queued. executeQueuedMessage reads this flag to skip
+// its own CreateUserMessage and avoid the duplicate observed when PromptTask
+// failed transiently and the queue was later drained via boot_ready.
+const metaKeyUserMessageRecorded = "user_message_recorded"
+
 type workflowMessageOrigin struct {
 	StepID    string
 	StepName  string
@@ -1185,7 +1192,10 @@ func (s *Service) autoStartStepPrompt(
 	}
 
 	if shouldQueueIfBusy {
-		queued, err := s.queueAutoStartPromptIfRunning(ctx, taskID, session, prompt, planMode, attachments, origin)
+		// userMessageRecorded=false: recordAutoStartMessage has not run yet —
+		// the drain side (executeQueuedMessage) is responsible for inserting
+		// the chat-history row.
+		queued, err := s.queueAutoStartPromptIfRunning(ctx, taskID, session, prompt, planMode, attachments, origin, false)
 		if err != nil {
 			requeueTaken()
 			return err
@@ -1251,8 +1261,10 @@ func (s *Service) autoStartStepPrompt(
 		// "already has an agent running" means the execution store still tracks
 		// an active agent for this session (e.g. session state is CREATED but
 		// the agent was launched by a concurrent path). Queue instead of retrying.
+		// userMessageRecorded=true: recordAutoStartMessage already inserted the
+		// chat row above, so the drain side must NOT re-insert it.
 		if isAgentAlreadyRunningError(err) && shouldQueueIfBusy {
-			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin); queueErr != nil {
+			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, true); queueErr != nil {
 				requeueTaken()
 				return queueErr
 			}
@@ -1265,7 +1277,9 @@ func (s *Service) autoStartStepPrompt(
 		}
 
 		if shouldQueueIfBusy {
-			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin); queueErr != nil {
+			// userMessageRecorded=true: recordAutoStartMessage already inserted
+			// the chat row above before this retry loop began.
+			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, true); queueErr != nil {
 				requeueTaken()
 				return queueErr
 			}
@@ -1421,11 +1435,12 @@ func (s *Service) queueAutoStartPromptIfRunning(
 	planMode bool,
 	attachments []v1.MessageAttachment,
 	origin workflowMessageOrigin,
+	userMessageRecorded bool,
 ) (bool, error) {
 	if session.State != models.TaskSessionStateRunning && session.State != models.TaskSessionStateStarting {
 		return false, nil
 	}
-	if err := s.queueAutoStartPrompt(ctx, taskID, session.ID, prompt, planMode, attachments, origin); err != nil {
+	if err := s.queueAutoStartPrompt(ctx, taskID, session.ID, prompt, planMode, attachments, origin, userMessageRecorded); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -1446,15 +1461,29 @@ func toQueuedAttachments(attachments []v1.MessageAttachment) []messagequeue.Mess
 	return queued
 }
 
+// queueAutoStartPrompt persists a workflow auto-start prompt for later drain.
+// userMessageRecorded must be true when the caller has already inserted the
+// chat-history user message via recordAutoStartMessage — the flag is stamped
+// onto the queue metadata so executeQueuedMessage skips its own
+// CreateUserMessage and avoids the duplicate-user-message bug observed when
+// PromptTask failed transiently and the queue was later drained on boot_ready.
+// Callers that queue BEFORE recordAutoStartMessage runs (e.g.
+// queueAutoStartPromptIfRunning's early-busy path) must pass false so the
+// drain side still records the message.
 func (s *Service) queueAutoStartPrompt(
 	ctx context.Context,
 	taskID, sessionID, prompt string,
 	planMode bool,
 	attachments []v1.MessageAttachment,
 	origin workflowMessageOrigin,
+	userMessageRecorded bool,
 ) error {
 	if s.messageQueue == nil {
 		return fmt.Errorf("message queue is not configured")
+	}
+	meta := workflowMessageMetadata(planMode, origin)
+	if userMessageRecorded {
+		meta[metaKeyUserMessageRecorded] = true
 	}
 	_, err := s.messageQueue.QueueMessageWithMetadata(
 		ctx,
@@ -1465,7 +1494,7 @@ func (s *Service) queueAutoStartPrompt(
 		messagequeue.QueuedByWorkflow,
 		planMode,
 		toQueuedAttachments(attachments),
-		workflowMessageMetadata(planMode, origin),
+		meta,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to queue workflow auto-start prompt: %w", err)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -1219,7 +1219,7 @@ func (s *Service) autoStartStepPrompt(
 	if session.State == models.TaskSessionStateCreated && !session.IsPassthrough && (prompt != "" || len(attachments) > 0) && !sysprompt.HasKandevContext(prompt) {
 		recordedPrompt = sysprompt.InjectKandevContext(taskID, sessionID, prompt)
 	}
-	s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode, origin)
+	userMsgRecorded := s.recordAutoStartMessage(ctx, taskID, sessionID, recordedPrompt, planMode, origin)
 
 	// If the session is in CREATED state, the agent was never started (e.g. workspace-only
 	// preparation from a blocked auto-start). PromptTask will reject CREATED sessions,
@@ -1261,10 +1261,11 @@ func (s *Service) autoStartStepPrompt(
 		// "already has an agent running" means the execution store still tracks
 		// an active agent for this session (e.g. session state is CREATED but
 		// the agent was launched by a concurrent path). Queue instead of retrying.
-		// userMessageRecorded=true: recordAutoStartMessage already inserted the
-		// chat row above, so the drain side must NOT re-insert it.
+		// Pass userMsgRecorded so the drain skips CreateUserMessage only when the
+		// chat row was successfully inserted above; a failed write passes false,
+		// letting the drain re-attempt insertion.
 		if isAgentAlreadyRunningError(err) && shouldQueueIfBusy {
-			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, true); queueErr != nil {
+			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, userMsgRecorded); queueErr != nil {
 				requeueTaken()
 				return queueErr
 			}
@@ -1277,9 +1278,9 @@ func (s *Service) autoStartStepPrompt(
 		}
 
 		if shouldQueueIfBusy {
-			// userMessageRecorded=true: recordAutoStartMessage already inserted
-			// the chat row above before this retry loop began.
-			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, true); queueErr != nil {
+			// Pass userMsgRecorded so the drain skips CreateUserMessage only when
+			// the chat row was successfully inserted above by recordAutoStartMessage.
+			if queueErr := s.queueAutoStartPrompt(ctx, taskID, sessionID, prompt, planMode, attachments, origin, userMsgRecorded); queueErr != nil {
 				requeueTaken()
 				return queueErr
 			}
@@ -1393,14 +1394,19 @@ func (s *Service) takeAndMergeHandoffMessage(ctx context.Context, sessionID, bas
 // recordAutoStartMessage creates a user message for a workflow auto-start prompt
 // so it appears in the chat history. The prompt content includes system-injected
 // tags which are stripped when displayed to users via ToAPI().
+// Returns true when the chat row was successfully inserted, false otherwise
+// (messageCreator nil, empty prompt, or DB write failure). Callers that queue
+// the prompt after this call must pass the return value to queueAutoStartPrompt
+// as userMessageRecorded, so the drain side only skips CreateUserMessage when
+// the write actually succeeded.
 func (s *Service) recordAutoStartMessage(
 	ctx context.Context,
 	taskID, sessionID, prompt string,
 	planMode bool,
 	origin workflowMessageOrigin,
-) {
+) bool {
 	if s.messageCreator == nil || prompt == "" {
-		return
+		return false
 	}
 	turnID := s.getActiveTurnID(sessionID)
 	if turnID == "" {
@@ -1420,7 +1426,9 @@ func (s *Service) recordAutoStartMessage(
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.Error(err))
+		return false
 	}
+	return true
 }
 
 // queueAutoStartPromptIfRunning queues the workflow auto-start prompt only
@@ -1462,14 +1470,14 @@ func toQueuedAttachments(attachments []v1.MessageAttachment) []messagequeue.Mess
 }
 
 // queueAutoStartPrompt persists a workflow auto-start prompt for later drain.
-// userMessageRecorded must be true when the caller has already inserted the
-// chat-history user message via recordAutoStartMessage — the flag is stamped
-// onto the queue metadata so executeQueuedMessage skips its own
-// CreateUserMessage and avoids the duplicate-user-message bug observed when
-// PromptTask failed transiently and the queue was later drained on boot_ready.
+// userMessageRecorded must be the return value of recordAutoStartMessage: true
+// only when CreateUserMessage actually succeeded. The flag is stamped onto the
+// queue metadata so executeQueuedMessage skips its own CreateUserMessage and
+// avoids the duplicate-user-message bug observed when PromptTask failed
+// transiently and the queue drained on boot_ready. Passing false (failed write
+// or pre-record queue path) lets the drain side record the message instead.
 // Callers that queue BEFORE recordAutoStartMessage runs (e.g.
-// queueAutoStartPromptIfRunning's early-busy path) must pass false so the
-// drain side still records the message.
+// queueAutoStartPromptIfRunning's early-busy path) must pass false.
 func (s *Service) queueAutoStartPrompt(
 	ctx context.Context,
 	taskID, sessionID, prompt string,

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
@@ -362,7 +362,7 @@ func TestHandleTaskMovedWithSession(t *testing.T) {
 		_ = repo.UpdateTaskSession(ctx, session)
 
 		svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
-		queued, err := svc.queueAutoStartPromptIfRunning(ctx, "t1", session, "prompt", false, nil, workflowMessageOrigin{})
+		queued, err := svc.queueAutoStartPromptIfRunning(ctx, "t1", session, "prompt", false, nil, workflowMessageOrigin{}, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
## Summary

- Workflow auto-start prompts were being inserted into chat history twice when a transient `PromptTask` failure caused the prompt to be queued, and the queue later drained on `boot_ready`.
- Root cause: `autoStartStepPrompt` called `recordAutoStartMessage` (inserting the chat row) **before** queueing in its retry branches, but `executeQueuedMessage` unconditionally called `CreateUserMessage` again on every drain — producing duplicate \"Merge\" (or similar) user messages.
- Fix: stamp a `user_message_recorded` flag on queue metadata when the chat row was already inserted before queueing; `executeQueuedMessage` skips `CreateUserMessage` when the flag is present. The early-busy queue path (`queueAutoStartPromptIfRunning`) queues **without** the flag, preserving the original behavior where the drain side owns the record.

## Implementation notes

A new package-level constant `metaKeyUserMessageRecorded = "user_message_recorded"` is introduced in `event_handlers_workflow.go`. The flag is a required positional `bool` added to `queueAutoStartPrompt` and `queueAutoStartPromptIfRunning`, so the compiler enforces an explicit choice at every call site. Metadata is persisted as JSON by the queue repository — booleans round-trip fine, mirroring the existing `plan_mode` pattern.

`executeQueuedMessage` reads the flag with a nil-safe type assertion (`(bool)` on a nil map returns `(false, false)`, no panic), logs a Debug line when skipping, and leaves `PromptTask` + all downstream processing untouched. The turn-start dance is also skipped when the flag is set; `PromptTask` starts its own turn when none is active, so chat history remains intact.

## Test plan

- [x] New focused unit test `TestExecuteQueuedMessage_SkipsUserMessageWhenAlreadyRecorded` in `event_handlers_queue_test.go`: queues a message with `user_message_recorded: true`, asserts `msgCreator.userMessages` is empty and the prompt still reaches `PromptAgent`.
- [x] Regression test `TestAutoStartTransientError_BootReadyDrainsOrphanedQueue` extended with a post-drain message-count assertion: exactly 1 `Merge` user message after boot_ready drain (was 2 before this fix).
- [x] Existing `TestQueueAutoStartPromptIfRunning` / `TestHandleTaskMovedWithSession` updated with new `false` argument — behavior unchanged.
- [x] Full orchestrator suite: `go test ./internal/orchestrator/... -count=1 -race` — all passing.
- [ ] CI to verify `make fmt && make typecheck test lint` across the backend.

## Risks & rollback

- **Rollback**: single revert of the five changed files; no DB migration, no schema change. Queue entries that predate the fix carry no flag, so they continue through the unmodified drain path.
- **New callers**: `queueAutoStartPrompt` now takes a required `bool` — the compiler refuses callers that don't make a choice, making it hard to silently re-introduce the dup.
- **Turn ownership**: skipping `startTurnForSession` in the drain path is safe because `PromptTask` → `dispatchPromptAsync` → `startTurnForSession` starts the turn when none is active. Verified by tracing that code path.