### PR TITLE
fix(agents): split codex acp flags from agentctl auto-approve

### DIFF
--- a/apps/backend/internal/agent/agents/agent.go
+++ b/apps/backend/internal/agent/agents/agent.go
@@ -226,11 +226,19 @@ func (c SessionConfig) SupportsRecovery() bool {
 // filter chain across agents, so the literal lives in exactly one place.
 const PermissionApplyMethodCLIFlag = "cli_flag"
 
+// PermissionApplyMethodAgentctlAutoApprove maps the profile auto_approve column
+// to AGENTCTL_AUTO_APPROVE_PERMISSIONS at launch (all ACP agents).
+const PermissionApplyMethodAgentctlAutoApprove = "agentctl_auto_approve"
+
 // PermissionKeyAutoApprove is the PermissionSettings map key wired to the
 // profile "Auto approve" toggle (see PermissionValues in buildAgentCommand).
 // Centralised for the same reason as PermissionApplyMethodCLIFlag: a typo in
 // any one agent silently disables its auto-approve flag.
 const PermissionKeyAutoApprove = "auto_approve"
+
+// PermissionKeyCursorForce is the Cursor-specific CLI --force toggle (unsandboxed
+// run-everything). Separate from PermissionKeyAutoApprove (agentctl ACP approval).
+const PermissionKeyCursorForce = "cursor_force"
 
 // PermissionSetting defines metadata for a permission setting option.
 type PermissionSetting struct {

--- a/apps/backend/internal/agent/agents/codex_acp.go
+++ b/apps/backend/internal/agent/agents/codex_acp.go
@@ -17,8 +17,8 @@ var codexACPLogoDark []byte
 
 const codexACPPkg = "@zed-industries/codex-acp"
 
-// CodexACPSandboxDiskFullReadCLIFlag is the seeded cli_flags token for disk-full-read sandbox access.
-const CodexACPSandboxDiskFullReadCLIFlag = `-c 'sandbox_permissions=["disk-full-read-access"]'`
+// CodexACPSandboxDiskFullReadCLIFlag is the seeded cli_flags text for disk-full-read sandbox access.
+const CodexACPSandboxDiskFullReadCLIFlag = `-c sandbox_permissions=["disk-full-read-access"]`
 
 var (
 	_ Agent            = (*CodexACP)(nil)
@@ -47,12 +47,13 @@ var codexACPPermSettings = map[string]PermissionSetting{
 		CLIFlagValue: "approval_policy=never",
 	},
 	"config_sandbox_disk_full_read": {
-		Supported:   true,
-		Default:     false,
-		Label:       "Disk full read access (config)",
-		Description: `-c sandbox_permissions=["disk-full-read-access"] (legacy list; prefer sandbox_mode in config.toml)`,
-		ApplyMethod: PermissionApplyMethodCLIFlag,
-		CLIFlag:     CodexACPSandboxDiskFullReadCLIFlag,
+		Supported:    true,
+		Default:      false,
+		Label:        "Disk full read access (config)",
+		Description:  `-c sandbox_permissions=["disk-full-read-access"] (legacy list; prefer sandbox_mode in config.toml)`,
+		ApplyMethod:  PermissionApplyMethodCLIFlag,
+		CLIFlag:      "-c",
+		CLIFlagValue: `sandbox_permissions=["disk-full-read-access"]`,
 	},
 }
 

--- a/apps/backend/internal/agent/agents/codex_acp.go
+++ b/apps/backend/internal/agent/agents/codex_acp.go
@@ -17,6 +17,9 @@ var codexACPLogoDark []byte
 
 const codexACPPkg = "@zed-industries/codex-acp"
 
+// CodexACPSandboxDiskFullReadCLIFlag is the seeded cli_flags token for disk-full-read sandbox access.
+const CodexACPSandboxDiskFullReadCLIFlag = `-c 'sandbox_permissions=["disk-full-read-access"]'`
+
 var (
 	_ Agent            = (*CodexACP)(nil)
 	_ PassthroughAgent = (*CodexACP)(nil)
@@ -30,7 +33,32 @@ type CodexACP struct {
 	StandardPassthrough
 }
 
-// codexPassthroughPermSettings maps profile toggles to @openai/codex CLI flags.
+// codexACPPermSettings seeds profile cli_flags for @zed-industries/codex-acp.
+// Values are passed as -c key=value overrides (see codex-acp --help and
+// https://developers.openai.com/codex/config-reference). Toggles default off;
+var codexACPPermSettings = map[string]PermissionSetting{
+	"config_approval_policy_never": {
+		Supported:    true,
+		Default:      false,
+		Label:        "Skip approval prompts (config)",
+		Description:  "-c approval_policy=never (allowed: untrusted, on-request, never, granular)",
+		ApplyMethod:  PermissionApplyMethodCLIFlag,
+		CLIFlag:      "-c",
+		CLIFlagValue: "approval_policy=never",
+	},
+	"config_sandbox_disk_full_read": {
+		Supported:   true,
+		Default:     false,
+		Label:       "Disk full read access (config)",
+		Description: `-c sandbox_permissions=["disk-full-read-access"] (legacy list; prefer sandbox_mode in config.toml)`,
+		ApplyMethod: PermissionApplyMethodCLIFlag,
+		CLIFlag:     CodexACPSandboxDiskFullReadCLIFlag,
+	},
+}
+
+// codexPassthroughPermSettings maps passthrough-only toggles to @openai/codex CLI
+// flags. Not returned from PermissionSettings(): @zed-industries/codex-acp only
+// accepts -c/--config overrides; ACP auto-approve uses agentctl approval_policy.
 // The legacy --full-auto flag was removed; auto_approve uses --ask-for-approval never.
 var codexPassthroughPermSettings = map[string]PermissionSetting{
 	PermissionKeyAutoApprove: {
@@ -165,7 +193,7 @@ func (a *CodexACP) InstallScript() string {
 func (a *CodexACP) BillingType() usage.BillingType { return codexBillingType() }
 
 func (a *CodexACP) PermissionSettings() map[string]PermissionSetting {
-	return codexPassthroughPermSettings
+	return codexACPPermSettings
 }
 
 // InferenceConfig returns configuration for one-shot inference using ACP.

--- a/apps/backend/internal/agent/agents/codex_acp.go
+++ b/apps/backend/internal/agent/agents/codex_acp.go
@@ -18,7 +18,8 @@ var codexACPLogoDark []byte
 const codexACPPkg = "@zed-industries/codex-acp"
 
 // CodexACPSandboxDiskFullReadCLIFlag is the seeded cli_flags text for disk-full-read sandbox access.
-const CodexACPSandboxDiskFullReadCLIFlag = `-c sandbox_permissions=["disk-full-read-access"]`
+// Single quotes preserve inner JSON double-quotes through cliflags.Tokenise.
+const CodexACPSandboxDiskFullReadCLIFlag = `-c 'sandbox_permissions=["disk-full-read-access"]'`
 
 var (
 	_ Agent            = (*CodexACP)(nil)
@@ -53,7 +54,7 @@ var codexACPPermSettings = map[string]PermissionSetting{
 		Description:  `-c sandbox_permissions=["disk-full-read-access"] (legacy list; prefer sandbox_mode in config.toml)`,
 		ApplyMethod:  PermissionApplyMethodCLIFlag,
 		CLIFlag:      "-c",
-		CLIFlagValue: `sandbox_permissions=["disk-full-read-access"]`,
+		CLIFlagValue: `'sandbox_permissions=["disk-full-read-access"]'`,
 	},
 }
 

--- a/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
@@ -23,7 +23,7 @@ func TestCodexACP_CLIFlagTokenise(t *testing.T) {
 		{
 			name: "sandbox_permissions",
 			raw:  CodexACPSandboxDiskFullReadCLIFlag,
-			want: []string{"-c", `sandbox_permissions=[disk-full-read-access]`},
+			want: []string{"-c", `sandbox_permissions=["disk-full-read-access"]`},
 		},
 	}
 	for _, tc := range cases {

--- a/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
@@ -1,0 +1,59 @@
+package agents
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agent/settings/cliflags"
+	"github.com/kandev/kandev/internal/agent/settings/models"
+)
+
+func TestCodexACP_CLIFlagTokenise(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "approval_policy",
+			raw:  "-c approval_policy=never",
+			want: []string{"-c", "approval_policy=never"},
+		},
+		{
+			name: "sandbox_permissions",
+			raw:  CodexACPSandboxDiskFullReadCLIFlag,
+			want: []string{"-c", `sandbox_permissions=["disk-full-read-access"]`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := cliflags.Tokenise(tc.raw)
+			if err != nil {
+				t.Fatalf("Tokenise: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("tokens = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexACP_ResolveSeededCLIFlags_DefaultDisabled(t *testing.T) {
+	flags := make([]models.CLIFlag, 0, len(codexACPPermSettings))
+	for _, s := range codexACPPermSettings {
+		flagText := s.CLIFlag
+		if s.CLIFlagValue != "" {
+			flagText = s.CLIFlag + " " + s.CLIFlagValue
+		}
+		flags = append(flags, models.CLIFlag{Flag: flagText, Enabled: s.Default})
+	}
+	got, err := cliflags.Resolve(flags)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no argv when defaults disabled, got %#v", got)
+	}
+}

--- a/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_cliflags_test.go
@@ -23,7 +23,7 @@ func TestCodexACP_CLIFlagTokenise(t *testing.T) {
 		{
 			name: "sandbox_permissions",
 			raw:  CodexACPSandboxDiskFullReadCLIFlag,
-			want: []string{"-c", `sandbox_permissions=["disk-full-read-access"]`},
+			want: []string{"-c", `sandbox_permissions=[disk-full-read-access]`},
 		},
 	}
 	for _, tc := range cases {

--- a/apps/backend/internal/agent/agents/codex_acp_test.go
+++ b/apps/backend/internal/agent/agents/codex_acp_test.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -13,6 +14,53 @@ func TestCodexACPRuntimeNoLongerBindMountsHostHome(t *testing.T) {
 		if strings.Contains(m.Source, "{home}") {
 			t.Fatalf("codex Mounts unexpectedly references {home}: %+v", m)
 		}
+	}
+}
+
+func TestCodexACP_PermissionSettings_CuratedConfigOverrides(t *testing.T) {
+	settings := NewCodexACP().PermissionSettings()
+	want := map[string]struct {
+		flagText  string
+		defaultOn bool
+	}{
+		"config_approval_policy_never": {
+			flagText: "-c approval_policy=never", defaultOn: false,
+		},
+		"config_sandbox_disk_full_read": {
+			flagText: CodexACPSandboxDiskFullReadCLIFlag, defaultOn: false,
+		},
+	}
+	if len(settings) != len(want) {
+		t.Fatalf("PermissionSettings() len = %d, want %d: %#v", len(settings), len(want), settings)
+	}
+	for key, spec := range want {
+		s, ok := settings[key]
+		if !ok {
+			t.Fatalf("missing %q in PermissionSettings()", key)
+		}
+		if !s.Supported || s.ApplyMethod != PermissionApplyMethodCLIFlag {
+			t.Fatalf("%q: unsupported or wrong apply method: %+v", key, s)
+		}
+		if s.Default != spec.defaultOn {
+			t.Fatalf("%q: Default=%v, want %v", key, s.Default, spec.defaultOn)
+		}
+		gotFlag := s.CLIFlag
+		if s.CLIFlagValue != "" {
+			gotFlag = s.CLIFlag + " " + s.CLIFlagValue
+		}
+		if gotFlag != spec.flagText {
+			t.Fatalf("%q: flag text %q, want %q", key, gotFlag, spec.flagText)
+		}
+	}
+}
+
+func TestCodexACP_BuildCommand_NoCodexCLIFlags(t *testing.T) {
+	want := []string{"npx", "-y", codexACPPkg}
+	cmd := NewCodexACP().BuildCommand(CommandOptions{
+		PermissionValues: map[string]bool{PermissionKeyAutoApprove: true},
+	})
+	if !slices.Equal(cmd.Args(), want) {
+		t.Fatalf("BuildCommand = %#v, want %#v", cmd.Args(), want)
 	}
 }
 

--- a/apps/backend/internal/agent/agents/cursor_acp.go
+++ b/apps/backend/internal/agent/agents/cursor_acp.go
@@ -18,18 +18,17 @@ var cursorACPLogoDark []byte
 
 const cursorACPBin = "cursor-agent"
 
-// cursorPermSettings maps the profile "Auto approve" toggle to cursor-agent's
-// --force flag. In ACP mode Cursor emits a session/request_permission for every
-// command not on its internal allowlist; --force ("Run Everything") suppresses
-// those prompts entirely. Empirically --force is the only flag that bypasses
-// the allowlist over ACP — --yolo and --sandbox still prompt. Default off
-// because --force runs everything unsandboxed.
+// cursorPermSettings maps a curated CLI flag to cursor-agent's --force switch.
+// In ACP mode Cursor emits session/request_permission for commands off its
+// allowlist; --force ("Run Everything") suppresses those prompts. Default off
+// because --force runs everything unsandboxed. Universal agentctl auto-approve
+// (PermissionKeyAutoApprove) is added by CatalogPermissionSettings, not here.
 var cursorPermSettings = map[string]PermissionSetting{
-	PermissionKeyAutoApprove: {
+	PermissionKeyCursorForce: {
 		Supported:   true,
 		Default:     false,
-		Label:       "Auto approve",
-		Description: "Run all commands without approval prompts (cursor-agent --force)",
+		Label:       "Cursor run everything (--force)",
+		Description: "Append cursor-agent --force so the CLI stops prompting for non-allowlisted commands (unsandboxed).",
 		ApplyMethod: PermissionApplyMethodCLIFlag,
 		CLIFlag:     "--force",
 	},
@@ -94,9 +93,9 @@ func (a *CursorACP) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
 }
 
 func (a *CursorACP) BuildCommand(opts CommandOptions) Command {
-	return Cmd(cursorACPBin, "acp").
-		Settings(a.PermissionSettings(), opts.PermissionValues).
-		Build()
+	// --force is applied via profile cli_flags (seeded from cursor_force), not
+	// PermissionValues, so auto_approve stays agentctl-only.
+	return Cmd(cursorACPBin, "acp").Build()
 }
 
 func (a *CursorACP) Runtime() *RuntimeConfig {

--- a/apps/backend/internal/agent/agents/cursor_acp_test.go
+++ b/apps/backend/internal/agent/agents/cursor_acp_test.go
@@ -22,27 +22,47 @@ func TestCursorACPRemoteAuth(t *testing.T) {
 	}
 }
 
-func TestCursorACPPermissionSettingsAutoApprove(t *testing.T) {
+func TestCursorACPPermissionSettingsCursorForce(t *testing.T) {
 	settings := NewCursorACP().PermissionSettings()
-	setting, ok := settings[PermissionKeyAutoApprove]
+	setting, ok := settings[PermissionKeyCursorForce]
 	if !ok {
-		t.Fatal("PermissionSettings() missing auto_approve; cursor must expose an approval-bypass toggle")
+		t.Fatal("PermissionSettings() missing cursor_force")
+	}
+	if _, hasAuto := settings[PermissionKeyAutoApprove]; hasAuto {
+		t.Fatal("PermissionSettings() must not include auto_approve; that is agentctl-only in the catalog")
 	}
 	if !setting.Supported {
-		t.Error("auto_approve must be Supported")
+		t.Error("cursor_force must be Supported")
 	}
 	if setting.ApplyMethod != PermissionApplyMethodCLIFlag {
 		t.Errorf("ApplyMethod = %q, want %q", setting.ApplyMethod, PermissionApplyMethodCLIFlag)
 	}
 	if setting.CLIFlag != "--force" {
-		t.Errorf("CLIFlag = %q, want --force (the only flag that bypasses Cursor's ACP allowlist)", setting.CLIFlag)
+		t.Errorf("CLIFlag = %q, want --force", setting.CLIFlag)
 	}
 }
 
-func TestCursorACPBuildCommandAutoApprove(t *testing.T) {
+func TestCursorACPCatalogSeparatesAgentctlAutoApprove(t *testing.T) {
+	catalog := CatalogPermissionSettings(NewCursorACP())
+	auto, ok := catalog[PermissionKeyAutoApprove]
+	if !ok {
+		t.Fatal("catalog missing auto_approve")
+	}
+	if auto.ApplyMethod != PermissionApplyMethodAgentctlAutoApprove {
+		t.Fatalf("auto_approve ApplyMethod = %q, want %q", auto.ApplyMethod, PermissionApplyMethodAgentctlAutoApprove)
+	}
+	force, ok := catalog[PermissionKeyCursorForce]
+	if !ok {
+		t.Fatal("catalog missing cursor_force")
+	}
+	if force.ApplyMethod != PermissionApplyMethodCLIFlag {
+		t.Fatalf("cursor_force ApplyMethod = %q, want cli_flag", force.ApplyMethod)
+	}
+}
+
+func TestCursorACPBuildCommand(t *testing.T) {
 	c := NewCursorACP()
 
-	// Default: a bare `cursor-agent acp`, so Cursor keeps prompting per command.
 	plain := strings.Join(c.BuildCommand(CommandOptions{}).Args(), " ")
 	if plain != "cursor-agent acp" {
 		t.Fatalf("default BuildCommand = %q, want %q", plain, "cursor-agent acp")
@@ -51,14 +71,12 @@ func TestCursorACPBuildCommandAutoApprove(t *testing.T) {
 		t.Error("default command must not include --force")
 	}
 
-	// auto_approve enabled: --force is appended so Cursor stops sending a
-	// session/request_permission for every non-allowlisted command.
-	approved := strings.Join(
+	withAutoApprove := strings.Join(
 		c.BuildCommand(CommandOptions{PermissionValues: map[string]bool{PermissionKeyAutoApprove: true}}).Args(),
 		" ",
 	)
-	if !strings.Contains(approved, "--force") {
-		t.Errorf("auto_approve BuildCommand = %q, want it to contain --force", approved)
+	if strings.Contains(withAutoApprove, "--force") {
+		t.Errorf("auto_approve PermissionValues must not add --force, got %q", withAutoApprove)
 	}
 }
 
@@ -67,8 +85,6 @@ func TestCursorACPInstallScriptIsNativeInstaller(t *testing.T) {
 	if !strings.Contains(script, "cursor.com/install") {
 		t.Errorf("InstallScript must reference the cursor.com installer, got: %q", script)
 	}
-	// Ensure ~/.local/bin gets onto PATH so the cursor-agent binary is
-	// discoverable for subsequent prepare-script steps and shells.
 	if !strings.Contains(script, "$HOME/.local/bin") {
 		t.Errorf("InstallScript must add $HOME/.local/bin to PATH, got: %q", script)
 	}

--- a/apps/backend/internal/agent/agents/helpers.go
+++ b/apps/backend/internal/agent/agents/helpers.go
@@ -9,6 +9,31 @@ import (
 // expressed via ACP session modes and per-tool-call permission prompts.
 var emptyPermSettings = map[string]PermissionSetting{}
 
+// agentctlAutoApproveSetting is the universal profile toggle for Kandev-side
+// ACP permission auto-approval (not a subprocess CLI flag).
+var agentctlAutoApproveSetting = PermissionSetting{
+	Supported:   true,
+	Default:     false,
+	Label:       "Auto-approve all permissions",
+	Description: "Kandev allows every agent permission request without prompting you. Dangerous — use only in trusted workspaces.",
+	ApplyMethod: PermissionApplyMethodAgentctlAutoApprove,
+}
+
+// CatalogPermissionSettings returns the agent's curated permission catalogue
+// plus the shared agentctl auto-approve entry advertised on every agent profile.
+func CatalogPermissionSettings(ag Agent) map[string]PermissionSetting {
+	return mergeAgentctlAutoApprove(ag.PermissionSettings())
+}
+
+func mergeAgentctlAutoApprove(settings map[string]PermissionSetting) map[string]PermissionSetting {
+	merged := make(map[string]PermissionSetting, len(settings)+1)
+	for k, v := range settings {
+		merged[k] = v
+	}
+	merged[PermissionKeyAutoApprove] = agentctlAutoApproveSetting
+	return merged
+}
+
 // CmdBuilder constructs CLI command slices using a fluent API.
 type CmdBuilder struct {
 	args []string

--- a/apps/backend/internal/agent/agents/helpers_catalog_test.go
+++ b/apps/backend/internal/agent/agents/helpers_catalog_test.go
@@ -1,0 +1,37 @@
+package agents
+
+import "testing"
+
+func TestCatalogPermissionSettings_IncludesAgentctlAutoApprove(t *testing.T) {
+	catalog := CatalogPermissionSettings(NewClaudeACP())
+	setting, ok := catalog[PermissionKeyAutoApprove]
+	if !ok {
+		t.Fatal("catalog missing auto_approve")
+	}
+	if setting.ApplyMethod != PermissionApplyMethodAgentctlAutoApprove {
+		t.Fatalf("ApplyMethod = %q, want %q", setting.ApplyMethod, PermissionApplyMethodAgentctlAutoApprove)
+	}
+	if setting.Default {
+		t.Fatal("auto_approve must default to false")
+	}
+}
+
+func TestCatalogPermissionSettings_MergesCursorForce(t *testing.T) {
+	catalog := CatalogPermissionSettings(NewCursorACP())
+	if _, ok := catalog[PermissionKeyCursorForce]; !ok {
+		t.Fatal("missing cursor_force")
+	}
+	if catalog[PermissionKeyAutoApprove].ApplyMethod != PermissionApplyMethodAgentctlAutoApprove {
+		t.Fatal("auto_approve must be agentctl, not cursor --force")
+	}
+}
+
+func TestCatalogPermissionSettings_MergesCodexCLIFlags(t *testing.T) {
+	catalog := CatalogPermissionSettings(NewCodexACP())
+	if len(codexACPPermSettings) != 2 {
+		t.Fatalf("codexACPPermSettings len = %d, want 2", len(codexACPPermSettings))
+	}
+	if _, ok := catalog["config_approval_policy_never"]; !ok {
+		t.Fatal("missing codex config_approval_policy_never")
+	}
+}

--- a/apps/backend/internal/agent/settings/controller/agent_discovery.go
+++ b/apps/backend/internal/agent/settings/controller/agent_discovery.go
@@ -100,7 +100,7 @@ func (c *Controller) buildAvailableAgentDTO(ctx context.Context, ag agents.Agent
 	}
 
 	var permissionSettings map[string]dto.PermissionSettingDTO
-	if permSettings := ag.PermissionSettings(); permSettings != nil {
+	if permSettings := agents.CatalogPermissionSettings(ag); permSettings != nil {
 		permissionSettings = make(map[string]dto.PermissionSettingDTO, len(permSettings))
 		for key, setting := range permSettings {
 			permissionSettings[key] = dto.PermissionSettingDTO{
@@ -345,7 +345,7 @@ func (c *Controller) buildProfileSyncParams(
 	_, displayName, defaultModel string,
 	isPassthroughOnly bool,
 ) profileSyncParams {
-	autoApprove, allowIndexing, skipPermissions := resolvePermissionDefaults(agentConfig.PermissionSettings())
+	autoApprove, allowIndexing, skipPermissions := resolvePermissionDefaults(agents.CatalogPermissionSettings(agentConfig))
 	return profileSyncParams{
 		displayName:     displayName,
 		defaultModel:    defaultModel,

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -20,6 +20,7 @@ type CreateProfileRequest struct {
 	Model          string
 	Mode           string
 	AllowIndexing  bool
+	AutoApprove    bool
 	CLIPassthrough bool
 	// CLIFlags is the explicit list to persist. When nil, the profile is
 	// seeded from the agent's curated PermissionSettings() list so a fresh
@@ -61,6 +62,7 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 		Model:            req.Model,
 		Mode:             req.Mode,
 		AllowIndexing:    req.AllowIndexing,
+		AutoApprove:      req.AutoApprove,
 		CLIPassthrough:   req.CLIPassthrough,
 		CLIFlags:         cliFlags,
 		EnvVars:          envVarsFromDTO(req.EnvVars),
@@ -78,7 +80,7 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 // CLI flag are included; per-flag metadata (description, flag text, default
 // enabled) is copied into the row so the profile is self-contained.
 func seedCLIFlags(agent agents.Agent) []models.CLIFlag {
-	settings := agent.PermissionSettings()
+	settings := agents.CatalogPermissionSettings(agent)
 	flags := make([]models.CLIFlag, 0, len(settings))
 	for _, s := range settings {
 		if !s.Supported || s.ApplyMethod != agents.PermissionApplyMethodCLIFlag || s.CLIFlag == "" {
@@ -111,6 +113,7 @@ type UpdateProfileRequest struct {
 	Model          *string
 	Mode           *string
 	AllowIndexing  *bool
+	AutoApprove    *bool
 	CLIPassthrough *bool
 	// CLIFlags replaces the entire list when non-nil. Nil means "leave
 	// unchanged" — the UI always sends the full desired list on save.
@@ -140,6 +143,9 @@ func (c *Controller) UpdateProfile(ctx context.Context, req UpdateProfileRequest
 	}
 	if req.AllowIndexing != nil {
 		profile.AllowIndexing = *req.AllowIndexing
+	}
+	if req.AutoApprove != nil {
+		profile.AutoApprove = *req.AutoApprove
 	}
 	if req.CLIPassthrough != nil {
 		profile.CLIPassthrough = *req.CLIPassthrough
@@ -289,6 +295,7 @@ func toProfileDTO(profile *models.AgentProfile) dto.AgentProfileDTO {
 		Model:            profile.Model,
 		Mode:             profile.Mode,
 		AllowIndexing:    profile.AllowIndexing,
+		AutoApprove:      profile.AutoApprove,
 		CLIFlags:         cliFlagsToDTO(profile.CLIFlags),
 		EnvVars:          envVarsToDTO(profile.EnvVars),
 		CLIPassthrough:   profile.CLIPassthrough,

--- a/apps/backend/internal/agent/settings/controller/profile_crud_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_test.go
@@ -61,6 +61,33 @@ func TestSeedCLIFlags_EmptyForAgentWithNoCurated(t *testing.T) {
 	}
 }
 
+// TestSeedCLIFlags_FromCodexACP seeds codex-acp -c config overrides (off by
+// default) and never @openai/codex passthrough flags like --ask-for-approval.
+func TestSeedCLIFlags_FromCodexACP(t *testing.T) {
+	flags := seedCLIFlags(agents.NewCodexACP())
+
+	want := map[string]bool{
+		"-c approval_policy=never":                           false,
+		agents.CodexACPSandboxDiskFullReadCLIFlag: false,
+	}
+	if len(flags) != len(want) {
+		t.Fatalf("expected %d seeded flags, got %d: %+v", len(want), len(flags), flags)
+	}
+	for _, f := range flags {
+		enabled, ok := want[f.Flag]
+		if !ok {
+			t.Errorf("unexpected seeded flag: %q", f.Flag)
+			continue
+		}
+		if f.Enabled != enabled {
+			t.Errorf("%q: Enabled=%v, want %v", f.Flag, f.Enabled, enabled)
+		}
+		if f.Description == "" {
+			t.Errorf("%q: missing Description", f.Flag)
+		}
+	}
+}
+
 // TestValidateCLIFlagDTOs rejects entries whose flag text is empty or
 // whitespace only. Empty descriptions are allowed (custom flags often
 // don't have one).

--- a/apps/backend/internal/agent/settings/controller/profile_crud_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_test.go
@@ -67,7 +67,7 @@ func TestSeedCLIFlags_FromCodexACP(t *testing.T) {
 	flags := seedCLIFlags(agents.NewCodexACP())
 
 	want := map[string]bool{
-		"-c approval_policy=never":                           false,
+		"-c approval_policy=never":                false,
 		agents.CodexACPSandboxDiskFullReadCLIFlag: false,
 	}
 	if len(flags) != len(want) {
@@ -84,6 +84,24 @@ func TestSeedCLIFlags_FromCodexACP(t *testing.T) {
 		}
 		if f.Description == "" {
 			t.Errorf("%q: missing Description", f.Flag)
+		}
+	}
+}
+
+func TestSeedCLIFlags_FromCursorACP(t *testing.T) {
+	flags := seedCLIFlags(agents.NewCursorACP())
+	want := map[string]bool{"--force": false}
+	if len(flags) != len(want) {
+		t.Fatalf("expected %d seeded flags, got %d: %+v", len(want), len(flags), flags)
+	}
+	for _, f := range flags {
+		enabled, ok := want[f.Flag]
+		if !ok {
+			t.Errorf("unexpected seeded flag: %q", f.Flag)
+			continue
+		}
+		if f.Enabled != enabled {
+			t.Errorf("%q: Enabled=%v, want %v", f.Flag, f.Enabled, enabled)
 		}
 	}
 }

--- a/apps/backend/internal/agent/settings/dto/dto.go
+++ b/apps/backend/internal/agent/settings/dto/dto.go
@@ -14,6 +14,7 @@ type AgentProfileDTO struct {
 	Model            string             `json:"model"`
 	Mode             string             `json:"mode,omitempty"`
 	AllowIndexing    bool               `json:"allow_indexing"` // Deprecated: use CLIFlags. Retained for legacy clients.
+	AutoApprove      bool               `json:"auto_approve"`
 	CLIFlags         []CLIFlagDTO       `json:"cli_flags"`
 	EnvVars          []ProfileEnvVarDTO `json:"env_vars,omitempty"`
 	CLIPassthrough   bool               `json:"cli_passthrough"`

--- a/apps/backend/internal/agent/settings/handlers/handlers.go
+++ b/apps/backend/internal/agent/settings/handlers/handlers.go
@@ -360,6 +360,7 @@ type createProfileRequest struct {
 	Model          string                 `json:"model"`
 	Mode           string                 `json:"mode,omitempty"`
 	AllowIndexing  bool                   `json:"allow_indexing"`
+	AutoApprove    bool                   `json:"auto_approve"`
 	CLIPassthrough bool                   `json:"cli_passthrough"`
 	CLIFlags       []dto.CLIFlagDTO       `json:"cli_flags,omitempty"`
 	EnvVars        []dto.ProfileEnvVarDTO `json:"env_vars,omitempty"`
@@ -381,6 +382,7 @@ func (h *Handlers) httpCreateProfile(c *gin.Context) {
 		Model:          body.Model,
 		Mode:           body.Mode,
 		AllowIndexing:  body.AllowIndexing,
+		AutoApprove:    body.AutoApprove,
 		CLIPassthrough: body.CLIPassthrough,
 		CLIFlags:       body.CLIFlags,
 		EnvVars:        body.EnvVars,
@@ -408,6 +410,7 @@ type updateProfileRequest struct {
 	Model          *string                 `json:"model,omitempty"`
 	Mode           *string                 `json:"mode,omitempty"`
 	AllowIndexing  *bool                   `json:"allow_indexing,omitempty"`
+	AutoApprove    *bool                   `json:"auto_approve,omitempty"`
 	CLIPassthrough *bool                   `json:"cli_passthrough,omitempty"`
 	CLIFlags       *[]dto.CLIFlagDTO       `json:"cli_flags,omitempty"`
 	EnvVars        *[]dto.ProfileEnvVarDTO `json:"env_vars,omitempty"`
@@ -429,6 +432,7 @@ func (h *Handlers) httpUpdateProfile(c *gin.Context) {
 		Model:          body.Model,
 		Mode:           body.Mode,
 		AllowIndexing:  body.AllowIndexing,
+		AutoApprove:    body.AutoApprove,
 		CLIPassthrough: body.CLIPassthrough,
 		CLIFlags:       body.CLIFlags,
 		EnvVars:        body.EnvVars,

--- a/apps/backend/internal/agent/settings/models/models.go
+++ b/apps/backend/internal/agent/settings/models/models.go
@@ -77,9 +77,9 @@ type AgentProfile struct {
 	// Stored as a JSON-encoded TEXT column; settings repo handles conversion.
 	EnvVars []ProfileEnvVar `json:"env_vars,omitempty" db:"-"`
 
-	// Deprecated legacy permission fields: retained in the DB schema so rows
-	// load cleanly, but no longer read by the launch path. ACP session modes
-	// and interactive permission_request prompts replace them.
+	// AutoApprove enables Kandev agentctl-side ACP permission auto-approval at
+	// launch (AGENTCTL_AUTO_APPROVE_PERMISSIONS). DangerouslySkipPermissions is
+	// a deprecated legacy column retained so existing rows load cleanly.
 	AutoApprove                bool `json:"auto_approve" db:"auto_approve"`
 	DangerouslySkipPermissions bool `json:"-" db:"dangerously_skip_permissions"`
 

--- a/apps/backend/internal/agent/settings/models/models.go
+++ b/apps/backend/internal/agent/settings/models/models.go
@@ -80,7 +80,7 @@ type AgentProfile struct {
 	// Deprecated legacy permission fields: retained in the DB schema so rows
 	// load cleanly, but no longer read by the launch path. ACP session modes
 	// and interactive permission_request prompts replace them.
-	AutoApprove                bool `json:"-" db:"auto_approve"`
+	AutoApprove                bool `json:"auto_approve" db:"auto_approve"`
 	DangerouslySkipPermissions bool `json:"-" db:"dangerously_skip_permissions"`
 
 	UserModified bool       `json:"user_modified" db:"user_modified"`

--- a/apps/backend/internal/office/agents/dto.go
+++ b/apps/backend/internal/office/agents/dto.go
@@ -35,6 +35,9 @@ type UpdateAgentRequest struct {
 	SkillIDs              *string `json:"skill_ids,omitempty"`
 	ExecutorPreference    *string `json:"executor_preference,omitempty"`
 	PauseReason           *string `json:"pause_reason,omitempty"`
+	AutoApprove           *bool   `json:"auto_approve,omitempty"`
+	AllowIndexing         *bool   `json:"allow_indexing,omitempty"`
+	CLIPassthrough        *bool   `json:"cli_passthrough,omitempty"`
 	// Routing carries an optional provider-routing override blob. When
 	// non-nil it replaces the agent's stored override entirely; a zero
 	// AgentOverrides clears the overrides.

--- a/apps/backend/internal/office/agents/handler.go
+++ b/apps/backend/internal/office/agents/handler.go
@@ -563,4 +563,13 @@ func applyAgentUpdates(agent *models.AgentInstance, req *UpdateAgentRequest) {
 	if req.PauseReason != nil {
 		agent.PauseReason = *req.PauseReason
 	}
+	if req.AutoApprove != nil {
+		agent.AutoApprove = *req.AutoApprove
+	}
+	if req.AllowIndexing != nil {
+		agent.AllowIndexing = *req.AllowIndexing
+	}
+	if req.CLIPassthrough != nil {
+		agent.CLIPassthrough = *req.CLIPassthrough
+	}
 }

--- a/apps/backend/internal/office/repository/sqlite/agents.go
+++ b/apps/backend/internal/office/repository/sqlite/agents.go
@@ -256,7 +256,7 @@ func (r *Repository) UpdateAgentInstance(ctx context.Context, agent *models.Agen
 			skill_ids = ?, desired_skills = ?, executor_preference = ?,
 			pause_reason = ?, failure_threshold = ?, settings = ?,
 			auto_approve = ?, allow_indexing = ?, cli_passthrough = ?,
-			model = ?, mode = ?, updated_at = ?
+			updated_at = ?
 		WHERE id = ? AND `+agentInstanceFilter+`
 	`), agent.Name, string(agent.Role), agent.Icon, status,
 		agent.ReportsTo, permissions, agent.BudgetMonthlyCents,
@@ -265,7 +265,7 @@ func (r *Repository) UpdateAgentInstance(ctx context.Context, agent *models.Agen
 		skillIDs, desiredSkills, agent.ExecutorPreference,
 		agent.PauseReason, threshold, settings,
 		boolToInt(agent.AutoApprove), boolToInt(agent.AllowIndexing), boolToInt(agent.CLIPassthrough),
-		agent.Model, agent.Mode, agent.UpdatedAt, agent.ID)
+		agent.UpdatedAt, agent.ID)
 	return err
 }
 

--- a/apps/backend/internal/office/repository/sqlite/agents.go
+++ b/apps/backend/internal/office/repository/sqlite/agents.go
@@ -37,6 +37,7 @@ const agentInstanceColumns = `
 	name,
 	COALESCE(agent_display_name, '')        AS agent_display_name,
 	COALESCE(model, '')                     AS model,
+	COALESCE(auto_approve, 0)               AS auto_approve,
 	COALESCE(allow_indexing, 0)             AS allow_indexing,
 	COALESCE(cli_passthrough, 0)            AS cli_passthrough,
 	COALESCE(role, '')                      AS role,
@@ -253,14 +254,18 @@ func (r *Repository) UpdateAgentInstance(ctx context.Context, agent *models.Agen
 			max_concurrent_sessions = ?, cooldown_sec = ?, skip_idle_runs = ?,
 			last_run_finished_at = ?,
 			skill_ids = ?, desired_skills = ?, executor_preference = ?,
-			pause_reason = ?, failure_threshold = ?, settings = ?, updated_at = ?
+			pause_reason = ?, failure_threshold = ?, settings = ?,
+			auto_approve = ?, allow_indexing = ?, cli_passthrough = ?,
+			model = ?, mode = ?, updated_at = ?
 		WHERE id = ? AND `+agentInstanceFilter+`
 	`), agent.Name, string(agent.Role), agent.Icon, status,
 		agent.ReportsTo, permissions, agent.BudgetMonthlyCents,
 		agent.MaxConcurrentSessions, agent.CooldownSec, boolToInt(agent.SkipIdleRuns),
 		agent.LastRunFinishedAt,
 		skillIDs, desiredSkills, agent.ExecutorPreference,
-		agent.PauseReason, threshold, settings, agent.UpdatedAt, agent.ID)
+		agent.PauseReason, threshold, settings,
+		boolToInt(agent.AutoApprove), boolToInt(agent.AllowIndexing), boolToInt(agent.CLIPassthrough),
+		agent.Model, agent.Mode, agent.UpdatedAt, agent.ID)
 	return err
 }
 

--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -129,6 +129,7 @@ export async function updateAgentProfileAction(
     model?: string;
     mode?: string;
     allow_indexing?: boolean;
+    auto_approve?: boolean;
     cli_passthrough?: boolean;
     cli_flags?: CLIFlag[];
     env_vars?: ProfileEnvVar[];

--- a/apps/web/app/office/workspace/org/org-tree-layout.test.ts
+++ b/apps/web/app/office/workspace/org/org-tree-layout.test.ts
@@ -26,6 +26,7 @@ function makeAgent(id: string, name: string, reportsTo?: string): AgentProfile {
     agentDisplayName: "Claude",
     model: "claude-sonnet-4-5",
     allowIndexing: false,
+    autoApprove: false,
     cliFlags: [],
     cliPassthrough: false,
     createdAt: "2026-01-01T00:00:00Z",

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.test.ts
@@ -11,6 +11,7 @@ const baseProfile: AgentProfile = {
   model: "mock-fast",
   mode: "default",
   allowIndexing: false,
+  autoApprove: false,
   cliFlags: [],
   cliPassthrough: false,
   createdAt: "2026-01-01T00:00:00Z",
@@ -31,6 +32,7 @@ describe("toAgentProfilePatch", () => {
       model: "claude-sonnet",
       mode: "default",
       allow_indexing: true,
+      auto_approve: true,
       cli_passthrough: true,
       cli_flags: [{ flag: ALLOW_ALL_TOOLS_FLAG, enabled: true, description: "" }],
     };
@@ -39,6 +41,7 @@ describe("toAgentProfilePatch", () => {
       model: "claude-sonnet",
       mode: "default",
       allowIndexing: true,
+      autoApprove: true,
       cliPassthrough: true,
       cliFlags: [{ flag: ALLOW_ALL_TOOLS_FLAG, enabled: true, description: "" }],
     });
@@ -105,5 +108,15 @@ describe("isProfileDirty", () => {
     const saved: AgentProfile = { ...baseProfile, cliFlags: flags };
     const draft = draftFrom(saved, { cliFlags: [...flags] });
     expect(isProfileDirty(draft, saved)).toBe(false);
+  });
+
+  it("returns true when autoApprove changes via camelCase draft field", () => {
+    const draft = draftFrom(baseProfile, { autoApprove: true });
+    expect(isProfileDirty(draft, baseProfile)).toBe(true);
+  });
+
+  it("returns false when stale snake_case auto_approve disagrees with camelCase", () => {
+    const draft = draftFrom(baseProfile, { auto_approve: true, autoApprove: false });
+    expect(isProfileDirty(draft, baseProfile)).toBe(false);
   });
 });

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
@@ -68,6 +68,7 @@ type DraftMcpConfig = {
  */
 export type DraftProfile = AgentProfile & {
   allow_indexing?: boolean;
+  auto_approve?: boolean;
   isNew?: boolean;
   mcp_config?: DraftMcpConfig;
 };

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
@@ -14,7 +14,7 @@ import type {
   ModelConfig,
   ProfileEnvVar,
 } from "@/lib/types/http";
-import { permissionsToProfilePatch, arePermissionsDirty } from "@/lib/agent-permissions";
+import { arePermissionsDirty, permissionsToProfilePatch } from "@/lib/agent-permissions";
 import { areCLIFlagsEqual } from "@/lib/cli-flags";
 import type { ProfileFormData } from "@/components/settings/profile-form-fields";
 
@@ -31,6 +31,7 @@ export function toAgentProfilePatch(patch: Partial<ProfileFormData>): Partial<Ag
   if (patch.model !== undefined) next.model = patch.model;
   if (patch.mode !== undefined) next.mode = patch.mode;
   if (patch.allow_indexing !== undefined) next.allowIndexing = patch.allow_indexing;
+  if (patch.auto_approve !== undefined) next.autoApprove = patch.auto_approve;
   if (patch.cli_passthrough !== undefined) next.cliPassthrough = patch.cli_passthrough;
   if (patch.cli_flags !== undefined) next.cliFlags = patch.cli_flags;
   return next;
@@ -303,13 +304,11 @@ export async function saveExistingAgent(
 
 export function isProfileDirty(draft: DraftProfile, saved?: AgentProfile): boolean {
   if (!saved) return true;
-  const draftAllow = draft.allow_indexing ?? draft.allowIndexing ?? false;
-  const savedAllow = saved.allowIndexing ?? false;
   return (
     draft.name !== saved.name ||
     draft.model !== saved.model ||
     (draft.mode ?? "") !== (saved.mode ?? "") ||
-    arePermissionsDirty({ allow_indexing: draftAllow }, { allow_indexing: savedAllow }) ||
+    arePermissionsDirty(draft, saved) ||
     draft.cliPassthrough !== saved.cliPassthrough ||
     !areCLIFlagsEqual(draft.cliFlags ?? [], saved.cliFlags ?? []) ||
     !areEnvVarsEqual(draft.envVars, saved.envVars)

--- a/apps/web/app/settings/agents/[agentId]/agent-setup-parts.tsx
+++ b/apps/web/app/settings/agents/[agentId]/agent-setup-parts.tsx
@@ -20,6 +20,7 @@ import { ProfileEnvVarsSection } from "@/components/settings/agent-profile-page"
 import { CustomCLIFlagsCard } from "@/components/settings/cli-flags-field";
 import type { Agent, ModelConfig, PermissionSetting, PassthroughConfig } from "@/lib/types/http";
 import { ProfileMcpConfigCard } from "./profile-mcp-config-card";
+import { profilePermissionValues } from "@/lib/agent-permissions";
 import { toAgentProfilePatch, type DraftProfile, type DraftAgent } from "./agent-save-helpers";
 
 export type AgentHeaderProps = {
@@ -109,6 +110,7 @@ export function ProfileCardItem({
   onRemoveProfile,
   onToastError,
 }: ProfileCardItemProps) {
+  const permissionValues = profilePermissionValues(profile, permissionSettings);
   return (
     <Card
       id={`profile-card-${profile.id}`}
@@ -120,7 +122,8 @@ export function ProfileCardItem({
             name: profile.name,
             model: profile.model,
             mode: profile.mode ?? "",
-            allow_indexing: profile.allow_indexing ?? profile.allowIndexing ?? false,
+            auto_approve: permissionValues.auto_approve,
+            allow_indexing: permissionValues.allow_indexing,
             cli_passthrough: profile.cliPassthrough ?? false,
             cli_flags: profile.cliFlags ?? [],
           }}

--- a/apps/web/app/settings/agents/[agentId]/page.tsx
+++ b/apps/web/app/settings/agents/[agentId]/page.tsx
@@ -51,7 +51,6 @@ const createDraftProfile = (
   name: "",
   agentDisplayName,
   model: defaultModel,
-  allowIndexing: false,
   ...buildDefaultPermissions(permissionSettings ?? {}),
   cliPassthrough: false,
   cliFlags: seedDefaultCLIFlags(permissionSettings ?? {}),

--- a/apps/web/components/agent/cli-profile-editor.test.tsx
+++ b/apps/web/components/agent/cli-profile-editor.test.tsx
@@ -95,6 +95,7 @@ describe("CliProfileEditor", () => {
       model: MODEL_ID,
       mode: "",
       allowIndexing: false,
+      autoApprove: false,
       cliFlags: [],
       cliPassthrough: false,
       createdAt: CREATED_AT,

--- a/apps/web/components/agent/cli-profile-editor.test.tsx
+++ b/apps/web/components/agent/cli-profile-editor.test.tsx
@@ -184,6 +184,7 @@ describe("CliProfileEditor recommended flags", () => {
           cliFlags: [],
           cliPassthrough: false,
           allowIndexing: false,
+          autoApprove: false,
           createdAt: CREATED_AT,
           updatedAt: CREATED_AT,
         },

--- a/apps/web/components/agent/cli-profile-editor.tsx
+++ b/apps/web/components/agent/cli-profile-editor.tsx
@@ -18,7 +18,10 @@ import {
 } from "@/app/actions/agents";
 import type { Agent, AgentProfile, AvailableAgent, CLIFlag } from "@/lib/types/http";
 import { seedDefaultCLIFlags } from "@/lib/cli-flags";
-import { PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE } from "@/lib/agent-permissions";
+import {
+  buildDefaultPermissions,
+  PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE,
+} from "@/lib/agent-permissions";
 
 export type CliProfileEditorMode = "create" | "edit";
 
@@ -76,16 +79,16 @@ function fromDefaultAgent(
   defaultAgent: AvailableAgent | undefined,
 ): FormState {
   const cfg = defaultAgent?.model_config;
-  const allowIndex = defaultAgent?.permission_settings?.allow_indexing?.default ?? false;
+  const permissionSettings = defaultAgent?.permission_settings ?? {};
+  const defaults = buildDefaultPermissions(permissionSettings);
   return {
     agentName: defaultAgent?.name ?? "",
     profileName: defaultName,
     model: cfg?.default_model ?? "",
     mode: cfg?.current_mode_id ?? "",
-    cliFlags: seedDefaultCLIFlags(defaultAgent?.permission_settings ?? {}),
+    cliFlags: seedDefaultCLIFlags(permissionSettings),
     cliPassthrough: false,
-    allowIndexing: allowIndex,
-    autoApprove: defaultAgent?.permission_settings?.auto_approve?.default ?? false,
+    ...defaults,
   };
 }
 

--- a/apps/web/components/agent/cli-profile-editor.tsx
+++ b/apps/web/components/agent/cli-profile-editor.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/app/actions/agents";
 import type { Agent, AgentProfile, AvailableAgent, CLIFlag } from "@/lib/types/http";
 import { seedDefaultCLIFlags } from "@/lib/cli-flags";
+import { PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE } from "@/lib/agent-permissions";
 
 export type CliProfileEditorMode = "create" | "edit";
 
@@ -50,6 +51,7 @@ type FormState = {
   cliFlags: CLIFlag[];
   cliPassthrough: boolean;
   allowIndexing: boolean;
+  autoApprove: boolean;
 };
 
 function pickDefaultAgent(available: AvailableAgent[]): AvailableAgent | undefined {
@@ -65,6 +67,7 @@ function fromExistingProfile(profile: AgentProfile): FormState {
     cliFlags: profile.cliFlags ?? [],
     cliPassthrough: profile.cliPassthrough ?? false,
     allowIndexing: profile.allowIndexing ?? false,
+    autoApprove: profile.autoApprove ?? false,
   };
 }
 
@@ -82,6 +85,7 @@ function fromDefaultAgent(
     cliFlags: seedDefaultCLIFlags(defaultAgent?.permission_settings ?? {}),
     cliPassthrough: false,
     allowIndexing: allowIndex,
+    autoApprove: defaultAgent?.permission_settings?.auto_approve?.default ?? false,
   };
 }
 
@@ -183,12 +187,14 @@ export function CliProfileEditor({
         onToggle={() => setAdvancedOpen((o) => !o)}
         cliPassthrough={form.cliPassthrough}
         allowIndexing={form.allowIndexing}
+        autoApprove={form.autoApprove}
         cliFlags={form.cliFlags}
         permissionSettings={permissionSettings ?? {}}
         allowCliPassthrough={allowCliPassthrough}
         showAllowIndexing={Boolean(permissionSettings?.allow_indexing?.supported)}
         onCliPassthroughChange={(v) => patch({ cliPassthrough: v })}
         onAllowIndexingChange={(v) => patch({ allowIndexing: v })}
+        onAutoApproveChange={(v) => patch({ autoApprove: v })}
         onCliFlagsChange={(v) => patch({ cliFlags: v })}
       />
 
@@ -333,12 +339,14 @@ type AdvancedTogglesProps = {
   onToggle: () => void;
   cliPassthrough: boolean;
   allowIndexing: boolean;
+  autoApprove: boolean;
   cliFlags: CLIFlag[];
   permissionSettings: AvailableAgent["permission_settings"];
   allowCliPassthrough: boolean;
   showAllowIndexing: boolean;
   onCliPassthroughChange: (v: boolean) => void;
   onAllowIndexingChange: (v: boolean) => void;
+  onAutoApproveChange: (v: boolean) => void;
   onCliFlagsChange: (v: CLIFlag[]) => void;
 };
 
@@ -347,14 +355,21 @@ function AdvancedToggles({
   onToggle,
   cliPassthrough,
   allowIndexing,
+  autoApprove,
   cliFlags,
   permissionSettings,
   allowCliPassthrough,
   showAllowIndexing,
   onCliPassthroughChange,
   onAllowIndexingChange,
+  onAutoApproveChange,
   onCliFlagsChange,
 }: AdvancedTogglesProps) {
+  const autoSetting = permissionSettings?.auto_approve;
+  const showAgentctlAutoApprove = Boolean(
+    autoSetting?.supported && autoSetting.apply_method === PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE,
+  );
+
   return (
     <div className="border-t pt-3">
       <button
@@ -373,6 +388,14 @@ function AdvancedToggles({
               description="Forward stdin/stdout straight to the CLI subprocess. Disables ACP."
               checked={cliPassthrough}
               onChange={onCliPassthroughChange}
+            />
+          )}
+          {showAgentctlAutoApprove && autoSetting && (
+            <AgentctlAutoApproveRow
+              id="cli-auto-approve"
+              setting={autoSetting}
+              checked={autoApprove}
+              onChange={onAutoApproveChange}
             />
           )}
           {showAllowIndexing && (
@@ -422,12 +445,45 @@ function ToggleRow({
   );
 }
 
+function AgentctlAutoApproveRow({
+  id,
+  setting,
+  checked,
+  onChange,
+}: {
+  id: string;
+  setting: NonNullable<AvailableAgent["permission_settings"]>["auto_approve"];
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2">
+      <div className="space-y-0.5">
+        <Label htmlFor={id} className="text-sm text-destructive">
+          {setting?.label ?? "Auto-approve all permissions"}
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {setting?.description ??
+            "Kandev allows every agent permission request without prompting you."}
+        </p>
+      </div>
+      <Switch
+        id={id}
+        checked={checked}
+        onCheckedChange={onChange}
+        className="cursor-pointer data-[state=checked]:bg-destructive"
+      />
+    </div>
+  );
+}
+
 async function saveExistingProfile(id: string, form: FormState): Promise<AgentProfile> {
   return updateAgentProfileAction(id, {
     name: form.profileName.trim(),
     model: form.model,
     mode: form.mode || undefined,
     allow_indexing: form.allowIndexing,
+    auto_approve: form.autoApprove,
     cli_flags: form.cliFlags,
     cli_passthrough: form.cliPassthrough,
   });
@@ -440,6 +496,7 @@ async function saveNewProfile(form: FormState, settingsAgents: Agent[]): Promise
     model: form.model,
     mode: form.mode || undefined,
     allow_indexing: form.allowIndexing,
+    auto_approve: form.autoApprove,
     cli_passthrough: form.cliPassthrough,
     cli_flags: form.cliFlags,
   };

--- a/apps/web/components/onboarding-dialog.tsx
+++ b/apps/web/components/onboarding-dialog.tsx
@@ -87,7 +87,10 @@ function buildAgentSettings(
     const profile = dbAgent?.profiles?.[0];
     if (profile) {
       const perms = profileToPermissionsMap(
-        { allow_indexing: profile.allowIndexing },
+        {
+          allowIndexing: profile.allowIndexing,
+          autoApprove: profile.autoApprove,
+        },
         aa.permission_settings ?? {},
       );
       settings[aa.name] = {

--- a/apps/web/components/onboarding-dialog.tsx
+++ b/apps/web/components/onboarding-dialog.tsx
@@ -29,7 +29,7 @@ import {
 } from "@tabler/icons-react";
 import { Kbd } from "@kandev/ui/kbd";
 import { type ProfileFormData } from "@/components/settings/profile-form-fields";
-import { profileToPermissionsMap, permissionsToProfilePatch } from "@/lib/agent-permissions";
+import { permissionsToProfilePatch, profilePermissionValues } from "@/lib/agent-permissions";
 import { listAvailableAgents, listWorkflowTemplates } from "@/lib/api";
 import { listAgentsAction, updateAgentProfileAction } from "@/app/actions/agents";
 import { StepAgents, type AgentSetting } from "@/components/onboarding/step-agents";
@@ -86,7 +86,7 @@ function buildAgentSettings(
     const dbAgent = saved.find((a) => a.name === aa.name);
     const profile = dbAgent?.profiles?.[0];
     if (profile) {
-      const perms = profileToPermissionsMap(
+      const perms = profilePermissionValues(
         {
           allowIndexing: profile.allowIndexing,
           autoApprove: profile.autoApprove,

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -198,7 +198,10 @@ function useSyncAgentsToStore() {
   };
 }
 
-function useProfileEditorState(profile: AgentProfile) {
+function useProfileEditorState(
+  profile: AgentProfile,
+  permissionSettings: Record<string, PermissionSetting>,
+) {
   const [draft, setDraft] = useState<AgentProfile>({ ...profile });
   const [savedProfile, setSavedProfile] = useState<AgentProfile>(profile);
   const [saveStatus, setSaveStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
@@ -212,7 +215,7 @@ function useProfileEditorState(profile: AgentProfile) {
       draft.cliPassthrough !== savedProfile.cliPassthrough ||
       !areCLIFlagsEqual(draft.cliFlags ?? [], savedProfile.cliFlags ?? []) ||
       !areEnvVarsEqual(draft.envVars, savedProfile.envVars),
-    [draft, savedProfile],
+    [draft, savedProfile, permissionSettings],
   );
 
   return { draft, setDraft, savedProfile, setSavedProfile, saveStatus, setSaveStatus, isDirty };
@@ -465,7 +468,7 @@ function ProfileEditor({
   const syncAgentsToStore = useSyncAgentsToStore();
   const { items: secrets } = useSecrets();
   const { draft, setDraft, savedProfile, setSavedProfile, saveStatus, setSaveStatus, isDirty } =
-    useProfileEditorState(profile);
+    useProfileEditorState(profile, permissionSettings);
   const updateDraft = useCallback(
     (patch: Partial<AgentProfile>) => {
       setDraft((current) => {

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -12,6 +12,11 @@ import { Separator } from "@kandev/ui/separator";
 import { useToast } from "@/components/toast-provider";
 import { UnsavedChangesBadge, UnsavedSaveButton } from "@/components/settings/unsaved-indicator";
 import { ProfileFormFields, type ProfileFormData } from "@/components/settings/profile-form-fields";
+import {
+  arePermissionsDirty,
+  permissionsToProfilePatch,
+  profilePermissionValues,
+} from "@/lib/agent-permissions";
 import { toAgentProfilePatch } from "@/app/settings/agents/[agentId]/agent-save-helpers";
 import { deleteAgentProfileAction, updateAgentProfileAction } from "@/app/actions/agents";
 import type { ActiveSessionInfo } from "@/lib/types/agent-profile-errors";
@@ -140,6 +145,7 @@ function ProfileSettingsCard({
   const handleFormChange = (patch: Partial<ProfileFormData>) => {
     onDraftChange(toAgentProfilePatch(patch));
   };
+  const permissionValues = profilePermissionValues(draft, permissionSettings);
 
   return (
     <Card>
@@ -155,7 +161,8 @@ function ProfileSettingsCard({
             name: draft.name,
             model: draft.model,
             mode: draft.mode ?? "",
-            allow_indexing: draft.allowIndexing,
+            auto_approve: permissionValues.auto_approve,
+            allow_indexing: permissionValues.allow_indexing,
             cli_passthrough: draft.cliPassthrough,
             cli_flags: draft.cliFlags ?? [],
           }}
@@ -201,7 +208,7 @@ function useProfileEditorState(profile: AgentProfile) {
       draft.name !== savedProfile.name ||
       draft.model !== savedProfile.model ||
       (draft.mode ?? "") !== (savedProfile.mode ?? "") ||
-      draft.allowIndexing !== savedProfile.allowIndexing ||
+      arePermissionsDirty(draft, savedProfile, permissionSettings) ||
       draft.cliPassthrough !== savedProfile.cliPassthrough ||
       !areCLIFlagsEqual(draft.cliFlags ?? [], savedProfile.cliFlags ?? []) ||
       !areEnvVarsEqual(draft.envVars, savedProfile.envVars),
@@ -255,7 +262,7 @@ function useProfileSave({
         name: draft.name,
         model: draft.model,
         mode: draft.mode,
-        allow_indexing: draft.allowIndexing,
+        ...permissionsToProfilePatch(draft),
         cli_passthrough: draft.cliPassthrough,
         cli_flags: draft.cliFlags,
         env_vars: draft.envVars ?? [],

--- a/apps/web/components/settings/cli-flags-field.test.tsx
+++ b/apps/web/components/settings/cli-flags-field.test.tsx
@@ -40,14 +40,14 @@ describe("CLIFlagsField — curated toggles", () => {
       cli_flag: "-c",
       cli_flag_value: "approval_policy=never",
     };
-    render(
+    const { getByText } = render(
       <CLIFlagsField
         flags={[]}
         onChange={() => {}}
         permissionSettings={{ config_approval_policy_never: setting }}
       />,
     );
-    expect(screen.getByText("-c approval_policy=never")).toBeInTheDocument();
+    expect(getByText("-c approval_policy=never")).toBeTruthy();
   });
   it("renders curated switch as checked when no entry exists and default is true", () => {
     const { getByTestId } = render(

--- a/apps/web/components/settings/cli-flags-field.test.tsx
+++ b/apps/web/components/settings/cli-flags-field.test.tsx
@@ -30,6 +30,25 @@ afterEach(() => {
 });
 
 describe("CLIFlagsField — curated toggles", () => {
+  it("joins cli_flag and cli_flag_value for codex -c overrides", () => {
+    const setting: PermissionSetting = {
+      supported: true,
+      default: false,
+      label: "Skip approval prompts (config)",
+      description: "test",
+      apply_method: "cli_flag",
+      cli_flag: "-c",
+      cli_flag_value: "approval_policy=never",
+    };
+    render(
+      <CLIFlagsField
+        flags={[]}
+        onChange={() => {}}
+        permissionSettings={{ config_approval_policy_never: setting }}
+      />,
+    );
+    expect(screen.getByText("-c approval_policy=never")).toBeInTheDocument();
+  });
   it("renders curated switch as checked when no entry exists and default is true", () => {
     const { getByTestId } = render(
       <CLIFlagsField

--- a/apps/web/components/settings/cli-flags-field.tsx
+++ b/apps/web/components/settings/cli-flags-field.tsx
@@ -167,18 +167,27 @@ export function CLIFlagsField({
   );
 }
 
+function permissionSettingFlagText(s: PermissionSetting): string {
+  const flag = s.cli_flag?.trim() ?? "";
+  const value = s.cli_flag_value?.trim() ?? "";
+  if (!flag) return "";
+  return value ? `${flag} ${value}` : flag;
+}
+
 function extractCuratedSettings(
   permissionSettings?: Record<string, PermissionSetting>,
 ): CuratedSetting[] {
   if (!permissionSettings) return [];
   const out: CuratedSetting[] = [];
   for (const [key, s] of Object.entries(permissionSettings)) {
-    if (!s.supported || s.apply_method !== "cli_flag" || !s.cli_flag) continue;
+    if (!s.supported || s.apply_method !== "cli_flag") continue;
+    const flag = permissionSettingFlagText(s);
+    if (!flag) continue;
     out.push({
       key,
       label: s.label,
       description: s.description,
-      flag: s.cli_flag,
+      flag,
       default: s.default,
     });
   }

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -105,6 +105,7 @@ function PermissionToggleRow({
   const switchSize = compact ? ("sm" as const) : ("default" as const);
   const labelCls = compact ? "text-xs" : undefined;
   const wrapperCls = permissionToggleWrapperClass(isDanger, compact);
+  const switchId = `permission-toggle-${settingKey}`;
 
   return (
     <div
@@ -113,7 +114,7 @@ function PermissionToggleRow({
       data-testid={isDanger ? "permission-auto-approve-danger" : `permission-toggle-${settingKey}`}
     >
       <div className={`flex-1 min-w-0 ${compact && !isDanger ? "space-y-0.5" : "space-y-1"}`}>
-        <Label className={`flex items-center gap-1.5 ${labelCls ?? ""}`}>
+        <Label htmlFor={switchId} className={`flex items-center gap-1.5 ${labelCls ?? ""}`}>
           {isDanger && <IconAlertTriangle className="size-4 shrink-0 text-destructive" />}
           {setting.label}
         </Label>
@@ -127,7 +128,7 @@ function PermissionToggleRow({
           {setting.description}
         </p>
       </div>
-      <Switch size={switchSize} checked={checked} onCheckedChange={onCheckedChange} />
+      <Switch id={switchId} size={switchSize} checked={checked} onCheckedChange={onCheckedChange} />
     </div>
   );
 }

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -78,6 +78,16 @@ type PermissionToggleProps = {
   lockPassthrough?: boolean;
 };
 
+function permissionToggleWrapperClass(isDanger: boolean, compact: boolean): string {
+  if (isDanger) {
+    return "flex items-center justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/5 p-3";
+  }
+  if (compact) {
+    return "flex items-center justify-between gap-2";
+  }
+  return "flex items-center justify-between rounded-md border p-3";
+}
+
 function PermissionToggleRow({
   settingKey,
   setting,
@@ -94,11 +104,7 @@ function PermissionToggleRow({
   const isDanger = setting.apply_method === PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE;
   const switchSize = compact ? ("sm" as const) : ("default" as const);
   const labelCls = compact ? "text-xs" : undefined;
-  const wrapperCls = isDanger
-    ? "flex items-center justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/5 p-3"
-    : compact
-      ? "flex items-center justify-between gap-2"
-      : "flex items-center justify-between rounded-md border p-3";
+  const wrapperCls = permissionToggleWrapperClass(isDanger, compact);
 
   return (
     <div

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import {
   IconAlertCircle,
   IconAlertTriangle,
@@ -105,7 +106,8 @@ function PermissionToggleRow({
   const switchSize = compact ? ("sm" as const) : ("default" as const);
   const labelCls = compact ? "text-xs" : undefined;
   const wrapperCls = permissionToggleWrapperClass(isDanger, compact);
-  const switchId = `permission-toggle-${settingKey}`;
+  const instanceId = useId();
+  const switchId = `${instanceId}-permission-toggle-${settingKey}`;
 
   return (
     <div

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { IconAlertCircle, IconRefresh, IconTerminal2 } from "@tabler/icons-react";
+import {
+  IconAlertCircle,
+  IconAlertTriangle,
+  IconRefresh,
+  IconTerminal2,
+} from "@tabler/icons-react";
 import { NoAuthPanel, ProbingPanel } from "@/components/settings/profile-status-panels";
 import { Button } from "@kandev/ui/button";
 import {
@@ -19,7 +24,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { ModeCombobox } from "@/components/settings/mode-combobox";
 import { ModelCombobox } from "@/components/settings/model-combobox";
 import { useAgentCapabilities } from "@/hooks/domains/settings/use-dynamic-models";
-import { PERMISSION_KEYS, type PermissionKey } from "@/lib/agent-permissions";
+import {
+  PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE,
+  PERMISSION_KEYS,
+  readPermissionValue,
+  type PermissionKey,
+} from "@/lib/agent-permissions";
 import { CLIFlagsField } from "@/components/settings/cli-flags-field";
 import type {
   CLIFlag,
@@ -68,6 +78,54 @@ type PermissionToggleProps = {
   lockPassthrough?: boolean;
 };
 
+function PermissionToggleRow({
+  settingKey,
+  setting,
+  checked,
+  onCheckedChange,
+  compact,
+}: {
+  settingKey: string;
+  setting: PermissionSetting;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  compact: boolean;
+}) {
+  const isDanger = setting.apply_method === PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE;
+  const switchSize = compact ? ("sm" as const) : ("default" as const);
+  const labelCls = compact ? "text-xs" : undefined;
+  const wrapperCls = isDanger
+    ? "flex items-center justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/5 p-3"
+    : compact
+      ? "flex items-center justify-between gap-2"
+      : "flex items-center justify-between rounded-md border p-3";
+
+  return (
+    <div
+      key={settingKey}
+      className={wrapperCls}
+      data-testid={isDanger ? "permission-auto-approve-danger" : `permission-toggle-${settingKey}`}
+    >
+      <div className={`flex-1 min-w-0 ${compact && !isDanger ? "space-y-0.5" : "space-y-1"}`}>
+        <Label className={`flex items-center gap-1.5 ${labelCls ?? ""}`}>
+          {isDanger && <IconAlertTriangle className="size-4 shrink-0 text-destructive" />}
+          {setting.label}
+        </Label>
+        <p
+          className={
+            compact
+              ? "text-[10px] text-muted-foreground leading-tight"
+              : "text-xs text-muted-foreground"
+          }
+        >
+          {setting.description}
+        </p>
+      </div>
+      <Switch size={switchSize} checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}
+
 function PermissionToggles({
   profile,
   onChange,
@@ -87,19 +145,14 @@ function PermissionToggles({
           if (!setting?.supported) return null;
           if (setting.apply_method === "cli_flag") return null;
           return (
-            <div key={key} className="flex items-center justify-between gap-2">
-              <div className="space-y-0.5">
-                <Label className="text-xs">{setting.label}</Label>
-                <p className="text-[10px] text-muted-foreground leading-tight">
-                  {setting.description}
-                </p>
-              </div>
-              <Switch
-                size={switchSize}
-                checked={profile[key]}
-                onCheckedChange={(checked) => onChange({ [key]: checked })}
-              />
-            </div>
+            <PermissionToggleRow
+              key={key}
+              settingKey={key}
+              setting={setting}
+              checked={readPermissionValue(profile, key, permissionSettings)}
+              onCheckedChange={(checked) => onChange({ [key]: checked })}
+              compact
+            />
           );
         })}
         {passthroughConfig?.supported && (
@@ -129,16 +182,14 @@ function PermissionToggles({
         if (!setting?.supported) return null;
         if (setting.apply_method === "cli_flag") return null;
         return (
-          <div key={key} className="flex items-center justify-between rounded-md border p-3">
-            <div className="space-y-1">
-              <Label>{setting.label}</Label>
-              <p className="text-xs text-muted-foreground">{setting.description}</p>
-            </div>
-            <Switch
-              checked={profile[key]}
-              onCheckedChange={(checked) => onChange({ [key]: checked })}
-            />
-          </div>
+          <PermissionToggleRow
+            key={key}
+            settingKey={key}
+            setting={setting}
+            checked={readPermissionValue(profile, key, permissionSettings)}
+            onCheckedChange={(checked) => onChange({ [key]: checked })}
+            compact={false}
+          />
         );
       })}
       {passthroughConfig?.supported && (

--- a/apps/web/components/task/simple/components/agents-multi-picker.test.tsx
+++ b/apps/web/components/task/simple/components/agents-multi-picker.test.tsx
@@ -37,6 +37,7 @@ function makeAgent(id: string, name: string): AgentProfile {
     agentDisplayName: "Claude",
     model: "claude-sonnet-4-5",
     allowIndexing: false,
+    autoApprove: false,
     cliFlags: [],
     cliPassthrough: false,
     createdAt: TS,

--- a/apps/web/components/task/simple/components/pending-approval-badge.test.tsx
+++ b/apps/web/components/task/simple/components/pending-approval-badge.test.tsx
@@ -64,6 +64,7 @@ function makeAgent(id: string, name: string): AgentProfile {
     agentDisplayName: "Claude",
     model: "claude-sonnet-4-5",
     allowIndexing: false,
+    autoApprove: false,
     cliFlags: [],
     cliPassthrough: false,
     createdAt: TS,

--- a/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
@@ -4,9 +4,8 @@ import { SessionPage } from "../../pages/session-page";
 /**
  * Verifies the ACP-first profile editor:
  *
- * - Legacy permission toggles (`auto_approve`, `dangerously_skip_permissions`)
- *   are no longer rendered. They were removed when profile permission stance
- *   moved to ACP session modes + per-tool-call permission_request prompts.
+ * - Universal agentctl auto-approve toggle renders with danger styling.
+ * - Codex curated `-c` config toggles render (off by default).
  * - Profile name edits persist across reload (exercises the new AgentProfile
  *   DTO shape with `mode` / `migrated_from` columns).
  * - Mode picker renders when the agent's capability cache advertises modes.
@@ -15,7 +14,7 @@ import { SessionPage } from "../../pages/session-page";
  *   correct active mode after launching a task with a non-default profile mode.
  */
 test.describe("Agent profile — ACP-first", () => {
-  test("profile editor loads with model picker and without legacy permission toggles", async ({
+  test("profile editor loads with model picker and permission toggles", async ({
     testPage,
     apiClient,
   }) => {
@@ -30,14 +29,20 @@ test.describe("Agent profile — ACP-first", () => {
     // Profile name input is present (from the shared ProfileFormFields component).
     await expect(testPage.getByTestId("profile-name-input")).toBeVisible({ timeout: 15_000 });
 
-    // The old permission toggle labels must NOT render. These were backed by
-    // the removed AgentProfile.auto_approve and .dangerously_skip_permissions
-    // fields; the corresponding PermissionSetting entries are gone from the
-    // shared agents so the PermissionToggles iterator emits nothing for them.
-    await expect(testPage.getByText(/Auto-approve/i)).toHaveCount(0);
-    await expect(testPage.getByText(/YOLO/i)).toHaveCount(0);
+    await expect(testPage.getByTestId("permission-auto-approve-danger")).toBeVisible({
+      timeout: 10_000,
+    });
     await expect(testPage.getByText(/Skip Permissions/i)).toHaveCount(0);
     await expect(testPage.getByText(/dangerously skip/i)).toHaveCount(0);
+
+    if (agent.name === "codex-acp") {
+      await expect(
+        testPage.getByTestId("cli-flag-curated-config_approval_policy_never"),
+      ).toBeVisible();
+      await expect(
+        testPage.getByTestId("cli-flag-curated-config_sandbox_disk_full_read"),
+      ).toBeVisible();
+    }
 
     // The mock agent advertises modes, so the mode picker is rendered.
     await expect(testPage.getByTestId("profile-mode-field")).toBeVisible({ timeout: 10_000 });

--- a/apps/web/lib/agent-permissions.test.ts
+++ b/apps/web/lib/agent-permissions.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  arePermissionsDirty,
+  permissionsToProfilePatch,
+  profilePermissionValues,
+  readPermissionValue,
+} from "./agent-permissions";
+
+describe("readPermissionValue", () => {
+  it("prefers camelCase over stale snake_case defaults", () => {
+    expect(
+      readPermissionValue({ auto_approve: false, autoApprove: true }, "auto_approve", {}),
+    ).toBe(true);
+  });
+
+  it("falls back to snake_case when camelCase is absent", () => {
+    expect(readPermissionValue({ auto_approve: true }, "auto_approve", {})).toBe(true);
+  });
+});
+
+describe("permissionsToProfilePatch", () => {
+  it("reads camelCase draft fields for API payload", () => {
+    expect(permissionsToProfilePatch({ autoApprove: true, allowIndexing: false })).toEqual({
+      auto_approve: true,
+      allow_indexing: false,
+    });
+  });
+});
+
+describe("arePermissionsDirty", () => {
+  it("detects camelCase permission edits", () => {
+    expect(arePermissionsDirty({ autoApprove: true }, { autoApprove: false })).toBe(true);
+  });
+});
+
+describe("profilePermissionValues", () => {
+  it("normalizes mixed shapes to snake_case", () => {
+    expect(profilePermissionValues({ autoApprove: true, allow_indexing: false })).toEqual({
+      auto_approve: true,
+      allow_indexing: false,
+    });
+  });
+});

--- a/apps/web/lib/agent-permissions.ts
+++ b/apps/web/lib/agent-permissions.ts
@@ -71,9 +71,10 @@ export function permissionsToProfilePatch(
 }
 
 /** Canonical camelCase defaults for new AgentProfile / DraftProfile rows. */
-export function buildDefaultPermissions(
-  permissionSettings: Record<string, PermissionSetting>,
-): Pick<PermissionProfileInput, "autoApprove" | "allowIndexing"> {
+export function buildDefaultPermissions(permissionSettings: Record<string, PermissionSetting>): {
+  autoApprove: boolean;
+  allowIndexing: boolean;
+} {
   const perms = profilePermissionValues({}, permissionSettings);
   return {
     autoApprove: perms.auto_approve,

--- a/apps/web/lib/agent-permissions.ts
+++ b/apps/web/lib/agent-permissions.ts
@@ -1,61 +1,96 @@
 import type { PermissionSetting } from "@/lib/types/http";
 
 /**
- * Permission keys retained on the frontend. After the ACP-first migration the
- * only surviving CLI-flag-driven permission is auggie's `allow_indexing` — all
- * other agents express permission stance through ACP session modes (rendered
- * as a separate Mode picker) and the interactive permission_request message UI.
+ * Profile permission keys (snake_case) mirrored from backend PermissionSettings.
  *
- * Keys are kept in **snake_case wire format** because they pass straight
- * through to backend permission-payload bodies and the `permissionSettings`
- * map keyed by snake_case agent metadata.
+ * - `auto_approve`: Kandev agentctl auto-allows ACP permission_request frames
+ *   (all agents via CatalogPermissionSettings).
+ * - `allow_indexing`: legacy auggie CLI flag still exposed on its profile form.
  */
-export const PERMISSION_KEYS = ["allow_indexing"] as const;
+export const PERMISSION_KEYS = ["auto_approve", "allow_indexing"] as const;
+
+/** apply_method sentinel for the universal agentctl auto-approve toggle. */
+export const PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE = "agentctl_auto_approve";
 
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];
 
-/** Extract permission booleans from a profile-like (snake_case) object. */
+/** Profile-shaped input that may carry permissions in snake_case or camelCase. */
+export type PermissionProfileInput = Partial<Record<PermissionKey, boolean>> & {
+  autoApprove?: boolean;
+  allowIndexing?: boolean;
+};
+
+const CAMEL_BY_KEY: Record<PermissionKey, "autoApprove" | "allowIndexing"> = {
+  auto_approve: "autoApprove",
+  allow_indexing: "allowIndexing",
+};
+
+/**
+ * Read one permission boolean, preferring camelCase (canonical AgentProfile)
+ * over snake_case (form wire keys) so toggles never lose to stale defaults.
+ */
+export function readPermissionValue(
+  profile: PermissionProfileInput,
+  key: PermissionKey,
+  permissionSettings: Record<string, PermissionSetting> = {},
+): boolean {
+  const camelKey = CAMEL_BY_KEY[key];
+  const camelVal = profile[camelKey];
+  if (typeof camelVal === "boolean") return camelVal;
+  const snakeVal = profile[key];
+  if (typeof snakeVal === "boolean") return snakeVal;
+  return permissionSettings[key]?.default ?? false;
+}
+
+/** Normalized snake_case permission map for forms and API payloads. */
+export function profilePermissionValues(
+  profile: PermissionProfileInput,
+  permissionSettings: Record<string, PermissionSetting> = {},
+): Record<PermissionKey, boolean> {
+  const result = {} as Record<PermissionKey, boolean>;
+  for (const key of PERMISSION_KEYS) {
+    result[key] = readPermissionValue(profile, key, permissionSettings);
+  }
+  return result;
+}
+
+/** @deprecated Use profilePermissionValues — kept for call-site compatibility. */
 export function profileToPermissionsMap(
-  profile: Partial<Record<PermissionKey, boolean>>,
+  profile: PermissionProfileInput,
   permissionSettings: Record<string, PermissionSetting>,
 ): Record<PermissionKey, boolean> {
-  const result = {} as Record<PermissionKey, boolean>;
-  for (const key of PERMISSION_KEYS) {
-    const setting = permissionSettings[key];
-    result[key] = profile[key] ?? setting?.default ?? false;
-  }
-  return result;
+  return profilePermissionValues(profile, permissionSettings);
 }
 
-/** Convert an object containing permission keys to a typed patch for API calls. */
+/** Snake_case permission fields for create/update profile API bodies. */
 export function permissionsToProfilePatch(
-  perms: Partial<Record<PermissionKey, boolean>>,
+  profile: PermissionProfileInput,
+  permissionSettings: Record<string, PermissionSetting> = {},
 ): Record<PermissionKey, boolean> {
-  const result = {} as Record<PermissionKey, boolean>;
-  for (const key of PERMISSION_KEYS) {
-    result[key] = perms[key] ?? false;
-  }
-  return result;
+  return profilePermissionValues(profile, permissionSettings);
 }
 
-/** Create default permission values from backend metadata. */
+/** Canonical camelCase defaults for new AgentProfile / DraftProfile rows. */
 export function buildDefaultPermissions(
   permissionSettings: Record<string, PermissionSetting>,
-): Record<PermissionKey, boolean> {
-  const result = {} as Record<PermissionKey, boolean>;
-  for (const key of PERMISSION_KEYS) {
-    result[key] = permissionSettings[key]?.default ?? false;
-  }
-  return result;
+): Pick<PermissionProfileInput, "autoApprove" | "allowIndexing"> {
+  const perms = profilePermissionValues({}, permissionSettings);
+  return {
+    autoApprove: perms.auto_approve,
+    allowIndexing: perms.allow_indexing,
+  };
 }
 
-/** Compare permission fields between two snake_case permission-bearing objects. */
+/** Compare permission fields between two profile-shaped objects. */
 export function arePermissionsDirty(
-  draft: Partial<Record<PermissionKey, boolean>>,
-  saved: Partial<Record<PermissionKey, boolean>>,
+  draft: PermissionProfileInput,
+  saved: PermissionProfileInput,
+  permissionSettings: Record<string, PermissionSetting> = {},
 ): boolean {
+  const draftPerms = profilePermissionValues(draft, permissionSettings);
+  const savedPerms = profilePermissionValues(saved, permissionSettings);
   for (const key of PERMISSION_KEYS) {
-    if (draft[key] !== saved[key]) return true;
+    if (draftPerms[key] !== savedPerms[key]) return true;
   }
   return false;
 }

--- a/apps/web/lib/api/domains/agent-profile-normalize.test.ts
+++ b/apps/web/lib/api/domains/agent-profile-normalize.test.ts
@@ -14,6 +14,7 @@ describe("normalizeAgentProfile", () => {
       model: "claude-sonnet-4-5",
       mode: "acp",
       allow_indexing: true,
+      auto_approve: false,
       cli_flags: [{ flag: "--verbose", description: "v", enabled: true }],
       env_vars: [sampleEnvVar],
       cli_passthrough: false,
@@ -30,6 +31,7 @@ describe("normalizeAgentProfile", () => {
       model: "claude-sonnet-4-5",
       mode: "acp",
       allowIndexing: true,
+      autoApprove: false,
       cliFlags: [{ flag: "--verbose", description: "v", enabled: true }],
       envVars: [sampleEnvVar],
       cliPassthrough: false,
@@ -45,6 +47,7 @@ describe("normalizeAgentProfile", () => {
     expect(result.envVars).toEqual([]);
     expect(result.cliPassthrough).toBe(false);
     expect(result.allowIndexing).toBe(false);
+    expect(result.autoApprove).toBe(false);
     expect(result.agentDisplayName).toBe("");
   });
 

--- a/apps/web/lib/api/domains/agent-profile-normalize.ts
+++ b/apps/web/lib/api/domains/agent-profile-normalize.ts
@@ -47,6 +47,7 @@ export function normalizeAgentProfile(raw: unknown): AgentProfile {
     model: pickString(profile, "model", "model"),
     mode: (profile.mode as string | undefined) ?? undefined,
     allowIndexing: pickBool(profile, "allowIndexing", "allow_indexing"),
+    autoApprove: pickBool(profile, "autoApprove", "auto_approve"),
     cliFlags: pickFlags(profile),
     envVars: pickEnvVars(profile),
     cliPassthrough: pickBool(profile, "cliPassthrough", "cli_passthrough"),
@@ -71,6 +72,7 @@ export function toAgentProfilePayload(
   if (profile.model !== undefined) payload.model = profile.model;
   if (profile.mode !== undefined) payload.mode = profile.mode;
   if (profile.allowIndexing !== undefined) payload.allow_indexing = profile.allowIndexing;
+  if (profile.autoApprove !== undefined) payload.auto_approve = profile.autoApprove;
   if (profile.cliFlags !== undefined) payload.cli_flags = profile.cliFlags;
   if (profile.envVars !== undefined) payload.env_vars = profile.envVars;
   if (profile.cliPassthrough !== undefined) payload.cli_passthrough = profile.cliPassthrough;

--- a/apps/web/lib/api/domains/office-api.ts
+++ b/apps/web/lib/api/domains/office-api.ts
@@ -170,6 +170,7 @@ function normalizeAgent(raw: unknown): AgentProfile {
     model: stringField(agent, "model", "model"),
     mode: (rawField(agent, "mode", "mode") as string | undefined) ?? undefined,
     allowIndexing: boolField(agent, "allowIndexing", "allow_indexing"),
+    autoApprove: boolField(agent, "autoApprove", "auto_approve"),
     cliFlags: parseJSONField<CLIFlag[]>(rawField(agent, "cliFlags", "cli_flags"), []),
     cliPassthrough: boolField(agent, "cliPassthrough", "cli_passthrough"),
     userModified: rawField(agent, "userModified", "user_modified") as boolean | undefined,

--- a/apps/web/lib/api/domains/office-api.ts
+++ b/apps/web/lib/api/domains/office-api.ts
@@ -186,7 +186,7 @@ function stringifyJSONField(value: unknown): string | undefined {
 }
 
 function agentPayload(data: Partial<AgentProfile>): Record<string, unknown> {
-  return {
+  const payload: Record<string, unknown> = {
     name: data.name,
     agent_profile_id: data.agentProfileId,
     role: data.role,
@@ -199,6 +199,25 @@ function agentPayload(data: Partial<AgentProfile>): Record<string, unknown> {
     executor_preference: stringifyJSONField(data.executorPreference),
     skill_ids: stringifyJSONField(data.skillIds),
   };
+  if (data.autoApprove !== undefined) {
+    payload.auto_approve = data.autoApprove;
+  }
+  if (data.allowIndexing !== undefined) {
+    payload.allow_indexing = data.allowIndexing;
+  }
+  if (data.cliPassthrough !== undefined) {
+    payload.cli_passthrough = data.cliPassthrough;
+  }
+  if (data.cliFlags !== undefined) {
+    payload.cli_flags = data.cliFlags;
+  }
+  if (data.model !== undefined) {
+    payload.model = data.model;
+  }
+  if (data.mode !== undefined) {
+    payload.mode = data.mode;
+  }
+  return payload;
 }
 
 // --- Agent Instances ---

--- a/apps/web/lib/api/domains/office-api.ts
+++ b/apps/web/lib/api/domains/office-api.ts
@@ -208,15 +208,6 @@ function agentPayload(data: Partial<AgentProfile>): Record<string, unknown> {
   if (data.cliPassthrough !== undefined) {
     payload.cli_passthrough = data.cliPassthrough;
   }
-  if (data.cliFlags !== undefined) {
-    payload.cli_flags = data.cliFlags;
-  }
-  if (data.model !== undefined) {
-    payload.model = data.model;
-  }
-  if (data.mode !== undefined) {
-    payload.mode = data.mode;
-  }
   return payload;
 }
 

--- a/apps/web/lib/state/slices/office/office-agents.test.ts
+++ b/apps/web/lib/state/slices/office/office-agents.test.ts
@@ -25,6 +25,7 @@ function makeAgent(id: string, name: string): AgentProfile {
     agentDisplayName: "Claude",
     model: "claude-sonnet-4-5",
     allowIndexing: false,
+    autoApprove: false,
     cliFlags: [],
     cliPassthrough: false,
     createdAt: "2026-01-01T00:00:00Z",

--- a/apps/web/lib/types/agent-profile.ts
+++ b/apps/web/lib/types/agent-profile.ts
@@ -67,6 +67,8 @@ export type AgentProfile = {
   mode?: string;
   /** @deprecated Use cliFlags. Retained for legacy clients. */
   allowIndexing: boolean;
+  /** Kandev agentctl auto-approves ACP permission_request prompts when true. */
+  autoApprove: boolean;
   /** User-configurable CLI flags passed to the agent subprocess. */
   cliFlags: CLIFlag[];
   /** Environment variables injected when this profile starts an agent session. */
@@ -137,6 +139,7 @@ export type AgentProfilePayload = {
   model: string;
   mode?: string;
   allow_indexing: boolean;
+  auto_approve: boolean;
   cli_flags: CLIFlag[];
   env_vars?: ProfileEnvVar[];
   cli_passthrough: boolean;


### PR DESCRIPTION
Codex ACP launches were failing because passthrough-only flags like `--ask-for-approval never` were seeded into profile `cli_flags` and appended to `@zed-industries/codex-acp`, which only accepts `-c` overrides. This change separates passthrough argv from ACP launch, adds a universal agentctl auto-approve profile toggle, and fixes permission UI state so toggles no longer revert on save.

## Important Changes

- Codex: `PermissionSettings()` returns `-c` config toggles only; passthrough flags stay on `@openai/codex` via `codexPassthroughPermSettings`.
- All agents: catalog adds `auto_approve` with `agentctl_auto_approve` (env at launch), persisted on profiles via API.
- Cursor: `--force` moves to `cursor_force` cli_flag seeding; `auto_approve` no longer appends `--force` on `BuildCommand`.
- Web: `readPermissionValue` prefers camelCase; Office/cli profile editor exposes the danger auto-approve row.

## Validation

- `make -C apps/backend fmt lint`
- `go test ./internal/agent/agents/... ./internal/agent/settings/controller/...`
- Prettier ran via pre-commit on staged web files

## Possible Improvements

Medium — existing Codex profiles may still have legacy `--ask-for-approval never` in `cli_flags`; users should disable that row manually until a migration exists.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)