### PR TITLE
fix(web): sort kanban cards by newest created

### DIFF
--- a/apps/web/components/kanban-board-grid.tsx
+++ b/apps/web/components/kanban-board-grid.tsx
@@ -21,6 +21,7 @@ import { MobileFab } from "./kanban/mobile-fab";
 import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import { useAppStore } from "@/components/state-provider";
 import { getKanbanColumnGridTemplate } from "./kanban/kanban-grid-template";
+import { compareTasksByCreatedDesc } from "@/lib/kanban/task-order";
 
 export type KanbanBoardGridProps = {
   steps: WorkflowStep[];
@@ -61,7 +62,7 @@ function getTasksForStep(tasks: Task[], stepId: string) {
   return tasks
     .filter((task) => task.workflowStepId === stepId)
     .map((task) => ({ ...task, position: task.position ?? 0 }))
-    .sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+    .sort(compareTasksByCreatedDesc);
 }
 
 function EmptyState({ showLoading }: { showLoading: boolean }) {

--- a/apps/web/components/kanban/swimlane-graph-content.tsx
+++ b/apps/web/components/kanban/swimlane-graph-content.tsx
@@ -24,6 +24,7 @@ import type { WorkflowStep } from "@/components/kanban-column";
 import type { MoveTaskError } from "@/hooks/use-drag-and-drop";
 import type { KanbanState } from "@/lib/state/slices/kanban/types";
 import { useTaskPendingClarification } from "@/hooks/use-task-pending-clarification";
+import { compareTasksByCreatedDesc } from "@/lib/kanban/task-order";
 
 export type SwimlaneGraphContentProps = {
   workflowId: string;
@@ -199,7 +200,7 @@ function useSwimlaneGraphDnd({ tasks, steps, workflowId, onMoveError }: Swimlane
     for (const col of steps) {
       map[col.id] = tasks
         .filter((t) => t.workflowStepId === col.id)
-        .sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+        .sort(compareTasksByCreatedDesc);
     }
     return map;
   }, [steps, tasks]);

--- a/apps/web/components/kanban/swimlane-kanban-content.tsx
+++ b/apps/web/components/kanban/swimlane-kanban-content.tsx
@@ -24,6 +24,7 @@ import { SwipeableColumns } from "./swipeable-columns";
 import { MobileDropTargets } from "./mobile-drop-targets";
 import { getKanbanColumnGridTemplate } from "./kanban-grid-template";
 import type { KanbanState } from "@/lib/state/slices/kanban/types";
+import { compareTasksByCreatedDesc } from "@/lib/kanban/task-order";
 
 export type SwimlaneKanbanContentProps = {
   workflowId: string;
@@ -80,13 +81,9 @@ function useSwimlaneKanbanDnd({ tasks, workflowId, onMoveError }: SwimlaneKanban
       const snapshot = state.kanbanMulti.snapshots[workflowId];
       if (!snapshot) return;
 
-      const targetTasks = snapshot.tasks
-        .filter(
-          (t: KanbanState["tasks"][number]) => t.workflowStepId === targetStepId && t.id !== taskId,
-        )
-        .sort((a: KanbanState["tasks"][number], b: KanbanState["tasks"][number]) =>
-          (a.createdAt ?? "").localeCompare(b.createdAt ?? ""),
-        );
+      const targetTasks = snapshot.tasks.filter(
+        (t: KanbanState["tasks"][number]) => t.workflowStepId === targetStepId && t.id !== taskId,
+      );
       const nextPosition = targetTasks.length;
       const originalTasks = snapshot.tasks;
 
@@ -166,9 +163,7 @@ function useMobileColumnIndex(steps: WorkflowStep[], tasks: Task[]) {
 function useTasksByStep(tasks: Task[]) {
   return useCallback(
     (stepId: string) =>
-      tasks
-        .filter((t) => t.workflowStepId === stepId)
-        .sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? "")),
+      tasks.filter((t) => t.workflowStepId === stepId).sort(compareTasksByCreatedDesc),
     [tasks],
   );
 }

--- a/apps/web/components/kanban/swipeable-columns.tsx
+++ b/apps/web/components/kanban/swipeable-columns.tsx
@@ -4,6 +4,7 @@ import { useEffect, useCallback, useRef, useMemo, useState } from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import { KanbanColumn, WorkflowStep } from "../kanban-column";
 import { Task } from "../kanban-card";
+import { compareTasksByCreatedDesc } from "@/lib/kanban/task-order";
 
 type SwipeableColumnsProps = {
   steps: WorkflowStep[];
@@ -61,7 +62,7 @@ export function SwipeableColumns({
       return tasks
         .filter((task) => task.workflowStepId === stepId)
         .map((task) => ({ ...task, position: task.position ?? 0 }))
-        .sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+        .sort(compareTasksByCreatedDesc);
     },
     [tasks],
   );

--- a/apps/web/lib/kanban/task-order.test.ts
+++ b/apps/web/lib/kanban/task-order.test.ts
@@ -13,4 +13,39 @@ describe("compareTasksByCreatedDesc", () => {
       "old",
     ]);
   });
+
+  it("sorts tasks without createdAt after dated tasks", () => {
+    const tasks = [
+      { id: "missing" },
+      { id: "old", createdAt: "2026-05-01T10:00:00Z" },
+      { id: "new", createdAt: "2026-05-02T10:00:00Z" },
+    ];
+
+    expect([...tasks].sort(compareTasksByCreatedDesc).map((task) => task.id)).toEqual([
+      "new",
+      "old",
+      "missing",
+    ]);
+  });
+
+  it("sorts by actual timestamp when ISO offsets differ", () => {
+    const tasks = [
+      { id: "later-offset", createdAt: "2026-05-02T09:30:00-04:00" },
+      { id: "earlier-zulu", createdAt: "2026-05-02T13:00:00Z" },
+    ];
+
+    expect([...tasks].sort(compareTasksByCreatedDesc).map((task) => task.id)).toEqual([
+      "later-offset",
+      "earlier-zulu",
+    ]);
+  });
+
+  it("keeps equal missing createdAt tasks stable", () => {
+    const tasks: Array<{ id: string; createdAt?: string }> = [{ id: "first" }, { id: "second" }];
+
+    expect([...tasks].sort(compareTasksByCreatedDesc).map((task) => task.id)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
 });

--- a/apps/web/lib/kanban/task-order.test.ts
+++ b/apps/web/lib/kanban/task-order.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { compareTasksByCreatedDesc } from "./task-order";
+
+describe("compareTasksByCreatedDesc", () => {
+  it("sorts newer created tasks first", () => {
+    const tasks = [
+      { id: "old", createdAt: "2026-05-01T10:00:00Z" },
+      { id: "new", createdAt: "2026-05-02T10:00:00Z" },
+    ];
+
+    expect([...tasks].sort(compareTasksByCreatedDesc).map((task) => task.id)).toEqual([
+      "new",
+      "old",
+    ]);
+  });
+});

--- a/apps/web/lib/kanban/task-order.test.ts
+++ b/apps/web/lib/kanban/task-order.test.ts
@@ -48,4 +48,8 @@ describe("compareTasksByCreatedDesc", () => {
       "second",
     ]);
   });
+
+  it("returns 0 when both tasks are missing createdAt", () => {
+    expect(compareTasksByCreatedDesc({}, {})).toBe(0);
+  });
 });

--- a/apps/web/lib/kanban/task-order.ts
+++ b/apps/web/lib/kanban/task-order.ts
@@ -9,5 +9,9 @@ function createdAtTime(task: CreatedTask): number {
 }
 
 export function compareTasksByCreatedDesc(a: CreatedTask, b: CreatedTask): number {
-  return createdAtTime(b) - createdAtTime(a);
+  const aTime = createdAtTime(a);
+  const bTime = createdAtTime(b);
+  if (bTime > aTime) return 1;
+  if (bTime < aTime) return -1;
+  return 0;
 }

--- a/apps/web/lib/kanban/task-order.ts
+++ b/apps/web/lib/kanban/task-order.ts
@@ -2,6 +2,12 @@ type CreatedTask = {
   createdAt?: string;
 };
 
+function createdAtTime(task: CreatedTask): number {
+  if (!task.createdAt) return Number.NEGATIVE_INFINITY;
+  const time = Date.parse(task.createdAt);
+  return Number.isNaN(time) ? Number.NEGATIVE_INFINITY : time;
+}
+
 export function compareTasksByCreatedDesc(a: CreatedTask, b: CreatedTask): number {
-  return (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+  return createdAtTime(b) - createdAtTime(a);
 }

--- a/apps/web/lib/kanban/task-order.ts
+++ b/apps/web/lib/kanban/task-order.ts
@@ -1,0 +1,7 @@
+type CreatedTask = {
+  createdAt?: string;
+};
+
+export function compareTasksByCreatedDesc(a: CreatedTask, b: CreatedTask): number {
+  return (b.createdAt ?? "").localeCompare(a.createdAt ?? "");
+}


### PR DESCRIPTION
Kanban cards were appearing oldest-first, which made recently created work fall to the bottom of each column. This changes the kanban home and related kanban layouts to show newest-created cards first so the board matches the sidebar's recency behavior.

## Important Changes
- Adds a shared kanban task-created comparator used by desktop, mobile swipe, swimlane kanban, and swimlane graph card lists.
- Covers the comparator with a focused unit test.

## Validation
- `make fmt`
- `make typecheck test lint`
- `pnpm --filter @kandev/web test -- --run lib/kanban/task-order.test.ts`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Possible Improvements
- This keeps API ordering unchanged; only rendered kanban card order changes.

## Checklist
- [ ] I have tested the changes locally
- [ ] I have updated documentation where needed
- [ ] I have considered mobile/responsive behavior