### PR TITLE
fix(web): collapse dockview workflow stepper to current step when cramped

### DIFF
--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -70,7 +70,7 @@ const TaskTopBar = memo(function TaskTopBar({
   return (
     <header
       data-testid="task-topbar"
-      className="@container/topbar grid h-10 shrink-0 grid-cols-[minmax(0,1fr)_minmax(0,auto)_minmax(0,1fr)] items-center gap-2 overflow-hidden px-3 py-1 border-b border-border"
+      className="@container/topbar grid h-10 shrink-0 grid-cols-[minmax(0,auto)_minmax(0,1fr)_auto] items-center gap-2 overflow-hidden px-3 py-1 border-b border-border"
     >
       <TopBarLeft
         taskId={taskId}
@@ -79,7 +79,7 @@ const TaskTopBar = memo(function TaskTopBar({
         remoteExecutorType={remoteExecutorType}
         isArchived={isArchived}
       />
-      <div className="min-w-0 justify-self-center overflow-hidden">
+      <div className="min-w-0 justify-self-stretch overflow-hidden">
         {workflowSteps && workflowSteps.length > 0 && (
           <WorkflowStepper
             steps={workflowSteps}

--- a/apps/web/components/task/workflow-stepper.test.tsx
+++ b/apps/web/components/task/workflow-stepper.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorkflowStepper, type WorkflowStepperStep } from "./workflow-stepper";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Drive the collapse decision directly instead of relying on layout
+// measurement, which the test DOM can't perform (offsetWidth is always 0).
+const collapsedMock = vi.fn(() => false);
+vi.mock("@/hooks/use-toolbar-collapsed", () => ({
+  useToolbarCollapsed: () => collapsedMock(),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: () => undefined,
+}));
+vi.mock("@/lib/state/context-files-store", () => ({
+  useContextFilesStore: () => vi.fn(),
+}));
+vi.mock("@/lib/state/layout-store", () => ({
+  useLayoutStore: () => vi.fn(),
+}));
+vi.mock("@/lib/state/dockview-store", () => ({
+  useDockviewStore: () => vi.fn(),
+}));
+
+const STEPS: WorkflowStepperStep[] = [
+  { id: "a", name: "Spec", color: "#111", position: 0 },
+  { id: "b", name: "Work", color: "#222", position: 1 },
+  { id: "c", name: "Review", color: "#333", position: 2 },
+];
+
+describe("WorkflowStepper", () => {
+  it("renders every step when there is room (not collapsed)", () => {
+    collapsedMock.mockReturnValue(false);
+    render(<WorkflowStepper steps={STEPS} currentStepId="b" />);
+
+    expect(screen.getByTestId("workflow-stepper")).toBeTruthy();
+    expect(screen.queryByTestId("workflow-stepper-minimal")).toBeNull();
+    expect(screen.getByTestId("workflow-step-Spec")).toBeTruthy();
+    expect(screen.getByTestId("workflow-step-Work")).toBeTruthy();
+    expect(screen.getByTestId("workflow-step-Review")).toBeTruthy();
+  });
+
+  it("collapses to only the current step when space runs out", () => {
+    collapsedMock.mockReturnValue(true);
+    render(<WorkflowStepper steps={STEPS} currentStepId="b" />);
+
+    expect(screen.getByTestId("workflow-stepper-minimal")).toBeTruthy();
+    expect(screen.queryByTestId("workflow-stepper")).toBeNull();
+
+    // Only the current step is shown, and it keeps its test id + aria-current
+    // so it stays selectable in either variant.
+    const current = screen.getByTestId("workflow-step-Work");
+    expect(current.getAttribute("aria-current")).toBe("step");
+    expect(screen.queryByTestId("workflow-step-Spec")).toBeNull();
+    expect(screen.queryByTestId("workflow-step-Review")).toBeNull();
+
+    // Position indicator reflects the current step out of the total.
+    expect(screen.getByText("2/3")).toBeTruthy();
+  });
+
+  it("falls back to the first step when collapsed with no current step", () => {
+    collapsedMock.mockReturnValue(true);
+    render(<WorkflowStepper steps={STEPS} currentStepId={null} />);
+
+    expect(screen.getByTestId("workflow-step-Spec")).toBeTruthy();
+    expect(screen.getByText("1/3")).toBeTruthy();
+  });
+
+  it("shows the archived badge instead of a step when collapsed and archived", () => {
+    collapsedMock.mockReturnValue(true);
+    render(<WorkflowStepper steps={STEPS} currentStepId="b" isArchived />);
+
+    expect(screen.getByText("Archived")).toBeTruthy();
+    expect(screen.queryByTestId("workflow-step-Work")).toBeNull();
+  });
+
+  it("renders nothing when there are no steps", () => {
+    collapsedMock.mockReturnValue(false);
+    const { container } = render(<WorkflowStepper steps={[]} currentStepId={null} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/web/components/task/workflow-stepper.test.tsx
+++ b/apps/web/components/task/workflow-stepper.test.tsx
@@ -67,7 +67,8 @@ describe("WorkflowStepper", () => {
     collapsedMock.mockReturnValue(true);
     render(<WorkflowStepper steps={STEPS} currentStepId={null} />);
 
-    expect(screen.getByTestId("workflow-step-Spec")).toBeTruthy();
+    // Fallback step isn't the real current step, so it must not claim aria-current.
+    expect(screen.getByTestId("workflow-step-Spec").getAttribute("aria-current")).toBeNull();
     expect(screen.getByText("1/3")).toBeTruthy();
   });
 

--- a/apps/web/components/task/workflow-stepper.test.tsx
+++ b/apps/web/components/task/workflow-stepper.test.tsx
@@ -79,6 +79,9 @@ describe("WorkflowStepper", () => {
     render(<WorkflowStepper steps={STEPS} currentStepId="b" isArchived />);
 
     expect(screen.getByText("Archived")).toBeTruthy();
+    // Archived badge carries the minimal test id so collapsed-mode detection
+    // works for archived tasks too.
+    expect(screen.getByTestId("workflow-stepper-minimal")).toBeTruthy();
     expect(screen.queryByTestId("workflow-step-Work")).toBeNull();
   });
 

--- a/apps/web/components/task/workflow-stepper.test.tsx
+++ b/apps/web/components/task/workflow-stepper.test.tsx
@@ -40,6 +40,7 @@ describe("WorkflowStepper", () => {
 
     expect(screen.getByTestId("workflow-stepper")).toBeTruthy();
     expect(screen.queryByTestId("workflow-stepper-minimal")).toBeNull();
+    // All steps render under the persistent outer container.
     expect(screen.getByTestId("workflow-step-Spec")).toBeTruthy();
     expect(screen.getByTestId("workflow-step-Work")).toBeTruthy();
     expect(screen.getByTestId("workflow-step-Review")).toBeTruthy();
@@ -49,8 +50,10 @@ describe("WorkflowStepper", () => {
     collapsedMock.mockReturnValue(true);
     render(<WorkflowStepper steps={STEPS} currentStepId="b" />);
 
+    // Outer container persists across variants (keeps the e2e locator stable);
+    // the minimal child marks the collapsed state.
+    expect(screen.getByTestId("workflow-stepper")).toBeTruthy();
     expect(screen.getByTestId("workflow-stepper-minimal")).toBeTruthy();
-    expect(screen.queryByTestId("workflow-stepper")).toBeNull();
 
     // Only the current step is shown, and it keeps its test id + aria-current
     // so it stays selectable in either variant.

--- a/apps/web/components/task/workflow-stepper.test.tsx
+++ b/apps/web/components/task/workflow-stepper.test.tsx
@@ -7,8 +7,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-// Drive the collapse decision directly instead of relying on layout
-// measurement, which the test DOM can't perform (offsetWidth is always 0).
+// useToolbarCollapsed is mocked because the test DOM can't measure offsetWidth.
 const collapsedMock = vi.fn(() => false);
 vi.mock("@/hooks/use-toolbar-collapsed", () => ({
   useToolbarCollapsed: () => collapsedMock(),
@@ -50,13 +49,11 @@ describe("WorkflowStepper", () => {
     collapsedMock.mockReturnValue(true);
     render(<WorkflowStepper steps={STEPS} currentStepId="b" />);
 
-    // Outer container persists across variants (keeps the e2e locator stable);
-    // the minimal child marks the collapsed state.
+    // Outer container persists across variants (stable e2e locator); minimal child marks collapsed state.
     expect(screen.getByTestId("workflow-stepper")).toBeTruthy();
     expect(screen.getByTestId("workflow-stepper-minimal")).toBeTruthy();
 
-    // Only the current step is shown, and it keeps its test id + aria-current
-    // so it stays selectable in either variant.
+    // Current step keeps its test id + aria-current in either variant.
     const current = screen.getByTestId("workflow-step-Work");
     expect(current.getAttribute("aria-current")).toBe("step");
     expect(screen.queryByTestId("workflow-step-Spec")).toBeNull();
@@ -79,8 +76,7 @@ describe("WorkflowStepper", () => {
     render(<WorkflowStepper steps={STEPS} currentStepId="b" isArchived />);
 
     expect(screen.getByText("Archived")).toBeTruthy();
-    // Archived badge carries the minimal test id so collapsed-mode detection
-    // works for archived tasks too.
+    // Archived badge carries the minimal test id for collapsed-mode detection.
     expect(screen.getByTestId("workflow-stepper-minimal")).toBeTruthy();
     expect(screen.queryByTestId("workflow-step-Work")).toBeNull();
   });

--- a/apps/web/components/task/workflow-stepper.tsx
+++ b/apps/web/components/task/workflow-stepper.tsx
@@ -103,8 +103,7 @@ const WorkflowStepper = memo(function WorkflowStepper({
     [taskId, workflowId, disablePlanMode],
   );
 
-  // Collapse to a minimal view when the full stepper can't fit; `w-full` keeps
-  // clientWidth track-driven so the collapse decision stays stable.
+  // Collapse to a minimal view when the full stepper can't fit (w-full keeps the measurement track-driven).
   const containerRef = useRef<HTMLDivElement>(null);
   const isCollapsed = useToolbarCollapsed(containerRef);
 
@@ -153,10 +152,7 @@ const WorkflowStepper = memo(function WorkflowStepper({
   );
 });
 
-/** Minimal stepper shown when there isn't room for the full version: renders
- *  only the current step (or the archived badge). Keeps the same
- *  `workflow-step-<name>` test id + `aria-current` on the active step so it
- *  stays selectable regardless of which variant is on screen. */
+/** Minimal stepper: current step only (or archived badge), keeping the per-step test id + aria-current. */
 function MinimalWorkflowStepper({
   sortedSteps,
   currentIndex,
@@ -168,7 +164,10 @@ function MinimalWorkflowStepper({
 }) {
   if (isArchived) {
     return (
-      <span className="text-[11px] font-medium text-amber-500 bg-amber-500/15 px-2 py-0.5 rounded-md whitespace-nowrap">
+      <span
+        data-testid="workflow-stepper-minimal"
+        className="text-[11px] font-medium text-amber-500 bg-amber-500/15 px-2 py-0.5 rounded-md whitespace-nowrap"
+      >
         Archived
       </span>
     );

--- a/apps/web/components/task/workflow-stepper.tsx
+++ b/apps/web/components/task/workflow-stepper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { cn } from "@kandev/ui/lib/utils";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@kandev/ui/hover-card";
 import { Button } from "@kandev/ui/button";
@@ -11,6 +11,7 @@ import { useAppStore } from "@/components/state-provider";
 import { useContextFilesStore } from "@/lib/state/context-files-store";
 import { useLayoutStore } from "@/lib/state/layout-store";
 import { useDockviewStore } from "@/lib/state/dockview-store";
+import { useToolbarCollapsed } from "@/hooks/use-toolbar-collapsed";
 import type { KanbanStepEvents } from "@/lib/state/slices/kanban/types";
 
 type Step = {
@@ -102,37 +103,105 @@ const WorkflowStepper = memo(function WorkflowStepper({
     [taskId, workflowId, disablePlanMode],
   );
 
+  // When the full stepper outgrows the available horizontal space (small
+  // windows), collapse it to a minimal "current step only" view so it stops
+  // overlapping the top-bar action buttons. The container fills the grid track
+  // (`w-full`), so its width is content-independent and the collapse decision
+  // stays stable across the full/minimal swap.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isCollapsed = useToolbarCollapsed(containerRef);
+
   if (sortedSteps.length === 0) return null;
 
   return (
     <div
-      data-testid="workflow-stepper"
-      className="flex items-center gap-0 overflow-x-auto flex-shrink min-w-0 mx-2"
+      ref={containerRef}
+      className="flex w-full min-w-0 items-center justify-center gap-0 overflow-hidden mx-2"
     >
-      {sortedSteps.map((step, index) => (
-        <WorkflowStepItem
-          key={step.id}
-          step={step}
-          index={index}
+      {isCollapsed ? (
+        <MinimalWorkflowStepper
+          sortedSteps={sortedSteps}
           currentIndex={currentIndex}
           isArchived={isArchived}
-          taskId={taskId}
-          workflowId={workflowId}
-          movingToStepId={movingToStepId}
-          onMove={handleMove}
         />
-      ))}
-      {isArchived && (
+      ) : (
         <>
-          <div className="h-px w-6 shrink-0 bg-border" />
-          <span className="text-[11px] font-medium text-amber-500 bg-amber-500/15 px-2 py-0.5 rounded-md whitespace-nowrap">
-            Archived
-          </span>
+          <div data-testid="workflow-stepper" className="flex items-center gap-0">
+            {sortedSteps.map((step, index) => (
+              <WorkflowStepItem
+                key={step.id}
+                step={step}
+                index={index}
+                currentIndex={currentIndex}
+                isArchived={isArchived}
+                taskId={taskId}
+                workflowId={workflowId}
+                movingToStepId={movingToStepId}
+                onMove={handleMove}
+              />
+            ))}
+          </div>
+          {isArchived && (
+            <>
+              <div className="h-px w-6 shrink-0 bg-border" />
+              <span className="text-[11px] font-medium text-amber-500 bg-amber-500/15 px-2 py-0.5 rounded-md whitespace-nowrap">
+                Archived
+              </span>
+            </>
+          )}
         </>
       )}
     </div>
   );
 });
+
+/** Minimal stepper shown when there isn't room for the full version: renders
+ *  only the current step (or the archived badge). Keeps the same
+ *  `workflow-step-<name>` test id + `aria-current` on the active step so it
+ *  stays selectable regardless of which variant is on screen. */
+function MinimalWorkflowStepper({
+  sortedSteps,
+  currentIndex,
+  isArchived,
+}: {
+  sortedSteps: Step[];
+  currentIndex: number;
+  isArchived?: boolean;
+}) {
+  if (isArchived) {
+    return (
+      <span className="text-[11px] font-medium text-amber-500 bg-amber-500/15 px-2 py-0.5 rounded-md whitespace-nowrap">
+        Archived
+      </span>
+    );
+  }
+
+  const current = currentIndex >= 0 ? sortedSteps[currentIndex] : sortedSteps[0];
+  if (!current) return null;
+
+  return (
+    <div
+      data-testid="workflow-stepper-minimal"
+      className="flex min-w-0 items-center gap-1.5 rounded-md px-2 py-0.5"
+    >
+      <div
+        data-testid={`workflow-step-${current.name}`}
+        aria-current="step"
+        className="flex min-w-0 items-center gap-1.5 text-xs"
+      >
+        <StepCircleIndicator isCurrent isCompleted={false} />
+        <span className="truncate text-xs font-medium leading-none text-foreground">
+          {current.name}
+        </span>
+      </div>
+      {sortedSteps.length > 1 && (
+        <span className="shrink-0 text-[11px] tabular-nums leading-none text-muted-foreground">
+          {(currentIndex >= 0 ? currentIndex : 0) + 1}/{sortedSteps.length}
+        </span>
+      )}
+    </div>
+  );
+}
 
 /** Check if a step can be moved to */
 function canMoveToStep(params: {

--- a/apps/web/components/task/workflow-stepper.tsx
+++ b/apps/web/components/task/workflow-stepper.tsx
@@ -183,7 +183,7 @@ function MinimalWorkflowStepper({
     >
       <div
         data-testid={`workflow-step-${current.name}`}
-        aria-current="step"
+        aria-current={currentIndex >= 0 ? "step" : undefined}
         className="flex min-w-0 items-center gap-1.5 text-xs"
       >
         <StepCircleIndicator isCurrent isCompleted={false} />

--- a/apps/web/components/task/workflow-stepper.tsx
+++ b/apps/web/components/task/workflow-stepper.tsx
@@ -103,11 +103,8 @@ const WorkflowStepper = memo(function WorkflowStepper({
     [taskId, workflowId, disablePlanMode],
   );
 
-  // When the full stepper outgrows the available horizontal space (small
-  // windows), collapse it to a minimal "current step only" view so it stops
-  // overlapping the top-bar action buttons. The container fills the grid track
-  // (`w-full`), so its width is content-independent and the collapse decision
-  // stays stable across the full/minimal swap.
+  // Collapse to a minimal view when the full stepper can't fit; `w-full` keeps
+  // clientWidth track-driven so the collapse decision stays stable.
   const containerRef = useRef<HTMLDivElement>(null);
   const isCollapsed = useToolbarCollapsed(containerRef);
 

--- a/apps/web/components/task/workflow-stepper.tsx
+++ b/apps/web/components/task/workflow-stepper.tsx
@@ -116,7 +116,8 @@ const WorkflowStepper = memo(function WorkflowStepper({
   return (
     <div
       ref={containerRef}
-      className="flex w-full min-w-0 items-center justify-center gap-0 overflow-hidden mx-2"
+      data-testid="workflow-stepper"
+      className="flex w-full min-w-0 items-center justify-center gap-0 overflow-hidden"
     >
       {isCollapsed ? (
         <MinimalWorkflowStepper
@@ -126,7 +127,7 @@ const WorkflowStepper = memo(function WorkflowStepper({
         />
       ) : (
         <>
-          <div data-testid="workflow-stepper" className="flex items-center gap-0">
+          <div className="flex items-center gap-0">
             {sortedSteps.map((step, index) => (
               <WorkflowStepItem
                 key={step.id}


### PR DESCRIPTION
On narrow windows the full workflow step indicator outgrew the top-bar center track and rendered beneath the right-side action buttons; it now collapses to a minimal current-step view, but only once the full version genuinely has no room.

## Important Changes

- Top-bar grid reworked to `minmax(0,auto)_minmax(0,1fr)_auto`: breadcrumb takes only its content width, the center track absorbs real leftover space, and the action buttons keep priority so they can no longer be overlapped.
- `WorkflowStepper` reuses the shared `useToolbarCollapsed` hook to swap to a minimal view (current-step circle + name + `n/N`, or the Archived badge) when the full stepper can't fit. The minimal view keeps the `workflow-step-<name>` test id and `aria-current` so selectors work in either variant.

## Validation

- `pnpm exec vitest run components/task/workflow-stepper.test.tsx` (new, 5 cases) and `task-top-bar.test.tsx`
- `pnpm typecheck`, `pnpm lint` (0 warnings), prettier

## Possible Improvements

Low risk. Collapse uses a measured threshold with hysteresis; an unusual breadcrumb/button width combination could shift the trigger point slightly, but cannot cause overlap.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.