### PR TITLE
feat(fibo): add memoized recursive Fibonacci helper

### DIFF
--- a/apps/backend/internal/fibo/fibo.go
+++ b/apps/backend/internal/fibo/fibo.go
@@ -1,0 +1,24 @@
+// Package fibo computes Fibonacci numbers via top-down memoized recursion.
+package fibo
+
+// Fib returns the n-th Fibonacci number (Fib(0)=0, Fib(1)=1).
+// Negative n is treated as 0.
+func Fib(n int) uint64 {
+	if n <= 0 {
+		return 0
+	}
+	memo := make(map[int]uint64, n+1)
+	return fibMemo(n, memo)
+}
+
+func fibMemo(n int, memo map[int]uint64) uint64 {
+	if n < 2 {
+		return uint64(n)
+	}
+	if v, ok := memo[n]; ok {
+		return v
+	}
+	v := fibMemo(n-1, memo) + fibMemo(n-2, memo)
+	memo[n] = v
+	return v
+}

--- a/apps/backend/internal/fibo/fibo_test.go
+++ b/apps/backend/internal/fibo/fibo_test.go
@@ -1,0 +1,24 @@
+package fibo
+
+import "testing"
+
+func TestFib(t *testing.T) {
+	cases := []struct {
+		n    int
+		want uint64
+	}{
+		{-1, 0},
+		{0, 0},
+		{1, 1},
+		{2, 1},
+		{3, 2},
+		{10, 55},
+		{20, 6765},
+		{50, 12586269025},
+	}
+	for _, c := range cases {
+		if got := Fib(c.n); got != c.want {
+			t.Errorf("Fib(%d) = %d, want %d", c.n, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `apps/backend/internal/fibo` package with `Fib(n)` using top-down memoized recursion.
- Negative `n` returns 0; returns `uint64`.
- Unit tests cover edge cases and known values up to n=50.

## Test plan
- [x] `go test ./internal/fibo/...` passes from `apps/backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)