### PR TITLE
fix: alert when git executable is missing

### DIFF
--- a/apps/backend/cmd/kandev/helpers.go
+++ b/apps/backend/cmd/kandev/helpers.go
@@ -874,6 +874,7 @@ func registerHealthRoutes(p routeParams) {
 		5*time.Minute,
 	)
 	healthSvc := health.NewService(p.log,
+		health.NewGitExecutableChecker(),
 		githubChecker,
 		health.NewAgentChecker(p.agentSettingsController),
 		osLimitsChecker,

--- a/apps/backend/internal/health/checks.go
+++ b/apps/backend/internal/health/checks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"time"
 )
 
@@ -113,6 +114,41 @@ func rateLimitMessage(status GitHubRateLimitStatus) string {
 		return "PR/issue checks are paused until the limit resets."
 	}
 	return fmt.Sprintf("PR/issue checks are paused; resets in %s.", wait)
+}
+
+// GitExecutableChecker checks whether the host git executable is available.
+type GitExecutableChecker struct {
+	lookPath func(string) (string, error)
+}
+
+// NewGitExecutableChecker creates a checker for the required host git binary.
+func NewGitExecutableChecker() *GitExecutableChecker {
+	return &GitExecutableChecker{lookPath: exec.LookPath}
+}
+
+// Name returns the user-facing label for this check.
+func (c *GitExecutableChecker) Name() string { return "Git executable" }
+
+// Category returns the issue category this checker emits issues under.
+func (c *GitExecutableChecker) Category() string { return "system_requirements" }
+
+func (c *GitExecutableChecker) Check(_ context.Context) []Issue {
+	lookPath := c.lookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	if _, err := lookPath("git"); err == nil {
+		return nil
+	}
+	return []Issue{{
+		ID:       "git_executable_missing",
+		Category: c.Category(),
+		Title:    "Git executable is required",
+		Message:  "Install Git and ensure the git executable is available on PATH.",
+		Severity: SeverityError,
+		FixURL:   "/settings/system/status",
+		FixLabel: "View system status",
+	}}
 }
 
 // AgentDiscoveryProvider abstracts the agent discovery check.

--- a/apps/backend/internal/health/checks.go
+++ b/apps/backend/internal/health/checks.go
@@ -133,11 +133,7 @@ func (c *GitExecutableChecker) Name() string { return "Git executable" }
 func (c *GitExecutableChecker) Category() string { return "system_requirements" }
 
 func (c *GitExecutableChecker) Check(_ context.Context) []Issue {
-	lookPath := c.lookPath
-	if lookPath == nil {
-		lookPath = exec.LookPath
-	}
-	if _, err := lookPath("git"); err == nil {
+	if _, err := c.lookPath("git"); err == nil {
 		return nil
 	}
 	return []Issue{{

--- a/apps/backend/internal/health/checks_test.go
+++ b/apps/backend/internal/health/checks_test.go
@@ -106,6 +106,51 @@ func TestGitHubChecker_AuthenticatedRateProviderEmpty(t *testing.T) {
 	}
 }
 
+// --- GitExecutableChecker tests ---
+
+func TestGitExecutableChecker_Found(t *testing.T) {
+	checker := &GitExecutableChecker{lookPath: func(name string) (string, error) {
+		if name != "git" {
+			t.Fatalf("lookPath name = %q, want git", name)
+		}
+		return "/usr/bin/git", nil
+	}}
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues, got %d", len(issues))
+	}
+}
+
+func TestGitExecutableChecker_Missing(t *testing.T) {
+	checker := &GitExecutableChecker{lookPath: func(name string) (string, error) {
+		if name != "git" {
+			t.Fatalf("lookPath name = %q, want git", name)
+		}
+		return "", fmt.Errorf("not found")
+	}}
+
+	issues := checker.Check(context.Background())
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].ID != "git_executable_missing" {
+		t.Errorf("issue ID = %q, want %q", issues[0].ID, "git_executable_missing")
+	}
+	if issues[0].Category != "system_requirements" {
+		t.Errorf("category = %q, want %q", issues[0].Category, "system_requirements")
+	}
+	if issues[0].Severity != SeverityError {
+		t.Errorf("severity = %q, want %q", issues[0].Severity, SeverityError)
+	}
+	if !strings.Contains(issues[0].Message, "available on PATH") {
+		t.Errorf("message should mention PATH, got %q", issues[0].Message)
+	}
+	if issues[0].FixURL != "/settings/system/status" {
+		t.Errorf("FixURL = %q, want %q", issues[0].FixURL, "/settings/system/status")
+	}
+}
+
 // --- AgentChecker tests ---
 
 type mockAgentProvider struct {

--- a/apps/web/e2e/tests/kanban/health-fixtures.ts
+++ b/apps/web/e2e/tests/kanban/health-fixtures.ts
@@ -1,0 +1,15 @@
+export const missingGitHealth = {
+  healthy: false,
+  issues: [
+    {
+      id: "git_executable_missing",
+      category: "system_requirements",
+      title: "Git executable is required",
+      message: "Install Git and ensure the git executable is available on PATH.",
+      severity: "error",
+      fix_url: "/settings/system/status",
+      fix_label: "View system status",
+    },
+  ],
+  checks: [],
+};

--- a/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
@@ -1,6 +1,22 @@
 import { test, expect } from "../../fixtures/test-base";
 import { KanbanPage } from "../../pages/kanban-page";
 
+const missingGitHealth = {
+  healthy: false,
+  issues: [
+    {
+      id: "git_executable_missing",
+      category: "system_requirements",
+      title: "Git executable is required",
+      message: "Install Git and ensure the git executable is available on PATH.",
+      severity: "error",
+      fix_url: "/settings/system/status",
+      fix_label: "View system status",
+    },
+  ],
+  checks: [],
+};
+
 test.describe("Kanban topbar utilities", () => {
   // Post-overhaul: Settings is no longer a topbar link/dropdown. It lives behind
   // the AppSidebar footer gear, which toggles a full-height settings takeover
@@ -99,5 +115,34 @@ test.describe("Kanban topbar utilities", () => {
 
     await expect(testPage.getByText("Inotify instances limit nearly exhausted")).toBeVisible();
     await expect(testPage.getByRole("button", { name: "View system status" })).toBeVisible();
+  });
+
+  test("missing git executable appears in the homepage health dialog", async ({
+    testPage,
+    backend,
+  }) => {
+    await testPage.setViewportSize({ width: 1280, height: 800 });
+
+    await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(missingGitHealth),
+      }),
+    );
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    const issueButton = testPage.getByRole("button", { name: "Setup Issues" });
+    await expect(issueButton).toBeVisible();
+    await issueButton.click();
+
+    const dialog = testPage.getByRole("dialog", { name: "Setup Issues" });
+    await expect(dialog.getByText("Git executable is required")).toBeVisible();
+    await expect(
+      dialog.getByText("Install Git and ensure the git executable is available on PATH."),
+    ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "View system status" })).toBeVisible();
   });
 });

--- a/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
+++ b/apps/web/e2e/tests/kanban/kanban-topbar-utilities.spec.ts
@@ -1,21 +1,6 @@
 import { test, expect } from "../../fixtures/test-base";
 import { KanbanPage } from "../../pages/kanban-page";
-
-const missingGitHealth = {
-  healthy: false,
-  issues: [
-    {
-      id: "git_executable_missing",
-      category: "system_requirements",
-      title: "Git executable is required",
-      message: "Install Git and ensure the git executable is available on PATH.",
-      severity: "error",
-      fix_url: "/settings/system/status",
-      fix_label: "View system status",
-    },
-  ],
-  checks: [],
-};
+import { missingGitHealth } from "./health-fixtures";
 
 test.describe("Kanban topbar utilities", () => {
   // Post-overhaul: Settings is no longer a topbar link/dropdown. It lives behind

--- a/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
@@ -1,6 +1,22 @@
 import { test, expect } from "../../fixtures/test-base";
 import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
 
+const missingGitHealth = {
+  healthy: false,
+  issues: [
+    {
+      id: "git_executable_missing",
+      category: "system_requirements",
+      title: "Git executable is required",
+      message: "Install Git and ensure the git executable is available on PATH.",
+      severity: "error",
+      fix_url: "/settings/system/status",
+      fix_label: "View system status",
+    },
+  ],
+  checks: [],
+};
+
 test.describe("Mobile kanban view", () => {
   test("renders mobile layout with column tabs and swipeable columns", async ({
     testPage,
@@ -85,6 +101,28 @@ test.describe("Mobile kanban view", () => {
     // Menu sheet should open with display options
     await expect(testPage.getByRole("heading", { name: "Menu" })).toBeVisible();
     await expect(testPage.getByText("Display Options")).toBeVisible();
+  });
+
+  test("opens missing git health issue from mobile menu", async ({ testPage, backend }) => {
+    await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(missingGitHealth),
+      }),
+    );
+
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    await mobile.mobileMenuButton.click();
+    await testPage.getByRole("button", { name: "Health issues" }).click();
+
+    const dialog = testPage.getByRole("dialog", { name: "Setup Issues" });
+    await expect(dialog.getByText("Git executable is required")).toBeVisible();
+    await expect(
+      dialog.getByText("Install Git and ensure the git executable is available on PATH."),
+    ).toBeVisible();
   });
 
   test("column tabs allow switching between workflow steps", async ({

--- a/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
@@ -1,21 +1,6 @@
 import { test, expect } from "../../fixtures/test-base";
 import { MobileKanbanPage } from "../../pages/mobile-kanban-page";
-
-const missingGitHealth = {
-  healthy: false,
-  issues: [
-    {
-      id: "git_executable_missing",
-      category: "system_requirements",
-      title: "Git executable is required",
-      message: "Install Git and ensure the git executable is available on PATH.",
-      severity: "error",
-      fix_url: "/settings/system/status",
-      fix_label: "View system status",
-    },
-  ],
-  checks: [],
-};
+import { missingGitHealth } from "./health-fixtures";
 
 test.describe("Mobile kanban view", () => {
   test("renders mobile layout with column tabs and swipeable columns", async ({
@@ -123,6 +108,7 @@ test.describe("Mobile kanban view", () => {
     await expect(
       dialog.getByText("Install Git and ensure the git executable is available on PATH."),
     ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "View system status" })).toBeVisible();
   });
 
   test("column tabs allow switching between workflow steps", async ({


### PR DESCRIPTION
Kandev depends on the host `git` binary for repository workflows, but system health did not tell users when it was missing. The health endpoint now reports that requirement, and the homepage setup dialog surfaces it on desktop and mobile.

## Validation

- `go test ./internal/health`
- `pnpm exec prettier --check e2e/tests/kanban/kanban-topbar-utilities.spec.ts e2e/tests/kanban/mobile-kanban.spec.ts`
- `make build-backend`
- `make build-web`
- `pnpm exec playwright test --config e2e/playwright.config.ts e2e/tests/kanban/kanban-topbar-utilities.spec.ts e2e/tests/kanban/mobile-kanban.spec.ts -g "missing git"`
- `make fmt`
- `make typecheck test lint`

## Possible Improvements

Low risk: the first full verification run hit an unrelated ACP replay-burst timeout, then the focused test and full retry both passed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.