### PR TITLE
feat(web): add voice mode to task create dialog

### DIFF
--- a/apps/web/components/task-create-dialog-form-body.test.tsx
+++ b/apps/web/components/task-create-dialog-form-body.test.tsx
@@ -190,6 +190,24 @@ describe("DialogPromptSection (CLI-mode parity)", () => {
     expect((last.jiraImport as { disabled: boolean } | undefined)?.disabled).toBe(false);
     expect((last.linearImport as { disabled: boolean } | undefined)?.disabled).toBe(false);
   });
+
+  it("forwards onVoiceAutoSend to TaskFormInputs", () => {
+    taskFormInputsCalls.length = 0;
+    const onVoiceAutoSend = () => {};
+    render(
+      <DialogPromptSection
+        isSessionMode={false}
+        isTaskStarted={false}
+        initialDescription=""
+        fs={makeFs()}
+        handleKeyDown={(() => {}) as never}
+        onVoiceAutoSend={onVoiceAutoSend}
+      />,
+    );
+
+    const last = taskFormInputsCalls.at(-1)!;
+    expect(last.onVoiceAutoSend).toBe(onVoiceAutoSend);
+  });
 });
 
 describe("CreateEditSelectors", () => {

--- a/apps/web/components/task-create-dialog-form-body.tsx
+++ b/apps/web/components/task-create-dialog-form-body.tsx
@@ -369,6 +369,8 @@ export type DialogPromptSectionProps = {
    * description should pass `false` so the name field wins focus.
    */
   autoFocusDescription?: boolean;
+  /** Called after a non-empty voice transcript is inserted and auto-send is on. */
+  onVoiceAutoSend?: () => void;
 };
 
 // importBindings collapses the optional Jira/Linear import callbacks into the
@@ -398,6 +400,7 @@ export function DialogPromptSection({
   descriptionPlaceholder,
   aboveDescriptionSlot,
   autoFocusDescription,
+  onVoiceAutoSend,
 }: DialogPromptSectionProps) {
   const importsEnabled = !isSessionMode && !isTaskStarted;
   const ws = workspaceId ?? null;
@@ -420,6 +423,7 @@ export function DialogPromptSection({
         isUtilityConfigured={enhance?.isConfigured}
         jiraImport={importBindings(importsEnabled, ws, onJiraImport)}
         linearImport={importBindings(importsEnabled, ws, onLinearImport)}
+        onVoiceAutoSend={onVoiceAutoSend}
       />
       {extraFormSlot}
     </>

--- a/apps/web/components/task-create-dialog-selectors.test.tsx
+++ b/apps/web/components/task-create-dialog-selectors.test.tsx
@@ -72,12 +72,70 @@ function renderTaskFormInputs(initial: string) {
   return { ...utils, textarea, ref };
 }
 
-describe("TaskFormInputs voice-input wiring", () => {
+describe("TaskFormInputs voice-input wiring — rendering", () => {
   it("renders the voice button inside the prompt toolbar", () => {
     renderTaskFormInputs("");
     expect(screen.getByTestId("voice-input-button")).toBeTruthy();
   });
 
+  it("renders the voice button in session mode too", () => {
+    const ref = createRef<TaskFormInputsHandle>();
+    render(
+      <TaskFormInputs
+        isSessionMode
+        autoFocus={false}
+        initialDescription=""
+        onDescriptionChange={() => {}}
+        onKeyDown={() => {}}
+        descriptionValueRef={ref}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByTestId("voice-input-button")).toBeTruthy();
+    expect(lastVoiceProps()).toBeTruthy();
+  });
+
+  it("forwards onVoiceAutoSend to the voice button", () => {
+    const onVoiceAutoSend = vi.fn();
+    const ref = createRef<TaskFormInputsHandle>();
+    render(
+      <TaskFormInputs
+        isSessionMode={false}
+        autoFocus={false}
+        initialDescription=""
+        onDescriptionChange={() => {}}
+        onKeyDown={() => {}}
+        descriptionValueRef={ref}
+        onVoiceAutoSend={onVoiceAutoSend}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const { onAutoSend } = lastVoiceProps();
+    onAutoSend?.();
+    expect(onVoiceAutoSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the voice button when the form is disabled", () => {
+    const ref = createRef<TaskFormInputsHandle>();
+    render(
+      <TaskFormInputs
+        isSessionMode={false}
+        autoFocus={false}
+        initialDescription=""
+        onDescriptionChange={() => {}}
+        onKeyDown={() => {}}
+        descriptionValueRef={ref}
+        disabled
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(lastVoiceProps().disabled).toBe(true);
+  });
+});
+
+describe("TaskFormInputs voice-input wiring — at-cursor splice", () => {
   it("splices the transcript at the caret with a leading space after a word", () => {
     const { textarea } = renderTaskFormInputs("hello world");
     textarea.focus();
@@ -121,42 +179,36 @@ describe("TaskFormInputs voice-input wiring", () => {
     expect(textarea.value).toBe("hello");
   });
 
-  it("forwards onVoiceAutoSend to the voice button", () => {
-    const onVoiceAutoSend = vi.fn();
-    const ref = createRef<TaskFormInputsHandle>();
-    render(
-      <TaskFormInputs
-        isSessionMode={false}
-        autoFocus={false}
-        initialDescription=""
-        onDescriptionChange={() => {}}
-        onKeyDown={() => {}}
-        descriptionValueRef={ref}
-        onVoiceAutoSend={onVoiceAutoSend}
-      />,
-      { wrapper: Wrapper },
-    );
+  it("inserts the transcript into a multi-line description at the line caret", () => {
+    const { textarea } = renderTaskFormInputs("line one\nline two");
+    textarea.focus();
+    // Caret right after "line one" on the first line — char-before is "e",
+    // non-whitespace, so a leading space is prepended.
+    textarea.setSelectionRange(8, 8);
 
-    const { onAutoSend } = lastVoiceProps();
-    onAutoSend?.();
-    expect(onVoiceAutoSend).toHaveBeenCalledTimes(1);
+    act(() => lastVoiceProps().onTranscript("added"));
+
+    expect(textarea.value).toBe("line one added\nline two");
+    expect(textarea.selectionStart).toBe(14);
   });
 
-  it("disables the voice button when the form is disabled", () => {
-    const ref = createRef<TaskFormInputsHandle>();
-    render(
-      <TaskFormInputs
-        isSessionMode={false}
-        autoFocus={false}
-        initialDescription=""
-        onDescriptionChange={() => {}}
-        onKeyDown={() => {}}
-        descriptionValueRef={ref}
-        disabled
-      />,
-      { wrapper: Wrapper },
-    );
+  it("preserves internal newlines from the transcript", () => {
+    const { textarea } = renderTaskFormInputs("");
+    textarea.focus();
+    textarea.setSelectionRange(0, 0);
 
-    expect(lastVoiceProps().disabled).toBe(true);
+    act(() => lastVoiceProps().onTranscript("first\nsecond"));
+
+    expect(textarea.value).toBe("first\nsecond");
+  });
+
+  it("treats existing tabs / newlines before the caret as whitespace (no extra space)", () => {
+    const { textarea } = renderTaskFormInputs("line\n");
+    textarea.focus();
+    textarea.setSelectionRange(5, 5);
+
+    act(() => lastVoiceProps().onTranscript("two"));
+
+    expect(textarea.value).toBe("line\ntwo");
   });
 });

--- a/apps/web/components/task-create-dialog-selectors.test.tsx
+++ b/apps/web/components/task-create-dialog-selectors.test.tsx
@@ -1,0 +1,162 @@
+import { createRef, type ReactNode } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { TaskFormInputs } from "./task-create-dialog-selectors";
+import type { TaskFormInputsHandle } from "./task-create-dialog-types";
+
+// Capture the props (notably `onTranscript` / `onAutoSend`) that
+// TaskFormInputs hands the voice button so we can drive transcripts
+// without instantiating the real VoiceInputButton (which subscribes to
+// the user-settings store and instantiates voice engines).
+type VoiceProps = {
+  onTranscript: (text: string) => void;
+  onAutoSend?: () => void;
+  disabled?: boolean;
+};
+const voiceCalls: VoiceProps[] = [];
+vi.mock("@/components/task/chat/voice-input-button", () => ({
+  VoiceInputButton: (props: VoiceProps) => {
+    voiceCalls.push(props);
+    return <button type="button" data-testid="voice-input-button" />;
+  },
+}));
+
+// Inert mention popover — the real hook installs a `keydown` listener that
+// drains React's event queue across re-renders and adds noise to assertions.
+vi.mock("@/hooks/use-task-create-prompt-mention", () => ({
+  useTaskCreatePromptMention: () => ({
+    isOpen: false,
+    isLoading: false,
+    position: null,
+    items: [],
+    query: "",
+    selectedIndex: 0,
+    handleChange: (_: string) => {},
+    handleKeyDown: (_: React.KeyboardEvent) => {},
+    handleSelect: () => {},
+    closeMenu: () => {},
+    setSelectedIndex: () => {},
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  voiceCalls.length = 0;
+});
+
+function lastVoiceProps(): VoiceProps {
+  const last = voiceCalls.at(-1);
+  if (!last) throw new Error("VoiceInputButton was not rendered");
+  return last;
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+function renderTaskFormInputs(initial: string) {
+  const ref = createRef<TaskFormInputsHandle>();
+  const utils = render(
+    <TaskFormInputs
+      isSessionMode={false}
+      autoFocus={false}
+      initialDescription={initial}
+      onDescriptionChange={() => {}}
+      onKeyDown={() => {}}
+      descriptionValueRef={ref}
+    />,
+    { wrapper: Wrapper },
+  );
+  const textarea = screen.getByTestId("task-description-input") as HTMLTextAreaElement;
+  return { ...utils, textarea, ref };
+}
+
+describe("TaskFormInputs voice-input wiring", () => {
+  it("renders the voice button inside the prompt toolbar", () => {
+    renderTaskFormInputs("");
+    expect(screen.getByTestId("voice-input-button")).toBeTruthy();
+  });
+
+  it("splices the transcript at the caret with a leading space after a word", () => {
+    const { textarea } = renderTaskFormInputs("hello world");
+    textarea.focus();
+    textarea.setSelectionRange(5, 5);
+
+    act(() => lastVoiceProps().onTranscript("there"));
+
+    expect(textarea.value).toBe("hello there world");
+    expect(textarea.selectionStart).toBe(11);
+    expect(textarea.selectionEnd).toBe(11);
+  });
+
+  it("inserts the transcript without a leading space when the caret follows whitespace", () => {
+    const { textarea } = renderTaskFormInputs("hello ");
+    textarea.focus();
+    textarea.setSelectionRange(6, 6);
+
+    act(() => lastVoiceProps().onTranscript("world"));
+
+    expect(textarea.value).toBe("hello world");
+    expect(textarea.selectionStart).toBe(11);
+  });
+
+  it("replaces selected text with the transcript", () => {
+    const { textarea } = renderTaskFormInputs("hello world");
+    textarea.focus();
+    textarea.setSelectionRange(6, 11);
+
+    act(() => lastVoiceProps().onTranscript("there"));
+
+    expect(textarea.value).toBe("hello there");
+  });
+
+  it("ignores empty / whitespace-only transcripts", () => {
+    const { textarea } = renderTaskFormInputs("hello");
+    textarea.focus();
+    textarea.setSelectionRange(5, 5);
+
+    act(() => lastVoiceProps().onTranscript("   "));
+
+    expect(textarea.value).toBe("hello");
+  });
+
+  it("forwards onVoiceAutoSend to the voice button", () => {
+    const onVoiceAutoSend = vi.fn();
+    const ref = createRef<TaskFormInputsHandle>();
+    render(
+      <TaskFormInputs
+        isSessionMode={false}
+        autoFocus={false}
+        initialDescription=""
+        onDescriptionChange={() => {}}
+        onKeyDown={() => {}}
+        descriptionValueRef={ref}
+        onVoiceAutoSend={onVoiceAutoSend}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const { onAutoSend } = lastVoiceProps();
+    onAutoSend?.();
+    expect(onVoiceAutoSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the voice button when the form is disabled", () => {
+    const ref = createRef<TaskFormInputsHandle>();
+    render(
+      <TaskFormInputs
+        isSessionMode={false}
+        autoFocus={false}
+        initialDescription=""
+        onDescriptionChange={() => {}}
+        onKeyDown={() => {}}
+        descriptionValueRef={ref}
+        disabled
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(lastVoiceProps().disabled).toBe(true);
+  });
+});

--- a/apps/web/components/task-create-dialog-selectors.tsx
+++ b/apps/web/components/task-create-dialog-selectors.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- groups all create-dialog selector subcomponents; splitting per-selector files is a separate refactor. */
 "use client";
 
-import { useEffect, useRef, useState, memo, useCallback, useMemo } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, memo, useCallback, useMemo } from "react";
 import { Textarea } from "@kandev/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { IconPaperclip } from "@tabler/icons-react";
@@ -22,6 +22,7 @@ import type { TaskFormInputsHandle } from "@/components/task-create-dialog-types
 import { EnhancePromptButton } from "@/components/enhance-prompt-button";
 import { JiraImportBar } from "@/components/jira/jira-import-bar";
 import { LinearImportBar } from "@/components/linear/linear-import-bar";
+import { VoiceInputButton } from "@/components/task/chat/voice-input-button";
 import type { JiraTicket } from "@/lib/types/jira";
 import type { LinearIssue } from "@/lib/types/linear";
 import { useTaskCreatePromptMention } from "@/hooks/use-task-create-prompt-mention";
@@ -297,6 +298,12 @@ type TaskFormInputsProps = {
     disabled?: boolean;
     onImport: (issue: LinearIssue) => void;
   };
+  /**
+   * Called after a non-empty voice transcript was inserted into the description
+   * when the user has voice auto-send enabled. The dialog wires this to a
+   * programmatic form submit so dictation can create the task hands-free.
+   */
+  onVoiceAutoSend?: () => void;
 };
 
 function useFileAttachments() {
@@ -461,6 +468,10 @@ function useDescriptionInput(
 ) {
   const [description, setDescription] = useState(initialDescription);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Caret offset to restore after a non-typed value mutation (e.g. voice
+  // transcript splice). Consumed inside useLayoutEffect so the cursor lands
+  // before the next paint and the user sees no jump.
+  const pendingCursorRef = useRef<number | null>(null);
 
   useEffect(() => {
     const ref = descriptionValueRef as React.MutableRefObject<TaskFormInputsHandle | null>;
@@ -483,6 +494,16 @@ function useDescriptionInput(
     textarea.style.height = `${textarea.scrollHeight}px`;
   }, [description]);
 
+  useLayoutEffect(() => {
+    const pos = pendingCursorRef.current;
+    if (pos === null) return;
+    pendingCursorRef.current = null;
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.focus();
+    textarea.setSelectionRange(pos, pos);
+  }, [description]);
+
   useEffect(() => {
     if (!autoFocus) return;
     const textarea = textareaRef.current;
@@ -501,7 +522,24 @@ function useDescriptionInput(
     [description, onDescriptionChange],
   );
 
-  return { description, textareaRef, setDescriptionValue };
+  const insertAtCursor = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const textarea = textareaRef.current;
+      const start = textarea?.selectionStart ?? description.length;
+      const end = textarea?.selectionEnd ?? description.length;
+      const charBefore = start > 0 ? description.charAt(start - 1) : "";
+      const needsLeadingSpace = charBefore !== "" && !/\s/.test(charBefore);
+      const insert = needsLeadingSpace ? ` ${trimmed}` : trimmed;
+      const next = description.slice(0, start) + insert + description.slice(end);
+      pendingCursorRef.current = start + insert.length;
+      setDescriptionValue(next);
+    },
+    [description, setDescriptionValue],
+  );
+
+  return { description, textareaRef, setDescriptionValue, insertAtCursor };
 }
 
 type FormInputsToolbarProps = {
@@ -512,6 +550,10 @@ type FormInputsToolbarProps = {
   isUtilityConfigured?: boolean;
   jiraImport?: TaskFormInputsProps["jiraImport"];
   linearImport?: TaskFormInputsProps["linearImport"];
+  voice?: {
+    onTranscript: (text: string) => void;
+    onAutoSend?: () => void;
+  };
 };
 
 function FormInputsToolbar({
@@ -522,6 +564,7 @@ function FormInputsToolbar({
   isUtilityConfigured,
   jiraImport,
   linearImport,
+  voice,
 }: FormInputsToolbarProps) {
   return (
     <div className="flex items-center px-1 pb-1">
@@ -546,6 +589,15 @@ function FormInputsToolbar({
           disabled={linearImport.disabled}
           onImport={linearImport.onImport}
         />
+      )}
+      {voice && (
+        <div className="ml-auto flex items-center">
+          <VoiceInputButton
+            onTranscript={voice.onTranscript}
+            onAutoSend={voice.onAutoSend}
+            disabled={disabled}
+          />
+        </div>
       )}
     </div>
   );
@@ -647,6 +699,7 @@ export const TaskFormInputs = memo(function TaskFormInputs({
   isUtilityConfigured,
   jiraImport,
   linearImport,
+  onVoiceAutoSend,
 }: TaskFormInputsProps) {
   const { attachments, isDragging, setIsDragging, addFiles, handleRemoveAttachment } =
     useFileAttachments();
@@ -659,7 +712,7 @@ export const TaskFormInputs = memo(function TaskFormInputs({
     () => toContextItems(attachments, handleRemoveAttachment),
     [attachments, handleRemoveAttachment],
   );
-  const { description, textareaRef, setDescriptionValue } = useDescriptionInput(
+  const { description, textareaRef, setDescriptionValue, insertAtCursor } = useDescriptionInput(
     initialDescription,
     autoFocus,
     descriptionValueRef,
@@ -673,6 +726,10 @@ export const TaskFormInputs = memo(function TaskFormInputs({
   });
   const { handleChange, handleKeyDown } = useTextareaHandlers(mention, onKeyDown);
   const { fileInputRef, handleAttachClick, handleFileInputChange } = useFileInputClick(addFiles);
+  const voiceBinding = useMemo(
+    () => ({ onTranscript: insertAtCursor, onAutoSend: onVoiceAutoSend }),
+    [insertAtCursor, onVoiceAutoSend],
+  );
 
   return (
     <div
@@ -711,6 +768,7 @@ export const TaskFormInputs = memo(function TaskFormInputs({
           isUtilityConfigured={isUtilityConfigured}
           jiraImport={jiraImport}
           linearImport={linearImport}
+          voice={voiceBinding}
         />
         <HiddenFileInput inputRef={fileInputRef} onChange={handleFileInputChange} />
       </div>

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -425,4 +425,11 @@ export type DialogFormBodyProps = {
   descriptionPlaceholder?: string;
   /** When true, hides the workflow picker so the enforced workflow can't be swapped. */
   workflowLocked?: boolean;
+  /**
+   * Called by the voice-input button after a non-empty transcript is inserted
+   * into the description when the user has voice auto-send enabled. The dialog
+   * routes this to a programmatic form submit so dictation can create the task
+   * hands-free.
+   */
+  onVoiceAutoSend?: () => void;
 };

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useCallback, useRef } from "react";
+import { FormEvent, useCallback } from "react";
 import type { JiraTicket } from "@/lib/types/jira";
 import type { LinearIssue } from "@/lib/types/linear";
 import { Dialog, DialogContent, DialogHeader, DialogFooter } from "@kandev/ui/dialog";
@@ -471,16 +471,24 @@ function useGuardedSubmit(
   );
 }
 
+// Synthetic submit event used by the voice auto-send path. Calling the form
+// handler directly (instead of `form.requestSubmit()`) matches the chat
+// composer's pattern and avoids the Safari < 16 gap where `requestSubmit` is
+// missing on `HTMLFormElement`. `guardedHandleSubmit` only reads
+// `preventDefault` off the event, so a stubbed shape is sufficient.
+const VOICE_SUBMIT_EVENT = { preventDefault: () => {} } as unknown as FormEvent;
+
 export function TaskCreateDialog(props: TaskCreateDialogProps) {
   const setup = useTaskCreateDialogSetup(props);
-  const formRef = useRef<HTMLFormElement>(null);
-  // Voice auto-send fires the form's native submit so every existing gate
-  // (missing title/repo/branch/agent, `submitBlockedReason`, in-flight create)
-  // still applies — the disabled submit button silently no-ops if any gate
-  // is unmet, matching the chat composer's voice auto-send behaviour.
+  const { guardedHandleSubmit } = setup;
+  // Voice auto-send invokes the same submit handler as the in-form Submit
+  // button. Every existing validation gate (missing title/repo/branch/agent,
+  // `submitBlockedReason`, in-flight create) still applies because they live
+  // inside `handleSubmit` itself, so a dictation with incomplete fields
+  // silently no-ops rather than creating a malformed task.
   const handleVoiceAutoSend = useCallback(() => {
-    formRef.current?.requestSubmit();
-  }, []);
+    guardedHandleSubmit(VOICE_SUBMIT_EVENT);
+  }, [guardedHandleSubmit]);
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent
@@ -495,11 +503,7 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
             initialTitle={props.initialValues?.title}
           />
         </DialogHeader>
-        <form
-          ref={formRef}
-          onSubmit={setup.guardedHandleSubmit}
-          className="flex flex-col gap-4 overflow-hidden"
-        >
+        <form onSubmit={guardedHandleSubmit} className="flex flex-col gap-4 overflow-hidden">
           <DialogFormBody
             {...buildDialogFormBodyProps(setup, props)}
             onVoiceAutoSend={handleVoiceAutoSend}

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useCallback } from "react";
+import { FormEvent, useCallback, useRef } from "react";
 import type { JiraTicket } from "@/lib/types/jira";
 import type { LinearIssue } from "@/lib/types/linear";
 import { Dialog, DialogContent, DialogHeader, DialogFooter } from "@kandev/ui/dialog";
@@ -168,6 +168,7 @@ function CreateModeBody(props: DialogFormBodyProps) {
         aboveDescriptionSlot={props.aboveDescriptionSlot}
         extraFormSlot={props.extraFormSlot}
         autoFocusDescription={!isTaskStarted && !(showTaskName && taskNameAutoFocus)}
+        onVoiceAutoSend={props.onVoiceAutoSend}
       />
       <CreateModeSelectors
         isTaskStarted={isTaskStarted}
@@ -201,6 +202,7 @@ function SessionModeBody(props: DialogFormBodyProps) {
         enhance={props.enhance}
         workspaceId={props.workspaceId}
         onJiraImport={props.onJiraImport}
+        onVoiceAutoSend={props.onVoiceAutoSend}
       />
       <SessionSelectors
         agentProfileOptions={props.agentProfileOptions}
@@ -471,6 +473,14 @@ function useGuardedSubmit(
 
 export function TaskCreateDialog(props: TaskCreateDialogProps) {
   const setup = useTaskCreateDialogSetup(props);
+  const formRef = useRef<HTMLFormElement>(null);
+  // Voice auto-send fires the form's native submit so every existing gate
+  // (missing title/repo/branch/agent, `submitBlockedReason`, in-flight create)
+  // still applies — the disabled submit button silently no-ops if any gate
+  // is unmet, matching the chat composer's voice auto-send behaviour.
+  const handleVoiceAutoSend = useCallback(() => {
+    formRef.current?.requestSubmit();
+  }, []);
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent
@@ -485,8 +495,15 @@ export function TaskCreateDialog(props: TaskCreateDialogProps) {
             initialTitle={props.initialValues?.title}
           />
         </DialogHeader>
-        <form onSubmit={setup.guardedHandleSubmit} className="flex flex-col gap-4 overflow-hidden">
-          <DialogFormBody {...buildDialogFormBodyProps(setup, props)} />
+        <form
+          ref={formRef}
+          onSubmit={setup.guardedHandleSubmit}
+          className="flex flex-col gap-4 overflow-hidden"
+        >
+          <DialogFormBody
+            {...buildDialogFormBodyProps(setup, props)}
+            onVoiceAutoSend={handleVoiceAutoSend}
+          />
           <DialogFooter className="border-t border-border pt-3 flex-col gap-3 sm:flex-row sm:gap-2">
             <TaskCreateDialogFooter {...buildDialogFooterProps(setup, props)} />
           </DialogFooter>


### PR DESCRIPTION
## Summary

- Adds a microphone button to the task-create dialog's prompt toolbar, mirroring the existing voice input already available in the chat composer.
- Transcript text is spliced at the current textarea cursor position (with a leading space when the preceding character is non-whitespace), preserving existing content rather than overwriting it.
- Voice auto-send wires dictation to the existing `guardedHandleSubmit` path so every validation gate (missing title/repo/branch/agent, in-flight create) still applies — incomplete fields silently no-op rather than creating malformed tasks.

## Implementation notes

The voice button (`VoiceInputButton`) already self-hides when `userSettings.voiceMode.enabled` is false and renders greyed-out when the browser lacks mic access, so no new settings or feature flags are needed.

Cursor restoration after splice uses `useLayoutEffect` keyed on a `pendingCursorRef` so the caret lands before the next paint. The auto-send path calls `guardedHandleSubmit` directly (rather than `form.requestSubmit()`) to avoid the Safari < 16 gap and to stay consistent with how the chat composer's voice auto-send works.

The `voice` prop is bundled into a single object on `FormInputsToolbar` to stay under the 5-param lint limit.

## Test plan

- [x] `task-create-dialog-selectors.test.tsx` (new, 214 lines) — 9 tests covering: button render in both create/session modes, `onVoiceAutoSend` forwarding, `disabled` propagation, at-cursor splice (word boundary, whitespace boundary, selection replace, empty transcript, multiline, embedded newlines, tab/newline as preceding whitespace)
- [x] `task-create-dialog-form-body.test.tsx` — added assertion that `onVoiceAutoSend` is forwarded through `DialogPromptSection → TaskFormInputs`
- [x] All existing `task-create-dialog-*.test.*` suites kept green
- [x] Typecheck: `pnpm --filter @kandev/web typecheck`
- [x] Lint: `pnpm --filter @kandev/web lint`
- [ ] CI run — verify `toolbar-overflow.spec.ts` still passes (the E2E uses `submit-message-button` testid, not a generic button selector, so the new mic button should not interfere)

## Risks & rollback

**Layout**: the mic button is `h-7 w-7`, same size as sibling icons; placed in an `ml-auto` wrapper on the right end of the flex toolbar row. Narrow mobile viewports should not overflow, but reviewers should check the Playwright trace on a mobile viewport if CI runs E2E.

**Form re-entry**: rapid dictation could fire multiple `handleVoiceAutoSend` calls before the first submit completes. The existing `isCreatingTask`/`isCreatingSession` guard inside `guardedHandleSubmit` short-circuits subsequent calls — same protection as the Submit button double-click path.

**Rollback**: revert the 6-file change. No migrations, no settings schema change, no API surface change.