### PR TITLE
feat(web): bubble subtask state to parent in sidebar state sort

### DIFF
--- a/apps/web/e2e/tests/task/sidebar-subtask-state-sort.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-subtask-state-sort.spec.ts
@@ -39,6 +39,7 @@ test.describe("Sidebar subtasks — effective state sort", () => {
       workflow_id: seedData.workflowId,
       workflow_step_id: seedData.startStepId,
       parent_id: parent.id,
+      repository_ids: [seedData.repositoryId],
     });
     await apiClient.updateTaskState(child.id, "IN_PROGRESS");
 

--- a/apps/web/e2e/tests/task/sidebar-subtask-state-sort.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-subtask-state-sort.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * E2E test for effective-state sort bubbling in the left sidebar.
+ *
+ * When the sidebar is sorted by state (the default), a parent task should
+ * adopt the highest-priority state bucket among itself and its direct
+ * subtasks. So a backlog parent with an in-progress subtask must bubble up
+ * above an unrelated backlog peer.
+ *
+ * This is the end-to-end counterpart to the unit coverage in
+ * `lib/sidebar/apply-view.test.ts`: it proves the live store threads the
+ * active `state` sort through `applyView` and the sidebar renders the
+ * bubbled order in the DOM.
+ *
+ * Regression value: without the fix both parent and peer share the backlog
+ * bucket, where the tiebreak is `createdAt` desc — so the newer peer (created
+ * last) would render ABOVE the older parent. The assertion below only holds
+ * once the subtask bubbles the parent into the in_progress bucket.
+ */
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+test.describe("Sidebar subtasks — effective state sort", () => {
+  test("a backlog parent with an in-progress subtask bubbles above a backlog peer", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // Parent task — stays in a backlog-bucket state.
+    const parent = await apiClient.createTask(seedData.workspaceId, "Bubble Parent Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    // Child subtask whose task state we flip to IN_PROGRESS. `classifyTask`
+    // buckets a task with no session by its persisted state, so this lands in
+    // the in_progress bucket without needing to drive an agent.
+    const child = await apiClient.createTask(seedData.workspaceId, "Bubble Child Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      parent_id: parent.id,
+    });
+    await apiClient.updateTaskState(child.id, "IN_PROGRESS");
+
+    // A second root task created LAST — stays in the backlog bucket. Without
+    // bubbling it would sort above the older parent (backlog tiebreak is
+    // newest-createdAt-first).
+    const peer = await apiClient.createTask(seedData.workspaceId, "Bubble Backlog Peer", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    await testPage.goto(`/t/${parent.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.sidebar).toBeVisible({ timeout: 10_000 });
+
+    // Wait for both root rows to render before reading order.
+    const parentBlock = session.sidebar.locator(
+      `[data-testid='sortable-task-block'][data-task-id='${parent.id}']`,
+    );
+    const peerBlock = session.sidebar.locator(
+      `[data-testid='sortable-task-block'][data-task-id='${peer.id}']`,
+    );
+    await expect(parentBlock).toBeVisible({ timeout: 10_000 });
+    await expect(peerBlock).toBeVisible({ timeout: 10_000 });
+
+    // Read root-task order from the DOM and assert the parent precedes the peer.
+    // Comparing indices (not absolute positions) keeps this robust against any
+    // other tasks present in the sidebar.
+    const rootBlocks = session.sidebar.locator("[data-testid='sortable-task-block']");
+    const orderedIds = await rootBlocks.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-task-id")),
+    );
+    expect(orderedIds.indexOf(parent.id)).toBeGreaterThanOrEqual(0);
+    expect(orderedIds.indexOf(parent.id)).toBeLessThan(orderedIds.indexOf(peer.id));
+  });
+});

--- a/apps/web/lib/sidebar/apply-view-effective-state.test.ts
+++ b/apps/web/lib/sidebar/apply-view-effective-state.test.ts
@@ -162,6 +162,23 @@ describe("applyGroup — effective state grouping (subtasks)", () => {
     const completedGroup = out.groups.find((g) => g.key === "COMPLETED");
     expect(completedGroup?.tasks.map((t) => t.id)).toEqual(["p"]);
   });
+
+  it("parent with null-state running subtask stays in its own group", () => {
+    const parent = task({ id: "p", state: "TODO" });
+    const nullStateSub = task({
+      id: "sub",
+      parentTaskId: "p",
+      sessionState: "RUNNING",
+      // state intentionally omitted — subtask has a live session but no persisted state
+    });
+    const subMap = new Map<string, TaskSwitcherItem[]>([["p", [nullStateSub]]]);
+    const out = applyGroup([parent, nullStateSub], "state", subMap);
+    // Null-state subtask must not displace the parent from its own TODO group
+    const todoGroup = out.groups.find((g) => g.key === "TODO");
+    expect(todoGroup?.tasks.map((t) => t.id)).toContain("p");
+    // Should NOT appear under NOT_STARTED (the old bug) or IN_PROGRESS
+    expect(out.groups.find((g) => g.key === "__not_started__")).toBeUndefined();
+  });
 });
 
 describe("applyView — effective state bubbling (integration)", () => {

--- a/apps/web/lib/sidebar/apply-view-effective-state.test.ts
+++ b/apps/web/lib/sidebar/apply-view-effective-state.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import type { TaskSwitcherItem } from "@/components/task/task-switcher";
+import { applySort, applyGroup, applyView } from "./apply-view";
+import type { SidebarView } from "@/lib/state/slices/ui/sidebar-view-types";
+
+function task(overrides: Partial<TaskSwitcherItem>): TaskSwitcherItem {
+  return {
+    id: overrides.id ?? "t",
+    title: overrides.title ?? "Task",
+    ...overrides,
+  };
+}
+
+describe("applySort — effective state bubbling (subtasks)", () => {
+  const stateAsc = { key: "state" as const, direction: "asc" as const };
+
+  it("parent with running subtask sorts above a backlog parent", () => {
+    const backlogParent = task({ id: "bk", state: "TODO" });
+    const runningParent = task({ id: "run", state: "TODO" });
+    const runningSub = task({
+      id: "sub",
+      parentTaskId: "run",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const subMap = new Map<string, TaskSwitcherItem[]>([["run", [runningSub]]]);
+    const out = applySort([backlogParent, runningParent, runningSub], stateAsc, [], subMap);
+    // "run" should bubble above "bk" because its subtask is in_progress (1 vs backlog 2)
+    expect(out.map((t) => t.id)).toEqual(["run", "sub", "bk"]);
+  });
+
+  it("parent with review subtask sorts above an in_progress parent", () => {
+    const inProgressParent = task({ id: "ip", state: "IN_PROGRESS", sessionState: "RUNNING" });
+    const reviewParent = task({ id: "rv", state: "TODO" });
+    const reviewSub = task({
+      id: "sub",
+      parentTaskId: "rv",
+      state: "REVIEW",
+      sessionState: "WAITING_FOR_INPUT",
+    });
+    const subMap = new Map<string, TaskSwitcherItem[]>([["rv", [reviewSub]]]);
+    const out = applySort([inProgressParent, reviewParent, reviewSub], stateAsc, [], subMap);
+    // review bucket (0) < in_progress bucket (1)
+    expect(out.map((t) => t.id)).toEqual(["rv", "sub", "ip"]);
+  });
+
+  it("parent with multiple subtasks uses the best (lowest-order) bucket", () => {
+    const parent = task({ id: "p", state: "TODO" });
+    const reviewSub = task({
+      id: "sr",
+      parentTaskId: "p",
+      state: "REVIEW",
+      sessionState: "WAITING_FOR_INPUT",
+    });
+    const backlogSub = task({ id: "sb", parentTaskId: "p", state: "TODO", sessionState: "IDLE" });
+    const subMap = new Map<string, TaskSwitcherItem[]>([["p", [reviewSub, backlogSub]]]);
+    const out = applySort([parent, reviewSub, backlogSub], stateAsc, [], subMap);
+    // review (0) wins over backlog (2)
+    expect(out.map((t) => t.id)).toEqual(["p", "sr", "sb"]);
+  });
+
+  it("completed/failed subtask still bubbles parent to the review section", () => {
+    const parent = task({ id: "p", state: "TODO" });
+    const failedSub = task({
+      id: "sub",
+      parentTaskId: "p",
+      state: "FAILED",
+      sessionState: "FAILED",
+    });
+    const inProgressPeer = task({ id: "peer", state: "IN_PROGRESS", sessionState: "RUNNING" });
+    const subMap = new Map<string, TaskSwitcherItem[]>([["p", [failedSub]]]);
+    const out = applySort([parent, failedSub, inProgressPeer], stateAsc, [], subMap);
+    // review bucket (0) < in_progress bucket (1), so parent with failed sub
+    // sorts above the genuinely-running peer
+    expect(out.map((t) => t.id)).toEqual(["p", "sub", "peer"]);
+  });
+
+  it("orphan subtask (parent filtered out) does not bubble any unrelated parent", () => {
+    const orphanSub = task({
+      id: "orphan",
+      parentTaskId: "ghost",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const otherParent = task({ id: "other", state: "TODO" });
+    const subMap = new Map<string, TaskSwitcherItem[]>();
+    const out = applySort([orphanSub, otherParent], stateAsc, [], subMap);
+    // orphan is promoted to root; its state only affects itself
+    expect(out.map((t) => t.id)).toEqual(["orphan", "other"]);
+  });
+
+  it("falls back to static comparator when no subMap is provided", () => {
+    const running = task({ id: "run", sessionState: "RUNNING" });
+    const waiting = task({ id: "wait", sessionState: "WAITING_FOR_INPUT" });
+    const out = applySort([running, waiting], stateAsc);
+    expect(out.map((t) => t.id)).toEqual(["wait", "run"]);
+  });
+
+  it("title sort is unaffected by subMap", () => {
+    const a = task({ id: "a", title: "Zebra" });
+    const b = task({ id: "b", title: "Apple" });
+    const subMap = new Map<string, TaskSwitcherItem[]>([
+      ["a", [task({ id: "sub", parentTaskId: "a", sessionState: "RUNNING" })]],
+    ]);
+    const out = applySort([a, b], { key: "title", direction: "asc" }, [], subMap);
+    expect(out.map((t) => t.id)).toEqual(["b", "a"]);
+  });
+
+  it("createdAt sort is unaffected by subMap", () => {
+    const a = task({ id: "a", createdAt: "2026-02-01" });
+    const b = task({ id: "b", createdAt: "2026-01-01" });
+    const subMap = new Map<string, TaskSwitcherItem[]>([
+      ["a", [task({ id: "sub", parentTaskId: "a", sessionState: "RUNNING" })]],
+    ]);
+    const out = applySort([a, b], { key: "createdAt", direction: "asc" }, [], subMap);
+    expect(out.map((t) => t.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("applyGroup — effective state grouping (subtasks)", () => {
+  it("backlog parent with running subtask lands in IN_PROGRESS group", () => {
+    const parent = task({ id: "p", state: "TODO" });
+    const runningSub = task({
+      id: "sub",
+      parentTaskId: "p",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const subMap = new Map<string, TaskSwitcherItem[]>([["p", [runningSub]]]);
+    const out = applyGroup([parent, runningSub], "state", subMap);
+    const groupKeys = out.groups.map((g) => g.key);
+    expect(groupKeys).toContain("IN_PROGRESS");
+    expect(groupKeys).not.toContain("TODO");
+    const inProgressGroup = out.groups.find((g) => g.key === "IN_PROGRESS");
+    expect(inProgressGroup?.tasks.map((t) => t.id)).toEqual(["p"]);
+    expect(out.subTasksByParentId.get("p")?.map((t) => t.id)).toEqual(["sub"]);
+  });
+
+  it("parent with review subtask lands in REVIEW group", () => {
+    const parent = task({ id: "p", state: "TODO" });
+    const reviewSub = task({
+      id: "sub",
+      parentTaskId: "p",
+      state: "REVIEW",
+      sessionState: "WAITING_FOR_INPUT",
+    });
+    const subMap = new Map<string, TaskSwitcherItem[]>([["p", [reviewSub]]]);
+    const out = applyGroup([parent, reviewSub], "state", subMap);
+    const reviewGroup = out.groups.find((g) => g.key === "REVIEW");
+    expect(reviewGroup?.tasks.map((t) => t.id)).toEqual(["p"]);
+  });
+
+  it("falls back to own state group when subMap is not provided", () => {
+    const parent = task({ id: "p", state: "COMPLETED" });
+    const runningSub = task({
+      id: "sub",
+      parentTaskId: "p",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const out = applyGroup([parent, runningSub], "state");
+    const completedGroup = out.groups.find((g) => g.key === "COMPLETED");
+    expect(completedGroup?.tasks.map((t) => t.id)).toEqual(["p"]);
+  });
+});
+
+describe("applyView — effective state bubbling (integration)", () => {
+  const stateView: SidebarView = {
+    id: "v",
+    name: "v",
+    filters: [],
+    sort: { key: "state", direction: "asc" },
+    group: "none",
+    collapsedGroups: [],
+  };
+
+  it("bubbles a parent with a running subtask above a backlog peer", () => {
+    const backlogParent = task({ id: "bk", state: "TODO" });
+    const idleParent = task({ id: "idle", state: "TODO" });
+    const runningSub = task({
+      id: "sub",
+      parentTaskId: "idle",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const out = applyView([backlogParent, idleParent, runningSub], stateView);
+    // idleParent bubbles above backlogParent because its subtask is in_progress (1 vs 2)
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["idle", "bk"]);
+  });
+
+  it("pinned tasks still float above bubbled parents", () => {
+    const backlogParent = task({ id: "bk", state: "TODO" });
+    const idleParent = task({ id: "idle", state: "TODO" });
+    const runningSub = task({
+      id: "sub",
+      parentTaskId: "idle",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const out = applyView([backlogParent, idleParent, runningSub], stateView, {
+      pinnedTaskIds: ["bk"],
+      orderedTaskIds: [],
+    });
+    // pinned first, then bubbled idle parent
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["bk", "idle"]);
+  });
+
+  it("subtask manual order is preserved while parent bubbles among roots", () => {
+    const backlogParent = task({ id: "bk", state: "TODO" });
+    const idleParent = task({ id: "idle", state: "TODO" });
+    const sub1 = task({
+      id: "s1",
+      parentTaskId: "idle",
+      title: "S1",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const sub2 = task({
+      id: "s2",
+      parentTaskId: "idle",
+      title: "S2",
+      state: "IN_PROGRESS",
+      sessionState: "RUNNING",
+    });
+    const out = applyView([backlogParent, idleParent, sub1, sub2], stateView, {
+      pinnedTaskIds: [],
+      orderedTaskIds: [],
+      subtaskOrderByParentId: { idle: ["s2", "s1"] },
+    });
+    // idle parent bubbles above backlog because its subtasks are running (in_progress bucket)
+    expect(out.groups[0].tasks.map((t) => t.id)).toEqual(["idle", "bk"]);
+    // manual subtask order is preserved underneath the parent
+    expect(out.subTasksByParentId.get("idle")?.map((t) => t.id)).toEqual(["s2", "s1"]);
+  });
+});

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -224,8 +224,11 @@ function getEffectiveStateGroup(
         bestTask = sub;
         bestBucketOrder = subBucketOrder;
         bestStateOrder = STATE_GROUP_ORDER[sub.state ?? NOT_STARTED_STATE_GROUP_KEY] ?? 99;
-      } else if (subBucketOrder === bestBucketOrder) {
-        const subStateOrder = STATE_GROUP_ORDER[sub.state ?? NOT_STARTED_STATE_GROUP_KEY] ?? 99;
+      } else if (subBucketOrder === bestBucketOrder && sub.state) {
+        // Only subtasks with an explicit state participate in the tie-break.
+        // A subtask with no state would resolve to NOT_STARTED_STATE_GROUP_KEY
+        // (order 0) and incorrectly beat every explicit parent state.
+        const subStateOrder = STATE_GROUP_ORDER[sub.state] ?? 99;
         if (subStateOrder < bestStateOrder) {
           bestTask = sub;
           bestStateOrder = subStateOrder;
@@ -287,14 +290,14 @@ function separateSubtasks(tasks: TaskSwitcherItem[]): {
 export function applyGroup(
   tasks: TaskSwitcherItem[],
   groupKey: GroupKey,
-  subTasksByParentId?: Map<string, TaskSwitcherItem[]>,
+  effectiveStateSubMap?: Map<string, TaskSwitcherItem[]>,
 ): GroupedSidebarList {
-  const { rootTasks, subTasksByParentId: separatedSubMap } = separateSubtasks(tasks);
+  const { rootTasks, subTasksByParentId } = separateSubtasks(tasks);
 
   if (groupKey === "none") {
     return {
       groups: [{ key: "__all__", label: "All", tasks: rootTasks }],
-      subTasksByParentId: separatedSubMap,
+      subTasksByParentId,
     };
   }
 
@@ -302,8 +305,8 @@ export function applyGroup(
   const buckets = new Map<string, SidebarGroup>();
   for (const task of rootTasks) {
     const { key, label } =
-      groupKey === "state" && subTasksByParentId
-        ? getEffectiveStateGroup(task, subTasksByParentId)
+      groupKey === "state" && effectiveStateSubMap
+        ? getEffectiveStateGroup(task, effectiveStateSubMap)
         : extract(task);
     let group = buckets.get(key);
     if (!group) {
@@ -319,7 +322,7 @@ export function applyGroup(
     sortRepoGroups(groups);
   }
   if (groupKey === "state") sortStateGroups(groups);
-  return { groups, subTasksByParentId: separatedSubMap };
+  return { groups, subTasksByParentId };
 }
 
 function mergeSingleRepoUnassigned(groups: SidebarGroup[]): void {

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -219,15 +219,16 @@ function getEffectiveStateGroup(
   const subs = subMap.get(task.id);
   if (subs) {
     for (const sub of subs) {
+      // Subtasks without an explicit persisted state can't provide a meaningful
+      // group heading (getTaskStateGroup would return "not started"), so skip
+      // them entirely. The parent still bubbles in applySort via bucket numbers.
+      if (!sub.state) continue;
       const subBucketOrder = STATE_BUCKET_ORDER[getStateBucket(sub)];
       if (subBucketOrder < bestBucketOrder) {
         bestTask = sub;
         bestBucketOrder = subBucketOrder;
-        bestStateOrder = STATE_GROUP_ORDER[sub.state ?? NOT_STARTED_STATE_GROUP_KEY] ?? 99;
-      } else if (subBucketOrder === bestBucketOrder && sub.state) {
-        // Only subtasks with an explicit state participate in the tie-break.
-        // A subtask with no state would resolve to NOT_STARTED_STATE_GROUP_KEY
-        // (order 0) and incorrectly beat every explicit parent state.
+        bestStateOrder = STATE_GROUP_ORDER[sub.state] ?? 99;
+      } else if (subBucketOrder === bestBucketOrder) {
         const subStateOrder = STATE_GROUP_ORDER[sub.state] ?? 99;
         if (subStateOrder < bestStateOrder) {
           bestTask = sub;

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -133,9 +133,29 @@ export function applySort(
   tasks: TaskSwitcherItem[],
   spec: SortSpec,
   orderedTaskIds: string[] = [],
+  subTasksByParentId?: Map<string, TaskSwitcherItem[]>,
 ): TaskSwitcherItem[] {
-  const cmp: SortComparator =
-    spec.key === "custom" ? customComparator(orderedTaskIds) : SORT_COMPARATORS[spec.key];
+  let cmp: SortComparator;
+  if (spec.key === "state" && subTasksByParentId) {
+    const effectiveOrder = new Map<string, number>();
+    for (const t of tasks) {
+      let order = STATE_BUCKET_ORDER[getStateBucket(t)];
+      const subs = subTasksByParentId.get(t.id);
+      if (subs) {
+        for (const sub of subs) {
+          order = Math.min(order, STATE_BUCKET_ORDER[getStateBucket(sub)]);
+        }
+      }
+      effectiveOrder.set(t.id, order);
+    }
+    cmp = (a, b) => {
+      const bucket = effectiveOrder.get(a.id)! - effectiveOrder.get(b.id)!;
+      if (bucket !== 0) return bucket;
+      return (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+    };
+  } else {
+    cmp = spec.key === "custom" ? customComparator(orderedTaskIds) : SORT_COMPARATORS[spec.key];
+  }
   // "Custom" is a manual order — reversing it on direction=desc would flip
   // the user's drag, which has no intuitive meaning. The picker hides the
   // direction toggle for custom; this guard keeps the data layer consistent
@@ -174,6 +194,47 @@ function getTaskStateGroup(task: TaskSwitcherItem): { key: string; label: string
   if (!task.state)
     return { key: NOT_STARTED_STATE_GROUP_KEY, label: formatTaskStateLabel(undefined) };
   return { key: task.state, label: formatTaskStateLabel(task.state) };
+}
+
+/**
+ * Computes the effective state group for a parent task, considering its direct
+ * subtasks. The task (or its "best" subtask) with the highest-priority bucket
+ * (lowest STATE_BUCKET_ORDER) determines the group. This makes a parent with an
+ * active subtask bubble up to the same section as genuinely-running top-level
+ * tasks.
+ *
+ * Tie-break: when multiple candidates share the same bucket, prefer the one
+ * with the lowest STATE_GROUP_ORDER (i.e. the earlier/more-active lifecycle
+ * state). This is consistent with the existing top-level sort where review
+ * (which includes COMPLETED/FAILED/CANCELLED) sorts above in_progress.
+ */
+function getEffectiveStateGroup(
+  task: TaskSwitcherItem,
+  subMap: Map<string, TaskSwitcherItem[]>,
+): { key: string; label: string } {
+  let bestTask = task;
+  let bestBucketOrder = STATE_BUCKET_ORDER[getStateBucket(task)];
+  let bestStateOrder = STATE_GROUP_ORDER[task.state ?? NOT_STARTED_STATE_GROUP_KEY] ?? 99;
+
+  const subs = subMap.get(task.id);
+  if (subs) {
+    for (const sub of subs) {
+      const subBucketOrder = STATE_BUCKET_ORDER[getStateBucket(sub)];
+      if (subBucketOrder < bestBucketOrder) {
+        bestTask = sub;
+        bestBucketOrder = subBucketOrder;
+        bestStateOrder = STATE_GROUP_ORDER[sub.state ?? NOT_STARTED_STATE_GROUP_KEY] ?? 99;
+      } else if (subBucketOrder === bestBucketOrder) {
+        const subStateOrder = STATE_GROUP_ORDER[sub.state ?? NOT_STARTED_STATE_GROUP_KEY] ?? 99;
+        if (subStateOrder < bestStateOrder) {
+          bestTask = sub;
+          bestStateOrder = subStateOrder;
+        }
+      }
+    }
+  }
+
+  return getTaskStateGroup(bestTask);
 }
 
 const groupExtractors: Record<Exclude<GroupKey, "none">, GroupExtractor> = {
@@ -223,20 +284,27 @@ function separateSubtasks(tasks: TaskSwitcherItem[]): {
   return { rootTasks, subTasksByParentId: subMap };
 }
 
-export function applyGroup(tasks: TaskSwitcherItem[], groupKey: GroupKey): GroupedSidebarList {
-  const { rootTasks, subTasksByParentId } = separateSubtasks(tasks);
+export function applyGroup(
+  tasks: TaskSwitcherItem[],
+  groupKey: GroupKey,
+  subTasksByParentId?: Map<string, TaskSwitcherItem[]>,
+): GroupedSidebarList {
+  const { rootTasks, subTasksByParentId: separatedSubMap } = separateSubtasks(tasks);
 
   if (groupKey === "none") {
     return {
       groups: [{ key: "__all__", label: "All", tasks: rootTasks }],
-      subTasksByParentId,
+      subTasksByParentId: separatedSubMap,
     };
   }
 
   const extract = groupExtractors[groupKey];
   const buckets = new Map<string, SidebarGroup>();
   for (const task of rootTasks) {
-    const { key, label } = extract(task);
+    const { key, label } =
+      groupKey === "state" && subTasksByParentId
+        ? getEffectiveStateGroup(task, subTasksByParentId)
+        : extract(task);
     let group = buckets.get(key);
     if (!group) {
       group = { key, label, tasks: [] };
@@ -251,7 +319,7 @@ export function applyGroup(tasks: TaskSwitcherItem[], groupKey: GroupKey): Group
     sortRepoGroups(groups);
   }
   if (groupKey === "state") sortStateGroups(groups);
-  return { groups, subTasksByParentId };
+  return { groups, subTasksByParentId: separatedSubMap };
 }
 
 function mergeSingleRepoUnassigned(groups: SidebarGroup[]): void {
@@ -369,8 +437,9 @@ export function applyView(
   prefs?: SidebarTaskPrefs,
 ): GroupedSidebarList {
   const filtered = applyFilters(tasks, view.filters);
-  const sorted = applySort(filtered, view.sort, prefs?.orderedTaskIds);
-  const grouped = applyGroup(sorted, view.group);
+  const { subTasksByParentId } = separateSubtasks(filtered);
+  const sorted = applySort(filtered, view.sort, prefs?.orderedTaskIds, subTasksByParentId);
+  const grouped = applyGroup(sorted, view.group, subTasksByParentId);
   const subOrderMap = prefs?.subtaskOrderByParentId;
   if (subOrderMap) {
     for (const [parentId, orderedIds] of Object.entries(subOrderMap)) {


### PR DESCRIPTION
When the sidebar is sorted by status, a parent task now adopts the highest-priority state bucket among itself and its direct subtasks. This makes parents with active subtasks bubble up to the appropriate section instead of being buried in backlog.

**Important Changes**
- `getEffectiveStateGroup`: computes the best state bucket among a parent and its direct subtasks
- `applySort`: uses effective state bucket when sorting by `state`, with O(1) lookup via precomputed map
- `applyGroup`: places parents in the group matching their most urgent subtask when grouping by `state`
- `applyView`: builds the subtask map once and threads it through both sort and group

**Validation**
- `pnpm vitest run lib/sidebar/apply-view.test.ts lib/sidebar/apply-view-effective-state.test.ts components/task/task-switcher.test.ts` — 72 unit tests pass
- `pnpm e2e --project=chromium e2e/tests/task/sidebar-subtask-state-sort.spec.ts` — e2e passes
- `pnpm typecheck` — clean
- `pnpm lint` — clean

**Checklist**
- [x] Tests added/updated
- [x] Type check passes
- [x] Lint passes
- [x] E2E test added and passes