### PR TITLE
feat(fibo): add iterative Fibonacci helper

### DIFF
--- a/apps/backend/internal/fibo/fibo.go
+++ b/apps/backend/internal/fibo/fibo.go
@@ -1,0 +1,15 @@
+// Package fibo computes Fibonacci numbers via an iterative loop.
+package fibo
+
+// Fib returns the n-th Fibonacci number (Fib(0)=0, Fib(1)=1).
+// Negative n is treated as 0.
+func Fib(n int) uint64 {
+	if n <= 0 {
+		return 0
+	}
+	var a, b uint64 = 0, 1
+	for i := 2; i <= n; i++ {
+		a, b = b, a+b
+	}
+	return b
+}

--- a/apps/backend/internal/fibo/fibo_test.go
+++ b/apps/backend/internal/fibo/fibo_test.go
@@ -1,0 +1,24 @@
+package fibo
+
+import "testing"
+
+func TestFib(t *testing.T) {
+	cases := []struct {
+		n    int
+		want uint64
+	}{
+		{-1, 0},
+		{0, 0},
+		{1, 1},
+		{2, 1},
+		{3, 2},
+		{10, 55},
+		{20, 6765},
+		{50, 12586269025},
+	}
+	for _, c := range cases {
+		if got := Fib(c.n); got != c.want {
+			t.Errorf("Fib(%d) = %d, want %d", c.n, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `apps/backend/internal/fibo` package with `Fib(n)` using a bottom-up iterative loop (O(n) time, O(1) space).
- Negative `n` returns 0; returns `uint64`.
- Unit tests cover edge cases and known values up to n=50.

## Test plan
- [x] `go test ./internal/fibo/...` passes from `apps/backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)