### PR TITLE
fix: de-flake e2e resume flicker, WS-subscribe race, and agent-boot contention

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -25,9 +25,19 @@ func (s *Service) handleAgentRunning(ctx context.Context, data watcher.AgentEven
 		return
 	}
 
-	// Process on_turn_start workflow events (step transitions).
-	// For ACP sessions this happens in the message handler before PromptTask;
-	// for passthrough it happens here when the PTY detects user input.
+	// agent.running fires whenever the agent process starts running — including
+	// the boot of a silent resume after a backend restart (session/new fallback
+	// for agents without native resume, or a session/load reconnect), where no
+	// turn is actually in flight. ACP sessions drive RUNNING from the
+	// prompt-dispatch path (PromptTask / dispatchPromptAsync) and stream
+	// tool/message events, so reacting to the boot signal here would only flicker
+	// a settled WAITING_FOR_INPUT task into the Running bucket during resume.
+	// Passthrough sessions have no PromptTask, so agent.running IS their
+	// turn-start signal: handle on_turn_start and move the session to RUNNING.
+	if !s.agentManager.IsPassthroughSession(ctx, data.SessionID) {
+		return
+	}
+
 	session, err := s.repo.GetTaskSession(ctx, data.SessionID)
 	if err != nil {
 		s.logger.Warn("failed to load session for agent running",
@@ -39,11 +49,9 @@ func (s *Service) handleAgentRunning(ctx context.Context, data watcher.AgentEven
 	// on_turn_start is only needed for passthrough sessions where there's
 	// no PromptTask call to handle it. For ACP sessions, PromptTask or
 	// dispatchPromptAsync already processes on_turn_start.
-	if s.agentManager.IsPassthroughSession(ctx, data.SessionID) {
-		s.processOnTurnStartViaEngine(ctx, data.TaskID, session)
-	}
+	s.processOnTurnStartViaEngine(ctx, data.TaskID, session)
 
-	// Move session to running and task to in progress
+	// Move session to running and task to in progress.
 	s.setSessionRunning(ctx, data.TaskID, data.SessionID, session)
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_agent.go
+++ b/apps/backend/internal/orchestrator/event_handlers_agent.go
@@ -46,9 +46,6 @@ func (s *Service) handleAgentRunning(ctx context.Context, data watcher.AgentEven
 			zap.Error(err))
 		return
 	}
-	// on_turn_start is only needed for passthrough sessions where there's
-	// no PromptTask call to handle it. For ACP sessions, PromptTask or
-	// dispatchPromptAsync already processes on_turn_start.
 	s.processOnTurnStartViaEngine(ctx, data.TaskID, session)
 
 	// Move session to running and task to in progress.

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -1088,6 +1088,60 @@ func TestHandleAgentRunning_PassthroughGuard(t *testing.T) {
 	})
 }
 
+// TestHandleAgentRunning_DoesNotWakeWaitingAcpSession is the regression guard for
+// the silent-resume flicker (session-resume-keeps-review-state e2e). On resume,
+// the agent.running boot event fires for the reconnecting ACP session; it must
+// NOT wake a settled WAITING_FOR_INPUT session to RUNNING (which would displace
+// the task into the Running sidebar bucket). ACP turns drive RUNNING via the
+// prompt path instead. Passthrough sessions, which have no prompt path, must
+// still wake on agent.running.
+func TestHandleAgentRunning_DoesNotWakeWaitingAcpSession(t *testing.T) {
+	ctx := context.Background()
+
+	settleWaiting := func(t *testing.T, repo *sqliterepo.Repository) {
+		t.Helper()
+		if err := repo.UpdateTaskSessionState(ctx, "s1", models.TaskSessionStateWaitingForInput, ""); err != nil {
+			t.Fatalf("failed to settle session to WAITING_FOR_INPUT: %v", err)
+		}
+	}
+
+	t.Run("ACP boot does not wake session", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		settleWaiting(t, repo)
+
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(),
+			&mockAgentManager{isPassthrough: false})
+		svc.handleAgentRunning(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1"})
+
+		sess, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("failed to get session: %v", err)
+		}
+		if sess.State != models.TaskSessionStateWaitingForInput {
+			t.Errorf("ACP agent.running boot must keep session WAITING_FOR_INPUT, got %q", sess.State)
+		}
+	})
+
+	t.Run("passthrough turn wakes session", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		seedSession(t, repo, "t1", "s1", "step1")
+		settleWaiting(t, repo)
+
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(),
+			&mockAgentManager{isPassthrough: true})
+		svc.handleAgentRunning(ctx, watcher.AgentEventData{TaskID: "t1", SessionID: "s1"})
+
+		sess, err := repo.GetTaskSession(ctx, "s1")
+		if err != nil {
+			t.Fatalf("failed to get session: %v", err)
+		}
+		if sess.State != models.TaskSessionStateRunning {
+			t.Errorf("passthrough agent.running must wake session to RUNNING, got %q", sess.State)
+		}
+	})
+}
+
 func TestDeliverPassthroughPrompt(t *testing.T) {
 	ctx := context.Background()
 

--- a/apps/backend/internal/system/jobs/jobs_test.go
+++ b/apps/backend/internal/system/jobs/jobs_test.go
@@ -22,12 +22,24 @@ func newTestLogger() *logger.Logger {
 type stubBus struct {
 	mu     sync.Mutex
 	events []*bus.Event
+	notify chan struct{}
+}
+
+// newStubBus returns a stubBus with a buffered notify channel so Publish can
+// signal waiters without blocking. The buffer is size 1 because waiters always
+// re-check the event count after each wake, so a coalesced signal is enough.
+func newStubBus() *stubBus {
+	return &stubBus{notify: make(chan struct{}, 1)}
 }
 
 func (s *stubBus) Publish(_ context.Context, _ string, event *bus.Event) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.events = append(s.events, event)
+	s.mu.Unlock()
+	select {
+	case s.notify <- struct{}{}:
+	default:
+	}
 	return nil
 }
 
@@ -71,26 +83,33 @@ func waitForState(t *testing.T, tracker *Tracker, id string, target State) *Job 
 	return nil
 }
 
-// waitForEvents polls the stub bus until at least n events have been
-// published or the timeout fires. The terminal lifecycle event is published
-// after the transition releases the lock (see Tracker.transition), so
-// observing the terminal state via waitForState does not guarantee the
-// terminal event has landed yet - assertions on the event log must sync on
-// the published count, not the job state.
+// waitForEvents blocks until at least n events have been published or the
+// timeout fires. The terminal lifecycle event is published after the
+// transition releases the lock (see Tracker.transition), so observing the
+// terminal state via waitForState does not guarantee the terminal event has
+// landed yet - assertions on the event log must sync on the published count,
+// not the job state. It selects on the bus notify channel rather than polling
+// so the wait is deterministic (no time.Sleep).
 func waitForEvents(t *testing.T, stub *stubBus, n int) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	timeout := time.After(2 * time.Second)
+	for {
 		if len(stub.snapshot()) >= n {
 			return
 		}
-		time.Sleep(5 * time.Millisecond)
+		select {
+		case <-stub.notify:
+		case <-timeout:
+			if got := len(stub.snapshot()); got < n {
+				t.Fatalf("expected at least %d published events within 2s, got %d", n, got)
+			}
+			return
+		}
 	}
-	t.Fatalf("expected at least %d published events within 2s, got %d", n, len(stub.snapshot()))
 }
 
 func TestStart_PublishesQueuedRunningSucceeded(t *testing.T) {
-	stub := &stubBus{}
+	stub := newStubBus()
 	tracker := NewTracker(stub, newTestLogger())
 
 	id := tracker.Start(context.Background(), "vacuum", func(context.Context) (map[string]interface{}, error) {
@@ -124,7 +143,7 @@ func TestStart_PublishesQueuedRunningSucceeded(t *testing.T) {
 }
 
 func TestStart_PublishesFailed(t *testing.T) {
-	stub := &stubBus{}
+	stub := newStubBus()
 	tracker := NewTracker(stub, newTestLogger())
 
 	id := tracker.Start(context.Background(), "vacuum", func(context.Context) (map[string]interface{}, error) {
@@ -151,14 +170,14 @@ func TestStart_PublishesFailed(t *testing.T) {
 }
 
 func TestGet_UnknownReturnsNil(t *testing.T) {
-	tracker := NewTracker(&stubBus{}, newTestLogger())
+	tracker := NewTracker(newStubBus(), newTestLogger())
 	if got := tracker.Get("nonexistent"); got != nil {
 		t.Errorf("expected nil for unknown id, got %+v", got)
 	}
 }
 
 func TestList_ReturnsAllTrackedJobs(t *testing.T) {
-	tracker := NewTracker(&stubBus{}, newTestLogger())
+	tracker := NewTracker(newStubBus(), newTestLogger())
 	ids := make([]string, 0, 3)
 	for i := 0; i < 3; i++ {
 		ids = append(ids, tracker.Start(context.Background(), "noop", func(context.Context) (map[string]interface{}, error) {

--- a/apps/backend/internal/system/jobs/jobs_test.go
+++ b/apps/backend/internal/system/jobs/jobs_test.go
@@ -71,6 +71,24 @@ func waitForState(t *testing.T, tracker *Tracker, id string, target State) *Job 
 	return nil
 }
 
+// waitForEvents polls the stub bus until at least n events have been
+// published or the timeout fires. The terminal lifecycle event is published
+// after the transition releases the lock (see Tracker.transition), so
+// observing the terminal state via waitForState does not guarantee the
+// terminal event has landed yet - assertions on the event log must sync on
+// the published count, not the job state.
+func waitForEvents(t *testing.T, stub *stubBus, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(stub.snapshot()) >= n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected at least %d published events within 2s, got %d", n, len(stub.snapshot()))
+}
+
 func TestStart_PublishesQueuedRunningSucceeded(t *testing.T) {
 	stub := &stubBus{}
 	tracker := NewTracker(stub, newTestLogger())
@@ -84,6 +102,7 @@ func TestStart_PublishesQueuedRunningSucceeded(t *testing.T) {
 		t.Errorf("expected reclaimed_bytes in result, got %+v", job.Result)
 	}
 
+	waitForEvents(t, stub, 3)
 	events := stub.snapshot()
 	if len(events) < 3 {
 		t.Fatalf("expected at least 3 published events (queued/running/succeeded), got %d", len(events))
@@ -120,6 +139,7 @@ func TestStart_PublishesFailed(t *testing.T) {
 		t.Error("expected EndedAt to be set on failed job")
 	}
 
+	waitForEvents(t, stub, 3)
 	events := stub.snapshot()
 	if len(events) < 3 {
 		t.Fatalf("expected at least 3 events, got %d", len(events))

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -805,6 +805,29 @@ export class SessionPage {
     await this.page.getByTestId("submit-message-button").click();
   }
 
+  /**
+   * Wait for the agent reply containing `text` at the given 0-based match
+   * `index` to be visible after a follow-up prompt. On first timeout, reload
+   * once so SSR re-fetches the persisted turn, then re-assert.
+   *
+   * This rides out the same WS-subscribe race `waitForChatIdle` handles, but
+   * for the reply message itself: a mid-session prompt's response event can be
+   * dropped when the client's WS subscription loses the race with the agent's
+   * reply (common after repeated restart/resume cycles). The reply is persisted
+   * server-side, so a single reload recovers it.
+   */
+  async expectChatResponseVisible(text: string, index = 0, opts: { timeout?: number } = {}) {
+    const timeout = opts.timeout ?? 30_000;
+    const target = () => this.chat.getByText(text, { exact: false }).nth(index);
+    try {
+      await expect(target()).toBeVisible({ timeout });
+    } catch {
+      await this.page.reload();
+      await this.waitForLoad();
+      await expect(target()).toBeVisible({ timeout });
+    }
+  }
+
   /** Toggle plan mode on/off by clicking the plan mode toggle button in the toolbar.
    *
    * Waits for the button to advertise `data-plan-available="true"` before clicking.

--- a/apps/web/e2e/tests/chat/markdown-paragraph-breaks.spec.ts
+++ b/apps/web/e2e/tests/chat/markdown-paragraph-breaks.spec.ts
@@ -35,7 +35,7 @@ test.describe("Markdown paragraph breaks", () => {
     const session = new SessionPage(testPage);
     await session.waitForLoad();
     // Wait for the agent to finish processing the prompt and become idle.
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Wait for the agent response containing our paragraphs to appear.
     await expect(session.chat.getByText("Paragraph three.").last()).toBeVisible({

--- a/apps/web/e2e/tests/chat/model-selector-error.spec.ts
+++ b/apps/web/e2e/tests/chat/model-selector-error.spec.ts
@@ -32,7 +32,7 @@ test.describe("Chat model selector — RPC failure", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     const trigger = testPage.getByRole("button", { name: "Session model settings" });
     await expect(trigger).toBeVisible({ timeout: 15_000 });
@@ -87,7 +87,7 @@ test.describe("Chat model selector — RPC failure", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     const trigger = testPage.getByRole("button", { name: "Session model settings" });
     await expect(trigger).toContainText("Mock Fast", { timeout: 15_000 });
@@ -169,7 +169,7 @@ test.describe("Chat model selector — persistence", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     const trigger = testPage.getByRole("button", { name: "Session model settings" });
     await expect(trigger).toContainText("Mock Fast", { timeout: 15_000 });
@@ -228,7 +228,7 @@ test.describe("Chat model selector — popover open/close behavior", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     const trigger = testPage.getByRole("button", { name: "Session model settings" });
     await expect(trigger).toContainText("Mock Fast", { timeout: 15_000 });

--- a/apps/web/e2e/tests/chat/tool-completion.spec.ts
+++ b/apps/web/e2e/tests/chat/tool-completion.spec.ts
@@ -30,7 +30,7 @@ test.describe("Tool completion on turn end", () => {
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // After turn completes, no grid spinners should remain in the chat
     const spinners = session.chat.locator('[role="status"][aria-label="Loading"]');

--- a/apps/web/e2e/tests/chat/toolbar-overflow.spec.ts
+++ b/apps/web/e2e/tests/chat/toolbar-overflow.spec.ts
@@ -29,7 +29,10 @@ async function seedAndNavigate(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  // waitForChatIdle (not a raw idleInput wait) rides out the WS-subscribe race:
+  // the mock agent can settle RUNNING->WAITING_FOR_INPUT before the client's WS
+  // subscription registers, so the idle placeholder never renders without a reload.
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return session;
 }

--- a/apps/web/e2e/tests/git/git-commit.spec.ts
+++ b/apps/web/e2e/tests/git/git-commit.spec.ts
@@ -113,7 +113,7 @@ test.describe("Git commit body", () => {
     const session = await openTaskSession(testPage, "Git Commit Body Test");
 
     // Wait for agent to finish initial turn
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Set up git helper
     const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
@@ -212,7 +212,7 @@ test.describe("Git commit pre-hooks", () => {
     const session = await openTaskSession(testPage, "Git Hook Test");
 
     // Wait for agent to finish initial turn
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Set up git helper
     const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");

--- a/apps/web/e2e/tests/git/symlink-file.spec.ts
+++ b/apps/web/e2e/tests/git/symlink-file.spec.ts
@@ -31,7 +31,7 @@ async function seedSimpleTask(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return { session, sessionId: task.session_id ?? task.id };
 }

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -65,7 +65,7 @@ test.describe("Changes panel focus behavior", () => {
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Create a file and commit so there are existing changes
     git.createFile("test-file.txt", "hello world");
@@ -129,7 +129,7 @@ test.describe("Changes panel focus behavior", () => {
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Toggle plan mode — this moves changes into the center group
     await session.togglePlanMode();

--- a/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
+++ b/apps/web/e2e/tests/layout/plan-panel-indicator.spec.ts
@@ -82,8 +82,12 @@ test.describe("Plan panel auto-open + indicator", () => {
     await expect(session.chat).toBeVisible();
     await expect(planTabLocator(testPage)).not.toHaveClass(/dv-active-tab/);
 
-    // Indicator dot is visible on the Plan tab
-    await expect(planTabIndicator(testPage)).toBeVisible();
+    // Indicator dot is visible on the Plan tab. The indicator arms only once
+    // `plan.created_by === "agent"` lands in the store — that comes from the
+    // `task.plan.created` WS push, or the eager getTaskPlan self-heal if the
+    // push was missed. Both can land after the default 5s under shard load, so
+    // match the 15s tab budget.
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
   });
 
   test("clicking the Plan tab clears the indicator and reveals plan content", async ({
@@ -101,7 +105,7 @@ test.describe("Plan panel auto-open + indicator", () => {
       CREATE_PLAN_SCRIPT,
     );
     await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
-    await expect(planTabIndicator(testPage)).toBeVisible();
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
 
     await session.clickTab("Plan");
 
@@ -126,7 +130,7 @@ test.describe("Plan panel auto-open + indicator", () => {
       CREATE_PLAN_SCRIPT,
     );
     await expect(planTabLocator(testPage)).toBeVisible({ timeout: 15_000 });
-    await expect(planTabIndicator(testPage)).toBeVisible();
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
 
     // Acknowledge then leave back to chat
     await session.clickTab("Plan");
@@ -140,7 +144,7 @@ test.describe("Plan panel auto-open + indicator", () => {
 
     // Chat still focused, indicator re-armed
     await expect(planTabLocator(testPage)).not.toHaveClass(/dv-active-tab/);
-    await expect(planTabIndicator(testPage)).toBeVisible();
+    await expect(planTabIndicator(testPage)).toBeVisible({ timeout: 15_000 });
 
     // Clicking the Plan tab shows the updated content
     await session.clickTab("Plan");

--- a/apps/web/e2e/tests/layout/preview-tab-session-switch.spec.ts
+++ b/apps/web/e2e/tests/layout/preview-tab-session-switch.spec.ts
@@ -127,7 +127,7 @@ test.describe("Preview tab survives session switch", () => {
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Open a file in preview mode
     await openFileInPreview(testPage, session, FILE_A);
@@ -186,7 +186,7 @@ test.describe("Preview tab survives session switch", () => {
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Open file in preview, then promote via double-click. The panel keeps id
     // `preview:file-editor` with `params.promoted=true` until another file is
@@ -240,7 +240,7 @@ test.describe("Preview tab survives session switch", () => {
     await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Open file in preview — it auto-activates, but we click it explicitly to
     // make the intent clear and to be robust against any default-active changes.

--- a/apps/web/e2e/tests/pr/pr-checks-timer.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-checks-timer.spec.ts
@@ -104,7 +104,7 @@ test.describe("PR checks running timer", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Open PR detail panel
     await expect(session.prTopbarButton()).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e/tests/pr/pr-detail-auto-show.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-detail-auto-show.spec.ts
@@ -95,7 +95,7 @@ test.describe("PR detail panel", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Verify PR topbar button appears with PR number
     await expect(session.prTopbarButton()).toBeVisible({ timeout: 15_000 });
@@ -195,7 +195,7 @@ test.describe("PR detail panel", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Wait for PR data to arrive (topbar button confirms PR is loaded)
     await expect(session.prTopbarButton()).toBeVisible({ timeout: 15_000 });
@@ -212,7 +212,7 @@ test.describe("PR detail panel", () => {
     // 3. Reload page — panel should stay dismissed
     await testPage.reload();
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Give the auto-show hook time to fire (double rAF) — panel should NOT reappear
     await testPage.waitForTimeout(1_000);
@@ -324,13 +324,13 @@ test.describe("PR detail panel", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
     await expect(session.prDetailTab()).toBeVisible({ timeout: 15_000 });
 
     // Switch to Task B (no PR) — PR panel should be removed
     await session.clickTaskInSidebar("Plain Task");
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
     await expect(session.prDetailTab()).not.toBeVisible({ timeout: 10_000 });
 
     // Switch back to Task A — PR panel should re-appear
@@ -464,7 +464,7 @@ test.describe("PR detail panel", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
     await expect(session.prDetailTab()).toBeVisible({ timeout: 15_000 });
 
     // Invariant: PR panel shares the session's dockview group (is a tab, not a split).
@@ -475,7 +475,7 @@ test.describe("PR detail panel", () => {
     // against the new session. Assert the invariant still holds.
     await session.clickTaskInSidebar("Second PR Task");
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
     await expect(session.prDetailTab()).toBeVisible({ timeout: 15_000 });
     await session.expectPrPanelAndSessionShareGroup();
 
@@ -486,7 +486,7 @@ test.describe("PR detail panel", () => {
     // tab in a new group while the PR panel stayed in the old center group.
     await session.clickTaskInSidebar("First PR Task");
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
     await expect(session.prDetailTab()).toBeVisible({ timeout: 15_000 });
     await session.expectPrPanelAndSessionShareGroup();
   });

--- a/apps/web/e2e/tests/pr/pr-detail-dedup.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-detail-dedup.spec.ts
@@ -93,7 +93,7 @@ test.describe("PR detail panel dedup", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // PR auto-panel is open before any click on the topbar button.
     await expect(session.prDetailTab()).toBeVisible({ timeout: 15_000 });

--- a/apps/web/e2e/tests/pr/pr-detail-manual-open.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-detail-manual-open.spec.ts
@@ -99,7 +99,7 @@ test.describe("PR detail panel — manual open", () => {
 
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await session.idleInput().waitFor({ state: "visible", timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
     await expect(session.prTopbarButton()).toBeVisible({ timeout: 15_000 });
     await expect(session.prDetailTab()).toBeVisible({ timeout: 15_000 });
 

--- a/apps/web/e2e/tests/pr/pr-watcher-auto-start-on-move.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-auto-start-on-move.spec.ts
@@ -119,6 +119,6 @@ test.describe("PR watcher auto-start on move", () => {
     await sessionAfter.waitForLoad();
 
     // The agent should have completed — idle input visible
-    await expect(sessionAfter.idleInput()).toBeVisible({ timeout: 30_000 });
+    await sessionAfter.waitForChatIdle({ timeout: 30_000 });
   });
 });

--- a/apps/web/e2e/tests/pr/pr-watcher-dockview-layout.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-dockview-layout.spec.ts
@@ -157,7 +157,11 @@ test.describe("PR watcher dockview layout stability", () => {
           );
           return visible.filter(Boolean).length;
         },
-        { timeout: 90_000, intervals: [500, 1_000, 2_000] },
+        {
+          timeout: 90_000,
+          intervals: [500, 1_000, 2_000],
+          message: `Expected all 3 PR task cards (${prTaskTitles.join(", ")}) to appear in the Review column`,
+        },
       )
       .toBe(3);
 

--- a/apps/web/e2e/tests/pr/pr-watcher-dockview-layout.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-dockview-layout.spec.ts
@@ -27,7 +27,11 @@ test.describe("PR watcher dockview layout stability", () => {
     seedData,
     backend,
   }) => {
-    test.setTimeout(120_000);
+    // The review watcher auto-starts a mock agent for each of the 3 PR tasks,
+    // so 3 git checkouts + agent boots run concurrently up front. Under CI shard
+    // contention that inherent workload, plus three subsequent session
+    // navigations, can outlast the default budget — give the whole flow headroom.
+    test.setTimeout(180_000);
 
     // --- Register the GitHub repo so the PR watcher can resolve it to a real
     // local path (the seed repo created in test-base.ts has no provider info,
@@ -140,15 +144,22 @@ test.describe("PR watcher dockview layout stability", () => {
     const prTask2Title = "PR #202: Add dashboard";
     const prTask3Title = "PR #303: Update docs";
 
-    await expect(kanban.taskCardInColumn(prTask1Title, reviewStep.id)).toBeVisible({
-      timeout: 60_000,
-    });
-    await expect(kanban.taskCardInColumn(prTask2Title, reviewStep.id)).toBeVisible({
-      timeout: 60_000,
-    });
-    await expect(kanban.taskCardInColumn(prTask3Title, reviewStep.id)).toBeVisible({
-      timeout: 60_000,
-    });
+    // Poll for all 3 cards together in one shared budget rather than three
+    // independent per-card waits. The cards are created concurrently and render
+    // out of order under load; waiting for the whole set at once avoids
+    // cumulative per-card timeout pressure and settles as soon as all 3 appear.
+    const prTaskTitles = [prTask1Title, prTask2Title, prTask3Title];
+    await expect
+      .poll(
+        async () => {
+          const visible = await Promise.all(
+            prTaskTitles.map((title) => kanban.taskCardInColumn(title, reviewStep.id).isVisible()),
+          );
+          return visible.filter(Boolean).length;
+        },
+        { timeout: 90_000, intervals: [500, 1_000, 2_000] },
+      )
+      .toBe(3);
 
     // --- Click PR task 1 to enter session view ---
     await kanban.taskCardInColumn(prTask1Title, reviewStep.id).click();

--- a/apps/web/e2e/tests/pr/pr-watcher-missing-branch.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-missing-branch.spec.ts
@@ -88,10 +88,15 @@ test.describe("PR watcher missing branch", () => {
 
     const card = kanban.taskCardByTitle("PR #999: Already merged feature");
     await expect(card).toBeVisible({ timeout: 15_000 });
-    await card.click();
 
-    // Wait for navigation to session view
-    await expect(testPage).toHaveURL(/\/t\//, { timeout: 15_000 });
+    // Click → navigate to the session view. The card renders via SSR and its
+    // router.push click handler only fires once React has hydrated; under shard
+    // load the first click can land pre-hydration and no-op, so re-click until
+    // the URL flips. toPass stops on the first success, so no stray re-clicks.
+    await expect(async () => {
+      await card.click();
+      await expect(testPage).toHaveURL(/\/t\//, { timeout: 5_000 });
+    }).toPass({ timeout: 20_000 });
 
     const session = new SessionPage(testPage);
 

--- a/apps/web/e2e/tests/session/auto-start-session.spec.ts
+++ b/apps/web/e2e/tests/session/auto-start-session.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "../../fixtures/test-base";
+import { test } from "../../fixtures/test-base";
 import { SessionPage } from "../../pages/session-page";
 
 test.describe("Auto-start session on task page", () => {
@@ -28,6 +28,6 @@ test.describe("Auto-start session on task page", () => {
     await session.waitForLoad();
 
     // Wait for agent to complete — confirms session was started and ran successfully
-    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+    await session.waitForChatIdle({ timeout: 45_000 });
   });
 });

--- a/apps/web/e2e/tests/session/executor-not-found.spec.ts
+++ b/apps/web/e2e/tests/session/executor-not-found.spec.ts
@@ -68,8 +68,6 @@ test.describe("Executor not found after backend restart", () => {
     await session.sendMessage("/e2e:simple-message");
 
     // 7. The agent should respond successfully (not fail with executor not found)
-    await expect(
-      session.chat.getByText("simple mock response", { exact: false }).nth(1),
-    ).toBeVisible({ timeout: 30_000 });
+    await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });
   });
 });

--- a/apps/web/e2e/tests/session/maximize-sidebar-switch.spec.ts
+++ b/apps/web/e2e/tests/session/maximize-sidebar-switch.spec.ts
@@ -24,7 +24,7 @@ async function gotoTaskAndWaitForIdle(
   await testPage.goto(`/t/${taskId}`);
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: timeoutMs });
+  await session.waitForChatIdle({ timeout: timeoutMs });
   return session;
 }
 
@@ -95,7 +95,7 @@ test.describe("Maximize survives sidebar task switch", () => {
     await sessionA.clickTaskInSidebar("Maximize Task B");
     await expect(testPage).toHaveURL(new RegExp(`/t/${taskB.id}(?:\\?|$)`), { timeout: 15_000 });
     await sessionA.waitForLoad();
-    await expect(sessionA.idleInput()).toBeVisible({ timeout: 30_000 });
+    await sessionA.waitForChatIdle({ timeout: 30_000 });
     // Task B starts with the default layout — sanity check before the bug.
     await sessionA.expectDefaultLayout();
 

--- a/apps/web/e2e/tests/session/session-focus-signal.spec.ts
+++ b/apps/web/e2e/tests/session/session-focus-signal.spec.ts
@@ -42,7 +42,7 @@ test.describe("Session focus signal", () => {
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+    await session.waitForChatIdle({ timeout: 45_000 });
 
     // Poll for the expected WS frames. The page mount + auto-start + WS
     // connect sequence races, so useTaskFocus may fire a few hundred ms

--- a/apps/web/e2e/tests/session/session-layout.spec.ts
+++ b/apps/web/e2e/tests/session/session-layout.spec.ts
@@ -34,7 +34,7 @@ async function seedTaskWithSession(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return session;
 }
@@ -121,7 +121,7 @@ test.describe("Session layout", () => {
     // Foreground the chat tab — after the layout restore it can land as a
     // background tab in the right group, so the idle input isn't visible yet.
     await sessionB.showSessionContext(30_000);
-    await expect(sessionB.idleInput()).toBeVisible({ timeout: 30_000 });
+    await sessionB.waitForChatIdle({ timeout: 30_000 });
 
     // Task B should have default (non-maximized) layout
     await sessionB.expectDefaultLayout();

--- a/apps/web/e2e/tests/session/session-recovery.spec.ts
+++ b/apps/web/e2e/tests/session/session-recovery.spec.ts
@@ -30,7 +30,7 @@ async function seedTaskWithSession(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return session;
 }

--- a/apps/web/e2e/tests/session/session-resume-commands.spec.ts
+++ b/apps/web/e2e/tests/session/session-resume-commands.spec.ts
@@ -87,9 +87,7 @@ test.describe("Slash commands after session resume", () => {
     // 7. Send a follow-up message to trigger AvailableCommandsUpdate from the agent.
     //    The mock agent emits commands on the first Prompt after session load.
     await session.sendMessage("/e2e:simple-message");
-    await expect(
-      session.chat.getByText("simple mock response", { exact: false }).nth(1),
-    ).toBeVisible({ timeout: 30_000 });
+    await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });
     await session.waitForChatIdle({ timeout: 15_000 });
 
     // 8. Verify slash commands work after resume

--- a/apps/web/e2e/tests/session/session-resume-dedup.spec.ts
+++ b/apps/web/e2e/tests/session/session-resume-dedup.spec.ts
@@ -82,8 +82,6 @@ test.describe("Session resume boot-message dedup", () => {
 
     // 6. Agent interaction still works after dedup.
     await session.sendMessage("/e2e:simple-message");
-    await expect(
-      session.chat.getByText("simple mock response", { exact: false }).nth(1),
-    ).toBeVisible({ timeout: 30_000 });
+    await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });
   });
 });

--- a/apps/web/e2e/tests/session/session-resume-keeps-review-state.spec.ts
+++ b/apps/web/e2e/tests/session/session-resume-keeps-review-state.spec.ts
@@ -46,7 +46,7 @@ test.describe("Session resume — task state stability", () => {
     await expect(session.chat.getByText("simple mock response", { exact: false })).toBeVisible({
       timeout: 30_000,
     });
-    await expect(session.idleInput()).toBeVisible({ timeout: 15_000 });
+    await session.waitForChatIdle({ timeout: 15_000 });
     await expect(session.taskInSection("Resume Stable", "Turn Finished")).toBeVisible({
       timeout: 15_000,
     });

--- a/apps/web/e2e/tests/session/session-resume.spec.ts
+++ b/apps/web/e2e/tests/session/session-resume.spec.ts
@@ -106,9 +106,7 @@ test.describe("Session resume (ACP mode)", () => {
     await session.sendMessage("/e2e:simple-message");
 
     // 10. The agent should respond to the new prompt
-    await expect(
-      session.chat.getByText("simple mock response", { exact: false }).nth(1),
-    ).toBeVisible({ timeout: 30_000 });
+    await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });
   });
 });
 
@@ -468,8 +466,6 @@ test.describe("Session resume (active turn interrupted)", () => {
     //    execution (not stuck "Agent is not running") even though the previous
     //    turn was interrupted.
     await session.sendMessage("/e2e:simple-message");
-    await expect(session.chat.getByText("simple mock response", { exact: false })).toBeVisible({
-      timeout: 30_000,
-    });
+    await session.expectChatResponseVisible("simple mock response", 0, { timeout: 30_000 });
   });
 });

--- a/apps/web/e2e/tests/session/session-tab-close-guard.spec.ts
+++ b/apps/web/e2e/tests/session/session-tab-close-guard.spec.ts
@@ -22,7 +22,7 @@ test.describe("Session tab close guard", () => {
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Find the session tab
     const sessionTab = testPage.locator("[data-testid^='session-tab-']").first();

--- a/apps/web/e2e/tests/settings/vscode-open-file.spec.ts
+++ b/apps/web/e2e/tests/settings/vscode-open-file.spec.ts
@@ -52,7 +52,7 @@ async function seedTaskWithSession(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return { session, sessionId: task.session_id };
 }

--- a/apps/web/e2e/tests/settings/vscode-open-panel.spec.ts
+++ b/apps/web/e2e/tests/settings/vscode-open-panel.spec.ts
@@ -52,7 +52,7 @@ async function seedTaskWithSession(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return { session, sessionId: task.session_id };
 }

--- a/apps/web/e2e/tests/task/comment-run-not-queued.spec.ts
+++ b/apps/web/e2e/tests/task/comment-run-not-queued.spec.ts
@@ -41,7 +41,7 @@ async function seedTaskAndWaitForIdle(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return { session, taskId: task.id, sessionId: task.session_id! };
 }

--- a/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-changes-panel.spec.ts
@@ -179,7 +179,7 @@ test.describe("Mobile changes panel", () => {
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+    await session.waitForChatIdle({ timeout: 45_000 });
 
     await apiClient.mockGitHubReset();
     await apiClient.mockGitHubSetUser("test-user");
@@ -253,7 +253,7 @@ test.describe("Mobile changes panel", () => {
     await testPage.goto(`/t/${task.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 45_000 });
+    await session.waitForChatIdle({ timeout: 45_000 });
 
     await apiClient.mockGitHubReset();
     await apiClient.mockGitHubSetUser("test-user");

--- a/apps/web/e2e/tests/task/plan-mode-followup.spec.ts
+++ b/apps/web/e2e/tests/task/plan-mode-followup.spec.ts
@@ -41,7 +41,10 @@ async function seedTaskAndWaitForIdle(
 
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  // waitForChatIdle (not a raw idleInput wait) rides out the WS-subscribe race:
+  // the auto-started agent can settle RUNNING->WAITING_FOR_INPUT before the
+  // client subscribes, so the idle composer never renders without a reload.
+  await session.waitForChatIdle({ timeout: 30_000 });
 
   return { session, taskId: task.id, sessionId: task.session_id! };
 }

--- a/apps/web/e2e/tests/task/session-isolation.spec.ts
+++ b/apps/web/e2e/tests/task/session-isolation.spec.ts
@@ -37,7 +37,7 @@ test.describe("Session isolation", () => {
     await testPage.goto(`/t/${taskWithSession.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // 3. Verify there are messages in the chat (agent has responded)
     const chatPanel = testPage.getByTestId("session-chat");
@@ -89,7 +89,7 @@ test.describe("Session isolation", () => {
     await testPage.goto(`/t/${taskA.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // 3. Verify mock response message is visible for first task
     const chatPanel = testPage.getByTestId("session-chat");
@@ -118,7 +118,7 @@ test.describe("Session isolation", () => {
       timeout: 10_000,
     });
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // 7. The chat should NOT show messages from the first task's session
     // (the "simple-message" text should not appear for task B which uses "read-and-edit")

--- a/apps/web/e2e/tests/task/sessionless-task-switch.spec.ts
+++ b/apps/web/e2e/tests/task/sessionless-task-switch.spec.ts
@@ -52,7 +52,7 @@ test.describe("Sessionless task switching", () => {
     await session.waitForLoad();
 
     // Wait for parent agent to settle so the layout has stabilised.
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Poll the API until the MCP-created subtask exists. We need its ID for URL
     // assertions. The subtask is created by the agent asynchronously, so the

--- a/apps/web/e2e/tests/task/subtask.spec.ts
+++ b/apps/web/e2e/tests/task/subtask.spec.ts
@@ -76,7 +76,7 @@ test.describe("Subtask basics", () => {
     await session.waitForLoad();
 
     // Wait for agent to complete
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Open the New Subtask dialog from the sidebar New Task row's trailing
     // subtask affordance (shown while viewing a task).
@@ -306,7 +306,7 @@ test.describe("MCP subtask creation", () => {
     await testPage.goto(`/t/${parentTask.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // 3. Open the New Subtask dialog from the sidebar New Task subtask affordance.
     await testPage.getByTestId("sidebar-new-subtask").click();
@@ -640,7 +640,7 @@ test.describe("Subtask dialog feature parity", () => {
     await testPage.goto(`/t/${parentTask.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // 3. Open the subtask dialog and toggle to GitHub URL mode.
     await testPage.getByTestId("sidebar-new-subtask").click();
@@ -735,7 +735,7 @@ test.describe("Subtask dialog feature parity", () => {
     await testPage.goto(`/t/${parentTask.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // 3. Sanity-check via the API that backend discovery actually finds the
     //    on-disk directory. If this fails, the issue is the backend scan, not
@@ -817,7 +817,7 @@ test.describe("Subtask dialog feature parity", () => {
     await testPage.goto(`/t/${parentTask.id}`);
     const session = new SessionPage(testPage);
     await session.waitForLoad();
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // 3. Open the subtask dialog. The first chip is seeded with the parent's
     //    repo. Click the "+ add repository" button to append a second chip,

--- a/apps/web/e2e/tests/terminal/mobile-terminal-helpers.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-helpers.ts
@@ -1,0 +1,59 @@
+// Shared helpers for the mobile terminal specs (keybar + scroll). Both specs
+// run on the mobile-chrome Playwright project and share the same lazy-mount +
+// shell-connect path, so the connect/readiness helpers live here to avoid
+// drift between the two files.
+import { type Page, expect } from "@playwright/test";
+
+export async function tapTerminalTab(testPage: Page): Promise<void> {
+  await testPage.getByRole("button", { name: "Terminal" }).tap();
+}
+
+export async function switchToTerminalPanel(testPage: Page): Promise<void> {
+  // Confirm the panel actually mounted rather than firing a single tap. On
+  // mobile the bottom-nav button can be tapped before hydration wires its
+  // handler; a lost tap leaves the terminal panel unmounted, which would later
+  // strand waitForShellReady polling an element that never appears. Re-tap once
+  // if the first tap didn't take.
+  const panel = testPage.getByTestId("terminal-panel");
+  await tapTerminalTab(testPage);
+  if (!(await panel.isVisible())) {
+    await tapTerminalTab(testPage);
+  }
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+}
+
+export async function readTerminalBuffer(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const panel = document.querySelector('[data-testid="terminal-panel"]');
+    const xtermEl = panel?.querySelector(".xterm");
+    type XC = HTMLElement & { __xtermReadBuffer?: () => string };
+    const container = xtermEl?.parentElement as XC | null | undefined;
+    return container?.__xtermReadBuffer?.() ?? "";
+  });
+}
+
+/**
+ * Wait for the mobile shell to be ready by tailing xterm's buffer until it has
+ * any content (a prompt is enough). Mobile mounts the terminal lazily on tab
+ * switch so this can take longer than desktop.
+ *
+ * The shell WS connect can be missed under CI load (the auto-create guard only
+ * retries on a WS reconnect). If the panel falls out of view we re-tap it,
+ * which forces a remount and kicks the reconnect loop — so we don't blindly
+ * wait out the whole budget on a dead connection.
+ */
+export async function waitForShellReady(testPage: Page, timeout = 45_000): Promise<void> {
+  const panel = testPage.getByTestId("terminal-panel");
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if ((await readTerminalBuffer(testPage)).length > 0) return;
+    if (!(await panel.isVisible())) {
+      await switchToTerminalPanel(testPage);
+    }
+    await testPage.waitForTimeout(1_000);
+  }
+  expect(
+    (await readTerminalBuffer(testPage)).length,
+    "Waiting for mobile terminal shell to connect",
+  ).toBeGreaterThan(0);
+}

--- a/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
@@ -12,6 +12,7 @@ import type { ApiClient } from "../../helpers/api-client";
 import { SessionPage } from "../../pages/session-page";
 import { MobileTerminalKeybarPage } from "../../pages/mobile-terminal-keybar-page";
 import { attachShellInputCapture, type ShellInputFrame } from "../../helpers/ws-capture";
+import { switchToTerminalPanel, waitForShellReady } from "./mobile-terminal-helpers";
 
 async function seedTaskWithSession(
   testPage: Page,
@@ -35,50 +36,6 @@ async function seedTaskWithSession(
   await session.waitForLoad();
   await session.waitForChatIdle();
   return session;
-}
-
-async function tapTerminalTab(testPage: Page): Promise<void> {
-  await testPage.getByRole("button", { name: "Terminal" }).tap();
-}
-
-async function switchToTerminalPanel(testPage: Page): Promise<void> {
-  // Confirm the panel actually mounted rather than firing a single tap. On
-  // mobile the bottom-nav button can be tapped before hydration wires its
-  // handler; a lost tap leaves the terminal panel unmounted, which would later
-  // strand waitForShellReady polling an element that never appears. Re-tap once
-  // if the first tap didn't take.
-  const panel = testPage.getByTestId("terminal-panel");
-  await tapTerminalTab(testPage);
-  if (!(await panel.isVisible())) {
-    await tapTerminalTab(testPage);
-  }
-  await expect(panel).toBeVisible({ timeout: 10_000 });
-}
-
-/**
- * Wait for the mobile shell to be ready by tailing xterm's buffer until it has
- * any content (a prompt is enough). Mobile mounts the terminal lazily on tab
- * switch so this can take longer than desktop.
- *
- * The shell WS connect can be missed under CI load (the auto-create guard only
- * retries on a WS reconnect). If the panel falls out of view we re-tap it,
- * which forces a remount and kicks the reconnect loop — so we don't blindly
- * wait out the whole budget on a dead connection.
- */
-async function waitForShellReady(testPage: Page, timeout = 45_000): Promise<void> {
-  const panel = testPage.getByTestId("terminal-panel");
-  const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
-    if ((await readTerminalBuffer(testPage)).length > 0) return;
-    if (!(await panel.isVisible())) {
-      await switchToTerminalPanel(testPage);
-    }
-    await testPage.waitForTimeout(1_000);
-  }
-  expect(
-    (await readTerminalBuffer(testPage)).length,
-    "Waiting for mobile terminal shell to connect",
-  ).toBeGreaterThan(0);
 }
 
 /**
@@ -130,16 +87,6 @@ async function expectFrame(
       message: `Expected shell.input frame with data ${JSON.stringify(data)}`,
     })
     .toBeTruthy();
-}
-
-async function readTerminalBuffer(page: Page): Promise<string> {
-  return page.evaluate(() => {
-    const panel = document.querySelector('[data-testid="terminal-panel"]');
-    const xtermEl = panel?.querySelector(".xterm");
-    type XC = HTMLElement & { __xtermReadBuffer?: () => string };
-    const container = xtermEl?.parentElement as XC | null | undefined;
-    return container?.__xtermReadBuffer?.() ?? "";
-  });
 }
 
 async function inlineStyleProp(loc: Locator, prop: "top" | "bottom"): Promise<string> {

--- a/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
@@ -37,22 +37,48 @@ async function seedTaskWithSession(
   return session;
 }
 
-async function switchToTerminalPanel(testPage: Page): Promise<void> {
+async function tapTerminalTab(testPage: Page): Promise<void> {
   await testPage.getByRole("button", { name: "Terminal" }).tap();
+}
+
+async function switchToTerminalPanel(testPage: Page): Promise<void> {
+  // Confirm the panel actually mounted rather than firing a single tap. On
+  // mobile the bottom-nav button can be tapped before hydration wires its
+  // handler; a lost tap leaves the terminal panel unmounted, which would later
+  // strand waitForShellReady polling an element that never appears. Re-tap once
+  // if the first tap didn't take.
+  const panel = testPage.getByTestId("terminal-panel");
+  await tapTerminalTab(testPage);
+  if (!(await panel.isVisible())) {
+    await tapTerminalTab(testPage);
+  }
+  await expect(panel).toBeVisible({ timeout: 10_000 });
 }
 
 /**
  * Wait for the mobile shell to be ready by tailing xterm's buffer until it has
  * any content (a prompt is enough). Mobile mounts the terminal lazily on tab
  * switch so this can take longer than desktop.
+ *
+ * The shell WS connect can be missed under CI load (the auto-create guard only
+ * retries on a WS reconnect). If the panel falls out of view we re-tap it,
+ * which forces a remount and kicks the reconnect loop — so we don't blindly
+ * wait out the whole budget on a dead connection.
  */
 async function waitForShellReady(testPage: Page, timeout = 45_000): Promise<void> {
-  await expect
-    .poll(() => readTerminalBuffer(testPage).then((b) => b.length > 0), {
-      timeout,
-      message: "Waiting for mobile terminal shell to connect",
-    })
-    .toBe(true);
+  const panel = testPage.getByTestId("terminal-panel");
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if ((await readTerminalBuffer(testPage)).length > 0) return;
+    if (!(await panel.isVisible())) {
+      await switchToTerminalPanel(testPage);
+    }
+    await testPage.waitForTimeout(1_000);
+  }
+  expect(
+    (await readTerminalBuffer(testPage)).length,
+    "Waiting for mobile terminal shell to connect",
+  ).toBeGreaterThan(0);
 }
 
 /**

--- a/apps/web/e2e/tests/terminal/mobile-terminal-scroll.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-scroll.spec.ts
@@ -34,17 +34,42 @@ async function seedTaskWithSession(
   return session;
 }
 
-async function switchToTerminalPanel(testPage: Page): Promise<void> {
+async function tapTerminalTab(testPage: Page): Promise<void> {
   await testPage.getByRole("button", { name: "Terminal" }).tap();
 }
 
+async function switchToTerminalPanel(testPage: Page): Promise<void> {
+  // Confirm the panel actually mounted rather than firing a single tap. On
+  // mobile the bottom-nav button can be tapped before hydration wires its
+  // handler; a lost tap leaves the terminal panel unmounted, which would later
+  // strand waitForShellReady polling an element that never appears. Re-tap once
+  // if the first tap didn't take.
+  const panel = testPage.getByTestId("terminal-panel");
+  await tapTerminalTab(testPage);
+  if (!(await panel.isVisible())) {
+    await tapTerminalTab(testPage);
+  }
+  await expect(panel).toBeVisible({ timeout: 10_000 });
+}
+
 async function waitForShellReady(testPage: Page, timeout = 45_000): Promise<void> {
-  await expect
-    .poll(() => readTerminalBuffer(testPage).then((b) => b.length > 0), {
-      timeout,
-      message: "Waiting for mobile terminal shell to connect",
-    })
-    .toBe(true);
+  // The shell WS connect can be missed under CI load (the auto-create guard
+  // only retries on a WS reconnect). If the panel falls out of view we re-tap
+  // it, which forces a remount and kicks the reconnect loop — so we don't
+  // blindly wait out the whole budget on a dead connection.
+  const panel = testPage.getByTestId("terminal-panel");
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if ((await readTerminalBuffer(testPage)).length > 0) return;
+    if (!(await panel.isVisible())) {
+      await switchToTerminalPanel(testPage);
+    }
+    await testPage.waitForTimeout(1_000);
+  }
+  expect(
+    (await readTerminalBuffer(testPage)).length,
+    "Waiting for mobile terminal shell to connect",
+  ).toBeGreaterThan(0);
 }
 
 async function readTerminalBuffer(page: Page): Promise<string> {

--- a/apps/web/e2e/tests/terminal/mobile-terminal-scroll.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-scroll.spec.ts
@@ -9,6 +9,11 @@ import { test } from "../../fixtures/test-base";
 import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { SessionPage } from "../../pages/session-page";
+import {
+  readTerminalBuffer,
+  switchToTerminalPanel,
+  waitForShellReady,
+} from "./mobile-terminal-helpers";
 
 async function seedTaskWithSession(
   testPage: Page,
@@ -32,54 +37,6 @@ async function seedTaskWithSession(
   await session.waitForLoad();
   await session.waitForChatIdle();
   return session;
-}
-
-async function tapTerminalTab(testPage: Page): Promise<void> {
-  await testPage.getByRole("button", { name: "Terminal" }).tap();
-}
-
-async function switchToTerminalPanel(testPage: Page): Promise<void> {
-  // Confirm the panel actually mounted rather than firing a single tap. On
-  // mobile the bottom-nav button can be tapped before hydration wires its
-  // handler; a lost tap leaves the terminal panel unmounted, which would later
-  // strand waitForShellReady polling an element that never appears. Re-tap once
-  // if the first tap didn't take.
-  const panel = testPage.getByTestId("terminal-panel");
-  await tapTerminalTab(testPage);
-  if (!(await panel.isVisible())) {
-    await tapTerminalTab(testPage);
-  }
-  await expect(panel).toBeVisible({ timeout: 10_000 });
-}
-
-async function waitForShellReady(testPage: Page, timeout = 45_000): Promise<void> {
-  // The shell WS connect can be missed under CI load (the auto-create guard
-  // only retries on a WS reconnect). If the panel falls out of view we re-tap
-  // it, which forces a remount and kicks the reconnect loop — so we don't
-  // blindly wait out the whole budget on a dead connection.
-  const panel = testPage.getByTestId("terminal-panel");
-  const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
-    if ((await readTerminalBuffer(testPage)).length > 0) return;
-    if (!(await panel.isVisible())) {
-      await switchToTerminalPanel(testPage);
-    }
-    await testPage.waitForTimeout(1_000);
-  }
-  expect(
-    (await readTerminalBuffer(testPage)).length,
-    "Waiting for mobile terminal shell to connect",
-  ).toBeGreaterThan(0);
-}
-
-async function readTerminalBuffer(page: Page): Promise<string> {
-  return page.evaluate(() => {
-    const panel = document.querySelector('[data-testid="terminal-panel"]');
-    const xtermEl = panel?.querySelector(".xterm");
-    type XC = HTMLElement & { __xtermReadBuffer?: () => string };
-    const container = xtermEl?.parentElement as XC | null | undefined;
-    return container?.__xtermReadBuffer?.() ?? "";
-  });
 }
 
 async function readViewportY(page: Page): Promise<number> {

--- a/apps/web/e2e/tests/terminal/terminal-keyboard.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-keyboard.spec.ts
@@ -31,7 +31,10 @@ async function seedTaskWithSession(
   await testPage.goto(`/t/${task.id}`);
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  // waitForChatIdle (not a raw idleInput wait) rides out the WS-subscribe race:
+  // the mock agent can settle RUNNING->WAITING_FOR_INPUT before the client's WS
+  // subscription registers, so the idle placeholder never renders without a reload.
+  await session.waitForChatIdle({ timeout: 30_000 });
   return session;
 }
 

--- a/apps/web/e2e/tests/terminal/terminal-settings.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-settings.spec.ts
@@ -33,7 +33,10 @@ async function seedTaskWithSession(
   await testPage.goto(`/t/${task.id}`);
   const session = new SessionPage(testPage);
   await session.waitForLoad();
-  await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+  // waitForChatIdle (not a raw idleInput wait) rides out the WS-subscribe race:
+  // the auto-started agent can settle RUNNING->WAITING_FOR_INPUT before the
+  // client subscribes, so the idle composer never renders without a reload.
+  await session.waitForChatIdle({ timeout: 30_000 });
   return session;
 }
 

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -454,7 +454,9 @@ test.describe("Workflow agent profile switching", () => {
     apiClient,
     seedData,
   }) => {
-    test.setTimeout(60_000);
+    // Two agent boots (git worktree checkouts) — one before the move, one after —
+    // can outlast the default budget under CI shard contention; give headroom.
+    test.setTimeout(180_000);
     const { profileA, profileB } = await createProfiles(apiClient);
 
     // Step1 (profileA, auto_start, is_start) → Step2 (profileB, auto_start)
@@ -492,7 +494,7 @@ test.describe("Workflow agent profile switching", () => {
 
     // Wait for Profile A tab to appear and be active
     const profileATab = session.sessionTabByText("Profile A");
-    await expect(profileATab).toBeVisible({ timeout: 30_000 });
+    await expect(profileATab).toBeVisible({ timeout: 60_000 });
 
     // Wait for agent to be ready (WAITING_FOR_INPUT)
     await expect
@@ -501,7 +503,7 @@ test.describe("Workflow agent profile switching", () => {
           const { sessions } = await apiClient.listTaskSessions(task.id);
           return sessions.some((s) => s.state === "WAITING_FOR_INPUT");
         },
-        { timeout: 30_000, message: "Waiting for agent to be ready" },
+        { timeout: 60_000, message: "Waiting for agent to be ready" },
       )
       .toBe(true);
 
@@ -511,8 +513,8 @@ test.describe("Workflow agent profile switching", () => {
     // The new "Profile B" tab should appear and the primary star should move to it
     // (the active tab stays on Profile A because the SSR-load pin protects it).
     const profileBTab = session.sessionTabByText("Profile B");
-    await expect(profileBTab).toBeVisible({ timeout: 30_000 });
-    await expect(session.primaryStarInTab("Profile B")).toBeVisible({ timeout: 30_000 });
+    await expect(profileBTab).toBeVisible({ timeout: 60_000 });
+    await expect(session.primaryStarInTab("Profile B")).toBeVisible({ timeout: 60_000 });
   });
 
   /**
@@ -528,7 +530,9 @@ test.describe("Workflow agent profile switching", () => {
     apiClient,
     seedData,
   }) => {
-    test.setTimeout(60_000);
+    // Cascade boots two agents sequentially (step1 turn, then step2 on move_to_next);
+    // under CI shard contention that can outlast the default budget — give headroom.
+    test.setTimeout(180_000);
     const { profileA, profileB } = await createProfiles(apiClient);
 
     // Step1 (profileA, auto_start, move_to_next) → Step2 (profileB, auto_start)
@@ -568,8 +572,8 @@ test.describe("Workflow agent profile switching", () => {
 
     // After the cascade, the Profile B tab should appear and own the primary star.
     const profileBTab = session.sessionTabByText("Profile B");
-    await expect(profileBTab).toBeVisible({ timeout: 45_000 });
-    await expect(session.primaryStarInTab("Profile B")).toBeVisible({ timeout: 45_000 });
+    await expect(profileBTab).toBeVisible({ timeout: 90_000 });
+    await expect(session.primaryStarInTab("Profile B")).toBeVisible({ timeout: 90_000 });
   });
 
   /**
@@ -583,7 +587,9 @@ test.describe("Workflow agent profile switching", () => {
     apiClient,
     seedData,
   }) => {
-    test.setTimeout(60_000);
+    // Two agent boots (git worktree checkouts) — one before the move, one after —
+    // can outlast the default budget under CI shard contention; give headroom.
+    test.setTimeout(180_000);
     const { profileA, profileB } = await createProfiles(apiClient);
 
     const workflow = await apiClient.createWorkflow(seedData.workspaceId, "Primary Star Test");
@@ -624,7 +630,7 @@ test.describe("Workflow agent profile switching", () => {
           const { sessions } = await apiClient.listTaskSessions(task.id);
           return sessions.some((s) => s.state === "WAITING_FOR_INPUT");
         },
-        { timeout: 30_000, message: "Waiting for agent to be ready" },
+        { timeout: 60_000, message: "Waiting for agent to be ready" },
       )
       .toBe(true);
 
@@ -635,8 +641,8 @@ test.describe("Workflow agent profile switching", () => {
     // Per PR #743, the active dockview tab stays pinned to Profile A — the star
     // moving is what proves SetPrimarySession's WS broadcast landed.
     const profileBTab = session.sessionTabByText("Profile B");
-    await expect(profileBTab).toBeVisible({ timeout: 30_000 });
-    await expect(session.primaryStarInTab("Profile B")).toBeVisible({ timeout: 30_000 });
+    await expect(profileBTab).toBeVisible({ timeout: 60_000 });
+    await expect(session.primaryStarInTab("Profile B")).toBeVisible({ timeout: 60_000 });
   });
 
   /**
@@ -650,7 +656,9 @@ test.describe("Workflow agent profile switching", () => {
     apiClient,
     seedData,
   }) => {
-    test.setTimeout(60_000);
+    // Two agent boots (git worktree checkouts) — profileB on entry, profileA on
+    // revert — can outlast the default budget under CI shard contention; give headroom.
+    test.setTimeout(180_000);
     const { profileA, profileB } = await createProfiles(apiClient);
 
     // Step1 (profileB, auto_start) → Step2 (NO override, auto_start)
@@ -688,14 +696,14 @@ test.describe("Workflow agent profile switching", () => {
 
     // Wait for Profile B session (Step1 override) to be ready
     const profileBTab = session.sessionTabByText("Profile B");
-    await expect(profileBTab).toBeVisible({ timeout: 30_000 });
+    await expect(profileBTab).toBeVisible({ timeout: 60_000 });
     await expect
       .poll(
         async () => {
           const { sessions } = await apiClient.listTaskSessions(task.id);
           return sessions.some((s) => s.state === "WAITING_FOR_INPUT");
         },
-        { timeout: 30_000, message: "Waiting for agent to be ready" },
+        { timeout: 60_000, message: "Waiting for agent to be ready" },
       )
       .toBe(true);
 
@@ -706,8 +714,8 @@ test.describe("Workflow agent profile switching", () => {
     // Per PR #743, the user's pinned tab — Profile B from initial load — stays
     // active; the primary marker is what proves the revert-to-default landed.
     const profileATab = session.sessionTabByText("Profile A");
-    await expect(profileATab).toBeVisible({ timeout: 30_000 });
-    await expect(session.primaryStarInTab("Profile A")).toBeVisible({ timeout: 30_000 });
+    await expect(profileATab).toBeVisible({ timeout: 60_000 });
+    await expect(session.primaryStarInTab("Profile A")).toBeVisible({ timeout: 60_000 });
   });
 
   /**

--- a/apps/web/e2e/tests/workflow/workflow-automation.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-automation.spec.ts
@@ -217,9 +217,7 @@ test.describe("Workflow automation", () => {
     await session.sendMessage("/e2e:simple-message");
 
     // Wait for the agent to respond (second "simple mock response")
-    await expect(
-      session.chat.getByText("simple mock response", { exact: false }).nth(1),
-    ).toBeVisible({ timeout: 30_000 });
+    await session.expectChatResponseVisible("simple mock response", 1, { timeout: 30_000 });
 
     // Stepper still shows Review (no on_turn_complete events on Review)
     await expect(session.stepperStep("Review")).toHaveAttribute("aria-current", "step", {

--- a/apps/web/e2e/tests/workflow/workflow-automation.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-automation.spec.ts
@@ -91,7 +91,7 @@ test.describe("Workflow automation", () => {
     });
 
     // Session transitions to idle after agent completes
-    await expect(session.idleInput()).toBeVisible({ timeout: 15_000 });
+    await session.waitForChatIdle({ timeout: 15_000 });
 
     // Sidebar shows the task under "Turn Finished" section
     await expect(session.sidebarSection("Turn Finished")).toBeVisible();
@@ -442,7 +442,7 @@ test.describe("Workflow automation", () => {
 
     // Session transitions to idle after the cascade completes.
     // The cascade runs 4 sequential agent turns; session state may lag message display.
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Sidebar shows the task under "Turn Finished" section
     await expect(session.sidebarSection("Turn Finished")).toBeVisible();
@@ -603,7 +603,7 @@ test.describe("Workflow automation", () => {
     await session.waitForLoad();
 
     // Wait for the idle input (chat is ready)
-    await expect(session.idleInput()).toBeVisible({ timeout: 15_000 });
+    await session.waitForChatIdle({ timeout: 15_000 });
 
     // The backend downgraded auto-start to prepare: session exists but agent
     // was NOT started. Verify session was created in CREATED state.

--- a/apps/web/e2e/tests/workflow/workflow-queue-helpers.ts
+++ b/apps/web/e2e/tests/workflow/workflow-queue-helpers.ts
@@ -41,7 +41,23 @@ export async function seedQueuedWorkflowMessageScenario(
   await page.goto(`/t/${task.id}`);
   const session = new SessionPage(page);
   await session.waitForLoad();
-  await expect(session.agentStatus()).toBeVisible({ timeout: 20_000 });
+  // Confirm the agent is mid-turn before the manual move via the backend session
+  // state, not the transient "Agent is starting/running" badge. The badge depends
+  // on the client receiving the state over WS, and under the WS-subscribe race the
+  // client can miss it when its subscription registers after the transition fans
+  // out; the backend session state is the source of truth and avoids that race.
+  // The e2e:delay(8000) keeps the first turn busy long enough to observe a STARTING
+  // or RUNNING state (the mock agent can jump STARTING->WAITING_FOR_INPUT without
+  // ever surfacing RUNNING, so accept either busy state).
+  await expect
+    .poll(
+      async () => {
+        const { sessions } = await apiClient.listTaskSessions(task.id);
+        return sessions.find((s) => s.id === task.session_id)?.state ?? "";
+      },
+      { timeout: 20_000, message: "Waiting for agent to start its turn" },
+    )
+    .toMatch(/^(STARTING|RUNNING)$/);
 
   await apiClient.moveTask(task.id, workflow.id, reviewStep.id);
 

--- a/apps/web/e2e/tests/workflow/workflow-start-step.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-start-step.spec.ts
@@ -240,7 +240,7 @@ test.describe("Workflow start step placement", () => {
     });
 
     // Session transitions to idle
-    await expect(session.idleInput()).toBeVisible({ timeout: 15_000 });
+    await session.waitForChatIdle({ timeout: 15_000 });
   });
 
   /**

--- a/apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-step-proceed.spec.ts
@@ -73,7 +73,7 @@ test.describe("Manual proceed to next workflow step", () => {
     await session.waitForLoad();
 
     // Wait for agent to complete its turn (idle input visible)
-    await expect(session.idleInput()).toBeVisible({ timeout: 30_000 });
+    await session.waitForChatIdle({ timeout: 30_000 });
 
     // Stepper shows Spec as current step
     await expect(session.stepperStep("Spec")).toHaveAttribute("aria-current", "step", {

--- a/apps/web/hooks/use-plan-panel-auto-open.test.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.test.ts
@@ -177,6 +177,24 @@ describe("usePlanPanelAutoOpen — eager fetch", () => {
     expect(mockAddPlanPanel).not.toHaveBeenCalled();
   });
 
+  it("does not acknowledge a panel it just auto-opened when the eager fetch re-applies the plan", () => {
+    // First render: panel doesn't exist yet, so we auto-open it.
+    mockGetPanel.mockReturnValue(null);
+    const { rerender } = renderHook(() => usePlanPanelAutoOpen());
+    expect(mockAddPlanPanel).toHaveBeenCalledTimes(1);
+
+    // The eager getTaskPlan self-heal resolves after the WS push and
+    // re-applies an equivalent plan object (new reference, same updated_at),
+    // re-running the effect. By now the panel we added is registered, so
+    // getPanel returns it while lastSeen is still undefined. This must NOT
+    // mark the plan seen — that would suppress the indicator the user expects.
+    mockGetPanel.mockReturnValue({ id: "plan" });
+    mockPlan = agentPlan();
+    rerender();
+
+    expect(mockMarkTaskPlanSeen).not.toHaveBeenCalled();
+  });
+
   it("does not retry the eager fetch after a failure", async () => {
     mockIsLoaded = false;
     mockPlan = null;

--- a/apps/web/hooks/use-plan-panel-auto-open.ts
+++ b/apps/web/hooks/use-plan-panel-auto-open.ts
@@ -39,6 +39,14 @@ export function usePlanPanelAutoOpen() {
   // reconnect can retry any failed or not-yet-attempted tasks.
   const attemptedRef = useRef<Set<string>>(new Set());
 
+  // Whether *this* hook added the plan panel for the current task. Lets the
+  // reload-heal branch below tell "panel restored from a saved layout" (heal)
+  // apart from "panel we just auto-opened" (don't heal). Reset per task.
+  const addedPlanPanelRef = useRef(false);
+  useEffect(() => {
+    addedPlanPanelRef.current = false;
+  }, [activeTaskId]);
+
   // Eagerly fetch the plan on task load. The Plan panel mounts `useTaskPlan`
   // only after the panel exists, so without this fetch a plan written by the
   // agent before the browser's WS connected (fast auto-start path) would never
@@ -90,10 +98,20 @@ export function usePlanPanelAutoOpen() {
       // every reload. When a live update arrives after the reload,
       // `lastSeen` is defined so we don't suppress it — PlanTab reads the
       // store directly and re-arms the indicator.
-      if (lastSeen === undefined) markTaskPlanSeen(plan.task_id);
+      //
+      // Guard on `addedPlanPanelRef`: only heal panels we did *not* add this
+      // session. Otherwise this branch misfires when our own addPlanPanel
+      // below re-triggers the effect — e.g. the eager getTaskPlan self-heal
+      // resolves after the WS push and re-applies an equivalent plan object —
+      // which would mark a freshly auto-opened plan seen and suppress the
+      // indicator the user must see.
+      if (lastSeen === undefined && !addedPlanPanelRef.current) {
+        markTaskPlanSeen(plan.task_id);
+      }
       return;
     }
 
+    addedPlanPanelRef.current = true;
     addPlanPanel({ quiet: true, inCenter: true });
   }, [api, isRestoringLayout, plan, lastSeen, addPlanPanel, markTaskPlanSeen]);
 }


### PR DESCRIPTION
Several E2E specs flake in CI: a backend resume path briefly drives ACP sessions through RUNNING, and a set of specs lose the WS-subscribe race or run out of time budget under shard contention. This gates the resume wake to passthrough sessions and switches the affected specs to the established de-flake patterns so the suite stays green.

## Important Changes

- Gate `agent.running` so it only wakes passthrough sessions. ACP sessions drive state via protocol events, so the boot-time wake caused a transient RUNNING flicker during resume.
- Switch `plan-mode-followup` and `terminal-settings` seed helpers from a raw `idleInput()` wait to `waitForChatIdle`, the repo-wide helper that reloads once to ride out the WS-subscribe race.
- Coordinate the multi-card assertion in `pr-watcher-dockview-layout` with `expect.poll`, and raise the `workflow-agent-switch` budgets (per-test 180s, assertions 60s/90s) to absorb concurrent agent boots (git worktree checkouts) under CI shards.
- De-flake `seedQueuedWorkflowMessageScenario` (shared by `workflow-manual-move-queue` and `mobile-workflow-manual-move-queue`): poll the backend session state for `STARTING`/`RUNNING` instead of waiting on the transient "Agent is starting/running" badge, which depends on the client winning the WS-subscribe race. This was the CI shard 10 failure.

## Validation

- `make -C apps/backend test` (orchestrator package, incl. `TestHandleAgentRunning_DoesNotWakeWaitingAcpSession`)
- `pnpm --filter @kandev/web lint`
- `pnpm --filter @kandev/web typecheck`
- `playwright test --project=mobile-chrome --repeat-each=6` on `mobile-workflow-manual-move-queue` and `--project=chromium --repeat-each=6` on `workflow-manual-move-queue` (both 6/6 pass)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.