### PR TITLE
feat(workflow): ship explicit completion signal toggle + YAML round-trip

### DIFF
--- a/apps/backend/internal/workflow/models/export.go
+++ b/apps/backend/internal/workflow/models/export.go
@@ -42,16 +42,17 @@ type WorkflowPortable struct {
 
 // StepPortable is a workflow step without instance-specific fields.
 type StepPortable struct {
-	Name                  string                `json:"name" yaml:"name"`
-	Position              int                   `json:"position" yaml:"position"`
-	Color                 string                `json:"color" yaml:"color"`
-	Prompt                string                `json:"prompt,omitempty" yaml:"prompt,omitempty"`
-	Events                StepEvents            `json:"events" yaml:"events"`
-	IsStartStep           bool                  `json:"is_start_step" yaml:"is_start_step"`
-	ShowInCommandPanel    bool                  `json:"show_in_command_panel" yaml:"show_in_command_panel"`
-	AllowManualMove       bool                  `json:"allow_manual_move" yaml:"allow_manual_move"`
-	AutoArchiveAfterHours int                   `json:"auto_archive_after_hours,omitempty" yaml:"auto_archive_after_hours,omitempty"`
-	AgentProfile          *AgentProfilePortable `json:"agent_profile,omitempty" yaml:"agent_profile,omitempty"`
+	Name                      string                `json:"name" yaml:"name"`
+	Position                  int                   `json:"position" yaml:"position"`
+	Color                     string                `json:"color" yaml:"color"`
+	Prompt                    string                `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+	Events                    StepEvents            `json:"events" yaml:"events"`
+	IsStartStep               bool                  `json:"is_start_step" yaml:"is_start_step"`
+	ShowInCommandPanel        bool                  `json:"show_in_command_panel" yaml:"show_in_command_panel"`
+	AllowManualMove           bool                  `json:"allow_manual_move" yaml:"allow_manual_move"`
+	AutoArchiveAfterHours     int                   `json:"auto_archive_after_hours,omitempty" yaml:"auto_archive_after_hours,omitempty"`
+	AgentProfile              *AgentProfilePortable `json:"agent_profile,omitempty" yaml:"agent_profile,omitempty"`
+	AutoAdvanceRequiresSignal bool                  `json:"auto_advance_requires_signal,omitempty" yaml:"auto_advance_requires_signal,omitempty"`
 }
 
 // BuildWorkflowExport builds a portable WorkflowExport from domain models.
@@ -79,15 +80,16 @@ func buildWorkflowPortable(wf *taskmodels.Workflow, steps []*WorkflowStep, resol
 	}
 	for _, s := range steps {
 		sp := StepPortable{
-			Name:                  s.Name,
-			Position:              s.Position,
-			Color:                 s.Color,
-			Prompt:                s.Prompt,
-			Events:                convertStepIDToPosition(s.Events, idToPos),
-			IsStartStep:           s.IsStartStep,
-			ShowInCommandPanel:    s.ShowInCommandPanel,
-			AllowManualMove:       s.AllowManualMove,
-			AutoArchiveAfterHours: s.AutoArchiveAfterHours,
+			Name:                      s.Name,
+			Position:                  s.Position,
+			Color:                     s.Color,
+			Prompt:                    s.Prompt,
+			Events:                    convertStepIDToPosition(s.Events, idToPos),
+			IsStartStep:               s.IsStartStep,
+			ShowInCommandPanel:        s.ShowInCommandPanel,
+			AllowManualMove:           s.AllowManualMove,
+			AutoArchiveAfterHours:     s.AutoArchiveAfterHours,
+			AutoAdvanceRequiresSignal: s.AutoAdvanceRequiresSignal,
 		}
 		if resolveProfile != nil && s.AgentProfileID != "" {
 			sp.AgentProfile = resolveProfile(s.AgentProfileID)

--- a/apps/backend/internal/workflow/models/export.go
+++ b/apps/backend/internal/workflow/models/export.go
@@ -52,7 +52,7 @@ type StepPortable struct {
 	AllowManualMove           bool                  `json:"allow_manual_move" yaml:"allow_manual_move"`
 	AutoArchiveAfterHours     int                   `json:"auto_archive_after_hours,omitempty" yaml:"auto_archive_after_hours,omitempty"`
 	AgentProfile              *AgentProfilePortable `json:"agent_profile,omitempty" yaml:"agent_profile,omitempty"`
-	AutoAdvanceRequiresSignal bool                  `json:"auto_advance_requires_signal,omitempty" yaml:"auto_advance_requires_signal,omitempty"`
+	AutoAdvanceRequiresSignal bool                  `json:"auto_advance_requires_signal" yaml:"auto_advance_requires_signal"`
 }
 
 // BuildWorkflowExport builds a portable WorkflowExport from domain models.

--- a/apps/backend/internal/workflow/models/export_test.go
+++ b/apps/backend/internal/workflow/models/export_test.go
@@ -363,6 +363,25 @@ func TestRoundTrip(t *testing.T) {
 	})
 }
 
+func TestAutoAdvanceRequiresSignalExport(t *testing.T) {
+	t.Run("preserves auto_advance_requires_signal in export", func(t *testing.T) {
+		wf := &taskmodels.Workflow{ID: "wf-1", Name: "WF"}
+		steps := []*WorkflowStep{
+			{ID: "s1", Name: "Legacy", Position: 0, Color: "gray", AutoAdvanceRequiresSignal: false},
+			{ID: "s2", Name: "Gated", Position: 1, Color: "blue", AutoAdvanceRequiresSignal: true},
+		}
+		export := BuildWorkflowExport(
+			[]*taskmodels.Workflow{wf},
+			map[string][]*WorkflowStep{"wf-1": steps},
+			nil,
+		)
+
+		require.Len(t, export.Workflows[0].Steps, 2)
+		assert.False(t, export.Workflows[0].Steps[0].AutoAdvanceRequiresSignal)
+		assert.True(t, export.Workflows[0].Steps[1].AutoAdvanceRequiresSignal)
+	})
+}
+
 func TestShowInCommandPanelExport(t *testing.T) {
 	t.Run("preserves show_in_command_panel in export", func(t *testing.T) {
 		wf := &taskmodels.Workflow{ID: "wf-1", Name: "Test"}

--- a/apps/backend/internal/workflow/service/service.go
+++ b/apps/backend/internal/workflow/service/service.go
@@ -518,17 +518,18 @@ func (s *Service) importSingleWorkflow(ctx context.Context, workspaceID string, 
 	// Create each step with remapped events.
 	for _, sp := range pw.Steps {
 		step := &models.WorkflowStep{
-			ID:                    posToID[sp.Position],
-			WorkflowID:            wf.ID,
-			Name:                  sp.Name,
-			Position:              sp.Position,
-			Color:                 sp.Color,
-			Prompt:                sp.Prompt,
-			Events:                models.ConvertPositionToStepID(sp.Events, posToID),
-			IsStartStep:           sp.IsStartStep,
-			ShowInCommandPanel:    sp.ShowInCommandPanel,
-			AllowManualMove:       sp.AllowManualMove,
-			AutoArchiveAfterHours: sp.AutoArchiveAfterHours,
+			ID:                        posToID[sp.Position],
+			WorkflowID:                wf.ID,
+			Name:                      sp.Name,
+			Position:                  sp.Position,
+			Color:                     sp.Color,
+			Prompt:                    sp.Prompt,
+			Events:                    models.ConvertPositionToStepID(sp.Events, posToID),
+			IsStartStep:               sp.IsStartStep,
+			ShowInCommandPanel:        sp.ShowInCommandPanel,
+			AllowManualMove:           sp.AllowManualMove,
+			AutoArchiveAfterHours:     sp.AutoArchiveAfterHours,
+			AutoAdvanceRequiresSignal: sp.AutoAdvanceRequiresSignal,
 		}
 		// Match step-level agent profile if present.
 		if sp.AgentProfile != nil && s.matchProfile != nil {

--- a/apps/backend/internal/workflow/service/service_test.go
+++ b/apps/backend/internal/workflow/service/service_test.go
@@ -681,6 +681,36 @@ func TestImportWorkflows(t *testing.T) {
 		assert.False(t, steps[2].ShowInCommandPanel, "Done should not show in command panel")
 	})
 
+	t.Run("preserves auto_advance_requires_signal on import", func(t *testing.T) {
+		svc, _, _ := setupTestServiceWithProvider(t)
+		ctx := context.Background()
+
+		export := &models.WorkflowExport{
+			Version: models.ExportVersion,
+			Type:    models.ExportType,
+			Workflows: []models.WorkflowPortable{
+				{
+					Name: "Signal WF",
+					Steps: []models.StepPortable{
+						{Name: "Legacy", Position: 0, Color: "gray", AutoAdvanceRequiresSignal: false},
+						{Name: "Gated", Position: 1, Color: "blue", AutoAdvanceRequiresSignal: true},
+					},
+				},
+			},
+		}
+
+		result, err := svc.ImportWorkflows(ctx, "ws-1", export)
+		require.NoError(t, err)
+		require.Len(t, result.Created, 1)
+
+		steps, err := svc.repo.ListStepsByWorkflow(ctx, "imported-Signal WF")
+		require.NoError(t, err)
+		require.Len(t, steps, 2)
+
+		assert.False(t, steps[0].AutoAdvanceRequiresSignal, "Legacy step should not require signal")
+		assert.True(t, steps[1].AutoAdvanceRequiresSignal, "Gated step should require signal")
+	})
+
 	t.Run("rejects invalid export data", func(t *testing.T) {
 		svc, _, _ := setupTestServiceWithProvider(t)
 		ctx := context.Background()

--- a/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
@@ -249,16 +249,43 @@ export function TurnCompleteSelect({
           <HelpTip text="Turn off plan mode after the agent finishes this step." />
         </div>
       )}
+      <ExplicitCompletionToggle step={step} onUpdate={onUpdate} readOnly={readOnly} />
     </div>
   );
 }
 
-// ADR 0015 explicit-completion-signal UI (the "Wait for agent completion
-// signal" toggle) is deferred to a follow-up PR. The backend column ships
-// here so workflow steps can opt in via the MCP
-// `update_workflow_step_kandev` tool. The pipeline-editor toggle needs its
-// own iteration to avoid an unrelated E2E flake in
-// `workflow-agent-profile.spec.ts` caused by additional UI shifting the
-// Radix select dropdown into a sibling tooltip's hover path. The workflow
-// import/export YAML also needs to be extended to serialize this flag in
-// the follow-up so the toggle setting round-trips through export.
+// --- ExplicitCompletionToggle ---
+// ADR 0015: when checked, on_turn_complete transitions only fire after the
+// agent calls the `step_complete_kandev` MCP tool. Bare turn-end leaves the
+// task in WAITING_FOR_INPUT until the signal arrives.
+
+type ExplicitCompletionToggleProps = {
+  step: WorkflowStep;
+  onUpdate: (updates: Partial<WorkflowStep>) => void;
+  readOnly: boolean;
+};
+
+export function ExplicitCompletionToggle({
+  step,
+  onUpdate,
+  readOnly,
+}: ExplicitCompletionToggleProps) {
+  return (
+    <div className="flex items-center gap-2 pt-1" data-testid={`${step.id}-require-signal-row`}>
+      <Checkbox
+        id={`${step.id}-require-signal`}
+        data-testid={`${step.id}-require-signal-checkbox`}
+        checked={step.auto_advance_requires_signal === true}
+        onCheckedChange={(c) => {
+          if (readOnly) return;
+          onUpdate({ auto_advance_requires_signal: c === true });
+        }}
+        disabled={readOnly}
+      />
+      <Label htmlFor={`${step.id}-require-signal`} className="text-sm">
+        Wait for agent completion signal
+      </Label>
+      <HelpTip text="Only auto-advance once the agent calls step_complete_kandev. Otherwise turn-end is treated as completion." />
+    </div>
+  );
+}

--- a/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
@@ -249,7 +249,9 @@ export function TurnCompleteSelect({
           <HelpTip text="Turn off plan mode after the agent finishes this step." />
         </div>
       )}
-      <ExplicitCompletionToggle step={step} onUpdate={onUpdate} readOnly={readOnly} />
+      {transitionType !== "none" && (
+        <ExplicitCompletionToggle step={step} onUpdate={onUpdate} readOnly={readOnly} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
ADR 0015's "Wait for agent completion signal" UI shipped as a deferral comment in PR #1276 instead of a working toggle, and the `auto_advance_requires_signal` flag never reached the workflow export format. This wires the pipeline-editor sub-toggle and propagates the field through `StepPortable` so the setting survives export/import.

## Important Changes

- `apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx`: removed the deferral comment, added `ExplicitCompletionToggle` sub-component, and rendered it inside `TurnCompleteSelect` after the disable-plan-mode block. Toggle writes `auto_advance_requires_signal` via `onUpdate`. Placed in the right grid column at the bottom of the transitions section — far from the agent-profile select referenced in the original flake note, and using the same row layout as the existing plan-mode checkbox so no new tooltip lands in a Radix dropdown hover path.
- `apps/backend/internal/workflow/models/export.go`: added `AutoAdvanceRequiresSignal bool` to `StepPortable` with `json` + `yaml` tags and copied the field in `buildWorkflowPortable`.
- `apps/backend/internal/workflow/service/service.go`: `importSingleWorkflow` now assigns the flag onto created `WorkflowStep` rows.

## Validation

- `go test ./internal/workflow/... ./internal/orchestrator/... ./internal/mcp/...` — green, including new `TestAutoAdvanceRequiresSignalExport`.
- `make -C apps/backend test lint` — 0 issues.
- `pnpm --filter @kandev/web typecheck` — clean.
- `pnpm --filter @kandev/web lint` — clean.

## Possible Improvements

The pre-existing `workflow-agent-profile.spec.ts` flake the original deferral cited was speculative — the new toggle sits in a different panel section and uses the established checkbox pattern, so the agent-profile dropdown's hover path is unchanged. If CI does flake post-merge, the fix is local to that spec (e.g. force-click or keyboard nav on the option).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.