### PR TITLE
perf(web): eliminate sidebar close lag with many tasks

### DIFF
--- a/apps/web/components/app-sidebar/app-sidebar-section.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-section.test.tsx
@@ -69,6 +69,20 @@ describe("AppSidebarSection", () => {
     const after = screen.getByTestId(CHILDREN_TESTID);
     expect(after).toBe(before);
     expect(after.parentElement?.classList.contains("hidden")).toBe(true);
+
+    // round-trip: re-expanding should restore the visible state on the same node
+    rerender(
+      <TooltipProvider>
+        <AppSidebarSection id="tasks" label="Tasks" icon={IconCircleDot} collapsed={false} grow>
+          <div data-testid={CHILDREN_TESTID}>children</div>
+        </AppSidebarSection>
+      </TooltipProvider>,
+    );
+
+    const reopened = screen.getByTestId(CHILDREN_TESTID);
+    expect(reopened).toBe(before);
+    expect(reopened.parentElement?.classList.contains("hidden")).toBe(false);
+    expect(reopened.parentElement?.classList.contains("sidebar-fade-in")).toBe(true);
   });
 
   it("does not render grow-section children while the section accordion is closed", () => {

--- a/apps/web/components/app-sidebar/app-sidebar-section.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-section.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { IconCircleDot } from "@tabler/icons-react";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+
+const storeState = {
+  appSidebar: {
+    sectionExpanded: { tasks: true } as Record<string, boolean>,
+  },
+  toggleAppSidebarSection: vi.fn(),
+  setAppSidebarCollapsed: vi.fn(),
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: typeof storeState) => unknown) => selector(storeState),
+}));
+
+import { AppSidebarSection } from "./app-sidebar-section";
+
+const CHILDREN_TESTID = "section-children";
+
+function renderSection(props: { collapsed: boolean; grow?: boolean }) {
+  return render(
+    <TooltipProvider>
+      <AppSidebarSection id="tasks" label="Tasks" icon={IconCircleDot} {...props}>
+        <div data-testid={CHILDREN_TESTID}>children</div>
+      </AppSidebarSection>
+    </TooltipProvider>,
+  );
+}
+
+describe("AppSidebarSection", () => {
+  beforeEach(() => {
+    storeState.appSidebar.sectionExpanded = { tasks: true };
+    storeState.toggleAppSidebarSection = vi.fn();
+    storeState.setAppSidebarCollapsed = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("unmounts children of a non-grow section when the sidebar collapses", () => {
+    renderSection({ collapsed: true });
+    expect(screen.queryByTestId(CHILDREN_TESTID)).toBeNull();
+    expect(screen.getByRole("button", { name: "Tasks" })).toBeTruthy();
+  });
+
+  it("keeps grow-section children mounted but hidden when the sidebar collapses", () => {
+    renderSection({ collapsed: true, grow: true });
+    const children = screen.getByTestId(CHILDREN_TESTID);
+    expect(children.parentElement?.classList.contains("hidden")).toBe(true);
+    expect(screen.getByRole("button", { name: "Tasks" })).toBeTruthy();
+  });
+
+  it("preserves the grow-section children instance across a collapse toggle (no remount)", () => {
+    const { rerender } = renderSection({ collapsed: false, grow: true });
+    const before = screen.getByTestId(CHILDREN_TESTID);
+    expect(before.parentElement?.classList.contains("hidden")).toBe(false);
+
+    rerender(
+      <TooltipProvider>
+        <AppSidebarSection id="tasks" label="Tasks" icon={IconCircleDot} collapsed grow>
+          <div data-testid={CHILDREN_TESTID}>children</div>
+        </AppSidebarSection>
+      </TooltipProvider>,
+    );
+
+    const after = screen.getByTestId(CHILDREN_TESTID);
+    expect(after).toBe(before);
+    expect(after.parentElement?.classList.contains("hidden")).toBe(true);
+  });
+
+  it("does not render grow-section children while the section accordion is closed", () => {
+    storeState.appSidebar.sectionExpanded = { tasks: false };
+    renderSection({ collapsed: true, grow: true });
+    expect(screen.queryByTestId(CHILDREN_TESTID)).toBeNull();
+  });
+
+  it("expands the sidebar when the collapsed rail button is clicked", () => {
+    renderSection({ collapsed: true, grow: true });
+    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
+    expect(storeState.setAppSidebarCollapsed).toHaveBeenCalledWith(false);
+    expect(storeState.toggleAppSidebarSection).not.toHaveBeenCalled();
+  });
+
+  it("also re-opens the section accordion when expanding via the rail button", () => {
+    storeState.appSidebar.sectionExpanded = { tasks: false };
+    renderSection({ collapsed: true, grow: true });
+    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
+    expect(storeState.setAppSidebarCollapsed).toHaveBeenCalledWith(false);
+    expect(storeState.toggleAppSidebarSection).toHaveBeenCalledWith("tasks");
+  });
+});

--- a/apps/web/components/app-sidebar/app-sidebar-section.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-section.tsx
@@ -80,44 +80,62 @@ export function AppSidebarSection({
   const toggleSection = useAppStore((s) => s.toggleAppSidebarSection);
   const setCollapsed = useAppStore((s) => s.setAppSidebarCollapsed);
 
-  if (collapsed) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            className="flex h-9 w-9 mx-auto items-center justify-center rounded-md text-foreground/70 hover:bg-muted/60 cursor-pointer"
-            onClick={() => {
-              setCollapsed(false);
-              if (!expanded) toggleSection(id);
-            }}
-            aria-label={label}
-          >
-            <Icon className="h-4 w-4" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right">{label}</TooltipContent>
-      </Tooltip>
-    );
-  }
+  const railButton = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="flex h-9 w-9 mx-auto items-center justify-center rounded-md text-foreground/70 hover:bg-muted/60 cursor-pointer"
+          onClick={() => {
+            setCollapsed(false);
+            if (!expanded) toggleSection(id);
+          }}
+          aria-label={label}
+        >
+          <Icon className="h-4 w-4" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
+  );
+
+  if (collapsed && !grow) return railButton;
 
   const handleToggle = () => toggleSection(id);
 
   // The grow section (Tasks) absorbs remaining vertical space and scrolls
   // internally, so it stays flex-driven rather than animating to content
   // height like the fixed-size sections below.
+  //
+  // In rail mode its children stay mounted but CSS-hidden: this section holds
+  // the (potentially huge) task list, and unmounting it made collapsing the
+  // sidebar jank — React tore down every task row in the same frame the close
+  // animation started. Hiding is O(1) on close and makes reopening instant.
+  // The children div keeps the same position in the tree across the toggle so
+  // React preserves it instead of remounting.
   if (grow) {
     return (
-      <div className={cn(expanded && "flex-1 min-h-0 flex flex-col")}>
-        <SectionHeader
-          label={label}
-          expanded={expanded}
-          headerAction={headerAction}
-          headerActionVisibility={headerActionVisibility}
-          onToggle={handleToggle}
-        />
+      <div className={cn(!collapsed && expanded && "flex-1 min-h-0 flex flex-col")}>
+        {collapsed ? (
+          railButton
+        ) : (
+          <SectionHeader
+            label={label}
+            expanded={expanded}
+            headerAction={headerAction}
+            headerActionVisibility={headerActionVisibility}
+            onToggle={handleToggle}
+          />
+        )}
         {expanded && (
-          <div className="flex flex-col gap-0.5 flex-1 min-h-0 sidebar-fade-in">{children}</div>
+          <div
+            className={cn(
+              "flex flex-col gap-0.5",
+              collapsed ? "hidden" : "flex-1 min-h-0 sidebar-fade-in",
+            )}
+          >
+            {children}
+          </div>
         )}
       </div>
     );

--- a/apps/web/components/app-sidebar/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar.tsx
@@ -117,7 +117,10 @@ export function AppSidebar() {
         // absolute resize handle.
         "h-full min-h-0 border-r border-border bg-background hidden md:flex flex-col shrink-0",
         "md:relative",
-        "transition-all duration-300 ease-out",
+        // Animate only the width: `transition-all` makes the browser watch
+        // every animatable property, and any incidental property change on the
+        // aside (border, background) would also animate during open/close.
+        "transition-[width] duration-300 ease-out",
       )}
       style={{
         width: collapsed ? APP_SIDEBAR_COLLAPSED_WIDTH : expandedWidth,

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -635,6 +635,12 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
   const toggleSubtaskCollapsed = useAppStore((state) => state.toggleSubtaskCollapsed);
   const { grouped, effectiveView, prefs } = useGroupedSidebarView(displayTasks);
   const { pinnedTaskIds, togglePinnedTask, handleReorderGroup, handleReorderSubtasks } = prefs;
+  // Stable ref: an inline arrow here would defeat TaskSwitcher's memo() and
+  // re-render every task row whenever this component renders.
+  const handleToggleGroup = useCallback(
+    (groupKey: string) => toggleSidebarGroupCollapsed(effectiveView.id, groupKey),
+    [toggleSidebarGroupCollapsed, effectiveView.id],
+  );
   return (
     <PanelRoot data-testid="task-sidebar">
       {!hideFilterBar && <SidebarFilterBar />}
@@ -646,7 +652,7 @@ export const TaskSessionSidebar = memo(function TaskSessionSidebar({
           activeTaskId={highlightedTaskId}
           selectedTaskId={highlightedSelectedTaskId}
           collapsedGroupKeys={effectiveView.collapsedGroups}
-          onToggleGroup={(groupKey) => toggleSidebarGroupCollapsed(effectiveView.id, groupKey)}
+          onToggleGroup={handleToggleGroup}
           collapsedSubtaskParentIds={collapsedSubtaskParents}
           onToggleSubtasks={toggleSubtaskCollapsed}
           onSelectTask={handleSelectTask}

--- a/apps/web/components/task/task-switcher-subtask-dnd.tsx
+++ b/apps/web/components/task/task-switcher-subtask-dnd.tsx
@@ -21,6 +21,13 @@ import type { TaskSwitcherItem } from "./task-switcher";
 
 export const DRAG_ACTIVATION_DISTANCE = 8;
 
+// Skip layout/paint for rows outside the sidebar scrollport so long task lists
+// stay cheap to render and scroll. `auto 52px` seeds the height estimate before
+// first paint; afterwards the browser remembers each row's real size, so
+// scrollbar/anchor behavior stays stable and dnd-kit's drag-start rect
+// measurements remain accurate for previously rendered rows.
+const OFFSCREEN_SKIP = "[content-visibility:auto] [contain-intrinsic-block-size:auto_52px]";
+
 /** Sortable implementation — isolated so `useSortable` is never called conditionally. */
 function DraggableSortableTaskNode({
   taskId,
@@ -53,7 +60,7 @@ function DraggableSortableTaskNode({
       data-testid="sortable-task-block"
       data-task-id={taskId}
       data-depth={depth}
-      className={cn(isDragging && "z-50")}
+      className={cn(OFFSCREEN_SKIP, isDragging && "z-50")}
     >
       <div
         {...sortableAttributes}
@@ -99,7 +106,12 @@ export function SortableTaskNode({
 }) {
   if (!isDraggable) {
     return (
-      <div data-testid="sortable-task-block" data-task-id={taskId} data-depth={depth}>
+      <div
+        data-testid="sortable-task-block"
+        data-task-id={taskId}
+        data-depth={depth}
+        className={OFFSCREEN_SKIP}
+      >
         <div data-testid="sortable-task-handle">{handle}</div>
         {nested}
       </div>


### PR DESCRIPTION
Closing the app sidebar unmounted the entire task list in the same frame the width animation started, so close lag scaled with the number of rendered tasks. Collapse is now O(1) and reopening is instant.

## Important Changes

- `AppSidebarSection` (grow/Tasks section): children stay mounted but CSS-hidden in rail mode instead of unmounting — kills the per-task teardown cost on close and the remount cost on reopen. Trade-off: store/WS subscriptions stay live while collapsed.
- `task-session-sidebar.tsx`: `onToggleGroup` wrapped in `useCallback` — the inline arrow defeated `TaskSwitcher`'s `memo()`, re-rendering every task row on each sidebar render.
- `app-sidebar.tsx`: `transition-all` → `transition-[width]` so only the width animates.
- `task-switcher-subtask-dnd.tsx`: `content-visibility: auto` on task blocks skips layout/paint for rows outside the sidebar scrollport (chosen over list virtualization, which breaks dnd-kit drag-reorder when rows unmount mid-drag).

## Validation

- `pnpm --filter @kandev/web typecheck` — clean
- `pnpm --filter @kandev/web lint` — clean
- `pnpm --filter @kandev/web test` — 382 files, 3240 tests pass, incl. new `app-sidebar-section.test.tsx` (mounted-but-hidden behavior, child instance preserved across collapse toggle, rail-button actions)
- Manual: dev instance seeded with 74 tasks (incl. subtask trees); sidebar close/open, scroll, and drag-reorder verified smooth

## Possible Improvements

Low risk; if `content-visibility` height estimates ever cause scrollbar jitter on very long lists, real virtualization of the task list is the follow-up.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->