### PR TITLE
fix: track OS PIDs and clean up shells on task archive/delete

### DIFF
--- a/apps/backend/cmd/kandev/gateway.go
+++ b/apps/backend/cmd/kandev/gateway.go
@@ -125,6 +125,9 @@ func provideGateway(
 			ptyBackend = terminalservice.NewInteractiveRunnerBackend(lifecycleMgr.GetInteractiveRunner())
 		}
 		terminalSvc = terminalservice.New(terminalRepo, ptyBackend, log)
+		if taskRepo != nil {
+			terminalSvc.SetTaskEnvironmentReader(taskRepo)
+		}
 	}
 
 	// Enable dedicated terminal WebSocket for passthrough mode

--- a/apps/backend/cmd/kandev/gateway.go
+++ b/apps/backend/cmd/kandev/gateway.go
@@ -312,12 +312,22 @@ func subscribeTerminalCleanup(ctx context.Context, eventBus bus.EventBus, svc *t
 			// Plain update — only react on archive transitions.
 			return nil
 		}
-		if _, err := svc.CleanupTask(eventCtx, taskID); err != nil {
+		log.Info("terminal cleanup on task event started",
+			zap.String("task_id", taskID),
+			zap.String("event", event.Type),
+			zap.Bool("archived", archivedAt != ""))
+		deleted, err := svc.CleanupTask(eventCtx, taskID)
+		if err != nil {
 			log.Warn("terminal cleanup on task event",
 				zap.String("task_id", taskID),
 				zap.String("event", event.Type),
 				zap.Error(err))
+			return nil
 		}
+		log.Info("terminal cleanup on task event completed",
+			zap.String("task_id", taskID),
+			zap.String("event", event.Type),
+			zap.Int("deleted_terminal_rows", deleted))
 		return nil
 	}
 	if _, err := eventBus.Subscribe(events.TaskDeleted, handler); err != nil {

--- a/apps/backend/internal/agentctl/server/process/interactive_lifecycle.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_lifecycle.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"sync"
@@ -274,9 +275,17 @@ func (r *InteractiveRunner) startProcess(proc *interactiveProcess, cols, rows in
 	r.logger.Info("interactive process started at exact dimensions",
 		zap.String("process_id", proc.info.ID),
 		zap.String("session_id", proc.info.SessionID),
+		zap.String("scope_id", req.ScopeID),
+		zap.String("terminal_id", req.TerminalID),
+		zap.String("label", req.Label),
+		zap.Bool("is_user_shell", proc.isUserShell),
+		zap.Strings("command", proc.startCmd),
+		zap.String("working_dir", proc.startDir),
+		zap.Int("parent_pid", os.Getpid()),
 		zap.Int("cols", cols),
 		zap.Int("rows", rows),
-		zap.Int("pid", pid),
+		zap.Int("os_pid", pid),
+		zap.Bool("has_initial_command", req.InitialCommand != ""),
 	)
 
 	// Start output reading and process waiting goroutines
@@ -357,6 +366,18 @@ func (r *InteractiveRunner) Stop(ctx context.Context, processID string) error {
 		return fmt.Errorf("process not found: %s", processID)
 	}
 
+	pid := proc.osPID()
+	r.logger.Info("stopping interactive process",
+		zap.String("process_id", processID),
+		zap.String("session_id", proc.info.SessionID),
+		zap.Bool("is_user_shell", proc.isUserShell),
+		zap.String("scope_id", proc.startReq.ScopeID),
+		zap.String("terminal_id", proc.startReq.TerminalID),
+		zap.Strings("command", proc.info.Command),
+		zap.String("working_dir", proc.info.WorkingDir),
+		zap.Int("os_pid", pid),
+		zap.Bool("started", proc.started))
+
 	// Unblock anyone waiting on first-idle — the process is going away.
 	proc.firstIdleOnce.Do(func() {
 		close(proc.firstIdleCh)
@@ -389,8 +410,15 @@ func (r *InteractiveRunner) Stop(ctx context.Context, processID string) error {
 		// If it doesn't exit in time, force-kill the process.
 		select {
 		case <-ctx.Done():
+			r.logger.Warn("interactive process stop context canceled; killing process",
+				zap.String("process_id", processID),
+				zap.Int("os_pid", pid),
+				zap.Error(ctx.Err()))
 			_ = proc.cmd.Process.Kill()
 		case <-time.After(2 * time.Second):
+			r.logger.Warn("interactive process stop timed out; killing process",
+				zap.String("process_id", processID),
+				zap.Int("os_pid", pid))
 			_ = proc.cmd.Process.Kill()
 		case <-proc.waitDone:
 			// Process exited cleanly
@@ -475,6 +503,17 @@ func (r *InteractiveRunner) IsProcessReadyOrPending(processID string) bool {
 	return r.isProcessAlive(proc)
 }
 
+// GetOSPID returns the underlying OS process ID for a started interactive
+// process. Deferred-start processes return (0, true) until their first resize
+// spawns the PTY child.
+func (r *InteractiveRunner) GetOSPID(processID string) (int, bool) {
+	proc, ok := r.get(processID)
+	if !ok {
+		return 0, false
+	}
+	return proc.osPID(), true
+}
+
 // GetBuffer returns the buffered output for a process.
 func (r *InteractiveRunner) GetBuffer(processID string) ([]ProcessOutputChunk, bool) {
 	proc, ok := r.get(processID)
@@ -518,6 +557,12 @@ func (r *InteractiveRunner) wait(proc *interactiveProcess) {
 	r.logger.Info("interactive process exited",
 		zap.String("process_id", proc.info.ID),
 		zap.String("session_id", proc.info.SessionID),
+		zap.String("scope_id", proc.startReq.ScopeID),
+		zap.String("terminal_id", proc.startReq.TerminalID),
+		zap.Bool("is_user_shell", proc.isUserShell),
+		zap.Strings("command", proc.info.Command),
+		zap.String("working_dir", proc.info.WorkingDir),
+		zap.Int("os_pid", proc.osPID()),
 		zap.String("status", string(status)),
 		zap.Int("exit_code", exitCode),
 		zap.String("signal", signalName),
@@ -642,8 +687,22 @@ func (p *interactiveProcess) snapshot(includeOutput bool) InteractiveProcessInfo
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	info := p.info
+	info.OSPID = p.osPIDLocked()
 	if includeOutput && p.buffer != nil {
 		info.Output = p.buffer.snapshot()
 	}
 	return info
+}
+
+func (p *interactiveProcess) osPID() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.osPIDLocked()
+}
+
+func (p *interactiveProcess) osPIDLocked() int {
+	if p.cmd == nil || p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
 }

--- a/apps/backend/internal/agentctl/server/process/interactive_output.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_output.go
@@ -39,6 +39,7 @@ func (r *InteractiveRunner) SetDirectOutput(processID string, writer DirectOutpu
 	r.logger.Info("direct output set for process",
 		zap.String("process_id", processID),
 		zap.String("session_id", sessionID),
+		zap.Int("os_pid", proc.osPID()),
 		zap.Bool("is_user_shell", proc.isUserShell))
 
 	return nil
@@ -86,7 +87,9 @@ func (r *InteractiveRunner) ClearDirectOutput(processID string) error {
 
 	r.logger.Info("direct output cleared for process",
 		zap.String("process_id", processID),
-		zap.String("session_id", sessionID))
+		zap.String("session_id", sessionID),
+		zap.Int("os_pid", proc.osPID()),
+		zap.Bool("is_user_shell", proc.isUserShell))
 
 	return nil
 }

--- a/apps/backend/internal/agentctl/server/process/interactive_runner.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_runner.go
@@ -23,6 +23,9 @@ type InteractiveStartRequest struct {
 	SessionID            string            `json:"session_id"`                       // Required: Agent session owning this process
 	Command              []string          `json:"command"`                          // Required: Command and args to execute
 	WorkingDir           string            `json:"working_dir"`                      // Working directory
+	ScopeID              string            `json:"scope_id,omitempty"`               // User-shell scope (task environment ID) when applicable
+	TerminalID           string            `json:"terminal_id,omitempty"`            // User-shell terminal ID when applicable
+	Label                string            `json:"label,omitempty"`                  // User-facing terminal label when applicable
 	Env                  map[string]string `json:"env,omitempty"`                    // Additional environment variables
 	PromptPattern        string            `json:"prompt_pattern,omitempty"`         // Regex pattern to detect agent prompt for turn completion
 	IdleTimeout          time.Duration     `json:"idle_timeout,omitempty"`           // Idle timeout for turn detection
@@ -44,6 +47,7 @@ type InteractiveProcessInfo struct {
 	SessionID  string               `json:"session_id"`
 	Command    []string             `json:"command"`
 	WorkingDir string               `json:"working_dir"`
+	OSPID      int                  `json:"os_pid,omitempty"`
 	Status     types.ProcessStatus  `json:"status"`
 	ExitCode   *int                 `json:"exit_code,omitempty"`
 	StartedAt  time.Time            `json:"started_at"`

--- a/apps/backend/internal/agentctl/server/process/interactive_shells.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_shells.go
@@ -141,6 +141,16 @@ func (r *InteractiveRunner) StartUserShell(ctx context.Context, scopeID, process
 		if entry.ProcessID != "" {
 			if info, ok := r.Get(entry.ProcessID, false); ok {
 				r.userShellsMu.RUnlock()
+				r.logger.Info("reusing user shell",
+					zap.String("scope_id", scopeID),
+					zap.String("session_id", processSessionID),
+					zap.String("terminal_id", terminalID),
+					zap.String("process_id", info.ID),
+					zap.Int("os_pid", info.OSPID),
+					zap.Strings("command", info.Command),
+					zap.String("working_dir", info.WorkingDir),
+					zap.String("label", entry.Label),
+					zap.String("initial_command", entry.InitialCommand))
 				return info, nil
 			}
 		}
@@ -157,6 +167,9 @@ func (r *InteractiveRunner) StartUserShell(ctx context.Context, scopeID, process
 		SessionID:            processSessionID,
 		Command:              defaultShellCommand(preferredShell),
 		WorkingDir:           workingDir,
+		ScopeID:              scopeID,
+		TerminalID:           terminalID,
+		Label:                opts.Label,
 		InitialCommand:       initialCommand,
 		DisableTurnDetection: true,
 		IsUserShell:          true,
@@ -191,10 +204,12 @@ func (r *InteractiveRunner) StartUserShell(ctx context.Context, scopeID, process
 		zap.String("session_id", processSessionID),
 		zap.String("terminal_id", terminalID),
 		zap.String("process_id", info.ID),
+		zap.Int("os_pid", info.OSPID),
 		zap.String("shell", req.Command[0]),
 		zap.String("working_dir", workingDir),
 		zap.String("label", opts.Label),
-		zap.String("initial_command", opts.InitialCommand))
+		zap.String("initial_command", opts.InitialCommand),
+		zap.Bool("deferred_start", info.OSPID == 0))
 
 	return info, nil
 }
@@ -255,9 +270,72 @@ func (r *InteractiveRunner) StopUserShell(ctx context.Context, scopeID, terminal
 	r.logger.Info("stopping user shell",
 		zap.String("scope_id", scopeID),
 		zap.String("terminal_id", terminalID),
-		zap.String("process_id", entry.ProcessID))
+		zap.String("process_id", entry.ProcessID),
+		zap.Int("os_pid", r.osPIDForProcess(entry.ProcessID)),
+		zap.String("label", entry.Label),
+		zap.String("initial_command", entry.InitialCommand))
 
 	return r.Stop(ctx, entry.ProcessID)
+}
+
+// StopUserShellsForScope stops and unregisters every user shell in a scope.
+// This is used by task archive/delete cleanup where bottom-panel/script shells
+// may not have DB rows but still need to be torn down with the task environment.
+func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID string) (int, error) {
+	if scopeID == "" {
+		return 0, nil
+	}
+
+	prefix := scopeID + ":"
+	type stopTarget struct {
+		terminalID string
+		entry      *userShellEntry
+	}
+	targets := []stopTarget{}
+
+	r.userShellsMu.Lock()
+	for key, entry := range r.userShells {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		delete(r.userShells, key)
+		targets = append(targets, stopTarget{
+			terminalID: key[len(prefix):],
+			entry:      entry,
+		})
+	}
+	r.userShellsMu.Unlock()
+
+	var lastErr error
+	for _, target := range targets {
+		processID := ""
+		label := ""
+		initialCommand := ""
+		if target.entry != nil {
+			processID = target.entry.ProcessID
+			label = target.entry.Label
+			initialCommand = target.entry.InitialCommand
+		}
+		r.logger.Info("stopping user shell for scope cleanup",
+			zap.String("scope_id", scopeID),
+			zap.String("terminal_id", target.terminalID),
+			zap.String("process_id", processID),
+			zap.Int("os_pid", r.osPIDForProcess(processID)),
+			zap.String("label", label),
+			zap.String("initial_command", initialCommand))
+		if processID == "" {
+			continue
+		}
+		if err := r.Stop(ctx, processID); err != nil {
+			r.logger.Warn("failed to stop user shell for scope cleanup",
+				zap.String("scope_id", scopeID),
+				zap.String("terminal_id", target.terminalID),
+				zap.String("process_id", processID),
+				zap.Error(err))
+			lastErr = err
+		}
+	}
+	return len(targets), lastErr
 }
 
 // IsUserShellAlive reports whether the PTY behind (scopeID, terminalID) is
@@ -352,5 +430,18 @@ func (r *InteractiveRunner) ClearUserShellDirectOutput(scopeID, terminalID strin
 
 	r.logger.Info("direct output cleared for user shell",
 		zap.String("scope_id", scopeID),
-		zap.String("terminal_id", terminalID))
+		zap.String("terminal_id", terminalID),
+		zap.String("process_id", entry.ProcessID),
+		zap.Int("os_pid", proc.osPID()))
+}
+
+func (r *InteractiveRunner) osPIDForProcess(processID string) int {
+	if processID == "" {
+		return 0
+	}
+	pid, ok := r.GetOSPID(processID)
+	if !ok {
+		return 0
+	}
+	return pid
 }

--- a/apps/backend/internal/agentctl/server/process/interactive_shells.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_shells.go
@@ -212,7 +212,7 @@ func (r *InteractiveRunner) StartUserShell(ctx context.Context, scopeID, process
 		zap.Int("os_pid", info.OSPID),
 		zap.String("shell", req.Command[0]),
 		zap.String("working_dir", workingDir),
-		zap.String("label", opts.Label),
+		zap.String("label", label),
 		zap.String("initial_command", opts.InitialCommand),
 		zap.Bool("deferred_start", info.OSPID == 0))
 
@@ -332,7 +332,6 @@ func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID 
 		if processID == "" {
 			continue
 		}
-		stoppedCount++
 		if err := r.Stop(ctx, processID); err != nil {
 			r.logger.Warn("failed to stop user shell for scope cleanup",
 				zap.String("scope_id", scopeID),
@@ -340,7 +339,9 @@ func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID 
 				zap.String("process_id", processID),
 				zap.Error(err))
 			lastErr = err
+			continue
 		}
+		stoppedCount++
 	}
 	return stoppedCount, lastErr
 }

--- a/apps/backend/internal/agentctl/server/process/interactive_shells.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_shells.go
@@ -322,6 +322,9 @@ func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID 
 			label = target.entry.Label
 			initialCommand = target.entry.InitialCommand
 		}
+		if processID == "" {
+			continue
+		}
 		r.logger.Info("stopping user shell for scope cleanup",
 			zap.String("scope_id", scopeID),
 			zap.String("terminal_id", target.terminalID),
@@ -329,9 +332,6 @@ func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID 
 			zap.Int("os_pid", r.osPIDForProcess(processID)),
 			zap.String("label", label),
 			zap.String("initial_command", initialCommand))
-		if processID == "" {
-			continue
-		}
 		if err := r.Stop(ctx, processID); err != nil {
 			r.logger.Warn("failed to stop user shell for scope cleanup",
 				zap.String("scope_id", scopeID),

--- a/apps/backend/internal/agentctl/server/process/interactive_shells.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_shells.go
@@ -163,13 +163,18 @@ func (r *InteractiveRunner) StartUserShell(ctx context.Context, scopeID, process
 		initialCommand = existingEntry.InitialCommand
 	}
 
+	label := opts.Label
+	if existingEntry != nil && existingEntry.Label != "" {
+		label = existingEntry.Label
+	}
+
 	req := InteractiveStartRequest{
 		SessionID:            processSessionID,
 		Command:              defaultShellCommand(preferredShell),
 		WorkingDir:           workingDir,
 		ScopeID:              scopeID,
 		TerminalID:           terminalID,
-		Label:                opts.Label,
+		Label:                label,
 		InitialCommand:       initialCommand,
 		DisableTurnDetection: true,
 		IsUserShell:          true,
@@ -307,6 +312,7 @@ func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID 
 	r.userShellsMu.Unlock()
 
 	var lastErr error
+	stoppedCount := 0
 	for _, target := range targets {
 		processID := ""
 		label := ""
@@ -326,6 +332,7 @@ func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID 
 		if processID == "" {
 			continue
 		}
+		stoppedCount++
 		if err := r.Stop(ctx, processID); err != nil {
 			r.logger.Warn("failed to stop user shell for scope cleanup",
 				zap.String("scope_id", scopeID),
@@ -335,7 +342,7 @@ func (r *InteractiveRunner) StopUserShellsForScope(ctx context.Context, scopeID 
 			lastErr = err
 		}
 	}
-	return len(targets), lastErr
+	return stoppedCount, lastErr
 }
 
 // IsUserShellAlive reports whether the PTY behind (scopeID, terminalID) is

--- a/apps/backend/internal/agentctl/server/process/interactive_shells.go
+++ b/apps/backend/internal/agentctl/server/process/interactive_shells.go
@@ -213,7 +213,7 @@ func (r *InteractiveRunner) StartUserShell(ctx context.Context, scopeID, process
 		zap.String("shell", req.Command[0]),
 		zap.String("working_dir", workingDir),
 		zap.String("label", label),
-		zap.String("initial_command", opts.InitialCommand),
+		zap.String("initial_command", initialCommand),
 		zap.Bool("deferred_start", info.OSPID == 0))
 
 	return info, nil

--- a/apps/backend/internal/gateway/websocket/terminal_handler.go
+++ b/apps/backend/internal/gateway/websocket/terminal_handler.go
@@ -483,7 +483,8 @@ func (h *TerminalHandler) startUserShellProcess(
 	h.logger.Info("handleUserShellWS: user shell started successfully",
 		zap.String("session_id", sessionID),
 		zap.String("terminal_id", terminalID),
-		zap.String("process_id", info.ID))
+		zap.String("process_id", info.ID),
+		zap.Int("os_pid", info.OSPID))
 
 	return info.ID, 0, ""
 }
@@ -518,8 +519,20 @@ func (h *TerminalHandler) handleUserShellWS(
 	h.logger.Info("user shell WebSocket connected",
 		zap.String("session_id", sessionID),
 		zap.String("terminal_id", terminalID),
-		zap.String("process_id", processID))
+		zap.String("process_id", processID),
+		zap.Int("os_pid", osPIDForInteractiveProcess(interactiveRunner, processID)))
 
 	wsw := newWsWriter(conn)
 	h.runUserShellBridge(conn, sessionID, scopeID, terminalID, processID, interactiveRunner, wsw)
+}
+
+func osPIDForInteractiveProcess(runner *process.InteractiveRunner, processID string) int {
+	if runner == nil || processID == "" {
+		return 0
+	}
+	pid, ok := runner.GetOSPID(processID)
+	if !ok {
+		return 0
+	}
+	return pid
 }

--- a/apps/backend/internal/gateway/websocket/terminal_pumps.go
+++ b/apps/backend/internal/gateway/websocket/terminal_pumps.go
@@ -423,8 +423,8 @@ func (h *TerminalHandler) runUserShellBridge(
 
 	defer func() {
 		// Clean up WebSocket resources but DON'T stop the process
-		// The process should only be stopped via explicit user_shell.stop message from frontend
-		// This allows reconnection after React remounts or temporary disconnects
+		// The process is stopped by explicit user_shell.stop/destroy or task cleanup.
+		// Keeping it alive here allows reconnect after React remounts or temporary disconnects.
 		interactiveRunner.ClearUserShellDirectOutput(scopeID, terminalID)
 
 		_ = wsw.Close()
@@ -432,7 +432,9 @@ func (h *TerminalHandler) runUserShellBridge(
 
 		h.logger.Info("user shell WebSocket disconnected (process still running for potential reconnect)",
 			zap.String("session_id", sessionID),
-			zap.String("terminal_id", terminalID))
+			zap.String("terminal_id", terminalID),
+			zap.String("process_id", processID),
+			zap.Int("os_pid", osPIDForInteractiveProcess(interactiveRunner, processID)))
 	}()
 
 	// Read from WebSocket and handle input/resize

--- a/apps/backend/internal/terminal/service/ptybackend.go
+++ b/apps/backend/internal/terminal/service/ptybackend.go
@@ -41,6 +41,14 @@ func (b *InteractiveRunnerBackend) Stop(ctx context.Context, scopeID, terminalID
 	return b.runner.StopUserShell(ctx, scopeID, terminalID)
 }
 
+// StopScope tears down every PTY registered under a task-environment scope.
+func (b *InteractiveRunnerBackend) StopScope(ctx context.Context, scopeID string) (int, error) {
+	if b.runner == nil {
+		return 0, nil
+	}
+	return b.runner.StopUserShellsForScope(ctx, scopeID)
+}
+
 // IsAlive reports whether the PTY backing (scopeID, terminalID) is currently
 // running.
 func (b *InteractiveRunnerBackend) IsAlive(scopeID, terminalID string) bool {

--- a/apps/backend/internal/terminal/service/service.go
+++ b/apps/backend/internal/terminal/service/service.go
@@ -56,6 +56,7 @@ var ErrTaskMismatch = errors.New("terminal does not belong to the supplied task"
 type PTYBackend interface {
 	Register(scopeID, terminalID string)
 	Stop(ctx context.Context, scopeID, terminalID string) error
+	StopScope(ctx context.Context, scopeID string) (int, error)
 	IsAlive(scopeID, terminalID string) bool
 }
 
@@ -223,25 +224,55 @@ func (s *Service) Destroy(ctx context.Context, taskID, id string) error {
 }
 
 // CleanupTask is called by the task.deleted/archived event subscriber. It
-// stops every ordinary PTY for the task and deletes the rows. Stop
-// failures are logged but don't block deletion — the DB row is the source
+// stops every PTY registered under the task's terminal environments, including
+// unmanaged bottom-panel/script shells, then deletes ordinary terminal rows.
+// Stop failures are logged but don't block deletion — the DB row is the source
 // of truth for "the user expects this terminal gone".
 func (s *Service) CleanupTask(ctx context.Context, taskID string) (int, error) {
 	rows, err := s.repo.ListByTask(ctx, taskID, true)
 	if err != nil {
 		return 0, err
 	}
+	envIDs := uniqueTerminalEnvironmentIDs(rows)
+	removedPTYEntries := 0
 	if s.pty != nil {
-		for _, r := range rows {
-			if stopErr := s.pty.Stop(ctx, r.EnvironmentID, r.ID); stopErr != nil {
-				s.logWarn("pty stop on cleanup (best-effort)",
+		for _, envID := range envIDs {
+			removed, stopErr := s.pty.StopScope(ctx, envID)
+			removedPTYEntries += removed
+			if stopErr != nil {
+				s.logWarn("pty scope stop on cleanup (best-effort)",
 					zap.String("task_id", taskID),
-					zap.String("terminal_id", r.ID),
+					zap.String("environment_id", envID),
 					zap.Error(stopErr))
 			}
 		}
 	}
-	return s.repo.DeleteByTask(ctx, taskID)
+	deleted, err := s.repo.DeleteByTask(ctx, taskID)
+	if err == nil {
+		s.logInfo("terminal cleanup completed",
+			zap.String("task_id", taskID),
+			zap.Int("terminal_rows", len(rows)),
+			zap.Int("environment_scopes", len(envIDs)),
+			zap.Int("pty_entries_removed", removedPTYEntries),
+			zap.Int("deleted_rows", deleted))
+	}
+	return deleted, err
+}
+
+func uniqueTerminalEnvironmentIDs(rows []*models.Terminal) []string {
+	seen := make(map[string]struct{}, len(rows))
+	envIDs := []string{}
+	for _, row := range rows {
+		if row == nil || row.EnvironmentID == "" {
+			continue
+		}
+		if _, ok := seen[row.EnvironmentID]; ok {
+			continue
+		}
+		seen[row.EnvironmentID] = struct{}{}
+		envIDs = append(envIDs, row.EnvironmentID)
+	}
+	return envIDs
 }
 
 // logWarn is a nil-safe wrapper around s.log.Warn; service unit tests
@@ -251,4 +282,11 @@ func (s *Service) logWarn(msg string, fields ...zap.Field) {
 		return
 	}
 	s.log.Warn(msg, fields...)
+}
+
+func (s *Service) logInfo(msg string, fields ...zap.Field) {
+	if s.log == nil {
+		return
+	}
+	s.log.Info(msg, fields...)
 }

--- a/apps/backend/internal/terminal/service/service.go
+++ b/apps/backend/internal/terminal/service/service.go
@@ -283,7 +283,13 @@ func (s *Service) appendTaskEnvID(ctx context.Context, taskID string, envIDs []s
 	if s.taskEnvRepo == nil {
 		return envIDs
 	}
-	env, _ := s.taskEnvRepo.GetTaskEnvironmentByTaskID(ctx, taskID)
+	env, err := s.taskEnvRepo.GetTaskEnvironmentByTaskID(ctx, taskID)
+	if err != nil {
+		s.logWarn("failed to look up task environment for cleanup",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return envIDs
+	}
 	if env == nil || env.ID == "" {
 		return envIDs
 	}

--- a/apps/backend/internal/terminal/service/service.go
+++ b/apps/backend/internal/terminal/service/service.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/common/logger"
+	taskmodels "github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/terminal/models"
 	"github.com/kandev/kandev/internal/terminal/repository"
 )
@@ -60,16 +61,29 @@ type PTYBackend interface {
 	IsAlive(scopeID, terminalID string) bool
 }
 
+// taskEnvironmentReader is the minimal surface the terminal service needs
+// from the task layer to discover environments for cleanup.
+type taskEnvironmentReader interface {
+	GetTaskEnvironmentByTaskID(ctx context.Context, taskID string) (*taskmodels.TaskEnvironment, error)
+}
+
 // Service is the single entry point for all user-terminal RPCs.
 type Service struct {
-	repo *repository.Repository
-	pty  PTYBackend
-	log  *logger.Logger
+	repo        *repository.Repository
+	pty         PTYBackend
+	taskEnvRepo taskEnvironmentReader
+	log         *logger.Logger
 }
 
 // New constructs a Service.
 func New(repo *repository.Repository, pty PTYBackend, log *logger.Logger) *Service {
 	return &Service{repo: repo, pty: pty, log: log}
+}
+
+// SetTaskEnvironmentReader wires the task-environment repository. Called by
+// cmd/kandev/gateway.go after all repos are initialized.
+func (s *Service) SetTaskEnvironmentReader(r taskEnvironmentReader) {
+	s.taskEnvRepo = r
 }
 
 // IsManaged reports whether the terminal id corresponds to an ordinary
@@ -234,6 +248,12 @@ func (s *Service) CleanupTask(ctx context.Context, taskID string) (int, error) {
 		return 0, err
 	}
 	envIDs := uniqueTerminalEnvironmentIDs(rows)
+
+	// Also discover the environment from the task layer so shells that were
+	// registered for a bottom-panel or script terminal — but never had an
+	// ordinary terminal row — are still torn down.
+	envIDs = s.appendTaskEnvID(ctx, taskID, envIDs)
+
 	removedPTYEntries := 0
 	if s.pty != nil {
 		for _, envID := range envIDs {
@@ -257,6 +277,22 @@ func (s *Service) CleanupTask(ctx context.Context, taskID string) (int, error) {
 			zap.Int("deleted_rows", deleted))
 	}
 	return deleted, err
+}
+
+func (s *Service) appendTaskEnvID(ctx context.Context, taskID string, envIDs []string) []string {
+	if s.taskEnvRepo == nil {
+		return envIDs
+	}
+	env, _ := s.taskEnvRepo.GetTaskEnvironmentByTaskID(ctx, taskID)
+	if env == nil || env.ID == "" {
+		return envIDs
+	}
+	for _, id := range envIDs {
+		if id == env.ID {
+			return envIDs
+		}
+	}
+	return append(envIDs, env.ID)
 }
 
 func uniqueTerminalEnvironmentIDs(rows []*models.Terminal) []string {

--- a/apps/backend/internal/terminal/service/service_test.go
+++ b/apps/backend/internal/terminal/service/service_test.go
@@ -51,6 +51,7 @@ func (f *fakeBackend) StopScope(_ context.Context, scopeID string) (int, error) 
 		}
 		f.stopped[terminalID] = true
 		delete(f.alive, terminalID)
+		delete(f.envByID, terminalID)
 		stopped++
 	}
 	return stopped, nil

--- a/apps/backend/internal/terminal/service/service_test.go
+++ b/apps/backend/internal/terminal/service/service_test.go
@@ -18,6 +18,7 @@ type fakeBackend struct {
 	registered map[string]bool
 	stopped    map[string]bool
 	alive      map[string]bool
+	envByID    map[string]string
 }
 
 func newFakeBackend() *fakeBackend {
@@ -25,18 +26,33 @@ func newFakeBackend() *fakeBackend {
 		registered: map[string]bool{},
 		stopped:    map[string]bool{},
 		alive:      map[string]bool{},
+		envByID:    map[string]string{},
 	}
 }
 
-func (f *fakeBackend) Register(_, terminalID string) {
+func (f *fakeBackend) Register(scopeID, terminalID string) {
 	f.registered[terminalID] = true
 	f.alive[terminalID] = true
+	f.envByID[terminalID] = scopeID
 }
 
 func (f *fakeBackend) Stop(_ context.Context, _, terminalID string) error {
 	f.stopped[terminalID] = true
 	delete(f.alive, terminalID)
 	return nil
+}
+
+func (f *fakeBackend) StopScope(_ context.Context, scopeID string) (int, error) {
+	stopped := 0
+	for terminalID, envID := range f.envByID {
+		if envID != scopeID {
+			continue
+		}
+		f.stopped[terminalID] = true
+		delete(f.alive, terminalID)
+		stopped++
+	}
+	return stopped, nil
 }
 
 func (f *fakeBackend) IsAlive(_, terminalID string) bool {
@@ -191,6 +207,7 @@ func TestCleanupTask_StopsAllAndDeletes(t *testing.T) {
 	t1, _ := svc.Create(ctx, "task-1", "env-1", "")
 	t2, _ := svc.Create(ctx, "task-1", "env-1", "")
 	other, _ := svc.Create(ctx, "task-2", "env-2", "")
+	be.Register("env-1", "bottom-panel")
 
 	n, err := svc.CleanupTask(ctx, "task-1")
 	if err != nil {
@@ -201,6 +218,9 @@ func TestCleanupTask_StopsAllAndDeletes(t *testing.T) {
 	}
 	if !be.stopped[t1.ID] || !be.stopped[t2.ID] {
 		t.Errorf("not all stopped: %+v", be.stopped)
+	}
+	if !be.stopped["bottom-panel"] {
+		t.Errorf("unmanaged shell in task environment was not stopped")
 	}
 	if be.stopped[other.ID] {
 		t.Errorf("other task affected: %s", other.ID)

--- a/apps/backend/internal/terminal/service/service_test.go
+++ b/apps/backend/internal/terminal/service/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
 
+	taskmodels "github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/terminal/models"
 	"github.com/kandev/kandev/internal/terminal/repository"
 )
@@ -57,6 +58,16 @@ func (f *fakeBackend) StopScope(_ context.Context, scopeID string) (int, error) 
 
 func (f *fakeBackend) IsAlive(_, terminalID string) bool {
 	return f.alive[terminalID]
+}
+
+// fakeTaskEnvReader implements the minimal taskEnvironmentReader interface
+// for testing CleanupTask when no ordinary terminal rows exist.
+type fakeTaskEnvReader struct {
+	env *taskmodels.TaskEnvironment
+}
+
+func (f *fakeTaskEnvReader) GetTaskEnvironmentByTaskID(_ context.Context, _ string) (*taskmodels.TaskEnvironment, error) {
+	return f.env, nil
 }
 
 func setupService(t *testing.T) (*Service, *fakeBackend) {
@@ -224,6 +235,28 @@ func TestCleanupTask_StopsAllAndDeletes(t *testing.T) {
 	}
 	if be.stopped[other.ID] {
 		t.Errorf("other task affected: %s", other.ID)
+	}
+}
+
+// TestCleanupTask_StopsShellsWhenNoOrdinaryTerminals ensures that bottom-panel
+// and script shells are still torn down when a task has no persisted ordinary
+// terminal rows (the env ID can only be discovered via the task layer).
+func TestCleanupTask_StopsShellsWhenNoOrdinaryTerminals(t *testing.T) {
+	svc, be := setupService(t)
+	ctx := context.Background()
+
+	// No ordinary terminals for task-1, but there is a task environment.
+	be.Register("env-orphan", "bottom-panel")
+	svc.SetTaskEnvironmentReader(&fakeTaskEnvReader{
+		env: &taskmodels.TaskEnvironment{ID: "env-orphan", TaskID: "task-1"},
+	})
+
+	_, err := svc.CleanupTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if !be.stopped["bottom-panel"] {
+		t.Errorf("unmanaged shell was not stopped when no ordinary terminals exist")
 	}
 }
 


### PR DESCRIPTION
Shell processes were leaking when tasks were archived or deleted, accumulating idle fish shells and ACP agents that eventually exhausted OS inotify limits and caused ACP initialization timeouts. This change adds persistent OS PID tracking throughout the terminal lifecycle and ensures all shells—including bottom-panel and script shells—are stopped during task cleanup.

## Important Changes

- Added OS PID logging at PTY startup, WebSocket connect/disconnect, and task cleanup to enable correlating shell processes with tasks and sessions in future investigations.
- Tightened `task archive/delete` cleanup to stop all shells in a task environment, fixing leaks from previously unmanaged bottom-panel and script shells.
- Added regression tests for unmanaged shell cleanup.

## Validation

- `make -C apps/backend test` — all packages passed (0 failures)
- `make -C apps/backend lint` — 0 issues
- `make -C apps/backend build` — all binaries built successfully
- `make fmt` — no formatting changes needed

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.