### PR TITLE
fix(utility): list opencode models when ACP probe is empty

### DIFF
--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -336,19 +336,32 @@ func (e *ACPInferenceExecutor) Probe(ctx context.Context, req *ProbeRequest) (*P
 	return resp, nil
 }
 
+// isOpenCodeACPCommand reports whether the configured ACP probe command is
+// OpenCode's ACP transport.
 func isOpenCodeACPCommand(command []string) bool {
 	return len(command) >= 2 && filepath.Base(command[0]) == "opencode" && command[1] == "acp"
 }
 
+// applyOpenCodeModelsFallback fills an otherwise empty probe model list from
+// OpenCode's CLI model listing.
 func (e *ACPInferenceExecutor) applyOpenCodeModelsFallback(ctx context.Context, resp *ProbeResponse, resolvedCmd, workDir string) {
 	models, err := probeOpenCodeModels(ctx, resolvedCmd, workDir)
 	if err != nil {
-		e.logger.Warn("ACP probe: failed to list opencode models", zap.Error(err))
+		e.logger.Warn("ACP probe: failed to list opencode models",
+			zap.String("command", resolvedCmd),
+			zap.Error(err))
+		return
+	}
+	if len(models) == 0 {
+		e.logger.Warn("ACP probe: opencode models returned no valid model entries",
+			zap.String("command", resolvedCmd))
 		return
 	}
 	resp.Models = models
 }
 
+// probeOpenCodeModels runs the OpenCode model-listing command and converts its
+// output into probe model entries.
 func probeOpenCodeModels(ctx context.Context, resolvedCmd, workDir string) ([]ProbeModel, error) {
 	//nolint:gosec // resolvedCmd is from the same hard-coded allow-list used to launch the ACP probe.
 	cmd := exec.CommandContext(ctx, resolvedCmd, "models")
@@ -361,6 +374,8 @@ func probeOpenCodeModels(ctx context.Context, resolvedCmd, workDir string) ([]Pr
 	return parseOpenCodeModelsOutput(string(out)), nil
 }
 
+// environWithNoColor returns an environment that forces NO_COLOR=1, replacing
+// any caller-provided value.
 func environWithNoColor(environ []string) []string {
 	env := make([]string, 0, len(environ)+1)
 	for _, item := range environ {
@@ -371,6 +386,8 @@ func environWithNoColor(environ []string) []string {
 	return append(env, "NO_COLOR=1")
 }
 
+// commandErrorWithStderr preserves stderr from failed commands when Go exposes
+// it through exec.ExitError.
 func commandErrorWithStderr(err error) error {
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
@@ -382,6 +399,8 @@ func commandErrorWithStderr(err error) error {
 	return err
 }
 
+// parseOpenCodeModelsOutput converts newline-delimited OpenCode model IDs into
+// deduplicated probe model entries.
 func parseOpenCodeModelsOutput(output string) []ProbeModel {
 	seen := make(map[string]struct{})
 	var models []ProbeModel
@@ -399,6 +418,8 @@ func parseOpenCodeModelsOutput(output string) []ProbeModel {
 	return models
 }
 
+// isOpenCodeModelID accepts model-like OpenCode IDs and rejects decoration or
+// progress lines from CLI output.
 func isOpenCodeModelID(id string) bool {
 	return strings.Contains(id, "/") && !strings.ContainsAny(id, " \t\r")
 }

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -325,10 +326,55 @@ func (e *ACPInferenceExecutor) Probe(ctx context.Context, req *ProbeRequest) (*P
 			DurationMs: int(time.Since(startTime).Milliseconds()),
 		}, nil
 	}
+	if len(resp.Models) == 0 && isOpenCodeACPCommand(cfg.Command) {
+		e.applyOpenCodeModelsFallback(ctx, resp, resolvedCmd, workDir)
+	}
 
 	resp.Success = true
 	resp.DurationMs = int(time.Since(startTime).Milliseconds())
 	return resp, nil
+}
+
+func isOpenCodeACPCommand(command []string) bool {
+	return len(command) >= 2 && filepath.Base(command[0]) == "opencode" && command[1] == "acp"
+}
+
+func (e *ACPInferenceExecutor) applyOpenCodeModelsFallback(ctx context.Context, resp *ProbeResponse, resolvedCmd, workDir string) {
+	models, err := probeOpenCodeModels(ctx, resolvedCmd, workDir)
+	if err != nil {
+		e.logger.Warn("ACP probe: failed to list opencode models", zap.Error(err))
+		return
+	}
+	resp.Models = models
+}
+
+func probeOpenCodeModels(ctx context.Context, resolvedCmd, workDir string) ([]ProbeModel, error) {
+	//nolint:gosec // resolvedCmd is from the same hard-coded allow-list used to launch the ACP probe.
+	cmd := exec.CommandContext(ctx, resolvedCmd, "models")
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseOpenCodeModelsOutput(string(out)), nil
+}
+
+func parseOpenCodeModelsOutput(output string) []ProbeModel {
+	seen := make(map[string]struct{})
+	var models []ProbeModel
+	for _, line := range strings.Split(output, "\n") {
+		id := strings.TrimSpace(line)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		models = append(models, ProbeModel{ID: id, Name: id})
+	}
+	return models
 }
 
 // probeACPSession performs initialize + session/new and returns the parsed

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -2,6 +2,7 @@ package utility
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -352,12 +353,33 @@ func probeOpenCodeModels(ctx context.Context, resolvedCmd, workDir string) ([]Pr
 	//nolint:gosec // resolvedCmd is from the same hard-coded allow-list used to launch the ACP probe.
 	cmd := exec.CommandContext(ctx, resolvedCmd, "models")
 	cmd.Dir = workDir
-	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+	cmd.Env = environWithNoColor(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, commandErrorWithStderr(err)
 	}
 	return parseOpenCodeModelsOutput(string(out)), nil
+}
+
+func environWithNoColor(environ []string) []string {
+	env := make([]string, 0, len(environ)+1)
+	for _, item := range environ {
+		if !strings.HasPrefix(item, "NO_COLOR=") {
+			env = append(env, item)
+		}
+	}
+	return append(env, "NO_COLOR=1")
+}
+
+func commandErrorWithStderr(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr := strings.TrimSpace(string(exitErr.Stderr))
+		if stderr != "" {
+			return fmt.Errorf("%w: %s", err, stderr)
+		}
+	}
+	return err
 }
 
 func parseOpenCodeModelsOutput(output string) []ProbeModel {
@@ -365,7 +387,7 @@ func parseOpenCodeModelsOutput(output string) []ProbeModel {
 	var models []ProbeModel
 	for _, line := range strings.Split(output, "\n") {
 		id := strings.TrimSpace(line)
-		if id == "" {
+		if !isOpenCodeModelID(id) {
 			continue
 		}
 		if _, ok := seen[id]; ok {
@@ -375,6 +397,10 @@ func parseOpenCodeModelsOutput(output string) []ProbeModel {
 		models = append(models, ProbeModel{ID: id, Name: id})
 	}
 	return models
+}
+
+func isOpenCodeModelID(id string) bool {
+	return strings.Contains(id, "/") && !strings.ContainsAny(id, " \t\r")
 }
 
 // probeACPSession performs initialize + session/new and returns the parsed

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -31,6 +31,46 @@ func TestResolveProbeCommand_RejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestIsOpenCodeACPCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command []string
+		want    bool
+	}{
+		{name: "opencode acp", command: []string{"opencode", "acp"}, want: true},
+		{name: "path opencode acp", command: []string{filepath.Join("/usr/local/bin", "opencode"), "acp"}, want: true},
+		{name: "opencode non acp", command: []string{"opencode", "run"}, want: false},
+		{name: "too short", command: []string{"opencode"}, want: false},
+		{name: "other acp", command: []string{"claude", "acp"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isOpenCodeACPCommand(tt.command); got != tt.want {
+				t.Fatalf("isOpenCodeACPCommand(%v) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOpenCodeModelsOutput(t *testing.T) {
+	t.Parallel()
+
+	got := parseOpenCodeModelsOutput("\nopenai/gpt-5.5\nanthropic/claude-sonnet-4-5\nopenai/gpt-5.5\n")
+	want := []ProbeModel{
+		{ID: "openai/gpt-5.5", Name: "openai/gpt-5.5"},
+		{ID: "anthropic/claude-sonnet-4-5", Name: "anthropic/claude-sonnet-4-5"},
+	}
+	if !slices.EqualFunc(got, want, func(a, b ProbeModel) bool {
+		return a.ID == b.ID && a.Name == b.Name && a.Description == b.Description
+	}) {
+		t.Fatalf("parseOpenCodeModelsOutput() = %#v, want %#v", got, want)
+	}
+}
+
 func TestSanitizeInferenceChunk_DropsPiVersionBanner(t *testing.T) {
 	t.Parallel()
 

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -59,15 +59,51 @@ func TestIsOpenCodeACPCommand(t *testing.T) {
 func TestParseOpenCodeModelsOutput(t *testing.T) {
 	t.Parallel()
 
-	got := parseOpenCodeModelsOutput("\nopenai/gpt-5.5\nanthropic/claude-sonnet-4-5\nopenai/gpt-5.5\n")
+	got := parseOpenCodeModelsOutput("\nAvailable models:\nopenai/gpt-5.5\nanthropic/claude-sonnet-4-5\nloading models\nopenrouter/anthropic/claude-sonnet-4\nopenai/gpt-5.5\n")
 	want := []ProbeModel{
 		{ID: "openai/gpt-5.5", Name: "openai/gpt-5.5"},
 		{ID: "anthropic/claude-sonnet-4-5", Name: "anthropic/claude-sonnet-4-5"},
+		{ID: "openrouter/anthropic/claude-sonnet-4", Name: "openrouter/anthropic/claude-sonnet-4"},
 	}
 	if !slices.EqualFunc(got, want, func(a, b ProbeModel) bool {
 		return a.ID == b.ID && a.Name == b.Name && a.Description == b.Description
 	}) {
 		t.Fatalf("parseOpenCodeModelsOutput() = %#v, want %#v", got, want)
+	}
+}
+
+func TestEnvironWithNoColorOverridesExistingValue(t *testing.T) {
+	t.Parallel()
+
+	got := environWithNoColor([]string{"PATH=/usr/bin", "NO_COLOR=0", "HOME=/tmp"})
+	want := []string{"PATH=/usr/bin", "HOME=/tmp", "NO_COLOR=1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("environWithNoColor() = %#v, want %#v", got, want)
+	}
+}
+
+func TestIsOpenCodeModelID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{id: "openai/gpt-5.5", want: true},
+		{id: "openrouter/anthropic/claude-sonnet-4", want: true},
+		{id: "Available models:", want: false},
+		{id: "loading models", want: false},
+		{id: "", want: false},
+		{id: "openai /gpt-5.5", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			t.Parallel()
+			if got := isOpenCodeModelID(tt.id); got != tt.want {
+				t.Fatalf("isOpenCodeModelID(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -31,6 +31,8 @@ func TestResolveProbeCommand_RejectsUnknown(t *testing.T) {
 	}
 }
 
+// TestIsOpenCodeACPCommand verifies that the fallback only applies to
+// OpenCode's ACP transport command.
 func TestIsOpenCodeACPCommand(t *testing.T) {
 	t.Parallel()
 
@@ -56,6 +58,8 @@ func TestIsOpenCodeACPCommand(t *testing.T) {
 	}
 }
 
+// TestParseOpenCodeModelsOutput verifies parsing, deduplication, and filtering
+// of non-model lines from OpenCode CLI output.
 func TestParseOpenCodeModelsOutput(t *testing.T) {
 	t.Parallel()
 
@@ -72,6 +76,8 @@ func TestParseOpenCodeModelsOutput(t *testing.T) {
 	}
 }
 
+// TestEnvironWithNoColorOverridesExistingValue verifies that NO_COLOR=1 wins
+// over any pre-existing environment value.
 func TestEnvironWithNoColorOverridesExistingValue(t *testing.T) {
 	t.Parallel()
 
@@ -82,6 +88,8 @@ func TestEnvironWithNoColorOverridesExistingValue(t *testing.T) {
 	}
 }
 
+// TestIsOpenCodeModelID verifies the lightweight format guard for OpenCode
+// model IDs parsed from CLI output.
 func TestIsOpenCodeModelID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
OpenCode ACP can report as available while exposing no models through `session/new`, leaving KanDev's model dropdown empty. Falling back to `opencode models` for that specific empty-probe case lets KanDev populate OpenCode models without changing the normal ACP model path for other agents.

## Validation

- `docker run --rm -v "$PWD":/src -w /src/apps/backend golang:1.26 go test ./internal/agentctl/server/utility`
- `git diff --check`
- Manually verified `opencode models` returns model IDs on the affected machine.

## Possible Improvements

Low risk: #1263 also describes stale/dead probe-port refresh behavior, which may still need a separate lifecycle fix outside this model-list fallback.

## Related Issues

Refs #1263

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.
