### PR TITLE
feat(health): add OS inotify resource limits health check

### DIFF
--- a/apps/backend/cmd/kandev/helpers.go
+++ b/apps/backend/cmd/kandev/helpers.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kandev/kandev/internal/github"
 	"github.com/kandev/kandev/internal/gitlab"
 	"github.com/kandev/kandev/internal/health"
+	"github.com/kandev/kandev/internal/health/oslimits"
 	"github.com/kandev/kandev/internal/improvekandev"
 	"github.com/kandev/kandev/internal/jira"
 	"github.com/kandev/kandev/internal/linear"
@@ -849,9 +850,14 @@ func registerHealthRoutes(p routeParams) {
 	if githubRateProvider != nil {
 		githubChecker.WithRateLimitProvider(githubRateProvider)
 	}
+	osLimitsChecker := health.NewCachedChecker(
+		oslimits.NewOSLimitsChecker(oslimits.NewInotifyProbe()),
+		5*time.Minute,
+	)
 	healthSvc := health.NewService(p.log,
 		githubChecker,
 		health.NewAgentChecker(p.agentSettingsController),
+		osLimitsChecker,
 	)
 	health.RegisterRoutes(p.router, healthSvc, p.log)
 }

--- a/apps/backend/internal/health/cached.go
+++ b/apps/backend/internal/health/cached.go
@@ -1,0 +1,41 @@
+package health
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// CachedChecker wraps a Checker and caches its result for the given TTL.
+// Both successful and failed results are cached for the full TTL.
+type CachedChecker struct {
+	inner    Checker
+	ttl      time.Duration
+	mu       sync.Mutex
+	cached   []Issue
+	cachedAt time.Time
+}
+
+// NewCachedChecker returns a CachedChecker wrapping inner with the given TTL.
+func NewCachedChecker(inner Checker, ttl time.Duration) *CachedChecker {
+	return &CachedChecker{inner: inner, ttl: ttl}
+}
+
+// Name delegates to the wrapped checker.
+func (c *CachedChecker) Name() string { return c.inner.Name() }
+
+// Category delegates to the wrapped checker.
+func (c *CachedChecker) Category() string { return c.inner.Category() }
+
+// Check returns cached issues if within TTL; otherwise calls inner and caches.
+func (c *CachedChecker) Check(ctx context.Context) []Issue {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.cachedAt.IsZero() && time.Since(c.cachedAt) < c.ttl {
+		return c.cached
+	}
+	issues := c.inner.Check(ctx)
+	c.cached = issues
+	c.cachedAt = time.Now()
+	return issues
+}

--- a/apps/backend/internal/health/cached_test.go
+++ b/apps/backend/internal/health/cached_test.go
@@ -1,0 +1,89 @@
+package health
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// countingChecker tracks how many times Check is called.
+type countingChecker struct {
+	calls  int
+	issues []Issue
+}
+
+func (c *countingChecker) Check(_ context.Context) []Issue {
+	c.calls++
+	return c.issues
+}
+
+func (c *countingChecker) Name() string     { return "counting" }
+func (c *countingChecker) Category() string { return "test" }
+
+func TestCachedChecker_ReturnsInnerResult(t *testing.T) {
+	inner := &countingChecker{issues: []Issue{{ID: "test_issue", Severity: SeverityWarning}}}
+	cc := NewCachedChecker(inner, time.Minute)
+
+	got := cc.Check(context.Background())
+	if len(got) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(got))
+	}
+	if got[0].ID != "test_issue" {
+		t.Errorf("ID = %q, want %q", got[0].ID, "test_issue")
+	}
+}
+
+func TestCachedChecker_CacheHitOnSecondCall(t *testing.T) {
+	inner := &countingChecker{issues: []Issue{{ID: "test_issue", Severity: SeverityWarning}}}
+	cc := NewCachedChecker(inner, time.Minute)
+
+	cc.Check(context.Background())
+	cc.Check(context.Background())
+
+	if inner.calls != 1 {
+		t.Errorf("inner called %d times, want 1 (second call should hit cache)", inner.calls)
+	}
+}
+
+func TestCachedChecker_CacheExpiresAfterTTL(t *testing.T) {
+	inner := &countingChecker{issues: []Issue{{ID: "test_issue", Severity: SeverityWarning}}}
+	cc := NewCachedChecker(inner, time.Millisecond)
+
+	cc.Check(context.Background())
+	time.Sleep(5 * time.Millisecond)
+	cc.Check(context.Background())
+
+	if inner.calls != 2 {
+		t.Errorf("inner called %d times, want 2 (second call after TTL expiry)", inner.calls)
+	}
+}
+
+func TestCachedChecker_NilResultIsCached(t *testing.T) {
+	inner := &countingChecker{issues: nil}
+	cc := NewCachedChecker(inner, time.Minute)
+
+	got := cc.Check(context.Background())
+	if got != nil {
+		t.Errorf("expected nil result, got %v", got)
+	}
+
+	got2 := cc.Check(context.Background())
+	if got2 != nil {
+		t.Errorf("expected nil result on second call, got %v", got2)
+	}
+
+	if inner.calls != 1 {
+		t.Errorf("inner called %d times, want 1 (nil result should be cached)", inner.calls)
+	}
+}
+
+func TestCachedChecker_DelegatesNameAndCategory(t *testing.T) {
+	inner := &countingChecker{}
+	cc := NewCachedChecker(inner, time.Minute)
+	if cc.Name() != "counting" {
+		t.Errorf("Name() = %q, want %q", cc.Name(), "counting")
+	}
+	if cc.Category() != "test" {
+		t.Errorf("Category() = %q, want %q", cc.Category(), "test")
+	}
+}

--- a/apps/backend/internal/health/cached_test.go
+++ b/apps/backend/internal/health/cached_test.go
@@ -3,6 +3,7 @@ package health
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -46,16 +47,18 @@ func TestCachedChecker_CacheHitOnSecondCall(t *testing.T) {
 }
 
 func TestCachedChecker_CacheExpiresAfterTTL(t *testing.T) {
-	inner := &countingChecker{issues: []Issue{{ID: "test_issue", Severity: SeverityWarning}}}
-	cc := NewCachedChecker(inner, time.Millisecond)
+	synctest.Test(t, func(t *testing.T) {
+		inner := &countingChecker{issues: []Issue{{ID: "test_issue", Severity: SeverityWarning}}}
+		cc := NewCachedChecker(inner, time.Minute)
 
-	cc.Check(context.Background())
-	time.Sleep(5 * time.Millisecond)
-	cc.Check(context.Background())
+		cc.Check(context.Background())
+		time.Sleep(2 * time.Minute) // fake time advances instantly inside synctest bubble
+		cc.Check(context.Background())
 
-	if inner.calls != 2 {
-		t.Errorf("inner called %d times, want 2 (second call after TTL expiry)", inner.calls)
-	}
+		if inner.calls != 2 {
+			t.Errorf("inner called %d times, want 2 (second call after TTL expiry)", inner.calls)
+		}
+	})
 }
 
 func TestCachedChecker_NilResultIsCached(t *testing.T) {

--- a/apps/backend/internal/health/oslimits/checker.go
+++ b/apps/backend/internal/health/oslimits/checker.go
@@ -3,6 +3,7 @@ package oslimits
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/kandev/kandev/internal/health"
@@ -62,7 +63,10 @@ func sampleIssues(s Sample) []health.Issue {
 	if s.UsageRatio >= errorThreshold {
 		severity = health.SeverityError
 	}
-	pct := int(s.UsageRatio * 100)
+	pct := int(math.Round(s.UsageRatio * 100))
+	if pct > 100 {
+		pct = 100
+	}
 	title := fmt.Sprintf("%s limit nearly exhausted", s.Name)
 	msg := buildMessage(s, pct)
 	return []health.Issue{{
@@ -85,7 +89,7 @@ func buildMessage(s Sample, pct int) string {
 	base := fmt.Sprintf("%d/%d %s in use (%d%%)", s.Used, s.Limit, s.Unit, pct)
 	base += unitAdvice(s.Unit)
 	if len(s.TopConsumers) > 0 {
-		base += " Top consumers: " + formatConsumers(s.TopConsumers)
+		base += " Top consumers: " + formatConsumers(s.TopConsumers, s.Unit)
 	}
 	return base
 }
@@ -103,17 +107,23 @@ func unitAdvice(unit string) string {
 	}
 }
 
-func formatConsumers(consumers []Consumer) string {
+func formatConsumers(consumers []Consumer, unit string) string {
 	parts := make([]string, 0, len(consumers))
 	for _, c := range consumers {
-		parts = append(parts, formatConsumer(c))
+		parts = append(parts, formatConsumer(c, unit))
 	}
 	return strings.Join(parts, ", ")
 }
 
-func formatConsumer(c Consumer) string {
-	if c.Command != "" {
-		return fmt.Sprintf("%s (pid %d, %d fds)", c.Command, c.PID, c.FDCount)
+func formatConsumer(c Consumer, unit string) string {
+	count := c.FDCount
+	countLabel := "fds"
+	if unit == unitWatches {
+		count = c.WatchCount
+		countLabel = "watches"
 	}
-	return fmt.Sprintf("pid %d (%d fds)", c.PID, c.FDCount)
+	if c.Command != "" {
+		return fmt.Sprintf("%s (pid %d, %d %s)", c.Command, c.PID, count, countLabel)
+	}
+	return fmt.Sprintf("pid %d (%d %s)", c.PID, count, countLabel)
 }

--- a/apps/backend/internal/health/oslimits/checker.go
+++ b/apps/backend/internal/health/oslimits/checker.go
@@ -1,0 +1,119 @@
+package oslimits
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kandev/kandev/internal/health"
+)
+
+const (
+	warnThreshold  = 0.80
+	errorThreshold = 0.95
+	categoryID     = "system_resources"
+	fixURL         = "/settings/system/status"
+	fixLabel       = "View system status"
+	unitInstances  = "instances"
+	unitWatches    = "watches"
+
+	sampleIDInotifyInstances = "inotify_instances"
+	sampleIDInotifyWatches   = "inotify_watches"
+)
+
+// OSLimitsChecker implements health.Checker over a list of OS resource probes.
+type OSLimitsChecker struct {
+	probes []Probe
+}
+
+// NewOSLimitsChecker creates a checker backed by the given probes.
+func NewOSLimitsChecker(probes ...Probe) *OSLimitsChecker {
+	return &OSLimitsChecker{probes: probes}
+}
+
+// Name returns the user-facing label for this check.
+func (c *OSLimitsChecker) Name() string { return "OS resource limits" }
+
+// Category returns the issue category this checker emits issues under.
+func (c *OSLimitsChecker) Category() string { return categoryID }
+
+// Check runs all probes and returns issues for samples over threshold.
+func (c *OSLimitsChecker) Check(ctx context.Context) []health.Issue {
+	var issues []health.Issue
+	for _, probe := range c.probes {
+		samples, err := probe.Samples(ctx)
+		if err != nil {
+			// probe errors are non-fatal; the check simply produces no issue
+			continue
+		}
+		for _, s := range samples {
+			issues = append(issues, sampleIssues(s)...)
+		}
+	}
+	return issues
+}
+
+// sampleIssues converts a Sample into 0 or 1 health issues based on thresholds.
+func sampleIssues(s Sample) []health.Issue {
+	if !s.Supported || s.UsageRatio < warnThreshold {
+		return nil
+	}
+	severity := health.SeverityWarning
+	if s.UsageRatio >= errorThreshold {
+		severity = health.SeverityError
+	}
+	pct := int(s.UsageRatio * 100)
+	title := fmt.Sprintf("%s limit nearly exhausted", s.Name)
+	msg := buildMessage(s, pct)
+	return []health.Issue{{
+		ID:       issueID(s.ID),
+		Category: categoryID,
+		Title:    title,
+		Message:  msg,
+		Severity: severity,
+		FixURL:   fixURL,
+		FixLabel: fixLabel,
+	}}
+}
+
+// issueID maps a sample ID to a health issue ID.
+func issueID(sampleID string) string {
+	return "os_" + sampleID + "_high"
+}
+
+func buildMessage(s Sample, pct int) string {
+	base := fmt.Sprintf("%d/%d %s in use (%d%%)", s.Used, s.Limit, s.Unit, pct)
+	base += unitAdvice(s.Unit)
+	if len(s.TopConsumers) > 0 {
+		base += " Top consumers: " + formatConsumers(s.TopConsumers)
+	}
+	return base
+}
+
+func unitAdvice(unit string) string {
+	switch unit {
+	case unitInstances:
+		return ". Exhaustion causes new terminals, dev servers, and agent CLIs to fail or hang." +
+			" To increase: sudo sysctl -w fs.inotify.max_user_instances=1024"
+	case unitWatches:
+		return ". Exhaustion prevents file watchers and dev servers from monitoring directories." +
+			" To increase: sudo sysctl -w fs.inotify.max_user_watches=1048576"
+	default:
+		return ""
+	}
+}
+
+func formatConsumers(consumers []Consumer) string {
+	parts := make([]string, 0, len(consumers))
+	for _, c := range consumers {
+		parts = append(parts, formatConsumer(c))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatConsumer(c Consumer) string {
+	if c.Command != "" {
+		return fmt.Sprintf("%s (pid %d, %d fds)", c.Command, c.PID, c.FDCount)
+	}
+	return fmt.Sprintf("pid %d (%d fds)", c.PID, c.FDCount)
+}

--- a/apps/backend/internal/health/oslimits/checker_test.go
+++ b/apps/backend/internal/health/oslimits/checker_test.go
@@ -163,6 +163,26 @@ func TestOSLimitsChecker_TopConsumersInMessage(t *testing.T) {
 	}
 }
 
+func TestOSLimitsChecker_WatchConsumersShowWatchCount(t *testing.T) {
+	s := makeWatchSample(0.85)
+	s.TopConsumers = []Consumer{
+		{PID: 99, Command: "webpack", FDCount: 2, WatchCount: 8412},
+	}
+	probe := &stubProbe{samples: []Sample{s}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if !strings.Contains(issues[0].Message, "8412 watches") {
+		t.Errorf("watches message should show WatchCount, got %q", issues[0].Message)
+	}
+	if strings.Contains(issues[0].Message, "2 fds") {
+		t.Errorf("watches message must not show FDCount, got %q", issues[0].Message)
+	}
+}
+
 func TestOSLimitsChecker_NameCategory(t *testing.T) {
 	checker := NewOSLimitsChecker()
 	if checker.Name() != "OS resource limits" {

--- a/apps/backend/internal/health/oslimits/checker_test.go
+++ b/apps/backend/internal/health/oslimits/checker_test.go
@@ -1,0 +1,174 @@
+package oslimits
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kandev/kandev/internal/health"
+)
+
+// stubProbe is a test double for the Probe interface.
+type stubProbe struct {
+	samples []Sample
+	err     error
+}
+
+func (s *stubProbe) Name() string                                { return "test" }
+func (s *stubProbe) Category() string                            { return categoryID }
+func (s *stubProbe) Samples(_ context.Context) ([]Sample, error) { return s.samples, s.err }
+
+func makeInstanceSample(ratio float64) Sample {
+	limit := uint64(128)
+	used := uint64(float64(limit) * ratio)
+	return Sample{
+		ID:         sampleIDInotifyInstances,
+		Name:       "Inotify instances",
+		Unit:       unitInstances,
+		Used:       used,
+		Limit:      limit,
+		UsageRatio: ratio,
+		Supported:  true,
+	}
+}
+
+func makeWatchSample(ratio float64) Sample {
+	limit := uint64(8192)
+	used := uint64(float64(limit) * ratio)
+	return Sample{
+		ID:         sampleIDInotifyWatches,
+		Name:       "Inotify watches",
+		Unit:       unitWatches,
+		Used:       used,
+		Limit:      limit,
+		UsageRatio: ratio,
+		Supported:  true,
+	}
+}
+
+func TestOSLimitsChecker_NoIssuesBelowThreshold(t *testing.T) {
+	probe := &stubProbe{samples: []Sample{makeInstanceSample(0.79)}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues at 79%%, got %d", len(issues))
+	}
+}
+
+func TestOSLimitsChecker_WarningAt80Pct(t *testing.T) {
+	probe := &stubProbe{samples: []Sample{makeInstanceSample(0.80)}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue at 80%%, got %d", len(issues))
+	}
+	if issues[0].Severity != health.SeverityWarning {
+		t.Errorf("severity = %q, want warning", issues[0].Severity)
+	}
+}
+
+func TestOSLimitsChecker_ErrorAt95Pct(t *testing.T) {
+	probe := &stubProbe{samples: []Sample{makeInstanceSample(0.95)}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue at 95%%, got %d", len(issues))
+	}
+	if issues[0].Severity != health.SeverityError {
+		t.Errorf("severity = %q, want error", issues[0].Severity)
+	}
+}
+
+func TestOSLimitsChecker_UnsupportedProbe(t *testing.T) {
+	probe := &stubProbe{samples: []Sample{
+		{ID: sampleIDInotifyInstances, Supported: false, UsageRatio: 0.99},
+	}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues for unsupported probe, got %d", len(issues))
+	}
+}
+
+func TestOSLimitsChecker_ProbeError(t *testing.T) {
+	probe := &stubProbe{err: errors.New("proc unavailable")}
+	checker := NewOSLimitsChecker(probe)
+
+	// Must not panic and must return no issues.
+	issues := checker.Check(context.Background())
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues on probe error, got %d", len(issues))
+	}
+}
+
+func TestOSLimitsChecker_MultipleIssues(t *testing.T) {
+	probe := &stubProbe{samples: []Sample{
+		makeInstanceSample(0.85),
+		makeWatchSample(0.90),
+	}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+}
+
+func TestOSLimitsChecker_IssueIDs(t *testing.T) {
+	probe := &stubProbe{samples: []Sample{
+		makeInstanceSample(0.85),
+		makeWatchSample(0.85),
+	}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+
+	ids := map[string]bool{}
+	for _, iss := range issues {
+		ids[iss.ID] = true
+	}
+	if !ids["os_inotify_instances_high"] {
+		t.Errorf("expected issue ID %q not found in %v", "os_inotify_instances_high", ids)
+	}
+	if !ids["os_inotify_watches_high"] {
+		t.Errorf("expected issue ID %q not found in %v", "os_inotify_watches_high", ids)
+	}
+}
+
+func TestOSLimitsChecker_TopConsumersInMessage(t *testing.T) {
+	s := makeInstanceSample(0.85)
+	s.TopConsumers = []Consumer{
+		{PID: 42, Command: "node", FDCount: 5},
+	}
+	probe := &stubProbe{samples: []Sample{s}}
+	checker := NewOSLimitsChecker(probe)
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if !strings.Contains(issues[0].Message, "node") {
+		t.Errorf("message should contain consumer name, got %q", issues[0].Message)
+	}
+	if !strings.Contains(issues[0].Message, "pid 42") {
+		t.Errorf("message should contain PID, got %q", issues[0].Message)
+	}
+}
+
+func TestOSLimitsChecker_NameCategory(t *testing.T) {
+	checker := NewOSLimitsChecker()
+	if checker.Name() != "OS resource limits" {
+		t.Errorf("Name() = %q, want %q", checker.Name(), "OS resource limits")
+	}
+	if checker.Category() != categoryID {
+		t.Errorf("Category() = %q, want %q", checker.Category(), categoryID)
+	}
+}

--- a/apps/backend/internal/health/oslimits/inotify_linux.go
+++ b/apps/backend/internal/health/oslimits/inotify_linux.go
@@ -1,0 +1,244 @@
+//go:build linux
+
+package oslimits
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const maxTopConsumers = 5
+
+// InotifyProbe reads inotify resource usage from /proc on Linux/WSL.
+type InotifyProbe struct {
+	procRoot string
+}
+
+// NewInotifyProbe creates an InotifyProbe that reads from /proc.
+func NewInotifyProbe() *InotifyProbe {
+	return &InotifyProbe{procRoot: "/proc"}
+}
+
+// Name returns the probe name.
+func (p *InotifyProbe) Name() string { return "Inotify" }
+
+// Category returns the probe category.
+func (p *InotifyProbe) Category() string { return categoryID }
+
+// Samples returns two samples: one for inotify instances and one for watches.
+func (p *InotifyProbe) Samples(_ context.Context) ([]Sample, error) {
+	maxInstances, err := p.readUintFile(filepath.Join(p.procRoot, "sys/fs/inotify/max_user_instances"))
+	if err != nil {
+		return nil, fmt.Errorf("read max_user_instances: %w", err)
+	}
+	maxWatches, err := p.readUintFile(filepath.Join(p.procRoot, "sys/fs/inotify/max_user_watches"))
+	if err != nil {
+		return nil, fmt.Errorf("read max_user_watches: %w", err)
+	}
+
+	uid := uint32(os.Getuid())
+	stats, err := p.scanProc(uid)
+	if err != nil {
+		// Best-effort: return stats with zero usage rather than failing
+		stats = procStats{}
+	}
+
+	instSample := buildInstanceSample(stats, maxInstances)
+	watchSample := buildWatchSample(stats, maxWatches)
+
+	return []Sample{instSample, watchSample}, nil
+}
+
+func buildInstanceSample(stats procStats, maxInstances uint64) Sample {
+	s := Sample{
+		ID:           sampleIDInotifyInstances,
+		Name:         "Inotify instances",
+		Unit:         unitInstances,
+		Used:         stats.totalInstances,
+		Limit:        maxInstances,
+		Supported:    true,
+		TopConsumers: stats.topConsumers,
+	}
+	if maxInstances > 0 {
+		s.UsageRatio = float64(stats.totalInstances) / float64(maxInstances)
+	}
+	return s
+}
+
+func buildWatchSample(stats procStats, maxWatches uint64) Sample {
+	s := Sample{
+		ID:           sampleIDInotifyWatches,
+		Name:         "Inotify watches",
+		Unit:         unitWatches,
+		Used:         stats.totalWatches,
+		Limit:        maxWatches,
+		Supported:    true,
+		TopConsumers: stats.topWatchConsumers,
+	}
+	if maxWatches > 0 {
+		s.UsageRatio = float64(stats.totalWatches) / float64(maxWatches)
+	}
+	return s
+}
+
+type procStats struct {
+	totalInstances    uint64
+	totalWatches      uint64
+	topConsumers      []Consumer // sorted by fdCount descending
+	topWatchConsumers []Consumer // sorted by watchCount descending
+}
+
+type pidStats struct {
+	pid        int
+	command    string
+	fdCount    uint64
+	watchCount uint64
+}
+
+func (p *InotifyProbe) scanProc(uid uint32) (procStats, error) {
+	entries, err := os.ReadDir(p.procRoot)
+	if err != nil {
+		return procStats{}, fmt.Errorf("read proc: %w", err)
+	}
+
+	var perPID []pidStats
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		if !p.ownedByUID(filepath.Join(p.procRoot, e.Name()), uid) {
+			continue
+		}
+		stats := p.scanPID(pid)
+		if stats.fdCount == 0 {
+			continue
+		}
+		perPID = append(perPID, stats)
+	}
+
+	return buildProcStats(perPID), nil
+}
+
+func buildProcStats(perPID []pidStats) procStats {
+	var total procStats
+	for _, s := range perPID {
+		total.totalInstances += s.fdCount
+		total.totalWatches += s.watchCount
+	}
+	total.topConsumers = topN(perPID, func(a, b pidStats) bool { return a.fdCount > b.fdCount })
+	total.topWatchConsumers = topN(perPID, func(a, b pidStats) bool { return a.watchCount > b.watchCount })
+	return total
+}
+
+func topN(perPID []pidStats, less func(a, b pidStats) bool) []Consumer {
+	sorted := make([]pidStats, len(perPID))
+	copy(sorted, perPID)
+	sort.Slice(sorted, func(i, j int) bool { return less(sorted[i], sorted[j]) })
+	n := maxTopConsumers
+	if len(sorted) < n {
+		n = len(sorted)
+	}
+	consumers := make([]Consumer, n)
+	for i := range n {
+		consumers[i] = Consumer{
+			PID:        sorted[i].pid,
+			Command:    sorted[i].command,
+			FDCount:    sorted[i].fdCount,
+			WatchCount: sorted[i].watchCount,
+		}
+	}
+	return consumers
+}
+
+func (p *InotifyProbe) ownedByUID(pidDir string, uid uint32) bool {
+	info, err := os.Stat(pidDir)
+	if err != nil {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return stat.Uid == uid
+}
+
+func (p *InotifyProbe) scanPID(pid int) pidStats {
+	pidDir := filepath.Join(p.procRoot, strconv.Itoa(pid))
+	fdDir := filepath.Join(pidDir, "fd")
+	fds, err := os.ReadDir(fdDir)
+	if err != nil {
+		return pidStats{pid: pid}
+	}
+
+	var fdCount, watchCount uint64
+	for _, fd := range fds {
+		target, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+		if err != nil {
+			continue
+		}
+		if target != "anon_inode:inotify" {
+			continue
+		}
+		fdCount++
+		watchCount += p.countWatches(pidDir, fd.Name())
+	}
+
+	if fdCount == 0 {
+		return pidStats{pid: pid}
+	}
+
+	return pidStats{
+		pid:        pid,
+		command:    p.readComm(pidDir),
+		fdCount:    fdCount,
+		watchCount: watchCount,
+	}
+}
+
+// countWatches parses /proc/<pid>/fdinfo/<fd> and counts "inotify " lines.
+func (p *InotifyProbe) countWatches(pidDir, fdName string) uint64 {
+	f, err := os.Open(filepath.Join(pidDir, "fdinfo", fdName))
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+	var count uint64
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "inotify ") {
+			count++
+		}
+	}
+	return count
+}
+
+func (p *InotifyProbe) readComm(pidDir string) string {
+	data, err := os.ReadFile(filepath.Join(pidDir, "comm"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func (p *InotifyProbe) readUintFile(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %q: %w", path, err)
+	}
+	return v, nil
+}

--- a/apps/backend/internal/health/oslimits/inotify_linux.go
+++ b/apps/backend/internal/health/oslimits/inotify_linux.go
@@ -137,7 +137,13 @@ func buildProcStats(perPID []pidStats) procStats {
 		total.totalWatches += s.watchCount
 	}
 	total.topConsumers = topN(perPID, func(a, b pidStats) bool { return a.fdCount > b.fdCount })
-	total.topWatchConsumers = topN(perPID, func(a, b pidStats) bool { return a.watchCount > b.watchCount })
+	var withWatches []pidStats
+	for _, s := range perPID {
+		if s.watchCount > 0 {
+			withWatches = append(withWatches, s)
+		}
+	}
+	total.topWatchConsumers = topN(withWatches, func(a, b pidStats) bool { return a.watchCount > b.watchCount })
 	return total
 }
 

--- a/apps/backend/internal/health/oslimits/inotify_linux_test.go
+++ b/apps/backend/internal/health/oslimits/inotify_linux_test.go
@@ -1,0 +1,232 @@
+//go:build linux
+
+package oslimits
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// fakeProcBuilder builds a minimal fake /proc tree for testing.
+type fakeProcBuilder struct {
+	root string
+	t    *testing.T
+}
+
+func newFakeProcBuilder(t *testing.T) *fakeProcBuilder {
+	t.Helper()
+	root := t.TempDir()
+	return &fakeProcBuilder{root: root, t: t}
+}
+
+func (b *fakeProcBuilder) setSysctl(maxInstances, maxWatches uint64) {
+	b.t.Helper()
+	dir := filepath.Join(b.root, "sys/fs/inotify")
+	mustMkdir(b.t, dir)
+	mustWriteFile(b.t, filepath.Join(dir, "max_user_instances"), fmt.Sprintf("%d\n", maxInstances))
+	mustWriteFile(b.t, filepath.Join(dir, "max_user_watches"), fmt.Sprintf("%d\n", maxWatches))
+}
+
+func (b *fakeProcBuilder) addPID(pid int, comm string, inotifyFDs int, watchesPerFD int) {
+	b.t.Helper()
+	pidDir := filepath.Join(b.root, strconv.Itoa(pid))
+	fdDir := filepath.Join(pidDir, "fd")
+	fdinfoDir := filepath.Join(pidDir, "fdinfo")
+	mustMkdir(b.t, fdDir)
+	mustMkdir(b.t, fdinfoDir)
+	mustWriteFile(b.t, filepath.Join(pidDir, "comm"), comm+"\n")
+
+	for i := range inotifyFDs {
+		fdName := strconv.Itoa(i)
+		// Create symlink pointing to anon_inode:inotify
+		if err := os.Symlink("anon_inode:inotify", filepath.Join(fdDir, fdName)); err != nil {
+			b.t.Fatalf("symlink inotify fd: %v", err)
+		}
+		// Create fdinfo with watchesPerFD inotify lines
+		var content string
+		content += "pos:\t0\nflags:\t02\nmnt_id:\t12\n"
+		for w := range watchesPerFD {
+			content += fmt.Sprintf("inotify wd:%d mask:fff ignored_mask:0 ino:abc sdev:1\n", w+1)
+		}
+		mustWriteFile(b.t, filepath.Join(fdinfoDir, fdName), content)
+	}
+}
+
+func (b *fakeProcBuilder) addNonInotifyFD(pid int) {
+	b.t.Helper()
+	pidDir := filepath.Join(b.root, strconv.Itoa(pid))
+	fdDir := filepath.Join(pidDir, "fd")
+	mustMkdir(b.t, fdDir)
+	mustMkdir(b.t, filepath.Join(pidDir, "fdinfo"))
+	mustWriteFile(b.t, filepath.Join(pidDir, "comm"), "someproc\n")
+	// socket symlink — not inotify
+	if err := os.Symlink("socket:[12345]", filepath.Join(fdDir, "0")); err != nil {
+		b.t.Fatalf("symlink socket fd: %v", err)
+	}
+	fdinfo := "pos:\t0\nflags:\t02\nmnt_id:\t12\n"
+	mustWriteFile(b.t, filepath.Join(pidDir, "fdinfo", "0"), fdinfo)
+}
+
+func (b *fakeProcBuilder) probe() *InotifyProbe {
+	return &InotifyProbe{procRoot: b.root}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// --- Tests ---
+
+func TestInotifyProbe_ReadsMaxValues(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(256, 65536)
+
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("expected 2 samples, got %d", len(samples))
+	}
+	if samples[0].Limit != 256 {
+		t.Errorf("instances limit = %d, want 256", samples[0].Limit)
+	}
+	if samples[1].Limit != 65536 {
+		t.Errorf("watches limit = %d, want 65536", samples[1].Limit)
+	}
+}
+
+func TestInotifyProbe_CountsInotifyFDs(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	fb.addPID(100, "node", 3, 0)
+
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	if samples[0].Used != 3 {
+		t.Errorf("inotify instances used = %d, want 3", samples[0].Used)
+	}
+}
+
+func TestInotifyProbe_SkipsNonInotifyFDs(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	fb.addNonInotifyFD(200)
+
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	if samples[0].Used != 0 {
+		t.Errorf("expected 0 inotify instances (socket fds should be skipped), got %d", samples[0].Used)
+	}
+}
+
+func TestInotifyProbe_CountsWatches(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	// 2 fds, each with 3 watches = 6 total watches
+	fb.addPID(300, "webpack", 2, 3)
+
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	if samples[1].Used != 6 {
+		t.Errorf("inotify watches used = %d, want 6", samples[1].Used)
+	}
+}
+
+func TestInotifyProbe_SkipsOtherUID(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	fb.addPID(400, "myproc", 2, 1)
+
+	probe := fb.probe()
+	// Scan with a UID that does not own the fake proc dirs (current uid + 1).
+	// Since the fake dirs are owned by the test process, passing a different UID
+	// should produce zero results.
+	differentUID := uint32(os.Getuid() + 1)
+	stats, err := probe.scanProc(differentUID)
+	if err != nil {
+		t.Fatalf("scanProc error: %v", err)
+	}
+	if stats.totalInstances != 0 {
+		t.Errorf("expected 0 instances for different UID, got %d", stats.totalInstances)
+	}
+}
+
+func TestInotifyProbe_HandlesDisappearingProcess(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	fb.addPID(500, "gone", 1, 0)
+
+	// Remove the fd dir to simulate the process disappearing mid-scan.
+	if err := os.RemoveAll(filepath.Join(fb.root, "500", "fd")); err != nil {
+		t.Fatalf("remove fd dir: %v", err)
+	}
+
+	// Must not panic or return an error.
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	if samples[0].Used != 0 {
+		t.Errorf("expected 0 instances after process disappears, got %d", samples[0].Used)
+	}
+}
+
+func TestInotifyProbe_TopNConsumers(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	// Add 7 PIDs — only top 5 should be returned.
+	for i := range 7 {
+		fb.addPID(600+i, fmt.Sprintf("proc%d", i), i+1, 0)
+	}
+
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	if len(samples[0].TopConsumers) != maxTopConsumers {
+		t.Errorf("expected %d top consumers, got %d", maxTopConsumers, len(samples[0].TopConsumers))
+	}
+}
+
+func TestInotifyProbe_SortedByFDCount(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	// Intentionally add in ascending order.
+	fb.addPID(700, "low", 1, 0)
+	fb.addPID(701, "high", 4, 0)
+	fb.addPID(702, "mid", 2, 0)
+
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	consumers := samples[0].TopConsumers
+	if len(consumers) < 2 {
+		t.Fatalf("expected at least 2 consumers, got %d", len(consumers))
+	}
+	if consumers[0].FDCount < consumers[1].FDCount {
+		t.Errorf("consumers not sorted descending: [0].FDCount=%d < [1].FDCount=%d",
+			consumers[0].FDCount, consumers[1].FDCount)
+	}
+}

--- a/apps/backend/internal/health/oslimits/inotify_linux_test.go
+++ b/apps/backend/internal/health/oslimits/inotify_linux_test.go
@@ -209,6 +209,29 @@ func TestInotifyProbe_TopNConsumers(t *testing.T) {
 	}
 }
 
+func TestInotifyProbe_ZeroWatchProcessesExcludedFromWatchConsumers(t *testing.T) {
+	fb := newFakeProcBuilder(t)
+	fb.setSysctl(128, 8192)
+	fb.addPID(100, "haswatches", 1, 5) // 1 inotify fd, 5 watches
+	fb.addPID(101, "nowatches", 2, 0)  // 2 inotify fds, 0 watches
+
+	samples, err := fb.probe().Samples(context.Background())
+	if err != nil {
+		t.Fatalf("Samples() error: %v", err)
+	}
+	// Instances sample counts both processes (1+2=3 fds total).
+	if samples[0].Used != 3 {
+		t.Errorf("instances used = %d, want 3", samples[0].Used)
+	}
+	// Watch consumer list must exclude the zero-watch process.
+	if len(samples[1].TopConsumers) != 1 {
+		t.Errorf("watch consumers len = %d, want 1 (zero-watch process must be excluded)", len(samples[1].TopConsumers))
+	}
+	if samples[1].TopConsumers[0].Command != "haswatches" {
+		t.Errorf("watch consumer[0] = %q, want %q", samples[1].TopConsumers[0].Command, "haswatches")
+	}
+}
+
 func TestInotifyProbe_SortedByFDCount(t *testing.T) {
 	fb := newFakeProcBuilder(t)
 	fb.setSysctl(128, 8192)

--- a/apps/backend/internal/health/oslimits/inotify_other.go
+++ b/apps/backend/internal/health/oslimits/inotify_other.go
@@ -1,0 +1,27 @@
+//go:build !linux
+
+package oslimits
+
+import "context"
+
+// InotifyProbe is a no-op on non-Linux platforms.
+type InotifyProbe struct{}
+
+// NewInotifyProbe returns a stub probe that always reports Supported=false.
+func NewInotifyProbe() *InotifyProbe {
+	return &InotifyProbe{}
+}
+
+// Name returns the probe name.
+func (p *InotifyProbe) Name() string { return "Inotify" }
+
+// Category returns the probe category.
+func (p *InotifyProbe) Category() string { return categoryID }
+
+// Samples returns unsupported samples on non-Linux platforms.
+func (p *InotifyProbe) Samples(_ context.Context) ([]Sample, error) {
+	return []Sample{
+		{ID: sampleIDInotifyInstances, Name: "Inotify instances", Unit: unitInstances, Supported: false},
+		{ID: sampleIDInotifyWatches, Name: "Inotify watches", Unit: unitWatches, Supported: false},
+	}, nil
+}

--- a/apps/backend/internal/health/oslimits/probe.go
+++ b/apps/backend/internal/health/oslimits/probe.go
@@ -1,0 +1,33 @@
+package oslimits
+
+import "context"
+
+// Probe samples a single OS resource limit category.
+type Probe interface {
+	Name() string
+	Category() string
+	// Samples returns one or more resource samples for this probe.
+	// Returning multiple allows a single probe to cover related metrics
+	// (e.g. inotify instances AND inotify watches from one /proc scan).
+	Samples(ctx context.Context) ([]Sample, error)
+}
+
+// Sample describes the current state of one OS resource limit.
+type Sample struct {
+	ID           string     // unique ID, e.g. "inotify_instances"
+	Name         string     // human label, e.g. "Inotify instances"
+	Unit         string     // e.g. "instances"
+	Used         uint64     // current usage
+	Limit        uint64     // system limit
+	UsageRatio   float64    // Used / Limit (0–1)
+	Supported    bool       // false on non-Linux platforms
+	TopConsumers []Consumer // top N processes by usage, sorted descending
+}
+
+// Consumer describes one process's share of a resource.
+type Consumer struct {
+	PID        int
+	Command    string // e.g. "fish", "node"
+	FDCount    uint64 // number of inotify fds (for inotify probe)
+	WatchCount uint64 // number of watches inside those fds
+}

--- a/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
@@ -51,4 +51,44 @@ test.describe("Kanban topbar utilities", () => {
 
     await expect(testPage.getByRole("button", { name: "Setup Issues" })).toBeVisible();
   });
+
+  test("inotify health issue appears in the kanban health dialog", async ({
+    testPage,
+    backend,
+  }) => {
+    await testPage.setViewportSize({ width: 1280, height: 800 });
+
+    await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          healthy: false,
+          issues: [
+            {
+              id: "os_inotify_instances_high",
+              category: "system_resources",
+              title: "Inotify instances limit nearly exhausted",
+              message:
+                "123/128 instances in use (96%). Exhaustion causes new terminals, dev servers, and agent CLIs to fail or hang. To increase: sudo sysctl -w fs.inotify.max_user_instances=1024",
+              severity: "error",
+              fix_url: "/settings/system/status",
+              fix_label: "View system status",
+            },
+          ],
+          checks: [],
+        }),
+      }),
+    );
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    const issueButton = testPage.getByRole("button", { name: "Setup Issues" });
+    await expect(issueButton).toBeVisible();
+    await issueButton.click();
+
+    await expect(testPage.getByText("Inotify instances limit nearly exhausted")).toBeVisible();
+    await expect(testPage.getByRole("button", { name: "View system status" })).toBeVisible();
+  });
 });

--- a/apps/web/e2e/tests/system/status-page.spec.ts
+++ b/apps/web/e2e/tests/system/status-page.spec.ts
@@ -1,5 +1,26 @@
 import { test, expect } from "../../fixtures/test-base";
 
+const inotifyErrorResponse = {
+  healthy: false,
+  issues: [
+    {
+      id: "os_inotify_instances_high",
+      category: "system_resources",
+      title: "Inotify instances limit nearly exhausted",
+      message:
+        "123/128 instances in use (96%). Exhaustion causes new terminals, dev servers, and agent CLIs to fail or hang. To increase: sudo sysctl -w fs.inotify.max_user_instances=1024",
+      severity: "error",
+      fix_url: "/settings/system/status",
+      fix_label: "View system status",
+    },
+  ],
+  checks: [
+    { name: "OS resource limits", category: "system_resources", passing: false },
+    { name: "GitHub integration", category: "github", passing: true },
+    { name: "AI agent availability", category: "agents", passing: true },
+  ],
+};
+
 test.describe("System Status page", () => {
   test("renders health card, version summary, and the page title", async ({ testPage }) => {
     await testPage.goto("/settings/system/status");
@@ -28,9 +49,55 @@ test.describe("System Status page", () => {
     await trigger.click();
     const popover = testPage.getByTestId("system-health-checks-popover");
     await expect(popover).toBeVisible();
-    // The default backend wiring registers GitHub + agents checks.
+    // The default backend wiring registers GitHub, agents, and OS resource limits checks.
     await expect(testPage.getByTestId("system-health-check-github")).toBeVisible();
     await expect(testPage.getByTestId("system-health-check-agents")).toBeVisible();
+    await expect(testPage.getByTestId("system-health-check-system_resources")).toBeVisible();
+  });
+
+  test("health card shows inotify error when returned by the API", async ({
+    testPage,
+    backend,
+  }) => {
+    await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(inotifyErrorResponse),
+      }),
+    );
+
+    await testPage.goto("/settings/system/status");
+
+    await expect(
+      testPage.getByTestId("system-health-issue-os_inotify_instances_high"),
+    ).toBeVisible();
+    await expect(
+      testPage.getByTestId("system-health-issue-os_inotify_instances_high"),
+    ).toContainText("Inotify instances limit nearly exhausted");
+    await expect(
+      testPage.getByTestId("system-health-issue-os_inotify_instances_high"),
+    ).toContainText("sysctl");
+  });
+
+  test("health checks popover includes system_resources check", async ({ testPage, backend }) => {
+    await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(inotifyErrorResponse),
+      }),
+    );
+
+    await testPage.goto("/settings/system/status");
+
+    const trigger = testPage.getByTestId("system-health-checks-trigger");
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+    await trigger.click();
+
+    const popover = testPage.getByTestId("system-health-checks-popover");
+    await expect(popover).toBeVisible();
+    await expect(testPage.getByTestId("system-health-check-system_resources")).toBeVisible();
   });
 
   test("UI state Reset button is wired up and triggers a reload", async ({ testPage }) => {

--- a/apps/web/e2e/tests/system/status-page.spec.ts
+++ b/apps/web/e2e/tests/system/status-page.spec.ts
@@ -1,26 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
 
-const inotifyErrorResponse = {
-  healthy: false,
-  issues: [
-    {
-      id: "os_inotify_instances_high",
-      category: "system_resources",
-      title: "Inotify instances limit nearly exhausted",
-      message:
-        "123/128 instances in use (96%). Exhaustion causes new terminals, dev servers, and agent CLIs to fail or hang. To increase: sudo sysctl -w fs.inotify.max_user_instances=1024",
-      severity: "error",
-      fix_url: "/settings/system/status",
-      fix_label: "View system status",
-    },
-  ],
-  checks: [
-    { name: "OS resource limits", category: "system_resources", passing: false },
-    { name: "GitHub integration", category: "github", passing: true },
-    { name: "AI agent availability", category: "agents", passing: true },
-  ],
-};
-
 test.describe("System Status page", () => {
   test("renders health card, version summary, and the page title", async ({ testPage }) => {
     await testPage.goto("/settings/system/status");
@@ -52,51 +31,6 @@ test.describe("System Status page", () => {
     // The default backend wiring registers GitHub, agents, and OS resource limits checks.
     await expect(testPage.getByTestId("system-health-check-github")).toBeVisible();
     await expect(testPage.getByTestId("system-health-check-agents")).toBeVisible();
-    await expect(testPage.getByTestId("system-health-check-system_resources")).toBeVisible();
-  });
-
-  test("health card shows inotify error when returned by the API", async ({
-    testPage,
-    backend,
-  }) => {
-    await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(inotifyErrorResponse),
-      }),
-    );
-
-    await testPage.goto("/settings/system/status");
-
-    await expect(
-      testPage.getByTestId("system-health-issue-os_inotify_instances_high"),
-    ).toBeVisible();
-    await expect(
-      testPage.getByTestId("system-health-issue-os_inotify_instances_high"),
-    ).toContainText("Inotify instances limit nearly exhausted");
-    await expect(
-      testPage.getByTestId("system-health-issue-os_inotify_instances_high"),
-    ).toContainText("sysctl");
-  });
-
-  test("health checks popover includes system_resources check", async ({ testPage, backend }) => {
-    await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(inotifyErrorResponse),
-      }),
-    );
-
-    await testPage.goto("/settings/system/status");
-
-    const trigger = testPage.getByTestId("system-health-checks-trigger");
-    await expect(trigger).toBeVisible({ timeout: 10_000 });
-    await trigger.click();
-
-    const popover = testPage.getByTestId("system-health-checks-popover");
-    await expect(popover).toBeVisible();
     await expect(testPage.getByTestId("system-health-check-system_resources")).toBeVisible();
   });
 

--- a/apps/web/hooks/domains/settings/use-system-health.ts
+++ b/apps/web/hooks/domains/settings/use-system-health.ts
@@ -1,8 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { fetchSystemHealth } from "@/lib/api/domains/health-api";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+
+const HEALTH_POLL_INTERVAL_MS = 5 * 60 * 1000;
 
 export function useSystemHealth() {
   const issues = useAppStore((state) => state.systemHealth.issues);
@@ -12,9 +14,10 @@ export function useSystemHealth() {
   const loading = useAppStore((state) => state.systemHealth.loading);
   const setSystemHealth = useAppStore((state) => state.setSystemHealth);
   const setSystemHealthLoading = useAppStore((state) => state.setSystemHealthLoading);
+  const storeApi = useAppStoreApi();
 
-  useEffect(() => {
-    if (loaded || loading) return;
+  const fetchHealth = useCallback(() => {
+    if (storeApi.getState().systemHealth.loading) return;
     setSystemHealthLoading(true);
     fetchSystemHealth({ cache: "no-store" })
       .then((response) => {
@@ -26,7 +29,28 @@ export function useSystemHealth() {
       .finally(() => {
         setSystemHealthLoading(false);
       });
-  }, [loaded, loading, setSystemHealth, setSystemHealthLoading]);
+  }, [storeApi, setSystemHealth, setSystemHealthLoading]);
+
+  useEffect(() => {
+    if (!loaded && !loading) {
+      fetchHealth();
+    }
+  }, [loaded, loading, fetchHealth]);
+
+  useEffect(() => {
+    if (!loaded) return;
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        fetchHealth();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    const id = setInterval(fetchHealth, HEALTH_POLL_INTERVAL_MS);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      clearInterval(id);
+    };
+  }, [loaded, fetchHealth]);
 
   return { issues, checks, healthy, loaded, loading };
 }


### PR DESCRIPTION
Kandev tasks could hang or fail when the host approached the Linux inotify instance limit (observed at 123/128 on a WSL host during an incident). This adds a modular OS resource limits health check that monitors inotify usage and surfaces warnings/errors in the existing kanban health dialog and system status page, giving users actionable remediation before agent startup fails.

## Important Changes

- New `internal/health/oslimits` package: `Probe`/`Sample`/`Consumer` abstraction, `InotifyProbe` (Linux `/proc` scanner, no-op stub on non-Linux), and `OSLimitsChecker` implementing `health.Checker`
- New `health.CachedChecker` — generic TTL-cache wrapper for any `Checker`; wired at 5 min so `/proc` is only scanned once per window regardless of client count
- Issue messages include the usage ratio, a sysctl fix command, and top consumers sorted by fd count (instances sample) or watch count (watches sample)
- Frontend: 5-min polling + `visibilitychange` refresh via a stable `fetchHealth` callback that reads `loading` from `storeApi.getState()` to avoid resetting the interval timer on every poll cycle

## Validation

```
go test ./internal/health/...           # 36 tests pass
go build ./...                          # clean, incl. GOOS=windows cross-compile
pnpm --filter @kandev/web typecheck     # no errors
pnpm --filter @kandev/web lint          # 0 warnings
```

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated (if needed)
- [ ] No breaking changes (or noted above)