### PR TITLE
fix(web): guard dockview measure against mid-transition sidebar width

### DIFF
--- a/apps/web/lib/state/dockview-measure.test.ts
+++ b/apps/web/lib/state/dockview-measure.test.ts
@@ -23,6 +23,27 @@ describe("measureDockviewContainer", () => {
     expect(measureDockviewContainer(fakeApi(0, 0))).toEqual({ width: 1500, height: 700 });
   });
 
+  it("ignores an implausibly-narrow live width (sidebar mid-transition) and falls back to viewport", () => {
+    // Regression (post unified-sidebar #1165): the AppSidebar is a root-layout
+    // flex sibling with `transition-all duration-300`, so the dockview content
+    // container can be measured mid-animation at a tiny positive width. Building
+    // the default layout at that width collapses the horizontal columns into a
+    // vertical stack (chat / files+changes / terminal). On desktop the sidebar
+    // maxes at 30vw, so content is always >= ~70vw — a sub-half-viewport read is
+    // definitionally a transient and must be treated like a 0-width (not-yet
+    // laid-out) container: fall back to the viewport so the build stays
+    // horizontal; the resize observer then snaps to the exact size.
+    const parent = document.createElement("div");
+    Object.defineProperty(parent, "clientWidth", { value: 80, configurable: true });
+    Object.defineProperty(parent, "clientHeight", { value: 700, configurable: true });
+    const dv = document.createElement("div");
+    dv.className = "dv-dockview";
+    parent.appendChild(dv);
+    document.body.appendChild(parent);
+
+    expect(measureDockviewContainer(fakeApi(0, 0)).width).toBe(window.innerWidth);
+  });
+
   it("never returns a zero size on a fresh mount (no container, api not laid out yet)", () => {
     // Regression: a 0×0 measurement builds the default layout at zero width, so
     // dockview collapses the horizontal columns into a vertical stack (chat /

--- a/apps/web/lib/state/dockview-measure.test.ts
+++ b/apps/web/lib/state/dockview-measure.test.ts
@@ -23,16 +23,16 @@ describe("measureDockviewContainer", () => {
     expect(measureDockviewContainer(fakeApi(0, 0))).toEqual({ width: 1500, height: 700 });
   });
 
-  it("ignores an implausibly-narrow live width (sidebar mid-transition) and falls back to viewport", () => {
+  it("ignores an implausibly-narrow live width (sidebar mid-transition) but keeps the live height", () => {
     // Regression (post unified-sidebar #1165): the AppSidebar is a root-layout
     // flex sibling with `transition-all duration-300`, so the dockview content
     // container can be measured mid-animation at a tiny positive width. Building
     // the default layout at that width collapses the horizontal columns into a
     // vertical stack (chat / files+changes / terminal). On desktop the sidebar
     // maxes at 30vw, so content is always >= ~70vw — a sub-half-viewport read is
-    // definitionally a transient and must be treated like a 0-width (not-yet
-    // laid-out) container: fall back to the viewport so the build stays
-    // horizontal; the resize observer then snaps to the exact size.
+    // definitionally a transient: fall back the width to the viewport so the
+    // build stays horizontal (the resize observer then snaps to the exact size).
+    // The animation is horizontal, so the live height is reliable and is kept.
     const parent = document.createElement("div");
     Object.defineProperty(parent, "clientWidth", { value: 80, configurable: true });
     Object.defineProperty(parent, "clientHeight", { value: 700, configurable: true });
@@ -41,7 +41,9 @@ describe("measureDockviewContainer", () => {
     parent.appendChild(dv);
     document.body.appendChild(parent);
 
-    expect(measureDockviewContainer(fakeApi(0, 0)).width).toBe(window.innerWidth);
+    const result = measureDockviewContainer(fakeApi(0, 0));
+    expect(result.width).toBe(window.innerWidth);
+    expect(result.height).toBe(700);
   });
 
   it("never returns a zero size on a fresh mount (no container, api not laid out yet)", () => {

--- a/apps/web/lib/state/dockview-measure.ts
+++ b/apps/web/lib/state/dockview-measure.ts
@@ -39,8 +39,15 @@ function liveContainerSize(): { width: number; height: number } | null {
   const dv = document.querySelector(".dv-dockview") as HTMLElement | null;
   const parent = dv?.parentElement;
   if (!parent || parent.clientWidth <= 0 || parent.clientHeight <= 0) return null;
-  if (parent.clientWidth < viewportWidth() * MIN_PLAUSIBLE_WIDTH_RATIO) return null;
-  return { width: parent.clientWidth, height: parent.clientHeight };
+  // The sidebar animation is horizontal, so only the width can be a transient —
+  // the live height is reliable. Fall back just the width to the viewport so the
+  // build stays horizontal; keep the real height to avoid a needless vertical
+  // transient. The resize observer then snaps the width to the exact size.
+  const plausibleWidth = parent.clientWidth >= viewportWidth() * MIN_PLAUSIBLE_WIDTH_RATIO;
+  return {
+    width: plausibleWidth ? parent.clientWidth : viewportWidth(),
+    height: parent.clientHeight,
+  };
 }
 
 function viewportWidth(): number {

--- a/apps/web/lib/state/dockview-measure.ts
+++ b/apps/web/lib/state/dockview-measure.ts
@@ -25,11 +25,21 @@ export function measureDockviewContainer(api: DockviewApi): { width: number; hei
   };
 }
 
+// The dockview content area sits next to the unified AppSidebar (#1165), whose
+// width animates over 300ms (`transition-all`). During that animation `onReady`
+// can read the parent at a tiny positive width — building the default layout at
+// that width collapses the horizontal columns into a vertical stack. The
+// sidebar maxes at 30vw (desktop-only surface), so a healthy content width is
+// always >= ~70vw; anything below half the viewport is a mid-transition
+// transient and must be treated like a not-yet-laid-out (0-width) container.
+const MIN_PLAUSIBLE_WIDTH_RATIO = 0.5;
+
 function liveContainerSize(): { width: number; height: number } | null {
   if (typeof document === "undefined") return null;
   const dv = document.querySelector(".dv-dockview") as HTMLElement | null;
   const parent = dv?.parentElement;
   if (!parent || parent.clientWidth <= 0 || parent.clientHeight <= 0) return null;
+  if (parent.clientWidth < viewportWidth() * MIN_PLAUSIBLE_WIDTH_RATIO) return null;
   return { width: parent.clientWidth, height: parent.clientHeight };
 }
 


### PR DESCRIPTION
## Summary

Entering a task intermittently rendered the dockview panels collapsed into a vertical stack (Files/Changes group + an oversized Terminal, chat missing) instead of horizontal columns. After the unified AppSidebar (#1165) — a root-layout flex sibling that animates its width over 300ms — the dockview content container could be measured mid-transition at a tiny positive width in `onReady`, so the default layout built too narrow and dockview stacked its columns vertically. The race made it non-deterministic.

## Important Changes

- `measureDockviewContainer` now rejects an implausibly-small live container width (< 50% of viewport) as a not-yet-laid-out transient and falls back to the viewport, the same as the existing zero-width guard. The ResizeObserver then snaps the grid to the exact size, so the build stays horizontal. The sidebar is desktop-only and maxes at 30vw, so a healthy content width is always ≥ ~70vw; normal collapse/expand (Δ184px) never trips the guard, leaving the animation UX unchanged.

## Validation

- `pnpm --filter @kandev/web test` — 391 passed (incl. new regression test in `dockview-measure.test.ts`)
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] Tests added/updated
- [ ] Docs updated if needed
- [ ] Self-reviewed the diff