### PR TITLE
fix(web): apply repository filter correctly on task board

### DIFF
--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/types/http";
 import type { KanbanState } from "@/lib/state/slices";
 import { findTaskInSnapshots } from "@/lib/kanban/find-task";
+import { repositorySlug } from "@/lib/repository-slug";
 import { resolvePreferredSessionId } from "../task-select-helpers";
 
 // Map workflow snapshot to kanban state on workspace switch.
@@ -162,7 +163,7 @@ export function useSheetData(workspaceId: string | null) {
     const repositories = workspaceId ? (repositoriesByWorkspace[workspaceId] ?? []) : [];
     const ctx: SheetItemCtx = {
       repositoryPathsById: new Map(
-        repositories.map((repo: Repository) => [repo.id, repo.local_path]),
+        repositories.map((repo: Repository) => [repo.id, repositorySlug(repo)]),
       ),
       workflowNameById: new Map(workflows.map((w) => [w.id, w.name])),
       stepTitleById: new Map(allSteps.map((s) => [s.id, s.title])),

--- a/apps/web/components/task/sidebar-filter/use-filter-value-options.test.ts
+++ b/apps/web/components/task/sidebar-filter/use-filter-value-options.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect } from "vitest";
 import type { WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
-import { workflowStepOptions } from "./use-filter-value-options";
+import type { Repository } from "@/lib/types/http";
+import { repositorySlug } from "@/lib/repository-slug";
+import { repositoryOptions, workflowStepOptions } from "./use-filter-value-options";
+
+function repo(overrides: Partial<Repository>): Repository {
+  return {
+    id: "r1",
+    workspace_id: "w1",
+    name: "",
+    source_type: "local",
+    local_path: "",
+    provider: "",
+    provider_repo_id: "",
+    provider_owner: "",
+    provider_name: "",
+    default_branch: "main",
+    ...overrides,
+  } as Repository;
+}
 
 function snapshot(
   id: string,
@@ -19,6 +37,25 @@ function snapshot(
     tasks: [],
   };
 }
+
+describe("repositoryOptions (#1213)", () => {
+  // The option value becomes the saved filter clause value. It MUST equal what
+  // the task board sets as each task's repositoryPath (repositorySlug) — for a
+  // local repo that is the repo name, NOT the full local_path. Using local_path
+  // here was the bug: the clause matched no task and the board went empty.
+  it("uses repositorySlug as the option value (local repo → name, not local_path)", () => {
+    const local = repo({ name: "kandev", local_path: "/home/carlos/Projects/kandev" });
+    const provider = repo({ provider_owner: "kdlbs", provider_name: "kandev-web" });
+    const options = repositoryOptions({ w1: [local, provider] });
+    expect(options).toEqual([
+      { value: repositorySlug(local), label: repositorySlug(local) },
+      { value: repositorySlug(provider), label: repositorySlug(provider) },
+    ]);
+    expect(options[0].value).toBe("kandev");
+    expect(options[0].value).not.toBe(local.local_path);
+    expect(options[1].value).toBe("kdlbs/kandev-web");
+  });
+});
 
 describe("workflowStepOptions", () => {
   it("tags each step with its workflow name as the group", () => {

--- a/apps/web/components/task/sidebar-filter/use-filter-value-options.ts
+++ b/apps/web/components/task/sidebar-filter/use-filter-value-options.ts
@@ -5,6 +5,7 @@ import { useAppStore } from "@/components/state-provider";
 import type { AppState } from "@/lib/state/store";
 import type { FilterDimension } from "@/lib/state/slices/ui/sidebar-view-types";
 import { getExecutorLabel } from "@/lib/executor-icons";
+import { repositorySlug } from "@/lib/repository-slug";
 
 type Option = { value: string; label: string; color?: string; group?: string };
 type Snapshots = AppState["kanbanMulti"]["snapshots"];
@@ -45,11 +46,10 @@ function executorTypeOptions(snapshots: Snapshots): Option[] {
   return [...seen].sort().map((v) => ({ value: v, label: getExecutorLabel(v) }));
 }
 
-function repositoryOptions(repositoriesByWorkspace: ReposByWorkspace): Option[] {
+export function repositoryOptions(repositoriesByWorkspace: ReposByWorkspace): Option[] {
   const repos = Object.values(repositoriesByWorkspace).flat();
   return repos.map((r) => {
-    const slug =
-      r.provider_owner && r.provider_name ? `${r.provider_owner}/${r.provider_name}` : r.local_path;
+    const slug = repositorySlug(r);
     return { value: slug, label: slug };
   });
 }

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -24,6 +24,7 @@ import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-pr
 import { useTaskActions, useArchiveAndSwitchTask } from "@/hooks/use-task-actions";
 import { useTaskRemoval } from "@/hooks/use-task-removal";
 import { findTaskInSnapshots } from "@/lib/kanban/find-task";
+import { repositorySlug } from "@/lib/repository-slug";
 import { buildSwitchToSession, selectTaskWithLayout } from "./task-select-helpers";
 import { getSessionInfoForTask } from "@/lib/utils/session-info";
 import { getWebSocketClient } from "@/lib/ws/connection";
@@ -239,12 +240,7 @@ function useSidebarData(workspaceId: string | null) {
   const tasksWithRepositories = useMemo(() => {
     const repositories = workspaceId ? (repositoriesByWorkspace[workspaceId] ?? []) : [];
     const repositorySlugById = new Map(
-      repositories.map((repo: Repository) => [
-        repo.id,
-        repo.provider_owner && repo.provider_name
-          ? `${repo.provider_owner}/${repo.provider_name}`
-          : repo.name || repo.local_path?.split("/").filter(Boolean).pop() || repo.local_path,
-      ]),
+      repositories.map((repo: Repository) => [repo.id, repositorySlug(repo)]),
     );
     const titleById = new Map(allTasks.map((t) => [t.id, t.title]));
     const workflowNameById = new Map(workflows.map((w) => [w.id, w.name]));

--- a/apps/web/e2e/pages/sidebar-filter-popover.ts
+++ b/apps/web/e2e/pages/sidebar-filter-popover.ts
@@ -114,6 +114,13 @@ export class SidebarFilterPopoverPage {
     await this.clauseRow(index).getByTestId("filter-value-input").fill(value);
   }
 
+  /** Pick a single-select enum clause value (e.g. repository) by its option label. */
+  async setClauseEnumValue(index: number, optionLabel: string): Promise<void> {
+    const trigger = this.clauseRow(index).getByTestId("filter-value-select");
+    await trigger.click();
+    await this.page.getByRole("option", { name: optionLabel, exact: true }).first().click();
+  }
+
   async removeClause(index: number): Promise<void> {
     await this.clauseRow(index).getByTestId("filter-clause-remove").click();
   }

--- a/apps/web/e2e/pages/sidebar-filter-popover.ts
+++ b/apps/web/e2e/pages/sidebar-filter-popover.ts
@@ -118,7 +118,9 @@ export class SidebarFilterPopoverPage {
   async setClauseEnumValue(index: number, optionLabel: string): Promise<void> {
     const trigger = this.clauseRow(index).getByTestId("filter-value-select");
     await trigger.click();
-    await this.page.getByRole("option", { name: optionLabel, exact: true }).first().click();
+    // No .first(): exact:true + unique slugs mean a single match, so Playwright's
+    // strict mode surfaces a duplicate-option regression instead of masking it.
+    await this.page.getByRole("option", { name: optionLabel, exact: true }).click();
   }
 
   async removeClause(index: number): Promise<void> {

--- a/apps/web/e2e/tests/task/sidebar-filter.spec.ts
+++ b/apps/web/e2e/tests/task/sidebar-filter.spec.ts
@@ -12,7 +12,11 @@
  *   - Draft semantics + discard
  *   - Last-view deletion guard
  */
+import path from "node:path";
+import fs from "node:fs";
+import { execSync } from "node:child_process";
 import { test, expect } from "../../fixtures/test-base";
+import { makeGitEnv } from "../../helpers/git-helper";
 import { SessionPage } from "../../pages/session-page";
 import { SidebarFilterPopoverPage } from "../../pages/sidebar-filter-popover";
 
@@ -301,6 +305,67 @@ test.describe("Sidebar filter — saved views CRUD", () => {
     const { filters } = await openWithSeed(testPage, apiClient, seedData, ["Last View Task"]);
     await filters.open();
     await expect(filters.popover.getByTestId("view-delete-button")).toHaveCount(0);
+  });
+});
+
+test.describe("Sidebar filter — repository dimension (#1213)", () => {
+  test("filtering by a repository keeps only that repo's tasks (not an empty board)", async ({
+    testPage,
+    apiClient,
+    backend,
+    seedData,
+  }) => {
+    // The default seeded repo is a LOCAL repo (no GitHub provider), named
+    // "E2E Repo". Regression for #1213: a local repo's filter option value used
+    // to be its full local_path while each task carried the repo *name*, so a
+    // saved repository clause matched nothing and the board went empty.
+
+    // A second, distinct local repo so we can prove the clause keeps matches and
+    // drops non-matches.
+    const repoBName = "Second E2E Repo";
+    const repoBDir = path.join(backend.tmpDir, "repos", "e2e-repo-filter-b");
+    fs.mkdirSync(repoBDir, { recursive: true });
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    execSync("git init -b main", { cwd: repoBDir, env: gitEnv });
+    execSync('git commit --allow-empty -m "init"', { cwd: repoBDir, env: gitEnv });
+    const repoB = await apiClient.createRepository(seedData.workspaceId, repoBDir, "main", {
+      name: repoBName,
+    });
+
+    await apiClient.createTask(seedData.workspaceId, "Task in repo A", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+    await apiClient.createTask(seedData.workspaceId, "Task in repo B", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [repoB.id],
+    });
+
+    const navTask = await apiClient.createTask(seedData.workspaceId, "Repo Filter Nav", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    await testPage.goto(`/t/${navTask.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await expect(session.sidebar).toBeVisible({ timeout: 10_000 });
+    const filters = new SidebarFilterPopoverPage(testPage);
+    await expect(filters.bar).toBeVisible();
+
+    // Both tasks visible before filtering.
+    await expect(session.sidebar.getByText("Task in repo A")).toBeVisible();
+    await expect(session.sidebar.getByText("Task in repo B")).toBeVisible();
+
+    await filters.addFilterRow();
+    await filters.setClauseDimension(0, "Repository");
+    await filters.setClauseEnumValue(0, "E2E Repo");
+    await filters.close();
+
+    // Repo A's task survives (this was empty before the fix); repo B's is hidden.
+    await expect(session.sidebar.getByText("Task in repo A")).toBeVisible();
+    await expect(session.sidebar.getByText("Task in repo B")).toHaveCount(0);
   });
 });
 

--- a/apps/web/lib/repository-slug.test.ts
+++ b/apps/web/lib/repository-slug.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import type { Repository } from "@/lib/types/http";
+import { repositorySlug } from "./repository-slug";
+
+function repo(overrides: Partial<Repository>): Repository {
+  return {
+    id: "r1",
+    workspace_id: "w1",
+    name: "",
+    source_type: "local",
+    local_path: "",
+    provider: "",
+    provider_repo_id: "",
+    provider_owner: "",
+    provider_name: "",
+    default_branch: "main",
+    ...overrides,
+  } as Repository;
+}
+
+describe("repositorySlug", () => {
+  it("uses owner/name for provider-backed repos", () => {
+    expect(repositorySlug(repo({ provider_owner: "kdlbs", provider_name: "kandev" }))).toBe(
+      "kdlbs/kandev",
+    );
+  });
+
+  it("falls back to the repo name for local repos (matches board grouping identity)", () => {
+    expect(
+      repositorySlug(repo({ name: "kandev", local_path: "/home/carlos/Projects/kandev" })),
+    ).toBe("kandev");
+  });
+
+  it("falls back to the last path segment when name is empty", () => {
+    expect(repositorySlug(repo({ name: "", local_path: "/home/carlos/Projects/kandev" }))).toBe(
+      "kandev",
+    );
+  });
+
+  it("falls back to the full local_path when nothing else is available", () => {
+    expect(repositorySlug(repo({ name: "", local_path: "kandev" }))).toBe("kandev");
+  });
+});

--- a/apps/web/lib/repository-slug.test.ts
+++ b/apps/web/lib/repository-slug.test.ts
@@ -37,7 +37,9 @@ describe("repositorySlug", () => {
     );
   });
 
-  it("falls back to the full local_path when nothing else is available", () => {
-    expect(repositorySlug(repo({ name: "", local_path: "kandev" }))).toBe("kandev");
+  it("falls back to the full local_path when no path segment is available", () => {
+    // "/" collapses to an empty array after split/filter, so the final
+    // `|| repo.local_path` branch is the one actually exercised here.
+    expect(repositorySlug(repo({ name: "", local_path: "/" }))).toBe("/");
   });
 });

--- a/apps/web/lib/repository-slug.ts
+++ b/apps/web/lib/repository-slug.ts
@@ -1,0 +1,18 @@
+import type { Repository } from "@/lib/types/http";
+
+/**
+ * Canonical identity string for a repository, used as both the task board's
+ * per-task `repositoryPath` and the sidebar filter's selectable option value
+ * (and the repository grouping key). Both sides MUST derive it the same way —
+ * otherwise a saved repository filter compares a clause value against a task
+ * field that was built differently and silently matches nothing (#1213).
+ *
+ * Provider-backed repos use the `owner/name` slug; local repos fall back to the
+ * repo name, then the last path segment, then the raw local path.
+ */
+export function repositorySlug(repo: Repository): string {
+  if (repo.provider_owner && repo.provider_name) {
+    return `${repo.provider_owner}/${repo.provider_name}`;
+  }
+  return repo.name || repo.local_path?.split("/").filter(Boolean).pop() || repo.local_path;
+}

--- a/apps/web/lib/repository-slug.ts
+++ b/apps/web/lib/repository-slug.ts
@@ -1,18 +1,14 @@
 import type { Repository } from "@/lib/types/http";
 
 /**
- * Canonical identity string for a repository, used as both the task board's
- * per-task `repositoryPath` and the sidebar filter's selectable option value
- * (and the repository grouping key). Both sides MUST derive it the same way —
- * otherwise a saved repository filter compares a clause value against a task
- * field that was built differently and silently matches nothing (#1213).
- *
- * Provider-backed repos use the `owner/name` slug; local repos fall back to the
- * repo name, then the last path segment, then the raw local path.
+ * Canonical identity for a repository — the task board's per-task
+ * `repositoryPath`, the sidebar filter's option value, and the grouping key.
+ * All sites MUST derive it identically, or a saved repo filter compares
+ * mismatched strings and silently matches nothing (#1213).
  */
 export function repositorySlug(repo: Repository): string {
   if (repo.provider_owner && repo.provider_name) {
     return `${repo.provider_owner}/${repo.provider_name}`;
   }
-  return repo.name || repo.local_path?.split("/").filter(Boolean).pop() || repo.local_path;
+  return repo.name || repo.local_path.split("/").filter(Boolean).pop() || repo.local_path;
 }

--- a/apps/web/lib/sidebar/apply-view.test.ts
+++ b/apps/web/lib/sidebar/apply-view.test.ts
@@ -3,6 +3,8 @@ import type { TaskSwitcherItem } from "@/components/task/task-switcher";
 import { applyFilters, applyGroup, applySort, applyView, mergeGroupOrder } from "./apply-view";
 import type { FilterClause, SidebarView } from "@/lib/state/slices/ui/sidebar-view-types";
 import { DEFAULT_VIEW } from "@/lib/state/slices/ui/sidebar-view-builtins";
+import type { Repository } from "@/lib/types/http";
+import { repositorySlug } from "@/lib/repository-slug";
 
 function task(overrides: Partial<TaskSwitcherItem>): TaskSwitcherItem {
   return {
@@ -144,6 +146,38 @@ describe("applyFilters — per-dimension", () => {
     expect(withDiff.map((t) => t.id)).toEqual(["a"]);
     const noDiff = applyFilters(tasks, [C({ dimension: "hasDiff", op: "is", value: false })]);
     expect(noDiff.map((t) => t.id).sort()).toEqual(["b", "c"]);
+  });
+});
+
+describe("applyFilters — repository (#1213)", () => {
+  // The saved clause value is the filter option value, and the board sets each
+  // task's repositoryPath — BOTH via repositorySlug. For a local repo the slug
+  // is the repo name (not the full local_path). The bug was that the option
+  // value used local_path while the board used the name, so the clause matched
+  // nothing and the board went empty.
+  it("filters by a local repository (option value matches the board task field)", () => {
+    const localRepo = {
+      id: "r1",
+      workspace_id: "w1",
+      name: "kandev",
+      source_type: "local",
+      local_path: "/home/carlos/Projects/kandev",
+      provider: "",
+      provider_repo_id: "",
+      provider_owner: "",
+      provider_name: "",
+      default_branch: "main",
+    } as Repository;
+    const optionValue = repositorySlug(localRepo);
+    // The option value is the repo name, never the full filesystem path.
+    expect(optionValue).toBe("kandev");
+    expect(optionValue).not.toBe(localRepo.local_path);
+    const tasks = [
+      task({ id: "a", repositoryPath: repositorySlug(localRepo) }),
+      task({ id: "b", repositoryPath: "org/other" }),
+    ];
+    const out = applyFilters(tasks, [C({ dimension: "repository", op: "is", value: optionValue })]);
+    expect(out.map((t) => t.id)).toEqual(["a"]);
   });
 });
 


### PR DESCRIPTION
Saving a repository filter on the task board emptied the board instead of showing the selected repo's tasks, because the filter's saved clause value and each task's `repositoryPath` were derived from the same `Repository` objects by two divergent slug functions — for a local (non-GitHub) repo the option used `local_path` while the board used the repo name, so the clause matched nothing. A single shared `repositorySlug()` helper now drives both sides, so the option value always equals the task field the predicate reads.

## Important Changes

- New `apps/web/lib/repository-slug.ts` is the canonical repository identity (provider repos → `owner/name`, local repos → name → last path segment → `local_path`).
- Routed the filter options (`use-filter-value-options.ts`), the desktop board (`task-session-sidebar.tsx`), and the mobile switcher (`session-task-switcher-sheet-hooks.ts`, which also runs `applyView`) through the helper. The mobile path previously used `local_path` and would have broken in the opposite direction without this.

## Validation

- `pnpm --filter @kandev/web lint typecheck` — clean
- `vitest run` on `repository-slug`, `apply-view`, `use-filter-value-options` — 63 passed
- Red→green proof: reintroducing the bug (`option value = local_path`) fails the new `use-filter-value-options` guard; restoring passes
- New e2e `tests/task/sidebar-filter.spec.ts` (real backend + Next standalone + Chromium): seeds two local repos, filters by one, asserts only that repo's tasks remain — `1 passed`

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

Closes #1213