### PR TITLE
fix(orchestrator): reconcile task state when user cancels turn

### DIFF
--- a/apps/backend/cmd/kandev/adapters.go
+++ b/apps/backend/cmd/kandev/adapters.go
@@ -48,6 +48,14 @@ func (a *taskRepositoryAdapter) UpdateTaskState(ctx context.Context, taskID stri
 	return err
 }
 
+// UpdateTaskStateIfCurrentIn transitions task state via the service when the
+// current state is in allowed.
+func (a *taskRepositoryAdapter) UpdateTaskStateIfCurrentIn(
+	ctx context.Context, taskID string, state v1.TaskState, allowed []v1.TaskState,
+) (bool, error) {
+	return a.svc.UpdateTaskStateIfCurrentIn(ctx, taskID, state, allowed)
+}
+
 // lifecycleAdapter adapts the lifecycle manager as an AgentManagerClient
 type lifecycleAdapter struct {
 	mgr      *lifecycle.Manager

--- a/apps/backend/internal/agent/runtime/lifecycle/manager.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager.go
@@ -87,6 +87,7 @@ type Manager struct {
 	remoteStatusMu           sync.RWMutex
 	remoteStatusBySession    map[string]*RemoteStatus
 	stopCh                   chan struct{}
+	stopOnce                 sync.Once
 	wg                       sync.WaitGroup
 	// shuttingDown is flipped true when graceful shutdown begins (see
 	// StopAllAgents) so handlers running in detached goroutines can

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_boot_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_boot_test.go
@@ -64,7 +64,7 @@ func (m *MockBootMessageService) getLastUpdatedMessage() *models.Message {
 }
 
 func TestFinalizeBootMessage_Success(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	bootSvc := &MockBootMessageService{}
 	mgr.bootMessageService = bootSvc
 
@@ -102,7 +102,7 @@ func TestFinalizeBootMessage_Success(t *testing.T) {
 }
 
 func TestFinalizeBootMessage_Failed(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	bootSvc := &MockBootMessageService{}
 	mgr.bootMessageService = bootSvc
 
@@ -129,7 +129,7 @@ func TestFinalizeBootMessage_Failed(t *testing.T) {
 }
 
 func TestFinalizeBootMessage_NilMessage(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	bootSvc := &MockBootMessageService{}
 	mgr.bootMessageService = bootSvc
 
@@ -144,7 +144,7 @@ func TestFinalizeBootMessage_NilMessage(t *testing.T) {
 }
 
 func TestFinalizeBootMessage_NilService(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	// bootMessageService is nil by default
 
 	msg := &models.Message{
@@ -187,7 +187,7 @@ func TestBootMessage_IsResumingFlag(t *testing.T) {
 }
 
 func TestPollAgentStderr_StopsOnClose(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	bootSvc := &MockBootMessageService{}
 	mgr.bootMessageService = bootSvc
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_cancel_test.go
@@ -54,7 +54,7 @@ func TestManager_CancelAgent_EscalatesWhenAgentHangs(t *testing.T) {
 		t.Fatal("mock server did not see WS connection")
 	}
 
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	promptFinished := make(chan struct{})
 	exec := &AgentExecution{
@@ -155,7 +155,7 @@ func TestManager_CancelAgent_EscalationCleanupSurvivesCtxCancel(t *testing.T) {
 		t.Fatal("mock server did not see WS connection")
 	}
 
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	// promptFinished is deliberately never closed — simulates a SendPrompt that
 	// is blocked on something other than promptDoneCh (so escalation can't

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -184,7 +184,7 @@ func (m *restartMockAgentctlServer) getWSActions() []string {
 }
 
 func TestManager_RestartAgentProcess_Success(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mock := newRestartMockAgentctlServer(t, false, false)
 
 	client := createTestClient(t, mock.server.URL)
@@ -276,7 +276,7 @@ func TestManager_RestartAgentProcess_Success(t *testing.T) {
 }
 
 func TestManager_RestartAgentProcess_StopErrorIsNonFatal(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mock := newRestartMockAgentctlServer(t, true, false)
 
 	client := createTestClient(t, mock.server.URL)
@@ -304,7 +304,7 @@ func TestManager_RestartAgentProcess_StopErrorIsNonFatal(t *testing.T) {
 }
 
 func TestManager_RestartAgentProcess_SessionInitFailure(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mock := newRestartMockAgentctlServer(t, false, true)
 
 	client := createTestClient(t, mock.server.URL)
@@ -360,7 +360,7 @@ func TestManager_RestartAgentProcess_SessionInitFailure(t *testing.T) {
 // accept-edits) chosen by the user must be re-applied to the fresh ACP session
 // after restart instead of silently reverting to the agent's default.
 func TestManager_RestartAgentProcess_ReappliesSessionMode(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mock := newRestartMockAgentctlServer(t, false, false)
 
 	client := createTestClient(t, mock.server.URL)
@@ -400,7 +400,7 @@ func TestManager_RestartAgentProcess_ReappliesSessionMode(t *testing.T) {
 // the ACP fast-path (session reset without a process restart): the user's chosen
 // session permission mode must deterministically survive the reset.
 func TestManager_ResetAgentContext_ReappliesSessionMode(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mock := newRestartMockAgentctlServer(t, false, false)
 
 	client := createTestClient(t, mock.server.URL)
@@ -448,7 +448,7 @@ func TestManager_ResetAgentContext_ReappliesSessionMode(t *testing.T) {
 // mode event is async). The restart must restore the persisted (DB) mode, not the
 // stale cached one.
 func TestManager_RestartAgentProcess_PrefersPersistedModeOverStaleCache(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
 		infos: map[string]*WorkspaceInfo{
 			"session-1": {SessionID: "session-1", SessionMode: "acceptEdits"},
@@ -491,7 +491,7 @@ func TestManager_RestartAgentProcess_PrefersPersistedModeOverStaleCache(t *testi
 // The fix: passthrough sessions persist a model_override on the execution and
 // restart the PTY so the next launch uses the new --model.
 func TestManager_SetSessionModel_Passthrough_PersistsOverride(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	exec := &AgentExecution{
 		ID:                   "exec-pt",
 		SessionID:            "session-pt",
@@ -710,7 +710,7 @@ func TestEffectiveSessionMode(t *testing.T) {
 	exec := &AgentExecution{ID: "exec-1", TaskID: "task-1", SessionID: "session-1"}
 
 	t.Run("session mode overrides profile mode", func(t *testing.T) {
-		mgr := newTestManager()
+		mgr := newTestManager(t)
 		mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
 			infos: map[string]*WorkspaceInfo{"session-1": {SessionID: "session-1", SessionMode: "acceptEdits"}},
 		}
@@ -718,7 +718,7 @@ func TestEffectiveSessionMode(t *testing.T) {
 	})
 
 	t.Run("falls back to profile mode when no session mode set", func(t *testing.T) {
-		mgr := newTestManager()
+		mgr := newTestManager(t)
 		mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
 			infos: map[string]*WorkspaceInfo{"session-1": {SessionID: "session-1"}},
 		}
@@ -726,13 +726,13 @@ func TestEffectiveSessionMode(t *testing.T) {
 	})
 
 	t.Run("falls back to profile mode on provider error", func(t *testing.T) {
-		mgr := newTestManager()
+		mgr := newTestManager(t)
 		mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{err: fmt.Errorf("boom")}
 		require.Equal(t, "default", mgr.effectiveSessionMode(context.Background(), exec, "default"))
 	})
 
 	t.Run("falls back to profile mode when no provider wired", func(t *testing.T) {
-		mgr := newTestManager()
+		mgr := newTestManager(t)
 		require.Equal(t, "default", mgr.effectiveSessionMode(context.Background(), exec, "default"))
 	})
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_launch_test.go
@@ -42,7 +42,7 @@ func (a *resumeTestAgent) Runtime() *agents.RuntimeConfig {
 }
 
 func TestBuildAgentCommand_ResumeFlag(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	canRecoverTrue := true
 	canRecoverFalse := false
 
@@ -91,7 +91,7 @@ func (a *cliFlagTestAgent) BuildCommand(_ agents.CommandOptions) agents.Command 
 }
 
 func TestBuildAgentCommand_CLIFlagsAppended(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	ag := &cliFlagTestAgent{}
 
 	t.Run("enabled entries reach argv, disabled do not", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestBuildEnvForExecution_ResolvesSecretBackedProfileEnv(t *testing.T) {
 		t.Fatalf("seed secret: %v", err)
 	}
 
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.secretStore = store
 	profileInfo := &AgentProfileInfo{
 		EnvVars: []settingsmodels.ProfileEnvVar{{Key: "FROM_SECRET", SecretID: "sec-1"}},
@@ -161,7 +161,7 @@ func TestBuildEnvForExecution_ResolvesSecretBackedProfileEnv(t *testing.T) {
 }
 
 func TestSetExecutionEnv_DoesNotSnapshotProfileEnvVars(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.profileResolver = &mockPassthroughProfileResolver{
 		envVars: []settingsmodels.ProfileEnvVar{{Key: "PROFILE_ONLY", Value: "new-value"}},
 	}
@@ -299,7 +299,7 @@ func requirePrepareStep(t *testing.T, steps []PrepareStep, name string) {
 }
 
 func TestRunEnvironmentPreparer_CalledOnFreshLaunch(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	preparer := &trackingPreparer{}
 	mgr.preparerRegistry = NewPreparerRegistry(mgr.logger)
 	mgr.preparerRegistry.Register(models.ExecutorTypeLocal, preparer)
@@ -318,7 +318,7 @@ func TestRunEnvironmentPreparer_CalledOnFreshLaunch(t *testing.T) {
 }
 
 func TestRunEnvironmentPreparer_SkippedWithoutRepoPath(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	preparer := &trackingPreparer{}
 	mgr.preparerRegistry = NewPreparerRegistry(mgr.logger)
 	mgr.preparerRegistry.Register(models.ExecutorTypeLocal, preparer)
@@ -336,7 +336,7 @@ func TestRunEnvironmentPreparer_SkippedWithoutRepoPath(t *testing.T) {
 }
 
 func TestLaunchResolveWorkspacePath_EphemeralCreatesQuickChatDir(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.dataDir = t.TempDir()
 
 	req := &LaunchRequest{
@@ -351,7 +351,7 @@ func TestLaunchResolveWorkspacePath_EphemeralCreatesQuickChatDir(t *testing.T) {
 }
 
 func TestLaunchResolveWorkspacePath_NonEphemeralRepoLessGetsScratchDir(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.dataDir = t.TempDir()
 
 	req := &LaunchRequest{
@@ -369,7 +369,7 @@ func TestLaunchResolveWorkspacePath_NonEphemeralRepoLessGetsScratchDir(t *testin
 }
 
 func TestLaunchResolveWorkspacePath_NonEphemeralWithoutWorkspaceIDReturnsEmpty(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.dataDir = t.TempDir()
 
 	// Non-ephemeral repo-less task missing workspace_id should not get a path
@@ -385,7 +385,7 @@ func TestLaunchResolveWorkspacePath_NonEphemeralWithoutWorkspaceIDReturnsEmpty(t
 }
 
 func TestLaunchResolveWorkspacePath_PickedFolderUsedDirectly(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.dataDir = t.TempDir()
 	picked := t.TempDir() // some existing folder the user picked
 
@@ -399,7 +399,7 @@ func TestLaunchResolveWorkspacePath_PickedFolderUsedDirectly(t *testing.T) {
 }
 
 func TestLaunchResolveWorkspacePath_WorktreeWithoutRepoFallsBackToScratch(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.dataDir = t.TempDir()
 
 	// UseWorktree=true but no RepositoryPath — should not return empty,
@@ -425,7 +425,7 @@ func TestLaunchResolveWorkspacePath_WorktreeWithoutRepoFallsBackToScratch(t *tes
 // backend restart, where a workspace-only execution was returned to the resume
 // path and StartAgentProcess() then failed with "no agent command configured".
 func TestLaunch_PromotesWorkspaceOnlyExecution(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	// Inject a workspace-only execution: AgentCommand is intentionally empty,
 	// matching what createExecution produces when called from
@@ -458,7 +458,7 @@ func TestLaunch_PromotesWorkspaceOnlyExecution(t *testing.T) {
 // an agent running" guard still fires when the existing execution is a real
 // agent-equipped one (AgentCommand populated), preventing duplicate launches.
 func TestLaunch_RejectsWhenAgentAlreadyRunning(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	existing := &AgentExecution{
 		ID:             "exec-running",

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle.go
@@ -165,11 +165,16 @@ func (m *Manager) IsShuttingDown() bool {
 	return m.shuttingDown.Load()
 }
 
+// closeStopCh closes the manager shutdown channel at most once.
+func (m *Manager) closeStopCh() {
+	m.stopOnce.Do(func() { close(m.stopCh) })
+}
+
 // Stop stops the lifecycle manager and releases resources held by executors.
 func (m *Manager) Stop() error {
 	m.logger.Info("stopping lifecycle manager")
 
-	close(m.stopCh)
+	m.closeStopCh()
 	if m.streamManager != nil {
 		m.streamManager.Wait()
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestManager_MarkCompleted_Success(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	execution := &AgentExecution{
 		ID:             "test-execution-id",
@@ -43,7 +43,7 @@ func TestManager_MarkCompleted_Success(t *testing.T) {
 }
 
 func TestManager_MarkCompleted_Failure(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	execution := &AgentExecution{
 		ID:             "test-execution-id",
@@ -75,7 +75,7 @@ func TestManager_MarkCompleted_Failure(t *testing.T) {
 }
 
 func TestManager_MarkCompleted_Idempotent(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	execution := &AgentExecution{
 		ID:             "test-execution-id",
@@ -103,7 +103,7 @@ func TestManager_MarkCompleted_Idempotent(t *testing.T) {
 }
 
 func TestManager_MarkCompleted_NotFound(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	err := mgr.MarkCompleted("non-existent", 0, "")
 	if err == nil {
@@ -112,7 +112,7 @@ func TestManager_MarkCompleted_NotFound(t *testing.T) {
 }
 
 func TestManager_RemoveExecution(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	execution := &AgentExecution{
 		ID:          "test-execution-id",
@@ -179,7 +179,7 @@ func TestManager_CleanupStaleExecution_StopsRuntimeInstance(t *testing.T) {
 }
 
 func TestManager_CleanupStaleExecution_NoopForMissingSession(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	err := mgr.CleanupStaleExecutionBySessionID(context.Background(), "non-existent")
 	if err != nil {
@@ -188,7 +188,7 @@ func TestManager_CleanupStaleExecution_NoopForMissingSession(t *testing.T) {
 }
 
 func TestManager_CleanupStaleExecution_SkipsStopWhenNoRuntime(t *testing.T) {
-	mgr := newTestManager() // no executor registry
+	mgr := newTestManager(t) // no executor registry
 
 	execution := &AgentExecution{
 		ID:          "exec-1",
@@ -238,7 +238,7 @@ func (m *mockStopTracker) ShouldApplyPreferredShell() bool { return false }
 func (m *mockStopTracker) IsAlwaysResumable() bool         { return false }
 
 func TestManager_StartStop(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	ctx := context.Background()
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_passthrough_autoinject_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_passthrough_autoinject_test.go
@@ -71,7 +71,7 @@ func newAutoInjectExecution(description string) *AgentExecution {
 }
 
 func TestAutoInject_disabled_does_nothing(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	runner := &fakePassthroughRunner{}
 
 	mgr.autoInjectInitialPromptWith(runner, newAutoInjectExecution("do a thing"), agents.PassthroughConfig{
@@ -85,7 +85,7 @@ func TestAutoInject_disabled_does_nothing(t *testing.T) {
 }
 
 func TestAutoInject_skipped_when_PromptFlag_set(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	runner := &fakePassthroughRunner{}
 
 	mgr.autoInjectInitialPromptWith(runner, newAutoInjectExecution("do a thing"), agents.PassthroughConfig{
@@ -100,7 +100,7 @@ func TestAutoInject_skipped_when_PromptFlag_set(t *testing.T) {
 }
 
 func TestAutoInject_skipped_when_description_empty(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	runner := &fakePassthroughRunner{}
 
 	mgr.autoInjectInitialPromptWith(runner, newAutoInjectExecution(""), agents.PassthroughConfig{
@@ -114,7 +114,7 @@ func TestAutoInject_skipped_when_description_empty(t *testing.T) {
 }
 
 func TestAutoInject_writes_description_plus_submit(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	runner := &fakePassthroughRunner{}
 
 	mgr.autoInjectInitialPromptWith(runner, newAutoInjectExecution("hello world"), agents.PassthroughConfig{
@@ -137,7 +137,7 @@ func TestAutoInject_writes_description_plus_submit(t *testing.T) {
 // error-return path: the helper must skip the stdin write and exit cleanly
 // rather than panic or loop.
 func TestAutoInject_returns_when_wait_errors(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	runner := &fakePassthroughRunner{waitErr: context.DeadlineExceeded}
 
 	done := make(chan struct{})
@@ -166,7 +166,7 @@ func TestAutoInject_returns_when_wait_errors(t *testing.T) {
 // sees the trailing \r as a discrete keystroke instead of absorbing it into the
 // pasted text.
 func TestAutoInject_SubmitDelay_splits_writes_with_pause(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	runner := &fakePassthroughRunner{}
 
 	const delay = 40 * time.Millisecond
@@ -196,7 +196,7 @@ func TestAutoInject_SubmitDelay_splits_writes_with_pause(t *testing.T) {
 }
 
 func TestAutoInject_skipped_when_process_id_missing(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	runner := &fakePassthroughRunner{}
 
 	exec := newAutoInjectExecution("hello")

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_passthrough_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_passthrough_test.go
@@ -76,7 +76,7 @@ func assertClaudePassthroughMCPConfig(t *testing.T, cmd agents.Command, wantURL 
 func newClaudePassthroughMCPTestManager(t *testing.T) (*Manager, *AgentExecution, *AgentProfileInfo) {
 	t.Helper()
 
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.dataDir = t.TempDir()
 	mgr.profileResolver = &mockPassthroughProfileResolver{
 		agentName:      "claude-acp",
@@ -477,7 +477,7 @@ func TestWritePassthroughMCPConfigKeepsLiteralSessionFilename(t *testing.T) {
 // cleanupDelay (and then take the nil-runner branch in the test rig).
 func TestManager_HandlePassthroughExit_SkipsDuringShutdown(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		mgr := newTestManager()
+		mgr := newTestManager(t)
 
 		if mgr.IsShuttingDown() {
 			t.Fatal("fresh manager reports IsShuttingDown() == true")
@@ -508,7 +508,7 @@ func TestManager_HandlePassthroughExit_SkipsDuringShutdown(t *testing.T) {
 // teardown.
 func TestManager_HandlePassthroughExit_ResumeFallback_SkipsDuringShutdown(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		mgr := newTestManager()
+		mgr := newTestManager(t)
 		if err := mgr.StopAllAgents(context.Background()); err != nil {
 			t.Fatalf("StopAllAgents returned error: %v", err)
 		}
@@ -597,7 +597,7 @@ func TestIsFastFailExit(t *testing.T) {
 // reach the passthrough launch path (regression for issue #718, where the
 // passthrough builder silently dropped them).
 func TestManager_ProfileCLIFlagTokens(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	t.Run("nil profile returns nil", func(t *testing.T) {
 		if got := mgr.profileCLIFlagTokens(nil); got != nil {
@@ -640,7 +640,7 @@ func TestManager_ProfileCLIFlagTokens(t *testing.T) {
 }
 
 func TestBuildPassthroughEnv_MergesProfileEnvVars(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.profileResolver = &mockPassthroughProfileResolver{
 		envVars: []settingsmodels.ProfileEnvVar{
 			{Key: "PLAIN", Value: "plain-value"},
@@ -682,7 +682,7 @@ func TestManager_VerifyPassthroughEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mgr := newTestManager()
+			mgr := newTestManager(t)
 
 			// Override profile resolver for this test
 			if tt.profileID != "" {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_startup_test.go
@@ -30,7 +30,7 @@ func (m *mockAgentProfileResolver) ResolveProfile(_ context.Context, profileID s
 }
 
 func TestStartAgentProcess_NotFound(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	err := mgr.StartAgentProcess(context.Background(), "non-existent")
 	if err == nil {
 		t.Fatal("expected error for non-existent execution")
@@ -41,7 +41,7 @@ func TestStartAgentProcess_NotFound(t *testing.T) {
 }
 
 func TestStartAgentProcess_NonPassthrough_NoAgentctl(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	// Use a resolver that returns CLIPassthrough=false
 	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: false}
 
@@ -64,7 +64,7 @@ func TestStartAgentProcess_NonPassthrough_NoAgentctl(t *testing.T) {
 }
 
 func TestStartAgentProcess_Passthrough_NotResumed(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: true}
 
 	execution := &AgentExecution{
@@ -89,7 +89,7 @@ func TestStartAgentProcess_Passthrough_NotResumed(t *testing.T) {
 }
 
 func TestStartAgentProcess_Passthrough_Resumed(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: true}
 
 	execution := &AgentExecution{
@@ -122,7 +122,7 @@ func TestStartAgentProcess_Passthrough_Resumed(t *testing.T) {
 // even after its profile has been toggled to CLIPassthrough — the
 // session-snapshot wins so existing sessions don't get stranded.
 func TestStartAgentProcess_AgentSession_IgnoresProfileToggleToPassthrough(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	// Profile currently advertises passthrough — simulates the post-toggle state.
 	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: true}
 
@@ -153,7 +153,7 @@ func TestStartAgentProcess_AgentSession_IgnoresProfileToggleToPassthrough(t *tes
 // passthrough mode must keep using the passthrough path even if the profile
 // is later toggled back to ACP.
 func TestStartAgentProcess_PassthroughSession_IgnoresProfileToggleToAgent(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	// Profile currently advertises ACP — simulates a toggle away from passthrough.
 	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: false}
 
@@ -183,7 +183,7 @@ func TestStartAgentProcess_PassthroughSession_IgnoresProfileToggleToAgent(t *tes
 // what matters is that we do NOT silently fall through to the ACP path (the
 // bug that would otherwise strand the session in the wrong launch mode).
 func TestStartAgentProcess_PassthroughResume_SurvivesProfileResolveError(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.profileResolver = &mockAgentProfileResolver{err: errors.New("transient DB error")}
 
 	execution := &AgentExecution{
@@ -212,7 +212,7 @@ func TestStartAgentProcess_PassthroughResume_SurvivesProfileResolveError(t *test
 // building, so a profile-resolve error must surface as an explicit error
 // rather than silently falling through to ACP.
 func TestStartAgentProcess_FreshPassthrough_SurfacesProfileResolveError(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.profileResolver = &mockAgentProfileResolver{err: errors.New("transient DB error")}
 
 	execution := &AgentExecution{
@@ -241,7 +241,7 @@ func TestStartAgentProcess_FreshPassthrough_SurfacesProfileResolveError(t *testi
 // doesn't carry a SessionID) still fall back to live profile resolution so
 // first-time launches reflect the current mode.
 func TestStartAgentProcess_NoSession_FallsBackToLiveProfile(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	mgr.profileResolver = &mockAgentProfileResolver{cliPassthrough: true}
 
 	execution := &AgentExecution{

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_test.go
@@ -188,7 +188,7 @@ func closeStopChOnce(stopCh chan struct{}) {
 func cleanupManagerStopCh(t *testing.T, mgr *Manager) {
 	t.Helper()
 	t.Cleanup(func() {
-		closeStopChOnce(mgr.stopCh)
+		mgr.closeStopCh()
 		if mgr.streamManager != nil {
 			mgr.streamManager.Wait()
 		}
@@ -223,19 +223,24 @@ func (m *MockProfileResolver) ResolveProfile(ctx context.Context, profileID stri
 	}, nil
 }
 
-// newTestManager creates a Manager for testing with mock dependencies
-func newTestManager() *Manager {
+// newTestManager creates a Manager for testing with mock dependencies.
+// Registers t.Cleanup to close stopCh and drain StreamManager goroutines so
+// goleak.VerifyTestMain stays green when tests trigger ConnectWorkspaceStream.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
 	log := newTestLogger()
 	reg := newTestRegistry()
 	eventBus := &MockEventBus{}
 	credsMgr := &MockCredentialsManager{}
 	profileResolver := &MockProfileResolver{}
 	// Pass nil for runtime - tests don't need them
-	return NewManager(reg, eventBus, nil, credsMgr, profileResolver, nil, ExecutorFallbackWarn, "", log)
+	mgr := NewManager(reg, eventBus, nil, credsMgr, profileResolver, nil, ExecutorFallbackWarn, "", log)
+	cleanupManagerStopCh(t, mgr)
+	return mgr
 }
 
 func TestNewManager(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	if mgr == nil {
 		t.Fatal("expected non-nil manager")
@@ -246,14 +251,14 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestNewManager_WiresRemediateNpxCacheDefault(t *testing.T) {
-	m := newTestManager()
+	m := newTestManager(t)
 	if m.remediateNpxCache == nil {
 		t.Fatal("NewManager must wire default remediateNpxCache")
 	}
 }
 
 func TestManager_GetExecution(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	// Manually add an execution for testing
 	execution := &AgentExecution{
@@ -284,7 +289,7 @@ func TestManager_GetExecution(t *testing.T) {
 }
 
 func TestManager_GetExecutionBySessionID(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	execution := &AgentExecution{
 		ID:             "test-execution-id",
@@ -315,7 +320,7 @@ func TestManager_GetExecutionBySessionID(t *testing.T) {
 }
 
 func TestManager_ListExecutions(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	// Empty list
 	list := mgr.ListExecutions()
@@ -334,7 +339,7 @@ func TestManager_ListExecutions(t *testing.T) {
 }
 
 func TestManager_UpdateStatus(t *testing.T) {
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 
 	execution := &AgentExecution{
 		ID:     "test-execution-id",

--- a/apps/backend/internal/agent/runtime/lifecycle/wakeup_e2e_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/wakeup_e2e_test.go
@@ -188,7 +188,7 @@ func TestWakeupE2EFullPipeline_BridgeToEventBus(t *testing.T) {
 	})
 
 	// ---- Set up lifecycle Manager with tracking bus ----
-	mgr := newTestManager()
+	mgr := newTestManager(t)
 	trackBus := &trackingBus{}
 	// Reach into the manager's event publisher: replace the bus with the
 	// tracker. eventPublisher is the only thing that calls eventBus.Publish.

--- a/apps/backend/internal/integration/test_server_test.go
+++ b/apps/backend/internal/integration/test_server_test.go
@@ -67,6 +67,12 @@ func (a *taskRepositoryAdapter) UpdateTaskState(ctx context.Context, taskID stri
 	return err
 }
 
+func (a *taskRepositoryAdapter) UpdateTaskStateIfCurrentIn(
+	ctx context.Context, taskID string, state v1.TaskState, allowed []v1.TaskState,
+) (bool, error) {
+	return a.svc.UpdateTaskStateIfCurrentIn(ctx, taskID, state, allowed)
+}
+
 // testMessageCreatorAdapter adapts the task service to the orchestrator.MessageCreator interface for tests
 type testMessageCreatorAdapter struct {
 	svc *taskservice.Service

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -557,6 +557,44 @@ func (s *Service) writeTaskReviewState(ctx context.Context, taskID string) {
 		zap.String("task_id", taskID))
 }
 
+// writeTaskWaitingForInputState clears the kanban "actively working" task states
+// when the user cancels a turn mid-flight. Normal turn completion lands on
+// REVIEW via setSessionWaitingForInput; cancel bypasses that path and must
+// reconcile tasks.state explicitly or the card stays IN_PROGRESS.
+func (s *Service) writeTaskWaitingForInputState(ctx context.Context, taskID string) {
+	dbTask, err := s.repo.GetTask(ctx, taskID)
+	if err != nil || dbTask == nil {
+		if err != nil {
+			s.logger.Warn("failed to load task for cancel state reconcile",
+				zap.String("task_id", taskID),
+				zap.Error(err))
+		}
+		return
+	}
+	// Office task status reflects workflow position, not runtime cancel.
+	if dbTask.AssigneeAgentProfileID != "" {
+		return
+	}
+
+	updated, err := s.taskRepo.UpdateTaskStateIfCurrentIn(
+		ctx,
+		taskID,
+		v1.TaskStateWaitingForInput,
+		[]v1.TaskState{v1.TaskStateInProgress, v1.TaskStateScheduling},
+	)
+	if err != nil {
+		s.logger.Error("failed to update task state to WAITING_FOR_INPUT",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	if !updated {
+		return
+	}
+	s.logger.Info("task moved to WAITING_FOR_INPUT state after turn cancel",
+		zap.String("task_id", taskID))
+}
+
 func (s *Service) setSessionRunning(ctx context.Context, taskID, sessionID string, preloadedSession ...*models.TaskSession) {
 	// Resolve session up front so we can guard the task write against terminal
 	// states. updateTaskSessionState silently no-ops for terminal sessions, so

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -128,7 +128,7 @@ func (m *mockTaskRepo) UpdateTaskStateIfCurrentIn(
 	defer m.mu.Unlock()
 	t, ok := m.tasks[taskID]
 	if !ok {
-		return false, nil
+		return false, fmt.Errorf("%w: %s", sqliterepo.ErrTaskNotFound, taskID)
 	}
 	for _, candidate := range allowed {
 		if t.State != candidate {

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -115,7 +115,31 @@ func (m *mockTaskRepo) UpdateTaskState(_ context.Context, taskID string, state v
 	defer m.mu.Unlock()
 	m.updatedStates[taskID] = state
 	m.stateWrites[taskID]++
+	if t, ok := m.tasks[taskID]; ok {
+		t.State = state
+	}
 	return nil
+}
+
+func (m *mockTaskRepo) UpdateTaskStateIfCurrentIn(
+	_ context.Context, taskID string, state v1.TaskState, allowed []v1.TaskState,
+) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[taskID]
+	if !ok {
+		return false, nil
+	}
+	for _, candidate := range allowed {
+		if t.State != candidate {
+			continue
+		}
+		m.updatedStates[taskID] = state
+		m.stateWrites[taskID]++
+		t.State = state
+		return true, nil
+	}
+	return false, nil
 }
 
 // mockAgentManager is a minimal mock of executor.AgentManagerClient for testing.

--- a/apps/backend/internal/orchestrator/scheduler/scheduler.go
+++ b/apps/backend/internal/orchestrator/scheduler/scheduler.go
@@ -42,6 +42,7 @@ func DefaultSchedulerConfig() SchedulerConfig {
 type TaskRepository interface {
 	GetTask(ctx context.Context, taskID string) (*v1.Task, error)
 	UpdateTaskState(ctx context.Context, taskID string, state v1.TaskState) error
+	UpdateTaskStateIfCurrentIn(ctx context.Context, taskID string, state v1.TaskState, allowed []v1.TaskState) (bool, error)
 }
 
 // QueueStatus contains queue statistics

--- a/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
+++ b/apps/backend/internal/orchestrator/scheduler/scheduler_test.go
@@ -208,6 +208,25 @@ func (r *testTaskRepository) UpdateTaskState(ctx context.Context, taskID string,
 	return nil
 }
 
+func (r *testTaskRepository) UpdateTaskStateIfCurrentIn(
+	_ context.Context, taskID string, state v1.TaskState, allowed []v1.TaskState,
+) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	task, exists := r.tasks[taskID]
+	if !exists {
+		return false, fmt.Errorf("%w: %s", taskrepo.ErrTaskNotFound, taskID)
+	}
+	for _, candidate := range allowed {
+		if task.State != candidate {
+			continue
+		}
+		task.State = state
+		return true, nil
+	}
+	return false, nil
+}
+
 func createTestLogger() *logger.Logger {
 	log, _ := logger.NewLogger(logger.LoggingConfig{
 		Level:  "error", // Suppress logs during tests

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2289,6 +2289,7 @@ func (s *Service) CancelAgent(ctx context.Context, sessionID string) error {
 	// Transition to WAITING_FOR_INPUT so the user can send a new prompt
 	if session != nil {
 		s.updateTaskSessionState(ctx, session.TaskID, sessionID, models.TaskSessionStateWaitingForInput, "", true, session)
+		s.writeTaskWaitingForInputState(ctx, session.TaskID)
 	}
 
 	// Record cancellation in the message history

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -372,6 +372,69 @@ func TestCancelAgent_DeduplicatesConcurrentCalls(t *testing.T) {
 	}
 }
 
+// TestCancelAgent_TaskStateReconcile ensures cancel writes tasks.state for active
+// kanban tasks only. Office tasks and tasks already out of IN_PROGRESS /
+// SCHEDULING must be left untouched.
+func TestCancelAgent_TaskStateReconcile(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name            string
+		taskState       v1.TaskState
+		office          bool
+		wantStateUpdate bool
+	}{
+		{name: "in_progress", taskState: v1.TaskStateInProgress, wantStateUpdate: true},
+		{name: "scheduling", taskState: v1.TaskStateScheduling, wantStateUpdate: true},
+		{name: "review", taskState: v1.TaskStateReview},
+		{name: "office", taskState: v1.TaskStateInProgress, office: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			taskRepo := newMockTaskRepo()
+			agentMgr := &mockAgentManager{isAgentRunning: true}
+			svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+
+			taskID := "task-" + tc.name
+			sessionID := "session-" + tc.name
+
+			if tc.office {
+				seedOfficeSession(t, repo, taskID, sessionID, "")
+			} else {
+				seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateRunning)
+				task, err := repo.GetTask(ctx, taskID)
+				if err != nil {
+					t.Fatalf("get task: %v", err)
+				}
+				task.State = tc.taskState
+				if err := repo.UpdateTask(ctx, task); err != nil {
+					t.Fatalf("update task state: %v", err)
+				}
+				taskRepo.tasks[taskID] = &v1.Task{ID: taskID, State: tc.taskState}
+			}
+
+			if err := svc.CancelAgent(ctx, sessionID); err != nil {
+				t.Fatalf("cancel agent: %v", err)
+			}
+
+			got, ok := taskRepo.updatedStates[taskID]
+			if tc.wantStateUpdate {
+				if !ok {
+					t.Fatal("expected tasks.state to be updated on cancel")
+				}
+				if got != v1.TaskStateWaitingForInput {
+					t.Fatalf("expected task state %q, got %q", v1.TaskStateWaitingForInput, got)
+				}
+				return
+			}
+			if ok {
+				t.Fatalf("expected tasks.state to remain unchanged, got %q", got)
+			}
+		})
+	}
+}
+
 func TestCancelAgent_LeavesQueuedMessageForManualDrain(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -1067,6 +1130,15 @@ func (c *ctxAwareTaskRepo) UpdateTaskState(ctx context.Context, taskID string, s
 		return err
 	}
 	return c.inner.UpdateTaskState(ctx, taskID, state)
+}
+
+func (c *ctxAwareTaskRepo) UpdateTaskStateIfCurrentIn(
+	ctx context.Context, taskID string, state v1.TaskState, allowed []v1.TaskState,
+) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	return c.inner.UpdateTaskStateIfCurrentIn(ctx, taskID, state, allowed)
 }
 
 // TestResumeTaskSession_FailedStateWriteSurvivesCancelledCallerCtx verifies the

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -401,6 +401,10 @@ func TestCancelAgent_TaskStateReconcile(t *testing.T) {
 
 			if tc.office {
 				seedOfficeSession(t, repo, taskID, sessionID, "")
+				// Seed the mock so a missing office guard would fail the test: without
+				// AssigneeAgentProfileID early-return, UpdateTaskStateIfCurrentIn would
+				// run against this IN_PROGRESS row and write updatedStates.
+				taskRepo.tasks[taskID] = &v1.Task{ID: taskID, State: tc.taskState}
 			} else {
 				seedTaskAndSession(t, repo, taskID, sessionID, models.TaskSessionStateRunning)
 				task, err := repo.GetTask(ctx, taskID)

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -79,6 +79,9 @@ func (m *mockRepository) CountOpenWatcherCreatedTasks(_ context.Context, _, _ st
 func (m *mockRepository) UpdateTaskState(ctx context.Context, id string, state v1.TaskState) error {
 	return nil
 }
+func (m *mockRepository) UpdateTaskStateIfCurrentIn(_ context.Context, _ string, _ v1.TaskState, _ []v1.TaskState) (v1.TaskState, bool, error) {
+	return "", false, nil
+}
 func (m *mockRepository) AddTaskToWorkflow(ctx context.Context, taskID, workflowID, columnID string, position int) error {
 	return nil
 }

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -41,6 +41,10 @@ type TaskRepository interface {
 	// orchestrator's watcher throttle gate to enforce a per-watch cap.
 	CountOpenWatcherCreatedTasks(ctx context.Context, integration, watchID string) (int, error)
 	UpdateTaskState(ctx context.Context, id string, state v1.TaskState) error
+	// UpdateTaskStateIfCurrentIn atomically transitions state only when the
+	// task's current state is in allowed. Returns the pre-update state and
+	// whether a row was modified.
+	UpdateTaskStateIfCurrentIn(ctx context.Context, id string, state v1.TaskState, allowed []v1.TaskState) (v1.TaskState, bool, error)
 	CountTasksByWorkflow(ctx context.Context, workflowID string) (int, error)
 	CountTasksByWorkflowStep(ctx context.Context, stepID string) (int, error)
 	AddTaskToWorkflow(ctx context.Context, taskID, workflowID, workflowStepID string, position int) error

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -785,6 +786,60 @@ func (r *Repository) UpdateTaskState(ctx context.Context, id string, state v1.Ta
 		return fmt.Errorf("%w: %s", ErrTaskNotFound, id)
 	}
 	return nil
+}
+
+// UpdateTaskStateIfCurrentIn transitions state inside a transaction, re-checking
+// the current state on write so concurrent handlers cannot clobber a task that
+// moved out of allowed between read and update.
+func (r *Repository) UpdateTaskStateIfCurrentIn(
+	ctx context.Context, id string, state v1.TaskState, allowed []v1.TaskState,
+) (v1.TaskState, bool, error) {
+	if len(allowed) == 0 {
+		return "", false, nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var currentState v1.TaskState
+	err = tx.QueryRowContext(ctx, r.db.Rebind(`SELECT state FROM tasks WHERE id = ?`), id).Scan(&currentState)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, fmt.Errorf("%w: %s", ErrTaskNotFound, id)
+		}
+		return "", false, err
+	}
+	if !taskStateInSet(currentState, allowed) {
+		return currentState, false, nil
+	}
+
+	result, err := tx.ExecContext(ctx, r.db.Rebind(`
+		UPDATE tasks SET state = ?, updated_at = ?
+		WHERE id = ? AND state = ?
+	`), state, time.Now().UTC(), id, currentState)
+	if err != nil {
+		return "", false, err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return currentState, false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return "", false, err
+	}
+	return currentState, true, nil
+}
+
+func taskStateInSet(state v1.TaskState, allowed []v1.TaskState) bool {
+	for _, candidate := range allowed {
+		if state == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 // ListTasksByProject returns all non-archived, non-ephemeral tasks for a project.

--- a/apps/backend/internal/task/repository/task_repository_test.go
+++ b/apps/backend/internal/task/repository/task_repository_test.go
@@ -129,6 +129,56 @@ func TestSQLiteRepository_UpdateTaskStateNotFound(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepository_UpdateTaskStateIfCurrentIn(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	workflow := &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Test Workflow"}
+	_ = repo.CreateWorkflow(ctx, workflow)
+	task := &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", State: v1.TaskStateInProgress}
+	_ = repo.CreateTask(ctx, task)
+
+	oldState, updated, err := repo.UpdateTaskStateIfCurrentIn(
+		ctx, "task-123", v1.TaskStateWaitingForInput,
+		[]v1.TaskState{v1.TaskStateInProgress, v1.TaskStateScheduling},
+	)
+	if err != nil {
+		t.Fatalf("conditional update failed: %v", err)
+	}
+	if !updated {
+		t.Fatal("expected update from IN_PROGRESS")
+	}
+	if oldState != v1.TaskStateInProgress {
+		t.Fatalf("old state = %q, want IN_PROGRESS", oldState)
+	}
+
+	retrieved, _ := repo.GetTask(ctx, "task-123")
+	if retrieved.State != v1.TaskStateWaitingForInput {
+		t.Fatalf("expected WAITING_FOR_INPUT, got %s", retrieved.State)
+	}
+
+	_, updated, err = repo.UpdateTaskStateIfCurrentIn(
+		ctx, "task-123", v1.TaskStateWaitingForInput,
+		[]v1.TaskState{v1.TaskStateInProgress, v1.TaskStateScheduling},
+	)
+	if err != nil {
+		t.Fatalf("second conditional update failed: %v", err)
+	}
+	if updated {
+		t.Fatal("expected no update when current state is not allowed")
+	}
+
+	_, updated, err = repo.UpdateTaskStateIfCurrentIn(ctx, "missing", v1.TaskStateReview, []v1.TaskState{v1.TaskStateInProgress})
+	if err == nil {
+		t.Fatal("expected error for missing task")
+	}
+	if updated {
+		t.Fatal("expected no update for missing task")
+	}
+}
+
 func TestSQLiteRepository_ListTasks(t *testing.T) {
 	repo, cleanup := createTestSQLiteRepo(t)
 	defer cleanup()

--- a/apps/backend/internal/task/service/handoff_workspace_test.go
+++ b/apps/backend/internal/task/service/handoff_workspace_test.go
@@ -356,6 +356,10 @@ func (r *phase4TaskRepo) UpdateTaskState(context.Context, string, v1.TaskState) 
 	r.panicNotUsed("UpdateTaskState")
 	return nil
 }
+func (r *phase4TaskRepo) UpdateTaskStateIfCurrentIn(context.Context, string, v1.TaskState, []v1.TaskState) (v1.TaskState, bool, error) {
+	r.panicNotUsed("UpdateTaskStateIfCurrentIn")
+	return "", false, nil
+}
 func (r *phase4TaskRepo) CountTasksByWorkflow(context.Context, string) (int, error) {
 	r.panicNotUsed("CountTasksByWorkflow")
 	return 0, nil

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -200,6 +200,8 @@ func (s *Service) UpdateTaskStateIfCurrentIn(
 	if err != nil || !updated {
 		return false, err
 	}
+	// Unreachable for current callers (allowed never includes state) — kept so a
+	// future caller that includes state in allowed still skips a duplicate publish.
 	if oldState == state {
 		return false, nil
 	}
@@ -208,11 +210,14 @@ func (s *Service) UpdateTaskStateIfCurrentIn(
 	if err != nil {
 		return true, err
 	}
+	// The CAS wrote `state`; pin it on the payload so a concurrent transition
+	// between commit and read cannot publish a mismatched new_state.
+	task.State = state
 
 	s.logger.Info("task state updated",
 		zap.String("task_id", id),
 		zap.String("workflow_step_id", task.WorkflowStepID),
-		zap.String("state", string(task.State)))
+		zap.String("state", string(state)))
 
 	s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
 	s.logger.Info("task state changed",

--- a/apps/backend/internal/task/service/service_workflow.go
+++ b/apps/backend/internal/task/service/service_workflow.go
@@ -190,6 +190,39 @@ func (s *Service) UpdateTaskState(ctx context.Context, id string, state v1.TaskS
 	return task, nil
 }
 
+// UpdateTaskStateIfCurrentIn transitions state only when the task is currently
+// in one of the allowed values. Publishes task.state_changed only when a row
+// changes.
+func (s *Service) UpdateTaskStateIfCurrentIn(
+	ctx context.Context, id string, state v1.TaskState, allowed []v1.TaskState,
+) (bool, error) {
+	oldState, updated, err := s.tasks.UpdateTaskStateIfCurrentIn(ctx, id, state, allowed)
+	if err != nil || !updated {
+		return false, err
+	}
+	if oldState == state {
+		return false, nil
+	}
+
+	task, err := s.tasks.GetTask(ctx, id)
+	if err != nil {
+		return true, err
+	}
+
+	s.logger.Info("task state updated",
+		zap.String("task_id", id),
+		zap.String("workflow_step_id", task.WorkflowStepID),
+		zap.String("state", string(task.State)))
+
+	s.publishTaskEvent(ctx, events.TaskStateChanged, task, &oldState)
+	s.logger.Info("task state changed",
+		zap.String("task_id", id),
+		zap.String("old_state", string(oldState)),
+		zap.String("new_state", string(state)))
+
+	return true, nil
+}
+
 // UpdateTaskMetadata updates only the metadata of a task (merges with existing)
 func (s *Service) UpdateTaskMetadata(ctx context.Context, id string, metadata map[string]interface{}) (*models.Task, error) {
 	task, err := s.tasks.GetTask(ctx, id)


### PR DESCRIPTION
Cancelling an agent turn left the session at WAITING_FOR_INPUT while tasks.state stayed IN_PROGRESS, so kanban cards kept showing the task as actively running. Cancel now atomically moves active kanban tasks to WAITING_FOR_INPUT so the UI matches the idle, promptable session.

## Important Changes

- Add `UpdateTaskStateIfCurrentIn` (transactional CAS) on the task repo/service path so cancel cannot clobber a task that moved out of `IN_PROGRESS`/`SCHEDULING` concurrently.
- Call the reconcile from `CancelAgent`; skip office tasks whose workflow position drives state.

## Validation

- `make -C apps/backend fmt`
- `make -C apps/backend test lint`
- `go test ./internal/orchestrator -run TestCancelAgent`
- `go test ./internal/task/repository -run TestSQLiteRepository_UpdateTaskStateIfCurrentIn`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)