### PR TITLE
fix: keep agent tab before PR tab

### DIFF
--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -17,10 +17,25 @@ type FakePanel = {
   api: { close: ReturnType<typeof vi.fn<[], void>> };
 };
 
+type MoveToOptions = {
+  group: unknown;
+  position: "center";
+  index: number;
+  skipSetActive: boolean;
+};
+
+type MoveToCall = {
+  panelId: string;
+  options: MoveToOptions;
+};
+
 const KEEP = "keep";
 const KEEP_PANEL = `session:${KEEP}`;
 const LEAKED_PANEL = "session:leaked";
 const PENDING_SESSION_ID = "session-new";
+const TEST_GROUP_CENTER = "group-center";
+const CENTER_POSITION = "center";
+const SIBLING_PANEL = "session:sibling";
 
 /**
  * Builds a fake DockviewApi where `panel.api.close()` mutates the underlying
@@ -67,6 +82,42 @@ function makePositionApi(args: {
 
 function panelById(panels: FakePanel[], id: string): FakePanel | undefined {
   return panels.find((p) => p.id === id);
+}
+
+function makeTabOrderApi(panelIds: string[]): {
+  api: DockviewApi;
+  moveToCalls: MoveToCall[];
+} {
+  const moveToCalls: MoveToCall[] = [];
+  const group = { id: TEST_GROUP_CENTER, panels: [] as Array<{ id: string }> };
+  const panels = panelIds.map((id) => ({
+    id,
+    group,
+    api: {
+      moveTo: vi.fn((options: MoveToOptions) => {
+        moveToCalls.push({ panelId: id, options });
+      }),
+    },
+  }));
+  group.panels = panels;
+  return {
+    api: {
+      getPanel: (id: string) => panels.find((p) => p.id === id) ?? null,
+    } as unknown as DockviewApi,
+    moveToCalls,
+  };
+}
+
+function expectedMove(panelId: string, index: number): MoveToCall {
+  return {
+    panelId,
+    options: {
+      group: expect.objectContaining({ id: TEST_GROUP_CENTER }),
+      position: CENTER_POSITION,
+      index,
+      skipSetActive: true,
+    },
+  };
 }
 
 describe("reconcileRemovedSessionPanels", () => {
@@ -227,58 +278,52 @@ describe("resolveInitialPosition", () => {
 });
 
 describe("ensureSessionTabPrecedesNonSessionTabs", () => {
-  function makeTabOrderApi(panelIds: string[]): {
-    api: DockviewApi;
-    moveTo: ReturnType<typeof vi.fn>;
-  } {
-    const moveTo = vi.fn();
-    const group = { id: "group-center", panels: [] as Array<{ id: string }> };
-    const panels = panelIds.map((id) => ({
-      id,
-      group,
-      api: { moveTo },
-    }));
-    group.panels = panels;
-    return {
-      api: {
-        getPanel: (id: string) => panels.find((p) => p.id === id) ?? null,
-      } as unknown as DockviewApi,
-      moveTo,
-    };
-  }
-
   it("moves a restored session tab before a PR tab that was saved first", () => {
-    const { api, moveTo } = makeTabOrderApi(["pr-detail", KEEP_PANEL, "preview:file-diff"]);
+    const { api, moveToCalls } = makeTabOrderApi(["pr-detail", KEEP_PANEL, "preview:file-diff"]);
 
     ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
 
-    expect(moveTo).toHaveBeenCalledWith({
-      group: expect.objectContaining({ id: "group-center" }),
-      position: "center",
-      index: 0,
-      skipSetActive: true,
-    });
+    expect(moveToCalls).toEqual([expectedMove(KEEP_PANEL, 0)]);
+  });
+
+  it("moves interleaved session tabs as a stable block before non-session tabs", () => {
+    const { api, moveToCalls } = makeTabOrderApi(["pr-detail", SIBLING_PANEL, KEEP_PANEL]);
+
+    ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
+
+    expect(moveToCalls).toEqual([expectedMove(KEEP_PANEL, 0), expectedMove(SIBLING_PANEL, 0)]);
+  });
+
+  it("does not move when session tabs already precede non-session tabs", () => {
+    const { api, moveToCalls } = makeTabOrderApi([KEEP_PANEL, SIBLING_PANEL, "pr-detail"]);
+
+    ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
+
+    expect(moveToCalls).toEqual([]);
   });
 
   it("does not move when the session tab already precedes non-session tabs", () => {
-    const { api, moveTo } = makeTabOrderApi([KEEP_PANEL, "pr-detail"]);
+    const { api, moveToCalls } = makeTabOrderApi([KEEP_PANEL, "pr-detail"]);
 
     ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
 
-    expect(moveTo).not.toHaveBeenCalled();
+    expect(moveToCalls).toEqual([]);
   });
 
   it("keeps earlier session tabs ahead of the active session tab", () => {
-    const { api, moveTo } = makeTabOrderApi(["session:older", "pr-detail", KEEP_PANEL]);
+    const { api, moveToCalls } = makeTabOrderApi(["session:older", "pr-detail", KEEP_PANEL]);
 
     ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
 
-    expect(moveTo).toHaveBeenCalledWith({
-      group: expect.objectContaining({ id: "group-center" }),
-      position: "center",
-      index: 1,
-      skipSetActive: true,
-    });
+    expect(moveToCalls).toEqual([expectedMove(KEEP_PANEL, 1)]);
+  });
+
+  it("does not move when the target session panel is absent", () => {
+    const { api, moveToCalls } = makeTabOrderApi(["pr-detail", SIBLING_PANEL]);
+
+    ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
+
+    expect(moveToCalls).toEqual([]);
   });
 });
 

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { DockviewApi } from "dockview-react";
 import type { TaskSession } from "@/lib/types/http";
 import {
+  ensureSessionTabPrecedesNonSessionTabs,
   findSessionAnchorGroupId,
   reconcileRemovedSessionPanels,
   resolveInitialPosition,
@@ -221,6 +222,62 @@ describe("resolveInitialPosition", () => {
     expect(resolveInitialPosition(api)).toEqual({
       referenceGroup: RIGHT_TOP_GROUP,
       direction: "left",
+    });
+  });
+});
+
+describe("ensureSessionTabPrecedesNonSessionTabs", () => {
+  function makeTabOrderApi(panelIds: string[]): {
+    api: DockviewApi;
+    moveTo: ReturnType<typeof vi.fn>;
+  } {
+    const moveTo = vi.fn();
+    const group = { id: "group-center", panels: [] as Array<{ id: string }> };
+    const panels = panelIds.map((id) => ({
+      id,
+      group,
+      api: { moveTo },
+    }));
+    group.panels = panels;
+    return {
+      api: {
+        getPanel: (id: string) => panels.find((p) => p.id === id) ?? null,
+      } as unknown as DockviewApi,
+      moveTo,
+    };
+  }
+
+  it("moves a restored session tab before a PR tab that was saved first", () => {
+    const { api, moveTo } = makeTabOrderApi(["pr-detail", KEEP_PANEL, "preview:file-diff"]);
+
+    ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
+
+    expect(moveTo).toHaveBeenCalledWith({
+      group: expect.objectContaining({ id: "group-center" }),
+      position: "center",
+      index: 0,
+      skipSetActive: true,
+    });
+  });
+
+  it("does not move when the session tab already precedes non-session tabs", () => {
+    const { api, moveTo } = makeTabOrderApi([KEEP_PANEL, "pr-detail"]);
+
+    ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
+
+    expect(moveTo).not.toHaveBeenCalled();
+  });
+
+  it("keeps earlier session tabs ahead of the active session tab", () => {
+    const { api, moveTo } = makeTabOrderApi(["session:older", "pr-detail", KEEP_PANEL]);
+
+    ensureSessionTabPrecedesNonSessionTabs(api, KEEP);
+
+    expect(moveTo).toHaveBeenCalledWith({
+      group: expect.objectContaining({ id: "group-center" }),
+      position: "center",
+      index: 1,
+      skipSetActive: true,
     });
   });
 });

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -443,6 +443,33 @@ function removeChatPlaceholder(api: DockviewApi): void {
 }
 
 /**
+ * Keep agent/session tabs before contextual siblings in their tab group.
+ *
+ * Dockview restores saved tab order verbatim. If a task previously saved
+ * `pr-detail` before `session:<id>`, the restored agent panel already exists,
+ * so `resolveInitialPosition(... index: 0)` never runs. Move only across
+ * non-session siblings so multi-session ordering remains stable.
+ */
+export function ensureSessionTabPrecedesNonSessionTabs(api: DockviewApi, sessionId: string): void {
+  const panel = api.getPanel(`session:${sessionId}`);
+  const groupPanels = panel?.group?.panels;
+  if (!panel || !groupPanels) return;
+
+  const currentIndex = groupPanels.findIndex((p) => p.id === panel.id);
+  if (currentIndex <= 0) return;
+
+  const firstNonSessionIndex = groupPanels.findIndex((p) => !p.id.startsWith("session:"));
+  if (firstNonSessionIndex === -1 || firstNonSessionIndex >= currentIndex) return;
+
+  panel.api.moveTo({
+    group: panel.group,
+    position: "center",
+    index: firstNonSessionIndex,
+    skipSetActive: true,
+  });
+}
+
+/**
  * Decide whether to force-activate the session panel after it (and any
  * sibling tabs) have been ensured.
  *
@@ -690,6 +717,7 @@ function runAutoSessionTabEffect(
   // "chat" placeholder. Order matters: removing chat first would empty and
   // destroy the center group, collapsing the horizontal layout.
   removeChatPlaceholder(api);
+  ensureSessionTabPrecedesNonSessionTabs(api, effectiveSessionId);
 
   const activePanel = activateSessionPanel(
     api,

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -447,26 +447,29 @@ function removeChatPlaceholder(api: DockviewApi): void {
  *
  * Dockview restores saved tab order verbatim. If a task previously saved
  * `pr-detail` before `session:<id>`, the restored agent panel already exists,
- * so `resolveInitialPosition(... index: 0)` never runs. Move only across
- * non-session siblings so multi-session ordering remains stable.
+ * so `resolveInitialPosition(... index: 0)` never runs. Move session siblings
+ * as a stable block so multi-session ordering remains stable.
  */
 export function ensureSessionTabPrecedesNonSessionTabs(api: DockviewApi, sessionId: string): void {
   const panel = api.getPanel(`session:${sessionId}`);
   const groupPanels = panel?.group?.panels;
   if (!panel || !groupPanels) return;
 
-  const currentIndex = groupPanels.findIndex((p) => p.id === panel.id);
-  if (currentIndex <= 0) return;
-
   const firstNonSessionIndex = groupPanels.findIndex((p) => !p.id.startsWith("session:"));
-  if (firstNonSessionIndex === -1 || firstNonSessionIndex >= currentIndex) return;
+  if (firstNonSessionIndex === -1) return;
 
-  panel.api.moveTo({
-    group: panel.group,
-    position: "center",
-    index: firstNonSessionIndex,
-    skipSetActive: true,
-  });
+  const sessionPanelsToMove = groupPanels
+    .slice(firstNonSessionIndex + 1)
+    .filter((groupPanel) => groupPanel.id.startsWith("session:"));
+
+  for (const sessionPanel of sessionPanelsToMove.reverse()) {
+    sessionPanel.api.moveTo({
+      group: panel.group,
+      position: "center",
+      index: firstNonSessionIndex,
+      skipSetActive: true,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Restored Dockview layouts could preserve a PR-first tab order after task switches, making the agent tab appear second. Normalize restored session tab ordering so agent tabs stay ahead of PR/diff/file siblings.

## Validation

- `make fmt`
- `make typecheck test lint`

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->