### PR TITLE
fix: improve sidebar action layout

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-header.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { IconChevronsLeft, IconChevronsRight } from "@tabler/icons-react";
+import { IconLayoutSidebarLeftCollapse, IconLayoutSidebarLeftExpand } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -41,7 +41,7 @@ export function AppSidebarHeader({ collapsed, onToggleCollapse }: AppSidebarHead
               onClick={onToggleCollapse}
               aria-label="Expand sidebar"
             >
-              <IconChevronsRight className="h-4 w-4" />
+              <IconLayoutSidebarLeftExpand className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="right">Expand sidebar</TooltipContent>
@@ -82,7 +82,7 @@ export function AppSidebarHeader({ collapsed, onToggleCollapse }: AppSidebarHead
             onClick={onToggleCollapse}
             aria-label="Collapse sidebar"
           >
-            <IconChevronsLeft className="h-4 w-4" />
+            <IconLayoutSidebarLeftCollapse className="h-4 w-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent side="top">Collapse sidebar</TooltipContent>

--- a/apps/web/components/app-sidebar/app-sidebar-nav-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-nav-item.tsx
@@ -23,6 +23,8 @@ type AppSidebarNavItemProps = {
   disabled?: boolean;
   /** Optional data-testid placed on the button/link element. */
   testId?: string;
+  /** Optional extra classes for surface-specific spacing. */
+  className?: string;
 };
 
 type TriggerProps = {
@@ -83,6 +85,7 @@ export function AppSidebarNavItem({
   exactMatch = false,
   disabled = false,
   testId,
+  className,
 }: AppSidebarNavItemProps) {
   const pathname = usePathname();
   const active = isActive ?? isPathActive(pathname, href, exactMatch);
@@ -93,6 +96,7 @@ export function AppSidebarNavItem({
     disabled
       ? "cursor-not-allowed text-foreground/40"
       : cn("cursor-pointer", active ? SIDEBAR_ITEM_ACTIVE : SIDEBAR_ITEM_INACTIVE),
+    className,
   );
 
   const inner = (

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -149,6 +149,12 @@ describe("AppSidebarNewTaskItem row actions", () => {
     expect(screen.queryByTestId("sidebar-quick-chat-shortcut")).toBeNull();
   });
 
+  it("hides the quick chat shortcut when there is no active workspace", () => {
+    state.workspaces.activeId = null;
+    renderItem(false);
+    expect(screen.queryByTestId("sidebar-quick-chat-shortcut")).toBeNull();
+  });
+
   it("offers a subtask affordance when a task is active in regular mode", () => {
     state.tasks.activeTaskId = "t-1";
     renderItem(false);

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.test.tsx
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   routerPush: vi.fn(),
   setActiveTask: vi.fn(),
   setActiveSession: vi.fn(),
+  openQuickChat: vi.fn(),
   dialogTaskSessionId: null as string | null,
   dialogWillNavigate: false,
 }));
@@ -34,6 +35,9 @@ let pathname = "/";
 
 vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (s: typeof state) => unknown) => selector(state),
+}));
+vi.mock("@/hooks/use-quick-chat-launcher", () => ({
+  useQuickChatLauncher: () => mocks.openQuickChat,
 }));
 vi.mock("@/hooks/domains/features/use-feature", () => ({
   useFeature: () => officeEnabled,
@@ -79,24 +83,26 @@ const SUBTASK_TESTID = "sidebar-new-subtask";
 const OFFICE_DIALOG_TESTID = "office-new-task-dialog";
 const REGULAR_DIALOG_TESTID = "regular-task-create-dialog";
 
-describe("AppSidebarNewTaskItem", () => {
-  beforeEach(() => {
-    state.workspaces.activeId = "ws-1";
-    state.kanban.workflowId = "wf-1";
-    state.kanban.steps = [{ id: "s1", title: "Todo" }];
-    state.kanban.tasks = [{ id: "t-1", title: "Parent task" }];
-    state.tasks.activeTaskId = null;
-    mocks.routerPush.mockClear();
-    mocks.setActiveTask.mockClear();
-    mocks.setActiveSession.mockClear();
-    mocks.dialogTaskSessionId = null;
-    mocks.dialogWillNavigate = false;
-    officeEnabled = false;
-    pathname = "/";
-  });
+function resetTestState() {
+  state.workspaces.activeId = "ws-1";
+  state.kanban.workflowId = "wf-1";
+  state.kanban.steps = [{ id: "s1", title: "Todo" }];
+  state.kanban.tasks = [{ id: "t-1", title: "Parent task" }];
+  state.tasks.activeTaskId = null;
+  mocks.routerPush.mockClear();
+  mocks.setActiveTask.mockClear();
+  mocks.setActiveSession.mockClear();
+  mocks.openQuickChat.mockClear();
+  mocks.dialogTaskSessionId = null;
+  mocks.dialogWillNavigate = false;
+  officeEnabled = false;
+  pathname = "/";
+}
 
-  afterEach(() => cleanup());
+beforeEach(resetTestState);
+afterEach(() => cleanup());
 
+describe("AppSidebarNewTaskItem dialog routing", () => {
   it("uses the regular task-create dialog when office is disabled", () => {
     officeEnabled = false;
     renderItem(false);
@@ -129,6 +135,19 @@ describe("AppSidebarNewTaskItem", () => {
     expect(screen.queryByTestId(REGULAR_DIALOG_TESTID)).toBeNull();
     expect(screen.queryByTestId(OFFICE_DIALOG_TESTID)).toBeNull();
   });
+});
+
+describe("AppSidebarNewTaskItem row actions", () => {
+  it("opens quick chat from the trailing action beside New Task", () => {
+    renderItem(false);
+    screen.getByTestId("sidebar-quick-chat-shortcut").click();
+    expect(mocks.openQuickChat).toHaveBeenCalledOnce();
+  });
+
+  it("hides the quick chat shortcut when the rail is collapsed", () => {
+    renderItem(true);
+    expect(screen.queryByTestId("sidebar-quick-chat-shortcut")).toBeNull();
+  });
 
   it("offers a subtask affordance when a task is active in regular mode", () => {
     state.tasks.activeTaskId = "t-1";
@@ -160,7 +179,9 @@ describe("AppSidebarNewTaskItem", () => {
     renderItem(true);
     expect(screen.queryByTestId(SUBTASK_TESTID)).toBeNull();
   });
+});
 
+describe("AppSidebarNewTaskItem creation success", () => {
   it("focuses the created task after regular sidebar task creation succeeds", () => {
     renderItem(false);
     screen.getByTestId(REGULAR_DIALOG_TESTID).click();

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
@@ -27,6 +27,9 @@ type AppSidebarNewTaskItemProps = {
   collapsed: boolean;
 };
 
+const ONE_ROW_ACTION_INSET_CLASS = "pr-10";
+const TWO_ROW_ACTIONS_INSET_CLASS = "pr-16";
+
 type RowActionButtonProps = {
   icon: TablerIcon;
   label: string;
@@ -91,10 +94,12 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
   const canOpenQuickChat = !collapsed && !!workspaceId;
   const canCreateSubtask = !collapsed && !!workspaceId && !!activeTaskId;
   let actionInsetClass: string | undefined;
+  // Keep the label clear of the absolute action cluster:
+  // pr-10 covers one w-6 button + right-1.5 inset; pr-16 covers two buttons + gap-1.
   if (canCreateSubtask) {
-    actionInsetClass = "pr-16";
+    actionInsetClass = TWO_ROW_ACTIONS_INSET_CLASS;
   } else if (canOpenQuickChat) {
-    actionInsetClass = "pr-10";
+    actionInsetClass = ONE_ROW_ACTION_INSET_CLASS;
   }
   const handleRegularTaskCreated = useCallback(
     (

--- a/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-new-task-item.tsx
@@ -3,10 +3,12 @@
 import { useCallback, useState } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { IconSquarePlus, IconSubtask } from "@tabler/icons-react";
+import { IconMessageCircle, IconSquarePlus, IconSubtask } from "@tabler/icons-react";
+import type { Icon as TablerIcon } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useAppStore } from "@/components/state-provider";
 import { useInOffice } from "@/hooks/use-in-office";
+import { useQuickChatLauncher } from "@/hooks/use-quick-chat-launcher";
 import { TaskCreateDialog } from "@/components/task-create-dialog";
 import { linkToTask } from "@/lib/links";
 import type { Task } from "@/lib/types/http";
@@ -24,6 +26,32 @@ import { AppSidebarNavItem } from "./app-sidebar-nav-item";
 type AppSidebarNewTaskItemProps = {
   collapsed: boolean;
 };
+
+type RowActionButtonProps = {
+  icon: TablerIcon;
+  label: string;
+  testId: string;
+  onClick: () => void;
+};
+
+function RowActionButton({ icon: Icon, label, testId, onClick }: RowActionButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={label}
+          data-testid={testId}
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/70 hover:bg-muted hover:text-foreground cursor-pointer"
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 /**
  * "New Task" entry in the sidebar primary nav. Inside Office (an `/office`
@@ -52,6 +80,7 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
     return s.kanban.tasks.find((t) => t.id === id)?.title ?? "";
   });
   const inOffice = useInOffice();
+  const handleOpenQuickChat = useQuickChatLauncher(workspaceId);
   const [open, setOpen] = useState(false);
   const [subtaskOpen, setSubtaskOpen] = useState(false);
 
@@ -59,7 +88,14 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
   // dialog for the primary New Task, but subtasks always go through the compact
   // NewSubtaskDialog, matching the retired dropdown). It needs an active task
   // and the expanded rail to host the trailing button.
+  const canOpenQuickChat = !collapsed && !!workspaceId;
   const canCreateSubtask = !collapsed && !!workspaceId && !!activeTaskId;
+  let actionInsetClass: string | undefined;
+  if (canCreateSubtask) {
+    actionInsetClass = "pr-16";
+  } else if (canOpenQuickChat) {
+    actionInsetClass = "pr-10";
+  }
   const handleRegularTaskCreated = useCallback(
     (
       task: Task,
@@ -88,22 +124,25 @@ export function AppSidebarNewTaskItem({ collapsed }: AppSidebarNewTaskItemProps)
           collapsed={collapsed}
           disabled={!workspaceId}
           testId="create-task-button"
+          className={actionInsetClass}
         />
-        {canCreateSubtask && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
+        {canOpenQuickChat && (
+          <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-1 sidebar-fade-in">
+            <RowActionButton
+              icon={IconMessageCircle}
+              label="Quick Chat"
+              testId="sidebar-quick-chat-shortcut"
+              onClick={handleOpenQuickChat}
+            />
+            {canCreateSubtask && (
+              <RowActionButton
+                icon={IconSubtask}
+                label="New subtask of current task"
+                testId="sidebar-new-subtask"
                 onClick={() => setSubtaskOpen(true)}
-                aria-label="New subtask of current task"
-                data-testid="sidebar-new-subtask"
-                className="absolute right-1.5 top-1/2 -translate-y-1/2 flex h-6 w-6 items-center justify-center rounded text-muted-foreground/70 hover:bg-muted hover:text-foreground cursor-pointer"
-              >
-                <IconSubtask className="h-3.5 w-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">New subtask of current task</TooltipContent>
-          </Tooltip>
+              />
+            )}
+          </div>
         )}
       </div>
       {workspaceId &&

--- a/apps/web/components/app-sidebar/app-sidebar-primary-nav.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-primary-nav.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  openQuickChat: vi.fn(),
+}));
+
+const state = {
+  workspaces: { activeId: "ws-1" as string | null },
+  office: { inboxCount: 0 },
+};
+let inOffice = false;
+let pathname = "/";
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: typeof state) => unknown) => selector(state),
+}));
+
+vi.mock("@/hooks/use-in-office", () => ({
+  useInOffice: () => inOffice,
+}));
+
+vi.mock("@/hooks/use-quick-chat-launcher", () => ({
+  useQuickChatLauncher: () => mocks.openQuickChat,
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("./app-sidebar-new-task-item", () => ({
+  AppSidebarNewTaskItem: ({ collapsed }: { collapsed: boolean }) => (
+    <div data-testid="new-task-item" data-collapsed={collapsed ? "true" : "false"} />
+  ),
+}));
+
+import { AppSidebarPrimaryNav } from "./app-sidebar-primary-nav";
+
+function renderNav(collapsed: boolean) {
+  return render(
+    <TooltipProvider>
+      <AppSidebarPrimaryNav collapsed={collapsed} />
+    </TooltipProvider>,
+  );
+}
+
+describe("AppSidebarPrimaryNav", () => {
+  beforeEach(() => {
+    state.workspaces.activeId = "ws-1";
+    state.office.inboxCount = 0;
+    inOffice = false;
+    pathname = "/";
+    mocks.openQuickChat.mockClear();
+  });
+
+  afterEach(() => cleanup());
+
+  it("keeps Quick Chat reachable when the sidebar rail is collapsed", () => {
+    renderNav(true);
+
+    screen.getByRole("button", { name: "Quick Chat" }).click();
+    expect(mocks.openQuickChat).toHaveBeenCalledOnce();
+  });
+
+  it("omits the standalone Quick Chat row while expanded", () => {
+    renderNav(false);
+
+    expect(screen.queryByRole("button", { name: "Quick Chat" })).toBeNull();
+  });
+});

--- a/apps/web/components/app-sidebar/app-sidebar-primary-nav.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-primary-nav.test.tsx
@@ -69,4 +69,11 @@ describe("AppSidebarPrimaryNav", () => {
 
     expect(screen.queryByRole("button", { name: "Quick Chat" })).toBeNull();
   });
+
+  it("omits Quick Chat when the rail is collapsed but there is no workspace", () => {
+    state.workspaces.activeId = null;
+    renderNav(true);
+
+    expect(screen.queryByRole("button", { name: "Quick Chat" })).toBeNull();
+  });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-primary-nav.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-primary-nav.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { IconHome, IconInbox } from "@tabler/icons-react";
+import { IconHome, IconInbox, IconMessageCircle } from "@tabler/icons-react";
 import { useAppStore } from "@/components/state-provider";
 import { useInOffice } from "@/hooks/use-in-office";
+import { useQuickChatLauncher } from "@/hooks/use-quick-chat-launcher";
 import { AppSidebarNavItem } from "./app-sidebar-nav-item";
 import { AppSidebarNewTaskItem } from "./app-sidebar-new-task-item";
 
@@ -11,8 +12,10 @@ type AppSidebarPrimaryNavProps = {
 };
 
 export function AppSidebarPrimaryNav({ collapsed }: AppSidebarPrimaryNavProps) {
+  const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const inboxCount = useAppStore((s) => s.office.inboxCount);
   const inOffice = useInOffice();
+  const handleOpenQuickChat = useQuickChatLauncher(workspaceId);
 
   return (
     <div className="flex flex-col gap-0.5">
@@ -29,6 +32,14 @@ export function AppSidebarPrimaryNav({ collapsed }: AppSidebarPrimaryNavProps) {
           label="Inbox"
           href="/office/inbox"
           badge={inboxCount}
+          collapsed={collapsed}
+        />
+      )}
+      {workspaceId && collapsed && (
+        <AppSidebarNavItem
+          icon={IconMessageCircle}
+          label="Quick Chat"
+          onClick={handleOpenQuickChat}
           collapsed={collapsed}
         />
       )}

--- a/apps/web/components/app-sidebar/app-sidebar-primary-nav.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-primary-nav.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { IconHome, IconInbox, IconMessageCircle } from "@tabler/icons-react";
+import { IconHome, IconInbox } from "@tabler/icons-react";
 import { useAppStore } from "@/components/state-provider";
 import { useInOffice } from "@/hooks/use-in-office";
-import { useQuickChatLauncher } from "@/hooks/use-quick-chat-launcher";
 import { AppSidebarNavItem } from "./app-sidebar-nav-item";
 import { AppSidebarNewTaskItem } from "./app-sidebar-new-task-item";
 
@@ -12,10 +11,8 @@ type AppSidebarPrimaryNavProps = {
 };
 
 export function AppSidebarPrimaryNav({ collapsed }: AppSidebarPrimaryNavProps) {
-  const workspaceId = useAppStore((s) => s.workspaces.activeId);
   const inboxCount = useAppStore((s) => s.office.inboxCount);
   const inOffice = useInOffice();
-  const handleOpenQuickChat = useQuickChatLauncher(workspaceId);
 
   return (
     <div className="flex flex-col gap-0.5">
@@ -32,14 +29,6 @@ export function AppSidebarPrimaryNav({ collapsed }: AppSidebarPrimaryNavProps) {
           label="Inbox"
           href="/office/inbox"
           badge={inboxCount}
-          collapsed={collapsed}
-        />
-      )}
-      {workspaceId && (
-        <AppSidebarNavItem
-          icon={IconMessageCircle}
-          label="Quick Chat"
-          onClick={handleOpenQuickChat}
           collapsed={collapsed}
         />
       )}

--- a/apps/web/components/app-sidebar/app-sidebar-section.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-section.tsx
@@ -15,6 +15,8 @@ type AppSidebarSectionProps = {
   children: React.ReactNode;
   /** Optional control rendered between the label and the collapse chevron. */
   headerAction?: React.ReactNode;
+  /** By default header actions only render while expanded. */
+  headerActionVisibility?: "expanded" | "always";
   /** Fills remaining sidebar height when expanded. Parent must be a flex column. */
   grow?: boolean;
 };
@@ -23,10 +25,19 @@ type SectionHeaderProps = {
   label: string;
   expanded: boolean;
   headerAction?: React.ReactNode;
+  headerActionVisibility: "expanded" | "always";
   onToggle: () => void;
 };
 
-function SectionHeader({ label, expanded, headerAction, onToggle }: SectionHeaderProps) {
+function SectionHeader({
+  label,
+  expanded,
+  headerAction,
+  headerActionVisibility,
+  onToggle,
+}: SectionHeaderProps) {
+  const showHeaderAction = !!headerAction && (expanded || headerActionVisibility === "always");
+
   return (
     <div className="group/section flex items-center px-2 h-7 shrink-0">
       <button
@@ -37,9 +48,7 @@ function SectionHeader({ label, expanded, headerAction, onToggle }: SectionHeade
       >
         <span className="text-[11px] font-semibold uppercase tracking-wider truncate">{label}</span>
       </button>
-      {expanded && headerAction && (
-        <div className="shrink-0 mr-1 flex items-center">{headerAction}</div>
-      )}
+      {showHeaderAction && <div className="shrink-0 mr-1 flex items-center">{headerAction}</div>}
       <button
         type="button"
         onClick={onToggle}
@@ -62,6 +71,7 @@ export function AppSidebarSection({
   icon: Icon,
   children,
   headerAction,
+  headerActionVisibility = "expanded",
   grow,
 }: AppSidebarSectionProps) {
   const expanded = useAppStore((s) => s.appSidebar.sectionExpanded[id] ?? false);
@@ -101,6 +111,7 @@ export function AppSidebarSection({
           label={label}
           expanded={expanded}
           headerAction={headerAction}
+          headerActionVisibility={headerActionVisibility}
           onToggle={handleToggle}
         />
         {expanded && (
@@ -116,6 +127,7 @@ export function AppSidebarSection({
         label={label}
         expanded={expanded}
         headerAction={headerAction}
+        headerActionVisibility={headerActionVisibility}
         onToggle={handleToggle}
       />
       <CollapsibleContent className="sidebar-section-content">

--- a/apps/web/components/app-sidebar/app-sidebar-section.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-section.tsx
@@ -15,7 +15,9 @@ type AppSidebarSectionProps = {
   children: React.ReactNode;
   /** Optional control rendered between the label and the collapse chevron. */
   headerAction?: React.ReactNode;
-  /** By default header actions only render while expanded. */
+  /** By default header actions render only while the section accordion is open.
+   *  "always" keeps them visible while the accordion is closed, but has no
+   *  effect when the sidebar itself is in collapsed/rail mode. */
   headerActionVisibility?: "expanded" | "always";
   /** Fills remaining sidebar height when expanded. Parent must be a flex column. */
   grow?: boolean;

--- a/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigationMock = vi.hoisted(() => ({
+  pathname: "/",
+}));
+
+const linksMock = vi.hoisted(() =>
+  vi.fn(() => [
+    { id: "github", label: "GitHub", href: "/github" },
+    { id: "jira", label: "Jira", href: "/jira" },
+  ]),
+);
+
+const storeState = {
+  appSidebar: {
+    sectionExpanded: {
+      integrations: false,
+    },
+  },
+  toggleAppSidebarSection: vi.fn(),
+  setAppSidebarCollapsed: vi.fn(),
+};
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigationMock.pathname,
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof storeState) => unknown) => selector(storeState),
+}));
+
+vi.mock("@/components/integrations/integrations-menu", () => ({
+  useConfiguredIntegrationLinks: linksMock,
+}));
+
+vi.mock("@kandev/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+import { IntegrationsSection } from "./integrations-section";
+
+function renderSection() {
+  return render(
+    <TooltipProvider>
+      <IntegrationsSection collapsed={false} />
+    </TooltipProvider>,
+  );
+}
+
+describe("IntegrationsSection", () => {
+  beforeEach(() => {
+    navigationMock.pathname = "/";
+    storeState.appSidebar.sectionExpanded.integrations = false;
+    storeState.toggleAppSidebarSection.mockClear();
+    storeState.setAppSidebarCollapsed.mockClear();
+    linksMock.mockReturnValue([
+      { id: "github", label: "GitHub", href: "/github" },
+      { id: "jira", label: "Jira", href: "/jira" },
+    ]);
+  });
+
+  afterEach(() => cleanup());
+
+  it("keeps configured integration shortcuts visible while the section is collapsed", () => {
+    renderSection();
+
+    const shortcuts = screen.getAllByTestId("integration-header-shortcut");
+    expect(shortcuts.map((shortcut) => shortcut.getAttribute("aria-label"))).toEqual([
+      "GitHub",
+      "Jira",
+    ]);
+    expect(shortcuts.map((shortcut) => shortcut.getAttribute("href"))).toEqual([
+      "/github",
+      "/jira",
+    ]);
+  });
+
+  it("limits shortcuts to four integrations and leaves the full list in the expanded section", () => {
+    storeState.appSidebar.sectionExpanded.integrations = true;
+    linksMock.mockReturnValue([
+      { id: "github", label: "GitHub", href: "/github" },
+      { id: "gitlab", label: "GitLab", href: "/gitlab" },
+      { id: "jira", label: "Jira", href: "/jira" },
+      { id: "linear", label: "Linear", href: "/linear" },
+      { id: "sentry", label: "Sentry", href: "/sentry" },
+    ]);
+
+    renderSection();
+
+    expect(screen.getAllByTestId("integration-header-shortcut")).toHaveLength(4);
+    expect(screen.getByRole("link", { name: "Sentry" })).toBeTruthy();
+  });
+});

--- a/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
@@ -7,6 +7,10 @@ const navigationMock = vi.hoisted(() => ({
   pathname: "/",
 }));
 
+const collapsibleMock = vi.hoisted(() => ({
+  open: false,
+}));
+
 const linksMock = vi.hoisted(() =>
   vi.fn(() => [
     { id: "github", label: "GitHub", href: "/github" },
@@ -37,8 +41,12 @@ vi.mock("@/components/integrations/integrations-menu", () => ({
 }));
 
 vi.mock("@kandev/ui/collapsible", () => ({
-  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  CollapsibleContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Collapsible: ({ children, open }: { children: ReactNode; open?: boolean }) => {
+    collapsibleMock.open = !!open;
+    return <div>{children}</div>;
+  },
+  CollapsibleContent: ({ children }: { children: ReactNode }) =>
+    collapsibleMock.open ? <div>{children}</div> : null,
 }));
 
 import { IntegrationsSection } from "./integrations-section";
@@ -66,17 +74,30 @@ describe("IntegrationsSection", () => {
   afterEach(() => cleanup());
 
   it("keeps integration shortcuts visible while the section accordion is closed", () => {
+    linksMock.mockReturnValue([
+      { id: "github", label: "GitHub", href: "/github" },
+      { id: "gitlab", label: "GitLab", href: "/gitlab" },
+      { id: "jira", label: "Jira", href: "/jira" },
+      { id: "linear", label: "Linear", href: "/linear" },
+      { id: "sentry", label: "Sentry", href: "/sentry" },
+    ]);
+
     renderSection();
 
     const shortcuts = screen.getAllByTestId("integration-header-shortcut");
     expect(shortcuts.map((shortcut) => shortcut.getAttribute("aria-label"))).toEqual([
       "GitHub",
+      "GitLab",
       "Jira",
+      "Linear",
     ]);
     expect(shortcuts.map((shortcut) => shortcut.getAttribute("href"))).toEqual([
       "/github",
+      "/gitlab",
       "/jira",
+      "/linear",
     ]);
+    expect(screen.queryByRole("link", { name: "Sentry" })).toBeNull();
   });
 
   it("limits shortcuts to four integrations and leaves the full list in the expanded section", () => {

--- a/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.test.tsx
@@ -65,7 +65,7 @@ describe("IntegrationsSection", () => {
 
   afterEach(() => cleanup());
 
-  it("keeps configured integration shortcuts visible while the section is collapsed", () => {
+  it("keeps integration shortcuts visible while the section accordion is closed", () => {
     renderSection();
 
     const shortcuts = screen.getAllByTestId("integration-header-shortcut");

--- a/apps/web/components/app-sidebar/sections/integrations-section.tsx
+++ b/apps/web/components/app-sidebar/sections/integrations-section.tsx
@@ -10,6 +10,7 @@ import {
   IconTicket,
 } from "@tabler/icons-react";
 import type { Icon as TablerIcon } from "@tabler/icons-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useConfiguredIntegrationLinks } from "@/components/integrations/integrations-menu";
 import { cn } from "@/lib/utils";
 import {
@@ -30,6 +31,35 @@ const INTEGRATION_ICONS: Record<string, TablerIcon> = {
   linear: IconHexagon,
 };
 
+const MAX_HEADER_SHORTCUTS = 4;
+
+type ConfiguredIntegrationLink = ReturnType<typeof useConfiguredIntegrationLinks>[number];
+
+function IntegrationHeaderShortcuts({ links }: { links: ConfiguredIntegrationLink[] }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {links.slice(0, MAX_HEADER_SHORTCUTS).map(({ id, label, href }) => {
+        const Icon = INTEGRATION_ICONS[id] ?? IconPlugConnected;
+        return (
+          <Tooltip key={id}>
+            <TooltipTrigger asChild>
+              <Link
+                href={href}
+                aria-label={label}
+                data-testid="integration-header-shortcut"
+                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground cursor-pointer transition-colors"
+              >
+                <Icon className="h-3.5 w-3.5" />
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent side="right">{label}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}
+
 export function IntegrationsSection({ collapsed }: IntegrationsSectionProps) {
   const pathname = usePathname();
   const links = useConfiguredIntegrationLinks();
@@ -42,6 +72,8 @@ export function IntegrationsSection({ collapsed }: IntegrationsSectionProps) {
       label="Integrations"
       collapsed={collapsed}
       icon={IconPlugConnected}
+      headerAction={<IntegrationHeaderShortcuts links={links} />}
+      headerActionVisibility="always"
     >
       {links.map(({ id, label, href }) => {
         const Icon = INTEGRATION_ICONS[id] ?? IconPlugConnected;

--- a/apps/web/components/app-sidebar/sections/tasks-section.test.tsx
+++ b/apps/web/components/app-sidebar/sections/tasks-section.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = {
+  appSidebar: {
+    sectionExpanded: {
+      tasks: true,
+    },
+  },
+  workspaces: { activeId: "ws-1" as string | null },
+  kanban: { workflowId: "wf-1" as string | null },
+  sidebarViews: {
+    views: [{ id: "all", name: "All tasks" }],
+    activeViewId: "all",
+    draft: null,
+  },
+  toggleAppSidebarSection: vi.fn(),
+  setAppSidebarCollapsed: vi.fn(),
+  setSidebarActiveView: vi.fn(),
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: typeof state) => unknown) => selector(state),
+}));
+
+vi.mock("@/components/task/task-session-sidebar", () => ({
+  TaskSessionSidebar: () => <div data-testid="task-sidebar" />,
+}));
+
+vi.mock("@/components/task/sidebar-filter/sidebar-filter-popover", () => ({
+  SidebarFilterPopover: ({ trigger }: { trigger: ReactNode }) => trigger,
+}));
+
+import { TasksSection } from "./tasks-section";
+
+function renderSection() {
+  return render(
+    <TooltipProvider>
+      <TasksSection collapsed={false} />
+    </TooltipProvider>,
+  );
+}
+
+describe("TasksSection", () => {
+  beforeEach(() => {
+    state.appSidebar.sectionExpanded.tasks = true;
+    state.workspaces.activeId = "ws-1";
+    state.kanban.workflowId = "wf-1";
+    state.sidebarViews.views = [{ id: "all", name: "All tasks" }];
+    state.sidebarViews.activeViewId = "all";
+    state.sidebarViews.draft = null;
+    state.toggleAppSidebarSection.mockClear();
+    state.setAppSidebarCollapsed.mockClear();
+    state.setSidebarActiveView.mockClear();
+  });
+
+  afterEach(() => cleanup());
+
+  it("keeps the tasks view picker inline in the section header", () => {
+    renderSection();
+
+    const picker = screen.getByTestId("tasks-view-picker");
+    const header = screen.getByRole("button", { name: "Tasks" }).parentElement;
+
+    expect(header?.contains(picker)).toBe(true);
+  });
+});

--- a/apps/web/components/app-sidebar/sections/tasks-section.tsx
+++ b/apps/web/components/app-sidebar/sections/tasks-section.tsx
@@ -21,9 +21,11 @@ export function TasksSection({ collapsed }: TasksSectionProps) {
       label="Tasks"
       collapsed={collapsed}
       icon={IconCircleDot}
-      headerAction={<TasksViewPicker />}
       grow
     >
+      <div className="shrink-0 px-2 pb-1">
+        <TasksViewPicker />
+      </div>
       <div className="flex-1 min-h-0 [&_[data-testid=task-sidebar]]:bg-transparent [&_[data-testid=task-sidebar-scroll]]:bg-transparent">
         <TaskSessionSidebar workspaceId={workspaceId} workflowId={workflowId} hideFilterBar />
       </div>

--- a/apps/web/components/app-sidebar/sections/tasks-section.tsx
+++ b/apps/web/components/app-sidebar/sections/tasks-section.tsx
@@ -21,11 +21,9 @@ export function TasksSection({ collapsed }: TasksSectionProps) {
       label="Tasks"
       collapsed={collapsed}
       icon={IconCircleDot}
+      headerAction={<TasksViewPicker />}
       grow
     >
-      <div className="shrink-0 px-2 pb-1">
-        <TasksViewPicker />
-      </div>
       <div className="flex-1 min-h-0 [&_[data-testid=task-sidebar]]:bg-transparent [&_[data-testid=task-sidebar-scroll]]:bg-transparent">
         <TaskSessionSidebar workspaceId={workspaceId} workflowId={workflowId} hideFilterBar />
       </div>


### PR DESCRIPTION
The sidebar action cluster was crowded enough to make Quick Chat, New Task, integrations, and task filters compete for attention. The sidebar now keeps frequent actions visible while giving each section clearer visual ownership.

## Important Changes

- Quick Chat moved into the New Task row as an icon shortcut, keeping it visible without adding another primary-nav row.
- Integrations now exposes configured service shortcuts in the section header while preserving the expandable list.
- Task view and filter controls moved below the Tasks header so they no longer compete with the section chevron.
- The sidebar collapse control now uses explicit sidebar collapse/expand icons.

## Validation

- `make fmt`
- `make typecheck test lint`
- `pnpm --filter @kandev/web test -- --run components/app-sidebar/app-sidebar-new-task-item.test.tsx components/app-sidebar/sections/integrations-section.test.tsx`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Possible Improvements

Low risk: the global sidebar is desktop-only, so mobile parity is covered by leaving existing mobile navigation surfaces unchanged.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.