### PR TITLE
fix(task): reap active sessions when archiving a task

### DIFF
--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -267,6 +267,9 @@ func (m *mockRepository) ListActiveTaskSessions(ctx context.Context) ([]*models.
 func (m *mockRepository) ListActiveTaskSessionsByTaskID(ctx context.Context, taskID string) ([]*models.TaskSession, error) {
 	return nil, nil
 }
+func (m *mockRepository) CancelActiveTaskSessionsByTaskID(ctx context.Context, taskID, reason string) (int64, error) {
+	return 0, nil
+}
 func (m *mockRepository) HasActiveTaskSessionsByAgentProfile(ctx context.Context, agentProfileID string) (bool, error) {
 	return false, nil
 }

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -140,6 +140,7 @@ type SessionRepository interface {
 	ListTaskSessions(ctx context.Context, taskID string) ([]*models.TaskSession, error)
 	ListActiveTaskSessions(ctx context.Context) ([]*models.TaskSession, error)
 	ListActiveTaskSessionsByTaskID(ctx context.Context, taskID string) ([]*models.TaskSession, error)
+	CancelActiveTaskSessionsByTaskID(ctx context.Context, taskID, reason string) (int64, error)
 	HasActiveTaskSessionsByAgentProfile(ctx context.Context, agentProfileID string) (bool, error)
 	GetActiveTaskInfoByAgentProfile(ctx context.Context, agentProfileID string) ([]agentdto.ActiveTaskInfo, error)
 	HasActiveTaskSessionsByExecutor(ctx context.Context, executorID string) (bool, error)

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -514,6 +514,25 @@ func (r *Repository) UpdateTaskSessionState(ctx context.Context, id string, stat
 	return nil
 }
 
+// CancelActiveTaskSessionsByTaskID transitions every active session of a task
+// (CREATED/STARTING/RUNNING/WAITING_FOR_INPUT) to CANCELLED, returning the
+// number of rows changed. The transition is a pure DB state change and does not
+// require a live agent execution, making it the authoritative way to finalize a
+// task's sessions independent of agent-process teardown.
+func (r *Repository) CancelActiveTaskSessionsByTaskID(ctx context.Context, taskID, reason string) (int64, error) {
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+		UPDATE task_sessions
+		SET state = ?, error_message = ?, completed_at = ?, updated_at = ?
+		WHERE task_id = ?
+			AND state IN ('CREATED', 'STARTING', 'RUNNING', 'WAITING_FOR_INPUT')
+	`), string(models.TaskSessionStateCancelled), reason, now, now, taskID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 // UpdateSessionMetadata updates only the metadata column of a session,
 // avoiding a full-row overwrite that could clobber concurrent field updates.
 func (r *Repository) UpdateSessionMetadata(ctx context.Context, sessionID string, metadata map[string]interface{}) error {

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -455,3 +455,115 @@ func TestHasActiveTaskSessionsByRepository_ExcludesArchivedTasks(t *testing.T) {
 		t.Error("live task session must mark repository as active")
 	}
 }
+
+// insertSession inserts a task_session row in the given state directly, for
+// seeding multiple sessions on a single task (seedRepoLink can only create one
+// session per task because its task_repositories PK is keyed on task+repo).
+func insertSession(t *testing.T, repo *Repository, sessionID, taskID, state string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := repo.db.Exec(repo.db.Rebind(`
+		INSERT INTO task_sessions (id, task_id, state, started_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+	`), sessionID, taskID, state, now, now); err != nil {
+		t.Fatalf("seed session %s: %v", sessionID, err)
+	}
+}
+
+func sessionState(t *testing.T, repo *Repository, sessionID string) string {
+	t.Helper()
+	var state string
+	if err := repo.ro.QueryRowx(repo.ro.Rebind(
+		`SELECT state FROM task_sessions WHERE id = ?`), sessionID).Scan(&state); err != nil {
+		t.Fatalf("read state for %s: %v", sessionID, err)
+	}
+	return state
+}
+
+func sessionCancellationMetadata(t *testing.T, repo *Repository, sessionID string) (string, sql.NullTime, time.Time) {
+	t.Helper()
+	var errorMessage string
+	var completedAt sql.NullTime
+	var updatedAt time.Time
+	if err := repo.ro.QueryRowx(repo.ro.Rebind(
+		`SELECT error_message, completed_at, updated_at FROM task_sessions WHERE id = ?`),
+		sessionID,
+	).Scan(&errorMessage, &completedAt, &updatedAt); err != nil {
+		t.Fatalf("read cancellation metadata for %s: %v", sessionID, err)
+	}
+	return errorMessage, completedAt, updatedAt
+}
+
+func assertReapedSession(t *testing.T, repo *Repository, sessionID string, reapedAfter time.Time) {
+	t.Helper()
+	if got := sessionState(t, repo, sessionID); got != "CANCELLED" {
+		t.Errorf("%s = %q, want CANCELLED", sessionID, got)
+	}
+	errorMessage, completedAt, updatedAt := sessionCancellationMetadata(t, repo, sessionID)
+	if errorMessage != "task archived" {
+		t.Errorf("%s error_message = %q, want task archived", sessionID, errorMessage)
+	}
+	if !completedAt.Valid {
+		t.Errorf("%s completed_at should be set", sessionID)
+	}
+	if updatedAt.Before(reapedAfter) {
+		t.Errorf("%s updated_at = %s, want >= %s", sessionID, updatedAt, reapedAfter)
+	}
+}
+
+// TestCancelActiveTaskSessionsByTaskID verifies the archive reaper transitions
+// only the target task's still-active sessions to CANCELLED, leaves terminal
+// sessions and other tasks untouched, and reports the rows changed. It also
+// confirms the repo-delete guard reports the repository as free afterward —
+// the end-to-end purpose of the reap.
+func TestCancelActiveTaskSessionsByTaskID(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	// Target task: one active session via the link helper, plus a second active
+	// session, two pre-run sessions, and an already-terminal session inserted directly.
+	seedRepoLink(t, repo, "ws-r", "repo-r", "task-r", "sess-r1", "WAITING_FOR_INPUT")
+	insertSession(t, repo, "sess-r2", "task-r", "RUNNING")
+	insertSession(t, repo, "sess-r3", "task-r", "CREATED")
+	insertSession(t, repo, "sess-r4", "task-r", "STARTING")
+	insertSession(t, repo, "sess-r5", "task-r", "COMPLETED")
+	// A different task on a different repo — must be untouched.
+	seedRepoLink(t, repo, "ws-r", "repo-other", "task-other", "sess-o1", "RUNNING")
+
+	reapedAfter := time.Now().UTC()
+	reaped, err := repo.CancelActiveTaskSessionsByTaskID(ctx, "task-r", "task archived")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reaped != 4 {
+		t.Errorf("expected 4 active sessions reaped, got %d", reaped)
+	}
+	for _, sessionID := range []string{"sess-r1", "sess-r2", "sess-r3", "sess-r4"} {
+		assertReapedSession(t, repo, sessionID, reapedAfter)
+	}
+	if got := sessionState(t, repo, "sess-r5"); got != "COMPLETED" {
+		t.Errorf("sess-r5 (terminal) = %q, want unchanged COMPLETED", got)
+	}
+	if got := sessionState(t, repo, "sess-o1"); got != "RUNNING" {
+		t.Errorf("sess-o1 (other task) = %q, want unchanged RUNNING", got)
+	}
+
+	// End-to-end: the repository that only the reaped task referenced is now
+	// reported as free by the delete guard.
+	active, err := repo.HasActiveTaskSessionsByRepository(ctx, "repo-r")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Error("repo-r should have no active sessions after reaping its task")
+	}
+
+	// Idempotent: a second call changes nothing.
+	reaped, err = repo.CancelActiveTaskSessionsByTaskID(ctx, "task-r", "task archived")
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	if reaped != 0 {
+		t.Errorf("expected 0 rows on idempotent re-run, got %d", reaped)
+	}
+}

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -788,6 +788,19 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 		return err
 	}
 
+	// 3b. Finalize active sessions in the DB. The async cleanup below tears down
+	// the agent processes; this records the terminal session state, which
+	// process teardown does not persist on its own.
+	if reaped, rerr := s.sessions.CancelActiveTaskSessionsByTaskID(ctx, id, "task archived"); rerr != nil {
+		s.logger.Warn("failed to reap active sessions on archive",
+			zap.String("task_id", id),
+			zap.Error(rerr))
+	} else if reaped > 0 {
+		s.logger.Info("reaped active sessions on archive",
+			zap.String("task_id", id),
+			zap.Int64("count", reaped))
+	}
+
 	// 4. Re-read task for updated archived_at field
 	task, err = s.tasks.GetTask(ctx, id)
 	if err != nil {


### PR DESCRIPTION
## Problem

Archiving a task leaves its agent sessions in `WAITING_FOR_INPUT` **forever**. Because the repository-delete guard counts any `CREATED/STARTING/RUNNING/WAITING_FOR_INPUT` session as "active", these orphaned sessions make the task's repository permanently undeletable — surfacing in the UI as *"still linked to active tasks"* when no task is actually active.

Observed on a real instance: 124 sessions stuck in `WAITING_FOR_INPUT` (110 on archived tasks), 0 actually running, blocking 12 repositories.

## Root cause

`WAITING_FOR_INPUT` is the correct resting state for a live interactive session between turns (`manager_events.go` — *"after the previous turn ended the session is WaitingForInput"*), so that part is by design. The bug is that **archival's session reaping silently no-ops when the agent process is already gone**:

- `Service.ArchiveTask` gathers active sessions and runs `runAsyncTaskCleanup` → `StopExecution(executionID)` / `StopSession(sessionID)`.
- `StopExecution` (`executor_interaction.go`) only calls `StopAgentWithReason` — it **never writes session state**; it relies on the agent emitting a terminal event.
- `StopSession` → `stopWithSession` marks `CANCELLED` (`:46`) **only after** `GetExecutionIDForSession` succeeds — it returns `ErrExecutionNotFound` at `:33‑35` first when there's no live execution.

The in-memory execution store doesn't survive restarts and idle runtimes get torn down, so for any session parked in `WAITING_FOR_INPUT` across a restart there is no live execution → neither path transitions the DB state. (The same gap affects `CancelTaskExecution` → `StopByTaskID` → `stopWithSession`; see follow-up below.)

## Fix

Reap active sessions to `CANCELLED` directly in the DB at the archive boundary — synchronously and unconditionally, decoupled from process liveness. This mirrors `stopWithSession`'s own *"mark terminal in the DB, then tear down the process async"* split, and `CANCELLED` matches the state every other teardown path already produces (an archived, parked session was stopped externally, not finished successfully — so not `COMPLETED`). The async process teardown is unchanged; `task.state` is intentionally left untouched (archival is orthogonal to the kanban column).

New repo method `CancelActiveTaskSessionsByTaskID` (single `UPDATE` over the active-state set, mirroring `UpdateTaskSessionState`'s terminal `completed_at` handling), added to the `SessionRepository` interface and called from `Service.ArchiveTask` (which also covers the auto-archive path).

## Tests

`TestCancelActiveTaskSessionsByTaskID`: reaps only the target task's active sessions; leaves terminal sessions and other tasks untouched; reports rows changed; idempotent; and the repo-delete guard reports the repository free afterward.

```
make -C apps/backend fmt   # clean
go vet ./...   # clean
go build ./...   # clean
go test -race -count=1 ./internal/task/repository/sqlite/ ./internal/task/service/ ./internal/task/handlers/   # ok
golangci-lint run ./internal/task/repository/... ./internal/task/service/...   # 0 issues
```

## Relationship to the guard PR / follow-up

- Companion to the repo-delete guard PR (excludes archived tasks from the guard) — that's defense-in-depth and handles historical rows; **this PR fixes the generator** so new archived tasks stop accumulating active sessions.
- **Follow-up (not in this PR):** `stopWithSession` returning before its `CANCELLED` write when no live execution exists is a latent gap shared by all cancel-based paths (cascade `ArchiveTaskTree` → `cancelActiveRuns`, office tree controls, workspace deletion). Worth fixing at the executor primitive so those paths also reap state when the agent is already gone.