### PR TITLE
feat: annotate debug logs with task_id for per-task filtering

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -456,6 +456,19 @@ func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEv
 
 	transitioned := s.processOnTurnCompleteViaEngine(ctx, data.TaskID, session)
 
+	// Agent-exit path: unlike the streaming complete event, this path does NOT
+	// itself complete the open turn or clear the session's RUNNING state — it
+	// relies entirely on the workflow engine's on_turn_complete transition.
+	// workflow_transitioned=false means no transition fired, so the session may
+	// still be RUNNING (only the task row moves to REVIEW below) and the chat UI
+	// keeps showing the agent as working. Pairs with the frontend [session:state]
+	// / [session:turns] trace — filter both by the same task_id.
+	s.logger.Debug("agent.completed turn-complete decision (session state not cleared by this path)",
+		zap.String("task_id", data.TaskID),
+		zap.String("session_id", data.SessionID),
+		zap.String("session_state", string(session.State)),
+		zap.Bool("workflow_transitioned", transitioned))
+
 	// If no workflow transition occurred, move task to REVIEW state for user review
 	if !transitioned {
 		if err := s.taskRepo.UpdateTaskState(ctx, data.TaskID, v1.TaskStateReview); err != nil {

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -702,8 +702,7 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 		// same task_id to see whether a clear ever lands.
 		s.logger.Debug("complete-event deferring running->waiting to READY (turn done, state not yet cleared)",
 			zap.String("task_id", payload.TaskID),
-			zap.String("session_id", payload.SessionID),
-			zap.String("session_state", string(session.State)))
+			zap.String("session_id", payload.SessionID))
 		return
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -695,13 +695,36 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	// READY events own workflow transitions and queued prompt execution.
 	// If we're still RUNNING here, avoid racing READY by forcing WAITING/REVIEW.
 	if session != nil && session.State == models.TaskSessionStateRunning {
-		s.logger.Debug("skipping complete-event terminal state update while session is running",
+		// Deferring the running→waiting transition to a READY event. If no READY
+		// follows, the session stays RUNNING and the chat UI keeps showing the
+		// agent as working even though the turn already completed. This is the
+		// backend half of the frontend [session:state] trace — filter both by the
+		// same task_id to see whether a clear ever lands.
+		s.logger.Debug("complete-event deferring running->waiting to READY (turn done, state not yet cleared)",
 			zap.String("task_id", payload.TaskID),
-			zap.String("session_id", payload.SessionID))
+			zap.String("session_id", payload.SessionID),
+			zap.String("session_state", string(session.State)))
 		return
 	}
 
+	// Positive path: this complete event owns the running→WAITING_FOR_INPUT
+	// transition (no READY race). Pairs with the frontend [session:state] line
+	// under the same task_id.
+	s.logger.Debug("complete-event clearing running->waiting (this event owns the transition)",
+		zap.String("task_id", payload.TaskID),
+		zap.String("session_id", payload.SessionID),
+		zap.String("prev_state", sessionStateString(session)))
 	s.setSessionWaitingForInput(ctx, payload.TaskID, payload.SessionID, session)
+}
+
+// sessionStateString renders a session's state for logging, returning "" when
+// the session is nil (e.g. a complete event with no session ID). Kept tiny so
+// state-transition trace logs don't add branching to their hot-path callers.
+func sessionStateString(session *models.TaskSession) string {
+	if session == nil {
+		return ""
+	}
+	return string(session.State)
 }
 
 // Mirrors the same read in lifecycle/manager_events.go.

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -381,3 +381,10 @@ func TestSetSessionWaitingForInput_WritesOnTransition(t *testing.T) {
 		"setSessionWaitingForInput must write tasks.state on actual transition")
 	require.Equal(t, v1.TaskStateReview, taskRepo.updatedStates["t1"])
 }
+
+func TestSessionStateString(t *testing.T) {
+	require.Equal(t, "", sessionStateString(nil),
+		"nil session must render as empty so trace logs stay clean")
+	require.Equal(t, string(models.TaskSessionStateRunning),
+		sessionStateString(&models.TaskSession{State: models.TaskSessionStateRunning}))
+}

--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import type { StoreApi } from "zustand";
 import { useStore } from "zustand";
+import { IS_DEBUG, registerSessionTaskResolver } from "@/lib/debug/log";
 import type { AppState, StoreProviderProps } from "@/lib/state/store";
 import { createAppStore } from "@/lib/state/store";
 
@@ -21,6 +22,17 @@ export function StateProvider({ children, initialState }: StoreProviderProps) {
     if (win.__KANDEV_E2E_EXPOSE_STORE__) {
       win.__KANDEV_E2E_STORE__ = store;
     }
+  }, [store]);
+
+  // In debug builds, let the namespaced debug logger annotate every line that
+  // carries a sessionId with `task_id=<...>` so console/log filters can scope to
+  // a single task (see lib/debug/log.ts). No-op in production.
+  useEffect(() => {
+    if (!IS_DEBUG) return;
+    registerSessionTaskResolver(
+      (sessionId) => store.getState().taskSessions.items[sessionId]?.task_id ?? undefined,
+    );
+    return () => registerSessionTaskResolver(null);
   }, [store]);
 
   return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>;

--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -29,10 +29,9 @@ export function StateProvider({ children, initialState }: StoreProviderProps) {
   // a single task (see lib/debug/log.ts). No-op in production.
   useEffect(() => {
     if (!IS_DEBUG) return;
-    registerSessionTaskResolver(
+    return registerSessionTaskResolver(
       (sessionId) => store.getState().taskSessions.items[sessionId]?.task_id,
     );
-    return () => registerSessionTaskResolver(null);
   }, [store]);
 
   return <StoreContext.Provider value={store}>{children}</StoreContext.Provider>;

--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -30,7 +30,7 @@ export function StateProvider({ children, initialState }: StoreProviderProps) {
   useEffect(() => {
     if (!IS_DEBUG) return;
     registerSessionTaskResolver(
-      (sessionId) => store.getState().taskSessions.items[sessionId]?.task_id ?? undefined,
+      (sessionId) => store.getState().taskSessions.items[sessionId]?.task_id,
     );
     return () => registerSessionTaskResolver(null);
   }, [store]);

--- a/apps/web/lib/debug/log.test.ts
+++ b/apps/web/lib/debug/log.test.ts
@@ -143,6 +143,23 @@ describe("registerSessionTaskResolver", () => {
     log("msg", { sessionId: "s_1" });
     expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1");
   });
+
+  it("returned unregister clears the active resolver", () => {
+    const unregister = registerSessionTaskResolver(() => "t_42");
+    unregister();
+    const log = createDebugLogger("ns");
+    log("msg", { sessionId: "s_1" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1");
+  });
+
+  it("a stale unregister does not clear a newer resolver (HMR-safe)", () => {
+    const unregisterA = registerSessionTaskResolver(() => "t_A");
+    registerSessionTaskResolver(() => "t_B"); // newer registration takes over
+    unregisterA(); // stale cleanup must NOT kill the newer resolver
+    const log = createDebugLogger("ns");
+    log("msg", { sessionId: "s_1" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1 task_id=t_B");
+  });
 });
 
 describe("IS_DEBUG", () => {

--- a/apps/web/lib/debug/log.test.ts
+++ b/apps/web/lib/debug/log.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createDebugLogger } from "./log";
+import { createDebugLogger, registerSessionTaskResolver } from "./log";
 
 describe("createDebugLogger", () => {
   beforeEach(() => {
@@ -72,6 +72,69 @@ describe("createDebugLogger", () => {
     const log = createDebugLogger("ns");
     log("prefix", { a: 1 }, "suffix");
     expect(console.debug).toHaveBeenCalledWith("[ns] prefix a=1 suffix");
+  });
+});
+
+describe("registerSessionTaskResolver", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    registerSessionTaskResolver(null);
+    vi.restoreAllMocks();
+  });
+
+  it("annotates lines carrying a sessionId with task_id", () => {
+    registerSessionTaskResolver((sid) => (sid === "s_1" ? "t_42" : undefined));
+    const log = createDebugLogger("ns");
+    log("msg", { sessionId: "s_1", fileCount: 3 });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1 fileCount=3 task_id=t_42");
+  });
+
+  it("resolves from a snake_case session_id field too", () => {
+    registerSessionTaskResolver(() => "t_99");
+    const log = createDebugLogger("ns");
+    log("msg", { session_id: "s_1" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg session_id=s_1 task_id=t_99");
+  });
+
+  it("does not annotate when the line already names a task", () => {
+    registerSessionTaskResolver(() => "t_resolved");
+    const log = createDebugLogger("ns");
+    log("msg", { sessionId: "s_1", taskId: "t_explicit" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1 taskId=t_explicit");
+  });
+
+  it("does not annotate when no session is present", () => {
+    registerSessionTaskResolver(() => "t_42");
+    const log = createDebugLogger("ns");
+    log("msg", { foo: "bar" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg foo=bar");
+  });
+
+  it("omits task_id when the session cannot be resolved", () => {
+    registerSessionTaskResolver(() => undefined);
+    const log = createDebugLogger("ns");
+    log("msg", { sessionId: "s_unknown" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_unknown");
+  });
+
+  it("never throws when the resolver throws", () => {
+    registerSessionTaskResolver(() => {
+      throw new Error("store gone");
+    });
+    const log = createDebugLogger("ns");
+    expect(() => log("msg", { sessionId: "s_1" })).not.toThrow();
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1");
+  });
+
+  it("stops annotating once cleared with null", () => {
+    registerSessionTaskResolver(() => "t_42");
+    registerSessionTaskResolver(null);
+    const log = createDebugLogger("ns");
+    log("msg", { sessionId: "s_1" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1");
   });
 });
 

--- a/apps/web/lib/debug/log.test.ts
+++ b/apps/web/lib/debug/log.test.ts
@@ -99,11 +99,18 @@ describe("registerSessionTaskResolver", () => {
     expect(console.debug).toHaveBeenCalledWith("[ns] msg session_id=s_1 task_id=t_99");
   });
 
-  it("does not annotate when the line already names a task", () => {
+  it("does not annotate when the line already names a task via taskId", () => {
     registerSessionTaskResolver(() => "t_resolved");
     const log = createDebugLogger("ns");
     log("msg", { sessionId: "s_1", taskId: "t_explicit" });
     expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1 taskId=t_explicit");
+  });
+
+  it("does not annotate when the line already names a task via task_id", () => {
+    registerSessionTaskResolver(() => "t_resolved");
+    const log = createDebugLogger("ns");
+    log("msg", { sessionId: "s_1", task_id: "t_explicit" });
+    expect(console.debug).toHaveBeenCalledWith("[ns] msg sessionId=s_1 task_id=t_explicit");
   });
 
   it("does not annotate when no session is present", () => {

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -26,6 +26,21 @@
  *
  *   [namespace] message key1=value key2="value with space" key3={"nested":1}
  *
+ * ## Filtering by task
+ *
+ * Most call sites only have a `sessionId` in scope, but triage usually happens
+ * per *task*. When a session→task resolver is registered (the `StateProvider`
+ * wires one up in dev — see `registerSessionTaskResolver`), every line that
+ * carries a `sessionId` / `session_id` field is auto-annotated with a trailing
+ * `task_id=<...>`:
+ *
+ *   [git-status:ws] status_update received sessionId=abc fileCount=3 task_id=t_42
+ *
+ * So `task_id=t_42` in the devtools console filter narrows *all* namespaces to a
+ * single task. No call site has to thread the task ID through by hand — just keep
+ * logging `sessionId` and the task ID rides along. (If a line already names a
+ * task via `taskId` / `task_id`, it is left as-is.)
+ *
  * ## Namespace convention
  *
  * Names use `<domain>:<aspect>` so a devtools console filter can narrow on
@@ -114,6 +129,20 @@
  *                                    Virtuoso is mounted explains the
  *                                    agent-reply-pushed-below-fold scenario.
  *
+ *   Agent running-state (bug: ACP turn completes but chat still shows the agent
+ *   as running). The chat "agent is working" indicator is driven by
+ *   taskSessions.items[sessionId].state === "RUNNING"; it only clears when a
+ *   session.state_changed WS event flips new_state off RUNNING.
+ *     [session:state]         session.state_changed handler — old→new state per
+ *                             session. If you never see a line transitioning
+ *                             newState off RUNNING after the turn completes, the
+ *                             backend never published the clear (look at the
+ *                             orchestrator complete-event guard / handleAgentCompleted).
+ *     [session:turns]         session.turn.started / session.turn.completed
+ *                             handlers. A `turn.completed` line with no following
+ *                             `[session:state] newState=WAITING_FOR_INPUT` is the
+ *                             smoking gun: the turn ended but running-state stuck.
+ *
  *   Other
  *     [ws:connection]         WS hook mount + status transitions
  *     [dockview:*]            layout restore / save / env-switch / session-tabs / task-select
@@ -188,10 +217,67 @@ function flattenArgs(args: unknown[]): string {
   return parts.join(" ");
 }
 
+export type SessionTaskResolver = (sessionId: string) => string | undefined;
+
+let sessionTaskResolver: SessionTaskResolver | null = null;
+
+/**
+ * Register a function that maps a session ID to its owning task ID.
+ *
+ * Most debug call sites only have a `sessionId` in scope, but when triaging a
+ * problem you usually think in terms of a *task*. Once a resolver is registered,
+ * every `debug(...)` call that carries a `sessionId` / `session_id` field is
+ * automatically annotated with a trailing `task_id=<...>` — so a devtools
+ * console filter (or a grep over an exported log) can scope to a single task
+ * without every call site having to thread the task ID through.
+ *
+ * The frontend store is created per-`StateProvider` (there is no module-level
+ * singleton), so the provider wires this up on mount and tears it down on
+ * unmount — see `components/state-provider.tsx`. Pass `null` to clear it.
+ * Calls are no-ops in production because `createDebugLogger` returns `NOOP`.
+ */
+export function registerSessionTaskResolver(resolver: SessionTaskResolver | null): void {
+  sessionTaskResolver = resolver;
+}
+
+const SESSION_ID_KEYS = ["sessionId", "session_id"];
+const TASK_ID_KEYS = ["taskId", "task_id"];
+
+function readStringKey(args: unknown[], keys: string[]): string | undefined {
+  for (const arg of args) {
+    if (!isPlainObject(arg)) continue;
+    for (const key of keys) {
+      const val = arg[key];
+      if (typeof val === "string" && val.length > 0) return val;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the trailing ` task_id=<...>` annotation for a log line from the
+ * `sessionId` it already carries. Returns "" (no annotation) when there is no
+ * resolver, the line already names a task, no session is present, or the
+ * session can't be mapped. Never throws — a faulty resolver must not break a
+ * debug log.
+ */
+function resolveTaskAnnotation(args: unknown[]): string {
+  if (!sessionTaskResolver) return "";
+  if (readStringKey(args, TASK_ID_KEYS)) return ""; // already filterable by task
+  const sid = readStringKey(args, SESSION_ID_KEYS);
+  if (!sid) return "";
+  try {
+    const taskId = sessionTaskResolver(sid);
+    return taskId ? ` task_id=${formatValue(taskId)}` : "";
+  } catch {
+    return "";
+  }
+}
+
 export function createDebugLogger(namespace: string): DebugLogger {
   if (!IS_DEBUG) return NOOP;
   const prefix = `[${namespace}]`;
   return (...args: unknown[]) => {
-    console.debug(`${prefix} ${flattenArgs(args)}`);
+    console.debug(`${prefix} ${flattenArgs(args)}${resolveTaskAnnotation(args)}`);
   };
 }

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -220,9 +220,11 @@ function flattenArgs(args: unknown[]): string {
 export type SessionTaskResolver = (sessionId: string) => string | undefined;
 
 let sessionTaskResolver: SessionTaskResolver | null = null;
+let sessionTaskResolverToken = 0;
 
 /**
- * Register a function that maps a session ID to its owning task ID.
+ * Register a function that maps a session ID to its owning task ID, and return
+ * an unregister callback.
  *
  * Most debug call sites only have a `sessionId` in scope, but when triaging a
  * problem you usually think in terms of a *task*. Once a resolver is registered,
@@ -231,13 +233,22 @@ let sessionTaskResolver: SessionTaskResolver | null = null;
  * console filter (or a grep over an exported log) can scope to a single task
  * without every call site having to thread the task ID through.
  *
- * The frontend store is created per-`StateProvider` (there is no module-level
- * singleton), so the provider wires this up on mount and tears it down on
- * unmount — see `components/state-provider.tsx`. Pass `null` to clear it.
- * Calls are no-ops in production because `createDebugLogger` returns `NOOP`.
+ * The frontend store is created per-`StateProvider` (it is not a module-level
+ * singleton), so the provider wires this up on mount and calls the returned
+ * unregister on unmount — see `components/state-provider.tsx`. The resolver
+ * itself *is* a single module-level global, so the unregister callback only
+ * clears it when this registration is still the active one: during HMR or a
+ * provider swap the new provider mounts (and registers) before the old one's
+ * cleanup runs, and an unconditional null-clear would silently kill annotation
+ * until a full reload. Calls are no-ops in production because
+ * `createDebugLogger` returns `NOOP`.
  */
-export function registerSessionTaskResolver(resolver: SessionTaskResolver | null): void {
+export function registerSessionTaskResolver(resolver: SessionTaskResolver | null): () => void {
+  const token = ++sessionTaskResolverToken;
   sessionTaskResolver = resolver;
+  return () => {
+    if (sessionTaskResolverToken === token) sessionTaskResolver = null;
+  };
 }
 
 const SESSION_ID_KEYS = ["sessionId", "session_id"];

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -343,6 +343,11 @@ export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandle
 
       debug("state_changed", {
         sessionId,
+        // Logged before upsertTaskSessionList below, so on the first event for a
+        // session the store has no row yet and the auto-resolver can't map it —
+        // exactly the oldState="-" anchor line. taskId is already in scope, so
+        // pass it directly (rendered as task_id=, matching the auto-annotation).
+        task_id: taskId,
         oldState: existingSession?.state ?? "-",
         newState: newState ?? "-",
       });

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -1,4 +1,5 @@
 import type { StoreApi } from "zustand";
+import { createDebugLogger } from "@/lib/debug/log";
 import type { AppState } from "@/lib/state/store";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
 import {
@@ -9,6 +10,8 @@ import {
   type TaskSessionState,
 } from "@/lib/types/http";
 import type { QueuedMessage } from "@/lib/state/slices/session/types";
+
+const debug = createDebugLogger("session:state");
 
 const TERMINAL_SESSION_STATES: ReadonlySet<TaskSessionState> = new Set([
   "COMPLETED",
@@ -337,6 +340,12 @@ export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandle
 
       const sessionUpdate = buildSessionUpdate(payload);
       const existingSession = store.getState().taskSessions.items[sessionId];
+
+      debug("state_changed", {
+        sessionId,
+        oldState: existingSession?.state ?? "-",
+        newState: newState ?? "-",
+      });
 
       upsertTaskSessionList(store, taskId, sessionId, payload, sessionUpdate);
       extractContextWindow(store, sessionId, payload);

--- a/apps/web/lib/ws/handlers/turns.ts
+++ b/apps/web/lib/ws/handlers/turns.ts
@@ -15,7 +15,7 @@ export function registerTurnsHandlers(store: StoreApi<AppState>): WsHandlers {
       }
       debug("turn.started", {
         sessionId: payload.session_id,
-        task_id: payload.task_id,
+        task_id: payload.task_id ?? "-",
         turnId: payload.id,
       });
       store.getState().addTurn({
@@ -38,7 +38,7 @@ export function registerTurnsHandlers(store: StoreApi<AppState>): WsHandlers {
       }
       debug("turn.completed", {
         sessionId: payload.session_id,
-        task_id: payload.task_id,
+        task_id: payload.task_id ?? "-",
         turnId: payload.id,
         completedAt: payload.completed_at ?? "-",
       });

--- a/apps/web/lib/ws/handlers/turns.ts
+++ b/apps/web/lib/ws/handlers/turns.ts
@@ -1,7 +1,10 @@
 import type { StoreApi } from "zustand";
+import { createDebugLogger } from "@/lib/debug/log";
 import type { AppState } from "@/lib/state/store";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
 import { sessionId, taskId } from "@/lib/types/http";
+
+const debug = createDebugLogger("session:turns");
 
 export function registerTurnsHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
@@ -10,6 +13,7 @@ export function registerTurnsHandlers(store: StoreApi<AppState>): WsHandlers {
       if (!payload.session_id) {
         return;
       }
+      debug("turn.started", { sessionId: payload.session_id, turnId: payload.id });
       store.getState().addTurn({
         id: payload.id,
         session_id: sessionId(payload.session_id),
@@ -28,6 +32,11 @@ export function registerTurnsHandlers(store: StoreApi<AppState>): WsHandlers {
       if (!payload.session_id || !payload.id) {
         return;
       }
+      debug("turn.completed", {
+        sessionId: payload.session_id,
+        turnId: payload.id,
+        completedAt: payload.completed_at ?? "-",
+      });
       store
         .getState()
         .completeTurn(

--- a/apps/web/lib/ws/handlers/turns.ts
+++ b/apps/web/lib/ws/handlers/turns.ts
@@ -13,7 +13,11 @@ export function registerTurnsHandlers(store: StoreApi<AppState>): WsHandlers {
       if (!payload.session_id) {
         return;
       }
-      debug("turn.started", { sessionId: payload.session_id, turnId: payload.id });
+      debug("turn.started", {
+        sessionId: payload.session_id,
+        task_id: payload.task_id,
+        turnId: payload.id,
+      });
       store.getState().addTurn({
         id: payload.id,
         session_id: sessionId(payload.session_id),
@@ -34,6 +38,7 @@ export function registerTurnsHandlers(store: StoreApi<AppState>): WsHandlers {
       }
       debug("turn.completed", {
         sessionId: payload.session_id,
+        task_id: payload.task_id,
         turnId: payload.id,
         completedAt: payload.completed_at ?? "-",
       });


### PR DESCRIPTION
Debug logs keyed only on `sessionId`, so they couldn't be filtered by task — painful when chasing the "ACP turn completes but chat still shows the agent running" bug across the frontend/backend boundary. Now every session-aware debug line is filterable by `task_id`, and both sides emit aligned state-transition traces under the same task ID.

## Important Changes

- `createDebugLogger` auto-appends `task_id=<...>` to any line carrying a `sessionId`, resolved via a session→task resolver that `StateProvider` registers in debug builds. No call site has to thread the task ID through.
- New frontend WS-handler loggers: `[session:state]` (`session.state_changed`) and `[session:turns]` (`turn.started`/`turn.completed`).
- New backend Debug logs at the two turn-complete decision points: the streaming complete-event running→waiting branch (defer-to-READY vs clear) and the agent-exit path (`workflow_transitioned`). Backend already logs `task_id` via zap, so console and backend lines line up.
- All instrumentation is no-op in prod (frontend) / Debug-level (backend); surfaces under `make start-debug`.

## Validation

- Backend (`internal/orchestrator`): `go build`, `go vet`, `golangci-lint` (0 issues), `go test` — 551 pass incl. new `TestSessionStateString`.
- Frontend: `tsc --noEmit` clean; `vitest` — 99 pass across `lib/debug/log.test.ts` (7 new resolver tests) + `lib/ws/handlers/`.
- Rebased onto latest `main`; re-built and re-tested the orchestrator package after rebase.

## Possible Improvements

Low risk — observability-only, no behavior change. The frontend resolver reads the store per debug call, but only in debug builds where `createDebugLogger` is active.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.