### PR TITLE
fix(web): restore dockview sidebar layout

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-constants.ts
+++ b/apps/web/components/app-sidebar/app-sidebar-constants.ts
@@ -10,7 +10,7 @@ export const APP_SIDEBAR_SECTION_IDS = {
 export type AppSidebarSectionId =
   (typeof APP_SIDEBAR_SECTION_IDS)[keyof typeof APP_SIDEBAR_SECTION_IDS];
 
-export const APP_SIDEBAR_EXPANDED_WIDTH = 240;
+export const APP_SIDEBAR_EXPANDED_WIDTH = 320;
 export const APP_SIDEBAR_COLLAPSED_WIDTH = 56;
 
 /**

--- a/apps/web/components/app-sidebar/app-sidebar.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { APP_SIDEBAR_EXPANDED_WIDTH } from "./app-sidebar-constants";
 
 // The AppSidebar pulls in a lot of children that touch the dockview / kanban
 // data layer. For unit testing the collapse + section toggle behaviour we stub
@@ -61,7 +62,7 @@ const storeState = {
       integrations: false,
       settings: false,
     },
-    width: 240,
+    width: APP_SIDEBAR_EXPANDED_WIDTH,
     settingsMode: false,
   },
   toggleAppSidebar: vi.fn(),

--- a/apps/web/components/task/__tests__/use-auto-pr-panel.test.ts
+++ b/apps/web/components/task/__tests__/use-auto-pr-panel.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { DockviewApi } from "dockview-react";
 import { shouldAutoAddPRPanel, resolvePRPanelTargetGroup } from "../dockview-session-tabs";
+import { CENTER_GROUP, RIGHT_TOP_GROUP } from "@/lib/state/layout-manager";
 
 function makeApi(panels: Array<{ id: string; groupId: string }>): DockviewApi {
   return {
@@ -80,5 +81,17 @@ describe("resolvePRPanelTargetGroup", () => {
     // the new session's chat panel is the authoritative anchor.
     const api = makeApi([{ id: "session:new", groupId: "group-new" }]);
     expect(resolvePRPanelTargetGroup(api, "new", "group-old")).toBe("group-new");
+  });
+
+  it("falls back to the center group when the live session panel is in a right group", () => {
+    // Corrupted layouts can briefly leave the session panel in the right tools
+    // column. The PR panel must not follow it there.
+    const api = makeApi([{ id: "session:abc", groupId: RIGHT_TOP_GROUP }]);
+    expect(resolvePRPanelTargetGroup(api, "abc", "group-center")).toBe("group-center");
+  });
+
+  it("uses the well-known center group when both candidates are right groups", () => {
+    const api = makeApi([{ id: "session:abc", groupId: RIGHT_TOP_GROUP }]);
+    expect(resolvePRPanelTargetGroup(api, "abc", RIGHT_TOP_GROUP)).toBe(CENTER_GROUP);
   });
 });

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -4,8 +4,11 @@ import type { TaskSession } from "@/lib/types/http";
 import {
   findSessionAnchorGroupId,
   reconcileRemovedSessionPanels,
+  resolveInitialPosition,
   resolveSessionTabSyncTarget,
 } from "./dockview-session-tabs";
+import { RIGHT_TOP_GROUP } from "@/lib/state/layout-manager";
+import { useDockviewStore } from "@/lib/state/dockview-store";
 
 type FakePanel = {
   id: string;
@@ -41,6 +44,22 @@ function makeApi(panelIds: string[]): { api: DockviewApi; panels: FakePanel[] } 
     getPanel: (id: string) => panels.find((p) => p.id === id) ?? null,
   } as unknown as DockviewApi;
   return { api, panels };
+}
+
+function makePositionApi(args: {
+  groups: string[];
+  panels?: Array<{ id: string; groupId: string }>;
+}): DockviewApi {
+  const panels =
+    args.panels?.map((p) => ({
+      id: p.id,
+      group: { id: p.groupId },
+    })) ?? [];
+  return {
+    groups: args.groups.map((id) => ({ id })),
+    panels,
+    getPanel: (id: string) => panels.find((p) => p.id === id) ?? null,
+  } as unknown as DockviewApi;
 }
 
 function panelById(panels: FakePanel[], id: string): FakePanel | undefined {
@@ -189,6 +208,18 @@ describe("findSessionAnchorGroupId", () => {
     const api = makeApiWithPanels([]);
 
     expect(findSessionAnchorGroupId(api)).toBeNull();
+  });
+});
+
+describe("resolveInitialPosition", () => {
+  it("creates a center column left of the right sidebar when only the right group remains", () => {
+    useDockviewStore.setState({ centerGroupId: RIGHT_TOP_GROUP });
+    const api = makePositionApi({ groups: [RIGHT_TOP_GROUP] });
+
+    expect(resolveInitialPosition(api)).toEqual({
+      referenceGroup: RIGHT_TOP_GROUP,
+      direction: "left",
+    });
   });
 });
 

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -6,9 +6,8 @@ import { useDockviewStore } from "@/lib/state/dockview-store";
 import { focusOrAddPanel } from "@/lib/state/dockview-layout-builders";
 import {
   CENTER_GROUP,
-  RIGHT_BOTTOM_GROUP,
+  isCenterCandidateGroupId,
   RIGHT_TOP_GROUP,
-  SIDEBAR_GROUP,
 } from "@/lib/state/layout-manager";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { wasPRPanelOffered, markPRPanelOffered } from "@/lib/local-storage";
@@ -220,8 +219,9 @@ export function resolvePRPanelTargetGroup(
   centerGroupId: string,
 ): string {
   const sessionPanel = api.getPanel(`session:${sessionId}`);
-  const resolved = sessionPanel?.group?.id ?? centerGroupId;
-  return resolved;
+  const sessionGroupId = sessionPanel?.group?.id;
+  if (sessionGroupId && isCenterCandidateGroupId(sessionGroupId)) return sessionGroupId;
+  return isCenterCandidateGroupId(centerGroupId) ? centerGroupId : CENTER_GROUP;
 }
 
 /**
@@ -303,10 +303,6 @@ export function useAutoPRPanel() {
  */
 const SESSION_ANCHOR_PANEL_IDS = ["pr-detail"];
 
-function isCenterCandidateGroupId(groupId: string): boolean {
-  return groupId !== SIDEBAR_GROUP && groupId !== RIGHT_TOP_GROUP && groupId !== RIGHT_BOTTOM_GROUP;
-}
-
 export function findSessionAnchorGroupId(api: DockviewApi): string | null {
   for (const id of SESSION_ANCHOR_PANEL_IDS) {
     const exact = api.getPanel(id);
@@ -318,7 +314,7 @@ export function findSessionAnchorGroupId(api: DockviewApi): string | null {
   return null;
 }
 
-function resolveInitialPosition(api: DockviewApi): AddPanelOptions["position"] {
+export function resolveInitialPosition(api: DockviewApi): AddPanelOptions["position"] {
   // Prefer the live "chat" placeholder's group. The session panel must be added
   // INTO that group (so it's a tab beside chat) BEFORE chat is removed —
   // otherwise removing chat empties and destroys the center group, the stored

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -4,6 +4,12 @@ import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { focusOrAddPanel } from "@/lib/state/dockview-layout-builders";
+import {
+  CENTER_GROUP,
+  RIGHT_BOTTOM_GROUP,
+  RIGHT_TOP_GROUP,
+  SIDEBAR_GROUP,
+} from "@/lib/state/layout-manager";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { wasPRPanelOffered, markPRPanelOffered } from "@/lib/local-storage";
 import { sessionId as toSessionId } from "@/lib/types/ids";
@@ -169,7 +175,11 @@ export function setupChatPanelSafetyNet(
           position,
         });
         const nc = api.getPanel(`session:${activeSessionId}`);
-        if (nc) useDockviewStore.setState({ centerGroupId: nc.group.id });
+        if (nc) {
+          useDockviewStore.setState({
+            centerGroupId: isCenterCandidateGroupId(nc.group.id) ? nc.group.id : CENTER_GROUP,
+          });
+        }
       });
     });
   });
@@ -293,6 +303,10 @@ export function useAutoPRPanel() {
  */
 const SESSION_ANCHOR_PANEL_IDS = ["pr-detail"];
 
+function isCenterCandidateGroupId(groupId: string): boolean {
+  return groupId !== SIDEBAR_GROUP && groupId !== RIGHT_TOP_GROUP && groupId !== RIGHT_BOTTOM_GROUP;
+}
+
 export function findSessionAnchorGroupId(api: DockviewApi): string | null {
   for (const id of SESSION_ANCHOR_PANEL_IDS) {
     const exact = api.getPanel(id);
@@ -311,9 +325,12 @@ function resolveInitialPosition(api: DockviewApi): AddPanelOptions["position"] {
   // centerGroupId goes stale, and the session panel gets appended as a new row,
   // collapsing the horizontal default layout into a vertical stack.
   const chatGroupId = api.getPanel("chat")?.group?.id;
-  if (chatGroupId) return { referenceGroup: chatGroupId };
+  if (chatGroupId && isCenterCandidateGroupId(chatGroupId)) return { referenceGroup: chatGroupId };
   const { centerGroupId } = useDockviewStore.getState();
-  const centerGroupExists = centerGroupId && api.groups.some((g) => g.id === centerGroupId);
+  const centerGroupExists =
+    centerGroupId &&
+    isCenterCandidateGroupId(centerGroupId) &&
+    api.groups.some((g) => g.id === centerGroupId);
   if (centerGroupExists) return { referenceGroup: centerGroupId };
   const anchorGroupId = findSessionAnchorGroupId(api);
   // index:0 matches the project's session-on-the-left convention (agent tab
@@ -322,7 +339,11 @@ function resolveInitialPosition(api: DockviewApi): AddPanelOptions["position"] {
   // lost here — but the alternative (appending) would put the agent tab
   // to the right of pr-detail, which contradicts the default placement
   // every other code path produces. Pick the consistent default.
-  if (anchorGroupId) return { referenceGroup: anchorGroupId, index: 0 };
+  if (anchorGroupId && isCenterCandidateGroupId(anchorGroupId)) {
+    return { referenceGroup: anchorGroupId, index: 0 };
+  }
+  const rightTopExists = api.groups.some((g) => g.id === RIGHT_TOP_GROUP);
+  if (rightTopExists) return { referenceGroup: RIGHT_TOP_GROUP, direction: "left" };
   return undefined;
 }
 
@@ -499,7 +520,11 @@ function activateSessionPanel(
     });
   }
   if (shouldActivate) activePanel.api.setActive();
-  useDockviewStore.setState({ centerGroupId: activePanel.group.id });
+  useDockviewStore.setState({
+    centerGroupId: isCenterCandidateGroupId(activePanel.group.id)
+      ? activePanel.group.id
+      : CENTER_GROUP,
+  });
   return activePanel;
 }
 

--- a/apps/web/e2e/tests/kanban/kanban-board.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-board.spec.ts
@@ -53,19 +53,19 @@ test.describe("Kanban board", () => {
   // no longer room between the left/right action groups for the centered
   // search, so the header hides it (see useIsHeaderNarrow in kanban-header).
   //
-  // Post-overhaul: the always-on AppSidebar (~240px expanded) permanently eats
+  // Post-overhaul: the always-on AppSidebar (~320px expanded) permanently eats
   // horizontal space, so the header's own clientWidth is viewport − sidebar.
   // The default Desktop Chrome 1280px viewport now leaves the header below the
   // 1100px narrow threshold even with no preview open, so this test forces a
   // viewport wide enough that the centered search shows with the sidebar
-  // present (1400 − ~240 = ~1160 ≥ 1100), and opening the 500px preview drops
-  // it below the threshold (1400 − ~240 − 500 = ~660 < 1100).
+  // present (1500 − ~320 = ~1180 ≥ 1100), and opening the 500px preview drops
+  // it below the threshold (1500 − ~320 − 500 = ~680 < 1100).
   test("hides header search when preview panel narrows the kanban area", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
-    await testPage.setViewportSize({ width: 1400, height: 800 });
+    await testPage.setViewportSize({ width: 1500, height: 800 });
     await apiClient.saveUserSettings({ enable_preview_on_click: true });
 
     const task = await apiClient.createTask(seedData.workspaceId, "Header Squeeze Task", {

--- a/apps/web/lib/state/dockview-layout-builders.test.ts
+++ b/apps/web/lib/state/dockview-layout-builders.test.ts
@@ -47,6 +47,18 @@ describe("fallbackGroupPosition", () => {
     expect(fallbackGroupPosition(api)).toEqual({ referenceGroup: sessionGroupId });
   });
 
+  it("does not use a right-column session panel as a center fallback", () => {
+    // Regression: after restoring a bad task layout, the session tab could be
+    // added into group-right-top with Files/Changes. A stale centerGroupId then
+    // made center-targeted panels keep landing in that right tools group.
+    const api = makeApi(
+      [SIDEBAR_GROUP, RIGHT_TOP_GROUP, RIGHT_BOTTOM_GROUP],
+      [{ id: "session:abc", group: { id: RIGHT_TOP_GROUP } }],
+    );
+
+    expect(fallbackGroupPosition(api)).toBeUndefined();
+  });
+
   it("does not return a right-column group when no center-like group exists", () => {
     // Right-column groups (Changes/Files/Terminal) are tool columns — placing
     // a diff or PR panel there is the same UX bug as placing it in the sidebar.

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -22,6 +22,10 @@ export { getRootSplitview } from "./layout-manager";
 
 const debugWidths = createDebugLogger("dockview:widths");
 
+function isCenterCandidateGroupId(groupId: string): boolean {
+  return groupId !== SIDEBAR_GROUP && groupId !== RIGHT_TOP_GROUP && groupId !== RIGHT_BOTTOM_GROUP;
+}
+
 /** Dockview's measured grid width, or undefined when not yet laid out — passed
  *  to the cap helpers so they don't fall back to a possibly-stale
  *  `window.innerWidth`. */
@@ -244,14 +248,14 @@ export function fallbackGroupPosition(api: DockviewApi): { referenceGroup: strin
   if (centerGroup) return { referenceGroup: centerGroup.id };
 
   const chatGroupId = api.getPanel("chat")?.group?.id;
-  if (chatGroupId) return { referenceGroup: chatGroupId };
+  if (chatGroupId && isCenterCandidateGroupId(chatGroupId)) return { referenceGroup: chatGroupId };
 
   const sessionGroupId = api.panels.find((p) => p.id.startsWith("session:"))?.group?.id;
-  if (sessionGroupId) return { referenceGroup: sessionGroupId };
+  if (sessionGroupId && isCenterCandidateGroupId(sessionGroupId)) {
+    return { referenceGroup: sessionGroupId };
+  }
 
-  const centerish = api.groups.find(
-    (g) => g.id !== SIDEBAR_GROUP && g.id !== RIGHT_TOP_GROUP && g.id !== RIGHT_BOTTOM_GROUP,
-  );
+  const centerish = api.groups.find((g) => isCenterCandidateGroupId(g.id));
   if (centerish) return { referenceGroup: centerish.id };
 
   return undefined;

--- a/apps/web/lib/state/dockview-layout-builders.ts
+++ b/apps/web/lib/state/dockview-layout-builders.ts
@@ -1,7 +1,6 @@
 import type { DockviewApi, AddPanelOptions } from "dockview-react";
 import {
   SIDEBAR_LOCK,
-  SIDEBAR_GROUP,
   CENTER_GROUP,
   RIGHT_TOP_GROUP,
   RIGHT_BOTTOM_GROUP,
@@ -9,6 +8,7 @@ import {
   computeSidebarMaxPx,
   computeRightMaxPx,
   getPinnedWidth,
+  isCenterCandidateGroupId,
   getRootSplitview as getRootSplitviewImpl,
   resolveGroupIds,
   setPinnedTarget,
@@ -21,10 +21,6 @@ import { createDebugLogger, isDebug } from "@/lib/debug/log";
 export { getRootSplitview } from "./layout-manager";
 
 const debugWidths = createDebugLogger("dockview:widths");
-
-function isCenterCandidateGroupId(groupId: string): boolean {
-  return groupId !== SIDEBAR_GROUP && groupId !== RIGHT_TOP_GROUP && groupId !== RIGHT_BOTTOM_GROUP;
-}
 
 /** Dockview's measured grid width, or undefined when not yet laid out — passed
  *  to the cap helpers so they don't fall back to a possibly-stale

--- a/apps/web/lib/state/dockview-store.test.ts
+++ b/apps/web/lib/state/dockview-store.test.ts
@@ -100,8 +100,8 @@ describe("dockview-store resolveFilePath (via onDidActivePanelChange)", () => {
 
 describe("resolvePresetPinnedWidths", () => {
   // sidebar + center + right, with the legacy initial caps (sidebar 350, right
-  // 450). At totalWidth 1600 the ratio (0.25) is 400 → sidebar clamps to 350,
-  // right stays 400.
+  // 450). At totalWidth 1600 the sidebar ratio clamps to 350, while the right
+  // ratio clamps to 450.
   const cols = [
     { id: "sidebar", pinned: true, groups: [] },
     { id: "center", groups: [] },
@@ -120,7 +120,7 @@ describe("resolvePresetPinnedWidths", () => {
     const result = resolvePresetPinnedWidths(live, cols, 1600, true);
 
     expect(result.get("sidebar")).toBe(350); // clamped to legacy sidebar cap
-    expect(result.get("right")).toBe(400); // ratio 0.25 * 1600
+    expect(result.get("right")).toBe(450); // clamped to legacy right cap
     expect(result.has("center")).toBe(false); // not pinned
   });
 

--- a/apps/web/lib/state/layout-manager/applier.test.ts
+++ b/apps/web/lib/state/layout-manager/applier.test.ts
@@ -153,11 +153,11 @@ describe("applyLayout — pinned target capture with no override", () => {
     // Empty overrides → each pinned column should fall back to its default.
     applyLayout(api, state, new Map(), 1600, 800);
 
-    // Defaults at totalWidth 1600: ratio 0.25*1600 = 400 → sidebar clamps to
-    // 350, right stays 400. NOT the transient 245 / 258.
+    // Defaults at totalWidth 1600: sidebar ratio clamps to 350; right ratio
+    // clamps to its legacy 450 cap. NOT the transient 245 / 258.
     expect(getPinnedTarget("sidebar")).toBe(350);
-    expect(getPinnedTarget("right")).toBe(400);
+    expect(getPinnedTarget("right")).toBe(450);
     expect(resizeView).toHaveBeenCalledWith(0, 350);
-    expect(resizeView).toHaveBeenCalledWith(2, 400);
+    expect(resizeView).toHaveBeenCalledWith(2, 450);
   });
 });

--- a/apps/web/lib/state/layout-manager/applier.test.ts
+++ b/apps/web/lib/state/layout-manager/applier.test.ts
@@ -60,6 +60,22 @@ describe("resolveGroupIds", () => {
     expect(ids.centerGroupId).toBe(sessionGroupId);
   });
 
+  it("does not classify a right-column session panel as the center group", () => {
+    // Regression: a corrupted task layout restored only Files/Changes in
+    // group-right-top, then auto-added the session tab into that same group.
+    // Treating that session panel as the center poisoned centerGroupId and
+    // caused future center panels to land in the right tools column.
+    const api = makeApi(
+      [{ id: SIDEBAR_GROUP }, { id: RIGHT_TOP_GROUP }, { id: RIGHT_BOTTOM_GROUP }],
+      [{ id: "session:abc123", group: { id: RIGHT_TOP_GROUP } }],
+    );
+
+    const ids = resolveGroupIds(api);
+
+    expect(ids.centerGroupId).toBe(CENTER_GROUP);
+    expect(ids.centerGroupId).not.toBe(RIGHT_TOP_GROUP);
+  });
+
   it("returns the CENTER_GROUP constant as last-resort when nothing matches", () => {
     // Last-resort fallback: returns the well-known constant even when no live
     // group carries that ID. The caller (focusOrAddPanel) detects the stale ID

--- a/apps/web/lib/state/layout-manager/applier.ts
+++ b/apps/web/lib/state/layout-manager/applier.ts
@@ -34,6 +34,10 @@ function findGroupId(api: DockviewApi, knownId: string, fallbackPanelId: string)
   return pnl?.group?.id ?? knownId;
 }
 
+function isCenterCandidateGroupId(groupId: string): boolean {
+  return groupId !== SIDEBAR_GROUP && groupId !== RIGHT_TOP_GROUP && groupId !== RIGHT_BOTTOM_GROUP;
+}
+
 /** Find the center group, preferring the well-known ID, then "chat", then any
  *  "session:*" panel's group. When a session is active, "chat" is removed and
  *  replaced with per-session tabs — without the session fallback the returned
@@ -41,9 +45,13 @@ function findGroupId(api: DockviewApi, knownId: string, fallbackPanelId: string)
 function findCenterGroupId(api: DockviewApi): string {
   if (api.groups.some((g) => g.id === CENTER_GROUP)) return CENTER_GROUP;
   const chat = api.getPanel("chat");
-  if (chat?.group?.id) return chat.group.id;
+  if (chat?.group?.id && isCenterCandidateGroupId(chat.group.id)) return chat.group.id;
   const sessionPanel = api.panels.find((p) => p.id.startsWith("session:"));
-  if (sessionPanel?.group?.id) return sessionPanel.group.id;
+  if (sessionPanel?.group?.id && isCenterCandidateGroupId(sessionPanel.group.id)) {
+    return sessionPanel.group.id;
+  }
+  const centerish = api.groups.find((g) => isCenterCandidateGroupId(g.id));
+  if (centerish) return centerish.id;
   return CENTER_GROUP;
 }
 

--- a/apps/web/lib/state/layout-manager/applier.ts
+++ b/apps/web/lib/state/layout-manager/applier.ts
@@ -34,7 +34,7 @@ function findGroupId(api: DockviewApi, knownId: string, fallbackPanelId: string)
   return pnl?.group?.id ?? knownId;
 }
 
-function isCenterCandidateGroupId(groupId: string): boolean {
+export function isCenterCandidateGroupId(groupId: string): boolean {
   return groupId !== SIDEBAR_GROUP && groupId !== RIGHT_TOP_GROUP && groupId !== RIGHT_BOTTOM_GROUP;
 }
 

--- a/apps/web/lib/state/layout-manager/constants.ts
+++ b/apps/web/lib/state/layout-manager/constants.ts
@@ -3,15 +3,12 @@ import type { LayoutPanel } from "./types";
 // Layout sizing constants (single source of truth).
 // Pinned column max width is computed at runtime — see ./caps.ts.
 //
-// Ratio applied to viewport width to compute the initial default for any
-// pinned column when no user override exists. Sidebar and right pane share
-// the same initial fraction today; if they need to diverge later, split this
-// into per-column ratios at that time.
-export const LAYOUT_INITIAL_RATIO = 2.5 / 10;
-/** @deprecated use LAYOUT_INITIAL_RATIO. */
-export const LAYOUT_SIDEBAR_RATIO = LAYOUT_INITIAL_RATIO;
-/** @deprecated use LAYOUT_INITIAL_RATIO. */
-export const LAYOUT_RIGHT_RATIO = LAYOUT_INITIAL_RATIO;
+// Ratio applied to dockview width to compute initial defaults when no user
+// override exists. The left app sidebar now sits outside dockview, so the
+// right pane needs a larger dockview-relative ratio to preserve the old
+// laptop proportions after the app sidebar consumes horizontal space.
+export const LAYOUT_SIDEBAR_RATIO = 2.5 / 10;
+export const LAYOUT_RIGHT_RATIO = 1 / 3;
 
 // Well-known group/panel IDs
 export const SIDEBAR_GROUP = "group-sidebar";

--- a/apps/web/lib/state/layout-manager/index.ts
+++ b/apps/web/lib/state/layout-manager/index.ts
@@ -59,7 +59,12 @@ export { computeColumnWidths, computeGroupHeights, getPinnedWidth } from "./sizi
 export { toSerializedDockview, fromDockviewApi, filterEphemeral } from "./serializer";
 
 // Applier
-export { applyLayout, getRootSplitview, resolveGroupIds } from "./applier";
+export {
+  applyLayout,
+  getRootSplitview,
+  resolveGroupIds,
+  isCenterCandidateGroupId,
+} from "./applier";
 export type { LayoutGroupIds } from "./applier";
 
 // Merger

--- a/apps/web/lib/state/layout-manager/sizing.test.ts
+++ b/apps/web/lib/state/layout-manager/sizing.test.ts
@@ -43,7 +43,14 @@ describe("getPinnedWidth — global sidebar width pref", () => {
 
   it("does NOT apply the sidebar pref to the right column", () => {
     setGlobalSidebarWidth(200);
-    // right: ratio 0.25 * 1600 = 400, clamped to legacy right cap (450) → 400.
-    expect(getPinnedWidth(right(), TOTAL, undefined)).toBe(400);
+    // right: ratio 1/3 * 1600 = 533, clamped to legacy right cap (450).
+    expect(getPinnedWidth(right(), TOTAL, undefined)).toBe(450);
+  });
+
+  it("keeps the right pane near its old laptop width after the app sidebar is outside dockview", () => {
+    // MacBook Air-style viewport: 1280px total. The unified AppSidebar's
+    // 320px default leaves 960px for dockview; 1/3 restores the old 320px
+    // right pane that used to be computed as 25% of the full dockview.
+    expect(getPinnedWidth(right(), 960, undefined)).toBe(320);
   });
 });

--- a/apps/web/lib/state/layout-manager/sizing.ts
+++ b/apps/web/lib/state/layout-manager/sizing.ts
@@ -1,5 +1,5 @@
 import type { LayoutColumn, LayoutGroup } from "./types";
-import { LAYOUT_INITIAL_RATIO } from "./constants";
+import { LAYOUT_RIGHT_RATIO, LAYOUT_SIDEBAR_RATIO } from "./constants";
 import { computePinnedMaxPxFor, computeSidebarMaxPx, LAYOUT_PINNED_MIN_PX } from "./caps";
 import { getGlobalSidebarWidth } from "@/lib/local-storage";
 
@@ -38,7 +38,8 @@ export function getPinnedWidth(
       return Math.max(min, Math.min(pref, max));
     }
   }
-  const ratioWidth = Math.round(totalWidth * LAYOUT_INITIAL_RATIO);
+  const ratio = column.id === "sidebar" ? LAYOUT_SIDEBAR_RATIO : LAYOUT_RIGHT_RATIO;
+  const ratioWidth = Math.round(totalWidth * ratio);
   const initialCap =
     column.maxWidth ??
     (column.id === "sidebar" ? LEGACY_SIDEBAR_INITIAL_CAP : LEGACY_RIGHT_INITIAL_CAP);

--- a/apps/web/lib/state/slices/ui/ui-slice.test.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.test.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { updateUserSettings } from "@/lib/api/domains/settings-api";
 import { createUISlice } from "./ui-slice";
+import { APP_SIDEBAR_EXPANDED_WIDTH } from "@/components/app-sidebar/app-sidebar-constants";
 import type { SidebarViewDraft } from "./sidebar-view-types";
 import type { UISlice } from "./types";
 
@@ -224,6 +225,7 @@ describe("appSidebar actions", () => {
   it("hydrates default state when localStorage is empty", () => {
     const store = makeStore();
     expect(store.getState().appSidebar.collapsed).toBe(false);
+    expect(store.getState().appSidebar.width).toBe(APP_SIDEBAR_EXPANDED_WIDTH);
     expect(store.getState().appSidebar.sectionExpanded.tasks).toBe(true);
     expect(store.getState().appSidebar.sectionExpanded.projects).toBe(false);
   });

--- a/apps/web/lib/state/slices/ui/ui-slice.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.ts
@@ -21,6 +21,7 @@ import {
   buildAppSidebarActions,
   loadAppSidebarState,
 } from "./app-sidebar-actions";
+import { APP_SIDEBAR_EXPANDED_WIDTH } from "@/components/app-sidebar/app-sidebar-constants";
 import { buildSidebarTaskPrefsActions } from "./sidebar-task-prefs-actions";
 import { DEFAULT_ACTIVE_VIEW_ID, DEFAULT_VIEW } from "./sidebar-view-builtins";
 import type {
@@ -130,7 +131,7 @@ export const defaultUIState: UISliceState = {
   appSidebar: {
     collapsed: false,
     sectionExpanded: { ...DEFAULT_SECTION_EXPANDED },
-    width: 240,
+    width: APP_SIDEBAR_EXPANDED_WIDTH,
     settingsMode: false,
   },
 };


### PR DESCRIPTION
Dockview task switching regressed after layout persistence changes, allowing right-sidebar groups to be treated as center content and leaving laptop sidebars narrower than their previous proportions. This restores the intended group placement and default pane sizing so Files/Changes remain on the right and the app/sidebar widths match the old laptop feel.

## Important Changes

- Keep right dockview groups out of center-panel candidate selection during task/session switches.
- Restore the expanded AppSidebar default to 320px and persist that default through UI state hydration.
- Split pinned-column ratios so the right pane defaults to about 320px on a 1280px laptop viewport after the AppSidebar sits outside dockview.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Possible Improvements

These defaults are still fixed heuristics; a future viewport-specific visual regression test would catch proportion drift sooner.

## Checklist

- [ ] Added/updated tests, or explained why not needed
- [ ] Updated docs/AGENTS/specs/ADRs if conventions or architecture changed
- [ ] Confirmed the PR title follows Conventional Commits