### PR TITLE
fix(web): focus sidebar-created tasks

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  setActiveTask: vi.fn(),
+}));
+
 function renderItem(collapsed: boolean) {
   return render(
     <TooltipProvider>
@@ -18,6 +23,7 @@ const state = {
     tasks: [{ id: "t-1", title: "Parent task" }] as Array<{ id: string; title: string }>,
   },
   tasks: { activeTaskId: null as string | null },
+  setActiveTask: mocks.setActiveTask,
 };
 let officeEnabled = false;
 let pathname = "/";
@@ -29,14 +35,26 @@ vi.mock("@/hooks/domains/features/use-feature", () => ({
   useFeature: () => officeEnabled,
 }));
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mocks.routerPush }),
   usePathname: () => pathname,
 }));
 vi.mock("@/app/office/components/new-task-dialog", () => ({
   NewTaskDialog: () => <div data-testid="office-new-task-dialog" />,
 }));
 vi.mock("@/components/task-create-dialog", () => ({
-  TaskCreateDialog: () => <div data-testid="regular-task-create-dialog" />,
+  TaskCreateDialog: ({
+    onSuccess,
+  }: {
+    onSuccess?: (task: { id: string }, mode: "create" | "edit") => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="regular-task-create-dialog"
+      onClick={() => onSuccess?.({ id: "t-new" }, "create")}
+    >
+      regular dialog
+    </button>
+  ),
 }));
 vi.mock("@/components/task/new-subtask-dialog", () => ({
   NewSubtaskDialog: () => <div data-testid="new-subtask-dialog" />,
@@ -55,6 +73,8 @@ describe("AppSidebarNewTaskItem", () => {
     state.kanban.steps = [{ id: "s1", title: "Todo" }];
     state.kanban.tasks = [{ id: "t-1", title: "Parent task" }];
     state.tasks.activeTaskId = null;
+    mocks.routerPush.mockClear();
+    mocks.setActiveTask.mockClear();
     officeEnabled = false;
     pathname = "/";
   });
@@ -123,5 +143,12 @@ describe("AppSidebarNewTaskItem", () => {
     state.tasks.activeTaskId = "t-1";
     renderItem(true);
     expect(screen.queryByTestId(SUBTASK_TESTID)).toBeNull();
+  });
+
+  it("focuses the created task after regular sidebar task creation succeeds", () => {
+    renderItem(false);
+    screen.getByTestId(REGULAR_DIALOG_TESTID).click();
+    expect(mocks.setActiveTask).toHaveBeenCalledWith("t-new");
+    expect(mocks.routerPush).toHaveBeenCalledWith("/t/t-new");
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -5,6 +5,8 @@ import { TooltipProvider } from "@kandev/ui/tooltip";
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   setActiveTask: vi.fn(),
+  setActiveSession: vi.fn(),
+  dialogTaskSessionId: null as string | null,
   dialogWillNavigate: false,
 }));
 
@@ -25,6 +27,7 @@ const state = {
   },
   tasks: { activeTaskId: null as string | null },
   setActiveTask: mocks.setActiveTask,
+  setActiveSession: mocks.setActiveSession,
 };
 let officeEnabled = false;
 let pathname = "/";
@@ -56,7 +59,10 @@ vi.mock("@/components/task-create-dialog", () => ({
       type="button"
       data-testid="regular-task-create-dialog"
       onClick={() =>
-        onSuccess?.({ id: "t-new" }, "create", { willNavigate: mocks.dialogWillNavigate })
+        onSuccess?.({ id: "t-new" }, "create", {
+          taskSessionId: mocks.dialogTaskSessionId,
+          willNavigate: mocks.dialogWillNavigate,
+        })
       }
     >
       regular dialog
@@ -82,6 +88,8 @@ describe("AppSidebarNewTaskItem", () => {
     state.tasks.activeTaskId = null;
     mocks.routerPush.mockClear();
     mocks.setActiveTask.mockClear();
+    mocks.setActiveSession.mockClear();
+    mocks.dialogTaskSessionId = null;
     mocks.dialogWillNavigate = false;
     officeEnabled = false;
     pathname = "/";
@@ -157,6 +165,16 @@ describe("AppSidebarNewTaskItem", () => {
     renderItem(false);
     screen.getByTestId(REGULAR_DIALOG_TESTID).click();
     expect(mocks.setActiveTask).toHaveBeenCalledWith("t-new");
+    expect(mocks.setActiveSession).not.toHaveBeenCalled();
+    expect(mocks.routerPush).toHaveBeenCalledWith("/t/t-new");
+  });
+
+  it("focuses the created session after starting a sidebar task with an agent", () => {
+    mocks.dialogTaskSessionId = "s-new";
+    renderItem(false);
+    screen.getByTestId(REGULAR_DIALOG_TESTID).click();
+    expect(mocks.setActiveSession).toHaveBeenCalledWith("t-new", "s-new");
+    expect(mocks.setActiveTask).not.toHaveBeenCalled();
     expect(mocks.routerPush).toHaveBeenCalledWith("/t/t-new");
   });
 

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -185,4 +185,14 @@ describe("AppSidebarNewTaskItem", () => {
     expect(mocks.setActiveTask).toHaveBeenCalledWith("t-new");
     expect(mocks.routerPush).not.toHaveBeenCalled();
   });
+
+  it("focuses the created session without pushing when the dialog already navigates", () => {
+    mocks.dialogTaskSessionId = "s-new";
+    mocks.dialogWillNavigate = true;
+    renderItem(false);
+    screen.getByTestId(REGULAR_DIALOG_TESTID).click();
+    expect(mocks.setActiveSession).toHaveBeenCalledWith("t-new", "s-new");
+    expect(mocks.setActiveTask).not.toHaveBeenCalled();
+    expect(mocks.routerPush).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -45,7 +45,11 @@ vi.mock("@/components/task-create-dialog", () => ({
   TaskCreateDialog: ({
     onSuccess,
   }: {
-    onSuccess?: (task: { id: string }, mode: "create" | "edit") => void;
+    onSuccess?: (
+      task: { id: string },
+      mode: "create" | "edit",
+      meta?: { taskSessionId?: string | null },
+    ) => void;
   }) => (
     <button
       type="button"

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from "@kandev/ui/tooltip";
 const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   setActiveTask: vi.fn(),
+  dialogWillNavigate: false,
 }));
 
 function renderItem(collapsed: boolean) {
@@ -48,13 +49,15 @@ vi.mock("@/components/task-create-dialog", () => ({
     onSuccess?: (
       task: { id: string },
       mode: "create" | "edit",
-      meta?: { taskSessionId?: string | null },
+      meta?: { taskSessionId?: string | null; willNavigate?: boolean },
     ) => void;
   }) => (
     <button
       type="button"
       data-testid="regular-task-create-dialog"
-      onClick={() => onSuccess?.({ id: "t-new" }, "create")}
+      onClick={() =>
+        onSuccess?.({ id: "t-new" }, "create", { willNavigate: mocks.dialogWillNavigate })
+      }
     >
       regular dialog
     </button>
@@ -79,6 +82,7 @@ describe("AppSidebarNewTaskItem", () => {
     state.tasks.activeTaskId = null;
     mocks.routerPush.mockClear();
     mocks.setActiveTask.mockClear();
+    mocks.dialogWillNavigate = false;
     officeEnabled = false;
     pathname = "/";
   });
@@ -154,5 +158,13 @@ describe("AppSidebarNewTaskItem", () => {
     screen.getByTestId(REGULAR_DIALOG_TESTID).click();
     expect(mocks.setActiveTask).toHaveBeenCalledWith("t-new");
     expect(mocks.routerPush).toHaveBeenCalledWith("/t/t-new");
+  });
+
+  it("does not push twice when the regular task dialog already navigates", () => {
+    mocks.dialogWillNavigate = true;
+    renderItem(false);
+    screen.getByTestId(REGULAR_DIALOG_TESTID).click();
+    expect(mocks.setActiveTask).toHaveBeenCalledWith("t-new");
+    expect(mocks.routerPush).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
 import { IconSquarePlus, IconSubtask } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
 import { useInOffice } from "@/hooks/use-in-office";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
+import { linkToTask } from "@/lib/links";
+import type { Task } from "@/lib/types/http";
 
 // The Office "New issue" dialog only renders on `/office` routes, but this item
 // lives in the global sidebar (every page). Lazy-load it so its office-only
@@ -36,10 +39,12 @@ type AppSidebarNewTaskItemProps = {
  * used to provide.
  */
 export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps) {
+  const router = useRouter();
   const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const workflowId = useAppStore((s) => s.kanban.workflowId);
   const steps = useAppStore((s) => s.kanban.steps);
   const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
+  const setActiveTask = useAppStore((s) => s.setActiveTask);
   const activeTaskTitle = useAppStore((s) => {
     const id = s.tasks.activeTaskId;
     if (!id) return "";
@@ -54,6 +59,14 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
   // NewSubtaskDialog, matching the retired dropdown). It needs an active task
   // and the expanded rail to host the trailing button.
   const canCreateSubtask = !collapsed && !!workspaceId && !!activeTaskId;
+  const handleRegularTaskCreated = useCallback(
+    (task: Task) => {
+      setOpen(false);
+      setActiveTask(task.id);
+      router.push(linkToTask(task.id));
+    },
+    [router, setActiveTask],
+  );
 
   return (
     <>
@@ -95,7 +108,7 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
             workflowId={workflowId}
             defaultStepId={steps[0]?.id ?? null}
             steps={steps}
-            onSuccess={() => setOpen(false)}
+            onSuccess={handleRegularTaskCreated}
           />
         ))}
       {canCreateSubtask && (

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
@@ -45,6 +45,7 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
   const steps = useAppStore((s) => s.kanban.steps);
   const activeTaskId = useAppStore((s) => s.tasks.activeTaskId);
   const setActiveTask = useAppStore((s) => s.setActiveTask);
+  const setActiveSession = useAppStore((s) => s.setActiveSession);
   const activeTaskTitle = useAppStore((s) => {
     const id = s.tasks.activeTaskId;
     if (!id) return "";
@@ -60,13 +61,21 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
   // and the expanded rail to host the trailing button.
   const canCreateSubtask = !collapsed && !!workspaceId && !!activeTaskId;
   const handleRegularTaskCreated = useCallback(
-    (task: Task, _mode: "create" | "edit", meta?: { willNavigate?: boolean }) => {
+    (
+      task: Task,
+      _mode: "create" | "edit",
+      meta?: { taskSessionId?: string | null; willNavigate?: boolean },
+    ) => {
       setOpen(false);
-      setActiveTask(task.id);
+      if (meta?.taskSessionId) {
+        setActiveSession(task.id, meta.taskSessionId);
+      } else {
+        setActiveTask(task.id);
+      }
       if (meta?.willNavigate) return;
       router.push(linkToTask(task.id));
     },
-    [router, setActiveTask],
+    [router, setActiveSession, setActiveTask],
   );
 
   return (

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
@@ -60,9 +60,10 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
   // and the expanded rail to host the trailing button.
   const canCreateSubtask = !collapsed && !!workspaceId && !!activeTaskId;
   const handleRegularTaskCreated = useCallback(
-    (task: Task) => {
+    (task: Task, _mode: "create" | "edit", meta?: { willNavigate?: boolean }) => {
       setOpen(false);
       setActiveTask(task.id);
+      if (meta?.willNavigate) return;
       router.push(linkToTask(task.id));
     },
     [router, setActiveTask],

--- a/apps/web/components/task-create-dialog-setup.tsx
+++ b/apps/web/components/task-create-dialog-setup.tsx
@@ -48,7 +48,7 @@ export interface TaskCreateDialogProps {
   onSuccess?: (
     task: Task,
     mode: "create" | "edit",
-    meta?: { taskSessionId?: string | null },
+    meta?: { taskSessionId?: string | null; willNavigate?: boolean },
   ) => void;
   onCreateSession?: (data: { prompt: string; agentProfileId: string; executorId: string }) => void;
   initialValues?: TaskCreateDialogInitialValues;

--- a/apps/web/components/task-create-dialog-submit.tsx
+++ b/apps/web/components/task-create-dialog-submit.tsx
@@ -339,7 +339,8 @@ export function useTaskSubmitHandlers({
       const taskResponse = await createTaskWithFreshBranchRetry(buildPayload, opts.consented);
       if (!taskResponse) return;
       const newSessionId = taskResponse.session_id ?? taskResponse.primary_session_id ?? null;
-      onSuccess?.(taskResponse, "create", { taskSessionId: newSessionId });
+      const willNavigate = opts.withAgent && isPassthroughProfile && !opts.planMode;
+      onSuccess?.(taskResponse, "create", { taskSessionId: newSessionId, willNavigate });
       clearDraft();
       onOpenChange(false);
       if (opts.planMode && newSessionId) {

--- a/apps/web/components/task-create-dialog-submit.tsx
+++ b/apps/web/components/task-create-dialog-submit.tsx
@@ -340,8 +340,7 @@ export function useTaskSubmitHandlers({
       if (!taskResponse) return;
       const newSessionId = taskResponse.session_id ?? taskResponse.primary_session_id ?? null;
       const willNavigate =
-        (opts.withAgent && isPassthroughProfile && !opts.planMode) ||
-        !!(opts.planMode && newSessionId);
+        (opts.withAgent && isPassthroughProfile) || !!(opts.planMode && newSessionId);
       onSuccess?.(taskResponse, "create", { taskSessionId: newSessionId, willNavigate });
       clearDraft();
       onOpenChange(false);

--- a/apps/web/components/task-create-dialog-submit.tsx
+++ b/apps/web/components/task-create-dialog-submit.tsx
@@ -339,7 +339,9 @@ export function useTaskSubmitHandlers({
       const taskResponse = await createTaskWithFreshBranchRetry(buildPayload, opts.consented);
       if (!taskResponse) return;
       const newSessionId = taskResponse.session_id ?? taskResponse.primary_session_id ?? null;
-      const willNavigate = opts.withAgent && isPassthroughProfile && !opts.planMode;
+      const willNavigate =
+        (opts.withAgent && isPassthroughProfile && !opts.planMode) ||
+        !!(opts.planMode && newSessionId);
       onSuccess?.(taskResponse, "create", { taskSessionId: newSessionId, willNavigate });
       clearDraft();
       onOpenChange(false);

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -321,7 +321,7 @@ export type SubmitHandlersDeps = {
   onSuccess?: (
     task: Task,
     mode: "create" | "edit",
-    meta?: { taskSessionId?: string | null },
+    meta?: { taskSessionId?: string | null; willNavigate?: boolean },
   ) => void;
   onCreateSession?: (data: { prompt: string; agentProfileId: string; executorId: string }) => void;
   onOpenChange: (open: boolean) => void;

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -69,7 +69,7 @@ export interface TaskCreateDialogProps {
   onSuccess?: (
     task: Task,
     mode: "create" | "edit",
-    meta?: { taskSessionId?: string | null },
+    meta?: { taskSessionId?: string | null; willNavigate?: boolean },
   ) => void;
   onCreateSession?: (data: { prompt: string; agentProfileId: string; executorId: string }) => void;
   initialValues?: TaskCreateDialogInitialValues;

--- a/apps/web/e2e/tests/task/create-task-github-url.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-github-url.spec.ts
@@ -75,12 +75,6 @@ test.describe("Task creation from GitHub URL", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    // The new task card appears on the kanban board
-    const card = kanban.taskCardByTitle("GitHub URL Task");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-
-    // Click the card to navigate to the session
-    await card.click();
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const session = new SessionPage(testPage);
@@ -165,10 +159,6 @@ test.describe("Task creation from GitHub URL", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    const card = kanban.taskCardByTitle("Worktree GitHub Task");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-
-    await card.click();
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const session = new SessionPage(testPage);
@@ -243,7 +233,9 @@ test.describe("Task creation from GitHub URL", () => {
     await expect(startBtn).toBeEnabled({ timeout: 15_000 });
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
-    await expect(kanban.taskCardByTitle("Task A")).toBeVisible({ timeout: 10_000 });
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
+
+    await kanban.goto();
 
     // ── Second task from repo-b (different URL) ──
     await kanban.createTaskButton.first().click();
@@ -256,10 +248,7 @@ test.describe("Task creation from GitHub URL", () => {
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
     // Both cards visible — second task created successfully on its own repo
-    await expect(kanban.taskCardByTitle("Task B")).toBeVisible({ timeout: 10_000 });
-
-    // Navigate to Task B session and verify agent completes
-    await kanban.taskCardByTitle("Task B").click();
+    // The sidebar create flow navigates directly to Task B's session.
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
     const session = new SessionPage(testPage);
     await session.waitForLoad();
@@ -403,12 +392,6 @@ test.describe("Task creation from GitHub URL", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    // The new task card appears on the kanban board
-    const card = kanban.taskCardByTitle("PR Task Local");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-
-    // Navigate to the session and verify the agent completes
-    await card.click();
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const session = new SessionPage(testPage);
@@ -534,10 +517,6 @@ test.describe("Task creation from GitHub URL", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    const card = kanban.taskCardByTitle("PR Worktree Task");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-
-    await card.click();
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const session = new SessionPage(testPage);
@@ -646,10 +625,6 @@ test.describe("Task creation from GitHub URL", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    const card = kanban.taskCardByTitle("Warning Test Task");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-
-    await card.click();
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const session = new SessionPage(testPage);
@@ -777,10 +752,8 @@ test.describe("Task creation from GitHub URL", () => {
 
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
-    await expect(kanban.taskCardByTitle("Shared PR Task A")).toBeVisible({ timeout: 10_000 });
 
-    // Wait for Task A agent to complete before creating Task B
-    await kanban.taskCardByTitle("Shared PR Task A").click();
+    // Wait for Task A agent to complete before creating Task B.
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
     const sessionA = new SessionPage(testPage);
     await sessionA.waitForLoad();
@@ -818,10 +791,7 @@ test.describe("Task creation from GitHub URL", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    // Task B should also succeed (this would have failed before the fix)
-    await expect(kanban.taskCardByTitle("Shared PR Task B")).toBeVisible({ timeout: 10_000 });
-
-    await kanban.taskCardByTitle("Shared PR Task B").click();
+    // Task B should also succeed (this would have failed before the fix).
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
     const sessionB = new SessionPage(testPage);
     await sessionB.waitForLoad();

--- a/apps/web/e2e/tests/task/create-task-github-url.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-github-url.spec.ts
@@ -247,8 +247,7 @@ test.describe("Task creation from GitHub URL", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    // Both cards visible — second task created successfully on its own repo
-    // The sidebar create flow navigates directly to Task B's session.
+    // Task B created successfully on its own repo; sidebar navigates directly to its session.
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
     const session = new SessionPage(testPage);
     await session.waitForLoad();

--- a/apps/web/e2e/tests/task/create-task-remote-repo.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-remote-repo.spec.ts
@@ -140,9 +140,7 @@ test.describe("Task creation from Remote tab (chip picker)", () => {
       timeout: 10_000,
     });
 
-    const kanban2 = new KanbanPage(testPage);
-    const card = kanban2.taskCardByTitle("Remote picker happy path");
-    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     // Verify the task carries exactly one repository row resolved from the
     // picked URL.
@@ -190,8 +188,7 @@ test.describe("Task creation from Remote tab (chip picker)", () => {
       timeout: 10_000,
     });
 
-    const card = new KanbanPage(testPage).taskCardByTitle("Remote paste happy path");
-    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const taskList = await apiClient.listTasks(seedData.workspaceId);
     const created = taskList.tasks.find((t) => t.title === "Remote paste happy path");
@@ -272,8 +269,7 @@ test.describe("Task creation from Remote tab (chip picker)", () => {
       timeout: 10_000,
     });
 
-    const card = new KanbanPage(testPage).taskCardByTitle("Remote multi-row");
-    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     // Verify the task carries three TaskRepository rows in the order they
     // were added.
@@ -376,8 +372,7 @@ test.describe("Task creation from Remote tab (chip picker)", () => {
       timeout: 10_000,
     });
 
-    const card = new KanbanPage(testPage).taskCardByTitle("Banner paste fallback");
-    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     // Confirm the task was created with the pasted repo.
     const taskList = await apiClient.listTasks(seedData.workspaceId);

--- a/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
+++ b/apps/web/e2e/tests/task/create-task-url-reopen-no-branches.spec.ts
@@ -97,7 +97,7 @@ test.describe("Create-task URL flow - branches after reopen", () => {
     // open lists branches fresh from the backend — which is the behaviour a
     // user gets when reopening the dialog later. The provider-API path itself
     // is unchanged; this only avoids racing a stale empty cache entry.
-    await testPage.reload();
+    await kanban.goto();
     await kanban.board.waitFor({ state: "visible" });
 
     // ── Second open: pick the same repo from the workspace dropdown ──

--- a/apps/web/e2e/tests/task/create-task.spec.ts
+++ b/apps/web/e2e/tests/task/create-task.spec.ts
@@ -221,16 +221,10 @@ test.describe("Task creation", () => {
     const startBtn = testPage.getByTestId(START_AGENT_TEST_ID);
     await expect(startBtn).toBeEnabled({ timeout: START_ENABLED_TIMEOUT });
 
-    // Click "Start task" — the agent starts, the dialog closes, we stay on kanban
+    // Click "Start task" — the agent starts, the dialog closes, and sidebar creation
+    // focuses the newly created task immediately.
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
-
-    // The new task card appears on the kanban board (pushed via WS)
-    const card = kanban.taskCardByTitle("Start Agent Task");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-
-    // Clicking the card fetches the session and navigates to /t/<taskId>
-    await card.click();
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const session = new SessionPage(testPage);
@@ -422,11 +416,6 @@ test.describe("Create task regression", () => {
     await expect(startBtn).toBeEnabled({ timeout: START_ENABLED_TIMEOUT });
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
-
-    // Navigate to the task session
-    const card = kanban.taskCardByTitle("Regression Task");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-    await card.click();
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     const session = new SessionPage(testPage);

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -137,10 +137,7 @@ test.describe("MCP subtask creation", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    // 2. Click the parent task card to navigate to its session
-    const parentCard = kanban.taskCardByTitle("MCP Subtask Parent");
-    await expect(parentCard).toBeVisible({ timeout: 10_000 });
-    await parentCard.click();
+    // 2. Sidebar task creation navigates directly to the parent session.
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     // 3. Wait for the agent to complete — the MCP create_task call happens during execution
@@ -242,10 +239,7 @@ test.describe("MCP subtask creation", () => {
     await startBtn.click();
     await expect(dialog).not.toBeVisible({ timeout: 10_000 });
 
-    // 2. Click the parent card to navigate to its session
-    const parentCard = kanban.taskCardByTitle("Subtask Button Parent");
-    await expect(parentCard).toBeVisible({ timeout: 10_000 });
-    await parentCard.click();
+    // 2. Sidebar task creation navigates directly to the parent session.
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
 
     // 3. Wait for the agent to finish


### PR DESCRIPTION
Summary

Creating a task from the global sidebar left users on the previous task even though the new task appeared in the sidebar. This PR makes the sidebar creation flow focus the newly created task immediately and updates regression coverage for that route transition.

Validation

- pnpm --filter @kandev/web test -- --run components/app-sidebar/app-sidebar-new-task-item.test.tsx
- pnpm e2e:run tests/task/create-task.spec.ts -- --grep "start agent: creates|create and start agent"
- pnpm --filter @kandev/web exec prettier --check components/app-sidebar/app-sidebar-new-task-item.tsx components/app-sidebar/app-sidebar-new-task-item.test.tsx e2e/tests/task/create-task.spec.ts
- pnpm --filter @kandev/web typecheck
- pnpm --filter @kandev/web lint
- git diff --check

Possible Improvements

- Other task creation entry points intentionally keep their existing behavior; only the global sidebar path now auto-focuses the created task.

Checklist

- [ ] Tests pass locally
- [ ] Documentation updated where needed
- [ ] Screenshots or recordings added for UI changes where useful