### PR TITLE
fix(web): prevent cross-task session leak in dockview layout switch

### DIFF
--- a/apps/backend/internal/clarification/store.go
+++ b/apps/backend/internal/clarification/store.go
@@ -23,6 +23,12 @@ type Store struct {
 	mu      sync.RWMutex
 	pending map[string]*PendingClarification
 	timeout time.Duration
+
+	// onWaitEntered, if non-nil, is invoked inside WaitForResponse after the
+	// initial pending lookup and before the select blocks. Tests use it to
+	// coordinate multi-waiter scenarios deterministically; always nil in
+	// production.
+	onWaitEntered func(pendingID string)
 }
 
 // NewStore creates a new clarification store.
@@ -89,7 +95,12 @@ func (s *Store) GetRequest(pendingID string) (*Request, bool) {
 func (s *Store) WaitForResponse(ctx context.Context, pendingID string) (*Response, error) {
 	s.mu.RLock()
 	pending, ok := s.pending[pendingID]
+	hook := s.onWaitEntered
 	s.mu.RUnlock()
+
+	if hook != nil {
+		hook(pendingID)
+	}
 
 	if !ok {
 		return nil, fmt.Errorf("clarification request not found: %s", pendingID)

--- a/apps/backend/internal/clarification/store_test.go
+++ b/apps/backend/internal/clarification/store_test.go
@@ -372,28 +372,23 @@ func TestCreateRequest_NoDedup_DifferentQuestions(t *testing.T) {
 	}
 }
 
-// testStore wraps Store so WaitForResponse can signal that it has passed the
-// initial lookup and is about to block. This eliminates the race where
-// Respond fires before a late goroutine even enters WaitForResponse.
-type testStore struct {
-	*Store
-	entered chan string
-}
-
-func (ts *testStore) WaitForResponse(ctx context.Context, id string) (*Response, error) {
-	ts.entered <- id
-	return ts.Store.WaitForResponse(ctx, id)
-}
-
+// TestWaitForResponse_Broadcast_MultipleWaiters verifies that close(done) in
+// Respond unblocks every parked waiter. The onWaitEntered hook lets the test
+// observe each goroutine after it has captured a *PendingClarification pointer
+// but before it parks on the select, so Respond can fire only once both
+// waiters are guaranteed to see the broadcast. Signalling before the lookup
+// (the previous shape) raced with the first-reader-deletes path inside
+// WaitForResponse and was flaky under the Linux scheduler in CI.
 func TestWaitForResponse_Broadcast_MultipleWaiters(t *testing.T) {
 	s := NewStore(time.Minute)
-	ts := &testStore{Store: s, entered: make(chan string, 2)}
+	entered := make(chan string, 2)
+	s.onWaitEntered = func(id string) { entered <- id }
 	id, _ := s.CreateRequest(&Request{SessionID: "s1", Questions: []Question{{Prompt: "test?", Options: []Option{{ID: "o1", Label: "A"}}}}})
 
 	done := make(chan *Response, 2)
 	for i := 0; i < 2; i++ {
 		go func() {
-			resp, err := ts.WaitForResponse(context.Background(), id)
+			resp, err := s.WaitForResponse(context.Background(), id)
 			if err != nil {
 				done <- nil
 				return
@@ -401,8 +396,8 @@ func TestWaitForResponse_Broadcast_MultipleWaiters(t *testing.T) {
 			done <- resp
 		}()
 	}
-	<-ts.entered
-	<-ts.entered
+	<-entered
+	<-entered
 
 	if err := s.Respond(id, &Response{Answers: []Answer{{CustomText: "hello"}}}); err != nil {
 		t.Fatalf("unexpected respond error: %v", err)

--- a/apps/backend/internal/clarification/store_test.go
+++ b/apps/backend/internal/clarification/store_test.go
@@ -396,8 +396,16 @@ func TestWaitForResponse_Broadcast_MultipleWaiters(t *testing.T) {
 			done <- resp
 		}()
 	}
-	<-entered
-	<-entered
+	for i := 0; i < 2; i++ {
+		select {
+		case gotID := <-entered:
+			if gotID != id {
+				t.Fatalf("onWaitEntered id = %q, want %q", gotID, id)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("WaitForResponse did not reach the parked wait state")
+		}
+	}
 
 	if err := s.Respond(id, &Response{Answers: []Answer{{CustomText: "hello"}}}); err != nil {
 		t.Fatalf("unexpected respond error: %v", err)

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -585,11 +585,14 @@ func (s *Service) writeTaskReviewState(ctx context.Context, taskID string) {
 		zap.String("task_id", taskID))
 }
 
-// writeTaskWaitingForInputState clears the kanban "actively working" task states
-// when the user cancels a turn mid-flight. Normal turn completion lands on
-// REVIEW via setSessionWaitingForInput; cancel bypasses that path and must
-// reconcile tasks.state explicitly or the card stays IN_PROGRESS.
-func (s *Service) writeTaskWaitingForInputState(ctx context.Context, taskID string) {
+// writeTaskReviewStateOnCancel clears the kanban "actively working" task
+// states when the user cancels a turn mid-flight by landing the task in
+// REVIEW — the same bucket a normal turn completion uses, so the sidebar
+// shows the green check rather than the yellow "needs input" question icon.
+// Office task status reflects workflow position, not runtime cancel, so those
+// tasks are left alone. Only actively-working tasks are reconciled; tasks
+// already past IN_PROGRESS / SCHEDULING keep their state.
+func (s *Service) writeTaskReviewStateOnCancel(ctx context.Context, taskID string) {
 	dbTask, err := s.repo.GetTask(ctx, taskID)
 	if err != nil || dbTask == nil {
 		if err != nil {
@@ -599,7 +602,6 @@ func (s *Service) writeTaskWaitingForInputState(ctx context.Context, taskID stri
 		}
 		return
 	}
-	// Office task status reflects workflow position, not runtime cancel.
 	if dbTask.AssigneeAgentProfileID != "" {
 		return
 	}
@@ -607,11 +609,11 @@ func (s *Service) writeTaskWaitingForInputState(ctx context.Context, taskID stri
 	updated, err := s.taskRepo.UpdateTaskStateIfCurrentIn(
 		ctx,
 		taskID,
-		v1.TaskStateWaitingForInput,
+		v1.TaskStateReview,
 		[]v1.TaskState{v1.TaskStateInProgress, v1.TaskStateScheduling},
 	)
 	if err != nil {
-		s.logger.Error("failed to update task state to WAITING_FOR_INPUT",
+		s.logger.Error("failed to update task state to REVIEW",
 			zap.String("task_id", taskID),
 			zap.Error(err))
 		return
@@ -619,7 +621,7 @@ func (s *Service) writeTaskWaitingForInputState(ctx context.Context, taskID stri
 	if !updated {
 		return
 	}
-	s.logger.Info("task moved to WAITING_FOR_INPUT state after turn cancel",
+	s.logger.Info("task moved to REVIEW state after turn cancel",
 		zap.String("task_id", taskID))
 }
 

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2091,9 +2091,10 @@ func (s *Service) handlePromptError(ctx context.Context, taskID, sessionID strin
 	// wake transition; the flag only matters when going WAITING_FOR_INPUT → RUNNING.
 	s.updateTaskSessionState(ctx, taskID, sessionID, previousSessionState, "", false)
 	// ErrCancelEscalated means the user cancelled and the lifecycle manager had to
-	// force-unblock a hung agent. That is not a "review this failure" condition —
-	// Service.CancelAgent reconciles DB state (WAITING_FOR_INPUT, cancel message,
-	// complete turn) already.
+	// force-unblock a hung agent. Service.CancelAgent owns the cancel reconcile
+	// (session → WAITING_FOR_INPUT, task → REVIEW, cancel message, complete
+	// turn); skip the REVIEW write here so we don't race that path with a
+	// duplicate update.
 	// A transient provider error (529 Overloaded) is owned by the async
 	// retry-with-backoff path (handleTransientFailure), which keeps the task
 	// in progress while it retries — so don't flap it to REVIEW here.
@@ -2290,10 +2291,13 @@ func (s *Service) CancelAgent(ctx context.Context, sessionID string) error {
 		}
 	}
 
-	// Transition to WAITING_FOR_INPUT so the user can send a new prompt
+	// Transition session to WAITING_FOR_INPUT so the user can send a new
+	// prompt, and reconcile the task row to REVIEW so the sidebar shows the
+	// green check rather than the yellow "needs input" question icon — a
+	// cancelled turn is treated as finished work the user may want to review.
 	if session != nil {
 		s.updateTaskSessionState(ctx, session.TaskID, sessionID, models.TaskSessionStateWaitingForInput, "", true, session)
-		s.writeTaskWaitingForInputState(ctx, session.TaskID)
+		s.writeTaskReviewStateOnCancel(ctx, session.TaskID)
 	}
 
 	// Record cancellation in the message history

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -372,9 +372,10 @@ func TestCancelAgent_DeduplicatesConcurrentCalls(t *testing.T) {
 	}
 }
 
-// TestCancelAgent_TaskStateReconcile ensures cancel writes tasks.state for active
-// kanban tasks only. Office tasks and tasks already out of IN_PROGRESS /
-// SCHEDULING must be left untouched.
+// TestCancelAgent_TaskStateReconcile ensures cancel lands actively-working
+// kanban tasks in REVIEW (treated as finished work the user may want to
+// review). Office tasks and tasks already out of IN_PROGRESS / SCHEDULING
+// must be left untouched.
 func TestCancelAgent_TaskStateReconcile(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
@@ -427,8 +428,8 @@ func TestCancelAgent_TaskStateReconcile(t *testing.T) {
 				if !ok {
 					t.Fatal("expected tasks.state to be updated on cancel")
 				}
-				if got != v1.TaskStateWaitingForInput {
-					t.Fatalf("expected task state %q, got %q", v1.TaskStateWaitingForInput, got)
+				if got != v1.TaskStateReview {
+					t.Fatalf("expected task state %q, got %q", v1.TaskStateReview, got)
 				}
 				return
 			}

--- a/apps/web/components/shared/mermaid-block-streaming.test.tsx
+++ b/apps/web/components/shared/mermaid-block-streaming.test.tsx
@@ -68,6 +68,8 @@ async function flush(ms: number) {
   });
 }
 
+const VALID_DIAGRAM = "flowchart LR\n  A --> B";
+
 describe("MermaidBlock streaming behaviour", () => {
   it("debounces rapid prop changes to a single render of the final code", async () => {
     const { rerender } = render(<MermaidBlock code={"sequenceDiagram"} />);
@@ -97,11 +99,11 @@ describe("MermaidBlock streaming behaviour", () => {
       rerender(<MermaidBlock code={`flowchart LR\n  subgraph wave${i}`} />);
       await flush(50);
     }
-    rerender(<MermaidBlock code={"flowchart LR\n  A --> B"} />);
+    rerender(<MermaidBlock code={VALID_DIAGRAM} />);
 
     await flush(500);
     expect(renderCalls).toHaveLength(1);
-    expect(renderCalls[0]).toBe("flowchart LR\n  A --> B");
+    expect(renderCalls[0]).toBe(VALID_DIAGRAM);
     expect(mockToast).not.toHaveBeenCalled();
   });
 
@@ -118,11 +120,34 @@ describe("MermaidBlock streaming behaviour", () => {
     // (this is the regression — previously the success path was gated on
     // containerRef which had been unmounted by the error branch).
     nextResult = { kind: "ok", svg: "<svg data-test='recovered'></svg>" };
-    rerender(<MermaidBlock code={"flowchart LR\n  A --> B"} />);
+    rerender(<MermaidBlock code={VALID_DIAGRAM} />);
     await flush(500);
 
     expect(renderCalls).toHaveLength(2);
     expect(container.textContent).not.toContain("Failed to render diagram");
     expect(container.innerHTML).toContain('data-test="recovered"');
+  });
+
+  it("does not toast for a failed render when a prior successful svg is still visible", async () => {
+    // First attempt: succeed and pin a stable SVG on screen.
+    nextResult = { kind: "ok", svg: "<svg data-test='first'></svg>" };
+    const { rerender, container } = render(<MermaidBlock code={VALID_DIAGRAM} />);
+    await flush(500);
+    expect(renderCalls).toHaveLength(1);
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(container.innerHTML).toContain('data-test="first"');
+
+    // Second attempt with newly-invalid code (e.g. streaming resumed with a
+    // malformed suffix): the error banner is suppressed because a prior SVG
+    // is still showing, so the toast must be suppressed too — otherwise the
+    // user sees "Failed to render diagram" while the diagram keeps rendering.
+    nextResult = { kind: "fail", message: "Parse error on line 5" };
+    rerender(<MermaidBlock code={`${VALID_DIAGRAM}\n  subgraph`} />);
+    await flush(500);
+
+    expect(renderCalls).toHaveLength(2);
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(container.textContent).not.toContain("Failed to render diagram");
+    expect(container.innerHTML).toContain('data-test="first"');
   });
 });

--- a/apps/web/components/shared/mermaid-block-streaming.test.tsx
+++ b/apps/web/components/shared/mermaid-block-streaming.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for streaming-induced "Failed to render diagram" errors.
+ *
+ * When an assistant message containing a ```mermaid block streams in chunk by
+ * chunk, MermaidBlock used to fire mermaid.render for every partial chunk and
+ * toast on every parse error. Once it landed in the error branch, a later
+ * successful render could not clear the error because the success path was
+ * gated on a containerRef that had been unmounted by the error early-return.
+ *
+ * These tests pin down the new behaviour: render is debounced so streaming
+ * chunks coalesce into a single attempt, and a later successful render clears
+ * an earlier transient error.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { MermaidBlock } from "./mermaid-block";
+
+const mockToast = vi.fn();
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "dark" }),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: mockToast, updateToast: vi.fn(), dismissToast: vi.fn() }),
+}));
+
+// Track every call to mermaid.render so tests can assert how many fired and
+// with what input. Resolution / rejection is decided per-call by a queue the
+// tests set up before each render-driving action.
+const renderCalls: string[] = [];
+type NextResult = { kind: "ok"; svg: string } | { kind: "fail"; message: string };
+let nextResult: NextResult = { kind: "ok", svg: "<svg data-test='ok'></svg>" };
+
+vi.mock("mermaid", () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(async (_id: string, code: string) => {
+      renderCalls.push(code);
+      if (nextResult.kind === "fail") {
+        throw new Error(nextResult.message);
+      }
+      return { svg: nextResult.svg };
+    }),
+  },
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  renderCalls.length = 0;
+  mockToast.mockClear();
+  nextResult = { kind: "ok", svg: "<svg data-test='ok'></svg>" };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Helper: advance fake timers AND flush microtasks. mermaid.render returns a
+// promise, so we need both the setTimeout to fire and the resulting promise
+// chain to settle before assertions.
+async function flush(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    // Yield for the promise chain inside the component.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("MermaidBlock streaming behaviour", () => {
+  it("debounces rapid prop changes to a single render of the final code", async () => {
+    const { rerender } = render(<MermaidBlock code={"sequenceDiagram"} />);
+    rerender(<MermaidBlock code={"sequenceDiagram\n  participant"} />);
+    rerender(<MermaidBlock code={"sequenceDiagram\n  participant A"} />);
+    rerender(<MermaidBlock code={"sequenceDiagram\n  participant A\n  A->>B: hi"} />);
+
+    // Within the debounce window (< 300ms), nothing should have rendered yet.
+    await flush(50);
+    expect(renderCalls).toHaveLength(0);
+
+    // After the debounce settles, exactly one render fires with the latest code.
+    await flush(400);
+    expect(renderCalls).toHaveLength(1);
+    expect(renderCalls[0]).toContain("A->>B: hi");
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("does not toast for intermediate partial chunks during streaming", async () => {
+    // Simulate streaming: many partial-and-invalid chunks arriving rapidly,
+    // then a final valid chunk. The component must only attempt to render
+    // once the stream has settled.
+    nextResult = { kind: "ok", svg: "<svg data-test='final'></svg>" };
+
+    const { rerender } = render(<MermaidBlock code={"flowchart LR"} />);
+    for (let i = 1; i <= 6; i++) {
+      rerender(<MermaidBlock code={`flowchart LR\n  subgraph wave${i}`} />);
+      await flush(50);
+    }
+    rerender(<MermaidBlock code={"flowchart LR\n  A --> B"} />);
+
+    await flush(500);
+    expect(renderCalls).toHaveLength(1);
+    expect(renderCalls[0]).toBe("flowchart LR\n  A --> B");
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("clears a previous transient error when a later render succeeds", async () => {
+    // First attempt: fail.
+    nextResult = { kind: "fail", message: "Parse error on line 3" };
+    const { rerender, container } = render(<MermaidBlock code={"flowchart LR\n  subgraph"} />);
+    await flush(500);
+    expect(renderCalls).toHaveLength(1);
+    expect(mockToast).toHaveBeenCalledOnce();
+    expect(container.textContent).toContain("Failed to render diagram");
+
+    // Second attempt with full, valid code: succeed. The error UI must clear
+    // (this is the regression — previously the success path was gated on
+    // containerRef which had been unmounted by the error branch).
+    nextResult = { kind: "ok", svg: "<svg data-test='recovered'></svg>" };
+    rerender(<MermaidBlock code={"flowchart LR\n  A --> B"} />);
+    await flush(500);
+
+    expect(renderCalls).toHaveLength(2);
+    expect(container.textContent).not.toContain("Failed to render diagram");
+    expect(container.innerHTML).toContain('data-test="recovered"');
+  });
+});

--- a/apps/web/components/shared/mermaid-block.tsx
+++ b/apps/web/components/shared/mermaid-block.tsx
@@ -39,15 +39,20 @@ type MermaidBlockProps = {
   code: string;
 };
 
-export function MermaidBlock({ code }: MermaidBlockProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+type ToastFn = ReturnType<typeof useToast>["toast"];
+
+/**
+ * Debounced mermaid render. Owns the timer, the in-flight cancellation flag,
+ * and the toast-suppression rule (no toast while a previously-rendered svg is
+ * still visible). Returns the rendered svg and the last error so the caller
+ * can decide what to show.
+ */
+function useMermaidRender(code: string, resolvedTheme: string | undefined, toast: ToastFn) {
   const [svg, setSvg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [scale, setScale] = useState(DEFAULT_SCALE);
-  const [svgSize, setSvgSize] = useState<{ w: number; h: number } | null>(null);
-  const [showCode, setShowCode] = useState(false);
-  const { resolvedTheme } = useTheme();
-  const { toast } = useToast();
+  // Synchronous mirror of `svg` so the render closure can decide whether to
+  // toast without re-running the debounce effect on every successful render.
+  const svgRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!code.trim()) return;
@@ -66,6 +71,7 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
         .then(({ svg: rendered }) => {
           cleanupMermaidOrphans(id);
           if (cancelled) return;
+          svgRef.current = rendered;
           setSvg(rendered);
           setError(null);
         })
@@ -73,7 +79,16 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
           cleanupMermaidOrphans(id);
           if (cancelled) return;
           setError(err.message);
-          toast({ title: "Failed to render diagram", description: err.message, variant: "error" });
+          // Suppress the toast when a previously-rendered SVG is still on
+          // screen — the error banner is also suppressed in that case, so a
+          // toast here would surface a failure the user never sees in the UI.
+          if (svgRef.current === null) {
+            toast({
+              title: "Failed to render diagram",
+              description: err.message,
+              variant: "error",
+            });
+          }
         });
     }, RENDER_DEBOUNCE_MS);
 
@@ -82,6 +97,18 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
       clearTimeout(timer);
     };
   }, [code, resolvedTheme, toast]);
+
+  return { svg, error };
+}
+
+export function MermaidBlock({ code }: MermaidBlockProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(DEFAULT_SCALE);
+  const [svgSize, setSvgSize] = useState<{ w: number; h: number } | null>(null);
+  const [showCode, setShowCode] = useState(false);
+  const { resolvedTheme } = useTheme();
+  const { toast } = useToast();
+  const { svg, error } = useMermaidRender(code, resolvedTheme, toast);
 
   // Read intrinsic SVG dimensions once the rendered markup is in the DOM so
   // the zoom transform scales the correct box. Runs after every successful

--- a/apps/web/components/shared/mermaid-block.tsx
+++ b/apps/web/components/shared/mermaid-block.tsx
@@ -55,7 +55,14 @@ function useMermaidRender(code: string, resolvedTheme: string | undefined, toast
   const svgRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!code.trim()) return;
+    if (!code.trim()) {
+      // Source went blank (e.g. a streaming chunk emptied this block) — drop
+      // the previous diagram so we don't keep the stale SVG on screen.
+      svgRef.current = null;
+      setSvg(null);
+      setError(null);
+      return;
+    }
 
     let cancelled = false;
     const theme = resolvedTheme === "dark" ? "dark" : "default";
@@ -116,7 +123,11 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
   useLayoutEffect(() => {
     if (svg && containerRef.current) {
       setSvgSize(getSvgDimensions(containerRef.current));
+      return;
     }
+    // svg reset back to null — drop the stale footprint so the wrapper
+    // doesn't reserve space for a diagram that's no longer rendered.
+    setSvgSize(null);
   }, [svg]);
 
   const zoomIn = useCallback(() => setScale((s) => Math.min(s + SCALE_STEP, MAX_SCALE)), []);

--- a/apps/web/components/shared/mermaid-block.tsx
+++ b/apps/web/components/shared/mermaid-block.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
 import { useTheme } from "next-themes";
 import { IconZoomIn, IconZoomOut, IconCode } from "@tabler/icons-react";
 import {
@@ -26,12 +26,22 @@ function getMermaid(): Promise<MermaidAPI> {
   return mermaidPromise;
 }
 
+/**
+ * Streaming-aware debounce window. Chat messages stream in chunk by chunk and
+ * each intermediate prefix of a mermaid block is almost always invalid
+ * (`subgraph` without `end`, `loop` without `end`, etc). Waiting until the
+ * code prop has been stable for this long collapses the streaming chunks into
+ * a single render attempt so we don't toast on every partial parse error.
+ */
+const RENDER_DEBOUNCE_MS = 300;
+
 type MermaidBlockProps = {
   code: string;
 };
 
 export function MermaidBlock({ code }: MermaidBlockProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [svg, setSvg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [scale, setScale] = useState(DEFAULT_SCALE);
   const [svgSize, setSvgSize] = useState<{ w: number; h: number } | null>(null);
@@ -44,42 +54,54 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
 
     let cancelled = false;
     const theme = resolvedTheme === "dark" ? "dark" : "default";
-    const id = `mermaid-md-${++mermaidIdCounter}`;
-
     const sanitizedCode = sanitizeMermaidCode(code);
 
-    getMermaid()
-      .then((mermaid) => {
-        mermaid.initialize({ startOnLoad: false, theme, securityLevel: "loose" });
-        return mermaid.render(id, sanitizedCode);
-      })
-      .then(({ svg }) => {
-        cleanupMermaidOrphans(id);
-        if (!cancelled && containerRef.current) {
-          containerRef.current.innerHTML = svg;
-          setSvgSize(getSvgDimensions(containerRef.current));
+    const timer = setTimeout(() => {
+      const id = `mermaid-md-${++mermaidIdCounter}`;
+      getMermaid()
+        .then((mermaid) => {
+          mermaid.initialize({ startOnLoad: false, theme, securityLevel: "loose" });
+          return mermaid.render(id, sanitizedCode);
+        })
+        .then(({ svg: rendered }) => {
+          cleanupMermaidOrphans(id);
+          if (cancelled) return;
+          setSvg(rendered);
           setError(null);
-        }
-      })
-      .catch((err: Error) => {
-        cleanupMermaidOrphans(id);
-        if (!cancelled) {
+        })
+        .catch((err: Error) => {
+          cleanupMermaidOrphans(id);
+          if (cancelled) return;
           setError(err.message);
           toast({ title: "Failed to render diagram", description: err.message, variant: "error" });
-        }
-      });
+        });
+    }, RENDER_DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
   }, [code, resolvedTheme, toast]);
+
+  // Read intrinsic SVG dimensions once the rendered markup is in the DOM so
+  // the zoom transform scales the correct box. Runs after every successful
+  // render (svg state change).
+  useLayoutEffect(() => {
+    if (svg && containerRef.current) {
+      setSvgSize(getSvgDimensions(containerRef.current));
+    }
+  }, [svg]);
 
   const zoomIn = useCallback(() => setScale((s) => Math.min(s + SCALE_STEP, MAX_SCALE)), []);
   const zoomOut = useCallback(() => setScale((s) => Math.max(s - SCALE_STEP, MIN_SCALE)), []);
   const zoomReset = useCallback(() => setScale(DEFAULT_SCALE), []);
   const toggleCode = useCallback(() => setShowCode((v) => !v), []);
 
-  if (error) {
+  // Surface the error only when we have no previously-rendered svg to fall
+  // back to. Once a successful render lands, that svg stays visible even if a
+  // later code change fails to parse — better than flashing a red banner over
+  // a diagram that was working a moment ago.
+  if (error !== null && svg === null) {
     return (
       <div className="my-3 rounded-md border border-destructive/30 bg-destructive/5 p-3">
         <p className="text-xs text-destructive mb-2">Failed to render diagram</p>
@@ -105,7 +127,11 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
         style={{ display: showCode ? "none" : undefined }}
       >
         <div style={wrapperStyle}>
-          <div ref={containerRef} style={containerStyle} />
+          <div
+            ref={containerRef}
+            style={containerStyle}
+            dangerouslySetInnerHTML={{ __html: svg ?? "" }}
+          />
         </div>
       </div>
       {showCode && (

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import type { DockviewApi } from "dockview-react";
-import { findSessionAnchorGroupId, reconcileRemovedSessionPanels } from "./dockview-session-tabs";
+import type { TaskSession } from "@/lib/types/http";
+import {
+  findSessionAnchorGroupId,
+  reconcileRemovedSessionPanels,
+  resolveSessionTabSyncTarget,
+} from "./dockview-session-tabs";
 
 type FakePanel = {
   id: string;
@@ -184,5 +189,127 @@ describe("findSessionAnchorGroupId", () => {
     const api = makeApiWithPanels([]);
 
     expect(findSessionAnchorGroupId(api)).toBeNull();
+  });
+});
+
+describe("resolveSessionTabSyncTarget", () => {
+  function makeSession(id: string, taskId: string): TaskSession {
+    return { id, task_id: taskId } as unknown as TaskSession;
+  }
+
+  it("returns the (activeTaskId, sid) pair for a session that belongs to the active task", () => {
+    const target = resolveSessionTabSyncTarget({
+      panelId: "session:s-new",
+      activeTaskId: "task-A",
+      activeSessionId: "s-old",
+      taskSessionsById: { "s-new": makeSession("s-new", "task-A") },
+      environmentIdBySessionId: { "s-new": "env-A" },
+    });
+
+    expect(target).toEqual({ taskId: "task-A", sessionId: "s-new" });
+  });
+
+  it("returns null for non-session panels (sidebar, files, terminal, ...)", () => {
+    for (const panelId of ["sidebar", "files", "changes", "terminal:default", "pr-detail"]) {
+      expect(
+        resolveSessionTabSyncTarget({
+          panelId,
+          activeTaskId: "task-A",
+          activeSessionId: null,
+          taskSessionsById: {},
+          environmentIdBySessionId: {},
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("returns null when the activated session matches activeSessionId (no-op)", () => {
+    const target = resolveSessionTabSyncTarget({
+      panelId: "session:s-current",
+      activeTaskId: "task-A",
+      activeSessionId: "s-current",
+      taskSessionsById: { "s-current": makeSession("s-current", "task-A") },
+      environmentIdBySessionId: { "s-current": "env-A" },
+    });
+
+    expect(target).toBeNull();
+  });
+
+  /**
+   * Regression for a layout-leak observed when creating a new task: during
+   * the task switch dockview can briefly fire `onDidActivePanelChange` for a
+   * stale `session:<oldSid>` panel that still belongs to the previous task.
+   * If we wrote `setActiveSession(newTaskId, oldSid)`, that would poison
+   * `lastSessionByTaskId[newTaskId]` and the next re-entry to the new task
+   * would resolve to the cross-task session, restoring the wrong layout
+   * (e.g. the previous task's files/changes panels).
+   */
+  it("returns null when the activated session belongs to a different task than activeTaskId", () => {
+    const target = resolveSessionTabSyncTarget({
+      panelId: "session:s-belongs-to-B",
+      activeTaskId: "task-A",
+      activeSessionId: null,
+      taskSessionsById: { "s-belongs-to-B": makeSession("s-belongs-to-B", "task-B") },
+      environmentIdBySessionId: { "s-belongs-to-B": "env-B" },
+    });
+
+    expect(target).toBeNull();
+  });
+
+  it("accepts a session that has an env mapping but isn't yet hydrated into taskSessions.items", () => {
+    // The listener can fire before `session.state_changed` lands the new
+    // session in the items map. The env mapping is what guarantees the session
+    // exists at all — once that's present we trust the active task.
+    const target = resolveSessionTabSyncTarget({
+      panelId: "session:s-pending-hydration",
+      activeTaskId: "task-A",
+      activeSessionId: null,
+      taskSessionsById: {},
+      environmentIdBySessionId: { "s-pending-hydration": "env-A" },
+    });
+
+    expect(target).toEqual({ taskId: "task-A", sessionId: "s-pending-hydration" });
+  });
+
+  /**
+   * Regression for a one-frame UI glitch: `removeTaskSession` clears
+   * `taskSessions.items[sid]` and `environmentIdBySessionId[sid]` atomically.
+   * A dying panel firing activation between the clear and unmount must not
+   * write `activeSessionId = <deletedSid>` — the env-mapping gate catches it.
+   */
+  it("returns null when the activated session has no env mapping (deleted or stale)", () => {
+    const target = resolveSessionTabSyncTarget({
+      panelId: "session:s-deleted",
+      activeTaskId: "task-A",
+      activeSessionId: null,
+      taskSessionsById: {},
+      environmentIdBySessionId: {},
+    });
+
+    expect(target).toBeNull();
+  });
+
+  it("returns null when there is no active task", () => {
+    const target = resolveSessionTabSyncTarget({
+      panelId: "session:s",
+      activeTaskId: null,
+      activeSessionId: null,
+      taskSessionsById: {},
+      environmentIdBySessionId: { s: "env-A" },
+    });
+
+    expect(target).toBeNull();
+  });
+
+  it("returns null for a malformed session:<empty> panel id", () => {
+    const target = resolveSessionTabSyncTarget({
+      panelId: "session:",
+      activeTaskId: "task-A",
+      activeSessionId: null,
+      taskSessionsById: {},
+      environmentIdBySessionId: {},
+    });
+
+    expect(target).toBeNull();
   });
 });

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -8,8 +8,50 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { wasPRPanelOffered, markPRPanelOffered } from "@/lib/local-storage";
 import { sessionId as toSessionId } from "@/lib/types/ids";
 import { createDebugLogger, isDebug } from "@/lib/debug/log";
+import type { TaskSession } from "@/lib/types/http";
 
 const debug = createDebugLogger("dockview:session-tabs");
+
+/**
+ * Decide whether `onDidActivePanelChange` should write `setActiveSession`.
+ *
+ * The activated session must belong to the currently-active task. During a
+ * task switch dockview can briefly fire activation for a stale `session:<sid>`
+ * panel that still belongs to the previous task (panels are torn down async).
+ * Writing it would poison `lastSessionByTaskId[newTaskId]` with a session from
+ * a different task, which the next task-re-entry then prefers over the
+ * primary session, restoring the wrong layout.
+ *
+ * Two ownership gates:
+ * 1. Reject when the session is hydrated and known to belong to a different
+ *    task (the primary leak path).
+ * 2. Reject when the session has no `environmentIdBySessionId` entry. The
+ *    session slice clears `taskSessions.items[sid]` and
+ *    `environmentIdBySessionId[sid]` together on `removeTaskSession`, so a
+ *    missing env mapping means the session has been deleted or never existed.
+ *    Writing `activeSessionId = sid` in that window briefly points every
+ *    activeSessionId-consumer (chat / file editor / shell / pr-detail / ...)
+ *    at a dead session.
+ */
+export function resolveSessionTabSyncTarget(args: {
+  panelId: string;
+  activeTaskId: string | null;
+  activeSessionId: string | null;
+  taskSessionsById: Record<string, TaskSession>;
+  environmentIdBySessionId: Record<string, string>;
+}): { taskId: string; sessionId: string } | null {
+  const { panelId, activeTaskId, activeSessionId, taskSessionsById, environmentIdBySessionId } =
+    args;
+  if (!panelId.startsWith("session:")) return null;
+  const sid = panelId.slice("session:".length);
+  if (!sid) return null;
+  if (sid === activeSessionId) return null;
+  if (!activeTaskId) return null;
+  if (!environmentIdBySessionId[sid]) return null;
+  const sessionTaskId = taskSessionsById[sid]?.task_id;
+  if (sessionTaskId && sessionTaskId !== activeTaskId) return null;
+  return { taskId: activeTaskId, sessionId: sid };
+}
 
 /**
  * Sync `activeSessionId` in the store when the user clicks a session tab.
@@ -31,17 +73,30 @@ export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: St
       });
     }
     if (isRestoring) return;
-    if (!panel.id.startsWith("session:")) return;
-    const sid = panel.id.slice("session:".length);
-    if (sid && sid !== appStore.getState().tasks.activeSessionId) {
-      const taskId = appStore.getState().tasks.activeTaskId;
-      if (taskId) {
-        if (isDebug()) {
-          debug("setupSessionTabSync: setActiveSession", { taskId, newSessionId: sid });
-        }
-        appStore.getState().setActiveSession(taskId, sid);
+    const state = appStore.getState();
+    const target = resolveSessionTabSyncTarget({
+      panelId: panel.id,
+      activeTaskId: state.tasks.activeTaskId,
+      activeSessionId: state.tasks.activeSessionId,
+      taskSessionsById: state.taskSessions.items,
+      environmentIdBySessionId: state.environmentIdBySessionId,
+    });
+    if (!target) {
+      if (isDebug() && panel.id.startsWith("session:")) {
+        debug("setupSessionTabSync: skip (stale or cross-task panel)", {
+          panelId: panel.id,
+          activeTaskId: state.tasks.activeTaskId,
+        });
       }
+      return;
     }
+    if (isDebug()) {
+      debug("setupSessionTabSync: setActiveSession", {
+        taskId: target.taskId,
+        newSessionId: target.sessionId,
+      });
+    }
+    state.setActiveSession(target.taskId, target.sessionId);
   });
 }
 

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -505,12 +505,13 @@ export function useSheetActions(workspaceId: string | null, onOpenChange: (open:
       const state = store.getState();
       const task = findTaskInSnapshots(taskId, state.kanbanMulti.snapshots, state.kanban.tasks);
       if (task?.primarySessionId) {
-        const targetSessionId = resolvePreferredSessionId(
+        const targetSessionId = resolvePreferredSessionId({
           taskId,
-          task.primarySessionId,
-          state.tasks.lastSessionByTaskId,
-          state.environmentIdBySessionId,
-        );
+          primarySessionId: task.primarySessionId,
+          lastSessionByTaskId: state.tasks.lastSessionByTaskId,
+          environmentIdBySessionId: state.environmentIdBySessionId,
+          taskSessionsById: state.taskSessions.items,
+        });
         setActiveSession(taskId, targetSessionId);
         loadTaskSessionsForTask(taskId);
         replaceTaskUrl(taskId);

--- a/apps/web/components/task/task-select-helpers.test.ts
+++ b/apps/web/components/task/task-select-helpers.test.ts
@@ -185,6 +185,9 @@ describe("buildSwitchToSession", () => {
  * re-entry, as long as the session still has a known environment.
  */
 describe("selectTaskWithLayout — last-selected session preference", () => {
+  const TASK_ID = "task-A";
+  const PRIMARY = "sess-primary";
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -193,7 +196,12 @@ describe("selectTaskWithLayout — last-selected session preference", () => {
     activeSessionId: string | null;
     envIds: Record<string, string>;
     lastSessionByTaskId?: Record<string, string>;
+    sessionTaskIds?: Record<string, string>;
   }): StoreApi<AppState> {
+    const items: Record<string, { id: string; task_id: string }> = {};
+    for (const [sid, tid] of Object.entries(args.sessionTaskIds ?? {})) {
+      items[sid] = { id: sid, task_id: tid };
+    }
     const state = {
       tasks: {
         activeSessionId: args.activeSessionId,
@@ -201,6 +209,7 @@ describe("selectTaskWithLayout — last-selected session preference", () => {
       },
       taskPRs: { byTaskId: {} as Record<string, unknown[]> },
       environmentIdBySessionId: args.envIds,
+      taskSessions: { items },
     };
     return {
       getState: () => state as unknown as AppState,
@@ -209,21 +218,8 @@ describe("selectTaskWithLayout — last-selected session preference", () => {
     } as unknown as StoreApi<AppState>;
   }
 
-  it("prefers the user's last-selected session over primarySessionId on re-entry", () => {
-    const TASK_ID = "task-A";
-    const PRIMARY = "sess-primary";
-    const LAST = "sess-gpt";
-    const store = makeKanbanStore({
-      activeSessionId: "sess-other-task",
-      envIds: {
-        "sess-other-task": "env-B",
-        [PRIMARY]: "env-A",
-        [LAST]: "env-A",
-      },
-      lastSessionByTaskId: { [TASK_ID]: LAST },
-    });
+  function runSelect(store: StoreApi<AppState>) {
     const switchToSession = vi.fn();
-
     selectTaskWithLayout({
       taskId: TASK_ID,
       task: { primarySessionId: PRIMARY },
@@ -233,53 +229,65 @@ describe("selectTaskWithLayout — last-selected session preference", () => {
       setActiveTask: vi.fn(),
       setPreparingTaskId: vi.fn(),
     });
+    return switchToSession;
+  }
+
+  it("prefers the user's last-selected session over primarySessionId on re-entry", () => {
+    const LAST = "sess-gpt";
+    const switchToSession = runSelect(
+      makeKanbanStore({
+        activeSessionId: "sess-other-task",
+        envIds: { "sess-other-task": "env-B", [PRIMARY]: "env-A", [LAST]: "env-A" },
+        lastSessionByTaskId: { [TASK_ID]: LAST },
+      }),
+    );
 
     expect(switchToSession).toHaveBeenCalledWith(TASK_ID, LAST, "sess-other-task");
   });
 
   it("falls back to primarySessionId when the remembered session has no env mapping", () => {
-    const TASK_ID = "task-A";
-    const PRIMARY = "sess-primary";
-    const LAST = "sess-stale";
-    const store = makeKanbanStore({
-      activeSessionId: null,
-      envIds: { [PRIMARY]: "env-A" },
-      lastSessionByTaskId: { [TASK_ID]: LAST },
-    });
-    const switchToSession = vi.fn();
-
-    selectTaskWithLayout({
-      taskId: TASK_ID,
-      task: { primarySessionId: PRIMARY },
-      store,
-      switchToSession,
-      loadTaskSessionsForTask: vi.fn(async () => []),
-      setActiveTask: vi.fn(),
-      setPreparingTaskId: vi.fn(),
-    });
+    const switchToSession = runSelect(
+      makeKanbanStore({
+        activeSessionId: null,
+        envIds: { [PRIMARY]: "env-A" },
+        lastSessionByTaskId: { [TASK_ID]: "sess-stale" },
+      }),
+    );
 
     expect(switchToSession).toHaveBeenCalledWith(TASK_ID, PRIMARY, null);
   });
 
   it("uses primarySessionId when no last-selected session is recorded for the task", () => {
-    const TASK_ID = "task-A";
-    const PRIMARY = "sess-primary";
-    const store = makeKanbanStore({
-      activeSessionId: null,
-      envIds: { [PRIMARY]: "env-A" },
-      lastSessionByTaskId: {},
-    });
-    const switchToSession = vi.fn();
+    const switchToSession = runSelect(
+      makeKanbanStore({
+        activeSessionId: null,
+        envIds: { [PRIMARY]: "env-A" },
+        lastSessionByTaskId: {},
+      }),
+    );
 
-    selectTaskWithLayout({
-      taskId: TASK_ID,
-      task: { primarySessionId: PRIMARY },
-      store,
-      switchToSession,
-      loadTaskSessionsForTask: vi.fn(async () => []),
-      setActiveTask: vi.fn(),
-      setPreparingTaskId: vi.fn(),
-    });
+    expect(switchToSession).toHaveBeenCalledWith(TASK_ID, PRIMARY, null);
+  });
+
+  /**
+   * Regression for a layout-leak observed when creating a new task: the
+   * dockview tab-sync listener can fire `setActiveSession(newTaskId, oldSid)`
+   * during a task switch (stale panel still live), which writes
+   * `lastSessionByTaskId[newTaskId] = oldSid` even though `oldSid` belongs to
+   * a different task. Without this guard, re-entering the new task would
+   * resolve to that cross-task session, restoring the previous task's
+   * env-scoped panels (files/changes) instead of the new task's primary.
+   */
+  it("falls back to primarySessionId when the remembered session belongs to a different task", () => {
+    const POISONED = "sess-belongs-to-task-B";
+    const switchToSession = runSelect(
+      makeKanbanStore({
+        activeSessionId: null,
+        envIds: { [PRIMARY]: "env-A", [POISONED]: "env-B" },
+        lastSessionByTaskId: { [TASK_ID]: POISONED },
+        sessionTaskIds: { [POISONED]: "task-B", [PRIMARY]: TASK_ID },
+      }),
+    );
 
     expect(switchToSession).toHaveBeenCalledWith(TASK_ID, PRIMARY, null);
   });

--- a/apps/web/components/task/task-select-helpers.ts
+++ b/apps/web/components/task/task-select-helpers.ts
@@ -45,19 +45,30 @@ export function resolveLoadedSessionId(
  * `lastSessionByTaskId`) over `primarySessionId`, so opening a non-primary
  * tab then bouncing through another task does not silently snap the user
  * back to primary. Falls back to `primarySessionId` when the remembered
- * session is unknown / missing an env mapping (e.g. it was deleted).
+ * session is unknown / missing an env mapping (e.g. it was deleted), OR
+ * when it belongs to a different task — the latter guards against a poisoned
+ * `lastSessionByTaskId` entry written by a stale dockview panel-activation
+ * during a task switch (see `setupSessionTabSync`).
  */
-export function resolvePreferredSessionId(
-  taskId: string,
-  primarySessionId: string,
-  lastSessionByTaskId: Record<string, string>,
-  environmentIdBySessionId: Record<string, string>,
-): string {
+export function resolvePreferredSessionId(args: {
+  taskId: string;
+  primarySessionId: string;
+  lastSessionByTaskId: Record<string, string>;
+  environmentIdBySessionId: Record<string, string>;
+  taskSessionsById: Record<string, TaskSession>;
+}): string {
+  const {
+    taskId,
+    primarySessionId,
+    lastSessionByTaskId,
+    environmentIdBySessionId,
+    taskSessionsById,
+  } = args;
   const last = lastSessionByTaskId[taskId];
-  if (last && environmentIdBySessionId[last]) {
-    return last;
-  }
-  return primarySessionId;
+  if (!last || !environmentIdBySessionId[last]) return primarySessionId;
+  const lastTaskId = taskSessionsById[last]?.task_id;
+  if (lastTaskId && lastTaskId !== taskId) return primarySessionId;
+  return last;
 }
 
 export function buildSwitchToSession(
@@ -162,12 +173,13 @@ export function selectTaskWithLayout(params: {
     });
   }
   if (task?.primarySessionId) {
-    const targetSessionId = resolvePreferredSessionId(
+    const targetSessionId = resolvePreferredSessionId({
       taskId,
-      task.primarySessionId,
-      state.tasks.lastSessionByTaskId,
-      state.environmentIdBySessionId,
-    );
+      primarySessionId: task.primarySessionId,
+      lastSessionByTaskId: state.tasks.lastSessionByTaskId,
+      environmentIdBySessionId: state.environmentIdBySessionId,
+      taskSessionsById: state.taskSessions.items,
+    });
     const hasEnvId = !!state.environmentIdBySessionId[targetSessionId];
     if (hasEnvId) {
       switchToSession(taskId, targetSessionId, oldSessionId);

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -994,6 +994,13 @@ export function performLayoutSwitch(
  * that has no session (and prepare failed to launch one). Without this the
  * dockview keeps the outgoing env's panels live but disconnected from any
  * active session, and the corrupted state can be persisted on the next save.
+ *
+ * Flipping `isRestoringLayout` around `buildDefaultLayout(api)` mirrors what
+ * `performEnvSwitch` does and suppresses `setupSessionTabSync` from firing
+ * during the teardown. Without this, dockview can synchronously activate a
+ * stale `session:<sid>` panel (still mounted from the outgoing env) while we
+ * rebuild defaults — poisoning `lastSessionByTaskId[newTaskId]` with the
+ * previous task's session id.
  */
 export function releaseLayoutToDefault(oldEnvId: string | null): void {
   const { api, currentLayoutEnvId, preMaximizeLayout, buildDefaultLayout, pinnedWidths } =
@@ -1005,6 +1012,11 @@ export function releaseLayoutToDefault(oldEnvId: string | null): void {
     preMaximizeLayout: null,
     maximizedGroupId: null,
     currentLayoutEnvId: null,
+    isRestoringLayout: true,
   });
-  buildDefaultLayout(api);
+  try {
+    buildDefaultLayout(api);
+  } finally {
+    useDockviewStore.setState({ isRestoringLayout: false });
+  }
 }

--- a/apps/web/lib/state/dockview-store.ts
+++ b/apps/web/lib/state/dockview-store.ts
@@ -995,12 +995,15 @@ export function performLayoutSwitch(
  * dockview keeps the outgoing env's panels live but disconnected from any
  * active session, and the corrupted state can be persisted on the next save.
  *
- * Flipping `isRestoringLayout` around `buildDefaultLayout(api)` mirrors what
- * `performEnvSwitch` does and suppresses `setupSessionTabSync` from firing
- * during the teardown. Without this, dockview can synchronously activate a
- * stale `session:<sid>` panel (still mounted from the outgoing env) while we
- * rebuild defaults — poisoning `lastSessionByTaskId[newTaskId]` with the
- * previous task's session id.
+ * Pre-setting `isRestoringLayout: true` suppresses `setupSessionTabSync` from
+ * firing during the synchronous setState/saveOutgoingEnv window. Without this,
+ * dockview can synchronously activate a stale `session:<sid>` panel (still
+ * mounted from the outgoing env) while we rebuild defaults — poisoning
+ * `lastSessionByTaskId[newTaskId]` with the previous task's session id.
+ *
+ * `buildDefaultLayout` (`performBuildDefault`) owns the success-path reset: it
+ * re-asserts the flag synchronously and clears it inside its own rAF. We only
+ * clear here on a synchronous throw so the flag does not get stuck.
  */
 export function releaseLayoutToDefault(oldEnvId: string | null): void {
   const { api, currentLayoutEnvId, preMaximizeLayout, buildDefaultLayout, pinnedWidths } =
@@ -1016,7 +1019,8 @@ export function releaseLayoutToDefault(oldEnvId: string | null): void {
   });
   try {
     buildDefaultLayout(api);
-  } finally {
+  } catch (e) {
     useDockviewStore.setState({ isRestoringLayout: false });
+    throw e;
   }
 }


### PR DESCRIPTION
Switching tasks could restore the wrong dockview layout because a stale `session:<sid>` panel from the outgoing task fired `onDidActivePanelChange` after `activeTaskId` had already advanced, poisoning `lastSessionByTaskId[newTaskId]` with a cross-task session id. Layouts now stay isolated per task across switches and new-task creation.

## Important Changes

- `releaseLayoutToDefault` now flips `isRestoringLayout` around `buildDefaultLayout(api)`, mirroring `performEnvSwitch`. Suppresses the listener at the root cause when dockview tears down the outgoing env.
- `resolveSessionTabSyncTarget` rejects sessions whose `task_id` does not match `activeTaskId`, and requires an `environmentIdBySessionId` mapping. The env-mapping gate also closes a one-frame `activeSessionId` glitch during session deletion (`removeTaskSession` clears both maps atomically).
- `resolvePreferredSessionId` was converted to a required options object so future callers cannot silently drop the cross-task guard.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint` (0 warnings)
- `pnpm --filter @kandev/web test` (353 files, 3049 tests, 4 skipped)
- New regression tests in `dockview-session-tabs.test.ts` (cross-task panel + deleted-session env gate) and `task-select-helpers.test.ts` (cross-task remembered session).

## Possible Improvements

Low risk. The env-mapping gate now rejects activations for sessions without a known environment; if a future code path mounts a `session:` panel before populating `environmentIdBySessionId`, the listener will silently no-op the activation until the mapping lands.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.