### PR TITLE
feat(web): make chat reverse-i-search shortcut configurable

### DIFF
--- a/apps/web/components/task/chat/tiptap-editor-history.ts
+++ b/apps/web/components/task/chat/tiptap-editor-history.ts
@@ -3,6 +3,8 @@ import type { useEditor } from "@tiptap/react";
 import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { matchesShortcut } from "@/lib/keyboard/utils";
+import { getShortcut, type StoredShortcutOverrides } from "@/lib/keyboard/shortcut-overrides";
 import { navigateHistory, type HistoryState } from "./message-history";
 import { getMarkdownText, textToHtml } from "./tiptap-helpers";
 
@@ -46,6 +48,7 @@ export type HistoryKeymapRefs = {
   getHistoryRef: React.RefObject<() => readonly string[]>;
   onOpenReverseSearchRef: React.RefObject<(() => void) | undefined>;
   onChangeRef: React.RefObject<(value: string) => void>;
+  keyboardShortcutsRef: React.RefObject<StoredShortcutOverrides | undefined>;
 };
 
 export type HistoryNavController = {
@@ -129,7 +132,8 @@ function reverseSearchPlugin(state: HistoryRuntimeState, refs: HistoryKeymapRefs
     props: {
       handleKeyDown: (_view, event) => {
         if (refs.disabledRef.current) return false;
-        if (event.ctrlKey && !event.metaKey && !event.altKey && event.key.toLowerCase() === "r") {
+        const shortcut = getShortcut("REVERSE_SEARCH", refs.keyboardShortcutsRef.current);
+        if (matchesShortcut(event, shortcut)) {
           event.preventDefault();
           refs.onOpenReverseSearchRef.current?.();
           return true;

--- a/apps/web/components/task/chat/use-tiptap-editor.ts
+++ b/apps/web/components/task/chat/use-tiptap-editor.ts
@@ -265,6 +265,7 @@ export function useTipTapEditor(opts: UseTipTapEditorOptions) {
     getHistoryRef: refs.getHistoryRef,
     onOpenReverseSearchRef: refs.onOpenReverseSearchRef,
     onChangeRef: refs.onChangeRef,
+    keyboardShortcutsRef: refs.keyboardShortcutsRef,
   });
   const isSyncingRef = useRef(false);
   const initialSyncDoneRef = useRef(false);

--- a/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
+++ b/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
@@ -20,6 +20,7 @@ test.describe("Keyboard Shortcuts Settings", () => {
     await expect(testPage.getByTestId("shortcut-recorder-TOGGLE_PLAN_MODE")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-TASK_SWITCHER")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-TASK_SWITCHER_REVERSE")).toBeVisible();
+    await expect(testPage.getByTestId("shortcut-recorder-REVERSE_SEARCH")).toBeVisible();
   });
 
   test("can record a new shortcut and persist it", async ({ testPage, apiClient, seedData }) => {

--- a/apps/web/lib/keyboard/constants.ts
+++ b/apps/web/lib/keyboard/constants.ts
@@ -165,4 +165,11 @@ export const SHORTCUTS = {
     key: KEYS.M,
     modifiers: { ctrlOrCmd: true, shift: true },
   },
+  // Ctrl+R opens the bash-style reverse-i-search overlay on the chat composer.
+  // Defaults to plain Ctrl (not ctrlOrCmd) so the Mac browser refresh shortcut
+  // Cmd+R keeps working out of the box.
+  REVERSE_SEARCH: {
+    key: KEYS.R,
+    modifiers: { ctrl: true },
+  },
 } as const;

--- a/apps/web/lib/keyboard/shortcut-overrides.test.ts
+++ b/apps/web/lib/keyboard/shortcut-overrides.test.ts
@@ -22,7 +22,8 @@ describe("CONFIGURABLE_SHORTCUTS", () => {
     expect(ids).toContain("TASK_SWITCHER");
     expect(ids).toContain("TASK_SWITCHER_REVERSE");
     expect(ids).toContain("VOICE_INPUT_TOGGLE");
-    expect(ids).toHaveLength(12);
+    expect(ids).toContain("REVERSE_SEARCH");
+    expect(ids).toHaveLength(13);
   });
 
   it("each entry has a label and default matching SHORTCUTS", () => {
@@ -53,6 +54,9 @@ describe("CONFIGURABLE_SHORTCUTS", () => {
     expect(CONFIGURABLE_SHORTCUTS.TASK_SWITCHER_REVERSE.default).toBe(
       SHORTCUTS.TASK_SWITCHER_REVERSE,
     );
+
+    expect(CONFIGURABLE_SHORTCUTS.REVERSE_SEARCH.label).toBe("Reverse Chat Search");
+    expect(CONFIGURABLE_SHORTCUTS.REVERSE_SEARCH.default).toBe(SHORTCUTS.REVERSE_SEARCH);
   });
 });
 

--- a/apps/web/lib/keyboard/shortcut-overrides.ts
+++ b/apps/web/lib/keyboard/shortcut-overrides.ts
@@ -12,7 +12,8 @@ export type ConfigurableShortcutId =
   | "TOGGLE_PLAN_MODE"
   | "TASK_SWITCHER"
   | "TASK_SWITCHER_REVERSE"
-  | "VOICE_INPUT_TOGGLE";
+  | "VOICE_INPUT_TOGGLE"
+  | "REVERSE_SEARCH";
 
 export type StoredShortcutOverrides = Record<
   string,
@@ -38,6 +39,7 @@ export const CONFIGURABLE_SHORTCUTS: Record<
     default: SHORTCUTS.TASK_SWITCHER_REVERSE,
   },
   VOICE_INPUT_TOGGLE: { label: "Voice Input", default: SHORTCUTS.VOICE_INPUT_TOGGLE },
+  REVERSE_SEARCH: { label: "Reverse Chat Search", default: SHORTCUTS.REVERSE_SEARCH },
 };
 
 export function getShortcut(


### PR DESCRIPTION
Ctrl+R for the bash-style reverse-i-search overlay on the chat composer was hardcoded in the TipTap ProseMirror plugin, so users could not rebind it from Settings → Shortcuts. Registering it in the shared shortcut registry brings it inline with every other configurable shortcut and unblocks customisation.

## Important Changes
- `REVERSE_SEARCH` added to `SHORTCUTS` and `CONFIGURABLE_SHORTCUTS` registries (default `Ctrl+R`, plain `ctrl: true` so macOS `Cmd+R` browser refresh still works).
- `tiptap-editor-history.ts` reverse-search plugin now resolves the binding via `getShortcut("REVERSE_SEARCH", overrides)` + `matchesShortcut`, threaded through a new `keyboardShortcutsRef` on `HistoryKeymapRefs`.
- Settings page auto-picks up the new entry — it iterates `CONFIGURABLE_SHORTCUTS`.

## Validation
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web test -- --run components/task/chat/use-tiptap-editor.test.ts` (19 passed)
- `pnpm --filter @kandev/web lint`

## Checklist
- [ ] Tested on Mac (`Cmd+R` still reloads the browser, `Ctrl+R` opens reverse search)
- [ ] Tested rebinding via Settings → Shortcuts and verified persistence across reload