### PR TITLE
fix: default changes panel to tree view

### DIFF
--- a/apps/backend/internal/user/store/sqlite.go
+++ b/apps/backend/internal/user/store/sqlite.go
@@ -259,7 +259,7 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 		settings.ChatSubmitKey = "cmd_enter"
 		settings.KeyboardShortcuts = map[string]interface{}{}
 		settings.TerminalLinkBehavior = "new_tab"
-		settings.ChangesPanelLayout = "flat"
+		settings.ChangesPanelLayout = "tree"
 		settings.SidebarViews = []models.SidebarView{}
 		settings.VoiceMode = defaultVoiceModeSettings()
 		return settings, nil
@@ -350,10 +350,10 @@ func scanUserSettings(scanner interface{ Scan(dest ...any) error }, userID strin
 	settings.TerminalFontFamily = payload.TerminalFontFamily
 	settings.TerminalFontSize = payload.TerminalFontSize
 	settings.VoiceMode = mergeVoiceModeDefaults(payload.VoiceMode)
-	if payload.ChangesPanelLayout == "tree" {
-		settings.ChangesPanelLayout = "tree"
-	} else {
+	if payload.ChangesPanelLayout == "flat" {
 		settings.ChangesPanelLayout = "flat"
+	} else {
+		settings.ChangesPanelLayout = "tree"
 	}
 	return settings, nil
 }

--- a/apps/backend/internal/user/store/sqlite_test.go
+++ b/apps/backend/internal/user/store/sqlite_test.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+type settingsScanner struct {
+	raw string
+}
+
+func (s settingsScanner) Scan(dest ...any) error {
+	*(dest[0].(*string)) = s.raw
+	*(dest[1].(*time.Time)) = time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	return nil
+}
+
+func TestScanUserSettingsChangesPanelLayoutDefault(t *testing.T) {
+	t.Run("empty settings default to tree", func(t *testing.T) {
+		settings, err := scanUserSettings(settingsScanner{raw: "{}"}, DefaultUserID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if settings.ChangesPanelLayout != "tree" {
+			t.Fatalf("expected ChangesPanelLayout=tree, got %q", settings.ChangesPanelLayout)
+		}
+	})
+
+	t.Run("missing layout defaults to tree", func(t *testing.T) {
+		settings, err := scanUserSettings(settingsScanner{raw: `{"chat_submit_key":"cmd_enter"}`}, DefaultUserID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if settings.ChangesPanelLayout != "tree" {
+			t.Fatalf("expected ChangesPanelLayout=tree, got %q", settings.ChangesPanelLayout)
+		}
+	})
+
+	t.Run("explicit flat is preserved", func(t *testing.T) {
+		settings, err := scanUserSettings(settingsScanner{raw: `{"changes_panel_layout":"flat"}`}, DefaultUserID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if settings.ChangesPanelLayout != "flat" {
+			t.Fatalf("expected ChangesPanelLayout=flat, got %q", settings.ChangesPanelLayout)
+		}
+	})
+}

--- a/apps/backend/internal/user/store/sqlite_test.go
+++ b/apps/backend/internal/user/store/sqlite_test.go
@@ -11,7 +11,7 @@ type settingsScanner struct {
 
 func (s settingsScanner) Scan(dest ...any) error {
 	*(dest[0].(*string)) = s.raw
-	*(dest[1].(*time.Time)) = time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	*(dest[1].(*time.Time)) = time.Time{}
 	return nil
 }
 

--- a/apps/web/components/settings/editors-settings-state.tsx
+++ b/apps/web/components/settings/editors-settings-state.tsx
@@ -7,7 +7,11 @@ import { createEditor, deleteEditor, updateEditor, updateUserSettings } from "@/
 import { useRequest } from "@/lib/http/use-request";
 import type { EditorOption } from "@/lib/types/http";
 import { type ComboboxOption } from "@/components/combobox";
-import { parseTerminalLinkBehavior, parseVoiceMode } from "@/lib/ssr/user-settings";
+import {
+  parseChangesPanelLayout,
+  parseTerminalLinkBehavior,
+  parseVoiceMode,
+} from "@/lib/ssr/user-settings";
 import { fromApiSidebarView } from "@/lib/state/slices/ui/sidebar-view-wire";
 import {
   type EditorFormState,
@@ -244,7 +248,7 @@ function buildUserSettingsFromResponse(
     terminalLinkBehavior: parseTerminalLinkBehavior(s.terminal_link_behavior),
     terminalFontFamily: s.terminal_font_family || null,
     terminalFontSize: s.terminal_font_size || null,
-    changesPanelLayout: s.changes_panel_layout === "tree" ? ("tree" as const) : ("flat" as const),
+    changesPanelLayout: parseChangesPanelLayout(s.changes_panel_layout),
     voiceMode: parseVoiceMode(s.voice_mode),
     ...mapEditorSettingsFields(s),
   };

--- a/apps/web/components/task/changes-panel-body.tsx
+++ b/apps/web/components/task/changes-panel-body.tsx
@@ -108,7 +108,7 @@ type WorkingTreeProps = Pick<
   | "onRepoUnstageAll"
   | "onRepoCommit"
   | "repoDisplayName"
-> & { isLastUnstaged: boolean; isLastStaged: boolean };
+>;
 
 function WorkingTreeSections(props: WorkingTreeProps) {
   const isBulkOp = props.pendingStageFiles.size === 0;
@@ -119,7 +119,6 @@ function WorkingTreeSections(props: WorkingTreeProps) {
           variant="unstaged"
           files={props.unstagedFiles}
           pendingStageFiles={props.pendingStageFiles}
-          isLast={props.isLastUnstaged}
           actionLabel="Stage all"
           isActionLoading={isBulkOp && props.loadingOperation === "stage"}
           onAction={props.onStageAll}
@@ -139,7 +138,6 @@ function WorkingTreeSections(props: WorkingTreeProps) {
           variant="staged"
           files={props.stagedFiles}
           pendingStageFiles={props.pendingStageFiles}
-          isLast={props.isLastStaged}
           actionLabel="Commit"
           isActionLoading={props.loadingOperation === "commit"}
           onAction={() => props.dialogs.openCommitDialog()}
@@ -174,9 +172,7 @@ function ChangesPanelTimeline(props: TimelineProps) {
   const mergedCommits = mergeCommits(props.commits, props.prCommits);
   const hasMergedCommits = mergedCommits.length > 0;
   const hasLocalChanges = props.hasUnstaged || props.hasStaged;
-  const showCommits = props.hasStaged || props.hasCommits;
   const showCommitsList = props.hasStaged || hasMergedCommits;
-  const hasSomethingAfterStaged = (props.hasPRFiles && hasLocalChanges) || showCommitsList;
   // Auto-expand the first (topmost) visible section so the panel never opens
   // looking empty (e.g. review mode: PR + Commits both collapsed). Unstaged /
   // Staged keep their always-expanded default; PR and Commits are gated. Large
@@ -195,7 +191,6 @@ function ChangesPanelTimeline(props: TimelineProps) {
         <div data-testid="pr-files-section">
           <PRFilesSection
             files={props.prFiles}
-            isLast={!showCommitsList}
             onOpenDiff={props.onOpenDiffFile}
             repoDisplayName={props.repoDisplayName}
             defaultCollapsed={firstSection !== "pr"}
@@ -203,17 +198,12 @@ function ChangesPanelTimeline(props: TimelineProps) {
         </div>
       )}
 
-      <WorkingTreeSections
-        {...props}
-        isLastUnstaged={!props.hasStaged && !hasSomethingAfterStaged}
-        isLastStaged={!hasSomethingAfterStaged}
-      />
+      <WorkingTreeSections {...props} />
 
       {props.hasPRFiles && hasLocalChanges && (
         <div data-testid="pr-files-section">
           <PRFilesSection
             files={props.prFiles}
-            isLast={!showCommitsList}
             onOpenDiff={props.onOpenDiffFile}
             repoDisplayName={props.repoDisplayName}
           />
@@ -223,7 +213,6 @@ function ChangesPanelTimeline(props: TimelineProps) {
       {showCommitsList && (
         <CommitsSection
           commits={mergedCommits}
-          isLast={!showCommits}
           defaultCollapsed={firstSection !== "commits"}
           onOpenCommitDetail={props.onOpenCommitDetail}
           onRevertCommit={props.onRevertCommit}

--- a/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
+++ b/apps/web/components/task/changes-panel-timeline-grouping.test.tsx
@@ -43,7 +43,7 @@ afterEach(cleanup);
 type Props = ComponentProps<typeof FileListSection>;
 type CommitProps = ComponentProps<typeof CommitsSection>;
 
-const baseProps: Omit<Props, "files" | "variant" | "isLast" | "actionLabel" | "onAction"> = {
+const baseProps: Omit<Props, "files" | "variant" | "actionLabel" | "onAction"> = {
   pendingStageFiles: new Set(),
   onOpenDiff: vi.fn(),
   onEditFile: vi.fn(),
@@ -84,7 +84,6 @@ describe("FileListSection — multi-repo grouping", () => {
       <FileListSection
         {...baseProps}
         variant="unstaged"
-        isLast={false}
         actionLabel="Stage all"
         onAction={() => undefined}
         onRepoAction={() => undefined}
@@ -102,7 +101,6 @@ describe("FileListSection — multi-repo grouping", () => {
       <FileListSection
         {...baseProps}
         variant="unstaged"
-        isLast={false}
         actionLabel="Stage all"
         onAction={() => undefined}
         files={[
@@ -125,7 +123,6 @@ describe("FileListSection — multi-repo grouping", () => {
       <FileListSection
         {...baseProps}
         variant="unstaged"
-        isLast={false}
         actionLabel="Stage all"
         onAction={() => undefined}
         files={[file("a.ts", "only-repo")]}
@@ -139,7 +136,6 @@ describe("FileListSection — multi-repo grouping", () => {
       <FileListSection
         {...baseProps}
         variant="unstaged"
-        isLast={false}
         actionLabel="Stage all"
         onAction={() => undefined}
         files={[
@@ -172,7 +168,7 @@ describe("FileListSection — multi-repo grouping", () => {
 
 describe("CommitsSection", () => {
   it("renders the commits section header collapsed by default", () => {
-    render(<CommitsSection commits={[commit("abc123", "first")]} isLast />);
+    render(<CommitsSection commits={[commit("abc123", "first")]} />);
     // Commits section is collapsed by default; the toggle reflects that and
     // the commit rows are not in the DOM until the user expands the section.
     const toggle = screen.getByTestId(COMMITS_SECTION_TOGGLE_TID);
@@ -192,7 +188,6 @@ describe("CommitsSection", () => {
           commit("c2", "backend change", "backend"),
           commit("c3", "another frontend", "frontend"),
         ]}
-        isLast
       />,
     );
     fireEvent.click(screen.getByTestId(COMMITS_SECTION_TOGGLE_TID));
@@ -211,7 +206,6 @@ describe("CommitsSection", () => {
     render(
       <CommitsSection
         commits={[commit("c1", "msg"), commit("c2", "msg")]}
-        isLast
         onRepoPush={() => undefined}
       />,
     );
@@ -226,7 +220,6 @@ describe("CommitsSection actions", () => {
     render(
       <CommitsSection
         commits={[commit("c1", "already pushed"), commit("c2", "also pushed")]}
-        isLast
         onRepoPush={() => undefined}
         perRepoStatus={[{ repository_name: "", ahead: 0 }]}
       />,
@@ -243,7 +236,6 @@ describe("CommitsSection actions", () => {
     render(
       <CommitsSection
         commits={[commit("c1", "newest"), commit("c2", "middle"), commit("c3", "oldest")]}
-        isLast
         onRepoPush={() => undefined}
         perRepoStatus={[{ repository_name: "", ahead: 1 }]}
       />,
@@ -269,7 +261,6 @@ describe("CommitsSection actions", () => {
           commit("frontend-old", "frontend older", "frontend"),
           commit("backend-only", "backend latest", "backend"),
         ]}
-        isLast
         onRevertCommit={() => undefined}
       />,
     );
@@ -290,19 +281,14 @@ describe("section auto-expand (defaultCollapsed prop)", () => {
   }
 
   it("PR Changes is collapsed by default (no prop)", () => {
-    render(<PRFilesSection files={[prFile("a.ts")]} isLast onOpenDiff={vi.fn()} />);
+    render(<PRFilesSection files={[prFile("a.ts")]} onOpenDiff={vi.fn()} />);
     expect(screen.getByTestId(PR_TOGGLE_TID).getAttribute(ARIA_EXPANDED)).toBe("false");
     expect(screen.queryByTestId("pr-files-list")).toBeNull();
   });
 
   it("PR Changes is expanded when defaultCollapsed={false}", () => {
     render(
-      <PRFilesSection
-        files={[prFile("a.ts")]}
-        isLast
-        onOpenDiff={vi.fn()}
-        defaultCollapsed={false}
-      />,
+      <PRFilesSection files={[prFile("a.ts")]} onOpenDiff={vi.fn()} defaultCollapsed={false} />,
     );
     expect(screen.getByTestId(PR_TOGGLE_TID).getAttribute(ARIA_EXPANDED)).toBe("true");
     expect(screen.getByTestId("pr-files-list")).toBeTruthy();
@@ -321,7 +307,6 @@ describe("section auto-expand (defaultCollapsed prop)", () => {
             repository_name: undefined,
           },
         ]}
-        isLast
         defaultCollapsed={false}
       />,
     );

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -43,7 +43,6 @@ function TimelineSection({
   label,
   count,
   action,
-  isLast,
   children,
   collapsible = true,
   defaultCollapsed = false,
@@ -80,7 +79,6 @@ function TimelineSection({
       {/* Vertical line + dot */}
       <div className="flex flex-col items-center">
         <TimelineDot color={dotColor} />
-        {!isLast && <div className="w-px flex-1 bg-border/60" />}
       </div>
 
       {/* Content */}

--- a/apps/web/components/task/changes-panel-timeline.tsx
+++ b/apps/web/components/task/changes-panel-timeline.tsx
@@ -52,7 +52,6 @@ function TimelineSection({
   label?: string;
   count?: number;
   action?: React.ReactNode;
-  isLast?: boolean;
   children?: React.ReactNode;
   collapsible?: boolean;
   defaultCollapsed?: boolean;
@@ -130,7 +129,6 @@ function TimelineSection({
 
 type CommitsSectionProps = {
   commits: CommitItem[];
-  isLast: boolean;
   onOpenCommitDetail?: (sha: string, repo?: string) => void;
   // Handlers receive the commit's repository_name so amend/revert/reset land
   // in the right git repo. The empty string routes to the workspace root for
@@ -158,7 +156,6 @@ type CommitsSectionProps = {
 
 export function CommitsSection({
   commits,
-  isLast,
   onOpenCommitDetail,
   onRevertCommit,
   onAmendCommit,
@@ -194,7 +191,6 @@ export function CommitsSection({
       dotColor={DOT_COLORS.commits}
       label="Commits"
       count={commits.length}
-      isLast={isLast}
       defaultCollapsed={defaultCollapsed}
       data-testid="commits-section"
       action={sectionAction}
@@ -229,7 +225,6 @@ type FileListSectionProps = {
   variant: "unstaged" | "staged";
   files: ChangedFile[];
   pendingStageFiles: Set<string>;
-  isLast: boolean;
   actionLabel: string;
   isActionLoading?: boolean;
   onAction: () => void;
@@ -442,7 +437,6 @@ export function FileListSection(props: FileListSectionProps) {
     variant,
     files,
     pendingStageFiles,
-    isLast,
     onOpenDiff,
     onEditFile,
     onStage,
@@ -474,7 +468,6 @@ export function FileListSection(props: FileListSectionProps) {
       dotColor={dotColor}
       label={label}
       count={files.length}
-      isLast={isLast}
       data-testid={`${variant}-files-section`}
       action={
         isSingleRepo ? (
@@ -541,7 +534,6 @@ export type PRChangedFile = {
 
 type PRFilesSectionProps = {
   files: PRChangedFile[];
-  isLast: boolean;
   onOpenDiff: (path: string, options?: OpenDiffOptions) => void;
   /** Maps a repository_name to a human-readable label (used for the per-repo header). */
   repoDisplayName?: (repositoryName: string) => string | undefined;
@@ -551,7 +543,6 @@ type PRFilesSectionProps = {
 
 export function PRFilesSection({
   files,
-  isLast,
   onOpenDiff,
   repoDisplayName,
   defaultCollapsed = true,
@@ -561,7 +552,6 @@ export function PRFilesSection({
       dotColor={DOT_COLORS.pr}
       label="PR Changes"
       count={files.length}
-      isLast={isLast}
       defaultCollapsed={defaultCollapsed}
       data-testid="pr-changes-section"
     >

--- a/apps/web/e2e/tests/changes-panel-active-tab-highlight.spec.ts
+++ b/apps/web/e2e/tests/changes-panel-active-tab-highlight.spec.ts
@@ -99,11 +99,10 @@ test.describe("Changes Panel — Active-Tab Highlight", () => {
     // for the same path is still the active panel.
     git.stageFile("staged-active.ts");
 
-    const stagedList = session.changes.getByTestId("staged-file-list");
-    await expect(stagedList.getByText("staged-active.ts")).toBeVisible({ timeout: 15_000 });
+    const stagedRow = session.changesFileRow("staged-active.ts");
+    await expect(stagedRow).toBeVisible({ timeout: 15_000 });
 
-    // The active row should now live inside the staged list.
-    const stagedRow = stagedList.locator(`[data-changes-file="staged-active.ts"]`);
+    // The active row should still be the same staged path.
     await expect(stagedRow).toHaveAttribute("data-active", "true", { timeout: 5_000 });
   });
 });

--- a/apps/web/e2e/tests/changes-panel-active-tab-highlight.spec.ts
+++ b/apps/web/e2e/tests/changes-panel-active-tab-highlight.spec.ts
@@ -99,8 +99,11 @@ test.describe("Changes Panel — Active-Tab Highlight", () => {
     // for the same path is still the active panel.
     git.stageFile("staged-active.ts");
 
-    const stagedRow = session.changesFileRow("staged-active.ts");
+    const stagedSection = testPage.getByTestId("staged-files-section");
+    const unstagedSection = testPage.getByTestId("unstaged-files-section");
+    const stagedRow = stagedSection.locator('[data-changes-file="staged-active.ts"]');
     await expect(stagedRow).toBeVisible({ timeout: 15_000 });
+    await expect(unstagedSection.locator('[data-changes-file="staged-active.ts"]')).toHaveCount(0);
 
     // The active row should still be the same staged path.
     await expect(stagedRow).toHaveAttribute("data-active", "true", { timeout: 5_000 });

--- a/apps/web/e2e/tests/changes-panel-multi-select.spec.ts
+++ b/apps/web/e2e/tests/changes-panel-multi-select.spec.ts
@@ -87,9 +87,8 @@ test.describe("Git Panel Multi-Select", () => {
 
     await session.changesBulkStageButton().click();
 
-    const stagedList = session.changes.getByTestId("staged-file-list");
-    await expect(stagedList.getByText("stage-a.ts")).toBeVisible({ timeout: 15_000 });
-    await expect(stagedList.getByText("stage-b.ts")).toBeVisible({ timeout: 15_000 });
+    await expect(session.changesFileRow("stage-a.ts")).toBeVisible({ timeout: 15_000 });
+    await expect(session.changesFileRow("stage-b.ts")).toBeVisible({ timeout: 15_000 });
   });
 
   test("escape clears selection in git panel", async ({
@@ -125,8 +124,7 @@ test.describe("Git Panel Multi-Select", () => {
     const bulkBar = session.changesBulkActionBar("unstaged");
     await expect(bulkBar).toBeVisible({ timeout: 5_000 });
 
-    const fileList = testPage.getByTestId("unstaged-file-list");
-    await fileList.focus();
+    await fileA.focus();
     await testPage.keyboard.press("Escape");
 
     await expect(session.changesSelectedRows()).toHaveCount(0, { timeout: 5_000 });

--- a/apps/web/e2e/tests/changes-panel-multi-select.spec.ts
+++ b/apps/web/e2e/tests/changes-panel-multi-select.spec.ts
@@ -87,8 +87,16 @@ test.describe("Git Panel Multi-Select", () => {
 
     await session.changesBulkStageButton().click();
 
-    await expect(session.changesFileRow("stage-a.ts")).toBeVisible({ timeout: 15_000 });
-    await expect(session.changesFileRow("stage-b.ts")).toBeVisible({ timeout: 15_000 });
+    const stagedSection = testPage.getByTestId("staged-files-section");
+    const unstagedSection = testPage.getByTestId("unstaged-files-section");
+    await expect(stagedSection.locator('[data-changes-file="stage-a.ts"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(stagedSection.locator('[data-changes-file="stage-b.ts"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(unstagedSection.locator('[data-changes-file="stage-a.ts"]')).toHaveCount(0);
+    await expect(unstagedSection.locator('[data-changes-file="stage-b.ts"]')).toHaveCount(0);
   });
 
   test("escape clears selection in git panel", async ({

--- a/apps/web/hooks/use-user-display-settings.ts
+++ b/apps/web/hooks/use-user-display-settings.ts
@@ -59,7 +59,7 @@ function carryForwardCoreSettings(current: DisplaySettings) {
     sidebarViews: current.sidebarViews ?? [],
     defaultUtilityAgentId: current.defaultUtilityAgentId ?? null,
     keyboardShortcuts: current.keyboardShortcuts ?? {},
-    changesPanelLayout: current.changesPanelLayout ?? "flat",
+    changesPanelLayout: current.changesPanelLayout ?? "tree",
     voiceMode: current.voiceMode ?? { ...DEFAULT_VOICE_MODE_STATE },
   };
 }

--- a/apps/web/lib/ssr/user-settings.test.ts
+++ b/apps/web/lib/ssr/user-settings.test.ts
@@ -90,9 +90,9 @@ describe("mapUserSettingsResponse", () => {
     expect(result.terminalFontFamily).toBeNull();
   });
 
-  it("defaults changesPanelLayout to flat when response is null", () => {
+  it("defaults changesPanelLayout to tree when response is null", () => {
     const result = mapUserSettingsResponse(null);
-    expect(result.changesPanelLayout).toBe("flat");
+    expect(result.changesPanelLayout).toBe("tree");
   });
 });
 
@@ -101,11 +101,14 @@ describe("parseChangesPanelLayout", () => {
     expect(parseChangesPanelLayout("tree")).toBe("tree");
   });
 
-  it('returns "flat" for "flat", undefined, or unknown values', () => {
+  it('returns "flat" only for "flat"', () => {
     expect(parseChangesPanelLayout("flat")).toBe("flat");
-    expect(parseChangesPanelLayout(undefined)).toBe("flat");
-    expect(parseChangesPanelLayout("grid")).toBe("flat");
-    expect(parseChangesPanelLayout("")).toBe("flat");
+  });
+
+  it('returns "tree" for undefined or unknown values', () => {
+    expect(parseChangesPanelLayout(undefined)).toBe("tree");
+    expect(parseChangesPanelLayout("grid")).toBe("tree");
+    expect(parseChangesPanelLayout("")).toBe("tree");
   });
 });
 

--- a/apps/web/lib/ssr/user-settings.ts
+++ b/apps/web/lib/ssr/user-settings.ts
@@ -11,7 +11,7 @@ export function parseTerminalLinkBehavior(value: string | undefined): "new_tab" 
 }
 
 export function parseChangesPanelLayout(value: string | undefined): "flat" | "tree" {
-  return value === "tree" ? "tree" : "flat";
+  return value === "flat" ? "flat" : "tree";
 }
 
 /**
@@ -116,7 +116,7 @@ export function mapUserSettingsResponse(response: UserSettingsResponse | null) {
       terminalLinkBehavior: "new_tab" as const,
       terminalFontFamily: null,
       terminalFontSize: null,
-      changesPanelLayout: "flat" as const,
+      changesPanelLayout: "tree" as const,
       voiceMode: { ...DEFAULT_VOICE_MODE_STATE },
       ...buildLspFields(undefined),
       loaded: false,

--- a/apps/web/lib/state/slices/settings/settings-slice.ts
+++ b/apps/web/lib/state/slices/settings/settings-slice.ts
@@ -43,7 +43,7 @@ export const defaultSettingsState: SettingsSliceState = {
     keyboardShortcuts: {},
     terminalFontFamily: null,
     terminalFontSize: null,
-    changesPanelLayout: "flat",
+    changesPanelLayout: "tree",
     voiceMode: { ...DEFAULT_VOICE_MODE_STATE },
     loaded: false,
   },

--- a/apps/web/lib/ws/handlers/users.ts
+++ b/apps/web/lib/ws/handlers/users.ts
@@ -1,7 +1,7 @@
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
-import { parseVoiceMode } from "@/lib/ssr/user-settings";
+import { parseChangesPanelLayout, parseVoiceMode } from "@/lib/ssr/user-settings";
 
 export function registerUsersHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
@@ -31,7 +31,7 @@ export function registerUsersHandlers(store: StoreApi<AppState>): WsHandlers {
             message.payload.terminal_link_behavior === "browser_panel"
               ? "browser_panel"
               : "new_tab",
-          changesPanelLayout: message.payload.changes_panel_layout === "tree" ? "tree" : "flat",
+          changesPanelLayout: parseChangesPanelLayout(message.payload.changes_panel_layout),
           voiceMode: parseVoiceMode(message.payload.voice_mode),
           loaded: true,
         },


### PR DESCRIPTION
The changes panel should open in the hierarchy users expect without drawing a second border near the panel edge. Missing layout preferences now resolve to tree view, and the changes timeline no longer renders the left guideline.

## Important Changes

- Centralized frontend layout parsing so SSR, WebSocket updates, editor settings, and carry-forward settings share the same tree-default behavior.
- Updated backend user-settings normalization so empty or missing stored layout values default to tree while preserving explicit flat preferences.

## Validation

- `make fmt`
- `make typecheck`
- `make test` failed in `internal/system/updates` with service-mode env vars set in this shell; backend passed after unsetting `KANDEV_RUNNING_AS_SERVICE`, `KANDEV_SERVICE_MANAGER`, `KANDEV_SERVICE_METADATA`, and `KANDEV_SERVICE_MODE`.
- `make test-web`
- `make test-cli`
- `make lint`
- `pnpm --filter @kandev/web test lib/ssr/user-settings.test.ts components/task/changes-panel-timeline-grouping.test.tsx components/task/changes-panel-tree.test.tsx`
- `pnpm --filter @kandev/web typecheck`
- `go test ./internal/user/store ./internal/user/service`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.