### PR TITLE
fix: preserve chat session during workflow advances

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -495,22 +495,8 @@ func (s *Service) resolveStepAgentProfile(ctx context.Context, step *wfmodels.Wo
 	return ""
 }
 
-// sessionWasWorkflowSwitched reports whether the session was spawned by a
-// previous workflow step's agent_profile override (createNewSessionForStep)
-// rather than by the user. Used to decide whether transitioning to a step
-// with no override should revert to the task default.
-func sessionWasWorkflowSwitched(session *models.TaskSession) bool {
-	if session == nil || session.Metadata == nil {
-		return false
-	}
-	v, _ := session.Metadata[models.SessionMetaKeyCreatedBy].(string)
-	return v == models.SessionCreatedByWorkflowSwitch
-}
-
-// tagSessionAsWorkflowSwitched marks a session's metadata so it's recognised
-// as workflow-spawned by sessionWasWorkflowSwitched. Used by every code path
-// that ends up with a session whose agent_profile_id was decided by the
-// workflow step override rather than by the user. Uses the atomic
+// tagSessionAsWorkflowSwitched records that a session's profile came from a
+// workflow step override rather than direct user selection. Uses the atomic
 // SetSessionMetadataKey (json_set) so other metadata keys are preserved.
 func (s *Service) tagSessionAsWorkflowSwitched(ctx context.Context, sessionID string) {
 	if err := s.repo.SetSessionMetadataKey(ctx, sessionID, models.SessionMetaKeyCreatedBy, models.SessionCreatedByWorkflowSwitch); err != nil {
@@ -610,11 +596,8 @@ func (s *Service) reuseSessionForStep(ctx context.Context, taskID string, curren
 		s.reviveReusedSession(ctx, existing)
 	}
 
-	// Note: do not stamp created_by here. Reused sessions keep whatever tag
-	// they had when first created — workflow-spawned ones (createNewSessionForStep,
-	// StartCreatedSession, startTask) already carry the workflow_switch tag,
-	// and user-created ones must stay untagged so a later plain step doesn't
-	// silently revert their explicit profile choice to the task default.
+	// Note: do not stamp created_by here. Reused sessions keep whatever
+	// provenance tag they had when first created.
 
 	if err := s.SetPrimarySession(ctx, existing.ID); err != nil {
 		s.logger.Warn("failed to set reused session as primary",
@@ -698,10 +681,8 @@ func (s *Service) createNewSessionForStep(ctx context.Context, taskID string, cu
 		return nil, fmt.Errorf("failed to get new session: %w", err)
 	}
 
-	// Tag the session as workflow-spawned so a later transition to a plain
-	// step (no agent_profile override) knows it's safe to revert to the task
-	// default. User-created sessions intentionally lack this tag — reverting
-	// them would override an explicit user choice.
+	// Tag the session as workflow-spawned for provenance: its agent profile
+	// was selected by the workflow step override rather than direct user choice.
 	s.tagSessionAsWorkflowSwitched(ctx, newSession.ID)
 
 	// Inherit the task environment from the old session — the workspace is shared
@@ -784,9 +765,8 @@ func (s *Service) completeAndStopSession(ctx context.Context, taskID string, ses
 
 // maybySwitchSessionForProfile checks whether the step requires a different agent profile
 // and switches the session if so. Passthrough sessions are returned unchanged.
-// When the step has no agent_profile override, falls back to the task's original
-// agent profile (from task metadata) so that moving to a "plain" step reverts
-// to the default agent instead of keeping the previous step's override.
+// When the step has no explicit step/workflow profile, the current session is
+// preserved so workflow advancement does not reset the user's current agent mode.
 // Returns the effective session (new or original) and whether processing should continue.
 // A false return means the switch failed; the caller should return immediately.
 func (s *Service) maybySwitchSessionForProfile(
@@ -796,22 +776,6 @@ func (s *Service) maybySwitchSessionForProfile(
 		return session, true
 	}
 	effectiveProfile := s.resolveStepAgentProfile(ctx, step)
-
-	// When the step has no override, fall back to the task's original agent
-	// profile so that moving to a step without an agent_profile reverts to the
-	// default. Only do this when the current session was itself spawned by a
-	// previous step's override — a user-chosen session (e.g. "New Agent"
-	// button) must not be silently replaced by the task default, which would
-	// override the user's explicit choice.
-	if effectiveProfile == "" && sessionWasWorkflowSwitched(session) {
-		task, err := s.repo.GetTask(ctx, taskID)
-		if err == nil && task.Metadata != nil {
-			if pid, ok := task.Metadata[models.MetaKeyAgentProfileID].(string); ok && pid != "" {
-				effectiveProfile = pid
-			}
-		}
-	}
-
 	if effectiveProfile == "" || effectiveProfile == session.AgentProfileID {
 		return session, true
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -777,6 +777,17 @@ func (s *Service) maybySwitchSessionForProfile(
 	}
 	effectiveProfile := s.resolveStepAgentProfile(ctx, step)
 	if effectiveProfile == "" || effectiveProfile == session.AgentProfileID {
+		if !session.IsPrimary {
+			if err := s.SetPrimarySession(ctx, session.ID); err != nil {
+				s.logger.Warn("failed to preserve session as primary for workflow step",
+					zap.String("task_id", taskID),
+					zap.String("session_id", session.ID),
+					zap.String("step_id", step.ID),
+					zap.Error(err))
+			} else {
+				session.IsPrimary = true
+			}
+		}
 		return session, true
 	}
 	newSession, err := s.switchSessionForStep(ctx, taskID, session, effectiveProfile)

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -831,7 +831,7 @@ func TestProcessOnEnter_ProfileSwitch(t *testing.T) {
 			ExecutorID:        "exec-local",
 			ExecutorProfileID: "ep1",
 			State:             models.TaskSessionStateWaitingForInput,
-			IsPrimary:         true,
+			IsPrimary:         false,
 			Metadata:          map[string]interface{}{models.SessionMetaKeyCreatedBy: models.SessionCreatedByWorkflowSwitch},
 			StartedAt:         now,
 			UpdatedAt:         now,
@@ -879,6 +879,9 @@ func TestProcessOnEnter_ProfileSwitch(t *testing.T) {
 		}
 		if updated.AgentProfileID != "profile-b" {
 			t.Fatalf("expected active profile-b session to be preserved, got %q", updated.AgentProfileID)
+		}
+		if !updated.IsPrimary {
+			t.Fatal("expected preserved profile-b session to become primary")
 		}
 
 		sessions, err := repo.ListTaskSessions(ctx, "t1")

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_profile_test.go
@@ -804,10 +804,10 @@ func TestProcessOnEnter_ProfileSwitch(t *testing.T) {
 		}
 	})
 
-	// Inverse of the above: when the current session was spawned by a
-	// previous step's agent_profile override, transitioning to a plain step
-	// SHOULD revert to the task default.
-	t.Run("reverts to task default when current session was workflow-spawned", func(t *testing.T) {
+	// Workflow-spawned sessions should behave like user-chosen sessions when
+	// the target step has no profile override: preserve the active session
+	// instead of silently reverting to the task default.
+	t.Run("keeps workflow-spawned session when step has no override", func(t *testing.T) {
 		repo := setupTestRepo(t)
 		now := time.Now().UTC()
 
@@ -870,39 +870,23 @@ func TestProcessOnEnter_ProfileSwitch(t *testing.T) {
 
 		svc.processOnEnter(ctx, "t1", session, step, "desc")
 
-		oldSession, err := repo.GetTaskSession(ctx, "s1")
+		updated, err := repo.GetTaskSession(ctx, "s1")
 		if err != nil {
-			t.Fatalf("failed to get old session: %v", err)
+			t.Fatalf("failed to get session: %v", err)
 		}
-		if oldSession.State != models.TaskSessionStateCompleted {
-			t.Errorf("workflow-spawned session should be completed when reverting to default, got %s", oldSession.State)
+		if updated.State == models.TaskSessionStateCompleted {
+			t.Fatal("workflow-spawned session must not be completed when the target step has no override")
+		}
+		if updated.AgentProfileID != "profile-b" {
+			t.Fatalf("expected active profile-b session to be preserved, got %q", updated.AgentProfileID)
 		}
 
 		sessions, err := repo.ListTaskSessions(ctx, "t1")
 		if err != nil {
 			t.Fatalf("failed to list sessions: %v", err)
 		}
-		if len(sessions) != 2 {
-			t.Fatalf("expected exactly 2 sessions (old + reverted), got %d", len(sessions))
-		}
-		var newSession *models.TaskSession
-		profileACount := 0
-		for _, s := range sessions {
-			if s.AgentProfileID == "profile-a" {
-				profileACount++
-			}
-			if s.ID != "s1" {
-				newSession = s
-			}
-		}
-		if profileACount != 1 {
-			t.Fatalf("expected exactly one profile-a session after revert, got %d", profileACount)
-		}
-		if newSession == nil {
-			t.Fatal("expected a new session for task default profile")
-		}
-		if newSession.AgentProfileID != "profile-a" {
-			t.Errorf("expected reverted profile-a, got %q", newSession.AgentProfileID)
+		if len(sessions) != 1 {
+			t.Fatalf("expected no default-profile session to be spawned, got %d sessions", len(sessions))
 		}
 	})
 }

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -278,11 +278,8 @@ func (s *Service) StartCreatedSession(ctx context.Context, taskID, sessionID, ag
 			zap.String("old_profile", session.AgentProfileID),
 			zap.String("new_profile", effectiveProfileID))
 		session.AgentProfileID = effectiveProfileID
-		// Tag as workflow-spawned so a later transition to a plain step can
-		// correctly revert to the task default. Without this, the in-place
-		// profile mutation here is invisible to maybySwitchSessionForProfile,
-		// which would treat the session as user-chosen and leave it on the
-		// override forever.
+		// Tag as workflow-spawned provenance: the in-place profile mutation
+		// came from a workflow step override, not direct user selection.
 		s.tagSessionAsWorkflowSwitched(ctx, sessionID)
 		// Re-resolve the agent profile snapshot so the tab shows the correct agent logo/name.
 		// Set a minimal snapshot first so stale data is never persisted if resolution fails.
@@ -565,9 +562,8 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	}
 
 	// When the workflow step overrode the caller's profile, tag the session
-	// so maybySwitchSessionForProfile knows it can revert to the task default
-	// on a later plain-step transition. Without this tag, the session looks
-	// indistinguishable from a user-chosen one and stays on the override.
+	// for provenance: the profile came from workflow routing rather than
+	// direct user selection.
 	if overrideApplied {
 		s.tagSessionAsWorkflowSwitched(ctx, sessionID)
 	}
@@ -691,8 +687,8 @@ func (s *Service) createStartSession(
 		// mutation: the session is created directly with the assignee
 		// profile (which falls back to the step's agent_profile_id via the
 		// runner projection). If that profile differs from the caller's,
-		// the assignment was workflow-driven — tag so a later transition
-		// to a plain step knows it can revert to the task default.
+		// the assignment was workflow-driven, so keep that provenance on
+		// the session metadata.
 		if agentProfileID != "" && session.AgentProfileID != "" && session.AgentProfileID != agentProfileID {
 			s.tagSessionAsWorkflowSwitched(ctx, session.ID)
 		}

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -313,7 +313,7 @@ func (h *MessageHandlers) resolveSessionAfterTurnStart(
 			zap.String("task_id", taskID),
 			zap.String("session_id", submittedSessionID),
 			zap.Error(err))
-		return current, nil
+		return nil, errors.New("failed to reload submitted session after on_turn_start")
 	}
 	if reloaded.State != models.TaskSessionStateCompleted {
 		return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(reloaded)}, nil

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -225,7 +225,15 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 				zap.String("session_id", req.TaskSessionID),
 				zap.Error(err))
 		}
-		sessionResp = h.resolveSessionAfterTurnStart(ctx, req.TaskID, req.TaskSessionID, sessionResp)
+		var err error
+		sessionResp, err = h.resolveSessionAfterTurnStart(ctx, req.TaskID, req.TaskSessionID, sessionResp)
+		if err != nil {
+			h.logger.Warn("failed to resolve prompt session after on_turn_start",
+				zap.String("task_id", req.TaskID),
+				zap.String("session_id", req.TaskSessionID),
+				zap.Error(err))
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to resolve prompt session", nil)
+		}
 		req.TaskSessionID = sessionResp.Session.ID
 	}
 	isCreatedSession := sessionResp.Session.State == models.TaskSessionStateCreated
@@ -292,9 +300,9 @@ func (h *MessageHandlers) resolveSessionAfterTurnStart(
 	ctx context.Context,
 	taskID, submittedSessionID string,
 	current *dto.GetTaskSessionResponse,
-) *dto.GetTaskSessionResponse {
-	if current == nil || current.Session.ID == "" {
-		return current
+) (*dto.GetTaskSessionResponse, error) {
+	if current.Session.ID == "" {
+		return nil, errors.New("submitted session response missing session id")
 	}
 	reloaded, err := h.service.GetTaskSession(ctx, submittedSessionID)
 	if err != nil {
@@ -302,22 +310,25 @@ func (h *MessageHandlers) resolveSessionAfterTurnStart(
 			zap.String("task_id", taskID),
 			zap.String("session_id", submittedSessionID),
 			zap.Error(err))
-		return current
+		return current, nil
 	}
 	if reloaded.State != models.TaskSessionStateCompleted {
-		return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(reloaded)}
+		return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(reloaded)}, nil
 	}
 	primary, err := h.service.GetPrimarySession(ctx, taskID)
-	if err != nil || primary == nil || primary.ID == submittedSessionID {
+	if err != nil || primary == nil {
 		if err != nil {
 			h.logger.Warn("failed to load primary session after on_turn_start switch",
 				zap.String("task_id", taskID),
 				zap.String("session_id", submittedSessionID),
 				zap.Error(err))
 		}
-		return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(reloaded)}
+		return nil, errors.New("submitted session completed during on_turn_start without replacement primary session")
 	}
-	return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(primary)}
+	if primary.ID == submittedSessionID {
+		return nil, errors.New("submitted session completed during on_turn_start but remains primary")
+	}
+	return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(primary)}, nil
 }
 
 // validateAddMessageRequest returns a non-empty error string if the request is invalid.

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -236,6 +236,9 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 		}
 		req.TaskSessionID = sessionResp.Session.ID
 	}
+	if wsErr := h.errorForBlockedMessageSession(msg, sessionResp.Session.State); wsErr != nil {
+		return wsErr, nil
+	}
 	isCreatedSession := sessionResp.Session.State == models.TaskSessionStateCreated
 
 	// Build metadata with attachments, plan mode, review comments, and context files
@@ -331,6 +334,19 @@ func (h *MessageHandlers) resolveSessionAfterTurnStart(
 	return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(primary)}, nil
 }
 
+func (h *MessageHandlers) errorForBlockedMessageSession(msg *ws.Message, state models.TaskSessionState) *ws.Message {
+	switch state {
+	case models.TaskSessionStateRunning:
+		wsErr, _ := ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Agent is currently processing. Please wait for the current operation to complete.", nil)
+		return wsErr
+	case models.TaskSessionStateFailed, models.TaskSessionStateCancelled, models.TaskSessionStateCompleted:
+		wsErr, _ := ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Session has ended. Please create a new session to continue.", nil)
+		return wsErr
+	default:
+		return nil
+	}
+}
+
 // validateAddMessageRequest returns a non-empty error string if the request is invalid.
 func validateAddMessageRequest(req wsAddMessageRequest) string {
 	if req.TaskSessionID == "" {
@@ -360,18 +376,19 @@ func (h *MessageHandlers) checkSessionStateForMessage(ctx context.Context, msg *
 	}
 	sessionDTO := dto.FromTaskSession(session)
 	resp := &dto.GetTaskSessionResponse{Session: sessionDTO}
-	switch sessionDTO.State {
-	case models.TaskSessionStateRunning:
-		h.logger.Warn("rejected message submission while agent is busy",
-			zap.String("session_id", sessionID),
-			zap.String("session_state", string(sessionDTO.State)))
-		wsErr, _ := ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Agent is currently processing. Please wait for the current operation to complete.", nil)
-		return nil, wsErr
-	case models.TaskSessionStateFailed, models.TaskSessionStateCancelled:
-		wsErr, _ := ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "Session has ended. Please create a new session to continue.", nil)
+	if wsErr := h.errorForBlockedMessageSession(msg, sessionDTO.State); wsErr != nil {
+		if sessionDTO.State == models.TaskSessionStateRunning {
+			h.logBlockedRunningSession(sessionID, sessionDTO.State)
+		}
 		return nil, wsErr
 	}
 	return resp, nil
+}
+
+func (h *MessageHandlers) logBlockedRunningSession(sessionID string, state models.TaskSessionState) {
+	h.logger.Warn("rejected message submission while agent is busy",
+		zap.String("session_id", sessionID),
+		zap.String("session_state", string(state)))
 }
 
 // ensureTaskInProgress fetches the task and transitions it from REVIEW → IN_PROGRESS if needed.

--- a/apps/backend/internal/task/handlers/message_handlers.go
+++ b/apps/backend/internal/task/handlers/message_handlers.go
@@ -204,7 +204,6 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 	if wsErr != nil {
 		return wsErr, nil
 	}
-	isCreatedSession := sessionResp.Session.State == models.TaskSessionStateCreated
 
 	// Transition task from REVIEW → IN_PROGRESS if needed
 	if err := h.ensureTaskInProgress(ctx, req.TaskID); err != nil {
@@ -226,7 +225,10 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 				zap.String("session_id", req.TaskSessionID),
 				zap.Error(err))
 		}
+		sessionResp = h.resolveSessionAfterTurnStart(ctx, req.TaskID, req.TaskSessionID, sessionResp)
+		req.TaskSessionID = sessionResp.Session.ID
 	}
+	isCreatedSession := sessionResp.Session.State == models.TaskSessionStateCreated
 
 	// Build metadata with attachments, plan mode, review comments, and context files
 	meta := orchestrator.NewUserMessageMeta().
@@ -284,6 +286,38 @@ func (h *MessageHandlers) wsAddMessage(ctx context.Context, msg *ws.Message) (*w
 	}
 
 	return response, nil
+}
+
+func (h *MessageHandlers) resolveSessionAfterTurnStart(
+	ctx context.Context,
+	taskID, submittedSessionID string,
+	current *dto.GetTaskSessionResponse,
+) *dto.GetTaskSessionResponse {
+	if current == nil || current.Session.ID == "" {
+		return current
+	}
+	reloaded, err := h.service.GetTaskSession(ctx, submittedSessionID)
+	if err != nil {
+		h.logger.Warn("failed to reload session after on_turn_start",
+			zap.String("task_id", taskID),
+			zap.String("session_id", submittedSessionID),
+			zap.Error(err))
+		return current
+	}
+	if reloaded.State != models.TaskSessionStateCompleted {
+		return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(reloaded)}
+	}
+	primary, err := h.service.GetPrimarySession(ctx, taskID)
+	if err != nil || primary == nil || primary.ID == submittedSessionID {
+		if err != nil {
+			h.logger.Warn("failed to load primary session after on_turn_start switch",
+				zap.String("task_id", taskID),
+				zap.String("session_id", submittedSessionID),
+				zap.Error(err))
+		}
+		return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(reloaded)}
+	}
+	return &dto.GetTaskSessionResponse{Session: dto.FromTaskSession(primary)}
 }
 
 // validateAddMessageRequest returns a non-empty error string if the request is invalid.

--- a/apps/backend/internal/task/handlers/message_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -149,11 +150,13 @@ func TestWaitForSessionReady_ContextCancelled(t *testing.T) {
 
 type messageAddSwitchRepo struct {
 	mockRepository
-	tasks     map[string]*models.Task
-	sessions  map[string]*models.TaskSession
-	primaryID string
-	messages  []*models.Message
-	turns     []*models.Turn
+	tasks      map[string]*models.Task
+	sessions   map[string]*models.TaskSession
+	primaryID  string
+	messages   []*models.Message
+	turns      []*models.Turn
+	getCalls   map[string]int
+	failReload bool
 }
 
 func (r *messageAddSwitchRepo) GetTask(_ context.Context, id string) (*models.Task, error) {
@@ -164,6 +167,13 @@ func (r *messageAddSwitchRepo) GetTask(_ context.Context, id string) (*models.Ta
 }
 
 func (r *messageAddSwitchRepo) GetTaskSession(_ context.Context, id string) (*models.TaskSession, error) {
+	if r.getCalls == nil {
+		r.getCalls = make(map[string]int)
+	}
+	r.getCalls[id]++
+	if r.failReload && id == "s1" && r.getCalls[id] > 1 {
+		return nil, errors.New("reload failed")
+	}
 	if session, ok := r.sessions[id]; ok {
 		return session, nil
 	}
@@ -334,6 +344,46 @@ func TestWSAddMessageFailsWhenOnTurnStartCompletesSessionWithoutReplacement(t *t
 		Reviews: repo,
 	}, nil, log, service.RepositoryDiscoveryConfig{})
 	orch := &switchingTurnStartOrchestrator{repo: repo}
+	h := NewMessageHandlers(svc, orch, log)
+
+	req, err := ws.NewRequest("req-1", ws.ActionMessageAdd, map[string]interface{}{
+		"task_id":    "t1",
+		"session_id": "s1",
+		"content":    "continue here",
+	})
+	require.NoError(t, err)
+
+	resp, err := h.wsAddMessage(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeError, resp.Type)
+	assert.Empty(t, repo.messages)
+	assert.Empty(t, orch.getStartedSession())
+	assert.Empty(t, orch.getForwardedSession())
+}
+
+func TestWSAddMessageFailsWhenSessionReloadAfterOnTurnStartFails(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &messageAddSwitchRepo{
+		tasks: map[string]*models.Task{
+			"t1": {ID: "t1", State: v1.TaskStateReview, UpdatedAt: now},
+		},
+		sessions: map[string]*models.TaskSession{
+			"s1": {ID: "s1", TaskID: "t1", State: models.TaskSessionStateWaitingForInput, AgentProfileID: "profile-old", UpdatedAt: now},
+			"s2": {ID: "s2", TaskID: "t1", State: models.TaskSessionStateCreated, AgentProfileID: "profile-new", UpdatedAt: now},
+		},
+		primaryID:  "s1",
+		failReload: true,
+	}
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	orch := &switchingTurnStartOrchestrator{repo: repo, switchPrimary: true}
 	h := NewMessageHandlers(svc, orch, log)
 
 	req, err := ws.NewRequest("req-1", ws.ActionMessageAdd, map[string]interface{}{

--- a/apps/backend/internal/task/handlers/message_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_test.go
@@ -196,6 +196,7 @@ type switchingTurnStartOrchestrator struct {
 	repo             *messageAddSwitchRepo
 	forwardedSession string
 	startedSession   string
+	switchPrimary    bool
 }
 
 func (o *switchingTurnStartOrchestrator) PromptTask(
@@ -230,7 +231,9 @@ func (o *switchingTurnStartOrchestrator) StartCreatedSession(
 
 func (o *switchingTurnStartOrchestrator) ProcessOnTurnStart(context.Context, string, string) error {
 	o.repo.sessions["s1"].State = models.TaskSessionStateCompleted
-	o.repo.primaryID = "s2"
+	if o.switchPrimary {
+		o.repo.primaryID = "s2"
+	}
 	return nil
 }
 
@@ -239,6 +242,50 @@ func (o *switchingTurnStartOrchestrator) StepRequiresCompletionSignal(context.Co
 }
 
 func TestWSAddMessageUsesSessionSelectedByOnTurnStart(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &messageAddSwitchRepo{
+		tasks: map[string]*models.Task{
+			"t1": {ID: "t1", State: v1.TaskStateReview, UpdatedAt: now},
+		},
+		sessions: map[string]*models.TaskSession{
+			"s1": {ID: "s1", TaskID: "t1", State: models.TaskSessionStateWaitingForInput, AgentProfileID: "profile-old", UpdatedAt: now},
+			"s2": {ID: "s2", TaskID: "t1", State: models.TaskSessionStateCreated, AgentProfileID: "profile-new", UpdatedAt: now},
+		},
+		primaryID: "s1",
+	}
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	orch := &switchingTurnStartOrchestrator{repo: repo, switchPrimary: true}
+	h := NewMessageHandlers(svc, orch, log)
+
+	req, err := ws.NewRequest("req-1", ws.ActionMessageAdd, map[string]interface{}{
+		"task_id":    "t1",
+		"session_id": "s1",
+		"content":    "continue here",
+	})
+	require.NoError(t, err)
+
+	resp, err := h.wsAddMessage(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	require.Len(t, repo.messages, 1)
+	assert.Equal(t, "s2", repo.messages[0].TaskSessionID)
+
+	require.Eventually(t, func() bool {
+		return orch.startedSession != ""
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "s2", orch.startedSession)
+	assert.Empty(t, orch.forwardedSession)
+}
+
+func TestWSAddMessageFailsWhenOnTurnStartCompletesSessionWithoutReplacement(t *testing.T) {
 	now := time.Now().UTC()
 	repo := &messageAddSwitchRepo{
 		tasks: map[string]*models.Task{
@@ -271,13 +318,8 @@ func TestWSAddMessageUsesSessionSelectedByOnTurnStart(t *testing.T) {
 
 	resp, err := h.wsAddMessage(context.Background(), req)
 	require.NoError(t, err)
-	require.Equal(t, ws.MessageTypeResponse, resp.Type)
-	require.Len(t, repo.messages, 1)
-	assert.Equal(t, "s2", repo.messages[0].TaskSessionID)
-
-	require.Eventually(t, func() bool {
-		return orch.startedSession != ""
-	}, time.Second, 10*time.Millisecond)
-	assert.Equal(t, "s2", orch.startedSession)
+	require.Equal(t, ws.MessageTypeError, resp.Type)
+	assert.Empty(t, repo.messages)
+	assert.Empty(t, orch.startedSession)
 	assert.Empty(t, orch.forwardedSession)
 }

--- a/apps/backend/internal/task/handlers/message_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_test.go
@@ -2,16 +2,20 @@ package handlers
 
 import (
 	"context"
+	"database/sql"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/kandev/kandev/internal/orchestrator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/service"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+	ws "github.com/kandev/kandev/pkg/websocket"
 )
 
 // sessionStateSequencer is a mock repository that returns a sequence of session states.
@@ -141,4 +145,139 @@ func TestWaitForSessionReady_ContextCancelled(t *testing.T) {
 	err := h.waitForSessionReady(ctx, "session-1")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+type messageAddSwitchRepo struct {
+	mockRepository
+	tasks     map[string]*models.Task
+	sessions  map[string]*models.TaskSession
+	primaryID string
+	messages  []*models.Message
+	turns     []*models.Turn
+}
+
+func (r *messageAddSwitchRepo) GetTask(_ context.Context, id string) (*models.Task, error) {
+	if task, ok := r.tasks[id]; ok {
+		return task, nil
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *messageAddSwitchRepo) GetTaskSession(_ context.Context, id string) (*models.TaskSession, error) {
+	if session, ok := r.sessions[id]; ok {
+		return session, nil
+	}
+	return nil, sql.ErrNoRows
+}
+
+func (r *messageAddSwitchRepo) GetPrimarySessionByTaskID(_ context.Context, taskID string) (*models.TaskSession, error) {
+	session, ok := r.sessions[r.primaryID]
+	if !ok || session.TaskID != taskID {
+		return nil, sql.ErrNoRows
+	}
+	return session, nil
+}
+
+func (r *messageAddSwitchRepo) CreateMessage(_ context.Context, message *models.Message) error {
+	r.messages = append(r.messages, message)
+	return nil
+}
+
+func (r *messageAddSwitchRepo) GetActiveTurnBySessionID(_ context.Context, _ string) (*models.Turn, error) {
+	return nil, sql.ErrNoRows
+}
+
+func (r *messageAddSwitchRepo) CreateTurn(_ context.Context, turn *models.Turn) error {
+	r.turns = append(r.turns, turn)
+	return nil
+}
+
+type switchingTurnStartOrchestrator struct {
+	repo             *messageAddSwitchRepo
+	forwardedSession string
+	startedSession   string
+}
+
+func (o *switchingTurnStartOrchestrator) PromptTask(
+	_ context.Context,
+	_, sessionID, _, _ string,
+	_ bool,
+	_ []v1.MessageAttachment,
+	_ bool,
+) (*orchestrator.PromptResult, error) {
+	o.forwardedSession = sessionID
+	return &orchestrator.PromptResult{}, nil
+}
+
+func (o *switchingTurnStartOrchestrator) ResumeTaskSession(context.Context, string, string) error {
+	return nil
+}
+
+func (o *switchingTurnStartOrchestrator) StartCreatedSession(
+	_ context.Context,
+	_ string,
+	sessionID string,
+	_ string,
+	_ string,
+	_ bool,
+	_ bool,
+	_ bool,
+	_ []v1.MessageAttachment,
+) error {
+	o.startedSession = sessionID
+	return nil
+}
+
+func (o *switchingTurnStartOrchestrator) ProcessOnTurnStart(context.Context, string, string) error {
+	o.repo.sessions["s1"].State = models.TaskSessionStateCompleted
+	o.repo.primaryID = "s2"
+	return nil
+}
+
+func (o *switchingTurnStartOrchestrator) StepRequiresCompletionSignal(context.Context, string) bool {
+	return false
+}
+
+func TestWSAddMessageUsesSessionSelectedByOnTurnStart(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &messageAddSwitchRepo{
+		tasks: map[string]*models.Task{
+			"t1": {ID: "t1", State: v1.TaskStateReview, UpdatedAt: now},
+		},
+		sessions: map[string]*models.TaskSession{
+			"s1": {ID: "s1", TaskID: "t1", State: models.TaskSessionStateWaitingForInput, AgentProfileID: "profile-old", UpdatedAt: now},
+			"s2": {ID: "s2", TaskID: "t1", State: models.TaskSessionStateCreated, AgentProfileID: "profile-new", UpdatedAt: now},
+		},
+		primaryID: "s1",
+	}
+	log, err := logger.NewLogger(logger.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	orch := &switchingTurnStartOrchestrator{repo: repo}
+	h := NewMessageHandlers(svc, orch, log)
+
+	req, err := ws.NewRequest("req-1", ws.ActionMessageAdd, map[string]interface{}{
+		"task_id":    "t1",
+		"session_id": "s1",
+		"content":    "continue here",
+	})
+	require.NoError(t, err)
+
+	resp, err := h.wsAddMessage(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	require.Len(t, repo.messages, 1)
+	assert.Equal(t, "s2", repo.messages[0].TaskSessionID)
+
+	require.Eventually(t, func() bool {
+		return orch.startedSession != ""
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "s2", orch.startedSession)
+	assert.Empty(t, orch.forwardedSession)
 }

--- a/apps/backend/internal/task/handlers/message_handlers_test.go
+++ b/apps/backend/internal/task/handlers/message_handlers_test.go
@@ -193,10 +193,13 @@ func (r *messageAddSwitchRepo) CreateTurn(_ context.Context, turn *models.Turn) 
 }
 
 type switchingTurnStartOrchestrator struct {
+	mu               sync.Mutex
+	startOnce        sync.Once
 	repo             *messageAddSwitchRepo
 	forwardedSession string
 	startedSession   string
 	switchPrimary    bool
+	started          chan struct{}
 }
 
 func (o *switchingTurnStartOrchestrator) PromptTask(
@@ -206,7 +209,9 @@ func (o *switchingTurnStartOrchestrator) PromptTask(
 	_ []v1.MessageAttachment,
 	_ bool,
 ) (*orchestrator.PromptResult, error) {
+	o.mu.Lock()
 	o.forwardedSession = sessionID
+	o.mu.Unlock()
 	return &orchestrator.PromptResult{}, nil
 }
 
@@ -225,7 +230,14 @@ func (o *switchingTurnStartOrchestrator) StartCreatedSession(
 	_ bool,
 	_ []v1.MessageAttachment,
 ) error {
+	o.mu.Lock()
 	o.startedSession = sessionID
+	o.mu.Unlock()
+	o.startOnce.Do(func() {
+		if o.started != nil {
+			close(o.started)
+		}
+	})
 	return nil
 }
 
@@ -239,6 +251,18 @@ func (o *switchingTurnStartOrchestrator) ProcessOnTurnStart(context.Context, str
 
 func (o *switchingTurnStartOrchestrator) StepRequiresCompletionSignal(context.Context, string) bool {
 	return false
+}
+
+func (o *switchingTurnStartOrchestrator) getStartedSession() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.startedSession
+}
+
+func (o *switchingTurnStartOrchestrator) getForwardedSession() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.forwardedSession
 }
 
 func TestWSAddMessageUsesSessionSelectedByOnTurnStart(t *testing.T) {
@@ -262,7 +286,8 @@ func TestWSAddMessageUsesSessionSelectedByOnTurnStart(t *testing.T) {
 		Executors: repo, Environments: repo, TaskEnvironments: repo,
 		Reviews: repo,
 	}, nil, log, service.RepositoryDiscoveryConfig{})
-	orch := &switchingTurnStartOrchestrator{repo: repo, switchPrimary: true}
+	started := make(chan struct{})
+	orch := &switchingTurnStartOrchestrator{repo: repo, switchPrimary: true, started: started}
 	h := NewMessageHandlers(svc, orch, log)
 
 	req, err := ws.NewRequest("req-1", ws.ActionMessageAdd, map[string]interface{}{
@@ -278,11 +303,13 @@ func TestWSAddMessageUsesSessionSelectedByOnTurnStart(t *testing.T) {
 	require.Len(t, repo.messages, 1)
 	assert.Equal(t, "s2", repo.messages[0].TaskSessionID)
 
-	require.Eventually(t, func() bool {
-		return orch.startedSession != ""
-	}, time.Second, 10*time.Millisecond)
-	assert.Equal(t, "s2", orch.startedSession)
-	assert.Empty(t, orch.forwardedSession)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("created session was not started")
+	}
+	assert.Equal(t, "s2", orch.getStartedSession())
+	assert.Empty(t, orch.getForwardedSession())
 }
 
 func TestWSAddMessageFailsWhenOnTurnStartCompletesSessionWithoutReplacement(t *testing.T) {
@@ -320,6 +347,6 @@ func TestWSAddMessageFailsWhenOnTurnStartCompletesSessionWithoutReplacement(t *t
 	require.NoError(t, err)
 	require.Equal(t, ws.MessageTypeError, resp.Type)
 	assert.Empty(t, repo.messages)
-	assert.Empty(t, orch.startedSession)
-	assert.Empty(t, orch.forwardedSession)
+	assert.Empty(t, orch.getStartedSession())
+	assert.Empty(t, orch.getForwardedSession())
 }

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -497,9 +497,9 @@ func (h *TaskHandlers) httpCreateTask(c *gin.Context) {
 	}
 
 	// Always persist profile IDs in task metadata so they can be used as the
-	// task's "default" agent profile. This is needed both for deferred agent start
-	// (handleTaskMovedNoSession) and for reverting to the default agent when a
-	// workflow step has no agent_profile override.
+	// task's "default" agent profile. This is needed for deferred agent start
+	// (handleTaskMovedNoSession) and workflow steps that explicitly use the
+	// workflow/task default profile.
 	if body.AgentProfileID != "" {
 		if body.Metadata == nil {
 			body.Metadata = make(map[string]interface{})

--- a/apps/backend/internal/task/handlers/task_ws_handlers.go
+++ b/apps/backend/internal/task/handlers/task_ws_handlers.go
@@ -131,9 +131,9 @@ func (h *TaskHandlers) wsCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 	}
 
 	// Always persist profile IDs in task metadata so they can be used as the
-	// task's "default" agent profile. This is needed both for deferred agent start
-	// (handleTaskMovedNoSession) and for reverting to the default agent when a
-	// workflow step has no agent_profile override.
+	// task's "default" agent profile. This is needed for deferred agent start
+	// (handleTaskMovedNoSession) and workflow steps that explicitly use the
+	// workflow/task default profile.
 	if req.AgentProfileID != "" {
 		if req.Metadata == nil {
 			req.Metadata = make(map[string]interface{})

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -62,10 +62,8 @@ const (
 )
 
 // TaskSession.Metadata key that records how the session came into existence.
-// Read by maybySwitchSessionForProfile to decide whether transitioning to a
-// step with no agent_profile override should revert to the task default:
-// workflow-spawned sessions (created_by=workflow_switch) -> yes, revert.
-// user-created sessions (no created_by tag)              -> no, preserve.
+// workflow_switch means the session profile was selected by workflow routing
+// rather than direct user selection.
 const (
 	SessionMetaKeyCreatedBy        = "created_by"
 	SessionCreatedByWorkflowSwitch = "workflow_switch"

--- a/apps/web/components/task/chat/chat-input-area.test.tsx
+++ b/apps/web/components/task/chat/chat-input-area.test.tsx
@@ -1,8 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 const archiveAndSwitchMock = vi.fn();
 const toastMock = vi.fn();
+const handleSendMessageMock = vi.fn();
 const taskPRsByTaskId = vi.hoisted(() => ({
   value: {
     "task-1": [{ pr_number: 42, state: "merged" }],
@@ -50,7 +59,7 @@ vi.mock("@/hooks/use-keyboard-shortcut", () => ({
 
 vi.mock("@/hooks/use-message-handler", () => ({
   buildTaskMentionsContext: vi.fn(),
-  useMessageHandler: () => vi.fn(),
+  useMessageHandler: () => ({ handleSendMessage: handleSendMessageMock }),
 }));
 
 vi.mock("@/hooks/domains/kanban/use-plan-actions", () => ({
@@ -88,10 +97,11 @@ const mockState = {
   },
 };
 
-import { PRMergedBanner } from "./chat-input-area";
+import { PRMergedBanner, useSubmitHandler } from "./chat-input-area";
 
 beforeEach(() => {
   archiveAndSwitchMock.mockResolvedValue(undefined);
+  handleSendMessageMock.mockResolvedValue(undefined);
   taskPRsByTaskId.value = {
     "task-1": [{ pr_number: 42, state: "merged" }],
   };
@@ -124,5 +134,47 @@ describe("PRMergedBanner", () => {
         variant: "error",
       }),
     );
+  });
+});
+
+describe("useSubmitHandler", () => {
+  function panelState(overrides = {}) {
+    return {
+      resolvedSessionId: "session-1",
+      taskId: "task-1",
+      sessionModel: null,
+      activeModel: null,
+      isAgentBusy: false,
+      activeDocument: null,
+      planComments: [],
+      pendingPRFeedback: [],
+      contextFiles: [],
+      prompts: [],
+      markCommentsSent: vi.fn(),
+      clearSessionPlanComments: vi.fn(),
+      handleClearPRFeedback: vi.fn(),
+      clearEphemeral: vi.fn(),
+      addContextFile: vi.fn(),
+      planModeEnabled: false,
+      ...overrides,
+    } as never;
+  }
+
+  it("shows a toast when sending fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    handleSendMessageMock.mockRejectedValueOnce(new Error("WebSocket request timed out"));
+    const { result } = renderHook(() => useSubmitHandler(panelState()));
+
+    await act(async () => {
+      await result.current.handleSubmit("hello");
+    });
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Message send status unknown",
+      description:
+        "The connection dropped or timed out. Refresh the task to confirm whether it went through.",
+      variant: "error",
+    });
+    errorSpy.mockRestore();
   });
 });

--- a/apps/web/components/task/chat/chat-input-area.test.tsx
+++ b/apps/web/components/task/chat/chat-input-area.test.tsx
@@ -109,6 +109,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
@@ -161,7 +162,7 @@ describe("useSubmitHandler", () => {
   }
 
   it("shows a toast when sending fails", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
     handleSendMessageMock.mockRejectedValueOnce(new Error("WebSocket request timed out"));
     const { result } = renderHook(() => useSubmitHandler(panelState()));
 
@@ -175,6 +176,5 @@ describe("useSubmitHandler", () => {
         "The connection dropped or timed out. Refresh the task to confirm whether it went through.",
       variant: "error",
     });
-    errorSpy.mockRestore();
   });
 });

--- a/apps/web/components/task/chat/chat-input-area.tsx
+++ b/apps/web/components/task/chat/chat-input-area.tsx
@@ -16,6 +16,7 @@ import { type ContextFile } from "@/lib/state/context-files-store";
 import type { TaskMentionData } from "@/hooks/use-inline-mention";
 import {
   ChatInputContainer,
+  type ChatSubmitResult,
   type ChatInputContainerHandle,
   type MessageAttachment,
 } from "@/components/task/chat/chat-input-container";
@@ -99,12 +100,17 @@ function pickInputPlaceholder(a: PlaceholderArgs): string {
   );
 }
 
-export function useSubmitHandler(
-  panelState: ReturnType<typeof useChatPanelState>,
-  onSend?: (message: string) => void,
-) {
-  const [isSending, setIsSending] = useState(false);
-  const storeApi = useAppStoreApi();
+function showUnknownMessageSendToast(error: unknown, toast: ReturnType<typeof useToast>["toast"]) {
+  console.error("Failed to send message:", error);
+  toast({
+    title: "Message send status unknown",
+    description:
+      "The connection dropped or timed out. Refresh the task to confirm whether it went through.",
+    variant: "error",
+  });
+}
+
+function usePanelMessageHandler(panelState: ReturnType<typeof useChatPanelState>) {
   const {
     resolvedSessionId,
     sessionModel,
@@ -112,17 +118,10 @@ export function useSubmitHandler(
     isAgentBusy,
     activeDocument,
     planComments,
-    pendingPRFeedback,
     contextFiles,
     prompts,
-    markCommentsSent,
-    clearSessionPlanComments,
-    handleClearPRFeedback,
-    clearEphemeral,
-    addContextFile,
-    planModeEnabled,
   } = panelState;
-  const { handleSendMessage } = useMessageHandler({
+  return useMessageHandler({
     resolvedSessionId,
     taskId: panelState.taskId,
     sessionModel,
@@ -134,6 +133,27 @@ export function useSubmitHandler(
     contextFiles,
     prompts,
   });
+}
+
+export function useSubmitHandler(
+  panelState: ReturnType<typeof useChatPanelState>,
+  onSend?: (message: string) => void,
+) {
+  const [isSending, setIsSending] = useState(false);
+  const storeApi = useAppStoreApi();
+  const { toast } = useToast();
+  const {
+    resolvedSessionId,
+    planComments,
+    pendingPRFeedback,
+    markCommentsSent,
+    clearSessionPlanComments,
+    handleClearPRFeedback,
+    clearEphemeral,
+    addContextFile,
+    planModeEnabled,
+  } = panelState;
+  const { handleSendMessage } = usePanelMessageHandler(panelState);
 
   const handleSubmit = useCallback(
     async (
@@ -154,9 +174,7 @@ export function useSubmitHandler(
         );
         const hasReviewComments = !!(reviewComments && reviewComments.length > 0);
         if (onSend) {
-          // The onSend path bypasses useMessageHandler.buildFinalMessage, so
-          // expand task mentions here — otherwise the task chips show in the
-          // editor but the agent never receives the <kandev-system> block.
+          // Expand task mentions because onSend bypasses useMessageHandler.buildFinalMessage.
           const taskCtx = inlineTaskMentions?.length
             ? buildTaskMentionsContext(inlineTaskMentions, storeApi.getState())
             : "";
@@ -181,6 +199,9 @@ export function useSubmitHandler(
             addContextFile(resolvedSessionId, { path: PLAN_CONTEXT_PATH, name: "Plan" });
           }
         }
+      } catch (error) {
+        showUnknownMessageSendToast(error, toast);
+        return false;
       } finally {
         setIsSending(false);
       }
@@ -199,6 +220,7 @@ export function useSubmitHandler(
       clearEphemeral,
       planModeEnabled,
       addContextFile,
+      toast,
     ],
   );
 
@@ -456,7 +478,7 @@ type ChatInputAreaProps = {
     attachments?: MessageAttachment[],
     inlineMentions?: ContextFile[],
     inlineTaskMentions?: TaskMentionData[],
-  ) => Promise<void>;
+  ) => ChatSubmitResult;
   handleCancelTurn: () => Promise<void>;
   showRequestChangesTooltip: boolean;
   onRequestChangesTooltipDismiss?: () => void;

--- a/apps/web/components/task/chat/chat-input-container.tsx
+++ b/apps/web/components/task/chat/chat-input-container.tsx
@@ -42,6 +42,8 @@ export type ChatInputContainerHandle = {
   getAttachments: () => MessageAttachment[];
 };
 
+export type ChatSubmitResult = void | boolean | Promise<void | boolean>;
+
 type ChatInputContainerProps = {
   onSubmit: (
     message: string,
@@ -49,7 +51,7 @@ type ChatInputContainerProps = {
     attachments?: MessageAttachment[],
     inlineMentions?: ContextFile[],
     inlineTaskMentions?: import("@/hooks/use-inline-mention").TaskMentionData[],
-  ) => void;
+  ) => ChatSubmitResult;
   sessionId: string | null;
   taskId: string | null;
   taskTitle?: string;

--- a/apps/web/components/task/chat/use-chat-input-container.ts
+++ b/apps/web/components/task/chat/use-chat-input-container.ts
@@ -9,7 +9,11 @@ import type { ContextItem } from "@/lib/types/context";
 import type { ContextFile } from "@/lib/state/context-files-store";
 import type { Message } from "@/lib/types/http";
 import type { DiffComment } from "@/lib/diff/types";
-import type { MessageAttachment, ChatInputContainerHandle } from "./chat-input-container";
+import type {
+  ChatSubmitResult,
+  MessageAttachment,
+  ChatInputContainerHandle,
+} from "./chat-input-container";
 
 type UseChatInputContainerParams = {
   ref: React.ForwardedRef<ChatInputContainerHandle>;
@@ -44,7 +48,7 @@ type UseChatInputContainerParams = {
     attachments?: MessageAttachment[],
     inlineMentions?: ContextFile[],
     inlineTaskMentions?: import("@/hooks/use-inline-mention").TaskMentionData[],
-  ) => void;
+  ) => ChatSubmitResult;
 };
 
 function useInputHandle(

--- a/apps/web/components/task/chat/use-chat-input-state.test.ts
+++ b/apps/web/components/task/chat/use-chat-input-state.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type React from "react";
+import { useChatInputState } from "./use-chat-input-state";
+import type { TipTapInputHandle } from "./tiptap-input";
+
+type SubmitHandler = Parameters<typeof useChatInputState>[0]["onSubmit"];
+
+function renderInputState(onSubmit: SubmitHandler) {
+  return renderHook(() =>
+    useChatInputState({
+      sessionId: "session-1",
+      isSending: false,
+      contextItems: [],
+      showRequestChangesTooltip: false,
+      onSubmit,
+    }),
+  );
+}
+
+function attachInputHandle(
+  inputRef: React.RefObject<TipTapInputHandle | null>,
+  clear: ReturnType<typeof vi.fn>,
+) {
+  (inputRef as React.MutableRefObject<Partial<TipTapInputHandle> | null>).current = {
+    clear,
+    getMentions: () => [],
+    getTaskMentions: () => [],
+  };
+}
+
+describe("useChatInputState", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("keeps the draft when async submit reports failure", async () => {
+    const onSubmit = vi
+      .fn<Parameters<SubmitHandler>, ReturnType<SubmitHandler>>()
+      .mockResolvedValue(false);
+    const clear = vi.fn();
+    const { result } = renderInputState(onSubmit);
+
+    act(() => {
+      result.current.handleChange("hello");
+      attachInputHandle(result.current.inputRef, clear);
+    });
+    await waitFor(() => expect(result.current.value).toBe("hello"));
+
+    act(() => {
+      result.current.handleSubmit(vi.fn());
+    });
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith("hello", undefined, undefined, undefined, undefined),
+    );
+    expect(result.current.value).toBe("hello");
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("clears the draft when async submit succeeds", async () => {
+    const onSubmit = vi
+      .fn<Parameters<SubmitHandler>, ReturnType<SubmitHandler>>()
+      .mockResolvedValue(true);
+    const clear = vi.fn();
+    const resetHeight = vi.fn();
+    const { result } = renderInputState(onSubmit);
+
+    act(() => {
+      result.current.handleChange("hello");
+      attachInputHandle(result.current.inputRef, clear);
+    });
+    await waitFor(() => expect(result.current.value).toBe("hello"));
+
+    act(() => {
+      result.current.handleSubmit(resetHeight);
+    });
+
+    await waitFor(() => expect(result.current.value).toBe(""));
+    expect(clear).toHaveBeenCalled();
+    expect(resetHeight).toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/chat/use-chat-input-state.test.ts
+++ b/apps/web/components/task/chat/use-chat-input-state.test.ts
@@ -29,6 +29,14 @@ function attachInputHandle(
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("useChatInputState", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -77,6 +85,44 @@ describe("useChatInputState", () => {
     });
 
     await waitFor(() => expect(result.current.value).toBe(""));
+    expect(clear).toHaveBeenCalled();
+    expect(resetHeight).toHaveBeenCalled();
+  });
+
+  it("keeps newer attachments when async submit succeeds after attachments change", async () => {
+    const submit = deferred<boolean>();
+    const onSubmit = vi
+      .fn<Parameters<SubmitHandler>, ReturnType<SubmitHandler>>()
+      .mockReturnValue(submit.promise);
+    const clear = vi.fn();
+    const resetHeight = vi.fn();
+    const { result } = renderInputState(onSubmit);
+
+    act(() => {
+      result.current.handleChange("hello");
+      attachInputHandle(result.current.inputRef, clear);
+    });
+    await waitFor(() => expect(result.current.value).toBe("hello"));
+
+    act(() => {
+      result.current.handleSubmit(resetHeight);
+    });
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.addFiles([
+        new File(["new attachment"], "later.txt", { type: "text/plain" }),
+      ]);
+    });
+    await waitFor(() => expect(result.current.allItems).toHaveLength(1));
+
+    await act(async () => {
+      submit.resolve(true);
+      await submit.promise;
+    });
+
+    await waitFor(() => expect(result.current.value).toBe(""));
+    expect(result.current.allItems).toHaveLength(1);
     expect(clear).toHaveBeenCalled();
     expect(resetHeight).toHaveBeenCalled();
   });

--- a/apps/web/components/task/chat/use-chat-input-state.ts
+++ b/apps/web/components/task/chat/use-chat-input-state.ts
@@ -138,6 +138,8 @@ function clearSubmittedInput(args: ClearSubmittedInputArgs) {
 
 function handleSubmitResult(result: ChatSubmitResult, onSuccess: () => void) {
   if (isPromiseLike(result)) {
+    // Submitters should show user-visible failure feedback and resolve false;
+    // rejected promises are unexpected, so preserve the draft and log them.
     void result
       .then((submitted) => {
         if (submitted !== false) onSuccess();

--- a/apps/web/components/task/chat/use-chat-input-state.ts
+++ b/apps/web/components/task/chat/use-chat-input-state.ts
@@ -103,7 +103,7 @@ function clearDraftText(sessionId: string | null) {
 }
 
 function attachmentSnapshot(attachments: FileAttachment[]): string {
-  return attachments.map((att) => `${att.id}:${att.deliveryMode}`).join("|");
+  return attachments.map((att) => `${att.id}:${att.deliveryMode ?? "prompt"}`).join("|");
 }
 
 type ClearSubmittedInputArgs = {

--- a/apps/web/components/task/chat/use-chat-input-state.ts
+++ b/apps/web/components/task/chat/use-chat-input-state.ts
@@ -96,9 +96,21 @@ function clearDraft(sessionId: string | null) {
   setChatDraftAttachments(sessionId, []);
 }
 
+function clearDraftText(sessionId: string | null) {
+  if (!sessionId) return;
+  setChatDraftText(sessionId, "");
+  setChatDraftContent(sessionId, null);
+}
+
+function attachmentSnapshot(attachments: FileAttachment[]): string {
+  return attachments.map((att) => `${att.id}:${att.deliveryMode}`).join("|");
+}
+
 type ClearSubmittedInputArgs = {
   valueRef: MutableRefObject<string>;
   submittedText: string;
+  attachmentsRef: MutableRefObject<FileAttachment[]>;
+  submittedAttachments: string;
   inputRef: RefObject<TipTapInputHandle | null>;
   setValue: Dispatch<SetStateAction<string>>;
   setAttachments: Dispatch<SetStateAction<FileAttachment[]>>;
@@ -108,12 +120,19 @@ type ClearSubmittedInputArgs = {
 };
 
 function clearSubmittedInput(args: ClearSubmittedInputArgs) {
+  // Abort if the user already typed new content since this submit started.
   if (args.valueRef.current.trim() !== args.submittedText) return;
+  const attachmentsChanged =
+    attachmentSnapshot(args.attachmentsRef.current) !== args.submittedAttachments;
   args.inputRef.current?.clear();
   args.setValue("");
-  args.setAttachments([]);
   args.setHistoryIndex(-1);
   args.resetHeight();
+  if (attachmentsChanged) {
+    clearDraftText(args.sessionId);
+    return;
+  }
+  args.setAttachments([]);
   clearDraft(args.sessionId);
 }
 
@@ -139,7 +158,7 @@ type SubmitDraftArgs = {
   hasContextComments: boolean;
   inputRef: RefObject<TipTapInputHandle | null>;
   onSubmit: UseChatInputStateProps["onSubmit"];
-  clearArgs: Omit<ClearSubmittedInputArgs, "submittedText">;
+  clearArgs: Omit<ClearSubmittedInputArgs, "submittedText" | "submittedAttachments">;
 };
 
 function submitDraft(args: SubmitDraftArgs) {
@@ -147,6 +166,7 @@ function submitDraft(args: SubmitDraftArgs) {
   const trimmed = args.valueRef.current.trim();
   const allComments = collectComments(args.pendingCommentsRef.current);
   const currentAttachments = args.attachmentsRef.current;
+  const submittedAttachments = attachmentSnapshot(currentAttachments);
   const hasContent =
     trimmed || allComments.length > 0 || currentAttachments.length > 0 || args.hasContextComments;
   if (!hasContent) return;
@@ -161,7 +181,11 @@ function submitDraft(args: SubmitDraftArgs) {
     inlineTaskMentions.length > 0 ? inlineTaskMentions : undefined,
   );
   handleSubmitResult(result, () =>
-    clearSubmittedInput({ ...args.clearArgs, submittedText: trimmed }),
+    clearSubmittedInput({
+      ...args.clearArgs,
+      submittedText: trimmed,
+      submittedAttachments,
+    }),
   );
 }
 
@@ -313,6 +337,7 @@ export function useChatInputState({
         onSubmit,
         clearArgs: {
           valueRef,
+          attachmentsRef,
           inputRef,
           setValue,
           setAttachments,

--- a/apps/web/components/task/chat/use-chat-input-state.ts
+++ b/apps/web/components/task/chat/use-chat-input-state.ts
@@ -1,4 +1,15 @@
-import { useRef, useCallback, useState, useEffect, useLayoutEffect, useMemo } from "react";
+import {
+  useRef,
+  useCallback,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  type Dispatch,
+  type MutableRefObject,
+  type RefObject,
+  type SetStateAction,
+} from "react";
 import {
   getChatDraftText,
   setChatDraftText,
@@ -17,7 +28,7 @@ import {
 import type { ContextItem, ImageContextItem, FileAttachmentContextItem } from "@/lib/types/context";
 import type { ContextFile } from "@/lib/state/context-files-store";
 import type { DiffComment } from "@/lib/diff/types";
-import type { MessageAttachment } from "./chat-input-container";
+import type { ChatSubmitResult, MessageAttachment } from "./chat-input-container";
 import type { TipTapInputHandle } from "./tiptap-input";
 import type { TaskMentionData } from "@/hooks/use-inline-mention";
 
@@ -36,8 +47,17 @@ type UseChatInputStateProps = {
     attachments?: MessageAttachment[],
     inlineMentions?: ContextFile[],
     inlineTaskMentions?: TaskMentionData[],
-  ) => void;
+  ) => ChatSubmitResult;
 };
+
+function isPromiseLike(value: ChatSubmitResult): value is Promise<void | boolean> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function"
+  );
+}
 
 function collectComments(
   pendingCommentsByFile: Record<string, DiffComment[]> | undefined,
@@ -74,6 +94,75 @@ function clearDraft(sessionId: string | null) {
   setChatDraftText(sessionId, "");
   setChatDraftContent(sessionId, null);
   setChatDraftAttachments(sessionId, []);
+}
+
+type ClearSubmittedInputArgs = {
+  valueRef: MutableRefObject<string>;
+  submittedText: string;
+  inputRef: RefObject<TipTapInputHandle | null>;
+  setValue: Dispatch<SetStateAction<string>>;
+  setAttachments: Dispatch<SetStateAction<FileAttachment[]>>;
+  setHistoryIndex: Dispatch<SetStateAction<number>>;
+  resetHeight: () => void;
+  sessionId: string | null;
+};
+
+function clearSubmittedInput(args: ClearSubmittedInputArgs) {
+  if (args.valueRef.current.trim() !== args.submittedText) return;
+  args.inputRef.current?.clear();
+  args.setValue("");
+  args.setAttachments([]);
+  args.setHistoryIndex(-1);
+  args.resetHeight();
+  clearDraft(args.sessionId);
+}
+
+function handleSubmitResult(result: ChatSubmitResult, onSuccess: () => void) {
+  if (isPromiseLike(result)) {
+    void result
+      .then((submitted) => {
+        if (submitted !== false) onSuccess();
+      })
+      .catch((error) => {
+        console.error("Failed to submit chat input:", error);
+      });
+    return;
+  }
+  if (result !== false) onSuccess();
+}
+
+type SubmitDraftArgs = {
+  isSending: boolean;
+  valueRef: MutableRefObject<string>;
+  pendingCommentsRef: MutableRefObject<Record<string, DiffComment[]> | undefined>;
+  attachmentsRef: MutableRefObject<FileAttachment[]>;
+  hasContextComments: boolean;
+  inputRef: RefObject<TipTapInputHandle | null>;
+  onSubmit: UseChatInputStateProps["onSubmit"];
+  clearArgs: Omit<ClearSubmittedInputArgs, "submittedText">;
+};
+
+function submitDraft(args: SubmitDraftArgs) {
+  if (args.isSending) return;
+  const trimmed = args.valueRef.current.trim();
+  const allComments = collectComments(args.pendingCommentsRef.current);
+  const currentAttachments = args.attachmentsRef.current;
+  const hasContent =
+    trimmed || allComments.length > 0 || currentAttachments.length > 0 || args.hasContextComments;
+  if (!hasContent) return;
+  const messageAttachments = toMessageAttachments(currentAttachments);
+  const inlineMentions = args.inputRef.current?.getMentions() ?? [];
+  const inlineTaskMentions = args.inputRef.current?.getTaskMentions() ?? [];
+  const result = args.onSubmit(
+    trimmed,
+    allComments.length > 0 ? allComments : undefined,
+    messageAttachments.length > 0 ? messageAttachments : undefined,
+    inlineMentions.length > 0 ? inlineMentions : undefined,
+    inlineTaskMentions.length > 0 ? inlineTaskMentions : undefined,
+  );
+  handleSubmitResult(result, () =>
+    clearSubmittedInput({ ...args.clearArgs, submittedText: trimmed }),
+  );
 }
 
 function useAttachments(sessionId: string | null) {
@@ -214,29 +303,24 @@ export function useChatInputState({
 
   const handleSubmit = useCallback(
     (resetHeight: () => void) => {
-      if (isSending) return;
-      const trimmed = valueRef.current.trim();
-      const allComments = collectComments(pendingCommentsRef.current);
-      const currentAttachments = attachmentsRef.current;
-      const hasContent =
-        trimmed || allComments.length > 0 || currentAttachments.length > 0 || hasContextComments;
-      if (!hasContent) return;
-      const messageAttachments = toMessageAttachments(currentAttachments);
-      const inlineMentions = inputRef.current?.getMentions() ?? [];
-      const inlineTaskMentions = inputRef.current?.getTaskMentions() ?? [];
-      onSubmit(
-        trimmed,
-        allComments.length > 0 ? allComments : undefined,
-        messageAttachments.length > 0 ? messageAttachments : undefined,
-        inlineMentions.length > 0 ? inlineMentions : undefined,
-        inlineTaskMentions.length > 0 ? inlineTaskMentions : undefined,
-      );
-      inputRef.current?.clear();
-      setValue("");
-      setAttachments([]);
-      setHistoryIndex(-1);
-      resetHeight();
-      clearDraft(sessionId);
+      submitDraft({
+        isSending,
+        valueRef,
+        pendingCommentsRef,
+        attachmentsRef,
+        hasContextComments,
+        inputRef,
+        onSubmit,
+        clearArgs: {
+          valueRef,
+          inputRef,
+          setValue,
+          setAttachments,
+          setHistoryIndex,
+          resetHeight,
+          sessionId,
+        },
+      });
     },
     [onSubmit, isSending, sessionId, attachmentsRef, setAttachments, hasContextComments],
   );

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -646,23 +646,20 @@ test.describe("Workflow agent profile switching", () => {
   });
 
   /**
-   * Verifies that moving to a step with NO agent_profile override reverts
-   * to the task's original (default) agent profile from task metadata.
-   * Covers the fix: maybySwitchSessionForProfile falls back to
-   * task.Metadata["agent_profile_id"] when the step has no override.
+   * Verifies that moving to a step with NO agent_profile override keeps the
+   * active workflow-spawned agent instead of silently reverting to the task's
+   * original default profile.
    */
-  test("moving to step without agent override reverts to task default agent", async ({
+  test("moving to step without agent override preserves workflow agent", async ({
     testPage,
     apiClient,
     seedData,
   }) => {
-    // Two agent boots (git worktree checkouts) — profileB on entry, profileA on
-    // revert — can outlast the default budget under CI shard contention; give headroom.
     test.setTimeout(180_000);
     const { profileA, profileB } = await createProfiles(apiClient);
 
     // Step1 (profileB, auto_start) → Step2 (NO override, auto_start)
-    // Task created with profileA → Step1 overrides to profileB → Step2 should revert to profileA
+    // Task created with profileA → Step1 overrides to profileB → Step2 preserves profileB.
     const workflow = await apiClient.createWorkflow(seedData.workspaceId, "Revert Agent Test");
     const step1 = await apiClient.createWorkflowStep(workflow.id, "Step1", 0, {
       is_start_step: true,
@@ -674,7 +671,7 @@ test.describe("Workflow agent profile switching", () => {
       agent_profile_id: profileB.id,
       events: { on_enter: [{ type: "auto_start_agent" }] },
     });
-    // Step2 has NO agent_profile_id — should revert to task default (profileA)
+    // Step2 has NO agent_profile_id — it should not force a default-profile switch.
     await apiClient.updateWorkflowStep(step2.id, {
       events: { on_enter: [{ type: "auto_start_agent" }] },
     });
@@ -707,15 +704,28 @@ test.describe("Workflow agent profile switching", () => {
       )
       .toBe(true);
 
-    // Move to Step2 (no override) — should revert to profileA
+    // Move to Step2 (no override) — should preserve profileB.
     await apiClient.moveTask(task.id, workflow.id, step2.id);
 
-    // A Profile A session should appear and own the primary star (no reload needed).
-    // Per PR #743, the user's pinned tab — Profile B from initial load — stays
-    // active; the primary marker is what proves the revert-to-default landed.
-    const profileATab = session.sessionTabByText("Profile A");
-    await expect(profileATab).toBeVisible({ timeout: 60_000 });
-    await expect(session.primaryStarInTab("Profile A")).toBeVisible({ timeout: 60_000 });
+    // The existing Profile B session should remain primary, and no default-profile
+    // session should appear just because the target step omitted an override.
+    await expect
+      .poll(
+        async () => {
+          const { sessions } = await apiClient.listTaskSessions(task.id);
+          const profileBSessions = sessions.filter((s) => s.agent_profile_id === profileB.id);
+          const profileASessions = sessions.filter((s) => s.agent_profile_id === profileA.id);
+          return {
+            profileBPrimary: profileBSessions.some((s) => s.is_primary),
+            profileBCompleted: profileBSessions.some((s) => s.state === "COMPLETED"),
+            profileACount: profileASessions.length,
+          };
+        },
+        { timeout: 60_000, message: "Waiting for workflow agent to stay primary" },
+      )
+      .toEqual({ profileBPrimary: true, profileBCompleted: false, profileACount: 0 });
+    await expect(profileBTab).toBeVisible({ timeout: 60_000 });
+    await expect(session.sessionTabByText("Profile A")).toHaveCount(0);
   });
 
   /**


### PR DESCRIPTION
Workflow advances could silently move work to another session while the submitted prompt stayed behind, leaving chat history and agent mode out of sync. The send path now follows the session chosen by workflow startup, preserves explicit/current profiles when a step has no override, and gives users retryable feedback when message delivery is uncertain.

## Important Changes

- Message submission reloads the session after `on_turn_start` and uses the new primary session when the submitted session was completed by a workflow switch.
- Workflow step profile routing preserves the current session/profile unless the target step or workflow explicitly specifies a profile.
- Chat send failures surface a status-unknown toast and keep the composer draft available for retry.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `git diff --check`

## Possible Improvements

Low risk: Playwright coverage could be added later for the toast/draft retry UX if chat delivery regressions recur.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->