### PR TITLE
fix: improve diff undo and wrapping defaults

### DIFF
--- a/apps/web/components/diff/diff-defaults.ts
+++ b/apps/web/components/diff/diff-defaults.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_DIFF_WORD_WRAP = true;

--- a/apps/web/components/diff/diff-viewer.test.tsx
+++ b/apps/web/components/diff/diff-viewer.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DiffViewer } from "./diff-viewer";
+import type { FileDiffData } from "@/lib/diff/types";
+
+const fileDiffProps: Array<{ options?: { overflow?: string } }> = [];
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "dark" }),
+}));
+
+vi.mock("@pierre/diffs/react", () => ({
+  FileDiff: (props: { options?: { overflow?: string } }) => {
+    fileDiffProps.push(props);
+    return <div data-testid="file-diff" />;
+  },
+}));
+
+const data: FileDiffData = {
+  filePath: "src/example.ts",
+  diff: "diff --git a/src/example.ts b/src/example.ts\n--- a/src/example.ts\n+++ b/src/example.ts\n@@ -1 +1 @@\n-old\n+new\n",
+  oldContent: "old\n",
+  newContent: "new\n",
+  additions: 1,
+  deletions: 1,
+};
+
+afterEach(() => {
+  cleanup();
+  fileDiffProps.length = 0;
+});
+
+describe("DiffViewer", () => {
+  it("wraps diff lines by default", async () => {
+    render(<DiffViewer data={data} />);
+
+    await waitFor(() => expect(fileDiffProps.length).toBeGreaterThan(0));
+    expect(fileDiffProps.at(-1)?.options?.overflow).toBe("wrap");
+  });
+});

--- a/apps/web/components/diff/diff-viewer.tsx
+++ b/apps/web/components/diff/diff-viewer.tsx
@@ -6,6 +6,7 @@ import { cn } from "@kandev/ui/lib/utils";
 import type { FileDiffData, DiffComment } from "@/lib/diff/types";
 import { useHunkHover } from "./use-hunk-hover";
 import { useAnnotationRenderer } from "./use-diff-annotation-renderer";
+import { DEFAULT_DIFF_WORD_WRAP } from "./diff-defaults";
 import { useDiffOptions } from "./use-diff-options";
 import { useDiffViewerState } from "./use-diff-viewer-state";
 
@@ -207,7 +208,7 @@ export const DiffViewer = memo(function DiffViewer({
   onToggleExpandUnchanged: onToggleExpandUnchangedProp,
   repo,
 }: DiffViewerProps) {
-  const [wordWrapLocal, setWordWrap] = useState(false);
+  const [wordWrapLocal, setWordWrap] = useState(DEFAULT_DIFF_WORD_WRAP);
   const wordWrap = wordWrapProp ?? wordWrapLocal;
   const [expandUnchangedLocal, setExpandUnchangedLocal] = useState(false);
   const expandUnchanged = expandUnchangedProp ?? expandUnchangedLocal;

--- a/apps/web/components/diff/hunk-action-bar.test.tsx
+++ b/apps/web/components/diff/hunk-action-bar.test.tsx
@@ -26,4 +26,23 @@ describe("HunkActionBar", () => {
     await waitFor(() => expect(onRevert).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(button.hasAttribute("disabled")).toBe(false));
   });
+
+  it("clears loading and swallows the click error when revert rejects", async () => {
+    const onRevert = vi.fn().mockRejectedValue(new Error("revert failed"));
+
+    render(
+      <HunkActionBar
+        changeBlockId="cb-1"
+        onRevert={onRevert}
+        onMouseEnter={() => {}}
+        onMouseLeave={() => {}}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Undo" });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(onRevert).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(button.hasAttribute("disabled")).toBe(false));
+  });
 });

--- a/apps/web/components/diff/hunk-action-bar.test.tsx
+++ b/apps/web/components/diff/hunk-action-bar.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { HunkActionBar } from "./hunk-action-bar";
+
+describe("HunkActionBar", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("clears loading when revert resolves without unmounting the hunk", async () => {
+    const onRevert = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <HunkActionBar
+        changeBlockId="cb-1"
+        onRevert={onRevert}
+        onMouseEnter={() => {}}
+        onMouseLeave={() => {}}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Undo" });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(onRevert).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(button.hasAttribute("disabled")).toBe(false));
+  });
+});

--- a/apps/web/components/diff/hunk-action-bar.tsx
+++ b/apps/web/components/diff/hunk-action-bar.tsx
@@ -31,6 +31,9 @@ export function HunkActionBar({
     setLoading(true);
     try {
       await onRevert();
+    } catch {
+      // Revert failures are surfaced by the caller; keep this overlay from
+      // turning a failed async action into an unhandled event rejection.
     } finally {
       if (!mountedRef.current) return;
       setLoading(false);

--- a/apps/web/components/diff/hunk-action-bar.tsx
+++ b/apps/web/components/diff/hunk-action-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@kandev/ui/button";
 import { IconArrowBackUp, IconLoader2 } from "@tabler/icons-react";
 
@@ -18,14 +18,21 @@ export function HunkActionBar({
   onMouseLeave,
 }: HunkActionBarProps) {
   const [loading, setLoading] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
 
   const handleClick = async () => {
     setLoading(true);
     try {
       await onRevert();
-      // Don't setLoading(false) on success — the diff will re-render
-      // and unmount this component when the git status refreshes
-    } catch {
+    } finally {
+      if (!mountedRef.current) return;
       setLoading(false);
     }
   };

--- a/apps/web/components/diff/use-diff-options.tsx
+++ b/apps/web/components/diff/use-diff-options.tsx
@@ -52,6 +52,23 @@ const DIFF_UNSAFE_CSS = `
     padding-inline: 12px !important;
     background: var(--card) !important;
   }
+  [data-header-content] {
+    display: flex !important;
+    align-items: center !important;
+    gap: 6px !important;
+    min-width: 0 !important;
+  }
+  [data-title],
+  [data-prev-name] {
+    min-width: 0 !important;
+  }
+  [data-title] bdi,
+  [data-prev-name] bdi {
+    display: block !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
+  }
   /* Vertically center the "Add comment" hover button in the line gutter.
      Pierre 1.1.22 declares the slot wrapper as display:flex with top:0/bottom:0
      but no align-items, so our fixed-size button pins to the top of the line

--- a/apps/web/components/review/review-dialog.tsx
+++ b/apps/web/components/review/review-dialog.tsx
@@ -11,6 +11,7 @@ import { useGitOperations } from "@/hooks/use-git-operations";
 import { useReviewSidebarResize } from "@/hooks/use-review-sidebar-resize";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
+import { DEFAULT_DIFF_WORD_WRAP } from "@/components/diff/diff-defaults";
 import { ReviewTopBar } from "./review-top-bar";
 import { ReviewFileTree } from "./review-file-tree";
 import { ReviewDiffList } from "./review-diff-list";
@@ -317,7 +318,7 @@ function useReviewDialogState(props: ReviewDialogProps) {
   const [splitView, setSplitView] = useState(() =>
     typeof window === "undefined" ? false : localStorage.getItem("diff-view-mode") === "split",
   );
-  const [wordWrap, setWordWrap] = useState(false);
+  const [wordWrap, setWordWrap] = useState(DEFAULT_DIFF_WORD_WRAP);
   const autoMarkOnScroll = useAppStore((s) => s.userSettings.reviewAutoMarkOnScroll);
   const { reviews, markReviewed, markUnreviewed } = useSessionFileReviews(sessionId);
   const byId = useCommentsStore((s) => s.byId);

--- a/apps/web/components/task/commit-detail-panel.tsx
+++ b/apps/web/components/task/commit-detail-panel.tsx
@@ -4,6 +4,7 @@ import { memo, useEffect, useMemo } from "react";
 import { IconLoader2 } from "@tabler/icons-react";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { FileDiffViewer } from "@/components/diff";
+import { DEFAULT_DIFF_WORD_WRAP } from "@/components/diff/diff-defaults";
 import { useAppStore } from "@/components/state-provider";
 import { useSessionCommits } from "@/hooks/domains/session/use-session-commits";
 import { useCommitDiff } from "@/hooks/domains/session/use-commit-diff";
@@ -65,7 +66,7 @@ export const CommitDiffView = memo(function CommitDiffView({
   sha: commitSha,
   repo,
   onOpenFile,
-  wordWrap,
+  wordWrap = DEFAULT_DIFF_WORD_WRAP,
 }: CommitDiffViewProps) {
   const commit = useActiveCommit(commitSha);
   const { files, loading } = useCommitDiff(commitSha, repo);

--- a/apps/web/components/task/task-changes-panel.tsx
+++ b/apps/web/components/task/task-changes-panel.tsx
@@ -13,6 +13,7 @@ import { getWebSocketClient } from "@/lib/ws/connection";
 import { updateUserSettings } from "@/lib/api";
 import { formatReviewCommentsAsMarkdown } from "@/lib/state/slices/comments/format";
 import { ReviewDiffList } from "@/components/review/review-diff-list";
+import { DEFAULT_DIFF_WORD_WRAP } from "@/components/diff/diff-defaults";
 import type { ReviewFile } from "@/components/review/types";
 import { hashDiff, reviewFileKey, splitReviewFileKey } from "@/components/review/types";
 import { usePanelActions } from "@/hooks/use-panel-actions";
@@ -34,7 +35,7 @@ type TaskChangesPanelProps = {
    * filter). Mobile uses this for source tabs; desktop omits it.
    */
   sourceFilter?: "all" | ReviewSource;
-  /** Force word-wrap on diffs. Defaults to false (user-controlled). */
+  /** Force word-wrap on diffs. Defaults to the app diff preference. */
   wordWrap?: boolean;
 };
 
@@ -168,7 +169,7 @@ function persistAutoMarkSetting(checked: boolean) {
 function useChangesActions(
   activeSessionId: string | null | undefined,
   allFiles: ReviewFile[],
-  defaultWordWrap = false,
+  defaultWordWrap = DEFAULT_DIFF_WORD_WRAP,
 ) {
   const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
   const autoMarkOnScroll = useAppStore((s) => s.userSettings.reviewAutoMarkOnScroll);
@@ -439,7 +440,7 @@ const TaskChangesPanel = memo(function TaskChangesPanel({
   onBecameEmpty,
   onOpenFile: onOpenFileProp,
   sourceFilter = "all",
-  wordWrap: wordWrapProp = false,
+  wordWrap: wordWrapProp = DEFAULT_DIFF_WORD_WRAP,
 }: TaskChangesPanelProps) {
   const isArchived = useIsTaskArchived();
   const { openFile: panelOpenFile, openFileInMarkdownPreview } = usePanelActions();

--- a/apps/web/e2e/tests/git/diff-expansion.spec.ts
+++ b/apps/web/e2e/tests/git/diff-expansion.spec.ts
@@ -72,6 +72,14 @@ async function waitForDiffText(testPage: Page, text: string, timeout = 60_000) {
     .toBe(true);
 }
 
+async function readDiffOverflow(testPage: Page): Promise<string | null> {
+  return testPage.evaluate(() => {
+    const container = document.querySelector("diffs-container");
+    const shadow = container?.shadowRoot;
+    return shadow?.querySelector("pre[data-diff]")?.getAttribute("data-overflow") ?? null;
+  });
+}
+
 async function hoverUntilGutterSlotAppears(testPage: Page) {
   const points = await testPage.evaluate(() => {
     const container = document.querySelector("diffs-container");
@@ -234,6 +242,25 @@ test.describe("Diff expansion — Pierre Diffs provider", () => {
     await testPage.screenshot({ path: "test-results/diff-hover-button-extrusion.png" });
     expect(geometry.marginRight).toBeLessThan(0);
     expect(geometry.buttonRight).toBeGreaterThan(geometry.cellRight);
+  });
+
+  test("word wrap is enabled by default and can be toggled off", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    await seedExpansionTask(testPage, apiClient, seedData);
+    await openChangesTab(testPage);
+    await openExpansionFileDiff(testPage);
+
+    await waitForDiffText(testPage, "HUNK_TOP");
+    await expect.poll(() => readDiffOverflow(testPage), { timeout: 15_000 }).toBe("wrap");
+
+    const toggle = testPage.getByRole("button", { name: "Toggle word wrap" }).first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await toggle.click();
+
+    await expect.poll(() => readDiffOverflow(testPage), { timeout: 10_000 }).toBe("scroll");
   });
 
   test("renders Pierre Diffs viewer and shows both hunks", async ({


### PR DESCRIPTION
Diff actions could leave the Undo button spinning when a PR hunk reverted without unmounting, and diff views defaulted to horizontal scrolling despite the UI offering a wrap toggle. The diff surfaces now recover their loading state, default to wrapped lines, and give commit diff filenames better header spacing.

## Validation

- `make fmt && make typecheck && make test && make lint`
- `pnpm --filter @kandev/web test -- --run components/diff/diff-viewer.test.tsx components/diff/hunk-action-bar.test.tsx`
- `pnpm e2e:run tests/git/diff-expansion.spec.ts -- --grep "word wrap is enabled by default"`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->