### PR TITLE
fix(acp): handle config-option-only model state

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
@@ -55,8 +55,9 @@ func (a *Adapter) NewSession(ctx context.Context, mcpServers []types.McpServer) 
 	a.mu.Lock()
 	a.sessionID = string(resp.SessionId)
 	sessionID := a.sessionID
-	if resp.Models != nil {
-		a.availableModels = resp.Models.AvailableModels
+	initialModels := initialSessionModelState(resp.Models, resp.Meta, resp.ConfigOptions)
+	if initialModels != nil {
+		a.availableModels = initialModels.AvailableModels
 	}
 	a.mu.Unlock()
 	a.attachMgr.SetSessionID(sessionID)
@@ -69,9 +70,10 @@ func (a *Adapter) NewSession(ctx context.Context, mcpServers []types.McpServer) 
 		a.emitInitialModeState(resp.Modes)
 	}
 
-	// Emit session models if the agent returned model state
-	if resp.Models != nil {
-		a.emitSessionModels(sessionID, resp.Models, resp.Meta, resp.ConfigOptions)
+	// Emit session models if the agent returned model state, or if it exposes
+	// model selection only through configOptions.
+	if initialModels != nil {
+		a.emitSessionModels(sessionID, initialModels, resp.Meta, resp.ConfigOptions)
 	}
 
 	// Emit session status event to normalize with other adapters.
@@ -87,6 +89,30 @@ func (a *Adapter) NewSession(ctx context.Context, mcpServers []types.McpServer) 
 	})
 
 	return sessionID, nil
+}
+
+func initialSessionModelState(
+	models *acp.SessionModelState,
+	meta map[string]any,
+	configOptions []acp.SessionConfigOption,
+) *acp.SessionModelState {
+	if models != nil {
+		return models
+	}
+	if hasModelConfigOption(convertACPConfigOptions(configOptions)) ||
+		hasModelConfigOption(extractConfigOptions(meta)) {
+		return &acp.SessionModelState{}
+	}
+	return nil
+}
+
+func hasModelConfigOption(options []streams.ConfigOption) bool {
+	for _, option := range options {
+		if option.ID == configOptionIDModel || option.Category == configOptionIDModel {
+			return true
+		}
+	}
+	return false
 }
 
 // effectiveMcpCapabilities applies the adapter's AssumeMcpSse/AssumeMcpHttp

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
@@ -99,8 +99,7 @@ func initialSessionModelState(
 	if models != nil {
 		return models
 	}
-	if hasModelConfigOption(convertACPConfigOptions(configOptions)) ||
-		hasModelConfigOption(extractConfigOptions(meta)) {
+	if hasModelConfigOption(sessionConfigOptions(meta, configOptions)) {
 		return &acp.SessionModelState{}
 	}
 	return nil
@@ -113,6 +112,14 @@ func hasModelConfigOption(options []streams.ConfigOption) bool {
 		}
 	}
 	return false
+}
+
+func sessionConfigOptions(meta map[string]any, acpConfigOptions []acp.SessionConfigOption) []streams.ConfigOption {
+	configOptions := convertACPConfigOptions(acpConfigOptions)
+	if len(configOptions) > 0 {
+		return configOptions
+	}
+	return extractConfigOptions(meta)
 }
 
 // effectiveMcpCapabilities applies the adapter's AssumeMcpSse/AssumeMcpHttp
@@ -394,11 +401,9 @@ func (a *Adapter) emitInitialModeState(modes *acp.SessionModeState) {
 // emitSessionModels emits a session_models event from the session response.
 func (a *Adapter) emitSessionModels(sessionID string, models *acp.SessionModelState, meta map[string]any, acpConfigOptions []acp.SessionConfigOption) {
 	currentModelID := string(models.CurrentModelId)
-	// Prefer typed config options from the response; fall back to _meta extraction for older agents
-	configOptions := convertACPConfigOptions(acpConfigOptions)
-	if len(configOptions) == 0 {
-		configOptions = extractConfigOptions(meta)
-	}
+	// Prefer typed config options from the response; fall back to _meta
+	// extraction for older agents.
+	configOptions := sessionConfigOptions(meta, acpConfigOptions)
 
 	// Fallback: if the SDK didn't parse currentModelId (some agents omit it),
 	// try to resolve it from a model-shaped configOption. We deliberately do

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_session.go
@@ -292,8 +292,9 @@ func (a *Adapter) LoadSession(ctx context.Context, sessionID string, mcpServers 
 
 	a.mu.Lock()
 	a.sessionID = sessionID
-	if resp.Models != nil {
-		a.availableModels = resp.Models.AvailableModels
+	initialModels := initialSessionModelState(resp.Models, resp.Meta, resp.ConfigOptions)
+	if initialModels != nil {
+		a.availableModels = initialModels.AvailableModels
 	}
 	a.mu.Unlock()
 	a.attachMgr.SetSessionID(sessionID)
@@ -306,9 +307,10 @@ func (a *Adapter) LoadSession(ctx context.Context, sessionID string, mcpServers 
 		a.emitInitialModeState(resp.Modes)
 	}
 
-	// Emit session models if the agent returned model state
-	if resp.Models != nil {
-		a.emitSessionModels(sessionID, resp.Models, resp.Meta, resp.ConfigOptions)
+	// Emit session models if the agent returned model state, or if it exposes
+	// model selection only through configOptions.
+	if initialModels != nil {
+		a.emitSessionModels(sessionID, initialModels, resp.Meta, resp.ConfigOptions)
 	}
 
 	// Re-emit plan captured during history replay and clear the loading flag.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
@@ -195,6 +195,39 @@ func TestInitialSessionModelState_UsesConfigOptionsWithoutModels(t *testing.T) {
 	}
 }
 
+func TestInitialSessionModelState_UsesMetaConfigOptionsWithoutModels(t *testing.T) {
+	meta := map[string]any{
+		"configOptions": []any{
+			map[string]any{
+				"type":         "select",
+				"id":           "model",
+				"name":         "Model",
+				"category":     "model",
+				"currentValue": "gpt-5.5",
+			},
+		},
+	}
+
+	models := initialSessionModelState(nil, meta, nil)
+	if models == nil {
+		t.Fatal("initialSessionModelState returned nil for meta configOptions-only response")
+	}
+
+	a := newTestAdapter()
+	a.emitSessionModels("sess-1", models, meta, nil)
+
+	ev := findSessionModelsEvent(t, drainEvents(a))
+	if ev.CurrentModelID != "gpt-5.5" {
+		t.Errorf("CurrentModelID = %q, want %q", ev.CurrentModelID, "gpt-5.5")
+	}
+	if len(ev.ConfigOptions) != 1 {
+		t.Fatalf("ConfigOptions len = %d, want 1", len(ev.ConfigOptions))
+	}
+	if ev.ConfigOptions[0].ID != "model" {
+		t.Errorf("ConfigOptions[0].ID = %q, want model", ev.ConfigOptions[0].ID)
+	}
+}
+
 func TestInitialSessionModelState_IgnoresNonModelConfigOptions(t *testing.T) {
 	modeCategory := acp.SessionConfigOptionCategoryMode
 	modeOptions := acp.SessionConfigSelectOptionsUngrouped{

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
@@ -158,6 +158,65 @@ func TestEmitSessionModels_EmptyCurrentIDComposesReasoningEffortFromTypedOptions
 	}
 }
 
+func TestInitialSessionModelState_UsesConfigOptionsWithoutModels(t *testing.T) {
+	modelCategory := acp.SessionConfigOptionCategoryModel
+	modelOptions := acp.SessionConfigSelectOptionsUngrouped{
+		{Name: "GPT-5.5", Value: "gpt-5.5"},
+		{Name: "GPT-5.3-Codex-Spark", Value: "gpt-5.3-codex-spark"},
+	}
+	configOptions := []acp.SessionConfigOption{
+		{Select: &acp.SessionConfigOptionSelect{
+			Type:         "select",
+			Id:           "model",
+			Name:         "Model",
+			Category:     &modelCategory,
+			CurrentValue: "gpt-5.5",
+			Options:      acp.SessionConfigSelectOptions{Ungrouped: &modelOptions},
+		}},
+	}
+
+	models := initialSessionModelState(nil, nil, configOptions)
+	if models == nil {
+		t.Fatal("initialSessionModelState returned nil for configOptions-only response")
+	}
+
+	a := newTestAdapter()
+	a.emitSessionModels("sess-1", models, nil, configOptions)
+
+	ev := findSessionModelsEvent(t, drainEvents(a))
+	if ev.CurrentModelID != "gpt-5.5" {
+		t.Errorf("CurrentModelID = %q, want %q", ev.CurrentModelID, "gpt-5.5")
+	}
+	if len(ev.ConfigOptions) != 1 {
+		t.Fatalf("ConfigOptions len = %d, want 1", len(ev.ConfigOptions))
+	}
+	if ev.ConfigOptions[0].ID != "model" {
+		t.Errorf("ConfigOptions[0].ID = %q, want model", ev.ConfigOptions[0].ID)
+	}
+}
+
+func TestInitialSessionModelState_IgnoresNonModelConfigOptions(t *testing.T) {
+	modeCategory := acp.SessionConfigOptionCategoryMode
+	modeOptions := acp.SessionConfigSelectOptionsUngrouped{
+		{Name: "Read Only", Value: "read-only"},
+		{Name: "Default", Value: "auto"},
+	}
+	configOptions := []acp.SessionConfigOption{
+		{Select: &acp.SessionConfigOptionSelect{
+			Type:         "select",
+			Id:           "mode",
+			Name:         "Approval Preset",
+			Category:     &modeCategory,
+			CurrentValue: "read-only",
+			Options:      acp.SessionConfigSelectOptions{Ungrouped: &modeOptions},
+		}},
+	}
+
+	if models := initialSessionModelState(nil, nil, configOptions); models != nil {
+		t.Fatalf("initialSessionModelState returned %+v for non-model configOptions", models)
+	}
+}
+
 func TestResolveCurrentModelFromConfig_ComposesReasoningEffort(t *testing.T) {
 	options := []streams.ConfigOption{
 		{Type: "select", ID: "model", Category: "model", CurrentValue: "gpt-5.5"},

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/session_models_test.go
@@ -250,6 +250,38 @@ func TestInitialSessionModelState_IgnoresNonModelConfigOptions(t *testing.T) {
 	}
 }
 
+func TestInitialSessionModelState_UsesTypedConfigOptionPrecedence(t *testing.T) {
+	modeCategory := acp.SessionConfigOptionCategoryMode
+	modeOptions := acp.SessionConfigSelectOptionsUngrouped{
+		{Name: "Read Only", Value: "read-only"},
+	}
+	configOptions := []acp.SessionConfigOption{
+		{Select: &acp.SessionConfigOptionSelect{
+			Type:         "select",
+			Id:           "mode",
+			Name:         "Approval Preset",
+			Category:     &modeCategory,
+			CurrentValue: "read-only",
+			Options:      acp.SessionConfigSelectOptions{Ungrouped: &modeOptions},
+		}},
+	}
+	meta := map[string]any{
+		"configOptions": []any{
+			map[string]any{
+				"type":         "select",
+				"id":           "model",
+				"name":         "Model",
+				"category":     "model",
+				"currentValue": "gpt-5.5",
+			},
+		},
+	}
+
+	if models := initialSessionModelState(nil, meta, configOptions); models != nil {
+		t.Fatalf("initialSessionModelState returned %+v for non-model typed configOptions", models)
+	}
+}
+
 func TestResolveCurrentModelFromConfig_ComposesReasoningEffort(t *testing.T) {
 	options := []streams.ConfigOption{
 		{Type: "select", ID: "model", Category: "model", CurrentValue: "gpt-5.5"},


### PR DESCRIPTION
Codex ACP can advertise its selected model only through session config options, which caused new Spark-profile sessions to surface the bridge default instead of the configured profile. The ACP adapter now emits initial session model state for model-shaped config options so profile model application and the UI converge correctly.

## Important Changes

- Treat config-options-only ACP session responses with a model selector as model state, while ignoring unrelated config-only responses.
- Cover the Codex-style response shape and the non-model guard with regression tests.

## Validation

- `pnpm install --frozen-lockfile` from `apps/` to restore this worktree's dependencies.
- `make fmt`
- `node scripts/generate-release-notes.mjs && node scripts/generate-changelog.mjs` from `apps/web/`
- `make typecheck test lint`
- `go test ./internal/agentctl/server/adapter/transport/acp`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.