### PR TITLE
fix(linear): search linear issues by identifier

### DIFF
--- a/apps/backend/internal/linear/graphql_client.go
+++ b/apps/backend/internal/linear/graphql_client.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -512,7 +514,20 @@ func buildIssueFilter(f SearchFilter) map[string]interface{} {
 	if q := strings.TrimSpace(f.Query); q != "" {
 		// Linear has no top-level free-text field, but `searchableContent`
 		// matches across title and description.
-		out["searchableContent"] = map[string]interface{}{"contains": q}
+		contentFilter := map[string]interface{}{
+			"searchableContent": map[string]interface{}{"contains": q},
+		}
+		if teamKey, issueNumber, ok := parseIssueIdentifier(q); ok {
+			out["or"] = []map[string]interface{}{
+				contentFilter,
+				{
+					"team":   map[string]interface{}{"key": map[string]interface{}{"eq": teamKey}},
+					"number": map[string]interface{}{"eq": issueNumber},
+				},
+			}
+		} else {
+			out["searchableContent"] = contentFilter["searchableContent"]
+		}
 	}
 	if f.TeamKey != "" {
 		out["team"] = map[string]interface{}{"key": map[string]interface{}{"eq": f.TeamKey}}
@@ -557,6 +572,20 @@ func buildIssueFilter(f SearchFilter) map[string]interface{} {
 		return nil
 	}
 	return out
+}
+
+var issueIdentifierRE = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9]*)-([1-9][0-9]*)$`)
+
+func parseIssueIdentifier(input string) (string, int, bool) {
+	matches := issueIdentifierRE.FindStringSubmatch(strings.TrimSpace(input))
+	if matches == nil {
+		return "", 0, false
+	}
+	number, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return "", 0, false
+	}
+	return strings.ToUpper(matches[1]), number, true
 }
 
 // --- labels ---

--- a/apps/backend/internal/linear/graphql_client_test.go
+++ b/apps/backend/internal/linear/graphql_client_test.go
@@ -255,6 +255,81 @@ func TestBuildIssueFilter_DropsEmpty(t *testing.T) {
 	}
 }
 
+func TestParseIssueIdentifier(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantTeam   string
+		wantNumber int
+		wantOK     bool
+	}{
+		{name: "uppercase", input: "ENG-123", wantTeam: "ENG", wantNumber: 123, wantOK: true},
+		{name: "lowercase", input: "eng-123", wantTeam: "ENG", wantNumber: 123, wantOK: true},
+		{name: "trims space", input: " eng-123 ", wantTeam: "ENG", wantNumber: 123, wantOK: true},
+		{name: "text search", input: "ENG auth", wantOK: false},
+		{name: "missing number", input: "ENG-", wantOK: false},
+		{name: "zero number", input: "ENG-0", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTeam, gotNumber, gotOK := parseIssueIdentifier(tt.input)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok=%v, want %v", gotOK, tt.wantOK)
+			}
+			if gotTeam != tt.wantTeam || gotNumber != tt.wantNumber {
+				t.Fatalf("parseIssueIdentifier(%q)=(%q,%d), want (%q,%d)",
+					tt.input, gotTeam, gotNumber, tt.wantTeam, tt.wantNumber)
+			}
+		})
+	}
+}
+
+func TestBuildIssueFilter_IdentifierQuery(t *testing.T) {
+	got := buildIssueFilter(SearchFilter{Query: "eng-123"})
+	orFilters, ok := got["or"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected identifier query to build or filters, got %+v", got)
+	}
+	if len(orFilters) != 2 {
+		t.Fatalf("expected content and identifier filters, got %+v", orFilters)
+	}
+	if content := orFilters[0]["searchableContent"]; content == nil {
+		t.Fatalf("expected searchableContent branch, got %+v", orFilters[0])
+	}
+	identifier := orFilters[1]
+	team := identifier["team"].(map[string]interface{})
+	key := team["key"].(map[string]interface{})
+	if key["eq"] != "ENG" {
+		t.Fatalf("expected uppercase team key, got %+v", team)
+	}
+	number := identifier["number"].(map[string]interface{})
+	if number["eq"] != 123 {
+		t.Fatalf("expected exact issue number, got %+v", number)
+	}
+}
+
+func TestBuildIssueFilter_IdentifierComposesWithOtherFilters(t *testing.T) {
+	got := buildIssueFilter(SearchFilter{
+		Query:    "ENG-123",
+		TeamKey:  "ENG",
+		StateIDs: []string{"started"},
+		Assigned: "me",
+	})
+	if _, ok := got["or"]; !ok {
+		t.Fatalf("expected identifier query to preserve query or filter, got %+v", got)
+	}
+	if _, ok := got["team"]; !ok {
+		t.Fatalf("expected explicit team filter to remain top-level, got %+v", got)
+	}
+	if _, ok := got["state"]; !ok {
+		t.Fatalf("expected state filter to remain top-level, got %+v", got)
+	}
+	if _, ok := got["assignee"]; !ok {
+		t.Fatalf("expected assignee filter to remain top-level, got %+v", got)
+	}
+}
+
 func TestBuildIssueFilter_RichFilters(t *testing.T) {
 	min := 1.0
 	max := 5.0

--- a/apps/web/app/linear/linear-page-client.tsx
+++ b/apps/web/app/linear/linear-page-client.tsx
@@ -280,7 +280,7 @@ function FilterControls({
       <div className="relative flex-1 min-w-[280px]">
         <IconSearch className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input
-          placeholder="Search title or description"
+          placeholder="Search by ID, title, or description"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="pl-8"


### PR DESCRIPTION
## Summary
Fixes Linear search for ticket identifiers like ENG-123 in the Linear issue list.

## Changes
- Map identifier-like search queries to a Linear identifier match ( + ) with OR fallback to existing title/description search.
- Added backend regression tests for identifier parsing and filter composition.
- Updated search placeholder to include ID search.

Closes #1339