### PR TITLE
fix(backend): defer move_task when session is running

### DIFF
--- a/apps/backend/internal/mcp/handlers/config_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_handlers_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 	ws "github.com/kandev/kandev/pkg/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -390,6 +392,19 @@ func (r *recordingMessageQueuer) QueueMessage(_ context.Context, sessionID, task
 	return &msg, nil
 }
 
+type pendingMoveRecordingQueuer struct {
+	recordingMessageQueuer
+	pendingSessionID string
+	pendingMoves     []messagequeue.PendingMove
+}
+
+func (r *pendingMoveRecordingQueuer) SetPendingMove(_ context.Context, sessionID string, move *messagequeue.PendingMove) {
+	r.pendingSessionID = sessionID
+	if move != nil {
+		r.pendingMoves = append(r.pendingMoves, *move)
+	}
+}
+
 func (r *recordingMessageQueuer) SetPendingMove(_ context.Context, _ string, _ *messagequeue.PendingMove) {
 }
 
@@ -516,6 +531,66 @@ func TestHandleUpdateTaskState_MissingState(t *testing.T) {
 	resp, err := h.handleUpdateTaskState(context.Background(), msg)
 	require.NoError(t, err)
 	assertWSError(t, resp, ws.ErrorCodeValidation)
+}
+
+// TestHandleMoveTask_ActiveSessionWithoutPrompt_DefersMove pins the production
+// bug where an agent on Work called move_task_kandev → Done without a prompt
+// mid-turn. The immediate path hit validateMoveSessions (RUNNING session) and
+// returned INTERNAL_ERROR. Active-session moves must always defer.
+func TestHandleMoveTask_ActiveSessionWithoutPrompt_DefersMove(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{
+		ID: "ws-move", Name: "Move", CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, repo.CreateWorkflow(ctx, &models.Workflow{
+		ID: "wf-move", WorkspaceID: "ws-move", Name: "Board", CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, repo.CreateTask(ctx, &models.Task{
+		ID: "task-move", WorkspaceID: "ws-move", WorkflowID: "wf-move",
+		WorkflowStepID: "step-work", Title: "Move me", State: v1.TaskStateInProgress,
+		CreatedAt: now, UpdatedAt: now,
+	}))
+	require.NoError(t, repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID: "sess-move", TaskID: "task-move", State: models.TaskSessionStateRunning,
+		IsPrimary: true, StartedAt: now, UpdatedAt: now,
+	}))
+
+	queue := &pendingMoveRecordingQueuer{}
+	h := &Handlers{
+		taskSvc:      svc,
+		messageQueue: queue,
+		logger:       testLogger(t).WithFields(),
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMoveTask, map[string]interface{}{
+		"task_id":          "task-move",
+		"workflow_id":      "wf-move",
+		"workflow_step_id": "step-done",
+		"position":         0,
+	})
+
+	resp, err := h.handleMoveTask(ctx, msg)
+	require.NoError(t, err)
+	assert.NotEqual(t, ws.MessageTypeError, resp.Type, "active-session move without prompt must not fail")
+
+	require.Len(t, queue.pendingMoves, 1)
+	assert.Equal(t, "step-done", queue.pendingMoves[0].WorkflowStepID)
+	assert.Equal(t, "sess-move", queue.pendingSessionID)
+	assert.Empty(t, queue.calls, "no hand-off prompt should be queued when prompt omitted")
+
+	task, err := svc.GetTask(ctx, "task-move")
+	require.NoError(t, err)
+	assert.Equal(t, "step-work", task.WorkflowStepID, "deferred move must not apply immediately")
+}
+
+func TestNormalizeTaskState_AcceptsCommonAliases(t *testing.T) {
+	assert.Equal(t, v1.TaskStateCompleted, normalizeTaskState("complete"))
+	assert.Equal(t, v1.TaskStateCompleted, normalizeTaskState("DONE"))
+	assert.Equal(t, v1.TaskStateInProgress, normalizeTaskState("in_progress"))
+	assert.Equal(t, v1.TaskStateTODO, normalizeTaskState("open"))
 }
 
 func TestHandleUpdateTaskState_InvalidPayload(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/config_task_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_task_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/task/dto"
@@ -50,13 +51,15 @@ func (h *Handlers) handleMoveTask(ctx context.Context, msg *ws.Message) (*ws.Mes
 			"failed to look up task's primary session", nil)
 	}
 
-	// Active source session + prompt → deferred path. Running MoveTask now
-	// would race on_enter processing against the agent's still-active turn —
-	// corrupting session state and orphaning the queued prompt. Defer until
-	// handleAgentReady fires applyPendingMove on turn-end.
-	if req.Prompt != "" && session != nil &&
+	// Active source session → deferred path. Running MoveTask immediately would
+	// fail validateMoveSessions ("task has an active session (RUNNING)") and,
+	// if it somehow succeeded, would race on_enter processing against the
+	// agent's still-active turn. Defer until handleAgentReady fires
+	// applyPendingMove on turn-end. Prompt is optional: omit it for simple
+	// self-moves (e.g. Work → Done); include it for cross-agent hand-offs.
+	if session != nil &&
 		(session.State == models.TaskSessionStateRunning || session.State == models.TaskSessionStateStarting) {
-		return h.deferMoveTaskWithPrompt(ctx, msg, req, session)
+		return h.deferMoveTask(ctx, msg, req, session)
 	}
 
 	// Idle path — apply immediately. If a prompt was supplied, queue it on the
@@ -64,11 +67,11 @@ func (h *Handlers) handleMoveTask(ctx context.Context, msg *ws.Message) (*ws.Mes
 	return h.applyMoveTaskImmediate(ctx, msg, req, session)
 }
 
-// deferMoveTaskWithPrompt queues the hand-off prompt + records a PendingMove
-// for the agent's turn-end handler to apply. Used when the source session is
-// active and the caller supplied a prompt. Returns a synthetic moved-task DTO
-// so the agent's tool call resolves successfully and ends the turn cleanly.
-func (h *Handlers) deferMoveTaskWithPrompt(
+// deferMoveTask records a PendingMove for the agent's turn-end handler to
+// apply. Optionally queues a hand-off prompt when the caller supplied one.
+// Returns a synthetic moved-task DTO so the agent's tool call resolves
+// successfully and ends the turn cleanly.
+func (h *Handlers) deferMoveTask(
 	ctx context.Context,
 	msg *ws.Message,
 	req struct {
@@ -86,12 +89,14 @@ func (h *Handlers) deferMoveTaskWithPrompt(
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
 			"move_task requires message queue support while the source session is active", nil)
 	}
-	wrapped := "You were moved to this step with the following message: " + req.Prompt
-	if err := h.queueMoveTaskPrompt(ctx, req.TaskID, session.ID, wrapped); err != nil {
-		h.logger.Error("move_task: failed to queue hand-off prompt",
-			zap.String("task_id", req.TaskID), zap.String("session_id", session.ID), zap.Error(err))
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
-			"failed to queue move_task hand-off prompt", nil)
+	if req.Prompt != "" {
+		wrapped := "You were moved to this step with the following message: " + req.Prompt
+		if err := h.queueMoveTaskPrompt(ctx, req.TaskID, session.ID, wrapped); err != nil {
+			h.logger.Error("move_task: failed to queue hand-off prompt",
+				zap.String("task_id", req.TaskID), zap.String("session_id", session.ID), zap.Error(err))
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+				"failed to queue move_task hand-off prompt", nil)
+		}
 	}
 	h.messageQueue.SetPendingMove(ctx, session.ID, &messagequeue.PendingMove{
 		TaskID:         req.TaskID,
@@ -260,7 +265,7 @@ func (h *Handlers) handleUpdateTaskState(ctx context.Context, msg *ws.Message) (
 	if req.State == "" {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "state is required", nil)
 	}
-	state := v1.TaskState(req.State)
+	state := normalizeTaskState(req.State)
 	switch state {
 	case v1.TaskStateTODO, v1.TaskStateCreated, v1.TaskStateScheduling,
 		v1.TaskStateInProgress, v1.TaskStateReview, v1.TaskStateBlocked,
@@ -277,4 +282,39 @@ func (h *Handlers) handleUpdateTaskState(ctx context.Context, msg *ws.Message) (
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to update task state", nil)
 	}
 	return ws.NewResponse(msg.ID, msg.Action, dto.FromTask(task))
+}
+
+// normalizeTaskState maps common agent-supplied aliases to canonical TaskState
+// values. Agents often send lowercase or shorthand strings (e.g. "complete",
+// "done") that are not valid v1.TaskState constants.
+func normalizeTaskState(raw string) v1.TaskState {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return v1.TaskState("")
+	}
+	upper := strings.ToUpper(trimmed)
+	switch upper {
+	case "OPEN", "TODO":
+		return v1.TaskStateTODO
+	case "IN_PROGRESS", "INPROGRESS", "ACTIVE":
+		return v1.TaskStateInProgress
+	case "COMPLETE", "COMPLETED", "DONE":
+		return v1.TaskStateCompleted
+	case "BLOCKED":
+		return v1.TaskStateBlocked
+	case "CANCELLED", "CANCELED":
+		return v1.TaskStateCancelled
+	case "REVIEW":
+		return v1.TaskStateReview
+	case "FAILED":
+		return v1.TaskStateFailed
+	case "CREATED":
+		return v1.TaskStateCreated
+	case "SCHEDULING":
+		return v1.TaskStateScheduling
+	case "WAITING_FOR_INPUT", "WAITING":
+		return v1.TaskStateWaitingForInput
+	default:
+		return v1.TaskState(trimmed)
+	}
 }

--- a/apps/backend/internal/mcp/server/config_handlers.go
+++ b/apps/backend/internal/mcp/server/config_handlers.go
@@ -262,12 +262,12 @@ func (s *Server) registerConfigTaskTools() {
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("move_task_kandev",
-			mcp.WithDescription("Move a task to a different workflow step. Optionally send a hand-off prompt to the receiving agent — required only when handing the task off mid-turn (e.g. QA → review) with specific instructions. Plain admin/config moves can omit prompt."),
+			mcp.WithDescription("Move a task to a different workflow step. When the source session is mid-turn (RUNNING), the move is deferred to turn-end automatically — prompt is optional (use it for cross-agent hand-offs). Idle-session and admin moves apply immediately."),
 			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID")),
 			mcp.WithString("workflow_id", mcp.Required(), mcp.Description("Target workflow ID")),
 			mcp.WithString("workflow_step_id", mcp.Required(), mcp.Description("Target workflow step ID")),
 			mcp.WithNumber("position", mcp.Description("Position within the step (0-based)")),
-			mcp.WithString("prompt", mcp.Description("Optional hand-off message for the receiving agent. When supplied AND the source session is mid-turn, the move is deferred to the agent's turn-end and the prompt is delivered at the new step (concatenated after the step's own auto_start prompt, if any). Omit for plain admin/config moves where there's no agent to address.")),
+			mcp.WithString("prompt", mcp.Description("Optional hand-off message for the receiving agent at the new step. Mid-turn moves are always deferred; include a prompt when the next agent needs context (e.g. QA → review). Omit for self-moves like Work → Done.")),
 		),
 		s.wrapHandler("move_task_kandev", s.moveTaskHandler()),
 	)
@@ -289,7 +289,7 @@ func (s *Server) registerConfigTaskTools() {
 		mcp.NewTool("update_task_state_kandev",
 			mcp.WithDescription("Update the state of a task."),
 			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID")),
-			mcp.WithString("state", mcp.Required(), mcp.Description("New state: open, in_progress, complete, blocked, cancelled")),
+			mcp.WithString("state", mcp.Required(), mcp.Description("New state: CREATED, TODO, IN_PROGRESS, REVIEW, BLOCKED, WAITING_FOR_INPUT, COMPLETED, FAILED, CANCELLED (aliases like complete/done/in_progress accepted)")),
 		),
 		s.wrapHandler("update_task_state_kandev", s.updateTaskStateHandler()),
 	)

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -441,12 +441,12 @@ func (s *Server) registerKanbanTools() {
 	)
 	s.mcpServer.AddTool(
 		mcp.NewTool("move_task_kandev",
-			mcp.WithDescription("Move a task to a different workflow step. Optionally send a hand-off prompt to the receiving agent — required only when handing the task off mid-turn (e.g. QA → review) with specific instructions. Plain admin/config moves can omit prompt."),
+			mcp.WithDescription("Move a task to a different workflow step. When the source session is mid-turn (RUNNING), the move is deferred to turn-end automatically — prompt is optional (use it for cross-agent hand-offs). Idle-session and admin moves apply immediately."),
 			mcp.WithString("task_id", mcp.Required(), mcp.Description("The task ID")),
 			mcp.WithString("workflow_id", mcp.Required(), mcp.Description("Target workflow ID")),
 			mcp.WithString("workflow_step_id", mcp.Required(), mcp.Description("Target workflow step ID")),
 			mcp.WithNumber("position", mcp.Description("Position within the step (0-based)")),
-			mcp.WithString("prompt", mcp.Description("Optional hand-off message for the receiving agent. When supplied AND the source session is mid-turn, the move is deferred to the agent's turn-end and the prompt is delivered at the new step (concatenated after the step's own auto_start prompt, if any). Omit for plain admin/config moves where there's no agent to address.")),
+			mcp.WithString("prompt", mcp.Description("Optional hand-off message for the receiving agent at the new step. Mid-turn moves are always deferred; include a prompt when the next agent needs context (e.g. QA → review). Omit for self-moves like Work → Done.")),
 		),
 		s.wrapHandler("move_task_kandev", s.moveTaskHandler()),
 	)


### PR DESCRIPTION
## Summary
- Defer move_task_kandev for RUNNING/STARTING sessions instead of immediate MoveTask (fixes INTERNAL_ERROR on promptless Work to Done moves)
- Add normalizeTaskState() aliases for common agent-supplied state strings
- Regression test for active-session move without prompt; update MCP tool descriptions

## Test plan
- [x] go test ./internal/mcp/handlers/... -run MoveTask_ActiveSession
- [x] go test ./internal/mcp/server/...