### PR TITLE
feat: split general settings pages

### DIFF
--- a/apps/web/app/settings/general/appearance/page.tsx
+++ b/apps/web/app/settings/general/appearance/page.tsx
@@ -1,5 +1,13 @@
 import { AppearanceSettings } from "@/components/settings/general-settings";
+import { StateProvider } from "@/components/state-provider";
+import { getUserSettingsInitialState } from "../user-settings-state";
 
-export default function GeneralAppearancePage() {
-  return <AppearanceSettings />;
+export default async function GeneralAppearancePage() {
+  const initialState = await getUserSettingsInitialState();
+
+  return (
+    <StateProvider initialState={initialState}>
+      <AppearanceSettings />
+    </StateProvider>
+  );
 }

--- a/apps/web/app/settings/general/appearance/page.tsx
+++ b/apps/web/app/settings/general/appearance/page.tsx
@@ -1,0 +1,5 @@
+import { AppearanceSettings } from "@/components/settings/general-settings";
+
+export default function GeneralAppearancePage() {
+  return <AppearanceSettings />;
+}

--- a/apps/web/app/settings/general/backend-connection/page.tsx
+++ b/apps/web/app/settings/general/backend-connection/page.tsx
@@ -1,0 +1,5 @@
+import { BackendConnectionSettings } from "@/components/settings/general-settings";
+
+export default function GeneralBackendConnectionPage() {
+  return <BackendConnectionSettings />;
+}

--- a/apps/web/app/settings/general/backend-connection/page.tsx
+++ b/apps/web/app/settings/general/backend-connection/page.tsx
@@ -1,5 +1,0 @@
-import { BackendConnectionSettings } from "@/components/settings/general-settings";
-
-export default function GeneralBackendConnectionPage() {
-  return <BackendConnectionSettings />;
-}

--- a/apps/web/app/settings/general/changes-panel/page.tsx
+++ b/apps/web/app/settings/general/changes-panel/page.tsx
@@ -1,13 +1,5 @@
-import { ChangesPanelSettings } from "@/components/settings/general-settings";
-import { StateProvider } from "@/components/state-provider";
-import { getUserSettingsInitialState } from "../user-settings-state";
+import { redirect } from "next/navigation";
 
-export default async function GeneralChangesPanelPage() {
-  const initialState = await getUserSettingsInitialState();
-
-  return (
-    <StateProvider initialState={initialState}>
-      <ChangesPanelSettings />
-    </StateProvider>
-  );
+export default function GeneralChangesPanelPage() {
+  redirect("/settings/general/appearance");
 }

--- a/apps/web/app/settings/general/changes-panel/page.tsx
+++ b/apps/web/app/settings/general/changes-panel/page.tsx
@@ -1,0 +1,13 @@
+import { ChangesPanelSettings } from "@/components/settings/general-settings";
+import { StateProvider } from "@/components/state-provider";
+import { getUserSettingsInitialState } from "../user-settings-state";
+
+export default async function GeneralChangesPanelPage() {
+  const initialState = await getUserSettingsInitialState();
+
+  return (
+    <StateProvider initialState={initialState}>
+      <ChangesPanelSettings />
+    </StateProvider>
+  );
+}

--- a/apps/web/app/settings/general/chat-input/page.tsx
+++ b/apps/web/app/settings/general/chat-input/page.tsx
@@ -1,13 +1,5 @@
-import { ChatInputSettings } from "@/components/settings/general-settings";
-import { StateProvider } from "@/components/state-provider";
-import { getUserSettingsInitialState } from "../user-settings-state";
+import { redirect } from "next/navigation";
 
-export default async function GeneralChatInputPage() {
-  const initialState = await getUserSettingsInitialState();
-
-  return (
-    <StateProvider initialState={initialState}>
-      <ChatInputSettings />
-    </StateProvider>
-  );
+export default function GeneralChatInputPage() {
+  redirect("/settings/general/keyboard-shortcuts");
 }

--- a/apps/web/app/settings/general/chat-input/page.tsx
+++ b/apps/web/app/settings/general/chat-input/page.tsx
@@ -1,0 +1,13 @@
+import { ChatInputSettings } from "@/components/settings/general-settings";
+import { StateProvider } from "@/components/state-provider";
+import { getUserSettingsInitialState } from "../user-settings-state";
+
+export default async function GeneralChatInputPage() {
+  const initialState = await getUserSettingsInitialState();
+
+  return (
+    <StateProvider initialState={initialState}>
+      <ChatInputSettings />
+    </StateProvider>
+  );
+}

--- a/apps/web/app/settings/general/keyboard-shortcuts/page.tsx
+++ b/apps/web/app/settings/general/keyboard-shortcuts/page.tsx
@@ -1,0 +1,13 @@
+import { KeyboardShortcutsSettings } from "@/components/settings/general-settings";
+import { StateProvider } from "@/components/state-provider";
+import { getUserSettingsInitialState } from "../user-settings-state";
+
+export default async function GeneralKeyboardShortcutsPage() {
+  const initialState = await getUserSettingsInitialState();
+
+  return (
+    <StateProvider initialState={initialState}>
+      <KeyboardShortcutsSettings />
+    </StateProvider>
+  );
+}

--- a/apps/web/app/settings/general/page.tsx
+++ b/apps/web/app/settings/general/page.tsx
@@ -1,17 +1,9 @@
 import { GeneralSettings } from "@/components/settings/general-settings";
 import { StateProvider } from "@/components/state-provider";
-import { fetchUserSettings } from "@/lib/api";
-import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { getUserSettingsInitialState } from "./user-settings-state";
 
 export default async function GeneralSettingsPage() {
-  let initialState = {};
-  try {
-    const response = await fetchUserSettings({ cache: "no-store" });
-    const mapped = mapUserSettingsResponse(response);
-    initialState = { userSettings: mapped.loaded ? mapped : undefined };
-  } catch {
-    initialState = {};
-  }
+  const initialState = await getUserSettingsInitialState();
 
   return (
     <StateProvider initialState={initialState}>

--- a/apps/web/app/settings/general/page.tsx
+++ b/apps/web/app/settings/general/page.tsx
@@ -1,13 +1,5 @@
 import { GeneralSettings } from "@/components/settings/general-settings";
-import { StateProvider } from "@/components/state-provider";
-import { getUserSettingsInitialState } from "./user-settings-state";
 
-export default async function GeneralSettingsPage() {
-  const initialState = await getUserSettingsInitialState();
-
-  return (
-    <StateProvider initialState={initialState}>
-      <GeneralSettings />
-    </StateProvider>
-  );
+export default function GeneralSettingsPage() {
+  return <GeneralSettings />;
 }

--- a/apps/web/app/settings/general/resource-metrics/page.tsx
+++ b/apps/web/app/settings/general/resource-metrics/page.tsx
@@ -1,13 +1,5 @@
-import { ResourceMetricsSettings } from "@/components/settings/general-settings";
-import { StateProvider } from "@/components/state-provider";
-import { getUserSettingsInitialState } from "../user-settings-state";
+import { redirect } from "next/navigation";
 
-export default async function GeneralResourceMetricsPage() {
-  const initialState = await getUserSettingsInitialState();
-
-  return (
-    <StateProvider initialState={initialState}>
-      <ResourceMetricsSettings />
-    </StateProvider>
-  );
+export default function GeneralResourceMetricsPage() {
+  redirect("/settings/general/appearance");
 }

--- a/apps/web/app/settings/general/resource-metrics/page.tsx
+++ b/apps/web/app/settings/general/resource-metrics/page.tsx
@@ -1,0 +1,13 @@
+import { ResourceMetricsSettings } from "@/components/settings/general-settings";
+import { StateProvider } from "@/components/state-provider";
+import { getUserSettingsInitialState } from "../user-settings-state";
+
+export default async function GeneralResourceMetricsPage() {
+  const initialState = await getUserSettingsInitialState();
+
+  return (
+    <StateProvider initialState={initialState}>
+      <ResourceMetricsSettings />
+    </StateProvider>
+  );
+}

--- a/apps/web/app/settings/general/shell/page.tsx
+++ b/apps/web/app/settings/general/shell/page.tsx
@@ -1,0 +1,13 @@
+import { ShellSettings } from "@/components/settings/general-settings";
+import { StateProvider } from "@/components/state-provider";
+import { getUserSettingsInitialState } from "../user-settings-state";
+
+export default async function GeneralShellPage() {
+  const initialState = await getUserSettingsInitialState();
+
+  return (
+    <StateProvider initialState={initialState}>
+      <ShellSettings />
+    </StateProvider>
+  );
+}

--- a/apps/web/app/settings/general/shell/page.tsx
+++ b/apps/web/app/settings/general/shell/page.tsx
@@ -1,13 +1,5 @@
-import { ShellSettings } from "@/components/settings/general-settings";
-import { StateProvider } from "@/components/state-provider";
-import { getUserSettingsInitialState } from "../user-settings-state";
+import { redirect } from "next/navigation";
 
-export default async function GeneralShellPage() {
-  const initialState = await getUserSettingsInitialState();
-
-  return (
-    <StateProvider initialState={initialState}>
-      <ShellSettings />
-    </StateProvider>
-  );
+export default function GeneralShellPage() {
+  redirect("/settings/general/terminal");
 }

--- a/apps/web/app/settings/general/terminal/page.tsx
+++ b/apps/web/app/settings/general/terminal/page.tsx
@@ -1,0 +1,13 @@
+import { TerminalSettings } from "@/components/settings/terminal-settings";
+import { StateProvider } from "@/components/state-provider";
+import { getUserSettingsInitialState } from "../user-settings-state";
+
+export default async function GeneralTerminalPage() {
+  const initialState = await getUserSettingsInitialState();
+
+  return (
+    <StateProvider initialState={initialState}>
+      <TerminalSettings />
+    </StateProvider>
+  );
+}

--- a/apps/web/app/settings/general/user-settings-state.ts
+++ b/apps/web/app/settings/general/user-settings-state.ts
@@ -1,0 +1,12 @@
+import { fetchUserSettings } from "@/lib/api";
+import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+
+export async function getUserSettingsInitialState() {
+  try {
+    const response = await fetchUserSettings({ cache: "no-store" });
+    const mapped = mapUserSettingsResponse(response);
+    return { userSettings: mapped.loaded ? mapped : undefined };
+  } catch {
+    return {};
+  }
+}

--- a/apps/web/components/app-sidebar/sections/settings/general-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/general-group.tsx
@@ -1,11 +1,38 @@
 "use client";
 
-import { IconBell, IconCode, IconSettings } from "@tabler/icons-react";
+import {
+  IconActivity,
+  IconBell,
+  IconCommand,
+  IconCode,
+  IconGitBranch,
+  IconKeyboard,
+  IconPalette,
+  IconServer,
+  IconSettings,
+  IconTerminal2,
+} from "@tabler/icons-react";
+import type { Icon as TablerIcon } from "@tabler/icons-react";
 import { SettingsGroup, SettingsLeaf } from "./settings-nav-primitives";
 
 const GENERAL_HREF = "/settings/general";
-const NOTIFICATIONS_HREF = "/settings/general/notifications";
-const EDITORS_HREF = "/settings/general/editors";
+
+const GENERAL_ITEMS: Array<{ href: string; label: string; icon: TablerIcon }> = [
+  { href: "/settings/general/appearance", label: "Appearance", icon: IconPalette },
+  { href: "/settings/general/shell", label: "Shell", icon: IconTerminal2 },
+  { href: "/settings/general/terminal", label: "Terminal", icon: IconTerminal2 },
+  { href: "/settings/general/notifications", label: "Notifications", icon: IconBell },
+  { href: "/settings/general/editors", label: "Editors", icon: IconCode },
+  { href: "/settings/general/resource-metrics", label: "Resource Metrics", icon: IconActivity },
+  { href: "/settings/general/chat-input", label: "Chat Input", icon: IconKeyboard },
+  { href: "/settings/general/changes-panel", label: "Changes Panel", icon: IconGitBranch },
+  {
+    href: "/settings/general/keyboard-shortcuts",
+    label: "Keyboard Shortcuts",
+    icon: IconCommand,
+  },
+  { href: "/settings/general/backend-connection", label: "Backend Connection", icon: IconServer },
+];
 
 type GeneralGroupProps = {
   pathname: string;
@@ -23,20 +50,16 @@ export function GeneralGroup({ pathname, expanded, onToggle }: GeneralGroupProps
       expanded={expanded}
       onToggle={onToggle}
     >
-      <SettingsLeaf
-        href={NOTIFICATIONS_HREF}
-        label="Notifications"
-        icon={IconBell}
-        isActive={pathname === NOTIFICATIONS_HREF}
-        depth={1}
-      />
-      <SettingsLeaf
-        href={EDITORS_HREF}
-        label="Editors"
-        icon={IconCode}
-        isActive={pathname === EDITORS_HREF}
-        depth={1}
-      />
+      {GENERAL_ITEMS.map(({ href, label, icon }) => (
+        <SettingsLeaf
+          key={href}
+          href={href}
+          label={label}
+          icon={icon}
+          isActive={pathname === href}
+          depth={1}
+        />
+      ))}
     </SettingsGroup>
   );
 }

--- a/apps/web/components/app-sidebar/sections/settings/general-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/general-group.tsx
@@ -1,14 +1,10 @@
 "use client";
 
 import {
-  IconActivity,
   IconBell,
   IconCommand,
   IconCode,
-  IconGitBranch,
-  IconKeyboard,
   IconPalette,
-  IconServer,
   IconSettings,
   IconTerminal2,
 } from "@tabler/icons-react";
@@ -19,19 +15,14 @@ const GENERAL_HREF = "/settings/general";
 
 const GENERAL_ITEMS: Array<{ href: string; label: string; icon: TablerIcon }> = [
   { href: "/settings/general/appearance", label: "Appearance", icon: IconPalette },
-  { href: "/settings/general/shell", label: "Shell", icon: IconTerminal2 },
   { href: "/settings/general/terminal", label: "Terminal", icon: IconTerminal2 },
   { href: "/settings/general/notifications", label: "Notifications", icon: IconBell },
   { href: "/settings/general/editors", label: "Editors", icon: IconCode },
-  { href: "/settings/general/resource-metrics", label: "Resource Metrics", icon: IconActivity },
-  { href: "/settings/general/chat-input", label: "Chat Input", icon: IconKeyboard },
-  { href: "/settings/general/changes-panel", label: "Changes Panel", icon: IconGitBranch },
   {
     href: "/settings/general/keyboard-shortcuts",
     label: "Keyboard Shortcuts",
     icon: IconCommand,
   },
-  { href: "/settings/general/backend-connection", label: "Backend Connection", icon: IconServer },
 ];
 
 type GeneralGroupProps = {

--- a/apps/web/components/app-sidebar/sections/settings/general-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/general-group.tsx
@@ -1,29 +1,10 @@
 "use client";
 
-import {
-  IconBell,
-  IconCommand,
-  IconCode,
-  IconPalette,
-  IconSettings,
-  IconTerminal2,
-} from "@tabler/icons-react";
-import type { Icon as TablerIcon } from "@tabler/icons-react";
+import { IconSettings } from "@tabler/icons-react";
+import { GENERAL_NAV_ITEMS } from "@/components/settings/general-nav";
 import { SettingsGroup, SettingsLeaf } from "./settings-nav-primitives";
 
 const GENERAL_HREF = "/settings/general";
-
-const GENERAL_ITEMS: Array<{ href: string; label: string; icon: TablerIcon }> = [
-  { href: "/settings/general/appearance", label: "Appearance", icon: IconPalette },
-  { href: "/settings/general/terminal", label: "Terminal", icon: IconTerminal2 },
-  { href: "/settings/general/notifications", label: "Notifications", icon: IconBell },
-  { href: "/settings/general/editors", label: "Editors", icon: IconCode },
-  {
-    href: "/settings/general/keyboard-shortcuts",
-    label: "Keyboard Shortcuts",
-    icon: IconCommand,
-  },
-];
 
 type GeneralGroupProps = {
   pathname: string;
@@ -41,7 +22,7 @@ export function GeneralGroup({ pathname, expanded, onToggle }: GeneralGroupProps
       expanded={expanded}
       onToggle={onToggle}
     >
-      {GENERAL_ITEMS.map(({ href, label, icon }) => (
+      {GENERAL_NAV_ITEMS.map(({ href, label, icon }) => (
         <SettingsLeaf
           key={href}
           href={href}

--- a/apps/web/components/app-sidebar/sections/settings/settings-nav-primitives.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-nav-primitives.tsx
@@ -24,6 +24,8 @@ type SettingsLeafProps = {
 
 const LEAF_DEPTH_PADDING = ["px-2.5", "pl-7 pr-2.5", "pl-10 pr-2.5"] as const;
 const GROUP_DEPTH_PADDING = ["pl-2.5 pr-1", "pl-7 pr-1", "pl-10 pr-1"] as const;
+const NAV_FOCUS_CLASS =
+  "outline-none focus-visible:ring-1 focus-visible:ring-primary/50 focus-visible:ring-offset-1";
 
 function clampDepth(depth: number, max: number): number {
   if (depth < 0) return 0;
@@ -44,7 +46,7 @@ export function SettingsLeaf({
       href={href}
       className={cn(
         "flex items-center gap-2 py-1.5 text-[13px] font-medium rounded-md cursor-pointer",
-        "outline-none focus-visible:outline-none focus-visible:ring-0",
+        NAV_FOCUS_CLASS,
         LEAF_DEPTH_PADDING[clampDepth(depth, LEAF_DEPTH_PADDING.length - 1)],
         isActive ? ACTIVE_CLASS : INACTIVE_CLASS,
       )}
@@ -113,7 +115,10 @@ export function SettingsGroup({
         {href ? (
           <Link
             href={href}
-            className="flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer outline-none focus-visible:outline-none focus-visible:ring-0"
+            className={cn(
+              "flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer",
+              NAV_FOCUS_CLASS,
+            )}
           >
             {labelInner}
           </Link>
@@ -121,7 +126,10 @@ export function SettingsGroup({
           <button
             type="button"
             onClick={toggle}
-            className="flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer text-left outline-none focus-visible:outline-none focus-visible:ring-0"
+            className={cn(
+              "flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer text-left",
+              NAV_FOCUS_CLASS,
+            )}
           >
             {labelInner}
           </button>
@@ -131,7 +139,10 @@ export function SettingsGroup({
           onClick={toggle}
           aria-label={expanded ? `Collapse ${label}` : `Expand ${label}`}
           aria-expanded={expanded}
-          className="shrink-0 flex h-5 w-5 items-center justify-center text-muted-foreground/60 hover:text-foreground/80 cursor-pointer transition-colors outline-none focus-visible:outline-none focus-visible:ring-0"
+          className={cn(
+            "shrink-0 flex h-5 w-5 items-center justify-center text-muted-foreground/60 hover:text-foreground/80 cursor-pointer transition-colors",
+            NAV_FOCUS_CLASS,
+          )}
         >
           <IconChevronRight
             className={cn("h-3 w-3 transition-transform", expanded && "rotate-90")}

--- a/apps/web/components/app-sidebar/sections/settings/settings-nav-primitives.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-nav-primitives.tsx
@@ -44,6 +44,7 @@ export function SettingsLeaf({
       href={href}
       className={cn(
         "flex items-center gap-2 py-1.5 text-[13px] font-medium rounded-md cursor-pointer",
+        "outline-none focus-visible:outline-none focus-visible:ring-0",
         LEAF_DEPTH_PADDING[clampDepth(depth, LEAF_DEPTH_PADDING.length - 1)],
         isActive ? ACTIVE_CLASS : INACTIVE_CLASS,
       )}
@@ -112,7 +113,7 @@ export function SettingsGroup({
         {href ? (
           <Link
             href={href}
-            className="flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer"
+            className="flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer outline-none focus-visible:outline-none focus-visible:ring-0"
           >
             {labelInner}
           </Link>
@@ -120,7 +121,7 @@ export function SettingsGroup({
           <button
             type="button"
             onClick={toggle}
-            className="flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer text-left"
+            className="flex flex-1 min-w-0 items-center gap-2 py-1.5 text-[13px] font-medium cursor-pointer text-left outline-none focus-visible:outline-none focus-visible:ring-0"
           >
             {labelInner}
           </button>
@@ -130,7 +131,7 @@ export function SettingsGroup({
           onClick={toggle}
           aria-label={expanded ? `Collapse ${label}` : `Expand ${label}`}
           aria-expanded={expanded}
-          className="shrink-0 flex h-5 w-5 items-center justify-center text-muted-foreground/60 hover:text-foreground/80 cursor-pointer transition-colors"
+          className="shrink-0 flex h-5 w-5 items-center justify-center text-muted-foreground/60 hover:text-foreground/80 cursor-pointer transition-colors outline-none focus-visible:outline-none focus-visible:ring-0"
         >
           <IconChevronRight
             className={cn("h-3 w-3 transition-transform", expanded && "rotate-90")}

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree.test.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree.test.ts
@@ -18,13 +18,8 @@ describe("settingsGroupIdForPath", () => {
     expect(settingsGroupIdForPath("/settings/system/feature-toggles")).toBe("system");
     // General subpages stay under /settings/general so they belong to General.
     expect(settingsGroupIdForPath("/settings/general/appearance")).toBe("general");
-    expect(settingsGroupIdForPath("/settings/general/shell")).toBe("general");
     expect(settingsGroupIdForPath("/settings/general/terminal")).toBe("general");
-    expect(settingsGroupIdForPath("/settings/general/resource-metrics")).toBe("general");
-    expect(settingsGroupIdForPath("/settings/general/chat-input")).toBe("general");
-    expect(settingsGroupIdForPath("/settings/general/changes-panel")).toBe("general");
     expect(settingsGroupIdForPath("/settings/general/keyboard-shortcuts")).toBe("general");
-    expect(settingsGroupIdForPath("/settings/general/backend-connection")).toBe("general");
     expect(settingsGroupIdForPath("/settings/general/editors")).toBe("general");
   });
 

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree.test.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree.test.ts
@@ -16,7 +16,15 @@ describe("settingsGroupIdForPath", () => {
     expect(settingsGroupIdForPath("/settings/workspace/ws-1/repositories")).toBe("workspaces");
     expect(settingsGroupIdForPath("/settings/system/logs")).toBe("system");
     expect(settingsGroupIdForPath("/settings/system/feature-toggles")).toBe("system");
-    // Editors/Secrets live under /settings/general so they belong to General.
+    // General subpages stay under /settings/general so they belong to General.
+    expect(settingsGroupIdForPath("/settings/general/appearance")).toBe("general");
+    expect(settingsGroupIdForPath("/settings/general/shell")).toBe("general");
+    expect(settingsGroupIdForPath("/settings/general/terminal")).toBe("general");
+    expect(settingsGroupIdForPath("/settings/general/resource-metrics")).toBe("general");
+    expect(settingsGroupIdForPath("/settings/general/chat-input")).toBe("general");
+    expect(settingsGroupIdForPath("/settings/general/changes-panel")).toBe("general");
+    expect(settingsGroupIdForPath("/settings/general/keyboard-shortcuts")).toBe("general");
+    expect(settingsGroupIdForPath("/settings/general/backend-connection")).toBe("general");
     expect(settingsGroupIdForPath("/settings/general/editors")).toBe("general");
   });
 

--- a/apps/web/components/settings/general-nav.ts
+++ b/apps/web/components/settings/general-nav.ts
@@ -1,0 +1,42 @@
+import { IconBell, IconCommand, IconCode, IconPalette, IconTerminal2 } from "@tabler/icons-react";
+import type { Icon as TablerIcon } from "@tabler/icons-react";
+
+export type GeneralNavItem = {
+  href: string;
+  label: string;
+  description: string;
+  icon: TablerIcon;
+};
+
+export const GENERAL_NAV_ITEMS: GeneralNavItem[] = [
+  {
+    href: "/settings/general/appearance",
+    label: "Appearance",
+    description: "Theme, metrics, and changes panel preferences",
+    icon: IconPalette,
+  },
+  {
+    href: "/settings/general/terminal",
+    label: "Terminal",
+    description: "Shell, terminal fonts, and link behavior",
+    icon: IconTerminal2,
+  },
+  {
+    href: "/settings/general/notifications",
+    label: "Notifications",
+    description: "Providers and notification events",
+    icon: IconBell,
+  },
+  {
+    href: "/settings/general/editors",
+    label: "Editors",
+    description: "Editor integrations and defaults",
+    icon: IconCode,
+  },
+  {
+    href: "/settings/general/keyboard-shortcuts",
+    label: "Keyboard Shortcuts",
+    description: "Chat input and command shortcuts",
+    icon: IconCommand,
+  },
+];

--- a/apps/web/components/settings/general-settings.tsx
+++ b/apps/web/components/settings/general-settings.tsx
@@ -5,12 +5,9 @@ import Link from "next/link";
 import { useTheme } from "next-themes";
 import {
   IconActivity,
-  IconBell,
   IconCommand,
-  IconCode,
   IconPalette,
   IconKeyboard,
-  IconTerminal2,
   IconGitBranch,
 } from "@tabler/icons-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
@@ -20,42 +17,10 @@ import { Separator } from "@kandev/ui/separator";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { KeyboardShortcutsCard } from "@/components/settings/keyboard-shortcuts-card";
 import { SystemMetricsSettingsCard } from "@/components/settings/system-metrics-settings-card";
+import { GENERAL_NAV_ITEMS } from "@/components/settings/general-nav";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { updateUserSettings } from "@/lib/api";
 import type { Theme } from "@/lib/settings/types";
-
-const GENERAL_SETTING_LINKS = [
-  {
-    href: "/settings/general/appearance",
-    title: "Appearance",
-    description: "Theme, metrics, and changes panel preferences",
-    icon: IconPalette,
-  },
-  {
-    href: "/settings/general/terminal",
-    title: "Terminal",
-    description: "Shell, terminal fonts, and link behavior",
-    icon: IconTerminal2,
-  },
-  {
-    href: "/settings/general/notifications",
-    title: "Notifications",
-    description: "Providers and notification events",
-    icon: IconBell,
-  },
-  {
-    href: "/settings/general/editors",
-    title: "Editors",
-    description: "Editor integrations and defaults",
-    icon: IconCode,
-  },
-  {
-    href: "/settings/general/keyboard-shortcuts",
-    title: "Keyboard Shortcuts",
-    description: "Chat input and command shortcuts",
-    icon: IconCommand,
-  },
-];
 
 function ThemeSettingsCard() {
   const { theme: currentTheme, setTheme } = useTheme();
@@ -202,13 +167,13 @@ export function GeneralSettings() {
   return (
     <div className="space-y-8">
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-        {GENERAL_SETTING_LINKS.map(({ href, title, description, icon: Icon }) => (
+        {GENERAL_NAV_ITEMS.map(({ href, label, description, icon: Icon }) => (
           <Link key={href} href={href} className="cursor-pointer">
             <Card className="h-full transition-colors hover:bg-muted/40">
               <CardHeader className="pb-3">
                 <CardTitle className="flex items-center gap-2 text-base">
                   <Icon className="h-4 w-4 text-muted-foreground" />
-                  {title}
+                  {label}
                 </CardTitle>
               </CardHeader>
               <CardContent>

--- a/apps/web/components/settings/general-settings.tsx
+++ b/apps/web/components/settings/general-settings.tsx
@@ -201,21 +201,21 @@ export function AppearanceSettings() {
       <Separator />
 
       <SettingsSection
-        icon={<IconActivity className="h-5 w-5" />}
-        title="Resource Metrics"
-        description="Configure backend and execution resource sampling"
-      >
-        <SystemMetricsSettingsCard />
-      </SettingsSection>
-
-      <Separator />
-
-      <SettingsSection
         icon={<IconGitBranch className="h-5 w-5" />}
         title="Changes Panel"
         description="Customize how changed files are displayed"
       >
         <ChangesPanelLayoutCard />
+      </SettingsSection>
+
+      <Separator />
+
+      <SettingsSection
+        icon={<IconActivity className="h-5 w-5" />}
+        title="Resource Metrics"
+        description="Configure backend and execution resource sampling"
+      >
+        <SystemMetricsSettingsCard />
       </SettingsSection>
     </div>
   );

--- a/apps/web/components/settings/general-settings.tsx
+++ b/apps/web/components/settings/general-settings.tsx
@@ -1,30 +1,23 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useTheme } from "next-themes";
 import {
+  IconActivity,
+  IconBell,
   IconCommand,
+  IconCode,
   IconPalette,
   IconServer,
   IconKeyboard,
   IconTerminal2,
   IconGitBranch,
-  IconActivity,
 } from "@tabler/icons-react";
-import { Badge } from "@kandev/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
 import { Label } from "@kandev/ui/label";
 import { Input } from "@kandev/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from "@kandev/ui/select";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Separator } from "@kandev/ui/separator";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { ShellSettingsCard } from "@/components/settings/shell-settings-card";
@@ -33,9 +26,70 @@ import { SystemMetricsSettingsCard } from "@/components/settings/system-metrics-
 import { getBackendConfig } from "@/lib/config";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { updateUserSettings } from "@/lib/api";
-import { TERMINAL_FONT_PRESETS } from "@/lib/terminal/terminal-font";
-import type { FontCategory } from "@/lib/terminal/terminal-font";
 import type { Theme } from "@/lib/settings/types";
+
+const GENERAL_SETTING_LINKS = [
+  {
+    href: "/settings/general/appearance",
+    title: "Appearance",
+    description: "Color theme and visual preferences",
+    icon: IconPalette,
+  },
+  {
+    href: "/settings/general/shell",
+    title: "Shell",
+    description: "Default shell for task sessions",
+    icon: IconTerminal2,
+  },
+  {
+    href: "/settings/general/terminal",
+    title: "Terminal",
+    description: "Terminal fonts and link behavior",
+    icon: IconTerminal2,
+  },
+  {
+    href: "/settings/general/notifications",
+    title: "Notifications",
+    description: "Providers and notification events",
+    icon: IconBell,
+  },
+  {
+    href: "/settings/general/editors",
+    title: "Editors",
+    description: "Editor integrations and defaults",
+    icon: IconCode,
+  },
+  {
+    href: "/settings/general/resource-metrics",
+    title: "Resource Metrics",
+    description: "Backend and execution sampling",
+    icon: IconActivity,
+  },
+  {
+    href: "/settings/general/chat-input",
+    title: "Chat Input",
+    description: "Message submit behavior",
+    icon: IconKeyboard,
+  },
+  {
+    href: "/settings/general/changes-panel",
+    title: "Changes Panel",
+    description: "Changed-file display preferences",
+    icon: IconGitBranch,
+  },
+  {
+    href: "/settings/general/keyboard-shortcuts",
+    title: "Keyboard Shortcuts",
+    description: "Command panel shortcuts",
+    icon: IconCommand,
+  },
+  {
+    href: "/settings/general/backend-connection",
+    title: "Backend Connection",
+    description: "Runtime backend server URL",
+    icon: IconServer,
+  },
+];
 
 function ThemeSettingsCard() {
   const { theme: currentTheme, setTheme } = useTheme();
@@ -178,262 +232,6 @@ function ChangesPanelLayoutCard() {
   );
 }
 
-function TerminalLinksCard() {
-  const userSettings = useAppStore((state) => state.userSettings);
-  const setUserSettings = useAppStore((state) => state.setUserSettings);
-  const storeApi = useAppStoreApi();
-  const [isSaving, setIsSaving] = useState(false);
-
-  const handleChange = async (value: "new_tab" | "browser_panel") => {
-    if (isSaving) return;
-    setIsSaving(true);
-    const current = storeApi.getState().userSettings;
-    const previous = current.terminalLinkBehavior;
-    try {
-      setUserSettings({ ...current, terminalLinkBehavior: value });
-      await updateUserSettings({
-        workspace_id: current.workspaceId || "",
-        repository_ids: current.repositoryIds || [],
-        terminal_link_behavior: value,
-      });
-    } catch {
-      setUserSettings({
-        ...storeApi.getState().userSettings,
-        terminalLinkBehavior: previous,
-      });
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Terminal Links</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          <Label htmlFor="terminal-link-behavior">Open links in</Label>
-          <Select
-            value={userSettings.terminalLinkBehavior}
-            onValueChange={(v) => handleChange(v as "new_tab" | "browser_panel")}
-            disabled={isSaving}
-          >
-            <SelectTrigger id="terminal-link-behavior">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="new_tab">New browser tab</SelectItem>
-              <SelectItem value="browser_panel">Built-in browser panel</SelectItem>
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">Click a URL in the terminal to open it.</p>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-const CUSTOM_VALUE = "__custom__";
-const CATEGORY_LABELS: Record<FontCategory, string> = {
-  icons: "Nerd Fonts",
-  ligatures: "Programming",
-  system: "System",
-};
-const CATEGORY_BADGES: Partial<Record<FontCategory, string>> = {
-  icons: "Icons",
-  ligatures: "Ligatures",
-};
-const FONT_GROUPS: Record<string, typeof TERMINAL_FONT_PRESETS> = TERMINAL_FONT_PRESETS.reduce(
-  (acc, p) => {
-    (acc[p.category] ??= []).push(p);
-    return acc;
-  },
-  {} as Record<string, typeof TERMINAL_FONT_PRESETS>,
-);
-const FONT_CATEGORIES: FontCategory[] = ["icons", "ligatures", "system"];
-
-function FontGroupOptions() {
-  return FONT_CATEGORIES.map((category) => (
-    <SelectGroup key={category}>
-      <SelectLabel className="flex items-center gap-2">
-        {CATEGORY_LABELS[category]}
-        {CATEGORY_BADGES[category] && (
-          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-            {CATEGORY_BADGES[category]}
-          </Badge>
-        )}
-      </SelectLabel>
-      {(FONT_GROUPS[category] ?? []).map((preset) => (
-        <SelectItem key={preset.value} value={preset.value}>
-          {preset.label}
-        </SelectItem>
-      ))}
-    </SelectGroup>
-  ));
-}
-
-function TerminalFontSizeCard() {
-  const storeApi = useAppStoreApi();
-  const userSettings = useAppStore((state) => state.userSettings);
-  const setUserSettings = useAppStore((state) => state.setUserSettings);
-  const [isSaving, setIsSaving] = useState(false);
-  const [fontSize, setFontSize] = useState(() => userSettings.terminalFontSize ?? 13);
-
-  const saveFontSize = async (value: number) => {
-    if (isSaving) return;
-    if (value < 8 || value > 24) return;
-    setIsSaving(true);
-    const current = storeApi.getState().userSettings;
-    const previous = current.terminalFontSize;
-    try {
-      setUserSettings({ ...current, terminalFontSize: value });
-      await updateUserSettings({
-        workspace_id: current.workspaceId || "",
-        repository_ids: current.repositoryIds || [],
-        terminal_font_size: value,
-      });
-    } catch {
-      setUserSettings({ ...storeApi.getState().userSettings, terminalFontSize: previous });
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const handleFontSizeBlur = () => {
-    const v = Math.min(24, Math.max(8, fontSize));
-    setFontSize(v);
-    saveFontSize(v);
-  };
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Terminal Font Size</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          <Label htmlFor="terminal-font-size">Font Size</Label>
-          <div className="flex items-center gap-3">
-            <Input
-              id="terminal-font-size"
-              type="number"
-              min={8}
-              max={24}
-              value={fontSize}
-              onChange={(e) => setFontSize(Number(e.target.value))}
-              onBlur={handleFontSizeBlur}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleFontSizeBlur();
-              }}
-              className="w-20"
-              disabled={isSaving}
-              data-testid="terminal-font-size-input"
-            />
-            <span className="text-xs text-muted-foreground">px (8-24)</span>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Set the font size for the terminal. Default is 13px.
-          </p>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function TerminalFontCard() {
-  const storeApi = useAppStoreApi();
-  const userSettings = useAppStore((state) => state.userSettings);
-  const setUserSettings = useAppStore((state) => state.setUserSettings);
-  const [isSaving, setIsSaving] = useState(false);
-  const [isCustom, setIsCustom] = useState(() => {
-    const current = userSettings.terminalFontFamily;
-    if (!current) return false;
-    return !TERMINAL_FONT_PRESETS.some((p) => p.value === current);
-  });
-  const [customValue, setCustomValue] = useState(
-    () => (isCustom ? userSettings.terminalFontFamily : "") ?? "",
-  );
-
-  const saveFontFamily = async (value: string) => {
-    if (isSaving) return;
-    setIsSaving(true);
-    const current = storeApi.getState().userSettings;
-    const previous = current.terminalFontFamily;
-    try {
-      setUserSettings({ ...current, terminalFontFamily: value || null });
-      await updateUserSettings({
-        workspace_id: current.workspaceId || "",
-        repository_ids: current.repositoryIds || [],
-        terminal_font_family: value,
-      });
-    } catch {
-      setUserSettings({
-        ...storeApi.getState().userSettings,
-        terminalFontFamily: previous,
-      });
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const handleSelectChange = (value: string) => {
-    if (value === CUSTOM_VALUE) {
-      setIsCustom(true);
-      return;
-    }
-    setIsCustom(false);
-    setCustomValue("");
-    saveFontFamily(value === "default" ? "" : value);
-  };
-
-  const handleCustomBlur = () => {
-    const trimmed = customValue.trim();
-    if (trimmed) saveFontFamily(trimmed);
-  };
-
-  const selectValue = isCustom ? CUSTOM_VALUE : userSettings.terminalFontFamily || "default";
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Terminal Font</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-3">
-          <Label htmlFor="terminal-font">Font Family</Label>
-          <Select value={selectValue} onValueChange={handleSelectChange} disabled={isSaving}>
-            <SelectTrigger id="terminal-font" data-testid="terminal-font-select">
-              <SelectValue placeholder="Default" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="default">Default (Menlo / Monaco)</SelectItem>
-              <FontGroupOptions />
-              <SelectSeparator />
-              <SelectItem value={CUSTOM_VALUE}>Custom...</SelectItem>
-            </SelectContent>
-          </Select>
-          {isCustom && (
-            <Input
-              placeholder='e.g. "My Custom Font"'
-              value={customValue}
-              onChange={(e) => setCustomValue(e.target.value)}
-              onBlur={handleCustomBlur}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleCustomBlur();
-              }}
-              data-testid="terminal-font-custom-input"
-            />
-          )}
-          <p className="text-xs text-muted-foreground">
-            Choose a monospace font for the terminal. Nerd Fonts include icons for CLI tools.
-          </p>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
 function BackendConnectionCard() {
   const [backendUrl] = useState<string>(() => getBackendConfig().apiBaseUrl);
   const displayBackendUrl = backendUrl.replace(/^https?:\/\//, "").replace(/\/$/, "");
@@ -470,8 +268,39 @@ export function GeneralSettings() {
       <div>
         <h2 className="text-2xl font-bold">General Settings</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Manage your application preferences and notifications
+          Manage application preferences, input behavior, and local runtime defaults
         </p>
+      </div>
+
+      <Separator />
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {GENERAL_SETTING_LINKS.map(({ href, title, description, icon: Icon }) => (
+          <Link key={href} href={href} className="cursor-pointer">
+            <Card className="h-full transition-colors hover:bg-muted/40">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Icon className="h-4 w-4 text-muted-foreground" />
+                  {title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{description}</p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AppearanceSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Appearance</h2>
+        <p className="text-sm text-muted-foreground mt-1">Customize how the application looks</p>
       </div>
 
       <Separator />
@@ -483,22 +312,36 @@ export function GeneralSettings() {
       >
         <ThemeSettingsCard />
       </SettingsSection>
+    </div>
+  );
+}
+
+export function ShellSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Shell</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Pick the default shell for task sessions
+        </p>
+      </div>
 
       <Separator />
 
       <ShellSettingsCard />
+    </div>
+  );
+}
 
-      <Separator />
-
-      <SettingsSection
-        icon={<IconTerminal2 className="h-5 w-5" />}
-        title="Terminal"
-        description="Configure terminal appearance and behavior"
-      >
-        <TerminalFontCard />
-        <TerminalFontSizeCard />
-        <TerminalLinksCard />
-      </SettingsSection>
+export function ResourceMetricsSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Resource Metrics</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Configure backend and execution resource sampling
+        </p>
+      </div>
 
       <Separator />
 
@@ -509,6 +352,17 @@ export function GeneralSettings() {
       >
         <SystemMetricsSettingsCard />
       </SettingsSection>
+    </div>
+  );
+}
+
+export function ChatInputSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Chat Input</h2>
+        <p className="text-sm text-muted-foreground mt-1">Configure chat input behavior</p>
+      </div>
 
       <Separator />
 
@@ -519,6 +373,19 @@ export function GeneralSettings() {
       >
         <ChatSubmitKeyCard />
       </SettingsSection>
+    </div>
+  );
+}
+
+export function ChangesPanelSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Changes Panel</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Customize how changed files are displayed
+        </p>
+      </div>
 
       <Separator />
 
@@ -529,6 +396,19 @@ export function GeneralSettings() {
       >
         <ChangesPanelLayoutCard />
       </SettingsSection>
+    </div>
+  );
+}
+
+export function KeyboardShortcutsSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Keyboard Shortcuts</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Customize keyboard shortcuts for the command panel
+        </p>
+      </div>
 
       <Separator />
 
@@ -539,6 +419,17 @@ export function GeneralSettings() {
       >
         <KeyboardShortcutsCard />
       </SettingsSection>
+    </div>
+  );
+}
+
+export function BackendConnectionSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Backend Connection</h2>
+        <p className="text-sm text-muted-foreground mt-1">View the runtime backend server URL</p>
+      </div>
 
       <Separator />
 

--- a/apps/web/components/settings/general-settings.tsx
+++ b/apps/web/components/settings/general-settings.tsx
@@ -9,21 +9,17 @@ import {
   IconCommand,
   IconCode,
   IconPalette,
-  IconServer,
   IconKeyboard,
   IconTerminal2,
   IconGitBranch,
 } from "@tabler/icons-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
 import { Label } from "@kandev/ui/label";
-import { Input } from "@kandev/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { Separator } from "@kandev/ui/separator";
 import { SettingsSection } from "@/components/settings/settings-section";
-import { ShellSettingsCard } from "@/components/settings/shell-settings-card";
 import { KeyboardShortcutsCard } from "@/components/settings/keyboard-shortcuts-card";
 import { SystemMetricsSettingsCard } from "@/components/settings/system-metrics-settings-card";
-import { getBackendConfig } from "@/lib/config";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { updateUserSettings } from "@/lib/api";
 import type { Theme } from "@/lib/settings/types";
@@ -32,19 +28,13 @@ const GENERAL_SETTING_LINKS = [
   {
     href: "/settings/general/appearance",
     title: "Appearance",
-    description: "Color theme and visual preferences",
+    description: "Theme, metrics, and changes panel preferences",
     icon: IconPalette,
-  },
-  {
-    href: "/settings/general/shell",
-    title: "Shell",
-    description: "Default shell for task sessions",
-    icon: IconTerminal2,
   },
   {
     href: "/settings/general/terminal",
     title: "Terminal",
-    description: "Terminal fonts and link behavior",
+    description: "Shell, terminal fonts, and link behavior",
     icon: IconTerminal2,
   },
   {
@@ -60,34 +50,10 @@ const GENERAL_SETTING_LINKS = [
     icon: IconCode,
   },
   {
-    href: "/settings/general/resource-metrics",
-    title: "Resource Metrics",
-    description: "Backend and execution sampling",
-    icon: IconActivity,
-  },
-  {
-    href: "/settings/general/chat-input",
-    title: "Chat Input",
-    description: "Message submit behavior",
-    icon: IconKeyboard,
-  },
-  {
-    href: "/settings/general/changes-panel",
-    title: "Changes Panel",
-    description: "Changed-file display preferences",
-    icon: IconGitBranch,
-  },
-  {
     href: "/settings/general/keyboard-shortcuts",
     title: "Keyboard Shortcuts",
-    description: "Command panel shortcuts",
+    description: "Chat input and command shortcuts",
     icon: IconCommand,
-  },
-  {
-    href: "/settings/general/backend-connection",
-    title: "Backend Connection",
-    description: "Runtime backend server URL",
-    icon: IconServer,
   },
 ];
 
@@ -232,48 +198,9 @@ function ChangesPanelLayoutCard() {
   );
 }
 
-function BackendConnectionCard() {
-  const [backendUrl] = useState<string>(() => getBackendConfig().apiBaseUrl);
-  const displayBackendUrl = backendUrl.replace(/^https?:\/\//, "").replace(/\/$/, "");
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Backend Server URL</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          <Label htmlFor="backend-url">Server URL</Label>
-          <Input
-            id="backend-url"
-            type="url"
-            value={displayBackendUrl}
-            readOnly
-            disabled
-            placeholder="http://localhost:38429"
-            className="cursor-default"
-          />
-          <p className="text-xs text-muted-foreground">
-            Backend URL is provided at runtime for SSR and WebSocket connections.
-          </p>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
 export function GeneralSettings() {
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">General Settings</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Manage application preferences, input behavior, and local runtime defaults
-        </p>
-      </div>
-
-      <Separator />
-
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
         {GENERAL_SETTING_LINKS.map(({ href, title, description, icon: Icon }) => (
           <Link key={href} href={href} className="cursor-pointer">
@@ -298,13 +225,6 @@ export function GeneralSettings() {
 export function AppearanceSettings() {
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Appearance</h2>
-        <p className="text-sm text-muted-foreground mt-1">Customize how the application looks</p>
-      </div>
-
-      <Separator />
-
       <SettingsSection
         icon={<IconPalette className="h-5 w-5" />}
         title="Appearance"
@@ -312,36 +232,6 @@ export function AppearanceSettings() {
       >
         <ThemeSettingsCard />
       </SettingsSection>
-    </div>
-  );
-}
-
-export function ShellSettings() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Shell</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Pick the default shell for task sessions
-        </p>
-      </div>
-
-      <Separator />
-
-      <ShellSettingsCard />
-    </div>
-  );
-}
-
-export function ResourceMetricsSettings() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Resource Metrics</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Configure backend and execution resource sampling
-        </p>
-      </div>
 
       <Separator />
 
@@ -352,40 +242,6 @@ export function ResourceMetricsSettings() {
       >
         <SystemMetricsSettingsCard />
       </SettingsSection>
-    </div>
-  );
-}
-
-export function ChatInputSettings() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Chat Input</h2>
-        <p className="text-sm text-muted-foreground mt-1">Configure chat input behavior</p>
-      </div>
-
-      <Separator />
-
-      <SettingsSection
-        icon={<IconKeyboard className="h-5 w-5" />}
-        title="Chat Input"
-        description="Configure chat input behavior"
-      >
-        <ChatSubmitKeyCard />
-      </SettingsSection>
-    </div>
-  );
-}
-
-export function ChangesPanelSettings() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Changes Panel</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Customize how changed files are displayed
-        </p>
-      </div>
 
       <Separator />
 
@@ -403,12 +259,13 @@ export function ChangesPanelSettings() {
 export function KeyboardShortcutsSettings() {
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Keyboard Shortcuts</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Customize keyboard shortcuts for the command panel
-        </p>
-      </div>
+      <SettingsSection
+        icon={<IconKeyboard className="h-5 w-5" />}
+        title="Chat Input"
+        description="Configure chat input behavior"
+      >
+        <ChatSubmitKeyCard />
+      </SettingsSection>
 
       <Separator />
 
@@ -418,27 +275,6 @@ export function KeyboardShortcutsSettings() {
         description="Customize keyboard shortcuts for the command panel"
       >
         <KeyboardShortcutsCard />
-      </SettingsSection>
-    </div>
-  );
-}
-
-export function BackendConnectionSettings() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Backend Connection</h2>
-        <p className="text-sm text-muted-foreground mt-1">View the runtime backend server URL</p>
-      </div>
-
-      <Separator />
-
-      <SettingsSection
-        icon={<IconServer className="h-5 w-5" />}
-        title="Backend Connection"
-        description="Configure the backend server URL"
-      >
-        <BackendConnectionCard />
       </SettingsSection>
     </div>
   );

--- a/apps/web/components/settings/settings-layout-client.tsx
+++ b/apps/web/components/settings/settings-layout-client.tsx
@@ -112,7 +112,7 @@ function SettingsShell({
           backHref={backHref}
           backLabel={backLabel}
           parents={parents}
-          className="h-12"
+          className="h-10"
         />
         {/* Scroll the content, not the topbar: min-h-0 lets this flex child
             shrink below its content height so overflow-y-auto can take effect. */}

--- a/apps/web/components/settings/settings-layout-client.tsx
+++ b/apps/web/components/settings/settings-layout-client.tsx
@@ -112,13 +112,13 @@ function SettingsShell({
           backHref={backHref}
           backLabel={backLabel}
           parents={parents}
-          className="h-16 border-b-0"
+          className="h-12"
         />
         {/* Scroll the content, not the topbar: min-h-0 lets this flex child
             shrink below its content height so overflow-y-auto can take effect. */}
         <div
           data-testid="settings-scroll-container"
-          className="flex min-w-0 min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain p-4 pt-0 pb-20"
+          className="flex min-w-0 min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain p-4 pb-20"
         >
           {children}
         </div>

--- a/apps/web/components/settings/terminal-settings.test.ts
+++ b/apps/web/components/settings/terminal-settings.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTerminalFontSize } from "./terminal-settings";
+
+describe("normalizeTerminalFontSize", () => {
+  it("clamps finite font sizes to the supported range", () => {
+    expect(normalizeTerminalFontSize(6, 13)).toBe(8);
+    expect(normalizeTerminalFontSize(18, 13)).toBe(18);
+    expect(normalizeTerminalFontSize(30, 13)).toBe(24);
+  });
+
+  it("uses the fallback when the input is not finite", () => {
+    expect(normalizeTerminalFontSize(Number.NaN, 15)).toBe(15);
+    expect(normalizeTerminalFontSize(Number.POSITIVE_INFINITY, 15)).toBe(15);
+  });
+});

--- a/apps/web/components/settings/terminal-settings.tsx
+++ b/apps/web/components/settings/terminal-settings.tsx
@@ -91,7 +91,7 @@ function TerminalFontSizeCard() {
       });
     } catch {
       const latest = storeApi.getState().userSettings;
-      if (latest.workspaceId === current.workspaceId) {
+      if (latest.workspaceId === current.workspaceId && latest.terminalFontSize === value) {
         setUserSettings({ ...latest, terminalFontSize: previous });
       }
     } finally {
@@ -159,8 +159,9 @@ function TerminalFontCard() {
     setIsSaving(true);
     const current = storeApi.getState().userSettings;
     const previous = current.terminalFontFamily;
+    const nextValue = value || null;
     try {
-      setUserSettings({ ...current, terminalFontFamily: value || null });
+      setUserSettings({ ...current, terminalFontFamily: nextValue });
       await updateUserSettings({
         workspace_id: current.workspaceId || "",
         repository_ids: current.repositoryIds || [],
@@ -168,7 +169,7 @@ function TerminalFontCard() {
       });
     } catch {
       const latest = storeApi.getState().userSettings;
-      if (latest.workspaceId === current.workspaceId) {
+      if (latest.workspaceId === current.workspaceId && latest.terminalFontFamily === nextValue) {
         setUserSettings({ ...latest, terminalFontFamily: previous });
       }
     } finally {
@@ -253,7 +254,7 @@ function TerminalLinksCard() {
       });
     } catch {
       const latest = storeApi.getState().userSettings;
-      if (latest.workspaceId === current.workspaceId) {
+      if (latest.workspaceId === current.workspaceId && latest.terminalLinkBehavior === value) {
         setUserSettings({ ...latest, terminalLinkBehavior: previous });
       }
     } finally {

--- a/apps/web/components/settings/terminal-settings.tsx
+++ b/apps/web/components/settings/terminal-settings.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState } from "react";
+import { IconTerminal2 } from "@tabler/icons-react";
+import { Badge } from "@kandev/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
+import { Input } from "@kandev/ui/input";
+import { Label } from "@kandev/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@kandev/ui/select";
+import { Separator } from "@kandev/ui/separator";
+import { SettingsSection } from "@/components/settings/settings-section";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
+import { updateUserSettings } from "@/lib/api";
+import { TERMINAL_FONT_PRESETS } from "@/lib/terminal/terminal-font";
+import type { FontCategory } from "@/lib/terminal/terminal-font";
+
+const CUSTOM_VALUE = "__custom__";
+const CATEGORY_LABELS: Record<FontCategory, string> = {
+  icons: "Nerd Fonts",
+  ligatures: "Programming",
+  system: "System",
+};
+const CATEGORY_BADGES: Partial<Record<FontCategory, string>> = {
+  icons: "Icons",
+  ligatures: "Ligatures",
+};
+const FONT_GROUPS: Record<string, typeof TERMINAL_FONT_PRESETS> = TERMINAL_FONT_PRESETS.reduce(
+  (acc, p) => {
+    (acc[p.category] ??= []).push(p);
+    return acc;
+  },
+  {} as Record<string, typeof TERMINAL_FONT_PRESETS>,
+);
+const FONT_CATEGORIES: FontCategory[] = ["icons", "ligatures", "system"];
+
+function FontGroupOptions() {
+  return FONT_CATEGORIES.map((category) => (
+    <SelectGroup key={category}>
+      <SelectLabel className="flex items-center gap-2">
+        {CATEGORY_LABELS[category]}
+        {CATEGORY_BADGES[category] && (
+          <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+            {CATEGORY_BADGES[category]}
+          </Badge>
+        )}
+      </SelectLabel>
+      {(FONT_GROUPS[category] ?? []).map((preset) => (
+        <SelectItem key={preset.value} value={preset.value}>
+          {preset.label}
+        </SelectItem>
+      ))}
+    </SelectGroup>
+  ));
+}
+
+function TerminalFontSizeCard() {
+  const storeApi = useAppStoreApi();
+  const userSettings = useAppStore((state) => state.userSettings);
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const [isSaving, setIsSaving] = useState(false);
+  const [fontSize, setFontSize] = useState(() => userSettings.terminalFontSize ?? 13);
+
+  const saveFontSize = async (value: number) => {
+    if (isSaving) return;
+    if (value < 8 || value > 24) return;
+    setIsSaving(true);
+    const current = storeApi.getState().userSettings;
+    const previous = current.terminalFontSize;
+    try {
+      setUserSettings({ ...current, terminalFontSize: value });
+      await updateUserSettings({
+        workspace_id: current.workspaceId || "",
+        repository_ids: current.repositoryIds || [],
+        terminal_font_size: value,
+      });
+    } catch {
+      setUserSettings({ ...storeApi.getState().userSettings, terminalFontSize: previous });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleFontSizeBlur = () => {
+    const value = Math.min(24, Math.max(8, fontSize));
+    setFontSize(value);
+    void saveFontSize(value);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Terminal Font Size</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <Label htmlFor="terminal-font-size">Font Size</Label>
+          <div className="flex items-center gap-3">
+            <Input
+              id="terminal-font-size"
+              type="number"
+              min={8}
+              max={24}
+              value={fontSize}
+              onChange={(e) => setFontSize(Number(e.target.value))}
+              onBlur={handleFontSizeBlur}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleFontSizeBlur();
+              }}
+              className="w-20"
+              disabled={isSaving}
+              data-testid="terminal-font-size-input"
+            />
+            <span className="text-xs text-muted-foreground">px (8-24)</span>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Set the font size for the terminal. Default is 13px.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TerminalFontCard() {
+  const storeApi = useAppStoreApi();
+  const userSettings = useAppStore((state) => state.userSettings);
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isCustom, setIsCustom] = useState(() => {
+    const current = userSettings.terminalFontFamily;
+    if (!current) return false;
+    return !TERMINAL_FONT_PRESETS.some((p) => p.value === current);
+  });
+  const [customValue, setCustomValue] = useState(
+    () => (isCustom ? userSettings.terminalFontFamily : "") ?? "",
+  );
+
+  const saveFontFamily = async (value: string) => {
+    if (isSaving) return;
+    setIsSaving(true);
+    const current = storeApi.getState().userSettings;
+    const previous = current.terminalFontFamily;
+    try {
+      setUserSettings({ ...current, terminalFontFamily: value || null });
+      await updateUserSettings({
+        workspace_id: current.workspaceId || "",
+        repository_ids: current.repositoryIds || [],
+        terminal_font_family: value,
+      });
+    } catch {
+      setUserSettings({
+        ...storeApi.getState().userSettings,
+        terminalFontFamily: previous,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSelectChange = (value: string) => {
+    if (value === CUSTOM_VALUE) {
+      setIsCustom(true);
+      return;
+    }
+    setIsCustom(false);
+    setCustomValue("");
+    void saveFontFamily(value === "default" ? "" : value);
+  };
+
+  const handleCustomBlur = () => {
+    const trimmed = customValue.trim();
+    if (trimmed) void saveFontFamily(trimmed);
+  };
+
+  const selectValue = isCustom ? CUSTOM_VALUE : userSettings.terminalFontFamily || "default";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Terminal Font</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          <Label htmlFor="terminal-font">Font Family</Label>
+          <Select value={selectValue} onValueChange={handleSelectChange} disabled={isSaving}>
+            <SelectTrigger id="terminal-font" data-testid="terminal-font-select">
+              <SelectValue placeholder="Default" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">Default (Menlo / Monaco)</SelectItem>
+              <FontGroupOptions />
+              <SelectSeparator />
+              <SelectItem value={CUSTOM_VALUE}>Custom...</SelectItem>
+            </SelectContent>
+          </Select>
+          {isCustom && (
+            <Input
+              placeholder='e.g. "My Custom Font"'
+              value={customValue}
+              onChange={(e) => setCustomValue(e.target.value)}
+              onBlur={handleCustomBlur}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleCustomBlur();
+              }}
+              data-testid="terminal-font-custom-input"
+            />
+          )}
+          <p className="text-xs text-muted-foreground">
+            Choose a monospace font for the terminal. Nerd Fonts include icons for CLI tools.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TerminalLinksCard() {
+  const userSettings = useAppStore((state) => state.userSettings);
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const storeApi = useAppStoreApi();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleChange = async (value: "new_tab" | "browser_panel") => {
+    if (isSaving) return;
+    setIsSaving(true);
+    const current = storeApi.getState().userSettings;
+    const previous = current.terminalLinkBehavior;
+    try {
+      setUserSettings({ ...current, terminalLinkBehavior: value });
+      await updateUserSettings({
+        workspace_id: current.workspaceId || "",
+        repository_ids: current.repositoryIds || [],
+        terminal_link_behavior: value,
+      });
+    } catch {
+      setUserSettings({
+        ...storeApi.getState().userSettings,
+        terminalLinkBehavior: previous,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Terminal Links</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <Label htmlFor="terminal-link-behavior">Open links in</Label>
+          <Select
+            value={userSettings.terminalLinkBehavior}
+            onValueChange={(v) => void handleChange(v as "new_tab" | "browser_panel")}
+            disabled={isSaving}
+          >
+            <SelectTrigger id="terminal-link-behavior">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="new_tab">New browser tab</SelectItem>
+              <SelectItem value="browser_panel">Built-in browser panel</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">Click a URL in the terminal to open it.</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TerminalSettings() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-bold">Terminal</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Configure terminal appearance and behavior
+        </p>
+      </div>
+
+      <Separator />
+
+      <SettingsSection
+        icon={<IconTerminal2 className="h-5 w-5" />}
+        title="Terminal"
+        description="Configure terminal appearance and behavior"
+      >
+        <TerminalFontCard />
+        <TerminalFontSizeCard />
+        <TerminalLinksCard />
+      </SettingsSection>
+    </div>
+  );
+}

--- a/apps/web/components/settings/terminal-settings.tsx
+++ b/apps/web/components/settings/terminal-settings.tsx
@@ -167,10 +167,10 @@ function TerminalFontCard() {
         terminal_font_family: value,
       });
     } catch {
-      setUserSettings({
-        ...storeApi.getState().userSettings,
-        terminalFontFamily: previous,
-      });
+      const latest = storeApi.getState().userSettings;
+      if (latest.workspaceId === current.workspaceId) {
+        setUserSettings({ ...latest, terminalFontFamily: previous });
+      }
     } finally {
       setIsSaving(false);
     }
@@ -252,10 +252,10 @@ function TerminalLinksCard() {
         terminal_link_behavior: value,
       });
     } catch {
-      setUserSettings({
-        ...storeApi.getState().userSettings,
-        terminalLinkBehavior: previous,
-      });
+      const latest = storeApi.getState().userSettings;
+      if (latest.workspaceId === current.workspaceId) {
+        setUserSettings({ ...latest, terminalLinkBehavior: previous });
+      }
     } finally {
       setIsSaving(false);
     }

--- a/apps/web/components/settings/terminal-settings.tsx
+++ b/apps/web/components/settings/terminal-settings.tsx
@@ -43,6 +43,11 @@ const FONT_GROUPS: Record<string, typeof TERMINAL_FONT_PRESETS> = TERMINAL_FONT_
 );
 const FONT_CATEGORIES: FontCategory[] = ["icons", "ligatures", "system"];
 
+export function normalizeTerminalFontSize(value: number, fallback: number): number {
+  const base = Number.isFinite(value) ? value : fallback;
+  return Math.min(24, Math.max(8, base));
+}
+
 function FontGroupOptions() {
   return FONT_CATEGORIES.map((category) => (
     <SelectGroup key={category}>
@@ -72,6 +77,7 @@ function TerminalFontSizeCard() {
 
   const saveFontSize = async (value: number) => {
     if (isSaving) return;
+    if (!Number.isFinite(value)) return;
     if (value < 8 || value > 24) return;
     setIsSaving(true);
     const current = storeApi.getState().userSettings;
@@ -84,14 +90,17 @@ function TerminalFontSizeCard() {
         terminal_font_size: value,
       });
     } catch {
-      setUserSettings({ ...storeApi.getState().userSettings, terminalFontSize: previous });
+      const latest = storeApi.getState().userSettings;
+      if (latest.workspaceId === current.workspaceId) {
+        setUserSettings({ ...latest, terminalFontSize: previous });
+      }
     } finally {
       setIsSaving(false);
     }
   };
 
   const handleFontSizeBlur = () => {
-    const value = Math.min(24, Math.max(8, fontSize));
+    const value = normalizeTerminalFontSize(fontSize, userSettings.terminalFontSize ?? 13);
     setFontSize(value);
     void saveFontSize(value);
   };

--- a/apps/web/components/settings/terminal-settings.tsx
+++ b/apps/web/components/settings/terminal-settings.tsx
@@ -18,6 +18,7 @@ import {
 } from "@kandev/ui/select";
 import { Separator } from "@kandev/ui/separator";
 import { SettingsSection } from "@/components/settings/settings-section";
+import { ShellSettingsCard } from "@/components/settings/shell-settings-card";
 import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { updateUserSettings } from "@/lib/api";
 import { TERMINAL_FONT_PRESETS } from "@/lib/terminal/terminal-font";
@@ -282,12 +283,7 @@ function TerminalLinksCard() {
 export function TerminalSettings() {
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold">Terminal</h2>
-        <p className="text-sm text-muted-foreground mt-1">
-          Configure terminal appearance and behavior
-        </p>
-      </div>
+      <ShellSettingsCard />
 
       <Separator />
 

--- a/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
+++ b/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from "../../fixtures/test-base";
 
+const KEYBOARD_SETTINGS_PATH = "/settings/general/keyboard-shortcuts";
+
 test.describe("Keyboard Shortcuts Settings", () => {
   test.describe.configure({ retries: 1 });
 
   test("settings page shows all configurable shortcuts", async ({ testPage }) => {
-    await testPage.goto("/settings/general");
+    await testPage.goto(KEYBOARD_SETTINGS_PATH);
 
     // Original 3 shortcuts
     await expect(testPage.getByTestId("shortcut-recorder-SEARCH")).toBeVisible({ timeout: 10_000 });
@@ -30,7 +32,7 @@ test.describe("Keyboard Shortcuts Settings", () => {
       keyboard_shortcuts: {},
     });
 
-    await testPage.goto("/settings/general");
+    await testPage.goto(KEYBOARD_SETTINGS_PATH);
 
     // Find the BOTTOM_TERMINAL recorder and verify it shows the default (Cmd+J or Ctrl+J)
     const recorder = testPage.getByTestId("shortcut-recorder-BOTTOM_TERMINAL");
@@ -49,7 +51,7 @@ test.describe("Keyboard Shortcuts Settings", () => {
     await expect(recorder).toContainText("T", { timeout: 3_000 });
 
     // Reload the page and verify the shortcut persisted
-    await testPage.goto("/settings/general");
+    await testPage.goto(KEYBOARD_SETTINGS_PATH);
     const recorderAfterReload = testPage.getByTestId("shortcut-recorder-BOTTOM_TERMINAL");
     await expect(recorderAfterReload).toBeVisible({ timeout: 10_000 });
     await expect(recorderAfterReload).toContainText("T");
@@ -68,7 +70,7 @@ test.describe("Keyboard Shortcuts Settings", () => {
       },
     });
 
-    await testPage.goto("/settings/general");
+    await testPage.goto(KEYBOARD_SETTINGS_PATH);
 
     const recorder = testPage.getByTestId("shortcut-recorder-TOGGLE_SIDEBAR");
     await expect(recorder).toBeVisible({ timeout: 10_000 });

--- a/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
+++ b/apps/web/e2e/tests/settings/keyboard-shortcuts.spec.ts
@@ -8,8 +8,10 @@ test.describe("Keyboard Shortcuts Settings", () => {
   test("settings page shows all configurable shortcuts", async ({ testPage }) => {
     await testPage.goto(KEYBOARD_SETTINGS_PATH);
 
+    await expect(testPage.locator("#chat-submit-key")).toBeVisible({ timeout: 10_000 });
+
     // Original 3 shortcuts
-    await expect(testPage.getByTestId("shortcut-recorder-SEARCH")).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByTestId("shortcut-recorder-SEARCH")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-FILE_SEARCH")).toBeVisible();
     await expect(testPage.getByTestId("shortcut-recorder-QUICK_CHAT")).toBeVisible();
 

--- a/apps/web/e2e/tests/settings/mobile-general-settings.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-general-settings.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "../../fixtures/test-base";
+
+test.describe("Mobile general settings", () => {
+  test("opens a dedicated General settings page from the overview", async ({ testPage }) => {
+    await testPage.goto("/settings/general");
+
+    await expect(
+      testPage.getByRole("heading", { name: "General Settings", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await testPage.getByRole("link", { name: /Terminal/ }).click();
+
+    await expect(testPage).toHaveURL(/\/settings\/general\/terminal$/);
+    await expect(testPage.locator("h2", { hasText: "Terminal" })).toBeVisible();
+    await expect(testPage.getByTestId("terminal-font-select")).toBeVisible();
+    await expect(testPage.getByTestId("terminal-font-size-input")).toBeVisible();
+  });
+});

--- a/apps/web/e2e/tests/settings/mobile-general-settings.spec.ts
+++ b/apps/web/e2e/tests/settings/mobile-general-settings.spec.ts
@@ -4,14 +4,14 @@ test.describe("Mobile general settings", () => {
   test("opens a dedicated General settings page from the overview", async ({ testPage }) => {
     await testPage.goto("/settings/general");
 
-    await expect(
-      testPage.getByRole("heading", { name: "General Settings", exact: true }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(testPage.getByRole("link", { name: /Terminal/ })).toBeVisible({
+      timeout: 15_000,
+    });
 
     await testPage.getByRole("link", { name: /Terminal/ }).click();
 
     await expect(testPage).toHaveURL(/\/settings\/general\/terminal$/);
-    await expect(testPage.locator("h2", { hasText: "Terminal" })).toBeVisible();
+    await expect(testPage.getByRole("heading", { name: "Terminal", exact: true })).toBeVisible();
     await expect(testPage.getByTestId("terminal-font-select")).toBeVisible();
     await expect(testPage.getByTestId("terminal-font-size-input")).toBeVisible();
   });

--- a/apps/web/e2e/tests/terminal/terminal-settings.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-settings.spec.ts
@@ -4,6 +4,8 @@ import type { SeedData } from "../../fixtures/test-base";
 import type { ApiClient } from "../../helpers/api-client";
 import { SessionPage } from "../../pages/session-page";
 
+const TERMINAL_SETTINGS_PATH = "/settings/general/terminal";
+
 // The full font stack value for "JetBrains Mono" preset
 const JB_MONO_STACK = '"JetBrains Mono", "Fira Code", Menlo, Consolas, monospace';
 
@@ -116,7 +118,7 @@ test.describe("Terminal font settings", () => {
   });
 
   test("settings page shows font and size controls", async ({ testPage }) => {
-    await testPage.goto("/settings/general");
+    await testPage.goto(TERMINAL_SETTINGS_PATH);
 
     // Font family selector
     const fontSelect = testPage.getByTestId("terminal-font-select");
@@ -172,7 +174,7 @@ test.describe("Terminal link settings", () => {
   });
 
   test("settings page shows terminal links card and allows toggling", async ({ testPage }) => {
-    await testPage.goto("/settings");
+    await testPage.goto(TERMINAL_SETTINGS_PATH);
 
     // Terminal Links section visible
     await expect(testPage.locator("text=Terminal Links").first()).toBeVisible({ timeout: 10_000 });

--- a/apps/web/e2e/tests/terminal/terminal-settings.spec.ts
+++ b/apps/web/e2e/tests/terminal/terminal-settings.spec.ts
@@ -120,9 +120,11 @@ test.describe("Terminal font settings", () => {
   test("settings page shows font and size controls", async ({ testPage }) => {
     await testPage.goto(TERMINAL_SETTINGS_PATH);
 
+    await expect(testPage.getByText("Preferred Shell")).toBeVisible({ timeout: 10_000 });
+
     // Font family selector
     const fontSelect = testPage.getByTestId("terminal-font-select");
-    await expect(fontSelect).toBeVisible({ timeout: 10_000 });
+    await expect(fontSelect).toBeVisible();
     await fontSelect.click();
 
     // Verify a preset is listed (exact match to avoid matching Nerd Font variant)


### PR DESCRIPTION
The General settings page had grown into a long mixed-preference form, making settings harder to scan. It now acts as an overview while focused subpages keep each settings area easier to find and maintain.

## Important Changes

- Added dedicated General subroutes for appearance, shell, terminal, metrics, chat input, changes panel, keyboard shortcuts, and backend connection.
- Expanded the General sidebar group so desktop users can jump directly to each focused settings page.
- Added mobile coverage for opening a focused settings page from the General overview.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run --no-build --project mobile-chrome tests/settings/mobile-general-settings.spec.ts`
- `pnpm e2e:run --no-build tests/settings/keyboard-shortcuts.spec.ts tests/terminal/terminal-settings.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->