### PR TITLE
fix(agentctl): order workspace stream wg.Add before publish to fix Close race

### DIFF
--- a/apps/backend/internal/agent/runtime/agentctl/client_close_test.go
+++ b/apps/backend/internal/agent/runtime/agentctl/client_close_test.go
@@ -124,3 +124,57 @@ func TestClientClose_DrainsWorkspaceStream(t *testing.T) {
 		t.Error("StreamWorkspace after Close should return error, got nil")
 	}
 }
+
+// TestClientClose_StreamWorkspaceAddWaitRace exercises the window where one
+// goroutine has just published c.workspaceStream from StreamWorkspace and is
+// about to call stream.wg.Add(2), while another goroutine fires Close —
+// captures the same pointer and calls ws.Wait(). Pre-fix, the race detector
+// flagged Add(2) vs Wait() on the same WaitGroup because Add ran after the
+// publication unlock. With Add moved under the publication lock, the
+// unlock/lock pair carries the Add into Close's view.
+//
+// The test waits for the mock server to observe the WS upgrade before
+// firing Close — that is the same window the failing CI traces showed
+// (test code observes the connection, returns, deferred Close runs while
+// the StreamWorkspace goroutine has not yet reached Add(2)).
+func TestClientClose_StreamWorkspaceAddWaitRace(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		mock := newCloseBarrierMockServer(t)
+		client := newCloseBarrierTestClient(t, mock.server.URL)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+
+		streamErr := make(chan error, 1)
+		go func() {
+			_, err := client.StreamWorkspace(ctx, WorkspaceStreamCallbacks{})
+			streamErr <- err
+		}()
+
+		// Wait until the server side has observed the upgrade — at this point
+		// the client has either just unlocked after publishing the stream or
+		// is about to. Firing Close immediately maximises the chance of
+		// landing in the Add(2)-vs-Wait window.
+		select {
+		case <-mock.connected:
+		case <-time.After(2 * time.Second):
+			cancel()
+			t.Fatalf("iteration %d: mock never observed WS upgrade", i)
+		}
+
+		closeDone := make(chan struct{})
+		go func() {
+			client.Close()
+			close(closeDone)
+		}()
+
+		select {
+		case <-closeDone:
+		case <-time.After(3 * time.Second):
+			cancel()
+			t.Fatalf("iteration %d: Close did not return within 3s", i)
+		}
+		<-streamErr
+		cancel()
+	}
+}

--- a/apps/backend/internal/agent/runtime/agentctl/client_close_test.go
+++ b/apps/backend/internal/agent/runtime/agentctl/client_close_test.go
@@ -139,11 +139,12 @@ func TestClientClose_DrainsWorkspaceStream(t *testing.T) {
 // the StreamWorkspace goroutine has not yet reached Add(2)).
 func TestClientClose_StreamWorkspaceAddWaitRace(t *testing.T) {
 	const iterations = 100
-	for i := 0; i < iterations; i++ {
+	runIter := func(i int) {
 		mock := newCloseBarrierMockServer(t)
 		client := newCloseBarrierTestClient(t, mock.server.URL)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
 
 		streamErr := make(chan error, 1)
 		go func() {
@@ -158,7 +159,6 @@ func TestClientClose_StreamWorkspaceAddWaitRace(t *testing.T) {
 		select {
 		case <-mock.connected:
 		case <-time.After(2 * time.Second):
-			cancel()
 			t.Fatalf("iteration %d: mock never observed WS upgrade", i)
 		}
 
@@ -171,10 +171,11 @@ func TestClientClose_StreamWorkspaceAddWaitRace(t *testing.T) {
 		select {
 		case <-closeDone:
 		case <-time.After(3 * time.Second):
-			cancel()
 			t.Fatalf("iteration %d: Close did not return within 3s", i)
 		}
 		<-streamErr
-		cancel()
+	}
+	for i := 0; i < iterations; i++ {
+		runIter(i)
 	}
 }

--- a/apps/backend/internal/agent/runtime/agentctl/workspace_stream.go
+++ b/apps/backend/internal/agent/runtime/agentctl/workspace_stream.go
@@ -85,17 +85,20 @@ func (c *Client) StreamWorkspace(ctx context.Context, callbacks WorkspaceStreamC
 		_ = conn.Close()
 		return nil, fmt.Errorf("workspace stream already connected")
 	}
+	// Track both goroutines on the per-stream wg so WorkspaceStream.Wait can
+	// block until they have fully unwound. Add(2) must happen-before the
+	// stream pointer is published to c.workspaceStream: otherwise a concurrent
+	// Client.Close captures the new stream, calls ws.Wait() at counter 0, and
+	// races the subsequent Add(2). The read loop only invokes data callbacks
+	// (shell/git/process) and self-closes on exit — it never re-enters manager
+	// teardown — so draining it is side-effect-free.
+	stream.wg.Add(2)
 	c.workspaceStreamConn = conn
 	c.workspaceStream = stream
 	c.mu.Unlock()
 
 	c.logger.Info("connected to workspace stream", zap.String("url", wsURL))
 
-	// Track both goroutines on the per-stream wg so WorkspaceStream.Wait can
-	// block until they have fully unwound. The workspace read loop only invokes
-	// data callbacks (shell/git/process) and self-closes on exit — it never
-	// re-enters manager teardown — so draining it is side-effect-free.
-	stream.wg.Add(2)
 	go func() {
 		defer stream.wg.Done()
 		c.readWorkspaceStream(conn, stream, callbacks)


### PR DESCRIPTION
## Summary
- Fix the `WARNING: DATA RACE` on `WorkspaceStream.wg` (Add(2) vs Wait()) that has been failing **Backend Tests** on `main` for the last several pushes (`TestInitializeAndPrompt_StreamBeforeInitialize`, `TestManager_RestartAgentProcess_StopErrorIsNonFatal`).
- `Client.StreamWorkspace` published `c.workspaceStream = stream` under the lock, then released the lock and ran `stream.wg.Add(2)` afterwards. A concurrent `Client.Close` could capture the new pointer under the same lock and call `ws.Wait()` outside it — racing the not-yet-executed `Add(2)` on a counter still at 0.
- Move `stream.wg.Add(2)` under the same lock that publishes the pointer. The unlock/lock pair now carries the Add into `Close`'s view, so any caller that observes `c.workspaceStream` already sees the counter bumped before invoking `Wait`.
- Add `TestClientClose_StreamWorkspaceAddWaitRace` — waits for the mock server to observe the WS upgrade, then fires `Close` in parallel with `StreamWorkspace`. Pre-fix it deterministically triggers the same race in under 10 iterations; post-fix it stays quiet across 200+ iterations under `-race`.

### Race trace from CI (run 26925964563)

```
Write at 0x00c0005ccff0 by goroutine 1302:
  WorkspaceStream.Wait()  workspace_stream.go:228
  Client.Close()           client.go:693
  deferred test cleanup

Previous read at 0x00c0005ccff0 by goroutine 1305:
  Client.StreamWorkspace() workspace_stream.go:98  ← stream.wg.Add(2)
  StreamManager.connectWorkspaceStream  streams.go:442
  StreamManager.start.func1             streams.go:203
```

## Test plan
- [x] `go test -race -count=1 ./internal/agent/runtime/...` — green
- [x] `go test -race -run TestClientClose_StreamWorkspaceAddWaitRace -count=20 -cpu=8 ./internal/agent/runtime/agentctl/` — green
- [x] Revert fix locally → new regression test reliably fails under `-race`
- [x] `make fmt lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)