### PR TITLE
fix(acpdbg): read claude agent models and modes from configOptions

### DIFF
--- a/apps/backend/cmd/mock-agent/main.go
+++ b/apps/backend/cmd/mock-agent/main.go
@@ -105,9 +105,10 @@ func (a *mockAgent) NewSession(_ context.Context, req acp.NewSessionRequest) (ac
 	go a.emitAvailableCommandsAfterDelay(sid)
 
 	return acp.NewSessionResponse{
-		SessionId: sid,
-		Models:    mockSessionModels(),
-		Modes:     mockSessionModes(),
+		SessionId:     sid,
+		Models:        mockSessionModels(),
+		Modes:         mockSessionModes(),
+		ConfigOptions: mockSessionConfigOptions(),
 	}, nil
 }
 
@@ -140,6 +141,52 @@ func mockSessionModes() *acp.SessionModeState {
 			{Id: "plan-mock", Name: "Plan Mock", Description: &planDesc},
 		},
 	}
+}
+
+func mockSessionConfigOptions() []acp.SessionConfigOption {
+	modelCat := acp.SessionConfigOptionCategoryModel
+	modeCat := acp.SessionConfigOptionCategoryMode
+	thoughtCat := acp.SessionConfigOptionCategoryThoughtLevel
+	return []acp.SessionConfigOption{
+		{Select: &acp.SessionConfigOptionSelect{
+			Category:     &modelCat,
+			CurrentValue: "mock-fast",
+			Id:           "model",
+			Name:         "Model",
+			Options: acp.SessionConfigSelectOptions{Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+				{Value: "mock-fast", Name: "Mock Fast", Description: ptr("Fast mock model for testing")},
+				{Value: "mock-smart", Name: "Mock Smart", Description: ptr("Smart mock model for testing")},
+			}},
+			Type: "select",
+		}},
+		{Select: &acp.SessionConfigOptionSelect{
+			Category:     &modeCat,
+			CurrentValue: "default",
+			Id:           "mode",
+			Name:         "Mode",
+			Options: acp.SessionConfigSelectOptions{Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+				{Value: "default", Name: "Default", Description: ptr("Default mock mode")},
+				{Value: "plan-mock", Name: "Plan Mock", Description: ptr("Plan-style mock mode for testing")},
+			}},
+			Type: "select",
+		}},
+		{Select: &acp.SessionConfigOptionSelect{
+			Category:     &thoughtCat,
+			CurrentValue: "medium",
+			Id:           "effort",
+			Name:         "Effort",
+			Options: acp.SessionConfigSelectOptions{Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+				{Value: "low", Name: "Low"},
+				{Value: "medium", Name: "Medium"},
+				{Value: "high", Name: "High"},
+			}},
+			Type: "select",
+		}},
+	}
+}
+
+func ptr(s string) *string {
+	return &s
 }
 
 // LoadSession restores a previous session for resume.

--- a/apps/backend/internal/agent/acpdbg/ops.go
+++ b/apps/backend/internal/agent/acpdbg/ops.go
@@ -324,13 +324,54 @@ func parseSessionResult(newResult map[string]any, out *ProbeResult) {
 		if avail, ok := models["availableModels"].([]any); ok {
 			out.Models = extractStringField(avail, "modelId")
 		}
+	} else {
+		out.CurrentModelID, out.Models = extractSelectConfigOption(newResult, "model")
 	}
 	if modes, ok := newResult["modes"].(map[string]any); ok {
 		out.CurrentModeID, _ = modes["currentModeId"].(string)
 		if avail, ok := modes["availableModes"].([]any); ok {
 			out.Modes = extractStringField(avail, "id")
 		}
+	} else {
+		out.CurrentModeID, out.Modes = extractSelectConfigOption(newResult, "mode")
 	}
+}
+
+func extractSelectConfigOption(newResult map[string]any, category string) (string, []string) {
+	opts, ok := newResult["configOptions"].([]any)
+	if !ok {
+		return "", nil
+	}
+	for _, item := range opts {
+		opt, ok := item.(map[string]any)
+		if !ok || opt["category"] != category || opt["type"] != "select" {
+			continue
+		}
+		current, _ := opt["currentValue"].(string)
+		return current, extractConfigOptionValues(opt["options"])
+	}
+	return "", nil
+}
+
+func extractConfigOptionValues(raw any) []string {
+	if list, ok := raw.([]any); ok {
+		return extractStringField(list, "value")
+	}
+	groups, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, rawGroup := range groups {
+		group, ok := rawGroup.(map[string]any)
+		if !ok {
+			continue
+		}
+		if list, ok := group["options"].([]any); ok {
+			out = append(out, extractStringField(list, "value")...)
+		}
+	}
+	return out
 }
 
 // extractStringField pulls a string field from each map entry in the list.

--- a/apps/backend/internal/agent/acpdbg/ops.go
+++ b/apps/backend/internal/agent/acpdbg/ops.go
@@ -354,21 +354,22 @@ func extractSelectConfigOption(newResult map[string]any, category string) (strin
 }
 
 func extractConfigOptionValues(raw any) []string {
-	if list, ok := raw.([]any); ok {
-		return extractStringField(list, "value")
-	}
-	groups, ok := raw.(map[string]any)
+	list, ok := raw.([]any)
 	if !ok {
 		return nil
 	}
 	var out []string
-	for _, rawGroup := range groups {
-		group, ok := rawGroup.(map[string]any)
+	for _, item := range list {
+		m, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		if list, ok := group["options"].([]any); ok {
-			out = append(out, extractStringField(list, "value")...)
+		if v, ok := m["value"].(string); ok {
+			out = append(out, v)
+			continue
+		}
+		if nested, ok := m["options"].([]any); ok {
+			out = append(out, extractStringField(nested, "value")...)
 		}
 	}
 	return out

--- a/apps/backend/internal/agent/acpdbg/ops_test.go
+++ b/apps/backend/internal/agent/acpdbg/ops_test.go
@@ -1,0 +1,74 @@
+package acpdbg
+
+import "testing"
+
+func TestBuildProbeResult_FallsBackToConfigOptionModels(t *testing.T) {
+	t.Parallel()
+
+	initResp := Frame{"result": map[string]any{
+		"protocolVersion": float64(1),
+		"agentInfo":       map[string]any{"name": "claude-agent-acp", "version": "0.42.0"},
+	}}
+	newResp := Frame{"result": map[string]any{
+		"sessionId": "session-1",
+		"configOptions": []any{
+			map[string]any{
+				"category":     "model",
+				"currentValue": "default",
+				"type":         "select",
+				"options": []any{
+					map[string]any{"value": "default", "name": "Default"},
+					map[string]any{"value": "opus", "name": "Opus"},
+				},
+			},
+			map[string]any{
+				"category":     "mode",
+				"currentValue": "plan",
+				"type":         "select",
+				"options": []any{
+					map[string]any{"value": "default", "name": "Default"},
+					map[string]any{"value": "plan", "name": "Plan Mode"},
+				},
+			},
+		},
+	}}
+
+	got := buildProbeResult(initResp, newResp)
+
+	if got.CurrentModelID != "default" {
+		t.Fatalf("CurrentModelID = %q, want default", got.CurrentModelID)
+	}
+	if len(got.Models) != 2 || got.Models[0] != "default" || got.Models[1] != "opus" {
+		t.Fatalf("Models = %+v, want [default opus]", got.Models)
+	}
+	if got.CurrentModeID != "plan" {
+		t.Fatalf("CurrentModeID = %q, want plan", got.CurrentModeID)
+	}
+	if len(got.Modes) != 2 || got.Modes[0] != "default" || got.Modes[1] != "plan" {
+		t.Fatalf("Modes = %+v, want [default plan]", got.Modes)
+	}
+}
+
+func TestBuildProbeResult_PrefersLegacyModels(t *testing.T) {
+	t.Parallel()
+
+	got := buildProbeResult(Frame{}, Frame{"result": map[string]any{
+		"models": map[string]any{
+			"currentModelId":  "legacy",
+			"availableModels": []any{map[string]any{"modelId": "legacy"}},
+		},
+		"configOptions": []any{map[string]any{
+			"category":     "model",
+			"currentValue": "fallback",
+			"type":         "select",
+			"options":      []any{map[string]any{"value": "fallback"}},
+		}},
+	}})
+
+	if got.CurrentModelID != "legacy" {
+		t.Fatalf("CurrentModelID = %q, want legacy", got.CurrentModelID)
+	}
+	if len(got.Models) != 1 || got.Models[0] != "legacy" {
+		t.Fatalf("Models = %+v, want [legacy]", got.Models)
+	}
+}

--- a/apps/backend/internal/agent/acpdbg/ops_test.go
+++ b/apps/backend/internal/agent/acpdbg/ops_test.go
@@ -72,3 +72,70 @@ func TestBuildProbeResult_PrefersLegacyModels(t *testing.T) {
 		t.Fatalf("Models = %+v, want [legacy]", got.Models)
 	}
 }
+
+func TestBuildProbeResult_PrefersLegacyModes(t *testing.T) {
+	t.Parallel()
+
+	got := buildProbeResult(Frame{}, Frame{"result": map[string]any{
+		"modes": map[string]any{
+			"currentModeId":  "legacy-mode",
+			"availableModes": []any{map[string]any{"id": "legacy-mode"}},
+		},
+		"configOptions": []any{map[string]any{
+			"category":     "mode",
+			"currentValue": "fallback-mode",
+			"type":         "select",
+			"options":      []any{map[string]any{"value": "fallback-mode"}},
+		}},
+	}})
+
+	if got.CurrentModeID != "legacy-mode" {
+		t.Fatalf("CurrentModeID = %q, want legacy-mode", got.CurrentModeID)
+	}
+	if len(got.Modes) != 1 || got.Modes[0] != "legacy-mode" {
+		t.Fatalf("Modes = %+v, want [legacy-mode]", got.Modes)
+	}
+}
+
+func TestBuildProbeResult_FallsBackToConfigOptionGroupedModels(t *testing.T) {
+	t.Parallel()
+
+	got := buildProbeResult(Frame{}, Frame{"result": map[string]any{
+		"sessionId": "session-grouped",
+		"configOptions": []any{
+			map[string]any{
+				"category":     "model",
+				"currentValue": "opus",
+				"type":         "select",
+				"options": []any{
+					map[string]any{
+						"group": "Anthropic",
+						"options": []any{
+							map[string]any{"value": "opus", "name": "Opus"},
+							map[string]any{"value": "sonnet", "name": "Sonnet"},
+						},
+					},
+					map[string]any{
+						"group": "Other",
+						"options": []any{
+							map[string]any{"value": "haiku", "name": "Haiku"},
+						},
+					},
+				},
+			},
+		},
+	}})
+
+	if got.CurrentModelID != "opus" {
+		t.Fatalf("CurrentModelID = %q, want opus", got.CurrentModelID)
+	}
+	wantModels := map[string]bool{"opus": true, "sonnet": true, "haiku": true}
+	if len(got.Models) != 3 {
+		t.Fatalf("len(Models) = %d, want 3: %v", len(got.Models), got.Models)
+	}
+	for _, model := range got.Models {
+		if !wantModels[model] {
+			t.Fatalf("unexpected model %q in %v", model, got.Models)
+		}
+	}
+}

--- a/apps/backend/internal/agent/agents/auggie.go
+++ b/apps/backend/internal/agent/agents/auggie.go
@@ -78,8 +78,8 @@ func (a *Auggie) IsInstalled(ctx context.Context) (*DiscoveryResult, error) {
 }
 
 func (a *Auggie) BuildCommand(opts CommandOptions) Command {
-	// Model and mode are applied via ACP session/set_model and session/set_mode
-	// after session creation — no --model CLI flag. The --allow-indexing flag
+	// Model and mode are applied via ACP after session creation — no --model CLI flag.
+	// The --allow-indexing flag
 	// used to be applied here from PermissionValues; it now flows through
 	// AgentProfile.CLIFlags and is appended by CommandBuilder.BuildCommand.
 	return Cmd("npx", "-y", auggiePkg, "--acp").Build()

--- a/apps/backend/internal/agent/agents/mock_test.go
+++ b/apps/backend/internal/agent/agents/mock_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestMockAgent_BuildCommand_NoModelFlag(t *testing.T) {
-	// ACP agents apply model via session/set_model after session/new, not
-	// via --model CLI flag. BuildCommand must not add --model.
+	// ACP agents apply model after session/new, not via --model CLI flag.
+	// BuildCommand must not add --model.
 	a := NewMockAgent()
 	cmd := a.BuildCommand(CommandOptions{Model: "mock-fast"})
 	args := cmd.Args()

--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -439,6 +439,23 @@ func (m *Manager) probe(ctx context.Context, inst *instance, ia agents.Inference
 			ID: m.ID, Name: m.Name, Description: m.Description, Meta: m.Meta,
 		})
 	}
+	for _, opt := range resp.ConfigOptions {
+		choices := make([]ConfigOptionChoice, 0, len(opt.Options))
+		for _, choice := range opt.Options {
+			choices = append(choices, ConfigOptionChoice{
+				Value: choice.Value,
+				Name:  choice.Name,
+			})
+		}
+		caps.ConfigOptions = append(caps.ConfigOptions, ConfigOption{
+			Type:         opt.Type,
+			ID:           opt.ID,
+			Name:         opt.Name,
+			CurrentValue: opt.CurrentValue,
+			Category:     opt.Category,
+			Options:      choices,
+		})
+	}
 	for _, c := range resp.Commands {
 		caps.Commands = append(caps.Commands, Command{Name: c.Name, Description: c.Description})
 	}

--- a/apps/backend/internal/agent/hostutility/types.go
+++ b/apps/backend/internal/agent/hostutility/types.go
@@ -43,6 +43,8 @@ type AgentCapabilities struct {
 	Modes         []Mode `json:"modes,omitempty"`
 	CurrentModeID string `json:"current_mode_id,omitempty"`
 
+	ConfigOptions []ConfigOption `json:"config_options,omitempty"`
+
 	Commands []Command `json:"commands,omitempty"`
 
 	LastCheckedAt time.Time `json:"last_checked_at"`
@@ -89,6 +91,20 @@ type Mode struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	Meta        map[string]any `json:"meta,omitempty"`
+}
+
+type ConfigOption struct {
+	Type         string               `json:"type"`
+	ID           string               `json:"id"`
+	Name         string               `json:"name"`
+	CurrentValue string               `json:"current_value"`
+	Category     string               `json:"category,omitempty"`
+	Options      []ConfigOptionChoice `json:"options,omitempty"`
+}
+
+type ConfigOptionChoice struct {
+	Value string `json:"value"`
+	Name  string `json:"name"`
 }
 
 // PromptResult is returned from ExecutePrompt and RawPrompt calls.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -256,10 +256,10 @@ func (m *Manager) SetSessionModeBySessionID(ctx context.Context, sessionID, mode
 }
 
 // SetSessionModel changes the session model for a running agent. ACP agents
-// swap the model in-place via session.set_model. Passthrough (TUI) agents have
-// no protocol channel — the model is a CLI flag baked into the launch — so the
-// override is persisted on the execution and the PTY is relaunched so the next
-// process picks up the new --model.
+// swap the model in-place via their advertised model-selection mechanism.
+// Passthrough (TUI) agents have no protocol channel — the model is a CLI flag
+// baked into the launch — so the override is persisted on the execution and
+// the PTY is relaunched so the next process picks up the new --model.
 func (m *Manager) SetSessionModel(ctx context.Context, executionID, modelID string) error {
 	execution, exists := m.executionStore.Get(executionID)
 	if !exists {
@@ -291,6 +291,30 @@ func (m *Manager) SetSessionModelBySessionID(ctx context.Context, sessionID, mod
 		return fmt.Errorf("no agent running for session %q", sessionID)
 	}
 	return m.SetSessionModel(ctx, execution.ID, modelID)
+}
+
+// SetSessionConfigOption changes an ACP session config option for a running agent.
+func (m *Manager) SetSessionConfigOption(ctx context.Context, executionID, configID, value string) error {
+	execution, exists := m.executionStore.Get(executionID)
+	if !exists {
+		return fmt.Errorf("execution %q not found", executionID)
+	}
+	if execution.agentctl == nil {
+		return fmt.Errorf("execution %q has no agentctl client", executionID)
+	}
+	if !execution.sessionInitialized || execution.ACPSessionID == "" {
+		return fmt.Errorf("execution %q ACP session is not ready", executionID)
+	}
+	return execution.agentctl.SetConfigOption(ctx, configID, value)
+}
+
+// SetSessionConfigOptionBySessionID changes an ACP session config option by task session ID.
+func (m *Manager) SetSessionConfigOptionBySessionID(ctx context.Context, sessionID, configID, value string) error {
+	execution, exists := m.executionStore.GetBySessionID(sessionID)
+	if !exists {
+		return fmt.Errorf("no agent running for session %q", sessionID)
+	}
+	return m.SetSessionConfigOption(ctx, execution.ID, configID, value)
 }
 
 // AuthenticateBySessionID triggers authentication for a given auth method on the agent.

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -122,6 +122,10 @@ func newRestartMockAgentctlServer(t *testing.T, failStop, failSessionNew bool) *
 				resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 					"success": true,
 				})
+			case "agent.session.set_config_option":
+				resp, _ = ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+					"success": true,
+				})
 			default:
 				resp, _ = ws.NewError(msg.ID, msg.Action, ws.ErrorCodeUnknownAction, "unknown action", nil)
 			}
@@ -482,6 +486,34 @@ func TestManager_RestartAgentProcess_PrefersPersistedModeOverStaleCache(t *testi
 	require.NotNil(t, exec.GetModeState())
 	require.Equal(t, "acceptEdits", exec.GetModeState().CurrentModeID,
 		"restart must restore the persisted DB mode, not the stale in-memory cache")
+}
+
+func TestManager_SetSessionConfigOptionBySessionID(t *testing.T) {
+	mgr := newTestManager(t)
+	mock := newRestartMockAgentctlServer(t, false, false)
+
+	client := createTestClient(t, mock.server.URL)
+	t.Cleanup(client.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	require.NoError(t, client.StreamUpdates(ctx, func(agentctl.AgentEvent) {}, nil, nil))
+
+	exec := &AgentExecution{
+		ID:                 "exec-config-option",
+		TaskID:             "task-1",
+		SessionID:          "session-1",
+		AgentProfileID:     "profile-1",
+		ACPSessionID:       "acp-session-1",
+		Status:             v1.AgentStatusRunning,
+		WorkspacePath:      "/workspace",
+		agentctl:           client,
+		sessionInitialized: true,
+	}
+	require.NoError(t, mgr.executionStore.Add(exec))
+
+	require.NoError(t, mgr.SetSessionConfigOptionBySessionID(ctx, "session-1", "reasoning_effort", "high"))
+	require.Contains(t, mock.getWSActions(), "agent.session.set_config_option")
 }
 
 // --- SetSessionModel passthrough tests ---

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
@@ -144,17 +144,17 @@ func runtimeName(rt ExecutorBackend) executor.Name {
 	return rt.Name()
 }
 
-// resolveProfileModelAndMode resolves the model and mode configured on an agent profile.
-// Returns empty strings if the profile cannot be resolved.
-func (m *Manager) resolveProfileModelAndMode(ctx context.Context, profileID string) (string, string) {
+// resolveProfileSessionConfig resolves the ACP session config on an agent profile.
+// Returns empty values if the profile cannot be resolved.
+func (m *Manager) resolveProfileSessionConfig(ctx context.Context, profileID string) (string, string, map[string]string) {
 	if profileID == "" || m.profileResolver == nil {
-		return "", ""
+		return "", "", nil
 	}
 	info, err := m.profileResolver.ResolveProfile(ctx, profileID)
 	if err != nil || info == nil {
-		return "", ""
+		return "", "", nil
 	}
-	return info.Model, info.Mode
+	return info.Model, info.Mode, info.ConfigOptions
 }
 
 // initializeACPSession delegates to SessionManager for full ACP session initialization and prompting.
@@ -163,9 +163,9 @@ func (m *Manager) resolveProfileModelAndMode(ctx context.Context, profileID stri
 // signal (the agent has never run a turn). When there IS a prompt, the callback is unused and
 // MarkReady fires later from handleCompleteEvent — that path is the true turn-end.
 func (m *Manager) initializeACPSession(ctx context.Context, execution *AgentExecution, agentConfig agents.Agent, taskDescription string, attachments []MessageAttachment, mcpServers []agentctltypes.McpServer) error {
-	profileModel, profileMode := m.resolveProfileModelAndMode(ctx, execution.AgentProfileID)
+	profileModel, profileMode, profileConfigOptions := m.resolveProfileSessionConfig(ctx, execution.AgentProfileID)
 	mode := m.effectiveSessionMode(ctx, execution, profileMode)
-	return m.sessionManager.InitializeAndPrompt(ctx, execution, agentConfig, taskDescription, attachments, mcpServers, m.MarkBootReady, profileModel, mode)
+	return m.sessionManager.InitializeAndPrompt(ctx, execution, agentConfig, taskDescription, attachments, mcpServers, m.MarkBootReady, profileModel, mode, profileConfigOptions)
 }
 
 // effectiveSessionMode prefers a session-level permission mode persisted in the

--- a/apps/backend/internal/agent/runtime/lifecycle/profile_resolver.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/profile_resolver.go
@@ -71,6 +71,7 @@ func (r *StoreProfileResolver) ResolveProfile(ctx context.Context, profileID str
 		AgentName:                  agent.Name,
 		Model:                      model,
 		Mode:                       profile.Mode,
+		ConfigOptions:              profile.ConfigOptions,
 		AutoApprove:                profile.AutoApprove,
 		DangerouslySkipPermissions: profile.DangerouslySkipPermissions,
 		AllowIndexing:              profile.AllowIndexing,

--- a/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/profile_resolver_test.go
@@ -328,7 +328,7 @@ func TestStoreProfileResolver_ResolveProfile_FallbackToRegistryDefaultModel(t *t
 	}
 	// Static per-agent default models have been removed; an empty profile
 	// model stays empty until the host utility probe fills it in via the
-	// reconciler. The session-start hook calls session/set_model only when
+	// reconciler. The session-start hook applies model selection only when
 	// a model is set, otherwise the agent uses its own default.
 	if info.Model != "" {
 		t.Errorf("expected Model '' (no static fallback), got '%s'", info.Model)

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -264,6 +264,7 @@ func (sm *SessionManager) InitializeAndPrompt(
 	markReady func(executionID string) error,
 	profileModel string,
 	profileMode string,
+	profileConfigOptions map[string]string,
 ) error {
 	// Create session-level trace span to group all operations under one trace
 	_, sessionSpan := tracing.TraceSessionStart(
@@ -327,8 +328,9 @@ func (sm *SessionManager) InitializeAndPrompt(
 	execution.ACPSessionID = result.SessionID
 	execution.sessionInitialized = true
 
-	// Apply profile model via ACP session/set_model (best-effort).
-	// ACP is the only surface for model selection now; no --model CLI flag.
+	// Apply profile model through the ACP session's advertised model-selection
+	// mechanism (best-effort). ACP is the only surface for model selection now;
+	// no --model CLI flag.
 	if profileModel != "" && execution.agentctl != nil {
 		if err := execution.agentctl.SetModel(ctx, profileModel); err != nil {
 			sm.logger.Warn("failed to set profile model via ACP",
@@ -353,6 +355,30 @@ func (sm *SessionManager) InitializeAndPrompt(
 			sm.logger.Info("set profile mode on ACP session",
 				zap.String("execution_id", execution.ID),
 				zap.String("mode", profileMode))
+		}
+	}
+
+	// Apply any dynamic ACP config options saved on the profile. Model and
+	// mode are handled above so their existing semantics stay unchanged.
+	if len(profileConfigOptions) > 0 && execution.agentctl != nil {
+		for configID, value := range profileConfigOptions {
+			configID = strings.TrimSpace(configID)
+			value = strings.TrimSpace(value)
+			if configID == "" || value == "" || configID == "model" || configID == "mode" {
+				continue
+			}
+			if err := execution.agentctl.SetConfigOption(ctx, configID, value); err != nil {
+				sm.logger.Warn("failed to set profile config option via ACP",
+					zap.String("execution_id", execution.ID),
+					zap.String("config_id", configID),
+					zap.String("value", value),
+					zap.Error(err))
+			} else {
+				sm.logger.Info("set profile config option on ACP session",
+					zap.String("execution_id", execution.ID),
+					zap.String("config_id", configID),
+					zap.String("value", value))
+			}
 		}
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	"github.com/kandev/kandev/internal/agent/settings/profileconfig"
 	"github.com/kandev/kandev/internal/agentctl/tracing"
 	agentctltypes "github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/common/appctx"
@@ -360,25 +361,21 @@ func (sm *SessionManager) InitializeAndPrompt(
 
 	// Apply any dynamic ACP config options saved on the profile. Model and
 	// mode are handled above so their existing semantics stay unchanged.
-	if len(profileConfigOptions) > 0 && execution.agentctl != nil {
-		for configID, value := range profileConfigOptions {
-			configID = strings.TrimSpace(configID)
-			value = strings.TrimSpace(value)
-			if configID == "" || value == "" || configID == "model" || configID == "mode" {
-				continue
-			}
-			if err := execution.agentctl.SetConfigOption(ctx, configID, value); err != nil {
-				sm.logger.Warn("failed to set profile config option via ACP",
-					zap.String("execution_id", execution.ID),
-					zap.String("config_id", configID),
-					zap.String("value", value),
-					zap.Error(err))
-			} else {
-				sm.logger.Info("set profile config option on ACP session",
-					zap.String("execution_id", execution.ID),
-					zap.String("config_id", configID),
-					zap.String("value", value))
-			}
+	for configID, value := range profileconfig.SanitizeConfigOptions(profileConfigOptions) {
+		if execution.agentctl == nil {
+			break
+		}
+		if err := execution.agentctl.SetConfigOption(ctx, configID, value); err != nil {
+			sm.logger.Warn("failed to set profile config option via ACP",
+				zap.String("execution_id", execution.ID),
+				zap.String("config_id", configID),
+				zap.String("value", value),
+				zap.Error(err))
+		} else {
+			sm.logger.Info("set profile config option on ACP session",
+				zap.String("execution_id", execution.ID),
+				zap.String("config_id", configID),
+				zap.String("value", value))
 		}
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/session_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session_test.go
@@ -168,6 +168,11 @@ func (m *mockAgentServer) defaultHandler(msg ws.Message) *ws.Message {
 			"success": true,
 		})
 		return resp
+	case "agent.session.set_model", "agent.session.set_mode", "agent.session.set_config_option":
+		resp, _ := ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
+			"success": true,
+		})
+		return resp
 	default:
 		resp, _ := ws.NewError(msg.ID, msg.Action, ws.ErrorCodeUnknownAction, "unknown action", nil)
 		return resp
@@ -248,7 +253,7 @@ func TestInitializeAndPrompt_StreamBeforeInitialize(t *testing.T) {
 
 	err := sm.InitializeAndPrompt(ctx, execution, agentConfig, "", nil, nil, func(executionID string) error {
 		return nil
-	}, "", "")
+	}, "", "", nil)
 	if err != nil {
 		t.Fatalf("InitializeAndPrompt failed: %v", err)
 	}
@@ -277,6 +282,74 @@ func TestInitializeAndPrompt_StreamBeforeInitialize(t *testing.T) {
 	if execution.ACPSessionID != "test-session-123" {
 		t.Errorf("expected ACPSessionID 'test-session-123', got %q", execution.ACPSessionID)
 	}
+}
+
+func TestInitializeAndPrompt_AppliesProfileConfigOptions(t *testing.T) {
+	mock := newMockAgentServer(t)
+	defer mock.Close()
+
+	log := newSessionTestLogger()
+	stopCh := newTestStopCh(t)
+	sm := NewSessionManager(log, stopCh)
+	streamMgr := NewStreamManager(log, StreamCallbacks{
+		OnAgentEvent: func(execution *AgentExecution, event agentctl.AgentEvent) {},
+	}, nil, stopCh)
+	cleanupStreamManager(t, stopCh, streamMgr)
+	sm.SetDependencies(nil, streamMgr, nil, nil)
+
+	client := createTestClient(t, mock.server.URL)
+	defer client.Close()
+	execution := &AgentExecution{
+		ID:            "exec-1",
+		TaskID:        "task-1",
+		SessionID:     "session-1",
+		WorkspacePath: "/workspace",
+		agentctl:      client,
+		promptDoneCh:  make(chan PromptCompletionSignal, 1),
+	}
+	agentConfig := &testAgent{
+		id:      "test-agent",
+		enabled: true,
+		runtimeConfig: &agents.RuntimeConfig{
+			Cmd:            agents.NewCommand("test-agent"),
+			Protocol:       agent.ProtocolACP,
+			SessionConfig:  agents.SessionConfig{},
+			ResourceLimits: agents.ResourceLimits{MemoryMB: 512, CPUCores: 0.5, Timeout: time.Hour},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	err := sm.InitializeAndPrompt(ctx, execution, agentConfig, "", nil, nil, func(executionID string) error {
+		return nil
+	}, "sonnet", "plan", map[string]string{
+		"effort": "high",
+		"model":  "ignored",
+		"mode":   "ignored",
+	})
+	if err != nil {
+		t.Fatalf("InitializeAndPrompt failed: %v", err)
+	}
+
+	actions := mock.getActionLog()
+	for _, want := range []string{
+		"agent.session.set_model",
+		"agent.session.set_mode",
+		"agent.session.set_config_option",
+	} {
+		if !containsAction(actions, want) {
+			t.Fatalf("actions = %v, missing %s", actions, want)
+		}
+	}
+}
+
+func containsAction(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestInitializeAndPrompt_StreamTimeout(t *testing.T) {
@@ -331,7 +404,7 @@ func TestInitializeAndPrompt_StreamTimeout(t *testing.T) {
 
 	err = sm.InitializeAndPrompt(ctx, execution, agentConfig, "", nil, nil, func(executionID string) error {
 		return nil
-	}, "", "")
+	}, "", "", nil)
 
 	// Should fail because stream couldn't connect and Initialize fails
 	if err == nil {
@@ -386,7 +459,7 @@ func TestInitializeAndPrompt_WithTaskDescription(t *testing.T) {
 
 	err := sm.InitializeAndPrompt(ctx, execution, agentConfig, "Build a feature", nil, nil, func(executionID string) error {
 		return nil
-	}, "", "")
+	}, "", "", nil)
 	if err != nil {
 		t.Fatalf("InitializeAndPrompt failed: %v", err)
 	}
@@ -454,7 +527,7 @@ func TestInitializeAndPrompt_NoStreamManager(t *testing.T) {
 	// But it should NOT panic due to nil streamManager.
 	err := sm.InitializeAndPrompt(ctx, execution, agentConfig, "", nil, nil, func(executionID string) error {
 		return nil
-	}, "", "")
+	}, "", "", nil)
 
 	// Expect error because Initialize call over WS will fail (stream not connected)
 	if err == nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -442,9 +442,10 @@ type AgentProfileInfo struct {
 	ProfileName         string
 	AgentID             string
 	AgentName           string // e.g., "auggie", "claude", "codex"
-	Model               string // applied via ACP session/set_model at session start
+	Model               string // applied through ACP model selection at session start
 	Mode                string // applied via ACP session/set_mode at session start (empty = use agent default)
-	AllowIndexing       bool   // Deprecated: legacy, kept so existing call sites compile; launch path reads CLIFlags.
+	ConfigOptions       map[string]string
+	AllowIndexing       bool // Deprecated: legacy, kept so existing call sites compile; launch path reads CLIFlags.
 	CLIPassthrough      bool
 	NativeSessionResume bool // Agent supports ACP session/load for resume
 	SupportsMCP         bool

--- a/apps/backend/internal/agent/settings/controller/agent_discovery.go
+++ b/apps/backend/internal/agent/settings/controller/agent_discovery.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/discovery"
+	"github.com/kandev/kandev/internal/agent/hostutility"
 	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/agent/settings/models"
 )
@@ -197,6 +198,7 @@ func (c *Controller) buildModelConfigFromHostUtility(agentID string) dto.ModelCo
 	cfg.DefaultModel = caps.CurrentModelID
 	cfg.CurrentModelID = caps.CurrentModelID
 	cfg.CurrentModeID = caps.CurrentModeID
+	cfg.ConfigOptions = configOptionDTOs(caps.ConfigOptions)
 	for _, m := range caps.Models {
 		cfg.AvailableModels = append(cfg.AvailableModels, dto.ModelEntryDTO{
 			ID:          m.ID,
@@ -221,6 +223,28 @@ func (c *Controller) buildModelConfigFromHostUtility(agentID string) dto.ModelCo
 		})
 	}
 	return cfg
+}
+
+func configOptionDTOs(options []hostutility.ConfigOption) []dto.ConfigOptionDTO {
+	out := make([]dto.ConfigOptionDTO, 0, len(options))
+	for _, opt := range options {
+		choices := make([]dto.ConfigOptionChoiceDTO, 0, len(opt.Options))
+		for _, choice := range opt.Options {
+			choices = append(choices, dto.ConfigOptionChoiceDTO{
+				Value: choice.Value,
+				Name:  choice.Name,
+			})
+		}
+		out = append(out, dto.ConfigOptionDTO{
+			Type:         opt.Type,
+			ID:           opt.ID,
+			Name:         opt.Name,
+			CurrentValue: opt.CurrentValue,
+			Category:     opt.Category,
+			Options:      choices,
+		})
+	}
+	return out
 }
 
 func (c *Controller) EnsureInitialAgentProfiles(ctx context.Context) error {

--- a/apps/backend/internal/agent/settings/controller/controller_test.go
+++ b/apps/backend/internal/agent/settings/controller/controller_test.go
@@ -51,7 +51,7 @@ func (a *testAgent) IsInstalled(ctx context.Context) (*agents.DiscoveryResult, e
 }
 
 // BuildCommand builds a command using runtime config and permission flags.
-// Model/mode are applied via ACP session/set_model at session start, not via CLI.
+// Model/mode are applied through ACP session configuration at session start, not via CLI.
 func (a *testAgent) BuildCommand(opts agents.CommandOptions) agents.Command {
 	rt := a.Runtime()
 	if rt == nil {
@@ -149,7 +149,7 @@ func TestController_PreviewAgentCommand_StandardCommand(t *testing.T) {
 		t.Error("PreviewAgentCommand() Supported = false, want true")
 	}
 
-	// --model is no longer emitted: model is applied via ACP session/set_model.
+	// --model is no longer emitted: model is applied through ACP session configuration.
 	expectedParts := []string{"test-cli", "--verbose", "--yes"}
 	for _, part := range expectedParts {
 		found := false

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -19,6 +19,7 @@ type CreateProfileRequest struct {
 	Name           string
 	Model          string
 	Mode           string
+	ConfigOptions  map[string]string
 	AllowIndexing  bool
 	AutoApprove    bool
 	CLIPassthrough bool
@@ -33,7 +34,7 @@ type CreateProfileRequest struct {
 func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest) (*dto.AgentProfileDTO, error) {
 	// Model is optional — the profile reconciler fills it from the host
 	// utility probe cache on boot, and session start applies it via
-	// session/set_model. An empty model means "use the agent's default".
+	// ACP model selection. An empty model means "use the agent's default".
 	agent, err := c.repo.GetAgent(ctx, req.AgentID)
 	if err != nil {
 		return nil, err
@@ -61,6 +62,7 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 		AgentDisplayName: displayName,
 		Model:            req.Model,
 		Mode:             req.Mode,
+		ConfigOptions:    normalizeProfileConfigOptions(req.ConfigOptions),
 		AllowIndexing:    req.AllowIndexing,
 		AutoApprove:      req.AutoApprove,
 		CLIPassthrough:   req.CLIPassthrough,
@@ -119,6 +121,7 @@ type UpdateProfileRequest struct {
 	Name           *string
 	Model          *string
 	Mode           *string
+	ConfigOptions  *map[string]string
 	AllowIndexing  *bool
 	AutoApprove    *bool
 	CLIPassthrough *bool
@@ -147,6 +150,9 @@ func (c *Controller) UpdateProfile(ctx context.Context, req UpdateProfileRequest
 	}
 	if req.Mode != nil {
 		profile.Mode = *req.Mode
+	}
+	if req.ConfigOptions != nil {
+		profile.ConfigOptions = normalizeProfileConfigOptions(*req.ConfigOptions)
 	}
 	if req.AllowIndexing != nil {
 		profile.AllowIndexing = *req.AllowIndexing
@@ -372,6 +378,7 @@ func toProfileDTO(profile *models.AgentProfile) dto.AgentProfileDTO {
 		AgentDisplayName: profile.AgentDisplayName,
 		Model:            profile.Model,
 		Mode:             profile.Mode,
+		ConfigOptions:    normalizeProfileConfigOptions(profile.ConfigOptions),
 		AllowIndexing:    profile.AllowIndexing,
 		AutoApprove:      profile.AutoApprove,
 		CLIFlags:         cliFlagsToDTO(profile.CLIFlags),
@@ -422,6 +429,25 @@ func envVarsFromDTO(in []dto.ProfileEnvVarDTO) []models.ProfileEnvVar {
 			Value:    ev.Value,
 			SecretID: ev.SecretID,
 		})
+	}
+	return out
+}
+
+func normalizeProfileConfigOptions(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || key == "model" || key == "mode" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/apps/backend/internal/agent/settings/controller/profile_crud.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kandev/kandev/internal/agent/settings/cliflags"
 	"github.com/kandev/kandev/internal/agent/settings/dto"
 	"github.com/kandev/kandev/internal/agent/settings/models"
+	"github.com/kandev/kandev/internal/agent/settings/profileconfig"
 )
 
 type CreateProfileRequest struct {
@@ -62,7 +63,7 @@ func (c *Controller) CreateProfile(ctx context.Context, req CreateProfileRequest
 		AgentDisplayName: displayName,
 		Model:            req.Model,
 		Mode:             req.Mode,
-		ConfigOptions:    normalizeProfileConfigOptions(req.ConfigOptions),
+		ConfigOptions:    profileconfig.SanitizeConfigOptions(req.ConfigOptions),
 		AllowIndexing:    req.AllowIndexing,
 		AutoApprove:      req.AutoApprove,
 		CLIPassthrough:   req.CLIPassthrough,
@@ -152,7 +153,7 @@ func (c *Controller) UpdateProfile(ctx context.Context, req UpdateProfileRequest
 		profile.Mode = *req.Mode
 	}
 	if req.ConfigOptions != nil {
-		profile.ConfigOptions = normalizeProfileConfigOptions(*req.ConfigOptions)
+		profile.ConfigOptions = profileconfig.SanitizeConfigOptions(*req.ConfigOptions)
 	}
 	if req.AllowIndexing != nil {
 		profile.AllowIndexing = *req.AllowIndexing
@@ -378,7 +379,7 @@ func toProfileDTO(profile *models.AgentProfile) dto.AgentProfileDTO {
 		AgentDisplayName: profile.AgentDisplayName,
 		Model:            profile.Model,
 		Mode:             profile.Mode,
-		ConfigOptions:    normalizeProfileConfigOptions(profile.ConfigOptions),
+		ConfigOptions:    profileconfig.SanitizeConfigOptions(profile.ConfigOptions),
 		AllowIndexing:    profile.AllowIndexing,
 		AutoApprove:      profile.AutoApprove,
 		CLIFlags:         cliFlagsToDTO(profile.CLIFlags),
@@ -429,25 +430,6 @@ func envVarsFromDTO(in []dto.ProfileEnvVarDTO) []models.ProfileEnvVar {
 			Value:    ev.Value,
 			SecretID: ev.SecretID,
 		})
-	}
-	return out
-}
-
-func normalizeProfileConfigOptions(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(in))
-	for key, value := range in {
-		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
-		if key == "" || value == "" || key == "model" || key == "mode" {
-			continue
-		}
-		out[key] = value
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }

--- a/apps/backend/internal/agent/settings/controller/profile_crud_test.go
+++ b/apps/backend/internal/agent/settings/controller/profile_crud_test.go
@@ -206,6 +206,51 @@ func TestCreateProfile_PersistsEnvVars(t *testing.T) {
 	}
 }
 
+func TestCreateAndUpdateProfile_PersistsConfigOptions(t *testing.T) {
+	ctrl := newTestController(map[string]agents.Agent{"test-agent": &testAgent{
+		id:          "test-agent",
+		name:        "test-agent",
+		displayName: "Test Agent",
+		enabled:     true,
+	}})
+	st := newFakeStore()
+	agent := &models.Agent{ID: "agent-1", Name: "test-agent"}
+	st.agents[agent.ID] = agent
+	st.byName[agent.Name] = agent
+	ctrl.repo = st
+
+	profile, err := ctrl.CreateProfile(context.Background(), CreateProfileRequest{
+		AgentID: "agent-1",
+		Name:    "With config",
+		ConfigOptions: map[string]string{
+			"effort": " high ",
+			"model":  "ignored",
+			"mode":   "ignored",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	if profile.ConfigOptions["effort"] != "high" || len(profile.ConfigOptions) != 1 {
+		t.Fatalf("response config options: %+v", profile.ConfigOptions)
+	}
+	if len(st.created) != 1 || st.created[0].ConfigOptions["effort"] != "high" || len(st.created[0].ConfigOptions) != 1 {
+		t.Fatalf("stored config options: %+v", st.created)
+	}
+
+	next := map[string]string{"effort": "low"}
+	updated, err := ctrl.UpdateProfile(context.Background(), UpdateProfileRequest{
+		ID:            profile.ID,
+		ConfigOptions: &next,
+	})
+	if err != nil {
+		t.Fatalf("UpdateProfile: %v", err)
+	}
+	if updated.ConfigOptions["effort"] != "low" || len(updated.ConfigOptions) != 1 {
+		t.Fatalf("updated response config options: %+v", updated.ConfigOptions)
+	}
+}
+
 func TestCreateAgentProfiles_PersistsEnvVars(t *testing.T) {
 	ctrl := newTestController(nil)
 	st := newFakeStore()

--- a/apps/backend/internal/agent/settings/dto/dto.go
+++ b/apps/backend/internal/agent/settings/dto/dto.go
@@ -13,6 +13,7 @@ type AgentProfileDTO struct {
 	AgentDisplayName string             `json:"agent_display_name"`
 	Model            string             `json:"model"`
 	Mode             string             `json:"mode,omitempty"`
+	ConfigOptions    map[string]string  `json:"config_options,omitempty"`
 	AllowIndexing    bool               `json:"allow_indexing"` // Deprecated: use CLIFlags. Retained for legacy clients.
 	AutoApprove      bool               `json:"auto_approve"`
 	CLIFlags         []CLIFlagDTO       `json:"cli_flags"`
@@ -129,11 +130,26 @@ type ModelConfigDTO struct {
 	AvailableModes        []ModeEntryDTO    `json:"available_modes,omitempty"`
 	CurrentModeID         string            `json:"current_mode_id,omitempty"`
 	AvailableCommands     []CommandEntryDTO `json:"available_commands,omitempty"`
+	ConfigOptions         []ConfigOptionDTO `json:"config_options,omitempty"`
 	SupportsDynamicModels bool              `json:"supports_dynamic_models"`
 	// Status reflects the host utility probe state for this agent type:
 	// "probing" | "ok" | "auth_required" | "not_installed" | "failed".
 	Status string `json:"status,omitempty"`
 	Error  string `json:"error,omitempty"`
+}
+
+type ConfigOptionDTO struct {
+	Type         string                  `json:"type"`
+	ID           string                  `json:"id"`
+	Name         string                  `json:"name"`
+	CurrentValue string                  `json:"current_value"`
+	Category     string                  `json:"category,omitempty"`
+	Options      []ConfigOptionChoiceDTO `json:"options,omitempty"`
+}
+
+type ConfigOptionChoiceDTO struct {
+	Value string `json:"value"`
+	Name  string `json:"name"`
 }
 
 type PermissionSettingDTO struct {

--- a/apps/backend/internal/agent/settings/handlers/handlers.go
+++ b/apps/backend/internal/agent/settings/handlers/handlers.go
@@ -359,6 +359,7 @@ type createProfileRequest struct {
 	Name           string                 `json:"name"`
 	Model          string                 `json:"model"`
 	Mode           string                 `json:"mode,omitempty"`
+	ConfigOptions  map[string]string      `json:"config_options,omitempty"`
 	AllowIndexing  bool                   `json:"allow_indexing"`
 	AutoApprove    bool                   `json:"auto_approve"`
 	CLIPassthrough bool                   `json:"cli_passthrough"`
@@ -381,6 +382,7 @@ func (h *Handlers) httpCreateProfile(c *gin.Context) {
 		Name:           body.Name,
 		Model:          body.Model,
 		Mode:           body.Mode,
+		ConfigOptions:  body.ConfigOptions,
 		AllowIndexing:  body.AllowIndexing,
 		AutoApprove:    body.AutoApprove,
 		CLIPassthrough: body.CLIPassthrough,
@@ -409,6 +411,7 @@ type updateProfileRequest struct {
 	Name           *string                 `json:"name,omitempty"`
 	Model          *string                 `json:"model,omitempty"`
 	Mode           *string                 `json:"mode,omitempty"`
+	ConfigOptions  *map[string]string      `json:"config_options,omitempty"`
 	AllowIndexing  *bool                   `json:"allow_indexing,omitempty"`
 	AutoApprove    *bool                   `json:"auto_approve,omitempty"`
 	CLIPassthrough *bool                   `json:"cli_passthrough,omitempty"`
@@ -431,6 +434,7 @@ func (h *Handlers) httpUpdateProfile(c *gin.Context) {
 		Name:           body.Name,
 		Model:          body.Model,
 		Mode:           body.Mode,
+		ConfigOptions:  body.ConfigOptions,
 		AllowIndexing:  body.AllowIndexing,
 		AutoApprove:    body.AutoApprove,
 		CLIPassthrough: body.CLIPassthrough,

--- a/apps/backend/internal/agent/settings/models/models.go
+++ b/apps/backend/internal/agent/settings/models/models.go
@@ -41,7 +41,7 @@ type AgentProfile struct {
 	// Values: "api_key" | "subscription".
 	BillingType string `json:"billing_type,omitempty" db:"-"`
 
-	// Model is the ACP model ID applied via session/set_model at session start.
+	// Model is the ACP model ID applied through session model selection at session start.
 	// Validated against the host utility capability cache by the reconciler.
 	Model string `json:"model" db:"model"`
 
@@ -51,6 +51,11 @@ type AgentProfile struct {
 	// conversion via sql.NullString in scan/insert paths, so callers see a
 	// regular string here.
 	Mode string `json:"mode,omitempty" db:"-"`
+
+	// ConfigOptions are dynamic ACP session config options applied through
+	// session/set_config_option at session start. Model and mode stay in their
+	// dedicated fields.
+	ConfigOptions map[string]string `json:"config_options,omitempty" db:"-"`
 
 	// MigratedFrom records the agent_id this profile was migrated from, if any.
 	// Same db:"-" treatment as Mode (nullable column, settings repo handles).

--- a/apps/backend/internal/agent/settings/profileconfig/profileconfig.go
+++ b/apps/backend/internal/agent/settings/profileconfig/profileconfig.go
@@ -1,0 +1,24 @@
+package profileconfig
+
+import "strings"
+
+// SanitizeConfigOptions drops reserved model/mode keys and blank entries so
+// profile config options persist only auxiliary select values.
+func SanitizeConfigOptions(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || key == "model" || key == "mode" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/apps/backend/internal/agent/settings/profileconfig/profileconfig_test.go
+++ b/apps/backend/internal/agent/settings/profileconfig/profileconfig_test.go
@@ -1,0 +1,59 @@
+package profileconfig
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSanitizeConfigOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{name: "nil input returns nil", in: nil, want: nil},
+		{name: "empty returns nil", in: map[string]string{}, want: nil},
+		{
+			name: "reserved model key dropped",
+			in:   map[string]string{"model": "opus", "effort": "high"},
+			want: map[string]string{"effort": "high"},
+		},
+		{
+			name: "reserved mode key dropped",
+			in:   map[string]string{"mode": "plan", "effort": "low"},
+			want: map[string]string{"effort": "low"},
+		},
+		{
+			name: "blank value dropped",
+			in:   map[string]string{"effort": "", "level": "high"},
+			want: map[string]string{"level": "high"},
+		},
+		{
+			name: "blank key dropped",
+			in:   map[string]string{"": "x", "level": "high"},
+			want: map[string]string{"level": "high"},
+		},
+		{
+			name: "whitespace trimmed",
+			in:   map[string]string{" effort ": " high "},
+			want: map[string]string{"effort": "high"},
+		},
+		{
+			name: "all reserved returns nil",
+			in:   map[string]string{"model": "opus", "mode": "plan"},
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SanitizeConfigOptions(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/agent/settings/models"
+	"github.com/kandev/kandev/internal/agent/settings/profileconfig"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/db/dialect"
@@ -593,7 +594,7 @@ func settingsWithConfigOptions(raw string, options map[string]string) (string, e
 	if settings == nil {
 		settings = map[string]json.RawMessage{}
 	}
-	clean := cleanConfigOptions(options)
+	clean := profileconfig.SanitizeConfigOptions(options)
 	if len(clean) == 0 {
 		delete(settings, profileSettingsConfigOptionsKey)
 	} else {
@@ -621,26 +622,7 @@ func configOptionsFromSettings(raw string) map[string]string {
 	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
 		return nil
 	}
-	return cleanConfigOptions(payload.ConfigOptions)
-}
-
-func cleanConfigOptions(options map[string]string) map[string]string {
-	if len(options) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(options))
-	for key, value := range options {
-		key = strings.TrimSpace(key)
-		value = strings.TrimSpace(value)
-		if key == "" || value == "" || key == "model" || key == "mode" {
-			continue
-		}
-		out[key] = value
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
+	return profileconfig.SanitizeConfigOptions(payload.ConfigOptions)
 }
 
 // normalizeJSONArray returns "[]" for empty values; otherwise the input. Used

--- a/apps/backend/internal/agent/settings/store/sqlite.go
+++ b/apps/backend/internal/agent/settings/store/sqlite.go
@@ -553,6 +553,10 @@ func enrichmentValues(profile *models.AgentProfile) (profileEnrichmentValues, er
 	if settings == "" {
 		settings = "{}"
 	}
+	settings, err := settingsWithConfigOptions(settings, profile.ConfigOptions)
+	if err != nil {
+		return profileEnrichmentValues{}, err
+	}
 	permissions := profile.Permissions
 	if permissions == "" {
 		permissions = "{}"
@@ -573,6 +577,70 @@ func enrichmentValues(profile *models.AgentProfile) (profileEnrichmentValues, er
 		settings:              settings,
 		permissions:           permissions,
 	}, nil
+}
+
+const profileSettingsConfigOptionsKey = "config_options"
+
+func settingsWithConfigOptions(raw string, options map[string]string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		raw = "{}"
+	}
+	var settings map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &settings); err != nil {
+		return "", fmt.Errorf("parse profile settings: %w", err)
+	}
+	if settings == nil {
+		settings = map[string]json.RawMessage{}
+	}
+	clean := cleanConfigOptions(options)
+	if len(clean) == 0 {
+		delete(settings, profileSettingsConfigOptionsKey)
+	} else {
+		data, err := json.Marshal(clean)
+		if err != nil {
+			return "", fmt.Errorf("marshal profile config options: %w", err)
+		}
+		settings[profileSettingsConfigOptionsKey] = data
+	}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return "", fmt.Errorf("marshal profile settings: %w", err)
+	}
+	return string(data), nil
+}
+
+func configOptionsFromSettings(raw string) map[string]string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var payload struct {
+		ConfigOptions map[string]string `json:"config_options"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil
+	}
+	return cleanConfigOptions(payload.ConfigOptions)
+}
+
+func cleanConfigOptions(options map[string]string) map[string]string {
+	if len(options) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(options))
+	for key, value := range options {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || key == "model" || key == "mode" {
+			continue
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // normalizeJSONArray returns "[]" for empty values; otherwise the input. Used
@@ -975,6 +1043,7 @@ func scanAgentProfile(scanner interface {
 	profile.SkipIdleRuns = skipIdleRuns == 1
 	profile.Role = models.AgentRole(role)
 	profile.Status = models.AgentStatus(status)
+	profile.ConfigOptions = configOptionsFromSettings(profile.Settings)
 	if failureThreshold > 0 {
 		ft := failureThreshold
 		profile.FailureThreshold = &ft

--- a/apps/backend/internal/agent/settings/store/sqlite_enrichment_test.go
+++ b/apps/backend/internal/agent/settings/store/sqlite_enrichment_test.go
@@ -158,6 +158,78 @@ func TestEnrichment_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestProfileConfigOptions_RoundTripInSettings(t *testing.T) {
+	db, err := sqlx.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo, err := newSQLiteRepository(db, db, nil, false)
+	if err != nil {
+		t.Fatalf("newSQLiteRepository: %v", err)
+	}
+
+	ctx := context.Background()
+	agent := &models.Agent{Name: "claude-acp"}
+	if err := repo.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	profile := &models.AgentProfile{
+		AgentID:          agent.ID,
+		Name:             "profile",
+		AgentDisplayName: "Claude",
+		Model:            "sonnet",
+		Settings:         `{"office":"kept"}`,
+		ConfigOptions: map[string]string{
+			"effort": "high",
+			"model":  "ignored",
+			"mode":   "ignored",
+		},
+	}
+	if err := repo.CreateAgentProfile(ctx, profile); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+
+	got, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if got.ConfigOptions["effort"] != "high" || len(got.ConfigOptions) != 1 {
+		t.Fatalf("config options = %+v, want only effort=high", got.ConfigOptions)
+	}
+	if got.Settings != `{"config_options":{"effort":"high"},"office":"kept"}` {
+		t.Fatalf("settings = %s", got.Settings)
+	}
+
+	got.ConfigOptions = map[string]string{"effort": "low"}
+	if err := repo.UpdateAgentProfile(ctx, got); err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+	updated, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("get updated profile: %v", err)
+	}
+	if updated.ConfigOptions["effort"] != "low" || len(updated.ConfigOptions) != 1 {
+		t.Fatalf("updated config options = %+v, want only effort=low", updated.ConfigOptions)
+	}
+
+	updated.ConfigOptions = nil
+	if err := repo.UpdateAgentProfile(ctx, updated); err != nil {
+		t.Fatalf("clear config options: %v", err)
+	}
+	cleared, err := repo.GetAgentProfile(ctx, profile.ID)
+	if err != nil {
+		t.Fatalf("get cleared profile: %v", err)
+	}
+	if len(cleared.ConfigOptions) != 0 {
+		t.Fatalf("cleared config options = %+v, want empty", cleared.ConfigOptions)
+	}
+	if cleared.Settings != `{"office":"kept"}` {
+		t.Fatalf("cleared settings = %s", cleared.Settings)
+	}
+}
+
 // TestEnrichment_Migration_LegacyDB verifies that adding the new enrichment
 // columns on an existing database with the legacy CHECK(model != ”)
 // constraint does not regress existing reads. The legacy DB has rows that

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
@@ -608,42 +608,14 @@ func (a *Adapter) SetModel(ctx context.Context, modelID string) error {
 	return nil
 }
 
-type sessionModelConn interface {
-	SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error)
-	UnstableSetSessionModel(context.Context, acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error)
-}
-
-type sdkSessionModelApplier struct {
-	conn sessionModelConn
-}
-
-func (a sdkSessionModelApplier) SetConfigOption(ctx context.Context, sessionID, configID, value string) error {
-	_, err := a.conn.SetSessionConfigOption(ctx, acp.SetSessionConfigOptionRequest{
-		ValueId: &acp.SetSessionConfigOptionValueId{
-			SessionId: acp.SessionId(sessionID),
-			ConfigId:  acp.SessionConfigId(configID),
-			Value:     acp.SessionConfigValueId(value),
-		},
-	})
-	return err
-}
-
-func (a sdkSessionModelApplier) SetModel(ctx context.Context, sessionID, modelID string) error {
-	_, err := a.conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
-		SessionId: acp.SessionId(sessionID),
-		ModelId:   acp.UnstableModelId(modelID),
-	})
-	return err
-}
-
 func applySessionModel(
 	ctx context.Context,
-	conn sessionModelConn,
+	conn sessionmodel.SDKConn,
 	sessionID string,
 	modelID string,
 	configOptions []streams.ConfigOption,
 ) (sessionmodel.Method, error) {
-	return sessionmodel.Apply(ctx, sdkSessionModelApplier{conn: conn}, sessionmodel.Request{
+	return sessionmodel.ApplySDK(ctx, conn, sessionmodel.Request{
 		SessionID:     sessionID,
 		ModelID:       modelID,
 		ConfigOptions: sessionmodel.FromStreams(configOptions),

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coder/acp-go-sdk"
 	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
+	"github.com/kandev/kandev/internal/agentctl/sessionmodel"
 	"github.com/kandev/kandev/internal/agentctl/types"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 	"github.com/kandev/kandev/internal/common/logger"
@@ -564,7 +565,7 @@ func (a *Adapter) SetMode(ctx context.Context, modeID string) error {
 	return nil
 }
 
-// SetModel changes the agent's model via ACP session/set_model (unstable SDK method).
+// SetModel changes the agent's model via the ACP mechanism advertised by session/new.
 // If the model ID doesn't exist in the agent's available models, the call is skipped to avoid 404.
 func (a *Adapter) SetModel(ctx context.Context, modelID string) error {
 	// Snapshot sessionID + cached state under a single RLock so the
@@ -598,16 +599,55 @@ func (a *Adapter) SetModel(ctx context.Context, modelID string) error {
 		}
 	}
 
-	_, err := conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
-		SessionId: acp.SessionId(sessionID),
-		ModelId:   acp.UnstableModelId(modelID),
-	})
+	method, err := applySessionModel(ctx, conn, sessionID, modelID, cachedConfig)
 	if err != nil {
-		return fmt.Errorf("set session model failed: %w", err)
+		return fmt.Errorf("set session model failed via %s: %w", method, err)
 	}
 	a.resetContextWindowMaxSize(sessionID)
 	a.emitSetModelEvent(sessionID, modelID, available, cachedConfig)
 	return nil
+}
+
+type sessionModelConn interface {
+	SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error)
+	UnstableSetSessionModel(context.Context, acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error)
+}
+
+type sdkSessionModelApplier struct {
+	conn sessionModelConn
+}
+
+func (a sdkSessionModelApplier) SetConfigOption(ctx context.Context, sessionID, configID, value string) error {
+	_, err := a.conn.SetSessionConfigOption(ctx, acp.SetSessionConfigOptionRequest{
+		ValueId: &acp.SetSessionConfigOptionValueId{
+			SessionId: acp.SessionId(sessionID),
+			ConfigId:  acp.SessionConfigId(configID),
+			Value:     acp.SessionConfigValueId(value),
+		},
+	})
+	return err
+}
+
+func (a sdkSessionModelApplier) SetModel(ctx context.Context, sessionID, modelID string) error {
+	_, err := a.conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
+		SessionId: acp.SessionId(sessionID),
+		ModelId:   acp.UnstableModelId(modelID),
+	})
+	return err
+}
+
+func applySessionModel(
+	ctx context.Context,
+	conn sessionModelConn,
+	sessionID string,
+	modelID string,
+	configOptions []streams.ConfigOption,
+) (sessionmodel.Method, error) {
+	return sessionmodel.Apply(ctx, sdkSessionModelApplier{conn: conn}, sessionmodel.Request{
+		SessionID:     sessionID,
+		ModelID:       modelID,
+		ConfigOptions: sessionmodel.FromStreams(configOptions),
+	})
 }
 
 // maybeEmitAuthRequired inspects an ACP error and, if it represents an

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/model_apply_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/model_apply_test.go
@@ -1,0 +1,68 @@
+package acp
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	sdk "github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+type fakeModelApplier struct {
+	configErr error
+	modelErr  error
+	calls     []string
+}
+
+func (f *fakeModelApplier) SetSessionConfigOption(_ context.Context, req sdk.SetSessionConfigOptionRequest) (sdk.SetSessionConfigOptionResponse, error) {
+	f.calls = append(f.calls, "config:"+string(req.ValueId.ConfigId)+":"+string(req.ValueId.Value))
+	return sdk.SetSessionConfigOptionResponse{}, f.configErr
+}
+
+func (f *fakeModelApplier) UnstableSetSessionModel(_ context.Context, req sdk.UnstableSetSessionModelRequest) (sdk.UnstableSetSessionModelResponse, error) {
+	f.calls = append(f.calls, "model:"+string(req.ModelId))
+	return sdk.UnstableSetSessionModelResponse{}, f.modelErr
+}
+
+func TestApplySessionModel_UsesConfigOptionForModelConfig(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeModelApplier{}
+	method, err := applySessionModel(context.Background(), conn, "sess-1", "gpt-5.4-mini", []streams.ConfigOption{{
+		ID:       "model",
+		Category: "model",
+	}})
+
+	if err != nil {
+		t.Fatalf("applySessionModel() error = %v", err)
+	}
+	if method != "session/set_config_option" {
+		t.Fatalf("method = %q, want session/set_config_option", method)
+	}
+	wantCalls := []string{"config:model:gpt-5.4-mini"}
+	if !reflect.DeepEqual(conn.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", conn.calls, wantCalls)
+	}
+}
+
+func TestApplySessionModel_FallsBackToSetModelWhenSetConfigOptionMissing(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeModelApplier{configErr: sdk.NewMethodNotFound(sdk.AgentMethodSessionSetConfigOption)}
+	method, err := applySessionModel(context.Background(), conn, "sess-1", "claude-opus-4-8", []streams.ConfigOption{{
+		ID:       "model",
+		Category: "model",
+	}})
+
+	if err != nil {
+		t.Fatalf("applySessionModel() error = %v", err)
+	}
+	if method != "session/set_model" {
+		t.Fatalf("method = %q, want session/set_model", method)
+	}
+	wantCalls := []string{"config:model:claude-opus-4-8", "model:claude-opus-4-8"}
+	if !reflect.DeepEqual(conn.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", conn.calls, wantCalls)
+	}
+}

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -221,46 +221,14 @@ func (e *ACPInferenceExecutor) executeACPSession(
 	return result, nil
 }
 
-type sessionModelConn interface {
-	SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error)
-	UnstableSetSessionModel(context.Context, acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error)
-}
-
-type sdkSessionModelApplier struct {
-	conn sessionModelConn
-}
-
-func (a sdkSessionModelApplier) SetConfigOption(ctx context.Context, sessionID, configID, value string) error {
-	_, err := a.conn.SetSessionConfigOption(ctx, acp.SetSessionConfigOptionRequest{
-		ValueId: &acp.SetSessionConfigOptionValueId{
-			SessionId: acp.SessionId(sessionID),
-			ConfigId:  acp.SessionConfigId(configID),
-			Value:     acp.SessionConfigValueId(value),
-		},
-	})
-	return err
-}
-
-func (a sdkSessionModelApplier) SetModel(ctx context.Context, sessionID, modelID string) error {
-	_, err := a.conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
-		SessionId: acp.SessionId(sessionID),
-		ModelId:   acp.UnstableModelId(modelID),
-	})
-	return err
-}
-
 func applySessionModel(
 	ctx context.Context,
-	conn sessionModelConn,
+	conn sessionmodel.SDKConn,
 	sessionID acp.SessionId,
 	model string,
 	configOptions []acp.SessionConfigOption,
 ) (sessionmodel.Method, error) {
-	return sessionmodel.Apply(ctx, sdkSessionModelApplier{conn: conn}, sessionmodel.Request{
-		SessionID:     string(sessionID),
-		ModelID:       model,
-		ConfigOptions: sessionmodel.FromACP(configOptions),
-	})
+	return sessionmodel.ApplySDKFromACP(ctx, conn, string(sessionID), model, configOptions)
 }
 
 // toACPMcpServers converts the cross-process DTO list into the ACP SDK shape.

--- a/apps/backend/internal/agentctl/server/utility/acp_executor.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor.go
@@ -16,6 +16,7 @@ import (
 
 	acp "github.com/coder/acp-go-sdk"
 	acpclient "github.com/kandev/kandev/internal/agentctl/server/acp"
+	"github.com/kandev/kandev/internal/agentctl/sessionmodel"
 	"go.uber.org/zap"
 )
 
@@ -185,14 +186,12 @@ func (e *ACPInferenceExecutor) executeACPSession(
 	sessionID := sessionResp.SessionId
 
 	// Optionally set the session model before prompting. ACP-first agents
-	// declare no CLI ModelFlag, so `--model` is not appended at spawn time;
-	// the model has to be applied over the ACP protocol here.
+	// declare no CLI ModelFlag, so `--model` is not appended at spawn time.
+	// Model selection may be a model-shaped config option (Codex/Cursor) or
+	// the older unstable session/set_model method, depending on the agent.
 	if model != "" {
-		if _, err := conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
-			SessionId: sessionID,
-			ModelId:   acp.UnstableModelId(model),
-		}); err != nil {
-			return "", fmt.Errorf("ACP session/set_model failed: %w", err)
+		if _, err := applySessionModel(ctx, conn, sessionID, model, sessionResp.ConfigOptions); err != nil {
+			return "", fmt.Errorf("ACP model selection failed: %w", err)
 		}
 	}
 
@@ -220,6 +219,48 @@ func (e *ACPInferenceExecutor) executeACPSession(
 	mu.Unlock()
 
 	return result, nil
+}
+
+type sessionModelConn interface {
+	SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error)
+	UnstableSetSessionModel(context.Context, acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error)
+}
+
+type sdkSessionModelApplier struct {
+	conn sessionModelConn
+}
+
+func (a sdkSessionModelApplier) SetConfigOption(ctx context.Context, sessionID, configID, value string) error {
+	_, err := a.conn.SetSessionConfigOption(ctx, acp.SetSessionConfigOptionRequest{
+		ValueId: &acp.SetSessionConfigOptionValueId{
+			SessionId: acp.SessionId(sessionID),
+			ConfigId:  acp.SessionConfigId(configID),
+			Value:     acp.SessionConfigValueId(value),
+		},
+	})
+	return err
+}
+
+func (a sdkSessionModelApplier) SetModel(ctx context.Context, sessionID, modelID string) error {
+	_, err := a.conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
+		SessionId: acp.SessionId(sessionID),
+		ModelId:   acp.UnstableModelId(modelID),
+	})
+	return err
+}
+
+func applySessionModel(
+	ctx context.Context,
+	conn sessionModelConn,
+	sessionID acp.SessionId,
+	model string,
+	configOptions []acp.SessionConfigOption,
+) (sessionmodel.Method, error) {
+	return sessionmodel.Apply(ctx, sdkSessionModelApplier{conn: conn}, sessionmodel.Request{
+		SessionID:     string(sessionID),
+		ModelID:       model,
+		ConfigOptions: sessionmodel.FromACP(configOptions),
+	})
 }
 
 // toACPMcpServers converts the cross-process DTO list into the ACP SDK shape.
@@ -544,6 +585,7 @@ func buildInitProbeFields(initResp acp.InitializeResponse) *ProbeResponse {
 // legacy fields first, then fall back to configOptions when they are absent
 // so both shapes work.
 func applySessionProbeFields(out *ProbeResponse, sessionResp acp.NewSessionResponse) {
+	out.ConfigOptions = probeConfigOptions(sessionResp.ConfigOptions)
 	if sessionResp.Models != nil {
 		out.CurrentModelID = string(sessionResp.Models.CurrentModelId)
 		for _, m := range sessionResp.Models.AvailableModels {
@@ -577,6 +619,33 @@ func applySessionProbeFields(out *ProbeResponse, sessionResp acp.NewSessionRespo
 	if sessionResp.Modes == nil {
 		applyConfigOptionsAsModes(out, sessionResp.ConfigOptions)
 	}
+}
+
+func probeConfigOptions(opts []acp.SessionConfigOption) []ProbeConfigOption {
+	out := make([]ProbeConfigOption, 0, len(opts))
+	for _, opt := range opts {
+		sel := opt.Select
+		if sel == nil {
+			continue
+		}
+		config := ProbeConfigOption{
+			Type:         sel.Type,
+			ID:           string(sel.Id),
+			Name:         sel.Name,
+			CurrentValue: string(sel.CurrentValue),
+		}
+		if sel.Category != nil {
+			config.Category = string(*sel.Category)
+		}
+		for _, item := range selectOptionsUngrouped(sel.Options) {
+			config.Options = append(config.Options, ProbeConfigOptionChoice{
+				Value: string(item.Value),
+				Name:  item.Name,
+			})
+		}
+		out = append(out, config)
+	}
+	return out
 }
 
 // applyConfigOptionsAsModels extracts a ProbeModel list from any
@@ -680,7 +749,7 @@ func resolveProbeCommand(name string) string {
 
 // buildACPCommand builds the command arguments for ACP inference. The model
 // parameter is a no-op for ACP-first agents (they have no ModelFlag); model
-// selection is applied via the ACP session/set_model protocol call instead.
+// selection is applied through the ACP session after session/new instead.
 func buildACPCommand(cfg *InferenceConfigDTO, model string) []string {
 	args := make([]string, len(cfg.Command))
 	copy(args, cfg.Command)

--- a/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
+++ b/apps/backend/internal/agentctl/server/utility/acp_executor_test.go
@@ -195,6 +195,7 @@ func TestApplySessionProbeFields_FallsBackToConfigOptions(t *testing.T) {
 	t.Parallel()
 
 	modelCat := acp.SessionConfigOptionCategoryModel
+	thoughtCat := acp.SessionConfigOptionCategoryThoughtLevel
 	resp := acp.NewSessionResponse{
 		ConfigOptions: []acp.SessionConfigOption{
 			{Select: &acp.SessionConfigOptionSelect{
@@ -206,6 +207,18 @@ func TestApplySessionProbeFields_FallsBackToConfigOptions(t *testing.T) {
 					{Value: "default", Name: "Default (recommended)", Description: ptr("Sonnet 4.6")},
 					{Value: "opus", Name: "Opus", Description: ptr("Opus 4.7")},
 					{Value: "haiku", Name: "Haiku"},
+				}},
+				Type: "select",
+			}},
+			{Select: &acp.SessionConfigOptionSelect{
+				Category:     &thoughtCat,
+				CurrentValue: "medium",
+				Id:           "reasoning_effort",
+				Name:         "Reasoning effort",
+				Options: acp.SessionConfigSelectOptions{Ungrouped: &acp.SessionConfigSelectOptionsUngrouped{
+					{Value: "low", Name: "Low"},
+					{Value: "medium", Name: "Medium"},
+					{Value: "high", Name: "High"},
 				}},
 				Type: "select",
 			}},
@@ -226,6 +239,15 @@ func TestApplySessionProbeFields_FallsBackToConfigOptions(t *testing.T) {
 	}
 	if got, want := out.Models[0].Description, "Sonnet 4.6"; got != want {
 		t.Fatalf("Models[0].Description = %q, want %q", got, want)
+	}
+	if got, want := len(out.ConfigOptions), 2; got != want {
+		t.Fatalf("len(ConfigOptions) = %d, want %d", got, want)
+	}
+	if got, want := out.ConfigOptions[1].ID, "reasoning_effort"; got != want {
+		t.Fatalf("ConfigOptions[1].ID = %q, want %q", got, want)
+	}
+	if got, want := out.ConfigOptions[1].Options[2].Name, "High"; got != want {
+		t.Fatalf("ConfigOptions[1].Options[2].Name = %q, want %q", got, want)
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/utility/model_apply_test.go
+++ b/apps/backend/internal/agentctl/server/utility/model_apply_test.go
@@ -1,0 +1,66 @@
+package utility
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	acp "github.com/coder/acp-go-sdk"
+)
+
+type fakeModelConn struct {
+	calls []string
+}
+
+func (f *fakeModelConn) SetSessionConfigOption(_ context.Context, req acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	f.calls = append(f.calls, "config:"+string(req.ValueId.ConfigId)+":"+string(req.ValueId.Value))
+	return acp.SetSessionConfigOptionResponse{}, nil
+}
+
+func (f *fakeModelConn) UnstableSetSessionModel(_ context.Context, req acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error) {
+	f.calls = append(f.calls, "model:"+string(req.ModelId))
+	return acp.UnstableSetSessionModelResponse{}, nil
+}
+
+func TestApplySessionModel_UsesConfigOptionWhenSessionAdvertisesModelOption(t *testing.T) {
+	t.Parallel()
+
+	modelCat := acp.SessionConfigOptionCategoryModel
+	conn := &fakeModelConn{}
+	method, err := applySessionModel(context.Background(), conn, "sess-1", "gpt-5.4-mini", []acp.SessionConfigOption{
+		{Select: &acp.SessionConfigOptionSelect{
+			Id:       "model",
+			Category: &modelCat,
+			Type:     "select",
+		}},
+	})
+
+	if err != nil {
+		t.Fatalf("applySessionModel() error = %v", err)
+	}
+	if method != "session/set_config_option" {
+		t.Fatalf("method = %q, want session/set_config_option", method)
+	}
+	wantCalls := []string{"config:model:gpt-5.4-mini"}
+	if !reflect.DeepEqual(conn.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", conn.calls, wantCalls)
+	}
+}
+
+func TestApplySessionModel_UsesSetModelWithoutModelConfigOption(t *testing.T) {
+	t.Parallel()
+
+	conn := &fakeModelConn{}
+	method, err := applySessionModel(context.Background(), conn, "sess-1", "legacy-model", nil)
+
+	if err != nil {
+		t.Fatalf("applySessionModel() error = %v", err)
+	}
+	if method != "session/set_model" {
+		t.Fatalf("method = %q, want session/set_model", method)
+	}
+	wantCalls := []string{"model:legacy-model"}
+	if !reflect.DeepEqual(conn.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", conn.calls, wantCalls)
+	}
+}

--- a/apps/backend/internal/agentctl/server/utility/types.go
+++ b/apps/backend/internal/agentctl/server/utility/types.go
@@ -97,6 +97,9 @@ type ProbeResponse struct {
 	// CurrentModeID is the default/current mode selected by the agent.
 	CurrentModeID string `json:"current_mode_id,omitempty"`
 
+	// ConfigOptions are select-style session options advertised by session/new.
+	ConfigOptions []ProbeConfigOption `json:"config_options,omitempty"`
+
 	// Commands are the slash commands the agent advertises via the
 	// `available_commands_update` session notification (drained briefly
 	// after session/new).
@@ -132,6 +135,20 @@ type ProbeMode struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	Meta        map[string]any `json:"meta,omitempty"`
+}
+
+type ProbeConfigOption struct {
+	Type         string                    `json:"type"`
+	ID           string                    `json:"id"`
+	Name         string                    `json:"name"`
+	CurrentValue string                    `json:"current_value"`
+	Category     string                    `json:"category,omitempty"`
+	Options      []ProbeConfigOptionChoice `json:"options,omitempty"`
+}
+
+type ProbeConfigOptionChoice struct {
+	Value string `json:"value"`
+	Name  string `json:"name"`
 }
 
 // ProbeCommand is a single slash command advertised by the agent via the

--- a/apps/backend/internal/agentctl/sessionmodel/sessionmodel.go
+++ b/apps/backend/internal/agentctl/sessionmodel/sessionmodel.go
@@ -42,6 +42,56 @@ type Applier interface {
 	SetModel(ctx context.Context, sessionID, modelID string) error
 }
 
+// SDKConn is the subset of the ACP SDK connection used to apply model changes.
+type SDKConn interface {
+	SetSessionConfigOption(context.Context, acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error)
+	UnstableSetSessionModel(context.Context, acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error)
+}
+
+// SDKApplier applies model changes through a typed ACP SDK connection.
+type SDKApplier struct {
+	Conn SDKConn
+}
+
+func (a SDKApplier) SetConfigOption(ctx context.Context, sessionID, configID, value string) error {
+	_, err := a.Conn.SetSessionConfigOption(ctx, acp.SetSessionConfigOptionRequest{
+		ValueId: &acp.SetSessionConfigOptionValueId{
+			SessionId: acp.SessionId(sessionID),
+			ConfigId:  acp.SessionConfigId(configID),
+			Value:     acp.SessionConfigValueId(value),
+		},
+	})
+	return err
+}
+
+func (a SDKApplier) SetModel(ctx context.Context, sessionID, modelID string) error {
+	_, err := a.Conn.UnstableSetSessionModel(ctx, acp.UnstableSetSessionModelRequest{
+		SessionId: acp.SessionId(sessionID),
+		ModelId:   acp.UnstableModelId(modelID),
+	})
+	return err
+}
+
+// ApplySDK applies a model change through the ACP SDK connection.
+func ApplySDK(ctx context.Context, conn SDKConn, req Request) (Method, error) {
+	return Apply(ctx, SDKApplier{Conn: conn}, req)
+}
+
+// ApplySDKFromACP applies a model change using typed session config options.
+func ApplySDKFromACP(
+	ctx context.Context,
+	conn SDKConn,
+	sessionID string,
+	modelID string,
+	configOptions []acp.SessionConfigOption,
+) (Method, error) {
+	return ApplySDK(ctx, conn, Request{
+		SessionID:     sessionID,
+		ModelID:       modelID,
+		ConfigOptions: FromACP(configOptions),
+	})
+}
+
 // Apply chooses the model-switching mechanism supported by the session. Agents
 // that expose a model-shaped config option (Codex, Cursor, recent Claude) are
 // configured through session/set_config_option. If that RPC is not implemented,

--- a/apps/backend/internal/agentctl/sessionmodel/sessionmodel.go
+++ b/apps/backend/internal/agentctl/sessionmodel/sessionmodel.go
@@ -1,0 +1,110 @@
+// Package sessionmodel centralizes ACP model selection across long-lived
+// sessions and sessionless utility prompts.
+package sessionmodel
+
+import (
+	"context"
+	"errors"
+
+	acp "github.com/coder/acp-go-sdk"
+	"github.com/kandev/kandev/internal/agentctl/types/streams"
+)
+
+const modelConfigOption = "model"
+
+// Method is the ACP mechanism used to apply a requested model.
+type Method string
+
+const (
+	MethodNone            Method = ""
+	MethodSetModel        Method = "session/set_model"
+	MethodSetConfigOption Method = "session/set_config_option"
+)
+
+// ConfigOption is the subset of ACP session config options needed to decide
+// how a model should be applied.
+type ConfigOption struct {
+	ID       string
+	Category string
+}
+
+// Request describes a requested model change.
+type Request struct {
+	SessionID     string
+	ModelID       string
+	ConfigOptions []ConfigOption
+}
+
+// Applier performs the actual ACP calls. Implementations wrap either the ACP
+// SDK connection or the agentctl websocket client.
+type Applier interface {
+	SetConfigOption(ctx context.Context, sessionID, configID, value string) error
+	SetModel(ctx context.Context, sessionID, modelID string) error
+}
+
+// Apply chooses the model-switching mechanism supported by the session. Agents
+// that expose a model-shaped config option (Codex, Cursor, recent Claude) are
+// configured through session/set_config_option. If that RPC is not implemented,
+// we fall back to the older unstable session/set_model call.
+func Apply(ctx context.Context, applier Applier, req Request) (Method, error) {
+	if req.ModelID == "" {
+		return MethodNone, nil
+	}
+	if configID, ok := modelConfigID(req.ConfigOptions); ok {
+		if err := applier.SetConfigOption(ctx, req.SessionID, configID, req.ModelID); err != nil {
+			if !IsMethodNotFound(err) {
+				return MethodSetConfigOption, err
+			}
+		} else {
+			return MethodSetConfigOption, nil
+		}
+	}
+	if err := applier.SetModel(ctx, req.SessionID, req.ModelID); err != nil {
+		return MethodSetModel, err
+	}
+	return MethodSetModel, nil
+}
+
+// FromACP converts typed ACP SDK options to the shared strategy shape.
+func FromACP(opts []acp.SessionConfigOption) []ConfigOption {
+	out := make([]ConfigOption, 0, len(opts))
+	for _, opt := range opts {
+		if opt.Select == nil {
+			continue
+		}
+		co := ConfigOption{ID: string(opt.Select.Id)}
+		if opt.Select.Category != nil {
+			co.Category = string(*opt.Select.Category)
+		}
+		out = append(out, co)
+	}
+	return out
+}
+
+// FromStreams converts normalized stream config options to the shared strategy shape.
+func FromStreams(opts []streams.ConfigOption) []ConfigOption {
+	out := make([]ConfigOption, 0, len(opts))
+	for _, opt := range opts {
+		out = append(out, ConfigOption{ID: opt.ID, Category: opt.Category})
+	}
+	return out
+}
+
+func modelConfigID(opts []ConfigOption) (string, bool) {
+	for _, opt := range opts {
+		if opt.ID != modelConfigOption && opt.Category != modelConfigOption {
+			continue
+		}
+		if opt.ID != "" {
+			return opt.ID, true
+		}
+		return modelConfigOption, true
+	}
+	return "", false
+}
+
+// IsMethodNotFound reports JSON-RPC -32601 failures, even when wrapped by a caller.
+func IsMethodNotFound(err error) bool {
+	var reqErr *acp.RequestError
+	return errors.As(err, &reqErr) && reqErr.Code == -32601
+}

--- a/apps/backend/internal/agentctl/sessionmodel/sessionmodel_test.go
+++ b/apps/backend/internal/agentctl/sessionmodel/sessionmodel_test.go
@@ -1,0 +1,124 @@
+package sessionmodel
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	acp "github.com/coder/acp-go-sdk"
+)
+
+type fakeApplier struct {
+	configErr error
+	modelErr  error
+	calls     []string
+}
+
+func (f *fakeApplier) SetConfigOption(_ context.Context, _ string, configID, value string) error {
+	f.calls = append(f.calls, "config:"+configID+":"+value)
+	return f.configErr
+}
+
+func (f *fakeApplier) SetModel(_ context.Context, _, modelID string) error {
+	f.calls = append(f.calls, "model:"+modelID)
+	return f.modelErr
+}
+
+func TestApply_PrefersModelConfigOption(t *testing.T) {
+	t.Parallel()
+
+	applier := &fakeApplier{}
+	method, err := Apply(context.Background(), applier, Request{
+		SessionID: "sess-1",
+		ModelID:   "gpt-5.4-mini",
+		ConfigOptions: []ConfigOption{{
+			ID:       "model",
+			Category: "model",
+		}},
+	})
+
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if method != MethodSetConfigOption {
+		t.Fatalf("method = %q, want %q", method, MethodSetConfigOption)
+	}
+	wantCalls := []string{"config:model:gpt-5.4-mini"}
+	if !reflect.DeepEqual(applier.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", applier.calls, wantCalls)
+	}
+}
+
+func TestApply_FallsBackToSetModelWhenConfigOptionMethodMissing(t *testing.T) {
+	t.Parallel()
+
+	applier := &fakeApplier{configErr: acp.NewMethodNotFound(acp.AgentMethodSessionSetConfigOption)}
+	method, err := Apply(context.Background(), applier, Request{
+		SessionID: "sess-1",
+		ModelID:   "claude-opus-4-8",
+		ConfigOptions: []ConfigOption{{
+			ID:       "model",
+			Category: "model",
+		}},
+	})
+
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if method != MethodSetModel {
+		t.Fatalf("method = %q, want %q", method, MethodSetModel)
+	}
+	wantCalls := []string{"config:model:claude-opus-4-8", "model:claude-opus-4-8"}
+	if !reflect.DeepEqual(applier.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", applier.calls, wantCalls)
+	}
+}
+
+func TestApply_UsesSetModelWhenNoModelConfigOption(t *testing.T) {
+	t.Parallel()
+
+	applier := &fakeApplier{}
+	method, err := Apply(context.Background(), applier, Request{
+		SessionID:     "sess-1",
+		ModelID:       "legacy-model",
+		ConfigOptions: []ConfigOption{{ID: "mode", Category: "mode"}},
+	})
+
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if method != MethodSetModel {
+		t.Fatalf("method = %q, want %q", method, MethodSetModel)
+	}
+	wantCalls := []string{"model:legacy-model"}
+	if !reflect.DeepEqual(applier.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", applier.calls, wantCalls)
+	}
+}
+
+func TestApply_DoesNotFallbackForInvalidConfigOptionValue(t *testing.T) {
+	t.Parallel()
+
+	invalid := acp.NewInvalidParams(map[string]any{"message": "Invalid model value"})
+	applier := &fakeApplier{configErr: invalid}
+	method, err := Apply(context.Background(), applier, Request{
+		SessionID: "sess-1",
+		ModelID:   "claude-haiku-4-5",
+		ConfigOptions: []ConfigOption{{
+			ID:       "model",
+			Category: "model",
+		}},
+	})
+
+	if !errors.Is(err, invalid) {
+		t.Fatalf("Apply() error = %v, want %v", err, invalid)
+	}
+	if method != MethodSetConfigOption {
+		t.Fatalf("method = %q, want %q", method, MethodSetConfigOption)
+	}
+	wantCalls := []string{"config:model:claude-haiku-4-5"}
+	if !reflect.DeepEqual(applier.calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", applier.calls, wantCalls)
+	}
+}

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -135,7 +135,7 @@ type AgentManagerClient interface {
 	// For other agents, this falls back to RestartAgentProcess.
 	ResetAgentContext(ctx context.Context, agentExecutionID string) error
 
-	// SetSessionModelBySessionID attempts an in-place model switch via ACP session/set_model.
+	// SetSessionModelBySessionID attempts an in-place model switch via ACP model selection.
 	// Returns an error if the agent doesn't support in-place model switching.
 	SetSessionModelBySessionID(ctx context.Context, sessionID, modelID string) error
 

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -225,18 +225,19 @@ func (e *Executor) promptPassthrough(ctx context.Context, taskID, sessionID, pro
 	return &PromptResult{StopReason: stopReasonPassthrough}, nil
 }
 
-// SwitchModel switches the model for a running session. It first attempts an in-place switch
-// via ACP session/set_model (instant, no process restart). If the agent doesn't support
-// in-place switching, it falls back to stopping and restarting the agent with the new model.
+// SwitchModel switches the model for a running session. It first attempts an
+// in-place switch via ACP model selection (instant, no process restart). If
+// the agent doesn't support in-place switching, it falls back to stopping and
+// restarting the agent with the new model.
 func (e *Executor) SwitchModel(ctx context.Context, taskID, sessionID, newModel, prompt string) (*PromptResult, error) {
 	e.logger.Info("switching model for session",
 		zap.String("task_id", taskID),
 		zap.String("session_id", sessionID),
 		zap.String("new_model", newModel))
 
-	// Try in-place model switch first (ACP agents support session/set_model)
+	// Try in-place model switch first.
 	if err := e.agentManager.SetSessionModelBySessionID(ctx, sessionID, newModel); err == nil {
-		e.logger.Info("model switched in-place via ACP session/set_model",
+		e.logger.Info("model switched in-place via ACP model selection",
 			zap.String("session_id", sessionID),
 			zap.String("new_model", newModel))
 		e.persistInPlaceModelSwitch(ctx, sessionID, newModel)

--- a/apps/backend/internal/task/handlers/process_handlers.go
+++ b/apps/backend/internal/task/handlers/process_handlers.go
@@ -65,6 +65,7 @@ func RegisterProcessRoutes(
 	session := api.Group("/task-sessions/:id")
 	session.POST("/set-mode", handlers.httpSetSessionMode)
 	session.POST("/set-model", handlers.httpSetSessionModel)
+	session.POST("/set-config-option", handlers.httpSetSessionConfigOption)
 	session.POST("/authenticate", handlers.httpAuthenticate)
 }
 
@@ -513,6 +514,28 @@ func (h *ProcessHandlers) httpSetSessionModel(c *gin.Context) {
 		h.logger.Error("failed to set session model",
 			zap.String("session_id", sessionID),
 			zap.String("model_id", req.ModelID),
+			zap.Error(err))
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(200, gin.H{"ok": true})
+}
+
+// httpSetSessionConfigOption sets a session config option for a running agent.
+func (h *ProcessHandlers) httpSetSessionConfigOption(c *gin.Context) {
+	sessionID := c.Param("id")
+	var req struct {
+		ConfigID string `json:"config_id"`
+		Value    string `json:"value"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(400, gin.H{"error": "invalid request: " + err.Error()})
+		return
+	}
+	if err := h.lifecycleMgr.SetSessionConfigOptionBySessionID(c.Request.Context(), sessionID, req.ConfigID, req.Value); err != nil {
+		h.logger.Error("failed to set session config option",
+			zap.String("session_id", sessionID),
+			zap.String("config_id", req.ConfigID),
 			zap.Error(err))
 		c.JSON(500, gin.H{"error": err.Error()})
 		return

--- a/apps/backend/internal/utility/dto/dto.go
+++ b/apps/backend/internal/utility/dto/dto.go
@@ -180,8 +180,23 @@ type InferenceAgentDTO struct {
 	Name          string              `json:"name"`
 	DisplayName   string              `json:"display_name"`
 	Models        []InferenceModelDTO `json:"models"`
+	ConfigOptions []ConfigOptionDTO   `json:"config_options,omitempty"`
 	Status        string              `json:"status"`
 	StatusMessage string              `json:"status_message,omitempty"`
+}
+
+type ConfigOptionDTO struct {
+	Type         string                  `json:"type"`
+	ID           string                  `json:"id"`
+	Name         string                  `json:"name"`
+	CurrentValue string                  `json:"current_value"`
+	Category     string                  `json:"category,omitempty"`
+	Options      []ConfigOptionChoiceDTO `json:"options,omitempty"`
+}
+
+type ConfigOptionChoiceDTO struct {
+	Value string `json:"value"`
+	Name  string `json:"name"`
 }
 
 // InferenceAgentsResponse is the response for listing inference agents.

--- a/apps/backend/internal/utility/handlers/handlers.go
+++ b/apps/backend/internal/utility/handlers/handlers.go
@@ -398,6 +398,24 @@ func inferenceAgentDTOFromCaps(ia lifecycle.InferenceAgentInfo, caps hostutility
 			Meta:        m.Meta,
 		})
 	}
+	configOptions := make([]dto.ConfigOptionDTO, 0, len(caps.ConfigOptions))
+	for _, opt := range caps.ConfigOptions {
+		choices := make([]dto.ConfigOptionChoiceDTO, 0, len(opt.Options))
+		for _, choice := range opt.Options {
+			choices = append(choices, dto.ConfigOptionChoiceDTO{
+				Value: choice.Value,
+				Name:  choice.Name,
+			})
+		}
+		configOptions = append(configOptions, dto.ConfigOptionDTO{
+			Type:         opt.Type,
+			ID:           opt.ID,
+			Name:         opt.Name,
+			CurrentValue: opt.CurrentValue,
+			Category:     opt.Category,
+			Options:      choices,
+		})
+	}
 	status := string(caps.Status)
 	if !hasCaps || status == "" {
 		status = string(hostutility.StatusProbing)
@@ -407,6 +425,7 @@ func inferenceAgentDTOFromCaps(ia lifecycle.InferenceAgentInfo, caps hostutility
 		Name:          ia.Name,
 		DisplayName:   ia.DisplayName,
 		Models:        models,
+		ConfigOptions: configOptions,
 		Status:        status,
 		StatusMessage: sanitizeStatusMessage(caps.Error),
 	}

--- a/apps/backend/internal/utility/handlers/handlers_test.go
+++ b/apps/backend/internal/utility/handlers/handlers_test.go
@@ -84,9 +84,10 @@ type wantModel struct {
 
 // wantAgent is the expected shape of a single agent entry in the response.
 type wantAgent struct {
-	status string
-	hasMsg bool
-	models []wantModel
+	status        string
+	hasMsg        bool
+	models        []wantModel
+	configOptions int
 }
 
 // TestHttpListInferenceAgents covers the full /api/v1/utility/inference-agents
@@ -131,11 +132,23 @@ func TestHttpListInferenceAgents(t *testing.T) {
 						{ID: "sonnet", Name: "Sonnet"},
 						{ID: "opus", Name: "Opus"},
 					},
+					ConfigOptions: []hostutility.ConfigOption{{
+						Type:         "select",
+						ID:           "reasoning_effort",
+						Name:         "Reasoning effort",
+						CurrentValue: "medium",
+						Category:     "thought-level",
+						Options: []hostutility.ConfigOptionChoice{
+							{Value: "low", Name: "Low"},
+							{Value: "medium", Name: "Medium"},
+						},
+					}},
 				},
 			},
 			wantByAgent: map[string]wantAgent{
 				"Claude ACP Agent": {
-					status: "ok",
+					status:        "ok",
+					configOptions: 1,
 					models: []wantModel{
 						{id: "sonnet", isDefault: true},
 						{id: "opus", isDefault: false},
@@ -263,6 +276,13 @@ func TestHttpListInferenceAgents(t *testing.T) {
 						IsDefault bool           `json:"is_default"`
 						Meta      map[string]any `json:"meta,omitempty"`
 					} `json:"models"`
+					ConfigOptions []struct {
+						ID      string `json:"id"`
+						Options []struct {
+							Value string `json:"value"`
+							Name  string `json:"name"`
+						} `json:"options"`
+					} `json:"config_options"`
 				} `json:"agents"`
 			}
 			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
@@ -290,6 +310,9 @@ func TestHttpListInferenceAgents(t *testing.T) {
 				}
 				if !want.hasMsg && a.StatusMessage != "" {
 					t.Errorf("agent %q: expected empty status_message, got %q", a.Name, a.StatusMessage)
+				}
+				if len(a.ConfigOptions) != want.configOptions {
+					t.Errorf("agent %q: got %d config options, want %d", a.Name, len(a.ConfigOptions), want.configOptions)
 				}
 				if len(a.Models) != len(want.models) {
 					t.Errorf("agent %q: got %d models, want %d", a.Name, len(a.Models), len(want.models))
@@ -487,6 +510,13 @@ func agentNames(agents []struct {
 		IsDefault bool           `json:"is_default"`
 		Meta      map[string]any `json:"meta,omitempty"`
 	} `json:"models"`
+	ConfigOptions []struct {
+		ID      string `json:"id"`
+		Options []struct {
+			Value string `json:"value"`
+			Name  string `json:"name"`
+		} `json:"options"`
+	} `json:"config_options"`
 }) []string {
 	names := make([]string, 0, len(agents))
 	for _, a := range agents {

--- a/apps/web/app/actions/agents.ts
+++ b/apps/web/app/actions/agents.ts
@@ -110,6 +110,7 @@ export async function createAgentProfileAction(
     name: string;
     model: string;
     mode?: string;
+    config_options?: Record<string, string>;
     cli_passthrough: boolean;
     cli_flags?: CLIFlag[];
     env_vars?: ProfileEnvVar[];
@@ -128,6 +129,7 @@ export async function updateAgentProfileAction(
     name?: string;
     model?: string;
     mode?: string;
+    config_options?: Record<string, string>;
     allow_indexing?: boolean;
     auto_approve?: boolean;
     cli_passthrough?: boolean;

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
@@ -30,6 +30,7 @@ export function toAgentProfilePatch(patch: Partial<ProfileFormData>): Partial<Ag
   if (patch.name !== undefined) next.name = patch.name;
   if (patch.model !== undefined) next.model = patch.model;
   if (patch.mode !== undefined) next.mode = patch.mode;
+  if (patch.config_options !== undefined) next.configOptions = patch.config_options;
   if (patch.allow_indexing !== undefined) next.allowIndexing = patch.allow_indexing;
   if (patch.auto_approve !== undefined) next.autoApprove = patch.auto_approve;
   if (patch.cli_passthrough !== undefined) next.cliPassthrough = patch.cli_passthrough;
@@ -169,6 +170,7 @@ export async function saveNewAgent(draftAgent: DraftAgent, callbacks: SaveAgentC
       name: profile.name,
       model: profile.model,
       mode: profile.mode,
+      config_options: profile.configOptions ?? {},
       ...permissionsToProfilePatch(profile),
       cli_passthrough: profile.cliPassthrough ?? false,
       cli_flags: profile.cliFlags ?? [],
@@ -224,6 +226,7 @@ async function saveExistingProfiles(
         name: profile.name,
         model: profile.model,
         mode: profile.mode,
+        config_options: profile.configOptions ?? {},
         ...permissionsToProfilePatch(profile),
         cli_passthrough: profile.cliPassthrough ?? false,
         cli_flags: profile.cliFlags ?? [],
@@ -242,6 +245,7 @@ async function saveExistingProfiles(
         name: profile.name,
         model: profile.model,
         mode: profile.mode,
+        config_options: profile.configOptions ?? {},
         ...permissionsToProfilePatch(profile),
         cli_passthrough: profile.cliPassthrough ?? false,
         cli_flags: profile.cliFlags ?? [],
@@ -309,9 +313,19 @@ export function isProfileDirty(draft: DraftProfile, saved?: AgentProfile): boole
     draft.name !== saved.name ||
     draft.model !== saved.model ||
     (draft.mode ?? "") !== (saved.mode ?? "") ||
+    !areConfigOptionsEqual(draft.configOptions, saved.configOptions) ||
     arePermissionsDirty(draft, saved) ||
     draft.cliPassthrough !== saved.cliPassthrough ||
     !areCLIFlagsEqual(draft.cliFlags ?? [], saved.cliFlags ?? []) ||
     !areEnvVarsEqual(draft.envVars, saved.envVars)
   );
+}
+
+function areConfigOptionsEqual(a?: Record<string, string>, b?: Record<string, string>): boolean {
+  const left = a ?? {};
+  const right = b ?? {};
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }

--- a/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
+++ b/apps/web/app/settings/agents/[agentId]/agent-save-helpers.ts
@@ -16,6 +16,7 @@ import type {
 } from "@/lib/types/http";
 import { arePermissionsDirty, permissionsToProfilePatch } from "@/lib/agent-permissions";
 import { areCLIFlagsEqual } from "@/lib/cli-flags";
+import { areConfigOptionsEqual } from "@/lib/config-options";
 import type { ProfileFormData } from "@/components/settings/profile-form-fields";
 
 /**
@@ -319,13 +320,4 @@ export function isProfileDirty(draft: DraftProfile, saved?: AgentProfile): boole
     !areCLIFlagsEqual(draft.cliFlags ?? [], saved.cliFlags ?? []) ||
     !areEnvVarsEqual(draft.envVars, saved.envVars)
   );
-}
-
-function areConfigOptionsEqual(a?: Record<string, string>, b?: Record<string, string>): boolean {
-  const left = a ?? {};
-  const right = b ?? {};
-  const leftKeys = Object.keys(left).sort();
-  const rightKeys = Object.keys(right).sort();
-  if (leftKeys.length !== rightKeys.length) return false;
-  return leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }

--- a/apps/web/app/settings/agents/[agentId]/agent-setup-parts.tsx
+++ b/apps/web/app/settings/agents/[agentId]/agent-setup-parts.tsx
@@ -122,6 +122,7 @@ export function ProfileCardItem({
             name: profile.name,
             model: profile.model,
             mode: profile.mode ?? "",
+            config_options: profile.configOptions ?? {},
             auto_approve: permissionValues.auto_approve,
             allow_indexing: permissionValues.allow_indexing,
             cli_passthrough: profile.cliPassthrough ?? false,

--- a/apps/web/app/settings/agents/[agentId]/profiles/[profileId]/use-agent-profile-settings.ts
+++ b/apps/web/app/settings/agents/[agentId]/profiles/[profileId]/use-agent-profile-settings.ts
@@ -22,6 +22,28 @@ type AgentProfileSettingsResult = {
   passthroughConfig: PassthroughConfig | null;
 };
 
+const EMPTY_MODEL_CONFIG: ModelConfig = {
+  default_model: "",
+  available_models: [],
+  available_modes: [],
+  available_commands: [],
+  config_options: [],
+  supports_dynamic_models: false,
+};
+
+function normalizeModelConfig(raw: AvailableAgent["model_config"] | undefined): ModelConfig {
+  if (!raw) return EMPTY_MODEL_CONFIG;
+  return {
+    ...raw,
+    default_model: raw.default_model ?? "",
+    available_models: raw.available_models ?? [],
+    available_modes: raw.available_modes ?? [],
+    available_commands: raw.available_commands ?? [],
+    config_options: raw.config_options ?? [],
+    supports_dynamic_models: raw.supports_dynamic_models ?? false,
+  };
+}
+
 export function useAgentProfileSettings(
   agentKey: string,
   profileId: string,
@@ -75,19 +97,9 @@ export function useAgentProfileSettings(
   }, [availableAgents, agent?.name]);
 
   const modelConfig = useMemo(() => {
-    const raw = availableAgent?.model_config;
     // Defensive normalization: the backend may marshal nil slices as null.
     // Ensure arrays are always arrays so consumers can call .some()/.map().
-    return {
-      default_model: raw?.default_model ?? "",
-      available_models: raw?.available_models ?? [],
-      current_model_id: raw?.current_model_id,
-      available_modes: raw?.available_modes ?? [],
-      current_mode_id: raw?.current_mode_id,
-      supports_dynamic_models: raw?.supports_dynamic_models ?? false,
-      status: raw?.status,
-      error: raw?.error,
-    };
+    return normalizeModelConfig(availableAgent?.model_config);
   }, [availableAgent]);
 
   const permissionSettings = useMemo(() => {

--- a/apps/web/components/model-config-selector.tsx
+++ b/apps/web/components/model-config-selector.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { memo, useCallback, useState } from "react";
+import { IconCheck, IconChevronDown } from "@tabler/icons-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@kandev/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@kandev/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@kandev/ui/popover";
+import { ScrollArea } from "@kandev/ui/scroll-area";
+import { Separator } from "@kandev/ui/separator";
+
+export type ModelSelectorOption = {
+  id: string;
+  name: string;
+  description?: string;
+  usageMultiplier?: string;
+};
+
+export type DynamicConfigOption = {
+  type: string;
+  id: string;
+  name: string;
+  currentValue: string;
+  category?: string;
+  options?: { value: string; name: string }[];
+};
+
+export type SelectConfigOption = DynamicConfigOption & {
+  options: { value: string; name: string }[];
+};
+
+const MODEL_CONFIG_CATEGORY = "model";
+const MODE_CONFIG_CATEGORY = "mode";
+
+export function isModelConfigOption(option: Pick<DynamicConfigOption, "id" | "category">): boolean {
+  return option.id === MODEL_CONFIG_CATEGORY || option.category === MODEL_CONFIG_CATEGORY;
+}
+
+export function isModeConfigOption(option: Pick<DynamicConfigOption, "id" | "category">): boolean {
+  return option.id === MODE_CONFIG_CATEGORY || option.category === MODE_CONFIG_CATEGORY;
+}
+
+export function usableConfigOptions(
+  options: DynamicConfigOption[] | undefined,
+): SelectConfigOption[] {
+  return (options ?? []).filter(
+    (option): option is SelectConfigOption =>
+      option.type === "select" &&
+      !isModeConfigOption(option) &&
+      Array.isArray(option.options) &&
+      option.options.length > 0,
+  );
+}
+
+export function configOptionToModelOptions(
+  option: SelectConfigOption | undefined,
+): ModelSelectorOption[] {
+  if (!option) return [];
+  return option.options.map((item) => ({
+    id: item.value,
+    name: item.name,
+    description: item.value !== item.name ? item.value : undefined,
+  }));
+}
+
+function currentOptionName(option: DynamicConfigOption): string {
+  return (
+    option.options?.find((item) => item.value === option.currentValue)?.name ?? option.currentValue
+  );
+}
+
+function displayModelName(modelOptions: ModelSelectorOption[], currentModel: string): string {
+  return modelOptions.find((m) => m.id === currentModel)?.name ?? currentModel;
+}
+
+export function triggerLabel(
+  modelOptions: ModelSelectorOption[],
+  currentModel: string,
+  configOptions: DynamicConfigOption[],
+): string {
+  const modelConfig = configOptions.find(isModelConfigOption);
+  const modelValue = modelConfig
+    ? currentOptionName(modelConfig)
+    : displayModelName(modelOptions, currentModel);
+  const extras = configOptions
+    .filter((option) => !isModelConfigOption(option))
+    .map(currentOptionName)
+    .filter(Boolean);
+  return [modelValue, ...extras].join(" / ");
+}
+
+export function resolveTriggerLabel(
+  modelOptions: ModelSelectorOption[],
+  currentModel: string | null,
+  modelConfig: DynamicConfigOption | undefined,
+  configOptions: DynamicConfigOption[],
+): string {
+  const modelValue = currentModel || modelConfig?.currentValue;
+  if (!modelValue) return "";
+  return triggerLabel(modelOptions, modelValue, configOptions);
+}
+
+function ModelRow({
+  model,
+  selected,
+  onSelect,
+}: {
+  model: ModelSelectorOption;
+  selected: boolean;
+  onSelect: (value: string) => void;
+}) {
+  return (
+    <CommandItem
+      value={model.id}
+      keywords={[model.name, model.description ?? "", model.id]}
+      onSelect={() => onSelect(model.id)}
+      className="relative pr-7"
+    >
+      <div className="flex min-w-0 flex-1 items-center">
+        <div className="min-w-0 flex-1">
+          <div className="truncate">{model.name}</div>
+          {model.description && (
+            <div className="truncate text-xs text-muted-foreground" title={model.description}>
+              {model.description}
+            </div>
+          )}
+        </div>
+        {model.usageMultiplier && (
+          <span className="shrink-0 text-xs text-muted-foreground">{model.usageMultiplier}</span>
+        )}
+      </div>
+      <IconCheck
+        className={cn("absolute right-2 h-4 w-4", selected ? "opacity-100" : "opacity-0")}
+      />
+    </CommandItem>
+  );
+}
+
+function ConfigOptionSection({
+  option,
+  onChange,
+}: {
+  option: SelectConfigOption;
+  onChange?: (configId: string, value: string) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">
+        {option.name}
+      </div>
+      <div className="grid grid-cols-2 gap-1">
+        {option.options.map((item) => (
+          <Button
+            key={item.value}
+            type="button"
+            variant={item.value === option.currentValue ? "secondary" : "ghost"}
+            size="sm"
+            className="h-9 min-w-0 justify-start px-2 text-left"
+            disabled={!onChange}
+            onClick={() => onChange?.(option.id, item.value)}
+          >
+            <span className="truncate">{item.name}</span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export type ModelConfigSelectorProps = {
+  modelOptions: ModelSelectorOption[];
+  currentModel: string | null;
+  configOptions?: DynamicConfigOption[];
+  onModelChange: (modelId: string) => void;
+  onConfigChange?: (configId: string, value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  ariaLabel?: string;
+  variant?: "compact" | "field";
+  popoverSide?: "top" | "bottom";
+};
+
+export const ModelConfigSelector = memo(function ModelConfigSelector({
+  modelOptions,
+  currentModel,
+  configOptions = [],
+  onModelChange,
+  onConfigChange,
+  disabled,
+  placeholder = "Select model...",
+  ariaLabel = "Model settings",
+  variant = "field",
+  popoverSide = "bottom",
+}: ModelConfigSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const selectConfigOptions = usableConfigOptions(configOptions);
+  const modelConfig = selectConfigOptions.find(isModelConfigOption);
+  const extraConfigOptions = selectConfigOptions.filter((option) => !isModelConfigOption(option));
+  const currentModelValue = modelConfig?.currentValue || currentModel || "";
+  const label = resolveTriggerLabel(modelOptions, currentModel, modelConfig, configOptions);
+
+  const onModelSelect = useCallback(
+    (value: string) => {
+      if (!value) return;
+      onModelChange(value);
+    },
+    [onModelChange],
+  );
+
+  const triggerClassName =
+    variant === "compact"
+      ? "h-7 max-w-[min(18rem,70vw)] gap-1 px-2 text-xs hover:bg-muted/40"
+      : "h-9 w-full justify-between gap-2 px-3 text-sm";
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant={variant === "compact" ? "ghost" : "outline"}
+          size="sm"
+          className={triggerClassName}
+          aria-label={ariaLabel}
+          disabled={disabled}
+        >
+          <span className="truncate">{label || placeholder}</span>
+          <IconChevronDown className="h-3.5 w-3.5 shrink-0 opacity-70" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side={popoverSide}
+        className="w-[min(24rem,calc(100vw-1rem))] gap-2 p-2"
+      >
+        <Command>
+          <CommandInput placeholder="Filter models..." className="h-8" />
+          <CommandList className="max-h-60">
+            <CommandEmpty>No models found.</CommandEmpty>
+            <CommandGroup heading="Model">
+              {modelOptions.map((model) => (
+                <ModelRow
+                  key={model.id}
+                  model={model}
+                  selected={model.id === currentModelValue}
+                  onSelect={onModelSelect}
+                />
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+        {extraConfigOptions.length > 0 && (
+          <>
+            <Separator />
+            <ScrollArea className="max-h-56 pr-2">
+              <div className="space-y-3">
+                {extraConfigOptions.map((option) => (
+                  <ConfigOptionSection key={option.id} option={option} onChange={onConfigChange} />
+                ))}
+              </div>
+            </ScrollArea>
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+});

--- a/apps/web/components/model-config-selector.tsx
+++ b/apps/web/components/model-config-selector.tsx
@@ -217,8 +217,8 @@ export const ModelConfigSelector = memo(function ModelConfigSelector({
 
   const triggerClassName =
     variant === "compact"
-      ? "h-7 max-w-[min(18rem,70vw)] gap-1 px-2 text-xs hover:bg-muted/40"
-      : "h-9 w-full justify-between gap-2 px-3 text-sm";
+      ? "h-7 max-w-[min(18rem,70vw)] cursor-pointer gap-1 px-2 text-xs hover:bg-muted/40"
+      : "w-full justify-between font-normal cursor-pointer";
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -226,7 +226,7 @@ export const ModelConfigSelector = memo(function ModelConfigSelector({
         <Button
           type="button"
           variant={variant === "compact" ? "ghost" : "outline"}
-          size="sm"
+          size={variant === "compact" ? "sm" : "default"}
           className={triggerClassName}
           aria-label={ariaLabel}
           disabled={disabled}

--- a/apps/web/components/model-config-selector.tsx
+++ b/apps/web/components/model-config-selector.tsx
@@ -163,7 +163,7 @@ function ConfigOptionSection({
             type="button"
             variant={item.value === option.currentValue ? "secondary" : "ghost"}
             size="sm"
-            className="h-9 min-w-0 justify-start px-2 text-left"
+            className="h-9 min-w-0 cursor-pointer justify-start px-2 text-left"
             disabled={!onChange}
             onClick={() => onChange?.(option.id, item.value)}
           >

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -161,6 +161,7 @@ function ProfileSettingsCard({
             name: draft.name,
             model: draft.model,
             mode: draft.mode ?? "",
+            config_options: draft.configOptions ?? {},
             auto_approve: permissionValues.auto_approve,
             allow_indexing: permissionValues.allow_indexing,
             cli_passthrough: draft.cliPassthrough,
@@ -211,6 +212,7 @@ function useProfileEditorState(
       draft.name !== savedProfile.name ||
       draft.model !== savedProfile.model ||
       (draft.mode ?? "") !== (savedProfile.mode ?? "") ||
+      !areProfileConfigOptionsEqual(draft.configOptions, savedProfile.configOptions) ||
       arePermissionsDirty(draft, savedProfile, permissionSettings) ||
       draft.cliPassthrough !== savedProfile.cliPassthrough ||
       !areCLIFlagsEqual(draft.cliFlags ?? [], savedProfile.cliFlags ?? []) ||
@@ -258,13 +260,14 @@ function useProfileSave({
       return;
     }
     // Model is optional — an empty profile model means "use the agent's
-    // default", which is applied via ACP session/set_model at session start.
+    // default", which is applied through ACP session model selection at session start.
     setSaveStatus("loading");
     try {
       const updated = await updateAgentProfileAction(draft.id, {
         name: draft.name,
         model: draft.model,
         mode: draft.mode,
+        config_options: draft.configOptions ?? {},
         ...permissionsToProfilePatch(draft),
         cli_passthrough: draft.cliPassthrough,
         cli_flags: draft.cliFlags,
@@ -293,6 +296,18 @@ function useProfileSave({
       });
     }
   };
+}
+
+function areProfileConfigOptionsEqual(
+  a?: Record<string, string>,
+  b?: Record<string, string>,
+): boolean {
+  const left = a ?? {};
+  const right = b ?? {};
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }
 
 function useProfileDelete(

--- a/apps/web/components/settings/agent-profile-page.tsx
+++ b/apps/web/components/settings/agent-profile-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { IconTrash } from "@tabler/icons-react";
 import { areCLIFlagsEqual } from "@/lib/cli-flags";
+import { areConfigOptionsEqual } from "@/lib/config-options";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
@@ -212,7 +213,7 @@ function useProfileEditorState(
       draft.name !== savedProfile.name ||
       draft.model !== savedProfile.model ||
       (draft.mode ?? "") !== (savedProfile.mode ?? "") ||
-      !areProfileConfigOptionsEqual(draft.configOptions, savedProfile.configOptions) ||
+      !areConfigOptionsEqual(draft.configOptions, savedProfile.configOptions) ||
       arePermissionsDirty(draft, savedProfile, permissionSettings) ||
       draft.cliPassthrough !== savedProfile.cliPassthrough ||
       !areCLIFlagsEqual(draft.cliFlags ?? [], savedProfile.cliFlags ?? []) ||
@@ -296,18 +297,6 @@ function useProfileSave({
       });
     }
   };
-}
-
-function areProfileConfigOptionsEqual(
-  a?: Record<string, string>,
-  b?: Record<string, string>,
-): boolean {
-  const left = a ?? {};
-  const right = b ?? {};
-  const leftKeys = Object.keys(left).sort();
-  const rightKeys = Object.keys(right).sort();
-  if (leftKeys.length !== rightKeys.length) return false;
-  return leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
 }
 
 function useProfileDelete(

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -23,7 +23,13 @@ import { Skeleton } from "@kandev/ui/skeleton";
 import { Switch } from "@kandev/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { ModeCombobox } from "@/components/settings/mode-combobox";
-import { ModelCombobox } from "@/components/settings/model-combobox";
+import {
+  configOptionToModelOptions,
+  isModelConfigOption,
+  ModelConfigSelector,
+  type SelectConfigOption,
+  usableConfigOptions,
+} from "@/components/model-config-selector";
 import { useAgentCapabilities } from "@/hooks/domains/settings/use-dynamic-models";
 import {
   PERMISSION_APPLY_AGENTCTL_AUTO_APPROVE,
@@ -46,6 +52,7 @@ export type ProfileFormData = {
   name: string;
   model: string;
   mode: string;
+  config_options?: Record<string, string>;
   cli_passthrough: boolean;
   cli_flags: CLIFlag[];
 } & Record<PermissionKey, boolean>;
@@ -295,20 +302,44 @@ function ModelPicker({
   profile,
   models,
   currentModelId,
+  configOptions,
   onChange,
 }: {
   profile: ProfileFormData;
   models: ModelEntry[];
   currentModelId: string | undefined;
+  configOptions: SelectConfigOption[];
   onChange: (patch: Partial<ProfileFormData>) => void;
 }) {
+  const modelConfig = configOptions.find(isModelConfigOption);
+  const modelOptions = modelConfig
+    ? configOptionToModelOptions(modelConfig)
+    : models.map((model) => ({
+        id: model.id,
+        name: model.name,
+        description: model.description || (model.id !== model.name ? model.id : undefined),
+        usageMultiplier:
+          typeof model.meta?.copilotUsage === "string" ? model.meta.copilotUsage : undefined,
+      }));
+  const currentModel = profile.model || modelConfig?.currentValue || currentModelId || null;
+  const selectedConfigOptions = configOptions.map((option) => ({
+    ...option,
+    currentValue: isModelConfigOption(option)
+      ? profile.model || option.currentValue
+      : profile.config_options?.[option.id] || option.currentValue,
+  }));
+
   return (
-    <ModelCombobox
-      value={profile.model}
-      onChange={(value) => onChange({ model: value })}
-      models={models}
-      currentModelId={currentModelId}
+    <ModelConfigSelector
+      modelOptions={modelOptions}
+      currentModel={currentModel}
+      configOptions={selectedConfigOptions}
+      onModelChange={(value) => onChange({ model: value })}
+      onConfigChange={(configId, value) =>
+        onChange({ config_options: { ...(profile.config_options ?? {}), [configId]: value } })
+      }
       placeholder="Select a model..."
+      ariaLabel="Profile start model settings"
     />
   );
 }
@@ -331,6 +362,19 @@ function ModePicker({
       modes={modes}
       currentModeId={currentModeId}
     />
+  );
+}
+
+function modelConfigOptions(modelConfig: ModelConfig): SelectConfigOption[] {
+  return usableConfigOptions(
+    modelConfig.config_options?.map((option) => ({
+      type: option.type,
+      id: option.id,
+      name: option.name,
+      currentValue: option.current_value,
+      category: option.category,
+      options: option.options,
+    })),
   );
 }
 
@@ -402,6 +446,7 @@ function CapabilitiesRow({
   agentName: string;
 }) {
   const hasModes = modes.length > 0;
+  const configOptions = modelConfigOptions(modelConfig);
   const activeMode = hasModes
     ? modes.find((m) => m.id === (profile.mode || currentModeId || modes[0]?.id))
     : undefined;
@@ -443,6 +488,7 @@ function CapabilitiesRow({
             profile={profile}
             models={models}
             currentModelId={currentModelId}
+            configOptions={configOptions}
             onChange={onChange}
           />
         </div>

--- a/apps/web/components/settings/profile-form-fields.tsx
+++ b/apps/web/components/settings/profile-form-fields.tsx
@@ -457,7 +457,7 @@ function CapabilitiesRow({
     return (
       <div className={gapCls}>
         <Label className={labelCls}>Start model</Label>
-        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-7 w-full" />
       </div>
     );
   }

--- a/apps/web/components/settings/utility-sections.tsx
+++ b/apps/web/components/settings/utility-sections.tsx
@@ -14,7 +14,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@kandev/ui/select";
-import { ModelCombobox } from "@/components/settings/model-combobox";
+import {
+  configOptionToModelOptions,
+  isModelConfigOption,
+  ModelConfigSelector,
+  type SelectConfigOption,
+  usableConfigOptions,
+} from "@/components/model-config-selector";
 import { InferenceAgentStatusNote } from "@/components/settings/inference-agent-status";
 import type { UtilityAgent, InferenceAgent } from "@/lib/api/domains/utility-api";
 
@@ -32,6 +38,19 @@ function groupModelsByAgent(models: ModelOption[]): ModelGroup[] {
     else map.set(m.agentName, [m]);
   }
   return Array.from(map, ([agentName, items]) => ({ agentName, models: items }));
+}
+
+function utilityConfigOptions(agent: InferenceAgent | undefined): SelectConfigOption[] {
+  return usableConfigOptions(
+    agent?.config_options?.map((option) => ({
+      type: option.type,
+      id: option.id,
+      name: option.name,
+      currentValue: option.current_value,
+      category: option.category,
+      options: option.options,
+    })),
+  );
 }
 
 // Default model selector section
@@ -53,6 +72,23 @@ export function DefaultModelSection({
   const selectedAgent = inferenceAgents.find((a) => a.id === defaultAgentId);
   const modelOptions = selectedAgent?.models ?? [];
   const currentModelId = modelOptions.find((m) => m.is_default)?.id;
+  const configOptions = utilityConfigOptions(selectedAgent);
+  const modelConfig = configOptions.find(isModelConfigOption);
+  const selectorModels = modelConfig
+    ? configOptionToModelOptions(modelConfig)
+    : modelOptions.map((model) => ({
+        id: model.id,
+        name: model.name,
+        description: model.description || (model.id !== model.name ? model.id : undefined),
+        usageMultiplier:
+          typeof model.meta?.copilotUsage === "string" ? model.meta.copilotUsage : undefined,
+      }));
+  const selectedModel = defaultModel || modelConfig?.currentValue || currentModelId || null;
+  const selectedConfigOptions = configOptions.map((option) => ({
+    ...option,
+    currentValue:
+      isModelConfigOption(option) && selectedModel ? selectedModel : option.currentValue,
+  }));
 
   return (
     <div className="space-y-3">
@@ -62,8 +98,8 @@ export function DefaultModelSection({
           Select the default model used by all built-in utility actions.
         </p>
       </div>
-      <div className="flex gap-2">
-        <div className="w-[180px]">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <div className="w-full sm:w-[180px]">
           <Label className="text-xs text-muted-foreground mb-1 block">Agent</Label>
           <Select value={defaultAgentId} onValueChange={(v) => onDefaultChange(v, "")}>
             <SelectTrigger className="cursor-pointer">
@@ -78,15 +114,16 @@ export function DefaultModelSection({
             </SelectContent>
           </Select>
         </div>
-        <div className="w-[220px]">
+        <div className="w-full sm:w-[280px]">
           <Label className="text-xs text-muted-foreground mb-1 block">Model</Label>
-          <ModelCombobox
-            value={defaultModel}
-            onChange={(v) => onDefaultChange(defaultAgentId, v)}
-            models={modelOptions}
-            currentModelId={currentModelId}
-            placeholder="Select model..."
+          <ModelConfigSelector
+            modelOptions={selectorModels}
+            currentModel={selectedModel}
+            configOptions={selectedConfigOptions}
+            onModelChange={(v) => onDefaultChange(defaultAgentId, v)}
             disabled={!defaultAgentId}
+            placeholder="Select model..."
+            ariaLabel="Default utility model settings"
           />
         </div>
       </div>

--- a/apps/web/components/task/model-selector.test.ts
+++ b/apps/web/components/task/model-selector.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { triggerLabel, usableConfigOptions } from "@/components/model-config-selector";
+import type { ConfigOptionEntry } from "@/lib/state/slices/session-runtime/types";
+
+describe("model selector config options", () => {
+  it("keeps model-adjacent config options and excludes mode", () => {
+    const options: ConfigOptionEntry[] = [
+      {
+        type: "select",
+        id: "mode",
+        name: "Mode",
+        currentValue: "agent",
+        category: "mode",
+        options: [{ value: "agent", name: "Agent" }],
+      },
+      {
+        type: "select",
+        id: "model",
+        name: "Model",
+        currentValue: "gpt-5.5",
+        category: "model",
+        options: [{ value: "gpt-5.5", name: "GPT-5.5" }],
+      },
+      {
+        type: "select",
+        id: "reasoning_effort",
+        name: "Reasoning Effort",
+        currentValue: "high",
+        category: "thought_level",
+        options: [{ value: "high", name: "High" }],
+      },
+    ];
+
+    expect(usableConfigOptions(options).map((option) => option.id)).toEqual([
+      "model",
+      "reasoning_effort",
+    ]);
+  });
+
+  it("summarizes model and extra option values in one toolbar label", () => {
+    const label = triggerLabel([{ id: "gpt-5.5", name: "GPT-5.5" }], "gpt-5.5", [
+      {
+        type: "select",
+        id: "model",
+        name: "Model",
+        currentValue: "gpt-5.5",
+        category: "model",
+        options: [{ value: "gpt-5.5", name: "GPT-5.5" }],
+      },
+      {
+        type: "select",
+        id: "reasoning_effort",
+        name: "Reasoning Effort",
+        currentValue: "medium",
+        category: "thought_level",
+        options: [{ value: "medium", name: "Medium" }],
+      },
+    ]);
+
+    expect(label).toBe("GPT-5.5 / Medium");
+  });
+});

--- a/apps/web/components/task/model-selector.tsx
+++ b/apps/web/components/task/model-selector.tsx
@@ -1,26 +1,27 @@
 "use client";
 
 import { memo, useCallback, useMemo } from "react";
+
+import {
+  configOptionToModelOptions,
+  isModelConfigOption,
+  ModelConfigSelector,
+  type ModelSelectorOption,
+  type SelectConfigOption,
+  usableConfigOptions,
+} from "@/components/model-config-selector";
 import { useAppStore } from "@/components/state-provider";
-import { Combobox, type ComboboxOption } from "@/components/combobox";
 import { useAvailableAgents } from "@/hooks/domains/settings/use-available-agents";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
+import { setSessionConfigOption, setSessionModel } from "@/lib/api/domains/session-api";
 import type { Agent, AgentProfile, AvailableAgent } from "@/lib/types/http";
-import { setSessionModel } from "@/lib/api/domains/session-api";
-import type { SessionModelEntry } from "@/lib/state/slices/session-runtime/types";
+import type {
+  ConfigOptionEntry,
+  SessionModelEntry,
+} from "@/lib/state/slices/session-runtime/types";
 
 type ModelSelectorProps = {
   sessionId: string | null;
-};
-
-type ModelOption = {
-  id: string;
-  name: string;
-  provider?: string;
-  context_window?: number;
-  is_default?: boolean;
-  description?: string;
-  usageMultiplier?: string;
 };
 
 function resolveSnapshotModel(snapshot: unknown): string | null {
@@ -33,14 +34,13 @@ function resolveStaticModels(
   agents: Agent[],
   profileId: string | null | undefined,
   availableAgents: AvailableAgent[],
-): ModelOption[] {
+): ModelSelectorOption[] {
   if (!profileId) return [];
   for (const agent of agents) {
     const profile = agent.profiles.find((p: AgentProfile) => p.id === profileId);
     if (!profile) continue;
     const available = availableAgents.find((a: AvailableAgent) => a.name === agent.name);
     const models = available?.model_config?.available_models ?? [];
-    // Static models don't include description — use model ID as subtitle when it differs from name
     return models.map((m) => ({
       ...m,
       description: m.id !== m.name ? m.id : undefined,
@@ -49,31 +49,22 @@ function resolveStaticModels(
   return [];
 }
 
-function sessionModelsToOptions(models: SessionModelEntry[]): ModelOption[] {
+function sessionModelsToOptions(models: SessionModelEntry[]): ModelSelectorOption[] {
   return models.map((m) => ({
     id: m.modelId,
     name: m.name,
-    provider: "",
-    context_window: 0,
-    is_default: false,
     description: m.description,
     usageMultiplier: m.usageMultiplier,
   }));
 }
 
 function buildModelOptions(
-  availableModels: ModelOption[],
+  availableModels: ModelSelectorOption[],
   currentModel: string | null,
-): ModelOption[] {
+): ModelSelectorOption[] {
   const options = [...availableModels];
   if (currentModel && !options.some((m) => m.id === currentModel)) {
-    options.unshift({
-      id: currentModel,
-      name: currentModel,
-      provider: "unknown",
-      context_window: 0,
-      is_default: false,
-    });
+    options.unshift({ id: currentModel, name: currentModel });
   }
   return options;
 }
@@ -96,7 +87,47 @@ function resolveCurrentModel(
   return activeModel || acpCurrentModel || snapshotModel || profileModel;
 }
 
-/** Resolves available models and current model from store state. */
+function updateConfigOptionValue(
+  options: ConfigOptionEntry[],
+  configId: string,
+  value: string,
+): ConfigOptionEntry[] {
+  return options.map((option) =>
+    option.id === configId ? { ...option, currentValue: value } : option,
+  );
+}
+
+function nextCurrentModelId(
+  data: { currentModelId: string; configOptions: ConfigOptionEntry[] },
+  configId: string,
+  value: string,
+): string {
+  const option = data.configOptions.find((item) => item.id === configId);
+  if (option && isModelConfigOption(option)) return value;
+  return data.currentModelId;
+}
+
+function resolveAvailableModels({
+  modelConfig,
+  usingAcpModels,
+  sessionModels,
+  settingsAgents,
+  profileId,
+  availableAgents,
+}: {
+  modelConfig: SelectConfigOption | undefined;
+  usingAcpModels: boolean;
+  sessionModels: SessionModelEntry[];
+  settingsAgents: Agent[];
+  profileId: string | null | undefined;
+  availableAgents: AvailableAgent[];
+}): ModelSelectorOption[] {
+  if (modelConfig) return configOptionToModelOptions(modelConfig);
+  if (usingAcpModels) return sessionModelsToOptions(sessionModels);
+  return resolveStaticModels(settingsAgents, profileId, availableAgents);
+}
+
+/** Resolves available models, config options and current model from store state. */
 function useModelSelectorState(sessionId: string | null) {
   useSettingsData(true);
 
@@ -104,6 +135,7 @@ function useModelSelectorState(sessionId: string | null) {
   const taskSessions = useAppStore((state) => state.taskSessions.items);
   const activeModels = useAppStore((state) => state.activeModel.bySessionId);
   const setActiveModel = useAppStore((state) => state.setActiveModel);
+  const setSessionModels = useAppStore((state) => state.setSessionModels);
   const { items: availableAgents } = useAvailableAgents();
   const sessionModelsData = useAppStore((state) =>
     sessionId ? state.sessionModels.bySessionId[sessionId] : undefined,
@@ -117,9 +149,16 @@ function useModelSelectorState(sessionId: string | null) {
   );
 
   const usingAcpModels = !!sessionModelsData?.models?.length;
-  const availableModels = usingAcpModels
-    ? sessionModelsToOptions(sessionModelsData.models)
-    : resolveStaticModels(settingsAgents as Agent[], session?.agent_profile_id, availableAgents);
+  const configOptions = usableConfigOptions(sessionModelsData?.configOptions);
+  const modelConfig = configOptions.find(isModelConfigOption);
+  const availableModels = resolveAvailableModels({
+    modelConfig,
+    usingAcpModels,
+    sessionModels: sessionModelsData?.models ?? [],
+    settingsAgents: settingsAgents as Agent[],
+    profileId: session?.agent_profile_id,
+    availableAgents,
+  });
 
   const activeModel = sessionId ? activeModels[sessionId] || null : null;
   const acpCurrentModel = sessionModelsData?.currentModelId || null;
@@ -131,73 +170,83 @@ function useModelSelectorState(sessionId: string | null) {
   );
   const modelOptions = buildModelOptions(availableModels, currentModel);
 
+  const updateLocalConfig = useCallback(
+    (sid: string, configId: string, value: string) => {
+      if (!sessionModelsData) return;
+      setSessionModels(sid, {
+        ...sessionModelsData,
+        currentModelId: nextCurrentModelId(sessionModelsData, configId, value),
+        configOptions: updateConfigOptionValue(sessionModelsData.configOptions, configId, value),
+      });
+    },
+    [sessionModelsData, setSessionModels],
+  );
+
   const handleModelChange = useCallback(
     (sid: string, modelId: string) => {
       setActiveModel(sid, modelId);
+      const modelConfig = configOptions.find(isModelConfigOption);
+      if (modelConfig) {
+        updateLocalConfig(sid, modelConfig.id, modelId);
+        setSessionConfigOption(sid, modelConfig.id, modelId).catch((err) => {
+          console.error("[ModelSelector] set-config-option API failed:", err);
+        });
+        return;
+      }
       setSessionModel(sid, modelId).catch((err) => {
         console.error("[ModelSelector] set-model API failed:", err);
       });
     },
-    [setActiveModel],
+    [configOptions, setActiveModel, updateLocalConfig],
   );
 
-  return { currentModel, modelOptions, handleModelChange };
-}
+  const handleConfigChange = useCallback(
+    (sid: string, configId: string, value: string) => {
+      updateLocalConfig(sid, configId, value);
+      setSessionConfigOption(sid, configId, value).catch((err) => {
+        console.error("[ModelSelector] set-config-option API failed:", err);
+      });
+    },
+    [updateLocalConfig],
+  );
 
-function modelToComboboxOption(model: ModelOption): ComboboxOption {
-  return {
-    value: model.id,
-    label: model.name,
-    description: model.description,
-    renderLabel: () => (
-      <>
-        <div className="min-w-0 flex-1">
-          <div className="truncate">{model.name}</div>
-          {model.description && (
-            <div className="text-xs text-muted-foreground truncate" title={model.description}>
-              {model.description}
-            </div>
-          )}
-        </div>
-        {model.usageMultiplier && (
-          <span className="text-xs text-muted-foreground shrink-0">{model.usageMultiplier}</span>
-        )}
-      </>
-    ),
-  };
+  return { currentModel, modelOptions, configOptions, handleModelChange, handleConfigChange };
 }
 
 export const ModelSelector = memo(function ModelSelector({ sessionId }: ModelSelectorProps) {
-  const { currentModel, modelOptions, handleModelChange } = useModelSelectorState(sessionId);
+  const { currentModel, modelOptions, configOptions, handleModelChange, handleConfigChange } =
+    useModelSelectorState(sessionId);
+  const modelConfig = configOptions.find(isModelConfigOption);
 
-  const comboboxOptions = useMemo(() => modelOptions.map(modelToComboboxOption), [modelOptions]);
-
-  const onValueChange = useCallback(
+  const onModelChange = useCallback(
     (value: string) => {
-      // Don't allow deselecting — always keep a model selected
-      if (!value || !sessionId) return;
+      if (!sessionId) return;
       handleModelChange(sessionId, value);
     },
     [sessionId, handleModelChange],
   );
 
-  if (!sessionId || !currentModel) return null;
+  const onConfigChange = useCallback(
+    (configId: string, value: string) => {
+      if (!sessionId) return;
+      handleConfigChange(sessionId, configId, value);
+    },
+    [sessionId, handleConfigChange],
+  );
+
+  if (!sessionId || (!currentModel && !modelConfig)) return null;
 
   return (
-    <Combobox
-      options={comboboxOptions}
-      value={currentModel}
-      onValueChange={onValueChange}
-      placeholder="Select model..."
-      searchPlaceholder="Filter models..."
-      emptyMessage="No models found."
-      showSearch={modelOptions.length > 5}
-      dropdownLabel="Available Models"
-      triggerClassName="h-7 gap-1 px-2 text-xs w-auto hover:bg-muted/40 whitespace-nowrap"
-      className="min-w-[280px]"
-      plainTrigger
+    <ModelConfigSelector
+      modelOptions={modelOptions}
+      currentModel={currentModel}
+      configOptions={configOptions}
+      onModelChange={onModelChange}
+      onConfigChange={onConfigChange}
+      placeholder="Model"
+      ariaLabel="Session model settings"
+      variant="compact"
       popoverSide="top"
-      popoverAlign="end"
     />
   );
 });

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -329,6 +329,7 @@ export class ApiClient {
     opts: {
       model: string;
       mode?: string;
+      config_options?: Record<string, string>;
       cli_passthrough?: boolean;
       cli_flags?: Array<{ description: string; flag: string; enabled: boolean }>;
       env_vars?: Array<{ key: string; value?: string; secret_id?: string }>;
@@ -341,6 +342,7 @@ export class ApiClient {
       name,
       model: opts.model,
       mode: opts.mode,
+      config_options: opts.config_options,
       cli_passthrough: opts.cli_passthrough ?? false,
       cli_flags: opts.cli_flags,
       env_vars: opts.env_vars,
@@ -367,6 +369,7 @@ export class ApiClient {
       name?: string;
       model?: string;
       mode?: string;
+      config_options?: Record<string, string>;
       cli_passthrough?: boolean;
       cli_flags?: Array<{ description: string; flag: string; enabled: boolean }>;
       env_vars?: Array<{ key: string; value?: string; secret_id?: string }>;

--- a/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
+++ b/apps/web/e2e/tests/settings/agent-profile-acp.spec.ts
@@ -93,6 +93,76 @@ test.describe("Agent profile — ACP-first", () => {
     }
   });
 
+  test("profile model selector shows and saves dynamic config options", async ({
+    testPage,
+    apiClient,
+    backend,
+  }) => {
+    test.setTimeout(60_000);
+
+    await expect
+      .poll(
+        async () => {
+          const resp = await testPage.request.get(`${backend.baseUrl}/api/v1/agents/available`);
+          if (!resp.ok()) return false;
+          const data = (await resp.json()) as {
+            agents?: {
+              name: string;
+              model_config?: { config_options?: { id: string }[] };
+            }[];
+          };
+          const mock = data.agents?.find((a) => a.name === "mock-agent");
+          return Boolean(
+            mock?.model_config?.config_options?.some((option) => option.id === "effort"),
+          );
+        },
+        { timeout: 20_000, intervals: [250, 500, 1000] },
+      )
+      .toBe(true);
+
+    const { agents } = await apiClient.listAgents();
+    const agent = agents.find((item) => item.name === "mock-agent") ?? agents[0];
+    const profile = await apiClient.createAgentProfile(agent.id, "Config Option Test Profile", {
+      model: "mock-fast",
+      config_options: { effort: "high" },
+    });
+
+    try {
+      await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
+      const selector = testPage.getByRole("button", { name: "Profile start model settings" });
+      await expect(selector).toBeVisible({ timeout: 15_000 });
+      await expect(selector).toContainText("High", { timeout: 10_000 });
+
+      await selector.click();
+      await expect(testPage.getByText("Effort", { exact: true })).toBeVisible();
+      await testPage.getByRole("button", { name: "Low", exact: true }).click();
+      await expect(selector).toContainText("Low");
+
+      const saveButton = testPage.getByRole("button", { name: /^Save( changes)?$/i }).first();
+      await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+      await saveButton.click();
+      await expect(testPage.getByText(/unsaved changes/i)).toBeHidden({ timeout: 15_000 });
+
+      await expect
+        .poll(
+          async () => {
+            const saved = (await apiClient.getAgentProfile(profile.id)) as unknown as {
+              configOptions?: Record<string, string>;
+              config_options?: Record<string, string>;
+            };
+            return saved.configOptions?.effort ?? saved.config_options?.effort ?? "";
+          },
+          { timeout: 10_000, intervals: [250, 500, 1000] },
+        )
+        .toBe("low");
+
+      await testPage.reload();
+      await expect(selector).toContainText("Low", { timeout: 15_000 });
+    } finally {
+      await apiClient.deleteAgentProfile(profile.id, true);
+    }
+  });
+
   test("profile mode propagates to session mode selector", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/settings/mobile-agent-profile-config-selector.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-agent-profile-config-selector.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "../../fixtures/test-base";
+
+test.describe("Mobile agent profile config selector", () => {
+  test("changes a dynamic profile config option", async ({ testPage, apiClient, backend }) => {
+    test.setTimeout(60_000);
+
+    await expect
+      .poll(
+        async () => {
+          const resp = await testPage.request.get(`${backend.baseUrl}/api/v1/agents/available`);
+          if (!resp.ok()) return false;
+          const data = (await resp.json()) as {
+            agents?: {
+              name: string;
+              model_config?: { config_options?: { id: string }[] };
+            }[];
+          };
+          const mock = data.agents?.find((a) => a.name === "mock-agent");
+          return Boolean(
+            mock?.model_config?.config_options?.some((option) => option.id === "effort"),
+          );
+        },
+        { timeout: 20_000, intervals: [250, 500, 1000] },
+      )
+      .toBe(true);
+
+    const { agents } = await apiClient.listAgents();
+    const agent = agents.find((item) => item.name === "mock-agent") ?? agents[0];
+    const profile = await apiClient.createAgentProfile(agent.id, "Mobile Config Option Profile", {
+      model: "mock-fast",
+      config_options: { effort: "medium" },
+    });
+
+    try {
+      await testPage.goto(`/settings/agents/${agent.name}/profiles/${profile.id}`);
+      const selector = testPage.getByRole("button", { name: "Profile start model settings" });
+      await expect(selector).toBeVisible({ timeout: 15_000 });
+      await selector.click();
+      await expect(testPage.getByText("Effort", { exact: true })).toBeVisible();
+      await testPage.getByRole("button", { name: "High", exact: true }).click();
+      await expect(selector).toContainText("High");
+    } finally {
+      await apiClient.deleteAgentProfile(profile.id, true);
+    }
+  });
+});

--- a/apps/web/e2e/tests/settings/utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/utility-agents.spec.ts
@@ -148,20 +148,18 @@ test.describe("Utility Agents settings page", () => {
       testPage.getByRole("heading", { name: "Utility Agents", exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
-    // The default-model section has an Agent select (shadcn) and a Model
-    // combobox (the shared ModelCombobox from the profile page). Each is
-    // scoped by the Label above it (no `htmlFor`).
+    // The default-model section has an Agent select (shadcn) and the shared
+    // model/config selector button used by profile settings.
     const agentSelect = testPage
       .locator('div:has(> label:text-is("Agent"))')
       .first()
       .getByRole("combobox");
-    const modelCombobox = testPage
-      .locator('div:has(> label:text-is("Model"))')
-      .first()
-      .getByRole("combobox");
+    const modelSelector = testPage.getByRole("button", {
+      name: "Default utility model settings",
+    });
 
-    // Model combobox starts disabled until an agent is picked.
-    await expect(modelCombobox).toBeDisabled();
+    // Model selector starts disabled until an agent is picked.
+    await expect(modelSelector).toBeDisabled();
 
     // Open the Agent dropdown: the only healthy option in E2E is Mock.
     // This implicitly guards the backend filter — if an auth_required or
@@ -174,21 +172,21 @@ test.describe("Utility Agents settings page", () => {
     await agentListbox.getByRole("option", { name: "Mock", exact: true }).click();
     await expect(agentListbox).not.toBeVisible();
 
-    // Model combobox is now enabled. Open the popover and verify both
-    // probed models are listed as command items, along with the "(default)"
-    // badge on mock-fast.
-    await expect(modelCombobox).toBeEnabled();
-    await modelCombobox.click();
-    await expect(testPage.getByRole("option", { name: /Mock Fast.*\(default\)/ })).toBeVisible();
-    await expect(testPage.getByRole("option", { name: /Mock Smart/ })).toBeVisible();
+    // Model selector is now enabled. Open the popover and verify both
+    // probed models are listed.
+    await expect(modelSelector).toBeEnabled();
+    await modelSelector.click();
+    const suggestions = testPage.getByLabel("Suggestions");
+    await expect(suggestions.getByText("Mock Fast", { exact: true })).toBeVisible();
+    await expect(suggestions.getByText("Mock Smart", { exact: true })).toBeVisible();
 
-    // Search input is part of the ModelCombobox — filtering narrows the list.
-    await testPage.getByPlaceholder("Search models...").fill("smart");
-    await expect(testPage.getByRole("option", { name: /Mock Fast/ })).toHaveCount(0);
+    // Search input is part of the shared selector — filtering narrows the list.
+    await testPage.getByPlaceholder("Filter models...").fill("smart");
+    await expect(suggestions.getByText("Mock Fast", { exact: true })).toHaveCount(0);
 
     // Pick Mock Smart and verify the trigger reflects the selection.
-    await testPage.getByRole("option", { name: /Mock Smart/ }).click();
-    await expect(modelCombobox).toContainText("Mock Smart");
+    await suggestions.getByText("Mock Smart", { exact: true }).click();
+    await expect(modelSelector).toContainText("Mock Smart");
 
     expect(pageErrors, `uncaught errors: ${pageErrors.map((e) => e.message).join("; ")}`).toEqual(
       [],

--- a/apps/web/lib/api/domains/agent-profile-normalize.ts
+++ b/apps/web/lib/api/domains/agent-profile-normalize.ts
@@ -32,6 +32,16 @@ function pickEnvVars(raw: RawProfile): ProfileEnvVar[] {
   return Array.isArray(value) ? (value as ProfileEnvVar[]) : [];
 }
 
+function pickConfigOptions(raw: RawProfile): Record<string, string> | undefined {
+  const value = raw.configOptions ?? raw.config_options;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] =>
+      typeof entry[0] === "string" && typeof entry[1] === "string" && entry[0] !== "",
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 /**
  * Convert a kanban snake_case payload (or a partially-camelCased one) into
  * the canonical `AgentProfile`. Office-orchestration fields are left
@@ -46,6 +56,7 @@ export function normalizeAgentProfile(raw: unknown): AgentProfile {
     agentDisplayName: pickString(profile, "agentDisplayName", "agent_display_name"),
     model: pickString(profile, "model", "model"),
     mode: (profile.mode as string | undefined) ?? undefined,
+    configOptions: pickConfigOptions(profile),
     allowIndexing: pickBool(profile, "allowIndexing", "allow_indexing"),
     autoApprove: pickBool(profile, "autoApprove", "auto_approve"),
     cliFlags: pickFlags(profile),
@@ -57,6 +68,16 @@ export function normalizeAgentProfile(raw: unknown): AgentProfile {
   };
 }
 
+function setPayloadField<K extends keyof AgentProfilePayload>(
+  payload: Partial<AgentProfilePayload>,
+  key: K,
+  value: AgentProfilePayload[K] | undefined,
+) {
+  if (value !== undefined) {
+    payload[key] = value;
+  }
+}
+
 /**
  * Inverse of `normalizeAgentProfile` — convert the canonical shape back to
  * a snake_case wire payload for `POST/PATCH` to the kanban endpoints.
@@ -65,19 +86,20 @@ export function toAgentProfilePayload(
   profile: Partial<AgentProfile>,
 ): Partial<AgentProfilePayload> {
   const payload: Partial<AgentProfilePayload> = {};
-  if (profile.id !== undefined) payload.id = profile.id;
-  if (profile.name !== undefined) payload.name = profile.name;
-  if (profile.agentId !== undefined) payload.agent_id = profile.agentId;
-  if (profile.agentDisplayName !== undefined) payload.agent_display_name = profile.agentDisplayName;
-  if (profile.model !== undefined) payload.model = profile.model;
-  if (profile.mode !== undefined) payload.mode = profile.mode;
-  if (profile.allowIndexing !== undefined) payload.allow_indexing = profile.allowIndexing;
-  if (profile.autoApprove !== undefined) payload.auto_approve = profile.autoApprove;
-  if (profile.cliFlags !== undefined) payload.cli_flags = profile.cliFlags;
-  if (profile.envVars !== undefined) payload.env_vars = profile.envVars;
-  if (profile.cliPassthrough !== undefined) payload.cli_passthrough = profile.cliPassthrough;
-  if (profile.userModified !== undefined) payload.user_modified = profile.userModified;
-  if (profile.createdAt !== undefined) payload.created_at = profile.createdAt;
-  if (profile.updatedAt !== undefined) payload.updated_at = profile.updatedAt;
+  setPayloadField(payload, "id", profile.id);
+  setPayloadField(payload, "name", profile.name);
+  setPayloadField(payload, "agent_id", profile.agentId);
+  setPayloadField(payload, "agent_display_name", profile.agentDisplayName);
+  setPayloadField(payload, "model", profile.model);
+  setPayloadField(payload, "mode", profile.mode);
+  setPayloadField(payload, "config_options", profile.configOptions);
+  setPayloadField(payload, "allow_indexing", profile.allowIndexing);
+  setPayloadField(payload, "auto_approve", profile.autoApprove);
+  setPayloadField(payload, "cli_flags", profile.cliFlags);
+  setPayloadField(payload, "env_vars", profile.envVars);
+  setPayloadField(payload, "cli_passthrough", profile.cliPassthrough);
+  setPayloadField(payload, "user_modified", profile.userModified);
+  setPayloadField(payload, "created_at", profile.createdAt);
+  setPayloadField(payload, "updated_at", profile.updatedAt);
   return payload;
 }

--- a/apps/web/lib/api/domains/session-api.ts
+++ b/apps/web/lib/api/domains/session-api.ts
@@ -100,6 +100,12 @@ export async function setSessionModel(sessionId: string, modelId: string) {
   });
 }
 
+export async function setSessionConfigOption(sessionId: string, configId: string, value: string) {
+  return fetchJson<{ ok: boolean }>(`/api/v1/task-sessions/${sessionId}/set-config-option`, {
+    init: { method: "POST", body: JSON.stringify({ config_id: configId, value }) },
+  });
+}
+
 export async function authenticateSession(sessionId: string, methodId: string) {
   return fetchJson<{ ok: boolean }>(`/api/v1/task-sessions/${sessionId}/authenticate`, {
     init: { method: "POST", body: JSON.stringify({ method_id: methodId }) },

--- a/apps/web/lib/api/domains/utility-api.ts
+++ b/apps/web/lib/api/domains/utility-api.ts
@@ -51,6 +51,15 @@ export type InferenceModel = {
   meta?: Record<string, unknown>;
 };
 
+export type InferenceConfigOption = {
+  type: string;
+  id: string;
+  name: string;
+  current_value: string;
+  category?: string;
+  options?: { value: string; name: string }[];
+};
+
 /**
  * Probe outcome for the host-utility agentctl instance backing this agent.
  * Mirrors `hostutility.Status` (`apps/backend/internal/agent/hostutility/types.go`).
@@ -71,6 +80,7 @@ export type InferenceAgent = {
   name: string;
   display_name: string;
   models: InferenceModel[];
+  config_options?: InferenceConfigOption[];
   // Optional so older backends (or non-OK API consumers) that omit the
   // field decode without forcing a default; the UI treats missing status
   // as healthy when models are present.

--- a/apps/web/lib/config-options.ts
+++ b/apps/web/lib/config-options.ts
@@ -1,0 +1,11 @@
+export function areConfigOptionsEqual(
+  a?: Record<string, string>,
+  b?: Record<string, string>,
+): boolean {
+  const left = a ?? {};
+  const right = b ?? {};
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  if (leftKeys.length !== rightKeys.length) return false;
+  return leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
+}

--- a/apps/web/lib/types/agent-profile.ts
+++ b/apps/web/lib/types/agent-profile.ts
@@ -61,10 +61,12 @@ export type AgentProfile = {
   agentDisplayName: string;
 
   // --- CLI subprocess config ---
-  /** Model ID applied via ACP `session/set_model` at session start. */
+  /** Model ID applied through ACP session model selection at session start. */
   model: string;
   /** Optional ACP session mode applied via `session/set_mode`. */
   mode?: string;
+  /** Dynamic ACP session config options applied via `session/set_config_option`. */
+  configOptions?: Record<string, string>;
   /** @deprecated Use cliFlags. Retained for legacy clients. */
   allowIndexing: boolean;
   /** Kandev agentctl auto-approves ACP permission_request prompts when true. */
@@ -138,6 +140,7 @@ export type AgentProfilePayload = {
   agent_display_name: string;
   model: string;
   mode?: string;
+  config_options?: Record<string, string>;
   allow_indexing: boolean;
   auto_approve: boolean;
   cli_flags: CLIFlag[];

--- a/apps/web/lib/types/http-agents.ts
+++ b/apps/web/lib/types/http-agents.ts
@@ -113,6 +113,15 @@ export type CommandEntry = {
   description?: string;
 };
 
+export type ConfigOptionEntry = {
+  type: string;
+  id: string;
+  name: string;
+  current_value: string;
+  category?: string;
+  options?: { value: string; name: string }[];
+};
+
 // CapabilityStatus mirrors the host utility probe status. "probing" is the
 // in-flight state; "ok" is populated; the remaining values signal errors the
 // UI can surface directly (auth, install, generic failure, not started yet).
@@ -131,6 +140,7 @@ export type ModelConfig = {
   available_modes?: ModeEntry[];
   current_mode_id?: string;
   available_commands?: CommandEntry[];
+  config_options?: ConfigOptionEntry[];
   supports_dynamic_models: boolean;
   status?: CapabilityStatus;
   error?: string;


### PR DESCRIPTION
Claude ACP agents advertise model and mode choices through session
`configOptions` rather than the legacy `models`/`modes` fields, so ACP
probes returned empty lists. This adds a fallback parser so discovery
surfaces the available choices.

## Validation

- `make -C apps/backend fmt`
- `go test ./internal/agent/acpdbg/... -count=1`
- `golangci-lint run ./internal/agent/acpdbg/...`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

Made with [Cursor](https://cursor.com)