### PR TITLE
fix(agents): emit --dangerously-skip-permissions for Claude CLI passthrough

### DIFF
--- a/apps/backend/internal/agent/agents/agent.go
+++ b/apps/backend/internal/agent/agents/agent.go
@@ -250,6 +250,15 @@ const PermissionKeyAutoApprove = "auto_approve"
 // run-everything). Separate from PermissionKeyAutoApprove (agentctl ACP approval).
 const PermissionKeyCursorForce = "cursor_force"
 
+// PermissionKeyDangerouslySkipPermissions is wired to the profile's
+// DangerouslySkipPermissions column (a dedicated bool, not the cli_flags list).
+// Agents whose CLI accepts --dangerously-skip-permissions (or equivalent)
+// declare a PermissionSetting under this key with ApplyMethod=cli_flag so the
+// passthrough Settings() pass emits the flag from the profile bool. The
+// catalog seeder excludes this key to avoid duplicating the toggle into the
+// curated cli_flags list (which would also double-emit the flag at launch).
+const PermissionKeyDangerouslySkipPermissions = "dangerously_skip_permissions"
+
 // PermissionSetting defines metadata for a permission setting option.
 type PermissionSetting struct {
 	Supported    bool   `json:"supported"`

--- a/apps/backend/internal/agent/agents/claude_acp.go
+++ b/apps/backend/internal/agent/agents/claude_acp.go
@@ -18,6 +18,21 @@ var claudeACPLogoDark []byte
 
 const claudeACPPkg = "@agentclientprotocol/claude-agent-acp"
 
+// claudeACPPermSettings maps the profile DangerouslySkipPermissions toggle to
+// the Claude Code CLI's --dangerously-skip-permissions flag in passthrough mode.
+// ACP (non-passthrough) Claude does not consume this flag; permission bypass
+// there goes through agentctl's auto-approve channel.
+var claudeACPPermSettings = map[string]PermissionSetting{
+	PermissionKeyDangerouslySkipPermissions: {
+		Supported:   true,
+		Default:     false,
+		Label:       "Skip permission prompts",
+		Description: "Pass --dangerously-skip-permissions so Claude Code does not prompt for tool approvals.",
+		ApplyMethod: PermissionApplyMethodCLIFlag,
+		CLIFlag:     "--dangerously-skip-permissions",
+	},
+}
+
 var (
 	_ Agent            = (*ClaudeACP)(nil)
 	_ PassthroughAgent = (*ClaudeACP)(nil)
@@ -34,7 +49,7 @@ type ClaudeACP struct {
 func NewClaudeACP() *ClaudeACP {
 	return &ClaudeACP{
 		StandardPassthrough: StandardPassthrough{
-			PermSettings: emptyPermSettings,
+			PermSettings: claudeACPPermSettings,
 			Cfg: PassthroughConfig{
 				Supported:             true,
 				Label:                 "CLI Passthrough",
@@ -160,7 +175,7 @@ func (a *ClaudeACP) InstallScript() string {
 func (a *ClaudeACP) BillingType() usage.BillingType { return claudeBillingType() }
 
 func (a *ClaudeACP) PermissionSettings() map[string]PermissionSetting {
-	return emptyPermSettings
+	return claudeACPPermSettings
 }
 
 // InferenceConfig returns configuration for one-shot inference using ACP.

--- a/apps/backend/internal/agent/agents/claude_acp_test.go
+++ b/apps/backend/internal/agent/agents/claude_acp_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestClaudeACPPermissionSettingsSkipPermissions(t *testing.T) {
 	settings := NewClaudeACP().PermissionSettings()
-	setting, ok := settings["dangerously_skip_permissions"]
+	setting, ok := settings[PermissionKeyDangerouslySkipPermissions]
 	if !ok {
 		t.Fatal("PermissionSettings() missing dangerously_skip_permissions")
 	}
@@ -35,7 +35,7 @@ func TestClaudeACPBuildPassthroughCommandSkipPermissions(t *testing.T) {
 
 	with := strings.Join(
 		c.BuildPassthroughCommand(PassthroughOptions{
-			PermissionValues: map[string]bool{"dangerously_skip_permissions": true},
+			PermissionValues: map[string]bool{PermissionKeyDangerouslySkipPermissions: true},
 		}).Args(),
 		" ",
 	)

--- a/apps/backend/internal/agent/agents/claude_acp_test.go
+++ b/apps/backend/internal/agent/agents/claude_acp_test.go
@@ -1,0 +1,45 @@
+package agents
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClaudeACPPermissionSettingsSkipPermissions(t *testing.T) {
+	settings := NewClaudeACP().PermissionSettings()
+	setting, ok := settings["dangerously_skip_permissions"]
+	if !ok {
+		t.Fatal("PermissionSettings() missing dangerously_skip_permissions")
+	}
+	if !setting.Supported {
+		t.Error("dangerously_skip_permissions must be Supported")
+	}
+	if setting.ApplyMethod != PermissionApplyMethodCLIFlag {
+		t.Errorf("ApplyMethod = %q, want %q", setting.ApplyMethod, PermissionApplyMethodCLIFlag)
+	}
+	if setting.CLIFlag != "--dangerously-skip-permissions" {
+		t.Errorf("CLIFlag = %q, want --dangerously-skip-permissions", setting.CLIFlag)
+	}
+}
+
+// Passthrough launch path drives the flag via PermissionValues. Verify the
+// resulting command includes --dangerously-skip-permissions when the toggle is
+// on, and excludes it otherwise. Regression coverage for issue #1261.
+func TestClaudeACPBuildPassthroughCommandSkipPermissions(t *testing.T) {
+	c := NewClaudeACP()
+
+	without := strings.Join(c.BuildPassthroughCommand(PassthroughOptions{}).Args(), " ")
+	if strings.Contains(without, "--dangerously-skip-permissions") {
+		t.Errorf("default passthrough command must not include --dangerously-skip-permissions, got %q", without)
+	}
+
+	with := strings.Join(
+		c.BuildPassthroughCommand(PassthroughOptions{
+			PermissionValues: map[string]bool{"dangerously_skip_permissions": true},
+		}).Args(),
+		" ",
+	)
+	if !strings.Contains(with, "--dangerously-skip-permissions") {
+		t.Errorf("passthrough command with dangerously_skip_permissions=true must include --dangerously-skip-permissions, got %q", with)
+	}
+}

--- a/apps/backend/internal/agent/agents/claude_acp_test.go
+++ b/apps/backend/internal/agent/agents/claude_acp_test.go
@@ -9,7 +9,7 @@ func TestClaudeACPPermissionSettingsSkipPermissions(t *testing.T) {
 	settings := NewClaudeACP().PermissionSettings()
 	setting, ok := settings[PermissionKeyDangerouslySkipPermissions]
 	if !ok {
-		t.Fatal("PermissionSettings() missing dangerously_skip_permissions")
+		t.Fatalf("PermissionSettings() missing key %q", PermissionKeyDangerouslySkipPermissions)
 	}
 	if !setting.Supported {
 		t.Error("dangerously_skip_permissions must be Supported")

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -82,8 +82,15 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 func seedCLIFlags(agent agents.Agent) []models.CLIFlag {
 	settings := agents.CatalogPermissionSettings(agent)
 	flags := make([]models.CLIFlag, 0, len(settings))
-	for _, s := range settings {
+	for key, s := range settings {
 		if !s.Supported || s.ApplyMethod != agents.PermissionApplyMethodCLIFlag || s.CLIFlag == "" {
+			continue
+		}
+		// dangerously_skip_permissions is wired to the profile's dedicated
+		// DangerouslySkipPermissions column; the passthrough launch path emits
+		// the flag via PermissionValues. Seeding it as a curated cli_flag too
+		// would surface a duplicate toggle in the UI and double-emit the flag.
+		if key == agents.PermissionKeyDangerouslySkipPermissions {
 			continue
 		}
 		flagText := s.CLIFlag


### PR DESCRIPTION
## Summary

Closes #1261. In CLI passthrough mode, Claude Code ignored the profile's bypass-permissions toggle because the Claude ACP agent declared empty `PermSettings`, so the launch path's `PermissionValues` map (which carries `DangerouslySkipPermissions` from the profile) had no CLI-flag mapping to emit. Wiring the permission setting to `--dangerously-skip-permissions` makes bypass / auto-approve start-mode behave the same as the non-passthrough launch path.

## Important Changes

- `claudeACPPermSettings` maps `dangerously_skip_permissions` → `--dangerously-skip-permissions` with `ApplyMethod: cli_flag`. `BuildPassthroughCommand`'s `Settings()` pass now emits the flag when the profile bool is on.
- New `PermissionKeyDangerouslySkipPermissions` constant in `agents/agent.go` centralises the key (mirrors `PermissionKeyAutoApprove` / `PermissionKeyCursorForce`).
- `seedCLIFlags` (controller/profile_crud.go) skips the new key so the dedicated `DangerouslySkipPermissions` profile column is not duplicated into the curated `cli_flags` list (which would also double-emit the flag at launch).

## Validation

- `make -C apps/backend fmt lint test build` — clean
- `pnpm --filter @kandev/web lint typecheck` — clean
- New `claude_acp_test.go` regression: asserts the perm setting shape and that `BuildPassthroughCommand` emits `--dangerously-skip-permissions` iff the toggle is on.

## Possible Improvements

Same root cause likely affects other passthrough agents that still use `emptyPermSettings` (gemini, opencode, amp, droid, kimi, qwen, trae, kiro, kilocode, iflow, qoder, omp, pi). Each CLI uses a different bypass flag name (e.g. Gemini = `--yolo`) — out of scope here; follow-up per agent.

## Checklist

- [ ] I've added tests for my changes
- [ ] I've updated relevant documentation
- [ ] I've checked for accessibility issues (if UI changes)

Closes #1261