### PR TITLE
fix(web): use recent task after removal

### DIFF
--- a/apps/web/hooks/use-task-removal.test.ts
+++ b/apps/web/hooks/use-task-removal.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import { useTaskRemoval } from "./use-task-removal";
+import { setRecentTasks } from "@/lib/recent-tasks";
 
 type TaskRow = { id: string; primarySessionId: string | null };
 
@@ -90,6 +91,7 @@ const nextTask: TaskRow = { id: "task-next", primarySessionId: "sess-next" };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  window.localStorage.clear();
 });
 
 describe("useTaskRemoval — switch guard (current store wins)", () => {
@@ -225,5 +227,56 @@ describe("useTaskRemoval — switch guard (WS-clear fallback)", () => {
         value: originalLocation,
       });
     }
+  });
+});
+
+describe("useTaskRemoval — next task selection", () => {
+  it("switches to the most recent remaining task instead of the first snapshot task", async () => {
+    const recentTaskId = "task-recent";
+    const recentSessionId = "sess-recent";
+    const oldTask = { id: "task-old", primarySessionId: "sess-old" };
+    const recentTask = { id: recentTaskId, primarySessionId: recentSessionId };
+    const store = makeStore({
+      activeTaskId: "task-A",
+      activeSessionId: "sess-A",
+      remainingTasks: [{ id: "task-A", primarySessionId: "sess-A" }, oldTask, recentTask],
+    });
+    store.getRecorded().environmentIdBySessionId = {
+      ...store.getRecorded().environmentIdBySessionId,
+      "sess-old": "env-old",
+      [recentSessionId]: "env-recent",
+    };
+    setRecentTasks([
+      {
+        taskId: recentTaskId,
+        title: "Recent task",
+        visitedAt: "2026-06-07T10:00:00Z",
+      },
+      {
+        taskId: "task-A",
+        title: "Removed task",
+        visitedAt: "2026-06-07T09:00:00Z",
+      },
+      {
+        taskId: "task-old",
+        title: "Old task",
+        visitedAt: "2026-06-06T10:00:00Z",
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+    });
+
+    expect(store.getRecorded().setActiveSession).toHaveBeenCalledWith(
+      recentTaskId,
+      recentSessionId,
+    );
+    expect(replaceTaskUrlMock).toHaveBeenCalledWith(recentTaskId);
   });
 });

--- a/apps/web/hooks/use-task-removal.test.ts
+++ b/apps/web/hooks/use-task-removal.test.ts
@@ -231,13 +231,14 @@ describe("useTaskRemoval — switch guard (WS-clear fallback)", () => {
 });
 
 describe("useTaskRemoval — next task selection", () => {
-  it("switches to the most recent remaining task instead of the first snapshot task", async () => {
-    const recentTaskId = "task-recent";
-    const recentSessionId = "sess-recent";
+  const recentTaskId = "task-recent";
+  const recentSessionId = "sess-recent";
+
+  function makeStoreWithOldAndRecentTasks(activeTaskId: string | null) {
     const oldTask = { id: "task-old", primarySessionId: "sess-old" };
     const recentTask = { id: recentTaskId, primarySessionId: recentSessionId };
     const store = makeStore({
-      activeTaskId: "task-A",
+      activeTaskId,
       activeSessionId: "sess-A",
       remainingTasks: [{ id: "task-A", primarySessionId: "sess-A" }, oldTask, recentTask],
     });
@@ -246,6 +247,11 @@ describe("useTaskRemoval — next task selection", () => {
       "sess-old": "env-old",
       [recentSessionId]: "env-recent",
     };
+    return store;
+  }
+
+  it("switches to the most recent remaining task instead of the first snapshot task", async () => {
+    const store = makeStoreWithOldAndRecentTasks("task-A");
     setRecentTasks([
       {
         taskId: recentTaskId,
@@ -255,6 +261,42 @@ describe("useTaskRemoval — next task selection", () => {
       {
         taskId: "task-A",
         title: "Removed task",
+        visitedAt: "2026-06-07T09:00:00Z",
+      },
+      {
+        taskId: "task-old",
+        title: "Old task",
+        visitedAt: "2026-06-06T10:00:00Z",
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+    });
+
+    expect(store.getRecorded().setActiveSession).toHaveBeenCalledWith(
+      recentTaskId,
+      recentSessionId,
+    );
+    expect(replaceTaskUrlMock).toHaveBeenCalledWith(recentTaskId);
+  });
+
+  it("skips the removed active task when it is first in recent history", async () => {
+    const store = makeStoreWithOldAndRecentTasks("task-A");
+    setRecentTasks([
+      {
+        taskId: "task-A",
+        title: "Removed task",
+        visitedAt: "2026-06-07T10:00:00Z",
+      },
+      {
+        taskId: recentTaskId,
+        title: "Recent task",
         visitedAt: "2026-06-07T09:00:00Z",
       },
       {

--- a/apps/web/hooks/use-task-removal.ts
+++ b/apps/web/hooks/use-task-removal.ts
@@ -6,6 +6,7 @@ import type { TaskSession } from "@/lib/types/http";
 import { replaceTaskUrl } from "@/lib/links";
 import { listTaskSessions } from "@/lib/api";
 import { performLayoutSwitch } from "@/lib/state/dockview-store";
+import { getRecentTasks } from "@/lib/recent-tasks";
 
 type TaskRemovalOptions = {
   store: StoreApi<AppState>;
@@ -90,6 +91,17 @@ function collectRemainingTasks(store: StoreApi<AppState>): KanbanState["tasks"] 
     allRemainingTasks.push(...store.getState().kanban.tasks);
   }
   return allRemainingTasks;
+}
+
+function selectNextTaskAfterRemoval(
+  remainingTasks: KanbanState["tasks"],
+): KanbanState["tasks"][number] | null {
+  const remainingById = new Map(remainingTasks.map((task) => [task.id, task]));
+  for (const recent of getRecentTasks()) {
+    const task = remainingById.get(recent.taskId);
+    if (task) return task;
+  }
+  return remainingTasks[0] ?? null;
 }
 
 function switchToSessionForTask(params: {
@@ -201,10 +213,11 @@ export function useTaskRemoval({ store, useLayoutSwitch = false }: TaskRemovalOp
       if (!shouldSwitchAfterRemoval(store, taskId, opts)) return;
 
       const oldEnvId = resolveOldEnvId(store, opts);
-      if (allRemainingTasks.length > 0) {
+      const nextTask = selectNextTaskAfterRemoval(allRemainingTasks);
+      if (nextTask) {
         await switchToNextTask({
           store,
-          nextTask: allRemainingTasks[0],
+          nextTask,
           oldEnvId,
           useLayoutSwitch,
           loadTaskSessionsForTask,


### PR DESCRIPTION
Deleting or archiving the active task could jump to an old sidebar task because removal fallback used snapshot order. This now preserves the user's recent-task context and only falls back to snapshot order when no recent remaining task exists.

## Important Changes

- Select the next task after delete/archive from stored recent-task history before using sidebar snapshot order.
- Add a regression test covering a newer recent task appearing after an older task in snapshot order.

## Validation

- `pnpm --filter @kandev/web test -- --run hooks/use-task-removal.test.ts`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `make fmt typecheck test lint`

## Possible Improvements

The fallback still depends on snapshot order when local recent-task history is empty, which preserves existing behavior for first-time sessions.

## Checklist

- [ ] Tests updated
- [ ] Documentation updated, if needed
- [ ] Screenshots or recordings added, if UI changed