### PR TITLE
fix(web): restore debug UI on make start-debug

### DIFF
--- a/apps/cli/src/run.ts
+++ b/apps/cli/src/run.ts
@@ -19,7 +19,7 @@ import { sortVersionsDesc } from "./version";
 import { pickAvailablePort } from "./ports";
 import { createProcessSupervisor } from "./process";
 import { resolveRuntime, validateBundle } from "./runtime";
-import { attachBackendExitHandler, logStartupInfo } from "./shared";
+import { attachBackendExitHandler, buildBackendEnv, buildWebEnv, logStartupInfo } from "./shared";
 import { launchWebApp, openBrowser } from "./web";
 
 export type RunOptions = {
@@ -195,23 +195,30 @@ async function prepareBundleForLaunch({
 
   const backendBin = path.join(bundleDir, "bin", getBinaryName("kandev"));
 
-  const backendEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    KANDEV_SERVER_PORT: String(actualBackendPort),
-    KANDEV_WEB_INTERNAL_URL: `http://localhost:${actualWebPort}`,
-    KANDEV_AGENT_STANDALONE_PORT: String(agentctlPort),
-    KANDEV_DATABASE_PATH: dbPath,
-    KANDEV_LOG_LEVEL: logLevel,
-    ...(debug ? { KANDEV_DEBUG_AGENT_MESSAGES: "true", KANDEV_DEBUG_PPROF_ENABLED: "true" } : {}),
-  };
+  const backendEnv = buildBackendEnv({
+    ports: {
+      backendPort: actualBackendPort,
+      webPort: actualWebPort,
+      agentctlPort,
+      backendUrl,
+    },
+    logLevel,
+    extra: {
+      KANDEV_DATABASE_PATH: dbPath,
+      ...(debug ? { KANDEV_DEBUG_AGENT_MESSAGES: "true", KANDEV_DEBUG_PPROF_ENABLED: "true" } : {}),
+    },
+  });
 
-  const webEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    KANDEV_API_BASE_URL: backendUrl,
-    PORT: String(actualWebPort),
-    HOSTNAME: "127.0.0.1",
-  };
-  (webEnv as Record<string, string>).NODE_ENV = "production";
+  const webEnv = buildWebEnv({
+    ports: {
+      backendPort: actualBackendPort,
+      webPort: actualWebPort,
+      agentctlPort,
+      backendUrl,
+    },
+    production: true,
+    debug,
+  });
 
   return {
     bundleDir,

--- a/apps/cli/src/shared.test.ts
+++ b/apps/cli/src/shared.test.ts
@@ -64,7 +64,9 @@ describe("buildWebEnv", () => {
 
   it("enables debug flag when requested", () => {
     expect(buildWebEnv({ ports, debug: true }).NEXT_PUBLIC_KANDEV_DEBUG).toBe("true");
+    expect(buildWebEnv({ ports, debug: true }).KANDEV_DEBUG).toBe("true");
     expect(buildWebEnv({ ports }).NEXT_PUBLIC_KANDEV_DEBUG).toBeUndefined();
+    expect(buildWebEnv({ ports }).KANDEV_DEBUG).toBeUndefined();
   });
 });
 

--- a/apps/cli/src/shared.ts
+++ b/apps/cli/src/shared.ts
@@ -121,6 +121,7 @@ export function buildWebEnv(options: WebEnvOptions): NodeJS.ProcessEnv {
   }
 
   if (debug) {
+    env.KANDEV_DEBUG = "true";
     env.NEXT_PUBLIC_KANDEV_DEBUG = "true";
   }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -40,7 +40,8 @@ export default async function RootLayout({
   // In production single-port mode, this is not needed — the client uses
   // window.location.origin (same-origin, works for any domain / reverse proxy).
   const apiPort = process.env.NEXT_PUBLIC_KANDEV_API_PORT ?? null;
-  const debugMode = process.env.NEXT_PUBLIC_KANDEV_DEBUG === "true";
+  const debugMode =
+    process.env.KANDEV_DEBUG === "true" || process.env.NEXT_PUBLIC_KANDEV_DEBUG === "true";
 
   // SSR-fetch the deployment's feature flags so the entire client tree
   // (including the sidebar nav and gated routes) renders with the correct
@@ -48,10 +49,25 @@ export default async function RootLayout({
   // is unreachable. See docs/decisions/0007-runtime-feature-flags.md.
   const features = await getFeatureFlagsAction();
 
+  const runtimeConfigScript =
+    apiPort || debugMode
+      ? [
+          apiPort ? `window.__KANDEV_API_PORT = ${JSON.stringify(apiPort)};` : "",
+          debugMode ? `window.__KANDEV_DEBUG = true;` : "",
+        ]
+          .filter(Boolean)
+          .join("\n")
+      : null;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="apple-mobile-web-app-title" content="Kandev" />
+        {/* Inject runtime config before Next.js async chunks so debug UI flags
+            are visible when client modules first evaluate. */}
+        {runtimeConfigScript ? (
+          <script dangerouslySetInnerHTML={{ __html: runtimeConfigScript }} />
+        ) : null}
         {/* Preload the Seti icon webfont so file-tree glyphs (review dialog,
             file browser) don't flash blank on first render. */}
         <link
@@ -63,18 +79,6 @@ export default async function RootLayout({
         />
       </head>
       <body className="antialiased font-sans">
-        {apiPort || debugMode ? (
-          <script
-            dangerouslySetInnerHTML={{
-              __html: [
-                apiPort ? `window.__KANDEV_API_PORT = ${JSON.stringify(apiPort)};` : "",
-                debugMode ? `window.__KANDEV_DEBUG = true;` : "",
-              ]
-                .filter(Boolean)
-                .join("\n"),
-            }}
-          />
-        ) : null}
         <StateProvider initialState={{ features }}>
           <ThemeProvider>
             <DiffWorkerPoolProvider>

--- a/apps/web/components/session/prepare-progress.tsx
+++ b/apps/web/components/session/prepare-progress.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 import { stripAnsi } from "@/lib/utils/ansi";
 import { isSetupScriptMessage } from "@/hooks/use-processed-messages";
 import type { Message } from "@/lib/types/http";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import type {
   PrepareStepInfo,
   SessionPrepareState,
@@ -466,7 +466,7 @@ export function PrepareProgress({ sessionId }: PrepareProgressProps) {
   // env is still "preparing" combined with a Virtuoso initial-scroll race.
   const prevSnapshotRef = useRef<PrepareSnapshot | null>(null);
   useEffect(() => {
-    if (!IS_DEBUG) return;
+    if (!isDebug()) return;
     const snapshot: PrepareSnapshot = {
       status,
       autoExpand,

--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import type { StoreApi } from "zustand";
 import { useStore } from "zustand";
-import { IS_DEBUG, registerSessionTaskResolver } from "@/lib/debug/log";
+import { isDebug, registerSessionTaskResolver } from "@/lib/debug/log";
 import type { AppState, StoreProviderProps } from "@/lib/state/store";
 import { createAppStore } from "@/lib/state/store";
 
@@ -28,7 +28,7 @@ export function StateProvider({ children, initialState }: StoreProviderProps) {
   // carries a sessionId with `task_id=<...>` so console/log filters can scope to
   // a single task (see lib/debug/log.ts). No-op in production.
   useEffect(() => {
-    if (!IS_DEBUG) return;
+    if (!isDebug()) return;
     return registerSessionTaskResolver(
       (sessionId) => store.getState().taskSessions.items[sessionId]?.task_id,
     );

--- a/apps/web/components/task/chat/message-list-virtuoso.tsx
+++ b/apps/web/components/task/chat/message-list-virtuoso.tsx
@@ -17,7 +17,7 @@ import {
   getSessionRunningState,
   getLastTurnGroupId,
 } from "./message-list-shared";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const FIRST_INDEX_BASE = 100_000;
 
@@ -62,7 +62,7 @@ function useStableFirstItemIndex(items: RenderItem[]) {
 
   const [state, setState] = useState<IndexState>(() => {
     const firstItemIndex = FIRST_INDEX_BASE - keys.length + 1;
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debugFirstIndex("init", {
         keyCount: keys.length,
         firstItemIndex,
@@ -75,7 +75,7 @@ function useStableFirstItemIndex(items: RenderItem[]) {
 
   if (keys !== state.keys) {
     const nextIndex = computeFirstItemIndex(state.keys, state.firstItemIndex, keys);
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debugFirstIndex("transition", {
         prevKeyCount: state.keys.length,
         nextKeyCount: keys.length,
@@ -204,7 +204,7 @@ function VirtuosoBody(props: VirtuosoBodyProps) {
   // anchored on for that lifecycle.
   const mountSnapshotRef = useRef<{ itemCount: number; firstItemIndex: number } | null>(null);
   useEffect(() => {
-    if (!IS_DEBUG) return;
+    if (!isDebug()) return;
     if (mountSnapshotRef.current) return;
     mountSnapshotRef.current = { itemCount, firstItemIndex };
     debugVirtuoso("mount", {
@@ -308,7 +308,7 @@ function useVirtuosoDebugSnapshot({
 }: UseVirtuosoDebugSnapshotArgs) {
   const prevSnapshotRef = useRef<VirtuosoSnapshot | null>(null);
   useEffect(() => {
-    if (!IS_DEBUG) return;
+    if (!isDebug()) return;
     const snapshot: VirtuosoSnapshot = {
       branch: isInitialLoading || items.length === 0 ? "fallback" : "virtuoso",
       itemCount: items.length,
@@ -346,14 +346,14 @@ function useVisibleScrollParent() {
   const setScrollRef = useCallback((node: HTMLDivElement | null) => {
     nodeRef.current = node;
     if (node && node.offsetHeight > 0) {
-      if (IS_DEBUG) {
+      if (isDebug()) {
         debugScrollParent("ref-callback-ready", {
           offsetHeight: node.offsetHeight,
           path: "synchronous",
         });
       }
       setScrollParent(node);
-    } else if (IS_DEBUG) {
+    } else if (isDebug()) {
       debugScrollParent("ref-callback-defer", {
         hasNode: Boolean(node),
         offsetHeight: node?.offsetHeight ?? null,
@@ -364,7 +364,7 @@ function useVisibleScrollParent() {
   useEffect(() => {
     const node = nodeRef.current;
     if (!node || scrollParent) return;
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debugScrollParent("ro-attach", {
         initialHeight: node.offsetHeight,
       });
@@ -372,7 +372,7 @@ function useVisibleScrollParent() {
     const ro = new ResizeObserver((entries) => {
       for (const entry of entries) {
         if (entry.contentRect.height > 0) {
-          if (IS_DEBUG) {
+          if (isDebug()) {
             debugScrollParent("ro-ready", {
               height: entry.contentRect.height,
             });

--- a/apps/web/components/task/dockview-layout-restore.ts
+++ b/apps/web/components/task/dockview-layout-restore.ts
@@ -10,7 +10,7 @@ import type { LayoutState } from "@/lib/state/layout-manager";
 import { setPinnedTarget } from "@/lib/state/layout-manager";
 import type { AppState } from "@/lib/state/store";
 import { getEnvLayout, getEnvMaximizeState, removeEnvMaximizeState } from "@/lib/local-storage";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debug = createDebugLogger("dockview:restore");
 
@@ -46,7 +46,7 @@ function logSanitizeOutcome(
   validPanels: Record<string, any>,
   invalidIds: Set<string>,
 ): void {
-  if (!IS_DEBUG) return;
+  if (!isDebug()) return;
   debug("sanitizeLayout", {
     mode: describeSanitizeMode(options),
     excludeSessionCount: options.excludeSessionIds?.size ?? 0,
@@ -224,7 +224,7 @@ function tryRestoreEnvLayout(
     debug("tryRestoreEnvLayout: no saved layout for env", { envId });
     return false;
   }
-  if (IS_DEBUG) {
+  if (isDebug()) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rawPanelIds = Object.keys((envLayout as any).panels ?? {});
     debug("tryRestoreEnvLayout: loaded saved layout", {
@@ -241,7 +241,7 @@ function tryRestoreEnvLayout(
     debug("tryRestoreEnvLayout: sanitize returned null", { envId });
     return false;
   }
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("tryRestoreEnvLayout: calling api.fromJSON", {
       envId,
       sanitizedPanelIds: Object.keys(sanitized.panels),
@@ -306,7 +306,7 @@ export function restoreEnvLayout(
   validComponents: Set<string>,
 ): boolean {
   const phantoms = envId ? collectPhantomSessionIdsForEnv(appStore.getState(), envId) : undefined;
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("restoreEnvLayout: entry", {
       envId,
       phantomCount: phantoms?.size ?? 0,
@@ -315,7 +315,7 @@ export function restoreEnvLayout(
     });
   }
   const result = tryRestoreLayout(api, envId, validComponents, phantoms);
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("restoreEnvLayout: result", {
       envId,
       restored: result,

--- a/apps/web/components/task/dockview-layout-setup.ts
+++ b/apps/web/components/task/dockview-layout-setup.ts
@@ -15,7 +15,7 @@ import { setEnvLayout, setGlobalSidebarWidth } from "@/lib/local-storage";
 import { panelPortalManager } from "@/lib/layout/panel-portal-manager";
 import { stopVscode } from "@/lib/api/domains/vscode-api";
 import { stopUserShell } from "@/lib/api/domains/user-shell-api";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import { snapshotColumnWidths, formatWidthsSnapshot } from "@/lib/state/dockview-widths-debug";
 import { enforcePinnedTargets, setSashDragging } from "@/lib/state/dockview-pinned-enforce";
 
@@ -133,7 +133,7 @@ export function setupSashDragCapToggle(api: DockviewReadyEvent["api"]): () => vo
         store.setPinnedWidth("sidebar", sidebarW);
       }
       if (store.rightPanelsVisible) setPinnedTarget("right", sv.getViewSize(sv.length - 1));
-      if (IS_DEBUG) {
+      if (isDebug()) {
         debugWidths(`sash-drag-end ${formatWidthsSnapshot(snapshotColumnWidths(api))}`);
       }
     });
@@ -175,7 +175,7 @@ export function setupContainerResizeSync(api: DockviewReadyEvent["api"]): () => 
     const h = parent.clientHeight;
     if (w <= 0 || h <= 0) return;
     if (w === api.width && h === api.height) return;
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debugWidths(
         `container-resize prev=${api.width}x${api.height} next=${w}x${h} ` +
           `pre=${formatWidthsSnapshot(snapshotColumnWidths(api))}`,

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -7,7 +7,7 @@ import { focusOrAddPanel } from "@/lib/state/dockview-layout-builders";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { wasPRPanelOffered, markPRPanelOffered } from "@/lib/local-storage";
 import { sessionId as toSessionId } from "@/lib/types/ids";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debug = createDebugLogger("dockview:session-tabs");
 
@@ -21,7 +21,7 @@ export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: St
   return api.onDidActivePanelChange((panel) => {
     if (!panel) return;
     const isRestoring = useDockviewStore.getState().isRestoringLayout;
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("setupSessionTabSync: onDidActivePanelChange", {
         panelId: panel.id,
         isRestoring,
@@ -36,7 +36,7 @@ export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: St
     if (sid && sid !== appStore.getState().tasks.activeSessionId) {
       const taskId = appStore.getState().tasks.activeTaskId;
       if (taskId) {
-        if (IS_DEBUG) {
+        if (isDebug()) {
           debug("setupSessionTabSync: setActiveSession", { taskId, newSessionId: sid });
         }
         appStore.getState().setActiveSession(taskId, sid);
@@ -60,7 +60,7 @@ export function setupChatPanelSafetyNet(
     if (useDockviewStore.getState().isRestoringLayout) return;
     const isChatPanel = panel.id === "chat" || panel.id.startsWith("session:");
     if (!isChatPanel) return;
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("setupChatPanelSafetyNet: chat panel removed", {
         removedPanelId: panel.id,
         livePanelIds: api.panels.map((p) => p.id),
@@ -82,7 +82,7 @@ export function setupChatPanelSafetyNet(
         // If all sessions were deleted, leave the layout empty — the user
         // can create a new session via the "+" menu.
         if (!activeSessionId) {
-          if (IS_DEBUG) debug("setupChatPanelSafetyNet: skip recreate (no active session)");
+          if (isDebug()) debug("setupChatPanelSafetyNet: skip recreate (no active session)");
           return;
         }
         // Don't recreate a panel for a session that no longer exists in the
@@ -92,7 +92,7 @@ export function setupChatPanelSafetyNet(
           ? (appStore.getState().taskSessionsByTask.itemsByTaskId[activeTaskId] ?? [])
           : [];
         if (!knownSessions.some((s) => s.id === activeSessionId)) {
-          if (IS_DEBUG) {
+          if (isDebug()) {
             debug("setupChatPanelSafetyNet: skip recreate (session not in store)", {
               activeSessionId,
               activeTaskId,
@@ -101,7 +101,7 @@ export function setupChatPanelSafetyNet(
           }
           return;
         }
-        if (IS_DEBUG) {
+        if (isDebug()) {
           debug("setupChatPanelSafetyNet: recreating session panel", {
             activeSessionId,
             activeTaskId,
@@ -325,7 +325,7 @@ export function reconcileRemovedSessionPanels(
     }
     createdSet.delete(sid);
   }
-  if (IS_DEBUG) {
+  if (isDebug()) {
     const sessionPanels = api.panels.filter((p) => p.id.startsWith("session:"));
     debug("reconcileRemovedSessionPanels", {
       keepSessionId,
@@ -425,7 +425,7 @@ function activateSessionPanel(
     currentTaskId: tid,
     currentSessionId: effectiveSessionId,
   });
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("useAutoSessionTab: activation decision", {
       effectiveSessionId,
       shouldActivate,
@@ -456,7 +456,7 @@ function ensureSiblingPanels(
   const created: string[] = [];
   for (const sid of currentSessionIds) {
     if (sid === effectiveSessionId) continue;
-    if (IS_DEBUG && !api.getPanel(`session:${sid}`)) created.push(sid);
+    if (isDebug() && !api.getPanel(`session:${sid}`)) created.push(sid);
     ensureSessionPanel(api, sid, siblingAnchor, true, createdSet);
   }
   return created;
@@ -485,7 +485,7 @@ function shouldSkipPanelEnsure(
   createdSet: Set<string>,
 ): boolean {
   if (!currentSessionIds.includes(toSessionId(effectiveSessionId))) {
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("useAutoSessionTab: skip (session not in store yet)", {
         effectiveSessionId,
         currentSessionIds,
@@ -494,7 +494,7 @@ function shouldSkipPanelEnsure(
     return true;
   }
   if (!prepareLayoutForSessionPanels(api)) {
-    if (IS_DEBUG)
+    if (isDebug())
       debug("useAutoSessionTab: skip body (maximized - panels suppressed)", { effectiveSessionId });
     createdSet.add(effectiveSessionId);
     return true;
@@ -516,7 +516,7 @@ function runAutoSessionTabEffect(
 
   const { tid, currentSessionIds } = resolveCurrentSessionIds(appStore);
 
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("useAutoSessionTab: effect entry", {
       effectiveSessionId,
       activeTaskId: tid,
@@ -536,7 +536,7 @@ function runAutoSessionTabEffect(
   );
 
   if (!effectiveSessionId) {
-    if (IS_DEBUG) debug("useAutoSessionTab: no effectiveSessionId, returning");
+    if (isDebug()) debug("useAutoSessionTab: no effectiveSessionId, returning");
     return;
   }
 
@@ -554,7 +554,7 @@ function runAutoSessionTabEffect(
   const initialPosition = resolveInitialPosition(api);
   const sessionPanelExistedBefore = !!api.getPanel(`session:${effectiveSessionId}`);
 
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("useAutoSessionTab: ensuring active session panel", {
       effectiveSessionId,
       sessionPanelExistedBefore,
@@ -590,7 +590,7 @@ function runAutoSessionTabEffect(
     refs.sessionTabCreatedRef.current,
   );
 
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("useAutoSessionTab: effect exit", {
       effectiveSessionId,
       siblingsCreated,

--- a/apps/web/components/task/file-browser-hooks.ts
+++ b/apps/web/components/task/file-browser-hooks.ts
@@ -9,7 +9,7 @@ import { getFilesPanelExpandedPaths, setFilesPanelExpandedPaths } from "@/lib/lo
 import { useTree, type VisibleRow } from "@/hooks/use-tree";
 import { mergeTreeNodes } from "./file-browser-parts";
 import { compareTreeNodes, sortRootChildren } from "./file-tree-utils";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debugLoad = createDebugLogger("file-browser:load");
 const debugChanges = createDebugLogger("file-browser:changes");
@@ -141,7 +141,7 @@ export function applyFileChanges(ctx: {
     if (p === "" || expandedPaths.has(p)) foldersToRefresh.add(p);
   }
   if (foldersToRefresh.size === 0) {
-    if (IS_DEBUG)
+    if (isDebug())
       debugChanges("no-folders-to-refresh", {
         sessionId,
         candidates: changes.length,
@@ -149,7 +149,7 @@ export function applyFileChanges(ctx: {
       });
     return;
   }
-  if (IS_DEBUG)
+  if (isDebug())
     debugChanges("refresh", {
       sessionId,
       folders: Array.from(foldersToRefresh).slice(0, 5),
@@ -245,9 +245,9 @@ type TreeLoaderContext = {
   setLoadError: React.Dispatch<React.SetStateAction<string | null>>;
 };
 
-// Thin wrapper so loadTree callers don't each pay a complexity point for IS_DEBUG.
+// Thin wrapper so loadTree callers don't each pay a complexity point for isDebug().
 function logLoad(event: string, data: Record<string, unknown>) {
-  if (IS_DEBUG) debugLoad(event, data);
+  if (isDebug()) debugLoad(event, data);
 }
 
 function useTreeLoader(ctx: TreeLoaderContext) {
@@ -442,10 +442,10 @@ function useFileChangeSubscription({
     return client.on("session.workspace.file.changes", (msg) => {
       const changes = msg.payload?.changes;
       if (!changes || changes.length === 0) {
-        if (IS_DEBUG) debugChanges("event-empty", { sessionId: sessionIdRef.current });
+        if (isDebug()) debugChanges("event-empty", { sessionId: sessionIdRef.current });
         return;
       }
-      if (IS_DEBUG)
+      if (isDebug())
         debugChanges("event", {
           sessionId: sessionIdRef.current,
           count: changes.length,

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -16,7 +16,7 @@ import { IssueTaskIcon } from "@/components/github/issue-task-icon";
 import { useAppStore } from "@/components/state-provider";
 import { cn } from "@/lib/utils";
 import { computeRowIndent, resolveRowDepth } from "@/lib/sidebar/row-indent";
-import { DEBUG_UI } from "@/lib/config";
+import { isDebugUI } from "@/lib/config";
 import { useTaskColor } from "@/hooks/use-task-color";
 import { TASK_COLOR_BAR_CLASS, type TaskColor } from "@/lib/task-colors";
 import type { TaskState, TaskSessionState } from "@/lib/types/http";
@@ -171,7 +171,9 @@ function TaskItemStatsRow({
   primarySessionId?: string | null;
 }) {
   const pollMode = useAppStore((s) =>
-    DEBUG_UI && primarySessionId ? (s.sessionPollMode.bySessionId[primarySessionId] ?? null) : null,
+    isDebugUI() && primarySessionId
+      ? (s.sessionPollMode.bySessionId[primarySessionId] ?? null)
+      : null,
   );
 
   if (!updatedAt && !prInfo && !pollMode) return null;

--- a/apps/web/components/task/task-page-content.tsx
+++ b/apps/web/components/task/task-page-content.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/lib/types/http";
 import type { Terminal } from "@/hooks/domains/session/use-terminals";
 import type { KanbanState } from "@/lib/state/slices";
-import { DEBUG_UI } from "@/lib/config";
+import { isDebugUI } from "@/lib/config";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { useSessionAgent } from "@/hooks/domains/session/use-session-agent";
@@ -382,7 +382,7 @@ function TaskPageInner({
   const taskProps = resolveTaskProps(task, repository);
   const remote = resolveRemoteExecutor(resumption.sessionStatus as RemoteExecutorStatus | null);
   const debugEntries = maybeBuildDebugEntries({
-    isVisible: DEBUG_UI && showDebugOverlay,
+    isVisible: isDebugUI() && showDebugOverlay,
     connectionStatus,
     task,
     effectiveSessionId,

--- a/apps/web/components/task/task-select-helpers.ts
+++ b/apps/web/components/task/task-select-helpers.ts
@@ -16,7 +16,7 @@ import { INTENT_PR_REVIEW } from "@/lib/state/layout-manager";
 import { replaceTaskUrl } from "@/lib/links";
 import { launchSession } from "@/lib/services/session-launch-service";
 import { buildPrepareRequest } from "@/lib/services/session-launch-helpers";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debug = createDebugLogger("dockview:task-select");
 
@@ -68,7 +68,7 @@ export function buildSwitchToSession(
     const state = store.getState();
     const oldEnvId = oldSessionId ? (state.environmentIdBySessionId[oldSessionId] ?? null) : null;
     const newEnvId = state.environmentIdBySessionId[sessionId] ?? null;
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("switchToSession: entry", {
         taskId,
         sessionId,
@@ -90,7 +90,7 @@ export function buildSwitchToSession(
     // layout to default so the new task starts from a clean slate; when the
     // new env id arrives, useEnvSwitchCleanup will adopt it without rebuild.
     if (oldEnvId || oldSessionId !== sessionId) {
-      if (IS_DEBUG) {
+      if (isDebug()) {
         debug("switchToSession: releasing outgoing env (no newEnvId yet)", { oldEnvId });
       }
       releaseLayoutToDefault(oldEnvId);
@@ -153,7 +153,7 @@ export function selectTaskWithLayout(params: {
   const { taskId, task, store, switchToSession, loadTaskSessionsForTask } = params;
   const state = store.getState();
   const oldSessionId = state.tasks.activeSessionId;
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("selectTaskWithLayout: entry", {
       taskId,
       primarySessionId: task?.primarySessionId ?? null,

--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -41,7 +41,7 @@ import {
   type TopbarOverflowItem,
 } from "@/components/task/topbar-action-overflow";
 import { IntegrationsMenu } from "@/components/integrations/integrations-menu";
-import { DEBUG_UI } from "@/lib/config";
+import { isDebugUI } from "@/lib/config";
 
 type TaskTopBarProps = {
   taskId?: string | null;
@@ -234,7 +234,7 @@ function MoreToolsMenu({
   showDebugOverlay?: boolean;
   onToggleDebugOverlay?: () => void;
 }) {
-  const showDebugItem = DEBUG_UI && onToggleDebugOverlay;
+  const showDebugItem = isDebugUI() && onToggleDebugOverlay;
   const debugLabel = showDebugOverlay ? "Hide Debug Info" : "Show Debug Info";
 
   return (
@@ -341,7 +341,7 @@ function TopbarToolsGroup({
   onToggleDebugOverlay?: () => void;
   isArchived?: boolean;
 }) {
-  const showDebugMenu = DEBUG_UI && onToggleDebugOverlay;
+  const showDebugMenu = isDebugUI() && onToggleDebugOverlay;
 
   return (
     <TopbarCluster label="Task tools" className="[&_button]:h-8 [&_button]:text-xs">

--- a/apps/web/hooks/domains/session/use-session-git.ts
+++ b/apps/web/hooks/domains/session/use-session-git.ts
@@ -5,7 +5,7 @@ import { useSessionGitStatus, useSessionGitStatusByRepo } from "./use-session-gi
 import { useSessionCommits } from "./use-session-commits";
 import { useCumulativeDiff } from "./use-cumulative-diff";
 import { useGitOperations } from "@/hooks/use-git-operations";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import type {
   FileInfo,
   SessionCommit,
@@ -600,7 +600,7 @@ function useFileDerivations(
     [statusByRepo, gitStatus],
   );
   useEffect(() => {
-    if (!IS_DEBUG) return;
+    if (!isDebug()) return;
     debugDeriv("aggregate", {
       path: statusByRepo.length > 0 ? "multi-repo" : "single-repo-fallback",
       statusByRepoEntries: statusByRepo.map((s) => ({

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -3,7 +3,7 @@ import { getWebSocketClient } from "@/lib/ws/connection";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import type { TaskSessionState, Message } from "@/lib/types/http";
 import { listTaskSessionMessages } from "@/lib/api";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const INITIAL_FETCH_LIMIT = 100;
 const BACKFILL_PAGE_LIMIT = 100;
@@ -126,7 +126,7 @@ async function fetchAndStoreMessages(
   debug("message.list request", requestParams);
   const response = await client.request<MessageListResponse>("message.list", requestParams, 10000);
   const fetched = [...(response.messages ?? [])].reverse();
-  if (IS_DEBUG) {
+  if (isDebug()) {
     const summary = summarizeMessages(fetched);
     debug("message.list response", {
       sessionId,

--- a/apps/web/hooks/use-processed-messages.ts
+++ b/apps/web/hooks/use-processed-messages.ts
@@ -11,7 +11,7 @@ import {
   findPendingClarification,
   findPendingClarificationGroup,
 } from "@/lib/utils/pending-clarification";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debug = createDebugLogger("messages:process");
 
@@ -33,7 +33,7 @@ function useDebugProcessedPipeline(args: {
 }) {
   const { sessionId, messages, visibleMessages, footerActionCount, groupedItems } = args;
   useEffect(() => {
-    if (!IS_DEBUG) return;
+    if (!isDebug()) return;
     debug("pipeline", {
       sessionId,
       input: { count: messages.length, byType: countByType(messages) },

--- a/apps/web/lib/config.test.ts
+++ b/apps/web/lib/config.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("isDebugUI", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("is true when window.__KANDEV_DEBUG is set at runtime", async () => {
+    vi.stubEnv("NEXT_PUBLIC_KANDEV_DEBUG", "");
+    vi.stubGlobal("window", { __KANDEV_DEBUG: true });
+    const { isDebugUI } = await import("./config");
+    expect(isDebugUI()).toBe(true);
+  });
+
+  it("is false in production with no flags", async () => {
+    vi.stubEnv("NEXT_PUBLIC_KANDEV_DEBUG", "");
+    vi.stubGlobal("window", {});
+    const { isDebugUI } = await import("./config");
+    expect(isDebugUI()).toBe(false);
+  });
+
+  it("is true when NEXT_PUBLIC_KANDEV_DEBUG=true", async () => {
+    vi.stubEnv("NEXT_PUBLIC_KANDEV_DEBUG", "true");
+    vi.stubGlobal("window", {});
+    const { isDebugUI } = await import("./config");
+    expect(isDebugUI()).toBe(true);
+  });
+});

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -5,9 +5,21 @@ export type AppConfig = {
 // Server-side default (used during SSR - always localhost since SSR runs on same machine)
 const DEFAULT_API_BASE_URL = "http://localhost:38429";
 
-export const DEBUG_UI =
-  process.env.NEXT_PUBLIC_KANDEV_DEBUG === "true" ||
-  (typeof window !== "undefined" && window.__KANDEV_DEBUG === true);
+let debugUiCached: boolean | undefined;
+
+/** Whether debug-only UI (poll badges, debug overlay) should render. */
+export function isDebugUI(): boolean {
+  if (debugUiCached !== undefined) return debugUiCached;
+  debugUiCached =
+    process.env.NEXT_PUBLIC_KANDEV_DEBUG === "true" ||
+    (typeof window !== "undefined" && window.__KANDEV_DEBUG === true);
+  return debugUiCached;
+}
+
+/** @internal testing helper */
+export function resetDebugUIForTests(): void {
+  debugUiCached = undefined;
+}
 
 export function getBackendConfig(): AppConfig {
   // Server-side: use env vars or localhost defaults (SSR runs on same machine as backend)

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -16,11 +16,6 @@ export function isDebugUI(): boolean {
   return debugUiCached;
 }
 
-/** @internal testing helper */
-export function resetDebugUIForTests(): void {
-  debugUiCached = undefined;
-}
-
 export function getBackendConfig(): AppConfig {
   // Server-side: use env vars or localhost defaults (SSR runs on same machine as backend)
   if (typeof window === "undefined") {

--- a/apps/web/lib/debug/log.test.ts
+++ b/apps/web/lib/debug/log.test.ts
@@ -162,9 +162,9 @@ describe("registerSessionTaskResolver", () => {
   });
 });
 
-describe("IS_DEBUG", () => {
-  // Module re-imports are required because IS_DEBUG is a module-level constant
-  // evaluated at import time. resetModules forces re-evaluation with the
+describe("isDebug", () => {
+  // Module re-imports are required because isDebug memoizes its result.
+  // resetModules + resetDebugForTests forces re-evaluation with the
   // current env / globals each time.
 
   beforeEach(() => {
@@ -181,23 +181,23 @@ describe("IS_DEBUG", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_KANDEV_DEBUG", "");
     vi.stubGlobal("window", { __KANDEV_DEBUG: true });
-    const { IS_DEBUG } = await import("./log");
-    expect(IS_DEBUG).toBe(true);
+    const { isDebug } = await import("./log");
+    expect(isDebug()).toBe(true);
   });
 
   it("is false in a production build with no flag set", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_KANDEV_DEBUG", "");
     vi.stubGlobal("window", {});
-    const { IS_DEBUG } = await import("./log");
-    expect(IS_DEBUG).toBe(false);
+    const { isDebug } = await import("./log");
+    expect(isDebug()).toBe(false);
   });
 
   it("is true when NEXT_PUBLIC_KANDEV_DEBUG=true at build time", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_KANDEV_DEBUG", "true");
     vi.stubGlobal("window", {});
-    const { IS_DEBUG } = await import("./log");
-    expect(IS_DEBUG).toBe(true);
+    const { isDebug } = await import("./log");
+    expect(isDebug()).toBe(true);
   });
 });

--- a/apps/web/lib/debug/log.test.ts
+++ b/apps/web/lib/debug/log.test.ts
@@ -164,8 +164,7 @@ describe("registerSessionTaskResolver", () => {
 
 describe("isDebug", () => {
   // Module re-imports are required because isDebug memoizes its result.
-  // resetModules + resetDebugForTests forces re-evaluation with the
-  // current env / globals each time.
+  // resetModules forces a fresh module (and cache) on each test.
 
   beforeEach(() => {
     vi.resetModules();

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -176,11 +176,6 @@ export function isDebug(): boolean {
   return debugCached;
 }
 
-/** @internal testing helper */
-export function resetDebugForTests(): void {
-  debugCached = undefined;
-}
-
 const BARE_VALUE_RE = /^[A-Za-z0-9_\-:./@+]+$/;
 
 function formatValue(value: unknown): string {

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -16,7 +16,7 @@
  * before the call — so callers that compute expensive values (O(n) maps,
  * `.reduce()`, spread of large objects) must guard with the exported constant:
  *
- *   if (IS_DEBUG) { debug(...); }
+ *   if (isDebug()) { debug(...); }
  *
  * In a production build with no flag set, both `process.env` checks fold to
  * `false` and the `window` check short-circuits at runtime, so the guarded
@@ -164,12 +164,22 @@
 
 export type DebugLogger = (...args: unknown[]) => void;
 
-export const IS_DEBUG =
-  process.env.NODE_ENV !== "production" ||
-  process.env.NEXT_PUBLIC_KANDEV_DEBUG === "true" ||
-  (typeof window !== "undefined" && window.__KANDEV_DEBUG === true);
+let debugCached: boolean | undefined;
 
-const NOOP: DebugLogger = () => {};
+/** Whether namespaced debug logging is active. Evaluated lazily so production start-debug works. */
+export function isDebug(): boolean {
+  if (debugCached !== undefined) return debugCached;
+  debugCached =
+    process.env.NODE_ENV !== "production" ||
+    process.env.NEXT_PUBLIC_KANDEV_DEBUG === "true" ||
+    (typeof window !== "undefined" && window.__KANDEV_DEBUG === true);
+  return debugCached;
+}
+
+/** @internal testing helper */
+export function resetDebugForTests(): void {
+  debugCached = undefined;
+}
 
 const BARE_VALUE_RE = /^[A-Za-z0-9_\-:./@+]+$/;
 
@@ -240,8 +250,8 @@ let sessionTaskResolverToken = 0;
  * clears it when this registration is still the active one: during HMR or a
  * provider swap the new provider mounts (and registers) before the old one's
  * cleanup runs, and an unconditional null-clear would silently kill annotation
- * until a full reload. Calls are no-ops in production because
- * `createDebugLogger` returns `NOOP`.
+ * until a full reload. Calls are no-ops in production because `isDebug()` is
+ * false and `createDebugLogger` skips output.
  */
 export function registerSessionTaskResolver(resolver: SessionTaskResolver | null): () => void {
   const token = ++sessionTaskResolverToken;
@@ -286,9 +296,9 @@ function resolveTaskAnnotation(args: unknown[]): string {
 }
 
 export function createDebugLogger(namespace: string): DebugLogger {
-  if (!IS_DEBUG) return NOOP;
   const prefix = `[${namespace}]`;
   return (...args: unknown[]) => {
+    if (!isDebug()) return;
     console.debug(`${prefix} ${flattenArgs(args)}${resolveTaskAnnotation(args)}`);
   };
 }

--- a/apps/web/lib/state/dockview-env-switch.ts
+++ b/apps/web/lib/state/dockview-env-switch.ts
@@ -21,7 +21,7 @@ import {
 } from "./layout-manager";
 import type { LayoutState, LayoutGroupIds } from "./layout-manager";
 import { ENV_SCOPED_DOCKVIEW_COMPONENTS } from "./dockview-env-scoped-components";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import { snapshotColumnWidths, formatWidthsSnapshot } from "./dockview-widths-debug";
 
 const debug = createDebugLogger("dockview:env-switch");
@@ -221,7 +221,7 @@ function replaceStaleSessionPanels(api: DockviewApi, keepSessionId: string | nul
     }
   }
 
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("replaceStaleSessionPanels", {
       keepSessionId,
       livePanelIds: api.panels.map((p) => p.id),
@@ -275,7 +275,7 @@ function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
   }
 
   if (!structuresMatch) {
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("tryFastEnvSwitch: structures do not match, falling back to slow path", {
         newEnvId,
         hasSaved: !!saved,
@@ -290,7 +290,7 @@ function tryFastEnvSwitch(params: EnvSwitchParams): LayoutGroupIds | null {
     });
     return null;
   }
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("tryFastEnvSwitch: taking fast path", {
       newEnvId,
       activeSessionId,
@@ -389,7 +389,7 @@ function applyPinnedColumnSizes(
 
   const savedSizes = saved ? extractSavedColumnSizes(saved) : null;
   const liveLayout = fromDockviewApi(api);
-  if (IS_DEBUG) {
+  if (isDebug()) {
     const savedStr = savedSizes
       ? savedSizes.map((n) => (Number.isFinite(n) ? String(Math.round(n)) : "-")).join(",")
       : "-";
@@ -413,7 +413,7 @@ function applyPinnedColumnSizes(
       // Update the pinned-target so enforcement keeps the new env's width
       // through subsequent rebalances.
       setPinnedTarget(col.id, target);
-      if (IS_DEBUG) {
+      if (isDebug()) {
         debugWidths(`env-switch-resize-col col=${col.id} idx=${i} target=${Math.round(target)}`);
       }
     } catch {
@@ -462,7 +462,7 @@ function addIncomingSessionPanel(
  */
 export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
   const { api, oldEnvId, newEnvId, activeSessionId, safeWidth, safeHeight, buildDefault } = params;
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("performEnvSwitch: entry", {
       oldEnvId,
       newEnvId,
@@ -473,7 +473,7 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
 
   const fastResult = tryFastEnvSwitch(params);
   if (fastResult) {
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("performEnvSwitch: completed via fast path", {
         newEnvId,
         livePanelIdsAfter: api.panels.map((p) => p.id),
@@ -485,7 +485,7 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
   const saved = getHealthyEnvLayout(newEnvId);
   if (saved) {
     try {
-      if (IS_DEBUG) {
+      if (isDebug()) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const savedPanelIds = Object.keys((saved as any).panels ?? {});
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -506,7 +506,7 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
       // useAutoSessionTab will still no-op if the panel was just added here.
       replaceStaleSessionPanels(api, activeSessionId);
       api.layout(safeWidth, safeHeight);
-      if (IS_DEBUG) {
+      if (isDebug()) {
         debug("performEnvSwitch: completed via slow path (fromJSON)", {
           newEnvId,
           livePanelIdsAfter: api.panels.map((p) => p.id),
@@ -522,7 +522,7 @@ export function performEnvSwitch(params: EnvSwitchParams): LayoutGroupIds {
   debug("performEnvSwitch: building default layout", { newEnvId, hasSaved: !!saved });
   buildDefault(api);
   api.layout(safeWidth, safeHeight);
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debug("performEnvSwitch: completed via default build", {
       newEnvId,
       livePanelIdsAfter: api.panels.map((p) => p.id),

--- a/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
+++ b/apps/web/lib/state/dockview-layout-builders-fixups.test.ts
@@ -12,7 +12,7 @@ const RIGHT_CAP = 1029;
 
 vi.mock("@/lib/debug/log", () => ({
   createDebugLogger: () => () => {},
-  IS_DEBUG: false,
+  isDebug: () => false,
 }));
 
 vi.mock("@/lib/local-storage", () => ({

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -15,7 +15,7 @@ import {
 } from "./layout-manager";
 import type { LayoutGroupIds } from "./layout-manager";
 import { getGlobalSidebarWidth } from "@/lib/local-storage";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 // Re-export for consumers that import from this module
 export { getRootSplitview } from "./layout-manager";
@@ -32,7 +32,7 @@ function layoutWidth(api: DockviewApi): number | undefined {
 /** Best-effort caller chain for the fixups-capture debug log: pull the first
  *  few stack frames above `applyLayoutFixups` so we can see WHICH layout path
  *  (env-switch / restore / custom-layout / maximize) recorded a given target.
- *  Debug-only — never called when IS_DEBUG is false. */
+ *  Debug-only — never called when isDebug() is false. */
 const CALLER_CHAIN_SKIP = new Set(["captureCallerChain", "applyLayoutFixups", "logFixupsCapture"]);
 
 function captureCallerChain(): string {
@@ -200,7 +200,7 @@ function captureRightTarget(api: DockviewApi, sv: any, savedRightWidth?: number)
  *  to keep that function under the complexity limit; no-op in prod. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function logFixupsCapture(api: DockviewApi, sv: any): void {
-  if (!IS_DEBUG) return;
+  if (!isDebug()) return;
   // Decisive fields: `sidebarOverCap=true` means the recorded target exceeds
   // the cap that enforcement clamps the column to — i.e. an unreachable target
   // that makes `enforcePinnedTargets` spin forever. `cols` shows whether the

--- a/apps/web/lib/state/dockview-pinned-enforce.ts
+++ b/apps/web/lib/state/dockview-pinned-enforce.ts
@@ -20,7 +20,7 @@
  */
 import type { DockviewApi } from "dockview-react";
 import { getRootSplitview, getPinnedTarget, computeSidebarMaxPx } from "./layout-manager";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debugWidths = createDebugLogger("dockview:widths");
 
@@ -47,7 +47,7 @@ function restoreColumnToTarget(sv: any, idx: number, target: number | undefined)
   if (target === undefined) return;
   const cur = sv.getViewSize(idx);
   if (Math.abs(cur - target) <= 1) return;
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debugWidths(`enforce-restore idx=${idx} cur=${Math.round(cur)} target=${Math.round(target)}`);
   }
   try {

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -46,7 +46,7 @@ import {
 import { preserveChatScrollDuringLayout } from "./dockview-scroll-preserve";
 import { measureDockviewContainer } from "./dockview-measure";
 import { panelPortalManager } from "@/lib/layout/panel-portal-manager";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import { snapshotColumnWidths, formatWidthsSnapshot } from "./dockview-widths-debug";
 
 const debugSwitch = createDebugLogger("dockview:store-switch");
@@ -261,7 +261,7 @@ function syncPinnedWidthsFromApi(api: DockviewApi, set: StoreSet): void {
       rightPanelsVisible,
     });
     if (updates.size > 0) {
-      if (IS_DEBUG) {
+      if (isDebug()) {
         const pairs = Array.from(updates.entries())
           .map(([k, v]) => `${k}=${Math.round(v)}`)
           .join(",");
@@ -508,7 +508,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
         resetWidths,
       );
       const ids = applyLayout(api, state, cleanedWidths, safeWidth, safeHeight);
-      if (IS_DEBUG) {
+      if (isDebug()) {
         const applied =
           [...cleanedWidths].map(([k, v]) => `${k}:${Math.round(v)}`).join(",") || "-";
         debugWidths(
@@ -524,7 +524,7 @@ function buildPresetActions(set: StoreSet, get: StoreGet) {
       });
       requestAnimationFrame(() => {
         api.layout(safeWidth, safeHeight);
-        if (IS_DEBUG) {
+        if (isDebug()) {
           debugWidths(
             `preset-post-layout preset=${preset} ${formatWidthsSnapshot(snapshotColumnWidths(api))}`,
           );
@@ -618,7 +618,7 @@ function saveOutgoingEnv(
     debugSave("saveOutgoingEnv: skip (no oldEnvId)");
     return;
   }
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debugSave("saveOutgoingEnv: entry", {
       oldEnvId,
       livePanelIds: api.panels.map((p) => p.id),
@@ -672,7 +672,7 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
       debugSwitch("envSwitch: skip (no api)", { oldEnvId, newEnvId, activeSessionId });
       return;
     }
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debugSwitch("envSwitch: entry", {
         oldEnvId,
         newEnvId,
@@ -724,7 +724,7 @@ function buildEnvSwitchAction(set: StoreSet, get: StoreGet) {
       set(ids);
       enforceFromStore(api, get);
       set({ isRestoringLayout: false });
-      if (IS_DEBUG) {
+      if (isDebug()) {
         debugWidths(
           `env-switch-done old=${effectiveOld ?? "-"} new=${newEnvId} ` +
             `${formatWidthsSnapshot(snapshotColumnWidths(api))}`,
@@ -820,7 +820,7 @@ function performBuildDefault(
   // Capture dimensions before layout change — api.width can become stale
   // after fromJSON inside applyLayout
   const { width: safeWidth, height: safeHeight } = measureDockviewContainer(api);
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debugWidths(
       `build-default-entry intent=${intentName ?? "-"} ` +
         `measured=${safeWidth}x${safeHeight} ` +
@@ -856,7 +856,7 @@ function performBuildDefault(
     api.layout(safeWidth, safeHeight);
     enforceFromStore(api, get);
     syncPinnedWidthsFromApi(api, set);
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debugWidths(`build-default-done ${formatWidthsSnapshot(snapshotColumnWidths(api))}`);
     }
     set({ isRestoringLayout: false });

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -6,7 +6,7 @@ import type {
   GitStatusEntry,
   FileInfo,
 } from "./types";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debugGit = createDebugLogger("git-status:store");
 
@@ -401,7 +401,7 @@ export const createSessionRuntimeSlice: StateCreator<
       const repoMap = (draft.gitStatus.byEnvironmentRepo[envKey] ??= {});
       const existingRepo = repoMap[repoName];
       const repoChanged = !existingRepo || hasGitStatusChanged(existingRepo, gitStatus);
-      if (IS_DEBUG) {
+      if (isDebug()) {
         debugGit("setGitStatus", {
           sessionId,
           envKey,

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -3,7 +3,7 @@ import type { TaskSession } from "@/lib/types/http";
 import type { SessionSlice, SessionSliceState } from "./types";
 import { migrateEnvKeyedData } from "@/lib/state/slices/session-runtime/session-runtime-slice";
 import { prepareResultToSessionState } from "@/lib/state/slices/session-runtime/prepare-result";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debugEnv = createDebugLogger("session:env-mapping");
 
@@ -48,7 +48,7 @@ function mergeMessageFields(target: Record<string, unknown>, source: Record<stri
 function syncEnvironmentMapping(draft: any, sessionId: string, environmentId: string | undefined) {
   if (!environmentId) return;
   const previous = draft.environmentIdBySessionId[sessionId];
-  if (IS_DEBUG) {
+  if (isDebug()) {
     debugEnv("syncEnvironmentMapping", {
       sessionId,
       environmentId,

--- a/apps/web/lib/ws/client.ts
+++ b/apps/web/lib/ws/client.ts
@@ -1,7 +1,7 @@
 import type { BackendMessageMap, BackendMessageType } from "@/lib/types/backend";
 import type { ConnectionStatus } from "@/lib/types/connection";
 import { generateUUID } from "@/lib/utils";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debugDispatch = createDebugLogger("ws:dispatch");
 
@@ -128,7 +128,7 @@ export class WebSocketClient {
 
   send(payload: unknown) {
     const data = JSON.stringify(payload);
-    if (IS_DEBUG) {
+    if (isDebug()) {
       const p = payload as { action?: string; id?: string; type?: string } | null;
       const action = p?.action ?? "?";
       if (!DISPATCH_LOG_DENYLIST.has(action)) {
@@ -380,7 +380,7 @@ export class WebSocketClient {
   }
 
   private debugNotification(action: BackendMessageType, payload: unknown, handlerCount: number) {
-    if (!IS_DEBUG || DISPATCH_LOG_DENYLIST.has(action)) return;
+    if (!isDebug() || DISPATCH_LOG_DENYLIST.has(action)) return;
     const payloadSessionId = (payload as { session_id?: string } | undefined)?.session_id;
     debugDispatch("notification", {
       action,
@@ -393,12 +393,12 @@ export class WebSocketClient {
     const msgWithId = message as { id?: string; type: string };
 
     if (msgWithId.type === "response" && msgWithId.id) {
-      if (IS_DEBUG) debugDispatch("response", { id: msgWithId.id });
+      if (isDebug()) debugDispatch("response", { id: msgWithId.id });
       this.resolvePendingRequest(msgWithId.id, message.payload);
       return;
     }
     if (msgWithId.type === "error" && msgWithId.id) {
-      if (IS_DEBUG) debugDispatch("error-response", { id: msgWithId.id });
+      if (isDebug()) debugDispatch("error-response", { id: msgWithId.id });
       this.rejectPendingRequest(msgWithId.id, message.payload);
       return;
     }

--- a/apps/web/lib/ws/handlers/git-status.ts
+++ b/apps/web/lib/ws/handlers/git-status.ts
@@ -11,7 +11,7 @@ import type {
   GitBranchSwitchedEvent,
 } from "@/lib/types/git-events";
 import { invalidateCumulativeDiffCache } from "@/hooks/domains/session/use-cumulative-diff";
-import { createDebugLogger, IS_DEBUG } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 const debug = createDebugLogger("git-status:ws");
 
@@ -63,7 +63,7 @@ const gitEventHandlers: GitEventHandlers = {
   status_update: (store, event) => {
     const gitStatus = buildGitStatusEntry(event);
     const changed = statusUpdateChangesGitState(store, event.session_id, gitStatus);
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("status_update", {
         sessionId: event.session_id,
         repositoryName: event.status.repository_name ?? null,
@@ -87,7 +87,7 @@ const gitEventHandlers: GitEventHandlers = {
   },
 
   commit_created: (store, event) => {
-    if (IS_DEBUG) {
+    if (isDebug()) {
       debug("commit_created", {
         sessionId: event.session_id,
         sha: event.commit.commit_sha,
@@ -116,7 +116,7 @@ const gitEventHandlers: GitEventHandlers = {
   },
 
   commits_reset: (store, event) => {
-    if (IS_DEBUG) debug("commits_reset", { sessionId: event.session_id });
+    if (isDebug()) debug("commits_reset", { sessionId: event.session_id });
     // Trigger a refetch without clearing the visible commits — the Changes
     // panel would otherwise flicker through its empty state ("Your changed
     // files will appear here") while the refetch is in flight, because
@@ -128,7 +128,7 @@ const gitEventHandlers: GitEventHandlers = {
   },
 
   branch_switched: (store, event) => {
-    if (IS_DEBUG) debug("branch_switched", { sessionId: event.session_id });
+    if (isDebug()) debug("branch_switched", { sessionId: event.session_id });
     // Stale-while-revalidate (see commits_reset above): refetch with the new
     // base commit but keep the old list visible until the new one arrives.
     store.getState().bumpSessionCommitsRefetch(event.session_id);


### PR DESCRIPTION
Production `make start-debug` stopped surfacing poll badges, the debug overlay, and console logs because the debug flag was evaluated at module import time — before the inline script set `window.__KANDEV_DEBUG`. This restores that path with lazy runtime checks and earlier script injection.

## Important Changes

- Replace `DEBUG_UI` / `IS_DEBUG` constants with memoized `isDebugUI()` / `isDebug()` evaluated at call time
- Move runtime config injection to `<head>` so it runs before Next.js async chunks
- Add server-only `KANDEV_DEBUG` env (set by CLI) alongside `NEXT_PUBLIC_KANDEV_DEBUG`
- Wire `kandev run --debug` through `buildWebEnv` so installed releases get frontend debug too

## Validation

- `pnpm --filter @kandev/web test -- lib/config.test.ts lib/debug/log.test.ts`
- `pnpm --filter kandev test -- src/shared.test.ts`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Possible Improvements

Low risk — memoization means a debug flag flipped mid-session without reload would not take effect (unchanged from prior constant behavior once cached).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.