### PR TITLE
fix(web): move CI checks link beside popover title

### DIFF
--- a/apps/web/components/github/pr-ci-popover.tsx
+++ b/apps/web/components/github/pr-ci-popover.tsx
@@ -83,19 +83,8 @@ function PRCIPopoverHeader({ pr }: { pr: TaskPR }) {
       data-testid="pr-popover-header"
       className="flex items-center justify-between gap-2 border-b border-border/50 pb-2"
     >
-      <span className="text-sm font-medium">CI status</span>
       <div className="flex items-center gap-1.5">
-        <a
-          data-testid="pr-popover-pr-link"
-          href={pr.pr_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="cursor-pointer text-muted-foreground hover:text-foreground"
-          aria-label="View pull request on GitHub"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <IconGitPullRequest className="h-3.5 w-3.5" />
-        </a>
+        <span className="text-sm font-medium">CI status</span>
         <a
           data-testid="pr-popover-external-link"
           href={checksUrl}
@@ -108,6 +97,17 @@ function PRCIPopoverHeader({ pr }: { pr: TaskPR }) {
           <IconExternalLink className="h-3.5 w-3.5" />
         </a>
       </div>
+      <a
+        data-testid="pr-popover-pr-link"
+        href={pr.pr_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="cursor-pointer text-muted-foreground hover:text-foreground"
+        aria-label="View pull request on GitHub"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <IconGitPullRequest className="h-3.5 w-3.5" />
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
The CI status popover grouped the checks link with the PR link on the right, which made it harder to find the shortcut to GitHub checks. The checks link now sits immediately after the "CI status" label, with the PR link alone on the right.

## Validation

- `make fmt`
- `make typecheck test lint`
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)