### PR TITLE
fix: stabilize postgres startup and model dropdown scroll

### DIFF
--- a/apps/backend/internal/runtimeflags/postgres_store_test.go
+++ b/apps/backend/internal/runtimeflags/postgres_store_test.go
@@ -26,7 +26,11 @@ func TestPostgresStoreRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListOverrides: %v", err)
 	}
-	if overrides["features.office"] {
+	value, ok := overrides["features.office"]
+	if !ok {
+		t.Fatal("features.office override missing after upsert")
+	}
+	if value {
 		t.Fatal("features.office override = true, want false")
 	}
 

--- a/apps/backend/internal/runtimeflags/postgres_store_test.go
+++ b/apps/backend/internal/runtimeflags/postgres_store_test.go
@@ -1,0 +1,43 @@
+package runtimeflags
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/testutil"
+)
+
+func TestPostgresStoreRoundTrip(t *testing.T) {
+	db := testutil.OpenIsolatedPostgres(t, testutil.PostgresDSNFromEnv(t))
+	store, err := NewSQLiteStore(db, db)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore postgres: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.SetOverride(ctx, "features.office", true); err != nil {
+		t.Fatalf("SetOverride true: %v", err)
+	}
+	if err := store.SetOverride(ctx, "features.office", false); err != nil {
+		t.Fatalf("SetOverride false: %v", err)
+	}
+
+	overrides, err := store.ListOverrides(ctx)
+	if err != nil {
+		t.Fatalf("ListOverrides: %v", err)
+	}
+	if overrides["features.office"] {
+		t.Fatal("features.office override = true, want false")
+	}
+
+	if err := store.DeleteOverride(ctx, "features.office"); err != nil {
+		t.Fatalf("DeleteOverride: %v", err)
+	}
+	overrides, err = store.ListOverrides(ctx)
+	if err != nil {
+		t.Fatalf("ListOverrides after delete: %v", err)
+	}
+	if _, ok := overrides["features.office"]; ok {
+		t.Fatal("features.office override still present after delete")
+	}
+}

--- a/apps/backend/internal/runtimeflags/sqlite.go
+++ b/apps/backend/internal/runtimeflags/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/kandev/kandev/internal/db/dialect"
 )
 
 type SQLiteStore struct {
@@ -22,12 +23,16 @@ func NewSQLiteStore(writer, reader *sqlx.DB) (*SQLiteStore, error) {
 }
 
 func (s *SQLiteStore) initSchema() error {
-	_, err := s.writer.Exec(`CREATE TABLE IF NOT EXISTS runtime_flag_overrides (
+	timestampType := "DATETIME"
+	if dialect.IsPostgres(s.writer.DriverName()) {
+		timestampType = "TIMESTAMPTZ"
+	}
+	_, err := s.writer.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS runtime_flag_overrides (
 		key TEXT PRIMARY KEY,
 		value INTEGER NOT NULL CHECK (value IN (0, 1)),
-		created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-	)`)
+		created_at %s NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at %s NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`, timestampType, timestampType))
 	if err != nil {
 		return fmt.Errorf("create runtime_flag_overrides: %w", err)
 	}
@@ -62,9 +67,9 @@ func (s *SQLiteStore) SetOverride(ctx context.Context, key string, value bool) e
 	if value {
 		intValue = 1
 	}
-	_, err := s.writer.ExecContext(ctx, `INSERT INTO runtime_flag_overrides (key, value, created_at, updated_at)
+	_, err := s.writer.ExecContext(ctx, s.writer.Rebind(`INSERT INTO runtime_flag_overrides (key, value, created_at, updated_at)
 		VALUES (?, ?, ?, ?)
-		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`),
 		key, intValue, now, now)
 	if err != nil {
 		return fmt.Errorf("set runtime flag override %q: %w", key, err)
@@ -73,7 +78,7 @@ func (s *SQLiteStore) SetOverride(ctx context.Context, key string, value bool) e
 }
 
 func (s *SQLiteStore) DeleteOverride(ctx context.Context, key string) error {
-	if _, err := s.writer.ExecContext(ctx, `DELETE FROM runtime_flag_overrides WHERE key = ?`, key); err != nil {
+	if _, err := s.writer.ExecContext(ctx, s.writer.Rebind(`DELETE FROM runtime_flag_overrides WHERE key = ?`), key); err != nil {
 		return fmt.Errorf("delete runtime flag override %q: %w", key, err)
 	}
 	return nil

--- a/apps/packages/ui/src/select.tsx
+++ b/apps/packages/ui/src/select.tsx
@@ -55,6 +55,7 @@ function SelectContent({
   children,
   position = "item-aligned",
   align = "center",
+  onWheel,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -69,6 +70,10 @@ function SelectContent({
         )}
         position={position}
         align={align}
+        onWheel={(event) => {
+          onWheel?.(event);
+          event.stopPropagation();
+        }}
         {...props}
       >
         <SelectScrollUpButton />

--- a/apps/web/components/settings/utility-sections.tsx
+++ b/apps/web/components/settings/utility-sections.tsx
@@ -158,7 +158,10 @@ export function BuiltinActionRow({
     agent.agent_id && agent.model ? `${agent.agent_id}|${agent.model}` : USE_DEFAULT;
 
   return (
-    <div className="flex items-center gap-4 py-2 px-2 rounded hover:bg-muted/50">
+    <div
+      className="flex items-center gap-4 py-2 px-2 rounded hover:bg-muted/50"
+      data-testid={`utility-action-row-${agent.id}`}
+    >
       <div className="w-[420px] shrink-0">
         <div className="text-sm font-medium">{agent.name}</div>
         <p className="text-xs text-muted-foreground truncate">{agent.description}</p>

--- a/apps/web/e2e/tests/settings/utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/utility-agents.spec.ts
@@ -78,13 +78,19 @@ test.describe("Utility Agents settings page", () => {
       });
     });
 
-    const actionRow = testPage
-      .getByText("commit-message", { exact: true })
-      .locator("xpath=ancestor::div[contains(@class, 'items-center')][1]");
+    const actionRow = testPage.getByTestId("utility-action-row-builtin-commit-message");
     const actionSelect = actionRow.getByRole("combobox");
     await actionSelect.click();
     const selectContent = testPage.locator('[data-slot="select-content"]').first();
     await expect(selectContent).toBeVisible();
+    await selectContent.evaluate((element) => {
+      const testWindow = window as Window & { __utilitySelectRawWheelEvents?: number };
+      testWindow.__utilitySelectRawWheelEvents = 0;
+      element.addEventListener("wheel", () => {
+        testWindow.__utilitySelectRawWheelEvents =
+          (testWindow.__utilitySelectRawWheelEvents ?? 0) + 1;
+      });
+    });
 
     await selectContent.dispatchEvent("wheel", {
       bubbles: true,
@@ -101,6 +107,15 @@ test.describe("Utility Agents settings page", () => {
         ),
       )
       .toBe(0);
+    await expect
+      .poll(() =>
+        testPage.evaluate(
+          () =>
+            (window as Window & { __utilitySelectRawWheelEvents?: number })
+              .__utilitySelectRawWheelEvents ?? 0,
+        ),
+      )
+      .toBe(1);
   });
 
   test("does not crash when backend returns models: null", async ({ testPage }) => {

--- a/apps/web/e2e/tests/settings/utility-agents.spec.ts
+++ b/apps/web/e2e/tests/settings/utility-agents.spec.ts
@@ -10,6 +10,99 @@ import { test, expect } from "../../fixtures/test-base";
  * interactions (open the page, inspect sections, open the create dialog).
  */
 test.describe("Utility Agents settings page", () => {
+  test("action model dropdown keeps wheel scrolling inside the menu", async ({ testPage }) => {
+    const models = Array.from({ length: 36 }, (_, index) => ({
+      id: `claude-model-${String(index + 1).padStart(2, "0")}`,
+      name: `Claude Model ${String(index + 1).padStart(2, "0")}`,
+      description: "",
+      is_default: index === 0,
+    }));
+
+    await testPage.route("**/api/v1/utility/inference-agents", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          agents: [
+            {
+              id: "claude",
+              name: "claude",
+              display_name: "Claude",
+              status: "ok",
+              models,
+            },
+          ],
+        }),
+      }),
+    );
+    await testPage.route("**/api/v1/utility/agents", (route) => {
+      if (route.request().method() !== "GET") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          agents: [
+            {
+              id: "builtin-commit-message",
+              name: "commit-message",
+              description: "Generate a commit message.",
+              builtin: true,
+              enabled: true,
+              agent_id: "",
+              model: "",
+            },
+          ],
+        }),
+      });
+    });
+
+    await testPage.goto("/settings/utility-agents");
+    await expect(
+      testPage.getByRole("heading", { name: "Utility Agents", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await testPage.evaluate(() => {
+      const testWindow = window as Window & { __utilitySelectWheelEvents?: number };
+      testWindow.__utilitySelectWheelEvents = 0;
+      document.addEventListener("wheel", (event) => {
+        const target = event.target;
+        if (target instanceof Element && target.closest('[data-slot="select-content"]')) {
+          testWindow.__utilitySelectWheelEvents = (testWindow.__utilitySelectWheelEvents ?? 0) + 1;
+        }
+      });
+    });
+
+    const actionRow = testPage
+      .getByText("commit-message", { exact: true })
+      .locator("xpath=ancestor::div[contains(@class, 'items-center')][1]");
+    const actionSelect = actionRow.getByRole("combobox");
+    await actionSelect.click();
+    const selectContent = testPage.locator('[data-slot="select-content"]').first();
+    await expect(selectContent).toBeVisible();
+
+    await selectContent.dispatchEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 900,
+    });
+
+    await expect
+      .poll(() =>
+        testPage.evaluate(
+          () =>
+            (window as Window & { __utilitySelectWheelEvents?: number })
+              .__utilitySelectWheelEvents ?? 0,
+        ),
+      )
+      .toBe(0);
+  });
+
   test("does not crash when backend returns models: null", async ({ testPage }) => {
     // Simulate the exact shape the backend used to emit. Guards against a
     // regression where frontend null-deref would take the whole page down.


### PR DESCRIPTION
Postgres-backed installs could still fail during startup after the initial schema fixes, and long Utility Agents action model lists could hand wheel events back to the page. Runtime flag overrides now initialize and round-trip on Postgres, and action model dropdown scrolling stays contained in the menu.

## Important Changes

- Runtime flag override schema uses a Postgres-safe timestamp type and rebinding for write/delete queries.
- Shared select menus stop wheel propagation so long model lists do not fight the surrounding page scroll.

## Validation

- `make fmt`
- `make typecheck test lint`
- `KANDEV_TEST_POSTGRES_DSN="host=127.0.0.1 port=55432 user=kandev password=kandevpass dbname=kandev sslmode=disable" go test -v -run TestPostgresStoreRoundTrip ./internal/runtimeflags`
- `pnpm --filter @kandev/web exec playwright test --config e2e/playwright.config.ts --project=chromium tests/settings/utility-agents.spec.ts -g "action model dropdown keeps wheel"`

Closes #1270
Closes #1353

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->