### PR TITLE
fix: improve archive switch reliability

### DIFF
--- a/apps/web/components/task/task-session-sidebar-dialogs.tsx
+++ b/apps/web/components/task/task-session-sidebar-dialogs.tsx
@@ -12,6 +12,7 @@ export type SidebarDialogsActions = {
   handleRenameSubmit: (newTitle: string) => Promise<void> | void;
   archivingTask: Target;
   setArchivingTask: (next: Target) => void;
+  archivingTaskId: string | null;
   isArchiving: boolean;
   handleArchiveConfirm: (opts: { cascade: boolean }) => Promise<void> | void;
   deletingTask: Target;
@@ -27,6 +28,7 @@ export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) 
     handleRenameSubmit,
     archivingTask,
     setArchivingTask,
+    archivingTaskId,
     isArchiving,
     handleArchiveConfirm,
     deletingTask,
@@ -52,7 +54,7 @@ export function SidebarDialogs({ actions }: { actions: SidebarDialogsActions }) 
         taskTitle={archivingTask?.title ?? ""}
         taskId={archivingTask?.id}
         executorType={archivingTask?.executorType}
-        isArchiving={isArchiving}
+        isArchiving={isArchiving && archivingTask?.id === archivingTaskId}
         onConfirm={handleArchiveConfirm}
       />
       <TaskDeleteConfirmDialog

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -364,6 +364,7 @@ function useArchiveActions(store: StoreApi) {
     title: string;
     executorType?: string | null;
   } | null>(null);
+  const [archivingTaskId, setArchivingTaskId] = useState<string | null>(null);
   const [isArchiving, setIsArchiving] = useState(false);
 
   const handleArchiveTask = useCallback(
@@ -382,20 +383,30 @@ function useArchiveActions(store: StoreApi) {
   const handleArchiveConfirm = useCallback(
     async (opts: { cascade: boolean }) => {
       if (!archivingTask) return;
+      const taskId = archivingTask.id;
       setIsArchiving(true);
+      setArchivingTaskId(taskId);
       try {
-        await archiveAndSwitch(archivingTask.id, opts);
+        await archiveAndSwitch(taskId, opts);
       } catch (error) {
         console.error("Failed to archive task:", error);
       } finally {
         setIsArchiving(false);
-        setArchivingTask(null);
+        setArchivingTaskId((current) => (current === taskId ? null : current));
+        setArchivingTask((current) => (current?.id === taskId ? null : current));
       }
     },
     [archivingTask, archiveAndSwitch],
   );
 
-  return { archivingTask, setArchivingTask, isArchiving, handleArchiveTask, handleArchiveConfirm };
+  return {
+    archivingTask,
+    setArchivingTask,
+    archivingTaskId,
+    isArchiving,
+    handleArchiveTask,
+    handleArchiveConfirm,
+  };
 }
 
 function useDeleteActions(

--- a/apps/web/hooks/use-task-actions.test.ts
+++ b/apps/web/hooks/use-task-actions.test.ts
@@ -5,12 +5,24 @@ const archiveTaskMock = vi.fn();
 const removeTaskFromBoardMock = vi.fn();
 const getStateMock = vi.fn();
 const storeMock = { getState: getStateMock };
+const replaceTaskUrlMock = vi.fn();
+const setActiveSessionMock = vi.fn();
+const setActiveTaskMock = vi.fn();
+let storeState: {
+  tasks: { activeTaskId: string | null; activeSessionId: string | null };
+  setActiveSession: (...args: unknown[]) => void;
+  setActiveTask: (...args: unknown[]) => void;
+};
 
 vi.mock("@/lib/api", () => ({
   archiveTask: (...args: unknown[]) => archiveTaskMock(...args),
   deleteTask: vi.fn(),
   moveTask: vi.fn(),
   updateTask: vi.fn(),
+}));
+
+vi.mock("@/lib/links", () => ({
+  replaceTaskUrl: (...args: unknown[]) => replaceTaskUrlMock(...args),
 }));
 
 vi.mock("@/components/state-provider", () => ({
@@ -37,9 +49,13 @@ function deferred<T>() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  getStateMock.mockReturnValue({
+  storeState = {
     tasks: { activeTaskId: "task-A", activeSessionId: "sess-A" },
-  });
+    setActiveSession: (...args: unknown[]) => setActiveSessionMock(...args),
+    setActiveTask: (...args: unknown[]) => setActiveTaskMock(...args),
+  };
+  getStateMock.mockReturnValue(storeState);
+  removeTaskFromBoardMock.mockResolvedValue({ switchedTaskId: "task-B" });
 });
 
 describe("useArchiveAndSwitchTask", () => {
@@ -56,7 +72,7 @@ describe("useArchiveAndSwitchTask", () => {
     expect(removeTaskFromBoardMock).toHaveBeenCalledWith("task-A", {
       wasActiveTaskId: "task-A",
       wasActiveSessionId: "sess-A",
-      removeFromBoard: false,
+      switchOnly: true,
     });
 
     archive.resolve();
@@ -66,5 +82,27 @@ describe("useArchiveAndSwitchTask", () => {
       wasActiveTaskId: "task-A",
       wasActiveSessionId: "sess-A",
     });
+  });
+
+  it("restores active task when archive API rejects after switching", async () => {
+    const error = new Error("network error");
+    archiveTaskMock.mockRejectedValueOnce(error);
+    removeTaskFromBoardMock.mockImplementationOnce(async () => {
+      storeState.tasks.activeTaskId = "task-B";
+      return { switchedTaskId: "task-B" };
+    });
+    const { result } = renderHook(() => useArchiveAndSwitchTask());
+
+    await expect(result.current("task-A")).rejects.toThrow("network error");
+
+    expect(removeTaskFromBoardMock).toHaveBeenCalledTimes(1);
+    expect(removeTaskFromBoardMock).toHaveBeenCalledWith("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+      switchOnly: true,
+    });
+    expect(setActiveSessionMock).toHaveBeenCalledWith("task-A", "sess-A");
+    expect(replaceTaskUrlMock).toHaveBeenCalledWith("task-A");
+    expect(archiveTaskMock).toHaveBeenCalledWith("task-A", undefined);
   });
 });

--- a/apps/web/hooks/use-task-actions.test.ts
+++ b/apps/web/hooks/use-task-actions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const archiveTaskMock = vi.fn();
+const removeTaskFromBoardMock = vi.fn();
+const getStateMock = vi.fn();
+const storeMock = { getState: getStateMock };
+
+vi.mock("@/lib/api", () => ({
+  archiveTask: (...args: unknown[]) => archiveTaskMock(...args),
+  deleteTask: vi.fn(),
+  moveTask: vi.fn(),
+  updateTask: vi.fn(),
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStoreApi: () => storeMock,
+}));
+
+vi.mock("@/hooks/use-task-removal", () => ({
+  useTaskRemoval: () => ({
+    removeTaskFromBoard: (...args: unknown[]) => removeTaskFromBoardMock(...args),
+  }),
+}));
+
+import { useArchiveAndSwitchTask } from "./use-task-actions";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getStateMock.mockReturnValue({
+    tasks: { activeTaskId: "task-A", activeSessionId: "sess-A" },
+  });
+});
+
+describe("useArchiveAndSwitchTask", () => {
+  it("removes and switches away from the active task before archive API resolves", async () => {
+    const archive = deferred<void>();
+    archiveTaskMock.mockReturnValueOnce(archive.promise);
+    const { result } = renderHook(() => useArchiveAndSwitchTask());
+
+    let archiveAndSwitchPromise!: Promise<void>;
+    act(() => {
+      archiveAndSwitchPromise = result.current("task-A");
+    });
+
+    expect(removeTaskFromBoardMock).toHaveBeenCalledWith("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+      removeFromBoard: false,
+    });
+
+    archive.resolve();
+    await archiveAndSwitchPromise;
+    expect(archiveTaskMock).toHaveBeenCalledWith("task-A", undefined);
+    expect(removeTaskFromBoardMock).toHaveBeenLastCalledWith("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+    });
+  });
+});

--- a/apps/web/hooks/use-task-actions.ts
+++ b/apps/web/hooks/use-task-actions.ts
@@ -55,6 +55,7 @@ export function useArchiveAndSwitchTask(opts?: { useLayoutSwitch?: boolean }) {
       } catch (error) {
         if (
           wasActiveTaskId &&
+          initialSwitch.switchedTaskId !== null &&
           store.getState().tasks.activeTaskId === initialSwitch.switchedTaskId
         ) {
           if (wasActiveSessionId) {

--- a/apps/web/hooks/use-task-actions.ts
+++ b/apps/web/hooks/use-task-actions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { archiveTask, deleteTask, moveTask, updateTask } from "@/lib/api";
+import { replaceTaskUrl } from "@/lib/links";
 import { useAppStoreApi } from "@/components/state-provider";
 import { useTaskRemoval } from "@/hooks/use-task-removal";
 
@@ -41,13 +42,30 @@ export function useArchiveAndSwitchTask(opts?: { useLayoutSwitch?: boolean }) {
     async (taskId: string, opts?: { cascade?: boolean }) => {
       const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
         store.getState().tasks;
-      await removeTaskFromBoard(taskId, {
+
+      const initialSwitch = await removeTaskFromBoard(taskId, {
         wasActiveTaskId,
         wasActiveSessionId,
-        removeFromBoard: false,
+        switchOnly: true,
       });
-      await archiveTaskById(taskId, opts);
-      await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
+
+      try {
+        await archiveTaskById(taskId, opts);
+        await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
+      } catch (error) {
+        if (
+          wasActiveTaskId &&
+          store.getState().tasks.activeTaskId === initialSwitch.switchedTaskId
+        ) {
+          if (wasActiveSessionId) {
+            store.getState().setActiveSession(wasActiveTaskId, wasActiveSessionId);
+          } else {
+            store.getState().setActiveTask(wasActiveTaskId);
+          }
+          replaceTaskUrl(wasActiveTaskId);
+        }
+        throw error;
+      }
     },
     [archiveTaskById, removeTaskFromBoard, store],
   );

--- a/apps/web/hooks/use-task-actions.ts
+++ b/apps/web/hooks/use-task-actions.ts
@@ -41,6 +41,11 @@ export function useArchiveAndSwitchTask(opts?: { useLayoutSwitch?: boolean }) {
     async (taskId: string, opts?: { cascade?: boolean }) => {
       const { activeTaskId: wasActiveTaskId, activeSessionId: wasActiveSessionId } =
         store.getState().tasks;
+      await removeTaskFromBoard(taskId, {
+        wasActiveTaskId,
+        wasActiveSessionId,
+        removeFromBoard: false,
+      });
       await archiveTaskById(taskId, opts);
       await removeTaskFromBoard(taskId, { wasActiveTaskId, wasActiveSessionId });
     },

--- a/apps/web/hooks/use-task-removal.test.ts
+++ b/apps/web/hooks/use-task-removal.test.ts
@@ -340,7 +340,7 @@ describe("useTaskRemoval — next task selection", () => {
     await result.current.removeTaskFromBoard("task-A", {
       wasActiveTaskId: "task-A",
       wasActiveSessionId: "sess-A",
-      removeFromBoard: false,
+      switchOnly: true,
     });
 
     expect(store.getRecorded().setWorkflowSnapshot).not.toHaveBeenCalled();

--- a/apps/web/hooks/use-task-removal.test.ts
+++ b/apps/web/hooks/use-task-removal.test.ts
@@ -88,11 +88,69 @@ function makeStore(init: {
 }
 
 const nextTask: TaskRow = { id: "task-next", primarySessionId: "sess-next" };
+const recentTaskId = "task-recent";
+const recentSessionId = "sess-recent";
 
 beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();
 });
+
+function makeStoreWithOldAndRecentTasks(activeTaskId: string | null) {
+  const oldTask = { id: "task-old", primarySessionId: "sess-old" };
+  const recentTask = { id: recentTaskId, primarySessionId: recentSessionId };
+  const store = makeStore({
+    activeTaskId,
+    activeSessionId: "sess-A",
+    remainingTasks: [{ id: "task-A", primarySessionId: "sess-A" }, oldTask, recentTask],
+  });
+  store.getRecorded().environmentIdBySessionId = {
+    ...store.getRecorded().environmentIdBySessionId,
+    "sess-old": "env-old",
+    [recentSessionId]: "env-recent",
+  };
+  return store;
+}
+
+function setRecentTaskFirst() {
+  setRecentTasks([
+    {
+      taskId: recentTaskId,
+      title: "Recent task",
+      visitedAt: "2026-06-07T10:00:00Z",
+    },
+    {
+      taskId: "task-A",
+      title: "Removed task",
+      visitedAt: "2026-06-07T09:00:00Z",
+    },
+    {
+      taskId: "task-old",
+      title: "Old task",
+      visitedAt: "2026-06-06T10:00:00Z",
+    },
+  ]);
+}
+
+function setRemovedTaskFirst() {
+  setRecentTasks([
+    {
+      taskId: "task-A",
+      title: "Removed task",
+      visitedAt: "2026-06-07T10:00:00Z",
+    },
+    {
+      taskId: recentTaskId,
+      title: "Recent task",
+      visitedAt: "2026-06-07T09:00:00Z",
+    },
+    {
+      taskId: "task-old",
+      title: "Old task",
+      visitedAt: "2026-06-06T10:00:00Z",
+    },
+  ]);
+}
 
 describe("useTaskRemoval — switch guard (current store wins)", () => {
   it("switches to next task when activeTaskId === taskId (user still on removed task)", async () => {
@@ -231,44 +289,9 @@ describe("useTaskRemoval — switch guard (WS-clear fallback)", () => {
 });
 
 describe("useTaskRemoval — next task selection", () => {
-  const recentTaskId = "task-recent";
-  const recentSessionId = "sess-recent";
-
-  function makeStoreWithOldAndRecentTasks(activeTaskId: string | null) {
-    const oldTask = { id: "task-old", primarySessionId: "sess-old" };
-    const recentTask = { id: recentTaskId, primarySessionId: recentSessionId };
-    const store = makeStore({
-      activeTaskId,
-      activeSessionId: "sess-A",
-      remainingTasks: [{ id: "task-A", primarySessionId: "sess-A" }, oldTask, recentTask],
-    });
-    store.getRecorded().environmentIdBySessionId = {
-      ...store.getRecorded().environmentIdBySessionId,
-      "sess-old": "env-old",
-      [recentSessionId]: "env-recent",
-    };
-    return store;
-  }
-
   it("switches to the most recent remaining task instead of the first snapshot task", async () => {
     const store = makeStoreWithOldAndRecentTasks("task-A");
-    setRecentTasks([
-      {
-        taskId: recentTaskId,
-        title: "Recent task",
-        visitedAt: "2026-06-07T10:00:00Z",
-      },
-      {
-        taskId: "task-A",
-        title: "Removed task",
-        visitedAt: "2026-06-07T09:00:00Z",
-      },
-      {
-        taskId: "task-old",
-        title: "Old task",
-        visitedAt: "2026-06-06T10:00:00Z",
-      },
-    ]);
+    setRecentTaskFirst();
 
     const { result } = renderHook(() =>
       useTaskRemoval({ store: store as unknown as StoreApi<never> }),
@@ -288,23 +311,7 @@ describe("useTaskRemoval — next task selection", () => {
 
   it("skips the removed active task when it is first in recent history", async () => {
     const store = makeStoreWithOldAndRecentTasks("task-A");
-    setRecentTasks([
-      {
-        taskId: "task-A",
-        title: "Removed task",
-        visitedAt: "2026-06-07T10:00:00Z",
-      },
-      {
-        taskId: recentTaskId,
-        title: "Recent task",
-        visitedAt: "2026-06-07T09:00:00Z",
-      },
-      {
-        taskId: "task-old",
-        title: "Old task",
-        visitedAt: "2026-06-06T10:00:00Z",
-      },
-    ]);
+    setRemovedTaskFirst();
 
     const { result } = renderHook(() =>
       useTaskRemoval({ store: store as unknown as StoreApi<never> }),
@@ -315,6 +322,28 @@ describe("useTaskRemoval — next task selection", () => {
       wasActiveSessionId: "sess-A",
     });
 
+    expect(store.getRecorded().setActiveSession).toHaveBeenCalledWith(
+      recentTaskId,
+      recentSessionId,
+    );
+    expect(replaceTaskUrlMock).toHaveBeenCalledWith(recentTaskId);
+  });
+
+  it("can switch before removing the task from board state", async () => {
+    const store = makeStoreWithOldAndRecentTasks("task-A");
+    setRemovedTaskFirst();
+
+    const { result } = renderHook(() =>
+      useTaskRemoval({ store: store as unknown as StoreApi<never> }),
+    );
+
+    await result.current.removeTaskFromBoard("task-A", {
+      wasActiveTaskId: "task-A",
+      wasActiveSessionId: "sess-A",
+      removeFromBoard: false,
+    });
+
+    expect(store.getRecorded().setWorkflowSnapshot).not.toHaveBeenCalled();
     expect(store.getRecorded().setActiveSession).toHaveBeenCalledWith(
       recentTaskId,
       recentSessionId,

--- a/apps/web/hooks/use-task-removal.test.ts
+++ b/apps/web/hooks/use-task-removal.test.ts
@@ -274,10 +274,11 @@ describe("useTaskRemoval — switch guard (WS-clear fallback)", () => {
       const { result } = renderHook(() =>
         useTaskRemoval({ store: store as unknown as StoreApi<never> }),
       );
-      await result.current.removeTaskFromBoard("task-A", {
+      const removeResult = await result.current.removeTaskFromBoard("task-A", {
         wasActiveTaskId: "task-A",
         wasActiveSessionId: "sess-A",
       });
+      expect(removeResult.switchedTaskId).toBeNull();
       expect(hrefSetter).toHaveBeenCalledWith("/");
     } finally {
       Object.defineProperty(window, "location", {

--- a/apps/web/hooks/use-task-removal.ts
+++ b/apps/web/hooks/use-task-removal.ts
@@ -27,7 +27,11 @@ type RemoveFromBoardOptions = {
   /** The active session ID captured before the async delete API call. */
   wasActiveSessionId?: string | null;
   /** Switch away from the task without removing it from board state yet. */
-  removeFromBoard?: boolean;
+  switchOnly?: boolean;
+};
+
+type RemoveFromBoardResult = {
+  switchedTaskId: string | null;
 };
 
 function cachedSessionsHaveEnvIds(sessions: TaskSession[]): boolean {
@@ -211,11 +215,13 @@ export function useTaskRemoval({ store, useLayoutSwitch = false }: TaskRemovalOp
    * wins and the captured value is ignored (no auto-switch).
    */
   const removeTaskFromBoard = useCallback(
-    async (taskId: string, opts?: RemoveFromBoardOptions) => {
-      if (opts?.removeFromBoard !== false) removeTaskFromSnapshots(store, taskId);
+    async (taskId: string, opts?: RemoveFromBoardOptions): Promise<RemoveFromBoardResult> => {
+      if (!opts?.switchOnly) removeTaskFromSnapshots(store, taskId);
       const allRemainingTasks = collectRemainingTasks(store);
 
-      if (!shouldSwitchAfterRemoval(store, taskId, opts)) return;
+      if (!shouldSwitchAfterRemoval(store, taskId, opts)) {
+        return { switchedTaskId: null };
+      }
 
       const oldEnvId = resolveOldEnvId(store, opts);
       const nextTask = selectNextTaskAfterRemoval(allRemainingTasks, taskId);
@@ -227,9 +233,11 @@ export function useTaskRemoval({ store, useLayoutSwitch = false }: TaskRemovalOp
           useLayoutSwitch,
           loadTaskSessionsForTask,
         });
-      } else {
-        window.location.href = "/";
+        return { switchedTaskId: nextTask.id };
       }
+
+      window.location.href = "/";
+      return { switchedTaskId: taskId };
     },
     [store, useLayoutSwitch, loadTaskSessionsForTask],
   );

--- a/apps/web/hooks/use-task-removal.ts
+++ b/apps/web/hooks/use-task-removal.ts
@@ -237,7 +237,7 @@ export function useTaskRemoval({ store, useLayoutSwitch = false }: TaskRemovalOp
       }
 
       window.location.href = "/";
-      return { switchedTaskId: taskId };
+      return { switchedTaskId: null };
     },
     [store, useLayoutSwitch, loadTaskSessionsForTask],
   );

--- a/apps/web/hooks/use-task-removal.ts
+++ b/apps/web/hooks/use-task-removal.ts
@@ -26,6 +26,8 @@ type RemoveFromBoardOptions = {
   wasActiveTaskId?: string | null;
   /** The active session ID captured before the async delete API call. */
   wasActiveSessionId?: string | null;
+  /** Switch away from the task without removing it from board state yet. */
+  removeFromBoard?: boolean;
 };
 
 function cachedSessionsHaveEnvIds(sessions: TaskSession[]): boolean {
@@ -95,13 +97,16 @@ function collectRemainingTasks(store: StoreApi<AppState>): KanbanState["tasks"] 
 
 function selectNextTaskAfterRemoval(
   remainingTasks: KanbanState["tasks"],
+  removedTaskId: string,
 ): KanbanState["tasks"][number] | null {
-  const remainingById = new Map(remainingTasks.map((task) => [task.id, task]));
+  const remainingById = new Map(
+    remainingTasks.filter((task) => task.id !== removedTaskId).map((task) => [task.id, task]),
+  );
   for (const recent of getRecentTasks()) {
     const task = remainingById.get(recent.taskId);
     if (task) return task;
   }
-  return remainingTasks[0] ?? null;
+  return remainingTasks.find((task) => task.id !== removedTaskId) ?? null;
 }
 
 function switchToSessionForTask(params: {
@@ -207,13 +212,13 @@ export function useTaskRemoval({ store, useLayoutSwitch = false }: TaskRemovalOp
    */
   const removeTaskFromBoard = useCallback(
     async (taskId: string, opts?: RemoveFromBoardOptions) => {
-      removeTaskFromSnapshots(store, taskId);
+      if (opts?.removeFromBoard !== false) removeTaskFromSnapshots(store, taskId);
       const allRemainingTasks = collectRemainingTasks(store);
 
       if (!shouldSwitchAfterRemoval(store, taskId, opts)) return;
 
       const oldEnvId = resolveOldEnvId(store, opts);
-      const nextTask = selectNextTaskAfterRemoval(allRemainingTasks);
+      const nextTask = selectNextTaskAfterRemoval(allRemainingTasks, taskId);
       if (nextTask) {
         await switchToNextTask({
           store,


### PR DESCRIPTION
## Summary
- Switches away from the active task immediately when archive is confirmed, so the workspace moves to the last active remaining task without waiting for the archive API call to finish.
- Keeps board state conservative: the archived task is only removed from task lists after the archive request succeeds, while the initial step only changes the active task/session.
- Restores the previous active task and URL when archive fails and the user is still on the optimistic switch target, preserving manual navigation that happens during the request.
- Scopes archive dialog loading state to the task currently being archived so a fast switch does not leave the next task's archive confirmation disabled.

## Why
Archiving a task with a merged PR used to feel slow because the UI waited for the archive operation before switching task context. This change makes the context switch happen first, while still keeping data consistency and rollback behavior around the actual archive operation.

## Testing
- `pnpm --filter @kandev/web test hooks/use-task-removal.test.ts hooks/use-task-actions.test.ts components/task/task-archive-confirm-dialog.test.tsx`
- `pnpm --filter @kandev/web lint`
- `scripts/run-quiet build -- make build-backend build-web`
- `scripts/run-quiet e2e -- bash -c 'cd apps && pnpm --filter @kandev/web e2e -- tests/task/archive-task-redirect.spec.ts'`
- CI: all PR checks passing on `ff66b8a7`, including frontend build/tests/lint, CodeQL, and E2E shards.