### PR TITLE
fix(agentctl): unblock next prompt when agent does not acknowledge cancel

### DIFF
--- a/apps/backend/internal/agent/runtime/agentctl/agent.go
+++ b/apps/backend/internal/agent/runtime/agentctl/agent.go
@@ -497,8 +497,9 @@ func (c *Client) CloseUpdatesStream() {
 
 // CancelResponse is the response from the agentctl cancel endpoint.
 type CancelResponse struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
+	Success         bool   `json:"success"`
+	Error           string `json:"error,omitempty"`
+	NotAcknowledged bool   `json:"not_acknowledged,omitempty"`
 }
 
 // Cancel interrupts the current agent turn via the agent WebSocket stream.
@@ -521,6 +522,9 @@ func (c *Client) Cancel(ctx context.Context) error {
 		return fmt.Errorf("failed to parse cancel response: %w", err)
 	}
 	if !result.Success {
+		if result.NotAcknowledged {
+			return fmt.Errorf("%w: %s", ErrTurnCancelNotAcknowledged, result.Error)
+		}
 		return fmt.Errorf("cancel failed: %s", result.Error)
 	}
 	return nil

--- a/apps/backend/internal/agent/runtime/agentctl/errors.go
+++ b/apps/backend/internal/agent/runtime/agentctl/errors.go
@@ -1,0 +1,9 @@
+package client
+
+import (
+	acptransport "github.com/kandev/kandev/internal/agentctl/server/adapter/transport/acp"
+)
+
+// ErrTurnCancelNotAcknowledged means the agent did not end the in-flight prompt
+// after a cancel request within the join window.
+var ErrTurnCancelNotAcknowledged = acptransport.ErrTurnCancelNotAcknowledged

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/executor"
+	agentctlclient "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agent/runtime/routingerr"
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
@@ -92,7 +93,7 @@ func (m *Manager) PromptAgent(ctx context.Context, executionID string, prompt st
 }
 
 // cancelWaitTimeout bounds how long CancelAgent waits for the in-flight SendPrompt
-// to exit after the ACP cancel was acknowledged by the agent.
+// to exit after the in-flight session/prompt RPC has ended (cancel acknowledged).
 // Exposed as a var (not const) so tests can shorten it without fake clocks.
 var cancelWaitTimeout = 10 * time.Second
 
@@ -125,11 +126,12 @@ func (m *Manager) CancelAgent(ctx context.Context, executionID string) error {
 		zap.String("task_id", execution.TaskID),
 		zap.String("session_id", execution.SessionID))
 
-	if err := execution.agentctl.Cancel(ctx); err != nil {
+	cancelErr := execution.agentctl.Cancel(ctx)
+	if cancelErr != nil && !errors.Is(cancelErr, agentctlclient.ErrTurnCancelNotAcknowledged) {
 		m.logger.Error("failed to cancel agent turn",
 			zap.String("execution_id", executionID),
-			zap.Error(err))
-		return fmt.Errorf("failed to cancel agent: %w", err)
+			zap.Error(cancelErr))
+		return fmt.Errorf("failed to cancel agent: %w", cancelErr)
 	}
 
 	// Don't clear buffers or mark ready here.
@@ -137,11 +139,6 @@ func (m *Manager) CancelAgent(ctx context.Context, executionID string) error {
 	// which triggers handleCompleteEvent() to properly flush buffers and mark state.
 	// Clearing here would race with in-flight notifications and lose content.
 
-	m.logger.Info("agent cancel sent, waiting for turn completion",
-		zap.String("execution_id", executionID))
-
-	// Wait for the in-flight SendPrompt to finish processing the cancel completion.
-	// Without this, a follow-up PromptAgent races on promptDoneCh with two readers.
 	execution.promptFinishedMu.Lock()
 	ch := execution.promptFinished
 	execution.promptFinishedMu.Unlock()
@@ -150,6 +147,21 @@ func (m *Manager) CancelAgent(ctx context.Context, executionID string) error {
 		return nil
 	}
 
+	// The agent did not end the in-flight session/prompt RPC after cancel (e.g. it
+	// does not implement session/cancel). Escalate immediately so SendPrompt and the
+	// prompt gate are reconciled instead of waiting the full cancelWaitTimeout.
+	if errors.Is(cancelErr, agentctlclient.ErrTurnCancelNotAcknowledged) {
+		m.logger.Warn("agent cancel not acknowledged; escalating immediately",
+			zap.String("execution_id", executionID),
+			zap.Error(cancelErr))
+		return m.escalateStuckCancel(ctx, execution, ch)
+	}
+
+	m.logger.Info("agent cancel sent, waiting for turn completion",
+		zap.String("execution_id", executionID))
+
+	// Wait for the in-flight SendPrompt to finish processing the cancel completion.
+	// Without this, a follow-up PromptAgent races on promptDoneCh with two readers.
 	select {
 	case <-ch:
 		m.logger.Debug("in-flight prompt finished after cancel",

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter.go
@@ -192,6 +192,11 @@ type Adapter struct {
 	mu     sync.RWMutex
 	closed bool
 
+	// promptTurn tracks the in-flight session/prompt RPC so Cancel can interrupt it
+	// and wait for acknowledgment before reporting success.
+	promptTurnMu sync.Mutex
+	promptTurn   *promptTurnState
+
 	// promptGate is a 1-slot semaphore that serializes session/prompt calls so
 	// at most one is in flight against the bridge at a time. The ScheduleWakeup
 	// path injects a synthetic prompt via fireWakeup; without this gate it can
@@ -211,6 +216,17 @@ type Adapter struct {
 	lifetimeCtx    context.Context
 	lifetimeCancel context.CancelFunc
 }
+
+// promptTurnState holds synchronization for one in-flight session/prompt RPC.
+type promptTurnState struct {
+	endTurn context.CancelCauseFunc
+	rpcDone chan struct{}
+	abortCh chan struct{}
+}
+
+// promptCancelJoinTimeout bounds how long Cancel and sendPrompt wait for a stuck
+// session/prompt RPC to end after a user cancel. Exposed as a var for tests.
+var promptCancelJoinTimeout = 3 * time.Second
 
 // NewAdapter creates a new ACP protocol adapter.
 // Call Connect() after starting the subprocess to wire up stdin/stdout.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
@@ -105,12 +105,14 @@ func (a *Adapter) sendPrompt(ctx context.Context, message string, attachments []
 	}
 
 	// Start prompt span — notification spans become children via getPromptTraceCtx()
-	promptCtx, promptSpan := shared.TraceProtocolRequest(ctx, shared.ProtocolACP, a.agentID, "prompt")
+	traceCtx, promptSpan := shared.TraceProtocolRequest(ctx, shared.ProtocolACP, a.agentID, "prompt")
 	promptSpan.SetAttributes(
 		attribute.String("session_id", sessionID),
 		attribute.Int("prompt_length", len(finalMessage)),
 		attribute.Int("image_count", len(attachments)),
 	)
+	promptCtx, turn := a.registerPromptTurn(traceCtx)
+	defer a.clearPromptTurn(turn)
 	a.setPromptTraceCtx(promptCtx)
 
 	// Clear the loading flag before sending the prompt.
@@ -130,10 +132,22 @@ func (a *Adapter) sendPrompt(ctx context.Context, message string, attachments []
 		zap.Int("content_blocks", len(contentBlocks)),
 		zap.Int("image_attachments", len(attachments)))
 
-	resp, err := conn.Prompt(promptCtx, acp.PromptRequest{
-		SessionId: acp.SessionId(sessionID),
-		Prompt:    contentBlocks,
-	})
+	var resp acp.PromptResponse
+	var err error
+	go func() {
+		defer close(turn.rpcDone)
+		resp, err = conn.Prompt(promptCtx, acp.PromptRequest{
+			SessionId: acp.SessionId(sessionID),
+			Prompt:    contentBlocks,
+		})
+	}()
+
+	if waitErr := a.waitForPromptRPCAfterUserCancel(turn); waitErr != nil {
+		promptSpan.RecordError(waitErr)
+		promptSpan.End()
+		a.clearPromptTraceCtx()
+		return waitErr
+	}
 
 	// Clear prompt context and end span regardless of outcome
 	a.clearPromptTraceCtx()
@@ -331,13 +345,25 @@ func (a *Adapter) Cancel(ctx context.Context) error {
 	// Mark all active tool calls as cancelled before sending cancel to agent.
 	a.cancelActiveToolCalls(sessionID)
 
-	err := conn.Cancel(ctx, acp.CancelNotification{
+	if err := conn.Cancel(ctx, acp.CancelNotification{
 		SessionId: acp.SessionId(sessionID),
-	})
-	if err != nil {
+	}); err != nil {
 		span.RecordError(err)
+		return err
 	}
-	return err
+
+	turn := a.signalPromptTurnAbort()
+	if err := waitForPromptRPCAfterCancel(turn); err != nil {
+		span.RecordError(err)
+		a.logger.Warn("session/cancel sent but in-flight prompt did not end",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return err
+	}
+
+	a.logger.Info("cancel acknowledged by in-flight prompt",
+		zap.String("session_id", sessionID))
+	return nil
 }
 
 // cancelActiveToolCalls emits cancelled tool_update events for all in-flight tool calls

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt.go
@@ -349,6 +349,11 @@ func (a *Adapter) Cancel(ctx context.Context) error {
 		SessionId: acp.SessionId(sessionID),
 	}); err != nil {
 		span.RecordError(err)
+		// Still wake the in-flight prompt waiter so sendPrompt can exit within
+		// promptCancelJoinTimeout rather than blocking the gate forever. The
+		// timeout branch in waitForPromptRPCAfterUserCancel will cancel
+		// promptCtx if the agent never acknowledges.
+		a.signalPromptTurnAbort()
 		return err
 	}
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel.go
@@ -35,7 +35,12 @@ func (a *Adapter) currentPromptTurn() *promptTurnState {
 	return a.promptTurn
 }
 
-// signalPromptTurnAbort is called from Cancel to interrupt the in-flight RPC.
+// signalPromptTurnAbort wakes the in-flight prompt waiter via abortCh. It does
+// not cancel promptCtx here: for a compliant agent, conn.Cancel triggers the
+// agent to close its session/prompt RPC normally with stop_reason=cancelled, and
+// cancelling promptCtx pre-emptively would race that response and surface as
+// context.Canceled. promptCtx is cancelled only on the join-timeout branches
+// below, after the agent has had its chance to acknowledge.
 func (a *Adapter) signalPromptTurnAbort() *promptTurnState {
 	turn := a.currentPromptTurn()
 	if turn == nil {
@@ -45,9 +50,6 @@ func (a *Adapter) signalPromptTurnAbort() *promptTurnState {
 	case <-turn.abortCh:
 	default:
 		close(turn.abortCh)
-	}
-	if turn.endTurn != nil {
-		turn.endTurn(ErrTurnCancelNotAcknowledged)
 	}
 	return turn
 }
@@ -60,6 +62,9 @@ func waitForPromptRPCAfterCancel(turn *promptTurnState) error {
 	case <-turn.rpcDone:
 		return nil
 	case <-time.After(promptCancelJoinTimeout):
+		if turn.endTurn != nil {
+			turn.endTurn(ErrTurnCancelNotAcknowledged)
+		}
 		return fmt.Errorf("%w: in-flight session/prompt did not end within %s",
 			ErrTurnCancelNotAcknowledged, promptCancelJoinTimeout)
 	}
@@ -80,6 +85,9 @@ func (a *Adapter) waitForPromptRPCAfterUserCancel(turn *promptTurnState) error {
 		case <-turn.rpcDone:
 			return nil
 		case <-time.After(promptCancelJoinTimeout):
+			if turn.endTurn != nil {
+				turn.endTurn(ErrTurnCancelNotAcknowledged)
+			}
 			a.logger.Warn("in-flight session/prompt did not end after cancel; releasing prompt gate",
 				zap.Duration("timeout", promptCancelJoinTimeout))
 			return errPromptAbandonedAfterCancel

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel.go
@@ -1,0 +1,88 @@
+package acp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func (a *Adapter) registerPromptTurn(parent context.Context) (context.Context, *promptTurnState) {
+	promptCtx, endTurn := context.WithCancelCause(parent)
+	turn := &promptTurnState{
+		endTurn: endTurn,
+		rpcDone: make(chan struct{}),
+		abortCh: make(chan struct{}),
+	}
+	a.promptTurnMu.Lock()
+	a.promptTurn = turn
+	a.promptTurnMu.Unlock()
+	return promptCtx, turn
+}
+
+func (a *Adapter) clearPromptTurn(turn *promptTurnState) {
+	a.promptTurnMu.Lock()
+	if a.promptTurn == turn {
+		a.promptTurn = nil
+	}
+	a.promptTurnMu.Unlock()
+}
+
+func (a *Adapter) currentPromptTurn() *promptTurnState {
+	a.promptTurnMu.Lock()
+	defer a.promptTurnMu.Unlock()
+	return a.promptTurn
+}
+
+// signalPromptTurnAbort is called from Cancel to interrupt the in-flight RPC.
+func (a *Adapter) signalPromptTurnAbort() *promptTurnState {
+	turn := a.currentPromptTurn()
+	if turn == nil {
+		return nil
+	}
+	select {
+	case <-turn.abortCh:
+	default:
+		close(turn.abortCh)
+	}
+	if turn.endTurn != nil {
+		turn.endTurn(ErrTurnCancelNotAcknowledged)
+	}
+	return turn
+}
+
+func waitForPromptRPCAfterCancel(turn *promptTurnState) error {
+	if turn == nil {
+		return nil
+	}
+	select {
+	case <-turn.rpcDone:
+		return nil
+	case <-time.After(promptCancelJoinTimeout):
+		return fmt.Errorf("%w: in-flight session/prompt did not end within %s",
+			ErrTurnCancelNotAcknowledged, promptCancelJoinTimeout)
+	}
+}
+
+// waitForPromptRPCAfterUserCancel blocks until the in-flight session/prompt RPC
+// finishes. If the user cancels while this RPC is running, it waits briefly for
+// the agent to stop; otherwise it abandons the RPC so the prompt gate is released.
+func (a *Adapter) waitForPromptRPCAfterUserCancel(turn *promptTurnState) error {
+	if turn == nil {
+		return nil
+	}
+	select {
+	case <-turn.rpcDone:
+		return nil
+	case <-turn.abortCh:
+		select {
+		case <-turn.rpcDone:
+			return nil
+		case <-time.After(promptCancelJoinTimeout):
+			a.logger.Warn("in-flight session/prompt did not end after cancel; releasing prompt gate",
+				zap.Duration("timeout", promptCancelJoinTimeout))
+			return errPromptAbandonedAfterCancel
+		}
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel_test.go
@@ -1,0 +1,80 @@
+package acp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestWaitForPromptRPCAfterCancel_Acknowledged(t *testing.T) {
+	turn := &promptTurnState{rpcDone: make(chan struct{})}
+	close(turn.rpcDone)
+
+	if err := waitForPromptRPCAfterCancel(turn); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestWaitForPromptRPCAfterCancel_TimesOut(t *testing.T) {
+	prev := promptCancelJoinTimeout
+	promptCancelJoinTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { promptCancelJoinTimeout = prev })
+
+	turn := &promptTurnState{rpcDone: make(chan struct{})}
+	err := waitForPromptRPCAfterCancel(turn)
+	if !errors.Is(err, ErrTurnCancelNotAcknowledged) {
+		t.Fatalf("expected ErrTurnCancelNotAcknowledged, got %v", err)
+	}
+}
+
+func TestWaitForPromptRPCAfterUserCancel_AbortReleasesWhenRPCStuck(t *testing.T) {
+	prev := promptCancelJoinTimeout
+	promptCancelJoinTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { promptCancelJoinTimeout = prev })
+
+	a := newTestAdapter()
+	turn := &promptTurnState{
+		endTurn: func(error) {},
+		rpcDone: make(chan struct{}),
+		abortCh: make(chan struct{}),
+	}
+	a.promptTurn = turn
+	close(turn.abortCh)
+
+	err := a.waitForPromptRPCAfterUserCancel(turn)
+	if !errors.Is(err, errPromptAbandonedAfterCancel) {
+		t.Fatalf("expected errPromptAbandonedAfterCancel, got %v", err)
+	}
+}
+
+func TestWaitForPromptRPCAfterUserCancel_CompletesAfterAbort(t *testing.T) {
+	a := newTestAdapter()
+	turn := &promptTurnState{
+		endTurn: func(error) {},
+		rpcDone: make(chan struct{}),
+		abortCh: make(chan struct{}),
+	}
+	a.promptTurn = turn
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(turn.rpcDone)
+	}()
+	close(turn.abortCh)
+
+	if err := a.waitForPromptRPCAfterUserCancel(turn); err != nil {
+		t.Fatalf("expected nil after rpc completed, got %v", err)
+	}
+}
+
+func TestRegisterPromptTurn_CancelCause(t *testing.T) {
+	a := newTestAdapter()
+	ctx, turn := a.registerPromptTurn(context.Background())
+	defer a.clearPromptTurn(turn)
+
+	turn.endTurn(ErrTurnCancelNotAcknowledged)
+	if !errors.Is(context.Cause(ctx), ErrTurnCancelNotAcknowledged) {
+		t.Fatalf("expected cancel cause on prompt ctx, got %v", context.Cause(ctx))
+	}
+}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -49,23 +50,36 @@ func TestWaitForPromptRPCAfterUserCancel_AbortReleasesWhenRPCStuck(t *testing.T)
 }
 
 func TestWaitForPromptRPCAfterUserCancel_CompletesAfterAbort(t *testing.T) {
-	a := newTestAdapter()
-	turn := &promptTurnState{
-		endTurn: func(error) {},
-		rpcDone: make(chan struct{}),
-		abortCh: make(chan struct{}),
-	}
-	a.promptTurn = turn
+	// synctest lets us deterministically exercise the abort path: close abortCh
+	// first, run waitForPromptRPCAfterUserCancel in a goroutine, synctest.Wait
+	// until it blocks inside the inner select on rpcDone, then close rpcDone.
+	// Without synctest there's no way to deterministically distinguish the
+	// "outer select picked abort, then inner picked rpcDone" path from the
+	// "outer select picked rpcDone directly" path when both channels are ready.
+	synctest.Test(t, func(t *testing.T) {
+		a := newTestAdapter()
+		defer func() { _ = a.Close() }() // drain the update worker before synctest exits
+		turn := &promptTurnState{
+			endTurn: func(error) {},
+			rpcDone: make(chan struct{}),
+			abortCh: make(chan struct{}),
+		}
+		a.promptTurn = turn
+		close(turn.abortCh)
 
-	// Abort fires first, RPC completes before the inner timeout. Both channels
-	// are closed up front so the inner select picks rpcDone deterministically
-	// without needing a sleep-based scheduling delay.
-	close(turn.abortCh)
-	close(turn.rpcDone)
+		done := make(chan error, 1)
+		go func() {
+			done <- a.waitForPromptRPCAfterUserCancel(turn)
+		}()
 
-	if err := a.waitForPromptRPCAfterUserCancel(turn); err != nil {
-		t.Fatalf("expected nil after rpc completed, got %v", err)
-	}
+		// Wait until the goroutine is blocked inside the inner select.
+		synctest.Wait()
+		close(turn.rpcDone)
+
+		if err := <-done; err != nil {
+			t.Fatalf("expected nil after rpc completed, got %v", err)
+		}
+	})
 }
 
 func TestRegisterPromptTurn_CancelCause(t *testing.T) {
@@ -120,6 +134,28 @@ func TestWaitForPromptRPCAfterUserCancel_CancelsPromptCtxOnTimeout(t *testing.T)
 	close(turn.abortCh)
 	if err := a.waitForPromptRPCAfterUserCancel(turn); !errors.Is(err, errPromptAbandonedAfterCancel) {
 		t.Fatalf("expected errPromptAbandonedAfterCancel, got %v", err)
+	}
+	if !errors.Is(context.Cause(ctx), ErrTurnCancelNotAcknowledged) {
+		t.Fatalf("expected promptCtx cancelled with ErrTurnCancelNotAcknowledged on timeout, got %v",
+			context.Cause(ctx))
+	}
+}
+
+// Symmetric to TestWaitForPromptRPCAfterUserCancel_CancelsPromptCtxOnTimeout —
+// guards against future edits dropping the endTurn call from
+// waitForPromptRPCAfterCancel's timeout branch (the Cancel() caller-side path).
+func TestWaitForPromptRPCAfterCancel_CancelsPromptCtxOnTimeout(t *testing.T) {
+	prev := promptCancelJoinTimeout
+	promptCancelJoinTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { promptCancelJoinTimeout = prev })
+
+	a := newTestAdapter()
+	ctx, turn := a.registerPromptTurn(context.Background())
+	defer a.clearPromptTurn(turn)
+	turn.rpcDone = make(chan struct{})
+
+	if err := waitForPromptRPCAfterCancel(turn); !errors.Is(err, ErrTurnCancelNotAcknowledged) {
+		t.Fatalf("expected ErrTurnCancelNotAcknowledged, got %v", err)
 	}
 	if !errors.Is(context.Cause(ctx), ErrTurnCancelNotAcknowledged) {
 		t.Fatalf("expected promptCtx cancelled with ErrTurnCancelNotAcknowledged on timeout, got %v",

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_prompt_cancel_test.go
@@ -57,11 +57,11 @@ func TestWaitForPromptRPCAfterUserCancel_CompletesAfterAbort(t *testing.T) {
 	}
 	a.promptTurn = turn
 
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		close(turn.rpcDone)
-	}()
+	// Abort fires first, RPC completes before the inner timeout. Both channels
+	// are closed up front so the inner select picks rpcDone deterministically
+	// without needing a sleep-based scheduling delay.
 	close(turn.abortCh)
+	close(turn.rpcDone)
 
 	if err := a.waitForPromptRPCAfterUserCancel(turn); err != nil {
 		t.Fatalf("expected nil after rpc completed, got %v", err)
@@ -76,5 +76,53 @@ func TestRegisterPromptTurn_CancelCause(t *testing.T) {
 	turn.endTurn(ErrTurnCancelNotAcknowledged)
 	if !errors.Is(context.Cause(ctx), ErrTurnCancelNotAcknowledged) {
 		t.Fatalf("expected cancel cause on prompt ctx, got %v", context.Cause(ctx))
+	}
+}
+
+// signalPromptTurnAbort must only wake the waiter via abortCh — it must NOT
+// cancel promptCtx, because a compliant agent will close session/prompt
+// naturally after receiving session/cancel and we don't want to race that
+// response with a context.Canceled. promptCtx is cancelled only on the
+// timeout branches of the waiters.
+func TestSignalPromptTurnAbort_DoesNotCancelPromptCtx(t *testing.T) {
+	a := newTestAdapter()
+	ctx, turn := a.registerPromptTurn(context.Background())
+	defer a.clearPromptTurn(turn)
+
+	turn.rpcDone = make(chan struct{})
+	turn.abortCh = make(chan struct{})
+
+	got := a.signalPromptTurnAbort()
+	if got != turn {
+		t.Fatalf("expected signalPromptTurnAbort to return current turn")
+	}
+	select {
+	case <-turn.abortCh:
+	default:
+		t.Fatalf("expected abortCh to be closed")
+	}
+	if context.Cause(ctx) != nil {
+		t.Fatalf("expected promptCtx to be alive, got cause %v", context.Cause(ctx))
+	}
+}
+
+func TestWaitForPromptRPCAfterUserCancel_CancelsPromptCtxOnTimeout(t *testing.T) {
+	prev := promptCancelJoinTimeout
+	promptCancelJoinTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { promptCancelJoinTimeout = prev })
+
+	a := newTestAdapter()
+	ctx, turn := a.registerPromptTurn(context.Background())
+	defer a.clearPromptTurn(turn)
+	turn.rpcDone = make(chan struct{})
+	turn.abortCh = make(chan struct{})
+
+	close(turn.abortCh)
+	if err := a.waitForPromptRPCAfterUserCancel(turn); !errors.Is(err, errPromptAbandonedAfterCancel) {
+		t.Fatalf("expected errPromptAbandonedAfterCancel, got %v", err)
+	}
+	if !errors.Is(context.Cause(ctx), ErrTurnCancelNotAcknowledged) {
+		t.Fatalf("expected promptCtx cancelled with ErrTurnCancelNotAcknowledged on timeout, got %v",
+			context.Cause(ctx))
 	}
 }

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/errors.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/errors.go
@@ -1,0 +1,13 @@
+package acp
+
+import "errors"
+
+// ErrTurnCancelNotAcknowledged means session/cancel (and local prompt interruption)
+// were sent but the in-flight session/prompt RPC did not finish within the join
+// window. Callers should reconcile local state without assuming the agent stopped.
+var ErrTurnCancelNotAcknowledged = errors.New("turn cancel not acknowledged")
+
+// errPromptAbandonedAfterCancel is returned by sendPrompt when a user cancel was
+// requested but the session/prompt RPC did not end in time. The prompt gate is
+// released so a follow-up prompt can be dispatched.
+var errPromptAbandonedAfterCancel = errors.New("prompt abandoned after cancel")

--- a/apps/backend/internal/agentctl/server/api/agent.go
+++ b/apps/backend/internal/agentctl/server/api/agent.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/kandev/kandev/internal/agentctl/server/adapter"
+	acptransport "github.com/kandev/kandev/internal/agentctl/server/adapter/transport/acp"
 	"github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/common/constants"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
@@ -106,8 +108,9 @@ type AgentStderrResponse struct {
 
 // CancelResponse is the response from a cancel request.
 type CancelResponse struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
+	Success         bool   `json:"success"`
+	Error           string `json:"error,omitempty"`
+	NotAcknowledged bool   `json:"not_acknowledged,omitempty"`
 }
 
 // handleAgentStreamWS streams agent session notifications via WebSocket.
@@ -487,12 +490,21 @@ func (s *Server) handleWSCancel(ctx context.Context, msg *ws.Message) *ws.Messag
 	}
 
 	if err := adapter.Cancel(ctx); err != nil {
-		s.logger.Error("cancel failed", zap.Error(err))
-		resp, _ := ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
+		notAck := errors.Is(err, acptransport.ErrTurnCancelNotAcknowledged)
+		if notAck {
+			s.logger.Warn("cancel not acknowledged by in-flight prompt", zap.Error(err))
+		} else {
+			s.logger.Error("cancel failed", zap.Error(err))
+		}
+		resp, _ := ws.NewResponse(msg.ID, msg.Action, CancelResponse{
+			Success:         false,
+			Error:           err.Error(),
+			NotAcknowledged: notAck,
+		})
 		return resp
 	}
 
-	s.logger.Info("cancel completed")
+	s.logger.Info("cancel acknowledged")
 	resp, _ := ws.NewResponse(msg.ID, msg.Action, CancelResponse{Success: true})
 	return resp
 }


### PR DESCRIPTION
When an ACP agent does not implement `session/cancel` (e.g. OpenCode), a cancel-then-next-prompt sequence silently blocks the second prompt — `promptGate` is held forever because the in-flight RPC never stops.

The fix detects unacknowledged cancels at the adapter level, releases the prompt gate after a brief join window, and signals `not_acknowledged` to the lifecycle manager for immediate escalation instead of waiting the full 10s timeout.

## Important Changes

- New `ErrTurnCancelNotAcknowledged` / `errPromptAbandonedAfterCancel` sentinels for outcome-based cancel detection
- `promptTurnState` tracks the in-flight session/prompt RPC so `Cancel` can interrupt its context and join briefly rather than assuming success
- `sendPrompt` wraps `conn.Prompt` in a goroutine with channel-based join; waits for abort signal before releasing prompt gate
- Lifecycle manager escalates `ErrTurnCancelNotAcknowledged` immediately instead of waiting the full 10s timeout
- API layer surfaces `not_acknowledged` in the `CancelResponse` JSON payload

## Validation

- `make -C apps/backend fmt`
- `make -C apps/backend vet`
- `make -C apps/backend test`
- `make -C apps/backend lint`
- New unit tests cover acknowledged, timed-out, and abandoned-cancel scenarios

## Possible Improvements

Low risk. Compliant agents (Claude, Codex, Cursor) acknowledge cancel within the join window and behavior is unchanged. Non-compliant agents (OpenCode) unblock after the short timeout with a clear error path.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.