### PR TITLE
fix(web): render multi-level subtasks in sidebar task tree

### DIFF
--- a/apps/backend/internal/office/testharness/routes.go
+++ b/apps/backend/internal/office/testharness/routes.go
@@ -27,11 +27,25 @@ import (
 	officesqlite "github.com/kandev/kandev/internal/office/repository/sqlite"
 	"github.com/kandev/kandev/internal/task/models"
 	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // EnvVar gates registration of the test routes. Must be the literal string
 // "true" to enable — matches the convention used by KANDEV_MOCK_JIRA etc.
 const EnvVar = "KANDEV_E2E_MOCK"
+
+// errInvalidJSONPrefix is the shared 400 message for malformed request bodies.
+const errInvalidJSONPrefix = "invalid JSON: "
+
+// respKeyError is the JSON key for error responses. Older handlers in this file
+// inline the literal; new code uses errJSON so the heavily-repeated key isn't
+// duplicated again.
+const respKeyError = "error"
+
+// errJSON writes a `{"error": msg}` body with the given status code.
+func errJSON(c *gin.Context, code int, msg string) {
+	c.JSON(code, gin.H{respKeyError: msg})
+}
 
 // Enabled reports whether KANDEV_E2E_MOCK is set to "true".
 func Enabled() bool {
@@ -74,6 +88,7 @@ func RegisterRoutes(
 	g.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"ok": true})
 	})
+	g.POST("/tasks", seedTaskHandler(repo, log))
 	g.POST("/task-sessions", seedTaskSessionHandler(repo, eventBus, log))
 	g.POST("/messages", seedMessageHandler(repo, eventBus, log))
 	g.POST("/workflows", seedWorkflowHandler(repo, log))
@@ -92,6 +107,64 @@ func RegisterRoutes(
 	}
 	if agentSettings != nil {
 		g.POST("/agent-profiles/:id/desired-skills", setDesiredSkillsHandler(agentSettings, log))
+	}
+}
+
+type seedTaskRequest struct {
+	WorkspaceID    string `json:"workspace_id"`
+	WorkflowID     string `json:"workflow_id"`
+	WorkflowStepID string `json:"workflow_step_id"`
+	Title          string `json:"title"`
+	ParentID       string `json:"parent_id"`
+	State          string `json:"state"`
+}
+
+type seedTaskResponse struct {
+	TaskID string `json:"task_id"`
+}
+
+// seedTaskHandler creates a task row directly through the repository, which
+// bypasses the service-layer subtask-depth guard (validateSubtaskDepth runs in
+// Service.CreateTask only). This lets e2e tests build arbitrary parent_id
+// chains (depth >= 2) to exercise the sidebar's multi-level tree — production
+// CreateTask rejects depth > 1 for kanban tasks.
+func seedTaskHandler(repo *sqliterepo.Repository, log *logger.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req seedTaskRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			errJSON(c, http.StatusBadRequest, errInvalidJSONPrefix+err.Error())
+			return
+		}
+		if req.WorkspaceID == "" || req.Title == "" {
+			errJSON(c, http.StatusBadRequest, "workspace_id and title are required")
+			return
+		}
+		ctx := c.Request.Context()
+		if req.ParentID != "" {
+			if _, err := repo.GetTask(ctx, req.ParentID); err != nil {
+				errJSON(c, http.StatusBadRequest, "parent_id not found: "+req.ParentID)
+				return
+			}
+		}
+		state := req.State
+		if state == "" {
+			state = string(v1.TaskStateCreated)
+		}
+		task := &models.Task{
+			ID:             uuid.New().String(),
+			WorkspaceID:    req.WorkspaceID,
+			WorkflowID:     req.WorkflowID,
+			WorkflowStepID: req.WorkflowStepID,
+			Title:          req.Title,
+			State:          v1.TaskState(state),
+			ParentID:       req.ParentID,
+		}
+		if err := repo.CreateTask(ctx, task); err != nil {
+			log.Error("test harness: create task failed", zap.Error(err))
+			errJSON(c, http.StatusInternalServerError, err.Error())
+			return
+		}
+		c.JSON(http.StatusOK, seedTaskResponse{TaskID: task.ID})
 	}
 }
 

--- a/apps/backend/internal/office/testharness/routes_test.go
+++ b/apps/backend/internal/office/testharness/routes_test.go
@@ -291,6 +291,82 @@ func TestSeedMessageRejectsUnknownSession(t *testing.T) {
 	}
 }
 
+// The depth-1 guard lives in the task SERVICE; the harness writes through the
+// repository so e2e tests can build arbitrary parent_id chains (depth >= 2),
+// which is the only way to exercise the sidebar's multi-level rendering.
+func TestSeedTaskAllowsArbitraryDepthChain(t *testing.T) {
+	repo, _ := newTestRepo(t)
+	r := newRouter(t, repo, nil)
+
+	create := func(title, parentID string) string {
+		body := mustJSON(t, map[string]interface{}{
+			"workspace_id":     "ws-1",
+			"workflow_id":      "wf-1",
+			"workflow_step_id": "step-1",
+			"title":            title,
+			"parent_id":        parentID,
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/_test/tasks", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 creating %q, got %d: %s", title, w.Code, w.Body.String())
+		}
+		var resp struct {
+			TaskID string `json:"task_id"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		return resp.TaskID
+	}
+
+	root := create("Root", "")
+	child := create("Child", root)
+	grandchild := create("Grandchild", child) // depth 2 — would be rejected by the service guard
+
+	got, err := repo.GetTask(context.Background(), grandchild)
+	if err != nil {
+		t.Fatalf("get grandchild: %v", err)
+	}
+	if got.ParentID != child {
+		t.Fatalf("grandchild parent_id = %q, want %q (the child, i.e. depth 2)", got.ParentID, child)
+	}
+}
+
+func TestSeedTaskRejectsMissingFields(t *testing.T) {
+	repo, _ := newTestRepo(t)
+	r := newRouter(t, repo, nil)
+
+	body := mustJSON(t, map[string]interface{}{"workflow_id": "wf-1"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_test/tasks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing workspace_id/title, got %d", w.Code)
+	}
+}
+
+func TestSeedTaskRejectsUnknownParent(t *testing.T) {
+	repo, _ := newTestRepo(t)
+	r := newRouter(t, repo, nil)
+
+	body := mustJSON(t, map[string]interface{}{
+		"workspace_id": "ws-1",
+		"title":        "Orphan",
+		"parent_id":    "does-not-exist",
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/_test/tasks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown parent_id, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestSeedWorkflowPersistsStyle(t *testing.T) {
 	repo, _ := newTestRepo(t)
 	r := newRouter(t, repo, nil)

--- a/apps/web/components/task/mobile/session-mobile-top-bar.tsx
+++ b/apps/web/components/task/mobile/session-mobile-top-bar.tsx
@@ -153,7 +153,14 @@ function MobileTopBarActions({
         onRebase={onRebase}
         onMerge={onMerge}
       />
-      <Button variant="ghost" size="icon-sm" className="cursor-pointer" onClick={onMenuClick}>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        className="cursor-pointer"
+        onClick={onMenuClick}
+        data-testid="mobile-session-menu"
+        aria-label="Open task switcher"
+      >
         <IconMenu2 className="h-4 w-4" />
       </Button>
     </div>

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -312,6 +312,7 @@ function buildKanbanTaskUpsert(
   const taskSessionId = meta?.taskSessionId ?? null;
   return {
     id: task.id,
+    parentTaskId: task.parent_id ?? undefined,
     workflowStepId: task.workflow_step_id,
     title: task.title,
     description: task.description,

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -48,22 +48,17 @@ function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) 
     tasks: snapshot.tasks.map((task) => ({
       id: task.id,
       workflowStepId: task.workflow_step_id,
+      parentTaskId: task.parent_id ?? undefined,
       title: task.title,
       description: task.description ?? undefined,
       position: task.position ?? 0,
       state: task.state,
       repositoryId: task.repositories?.[0]?.repository_id ?? undefined,
       // Carry the full TaskRepository array so the mobile repo picker
-      // (useTaskRepoCount + MobileReposSection) keeps working after a
-      // workspace switch. Without this, the picker silently disappears for
-      // multi-repo tasks because length defaults to 0.
-      repositories: task.repositories?.map((r) => ({
-        id: r.id,
-        repository_id: r.repository_id,
-        base_branch: r.base_branch,
-        checkout_branch: r.checkout_branch,
-        position: r.position,
-      })),
+      // (useTaskRepoCount + MobileReposSection) keeps working after a workspace
+      // switch. Without this, the picker silently disappears for multi-repo
+      // tasks because length defaults to 0.
+      repositories: mapTaskRepositories(task.repositories),
       primarySessionId: task.primary_session_id ?? undefined,
       primarySessionState: task.primary_session_state ?? undefined,
       sessionCount: task.session_count ?? undefined,
@@ -108,6 +103,9 @@ function toSheetItem(
   return {
     id: task.id,
     title: task.title,
+    // Carry the parent link so the mobile task switcher nests subtasks the same
+    // way the desktop sidebar does (applyView/TaskSwitcher read parentTaskId).
+    parentTaskId: task.parentTaskId ?? undefined,
     state: task.state as TaskState | undefined,
     sessionState:
       sessionInfo.sessionState ?? (task.primarySessionState as TaskSessionState | undefined),

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -15,6 +15,7 @@ import { PRTaskIcon } from "@/components/github/pr-task-icon";
 import { IssueTaskIcon } from "@/components/github/issue-task-icon";
 import { useAppStore } from "@/components/state-provider";
 import { cn } from "@/lib/utils";
+import { computeRowIndent, resolveRowDepth } from "@/lib/sidebar/row-indent";
 import { DEBUG_UI } from "@/lib/config";
 import { useTaskColor } from "@/hooks/use-task-color";
 import { TASK_COLOR_BAR_CLASS, type TaskColor } from "@/lib/task-colors";
@@ -51,6 +52,12 @@ type TaskItemProps = {
   hasPendingPermission?: boolean;
   parentTaskTitle?: string;
   isSubTask?: boolean;
+  /**
+   * Nesting depth in the sidebar tree (0 = root). Drives left indentation so
+   * arbitrarily deep subtask trees read as a hierarchy. Falls back to
+   * `isSubTask` (depth 1) when omitted.
+   */
+  depth?: number;
   /** Number of subtasks under this parent task. Only set for parent rows. */
   subtaskCount?: number;
   /** Whether the subtasks of this parent are currently hidden. */
@@ -312,6 +319,7 @@ export const TaskItem = memo(function TaskItem({
   hasPendingClarification,
   hasPendingPermission,
   isSubTask,
+  depth,
   subtaskCount,
   subtasksCollapsed,
   onToggleSubtasks,
@@ -325,6 +333,7 @@ export const TaskItem = memo(function TaskItem({
   const hasDiffStats = !!diffStats && (diffStats.additions > 0 || diffStats.deletions > 0);
   const showSubtaskToggle = !!subtaskCount && subtaskCount > 0 && !!onToggleSubtasks;
   const taskColor = useTaskColor(taskId);
+  const indent = computeRowIndent(resolveRowDepth(depth, isSubTask));
 
   return (
     <div
@@ -333,16 +342,20 @@ export const TaskItem = memo(function TaskItem({
       data-testid="sidebar-task-item"
       onClick={onClick}
       onKeyDown={(e) => handleTaskItemKeyDown(e, onClick)}
+      style={indent.depth > 0 ? { paddingLeft: indent.paddingLeftPx } : undefined}
       className={cn(
         "group relative flex w-full items-start gap-2 py-2 pr-3 text-left text-sm outline-none cursor-pointer",
         "transition-colors duration-75 hover:bg-foreground/[0.05]",
         isSelected && "bg-primary/10",
-        isSubTask ? "pl-8" : "pl-3",
+        indent.depth === 0 && "pl-3",
       )}
     >
       <SelectionBar isSelected={isSelected} color={taskColor} />
-      {isSubTask && (
-        <span className="absolute left-3.5 top-[10px] select-none text-[11px] text-muted-foreground/30">
+      {indent.depth > 0 && (
+        <span
+          style={{ left: indent.connectorLeftPx }}
+          className="absolute top-[10px] select-none text-[11px] text-muted-foreground/30"
+        >
           ↳
         </span>
       )}

--- a/apps/web/components/task/task-switcher-subtask-dnd.tsx
+++ b/apps/web/components/task/task-switcher-subtask-dnd.tsx
@@ -21,19 +21,7 @@ import type { TaskSwitcherItem } from "./task-switcher";
 
 export const DRAG_ACTIVATION_DISTANCE = 8;
 
-/**
- * A single sortable node in the (arbitrarily deep) task tree.
- *
- * `setNodeRef` and the CSS transform live on the outer wrapper so the row and
- * its nested subtree move together while dragging. Drag listeners attach ONLY
- * to the `handle` (the task row) — `nested` (the child subtree) renders as a
- * sibling outside the handle so a pointer-down on a descendant row drags that
- * descendant, not this node. This is the same handle/children split the root
- * level has always used; generalizing it is what makes nesting safe at depth.
- */
-/**
- * Sortable variant — isolated so the hook is never called conditionally.
- */
+/** Sortable implementation — isolated so `useSortable` is never called conditionally. */
 function DraggableSortableTaskNode({
   taskId,
   depth,
@@ -84,6 +72,18 @@ function DraggableSortableTaskNode({
   );
 }
 
+/**
+ * A single sortable node in the (arbitrarily deep) task tree.
+ *
+ * `setNodeRef` and the CSS transform live on the outer wrapper so the row and
+ * its nested subtree move together while dragging. Drag listeners attach ONLY
+ * to the `handle` (the task row) — `nested` (the child subtree) renders as a
+ * sibling outside the handle so a pointer-down on a descendant row drags that
+ * descendant, not this node. This is the same handle/children split the root
+ * level has always used; generalizing it is what makes nesting safe at depth.
+ *
+ * When `isDraggable` is false, renders a plain wrapper with no DnD wiring.
+ */
 export function SortableTaskNode({
   taskId,
   depth,

--- a/apps/web/components/task/task-switcher-subtask-dnd.tsx
+++ b/apps/web/components/task/task-switcher-subtask-dnd.tsx
@@ -31,7 +31,10 @@ export const DRAG_ACTIVATION_DISTANCE = 8;
  * descendant, not this node. This is the same handle/children split the root
  * level has always used; generalizing it is what makes nesting safe at depth.
  */
-export function SortableTaskNode({
+/**
+ * Sortable variant — isolated so the hook is never called conditionally.
+ */
+function DraggableSortableTaskNode({
   taskId,
   depth,
   handle,
@@ -81,6 +84,33 @@ export function SortableTaskNode({
   );
 }
 
+export function SortableTaskNode({
+  taskId,
+  depth,
+  handle,
+  nested,
+  isDraggable = true,
+}: {
+  taskId: string;
+  depth: number;
+  handle: React.ReactNode;
+  nested?: React.ReactNode;
+  isDraggable?: boolean;
+}) {
+  if (!isDraggable) {
+    return (
+      <div data-testid="sortable-task-block" data-task-id={taskId} data-depth={depth}>
+        <div data-testid="sortable-task-handle">{handle}</div>
+        {nested}
+      </div>
+    );
+  }
+
+  return (
+    <DraggableSortableTaskNode taskId={taskId} depth={depth} handle={handle} nested={nested} />
+  );
+}
+
 /**
  * DnD wiring for one level of sibling tasks. Reordering is scoped to the
  * siblings sharing a parent (cross-parent drag is intentionally unsupported).
@@ -118,10 +148,11 @@ export function SortableTaskLevel({
 }: {
   tasks: TaskSwitcherItem[];
   onReorder?: (orderedTaskIds: string[]) => void;
-  renderNode: (task: TaskSwitcherItem) => React.ReactNode;
+  renderNode: (task: TaskSwitcherItem, isDraggable: boolean) => React.ReactNode;
 }) {
   const { sensors, handleDragEnd, sortableIds } = useLevelDnd(tasks, onReorder);
-  const body = tasks.map((task) => renderNode(task));
+  const isDraggable = !!onReorder;
+  const body = tasks.map((task) => renderNode(task, isDraggable));
   if (!onReorder) return <>{body}</>;
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>

--- a/apps/web/components/task/task-switcher-subtask-dnd.tsx
+++ b/apps/web/components/task/task-switcher-subtask-dnd.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   DndContext,
   PointerSensor,
@@ -21,7 +21,27 @@ import type { TaskSwitcherItem } from "./task-switcher";
 
 export const DRAG_ACTIVATION_DISTANCE = 8;
 
-function SortableSubtaskRow({ taskId, children }: { taskId: string; children: React.ReactNode }) {
+/**
+ * A single sortable node in the (arbitrarily deep) task tree.
+ *
+ * `setNodeRef` and the CSS transform live on the outer wrapper so the row and
+ * its nested subtree move together while dragging. Drag listeners attach ONLY
+ * to the `handle` (the task row) — `nested` (the child subtree) renders as a
+ * sibling outside the handle so a pointer-down on a descendant row drags that
+ * descendant, not this node. This is the same handle/children split the root
+ * level has always used; generalizing it is what makes nesting safe at depth.
+ */
+export function SortableTaskNode({
+  taskId,
+  depth,
+  handle,
+  nested,
+}: {
+  taskId: string;
+  depth: number;
+  handle: React.ReactNode;
+  nested?: React.ReactNode;
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: taskId,
   });
@@ -39,101 +59,74 @@ function SortableSubtaskRow({ taskId, children }: { taskId: string; children: Re
     <div
       ref={setNodeRef}
       style={style}
-      {...sortableAttributes}
-      {...listeners}
-      tabIndex={undefined}
-      data-testid="sortable-subtask-row"
+      data-testid="sortable-task-block"
       data-task-id={taskId}
-      className={cn("cursor-grab active:cursor-grabbing", isDragging && "z-50")}
+      data-depth={depth}
+      className={cn(isDragging && "z-50")}
     >
-      {children}
+      <div
+        {...sortableAttributes}
+        {...listeners}
+        // Strip dnd-kit's default tabIndex={0}: only PointerSensor is wired,
+        // so keyboard tab stops here lead nowhere. If KeyboardSensor is
+        // added later, drop this override.
+        tabIndex={undefined}
+        data-testid="sortable-task-handle"
+        className="cursor-grab active:cursor-grabbing"
+      >
+        {handle}
+      </div>
+      {nested}
     </div>
   );
 }
 
-function useSubtaskDnd(
-  parentTaskId: string,
-  subtasks: TaskSwitcherItem[],
-  onReorderSubtasks: (parentTaskId: string, orderedSubtaskIds: string[]) => void,
-) {
+/**
+ * DnD wiring for one level of sibling tasks. Reordering is scoped to the
+ * siblings sharing a parent (cross-parent drag is intentionally unsupported).
+ */
+function useLevelDnd(tasks: TaskSwitcherItem[], onReorder?: (orderedTaskIds: string[]) => void) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
   );
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      if (!onReorder) return;
       const { active, over } = event;
       if (!over || active.id === over.id) return;
-      const ids = subtasks.map((t) => t.id);
+      const ids = tasks.map((t) => t.id);
       const oldIndex = ids.indexOf(String(active.id));
       const newIndex = ids.indexOf(String(over.id));
       if (oldIndex < 0 || newIndex < 0) return;
-      onReorderSubtasks(parentTaskId, arrayMove(ids, oldIndex, newIndex));
+      onReorder(arrayMove(ids, oldIndex, newIndex));
     },
-    [parentTaskId, subtasks, onReorderSubtasks],
+    [tasks, onReorder],
   );
-  const sortableIds = useMemo(() => subtasks.map((t) => t.id), [subtasks]);
+  const sortableIds = useMemo(() => tasks.map((t) => t.id), [tasks]);
   return { sensors, handleDragEnd, sortableIds };
 }
 
 /**
- * Per-parent sortable list. When `onReorderSubtasks` is omitted the DnD
- * scaffolding (and the misleading grab cursor) is skipped — callers that
- * don't reorder get a plain list with no wasted setup.
+ * Renders one level of sibling task nodes. When `onReorder` is omitted the DnD
+ * scaffolding (and the misleading grab cursor) is skipped, so non-reorderable
+ * callers get a plain list with no wasted setup.
  */
-export function SortableSubtaskList({
-  parentTaskId,
-  subtasks,
-  onReorderSubtasks,
-  renderRow,
+export function SortableTaskLevel({
+  tasks,
+  onReorder,
+  renderNode,
 }: {
-  parentTaskId: string;
-  subtasks: TaskSwitcherItem[];
-  onReorderSubtasks?: (parentTaskId: string, orderedSubtaskIds: string[]) => void;
-  renderRow: (sub: TaskSwitcherItem) => React.ReactNode;
+  tasks: TaskSwitcherItem[];
+  onReorder?: (orderedTaskIds: string[]) => void;
+  renderNode: (task: TaskSwitcherItem) => React.ReactNode;
 }) {
-  if (!onReorderSubtasks) {
-    return (
-      <>
-        {subtasks.map((sub) => (
-          <Fragment key={sub.id}>{renderRow(sub)}</Fragment>
-        ))}
-      </>
-    );
-  }
-  return (
-    <SortableSubtaskListInner
-      parentTaskId={parentTaskId}
-      subtasks={subtasks}
-      onReorderSubtasks={onReorderSubtasks}
-      renderRow={renderRow}
-    />
-  );
-}
-
-function SortableSubtaskListInner({
-  parentTaskId,
-  subtasks,
-  onReorderSubtasks,
-  renderRow,
-}: {
-  parentTaskId: string;
-  subtasks: TaskSwitcherItem[];
-  onReorderSubtasks: (parentTaskId: string, orderedSubtaskIds: string[]) => void;
-  renderRow: (sub: TaskSwitcherItem) => React.ReactNode;
-}) {
-  const { sensors, handleDragEnd, sortableIds } = useSubtaskDnd(
-    parentTaskId,
-    subtasks,
-    onReorderSubtasks,
-  );
+  const { sensors, handleDragEnd, sortableIds } = useLevelDnd(tasks, onReorder);
+  const body = tasks.map((task) => renderNode(task));
+  if (!onReorder) return <>{body}</>;
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-        {subtasks.map((sub) => (
-          <SortableSubtaskRow key={sub.id} taskId={sub.id}>
-            {renderRow(sub)}
-          </SortableSubtaskRow>
-        ))}
+        {body}
       </SortableContext>
     </DndContext>
   );

--- a/apps/web/components/task/task-switcher.test.tsx
+++ b/apps/web/components/task/task-switcher.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { StateProvider } from "@/components/state-provider";
+import { ToastProvider } from "@/components/toast-provider";
+import { TaskSwitcher, type TaskSwitcherItem } from "./task-switcher";
+import type { GroupedSidebarList } from "@/lib/sidebar/apply-view";
+
+afterEach(() => cleanup());
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <StateProvider>
+      <ToastProvider>{children}</ToastProvider>
+    </StateProvider>
+  );
+}
+
+function item(id: string, parentTaskId?: string): TaskSwitcherItem {
+  return { id, title: id, state: "IN_PROGRESS", parentTaskId };
+}
+
+// root → child → grandchild (depth 2)
+const ROOT = item("Root");
+const CHILD = item("Child", "Root");
+const GRANDCHILD = item("Grandchild", "Child");
+
+function grouped(): GroupedSidebarList {
+  return {
+    groups: [{ key: "__all__", label: "All", tasks: [ROOT] }],
+    subTasksByParentId: new Map([
+      ["Root", [CHILD]],
+      ["Child", [GRANDCHILD]],
+    ]),
+  };
+}
+
+function renderSwitcher(collapsedSubtaskParentIds: string[] = []) {
+  return render(
+    <Providers>
+      <TaskSwitcher
+        grouped={grouped()}
+        activeTaskId={null}
+        selectedTaskId={null}
+        onSelectTask={vi.fn()}
+        onToggleSubtasks={vi.fn()}
+        collapsedSubtaskParentIds={collapsedSubtaskParentIds}
+      />
+    </Providers>,
+  );
+}
+
+function blockDepth(container: HTMLElement, taskId: string): string | null {
+  return (
+    container
+      .querySelector(`[data-testid='sortable-task-block'][data-task-id='${taskId}']`)
+      ?.getAttribute("data-depth") ?? null
+  );
+}
+
+describe("TaskSwitcher — nested subtasks beyond depth 1", () => {
+  it("renders the full tree (root, child, grandchild)", () => {
+    renderSwitcher();
+    expect(screen.queryByText("Root")).not.toBeNull();
+    expect(screen.queryByText("Child")).not.toBeNull();
+    expect(screen.queryByText("Grandchild")).not.toBeNull();
+  });
+
+  it("tags each row with its tree depth", () => {
+    const { container } = renderSwitcher();
+    expect(blockDepth(container, "Root")).toBe("0");
+    expect(blockDepth(container, "Child")).toBe("1");
+    expect(blockDepth(container, "Grandchild")).toBe("2");
+  });
+
+  it("collapsing a mid-level parent hides its whole subtree", () => {
+    renderSwitcher(["Child"]);
+    expect(screen.queryByText("Root")).not.toBeNull();
+    expect(screen.queryByText("Child")).not.toBeNull();
+    // Grandchild lives under the collapsed Child, so it must not render.
+    expect(screen.queryByText("Grandchild")).toBeNull();
+  });
+
+  it("group header counts the whole subtree, not just direct children", () => {
+    renderSwitcher();
+    // Header only shows for >1 group or a non-default key. Force it by using a
+    // keyed group instead of the implicit __all__ bucket.
+    cleanup();
+    render(
+      <Providers>
+        <TaskSwitcher
+          grouped={{
+            groups: [{ key: "wf1", label: "Workflow 1", tasks: [ROOT] }],
+            subTasksByParentId: grouped().subTasksByParentId,
+          }}
+          activeTaskId={null}
+          selectedTaskId={null}
+          onSelectTask={vi.fn()}
+          onToggleSubtasks={vi.fn()}
+          collapsedSubtaskParentIds={[]}
+        />
+      </Providers>,
+    );
+    // Root + Child + Grandchild = 3
+    expect(screen.queryByText("3")).not.toBeNull();
+  });
+});

--- a/apps/web/components/task/task-switcher.test.tsx
+++ b/apps/web/components/task/task-switcher.test.tsx
@@ -103,4 +103,36 @@ describe("TaskSwitcher — nested subtasks beyond depth 1", () => {
     // Root + Child + Grandchild = 3
     expect(screen.queryByText("3")).not.toBeNull();
   });
+
+  it("parent subtask toggle counts all descendants, not just direct children", () => {
+    const { container } = renderSwitcher();
+    const rootToggle = container.querySelector(
+      "[data-testid='sidebar-subtask-toggle'][data-task-id='Root']",
+    );
+    expect(rootToggle).not.toBeNull();
+    // Root → Child → Grandchild: badge should reflect 2 hidden rows, not 1.
+    expect(rootToggle!.textContent).toContain("2");
+  });
+
+  it("omits grab cursor on nested rows when subtask reorder is disabled", () => {
+    const { container } = render(
+      <Providers>
+        <TaskSwitcher
+          grouped={grouped()}
+          activeTaskId={null}
+          selectedTaskId={null}
+          onSelectTask={vi.fn()}
+          onToggleSubtasks={vi.fn()}
+          collapsedSubtaskParentIds={[]}
+        />
+      </Providers>,
+    );
+    for (const taskId of ["Child", "Grandchild"]) {
+      const handle = container.querySelector(
+        `[data-testid='sortable-task-block'][data-task-id='${taskId}'] > [data-testid='sortable-task-handle']`,
+      );
+      expect(handle).not.toBeNull();
+      expect(handle!.className).not.toContain("cursor-grab");
+    }
+  });
 });

--- a/apps/web/components/task/task-switcher.tsx
+++ b/apps/web/components/task/task-switcher.tsx
@@ -1,29 +1,18 @@
 "use client";
 
-import { memo, useCallback, useMemo } from "react";
+import { memo, useMemo } from "react";
 import { IconChevronDown } from "@tabler/icons-react";
-import {
-  DndContext,
-  PointerSensor,
-  closestCenter,
-  type DragEndEvent,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  arrayMove,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import type { TaskState, TaskSessionState } from "@/lib/types/http";
 import { cn } from "@/lib/utils";
 import { TaskItem } from "./task-item";
 import { TaskItemWithContextMenu, type StepDef } from "./task-switcher-context-menu";
-import type { GroupedSidebarList, SidebarGroup } from "@/lib/sidebar/apply-view";
+import {
+  countGroupTasks,
+  type GroupedSidebarList,
+  type SidebarGroup,
+} from "@/lib/sidebar/apply-view";
 import { type TaskMoveWorkflow } from "@/components/task/task-move-context-menu";
-import { DRAG_ACTIVATION_DISTANCE, SortableSubtaskList } from "./task-switcher-subtask-dnd";
+import { SortableTaskLevel, SortableTaskNode } from "./task-switcher-subtask-dnd";
 
 export type TaskSwitcherItem = {
   id: string;
@@ -135,6 +124,7 @@ function GroupHeader({
 type TaskRowProps = {
   task: TaskSwitcherItem;
   isSubTask?: boolean;
+  depth?: number;
   subtaskToggle?: SubtaskToggleInfo;
   workflows?: TaskMoveWorkflow[];
   stepsByWorkflowId?: Record<string, StepDef[]>;
@@ -153,6 +143,7 @@ type TaskRowProps = {
 function TaskRow({
   task,
   isSubTask,
+  depth,
   subtaskToggle,
   workflows,
   stepsByWorkflowId,
@@ -202,6 +193,7 @@ function TaskRow({
         prInfo={task.prInfo}
         issueInfo={task.issueInfo}
         isSubTask={isSubTask}
+        depth={depth}
         subtaskCount={subtaskToggle?.subtaskCount}
         subtasksCollapsed={subtaskToggle?.subtasksCollapsed}
         onToggleSubtasks={subtaskToggle?.onToggleSubtasks}
@@ -213,54 +205,89 @@ function TaskRow({
   );
 }
 
-function SortableTaskBlock({
-  taskId,
-  parent,
-  subTasks,
+// Shared, per-render context threaded through the recursive task tree so each
+// node can look up its children, collapse state, and reorder callbacks without
+// drilling a dozen props through every level.
+type TaskTreeContext = {
+  subTasksByParentId: Map<string, TaskSwitcherItem[]>;
+  collapsedSubs: Set<string>;
+  onToggleSubtasks?: (parentTaskId: string) => void;
+  pinnedSet: Set<string>;
+  rowProps: Omit<TaskRowProps, "task" | "subtaskToggle" | "isPinned" | "isSubTask" | "depth">;
+  onReorderGroup?: (groupTaskIds: string[]) => void;
+  onReorderSubtasks?: (parentTaskId: string, orderedSubtaskIds: string[]) => void;
+};
+
+// One task row plus — when expanded — its nested subtree. Mutually recursive
+// with TaskTreeLevel, so it renders arbitrarily deep hierarchies.
+function TaskTreeNode({
+  task,
+  depth,
+  ctx,
 }: {
-  taskId: string;
-  parent: React.ReactNode;
-  subTasks?: React.ReactNode;
+  task: TaskSwitcherItem;
+  depth: number;
+  ctx: TaskTreeContext;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: taskId,
-  });
-  const sortableAttributes = {
-    ...attributes,
-    role: undefined,
-    "aria-roledescription": undefined,
-  };
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : undefined,
-  };
-  // setNodeRef stays on the outer wrapper so the CSS transform applies to
-  // the parent row + its subtasks together. Drag listeners only attach to
-  // the parent row's wrapper, so a pointer-down on a subtask row does NOT
-  // trigger a drag of the parent block.
+  const subs = ctx.subTasksByParentId.get(task.id);
+  const hasSubs = !!subs?.length;
+  const subsHidden = hasSubs && !!ctx.onToggleSubtasks && ctx.collapsedSubs.has(task.id);
+  const toggleInfo: SubtaskToggleInfo | undefined =
+    hasSubs && ctx.onToggleSubtasks
+      ? {
+          subtaskCount: subs!.length,
+          subtasksCollapsed: subsHidden,
+          onToggleSubtasks: () => ctx.onToggleSubtasks!(task.id),
+        }
+      : undefined;
+  const isRoot = depth === 0;
+  const handle = (
+    <TaskRow
+      task={task}
+      depth={depth}
+      isSubTask={!isRoot}
+      subtaskToggle={toggleInfo}
+      isPinned={isRoot && ctx.pinnedSet.has(task.id)}
+      {...ctx.rowProps}
+      // Only root tasks are pinnable — `floatPinnedToTop` reorders root tasks
+      // only, so a pin on a nested row would show an icon but never move it.
+      onTogglePin={isRoot ? ctx.rowProps.onTogglePin : undefined}
+    />
+  );
+  const nested =
+    !subsHidden && hasSubs ? (
+      <TaskTreeLevel parentTaskId={task.id} tasks={subs!} depth={depth + 1} ctx={ctx} />
+    ) : undefined;
+  return <SortableTaskNode taskId={task.id} depth={depth} handle={handle} nested={nested} />;
+}
+
+// One level of sibling tasks. `parentTaskId === null` is the group root (whose
+// reorder maps to onReorderGroup); deeper levels reorder via onReorderSubtasks
+// scoped to that parent's children.
+function TaskTreeLevel({
+  parentTaskId,
+  tasks,
+  depth,
+  ctx,
+}: {
+  parentTaskId: string | null;
+  tasks: TaskSwitcherItem[];
+  depth: number;
+  ctx: TaskTreeContext;
+}) {
+  let onReorder: ((orderedTaskIds: string[]) => void) | undefined;
+  if (parentTaskId === null) {
+    onReorder = ctx.onReorderGroup;
+  } else if (ctx.onReorderSubtasks) {
+    const pid = parentTaskId;
+    onReorder = (ids: string[]) => ctx.onReorderSubtasks!(pid, ids);
+  }
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      data-testid="sortable-task-block"
-      data-task-id={taskId}
-      className={cn(isDragging && "z-50")}
-    >
-      <div
-        {...sortableAttributes}
-        {...listeners}
-        // Strip dnd-kit's default tabIndex={0}: only PointerSensor is wired,
-        // so keyboard tab stops here lead nowhere. If KeyboardSensor is
-        // added later, drop this override.
-        tabIndex={undefined}
-        data-testid="sortable-task-handle"
-        className="cursor-grab active:cursor-grabbing"
-      >
-        {parent}
-      </div>
-      {subTasks}
-    </div>
+    <SortableTaskLevel
+      tasks={tasks}
+      onReorder={onReorder}
+      renderNode={(task) => <TaskTreeNode key={task.id} task={task} depth={depth} ctx={ctx} />}
+    />
   );
 }
 
@@ -288,95 +315,6 @@ type GroupSectionProps = {
   deletingTaskId?: string | null;
 };
 
-function useGroupDnd(
-  groupTasks: TaskSwitcherItem[],
-  onReorderGroup?: (groupTaskIds: string[]) => void,
-) {
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
-  );
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      if (!onReorderGroup) return;
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-      const ids = groupTasks.map((t) => t.id);
-      const oldIndex = ids.indexOf(String(active.id));
-      const newIndex = ids.indexOf(String(over.id));
-      if (oldIndex < 0 || newIndex < 0) return;
-      onReorderGroup(arrayMove(ids, oldIndex, newIndex));
-    },
-    [groupTasks, onReorderGroup],
-  );
-  const sortableIds = useMemo(() => groupTasks.map((t) => t.id), [groupTasks]);
-  return { sensors, handleDragEnd, sortableIds };
-}
-
-function GroupTaskList({
-  group,
-  subTasksByParentId,
-  collapsedSubs,
-  onToggleSubtasks,
-  pinnedSet,
-  rowProps,
-  onReorderSubtasks,
-}: {
-  group: SidebarGroup;
-  subTasksByParentId: Map<string, TaskSwitcherItem[]>;
-  collapsedSubs: Set<string>;
-  onToggleSubtasks?: (parentTaskId: string) => void;
-  pinnedSet: Set<string>;
-  rowProps: Omit<TaskRowProps, "task" | "subtaskToggle" | "isPinned" | "isSubTask">;
-  onReorderSubtasks?: (parentTaskId: string, orderedSubtaskIds: string[]) => void;
-}) {
-  return (
-    <>
-      {group.tasks.map((task) => {
-        const subs = subTasksByParentId.get(task.id);
-        const hasSubs = !!subs?.length;
-        const subsHidden = hasSubs && !!onToggleSubtasks && collapsedSubs.has(task.id);
-        const toggleInfo: SubtaskToggleInfo | undefined =
-          hasSubs && onToggleSubtasks
-            ? {
-                subtaskCount: subs!.length,
-                subtasksCollapsed: subsHidden,
-                onToggleSubtasks: () => onToggleSubtasks(task.id),
-              }
-            : undefined;
-        return (
-          <SortableTaskBlock
-            key={task.id}
-            taskId={task.id}
-            parent={
-              <TaskRow
-                task={task}
-                subtaskToggle={toggleInfo}
-                isPinned={pinnedSet.has(task.id)}
-                {...rowProps}
-              />
-            }
-            subTasks={
-              !subsHidden && subs && subs.length > 0 ? (
-                <SortableSubtaskList
-                  parentTaskId={task.id}
-                  subtasks={subs}
-                  onReorderSubtasks={onReorderSubtasks}
-                  // Subtasks aren't pinnable — pinning would show an icon but
-                  // `floatPinnedToTop` only operates on root tasks, so the row
-                  // wouldn't move. Drop the prop to avoid the no-op menu item.
-                  renderRow={(sub) => (
-                    <TaskRow task={sub} isSubTask {...rowProps} onTogglePin={undefined} />
-                  )}
-                />
-              ) : undefined
-            }
-          />
-        );
-      })}
-    </>
-  );
-}
-
 function GroupSection({
   group,
   subTasksByParentId,
@@ -400,25 +338,28 @@ function GroupSection({
   pinnedSet,
   deletingTaskId,
 }: GroupSectionProps) {
-  const totalCount = group.tasks.reduce(
-    (sum, t) => sum + 1 + (subTasksByParentId.get(t.id)?.length ?? 0),
-    0,
-  );
-  const collapsedSubs = new Set(collapsedSubtaskParentIds ?? []);
-  const rowProps = {
-    workflows,
-    stepsByWorkflowId,
-    activeTaskId,
-    selectedTaskId,
-    onSelectTask,
-    onRenameTask,
-    onArchiveTask,
-    onDeleteTask,
-    onMoveToStep,
-    onTogglePin,
-    deletingTaskId,
+  const totalCount = countGroupTasks(group.tasks, subTasksByParentId);
+  const ctx: TaskTreeContext = {
+    subTasksByParentId,
+    collapsedSubs: new Set(collapsedSubtaskParentIds ?? []),
+    onToggleSubtasks,
+    pinnedSet,
+    rowProps: {
+      workflows,
+      stepsByWorkflowId,
+      activeTaskId,
+      selectedTaskId,
+      onSelectTask,
+      onRenameTask,
+      onArchiveTask,
+      onDeleteTask,
+      onMoveToStep,
+      onTogglePin,
+      deletingTaskId,
+    },
+    onReorderGroup,
+    onReorderSubtasks,
   };
-  const { sensors, handleDragEnd, sortableIds } = useGroupDnd(group.tasks, onReorderGroup);
 
   return (
     <div>
@@ -432,19 +373,7 @@ function GroupSection({
         />
       )}
       {!isCollapsed && (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-            <GroupTaskList
-              group={group}
-              subTasksByParentId={subTasksByParentId}
-              collapsedSubs={collapsedSubs}
-              onToggleSubtasks={onToggleSubtasks}
-              pinnedSet={pinnedSet}
-              rowProps={rowProps}
-              onReorderSubtasks={onReorderSubtasks}
-            />
-          </SortableContext>
-        </DndContext>
+        <TaskTreeLevel parentTaskId={null} tasks={group.tasks} depth={0} ctx={ctx} />
       )}
     </div>
   );

--- a/apps/web/components/task/task-switcher.tsx
+++ b/apps/web/components/task/task-switcher.tsx
@@ -224,10 +224,12 @@ function TaskTreeNode({
   task,
   depth,
   ctx,
+  isDraggable,
 }: {
   task: TaskSwitcherItem;
   depth: number;
   ctx: TaskTreeContext;
+  isDraggable: boolean;
 }) {
   const subs = ctx.subTasksByParentId.get(task.id);
   const hasSubs = !!subs?.length;
@@ -235,7 +237,7 @@ function TaskTreeNode({
   const toggleInfo: SubtaskToggleInfo | undefined =
     hasSubs && ctx.onToggleSubtasks
       ? {
-          subtaskCount: subs!.length,
+          subtaskCount: countGroupTasks(subs!, ctx.subTasksByParentId),
           subtasksCollapsed: subsHidden,
           onToggleSubtasks: () => ctx.onToggleSubtasks!(task.id),
         }
@@ -258,7 +260,15 @@ function TaskTreeNode({
     !subsHidden && hasSubs ? (
       <TaskTreeLevel parentTaskId={task.id} tasks={subs!} depth={depth + 1} ctx={ctx} />
     ) : undefined;
-  return <SortableTaskNode taskId={task.id} depth={depth} handle={handle} nested={nested} />;
+  return (
+    <SortableTaskNode
+      taskId={task.id}
+      depth={depth}
+      handle={handle}
+      nested={nested}
+      isDraggable={isDraggable}
+    />
+  );
 }
 
 // One level of sibling tasks. `parentTaskId === null` is the group root (whose
@@ -286,7 +296,15 @@ function TaskTreeLevel({
     <SortableTaskLevel
       tasks={tasks}
       onReorder={onReorder}
-      renderNode={(task) => <TaskTreeNode key={task.id} task={task} depth={depth} ctx={ctx} />}
+      renderNode={(task, levelDraggable) => (
+        <TaskTreeNode
+          key={task.id}
+          task={task}
+          depth={depth}
+          ctx={ctx}
+          isDraggable={levelDraggable}
+        />
+      )}
     />
   );
 }

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -216,6 +216,31 @@ export class ApiClient {
     });
   }
 
+  /**
+   * Seed a task row directly via the test harness, bypassing the service-layer
+   * subtask-depth guard. Use this (not `createTask`) to build nested chains
+   * deeper than one level — `createTask` rejects depth > 1 for kanban tasks.
+   */
+  async seedTask(
+    workspaceId: string,
+    title: string,
+    opts?: {
+      workflow_id?: string;
+      workflow_step_id?: string;
+      parent_id?: string;
+      state?: string;
+    },
+  ): Promise<{ task_id: string }> {
+    return this.request("POST", "/api/v1/_test/tasks", {
+      workspace_id: workspaceId,
+      title,
+      workflow_id: opts?.workflow_id ?? "",
+      workflow_step_id: opts?.workflow_step_id ?? "",
+      parent_id: opts?.parent_id ?? "",
+      state: opts?.state ?? "",
+    });
+  }
+
   async reorderWorkflows(
     workspaceId: string,
     workflowIds: string[],

--- a/apps/web/e2e/tests/task/mobile-sidebar-subtasks.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-subtasks.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Mobile parity for the sidebar subtask tree.
+ *
+ * The mobile task-switcher sheet renders through the same `TaskSwitcher` /
+ * `applyView` path as the desktop sidebar, so nested subtasks must show up in
+ * the sheet on a mobile viewport. This guards the shared recursive renderer
+ * against a mobile-only regression.
+ *
+ * Lives in `mobile-*.spec.ts` so the `mobile-chrome` Playwright project applies
+ * the mobile device automatically.
+ */
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+test.describe("Mobile sidebar — nested subtasks", () => {
+  test("multi-level subtasks render nested in the mobile task switcher sheet", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // Build a 3-level chain via the harness (createTask caps kanban depth at 1).
+    const stepOpts = {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    };
+    const root = await apiClient.seedTask(seedData.workspaceId, "Mobile Root Task", stepOpts);
+    const child = await apiClient.seedTask(seedData.workspaceId, "Mobile Child Task", {
+      ...stepOpts,
+      parent_id: root.task_id,
+    });
+    await apiClient.seedTask(seedData.workspaceId, "Mobile Grandchild Task", {
+      ...stepOpts,
+      parent_id: child.task_id,
+    });
+
+    await testPage.goto(`/t/${root.task_id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    // Open the task switcher sheet from the mobile session top bar. Scope all
+    // assertions to the sheet — task titles also appear in the session header.
+    await testPage.getByTestId("mobile-session-menu").click();
+    const sheet = testPage.getByRole("dialog");
+
+    // All three levels are listed in the sheet.
+    await expect(sheet.getByText("Mobile Root Task")).toBeVisible({ timeout: 10_000 });
+    await expect(sheet.getByText("Mobile Child Task")).toBeVisible({ timeout: 10_000 });
+    await expect(sheet.getByText("Mobile Grandchild Task")).toBeVisible({ timeout: 10_000 });
+
+    // The grandchild (depth 2) is DOM-nested inside the root block — mobile
+    // renders the full tree, not a flat list.
+    const grandchildBlock = sheet.locator(
+      `[data-testid='sortable-task-block'][data-task-id='${root.task_id}'] [data-testid='sortable-task-block'][data-depth='2']`,
+    );
+    await expect(grandchildBlock).toHaveCount(1);
+    await expect(grandchildBlock.getByText("Mobile Grandchild Task")).toBeVisible();
+  });
+});

--- a/apps/web/e2e/tests/task/sidebar-multilevel-subtasks.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-multilevel-subtasks.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * E2E for multi-level (depth >= 2) subtask nesting in the left sidebar.
+ *
+ * The production CreateTask path caps kanban nesting at depth 1, so this builds
+ * the root → child → grandchild chain through the test harness (`seedTask`),
+ * which writes directly via the repository and bypasses that guard — the same
+ * way real depth-2 trees arise (office tasks / pre-guard data).
+ *
+ * Covers:
+ *   - All three levels render, each tagged with its tree depth (0 / 1 / 2)
+ *   - A grandchild nests inside its child, which nests inside the root
+ *   - Collapsing a MID-level node hides its whole subtree (the grandchild),
+ *     while the root and the collapsed node stay visible
+ */
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+test.describe("Sidebar subtasks — multi-level nesting", () => {
+  test("renders and collapses a three-level tree", async ({ testPage, apiClient, seedData }) => {
+    const stepOpts = {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    };
+    const root = await apiClient.seedTask(seedData.workspaceId, "Tree Root Task", stepOpts);
+    const child = await apiClient.seedTask(seedData.workspaceId, "Tree Child Task", {
+      ...stepOpts,
+      parent_id: root.task_id,
+    });
+    const grandchild = await apiClient.seedTask(seedData.workspaceId, "Tree Grandchild Task", {
+      ...stepOpts,
+      parent_id: child.task_id,
+    });
+
+    await testPage.goto(`/t/${root.task_id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.sidebar).toBeVisible({ timeout: 10_000 });
+
+    // All three levels are visible (expanded by default).
+    await expect(session.sidebar.getByText("Tree Root Task")).toBeVisible({ timeout: 10_000 });
+    await expect(session.sidebar.getByText("Tree Child Task")).toBeVisible({ timeout: 10_000 });
+    await expect(session.sidebar.getByText("Tree Grandchild Task")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Each row carries its depth, and deeper blocks are DOM-nested in shallower
+    // ones — proving the tree renders past the old two-level cap.
+    const block = (id: string) =>
+      session.sidebar.locator(`[data-testid='sortable-task-block'][data-task-id='${id}']`);
+    await expect(block(root.task_id)).toHaveAttribute("data-depth", "0");
+    await expect(block(child.task_id)).toHaveAttribute("data-depth", "1");
+    await expect(block(grandchild.task_id)).toHaveAttribute("data-depth", "2");
+    // grandchild block lives inside the child block, which lives inside the root.
+    await expect(block(root.task_id).locator(`[data-task-id='${grandchild.task_id}']`)).toHaveCount(
+      1,
+    );
+
+    // Collapse the MID-level child: its subtree (the grandchild) disappears,
+    // while the root and the child itself stay visible.
+    const childChevron = session.sidebar.locator(
+      `[data-testid='sidebar-subtask-toggle'][data-task-id='${child.task_id}']`,
+    );
+    await expect(childChevron).toHaveAttribute("aria-expanded", "true");
+    await childChevron.click();
+
+    await expect(session.sidebar.getByText("Tree Grandchild Task")).not.toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(session.sidebar.getByText("Tree Root Task")).toBeVisible();
+    await expect(session.sidebar.getByText("Tree Child Task")).toBeVisible();
+    await expect(childChevron).toHaveAttribute("aria-expanded", "false");
+
+    // Expanding restores the grandchild.
+    await childChevron.click();
+    await expect(session.sidebar.getByText("Tree Grandchild Task")).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/apps/web/lib/sidebar/apply-view-count.test.ts
+++ b/apps/web/lib/sidebar/apply-view-count.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import type { TaskSwitcherItem } from "@/components/task/task-switcher";
+import { countGroupTasks } from "./apply-view";
+
+function task(id: string, parentTaskId?: string): TaskSwitcherItem {
+  return { id, title: id, parentTaskId };
+}
+
+describe("countGroupTasks — recursive subtree count", () => {
+  it("counts a root with no children as 1", () => {
+    expect(countGroupTasks([task("r1")], new Map())).toBe(1);
+  });
+
+  it("counts root + direct children (depth 1)", () => {
+    const subMap = new Map([["r1", [task("c1", "r1"), task("c2", "r1")]]]);
+    expect(countGroupTasks([task("r1")], subMap)).toBe(3);
+  });
+
+  it("counts nested grandchildren (depth 2+)", () => {
+    const subMap = new Map([
+      ["r1", [task("c1", "r1")]],
+      ["c1", [task("g1", "c1"), task("g2", "c1")]],
+      ["g1", [task("gg1", "g1")]],
+    ]);
+    // r1 + c1 + g1 + g2 + gg1 = 5
+    expect(countGroupTasks([task("r1")], subMap)).toBe(5);
+  });
+
+  it("sums across multiple roots", () => {
+    const subMap = new Map([
+      ["r1", [task("c1", "r1")]],
+      ["c1", [task("g1", "c1")]],
+    ]);
+    // (r1 + c1 + g1) + (r2) = 4
+    expect(countGroupTasks([task("r1"), task("r2")], subMap)).toBe(4);
+  });
+});

--- a/apps/web/lib/sidebar/apply-view-count.test.ts
+++ b/apps/web/lib/sidebar/apply-view-count.test.ts
@@ -34,4 +34,12 @@ describe("countGroupTasks — recursive subtree count", () => {
     // (r1 + c1 + g1) + (r2) = 4
     expect(countGroupTasks([task("r1"), task("r2")], subMap)).toBe(4);
   });
+
+  it("terminates on cyclic parent links instead of looping forever", () => {
+    const subMap = new Map([
+      ["a", [task("b", "a")]],
+      ["b", [task("a", "b")]],
+    ]);
+    expect(countGroupTasks([task("a")], subMap)).toBe(2);
+  });
 });

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -435,6 +435,26 @@ function applySubtaskOrder(
   return withSortIndex.map((x) => x.t);
 }
 
+/**
+ * Count a group's tasks including every nested descendant. The sidebar renders
+ * an arbitrarily deep tree, so the header count walks `subTasksByParentId`
+ * recursively rather than counting only root + direct children.
+ */
+export function countGroupTasks(
+  rootTasks: TaskSwitcherItem[],
+  subTasksByParentId: Map<string, TaskSwitcherItem[]>,
+): number {
+  let total = 0;
+  const stack = [...rootTasks];
+  while (stack.length > 0) {
+    const task = stack.pop()!;
+    total += 1;
+    const children = subTasksByParentId.get(task.id);
+    if (children) stack.push(...children);
+  }
+  return total;
+}
+
 export function applyView(
   tasks: TaskSwitcherItem[],
   view: SidebarView,

--- a/apps/web/lib/sidebar/apply-view.ts
+++ b/apps/web/lib/sidebar/apply-view.ts
@@ -445,9 +445,12 @@ export function countGroupTasks(
   subTasksByParentId: Map<string, TaskSwitcherItem[]>,
 ): number {
   let total = 0;
+  const visited = new Set<string>();
   const stack = [...rootTasks];
   while (stack.length > 0) {
     const task = stack.pop()!;
+    if (visited.has(task.id)) continue;
+    visited.add(task.id);
     total += 1;
     const children = subTasksByParentId.get(task.id);
     if (children) stack.push(...children);

--- a/apps/web/lib/sidebar/row-indent.test.ts
+++ b/apps/web/lib/sidebar/row-indent.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { computeRowIndent, resolveRowDepth } from "./row-indent";
+
+describe("resolveRowDepth", () => {
+  it("uses an explicit depth when provided", () => {
+    expect(resolveRowDepth(3, false)).toBe(3);
+    expect(resolveRowDepth(0, true)).toBe(0);
+  });
+
+  it("falls back to isSubTask (legacy single-level) when depth is absent", () => {
+    expect(resolveRowDepth(undefined, true)).toBe(1);
+    expect(resolveRowDepth(undefined, false)).toBe(0);
+    expect(resolveRowDepth(undefined, undefined)).toBe(0);
+  });
+});
+
+describe("computeRowIndent", () => {
+  it("root rows (depth 0) get base padding and no nesting", () => {
+    const indent = computeRowIndent(0);
+    expect(indent.depth).toBe(0);
+    expect(indent.paddingLeftPx).toBe(12);
+  });
+
+  it("depth 1 matches the legacy subtask indent (pl-8 / connector at 14px)", () => {
+    const indent = computeRowIndent(1);
+    expect(indent.depth).toBe(1);
+    expect(indent.paddingLeftPx).toBe(32);
+    expect(indent.connectorLeftPx).toBe(14);
+  });
+
+  it("each deeper level adds a fixed step", () => {
+    const d2 = computeRowIndent(2);
+    expect(d2.paddingLeftPx).toBe(52);
+    expect(d2.connectorLeftPx).toBe(34);
+  });
+
+  it("caps visual indent so deep trees don't squeeze the sidebar", () => {
+    const capped = computeRowIndent(6);
+    const deeper = computeRowIndent(20);
+    expect(deeper.paddingLeftPx).toBe(capped.paddingLeftPx);
+    expect(deeper.connectorLeftPx).toBe(capped.connectorLeftPx);
+    // Still flagged as nested so the connector renders.
+    expect(deeper.depth).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/lib/sidebar/row-indent.ts
+++ b/apps/web/lib/sidebar/row-indent.ts
@@ -1,0 +1,40 @@
+/** Base left padding (px) for a root sidebar row — matches the `pl-3` class. */
+const BASE_PADDING_PX = 12;
+/** Extra left padding (px) added per nesting level. Depth 1 = 32px ≈ `pl-8`. */
+const INDENT_STEP_PX = 20;
+/**
+ * Maximum visual nesting depth. Deeper rows keep nesting logically but stop
+ * indenting so a tall tree can't push titles off a narrow sidebar.
+ */
+const MAX_VISUAL_DEPTH = 6;
+
+export type RowIndent = {
+  /** Clamped depth used for layout. >0 means render the nesting connector. */
+  depth: number;
+  paddingLeftPx: number;
+  /** Left offset (px) for the `↳` connector glyph. Only used when depth > 0. */
+  connectorLeftPx: number;
+};
+
+/**
+ * Resolve a row's tree depth from the explicit `depth` prop, falling back to
+ * the legacy boolean `isSubTask` (depth 1) for callers that predate nesting.
+ */
+export function resolveRowDepth(depth: number | undefined, isSubTask: boolean | undefined): number {
+  if (typeof depth === "number") return depth;
+  return isSubTask ? 1 : 0;
+}
+
+/**
+ * Resolve the indentation for a sidebar task row at a given tree depth.
+ * Depth 1 reproduces the legacy single-level subtask look exactly; deeper
+ * levels add a fixed step, capped at {@link MAX_VISUAL_DEPTH}.
+ */
+export function computeRowIndent(depth: number): RowIndent {
+  const clamped = Math.min(Math.max(depth, 0), MAX_VISUAL_DEPTH);
+  return {
+    depth: clamped,
+    paddingLeftPx: BASE_PADDING_PX + clamped * INDENT_STEP_PX,
+    connectorLeftPx: BASE_PADDING_PX + 2 + (clamped - 1) * INDENT_STEP_PX,
+  };
+}


### PR DESCRIPTION
Grandchild tasks existed in the store but never appeared in the sidebar because the renderer only walked two levels. This replaces the flat root/subtask split with a recursive tree so any depth is visible, with collapse and sibling-scoped drag-and-drop at every level.

## Important Changes

- Recursive `TaskTreeNode` / `TaskTreeLevel` renderer replaces the hardcoded 2-level sidebar walk
- Depth-aware row indent (`row-indent.ts`) capped at visual depth 6 to protect narrow sidebars
- Mobile task switcher now maps `parentTaskId` so subtasks nest on mobile for the first time
- Gated `POST /api/v1/_test/tasks` harness route seeds depth ≥ 2 chains for e2e (bypasses service depth guard)

## Validation

- `make -C apps/backend fmt test lint`
- `pnpm --filter @kandev/web typecheck lint test run`
- E2E: `sidebar-multilevel-subtasks.spec.ts` (depth-3 desktop + mid-level collapse), `mobile-sidebar-subtasks.spec.ts` (depth-2 mobile), existing depth-1 sidebar spec

## Possible Improvements

Low risk — production CreateTask still enforces depth ≤ 1; this only affects display of existing deep trees and e2e-seeded data.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)