### PR TITLE
fix: preserve office sidebar workspace toggles

### DIFF
--- a/apps/web/app/office/page.test.tsx
+++ b/apps/web/app/office/page.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`redirect:${path}`);
+  }),
+  getOnboardingState: vi.fn(),
+  getDashboard: vi.fn(),
+  getActiveWorkspaceId: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+vi.mock("@/lib/api/domains/office-api", () => ({
+  getOnboardingState: mocks.getOnboardingState,
+  getDashboard: mocks.getDashboard,
+}));
+
+vi.mock("./lib/get-active-workspace", () => ({
+  getActiveWorkspaceId: mocks.getActiveWorkspaceId,
+}));
+
+vi.mock("./page-client", () => ({
+  OfficePageClient: ({ initialDashboard }: { initialDashboard: unknown }) => (
+    <div data-testid="office-page-client">{JSON.stringify(initialDashboard)}</div>
+  ),
+}));
+
+import OfficePage from "./page";
+
+describe("OfficePage", () => {
+  beforeEach(() => {
+    mocks.redirect.mockClear();
+    mocks.getOnboardingState.mockReset();
+    mocks.getDashboard.mockReset();
+    mocks.getActiveWorkspaceId.mockReset();
+  });
+
+  it("redirects to setup-new when no office workspace exists", async () => {
+    mocks.getOnboardingState.mockResolvedValue({ completed: true });
+    mocks.getActiveWorkspaceId.mockResolvedValue(null);
+
+    await expect(OfficePage({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      "redirect:/office/setup?mode=new",
+    );
+    expect(mocks.redirect).toHaveBeenCalledWith("/office/setup?mode=new");
+    expect(mocks.getDashboard).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/office/page.tsx
+++ b/apps/web/app/office/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 import { getDashboard, getOnboardingState } from "@/lib/api/domains/office-api";
 import { getActiveWorkspaceId } from "./lib/get-active-workspace";
 import { OfficePageClient } from "./page-client";
-import type { DashboardData } from "@/lib/state/slices/office/types";
 
 type SearchParams = Promise<{ workspaceId?: string }>;
 
@@ -20,8 +19,7 @@ export default async function OfficePage({ searchParams }: { searchParams?: Sear
     redirect("/office/setup?mode=new");
   }
 
-  let dashboard: DashboardData | null = null;
-  dashboard = await getDashboard(workspaceId, { cache: "no-store" }).catch(() => null);
+  const dashboard = await getDashboard(workspaceId, { cache: "no-store" }).catch(() => null);
 
   return <OfficePageClient initialDashboard={dashboard} />;
 }

--- a/apps/web/app/office/page.tsx
+++ b/apps/web/app/office/page.tsx
@@ -16,11 +16,12 @@ export default async function OfficePage({ searchParams }: { searchParams?: Sear
 
   const params = searchParams ? await searchParams : {};
   const workspaceId = await getActiveWorkspaceId(params.workspaceId);
+  if (!workspaceId) {
+    redirect("/office/setup?mode=new");
+  }
 
   let dashboard: DashboardData | null = null;
-  if (workspaceId) {
-    dashboard = await getDashboard(workspaceId, { cache: "no-store" }).catch(() => null);
-  }
+  dashboard = await getDashboard(workspaceId, { cache: "no-store" }).catch(() => null);
 
   return <OfficePageClient initialDashboard={dashboard} />;
 }

--- a/apps/web/components/app-sidebar/app-sidebar-footer.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-footer.test.tsx
@@ -150,4 +150,17 @@ describe("AppSidebarFooter", () => {
 
     expect(mocks.routerPush).toHaveBeenCalledWith("/?workspaceId=kanban-1");
   });
+
+  it("remembers the current office workspace when toggling back to kanban", () => {
+    officeEnabled = true;
+    state.workspaces.activeId = "office-2";
+    window.localStorage.setItem("kandev.lastKanbanWorkspaceId", "kanban-1");
+
+    renderFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Kanban" }));
+
+    expect(document.cookie).toContain("office-active-workspace=office-2");
+    expect(mocks.routerPush).toHaveBeenCalledWith("/?workspaceId=kanban-1");
+  });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-footer.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-footer.test.tsx
@@ -13,6 +13,7 @@ const state = {
     items: [
       { id: "kanban-1", name: "Kanban", office_workflow_id: "" },
       { id: "office-1", name: "Office", office_workflow_id: "wf-office" },
+      { id: "office-2", name: "Office 2", office_workflow_id: "wf-office-2" },
     ],
   },
   appSidebar: { settingsMode: false },
@@ -72,8 +73,14 @@ describe("AppSidebarFooter", () => {
   beforeEach(() => {
     officeEnabled = false;
     state.workspaces.activeId = "kanban-1";
+    state.workspaces.items = [
+      { id: "kanban-1", name: "Kanban", office_workflow_id: "" },
+      { id: "office-1", name: "Office", office_workflow_id: "wf-office" },
+      { id: "office-2", name: "Office 2", office_workflow_id: "wf-office-2" },
+    ];
     state.appSidebar.settingsMode = false;
     window.localStorage.clear();
+    document.cookie = "office-active-workspace=; path=/; max-age=0";
     mocks.routerPush.mockClear();
     mocks.toggleSettingsMode.mockClear();
   });
@@ -107,6 +114,28 @@ describe("AppSidebarFooter", () => {
     expect(mocks.routerPush).toHaveBeenNthCalledWith(1, "/stats");
     expect(mocks.routerPush).toHaveBeenNthCalledWith(2, "/office?workspaceId=office-1");
     expect(window.localStorage.getItem("kandev.lastKanbanWorkspaceId")).toBe("kanban-1");
+  });
+
+  it("navigates to the last active office workspace when kanban is active", () => {
+    officeEnabled = true;
+    document.cookie = "office-active-workspace=office-2; path=/";
+
+    renderFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Office" }));
+
+    expect(mocks.routerPush).toHaveBeenCalledWith("/office?workspaceId=office-2");
+  });
+
+  it("navigates to office setup when no office workspace exists", () => {
+    officeEnabled = true;
+    state.workspaces.items = [{ id: "kanban-1", name: "Kanban", office_workflow_id: "" }];
+
+    renderFooter();
+
+    fireEvent.click(screen.getByRole("button", { name: "Office" }));
+
+    expect(mocks.routerPush).toHaveBeenCalledWith("/office/setup?mode=new");
   });
 
   it("shows a Kanban button when an office workspace is active", () => {

--- a/apps/web/components/app-sidebar/app-sidebar-footer.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-footer.tsx
@@ -23,6 +23,7 @@ import { linkToTask } from "@/lib/links";
 import { cn } from "@/lib/utils";
 import {
   isOfficeWorkspace,
+  rememberLastOfficeWorkspace,
   rememberLastKanbanWorkspace,
   resolveLastOfficeWorkspace,
   resolveLastKanbanWorkspace,
@@ -155,6 +156,7 @@ export function AppSidebarFooter({ collapsed }: AppSidebarFooterProps) {
           collapsed={collapsed}
           onClick={() => {
             if (!activeIsOffice) rememberLastKanbanWorkspace(activeWorkspace);
+            if (activeIsOffice) rememberLastOfficeWorkspace(activeWorkspace);
             const href =
               !activeIsOffice && !targetWorkspace
                 ? "/office/setup?mode=new"

--- a/apps/web/components/app-sidebar/app-sidebar-footer.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-footer.tsx
@@ -24,7 +24,7 @@ import { cn } from "@/lib/utils";
 import {
   isOfficeWorkspace,
   rememberLastKanbanWorkspace,
-  resolveFirstOfficeWorkspace,
+  resolveLastOfficeWorkspace,
   resolveLastKanbanWorkspace,
   workspaceHomeHref,
 } from "./app-sidebar-workspace-navigation";
@@ -102,7 +102,7 @@ export function AppSidebarFooter({ collapsed }: AppSidebarFooterProps) {
   const activeIsOffice = isOfficeWorkspace(activeWorkspace);
   const targetWorkspace = activeIsOffice
     ? resolveLastKanbanWorkspace(workspaces.items)
-    : resolveFirstOfficeWorkspace(workspaces.items);
+    : resolveLastOfficeWorkspace(workspaces.items);
   const settingsMode = useAppStore((s) => s.appSidebar.settingsMode);
   const toggleSettingsMode = useAppStore((s) => s.toggleAppSidebarSettingsMode);
   const officeEnabled = useFeature("office");
@@ -155,7 +155,11 @@ export function AppSidebarFooter({ collapsed }: AppSidebarFooterProps) {
           collapsed={collapsed}
           onClick={() => {
             if (!activeIsOffice) rememberLastKanbanWorkspace(activeWorkspace);
-            router.push(workspaceHomeHref(targetWorkspace ?? undefined));
+            const href =
+              !activeIsOffice && !targetWorkspace
+                ? "/office/setup?mode=new"
+                : workspaceHomeHref(targetWorkspace ?? undefined);
+            router.push(href);
           }}
           testId={activeIsOffice ? "sidebar-kanban-button" : "sidebar-office-button"}
         />

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.test.ts
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   LAST_KANBAN_WORKSPACE_KEY,
   rememberLastKanbanWorkspace,
-  resolveFirstOfficeWorkspace,
+  resolveLastOfficeWorkspace,
   resolveLastKanbanWorkspace,
   workspaceHomeHref,
 } from "./app-sidebar-workspace-navigation";
@@ -10,6 +10,7 @@ import {
 const kanban = { id: "kanban-1", office_workflow_id: "" };
 const kanbanTwo = { id: "kanban-2", office_workflow_id: null };
 const office = { id: "office-1", office_workflow_id: "wf-office" };
+const officeTwo = { id: "office-2", office_workflow_id: "wf-office-2" };
 
 describe("app sidebar workspace navigation", () => {
   beforeEach(() => {
@@ -38,6 +39,18 @@ describe("app sidebar workspace navigation", () => {
 
   it("falls back to the first kanban workspace and first office workspace", () => {
     expect(resolveLastKanbanWorkspace([office, kanban, kanbanTwo])).toBe(kanban);
-    expect(resolveFirstOfficeWorkspace([kanban, office, kanbanTwo])).toBe(office);
+    expect(resolveLastOfficeWorkspace([kanban, office, officeTwo])).toBe(office);
+  });
+
+  it("resolves the last office workspace from the office-active-workspace cookie", () => {
+    document.cookie = "office-active-workspace=office-2; path=/";
+
+    expect(resolveLastOfficeWorkspace([kanban, office, officeTwo])).toBe(officeTwo);
+  });
+
+  it("falls back to the first office workspace when the office cookie is stale", () => {
+    document.cookie = "office-active-workspace=kanban-1; path=/";
+
+    expect(resolveLastOfficeWorkspace([kanban, office, officeTwo])).toBe(office);
   });
 });

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.test.ts
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   LAST_KANBAN_WORKSPACE_KEY,
+  OFFICE_ACTIVE_WORKSPACE_COOKIE,
+  rememberLastOfficeWorkspace,
   rememberLastKanbanWorkspace,
   resolveLastOfficeWorkspace,
   resolveLastKanbanWorkspace,
@@ -11,10 +13,15 @@ const kanban = { id: "kanban-1", office_workflow_id: "" };
 const kanbanTwo = { id: "kanban-2", office_workflow_id: null };
 const office = { id: "office-1", office_workflow_id: "wf-office" };
 const officeTwo = { id: "office-2", office_workflow_id: "wf-office-2" };
+const officeWithReservedChars = {
+  id: "office/2;mode",
+  office_workflow_id: "wf-office-reserved",
+};
 
 describe("app sidebar workspace navigation", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    document.cookie = "office-active-workspace=; path=/; max-age=0";
   });
 
   it("routes workspace home by active workspace type", () => {
@@ -35,6 +42,17 @@ describe("app sidebar workspace navigation", () => {
     rememberLastKanbanWorkspace(office);
 
     expect(resolveLastKanbanWorkspace([kanban, office])).toBe(kanban);
+  });
+
+  it("writes the last office workspace cookie with an encoded id", () => {
+    rememberLastOfficeWorkspace(officeWithReservedChars);
+
+    expect(document.cookie).toBe(
+      `${OFFICE_ACTIVE_WORKSPACE_COOKIE}=${encodeURIComponent(officeWithReservedChars.id)}`,
+    );
+    expect(resolveLastOfficeWorkspace([office, officeWithReservedChars])).toBe(
+      officeWithReservedChars,
+    );
   });
 
   it("falls back to the first kanban workspace and first office workspace", () => {

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.ts
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.ts
@@ -21,6 +21,11 @@ export function rememberLastKanbanWorkspace(workspace: SidebarWorkspace | undefi
   window.localStorage.setItem(LAST_KANBAN_WORKSPACE_KEY, workspace.id);
 }
 
+export function rememberLastOfficeWorkspace(workspace: SidebarWorkspace | undefined): void {
+  if (!workspace || !isOfficeWorkspace(workspace) || typeof document === "undefined") return;
+  document.cookie = `${OFFICE_ACTIVE_WORKSPACE_COOKIE}=${encodeURIComponent(workspace.id)}; path=/; max-age=86400; samesite=strict; secure`;
+}
+
 export function resolveLastKanbanWorkspace(
   workspaces: SidebarWorkspace[],
 ): SidebarWorkspace | null {

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.ts
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-navigation.ts
@@ -4,6 +4,7 @@ export type SidebarWorkspace = {
 };
 
 export const LAST_KANBAN_WORKSPACE_KEY = "kandev.lastKanbanWorkspaceId";
+export const OFFICE_ACTIVE_WORKSPACE_COOKIE = "office-active-workspace";
 
 export function isOfficeWorkspace(workspace: SidebarWorkspace | undefined): boolean {
   return Boolean(workspace?.office_workflow_id);
@@ -35,8 +36,24 @@ export function resolveLastKanbanWorkspace(
   return kanbanWorkspaces[0] ?? null;
 }
 
-export function resolveFirstOfficeWorkspace(
+export function resolveLastOfficeWorkspace(
   workspaces: SidebarWorkspace[],
 ): SidebarWorkspace | null {
-  return workspaces.find(isOfficeWorkspace) ?? null;
+  const officeWorkspaces = workspaces.filter(isOfficeWorkspace);
+  if (officeWorkspaces.length === 0) return null;
+
+  const storedId =
+    typeof document === "undefined" ? null : readCookieValue(OFFICE_ACTIVE_WORKSPACE_COOKIE);
+  const stored = officeWorkspaces.find((workspace) => workspace.id === storedId);
+  return stored ?? officeWorkspaces[0] ?? null;
+}
+
+function readCookieValue(name: string): string | null {
+  const prefix = `${name}=`;
+  const match = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  if (!match) return null;
+  return decodeURIComponent(match.slice(prefix.length));
 }

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -132,7 +132,7 @@ describe("AppSidebarWorkspacePicker — workspace select", () => {
     expect(navigationMock.push).not.toHaveBeenCalled();
   });
 
-  it("writes the active-workspace cookie and updates the store on select", () => {
+  it("writes the active office workspace cookie and updates the store on office select", () => {
     storeState.features.office = false;
     render(<AppSidebarWorkspacePicker />);
 
@@ -141,6 +141,20 @@ describe("AppSidebarWorkspacePicker — workspace select", () => {
     expect(cookieWrites.some((c) => c.startsWith("office-active-workspace=w2"))).toBe(true);
     expect(storeState.setActiveWorkspace).toHaveBeenCalledWith("w2");
     expect(navigationMock.push).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite the office workspace cookie when selecting a kanban workspace", () => {
+    storeState.features.office = true;
+    storeState.workspaces.activeId = "w2";
+    cookieWrites = ["office-active-workspace=w2; path=/"];
+    render(<AppSidebarWorkspacePicker />);
+
+    fireEvent.click(screen.getByTestId(KANBAN_WORKSPACE_ITEM));
+
+    expect(cookieWrites.some((c) => c.startsWith("office-active-workspace=w1"))).toBe(false);
+    expect(cookieWrites.some((c) => c.startsWith("office-active-workspace=w2"))).toBe(true);
+    expect(storeState.setActiveWorkspace).toHaveBeenCalledWith("w1");
+    expect(navigationMock.push).toHaveBeenCalledWith("/?workspaceId=w1");
   });
 
   it("navigates to the office workspace when the office feature is enabled", () => {

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -20,7 +20,7 @@ import { useAppStore } from "@/components/state-provider";
 import { useFeature } from "@/hooks/domains/features/use-feature";
 import { cn } from "@/lib/utils";
 import {
-  OFFICE_ACTIVE_WORKSPACE_COOKIE,
+  rememberLastOfficeWorkspace,
   rememberLastKanbanWorkspace,
 } from "./app-sidebar-workspace-navigation";
 
@@ -98,7 +98,7 @@ export function AppSidebarWorkspacePicker() {
       }
       const type = workspaceType(workspace);
       if (type === "office") {
-        document.cookie = `${OFFICE_ACTIVE_WORKSPACE_COOKIE}=${id}; path=/; max-age=86400; samesite=strict; secure`;
+        rememberLastOfficeWorkspace(workspace);
       }
       rememberLastKanbanWorkspace(workspace);
       setActiveWorkspace(id);

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -19,7 +19,10 @@ import {
 import { useAppStore } from "@/components/state-provider";
 import { useFeature } from "@/hooks/domains/features/use-feature";
 import { cn } from "@/lib/utils";
-import { rememberLastKanbanWorkspace } from "./app-sidebar-workspace-navigation";
+import {
+  OFFICE_ACTIVE_WORKSPACE_COOKIE,
+  rememberLastKanbanWorkspace,
+} from "./app-sidebar-workspace-navigation";
 
 /**
  * Compact, secondary workspace switcher inlined after the Kandev brand in the
@@ -93,11 +96,14 @@ export function AppSidebarWorkspacePicker() {
         setOpen(false);
         return;
       }
-      document.cookie = `office-active-workspace=${id}; path=/; max-age=86400; samesite=strict; secure`;
+      const type = workspaceType(workspace);
+      if (type === "office") {
+        document.cookie = `${OFFICE_ACTIVE_WORKSPACE_COOKIE}=${id}; path=/; max-age=86400; samesite=strict; secure`;
+      }
       rememberLastKanbanWorkspace(workspace);
       setActiveWorkspace(id);
       if (officeEnabled) {
-        const target = workspaceType(workspace) === "office" ? "/office" : "/";
+        const target = type === "office" ? "/office" : "/";
         router.push(`${target}?workspaceId=${id}`);
       }
       setOpen(false);


### PR DESCRIPTION
The office sidebar footer lost the user\047s last workspace context and could strand enabled office users without an office workspace. It now keeps kanban and office workspace memory separate, and sends first-time office users to setup.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->