### PR TITLE
fix(orchestrator): block workflow advance during pending clarifications

### DIFF
--- a/apps/backend/internal/clarification/canceller.go
+++ b/apps/backend/internal/clarification/canceller.go
@@ -41,6 +41,29 @@ func isTerminalStatus(status string) bool {
 	return false
 }
 
+// markMessagesDetached unblocks WaitForResponse and keeps the clarification
+// interactive: status stays pending and agent_disconnected is set so the UI
+// can route a late answer through the event fallback path.
+func (c *Canceller) markMessagesDetached(ctx context.Context, msgs []*taskmodels.Message, pendingID string) {
+	for _, msg := range msgs {
+		if msg.Metadata == nil {
+			msg.Metadata = map[string]any{}
+		}
+		if current, _ := msg.Metadata["status"].(string); isTerminalStatus(current) {
+			continue
+		}
+		msg.Metadata["agent_disconnected"] = true
+		if err := c.repo.UpdateMessage(ctx, msg); err != nil {
+			c.logger.Warn("failed to update message with detached status",
+				zap.String("pending_id", pendingID),
+				zap.String("message_id", msg.ID),
+				zap.Error(err))
+			continue
+		}
+		c.publishMessageUpdated(ctx, msg)
+	}
+}
+
 // markMessagesExpired updates the given messages to status=expired and publishes
 // a message.updated event for each one. It is idempotent: already-terminal
 // messages are skipped.
@@ -65,35 +88,68 @@ func (c *Canceller) markMessagesExpired(ctx context.Context, msgs []*taskmodels.
 	}
 }
 
-// CancelSessionAndNotify cancels all pending clarifications for a session,
-// unblocking WaitForResponse callers, and marks the database messages
-// as expired (with agent_disconnected=true for context) so the frontend
-// closes the interactive overlay and renders a "Timed out" history entry.
-// Returns the number of cancelled clarifications.
-//
-// Setting status=expired also prevents a UX bug where clicking the overlay's
-// X button after the agent moved on would trigger a new turn via the
-// respond handler's event fallback path (rejected responses were being
-// forwarded to the orchestrator as "User declined to answer").
-func (c *Canceller) CancelSessionAndNotify(ctx context.Context, sessionID string) int {
+func (c *Canceller) detachSessionBundles(ctx context.Context, sessionID string) int {
 	pendingIDs := c.store.CancelSession(sessionID)
 
 	handled := make(map[string]bool, len(pendingIDs))
 	for _, id := range pendingIDs {
 		msgs, err := c.repo.FindMessagesByPendingID(ctx, id)
 		if err != nil || len(msgs) == 0 {
-			c.logger.Debug("messages not found for cancelled clarification",
+			c.logger.Debug("messages not found for detached clarification",
 				zap.String("pending_id", id),
 				zap.Error(err))
+			continue
+		}
+		c.markMessagesDetached(ctx, msgs, id)
+		handled[id] = true
+	}
+
+	msgs, err := c.repo.FindPendingClarificationMessagesBySessionID(ctx, sessionID)
+	if err != nil || len(msgs) == 0 {
+		return len(pendingIDs)
+	}
+
+	byPendingID := make(map[string][]*taskmodels.Message)
+	for _, msg := range msgs {
+		pid := stringFromMetadata(msg.Metadata, "pending_id")
+		if pid == "" || handled[pid] {
+			continue
+		}
+		byPendingID[pid] = append(byPendingID[pid], msg)
+	}
+	for pid, bundle := range byPendingID {
+		c.markMessagesDetached(ctx, bundle, pid)
+	}
+	return len(pendingIDs) + len(byPendingID)
+}
+
+// DetachSessionAndNotify cancels in-memory WaitForResponse waiters for a session
+// and marks DB clarification messages as pending with agent_disconnected=true.
+// The overlay stays interactive; a late answer uses the event fallback path.
+func (c *Canceller) DetachSessionAndNotify(ctx context.Context, sessionID string) int {
+	return c.detachSessionBundles(ctx, sessionID)
+}
+
+// CancelSessionAndNotify is an alias for DetachSessionAndNotify.
+func (c *Canceller) CancelSessionAndNotify(ctx context.Context, sessionID string) int {
+	return c.DetachSessionAndNotify(ctx, sessionID)
+}
+
+// ExpireSessionAndNotify cancels in-memory waiters and marks clarification
+// messages expired so the overlay closes and history shows a timed-out entry.
+func (c *Canceller) ExpireSessionAndNotify(ctx context.Context, sessionID string) int {
+	pendingIDs := c.store.CancelSession(sessionID)
+
+	handled := make(map[string]bool, len(pendingIDs))
+	for _, id := range pendingIDs {
+		msgs, err := c.repo.FindMessagesByPendingID(ctx, id)
+		if err != nil || len(msgs) == 0 {
 			continue
 		}
 		c.markMessagesExpired(ctx, msgs, id)
 		handled[id] = true
 	}
 
-	// Defense-in-depth: also find any still-pending clarification messages in
-	// the DB whose in-memory store entry was already removed (e.g. by a racing
-	// timeout path). Group by pending_id and mark each bundle expired.
 	msgs, err := c.repo.FindPendingClarificationMessagesBySessionID(ctx, sessionID)
 	if err != nil || len(msgs) == 0 {
 		return len(pendingIDs)

--- a/apps/backend/internal/clarification/canceller.go
+++ b/apps/backend/internal/clarification/canceller.go
@@ -61,7 +61,7 @@ func (c *Canceller) markMessagesDetached(ctx context.Context, msgs []*taskmodels
 				zap.Error(err))
 			continue
 		}
-		c.publishMessageUpdated(ctx, msg)
+		c.publishMessageUpdated(writeCtx, msg)
 	}
 }
 
@@ -86,7 +86,7 @@ func (c *Canceller) markMessagesExpired(ctx context.Context, msgs []*taskmodels.
 				zap.Error(err))
 			continue
 		}
-		c.publishMessageUpdated(ctx, msg)
+		c.publishMessageUpdated(writeCtx, msg)
 	}
 }
 

--- a/apps/backend/internal/clarification/canceller.go
+++ b/apps/backend/internal/clarification/canceller.go
@@ -45,6 +45,7 @@ func isTerminalStatus(status string) bool {
 // interactive: status stays pending and agent_disconnected is set so the UI
 // can route a late answer through the event fallback path.
 func (c *Canceller) markMessagesDetached(ctx context.Context, msgs []*taskmodels.Message, pendingID string) {
+	writeCtx := context.WithoutCancel(ctx)
 	for _, msg := range msgs {
 		if msg.Metadata == nil {
 			msg.Metadata = map[string]any{}
@@ -53,7 +54,7 @@ func (c *Canceller) markMessagesDetached(ctx context.Context, msgs []*taskmodels
 			continue
 		}
 		msg.Metadata["agent_disconnected"] = true
-		if err := c.repo.UpdateMessage(ctx, msg); err != nil {
+		if err := c.repo.UpdateMessage(writeCtx, msg); err != nil {
 			c.logger.Warn("failed to update message with detached status",
 				zap.String("pending_id", pendingID),
 				zap.String("message_id", msg.ID),
@@ -68,6 +69,7 @@ func (c *Canceller) markMessagesDetached(ctx context.Context, msgs []*taskmodels
 // a message.updated event for each one. It is idempotent: already-terminal
 // messages are skipped.
 func (c *Canceller) markMessagesExpired(ctx context.Context, msgs []*taskmodels.Message, pendingID string) {
+	writeCtx := context.WithoutCancel(ctx)
 	for _, msg := range msgs {
 		if msg.Metadata == nil {
 			msg.Metadata = map[string]any{}
@@ -77,7 +79,7 @@ func (c *Canceller) markMessagesExpired(ctx context.Context, msgs []*taskmodels.
 		}
 		msg.Metadata["agent_disconnected"] = true
 		msg.Metadata["status"] = string(StatusExpired)
-		if err := c.repo.UpdateMessage(ctx, msg); err != nil {
+		if err := c.repo.UpdateMessage(writeCtx, msg); err != nil {
 			c.logger.Warn("failed to update message with expired status",
 				zap.String("pending_id", pendingID),
 				zap.String("message_id", msg.ID),

--- a/apps/backend/internal/clarification/canceller.go
+++ b/apps/backend/internal/clarification/canceller.go
@@ -130,13 +130,16 @@ func (c *Canceller) DetachSessionAndNotify(ctx context.Context, sessionID string
 	return c.detachSessionBundles(ctx, sessionID)
 }
 
-// CancelSessionAndNotify is an alias for DetachSessionAndNotify.
+// Deprecated: use DetachSessionAndNotify. This alias remains so older tests and
+// integrations keep the pre-rename entrypoint while detach semantics settle.
 func (c *Canceller) CancelSessionAndNotify(ctx context.Context, sessionID string) int {
 	return c.DetachSessionAndNotify(ctx, sessionID)
 }
 
 // ExpireSessionAndNotify cancels in-memory waiters and marks clarification
 // messages expired so the overlay closes and history shows a timed-out entry.
+// TODO: wire this into terminal teardown paths that should close the overlay
+// instead of preserving the deferred-answer UX.
 func (c *Canceller) ExpireSessionAndNotify(ctx context.Context, sessionID string) int {
 	pendingIDs := c.store.CancelSession(sessionID)
 

--- a/apps/backend/internal/clarification/canceller_test.go
+++ b/apps/backend/internal/clarification/canceller_test.go
@@ -72,12 +72,10 @@ func newTestCanceller(t *testing.T, msgs map[string][]*taskmodels.Message) (*Can
 	return NewCanceller(store, repo, eventBus, logger.Default()), repo, eventBus
 }
 
-// TestCanceller_MarksStatusExpiredOnDisconnect verifies that when the agent's
-// turn ends with a pending clarification, the message is marked status=expired.
-// This is what causes the frontend overlay to close — without it, the overlay
-// stays interactive and a user clicking X triggers an unintended new turn via
-// the event fallback path in the respond handler.
-func TestCanceller_MarksStatusExpiredOnDisconnect(t *testing.T) {
+// TestCanceller_MarksDetachedOnDisconnect verifies that when the agent's turn
+// ends with a pending clarification, the message stays pending with
+// agent_disconnected so the overlay remains interactive for a deferred answer.
+func TestCanceller_MarksDetachedOnDisconnect(t *testing.T) {
 	msgs := map[string][]*taskmodels.Message{}
 	c, repo, _ := newTestCanceller(t, msgs)
 
@@ -102,6 +100,34 @@ func TestCanceller_MarksStatusExpiredOnDisconnect(t *testing.T) {
 	if got, _ := updated.Metadata["agent_disconnected"].(bool); !got {
 		t.Errorf("expected agent_disconnected=true, got %v", updated.Metadata["agent_disconnected"])
 	}
+	if got, _ := updated.Metadata["status"].(string); got != "pending" {
+		t.Errorf("expected status=pending, got %q", got)
+	}
+}
+
+// TestCanceller_ExpireSessionAndNotify_MarksExpired verifies the explicit expiry
+// path closes the overlay and records a timed-out history entry.
+func TestCanceller_ExpireSessionAndNotify_MarksExpired(t *testing.T) {
+	msgs := map[string][]*taskmodels.Message{}
+	c, repo, _ := newTestCanceller(t, msgs)
+
+	pendingID, _ := c.store.CreateRequest(&Request{SessionID: "s1"})
+	msgs[pendingID] = []*taskmodels.Message{{
+		ID:            "m1",
+		TaskSessionID: "s1",
+		Metadata: map[string]any{
+			"status": "pending",
+		},
+	}}
+
+	cancelled := c.ExpireSessionAndNotify(context.Background(), "s1")
+	if cancelled != 1 {
+		t.Fatalf("expected 1 cancelled, got %d", cancelled)
+	}
+	if len(repo.updated) != 1 {
+		t.Fatalf("expected 1 message update, got %d", len(repo.updated))
+	}
+	updated := repo.updated[0]
 	if got, _ := updated.Metadata["status"].(string); got != "expired" {
 		t.Errorf("expected status=expired, got %q", got)
 	}
@@ -140,10 +166,9 @@ func TestCanceller_PublishesMessageUpdatedEvent(t *testing.T) {
 	}
 }
 
-// TestCanceller_MultiQuestion_MarksAllMessagesExpired confirms a multi-question
-// bundle has every message marked expired (and emits one update event each)
-// so the frontend overlay closes for the whole stack on agent timeout.
-func TestCanceller_MultiQuestion_MarksAllMessagesExpired(t *testing.T) {
+// TestCanceller_MultiQuestion_MarksAllMessagesDetached confirms a multi-question
+// bundle has every message marked agent_disconnected while staying pending.
+func TestCanceller_MultiQuestion_MarksAllMessagesDetached(t *testing.T) {
 	msgs := map[string][]*taskmodels.Message{}
 	c, _, eventBus := newTestCanceller(t, msgs)
 
@@ -163,10 +188,10 @@ func TestCanceller_MultiQuestion_MarksAllMessagesExpired(t *testing.T) {
 	}
 }
 
-// TestCanceller_MarksExpiredWhenStoreAlreadyDrained verifies that even when
+// TestCanceller_MarksDetachedWhenStoreAlreadyDrained verifies that even when
 // the in-memory store entry has already been removed (racing MCP-timeout path),
-// CancelSessionAndNotify still finds and marks the DB messages expired.
-func TestCanceller_MarksExpiredWhenStoreAlreadyDrained(t *testing.T) {
+// DetachSessionAndNotify still finds and marks the DB messages detached.
+func TestCanceller_MarksDetachedWhenStoreAlreadyDrained(t *testing.T) {
 	msgs := map[string][]*taskmodels.Message{}
 	c, repo, _ := newTestCanceller(t, msgs)
 
@@ -180,7 +205,7 @@ func TestCanceller_MarksExpiredWhenStoreAlreadyDrained(t *testing.T) {
 		},
 	}}
 
-	cancelled := c.CancelSessionAndNotify(context.Background(), "s1")
+	cancelled := c.DetachSessionAndNotify(context.Background(), "s1")
 	if cancelled != 1 {
 		t.Fatalf("expected 1 cancelled bundle from DB fallback, got %d", cancelled)
 	}
@@ -188,8 +213,11 @@ func TestCanceller_MarksExpiredWhenStoreAlreadyDrained(t *testing.T) {
 		t.Fatalf("expected 1 message update, got %d", len(repo.updated))
 	}
 	updated := repo.updated[0]
-	if got, _ := updated.Metadata["status"].(string); got != "expired" {
-		t.Errorf("expected status=expired, got %q", got)
+	if got, _ := updated.Metadata["status"].(string); got != "pending" {
+		t.Errorf("expected status=pending, got %q", got)
+	}
+	if got, _ := updated.Metadata["agent_disconnected"].(bool); !got {
+		t.Errorf("expected agent_disconnected=true")
 	}
 }
 

--- a/apps/backend/internal/clarification/handlers.go
+++ b/apps/backend/internal/clarification/handlers.go
@@ -309,8 +309,8 @@ func (h *Handlers) httpRespond(c *gin.Context) {
 	// If the user rejected (clicked X to dismiss), they're discarding a stale
 	// overlay — not continuing the conversation. Treat as a no-op so we don't
 	// surprise them by resuming the agent with "User declined to answer".
-	// The message status is already "expired" (set by the canceller), so the
-	// chat history will keep rendering the "Timed out" entry.
+	// The overlay is already detached (agent_disconnected, still pending), so
+	// dismissing it must not resume the agent with "User declined to answer".
 	if body.Rejected {
 		h.logger.Info("clarification rejected after agent moved on; no-op",
 			zap.String("pending_id", pendingID))

--- a/apps/backend/internal/clarification/handlers.go
+++ b/apps/backend/internal/clarification/handlers.go
@@ -446,6 +446,8 @@ func (h *Handlers) applyAnswersToMessages(c *gin.Context, pendingID string, reje
 	if h.messageCreator == nil {
 		return
 	}
+	// Durable status writes must complete even if the HTTP request context is canceled.
+	writeCtx := context.WithoutCancel(c.Request.Context())
 	sessionID := h.lookupSessionForPending(c, pendingID)
 
 	if rejected {
@@ -455,7 +457,7 @@ func (h *Handlers) applyAnswersToMessages(c *gin.Context, pendingID string, reje
 		if h.repo == nil {
 			return
 		}
-		msgs, err := h.repo.FindMessagesByPendingID(c.Request.Context(), pendingID)
+		msgs, err := h.repo.FindMessagesByPendingID(writeCtx, pendingID)
 		if err != nil || len(msgs) == 0 {
 			h.logger.Debug("rejected clarification: no messages to update",
 				zap.String("pending_id", pendingID),
@@ -467,7 +469,7 @@ func (h *Handlers) applyAnswersToMessages(c *gin.Context, pendingID string, reje
 			if questionID == "" {
 				continue
 			}
-			if err := h.messageCreator.UpdateClarificationMessage(c.Request.Context(), sessionID, pendingID, questionID, "rejected", nil); err != nil {
+			if err := h.messageCreator.UpdateClarificationMessage(writeCtx, sessionID, pendingID, questionID, "rejected", nil); err != nil {
 				h.logger.Warn("failed to mark clarification question rejected",
 					zap.String("pending_id", pendingID),
 					zap.String("question_id", questionID),
@@ -482,7 +484,7 @@ func (h *Handlers) applyAnswersToMessages(c *gin.Context, pendingID string, reje
 		if ans.QuestionID == "" {
 			continue
 		}
-		if err := h.messageCreator.UpdateClarificationMessage(c.Request.Context(), sessionID, pendingID, ans.QuestionID, "answered", &ans); err != nil {
+		if err := h.messageCreator.UpdateClarificationMessage(writeCtx, sessionID, pendingID, ans.QuestionID, "answered", &ans); err != nil {
 			h.logger.Warn("failed to update clarification question",
 				zap.String("pending_id", pendingID),
 				zap.String("question_id", ans.QuestionID),

--- a/apps/backend/internal/clarification/handlers.go
+++ b/apps/backend/internal/clarification/handlers.go
@@ -314,7 +314,9 @@ func (h *Handlers) httpRespond(c *gin.Context) {
 	// We still need to mark the bundle rejected in the DB; otherwise the durable
 	// pending-clarification guard would keep blocking future workflow transitions.
 	if body.Rejected {
+		writeCtx := context.WithoutCancel(c.Request.Context())
 		h.applyAnswersToMessages(c, pendingID, true, nil)
+		h.publishStaleDismissedEvent(writeCtx, pendingID)
 		h.logger.Info("clarification rejected after agent moved on; no-op",
 			zap.String("pending_id", pendingID))
 		c.JSON(http.StatusOK, gin.H{"success": true})
@@ -448,7 +450,7 @@ func (h *Handlers) applyAnswersToMessages(c *gin.Context, pendingID string, reje
 	}
 	// Durable status writes must complete even if the HTTP request context is canceled.
 	writeCtx := context.WithoutCancel(c.Request.Context())
-	sessionID := h.lookupSessionForPending(c, pendingID)
+	sessionID := h.lookupSessionForPendingCtx(writeCtx, pendingID)
 
 	if rejected {
 		// Mark every question in the bundle as rejected. Guard h.repo for
@@ -582,19 +584,48 @@ func (h *Handlers) publishCancelledEvent(c *gin.Context, pendingID string, req *
 	}
 }
 
-// lookupSessionForPending returns the session ID for a pending clarification.
+// lookupSessionForPendingCtx returns the session ID for a pending clarification.
 // Falls back to finding it from the database message.
-func (h *Handlers) lookupSessionForPending(c *gin.Context, pendingID string) string {
-	// Try the in-memory store first
+func (h *Handlers) lookupSessionForPendingCtx(ctx context.Context, pendingID string) string {
 	if req, ok := h.store.GetRequest(pendingID); ok {
 		return req.SessionID
 	}
-	// Fall back to database
-	msg, err := h.repo.FindMessageByPendingID(c.Request.Context(), pendingID)
+	if h.repo == nil {
+		return ""
+	}
+	msg, err := h.repo.FindMessageByPendingID(ctx, pendingID)
 	if err != nil {
 		return ""
 	}
 	return msg.TaskSessionID
+}
+
+func (h *Handlers) publishStaleDismissedEvent(ctx context.Context, pendingID string) {
+	if h.eventBus == nil {
+		return
+	}
+	clarificationCtx, err := h.resolveClarificationEventContext(ctx, pendingID)
+	if err != nil || clarificationCtx.SessionID == "" || clarificationCtx.TaskID == "" {
+		h.logger.Warn("failed to resolve context for stale-dismissed clarification event",
+			zap.String("pending_id", pendingID),
+			zap.Error(err))
+		return
+	}
+	eventData := map[string]any{
+		"session_id": clarificationCtx.SessionID,
+		"task_id":    clarificationCtx.TaskID,
+		"pending_id": pendingID,
+	}
+	if err := h.eventBus.Publish(ctx, events.ClarificationStaleDismissed, bus.NewEvent(
+		events.ClarificationStaleDismissed,
+		"clarification-handlers",
+		eventData,
+	)); err != nil {
+		h.logger.Warn("failed to publish stale-dismissed clarification event",
+			zap.String("pending_id", pendingID),
+			zap.String("session_id", clarificationCtx.SessionID),
+			zap.Error(err))
+	}
 }
 
 func (h *Handlers) publishPrimaryAnsweredEvent(c *gin.Context, pendingID string, answers []Answer, rejected bool, rejectReason string) {

--- a/apps/backend/internal/clarification/handlers.go
+++ b/apps/backend/internal/clarification/handlers.go
@@ -311,7 +311,10 @@ func (h *Handlers) httpRespond(c *gin.Context) {
 	// surprise them by resuming the agent with "User declined to answer".
 	// The overlay is already detached (agent_disconnected, still pending), so
 	// dismissing it must not resume the agent with "User declined to answer".
+	// We still need to mark the bundle rejected in the DB; otherwise the durable
+	// pending-clarification guard would keep blocking future workflow transitions.
 	if body.Rejected {
+		h.applyAnswersToMessages(c, pendingID, true, nil)
 		h.logger.Info("clarification rejected after agent moved on; no-op",
 			zap.String("pending_id", pendingID))
 		c.JSON(http.StatusOK, gin.H{"success": true})

--- a/apps/backend/internal/clarification/handlers_test.go
+++ b/apps/backend/internal/clarification/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
 )
 
@@ -95,15 +96,29 @@ func TestHttpRespond_RejectedAfterTimeout_NoNewTurn(t *testing.T) {
 			t.Errorf("expected no %s event; got events: %v", events.ClarificationAnswered, eventBus.events)
 		}
 	}
-	gotStaleDismissed := false
+	var staleEv *bus.Event
 	for _, ev := range eventBus.events {
 		if ev.Type == events.ClarificationStaleDismissed {
-			gotStaleDismissed = true
+			staleEv = ev
+			break
 		}
 	}
-	if !gotStaleDismissed {
-		t.Errorf("expected %s event for session cleanup; got events: %v",
+	if staleEv == nil {
+		t.Fatalf("expected %s event for session cleanup; got events: %v",
 			events.ClarificationStaleDismissed, eventBus.events)
+	}
+	data, ok := staleEv.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map event data, got %T", staleEv.Data)
+	}
+	if got, want := data["session_id"], "s1"; got != want {
+		t.Fatalf("session_id: got %v, want %v", got, want)
+	}
+	if got, want := data["task_id"], "t1"; got != want {
+		t.Fatalf("task_id: got %v, want %v", got, want)
+	}
+	if got, want := data["pending_id"], "pending-123"; got != want {
+		t.Fatalf("pending_id: got %v, want %v", got, want)
 	}
 
 	if len(messageCreator.updates) != 1 {

--- a/apps/backend/internal/clarification/handlers_test.go
+++ b/apps/backend/internal/clarification/handlers_test.go
@@ -64,14 +64,14 @@ func setupTestHandler(t *testing.T, msgs map[string][]*taskmodels.Message) (*Han
 // just dismissing a stale overlay; resuming the agent with "User declined
 // to answer" is surprising and wastes a turn.
 func TestHttpRespond_RejectedAfterTimeout_NoNewTurn(t *testing.T) {
-	// Message exists in DB (agent already moved on; canceller ran).
+	// Message exists in DB (agent already moved on; canceller detached it).
 	msgs := map[string][]*taskmodels.Message{
 		"pending-123": {{
 			ID:            "m1",
 			TaskID:        "t1",
 			TaskSessionID: "s1",
 			Metadata: map[string]any{
-				"status":             "expired",
+				"status":             "pending",
 				"agent_disconnected": true,
 				"pending_id":         "pending-123",
 				"question_id":        "q1",
@@ -96,12 +96,12 @@ func TestHttpRespond_RejectedAfterTimeout_NoNewTurn(t *testing.T) {
 		}
 	}
 
-	// The message is already "expired" (set by the canceller). The no-op path
-	// must NOT re-update the status — otherwise a stale X click would overwrite
-	// "expired" with "rejected" and the history entry would look wrong.
-	if len(messageCreator.updates) != 0 {
-		t.Errorf("expected no message updates in rejected no-op path, got %d: %+v",
+	if len(messageCreator.updates) != 1 {
+		t.Fatalf("expected one message update to clear the durable pending guard, got %d: %+v",
 			len(messageCreator.updates), messageCreator.updates)
+	}
+	if got := messageCreator.updates[0].status; got != "rejected" {
+		t.Fatalf("expected rejected status update, got %q", got)
 	}
 }
 

--- a/apps/backend/internal/clarification/handlers_test.go
+++ b/apps/backend/internal/clarification/handlers_test.go
@@ -95,6 +95,16 @@ func TestHttpRespond_RejectedAfterTimeout_NoNewTurn(t *testing.T) {
 			t.Errorf("expected no %s event; got events: %v", events.ClarificationAnswered, eventBus.events)
 		}
 	}
+	gotStaleDismissed := false
+	for _, ev := range eventBus.events {
+		if ev.Type == events.ClarificationStaleDismissed {
+			gotStaleDismissed = true
+		}
+	}
+	if !gotStaleDismissed {
+		t.Errorf("expected %s event for session cleanup; got events: %v",
+			events.ClarificationStaleDismissed, eventBus.events)
+	}
 
 	if len(messageCreator.updates) != 1 {
 		t.Fatalf("expected one message update to clear the durable pending guard, got %d: %+v",

--- a/apps/backend/internal/events/types.go
+++ b/apps/backend/internal/events/types.go
@@ -160,6 +160,7 @@ const (
 	ClarificationAnswered        = "clarification.answered"         // User answered agent's clarification question (fallback/new turn)
 	ClarificationPrimaryAnswered = "clarification.primary_answered" // User answered while agent is still waiting (same turn)
 	ClarificationCancelled       = "clarification.cancelled"        // User cancelled a pending clarification question
+	ClarificationStaleDismissed  = "clarification.stale_dismissed"  // User dismissed a detached overlay without resuming the agent
 )
 
 // Event types for workspace/git status

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -39,10 +39,10 @@ type ClarificationService interface {
 	CancelRequest(pendingID string) bool
 }
 
-// SessionCanceller cancels all pending clarifications for a session and marks
-// the related chat messages as expired. Used by the MCP-timeout handler.
+// SessionCanceller detaches in-memory clarification waiters while keeping DB
+// messages pending. Used by the MCP-timeout handler.
 type SessionCanceller interface {
-	CancelSessionAndNotify(ctx context.Context, sessionID string) int
+	DetachSessionAndNotify(ctx context.Context, sessionID string) int
 }
 
 // MessageCreator creates messages for clarification requests.
@@ -1513,9 +1513,9 @@ func (h *Handlers) handleClarificationTimeout(ctx context.Context, msg *ws.Messa
 
 	cancelled := 0
 	if h.sessionCanceller != nil {
-		cancelled = h.sessionCanceller.CancelSessionAndNotify(ctx, req.SessionID)
+		cancelled = h.sessionCanceller.DetachSessionAndNotify(ctx, req.SessionID)
 	}
-	h.logger.Info("cancelled pending clarifications on agent MCP timeout",
+	h.logger.Info("detached pending clarifications on agent MCP timeout",
 		zap.String("session_id", req.SessionID),
 		zap.Int("count", cancelled))
 

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1511,10 +1511,10 @@ func (h *Handlers) handleClarificationTimeout(ctx context.Context, msg *ws.Messa
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "session_id is required", nil)
 	}
 
-	cancelled := 0
-	if h.sessionCanceller != nil {
-		cancelled = h.sessionCanceller.DetachSessionAndNotify(ctx, req.SessionID)
+	if h.sessionCanceller == nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "sessionCanceller is required", nil)
 	}
+	cancelled := h.sessionCanceller.DetachSessionAndNotify(ctx, req.SessionID)
 	h.logger.Info("detached pending clarifications on agent MCP timeout",
 		zap.String("session_id", req.SessionID),
 		zap.Int("count", cancelled))

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -912,12 +912,12 @@ func TestHandleClarificationTimeout_DetachesMessages(t *testing.T) {
 	require.Equal(t, true, msgs[0].Metadata["agent_disconnected"])
 }
 
-func TestHandleClarificationTimeout_WithoutCanceller_ReturnsZero(t *testing.T) {
+func TestHandleClarificationTimeout_WithoutCanceller_ReturnsError(t *testing.T) {
 	h := &Handlers{sessionCanceller: nil, logger: testLogger(t).WithFields()}
 	msg := makeWSMessage(t, ws.ActionMCPClarificationTimeout, map[string]interface{}{"session_id": "s1"})
 	resp, err := h.handleClarificationTimeout(context.Background(), msg)
 	require.NoError(t, err)
-	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
 }
 
 func TestHandleAskUserQuestion_Dedup_CreatesOnePendingBundle(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -854,7 +854,7 @@ func TestHandleCreateTask_BlockedBy_Accepted(t *testing.T) {
 	assertWSError(t, resp, ws.ErrorCodeValidation)
 }
 
-func TestHandleClarificationTimeout_MarksMessagesExpired(t *testing.T) {
+func TestHandleClarificationTimeout_DetachesMessages(t *testing.T) {
 	svc, repo := newTestTaskService(t)
 	ctx := context.Background()
 
@@ -908,7 +908,8 @@ func TestHandleClarificationTimeout_MarksMessagesExpired(t *testing.T) {
 
 	msgs, err := repo.FindPendingClarificationMessagesBySessionID(ctx, sess.ID)
 	require.NoError(t, err)
-	require.Empty(t, msgs, "all clarification messages should be expired")
+	require.Len(t, msgs, 1, "clarification should stay pending for deferred answer")
+	require.Equal(t, true, msgs[0].Metadata["agent_disconnected"])
 }
 
 func TestHandleClarificationTimeout_WithoutCanceller_ReturnsZero(t *testing.T) {

--- a/apps/backend/internal/orchestrator/clarification_guard.go
+++ b/apps/backend/internal/orchestrator/clarification_guard.go
@@ -1,0 +1,24 @@
+package orchestrator
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// sessionHasPendingClarification reports whether the session still has durable
+// clarification_request rows awaiting user input. Used to fail closed on
+// workflow on_turn_complete while the user can still answer.
+func (s *Service) sessionHasPendingClarification(ctx context.Context, sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	msgs, err := s.repo.FindPendingClarificationMessagesBySessionID(ctx, sessionID)
+	if err != nil {
+		s.logger.Warn("failed to check pending clarifications; blocking turn-complete transition",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return true
+	}
+	return len(msgs) > 0
+}

--- a/apps/backend/internal/orchestrator/clarification_guard_test.go
+++ b/apps/backend/internal/orchestrator/clarification_guard_test.go
@@ -1,0 +1,41 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestSessionHasPendingClarification(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+
+	if svc.sessionHasPendingClarification(ctx, "s1") {
+		t.Fatal("expected no pending clarification")
+	}
+
+	now := time.Now().UTC()
+	requireNoError(t, repo.CreateTurn(ctx, &models.Turn{ID: "turn-1", TaskSessionID: "s1", TaskID: "t1", StartedAt: now}))
+	requireNoError(t, repo.CreateMessage(ctx, &models.Message{
+		ID:            "clarify-1",
+		TaskSessionID: "s1",
+		TaskID:        "t1",
+		TurnID:        "turn-1",
+		AuthorType:    models.MessageAuthorAgent,
+		Type:          "clarification_request",
+		Content:       "Q?",
+		CreatedAt:     now,
+		Metadata: map[string]interface{}{
+			"pending_id": "pending-1",
+			"status":     "pending",
+		},
+	}))
+
+	if !svc.sessionHasPendingClarification(ctx, "s1") {
+		t.Fatal("expected pending clarification")
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -253,6 +253,14 @@ func (s *Service) handleAgentReady(ctx context.Context, data watcher.AgentEventD
 		return
 	}
 
+	if s.sessionHasPendingClarification(ctx, data.SessionID) {
+		s.logger.Info("deferring on_turn_complete while clarification is pending",
+			zap.String("task_id", data.TaskID),
+			zap.String("session_id", data.SessionID))
+		s.setSessionWaitingForInput(ctx, data.TaskID, data.SessionID, session)
+		return
+	}
+
 	// Check for workflow transition based on session's current step.
 	// Uses the engine when available; falls back to legacy evaluation.
 	// The ViaEngine method handles setSessionWaitingForInput internally when no transition occurs.
@@ -470,6 +478,15 @@ func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEv
 			zap.String("task_id", data.TaskID),
 			zap.String("session_id", data.SessionID),
 			zap.String("session_state", string(session.State)))
+		go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
+		return
+	}
+
+	if s.sessionHasPendingClarification(ctx, data.SessionID) {
+		s.logger.Info("deferring on_turn_complete on agent.completed while clarification is pending",
+			zap.String("task_id", data.TaskID),
+			zap.String("session_id", data.SessionID))
+		s.setSessionWaitingForInput(ctx, data.TaskID, data.SessionID, session)
 		go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
 		return
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -253,6 +253,7 @@ func (s *Service) handleAgentReady(ctx context.Context, data watcher.AgentEventD
 		return
 	}
 
+	// Explicit agent-requested moves (move_task_kandev) take precedence over pending clarifications.
 	if s.sessionHasPendingClarification(ctx, data.SessionID) {
 		s.logger.Info("deferring on_turn_complete while clarification is pending",
 			zap.String("task_id", data.TaskID),
@@ -489,8 +490,9 @@ func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEv
 			zap.String("session_id", data.SessionID))
 		s.setSessionWaitingForInput(ctx, data.TaskID, data.SessionID, session)
 		go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
-		// captureGitStatusSnapshot and finalizeAutomationRunIfEphemeral run on the
-		// next agent turn that completes without a pending clarification.
+		// captureGitStatusSnapshot and finalizeAutomationRunIfEphemeral are deferred
+		// until a later agent turn completes without pending clarifications, or the
+		// user dismisses a stale overlay (clarification.stale_dismissed).
 		return
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -483,12 +483,14 @@ func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEv
 	}
 
 	if s.sessionHasPendingClarification(ctx, data.SessionID) {
-		s.completeTurnForSession(ctx, data.SessionID)
+		s.completeTurnForSession(context.WithoutCancel(ctx), data.SessionID)
 		s.logger.Info("deferring on_turn_complete on agent.completed while clarification is pending",
 			zap.String("task_id", data.TaskID),
 			zap.String("session_id", data.SessionID))
 		s.setSessionWaitingForInput(ctx, data.TaskID, data.SessionID, session)
 		go s.cleanupAgentExecution(data.AgentExecutionID, data.TaskID, data.SessionID)
+		// captureGitStatusSnapshot and finalizeAutomationRunIfEphemeral run on the
+		// next agent turn that completes without a pending clarification.
 		return
 	}
 

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -483,6 +483,7 @@ func (s *Service) handleAgentCompleted(ctx context.Context, data watcher.AgentEv
 	}
 
 	if s.sessionHasPendingClarification(ctx, data.SessionID) {
+		s.completeTurnForSession(ctx, data.SessionID)
 		s.logger.Info("deferring on_turn_complete on agent.completed while clarification is pending",
 			zap.String("task_id", data.TaskID),
 			zap.String("session_id", data.SessionID))

--- a/apps/backend/internal/orchestrator/event_handlers_agent_clarification_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent_clarification_test.go
@@ -1,0 +1,108 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+)
+
+func TestHandleAgentReady_BlocksOnTurnCompleteWhileClarificationPending(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	setSessionExecID(t, repo, "s1", "exec-1")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Plan", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+				{Type: wfmodels.OnTurnCompleteMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Name: "Implement", Position: 1,
+	}
+
+	svc := createEngineService(t, repo, stepGetter, &mockAgentManager{repoForExecutionLookup: repo})
+
+	t.Run("advances when no pending clarification", func(t *testing.T) {
+		svc.handleAgentReady(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1"})
+
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step2" {
+			t.Fatalf("expected workflow step step2, got %q", task.WorkflowStepID)
+		}
+	})
+
+	t.Run("does not advance while clarification is pending", func(t *testing.T) {
+		// Reset task to plan step after the subtest above advanced it.
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		task.WorkflowStepID = "step1"
+		if err := repo.UpdateTask(ctx, task); err != nil {
+			t.Fatalf("reset task step: %v", err)
+		}
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		session.State = models.TaskSessionStateRunning
+		if err := repo.UpdateTaskSession(ctx, session); err != nil {
+			t.Fatalf("reset session state: %v", err)
+		}
+
+		now := time.Now().UTC()
+		requireNoError(t, repo.CreateTurn(ctx, &models.Turn{ID: "turn-clarify", TaskSessionID: "s1", TaskID: "t1", StartedAt: now}))
+		requireNoError(t, repo.CreateMessage(ctx, &models.Message{
+			ID:            "clarify-1",
+			TaskSessionID: "s1",
+			TaskID:        "t1",
+			TurnID:        "turn-clarify",
+			AuthorType:    models.MessageAuthorAgent,
+			Type:          "clarification_request",
+			Content:       "Which approach?",
+			CreatedAt:     now,
+			Metadata: map[string]interface{}{
+				"pending_id":  "pending-1",
+				"question_id": "q1",
+				"status":      "pending",
+			},
+		}))
+
+		svc.handleAgentReady(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1"})
+
+		task, err = repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step1" {
+			t.Fatalf("expected workflow step to remain step1, got %q", task.WorkflowStepID)
+		}
+
+		session, err = repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		if session.State != models.TaskSessionStateWaitingForInput {
+			t.Fatalf("expected session %q, got %q", models.TaskSessionStateWaitingForInput, session.State)
+		}
+	})
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_agent_clarification_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent_clarification_test.go
@@ -2,6 +2,8 @@ package orchestrator
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +11,48 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
+
+type repoBackedTurnService struct {
+	repo testRepo
+}
+
+type testRepo interface {
+	CreateTurn(ctx context.Context, turn *models.Turn) error
+	CompleteTurn(ctx context.Context, id string) error
+	GetActiveTurnBySessionID(ctx context.Context, sessionID string) (*models.Turn, error)
+}
+
+func (s *repoBackedTurnService) StartTurn(ctx context.Context, sessionID string) (*models.Turn, error) {
+	turn := &models.Turn{
+		ID:            "turn-" + sessionID,
+		TaskSessionID: sessionID,
+		StartedAt:     time.Now().UTC(),
+	}
+	if err := s.repo.CreateTurn(ctx, turn); err != nil {
+		return nil, err
+	}
+	return turn, nil
+}
+
+func (s *repoBackedTurnService) CompleteTurn(ctx context.Context, turnID string) error {
+	return s.repo.CompleteTurn(ctx, turnID)
+}
+
+func (s *repoBackedTurnService) GetActiveTurn(ctx context.Context, sessionID string) (*models.Turn, error) {
+	return s.repo.GetActiveTurnBySessionID(ctx, sessionID)
+}
+
+func (s *repoBackedTurnService) AbandonOpenTurns(ctx context.Context, sessionID string) error {
+	for {
+		turn, err := s.repo.GetActiveTurnBySessionID(ctx, sessionID)
+		if err != nil || turn == nil {
+			return err
+		}
+		if err := s.repo.CompleteTurn(ctx, turn.ID); err != nil {
+			return err
+		}
+	}
+}
 
 func TestHandleAgentReady_BlocksOnTurnCompleteWhileClarificationPending(t *testing.T) {
 	ctx := context.Background()
@@ -96,6 +140,117 @@ func TestHandleAgentReady_BlocksOnTurnCompleteWhileClarificationPending(t *testi
 		}
 		if session.State != models.TaskSessionStateWaitingForInput {
 			t.Fatalf("expected session %q, got %q", models.TaskSessionStateWaitingForInput, session.State)
+		}
+	})
+}
+
+func TestHandleAgentCompleted_BlocksOnTurnCompleteWhileClarificationPending(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	setSessionExecID(t, repo, "s1", "exec-1")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+		ID: "step1", WorkflowID: "wf1", Name: "Plan", Position: 0,
+		Events: wfmodels.StepEvents{
+			OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+				{Type: wfmodels.OnTurnCompleteMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+		ID: "step2", WorkflowID: "wf1", Name: "Implement", Position: 1,
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createTestServiceWithScheduler(repo, stepGetter, newMockTaskRepo(), agentMgr)
+	svc.turnService = &repoBackedTurnService{repo: repo}
+
+	t.Run("advances when no pending clarification", func(t *testing.T) {
+		svc.handleAgentCompleted(ctx, watcher.AgentEventData{
+			TaskID:           "t1",
+			SessionID:        "s1",
+			AgentExecutionID: "exec-1",
+		})
+
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step2" {
+			t.Fatalf("expected workflow step step2, got %q", task.WorkflowStepID)
+		}
+	})
+
+	t.Run("does not advance while clarification is pending", func(t *testing.T) {
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		task.WorkflowStepID = "step1"
+		if err := repo.UpdateTask(ctx, task); err != nil {
+			t.Fatalf("reset task step: %v", err)
+		}
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		session.State = models.TaskSessionStateRunning
+		if err := repo.UpdateTaskSession(ctx, session); err != nil {
+			t.Fatalf("reset session state: %v", err)
+		}
+
+		now := time.Now().UTC()
+		requireNoError(t, repo.CreateTurn(ctx, &models.Turn{
+			ID:            "turn-clarify-completed",
+			TaskSessionID: "s1",
+			TaskID:        "t1",
+			StartedAt:     now,
+		}))
+		requireNoError(t, repo.CreateMessage(ctx, &models.Message{
+			ID:            "clarify-completed-1",
+			TaskSessionID: "s1",
+			TaskID:        "t1",
+			TurnID:        "turn-clarify-completed",
+			AuthorType:    models.MessageAuthorAgent,
+			Type:          "clarification_request",
+			Content:       "Which approach?",
+			CreatedAt:     now,
+			Metadata: map[string]interface{}{
+				"pending_id":  "pending-1",
+				"question_id": "q1",
+				"status":      "pending",
+			},
+		}))
+
+		svc.handleAgentCompleted(ctx, watcher.AgentEventData{
+			TaskID:           "t1",
+			SessionID:        "s1",
+			AgentExecutionID: "exec-1",
+		})
+
+		task, err = repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step1" {
+			t.Fatalf("expected workflow step to remain step1, got %q", task.WorkflowStepID)
+		}
+
+		session, err = repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		if session.State != models.TaskSessionStateWaitingForInput {
+			t.Fatalf("expected session %q, got %q", models.TaskSessionStateWaitingForInput, session.State)
+		}
+		turn, err := svc.turnService.GetActiveTurn(ctx, "s1")
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("get active turn: %v", err)
+		}
+		if turn != nil {
+			t.Fatalf("expected active turn to be completed before deferring, got %q", turn.ID)
 		}
 	})
 }

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -56,12 +56,13 @@ func (s *Service) handleClarificationStaleDismissed(ctx context.Context, event *
 	}
 
 	writeCtx := context.WithoutCancel(ctx)
-	s.captureGitStatusSnapshot(writeCtx, data.SessionID)
-	s.finalizeAutomationRunIfEphemeral(writeCtx, data.TaskID, data.SessionID, true, "")
-
 	if s.sessionHasPendingClarification(writeCtx, data.SessionID) {
 		return nil
 	}
+
+	s.captureGitStatusSnapshot(writeCtx, data.SessionID)
+	s.finalizeAutomationRunIfEphemeral(writeCtx, data.TaskID, data.SessionID, true, "")
+
 	session, err := s.repo.GetTaskSession(writeCtx, data.SessionID)
 	if err != nil {
 		s.logger.Warn("failed to load session for stale-dismissed clarification cleanup",

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -60,9 +60,6 @@ func (s *Service) handleClarificationStaleDismissed(ctx context.Context, event *
 		return nil
 	}
 
-	s.captureGitStatusSnapshot(writeCtx, data.SessionID)
-	s.finalizeAutomationRunIfEphemeral(writeCtx, data.TaskID, data.SessionID, true, "")
-
 	session, err := s.repo.GetTaskSession(writeCtx, data.SessionID)
 	if err != nil {
 		s.logger.Warn("failed to load session for stale-dismissed clarification cleanup",
@@ -70,6 +67,16 @@ func (s *Service) handleClarificationStaleDismissed(ctx context.Context, event *
 			zap.Error(err))
 		return nil
 	}
+	if isTerminalSessionState(session.State) {
+		s.logger.Debug("ignoring stale-dismissed clarification for terminal session",
+			zap.String("task_id", data.TaskID),
+			zap.String("session_id", data.SessionID),
+			zap.String("session_state", string(session.State)))
+		return nil
+	}
+
+	s.captureGitStatusSnapshot(writeCtx, data.SessionID)
+	s.finalizeAutomationRunIfEphemeral(writeCtx, data.TaskID, data.SessionID, true, "")
 	s.processOnTurnCompleteViaEngine(writeCtx, data.TaskID, session)
 	return nil
 }

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -30,6 +30,47 @@ func (s *Service) subscribeClarificationEvents() {
 	if _, err := s.eventBus.Subscribe(events.ClarificationCancelled, s.handleClarificationAnswered); err != nil {
 		s.logger.Error("failed to subscribe to clarification.cancelled events", zap.Error(err))
 	}
+	if _, err := s.eventBus.Subscribe(events.ClarificationStaleDismissed, s.handleClarificationStaleDismissed); err != nil {
+		s.logger.Error("failed to subscribe to clarification.stale_dismissed events", zap.Error(err))
+	}
+}
+
+// handleClarificationStaleDismissed runs session cleanup when the user dismisses
+// a detached clarification overlay without starting a new agent turn.
+func (s *Service) handleClarificationStaleDismissed(ctx context.Context, event *bus.Event) error {
+	dataBytes, err := json.Marshal(event.Data)
+	if err != nil {
+		s.logger.Error("failed to marshal stale-dismissed clarification event data", zap.Error(err))
+		return nil
+	}
+	var data clarificationAnsweredData
+	if err := json.Unmarshal(dataBytes, &data); err != nil {
+		s.logger.Error("failed to parse stale-dismissed clarification event data", zap.Error(err))
+		return nil
+	}
+	if data.SessionID == "" || data.TaskID == "" {
+		s.logger.Warn("stale-dismissed clarification event missing session_id or task_id",
+			zap.String("session_id", data.SessionID),
+			zap.String("task_id", data.TaskID))
+		return nil
+	}
+
+	writeCtx := context.WithoutCancel(ctx)
+	s.captureGitStatusSnapshot(writeCtx, data.SessionID)
+	s.finalizeAutomationRunIfEphemeral(writeCtx, data.TaskID, data.SessionID, true, "")
+
+	if s.sessionHasPendingClarification(writeCtx, data.SessionID) {
+		return nil
+	}
+	session, err := s.repo.GetTaskSession(writeCtx, data.SessionID)
+	if err != nil {
+		s.logger.Warn("failed to load session for stale-dismissed clarification cleanup",
+			zap.String("session_id", data.SessionID),
+			zap.Error(err))
+		return nil
+	}
+	s.processOnTurnCompleteViaEngine(writeCtx, data.TaskID, session)
+	return nil
 }
 
 // clarificationAnsweredData is the event payload for ClarificationAnswered events.

--- a/apps/backend/internal/orchestrator/event_handlers_clarification.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // subscribeClarificationEvents subscribes to clarification-related events.
@@ -77,7 +78,14 @@ func (s *Service) handleClarificationStaleDismissed(ctx context.Context, event *
 
 	s.captureGitStatusSnapshot(writeCtx, data.SessionID)
 	s.finalizeAutomationRunIfEphemeral(writeCtx, data.TaskID, data.SessionID, true, "")
-	s.processOnTurnCompleteViaEngine(writeCtx, data.TaskID, session)
+	transitioned := s.processOnTurnCompleteViaEngine(writeCtx, data.TaskID, session)
+	if !transitioned {
+		if err := s.taskRepo.UpdateTaskState(writeCtx, data.TaskID, v1.TaskStateReview); err != nil {
+			s.logger.Error("failed to update task state to REVIEW after stale-dismiss",
+				zap.String("task_id", data.TaskID),
+				zap.Error(err))
+		}
+	}
 	return nil
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
@@ -93,8 +93,31 @@ func TestHandleClarificationStaleDismissed(t *testing.T) {
 
 	t.Run("skips on_turn_complete while clarification still pending", func(t *testing.T) {
 		repo := setupTestRepo(t)
-		svc := createTestServiceWithScheduler(repo, newMockStepGetter(), newMockTaskRepo(), &mockAgentManager{})
-		seedTaskAndSession(t, repo, "t1", "s1", models.TaskSessionStateWaitingForInput)
+		seedSession(t, repo, "t1", "s1", "step1")
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+			ID: "step1", WorkflowID: "wf1", Name: "Plan", Position: 0,
+			Events: wfmodels.StepEvents{
+				OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+					{Type: wfmodels.OnTurnCompleteMoveToNext},
+				},
+			},
+		}
+		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Implement", Position: 1,
+		}
+		svc := createEngineService(t, repo, stepGetter, &mockAgentManager{})
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		session.State = models.TaskSessionStateWaitingForInput
+		if err := repo.UpdateTaskSession(ctx, session); err != nil {
+			t.Fatalf("set session waiting: %v", err)
+		}
+
 		now := time.Now().UTC()
 		requireNoError(t, repo.CreateTurn(ctx, &models.Turn{ID: "turn-1", TaskSessionID: "s1", TaskID: "t1", StartedAt: now}))
 		requireNoError(t, repo.CreateMessage(ctx, &models.Message{
@@ -110,6 +133,14 @@ func TestHandleClarificationStaleDismissed(t *testing.T) {
 		})
 		if err := svc.handleClarificationStaleDismissed(ctx, event); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step1" {
+			t.Fatalf("expected step to remain step1 while clarification pending, got %q", task.WorkflowStepID)
 		}
 	})
 

--- a/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
@@ -77,6 +77,42 @@ func TestHandleClarificationAnswered(t *testing.T) {
 	})
 }
 
+func TestHandleClarificationStaleDismissed(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns nil on missing session_id", func(t *testing.T) {
+		svc := &Service{logger: testLogger()}
+		event := bus.NewEvent("clarification.stale_dismissed", "test", map[string]any{
+			"task_id": "t1",
+		})
+		if err := svc.handleClarificationStaleDismissed(ctx, event); err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	})
+
+	t.Run("skips on_turn_complete while clarification still pending", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		svc := createTestServiceWithScheduler(repo, newMockStepGetter(), newMockTaskRepo(), &mockAgentManager{})
+		seedTaskAndSession(t, repo, "t1", "s1", models.TaskSessionStateWaitingForInput)
+		now := time.Now().UTC()
+		requireNoError(t, repo.CreateTurn(ctx, &models.Turn{ID: "turn-1", TaskSessionID: "s1", TaskID: "t1", StartedAt: now}))
+		requireNoError(t, repo.CreateMessage(ctx, &models.Message{
+			ID: "clarify-1", TaskSessionID: "s1", TaskID: "t1", TurnID: "turn-1",
+			AuthorType: models.MessageAuthorAgent, Type: "clarification_request", Content: "Q?",
+			CreatedAt: now, Metadata: map[string]interface{}{"pending_id": "pending-1", "status": "pending"},
+		}))
+
+		event := bus.NewEvent("clarification.stale_dismissed", "test", map[string]any{
+			"session_id": "s1",
+			"task_id":    "t1",
+			"pending_id": "pending-1",
+		})
+		if err := svc.handleClarificationStaleDismissed(ctx, event); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestBuildClarificationPrompt(t *testing.T) {
 	t.Run("builds accepted prompt with question and answer", func(t *testing.T) {
 		data := clarificationAnsweredData{

--- a/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 func TestHandleClarificationAnswered(t *testing.T) {
@@ -231,6 +232,41 @@ func TestHandleClarificationStaleDismissed(t *testing.T) {
 		}
 		if task.WorkflowStepID != "step2" {
 			t.Fatalf("expected workflow step step2 after deferred on_turn_complete, got %q", task.WorkflowStepID)
+		}
+	})
+
+	t.Run("moves task to REVIEW when no workflow transition fires", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+			ID: "step1", WorkflowID: "wf1", Name: "Plan", Position: 0,
+		}
+		taskRepo := newMockTaskRepo()
+		svc := createEngineService(t, repo, stepGetter, &mockAgentManager{})
+		svc.taskRepo = taskRepo
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		session.State = models.TaskSessionStateWaitingForInput
+		if err := repo.UpdateTaskSession(ctx, session); err != nil {
+			t.Fatalf("set session waiting: %v", err)
+		}
+
+		event := bus.NewEvent("clarification.stale_dismissed", "test", map[string]any{
+			"session_id": "s1",
+			"task_id":    "t1",
+			"pending_id": "pending-1",
+		})
+		if err := svc.handleClarificationStaleDismissed(ctx, event); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if state, ok := taskRepo.updatedStates["t1"]; !ok || state != v1.TaskStateReview {
+			t.Fatalf("expected task state %q, got %q (ok=%v)", v1.TaskStateReview, state, ok)
 		}
 	})
 }

--- a/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 )
 
 func TestHandleClarificationAnswered(t *testing.T) {
@@ -109,6 +110,51 @@ func TestHandleClarificationStaleDismissed(t *testing.T) {
 		})
 		if err := svc.handleClarificationStaleDismissed(ctx, event); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("advances workflow when no clarification is pending after dismiss", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+			ID: "step1", WorkflowID: "wf1", Name: "Plan", Position: 0,
+			Events: wfmodels.StepEvents{
+				OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+					{Type: wfmodels.OnTurnCompleteMoveToNext},
+				},
+			},
+		}
+		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Implement", Position: 1,
+		}
+		svc := createEngineService(t, repo, stepGetter, &mockAgentManager{})
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		session.State = models.TaskSessionStateWaitingForInput
+		if err := repo.UpdateTaskSession(ctx, session); err != nil {
+			t.Fatalf("set session waiting: %v", err)
+		}
+
+		event := bus.NewEvent("clarification.stale_dismissed", "test", map[string]any{
+			"session_id": "s1",
+			"task_id":    "t1",
+			"pending_id": "pending-1",
+		})
+		if err := svc.handleClarificationStaleDismissed(ctx, event); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step2" {
+			t.Fatalf("expected workflow step step2 after deferred on_turn_complete, got %q", task.WorkflowStepID)
 		}
 	})
 }

--- a/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_clarification_test.go
@@ -144,6 +144,51 @@ func TestHandleClarificationStaleDismissed(t *testing.T) {
 		}
 	})
 
+	t.Run("skips cleanup for terminal session state", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step1"] = &wfmodels.WorkflowStep{
+			ID: "step1", WorkflowID: "wf1", Name: "Plan", Position: 0,
+			Events: wfmodels.StepEvents{
+				OnTurnComplete: []wfmodels.OnTurnCompleteAction{
+					{Type: wfmodels.OnTurnCompleteMoveToNext},
+				},
+			},
+		}
+		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Implement", Position: 1,
+		}
+		svc := createEngineService(t, repo, stepGetter, &mockAgentManager{})
+
+		session, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("get session: %v", err)
+		}
+		session.State = models.TaskSessionStateCancelled
+		if err := repo.UpdateTaskSession(ctx, session); err != nil {
+			t.Fatalf("set session cancelled: %v", err)
+		}
+
+		event := bus.NewEvent("clarification.stale_dismissed", "test", map[string]any{
+			"session_id": "s1",
+			"task_id":    "t1",
+			"pending_id": "pending-1",
+		})
+		if err := svc.handleClarificationStaleDismissed(ctx, event); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		task, err := repo.GetTask(ctx, "t1")
+		if err != nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.WorkflowStepID != "step1" {
+			t.Fatalf("expected step to remain step1 for terminal session, got %q", task.WorkflowStepID)
+		}
+	})
+
 	t.Run("advances workflow when no clarification is pending after dismiss", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		seedSession(t, repo, "t1", "s1", "step1")

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -724,11 +724,11 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	// complete time.
 	s.publishAgentTurnComplete(ctx, payload)
 
-	// Cancel any pending clarifications for this session so WaitForResponse
-	// unblocks and later user responses go through the event fallback path.
+	// Detach any pending clarifications so WaitForResponse unblocks while the
+	// overlay stays interactive for a deferred answer via the event fallback path.
 	if s.clarificationCanceller != nil && payload.SessionID != "" {
-		if n := s.clarificationCanceller.CancelSessionAndNotify(ctx, payload.SessionID); n > 0 {
-			s.logger.Info("cancelled pending clarifications on turn complete",
+		if n := s.clarificationCanceller.DetachSessionAndNotify(ctx, payload.SessionID); n > 0 {
+			s.logger.Info("detached pending clarifications on turn complete",
 				zap.String("session_id", payload.SessionID),
 				zap.Int("count", n))
 		}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -184,6 +184,8 @@ type sessionExecutorStore interface {
 	// Messages — used by resume to backfill the initial user prompt when a
 	// prior launch failed before recordInitialMessage ran.
 	ListMessages(ctx context.Context, sessionID string) ([]*models.Message, error)
+	// Pending clarification rows — durable guard for on_turn_complete while the user is answering.
+	FindPendingClarificationMessagesBySessionID(ctx context.Context, sessionID string) ([]*models.Message, error)
 	// Workspace
 	GetWorkspace(ctx context.Context, id string) (*models.Workspace, error)
 	// Task environment
@@ -549,9 +551,10 @@ func (s *Service) SetWorkflowStepGetter(getter WorkflowStepGetter) {
 	s.initWorkflowEngine()
 }
 
-// ClarificationCanceller cancels pending clarifications when an agent's turn completes.
+// ClarificationCanceller detaches in-memory clarification waiters when an agent's
+// turn completes while questions are still pending in the DB.
 type ClarificationCanceller interface {
-	CancelSessionAndNotify(ctx context.Context, sessionID string) int
+	DetachSessionAndNotify(ctx context.Context, sessionID string) int
 }
 
 // SetClarificationCanceller sets the canceller for cleaning up pending clarifications on turn complete.

--- a/apps/web/e2e/tests/chat/clarification.spec.ts
+++ b/apps/web/e2e/tests/chat/clarification.spec.ts
@@ -74,7 +74,7 @@ test.describe("Clarification flow", () => {
     await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
   });
 
-  test("timeout closes overlay and renders expired entry in history", async ({
+  test("timeout detaches clarification but keeps overlay for deferred answer", async ({
     testPage,
     apiClient,
     seedData,
@@ -88,11 +88,13 @@ test.describe("Clarification flow", () => {
     );
 
     await expect(session.clarificationOverlay()).toBeVisible({ timeout: 30_000 });
-    await expect(session.chat).toContainText("timed out", { timeout: 30_000 });
-    await expect(session.clarificationOverlay()).not.toBeVisible({ timeout: 10_000 });
-    await expect(session.clarificationDeferredNotice()).not.toBeVisible();
-    await expect(session.clarificationExpiredNotice()).toBeVisible();
-    await expect(session.idleInput()).toBeVisible({ timeout: 10_000 });
+    await expect(session.chat).toContainText("Question timed out", { timeout: 30_000 });
+    await expect(session.clarificationDeferredNotice()).toBeVisible({ timeout: 10_000 });
+    await expect(session.clarificationExpiredNotice()).not.toBeVisible();
+
+    // Agent moved on; a late answer goes through the event fallback as a new prompt.
+    await session.clarificationOption("PostgreSQL").click();
+    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
   });
 
   test("options render label and description on separate rows", async ({

--- a/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-status-badge.spec.ts
@@ -161,7 +161,9 @@ test.describe("PR status badge", () => {
     const session = new SessionPage(testPage);
     await session.waitForLoad();
     await expect(session.prTopbarButton()).toBeVisible({ timeout: 15_000 });
-    await expect(session.prTopbarButton()).toHaveAttribute("data-pr-ready-to-merge", "true");
+    await expect(session.prTopbarButton()).toHaveAttribute("data-pr-ready-to-merge", "true", {
+      timeout: 15_000,
+    });
   });
 
   /**


### PR DESCRIPTION
Plan-mode tasks could auto-advance to the next workflow step while the user still had an unanswered `ask_user_question_kandev` overlay, because `on_turn_complete` did not check durable pending clarification state and turn-end handling expired those questions instead of keeping them answerable.

This change gates `on_turn_complete` on pending `clarification_request` rows, detaches (rather than expires) clarifications when the agent's turn ends so the overlay stays interactive with `agent_disconnected`, and adds regression tests for the canceller, MCP timeout, and `handleAgentReady` paths.

## Important Changes

- `DetachSessionAndNotify` keeps clarification messages `pending` with `agent_disconnected=true`; `ExpireSessionAndNotify` remains for explicit expiry.
- `handleAgentReady` / `handleAgentCompleted` skip workflow transitions while DB pending clarifications exist.

## Validation

- `go test ./internal/clarification/... ./internal/mcp/handlers/... ./internal/orchestrator/...` (1054 tests passed)

## Possible Improvements

Low risk; Playwright E2E for plan-step + ask + no auto-advance is still outstanding.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)