### PR TITLE
fix(office): disable create button until project + title set

### DIFF
--- a/apps/web/app/office/components/new-task-dialog.test.tsx
+++ b/apps/web/app/office/components/new-task-dialog.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+
+import { CreateTaskButton } from "./new-task-dialog";
+import type { IssueDraft } from "./new-task-draft";
+
+const BASE_DRAFT: IssueDraft = {
+  title: "",
+  description: "",
+  assigneeId: "",
+  projectId: "",
+  status: "todo",
+  priority: "medium",
+  showReviewer: false,
+  showApprover: false,
+  reviewerIds: [],
+  approverIds: [],
+};
+
+function renderButton(draft: Partial<IssueDraft>) {
+  return render(
+    <TooltipProvider>
+      <CreateTaskButton draft={{ ...BASE_DRAFT, ...draft }} submitting={false} onCreate={vi.fn()} />
+    </TooltipProvider>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe("CreateTaskButton", () => {
+  it("disables the button and labels missing project when no project selected", () => {
+    renderButton({ title: "do thing" });
+    const button = screen.getByTestId("new-task-create-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    // The tooltip content is rendered as accessible-name on the wrapper.
+    expect(screen.getByLabelText(/select a project to create a task/i)).toBeTruthy();
+  });
+
+  it("disables the button and labels missing title when title empty", () => {
+    renderButton({ projectId: "proj-1" });
+    const button = screen.getByTestId("new-task-create-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(screen.getByLabelText(/add a title to create a task/i)).toBeTruthy();
+  });
+
+  it("enables the button without a tooltip when both title and project are set", () => {
+    renderButton({ title: "do thing", projectId: "proj-1" });
+    const button = screen.getByTestId("new-task-create-button") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    expect(screen.queryByLabelText(/create a task/i)).toBeNull();
+  });
+});

--- a/apps/web/app/office/components/new-task-dialog.test.tsx
+++ b/apps/web/app/office/components/new-task-dialog.test.tsx
@@ -26,28 +26,47 @@ function renderButton(draft: Partial<IssueDraft>) {
   );
 }
 
+const TEST_ID = "new-task-create-button";
+
+function getButton() {
+  return screen.getByTestId(TEST_ID) as HTMLButtonElement;
+}
+
 afterEach(() => cleanup());
 
 describe("CreateTaskButton", () => {
   it("disables the button and labels missing project when no project selected", () => {
     renderButton({ title: "do thing" });
-    const button = screen.getByTestId("new-task-create-button") as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
+    expect(getButton().disabled).toBe(true);
     // The tooltip content is rendered as accessible-name on the wrapper.
     expect(screen.getByLabelText(/select a project to create a task/i)).toBeTruthy();
   });
 
   it("disables the button and labels missing title when title empty", () => {
     renderButton({ projectId: "proj-1" });
-    const button = screen.getByTestId("new-task-create-button") as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
+    expect(getButton().disabled).toBe(true);
     expect(screen.getByLabelText(/add a title to create a task/i)).toBeTruthy();
   });
 
   it("enables the button without a tooltip when both title and project are set", () => {
     renderButton({ title: "do thing", projectId: "proj-1" });
-    const button = screen.getByTestId("new-task-create-button") as HTMLButtonElement;
-    expect(button.disabled).toBe(false);
+    expect(getButton().disabled).toBe(false);
+    expect(screen.queryByLabelText(/create a task/i)).toBeNull();
+  });
+
+  it("disables the button and shows 'Creating...' while submitting", () => {
+    render(
+      <TooltipProvider>
+        <CreateTaskButton
+          draft={{ ...BASE_DRAFT, title: "do thing", projectId: "proj-1" }}
+          submitting={true}
+          onCreate={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+    const button = getButton();
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe("Creating...");
     expect(screen.queryByLabelText(/create a task/i)).toBeNull();
   });
 });

--- a/apps/web/app/office/components/new-task-dialog.tsx
+++ b/apps/web/app/office/components/new-task-dialog.tsx
@@ -56,7 +56,7 @@ export function NewTaskDialog({
   );
 
   const handleCreate = useCallback(async () => {
-    if (!draft.title.trim() || !workspaceId) return;
+    if (!draft.title.trim() || !draft.projectId || !workspaceId) return;
     setSubmitting(true);
     try {
       const executionPolicy = buildExecutionPolicy(stages);
@@ -175,7 +175,7 @@ function NewIssueDialogBody({
   );
 }
 
-function CreateTaskButton({
+export function CreateTaskButton({
   draft,
   submitting,
   onCreate,
@@ -207,7 +207,9 @@ function CreateTaskButton({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span tabIndex={0}>{button}</span>
+        <span tabIndex={0} aria-label={reason}>
+          {button}
+        </span>
       </TooltipTrigger>
       <TooltipContent>{reason}</TooltipContent>
     </Tooltip>

--- a/apps/web/app/office/components/new-task-dialog.tsx
+++ b/apps/web/app/office/components/new-task-dialog.tsx
@@ -5,6 +5,7 @@ import { Button } from "@kandev/ui/button";
 import { Badge } from "@kandev/ui/badge";
 import { Textarea } from "@kandev/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from "@kandev/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { toast } from "sonner";
 import { useAppStore } from "@/components/state-provider";
 import { createTask } from "@/lib/api/domains/kanban-api";
@@ -168,14 +169,47 @@ function NewIssueDialogBody({
         >
           Discard Draft
         </Button>
-        <Button
-          onClick={onCreate}
-          disabled={!draft.title.trim() || submitting}
-          className="cursor-pointer"
-        >
-          {submitting ? "Creating..." : "Create Task"}
-        </Button>
+        <CreateTaskButton draft={draft} submitting={submitting} onCreate={onCreate} />
       </DialogFooter>
     </>
+  );
+}
+
+function CreateTaskButton({
+  draft,
+  submitting,
+  onCreate,
+}: {
+  draft: IssueDraft;
+  submitting: boolean;
+  onCreate: () => void;
+}) {
+  const missingTitle = !draft.title.trim();
+  const missingProject = !draft.projectId;
+  const disabled = missingTitle || missingProject || submitting;
+  let reason: string | null = null;
+  if (missingProject) reason = "Select a project to create a task";
+  else if (missingTitle) reason = "Add a title to create a task";
+
+  const button = (
+    <Button
+      onClick={onCreate}
+      disabled={disabled}
+      className="cursor-pointer"
+      data-testid="new-task-create-button"
+    >
+      {submitting ? "Creating..." : "Create Task"}
+    </Button>
+  );
+
+  if (!reason) return button;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0}>{button}</span>
+      </TooltipTrigger>
+      <TooltipContent>{reason}</TooltipContent>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary

Office "New Task" dialog let users submit without selecting a project. The backend's `isOfficeRequest()` heuristic (`project_id != ""` OR `origin in {agent_created, routine, onboarding}`) fell through, the kanban validator fired, and the user saw `workflow_id is required for non-ephemeral tasks`. The dialog now disables the Create button until both title and project are set, and surfaces the missing field in a tooltip instead of letting the backend reject the request.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web format` (no changes)

## Checklist

- [ ] Tests added / updated
- [ ] Docs updated
- [ ] Self-reviewed