### PR TITLE
fix(web): point sidebar Home to office dashboard in office mode

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-primary-nav.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-primary-nav.tsx
@@ -19,7 +19,13 @@ export function AppSidebarPrimaryNav({ collapsed }: AppSidebarPrimaryNavProps) {
 
   return (
     <div className="flex flex-col gap-0.5">
-      <AppSidebarNavItem icon={IconHome} label="Home" href="/" collapsed={collapsed} exactMatch />
+      <AppSidebarNavItem
+        icon={IconHome}
+        label="Home"
+        href={inOffice ? "/office" : "/"}
+        collapsed={collapsed}
+        exactMatch
+      />
       {inOffice && (
         <AppSidebarNavItem
           icon={IconInbox}

--- a/apps/web/e2e/tests/office/sidebar-navigation.spec.ts
+++ b/apps/web/e2e/tests/office/sidebar-navigation.spec.ts
@@ -79,7 +79,10 @@ test.describe("Sidebar Home destination", () => {
     testPage,
     officeSeed: _,
   }) => {
-    await testPage.goto("/");
+    // Start from a non-home regular route so the Home click is a real
+    // navigation (not a no-op): from a Kanban-side route `useInOffice()` is
+    // false, so Home must land back on the board at `/`.
+    await testPage.goto("/settings/system/status");
     const home = testPage.getByRole("link", { name: "Home", exact: true });
     await expect(home).toBeVisible({ timeout: 15_000 });
     await home.click();

--- a/apps/web/e2e/tests/office/sidebar-navigation.spec.ts
+++ b/apps/web/e2e/tests/office/sidebar-navigation.spec.ts
@@ -57,3 +57,33 @@ test.describe("Sidebar navigation", () => {
     });
   });
 });
+
+// The sidebar "Home" item is office-aware: while on any /office/* route it
+// targets the office dashboard (/office), and on a regular Kanban route it
+// targets the board (/). Active-highlight stays exact-match in both modes.
+test.describe("Sidebar Home destination", () => {
+  test("Home goes to the office dashboard from an office route", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto("/office/inbox");
+    const home = testPage.getByRole("link", { name: "Home", exact: true });
+    await expect(home).toBeVisible({ timeout: 15_000 });
+    await home.click();
+    await expect(testPage).toHaveURL(/\/office$/);
+    // "Agents Enabled" is the stable dashboard metric marker.
+    await expect(testPage.getByText("Agents Enabled")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("Home goes to the Kanban board from a regular route", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto("/");
+    const home = testPage.getByRole("link", { name: "Home", exact: true });
+    await expect(home).toBeVisible({ timeout: 15_000 });
+    await home.click();
+    await expect(testPage).toHaveURL(/\/$/);
+    await expect(testPage.getByTestId("kanban-board")).toBeVisible({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
The AppSidebar **Home** item always navigated to the Kanban view (`/`), even when the user was in office mode — so clicking Home from an `/office/*` route dropped the user out of Office. Home is now office-aware: it targets the office dashboard (`/office`) while on any office route and the board (`/`) otherwise.

## Important Changes

- `app-sidebar-primary-nav.tsx`: Home `href` is now `inOffice ? "/office" : "/"` (the `useInOffice()` hook was already computed but unused). `exactMatch` is retained, so in office mode Home highlights only on the dashboard, not on `/office/inbox`/`/office/tasks`.

## Validation

- `pnpm --filter @kandev/web typecheck lint test` — all pass
- `make build-web && make build-backend`
- `pnpm e2e tests/office/sidebar-navigation.spec.ts` — 6 passed, including the two new cases (Home → `/office` dashboard from an office route; Home → `/` board from a regular route)

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] Self-reviewed the diff