### PR TITLE
fix(web): gate changes push button on ahead count

### DIFF
--- a/apps/web/components/task/changes-panel-repo-groups.tsx
+++ b/apps/web/components/task/changes-panel-repo-groups.tsx
@@ -197,7 +197,7 @@ export function CommitsGroupActions({
 
 /**
  * Per-repo group inside the Commits section. Like {@link RepoGroupItem} but
- * for commit rows; surfaces a Push button when the repo has unpushed commits.
+ * for commit rows; surfaces a Push button when the repo is ahead of its remote.
  */
 export function CommitsRepoGroup({
   repositoryName,

--- a/apps/web/components/task/changes-panel-repo-groups.tsx
+++ b/apps/web/components/task/changes-panel-repo-groups.tsx
@@ -143,7 +143,6 @@ export function FileSectionActions({
 
 export function CommitsGroupActions({
   repositoryName,
-  unpushedCount,
   aheadCount,
   prExists,
   canCreatePR,
@@ -152,7 +151,6 @@ export function CommitsGroupActions({
   stop,
 }: {
   repositoryName: string;
-  unpushedCount: number;
   aheadCount: number;
   prExists: boolean;
   canCreatePR: boolean;
@@ -162,7 +160,7 @@ export function CommitsGroupActions({
 }) {
   return (
     <div className="flex items-center gap-1" onClick={stop}>
-      {onRepoPush && (unpushedCount > 0 || aheadCount > 0) && (
+      {onRepoPush && aheadCount > 0 && (
         <Button
           size="sm"
           variant="ghost"
@@ -172,7 +170,7 @@ export function CommitsGroupActions({
         >
           <IconCloudUpload className="h-3 w-3" />
           Push
-          <span className="text-muted-foreground">{unpushedCount || aheadCount}</span>
+          <span className="text-muted-foreground">{aheadCount}</span>
         </Button>
       )}
       {onRepoCreatePR && (
@@ -237,7 +235,6 @@ export function CommitsRepoGroup({
   // Each repo has its own "latest unpushed commit" — revert/amend in this
   // group must target THIS repo's newest, not the merged-list newest.
   const firstUnpushedInGroup = groupCommits.findIndex((c) => c.pushed !== true);
-  const unpushedCount = groupCommits.filter((c) => !c.pushed).length;
   const stop = (e: React.MouseEvent) => e.stopPropagation();
   const label = displayName || repositoryName || "Repository";
   // Bug 10 acknowledged trade-off: `existingPrUrl` is sourced from a
@@ -288,7 +285,6 @@ export function CommitsRepoGroup({
         </button>
         <CommitsGroupActions
           repositoryName={repositoryName}
-          unpushedCount={unpushedCount}
           aheadCount={aheadCount}
           prExists={prExists}
           canCreatePR={canCreatePR}

--- a/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
+++ b/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
@@ -41,6 +41,7 @@ const ARIA_EXPANDED = "aria-expanded";
 afterEach(cleanup);
 
 type Props = ComponentProps<typeof FileListSection>;
+type CommitProps = ComponentProps<typeof CommitsSection>;
 
 const baseProps: Omit<Props, "files" | "variant" | "isLast" | "actionLabel" | "onAction"> = {
   pendingStageFiles: new Set(),
@@ -60,6 +61,17 @@ function file(path: string, repo?: string): Props["files"][number] {
     minus: 0,
     oldPath: undefined,
     repositoryName: repo,
+  };
+}
+
+function commit(sha: string, message: string, repo?: string): CommitProps["commits"][number] {
+  return {
+    commit_sha: sha,
+    commit_message: message,
+    insertions: 1,
+    deletions: 0,
+    pushed: false,
+    repository_name: repo,
   };
 }
 
@@ -159,19 +171,6 @@ describe("FileListSection — multi-repo grouping", () => {
 });
 
 describe("CommitsSection", () => {
-  type CommitProps = ComponentProps<typeof CommitsSection>;
-
-  function commit(sha: string, message: string, repo?: string): CommitProps["commits"][number] {
-    return {
-      commit_sha: sha,
-      commit_message: message,
-      insertions: 1,
-      deletions: 0,
-      pushed: false,
-      repository_name: repo,
-    };
-  }
-
   it("renders the commits section header collapsed by default", () => {
     render(<CommitsSection commits={[commit("abc123", "first")]} isLast />);
     // Commits section is collapsed by default; the toggle reflects that and
@@ -219,6 +218,41 @@ describe("CommitsSection", () => {
     fireEvent.click(screen.getByTestId(COMMITS_SECTION_TOGGLE_TID));
     expect(screen.queryAllByTestId("commits-repo-header")).toHaveLength(0);
     expect(screen.getAllByTestId(COMMIT_ROW_TID)).toHaveLength(2);
+  });
+});
+
+describe("CommitsSection actions", () => {
+  it("does not show Push when commits are already on the tracked remote", () => {
+    render(
+      <CommitsSection
+        commits={[commit("c1", "already pushed"), commit("c2", "also pushed")]}
+        isLast
+        onRepoPush={() => undefined}
+        perRepoStatus={[{ repository_name: "", ahead: 0 }]}
+      />,
+    );
+
+    expect(screen.queryByTestId("commits-repo-push")).toBeNull();
+
+    fireEvent.click(screen.getByTestId(COMMITS_SECTION_TOGGLE_TID));
+    expect(screen.getAllByTestId(COMMIT_ROW_TID)).toHaveLength(2);
+    expect(screen.queryByTestId("commits-repo-push")).toBeNull();
+  });
+
+  it("labels Push with the actual ahead count instead of the commit list count", () => {
+    render(
+      <CommitsSection
+        commits={[commit("c1", "newest"), commit("c2", "middle"), commit("c3", "oldest")]}
+        isLast
+        onRepoPush={() => undefined}
+        perRepoStatus={[{ repository_name: "", ahead: 1 }]}
+      />,
+    );
+
+    const push = screen.getByTestId("commits-repo-push");
+    expect(push.textContent).toContain("Push");
+    expect(push.textContent).toContain("1");
+    expect(push.textContent).not.toContain("3");
   });
 
   // Regression: previously isLatest was computed against the merged list, so

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -182,7 +182,6 @@ export function CommitsSection({
   const sectionAction = isSingleRepo ? (
     <CommitsGroupActions
       repositoryName=""
-      unpushedCount={groups[0].items.filter((c) => !c.pushed).length}
       aheadCount={aheadByRepo.get("") ?? 0}
       prExists={!!prByRepo?.[""]}
       canCreatePR={!!onRepoCreatePR && !prByRepo?.[""]}


### PR DESCRIPTION
The Changes panel could offer a Push action for commits that were already present on the tracked remote because the button fell back to the local commit-list count. This makes the action depend only on git's ahead count so pushed PR commits remain reviewable without showing a misleading push affordance.

## Validation

- `make fmt`
- `make typecheck test lint` (initial run hit a transient CLI `src/ports.test.ts` port-availability failure after backend and web tests passed)
- `pnpm -C apps/cli test`
- `make lint`

## Possible Improvements

Low risk: this only changes the Push affordance gating/count; commit rows still show their existing pushed/unpushed state independently.

## Checklist

- [ ] I have tested these changes locally
- [ ] I have added or updated tests where appropriate
- [ ] I have updated docs where needed