### PR TITLE
fix(web): stop refetching GitLab status on every tab refocus

### DIFF
--- a/apps/web/hooks/domains/gitlab/use-task-mr.test.ts
+++ b/apps/web/hooks/domains/gitlab/use-task-mr.test.ts
@@ -219,13 +219,17 @@ describe("useGitLabAvailable", () => {
     expect(result.current).toBe(false);
   });
 
-  it("re-probes when the window regains focus", async () => {
+  it("does not re-probe when the window regains focus", async () => {
+    // Regression guard: previously the hook re-fetched on every focus event,
+    // which hammered GET /api/v1/gitlab/status on every browser tab switch.
     fetchGitLabStatusMock.mockResolvedValue(makeStatus());
     renderHook(() => useGitLabAvailable(), { wrapper });
     await waitFor(() => expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(1));
     act(() => {
       window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("focus"));
     });
-    await waitFor(() => expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(2));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchGitLabStatusMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/hooks/domains/gitlab/use-task-mr.ts
+++ b/apps/web/hooks/domains/gitlab/use-task-mr.ts
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { fetchGitLabStatus, listWorkspaceTaskMRs } from "@/lib/api/domains/gitlab-api";
+import { useEffect, useRef } from "react";
+import { listWorkspaceTaskMRs } from "@/lib/api/domains/gitlab-api";
 import { useAppStore } from "@/components/state-provider";
 import type { TaskMR } from "@/lib/types/gitlab";
+import { useGitLabStatus } from "./use-gitlab-status";
 
 /**
  * Hydrate the gitlab task-MRs slice for a workspace. Fetches once per
@@ -58,30 +59,11 @@ export function useTaskMRs(taskId: string | null): TaskMR[] {
 /**
  * Returns whether GitLab is configured enough to surface in the integrations
  * menu. Token-configured or authenticated counts as "available" — same bar
- * as useGitHubStatus's `ready` flag. Probes /status on mount + after window
- * regains focus so settings changes propagate without a hard reload.
+ * as useGitHubStatus's `ready` flag. Backed by the store-cached
+ * useGitLabStatus hook, so multiple consumers share a single fetch and the
+ * status doesn't re-probe on every window focus.
  */
 export function useGitLabAvailable(): boolean {
-  const [available, setAvailable] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    const probe = () => {
-      // `cache` MUST be top-level — fetchJson reads options.cache directly
-      // and overwrites init.cache with undefined. See lib/api/client.ts.
-      fetchGitLabStatus({ cache: "no-store" })
-        .then((s) => {
-          if (!cancelled) setAvailable(Boolean(s?.authenticated || s?.token_configured));
-        })
-        .catch(() => {
-          if (!cancelled) setAvailable(false);
-        });
-    };
-    probe();
-    window.addEventListener("focus", probe);
-    return () => {
-      cancelled = true;
-      window.removeEventListener("focus", probe);
-    };
-  }, []);
-  return available;
+  const { status } = useGitLabStatus();
+  return Boolean(status?.authenticated || status?.token_configured);
 }


### PR DESCRIPTION
`useGitLabAvailable` registered a `window.addEventListener("focus", probe)` that re-fired `GET /api/v1/gitlab/status` on every browser tab switch back to kandev. Because `IntegrationsMenu` mounts globally in the topbar, the hammer was site-wide.

## Important Changes

- Route `useGitLabAvailable` through the store-cached `useGitLabStatus` hook. Consumers share a single fetch; the status no longer re-probes on window focus.
- Matches the `useGitHubStatus` pattern (single store-cached fetch). Jira/Linear use the 90s `setInterval` in `useIntegrationAuthed` and were not affected by this bug.
- Settings page already calls `reload()` after token changes, so propagation still works without the focus listener.

## Validation

- `pnpm --filter @kandev/web test -- hooks/domains/gitlab` — 11 pass
- `pnpm --filter @kandev/web test -- components/integrations` — 12 pass
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `make -C apps/backend fmt test lint`

## Possible Improvements

Settings page still wires its own `fetchGitLabStatus` instead of going through the store-cached hook — a follow-up could converge those, but it is out of scope for this fix.

## Checklist

- [ ] Tests added / updated
- [ ] Docs updated (if needed)
- [ ] No regressions in related areas