### PR TITLE
feat(mcp): expose workflow import tool

### DIFF
--- a/apps/backend/config/prompts/config-context.md
+++ b/apps/backend/config/prompts/config-context.md
@@ -10,6 +10,7 @@ WORKFLOW TOOLS:
 - create_workflow_kandev: Create a new workflow. Required: workspace_id, name. Optional: description.
 - update_workflow_kandev: Update a workflow. Required: workflow_id. Optional: name, description.
 - delete_workflow_kandev: Delete a workflow and all its steps (destructive). Required: workflow_id.
+- import_workflow_kandev: Import one or more workflows into a workspace from a portable document (the kandev_workflow YAML/JSON export envelope). Workflows whose name already exists are skipped. Required: workspace_id, document. Returns the created and skipped workflow names.
 - list_workflow_steps_kandev: List workflow steps (columns) in a workflow. Required: workflow_id.
 - create_workflow_step_kandev: Create a new workflow step. Required: workflow_id, name. Optional: position, color, prompt, is_start_step, allow_manual_move, show_in_command_panel, events.
 - update_workflow_step_kandev: Update a workflow step. Required: step_id. Optional: name, color, prompt, is_start_step, allow_manual_move, show_in_command_panel, auto_archive_after_hours, events.

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
@@ -11,6 +11,7 @@ import (
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	ws "github.com/kandev/kandev/pkg/websocket"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 func (h *Handlers) handleCreateWorkflow(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
@@ -79,6 +80,44 @@ func (h *Handlers) handleDeleteWorkflow(ctx context.Context, msg *ws.Message) (*
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to delete workflow", nil)
 	}
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{"success": true})
+}
+
+// handleImportWorkflow imports one or more workflows into a workspace from a
+// portable document. The document is the same YAML/JSON envelope produced by
+// the export endpoint; YAML parsing accepts JSON too, matching the HTTP
+// /workspaces/{id}/workflows/import contract.
+func (h *Handlers) handleImportWorkflow(ctx context.Context, msg *ws.Message) (*ws.Message, error) {
+	var req struct {
+		WorkspaceID string `json:"workspace_id"`
+		Document    string `json:"document"`
+	}
+	if err := json.Unmarshal(msg.Payload, &req); err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid payload: "+err.Error(), nil)
+	}
+	if req.WorkspaceID == "" {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "workspace_id is required", nil)
+	}
+	if req.Document == "" {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "document is required", nil)
+	}
+	// Mirror the 1 MB cap the HTTP import endpoint enforces — the WS tunnel
+	// permits much larger frames, so bound the document before parsing it.
+	const maxImportSize = 1 << 20
+	if len(req.Document) > maxImportSize {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "document exceeds 1MB limit", nil)
+	}
+
+	var export wfmodels.WorkflowExport
+	if err := yaml.Unmarshal([]byte(req.Document), &export); err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid document: "+err.Error(), nil)
+	}
+
+	result, err := h.workflowSvc.ImportWorkflows(ctx, req.WorkspaceID, &export)
+	if err != nil {
+		h.logger.Error("failed to import workflows", zap.Error(err))
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Failed to import workflows: "+err.Error(), nil)
+	}
+	return ws.NewResponse(msg.ID, msg.Action, result)
 }
 
 func (h *Handlers) handleCreateWorkflowStep(ctx context.Context, msg *ws.Message) (*ws.Message, error) {

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
@@ -111,11 +111,20 @@ func (h *Handlers) handleImportWorkflow(ctx context.Context, msg *ws.Message) (*
 	if err := yaml.Unmarshal([]byte(req.Document), &export); err != nil {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Invalid document: "+err.Error(), nil)
 	}
+	// Validate the document up front: a malformed envelope (wrong type/version,
+	// missing names, duplicate positions, bad move_to_step refs) is a client
+	// error, and surfacing the detail is what lets the calling agent fix its
+	// document. Past this point any ImportWorkflows error is a server-side DB
+	// failure, so it gets a generic internal error without leaking internals —
+	// matching the sibling workflow handlers.
+	if err := export.Validate(); err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Invalid workflow document: "+err.Error(), nil)
+	}
 
 	result, err := h.workflowSvc.ImportWorkflows(ctx, req.WorkspaceID, &export)
 	if err != nil {
 		h.logger.Error("failed to import workflows", zap.Error(err))
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "Failed to import workflows: "+err.Error(), nil)
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to import workflows", nil)
 	}
 	return ws.NewResponse(msg.ID, msg.Action, result)
 }

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
@@ -1,0 +1,244 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	taskmodels "github.com/kandev/kandev/internal/task/models"
+	workflowsvc "github.com/kandev/kandev/internal/workflow/service"
+
+	"github.com/kandev/kandev/internal/workflow/repository"
+	ws "github.com/kandev/kandev/pkg/websocket"
+)
+
+// memWorkflowProvider is a minimal in-memory WorkflowProvider for import tests.
+// The canonical mock lives in the workflow/service test package, which can't be
+// imported here, so we keep a tiny local copy covering only the methods the
+// import path uses.
+type memWorkflowProvider struct {
+	workflows []*taskmodels.Workflow
+}
+
+func (m *memWorkflowProvider) ListWorkflows(_ context.Context, workspaceID string, _ bool) ([]*taskmodels.Workflow, error) {
+	var result []*taskmodels.Workflow
+	for _, wf := range m.workflows {
+		if wf.WorkspaceID == workspaceID {
+			result = append(result, wf)
+		}
+	}
+	return result, nil
+}
+
+func (m *memWorkflowProvider) GetWorkflow(_ context.Context, id string) (*taskmodels.Workflow, error) {
+	for _, wf := range m.workflows {
+		if wf.ID == id {
+			return wf, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (m *memWorkflowProvider) CreateWorkflow(_ context.Context, workspaceID, name, description string) (*taskmodels.Workflow, error) {
+	now := time.Now().UTC()
+	wf := &taskmodels.Workflow{
+		ID:          "wf-" + name,
+		WorkspaceID: workspaceID,
+		Name:        name,
+		Description: description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	m.workflows = append(m.workflows, wf)
+	return wf, nil
+}
+
+func (m *memWorkflowProvider) UpdateWorkflow(_ context.Context, workflow *taskmodels.Workflow) error {
+	for i, wf := range m.workflows {
+		if wf.ID == workflow.ID {
+			m.workflows[i] = workflow
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+// setupImportHandlers wires a Handlers value backed by an in-memory workflow
+// service so handleImportWorkflow can persist for real.
+func setupImportHandlers(t *testing.T) (*Handlers, *memWorkflowProvider, *repository.Repository) {
+	t.Helper()
+	rawDB, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	db := sqlx.NewDb(rawDB, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+
+	// workflows table is normally owned by the task repo; create it for the test.
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS workflows (
+		id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL DEFAULT '',
+		workflow_template_id TEXT DEFAULT '', name TEXT NOT NULL,
+		description TEXT DEFAULT '', created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL
+	)`)
+	require.NoError(t, err)
+
+	repo, err := repository.NewWithDB(db, db, nil)
+	require.NoError(t, err)
+
+	svc := workflowsvc.NewService(repo, testLogger(t))
+	provider := &memWorkflowProvider{}
+	svc.SetWorkflowProvider(provider)
+
+	h := &Handlers{workflowSvc: svc, logger: testLogger(t).WithFields()}
+	return h, provider, repo
+}
+
+func TestHandleImportWorkflow_PersistsWorkflow(t *testing.T) {
+	h, provider, repo := setupImportHandlers(t)
+
+	doc := `version: 1
+type: kandev_workflow
+workflows:
+  - name: Sprint Board
+    description: A sprint workflow
+    steps:
+      - name: Todo
+        position: 0
+        color: "#3b82f6"
+        is_start_step: true
+      - name: Done
+        position: 1
+        color: "#22c55e"
+`
+	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
+		"workspace_id": "ws-1",
+		"document":     doc,
+	})
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	var result workflowsvc.ImportResult
+	require.NoError(t, json.Unmarshal(resp.Payload, &result))
+	assert.Equal(t, []string{"Sprint Board"}, result.Created)
+	assert.Empty(t, result.Skipped)
+
+	// The workflow row was created via the provider.
+	require.Len(t, provider.workflows, 1)
+	created := provider.workflows[0]
+	assert.Equal(t, "Sprint Board", created.Name)
+	assert.Equal(t, "ws-1", created.WorkspaceID)
+
+	// Its steps were persisted to the repository.
+	steps, err := repo.ListStepsByWorkflow(context.Background(), created.ID)
+	require.NoError(t, err)
+	require.Len(t, steps, 2)
+	assert.Equal(t, "Todo", steps[0].Name)
+	assert.True(t, steps[0].IsStartStep)
+	assert.Equal(t, "Done", steps[1].Name)
+}
+
+func TestHandleImportWorkflow_SkipsDuplicateName(t *testing.T) {
+	h, provider, _ := setupImportHandlers(t)
+	provider.workflows = append(provider.workflows, &taskmodels.Workflow{
+		ID: "wf-existing", WorkspaceID: "ws-1", Name: "Sprint Board",
+	})
+
+	doc := "version: 1\ntype: kandev_workflow\nworkflows:\n  - name: Sprint Board\n    steps: []\n"
+	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
+		"workspace_id": "ws-1",
+		"document":     doc,
+	})
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	var result workflowsvc.ImportResult
+	require.NoError(t, json.Unmarshal(resp.Payload, &result))
+	assert.Empty(t, result.Created)
+	assert.Equal(t, []string{"Sprint Board"}, result.Skipped)
+}
+
+func TestHandleImportWorkflow_MissingWorkspaceID(t *testing.T) {
+	h := &Handlers{}
+	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
+		"document": "version: 1",
+	})
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeValidation)
+}
+
+func TestHandleImportWorkflow_MissingDocument(t *testing.T) {
+	h := &Handlers{}
+	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
+		"workspace_id": "ws-1",
+	})
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeValidation)
+}
+
+func TestHandleImportWorkflow_InvalidPayload(t *testing.T) {
+	h := &Handlers{}
+	msg := &ws.Message{
+		ID:      "test-id",
+		Type:    ws.MessageTypeRequest,
+		Action:  ws.ActionMCPImportWorkflow,
+		Payload: json.RawMessage(`not json`),
+	}
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeBadRequest)
+}
+
+func TestHandleImportWorkflow_DocumentTooLarge(t *testing.T) {
+	h := &Handlers{}
+	big := make([]byte, (1<<20)+1)
+	for i := range big {
+		big[i] = 'a'
+	}
+	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
+		"workspace_id": "ws-1",
+		"document":     string(big),
+	})
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeBadRequest)
+}
+
+func TestHandleImportWorkflow_InvalidDocument(t *testing.T) {
+	h, _, _ := setupImportHandlers(t)
+	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
+		"workspace_id": "ws-1",
+		"document":     "version: 1\ntype: kandev_workflow\nworkflows: [oops",
+	})
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeBadRequest)
+}
+
+func TestHandleImportWorkflow_ValidationError(t *testing.T) {
+	h, _, _ := setupImportHandlers(t)
+	// Wrong export type fails WorkflowExport.Validate inside the service.
+	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
+		"workspace_id": "ws-1",
+		"document":     "version: 1\ntype: not_kandev\nworkflows:\n  - name: X\n    steps: []\n",
+	})
+
+	resp, err := h.handleImportWorkflow(context.Background(), msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeBadRequest)
+}

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
@@ -76,6 +76,10 @@ func setupImportHandlers(t *testing.T) (*Handlers, *memWorkflowProvider, *reposi
 	t.Helper()
 	rawDB, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)
+	// Pin the pool to a single connection: each new connection to an in-memory
+	// SQLite DB gets its own isolated database, so a second pooled connection
+	// would not see the schema created on the first, causing flaky failures.
+	rawDB.SetMaxOpenConns(1)
 	db := sqlx.NewDb(rawDB, "sqlite3")
 	t.Cleanup(func() { _ = db.Close() })
 
@@ -232,7 +236,8 @@ func TestHandleImportWorkflow_InvalidDocument(t *testing.T) {
 
 func TestHandleImportWorkflow_ValidationError(t *testing.T) {
 	h, _, _ := setupImportHandlers(t)
-	// Wrong export type fails WorkflowExport.Validate inside the service.
+	// Wrong export type fails WorkflowExport.Validate — a client-side error
+	// surfaced as a validation error so the agent can correct its document.
 	msg := makeWSMessage(t, ws.ActionMCPImportWorkflow, map[string]interface{}{
 		"workspace_id": "ws-1",
 		"document":     "version: 1\ntype: not_kandev\nworkflows:\n  - name: X\n    steps: []\n",
@@ -240,5 +245,5 @@ func TestHandleImportWorkflow_ValidationError(t *testing.T) {
 
 	resp, err := h.handleImportWorkflow(context.Background(), msg)
 	require.NoError(t, err)
-	assertWSError(t, resp, ws.ErrorCodeBadRequest)
+	assertWSError(t, resp, ws.ErrorCodeValidation)
 }

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -169,11 +169,12 @@ func (h *Handlers) RegisterHandlers(d *ws.Dispatcher) {
 		d.RegisterFunc(ws.ActionMCPCreateWorkflow, h.handleCreateWorkflow)
 		d.RegisterFunc(ws.ActionMCPUpdateWorkflow, h.handleUpdateWorkflow)
 		d.RegisterFunc(ws.ActionMCPDeleteWorkflow, h.handleDeleteWorkflow)
+		d.RegisterFunc(ws.ActionMCPImportWorkflow, h.handleImportWorkflow)
 		d.RegisterFunc(ws.ActionMCPCreateWorkflowStep, h.handleCreateWorkflowStep)
 		d.RegisterFunc(ws.ActionMCPUpdateWorkflowStep, h.handleUpdateWorkflowStep)
 		d.RegisterFunc(ws.ActionMCPDeleteWorkflowStep, h.handleDeleteWorkflowStep)
 		d.RegisterFunc(ws.ActionMCPReorderWorkflowStep, h.handleReorderWorkflowSteps)
-		count += 7
+		count += 8
 	}
 	if h.agentSettingsCtrl != nil {
 		d.RegisterFunc(ws.ActionMCPListAgents, h.handleListAgents)

--- a/apps/backend/internal/mcp/server/config_handlers.go
+++ b/apps/backend/internal/mcp/server/config_handlers.go
@@ -58,6 +58,14 @@ func (s *Server) registerConfigWorkflowTools() {
 		),
 		s.wrapHandler("delete_workflow_kandev", s.deleteWorkflowHandler()),
 	)
+	s.mcpServer.AddTool(
+		mcp.NewTool("import_workflow_kandev",
+			mcp.WithDescription("Import one or more workflows into a workspace from a portable document. The document is the same YAML/JSON envelope produced by the workflow export (type: kandev_workflow, version: 1) and may contain multiple workflows. Workflows whose name already exists in the workspace are skipped. Returns the names that were created and skipped."),
+			mcp.WithString("workspace_id", mcp.Required(), mcp.Description("The workspace ID to import the workflows into")),
+			mcp.WithString(documentArg, mcp.Required(), mcp.Description("The portable workflow document as a YAML or JSON string (a kandev_workflow export envelope). Includes the workflows and their steps.")),
+		),
+		s.wrapHandler("import_workflow_kandev", s.importWorkflowHandler()),
+	)
 	s.registerConfigWorkflowStepTools()
 }
 
@@ -347,6 +355,24 @@ func (s *Server) deleteWorkflowHandler() server.ToolHandlerFunc {
 			return mcp.NewToolResultError("workflow_id is required"), nil
 		}
 		return s.forwardToBackend(ctx, ws.ActionMCPDeleteWorkflow, map[string]string{"workflow_id": workflowID})
+	}
+}
+
+func (s *Server) importWorkflowHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		workspaceID, err := req.RequireString("workspace_id")
+		if err != nil {
+			return mcp.NewToolResultError("workspace_id is required"), nil
+		}
+		document, err := req.RequireString(documentArg)
+		if err != nil {
+			return mcp.NewToolResultError("document is required"), nil
+		}
+		payload := map[string]interface{}{
+			"workspace_id": workspaceID,
+			documentArg:    document,
+		}
+		return s.forwardToBackend(ctx, ws.ActionMCPImportWorkflow, payload)
 	}
 }
 

--- a/apps/backend/internal/mcp/server/config_handlers_test.go
+++ b/apps/backend/internal/mcp/server/config_handlers_test.go
@@ -68,6 +68,7 @@ func TestActionConstants_MatchWebSocketActions(t *testing.T) {
 	assert.Equal(t, "mcp.create_workflow", ws.ActionMCPCreateWorkflow)
 	assert.Equal(t, "mcp.update_workflow", ws.ActionMCPUpdateWorkflow)
 	assert.Equal(t, "mcp.delete_workflow", ws.ActionMCPDeleteWorkflow)
+	assert.Equal(t, "mcp.import_workflow", ws.ActionMCPImportWorkflow)
 	assert.Equal(t, "mcp.create_workflow_step", ws.ActionMCPCreateWorkflowStep)
 	assert.Equal(t, "mcp.update_workflow_step", ws.ActionMCPUpdateWorkflowStep)
 	assert.Equal(t, "mcp.delete_workflow_step", ws.ActionMCPDeleteWorkflowStep)
@@ -182,6 +183,48 @@ func TestDeleteWorkflowHandler_MissingWorkflowID(t *testing.T) {
 	s := newTestServer(t, backend)
 
 	result := callTool(t, s, "delete_workflow_kandev", map[string]interface{}{})
+
+	assert.True(t, result.IsError)
+}
+
+func TestImportWorkflowHandler_Success(t *testing.T) {
+	backend := &testBackend{
+		response: map[string]interface{}{"created": []interface{}{"Sprint Board"}, "skipped": []interface{}{}},
+	}
+	s := newTestServer(t, backend)
+
+	doc := "version: 1\ntype: kandev_workflow\nworkflows:\n  - name: Sprint Board\n    steps: []\n"
+	result := callTool(t, s, "import_workflow_kandev", map[string]interface{}{
+		"workspace_id": "ws-123",
+		"document":     doc,
+	})
+
+	assert.False(t, result.IsError)
+	assert.Equal(t, ws.ActionMCPImportWorkflow, backend.lastAction)
+	payload, ok := backend.lastPayload.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "ws-123", payload["workspace_id"])
+	assert.Equal(t, doc, payload["document"])
+}
+
+func TestImportWorkflowHandler_MissingWorkspaceID(t *testing.T) {
+	backend := &testBackend{}
+	s := newTestServer(t, backend)
+
+	result := callTool(t, s, "import_workflow_kandev", map[string]interface{}{
+		"document": "version: 1",
+	})
+
+	assert.True(t, result.IsError)
+}
+
+func TestImportWorkflowHandler_MissingDocument(t *testing.T) {
+	backend := &testBackend{}
+	s := newTestServer(t, backend)
+
+	result := callTool(t, s, "import_workflow_kandev", map[string]interface{}{
+		"workspace_id": "ws-123",
+	})
 
 	assert.True(t, result.IsError)
 }

--- a/apps/backend/internal/mcp/server/handlers.go
+++ b/apps/backend/internal/mcp/server/handlers.go
@@ -25,6 +25,7 @@ const (
 	questionIDFieldKey = "question_id"
 	answeredFieldKey   = "answered"
 	rejectedFieldKey   = "rejected"
+	documentArg        = "document"
 )
 
 func (s *Server) listWorkspacesHandler() server.ToolHandlerFunc {

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -279,7 +279,7 @@ func (s *Server) registerTools() {
 	switch s.mode {
 	case ModeConfig:
 		s.registerConfigWorkflowTools()
-		count += 11
+		count += 12
 		s.registerConfigAgentTools()
 		count += 4
 		s.registerConfigMcpTools()
@@ -297,7 +297,7 @@ func (s *Server) registerTools() {
 		// they can both manage Kandev configuration and spawn new tasks.
 		// No interaction or plan tools (no live session to attach them to).
 		s.registerConfigWorkflowTools()
-		count += 11
+		count += 12
 		s.registerConfigAgentTools()
 		count += 4
 		s.registerConfigMcpTools()

--- a/apps/backend/internal/mcp/server/server_test.go
+++ b/apps/backend/internal/mcp/server/server_test.go
@@ -107,6 +107,7 @@ func TestServerModeConfig_RegistersCorrectTools(t *testing.T) {
 	assert.Contains(t, tools, "create_workflow_kandev")
 	assert.Contains(t, tools, "update_workflow_kandev")
 	assert.Contains(t, tools, "delete_workflow_kandev")
+	assert.Contains(t, tools, "import_workflow_kandev")
 	assert.Contains(t, tools, "list_workflow_steps_kandev")
 	assert.Contains(t, tools, "create_workflow_step_kandev")
 	assert.Contains(t, tools, "update_workflow_step_kandev")
@@ -216,8 +217,8 @@ func TestServerModeConfig_ToolCount(t *testing.T) {
 
 	s := New(backend, "test-session", "test-task", 10005, log, "", false, ModeConfig)
 	tools := getRegisteredToolNames(s)
-	// 11 workflow (incl. list_repositories) + 4 agent + 4 mcp + 5 executor + 6 task + 1 interaction = 31
-	assert.Equal(t, 31, len(tools))
+	// 12 workflow (incl. list_repositories + import_workflow) + 4 agent + 4 mcp + 5 executor + 6 task + 1 interaction = 32
+	assert.Equal(t, 32, len(tools))
 }
 
 func TestServerModeConfig_ToolDescriptions(t *testing.T) {
@@ -360,8 +361,8 @@ func TestServerModeExternal_ToolCount(t *testing.T) {
 
 	s := New(backend, "", "", 0, log, "", true, ModeExternal)
 	tools := getRegisteredToolNames(s)
-	// 11 workflow (incl. list_repositories) + 4 agent + 4 mcp + 5 executor + 6 task + 1 create_task = 31
-	assert.Equal(t, 31, len(tools))
+	// 12 workflow (incl. list_repositories + import_workflow) + 4 agent + 4 mcp + 5 executor + 6 task + 1 create_task = 32
+	assert.Equal(t, 32, len(tools))
 }
 
 func TestNewExternal_Constructs(t *testing.T) {

--- a/apps/backend/pkg/websocket/actions.go
+++ b/apps/backend/pkg/websocket/actions.go
@@ -340,6 +340,7 @@ const (
 	ActionMCPCreateWorkflow = "mcp.create_workflow"
 	ActionMCPUpdateWorkflow = "mcp.update_workflow"
 	ActionMCPDeleteWorkflow = "mcp.delete_workflow"
+	ActionMCPImportWorkflow = "mcp.import_workflow"
 
 	ActionMCPCreateWorkflowStep  = "mcp.create_workflow_step"
 	ActionMCPUpdateWorkflowStep  = "mcp.update_workflow_step"


### PR DESCRIPTION
## Summary

Adds an `import_workflow_kandev` MCP tool so agents can provision workflows programmatically over MCP — previously the MCP surface could only list workflows and create tasks, with no way to create/import a workflow.

The tool wraps the existing `ImportWorkflows` service (`internal/workflow/service`) and accepts:
- `workspace_id` — target workspace
- `document` — the portable workflow envelope as a YAML **or** JSON string (the same `kandev_workflow` v1 format produced by export, may contain multiple workflows)

It returns the created and skipped workflow names (workflows whose name already exists in the workspace are skipped). This mirrors the HTTP `POST /api/v1/workspaces/{id}/workflows/import` endpoint exactly, including the YAML parse (YAML is a JSON superset) and the 1 MB document cap.

## Changes
- **`pkg/websocket/actions.go`** — new `ActionMCPImportWorkflow = "mcp.import_workflow"`.
- **`internal/mcp/server/config_handlers.go`** — register `import_workflow_kandev` (config + external modes) + `importWorkflowHandler` forwarding `{workspace_id, document}`.
- **`internal/mcp/server/server.go` / `handlers.go`** — tool counts bumped; shared `documentArg` const (goconst).
- **`internal/mcp/handlers/config_workflow_handlers.go`** — backend `handleImportWorkflow`: parses the document, enforces the 1 MB cap, calls `workflowSvc.ImportWorkflows`. Registered only in config mode (when `workflowSvc` is wired).
- **`config/prompts/config-context.md`** — document the new tool.

## Tests
- Server layer: success forwarding (asserts action + payload), missing `workspace_id`, missing `document`.
- Backend handler: real persistence (in-memory service + repo asserts the workflow and its steps land in the DB), duplicate-name skip, missing args, invalid payload, invalid YAML, `WorkflowExport.Validate` error path, and the 1 MB size cap.

`make`-equivalent checks run on the affected packages: `go build ./...`, `go test ./internal/mcp/... ./internal/workflow/... ./pkg/websocket/...`, and `golangci-lint run ./internal/mcp/...` all pass.

## Notes
- Return shape is `{created, skipped}` **names** rather than IDs — this matches the existing `ImportWorkflows` service / HTTP contract; surfacing IDs would require a service-signature change out of scope here.

## Related
- #1109 (trigger-dropping bug in this import/export path) and #1111 (portable YAML format docs) — coordinated but independent.

Closes #1112