### PR TITLE
fix(web): hide token usage when context window report is unreliable

### DIFF
--- a/apps/web/components/task/chat/token-usage-display.test.tsx
+++ b/apps/web/components/task/chat/token-usage-display.test.tsx
@@ -45,7 +45,7 @@ describe("TokenUsageDisplay", () => {
     vi.mocked(useSessionContextWindow).mockReturnValue({
       size: 200_000,
       used: 233_900,
-      remaining: 0,
+      remaining: -33_900,
       efficiency: 117,
     });
 

--- a/apps/web/components/task/chat/token-usage-display.test.tsx
+++ b/apps/web/components/task/chat/token-usage-display.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { useSessionContextWindow } from "@/hooks/domains/session/use-session-context-window";
+import { isContextWindowReliable, TokenUsageDisplay } from "./token-usage-display";
+
+vi.mock("@/hooks/domains/session/use-session-context-window", () => ({
+  useSessionContextWindow: vi.fn(),
+}));
+
+vi.mock("@kandev/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("isContextWindowReliable", () => {
+  it("accepts normal usage under the window", () => {
+    expect(isContextWindowReliable(200_000, 56_047)).toBe(true);
+  });
+
+  it("accepts exactly-full context (100%)", () => {
+    expect(isContextWindowReliable(200_000, 200_000)).toBe(true);
+  });
+
+  it("rejects impossible usage (used > size) — the wrong-window bug", () => {
+    expect(isContextWindowReliable(200_000, 233_900)).toBe(false);
+  });
+
+  it("rejects a zero/absent window size", () => {
+    expect(isContextWindowReliable(0, 0)).toBe(false);
+  });
+
+  it("accepts a correct large window", () => {
+    expect(isContextWindowReliable(1_000_000, 233_900)).toBe(true);
+  });
+});
+
+describe("TokenUsageDisplay", () => {
+  it("renders nothing when used exceeds size (wrong-window bug)", () => {
+    vi.mocked(useSessionContextWindow).mockReturnValue({
+      size: 200_000,
+      used: 233_900,
+      remaining: 0,
+      efficiency: 117,
+    });
+
+    const { container } = render(<TokenUsageDisplay sessionId="sess-1" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the indicator for valid usage under the window", () => {
+    vi.mocked(useSessionContextWindow).mockReturnValue({
+      size: 200_000,
+      used: 56_047,
+      remaining: 143_953,
+      efficiency: 28,
+    });
+
+    const { container } = render(<TokenUsageDisplay sessionId="sess-1" />);
+
+    expect(container.querySelector(".cursor-help")).not.toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/apps/web/components/task/chat/token-usage-display.tsx
+++ b/apps/web/components/task/chat/token-usage-display.tsx
@@ -47,13 +47,13 @@ export const TokenUsageDisplay = memo(function TokenUsageDisplay({
 
   if (!contextWindow) return null;
 
-  const { size, used, efficiency } = contextWindow;
+  const { size, used } = contextWindow;
 
   // Hide when there's no data yet (size 0) or the report is impossible
   // (used > size) — see isContextWindowReliable.
   if (!isContextWindowReliable(size, used)) return null;
 
-  const usagePercent = Math.min(efficiency, 100);
+  const usagePercent = (used / size) * 100;
   const progress = usagePercent / 100;
 
   // SVG circle parameters
@@ -89,7 +89,7 @@ export const TokenUsageDisplay = memo(function TokenUsageDisplay({
                 strokeLinecap="round"
                 strokeDasharray={circumference}
                 strokeDashoffset={strokeDashoffset}
-                className={cn(getCircleColor(efficiency), "transition-all duration-300 ease-out")}
+                className={cn(getCircleColor(usagePercent), "transition-all duration-300 ease-out")}
               />
             </svg>
           </div>
@@ -98,7 +98,7 @@ export const TokenUsageDisplay = memo(function TokenUsageDisplay({
       <TooltipContent side="top">
         <div className="text-xs space-y-1">
           <div className="font-medium">
-            {efficiency.toFixed(0)}% ({formatNumber(used)} / {formatNumber(size)})
+            {usagePercent.toFixed(0)}% ({formatNumber(used)} / {formatNumber(size)})
           </div>
         </div>
       </TooltipContent>

--- a/apps/web/components/task/chat/token-usage-display.tsx
+++ b/apps/web/components/task/chat/token-usage-display.tsx
@@ -10,6 +10,18 @@ type TokenUsageDisplayProps = {
   className?: string;
 };
 
+/**
+ * A context-window report is only trustworthy when we have a positive window
+ * size and usage that does not exceed it. `used > size` is impossible for a
+ * real window, so it means the agent (via the ACP bridge) reported a stale or
+ * wrong `size` (e.g. 200K for a model actually running on the 1M beta window).
+ * In that case we hide the indicator instead of showing a confusing >100%.
+ * `used === size` (exactly full) is valid and still renders.
+ */
+export function isContextWindowReliable(size: number, used: number): boolean {
+  return size > 0 && used <= size;
+}
+
 function formatNumber(num: number): string {
   if (num >= 1_000_000) {
     return `${(num / 1_000_000).toFixed(1)}M`;
@@ -33,9 +45,13 @@ export const TokenUsageDisplay = memo(function TokenUsageDisplay({
 }: TokenUsageDisplayProps) {
   const contextWindow = useSessionContextWindow(sessionId);
 
-  if (!contextWindow || contextWindow.size === 0) return null;
+  if (!contextWindow) return null;
 
   const { size, used, efficiency } = contextWindow;
+
+  // Hide when there's no data yet (size 0) or the report is impossible
+  // (used > size) — see isContextWindowReliable.
+  if (!isContextWindowReliable(size, used)) return null;
 
   const usagePercent = Math.min(efficiency, 100);
   const progress = usagePercent / 100;


### PR DESCRIPTION
The ACP bridge sometimes reports a 200K context window while token usage
exceeds that limit on models running with a larger effective window, which
produced misleading >100% token-usage rings. This hides the indicator when
`used > size` so users are not shown an impossible percentage.

## Validation

- `cd apps/web && pnpm test -- token-usage-display` — 7 tests pass
- `cd apps/web && pnpm lint` — clean
- `cd apps/web && pnpm typecheck` — clean

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)