### PR TITLE
feat(web): add reverse direction to recent task switcher

### DIFF
--- a/apps/web/components/task/recent-task-switcher-hooks.ts
+++ b/apps/web/components/task/recent-task-switcher-hooks.ts
@@ -34,14 +34,14 @@ import {
   type RecentTaskBuildContext,
   type RecentTaskDisplayItem,
 } from "./recent-task-switcher-model";
-
-/** Direction the switcher cycles through recent tasks. */
-type CycleDirection = "forward" | "backward";
 import {
   hasHoldModifier,
   isCommitReleaseEvent,
   isCycleShortcutEvent,
 } from "./recent-task-switcher-keys";
+
+/** Direction the switcher cycles through recent tasks. */
+type CycleDirection = "forward" | "backward";
 
 export type RecentTaskSwitcherController = {
   open: boolean;
@@ -64,6 +64,10 @@ type SwitcherRefs = {
   activeTaskIdRef: MutableRefObject<string | null>;
   shortcutRef: MutableRefObject<KeyboardShortcut>;
   reverseShortcutRef: MutableRefObject<KeyboardShortcut>;
+  // The binding whose hold-modifier release should commit — set to the shortcut
+  // of the direction that opened/last drove the switcher, so a divergent custom
+  // binding for the other direction can't commit early.
+  activeCommitShortcutRef: MutableRefObject<KeyboardShortcut | null>;
 };
 
 type SwitcherActions = {
@@ -211,6 +215,7 @@ function useSwitcherRefs({
   const activeTaskIdRef = useLatestRef(activeTaskId);
   const shortcutRef = useLatestRef(shortcut);
   const reverseShortcutRef = useLatestRef(reverseShortcut);
+  const activeCommitShortcutRef = useRef<KeyboardShortcut | null>(null);
 
   useEffect(() => {
     openRef.current = open;
@@ -226,6 +231,7 @@ function useSwitcherRefs({
     activeTaskIdRef,
     shortcutRef,
     reverseShortcutRef,
+    activeCommitShortcutRef,
   };
 }
 
@@ -244,6 +250,95 @@ function useSelectedIndexSetter(refs: SwitcherRefs, setRawSelectedIndex: (index:
   );
 }
 
+type SwitcherCycleActions = Pick<SwitcherActions, "openSwitcher" | "cycleSwitcher">;
+
+function useSwitcherCycleActions({
+  refs,
+  setCommandPanelOpen,
+  setOpenState,
+  setSelectedIndex,
+}: {
+  refs: SwitcherRefs;
+  setCommandPanelOpen: (open: boolean) => void;
+  setOpenState: (open: boolean) => void;
+  setSelectedIndex: (index: number) => void;
+}): SwitcherCycleActions {
+  const {
+    activeCommitShortcutRef,
+    activeTaskIdRef,
+    cancelledRef,
+    commitOnReleaseRef,
+    itemsRef,
+    openRef,
+    reverseShortcutRef,
+    selectedIndexRef,
+    shortcutRef,
+  } = refs;
+
+  const commitShortcutForDirection = useCallback(
+    (direction: CycleDirection) =>
+      direction === "backward" ? reverseShortcutRef.current : shortcutRef.current,
+    [reverseShortcutRef, shortcutRef],
+  );
+
+  const openSwitcher = useCallback(
+    (commitOnRelease: boolean, direction: CycleDirection = "forward") => {
+      setCommandPanelOpen(false);
+      cancelledRef.current = false;
+      commitOnReleaseRef.current = commitOnRelease;
+      activeCommitShortcutRef.current = commitShortcutForDirection(direction);
+      openRef.current = true;
+      const initialIndex =
+        direction === "backward"
+          ? getInitialReverseSelectionIndex(itemsRef.current, activeTaskIdRef.current)
+          : getInitialSelectionIndex(itemsRef.current, activeTaskIdRef.current);
+      setSelectedIndex(initialIndex);
+      setOpenState(true);
+    },
+    [
+      activeCommitShortcutRef,
+      activeTaskIdRef,
+      cancelledRef,
+      commitOnReleaseRef,
+      commitShortcutForDirection,
+      itemsRef,
+      openRef,
+      setCommandPanelOpen,
+      setOpenState,
+      setSelectedIndex,
+    ],
+  );
+
+  const cycleSwitcher = useCallback(
+    (commitOnRelease: boolean, direction: CycleDirection = "forward") => {
+      if (!openRef.current) {
+        openSwitcher(commitOnRelease, direction);
+        return;
+      }
+      if (commitOnRelease) commitOnReleaseRef.current = true;
+      activeCommitShortcutRef.current = commitShortcutForDirection(direction);
+      const count = itemsRef.current.length;
+      const nextIndex =
+        direction === "backward"
+          ? getPreviousSelectionIndex(selectedIndexRef.current, count)
+          : getNextSelectionIndex(selectedIndexRef.current, count);
+      setSelectedIndex(nextIndex);
+    },
+    [
+      activeCommitShortcutRef,
+      commitOnReleaseRef,
+      commitShortcutForDirection,
+      itemsRef,
+      openRef,
+      openSwitcher,
+      selectedIndexRef,
+      setSelectedIndex,
+    ],
+  );
+
+  return { openSwitcher, cycleSwitcher };
+}
+
 function useSwitcherActions({
   refs,
   routeToTask,
@@ -257,14 +352,27 @@ function useSwitcherActions({
   setOpenState: (open: boolean) => void;
   setSelectedIndex: (index: number) => void;
 }): SwitcherActions {
-  const { activeTaskIdRef, cancelledRef, commitOnReleaseRef, itemsRef, openRef, selectedIndexRef } =
-    refs;
+  const {
+    activeCommitShortcutRef,
+    cancelledRef,
+    commitOnReleaseRef,
+    itemsRef,
+    openRef,
+    selectedIndexRef,
+  } = refs;
+  const { openSwitcher, cycleSwitcher } = useSwitcherCycleActions({
+    refs,
+    setCommandPanelOpen,
+    setOpenState,
+    setSelectedIndex,
+  });
 
   const closeSwitcher = useCallback(() => {
     openRef.current = false;
     commitOnReleaseRef.current = false;
+    activeCommitShortcutRef.current = null;
     setOpenState(false);
-  }, [commitOnReleaseRef, openRef, setOpenState]);
+  }, [activeCommitShortcutRef, commitOnReleaseRef, openRef, setOpenState]);
 
   const cancelSwitcher = useCallback(() => {
     cancelledRef.current = true;
@@ -290,48 +398,6 @@ function useSwitcherActions({
       if (item) routeToTask(item.taskId);
     },
     [closeSwitcher, routeToTask],
-  );
-
-  const openSwitcher = useCallback(
-    (commitOnRelease: boolean, direction: CycleDirection = "forward") => {
-      setCommandPanelOpen(false);
-      cancelledRef.current = false;
-      commitOnReleaseRef.current = commitOnRelease;
-      openRef.current = true;
-      const initialIndex =
-        direction === "backward"
-          ? getInitialReverseSelectionIndex(itemsRef.current, activeTaskIdRef.current)
-          : getInitialSelectionIndex(itemsRef.current, activeTaskIdRef.current);
-      setSelectedIndex(initialIndex);
-      setOpenState(true);
-    },
-    [
-      activeTaskIdRef,
-      cancelledRef,
-      commitOnReleaseRef,
-      itemsRef,
-      openRef,
-      setCommandPanelOpen,
-      setOpenState,
-      setSelectedIndex,
-    ],
-  );
-
-  const cycleSwitcher = useCallback(
-    (commitOnRelease: boolean, direction: CycleDirection = "forward") => {
-      if (!openRef.current) {
-        openSwitcher(commitOnRelease, direction);
-        return;
-      }
-      if (commitOnRelease) commitOnReleaseRef.current = true;
-      const count = itemsRef.current.length;
-      const nextIndex =
-        direction === "backward"
-          ? getPreviousSelectionIndex(selectedIndexRef.current, count)
-          : getNextSelectionIndex(selectedIndexRef.current, count);
-      setSelectedIndex(nextIndex);
-    },
-    [commitOnReleaseRef, itemsRef, openRef, openSwitcher, selectedIndexRef, setSelectedIndex],
   );
 
   const selectCurrentItem = useCallback(() => {
@@ -367,7 +433,14 @@ function useRecentTaskSwitcherCommand(shortcut: KeyboardShortcut, openSwitcher: 
 }
 
 function useSwitcherGlobalKeyboard(refs: SwitcherRefs, actions: SwitcherActions) {
-  const { cancelledRef, commitOnReleaseRef, openRef, reverseShortcutRef, shortcutRef } = refs;
+  const {
+    activeCommitShortcutRef,
+    cancelledRef,
+    commitOnReleaseRef,
+    openRef,
+    reverseShortcutRef,
+    shortcutRef,
+  } = refs;
   const { cancelSwitcher, cycleSwitcher, selectCurrentItem } = actions;
 
   useEffect(() => {
@@ -400,12 +473,12 @@ function useSwitcherGlobalKeyboard(refs: SwitcherRefs, actions: SwitcherActions)
 
     const handleKeyUp = (event: KeyboardEvent) => {
       if (!openRef.current || !commitOnReleaseRef.current) return;
-      // Commit when the hold modifier of either direction is released. Both
-      // default to Ctrl/Cmd, but custom bindings may differ.
-      const released =
-        isCommitReleaseEvent(event, shortcutRef.current) ||
-        isCommitReleaseEvent(event, reverseShortcutRef.current);
-      if (!released) return;
+      // Commit only when the hold modifier of the binding that drove the
+      // switcher is released. Both directions default to Ctrl/Cmd, but custom
+      // bindings may differ — releasing the other direction's modifier must not
+      // commit early.
+      const activeShortcut = activeCommitShortcutRef.current;
+      if (!activeShortcut || !isCommitReleaseEvent(event, activeShortcut)) return;
 
       event.preventDefault();
       event.stopPropagation();
@@ -436,6 +509,7 @@ function useSwitcherGlobalKeyboard(refs: SwitcherRefs, actions: SwitcherActions)
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [
+    activeCommitShortcutRef,
     cancelSwitcher,
     cancelledRef,
     commitOnReleaseRef,

--- a/apps/web/components/task/recent-task-switcher-hooks.ts
+++ b/apps/web/components/task/recent-task-switcher-hooks.ts
@@ -27,12 +27,16 @@ import {
 import {
   buildRecentTaskDisplayItems,
   buildRecentTaskEntry,
+  getInitialReverseSelectionIndex,
   getInitialSelectionIndex,
   getNextSelectionIndex,
   getPreviousSelectionIndex,
   type RecentTaskBuildContext,
   type RecentTaskDisplayItem,
 } from "./recent-task-switcher-model";
+
+/** Direction the switcher cycles through recent tasks. */
+type CycleDirection = "forward" | "backward";
 import {
   hasHoldModifier,
   isCommitReleaseEvent,
@@ -46,6 +50,7 @@ export type RecentTaskSwitcherController = {
   selectedIndex: number;
   setSelectedIndex: (index: number) => void;
   shortcutLabel: string;
+  reverseShortcutLabel: string;
   selectItem: (item: RecentTaskDisplayItem | undefined) => void;
   handleKeyDown: (event: ReactKeyboardEvent) => void;
 };
@@ -58,14 +63,15 @@ type SwitcherRefs = {
   itemsRef: MutableRefObject<RecentTaskDisplayItem[]>;
   activeTaskIdRef: MutableRefObject<string | null>;
   shortcutRef: MutableRefObject<KeyboardShortcut>;
+  reverseShortcutRef: MutableRefObject<KeyboardShortcut>;
 };
 
 type SwitcherActions = {
   setOpen: (open: boolean) => void;
   setSelectedIndex: (index: number) => void;
   selectItem: (item: RecentTaskDisplayItem | undefined) => void;
-  openSwitcher: (commitOnRelease: boolean) => void;
-  cycleSwitcher: (commitOnRelease: boolean) => void;
+  openSwitcher: (commitOnRelease: boolean, direction?: CycleDirection) => void;
+  cycleSwitcher: (commitOnRelease: boolean, direction?: CycleDirection) => void;
   cancelSwitcher: () => void;
   selectCurrentItem: () => void;
 };
@@ -182,13 +188,21 @@ function useLatestRef<T>(value: T) {
   return ref;
 }
 
-function useSwitcherRefs(
-  open: boolean,
-  selectedIndex: number,
-  items: RecentTaskDisplayItem[],
-  activeTaskId: string | null,
-  shortcut: KeyboardShortcut,
-): SwitcherRefs {
+function useSwitcherRefs({
+  open,
+  selectedIndex,
+  items,
+  activeTaskId,
+  shortcut,
+  reverseShortcut,
+}: {
+  open: boolean;
+  selectedIndex: number;
+  items: RecentTaskDisplayItem[];
+  activeTaskId: string | null;
+  shortcut: KeyboardShortcut;
+  reverseShortcut: KeyboardShortcut;
+}): SwitcherRefs {
   const openRef = useRef(open);
   const selectedIndexRef = useRef(selectedIndex);
   const commitOnReleaseRef = useRef(false);
@@ -196,6 +210,7 @@ function useSwitcherRefs(
   const itemsRef = useLatestRef(items);
   const activeTaskIdRef = useLatestRef(activeTaskId);
   const shortcutRef = useLatestRef(shortcut);
+  const reverseShortcutRef = useLatestRef(reverseShortcut);
 
   useEffect(() => {
     openRef.current = open;
@@ -210,6 +225,7 @@ function useSwitcherRefs(
     itemsRef,
     activeTaskIdRef,
     shortcutRef,
+    reverseShortcutRef,
   };
 }
 
@@ -277,12 +293,16 @@ function useSwitcherActions({
   );
 
   const openSwitcher = useCallback(
-    (commitOnRelease: boolean) => {
+    (commitOnRelease: boolean, direction: CycleDirection = "forward") => {
       setCommandPanelOpen(false);
       cancelledRef.current = false;
       commitOnReleaseRef.current = commitOnRelease;
       openRef.current = true;
-      setSelectedIndex(getInitialSelectionIndex(itemsRef.current, activeTaskIdRef.current));
+      const initialIndex =
+        direction === "backward"
+          ? getInitialReverseSelectionIndex(itemsRef.current, activeTaskIdRef.current)
+          : getInitialSelectionIndex(itemsRef.current, activeTaskIdRef.current);
+      setSelectedIndex(initialIndex);
       setOpenState(true);
     },
     [
@@ -298,13 +318,18 @@ function useSwitcherActions({
   );
 
   const cycleSwitcher = useCallback(
-    (commitOnRelease: boolean) => {
+    (commitOnRelease: boolean, direction: CycleDirection = "forward") => {
       if (!openRef.current) {
-        openSwitcher(commitOnRelease);
+        openSwitcher(commitOnRelease, direction);
         return;
       }
       if (commitOnRelease) commitOnReleaseRef.current = true;
-      setSelectedIndex(getNextSelectionIndex(selectedIndexRef.current, itemsRef.current.length));
+      const count = itemsRef.current.length;
+      const nextIndex =
+        direction === "backward"
+          ? getPreviousSelectionIndex(selectedIndexRef.current, count)
+          : getNextSelectionIndex(selectedIndexRef.current, count);
+      setSelectedIndex(nextIndex);
     },
     [commitOnReleaseRef, itemsRef, openRef, openSwitcher, selectedIndexRef, setSelectedIndex],
   );
@@ -342,7 +367,7 @@ function useRecentTaskSwitcherCommand(shortcut: KeyboardShortcut, openSwitcher: 
 }
 
 function useSwitcherGlobalKeyboard(refs: SwitcherRefs, actions: SwitcherActions) {
-  const { cancelledRef, commitOnReleaseRef, openRef, shortcutRef } = refs;
+  const { cancelledRef, commitOnReleaseRef, openRef, reverseShortcutRef, shortcutRef } = refs;
   const { cancelSwitcher, cycleSwitcher, selectCurrentItem } = actions;
 
   useEffect(() => {
@@ -354,18 +379,33 @@ function useSwitcherGlobalKeyboard(refs: SwitcherRefs, actions: SwitcherActions)
         return;
       }
 
+      // Check the reverse shortcut first: it carries an extra modifier (Shift),
+      // so it is the more specific match and the forward shortcut never matches
+      // a Shift-held event anyway.
+      const reverseShortcut = reverseShortcutRef.current;
+      if (isCycleShortcutEvent(event, reverseShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        cycleSwitcher(hasHoldModifier(reverseShortcut), "backward");
+        return;
+      }
+
       const currentShortcut = shortcutRef.current;
       if (!isCycleShortcutEvent(event, currentShortcut)) return;
 
       event.preventDefault();
       event.stopPropagation();
-      cycleSwitcher(hasHoldModifier(currentShortcut));
+      cycleSwitcher(hasHoldModifier(currentShortcut), "forward");
     };
 
     const handleKeyUp = (event: KeyboardEvent) => {
-      const currentShortcut = shortcutRef.current;
       if (!openRef.current || !commitOnReleaseRef.current) return;
-      if (!isCommitReleaseEvent(event, currentShortcut)) return;
+      // Commit when the hold modifier of either direction is released. Both
+      // default to Ctrl/Cmd, but custom bindings may differ.
+      const released =
+        isCommitReleaseEvent(event, shortcutRef.current) ||
+        isCommitReleaseEvent(event, reverseShortcutRef.current);
+      if (!released) return;
 
       event.preventDefault();
       event.stopPropagation();
@@ -401,6 +441,7 @@ function useSwitcherGlobalKeyboard(refs: SwitcherRefs, actions: SwitcherActions)
     commitOnReleaseRef,
     cycleSwitcher,
     openRef,
+    reverseShortcutRef,
     selectCurrentItem,
     shortcutRef,
   ]);
@@ -451,12 +492,20 @@ export function useRecentTaskSwitcherController(): RecentTaskSwitcherController 
   const { setOpen: setCommandPanelOpen } = useCommandPanelOpen();
   const keyboardShortcuts = useAppStore((state) => state.userSettings.keyboardShortcuts);
   const shortcut = getShortcut("TASK_SWITCHER", keyboardShortcuts);
+  const reverseShortcut = getShortcut("TASK_SWITCHER_REVERSE", keyboardShortcuts);
   const context = useRecentTaskBuildContext();
   useRecordActiveTask(context);
 
   const items = useMemo(() => buildRecentTaskDisplayItems(entries, context), [entries, context]);
   const selectedIndex = getResolvedSelectionIndex(rawSelectedIndex, items, context.activeTaskId);
-  const refs = useSwitcherRefs(open, selectedIndex, items, context.activeTaskId, shortcut);
+  const refs = useSwitcherRefs({
+    open,
+    selectedIndex,
+    items,
+    activeTaskId: context.activeTaskId,
+    shortcut,
+    reverseShortcut,
+  });
   const setSelectedIndex = useSelectedIndexSetter(refs, setRawSelectedIndex);
   const routeToTask = useCallback((taskId: string) => router.push(linkToTask(taskId)), [router]);
   const actions = useSwitcherActions({
@@ -479,6 +528,7 @@ export function useRecentTaskSwitcherController(): RecentTaskSwitcherController 
     selectedIndex,
     setSelectedIndex,
     shortcutLabel: formatShortcut(shortcut),
+    reverseShortcutLabel: formatShortcut(reverseShortcut),
     selectItem: actions.selectItem,
     handleKeyDown,
   };

--- a/apps/web/components/task/recent-task-switcher-keys.test.ts
+++ b/apps/web/components/task/recent-task-switcher-keys.test.ts
@@ -24,6 +24,11 @@ const taskSwitcherShortcut: KeyboardShortcut = {
   modifiers: { ctrlOrCmd: true },
 };
 
+const taskSwitcherReverseShortcut: KeyboardShortcut = {
+  key: KEYS.SPACE,
+  modifiers: { ctrlOrCmd: true, shift: true },
+};
+
 function platform(platform: Platform): Platform {
   return platform;
 }
@@ -68,6 +73,30 @@ describe("recent task switcher key helpers", () => {
       true,
     );
     expect(isCycleShortcutEvent(event({ key: "y", ctrlKey: true }), shortcut)).toBe(false);
+  });
+
+  it("separates forward and reverse switcher shortcuts by the Shift modifier", () => {
+    const forwardEvent = event({ key: KEYS.SPACE, ctrlKey: true });
+    const reverseEvent = event({ key: KEYS.SPACE, ctrlKey: true, shiftKey: true });
+
+    // Forward fires only without Shift; reverse fires only with Shift.
+    expect(isCycleShortcutEvent(forwardEvent, taskSwitcherShortcut)).toBe(true);
+    expect(isCycleShortcutEvent(forwardEvent, taskSwitcherReverseShortcut)).toBe(false);
+    expect(isCycleShortcutEvent(reverseEvent, taskSwitcherShortcut)).toBe(false);
+    expect(isCycleShortcutEvent(reverseEvent, taskSwitcherReverseShortcut)).toBe(true);
+  });
+
+  it("commits the reverse shortcut on Ctrl/Cmd release, not Shift release", () => {
+    expect(
+      isCommitReleaseEvent(
+        event({ key: "Control" }),
+        taskSwitcherReverseShortcut,
+        platform("linux"),
+      ),
+    ).toBe(true);
+    expect(
+      isCommitReleaseEvent(event({ key: "Shift" }), taskSwitcherReverseShortcut, platform("linux")),
+    ).toBe(false);
   });
 
   it("matches the hold modifier release, not secondary modifier release", () => {

--- a/apps/web/components/task/recent-task-switcher-model.test.ts
+++ b/apps/web/components/task/recent-task-switcher-model.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildRecentTaskDisplayItems,
   buildRecentTaskEntry,
+  getInitialReverseSelectionIndex,
   getInitialSelectionIndex,
   getNextSelectionIndex,
   getPreviousSelectionIndex,
@@ -132,6 +133,26 @@ describe("recent task switcher model", () => {
     expect(getInitialSelectionIndex(items, CURRENT_TASK_ID)).toBe(1);
     expect(getInitialSelectionIndex(items, "task-missing")).toBe(0);
     expect(getInitialSelectionIndex([], CURRENT_TASK_ID)).toBe(-1);
+  });
+
+  it("starts reverse selection on the last non-current task", () => {
+    const items = [
+      { taskId: CURRENT_TASK_ID },
+      { taskId: PREVIOUS_TASK_ID },
+      { taskId: "task-older" },
+    ];
+
+    expect(getInitialReverseSelectionIndex(items, CURRENT_TASK_ID)).toBe(2);
+    // When the current task is the last item, skip back to the previous one.
+    expect(
+      getInitialReverseSelectionIndex(
+        [{ taskId: PREVIOUS_TASK_ID }, { taskId: CURRENT_TASK_ID }],
+        CURRENT_TASK_ID,
+      ),
+    ).toBe(0);
+    // All items are current -> fall back to the last index.
+    expect(getInitialReverseSelectionIndex([{ taskId: CURRENT_TASK_ID }], CURRENT_TASK_ID)).toBe(0);
+    expect(getInitialReverseSelectionIndex([], CURRENT_TASK_ID)).toBe(-1);
   });
 
   it("cycles through items and handles empty lists", () => {

--- a/apps/web/components/task/recent-task-switcher-model.ts
+++ b/apps/web/components/task/recent-task-switcher-model.ts
@@ -362,6 +362,17 @@ export function getInitialSelectionIndex(
   return firstNonCurrent === -1 ? 0 : firstNonCurrent;
 }
 
+export function getInitialReverseSelectionIndex(
+  items: Array<{ taskId: string }>,
+  currentTaskId: string | null,
+): number {
+  if (items.length === 0) return -1;
+  for (let index = items.length - 1; index >= 0; index--) {
+    if (items[index].taskId !== currentTaskId) return index;
+  }
+  return items.length - 1;
+}
+
 export function getNextSelectionIndex(currentIndex: number, itemCount: number): number {
   if (itemCount === 0) return -1;
   if (currentIndex < 0) return 0;

--- a/apps/web/components/task/recent-task-switcher.tsx
+++ b/apps/web/components/task/recent-task-switcher.tsx
@@ -128,10 +128,21 @@ function RecentTaskList({
   );
 }
 
-function SwitcherFooter({ shortcutLabel }: { shortcutLabel: string }) {
+function SwitcherFooter({
+  shortcutLabel,
+  reverseShortcutLabel,
+}: {
+  shortcutLabel: string;
+  reverseShortcutLabel: string;
+}) {
   return (
-    <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
-      <Kbd>{shortcutLabel}</Kbd>
+    <div className="flex items-center gap-3 border-t px-4 py-2 text-[11px] text-muted-foreground">
+      <span className="flex items-center gap-1.5">
+        <Kbd>{shortcutLabel}</Kbd> Next
+      </span>
+      <span className="flex items-center gap-1.5">
+        <Kbd>{reverseShortcutLabel}</Kbd> Previous
+      </span>
     </div>
   );
 }
@@ -160,7 +171,10 @@ function RecentTaskSwitcherDialog(props: RecentTaskSwitcherController) {
             selectItem={props.selectItem}
           />
         </div>
-        <SwitcherFooter shortcutLabel={props.shortcutLabel} />
+        <SwitcherFooter
+          shortcutLabel={props.shortcutLabel}
+          reverseShortcutLabel={props.reverseShortcutLabel}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
+++ b/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
@@ -19,6 +19,7 @@ test.describe("Keyboard Shortcuts Settings", () => {
     await expect(testPage.getByTestId("shortcut-recorder-FOCUS_INPUT")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-TOGGLE_PLAN_MODE")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-TASK_SWITCHER")).toBeVisible();
+    await expect(testPage.getByTestId("shortcut-recorder-TASK_SWITCHER_REVERSE")).toBeVisible();
   });
 
   test("can record a new shortcut and persist it", async ({ testPage, apiClient, seedData }) => {

--- a/apps/web/e2e/tests/task/recent-task-switcher.spec.ts
+++ b/apps/web/e2e/tests/task/recent-task-switcher.spec.ts
@@ -68,6 +68,58 @@ test.describe("Recent task switcher", () => {
     await expect(testPage).toHaveURL(new RegExp(`/t/${first.id}`), { timeout: 10_000 });
   });
 
+  test("reverse shortcut cycles backward through recent tasks", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const first = await apiClient.createTask(seedData.workspaceId, "Reverse Switcher One", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+    const second = await apiClient.createTask(seedData.workspaceId, "Reverse Switcher Two", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+    const third = await apiClient.createTask(seedData.workspaceId, "Reverse Switcher Three", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    // Visit oldest -> newest so the recent list is [third(current), second, first].
+    for (const task of [first, second, third]) {
+      await testPage.goto(`/t/${task.id}`);
+      await expect(testPage.getByText(`Reverse Switcher`, { exact: false }).first()).toBeVisible({
+        timeout: 15_000,
+      });
+    }
+
+    const modifier = taskSwitcherModifier();
+    await testPage.keyboard.down(modifier);
+    await testPage.keyboard.down("Shift");
+    await testPage.keyboard.press("Space");
+
+    const switcher = testPage.getByTestId("recent-task-switcher");
+    await expect(switcher).toBeVisible({ timeout: 5_000 });
+
+    // Reverse opens on the oldest non-current task (first).
+    const firstRow = switcher.getByTestId(`recent-task-switcher-item-${first.id}`);
+    const secondRow = switcher.getByTestId(`recent-task-switcher-item-${second.id}`);
+    await expect(firstRow).toHaveAttribute("data-selected", "true");
+
+    // Another reverse step moves selection backward to the newer "second" task.
+    await testPage.keyboard.press("Space");
+    await expect(secondRow).toHaveAttribute("data-selected", "true");
+
+    await testPage.keyboard.up("Shift");
+    await testPage.keyboard.up(modifier);
+    await expect(switcher).not.toBeVisible({ timeout: 5_000 });
+    await expect(testPage).toHaveURL(new RegExp(`/t/${second.id}`), { timeout: 10_000 });
+  });
+
   test("escape cancels the held switcher without routing on release", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/task/recent-task-switcher.spec.ts
+++ b/apps/web/e2e/tests/task/recent-task-switcher.spec.ts
@@ -90,11 +90,16 @@ test.describe("Recent task switcher", () => {
     });
 
     // Visit oldest -> newest so the recent list is [third(current), second, first].
+    const titleByTask = new Map([
+      [first.id, "Reverse Switcher One"],
+      [second.id, "Reverse Switcher Two"],
+      [third.id, "Reverse Switcher Three"],
+    ]);
     for (const task of [first, second, third]) {
       await testPage.goto(`/t/${task.id}`);
-      await expect(testPage.getByText(`Reverse Switcher`, { exact: false }).first()).toBeVisible({
-        timeout: 15_000,
-      });
+      await expect(
+        testPage.getByText(titleByTask.get(task.id)!, { exact: true }).first(),
+      ).toBeVisible({ timeout: 15_000 });
     }
 
     const modifier = taskSwitcherModifier();

--- a/apps/web/e2e/tests/task/recent-task-switcher.spec.ts
+++ b/apps/web/e2e/tests/task/recent-task-switcher.spec.ts
@@ -119,7 +119,11 @@ test.describe("Recent task switcher", () => {
     await testPage.keyboard.press("Space");
     await expect(secondRow).toHaveAttribute("data-selected", "true");
 
+    // Releasing Shift alone must not commit — only the hold modifier does.
     await testPage.keyboard.up("Shift");
+    await expect(switcher).toBeVisible();
+    await expect(secondRow).toHaveAttribute("data-selected", "true");
+
     await testPage.keyboard.up(modifier);
     await expect(switcher).not.toBeVisible({ timeout: 5_000 });
     await expect(testPage).toHaveURL(new RegExp(`/t/${second.id}`), { timeout: 10_000 });

--- a/apps/web/lib/keyboard/constants.ts
+++ b/apps/web/lib/keyboard/constants.ts
@@ -145,6 +145,12 @@ export const SHORTCUTS = {
     key: KEYS.SPACE,
     modifiers: { ctrlOrCmd: true },
   },
+  // Cycle the recent-task switcher backward (most-recent -> oldest). Shift
+  // distinguishes it from TASK_SWITCHER so both can be held together.
+  TASK_SWITCHER_REVERSE: {
+    key: KEYS.SPACE,
+    modifiers: { ctrlOrCmd: true, shift: true },
+  },
   BOTTOM_TERMINAL: {
     key: KEYS.J,
     modifiers: { ctrlOrCmd: true },

--- a/apps/web/lib/keyboard/constants.ts
+++ b/apps/web/lib/keyboard/constants.ts
@@ -145,7 +145,7 @@ export const SHORTCUTS = {
     key: KEYS.SPACE,
     modifiers: { ctrlOrCmd: true },
   },
-  // Cycle the recent-task switcher backward (most-recent -> oldest). Shift
+  // Cycle the recent-task switcher backward (oldest -> most-recent). Shift
   // distinguishes it from TASK_SWITCHER so both can be held together.
   TASK_SWITCHER_REVERSE: {
     key: KEYS.SPACE,

--- a/apps/web/lib/keyboard/shortcut-overrides.test.ts
+++ b/apps/web/lib/keyboard/shortcut-overrides.test.ts
@@ -20,8 +20,9 @@ describe("CONFIGURABLE_SHORTCUTS", () => {
     expect(ids).toContain("FOCUS_INPUT");
     expect(ids).toContain("TOGGLE_PLAN_MODE");
     expect(ids).toContain("TASK_SWITCHER");
+    expect(ids).toContain("TASK_SWITCHER_REVERSE");
     expect(ids).toContain("VOICE_INPUT_TOGGLE");
-    expect(ids).toHaveLength(11);
+    expect(ids).toHaveLength(12);
   });
 
   it("each entry has a label and default matching SHORTCUTS", () => {
@@ -45,6 +46,13 @@ describe("CONFIGURABLE_SHORTCUTS", () => {
 
     expect(CONFIGURABLE_SHORTCUTS.TASK_SWITCHER.label).toBe("Recent Task Switcher");
     expect(CONFIGURABLE_SHORTCUTS.TASK_SWITCHER.default).toBe(SHORTCUTS.TASK_SWITCHER);
+
+    expect(CONFIGURABLE_SHORTCUTS.TASK_SWITCHER_REVERSE.label).toBe(
+      "Recent Task Switcher (Backward)",
+    );
+    expect(CONFIGURABLE_SHORTCUTS.TASK_SWITCHER_REVERSE.default).toBe(
+      SHORTCUTS.TASK_SWITCHER_REVERSE,
+    );
   });
 });
 

--- a/apps/web/lib/keyboard/shortcut-overrides.ts
+++ b/apps/web/lib/keyboard/shortcut-overrides.ts
@@ -11,6 +11,7 @@ export type ConfigurableShortcutId =
   | "FOCUS_INPUT"
   | "TOGGLE_PLAN_MODE"
   | "TASK_SWITCHER"
+  | "TASK_SWITCHER_REVERSE"
   | "VOICE_INPUT_TOGGLE";
 
 export type StoredShortcutOverrides = Record<
@@ -32,6 +33,10 @@ export const CONFIGURABLE_SHORTCUTS: Record<
   FOCUS_INPUT: { label: "Focus Chat Input", default: SHORTCUTS.FOCUS_INPUT },
   TOGGLE_PLAN_MODE: { label: "Toggle Plan Mode", default: SHORTCUTS.TOGGLE_PLAN_MODE },
   TASK_SWITCHER: { label: "Recent Task Switcher", default: SHORTCUTS.TASK_SWITCHER },
+  TASK_SWITCHER_REVERSE: {
+    label: "Recent Task Switcher (Backward)",
+    default: SHORTCUTS.TASK_SWITCHER_REVERSE,
+  },
   VOICE_INPUT_TOGGLE: { label: "Voice Input", default: SHORTCUTS.VOICE_INPUT_TOGGLE },
 };
 


### PR DESCRIPTION
The task switcher only let you cycle forward through recent tasks, so stepping back to a task you just passed meant cycling all the way around. Cmd/Ctrl+Shift+Space now cycles backward, and both directions are user-configurable.

## Important Changes

- New `TASK_SWITCHER_REVERSE` shortcut; the extra Shift keeps it mutually exclusive with the forward binding, so both can be held together.
- A cycle direction is threaded through open/cycle; reverse opens on the oldest non-current task and commits on release of either binding's hold modifier.
- Both bindings are registered as configurable (Settings → Keyboard Shortcuts) and shown as Next / Previous in the switcher footer.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm vitest run` (2941 passed) — added unit coverage for reverse selection, forward/reverse mutual exclusivity, and the configurable-shortcuts registry
- Added e2e specs for backward cycling and the reverse recorder row (not run locally — needs Docker/Playwright env)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.