### PR TITLE
fix(web): preserve manual task selection during archive/delete

### DIFF
--- a/apps/web/hooks/use-task-removal.test.ts
+++ b/apps/web/hooks/use-task-removal.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { StoreApi } from "zustand";
+
+const replaceTaskUrlMock = vi.fn();
+const performLayoutSwitchMock = vi.fn();
+const listTaskSessionsMock = vi.fn();
+
+vi.mock("@/lib/links", () => ({
+  replaceTaskUrl: (...args: unknown[]) => replaceTaskUrlMock(...args),
+}));
+
+vi.mock("@/lib/state/dockview-store", () => ({
+  performLayoutSwitch: (...args: unknown[]) => performLayoutSwitchMock(...args),
+}));
+
+vi.mock("@/lib/api", () => ({
+  listTaskSessions: (...args: unknown[]) => listTaskSessionsMock(...args),
+}));
+
+import { useTaskRemoval } from "./use-task-removal";
+
+type TaskRow = { id: string; primarySessionId: string | null };
+
+type FakeState = {
+  tasks: { activeTaskId: string | null; activeSessionId: string | null };
+  kanban: { tasks: TaskRow[] };
+  kanbanMulti: { snapshots: Record<string, { tasks: TaskRow[] }> };
+  environmentIdBySessionId: Record<string, string>;
+  taskSessionsByTask: {
+    itemsByTaskId: Record<string, never[]>;
+    loadedByTaskId: Record<string, boolean>;
+    loadingByTaskId: Record<string, boolean>;
+  };
+  setActiveTask: ReturnType<typeof vi.fn>;
+  setActiveSession: ReturnType<typeof vi.fn>;
+  setWorkflowSnapshot: ReturnType<typeof vi.fn>;
+  setTaskSessionsForTask: ReturnType<typeof vi.fn>;
+  setTaskSessionsLoading: ReturnType<typeof vi.fn>;
+};
+
+function makeStore(init: {
+  activeTaskId: string | null;
+  activeSessionId?: string | null;
+  remainingTasks: TaskRow[];
+}): StoreApi<FakeState> & { getRecorded: () => FakeState } {
+  const state: FakeState = {
+    tasks: {
+      activeTaskId: init.activeTaskId,
+      activeSessionId: init.activeSessionId ?? null,
+    },
+    kanban: { tasks: [] },
+    kanbanMulti: {
+      snapshots: { "wf-1": { tasks: init.remainingTasks } },
+    },
+    environmentIdBySessionId: { "sess-next": "env-next", "sess-A": "env-A" },
+    taskSessionsByTask: {
+      itemsByTaskId: {},
+      loadedByTaskId: {},
+      loadingByTaskId: {},
+    },
+    setActiveTask: vi.fn() as ReturnType<typeof vi.fn>,
+    setActiveSession: vi.fn() as ReturnType<typeof vi.fn>,
+    setWorkflowSnapshot: vi.fn((wfId: string, snapshot: { tasks: TaskRow[] }) => {
+      state.kanbanMulti.snapshots[wfId] = snapshot;
+    }) as unknown as ReturnType<typeof vi.fn>,
+    setTaskSessionsForTask: vi.fn() as ReturnType<typeof vi.fn>,
+    setTaskSessionsLoading: vi.fn() as ReturnType<typeof vi.fn>,
+  };
+
+  const api: StoreApi<FakeState> = {
+    getState: () => state,
+    setState: (updater: unknown) => {
+      const next =
+        typeof updater === "function"
+          ? (updater as (s: FakeState) => FakeState)(state)
+          : (updater as FakeState);
+      Object.assign(state, next);
+    },
+    subscribe: () => () => {},
+    getInitialState: () => state,
+  } as unknown as StoreApi<FakeState>;
+
+  return Object.assign(api, { getRecorded: () => state }) as StoreApi<FakeState> & {
+    getRecorded: () => FakeState;
+  };
+}
+
+const nextTask: TaskRow = { id: "task-next", primarySessionId: "sess-next" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useTaskRemoval — switch guard (current store wins)", () => {
+  it("switches to next task when activeTaskId === taskId (user still on removed task)", async () => {
+    const store = makeStore({
+      activeTaskId: "task-A",
+      activeSessionId: "sess-A",
+      remainingTasks: [{ id: "task-A", primarySessionId: "sess-A" }, nextTask],
+    });
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+    });
+
+    expect(store.getRecorded().setActiveSession).toHaveBeenCalledWith("task-next", "sess-next");
+    expect(replaceTaskUrlMock).toHaveBeenCalledWith("task-next");
+  });
+
+  it("does NOT switch when user manually moved to a different task during in-flight archive", async () => {
+    const store = makeStore({
+      activeTaskId: "task-B",
+      activeSessionId: "sess-B",
+      remainingTasks: [{ id: "task-B", primarySessionId: "sess-B" }, nextTask],
+    });
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+    });
+
+    expect(store.getRecorded().setActiveSession).not.toHaveBeenCalled();
+    expect(store.getRecorded().setActiveTask).not.toHaveBeenCalled();
+    expect(replaceTaskUrlMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useTaskRemoval — switch guard (WS-clear fallback)", () => {
+  it("switches when WS cleared activeTaskId AND wasActiveTaskId matches removed task", async () => {
+    const store = makeStore({
+      activeTaskId: null,
+      activeSessionId: null,
+      remainingTasks: [nextTask],
+    });
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+    });
+
+    expect(store.getRecorded().setActiveSession).toHaveBeenCalledWith("task-next", "sess-next");
+    expect(replaceTaskUrlMock).toHaveBeenCalledWith("task-next");
+  });
+
+  it("does NOT switch when activeTaskId is null AND wasActiveTaskId does not match removed task", async () => {
+    const store = makeStore({
+      activeTaskId: null,
+      activeSessionId: null,
+      remainingTasks: [nextTask],
+    });
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A", {
+      wasActiveTaskId: "task-B",
+      wasActiveSessionId: "sess-B",
+    });
+
+    expect(store.getRecorded().setActiveSession).not.toHaveBeenCalled();
+    expect(store.getRecorded().setActiveTask).not.toHaveBeenCalled();
+    expect(replaceTaskUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to / when no remaining tasks AND user still on removed task", async () => {
+    const store = makeStore({
+      activeTaskId: "task-A",
+      activeSessionId: "sess-A",
+      remainingTasks: [{ id: "task-A", primarySessionId: "sess-A" }],
+    });
+    const hrefSetter = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        get href() {
+          return "";
+        },
+        set href(value: string) {
+          hrefSetter(value);
+        },
+      },
+    });
+
+    try {
+      const { result } = renderHook(() =>
+        useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+      );
+      await result.current.removeTaskFromBoard("task-A", {
+        wasActiveTaskId: "task-A",
+        wasActiveSessionId: "sess-A",
+      });
+      expect(hrefSetter).toHaveBeenCalledWith("/");
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+});

--- a/apps/web/hooks/use-task-removal.test.ts
+++ b/apps/web/hooks/use-task-removal.test.ts
@@ -153,6 +153,23 @@ describe("useTaskRemoval — switch guard (WS-clear fallback)", () => {
     expect(replaceTaskUrlMock).toHaveBeenCalledWith("task-next");
   });
 
+  it("does NOT switch when no opts provided and WS already cleared activeTaskId", async () => {
+    const store = makeStore({
+      activeTaskId: null,
+      activeSessionId: null,
+      remainingTasks: [nextTask],
+    });
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A");
+
+    expect(store.getRecorded().setActiveSession).not.toHaveBeenCalled();
+    expect(store.getRecorded().setActiveTask).not.toHaveBeenCalled();
+    expect(replaceTaskUrlMock).not.toHaveBeenCalled();
+  });
+
   it("does NOT switch when activeTaskId is null AND wasActiveTaskId does not match removed task", async () => {
     const store = makeStore({
       activeTaskId: null,

--- a/apps/web/hooks/use-task-removal.ts
+++ b/apps/web/hooks/use-task-removal.ts
@@ -166,7 +166,7 @@ function shouldSwitchAfterRemoval(
 ): boolean {
   const currentActiveTaskId = store.getState().tasks.activeTaskId;
   const stillOnRemoved = currentActiveTaskId === taskId;
-  const wsCleared = currentActiveTaskId == null && opts?.wasActiveTaskId === taskId;
+  const wsCleared = currentActiveTaskId === null && opts?.wasActiveTaskId === taskId;
   return stillOnRemoved || wsCleared;
 }
 

--- a/apps/web/hooks/use-task-removal.ts
+++ b/apps/web/hooks/use-task-removal.ts
@@ -15,9 +15,12 @@ type TaskRemovalOptions = {
 
 type RemoveFromBoardOptions = {
   /**
-   * The active task ID captured **before** the async delete API call.
-   * Avoids a race with the WS "task.deleted" handler that may clear
-   * activeTaskId before removeTaskFromBoard runs.
+   * The active task ID captured **before** the async delete/archive API call.
+   * Only honored when the current `activeTaskId` has been cleared to `null`
+   * by the WS "task.deleted" / "task.updated(archived_at)" handler racing
+   * ahead of this function. If the user has manually navigated to a different
+   * task during the in-flight API call, the current store value wins and
+   * this captured value is ignored.
    */
   wasActiveTaskId?: string | null;
   /** The active session ID captured before the async delete API call. */
@@ -144,13 +147,27 @@ function resolveOldEnvId(store: StoreApi<AppState>, opts?: RemoveFromBoardOption
   return oldSessionId ? (store.getState().environmentIdBySessionId[oldSessionId] ?? null) : null;
 }
 
-function resolveActiveTaskId(
+/**
+ * Decide whether the removed task is the one the user is currently viewing.
+ *
+ * Two cases count as "still on the removed task":
+ *   1. `stillOnRemoved` — the store's current `activeTaskId` matches `taskId`.
+ *   2. `wsCleared` — the store's `activeTaskId` has been cleared to `null`
+ *      (the WS `task.deleted` / `task.updated(archived_at)` handler raced
+ *      ahead of us) AND the caller-captured `wasActiveTaskId` matches `taskId`.
+ *
+ * Any other state means the user manually moved to a different task during
+ * the in-flight API call — leave them on their chosen task.
+ */
+function shouldSwitchAfterRemoval(
   store: StoreApi<AppState>,
+  taskId: string,
   opts?: RemoveFromBoardOptions,
-): string | null {
-  return opts?.wasActiveTaskId !== undefined
-    ? opts.wasActiveTaskId
-    : store.getState().tasks.activeTaskId;
+): boolean {
+  const currentActiveTaskId = store.getState().tasks.activeTaskId;
+  const stillOnRemoved = currentActiveTaskId === taskId;
+  const wsCleared = currentActiveTaskId == null && opts?.wasActiveTaskId === taskId;
+  return stillOnRemoved || wsCleared;
 }
 
 /**
@@ -170,20 +187,18 @@ export function useTaskRemoval({ store, useLayoutSwitch = false }: TaskRemovalOp
    * and switch to the next available task if the removed task was active.
    *
    * Pass `opts.wasActiveTaskId` / `opts.wasActiveSessionId` when calling after
-   * an async API call (e.g. deleteTaskById) — the WS "task.deleted" handler may
-   * clear activeTaskId before this function runs.
+   * an async API call (e.g. deleteTaskById, archiveTask) — the WS handler may
+   * clear activeTaskId before this function runs. The captured value is only
+   * consulted as a fallback when the current store value has been cleared; if
+   * the user manually navigated to a different task mid-flight, the store
+   * wins and the captured value is ignored (no auto-switch).
    */
   const removeTaskFromBoard = useCallback(
     async (taskId: string, opts?: RemoveFromBoardOptions) => {
       removeTaskFromSnapshots(store, taskId);
       const allRemainingTasks = collectRemainingTasks(store);
 
-      // Use the caller-provided active task ID (captured before the async API
-      // call) to avoid the race with the WS handler that may have already
-      // cleared it.  Fall back to the current store value for callers that
-      // don't provide it (e.g. archive, which doesn't go through the API).
-      const activeTaskId = resolveActiveTaskId(store, opts);
-      if (activeTaskId !== taskId) return;
+      if (!shouldSwitchAfterRemoval(store, taskId, opts)) return;
 
       const oldEnvId = resolveOldEnvId(store, opts);
       if (allRemainingTasks.length > 0) {


### PR DESCRIPTION
## Summary
- Fix race where archiving or deleting a task could clobber the user's manual navigation to another task during the in-flight API call.
- `resolveActiveTaskId` always preferred the caller-captured pre-API `wasActiveTaskId` over the live store value, so if the user clicked another task while archive/delete was still resolving, the auto-switch logic still treated the removed task as "active" and jumped to `allRemainingTasks[0]` — overwriting the user's pick.
- Replaced with `shouldSwitchAfterRemoval`, a two-condition guard that only auto-switches when (a) the store still points at the removed task, or (b) the store has been WS-cleared to `null` **and** the captured value matches the removed task.

## Implementation notes
The captured `wasActiveTaskId` was originally added to survive the WS `task.deleted` / `task.updated(archived_at)` handler clearing `activeTaskId` to `null` before `removeTaskFromBoard` ran. That protection is still needed, but it shouldn't override a non-null store value — a non-null store value that differs from the removed task means the user deliberately moved on.

`shouldSwitchAfterRemoval` reads the live `activeTaskId` and only honors `opts.wasActiveTaskId` when the live value has been cleared to `null`. `resolveOldEnvId` is unchanged — once we decide to switch, we still need the pre-WS-clear `activeSessionId` to compute `oldEnvId`. No call-site changes required: the six callers (archive sidebar, archive PR-merged banner, archive action-message, sheet archive, sidebar delete, sheet delete) all benefit transparently.

## Test plan
- [x] New `apps/web/hooks/use-task-removal.test.ts` covering the five guard cases:
  1. `activeTaskId === taskId` → switch to next task.
  2. `activeTaskId === otherId` (manual move) → no switch, URL untouched.
  3. `activeTaskId == null`, `wasActiveTaskId === taskId` (WS race) → switch.
  4. `activeTaskId == null`, `wasActiveTaskId !== taskId` → no switch.
  5. No remaining tasks + still on removed task → redirect to `/`.
- [x] `pnpm --filter @kandev/web test -- use-task-removal` — passes.
- [x] `pnpm --filter @kandev/web typecheck` / `lint` — clean.
- [ ] CI to re-run existing `archive-task-redirect.spec.ts`, `delete-task-redirect.spec.ts`, `sidebar-delete-confirm.spec.ts` — same paths exercised, expected green.

## Risks & rollback
- **Risk**: a caller relies on the legacy "switch even after the user moved on" behavior. Audited all six call sites — every one describes "switch *if the removed task was active*", not "always switch".
- **Risk**: a `setActiveTask(null)` path outside the WS handler trips the `wsCleared` branch incorrectly. None found; `activeTaskId` only changes via user navigation or the two WS handlers.
- **Rollback**: revert the single hook change; the new test file can stay deleted. No data, API, or schema changes.