### PR TITLE
fix: persist session runtime config

### DIFF
--- a/apps/backend/cmd/kandev/main.go
+++ b/apps/backend/cmd/kandev/main.go
@@ -796,6 +796,7 @@ func initOfficeServices(
 		CachePath: modelsdevCachePath,
 	}, log)
 	services.Office.SetPricingLookup(pricingLookup)
+	orchestratorSvc.SetModelInfoLookup(pricingLookup)
 	services.Office.SetSessionUsageWriter(repos.Task)
 
 	// ADR 0005 Wave E: plug the runtime-tier skill deployer into the

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -769,6 +769,52 @@ func TestEffectiveSessionMode(t *testing.T) {
 	})
 }
 
+func TestEffectiveSessionRuntimeConfig(t *testing.T) {
+	exec := &AgentExecution{ID: "exec-1", TaskID: "task-1", SessionID: "session-1"}
+	profileOptions := map[string]string{"reasoning_effort": "medium"}
+
+	t.Run("session runtime config overrides profile defaults", func(t *testing.T) {
+		mgr := newTestManager(t)
+		mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
+			infos: map[string]*WorkspaceInfo{
+				"session-1": {
+					SessionID:            "session-1",
+					SessionMode:          "full-access",
+					RuntimeModel:         "gpt-5.3-codex-spark",
+					RuntimeConfigOptions: map[string]string{"reasoning_effort": "low"},
+				},
+			},
+		}
+
+		model, mode, options := mgr.effectiveSessionRuntimeConfig(
+			context.Background(),
+			exec,
+			"gpt-5.5",
+			"auto",
+			profileOptions,
+		)
+
+		require.Equal(t, "gpt-5.3-codex-spark", model)
+		require.Equal(t, "full-access", mode)
+		require.Equal(t, map[string]string{"reasoning_effort": "low"}, options)
+	})
+
+	t.Run("falls back to profile defaults", func(t *testing.T) {
+		mgr := newTestManager(t)
+		model, mode, options := mgr.effectiveSessionRuntimeConfig(
+			context.Background(),
+			exec,
+			"gpt-5.5",
+			"auto",
+			profileOptions,
+		)
+
+		require.Equal(t, "gpt-5.5", model)
+		require.Equal(t, "auto", mode)
+		require.Equal(t, profileOptions, options)
+	})
+}
+
 // --- IsRemoteSession tests ---
 
 type mockWorkspaceInfoProvider struct {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -777,10 +777,11 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 		provider := &mockWorkspaceInfoProvider{
 			infos: map[string]*WorkspaceInfo{
 				"session-1": {
-					SessionID:            "session-1",
-					SessionMode:          "full-access",
-					RuntimeModel:         "gpt-5.3-codex-spark",
-					RuntimeConfigOptions: map[string]string{"reasoning_effort": "low"},
+					SessionID:               "session-1",
+					SessionMode:             "full-access",
+					RuntimeModel:            "gpt-5.3-codex-spark",
+					RuntimeConfigOptions:    map[string]string{"reasoning_effort": "low"},
+					RuntimeConfigOptionsSet: true,
 				},
 			},
 		}
@@ -799,6 +800,32 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 		require.Equal(t, "full-access", mode)
 		require.Equal(t, map[string]string{"reasoning_effort": "low"}, options)
 		require.Equal(t, 1, provider.sessionCalls)
+	})
+
+	t.Run("empty session runtime options override profile defaults", func(t *testing.T) {
+		provider := &mockWorkspaceInfoProvider{
+			infos: map[string]*WorkspaceInfo{
+				"session-1": {
+					SessionID:               "session-1",
+					RuntimeModel:            "gpt-5.3-codex-spark",
+					RuntimeConfigOptionsSet: true,
+				},
+			},
+		}
+		mgr := newTestManager(t)
+		mgr.workspaceInfoProvider = provider
+
+		model, mode, options := mgr.effectiveSessionRuntimeConfig(
+			context.Background(),
+			exec,
+			"gpt-5.5",
+			"auto",
+			profileOptions,
+		)
+
+		require.Equal(t, "gpt-5.3-codex-spark", model)
+		require.Equal(t, "auto", mode)
+		require.Nil(t, options)
 	})
 
 	t.Run("falls back to profile defaults", func(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -802,13 +802,12 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 		require.Equal(t, 1, provider.sessionCalls)
 	})
 
-	t.Run("empty session runtime options override profile defaults", func(t *testing.T) {
+	t.Run("model-only session runtime config keeps profile options", func(t *testing.T) {
 		provider := &mockWorkspaceInfoProvider{
 			infos: map[string]*WorkspaceInfo{
 				"session-1": {
-					SessionID:               "session-1",
-					RuntimeModel:            "gpt-5.3-codex-spark",
-					RuntimeConfigOptionsSet: true,
+					SessionID:    "session-1",
+					RuntimeModel: "gpt-5.3-codex-spark",
 				},
 			},
 		}
@@ -825,7 +824,7 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 
 		require.Equal(t, "gpt-5.3-codex-spark", model)
 		require.Equal(t, "auto", mode)
-		require.Nil(t, options)
+		require.Equal(t, profileOptions, options)
 	})
 
 	t.Run("falls back to profile defaults", func(t *testing.T) {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -774,8 +774,7 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 	profileOptions := map[string]string{"reasoning_effort": "medium"}
 
 	t.Run("session runtime config overrides profile defaults", func(t *testing.T) {
-		mgr := newTestManager(t)
-		mgr.workspaceInfoProvider = &mockWorkspaceInfoProvider{
+		provider := &mockWorkspaceInfoProvider{
 			infos: map[string]*WorkspaceInfo{
 				"session-1": {
 					SessionID:            "session-1",
@@ -785,6 +784,8 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 				},
 			},
 		}
+		mgr := newTestManager(t)
+		mgr.workspaceInfoProvider = provider
 
 		model, mode, options := mgr.effectiveSessionRuntimeConfig(
 			context.Background(),
@@ -797,6 +798,7 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 		require.Equal(t, "gpt-5.3-codex-spark", model)
 		require.Equal(t, "full-access", mode)
 		require.Equal(t, map[string]string{"reasoning_effort": "low"}, options)
+		require.Equal(t, 1, provider.sessionCalls)
 	})
 
 	t.Run("falls back to profile defaults", func(t *testing.T) {
@@ -818,12 +820,14 @@ func TestEffectiveSessionRuntimeConfig(t *testing.T) {
 // --- IsRemoteSession tests ---
 
 type mockWorkspaceInfoProvider struct {
-	infos    map[string]*WorkspaceInfo
-	envInfos map[string]*WorkspaceInfo
-	err      error
+	infos        map[string]*WorkspaceInfo
+	envInfos     map[string]*WorkspaceInfo
+	err          error
+	sessionCalls int
 }
 
 func (m *mockWorkspaceInfoProvider) GetWorkspaceInfoForSession(_ context.Context, _, sessionID string) (*WorkspaceInfo, error) {
+	m.sessionCalls++
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
@@ -174,7 +174,7 @@ func (m *Manager) initializeACPSession(ctx context.Context, execution *AgentExec
 
 func (m *Manager) effectiveSessionRuntimeConfig(ctx context.Context, execution *AgentExecution, profileModel, profileMode string, profileConfigOptions map[string]string) (string, string, map[string]string) {
 	model := profileModel
-	mode := m.effectiveSessionMode(ctx, execution, profileMode)
+	mode := profileMode
 	configOptions := profileConfigOptions
 	info := m.sessionWorkspaceInfo(ctx, execution)
 	if info == nil {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
@@ -163,20 +163,33 @@ func (m *Manager) resolveProfileSessionConfig(ctx context.Context, profileID str
 // signal (the agent has never run a turn). When there IS a prompt, the callback is unused and
 // MarkReady fires later from handleCompleteEvent — that path is the true turn-end.
 //
-// Note: the only session-level override applied on resume is `mode` (see
-// effectiveSessionMode / issue #1183). We deliberately do NOT replay the
-// model or dynamic config options from AgentProfileSnapshot here. Agents
-// that support session/load preserve those values themselves; agents that
-// don't can use the profile defaults. Replaying snapshot state on every
-// resume issues redundant SetModel / SetConfigOption RPCs that cycle the
-// session through STARTING / RUNNING and flicker the task into the sidebar's
-// Running bucket (see session-resume-keeps-review-state.spec.ts).
-// SSR-side page-reload persistence still works because the model selector
-// reads `agent_profile_snapshot.model` directly.
+// Session runtime config persisted in task_sessions.metadata.runtime_config
+// takes precedence over profile defaults. This preserves user-selected model
+// and reasoning-effort values across process recovery.
 func (m *Manager) initializeACPSession(ctx context.Context, execution *AgentExecution, agentConfig agents.Agent, taskDescription string, attachments []MessageAttachment, mcpServers []agentctltypes.McpServer) error {
 	profileModel, profileMode, profileConfigOptions := m.resolveProfileSessionConfig(ctx, execution.AgentProfileID)
+	model, mode, configOptions := m.effectiveSessionRuntimeConfig(ctx, execution, profileModel, profileMode, profileConfigOptions)
+	return m.sessionManager.InitializeAndPrompt(ctx, execution, agentConfig, taskDescription, attachments, mcpServers, m.MarkBootReady, model, mode, configOptions)
+}
+
+func (m *Manager) effectiveSessionRuntimeConfig(ctx context.Context, execution *AgentExecution, profileModel, profileMode string, profileConfigOptions map[string]string) (string, string, map[string]string) {
+	model := profileModel
 	mode := m.effectiveSessionMode(ctx, execution, profileMode)
-	return m.sessionManager.InitializeAndPrompt(ctx, execution, agentConfig, taskDescription, attachments, mcpServers, m.MarkBootReady, profileModel, mode, profileConfigOptions)
+	configOptions := profileConfigOptions
+	info := m.sessionWorkspaceInfo(ctx, execution)
+	if info == nil {
+		return model, mode, configOptions
+	}
+	if info.RuntimeModel != "" {
+		model = info.RuntimeModel
+	}
+	if info.SessionMode != "" {
+		mode = info.SessionMode
+	}
+	if len(info.RuntimeConfigOptions) > 0 {
+		configOptions = info.RuntimeConfigOptions
+	}
+	return model, mode, configOptions
 }
 
 // effectiveSessionMode prefers a session-level permission mode persisted in the
@@ -186,12 +199,20 @@ func (m *Manager) initializeACPSession(ctx context.Context, execution *AgentExec
 // reverting to the profile default. Falls back to profileMode when no provider
 // is wired, the lookup fails, or no session mode is set. See issue #1183.
 func (m *Manager) effectiveSessionMode(ctx context.Context, execution *AgentExecution, profileMode string) string {
-	if m.workspaceInfoProvider == nil {
-		return profileMode
-	}
-	info, err := m.workspaceInfoProvider.GetWorkspaceInfoForSession(ctx, execution.TaskID, execution.SessionID)
-	if err != nil || info == nil || info.SessionMode == "" {
+	info := m.sessionWorkspaceInfo(ctx, execution)
+	if info == nil || info.SessionMode == "" {
 		return profileMode
 	}
 	return info.SessionMode
+}
+
+func (m *Manager) sessionWorkspaceInfo(ctx context.Context, execution *AgentExecution) *WorkspaceInfo {
+	if m.workspaceInfoProvider == nil || execution == nil {
+		return nil
+	}
+	info, err := m.workspaceInfoProvider.GetWorkspaceInfoForSession(ctx, execution.TaskID, execution.SessionID)
+	if err != nil {
+		return nil
+	}
+	return info
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_profile.go
@@ -186,7 +186,7 @@ func (m *Manager) effectiveSessionRuntimeConfig(ctx context.Context, execution *
 	if info.SessionMode != "" {
 		mode = info.SessionMode
 	}
-	if len(info.RuntimeConfigOptions) > 0 {
+	if info.RuntimeConfigOptionsSet {
 		configOptions = info.RuntimeConfigOptions
 	}
 	return model, mode, configOptions

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -501,6 +501,11 @@ type WorkspaceInfo struct {
 	// a user toggle. Applied as a mode override at ACP session init so a fresh
 	// launch starts in the declared mode before the first prompt. See issue #1183.
 	SessionMode string
+	// RuntimeModel/RuntimeConfigOptions are user-selected ACP session runtime
+	// settings persisted in task_sessions.metadata.runtime_config. They take
+	// precedence over profile defaults when resuming or recreating a session.
+	RuntimeModel         string
+	RuntimeConfigOptions map[string]string
 
 	// Executor-aware fields for correct runtime selection and remote reconnection
 	ExecutorType     string                 // Executor type (e.g., "local_pc", "sprites")

--- a/apps/backend/internal/agent/runtime/lifecycle/types.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/types.go
@@ -504,8 +504,9 @@ type WorkspaceInfo struct {
 	// RuntimeModel/RuntimeConfigOptions are user-selected ACP session runtime
 	// settings persisted in task_sessions.metadata.runtime_config. They take
 	// precedence over profile defaults when resuming or recreating a session.
-	RuntimeModel         string
-	RuntimeConfigOptions map[string]string
+	RuntimeModel            string
+	RuntimeConfigOptions    map[string]string
+	RuntimeConfigOptionsSet bool
 
 	// Executor-aware fields for correct runtime selection and remote reconnection
 	ExecutorType     string                 // Executor type (e.g., "local_pc", "sprites")

--- a/apps/backend/internal/office/costs/modelsdev/client.go
+++ b/apps/backend/internal/office/costs/modelsdev/client.go
@@ -47,8 +47,14 @@ type Client struct {
 
 	mu       sync.RWMutex
 	index    map[string]shared.ModelPricing
+	info     map[string]ModelInfo
 	loadedAt time.Time
 	cacheBuf []byte // raw on-disk JSON (parsed lazily on miss)
+}
+
+// ModelInfo holds non-pricing metadata from models.dev for a model.
+type ModelInfo struct {
+	ContextWindow int64
 }
 
 // Config bundles construction parameters.
@@ -80,6 +86,7 @@ func New(cfg Config, log *logger.Logger) *Client {
 		httpClient: cfg.HTTPClient,
 		logger:     log.WithFields(zap.String("component", "modelsdev")),
 		index:      make(map[string]shared.ModelPricing),
+		info:       make(map[string]ModelInfo),
 	}
 }
 
@@ -111,6 +118,33 @@ func (c *Client) LookupForModel(ctx context.Context, modelID string) (shared.Mod
 
 	c.maybeRefresh(ctx)
 	return shared.ModelPricing{}, false
+}
+
+// LookupModelInfo returns model metadata from models.dev using the
+// same normalization, lazy disk warm, and stale-while-revalidate
+// behavior as LookupForModel.
+func (c *Client) LookupModelInfo(ctx context.Context, modelID string) (ModelInfo, bool) {
+	key, strategy := Normalize(modelID)
+	if strategy != StrategyLookup {
+		return ModelInfo{}, false
+	}
+	c.once.Do(func() { c.warmFromDisk(ctx) })
+
+	c.mu.RLock()
+	info, ok := c.info[key]
+	c.mu.RUnlock()
+	if ok {
+		c.maybeRefresh(ctx)
+		return info, true
+	}
+
+	if info, ok = c.parseModelInfoFromBuffer(key); ok {
+		c.maybeRefresh(ctx)
+		return info, true
+	}
+
+	c.maybeRefresh(ctx)
+	return ModelInfo{}, false
 }
 
 // warmFromDisk reads the cache file into cacheBuf so subsequent
@@ -164,6 +198,26 @@ func (c *Client) parseFromBuffer(key string) (shared.ModelPricing, bool) {
 	c.index[key] = pricing
 	c.mu.Unlock()
 	return pricing, true
+}
+
+// parseModelInfoFromBuffer pulls one model entry out of the on-disk
+// JSON and caches resulting metadata in the in-memory index. Returns
+// (zero, false) when the key or metadata is absent.
+func (c *Client) parseModelInfoFromBuffer(key string) (ModelInfo, bool) {
+	c.mu.RLock()
+	buf := c.cacheBuf
+	c.mu.RUnlock()
+	if len(buf) == 0 {
+		return ModelInfo{}, false
+	}
+	info, ok := lookupModelInfoInDataset(buf, key)
+	if !ok {
+		return ModelInfo{}, false
+	}
+	c.mu.Lock()
+	c.info[key] = info
+	c.mu.Unlock()
+	return info, true
 }
 
 // maybeRefresh fires a background refresh when the loaded buffer is
@@ -228,6 +282,13 @@ func (c *Client) Refresh(ctx context.Context) error {
 			delete(c.index, k)
 		}
 	}
+	for k := range c.info {
+		if info, ok := lookupModelInfoInDataset(buf, k); ok {
+			c.info[k] = info
+		} else {
+			delete(c.info, k)
+		}
+	}
 	c.mu.Unlock()
 	return nil
 }
@@ -262,6 +323,9 @@ type datasetEntry struct {
 		CacheRead  float64 `json:"cache_read"`
 		CacheWrite float64 `json:"cache_write"`
 	} `json:"cost"`
+	Limit struct {
+		Context int64 `json:"context"`
+	} `json:"limit"`
 }
 
 type datasetProvider struct {
@@ -298,6 +362,33 @@ func lookupInDataset(buf []byte, key string) (shared.ModelPricing, bool) {
 		}
 	}
 	return shared.ModelPricing{}, false
+}
+
+// lookupModelInfoInDataset searches the provider-keyed JSON for a
+// model id and returns metadata when models.dev exposes it.
+func lookupModelInfoInDataset(buf []byte, key string) (ModelInfo, bool) {
+	dataset := make(map[string]datasetProvider)
+	if err := json.Unmarshal(buf, &dataset); err != nil {
+		return ModelInfo{}, false
+	}
+
+	candidates := []string{key, swapHyphenDot(key)}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		for _, provider := range dataset {
+			entry, ok := provider.Models[candidate]
+			if !ok {
+				continue
+			}
+			if entry.Limit.Context <= 0 {
+				return ModelInfo{}, false
+			}
+			return ModelInfo{ContextWindow: entry.Limit.Context}, true
+		}
+	}
+	return ModelInfo{}, false
 }
 
 // swapHyphenDot converts hyphens to dots and vice-versa so a key like

--- a/apps/backend/internal/office/costs/modelsdev/client.go
+++ b/apps/backend/internal/office/costs/modelsdev/client.go
@@ -383,7 +383,7 @@ func lookupModelInfoInDataset(buf []byte, key string) (ModelInfo, bool) {
 				continue
 			}
 			if entry.Limit.Context <= 0 {
-				return ModelInfo{}, false
+				continue
 			}
 			return ModelInfo{ContextWindow: entry.Limit.Context}, true
 		}

--- a/apps/backend/internal/office/costs/modelsdev/client_test.go
+++ b/apps/backend/internal/office/costs/modelsdev/client_test.go
@@ -25,7 +25,8 @@ const sampleDataset = `{
   "openai": {
     "models": {
       "gpt-5-mini":     {"cost": {"input": 0.4,  "output": 1.6, "cache_read": 0.1, "cache_write": 0.5}},
-      "gpt-5.4-mini":   {"cost": {"input": 0.5,  "output": 2.0, "cache_read": 0.1, "cache_write": 0.6}}
+      "gpt-5.3-codex-spark": {"cost": {"input": 0.4, "output": 1.6}, "limit": {"context": 128000}},
+      "gpt-5.4-mini":   {"cost": {"input": 0.5,  "output": 2.0, "cache_read": 0.1, "cache_write": 0.6}, "limit": {"context": 256000}}
     }
   },
   "google": {
@@ -129,6 +130,59 @@ func TestClient_NormalizesCodexAndOpencodeForms(t *testing.T) {
 	// opencode-acp: github-copilot/gpt-5-mini -> gpt-5-mini.
 	if _, ok := c.LookupForModel(context.Background(), "github-copilot/gpt-5-mini"); !ok {
 		t.Error("expected hit on opencode-acp shaped id")
+	}
+}
+
+func TestClient_LookupModelInfo(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "models-dev.json")
+	c, _ := newTestClient(t, cachePath)
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	info, ok := c.LookupModelInfo(context.Background(), "gpt-5.3-codex-spark")
+	if !ok {
+		t.Fatal("expected hit on gpt-5.3-codex-spark")
+	}
+	if info.ContextWindow != 128000 {
+		t.Errorf("ContextWindow = %d, want 128000", info.ContextWindow)
+	}
+}
+
+func TestClient_LookupModelInfoNormalizesModelID(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "models-dev.json")
+	c, _ := newTestClient(t, cachePath)
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	info, ok := c.LookupModelInfo(context.Background(), "github-copilot/gpt-5.4-mini/medium")
+	if !ok {
+		t.Fatal("expected hit on normalized gpt-5.4-mini")
+	}
+	if info.ContextWindow != 256000 {
+		t.Errorf("ContextWindow = %d, want 256000", info.ContextWindow)
+	}
+}
+
+func TestClient_LookupModelInfoMissesGracefully(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "models-dev.json")
+	c, _ := newTestClient(t, cachePath)
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	if _, ok := c.LookupModelInfo(context.Background(), "claude-opus-4-7"); ok {
+		t.Error("expected miss when model has no context limit")
+	}
+	if _, ok := c.LookupModelInfo(context.Background(), "gpt-unknown"); ok {
+		t.Error("expected miss on unknown model")
+	}
+	if _, ok := c.LookupModelInfo(context.Background(), "sonnet"); ok {
+		t.Error("expected miss on logical alias sonnet")
 	}
 }
 

--- a/apps/backend/internal/office/costs/modelsdev/client_test.go
+++ b/apps/backend/internal/office/costs/modelsdev/client_test.go
@@ -22,13 +22,15 @@ const sampleDataset = `{
       "claude-sonnet-4-5": {"cost": {"input": 3.0,   "output": 15.0, "cache_read": 0.3, "cache_write": 3.75}}
     }
   },
-  "openai": {
-    "models": {
-      "gpt-5-mini":     {"cost": {"input": 0.4,  "output": 1.6, "cache_read": 0.1, "cache_write": 0.5}},
-      "gpt-5.3-codex-spark": {"cost": {"input": 0.4, "output": 1.6}, "limit": {"context": 128000}},
-      "gpt-5.4-mini":   {"cost": {"input": 0.5,  "output": 2.0, "cache_read": 0.1, "cache_write": 0.6}, "limit": {"context": 256000}}
-    }
-  },
+	  "openai": {
+	    "models": {
+	      "gpt-5-mini":     {"cost": {"input": 0.4,  "output": 1.6, "cache_read": 0.1, "cache_write": 0.5}},
+	      "gpt-5.3-codex-spark": {"cost": {"input": 0.4, "output": 1.6}, "limit": {"context": 128000}},
+	      "gpt-5.4-zero": {"cost": {"input": 0.4, "output": 1.6}, "limit": {"context": 0}},
+	      "gpt.5-4.zero": {"cost": {"input": 0.4, "output": 1.6}, "limit": {"context": 64000}},
+	      "gpt-5.4-mini":   {"cost": {"input": 0.5,  "output": 2.0, "cache_read": 0.1, "cache_write": 0.6}, "limit": {"context": 256000}}
+	    }
+	  },
   "google": {
     "models": {
       "gemini-2.5-pro": {"cost": {"input": 1.25, "output": 10.0, "cache_read": 0.31, "cache_write": 1.56}}
@@ -164,6 +166,23 @@ func TestClient_LookupModelInfoNormalizesModelID(t *testing.T) {
 	}
 	if info.ContextWindow != 256000 {
 		t.Errorf("ContextWindow = %d, want 256000", info.ContextWindow)
+	}
+}
+
+func TestClient_LookupModelInfoTriesSwappedCandidateAfterZeroLimit(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "models-dev.json")
+	c, _ := newTestClient(t, cachePath)
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	info, ok := c.LookupModelInfo(context.Background(), "gpt-5.4-zero")
+	if !ok {
+		t.Fatal("expected fallback hit on swapped model id")
+	}
+	if info.ContextWindow != 64000 {
+		t.Errorf("ContextWindow = %d, want 64000", info.ContextWindow)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -386,14 +386,15 @@ func (s *Service) resolveContextWindowValues(ctx context.Context, data watcher.C
 	if data.ContextWindowSize > 0 {
 		return data.ContextWindowSize, data.ContextWindowRemaining, data.ContextEfficiency, true
 	}
-	if s.modelInfoLookup == nil {
+	lookup := s.currentModelInfoLookup()
+	if lookup == nil {
 		return 0, 0, 0, false
 	}
 	modelID := s.currentRuntimeModel(ctx, data.TaskSessionID)
 	if modelID == "" {
 		return 0, 0, 0, false
 	}
-	info, ok := s.modelInfoLookup.LookupModelInfo(ctx, modelID)
+	info, ok := lookup.LookupModelInfo(ctx, modelID)
 	if !ok || info.ContextWindow <= 0 {
 		return 0, 0, 0, false
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -407,6 +407,11 @@ func (s *Service) resolveContextWindowValues(ctx context.Context, data watcher.C
 }
 
 func (s *Service) currentRuntimeModel(ctx context.Context, sessionID string) string {
+	if model, ok := s.runtimeModelBySession.Load(sessionID); ok {
+		if modelID, _ := model.(string); modelID != "" {
+			return modelID
+		}
+	}
 	session, err := s.repo.GetTaskSession(ctx, sessionID)
 	if err != nil || session == nil {
 		return ""

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -338,11 +338,16 @@ func (s *Service) handleContextWindowUpdated(ctx context.Context, data watcher.C
 		return
 	}
 
+	size, remaining, efficiency, ok := s.resolveContextWindowValues(ctx, data)
+	if !ok {
+		return
+	}
+
 	contextWindowData := map[string]interface{}{
-		"size":       data.ContextWindowSize,
+		"size":       size,
 		"used":       data.ContextWindowUsed,
-		"remaining":  data.ContextWindowRemaining,
-		"efficiency": data.ContextEfficiency,
+		"remaining":  remaining,
+		"efficiency": efficiency,
 	}
 
 	// Persist to database asynchronously using json_set to atomically set one
@@ -375,6 +380,48 @@ func (s *Service) handleContextWindowUpdated(ctx context.Context, data watcher.C
 			},
 		))
 	}
+}
+
+func (s *Service) resolveContextWindowValues(ctx context.Context, data watcher.ContextWindowData) (int64, int64, float64, bool) {
+	if data.ContextWindowSize > 0 {
+		return data.ContextWindowSize, data.ContextWindowRemaining, data.ContextEfficiency, true
+	}
+	if s.modelInfoLookup == nil {
+		return 0, 0, 0, false
+	}
+	modelID := s.currentRuntimeModel(ctx, data.TaskSessionID)
+	if modelID == "" {
+		return 0, 0, 0, false
+	}
+	info, ok := s.modelInfoLookup.LookupModelInfo(ctx, modelID)
+	if !ok || info.ContextWindow <= 0 {
+		return 0, 0, 0, false
+	}
+	remaining := info.ContextWindow - data.ContextWindowUsed
+	if remaining < 0 {
+		remaining = 0
+	}
+	efficiency := 0.0
+	if info.ContextWindow > 0 {
+		efficiency = float64(data.ContextWindowUsed) / float64(info.ContextWindow) * 100
+	}
+	return info.ContextWindow, remaining, efficiency, true
+}
+
+func (s *Service) currentRuntimeModel(ctx context.Context, sessionID string) string {
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil || session == nil {
+		return ""
+	}
+	if cfg, ok := models.LoadSessionRuntimeConfig(session.Metadata); ok && cfg.Model != "" {
+		return cfg.Model
+	}
+	if session.AgentProfileSnapshot != nil {
+		if model, ok := session.AgentProfileSnapshot["model"].(string); ok {
+			return model
+		}
+	}
+	return ""
 }
 
 // handlePermissionRequest handles permission request events and saves as message

--- a/apps/backend/internal/orchestrator/event_handlers_git.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git.go
@@ -402,10 +402,7 @@ func (s *Service) resolveContextWindowValues(ctx context.Context, data watcher.C
 	if remaining < 0 {
 		remaining = 0
 	}
-	efficiency := 0.0
-	if info.ContextWindow > 0 {
-		efficiency = float64(data.ContextWindowUsed) / float64(info.ContextWindow) * 100
-	}
+	efficiency := float64(data.ContextWindowUsed) / float64(info.ContextWindow) * 100
 	return info.ContextWindow, remaining, efficiency, true
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_git_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git_test.go
@@ -289,6 +289,23 @@ func TestResolveContextWindowValues(t *testing.T) {
 		require.Equal(t, 50.0, efficiency)
 	})
 
+	t.Run("models.dev fallback uses cached runtime model before session load", func(t *testing.T) {
+		svc := &Service{
+			modelInfoLookup: fakeModelInfoLookup{info: modelsdev.ModelInfo{ContextWindow: 96000}, ok: true},
+		}
+		svc.runtimeModelBySession.Store("s1", "gpt-5.3-codex-spark")
+		size, remaining, efficiency, ok := svc.resolveContextWindowValues(ctx, watcher.ContextWindowData{
+			TaskID:            base.TaskID,
+			TaskSessionID:     base.TaskSessionID,
+			ContextWindowUsed: 24000,
+		})
+
+		require.True(t, ok)
+		require.Equal(t, int64(96000), size)
+		require.Equal(t, int64(72000), remaining)
+		require.Equal(t, 25.0, efficiency)
+	})
+
 	t.Run("lookup miss hides context window", func(t *testing.T) {
 		svc := &Service{repo: repo, modelInfoLookup: fakeModelInfoLookup{}}
 		_, _, _, ok := svc.resolveContextWindowValues(ctx, watcher.ContextWindowData{

--- a/apps/backend/internal/orchestrator/event_handlers_git_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_git_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/github"
+	"github.com/kandev/kandev/internal/office/costs/modelsdev"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 )
@@ -225,4 +228,75 @@ func TestPushTrackerForget(t *testing.T) {
 			t.Errorf("expected %q to survive (different session)", k)
 		}
 	}
+}
+
+type fakeModelInfoLookup struct {
+	info modelsdev.ModelInfo
+	ok   bool
+}
+
+func (f fakeModelInfoLookup) LookupModelInfo(context.Context, string) (modelsdev.ModelInfo, bool) {
+	return f.info, f.ok
+}
+
+func TestResolveContextWindowValues(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	require.NoError(t, repo.SetSessionMetadataKey(ctx, "s1", models.SessionMetaKeyRuntimeConfig, models.SessionRuntimeConfig{
+		Model: "gpt-5.3-codex-spark",
+	}))
+
+	base := watcher.ContextWindowData{
+		TaskID:        "t1",
+		TaskSessionID: "s1",
+	}
+
+	t.Run("positive ACP size wins", func(t *testing.T) {
+		svc := &Service{
+			repo:            repo,
+			modelInfoLookup: fakeModelInfoLookup{info: modelsdev.ModelInfo{ContextWindow: 128000}, ok: true},
+		}
+		size, remaining, efficiency, ok := svc.resolveContextWindowValues(ctx, watcher.ContextWindowData{
+			TaskID:                 base.TaskID,
+			TaskSessionID:          base.TaskSessionID,
+			ContextWindowSize:      258400,
+			ContextWindowUsed:      100000,
+			ContextWindowRemaining: 158400,
+			ContextEfficiency:      38.7,
+		})
+
+		require.True(t, ok)
+		require.Equal(t, int64(258400), size)
+		require.Equal(t, int64(158400), remaining)
+		require.Equal(t, 38.7, efficiency)
+	})
+
+	t.Run("models.dev fallback supplies missing ACP size", func(t *testing.T) {
+		svc := &Service{
+			repo:            repo,
+			modelInfoLookup: fakeModelInfoLookup{info: modelsdev.ModelInfo{ContextWindow: 128000}, ok: true},
+		}
+		size, remaining, efficiency, ok := svc.resolveContextWindowValues(ctx, watcher.ContextWindowData{
+			TaskID:            base.TaskID,
+			TaskSessionID:     base.TaskSessionID,
+			ContextWindowUsed: 64000,
+		})
+
+		require.True(t, ok)
+		require.Equal(t, int64(128000), size)
+		require.Equal(t, int64(64000), remaining)
+		require.Equal(t, 50.0, efficiency)
+	})
+
+	t.Run("lookup miss hides context window", func(t *testing.T) {
+		svc := &Service{repo: repo, modelInfoLookup: fakeModelInfoLookup{}}
+		_, _, _, ok := svc.resolveContextWindowValues(ctx, watcher.ContextWindowData{
+			TaskID:            base.TaskID,
+			TaskSessionID:     base.TaskSessionID,
+			ContextWindowUsed: 64000,
+		})
+
+		require.False(t, ok)
+	})
 }

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -1090,7 +1090,13 @@ func (s *Service) persistSessionModel(ctx context.Context, sessionID, model stri
 
 func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, model, mode string, options []streams.ConfigOption) {
 	session, err := s.repo.GetTaskSession(ctx, sessionID)
-	if err != nil || session == nil {
+	if err != nil {
+		s.logger.Warn("failed to load session for runtime config persistence",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return
+	}
+	if session == nil {
 		return
 	}
 	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
@@ -1116,9 +1122,20 @@ func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, mo
 	if cfg.IsZero() {
 		return
 	}
-	_ = s.repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyRuntimeConfig, cfg)
+	if err := s.repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyRuntimeConfig, cfg); err != nil {
+		s.logger.Warn("failed to persist session runtime config",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return
+	}
 	if cfg.Model != "" && previousModel != "" && cfg.Model != previousModel {
-		_ = s.repo.SetSessionMetadataKey(ctx, sessionID, "context_window", nil)
+		if err := s.repo.SetSessionMetadataKey(ctx, sessionID, "context_window", nil); err != nil {
+			s.logger.Warn("failed to clear stale context window after runtime model change",
+				zap.String("session_id", sessionID),
+				zap.String("previous_model", previousModel),
+				zap.String("model", cfg.Model),
+				zap.Error(err))
+		}
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -1101,24 +1101,7 @@ func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, mo
 	}
 	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
 	previousModel := cfg.Model
-	if model != "" {
-		cfg.Model = model
-	}
-	if mode != "" {
-		cfg.Mode = mode
-	}
-	for _, option := range options {
-		if option.ID == "" || option.CurrentValue == "" {
-			continue
-		}
-		if cfg.ConfigOptions == nil {
-			cfg.ConfigOptions = make(map[string]string)
-		}
-		cfg.ConfigOptions[option.ID] = option.CurrentValue
-		if option.ID == "model" || option.Category == "model" {
-			cfg.Model = option.CurrentValue
-		}
-	}
+	applySessionRuntimeConfigUpdate(&cfg, model, mode, options)
 	if cfg.IsZero() {
 		return
 	}
@@ -1136,6 +1119,27 @@ func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, mo
 				zap.String("previous_model", previousModel),
 				zap.String("model", cfg.Model),
 				zap.Error(err))
+		}
+	}
+}
+
+func applySessionRuntimeConfigUpdate(cfg *models.SessionRuntimeConfig, model, mode string, options []streams.ConfigOption) {
+	if model != "" {
+		cfg.Model = model
+	}
+	if mode != "" {
+		cfg.Mode = mode
+	}
+	for _, option := range options {
+		if option.ID == "" || option.CurrentValue == "" {
+			continue
+		}
+		if cfg.ConfigOptions == nil {
+			cfg.ConfigOptions = make(map[string]string)
+		}
+		cfg.ConfigOptions[option.ID] = option.CurrentValue
+		if option.ID == "model" || option.Category == "model" {
+			cfg.Model = option.CurrentValue
 		}
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -1122,14 +1122,15 @@ func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, mo
 	if cfg.IsZero() {
 		return
 	}
-	if err := s.repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyRuntimeConfig, cfg); err != nil {
+	writeCtx := context.WithoutCancel(ctx)
+	if err := s.repo.SetSessionMetadataKey(writeCtx, sessionID, models.SessionMetaKeyRuntimeConfig, cfg); err != nil {
 		s.logger.Warn("failed to persist session runtime config",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 		return
 	}
-	if cfg.Model != "" && previousModel != "" && cfg.Model != previousModel {
-		if err := s.repo.SetSessionMetadataKey(ctx, sessionID, "context_window", nil); err != nil {
+	if cfg.Model != "" && cfg.Model != previousModel {
+		if err := s.repo.SetSessionMetadataKey(writeCtx, sessionID, "context_window", nil); err != nil {
 			s.logger.Warn("failed to clear stale context window after runtime model change",
 				zap.String("session_id", sessionID),
 				zap.String("previous_model", previousModel),

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -999,6 +999,7 @@ func (s *Service) persistSessionMode(ctx context.Context, sessionID, modeID stri
 			zap.String("mode", modeID),
 			zap.Error(err))
 	}
+	s.persistSessionRuntimeConfig(ctx, sessionID, "", modeID, nil)
 }
 
 // handleAgentCapabilitiesEvent broadcasts agent_capabilities events to the WebSocket.
@@ -1034,6 +1035,7 @@ func (s *Service) handleSessionModelsEvent(ctx context.Context, payload *lifecyc
 	// selector trigger with the right value on a page reload instead of
 	// flashing the profile default before the WS catches up.
 	s.persistSessionModel(ctx, sessionID, payload.Data.CurrentModelID)
+	s.persistSessionRuntimeConfig(ctx, sessionID, payload.Data.CurrentModelID, "", payload.Data.ConfigOptions)
 
 	eventPayload := lifecycle.SessionModelsEventPayload{
 		TaskID:         payload.TaskID,
@@ -1083,6 +1085,40 @@ func (s *Service) persistSessionModel(ctx context.Context, sessionID, model stri
 	// Invalidate the message creator's model cache so subsequent messages use the new model.
 	if s.messageCreator != nil {
 		s.messageCreator.InvalidateModelCache(sessionID)
+	}
+}
+
+func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, model, mode string, options []streams.ConfigOption) {
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil || session == nil {
+		return
+	}
+	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
+	previousModel := cfg.Model
+	if model != "" {
+		cfg.Model = model
+	}
+	if mode != "" {
+		cfg.Mode = mode
+	}
+	for _, option := range options {
+		if option.ID == "" || option.CurrentValue == "" {
+			continue
+		}
+		if cfg.ConfigOptions == nil {
+			cfg.ConfigOptions = make(map[string]string)
+		}
+		cfg.ConfigOptions[option.ID] = option.CurrentValue
+		if option.ID == "model" || option.Category == "model" {
+			cfg.Model = option.CurrentValue
+		}
+	}
+	if cfg.IsZero() {
+		return
+	}
+	_ = s.repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyRuntimeConfig, cfg)
+	if cfg.Model != "" && previousModel != "" && cfg.Model != previousModel {
+		_ = s.repo.SetSessionMetadataKey(ctx, sessionID, "context_window", nil)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -1034,8 +1034,7 @@ func (s *Service) handleSessionModelsEvent(ctx context.Context, payload *lifecyc
 	// Persist the agent-reported current model so SSR can render the model
 	// selector trigger with the right value on a page reload instead of
 	// flashing the profile default before the WS catches up.
-	s.persistSessionModel(ctx, sessionID, payload.Data.CurrentModelID)
-	s.persistSessionRuntimeConfig(ctx, sessionID, payload.Data.CurrentModelID, "", payload.Data.ConfigOptions)
+	s.persistSessionModelAndRuntimeConfig(ctx, sessionID, payload.Data.CurrentModelID, "", payload.Data.ConfigOptions)
 
 	eventPayload := lifecycle.SessionModelsEventPayload{
 		TaskID:         payload.TaskID,
@@ -1074,18 +1073,24 @@ func (s *Service) persistSessionModel(ctx context.Context, sessionID, model stri
 	if err != nil {
 		return
 	}
-	if session.AgentProfileSnapshot == nil {
-		session.AgentProfileSnapshot = make(map[string]interface{})
-	}
-	if existing, _ := session.AgentProfileSnapshot["model"].(string); existing == model {
+	s.persistSessionModelOnSession(ctx, sessionID, session, model)
+}
+
+func (s *Service) persistSessionModelAndRuntimeConfig(ctx context.Context, sessionID, model, mode string, options []streams.ConfigOption) {
+	session, err := s.repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		s.logger.Warn("failed to load session for session model persistence",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
 		return
 	}
-	session.AgentProfileSnapshot["model"] = model
-	_ = s.repo.UpdateTaskSession(ctx, session)
-	// Invalidate the message creator's model cache so subsequent messages use the new model.
-	if s.messageCreator != nil {
-		s.messageCreator.InvalidateModelCache(sessionID)
+	if session == nil {
+		return
 	}
+	if model != "" {
+		s.persistSessionModelOnSession(ctx, sessionID, session, model)
+	}
+	s.persistSessionRuntimeConfigOnSession(ctx, sessionID, session, model, mode, options)
 }
 
 func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, model, mode string, options []streams.ConfigOption) {
@@ -1099,6 +1104,10 @@ func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, mo
 	if session == nil {
 		return
 	}
+	s.persistSessionRuntimeConfigOnSession(ctx, sessionID, session, model, mode, options)
+}
+
+func (s *Service) persistSessionRuntimeConfigOnSession(ctx context.Context, sessionID string, session *models.TaskSession, model, mode string, options []streams.ConfigOption) {
 	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
 	previousModel := cfg.Model
 	applySessionRuntimeConfigUpdate(&cfg, model, mode, options)
@@ -1112,6 +1121,9 @@ func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, mo
 			zap.Error(err))
 		return
 	}
+	if cfg.Model != "" {
+		s.runtimeModelBySession.Store(sessionID, cfg.Model)
+	}
 	if cfg.Model != "" && cfg.Model != previousModel {
 		if err := s.repo.SetSessionMetadataKey(writeCtx, sessionID, "context_window", nil); err != nil {
 			s.logger.Warn("failed to clear stale context window after runtime model change",
@@ -1120,6 +1132,21 @@ func (s *Service) persistSessionRuntimeConfig(ctx context.Context, sessionID, mo
 				zap.String("model", cfg.Model),
 				zap.Error(err))
 		}
+	}
+}
+
+func (s *Service) persistSessionModelOnSession(ctx context.Context, sessionID string, session *models.TaskSession, model string) {
+	if session.AgentProfileSnapshot == nil {
+		session.AgentProfileSnapshot = make(map[string]interface{})
+	}
+	if existing, _ := session.AgentProfileSnapshot["model"].(string); existing == model {
+		return
+	}
+	session.AgentProfileSnapshot["model"] = model
+	_ = s.repo.UpdateTaskSession(ctx, session)
+	// Invalidate the message creator's model cache so subsequent messages use the new model.
+	if s.messageCreator != nil {
+		s.messageCreator.InvalidateModelCache(sessionID)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -513,3 +513,26 @@ func TestPersistSessionRuntimeConfigFromSessionModels(t *testing.T) {
 		"reasoning_effort": "low",
 	}, cfg.ConfigOptions)
 }
+
+func TestPersistSessionModelAndRuntimeConfigPersistsSnapshotRuntimeConfigAndCache(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	require.NoError(t, repo.SetSessionMetadataKey(ctx, "s1", "context_window", map[string]interface{}{"size": int64(256000)}))
+	svc := &Service{logger: testLogger(), repo: repo}
+
+	svc.persistSessionModelAndRuntimeConfig(ctx, "s1", "gpt-5.3-codex-spark", "", []streams.ConfigOption{
+		{ID: "reasoning_effort", Category: "thought_level", CurrentValue: "low"},
+	})
+
+	updated, err := repo.GetTaskSession(ctx, "s1")
+	require.NoError(t, err)
+	require.Equal(t, "gpt-5.3-codex-spark", updated.AgentProfileSnapshot["model"])
+	cfg, ok := models.LoadSessionRuntimeConfig(updated.Metadata)
+	require.True(t, ok)
+	require.Equal(t, "gpt-5.3-codex-spark", cfg.Model)
+	require.Equal(t, "low", cfg.ConfigOptions["reasoning_effort"])
+	require.Nil(t, updated.Metadata["context_window"])
+	model, _ := svc.runtimeModelBySession.Load("s1")
+	require.Equal(t, "gpt-5.3-codex-spark", model)
+}

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -491,3 +491,25 @@ func TestPersistSessionModel(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "gpt-5.4", preserved.AgentProfileSnapshot["model"])
 }
+
+func TestPersistSessionRuntimeConfigFromSessionModels(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "t1", "s1", "step1")
+	svc := &Service{logger: testLogger(), repo: repo}
+
+	svc.persistSessionRuntimeConfig(ctx, "s1", "gpt-5.3-codex-spark", "", []streams.ConfigOption{
+		{ID: "model", Category: "model", CurrentValue: "gpt-5.3-codex-spark"},
+		{ID: "reasoning_effort", Category: "thought_level", CurrentValue: "low"},
+	})
+
+	updated, err := repo.GetTaskSession(ctx, "s1")
+	require.NoError(t, err)
+	cfg, ok := models.LoadSessionRuntimeConfig(updated.Metadata)
+	require.True(t, ok)
+	require.Equal(t, "gpt-5.3-codex-spark", cfg.Model)
+	require.Equal(t, map[string]string{
+		"model":            "gpt-5.3-codex-spark",
+		"reasoning_effort": "low",
+	}, cfg.ConfigOptions)
+}

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -208,8 +208,14 @@ type mockAgentManager struct {
 	// returned to simulate "no running agent".
 	setSessionModeCalls      []sessionModeCall
 	setSessionModeErr        error
+	setSessionModelCalls     []sessionModelCall
 	setSessionModelSupported bool
 	setSessionModelErr       error
+}
+
+type sessionModelCall struct {
+	SessionID string
+	ModelID   string
 }
 
 type sessionModeCall struct {
@@ -323,10 +329,13 @@ func (m *mockAgentManager) SetExecutionDescription(_ context.Context, _, _ strin
 func (m *mockAgentManager) SetExecutionEnv(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
-func (m *mockAgentManager) SetSessionModelBySessionID(_ context.Context, _, _ string) error {
+func (m *mockAgentManager) SetSessionModelBySessionID(_ context.Context, sessionID, modelID string) error {
 	if !m.setSessionModelSupported {
 		return fmt.Errorf("not supported")
 	}
+	m.mu.Lock()
+	m.setSessionModelCalls = append(m.setSessionModelCalls, sessionModelCall{SessionID: sessionID, ModelID: modelID})
+	m.mu.Unlock()
 	if m.setSessionModelErr != nil {
 		return m.setSessionModelErr
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -206,8 +206,10 @@ type mockAgentManager struct {
 	// set_session_mode tracking (issue #1183). Records (sessionID, modeID) for
 	// every SetSessionModeBySessionID call. setSessionModeErr, when set, is
 	// returned to simulate "no running agent".
-	setSessionModeCalls []sessionModeCall
-	setSessionModeErr   error
+	setSessionModeCalls      []sessionModeCall
+	setSessionModeErr        error
+	setSessionModelSupported bool
+	setSessionModelErr       error
 }
 
 type sessionModeCall struct {
@@ -322,7 +324,13 @@ func (m *mockAgentManager) SetExecutionEnv(_ context.Context, _ string, _ map[st
 	return nil
 }
 func (m *mockAgentManager) SetSessionModelBySessionID(_ context.Context, _, _ string) error {
-	return fmt.Errorf("not supported")
+	if !m.setSessionModelSupported {
+		return fmt.Errorf("not supported")
+	}
+	if m.setSessionModelErr != nil {
+		return m.setSessionModelErr
+	}
+	return nil
 }
 func (m *mockAgentManager) SetSessionModeBySessionID(_ context.Context, sessionID, modeID string) error {
 	m.mu.Lock()

--- a/apps/backend/internal/orchestrator/executor/executor.go
+++ b/apps/backend/internal/orchestrator/executor/executor.go
@@ -30,6 +30,7 @@ type executorStore interface {
 	// Session
 	CreateTaskSession(ctx context.Context, session *models.TaskSession) error
 	GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error)
+	SetSessionMetadataKey(ctx context.Context, sessionID, key string, value interface{}) error
 	UpdateTaskSession(ctx context.Context, session *models.TaskSession) error
 	UpdateTaskSessionState(ctx context.Context, id string, state models.TaskSessionState, errorMessage string) error
 	UpdateTaskSessionBaseCommit(ctx context.Context, id string, baseCommitSHA string) error

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -446,6 +446,7 @@ func (e *Executor) persistModelSwitchState(ctx context.Context, taskID, sessionI
 		session.AgentProfileSnapshot = make(map[string]interface{})
 	}
 	session.AgentProfileSnapshot["model"] = newModel
+	persistRuntimeModelOnSession(session, newModel)
 
 	if err := e.repo.UpdateTaskSession(ctx, session); err != nil {
 		e.logger.Error("failed to update session after model switch",
@@ -469,11 +470,22 @@ func (e *Executor) persistInPlaceModelSwitch(ctx context.Context, sessionID, new
 		session.AgentProfileSnapshot = make(map[string]interface{})
 	}
 	session.AgentProfileSnapshot["model"] = newModel
+	persistRuntimeModelOnSession(session, newModel)
 	if err := e.repo.UpdateTaskSession(ctx, session); err != nil {
 		e.logger.Warn("failed to persist in-place model switch",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 	}
+}
+
+func persistRuntimeModelOnSession(session *models.TaskSession, modelID string) {
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]interface{})
+	}
+	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
+	cfg.Model = modelID
+	session.Metadata[models.SessionMetaKeyRuntimeConfig] = cfg
+	session.Metadata["context_window"] = nil
 }
 
 // RespondToPermission sends a response to a permission request for a session

--- a/apps/backend/internal/orchestrator/executor/executor_interaction.go
+++ b/apps/backend/internal/orchestrator/executor/executor_interaction.go
@@ -446,14 +446,15 @@ func (e *Executor) persistModelSwitchState(ctx context.Context, taskID, sessionI
 		session.AgentProfileSnapshot = make(map[string]interface{})
 	}
 	session.AgentProfileSnapshot["model"] = newModel
-	persistRuntimeModelOnSession(session, newModel)
 
 	if err := e.repo.UpdateTaskSession(ctx, session); err != nil {
 		e.logger.Error("failed to update session after model switch",
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
 			zap.Error(err))
+		return
 	}
+	e.persistRuntimeModelMetadata(ctx, sessionID, session, newModel)
 }
 
 // persistInPlaceModelSwitch updates the session snapshot model after a successful
@@ -470,22 +471,32 @@ func (e *Executor) persistInPlaceModelSwitch(ctx context.Context, sessionID, new
 		session.AgentProfileSnapshot = make(map[string]interface{})
 	}
 	session.AgentProfileSnapshot["model"] = newModel
-	persistRuntimeModelOnSession(session, newModel)
 	if err := e.repo.UpdateTaskSession(ctx, session); err != nil {
 		e.logger.Warn("failed to persist in-place model switch",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
+		return
 	}
+	e.persistRuntimeModelMetadata(ctx, sessionID, session, newModel)
 }
 
-func persistRuntimeModelOnSession(session *models.TaskSession, modelID string) {
-	if session.Metadata == nil {
-		session.Metadata = make(map[string]interface{})
-	}
+func (e *Executor) persistRuntimeModelMetadata(ctx context.Context, sessionID string, session *models.TaskSession, modelID string) {
 	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
 	cfg.Model = modelID
-	session.Metadata[models.SessionMetaKeyRuntimeConfig] = cfg
-	session.Metadata["context_window"] = nil
+	writeCtx := context.WithoutCancel(ctx)
+	if err := e.repo.SetSessionMetadataKey(writeCtx, sessionID, models.SessionMetaKeyRuntimeConfig, cfg); err != nil {
+		e.logger.Warn("failed to persist runtime model after model switch",
+			zap.String("session_id", sessionID),
+			zap.String("model", modelID),
+			zap.Error(err))
+		return
+	}
+	if err := e.repo.SetSessionMetadataKey(writeCtx, sessionID, "context_window", nil); err != nil {
+		e.logger.Warn("failed to clear context window after model switch",
+			zap.String("session_id", sessionID),
+			zap.String("model", modelID),
+			zap.Error(err))
+	}
 }
 
 // RespondToPermission sends a response to a permission request for a session

--- a/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_mocks_test.go
@@ -249,9 +249,16 @@ type mockRepository struct {
 	// Track calls for verification
 	createTaskSessionCalls     []*models.TaskSession
 	updateTaskSessionCalls     []*models.TaskSession
+	setSessionMetadataKeyCalls []setSessionMetadataKeyCall
 	setSessionPrimaryCalls     []string
 	createTaskEnvironmentCalls []*models.TaskEnvironment
 	updateTaskEnvironmentCalls []*models.TaskEnvironment
+}
+
+type setSessionMetadataKeyCall struct {
+	SessionID string
+	Key       string
+	Value     interface{}
 }
 
 func newMockRepository() *mockRepository {
@@ -608,6 +615,21 @@ func (m *mockRepository) UpdateSessionMetadata(ctx context.Context, sessionID st
 	return nil
 }
 func (m *mockRepository) SetSessionMetadataKey(ctx context.Context, sessionID, key string, value interface{}) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setSessionMetadataKeyCalls = append(m.setSessionMetadataKeyCalls, setSessionMetadataKeyCall{
+		SessionID: sessionID,
+		Key:       key,
+		Value:     value,
+	})
+	session := m.sessions[sessionID]
+	if session == nil {
+		return nil
+	}
+	if session.Metadata == nil {
+		session.Metadata = make(map[string]interface{})
+	}
+	session.Metadata[key] = value
 	return nil
 }
 func (m *mockRepository) GetLastAgentMessage(_ context.Context, _ string) (string, error) {

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -61,6 +61,46 @@ func TestPrepareSession_Success(t *testing.T) {
 	}
 }
 
+func TestPersistRuntimeModelMetadataStoresRuntimeConfigAndClearsContextWindow(t *testing.T) {
+	repo := newMockRepository()
+	exec := newTestExecutor(t, &mockAgentManager{}, repo)
+	session := &models.TaskSession{
+		ID:     "session-123",
+		TaskID: "task-123",
+		Metadata: map[string]interface{}{
+			models.SessionMetaKeyRuntimeConfig: models.SessionRuntimeConfig{
+				Mode:          "fast",
+				ConfigOptions: map[string]string{"reasoning_effort": "low"},
+			},
+			"context_window": map[string]interface{}{"size": int64(256000)},
+		},
+	}
+	repo.sessions[session.ID] = session
+
+	exec.persistRuntimeModelMetadata(context.Background(), session.ID, session, "gpt-5.3-codex-spark")
+
+	updated := repo.sessions[session.ID]
+	cfg, ok := models.LoadSessionRuntimeConfig(updated.Metadata)
+	if !ok {
+		t.Fatal("expected runtime config metadata")
+	}
+	if cfg.Model != "gpt-5.3-codex-spark" {
+		t.Fatalf("expected runtime model to be persisted, got %q", cfg.Model)
+	}
+	if cfg.Mode != "fast" {
+		t.Fatalf("expected mode to be preserved, got %q", cfg.Mode)
+	}
+	if cfg.ConfigOptions["reasoning_effort"] != "low" {
+		t.Fatalf("expected config options to be preserved, got %#v", cfg.ConfigOptions)
+	}
+	if updated.Metadata["context_window"] != nil {
+		t.Fatalf("expected context_window to be cleared, got %#v", updated.Metadata["context_window"])
+	}
+	if len(repo.setSessionMetadataKeyCalls) != 2 {
+		t.Fatalf("expected runtime config and context window metadata writes, got %d", len(repo.setSessionMetadataKeyCalls))
+	}
+}
+
 func TestPrepareSession_InvokesPrimarySessionCallback(t *testing.T) {
 	repo := newMockRepository()
 	agentManager := &mockAgentManager{}

--- a/apps/backend/internal/orchestrator/model_info.go
+++ b/apps/backend/internal/orchestrator/model_info.go
@@ -15,5 +15,13 @@ type ModelInfoLookup interface {
 // SetModelInfoLookup wires optional models.dev metadata lookup for
 // context-window fallback. Nil means ACP-only behavior.
 func (s *Service) SetModelInfoLookup(lookup ModelInfoLookup) {
+	s.modelInfoMu.Lock()
+	defer s.modelInfoMu.Unlock()
 	s.modelInfoLookup = lookup
+}
+
+func (s *Service) currentModelInfoLookup() ModelInfoLookup {
+	s.modelInfoMu.RLock()
+	defer s.modelInfoMu.RUnlock()
+	return s.modelInfoLookup
 }

--- a/apps/backend/internal/orchestrator/model_info.go
+++ b/apps/backend/internal/orchestrator/model_info.go
@@ -1,0 +1,19 @@
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/kandev/kandev/internal/office/costs/modelsdev"
+)
+
+// ModelInfoLookup resolves optional model metadata from the existing
+// models.dev cache client.
+type ModelInfoLookup interface {
+	LookupModelInfo(ctx context.Context, modelID string) (modelsdev.ModelInfo, bool)
+}
+
+// SetModelInfoLookup wires optional models.dev metadata lookup for
+// context-window fallback. Nil means ACP-only behavior.
+func (s *Service) SetModelInfoLookup(lookup ModelInfoLookup) {
+	s.modelInfoLookup = lookup
+}

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -290,8 +290,9 @@ type Service struct {
 	profileLookup ProfileLookup
 	// modelInfoLookup resolves optional model metadata from models.dev. Nil-safe;
 	// ACP context-window events remain authoritative when they include a size.
-	modelInfoMu     sync.RWMutex
-	modelInfoLookup ModelInfoLookup
+	modelInfoMu           sync.RWMutex
+	modelInfoLookup       ModelInfoLookup
+	runtimeModelBySession sync.Map
 
 	// Jira service for issue watch dedup operations
 	jiraService JiraService

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -290,6 +290,7 @@ type Service struct {
 	profileLookup ProfileLookup
 	// modelInfoLookup resolves optional model metadata from models.dev. Nil-safe;
 	// ACP context-window events remain authoritative when they include a size.
+	modelInfoMu     sync.RWMutex
 	modelInfoLookup ModelInfoLookup
 
 	// Jira service for issue watch dedup operations

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -288,6 +288,9 @@ type Service struct {
 	// dispatch pre-flight. Set via SetProfileLookup from main; nil-safe so
 	// the legacy code path (and tests without profile wiring) keep working.
 	profileLookup ProfileLookup
+	// modelInfoLookup resolves optional model metadata from models.dev. Nil-safe;
+	// ACP context-window events remain authoritative when they include a size.
+	modelInfoLookup ModelInfoLookup
 
 	// Jira service for issue watch dedup operations
 	jiraService JiraService

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2136,6 +2136,7 @@ func (s *Service) trySwitchModel(ctx context.Context, taskID, sessionID, model, 
 	if err != nil {
 		return nil, true, fmt.Errorf("model switch failed: %w", err)
 	}
+	s.runtimeModelBySession.Store(sessionID, model)
 	if switchResult.StopReason == "model_switched_in_place" {
 		// Agent is still running with the new model — let PromptTask send the prompt normally.
 		// Invalidate the message creator's model cache so the next message picks up the new model.

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -114,6 +114,12 @@ func TestTrySwitchModelUpdatesRuntimeModelCache(t *testing.T) {
 	if result != nil {
 		t.Fatalf("expected nil prompt result for in-place switch, got %#v", result)
 	}
+	if len(agentMgr.setSessionModelCalls) != 1 {
+		t.Fatalf("expected one model switch call, got %d", len(agentMgr.setSessionModelCalls))
+	}
+	if agentMgr.setSessionModelCalls[0] != (sessionModelCall{SessionID: "session1", ModelID: "gpt-5.3-codex-spark"}) {
+		t.Fatalf("unexpected model switch call: %#v", agentMgr.setSessionModelCalls[0])
+	}
 	cached, ok := svc.runtimeModelBySession.Load("session1")
 	if !ok {
 		t.Fatal("expected runtime model cache entry")

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -83,6 +83,46 @@ func TestPromptTask_SessionAlreadyRunning(t *testing.T) {
 	}
 }
 
+func TestTrySwitchModelUpdatesRuntimeModelCache(t *testing.T) {
+	repo := setupTestRepo(t)
+	agentMgr := &mockAgentManager{
+		isAgentRunning:           true,
+		setSessionModelSupported: true,
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+	session, err := repo.GetTaskSession(context.Background(), "session1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	session.AgentProfileSnapshot = map[string]interface{}{"model": "gpt-5.5"}
+	seedExecutorRunning(t, repo, session.ID, session.TaskID, "exec-1")
+	if err := repo.UpdateTaskSession(context.Background(), session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+	svc.runtimeModelBySession.Store("session1", "gpt-5.5")
+
+	result, switched, err := svc.trySwitchModel(context.Background(), "task1", "session1", "gpt-5.3-codex-spark", "continue", session)
+	if err != nil {
+		t.Fatalf("trySwitchModel returned error: %v", err)
+	}
+	if switched {
+		t.Fatal("in-place model switch should let prompt dispatch continue")
+	}
+	if result != nil {
+		t.Fatalf("expected nil prompt result for in-place switch, got %#v", result)
+	}
+	cached, ok := svc.runtimeModelBySession.Load("session1")
+	if !ok {
+		t.Fatal("expected runtime model cache entry")
+	}
+	if cached != "gpt-5.3-codex-spark" {
+		t.Fatalf("expected runtime model cache to update, got %#v", cached)
+	}
+}
+
 func TestPromptTask_TransientErrorDoesNotMoveTaskToReview(t *testing.T) {
 	repo := setupTestRepo(t)
 	taskRepo := newMockTaskRepo()

--- a/apps/backend/internal/task/handlers/process_handlers.go
+++ b/apps/backend/internal/task/handlers/process_handlers.go
@@ -497,12 +497,13 @@ func (h *ProcessHandlers) httpSetSessionMode(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.PersistSessionRuntimeMode(c.Request.Context(), sessionID, req.ModeID); err != nil {
+	writeCtx := context.WithoutCancel(c.Request.Context())
+	if err := h.service.PersistSessionRuntimeMode(writeCtx, sessionID, req.ModeID); err != nil {
 		h.logger.Error("failed to persist session mode",
 			zap.String("session_id", sessionID),
 			zap.String("mode_id", req.ModeID),
 			zap.Error(err))
-		c.JSON(500, gin.H{"error": err.Error()})
+		c.JSON(500, gin.H{"error": "failed to persist session runtime config"})
 		return
 	}
 	c.JSON(200, gin.H{"ok": true})
@@ -526,12 +527,13 @@ func (h *ProcessHandlers) httpSetSessionModel(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.PersistSessionRuntimeModel(c.Request.Context(), sessionID, req.ModelID); err != nil {
+	writeCtx := context.WithoutCancel(c.Request.Context())
+	if err := h.service.PersistSessionRuntimeModel(writeCtx, sessionID, req.ModelID); err != nil {
 		h.logger.Error("failed to persist session model",
 			zap.String("session_id", sessionID),
 			zap.String("model_id", req.ModelID),
 			zap.Error(err))
-		c.JSON(500, gin.H{"error": err.Error()})
+		c.JSON(500, gin.H{"error": "failed to persist session runtime config"})
 		return
 	}
 	c.JSON(200, gin.H{"ok": true})
@@ -556,12 +558,13 @@ func (h *ProcessHandlers) httpSetSessionConfigOption(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	if err := h.service.PersistSessionRuntimeConfigOption(c.Request.Context(), sessionID, req.ConfigID, req.Value); err != nil {
+	writeCtx := context.WithoutCancel(c.Request.Context())
+	if err := h.service.PersistSessionRuntimeConfigOption(writeCtx, sessionID, req.ConfigID, req.Value); err != nil {
 		h.logger.Error("failed to persist session config option",
 			zap.String("session_id", sessionID),
 			zap.String("config_id", req.ConfigID),
 			zap.Error(err))
-		c.JSON(500, gin.H{"error": err.Error()})
+		c.JSON(500, gin.H{"error": "failed to persist session runtime config"})
 		return
 	}
 	c.JSON(200, gin.H{"ok": true})

--- a/apps/backend/internal/task/handlers/process_handlers.go
+++ b/apps/backend/internal/task/handlers/process_handlers.go
@@ -497,6 +497,14 @@ func (h *ProcessHandlers) httpSetSessionMode(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
+	if err := h.service.PersistSessionRuntimeMode(c.Request.Context(), sessionID, req.ModeID); err != nil {
+		h.logger.Error("failed to persist session mode",
+			zap.String("session_id", sessionID),
+			zap.String("mode_id", req.ModeID),
+			zap.Error(err))
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
 	c.JSON(200, gin.H{"ok": true})
 }
 
@@ -512,6 +520,14 @@ func (h *ProcessHandlers) httpSetSessionModel(c *gin.Context) {
 	}
 	if err := h.lifecycleMgr.SetSessionModelBySessionID(c.Request.Context(), sessionID, req.ModelID); err != nil {
 		h.logger.Error("failed to set session model",
+			zap.String("session_id", sessionID),
+			zap.String("model_id", req.ModelID),
+			zap.Error(err))
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.service.PersistSessionRuntimeModel(c.Request.Context(), sessionID, req.ModelID); err != nil {
+		h.logger.Error("failed to persist session model",
 			zap.String("session_id", sessionID),
 			zap.String("model_id", req.ModelID),
 			zap.Error(err))
@@ -534,6 +550,14 @@ func (h *ProcessHandlers) httpSetSessionConfigOption(c *gin.Context) {
 	}
 	if err := h.lifecycleMgr.SetSessionConfigOptionBySessionID(c.Request.Context(), sessionID, req.ConfigID, req.Value); err != nil {
 		h.logger.Error("failed to set session config option",
+			zap.String("session_id", sessionID),
+			zap.String("config_id", req.ConfigID),
+			zap.Error(err))
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.service.PersistSessionRuntimeConfigOption(c.Request.Context(), sessionID, req.ConfigID, req.Value); err != nil {
+		h.logger.Error("failed to persist session config option",
 			zap.String("session_id", sessionID),
 			zap.String("config_id", req.ConfigID),
 			zap.Error(err))

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -76,6 +76,21 @@ const (
 // SSR reload, alongside the in-memory re-apply on context reset. See issue #1183.
 const SessionMetaKeySessionMode = "session_mode"
 
+// SessionMetaKeyRuntimeConfig records user-selected session runtime settings
+// (model, mode, and dynamic config options) separately from the immutable-ish
+// agent profile snapshot that seeded the session.
+const SessionMetaKeyRuntimeConfig = "runtime_config"
+
+// SessionRuntimeConfig is persisted under
+// TaskSession.Metadata[SessionMetaKeyRuntimeConfig]. It captures live ACP
+// settings chosen after session start so process resume can restore the same
+// model/config instead of reverting to profile defaults.
+type SessionRuntimeConfig struct {
+	Model         string            `json:"model,omitempty"`
+	Mode          string            `json:"mode,omitempty"`
+	ConfigOptions map[string]string `json:"config_options,omitempty"`
+}
+
 // SessionMetaKeyPendingStepCompletion stores the agent's (or manual fallback's)
 // step-complete signal under TaskSession.Metadata. ADR 0015: the orchestrator
 // reads this on turn-end for steps with AutoAdvanceRequiresSignal=true and
@@ -102,6 +117,58 @@ type PendingStepCompletionSignal struct {
 	Handoff    string    `json:"handoff,omitempty"`
 	Blockers   string    `json:"blockers,omitempty"`
 	SignaledAt time.Time `json:"signaled_at"`
+}
+
+// LoadSessionRuntimeConfig decodes the runtime-config bag entry from session
+// metadata. It tolerates both typed values and JSON-rehydrated maps.
+func LoadSessionRuntimeConfig(metadata map[string]interface{}) (SessionRuntimeConfig, bool) {
+	if metadata == nil {
+		return SessionRuntimeConfig{}, false
+	}
+	raw, ok := metadata[SessionMetaKeyRuntimeConfig]
+	if !ok || raw == nil {
+		return SessionRuntimeConfig{}, false
+	}
+	switch v := raw.(type) {
+	case SessionRuntimeConfig:
+		return v, !v.IsZero()
+	case map[string]string:
+		out := SessionRuntimeConfig{ConfigOptions: maps.Clone(v)}
+		return out, !out.IsZero()
+	case map[string]interface{}:
+		out := SessionRuntimeConfig{
+			Model: StringFromAny(v["model"]),
+			Mode:  StringFromAny(v["mode"]),
+		}
+		if opts := stringMapFromAny(v["config_options"]); len(opts) > 0 {
+			out.ConfigOptions = opts
+		}
+		return out, !out.IsZero()
+	default:
+		return SessionRuntimeConfig{}, false
+	}
+}
+
+// IsZero reports whether the runtime config carries any selected value.
+func (c SessionRuntimeConfig) IsZero() bool {
+	return c.Model == "" && c.Mode == "" && len(c.ConfigOptions) == 0
+}
+
+func stringMapFromAny(raw interface{}) map[string]string {
+	switch v := raw.(type) {
+	case map[string]string:
+		return maps.Clone(v)
+	case map[string]interface{}:
+		out := make(map[string]string, len(v))
+		for key, value := range v {
+			if str := StringFromAny(value); str != "" {
+				out[key] = str
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 // LoadPendingStepSignal decodes the pending-completion bag entry from a

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -133,7 +133,16 @@ func LoadSessionRuntimeConfig(metadata map[string]interface{}) (SessionRuntimeCo
 	case SessionRuntimeConfig:
 		return v, !v.IsZero()
 	case map[string]string:
-		out := SessionRuntimeConfig{ConfigOptions: maps.Clone(v)}
+		out := SessionRuntimeConfig{
+			Model:         v["model"],
+			Mode:          v["mode"],
+			ConfigOptions: maps.Clone(v),
+		}
+		delete(out.ConfigOptions, "model")
+		delete(out.ConfigOptions, "mode")
+		if len(out.ConfigOptions) == 0 {
+			out.ConfigOptions = nil
+		}
 		return out, !out.IsZero()
 	case map[string]interface{}:
 		out := SessionRuntimeConfig{

--- a/apps/backend/internal/task/models/models_test.go
+++ b/apps/backend/internal/task/models/models_test.go
@@ -8,6 +8,34 @@ import (
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
+func TestLoadSessionRuntimeConfigMapStringExtractsReservedKeys(t *testing.T) {
+	cfg, ok := LoadSessionRuntimeConfig(map[string]interface{}{
+		SessionMetaKeyRuntimeConfig: map[string]string{
+			"model":            "gpt-5.3-codex-spark",
+			"mode":             "acceptEdits",
+			"reasoning_effort": "low",
+		},
+	})
+	if !ok {
+		t.Fatal("expected runtime config")
+	}
+	if cfg.Model != "gpt-5.3-codex-spark" {
+		t.Fatalf("Model = %q", cfg.Model)
+	}
+	if cfg.Mode != "acceptEdits" {
+		t.Fatalf("Mode = %q", cfg.Mode)
+	}
+	if got := cfg.ConfigOptions["reasoning_effort"]; got != "low" {
+		t.Fatalf("reasoning_effort = %q", got)
+	}
+	if _, ok := cfg.ConfigOptions["model"]; ok {
+		t.Fatal("model key should not remain in ConfigOptions")
+	}
+	if _, ok := cfg.ConfigOptions["mode"]; ok {
+		t.Fatal("mode key should not remain in ConfigOptions")
+	}
+}
+
 func TestTaskStateConstants(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/apps/backend/internal/task/service/service_turns.go
+++ b/apps/backend/internal/task/service/service_turns.go
@@ -376,6 +376,7 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 	// Get ACP session ID and persisted session runtime settings from metadata.
 	var acpSessionID, sessionMode string
 	var runtimeConfig models.SessionRuntimeConfig
+	runtimeConfigSet := false
 	if session.Metadata != nil {
 		if id, ok := session.Metadata["acp_session_id"].(string); ok {
 			acpSessionID = id
@@ -385,6 +386,7 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 		}
 		if cfg, ok := models.LoadSessionRuntimeConfig(session.Metadata); ok {
 			runtimeConfig = cfg
+			runtimeConfigSet = true
 			if sessionMode == "" {
 				sessionMode = cfg.Mode
 			}
@@ -392,16 +394,17 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 	}
 
 	info := &lifecycle.WorkspaceInfo{
-		TaskID:               taskID,
-		SessionID:            sessionID,
-		TaskEnvironmentID:    session.TaskEnvironmentID,
-		WorkspacePath:        workspacePath,
-		AgentProfileID:       session.AgentProfileID,
-		AgentID:              agentID,
-		ACPSessionID:         acpSessionID,
-		SessionMode:          sessionMode,
-		RuntimeModel:         runtimeConfig.Model,
-		RuntimeConfigOptions: runtimeConfig.ConfigOptions,
+		TaskID:                  taskID,
+		SessionID:               sessionID,
+		TaskEnvironmentID:       session.TaskEnvironmentID,
+		WorkspacePath:           workspacePath,
+		AgentProfileID:          session.AgentProfileID,
+		AgentID:                 agentID,
+		ACPSessionID:            acpSessionID,
+		SessionMode:             sessionMode,
+		RuntimeModel:            runtimeConfig.Model,
+		RuntimeConfigOptions:    runtimeConfig.ConfigOptions,
+		RuntimeConfigOptionsSet: runtimeConfigSet,
 	}
 
 	var taskEnv *models.TaskEnvironment

--- a/apps/backend/internal/task/service/service_turns.go
+++ b/apps/backend/internal/task/service/service_turns.go
@@ -522,6 +522,9 @@ func (s *Service) updateSessionRuntimeConfig(ctx context.Context, sessionID stri
 	if err != nil {
 		return err
 	}
+	if session == nil {
+		return fmt.Errorf("agent session not found: %s", sessionID)
+	}
 	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
 	mutate(&cfg)
 	if cfg.IsZero() {

--- a/apps/backend/internal/task/service/service_turns.go
+++ b/apps/backend/internal/task/service/service_turns.go
@@ -373,8 +373,9 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 		}
 	}
 
-	// Get ACP session ID and persisted session permission mode from metadata.
+	// Get ACP session ID and persisted session runtime settings from metadata.
 	var acpSessionID, sessionMode string
+	var runtimeConfig models.SessionRuntimeConfig
 	if session.Metadata != nil {
 		if id, ok := session.Metadata["acp_session_id"].(string); ok {
 			acpSessionID = id
@@ -382,17 +383,25 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 		if mode, ok := session.Metadata[models.SessionMetaKeySessionMode].(string); ok {
 			sessionMode = mode
 		}
+		if cfg, ok := models.LoadSessionRuntimeConfig(session.Metadata); ok {
+			runtimeConfig = cfg
+			if sessionMode == "" {
+				sessionMode = cfg.Mode
+			}
+		}
 	}
 
 	info := &lifecycle.WorkspaceInfo{
-		TaskID:            taskID,
-		SessionID:         sessionID,
-		TaskEnvironmentID: session.TaskEnvironmentID,
-		WorkspacePath:     workspacePath,
-		AgentProfileID:    session.AgentProfileID,
-		AgentID:           agentID,
-		ACPSessionID:      acpSessionID,
-		SessionMode:       sessionMode,
+		TaskID:               taskID,
+		SessionID:            sessionID,
+		TaskEnvironmentID:    session.TaskEnvironmentID,
+		WorkspacePath:        workspacePath,
+		AgentProfileID:       session.AgentProfileID,
+		AgentID:              agentID,
+		ACPSessionID:         acpSessionID,
+		SessionMode:          sessionMode,
+		RuntimeModel:         runtimeConfig.Model,
+		RuntimeConfigOptions: runtimeConfig.ConfigOptions,
 	}
 
 	var taskEnv *models.TaskEnvironment
@@ -455,6 +464,67 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 	}
 
 	return info, nil
+}
+
+// PersistSessionRuntimeModel records the session's selected ACP model.
+func (s *Service) PersistSessionRuntimeModel(ctx context.Context, sessionID, modelID string) error {
+	if modelID == "" {
+		return nil
+	}
+	if err := s.updateSessionRuntimeConfig(ctx, sessionID, func(cfg *models.SessionRuntimeConfig) {
+		cfg.Model = modelID
+	}); err != nil {
+		return err
+	}
+	return s.sessions.SetSessionMetadataKey(ctx, sessionID, "context_window", nil)
+}
+
+// PersistSessionRuntimeMode records the session's selected ACP permission mode.
+func (s *Service) PersistSessionRuntimeMode(ctx context.Context, sessionID, modeID string) error {
+	if modeID == "" {
+		return nil
+	}
+	if err := s.sessions.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeySessionMode, modeID); err != nil {
+		return err
+	}
+	return s.updateSessionRuntimeConfig(ctx, sessionID, func(cfg *models.SessionRuntimeConfig) {
+		cfg.Mode = modeID
+	})
+}
+
+// PersistSessionRuntimeConfigOption records a selected dynamic ACP config option.
+func (s *Service) PersistSessionRuntimeConfigOption(ctx context.Context, sessionID, configID, value string) error {
+	if configID == "" {
+		return nil
+	}
+	if err := s.updateSessionRuntimeConfig(ctx, sessionID, func(cfg *models.SessionRuntimeConfig) {
+		if cfg.ConfigOptions == nil {
+			cfg.ConfigOptions = make(map[string]string)
+		}
+		cfg.ConfigOptions[configID] = value
+		if configID == "model" {
+			cfg.Model = value
+		}
+	}); err != nil {
+		return err
+	}
+	if configID == "model" {
+		return s.sessions.SetSessionMetadataKey(ctx, sessionID, "context_window", nil)
+	}
+	return nil
+}
+
+func (s *Service) updateSessionRuntimeConfig(ctx context.Context, sessionID string, mutate func(*models.SessionRuntimeConfig)) error {
+	session, err := s.sessions.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	cfg, _ := models.LoadSessionRuntimeConfig(session.Metadata)
+	mutate(&cfg)
+	if cfg.IsZero() {
+		return nil
+	}
+	return s.sessions.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyRuntimeConfig, cfg)
 }
 
 func applyTaskEnvironmentToWorkspaceInfo(info *lifecycle.WorkspaceInfo, env *models.TaskEnvironment) {

--- a/apps/backend/internal/task/service/service_turns.go
+++ b/apps/backend/internal/task/service/service_turns.go
@@ -376,7 +376,7 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 	// Get ACP session ID and persisted session runtime settings from metadata.
 	var acpSessionID, sessionMode string
 	var runtimeConfig models.SessionRuntimeConfig
-	runtimeConfigSet := false
+	runtimeConfigOptionsSet := false
 	if session.Metadata != nil {
 		if id, ok := session.Metadata["acp_session_id"].(string); ok {
 			acpSessionID = id
@@ -386,7 +386,7 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 		}
 		if cfg, ok := models.LoadSessionRuntimeConfig(session.Metadata); ok {
 			runtimeConfig = cfg
-			runtimeConfigSet = true
+			runtimeConfigOptionsSet = cfg.ConfigOptions != nil
 			if sessionMode == "" {
 				sessionMode = cfg.Mode
 			}
@@ -404,7 +404,7 @@ func (s *Service) GetWorkspaceInfoForSession(ctx context.Context, taskID, sessio
 		SessionMode:             sessionMode,
 		RuntimeModel:            runtimeConfig.Model,
 		RuntimeConfigOptions:    runtimeConfig.ConfigOptions,
-		RuntimeConfigOptionsSet: runtimeConfigSet,
+		RuntimeConfigOptionsSet: runtimeConfigOptionsSet,
 	}
 
 	var taskEnv *models.TaskEnvironment

--- a/apps/backend/internal/task/service/service_turns_test.go
+++ b/apps/backend/internal/task/service/service_turns_test.go
@@ -91,6 +91,59 @@ func TestGetWorkspaceInfoForSession_BasicFields(t *testing.T) {
 	}
 }
 
+func TestGetWorkspaceInfoForSession_RuntimeConfigOptionsSetOnlyWhenOptionsPresent(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+
+	setupTestTask(t, repo)
+	now := time.Now().UTC()
+
+	modelOnly := &models.TaskSession{
+		ID:        "session-model-only",
+		TaskID:    "task-123",
+		State:     models.TaskSessionStateCompleted,
+		StartedAt: now,
+		UpdatedAt: now,
+		Metadata: map[string]interface{}{
+			models.SessionMetaKeyRuntimeConfig: models.SessionRuntimeConfig{Model: "gpt-5.3-codex-spark"},
+		},
+	}
+	if err := repo.CreateTaskSession(ctx, modelOnly); err != nil {
+		t.Fatalf("failed to create model-only session: %v", err)
+	}
+	modelOnlyInfo, err := svc.GetWorkspaceInfoForSession(ctx, "task-123", "session-model-only")
+	if err != nil {
+		t.Fatalf("GetWorkspaceInfoForSession model-only: %v", err)
+	}
+	if modelOnlyInfo.RuntimeConfigOptionsSet {
+		t.Fatal("model-only runtime config should not mark config options as set")
+	}
+
+	withOptions := &models.TaskSession{
+		ID:        "session-with-options",
+		TaskID:    "task-123",
+		State:     models.TaskSessionStateCompleted,
+		StartedAt: now,
+		UpdatedAt: now,
+		Metadata: map[string]interface{}{
+			models.SessionMetaKeyRuntimeConfig: models.SessionRuntimeConfig{
+				Model:         "gpt-5.3-codex-spark",
+				ConfigOptions: map[string]string{"reasoning_effort": "low"},
+			},
+		},
+	}
+	if err := repo.CreateTaskSession(ctx, withOptions); err != nil {
+		t.Fatalf("failed to create options session: %v", err)
+	}
+	optionsInfo, err := svc.GetWorkspaceInfoForSession(ctx, "task-123", "session-with-options")
+	if err != nil {
+		t.Fatalf("GetWorkspaceInfoForSession with options: %v", err)
+	}
+	if !optionsInfo.RuntimeConfigOptionsSet {
+		t.Fatal("runtime config with options should mark config options as set")
+	}
+}
+
 func TestPersistSessionRuntimeModelMissingSessionDoesNotPanic(t *testing.T) {
 	svc := &Service{sessions: nilTaskSessionRepo{}}
 

--- a/apps/backend/internal/task/service/service_turns_test.go
+++ b/apps/backend/internal/task/service/service_turns_test.go
@@ -9,7 +9,20 @@ import (
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
 )
+
+type nilTaskSessionRepo struct {
+	repository.SessionRepository
+}
+
+func (nilTaskSessionRepo) GetTaskSession(context.Context, string) (*models.TaskSession, error) {
+	return nil, nil
+}
+
+func (nilTaskSessionRepo) SetSessionMetadataKey(context.Context, string, string, interface{}) error {
+	panic("SetSessionMetadataKey should not be called for a nil session")
+}
 
 func TestGetWorkspaceInfoForSession_BasicFields(t *testing.T) {
 	svc, _, repo := createTestService(t)
@@ -75,6 +88,16 @@ func TestGetWorkspaceInfoForSession_BasicFields(t *testing.T) {
 	}
 	if info.ACPSessionID != "acp-123" {
 		t.Errorf("expected ACPSessionID 'acp-123', got %q", info.ACPSessionID)
+	}
+}
+
+func TestPersistSessionRuntimeModelMissingSessionDoesNotPanic(t *testing.T) {
+	svc := &Service{sessions: nilTaskSessionRepo{}}
+
+	err := svc.PersistSessionRuntimeModel(context.Background(), "missing-session", "gpt-5.3-codex-spark")
+
+	if err == nil {
+		t.Fatal("expected missing session error")
 	}
 }
 

--- a/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
+++ b/apps/web/e2e/tests/terminal/mobile-terminal-keybar.spec.ts
@@ -43,7 +43,7 @@ async function seedTaskWithSession(
  * xterm focuses its hidden textarea.
  */
 async function focusTerminalForTyping(session: SessionPage): Promise<void> {
-  await session.terminal.locator(".xterm").click();
+  await session.terminal.locator(".xterm").last().click();
 }
 
 /**

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -382,6 +382,47 @@ export function migrateEnvKeyedData(
   migrate(draft.userShells.loaded);
 }
 
+function buildGitStatusActions(set: ImmerSet) {
+  return {
+    setGitStatus: (sessionId: string, gitStatus: GitStatusEntry) =>
+      set((draft) => {
+        const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
+        // Multi-repo: when the update is tagged with repository_name, route it
+        // into the per-repo map. Single-repo updates (no name) keep the legacy
+        // single-status path; the per-repo map mirrors the same entry under an
+        // empty key so consumers using only byEnvironmentRepo still see it.
+        const repoName = gitStatus.repository_name ?? "";
+        const repoMap = (draft.gitStatus.byEnvironmentRepo[envKey] ??= {});
+        const existingRepo = repoMap[repoName];
+        const repoChanged = !existingRepo || hasGitStatusChanged(existingRepo, gitStatus);
+        if (isDebug()) {
+          debugGit("setGitStatus", {
+            sessionId,
+            envKey,
+            usingFallbackKey: envKey === sessionId,
+            repoName,
+            prevFileCount: Object.keys(existingRepo?.files ?? {}).length,
+            nextFileCount: Object.keys(gitStatus.files ?? {}).length,
+            prevRepoKeys: Object.keys(repoMap),
+            willMutate: gitStatusWouldMutate(draft.gitStatus, envKey, gitStatus),
+          });
+        }
+        if (repoChanged) {
+          repoMap[repoName] = gitStatus;
+        }
+        if (repoName === "") {
+          const existing = draft.gitStatus.byEnvironmentId[envKey];
+          if (!existing || hasGitStatusChanged(existing, gitStatus)) {
+            draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
+          }
+        } else if (repoChanged) {
+          // Multi-repo: only mirror into the legacy map when this repo's entry changed.
+          draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
+        }
+      }),
+  };
+}
+
 export const createSessionRuntimeSlice: StateCreator<
   SessionRuntimeSlice,
   [["zustand/immer", never]],
@@ -390,42 +431,7 @@ export const createSessionRuntimeSlice: StateCreator<
 > = (set) => ({
   ...defaultSessionRuntimeState,
   ...buildTerminalShellProcessActions(set),
-  setGitStatus: (sessionId, gitStatus) =>
-    set((draft) => {
-      const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
-      // Multi-repo: when the update is tagged with repository_name, route it
-      // into the per-repo map. Single-repo updates (no name) keep the legacy
-      // single-status path; the per-repo map mirrors the same entry under an
-      // empty key so consumers using only byEnvironmentRepo still see it.
-      const repoName = gitStatus.repository_name ?? "";
-      const repoMap = (draft.gitStatus.byEnvironmentRepo[envKey] ??= {});
-      const existingRepo = repoMap[repoName];
-      const repoChanged = !existingRepo || hasGitStatusChanged(existingRepo, gitStatus);
-      if (isDebug()) {
-        debugGit("setGitStatus", {
-          sessionId,
-          envKey,
-          usingFallbackKey: envKey === sessionId,
-          repoName,
-          prevFileCount: Object.keys(existingRepo?.files ?? {}).length,
-          nextFileCount: Object.keys(gitStatus.files ?? {}).length,
-          prevRepoKeys: Object.keys(repoMap),
-          willMutate: gitStatusWouldMutate(draft.gitStatus, envKey, gitStatus),
-        });
-      }
-      if (repoChanged) {
-        repoMap[repoName] = gitStatus;
-      }
-      if (repoName === "") {
-        const existing = draft.gitStatus.byEnvironmentId[envKey];
-        if (!existing || hasGitStatusChanged(existing, gitStatus)) {
-          draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
-        }
-      } else if (repoChanged) {
-        // Multi-repo: only mirror into the legacy map when this repo's entry changed.
-        draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
-      }
-    }),
+  ...buildGitStatusActions(set),
   clearGitStatus: (sessionId) =>
     set((draft) => {
       const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
@@ -455,6 +461,10 @@ export const createSessionRuntimeSlice: StateCreator<
   setContextWindow: (sessionId, contextWindow) =>
     set((draft) => {
       draft.contextWindow.bySessionId[sessionId] = contextWindow;
+    }),
+  clearContextWindow: (sessionId) =>
+    set((draft) => {
+      delete draft.contextWindow.bySessionId[sessionId];
     }),
   ...buildSessionCommitActions(set),
   setAvailableCommands: (sessionId, commands) =>

--- a/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
+++ b/apps/web/lib/state/slices/session-runtime/session-runtime-slice.ts
@@ -382,43 +382,18 @@ export function migrateEnvKeyedData(
   migrate(draft.userShells.loaded);
 }
 
-function buildGitStatusActions(set: ImmerSet) {
+function buildContextWindowActions(set: ImmerSet) {
   return {
-    setGitStatus: (sessionId: string, gitStatus: GitStatusEntry) =>
+    setContextWindow: (
+      sessionId: string,
+      contextWindow: Parameters<SessionRuntimeSlice["setContextWindow"]>[1],
+    ) =>
       set((draft) => {
-        const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
-        // Multi-repo: when the update is tagged with repository_name, route it
-        // into the per-repo map. Single-repo updates (no name) keep the legacy
-        // single-status path; the per-repo map mirrors the same entry under an
-        // empty key so consumers using only byEnvironmentRepo still see it.
-        const repoName = gitStatus.repository_name ?? "";
-        const repoMap = (draft.gitStatus.byEnvironmentRepo[envKey] ??= {});
-        const existingRepo = repoMap[repoName];
-        const repoChanged = !existingRepo || hasGitStatusChanged(existingRepo, gitStatus);
-        if (isDebug()) {
-          debugGit("setGitStatus", {
-            sessionId,
-            envKey,
-            usingFallbackKey: envKey === sessionId,
-            repoName,
-            prevFileCount: Object.keys(existingRepo?.files ?? {}).length,
-            nextFileCount: Object.keys(gitStatus.files ?? {}).length,
-            prevRepoKeys: Object.keys(repoMap),
-            willMutate: gitStatusWouldMutate(draft.gitStatus, envKey, gitStatus),
-          });
-        }
-        if (repoChanged) {
-          repoMap[repoName] = gitStatus;
-        }
-        if (repoName === "") {
-          const existing = draft.gitStatus.byEnvironmentId[envKey];
-          if (!existing || hasGitStatusChanged(existing, gitStatus)) {
-            draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
-          }
-        } else if (repoChanged) {
-          // Multi-repo: only mirror into the legacy map when this repo's entry changed.
-          draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
-        }
+        draft.contextWindow.bySessionId[sessionId] = contextWindow;
+      }),
+    clearContextWindow: (sessionId: string) =>
+      set((draft) => {
+        delete draft.contextWindow.bySessionId[sessionId];
       }),
   };
 }
@@ -431,7 +406,42 @@ export const createSessionRuntimeSlice: StateCreator<
 > = (set) => ({
   ...defaultSessionRuntimeState,
   ...buildTerminalShellProcessActions(set),
-  ...buildGitStatusActions(set),
+  setGitStatus: (sessionId, gitStatus) =>
+    set((draft) => {
+      const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
+      // Multi-repo: when the update is tagged with repository_name, route it
+      // into the per-repo map. Single-repo updates (no name) keep the legacy
+      // single-status path; the per-repo map mirrors the same entry under an
+      // empty key so consumers using only byEnvironmentRepo still see it.
+      const repoName = gitStatus.repository_name ?? "";
+      const repoMap = (draft.gitStatus.byEnvironmentRepo[envKey] ??= {});
+      const existingRepo = repoMap[repoName];
+      const repoChanged = !existingRepo || hasGitStatusChanged(existingRepo, gitStatus);
+      if (isDebug()) {
+        debugGit("setGitStatus", {
+          sessionId,
+          envKey,
+          usingFallbackKey: envKey === sessionId,
+          repoName,
+          prevFileCount: Object.keys(existingRepo?.files ?? {}).length,
+          nextFileCount: Object.keys(gitStatus.files ?? {}).length,
+          prevRepoKeys: Object.keys(repoMap),
+          willMutate: gitStatusWouldMutate(draft.gitStatus, envKey, gitStatus),
+        });
+      }
+      if (repoChanged) {
+        repoMap[repoName] = gitStatus;
+      }
+      if (repoName === "") {
+        const existing = draft.gitStatus.byEnvironmentId[envKey];
+        if (!existing || hasGitStatusChanged(existing, gitStatus)) {
+          draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
+        }
+      } else if (repoChanged) {
+        // Multi-repo: only mirror into the legacy map when this repo's entry changed.
+        draft.gitStatus.byEnvironmentId[envKey] = gitStatus;
+      }
+    }),
   clearGitStatus: (sessionId) =>
     set((draft) => {
       const envKey = draft.environmentIdBySessionId[sessionId] ?? sessionId;
@@ -458,14 +468,7 @@ export const createSessionRuntimeSlice: StateCreator<
       draft.environmentIdBySessionId[sessionId] = environmentId;
       migrateEnvKeyedData(draft, sessionId, environmentId);
     }),
-  setContextWindow: (sessionId, contextWindow) =>
-    set((draft) => {
-      draft.contextWindow.bySessionId[sessionId] = contextWindow;
-    }),
-  clearContextWindow: (sessionId) =>
-    set((draft) => {
-      delete draft.contextWindow.bySessionId[sessionId];
-    }),
+  ...buildContextWindowActions(set),
   ...buildSessionCommitActions(set),
   setAvailableCommands: (sessionId, commands) =>
     set((draft) => {

--- a/apps/web/lib/state/slices/session-runtime/types.ts
+++ b/apps/web/lib/state/slices/session-runtime/types.ts
@@ -367,6 +367,7 @@ export type SessionRuntimeSliceActions = {
   clearLegacyGitStatusEntry: (sessionId: string) => void;
   registerSessionEnvironment: (sessionId: string, environmentId: string) => void;
   setContextWindow: (sessionId: string, contextWindow: ContextWindowEntry) => void;
+  clearContextWindow: (sessionId: string) => void;
   // Session commit actions
   setSessionCommits: (
     sessionId: string,

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -427,6 +427,7 @@ export type AppState = {
   clearSessionCommits: (sessionId: string) => void;
   bumpSessionCommitsRefetch: (sessionId: string) => void;
   setContextWindow: (sessionId: string, contextWindow: ContextWindowEntry) => void;
+  clearContextWindow: (sessionId: string) => void;
   bumpAgentProfilesVersion: () => void;
   setPendingModel: (sessionId: string, modelId: string) => void;
   clearPendingModel: (sessionId: string) => void;

--- a/apps/web/lib/ws/handlers/session-models.test.ts
+++ b/apps/web/lib/ws/handlers/session-models.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
+import type { BackendMessageMap } from "@/lib/types/backend";
+import type { SessionModelsPayload } from "@/lib/types/session-runtime-payloads";
+import { registerSessionModelsHandlers } from "./session-models";
+
+function makeStore(overrides: Partial<AppState> = {}) {
+  const state = {
+    activeModel: { bySessionId: {} },
+    contextWindow: { bySessionId: {} },
+    sessionModels: { bySessionId: {} },
+    setActiveModel: vi.fn(),
+    ...overrides,
+  } as unknown as AppState;
+  state.setSessionModels = vi.fn((sessionId, data) => {
+    state.sessionModels.bySessionId[sessionId] = data;
+  });
+  state.clearContextWindow = vi.fn((sessionId) => {
+    delete state.contextWindow.bySessionId[sessionId];
+  });
+
+  return {
+    getState: () => state,
+    setState: vi.fn(),
+    subscribe: vi.fn(),
+    destroy: vi.fn(),
+    getInitialState: vi.fn(),
+  } as unknown as StoreApi<AppState>;
+}
+
+function makePayload(
+  currentModelId: string,
+  overrides: Partial<SessionModelsPayload> = {},
+): SessionModelsPayload {
+  return {
+    task_id: "task-1",
+    session_id: "session-1",
+    agent_id: "agent-1",
+    current_model_id: currentModelId,
+    models: [],
+    config_options: [],
+    timestamp: "2026-06-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeMessage(payload: SessionModelsPayload): BackendMessageMap["session.models_updated"] {
+  return {
+    id: "message-1",
+    type: "notification",
+    action: "session.models_updated",
+    payload,
+  };
+}
+
+describe("session.models_updated handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears stale context window when the current model changes", () => {
+    const store = makeStore({
+      contextWindow: {
+        bySessionId: {
+          "session-1": {
+            size: 258400,
+            used: 114000,
+            remaining: 144400,
+            efficiency: 44,
+          },
+        },
+      } as AppState["contextWindow"],
+      sessionModels: {
+        bySessionId: {
+          "session-1": {
+            currentModelId: "gpt-5.5",
+            models: [],
+            configOptions: [],
+          },
+        },
+      } as AppState["sessionModels"],
+    });
+    const handler = registerSessionModelsHandlers(store)["session.models_updated"]!;
+
+    handler(makeMessage(makePayload("gpt-5.3-codex-spark")));
+
+    expect(store.getState().clearContextWindow).toHaveBeenCalledWith("session-1");
+    expect(store.getState().contextWindow.bySessionId["session-1"]).toBeUndefined();
+    expect(store.getState().setSessionModels).toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ currentModelId: "gpt-5.3-codex-spark" }),
+    );
+  });
+
+  it("keeps context window when the current model is unchanged", () => {
+    const store = makeStore({
+      contextWindow: {
+        bySessionId: {
+          "session-1": {
+            size: 258400,
+            used: 114000,
+            remaining: 144400,
+            efficiency: 44,
+          },
+        },
+      } as AppState["contextWindow"],
+      sessionModels: {
+        bySessionId: {
+          "session-1": {
+            currentModelId: "gpt-5.5",
+            models: [],
+            configOptions: [],
+          },
+        },
+      } as AppState["sessionModels"],
+    });
+    const handler = registerSessionModelsHandlers(store)["session.models_updated"]!;
+
+    handler(makeMessage(makePayload("gpt-5.5")));
+
+    expect(store.getState().clearContextWindow).not.toHaveBeenCalled();
+    expect(store.getState().contextWindow.bySessionId["session-1"]).toEqual({
+      size: 258400,
+      used: 114000,
+      remaining: 144400,
+      efficiency: 44,
+    });
+    expect(store.getState().setSessionModels).toHaveBeenCalledWith(
+      "session-1",
+      expect.objectContaining({ currentModelId: "gpt-5.5" }),
+    );
+  });
+});

--- a/apps/web/lib/ws/handlers/session-models.ts
+++ b/apps/web/lib/ws/handlers/session-models.ts
@@ -3,6 +3,41 @@ import type { AppState } from "@/lib/state/store";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
 import type { SessionModelsPayload } from "@/lib/types/backend";
 
+type SessionModelConfigOption = SessionModelsPayload["config_options"][number];
+
+function resolveCurrentModelId(payload: SessionModelsPayload): string {
+  if (payload.current_model_id) {
+    return payload.current_model_id;
+  }
+  const modelOpt = (payload.config_options ?? []).find(isModelConfigOption);
+  return modelOpt?.current_value ?? "";
+}
+
+function isModelConfigOption(option: SessionModelConfigOption): boolean {
+  return option.id === "model" || option.category === "model";
+}
+
+function clearStaleContextWindow(state: AppState, sessionId: string, currentModelId: string) {
+  const previousModelId = state.sessionModels.bySessionId[sessionId]?.currentModelId ?? "";
+  if (previousModelId && currentModelId && previousModelId !== currentModelId) {
+    state.clearContextWindow(sessionId);
+  }
+}
+
+function clearStaleActiveModel(
+  state: AppState,
+  sessionId: string,
+  acpModels: SessionModelsPayload["models"],
+) {
+  if (!acpModels?.length) {
+    return;
+  }
+  const currentActive = state.activeModel.bySessionId[sessionId];
+  if (currentActive && !acpModels.some((m) => m.model_id === currentActive)) {
+    state.setActiveModel(sessionId, "");
+  }
+}
+
 export function registerSessionModelsHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
     "session.models_updated": (message) => {
@@ -11,18 +46,12 @@ export function registerSessionModelsHandlers(store: StoreApi<AppState>): WsHand
         return;
       }
       const acpModels = payload.models ?? [];
-      // Resolve currentModelId: prefer the explicit field, fall back to the "model"
-      // config option's currentValue (some ACP agents send currentModelId as empty).
-      let currentModelId = payload.current_model_id || "";
-      if (!currentModelId) {
-        const modelOpt = (payload.config_options ?? []).find(
-          (o) => o.id === "model" || o.category === "model",
-        );
-        if (modelOpt?.current_value) {
-          currentModelId = modelOpt.current_value;
-        }
-      }
-      store.getState().setSessionModels(payload.session_id, {
+      const sessionId = payload.session_id;
+      const currentModelId = resolveCurrentModelId(payload);
+      const state = store.getState();
+      clearStaleContextWindow(state, sessionId, currentModelId);
+
+      state.setSessionModels(sessionId, {
         currentModelId,
         models: acpModels.map((m) => ({
           modelId: m.model_id,
@@ -41,15 +70,7 @@ export function registerSessionModelsHandlers(store: StoreApi<AppState>): WsHand
         })),
       });
 
-      // Clear stale activeModel if it uses a profile ID that doesn't exist in ACP models.
-      // This happens when a user selected a static model before ACP models arrived.
-      if (acpModels.length > 0) {
-        const state = store.getState();
-        const currentActive = state.activeModel.bySessionId[payload.session_id];
-        if (currentActive && !acpModels.some((m) => m.model_id === currentActive)) {
-          state.setActiveModel(payload.session_id, "");
-        }
-      }
+      clearStaleActiveModel(state, sessionId, acpModels);
     },
   };
 }


### PR DESCRIPTION
Runtime settings selected during a task could be lost on resume and context-window UI could keep stale model sizes after model switches. Session runtime config is now persisted and replayed, while context-window sizing uses ACP as source of truth with a models.dev fallback only when ACP omits the size.

## Important Changes

- Persist and replay session model, effort/mode, and config options ahead of profile defaults on resume.
- Clear persisted and frontend context-window state when the effective model changes.
- Use ACP context-window size when available, falling back to models.dev model metadata only when ACP does not report a size.
- Add models.dev context-window metadata lookup without hardcoded model sizes.

## Validation

- `make fmt`
- `make typecheck test lint`
- `cd apps && pnpm --filter @kandev/web typecheck && pnpm --filter @kandev/web lint`

## Possible Improvements

Low risk: models.dev fallback only helps models present in the cached/fetched metadata; unknown models continue hiding the context-size indicator until ACP reports size.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.