### PR TITLE
feat: add go fibonacci implementation

### DIFF
--- a/fibonacci/fib.go
+++ b/fibonacci/fib.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func Fib(n int) (uint64, error) {
+	if n < 0 {
+		return 0, fmt.Errorf("n must be non-negative")
+	}
+	var a, b uint64 = 0, 1
+	for i := 0; i < n; i++ {
+		a, b = b, a+b
+	}
+	return a, nil
+}
+
+func main() {
+	n := 10
+	if len(os.Args) > 1 {
+		v, err := strconv.Atoi(os.Args[1])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "invalid n:", err)
+			os.Exit(1)
+		}
+		n = v
+	}
+	r, err := Fib(n)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println(r)
+}


### PR DESCRIPTION
## Summary
- Add iterative Go fibonacci at `fibonacci/fib.go`
- CLI arg or default n=10
- Returns `uint64`, errors on negative input

## Test plan
- [ ] `go run fibonacci/fib.go 10` → `55`
- [ ] `go run fibonacci/fib.go 0` → `0`
- [ ] negative arg exits non-zero with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)