### PR TITLE
feat(mcp): expose task delete and archive tools to kanban agents

### DIFF
--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -333,7 +333,7 @@ func (s *Server) registerTools() {
 		// a sibling to message_task_kandev) but NOT the task-document
 		// tools — those are office coordination plumbing.
 		s.registerKanbanTools()
-		count += 11
+		count += 13
 		if !s.disableAskQuestion {
 			s.registerInteractionTools()
 			count++
@@ -417,6 +417,20 @@ func (s *Server) registerKanbanTools() {
 			mcp.WithString("prompt", mcp.Description("Optional hand-off message for the receiving agent. When supplied AND the source session is mid-turn, the move is deferred to the agent's turn-end and the prompt is delivered at the new step (concatenated after the step's own auto_start prompt, if any). Omit for plain admin/config moves where there's no agent to address.")),
 		),
 		s.wrapHandler("move_task_kandev", s.moveTaskHandler()),
+	)
+	s.mcpServer.AddTool(
+		mcp.NewTool("delete_task_kandev",
+			mcp.WithDescription("Delete a task permanently. Use to clean up orphaned, duplicate, or test tasks you no longer need. This cannot be undone — prefer archive_task_kandev when the task may still be wanted. Restoring an archived task is a user action done from the UI, not via MCP."),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to delete")),
+		),
+		s.wrapHandler("delete_task_kandev", s.deleteTaskHandler()),
+	)
+	s.mcpServer.AddTool(
+		mcp.NewTool("archive_task_kandev",
+			mcp.WithDescription("Archive a task. The task is hidden from active board views but kept in the database. Use to tidy up finished or abandoned tasks. Unarchiving is a user action done from the UI, not via MCP."),
+			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID to archive")),
+		),
+		s.wrapHandler("archive_task_kandev", s.archiveTaskHandler()),
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("message_task_kandev",

--- a/apps/backend/internal/mcp/server/server_test.go
+++ b/apps/backend/internal/mcp/server/server_test.go
@@ -66,6 +66,13 @@ func TestServerModeTask_RegistersCorrectTools(t *testing.T) {
 	assert.NotContains(t, tools, "get_task_document_kandev")
 	assert.NotContains(t, tools, "write_task_document_kandev")
 
+	// Task mode exposes delete + archive so agents can clean up the tasks
+	// they fan out. Restore/unarchive is intentionally NOT exposed via MCP —
+	// it stays a user action in the UI.
+	assert.Contains(t, tools, "delete_task_kandev")
+	assert.Contains(t, tools, "archive_task_kandev")
+	assert.NotContains(t, tools, "restore_task_kandev")
+
 	// Task mode should NOT have config/mutation tools
 	assert.NotContains(t, tools, "create_workflow_kandev")
 	assert.NotContains(t, tools, "update_workflow_kandev")
@@ -79,8 +86,6 @@ func TestServerModeTask_RegistersCorrectTools(t *testing.T) {
 	assert.NotContains(t, tools, "update_agent_profile_kandev")
 	assert.NotContains(t, tools, "get_mcp_config_kandev")
 	assert.NotContains(t, tools, "update_mcp_config_kandev")
-	assert.NotContains(t, tools, "delete_task_kandev")
-	assert.NotContains(t, tools, "archive_task_kandev")
 	assert.NotContains(t, tools, "list_executors_kandev")
 	assert.NotContains(t, tools, "create_executor_profile_kandev")
 	assert.NotContains(t, tools, "update_executor_profile_kandev")
@@ -205,9 +210,9 @@ func TestServerModeTask_ToolCount(t *testing.T) {
 
 	s := New(backend, "test-session", "test-task", 10005, log, "", false, ModeTask)
 	tools := getRegisteredToolNames(s)
-	// 11 kanban + 1 interaction + 4 plan + 1 related-tasks = 17.
-	// Task-document tools (list/get/write) are office-only.
-	assert.Equal(t, 17, len(tools))
+	// 13 kanban (incl. delete + archive task) + 1 interaction + 4 plan
+	// + 1 related-tasks = 19. Task-document tools (list/get/write) are office-only.
+	assert.Equal(t, 19, len(tools))
 }
 
 func TestServerModeConfig_ToolCount(t *testing.T) {


### PR DESCRIPTION
## Summary

MCP agents could create/update/move/list tasks but had no way to clean up the tasks they fan out (orphaned, duplicate, or test tasks). This exposes **delete** and **archive** in the default kanban (task) MCP mode.

## What changed

- **`registerKanbanTools`** now registers `delete_task_kandev` and `archive_task_kandev`. Both reuse the **existing** server handlers (`deleteTaskHandler`/`archiveTaskHandler`) and backend dispatcher actions (`handleDeleteTask` → `Service.DeleteTask`, `handleArchiveTask` → `Service.ArchiveTask`) that config mode already used — the only thing missing was the task-mode registration. No backend, service, repository, or new-action changes.
- Updated the task-mode tool count (17 → 19) and registration assertions.

## Scope decision: no restore via MCP

The original issue mentioned a `restore` tool, but **restore/unarchive is intentionally not exposed over MCP**. Archiving is a reasonable cleanup action for an agent to take; bringing an archived task back onto the board is a deliberate user action that stays in the UI. The tool descriptions say so explicitly, and a test asserts `restore_task_kandev` is absent from task mode.

## Tests

`go test ./internal/mcp/...` passes (200 tests); `golangci-lint` and `go build ./...` clean. Task-mode registration test asserts delete + archive are present and restore is absent.

Closes #1134