### PR TITLE
fix: open markdown file links with line suffixes

### DIFF
--- a/apps/web/components/shared/markdown-components.test.tsx
+++ b/apps/web/components/shared/markdown-components.test.tsx
@@ -108,6 +108,20 @@ describe("markdownComponents", () => {
     expect(openFile).toHaveBeenCalledWith("docs/specs/native/spec.md");
   });
 
+  it("opens absolute worktree file links with line suffixes in the editor", () => {
+    render(
+      <Markdown>
+        {
+          "[workflow](/root/.kandev/tasks/example/kandev/.github/workflows/opencode-code-review.yml:1)"
+        }
+      </Markdown>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "workflow" }));
+
+    expect(openFile).toHaveBeenCalledWith(".github/workflows/opencode-code-review.yml");
+  });
+
   it("opens relative file links in the editor", () => {
     render(<Markdown>{"[plan.md](docs/specs/native/plan.md)"}</Markdown>);
 
@@ -124,6 +138,14 @@ describe("markdownComponents", () => {
 
     const link = screen.getByRole("link", { name: "migration" });
     fireEvent.click(link);
+
+    expect(openFile).toHaveBeenCalledWith("docs/nextjs-spa-migration.md");
+  });
+
+  it("opens repo-root file links with line and column suffixes in the editor", () => {
+    render(<Markdown>{"[migration](/docs/nextjs-spa-migration.md:12:3)"}</Markdown>);
+
+    fireEvent.click(screen.getByRole("link", { name: "migration" }));
 
     expect(openFile).toHaveBeenCalledWith("docs/nextjs-spa-migration.md");
   });

--- a/apps/web/components/shared/markdown-components.tsx
+++ b/apps/web/components/shared/markdown-components.tsx
@@ -80,9 +80,13 @@ function stripHashAndQuery(href: string): string {
   return href.split(/[?#]/, 1)[0] ?? "";
 }
 
+function stripSourceLocationSuffix(path: string): string {
+  return path.replace(/:\d+(?::\d+)?$/, "");
+}
+
 function decodeHrefPath(href: string): string | null {
   try {
-    return decodeURIComponent(stripHashAndQuery(href));
+    return stripSourceLocationSuffix(decodeURIComponent(stripHashAndQuery(href)));
   } catch {
     return null;
   }

--- a/docs/specs/ui/comment-markdown.md
+++ b/docs/specs/ui/comment-markdown.md
@@ -16,6 +16,7 @@ Task comments render as plain text with `whitespace-pre-wrap`. Agent responses r
 - `react-markdown` with `remark-gfm` processes comment content. `rehype-sanitize` blocks raw HTML injection (already in dependencies). No `dangerouslySetInnerHTML`.
 - Fenced code blocks display syntax highlighting and a one-click copy button.
 - Bare URLs in comment text are auto-linked (handled by `remark-gfm` linkify).
+- Markdown links to files in the active worktree open the in-app file editor; absolute worktree paths and repo-root paths may include `:line` or `:line:column` suffixes without navigating the browser away from the task.
 - Patterns matching `[A-Z]+-\d+` (e.g., `KAN-42`, `QA-7`) are rendered as links to `/office/tasks/<identifier>`. The link uses the raw identifier as the URL segment; resolution to an internal task ID (if needed) is handled by the issue page.
 - The comment list in `TaskChat` uses `react-virtuoso` (already in dependencies). Only visible comments plus a small buffer are mounted.
 - Scroll position is preserved when new comments arrive if the user has scrolled away from the bottom.
@@ -27,6 +28,7 @@ Task comments render as plain text with `whitespace-pre-wrap`. Agent responses r
 - **GIVEN** a comment containing a fenced code block, **WHEN** rendered, **THEN** the block has syntax highlighting and a copy button that copies the block contents.
 - **GIVEN** a comment containing the text `see KAN-42 for context`, **WHEN** rendered, **THEN** `KAN-42` is a clickable link navigating to `/office/tasks/KAN-42`.
 - **GIVEN** a comment containing `https://example.com`, **WHEN** rendered, **THEN** the URL is a clickable hyperlink.
+- **GIVEN** a comment contains a markdown link to `/root/.kandev/tasks/example/kandev/.github/workflows/build.yml:12`, **WHEN** the user clicks it while the active worktree is `/root/.kandev/tasks/example/kandev`, **THEN** the in-app editor opens `.github/workflows/build.yml` instead of navigating to that absolute URL.
 - **GIVEN** a thread with 200 comments, **WHEN** the user opens the issue, **THEN** fewer than 30 comment nodes are in the DOM at any time.
 - **GIVEN** the user has scrolled up to read earlier comments and a new comment arrives, **WHEN** the comment is appended, **THEN** the scroll position does not move.
 - **GIVEN** the user is at the bottom of the thread and a new comment arrives, **WHEN** the comment is appended, **THEN** the viewport auto-scrolls to show the new comment.


### PR DESCRIPTION
Markdown file links with source-location suffixes were falling through to browser navigation,
which produced 404s for absolute worktree paths. The renderer now treats `:line` and
`:line:column` suffixes as editor locations and opens the underlying file in-app.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->