### PR TITLE
fix(cli): generate brew-upgrade-resilient systemd unit

### DIFF
--- a/apps/cli/src/service/paths.test.ts
+++ b/apps/cli/src/service/paths.test.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { resolveHomeDir, resolveServiceUser } from "./paths";
+import { homebrewShimPath, resolveHomeDir, resolveServiceUser } from "./paths";
 
 describe("resolveServiceUser", () => {
   const originalSudoUser = process.env.SUDO_USER;
@@ -100,5 +100,23 @@ describe("resolveHomeDir", () => {
     // time. We just check it ends with .kandev and starts with the home dir.
     const result = resolveHomeDir(undefined, false);
     expect(result.endsWith(".kandev")).toBe(true);
+  });
+});
+
+describe("homebrewShimPath", () => {
+  it("derives the floating bin shim from a linuxbrew Cellar cli.js path", () => {
+    expect(
+      homebrewShimPath("/home/linuxbrew/.linuxbrew/Cellar/kandev/0.52.0/libexec/cli/bin/cli.js"),
+    ).toBe("/home/linuxbrew/.linuxbrew/bin/kandev");
+  });
+
+  it("derives the floating bin shim from an Apple-silicon Cellar path", () => {
+    expect(homebrewShimPath("/opt/homebrew/Cellar/kandev/1.2.3/libexec/cli/bin/cli.js")).toBe(
+      "/opt/homebrew/bin/kandev",
+    );
+  });
+
+  it("returns undefined for a non-Cellar path (npm install)", () => {
+    expect(homebrewShimPath("/usr/local/lib/node_modules/kandev/bin/cli.js")).toBeUndefined();
   });
 });

--- a/apps/cli/src/service/paths.test.ts
+++ b/apps/cli/src/service/paths.test.ts
@@ -1,8 +1,9 @@
+import fs from "node:fs";
 import os from "node:os";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { homebrewShimPath, resolveHomeDir, resolveServiceUser } from "./paths";
+import { captureLauncher, homebrewShimPath, resolveHomeDir, resolveServiceUser } from "./paths";
 
 describe("resolveServiceUser", () => {
   const originalSudoUser = process.env.SUDO_USER;
@@ -118,5 +119,40 @@ describe("homebrewShimPath", () => {
 
   it("returns undefined for a non-Cellar path (npm install)", () => {
     expect(homebrewShimPath("/usr/local/lib/node_modules/kandev/bin/cli.js")).toBeUndefined();
+  });
+});
+
+describe("captureLauncher shim resolution", () => {
+  const originalArgv = process.argv;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("adopts the floating shim when it exists on disk", () => {
+    const cliEntry = "/opt/homebrew/Cellar/kandev/1.2.3/libexec/cli/bin/cli.js";
+    const shim = "/opt/homebrew/bin/kandev";
+    process.argv = ["/path/to/node", cliEntry];
+    vi.stubEnv("KANDEV_BUNDLE_DIR", "/opt/homebrew/Cellar/kandev/1.2.3/libexec");
+    // Both the cli.js entry and the shim resolve on disk.
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => p === cliEntry || p === shim);
+
+    const info = captureLauncher();
+    expect(info.kind).toBe("homebrew");
+    expect(info.shimPath).toBe(shim);
+  });
+
+  it("falls back to version-pinned paths when the shim is absent on disk", () => {
+    const cliEntry = "/opt/homebrew/Cellar/kandev/1.2.3/libexec/cli/bin/cli.js";
+    process.argv = ["/path/to/node", cliEntry];
+    vi.stubEnv("KANDEV_BUNDLE_DIR", "/opt/homebrew/Cellar/kandev/1.2.3/libexec");
+    // The cli.js entry resolves, but the floating shim does not exist.
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => p === cliEntry);
+
+    const info = captureLauncher();
+    expect(info.kind).toBe("homebrew");
+    expect(info.shimPath).toBeUndefined();
   });
 });

--- a/apps/cli/src/service/paths.ts
+++ b/apps/cli/src/service/paths.ts
@@ -47,7 +47,34 @@ export type LauncherInfo = {
   bundleDir?: string;
   /** KANDEV_VERSION if set (Homebrew sets this). */
   version?: string;
+  /**
+   * Absolute path to the floating Homebrew launcher shim
+   * (`<prefix>/bin/kandev`), set only for Homebrew installs where the shim
+   * exists on disk. When present, the unit is rendered to exec this shim
+   * instead of the version-pinned Cellar node + cli.js, so it survives
+   * `brew upgrade`. See {@link homebrewShimPath}.
+   */
+  shimPath?: string;
 };
+
+const HOMEBREW_CELLAR_SEGMENT = `${path.sep}Cellar${path.sep}`;
+
+/**
+ * Derive the floating Homebrew launcher shim from a Cellar-installed cli.js path.
+ *
+ * Homebrew installs the CLI under `<prefix>/Cellar/kandev/<version>/...` and
+ * symlinks a version-independent shim at `<prefix>/bin/kandev`. That shim sets
+ * KANDEV_BUNDLE_DIR / KANDEV_VERSION itself and execs cli.js via the floating
+ * `opt/node` symlink, so it keeps working after `brew upgrade` deletes the old
+ * Cellar dir. Returns undefined when `cliEntry` isn't a Cellar layout (npm /
+ * unknown installs), so callers fall back to the version-pinned paths.
+ */
+export function homebrewShimPath(cliEntry: string): string | undefined {
+  const idx = cliEntry.indexOf(HOMEBREW_CELLAR_SEGMENT);
+  if (idx === -1) return undefined;
+  const prefix = cliEntry.slice(0, idx);
+  return path.join(prefix, "bin", SERVICE_NAME);
+}
 
 /**
  * Snapshot the current invocation so the service unit can faithfully reproduce it.
@@ -67,7 +94,16 @@ export function captureLauncher(): LauncherInfo {
     : cliEntry.includes(`${path.sep}node_modules${path.sep}`)
       ? "npm"
       : "unknown";
-  return { nodePath, cliEntry, kind, bundleDir, version };
+  // For Homebrew installs, prefer the floating bin shim so the unit survives
+  // `brew upgrade` (which deletes the versioned Cellar dir baked into nodePath
+  // /cliEntry). Only adopt it when the shim actually exists on disk; otherwise
+  // fall back to the version-pinned paths below.
+  let shimPath: string | undefined;
+  if (kind === "homebrew") {
+    const candidate = homebrewShimPath(cliEntry);
+    if (candidate && fs.existsSync(candidate)) shimPath = candidate;
+  }
+  return { nodePath, cliEntry, kind, bundleDir, version, shimPath };
 }
 
 function resolveCliEntry(): string {

--- a/apps/cli/src/service/paths.ts
+++ b/apps/cli/src/service/paths.ts
@@ -57,7 +57,11 @@ export type LauncherInfo = {
   shimPath?: string;
 };
 
-const HOMEBREW_CELLAR_SEGMENT = `${path.sep}Cellar${path.sep}`;
+// Homebrew is POSIX-only, so the Cellar segment is a hardcoded "/Cellar/"
+// rather than `path.sep`-based. On a Windows CI runner `path.sep` would be
+// "\\", which would never match a POSIX Cellar path and silently break shim
+// derivation (and its tests).
+const HOMEBREW_CELLAR_SEGMENT = "/Cellar/";
 
 /**
  * Derive the floating Homebrew launcher shim from a Cellar-installed cli.js path.
@@ -73,7 +77,9 @@ export function homebrewShimPath(cliEntry: string): string | undefined {
   const idx = cliEntry.indexOf(HOMEBREW_CELLAR_SEGMENT);
   if (idx === -1) return undefined;
   const prefix = cliEntry.slice(0, idx);
-  return path.join(prefix, "bin", SERVICE_NAME);
+  // Homebrew layout is POSIX; use path.posix.join so the result keeps forward
+  // slashes regardless of the host the install/tests run on.
+  return path.posix.join(prefix, "bin", SERVICE_NAME);
 }
 
 /**

--- a/apps/cli/src/service/templates.test.ts
+++ b/apps/cli/src/service/templates.test.ts
@@ -210,10 +210,10 @@ describe("renderSystemdUnit", () => {
       mode: "user",
     });
     expect(unit).toContain("ExecStart=/home/linuxbrew/.linuxbrew/bin/kandev --headless");
-    // No version-pinned Cellar paths anywhere in the unit (node or kandev).
+    // No version-pinned Cellar paths anywhere in the unit — this single check
+    // covers both the kandev cli.js path and the versioned node bin dir, since
+    // any `/Cellar/node/...` or `/Cellar/kandev/...` path contains "/Cellar/".
     expect(unit).not.toContain("/Cellar/");
-    // The versioned node bin dir must not leak into PATH either.
-    expect(unit).not.toContain("Cellar/node");
   });
 
   it("drops KANDEV_BUNDLE_DIR / KANDEV_VERSION and the versioned node bin dir when using the shim", () => {

--- a/apps/cli/src/service/templates.test.ts
+++ b/apps/cli/src/service/templates.test.ts
@@ -244,6 +244,24 @@ describe("renderSystemdUnit", () => {
       "ExecStart=/usr/local/bin/node /usr/local/lib/node_modules/kandev/bin/cli.js --headless",
     );
   });
+
+  it("prepends the shim's bin dir to PATH for a custom Homebrew prefix not in the base PATH", () => {
+    const unit = renderSystemdUnit({
+      launcher: {
+        nodePath: "/home/me/.brew/Cellar/node/26.0.0/bin/node",
+        cliEntry: "/home/me/.brew/Cellar/kandev/0.52.0/libexec/cli/bin/cli.js",
+        kind: "homebrew",
+        shimPath: "/home/me/.brew/bin/kandev",
+      },
+      homeDir: "/home/me/.kandev",
+      logDir: "/home/me/.kandev/logs",
+      mode: "user",
+    });
+    // Custom prefix's bin dir is prepended so npm/npx resolve, even though it
+    // isn't one of the hardcoded default prefixes.
+    expect(unit).toContain("Environment=PATH=/home/me/.brew/bin:%h/.local/bin:%h/.bun/bin:");
+    expect(unit).not.toContain("/Cellar/");
+  });
 });
 
 describe("renderLaunchdPlist", () => {

--- a/apps/cli/src/service/templates.test.ts
+++ b/apps/cli/src/service/templates.test.ts
@@ -212,6 +212,8 @@ describe("renderSystemdUnit", () => {
     expect(unit).toContain("ExecStart=/home/linuxbrew/.linuxbrew/bin/kandev --headless");
     // No version-pinned Cellar paths anywhere in the unit (node or kandev).
     expect(unit).not.toContain("/Cellar/");
+    // The versioned node bin dir must not leak into PATH either.
+    expect(unit).not.toContain("Cellar/node");
   });
 
   it("drops KANDEV_BUNDLE_DIR / KANDEV_VERSION and the versioned node bin dir when using the shim", () => {
@@ -223,9 +225,11 @@ describe("renderSystemdUnit", () => {
     });
     expect(unit).not.toContain("KANDEV_BUNDLE_DIR");
     expect(unit).not.toContain("KANDEV_VERSION");
-    // PATH must fall back to the static base path, not the versioned Cellar node bin.
+    // PATH must fall back to the static base path, not the versioned Cellar node
+    // bin. The shim's own bin dir (/home/linuxbrew/.linuxbrew/bin) is already in
+    // the base path, so it is not duplicated.
     expect(unit).toContain(
-      "Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+      "Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
     );
   });
 

--- a/apps/cli/src/service/templates.test.ts
+++ b/apps/cli/src/service/templates.test.ts
@@ -25,6 +25,19 @@ const FNM_LAUNCHER: LauncherInfo = {
   kind: "npm",
 };
 
+// A Homebrew launcher whose floating shim has been resolved. nodePath/cliEntry
+// still point at the versioned Cellar paths (as captured at install time), but
+// shimPath is the version-independent `<prefix>/bin/kandev` symlink that
+// survives `brew upgrade`. See issue #1162.
+const SHIM_LAUNCHER: LauncherInfo = {
+  nodePath: "/home/linuxbrew/.linuxbrew/Cellar/node/26.0.0/bin/node",
+  cliEntry: "/home/linuxbrew/.linuxbrew/Cellar/kandev/0.52.0/libexec/cli/bin/cli.js",
+  kind: "homebrew",
+  bundleDir: "/home/linuxbrew/.linuxbrew/Cellar/kandev/0.52.0/libexec",
+  version: "0.52.0",
+  shimPath: "/home/linuxbrew/.linuxbrew/bin/kandev",
+};
+
 describe("renderSystemdUnit", () => {
   it("renders a user unit with absolute paths and --headless", () => {
     const unit = renderSystemdUnit({
@@ -183,6 +196,48 @@ describe("renderSystemdUnit", () => {
     });
     expect(unit).toContain(
       `ExecStart="/Library/Application Support/node" "/Library/Application Support/kandev/cli.js" --headless`,
+    );
+  });
+
+  // Regression: https://github.com/kdlbs/kandev/issues/1162 — the unit must not
+  // bake version-pinned Cellar paths for Homebrew installs, or it crash-loops
+  // after `brew upgrade` deletes the old Cellar dir.
+  it("uses the floating Homebrew shim in ExecStart when shimPath is set", () => {
+    const unit = renderSystemdUnit({
+      launcher: SHIM_LAUNCHER,
+      homeDir: "/home/alice/.kandev",
+      logDir: "/home/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(unit).toContain("ExecStart=/home/linuxbrew/.linuxbrew/bin/kandev --headless");
+    // No version-pinned Cellar paths anywhere in the unit (node or kandev).
+    expect(unit).not.toContain("/Cellar/");
+  });
+
+  it("drops KANDEV_BUNDLE_DIR / KANDEV_VERSION and the versioned node bin dir when using the shim", () => {
+    const unit = renderSystemdUnit({
+      launcher: SHIM_LAUNCHER,
+      homeDir: "/home/alice/.kandev",
+      logDir: "/home/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(unit).not.toContain("KANDEV_BUNDLE_DIR");
+    expect(unit).not.toContain("KANDEV_VERSION");
+    // PATH must fall back to the static base path, not the versioned Cellar node bin.
+    expect(unit).toContain(
+      "Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/home/linuxbrew/.linuxbrew/bin",
+    );
+  });
+
+  it("keeps versioned node + cli.js ExecStart for npm installs (no shim)", () => {
+    const unit = renderSystemdUnit({
+      launcher: NPM_LAUNCHER,
+      homeDir: "/home/alice/.kandev",
+      logDir: "/home/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(unit).toContain(
+      "ExecStart=/usr/local/bin/node /usr/local/lib/node_modules/kandev/bin/cli.js --headless",
     );
   });
 });
@@ -383,5 +438,20 @@ describe("renderLaunchdPlist", () => {
       mode: "user",
     });
     expect(plist).not.toContain("<key>UserName</key>");
+  });
+
+  // Regression: https://github.com/kdlbs/kandev/issues/1162
+  it("uses the floating Homebrew shim in ProgramArguments when shimPath is set", () => {
+    const plist = renderLaunchdPlist({
+      launcher: SHIM_LAUNCHER,
+      homeDir: "/Users/alice/.kandev",
+      logDir: "/Users/alice/.kandev/logs",
+      mode: "user",
+    });
+    expect(plist).toContain("<string>/home/linuxbrew/.linuxbrew/bin/kandev</string>");
+    expect(plist).toContain("<string>--headless</string>");
+    expect(plist).not.toContain("/Cellar/");
+    expect(plist).not.toContain("KANDEV_BUNDLE_DIR");
+    expect(plist).not.toContain("KANDEV_VERSION");
   });
 });

--- a/apps/cli/src/service/templates.ts
+++ b/apps/cli/src/service/templates.ts
@@ -66,31 +66,40 @@ export function looksLikeManagedUnit(content: string): boolean {
  * Render a systemd unit file for kandev.
  *
  * The unit hard-codes absolute paths so it works without a user PATH. We pass
- * `--headless` so the daemon doesn't try to open a browser. KANDEV_BUNDLE_DIR /
- * KANDEV_VERSION are surfaced only when present (Homebrew installs only) so
- * `npm i -g` installs don't get spurious env vars.
+ * `--headless` so the daemon doesn't try to open a browser.
+ *
+ * For Homebrew installs the launcher carries a resolved `shimPath` — the
+ * floating `<prefix>/bin/kandev` shim that survives `brew upgrade`. When set we
+ * exec that shim and omit KANDEV_BUNDLE_DIR / KANDEV_VERSION and the
+ * version-pinned node bin dir from PATH, because the shim supplies all three
+ * itself. Otherwise (npm / unknown installs) we fall back to the version-pinned
+ * node + cli.js and surface KANDEV_BUNDLE_DIR / KANDEV_VERSION only when present.
  */
 export function renderSystemdUnit(input: UnitInputs): string {
+  const shimPath = input.launcher.shimPath;
   const basePath = input.mode === "system" ? SYSTEMD_SYSTEM_PATH : SYSTEMD_USER_PATH;
+  const pathValue = shimPath ? basePath : pathWithNodeBinDir(basePath, input.launcher.nodePath);
   const env: string[] = [
     envLine("KANDEV_HOME_DIR", input.homeDir),
     envLine("KANDEV_LOG_LEVEL", "info"),
-    envLine("PATH", pathWithNodeBinDir(basePath, input.launcher.nodePath)),
+    envLine("PATH", pathValue),
   ];
   if (input.port !== undefined) {
     env.push(envLine("KANDEV_SERVER_PORT", String(input.port)));
   }
-  if (input.launcher.bundleDir) {
+  if (!shimPath && input.launcher.bundleDir) {
     env.push(envLine("KANDEV_BUNDLE_DIR", input.launcher.bundleDir));
   }
-  if (input.launcher.version) {
+  if (!shimPath && input.launcher.version) {
     env.push(envLine("KANDEV_VERSION", input.launcher.version));
   }
 
   const wantedBy = input.mode === "system" ? "multi-user.target" : "default.target";
   const userLine = input.mode === "system" && input.systemUser ? `User=${input.systemUser}\n` : "";
 
-  const exec = `${quoteForUnit(input.launcher.nodePath)} ${quoteForUnit(input.launcher.cliEntry)} --headless`;
+  const exec = shimPath
+    ? `${quoteForUnit(shimPath)} --headless`
+    : `${quoteForUnit(input.launcher.nodePath)} ${quoteForUnit(input.launcher.cliEntry)} --headless`;
 
   return `${SYSTEMD_MARKER}
 [Unit]
@@ -121,19 +130,21 @@ WantedBy=${wantedBy}
  * get a LaunchDaemon that runs at boot regardless of login.
  */
 export function renderLaunchdPlist(input: UnitInputs): string {
+  const shimPath = input.launcher.shimPath;
   const basePath = input.mode === "system" ? LAUNCHD_SYSTEM_PATH : launchdUserPath();
+  const pathValue = shimPath ? basePath : pathWithNodeBinDir(basePath, input.launcher.nodePath);
   const envEntries: Array<[string, string]> = [
     ["KANDEV_HOME_DIR", input.homeDir],
     ["KANDEV_LOG_LEVEL", "info"],
-    ["PATH", pathWithNodeBinDir(basePath, input.launcher.nodePath)],
+    ["PATH", pathValue],
   ];
   if (input.port !== undefined) {
     envEntries.push(["KANDEV_SERVER_PORT", String(input.port)]);
   }
-  if (input.launcher.bundleDir) {
+  if (!shimPath && input.launcher.bundleDir) {
     envEntries.push(["KANDEV_BUNDLE_DIR", input.launcher.bundleDir]);
   }
-  if (input.launcher.version) {
+  if (!shimPath && input.launcher.version) {
     envEntries.push(["KANDEV_VERSION", input.launcher.version]);
   }
 
@@ -141,7 +152,9 @@ export function renderLaunchdPlist(input: UnitInputs): string {
     .map(([k, v]) => `      <key>${escapeXml(k)}</key>\n      <string>${escapeXml(v)}</string>`)
     .join("\n");
 
-  const args = [input.launcher.nodePath, input.launcher.cliEntry, "--headless"];
+  const args = shimPath
+    ? [shimPath, "--headless"]
+    : [input.launcher.nodePath, input.launcher.cliEntry, "--headless"];
   const argsXml = args.map((a) => `    <string>${escapeXml(a)}</string>`).join("\n");
 
   // For system-mode LaunchDaemons, run as a specific user instead of root.

--- a/apps/cli/src/service/templates.ts
+++ b/apps/cli/src/service/templates.ts
@@ -78,7 +78,10 @@ export function looksLikeManagedUnit(content: string): boolean {
 export function renderSystemdUnit(input: UnitInputs): string {
   const shimPath = input.launcher.shimPath;
   const basePath = input.mode === "system" ? SYSTEMD_SYSTEM_PATH : SYSTEMD_USER_PATH;
-  const pathValue = shimPath ? basePath : pathWithNodeBinDir(basePath, input.launcher.nodePath);
+  // For the shim, prepend its own bin dir (the Homebrew prefix's `bin`, where
+  // node/npm/npx live) so npx-based agents resolve even when the prefix isn't
+  // one of the hardcoded defaults. pathWithNodeBinDir dedupes when it already is.
+  const pathValue = pathWithNodeBinDir(basePath, shimPath ?? input.launcher.nodePath);
   const env: string[] = [
     envLine("KANDEV_HOME_DIR", input.homeDir),
     envLine("KANDEV_LOG_LEVEL", "info"),
@@ -132,7 +135,8 @@ WantedBy=${wantedBy}
 export function renderLaunchdPlist(input: UnitInputs): string {
   const shimPath = input.launcher.shimPath;
   const basePath = input.mode === "system" ? LAUNCHD_SYSTEM_PATH : launchdUserPath();
-  const pathValue = shimPath ? basePath : pathWithNodeBinDir(basePath, input.launcher.nodePath);
+  // See renderSystemdUnit: prepend the shim's own bin dir so npm/npx resolve.
+  const pathValue = pathWithNodeBinDir(basePath, shimPath ?? input.launcher.nodePath);
   const envEntries: Array<[string, string]> = [
     ["KANDEV_HOME_DIR", input.homeDir],
     ["KANDEV_LOG_LEVEL", "info"],


### PR DESCRIPTION
## Summary

`kandev service install` baked the version-pinned Homebrew Cellar paths for both `node` and `cli.js` into the generated systemd unit / launchd plist, so after `brew upgrade` deleted the old `Cellar/<pkg>/<version>` dir the daemon crash-looped forever with `MODULE_NOT_FOUND` under `Restart=on-failure`; the unit now execs the floating `<prefix>/bin/kandev` shim for Homebrew installs so it survives upgrades.

## Important Changes

- `homebrewShimPath()` (new, pure) derives `<prefix>/bin/kandev` from a `.../Cellar/kandev/<version>/...` layout, returning `undefined` for npm/unknown installs.
- `captureLauncher()` adopts the shim only when it exists on disk; otherwise it falls back to the version-pinned paths, keeping relocated/edge installs safe.
- `renderSystemdUnit` / `renderLaunchdPlist` exec the shim when present and drop `KANDEV_BUNDLE_DIR` / `KANDEV_VERSION` and the version-pinned `node` bin dir (the shim supplies all three itself). npm / unknown installs keep the existing version-pinned behaviour.

## Validation

- `vitest run` — 192 passing (8 new regression tests: shim ExecStart/ProgramArguments, dropped env vars, npm fallback, and `homebrewShimPath` derivation).
- `tsc -p tsconfig.json --noEmit` — clean.
- `prettier --check` on all changed files — clean.

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] Self-reviewed the diff

Closes #1162