### PR TITLE
ci: avoid unconditional playwright apt install

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -284,12 +284,38 @@ jobs:
             cp -a /ms-playwright/. /dest/
           echo "PLAYWRIGHT_BROWSERS_PATH=/tmp/ms-playwright" >> "$GITHUB_ENV"
 
-      # Browser binaries come from the image above; this only installs the
-      # apt-level shared libs chromium links against. Fast (~20–30s) and avoids
-      # any CDN dependency.
-      - name: Install Playwright system deps
+      # Browser binaries come from the image above. GitHub's Ubuntu runners
+      # usually already have the shared libs Chromium needs, so smoke-test the
+      # copied browser first and only hit apt as a bounded fallback.
+      - name: Verify Playwright browser runtime
         working-directory: apps/web
-        run: npx playwright install-deps chromium
+        run: |
+          set -euo pipefail
+
+          smoke_test() {
+            node <<'NODE'
+          const { chromium } = require("@playwright/test");
+
+          (async () => {
+            const browser = await chromium.launch({ headless: true });
+            const page = await browser.newPage();
+            await page.goto("data:text/html,ok");
+            await browser.close();
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+          }
+
+          if smoke_test; then
+            echo "Playwright Chromium launches with existing runner packages."
+            exit 0
+          fi
+
+          echo "::warning::Playwright Chromium failed to launch; installing missing host packages."
+          timeout 180s npx playwright install-deps chromium
+          smoke_test
 
       - name: Download backend build
         uses: actions/download-artifact@v5


### PR DESCRIPTION
Container-backed E2E jobs were still allowed to spend the whole job timeout in Playwright's apt dependency installer. The workflow now treats host package installation as a bounded fallback after proving whether the copied browser from the CI image already launches.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `git diff --check`
- Parsed `.github/workflows/e2e-tests.yml` with `js-yaml`

## Possible Improvements

Low risk: if GitHub changes runner packages and Chromium cannot launch, the workflow still falls back to `playwright install-deps`, but that fallback is now capped at 180 seconds.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->