### PR TITLE
fix(github): detect fork PRs by branch

### DIFF
--- a/apps/backend/internal/github/graphql.go
+++ b/apps/backend/internal/github/graphql.go
@@ -511,14 +511,17 @@ func runBatchedBranchQuery(ctx context.Context, exec GraphQLExecutor, refs []gra
 		if err := graphQLErrorsToErr(resp.Errors); err != nil {
 			return nil, err
 		}
-		decodeBatchedBranchChunk(chunk, resp.Data, result)
+		if err := decodeBatchedBranchChunk(chunk, resp.Data, result); err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }
 
-func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawMessage, result map[string]*PRStatus) {
+func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawMessage, result map[string]*PRStatus) error {
 	for i, ref := range refs {
-		raw, ok := data[fmt.Sprintf("b%d", i)]
+		alias := fmt.Sprintf("b%d", i)
+		raw, ok := data[alias]
 		if !ok || len(raw) == 0 || string(raw) == "null" {
 			continue
 		}
@@ -528,7 +531,7 @@ func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawM
 			} `json:"pullRequests"`
 		}
 		if err := json.Unmarshal(raw, &inner); err != nil {
-			continue
+			return fmt.Errorf("decode branch alias %s: %w", alias, err)
 		}
 		node, ok := selectBatchedBranchPRNode(inner.PullRequests.Nodes)
 		if !ok {
@@ -537,6 +540,7 @@ func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawM
 		status := convertBatchedPRResult(&node.batchedPRResult, ref.Owner, ref.Repo, node.Number)
 		result[graphqlBranchKey(ref.Owner, ref.Repo, ref.Branch)] = status
 	}
+	return nil
 }
 
 func selectBatchedBranchPRNode(nodes []batchedBranchPRNode) (*batchedBranchPRNode, bool) {

--- a/apps/backend/internal/github/graphql.go
+++ b/apps/backend/internal/github/graphql.go
@@ -194,14 +194,14 @@ func prFieldsBlock() string {
 		`commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }`
 }
 
-// buildBatchedBranchQuery emits one aliased associatedPullRequests block per
-// (owner, repo, branch) ref. Used to batch the "find PR by branch" path.
+// buildBatchedBranchQuery emits one aliased pullRequests(headRefName:) block
+// per (owner, repo, branch). Used to batch the "find PR by branch" path.
 func buildBatchedBranchQuery(refs []graphQLBranchRef) (string, map[string]any) {
 	var b strings.Builder
 	b.WriteString("query Branches { ")
 	for i, r := range refs {
-		fmt.Fprintf(&b, `b%d: repository(owner: %q, name: %q) { ref(qualifiedName: %q) { associatedPullRequests(first: 1, states: OPEN) { nodes { number %s } } } } `,
-			i, r.Owner, r.Repo, "refs/heads/"+r.Branch, prFieldsBlock())
+		fmt.Fprintf(&b, `b%d: repository(owner: %q, name: %q) { pullRequests(first: 1, states: OPEN, headRefName: %q) { nodes { number %s } } } `,
+			i, r.Owner, r.Repo, r.Branch, prFieldsBlock())
 	}
 	b.WriteString(`rateLimit { limit remaining resetAt cost } `)
 	b.WriteString(`}`)
@@ -483,7 +483,7 @@ func decodeBatchedPRChunk(refs []graphQLPRRef, data map[string]json.RawMessage, 
 }
 
 // runBatchedBranchQuery executes the branch-lookup query in chunks and maps
-// each branch ref to its first OPEN associated PR (if any). Result keys are
+// each branch name to its first OPEN PR (if any). Result keys are
 // "owner/repo/branch" so callers can index by their input refs.
 func runBatchedBranchQuery(ctx context.Context, exec GraphQLExecutor, refs []graphQLBranchRef) (map[string]*PRStatus, error) {
 	if exec == nil || len(refs) == 0 {
@@ -514,22 +514,20 @@ func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawM
 			continue
 		}
 		var inner struct {
-			Ref *struct {
-				AssociatedPullRequests struct {
-					Nodes []struct {
-						Number int `json:"number"`
-						batchedPRResult
-					} `json:"nodes"`
-				} `json:"associatedPullRequests"`
-			} `json:"ref"`
+			PullRequests struct {
+				Nodes []struct {
+					Number int `json:"number"`
+					batchedPRResult
+				} `json:"nodes"`
+			} `json:"pullRequests"`
 		}
 		if err := json.Unmarshal(raw, &inner); err != nil {
 			continue
 		}
-		if inner.Ref == nil || len(inner.Ref.AssociatedPullRequests.Nodes) == 0 {
+		if len(inner.PullRequests.Nodes) == 0 {
 			continue
 		}
-		node := inner.Ref.AssociatedPullRequests.Nodes[0]
+		node := inner.PullRequests.Nodes[0]
 		status := convertBatchedPRResult(&node.batchedPRResult, ref.Owner, ref.Repo, node.Number)
 		result[graphqlBranchKey(ref.Owner, ref.Repo, ref.Branch)] = status
 	}

--- a/apps/backend/internal/github/graphql.go
+++ b/apps/backend/internal/github/graphql.go
@@ -28,6 +28,10 @@ const graphQLPRBatchAlias = "pr"
 // fields = ~500 nodes, leaving headroom.
 const graphQLBatchChunkSize = 50
 
+// graphQLBranchProbeLimit fetches two matches so branch lookup can detect
+// ambiguous fork heads instead of linking the first arbitrary PR.
+const graphQLBranchProbeLimit = 2
+
 // reviewNode is one PR review entry from the batched GraphQL query.
 type reviewNode struct {
 	State  string `json:"state"`
@@ -109,6 +113,14 @@ type batchedPRResult struct {
 			} `json:"commit"`
 		} `json:"nodes"`
 	} `json:"commits"`
+}
+
+type batchedBranchPRNode struct {
+	Number              int `json:"number"`
+	HeadRepositoryOwner struct {
+		Login string `json:"login"`
+	} `json:"headRepositoryOwner"`
+	batchedPRResult
 }
 
 // graphQLError mirrors a single entry in a GraphQL response's "errors" array.
@@ -200,8 +212,8 @@ func buildBatchedBranchQuery(refs []graphQLBranchRef) (string, map[string]any) {
 	var b strings.Builder
 	b.WriteString("query Branches { ")
 	for i, r := range refs {
-		fmt.Fprintf(&b, `b%d: repository(owner: %q, name: %q) { pullRequests(first: 1, states: OPEN, headRefName: %q) { nodes { number %s } } } `,
-			i, r.Owner, r.Repo, r.Branch, prFieldsBlock())
+		fmt.Fprintf(&b, `b%d: repository(owner: %q, name: %q) { pullRequests(first: %d, states: OPEN, headRefName: %q) { nodes { number headRepositoryOwner { login } %s } } } `,
+			i, r.Owner, r.Repo, graphQLBranchProbeLimit, r.Branch, prFieldsBlock())
 	}
 	b.WriteString(`rateLimit { limit remaining resetAt cost } `)
 	b.WriteString(`}`)
@@ -483,7 +495,7 @@ func decodeBatchedPRChunk(refs []graphQLPRRef, data map[string]json.RawMessage, 
 }
 
 // runBatchedBranchQuery executes the branch-lookup query in chunks and maps
-// each branch name to its first OPEN PR (if any). Result keys are
+// each branch name to its unambiguous OPEN PR (if any). Result keys are
 // "owner/repo/branch" so callers can index by their input refs.
 func runBatchedBranchQuery(ctx context.Context, exec GraphQLExecutor, refs []graphQLBranchRef) (map[string]*PRStatus, error) {
 	if exec == nil || len(refs) == 0 {
@@ -515,22 +527,39 @@ func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawM
 		}
 		var inner struct {
 			PullRequests struct {
-				Nodes []struct {
-					Number int `json:"number"`
-					batchedPRResult
-				} `json:"nodes"`
+				Nodes []batchedBranchPRNode `json:"nodes"`
 			} `json:"pullRequests"`
 		}
 		if err := json.Unmarshal(raw, &inner); err != nil {
 			continue
 		}
-		if len(inner.PullRequests.Nodes) == 0 {
+		node, ok := selectBatchedBranchPRNode(inner.PullRequests.Nodes, ref.Owner)
+		if !ok {
 			continue
 		}
-		node := inner.PullRequests.Nodes[0]
 		status := convertBatchedPRResult(&node.batchedPRResult, ref.Owner, ref.Repo, node.Number)
 		result[graphqlBranchKey(ref.Owner, ref.Repo, ref.Branch)] = status
 	}
+}
+
+func selectBatchedBranchPRNode(nodes []batchedBranchPRNode, owner string) (*batchedBranchPRNode, bool) {
+	if len(nodes) == 0 {
+		return nil, false
+	}
+	if len(nodes) == 1 {
+		return &nodes[0], true
+	}
+	var selected *batchedBranchPRNode
+	for i := range nodes {
+		if !strings.EqualFold(nodes[i].HeadRepositoryOwner.Login, owner) {
+			continue
+		}
+		if selected != nil {
+			return nil, false
+		}
+		selected = &nodes[i]
+	}
+	return selected, selected != nil
 }
 
 // graphqlBranchKey is the lookup key used in batched-branch result maps.

--- a/apps/backend/internal/github/graphql.go
+++ b/apps/backend/internal/github/graphql.go
@@ -116,10 +116,7 @@ type batchedPRResult struct {
 }
 
 type batchedBranchPRNode struct {
-	Number              int `json:"number"`
-	HeadRepositoryOwner struct {
-		Login string `json:"login"`
-	} `json:"headRepositoryOwner"`
+	Number int `json:"number"`
 	batchedPRResult
 }
 
@@ -212,7 +209,7 @@ func buildBatchedBranchQuery(refs []graphQLBranchRef) (string, map[string]any) {
 	var b strings.Builder
 	b.WriteString("query Branches { ")
 	for i, r := range refs {
-		fmt.Fprintf(&b, `b%d: repository(owner: %q, name: %q) { pullRequests(first: %d, states: OPEN, headRefName: %q) { nodes { number headRepositoryOwner { login } %s } } } `,
+		fmt.Fprintf(&b, `b%d: repository(owner: %q, name: %q) { pullRequests(first: %d, states: OPEN, headRefName: %q) { nodes { number %s } } } `,
 			i, r.Owner, r.Repo, graphQLBranchProbeLimit, r.Branch, prFieldsBlock())
 	}
 	b.WriteString(`rateLimit { limit remaining resetAt cost } `)
@@ -533,7 +530,7 @@ func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawM
 		if err := json.Unmarshal(raw, &inner); err != nil {
 			continue
 		}
-		node, ok := selectBatchedBranchPRNode(inner.PullRequests.Nodes, ref.Owner)
+		node, ok := selectBatchedBranchPRNode(inner.PullRequests.Nodes)
 		if !ok {
 			continue
 		}
@@ -542,24 +539,11 @@ func decodeBatchedBranchChunk(refs []graphQLBranchRef, data map[string]json.RawM
 	}
 }
 
-func selectBatchedBranchPRNode(nodes []batchedBranchPRNode, owner string) (*batchedBranchPRNode, bool) {
-	if len(nodes) == 0 {
+func selectBatchedBranchPRNode(nodes []batchedBranchPRNode) (*batchedBranchPRNode, bool) {
+	if len(nodes) != 1 {
 		return nil, false
 	}
-	if len(nodes) == 1 {
-		return &nodes[0], true
-	}
-	var selected *batchedBranchPRNode
-	for i := range nodes {
-		if !strings.EqualFold(nodes[i].HeadRepositoryOwner.Login, owner) {
-			continue
-		}
-		if selected != nil {
-			return nil, false
-		}
-		selected = &nodes[i]
-	}
-	return selected, selected != nil
+	return &nodes[0], true
 }
 
 // graphqlBranchKey is the lookup key used in batched-branch result maps.

--- a/apps/backend/internal/github/graphql_test.go
+++ b/apps/backend/internal/github/graphql_test.go
@@ -54,8 +54,11 @@ func TestBuildBatchedBranchQuery_AliasesAllBranches(t *testing.T) {
 	if !strings.Contains(q, `b0: repository`) || !strings.Contains(q, `b1: repository`) {
 		t.Errorf("expected b0/b1 aliases: %s", q)
 	}
-	if !strings.Contains(q, `qualifiedName: "refs/heads/feat-1"`) {
-		t.Errorf("expected qualifiedName for feat-1: %s", q)
+	if !strings.Contains(q, `pullRequests(first: 1, states: OPEN, headRefName: "feat-1")`) {
+		t.Errorf("expected headRefName lookup for feat-1: %s", q)
+	}
+	if strings.Contains(q, `ref(qualifiedName:`) {
+		t.Errorf("branch lookup should not require a base-repo ref: %s", q)
 	}
 }
 
@@ -184,19 +187,17 @@ func TestRunBatchedBranchQuery_DecodesPRNode(t *testing.T) {
 		response: `{
 			"data": {
 				"b0": {
-					"ref": {
-						"associatedPullRequests": {
-							"nodes": [{
-								"number": 7,
-								"state": "OPEN", "title": "branch PR", "url": "https://x/7",
-								"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
-								"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
-								"author": {"login":"alice"},
-								"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
-								"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
-								"commits": {"nodes": []}
-							}]
-						}
+					"pullRequests": {
+						"nodes": [{
+							"number": 7,
+							"state": "OPEN", "title": "branch PR", "url": "https://x/7",
+							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+							"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
+							"author": {"login":"alice"},
+							"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+							"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
+							"commits": {"nodes": []}
+						}]
 					}
 				}
 			}

--- a/apps/backend/internal/github/graphql_test.go
+++ b/apps/backend/internal/github/graphql_test.go
@@ -54,7 +54,7 @@ func TestBuildBatchedBranchQuery_AliasesAllBranches(t *testing.T) {
 	if !strings.Contains(q, `b0: repository`) || !strings.Contains(q, `b1: repository`) {
 		t.Errorf("expected b0/b1 aliases: %s", q)
 	}
-	if !strings.Contains(q, `pullRequests(first: 1, states: OPEN, headRefName: "feat-1")`) {
+	if !strings.Contains(q, `pullRequests(first: 2, states: OPEN, headRefName: "feat-1")`) {
 		t.Errorf("expected headRefName lookup for feat-1: %s", q)
 	}
 	if strings.Contains(q, `ref(qualifiedName:`) {
@@ -215,6 +215,72 @@ func TestRunBatchedBranchQuery_DecodesPRNode(t *testing.T) {
 	}
 	if status.PR == nil || status.PR.Number != 7 {
 		t.Errorf("expected PR number 7, got %#v", status.PR)
+	}
+}
+
+func TestRunBatchedBranchQuery_EmptyNodesReturnsNoResult(t *testing.T) {
+	exec := &stubGraphQLExecutor{
+		response: `{
+			"data": {
+				"b0": {
+					"pullRequests": {
+						"nodes": []
+					}
+				}
+			}
+		}`,
+	}
+	got, err := runBatchedBranchQuery(context.Background(), exec, []graphQLBranchRef{
+		{Owner: "o", Repo: "r", Branch: "feat"},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no branch result, got %#v", got)
+	}
+}
+
+func TestRunBatchedBranchQuery_SkipsAmbiguousForkHeads(t *testing.T) {
+	exec := &stubGraphQLExecutor{
+		response: `{
+			"data": {
+				"b0": {
+					"pullRequests": {
+						"nodes": [{
+							"number": 7,
+							"headRepositoryOwner": {"login":"alice"},
+							"state": "OPEN", "title": "branch PR A", "url": "https://x/7",
+							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+							"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
+							"author": {"login":"alice"},
+							"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+							"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
+							"commits": {"nodes": []}
+						}, {
+							"number": 8,
+							"headRepositoryOwner": {"login":"bob"},
+							"state": "OPEN", "title": "branch PR B", "url": "https://x/8",
+							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+							"headRefName": "feat", "baseRefName": "main", "headRefOid": "cafebabe",
+							"author": {"login":"bob"},
+							"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+							"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
+							"commits": {"nodes": []}
+						}]
+					}
+				}
+			}
+		}`,
+	}
+	got, err := runBatchedBranchQuery(context.Background(), exec, []graphQLBranchRef{
+		{Owner: "o", Repo: "r", Branch: "feat"},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected ambiguous fork heads to be skipped, got %#v", got)
 	}
 }
 

--- a/apps/backend/internal/github/graphql_test.go
+++ b/apps/backend/internal/github/graphql_test.go
@@ -249,7 +249,6 @@ func TestRunBatchedBranchQuery_SkipsAmbiguousForkHeads(t *testing.T) {
 					"pullRequests": {
 						"nodes": [{
 							"number": 7,
-							"headRepositoryOwner": {"login":"alice"},
 							"state": "OPEN", "title": "branch PR A", "url": "https://x/7",
 							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
 							"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
@@ -259,7 +258,6 @@ func TestRunBatchedBranchQuery_SkipsAmbiguousForkHeads(t *testing.T) {
 							"commits": {"nodes": []}
 						}, {
 							"number": 8,
-							"headRepositoryOwner": {"login":"bob"},
 							"state": "OPEN", "title": "branch PR B", "url": "https://x/8",
 							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
 							"headRefName": "feat", "baseRefName": "main", "headRefOid": "cafebabe",
@@ -292,7 +290,6 @@ func TestRunBatchedBranchQuery_SkipsMultipleBranchMatchesEvenWithOwnerMatch(t *t
 					"pullRequests": {
 						"nodes": [{
 							"number": 7,
-							"headRepositoryOwner": {"login":"alice"},
 							"state": "OPEN", "title": "fork PR", "url": "https://x/7",
 							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
 							"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
@@ -302,7 +299,6 @@ func TestRunBatchedBranchQuery_SkipsMultipleBranchMatchesEvenWithOwnerMatch(t *t
 							"commits": {"nodes": []}
 						}, {
 							"number": 9,
-							"headRepositoryOwner": {"login":"o"},
 							"state": "OPEN", "title": "base PR", "url": "https://x/9",
 							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
 							"headRefName": "feat", "baseRefName": "main", "headRefOid": "cafebabe",

--- a/apps/backend/internal/github/graphql_test.go
+++ b/apps/backend/internal/github/graphql_test.go
@@ -182,6 +182,19 @@ func TestRunBatchedBranchQuery_SurfacesGraphQLErrors(t *testing.T) {
 	}
 }
 
+func TestRunBatchedBranchQuery_SurfacesDecodeErrors(t *testing.T) {
+	exec := &stubGraphQLExecutor{
+		response: `{"data": {"b0": {"pullRequests": {"nodes": [{"number": "bad"}]}}}}`,
+	}
+	_, err := runBatchedBranchQuery(context.Background(), exec, []graphQLBranchRef{{Owner: "o", Repo: "r", Branch: "feat"}})
+	if err == nil {
+		t.Fatalf("expected malformed branch node to return an error")
+	}
+	if !strings.Contains(err.Error(), "decode branch alias b0") {
+		t.Errorf("expected error to identify branch alias, got: %v", err)
+	}
+}
+
 func TestRunBatchedBranchQuery_DecodesPRNode(t *testing.T) {
 	exec := &stubGraphQLExecutor{
 		response: `{

--- a/apps/backend/internal/github/graphql_test.go
+++ b/apps/backend/internal/github/graphql_test.go
@@ -284,6 +284,49 @@ func TestRunBatchedBranchQuery_SkipsAmbiguousForkHeads(t *testing.T) {
 	}
 }
 
+func TestRunBatchedBranchQuery_SkipsMultipleBranchMatchesEvenWithOwnerMatch(t *testing.T) {
+	exec := &stubGraphQLExecutor{
+		response: `{
+			"data": {
+				"b0": {
+					"pullRequests": {
+						"nodes": [{
+							"number": 7,
+							"headRepositoryOwner": {"login":"alice"},
+							"state": "OPEN", "title": "fork PR", "url": "https://x/7",
+							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+							"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
+							"author": {"login":"alice"},
+							"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+							"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
+							"commits": {"nodes": []}
+						}, {
+							"number": 9,
+							"headRepositoryOwner": {"login":"o"},
+							"state": "OPEN", "title": "base PR", "url": "https://x/9",
+							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+							"headRefName": "feat", "baseRefName": "main", "headRefOid": "cafebabe",
+							"author": {"login":"o"},
+							"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+							"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
+							"commits": {"nodes": []}
+						}]
+					}
+				}
+			}
+		}`,
+	}
+	got, err := runBatchedBranchQuery(context.Background(), exec, []graphQLBranchRef{
+		{Owner: "o", Repo: "r", Branch: "feat"},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected duplicate branch matches to be skipped, got %#v", got)
+	}
+}
+
 func TestSummarizeReviewState_PrefersChangesRequested(t *testing.T) {
 	mk := func(login, state string, sec int) reviewNode {
 		var n reviewNode

--- a/apps/backend/internal/github/pat_client.go
+++ b/apps/backend/internal/github/pat_client.go
@@ -166,16 +166,19 @@ func (c *PATClient) GetPR(ctx context.Context, owner, repo string, number int) (
 }
 
 func (c *PATClient) FindPRByBranch(ctx context.Context, owner, repo, branch string) (*PR, error) {
-	var raw []patPR
-	endpoint := fmt.Sprintf("/repos/%s/%s/pulls?head=%s:%s&state=open&per_page=1",
-		owner, repo, owner, branch)
-	if err := c.get(ctx, endpoint, &raw); err != nil {
-		return nil, fmt.Errorf("find PR by branch: %w", err)
+	statuses, err := runBatchedBranchQuery(ctx, c, []graphQLBranchRef{{
+		Owner:  owner,
+		Repo:   repo,
+		Branch: branch,
+	}})
+	if err != nil {
+		return nil, fmt.Errorf("find PR by branch %q: %w", branch, err)
 	}
-	if len(raw) == 0 {
+	status := statuses[graphqlBranchKey(owner, repo, branch)]
+	if status == nil {
 		return nil, nil
 	}
-	return convertPatPR(&raw[0], owner, repo), nil
+	return status.PR, nil
 }
 
 func (c *PATClient) ListAuthoredPRs(ctx context.Context, owner, repo string) ([]*PR, error) {

--- a/apps/backend/internal/github/pat_client_test.go
+++ b/apps/backend/internal/github/pat_client_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -151,6 +152,63 @@ func TestConvertPatPR_MergeableState(t *testing.T) {
 	pr := convertPatPR(raw, "o", "r")
 	if pr.MergeableState != "clean" {
 		t.Errorf("expected normalized mergeable_state=clean, got %q", pr.MergeableState)
+	}
+}
+
+func TestPATClient_FindPRByBranch_UsesGraphQLHeadRefName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			t.Errorf("unexpected path %q, want /graphql", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusInternalServerError)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		var body struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(body.Query, `pullRequests(first: 2, states: OPEN, headRefName: "feature")`) {
+			t.Errorf("query should look up branch by headRefName, got: %s", body.Query)
+		}
+		if strings.Contains(body.Query, `head=acme:feature`) || strings.Contains(body.Query, `ref(qualifiedName:`) {
+			t.Errorf("query should not require a base-repo branch ref, got: %s", body.Query)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"b0": {
+					"pullRequests": {
+						"nodes": [{
+							"number": 12,
+							"headRepositoryOwner": {"login":"fork-owner"},
+							"state": "OPEN", "title": "fork PR", "url": "https://x/12",
+							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+							"headRefName": "feature", "baseRefName": "main", "headRefOid": "abc123",
+							"author": {"login":"alice"},
+							"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+							"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
+							"commits": {"nodes": []}
+						}]
+					}
+				}
+			}
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newPATClientPointingAt(t, srv.URL)
+	pr, err := c.FindPRByBranch(context.Background(), "acme", "widget", "feature")
+	if err != nil {
+		t.Fatalf("FindPRByBranch: %v", err)
+	}
+	if pr == nil || pr.Number != 12 || pr.HeadBranch != "feature" {
+		t.Fatalf("unexpected PR: %#v", pr)
 	}
 }
 

--- a/apps/backend/internal/github/pat_client_test.go
+++ b/apps/backend/internal/github/pat_client_test.go
@@ -186,7 +186,6 @@ func TestPATClient_FindPRByBranch_UsesGraphQLHeadRefName(t *testing.T) {
 					"pullRequests": {
 						"nodes": [{
 							"number": 12,
-							"headRepositoryOwner": {"login":"fork-owner"},
 							"state": "OPEN", "title": "fork PR", "url": "https://x/12",
 							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
 							"headRefName": "feature", "baseRefName": "main", "headRefOid": "abc123",

--- a/apps/backend/internal/github/poller_test.go
+++ b/apps/backend/internal/github/poller_test.go
@@ -641,19 +641,17 @@ func TestTryBatchedPRWatchCheck_SearchingWatch_DetectsPR(t *testing.T) {
 	gh.branchResponses = []string{`{
 		"data": {
 			"b0": {
-				"ref": {
-					"associatedPullRequests": {
-						"nodes": [{
-							"number": 7,
-							"state": "OPEN", "title": "branch PR", "url": "https://x/7",
-							"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
-							"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
-							"author": {"login": "alice"},
-							"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
-							"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
-							"commits": {"nodes": []}
-						}]
-					}
+				"pullRequests": {
+					"nodes": [{
+						"number": 7,
+						"state": "OPEN", "title": "branch PR", "url": "https://x/7",
+						"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+						"headRefName": "feat", "baseRefName": "main", "headRefOid": "deadbeef",
+						"author": {"login": "alice"},
+						"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+						"reviews": {"nodes": []}, "reviewRequests": {"totalCount": 0},
+						"commits": {"nodes": []}
+					}]
 				}
 			}
 		}


### PR DESCRIPTION
GitHub PR auto-detection skipped fork branches because one path looked for refs in the base repository and the PAT on-demand path constrained `head` to the base owner. This switches branch discovery to repository-level GraphQL head-branch lookup, while avoiding wrong links when duplicate fork branch names make the match ambiguous.

**Important Changes**
- Query open PRs with `pullRequests(headRefName:)` instead of `ref(...).associatedPullRequests`.
- Reuse the GraphQL branch lookup from PAT-backed on-demand PR detection.
- Fetch up to two branch matches and skip duplicate branch matches instead of linking an arbitrary PR.
- Add regression coverage for fork branch lookup, empty results, duplicate branch matches, and the poller response shape.

**Validation**
- `go test ./internal/github -run 'TestPATClient_FindPRByBranch_UsesGraphQLHeadRefName|TestBuildBatchedBranchQuery_AliasesAllBranches|TestRunBatchedBranchQuery_EmptyNodesReturnsNoResult|TestRunBatchedBranchQuery_SkipsAmbiguousForkHeads' -count=1` (failed before fix)
- `go test ./internal/github -run 'TestPATClient_FindPRByBranch_UsesGraphQLHeadRefName|TestBuildBatchedBranchQuery_AliasesAllBranches|TestRunBatchedBranchQuery_EmptyNodesReturnsNoResult|TestRunBatchedBranchQuery_SkipsAmbiguousForkHeads|TestRunBatchedBranchQuery_SkipsMultipleBranchMatchesEvenWithOwnerMatch|TestRunBatchedBranchQuery_DecodesPRNode|TestTryBatchedPRWatchCheck_SearchingWatch_DetectsPR' -count=1`
- `go test ./internal/github -count=1`
- `NODENV_VERSION=24.12.0 make fmt`
- `PATH="$HOME/.nodenv/versions/24.12.0/bin:$PATH" make typecheck test lint`

**Possible Improvements**
- If PR watches later store the fork owner, use it to disambiguate duplicate fork branch names instead of skipping those rare matches.

**Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)

Refs #1148