### PR TITLE
fix: keep env prep out of partial tool history

### DIFF
--- a/apps/web/components/task/chat/messages/turn-group-message.test.tsx
+++ b/apps/web/components/task/chat/messages/turn-group-message.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { sessionId as toSessionId, taskId as toTaskId, type Message } from "@/lib/types/http";
+import { TurnGroupMessage } from "./turn-group-message";
+
+function toolExecute(id: string, command = "gh pr checks"): Message {
+  return {
+    id,
+    session_id: toSessionId("s1"),
+    task_id: toTaskId("t1"),
+    author_type: "agent",
+    content: command,
+    type: "tool_execute",
+    turn_id: "turn-1",
+    created_at: "2026-05-30T10:00:00Z",
+    metadata: {
+      status: "complete",
+      normalized: {
+        shell_exec: {
+          command,
+          output: { exit_code: 0, stdout: "1" },
+        },
+      },
+    },
+  };
+}
+
+describe("TurnGroupMessage repeated tool compaction", () => {
+  it("summarizes the middle of a long run of identical terminal commands", () => {
+    const messages = Array.from({ length: 6 }, (_, i) => toolExecute(`tool-${i + 1}`));
+
+    const html = renderToStaticMarkup(
+      <TurnGroupMessage
+        group={{
+          type: "turn_group",
+          id: "turn-group-tool-1",
+          turnId: "turn-1",
+          messages,
+        }}
+        sessionId="s1"
+        permissionsByToolCallId={new Map()}
+        isLastGroup
+        isTurnActive
+      />,
+    );
+
+    expect(html).toContain('data-testid="repeated-tool-summary"');
+    expect(html).toContain("4 repeated identical terminal commands hidden");
+  });
+});

--- a/apps/web/components/task/chat/messages/turn-group-message.tsx
+++ b/apps/web/components/task/chat/messages/turn-group-message.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, memo } from "react";
+import { useState, useCallback, memo, useMemo } from "react";
 import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import { GridSpinner } from "@/components/grid-spinner";
 import { cn, transformPathsInText } from "@/lib/utils";
@@ -183,22 +183,20 @@ function getCompleteShellExec(message: Message): ShellExecPayload | null {
   return metadata.normalized?.shell_exec ?? null;
 }
 
-function readZeroExitCode(shellExec: ShellExecPayload): number | null {
-  const output = shellExec?.output;
-  const exitCode = output?.exit_code ?? 0;
-  return exitCode === 0 ? exitCode : null;
+function isZeroExitCode(shellExec: ShellExecPayload): boolean {
+  const exitCode = shellExec?.output?.exit_code;
+  return exitCode === 0;
 }
 
 function readShellExecSummary(message: Message): ShellExecSummary | null {
   const shellExec = getCompleteShellExec(message);
   if (!shellExec) return null;
-  const exitCode = readZeroExitCode(shellExec);
-  if (exitCode === null) return null;
+  if (!isZeroExitCode(shellExec)) return null;
   const output = shellExec.output;
   return {
     command: shellExec?.command ?? message.content,
     workDir: shellExec?.work_dir ?? "",
-    exitCode,
+    exitCode: 0,
     stdout: output?.stdout ?? "",
     stderr: output?.stderr ?? "",
   };
@@ -339,9 +337,10 @@ function TurnGroupContent({
     taskState,
     onScrollToMessage,
   };
+  const compacted = useMemo(() => compactTurnGroupMessages(group.messages), [group.messages]);
   return (
     <div className="ml-2 pl-4 border-l-2 border-border/30 mt-1 space-y-2">
-      {compactTurnGroupMessages(group.messages).map((entry) =>
+      {compacted.map((entry) =>
         entry.kind === "message" ? (
           renderMessageEntry(entry.message, renderProps)
         ) : (

--- a/apps/web/components/task/chat/messages/turn-group-message.tsx
+++ b/apps/web/components/task/chat/messages/turn-group-message.tsx
@@ -290,7 +290,7 @@ function RepeatedToolSummary({
         aria-expanded={expanded}
         onClick={() => setExpanded((prev) => !prev)}
         className={cn(
-          "flex w-full items-center gap-2 rounded px-2 py-1 -mx-2 text-left",
+          "flex w-full items-center gap-2 rounded px-2 py-1 -mx-2 text-left cursor-pointer",
           "hover:bg-muted/40 transition-colors",
         )}
       >

--- a/apps/web/components/task/chat/messages/turn-group-message.tsx
+++ b/apps/web/components/task/chat/messages/turn-group-message.tsx
@@ -160,6 +160,160 @@ type TurnGroupContentProps = {
   onScrollToMessage?: (messageId: string) => void;
 };
 
+const MIN_REPEAT_TOOL_RUN = 4;
+
+type TurnGroupContentEntry =
+  | { kind: "message"; message: Message }
+  | { kind: "repeated_tool_summary"; id: string; messages: Message[] };
+
+type ShellExecSummary = {
+  command: string;
+  workDir: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+type ShellExecPayload = NonNullable<NonNullable<ToolCallMetadata["normalized"]>["shell_exec"]>;
+
+function getCompleteShellExec(message: Message): ShellExecPayload | null {
+  if (message.type !== "tool_execute") return null;
+  const metadata = message.metadata as ToolCallMetadata | undefined;
+  if (metadata?.status !== "complete") return null;
+  return metadata.normalized?.shell_exec ?? null;
+}
+
+function readZeroExitCode(shellExec: ShellExecPayload): number | null {
+  const output = shellExec?.output;
+  const exitCode = output?.exit_code ?? 0;
+  return exitCode === 0 ? exitCode : null;
+}
+
+function readShellExecSummary(message: Message): ShellExecSummary | null {
+  const shellExec = getCompleteShellExec(message);
+  if (!shellExec) return null;
+  const exitCode = readZeroExitCode(shellExec);
+  if (exitCode === null) return null;
+  const output = shellExec.output;
+  return {
+    command: shellExec?.command ?? message.content,
+    workDir: shellExec?.work_dir ?? "",
+    exitCode,
+    stdout: output?.stdout ?? "",
+    stderr: output?.stderr ?? "",
+  };
+}
+
+function repeatFingerprint(message: Message): string | null {
+  const summary = readShellExecSummary(message);
+  return summary ? JSON.stringify(summary) : null;
+}
+
+function compactRepeatRun(entries: TurnGroupContentEntry[], run: Message[]) {
+  if (run.length >= MIN_REPEAT_TOOL_RUN) {
+    entries.push({ kind: "message", message: run[0] });
+    entries.push({
+      kind: "repeated_tool_summary",
+      id: `repeated-tools-${run[1].id}`,
+      messages: run.slice(1, -1),
+    });
+    entries.push({ kind: "message", message: run[run.length - 1] });
+    return;
+  }
+  for (const message of run) entries.push({ kind: "message", message });
+}
+
+export function compactTurnGroupMessages(messages: Message[]): TurnGroupContentEntry[] {
+  const entries: TurnGroupContentEntry[] = [];
+  let repeatRun: Message[] = [];
+  let currentFingerprint: string | null = null;
+
+  const flushRun = () => {
+    if (repeatRun.length === 0) return;
+    compactRepeatRun(entries, repeatRun);
+    repeatRun = [];
+    currentFingerprint = null;
+  };
+
+  for (const message of messages) {
+    const fingerprint = repeatFingerprint(message);
+    if (!fingerprint) {
+      flushRun();
+      entries.push({ kind: "message", message });
+      continue;
+    }
+    if (currentFingerprint === fingerprint) {
+      repeatRun.push(message);
+      continue;
+    }
+    flushRun();
+    currentFingerprint = fingerprint;
+    repeatRun = [message];
+  }
+  flushRun();
+  return entries;
+}
+
+type MessageRenderProps = Omit<TurnGroupContentProps, "group">;
+
+function renderMessageEntry(message: Message, props: MessageRenderProps) {
+  return (
+    <MessageRenderer
+      key={message.id}
+      comment={message}
+      isTaskDescription={false}
+      taskId={props.taskId}
+      sessionState={props.sessionState}
+      taskState={props.taskState}
+      permissionsByToolCallId={props.permissionsByToolCallId}
+      childrenByParentToolCallId={props.childrenByParentToolCallId}
+      worktreePath={props.worktreePath}
+      sessionId={props.sessionId ?? undefined}
+      onOpenFile={props.onOpenFile}
+      allMessages={props.allMessages}
+      onScrollToMessage={props.onScrollToMessage}
+    />
+  );
+}
+
+function RepeatedToolSummary({
+  entry,
+  renderProps,
+}: {
+  entry: Extract<TurnGroupContentEntry, { kind: "repeated_tool_summary" }>;
+  renderProps: MessageRenderProps;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const count = entry.messages.length;
+  return (
+    <div data-testid="repeated-tool-summary" className="text-xs text-muted-foreground">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+        className={cn(
+          "flex w-full items-center gap-2 rounded px-2 py-1 -mx-2 text-left",
+          "hover:bg-muted/40 transition-colors",
+        )}
+      >
+        {expanded ? (
+          <IconChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+        ) : (
+          <IconChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+        )}
+        <span className="min-w-0 break-words">
+          {count} repeated identical terminal commands {expanded ? "shown" : "hidden"}
+        </span>
+      </button>
+      {expanded && (
+        <div className="mt-1 space-y-2">
+          {entry.messages.map((msg) => renderMessageEntry(msg, renderProps))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function TurnGroupContent({
   group,
   sessionId,
@@ -173,25 +327,27 @@ function TurnGroupContent({
   taskState,
   onScrollToMessage,
 }: TurnGroupContentProps) {
+  const renderProps: MessageRenderProps = {
+    sessionId,
+    permissionsByToolCallId,
+    childrenByParentToolCallId,
+    taskId,
+    worktreePath,
+    onOpenFile,
+    allMessages,
+    sessionState,
+    taskState,
+    onScrollToMessage,
+  };
   return (
     <div className="ml-2 pl-4 border-l-2 border-border/30 mt-1 space-y-2">
-      {group.messages.map((msg) => (
-        <MessageRenderer
-          key={msg.id}
-          comment={msg}
-          isTaskDescription={false}
-          taskId={taskId}
-          sessionState={sessionState}
-          taskState={taskState}
-          permissionsByToolCallId={permissionsByToolCallId}
-          childrenByParentToolCallId={childrenByParentToolCallId}
-          worktreePath={worktreePath}
-          sessionId={sessionId ?? undefined}
-          onOpenFile={onOpenFile}
-          allMessages={allMessages}
-          onScrollToMessage={onScrollToMessage}
-        />
-      ))}
+      {compactTurnGroupMessages(group.messages).map((entry) =>
+        entry.kind === "message" ? (
+          renderMessageEntry(entry.message, renderProps)
+        ) : (
+          <RepeatedToolSummary key={entry.id} entry={entry} renderProps={renderProps} />
+        ),
+      )}
     </div>
   );
 }

--- a/apps/web/components/task/chat/use-chat-panel-state.ts
+++ b/apps/web/components/task/chat/use-chat-panel-state.ts
@@ -384,8 +384,14 @@ function useSessionData(
   taskId: string | null,
   taskDescription: string | null,
 ) {
-  const { messages, isLoading: messagesLoading } = useSessionMessages(resolvedSessionId);
-  const processed = useProcessedMessages(messages, taskId, resolvedSessionId, taskDescription);
+  const {
+    messages,
+    isLoading: messagesLoading,
+    hasMore: hasOlderMessages,
+  } = useSessionMessages(resolvedSessionId);
+  const processed = useProcessedMessages(messages, taskId, resolvedSessionId, taskDescription, {
+    hasOlderMessages,
+  });
   const { sessionModel, activeModel } = useSessionModel(
     resolvedSessionId,
     session?.agent_profile_id,

--- a/apps/web/e2e/tests/chat/mobile-repeated-tool-activity.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-repeated-tool-activity.spec.ts
@@ -1,0 +1,58 @@
+// Filename starts with "mobile-" so the mobile-chrome project exercises this
+// narrow-touch chat surface.
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+function repeatedToolMetadata(i: number) {
+  return {
+    status: "complete",
+    tool_call_id: `tc-repeat-${i}`,
+    normalized: {
+      shell_exec: {
+        command: "gh pr checks",
+        output: { exit_code: 0, stdout: "1" },
+      },
+    },
+  };
+}
+
+test.describe("mobile: repeated tool activity", () => {
+  test("compacts repeated terminal commands inside an expanded turn group", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "Repeated Tool Activity", {
+      description: "seeded repeated tool activity",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      agent_profile_id: seedData.agentProfileId,
+      repository_ids: [seedData.repositoryId],
+    });
+    const { session_id: sessionId } = await apiClient.seedTaskSession(task.id, {
+      state: "IDLE",
+      agentProfileId: seedData.agentProfileId,
+    });
+
+    for (let i = 0; i < 6; i++) {
+      await apiClient.seedSessionMessage(sessionId, {
+        type: "tool_execute",
+        content: "gh pr checks",
+        metadata: repeatedToolMetadata(i),
+      });
+    }
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    const chat = session.activeChat();
+    const groupToggle = chat.getByRole("button", { name: /6\s+tool calls/i });
+    await expect(groupToggle).toBeVisible({ timeout: 15_000 });
+    await groupToggle.click();
+
+    await expect(chat.getByTestId("repeated-tool-summary")).toContainText(
+      "4 repeated identical terminal commands hidden",
+    );
+  });
+});

--- a/apps/web/hooks/domains/session/use-session-messages.test.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.test.ts
@@ -30,6 +30,7 @@ import {
   hasUserOrAgentMessage,
   runBackfillRound,
   autoBackfillUntilUserMessage,
+  MAX_AUTO_BACKFILL_PAGES,
 } from "./use-session-messages";
 
 function makeMessage(overrides: Partial<Message>): Message {
@@ -198,7 +199,7 @@ describe("autoBackfillUntilUserMessage", () => {
     });
     const store = makeStore({ messages: [], hasMore: true, oldestCursor: "cursor-0" });
     await autoBackfillUntilUserMessage("sess-1", store as never);
-    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(10);
+    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(MAX_AUTO_BACKFILL_PAGES);
   });
 
   it("stops after round 1 once a user message is prepended", async () => {

--- a/apps/web/hooks/domains/session/use-session-messages.test.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.test.ts
@@ -162,14 +162,43 @@ describe("runBackfillRound", () => {
 });
 
 describe("autoBackfillUntilUserMessage", () => {
-  it("stops after MAX_BACKFILL_ROUNDS (3) without finding a user/agent message", async () => {
+  it("continues past three pages until a user/agent message is found", async () => {
+    mockListTaskSessionMessages
+      .mockResolvedValueOnce({
+        messages: [makeMessage({ id: "tool-1", type: "tool_call", author_type: "agent" })],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        messages: [makeMessage({ id: "tool-2", type: "tool_call", author_type: "agent" })],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        messages: [makeMessage({ id: "tool-3", type: "tool_call", author_type: "agent" })],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        messages: [makeMessage({ id: "tool-4", type: "tool_call", author_type: "agent" })],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        messages: [makeMessage({ id: "user-1", type: "message", author_type: "user" })],
+        has_more: true,
+      });
+    const store = makeStore({ messages: [], hasMore: true, oldestCursor: "cursor-0" });
+
+    await autoBackfillUntilUserMessage("sess-1", store as never);
+
+    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(5);
+  });
+
+  it("stops after the auto-backfill page budget without finding a user/agent message", async () => {
     mockListTaskSessionMessages.mockResolvedValue({
       messages: [makeMessage({ id: "t1", type: "tool_call", author_type: "agent" })],
       has_more: true,
     });
     const store = makeStore({ messages: [], hasMore: true, oldestCursor: "cursor-0" });
     await autoBackfillUntilUserMessage("sess-1", store as never);
-    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(3);
+    expect(mockListTaskSessionMessages).toHaveBeenCalledTimes(10);
   });
 
   it("stops after round 1 once a user message is prepended", async () => {

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -7,7 +7,7 @@ import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const INITIAL_FETCH_LIMIT = 100;
 const BACKFILL_PAGE_LIMIT = 100;
-const MAX_BACKFILL_ROUNDS = 3;
+const MAX_AUTO_BACKFILL_PAGES = 10;
 
 export function hasUserOrAgentMessage(messages: Message[]): boolean {
   return messages.some(
@@ -120,7 +120,7 @@ async function fetchAndStoreMessages(
  * past — the lazy-load sentinel at the top of the list never fires because
  * the user has no anchor to scroll from. Paginate backward via the same HTTP
  * endpoint `useLazyLoadMessages` uses until we span at least one user/agent
- * message or hit the round cap.
+ * message or hit the page budget.
  */
 export type BackfillStep = "continue" | "stop";
 
@@ -178,13 +178,14 @@ export async function autoBackfillUntilUserMessage(
   sessionId: string,
   store: ReturnType<typeof useAppStoreApi>,
 ): Promise<void> {
-  for (let round = 0; round < MAX_BACKFILL_ROUNDS; round++) {
+  for (let round = 0; round < MAX_AUTO_BACKFILL_PAGES; round++) {
     const step = await runBackfillRound(sessionId, store, round);
     if (step === "stop") return;
   }
-  debug("autoBackfill: hit round cap without finding user/agent message", {
+  debug("autoBackfill: hit page budget without finding user/agent message", {
     sessionId,
-    cap: MAX_BACKFILL_ROUNDS,
+    pageBudget: MAX_AUTO_BACKFILL_PAGES,
+    messageBudget: MAX_AUTO_BACKFILL_PAGES * BACKFILL_PAGE_LIMIT,
   });
 }
 

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -7,7 +7,7 @@ import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
 
 const INITIAL_FETCH_LIMIT = 100;
 const BACKFILL_PAGE_LIMIT = 100;
-const MAX_AUTO_BACKFILL_PAGES = 10;
+export const MAX_AUTO_BACKFILL_PAGES = 10;
 
 export function hasUserOrAgentMessage(messages: Message[]): boolean {
   return messages.some(

--- a/apps/web/hooks/use-processed-messages.test.ts
+++ b/apps/web/hooks/use-processed-messages.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/types/http";
 import type { RichMetadata } from "@/components/task/chat/types";
 import {
+  buildGroupedRenderItems,
   collapseTodoSnapshotsPerTurn,
   deduplicateAgentBootResumes,
   isAgentBootResumeMessage,
@@ -37,6 +38,17 @@ function makeTodo(
   todos: Array<{ text: string; done?: boolean }>,
 ): Message {
   return { ...makeMessage(id, "todo", { todos }), turn_id: turnId };
+}
+
+function toolExecute(id: string, turnId = "turn-1"): Message {
+  return {
+    ...makeMessage(id, "tool_execute", {
+      status: "complete",
+      normalized: { shell_exec: { command: "gh pr checks", output: { exit_code: 0 } } },
+    }),
+    content: "gh pr checks",
+    turn_id: turnId,
+  };
 }
 
 function bootStarted(id: string): Message {
@@ -221,5 +233,27 @@ describe("collapseTodoSnapshotsPerTurn", () => {
     collapseTodoSnapshotsPerTurn([t1, t2]);
     expect(t1.metadata).toEqual({ todos: [{ text: "a" }] });
     expect(t2.metadata).toEqual({ todos: [{ text: "a", done: true }] });
+  });
+});
+
+describe("buildGroupedRenderItems prepare progress placement", () => {
+  it("does not inject prepare progress into a partial tool-only history window", () => {
+    const partialWindow = [toolExecute("tool-1"), toolExecute("tool-2")];
+
+    const result = buildGroupedRenderItems(partialWindow, "s1", {
+      canAnchorPrepareProgress: false,
+    });
+
+    expect(result.map((item) => item.type)).toEqual(["turn_group"]);
+  });
+
+  it("injects prepare progress when the session start is loaded", () => {
+    const initialPrompt = makeMessage("user-1", "message", undefined, "start");
+
+    const result = buildGroupedRenderItems([initialPrompt], "s1", {
+      canAnchorPrepareProgress: true,
+    });
+
+    expect(result.map((item) => item.type)).toEqual(["message", "prepare_progress"]);
   });
 });

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -105,6 +105,14 @@ export type PrepareProgressItem = {
 
 export type RenderItem = { type: "message"; message: Message } | TurnGroup | PrepareProgressItem;
 
+export type GroupedRenderOptions = {
+  canAnchorPrepareProgress?: boolean;
+};
+
+export type ProcessedMessagesOptions = {
+  hasOlderMessages?: boolean;
+};
+
 function buildToolCallIds(messages: Message[]): Set<string> {
   const set = new Set<string>();
   for (const message of messages) {
@@ -332,8 +340,10 @@ function groupActivityMessages(allMessages: Message[]): RenderItem[] {
 function injectPrepareProgressItem(
   items: RenderItem[],
   resolvedSessionId: string | null,
+  options: GroupedRenderOptions = {},
 ): RenderItem[] {
   if (!resolvedSessionId) return items;
+  if (options.canAnchorPrepareProgress === false) return items;
   const prepareItem: PrepareProgressItem = {
     type: "prepare_progress",
     id: `prepare-progress-${resolvedSessionId}`,
@@ -343,11 +353,58 @@ function injectPrepareProgressItem(
   return [items[0], prepareItem, ...items.slice(1)];
 }
 
+export function buildGroupedRenderItems(
+  regularMessages: Message[],
+  resolvedSessionId: string | null,
+  options: GroupedRenderOptions = {},
+): RenderItem[] {
+  return injectPrepareProgressItem(
+    groupActivityMessages(regularMessages),
+    resolvedSessionId,
+    options,
+  );
+}
+
+function canAnchorPrepareProgress(messages: Message[], hasOlderMessages: boolean): boolean {
+  if (!hasOlderMessages) return true;
+  return messages.some(isSetupScriptMessage);
+}
+
+function buildGroupedItemsForHook(args: {
+  regularMessages: Message[];
+  allSessionMessages: Message[];
+  resolvedSessionId: string | null;
+  hasOlderMessages: boolean;
+}): RenderItem[] {
+  return buildGroupedRenderItems(args.regularMessages, args.resolvedSessionId, {
+    canAnchorPrepareProgress: canAnchorPrepareProgress(
+      args.allSessionMessages,
+      args.hasOlderMessages,
+    ),
+  });
+}
+
+function buildTodoItems(visibleMessages: Message[]) {
+  const latestTodos = [...visibleMessages]
+    .reverse()
+    .find((message) => message.type === "todo" || (message.metadata as { todos?: unknown })?.todos);
+  return (
+    (
+      latestTodos?.metadata as
+        | { todos?: Array<{ text: string; done?: boolean } | string> }
+        | undefined
+    )?.todos
+      ?.map((item) => (typeof item === "string" ? { text: item, done: false } : item))
+      .filter((item) => item.text) ?? []
+  );
+}
+
 export function useProcessedMessages(
   messages: Message[],
   taskId: string | null,
   resolvedSessionId: string | null,
   taskDescription: string | null,
+  options: ProcessedMessagesOptions = {},
 ) {
   const toolCallIds = useMemo(() => buildToolCallIds(messages), [messages]);
   const permissionsByToolCallId = useMemo(() => buildPermissionsByToolCallId(messages), [messages]);
@@ -388,22 +445,7 @@ export function useProcessedMessages(
     return taskDescriptionMessage ? [taskDescriptionMessage, ...visibleMessages] : visibleMessages;
   }, [taskDescriptionMessage, visibleMessages]);
 
-  const todoItems = useMemo(() => {
-    const latestTodos = [...visibleMessages]
-      .reverse()
-      .find(
-        (message) => message.type === "todo" || (message.metadata as { todos?: unknown })?.todos,
-      );
-    return (
-      (
-        latestTodos?.metadata as
-          | { todos?: Array<{ text: string; done?: boolean } | string> }
-          | undefined
-      )?.todos
-        ?.map((item) => (typeof item === "string" ? { text: item, done: false } : item))
-        .filter((item) => item.text) ?? []
-    );
-  }, [visibleMessages]);
+  const todoItems = useMemo(() => buildTodoItems(visibleMessages), [visibleMessages]);
 
   const agentMessageCount = useMemo(() => {
     return visibleMessages.filter((c) => c.author_type !== "user").length;
@@ -426,8 +468,13 @@ export function useProcessedMessages(
   }, [allMessages]);
 
   const groupedItems = useMemo<RenderItem[]>(() => {
-    return injectPrepareProgressItem(groupActivityMessages(regularMessages), resolvedSessionId);
-  }, [regularMessages, resolvedSessionId]);
+    return buildGroupedItemsForHook({
+      regularMessages,
+      allSessionMessages: messages,
+      resolvedSessionId,
+      hasOlderMessages: options.hasOlderMessages ?? false,
+    });
+  }, [regularMessages, resolvedSessionId, messages, options.hasOlderMessages]);
 
   useDebugProcessedPipeline({
     sessionId: resolvedSessionId,


### PR DESCRIPTION
The chat could show environment preparation inside a long-running tool turn when only a partial message window was loaded. Environment prep is now anchored only when session-start history is available, and repeated terminal activity is compacted so large turns stay usable.

## Important Changes

- Guard prepare-progress injection when older session history is still unloaded.
- Increase automatic tool-only backfill to a bounded 10-page budget.
- Collapse identical successful terminal executions inside expanded turn groups, with a mobile E2E regression.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run tests/chat/mobile-repeated-tool-activity.spec.ts -- --project=mobile-chrome`

## Possible Improvements

Low risk: a backend latest-window-plus-anchor API would avoid bounded client-side backfill for extremely large turns.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.