### PR TITLE
fix(web): suppress kanban spinner for TODO tasks

### DIFF
--- a/apps/web/lib/ui/state-icons.test.tsx
+++ b/apps/web/lib/ui/state-icons.test.tsx
@@ -71,4 +71,16 @@ describe("shouldShowTaskRunningSpinner", () => {
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "WAITING_FOR_INPUT")).toBe(false);
     expect(shouldShowTaskRunningSpinner("IN_PROGRESS", "IDLE")).toBe(false);
   });
+
+  it("suppresses the spinner for TODO regardless of primary session state", () => {
+    // TODO is the queued/not-started column. A stale primary session state
+    // (e.g. task moved back from IN_PROGRESS with the session still alive)
+    // must not paint the running spinner on the kanban card.
+    expect(shouldShowTaskRunningSpinner("TODO", "RUNNING")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("TODO", "STARTING")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("TODO", "CREATED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("TODO", "COMPLETED")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("TODO", "WAITING_FOR_INPUT")).toBe(false);
+    expect(shouldShowTaskRunningSpinner("TODO", "IDLE")).toBe(false);
+  });
 });

--- a/apps/web/lib/ui/state-icons.test.tsx
+++ b/apps/web/lib/ui/state-icons.test.tsx
@@ -31,7 +31,7 @@ describe("shouldShowTaskRunningSpinner", () => {
     expect(shouldShowTaskRunningSpinner("TODO")).toBe(false);
   });
 
-  it("returns true when any task state has an actively running primary session", () => {
+  it("returns true for non-TODO task states with an actively running primary session", () => {
     expect(shouldShowTaskRunningSpinner("REVIEW", "RUNNING")).toBe(true);
     expect(shouldShowTaskRunningSpinner("COMPLETED", "RUNNING")).toBe(true);
     expect(shouldShowTaskRunningSpinner("FAILED", "RUNNING")).toBe(true);

--- a/apps/web/lib/ui/state-icons.tsx
+++ b/apps/web/lib/ui/state-icons.tsx
@@ -92,11 +92,16 @@ const ACTIVE_SESSION_STATES: ReadonlySet<string> = new Set<TaskSessionState>([
  * When no primary session is attached yet (task just created / scheduling),
  * we still show the spinner so users see the imminent work; otherwise we
  * require an active session state.
+ *
+ * Exception: `TODO` is the queued/not-started column. Any active session
+ * state reported there is stale (task moved back from IN_PROGRESS, session
+ * still alive) or transient, and the spinner would mislead — suppress it.
  */
 export function shouldShowTaskRunningSpinner(
   taskState?: TaskState,
   primarySessionState?: string | null,
 ): boolean {
+  if (taskState === "TODO") return false;
   if (primarySessionState) return ACTIVE_SESSION_STATES.has(primarySessionState);
   return taskState === "IN_PROGRESS" || taskState === "SCHEDULING";
 }


### PR DESCRIPTION
## Summary
- Kanban cards in the `TODO` column no longer render the blue running spinner when a stale or transient `primarySessionState` (e.g. `RUNNING`, `STARTING`, `CREATED`) is still attached to the task.
- `TODO` is the canonical "queued, work not yet started" column; any active session activity reported there is either stale (task was moved back from `IN_PROGRESS` with a session still alive) or transient. The spinner was misleading in both cases.

## Implementation notes
Single-line guard at the top of `shouldShowTaskRunningSpinner` in `apps/web/lib/ui/state-icons.tsx`: when `taskState === "TODO"`, return `false` regardless of `primarySessionState`. The helper has exactly one consumer (`apps/web/components/kanban-card-content.tsx`), so the change is contained — `TopbarWorkingIndicator` uses live session lookup and is unaffected.

Rejected a backend fix (don't publish `primarySessionState` for TODO tasks) because the blast radius is wider (HTTP DTO + `task.updated` WS payload) and the frontend should still defend against stale state. Also rejected broadening `ACTIVE_SESSION_STATES` exclusions per task state — would couple session-state policy to workflow-column policy.

The clarification-request affordance (`shouldUseQuestionTaskIcon`) runs independently in `kanban-card-content.tsx` and still wins, so `TODO` + `WAITING_FOR_INPUT` + pending clarification keeps the question icon.

## Test plan
- [x] New `it("suppresses the spinner for TODO regardless of primary session state", ...)` block in `apps/web/lib/ui/state-icons.test.tsx` asserting `false` for `TODO` paired with `RUNNING`, `STARTING`, `CREATED`, `COMPLETED`, `WAITING_FOR_INPUT`, and `IDLE`.
- [x] Existing `shouldShowTaskRunningSpinner` cases (REVIEW/COMPLETED/FAILED/CANCELLED + RUNNING → true; IN_PROGRESS + non-active → false) remain green — TODO guard does not affect those branches.
- [x] `pnpm --filter @kandev/web test -- state-icons`, typecheck, lint.
- [ ] CI to re-run the full web test suite on push.

## Risks & rollback
Low risk. Single file behavior change; no DB, no API contract, no serialized state touched. If a custom workflow legitimately wants TODO tasks with active sessions to show the spinner, we can swap the rule to "TODO + session in CREATED → false" but keep `RUNNING` true. Rollback = revert the two-file commit.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->