### PR TITLE
docs(agentctl): clarify default_child_ordering is not enforced outside office

### DIFF
--- a/apps/backend/cmd/agentctl/kandev_task.go
+++ b/apps/backend/cmd/agentctl/kandev_task.go
@@ -102,7 +102,7 @@ func taskCreate(args []string) int {
 	workspaceMode := fs.String("workspace-mode", "", "Workspace mode for this task: inherit_parent, new_workspace, or shared_group")
 	workspaceGroupID := fs.String("workspace-group-id", "", "Workspace group ID to join (required when --workspace-mode=shared_group)")
 	defaultChildWorkspace := fs.String("default-child-workspace", "", "Parent-only: default workspace mode for children (inherit_parent or new_workspace)")
-	defaultChildOrdering := fs.String("default-child-ordering", "", "Parent-only ordering policy for children. 'sequential' records sibling blocker edges that gate execution ONLY in office workflows (released by on_blocker_resolved); in plain kanban they drive the subtask-stepper UI but do NOT defer auto-start, so children still start immediately. 'parallel' = no edges, siblings run concurrently.")
+	defaultChildOrdering := fs.String("default-child-ordering", "", "Parent-only ordering policy for children. 'sequential' records dependency edges between siblings; 'parallel' records none. Note: recording an edge does NOT by itself defer when a child starts.")
 	if err := fs.Parse(args); err != nil {
 		cliError("parse flags: %v", err)
 		return 1

--- a/apps/backend/cmd/agentctl/kandev_task.go
+++ b/apps/backend/cmd/agentctl/kandev_task.go
@@ -102,7 +102,7 @@ func taskCreate(args []string) int {
 	workspaceMode := fs.String("workspace-mode", "", "Workspace mode for this task: inherit_parent, new_workspace, or shared_group")
 	workspaceGroupID := fs.String("workspace-group-id", "", "Workspace group ID to join (required when --workspace-mode=shared_group)")
 	defaultChildWorkspace := fs.String("default-child-workspace", "", "Parent-only: default workspace mode for children (inherit_parent or new_workspace)")
-	defaultChildOrdering := fs.String("default-child-ordering", "", "Parent-only: ordering for children — 'sequential' adds dependency edges between siblings, 'parallel' lets them run concurrently")
+	defaultChildOrdering := fs.String("default-child-ordering", "", "Parent-only ordering policy for children. 'sequential' records sibling blocker edges that gate execution ONLY in office workflows (released by on_blocker_resolved); in plain kanban they drive the subtask-stepper UI but do NOT defer auto-start, so children still start immediately. 'parallel' = no edges, siblings run concurrently.")
 	if err := fs.Parse(args); err != nil {
 		cliError("parse flags: %v", err)
 		return 1

--- a/apps/backend/internal/task/service/handoff_service.go
+++ b/apps/backend/internal/task/service/handoff_service.go
@@ -89,6 +89,10 @@ type WorkspacePolicy struct {
 	// ParentOrdering is the ordering policy resolved from the parent
 	// task's metadata. Drives whether AttachWorkspacePolicy adds a
 	// blocker chain on the new task. Empty means parallel (no chain).
+	// Note: the resulting blocker edges gate execution only in office
+	// workflows (released via the on_blocker_resolved trigger). In plain
+	// kanban nothing consults them at auto-start time — they drive the
+	// subtask-stepper UI / ordering display, not execution order.
 	ParentOrdering string
 }
 


### PR DESCRIPTION
The `default_child_ordering` flag implied sequential ordering gates execution, but kanban auto-start never consults the blocker edges it records — ordering is only enforced inside office workflows. This clarifies the docs so users building dependent subtask chains know to use an office workflow for enforced ordering, resolving the docs/behavior mismatch in #1110.

## Important Changes
- The misleading param was already moved off the `create_task_kandev` MCP tool onto the `agentctl kandev tasks create --default-child-ordering` CLI flag in #1181, so the general MCP surface is already clean. This PR fixes the surviving wording on the CLI flag help and documents the same nuance on `WorkspacePolicy.ParentOrdering`.
- Kept docs-only: the `sequential` blocker edges are intentionally retained — the subtask-stepper UI reads them. Enforced ordered execution requires an office workflow (`on_blocker_resolved` releases the next sibling).

## Validation
- `make fmt` (no changes)
- `go build ./...`
- `go test ./cmd/agentctl/... ./internal/task/service/...` — 324 passed
- `golangci-lint run ./cmd/agentctl/... ./internal/task/service/...` — no issues

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] Self-reviewed

Closes #1110