### PR TITLE
feat(web): show inline download progress for Whisper Web model

### DIFF
--- a/apps/web/components/task/chat/voice-input-button.tsx
+++ b/apps/web/components/task/chat/voice-input-button.tsx
@@ -267,7 +267,7 @@ function EnabledVoiceInputButton({ onTranscript, onAutoSend, disabled }: VoiceIn
         </TooltipTrigger>
         <TooltipContent>
           {modelLoad.state === "loading"
-            ? `Loading model… ${Math.round(modelLoad.progress * 100)}%`
+            ? `Downloading ${modelLabel}… ${Math.round(modelLoad.progress * 100)}%`
             : `${TOOLTIP_BY_STATE[state]}${holdMode && state === "idle" ? " (hold)" : ""}`}
         </TooltipContent>
       </Tooltip>

--- a/apps/web/components/task/chat/voice-input-button.tsx
+++ b/apps/web/components/task/chat/voice-input-button.tsx
@@ -16,6 +16,8 @@ import { useAppStore } from "@/components/state-provider";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 import { useToast } from "@/components/toast-provider";
 import { getShortcut } from "@/lib/keyboard/shortcut-overrides";
+import { whisperModelConfig } from "@/lib/voice/whisper-web-models";
+import { VoiceModelLoadIndicator } from "./voice-model-load-indicator";
 
 type VoiceInputButtonProps = {
   /** Inserts the recognized transcript at the current cursor position. */
@@ -222,44 +224,53 @@ function EnabledVoiceInputButton({ onTranscript, onAutoSend, disabled }: VoiceIn
   const pointerHandlers = holdMode ? buildHoldHandlers(start, stop) : {};
   const onClick = holdMode ? undefined : buildToggleHandler(state, start, stop);
 
+  const modelLabel = whisperModelConfig(voiceMode.whisperWebModel).label;
+
   // Styled to mirror SubmitButton (h-7 w-7 rounded-full primary fill) so the
   // two prominent input actions read as a pair on the right of the toolbar.
   // Recording flips to a destructive fill with a pulsing ring so the active
   // state is unmistakable even on mobile.
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          type="button"
-          variant="default"
-          size="icon"
-          aria-label={ARIA_BY_STATE[state]}
-          aria-pressed={isRecording}
-          data-testid="voice-input-button"
-          data-state={state}
-          data-mode={voiceMode.mode}
-          disabled={!!disabled || (isBusy && state !== "recording")}
-          onClick={onClick}
-          {...pointerHandlers}
-          className={cn(
-            "h-7 w-7 rounded-full cursor-pointer relative select-none",
-            isRecording && "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-          )}
-        >
-          <ButtonIcon state={state} modelLoad={modelLoad} />
-          {isRecording && (
-            <span
-              aria-hidden
-              className="absolute inset-0 rounded-full ring-2 ring-destructive/40 animate-pulse"
-            />
-          )}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        {modelLoad.state === "loading"
-          ? `Loading model… ${Math.round(modelLoad.progress * 100)}%`
-          : `${TOOLTIP_BY_STATE[state]}${holdMode && state === "idle" ? " (hold)" : ""}`}
-      </TooltipContent>
-    </Tooltip>
+    <div className="flex items-center gap-1.5">
+      <VoiceModelLoadIndicator
+        state={modelLoad.state}
+        progress={modelLoad.progress}
+        modelLabel={modelLabel}
+      />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="default"
+            size="icon"
+            aria-label={ARIA_BY_STATE[state]}
+            aria-pressed={isRecording}
+            data-testid="voice-input-button"
+            data-state={state}
+            data-mode={voiceMode.mode}
+            disabled={!!disabled || (isBusy && state !== "recording")}
+            onClick={onClick}
+            {...pointerHandlers}
+            className={cn(
+              "h-7 w-7 rounded-full cursor-pointer relative select-none",
+              isRecording && "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+            )}
+          >
+            <ButtonIcon state={state} modelLoad={modelLoad} />
+            {isRecording && (
+              <span
+                aria-hidden
+                className="absolute inset-0 rounded-full ring-2 ring-destructive/40 animate-pulse"
+              />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {modelLoad.state === "loading"
+            ? `Loading model… ${Math.round(modelLoad.progress * 100)}%`
+            : `${TOOLTIP_BY_STATE[state]}${holdMode && state === "idle" ? " (hold)" : ""}`}
+        </TooltipContent>
+      </Tooltip>
+    </div>
   );
 }

--- a/apps/web/components/task/chat/voice-input-button.tsx
+++ b/apps/web/components/task/chat/voice-input-button.tsx
@@ -267,7 +267,7 @@ function EnabledVoiceInputButton({ onTranscript, onAutoSend, disabled }: VoiceIn
         </TooltipTrigger>
         <TooltipContent>
           {modelLoad.state === "loading"
-            ? `Downloading ${modelLabel}… ${Math.round(modelLoad.progress * 100)}%`
+            ? `Downloading ${modelLabel}… ${Math.min(100, Math.max(0, Math.round(modelLoad.progress * 100)))}%`
             : `${TOOLTIP_BY_STATE[state]}${holdMode && state === "idle" ? " (hold)" : ""}`}
         </TooltipContent>
       </Tooltip>

--- a/apps/web/components/task/chat/voice-input-button.tsx
+++ b/apps/web/components/task/chat/voice-input-button.tsx
@@ -267,7 +267,7 @@ function EnabledVoiceInputButton({ onTranscript, onAutoSend, disabled }: VoiceIn
         </TooltipTrigger>
         <TooltipContent>
           {modelLoad.state === "loading"
-            ? `Downloading ${modelLabel}… ${Math.min(100, Math.max(0, Math.round(modelLoad.progress * 100)))}%`
+            ? `Downloading ${modelLabel}… ${Number.isFinite(modelLoad.progress) ? Math.min(100, Math.max(0, Math.round(modelLoad.progress * 100))) : 0}%`
             : `${TOOLTIP_BY_STATE[state]}${holdMode && state === "idle" ? " (hold)" : ""}`}
         </TooltipContent>
       </Tooltip>

--- a/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
@@ -33,7 +33,9 @@ describe("VoiceModelLoadIndicator", () => {
     const root = getIndicator();
     expect(root.getAttribute("data-state")).toBe("loading");
     expect(root.textContent).toContain("Downloading Whisper Base… 42%");
-    expect(root.getAttribute("aria-label")).toBe("Downloading Whisper Base, 42 percent");
+    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe(
+      "Downloading Whisper Base, 42 percent",
+    );
   });
 
   it("renders an error label when state is error", () => {

--- a/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
@@ -40,7 +40,7 @@ describe("VoiceModelLoadIndicator", () => {
     render(<VoiceModelLoadIndicator state="error" progress={0} modelLabel={MODEL_LABEL} />);
     const root = getIndicator();
     expect(root.getAttribute("data-state")).toBe("error");
-    expect(root.textContent).toContain("Voice model failed to load");
+    expect(root.textContent).toContain(`${MODEL_LABEL} failed to load`);
   });
 
   it("clamps percent to 0–100 when progress is out of range", () => {

--- a/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VoiceModelLoadIndicator } from "./voice-model-load-indicator";
+
+const MODEL_LABEL = "Whisper Base";
+const INDICATOR_TESTID = "voice-model-load-indicator";
+
+function getIndicator() {
+  return screen.getByTestId(INDICATOR_TESTID);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("VoiceModelLoadIndicator", () => {
+  it("renders nothing when state is idle", () => {
+    const { container } = render(
+      <VoiceModelLoadIndicator state="idle" progress={0} modelLabel={MODEL_LABEL} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when state is ready", () => {
+    const { container } = render(
+      <VoiceModelLoadIndicator state="ready" progress={1} modelLabel={MODEL_LABEL} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders progress bar and percent text when loading", () => {
+    render(<VoiceModelLoadIndicator state="loading" progress={0.42} modelLabel={MODEL_LABEL} />);
+    const root = getIndicator();
+    expect(root.getAttribute("data-state")).toBe("loading");
+    expect(root.textContent).toContain("Downloading Whisper Base… 42%");
+    expect(root.getAttribute("aria-label")).toBe("Downloading Whisper Base, 42 percent");
+  });
+
+  it("renders an error label when state is error", () => {
+    render(<VoiceModelLoadIndicator state="error" progress={0} modelLabel={MODEL_LABEL} />);
+    const root = getIndicator();
+    expect(root.getAttribute("data-state")).toBe("error");
+    expect(root.textContent).toContain("Voice model failed to load");
+  });
+
+  it("clamps percent to 0–100 when progress is out of range", () => {
+    render(<VoiceModelLoadIndicator state="loading" progress={1.5} modelLabel={MODEL_LABEL} />);
+    expect(getIndicator().textContent).toContain("100%");
+    cleanup();
+
+    render(<VoiceModelLoadIndicator state="loading" progress={-0.5} modelLabel={MODEL_LABEL} />);
+    expect(getIndicator().textContent).toContain("0%");
+    cleanup();
+
+    render(
+      <VoiceModelLoadIndicator state="loading" progress={Number.NaN} modelLabel={MODEL_LABEL} />,
+    );
+    expect(getIndicator().textContent).toContain("0%");
+  });
+});

--- a/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.test.tsx
@@ -43,6 +43,7 @@ describe("VoiceModelLoadIndicator", () => {
     const root = getIndicator();
     expect(root.getAttribute("data-state")).toBe("error");
     expect(root.textContent).toContain(`${MODEL_LABEL} failed to load`);
+    expect(root.getAttribute("aria-label")).toBe(`${MODEL_LABEL} failed to load`);
   });
 
   it("clamps percent to 0–100 when progress is out of range", () => {

--- a/apps/web/components/task/chat/voice-model-load-indicator.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.tsx
@@ -25,38 +25,47 @@ export function VoiceModelLoadIndicator({
 }: VoiceModelLoadIndicatorProps) {
   if (state === "idle" || state === "ready") return null;
 
-  if (state === "error") {
-    return (
-      <div
-        data-testid="voice-model-load-indicator"
-        data-state="error"
-        className="flex items-center gap-1 text-xs text-destructive"
-        role="status"
-        aria-live="polite"
-        aria-label={`${modelLabel} failed to load`}
-      >
-        <IconAlertTriangle className="h-3.5 w-3.5 shrink-0" />
-        <span className="hidden sm:inline">Voice model failed to load</span>
-      </div>
-    );
-  }
-
   const pct = clampPercent(progress);
+
+  // Single stable role="status" wrapper so AT announces the loading→error
+  // transition (a newly-inserted live region would be silently ignored).
+  // The inner progressbar role handles numeric progress without announcing
+  // every percent tick.
   return (
     <div
       data-testid="voice-model-load-indicator"
-      data-state="loading"
-      className="flex items-center gap-1.5 w-32"
+      data-state={state}
       role="status"
-      aria-live="polite"
-      aria-label={`Downloading ${modelLabel}, ${pct} percent`}
+      aria-label={
+        state === "error"
+          ? `${modelLabel} failed to load`
+          : `Downloading ${modelLabel}, ${pct} percent`
+      }
+      className={
+        state === "error"
+          ? "flex items-center gap-1 text-xs text-destructive"
+          : "flex items-center gap-1.5 w-32"
+      }
     >
-      <div className="flex flex-col gap-0.5 min-w-0 flex-1">
-        <span className="hidden sm:inline text-[10px] leading-none text-muted-foreground truncate">
-          Downloading {modelLabel}… {pct}%
-        </span>
-        <Progress value={pct} className="h-1" />
-      </div>
+      {state === "error" ? (
+        <>
+          <IconAlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          <span className="hidden sm:inline">{modelLabel} failed to load</span>
+        </>
+      ) : (
+        <div
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          className="flex flex-col gap-0.5 min-w-0 flex-1"
+        >
+          <span className="hidden sm:inline text-[10px] leading-none text-muted-foreground truncate">
+            Downloading {modelLabel}… {pct}%
+          </span>
+          <Progress value={pct} className="h-1" />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/task/chat/voice-model-load-indicator.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { IconAlertTriangle } from "@tabler/icons-react";
+import { Progress } from "@kandev/ui/progress";
+import { cn } from "@/lib/utils";
+
+export type VoiceModelLoadIndicatorProps = {
+  state: "idle" | "loading" | "ready" | "error";
+  /** 0–1 fraction; clamped before rendering. */
+  progress: number;
+  modelLabel: string;
+};
+
+function clampPercent(progress: number): number {
+  if (!Number.isFinite(progress)) return 0;
+  const pct = Math.round(progress * 100);
+  if (pct < 0) return 0;
+  if (pct > 100) return 100;
+  return pct;
+}
+
+export function VoiceModelLoadIndicator({
+  state,
+  progress,
+  modelLabel,
+}: VoiceModelLoadIndicatorProps) {
+  if (state === "idle" || state === "ready") return null;
+
+  if (state === "error") {
+    return (
+      <div
+        data-testid="voice-model-load-indicator"
+        data-state="error"
+        className="flex items-center gap-1 text-xs text-destructive"
+        role="status"
+        aria-live="polite"
+      >
+        <IconAlertTriangle className="h-3.5 w-3.5 shrink-0" />
+        <span className="hidden sm:inline">Voice model failed to load</span>
+      </div>
+    );
+  }
+
+  const pct = clampPercent(progress);
+  return (
+    <div
+      data-testid="voice-model-load-indicator"
+      data-state="loading"
+      className={cn("flex items-center gap-1.5 w-32 max-w-[8rem]")}
+      role="status"
+      aria-live="polite"
+      aria-label={`Downloading ${modelLabel}, ${pct} percent`}
+    >
+      <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+        <span className="hidden sm:inline text-[10px] leading-none text-muted-foreground truncate">
+          Downloading {modelLabel}… {pct}%
+        </span>
+        <Progress value={pct} className="h-1" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/task/chat/voice-model-load-indicator.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.tsx
@@ -39,7 +39,7 @@ export function VoiceModelLoadIndicator({
       aria-label={state === "error" ? `${modelLabel} failed to load` : undefined}
       className={
         state === "error"
-          ? "flex items-center gap-1 text-xs text-destructive"
+          ? "flex items-center gap-1 text-xs text-destructive w-32"
           : "flex items-center gap-1.5 w-32"
       }
     >

--- a/apps/web/components/task/chat/voice-model-load-indicator.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.tsx
@@ -29,18 +29,14 @@ export function VoiceModelLoadIndicator({
 
   // Single stable role="status" wrapper so AT announces the loading→error
   // transition (a newly-inserted live region would be silently ignored).
-  // The inner progressbar role handles numeric progress without announcing
-  // every percent tick.
+  // <Progress> (Radix) already renders its own role="progressbar" — the
+  // wrapper div intentionally has no role to avoid nested progressbar nodes.
   return (
     <div
       data-testid="voice-model-load-indicator"
       data-state={state}
       role="status"
-      aria-label={
-        state === "error"
-          ? `${modelLabel} failed to load`
-          : `Downloading ${modelLabel}, ${pct} percent`
-      }
+      aria-label={state === "error" ? `${modelLabel} failed to load` : undefined}
       className={
         state === "error"
           ? "flex items-center gap-1 text-xs text-destructive"
@@ -53,17 +49,15 @@ export function VoiceModelLoadIndicator({
           <span className="hidden sm:inline">{modelLabel} failed to load</span>
         </>
       ) : (
-        <div
-          role="progressbar"
-          aria-valuenow={pct}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          className="flex flex-col gap-0.5 min-w-0 flex-1"
-        >
+        <div className="flex flex-col gap-0.5 min-w-0 flex-1">
           <span className="hidden sm:inline text-[10px] leading-none text-muted-foreground truncate">
             Downloading {modelLabel}… {pct}%
           </span>
-          <Progress value={pct} className="h-1" />
+          <Progress
+            value={pct}
+            className="h-1"
+            aria-label={`Downloading ${modelLabel}, ${pct} percent`}
+          />
         </div>
       )}
     </div>

--- a/apps/web/components/task/chat/voice-model-load-indicator.tsx
+++ b/apps/web/components/task/chat/voice-model-load-indicator.tsx
@@ -2,7 +2,6 @@
 
 import { IconAlertTriangle } from "@tabler/icons-react";
 import { Progress } from "@kandev/ui/progress";
-import { cn } from "@/lib/utils";
 
 export type VoiceModelLoadIndicatorProps = {
   state: "idle" | "loading" | "ready" | "error";
@@ -34,6 +33,7 @@ export function VoiceModelLoadIndicator({
         className="flex items-center gap-1 text-xs text-destructive"
         role="status"
         aria-live="polite"
+        aria-label={`${modelLabel} failed to load`}
       >
         <IconAlertTriangle className="h-3.5 w-3.5 shrink-0" />
         <span className="hidden sm:inline">Voice model failed to load</span>
@@ -46,7 +46,7 @@ export function VoiceModelLoadIndicator({
     <div
       data-testid="voice-model-load-indicator"
       data-state="loading"
-      className={cn("flex items-center gap-1.5 w-32 max-w-[8rem]")}
+      className="flex items-center gap-1.5 w-32"
       role="status"
       aria-live="polite"
       aria-label={`Downloading ${modelLabel}, ${pct} percent`}


### PR DESCRIPTION
## Summary

- Adds a `VoiceModelLoadIndicator` component that renders an inline pill (thin progress bar + percent text) next to the mic button while the Whisper Web model is downloading.
- The indicator is driven by the existing `modelLoad: { state, progress }` already tracked in `useVoiceInput` — no new state, no store changes.
- Disappears automatically on `ready`/`idle`; shows a compact error label on `error`.

## Implementation notes

The download state was previously only surfaced on hover via the mic button's tooltip, making multi-second first-time downloads invisible. The new component is rendered as a flex sibling to the mic button's `<Tooltip>` wrapper inside `EnabledVoiceInputButton`, keeping the change fully contained to the voice subsystem without lifting state or threading props.

`VoiceModelLoadIndicator` is purely presentational: `state` + `progress` + `modelLabel` in, DOM out. Progress is clamped and `Math.round`-ed before render to handle the `1.0000001` edge case from transformers.js. Text is `hidden sm:inline` so only the bar shows on narrow viewports.

## Test plan

- [x] New `voice-model-load-indicator.test.tsx`: renders `null` for `idle`/`ready`; renders bar + percent for `loading` (incl. correct label, percent, `data-state`); renders error label for `error`; clamps out-of-range `progress` values.
- [x] `pnpm --filter @kandev/web test -- voice-model-load-indicator` — all 5 cases pass.
- [x] `pnpm --filter @kandev/web typecheck lint` — clean.
- [ ] Manual smoke: throttle DevTools network → first Whisper Web transcribe → indicator should appear during download and disappear when ready.

## Risks & rollback

Layout risk: sibling node in `EnabledVoiceInputButton` could shift the toolbar overflow trigger — mitigated by fixed `w-32` width, `hidden sm:inline` text, and `data-state`-driven visibility. Rollback = revert `voice-input-button.tsx` edits + delete the two new files.