### PR TITLE
fix: use muted color for scheduling/starting spinner

### DIFF
--- a/apps/web/components/task/task-item.test.tsx
+++ b/apps/web/components/task/task-item.test.tsx
@@ -11,7 +11,7 @@ const WAITING_FOR_INPUT_ICON_TEST_ID = "task-state-waiting-for-input";
 const PENDING_PERMISSION_ICON_TEST_ID = "task-state-pending-permission";
 const AGENT_ERROR_ICON_TEST_ID = "task-agent-error-icon";
 const PREPARING_PHASE = "preparing";
-const PURPLE_SPINNER_CLASS = "text-purple-500";
+const PREPARING_SPINNER_CLASS = "text-muted-foreground/40";
 const SPIN_CLASS = "animate-spin";
 const SLOW_SPIN_CLASS = "[animation-duration:2s]";
 
@@ -30,7 +30,7 @@ function renderTaskItem(props: Partial<ComponentProps<typeof TaskItem>> = {}) {
 function expectPreparingSpinner(): void {
   const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
   expect(icon.getAttribute("data-loading-phase")).toBe(PREPARING_PHASE);
-  expect(icon.classList.contains(PURPLE_SPINNER_CLASS)).toBe(true);
+  expect(icon.classList.contains(PREPARING_SPINNER_CLASS)).toBe(true);
   expect(icon.classList.contains(SPIN_CLASS)).toBe(true);
   expect(icon.classList.contains(SLOW_SPIN_CLASS)).toBe(true);
 }
@@ -76,19 +76,19 @@ describe("TaskItem status icon", () => {
     expect(screen.queryByTestId(PENDING_PERMISSION_ICON_TEST_ID)).toBeNull();
   });
 
-  it("shows a slower purple spinner while the workflow is scheduling", () => {
+  it("shows a slower muted spinner while the workflow is scheduling", () => {
     renderTaskItem({ state: "SCHEDULING" });
 
     expectPreparingSpinner();
   });
 
-  it("shows a slower purple spinner while the session is starting before progress", () => {
+  it("shows a slower muted spinner while the session is starting before progress", () => {
     renderTaskItem({ state: "TODO", sessionState: "STARTING" });
 
     expectPreparingSpinner();
   });
 
-  it("shows a slower purple spinner for in-progress tasks while the session is starting", () => {
+  it("shows a slower muted spinner for in-progress tasks while the session is starting", () => {
     renderTaskItem({ state: "IN_PROGRESS", sessionState: "STARTING" });
 
     expectPreparingSpinner();
@@ -108,7 +108,7 @@ describe("TaskItem status icon", () => {
     expect(icon.getAttribute("data-loading-phase")).toBe("running");
     expect(icon.classList.contains("text-yellow-500")).toBe(true);
     expect(icon.classList.contains(SPIN_CLASS)).toBe(true);
-    expect(icon.classList.contains(PURPLE_SPINNER_CLASS)).toBe(false);
+    expect(icon.classList.contains(PREPARING_SPINNER_CLASS)).toBe(false);
   });
 
   it("keeps the review check for completed review tasks", () => {

--- a/apps/web/components/task/task-item.tsx
+++ b/apps/web/components/task/task-item.tsx
@@ -142,7 +142,7 @@ function TaskStateIcon({
       <IconCircleDashed
         data-testid="task-state-running"
         data-loading-phase="preparing"
-        className="mt-[1px] h-3.5 w-3.5 shrink-0 animate-spin text-purple-500 [animation-duration:2s]"
+        className="mt-[1px] h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground/40 [animation-duration:2s]"
       />
     );
   }


### PR DESCRIPTION
The scheduling/starting spinner in the sidebar shared its purple with the merged-PR icon, which made it easy to mistake a starting task for a merged one. Switched it to the same muted color as the backlog icon, keeping the slower 2s spin so it is still visually distinct from the in-progress yellow spinner.

## Validation

- `make fmt` — clean
- `make typecheck` — clean (pre-existing unrelated error in `hooks/use-file-editors.build-state.test.ts:50` is unchanged)
- `make test` — 3399 web tests + 279 backend tests passing, including the 12 `task-item` tests covering scheduling/starting/running transitions
- `make lint` — clean

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->