### PR TITLE
fix(web): suppress archive success toast

### DIFF
--- a/apps/web/components/task/chat/chat-input-area.test.tsx
+++ b/apps/web/components/task/chat/chat-input-area.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const archiveAndSwitchMock = vi.fn();
+const toastMock = vi.fn();
+const taskPRsByTaskId = vi.hoisted(() => ({
+  value: {
+    "task-1": [{ pr_number: 42, state: "merged" }],
+  } as Record<string, Array<{ pr_number: number; state: string }>>,
+}));
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+  useAppStoreApi: () => ({ getState: () => mockState }),
+}));
+
+vi.mock("@/hooks/use-task-actions", () => ({
+  useArchiveAndSwitchTask: () => archiveAndSwitchMock,
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/components/github/pr-status-chip", () => ({
+  PRStatusChip: () => null,
+}));
+
+vi.mock("@/components/task/share/share-button", () => ({
+  ShareButton: () => null,
+  shareableSessionStateClient: () => false,
+}));
+
+vi.mock("@/components/task/chat/queued-ghost-list", () => ({
+  QueueAffordance: ({ children }: { children: (queueChip: React.ReactNode) => React.ReactNode }) =>
+    children(null),
+}));
+
+vi.mock("@/components/task/chat/chat-input-container", () => ({
+  ChatInputContainer: () => null,
+}));
+
+vi.mock("@/components/task/chat/todo-indicator", () => ({
+  TodoIndicator: () => null,
+}));
+
+vi.mock("@/hooks/use-keyboard-shortcut", () => ({
+  useKeyboardShortcut: () => undefined,
+}));
+
+vi.mock("@/hooks/use-message-handler", () => ({
+  buildTaskMentionsContext: vi.fn(),
+  useMessageHandler: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/domains/kanban/use-plan-actions", () => ({
+  usePlanActions: () => ({
+    implementPlanHandler: vi.fn(),
+    proceedStepName: null,
+    proceed: vi.fn(),
+    isMoving: false,
+  }),
+}));
+
+vi.mock("@/hooks/domains/session/use-executor-environment-availability", () => ({
+  useExecutorEnvironmentAvailability: () => ({
+    unavailable: false,
+    status: null,
+  }),
+}));
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: () => ({ send: vi.fn() }),
+}));
+
+vi.mock("@/lib/local-storage", () => ({
+  markPRClosedBannerDismissed: vi.fn(),
+  markPRMergedBannerDismissed: vi.fn(),
+  wasPRClosedBannerDismissed: () => false,
+  wasPRMergedBannerDismissed: () => false,
+}));
+
+const mockState = {
+  taskPRs: { byTaskId: taskPRsByTaskId.value },
+};
+
+import { PRMergedBanner } from "./chat-input-area";
+
+beforeEach(() => {
+  archiveAndSwitchMock.mockResolvedValue(undefined);
+  taskPRsByTaskId.value = {
+    "task-1": [{ pr_number: 42, state: "merged" }],
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PRMergedBanner", () => {
+  it("archives without showing a success toast", async () => {
+    render(<PRMergedBanner taskId="task-1" />);
+
+    fireEvent.click(screen.getByTestId("pr-merged-archive-button"));
+
+    await waitFor(() => expect(archiveAndSwitchMock).toHaveBeenCalledWith("task-1"));
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the failure toast when archive fails", async () => {
+    archiveAndSwitchMock.mockRejectedValueOnce(new Error("archive failed"));
+    render(<PRMergedBanner taskId="task-1" />);
+
+    fireEvent.click(screen.getByTestId("pr-merged-archive-button"));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith({
+        description: "Failed to archive task",
+        variant: "error",
+      }),
+    );
+  });
+});

--- a/apps/web/components/task/chat/chat-input-area.test.tsx
+++ b/apps/web/components/task/chat/chat-input-area.test.tsx
@@ -81,7 +81,11 @@ vi.mock("@/lib/local-storage", () => ({
 }));
 
 const mockState = {
-  taskPRs: { byTaskId: taskPRsByTaskId.value },
+  taskPRs: {
+    get byTaskId() {
+      return taskPRsByTaskId.value;
+    },
+  },
 };
 
 import { PRMergedBanner } from "./chat-input-area";

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -246,14 +246,13 @@ export function useChatPanelHandlers(
 }
 
 // Shared archive-task action for the terminal-state banners: archives the task,
-// switches to the next one, and toasts the outcome.
+// switches to the next one, and only toasts on failure.
 function useArchiveTaskAction(taskId: string) {
   const archiveAndSwitch = useArchiveAndSwitchTask();
   const { toast } = useToast();
   return useCallback(async () => {
     try {
       await archiveAndSwitch(taskId);
-      toast({ description: "Task archived" });
     } catch {
       toast({ description: "Failed to archive task", variant: "error" });
     }


### PR DESCRIPTION
## Summary

- remove success toast from PR merged/closed terminal-state archive action so archiving from the chat status banner is silent when successful
- keep existing error toast on archive failure
- add a focused regression test ensuring success path does not emit a toast

## Testing

- apps                                     |  WARN  The field "pnpm.overrides" was found in /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.
apps                                     |  WARN  The field "pnpm.onlyBuiltDependencies" was found in /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/package.json. This will not take effect. You should configure "pnpm.onlyBuiltDependencies" at the root of the workspace instead.

> @kandev/web@0.1.0 test /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/web
> vitest run --run components/task/chat/chat-input-area.test.tsx


 RUN  v1.6.1 /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/web

 ✓ components/task/chat/chat-input-area.test.tsx  (2 tests) 75ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  18:49:30
   Duration  1.02s (transform 76ms, setup 12ms, collect 403ms, tests 75ms, environment 193ms, prepare 56ms)
- apps                                     |  WARN  The field "pnpm.overrides" was found in /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.
apps                                     |  WARN  The field "pnpm.onlyBuiltDependencies" was found in /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/package.json. This will not take effect. You should configure "pnpm.onlyBuiltDependencies" at the root of the workspace instead.

> @kandev/web@0.1.0 pretypecheck /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/web
> node scripts/generate-release-notes.mjs && node scripts/generate-changelog.mjs

[release-notes] extracted notes for v0.57.0
[changelog] parsed 71 version entries

> @kandev/web@0.1.0 typecheck /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/web
> tsc --noEmit
- apps                                     |  WARN  The field "pnpm.overrides" was found in /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/package.json. This will not take effect. You should configure "pnpm.overrides" at the root of the workspace instead.
apps                                     |  WARN  The field "pnpm.onlyBuiltDependencies" was found in /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/package.json. This will not take effect. You should configure "pnpm.onlyBuiltDependencies" at the root of the workspace instead.

> @kandev/web@0.1.0 lint /root/.kandev/tasks/remove-toast-task-ar_i5m/kandev/apps/web
> eslint --max-warnings 0