### PR TITLE
feat(backend): per-session ACP debug logs with rotation and retention

### DIFF
--- a/apps/backend/cmd/agentctl/main.go
+++ b/apps/backend/cmd/agentctl/main.go
@@ -89,6 +89,12 @@ func main() {
 // run starts the agentctl server.
 // All instances are managed through the instance management API.
 func run(cfg *config.Config, log *logger.Logger) {
+	// Start the ACP debug-log janitor (no-op unless KANDEV_DEBUG_AGENT_MESSAGES
+	// is set). It periodically flushes the per-session debug writers and prunes
+	// old/oversized files so an always-on debug session can't fill the disk.
+	acpJanitor := shared.NewACPJanitor()
+	acpJanitor.Start(context.Background())
+
 	// Create instance manager
 	instMgr := instance.NewManager(cfg, log)
 
@@ -143,10 +149,13 @@ func run(cfg *config.Config, log *logger.Logger) {
 		if err := shared.ShutdownTracing(ctx); err != nil {
 			log.Error("error shutting down tracing", zap.Error(err))
 		}
-		// Shutdown all instances
+		// Shutdown all instances first so any final ACP frames they emit during
+		// teardown are still captured by the (still-live) debug writers.
 		if err := instMgr.Shutdown(ctx); err != nil {
 			log.Error("error shutting down instance manager", zap.Error(err))
 		}
+		// Then flush + close all debug-log writers as the final logging step.
+		acpJanitor.Stop()
 		if err := httpServer.Shutdown(ctx); err != nil {
 			log.Error("error shutting down HTTP server", zap.Error(err))
 		}

--- a/apps/backend/internal/agent/runtime/lifecycle/streams.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/streams.go
@@ -38,6 +38,27 @@ type StreamManager struct {
 	stopCh <-chan struct{}
 }
 
+type stopChannelContext struct {
+	context.Context
+	stopCh <-chan struct{}
+}
+
+func (c stopChannelContext) Done() <-chan struct{} {
+	if c.stopCh == nil {
+		return c.Context.Done()
+	}
+	return c.stopCh
+}
+
+func (c stopChannelContext) Err() error {
+	select {
+	case <-c.stopCh:
+		return context.Canceled
+	default:
+		return c.Context.Err()
+	}
+}
+
 // NewStreamManager creates a new StreamManager.
 //
 // stopCh is the Manager-owned shutdown signal used by the workspace-stream
@@ -112,9 +133,19 @@ func (sm *StreamManager) sleepOrStop(d time.Duration) bool {
 	}
 }
 
+// streamContext preserves the execution's session trace values while making
+// in-flight WebSocket dials cancellable by the manager shutdown signal.
+func (sm *StreamManager) streamContext(execution *AgentExecution) context.Context {
+	ctx := execution.SessionTraceContext()
+	if sm.stopCh == nil {
+		return ctx
+	}
+	return stopChannelContext{Context: ctx, stopCh: sm.stopCh}
+}
+
 // connectUpdatesStream handles the updates WebSocket stream with ready signaling
 func (sm *StreamManager) connectUpdatesStream(execution *AgentExecution, ready chan<- struct{}) {
-	ctx := execution.SessionTraceContext()
+	ctx := sm.streamContext(execution)
 
 	err := execution.agentctl.StreamUpdates(ctx, func(event agentctl.AgentEvent) {
 		if sm.callbacks.OnAgentEvent != nil {
@@ -215,7 +246,7 @@ func (sm *StreamManager) buildWorkspaceCallbacks(execution *AgentExecution) agen
 
 // connectWorkspaceStream handles the unified workspace stream with retry logic
 func (sm *StreamManager) connectWorkspaceStream(execution *AgentExecution, ready chan<- struct{}) {
-	ctx := execution.SessionTraceContext()
+	ctx := sm.streamContext(execution)
 
 	// Retry connection with exponential backoff
 	maxRetries := 5

--- a/apps/backend/internal/agent/runtime/lifecycle/streams_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/streams_test.go
@@ -1,6 +1,7 @@
 package lifecycle
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -82,6 +83,23 @@ func TestConnectWorkspaceStream_BackoffDrainsOnStop(t *testing.T) {
 	case <-done:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("connectWorkspaceStream did not drain on stopCh close — backoff is leaking")
+	}
+}
+
+func TestStreamContextCancelsOnStop(t *testing.T) {
+	stopCh := make(chan struct{})
+	sm := NewStreamManager(newTestLogger(), StreamCallbacks{}, nil, stopCh)
+
+	ctx := sm.streamContext(&AgentExecution{ID: "exec-context"})
+	close(stopCh)
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stream context did not observe stopCh close")
+	}
+	if err := ctx.Err(); err != context.Canceled {
+		t.Fatalf("ctx.Err() = %v, want context.Canceled", err)
 	}
 }
 

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -39,6 +39,20 @@ Protocol adapters in `server/adapter/transport/` normalize different agent CLIs:
 
 JSON-RPC 2.0 over stdin/stdout between agentctl and agent process. Requests: `initialize`, `session/new`, `session/load`, `session/prompt`, `session/cancel`. Notifications: `session/update` with types `message_chunk`, `tool_call`, `tool_update`, `complete`, `error`, `permission_request`, `context_window`.
 
+### ACP frame debug logging (`adapter/transport/shared/acplog.go`)
+
+When `KANDEV_DEBUG_AGENT_MESSAGES=true` (on by default in the **dev** profile), the ACP adapter dumps every raw + normalized frame to **per-session** JSONL files:
+
+- Files: `raw-{protocol}-{agentID}-{sessionID}.jsonl` and `normalized-{protocol}-{agentID}-{sessionID}.jsonl` (the `raw-`/`normalized-` prefix + `.jsonl` suffix is a contract with the reader in `internal/debug`).
+- Default dir: `~/.kandev/logs/acp/` (override with `KANDEV_DEBUG_LOG_DIR`).
+- One kept-open buffered writer + dedicated mutex per session (no global lock on the hot path); rotates on a per-file byte cap.
+- A `shared.Janitor` (owned by `cmd/agentctl/main.go run()`, `Start`/`Stop`) flushes periodically and prunes oldest-by-mtime first, enforcing a total-file cap and an age cap so an always-on dev session can't fill the disk. It also closes idle writers so handles don't leak.
+- Dev-only live tail of a stuck session from an in-memory ring buffer (zero disk growth): `GET /api/v1/debug/acp/{session}?n=200`.
+
+Env knobs (all optional): `KANDEV_DEBUG_ACP_MAX_FILES` (default 200), `KANDEV_DEBUG_ACP_RETENTION_HOURS` (default 48), `KANDEV_DEBUG_ACP_MAX_FILE_BYTES` (default 8 MiB).
+
+**PRIVACY / PERF:** frames carry the full prompt, file, and tool-call content. Keep this strictly behind the debug flag and local-dev-scoped — never enable in a shared/production deployment. When agentctl runs inside a Docker executor the files land *inside the container*, so this is meant for standalone/dev.
+
 ## Further scoped notes
 
 - `server/api/AGENTS.md` — reverse-proxy body rewriting (`Accept-Encoding`) and iframe-blocking header stripping.

--- a/apps/backend/internal/agentctl/server/adapter/e2e/harness.go
+++ b/apps/backend/internal/agentctl/server/adapter/e2e/harness.go
@@ -10,7 +10,9 @@
 //
 // Tests skip gracefully when an agent binary is not installed on PATH.
 //
-// Debug logging (set externally — read at package init time):
+// Debug logging (set externally — read at package init time). Frames are
+// written to per-session files raw-/normalized-{protocol}-{agentID}-{sessionID}.jsonl
+// under KANDEV_DEBUG_LOG_DIR (default ~/.kandev/logs/acp):
 //
 //	KANDEV_DEBUG_AGENT_MESSAGES=true KANDEV_DEBUG_LOG_DIR=/tmp/e2e-debug ...
 //

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_updates.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_updates.go
@@ -17,7 +17,7 @@ func (a *Adapter) handleACPUpdate(n acp.SessionNotification) {
 
 	// Log raw event for debugging
 	if len(rawData) > 0 {
-		shared.LogRawEvent(shared.ProtocolACP, a.agentID, "session_notification", rawData)
+		shared.LogRawEvent(shared.ProtocolACP, a.agentID, string(n.SessionId), "session_notification", rawData)
 	}
 
 	// During session/load, suppress history replay notifications.
@@ -65,7 +65,7 @@ func (a *Adapter) handleACPUpdate(n acp.SessionNotification) {
 		event = a.tryConvertUntypedUpdate(rawData, sessionID)
 	}
 	if event != nil {
-		shared.LogNormalizedEvent(shared.ProtocolACP, a.agentID, event)
+		shared.LogNormalizedEvent(shared.ProtocolACP, a.agentID, sessionID, event)
 		shared.TraceProtocolEvent(a.getPromptTraceCtx(), shared.ProtocolACP, a.agentID,
 			event.Type, rawData, event)
 		a.sendUpdate(*event)

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor.go
@@ -19,6 +19,7 @@ type Janitor struct {
 
 	mu      sync.Mutex
 	started bool
+	gen     uint64
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 }
@@ -57,6 +58,7 @@ func (j *Janitor) Start(ctx context.Context) {
 		return
 	}
 	j.started = true
+	j.gen++
 	loopCtx, cancel := context.WithCancel(ctx)
 	j.cancel = cancel
 	// Add to the WaitGroup while still holding j.mu so a concurrent Stop()
@@ -66,6 +68,8 @@ func (j *Janitor) Start(ctx context.Context) {
 	j.mu.Unlock()
 
 	// Initial pass on startup so a previous run's files are pruned promptly.
+	// Stop() may wait for this scan to finish before the goroutine starts and
+	// observes cancellation; the bounded dev-log directory keeps that brief.
 	j.mgr.prune(time.Now())
 
 	go j.loop(loopCtx)
@@ -103,9 +107,8 @@ func (j *Janitor) Stop() {
 		j.mu.Unlock()
 		return
 	}
-	j.started = false
+	gen := j.gen
 	cancel := j.cancel
-	j.cancel = nil
 	j.mu.Unlock()
 
 	if cancel != nil {
@@ -113,4 +116,11 @@ func (j *Janitor) Stop() {
 	}
 	j.wg.Wait()
 	j.mgr.closeAll()
+
+	j.mu.Lock()
+	if j.gen == gen {
+		j.started = false
+		j.cancel = nil
+	}
+	j.mu.Unlock()
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor.go
@@ -1,0 +1,113 @@
+package shared
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Janitor periodic-flushes the managed ACP debug writers and prunes old debug
+// files so an always-on debug session can't grow disk without bound. It owns a
+// single background goroutine with explicit Start/Stop lifecycle per the
+// backend goroutine-ownership conventions (ctx cancel + wg.Wait, no
+// time.Sleep).
+type Janitor struct {
+	mgr         *acpLogManager
+	flushEvery  time.Duration
+	retainEvery time.Duration
+	idleTimeout time.Duration
+
+	mu      sync.Mutex
+	started bool
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+const (
+	defaultACPFlushEvery  = 2 * time.Second
+	defaultACPRetainEvery = 5 * time.Minute
+	defaultACPIdleTimeout = 10 * time.Minute
+)
+
+// NewACPJanitor returns a Janitor over the process-wide debug-log registry
+// with default intervals. It is a no-op to Start when debug mode is off.
+func NewACPJanitor() *Janitor {
+	return newJanitor(acpLog, defaultACPFlushEvery, defaultACPRetainEvery, defaultACPIdleTimeout)
+}
+
+func newJanitor(mgr *acpLogManager, flushEvery, retainEvery, idleTimeout time.Duration) *Janitor {
+	return &Janitor{
+		mgr:         mgr,
+		flushEvery:  flushEvery,
+		retainEvery: retainEvery,
+		idleTimeout: idleTimeout,
+	}
+}
+
+// Start runs an immediate retention pass and then spawns the background loop.
+// Idempotent; calling Start again while running is a no-op. When debug mode is
+// off it does nothing — there is no work to do.
+func (j *Janitor) Start(ctx context.Context) {
+	if !debugMode {
+		return
+	}
+	j.mu.Lock()
+	if j.started {
+		j.mu.Unlock()
+		return
+	}
+	j.started = true
+	loopCtx, cancel := context.WithCancel(ctx)
+	j.cancel = cancel
+	j.mu.Unlock()
+
+	// Initial pass on startup so a previous run's files are pruned promptly.
+	j.mgr.prune(time.Now())
+
+	j.wg.Add(1)
+	go j.loop(loopCtx)
+}
+
+func (j *Janitor) loop(ctx context.Context) {
+	defer j.wg.Done()
+	flush := time.NewTicker(j.flushEvery)
+	defer flush.Stop()
+	retain := time.NewTicker(j.retainEvery)
+	defer retain.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-flush.C:
+			j.mgr.flushAll()
+		case <-retain.C:
+			// Flush first so on-disk mtimes reflect recent buffered writes
+			// before prune evaluates file age, then close idle writers/rings
+			// and prune.
+			j.mgr.flushAll()
+			j.mgr.closeIdle(j.idleTimeout)
+			j.mgr.prune(time.Now())
+		}
+	}
+}
+
+// Stop cancels the loop, waits for it to drain, then flushes and closes all
+// open writers. Idempotent.
+func (j *Janitor) Stop() {
+	j.mu.Lock()
+	if !j.started {
+		j.mu.Unlock()
+		return
+	}
+	j.started = false
+	cancel := j.cancel
+	j.cancel = nil
+	j.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	j.wg.Wait()
+	j.mgr.closeAll()
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor.go
@@ -59,12 +59,15 @@ func (j *Janitor) Start(ctx context.Context) {
 	j.started = true
 	loopCtx, cancel := context.WithCancel(ctx)
 	j.cancel = cancel
+	// Add to the WaitGroup while still holding j.mu so a concurrent Stop()
+	// (which must take j.mu before it can Wait) can't reach wg.Wait() before
+	// this Add — that would be a WaitGroup misuse on a zero counter.
+	j.wg.Add(1)
 	j.mu.Unlock()
 
 	// Initial pass on startup so a previous run's files are pruned promptly.
 	j.mgr.prune(time.Now())
 
-	j.wg.Add(1)
 	go j.loop(loopCtx)
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor_test.go
@@ -158,4 +158,7 @@ func TestJanitor_StartStopIdempotent(t *testing.T) {
 	j.Start(context.Background()) // no-op
 	j.Stop()
 	j.Stop() // no-op
+
+	j.Start(context.Background())
+	j.Stop()
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acpjanitor_test.go
@@ -1,0 +1,161 @@
+package shared
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+// seedLogFiles writes the given debug-log files with mtimes staggered one
+// second apart (oldest first) so retention's mtime sort is deterministic.
+func seedLogFiles(t *testing.T, dir string, names []string) {
+	t.Helper()
+	for i, name := range names {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		mt := time.Now().Add(time.Duration(i) * time.Second)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatalf("chtimes %s: %v", name, err)
+		}
+	}
+}
+
+func countFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	return len(entries)
+}
+
+// TestACPPrune_KeepsNewestN mirrors the persistence.pruneBackups test: only the
+// newest N files survive, oldest-by-mtime deleted first.
+func TestACPPrune_KeepsNewestN(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFiles: 2, maxFileBytes: 1 << 20, ringSize: 4})
+
+	names := []string{
+		"normalized-acp-x-s1.jsonl", // oldest
+		"normalized-acp-x-s2.jsonl",
+		"raw-acp-x-s3.jsonl", // newest
+	}
+	seedLogFiles(t, dir, names)
+
+	m.prune(time.Now())
+
+	if got := countFiles(t, dir); got != 2 {
+		t.Fatalf("expected 2 files after prune, got %d", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, names[0])); !os.IsNotExist(err) {
+		t.Errorf("oldest file %q should have been pruned", names[0])
+	}
+}
+
+// TestACPPrune_AgeCap deletes files older than the retention window and leaves
+// non-log files untouched.
+func TestACPPrune_AgeCap(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFiles: 100, retention: time.Hour, maxFileBytes: 1 << 20, ringSize: 4})
+
+	fresh := filepath.Join(dir, "normalized-acp-x-fresh.jsonl")
+	stale := filepath.Join(dir, "normalized-acp-x-stale.jsonl")
+	other := filepath.Join(dir, "keepme.txt")
+	for _, p := range []string{fresh, stale, other} {
+		if err := os.WriteFile(p, []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	m.prune(time.Now())
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale file should have been pruned by age")
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("fresh file should survive: %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("non-log file should be left untouched: %v", err)
+	}
+}
+
+// TestACPPrune_SkipsActiveWriter verifies retention won't delete a file whose
+// session is still being written, even when buffering leaves the on-disk mtime
+// looking stale (the retain tick racing ahead of the flush tick).
+func TestACPPrune_SkipsActiveWriter(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFiles: 100, retention: time.Hour, maxFileBytes: 1 << 20, ringSize: 4})
+	defer m.closeAll()
+
+	// Buffered write: opens a live writer (fresh lastWrite); data isn't flushed.
+	m.writeNormalized(ProtocolACP, "acp", "sess", testEvent("sess"))
+	path := filepath.Join(dir, "normalized-acp-acp-sess.jsonl")
+	// Force a stale on-disk mtime to simulate the unflushed-but-recent case.
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	m.prune(time.Now())
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("active-writer file pruned despite recent buffered write: %v", err)
+	}
+}
+
+// TestJanitor_StartStop verifies the background loop's retention ticker fires
+// (pruning files seeded after Start) and that Stop drains the goroutine
+// cleanly — leak detection comes from goleak in TestMain. Uses synctest so the
+// tickers advance instantly without real sleeps.
+func TestJanitor_StartStop(t *testing.T) {
+	prev := debugMode
+	debugMode = true
+	defer func() { debugMode = prev }()
+
+	synctest.Test(t, func(t *testing.T) {
+		dir := t.TempDir()
+		m := newACPLogManager(acpLogConfig{dir: dir, maxFiles: 1, maxFileBytes: 1 << 20, ringSize: 4})
+		j := newJanitor(m, 5*time.Millisecond, 20*time.Millisecond, time.Minute)
+
+		j.Start(context.Background())
+		// Seed AFTER Start so only the background retain tick can prune them.
+		seedLogFiles(t, dir, []string{
+			"normalized-acp-x-a.jsonl",
+			"normalized-acp-x-b.jsonl",
+			"raw-acp-x-c.jsonl",
+		})
+		// Advance fake time well past several retain ticks.
+		time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+
+		if got := countFiles(t, dir); got != 1 {
+			t.Errorf("expected janitor to prune to 1 file, got %d", got)
+		}
+		j.Stop()
+	})
+}
+
+// TestJanitor_StartStopIdempotent ensures double Start/Stop is safe.
+func TestJanitor_StartStopIdempotent(t *testing.T) {
+	prev := debugMode
+	debugMode = true
+	defer func() { debugMode = prev }()
+
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFiles: 10, maxFileBytes: 1 << 20, ringSize: 4})
+	j := newJanitor(m, time.Hour, time.Hour, time.Hour)
+	j.Start(context.Background())
+	j.Start(context.Background()) // no-op
+	j.Stop()
+	j.Stop() // no-op
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog.go
@@ -1,0 +1,565 @@
+package shared
+
+import (
+	"bufio"
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+// PRIVACY / PERF: the JSONL frames written here contain the full prompt, file,
+// and tool-call content exchanged with the agent. They are strictly a
+// local-dev debugging aid gated behind KANDEV_DEBUG_AGENT_MESSAGES and must
+// never be enabled in a shared/production deployment. See the agentctl
+// CLAUDE.md "ACP Protocol" section for the documented env knobs.
+
+// Debug-log filename pieces. The "raw-"/"normalized-" prefix and ".jsonl"
+// suffix are a compatibility contract with the debug reader in
+// internal/debug (discoverNormalizedFiles + handleReadNormalizedEvents) —
+// do not change them without updating that package.
+const (
+	rawPrefix        = "raw-"
+	normalizedPrefix = "normalized-"
+	jsonlSuffix      = ".jsonl"
+)
+
+// Environment knobs (all optional; sensible defaults below).
+const (
+	envDebugMessages   = "KANDEV_DEBUG_AGENT_MESSAGES"
+	envLogDir          = "KANDEV_DEBUG_LOG_DIR"
+	envACPMaxFiles     = "KANDEV_DEBUG_ACP_MAX_FILES"
+	envACPRetentionHrs = "KANDEV_DEBUG_ACP_RETENTION_HOURS"
+	envACPMaxFileBytes = "KANDEV_DEBUG_ACP_MAX_FILE_BYTES"
+)
+
+const (
+	defaultACPMaxFiles     = 200
+	defaultACPRetentionHrs = 48
+	defaultACPMaxFileBytes = 8 << 20 // 8 MiB
+	defaultACPRingSize     = 500
+)
+
+// acpLogConfig is the resolved configuration for the managed writer registry.
+type acpLogConfig struct {
+	dir          string
+	maxFileBytes int64
+	maxFiles     int
+	retention    time.Duration
+	ringSize     int
+}
+
+// acpLogConfigFromEnv resolves the on-disk config from the environment,
+// applying defaults. The output directory resolves to KANDEV_DEBUG_LOG_DIR,
+// then ~/.kandev/logs/acp, then the process CWD as a last resort.
+func acpLogConfigFromEnv() acpLogConfig {
+	return acpLogConfig{
+		dir:          resolveACPLogDir(),
+		maxFileBytes: envInt64(envACPMaxFileBytes, defaultACPMaxFileBytes),
+		maxFiles:     int(envInt64(envACPMaxFiles, defaultACPMaxFiles)),
+		retention:    time.Duration(envInt64(envACPRetentionHrs, defaultACPRetentionHrs)) * time.Hour,
+		ringSize:     defaultACPRingSize,
+	}
+}
+
+func resolveACPLogDir() string {
+	if dir := os.Getenv(envLogDir); dir != "" {
+		return dir
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".kandev", "logs", "acp")
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return cwd
+	}
+	return "."
+}
+
+func envInt64(key string, def int64) int64 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// acpLogManager owns one kept-open buffered writer per session file plus a
+// bounded in-memory ring buffer per session. Writers carry their own mutex so
+// the streaming hot path never contends on a single global lock.
+type acpLogManager struct {
+	cfg     acpLogConfig
+	mu      sync.Mutex // guards writers + rings maps
+	writers map[string]*acpWriter
+	rings   map[string]*ringBuffer
+}
+
+func newACPLogManager(cfg acpLogConfig) *acpLogManager {
+	if cfg.ringSize <= 0 {
+		cfg.ringSize = defaultACPRingSize
+	}
+	if cfg.maxFileBytes <= 0 {
+		cfg.maxFileBytes = defaultACPMaxFileBytes
+	}
+	return &acpLogManager{
+		cfg:     cfg,
+		writers: make(map[string]*acpWriter),
+		rings:   make(map[string]*ringBuffer),
+	}
+}
+
+// rawEntry mirrors the legacy raw debug-log line shape.
+type rawEntry struct {
+	Ts       int64           `json:"ts"`
+	Protocol string          `json:"protocol"`
+	Agent    string          `json:"agent"`
+	Event    string          `json:"event"`
+	Data     json.RawMessage `json:"data"`
+}
+
+// normalizedEntry mirrors the legacy normalized debug-log line shape consumed
+// by internal/debug.readNormalizedEventsAsMessages.
+type normalizedEntry struct {
+	Ts    int64               `json:"ts"`
+	Event *streams.AgentEvent `json:"event"`
+}
+
+func (m *acpLogManager) writeRaw(protocol, agentID, sessionID, eventType string, rawData json.RawMessage) {
+	entry := rawEntry{
+		Ts:       time.Now().UnixMilli(),
+		Protocol: protocol,
+		Agent:    agentID,
+		Event:    eventType,
+		Data:     rawData,
+	}
+	m.write(rawFileName(protocol, agentID, sessionID), entry)
+}
+
+func (m *acpLogManager) writeNormalized(protocol, agentID, sessionID string, event *streams.AgentEvent) {
+	entry := normalizedEntry{Ts: time.Now().UnixMilli(), Event: event}
+	line := m.write(normalizedFileName(protocol, agentID, sessionID), entry)
+	if line != nil {
+		// Copy: json.Marshal returns a fresh slice, safe to retain.
+		m.ring(sessionID).add(line)
+	}
+}
+
+// write marshals entry and appends it to the named file's writer. Returns the
+// marshaled line so callers can also feed it to the ring buffer.
+func (m *acpLogManager) write(name string, entry any) []byte {
+	line, err := json.Marshal(entry)
+	if err != nil {
+		log.Printf("[DEBUG] acplog: marshal entry: %v", err)
+		return nil
+	}
+	w := m.getWriter(name)
+	if w == nil {
+		return line
+	}
+	w.writeLine(line)
+	return line
+}
+
+func (m *acpLogManager) getWriter(name string) *acpWriter {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if w, ok := m.writers[name]; ok {
+		return w
+	}
+	if err := os.MkdirAll(m.cfg.dir, 0o755); err != nil {
+		log.Printf("[DEBUG] acplog: mkdir %s: %v", m.cfg.dir, err)
+		return nil
+	}
+	path := filepath.Join(m.cfg.dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		log.Printf("[DEBUG] acplog: open %s: %v", path, err)
+		return nil
+	}
+	var size int64
+	if info, statErr := f.Stat(); statErr == nil {
+		size = info.Size()
+	}
+	w := &acpWriter{
+		path:      path,
+		f:         f,
+		buf:       bufio.NewWriter(f),
+		size:      size,
+		maxBytes:  m.cfg.maxFileBytes,
+		lastWrite: time.Now(),
+	}
+	m.writers[name] = w
+	return w
+}
+
+func (m *acpLogManager) ring(sessionID string) *ringBuffer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.rings[sessionID]
+	if !ok {
+		r = newRingBuffer(m.cfg.ringSize)
+		m.rings[sessionID] = r
+	}
+	return r
+}
+
+// ringTail returns up to n most recent normalized entries for a session, or
+// nil if the session has no ring buffer.
+func (m *acpLogManager) ringTail(sessionID string, n int) []json.RawMessage {
+	m.mu.Lock()
+	r := m.rings[sessionID]
+	m.mu.Unlock()
+	if r == nil {
+		return nil
+	}
+	return r.tail(n)
+}
+
+func (m *acpLogManager) writersSnapshot() []*acpWriter {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*acpWriter, 0, len(m.writers))
+	for _, w := range m.writers {
+		out = append(out, w)
+	}
+	return out
+}
+
+func (m *acpLogManager) flushAll() {
+	for _, w := range m.writersSnapshot() {
+		w.flush()
+	}
+}
+
+func (m *acpLogManager) closeAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, w := range m.writers {
+		w.close()
+		delete(m.writers, name)
+	}
+}
+
+// closeIdle flushes+closes writers untouched for longer than maxIdle so file
+// handles don't leak across many short-lived sessions, and evicts the matching
+// idle ring buffers so an always-on process doesn't accumulate one per
+// historical session. The file stays on disk (retention decides deletion); a
+// later write reopens it in append mode and re-creates the ring.
+func (m *acpLogManager) closeIdle(maxIdle time.Duration) {
+	cutoff := time.Now().Add(-maxIdle)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, w := range m.writers {
+		if w.idleSince(cutoff) {
+			w.close()
+			delete(m.writers, name)
+		}
+	}
+	for sid, r := range m.rings {
+		if r.idleSince(cutoff) {
+			delete(m.rings, sid)
+		}
+	}
+}
+
+// writerActiveSince reports whether an open writer for path has a buffered
+// last-write at or after cutoff (i.e. the session is still being written).
+func (m *acpLogManager) writerActiveSince(path string, cutoff time.Time) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, w := range m.writers {
+		if w.path == path {
+			return !w.idleSince(cutoff)
+		}
+	}
+	return false
+}
+
+// closeWriterForPath closes and forgets any open writer for path so the file
+// can be removed (required on Windows, where deleting an open file fails).
+func (m *acpLogManager) closeWriterForPath(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for name, w := range m.writers {
+		if w.path == path {
+			w.close()
+			delete(m.writers, name)
+			return
+		}
+	}
+}
+
+// logFileInfo is a discovered debug-log file and its mtime, used for retention.
+type logFileInfo struct {
+	path  string
+	mtime time.Time
+}
+
+// isACPLogFile reports whether name is one of our debug-log files (active or
+// rotated). Mirrors the prefix/suffix contract enforced by internal/debug.
+func isACPLogFile(name string) bool {
+	return strings.HasSuffix(name, jsonlSuffix) &&
+		(strings.HasPrefix(name, rawPrefix) || strings.HasPrefix(name, normalizedPrefix))
+}
+
+func (m *acpLogManager) listLogFiles() []logFileInfo {
+	entries, err := os.ReadDir(m.cfg.dir)
+	if err != nil {
+		return nil
+	}
+	out := make([]logFileInfo, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !isACPLogFile(e.Name()) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		out = append(out, logFileInfo{path: filepath.Join(m.cfg.dir, e.Name()), mtime: info.ModTime()})
+	}
+	return out
+}
+
+// removeFile closes any open writer for path (so deletion works on Windows)
+// and unlinks the file.
+func (m *acpLogManager) removeFile(path string) {
+	m.closeWriterForPath(path)
+	_ = os.Remove(path)
+}
+
+// prune enforces the age cap then the total-file cap, deleting oldest-by-mtime
+// first. Non-log files in the directory are left untouched. Mirrors the
+// keep-newest-N shape of persistence.pruneBackups, generalized to age+count.
+func (m *acpLogManager) prune(now time.Time) {
+	files := m.listLogFiles()
+
+	// Age cap: drop files last written before the retention cutoff. An open
+	// writer whose buffered last-write is recent keeps its file alive even when
+	// the on-disk mtime still looks stale (the flush hasn't landed yet), so a
+	// retention tick that races ahead of the flush tick can't delete a file
+	// that's actively being written.
+	if m.cfg.retention > 0 {
+		cutoff := now.Add(-m.cfg.retention)
+		survivors := make([]logFileInfo, 0, len(files))
+		for _, f := range files {
+			if f.mtime.Before(cutoff) && !m.writerActiveSince(f.path, cutoff) {
+				m.removeFile(f.path)
+			} else {
+				survivors = append(survivors, f)
+			}
+		}
+		files = survivors
+	}
+
+	// Count cap: keep only the newest maxFiles by mtime.
+	if m.cfg.maxFiles > 0 && len(files) > m.cfg.maxFiles {
+		sort.Slice(files, func(i, j int) bool { return files[i].mtime.After(files[j].mtime) })
+		for _, f := range files[m.cfg.maxFiles:] {
+			m.removeFile(f.path)
+		}
+	}
+}
+
+// acpWriter is a single kept-open, line-buffered file handle with its own lock
+// and rotation on a byte cap.
+type acpWriter struct {
+	mu        sync.Mutex
+	path      string
+	f         *os.File
+	buf       *bufio.Writer
+	size      int64
+	maxBytes  int64
+	seq       int
+	lastWrite time.Time
+}
+
+func (w *acpWriter) writeLine(line []byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return
+	}
+	need := int64(len(line) + 1)
+	if w.size > 0 && w.size+need > w.maxBytes {
+		w.rotate()
+	}
+	if w.f == nil {
+		return
+	}
+	_, _ = w.buf.Write(line)
+	_ = w.buf.WriteByte('\n')
+	w.size += need
+	w.lastWrite = time.Now()
+}
+
+// rotate rolls the active file to a numbered sibling that keeps the reader's
+// prefix/suffix, then reopens a fresh, empty active file. Caller holds w.mu.
+func (w *acpWriter) rotate() {
+	_ = w.buf.Flush()
+	_ = w.f.Close()
+
+	rotated := w.nextRotatedPath()
+	if err := os.Rename(w.path, rotated); err != nil {
+		// Rotation failed (e.g. a transient FS error). Reopen the existing file
+		// in append mode rather than truncating it, so the current segment is
+		// preserved; the roll is retried on the next write.
+		log.Printf("[DEBUG] acplog: rotate %s: %v", w.path, err)
+		w.reopen(os.O_APPEND, true /* keepSize */)
+		return
+	}
+	w.reopen(os.O_TRUNC, false /* keepSize */)
+}
+
+// nextRotatedPath returns a rotated sibling filename that does not yet exist.
+// seq resets to 0 on every fresh writer (restart, idle reopen), so probing for
+// a free slot is what prevents clobbering an older rotated segment.
+func (w *acpWriter) nextRotatedPath() string {
+	base := strings.TrimSuffix(w.path, jsonlSuffix)
+	for {
+		w.seq++
+		candidate := base + "." + strconv.Itoa(w.seq) + jsonlSuffix
+		// Only skip a candidate that definitively exists; treat NotExist (and
+		// any other stat error) as "safe to use" so we never loop forever.
+		if _, err := os.Stat(candidate); err != nil {
+			return candidate
+		}
+	}
+}
+
+// reopen re-opens w.path with the given mode bit (O_TRUNC for a fresh segment,
+// O_APPEND to keep the existing one) and resets the buffered writer. keepSize
+// preserves the on-disk size so a failed rotation retries on the next write.
+func (w *acpWriter) reopen(modeBit int, keepSize bool) {
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|modeBit, 0o644)
+	if err != nil {
+		log.Printf("[DEBUG] acplog: reopen %s: %v", w.path, err)
+		w.f = nil
+		w.buf = nil
+		return
+	}
+	w.f = f
+	w.buf = bufio.NewWriter(f)
+	if keepSize {
+		if info, statErr := f.Stat(); statErr == nil {
+			w.size = info.Size()
+		}
+	} else {
+		w.size = 0
+	}
+}
+
+func (w *acpWriter) flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buf != nil {
+		_ = w.buf.Flush()
+	}
+}
+
+func (w *acpWriter) close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buf != nil {
+		_ = w.buf.Flush()
+		w.buf = nil
+	}
+	if w.f != nil {
+		_ = w.f.Close()
+		w.f = nil
+	}
+}
+
+func (w *acpWriter) idleSince(cutoff time.Time) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.lastWrite.Before(cutoff)
+}
+
+// --- filename helpers ---
+
+func rawFileName(protocol, agentID, sessionID string) string {
+	return rawPrefix + fileKey(protocol, agentID, sessionID) + jsonlSuffix
+}
+
+func normalizedFileName(protocol, agentID, sessionID string) string {
+	return normalizedPrefix + fileKey(protocol, agentID, sessionID) + jsonlSuffix
+}
+
+func fileKey(protocol, agentID, sessionID string) string {
+	return sanitizeFilenamePart(protocol) + "-" +
+		sanitizeFilenamePart(agentID) + "-" +
+		sanitizeFilenamePart(sessionID)
+}
+
+// sanitizeFilenamePart keeps only filename-safe characters so a hostile or
+// path-like session id can't escape the log dir or break Windows filenames.
+func sanitizeFilenamePart(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// --- ring buffer ---
+
+// ringBuffer is a fixed-capacity FIFO of the most recent normalized entries
+// for one session, used by the dev-only live-tail endpoint.
+type ringBuffer struct {
+	mu        sync.Mutex
+	entries   []json.RawMessage
+	cap       int
+	lastWrite time.Time
+}
+
+func newRingBuffer(capacity int) *ringBuffer {
+	if capacity <= 0 {
+		capacity = defaultACPRingSize
+	}
+	return &ringBuffer{cap: capacity}
+}
+
+func (r *ringBuffer) add(entry json.RawMessage) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries = append(r.entries, entry)
+	if len(r.entries) > r.cap {
+		// Drop oldest; copy to avoid unbounded backing-array growth.
+		r.entries = append([]json.RawMessage(nil), r.entries[len(r.entries)-r.cap:]...)
+	}
+	r.lastWrite = time.Now()
+}
+
+func (r *ringBuffer) idleSince(cutoff time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastWrite.Before(cutoff)
+}
+
+func (r *ringBuffer) tail(n int) []json.RawMessage {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if n <= 0 || n > len(r.entries) {
+		n = len(r.entries)
+	}
+	out := make([]json.RawMessage, n)
+	copy(out, r.entries[len(r.entries)-n:])
+	return out
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog.go
@@ -197,6 +197,10 @@ func (m *acpLogManager) getWriter(name string) *acpWriter {
 		log.Printf("[DEBUG] acplog: mkdir %s: %v", m.cfg.dir, err)
 		return nil
 	}
+	if err := os.Chmod(m.cfg.dir, acpDirPerm); err != nil {
+		log.Printf("[DEBUG] acplog: chmod %s: %v", m.cfg.dir, err)
+		return nil
+	}
 	path := filepath.Join(m.cfg.dir, name)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, acpFilePerm)
 	if err != nil {
@@ -265,6 +269,7 @@ func (m *acpLogManager) closeAll() {
 		w.close()
 		delete(m.writers, name)
 	}
+	m.rings = make(map[string]*ringBuffer)
 }
 
 // closeIdle flushes+closes writers untouched for longer than maxIdle so file
@@ -551,7 +556,7 @@ func sanitizeFilenamePart(s string) string {
 type ringBuffer struct {
 	mu        sync.Mutex
 	entries   []json.RawMessage
-	cap       int
+	capacity  int
 	lastWrite time.Time
 }
 
@@ -559,18 +564,18 @@ func newRingBuffer(capacity int) *ringBuffer {
 	if capacity <= 0 {
 		capacity = defaultACPRingSize
 	}
-	return &ringBuffer{cap: capacity}
+	return &ringBuffer{capacity: capacity}
 }
 
 func (r *ringBuffer) add(entry json.RawMessage) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.entries = append(r.entries, entry)
-	if len(r.entries) > r.cap {
+	if len(r.entries) > r.capacity {
 		// Drop oldest. Pre-size with one spare slot so the next append lands in
 		// the existing backing array instead of reallocating every time.
-		trimmed := make([]json.RawMessage, r.cap, r.cap+1)
-		copy(trimmed, r.entries[len(r.entries)-r.cap:])
+		trimmed := make([]json.RawMessage, r.capacity, r.capacity+1)
+		copy(trimmed, r.entries[len(r.entries)-r.capacity:])
 		r.entries = trimmed
 	}
 	r.lastWrite = time.Now()

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog.go
@@ -45,6 +45,10 @@ const (
 	defaultACPRetentionHrs = 48
 	defaultACPMaxFileBytes = 8 << 20 // 8 MiB
 	defaultACPRingSize     = 500
+
+	// Owner-only perms: these files carry full prompt/file/tool content.
+	acpDirPerm  = 0o700
+	acpFilePerm = 0o600
 )
 
 // acpLogConfig is the resolved configuration for the managed writer registry.
@@ -63,10 +67,22 @@ func acpLogConfigFromEnv() acpLogConfig {
 	return acpLogConfig{
 		dir:          resolveACPLogDir(),
 		maxFileBytes: envInt64(envACPMaxFileBytes, defaultACPMaxFileBytes),
-		maxFiles:     int(envInt64(envACPMaxFiles, defaultACPMaxFiles)),
+		maxFiles:     envInt(envACPMaxFiles, defaultACPMaxFiles),
 		retention:    time.Duration(envInt64(envACPRetentionHrs, defaultACPRetentionHrs)) * time.Hour,
 		ringSize:     defaultACPRingSize,
 	}
+}
+
+// envInt reads a positive int env var with a sane upper bound, so the value
+// (a file-count cap) can't overflow when narrowed from the parsed int64 on a
+// 32-bit platform.
+func envInt(key string, def int) int {
+	const maxInt = 1 << 30 // generous; well within int on every platform
+	n := envInt64(key, int64(def))
+	if n > maxInt {
+		return maxInt
+	}
+	return int(n)
 }
 
 func resolveACPLogDir() string {
@@ -161,6 +177,10 @@ func (m *acpLogManager) write(name string, entry any) []byte {
 	}
 	w := m.getWriter(name)
 	if w == nil {
+		// The file couldn't be opened (e.g. no writable dir, as in a container
+		// without a mounted volume). Still return the marshaled line so the
+		// in-memory ring buffer / live-tail endpoint keeps working — those
+		// events just aren't persisted to disk.
 		return line
 	}
 	w.writeLine(line)
@@ -173,12 +193,12 @@ func (m *acpLogManager) getWriter(name string) *acpWriter {
 	if w, ok := m.writers[name]; ok {
 		return w
 	}
-	if err := os.MkdirAll(m.cfg.dir, 0o755); err != nil {
+	if err := os.MkdirAll(m.cfg.dir, acpDirPerm); err != nil {
 		log.Printf("[DEBUG] acplog: mkdir %s: %v", m.cfg.dir, err)
 		return nil
 	}
 	path := filepath.Join(m.cfg.dir, name)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, acpFilePerm)
 	if err != nil {
 		log.Printf("[DEBUG] acplog: open %s: %v", path, err)
 		return nil
@@ -385,7 +405,13 @@ func (w *acpWriter) writeLine(line []byte) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.f == nil {
-		return
+		// A prior open/rotate left this writer without a handle. Retry here so
+		// a transient FS error doesn't permanently disable a session's logging
+		// (the writer stays cached in the manager map and self-heals).
+		w.reopen(os.O_APPEND, true /* keepSize */)
+		if w.f == nil {
+			return
+		}
 	}
 	need := int64(len(line) + 1)
 	if w.size > 0 && w.size+need > w.maxBytes {
@@ -438,7 +464,7 @@ func (w *acpWriter) nextRotatedPath() string {
 // O_APPEND to keep the existing one) and resets the buffered writer. keepSize
 // preserves the on-disk size so a failed rotation retries on the next write.
 func (w *acpWriter) reopen(modeBit int, keepSize bool) {
-	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|modeBit, 0o644)
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|modeBit, acpFilePerm)
 	if err != nil {
 		log.Printf("[DEBUG] acplog: reopen %s: %v", w.path, err)
 		w.f = nil
@@ -541,8 +567,11 @@ func (r *ringBuffer) add(entry json.RawMessage) {
 	defer r.mu.Unlock()
 	r.entries = append(r.entries, entry)
 	if len(r.entries) > r.cap {
-		// Drop oldest; copy to avoid unbounded backing-array growth.
-		r.entries = append([]json.RawMessage(nil), r.entries[len(r.entries)-r.cap:]...)
+		// Drop oldest. Pre-size with one spare slot so the next append lands in
+		// the existing backing array instead of reallocating every time.
+		trimmed := make([]json.RawMessage, r.cap, r.cap+1)
+		copy(trimmed, r.entries[len(r.entries)-r.cap:])
+		r.entries = trimmed
 	}
 	r.lastWrite = time.Now()
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog_test.go
@@ -67,6 +67,25 @@ func TestACPLog_SanitizesSessionID(t *testing.T) {
 	}
 }
 
+func TestACPLog_EnforcesPrivateDirPerm(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod broad dir: %v", err)
+	}
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 1 << 20, ringSize: 8})
+	defer m.closeAll()
+
+	m.writeNormalized(ProtocolACP, "claude-acp", "sess", testEvent("sess"))
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat log dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != acpDirPerm {
+		t.Fatalf("log dir perms = %o, want %o", got, acpDirPerm)
+	}
+}
+
 // TestACPLog_Rotation verifies a chatty session rolls its file once it passes
 // the byte cap, capping a single file's size while preserving prior data in a
 // rotated sibling.
@@ -176,6 +195,22 @@ func TestACPLog_RingEviction(t *testing.T) {
 
 	if got := m.ringTail("sess", 10); got != nil {
 		t.Errorf("expected ring evicted after idle sweep, got %d entries", len(got))
+	}
+}
+
+func TestACPLog_CloseAllClearsRings(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 1 << 20, ringSize: 4})
+
+	m.writeNormalized(ProtocolACP, "acp", "sess", testEvent("sess"))
+	if m.ringTail("sess", 10) == nil {
+		t.Fatal("expected ring tail before closeAll")
+	}
+
+	m.closeAll()
+
+	if got := m.ringTail("sess", 10); got != nil {
+		t.Errorf("expected closeAll to clear ring buffers, got %d entries", len(got))
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog_test.go
@@ -113,10 +113,11 @@ func TestACPLog_RingTail(t *testing.T) {
 	if len(tail) != 3 {
 		t.Fatalf("ring should cap at 3, got %d", len(tail))
 	}
-	// Oldest two (a,b) evicted; newest is 'e'.
+	// Oldest two (a,b) evicted; newest is 'e'. Assert the specific text field
+	// so the check can't pass on an incidental 'e' in some JSON key.
 	last := string(tail[len(tail)-1])
-	if !strings.Contains(last, `"e"`) && !strings.Contains(last, "e") {
-		t.Errorf("expected newest entry to contain 'e', got %s", last)
+	if !strings.Contains(last, `"text":"e"`) {
+		t.Errorf("expected newest entry text 'e', got %s", last)
 	}
 	if got := m.ringTail("nope", 10); got != nil {
 		t.Errorf("unknown session should return nil tail, got %v", got)
@@ -183,9 +184,12 @@ func TestACPLog_RingEviction(t *testing.T) {
 // disabled mode records nothing.
 func TestACPRingTail_GlobalWrapper(t *testing.T) {
 	prevMgr, prevDebug := acpLog, debugMode
-	acpLog = newACPLogManager(acpLogConfig{dir: t.TempDir(), maxFileBytes: 1 << 20, ringSize: 8})
+	mgr := newACPLogManager(acpLogConfig{dir: t.TempDir(), maxFileBytes: 1 << 20, ringSize: 8})
+	acpLog = mgr
 	debugMode = true
-	t.Cleanup(func() { acpLog = prevMgr; debugMode = prevDebug })
+	// Close the temporary manager's writers (not just restore the globals) so
+	// no file handles leak.
+	t.Cleanup(func() { mgr.closeAll(); acpLog = prevMgr; debugMode = prevDebug })
 
 	for range 3 {
 		LogNormalizedEvent(ProtocolACP, "acp", "sess", testEvent("sess"))

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/acplog_test.go
@@ -1,0 +1,240 @@
+package shared
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+func testEvent(sessionID string) *streams.AgentEvent {
+	return &streams.AgentEvent{Type: streams.EventTypeMessageChunk, SessionID: sessionID, Text: "hello"}
+}
+
+// TestACPLog_PerSessionRouting verifies two sessions land in two distinct
+// files, each filename carrying its own session id, and keeping the
+// normalized-/raw- prefix + .jsonl suffix the debug reader requires.
+func TestACPLog_PerSessionRouting(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 1 << 20, ringSize: 8})
+	defer m.closeAll()
+
+	m.writeNormalized(ProtocolACP, "claude-acp", "sess-A", testEvent("sess-A"))
+	m.writeNormalized(ProtocolACP, "claude-acp", "sess-B", testEvent("sess-B"))
+	m.writeRaw(ProtocolACP, "claude-acp", "sess-A", "session_notification", json.RawMessage(`{"a":1}`))
+	m.flushAll()
+
+	want := []string{
+		"normalized-acp-claude-acp-sess-A.jsonl",
+		"normalized-acp-claude-acp-sess-B.jsonl",
+		"raw-acp-claude-acp-sess-A.jsonl",
+	}
+	for _, name := range want {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected file %s: %v", name, err)
+		}
+		if !strings.HasSuffix(name, jsonlSuffix) {
+			t.Errorf("file %s missing .jsonl suffix", name)
+		}
+	}
+}
+
+// TestACPLog_SanitizesSessionID ensures path-unsafe characters in a session
+// id can't escape the log dir or break Windows filenames.
+func TestACPLog_SanitizesSessionID(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 1 << 20, ringSize: 8})
+	defer m.closeAll()
+
+	m.writeNormalized(ProtocolACP, "claude-acp", "../../etc/passwd:bad", testEvent("x"))
+	m.flushAll()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 file in dir, got %d", len(entries))
+	}
+	name := entries[0].Name()
+	if strings.ContainsAny(name, `/\:`) {
+		t.Errorf("filename %q contains path-unsafe characters", name)
+	}
+}
+
+// TestACPLog_Rotation verifies a chatty session rolls its file once it passes
+// the byte cap, capping a single file's size while preserving prior data in a
+// rotated sibling.
+func TestACPLog_Rotation(t *testing.T) {
+	dir := t.TempDir()
+	// Tiny cap so a handful of lines triggers a roll.
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 200, ringSize: 8})
+	defer m.closeAll()
+
+	big := strings.Repeat("x", 80)
+	for range 10 {
+		m.writeNormalized(ProtocolACP, "acp", "sess", &streams.AgentEvent{Type: streams.EventTypeMessageChunk, SessionID: "sess", Text: big})
+	}
+	m.flushAll()
+
+	active := filepath.Join(dir, "normalized-acp-acp-sess.jsonl")
+	info, err := os.Stat(active)
+	if err != nil {
+		t.Fatalf("stat active: %v", err)
+	}
+	if info.Size() > 200+128 {
+		t.Errorf("active file not capped: %d bytes", info.Size())
+	}
+	// A rotated sibling must exist and still match the reader's prefix/suffix.
+	rotated, _ := filepath.Glob(filepath.Join(dir, "normalized-acp-acp-sess.*.jsonl"))
+	if len(rotated) == 0 {
+		t.Errorf("expected a rotated sibling file, found none")
+	}
+}
+
+// TestACPLog_RingTail returns the most recent normalized events for a session
+// without touching disk.
+func TestACPLog_RingTail(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 1 << 20, ringSize: 3})
+	defer m.closeAll()
+
+	for i := range 5 {
+		m.writeNormalized(ProtocolACP, "acp", "sess", &streams.AgentEvent{
+			Type: streams.EventTypeMessageChunk, SessionID: "sess", Text: string(rune('a' + i)),
+		})
+	}
+	tail := m.ringTail("sess", 10)
+	if len(tail) != 3 {
+		t.Fatalf("ring should cap at 3, got %d", len(tail))
+	}
+	// Oldest two (a,b) evicted; newest is 'e'.
+	last := string(tail[len(tail)-1])
+	if !strings.Contains(last, `"e"`) && !strings.Contains(last, "e") {
+		t.Errorf("expected newest entry to contain 'e', got %s", last)
+	}
+	if got := m.ringTail("nope", 10); got != nil {
+		t.Errorf("unknown session should return nil tail, got %v", got)
+	}
+}
+
+// TestACPLog_RotationDoesNotClobberExisting verifies rotation picks a free
+// sibling name instead of reusing ".1.jsonl" (seq resets per writer), so a
+// rotated segment from a previous run survives.
+func TestACPLog_RotationDoesNotClobberExisting(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 200, ringSize: 4})
+	defer m.closeAll()
+
+	// Pre-create the .1 rotated sibling as if from a previous process run.
+	pre := filepath.Join(dir, "normalized-acp-acp-sess.1.jsonl")
+	if err := os.WriteFile(pre, []byte("SENTINEL\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	big := strings.Repeat("x", 80)
+	for range 6 {
+		m.writeNormalized(ProtocolACP, "acp", "sess", &streams.AgentEvent{
+			Type: streams.EventTypeMessageChunk, SessionID: "sess", Text: big,
+		})
+	}
+	m.flushAll()
+
+	got, err := os.ReadFile(pre)
+	if err != nil || string(got) != "SENTINEL\n" {
+		t.Errorf("pre-existing rotated file clobbered: got %q err %v", string(got), err)
+	}
+	rotated, _ := filepath.Glob(filepath.Join(dir, "normalized-acp-acp-sess.*.jsonl"))
+	if len(rotated) < 2 {
+		t.Errorf("expected >=2 rotated siblings (pre-existing + new), got %d: %v", len(rotated), rotated)
+	}
+}
+
+// TestACPLog_RingEviction confirms idle ring buffers are dropped so memory
+// doesn't accumulate one per historical session.
+func TestACPLog_RingEviction(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 1 << 20, ringSize: 4})
+	defer m.closeAll()
+
+	m.writeNormalized(ProtocolACP, "acp", "sess", testEvent("sess"))
+	if m.ringTail("sess", 10) == nil {
+		t.Fatal("expected ring tail before eviction")
+	}
+	r := m.ring("sess")
+	r.mu.Lock()
+	r.lastWrite = time.Now().Add(-time.Hour)
+	r.mu.Unlock()
+
+	m.closeIdle(time.Minute)
+
+	if got := m.ringTail("sess", 10); got != nil {
+		t.Errorf("expected ring evicted after idle sweep, got %d entries", len(got))
+	}
+}
+
+// TestACPRingTail_GlobalWrapper exercises the exported ACPRingTail over the
+// process-wide registry: n cap, n<=0 returns all, unknown session is nil, and
+// disabled mode records nothing.
+func TestACPRingTail_GlobalWrapper(t *testing.T) {
+	prevMgr, prevDebug := acpLog, debugMode
+	acpLog = newACPLogManager(acpLogConfig{dir: t.TempDir(), maxFileBytes: 1 << 20, ringSize: 8})
+	debugMode = true
+	t.Cleanup(func() { acpLog = prevMgr; debugMode = prevDebug })
+
+	for range 3 {
+		LogNormalizedEvent(ProtocolACP, "acp", "sess", testEvent("sess"))
+	}
+	if got := ACPRingTail("sess", 2); len(got) != 2 {
+		t.Errorf("expected n=2 cap, got %d", len(got))
+	}
+	if got := ACPRingTail("sess", 0); len(got) != 3 {
+		t.Errorf("expected all 3 with n<=0, got %d", len(got))
+	}
+	if got := ACPRingTail("unknown", 10); got != nil {
+		t.Errorf("unknown session should be nil, got %v", got)
+	}
+
+	debugMode = false
+	LogNormalizedEvent(ProtocolACP, "acp", "sess2", testEvent("sess2"))
+	if ACPRingTail("sess2", 10) != nil {
+		t.Errorf("disabled mode should not record events")
+	}
+}
+
+// TestACPLog_ConcurrentSessions exercises many goroutines writing distinct
+// sessions concurrently; run with -race.
+func TestACPLog_ConcurrentSessions(t *testing.T) {
+	dir := t.TempDir()
+	m := newACPLogManager(acpLogConfig{dir: dir, maxFileBytes: 1 << 20, ringSize: 16})
+	defer m.closeAll()
+
+	var wg sync.WaitGroup
+	for s := range 16 {
+		wg.Add(1)
+		go func(s int) {
+			defer wg.Done()
+			sess := "sess-" + string(rune('A'+s))
+			for range 50 {
+				m.writeNormalized(ProtocolACP, "acp", sess, testEvent(sess))
+				m.writeRaw(ProtocolACP, "acp", sess, "n", json.RawMessage(`{}`))
+			}
+		}(s)
+	}
+	wg.Wait()
+	m.flushAll()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	// 16 sessions × {normalized,raw} = 32 files.
+	if len(entries) != 32 {
+		t.Errorf("expected 32 files, got %d", len(entries))
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/debug.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/debug.go
@@ -3,30 +3,20 @@ package shared
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
 	"os"
-	"path/filepath"
-	"sync"
-	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 )
 
 // debugMode controls whether agent messages are logged.
 // Enable via KANDEV_DEBUG_AGENT_MESSAGES=true environment variable.
-var debugMode = os.Getenv("KANDEV_DEBUG_AGENT_MESSAGES") == "true"
+var debugMode = os.Getenv(envDebugMessages) == "true"
 
-// debugLogDir is the directory where debug log files are written.
-// Defaults to the process CWD; override with KANDEV_DEBUG_LOG_DIR.
-var debugLogDir = resolveDebugLogDir()
-
-// debugLogMu protects concurrent writes to debug log files.
-var debugLogMu sync.Mutex
-
-// initializedFiles tracks which log files have been truncated in this session.
-// First write to a file truncates it; subsequent writes append.
-var initializedFiles = make(map[string]bool)
+// acpLog is the process-wide managed writer registry. It is allocated even
+// when debug mode is off (cheap, no file handles) so the janitor and tail
+// endpoint can reference a stable instance; nothing is written unless
+// debugMode is true.
+var acpLog = newACPLogManager(acpLogConfigFromEnv())
 
 // Protocol constants for debug file naming
 const (
@@ -38,78 +28,37 @@ const (
 	ProtocolCopilot    = "copilot"
 )
 
-func resolveDebugLogDir() string {
-	if dir := os.Getenv("KANDEV_DEBUG_LOG_DIR"); dir != "" {
-		return dir
-	}
-	if cwd, err := os.Getwd(); err == nil {
-		return cwd
-	}
-	return "."
+// ACPDebugEnabled reports whether agent-message debug logging is on.
+func ACPDebugEnabled() bool { return debugMode }
+
+// ACPLogDir returns the directory debug log files are written to. Exported so
+// the debug reader (internal/debug) can discover per-session files. It
+// resolves live from the environment: the reader runs in the backend process
+// while the writer runs in agentctl, but both start from the same forwarded
+// env so they resolve to the same directory.
+func ACPLogDir() string { return resolveACPLogDir() }
+
+// ACPRingTail returns up to n most recent normalized events for a session as
+// raw JSON lines, for the dev-only live-tail endpoint. Returns nil when the
+// session is unknown.
+func ACPRingTail(sessionID string, n int) []json.RawMessage {
+	return acpLog.ringTail(sessionID, n)
 }
 
 // LogRawEvent logs a raw protocol event without transformation.
-// File: raw-{protocol}-{agentId}.jsonl
-func LogRawEvent(protocol, agentID, eventType string, rawData json.RawMessage) {
+// File: raw-{protocol}-{agentID}-{sessionID}.jsonl
+func LogRawEvent(protocol, agentID, sessionID, eventType string, rawData json.RawMessage) {
 	if !debugMode {
 		return
 	}
-
-	entry := map[string]any{
-		"ts":       time.Now().UnixMilli(),
-		"protocol": protocol,
-		"agent":    agentID,
-		"event":    eventType,
-		"data":     rawData,
-	}
-
-	logFile := filepath.Join(debugLogDir, fmt.Sprintf("raw-%s-%s.jsonl", protocol, agentID))
-	writeJSONLine(logFile, entry)
+	acpLog.writeRaw(protocol, agentID, sessionID, eventType, rawData)
 }
 
 // LogNormalizedEvent logs a normalized AgentEvent.
-// File: normalized-{protocol}-{agentId}.jsonl
-func LogNormalizedEvent(protocol, agentID string, event *streams.AgentEvent) {
+// File: normalized-{protocol}-{agentID}-{sessionID}.jsonl
+func LogNormalizedEvent(protocol, agentID, sessionID string, event *streams.AgentEvent) {
 	if !debugMode {
 		return
 	}
-
-	entry := map[string]any{
-		"ts":    time.Now().UnixMilli(),
-		"event": event,
-	}
-
-	logFile := filepath.Join(debugLogDir, fmt.Sprintf("normalized-%s-%s.jsonl", protocol, agentID))
-	writeJSONLine(logFile, entry)
-}
-
-// writeJSONLine writes a JSON entry as a line to the specified file.
-// On first write to a file in this session, the file is truncated.
-func writeJSONLine(logFile string, entry any) {
-	entryJSON, err := json.Marshal(entry)
-	if err != nil {
-		log.Printf("[DEBUG] Failed to marshal entry: %v", err)
-		return
-	}
-
-	debugLogMu.Lock()
-	defer debugLogMu.Unlock()
-
-	// Determine open flags: truncate on first write, append on subsequent
-	flags := os.O_CREATE | os.O_WRONLY
-	if initializedFiles[logFile] {
-		flags |= os.O_APPEND
-	} else {
-		flags |= os.O_TRUNC
-		initializedFiles[logFile] = true
-	}
-
-	f, err := os.OpenFile(logFile, flags, 0644)
-	if err != nil {
-		log.Printf("[DEBUG] Failed to open log file %s: %v", logFile, err)
-		return
-	}
-	defer func() { _ = f.Close() }()
-
-	_, _ = f.WriteString(string(entryJSON) + "\n")
+	acpLog.writeNormalized(protocol, agentID, sessionID, event)
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/testmain_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/testmain_test.go
@@ -1,0 +1,13 @@
+package shared
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain runs the shared transport tests under goleak so the ACP debug-log
+// janitor's background goroutine is verified leak-free (Start/Stop drains it).
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/apps/backend/internal/agentctl/server/api/acp_debug_test.go
+++ b/apps/backend/internal/agentctl/server/api/acp_debug_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	envMessages = "KANDEV_DEBUG_AGENT_MESSAGES"
+	envDevMode  = "KANDEV_DEBUG_DEV_MODE"
+	enabled     = "true"
+	disabled    = ""
+)
+
+func acpTailStatus(t *testing.T, s *Server) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug/acp/some-session", nil)
+	s.router.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+// TestACPRingTailRoute_Gating verifies the live-tail route is registered only
+// when BOTH frame logging and dev mode are on — message logging alone (e.g. a
+// non-dev deployment) must not expose it.
+func TestACPRingTailRoute_Gating(t *testing.T) {
+	// Neither flag → route absent. (Clear explicitly: the test may run inside a
+	// dev session where these are already exported.)
+	t.Setenv(envMessages, disabled)
+	t.Setenv(envDevMode, disabled)
+	if status := acpTailStatus(t, newTestServer(t)); status != http.StatusNotFound {
+		t.Errorf("expected 404 when disabled, got %d", status)
+	}
+
+	// Message logging only → still absent.
+	t.Setenv(envMessages, enabled)
+	if status := acpTailStatus(t, newTestServer(t)); status != http.StatusNotFound {
+		t.Errorf("expected 404 with messages-only, got %d", status)
+	}
+
+	// Both flags → route present.
+	t.Setenv(envDevMode, enabled)
+	if status := acpTailStatus(t, newTestServer(t)); status != http.StatusOK {
+		t.Errorf("expected 200 when dev+messages on, got %d", status)
+	}
+}
+
+// TestACPRingTailHandler_UnknownSession verifies the handler returns a 200 with
+// an empty (non-null) events array and echoes the session + parses n.
+func TestACPRingTailHandler_UnknownSession(t *testing.T) {
+	t.Setenv(envMessages, enabled)
+	t.Setenv(envDevMode, enabled)
+	s := newTestServer(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug/acp/no-such-session?n=5", nil)
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var body struct {
+		Session string            `json:"session"`
+		Count   int               `json:"count"`
+		Events  []json.RawMessage `json:"events"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Session != "no-such-session" {
+		t.Errorf("session = %q, want no-such-session", body.Session)
+	}
+	if body.Count != 0 {
+		t.Errorf("count = %d, want 0", body.Count)
+	}
+	if body.Events == nil {
+		t.Errorf("events should serialize as [] not null")
+	}
+}

--- a/apps/backend/internal/agentctl/server/api/server.go
+++ b/apps/backend/internal/agentctl/server/api/server.go
@@ -2,14 +2,17 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/pprof"
 	"os"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
+	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
 	"github.com/kandev/kandev/internal/agentctl/server/config"
 	"github.com/kandev/kandev/internal/agentctl/server/process"
 	"github.com/kandev/kandev/internal/agentctl/server/utility"
@@ -183,6 +186,45 @@ func (s *Server) setupRoutes() {
 	if os.Getenv("KANDEV_DEBUG_PPROF_ENABLED") == "true" { //nolint:goconst // env-var check, not a query param
 		s.registerPprofRoutes()
 	}
+
+	// Dev-only live tail of a session's recent ACP frames from an in-memory
+	// ring buffer (zero disk growth). Complements the file sink for
+	// investigating a currently-stuck session. Frames carry full prompt/tool
+	// content, so require BOTH frame logging and dev mode to be on — message
+	// logging alone (e.g. someone debugging a non-dev deployment) must not
+	// expose this endpoint.
+	if acpDebugTailEnabled() {
+		s.router.GET("/api/v1/debug/acp/:session", s.handleACPRingTail)
+	}
+}
+
+// acpDebugTailEnabled gates the ACP live-tail endpoint on both ACP frame
+// logging and dev mode. Read live (like the pprof gate) so it is testable.
+func acpDebugTailEnabled() bool {
+	return os.Getenv("KANDEV_DEBUG_AGENT_MESSAGES") == "true" && //nolint:goconst // env-var values, not query params
+		os.Getenv("KANDEV_DEBUG_DEV_MODE") == "true"
+}
+
+// handleACPRingTail returns the most recent normalized ACP events for a
+// session from the in-memory ring buffer. Query param n caps the count
+// (default 200).
+func (s *Server) handleACPRingTail(c *gin.Context) {
+	session := c.Param("session")
+	n := 200
+	if v := c.Query("n"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			n = parsed
+		}
+	}
+	events := shared.ACPRingTail(session, n)
+	if events == nil {
+		events = []json.RawMessage{}
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"session": session,
+		"count":   len(events),
+		"events":  events,
+	})
 }
 
 // Health check response

--- a/apps/backend/internal/agentctl/server/api/server.go
+++ b/apps/backend/internal/agentctl/server/api/server.go
@@ -207,12 +207,19 @@ func acpDebugTailEnabled() bool {
 
 // handleACPRingTail returns the most recent normalized ACP events for a
 // session from the in-memory ring buffer. Query param n caps the count
-// (default 200).
+// (default 200, max 1000).
 func (s *Server) handleACPRingTail(c *gin.Context) {
+	const (
+		defaultACPRingTailCount = 200
+		maxACPRingTailCount     = 1000
+	)
 	session := c.Param("session")
-	n := 200
+	n := defaultACPRingTailCount
+	// Bound the untrusted n at the source so it can't drive an oversized
+	// allocation downstream (the ring tail clamps to its size too, but
+	// keeping the limit explicit here is the defensive default).
 	if v := c.Query("n"); v != "" {
-		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 && parsed <= maxACPRingTailCount {
 			n = parsed
 		}
 	}

--- a/apps/backend/internal/debug/fixture.go
+++ b/apps/backend/internal/debug/fixture.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/acp"
+	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
@@ -101,32 +102,50 @@ func discoverFixtureFiles(baseDir string) ([]DiscoveredFile, error) {
 }
 
 // discoverNormalizedFiles finds all normalized event files (normalized-*.jsonl).
+// It looks in two places: the legacy backend-root location (where older runs
+// wrote files into the process CWD) and the per-session log dir used by the
+// managed ACP writer (~/.kandev/logs/acp by default).
 func discoverNormalizedFiles(baseDir string) ([]DiscoveredFile, error) {
-	backendRoot := filepath.Join(baseDir, "..", "..", "..", "..")
-	pattern := filepath.Join(backendRoot, "normalized-*.jsonl")
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return nil, err
+	dirs := []string{
+		filepath.Join(baseDir, "..", "..", "..", ".."), // backend root (legacy CWD)
+		shared.ACPLogDir(), // per-session managed writer dir
 	}
 
+	seen := make(map[string]bool)
 	var files []DiscoveredFile
-	for _, fullPath := range matches {
-		filename := filepath.Base(fullPath)
-		_, protocol, agent := parseDebugFilename(filename)
-		count := countLines(fullPath)
-		relPath, err := filepath.Rel(baseDir, fullPath)
+	for _, dir := range dirs {
+		matches, err := filepath.Glob(filepath.Join(dir, "normalized-*.jsonl"))
 		if err != nil {
-			relPath = fullPath
+			return nil, err
 		}
-		files = append(files, DiscoveredFile{
-			Path:         relPath,
-			Protocol:     protocol,
-			Agent:        agent,
-			MessageCount: count,
-			FileType:     "normalized",
-		})
+		for _, fullPath := range matches {
+			if seen[fullPath] {
+				continue
+			}
+			seen[fullPath] = true
+			files = append(files, normalizedFileEntry(baseDir, fullPath))
+		}
 	}
 	return files, nil
+}
+
+// normalizedFileEntry builds a DiscoveredFile for a normalized log file, with a
+// path expressed relative to baseDir so handleReadNormalizedEvents can re-join
+// it.
+func normalizedFileEntry(baseDir, fullPath string) DiscoveredFile {
+	filename := filepath.Base(fullPath)
+	_, protocol, agent := parseDebugFilename(filename)
+	relPath, err := filepath.Rel(baseDir, fullPath)
+	if err != nil {
+		relPath = fullPath
+	}
+	return DiscoveredFile{
+		Path:         relPath,
+		Protocol:     protocol,
+		Agent:        agent,
+		MessageCount: countLines(fullPath),
+		FileType:     "normalized",
+	}
 }
 
 // readNormalizedEventsAsMessages reads a normalized events file and returns v1.Message objects.

--- a/apps/backend/internal/debug/fixture.go
+++ b/apps/backend/internal/debug/fixture.go
@@ -355,12 +355,28 @@ func parseDebugFilename(filename string) (fileType, protocol, agent string) {
 }
 
 // splitProtocolAgent splits "{protocol}-{agent}" into protocol and agent.
+// Per-session ACP debug files append "-{sessionID}" after the agent ID. ACP
+// registry IDs consistently end in "-acp", so trim that session tail for
+// display while leaving unknown legacy shapes unchanged.
 func splitProtocolAgent(s string) (protocol, agent string) {
 	idx := strings.Index(s, "-")
 	if idx <= 0 {
 		return s, ""
 	}
-	return s[:idx], s[idx+1:]
+	protocol, agent = s[:idx], s[idx+1:]
+	if protocol == protocolACP {
+		agent = trimACPSessionTail(agent)
+	}
+	return protocol, agent
+}
+
+func trimACPSessionTail(agent string) string {
+	const acpMarker = "-acp-"
+	idx := strings.Index(agent, acpMarker)
+	if idx < 0 {
+		return agent
+	}
+	return agent[:idx+len("-acp")]
 }
 
 // parseProtocolFromFilename extracts protocol from filename patterns (legacy).

--- a/apps/backend/internal/debug/fixture_test.go
+++ b/apps/backend/internal/debug/fixture_test.go
@@ -37,8 +37,25 @@ func TestDiscoverNormalizedFiles_FindsPerSessionFiles(t *testing.T) {
 	if found.Protocol != "acp" {
 		t.Errorf("expected protocol acp, got %q", found.Protocol)
 	}
+	if found.Agent != "claude-acp" {
+		t.Errorf("expected agent claude-acp, got %q", found.Agent)
+	}
 	if found.MessageCount != 1 {
 		t.Errorf("expected 1 message, got %d", found.MessageCount)
+	}
+}
+
+func TestParseDebugFilename_TrimsPerSessionACPTail(t *testing.T) {
+	fileType, protocol, agent := parseDebugFilename("normalized-acp-opencode-acp-sess-xyz.jsonl")
+
+	if fileType != "normalized" {
+		t.Fatalf("fileType = %q, want normalized", fileType)
+	}
+	if protocol != "acp" {
+		t.Fatalf("protocol = %q, want acp", protocol)
+	}
+	if agent != "opencode-acp" {
+		t.Fatalf("agent = %q, want opencode-acp", agent)
 	}
 }
 

--- a/apps/backend/internal/debug/fixture_test.go
+++ b/apps/backend/internal/debug/fixture_test.go
@@ -1,0 +1,62 @@
+package debug
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDiscoverNormalizedFiles_FindsPerSessionFiles verifies the debug reader
+// still discovers normalized event files after they moved to the per-session
+// managed log dir (~/.kandev/logs/acp, overridable via KANDEV_DEBUG_LOG_DIR).
+func TestDiscoverNormalizedFiles_FindsPerSessionFiles(t *testing.T) {
+	logDir := t.TempDir()
+	t.Setenv("KANDEV_DEBUG_LOG_DIR", logDir)
+
+	name := "normalized-acp-claude-acp-sess-123.jsonl"
+	line := `{"ts":1,"event":{"type":"message_chunk","session_id":"sess-123","text":"hi"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(logDir, name), []byte(line), 0o644); err != nil {
+		t.Fatalf("write log file: %v", err)
+	}
+
+	files, err := discoverNormalizedFiles(t.TempDir())
+	if err != nil {
+		t.Fatalf("discoverNormalizedFiles: %v", err)
+	}
+
+	var found *DiscoveredFile
+	for i := range files {
+		if filepath.Base(files[i].Path) == name {
+			found = &files[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("per-session file %q not discovered; got %d files", name, len(files))
+	}
+	if found.Protocol != "acp" {
+		t.Errorf("expected protocol acp, got %q", found.Protocol)
+	}
+	if found.MessageCount != 1 {
+		t.Errorf("expected 1 message, got %d", found.MessageCount)
+	}
+}
+
+// TestReadNormalizedEvents_ReadsPerSessionFile end-to-ends discovery → read:
+// the file the reader discovers must also parse back into messages.
+func TestReadNormalizedEvents_ReadsPerSessionFile(t *testing.T) {
+	logDir := t.TempDir()
+	path := filepath.Join(logDir, "normalized-acp-claude-acp-sess-xyz.jsonl")
+	line := `{"ts":1,"event":{"type":"message_chunk","session_id":"sess-xyz","text":"hello"}}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	msgs, err := readNormalizedEventsAsMessages(path)
+	if err != nil {
+		t.Fatalf("readNormalizedEventsAsMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+}

--- a/apps/backend/internal/profiles/profiles.yaml
+++ b/apps/backend/internal/profiles/profiles.yaml
@@ -96,6 +96,23 @@ debug:
     dev:  "true"
     e2e:  ""
 
+  # Dump every ACP protocol frame (raw + normalized) to per-session JSONL
+  # files for offline debugging of stuck/odd sessions. Always-on in dev:
+  # the agentctl janitor caps file size (rotation), prunes by age + total
+  # count, and flushes/closes writers on shutdown, so it can't grow disk
+  # without bound. Files default to ~/.kandev/logs/acp/ (override with
+  # KANDEV_DEBUG_LOG_DIR). PRIVACY: frames carry full prompt/file/tool
+  # content — strictly local-dev; never enable in prod. When agentctl runs
+  # inside a Docker executor the files land *inside the container*, so this
+  # is meant for standalone/dev. Retention knobs (all optional):
+  #   KANDEV_DEBUG_ACP_MAX_FILES       (default 200)
+  #   KANDEV_DEBUG_ACP_RETENTION_HOURS (default 48)
+  #   KANDEV_DEBUG_ACP_MAX_FILE_BYTES  (default 8388608 = 8 MiB)
+  KANDEV_DEBUG_AGENT_MESSAGES:
+    prod: ""
+    dev:  "true"
+    e2e:  ""
+
 # ── E2E test tuning ───────────────────────────────────────────────
 # Behaviour knobs that only matter when running playwright. These
 # don't belong in dev (would mask real interactions) and never in


### PR DESCRIPTION
## Summary

`KANDEV_DEBUG_AGENT_MESSAGES` dumps ACP protocol frames to JSONL for offline debugging of stuck/odd sessions, but the original sink wasn't built for a live multi-task app: every session of an agent type interleaved into one shared file, each frame did open+write+close under a single global lock, and nothing capped or pruned the output — so it couldn't be left on. This reworks the sink into per-session files with bounded growth and automatic cleanup, then enables it by default in the dev profile.

## Important Changes

- **Per-session files** keyed by session id (`{raw,normalized}-{protocol}-{agentID}-{sessionID}.jsonl`), each with a kept-open buffered writer and a dedicated mutex — no global lock on the streaming hot path. The `raw-`/`normalized-` prefix + `.jsonl` suffix contract with the `internal/debug` reader is preserved.
- **Per-file byte-cap rotation** to non-colliding numbered siblings (probes for a free name so a restart/idle-reopen can't clobber an older segment; never truncates on a failed rename).
- **Retention janitor** with `Start(ctx)`/`Stop()` (ticker + `ctx.Done()`, no `time.Sleep`): periodic flush, closes idle writers and ring buffers, and prunes oldest-by-mtime first under an age cap and a total-file cap. A flush precedes prune and active writers are skipped, so a recently-written (still-buffered) file is never deleted mid-session.
- **Default dir** `~/.kandev/logs/acp/` (override with `KANDEV_DEBUG_LOG_DIR`); enabled in the **dev** profile. Tunable via `KANDEV_DEBUG_ACP_MAX_FILES` (200), `KANDEV_DEBUG_ACP_RETENTION_HOURS` (48), `KANDEV_DEBUG_ACP_MAX_FILE_BYTES` (8 MiB).
- **Dev-only live tail** of a stuck session from an in-memory ring buffer (zero disk growth): `GET /api/v1/debug/acp/{session}?n=200`, gated on both frame logging and dev mode.
- The debug reader (`internal/debug`) now discovers the new per-session files.

Privacy note (in code + agentctl AGENTS.md): frames carry full prompt/file/tool content, so this stays strictly behind the debug flag and local-dev-scoped; inside a Docker executor the files land in the container.

## Validation

- `make -C apps/backend fmt`
- `go build ./...` and `GOOS=windows go build ./...` (cross-platform home/path handling)
- `go vet ./...` and `golangci-lint run` — clean
- `go test ./...` — full backend suite passes (7023 tests); changed packages also run under `-race`, and the janitor goroutine is verified leak-free with `goleak` (timing via `testing/synctest`)

## Possible Improvements

Rotation and retention defaults are coarse byte/age/count caps rather than a true logrotate; a single oversized line can exceed the per-file cap (JSON lines aren't split). The ring buffer endpoint reads a process-global buffer, so it's only meaningful in standalone/dev where one agentctl process serves the sessions.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings