### PR TITLE
fix(cli): add ~/.bun/bin to service PATH

### DIFF
--- a/apps/cli/src/service/templates.test.ts
+++ b/apps/cli/src/service/templates.test.ts
@@ -51,8 +51,18 @@ describe("renderSystemdUnit", () => {
       mode: "user",
     });
     expect(unit).toMatch(
-      /^Environment=PATH=%h\/\.local\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin:\/opt\/homebrew\/bin:\/home\/linuxbrew\/\.linuxbrew\/bin$/m,
+      /^Environment=PATH=%h\/\.local\/bin:%h\/\.bun\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin:\/opt\/homebrew\/bin:\/home\/linuxbrew\/\.linuxbrew\/bin$/m,
     );
+  });
+
+  it("includes %h/.bun/bin in PATH for user-mode units so Bun-global agent CLIs (e.g. omp) resolve", () => {
+    const unit = renderSystemdUnit({
+      launcher: NPM_LAUNCHER,
+      homeDir: "/home/alice/.kandev",
+      logDir: "/home/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(unit).toContain("%h/.bun/bin");
   });
 
   it("omits %h/.local/bin from PATH for system-mode units", () => {
@@ -109,7 +119,7 @@ describe("renderSystemdUnit", () => {
       mode: "user",
     });
     expect(unit).toContain(
-      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.14.0/installation/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.14.0/installation/bin:%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
     );
   });
 
@@ -122,7 +132,7 @@ describe("renderSystemdUnit", () => {
     });
     // /usr/local/bin already in SYSTEMD_USER_PATH — dirname(nodePath) must not double it.
     expect(unit).toContain(
-      "Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+      "Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
     );
     expect(unit).not.toContain("/usr/local/bin:/usr/local/bin");
   });
@@ -156,7 +166,7 @@ describe("renderSystemdUnit", () => {
     });
     expect(unit).not.toMatch(/^Environment=PATH=\.:/m);
     expect(unit).toContain(
-      "Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+      "Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
     );
   });
 
@@ -207,7 +217,7 @@ describe("renderLaunchdPlist", () => {
       mode: "user",
     });
     expect(plist).toMatch(
-      /<key>PATH<\/key>\s*<string>\/Users\/alice\/\.volta\/tools\/image\/node\/24\.14\.0\/bin:[^<]+\/\.local\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
+      /<key>PATH<\/key>\s*<string>\/Users\/alice\/\.volta\/tools\/image\/node\/24\.14\.0\/bin:[^<]+\/\.local\/bin:[^<]+\/\.bun\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
     );
   });
 
@@ -220,7 +230,7 @@ describe("renderLaunchdPlist", () => {
     });
     // /opt/homebrew/bin already in LAUNCHD_USER_PATH — must not be doubled.
     expect(plist).toMatch(
-      /<key>PATH<\/key>\s*<string>[^<]+\/\.local\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
+      /<key>PATH<\/key>\s*<string>[^<]+\/\.local\/bin:[^<]+\/\.bun\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
     );
     expect(plist).not.toContain("/opt/homebrew/bin:/opt/homebrew/bin");
   });
@@ -233,8 +243,18 @@ describe("renderLaunchdPlist", () => {
       mode: "user",
     });
     expect(plist).toMatch(
-      /<key>PATH<\/key>\s*<string>[^<]+\/\.local\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
+      /<key>PATH<\/key>\s*<string>[^<]+\/\.local\/bin:[^<]+\/\.bun\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
     );
+  });
+
+  it("includes $HOME/.bun/bin in PATH for user-mode plists so Bun-global agent CLIs (e.g. omp) resolve", () => {
+    const plist = renderLaunchdPlist({
+      launcher: NPM_LAUNCHER,
+      homeDir: "/Users/alice/.kandev",
+      logDir: "/Users/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(plist).toMatch(/<key>PATH<\/key>\s*<string>[^<]*\/\.bun\/bin:/);
   });
 
   it("prepends node bin dir for system-mode LaunchDaemons too", () => {
@@ -281,7 +301,7 @@ describe("renderLaunchdPlist", () => {
     });
     expect(plist).not.toMatch(/<key>PATH<\/key>\s*<string>\.:/);
     expect(plist).toMatch(
-      /<key>PATH<\/key>\s*<string>[^<]+\/\.local\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
+      /<key>PATH<\/key>\s*<string>[^<]+\/\.local\/bin:[^<]+\/\.bun\/bin:\/opt\/homebrew\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin<\/string>/,
     );
   });
 
@@ -322,7 +342,7 @@ describe("renderLaunchdPlist", () => {
     // The whole assignment must be wrapped, not just the value.
     expect(unit).toContain('Environment="KANDEV_HOME_DIR=/home/john doe/.kandev"');
     // PATH always contains colons but no spaces — should NOT be quoted.
-    expect(unit).toMatch(/^Environment=PATH=%h\/\.local\/bin:\/usr\/local\/bin/m);
+    expect(unit).toMatch(/^Environment=PATH=%h\/\.local\/bin:%h\/\.bun\/bin:\/usr\/local\/bin/m);
   });
 
   it("escapes backslash + double-quote in Environment= and ExecStart values", () => {

--- a/apps/cli/src/service/templates.ts
+++ b/apps/cli/src/service/templates.ts
@@ -19,13 +19,15 @@ export type UnitInputs = {
   mode: "user" | "system";
 };
 
-// User-mode PATH includes ~/.local/bin so user-installed agent CLIs (npm user
-// prefix, pipx, fnm, etc.) are discoverable.
+// User-mode PATH includes ~/.local/bin and ~/.bun/bin so user-installed agent
+// CLIs (npm user prefix, pipx, fnm, Bun globals like oh-my-pi/omp, etc.) are
+// discoverable.
 const SYSTEMD_SYSTEM_PATH =
   "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin";
-const SYSTEMD_USER_PATH = `%h/.local/bin:${SYSTEMD_SYSTEM_PATH}`;
+const SYSTEMD_USER_PATH = `%h/.local/bin:%h/.bun/bin:${SYSTEMD_SYSTEM_PATH}`;
 const LAUNCHD_SYSTEM_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
-const launchdUserPath = (): string => `${os.homedir()}/.local/bin:${LAUNCHD_SYSTEM_PATH}`;
+const launchdUserPath = (): string =>
+  `${os.homedir()}/.local/bin:${os.homedir()}/.bun/bin:${LAUNCHD_SYSTEM_PATH}`;
 
 // Prepend the launcher node's bin dir so `npm`/`npx` resolve under per-user
 // node managers (fnm, nvm, asdf, volta, mise), where node lives in a versioned


### PR DESCRIPTION
## Problem

`kandev service install` generates a service unit (launchd plist / systemd unit) whose PATH omits `~/.bun/bin`. Agent CLIs installed as Bun globals (e.g. `omp` / oh-my-pi at `~/.bun/bin/omp`) are therefore invisible to the headless service and probe as `capability_status: "not_installed"`. They work fine from an interactive shell, which makes this confusing to diagnose. npx-based ACP agents (claude, codex, opencode, cursor) are unaffected because they resolve through the prepended Node bin dir.

## Root cause

The user-mode PATH constants in `apps/cli/src/service/templates.ts` omit Bun's global bin dir:
- launchd: `launchdUserPath()` → `~/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`
- systemd: `SYSTEMD_USER_PATH` → `%h/.local/bin:` + system path

The existing comment already documents the intent ("so user-installed agent CLIs … are discoverable") — Bun's global bin dir was the missing member of that set.

## Fix

Add `~/.bun/bin` to the user-mode PATH on both platforms, alongside `~/.local/bin`:
- launchd: `${os.homedir()}/.bun/bin`
- systemd: `%h/.bun/bin`

Updated the intent comment and extended the unit tests to assert the generated PATH contains `.bun/bin` on both platforms.

## Testing

- `pnpm test src/service/templates.test.ts` — 26 passed
- `tsc -p tsconfig.json --noEmit` — clean
- `prettier --check` — clean

Closes #1167