### PR TITLE
docs: add sentry to integrations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Open source, multi-provider, no telemetry, not tied to any cloud.
   <a href="https://github.com/"><img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub"></a>
   <a href="https://www.atlassian.com/software/jira"><img src="https://img.shields.io/badge/Jira-0052CC?style=for-the-badge&logo=jira&logoColor=white" alt="Jira"></a>
   <a href="https://linear.app/"><img src="https://img.shields.io/badge/Linear-5E6AD2?style=for-the-badge&logo=linear&logoColor=white" alt="Linear"></a>
+  <a href="https://sentry.io/"><img src="https://img.shields.io/badge/Sentry-362D59?style=for-the-badge&logo=sentry&logoColor=white" alt="Sentry"></a>
 </p>
 
 Connect Kandev to the tools your team already uses — pull issues into the kanban, link tasks to PRs, and surface review activity inline.


### PR DESCRIPTION
Sentry is a supported integration in kandev, but the README advertised only GitHub, Jira, and Linear, which gave users an incomplete view of available integrations. Adding Sentry to the README badge list aligns documentation with actual capabilities and makes discovery of the Sentry setup path clearer.

## Validation

- Not run (documentation-only change)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.