### PR TITLE
fix(web): portal inline-code tooltip to body to prevent clipping

### DIFF
--- a/apps/web/components/task/chat/messages/inline-code.test.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.test.tsx
@@ -25,8 +25,7 @@ describe("InlineCode", () => {
   });
 
   it("portals the hover tooltip to document.body so overflow-hidden ancestors cannot clip it", () => {
-    // Mirrors the user-message bubble: content wrapped in nested overflow-hidden
-    // layers that previously clipped the in-flow absolute tooltip.
+    // Mirrors the user-message bubble with nested overflow-hidden layers that previously clipped the tooltip.
     const { container } = render(
       <div className="overflow-hidden">
         <div className="overflow-hidden">
@@ -39,8 +38,7 @@ describe("InlineCode", () => {
 
     const tooltip = screen.getByRole("tooltip");
     expect(tooltip.textContent).toBe("Copy to clipboard");
-    // The tooltip must escape the clipping wrapper: it lives on document.body,
-    // not inside the overflow-hidden container.
+    // Tooltip must escape the clipping wrapper: lives on document.body, not inside the container.
     expect(container.contains(tooltip)).toBe(false);
     expect(document.body.contains(tooltip)).toBe(true);
   });

--- a/apps/web/components/task/chat/messages/inline-code.test.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.test.tsx
@@ -77,6 +77,9 @@ describe("InlineCode", () => {
     const tooltip = screen.getByRole("tooltip");
     expect(code.getAttribute("aria-describedby")).toBe(tooltip.id);
     expect(tooltip.id).not.toBe("");
+
+    fireEvent.mouseLeave(code);
+    expect(code.getAttribute("aria-describedby")).toBeNull();
   });
 
   it("dismisses the tooltip on scroll so it cannot drift from the anchored code", () => {

--- a/apps/web/components/task/chat/messages/inline-code.test.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { InlineCode } from "./inline-code";
+
+const { copyMock } = vi.hoisted(() => ({
+  copyMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/hooks/use-copy-to-clipboard", () => ({
+  useCopyToClipboard: () => ({ copy: copyMock }),
+}));
+
+describe("InlineCode", () => {
+  beforeEach(() => {
+    copyMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the inline code content", () => {
+    render(<InlineCode>npm install</InlineCode>);
+    expect(screen.getByText("npm install")).toBeDefined();
+  });
+
+  it("portals the hover tooltip to document.body so overflow-hidden ancestors cannot clip it", () => {
+    // Mirrors the user-message bubble: content wrapped in nested overflow-hidden
+    // layers that previously clipped the in-flow absolute tooltip.
+    const { container } = render(
+      <div className="overflow-hidden">
+        <div className="overflow-hidden">
+          <InlineCode>git status</InlineCode>
+        </div>
+      </div>,
+    );
+
+    fireEvent.mouseEnter(screen.getByText("git status"));
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip.textContent).toBe("Copy to clipboard");
+    // The tooltip must escape the clipping wrapper: it lives on document.body,
+    // not inside the overflow-hidden container.
+    expect(container.contains(tooltip)).toBe(false);
+    expect(document.body.contains(tooltip)).toBe(true);
+  });
+
+  it("hides the tooltip when the pointer leaves", () => {
+    render(<InlineCode>ls</InlineCode>);
+    const code = screen.getByText("ls");
+
+    fireEvent.mouseEnter(code);
+    expect(screen.queryByRole("tooltip")).not.toBeNull();
+
+    fireEvent.mouseLeave(code);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("copies the content and shows a Copied! confirmation on click", async () => {
+    render(<InlineCode>echo hi</InlineCode>);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("echo hi"));
+    });
+
+    expect(copyMock).toHaveBeenCalledWith("echo hi");
+    expect(screen.getByRole("tooltip").textContent).toBe("Copied!");
+  });
+});

--- a/apps/web/components/task/chat/messages/inline-code.test.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.test.tsx
@@ -66,4 +66,29 @@ describe("InlineCode", () => {
     expect(copyMock).toHaveBeenCalledWith("echo hi");
     expect(screen.getByRole("tooltip").textContent).toBe("Copied!");
   });
+
+  it("wires the trigger to the tooltip via aria-describedby only while visible", () => {
+    render(<InlineCode>pwd</InlineCode>);
+    const code = screen.getByText("pwd");
+
+    expect(code.getAttribute("aria-describedby")).toBeNull();
+
+    fireEvent.mouseEnter(code);
+    const tooltip = screen.getByRole("tooltip");
+    expect(code.getAttribute("aria-describedby")).toBe(tooltip.id);
+    expect(tooltip.id).not.toBe("");
+  });
+
+  it("dismisses the tooltip on scroll so it cannot drift from the anchored code", () => {
+    render(<InlineCode>cd</InlineCode>);
+
+    fireEvent.mouseEnter(screen.getByText("cd"));
+    expect(screen.queryByRole("tooltip")).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
 });

--- a/apps/web/components/task/chat/messages/inline-code.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.tsx
@@ -85,6 +85,7 @@ export function InlineCode({ children }: InlineCodeProps) {
               "fixed z-50 -translate-x-1/2 -translate-y-full",
               "rounded border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md",
               "pointer-events-none select-none whitespace-nowrap",
+              "animate-in fade-in-0 duration-150",
             )}
           >
             {copied ? "Copied!" : "Copy to clipboard"}

--- a/apps/web/components/task/chat/messages/inline-code.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
@@ -13,22 +13,14 @@ const COPIED_RESET_MS = 1500;
 
 type TooltipAnchor = { left: number; top: number };
 
-/**
- * Inline `code` span with a click-to-copy affordance.
- *
- * The hover / "Copied!" tooltip is rendered through a portal on `document.body`
- * rather than as an absolutely-positioned child. Inline code frequently lives
- * inside containers that clip their overflow (e.g. the rounded user-message
- * bubble, which nests several `overflow-hidden` layers); an in-flow absolute
- * tooltip gets clipped by those ancestors. Portaling it to the body lets it
- * float freely so it is never clipped.
- */
+// Tooltip is portaled to document.body so overflow-hidden ancestors (e.g. the user-message bubble) can't clip it.
 export function InlineCode({ children }: InlineCodeProps) {
   const { copy } = useCopyToClipboard();
   const [anchor, setAnchor] = useState<TooltipAnchor | null>(null);
   const [hovered, setHovered] = useState(false);
   const [copied, setCopied] = useState(false);
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
 
   useEffect(
     () => () => {
@@ -36,6 +28,23 @@ export function InlineCode({ children }: InlineCodeProps) {
     },
     [],
   );
+
+  // The anchor is a captured viewport rect, so scroll/resize would let the
+  // fixed tooltip drift away from the code. Dismiss it instead of repositioning.
+  const visible = hovered || copied;
+  useEffect(() => {
+    if (!visible) return;
+    const dismiss = () => {
+      setHovered(false);
+      setCopied(false);
+    };
+    window.addEventListener("scroll", dismiss, true);
+    window.addEventListener("resize", dismiss);
+    return () => {
+      window.removeEventListener("scroll", dismiss, true);
+      window.removeEventListener("resize", dismiss);
+    };
+  }, [visible]);
 
   const anchorTo = (el: HTMLElement) => {
     const rect = el.getBoundingClientRect();
@@ -59,17 +68,19 @@ export function InlineCode({ children }: InlineCodeProps) {
           setHovered(true);
         }}
         onMouseLeave={() => setHovered(false)}
+        aria-describedby={visible ? tooltipId : undefined}
         className="cursor-pointer hover:bg-foreground/10 transition-colors"
       >
         {children}
       </code>
 
-      {(hovered || copied) &&
+      {visible &&
         anchor &&
         typeof document !== "undefined" &&
         createPortal(
           <span
             role="tooltip"
+            id={tooltipId}
             style={{ left: anchor.left, top: anchor.top - 4 }}
             className={cn(
               "fixed z-50 -translate-x-1/2 -translate-y-full",

--- a/apps/web/components/task/chat/messages/inline-code.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.tsx
@@ -29,8 +29,7 @@ export function InlineCode({ children }: InlineCodeProps) {
     [],
   );
 
-  // The anchor is a captured viewport rect, so scroll/resize would let the
-  // fixed tooltip drift away from the code. Dismiss it instead of repositioning.
+  // Viewport snapshot; dismiss on scroll/resize rather than repositioning.
   const visible = hovered || copied;
   useEffect(() => {
     if (!visible) return;

--- a/apps/web/components/task/chat/messages/inline-code.tsx
+++ b/apps/web/components/task/chat/messages/inline-code.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 
@@ -8,45 +9,78 @@ type InlineCodeProps = {
   children: React.ReactNode;
 };
 
+const COPIED_RESET_MS = 1500;
+
+type TooltipAnchor = { left: number; top: number };
+
+/**
+ * Inline `code` span with a click-to-copy affordance.
+ *
+ * The hover / "Copied!" tooltip is rendered through a portal on `document.body`
+ * rather than as an absolutely-positioned child. Inline code frequently lives
+ * inside containers that clip their overflow (e.g. the rounded user-message
+ * bubble, which nests several `overflow-hidden` layers); an in-flow absolute
+ * tooltip gets clipped by those ancestors. Portaling it to the body lets it
+ * float freely so it is never clipped.
+ */
 export function InlineCode({ children }: InlineCodeProps) {
   const { copy } = useCopyToClipboard();
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [tooltipText, setTooltipText] = useState("Copy to clipboard");
+  const [anchor, setAnchor] = useState<TooltipAnchor | null>(null);
+  const [hovered, setHovered] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleClick = async () => {
-    const text = String(children);
-    await copy(text);
-    setTooltipText("Copied!");
-    setShowTooltip(true);
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
 
-    setTimeout(() => {
-      setShowTooltip(false);
-      setTimeout(() => setTooltipText("Copy to clipboard"), 200);
-    }, 1500);
+  const anchorTo = (el: HTMLElement) => {
+    const rect = el.getBoundingClientRect();
+    setAnchor({ left: rect.left + rect.width / 2, top: rect.top });
+  };
+
+  const handleClick = async (event: React.MouseEvent<HTMLElement>) => {
+    anchorTo(event.currentTarget);
+    await copy(String(children));
+    setCopied(true);
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
   };
 
   return (
-    <span className="relative inline-block group/inline-code">
+    <>
       <code
         onClick={handleClick}
+        onMouseEnter={(event) => {
+          anchorTo(event.currentTarget);
+          setHovered(true);
+        }}
+        onMouseLeave={() => setHovered(false)}
         className="cursor-pointer hover:bg-foreground/10 transition-colors"
       >
         {children}
       </code>
 
-      {/* Tooltip */}
-      <span
-        className={cn(
-          "absolute bottom-full left-1/2 -translate-x-1/2 mb-1",
-          "px-2 py-1 text-xs text-popover-foreground bg-popover border border-border rounded shadow-md whitespace-nowrap",
-          "pointer-events-none select-none transition-opacity duration-200",
-          "opacity-0 group-hover/inline-code:opacity-100",
-          showTooltip && "opacity-100",
+      {(hovered || copied) &&
+        anchor &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <span
+            role="tooltip"
+            style={{ left: anchor.left, top: anchor.top - 4 }}
+            className={cn(
+              "fixed z-50 -translate-x-1/2 -translate-y-full",
+              "rounded border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md",
+              "pointer-events-none select-none whitespace-nowrap",
+            )}
+          >
+            {copied ? "Copied!" : "Copy to clipboard"}
+          </span>,
+          document.body,
         )}
-      >
-        {tooltipText}
-        <span className="absolute top-full left-1/2 -translate-x-1/2 -mt-px border-4 border-transparent border-t-border" />
-      </span>
-    </span>
+    </>
   );
 }


### PR DESCRIPTION
User message bubbles nest their content inside three `overflow-hidden` layers, which clipped the absolutely-positioned hover/copy tooltip on inline `code` spans — the tooltip was cut off at the top of the bubble when the code appeared on the first line. Porting the tooltip to `document.body` via a React portal lets it escape the clipping context and always render correctly above the bubble.

## Validation

- `pnpm exec vitest run components/task/chat/messages/inline-code.test.tsx` — 4 tests pass, including a regression test that asserts the tooltip lands on `document.body` and not inside an `overflow-hidden` wrapper
- `pnpm --filter @kandev/web lint` — clean
- `pnpm typecheck` — clean

## Checklist

- [ ] Tests added/updated
- [ ] Types updated
- [ ] No breaking changes