### PR TITLE
fix(web): make toggle-sidebar shortcut work on every route

### DIFF
--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -83,6 +83,10 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
         : {}),
     };
   } catch {
+    // If any non-settings fetch (workspaces, executors, agents, …) throws, we
+    // render with empty initial state — losing the userSettings overrides too.
+    // That's acceptable: the page is already degraded (no executors/agents), so
+    // override-driven shortcuts being inactive until client hydration is fine.
     initialState = {};
   }
 

--- a/apps/web/app/settings/layout.tsx
+++ b/apps/web/app/settings/layout.tsx
@@ -1,12 +1,14 @@
 import { SettingsLayoutClient } from "@/components/settings/settings-layout-client";
 import { StateHydrator } from "@/components/state-hydrator";
 import {
+  fetchUserSettings,
   listAgentDiscovery,
   listAgents,
   listAvailableAgents,
   listExecutors,
   listWorkspaces,
 } from "@/lib/api";
+import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { toAgentProfileOption } from "@/lib/state/slices/settings/types";
 
 export default function SettingsLayout({ children }: { children: React.ReactNode }) {
@@ -19,13 +21,20 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
     // Fetch discovery + available agents alongside the DB-backed list so a
     // hard refresh of /settings/agents/[name] (where no profile exists yet)
     // can still render the agent from the discovered set.
-    const [workspaces, executors, agents, discovery, available] = await Promise.all([
-      listWorkspaces({ cache: "no-store" }),
-      listExecutors({ cache: "no-store" }),
-      listAgents({ cache: "no-store" }),
-      listAgentDiscovery({ cache: "no-store" }),
-      listAvailableAgents({ cache: "no-store" }),
-    ]);
+    const [workspaces, executors, agents, discovery, available, userSettingsResponse] =
+      await Promise.all([
+        listWorkspaces({ cache: "no-store" }),
+        listExecutors({ cache: "no-store" }),
+        listAgents({ cache: "no-store" }),
+        listAgentDiscovery({ cache: "no-store" }),
+        listAvailableAgents({ cache: "no-store" }),
+        fetchUserSettings({ cache: "no-store" }).catch(() => null),
+      ]);
+    // Hydrate userSettings into the ROOT store so app-global, override-driven
+    // shortcuts (TOGGLE_SIDEBAR, Quick Chat) work on settings routes too. The
+    // settings/general page mounts its own nested store for editing; that store
+    // is invisible to the root-mounted GlobalCommands/useAppShortcuts.
+    const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
     initialState = {
       workspaces: {
         items: workspaces.workspaces.map((workspace) => ({
@@ -64,6 +73,14 @@ async function SettingsLayoutServer({ children }: { children: React.ReactNode })
         executorsLoaded: true,
         agentsLoaded: true,
       },
+      ...(mappedUserSettings.loaded
+        ? {
+            userSettings: {
+              ...mappedUserSettings,
+              workspaceId: workspaces.workspaces[0]?.id ?? null,
+            },
+          }
+        : {}),
     };
   } catch {
     initialState = {};

--- a/apps/web/components/global-commands.tsx
+++ b/apps/web/components/global-commands.tsx
@@ -20,6 +20,7 @@ import {
 } from "@tabler/icons-react";
 import { useRegisterCommands } from "@/hooks/use-register-commands";
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
+import { useAppShortcuts } from "@/hooks/use-app-shortcuts";
 import { useAppStore } from "@/components/state-provider";
 import { getShortcut } from "@/lib/keyboard/shortcut-overrides";
 import type { CommandItem } from "@/lib/commands/types";
@@ -216,6 +217,7 @@ export function GlobalCommands() {
 
   useRegisterCommands(commands);
   useKeyboardShortcut(quickChatShortcut, handleOpenQuickChat);
+  useAppShortcuts();
 
   return null;
 }

--- a/apps/web/e2e/tests/layout/toggle-sidebar-shortcut.spec.ts
+++ b/apps/web/e2e/tests/layout/toggle-sidebar-shortcut.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "../../fixtures/test-base";
+import type { Page, Locator } from "@playwright/test";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+// The TOGGLE_SIDEBAR shortcut lives on a global app-root listener (useAppShortcuts),
+// so Cmd/Ctrl+B must collapse/expand the unified AppSidebar on every route — not
+// just inside the dockview session editor. It is UNBOUND by default on this
+// branch, so each test binds it to Cmd/Ctrl+B first (mirroring how a user would
+// set it in Settings).
+
+const MODIFIER = process.platform === "darwin" ? "Meta" : "Control";
+
+/** Bind TOGGLE_SIDEBAR to Cmd/Ctrl+B (unbound by default) for the active user. */
+async function bindToggleSidebar(apiClient: ApiClient, seedData: SeedData): Promise<void> {
+  await apiClient.saveUserSettings({
+    workspace_id: seedData.workspaceId,
+    keyboard_shortcuts: {
+      TOGGLE_SIDEBAR: { key: "b", modifiers: { ctrlOrCmd: true } },
+    },
+  });
+}
+
+/** Press Cmd/Ctrl+B and assert the AppSidebar's collapsed state flips both ways. */
+async function expectShortcutTogglesSidebar(page: Page, sidebar: Locator): Promise<void> {
+  await expect(sidebar).toBeVisible();
+  // The shortcut is intentionally ignored while typing — clear focus first so a
+  // page-autofocused input can't suppress it.
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+
+  const initial = (await sidebar.getAttribute("data-collapsed")) ?? "false";
+  const flipped = initial === "true" ? "false" : "true";
+
+  await page.keyboard.press(`${MODIFIER}+b`);
+  await expect(sidebar).toHaveAttribute("data-collapsed", flipped);
+
+  await page.keyboard.press(`${MODIFIER}+b`);
+  await expect(sidebar).toHaveAttribute("data-collapsed", initial);
+}
+
+test.describe("Toggle sidebar shortcut (global)", () => {
+  test("toggles the AppSidebar on the Kanban board", async ({ testPage, apiClient, seedData }) => {
+    await bindToggleSidebar(apiClient, seedData);
+    await testPage.goto("/");
+    await expectShortcutTogglesSidebar(testPage, testPage.getByTestId("app-sidebar"));
+  });
+
+  test("toggles the AppSidebar on a Settings page", async ({ testPage, apiClient, seedData }) => {
+    await bindToggleSidebar(apiClient, seedData);
+    await testPage.goto("/settings/general");
+    await expectShortcutTogglesSidebar(testPage, testPage.getByTestId("app-sidebar"));
+  });
+
+  test("still toggles the AppSidebar on the dockview session page", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await bindToggleSidebar(apiClient, seedData);
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Toggle sidebar shortcut session",
+      seedData.agentProfileId,
+      {
+        description: "/e2e:simple-message",
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    // Target the global rail (app-sidebar), not the dockview's per-session
+    // sidebar (task-sidebar).
+    await expectShortcutTogglesSidebar(testPage, testPage.getByTestId("app-sidebar"));
+  });
+});

--- a/apps/web/hooks/use-app-shortcuts.test.ts
+++ b/apps/web/hooks/use-app-shortcuts.test.ts
@@ -23,16 +23,17 @@ const CTRL_B_OVERRIDE: StoredShortcutOverrides = {
   TOGGLE_SIDEBAR: { key: "b", modifiers: { ctrlOrCmd: true } },
 };
 
-function pressCtrlB(target: EventTarget = window): KeyboardEvent {
-  const event = new KeyboardEvent("keydown", {
-    key: "b",
-    ctrlKey: true,
-    bubbles: true,
-    cancelable: true,
-  });
+function pressB(modifier: "ctrlKey" | "metaKey", target: EventTarget = window): KeyboardEvent {
+  const init: KeyboardEventInit = { key: "b", bubbles: true, cancelable: true };
+  init[modifier] = true;
+  const event = new KeyboardEvent("keydown", init);
   target.dispatchEvent(event);
   return event;
 }
+
+// Cover both `ctrlOrCmd` branches: Ctrl on Windows/Linux, Cmd (metaKey) on macOS.
+const pressCtrlB = (target?: EventTarget) => pressB("ctrlKey", target);
+const pressMetaB = (target?: EventTarget) => pressB("metaKey", target);
 
 describe("useAppShortcuts", () => {
   beforeEach(() => {
@@ -55,6 +56,15 @@ describe("useAppShortcuts", () => {
     renderHook(() => useAppShortcuts());
 
     const event = pressCtrlB();
+    expect(mockToggleAppSidebar).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("toggles the sidebar with Cmd (metaKey) too — the macOS path", () => {
+    mockShortcuts = CTRL_B_OVERRIDE;
+    renderHook(() => useAppShortcuts());
+
+    const event = pressMetaB();
     expect(mockToggleAppSidebar).toHaveBeenCalledTimes(1);
     expect(event.defaultPrevented).toBe(true);
   });

--- a/apps/web/hooks/use-app-shortcuts.test.ts
+++ b/apps/web/hooks/use-app-shortcuts.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+import type { StoredShortcutOverrides } from "@/lib/keyboard/shortcut-overrides";
+
+const mockToggleAppSidebar = vi.fn();
+let mockShortcuts: StoredShortcutOverrides = {};
+
+function buildState() {
+  return {
+    userSettings: { keyboardShortcuts: mockShortcuts },
+    toggleAppSidebar: mockToggleAppSidebar,
+  };
+}
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStoreApi: () => ({ getState: () => buildState() }),
+}));
+
+import { useAppShortcuts } from "./use-app-shortcuts";
+
+/** Bind TOGGLE_SIDEBAR to Cmd/Ctrl+B (it is unbound by default). */
+const CTRL_B_OVERRIDE: StoredShortcutOverrides = {
+  TOGGLE_SIDEBAR: { key: "b", modifiers: { ctrlOrCmd: true } },
+};
+
+function pressCtrlB(target: EventTarget = window): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "b",
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("useAppShortcuts", () => {
+  beforeEach(() => {
+    mockToggleAppSidebar.mockClear();
+    mockShortcuts = {};
+  });
+
+  // renderHook attaches a window listener; unmount it between tests so stale
+  // listeners from earlier tests don't fire on later dispatches.
+  afterEach(() => cleanup());
+
+  it("does nothing by default — TOGGLE_SIDEBAR is unbound", () => {
+    renderHook(() => useAppShortcuts());
+    pressCtrlB();
+    expect(mockToggleAppSidebar).not.toHaveBeenCalled();
+  });
+
+  it("toggles the sidebar when the shortcut is bound to Cmd/Ctrl+B", () => {
+    mockShortcuts = CTRL_B_OVERRIDE;
+    renderHook(() => useAppShortcuts());
+
+    const event = pressCtrlB();
+    expect(mockToggleAppSidebar).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores the shortcut while typing in an editable element", () => {
+    mockShortcuts = CTRL_B_OVERRIDE;
+    renderHook(() => useAppShortcuts());
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    pressCtrlB(input);
+    expect(mockToggleAppSidebar).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("removes its listener on unmount", () => {
+    mockShortcuts = CTRL_B_OVERRIDE;
+    const { unmount } = renderHook(() => useAppShortcuts());
+    unmount();
+
+    pressCtrlB();
+    expect(mockToggleAppSidebar).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hooks/use-app-shortcuts.ts
+++ b/apps/web/hooks/use-app-shortcuts.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAppStoreApi } from "@/components/state-provider";
+import { matchesShortcut } from "@/lib/keyboard/utils";
+import { getShortcut } from "@/lib/keyboard/shortcut-overrides";
+
+/** Returns true if the active element is a text input or contenteditable. */
+function isEditableTarget(e: KeyboardEvent): boolean {
+  const tag = (e.target as HTMLElement)?.tagName;
+  return (
+    tag === "INPUT" || tag === "TEXTAREA" || (e.target as HTMLElement)?.isContentEditable === true
+  );
+}
+
+/**
+ * App-root keyboard shortcuts that must fire on every route — not just inside
+ * the dockview session editor.
+ *
+ * Currently handles `TOGGLE_SIDEBAR` (collapse/expand the global AppSidebar).
+ * Previously this lived in {@link useEditorKeybinds}, which is mounted only by
+ * the dockview desktop layout, so the shortcut was dead on the Kanban board,
+ * task list, Office, Settings, etc. Mount this once near the app root (it has
+ * no dockview dependency) so the binding works everywhere.
+ *
+ * The AppSidebar is desktop-only (`hidden md:flex`); on mobile the toggle still
+ * flips store state but has no visible effect, which is fine.
+ */
+export function useAppShortcuts() {
+  const appStore = useAppStoreApi();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (isEditableTarget(e)) return;
+
+      const overrides = appStore.getState().userSettings.keyboardShortcuts;
+      if (matchesShortcut(e, getShortcut("TOGGLE_SIDEBAR", overrides))) {
+        e.preventDefault();
+        e.stopPropagation();
+        appStore.getState().toggleAppSidebar();
+      }
+    };
+
+    // Capture phase so we win the event before focus-trapped surfaces (e.g.
+    // xterm.js) can swallow it — mirrors useEditorKeybinds.
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [appStore]);
+}

--- a/apps/web/hooks/use-editor-keybinds.ts
+++ b/apps/web/hooks/use-editor-keybinds.ts
@@ -73,31 +73,6 @@ function handleTerminalToggle(
     });
 }
 
-/** Returns true if the active element is a text input or contenteditable. */
-function isEditableTarget(e: KeyboardEvent): boolean {
-  const tag = (e.target as HTMLElement)?.tagName;
-  return (
-    tag === "INPUT" || tag === "TEXTAREA" || (e.target as HTMLElement)?.isContentEditable === true
-  );
-}
-
-function handleLayoutToggle(
-  e: KeyboardEvent,
-  overrides: StoredShortcutOverrides | undefined,
-  appStore: ReturnType<typeof useAppStoreApi>,
-): boolean {
-  if (isEditableTarget(e)) return false;
-
-  if (matchesShortcut(e, getShortcut("TOGGLE_SIDEBAR", overrides))) {
-    e.preventDefault();
-    e.stopPropagation();
-    appStore.getState().toggleAppSidebar();
-    return true;
-  }
-
-  return false;
-}
-
 function handleBottomTerminal(
   e: KeyboardEvent,
   appStore: ReturnType<typeof useAppStoreApi>,
@@ -146,8 +121,10 @@ function handleBottomTerminal(
  * Global editor keybinds for dockview:
  * - Cmd/Ctrl+Shift+[ / ] — navigate prev/next tab in active group
  * - Ctrl+` — toggle terminal focus
- * - Cmd/Ctrl+B — toggle sidebar
  * - Cmd/Ctrl+J — toggle bottom terminal panel
+ *
+ * Note: `TOGGLE_SIDEBAR` (Cmd/Ctrl+B) is handled app-wide by `useAppShortcuts`
+ * (mounted near the root), not here, so it works on every route.
  */
 export function useEditorKeybinds() {
   const previousPanelIdRef = useRef<string | null>(null);
@@ -188,7 +165,6 @@ export function useEditorKeybinds() {
         return;
       }
 
-      if (handleLayoutToggle(e, overrides, appStore)) return;
       handleBottomTerminal(e, appStore, previousFocusRef, overrides);
     };
 


### PR DESCRIPTION
Pressing the Toggle Sidebar shortcut (Cmd/Ctrl+B) only collapsed the rail while viewing a task session on the dockview; everywhere else it did nothing. The shortcut now works on every route.

## Important Changes

- Lift `TOGGLE_SIDEBAR` from the dockview-only `useEditorKeybinds` to a global app-root listener (`useAppShortcuts`, mounted in `GlobalCommands`); honors user overrides via `getShortcut` and keeps the `isEditableTarget` guard.
- Hydrate `userSettings` into the **root** store on `/settings` routes — they mount an isolated nested store, so override-driven global shortcuts (and Quick Chat) were dead there.
- Default binding stays **unbound** (deliberate, commit `83f0359ca`); the shortcut activates once a user binds it in Settings.

## Validation

- `pnpm --filter @kandev/web typecheck` · `lint` · `test` (3101 passed)
- `make build-web`, then Playwright: new `e2e/tests/layout/toggle-sidebar-shortcut.spec.ts` (Kanban, Settings, dockview) + `settings/keyboard-shortcuts` and `settings/settings-gear-only` for regressions — all green.

## Possible Improvements

Low risk. Behavior-only on the FE; no default binding change, so existing users see no difference until they bind the key.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.