### PR TITLE
fix: show preparing task spinner

### DIFF
--- a/apps/web/components/task/task-item.test.tsx
+++ b/apps/web/components/task/task-item.test.tsx
@@ -5,6 +5,7 @@ import { StateProvider } from "@/components/state-provider";
 import { TaskItem } from "./task-item";
 
 const REVIEW_ICON_TEST_ID = "task-state-review";
+const RUNNING_ICON_TEST_ID = "task-state-running";
 const WAITING_FOR_INPUT_ICON_TEST_ID = "task-state-waiting-for-input";
 const PENDING_PERMISSION_ICON_TEST_ID = "task-state-pending-permission";
 
@@ -57,6 +58,36 @@ describe("TaskItem status icon", () => {
 
     expect(screen.queryByTestId(WAITING_FOR_INPUT_ICON_TEST_ID)).not.toBeNull();
     expect(screen.queryByTestId(PENDING_PERMISSION_ICON_TEST_ID)).toBeNull();
+  });
+
+  it("shows a slower purple spinner while the workflow is scheduling", () => {
+    renderTaskItem({ state: "SCHEDULING" });
+
+    const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
+    expect(icon.getAttribute("data-loading-phase")).toBe("preparing");
+    expect(icon.classList.contains("text-purple-500")).toBe(true);
+    expect(icon.classList.contains("animate-spin")).toBe(true);
+    expect(icon.classList.contains("[animation-duration:2s]")).toBe(true);
+  });
+
+  it("shows a slower purple spinner while the session is starting before progress", () => {
+    renderTaskItem({ state: "TODO", sessionState: "STARTING" });
+
+    const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
+    expect(icon.getAttribute("data-loading-phase")).toBe("preparing");
+    expect(icon.classList.contains("text-purple-500")).toBe(true);
+    expect(icon.classList.contains("animate-spin")).toBe(true);
+    expect(icon.classList.contains("[animation-duration:2s]")).toBe(true);
+  });
+
+  it("keeps running tasks on the normal running spinner", () => {
+    renderTaskItem({ state: "IN_PROGRESS", sessionState: "RUNNING" });
+
+    const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
+    expect(icon.getAttribute("data-loading-phase")).toBe("running");
+    expect(icon.classList.contains("text-yellow-500")).toBe(true);
+    expect(icon.classList.contains("animate-spin")).toBe(true);
+    expect(icon.classList.contains("text-purple-500")).toBe(false);
   });
 
   it("keeps the review check for completed review tasks", () => {

--- a/apps/web/components/task/task-item.test.tsx
+++ b/apps/web/components/task/task-item.test.tsx
@@ -8,6 +8,10 @@ const REVIEW_ICON_TEST_ID = "task-state-review";
 const RUNNING_ICON_TEST_ID = "task-state-running";
 const WAITING_FOR_INPUT_ICON_TEST_ID = "task-state-waiting-for-input";
 const PENDING_PERMISSION_ICON_TEST_ID = "task-state-pending-permission";
+const PREPARING_PHASE = "preparing";
+const PURPLE_SPINNER_CLASS = "text-purple-500";
+const SPIN_CLASS = "animate-spin";
+const SLOW_SPIN_CLASS = "[animation-duration:2s]";
 
 afterEach(() => cleanup());
 
@@ -17,6 +21,14 @@ function renderTaskItem(props: Partial<ComponentProps<typeof TaskItem>> = {}) {
       <TaskItem title="Needs answer" state="REVIEW" {...props} />
     </StateProvider>,
   );
+}
+
+function expectPreparingSpinner(): void {
+  const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
+  expect(icon.getAttribute("data-loading-phase")).toBe(PREPARING_PHASE);
+  expect(icon.classList.contains(PURPLE_SPINNER_CLASS)).toBe(true);
+  expect(icon.classList.contains(SPIN_CLASS)).toBe(true);
+  expect(icon.classList.contains(SLOW_SPIN_CLASS)).toBe(true);
 }
 
 describe("TaskItem status icon", () => {
@@ -63,21 +75,26 @@ describe("TaskItem status icon", () => {
   it("shows a slower purple spinner while the workflow is scheduling", () => {
     renderTaskItem({ state: "SCHEDULING" });
 
-    const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
-    expect(icon.getAttribute("data-loading-phase")).toBe("preparing");
-    expect(icon.classList.contains("text-purple-500")).toBe(true);
-    expect(icon.classList.contains("animate-spin")).toBe(true);
-    expect(icon.classList.contains("[animation-duration:2s]")).toBe(true);
+    expectPreparingSpinner();
   });
 
   it("shows a slower purple spinner while the session is starting before progress", () => {
     renderTaskItem({ state: "TODO", sessionState: "STARTING" });
 
-    const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
-    expect(icon.getAttribute("data-loading-phase")).toBe("preparing");
-    expect(icon.classList.contains("text-purple-500")).toBe(true);
-    expect(icon.classList.contains("animate-spin")).toBe(true);
-    expect(icon.classList.contains("[animation-duration:2s]")).toBe(true);
+    expectPreparingSpinner();
+  });
+
+  it("shows a slower purple spinner for in-progress tasks while the session is starting", () => {
+    renderTaskItem({ state: "IN_PROGRESS", sessionState: "STARTING" });
+
+    expectPreparingSpinner();
+  });
+
+  it("does not show preparing spinner for a review task whose session transiently hits STARTING", () => {
+    renderTaskItem({ state: "REVIEW", sessionState: "STARTING" });
+
+    expect(screen.queryByTestId(REVIEW_ICON_TEST_ID)).not.toBeNull();
+    expect(screen.queryByTestId(RUNNING_ICON_TEST_ID)).toBeNull();
   });
 
   it("keeps running tasks on the normal running spinner", () => {
@@ -86,8 +103,8 @@ describe("TaskItem status icon", () => {
     const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
     expect(icon.getAttribute("data-loading-phase")).toBe("running");
     expect(icon.classList.contains("text-yellow-500")).toBe(true);
-    expect(icon.classList.contains("animate-spin")).toBe(true);
-    expect(icon.classList.contains("text-purple-500")).toBe(false);
+    expect(icon.classList.contains(SPIN_CLASS)).toBe(true);
+    expect(icon.classList.contains(PURPLE_SPINNER_CLASS)).toBe(false);
   });
 
   it("keeps the review check for completed review tasks", () => {

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -95,6 +95,11 @@ function computeIsInProgress(state?: TaskState, sessionState?: TaskSessionState)
   return classifyTask(sessionState, state) === "in_progress";
 }
 
+function computeIsPreparing(state?: TaskState, sessionState?: TaskSessionState): boolean {
+  if (state === "SCHEDULING") return true;
+  return sessionState === "STARTING" && classifyTask(sessionState, state) !== "review";
+}
+
 function handleTaskItemKeyDown(e: React.KeyboardEvent<HTMLDivElement>, onClick?: () => void): void {
   if (e.key !== "Enter" && e.key !== " ") return;
   e.preventDefault();
@@ -130,10 +135,20 @@ function TaskStateIcon({
       />
     );
   }
+  if (computeIsPreparing(state, sessionState)) {
+    return (
+      <IconCircleDashed
+        data-testid="task-state-running"
+        data-loading-phase="preparing"
+        className="mt-[1px] h-3.5 w-3.5 shrink-0 animate-spin text-purple-500 [animation-duration:2s]"
+      />
+    );
+  }
   if (isInProgress) {
     return (
       <IconCircleDashed
         data-testid="task-state-running"
+        data-loading-phase="running"
         className="mt-[1px] h-3.5 w-3.5 shrink-0 text-yellow-500 animate-spin"
       />
     );


### PR DESCRIPTION
Tasks can sit in the pre-run phase while remote executors prepare, but the sidebar looked idle. The task row now shows a slower purple spinner for scheduling/starting work so users can tell progress is underway.

## Validation

- `git fetch origin main`
- `git rev-list --left-right --count HEAD...origin/main` → `0 0`
- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->