### PR TITLE
fix(backend): prevent nested subtask creation for kanban tasks (depth > 1)

### DIFF
--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -461,6 +461,8 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 	})
 	if err != nil {
 		h.logger.Error("failed to create task", zap.Error(err))
+		// Defense-in-depth: resolveTaskRepositories already catches this for the
+		// MCP path, but non-MCP callers (UI, internal engine) reach here directly.
 		if errors.Is(err, service.ErrSubtaskDepthExceeded) {
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, err.Error(), nil)
 		}

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -523,6 +523,9 @@ func (h *Handlers) resolveTaskRepositories(
 		if parent.IsEphemeral {
 			return taskRepoResult{}, fmt.Errorf("cannot create subtasks of an ephemeral task (quick chat); omit parent_id to create a top-level task")
 		}
+		if parent.ParentID != "" && !parent.IsFromOffice {
+			return taskRepoResult{}, fmt.Errorf("cannot create a subtask of a subtask — maximum nesting depth is 1 for kanban tasks. Create a sibling task under the same parent or a top-level task instead")
+		}
 		repos := explicitRepos
 		if repos == nil {
 			repos = inheritedRepoInputs(parent.Repositories)

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -461,6 +461,9 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 	})
 	if err != nil {
 		h.logger.Error("failed to create task", zap.Error(err))
+		if errors.Is(err, service.ErrSubtaskDepthExceeded) {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, err.Error(), nil)
+		}
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to create task", nil)
 	}
 
@@ -524,7 +527,7 @@ func (h *Handlers) resolveTaskRepositories(
 			return taskRepoResult{}, fmt.Errorf("cannot create subtasks of an ephemeral task (quick chat); omit parent_id to create a top-level task")
 		}
 		if parent.ParentID != "" && !parent.IsFromOffice {
-			return taskRepoResult{}, fmt.Errorf("cannot create a subtask of a subtask — maximum nesting depth is 1 for kanban tasks. Create a sibling task under the same parent or a top-level task instead")
+			return taskRepoResult{}, service.ErrSubtaskDepthExceeded
 		}
 		repos := explicitRepos
 		if repos == nil {

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -509,6 +509,67 @@ func TestResolveTaskRepositories_EphemeralParent_Rejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "ephemeral")
 }
 
+func TestResolveTaskRepositories_SubtaskParent_Rejected(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+
+	// Seed workspace, non-office workflow, root task, and a subtask
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Test"}))
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Board"}))
+	root, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		Title:       "Root task",
+	})
+	require.NoError(t, err)
+	child, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		ParentID:    root.ID,
+		Title:       "Subtask",
+	})
+	require.NoError(t, err)
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+
+	_, err = h.resolveTaskRepositories(ctx, child.ID, "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum nesting depth is 1")
+}
+
+func TestResolveTaskRepositories_OfficeSubtaskParent_Allowed(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+
+	// Seed office workspace (office workflow stamps IsFromOffice = true)
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-office", Name: "Office"}))
+	_, err := repo.EnsureOfficeWorkflow(ctx, "ws-office")
+	require.NoError(t, err)
+
+	root, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-office",
+		Title:       "Root office task",
+		ProjectID:   "proj-1",
+	})
+	require.NoError(t, err)
+	child, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: "ws-office",
+		ParentID:    root.ID,
+		Title:       "Office subtask",
+		ProjectID:   "proj-1",
+	})
+	require.NoError(t, err)
+
+	log := testLogger(t)
+	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
+
+	result, err := h.resolveTaskRepositories(ctx, child.ID, "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "ws-office", result.WorkspaceID)
+	assert.Equal(t, root.WorkflowID, result.WorkflowID)
+}
+
 func TestResolveTaskRepositories_ExplicitRepos_InheritsSourceWorkspace(t *testing.T) {
 	svc, repo := newTestTaskService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -535,7 +536,7 @@ func TestResolveTaskRepositories_SubtaskParent_Rejected(t *testing.T) {
 
 	_, err = h.resolveTaskRepositories(ctx, child.ID, "", nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "maximum nesting depth is 1")
+	assert.True(t, errors.Is(err, service.ErrSubtaskDepthExceeded), "expected ErrSubtaskDepthExceeded, got: %v", err)
 }
 
 func TestResolveTaskRepositories_OfficeSubtaskParent_Allowed(t *testing.T) {

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -478,7 +478,8 @@ IMPORTANT:
   - Pass base_branch explicitly to override either default. Use list_repositories_kandev to see each repo's default_branch.
 - Top-level tasks need a repository via repository_url, repository_id, or local_path
 - 'description' is the sub-agent's initial prompt — be specific and detailed
-- start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the description. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later, or creating a tracking task with no immediate work). When in doubt, leave it true.`
+- start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the description. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later, or creating a tracking task with no immediate work). When in doubt, leave it true.
+- Kanban subtasks cannot have their own subtasks (max nesting depth is 1). To break work down further, create a sibling under the same parent. (Office task trees are exempt.)`
 	parentDesc := "Parent task ID for subtasks. Use 'self' to create a subtask of your current task (RECOMMENDED for plan phases, delegated work). Omit only for unrelated top-level tasks."
 
 	if s.mode == ModeExternal {

--- a/apps/backend/internal/task/service/service_child_task_test.go
+++ b/apps/backend/internal/task/service/service_child_task_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -226,8 +227,8 @@ func TestCreateTask_SubtaskOfSubtask_Kanban_Rejected(t *testing.T) {
 		ParentID:    child.ID,
 		Title:       "Grandchild",
 	})
-	if err == nil || !strings.Contains(err.Error(), "maximum nesting depth is 1") {
-		t.Fatalf("expected depth error, got: %v", err)
+	if err == nil || !errors.Is(err, ErrSubtaskDepthExceeded) {
+		t.Fatalf("expected ErrSubtaskDepthExceeded, got: %v", err)
 	}
 }
 

--- a/apps/backend/internal/task/service/service_child_task_test.go
+++ b/apps/backend/internal/task/service/service_child_task_test.go
@@ -193,3 +193,82 @@ func TestCreateChildTask_RequiresTitle(t *testing.T) {
 		t.Fatalf("expected title error, got: %v", err)
 	}
 }
+
+func TestCreateTask_SubtaskOfSubtask_Kanban_Rejected(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Board"})
+
+	root, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		Title:       "Root",
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	child, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		ParentID:    root.ID,
+		Title:       "Child",
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	_, err = svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		WorkflowID:  "wf-1",
+		ParentID:    child.ID,
+		Title:       "Grandchild",
+	})
+	if err == nil || !strings.Contains(err.Error(), "maximum nesting depth is 1") {
+		t.Fatalf("expected depth error, got: %v", err)
+	}
+}
+
+func TestCreateTask_SubtaskOfSubtask_Office_Allowed(t *testing.T) {
+	svc, repo := setupOfficeTest(t)
+	ctx := context.Background()
+
+	root, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		Title:       "Root office",
+		ProjectID:   "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+
+	child, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		ParentID:    root.ID,
+		Title:       "Child office",
+		ProjectID:   "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	grandchild, err := svc.CreateTask(ctx, &CreateTaskRequest{
+		WorkspaceID: "ws-1",
+		ParentID:    child.ID,
+		Title:       "Grandchild office",
+		ProjectID:   "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("create grandchild: %v", err)
+	}
+
+	got, err := repo.GetTask(ctx, grandchild.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.ParentID != child.ID {
+		t.Errorf("parent_id = %q, want %q", got.ParentID, child.ID)
+	}
+}

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -53,6 +53,9 @@ func (s *Service) CreateTask(ctx context.Context, req *CreateTaskRequest) (*mode
 	if err := s.validateCreateTaskRequest(req); err != nil {
 		return nil, err
 	}
+	if err := s.validateSubtaskDepth(ctx, req); err != nil {
+		return nil, err
+	}
 
 	// Subtasks created without explicit repositories inherit the parent's, so
 	// an inherit_parent subtask resolves a repo at launch and can reuse the
@@ -155,6 +158,22 @@ func (s *Service) validateCreateTaskRequest(req *CreateTaskRequest) error {
 	}
 	if req.IsEphemeral && req.WorkflowID != "" {
 		return fmt.Errorf("workflow_id must be empty for ephemeral tasks")
+	}
+	return nil
+}
+
+// validateSubtaskDepth prevents nesting deeper than one level for kanban
+// (non-office) tasks. Office task trees intentionally allow arbitrary depth.
+func (s *Service) validateSubtaskDepth(ctx context.Context, req *CreateTaskRequest) error {
+	if req.ParentID == "" {
+		return nil
+	}
+	parent, err := s.tasks.GetTask(ctx, req.ParentID)
+	if err != nil {
+		return fmt.Errorf("invalid parent_id: %w", err)
+	}
+	if parent.ParentID != "" && !parent.IsFromOffice {
+		return fmt.Errorf("cannot create a subtask of a subtask — maximum nesting depth is 1 for kanban tasks. Create a sibling task under the same parent or a top-level task instead")
 	}
 	return nil
 }

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -24,6 +24,11 @@ import (
 // Used when a caller omits priority so the DB CHECK constraint is satisfied.
 const defaultPriority = "medium"
 
+// ErrSubtaskDepthExceeded is returned when a caller tries to create a
+// subtask of a kanban subtask (nesting depth > 1). Office task trees are
+// intentionally exempt.
+var ErrSubtaskDepthExceeded = fmt.Errorf("cannot create a subtask of a subtask — maximum nesting depth is 1 for kanban tasks. Create a sibling task under the same parent or a top-level task instead")
+
 type taskStopTarget struct {
 	sessionID   string
 	executionID string
@@ -173,7 +178,7 @@ func (s *Service) validateSubtaskDepth(ctx context.Context, req *CreateTaskReque
 		return fmt.Errorf("invalid parent_id: %w", err)
 	}
 	if parent.ParentID != "" && !parent.IsFromOffice {
-		return fmt.Errorf("cannot create a subtask of a subtask — maximum nesting depth is 1 for kanban tasks. Create a sibling task under the same parent or a top-level task instead")
+		return ErrSubtaskDepthExceeded
 	}
 	return nil
 }


### PR DESCRIPTION
The Kandev kanban sidebar only supports one level of task nesting (parent + subtasks). The MCP `create_task_kandev` tool previously accepted `parent_id='self'` even when the current task was already a subtask, creating grand-children that never appear in the sidebar.

This PR adds a backend guard that rejects nesting deeper than one level for kanban (non-office) tasks, while leaving Office task trees unrestricted since they support arbitrary-depth trees by design.

**Validation**
- `go test ./internal/mcp/handlers/ -run 'TestResolveTaskRepositories' -v` — pass
- `go test ./internal/task/service/ -run 'TestCreateTask_SubtaskOfSubtask' -v` — pass
- `make lint` — 0 issues

**Checklist**
- [x] I have read the contribution guidelines
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally