### PR TITLE
fix(repo): exclude archived tasks from repository delete guard

### DIFF
--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -779,12 +779,16 @@ func (r *Repository) HasActiveTaskSessionsByEnvironment(ctx context.Context, env
 
 func (r *Repository) HasActiveTaskSessionsByRepository(ctx context.Context, repositoryID string) (bool, error) {
 	var exists int
+	// Only sessions of live (non-archived) tasks count; archived tasks never
+	// block repository deletion.
 	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
 		SELECT 1
 		FROM task_sessions s
 		INNER JOIN task_repositories tr ON tr.task_id = s.task_id
+		INNER JOIN tasks t ON t.id = s.task_id
 		WHERE s.state IN ('CREATED', 'STARTING', 'RUNNING', 'WAITING_FOR_INPUT')
 			AND tr.repository_id = ?
+			AND t.archived_at IS NULL
 		LIMIT 1
 	`), repositoryID).Scan(&exists)
 	if err == sql.ErrNoRows {
@@ -795,12 +799,16 @@ func (r *Repository) HasActiveTaskSessionsByRepository(ctx context.Context, repo
 
 func (r *Repository) CountActiveTaskSessionsByRepository(ctx context.Context, repositoryID string) (int, error) {
 	var count int
+	// Counts only sessions of live (non-archived) tasks, matching
+	// HasActiveTaskSessionsByRepository.
 	err := r.ro.QueryRowContext(ctx, r.ro.Rebind(`
 		SELECT COUNT(*)
 		FROM task_sessions s
 		INNER JOIN task_repositories tr ON tr.task_id = s.task_id
+		INNER JOIN tasks t ON t.id = s.task_id
 		WHERE s.state IN ('CREATED', 'STARTING', 'RUNNING', 'WAITING_FOR_INPUT')
 			AND tr.repository_id = ?
+			AND t.archived_at IS NULL
 	`), repositoryID).Scan(&count)
 	if err != nil {
 		return 0, err

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -385,3 +385,73 @@ func TestCountActiveTaskSessionsByRepository_RequiresJoinRow(t *testing.T) {
 		t.Errorf("expected only the linked session to be counted, got %d", count)
 	}
 }
+
+// archiveTask marks a seeded task as archived so the repo-delete guard tests
+// can exercise the archived_at exclusion.
+func archiveTask(t *testing.T, repo *Repository, taskID string) {
+	t.Helper()
+	if _, err := repo.db.Exec(repo.db.Rebind(
+		`UPDATE tasks SET archived_at = ? WHERE id = ?`), time.Now().UTC(), taskID); err != nil {
+		t.Fatalf("archive task %s: %v", taskID, err)
+	}
+}
+
+// TestCountActiveTaskSessionsByRepository_ExcludesArchivedTasks verifies that an
+// active session belonging to an archived task is not counted, so archived tasks
+// never block repository deletion, while a live task's active session still is.
+func TestCountActiveTaskSessionsByRepository_ExcludesArchivedTasks(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	// Active session on an archived task — must NOT count.
+	seedRepoLink(t, repo, "ws-x", "repo-x", "task-x1", "sess-x1", "WAITING_FOR_INPUT")
+	archiveTask(t, repo, "task-x1")
+
+	count, err := repo.CountActiveTaskSessionsByRepository(ctx, "repo-x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("archived task must not block deletion, got %d active sessions", count)
+	}
+
+	// A live (non-archived) task with an active session on the same repo still
+	// counts — pins that the archived_at filter did not over-broaden.
+	seedRepoLink(t, repo, "ws-x", "repo-x", "task-x2", "sess-x2", "RUNNING")
+	count, err = repo.CountActiveTaskSessionsByRepository(ctx, "repo-x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("live task session must still count, got %d", count)
+	}
+}
+
+// TestHasActiveTaskSessionsByRepository_ExcludesArchivedTasks verifies the
+// boolean delete guard mirrors the count: an archived task's active session
+// does not report the repository as in use, but a live task's does.
+func TestHasActiveTaskSessionsByRepository_ExcludesArchivedTasks(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	seedRepoLink(t, repo, "ws-h", "repo-h", "task-h1", "sess-h1", "WAITING_FOR_INPUT")
+	archiveTask(t, repo, "task-h1")
+
+	active, err := repo.HasActiveTaskSessionsByRepository(ctx, "repo-h")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Error("archived task must not mark repository as having active sessions")
+	}
+
+	// Add a live task on the same repo — now it must report active.
+	seedRepoLink(t, repo, "ws-h", "repo-h", "task-h2", "sess-h2", "RUNNING")
+	active, err = repo.HasActiveTaskSessionsByRepository(ctx, "repo-h")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !active {
+		t.Error("live task session must mark repository as active")
+	}
+}


### PR DESCRIPTION
## Problem

Deleting a repository fails with *"still linked to active tasks"* even when no task is active. The guard (`HasActiveTaskSessionsByRepository` / `CountActiveTaskSessionsByRepository` in `task/repository/sqlite/session.go`) blocks deletion whenever a linked `task_session` is in an active state (`CREATED`/`STARTING`/`RUNNING`/`WAITING_FOR_INPUT`).

The trap: when an agent finishes a turn it parks the session in `WAITING_FOR_INPUT` indefinitely. **Archiving the task does not transition its sessions out of that state** — archival only sets `tasks.archived_at`/`state`. Since the guard never filtered on `archived_at`, a long-finished, archived task kept its repository permanently undeletable. The UI label says "active tasks", but the real predicate is "active task *sessions*", and archived tasks are invisible on the board — so users see "no active tasks" yet cannot delete.

Observed on a real instance: 124 sessions stuck in `WAITING_FOR_INPUT` (110 on archived tasks), 0 actually running, blocking 12 repositories.

## Fix

Join `tasks` and add `AND t.archived_at IS NULL` to both guard queries, mirroring the existing idiom in `session_branch.go`. Archived tasks no longer block deletion; live (non-archived) tasks with resumable sessions still block it exactly as before.

## Tests

- `TestCountActiveTaskSessionsByRepository_ExcludesArchivedTasks` — archived task's active session does not count; a live task on the same repo still does (guards against over-broadening).
- `TestHasActiveTaskSessionsByRepository_ExcludesArchivedTasks` — boolean guard mirrors the count.

Verified red before the fix, green after.

```
make -C apps/backend fmt   # clean
go vet ./internal/task/repository/sqlite/   # clean
go build ./...   # clean
go test -race -count=1 ./internal/task/repository/sqlite/   # ok
golangci-lint run ./internal/task/repository/sqlite/...   # 0 issues
```

## Note / possible follow-up

This fixes the guard. A deeper option (out of scope here to keep the change minimal) is to have task archival reap its sessions into a terminal state, so archived tasks never retain `WAITING_FOR_INPUT` rows at all.