### PR TITLE
feat(web): add PR closed banner and hide CI chip on terminal state

### DIFF
--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -89,6 +89,22 @@ describe("PRStatusChip", () => {
     expect(screen.queryByTestId(CHIP_TESTID)).toBeNull();
   });
 
+  it("returns null when the PR has been merged (terminal state)", () => {
+    renderWithStore(
+      { taskPRs: { byTaskId: { "task-1": [makePR({ state: "merged" })] } } },
+      <PRStatusChip taskId="task-1" />,
+    );
+    expect(screen.queryByTestId(CHIP_TESTID)).toBeNull();
+  });
+
+  it("returns null when the PR has been closed (terminal state)", () => {
+    renderWithStore(
+      { taskPRs: { byTaskId: { "task-1": [makePR({ state: "closed" })] } } },
+      <PRStatusChip taskId="task-1" />,
+    );
+    expect(screen.queryByTestId(CHIP_TESTID)).toBeNull();
+  });
+
   describe("desktop branch", () => {
     beforeEach(() => isMobileMock.mockReturnValue(false));
 

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -63,7 +63,9 @@ function chipStatus(pr: TaskPR): ChipStatus {
  * Mobile: tapping opens the same popover content inside a bottom-sheet Drawer
  * — hover is unreachable on touch devices.
  *
- * Returns null when the task has no PR yet.
+ * Returns null when the task has no PR yet, or once the PR reaches a terminal
+ * state (merged / closed) — the chat-input banner already conveys that, so the
+ * CI chip would be redundant.
  */
 export function PRStatusChip({ taskId }: { taskId: string | null }) {
   const { pr } = useTaskPR(taskId);
@@ -71,6 +73,7 @@ export function PRStatusChip({ taskId }: { taskId: string | null }) {
   // top-bar PR button isn't mounted (e.g. small viewport that hides it).
   usePRFeedbackBackgroundSync(pr);
   if (!pr) return null;
+  if (pr.state === "merged" || pr.state === "closed") return null;
   return <PRStatusChipInner pr={pr} />;
 }
 

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -29,11 +29,11 @@ import type { TaskPR } from "@/lib/types/github";
 const HOVER_OPEN_DELAY_MS = 150;
 const HOVER_CLOSE_DELAY_MS = 150;
 
-type ChipStatus = "passed" | "failed" | "in_progress" | "merged" | "closed" | "neutral";
+// Terminal states (merged / closed) never reach here — PRStatusChip returns
+// null for them before rendering — so the chip status union omits them.
+type ChipStatus = "passed" | "failed" | "in_progress" | "neutral";
 
 function chipStatus(pr: TaskPR): ChipStatus {
-  if (pr.state === "merged") return "merged";
-  if (pr.state === "closed") return "closed";
   if (pr.review_state === "changes_requested" || pr.checks_state === "failure") return "failed";
   // Pending checks / pending review must beat checks_state === "success" so a
   // PR with all checks green but reviewers still outstanding renders as
@@ -54,7 +54,6 @@ function chipStatus(pr: TaskPR): ChipStatus {
  *   passed  → green check
  *   failed  → red X
  *   in progress → yellow spinner
- *   merged  → purple dot
  *   neutral → muted dot
  *
  * Desktop: hovering opens the full PRCIPopover anchored to the top edge so the
@@ -193,10 +192,6 @@ function ChipStatusGlyph({ status }: { status: ChipStatus }) {
           aria-hidden="true"
         />
       );
-    case "merged":
-      return <IconPointFilled className="h-3.5 w-3.5 text-purple-500" aria-hidden="true" />;
-    case "closed":
-      return <IconPointFilled className="h-3.5 w-3.5 text-red-500" aria-hidden="true" />;
     default:
       return <IconPointFilled className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />;
   }

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -414,8 +414,11 @@ function ChatStatusBar({
       {showTodos && <TodoIndicator todos={todoItems} />}
       <PRStatusChip taskId={taskId} />
       {queueChip}
-      {taskId && <PRMergedBanner key={taskId} taskId={taskId} />}
-      {taskId && <PRClosedBanner key={taskId} taskId={taskId} />}
+      {/* Distinct per-banner keys: the key remounts the banner on task switch
+          so its dismissed state re-initialises, and keeping the two suffixes
+          different avoids a duplicate-sibling-key collision. */}
+      {taskId && <PRMergedBanner key={`${taskId}-merged`} taskId={taskId} />}
+      {taskId && <PRClosedBanner key={`${taskId}-closed`} taskId={taskId} />}
       {canShare && taskId && sessionId && (
         <div className="ml-auto">
           <ShareButton taskId={taskId} sessionId={sessionId} iconOnly />

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -415,7 +415,7 @@ function ChatStatusBar({
       <PRStatusChip taskId={taskId} />
       {queueChip}
       {taskId && <PRMergedBanner key={taskId} taskId={taskId} />}
-      {taskId && <PRClosedBanner key={`${taskId}-closed`} taskId={taskId} />}
+      {taskId && <PRClosedBanner key={taskId} taskId={taskId} />}
       {canShare && taskId && sessionId && (
         <div className="ml-auto">
           <ShareButton taskId={taskId} sessionId={sessionId} iconOnly />

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState, type ReactNode } from "react";
-import { IconArrowRight, IconGitMerge, IconX } from "@tabler/icons-react";
+import { IconArrowRight, IconGitMerge, IconGitPullRequestClosed, IconX } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { TodoIndicator } from "./todo-indicator";
@@ -29,7 +29,12 @@ import { usePlanActions } from "@/hooks/domains/kanban/use-plan-actions";
 import { useExecutorEnvironmentAvailability } from "@/hooks/domains/session/use-executor-environment-availability";
 import { useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useToast } from "@/components/toast-provider";
-import { markPRMergedBannerDismissed, wasPRMergedBannerDismissed } from "@/lib/local-storage";
+import {
+  markPRClosedBannerDismissed,
+  markPRMergedBannerDismissed,
+  wasPRClosedBannerDismissed,
+  wasPRMergedBannerDismissed,
+} from "@/lib/local-storage";
 import type { DiffComment } from "@/lib/diff/types";
 import type { useChatPanelState } from "./use-chat-panel-state";
 
@@ -240,18 +245,12 @@ export function useChatPanelHandlers(
   return { handleCancelTurn };
 }
 
-export function PRMergedBanner({ taskId }: { taskId: string }) {
-  const taskPRs = useAppStore((state) => state.taskPRs.byTaskId[taskId]);
-  const [dismissed, setDismissed] = useState(() => wasPRMergedBannerDismissed(taskId));
+// Shared archive-task action for the terminal-state banners: archives the task,
+// switches to the next one, and toasts the outcome.
+function useArchiveTaskAction(taskId: string) {
   const archiveAndSwitch = useArchiveAndSwitchTask();
   const { toast } = useToast();
-
-  const handleDismiss = useCallback(() => {
-    markPRMergedBannerDismissed(taskId);
-    setDismissed(true);
-  }, [taskId]);
-
-  const handleArchive = useCallback(async () => {
+  return useCallback(async () => {
     try {
       await archiveAndSwitch(taskId);
       toast({ description: "Task archived" });
@@ -259,6 +258,64 @@ export function PRMergedBanner({ taskId }: { taskId: string }) {
       toast({ description: "Failed to archive task", variant: "error" });
     }
   }, [taskId, archiveAndSwitch, toast]);
+}
+
+// Presentational banner shared by PRMergedBanner / PRClosedBanner — an icon, a
+// message, and Archive + Dismiss controls. Colors/icon/testIds are supplied by
+// the caller so the two variants stay visually distinct.
+function ArchiveDismissBanner({
+  testIdPrefix,
+  icon,
+  text,
+  containerClass,
+  archiveClass,
+  dismissClass,
+  onArchive,
+  onDismiss,
+}: {
+  testIdPrefix: string;
+  icon: ReactNode;
+  text: string;
+  containerClass: string;
+  archiveClass: string;
+  dismissClass: string;
+  onArchive: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div data-testid={`${testIdPrefix}-banner`} className={containerClass}>
+      {icon}
+      <span className="flex-1">{text}</span>
+      <button
+        type="button"
+        data-testid={`${testIdPrefix}-archive-button`}
+        onClick={onArchive}
+        className={archiveClass}
+      >
+        Archive
+      </button>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        data-testid={`${testIdPrefix}-dismiss-button`}
+        onClick={onDismiss}
+        className={dismissClass}
+      >
+        <IconX className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+export function PRMergedBanner({ taskId }: { taskId: string }) {
+  const taskPRs = useAppStore((state) => state.taskPRs.byTaskId[taskId]);
+  const [dismissed, setDismissed] = useState(() => wasPRMergedBannerDismissed(taskId));
+  const handleArchive = useArchiveTaskAction(taskId);
+
+  const handleDismiss = useCallback(() => {
+    markPRMergedBannerDismissed(taskId);
+    setDismissed(true);
+  }, [taskId]);
 
   // Multi-repo: only show "ready to archive" once every PR is merged. A
   // single merged repo with others still open means the task isn't done yet.
@@ -271,30 +328,50 @@ export function PRMergedBanner({ taskId }: { taskId: string }) {
       : `All ${taskPRs.length} PRs have been merged. You can archive this task.`;
 
   return (
-    <div
-      data-testid="pr-merged-banner"
-      className="flex flex-1 items-center gap-2 rounded-md bg-purple-500/10 px-2 py-1 text-purple-600 dark:text-purple-400"
-    >
-      <IconGitMerge className="h-3.5 w-3.5 shrink-0" />
-      <span className="flex-1">{bannerText}</span>
-      <button
-        type="button"
-        data-testid="pr-merged-archive-button"
-        onClick={handleArchive}
-        className="underline underline-offset-2 hover:text-purple-700 dark:hover:text-purple-300 cursor-pointer"
-      >
-        Archive
-      </button>
-      <button
-        type="button"
-        aria-label="Dismiss"
-        data-testid="pr-merged-dismiss-button"
-        onClick={handleDismiss}
-        className="p-0.5 hover:bg-purple-500/10 rounded cursor-pointer"
-      >
-        <IconX className="h-3 w-3" />
-      </button>
-    </div>
+    <ArchiveDismissBanner
+      testIdPrefix="pr-merged"
+      icon={<IconGitMerge className="h-3.5 w-3.5 shrink-0" />}
+      text={bannerText}
+      containerClass="flex flex-1 items-center gap-2 rounded-md bg-purple-500/10 px-2 py-1 text-purple-600 dark:text-purple-400"
+      archiveClass="underline underline-offset-2 hover:text-purple-700 dark:hover:text-purple-300 cursor-pointer"
+      dismissClass="p-0.5 hover:bg-purple-500/10 rounded cursor-pointer"
+      onArchive={handleArchive}
+      onDismiss={handleDismiss}
+    />
+  );
+}
+
+export function PRClosedBanner({ taskId }: { taskId: string }) {
+  const taskPRs = useAppStore((state) => state.taskPRs.byTaskId[taskId]);
+  const [dismissed, setDismissed] = useState(() => wasPRClosedBannerDismissed(taskId));
+  const handleArchive = useArchiveTaskAction(taskId);
+
+  const handleDismiss = useCallback(() => {
+    markPRClosedBannerDismissed(taskId);
+    setDismissed(true);
+  }, [taskId]);
+
+  // Mirror the merged banner's all-or-nothing rule: show only once every PR is
+  // closed-without-merging. A mix of merged + closed shows neither banner.
+  const allClosed = !!taskPRs && taskPRs.length > 0 && taskPRs.every((pr) => pr.state === "closed");
+  if (!allClosed || dismissed) return null;
+
+  const bannerText =
+    taskPRs.length === 1
+      ? `PR #${taskPRs[0].pr_number} was closed without merging. You can archive this task.`
+      : `All ${taskPRs.length} PRs were closed without merging. You can archive this task.`;
+
+  return (
+    <ArchiveDismissBanner
+      testIdPrefix="pr-closed"
+      icon={<IconGitPullRequestClosed className="h-3.5 w-3.5 shrink-0" />}
+      text={bannerText}
+      containerClass="flex flex-1 items-center gap-2 rounded-md bg-red-500/10 px-2 py-1 text-red-600 dark:text-red-400"
+      archiveClass="underline underline-offset-2 hover:text-red-700 dark:hover:text-red-300 cursor-pointer"
+      dismissClass="p-0.5 hover:bg-red-500/10 rounded cursor-pointer"
+      onArchive={handleArchive}
+      onDismiss={handleDismiss}
+    />
   );
 }
 
@@ -338,6 +415,7 @@ function ChatStatusBar({
       <PRStatusChip taskId={taskId} />
       {queueChip}
       {taskId && <PRMergedBanner key={taskId} taskId={taskId} />}
+      {taskId && <PRClosedBanner key={`${taskId}-closed`} taskId={taskId} />}
       {canShare && taskId && sessionId && (
         <div className="ml-auto">
           <ShareButton taskId={taskId} sessionId={sessionId} iconOnly />

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -61,6 +61,18 @@ export class SessionPage {
   prMergedDismissButton() {
     return this.page.getByTestId("pr-merged-dismiss-button");
   }
+  prClosedBanner() {
+    return this.page.getByTestId("pr-closed-banner");
+  }
+  prClosedArchiveButton() {
+    return this.page.getByTestId("pr-closed-archive-button");
+  }
+  prClosedDismissButton() {
+    return this.page.getByTestId("pr-closed-dismiss-button");
+  }
+  prStatusChip() {
+    return this.page.getByTestId("pr-status-chip");
+  }
   todoIndicator() {
     return this.page.getByTestId("todo-indicator");
   }

--- a/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
@@ -252,6 +252,62 @@ test.describe("Chat status bar", () => {
     await expect(session.prMergedBanner()).not.toBeVisible();
   });
 
+  test("shows PR closed banner and hides the CI chip when the PR is closed", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "PR Closed Banner Task",
+      seedData.agentProfileId,
+      {
+        description: 'e2e:message("pr closed banner response")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: task.id,
+      owner: "test-org",
+      repo: "test-repo",
+      pr_number: 505,
+      pr_url: "https://github.com/test-org/test-repo/pull/505",
+      pr_title: "Closed Test PR",
+      head_branch: "feature/closed",
+      base_branch: "main",
+      author_login: "test-user",
+      state: "closed",
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    const card = kanban.taskCardByTitle("PR Closed Banner Task");
+    await expect(card).toBeVisible({ timeout: 30_000 });
+    await card.click();
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
+
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    await expect(session.chat.getByText("pr closed banner response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const statusBar = session.chatStatusBar();
+    await expect(statusBar).toBeVisible({ timeout: 10_000 });
+    await expect(session.prClosedBanner()).toBeVisible({ timeout: 10_000 });
+    await expect(session.prClosedBanner()).toContainText("PR #505 was closed without merging");
+    // The CI chip is redundant once the PR is terminal — the banner conveys it.
+    await expect(session.prStatusChip()).not.toBeVisible();
+    await expect(session.prMergedBanner()).not.toBeVisible();
+  });
+
   test("archive via PR banner switches to next task", async ({ testPage, apiClient, seedData }) => {
     test.setTimeout(90_000);
 

--- a/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
+++ b/apps/web/e2e/tests/chat/chat-status-bar.spec.ts
@@ -308,6 +308,93 @@ test.describe("Chat status bar", () => {
     await expect(session.prMergedBanner()).not.toBeVisible();
   });
 
+  test("dismissed PR closed banner stays hidden across reload and task switch", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const taskA = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Dismiss Closed Banner Task A",
+      seedData.agentProfileId,
+      {
+        description: 'e2e:message("dismiss closed alpha response")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Dismiss Closed Banner Task B",
+      seedData.agentProfileId,
+      {
+        description: 'e2e:message("dismiss closed beta response")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: taskA.id,
+      owner: "test-org",
+      repo: "test-repo",
+      pr_number: 606,
+      pr_url: "https://github.com/test-org/test-repo/pull/606",
+      pr_title: "Dismiss Closed Test PR",
+      head_branch: "feature/dismiss-closed",
+      base_branch: "main",
+      author_login: "test-user",
+      state: "closed",
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    const cardA = kanban.taskCardByTitle("Dismiss Closed Banner Task A");
+    await expect(cardA).toBeVisible({ timeout: 30_000 });
+    await cardA.click();
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
+
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    await expect(session.chat.getByText("dismiss closed alpha response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Banner appears, then user dismisses it.
+    await expect(session.prClosedBanner()).toBeVisible({ timeout: 10_000 });
+    await session.prClosedDismissButton().click();
+    await expect(session.prClosedBanner()).not.toBeVisible();
+
+    // Persists across reload.
+    await testPage.reload();
+    await session.waitForLoad();
+    await expect(session.chat.getByText("dismiss closed alpha response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(session.prClosedBanner()).not.toBeVisible();
+
+    // Switch to task B (no closed PR, so never shows the banner) and back. The
+    // proof of cross-task-switch persistence is the banner still hidden on the
+    // return trip to task A.
+    await session.taskInSidebar("Dismiss Closed Banner Task B").first().click();
+    await expect(session.chat.getByText("dismiss closed beta response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await session.taskInSidebar("Dismiss Closed Banner Task A").first().click();
+    await expect(session.chat.getByText("dismiss closed alpha response").last()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(session.prClosedBanner()).not.toBeVisible();
+  });
+
   test("archive via PR banner switches to next task", async ({ testPage, apiClient, seedData }) => {
     test.setTimeout(90_000);
 

--- a/apps/web/lib/local-storage.test.ts
+++ b/apps/web/lib/local-storage.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   cleanupTaskStorage,
+  markPRClosedBannerDismissed,
   markPRMergedBannerDismissed,
+  wasPRClosedBannerDismissed,
   wasPRMergedBannerDismissed,
 } from "./local-storage";
 
@@ -29,5 +31,38 @@ describe("PR merged banner dismissal storage", () => {
 
     expect(wasPRMergedBannerDismissed("task-a")).toBe(false);
     expect(wasPRMergedBannerDismissed("task-b")).toBe(true);
+  });
+});
+
+describe("PR closed banner dismissal storage", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("returns false when no dismissal has been recorded", () => {
+    expect(wasPRClosedBannerDismissed("task-a")).toBe(false);
+  });
+
+  it("persists dismissal per task and reads it back", () => {
+    markPRClosedBannerDismissed("task-a");
+
+    expect(wasPRClosedBannerDismissed("task-a")).toBe(true);
+    expect(wasPRClosedBannerDismissed("task-b")).toBe(false);
+  });
+
+  it("is independent from the merged banner dismissal flag", () => {
+    markPRMergedBannerDismissed("task-a");
+
+    expect(wasPRClosedBannerDismissed("task-a")).toBe(false);
+  });
+
+  it("clears the dismissal flag via cleanupTaskStorage", () => {
+    markPRClosedBannerDismissed("task-a");
+    markPRClosedBannerDismissed("task-b");
+
+    cleanupTaskStorage("task-a", []);
+
+    expect(wasPRClosedBannerDismissed("task-a")).toBe(false);
+    expect(wasPRClosedBannerDismissed("task-b")).toBe(true);
   });
 });

--- a/apps/web/lib/local-storage.ts
+++ b/apps/web/lib/local-storage.ts
@@ -386,6 +386,28 @@ export function markPRMergedBannerDismissed(taskId: string): void {
   }
 }
 
+// PR closed banner dismissal — same lifetime as the merged banner: per-task,
+// survives reload + task switch within the tab session, resets on tab close.
+const PR_CLOSED_BANNER_DISMISSED_PREFIX = "kandev.pr-closed-banner-dismissed.";
+
+export function wasPRClosedBannerDismissed(taskId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(`${PR_CLOSED_BANNER_DISMISSED_PREFIX}${taskId}`) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markPRClosedBannerDismissed(taskId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(`${PR_CLOSED_BANNER_DISMISSED_PREFIX}${taskId}`, "1");
+  } catch {
+    // Ignore write failures
+  }
+}
+
 // Internal storage keys for open file tabs
 const OPEN_FILES_KEY = "kandev.openFiles";
 const ACTIVE_TAB_KEY = "kandev.activeTab";
@@ -595,8 +617,9 @@ export function cleanupTaskStorage(
   // Plan notification (localStorage, keyed per task inside a Record)
   setPlanLastSeen(taskId, null);
 
-  // PR merged banner dismissal (sessionStorage, keyed per task)
+  // PR merged / closed banner dismissal (sessionStorage, keyed per task)
   removeSessionStorage(`${PR_MERGED_BANNER_DISMISSED_PREFIX}${taskId}`);
+  removeSessionStorage(`${PR_CLOSED_BANNER_DISMISSED_PREFIX}${taskId}`);
 
   // Sidebar collapsed-subtask set (sessionStorage, array keyed by parent taskId)
   const collapsed = getStoredCollapsedSubtaskParents();


### PR DESCRIPTION
A closed-without-merging PR left the chat input with only a stale CI chip and no cue that the task was done; this adds a "PR closed" banner mirroring the merged one and hides the now-redundant CI chip once a PR is terminal.

## Important Changes

- New `PRClosedBanner` shown once every PR for the task is `closed` (mirrors the merged banner's all-or-nothing, multi-repo rule); a mix of merged + closed shows neither.
- `PRStatusChip` returns `null` when the PR state is `merged` or `closed` — the banner already conveys terminal state.
- Extracted a shared `ArchiveDismissBanner` + `useArchiveTaskAction` so merged and closed variants stay DRY while keeping distinct colors, icons, and test ids.
- Added per-task `sessionStorage` dismissal helpers for the closed banner, cleaned up alongside the merged one on task deletion.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` (incl. new local-storage + pr-status-chip cases)
- `playwright test e2e/tests/chat/chat-status-bar.spec.ts` — 6/6 passed, incl. new "shows PR closed banner and hides the CI chip when the PR is closed"

## Possible Improvements

Low risk. On multi-repo tasks the chip reflects the primary PR while the banner checks all PRs, so they can briefly disagree on a mixed-state task — acceptable for now.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.