### PR TITLE
fix(agentctl): read models from configOptions fallback

### DIFF
--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -437,6 +437,12 @@ func buildInitProbeFields(initResp acp.InitializeResponse) *ProbeResponse {
 }
 
 // applySessionProbeFields populates models and modes from an ACP session/new response.
+//
+// The legacy `models`/`modes` fields were marked UNSTABLE in the ACP spec and
+// newer agents (e.g. claude-agent-acp v0.42+) drop them in favour of the
+// general `configOptions[]` carrier with `category: model | mode`. Read the
+// legacy fields first, then fall back to configOptions when they are absent
+// so both shapes work.
 func applySessionProbeFields(out *ProbeResponse, sessionResp acp.NewSessionResponse) {
 	if sessionResp.Models != nil {
 		out.CurrentModelID = string(sessionResp.Models.CurrentModelId)
@@ -460,6 +466,80 @@ func applySessionProbeFields(out *ProbeResponse, sessionResp acp.NewSessionRespo
 			})
 		}
 	}
+	if len(out.Models) == 0 {
+		applyConfigOptionsAsModels(out, sessionResp.ConfigOptions)
+	}
+	if len(out.Modes) == 0 {
+		applyConfigOptionsAsModes(out, sessionResp.ConfigOptions)
+	}
+}
+
+// applyConfigOptionsAsModels extracts a ProbeModel list from any
+// configOptions[] entry tagged with category=model. Used as a fallback when
+// the legacy `models` field is omitted by the agent.
+func applyConfigOptionsAsModels(out *ProbeResponse, opts []acp.SessionConfigOption) {
+	sel := findSelectConfigOption(opts, acp.SessionConfigOptionCategoryModel)
+	if sel == nil {
+		return
+	}
+	out.CurrentModelID = string(sel.CurrentValue)
+	for _, opt := range selectOptionsUngrouped(sel.Options) {
+		out.Models = append(out.Models, ProbeModel{
+			ID:          string(opt.Value),
+			Name:        opt.Name,
+			Description: derefString(opt.Description),
+			Meta:        opt.Meta,
+		})
+	}
+}
+
+// applyConfigOptionsAsModes mirrors applyConfigOptionsAsModels for modes.
+func applyConfigOptionsAsModes(out *ProbeResponse, opts []acp.SessionConfigOption) {
+	sel := findSelectConfigOption(opts, acp.SessionConfigOptionCategoryMode)
+	if sel == nil {
+		return
+	}
+	out.CurrentModeID = string(sel.CurrentValue)
+	for _, opt := range selectOptionsUngrouped(sel.Options) {
+		out.Modes = append(out.Modes, ProbeMode{
+			ID:          string(opt.Value),
+			Name:        opt.Name,
+			Description: derefString(opt.Description),
+			Meta:        opt.Meta,
+		})
+	}
+}
+
+// findSelectConfigOption returns the first Select-typed configOption whose
+// category matches. Boolean toggles and other categories are skipped.
+func findSelectConfigOption(opts []acp.SessionConfigOption, want acp.SessionConfigOptionCategory) *acp.SessionConfigOptionSelect {
+	for i := range opts {
+		sel := opts[i].Select
+		if sel == nil || sel.Category == nil {
+			continue
+		}
+		if *sel.Category == want {
+			return sel
+		}
+	}
+	return nil
+}
+
+// selectOptionsUngrouped flattens a SessionConfigSelectOptions union to a
+// plain slice. Grouped options are flattened group-by-group so callers do not
+// need to care about the nesting.
+func selectOptionsUngrouped(opts acp.SessionConfigSelectOptions) []acp.SessionConfigSelectOption {
+	if opts.Ungrouped != nil {
+		return []acp.SessionConfigSelectOption(*opts.Ungrouped)
+	}
+	if opts.Grouped == nil {
+		return nil
+	}
+	var out []acp.SessionConfigSelectOption
+	for _, g := range *opts.Grouped {
+		out = append(out, g.Options...)
+	}
+	return out
 }
 
 func derefString(p *string) string {

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -466,10 +466,15 @@ func applySessionProbeFields(out *ProbeResponse, sessionResp acp.NewSessionRespo
 			})
 		}
 	}
-	if len(out.Models) == 0 {
+	// Gate the fallback on the legacy field being absent (nil) rather than
+	// producing an empty slice. A non-nil `Models` with an empty
+	// `AvailableModels` is schema-valid and would otherwise mix sources:
+	// `CurrentModelID` set from the legacy field, then immediately
+	// overwritten by the configOptions fallback. Same for modes.
+	if sessionResp.Models == nil {
 		applyConfigOptionsAsModels(out, sessionResp.ConfigOptions)
 	}
-	if len(out.Modes) == 0 {
+	if sessionResp.Modes == nil {
 		applyConfigOptionsAsModes(out, sessionResp.ConfigOptions)
 	}
 }

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -184,6 +184,42 @@ func TestApplySessionProbeFields_PrefersLegacyModelsField(t *testing.T) {
 	}
 }
 
+// A non-nil `Models` struct with an empty `AvailableModels` slice is
+// schema-valid. The fallback must NOT fire in that case — otherwise
+// `CurrentModelID` set from the legacy field gets clobbered by the
+// configOptions value, mixing sources.
+func TestApplySessionProbeFields_LegacyEmptyModelsBlocksFallback(t *testing.T) {
+	t.Parallel()
+
+	modelCat := acp.SessionConfigOptionCategoryModel
+	resp := acp.NewSessionResponse{
+		Models: &acp.SessionModelState{
+			CurrentModelId:  "legacy-current",
+			AvailableModels: nil,
+		},
+		ConfigOptions: []acp.SessionConfigOption{
+			{Select: &acp.SessionConfigOptionSelect{
+				Category:     &modelCat,
+				CurrentValue: "fallback-current",
+				Options: acp.SessionConfigSelectOptions{Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+					{Value: "fallback-current", Name: "Fallback"},
+				}},
+				Type: "select",
+			}},
+		},
+	}
+
+	out := &ProbeResponse{}
+	applySessionProbeFields(out, resp)
+
+	if got, want := out.CurrentModelID, "legacy-current"; got != want {
+		t.Fatalf("CurrentModelID = %q, want %q (legacy must win, fallback must not fire)", got, want)
+	}
+	if len(out.Models) != 0 {
+		t.Fatalf("Models = %+v, want empty (fallback should be skipped when legacy field is non-nil)", out.Models)
+	}
+}
+
 // Grouped select-option payloads are flattened group-by-group so the
 // fallback works regardless of whether the agent groups its options.
 func TestApplySessionProbeFields_FlattensGroupedConfigOptions(t *testing.T) {

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -5,7 +5,11 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+
+	acp "github.com/coder/acp-go-sdk"
 )
+
+func ptr[T any](v T) *T { return &v }
 
 func TestResolveProbeCommand_AllowsEveryListedBinary(t *testing.T) {
 	t.Parallel()
@@ -95,5 +99,122 @@ func TestSanitizeInferenceChunk_RemovesMultipleBannerLines(t *testing.T) {
 	want := "fix: tighten prompt parsing"
 	if got != want {
 		t.Fatalf("sanitizeInferenceChunk() = %q, want %q", got, want)
+	}
+}
+
+// Reproduces the regression behind "Claude advertised no models": newer
+// claude-agent-acp (v0.42+) drops the unstable `models` / `modes` fields and
+// publishes the same data through `configOptions[]`. The probe must fall back
+// to that shape so the inference-agents endpoint still surfaces the model
+// list.
+func TestApplySessionProbeFields_FallsBackToConfigOptions(t *testing.T) {
+	t.Parallel()
+
+	modelCat := acp.SessionConfigOptionCategoryModel
+	resp := acp.NewSessionResponse{
+		ConfigOptions: []acp.SessionConfigOption{
+			{Select: &acp.SessionConfigOptionSelect{
+				Category:     &modelCat,
+				CurrentValue: "opus",
+				Id:           "model",
+				Name:         "Model",
+				Options: acp.SessionConfigSelectOptions{Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+					{Value: "default", Name: "Default (recommended)", Description: ptr("Sonnet 4.6")},
+					{Value: "opus", Name: "Opus", Description: ptr("Opus 4.7")},
+					{Value: "haiku", Name: "Haiku"},
+				}},
+				Type: "select",
+			}},
+		},
+	}
+
+	out := &ProbeResponse{}
+	applySessionProbeFields(out, resp)
+
+	if got, want := out.CurrentModelID, "opus"; got != want {
+		t.Fatalf("CurrentModelID = %q, want %q", got, want)
+	}
+	if got, want := len(out.Models), 3; got != want {
+		t.Fatalf("len(Models) = %d, want %d", got, want)
+	}
+	if got, want := out.Models[1].ID, "opus"; got != want {
+		t.Fatalf("Models[1].ID = %q, want %q", got, want)
+	}
+	if got, want := out.Models[0].Description, "Sonnet 4.6"; got != want {
+		t.Fatalf("Models[0].Description = %q, want %q", got, want)
+	}
+}
+
+// The legacy `models` field still wins when present so existing agents are
+// unaffected; configOptions is only consulted as a fallback.
+func TestApplySessionProbeFields_PrefersLegacyModelsField(t *testing.T) {
+	t.Parallel()
+
+	modelCat := acp.SessionConfigOptionCategoryModel
+	resp := acp.NewSessionResponse{
+		Models: &acp.SessionModelState{
+			CurrentModelId: "legacy",
+			AvailableModels: []acp.ModelInfo{
+				{ModelId: "legacy", Name: "Legacy"},
+			},
+		},
+		ConfigOptions: []acp.SessionConfigOption{
+			{Select: &acp.SessionConfigOptionSelect{
+				Category:     &modelCat,
+				CurrentValue: "fallback",
+				Options: acp.SessionConfigSelectOptions{Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+					{Value: "fallback", Name: "Fallback"},
+				}},
+				Type: "select",
+			}},
+		},
+	}
+
+	out := &ProbeResponse{}
+	applySessionProbeFields(out, resp)
+
+	if got, want := out.CurrentModelID, "legacy"; got != want {
+		t.Fatalf("CurrentModelID = %q, want %q", got, want)
+	}
+	if got, want := len(out.Models), 1; got != want {
+		t.Fatalf("len(Models) = %d, want %d", got, want)
+	}
+	if got, want := out.Models[0].ID, "legacy"; got != want {
+		t.Fatalf("Models[0].ID = %q, want %q", got, want)
+	}
+}
+
+// Grouped select-option payloads are flattened group-by-group so the
+// fallback works regardless of whether the agent groups its options.
+func TestApplySessionProbeFields_FlattensGroupedConfigOptions(t *testing.T) {
+	t.Parallel()
+
+	modeCat := acp.SessionConfigOptionCategoryMode
+	resp := acp.NewSessionResponse{
+		ConfigOptions: []acp.SessionConfigOption{
+			{Select: &acp.SessionConfigOptionSelect{
+				Category:     &modeCat,
+				CurrentValue: "default",
+				Options: acp.SessionConfigSelectOptions{Grouped: &acp.SessionConfigSelectOptionsGrouped{
+					{Group: "safe", Name: "Safe", Options: []acp.SessionConfigSelectOption{
+						{Value: "default", Name: "Default"},
+					}},
+					{Group: "danger", Name: "Danger", Options: []acp.SessionConfigSelectOption{
+						{Value: "bypass", Name: "Bypass"},
+					}},
+				}},
+				Type: "select",
+			}},
+		},
+	}
+
+	out := &ProbeResponse{}
+	applySessionProbeFields(out, resp)
+
+	if got, want := len(out.Modes), 2; got != want {
+		t.Fatalf("len(Modes) = %d, want %d", got, want)
+	}
+	if out.Modes[0].ID != "default" || out.Modes[1].ID != "bypass" {
+		t.Fatalf("Modes = %+v, want [default bypass]", out.Modes)
 	}
 }


### PR DESCRIPTION
## Summary

- claude-agent-acp v0.42 dropped the unstable `models` field from `session/new` and now publishes models only through `configOptions[]` with `category=model`. The probe still read the legacy field, so the inference-agents endpoint reported zero models and the settings UI showed "Claude advertised no models."
- `applySessionProbeFields` (`internal/agentctl/server/utility/acp_executor.go`) now falls back to extracting models / modes from `sessionResp.ConfigOptions` when the legacy fields are absent. The legacy fields still win when present so older agents are unaffected.
- Helper `selectOptionsUngrouped` flattens both the ungrouped and grouped variants of `SessionConfigSelectOptions`, so the fallback works regardless of which shape the agent picks.

## Test plan

- [x] `go test ./internal/agentctl/server/utility/` — three new unit tests cover configOptions fallback, legacy-precedence, and grouped-options flattening.
- [x] Isolation reproducer: drove `ACPInferenceExecutor.Probe` against locally-installed `@agentclientprotocol/claude-agent-acp@0.42.0`. Before fix: `models=0`. After fix: `models=3` (default/opus/haiku, current=opus).
- [x] `make build lint test` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)