### PR TITLE
feat(web): tabbed multi-PR CI popover for topbar button and chat status chip

### DIFF
--- a/apps/web/components/github/multi-pr-ci-popover.tsx
+++ b/apps/web/components/github/multi-pr-ci-popover.tsx
@@ -30,7 +30,9 @@ function PRTab({
   return (
     <button
       type="button"
-      data-testid={`pr-popover-tab-${pr.pr_number}`}
+      role="tab"
+      aria-selected={active}
+      data-testid={`pr-popover-tab-${pr.repo}-${pr.pr_number}`}
       data-active={active ? "true" : "false"}
       onClick={() => onSelect(pr)}
       className={cn(
@@ -75,6 +77,8 @@ export function MultiPRCIPopover({
         <PRFeedbackWarmer key={pr.id} pr={pr} />
       ))}
       <div
+        role="tablist"
+        aria-label="Pull requests"
         data-testid="pr-multi-popover-tabs"
         className="flex gap-1 overflow-x-auto border-b border-border/50 pb-2"
       >

--- a/apps/web/components/github/multi-pr-ci-popover.tsx
+++ b/apps/web/components/github/multi-pr-ci-popover.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { IconGitPullRequest } from "@tabler/icons-react";
+import { cn } from "@/lib/utils";
+import { PRCIPopover } from "@/components/github/pr-ci-popover";
+import { getPRStatusColor, pickDefaultPR } from "@/components/github/pr-task-icon";
+import { usePRFeedbackBackgroundSync } from "@/hooks/domains/github/use-pr-ci-popover";
+import type { TaskPR } from "@/lib/types/github";
+
+/**
+ * Renders nothing — just keeps one PR's feedback cache warm while the popover
+ * is mounted, so switching tabs shows fresh data immediately. One instance per
+ * PR (keyed by id) so the hook count stays stable as the list changes.
+ */
+function PRFeedbackWarmer({ pr }: { pr: TaskPR }) {
+  usePRFeedbackBackgroundSync(pr);
+  return null;
+}
+
+function PRTab({
+  pr,
+  active,
+  onSelect,
+}: {
+  pr: TaskPR;
+  active: boolean;
+  onSelect: (pr: TaskPR) => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={`pr-popover-tab-${pr.pr_number}`}
+      data-active={active ? "true" : "false"}
+      onClick={() => onSelect(pr)}
+      className={cn(
+        "flex shrink-0 cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs whitespace-nowrap transition-colors",
+        active ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50",
+      )}
+    >
+      <IconGitPullRequest className={cn("h-3.5 w-3.5", getPRStatusColor(pr))} />
+      <span className="font-medium">
+        {pr.repo} #{pr.pr_number}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Multi-PR variant of the CI popover. A segmented header lists every PR linked
+ * to the task (one chip per PR, coloured by its status); the body reuses the
+ * single-PR PRCIPopover for whichever PR is selected. Defaults to the
+ * worst-status open PR so problems surface first.
+ */
+export function MultiPRCIPopover({
+  prs,
+  enabled,
+  onOpenDetailPanel,
+}: {
+  prs: TaskPR[];
+  enabled: boolean;
+  onOpenDetailPanel?: (pr: TaskPR) => void;
+}) {
+  // `overrideId` is only set when the user clicks a tab. The displayed PR is
+  // derived: honour the override while it still exists, otherwise fall back to
+  // the worst-status PR. This keeps the selection valid as the list changes
+  // (PR closed, new PR opened, task switch) without a setState-in-effect.
+  const [overrideId, setOverrideId] = useState<string | null>(null);
+  const selected = prs.find((p) => p.id === overrideId) ?? pickDefaultPR(prs);
+  if (!selected) return null;
+
+  return (
+    <div data-testid="pr-multi-popover" className="flex flex-col gap-2">
+      {prs.map((pr) => (
+        <PRFeedbackWarmer key={pr.id} pr={pr} />
+      ))}
+      <div
+        data-testid="pr-multi-popover-tabs"
+        className="flex gap-1 overflow-x-auto border-b border-border/50 pb-2"
+      >
+        {prs.map((pr) => (
+          <PRTab
+            key={pr.id}
+            pr={pr}
+            active={pr.id === selected.id}
+            onSelect={(p) => setOverrideId(p.id)}
+          />
+        ))}
+      </div>
+      <PRCIPopover
+        pr={selected}
+        enabled={enabled}
+        onOpenDetailPanel={onOpenDetailPanel ? () => onOpenDetailPanel(selected) : undefined}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/github/multi-pr-ci-popover.tsx
+++ b/apps/web/components/github/multi-pr-ci-popover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState, type KeyboardEvent } from "react";
 import { IconGitPullRequest } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { PRCIPopover } from "@/components/github/pr-ci-popover";
@@ -18,12 +18,20 @@ function PRFeedbackWarmer({ pr }: { pr: TaskPR }) {
   return null;
 }
 
+function prTabDomId(uid: string, pr: TaskPR): string {
+  return `${uid}-pr-tab-${pr.repo}-${pr.pr_number}`;
+}
+
 function PRTab({
   pr,
+  uid,
+  panelId,
   active,
   onSelect,
 }: {
   pr: TaskPR;
+  uid: string;
+  panelId: string;
   active: boolean;
   onSelect: (pr: TaskPR) => void;
 }) {
@@ -31,9 +39,12 @@ function PRTab({
     <button
       type="button"
       role="tab"
-      id={`pr-tab-${pr.repo}-${pr.pr_number}`}
+      id={prTabDomId(uid, pr)}
+      // Roving tabindex (WAI-ARIA tabs pattern): only the active tab is in the
+      // page tab order; ArrowLeft/ArrowRight move between tabs.
+      tabIndex={active ? 0 : -1}
       aria-selected={active}
-      aria-controls={`pr-tabpanel-${pr.repo}-${pr.pr_number}`}
+      aria-controls={panelId}
       data-testid={`pr-popover-tab-${pr.repo}-${pr.pr_number}`}
       data-active={active ? "true" : "false"}
       onClick={() => onSelect(pr)}
@@ -65,13 +76,30 @@ export function MultiPRCIPopover({
   enabled: boolean;
   onOpenDetailPanel?: (pr: TaskPR) => void;
 }) {
-  // `overrideId` is only set when the user clicks a tab. The displayed PR is
+  // `overrideId` is only set when the user activates a tab. The displayed PR is
   // derived: honour the override while it still exists, otherwise fall back to
   // the worst-status PR. This keeps the selection valid as the list changes
   // (PR closed, new PR opened, task switch) without a setState-in-effect.
   const [overrideId, setOverrideId] = useState<string | null>(null);
+  // useId-scoped DOM ids so two mounted popovers (chip + topbar) can't collide.
+  // The panel id is stable across tab switches so every tab's aria-controls
+  // always references an element that exists in the DOM.
+  const uid = useId();
+  const panelId = `${uid}-pr-ci-tabpanel`;
   const selected = prs.find((p) => p.id === overrideId) ?? pickDefaultPR(prs);
   if (!selected) return null;
+
+  // ArrowLeft/ArrowRight move selection (and focus) within the tablist,
+  // wrapping at the ends — selection follows focus, per the ARIA tabs pattern.
+  const onTablistKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const idx = prs.findIndex((p) => p.id === selected.id);
+    const delta = e.key === "ArrowRight" ? 1 : -1;
+    const next = prs[(idx + delta + prs.length) % prs.length];
+    setOverrideId(next.id);
+    document.getElementById(prTabDomId(uid, next))?.focus();
+  };
 
   return (
     <div data-testid="pr-multi-popover" className="flex flex-col gap-2">
@@ -85,21 +113,20 @@ export function MultiPRCIPopover({
         aria-label="Pull requests"
         data-testid="pr-multi-popover-tabs"
         className="flex gap-1 overflow-x-auto border-b border-border/50 pb-2"
+        onKeyDown={onTablistKeyDown}
       >
         {prs.map((pr) => (
           <PRTab
             key={pr.id}
             pr={pr}
+            uid={uid}
+            panelId={panelId}
             active={pr.id === selected.id}
             onSelect={(p) => setOverrideId(p.id)}
           />
         ))}
       </div>
-      <div
-        role="tabpanel"
-        id={`pr-tabpanel-${selected.repo}-${selected.pr_number}`}
-        aria-labelledby={`pr-tab-${selected.repo}-${selected.pr_number}`}
-      >
+      <div role="tabpanel" id={panelId} aria-labelledby={prTabDomId(uid, selected)}>
         <PRCIPopover
           pr={selected}
           enabled={enabled}

--- a/apps/web/components/github/multi-pr-ci-popover.tsx
+++ b/apps/web/components/github/multi-pr-ci-popover.tsx
@@ -31,7 +31,9 @@ function PRTab({
     <button
       type="button"
       role="tab"
+      id={`pr-tab-${pr.repo}-${pr.pr_number}`}
       aria-selected={active}
+      aria-controls={`pr-tabpanel-${pr.repo}-${pr.pr_number}`}
       data-testid={`pr-popover-tab-${pr.repo}-${pr.pr_number}`}
       data-active={active ? "true" : "false"}
       onClick={() => onSelect(pr)}
@@ -73,9 +75,11 @@ export function MultiPRCIPopover({
 
   return (
     <div data-testid="pr-multi-popover" className="flex flex-col gap-2">
-      {prs.map((pr) => (
-        <PRFeedbackWarmer key={pr.id} pr={pr} />
-      ))}
+      {prs
+        .filter((p) => p.state === "open")
+        .map((pr) => (
+          <PRFeedbackWarmer key={pr.id} pr={pr} />
+        ))}
       <div
         role="tablist"
         aria-label="Pull requests"
@@ -91,11 +95,17 @@ export function MultiPRCIPopover({
           />
         ))}
       </div>
-      <PRCIPopover
-        pr={selected}
-        enabled={enabled}
-        onOpenDetailPanel={onOpenDetailPanel ? () => onOpenDetailPanel(selected) : undefined}
-      />
+      <div
+        role="tabpanel"
+        id={`pr-tabpanel-${selected.repo}-${selected.pr_number}`}
+        aria-labelledby={`pr-tab-${selected.repo}-${selected.pr_number}`}
+      >
+        <PRCIPopover
+          pr={selected}
+          enabled={enabled}
+          onOpenDetailPanel={onOpenDetailPanel ? () => onOpenDetailPanel(selected) : undefined}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/components/github/pr-ci-popover.tsx
+++ b/apps/web/components/github/pr-ci-popover.tsx
@@ -591,7 +591,3 @@ function useAddCheckToContext(pr: TaskPR): ((message: string) => void) | null {
   );
   return sessionId ? handler : null;
 }
-
-// Multi-PR aggregate popover deferred — multi-PR tasks currently keep the
-// existing DropdownMenu trigger (no hover popover). The aggregate component
-// will land alongside that hover variant when it ships, see follow-up.

--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -266,9 +266,10 @@ describe("PRStatusChip — multiple PRs", () => {
       });
       expect(document.querySelector(DRAWER_SELECTOR)).not.toBeNull();
       expect(document.querySelector("[data-testid='pr-multi-popover']")).not.toBeNull();
-      // One tab per PR.
-      expect(document.querySelector("[data-testid='pr-popover-tab-1']")).not.toBeNull();
-      expect(document.querySelector("[data-testid='pr-popover-tab-2']")).not.toBeNull();
+      // One tab per PR (testid is repo-scoped so same-number PRs on
+      // different repos stay unique).
+      expect(document.querySelector("[data-testid='pr-popover-tab-demo-1']")).not.toBeNull();
+      expect(document.querySelector("[data-testid='pr-popover-tab-demo-2']")).not.toBeNull();
     });
   });
 });

--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { StateProvider } from "@/components/state-provider";
 import { ToastProvider } from "@/components/toast-provider";
-import { PRStatusChip } from "./pr-status-chip";
+import { PRStatusChip, aggregateChipStatus } from "./pr-status-chip";
 import type { AppState } from "@/lib/state/store";
 import type { TaskPR } from "@/lib/types/github";
 
@@ -79,9 +79,16 @@ afterEach(() => {
 });
 
 const CHIP_TESTID = "pr-status-chip";
+const ATTR_PR_NUMBER = "data-pr-number";
+const ATTR_STATUS = "data-status";
+const DRAWER_SELECTOR = "[data-testid='pr-status-chip-drawer']";
 const seededState: Partial<AppState> = {
   taskPRs: { byTaskId: { "task-1": [makePR()] } },
 };
+
+function multiState(prs: TaskPR[]): Partial<AppState> {
+  return { taskPRs: { byTaskId: { "task-1": prs } } };
+}
 
 describe("PRStatusChip", () => {
   it("returns null when the task has no PR", () => {
@@ -117,15 +124,15 @@ describe("PRStatusChip", () => {
       act(() => {
         fireEvent.click(chip);
       });
-      expect(document.querySelector("[data-testid='pr-status-chip-drawer']")).toBeNull();
+      expect(document.querySelector(DRAWER_SELECTOR)).toBeNull();
     });
 
     it("exposes the canonical data attributes that desktop tests rely on", () => {
       renderWithStore(seededState, <PRStatusChip taskId="task-1" />);
       const chip = screen.getByTestId(CHIP_TESTID);
-      expect(chip.getAttribute("data-pr-number")).toBe("42");
+      expect(chip.getAttribute(ATTR_PR_NUMBER)).toBe("42");
       expect(chip.getAttribute("data-pr-state")).toBe("open");
-      expect(chip.getAttribute("data-status")).toBe("passed");
+      expect(chip.getAttribute(ATTR_STATUS)).toBe("passed");
       expect(chip.getAttribute("data-pr-ready-to-merge")).toBe("true");
     });
   });
@@ -137,14 +144,14 @@ describe("PRStatusChip", () => {
       renderWithStore(seededState, <PRStatusChip taskId="task-1" />);
       // Drawer must not be in the DOM before the user taps the chip — relied
       // on by the e2e spec's `toHaveCount(0)` precondition.
-      expect(document.querySelector("[data-testid='pr-status-chip-drawer']")).toBeNull();
+      expect(document.querySelector(DRAWER_SELECTOR)).toBeNull();
 
       const chip = screen.getByTestId(CHIP_TESTID);
       act(() => {
         fireEvent.click(chip);
       });
 
-      const drawer = document.querySelector("[data-testid='pr-status-chip-drawer']");
+      const drawer = document.querySelector(DRAWER_SELECTOR);
       expect(drawer).not.toBeNull();
       // Inner popover body + close button render inside the drawer.
       expect(document.querySelector("[data-testid='pr-topbar-popover-inner']")).not.toBeNull();
@@ -154,9 +161,9 @@ describe("PRStatusChip", () => {
     it("preserves the same data attributes as the desktop chip", () => {
       renderWithStore(seededState, <PRStatusChip taskId="task-1" />);
       const chip = screen.getByTestId(CHIP_TESTID);
-      expect(chip.getAttribute("data-pr-number")).toBe("42");
+      expect(chip.getAttribute(ATTR_PR_NUMBER)).toBe("42");
       expect(chip.getAttribute("data-pr-state")).toBe("open");
-      expect(chip.getAttribute("data-status")).toBe("passed");
+      expect(chip.getAttribute(ATTR_STATUS)).toBe("passed");
       expect(chip.getAttribute("data-pr-ready-to-merge")).toBe("true");
     });
 
@@ -165,7 +172,7 @@ describe("PRStatusChip", () => {
         { taskPRs: { byTaskId: { "task-1": [makePR({ checks_state: "failure" })] } } },
         <PRStatusChip taskId="task-1" />,
       );
-      expect(screen.getByTestId(CHIP_TESTID).getAttribute("data-status")).toBe("failed");
+      expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("failed");
     });
 
     // NOTE: vaul's close animation depends on CSS transition events that
@@ -196,6 +203,72 @@ describe("PRStatusChip", () => {
         fireEvent.click(screen.getByTestId(CHIP_TESTID));
       });
       expect(document.querySelector("[data-testid='pr-checks-empty']")).not.toBeNull();
+    });
+  });
+});
+
+describe("aggregateChipStatus", () => {
+  it("returns 'neutral' for an empty list", () => {
+    expect(aggregateChipStatus([])).toBe("neutral");
+  });
+
+  it("lets one failing PR dominate a passing sibling", () => {
+    const passing = makePR();
+    const failing = makePR({ id: "fail", checks_state: "failure" });
+    expect(aggregateChipStatus([passing, failing])).toBe("failed");
+  });
+
+  it("returns 'in_progress' when the worst is a pending PR", () => {
+    const passing = makePR();
+    const pending = makePR({ id: "pend", review_state: "", checks_state: "pending" });
+    expect(aggregateChipStatus([passing, pending])).toBe("in_progress");
+  });
+});
+
+describe("PRStatusChip — multiple PRs", () => {
+  const TWO_OPEN = [
+    makePR({ id: "a", pr_number: 1 }),
+    makePR({ id: "b", pr_number: 2, checks_state: "failure" }),
+  ];
+
+  it("renders one aggregate chip with a PR count and worst-of status", () => {
+    renderWithStore(multiState(TWO_OPEN), <PRStatusChip taskId="task-1" />);
+    const chip = screen.getByTestId(CHIP_TESTID);
+    expect(chip.getAttribute("data-pr-count")).toBe("2");
+    // PR #2 is failing, so the aggregate glyph is red.
+    expect(chip.getAttribute(ATTR_STATUS)).toBe("failed");
+  });
+
+  it("stays visible while at least one PR is still open", () => {
+    renderWithStore(
+      multiState([makePR({ id: "a", state: "merged" }), makePR({ id: "b", pr_number: 2 })]),
+      <PRStatusChip taskId="task-1" />,
+    );
+    // Only one PR is open, so it renders as the single-PR chip (its number).
+    expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_PR_NUMBER)).toBe("2");
+  });
+
+  it("returns null only when every PR is terminal", () => {
+    renderWithStore(
+      multiState([makePR({ id: "a", state: "merged" }), makePR({ id: "b", state: "closed" })]),
+      <PRStatusChip taskId="task-1" />,
+    );
+    expect(screen.queryByTestId(CHIP_TESTID)).toBeNull();
+  });
+
+  describe("mobile drawer", () => {
+    beforeEach(() => isMobileMock.mockReturnValue(true));
+
+    it("opens a drawer with the tabbed multi-PR popover", () => {
+      renderWithStore(multiState(TWO_OPEN), <PRStatusChip taskId="task-1" />);
+      act(() => {
+        fireEvent.click(screen.getByTestId(CHIP_TESTID));
+      });
+      expect(document.querySelector(DRAWER_SELECTOR)).not.toBeNull();
+      expect(document.querySelector("[data-testid='pr-multi-popover']")).not.toBeNull();
+      // One tab per PR.
+      expect(document.querySelector("[data-testid='pr-popover-tab-1']")).not.toBeNull();
+      expect(document.querySelector("[data-testid='pr-popover-tab-2']")).not.toBeNull();
     });
   });
 });

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -110,10 +110,14 @@ function useChipTriggerGuard() {
  */
 export function PRStatusChip({ taskId }: { taskId: string | null }) {
   const { prs } = useTaskPR(taskId);
+  // Defensive Array.isArray: a partial hydration can briefly seed the store
+  // with a non-array value (same guard as PRTaskIcon).
   // Only open PRs are worth a CI chip — terminal PRs (merged/closed) are
   // already conveyed by the chat-input banner. With multiple PRs the chip
   // stays visible as long as at least one is still open.
-  const openPRs = prs.filter((p) => p.state !== "merged" && p.state !== "closed");
+  const openPRs = Array.isArray(prs)
+    ? prs.filter((p) => p.state !== "merged" && p.state !== "closed")
+    : [];
   // Subscribe at the chip level so the cache warms even when the top-bar PR
   // button isn't mounted (e.g. small viewport that hides it). The remaining
   // PRs in a multi-PR task warm when the popover opens.

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -23,7 +23,11 @@ import { useTaskPR } from "@/hooks/domains/github/use-task-pr";
 import { usePRFeedbackBackgroundSync } from "@/hooks/domains/github/use-pr-ci-popover";
 import { PRCIPopover } from "@/components/github/pr-ci-popover";
 import { MultiPRCIPopover } from "@/components/github/multi-pr-ci-popover";
-import { isPRAwaitingReview, isPRReadyToMerge } from "@/components/github/pr-task-icon";
+import {
+  isPRAwaitingReview,
+  isPRReadyToMerge,
+  pickDefaultPR,
+} from "@/components/github/pr-task-icon";
 import { useIsMobile } from "@/hooks/use-mobile";
 import type { TaskPR } from "@/lib/types/github";
 
@@ -119,9 +123,11 @@ export function PRStatusChip({ taskId }: { taskId: string | null }) {
     ? prs.filter((p) => p.state !== "merged" && p.state !== "closed")
     : [];
   // Subscribe at the chip level so the cache warms even when the top-bar PR
-  // button isn't mounted (e.g. small viewport that hides it). The remaining
-  // PRs in a multi-PR task warm when the popover opens.
-  usePRFeedbackBackgroundSync(openPRs[0] ?? null);
+  // button isn't mounted (e.g. small viewport that hides it). Warm the PR the
+  // popover will actually open first (worst-status via pickDefaultPR — for a
+  // single PR that's just the PR itself); the remaining PRs in a multi-PR
+  // task warm when the popover opens.
+  usePRFeedbackBackgroundSync(pickDefaultPR(openPRs));
   if (openPRs.length === 0) return null;
   if (openPRs.length === 1) return <PRStatusChipInner pr={openPRs[0]} />;
   return <PRStatusChipMultiInner prs={openPRs} />;

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   IconCircleCheckFilled,
   IconCircleXFilled,
@@ -22,6 +22,7 @@ import { Button } from "@kandev/ui/button";
 import { useTaskPR } from "@/hooks/domains/github/use-task-pr";
 import { usePRFeedbackBackgroundSync } from "@/hooks/domains/github/use-pr-ci-popover";
 import { PRCIPopover } from "@/components/github/pr-ci-popover";
+import { MultiPRCIPopover } from "@/components/github/multi-pr-ci-popover";
 import { isPRAwaitingReview, isPRReadyToMerge } from "@/components/github/pr-task-icon";
 import { useIsMobile } from "@/hooks/use-mobile";
 import type { TaskPR } from "@/lib/types/github";
@@ -48,6 +49,47 @@ function chipStatus(pr: TaskPR): ChipStatus {
   return "neutral";
 }
 
+// Higher = more attention-worthy. Drives the aggregate glyph when a task has
+// multiple open PRs — one failing PR colours the whole chip red.
+const CHIP_STATUS_RANK: Record<ChipStatus, number> = {
+  failed: 3,
+  in_progress: 2,
+  passed: 1,
+  neutral: 0,
+};
+
+export function aggregateChipStatus(prs: TaskPR[]): ChipStatus {
+  let worst: ChipStatus = "neutral";
+  for (const pr of prs) {
+    const status = chipStatus(pr);
+    if (CHIP_STATUS_RANK[status] > CHIP_STATUS_RANK[worst]) worst = status;
+  }
+  return worst;
+}
+
+const CHIP_BUTTON_CLASS =
+  "cursor-pointer inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-xs";
+
+/**
+ * Radix HoverCard treats the trigger as outside the content's bounding box, so
+ * a click on the chip would auto-close the popover. This guard filters out
+ * trigger clicks so clicking the chip is a no-op while the popover stays open
+ * via hover. Returns the trigger ref plus a memoised handler that reads the ref
+ * lazily (inside the callback, never during render).
+ */
+function useChipTriggerGuard() {
+  const ref = useRef<HTMLButtonElement>(null);
+  const onPointerDownOutside = useCallback(
+    (e: { target: EventTarget | null; preventDefault: () => void }) => {
+      if (ref.current && ref.current.contains(e.target as Node)) {
+        e.preventDefault();
+      }
+    },
+    [],
+  );
+  return { ref, onPointerDownOutside };
+}
+
 /**
  * Compact CI indicator for the chat status bar — a "CI" prefix icon plus a
  * status glyph that mirrors the popover's bucket colors:
@@ -67,13 +109,18 @@ function chipStatus(pr: TaskPR): ChipStatus {
  * CI chip would be redundant.
  */
 export function PRStatusChip({ taskId }: { taskId: string | null }) {
-  const { pr } = useTaskPR(taskId);
-  // Subscribe at the chip level so the cache warms even when the
-  // top-bar PR button isn't mounted (e.g. small viewport that hides it).
-  usePRFeedbackBackgroundSync(pr);
-  if (!pr) return null;
-  if (pr.state === "merged" || pr.state === "closed") return null;
-  return <PRStatusChipInner pr={pr} />;
+  const { prs } = useTaskPR(taskId);
+  // Only open PRs are worth a CI chip — terminal PRs (merged/closed) are
+  // already conveyed by the chat-input banner. With multiple PRs the chip
+  // stays visible as long as at least one is still open.
+  const openPRs = prs.filter((p) => p.state !== "merged" && p.state !== "closed");
+  // Subscribe at the chip level so the cache warms even when the top-bar PR
+  // button isn't mounted (e.g. small viewport that hides it). The remaining
+  // PRs in a multi-PR task warm when the popover opens.
+  usePRFeedbackBackgroundSync(openPRs[0] ?? null);
+  if (openPRs.length === 0) return null;
+  if (openPRs.length === 1) return <PRStatusChipInner pr={openPRs[0]} />;
+  return <PRStatusChipMultiInner prs={openPRs} />;
 }
 
 type ChipButtonAttrs = {
@@ -94,7 +141,7 @@ function chipButtonAttrs(pr: TaskPR, status: ChipStatus): ChipButtonAttrs {
     "data-status": status,
     "data-pr-ready-to-merge": isPRReadyToMerge(pr) ? "true" : "false",
     "aria-label": `Pull request #${pr.pr_number} CI status`,
-    className: "cursor-pointer inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-xs",
+    className: CHIP_BUTTON_CLASS,
   };
 }
 
@@ -106,11 +153,11 @@ function PRStatusChipInner({ pr }: { pr: TaskPR }) {
 
 function PRStatusChipHoverCard({ pr }: { pr: TaskPR }) {
   const status = chipStatus(pr);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const { ref, onPointerDownOutside } = useChipTriggerGuard();
   return (
     <HoverCard openDelay={HOVER_OPEN_DELAY_MS} closeDelay={HOVER_CLOSE_DELAY_MS}>
       <HoverCardTrigger asChild>
-        <button ref={triggerRef} type="button" {...chipButtonAttrs(pr, status)}>
+        <button ref={ref} type="button" {...chipButtonAttrs(pr, status)}>
           <IconChecklist className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
           <ChipStatusGlyph status={status} />
         </button>
@@ -120,19 +167,108 @@ function PRStatusChipHoverCard({ pr }: { pr: TaskPR }) {
         align="start"
         sideOffset={8}
         className="w-80 p-2.5"
-        onPointerDownOutside={(e) => {
-          // Radix HoverCard treats the trigger as outside the content's
-          // bounding box, so a click on the chip would auto-close the
-          // popover. Filter out trigger clicks so clicking the chip is
-          // a no-op while the popover stays open via hover.
-          if (triggerRef.current && triggerRef.current.contains(e.target as Node)) {
-            e.preventDefault();
-          }
-        }}
+        onPointerDownOutside={onPointerDownOutside}
       >
         <PRCIPopover pr={pr} enabled={true} />
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+function PRStatusChipMultiInner({ prs }: { prs: TaskPR[] }) {
+  const isMobile = useIsMobile();
+  if (isMobile) return <PRStatusChipMultiDrawer prs={prs} />;
+  return <PRStatusChipMultiHoverCard prs={prs} />;
+}
+
+type MultiChipButtonAttrs = {
+  "data-testid": "pr-status-chip";
+  "data-pr-count": number;
+  "data-status": ChipStatus;
+  "aria-label": string;
+  className: string;
+};
+
+function multiChipButtonAttrs(prs: TaskPR[], status: ChipStatus): MultiChipButtonAttrs {
+  return {
+    "data-testid": "pr-status-chip",
+    "data-pr-count": prs.length,
+    "data-status": status,
+    "aria-label": `${prs.length} pull requests CI status`,
+    className: CHIP_BUTTON_CLASS,
+  };
+}
+
+function MultiChipGlyph({ prs, status }: { prs: TaskPR[]; status: ChipStatus }) {
+  return (
+    <>
+      <IconChecklist className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+      <ChipStatusGlyph status={status} />
+      <span className="text-[9px] font-semibold leading-none tabular-nums">{prs.length}</span>
+    </>
+  );
+}
+
+function PRStatusChipMultiHoverCard({ prs }: { prs: TaskPR[] }) {
+  const status = aggregateChipStatus(prs);
+  const { ref, onPointerDownOutside } = useChipTriggerGuard();
+  return (
+    <HoverCard openDelay={HOVER_OPEN_DELAY_MS} closeDelay={HOVER_CLOSE_DELAY_MS}>
+      <HoverCardTrigger asChild>
+        <button ref={ref} type="button" {...multiChipButtonAttrs(prs, status)}>
+          <MultiChipGlyph prs={prs} status={status} />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-96 p-2.5"
+        onPointerDownOutside={onPointerDownOutside}
+      >
+        <MultiPRCIPopover prs={prs} enabled={true} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function PRStatusChipMultiDrawer({ prs }: { prs: TaskPR[] }) {
+  const status = aggregateChipStatus(prs);
+  const [open, setOpen] = useState(false);
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        {...multiChipButtonAttrs(prs, status)}
+      >
+        <MultiChipGlyph prs={prs} status={status} />
+      </button>
+      <DrawerContent data-testid="pr-status-chip-drawer" className="max-h-[80vh] flex flex-col">
+        <DrawerHeader className="flex flex-row items-center justify-between border-b py-2">
+          <DrawerTitle className="text-sm">{prs.length} pull requests</DrawerTitle>
+          <DrawerDescription className="sr-only">
+            Pull request CI status, reviews, and checks summary.
+          </DrawerDescription>
+          <DrawerClose asChild>
+            <Button
+              data-testid="pr-status-chip-drawer-close"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Close PR status"
+              className="cursor-pointer"
+            >
+              <IconX className="h-4 w-4" />
+            </Button>
+          </DrawerClose>
+        </DrawerHeader>
+        <div className="flex-1 min-h-0 overflow-y-auto p-3" data-vaul-no-drag>
+          <MultiPRCIPopover prs={prs} enabled={open} />
+        </div>
+      </DrawerContent>
+    </Drawer>
   );
 }
 

--- a/apps/web/components/github/pr-task-icon.test.ts
+++ b/apps/web/components/github/pr-task-icon.test.ts
@@ -6,6 +6,8 @@ import {
   getPRTooltip,
   isPRAwaitingReview,
   isPRReadyToMerge,
+  pickDefaultPR,
+  prStatusRank,
 } from "./pr-task-icon";
 import type { TaskPR } from "@/lib/types/github";
 
@@ -483,6 +485,60 @@ describe("areAllOpenPRsReadyToMerge", () => {
 
   it("is true when every open PR is ready", () => {
     expect(areAllOpenPRsReadyToMerge([ready(), ready()])).toBe(true);
+  });
+});
+
+describe("prStatusRank", () => {
+  it("returns -1 for terminal PRs so they're never the default focus", () => {
+    expect(prStatusRank(makePR({ state: "merged" }))).toBe(-1);
+    expect(prStatusRank(makePR({ state: "closed" }))).toBe(-1);
+  });
+
+  it("ranks a failing open PR above a passing open PR", () => {
+    const failing = makePR({ state: "open", checks_state: "failure" });
+    const passing = makePR({
+      state: "open",
+      review_state: "approved",
+      checks_state: "success",
+      mergeable_state: "clean",
+    });
+    expect(prStatusRank(failing)).toBeGreaterThan(prStatusRank(passing));
+  });
+});
+
+describe("pickDefaultPR", () => {
+  it("returns null for an empty list", () => {
+    expect(pickDefaultPR([])).toBeNull();
+  });
+
+  it("picks the worst-status open PR (failing over passing)", () => {
+    const passing = makePR({
+      id: "pass",
+      state: "open",
+      review_state: "approved",
+      checks_state: "success",
+      mergeable_state: "clean",
+    });
+    const failing = makePR({ id: "fail", state: "open", checks_state: "failure" });
+    expect(pickDefaultPR([passing, failing])?.id).toBe("fail");
+  });
+
+  it("prefers an open PR over a terminal one even when listed first", () => {
+    const merged = makePR({ id: "merged", state: "merged" });
+    const open = makePR({ id: "open", state: "open", checks_state: "pending" });
+    expect(pickDefaultPR([merged, open])?.id).toBe("open");
+  });
+
+  it("breaks ties on the first PR (creation order)", () => {
+    const first = makePR({ id: "first", state: "open", checks_state: "failure" });
+    const second = makePR({ id: "second", state: "open", checks_state: "failure" });
+    expect(pickDefaultPR([first, second])?.id).toBe("first");
+  });
+
+  it("falls back to the first PR when every PR is terminal", () => {
+    const merged = makePR({ id: "merged", state: "merged" });
+    const closed = makePR({ id: "closed", state: "closed" });
+    expect(pickDefaultPR([merged, closed])?.id).toBe("merged");
   });
 });
 

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -121,6 +121,36 @@ export function areAllOpenPRsReadyToMerge(prs: TaskPR[]): boolean {
   return openPRs.length > 0 && openPRs.every(isPRReadyToMerge);
 }
 
+/**
+ * Attention rank for a single PR, reusing the same colour→rank table that
+ * drives the aggregate icon. Terminal PRs (merged/closed) return -1 so they're
+ * never the default focus when a task mixes open and finished PRs.
+ */
+export function prStatusRank(pr: TaskPR): number {
+  if (pr.state !== "open") return -1;
+  return STATUS_RANK[getPRStatusColor(pr)] ?? 0;
+}
+
+/**
+ * Picks the most attention-worthy PR to focus first in a multi-PR popover —
+ * the worst open status (failing > pending > awaiting-review > ready/passing).
+ * Ties resolve to the first PR (creation order). Falls back to the first PR
+ * when every PR is terminal so the popover always has something to show.
+ */
+export function pickDefaultPR(prs: TaskPR[]): TaskPR | null {
+  if (prs.length === 0) return null;
+  let best = prs[0];
+  let bestRank = prStatusRank(prs[0]);
+  for (const pr of prs) {
+    const rank = prStatusRank(pr);
+    if (rank > bestRank) {
+      best = pr;
+      bestRank = rank;
+    }
+  }
+  return best;
+}
+
 export function PRTaskIcon({ taskId }: { taskId: string }) {
   const prs = useAppStore((state) => state.taskPRs.byTaskId[taskId] ?? null);
 

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -141,10 +141,10 @@ export function pickDefaultPR(prs: TaskPR[]): TaskPR | null {
   if (prs.length === 0) return null;
   let best = prs[0];
   let bestRank = prStatusRank(prs[0]);
-  for (const pr of prs) {
-    const rank = prStatusRank(pr);
+  for (let i = 1; i < prs.length; i++) {
+    const rank = prStatusRank(prs[i]);
     if (rank > bestRank) {
-      best = pr;
+      best = prs[i];
       bestRank = rank;
     }
   }

--- a/apps/web/components/github/pr-topbar-button.tsx
+++ b/apps/web/components/github/pr-topbar-button.tsx
@@ -205,12 +205,15 @@ function PRMultiButton({ prs }: { prs: TaskPR[] }) {
   const addPRPanel = useDockviewStore((s) => s.addPRPanel);
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
   const { isMobile, open, onOpenChange, handleEnter, handleLeave } = usePopoverInteractions();
+  const [menuOpen, setMenuOpen] = useState(false);
   const aggColor = aggregatePRStatusColor(prs);
 
   // The trigger is the click target for the dropdown AND the hover anchor for
   // the popover. On desktop we wrap it in a PopoverAnchor so all the asChild
   // layers (Tooltip → Popover → Dropdown) collapse onto the single Button and
-  // the popover positions against it.
+  // the popover positions against it. While the dropdown is open the hover
+  // popover is closed and hover re-opens are suppressed, so the two overlays
+  // never stack.
   const triggerButton = (
     <DropdownMenuTrigger asChild>
       <Button
@@ -219,7 +222,7 @@ function PRMultiButton({ prs }: { prs: TaskPR[] }) {
         size="sm"
         variant="outline"
         className="cursor-pointer gap-1.5 px-2"
-        onMouseEnter={handleEnter}
+        onMouseEnter={menuOpen ? undefined : handleEnter}
         onMouseLeave={handleLeave}
       >
         <IconGitPullRequest className={`h-4 w-4 ${aggColor}`} />
@@ -230,7 +233,12 @@ function PRMultiButton({ prs }: { prs: TaskPR[] }) {
   );
 
   const dropdown = (
-    <DropdownMenu>
+    <DropdownMenu
+      onOpenChange={(next) => {
+        setMenuOpen(next);
+        if (next) onOpenChange(false);
+      }}
+    >
       <Tooltip>
         <TooltipTrigger asChild>
           {isMobile ? triggerButton : <PopoverAnchor asChild>{triggerButton}</PopoverAnchor>}

--- a/apps/web/components/github/pr-topbar-button.tsx
+++ b/apps/web/components/github/pr-topbar-button.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/github/pr-task-icon";
 import { prTaskKey } from "@/components/github/pr-detail-panel";
 import { PRCIPopover } from "@/components/github/pr-ci-popover";
+import { MultiPRCIPopover } from "@/components/github/multi-pr-ci-popover";
 import { useAppStore } from "@/components/state-provider";
 import type { TaskPR } from "@/lib/types/github";
 
@@ -197,57 +198,100 @@ function PRSingleButton({ pr }: { pr: TaskPR }) {
 }
 
 function PRMultiButton({ prs }: { prs: TaskPR[] }) {
-  // Multi-PR keeps the original dropdown semantics on every form factor —
-  // the popover lives inside the dropdown trigger via hover only, and the
-  // per-PR rows are the click targets that addPRPanel.
-  return <PRMultiDropdown prs={prs} />;
-}
-
-function PRMultiDropdown({ prs }: { prs: TaskPR[] }) {
+  // Click still drives the dropdown (the explicit "jump to this PR's panel"
+  // affordance, and the only interaction on touch). Hover adds the aggregate
+  // CI popover with a tab per PR — desktop only, suppressed on touch where
+  // there is no hover.
   const addPRPanel = useDockviewStore((s) => s.addPRPanel);
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
+  const { isMobile, open, onOpenChange, handleEnter, handleLeave } = usePopoverInteractions();
   const aggColor = aggregatePRStatusColor(prs);
-  return (
+
+  // The trigger is the click target for the dropdown AND the hover anchor for
+  // the popover. On desktop we wrap it in a PopoverAnchor so all the asChild
+  // layers (Tooltip → Popover → Dropdown) collapse onto the single Button and
+  // the popover positions against it.
+  const triggerButton = (
+    <DropdownMenuTrigger asChild>
+      <Button
+        data-testid="pr-topbar-button"
+        data-pr-count={prs.length}
+        size="sm"
+        variant="outline"
+        className="cursor-pointer gap-1.5 px-2"
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+      >
+        <IconGitPullRequest className={`h-4 w-4 ${aggColor}`} />
+        <span className="text-xs font-medium">{prs.length} PRs</span>
+        <IconChevronDown className="h-3 w-3 text-muted-foreground" />
+      </Button>
+    </DropdownMenuTrigger>
+  );
+
+  const dropdown = (
     <DropdownMenu>
       <Tooltip>
         <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              data-testid="pr-topbar-button"
-              data-pr-count={prs.length}
-              size="sm"
-              variant="outline"
-              className="cursor-pointer gap-1.5 px-2"
-            >
-              <IconGitPullRequest className={`h-4 w-4 ${aggColor}`} />
-              <span className="text-xs font-medium">{prs.length} PRs</span>
-              <IconChevronDown className="h-3 w-3 text-muted-foreground" />
-            </Button>
-          </DropdownMenuTrigger>
+          {isMobile ? triggerButton : <PopoverAnchor asChild>{triggerButton}</PopoverAnchor>}
         </TooltipTrigger>
         <TooltipContent>{prs.length} pull requests linked to this task — open one</TooltipContent>
       </Tooltip>
-      <DropdownMenuContent align="end" className="w-72">
-        <DropdownMenuLabel className="text-xs">Pull requests</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {prs.map((pr) => (
-          <DropdownMenuItem
-            key={pr.id}
-            onClick={() => addPRPanel(prTaskKey(pr), activeSessionId)}
-            className="cursor-pointer gap-2"
-            data-testid={`pr-topbar-menu-item-${pr.pr_number}`}
-          >
-            <IconGitPullRequest className={`h-4 w-4 shrink-0 ${getPRStatusColor(pr)}`} />
-            <div className="flex flex-col min-w-0 flex-1">
-              <span className="text-xs font-medium">
-                {pr.repo} #{pr.pr_number}
-              </span>
-              <span className="text-[11px] text-muted-foreground truncate">{pr.pr_title}</span>
-            </div>
-            <PRStatusIcon pr={pr} />
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
+      <MultiPRMenuContent prs={prs} />
     </DropdownMenu>
+  );
+
+  if (isMobile) return dropdown;
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      {dropdown}
+      <PopoverContent
+        data-testid="pr-topbar-popover"
+        align="end"
+        sideOffset={4}
+        className="w-96"
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <MultiPRCIPopover
+          prs={prs}
+          enabled={open}
+          onOpenDetailPanel={(pr) => {
+            addPRPanel(prTaskKey(pr), activeSessionId);
+            onOpenChange(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function MultiPRMenuContent({ prs }: { prs: TaskPR[] }) {
+  const addPRPanel = useDockviewStore((s) => s.addPRPanel);
+  const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
+  return (
+    <DropdownMenuContent align="end" className="w-72">
+      <DropdownMenuLabel className="text-xs">Pull requests</DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      {prs.map((pr) => (
+        <DropdownMenuItem
+          key={pr.id}
+          onClick={() => addPRPanel(prTaskKey(pr), activeSessionId)}
+          className="cursor-pointer gap-2"
+          data-testid={`pr-topbar-menu-item-${pr.pr_number}`}
+        >
+          <IconGitPullRequest className={`h-4 w-4 shrink-0 ${getPRStatusColor(pr)}`} />
+          <div className="flex flex-col min-w-0 flex-1">
+            <span className="text-xs font-medium">
+              {pr.repo} #{pr.pr_number}
+            </span>
+            <span className="text-[11px] text-muted-foreground truncate">{pr.pr_title}</span>
+          </div>
+          <PRStatusIcon pr={pr} />
+        </DropdownMenuItem>
+      ))}
+    </DropdownMenuContent>
   );
 }

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -592,9 +592,9 @@ export class SessionPage {
     return this.page.getByTestId("pr-multi-popover");
   }
 
-  /** A single PR tab inside the multi-PR aggregate popover, by PR number. */
-  prMultiPopoverTab(prNumber: number): Locator {
-    return this.page.getByTestId(`pr-popover-tab-${prNumber}`);
+  /** A single PR tab inside the multi-PR aggregate popover, by repo + PR number. */
+  prMultiPopoverTab(repo: string, prNumber: number): Locator {
+    return this.page.getByTestId(`pr-popover-tab-${repo}-${prNumber}`);
   }
 
   /** A specific bucket group inside the popover by kind. */

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -597,7 +597,13 @@ export class SessionPage {
     return this.page.getByTestId(`pr-popover-tab-${repo}-${prNumber}`);
   }
 
-  /** A specific bucket group inside the popover by kind. */
+  /**
+   * A specific bucket group inside the popover by kind.
+   *
+   * Scoped to the TOPBAR popover (`pr-topbar-popover`) — the chip's HoverCard
+   * renders the same inner content without that wrapper, so specs asserting
+   * check groups after hovering the status chip need a chip-scoped variant.
+   */
   prCheckGroup(kind: "passed" | "in_progress" | "failed"): Locator {
     return this.prTopbarPopover().locator(`[data-testid='pr-check-group'][data-kind='${kind}']`);
   }

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -587,9 +587,14 @@ export class SessionPage {
     await expect(this.prStatusChipDrawer()).toBeVisible({ timeout: 5_000 });
   }
 
-  /** Multi-PR aggregate popover content. */
+  /** Multi-PR aggregate popover content (segmented tabs + selected PR's CI). */
   prTopbarPopoverAggregate(): Locator {
-    return this.page.getByTestId("pr-topbar-popover-aggregate");
+    return this.page.getByTestId("pr-multi-popover");
+  }
+
+  /** A single PR tab inside the multi-PR aggregate popover, by PR number. */
+  prMultiPopoverTab(prNumber: number): Locator {
+    return this.page.getByTestId(`pr-popover-tab-${prNumber}`);
   }
 
   /** A specific bucket group inside the popover by kind. */

--- a/apps/web/e2e/tests/pr/pr-multi-popover.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-multi-popover.spec.ts
@@ -142,14 +142,14 @@ test.describe("Multi-PR CI popover", () => {
     await expect(session.prTopbarPopoverAggregate()).toBeVisible({ timeout: 10_000 });
 
     // Default tab = worst status: failing web#42, not first-created green api#77.
-    await expect(session.prMultiPopoverTab(42)).toHaveAttribute("data-active", "true");
-    await expect(session.prMultiPopoverTab(77)).toHaveAttribute("data-active", "false");
+    await expect(session.prMultiPopoverTab("web", 42)).toHaveAttribute("data-active", "true");
+    await expect(session.prMultiPopoverTab("api", 77)).toHaveAttribute("data-active", "false");
     // Body shows the failing PR's bucket groups (failed group present).
     await expect(session.prCheckGroup("failed")).toBeVisible();
 
     // Switch to the green PR: failed group disappears, passed shows 4.
-    await session.prMultiPopoverTab(77).click();
-    await expect(session.prMultiPopoverTab(77)).toHaveAttribute("data-active", "true");
+    await session.prMultiPopoverTab("api", 77).click();
+    await expect(session.prMultiPopoverTab("api", 77)).toHaveAttribute("data-active", "true");
     await expect(session.prCheckGroup("failed")).toHaveCount(0);
     await expect(session.prCheckGroupCount("passed")).toHaveText("4");
   });
@@ -179,7 +179,7 @@ test.describe("Multi-PR CI popover", () => {
 
     await chip.hover();
     await expect(session.prTopbarPopoverAggregate()).toBeVisible({ timeout: 10_000 });
-    await expect(session.prMultiPopoverTab(42)).toHaveAttribute("data-active", "true");
+    await expect(session.prMultiPopoverTab("web", 42)).toHaveAttribute("data-active", "true");
   });
 
   test("clicking the multi-PR button still opens the dropdown with per-PR rows", async ({

--- a/apps/web/e2e/tests/pr/pr-multi-popover.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-multi-popover.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+import { SessionPage } from "../../pages/session-page";
+import type { ApiClient } from "../../helpers/api-client";
+
+const OWNER = "acme";
+
+type SeedResult = {
+  workflowId: string;
+  workingStepId: string;
+  doneStepId: string;
+  taskId: string;
+};
+
+/**
+ * Stand up a workspace + workflow + task that reaches the Done column
+ * immediately (auto-start + on_turn_complete moves it), mirroring
+ * pr-topbar-popover.spec.ts.
+ */
+async function seedTask(
+  apiClient: ApiClient,
+  workspaceId: string,
+  agentProfileId: string,
+  repositoryId: string,
+  title: string,
+): Promise<SeedResult> {
+  const workflow = await apiClient.createWorkflow(workspaceId, `${title} Workflow`);
+  const inbox = await apiClient.createWorkflowStep(workflow.id, "Inbox", 0);
+  const working = await apiClient.createWorkflowStep(workflow.id, "Working", 1);
+  const done = await apiClient.createWorkflowStep(workflow.id, "Done", 2);
+
+  await apiClient.updateWorkflowStep(working.id, {
+    prompt: 'e2e:message("done")\n{{task_prompt}}',
+    events: {
+      on_enter: [{ type: "auto_start_agent" }],
+      on_turn_complete: [{ type: "move_to_step", config: { step_id: done.id } }],
+    },
+  });
+
+  await apiClient.saveUserSettings({
+    workspace_id: workspaceId,
+    workflow_filter_id: workflow.id,
+    enable_preview_on_click: false,
+  });
+
+  await apiClient.mockGitHubReset();
+  await apiClient.mockGitHubSetUser("test-user");
+
+  const task = await apiClient.createTask(workspaceId, title, {
+    workflow_id: workflow.id,
+    workflow_step_id: inbox.id,
+    agent_profile_id: agentProfileId,
+    repository_ids: [repositoryId],
+  });
+
+  return {
+    workflowId: workflow.id,
+    workingStepId: working.id,
+    doneStepId: done.id,
+    taskId: task.id,
+  };
+}
+
+/** Associate two open PRs with the task: web#42 failing, api#77 all green. */
+async function associateTwoPRs(apiClient: ApiClient, taskId: string) {
+  await apiClient.mockGitHubAssociateTaskPR({
+    task_id: taskId,
+    owner: OWNER,
+    repo: "web",
+    pr_number: 42,
+    pr_url: `https://github.com/${OWNER}/web/pull/42`,
+    pr_title: "Failing web PR",
+    head_branch: "feat/web",
+    base_branch: "main",
+    author_login: "test-user",
+    state: "open",
+    checks_state: "failure",
+    checks_total: 6,
+    checks_passing: 4,
+    review_state: "changes_requested",
+    review_count: 1,
+  });
+  await apiClient.mockGitHubAssociateTaskPR({
+    task_id: taskId,
+    owner: OWNER,
+    repo: "api",
+    pr_number: 77,
+    pr_url: `https://github.com/${OWNER}/api/pull/77`,
+    pr_title: "Green api PR",
+    head_branch: "feat/api",
+    base_branch: "main",
+    author_login: "test-user",
+    state: "open",
+    checks_state: "success",
+    checks_total: 4,
+    checks_passing: 4,
+    review_state: "approved",
+    review_count: 2,
+    required_reviews: 2,
+    mergeable_state: "clean",
+  });
+}
+
+async function openTaskAndWait(
+  testPage: import("@playwright/test").Page,
+  apiClient: ApiClient,
+  seed: SeedResult,
+  title: string,
+): Promise<SessionPage> {
+  const kanban = new KanbanPage(testPage);
+  await kanban.goto();
+  await apiClient.moveTask(seed.taskId, seed.workflowId, seed.workingStepId);
+  await expect(kanban.taskCardInColumn(title, seed.doneStepId)).toBeVisible({ timeout: 45_000 });
+  await kanban.taskCardInColumn(title, seed.doneStepId).click();
+  await expect(testPage).toHaveURL(/\/[st]\//, { timeout: 15_000 });
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  await expect(session.prTopbarButton()).toBeVisible({ timeout: 15_000 });
+  return session;
+}
+
+test.describe("Multi-PR CI popover", () => {
+  test("hover opens tabbed popover defaulting to the worst-status PR; tab switch swaps CI detail", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const title = "Multi Popover Tabs";
+    const seed = await seedTask(
+      apiClient,
+      seedData.workspaceId,
+      seedData.agentProfileId,
+      seedData.repositoryId,
+      title,
+    );
+    await associateTwoPRs(apiClient, seed.taskId);
+    const session = await openTaskAndWait(testPage, apiClient, seed, title);
+
+    await expect(session.prTopbarButton()).toHaveAttribute("data-pr-count", "2");
+    await session.hoverPRTopbar();
+    await expect(session.prTopbarPopoverAggregate()).toBeVisible({ timeout: 10_000 });
+
+    // Default tab = worst status: failing web#42, not first-created green api#77.
+    await expect(session.prMultiPopoverTab(42)).toHaveAttribute("data-active", "true");
+    await expect(session.prMultiPopoverTab(77)).toHaveAttribute("data-active", "false");
+    // Body shows the failing PR's bucket groups (failed group present).
+    await expect(session.prCheckGroup("failed")).toBeVisible();
+
+    // Switch to the green PR: failed group disappears, passed shows 4.
+    await session.prMultiPopoverTab(77).click();
+    await expect(session.prMultiPopoverTab(77)).toHaveAttribute("data-active", "true");
+    await expect(session.prCheckGroup("failed")).toHaveCount(0);
+    await expect(session.prCheckGroupCount("passed")).toHaveText("4");
+  });
+
+  test("chat-input chip aggregates multiple PRs and opens the tabbed popover", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const title = "Multi Popover Chip";
+    const seed = await seedTask(
+      apiClient,
+      seedData.workspaceId,
+      seedData.agentProfileId,
+      seedData.repositoryId,
+      title,
+    );
+    await associateTwoPRs(apiClient, seed.taskId);
+    const session = await openTaskAndWait(testPage, apiClient, seed, title);
+
+    const chip = session.prStatusChip();
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveAttribute("data-pr-count", "2");
+    // web#42 is failing, so the aggregate (worst-of) status is failed.
+    await expect(chip).toHaveAttribute("data-status", "failed");
+
+    await chip.hover();
+    await expect(session.prTopbarPopoverAggregate()).toBeVisible({ timeout: 10_000 });
+    await expect(session.prMultiPopoverTab(42)).toHaveAttribute("data-active", "true");
+  });
+
+  test("clicking the multi-PR button still opens the dropdown with per-PR rows", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const title = "Multi Popover Dropdown";
+    const seed = await seedTask(
+      apiClient,
+      seedData.workspaceId,
+      seedData.agentProfileId,
+      seedData.repositoryId,
+      title,
+    );
+    await associateTwoPRs(apiClient, seed.taskId);
+    const session = await openTaskAndWait(testPage, apiClient, seed, title);
+
+    await session.prTopbarButton().click();
+    await expect(testPage.getByTestId("pr-topbar-menu-item-42")).toBeVisible();
+    await expect(testPage.getByTestId("pr-topbar-menu-item-77")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Tasks with 2+ PRs (multi-repo) lost all rich CI detail: the topbar button degraded to a plain dropdown with no checks/review info, and the chat-input CI chip silently showed only the first PR, hiding the rest. Both surfaces now share a tabbed `MultiPRCIPopover` that reuses the existing single-PR popover per tab, so multi-PR tasks get full CI fidelity (pass-rate bar, workflow groups, merge button) with problems surfaced first.

## Important Changes

- New `multi-pr-ci-popover.tsx`: segmented tab header (one chip per PR, status-colored) + body delegating to `PRCIPopover` for the selected PR; defaults to the worst-status open PR via new `pickDefaultPR`/`prStatusRank` helpers in `pr-task-icon.tsx`.
- Topbar `N PRs` button: hover now opens the tabbed popover; click keeps the existing dropdown → PR-panel navigation (no behavior regression).
- Chat-input `PRStatusChip`: aggregates worst-of status across open PRs with a count badge, opens the tabbed popover (HoverCard on desktop, Drawer on mobile), and hides only when **all** PRs are terminal — previously an open PR vanished if the first PR was merged/closed.

## Validation

- `pnpm --filter @kandev/web typecheck` / `lint` / `prettier --check` — clean
- `vitest run components/github` — 145 passed (incl. new `pickDefaultPR`, `prStatusRank`, `aggregateChipStatus`, multi-PR chip render tests)
- `playwright test tests/pr/pr-multi-popover.spec.ts` — 3 passed (default tab = worst status, tab switch swaps CI detail, chip aggregate + count, dropdown preserved)
- Manually verified against an isolated mock-GitHub instance: tab switching, merge button on green tab, add-to-context on failing workflows, dropdown nav.

## Possible Improvements

Tab header scrolls horizontally for 5+ PRs but has no overflow indicator; if multi-repo tasks routinely exceed ~4 PRs a master-detail layout would scale better.

## Checklist

- [ ] Code follows project conventions
- [ ] Tests added/updated
- [ ] Documentation updated if needed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->