### PR TITLE
fix(web): collapse large PR Changes and expand Commits by default

### DIFF
--- a/apps/web/components/task/changes-panel-body.tsx
+++ b/apps/web/components/task/changes-panel-body.tsx
@@ -179,12 +179,14 @@ function ChangesPanelTimeline(props: TimelineProps) {
   const hasSomethingAfterStaged = (props.hasPRFiles && hasLocalChanges) || showCommitsList;
   // Auto-expand the first (topmost) visible section so the panel never opens
   // looking empty (e.g. review mode: PR + Commits both collapsed). Unstaged /
-  // Staged keep their always-expanded default; only PR and Commits are gated.
+  // Staged keep their always-expanded default; PR and Commits are gated. Large
+  // PR diffs (>5 files) skip PR Changes and expand Commits instead.
   const firstSection = firstVisibleSection({
     hasPRFiles: props.hasPRFiles,
     hasUnstaged: props.hasUnstaged,
     hasStaged: props.hasStaged,
     showCommitsList,
+    prFileCount: props.prFiles.length,
   });
 
   return (

--- a/apps/web/components/task/changes-panel-helpers.test.ts
+++ b/apps/web/components/task/changes-panel-helpers.test.ts
@@ -94,7 +94,7 @@ describe("buildPrByRepoMap", () => {
   });
 });
 
-import { firstVisibleSection } from "./changes-panel-helpers";
+import { firstVisibleSection, PR_CHANGES_AUTO_EXPAND_MAX_FILES } from "./changes-panel-helpers";
 
 describe("firstVisibleSection", () => {
   const flags = (over: Partial<Parameters<typeof firstVisibleSection>[0]>) => ({
@@ -109,8 +109,39 @@ describe("firstVisibleSection", () => {
     expect(firstVisibleSection(flags({}))).toBeNull();
   });
 
-  it("review mode: PR is first when there are no local changes", () => {
-    expect(firstVisibleSection(flags({ hasPRFiles: true, showCommitsList: true }))).toBe("pr");
+  it("review mode: PR is first when there are no local changes and few files", () => {
+    expect(
+      firstVisibleSection(
+        flags({
+          hasPRFiles: true,
+          showCommitsList: true,
+          prFileCount: PR_CHANGES_AUTO_EXPAND_MAX_FILES,
+        }),
+      ),
+    ).toBe("pr");
+  });
+
+  it("review mode: commits expand instead of PR when diff exceeds file threshold", () => {
+    expect(
+      firstVisibleSection(
+        flags({
+          hasPRFiles: true,
+          showCommitsList: true,
+          prFileCount: PR_CHANGES_AUTO_EXPAND_MAX_FILES + 1,
+        }),
+      ),
+    ).toBe("commits");
+  });
+
+  it("review mode: large PR with no commits list auto-expands nothing", () => {
+    expect(
+      firstVisibleSection(
+        flags({
+          hasPRFiles: true,
+          prFileCount: PR_CHANGES_AUTO_EXPAND_MAX_FILES + 1,
+        }),
+      ),
+    ).toBeNull();
   });
 
   it("commits is first when it is the only section", () => {

--- a/apps/web/components/task/changes-panel-helpers.ts
+++ b/apps/web/components/task/changes-panel-helpers.ts
@@ -141,6 +141,9 @@ export function filterUnpushedCommits<T extends { commit_sha: string }>(
 /** Which timeline section, if any, renders first (topmost) in the Changes panel. */
 type FirstVisibleSection = "pr" | "unstaged" | "staged" | "commits" | null;
 
+/** PR Changes auto-expands only when the diff is small enough to scan inline. */
+export const PR_CHANGES_AUTO_EXPAND_MAX_FILES = 5;
+
 /**
  * Computes the first (topmost) visible section so the panel can auto-expand it,
  * mirroring the render precedence in `ChangesPanelTimeline`:
@@ -148,16 +151,22 @@ type FirstVisibleSection = "pr" | "unstaged" | "staged" | "commits" | null;
  *
  * The "review mode" PR section only sits at the top when there are no local
  * working-tree changes; with local changes the PR section moves below Staged and
- * is therefore never first. Returns null when nothing is shown.
+ * is therefore never first. Large PR diffs (>5 files) skip auto-expanding PR
+ * Changes and expand Commits instead. Returns null when nothing is shown.
  */
 export function firstVisibleSection(flags: {
   hasPRFiles: boolean;
   hasUnstaged: boolean;
   hasStaged: boolean;
   showCommitsList: boolean;
+  prFileCount?: number;
 }): FirstVisibleSection {
-  const { hasPRFiles, hasUnstaged, hasStaged, showCommitsList } = flags;
-  if (hasPRFiles && !hasUnstaged && !hasStaged) return "pr";
+  const { hasPRFiles, hasUnstaged, hasStaged, showCommitsList, prFileCount = 0 } = flags;
+  if (hasPRFiles && !hasUnstaged && !hasStaged) {
+    if (prFileCount <= PR_CHANGES_AUTO_EXPAND_MAX_FILES) return "pr";
+    if (showCommitsList) return "commits";
+    return null;
+  }
   if (hasUnstaged) return "unstaged";
   if (hasStaged) return "staged";
   if (showCommitsList) return "commits";

--- a/apps/web/e2e/tests/git/changes-panel-section-order.spec.ts
+++ b/apps/web/e2e/tests/git/changes-panel-section-order.spec.ts
@@ -318,9 +318,8 @@ test.describe("Changes panel section ordering", () => {
     // PR files should appear above commits
     await expectAbove(prFiles, commits);
 
-    // Review mode (PR, no local changes): PR Changes is the first visible
-    // section, so it is expanded by default — the panel never opens looking
-    // empty. Commits, being second, stays collapsed.
+    // Review mode (PR, no local changes): with ≤5 PR files, PR Changes is
+    // expanded by default; Commits stays collapsed.
     await expect(testPage.getByTestId("pr-changes-section-collapse-toggle")).toHaveAttribute(
       "aria-expanded",
       "true",
@@ -333,6 +332,106 @@ test.describe("Changes panel section ordering", () => {
     // No unstaged or staged sections
     await expect(testPage.getByTestId("unstaged-files-section")).not.toBeVisible();
     await expect(testPage.getByTestId("staged-files-section")).not.toBeVisible();
+  });
+
+  /**
+   * Large PR diffs (>5 files) skip auto-expanding PR Changes and expand
+   * Commits instead so the panel doesn't open buried in a long file list.
+   */
+  test("large PR diff expands commits instead of PR Changes", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    const { workflow, inboxStep, workingStep, doneStep } = await seedWorkflow(
+      apiClient,
+      seedData.workspaceId,
+    );
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 301,
+        title: "Large PR",
+        state: "open",
+        head_branch: "feat/large",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: "testorg",
+        repo_name: "testrepo",
+        additions: 100,
+        deletions: 10,
+      },
+    ]);
+    await apiClient.mockGitHubAddPRFiles(
+      "testorg",
+      "testrepo",
+      301,
+      Array.from({ length: 6 }, (_, i) => ({
+        filename: `file-${i}.ts`,
+        status: "modified" as const,
+        additions: 10,
+        deletions: 1,
+      })),
+    );
+    await apiClient.mockGitHubAddPRCommits("testorg", "testrepo", 301, [
+      {
+        sha: "eee1111222233334444555566667777aaaabbbb",
+        message: "large change",
+        author_login: "test-user",
+        author_date: "2026-03-01T12:00:00Z",
+      },
+    ]);
+
+    const profile = await createStandardProfile(apiClient, "Large PR Profile");
+    const task = await apiClient.createTask(seedData.workspaceId, "Large PR Task", {
+      workflow_id: workflow.id,
+      workflow_step_id: inboxStep.id,
+      agent_profile_id: profile.id,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await apiClient.moveTask(task.id, workflow.id, workingStep.id);
+    await expect(kanban.taskCardInColumn("Large PR Task", doneStep.id)).toBeVisible({
+      timeout: 45_000,
+    });
+
+    await apiClient.mockGitHubAssociateTaskPR({
+      task_id: task.id,
+      owner: "testorg",
+      repo: "testrepo",
+      pr_number: 301,
+      pr_url: "https://github.com/testorg/testrepo/pull/301",
+      pr_title: "Large PR",
+      head_branch: "feat/large",
+      base_branch: "main",
+      author_login: "test-user",
+      additions: 100,
+      deletions: 10,
+    });
+
+    await kanban.taskCardInColumn("Large PR Task", doneStep.id).click();
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.clickTab("Changes");
+
+    await expect(testPage.getByTestId("pr-files-section")).toBeVisible({ timeout: 15_000 });
+    await expect(testPage.getByTestId("commits-section")).toBeVisible({ timeout: 15_000 });
+
+    await expect(testPage.getByTestId("pr-changes-section-collapse-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    await expect(testPage.getByTestId("commits-section-collapse-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
   });
 
   /**


### PR DESCRIPTION
Large PR diffs were auto-expanding the PR Changes section on panel open, burying the user in a long file list. The panel now only expands PR Changes when there are five or fewer changed files; otherwise Commits opens instead.

## Validation

- `pnpm --filter @kandev/web exec vitest run components/task/changes-panel-helpers.test.ts`
- Full verify pipeline: format, lint, typecheck, web unit tests, backend test/lint

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)