### PR TITLE
feat(web): chat history nav with ArrowUp/Down and Ctrl+R fuzzy search

### DIFF
--- a/apps/web/components/task/chat/message-history-search-row.tsx
+++ b/apps/web/components/task/chat/message-history-search-row.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { SearchHit } from "./message-history";
+
+export type HitRowProps = {
+  hit: SearchHit;
+  isSelected: boolean;
+  rowIndex: number;
+  onMouseEnter: (rowIndex: number) => void;
+  onClick: (historyIndex: number) => void;
+};
+
+export function HitRow({ hit, isSelected, rowIndex, onMouseEnter, onClick }: HitRowProps) {
+  const firstLine = hit.content.split("\n", 1)[0];
+  return (
+    <button
+      type="button"
+      data-hit-index={rowIndex}
+      data-testid="history-search-row"
+      onMouseEnter={() => onMouseEnter(rowIndex)}
+      onClick={() => onClick(hit.index)}
+      className={cn(
+        "flex w-full cursor-pointer select-none items-center gap-2 rounded-[6px] mx-1 px-2 py-1.5 text-xs text-left",
+        "hover:bg-muted/50",
+        isSelected && "bg-muted/50",
+      )}
+      style={{ width: "calc(100% - 8px)" }}
+    >
+      <span className="truncate flex-1">{firstLine || "(empty)"}</span>
+    </button>
+  );
+}

--- a/apps/web/components/task/chat/message-history-search.tsx
+++ b/apps/web/components/task/chat/message-history-search.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { cn } from "@/lib/utils";
 import { searchHistory, type SearchHit } from "./message-history";
+import { HitRow } from "./message-history-search-row";
 
 type MessageHistorySearchProps = {
   isOpen: boolean;
@@ -106,35 +106,6 @@ function computeStyle(anchorRect: DOMRect | null): React.CSSProperties | null {
     zIndex: 60,
     pointerEvents: "auto",
   };
-}
-
-type HighlightedRowProps = {
-  hit: SearchHit;
-  isSelected: boolean;
-  rowIndex: number;
-  onMouseEnter: (rowIndex: number) => void;
-  onClick: (historyIndex: number) => void;
-};
-
-function HitRow({ hit, isSelected, rowIndex, onMouseEnter, onClick }: HighlightedRowProps) {
-  const firstLine = hit.content.split("\n", 1)[0];
-  return (
-    <button
-      type="button"
-      data-hit-index={rowIndex}
-      data-testid="history-search-row"
-      onMouseEnter={() => onMouseEnter(rowIndex)}
-      onClick={() => onClick(hit.index)}
-      className={cn(
-        "flex w-full cursor-pointer select-none items-center gap-2 rounded-[6px] mx-1 px-2 py-1.5 text-xs text-left",
-        "hover:bg-muted/50",
-        isSelected && "bg-muted/50",
-      )}
-      style={{ width: "calc(100% - 8px)" }}
-    >
-      <span className="truncate flex-1">{firstLine || "(empty)"}</span>
-    </button>
-  );
 }
 
 export function MessageHistorySearch({

--- a/apps/web/components/task/chat/message-history-search.tsx
+++ b/apps/web/components/task/chat/message-history-search.tsx
@@ -6,7 +6,6 @@ import { searchHistory, type SearchHit } from "./message-history";
 import { HitRow } from "./message-history-search-row";
 
 type MessageHistorySearchProps = {
-  isOpen: boolean;
   /** Newest-first list of the user's previous messages for this session. */
   history: readonly string[];
   /** True while older messages are still being paginated in from the backend
@@ -109,7 +108,6 @@ function computeStyle(anchorRect: DOMRect | null): React.CSSProperties | null {
 }
 
 export function MessageHistorySearch({
-  isOpen,
   history,
   isLoadingOlder = false,
   anchorRect,
@@ -139,7 +137,6 @@ export function MessageHistorySearch({
 
   useScrollSelectedIntoView(selectedIndex, listRef);
 
-  if (!isOpen) return null;
   if (typeof document === "undefined") return null;
   const style = computeStyle(anchorRect);
   if (!style) return null;

--- a/apps/web/components/task/chat/message-history-search.tsx
+++ b/apps/web/components/task/chat/message-history-search.tsx
@@ -168,9 +168,10 @@ export function MessageHistorySearch({
 
   useScrollSelectedIntoView(selectedIndex, listRef);
 
-  const style = computeStyle(anchorRect);
-  if (!isOpen || !style) return null;
+  if (!isOpen) return null;
   if (typeof document === "undefined") return null;
+  const style = computeStyle(anchorRect);
+  if (!style) return null;
 
   const overlay = (
     <div
@@ -214,7 +215,7 @@ export function MessageHistorySearch({
         ) : (
           hits.map((hit, rowIndex) => (
             <HitRow
-              key={`${hit.index}-${rowIndex}`}
+              key={hit.index}
               hit={hit}
               isSelected={rowIndex === selectedIndex}
               rowIndex={rowIndex}

--- a/apps/web/components/task/chat/message-history-search.tsx
+++ b/apps/web/components/task/chat/message-history-search.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
+import { searchHistory, type SearchHit } from "./message-history";
+
+type MessageHistorySearchProps = {
+  isOpen: boolean;
+  /** Newest-first list of the user's previous messages for this session. */
+  history: readonly string[];
+  /** True while older messages are still being paginated in from the backend
+   *  (overlay-driven drain). The list updates live as more arrive. */
+  isLoadingOlder?: boolean;
+  /** Bottom-anchor rect (typically the chat input's bounding rect). The
+   *  overlay positions itself directly above this rect. */
+  anchorRect: DOMRect | null;
+  onClose: () => void;
+  /** Invoked when the user picks a result. `index` is the position in
+   *  `history` so the editor's history navigation can resume from there. */
+  onSelect: (index: number) => void;
+};
+
+const OVERLAY_HEIGHT = 280;
+const OVERLAY_MAX_WIDTH = 700;
+
+function clampSelectedIndex(prev: number, hitCount: number): number {
+  if (hitCount === 0) return 0;
+  if (prev >= hitCount) return hitCount - 1;
+  if (prev < 0) return 0;
+  return prev;
+}
+
+function useHits(history: readonly string[], query: string): SearchHit[] {
+  return useMemo(() => searchHistory(history, query), [history, query]);
+}
+
+/** Track the selected index without an effect: reset to 0 when the query
+ *  changes (state-during-render pattern), then clamp against the live hit
+ *  count when reading. The setter remains stable so handlers can move it. */
+function useSelectedIndex(hitCount: number, query: string) {
+  const [rawSelectedIndex, setSelectedIndex] = useState(0);
+  const [trackedQuery, setTrackedQuery] = useState(query);
+  if (trackedQuery !== query) {
+    setTrackedQuery(query);
+    setSelectedIndex(0);
+  }
+  const selectedIndex = clampSelectedIndex(rawSelectedIndex, hitCount);
+  return [selectedIndex, setSelectedIndex] as const;
+}
+
+type OverlayKeyArgs = {
+  hits: SearchHit[];
+  selectedIndex: number;
+  setSelectedIndex: React.Dispatch<React.SetStateAction<number>>;
+  onSelect: (index: number) => void;
+  onClose: () => void;
+};
+
+function handleOverlayKeyDown(event: React.KeyboardEvent, args: OverlayKeyArgs) {
+  const { hits, selectedIndex, setSelectedIndex, onSelect, onClose } = args;
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    setSelectedIndex((i) => Math.min(i + 1, hits.length - 1));
+    return;
+  }
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    setSelectedIndex((i) => Math.max(i - 1, 0));
+    return;
+  }
+  if (event.key === "Enter") {
+    event.preventDefault();
+    const hit = hits[selectedIndex];
+    if (hit) onSelect(hit.index);
+    return;
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    onClose();
+  }
+}
+
+function useScrollSelectedIntoView(
+  selectedIndex: number,
+  listRef: React.RefObject<HTMLDivElement | null>,
+) {
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const item = list.querySelector<HTMLElement>(`[data-hit-index="${selectedIndex}"]`);
+    if (item) item.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex, listRef]);
+}
+
+function computeStyle(anchorRect: DOMRect | null): React.CSSProperties | null {
+  if (!anchorRect) return null;
+  const left = Math.max(8, anchorRect.left);
+  const maxWidth = Math.min(OVERLAY_MAX_WIDTH, Math.max(200, window.innerWidth - left - 8));
+  return {
+    position: "fixed",
+    left,
+    width: Math.min(maxWidth, anchorRect.width || maxWidth),
+    bottom: window.innerHeight - anchorRect.top + 8,
+    maxHeight: OVERLAY_HEIGHT,
+    zIndex: 60,
+    pointerEvents: "auto",
+  };
+}
+
+type HighlightedRowProps = {
+  hit: SearchHit;
+  isSelected: boolean;
+  rowIndex: number;
+  onMouseEnter: (rowIndex: number) => void;
+  onClick: (historyIndex: number) => void;
+};
+
+function HitRow({ hit, isSelected, rowIndex, onMouseEnter, onClick }: HighlightedRowProps) {
+  const firstLine = hit.content.split("\n", 1)[0];
+  return (
+    <button
+      type="button"
+      data-hit-index={rowIndex}
+      data-testid="history-search-row"
+      onMouseEnter={() => onMouseEnter(rowIndex)}
+      onClick={() => onClick(hit.index)}
+      className={cn(
+        "flex w-full cursor-pointer select-none items-center gap-2 rounded-[6px] mx-1 px-2 py-1.5 text-xs text-left",
+        "hover:bg-muted/50",
+        isSelected && "bg-muted/50",
+      )}
+      style={{ width: "calc(100% - 8px)" }}
+    >
+      <span className="truncate flex-1">{firstLine || "(empty)"}</span>
+    </button>
+  );
+}
+
+export function MessageHistorySearch({
+  isOpen,
+  history,
+  isLoadingOlder = false,
+  anchorRect,
+  onClose,
+  onSelect,
+}: MessageHistorySearchProps) {
+  const [query, setQuery] = useState("");
+  const hits = useHits(history, query);
+  const [selectedIndex, setSelectedIndex] = useSelectedIndex(hits.length, query);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [onClose]);
+
+  useScrollSelectedIntoView(selectedIndex, listRef);
+
+  const style = computeStyle(anchorRect);
+  if (!isOpen || !style) return null;
+  if (typeof document === "undefined") return null;
+
+  const overlay = (
+    <div
+      ref={containerRef}
+      style={style}
+      className="overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
+      data-testid="history-search-overlay"
+    >
+      <div className="flex items-center gap-2 px-2 py-1.5 border-b border-border/50">
+        <span className="text-xs font-medium text-muted-foreground shrink-0">
+          (reverse-i-search)
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) =>
+            handleOverlayKeyDown(e, { hits, selectedIndex, setSelectedIndex, onSelect, onClose })
+          }
+          placeholder="Type to search previous messages..."
+          className="flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+          data-testid="history-search-input"
+        />
+        {isLoadingOlder && (
+          <span
+            className="text-[10px] text-muted-foreground shrink-0"
+            data-testid="history-search-loading-older"
+          >
+            loading older…
+          </span>
+        )}
+      </div>
+      <div
+        ref={listRef}
+        className="overflow-y-auto py-1 scrollbar-thin"
+        style={{ maxHeight: OVERLAY_HEIGHT - 36 }}
+      >
+        {hits.length === 0 ? (
+          <div className="px-3 py-2 text-xs text-muted-foreground">No matches</div>
+        ) : (
+          hits.map((hit, rowIndex) => (
+            <HitRow
+              key={`${hit.index}-${rowIndex}`}
+              hit={hit}
+              isSelected={rowIndex === selectedIndex}
+              rowIndex={rowIndex}
+              onMouseEnter={setSelectedIndex}
+              onClick={onSelect}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+
+  return createPortal(overlay, document.body);
+}

--- a/apps/web/components/task/chat/message-history.test.ts
+++ b/apps/web/components/task/chat/message-history.test.ts
@@ -77,6 +77,16 @@ describe("extractUserHistory", () => {
     expect(extractUserHistory(messages)).toEqual(["a", "b", "a"]);
   });
 
+  it("keeps duplicates separated by agent/tool turns (adjacency is in original stream)", () => {
+    const messages: Message[] = [
+      msg({ id: "1", content: "fix bug" }),
+      msg({ id: "2", content: "working on it", author_type: "agent" }),
+      msg({ id: "3", content: "ran cmd", type: "tool_execute" }),
+      msg({ id: "4", content: "fix bug" }),
+    ];
+    expect(extractUserHistory(messages)).toEqual(["fix bug", "fix bug"]);
+  });
+
   it("returns empty for empty input", () => {
     expect(extractUserHistory([])).toEqual([]);
   });

--- a/apps/web/components/task/chat/message-history.test.ts
+++ b/apps/web/components/task/chat/message-history.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractUserHistory,
+  navigateHistory,
+  fuzzyScore,
+  searchHistory,
+  type HistoryState,
+} from "./message-history";
+import type { Message } from "@/lib/types/http";
+
+function msg(partial: Partial<Message>): Message {
+  return {
+    id: partial.id ?? "m",
+    session_id: "s1" as Message["session_id"],
+    task_id: "t1" as Message["task_id"],
+    author_type: partial.author_type ?? "user",
+    type: partial.type ?? "message",
+    content: partial.content ?? "",
+    created_at: partial.created_at ?? "2026-01-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+describe("extractUserHistory", () => {
+  it("returns user message contents newest-first", () => {
+    const messages: Message[] = [
+      msg({ id: "1", content: "first" }),
+      msg({ id: "2", content: "second" }),
+      msg({ id: "3", content: "third" }),
+    ];
+    expect(extractUserHistory(messages)).toEqual(["third", "second", "first"]);
+  });
+
+  it("skips agent messages", () => {
+    const messages: Message[] = [
+      msg({ id: "1", content: "user-a" }),
+      msg({ id: "2", content: "agent-reply", author_type: "agent" }),
+      msg({ id: "3", content: "user-b" }),
+    ];
+    expect(extractUserHistory(messages)).toEqual(["user-b", "user-a"]);
+  });
+
+  it("skips non-message types (tool_call, thinking, etc.)", () => {
+    const messages: Message[] = [
+      msg({ id: "1", content: "real prompt" }),
+      msg({ id: "2", content: "thought", type: "thinking" }),
+      msg({ id: "3", content: "ran cmd", type: "tool_execute" }),
+    ];
+    expect(extractUserHistory(messages)).toEqual(["real prompt"]);
+  });
+
+  it("skips empty/whitespace content", () => {
+    const messages: Message[] = [
+      msg({ id: "1", content: "real" }),
+      msg({ id: "2", content: "" }),
+      msg({ id: "3", content: "   " }),
+    ];
+    expect(extractUserHistory(messages)).toEqual(["real"]);
+  });
+
+  it("collapses consecutive duplicates", () => {
+    const messages: Message[] = [
+      msg({ id: "1", content: "fix bug" }),
+      msg({ id: "2", content: "fix bug" }),
+      msg({ id: "3", content: "fix bug" }),
+      msg({ id: "4", content: "ship it" }),
+    ];
+    expect(extractUserHistory(messages)).toEqual(["ship it", "fix bug"]);
+  });
+
+  it("keeps non-consecutive duplicates", () => {
+    const messages: Message[] = [
+      msg({ id: "1", content: "a" }),
+      msg({ id: "2", content: "b" }),
+      msg({ id: "3", content: "a" }),
+    ];
+    expect(extractUserHistory(messages)).toEqual(["a", "b", "a"]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(extractUserHistory([])).toEqual([]);
+  });
+});
+
+describe("navigateHistory", () => {
+  const empty: HistoryState = { index: null };
+
+  it("returns null when there is no history", () => {
+    expect(navigateHistory(empty, "up", 0)).toBeNull();
+    expect(navigateHistory(empty, "down", 0)).toBeNull();
+  });
+
+  it("first ArrowUp enters history at index 0", () => {
+    expect(navigateHistory(empty, "up", 3)).toEqual({ index: 0 });
+  });
+
+  it("subsequent ArrowUp moves further back", () => {
+    expect(navigateHistory({ index: 0 }, "up", 3)).toEqual({ index: 1 });
+    expect(navigateHistory({ index: 1 }, "up", 3)).toEqual({ index: 2 });
+  });
+
+  it("ArrowUp at the oldest entry returns null", () => {
+    expect(navigateHistory({ index: 2 }, "up", 3)).toBeNull();
+  });
+
+  it("ArrowDown from null defers (returns null)", () => {
+    expect(navigateHistory(empty, "down", 3)).toBeNull();
+  });
+
+  it("ArrowDown moves toward newer entries", () => {
+    expect(navigateHistory({ index: 2 }, "down", 3)).toEqual({ index: 1 });
+    expect(navigateHistory({ index: 1 }, "down", 3)).toEqual({ index: 0 });
+  });
+
+  it("ArrowDown from index 0 exits history (restores draft)", () => {
+    expect(navigateHistory({ index: 0 }, "down", 3)).toEqual({ index: null });
+  });
+});
+
+describe("fuzzyScore", () => {
+  it("returns a positive score for an empty needle", () => {
+    expect(fuzzyScore("", "anything")).toBeGreaterThan(0);
+  });
+
+  it("matches subsequences in order, case-insensitive", () => {
+    expect(fuzzyScore("fb", "fix bug")).not.toBeNull();
+    expect(fuzzyScore("FB", "Fix Bug")).not.toBeNull();
+  });
+
+  it("returns null when characters cannot be matched in order", () => {
+    expect(fuzzyScore("xyz", "fix bug")).toBeNull();
+    expect(fuzzyScore("gf", "fix bug")).toBeNull(); // g comes after f in haystack? no - 'g' is in 'bug', 'f' is before
+  });
+
+  it("ranks word-boundary matches above mid-word ones", () => {
+    const boundary = fuzzyScore("fb", "fix bug")!;
+    const midword = fuzzyScore("fb", "affable")!;
+    expect(boundary).not.toBeNull();
+    expect(midword).not.toBeNull();
+    expect(boundary).toBeGreaterThan(midword);
+  });
+
+  it("ranks consecutive matches above scattered ones", () => {
+    const consecutive = fuzzyScore("fix", "fix bug")!;
+    const scattered = fuzzyScore("fix", "f i x in mix")!;
+    expect(consecutive).toBeGreaterThan(scattered);
+  });
+});
+
+describe("searchHistory", () => {
+  it("returns every entry unchanged for an empty query", () => {
+    const history = ["c", "b", "a"];
+    expect(searchHistory(history, "")).toEqual([
+      { index: 0, content: "c", score: 0 },
+      { index: 1, content: "b", score: 0 },
+      { index: 2, content: "a", score: 0 },
+    ]);
+  });
+
+  it("filters out non-matching entries", () => {
+    const history = ["fix bug", "ship it", "rename foo"];
+    const hits = searchHistory(history, "fb");
+    expect(hits.map((h) => h.content)).toEqual(["fix bug"]);
+  });
+
+  it("orders matches best-first (consecutive chars beat scattered)", () => {
+    const history = ["find the bug later", "fb shortcut win"];
+    const hits = searchHistory(history, "fb");
+    expect(hits[0].content).toBe("fb shortcut win");
+  });
+
+  it("preserves the original index so callers can jump history position", () => {
+    const history = ["a", "fb match", "c"];
+    const [hit] = searchHistory(history, "fb");
+    expect(hit.index).toBe(1);
+  });
+});

--- a/apps/web/components/task/chat/message-history.ts
+++ b/apps/web/components/task/chat/message-history.ts
@@ -1,9 +1,10 @@
 import type { Message } from "@/lib/types/http";
 
 /** Extract the user's previously sent text messages for a session, newest-first.
- *  Consecutive duplicates are collapsed so pressing ArrowUp moves through
- *  distinct entries (mirrors shell history). Empty/whitespace-only messages
- *  are skipped. */
+ *  Consecutive duplicates *in the original message stream* are collapsed —
+ *  duplicates separated by an assistant or tool turn stay, since the user
+ *  meaningfully repeated themselves and should be able to recall the older
+ *  one from history. Empty/whitespace-only messages are skipped. */
 export function extractUserHistory(messages: readonly Message[]): string[] {
   const out: string[] = [];
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -11,7 +12,12 @@ export function extractUserHistory(messages: readonly Message[]): string[] {
     if (m.author_type !== "user" || m.type !== "message") continue;
     const content = m.content ?? "";
     if (!content.trim()) continue;
-    if (out.length > 0 && out[out.length - 1] === content) continue;
+    const newer = messages[i + 1];
+    const isAdjacentUserDuplicate =
+      newer?.author_type === "user" &&
+      newer.type === "message" &&
+      (newer.content ?? "") === content;
+    if (isAdjacentUserDuplicate) continue;
     out.push(content);
   }
   return out;

--- a/apps/web/components/task/chat/message-history.ts
+++ b/apps/web/components/task/chat/message-history.ts
@@ -1,0 +1,96 @@
+import type { Message } from "@/lib/types/http";
+
+/** Extract the user's previously sent text messages for a session, newest-first.
+ *  Consecutive duplicates are collapsed so pressing ArrowUp moves through
+ *  distinct entries (mirrors shell history). Empty/whitespace-only messages
+ *  are skipped. */
+export function extractUserHistory(messages: readonly Message[]): string[] {
+  const out: string[] = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.author_type !== "user" || m.type !== "message") continue;
+    const content = m.content ?? "";
+    if (!content.trim()) continue;
+    if (out.length > 0 && out[out.length - 1] === content) continue;
+    out.push(content);
+  }
+  return out;
+}
+
+export type HistoryState = {
+  /** Position within the history list (0 = most recent). `null` means the user
+   *  is currently editing their own draft, not viewing history. */
+  index: number | null;
+};
+
+/** Decide the next history navigation state when ArrowUp/ArrowDown is pressed.
+ *  Returns `null` if the press should be deferred (e.g. no history, or at the
+ *  oldest entry on ArrowUp — caller should treat as a no-op). */
+export function navigateHistory(
+  state: HistoryState,
+  direction: "up" | "down",
+  historyLength: number,
+): HistoryState | null {
+  if (historyLength === 0) return null;
+  if (direction === "up") {
+    const next = state.index === null ? 0 : state.index + 1;
+    if (next >= historyLength) return null;
+    return { index: next };
+  }
+  if (state.index === null) return null;
+  if (state.index === 0) return { index: null };
+  return { index: state.index - 1 };
+}
+
+/** Lightweight subsequence-fuzzy scorer. Returns `null` if `needle`'s
+ *  characters cannot be found in `haystack` in order (case-insensitive).
+ *  Higher score = better match; consecutive matches and word-boundary hits
+ *  rank higher. Shorter haystacks tie-break ahead of longer ones. */
+export function fuzzyScore(needle: string, haystack: string): number | null {
+  if (!needle) return 1;
+  const n = needle.toLowerCase();
+  const h = haystack.toLowerCase();
+  let hi = 0;
+  let score = 0;
+  let consecutive = 0;
+  for (let ni = 0; ni < n.length; ni++) {
+    const c = n.charAt(ni);
+    const next = h.indexOf(c, hi);
+    if (next === -1) return null;
+    if (next === hi) {
+      consecutive++;
+      score += 2 + consecutive;
+    } else {
+      consecutive = 0;
+      score += 1;
+    }
+    const prev = next === 0 ? "" : h.charAt(next - 1);
+    if (next === 0 || /[\s\-_/.,(){}[\]]/.test(prev)) score += 2;
+    hi = next + 1;
+  }
+  return score - haystack.length * 0.01;
+}
+
+export type SearchHit = {
+  /** Original index in the history array (lets the caller jump the history
+   *  index when the user picks a search result). */
+  index: number;
+  content: string;
+  score: number;
+};
+
+/** Score every history entry against `query` and return matches sorted
+ *  best-first. An empty query returns every entry in newest-first order
+ *  (preserving the original index). */
+export function searchHistory(history: readonly string[], query: string): SearchHit[] {
+  if (!query) {
+    return history.map((content, index) => ({ index, content, score: 0 }));
+  }
+  const hits: SearchHit[] = [];
+  for (let i = 0; i < history.length; i++) {
+    const score = fuzzyScore(query, history[i]);
+    if (score !== null) hits.push({ index: i, content: history[i], score });
+  }
+  hits.sort((a, b) => b.score - a.score);
+  return hits;
+}

--- a/apps/web/components/task/chat/tiptap-editor-history.ts
+++ b/apps/web/components/task/chat/tiptap-editor-history.ts
@@ -71,14 +71,17 @@ function writeHistoryContent(
 ): void {
   if (!editor) return;
   state.isApplying = true;
-  if (text === "") {
-    editor.chain().focus().clearContent().run();
-  } else {
-    editor.chain().focus().setContent(textToHtml(text)).run();
-    editor.commands.focus("end");
+  try {
+    if (text === "") {
+      editor.chain().focus().clearContent().run();
+    } else {
+      editor.chain().focus().setContent(textToHtml(text)).run();
+      editor.commands.focus("end");
+    }
+    onChange(getMarkdownText(editor));
+  } finally {
+    state.isApplying = false;
   }
-  state.isApplying = false;
-  onChange(getMarkdownText(editor));
 }
 
 function caretAtBoundary(editor: Editor, direction: "up" | "down"): boolean {

--- a/apps/web/components/task/chat/tiptap-editor-history.ts
+++ b/apps/web/components/task/chat/tiptap-editor-history.ts
@@ -1,0 +1,185 @@
+import { useMemo } from "react";
+import type { useEditor } from "@tiptap/react";
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { navigateHistory, type HistoryState } from "./message-history";
+import { getMarkdownText, textToHtml } from "./tiptap-helpers";
+
+export type HistoryNavDecision =
+  | { kind: "defer" }
+  | { kind: "consume-noop" }
+  | { kind: "apply"; index: number | null };
+
+/** Pure decision for whether ArrowUp/ArrowDown should engage message history
+ *  navigation. Kept pure so the keymap contract is unit-testable without
+ *  mounting TipTap. `atBoundary` is true when the caret is at the top of the
+ *  first textblock (for "up") or the bottom of the last textblock (for
+ *  "down") — pressing the arrow elsewhere should defer to normal cursor
+ *  movement. */
+export function decideHistoryNav(args: {
+  direction: "up" | "down";
+  disabled: boolean;
+  isSuggestionMenuOpen: boolean;
+  isReverseSearchOpen: boolean;
+  atBoundary: boolean;
+  historyLength: number;
+  state: HistoryState;
+}): HistoryNavDecision {
+  if (args.disabled) return { kind: "defer" };
+  if (args.isSuggestionMenuOpen) return { kind: "defer" };
+  if (args.isReverseSearchOpen) return { kind: "defer" };
+  if (args.historyLength === 0) return { kind: "defer" };
+  if (!args.atBoundary) return { kind: "defer" };
+  const next = navigateHistory(args.state, args.direction, args.historyLength);
+  if (next === null) {
+    if (args.direction === "up") return { kind: "consume-noop" };
+    return { kind: "defer" };
+  }
+  return { kind: "apply", index: next.index };
+}
+
+export type HistoryKeymapRefs = {
+  disabledRef: React.RefObject<boolean | undefined>;
+  isSuggestionMenuOpenRef: React.RefObject<boolean>;
+  isReverseSearchOpenRef: React.RefObject<boolean>;
+  getHistoryRef: React.RefObject<() => readonly string[]>;
+  onOpenReverseSearchRef: React.RefObject<(() => void) | undefined>;
+  onChangeRef: React.RefObject<(value: string) => void>;
+};
+
+export type HistoryNavController = {
+  extension: Extension;
+  /** Apply a specific history entry by index. Used by the reverse-search
+   *  overlay so the picked entry slots back into the up/down cycle. */
+  applyHistoryIndex: (editor: ReturnType<typeof useEditor> | null, index: number) => void;
+};
+
+type Editor = ReturnType<typeof useEditor>;
+
+type HistoryRuntimeState = {
+  index: number | null;
+  draft: string;
+  isApplying: boolean;
+};
+
+function writeHistoryContent(
+  editor: Editor,
+  state: HistoryRuntimeState,
+  text: string,
+  onChange: (value: string) => void,
+): void {
+  if (!editor) return;
+  state.isApplying = true;
+  if (text === "") {
+    editor.chain().focus().clearContent().run();
+  } else {
+    editor.chain().focus().setContent(textToHtml(text)).run();
+    editor.commands.focus("end");
+  }
+  state.isApplying = false;
+  onChange(getMarkdownText(editor));
+}
+
+function caretAtBoundary(editor: Editor, direction: "up" | "down"): boolean {
+  if (!editor) return false;
+  const view = editor.view;
+  const { selection, doc } = editor.state;
+  const parent = selection.$from.parent as ProseMirrorNode;
+  if (direction === "up") {
+    return parent === doc.firstChild && view.endOfTextblock("up");
+  }
+  return parent === doc.lastChild && view.endOfTextblock("down");
+}
+
+function runHistoryArrow(
+  editor: Editor,
+  direction: "up" | "down",
+  state: HistoryRuntimeState,
+  refs: HistoryKeymapRefs,
+): boolean {
+  if (!editor) return false;
+  const history = refs.getHistoryRef.current?.() ?? [];
+  const decision = decideHistoryNav({
+    direction,
+    disabled: !!refs.disabledRef.current,
+    isSuggestionMenuOpen: refs.isSuggestionMenuOpenRef.current,
+    isReverseSearchOpen: refs.isReverseSearchOpenRef.current,
+    atBoundary: caretAtBoundary(editor, direction),
+    historyLength: history.length,
+    state: { index: state.index },
+  });
+  if (decision.kind === "defer") return false;
+  if (decision.kind === "consume-noop") return true;
+  if (state.index === null && decision.index !== null) {
+    state.draft = getMarkdownText(editor);
+  }
+  const text = decision.index === null ? state.draft : history[decision.index];
+  writeHistoryContent(editor, state, text, refs.onChangeRef.current);
+  state.index = decision.index;
+  return true;
+}
+
+function reverseSearchPlugin(state: HistoryRuntimeState, refs: HistoryKeymapRefs): Plugin {
+  return new Plugin({
+    key: new PluginKey("messageHistoryReverseSearch"),
+    props: {
+      handleKeyDown: (_view, event) => {
+        if (refs.disabledRef.current) return false;
+        if (event.ctrlKey && !event.metaKey && !event.altKey && event.key.toLowerCase() === "r") {
+          event.preventDefault();
+          refs.onOpenReverseSearchRef.current?.();
+          return true;
+        }
+        return false;
+      },
+    },
+    filterTransaction: (tr) => {
+      if (tr.docChanged && !state.isApplying && state.index !== null) {
+        state.index = null;
+        state.draft = "";
+      }
+      return true;
+    },
+  });
+}
+
+function buildHistoryExtension(state: HistoryRuntimeState, refs: HistoryKeymapRefs): Extension {
+  return Extension.create({
+    name: "messageHistoryKeymap",
+    addKeyboardShortcuts() {
+      return {
+        ArrowUp: ({ editor }) => runHistoryArrow(editor, "up", state, refs),
+        ArrowDown: ({ editor }) => runHistoryArrow(editor, "down", state, refs),
+      };
+    },
+    addProseMirrorPlugins() {
+      return [reverseSearchPlugin(state, refs)];
+    },
+  });
+}
+
+function applyHistoryIndexImpl(
+  editor: Editor | null,
+  state: HistoryRuntimeState,
+  index: number,
+  refs: HistoryKeymapRefs,
+): void {
+  if (!editor) return;
+  const history = refs.getHistoryRef.current?.() ?? [];
+  if (index < 0 || index >= history.length) return;
+  if (state.index === null) state.draft = getMarkdownText(editor);
+  writeHistoryContent(editor, state, history[index], refs.onChangeRef.current);
+  state.index = index;
+}
+
+export function useHistoryKeymap(refs: HistoryKeymapRefs): HistoryNavController {
+  return useMemo(() => {
+    const state: HistoryRuntimeState = { index: null, draft: "", isApplying: false };
+    const extension = buildHistoryExtension(state, refs);
+    const applyHistoryIndex: HistoryNavController["applyHistoryIndex"] = (editor, index) =>
+      applyHistoryIndexImpl(editor, state, index, refs);
+    return { extension, applyHistoryIndex };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -385,7 +385,7 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
     (menu.mentionMenu.isOpen && menu.mentionMenu.items.length > 0) ||
     (menu.slashMenu.isOpen && menu.slashMenu.items.length > 0);
   const { history, getHistory } = useChatHistory(sessionId);
-  const { editorWrapperRef, ...overlay } = useReverseSearchOverlay(history.length);
+  const { editorWrapperRef, ...overlay } = useReverseSearchOverlay(sessionId);
   const { isDraining } = useDrainOlderMessages(sessionId, overlay.isReverseSearchOpen);
   const { editor, applyHistoryEntry } = useTipTapEditor({
     value,
@@ -409,13 +409,14 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
     isReverseSearchOpen: overlay.isReverseSearchOpen,
     ref,
   });
+  const { closeReverseSearch } = overlay;
   const handleReverseSearchSelect = useCallback(
     (index: number) => {
       applyHistoryEntry(index);
-      overlay.closeReverseSearch();
+      closeReverseSearch();
       editor?.commands.focus("end");
     },
-    [applyHistoryEntry, overlay, editor],
+    [applyHistoryEntry, closeReverseSearch, editor],
   );
   return (
     <>
@@ -504,16 +505,16 @@ function useChatHistory(sessionId: string | null) {
   return { history, getHistory, historyRef };
 }
 
-function useReverseSearchOverlay(historyLength: number) {
+function useReverseSearchOverlay(sessionId: string | null) {
   const editorWrapperRef = useRef<HTMLDivElement>(null);
   const [reverseSearchAnchor, setReverseSearchAnchor] = useState<DOMRect | null>(null);
   const [isReverseSearchOpen, setIsReverseSearchOpen] = useState(false);
-  const historyLengthRef = useRef(historyLength);
+  const sessionIdRef = useRef(sessionId);
   useLayoutEffect(() => {
-    historyLengthRef.current = historyLength;
+    sessionIdRef.current = sessionId;
   });
   const openReverseSearch = useCallback(() => {
-    if (historyLengthRef.current === 0) return;
+    if (!sessionIdRef.current) return;
     setReverseSearchAnchor(editorWrapperRef.current?.getBoundingClientRect() ?? null);
     setIsReverseSearchOpen(true);
   }, []);

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -16,8 +16,11 @@ import { getWebSocketClient } from "@/lib/ws/connection";
 import { searchWorkspaceFiles } from "@/lib/ws/workspace-files";
 import { EditorContextProvider } from "./editor-context";
 import { MentionMenu } from "./mention-menu";
+import { MessageHistorySearch } from "./message-history-search";
 import { SlashCommandMenu } from "./slash-command-menu";
 import { buildTaskMentionItems } from "./task-mention-items";
+import { extractUserHistory } from "./message-history";
+import { useDrainOlderMessages } from "./use-drain-older-messages";
 import {
   createMentionSuggestion,
   createSlashSuggestion,
@@ -368,38 +371,23 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
   },
   ref,
 ) {
-  const {
-    mentionMenu,
-    setMentionMenu,
-    slashMenu,
-    setSlashMenu,
-    mentionSelectedIndex,
-    setMentionSelectedIndex,
-    slashSelectedIndex,
-    setSlashSelectedIndex,
-    onMentionKeyDown,
-    onSlashKeyDown,
-    handleMentionSelect,
-    handleMentionClose,
-    handleSlashSelect,
-    handleSlashClose,
-  } = useMenuHandlers();
-
+  const menu = useMenuHandlers();
   const { mentionSuggestion, slashSuggestion } = useSuggestionConfigs({
     sessionId,
     taskId: taskId ?? null,
     onAgentCommand,
-    onMentionKeyDown,
-    onSlashKeyDown,
-    setMentionMenu,
-    setSlashMenu,
+    onMentionKeyDown: menu.onMentionKeyDown,
+    onSlashKeyDown: menu.onSlashKeyDown,
+    setMentionMenu: menu.setMentionMenu,
+    setSlashMenu: menu.setSlashMenu,
   });
-
   const isSuggestionMenuOpen =
-    (mentionMenu.isOpen && mentionMenu.items.length > 0) ||
-    (slashMenu.isOpen && slashMenu.items.length > 0);
-
-  const editor = useTipTapEditor({
+    (menu.mentionMenu.isOpen && menu.mentionMenu.items.length > 0) ||
+    (menu.slashMenu.isOpen && menu.slashMenu.items.length > 0);
+  const { history, getHistory } = useChatHistory(sessionId);
+  const { editorWrapperRef, ...overlay } = useReverseSearchOverlay(history.length);
+  const { isDraining } = useDrainOlderMessages(sessionId, overlay.isReverseSearchOpen);
+  const { editor, applyHistoryEntry } = useTipTapEditor({
     value,
     onChange,
     onSubmit,
@@ -416,37 +404,125 @@ export const TipTapInput = forwardRef<TipTapInputHandle, TipTapInputProps>(funct
     mentionSuggestion,
     slashSuggestion,
     isSuggestionMenuOpen,
+    getHistory,
+    onOpenReverseSearch: overlay.openReverseSearch,
+    isReverseSearchOpen: overlay.isReverseSearchOpen,
     ref,
   });
-
+  const handleReverseSearchSelect = useCallback(
+    (index: number) => {
+      applyHistoryEntry(index);
+      overlay.closeReverseSearch();
+      editor?.commands.focus("end");
+    },
+    [applyHistoryEntry, overlay, editor],
+  );
   return (
     <>
-      <MentionMenu
-        isOpen={mentionMenu.isOpen}
-        isLoading={false}
-        clientRect={mentionMenu.clientRect}
-        items={mentionMenu.items}
-        query={mentionMenu.query}
-        selectedIndex={mentionSelectedIndex}
-        onSelect={handleMentionSelect}
-        onClose={handleMentionClose}
-        setSelectedIndex={setMentionSelectedIndex}
-      />
-      <SlashCommandMenu
-        isOpen={slashMenu.isOpen}
-        clientRect={slashMenu.clientRect}
-        commands={slashMenu.items}
-        selectedIndex={slashSelectedIndex}
-        onSelect={handleSlashSelect}
-        onClose={handleSlashClose}
-        setSelectedIndex={setSlashSelectedIndex}
+      <TipTapPopups
+        menu={menu}
+        overlay={overlay}
+        history={history}
+        isDraining={isDraining}
+        onReverseSearchSelect={handleReverseSearchSelect}
       />
       <EditorContextProvider value={{ sessionId, taskId: taskId ?? null }}>
-        <EditorContent
-          editor={editor}
-          className="h-full [&_.tiptap]:h-full [&_.tiptap]:outline-none"
-        />
+        <div ref={editorWrapperRef} className="h-full">
+          <EditorContent
+            editor={editor}
+            className="h-full [&_.tiptap]:h-full [&_.tiptap]:outline-none"
+          />
+        </div>
       </EditorContextProvider>
     </>
   );
 });
+
+type TipTapPopupsProps = {
+  menu: ReturnType<typeof useMenuHandlers>;
+  overlay: Omit<ReturnType<typeof useReverseSearchOverlay>, "editorWrapperRef">;
+  history: readonly string[];
+  isDraining: boolean;
+  onReverseSearchSelect: (index: number) => void;
+};
+
+function TipTapPopups({
+  menu,
+  overlay,
+  history,
+  isDraining,
+  onReverseSearchSelect,
+}: TipTapPopupsProps) {
+  return (
+    <>
+      <MentionMenu
+        isOpen={menu.mentionMenu.isOpen}
+        isLoading={false}
+        clientRect={menu.mentionMenu.clientRect}
+        items={menu.mentionMenu.items}
+        query={menu.mentionMenu.query}
+        selectedIndex={menu.mentionSelectedIndex}
+        onSelect={menu.handleMentionSelect}
+        onClose={menu.handleMentionClose}
+        setSelectedIndex={menu.setMentionSelectedIndex}
+      />
+      <SlashCommandMenu
+        isOpen={menu.slashMenu.isOpen}
+        clientRect={menu.slashMenu.clientRect}
+        commands={menu.slashMenu.items}
+        selectedIndex={menu.slashSelectedIndex}
+        onSelect={menu.handleSlashSelect}
+        onClose={menu.handleSlashClose}
+        setSelectedIndex={menu.setSlashSelectedIndex}
+      />
+      {overlay.isReverseSearchOpen && (
+        <MessageHistorySearch
+          isOpen
+          history={history}
+          isLoadingOlder={isDraining}
+          anchorRect={overlay.reverseSearchAnchor}
+          onClose={overlay.closeReverseSearch}
+          onSelect={onReverseSearchSelect}
+        />
+      )}
+    </>
+  );
+}
+
+function useMessageHistoryForSession(sessionId: string | null): string[] {
+  const messages = useAppStore((s) => (sessionId ? s.messages.bySession[sessionId] : undefined));
+  return useMemo(() => extractUserHistory(messages ?? []), [messages]);
+}
+
+function useChatHistory(sessionId: string | null) {
+  const history = useMessageHistoryForSession(sessionId);
+  const historyRef = useRef(history);
+  useLayoutEffect(() => {
+    historyRef.current = history;
+  });
+  const getHistory = useCallback(() => historyRef.current, []);
+  return { history, getHistory, historyRef };
+}
+
+function useReverseSearchOverlay(historyLength: number) {
+  const editorWrapperRef = useRef<HTMLDivElement>(null);
+  const [reverseSearchAnchor, setReverseSearchAnchor] = useState<DOMRect | null>(null);
+  const [isReverseSearchOpen, setIsReverseSearchOpen] = useState(false);
+  const historyLengthRef = useRef(historyLength);
+  useLayoutEffect(() => {
+    historyLengthRef.current = historyLength;
+  });
+  const openReverseSearch = useCallback(() => {
+    if (historyLengthRef.current === 0) return;
+    setReverseSearchAnchor(editorWrapperRef.current?.getBoundingClientRect() ?? null);
+    setIsReverseSearchOpen(true);
+  }, []);
+  const closeReverseSearch = useCallback(() => setIsReverseSearchOpen(false), []);
+  return {
+    editorWrapperRef,
+    reverseSearchAnchor,
+    isReverseSearchOpen,
+    openReverseSearch,
+    closeReverseSearch,
+  };
+}

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -478,7 +478,6 @@ function TipTapPopups({
       />
       {overlay.isReverseSearchOpen && (
         <MessageHistorySearch
-          isOpen
           history={history}
           isLoadingOlder={isDraining}
           anchorRect={overlay.reverseSearchAnchor}
@@ -521,14 +520,17 @@ function useReverseSearchOverlay(sessionId: string | null) {
   const closeReverseSearch = useCallback(() => setIsReverseSearchOpen(false), []);
   // The anchor rect is captured once at open time; dismiss on viewport
   // changes rather than recompute, matching how the project's other
-  // fixed-position popups behave on resize/scroll.
+  // fixed-position popups behave on resize/scroll. Bubbling-phase scroll
+  // only — capture-phase would also catch the overlay's own list scroll
+  // (e.g. from scrollIntoView during keyboard navigation), which would
+  // dismiss the overlay mid-browse.
   useEffect(() => {
     if (!isReverseSearchOpen) return;
     window.addEventListener("resize", closeReverseSearch);
-    window.addEventListener("scroll", closeReverseSearch, true);
+    window.addEventListener("scroll", closeReverseSearch);
     return () => {
       window.removeEventListener("resize", closeReverseSearch);
-      window.removeEventListener("scroll", closeReverseSearch, true);
+      window.removeEventListener("scroll", closeReverseSearch);
     };
   }, [isReverseSearchOpen, closeReverseSearch]);
   return {

--- a/apps/web/components/task/chat/tiptap-input.tsx
+++ b/apps/web/components/task/chat/tiptap-input.tsx
@@ -502,7 +502,7 @@ function useChatHistory(sessionId: string | null) {
     historyRef.current = history;
   });
   const getHistory = useCallback(() => historyRef.current, []);
-  return { history, getHistory, historyRef };
+  return { history, getHistory };
 }
 
 function useReverseSearchOverlay(sessionId: string | null) {
@@ -519,6 +519,18 @@ function useReverseSearchOverlay(sessionId: string | null) {
     setIsReverseSearchOpen(true);
   }, []);
   const closeReverseSearch = useCallback(() => setIsReverseSearchOpen(false), []);
+  // The anchor rect is captured once at open time; dismiss on viewport
+  // changes rather than recompute, matching how the project's other
+  // fixed-position popups behave on resize/scroll.
+  useEffect(() => {
+    if (!isReverseSearchOpen) return;
+    window.addEventListener("resize", closeReverseSearch);
+    window.addEventListener("scroll", closeReverseSearch, true);
+    return () => {
+      window.removeEventListener("resize", closeReverseSearch);
+      window.removeEventListener("scroll", closeReverseSearch, true);
+    };
+  }, [isReverseSearchOpen, closeReverseSearch]);
   return {
     editorWrapperRef,
     reverseSearchAnchor,

--- a/apps/web/components/task/chat/use-drain-older-messages.test.ts
+++ b/apps/web/components/task/chat/use-drain-older-messages.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, cleanup, waitFor } from "@testing-library/react";
+
+const loadMoreMock = vi.fn<[], Promise<number>>();
+
+vi.mock("@/hooks/use-lazy-load-messages", () => ({
+  useLazyLoadMessages: () => ({ loadMore: loadMoreMock, hasMore: true, isLoading: false }),
+}));
+
+import { useDrainOlderMessages } from "./use-drain-older-messages";
+
+beforeEach(() => {
+  loadMoreMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useDrainOlderMessages", () => {
+  it("is idle when inactive", () => {
+    const { result } = renderHook(() => useDrainOlderMessages("s1", false));
+    expect(result.current.isDraining).toBe(false);
+    expect(loadMoreMock).not.toHaveBeenCalled();
+  });
+
+  it("is idle when sessionId is null", () => {
+    const { result } = renderHook(() => useDrainOlderMessages(null, true));
+    expect(result.current.isDraining).toBe(false);
+    expect(loadMoreMock).not.toHaveBeenCalled();
+  });
+
+  it("drains batches until loadMore returns 0", async () => {
+    loadMoreMock.mockResolvedValueOnce(20).mockResolvedValueOnce(20).mockResolvedValueOnce(0);
+    const { result } = renderHook(() => useDrainOlderMessages("s1", true));
+    expect(result.current.isDraining).toBe(true);
+    await waitFor(() => expect(result.current.isDraining).toBe(false));
+    expect(loadMoreMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops at the batch cap when loadMore never empties", async () => {
+    loadMoreMock.mockResolvedValue(20);
+    const { result } = renderHook(() => useDrainOlderMessages("s1", true));
+    await waitFor(() => expect(result.current.isDraining).toBe(false));
+    expect(loadMoreMock).toHaveBeenCalledTimes(50);
+  });
+
+  it("clears isDraining when active flips to false mid-drain", async () => {
+    let resolveFirst: (value: number) => void = () => {};
+    loadMoreMock.mockImplementationOnce(
+      () => new Promise<number>((resolve) => (resolveFirst = resolve)),
+    );
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) => useDrainOlderMessages("s1", active),
+      { initialProps: { active: true } },
+    );
+    expect(result.current.isDraining).toBe(true);
+    rerender({ active: false });
+    expect(result.current.isDraining).toBe(false);
+    resolveFirst(20);
+  });
+
+  it("clears isDraining if loadMore rejects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    loadMoreMock.mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useDrainOlderMessages("s1", true));
+    await waitFor(() => expect(result.current.isDraining).toBe(false));
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/web/components/task/chat/use-drain-older-messages.ts
+++ b/apps/web/components/task/chat/use-drain-older-messages.ts
@@ -16,18 +16,23 @@ export function useDrainOlderMessages(sessionId: string | null, active: boolean)
   useEffect(() => {
     if (!active || !sessionId) return;
     let cancelled = false;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsDraining(true);
     void (async () => {
-      for (let i = 0; i < MAX_DRAIN_BATCHES; i++) {
-        if (cancelled) return;
-        const fetched = await loadMore();
-        if (fetched === 0) break;
+      try {
+        for (let i = 0; i < MAX_DRAIN_BATCHES; i++) {
+          if (cancelled) return;
+          const fetched = await loadMore();
+          if (fetched === 0) break;
+        }
+      } catch (error) {
+        console.error("[useDrainOlderMessages] drain failed:", error);
+      } finally {
+        if (!cancelled) setIsDraining(false);
       }
-      if (!cancelled) setIsDraining(false);
     })();
     return () => {
       cancelled = true;
+      setIsDraining(false);
     };
   }, [active, sessionId, loadMore]);
   return { isDraining };

--- a/apps/web/components/task/chat/use-drain-older-messages.ts
+++ b/apps/web/components/task/chat/use-drain-older-messages.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { useLazyLoadMessages } from "@/hooks/use-lazy-load-messages";
+
+/** Hard cap on background pagination batches when draining older messages so
+ *  a runaway session (or buggy `has_more=true` with empty pages) can't loop
+ *  forever. 50 × 20 messages = 1000-message ceiling. */
+const MAX_DRAIN_BATCHES = 50;
+
+/** When `active` flips true, walk the message pagination cursor until the
+ *  server reports no more older messages (or the cap is hit). Used by the
+ *  Ctrl+R reverse-search overlay so the user can fuzzy-search the entire
+ *  session history, not only the pages already loaded by the chat list. */
+export function useDrainOlderMessages(sessionId: string | null, active: boolean) {
+  const { loadMore } = useLazyLoadMessages(sessionId);
+  const [isDraining, setIsDraining] = useState(false);
+  useEffect(() => {
+    if (!active || !sessionId) return;
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsDraining(true);
+    void (async () => {
+      for (let i = 0; i < MAX_DRAIN_BATCHES; i++) {
+        if (cancelled) return;
+        const fetched = await loadMore();
+        if (fetched === 0) break;
+      }
+      if (!cancelled) setIsDraining(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [active, sessionId, loadMore]);
+  return { isDraining };
+}

--- a/apps/web/components/task/chat/use-tiptap-editor.test.ts
+++ b/apps/web/components/task/chat/use-tiptap-editor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { decideSubmitShortcut } from "./use-tiptap-editor";
+import { decideHistoryNav } from "./tiptap-editor-history";
 
 describe("decideSubmitShortcut", () => {
   describe("submitKey=enter", () => {
@@ -99,6 +100,87 @@ describe("decideSubmitShortcut", () => {
           isSuggestionMenuOpen: false,
         }),
       ).toBe("consume-noop");
+    });
+  });
+});
+
+describe("decideHistoryNav", () => {
+  const base = {
+    disabled: false,
+    isSuggestionMenuOpen: false,
+    isReverseSearchOpen: false,
+    atBoundary: true,
+    historyLength: 3,
+    state: { index: null as number | null },
+  };
+
+  it("defers when disabled", () => {
+    expect(decideHistoryNav({ ...base, direction: "up", disabled: true })).toEqual({
+      kind: "defer",
+    });
+  });
+
+  it("defers when the slash/@ menu is open", () => {
+    expect(decideHistoryNav({ ...base, direction: "up", isSuggestionMenuOpen: true })).toEqual({
+      kind: "defer",
+    });
+  });
+
+  it("defers when the reverse-search overlay owns focus", () => {
+    expect(decideHistoryNav({ ...base, direction: "up", isReverseSearchOpen: true })).toEqual({
+      kind: "defer",
+    });
+  });
+
+  it("defers when history is empty", () => {
+    expect(decideHistoryNav({ ...base, direction: "up", historyLength: 0 })).toEqual({
+      kind: "defer",
+    });
+  });
+
+  it("defers when caret is not at the textblock boundary", () => {
+    expect(decideHistoryNav({ ...base, direction: "up", atBoundary: false })).toEqual({
+      kind: "defer",
+    });
+  });
+
+  it("applies index 0 on first ArrowUp", () => {
+    expect(decideHistoryNav({ ...base, direction: "up" })).toEqual({
+      kind: "apply",
+      index: 0,
+    });
+  });
+
+  it("walks back on subsequent ArrowUp", () => {
+    expect(decideHistoryNav({ ...base, direction: "up", state: { index: 1 } })).toEqual({
+      kind: "apply",
+      index: 2,
+    });
+  });
+
+  it("consumes ArrowUp at the oldest entry (no cursor escape)", () => {
+    expect(decideHistoryNav({ ...base, direction: "up", state: { index: 2 } })).toEqual({
+      kind: "consume-noop",
+    });
+  });
+
+  it("defers ArrowDown when not in history mode (let cursor move normally)", () => {
+    expect(decideHistoryNav({ ...base, direction: "down" })).toEqual({
+      kind: "defer",
+    });
+  });
+
+  it("walks forward on ArrowDown while in history", () => {
+    expect(decideHistoryNav({ ...base, direction: "down", state: { index: 2 } })).toEqual({
+      kind: "apply",
+      index: 1,
+    });
+  });
+
+  it("exits history (restores draft) on ArrowDown from index 0", () => {
+    expect(decideHistoryNav({ ...base, direction: "down", state: { index: 0 } })).toEqual({
+      kind: "apply",
+      index: null,
     });
   });
 });

--- a/apps/web/components/task/chat/use-tiptap-editor.ts
+++ b/apps/web/components/task/chat/use-tiptap-editor.ts
@@ -13,6 +13,7 @@ import { getShortcut, type StoredShortcutOverrides } from "@/lib/keyboard/shortc
 import { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { Extension, isNodeEmpty } from "@tiptap/core";
+import { useHistoryKeymap } from "./tiptap-editor-history";
 import Code from "@tiptap/extension-code";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import { common, createLowlight } from "lowlight";
@@ -121,6 +122,18 @@ type UseTipTapEditorOptions = {
    *  must defer to the suggestion plugin so the highlighted item is inserted
    *  instead of submitting the message. */
   isSuggestionMenuOpen: boolean;
+  /** Returns the user's previous messages for this session, newest-first. The
+   *  caller maintains the actual list; the editor reads it on each keypress so
+   *  ArrowUp/ArrowDown navigate the latest history without prop churn. */
+  getHistory: () => readonly string[];
+  /** Open the Ctrl+R fuzzy search overlay. The overlay lives in the parent
+   *  component (so it can position itself relative to the editor) — the editor
+   *  only knows when to open it. */
+  onOpenReverseSearch: () => void;
+  /** True while the reverse-search overlay owns focus. The editor must ignore
+   *  ArrowUp/ArrowDown in that state so the overlay's own list navigation
+   *  isn't shadowed. */
+  isReverseSearchOpen: boolean;
   ref: React.ForwardedRef<TipTapInputHandle>;
 };
 
@@ -134,6 +147,9 @@ function useTipTapRefs(opts: UseTipTapEditorOptions) {
   const planModeEnabledRef = useRef(opts.planModeEnabled);
   const onPlanModeChangeRef = useRef(opts.onPlanModeChange);
   const isSuggestionMenuOpenRef = useRef(opts.isSuggestionMenuOpen);
+  const getHistoryRef = useRef(opts.getHistory);
+  const onOpenReverseSearchRef = useRef(opts.onOpenReverseSearch);
+  const isReverseSearchOpenRef = useRef(opts.isReverseSearchOpen);
   const keyboardShortcuts = useAppStore((s) => s.userSettings.keyboardShortcuts);
   const keyboardShortcutsRef = useRef(keyboardShortcuts);
   useLayoutEffect(() => {
@@ -146,6 +162,9 @@ function useTipTapRefs(opts: UseTipTapEditorOptions) {
     planModeEnabledRef.current = opts.planModeEnabled;
     onPlanModeChangeRef.current = opts.onPlanModeChange;
     isSuggestionMenuOpenRef.current = opts.isSuggestionMenuOpen;
+    getHistoryRef.current = opts.getHistory;
+    onOpenReverseSearchRef.current = opts.onOpenReverseSearch;
+    isReverseSearchOpenRef.current = opts.isReverseSearchOpen;
     keyboardShortcutsRef.current = keyboardShortcuts;
   });
   return {
@@ -158,25 +177,77 @@ function useTipTapRefs(opts: UseTipTapEditorOptions) {
     planModeEnabledRef,
     onPlanModeChangeRef,
     isSuggestionMenuOpenRef,
+    getHistoryRef,
+    onOpenReverseSearchRef,
+    isReverseSearchOpenRef,
     keyboardShortcutsRef,
   };
 }
 
+function buildEditorExtensions(args: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mentionSuggestion: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  slashSuggestion: any;
+  submitKeymap: Extension;
+  historyKeymap: Extension;
+}) {
+  return [
+    Document,
+    Paragraph,
+    Text,
+    HardBreak,
+    History,
+    Code,
+    CodeBlockLowlight.extend({
+      addNodeView() {
+        return ReactNodeViewRenderer(CodeBlockView);
+      },
+    }).configure({ lowlight: lowlightInstance }),
+    DynamicPlaceholder,
+    ContextMention.configure({
+      suggestions: [args.mentionSuggestion, args.slashSuggestion],
+    }),
+    args.submitKeymap,
+    args.historyKeymap,
+  ];
+}
+
+function buildEditorProps(args: {
+  planModeEnabled: boolean;
+  className: string | undefined;
+  onFocus: (() => void) | undefined;
+  onBlur: (() => void) | undefined;
+  onImagePasteRef: React.RefObject<((files: File[]) => void) | undefined>;
+}) {
+  return {
+    attributes: {
+      class: cn(
+        "w-full h-full resize-none bg-transparent px-2 py-2 overflow-y-auto",
+        "text-sm leading-relaxed",
+        "placeholder:text-muted-foreground",
+        "focus:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        args.planModeEnabled && "border-primary/40",
+        args.className,
+      ),
+    },
+    handlePaste: (view: import("@tiptap/pm/view").EditorView, event: ClipboardEvent) =>
+      handleEditorPaste(view, event, args.onImagePasteRef),
+    handleDOMEvents: {
+      focus: () => {
+        args.onFocus?.();
+        return false;
+      },
+      blur: () => {
+        args.onBlur?.();
+        return false;
+      },
+    },
+  };
+}
+
 export function useTipTapEditor(opts: UseTipTapEditorOptions) {
-  const {
-    value,
-    onChange,
-    placeholder,
-    disabled,
-    className,
-    planModeEnabled,
-    onFocus,
-    onBlur,
-    sessionId,
-    mentionSuggestion,
-    slashSuggestion,
-    ref,
-  } = opts;
   const refs = useTipTapRefs(opts);
   const SubmitKeymap = useSubmitKeymap({
     disabledRef: refs.disabledRef,
@@ -187,50 +258,31 @@ export function useTipTapEditor(opts: UseTipTapEditorOptions) {
     isSuggestionMenuOpenRef: refs.isSuggestionMenuOpenRef,
     keyboardShortcutsRef: refs.keyboardShortcutsRef,
   });
+  const historyController = useHistoryKeymap({
+    disabledRef: refs.disabledRef,
+    isSuggestionMenuOpenRef: refs.isSuggestionMenuOpenRef,
+    isReverseSearchOpenRef: refs.isReverseSearchOpenRef,
+    getHistoryRef: refs.getHistoryRef,
+    onOpenReverseSearchRef: refs.onOpenReverseSearchRef,
+    onChangeRef: refs.onChangeRef,
+  });
   const isSyncingRef = useRef(false);
   const initialSyncDoneRef = useRef(false);
   const editor = useEditor({
     immediatelyRender: false,
-    extensions: [
-      Document,
-      Paragraph,
-      Text,
-      HardBreak,
-      History,
-      Code,
-      CodeBlockLowlight.extend({
-        addNodeView() {
-          return ReactNodeViewRenderer(CodeBlockView);
-        },
-      }).configure({ lowlight: lowlightInstance }),
-      DynamicPlaceholder,
-      ContextMention.configure({ suggestions: [mentionSuggestion, slashSuggestion] }),
-      SubmitKeymap,
-    ],
-    editorProps: {
-      attributes: {
-        class: cn(
-          "w-full h-full resize-none bg-transparent px-2 py-2 overflow-y-auto",
-          "text-sm leading-relaxed",
-          "placeholder:text-muted-foreground",
-          "focus:outline-none",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          planModeEnabled && "border-primary/40",
-          className,
-        ),
-      },
-      handlePaste: (view, event) => handleEditorPaste(view, event, refs.onImagePasteRef),
-      handleDOMEvents: {
-        focus: () => {
-          onFocus?.();
-          return false;
-        },
-        blur: () => {
-          onBlur?.();
-          return false;
-        },
-      },
-    },
+    extensions: buildEditorExtensions({
+      mentionSuggestion: opts.mentionSuggestion,
+      slashSuggestion: opts.slashSuggestion,
+      submitKeymap: SubmitKeymap,
+      historyKeymap: historyController.extension,
+    }),
+    editorProps: buildEditorProps({
+      planModeEnabled: opts.planModeEnabled,
+      className: opts.className,
+      onFocus: opts.onFocus,
+      onBlur: opts.onBlur,
+      onImagePasteRef: refs.onImagePasteRef,
+    }),
     onUpdate: ({ editor: e }) => {
       if (isSyncingRef.current || !initialSyncDoneRef.current) return;
       const text = getMarkdownText(e);
@@ -238,20 +290,24 @@ export function useTipTapEditor(opts: UseTipTapEditorOptions) {
       const sid = refs.sessionIdRef.current;
       if (sid) setChatDraftContent(sid, e.getJSON());
     },
-    editable: !disabled,
+    editable: !opts.disabled,
   });
   useSyncEditor({
     editor,
-    disabled,
-    placeholder,
-    sessionId,
-    value,
+    disabled: opts.disabled,
+    placeholder: opts.placeholder,
+    sessionId: opts.sessionId,
+    value: opts.value,
     isSyncingRef,
     initialSyncDoneRef,
     onChangeRef: refs.onChangeRef,
   });
-  useEditorImperativeHandle(ref, editor, onChange, isSyncingRef);
-  return editor;
+  useEditorImperativeHandle(opts.ref, editor, opts.onChange, isSyncingRef);
+  const applyHistoryEntry = useMemo(
+    () => (index: number) => historyController.applyHistoryIndex(editor, index),
+    [editor, historyController],
+  );
+  return { editor, applyHistoryEntry };
 }
 
 // ── Sync hook ─────────────────────────────────────────────────────


### PR DESCRIPTION
Power-user navigation for the chat composer: ArrowUp/ArrowDown cycle previously sent user messages (bash-style), and Ctrl+R opens a fuzzy reverse-search overlay so picking an old prompt to resend or remix doesn't require scrolling the chat list.

## Important Changes

- New ProseMirror keymap extension (`tiptap-editor-history.ts`) owns history index + draft state and exposes an `applyHistoryIndex` imperative so the search overlay can slot a picked entry back into the up/down cycle.
- Ctrl+R overlay (`message-history-search.tsx`) renders via portal anchored to the editor's bounding rect; on open it triggers `useDrainOlderMessages` to walk the paginated `message.list` cursor (cap: 50 batches / 1000 msgs) so the search covers the full session, not only pages already loaded by the chat list. The list updates live as batches arrive.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web test` — 343 files / 2970 tests pass (added 23 cases for `extractUserHistory`/`navigateHistory`/`fuzzyScore`/`searchHistory` and 11 for `decideHistoryNav`).
- Manual browser smoke-test still pending — keymap/overlay logic is covered by pure-function tests against `decideHistoryNav` + `searchHistory`, but real-editor interaction (ArrowUp at the top of a multi-line paragraph, Ctrl+R focus stealing, mobile Safari) is worth eyeballing before merging.

## Possible Improvements

- Low risk: keymap defers to normal cursor movement whenever the caret isn't at the first/last textblock boundary, so unrelated arrow-key behaviour is unaffected. Worst case if the drain loop misbehaves is wasted requests up to the 50-batch cap — the overlay still works against whatever pages are loaded.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.