### PR TITLE
fix(web): align office topbar border with sidebar header (h-10)

### DIFF
--- a/apps/web/app/office/components/office-topbar.tsx
+++ b/apps/web/app/office/components/office-topbar.tsx
@@ -44,7 +44,10 @@ export function OfficeTopbar() {
   const detail = isDetailPage(pathname);
 
   return (
-    <div className="flex items-center gap-2 px-4 h-12 border-b border-border bg-background shrink-0">
+    <div
+      data-testid="office-topbar"
+      className="flex items-center gap-2 px-4 h-10 border-b border-border bg-background shrink-0"
+    >
       {detail ? (
         <div id="office-topbar-slot" className="flex items-center gap-2 flex-1 min-w-0" />
       ) : (

--- a/apps/web/components/app-sidebar/app-sidebar-header.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-header.tsx
@@ -55,7 +55,10 @@ export function AppSidebarHeader({ collapsed, onToggleCollapse }: AppSidebarHead
   // workspace share the same text size so they sit on a common baseline; the
   // brand carries weight/colour, the workspace stays muted and secondary.
   return (
-    <div className="flex items-center gap-1.5 h-10 px-3 shrink-0 border-b border-border">
+    <div
+      data-testid="app-sidebar-header"
+      className="flex items-center gap-1.5 h-10 px-3 shrink-0 border-b border-border"
+    >
       <Link
         href="/"
         aria-label="Kandev home"

--- a/apps/web/e2e/tests/office/topbar-breadcrumb.spec.ts
+++ b/apps/web/e2e/tests/office/topbar-breadcrumb.spec.ts
@@ -17,4 +17,29 @@ test.describe("Topbar breadcrumb", () => {
       timeout: 10_000,
     });
   });
+
+  // Regression: the office topbar bottom border must line up with the AppSidebar
+  // header's bottom border (the line under the workspace picker) — both are h-10
+  // so the two horizontal borders form one continuous seam where the sidebar
+  // meets the page content. Previously the topbar was h-12 and sat ~8px lower.
+  test("topbar bottom aligns with sidebar header bottom", async ({ testPage, officeSeed: _ }) => {
+    await testPage.setViewportSize({ width: 1280, height: 900 });
+    await testPage.goto("/office/inbox");
+
+    const topbar = testPage.getByTestId("office-topbar");
+    const sidebarHeader = testPage.getByTestId("app-sidebar-header");
+    await expect(topbar).toBeVisible({ timeout: 10_000 });
+    await expect(sidebarHeader).toBeVisible({ timeout: 10_000 });
+
+    const topbarBox = await topbar.boundingBox();
+    const sidebarBox = await sidebarHeader.boundingBox();
+    expect(topbarBox).not.toBeNull();
+    expect(sidebarBox).not.toBeNull();
+
+    // Same height (both h-10) and same bottom y-position → flush borders.
+    expect(Math.abs(topbarBox!.height - sidebarBox!.height)).toBeLessThanOrEqual(1);
+    const topbarBottom = topbarBox!.y + topbarBox!.height;
+    const sidebarBottom = sidebarBox!.y + sidebarBox!.height;
+    expect(Math.abs(topbarBottom - sidebarBottom)).toBeLessThanOrEqual(1);
+  });
 });

--- a/apps/web/e2e/tests/office/topbar-breadcrumb.spec.ts
+++ b/apps/web/e2e/tests/office/topbar-breadcrumb.spec.ts
@@ -23,6 +23,14 @@ test.describe("Topbar breadcrumb", () => {
   // so the two horizontal borders form one continuous seam where the sidebar
   // meets the page content. Previously the topbar was h-12 and sat ~8px lower.
   test("topbar bottom aligns with sidebar header bottom", async ({ testPage, officeSeed: _ }) => {
+    // The seam we assert exists only for the EXPANDED sidebar header — its
+    // border sits under the workspace picker, and data-testid="app-sidebar-header"
+    // lives on the expanded layout. Force the collapse flag off before load so a
+    // leftover collapsed state can't turn this into a confusing timeout (the
+    // collapsed-rail header carries no testid) rather than a real assertion.
+    await testPage.addInitScript(() => {
+      window.localStorage.setItem("kandev.appSidebar.collapsed", "false");
+    });
     await testPage.setViewportSize({ width: 1280, height: 900 });
     await testPage.goto("/office/inbox");
 


### PR DESCRIPTION
## Problem

In office mode (e.g. `/office/inbox`), the office top bar's bottom border did not line up with the AppSidebar header's border under the workspace picker. The two horizontal borders should form one continuous seam where the sidebar meets the page content, but the office top bar sat ~8px lower.

## Root cause

A simple height mismatch between two always-bordered top sections, fallout from the unified-AppSidebar overhaul (#1165):

- **AppSidebar header** — `h-10` (40px), `border-b` (`app-sidebar-header.tsx`). Its comment notes it is `h-10` *specifically* to line up with the page/dockview top bar.
- **OfficeTopbar** — was `h-12` (48px), `border-b` (`office-topbar.tsx`).

40px vs 48px → borders misaligned by 8px on every office route (the OfficeTopbar is shared).

## Fix

Change the OfficeTopbar wrapper from `h-12` to `h-10`, matching the sidebar header and the `PageTopbar`/dockview top bars used elsewhere. The topbar's only content is a `text-sm` title or the breadcrumb portal slot — both fit comfortably at 40px (the sidebar header carries equivalent content at `h-10`).

## Tests

- Added `data-testid` hooks to both bordered sections and a Playwright regression (`topbar-breadcrumb.spec.ts`) asserting the office topbar and sidebar header resolve to the same height and same bottom y-position (within 1px).
- `pnpm --filter @kandev/web typecheck lint` — clean.
- `pnpm --filter @kandev/web test` — 3097 passed.
- E2E `topbar-breadcrumb` (against production build) — 3 passed, including the new alignment check.

> Based on `feature/ui-overhaul-i0h`, which has since squash-merged via #1165, so this targets `main`.