### PR TITLE
fix(office): route setup cancel to homepage

### DIFF
--- a/apps/web/app/office/setup/setup-wizard.tsx
+++ b/apps/web/app/office/setup/setup-wizard.tsx
@@ -198,7 +198,7 @@ export function SetupWizard({
     }
   }, [router]);
 
-  const closeHref = mode === "new" ? "/office" : "/";
+  const closeHref = "/";
 
   if (!showWizard) {
     return (

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -140,7 +140,7 @@ export class SessionPage {
     const attemptTimeout =
       opts.attemptTimeout ?? Math.min(15_000, Math.max(5_000, Math.floor(softTotalTimeout / 3)));
     const pollSlice = 1_500;
-    const idle = this.idleInput();
+    const idle = this.anyIdleInput();
     const start = Date.now();
     let reloaded = false;
 
@@ -297,6 +297,14 @@ export class SessionPage {
   /** Chat input placeholder when agent is idle (default mode). */
   idleInput(): Locator {
     return this.page.locator('[data-placeholder="Continue working on the task..."]');
+  }
+
+  /** Chat input placeholder when agent is idle in any current mode. */
+  anyIdleInput(): Locator {
+    return this.page
+      .locator('[data-placeholder="Continue working on the task..."]')
+      .or(this.page.locator('[data-placeholder="Continue working on the plan..."]'))
+      .or(this.page.locator('[data-placeholder="Continue working on the file..."]'));
   }
 
   /** Chat input placeholder when agent is idle (plan mode). */

--- a/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
@@ -41,6 +41,18 @@ test.describe("Office onboarding — mobile layout", () => {
     expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
   });
 
+  test("close button returns to homepage on mobile when adding a workspace", async ({
+    testPage,
+    officeSeed: _,
+  }) => {
+    await testPage.goto(SETUP_ROUTE);
+    await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
+
+    await testPage.getByRole("button", { name: "Cancel" }).tap();
+
+    await expect(testPage).toHaveURL(/\/$/, { timeout: 10_000 });
+  });
+
   test("agent step (Step 1) fits within the viewport horizontally", async ({
     testPage,
     officeSeed: _,

--- a/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/mobile-onboarding.spec.ts
@@ -48,9 +48,9 @@ test.describe("Office onboarding — mobile layout", () => {
     await testPage.goto(SETUP_ROUTE);
     await expect(testPage.getByRole("heading", { name: STEP_0_HEADING })).toBeVisible();
 
-    await testPage.getByRole("button", { name: "Cancel" }).tap();
+    await testPage.getByRole("button", { name: "Cancel" }).click();
 
-    await expect(testPage).toHaveURL(/\/$/, { timeout: 10_000 });
+    await expect(testPage).toHaveURL((url) => url.pathname === "/", { timeout: 10_000 });
   });
 
   test("agent step (Step 1) fits within the viewport horizontally", async ({

--- a/apps/web/e2e/tests/office/onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/onboarding.spec.ts
@@ -93,7 +93,7 @@ test.describe("Onboarding", () => {
     });
 
     await testPage.getByRole("button", { name: "Cancel" }).click();
-    await expect(testPage).toHaveURL(/\/$/, { timeout: 10_000 });
+    await expect(testPage).toHaveURL((url) => url.pathname === "/", { timeout: 10_000 });
   });
 
   test("cancel button returns to homepage when adding a new workspace", async ({
@@ -107,7 +107,7 @@ test.describe("Onboarding", () => {
 
     await testPage.getByRole("button", { name: "Cancel" }).click();
 
-    await expect(testPage).toHaveURL(/\/$/, { timeout: 10_000 });
+    await expect(testPage).toHaveURL((url) => url.pathname === "/", { timeout: 10_000 });
   });
 
   test("inline CLI profile creation selects the profile for the new agent", async ({

--- a/apps/web/e2e/tests/office/onboarding.spec.ts
+++ b/apps/web/e2e/tests/office/onboarding.spec.ts
@@ -74,7 +74,7 @@ test.describe("Onboarding", () => {
     });
   });
 
-  test('"Add workspace" button navigates to setup with mode=new', async ({
+  test('"Add workspace" button opens setup and close returns to homepage', async ({
     testPage,
     officeSeed: _,
   }) => {
@@ -91,9 +91,12 @@ test.describe("Onboarding", () => {
     ).toBeVisible({
       timeout: 10_000,
     });
+
+    await testPage.getByRole("button", { name: "Cancel" }).click();
+    await expect(testPage).toHaveURL(/\/$/, { timeout: 10_000 });
   });
 
-  test("cancel button returns to dashboard when adding a new workspace", async ({
+  test("cancel button returns to homepage when adding a new workspace", async ({
     testPage,
     officeSeed: _,
   }) => {
@@ -104,10 +107,7 @@ test.describe("Onboarding", () => {
 
     await testPage.getByRole("button", { name: "Cancel" }).click();
 
-    await expect(testPage).toHaveURL(/\/office$/, { timeout: 10_000 });
-    await expect(testPage.getByRole("heading", { name: /Dashboard/i }).first()).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(testPage).toHaveURL(/\/$/, { timeout: 10_000 });
   });
 
   test("inline CLI profile creation selects the profile for the new agent", async ({


### PR DESCRIPTION
The Office setup wizard in `mode=new` had a cancel path that routed to `/office`, which can redirect users back into setup when onboarding is incomplete; it should always return to the app homepage as an explicit abort destination.
I changed the close destination to `/` and added focused Playwright coverage to confirm cancel/close behavior on desktop and mobile.

## Important Changes

- Changed close navigation in `apps/web/app/office/setup/setup-wizard.tsx` to always use `/` so the setup wizard cannot immediately bounce back into `/office/setup`.
- Added/updated onboarding E2E assertions in `apps/web/e2e/tests/office/onboarding.spec.ts` and `apps/web/e2e/tests/office/mobile-onboarding.spec.ts` for cancel-to-homepage behavior.

## Validation

- `pnpm --filter @kandev/web e2e --project=chromium tests/office/onboarding.spec.ts -g "close returns to homepage|cancel button returns to homepage" --reporter=list`
- `pnpm --filter @kandev/web e2e --project=mobile-chrome tests/office/mobile-onboarding.spec.ts -g "close button returns to homepage" --reporter=list`
- `make fmt`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.