### PR TITLE
feat: add PR link to CI status popover header

### DIFF
--- a/apps/web/components/github/pr-ci-popover.tsx
+++ b/apps/web/components/github/pr-ci-popover.tsx
@@ -84,17 +84,30 @@ function PRCIPopoverHeader({ pr }: { pr: TaskPR }) {
       className="flex items-center justify-between gap-2 border-b border-border/50 pb-2"
     >
       <span className="text-sm font-medium">CI status</span>
-      <a
-        data-testid="pr-popover-external-link"
-        href={checksUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="cursor-pointer text-muted-foreground hover:text-foreground"
-        aria-label="View all checks on GitHub"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <IconExternalLink className="h-3.5 w-3.5" />
-      </a>
+      <div className="flex items-center gap-1.5">
+        <a
+          data-testid="pr-popover-pr-link"
+          href={pr.pr_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cursor-pointer text-muted-foreground hover:text-foreground"
+          aria-label="View pull request on GitHub"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <IconGitPullRequest className="h-3.5 w-3.5" />
+        </a>
+        <a
+          data-testid="pr-popover-external-link"
+          href={checksUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cursor-pointer text-muted-foreground hover:text-foreground"
+          aria-label="View all checks on GitHub"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <IconExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
     </div>
   );
 }

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -583,6 +583,11 @@ export class SessionPage {
     return this.prTopbarPopover().getByTestId("pr-comments-row");
   }
 
+  /** Header PR-link icon (top-right corner of the popover). */
+  prPopoverPRLink(): Locator {
+    return this.prTopbarPopover().getByTestId("pr-popover-pr-link");
+  }
+
   /** Header external-link icon (top-right corner of the popover). */
   prPopoverExternalLink(): Locator {
     return this.prTopbarPopover().getByTestId("pr-popover-external-link");


### PR DESCRIPTION
The CI status popover header only had a link to the PR checks page, so users couldn't directly open the PR itself from the hover menu. Add a pull-request icon link next to the existing external-link icon so the PR URL is reachable in one click.

**Validation**
- `cd apps && pnpm --filter @kandev/web lint` — passed
- `cd apps && pnpm --filter @kandev/web typecheck` — passed
- `make -C apps/backend test lint` — passed

**Checklist**
- [ ] I have read the contributing guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation if needed
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published