### PR TITLE
fix: dockview/editor restore races, office rebroadcast, and flaky tests

### DIFF
--- a/apps/backend/internal/gateway/websocket/office_notifications.go
+++ b/apps/backend/internal/gateway/websocket/office_notifications.go
@@ -34,7 +34,14 @@ func RegisterOfficeNotifications(ctx context.Context, eventBus bus.EventBus, hub
 	// Task lifecycle events
 	b.subscribe(eventBus, events.TaskUpdated, ws.ActionOfficeTaskUpdated)
 	b.subscribe(eventBus, events.TaskCreated, ws.ActionOfficeTaskCreated)
-	b.subscribe(eventBus, events.TaskMoved, ws.ActionOfficeTaskMoved)
+	// task.moved → office.task.moved is a WORKSPACE-scoped notification (clients
+	// filter by workspace_id). The underlying task.moved event carries a
+	// session_id for the orchestrator's on_exit/on_enter wiring, but no office
+	// consumer reads it. Forwarding it verbatim makes the FE WS-account stamp
+	// the envelope as session-routed, so the bridge audit then expects a
+	// per-session cache mutation that an office handler legitimately never makes
+	// on a non-office page. Drop the session-scoped fields from the re-broadcast.
+	b.subscribeWithout(eventBus, events.TaskMoved, ws.ActionOfficeTaskMoved, "session_id")
 	b.subscribe(eventBus, events.OfficeTaskStatusChanged, ws.ActionOfficeTaskStatus)
 	b.subscribe(eventBus, events.OfficeTaskUpdated, ws.ActionOfficeTaskUpdated)
 	b.subscribe(eventBus, events.OfficeTaskDecisionRecorded, ws.ActionOfficeTaskDecision)
@@ -83,8 +90,39 @@ func (b *OfficeEventBroadcaster) Close() {
 }
 
 func (b *OfficeEventBroadcaster) subscribe(eventBus bus.EventBus, subject, action string) {
+	b.subscribeWithout(eventBus, subject, action)
+}
+
+// stripPayloadKeys returns the event payload with the named keys removed. When
+// no keys are requested (or the payload isn't a map) the original value is
+// returned unchanged. Always clones before deleting so the source event payload
+// — shared with every other subscriber — is never mutated.
+func stripPayloadKeys(data interface{}, dropKeys []string) interface{} {
+	if len(dropKeys) == 0 {
+		return data
+	}
+	m, ok := data.(map[string]interface{})
+	if !ok {
+		return data
+	}
+	cp := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	for _, key := range dropKeys {
+		delete(cp, key)
+	}
+	return cp
+}
+
+// subscribeWithout is like subscribe but strips the named payload keys from the
+// re-broadcast notification. Office notifications are workspace-scoped (clients
+// filter by workspace_id); session-scoped fields leaked from the source event
+// would otherwise mis-classify the envelope as session-routed for accounting.
+func (b *OfficeEventBroadcaster) subscribeWithout(eventBus bus.EventBus, subject, action string, dropKeys ...string) {
 	sub, err := eventBus.Subscribe(subject, func(_ context.Context, event *bus.Event) error {
-		msg, err := ws.NewNotification(action, event.Data)
+		data := stripPayloadKeys(event.Data, dropKeys)
+		msg, err := ws.NewNotification(action, data)
 		if err != nil {
 			b.logger.Error("failed to build office ws notification",
 				zap.String("action", action), zap.Error(err))

--- a/apps/backend/internal/gateway/websocket/office_notifications_test.go
+++ b/apps/backend/internal/gateway/websocket/office_notifications_test.go
@@ -81,6 +81,48 @@ func TestOfficeEventBroadcaster_BroadcastsEvent(t *testing.T) {
 	}
 }
 
+// TestStripPayloadKeys verifies the office re-broadcast payload transform:
+// office.task.moved is workspace-scoped, so the session-scoped session_id it
+// inherits from the source task.moved event must be dropped (otherwise the FE
+// WS-account stamps the envelope session-routed and the bridge audit then
+// expects a per-session cache mutation that no office handler makes on a
+// non-office page). workspace_id and the rest must survive, and the source
+// payload (shared with other subscribers) must not be mutated.
+func TestStripPayloadKeys(t *testing.T) {
+	source := map[string]interface{}{
+		"workspace_id": "ws-1",
+		"task_id":      "t-1",
+		"session_id":   "sess-1",
+		"to_step_id":   "step-2",
+	}
+
+	out := stripPayloadKeys(source, []string{"session_id"})
+	m, ok := out.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map output, got %T", out)
+	}
+	if _, present := m["session_id"]; present {
+		t.Error("session_id must be stripped from the office.task.moved payload")
+	}
+	if m["workspace_id"] != "ws-1" || m["task_id"] != "t-1" || m["to_step_id"] != "step-2" {
+		t.Errorf("non-dropped fields must be preserved, got %#v", m)
+	}
+	// Source must be untouched — every other subscriber shares this map.
+	if source["session_id"] != "sess-1" {
+		t.Error("source payload must not be mutated")
+	}
+}
+
+func TestStripPayloadKeys_NoKeysOrNonMap(t *testing.T) {
+	source := map[string]interface{}{"a": 1}
+	if got := stripPayloadKeys(source, nil); got == nil {
+		t.Fatal("nil dropKeys should return the payload unchanged")
+	}
+	if got := stripPayloadKeys("not-a-map", []string{"x"}); got != "not-a-map" {
+		t.Errorf("non-map payload should pass through, got %v", got)
+	}
+}
+
 // TestOfficeEventBroadcaster_NilEventBus verifies no panic when event bus is nil.
 func TestOfficeEventBroadcaster_NilEventBus(t *testing.T) {
 	log := testLogger()

--- a/apps/backend/internal/office/costs/modelsdev/client_test.go
+++ b/apps/backend/internal/office/costs/modelsdev/client_test.go
@@ -136,7 +136,28 @@ func TestClient_NormalizesCodexAndOpencodeForms(t *testing.T) {
 func TestClient_FirstBootMissesGracefully(t *testing.T) {
 	dir := t.TempDir()
 	cachePath := filepath.Join(dir, "models-dev.json")
-	c, _ := newTestClient(t, cachePath)
+
+	// A cold-boot lookup schedules a background refresh against the
+	// configured URL. Block that refresh at the server so it can't
+	// populate the cache before the lookup reads it — otherwise the
+	// "miss" we're asserting races a fast background fetch and flakes
+	// into a hit. The handler unblocks at cleanup so nothing leaks.
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		_, _ = w.Write([]byte(sampleDataset))
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+	c := modelsdev.New(modelsdev.Config{
+		CachePath:  cachePath,
+		URL:        srv.URL,
+		TTL:        time.Hour,
+		HTTPClient: srv.Client(),
+	}, logger.Default())
+
 	// No Refresh — simulating cold boot before any HTTP fetch.
 	if _, ok := c.LookupForModel(context.Background(), "claude-opus-4-7"); ok {
 		t.Error("expected miss on cold-boot lookup")

--- a/apps/web/components/task/dockview-shared.tsx
+++ b/apps/web/components/task/dockview-shared.tsx
@@ -35,7 +35,8 @@ import { VscodePanel } from "./vscode-panel";
 import { CommitDetailPanel } from "./commit-detail-panel";
 import { PRDetailPanelComponent } from "@/components/github/pr-detail-panel";
 
-import { setPanelTitle } from "@/lib/layout/panel-portal-manager";
+import { setPanelTitle, panelPortalManager } from "@/lib/layout/panel-portal-manager";
+import { getWebSocketClient } from "@/lib/ws/connection";
 import { usePortalSlot } from "@/lib/layout/panel-portal-host";
 import { ENV_SCOPED_DOCKVIEW_COMPONENTS } from "@/lib/state/dockview-env-scoped-components";
 
@@ -217,6 +218,45 @@ function ChatContent({ panelId, params }: { panelId: string; params: Record<stri
   );
 }
 
+/**
+ * Force a fresh git-status push whenever the diff panel becomes the active
+ * dockview tab.
+ *
+ * Background: the diff panel's content is derived from `gitStatus` (the
+ * per-file `.diff` string), which only refreshes when a `session.git.event`
+ * status_update arrives from agentctl's workspace poll loop. That loop runs at
+ * 3s (fast) only while the workspace is in fast poll mode; if the focus→fast
+ * upgrade lost a race with agentctl startup the loop can sit in slow mode (30s)
+ * and the open diff shows stale content until the next slow tick.
+ *
+ * This is the diff-side analog of `useResyncOnTabActivate` in
+ * file-editor-panel.tsx (which force-syncs editor content on activation). Tab
+ * activation is a deterministic, user-driven "I'm about to look at this diff"
+ * signal, so we ask the backend for a fresh git-status snapshot via
+ * `refreshSessionData` (re-sends `session.focus`, whose handler pushes a fresh
+ * `GetGitStatusMultiFresh` result) — closing the WS-event-miss gap without
+ * depending on poll cadence. No-op when the session isn't focused.
+ */
+function useResyncGitStatusOnTabActivate(panelId: string, sessionId: string | null) {
+  useEffect(() => {
+    if (!sessionId) return;
+    const entry = panelPortalManager.get(panelId);
+    if (!entry?.api) return;
+    const refreshNow = () => {
+      const client = getWebSocketClient();
+      client?.refreshSessionData(sessionId);
+    };
+    // If the panel is already active when this effect first runs,
+    // onDidActiveChange won't fire (no transition) — refresh immediately so the
+    // initial open benefits from the same WS-event-miss recovery.
+    if (entry.api.isActive) refreshNow();
+    const disposable = entry.api.onDidActiveChange((event) => {
+      if (event.isActive) refreshNow();
+    });
+    return () => disposable.dispose();
+  }, [panelId, sessionId]);
+}
+
 function DiffViewerContent({
   panelId,
   params,
@@ -227,9 +267,11 @@ function DiffViewerContent({
   const selectedDiff = useDockviewStore((s) => s.selectedDiff);
   const setSelectedDiff = useDockviewStore((s) => s.setSelectedDiff);
   const { openFile } = useFileEditors();
+  const activeSessionId = useAppStore((state) => state.tasks.activeSessionId);
   const panelKind = (params?.kind as string) ?? "all";
   const selectedPath = panelKind === "file" ? (params?.path as string) : undefined;
   const panelSelectedDiff = panelKind === "all" ? selectedDiff : null;
+  useResyncGitStatusOnTabActivate(panelId, activeSessionId);
   const handleClosePanel = useCallback(() => {
     const dockApi = useDockviewStore.getState().api;
     const panel = dockApi?.getPanel(panelId);

--- a/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-branch-selector.spec.ts
@@ -610,20 +610,25 @@ test.describe("Branch refresh + filter", () => {
     // fires and `waitForRequest` hangs the full test timeout.
     await expect(testPage.getByRole("option").first()).toBeVisible({ timeout: 10_000 });
 
-    // Set the listener up before the click — Promise.all guarantees ordering
-    // and the explicit timeout makes a missed request fail fast instead of
-    // hanging until the test-level 60s cap. No assertion needed: a missed
-    // request throws from inside Promise.all.
-    await Promise.all([
-      testPage.waitForRequest(
+    // Retry the click until the ?refresh=true request actually fires. Even
+    // with the button enabled and an option visible, there's a brief
+    // hydration window (documented above) where a click is swallowed before
+    // the refresh handler is wired — so a single click can never produce the
+    // request and the listener hangs the full test timeout. `toPass` re-runs
+    // the whole block: a swallowed click just clicks again next attempt, and
+    // once the handler is wired the request fires and the block passes. The
+    // refresh is idempotent, so an extra click is harmless.
+    await expect(async () => {
+      const requestPromise = testPage.waitForRequest(
         (req) =>
           req.url().includes(`/repositories/${seedData.repositoryId}/branches`) &&
           req.url().includes("refresh=true") &&
           req.method() === "GET",
-        { timeout: 15_000 },
-      ),
-      refreshButton.click(),
-    ]);
+        { timeout: 4_000 },
+      );
+      await refreshButton.click();
+      await requestPromise;
+    }).toPass({ timeout: 30_000 });
   });
 
   test("branch filter ranks exact match above substring matches", async ({

--- a/apps/web/hooks/use-file-editors.ts
+++ b/apps/web/hooks/use-file-editors.ts
@@ -140,6 +140,22 @@ async function loadAndRestoreTabs(params: RestoreTabsParams, retryCount = 0): Pr
       quiet: true,
       pin: savedTab.pinned,
     });
+    // Seed a placeholder file state synchronously, carrying the restored
+    // `markdownPreview` flag. This makes `openFiles.has(path)` true the moment
+    // FileEditorPanel mounts, which suppresses its own `useFileLoader` fetch.
+    // Without this seed, useFileLoader races the per-tab fetch below: both call
+    // setFileState (a wholesale replace), and useFileLoader's state has no
+    // markdownPreview — so when it wins the race (common under CPU load) the
+    // restored preview flag is clobbered and the tab reopens in code view.
+    setFileState(savedTab.path, {
+      path: savedTab.path,
+      name: savedTab.name,
+      content: "",
+      originalContent: "",
+      originalHash: "",
+      isDirty: false,
+      markdownPreview: savedTab.markdownPreview,
+    });
   }
   for (const savedTab of savedTabs) {
     try {

--- a/apps/web/lib/ws/client.ts
+++ b/apps/web/lib/ws/client.ts
@@ -210,6 +210,34 @@ export class WebSocketClient {
     return () => this.unfocusSession(sessionId);
   }
 
+  /**
+   * Re-send a `session.focus` frame for an already-focused session WITHOUT
+   * touching the focus ref-count. The backend's focus handler pushes a fresh
+   * live git-status snapshot as a side effect (see `handleSessionFocus` →
+   * `sendSessionData` → `appendLiveGitStatusMessage`, which forces a
+   * `GetGitStatusMultiFresh` query that bypasses the workspace poll cache).
+   *
+   * This is the deterministic recovery for the focus-gated polling race: the
+   * agent edits a file, but if the workspace is still in slow poll mode (the
+   * focus→fast push lost a race with agentctl startup) the next
+   * `session.git.event` may be up to 30s away. Components that become visible
+   * and need fresh diff data (the diff panel becoming the active tab) call
+   * this to pull the latest git status immediately.
+   *
+   * No-op when the session isn't currently focused (the regular focus frame,
+   * sent on 0→1, already pushed fresh data).
+   */
+  refreshSessionData(sessionId: string) {
+    if (this.status !== "connected") return;
+    if (!this.sessionFocusCounts.get(sessionId)) return;
+    this.send({
+      id: generateUUID(),
+      type: "request",
+      action: "session.focus",
+      payload: { session_id: sessionId },
+    });
+  }
+
   unfocusSession(sessionId: string) {
     const currentCount = this.sessionFocusCounts.get(sessionId);
     if (!currentCount) return;


### PR DESCRIPTION
Five independent fixes extracted from PR #1130 so they can land on `main` sooner. They touch disjoint files and were each verified on the source branch.

**Reliability (user-facing)**
- Preserve the markdown-preview flag on file-tab restore — it was being lost to a race with `useFileLoader`.
- Resync git status on diff-panel tab activation — a focus→fast-poll race left the diff stale; adds `client.refreshSessionData()`.

**Backend correctness**
- Strip `session_id` from the `office.task.moved` rebroadcast — a workspace-level event should not be session-tagged.

**Test stability**
- Deflake the models.dev cold-boot cache test (background-refresh race).
- Retry the e2e branch-selector refresh click until the request actually fires.

## Validation

- `go build ./...` — passes.
- `go test ./internal/gateway/websocket/... ./internal/office/costs/modelsdev/...` — passes (modelsdev cold-boot also clean under `-race -count=20`).
- `pnpm --filter @kandev/web typecheck` — passes.
- `pnpm --filter @kandev/web lint` — passes (`--max-warnings 0`).
- Frontend unit tests — all green.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.