### PR TITLE
fix(web): restore default layout during session preparation

### DIFF
--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -226,6 +226,18 @@ describe("resolveInitialPosition", () => {
 });
 
 describe("shouldRebuildDefaultForPendingSession", () => {
+  it("does not rebuild when there is no effective session id", () => {
+    const api = makePositionApi({
+      groups: [RIGHT_TOP_GROUP],
+      panels: [
+        { id: "session:missing", groupId: RIGHT_TOP_GROUP },
+        { id: "files", groupId: RIGHT_TOP_GROUP },
+      ],
+    });
+
+    expect(shouldRebuildDefaultForPendingSession(api, null, [])).toBe(false);
+  });
+
   it("rebuilds default when the active session is pending and no chat group remains", () => {
     const api = makePositionApi({
       groups: [RIGHT_TOP_GROUP],

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -6,8 +6,9 @@ import {
   reconcileRemovedSessionPanels,
   resolveInitialPosition,
   resolveSessionTabSyncTarget,
+  shouldRebuildDefaultForPendingSession,
 } from "./dockview-session-tabs";
-import { RIGHT_TOP_GROUP } from "@/lib/state/layout-manager";
+import { CENTER_GROUP, RIGHT_TOP_GROUP } from "@/lib/state/layout-manager";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 
 type FakePanel = {
@@ -18,6 +19,7 @@ type FakePanel = {
 const KEEP = "keep";
 const KEEP_PANEL = `session:${KEEP}`;
 const LEAKED_PANEL = "session:leaked";
+const PENDING_SESSION_ID = "session-new";
 
 /**
  * Builds a fake DockviewApi where `panel.api.close()` mutates the underlying
@@ -220,6 +222,53 @@ describe("resolveInitialPosition", () => {
       referenceGroup: RIGHT_TOP_GROUP,
       direction: "left",
     });
+  });
+});
+
+describe("shouldRebuildDefaultForPendingSession", () => {
+  it("rebuilds default when the active session is pending and no chat group remains", () => {
+    const api = makePositionApi({
+      groups: [RIGHT_TOP_GROUP],
+      panels: [
+        { id: "files", groupId: RIGHT_TOP_GROUP },
+        { id: "changes", groupId: RIGHT_TOP_GROUP },
+      ],
+    });
+
+    expect(shouldRebuildDefaultForPendingSession(api, PENDING_SESSION_ID, [])).toBe(true);
+  });
+
+  it("rebuilds before stale session panels are reconciled away", () => {
+    const api = makePositionApi({
+      groups: ["stale-center", RIGHT_TOP_GROUP],
+      panels: [
+        { id: "session:old", groupId: "stale-center" },
+        { id: "files", groupId: RIGHT_TOP_GROUP },
+        { id: "changes", groupId: RIGHT_TOP_GROUP },
+      ],
+    });
+
+    expect(shouldRebuildDefaultForPendingSession(api, PENDING_SESSION_ID, [])).toBe(true);
+  });
+
+  it("does not rebuild while the chat placeholder is still present", () => {
+    const api = makePositionApi({
+      groups: [CENTER_GROUP, RIGHT_TOP_GROUP],
+      panels: [
+        { id: "chat", groupId: CENTER_GROUP },
+        { id: "files", groupId: RIGHT_TOP_GROUP },
+      ],
+    });
+
+    expect(shouldRebuildDefaultForPendingSession(api, PENDING_SESSION_ID, [])).toBe(false);
+  });
+
+  it("does not rebuild once the active session is hydrated for the task", () => {
+    const api = makePositionApi({ groups: [RIGHT_TOP_GROUP] });
+
+    expect(
+      shouldRebuildDefaultForPendingSession(api, PENDING_SESSION_ID, [PENDING_SESSION_ID]),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, type MutableRefObject } from "react";
 import type { DockviewApi, DockviewReadyEvent, AddPanelOptions } from "dockview-react";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
-import { useDockviewStore } from "@/lib/state/dockview-store";
+import { releaseLayoutToDefault, useDockviewStore } from "@/lib/state/dockview-store";
 import { focusOrAddPanel } from "@/lib/state/dockview-layout-builders";
 import {
   CENTER_GROUP,
@@ -585,6 +585,36 @@ function shouldSkipPanelEnsure(
   return false;
 }
 
+export function shouldRebuildDefaultForPendingSession(
+  api: DockviewApi,
+  effectiveSessionId: string | null,
+  currentSessionIds: string[],
+): boolean {
+  if (!effectiveSessionId) return false;
+  if (currentSessionIds.includes(toSessionId(effectiveSessionId))) return false;
+  if (api.getPanel("chat")) return false;
+  return true;
+}
+
+function logAutoSessionTabEffectEntry(
+  api: DockviewApi,
+  effectiveSessionId: string | null,
+  tid: string | null,
+  currentSessionIds: string[],
+  refs: AutoSessionTabRefs,
+): void {
+  if (!isDebug()) return;
+  debug("useAutoSessionTab: effect entry", {
+    effectiveSessionId,
+    activeTaskId: tid,
+    prevTaskId: refs.prevTaskIdRef.current,
+    prevSessionId: refs.prevSessionIdRef.current,
+    currentSessionIds,
+    livePanelIdsBefore: api.panels.map((p) => p.id),
+    createdSet: Array.from(refs.sessionTabCreatedRef.current),
+  });
+}
+
 /**
  * Core effect body for useAutoSessionTab — extracted to reduce complexity of
  * the hook itself.
@@ -599,16 +629,19 @@ function runAutoSessionTabEffect(
 
   const { tid, currentSessionIds } = resolveCurrentSessionIds(appStore);
 
-  if (isDebug()) {
-    debug("useAutoSessionTab: effect entry", {
-      effectiveSessionId,
-      activeTaskId: tid,
-      prevTaskId: refs.prevTaskIdRef.current,
-      prevSessionId: refs.prevSessionIdRef.current,
-      currentSessionIds,
-      livePanelIdsBefore: api.panels.map((p) => p.id),
-      createdSet: Array.from(refs.sessionTabCreatedRef.current),
-    });
+  logAutoSessionTabEffectEntry(api, effectiveSessionId, tid, currentSessionIds, refs);
+
+  if (shouldRebuildDefaultForPendingSession(api, effectiveSessionId, currentSessionIds)) {
+    if (isDebug()) {
+      debug("useAutoSessionTab: release default for pending session", {
+        effectiveSessionId,
+        currentSessionIds,
+        currentLayoutEnvId: useDockviewStore.getState().currentLayoutEnvId,
+        livePanelIds: api.panels.map((p) => p.id),
+      });
+    }
+    releaseLayoutToDefault(useDockviewStore.getState().currentLayoutEnvId);
+    return;
   }
 
   reconcileRemovedSessionPanels(


### PR DESCRIPTION
Fixes a layout flash when a new task session opens before the agent session is hydrated by quickly rebuilding to the default Dockview grid when the active session is still pending.

This prevents the UI from briefly showing a stale/partial panel arrangement and ensures the chat task session starts from the standard default layout dimensions from the first paint.

## Important Changes
- Added a pending-session check in `useAutoSessionTab` to detect active task sessions not yet present in the Dockview session registry.
- Triggered `releaseLayoutToDefault` before stale-panel reconciliation when a pending session is detected, so the workspace is restored to default panel sizing immediately.
- Added focused unit tests for the new guard path in dockview session tab logic.

## Validation
- `cd apps && pnpm --filter @kandev/web test -- --run components/task/dockview-session-tabs.test.ts`
- `cd apps && pnpm --filter @kandev/web lint -- components/task/dockview-session-tabs.ts components/task/dockview-session-tabs.test.ts`
- `cd apps && pnpm --filter @kandev/web typecheck`
- `cd apps && pnpm --filter @kandev/web test -- --run lib/state/dockview-env-switch-action.test.ts lib/state/dockview-layout-builders.test.ts lib/state/layout-manager/presets.test.ts`
- `cd apps && pnpm --filter @kandev/web test -- --run components/task/dockview-desktop-layout.test.ts components/task/dockview-layout-restore.test.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.