### PR TITLE
fix(agentctl): reap disconnected ACP sessions + MCP child trees

### DIFF
--- a/apps/backend/internal/agent/agents/agent.go
+++ b/apps/backend/internal/agent/agents/agent.go
@@ -183,6 +183,12 @@ type RuntimeConfig struct {
 	AssumeMcpHttp   bool   // Override: assume agent supports HTTP MCP servers even if not advertised
 	ProjectSkillDir string // CWD-relative path for project-level skills (e.g. ".claude/skills")
 	UserSkillDir    string // home-relative path for user-level skills (e.g. ".claude/skills")
+	// RequiresProcessKill is true for agents whose subprocess does not exit
+	// when stdin is closed (e.g. OpenCode's ACP runtime, which keeps its HTTP
+	// server and MCP child tree alive). When true, the agentctl process
+	// manager kills the whole process group on shutdown so MCP children
+	// don't leak.
+	RequiresProcessKill bool
 }
 
 // MountTemplate defines a mount with template variables.

--- a/apps/backend/internal/agent/agents/opencode_acp.go
+++ b/apps/backend/internal/agent/agents/opencode_acp.go
@@ -92,6 +92,11 @@ func (a *OpenCodeACP) Runtime() *RuntimeConfig {
 		Protocol:        agent.ProtocolACP,
 		ProjectSkillDir: ".agents/skills",
 		UserSkillDir:    ".config/opencode/skills",
+		// opencode acp runs its HTTP server + MCP child tree alongside the
+		// ACP stdin/stdout. Closing stdin doesn't terminate the process —
+		// we have to kill its process group to reap the MCP children.
+		// See GH issue #1247.
+		RequiresProcessKill: true,
 		SessionConfig: SessionConfig{
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,

--- a/apps/backend/internal/agent/agents/opencode_acp_test.go
+++ b/apps/backend/internal/agent/agents/opencode_acp_test.go
@@ -5,6 +5,49 @@ import (
 	"testing"
 )
 
+// TestOpenCodeACPRuntime_RequiresProcessKill is the regression test for GH
+// issue #1247: opencode acp keeps its HTTP server + MCP child tree alive
+// when stdin closes, so its RuntimeConfig must signal that the process
+// group has to be killed on shutdown. Without this flag the ACP adapter
+// returns RequiresProcessKill=false and the process manager only closes
+// stdin — opencode never exits and MCP children leak.
+func TestOpenCodeACPRuntime_RequiresProcessKill(t *testing.T) {
+	rt := NewOpenCodeACP().Runtime()
+	if rt == nil {
+		t.Fatal("Runtime() returned nil")
+	}
+	if !rt.RequiresProcessKill {
+		t.Error("RequiresProcessKill = false; opencode acp must opt into process-group kill")
+	}
+}
+
+// TestACPAgents_DefaultProcessKill confirms the rest of the ACP agents
+// stick with the default (false). They communicate over plain stdin/stdout
+// and exit on EOF, so the process manager's graceful-stdin-close path is
+// the correct shutdown signal — flipping this true would force-kill agents
+// that are perfectly capable of cleanup.
+func TestACPAgents_DefaultProcessKill(t *testing.T) {
+	cases := []struct {
+		name  string
+		agent Agent
+	}{
+		{"claude", NewClaudeACP()},
+		{"codex", NewCodexACP()},
+		{"cursor", NewCursorACP()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := tc.agent.Runtime()
+			if rt == nil {
+				t.Fatalf("%s Runtime() returned nil", tc.name)
+			}
+			if rt.RequiresProcessKill {
+				t.Errorf("%s RequiresProcessKill = true; expected default false", tc.name)
+			}
+		})
+	}
+}
+
 func TestOpenCodeACPRemoteAuth(t *testing.T) {
 	auth := NewOpenCodeACP().RemoteAuth()
 	if auth == nil {

--- a/apps/backend/internal/agent/runtime/agentctl/control.go
+++ b/apps/backend/internal/agent/runtime/agentctl/control.go
@@ -54,6 +54,11 @@ type CreateInstanceRequest struct {
 	AssumeMcpSse       bool              `json:"assume_mcp_sse,omitempty"`       // Assume agent supports SSE MCP servers
 	AssumeMcpHttp      bool              `json:"assume_mcp_http,omitempty"`      // Assume agent supports HTTP MCP servers
 	McpMode            string            `json:"mcp_mode,omitempty"`             // MCP tool mode: "task" (default) or "config"
+	// RequiresProcessKill forces agentctl to kill the agent's process group
+	// (not just close stdin) on shutdown. Required for agents whose runtime
+	// keeps child processes (e.g. MCP servers) alive when stdin closes —
+	// notably opencode acp.
+	RequiresProcessKill bool `json:"requires_process_kill,omitempty"`
 }
 
 // CreateInstanceResponse contains the result of creating a new agent instance.

--- a/apps/backend/internal/agent/runtime/lifecycle/container.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/container.go
@@ -203,26 +203,29 @@ func (cm *ContainerManager) createInstanceAndClient(
 	disableAskQuestion := agents.IsPassthroughOnly(config.AgentConfig)
 	assumeMcpSse := false
 	assumeMcpHttp := false
+	requiresProcessKill := false
 	if config.AgentConfig != nil {
 		if rt := config.AgentConfig.Runtime(); rt != nil {
 			assumeMcpSse = rt.AssumeMcpSse
 			assumeMcpHttp = rt.AssumeMcpHttp
+			requiresProcessKill = rt.RequiresProcessKill
 		}
 	}
 
 	createReq := &agentctl.CreateInstanceRequest{
-		ID:                 config.InstanceID,
-		WorkspacePath:      "/workspace",
-		AgentCommand:       "",
-		AgentType:          agentType,
-		Env:                config.Credentials,
-		AutoStart:          false,
-		McpServers:         config.McpServers,
-		SessionID:          config.SessionID,
-		DisableAskQuestion: disableAskQuestion,
-		AssumeMcpSse:       assumeMcpSse,
-		AssumeMcpHttp:      assumeMcpHttp,
-		McpMode:            config.McpMode,
+		ID:                  config.InstanceID,
+		WorkspacePath:       "/workspace",
+		AgentCommand:        "",
+		AgentType:           agentType,
+		Env:                 config.Credentials,
+		AutoStart:           false,
+		McpServers:          config.McpServers,
+		SessionID:           config.SessionID,
+		DisableAskQuestion:  disableAskQuestion,
+		AssumeMcpSse:        assumeMcpSse,
+		AssumeMcpHttp:       assumeMcpHttp,
+		McpMode:             config.McpMode,
+		RequiresProcessKill: requiresProcessKill,
 	}
 
 	resp, err := ctl.CreateInstance(ctx, createReq)

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_docker.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_docker.go
@@ -444,27 +444,30 @@ func buildReconnectCreateInstanceRequest(req *ExecutorCreateRequest, instanceID 
 	disableAskQuestion := false
 	assumeMcpSse := false
 	assumeMcpHttp := false
+	requiresProcessKill := false
 	if req.AgentConfig != nil {
 		agentType = req.AgentConfig.ID()
 		disableAskQuestion = agents.IsPassthroughOnly(req.AgentConfig)
 		if rt := req.AgentConfig.Runtime(); rt != nil {
 			assumeMcpSse = rt.AssumeMcpSse
 			assumeMcpHttp = rt.AssumeMcpHttp
+			requiresProcessKill = rt.RequiresProcessKill
 		}
 	}
 	return &agentctl.CreateInstanceRequest{
-		ID:                 instanceID,
-		WorkspacePath:      dockerWorkspacePath,
-		AgentType:          agentType,
-		Env:                req.Env,
-		AutoStart:          false,
-		McpServers:         req.McpServers,
-		SessionID:          req.SessionID,
-		TaskID:             req.TaskID,
-		DisableAskQuestion: disableAskQuestion,
-		AssumeMcpSse:       assumeMcpSse,
-		AssumeMcpHttp:      assumeMcpHttp,
-		McpMode:            req.McpMode,
+		ID:                  instanceID,
+		WorkspacePath:       dockerWorkspacePath,
+		AgentType:           agentType,
+		Env:                 req.Env,
+		AutoStart:           false,
+		McpServers:          req.McpServers,
+		SessionID:           req.SessionID,
+		TaskID:              req.TaskID,
+		DisableAskQuestion:  disableAskQuestion,
+		AssumeMcpSse:        assumeMcpSse,
+		AssumeMcpHttp:       assumeMcpHttp,
+		McpMode:             req.McpMode,
+		RequiresProcessKill: requiresProcessKill,
 	}
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_sprites_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_sprites_operations.go
@@ -357,14 +357,15 @@ func (r *SpritesExecutor) createAgentInstance(
 	req *ExecutorCreateRequest,
 ) (int, error) {
 	instanceReq := agentctl.CreateInstanceRequest{
-		ID:            req.InstanceID,
-		WorkspacePath: spritesWorkspacePath,
-		SessionID:     req.SessionID,
-		TaskID:        req.TaskID,
-		Protocol:      req.Protocol,
-		AgentType:     agentTypeFromReq(req),
-		McpServers:    req.McpServers,
-		McpMode:       req.McpMode,
+		ID:                  req.InstanceID,
+		WorkspacePath:       spritesWorkspacePath,
+		SessionID:           req.SessionID,
+		TaskID:              req.TaskID,
+		Protocol:            req.Protocol,
+		AgentType:           agentTypeFromReq(req),
+		McpServers:          req.McpServers,
+		McpMode:             req.McpMode,
+		RequiresProcessKill: requiresProcessKillFromReq(req),
 	}
 	reqJSON, err := json.Marshal(instanceReq)
 	if err != nil {
@@ -467,6 +468,19 @@ func agentTypeFromReq(req *ExecutorCreateRequest) string {
 		return req.AgentConfig.ID()
 	}
 	return ""
+}
+
+// requiresProcessKillFromReq returns the agent's RequiresProcessKill setting
+// from its RuntimeConfig (false when unset).
+func requiresProcessKillFromReq(req *ExecutorCreateRequest) bool {
+	if req == nil || req.AgentConfig == nil {
+		return false
+	}
+	rt := req.AgentConfig.Runtime()
+	if rt == nil {
+		return false
+	}
+	return rt.RequiresProcessKill
 }
 
 func (r *SpritesExecutor) waitForHealth(ctx context.Context, sprite *sprites.Sprite) error {

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -471,14 +471,15 @@ func createRemoteAgentInstance(
 	log *logger.Logger,
 ) (int, error) {
 	body, err := json.Marshal(agentctl.CreateInstanceRequest{
-		ID:            req.InstanceID,
-		WorkspacePath: workspacePath,
-		SessionID:     req.SessionID,
-		TaskID:        req.TaskID,
-		Protocol:      req.Protocol,
-		AgentType:     sshAgentTypeFromReq(req),
-		McpServers:    req.McpServers,
-		McpMode:       req.McpMode,
+		ID:                  req.InstanceID,
+		WorkspacePath:       workspacePath,
+		SessionID:           req.SessionID,
+		TaskID:              req.TaskID,
+		Protocol:            req.Protocol,
+		AgentType:           sshAgentTypeFromReq(req),
+		McpServers:          req.McpServers,
+		McpMode:             req.McpMode,
+		RequiresProcessKill: requiresProcessKillFromReq(req),
 	})
 	if err != nil {
 		return 0, fmt.Errorf("ssh: marshal create-instance: %w", err)

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_standalone.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_standalone.go
@@ -97,28 +97,31 @@ func (r *StandaloneExecutor) CreateInstance(ctx context.Context, req *ExecutorCr
 	disableAskQuestion := agents.IsPassthroughOnly(req.AgentConfig)
 	assumeMcpSse := false
 	assumeMcpHttp := false
+	requiresProcessKill := false
 	if req.AgentConfig != nil {
 		if rt := req.AgentConfig.Runtime(); rt != nil {
 			assumeMcpSse = rt.AssumeMcpSse
 			assumeMcpHttp = rt.AssumeMcpHttp
+			requiresProcessKill = rt.RequiresProcessKill
 		}
 	}
 
 	createReq := &agentctl.CreateInstanceRequest{
-		ID:                 req.InstanceID,
-		WorkspacePath:      req.WorkspacePath,
-		AgentCommand:       "", // Agent command set via Configure endpoint
-		Protocol:           req.Protocol,
-		AgentType:          agentType,
-		Env:                env,
-		AutoStart:          false,
-		McpServers:         req.McpServers,
-		SessionID:          req.SessionID,
-		TaskID:             req.TaskID,
-		DisableAskQuestion: disableAskQuestion,
-		AssumeMcpSse:       assumeMcpSse,
-		AssumeMcpHttp:      assumeMcpHttp,
-		McpMode:            req.McpMode,
+		ID:                  req.InstanceID,
+		WorkspacePath:       req.WorkspacePath,
+		AgentCommand:        "", // Agent command set via Configure endpoint
+		Protocol:            req.Protocol,
+		AgentType:           agentType,
+		Env:                 env,
+		AutoStart:           false,
+		McpServers:          req.McpServers,
+		SessionID:           req.SessionID,
+		TaskID:              req.TaskID,
+		DisableAskQuestion:  disableAskQuestion,
+		AssumeMcpSse:        assumeMcpSse,
+		AssumeMcpHttp:       assumeMcpHttp,
+		McpMode:             req.McpMode,
+		RequiresProcessKill: requiresProcessKill,
 	}
 
 	r.logger.Info("CreateInstance: sending request to agentctl",

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -82,7 +82,7 @@ The signal flows agent → adapter → process manager via a single bool:
 3. `instance.Manager` stores it on `config.InstanceConfig.RequiresProcessKill`.
 4. `process.Manager.buildAdapterConfig` forwards it into `adapter.Config` → `shared.Config`.
 5. `acp.Adapter.RequiresProcessKill()` returns `cfg.RequiresProcessKill`.
-6. On shutdown, `process.Manager.killProcessGroupIfRequired` consults the adapter and, when true, sends SIGTERM to the whole pgid. The timeout fallback in `waitForProcessExit` *always* kills the pgid (not just the leader) — belt-and-braces for any future ACP CLI that decides to ignore stdin close.
+6. On shutdown, `process.Manager.killProcessGroupIfRequired` consults the adapter and, when true, sends SIGKILL to the whole pgid via `killProcessGroup` (`syscall.Kill(-pid, SIGKILL)` on Unix). If `Stop(ctx)` further times out before the process exits, `waitForProcessExit`'s `ctx.Done` branch re-runs the pgid SIGKILL (falling back to a leader-only kill if the group call errors) — belt-and-braces for any future ACP CLI that decides to ignore stdin close.
 
 To add another agent that needs this: set `RequiresProcessKill: true` in its `Runtime()` config — that's all.
 

--- a/apps/backend/internal/agentctl/AGENTS.md
+++ b/apps/backend/internal/agentctl/AGENTS.md
@@ -71,6 +71,35 @@ Kandev renders subagents (the `Task` tool) as cards and *wants* to nest each sub
 
 Claude is the one that works today: `claude-agent-acp` (since PR #341) sets `_meta.claudeCode.parentToolUseId` on a subagent's internal calls, and its value already equals the parent Task tool_call id — so it maps straight onto our `parent_tool_call_id`. Cursor exposes nothing to nest. OpenCode needs a kandev-side child-session merge. (Top-level `parentToolCallId` is NOT in the ACP schema — `_meta` is the spec-compliant carrier.)
 
+## Process-group kill for HTTP-server agents (`RequiresProcessKill`)
+
+Most ACP agents (Claude Code, Codex, Cursor, …) exit cleanly when stdin is closed. Some agents — notably `opencode acp` — keep their HTTP server and an MCP child tree alive after stdin EOF. For those agents, closing stdin on shutdown is not enough; the process group has to be SIGKILLed so the MCP children don't re-parent to init and leak (GH issue #1247).
+
+The signal flows agent → adapter → process manager via a single bool:
+
+1. `agents.RuntimeConfig.RequiresProcessKill` (set `true` on `OpenCodeACP`).
+2. The lifecycle executors copy it into `agentctl.CreateInstanceRequest.RequiresProcessKill`.
+3. `instance.Manager` stores it on `config.InstanceConfig.RequiresProcessKill`.
+4. `process.Manager.buildAdapterConfig` forwards it into `adapter.Config` → `shared.Config`.
+5. `acp.Adapter.RequiresProcessKill()` returns `cfg.RequiresProcessKill`.
+6. On shutdown, `process.Manager.killProcessGroupIfRequired` consults the adapter and, when true, sends SIGTERM to the whole pgid. The timeout fallback in `waitForProcessExit` *always* kills the pgid (not just the leader) — belt-and-braces for any future ACP CLI that decides to ignore stdin close.
+
+To add another agent that needs this: set `RequiresProcessKill: true` in its `Runtime()` config — that's all.
+
+## Idle-instance reaper (`KANDEV_ACP_IDLE_TIMEOUT`)
+
+`instance.Manager` runs a background goroutine that reaps instances whose owning kandev backend appears to be gone. An instance is "idle" when it has zero in-flight HTTP requests *and* its most recent observed activity is older than the configured timeout. Activity is tracked by a middleware on the per-instance handler that bumps a counter on every request entry/exit, so a long-lived `/agent/stream` WebSocket keeps the instance "active" for as long as the stream is open.
+
+Env knobs:
+- `KANDEV_ACP_IDLE_TIMEOUT` (default `1h`, `0` to disable)
+- `KANDEV_ACP_IDLE_REAPER_INTERVAL` (default `1m`)
+
+Both accept any value `time.ParseDuration` accepts (`30m`, `2h`, `500ms`, …). Disabled mode is intended for tests and edge cases — production should keep the reaper on.
+
+## MCP stdio command validation
+
+`instance.Manager.buildMcpServerConfigs` calls `exec.LookPath` on every stdio MCP `Command` before passing the list to the agent. Entries whose command can't be resolved are dropped with a warn log (URL-transport MCPs always pass through). This prevents the `/snap/bin/brave` repro in GH issue #1247 — an MCP whose binary was uninstalled after config save no longer causes a permanently broken child process to be spawned every session.
+
 ## Further scoped notes
 
 - `server/api/AGENTS.md` — reverse-proxy body rewriting (`Accept-Encoding`) and iframe-blocking header stripping.

--- a/apps/backend/internal/agentctl/server/adapter/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/adapter.go
@@ -270,6 +270,12 @@ type Config struct {
 
 	// AssumeMcpHttp overrides MCP capability filtering to assume HTTP support.
 	AssumeMcpHttp bool
+
+	// RequiresProcessKill is read by the transport adapter's RequiresProcessKill()
+	// method. Set true for agents whose subprocess does not exit on stdin close
+	// (opencode acp). The process manager uses the adapter's return value to
+	// decide whether to kill the entire process group on shutdown.
+	RequiresProcessKill bool
 }
 
 // ToSharedConfig converts this Config to the shared.Config used by transport adapters.
@@ -287,18 +293,19 @@ func (c *Config) ToSharedConfig() *shared.Config {
 		}
 	}
 	return &shared.Config{
-		WorkDir:        c.WorkDir,
-		AutoApprove:    c.AutoApprove,
-		ApprovalPolicy: c.ApprovalPolicy,
-		McpServers:     mcpServers,
-		AgentID:        c.AgentID,
-		AgentName:      c.AgentName,
-		BaseURL:        c.BaseURL,
-		AuthHeader:     c.AuthHeader,
-		AuthValue:      c.AuthValue,
-		Headers:        c.Headers,
-		Extra:          c.Extra,
-		AssumeMcpSse:   c.AssumeMcpSse,
-		AssumeMcpHttp:  c.AssumeMcpHttp,
+		WorkDir:             c.WorkDir,
+		AutoApprove:         c.AutoApprove,
+		ApprovalPolicy:      c.ApprovalPolicy,
+		McpServers:          mcpServers,
+		AgentID:             c.AgentID,
+		AgentName:           c.AgentName,
+		BaseURL:             c.BaseURL,
+		AuthHeader:          c.AuthHeader,
+		AuthValue:           c.AuthValue,
+		Headers:             c.Headers,
+		Extra:               c.Extra,
+		AssumeMcpSse:        c.AssumeMcpSse,
+		AssumeMcpHttp:       c.AssumeMcpHttp,
+		RequiresProcessKill: c.RequiresProcessKill,
 	}
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -397,9 +397,14 @@ func (a *Adapter) Close() error {
 	return nil
 }
 
-// RequiresProcessKill returns false because ACP agents exit when stdin is closed.
+// RequiresProcessKill reports whether the agent's process group must be killed
+// on shutdown. Most ACP agents exit cleanly when stdin closes, but some (notably
+// opencode acp) keep an HTTP server and MCP child tree alive after EOF —
+// those agents set cfg.RequiresProcessKill so the process manager reaps the
+// entire group instead of waiting for a graceful exit that never comes.
+// See GH issue #1247.
 func (a *Adapter) RequiresProcessKill() bool {
-	return false
+	return a.cfg != nil && a.cfg.RequiresProcessKill
 }
 
 // getPromptTraceCtx returns the current prompt span context for child-span linking.

--- a/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/shared/config.go
@@ -52,6 +52,13 @@ type Config struct {
 
 	// AssumeMcpHttp overrides MCP capability filtering to assume HTTP support.
 	AssumeMcpHttp bool
+
+	// RequiresProcessKill is returned verbatim from the adapter's
+	// RequiresProcessKill() method. Set true for agents whose subprocess does
+	// not exit on stdin close (opencode acp). The process manager uses the
+	// adapter's return value to decide whether to kill the entire process
+	// group on shutdown so MCP child processes don't leak.
+	RequiresProcessKill bool
 }
 
 // GetPermissionTimeout returns the configured permission timeout or the default.

--- a/apps/backend/internal/agentctl/server/config/config.go
+++ b/apps/backend/internal/agentctl/server/config/config.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kandev/kandev/pkg/agent"
 )
@@ -56,6 +57,18 @@ type Config struct {
 	// at startup and exposes POST /auth/handshake for the backend to retrieve it.
 	// The nonce is burned after a single successful handshake.
 	BootstrapNonce string
+
+	// IdleTimeout is the duration after which an instance with no in-flight
+	// requests and no recent HTTP activity is reaped by the instance
+	// manager. Sourced from KANDEV_ACP_IDLE_TIMEOUT (default 1h).
+	// Setting it to 0 disables the reaper.
+	IdleTimeout time.Duration
+
+	// IdleReaperInterval is how often the idle reaper scans for stale
+	// instances. Sourced from KANDEV_ACP_IDLE_REAPER_INTERVAL (default 1m).
+	// Only the test suite needs to override this; production code should
+	// rely on the default.
+	IdleReaperInterval time.Duration
 
 	// mu protects BootstrapNonce from concurrent access during handshake.
 	mu sync.Mutex
@@ -202,6 +215,11 @@ type InstanceConfig struct {
 	// AuthToken is a shared secret for authenticating requests.
 	// Inherited from the parent Config at instance creation time.
 	AuthToken string
+
+	// RequiresProcessKill forces the agent's process group to be killed on
+	// shutdown instead of relying on stdin close. Required for agents whose
+	// runtime keeps child processes alive when stdin closes (opencode acp).
+	RequiresProcessKill bool
 }
 
 // Load loads the configuration from environment variables.
@@ -221,11 +239,13 @@ func Load() *Config {
 			HealthCheckInterval:    getEnvInt("AGENTCTL_HEALTH_CHECK_INTERVAL", 5),
 			ProcessBufferMaxBytes:  getEnvInt64("AGENTCTL_PROCESS_BUFFER_MAX_BYTES", 2*1024*1024),
 		},
-		ShellEnabled:  getEnvBool("AGENTCTL_SHELL_ENABLED", true),
-		LogLevel:      getEnvWithFallback("AGENTCTL_LOG_LEVEL", "KANDEV_LOG_LEVEL", "info"),
-		LogFormat:     getEnv("AGENTCTL_LOG_FORMAT", "json"),
-		McpLogFile:    getEnv("KANDEV_MCP_LOG_FILE", ""),
-		VscodeCommand: getEnv("AGENTCTL_VSCODE_COMMAND", "code-server"),
+		ShellEnabled:       getEnvBool("AGENTCTL_SHELL_ENABLED", true),
+		LogLevel:           getEnvWithFallback("AGENTCTL_LOG_LEVEL", "KANDEV_LOG_LEVEL", "info"),
+		LogFormat:          getEnv("AGENTCTL_LOG_FORMAT", "json"),
+		McpLogFile:         getEnv("KANDEV_MCP_LOG_FILE", ""),
+		VscodeCommand:      getEnv("AGENTCTL_VSCODE_COMMAND", "code-server"),
+		IdleTimeout:        getEnvDuration("KANDEV_ACP_IDLE_TIMEOUT", time.Hour),
+		IdleReaperInterval: getEnvDuration("KANDEV_ACP_IDLE_REAPER_INTERVAL", time.Minute),
 	}
 
 	// Bootstrap nonce mode: agentctl generates its own token and the backend
@@ -357,25 +377,29 @@ func applyOverrides(cfg *InstanceConfig, overrides *InstanceOverrides) {
 	if overrides.McpMode != "" {
 		cfg.McpMode = overrides.McpMode
 	}
+	if overrides.RequiresProcessKill {
+		cfg.RequiresProcessKill = true
+	}
 }
 
 // InstanceOverrides allows overriding default values when creating an instance
 type InstanceOverrides struct {
-	InstanceID         string
-	Protocol           agent.Protocol
-	AgentCommand       string
-	WorkDir            string
-	AutoStart          *bool
-	Env                []string
-	ApprovalPolicy     string
-	AgentType          string
-	McpServers         []McpServerConfig
-	SessionID          string
-	TaskID             string
-	DisableAskQuestion bool
-	AssumeMcpSse       bool
-	AssumeMcpHttp      bool
-	McpMode            string
+	InstanceID          string
+	Protocol            agent.Protocol
+	AgentCommand        string
+	WorkDir             string
+	AutoStart           *bool
+	Env                 []string
+	ApprovalPolicy      string
+	AgentType           string
+	McpServers          []McpServerConfig
+	SessionID           string
+	TaskID              string
+	DisableAskQuestion  bool
+	AssumeMcpSse        bool
+	AssumeMcpHttp       bool
+	McpMode             string
+	RequiresProcessKill bool
 }
 
 // ParseCommand splits a command string into arguments
@@ -464,6 +488,21 @@ func getEnvBool(key string, defaultValue bool) bool {
 		return strings.ToLower(value) == "true" || value == "1"
 	}
 	return defaultValue
+}
+
+// getEnvDuration parses a duration value from an env var. Accepts any value
+// time.ParseDuration accepts (e.g. "1h", "30m", "500ms"). "0" disables the
+// feature. Invalid or missing values return defaultValue.
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return defaultValue
+	}
+	return d
 }
 
 // kandevMcpServerName is the name used for the local kandev MCP server.

--- a/apps/backend/internal/agentctl/server/instance/idle_reaper.go
+++ b/apps/backend/internal/agentctl/server/instance/idle_reaper.go
@@ -1,0 +1,100 @@
+package instance
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// idleReaperShutdownTimeout bounds how long an idle StopInstance call can
+// take before the reaper moves on. Mirrors the timeout used by the regular
+// DELETE /instances/{id} HTTP path (control_server.go), so a stuck
+// teardown can't block the periodic sweep.
+const idleReaperShutdownTimeout = 15 * time.Second
+
+// activityMiddleware wraps a handler so every request bumps the owning
+// instance's lastActivity timestamp and inflight counter. The counter is
+// kept above zero for the full duration of long-lived requests
+// (WebSocket streams), which is the signal the idle reaper uses to treat
+// an instance with an open stream as active even when no new HTTP request
+// arrives.
+func activityMiddleware(inst *Instance) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			inst.inflightRequests.Add(1)
+			inst.MarkActivity()
+			defer func() {
+				inst.inflightRequests.Add(-1)
+				inst.MarkActivity()
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// runIdleReaper periodically scans instances and stops any that have been
+// idle (no in-flight requests, no recent activity) for the configured
+// idle timeout. Returns when the manager's stop channel closes.
+func (m *Manager) runIdleReaper(timeout, interval time.Duration) {
+	defer m.reaperWG.Done()
+	if timeout <= 0 {
+		return
+	}
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	m.logger.Info("idle reaper started",
+		zap.Duration("idle_timeout", timeout),
+		zap.Duration("interval", interval))
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.reaperStop:
+			m.logger.Debug("idle reaper stopped")
+			return
+		case <-ticker.C:
+			m.reapIdleInstances(timeout)
+		}
+	}
+}
+
+// reapIdleInstances identifies and stops every instance that has been idle
+// for at least the configured timeout. The scan is snapshotted under the
+// instances lock; StopInstance is called outside the lock so a slow
+// teardown can't block other Manager operations.
+func (m *Manager) reapIdleInstances(timeout time.Duration) {
+	now := time.Now()
+	idle := m.snapshotIdleInstances(now, timeout)
+	for _, id := range idle {
+		m.logger.Info("reaping idle agent instance",
+			zap.String("instance_id", id),
+			zap.Duration("idle_timeout", timeout))
+		ctx, cancel := context.WithTimeout(context.Background(), idleReaperShutdownTimeout)
+		if err := m.StopInstance(ctx, id); err != nil {
+			m.logger.Warn("idle reaper: failed to stop instance",
+				zap.String("instance_id", id),
+				zap.Error(err))
+		}
+		cancel()
+	}
+}
+
+// snapshotIdleInstances returns the IDs of instances whose IsIdle returns true.
+// Holding the read lock during the scan keeps StopInstance / CreateInstance
+// concurrency intact; iteration happens after the lock is released.
+func (m *Manager) snapshotIdleInstances(now time.Time, timeout time.Duration) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]string, 0)
+	for id, inst := range m.instances {
+		if inst != nil && inst.IsIdle(now, timeout) {
+			out = append(out, id)
+		}
+	}
+	return out
+}

--- a/apps/backend/internal/agentctl/server/instance/idle_reaper.go
+++ b/apps/backend/internal/agentctl/server/instance/idle_reaper.go
@@ -66,21 +66,36 @@ func (m *Manager) runIdleReaper(timeout, interval time.Duration) {
 // reapIdleInstances identifies and stops every instance that has been idle
 // for at least the configured timeout. The scan is snapshotted under the
 // instances lock; StopInstance is called outside the lock so a slow
-// teardown can't block other Manager operations.
+// teardown can't block other Manager operations. The reaper-stop signal
+// is polled between each StopInstance so Shutdown doesn't wait for an
+// entire idle sweep to drain when callers are trying to exit.
 func (m *Manager) reapIdleInstances(timeout time.Duration) {
 	now := time.Now()
 	idle := m.snapshotIdleInstances(now, timeout)
 	for _, id := range idle {
+		select {
+		case <-m.reaperStop:
+			return
+		default:
+		}
 		m.logger.Info("reaping idle agent instance",
 			zap.String("instance_id", id),
 			zap.Duration("idle_timeout", timeout))
-		ctx, cancel := context.WithTimeout(context.Background(), idleReaperShutdownTimeout)
-		if err := m.StopInstance(ctx, id); err != nil {
-			m.logger.Warn("idle reaper: failed to stop instance",
-				zap.String("instance_id", id),
-				zap.Error(err))
-		}
-		cancel()
+		m.reapSingleIdleInstance(id)
+	}
+}
+
+// reapSingleIdleInstance wraps StopInstance with a bounded context and
+// guarantees cancel() runs even on panic. Kept separate so the timeout
+// scope is obvious and `defer cancel()` doesn't pin context lifetimes to
+// the whole sweep.
+func (m *Manager) reapSingleIdleInstance(id string) {
+	ctx, cancel := context.WithTimeout(context.Background(), idleReaperShutdownTimeout)
+	defer cancel()
+	if err := m.StopInstance(ctx, id); err != nil {
+		m.logger.Warn("idle reaper: failed to stop instance",
+			zap.String("instance_id", id),
+			zap.Error(err))
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/instance/idle_reaper_test.go
+++ b/apps/backend/internal/agentctl/server/instance/idle_reaper_test.go
@@ -1,0 +1,205 @@
+package instance
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/internal/agentctl/server/process"
+	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/pkg/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsIdle_RespectsInflightRequests verifies that an instance with at
+// least one in-flight HTTP request is never considered idle, even when
+// LastActivity is older than the timeout. This is the WebSocket-stream case
+// — a long-lived /agent/stream request keeps the counter above zero so the
+// reaper doesn't kill an actively-connected session.
+func TestIsIdle_RespectsInflightRequests(t *testing.T) {
+	inst := &Instance{CreatedAt: time.Now().Add(-1 * time.Hour)}
+	inst.lastActivityNanos.Store(time.Now().Add(-1 * time.Hour).UnixNano())
+	inst.inflightRequests.Store(1)
+
+	assert.False(t, inst.IsIdle(time.Now(), 5*time.Minute),
+		"instance with in-flight request must never be idle")
+
+	inst.inflightRequests.Store(0)
+	assert.True(t, inst.IsIdle(time.Now(), 5*time.Minute),
+		"instance with no in-flight requests and stale activity must be idle")
+}
+
+// TestIsIdle_FallsBackToCreatedAt covers the "instance was created but
+// never received any HTTP traffic" case — the reaper should still kick in
+// after timeout based on CreatedAt.
+func TestIsIdle_FallsBackToCreatedAt(t *testing.T) {
+	inst := &Instance{CreatedAt: time.Now().Add(-2 * time.Hour)}
+	// lastActivityNanos stays zero.
+
+	assert.True(t, inst.IsIdle(time.Now(), 1*time.Hour),
+		"instance with no activity must fall back to CreatedAt for idle decision")
+}
+
+// TestActivityMiddleware_BumpsAndDecrements asserts the middleware
+// increments inflightRequests on entry, decrements on exit, and stamps
+// lastActivity in both transitions. While the handler is mid-flight the
+// counter stays at 1; after it returns the counter is back to 0.
+func TestActivityMiddleware_BumpsAndDecrements(t *testing.T) {
+	inst := &Instance{CreatedAt: time.Now()}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := activityMiddleware(inst)(handler)
+	srv := httptest.NewServer(wrapped)
+	t.Cleanup(srv.Close)
+
+	go func() {
+		resp, err := http.Get(srv.URL + "/")
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	<-started
+	assert.Equal(t, int32(1), inst.inflightRequests.Load(),
+		"in-flight counter must be 1 while handler is executing")
+	assert.False(t, inst.LastActivity().IsZero(),
+		"lastActivity must be stamped on request entry")
+
+	close(release)
+
+	assert.Eventually(t, func() bool {
+		return inst.inflightRequests.Load() == 0
+	}, time.Second, 10*time.Millisecond,
+		"in-flight counter must drop to 0 after handler returns")
+}
+
+// TestManager_IdleReaper_StopsIdleInstance is the end-to-end regression
+// test for the disconnected-session leak (GH issue #1247). A configured
+// idle timeout + reaper interval well under a second drives the reaper
+// fast enough for a unit test; once the instance has been idle past the
+// timeout the reaper calls StopInstance and the instance disappears from
+// the manager's map.
+func TestManager_IdleReaper_StopsIdleInstance(t *testing.T) {
+	log := newTestLogger(t)
+	cfg := &config.Config{
+		Ports:              config.PortConfig{Base: 0, Max: 0},
+		Defaults:           config.InstanceDefaults{Protocol: agent.ProtocolACP},
+		IdleTimeout:        50 * time.Millisecond,
+		IdleReaperInterval: 20 * time.Millisecond,
+	}
+	mgr := NewManager(cfg, log)
+	t.Cleanup(func() {
+		_ = mgr.Shutdown(context.Background())
+	})
+
+	// Server factory that returns a no-op handler — we don't need a real
+	// API server to drive the reaper; lastActivity stays at instance
+	// creation time and the reaper picks it up after IdleTimeout elapses.
+	mgr.SetServerFactory(func(_ *config.InstanceConfig, _ *process.Manager, _ *logger.Logger) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+	})
+
+	// Allocate a real free port without going through Manager.CreateInstance
+	// (which needs a workspace path / process manager). Use port 0 via
+	// allocator by stubbing the manager state instead.
+	inst := &Instance{
+		ID:        "idle-test",
+		Port:      0,
+		Status:    "running",
+		CreatedAt: time.Now().Add(-time.Second), // already older than IdleTimeout
+	}
+	mgr.mu.Lock()
+	mgr.instances[inst.ID] = inst
+	mgr.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		mgr.mu.RLock()
+		_, exists := mgr.instances[inst.ID]
+		mgr.mu.RUnlock()
+		return !exists
+	}, 2*time.Second, 20*time.Millisecond,
+		"idle reaper should have stopped the instance and removed it from the map")
+}
+
+// TestManager_IdleReaper_DisabledByZeroTimeout verifies that setting
+// IdleTimeout = 0 disables the reaper entirely — no goroutine should fire,
+// no instance should be touched, regardless of how old it is.
+func TestManager_IdleReaper_DisabledByZeroTimeout(t *testing.T) {
+	log := newTestLogger(t)
+	cfg := &config.Config{
+		Ports:    config.PortConfig{Base: 0, Max: 0},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+		// IdleTimeout zero => disabled.
+	}
+	mgr := NewManager(cfg, log)
+	t.Cleanup(func() {
+		_ = mgr.Shutdown(context.Background())
+	})
+
+	inst := &Instance{ID: "no-reaper", CreatedAt: time.Now().Add(-24 * time.Hour)}
+	mgr.mu.Lock()
+	mgr.instances[inst.ID] = inst
+	mgr.mu.Unlock()
+
+	time.Sleep(100 * time.Millisecond)
+
+	mgr.mu.RLock()
+	_, exists := mgr.instances[inst.ID]
+	mgr.mu.RUnlock()
+	assert.True(t, exists, "reaper must be disabled when IdleTimeout=0")
+}
+
+// TestActivityMiddleware_Concurrent ensures the inflight counter stays
+// consistent under concurrent requests (using atomic ops, no false zero
+// while another request is still in flight).
+func TestActivityMiddleware_Concurrent(t *testing.T) {
+	inst := &Instance{CreatedAt: time.Now()}
+	var seenZero atomic.Int32
+
+	gate := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-gate
+		if inst.inflightRequests.Load() == 0 {
+			seenZero.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := activityMiddleware(inst)(handler)
+	srv := httptest.NewServer(wrapped)
+	t.Cleanup(srv.Close)
+
+	for i := 0; i < 5; i++ {
+		go func() {
+			resp, err := http.Get(srv.URL + "/")
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+		}()
+	}
+
+	assert.Eventually(t, func() bool {
+		return inst.inflightRequests.Load() == 5
+	}, time.Second, 10*time.Millisecond,
+		"all five concurrent requests should be counted")
+
+	close(gate)
+	assert.Eventually(t, func() bool {
+		return inst.inflightRequests.Load() == 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, int32(0), seenZero.Load(),
+		"no handler should ever observe a zero inflight counter while another request is mid-flight")
+}

--- a/apps/backend/internal/agentctl/server/instance/instance.go
+++ b/apps/backend/internal/agentctl/server/instance/instance.go
@@ -5,6 +5,7 @@ package instance
 
 import (
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/kandev/kandev/internal/agentctl/server/process"
@@ -39,6 +40,55 @@ type Instance struct {
 
 	// server is the HTTP server for this instance's API (unexported)
 	server *http.Server
+
+	// lastActivityNanos is the unix-nano timestamp of the most recently
+	// observed HTTP request on this instance's port. Used by the idle reaper
+	// to detect disconnected sessions. Bumped on request entry and exit by
+	// the activity middleware installed in instance.Manager.CreateInstance.
+	lastActivityNanos atomic.Int64
+
+	// inflightRequests counts HTTP requests currently being served on this
+	// instance's port. Long-lived requests (WebSocket upgrades for
+	// /agent/stream, /workspace/stream, etc.) keep this above zero for the
+	// full duration of the connection, so the idle reaper treats an
+	// instance with an open WS as active even when no new HTTP request
+	// arrives. Maintained by the activity middleware.
+	inflightRequests atomic.Int32
+}
+
+// MarkActivity stamps the current time as the most recent activity on this
+// instance. Called by the activity middleware on every request entry and exit.
+func (i *Instance) MarkActivity() {
+	i.lastActivityNanos.Store(time.Now().UnixNano())
+}
+
+// LastActivity returns the timestamp of the most recent observed activity on
+// this instance. Zero if no activity has been recorded yet.
+func (i *Instance) LastActivity() time.Time {
+	v := i.lastActivityNanos.Load()
+	if v == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, v)
+}
+
+// IsIdle reports whether the instance has been idle for at least `timeout`.
+// An instance with any in-flight HTTP request (notably an open WebSocket
+// stream) is never considered idle.
+func (i *Instance) IsIdle(now time.Time, timeout time.Duration) bool {
+	if i.inflightRequests.Load() > 0 {
+		return false
+	}
+	last := i.LastActivity()
+	if last.IsZero() {
+		// No activity observed since creation — fall back to CreatedAt so a
+		// never-touched instance still gets reaped after timeout.
+		last = i.CreatedAt
+	}
+	if last.IsZero() {
+		return false
+	}
+	return now.Sub(last) >= timeout
 }
 
 // McpServerConfig holds configuration for an MCP server.
@@ -100,6 +150,12 @@ type CreateRequest struct {
 
 	// McpMode controls which MCP tools are registered: "task" (default) or "config".
 	McpMode string `json:"mcp_mode,omitempty"`
+
+	// RequiresProcessKill forces the agent's process group to be killed on
+	// shutdown instead of relying on stdin close. Required for agents whose
+	// runtime keeps child processes alive when stdin closes (notably
+	// opencode acp, which spawns MCP server children that leak otherwise).
+	RequiresProcessKill bool `json:"requires_process_kill,omitempty"`
 }
 
 // CreateResponse contains the result of creating a new agent instance.

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os/exec"
 	"strings"
 	"sync"
 	"syscall"
@@ -33,19 +34,35 @@ type Manager struct {
 	portAlloc     *PortAllocator
 	serverFactory ServerFactory
 	mu            sync.RWMutex
+
+	// reaperStop is closed by Shutdown to signal the idle reaper to exit.
+	// reaperWG waits for the reaper goroutine to finish before Shutdown returns.
+	reaperStop chan struct{}
+	reaperWG   sync.WaitGroup
 }
 
 // NewManager creates a new instance manager.
+// If cfg.IdleTimeout > 0, a background goroutine periodically reaps
+// instances that have been idle (no in-flight HTTP requests and no
+// activity) for the configured duration.
 func NewManager(cfg *config.Config, log *logger.Logger) *Manager {
 	// Clean up code-server processes orphaned by a previous session (safety net).
 	process.CleanupOrphanedCodeServers(log)
 
-	return &Manager{
-		config:    cfg,
-		logger:    log.WithFields(zap.String("component", "instance-manager")),
-		instances: make(map[string]*Instance),
-		portAlloc: NewPortAllocator(cfg.Ports.Base, cfg.Ports.Max),
+	m := &Manager{
+		config:     cfg,
+		logger:     log.WithFields(zap.String("component", "instance-manager")),
+		instances:  make(map[string]*Instance),
+		portAlloc:  NewPortAllocator(cfg.Ports.Base, cfg.Ports.Max),
+		reaperStop: make(chan struct{}),
 	}
+
+	if cfg.IdleTimeout > 0 {
+		m.reaperWG.Add(1)
+		go m.runIdleReaper(cfg.IdleTimeout, cfg.IdleReaperInterval)
+	}
+
+	return m
 }
 
 // SetServerFactory sets the factory function for creating HTTP handlers for instances.
@@ -74,27 +91,28 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 
 	agentCmd := m.resolveAgentCommand(req)
 	autoStart := req.AutoStart
-	mcpServers := buildMcpServerConfigs(req.McpServers)
+	mcpServers := m.buildMcpServerConfigs(req.McpServers)
 
 	m.logger.Info("CreateInstance: received request",
 		zap.String("req_protocol", req.Protocol),
 		zap.String("workspace_path", req.WorkspacePath))
 
 	overrides := &config.InstanceOverrides{
-		InstanceID:         id,
-		Protocol:           agent.Protocol(req.Protocol),
-		AgentCommand:       agentCmd,
-		WorkDir:            req.WorkspacePath,
-		AutoStart:          &autoStart,
-		Env:                config.CollectAgentEnv(req.Env),
-		AgentType:          req.AgentType,
-		McpServers:         mcpServers,
-		SessionID:          req.SessionID,
-		TaskID:             req.TaskID,
-		DisableAskQuestion: req.DisableAskQuestion,
-		AssumeMcpSse:       req.AssumeMcpSse,
-		AssumeMcpHttp:      req.AssumeMcpHttp,
-		McpMode:            req.McpMode,
+		InstanceID:          id,
+		Protocol:            agent.Protocol(req.Protocol),
+		AgentCommand:        agentCmd,
+		WorkDir:             req.WorkspacePath,
+		AutoStart:           &autoStart,
+		Env:                 config.CollectAgentEnv(req.Env),
+		AgentType:           req.AgentType,
+		McpServers:          mcpServers,
+		SessionID:           req.SessionID,
+		TaskID:              req.TaskID,
+		DisableAskQuestion:  req.DisableAskQuestion,
+		AssumeMcpSse:        req.AssumeMcpSse,
+		AssumeMcpHttp:       req.AssumeMcpHttp,
+		McpMode:             req.McpMode,
+		RequiresProcessKill: req.RequiresProcessKill,
 	}
 
 	m.logger.Info("CreateInstance: applying overrides",
@@ -112,10 +130,7 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 	// Start root + per-repo trackers so file-change events fire even in passthrough mode.
 	procMgr.StartAllWorkspaceTrackers(context.Background())
 
-	handler := m.buildHTTPHandler(instanceCfg, procMgr)
-	httpServer := m.startHTTPServer(port, listener, handler, id)
-
-	// Create and store instance
+	// Create instance up-front so the activity middleware can reference it.
 	inst := &Instance{
 		ID:            id,
 		Port:          port,
@@ -125,8 +140,12 @@ func (m *Manager) CreateInstance(ctx context.Context, req *CreateRequest) (*Crea
 		Env:           req.Env,
 		CreatedAt:     time.Now(),
 		manager:       procMgr,
-		server:        httpServer,
 	}
+	inst.MarkActivity()
+
+	handler := activityMiddleware(inst)(m.buildHTTPHandler(instanceCfg, procMgr))
+	httpServer := m.startHTTPServer(port, listener, handler, id)
+	inst.server = httpServer
 	m.instances[id] = inst
 
 	m.logger.Info("created instance",
@@ -177,10 +196,22 @@ func (m *Manager) resolveAgentCommand(req *CreateRequest) string {
 	return agentCmd
 }
 
-// buildMcpServerConfigs converts instance McpServerConfig entries to config.McpServerConfig.
-func buildMcpServerConfigs(mcpServers []McpServerConfig) []config.McpServerConfig {
+// buildMcpServerConfigs converts instance McpServerConfig entries to
+// config.McpServerConfig. Stdio entries whose Command can't be resolved
+// (binary missing from PATH, no longer installed, etc.) are dropped with
+// a warning so the agent doesn't spawn a permanently-broken child for an
+// MCP it can never invoke. See GH issue #1247 — the `/snap/bin/brave`
+// stale-MCP repro.
+func (m *Manager) buildMcpServerConfigs(mcpServers []McpServerConfig) []config.McpServerConfig {
 	result := make([]config.McpServerConfig, 0, len(mcpServers))
 	for _, mcp := range mcpServers {
+		if reason := mcpStdioValidationError(mcp); reason != "" {
+			m.logger.Warn("dropping MCP server: stdio command unavailable",
+				zap.String("mcp_name", mcp.Name),
+				zap.String("command", mcp.Command),
+				zap.String("reason", reason))
+			continue
+		}
 		result = append(result, config.McpServerConfig{
 			Name:    mcp.Name,
 			URL:     mcp.URL,
@@ -192,6 +223,24 @@ func buildMcpServerConfigs(mcpServers []McpServerConfig) []config.McpServerConfi
 		})
 	}
 	return result
+}
+
+// mcpStdioValidationError returns an empty string when the MCP entry is
+// either non-stdio (URL transport) or its stdio Command resolves on PATH.
+// Otherwise it returns a human-readable reason the entry should be dropped.
+func mcpStdioValidationError(mcp McpServerConfig) string {
+	// Non-stdio transports (sse, http, streamable_http) carry their endpoint
+	// in URL — nothing to validate locally.
+	if mcp.URL != "" {
+		return ""
+	}
+	if mcp.Command == "" {
+		return ""
+	}
+	if _, err := exec.LookPath(mcp.Command); err != nil {
+		return err.Error()
+	}
+	return ""
 }
 
 // buildHTTPHandler creates the HTTP handler for an instance.
@@ -298,6 +347,10 @@ func (m *Manager) StopInstance(ctx context.Context, id string) error {
 
 // Shutdown stops all instances gracefully.
 func (m *Manager) Shutdown(ctx context.Context) error {
+	// Stop the idle reaper first so it doesn't fire StopInstance concurrently
+	// with our explicit per-instance shutdown loop.
+	m.stopReaperOnce()
+
 	m.mu.Lock()
 	ids := make([]string, 0, len(m.instances))
 	for id := range m.instances {
@@ -316,4 +369,20 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 	}
 
 	return lastErr
+}
+
+// stopReaperOnce closes the reaper stop channel exactly once and waits for
+// the reaper goroutine to drain. Safe to call multiple times.
+func (m *Manager) stopReaperOnce() {
+	m.mu.Lock()
+	select {
+	case <-m.reaperStop:
+		// Already closed.
+		m.mu.Unlock()
+		return
+	default:
+		close(m.reaperStop)
+	}
+	m.mu.Unlock()
+	m.reaperWG.Wait()
 }

--- a/apps/backend/internal/agentctl/server/instance/manager.go
+++ b/apps/backend/internal/agentctl/server/instance/manager.go
@@ -36,9 +36,13 @@ type Manager struct {
 	mu            sync.RWMutex
 
 	// reaperStop is closed by Shutdown to signal the idle reaper to exit.
+	// reaperStopOnce serializes the close so concurrent Shutdown calls can't
+	// double-close; sync.Once is used instead of m.mu because m.mu guards
+	// the instances map and shouldn't gate a one-shot lifecycle signal.
 	// reaperWG waits for the reaper goroutine to finish before Shutdown returns.
-	reaperStop chan struct{}
-	reaperWG   sync.WaitGroup
+	reaperStop     chan struct{}
+	reaperStopOnce sync.Once
+	reaperWG       sync.WaitGroup
 }
 
 // NewManager creates a new instance manager.
@@ -228,6 +232,16 @@ func (m *Manager) buildMcpServerConfigs(mcpServers []McpServerConfig) []config.M
 // mcpStdioValidationError returns an empty string when the MCP entry is
 // either non-stdio (URL transport) or its stdio Command resolves on PATH.
 // Otherwise it returns a human-readable reason the entry should be dropped.
+//
+// Caveat: PATH is resolved against the agentctl process's environment.
+// In Docker and SSH executor modes the agent may launch in a different
+// environment than agentctl, so a binary that lives only inside the
+// container/remote host but not on the agentctl host will be dropped
+// here even though it would have worked at agent runtime. For Standalone
+// and Sprites this is unambiguously correct; for Docker/SSH it's an
+// acceptable false positive — surfacing the warn log is better than
+// spawning a permanently broken child every session (the `/snap/bin/brave`
+// repro in GH issue #1247).
 func mcpStdioValidationError(mcp McpServerConfig) string {
 	// Non-stdio transports (sse, http, streamable_http) carry their endpoint
 	// in URL — nothing to validate locally.
@@ -235,9 +249,18 @@ func mcpStdioValidationError(mcp McpServerConfig) string {
 		return ""
 	}
 	if mcp.Command == "" {
-		return ""
+		return "stdio MCP entry has neither URL nor Command"
 	}
-	if _, err := exec.LookPath(mcp.Command); err != nil {
+	// Tolerate a compound `Command` string like "python3 -m mcp_server"
+	// where the user collapsed Command+Args into Command. The first token
+	// is the actual binary to look up; everything else is argv that the
+	// agent will splice in later. This is more permissive than the
+	// schema strictly allows, but it matches what real configs look like.
+	bin := mcp.Command
+	if i := strings.IndexAny(bin, " \t"); i > 0 {
+		bin = bin[:i]
+	}
+	if _, err := exec.LookPath(bin); err != nil {
 		return err.Error()
 	}
 	return ""
@@ -373,16 +396,17 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 
 // stopReaperOnce closes the reaper stop channel exactly once and waits for
 // the reaper goroutine to drain. Safe to call multiple times.
+//
+// Note: reaperWG.Wait() blocks until the reaper finishes whatever sweep
+// is currently in flight. Each instance in that sweep gets its own bounded
+// context (idleReaperShutdownTimeout) independent of any caller deadline,
+// so a Shutdown(ctx) caller with a tight deadline can find that the
+// reaper drain consumed it before the main shutdown loop starts. The
+// reaper polls reaperStop between instances, so the worst-case drain is
+// one StopInstance round (15s), not N×timeout.
 func (m *Manager) stopReaperOnce() {
-	m.mu.Lock()
-	select {
-	case <-m.reaperStop:
-		// Already closed.
-		m.mu.Unlock()
-		return
-	default:
+	m.reaperStopOnce.Do(func() {
 		close(m.reaperStop)
-	}
-	m.mu.Unlock()
+	})
 	m.reaperWG.Wait()
 }

--- a/apps/backend/internal/agentctl/server/instance/mcp_validation_test.go
+++ b/apps/backend/internal/agentctl/server/instance/mcp_validation_test.go
@@ -71,9 +71,9 @@ func TestMcpStdioValidationError(t *testing.T) {
 			expect: "ok",
 		},
 		{
-			name:   "empty command skips validation",
+			name:   "empty command and empty URL fails",
 			mcp:    McpServerConfig{Name: "x"},
-			expect: "ok",
+			expect: "error",
 		},
 		{
 			name:   "missing absolute path fails",
@@ -83,6 +83,16 @@ func TestMcpStdioValidationError(t *testing.T) {
 		{
 			name:   "missing PATH binary fails",
 			mcp:    McpServerConfig{Name: "x", Command: "definitely-not-a-real-binary-1247"},
+			expect: "error",
+		},
+		{
+			name:   "compound command first token resolves",
+			mcp:    McpServerConfig{Name: "x", Command: "sh -c 'echo hi'"},
+			expect: "ok",
+		},
+		{
+			name:   "compound command with missing first token fails",
+			mcp:    McpServerConfig{Name: "x", Command: "definitely-not-a-real-binary-1247 -m mcp_server"},
 			expect: "error",
 		},
 	}

--- a/apps/backend/internal/agentctl/server/instance/mcp_validation_test.go
+++ b/apps/backend/internal/agentctl/server/instance/mcp_validation_test.go
@@ -1,0 +1,100 @@
+package instance
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentctl/server/config"
+	"github.com/kandev/kandev/pkg/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBuildMcpServerConfigs_DropsMissingStdioCommand is the regression
+// test for GH issue #1247's "stale `/snap/bin/brave` MCP" repro: a stdio
+// MCP entry whose Command binary no longer exists on disk should not be
+// passed through to the agent — it would just spawn a permanently-broken
+// child process. URL-transport MCPs should always pass through.
+func TestBuildMcpServerConfigs_DropsMissingStdioCommand(t *testing.T) {
+	mgr := NewManager(&config.Config{
+		Ports:    config.PortConfig{Base: 0, Max: 0},
+		Defaults: config.InstanceDefaults{Protocol: agent.ProtocolACP},
+		// IdleTimeout zero => reaper goroutine never starts; no shutdown needed.
+	}, newTestLogger(t))
+
+	// Create a valid stdio command so we have at least one survivor.
+	validCmd := filepath.Join(t.TempDir(), "valid-mcp")
+	require := func(err error) {
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+	require(os.WriteFile(validCmd, []byte("#!/bin/sh\nsleep 1\n"), 0o755))
+
+	input := []McpServerConfig{
+		{Name: "missing-stdio", Command: "/nonexistent/abs/path/does-not-exist"},
+		{Name: "missing-on-path", Command: "this-binary-is-definitely-not-on-path-xyzzy-1247"},
+		{Name: "ok-stdio", Command: validCmd},
+		{Name: "ok-http", URL: "http://localhost:9999/mcp", Type: "http"},
+		{Name: "ok-sse", URL: "http://localhost:9999/sse", Type: "sse"},
+	}
+
+	got := mgr.buildMcpServerConfigs(input)
+
+	names := make([]string, 0, len(got))
+	for _, srv := range got {
+		names = append(names, srv.Name)
+	}
+
+	assert.NotContains(t, names, "missing-stdio",
+		"missing absolute-path stdio MCP must be dropped")
+	assert.NotContains(t, names, "missing-on-path",
+		"missing on-PATH stdio MCP must be dropped")
+	assert.Contains(t, names, "ok-stdio",
+		"resolvable stdio MCP must survive")
+	assert.Contains(t, names, "ok-http",
+		"URL-transport MCP must always survive (no command to validate)")
+	assert.Contains(t, names, "ok-sse",
+		"URL-transport MCP must always survive (no command to validate)")
+}
+
+// TestMcpStdioValidationError covers the helper directly.
+func TestMcpStdioValidationError(t *testing.T) {
+	tests := []struct {
+		name   string
+		mcp    McpServerConfig
+		expect string // "ok" or "error"
+	}{
+		{
+			name:   "url-only entry skips validation",
+			mcp:    McpServerConfig{Name: "x", URL: "http://example.test"},
+			expect: "ok",
+		},
+		{
+			name:   "empty command skips validation",
+			mcp:    McpServerConfig{Name: "x"},
+			expect: "ok",
+		},
+		{
+			name:   "missing absolute path fails",
+			mcp:    McpServerConfig{Name: "x", Command: "/this/path/does/not/exist"},
+			expect: "error",
+		},
+		{
+			name:   "missing PATH binary fails",
+			mcp:    McpServerConfig{Name: "x", Command: "definitely-not-a-real-binary-1247"},
+			expect: "error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mcpStdioValidationError(tc.mcp)
+			if tc.expect == "ok" {
+				assert.Empty(t, got, "expected validation pass")
+			} else {
+				assert.NotEmpty(t, got, "expected validation failure")
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agentctl/server/instance/testing_helpers_test.go
+++ b/apps/backend/internal/agentctl/server/instance/testing_helpers_test.go
@@ -1,0 +1,19 @@
+package instance
+
+import (
+	"testing"
+
+	"github.com/kandev/kandev/internal/common/logger"
+)
+
+func newTestLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	log, err := logger.NewLogger(logger.LoggingConfig{
+		Level:  "error",
+		Format: "json",
+	})
+	if err != nil {
+		t.Fatalf("failed to create logger: %v", err)
+	}
+	return log
+}

--- a/apps/backend/internal/agentctl/server/instance/testmain_test.go
+++ b/apps/backend/internal/agentctl/server/instance/testmain_test.go
@@ -1,0 +1,16 @@
+package instance
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain wraps the instance package's test suite in goleak so the idle
+// reaper goroutine (and any future long-lived helper) is verified to
+// drain on Shutdown. Matches the goleak convention already used by
+// internal/gateway/websocket, agentctl/server/process, and the runtime
+// lifecycle package.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/apps/backend/internal/agentctl/server/process/manager.go
+++ b/apps/backend/internal/agentctl/server/process/manager.go
@@ -674,13 +674,14 @@ func (m *Manager) buildAdapterConfig() error {
 		}
 	}
 	m.adapterCfg = &adapter.Config{
-		WorkDir:        m.cfg.WorkDir,
-		AutoApprove:    m.cfg.AutoApprovePermissions,
-		ApprovalPolicy: m.cfg.ApprovalPolicy,
-		McpServers:     mcpServers,
-		AgentID:        m.cfg.AgentType, // From registry (e.g., "auggie", "amp", "claude-code")
-		AssumeMcpSse:   m.cfg.AssumeMcpSse,
-		AssumeMcpHttp:  m.cfg.AssumeMcpHttp,
+		WorkDir:             m.cfg.WorkDir,
+		AutoApprove:         m.cfg.AutoApprovePermissions,
+		ApprovalPolicy:      m.cfg.ApprovalPolicy,
+		McpServers:          mcpServers,
+		AgentID:             m.cfg.AgentType, // From registry (e.g., "auggie", "amp", "claude-code")
+		AssumeMcpSse:        m.cfg.AssumeMcpSse,
+		AssumeMcpHttp:       m.cfg.AssumeMcpHttp,
+		RequiresProcessKill: m.cfg.RequiresProcessKill,
 	}
 
 	// Configure one-shot mode when a continue command is provided.
@@ -1119,6 +1120,12 @@ func (m *Manager) killProcessGroupIfRequired() {
 }
 
 // waitForProcessExit waits for all goroutines to finish, force-killing on context timeout.
+//
+// On timeout the entire process group is killed (not just the leader) so that
+// child processes — most importantly MCP servers spawned by the agent — don't
+// re-parent to init and leak. setProcGroup at command-build time puts the
+// agent in its own pgid; here we deliver SIGKILL to that pgid. Falls back to
+// a single-process kill only if the process-group call fails.
 func (m *Manager) waitForProcessExit(ctx context.Context) {
 	m.logger.Debug("waiting for process to exit")
 	done := make(chan struct{})
@@ -1131,8 +1138,14 @@ func (m *Manager) waitForProcessExit(ctx context.Context) {
 	case <-done:
 		m.logger.Info("agent process stopped gracefully")
 	case <-ctx.Done():
-		if m.cmd != nil && m.cmd.Process != nil {
-			m.logger.Warn("force killing agent process")
+		if m.cmd == nil || m.cmd.Process == nil {
+			return
+		}
+		pid := m.cmd.Process.Pid
+		m.logger.Warn("force killing agent process group", zap.Int("pgid", pid))
+		if err := killProcessGroup(pid); err != nil {
+			m.logger.Warn("failed to kill agent process group, falling back to single-process kill",
+				zap.Error(err))
 			if err := m.cmd.Process.Kill(); err != nil {
 				m.logger.Warn("failed to kill agent process", zap.Error(err))
 			}

--- a/apps/backend/internal/agentctl/server/process/manager_killgroup_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_killgroup_test.go
@@ -4,8 +4,10 @@ package process
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -68,11 +70,15 @@ func TestWaitForProcessExit_KillsProcessGroupOnTimeout(t *testing.T) {
 	m.waitForProcessExit(ctx)
 
 	// Both parent and child must be reaped within a short window. We waited
-	// the parent ourselves; for the child we poll /proc (Linux) or use
-	// signal-0 probe (portable).
+	// the parent ourselves; for the child we treat both "process gone" and
+	// "process exists in zombie state" as success — in CI the orphan
+	// re-parents to a container's PID 1 (tini-style) that may take longer
+	// than the kill itself to harvest the zombie, but for our purposes the
+	// SIGKILL has already done its job once the kernel marks the task as
+	// dead. 15s window covers slow CI runners on Linux.
 	require.Eventually(t, func() bool {
 		return !processAlive(childPID)
-	}, 5*time.Second, 50*time.Millisecond,
+	}, 15*time.Second, 50*time.Millisecond,
 		"child process %d should be killed by process-group reap", childPID)
 }
 
@@ -96,11 +102,34 @@ func waitForChildPID(t *testing.T, pidFile string, timeout time.Duration) int {
 	}
 }
 
-// processAlive reports whether a PID exists and can receive a signal.
-// On Unix, sending signal 0 returns nil for live processes and ESRCH for dead.
+// processAlive reports whether a PID exists, is not a zombie, and can
+// receive a signal. A zombie is treated as dead — the task has already
+// been killed; we're just waiting for the parent (or init) to harvest the
+// exit status, which is irrelevant to the regression we're testing for.
+//
+// On Linux we consult /proc/<pid>/stat to detect zombie state (field 3,
+// `R` running, `S` sleeping, `D` uninterruptible, `Z` zombie, `T` stopped).
+// On other Unix platforms we fall back to signal(0), which still catches
+// the leak case in the bug report — opencode acp processes live with
+// state 'S' on Linux until killed.
 func processAlive(pid int) bool {
 	if pid <= 0 {
 		return false
+	}
+	if runtime.GOOS == "linux" {
+		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+		if err != nil {
+			return false // /proc entry gone => process gone
+		}
+		// Format: `<pid> (<comm>) <state> ...`. comm may contain spaces,
+		// so anchor on the trailing ")" before the state field.
+		s := string(raw)
+		idx := strings.LastIndex(s, ") ")
+		if idx == -1 || idx+2 >= len(s) {
+			return false
+		}
+		state := s[idx+2]
+		return state != 'Z'
 	}
 	proc, err := os.FindProcess(pid)
 	if err != nil {

--- a/apps/backend/internal/agentctl/server/process/manager_killgroup_test.go
+++ b/apps/backend/internal/agentctl/server/process/manager_killgroup_test.go
@@ -1,0 +1,113 @@
+//go:build !windows
+
+package process
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWaitForProcessExit_KillsProcessGroupOnTimeout is the regression guard
+// for GH issue #1247: when an agent subprocess does not exit on stdin close
+// (opencode acp), the timeout fallback in waitForProcessExit used to call
+// only cmd.Process.Kill(), leaving MCP children re-parented to init.
+// After the fix, killProcessGroup is delivered to the leader's pgid so the
+// whole tree dies.
+func TestWaitForProcessExit_KillsProcessGroupOnTimeout(t *testing.T) {
+	log := newTestLogger(t)
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+
+	m := &Manager{
+		logger: log,
+	}
+	m.cmd = fixtureCmd("sleep-with-child " + pidFile + " 30")
+	setProcGroup(m.cmd)
+	require.NoError(t, m.cmd.Start())
+	t.Cleanup(func() {
+		// Best-effort: nuke the leader's pgid in case the test left the
+		// fixture alive (e.g. assertion failed before reaping).
+		_ = killProcessGroup(m.cmd.Process.Pid)
+		_, _ = m.cmd.Process.Wait()
+	})
+
+	// Wait for the child to be spawned and the pidfile to land. The fixture
+	// writes the PID before sleeping; bound the wait so a broken fixture
+	// can't hang the test.
+	childPID := waitForChildPID(t, pidFile, 5*time.Second)
+
+	// Sanity: the parent is in its own process group, and the child should
+	// have inherited it (no setpgid call inside the fixture).
+	parentPGID, err := syscall.Getpgid(m.cmd.Process.Pid)
+	require.NoError(t, err)
+	childPGID, err := syscall.Getpgid(childPID)
+	require.NoError(t, err)
+	require.Equal(t, parentPGID, childPGID,
+		"child must inherit parent's pgid for the group-kill assumption to hold")
+
+	// Keep waitForProcessExit's internal wg.Wait() blocked so the select
+	// hits the ctx.Done branch (the path we're regression-testing). The
+	// real Start() path Add()s for readStderr/waitForExit; this test
+	// bypasses Start so we Add(1) ourselves and Done at the very end so
+	// goleak in TestMain stays clean.
+	m.wg.Add(1)
+	defer m.wg.Done()
+
+	// Drive the timeout fallback path: context is already done, so
+	// waitForProcessExit jumps straight to the kill branch.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	m.waitForProcessExit(ctx)
+
+	// Both parent and child must be reaped within a short window. We waited
+	// the parent ourselves; for the child we poll /proc (Linux) or use
+	// signal-0 probe (portable).
+	require.Eventually(t, func() bool {
+		return !processAlive(childPID)
+	}, 5*time.Second, 50*time.Millisecond,
+		"child process %d should be killed by process-group reap", childPID)
+}
+
+// waitForChildPID polls pidFile until it contains a valid PID or timeout
+// expires. Returns the parsed PID. Fails the test on timeout.
+func waitForChildPID(t *testing.T, pidFile string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		raw, err := os.ReadFile(pidFile)
+		if err == nil {
+			pid, perr := strconv.Atoi(strings.TrimSpace(string(raw)))
+			if perr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for fixture to write child pid to %s", pidFile)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// processAlive reports whether a PID exists and can receive a signal.
+// On Unix, sending signal 0 returns nil for live processes and ESRCH for dead.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// signal 0 doesn't deliver anything; it just checks whether the kernel
+	// could have delivered a signal — i.e. the process exists.
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/apps/backend/internal/agentctl/server/process/testmain_test.go
+++ b/apps/backend/internal/agentctl/server/process/testmain_test.go
@@ -85,6 +85,33 @@ func runFixture(spec string) {
 			os.Exit(2)
 		}
 		time.Sleep(time.Duration(secs) * time.Second)
+	case "sleep-with-child":
+		// Forks a child copy of this fixture binary (also sleeping <secs>),
+		// writes the child PID to <pidfile>, then sleeps itself. Used by the
+		// process group kill regression test: when the parent's process
+		// group is reaped, the child must die too. Both processes ignore
+		// stdin so close-stdin-then-wait can't reach them on its own.
+		if len(parts) != 3 {
+			fmt.Fprintln(os.Stderr, "fixture: sleep-with-child takes 2 args")
+			os.Exit(2)
+		}
+		pidFile := parts[1]
+		secs, err := strconv.Atoi(parts[2])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fixture: sleep-with-child: bad seconds %q\n", parts[2])
+			os.Exit(2)
+		}
+		childCmd := exec.Command(os.Args[0])
+		childCmd.Env = append(os.Environ(), kandevTestFixtureEnv+"=sleep "+strconv.Itoa(secs))
+		if err := childCmd.Start(); err != nil {
+			fmt.Fprintf(os.Stderr, "fixture: sleep-with-child: spawn child: %v\n", err)
+			os.Exit(2)
+		}
+		if err := os.WriteFile(pidFile, []byte(strconv.Itoa(childCmd.Process.Pid)), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "fixture: sleep-with-child: write pidfile: %v\n", err)
+			os.Exit(2)
+		}
+		time.Sleep(time.Duration(secs) * time.Second)
 	default:
 		fmt.Fprintf(os.Stderr, "fixture: unknown command %q\n", parts[0])
 		os.Exit(2)


### PR DESCRIPTION
opencode ACP sessions accumulated indefinitely (#1247): instance.Manager only reaped on explicit kandev DELETE, and even when DELETE fired the ACP adapter unconditionally returned RequiresProcessKill=false so opencode's HTTP server + MCP child tree survived stdin close. After a day of normal use this left dozens of stale sessions, hundreds of MCP processes, and ~382 GB of per-session journaling. Now disconnected instances are reaped on an idle timer, opencode acp opts into process-group kill, and the timeout fallback always nukes the full pgid.

## Important Changes

- New `RuntimeConfig.RequiresProcessKill` plumbed from `agents.OpenCodeACP` through `ExecutorCreateRequest` -> `agentctl.CreateInstanceRequest` -> `InstanceConfig` -> `adapter.Config` -> `shared.Config`. `acp.Adapter.RequiresProcessKill()` reads it from cfg instead of returning a hardcoded false.
- `process.Manager.waitForProcessExit` timeout fallback now calls `killProcessGroup` first; falls back to `cmd.Process.Kill()` only if the group kill fails.
- New idle reaper in `instance.Manager`: activity middleware tracks inflight HTTP requests + lastActivity per instance; background goroutine sweeps every minute and stops instances idle past `KANDEV_ACP_IDLE_TIMEOUT` (default 1h, set to 0 to disable). Long-lived `/agent/stream` WS keeps inflight > 0 so active sessions are never reaped.
- `instance.Manager.buildMcpServerConfigs` validates stdio MCP commands via `exec.LookPath`; missing entries are dropped with a warn instead of spawning a permanently broken child every session (fixes the stale `/snap/bin/brave` repro).

## Validation

- `make fmt` / `make lint` / `make test` (full backend test suite, ~60 packages, all green)
- New tests: process-group kill (parent+child fixture in `manager_killgroup_test.go`), idle reaper end-to-end + activity middleware + concurrent inflight counter, MCP stdio validation, opencode-acp opt-in vs other ACP agents' default
- `pnpm format` / `pnpm --filter @kandev/web lint`

## Possible Improvements

Low risk. Idle timeout defaults to 1h which is generous; if a kandev backend genuinely hangs between requests for longer than that with no open WS, its instances will be reaped. Set `KANDEV_ACP_IDLE_TIMEOUT=0` to disable, or raise it.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Closes #1247