### PR TITLE
fix(web): remove agent id from subagent metadata chips

### DIFF
--- a/apps/web/components/task/chat/messages/subagent-meta-row.tsx
+++ b/apps/web/components/task/chat/messages/subagent-meta-row.tsx
@@ -3,7 +3,7 @@ import type { SubagentTaskPayload } from "@/components/task/chat/types";
 import { subagentMetaChips } from "@/components/task/chat/messages/subagent-meta";
 
 /**
- * Compact row of metadata chips (duration, tokens, tools, model, ids) rendered
+ * Compact row of metadata chips (duration, tokens, tools, model, session) rendered
  * under a completed subagent's header. Renders nothing when no metric fields
  * are present, so the card degrades gracefully across agents.
  */

--- a/apps/web/components/task/chat/messages/subagent-meta.test.ts
+++ b/apps/web/components/task/chat/messages/subagent-meta.test.ts
@@ -25,7 +25,6 @@ describe("subagentMetaChips", () => {
       { label: "duration", value: "2.2s" },
       { label: "tokens", value: "9,987 tokens" },
       { label: "tools", value: "0 tools" },
-      { label: "agent", value: "agent_012345…" },
     ]);
   });
 
@@ -55,7 +54,9 @@ describe("subagentMetaChips", () => {
     expect(subagentMetaChips(payload)).toEqual([{ label: "tools", value: "0 tools" }]);
   });
 
-  it("does not truncate short ids", () => {
-    expect(subagentMetaChips({ agent_id: "short" })).toEqual([{ label: "agent", value: "short" }]);
+  it("does not truncate short session ids", () => {
+    expect(subagentMetaChips({ child_session_id: "short" })).toEqual([
+      { label: "session", value: "short" },
+    ]);
   });
 });

--- a/apps/web/components/task/chat/messages/subagent-meta.ts
+++ b/apps/web/components/task/chat/messages/subagent-meta.ts
@@ -27,8 +27,8 @@ function formatTools(count: number): string {
 
 /**
  * Turns a SubagentTaskPayload into an ordered list of display chips. Different
- * agents populate different subsets (Claude: agent_id/tokens/duration/
- * tool_use_count; OpenCode: model/child_session_id; Cursor: duration_ms only),
+ * agents populate different subsets (Claude: tokens/duration/tool_use_count;
+ * OpenCode: model/child_session_id; Cursor: duration_ms only),
  * so each field is only included when meaningfully present. Duration and tokens
  * are skipped when zero; tool_use_count is shown even at zero since "0 tools"
  * is meaningful for a completed subagent.
@@ -49,9 +49,6 @@ export function subagentMetaChips(payload: SubagentTaskPayload | undefined): Sub
   }
   if (payload.model) {
     chips.push({ label: "model", value: payload.model });
-  }
-  if (payload.agent_id) {
-    chips.push({ label: "agent", value: truncateId(payload.agent_id) });
   }
   if (payload.child_session_id) {
     chips.push({ label: "session", value: truncateId(payload.child_session_id) });

--- a/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-subagent.spec.ts
@@ -47,7 +47,6 @@ test.describe("Mobile subagent card", () => {
     await expect(card.locator('[data-testid="subagent-meta-duration"]')).toContainText("2.2s");
     await expect(card.locator('[data-testid="subagent-meta-tokens"]')).toContainText("9,987");
     await expect(card.locator('[data-testid="subagent-meta-tools"]')).toContainText("3 tools");
-    await expect(card.locator('[data-testid="subagent-meta-agent"]')).toContainText("agent_e2e");
 
     // The subagent's internal tool call nests under its card (parentToolUseId).
     await expect(card.locator('[data-testid="subagent-child-count"]')).toContainText("1 tool call");

--- a/apps/web/e2e/tests/chat/subagent.spec.ts
+++ b/apps/web/e2e/tests/chat/subagent.spec.ts
@@ -55,8 +55,6 @@ test.describe("Subagent card", () => {
     await expect(card.locator('[data-testid="subagent-meta-duration"]')).toContainText("2.2s");
     await expect(card.locator('[data-testid="subagent-meta-tokens"]')).toContainText("9,987");
     await expect(card.locator('[data-testid="subagent-meta-tools"]')).toContainText("3 tools");
-    // The agent id is truncated with an ellipsis, so assert on a substring.
-    await expect(card.locator('[data-testid="subagent-meta-agent"]')).toContainText("agent_e2e");
 
     // The subagent's internal tool call is nested UNDER its card (the mock emits
     // a child carrying `_meta.claudeCode.parentToolUseId`), not as a flat sibling.


### PR DESCRIPTION
The subagent card metadata row showed a truncated Claude `agentId` that looked like a random hash and gave users no actionable context. This drops that chip so Claude subagents surface only duration, tokens, and tool count.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web test` (includes `subagent-meta.test.ts`)
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)