### PR TITLE
fix: preserve settings sidebar on refresh

### DIFF
--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -19,6 +19,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	openCodeCommand       = "opencode"
+	openCodeACPSubcommand = "acp"
+)
+
 // ACPInferenceExecutor executes one-shot prompts using the ACP protocol.
 // It spawns a new agent process, performs the ACP handshake, sends the prompt,
 // collects the response, and tears down the process.
@@ -339,7 +344,9 @@ func (e *ACPInferenceExecutor) Probe(ctx context.Context, req *ProbeRequest) (*P
 // isOpenCodeACPCommand reports whether the configured ACP probe command is
 // OpenCode's ACP transport.
 func isOpenCodeACPCommand(command []string) bool {
-	return len(command) >= 2 && filepath.Base(command[0]) == "opencode" && command[1] == "acp"
+	return len(command) >= 2 &&
+		filepath.Base(command[0]) == openCodeCommand &&
+		command[1] == openCodeACPSubcommand
 }
 
 // applyOpenCodeModelsFallback fills an otherwise empty probe model list from
@@ -660,7 +667,7 @@ var allowedProbeCommands = map[string]string{
 	"mock-agent":    "mock-agent",
 	"npx":           "npx",
 	"omp":           "omp",
-	"opencode":      "opencode",
+	openCodeCommand: openCodeCommand,
 	"qodercli":      "qodercli",
 	"traecli":       "traecli",
 }

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -45,11 +45,11 @@ func TestIsOpenCodeACPCommand(t *testing.T) {
 		command []string
 		want    bool
 	}{
-		{name: "opencode acp", command: []string{"opencode", "acp"}, want: true},
-		{name: "path opencode acp", command: []string{filepath.Join("/usr/local/bin", "opencode"), "acp"}, want: true},
-		{name: "opencode non acp", command: []string{"opencode", "run"}, want: false},
-		{name: "too short", command: []string{"opencode"}, want: false},
-		{name: "other acp", command: []string{"claude", "acp"}, want: false},
+		{name: "opencode acp", command: []string{openCodeCommand, openCodeACPSubcommand}, want: true},
+		{name: "path opencode acp", command: []string{filepath.Join("/usr/local/bin", openCodeCommand), openCodeACPSubcommand}, want: true},
+		{name: "opencode non acp", command: []string{openCodeCommand, "run"}, want: false},
+		{name: "too short", command: []string{openCodeCommand}, want: false},
+		{name: "other acp", command: []string{"claude", openCodeACPSubcommand}, want: false},
 	}
 
 	for _, tt := range tests {

--- a/apps/web/components/app-sidebar/app-sidebar.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.test.tsx
@@ -131,4 +131,18 @@ describe("AppSidebar", () => {
       expect(storeState.toggleAppSidebarSettingsMode).toHaveBeenCalledOnce();
     });
   });
+
+  it("exits settings mode when navigating from a settings route to a non-settings route", async () => {
+    navigationMock.pathname = "/settings/agents";
+    storeState.appSidebar.settingsMode = true;
+
+    const { rerender } = render(<AppSidebar />);
+
+    navigationMock.pathname = "/office/tasks";
+    rerender(<AppSidebar />);
+
+    await waitFor(() => {
+      expect(storeState.toggleAppSidebarSettingsMode).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/apps/web/components/app-sidebar/app-sidebar.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { APP_SIDEBAR_EXPANDED_WIDTH } from "./app-sidebar-constants";
+
+const navigationMock = vi.hoisted(() => ({
+  pathname: "/",
+}));
 
 // The AppSidebar pulls in a lot of children that touch the dockview / kanban
 // data layer. For unit testing the collapse + section toggle behaviour we stub
@@ -47,9 +51,12 @@ vi.mock("./sections/integrations-section", () => ({
 vi.mock("./app-sidebar-footer", () => ({
   AppSidebarFooter: () => <div data-testid="footer" />,
 }));
+vi.mock("./app-sidebar-settings-mode", () => ({
+  AppSidebarSettingsMode: () => <div data-testid="settings-mode" />,
+}));
 
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/",
+  usePathname: () => navigationMock.pathname,
 }));
 
 const storeState = {
@@ -80,9 +87,12 @@ import { AppSidebar } from "./app-sidebar";
 
 describe("AppSidebar", () => {
   beforeEach(() => {
+    navigationMock.pathname = "/";
     storeState.appSidebar.collapsed = false;
+    storeState.appSidebar.settingsMode = false;
     storeState.toggleAppSidebar = vi.fn();
     storeState.toggleAppSidebarSection = vi.fn();
+    storeState.toggleAppSidebarSettingsMode = vi.fn();
   });
 
   afterEach(() => {
@@ -109,5 +119,16 @@ describe("AppSidebar", () => {
     render(<AppSidebar />);
     fireEvent.click(screen.getByTestId("header-toggle"));
     expect(storeState.toggleAppSidebar).toHaveBeenCalledOnce();
+  });
+
+  it("enters settings mode on initial mount for a deep settings route", async () => {
+    navigationMock.pathname =
+      "/settings/agents/opencode-acp/profiles/1f593628-6752-4972-95ab-5c8c3e7eaeab";
+
+    render(<AppSidebar />);
+
+    await waitFor(() => {
+      expect(storeState.toggleAppSidebarSettingsMode).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.tsx
@@ -28,6 +28,10 @@ const SECTION_ROUTE_MAP: Array<{ id: string; matches: (path: string) => boolean 
   { id: APP_SIDEBAR_SECTION_IDS.agents, matches: (p) => p.startsWith("/office/agents") },
 ];
 
+function isSettingsRoute(pathname: string | null): boolean {
+  return pathname === "/settings" || Boolean(pathname?.startsWith("/settings/"));
+}
+
 /**
  * Unified app sidebar mounted at the root layout. Replaces the legacy
  * WorkspaceRail + OfficeSidebar + dockview-embedded sidebar surfaces.
@@ -73,16 +77,19 @@ export function AppSidebar() {
 
   const expandedWidth = Math.max(APP_SIDEBAR_EXPANDED_WIDTH, storedWidth);
 
-  // Close the settings takeover when the user navigates off the settings
-  // surface — e.g. the Home button, the Kandev brand, the Office/Stats footer
-  // buttons, or opening a task. Keyed on an actual pathname *change* so opening
-  // the gear from a non-settings page (no navigation) doesn't immediately close
-  // it, and clicking within the tree (`/settings/...`) keeps it open.
-  const prevPathnameRef = useRef(pathname);
+  // Keep the transient settings takeover aligned with route ownership. It is
+  // intentionally not persisted, so direct reloads on `/settings/...` need to
+  // enter it from the current pathname. Key on actual pathname changes so a
+  // user can still close the takeover while staying on a settings page.
+  const prevPathnameRef = useRef<string | null>(null);
   useEffect(() => {
-    if (prevPathnameRef.current === pathname) return;
+    if (!pathname || prevPathnameRef.current === pathname) return;
     prevPathnameRef.current = pathname;
-    if (settingsMode && (!pathname || !pathname.startsWith("/settings"))) {
+    if (isSettingsRoute(pathname)) {
+      if (!settingsMode) toggleSettingsMode();
+      return;
+    }
+    if (settingsMode) {
       toggleSettingsMode();
     }
   }, [pathname, settingsMode, toggleSettingsMode]);

--- a/apps/web/e2e/tests/office/sidebar-navigation.spec.ts
+++ b/apps/web/e2e/tests/office/sidebar-navigation.spec.ts
@@ -80,9 +80,10 @@ test.describe("Sidebar Home destination", () => {
     officeSeed: _,
   }) => {
     // Start from a non-home regular route so the Home click is a real
-    // navigation (not a no-op): from a Kanban-side route `useInOffice()` is
-    // false, so Home must land back on the board at `/`.
-    await testPage.goto("/settings/system/status");
+    // navigation (not a no-op): from a non-office route `useInOffice()` is
+    // false, so Home must land back on the board at `/`. Avoid settings routes
+    // because they intentionally replace the primary nav with settings mode.
+    await testPage.goto("/stats");
     const home = testPage.getByRole("link", { name: "Home", exact: true });
     await expect(home).toBeVisible({ timeout: 15_000 });
     await home.click();

--- a/apps/web/e2e/tests/settings/settings-gear-only.spec.ts
+++ b/apps/web/e2e/tests/settings/settings-gear-only.spec.ts
@@ -1,29 +1,32 @@
 import { test, expect } from "../../fixtures/test-base";
 
-// Settings is reachable ONLY via the footer gear (no nav "Settings" section),
-// and the gear closes the settings-tree takeover even while on a settings page.
+// Settings has no nav "Settings" section; direct settings routes keep the
+// gear-gated tree open so a hard refresh preserves settings navigation context.
 test.describe("Settings sidebar takeover", () => {
-  test("gear opens the tree, and closes it even on a settings page", async ({ testPage }) => {
+  test("direct settings routes open the tree, and the gear can close it", async ({ testPage }) => {
     await testPage.goto("/settings");
 
     const gear = testPage.getByTestId("sidebar-settings-gear");
     const takeover = testPage.getByTestId("app-sidebar-settings-mode");
 
-    // No standalone "Settings" nav section: the tree is not shown until the gear
-    // is toggled, even though we're sitting on a settings page.
+    // Direct settings routes preserve sidebar context after a hard refresh.
     await expect(gear).toBeVisible();
+    await expect(takeover).toBeVisible();
+
+    // Gear closes the takeover even though we're sitting on a settings page.
+    await gear.click();
     await expect(takeover).toHaveCount(0);
 
-    // Gear opens the takeover.
+    // Gear opens the takeover again.
     await gear.click();
     await expect(takeover).toBeVisible();
 
-    // Enter a section — navigates to a settings sub-page; takeover stays open.
+    // Enter a section: navigates to a settings sub-page; takeover stays open.
     await takeover.locator('a[href="/settings/agents"]').first().click();
     await expect(testPage).toHaveURL(/\/settings\/agents/);
     await expect(takeover).toBeVisible();
 
-    // Clicking the gear again must close the tree — even though we're still on a
+    // Clicking the gear again must close the tree even though we're still on a
     // settings page (the previous bug left it open).
     await gear.click();
     await expect(takeover).toHaveCount(0);
@@ -34,14 +37,12 @@ test.describe("Settings sidebar takeover", () => {
   }) => {
     await testPage.goto("/settings");
 
-    const gear = testPage.getByTestId("sidebar-settings-gear");
     const takeover = testPage.getByTestId("app-sidebar-settings-mode");
     const sidebar = testPage.getByTestId("app-sidebar");
 
-    await gear.click();
     await expect(takeover).toBeVisible();
 
-    // The Kandev brand navigates Home — leaving the settings surface must close
+    // The Kandev brand navigates Home; leaving the settings surface must close
     // the takeover (the bug left the tree up after going Home).
     await sidebar.locator('[aria-label="Kandev home"]').first().click();
     await expect(testPage).not.toHaveURL(/\/settings/);
@@ -58,7 +59,7 @@ test.describe("Settings sidebar takeover", () => {
     await sidebar.getByRole("button", { name: "Collapse sidebar" }).click();
     await expect(sidebar).toHaveAttribute("data-collapsed", "true");
 
-    // Clicking the gear while collapsed must expand the rail AND show the tree —
+    // Clicking the gear while collapsed must expand the rail AND show the tree:
     // a collapsed rail can't host the settings tree.
     await testPage.getByTestId("sidebar-settings-gear").click();
     await expect(sidebar).toHaveAttribute("data-collapsed", "false");

--- a/apps/web/e2e/tests/system/sidebar-navigation.spec.ts
+++ b/apps/web/e2e/tests/system/sidebar-navigation.spec.ts
@@ -21,7 +21,6 @@ test.describe("System sidebar navigation", () => {
     // sub-entries are only mounted while that group is the open one. Landing on
     // a System page route-syncs the System group open, so its sub-entries show.
     await testPage.goto("/settings/system/status");
-    await testPage.getByTestId("sidebar-settings-gear").click();
     await expect(testPage.getByTestId("app-sidebar-settings-mode")).toBeVisible();
 
     // Each sub-entry is present in the settings sidebar.


### PR DESCRIPTION
Settings pages could reload with the app sidebar showing the main Home/Tasks view, which made deep agent profile routes look detached from their active navigation context. The sidebar now derives settings mode from `/settings` routes on mount and route changes, so refreshed profile pages reopen the settings tree and active group.

## Validation

- `pnpm --filter @kandev/web test -- --run components/app-sidebar/app-sidebar.test.tsx`
- `pnpm --filter @kandev/web exec prettier --check components/app-sidebar/app-sidebar.tsx components/app-sidebar/app-sidebar.test.tsx`
- `pnpm --filter @kandev/web exec eslint components/app-sidebar/app-sidebar.tsx components/app-sidebar/app-sidebar.test.tsx --max-warnings 0`
- `pnpm --filter @kandev/web typecheck`
- `go test -tags fts5 ./internal/agentctl/server/utility`
- `make -C apps/backend lint`
- `make fmt`
- `make typecheck test lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.