### PR TITLE
fix: restore missing settings sidebar links

### DIFF
--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -69,7 +69,11 @@ describe("SettingsTree rendering", () => {
       { id: ARCHIVE_WORKSPACE_ID, name: ARCHIVE_WORKSPACE_NAME },
     ];
 
-    render(<WorkspacesGroup pathname="/settings/workspace/ws-10/repositories" expanded />);
+    const { rerender } = render(<WorkspacesGroup pathname="/settings/workspace" expanded />);
+
+    expect(screen.getAllByRole("link", { name: "Repositories" })).toHaveLength(2);
+
+    rerender(<WorkspacesGroup pathname="/settings/workspace/ws-10/repositories" expanded />);
 
     expect(screen.getByRole("link", { name: MAIN_WORKSPACE_NAME }).getAttribute("href")).toBe(
       "/settings/workspace/ws-1",

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = {
+  workspaces: {
+    items: [{ id: "ws-1", name: "Main Workspace" }],
+  },
+  settingsAgents: {
+    items: [],
+  },
+  executors: {
+    items: [],
+  },
+};
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (s: typeof state) => unknown) => selector(state),
+}));
+
+vi.mock("@/hooks/domains/settings/use-available-agents", () => ({
+  useAvailableAgents: () => undefined,
+}));
+
+vi.mock("@kandev/ui/collapsible", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  const CollapsibleContext = React.createContext(false);
+  return {
+    Collapsible: ({ open, children }: { open?: boolean; children: ReactNode }) =>
+      React.createElement(CollapsibleContext.Provider, { value: Boolean(open) }, children),
+    CollapsibleContent: ({ children, className }: { children: ReactNode; className?: string }) => {
+      const open = React.useContext(CollapsibleContext);
+      return open ? React.createElement("div", { className }, children) : null;
+    },
+  };
+});
+
+import { SettingsTree } from "./settings-tree";
+import { WorkspacesGroup } from "./workspaces-group";
+
+describe("SettingsTree rendering", () => {
+  beforeEach(() => {
+    state.workspaces.items = [{ id: "ws-1", name: "Main Workspace" }];
+    state.settingsAgents.items = [];
+    state.executors.items = [];
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders workspace repository and workflow links when Workspaces is open", () => {
+    render(<WorkspacesGroup pathname="/settings/workspace" expanded />);
+
+    expect(screen.getByRole("link", { name: "Repositories" }).getAttribute("href")).toBe(
+      "/settings/workspace/ws-1/repositories",
+    );
+    expect(screen.getByRole("link", { name: "Workflows" }).getAttribute("href")).toBe(
+      "/settings/workspace/ws-1/workflows",
+    );
+  });
+
+  it("keeps Voice Mode in the settings tree", () => {
+    render(<SettingsTree pathname="/settings" />);
+
+    expect(screen.getByRole("link", { name: "Voice Mode" }).getAttribute("href")).toBe(
+      "/settings/voice-mode",
+    );
+  });
+});

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -2,9 +2,14 @@ import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const MAIN_WORKSPACE_ID = "ws-1";
+const ARCHIVE_WORKSPACE_ID = "ws-2";
+const MAIN_WORKSPACE_NAME = "Main Workspace";
+const ARCHIVE_WORKSPACE_NAME = "Archive Workspace";
+
 const state = {
   workspaces: {
-    items: [{ id: "ws-1", name: "Main Workspace" }],
+    items: [{ id: MAIN_WORKSPACE_ID, name: MAIN_WORKSPACE_NAME }],
   },
   settingsAgents: {
     items: [],
@@ -40,7 +45,7 @@ import { WorkspacesGroup } from "./workspaces-group";
 
 describe("SettingsTree rendering", () => {
   beforeEach(() => {
-    state.workspaces.items = [{ id: "ws-1", name: "Main Workspace" }];
+    state.workspaces.items = [{ id: MAIN_WORKSPACE_ID, name: MAIN_WORKSPACE_NAME }];
     state.settingsAgents.items = [];
     state.executors.items = [];
   });
@@ -58,11 +63,43 @@ describe("SettingsTree rendering", () => {
     );
   });
 
-  it("keeps Voice Mode in the settings tree", () => {
+  it("only opens the active workspace subsection on workspace detail routes", () => {
+    state.workspaces.items = [
+      { id: MAIN_WORKSPACE_ID, name: MAIN_WORKSPACE_NAME },
+      { id: ARCHIVE_WORKSPACE_ID, name: ARCHIVE_WORKSPACE_NAME },
+    ];
+
+    render(<WorkspacesGroup pathname="/settings/workspace/ws-1/repositories" expanded />);
+
+    expect(screen.getByRole("link", { name: MAIN_WORKSPACE_NAME }).getAttribute("href")).toBe(
+      "/settings/workspace/ws-1",
+    );
+    const repositoryLinks = screen.getAllByRole("link", { name: "Repositories" });
+    const workflowLinks = screen.getAllByRole("link", { name: "Workflows" });
+
+    expect(repositoryLinks).toHaveLength(1);
+    expect(workflowLinks).toHaveLength(1);
+    expect(repositoryLinks[0].getAttribute("href")).toBe("/settings/workspace/ws-1/repositories");
+    expect(workflowLinks[0].getAttribute("href")).toBe("/settings/workspace/ws-1/workflows");
+    expect(screen.getByRole("link", { name: ARCHIVE_WORKSPACE_NAME }).getAttribute("href")).toBe(
+      "/settings/workspace/ws-2",
+    );
+  });
+
+  it("keeps Voice Mode in the settings tree as a standalone active leaf", () => {
     render(<SettingsTree pathname="/settings" />);
 
     expect(screen.getByRole("link", { name: "Voice Mode" }).getAttribute("href")).toBe(
       "/settings/voice-mode",
     );
+
+    cleanup();
+
+    render(<SettingsTree pathname="/settings/voice-mode" />);
+
+    expect(screen.getByRole("link", { name: "Voice Mode" }).className).toContain(
+      "before:bg-primary",
+    );
+    expect(screen.queryByRole("link", { name: "Appearance" })).toBeNull();
   });
 });

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree-render.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const MAIN_WORKSPACE_ID = "ws-1";
-const ARCHIVE_WORKSPACE_ID = "ws-2";
+const ARCHIVE_WORKSPACE_ID = "ws-10";
 const MAIN_WORKSPACE_NAME = "Main Workspace";
 const ARCHIVE_WORKSPACE_NAME = "Archive Workspace";
 
@@ -69,7 +69,7 @@ describe("SettingsTree rendering", () => {
       { id: ARCHIVE_WORKSPACE_ID, name: ARCHIVE_WORKSPACE_NAME },
     ];
 
-    render(<WorkspacesGroup pathname="/settings/workspace/ws-1/repositories" expanded />);
+    render(<WorkspacesGroup pathname="/settings/workspace/ws-10/repositories" expanded />);
 
     expect(screen.getByRole("link", { name: MAIN_WORKSPACE_NAME }).getAttribute("href")).toBe(
       "/settings/workspace/ws-1",
@@ -79,10 +79,10 @@ describe("SettingsTree rendering", () => {
 
     expect(repositoryLinks).toHaveLength(1);
     expect(workflowLinks).toHaveLength(1);
-    expect(repositoryLinks[0].getAttribute("href")).toBe("/settings/workspace/ws-1/repositories");
-    expect(workflowLinks[0].getAttribute("href")).toBe("/settings/workspace/ws-1/workflows");
+    expect(repositoryLinks[0].getAttribute("href")).toBe("/settings/workspace/ws-10/repositories");
+    expect(workflowLinks[0].getAttribute("href")).toBe("/settings/workspace/ws-10/workflows");
     expect(screen.getByRole("link", { name: ARCHIVE_WORKSPACE_NAME }).getAttribute("href")).toBe(
-      "/settings/workspace/ws-2",
+      "/settings/workspace/ws-10",
     );
   });
 

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree.test.ts
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree.test.ts
@@ -26,6 +26,7 @@ describe("settingsGroupIdForPath", () => {
   it("returns null for standalone leaves with no owning group", () => {
     expect(settingsGroupIdForPath("/settings/automations")).toBeNull();
     expect(settingsGroupIdForPath("/settings/prompts")).toBeNull();
+    expect(settingsGroupIdForPath("/settings/voice-mode")).toBeNull();
     expect(settingsGroupIdForPath("/settings/utility-agents")).toBeNull();
     expect(settingsGroupIdForPath("/settings/external-mcp")).toBeNull();
     expect(settingsGroupIdForPath("/settings")).toBeNull();

--- a/apps/web/components/app-sidebar/sections/settings/settings-tree.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/settings-tree.tsx
@@ -5,6 +5,7 @@ import {
   IconBolt,
   IconKey,
   IconMessageCircle,
+  IconMicrophone,
   IconPlugConnected,
   IconWand,
 } from "@tabler/icons-react";
@@ -18,6 +19,7 @@ import { WorkspacesGroup } from "./workspaces-group";
 
 const AUTOMATIONS_HREF = "/settings/automations";
 const PROMPTS_HREF = "/settings/prompts";
+const VOICE_MODE_HREF = "/settings/voice-mode";
 const UTILITY_HREF = "/settings/utility-agents";
 const SECRETS_HREF = "/settings/general/secrets";
 const EXT_MCP_HREF = "/settings/external-mcp";
@@ -78,6 +80,12 @@ export function SettingsTree({ pathname }: { pathname: string }) {
         label="Prompts"
         icon={IconMessageCircle}
         isActive={pathname === PROMPTS_HREF}
+      />
+      <SettingsLeaf
+        href={VOICE_MODE_HREF}
+        label="Voice Mode"
+        icon={IconMicrophone}
+        isActive={pathname === VOICE_MODE_HREF}
       />
       <SettingsLeaf
         href={UTILITY_HREF}

--- a/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
@@ -34,7 +34,7 @@ export function WorkspacesGroup({ pathname, expanded, onToggle }: WorkspacesGrou
             label={workspace.name}
             href={workspacePath}
             isActive={pathname === workspacePath}
-            defaultExpanded={pathname.startsWith(workspacePath)}
+            defaultExpanded
             depth={1}
           >
             <SettingsLeaf

--- a/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
@@ -12,8 +12,15 @@ type WorkspacesGroupProps = {
   onToggle?: () => void;
 };
 
+function isWorkspaceRoute(pathname: string, workspaceId: string): boolean {
+  return pathname.startsWith(`${ROOT_HREF}/${workspaceId}`);
+}
+
 export function WorkspacesGroup({ pathname, expanded, onToggle }: WorkspacesGroupProps) {
   const workspaces = useAppStore((s) => s.workspaces.items);
+  const hasActiveWorkspaceRoute = workspaces.some((workspace) =>
+    isWorkspaceRoute(pathname, workspace.id),
+  );
 
   return (
     <SettingsGroup
@@ -34,7 +41,7 @@ export function WorkspacesGroup({ pathname, expanded, onToggle }: WorkspacesGrou
             label={workspace.name}
             href={workspacePath}
             isActive={pathname === workspacePath}
-            defaultExpanded
+            defaultExpanded={!hasActiveWorkspaceRoute || isWorkspaceRoute(pathname, workspace.id)}
             depth={1}
           >
             <SettingsLeaf

--- a/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
@@ -13,7 +13,8 @@ type WorkspacesGroupProps = {
 };
 
 function isWorkspaceRoute(pathname: string, workspaceId: string): boolean {
-  return pathname.startsWith(`${ROOT_HREF}/${workspaceId}`);
+  const workspacePath = `${ROOT_HREF}/${workspaceId}`;
+  return pathname === workspacePath || pathname.startsWith(`${workspacePath}/`);
 }
 
 export function WorkspacesGroup({ pathname, expanded, onToggle }: WorkspacesGroupProps) {

--- a/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
+++ b/apps/web/components/app-sidebar/sections/settings/workspaces-group.tsx
@@ -19,9 +19,14 @@ function isWorkspaceRoute(pathname: string, workspaceId: string): boolean {
 
 export function WorkspacesGroup({ pathname, expanded, onToggle }: WorkspacesGroupProps) {
   const workspaces = useAppStore((s) => s.workspaces.items);
-  const hasActiveWorkspaceRoute = workspaces.some((workspace) =>
-    isWorkspaceRoute(pathname, workspace.id),
-  );
+  const activeWorkspaceId =
+    workspaces.find((workspace) => isWorkspaceRoute(pathname, workspace.id))?.id ?? null;
+  const routeExpansionKey = activeWorkspaceId ?? "all";
+  const hasActiveWorkspaceRoute = activeWorkspaceId !== null;
+
+  function shouldExpandWorkspace(workspaceId: string): boolean {
+    return !hasActiveWorkspaceRoute || activeWorkspaceId === workspaceId;
+  }
 
   return (
     <SettingsGroup
@@ -38,11 +43,11 @@ export function WorkspacesGroup({ pathname, expanded, onToggle }: WorkspacesGrou
         const workflowsPath = `${workspacePath}/workflows`;
         return (
           <SettingsGroup
-            key={workspace.id}
+            key={`${workspace.id}:${routeExpansionKey}`}
             label={workspace.name}
             href={workspacePath}
             isActive={pathname === workspacePath}
-            defaultExpanded={!hasActiveWorkspaceRoute || isWorkspaceRoute(pathname, workspace.id)}
+            defaultExpanded={shouldExpandWorkspace(workspace.id)}
             depth={1}
           >
             <SettingsLeaf


### PR DESCRIPTION
The settings sidebar migration hid workspace repository and workflow links behind collapsed workspace rows and dropped the Voice Mode entry. Restored those navigation paths and added regression coverage so the links stay visible.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->