### PR TITLE
feat: add tooltip explaining reset environment behavior

### DIFF
--- a/apps/web/components/task/executor-settings-button.test.tsx
+++ b/apps/web/components/task/executor-settings-button.test.tsx
@@ -44,6 +44,12 @@ vi.mock("./task-reset-env-confirm-dialog", () => ({
   TaskResetEnvConfirmDialog: () => null,
 }));
 
+vi.mock("@kandev/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 import { ExecutorSettingsButton } from "./executor-settings-button";
 
 describe("ExecutorSettingsButton", () => {

--- a/apps/web/components/task/executor-settings-button.test.tsx
+++ b/apps/web/components/task/executor-settings-button.test.tsx
@@ -11,7 +11,7 @@ const PREPARE_STATUS_TESTID = "executor-prepare-status";
 const SETTINGS_BUTTON_TESTID = "executor-settings-button";
 const BRANCH_PUSH_HINT_TEXT =
   "Check Push the current branch... in the confirm step first to preserve committed work before resetting.";
-const BRANCH_PUSH_HINT = new RegExp(BRANCH_PUSH_HINT_TEXT);
+const BRANCH_PUSH_HINT = BRANCH_PUSH_HINT_TEXT;
 const SPRITES_ENV = { executor_type: "sprites", sandbox_id: "kandev-abc" };
 const SPRITES_WORKTREE_ENV = { ...SPRITES_ENV, worktree_path: "/tmp/worktree" };
 const DOCKER_ENV = { executor_type: "local_docker", container_id: "abcdef" };
@@ -189,11 +189,14 @@ describe("ExecutorSettingsButton prepare status", () => {
 });
 
 describe("ExecutorSettingsButton reset tooltip", () => {
-  it("does not mention branch push in tooltip when no worktree path exists", () => {
+  it("does not mention branch push in tooltip when no worktree path exists", async () => {
     mockEnv = SPRITES_ENV;
 
     renderButton();
     hoverSettingsButton();
+
+    // Wait for env to load — the cloud icon only renders once executor_type resolves.
+    await screen.findByTestId("executor-status-cloud-icon");
 
     expect(screen.queryByText(BRANCH_PUSH_HINT)).toBeNull();
   });

--- a/apps/web/components/task/executor-settings-button.test.tsx
+++ b/apps/web/components/task/executor-settings-button.test.tsx
@@ -2,21 +2,46 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionPrepareState } from "@/lib/state/slices/session-runtime/types";
 
-// Constants declared *above* the vi.mock factories so the mocks can reference
-// them without relying on vitest's hoisting capturing TDZ-undefined closures.
-// The previous layout worked by accident (factories aren't invoked until the
-// test imports the module under test, by which time the const initialization
-// has run), but a refactor that imports the module earlier — for example, a
-// shared test helper — would break the closure silently.
+// Constants declared before mocks so the mocked factories can reference them without
+// hoisting-related TDZ pitfalls.
 const SESSION_ID = "session-1";
 const TASK_ID = "task-1";
 const STEP_CREATE_SANDBOX = "Creating cloud sandbox";
 const PREPARE_STATUS_TESTID = "executor-prepare-status";
 const SETTINGS_BUTTON_TESTID = "executor-settings-button";
+const BRANCH_PUSH_HINT_TEXT =
+  "Check Push the current branch... in the confirm step first to preserve committed work before resetting.";
+const BRANCH_PUSH_HINT = new RegExp(BRANCH_PUSH_HINT_TEXT);
+const SPRITES_ENV = { executor_type: "sprites", sandbox_id: "kandev-abc" };
+const SPRITES_WORKTREE_ENV = { ...SPRITES_ENV, worktree_path: "/tmp/worktree" };
+const DOCKER_ENV = { executor_type: "local_docker", container_id: "abcdef" };
+
+type MockEnv = {
+  executor_type: string;
+  sandbox_id?: string;
+  container_id?: string;
+  worktree_path?: string;
+};
 
 let mockPrepareState: SessionPrepareState | null = null;
 let mockSessionState: string | null = null;
-let mockEnv: { executor_type: string; sandbox_id?: string; container_id?: string } | null = null;
+let mockEnv: MockEnv | null = null;
+
+const renderButton = () => {
+  render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
+};
+
+const hoverSettingsButton = () =>
+  fireEvent.pointerEnter(screen.getByTestId(SETTINGS_BUTTON_TESTID));
+
+const flushTicks = () => Promise.resolve().then(() => Promise.resolve());
+
+afterEach(() => {
+  cleanup();
+  mockPrepareState = null;
+  mockSessionState = null;
+  mockEnv = null;
+});
 
 vi.mock("@/components/state-provider", () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
@@ -52,48 +77,42 @@ vi.mock("@kandev/ui/tooltip", () => ({
 
 import { ExecutorSettingsButton } from "./executor-settings-button";
 
-describe("ExecutorSettingsButton", () => {
-  afterEach(() => {
-    cleanup();
-    mockPrepareState = null;
-    mockSessionState = null;
-    mockEnv = null;
-  });
-
+describe("ExecutorSettingsButton icon states", () => {
   it("shows the cloud icon when the executor type is sprites", async () => {
-    mockEnv = { executor_type: "sprites", sandbox_id: "kandev-abc" };
+    mockEnv = SPRITES_ENV;
 
-    render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
+    renderButton();
+    await flushTicks();
+    await flushTicks();
 
-    // Wait a tick for the live fetch to resolve.
-    await Promise.resolve();
-    await Promise.resolve();
     expect(await screen.findByTestId("executor-status-cloud-icon")).toBeTruthy();
   });
 
   it("shows the container icon for both docker variants", async () => {
-    mockEnv = { executor_type: "local_docker", container_id: "abcdef" };
+    mockEnv = DOCKER_ENV;
 
-    render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
+    renderButton();
+    await flushTicks();
 
-    await Promise.resolve();
     expect(await screen.findByTestId("executor-status-container-icon")).toBeTruthy();
   });
 
   it("swaps to a spinner while the prepare progress is preparing", async () => {
-    mockEnv = { executor_type: "sprites", sandbox_id: "kandev-abc" };
+    mockEnv = SPRITES_ENV;
     mockPrepareState = {
       sessionId: SESSION_ID,
       status: "preparing",
       steps: [{ name: STEP_CREATE_SANDBOX, status: "running" }],
     };
 
-    render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
+    renderButton();
 
     expect(screen.getByTestId("executor-settings-button-spinner")).toBeTruthy();
     expect(screen.queryByTestId("executor-status-cloud-icon")).toBeNull();
   });
+});
 
+describe("ExecutorSettingsButton prepare status", () => {
   it("renders the preparing section with current step copy", async () => {
     mockPrepareState = {
       sessionId: SESSION_ID,
@@ -105,11 +124,8 @@ describe("ExecutorSettingsButton", () => {
       ],
     };
 
-    render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
-
-    // Open the hover card by hovering the trigger (not clicking — it's a
-    // borderless info surface, not a button).
-    fireEvent.pointerEnter(screen.getByTestId(SETTINGS_BUTTON_TESTID));
+    renderButton();
+    hoverSettingsButton();
 
     expect(await screen.findByTestId(PREPARE_STATUS_TESTID)).toHaveProperty(
       "dataset.phase",
@@ -133,8 +149,8 @@ describe("ExecutorSettingsButton", () => {
       ],
     };
 
-    render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
-    fireEvent.pointerEnter(screen.getByTestId(SETTINGS_BUTTON_TESTID));
+    renderButton();
+    hoverSettingsButton();
 
     const status = await screen.findByTestId(PREPARE_STATUS_TESTID);
     expect(status.dataset.phase).toBe("preparing_fallback");
@@ -144,10 +160,9 @@ describe("ExecutorSettingsButton", () => {
   it("renders the Resuming session row when session is STARTING with no prepare events", async () => {
     mockSessionState = "STARTING";
 
-    render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
-
+    renderButton();
     expect(screen.getByTestId("executor-settings-button-spinner")).toBeTruthy();
-    fireEvent.pointerEnter(screen.getByTestId(SETTINGS_BUTTON_TESTID));
+    hoverSettingsButton();
 
     const status = await screen.findByTestId(PREPARE_STATUS_TESTID);
     expect(status.dataset.phase).toBe("resuming");
@@ -156,19 +171,39 @@ describe("ExecutorSettingsButton", () => {
   });
 
   it("hides the prepare-status section once preparation completes", async () => {
-    // The READY badge next to the executor name conveys ready-state; the
-    // dedicated "Environment ready · 12s" row is redundant noise.
+    // The READY badge next to the executor name conveys ready-state; this dedicated
+    // "Environment ready · 12s" row is redundant in the tooltip.
     mockPrepareState = {
       sessionId: SESSION_ID,
       status: "completed",
-      steps: [{ name: "Creating cloud sandbox", status: "completed" }],
+      steps: [{ name: STEP_CREATE_SANDBOX, status: "completed" }],
       durationMs: 12500,
     };
 
-    render(<ExecutorSettingsButton taskId={TASK_ID} sessionId={SESSION_ID} />);
-    fireEvent.pointerEnter(screen.getByTestId(SETTINGS_BUTTON_TESTID));
+    renderButton();
+    hoverSettingsButton();
 
     expect(screen.queryByTestId(PREPARE_STATUS_TESTID)).toBeNull();
     expect(screen.queryByText(/Environment ready/)).toBeNull();
+  });
+});
+
+describe("ExecutorSettingsButton reset tooltip", () => {
+  it("does not mention branch push in tooltip when no worktree path exists", () => {
+    mockEnv = SPRITES_ENV;
+
+    renderButton();
+    hoverSettingsButton();
+
+    expect(screen.queryByText(BRANCH_PUSH_HINT)).toBeNull();
+  });
+
+  it("mentions branch push in tooltip when a worktree path exists", async () => {
+    mockEnv = SPRITES_WORKTREE_ENV;
+
+    renderButton();
+    hoverSettingsButton();
+
+    expect(await screen.findByText(BRANCH_PUSH_HINT)).toBeTruthy();
   });
 });

--- a/apps/web/components/task/executor-settings-button.test.tsx
+++ b/apps/web/components/task/executor-settings-button.test.tsx
@@ -9,9 +9,8 @@ const TASK_ID = "task-1";
 const STEP_CREATE_SANDBOX = "Creating cloud sandbox";
 const PREPARE_STATUS_TESTID = "executor-prepare-status";
 const SETTINGS_BUTTON_TESTID = "executor-settings-button";
-const BRANCH_PUSH_HINT_TEXT =
-  "Check Push the current branch... in the confirm step first to preserve committed work before resetting.";
-const BRANCH_PUSH_HINT = BRANCH_PUSH_HINT_TEXT;
+const BRANCH_PUSH_HINT =
+  "Push your branch to its remote in the confirmation dialog to preserve committed work before resetting.";
 const SPRITES_ENV = { executor_type: "sprites", sandbox_id: "kandev-abc" };
 const SPRITES_WORKTREE_ENV = { ...SPRITES_ENV, worktree_path: "/tmp/worktree" };
 const DOCKER_ENV = { executor_type: "local_docker", container_id: "abcdef" };
@@ -195,8 +194,11 @@ describe("ExecutorSettingsButton reset tooltip", () => {
     renderButton();
     hoverSettingsButton();
 
-    // Wait for env to load — the cloud icon only renders once executor_type resolves.
-    await screen.findByTestId("executor-status-cloud-icon");
+    // Confirm HoverCardContent is open before asserting the hint is absent —
+    // the reset button lives inside the popover, so finding it proves the
+    // popover has rendered (and the hint would have too, if it weren't
+    // gated on hasWorktreePath).
+    await screen.findByTestId("executor-settings-reset");
 
     expect(screen.queryByText(BRANCH_PUSH_HINT)).toBeNull();
   });

--- a/apps/web/components/task/executor-settings-button.test.tsx
+++ b/apps/web/components/task/executor-settings-button.test.tsx
@@ -194,10 +194,9 @@ describe("ExecutorSettingsButton reset tooltip", () => {
     renderButton();
     hoverSettingsButton();
 
-    // Confirm HoverCardContent is open before asserting the hint is absent —
-    // the reset button lives inside the popover, so finding it proves the
-    // popover has rendered (and the hint would have too, if it weren't
-    // gated on hasWorktreePath).
+    // Wait for env to load (cloud icon only renders once executor_type resolves)
+    // and for HoverCardContent to open (reset button lives inside the popover).
+    await screen.findByTestId("executor-status-cloud-icon");
     await screen.findByTestId("executor-settings-reset");
 
     expect(screen.queryByText(BRANCH_PUSH_HINT)).toBeNull();

--- a/apps/web/components/task/executor-settings-button.tsx
+++ b/apps/web/components/task/executor-settings-button.tsx
@@ -86,7 +86,7 @@ export function ExecutorSettingsButton({
           <div className="border-t border-border px-2 py-1.5 flex items-center justify-end">
             <Tooltip>
               <TooltipTrigger asChild>
-                <span tabIndex={0} aria-label="Reset environment">
+                <span tabIndex={!env || isResetting ? 0 : -1} aria-label="Reset environment">
                   <Button
                     variant="destructive"
                     size="sm"
@@ -110,7 +110,7 @@ export function ExecutorSettingsButton({
                 </p>
                 {hasWorktreePath && (
                   <p className="mt-1 text-xs text-muted-foreground">
-                    Check Push the current branch... in the confirm step first to preserve committed
+                    Push your branch to its remote in the confirmation dialog to preserve committed
                     work before resetting.
                   </p>
                 )}

--- a/apps/web/components/task/executor-settings-button.tsx
+++ b/apps/web/components/task/executor-settings-button.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { IconBox, IconLoader2, IconTrash } from "@tabler/icons-react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@kandev/ui/hover-card";
 import { Button } from "@kandev/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 
 import { getExecutorStatusIcon } from "@/lib/executor-icons";
 import { TaskResetEnvConfirmDialog } from "./task-reset-env-confirm-dialog";
@@ -82,16 +83,34 @@ export function ExecutorSettingsButton({
           <PrepareStatusSection summary={prepare} />
           <EnvironmentInfo env={env} container={container} ssh={ssh} loading={loading} />
           <div className="border-t border-border px-2 py-1.5 flex items-center justify-end">
-            <Button
-              variant="destructive"
-              size="sm"
-              className="cursor-pointer text-xs"
-              disabled={!env || isResetting}
-              data-testid="executor-settings-reset"
-              onClick={() => setResetDialogOpen(true)}
-            >
-              <IconTrash className="h-3.5 w-3.5 mr-1" /> Reset environment
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="cursor-pointer text-xs"
+                  disabled={!env || isResetting}
+                  data-testid="executor-settings-reset"
+                  onClick={() => setResetDialogOpen(true)}
+                >
+                  <IconTrash className="h-3.5 w-3.5 mr-1" /> Reset environment
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p className="font-medium">Reset environment</p>
+                <p className="mt-1 text-xs">
+                  Deletes the current task environment (container, sandbox, and/or worktree) and
+                  forces a fresh one to be created for your next run.
+                </p>
+                <p className="mt-1 text-xs text-destructive">
+                  Any uncommitted or unpushed changes are lost.
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Check Push the current branch... in the confirm step first to preserve committed
+                  work before resetting.
+                </p>
+              </TooltipContent>
+            </Tooltip>
           </div>
         </HoverCardContent>
       </HoverCard>

--- a/apps/web/components/task/executor-settings-button.tsx
+++ b/apps/web/components/task/executor-settings-button.tsx
@@ -86,16 +86,18 @@ export function ExecutorSettingsButton({
           <div className="border-t border-border px-2 py-1.5 flex items-center justify-end">
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  className="cursor-pointer text-xs"
-                  disabled={!env || isResetting}
-                  data-testid="executor-settings-reset"
-                  onClick={() => setResetDialogOpen(true)}
-                >
-                  <IconTrash className="h-3.5 w-3.5 mr-1" /> Reset environment
-                </Button>
+                <span tabIndex={0} aria-label="Reset environment">
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="cursor-pointer text-xs"
+                    disabled={!env || isResetting}
+                    data-testid="executor-settings-reset"
+                    onClick={() => setResetDialogOpen(true)}
+                  >
+                    <IconTrash className="h-3.5 w-3.5 mr-1" /> Reset environment
+                  </Button>
+                </span>
               </TooltipTrigger>
               <TooltipContent className="max-w-xs">
                 <p className="font-medium">Reset environment</p>

--- a/apps/web/components/task/executor-settings-button.tsx
+++ b/apps/web/components/task/executor-settings-button.tsx
@@ -36,6 +36,7 @@ export function ExecutorSettingsButton({
     taskId,
     open || isPreparing,
   );
+  const hasWorktreePath = Boolean(env?.worktree_path);
 
   const handleReset = useCallback(
     async (opts: { pushBranch: boolean }) => {
@@ -105,10 +106,12 @@ export function ExecutorSettingsButton({
                 <p className="mt-1 text-xs text-destructive">
                   Any uncommitted or unpushed changes are lost.
                 </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Check Push the current branch... in the confirm step first to preserve committed
-                  work before resetting.
-                </p>
+                {hasWorktreePath && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Check Push the current branch... in the confirm step first to preserve committed
+                    work before resetting.
+                  </p>
+                )}
               </TooltipContent>
             </Tooltip>
           </div>
@@ -118,7 +121,7 @@ export function ExecutorSettingsButton({
       <TaskResetEnvConfirmDialog
         open={resetDialogOpen}
         onOpenChange={setResetDialogOpen}
-        hasWorktreePath={Boolean(env?.worktree_path)}
+        hasWorktreePath={hasWorktreePath}
         isResetting={isResetting}
         onConfirm={handleReset}
       />


### PR DESCRIPTION
## Summary
- Add a tooltip around the Reset environment button in executor settings that explains exactly what reset does and what data it affects.
- The tooltip states that reset deletes the current container/sandbox/worktree, creates a fresh environment on next run, and that uncommitted/unpushed changes will be lost.
- Updates unit tests for the button with tooltip component mocks.

## Validation
- make test (backend + web + cli): passed
- commit: f6a43f2c

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->