### PR TITLE
feat(github): publish GitHubPRMerged event on PR merge

### DIFF
--- a/apps/backend/internal/events/types.go
+++ b/apps/backend/internal/events/types.go
@@ -1,6 +1,8 @@
 // Package events provides event types and utilities for the Kandev event system.
 package events
 
+import "time"
+
 // Event types for tasks
 const (
 	TaskCreated      = "task.created"
@@ -229,12 +231,24 @@ const (
 const (
 	GitHubPRFeedback       = "github.pr_feedback"        // PR has new feedback (UI notification only)
 	GitHubPRStateChanged   = "github.pr_state_changed"   // PR state changed (merged, closed, etc.)
+	GitHubPRMerged         = "github.pr_merged"          // PR transitioned to merged (merged_at: nil -> time); fires once per merge
 	GitHubNewReviewPR      = "github.new_pr_to_review"   // New PR found needing review
 	GitHubNewIssue         = "github.new_issue"          // New issue found matching issue watch
 	GitHubTaskPRUpdated    = "github.task_pr.updated"    // TaskPR record updated (for UI refresh)
 	GitHubWatchEvent       = "github.watch.event"        // Watch created/deleted
 	GitHubRateLimitUpdated = "github.rate_limit.updated" // GitHub API rate-limit snapshot changed
 )
+
+// GitHubPRMergedEvent is the payload of a GitHubPRMerged bus event. It carries
+// just the identifiers needed by downstream subscribers (workflow engine,
+// Mantis push, etc.) so the github package owns the transition detection and
+// consumers don't need to re-derive "did this PR just merge?" from a full
+// TaskPR diff.
+type GitHubPRMergedEvent struct {
+	TaskID   string    `json:"task_id"`
+	PRNumber int       `json:"pr_number"`
+	MergedAt time.Time `json:"merged_at"`
+}
 
 // Event types for GitLab integration
 const (

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -505,6 +505,9 @@ func (s *Service) SyncTaskPR(ctx context.Context, taskID string, status *PRStatu
 	if err != nil || tp == nil {
 		return err
 	}
+	// Snapshot MergedAt before the field reassignments below so we can detect
+	// the nil -> time transition and publish GitHubPRMerged exactly once.
+	prevMergedAt := tp.MergedAt
 
 	// Some sync paths (notably the batched GraphQL poller) don't populate
 	// ChecksTotal / ChecksPassing — they only carry the rollup state. The
@@ -598,7 +601,27 @@ func (s *Service) SyncTaskPR(ctx context.Context, taskID string, status *PRStatu
 			s.logger.Debug("failed to publish task PR updated event", zap.Error(err))
 		}
 	}
+	s.publishPRMergedIfTransitioned(ctx, taskID, tp.PRNumber, prevMergedAt, status.PR.MergedAt)
 	return nil
+}
+
+// publishPRMergedIfTransitioned emits a GitHubPRMerged event when MergedAt
+// crosses from nil to a concrete time. Only the transition fires the event —
+// a second sync with the same MergedAt, or a row that was already merged
+// when first written, are both no-ops, so workflow subscribers can treat the
+// event as a one-shot merge trigger without their own deduplication.
+func (s *Service) publishPRMergedIfTransitioned(ctx context.Context, taskID string, prNumber int, prev, next *time.Time) {
+	if prev != nil || next == nil || s.eventBus == nil {
+		return
+	}
+	event := bus.NewEvent(events.GitHubPRMerged, "github", events.GitHubPRMergedEvent{
+		TaskID:   taskID,
+		PRNumber: prNumber,
+		MergedAt: *next,
+	})
+	if err := s.eventBus.Publish(ctx, events.GitHubPRMerged, event); err != nil {
+		s.logger.Debug("failed to publish PR merged event", zap.Error(err))
+	}
 }
 
 // TriggerPRSync performs an immediate PR status sync for a task. Single-repo

--- a/apps/backend/internal/github/service_pr_watch_test.go
+++ b/apps/backend/internal/github/service_pr_watch_test.go
@@ -1,0 +1,173 @@
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
+)
+
+// countEventsOfType returns the number of mockEventBus events whose Type
+// matches the supplied subject. The bus carries every github.* event the
+// service emits, so PR-merge tests have to filter rather than trust the raw
+// total — a sync that publishes both task_pr.updated and pr_merged otherwise
+// looks like 2 merge events.
+func countEventsOfType(eb *mockEventBus, eventType string) int {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	n := 0
+	for _, e := range eb.events {
+		if e != nil && e.Type == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+// findEventOfType returns the first event of the given type, or nil if none.
+func findEventOfType(eb *mockEventBus, eventType string) *bus.Event {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	for _, e := range eb.events {
+		if e != nil && e.Type == eventType {
+			return e
+		}
+	}
+	return nil
+}
+
+// TestSyncTaskPR_PublishesPRMergedOnNilToTimeTransition exercises the
+// acceptance criteria of the GitHubPRMerged publisher:
+//   - First sync with merged_at=nil publishes no merge event.
+//   - Second sync where merged_at goes from nil to a concrete time publishes
+//     exactly one GitHubPRMerged event.
+//   - Third sync with an unchanged merged_at must publish no further merge
+//     event (idempotency — without this guarantee, every poll cycle after a
+//     merge would re-fire the trigger downstream).
+func TestSyncTaskPR_PublishesPRMergedOnNilToTimeTransition(t *testing.T) {
+	svc, store, eb := setupSyncTest(t)
+	ctx := context.Background()
+
+	if err := store.CreateTaskPR(ctx, &TaskPR{
+		TaskID:     "t1",
+		Owner:      "owner",
+		Repo:       "repo",
+		PRNumber:   42,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		PRTitle:    "Feature",
+		HeadBranch: "feat",
+		BaseBranch: "main",
+		State:      "open",
+	}); err != nil {
+		t.Fatalf("create task PR: %v", err)
+	}
+
+	// First sync: PR still open, merged_at=nil. The task_pr.updated event
+	// fires because the row is brand new with no review state, but no
+	// pr_merged event should appear.
+	openStatus := &PRStatus{
+		PR: &PR{
+			Number:    42,
+			Title:     "Feature",
+			State:     "open",
+			RepoOwner: "owner",
+			RepoName:  "repo",
+		},
+	}
+	if err := svc.SyncTaskPR(ctx, "t1", openStatus); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if got := countEventsOfType(eb, events.GitHubPRMerged); got != 0 {
+		t.Fatalf("expected no GitHubPRMerged event when PR is still open, got %d", got)
+	}
+
+	// Second sync: merged_at transitions from nil to a concrete time.
+	mergedAt := time.Date(2026, 6, 17, 10, 0, 0, 0, time.UTC)
+	mergedStatus := &PRStatus{
+		PR: &PR{
+			Number:    42,
+			Title:     "Feature",
+			State:     "merged",
+			RepoOwner: "owner",
+			RepoName:  "repo",
+			MergedAt:  &mergedAt,
+		},
+	}
+	if err := svc.SyncTaskPR(ctx, "t1", mergedStatus); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if got := countEventsOfType(eb, events.GitHubPRMerged); got != 1 {
+		t.Fatalf("expected exactly 1 GitHubPRMerged event on nil->time transition, got %d", got)
+	}
+
+	// Inspect the payload so downstream subscribers can rely on the contract.
+	evt := findEventOfType(eb, events.GitHubPRMerged)
+	if evt == nil {
+		t.Fatal("expected to find the GitHubPRMerged event")
+	}
+	payload, ok := evt.Data.(events.GitHubPRMergedEvent)
+	if !ok {
+		t.Fatalf("expected payload of type events.GitHubPRMergedEvent, got %T", evt.Data)
+	}
+	if payload.TaskID != "t1" {
+		t.Errorf("payload TaskID = %q, want %q", payload.TaskID, "t1")
+	}
+	if payload.PRNumber != 42 {
+		t.Errorf("payload PRNumber = %d, want %d", payload.PRNumber, 42)
+	}
+	if !payload.MergedAt.Equal(mergedAt) {
+		t.Errorf("payload MergedAt = %v, want %v", payload.MergedAt, mergedAt)
+	}
+
+	// Third sync: identical merged_at — no additional merge event.
+	if err := svc.SyncTaskPR(ctx, "t1", mergedStatus); err != nil {
+		t.Fatalf("third sync: %v", err)
+	}
+	if got := countEventsOfType(eb, events.GitHubPRMerged); got != 1 {
+		t.Errorf("expected idempotency: still 1 GitHubPRMerged event after unchanged sync, got %d", got)
+	}
+}
+
+// TestSyncTaskPR_PRMergedNotPublishedWhenAlreadyMerged covers the case where
+// the row's MergedAt was already populated (e.g. PR imported via URL after a
+// merge had already happened). The transition guard is "nil -> non-nil", so
+// even though the value is non-nil after this sync, no event should fire.
+func TestSyncTaskPR_PRMergedNotPublishedWhenAlreadyMerged(t *testing.T) {
+	svc, store, eb := setupSyncTest(t)
+	ctx := context.Background()
+
+	mergedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	if err := store.CreateTaskPR(ctx, &TaskPR{
+		TaskID:     "t1",
+		Owner:      "owner",
+		Repo:       "repo",
+		PRNumber:   7,
+		PRURL:      "https://github.com/owner/repo/pull/7",
+		PRTitle:    "Already merged",
+		HeadBranch: "feat",
+		BaseBranch: "main",
+		State:      "merged",
+		MergedAt:   &mergedAt,
+	}); err != nil {
+		t.Fatalf("create task PR: %v", err)
+	}
+
+	status := &PRStatus{
+		PR: &PR{
+			Number:    7,
+			Title:     "Already merged",
+			State:     "merged",
+			RepoOwner: "owner",
+			RepoName:  "repo",
+			MergedAt:  &mergedAt,
+		},
+	}
+	if err := svc.SyncTaskPR(ctx, "t1", status); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if got := countEventsOfType(eb, events.GitHubPRMerged); got != 0 {
+		t.Errorf("expected no merge event when MergedAt was already set, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a generic `GitHubPRMerged` bus event so workflow subscribers can fire on-merge actions without re-deriving the `MergedAt: nil -> time` transition from a full `TaskPR` diff. T07 of the Mantis-Lifecycle-Sync walking skeleton, but the event itself is integration-agnostic (no Mantis dependency).

- New constant `events.GitHubPRMerged = "github.pr_merged"` and payload struct `events.GitHubPRMergedEvent{TaskID, PRNumber, MergedAt}` in `apps/backend/internal/events/types.go`.
- `Service.SyncTaskPR` (in `apps/backend/internal/github/service_pr_watch.go`) now snapshots `MergedAt` before the field reassignments and a new helper `publishPRMergedIfTransitioned` emits the event after the DB write only when the field went from `nil` to a concrete time. Subsequent syncs with the same `MergedAt` are no-ops, so the event fires exactly once per merge.
- Tests in the new `apps/backend/internal/github/service_pr_watch_test.go` cover the three acceptance criteria: first sync (open, `merged_at=nil`) publishes nothing; second sync (`merged_at=<time>`) publishes exactly once; third identical sync publishes nothing (idempotency). A second test guards the already-merged-on-create case so the event does not double-fire when a task is imported with a PR that was merged upstream.

## Note on `GitHubPRStateChanged`

The existing `events.GitHubPRStateChanged` constant at `events/types.go:231` is **declared but unused** in the codebase. This PR intentionally leaves it as-is per the task scope, but if downstream work in T08 (workflow subscriber + `on_pr_merged` trigger) confirms that `GitHubPRMerged` fully replaces the role `GitHubPRStateChanged` was reserved for, that constant becomes safe to delete in a follow-up.

## Test plan

- [x] `make -C apps/backend fmt` — no changes needed
- [x] `make -C apps/backend vet` — clean
- [x] `make -C apps/backend test` — full backend suite passes, including the existing `service_pr_sync_test.go` path
- [x] `golangci-lint run ./... --new-from-rev=<merge-base>` — 0 issues, function-length / complexity limits respected via the small extracted helper
- [ ] Manual: confirm an actual GitHub PR merge fires the event end-to-end once the T08 subscriber lands

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

