### PR TITLE
fix: preserve whitespace in acp message chunks

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_updates.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_updates.go
@@ -287,11 +287,13 @@ func (a *Adapter) convertMessageChunk(sessionID string, content acp.ContentBlock
 		// strip them from the chat text. Assistant role only — genuine user
 		// messages don't carry these.
 		if role == "assistant" {
-			text = a.routeMonitorEvents(sessionID, text)
-			if isMonitorHumanEcho(text) {
+			cleaned := a.routeMonitorEvents(sessionID, text)
+			monitorTextRemoved := cleaned != text
+			text = cleaned
+			if monitorTextRemoved && strings.TrimSpace(text) == "" {
 				return nil
 			}
-			if strings.TrimSpace(text) == "" {
+			if isMonitorHumanEcho(text) {
 				return nil
 			}
 		}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/conversion_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/conversion_test.go
@@ -466,6 +466,22 @@ func TestConvertMessageChunk_TextAssistant(t *testing.T) {
 	}
 }
 
+func TestConvertMessageChunk_PreservesAssistantWhitespaceOnlyText(t *testing.T) {
+	a := newTestAdapter()
+	cases := []string{" ", "\n", "\n\n"}
+
+	for _, text := range cases {
+		result := a.convertMessageChunk("session-1", acp.TextBlock(text), "assistant")
+
+		if result == nil {
+			t.Fatalf("expected non-nil result for %q", text)
+		}
+		if result.Text != text {
+			t.Errorf("Text = %q, want %q", result.Text, text)
+		}
+	}
+}
+
 func TestConvertMessageChunk_TextUser(t *testing.T) {
 	a := newTestAdapter()
 	cb := acp.TextBlock("Hello from user")

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/conversion_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/conversion_test.go
@@ -474,11 +474,28 @@ func TestConvertMessageChunk_PreservesAssistantWhitespaceOnlyText(t *testing.T) 
 		result := a.convertMessageChunk("session-1", acp.TextBlock(text), "assistant")
 
 		if result == nil {
-			t.Fatalf("expected non-nil result for %q", text)
+			t.Errorf("expected non-nil result for %q", text)
+			continue
 		}
 		if result.Text != text {
 			t.Errorf("Text = %q, want %q", result.Text, text)
 		}
+	}
+}
+
+func TestConvertMessageChunk_MonitorEnvelopeRemovedLeavesWhitespace_DropsChunk(t *testing.T) {
+	a := newTestAdapter()
+	seedMonitor(t, a, "s1", "t1", "tc-monitor")
+
+	// The envelope is the only non-whitespace content; after stripping it only
+	// "\n\n" remains. Because monitorTextRemoved is true and the remainder is
+	// whitespace-only, the chunk should be suppressed (return nil).
+	chunk := acp.TextBlock(
+		"<task-notification><task-id>t1</task-id><event>x</event></task-notification>\n\n",
+	)
+	ev := a.convertMessageChunk("s1", chunk, "assistant")
+	if ev != nil {
+		t.Errorf("expected nil (envelope stripped to whitespace-only should drop), got %+v", ev)
 	}
 }
 


### PR DESCRIPTION
ACP streaming can deliver structural whitespace as standalone chunks; dropping those chunks corrupts persisted markdown before the UI sees it. The ACP normalizer now preserves ordinary whitespace while still suppressing Monitor envelope-only chunks.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.