### PR TITLE
fix: correct sidebar workspace switcher routing and selection persistence

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from "next/headers";
 import { PageClient } from "@/app/page-client";
 import { StateHydrator } from "@/components/state-hydrator";
 import {
@@ -13,6 +14,7 @@ import { listWorkspaceTaskPRs } from "@/lib/api/domains/github-api";
 import { snapshotToState } from "@/lib/ssr/mapper";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { resolveDesiredWorkflowId } from "@/lib/kanban/resolve-workflow";
+import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
 import type { AppState } from "@/lib/state/store";
 import type { ListWorkspacesResponse, UserSettingsResponse } from "@/lib/types/http";
 
@@ -54,19 +56,6 @@ function readAgentProfileId(
   if (!metadata || typeof metadata !== "object") return undefined;
   const value = metadata.agent_profile_id;
   return typeof value === "string" ? value : undefined;
-}
-
-function resolveActiveId<T extends { id: string }>(
-  items: T[],
-  preferredId?: string,
-  fallbackId?: string | null,
-): string | null {
-  return (
-    items.find((i) => i.id === preferredId)?.id ??
-    items.find((i) => i.id === fallbackId)?.id ??
-    items[0]?.id ??
-    null
-  );
 }
 
 function buildBaseState(
@@ -124,15 +113,21 @@ export default async function Page({ searchParams }: PageProps) {
     const taskId = resolveParam(resolvedParams.taskId);
     const sessionId = resolveParam(resolvedParams.sessionId);
 
-    const [workspaces, userSettingsResponse] = await Promise.all([
+    const [workspaces, userSettingsResponse, cookieStore] = await Promise.all([
       listWorkspaces({ cache: "no-store" }),
       fetchUserSettings({ cache: "no-store" }).catch(() => null),
+      cookies().catch(() => null),
     ]);
     const settingsWorkspaceId = userSettingsResponse?.settings?.workspace_id || null;
     const settingsWorkflowId = userSettingsResponse?.settings?.workflow_filter_id || null;
+    // The sidebar picker writes the selected workspace to this cookie so the
+    // choice survives a refresh even when office is disabled (userSettings is
+    // not updated on select). Priority: URL param > cookie > saved setting.
+    const cookieWorkspaceId = cookieStore?.get("office-active-workspace")?.value ?? null;
     const activeWorkspaceId = resolveActiveId(
       workspaces.workspaces,
       workspaceId,
+      cookieWorkspaceId,
       settingsWorkspaceId,
     );
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -116,7 +116,10 @@ export default async function Page({ searchParams }: PageProps) {
     const [workspaces, userSettingsResponse, cookieStore] = await Promise.all([
       listWorkspaces({ cache: "no-store" }),
       fetchUserSettings({ cache: "no-store" }).catch(() => null),
-      cookies().catch(() => null),
+      cookies().catch((error) => {
+        console.error("Failed to read cookies on Kanban page:", error);
+        return null;
+      }),
     ]);
     const settingsWorkspaceId = userSettingsResponse?.settings?.workspace_id || null;
     const settingsWorkflowId = userSettingsResponse?.settings?.workflow_filter_id || null;

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -18,12 +18,14 @@ vi.mock("@kandev/ui/dropdown-menu", () => ({
     children,
     onSelect,
     disabled,
+    "data-testid": testId,
   }: {
     children: React.ReactNode;
     onSelect?: () => void;
     disabled?: boolean;
+    "data-testid"?: string;
   }) => (
-    <button type="button" disabled={disabled} onClick={() => onSelect?.()}>
+    <button type="button" disabled={disabled} data-testid={testId} onClick={() => onSelect?.()}>
       {children}
     </button>
   ),
@@ -72,5 +74,54 @@ describe("AppSidebarWorkspacePicker — Add workspace routing", () => {
     fireEvent.click(screen.getByText("Add workspace"));
 
     expect(navigationMock.push).toHaveBeenCalledWith("/settings/workspace");
+  });
+});
+
+describe("AppSidebarWorkspacePicker — workspace select", () => {
+  // jsdom over http drops `secure` cookies, so intercept the setter to capture
+  // the write directly rather than reading `document.cookie` back.
+  let cookieWrites: string[] = [];
+  let cookieDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    navigationMock.push = vi.fn();
+    storeState.setActiveWorkspace = vi.fn();
+    cookieWrites = [];
+    cookieDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "cookie");
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get: () => cookieWrites.join("; "),
+      set: (value: string) => {
+        cookieWrites.push(value);
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (cookieDescriptor) {
+      Object.defineProperty(document, "cookie", cookieDescriptor);
+    }
+    cleanup();
+  });
+
+  it("writes the active-workspace cookie and updates the store on select", () => {
+    storeState.features.office = false;
+    render(<AppSidebarWorkspacePicker />);
+
+    fireEvent.click(screen.getByTestId("sidebar-workspace-item-w1"));
+
+    expect(cookieWrites.some((c) => c.startsWith("office-active-workspace=w1"))).toBe(true);
+    expect(storeState.setActiveWorkspace).toHaveBeenCalledWith("w1");
+    expect(navigationMock.push).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the office workspace when the office feature is enabled", () => {
+    storeState.features.office = true;
+    render(<AppSidebarWorkspacePicker />);
+
+    fireEvent.click(screen.getByTestId("sidebar-workspace-item-w1"));
+
+    expect(storeState.setActiveWorkspace).toHaveBeenCalledWith("w1");
+    expect(navigationMock.push).toHaveBeenCalledWith("/office?workspaceId=w1");
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+const navigationMock = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: navigationMock.push }),
+}));
+
+// Radix dropdown primitives rely on pointer/portal behaviour that jsdom doesn't
+// model well. Render them as plain elements so the focus stays on the picker's
+// routing logic: `onSelect` fires on click of the item.
+vi.mock("@kandev/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" disabled={disabled} onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+const storeState = {
+  features: { office: false },
+  workspaces: {
+    items: [{ id: "w1", name: "Default Workspace" }],
+    activeId: "w1",
+  },
+  setActiveWorkspace: vi.fn(),
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof storeState) => unknown) => selector(storeState),
+}));
+
+import { AppSidebarWorkspacePicker } from "./app-sidebar-workspace-picker";
+
+describe("AppSidebarWorkspacePicker — Add workspace routing", () => {
+  beforeEach(() => {
+    navigationMock.push = vi.fn();
+    storeState.features.office = false;
+    storeState.setActiveWorkspace = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("routes to the office setup wizard when the office feature is enabled", () => {
+    storeState.features.office = true;
+    render(<AppSidebarWorkspacePicker />);
+
+    fireEvent.click(screen.getByText("Add workspace"));
+
+    expect(navigationMock.push).toHaveBeenCalledWith("/office/setup?mode=new");
+  });
+
+  it("routes to the settings workspaces page when the office feature is disabled", () => {
+    storeState.features.office = false;
+    render(<AppSidebarWorkspacePicker />);
+
+    fireEvent.click(screen.getByText("Add workspace"));
+
+    expect(navigationMock.push).toHaveBeenCalledWith("/settings/workspace");
+  });
+});

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -93,7 +93,7 @@ export function AppSidebarWorkspacePicker() {
         <DropdownMenuItem
           className="cursor-pointer gap-2"
           onSelect={() => {
-            router.push("/office/setup?mode=new");
+            router.push(officeEnabled ? "/office/setup?mode=new" : "/settings/workspace");
           }}
         >
           <IconPlus className="h-3.5 w-3.5" />

--- a/apps/web/lib/ssr/resolve-active-id.test.ts
+++ b/apps/web/lib/ssr/resolve-active-id.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { resolveActiveId } from "./resolve-active-id";
+
+const items = [{ id: "sky" }, { id: "test" }];
+
+describe("resolveActiveId", () => {
+  it("returns the first candidate that exists in items", () => {
+    expect(resolveActiveId(items, "test")).toBe("test");
+  });
+
+  it("honours candidate priority order (earlier wins)", () => {
+    // URL param > cookie > setting: the cookie ("test") should win over the
+    // saved setting ("sky") when no URL param is given.
+    expect(resolveActiveId(items, undefined, "test", "sky")).toBe("test");
+  });
+
+  it("falls through to the next candidate when an earlier one is missing", () => {
+    expect(resolveActiveId(items, "ghost", "test")).toBe("test");
+  });
+
+  it("skips null/undefined candidates", () => {
+    expect(resolveActiveId(items, null, undefined, "sky")).toBe("sky");
+  });
+
+  it("falls back to the first item when no candidate matches", () => {
+    expect(resolveActiveId(items, "ghost", null)).toBe("sky");
+  });
+
+  it("returns null when there are no items", () => {
+    expect(resolveActiveId([], "test")).toBeNull();
+  });
+});

--- a/apps/web/lib/ssr/resolve-active-id.ts
+++ b/apps/web/lib/ssr/resolve-active-id.ts
@@ -1,12 +1,5 @@
-/**
- * Pick the first candidate id that exists in `items`, falling back to the
- * first item. Candidates are checked in the order given, so callers pass them
- * highest-priority first.
- *
- * Used by SSR to resolve the active workspace from (in priority order) a URL
- * `workspaceId` param, the `office-active-workspace` cookie set by the sidebar
- * picker, and the user's saved `workspace_id` setting.
- */
+// Returns the first candidate id present in `items` (checked in order, so callers
+// pass highest-priority first), falling back to the first item's id.
 export function resolveActiveId<T extends { id: string }>(
   items: T[],
   ...preferredIds: (string | null | undefined)[]

--- a/apps/web/lib/ssr/resolve-active-id.ts
+++ b/apps/web/lib/ssr/resolve-active-id.ts
@@ -1,0 +1,20 @@
+/**
+ * Pick the first candidate id that exists in `items`, falling back to the
+ * first item. Candidates are checked in the order given, so callers pass them
+ * highest-priority first.
+ *
+ * Used by SSR to resolve the active workspace from (in priority order) a URL
+ * `workspaceId` param, the `office-active-workspace` cookie set by the sidebar
+ * picker, and the user's saved `workspace_id` setting.
+ */
+export function resolveActiveId<T extends { id: string }>(
+  items: T[],
+  ...preferredIds: (string | null | undefined)[]
+): string | null {
+  for (const id of preferredIds) {
+    if (id == null) continue;
+    const match = items.find((i) => i.id === id);
+    if (match) return match.id;
+  }
+  return items[0]?.id ?? null;
+}


### PR DESCRIPTION
The sidebar workspace switcher had two defects when used outside office mode: the "Add workspace" item routed to the office-only setup wizard (which 404s when the office feature flag is off), and a selected workspace reverted to the first workspace after a page refresh because the kanban root page never read the selection cookie. Both surfaces now behave consistently.

## Important Changes

- "Add workspace" routes to `/settings/workspace` when office is disabled and to the office setup wizard when enabled.
- The kanban root page (`app/page.tsx`) now reads the `office-active-workspace` cookie during SSR, matching the pattern the office layout already used. Resolution priority is URL param > cookie > saved setting > first.
- Extracted the SSR active-id resolution into a reusable, tested helper (`lib/ssr/resolve-active-id.ts`).

## Validation

- `pnpm --filter @kandev/web exec vitest run` for the new specs (`app-sidebar-workspace-picker.test.tsx`, `resolve-active-id.test.ts`)
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web typecheck`

## Possible Improvements

Low risk. The cookie is still named `office-active-workspace` even though it now also drives kanban selection; office and kanban keep near-identical resolver logic that could later be unified onto the shared helper.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.