### PR TITLE
fix(web): restore Sentry entry in settings integrations nav

### DIFF
--- a/apps/web/components/app-sidebar/sections/settings/integrations-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/integrations-group.tsx
@@ -3,6 +3,7 @@
 import {
   IconBrandGithub,
   IconBrandGitlab,
+  IconBrandSentry,
   IconBrandSlack,
   IconHexagon,
   IconPlugConnected,
@@ -18,6 +19,7 @@ const ITEMS: Array<{ href: string; label: string; icon: TablerIcon }> = [
   { href: `${ROOT_HREF}/gitlab`, label: "GitLab", icon: IconBrandGitlab },
   { href: `${ROOT_HREF}/jira`, label: "Jira", icon: IconTicket },
   { href: `${ROOT_HREF}/linear`, label: "Linear", icon: IconHexagon },
+  { href: `${ROOT_HREF}/sentry`, label: "Sentry", icon: IconBrandSentry },
   { href: `${ROOT_HREF}/slack`, label: "Slack", icon: IconBrandSlack },
 ];
 


### PR DESCRIPTION
## Summary

The Sentry integration disappeared from the **Settings → Integrations** left-nav. Root cause: PR #1165 (`feat(web): unified app sidebar`) deleted the old `settings-app-sidebar.tsx` and rebuilt the settings nav as `integrations-group.tsx`. When the `ITEMS` array was re-authored by hand, the Sentry entry (present in the old sidebar since #1133) was dropped — only GitHub, GitLab, Jira, Linear, and Slack were carried over.

Sentry itself was otherwise intact (settings page at `/settings/integrations/sentry`, the integrations index card grid, and contextual task buttons all still work), which is why it looked like a nav-only disappearance.

This restores the `Sentry` entry (`IconBrandSentry`, `/settings/integrations/sentry`) in its original position between Linear and Slack — matching the order on the `/settings/integrations` index page.

## Test plan
- [x] Lint passes (`pnpm --filter @kandev/web lint`)
- [x] Typecheck passes (`pnpm --filter @kandev/web typecheck`)
- [x] Unit tests pass (`pnpm --filter @kandev/web test -- --run app-sidebar`, 33/33)
- [ ] Manual: Settings → Integrations sidebar now lists Sentry

## Notes
- The `ITEMS` array is static nav markup (covered by CLAUDE.md's "React component markup" test exception); sibling groups (`agents-group`, `executors-group`, etc.) follow the same untested-static-list convention. The regression was untested because `settings-tree.test.ts` only covers path→group-id mapping, not the per-group item lists.