### PR TITLE
fix(agent-settings): stop reseeding agent profiles the user deleted

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
@@ -101,6 +101,10 @@ func (m *MockRepository) ListAgentProfiles(ctx context.Context, agentID string) 
 	return []*models.AgentProfile{}, nil
 }
 
+func (m *MockRepository) HasDeletedAgentProfiles(ctx context.Context, agentID string) (bool, error) {
+	return false, nil
+}
+
 func (m *MockRepository) ListTUIAgents(ctx context.Context) ([]*models.Agent, error) {
 	return []*models.Agent{}, nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
@@ -23,6 +23,7 @@ type MockRepository struct {
 	GetAgentProfileIncludingDeletedFn func(ctx context.Context, id string) (*models.AgentProfile, error)
 	ListAgentsFn                      func(ctx context.Context) ([]*models.Agent, error)
 	ListAgentProfilesFn               func(ctx context.Context, agentID string) ([]*models.AgentProfile, error)
+	HasDeletedAgentProfilesFn         func(ctx context.Context, agentID string) (bool, error)
 }
 
 var _ store.Repository = (*MockRepository)(nil)
@@ -102,6 +103,9 @@ func (m *MockRepository) ListAgentProfiles(ctx context.Context, agentID string) 
 }
 
 func (m *MockRepository) HasDeletedAgentProfiles(ctx context.Context, agentID string) (bool, error) {
+	if m.HasDeletedAgentProfilesFn != nil {
+		return m.HasDeletedAgentProfilesFn(ctx, agentID)
+	}
 	return false, nil
 }
 

--- a/apps/backend/internal/agent/settings/controller/agent_discovery.go
+++ b/apps/backend/internal/agent/settings/controller/agent_discovery.go
@@ -328,6 +328,8 @@ func (c *Controller) syncAgentFromDiscovery(ctx context.Context, result discover
 	// No live profiles. Only seed a default for an agent that has never been
 	// provisioned. If soft-deleted rows exist the user deliberately removed
 	// the profile(s); recreating one here would resurrect it on every restart.
+	// (A soft-deleted row implies a user deletion, not system orphan cleanup —
+	// see ProfileReconciler.reconcileAgent for the disjoint-enabled-set reasoning.)
 	hadProfiles, err := c.repo.HasDeletedAgentProfiles(ctx, agent.ID)
 	if err != nil {
 		return err

--- a/apps/backend/internal/agent/settings/controller/agent_discovery.go
+++ b/apps/backend/internal/agent/settings/controller/agent_discovery.go
@@ -325,6 +325,16 @@ func (c *Controller) syncAgentFromDiscovery(ctx context.Context, result discover
 	if len(profiles) > 0 {
 		return c.updateExistingProfiles(ctx, profiles, p)
 	}
+	// No live profiles. Only seed a default for an agent that has never been
+	// provisioned. If soft-deleted rows exist the user deliberately removed
+	// the profile(s); recreating one here would resurrect it on every restart.
+	hadProfiles, err := c.repo.HasDeletedAgentProfiles(ctx, agent.ID)
+	if err != nil {
+		return err
+	}
+	if hadProfiles {
+		return nil
+	}
 	return c.createDefaultProfile(ctx, agent.ID, p)
 }
 

--- a/apps/backend/internal/agent/settings/controller/reconciler.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler.go
@@ -146,6 +146,20 @@ func (r *ProfileReconciler) reconcileAgent(ctx context.Context, ag agents.Agent)
 	}
 
 	if len(profiles) == 0 {
+		// Only seed for an agent that has never been provisioned. Soft-deleted
+		// rows mean the user deliberately removed the profile(s) — re-seeding
+		// here would resurrect them on every boot (the bug this guards).
+		hadProfiles, err := r.store.HasDeletedAgentProfiles(ctx, dbAgent.ID)
+		if err != nil {
+			r.log.Warn("reconcile: check deleted profiles failed",
+				zap.String("agent_id", agentType), zap.Error(err))
+			return
+		}
+		if hadProfiles {
+			r.log.Debug("skipping seed: agent has user-deleted profiles",
+				zap.String("agent_id", agentType))
+			return
+		}
 		r.seedDefaultProfile(ctx, ag, dbAgent, caps)
 		return
 	}

--- a/apps/backend/internal/agent/settings/controller/reconciler.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler.go
@@ -147,8 +147,17 @@ func (r *ProfileReconciler) reconcileAgent(ctx context.Context, ag agents.Agent)
 
 	if len(profiles) == 0 {
 		// Only seed for an agent that has never been provisioned. Soft-deleted
-		// rows mean the user deliberately removed the profile(s) — re-seeding
-		// here would resurrect them on every boot (the bug this guards).
+		// rows mean the profile(s) were deliberately removed, so re-seeding
+		// would resurrect them on every boot (the bug this guards).
+		//
+		// A soft-deleted row here implies a *user* deletion, not system orphan
+		// cleanup: cleanupOrphans is the only system path that soft-deletes
+		// profiles, and it acts solely on agents absent from ListEnabled(),
+		// whereas reconcileAgent runs only for ListInferenceAgents(). Both gate
+		// on Enabled(), so the sets are disjoint — an enabled, reconciled agent
+		// is never orphan-cleaned. (If Enabled() ever becomes dynamic, revisit:
+		// a re-enabled agent reuses its DB id via ensureDBAgent and would then
+		// see its orphan-cleaned rows here.)
 		hadProfiles, err := r.store.HasDeletedAgentProfiles(ctx, dbAgent.ID)
 		if err != nil {
 			r.log.Warn("reconcile: check deleted profiles failed",

--- a/apps/backend/internal/agent/settings/controller/reconciler_test.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kandev/kandev/internal/agent/agents"
+	"github.com/kandev/kandev/internal/agent/discovery"
 	"github.com/kandev/kandev/internal/agent/hostutility"
 	"github.com/kandev/kandev/internal/agent/registry"
 	"github.com/kandev/kandev/internal/agent/settings/models"
@@ -28,7 +29,7 @@ type fakeStore struct {
 	agents       map[string]*models.Agent          // keyed by DB ID
 	byName       map[string]*models.Agent          // keyed by Name
 	profiles     map[string][]*models.AgentProfile // keyed by DB agent ID (live)
-	deleted      map[string]bool                   // keyed by DB agent ID (has soft-deleted rows)
+	deleted      map[string][]*models.AgentProfile // keyed by DB agent ID (soft-deleted)
 	created      []*models.AgentProfile
 	updated      []*models.AgentProfile
 	softDeleted  []string
@@ -42,7 +43,7 @@ func newFakeStore() *fakeStore {
 		agents:   map[string]*models.Agent{},
 		byName:   map[string]*models.Agent{},
 		profiles: map[string][]*models.AgentProfile{},
-		deleted:  map[string]bool{},
+		deleted:  map[string][]*models.AgentProfile{},
 	}
 }
 
@@ -105,13 +106,14 @@ func (f *fakeStore) UpdateAgentProfile(_ context.Context, p *models.AgentProfile
 
 func (f *fakeStore) DeleteAgentProfile(_ context.Context, id string) error {
 	f.softDeleted = append(f.softDeleted, id)
-	// Faithfully model soft-delete: drop the row from the live list and record
-	// that the owning agent now has a deleted profile.
+	// Faithfully model soft-delete: move the row out of the live list into the
+	// deleted list so HasDeletedAgentProfiles and GetAgentProfileIncludingDeleted
+	// stay consistent with the live ListAgentProfiles view.
 	for agentID, list := range f.profiles {
 		kept := list[:0:0]
 		for _, p := range list {
 			if p.ID == id {
-				f.deleted[agentID] = true
+				f.deleted[agentID] = append(f.deleted[agentID], p)
 				continue
 			}
 			kept = append(kept, p)
@@ -122,7 +124,7 @@ func (f *fakeStore) DeleteAgentProfile(_ context.Context, id string) error {
 }
 
 func (f *fakeStore) HasDeletedAgentProfiles(_ context.Context, agentID string) (bool, error) {
-	return f.deleted[agentID], nil
+	return len(f.deleted[agentID]) > 0, nil
 }
 
 func (f *fakeStore) GetAgentProfile(_ context.Context, id string) (*models.AgentProfile, error) {
@@ -137,10 +139,19 @@ func (f *fakeStore) GetAgentProfile(_ context.Context, id string) (*models.Agent
 }
 
 func (f *fakeStore) GetAgentProfileIncludingDeleted(ctx context.Context, id string) (*models.AgentProfile, error) {
-	// Delegate to the deleted_at-aware lookup; the fake does not model
-	// soft-delete state, so both methods see the same rows. This keeps
-	// nil dereferences out of any test that calls the new method.
-	return f.GetAgentProfile(ctx, id)
+	if p, err := f.GetAgentProfile(ctx, id); err == nil {
+		return p, nil
+	}
+	// Fall back to the soft-deleted set so this method, unlike GetAgentProfile,
+	// surfaces rows that DeleteAgentProfile moved out of the live list.
+	for _, list := range f.deleted {
+		for _, p := range list {
+			if p.ID == id {
+				return p, nil
+			}
+		}
+	}
+	return nil, sql.ErrNoRows
 }
 
 func (f *fakeStore) ListAgentProfiles(_ context.Context, agentID string) ([]*models.AgentProfile, error) {
@@ -239,10 +250,14 @@ func TestProfileReconciler_SeedsDefaultProfile(t *testing.T) {
 func TestProfileReconciler_DoesNotReseedAfterUserDelete(t *testing.T) {
 	st := newFakeStore()
 	// Agent exists and was provisioned before, but the user deleted every
-	// profile — modelled as zero live rows plus a recorded soft-delete.
+	// profile — modelled by creating a profile and soft-deleting it via the
+	// real delete path, leaving zero live rows and one soft-deleted row.
 	dbAgent := &models.Agent{Name: "claude-acp"}
 	_ = st.CreateAgent(context.Background(), dbAgent)
-	st.deleted[dbAgent.ID] = true
+	deletedProfile := &models.AgentProfile{AgentID: dbAgent.ID, Name: "Sonnet 4.6", Model: "claude-sonnet"}
+	_ = st.CreateAgentProfile(context.Background(), deletedProfile)
+	_ = st.DeleteAgentProfile(context.Background(), deletedProfile.ID)
+	st.created = nil // discard setup bookkeeping; measure only what Run() seeds
 
 	ag := &mockInferenceAgent{id: "claude-acp", displayName: "Claude", enabled: true}
 	caps := &fakeCapReader{
@@ -328,5 +343,62 @@ func TestProfileReconciler_CleansOrphanProfiles(t *testing.T) {
 	}
 	if len(st.softDeleted) != 1 || st.softDeleted[0] != orphanProfile.ID {
 		t.Fatalf("expected orphan profile to be soft-deleted, got %v", st.softDeleted)
+	}
+}
+
+// newDiscoveryController builds a Controller with just the dependencies that
+// syncAgentFromDiscovery touches: the agent registry, the store, and a logger.
+func newDiscoveryController(t *testing.T, st *fakeStore, ag agents.Agent) *Controller {
+	t.Helper()
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	reg := registry.NewRegistry(log)
+	if err := reg.Register(ag); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return &Controller{agentRegistry: reg, repo: st, logger: log}
+}
+
+// TestSyncAgentFromDiscovery_DoesNotReseedAfterUserDelete pins the discovery
+// seed path — the other half of the fix. An agent whose only profile the user
+// deleted must NOT have a default recreated when discovery runs on boot.
+func TestSyncAgentFromDiscovery_DoesNotReseedAfterUserDelete(t *testing.T) {
+	st := newFakeStore()
+	ag := &mockInferenceAgent{id: "claude-acp", displayName: "Claude", enabled: true}
+
+	dbAgent := &models.Agent{Name: "claude-acp"}
+	_ = st.CreateAgent(context.Background(), dbAgent)
+	deletedProfile := &models.AgentProfile{AgentID: dbAgent.ID, Name: "Sonnet 4.6", Model: "claude-sonnet"}
+	_ = st.CreateAgentProfile(context.Background(), deletedProfile)
+	_ = st.DeleteAgentProfile(context.Background(), deletedProfile.ID)
+	st.created = nil // discard setup bookkeeping; measure only what sync seeds
+
+	c := newDiscoveryController(t, st, ag)
+	result := discovery.Availability{Name: "claude-acp", Available: true}
+	if err := c.syncAgentFromDiscovery(context.Background(), result); err != nil {
+		t.Fatalf("syncAgentFromDiscovery: %v", err)
+	}
+	if len(st.created) != 0 {
+		t.Fatalf("expected no profile to be recreated after user delete, got %d: %+v",
+			len(st.created), st.created)
+	}
+}
+
+// TestSyncAgentFromDiscovery_SeedsFreshAgent is the positive counterpart: an
+// agent that has never been provisioned (no live and no deleted rows) still
+// gets its default profile, so the guard does not break new-agent detection.
+func TestSyncAgentFromDiscovery_SeedsFreshAgent(t *testing.T) {
+	st := newFakeStore()
+	ag := &mockInferenceAgent{id: "claude-acp", displayName: "Claude", enabled: true}
+
+	c := newDiscoveryController(t, st, ag)
+	result := discovery.Availability{Name: "claude-acp", Available: true}
+	if err := c.syncAgentFromDiscovery(context.Background(), result); err != nil {
+		t.Fatalf("syncAgentFromDiscovery: %v", err)
+	}
+	if len(st.created) != 1 {
+		t.Fatalf("expected fresh agent to be seeded, got %d created", len(st.created))
 	}
 }

--- a/apps/backend/internal/agent/settings/controller/reconciler_test.go
+++ b/apps/backend/internal/agent/settings/controller/reconciler_test.go
@@ -27,7 +27,8 @@ func (f *fakeCapReader) Get(agentType string) (hostutility.AgentCapabilities, bo
 type fakeStore struct {
 	agents       map[string]*models.Agent          // keyed by DB ID
 	byName       map[string]*models.Agent          // keyed by Name
-	profiles     map[string][]*models.AgentProfile // keyed by DB agent ID
+	profiles     map[string][]*models.AgentProfile // keyed by DB agent ID (live)
+	deleted      map[string]bool                   // keyed by DB agent ID (has soft-deleted rows)
 	created      []*models.AgentProfile
 	updated      []*models.AgentProfile
 	softDeleted  []string
@@ -41,6 +42,7 @@ func newFakeStore() *fakeStore {
 		agents:   map[string]*models.Agent{},
 		byName:   map[string]*models.Agent{},
 		profiles: map[string][]*models.AgentProfile{},
+		deleted:  map[string]bool{},
 	}
 }
 
@@ -103,7 +105,24 @@ func (f *fakeStore) UpdateAgentProfile(_ context.Context, p *models.AgentProfile
 
 func (f *fakeStore) DeleteAgentProfile(_ context.Context, id string) error {
 	f.softDeleted = append(f.softDeleted, id)
+	// Faithfully model soft-delete: drop the row from the live list and record
+	// that the owning agent now has a deleted profile.
+	for agentID, list := range f.profiles {
+		kept := list[:0:0]
+		for _, p := range list {
+			if p.ID == id {
+				f.deleted[agentID] = true
+				continue
+			}
+			kept = append(kept, p)
+		}
+		f.profiles[agentID] = kept
+	}
 	return nil
+}
+
+func (f *fakeStore) HasDeletedAgentProfiles(_ context.Context, agentID string) (bool, error) {
+	return f.deleted[agentID], nil
 }
 
 func (f *fakeStore) GetAgentProfile(_ context.Context, id string) (*models.AgentProfile, error) {
@@ -211,6 +230,39 @@ func TestProfileReconciler_SeedsDefaultProfile(t *testing.T) {
 	}
 	if p.Mode != "default" {
 		t.Errorf("mode = %q, want default", p.Mode)
+	}
+}
+
+// TestProfileReconciler_DoesNotReseedAfterUserDelete pins the core fix: an
+// agent whose only profile the user deleted (zero live rows, but soft-deleted
+// rows present) must NOT have a default profile recreated on the next boot.
+func TestProfileReconciler_DoesNotReseedAfterUserDelete(t *testing.T) {
+	st := newFakeStore()
+	// Agent exists and was provisioned before, but the user deleted every
+	// profile — modelled as zero live rows plus a recorded soft-delete.
+	dbAgent := &models.Agent{Name: "claude-acp"}
+	_ = st.CreateAgent(context.Background(), dbAgent)
+	st.deleted[dbAgent.ID] = true
+
+	ag := &mockInferenceAgent{id: "claude-acp", displayName: "Claude", enabled: true}
+	caps := &fakeCapReader{
+		caps: map[string]hostutility.AgentCapabilities{
+			"claude-acp": {
+				AgentType:      "claude-acp",
+				Status:         hostutility.StatusOK,
+				Models:         []hostutility.Model{{ID: "claude-sonnet", Name: "Sonnet"}},
+				CurrentModelID: "claude-sonnet",
+				CurrentModeID:  "default",
+			},
+		},
+	}
+	r := newReconciler(t, st, caps, ag)
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(st.created) != 0 {
+		t.Fatalf("expected no profile to be recreated after user delete, got %d: %+v",
+			len(st.created), st.created)
 	}
 }
 

--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -799,6 +799,21 @@ func (r *sqliteRepository) ListAgentProfiles(ctx context.Context, agentID string
 	return result, rows.Err()
 }
 
+// HasDeletedAgentProfiles reports whether the agent has any soft-deleted
+// profile rows (deleted_at IS NOT NULL). It is the "has been provisioned
+// before" signal the boot-time seeders consult before recreating a default
+// profile, so a profile the user deleted is not silently resurrected.
+func (r *sqliteRepository) HasDeletedAgentProfiles(ctx context.Context, agentID string) (bool, error) {
+	var exists int
+	err := r.ro.QueryRowContext(ctx,
+		r.ro.Rebind(`SELECT EXISTS(SELECT 1 FROM agent_profiles WHERE agent_id = ? AND deleted_at IS NOT NULL)`),
+		agentID).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists == 1, nil
+}
+
 // applyLegacyBackfill returns the profile with CLIFlags populated from the
 // legacy allow_indexing column for Auggie rows that predate the cli_flags
 // column. The backfill is scoped to auggie only so a legacy Claude/Codex/

--- a/apps/backend/internal/agent/settings/store/sqlite_soft_delete_test.go
+++ b/apps/backend/internal/agent/settings/store/sqlite_soft_delete_test.go
@@ -69,6 +69,52 @@ func TestGetAgentProfileIncludingDeleted_MissingRowStillErrors(t *testing.T) {
 	}
 }
 
+// TestHasDeletedAgentProfiles pins the "has been provisioned before" signal the
+// boot-time seeders rely on: false while a profile is live (or never existed),
+// true once the user soft-deletes it. This is what stops a deleted profile from
+// being resurrected on the next restart.
+func TestHasDeletedAgentProfiles(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	id := seedAgentProfile(t, repo, "kilo-default", "kilocode-acp")
+
+	live, err := repo.GetAgentProfileIncludingDeleted(ctx, id)
+	if err != nil {
+		t.Fatalf("lookup profile: %v", err)
+	}
+	agentID := live.AgentID
+
+	// Fresh agent with no deleted rows -> false.
+	has, err := repo.HasDeletedAgentProfiles(ctx, agentID)
+	if err != nil {
+		t.Fatalf("HasDeletedAgentProfiles (live): %v", err)
+	}
+	if has {
+		t.Fatal("expected false while the only profile is still live")
+	}
+
+	// Unknown agent -> false (not an error).
+	has, err = repo.HasDeletedAgentProfiles(ctx, "agent-that-never-existed")
+	if err != nil {
+		t.Fatalf("HasDeletedAgentProfiles (unknown): %v", err)
+	}
+	if has {
+		t.Fatal("expected false for an agent with no profile rows at all")
+	}
+
+	if err := repo.DeleteAgentProfile(ctx, id); err != nil {
+		t.Fatalf("soft-delete failed: %v", err)
+	}
+
+	has, err = repo.HasDeletedAgentProfiles(ctx, agentID)
+	if err != nil {
+		t.Fatalf("HasDeletedAgentProfiles (deleted): %v", err)
+	}
+	if !has {
+		t.Fatal("expected true once the agent has a soft-deleted profile")
+	}
+}
+
 // seedAgentProfile creates a parent agent + a profile referencing it and
 // returns the profile id. Centralised so the table+FK setup stays in one
 // place even if the schema grows new required columns.

--- a/apps/backend/internal/agent/settings/store/store.go
+++ b/apps/backend/internal/agent/settings/store/store.go
@@ -28,6 +28,12 @@ type Repository interface {
 	// only used by callers of ProfileResolver, which wraps this method.
 	GetAgentProfileIncludingDeleted(ctx context.Context, id string) (*models.AgentProfile, error)
 	ListAgentProfiles(ctx context.Context, agentID string) ([]*models.AgentProfile, error)
+	// HasDeletedAgentProfiles reports whether the agent has any soft-deleted
+	// profile rows. Seeding paths use this to distinguish a fresh agent that
+	// has never been provisioned (no rows at all -> seed a default) from one
+	// whose profiles the user deliberately deleted (deleted rows present ->
+	// do not resurrect them on the next boot).
+	HasDeletedAgentProfiles(ctx context.Context, agentID string) (bool, error)
 
 	Close() error
 }


### PR DESCRIPTION
## Summary

Agent profiles the user had deleted were being **recreated on every `kandev service restart`**. This fixes the root cause.

### Root cause
Two boot-time seeders treat *"an available agent has zero **live** profiles"* as *"seed a default profile"*, with no awareness of soft-deleted rows:

1. `runInitialAgentSetup` → `EnsureInitialAgentProfiles` → `syncAgentFromDiscovery` → `createDefaultProfile` (early, synchronous)
2. `ProfileReconciler.Run` → `reconcileAgent` → `seedDefaultProfile` (after the ACP capability probe)

Profile deletion is a **soft delete** (`DeleteAgentProfile` sets `deleted_at`), and `ListAgentProfiles` filters `deleted_at IS NULL`. So deleting an agent's only profile makes `len(profiles)==0` again → a fresh default is recreated (new UUID, `user_modified=0`), which the reconciler then heals to the probed model name. The result was a trail of soft-deleted duplicates plus one live recreation per restart.

### Fix
Add `Repository.HasDeletedAgentProfiles(agentID)` (`SELECT EXISTS(... deleted_at IS NOT NULL)`) and gate **both** seed paths on it: seed only when the agent has never been provisioned (no live **and** no soft-deleted rows). Gating only one path would let the other resurrect, so both are gated.

- A genuinely new agent (no rows of either kind) still gets its default profile → newly-added-agent detection preserved.
- A profile the user deleted stays deleted across restarts. There is no profile restore/undelete path in the backend, so once soft-deleted a profile is never resurrected.

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test -race` on affected packages
- [x] Regression tests for **both** seed paths, each TDD-verified to fail when its guard is reverted (`TestProfileReconciler_DoesNotReseedAfterUserDelete`, `TestSyncAgentFromDiscovery_DoesNotReseedAfterUserDelete`)
- [x] Positive cases retained (`*_SeedsDefaultProfile`, `*_SeedsFreshAgent`); store-level `TestHasDeletedAgentProfiles`