### PR TITLE
fix: show quick chat session model options

### DIFF
--- a/apps/web/e2e/tests/chat/quick-chat.spec.ts
+++ b/apps/web/e2e/tests/chat/quick-chat.spec.ts
@@ -184,6 +184,20 @@ test.describe("Quick Chat", () => {
     await expect(testPage.getByText("/error")).toBeVisible({ timeout: 5_000 });
   });
 
+  test("model selector shows dynamic session options before first message", async ({
+    testPage,
+  }) => {
+    const dialog = await openQuickChatWithAgent(testPage);
+
+    const trigger = dialog.getByRole("button", { name: "Session model settings" });
+    await expect(trigger).toContainText("Mock Fast", { timeout: 15_000 });
+    await trigger.click();
+
+    await expect(testPage.getByTestId("config-option-section-effort")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
   test("supports multiple chat tabs and switching between them", async ({ testPage }) => {
     test.setTimeout(90_000);
 

--- a/apps/web/hooks/domains/session/use-session-messages.test.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.test.ts
@@ -31,6 +31,7 @@ import {
   hasUserOrAgentMessage,
   isTurnSettleTransition,
   shouldRunMessageBackfill,
+  shouldRetryUnknownSessionSubscription,
   runBackfillRound,
   autoBackfillUntilUserMessage,
   nextFetchSeq,
@@ -216,6 +217,40 @@ describe("running message backfill guards", () => {
         connectionStatus: "connected",
         activeTurnId: null,
         messages,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("unknown session subscription retry guard", () => {
+  it("retries only while a connected session id has no session state", () => {
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: "sess-1",
+        taskSessionState: null,
+        connectionStatus: "connected",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: "sess-1",
+        taskSessionState: "STARTING",
+        connectionStatus: "connected",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: null,
+        taskSessionState: null,
+        connectionStatus: "connected",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: "sess-1",
+        taskSessionState: null,
+        connectionStatus: "connecting",
       }),
     ).toBe(false);
   });

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -4,6 +4,9 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import type { TaskSessionState, Message } from "@/lib/types/http";
 import { listTaskSessionMessages } from "@/lib/api";
 import { createDebugLogger, isDebug } from "@/lib/debug/log";
+import { useUnknownSessionSubscriptionRetry } from "./use-session-subscription-retry";
+
+export { shouldRetryUnknownSessionSubscription } from "./use-session-subscription-retry";
 
 const INITIAL_FETCH_LIMIT = 100;
 const BACKFILL_PAGE_LIMIT = 100;
@@ -423,6 +426,7 @@ function useSessionSubscription(
   taskSessionId: string | null,
   connectionStatus: string,
   isSessionStartingOrUnknown: boolean,
+  retryToken: number,
   store: ReturnType<typeof useAppStoreApi>,
 ) {
   useEffect(() => {
@@ -454,7 +458,7 @@ function useSessionSubscription(
       debug("subscription: unsubscribing", { sessionId: taskSessionId });
       unsubscribe();
     };
-  }, [taskSessionId, connectionStatus, store, isSessionStartingOrUnknown]);
+  }, [taskSessionId, connectionStatus, store, isSessionStartingOrUnknown, retryToken]);
 }
 
 /**
@@ -563,6 +567,47 @@ function useSessionMessageInputs(taskSessionId: string | null) {
   return { messages, messagesMeta, taskSessionState, activeTurnId, connectionStatus };
 }
 
+function useSessionLifecycleSubscriptions(params: {
+  taskSessionId: string | null;
+  taskSessionState: TaskSessionState | null;
+  connectionStatus: string;
+  activeTurnId: string | null;
+  messages: Message[];
+  store: ReturnType<typeof useAppStoreApi>;
+}) {
+  const { taskSessionId, taskSessionState, connectionStatus, activeTurnId, messages, store } =
+    params;
+  // Bool flips exactly once when a freshly-adopted session leaves STARTING,
+  // so the subscription effect re-runs then (covering the backend race where
+  // session.subscribe arrives before the session is fully constructed) without
+  // churning on every subsequent RUNNING ↔ WAITING_FOR_INPUT transition.
+  const isSessionStartingOrUnknown = taskSessionState === null || taskSessionState === "STARTING";
+  const unknownSessionRetryToken = useUnknownSessionSubscriptionRetry({
+    taskSessionId,
+    taskSessionState,
+    connectionStatus,
+  });
+
+  useSessionSubscription(
+    taskSessionId,
+    connectionStatus,
+    isSessionStartingOrUnknown,
+    unknownSessionRetryToken,
+    store,
+  );
+  useResyncOnTurnSettle(taskSessionId, taskSessionState, connectionStatus, store);
+  useRunningMessageBackfill(
+    taskSessionId,
+    shouldRunMessageBackfill({
+      taskSessionState,
+      connectionStatus,
+      activeTurnId,
+      messages,
+    }),
+    store,
+  );
+}
+
 export function useSessionMessages(taskSessionId: string | null): UseSessionMessagesReturn {
   const store = useAppStoreApi();
   const { messages, messagesMeta, taskSessionState, activeTurnId, connectionStatus } =
@@ -646,24 +691,15 @@ export function useSessionMessages(taskSessionId: string | null): UseSessionMess
     fetchRefs,
   ]);
 
-  // Bool flips exactly once when a freshly-adopted session leaves STARTING,
-  // so the subscription effect re-runs then (covering the backend race where
-  // session.subscribe arrives before the session is fully constructed) without
-  // churning on every subsequent RUNNING ↔ WAITING_FOR_INPUT transition.
-  const isSessionStartingOrUnknown = taskSessionState === null || taskSessionState === "STARTING";
-
-  useSessionSubscription(taskSessionId, connectionStatus, isSessionStartingOrUnknown, store);
-  useResyncOnTurnSettle(taskSessionId, taskSessionState, connectionStatus, store);
-  useRunningMessageBackfill(
+  useSessionLifecycleSubscriptions({
     taskSessionId,
-    shouldRunMessageBackfill({
-      taskSessionState,
-      connectionStatus,
-      activeTurnId,
-      messages,
-    }),
+    taskSessionState,
+    connectionStatus,
+    activeTurnId,
+    messages,
     store,
-  );
+  });
+
   useVisibilityBackfill(taskSessionId, store);
 
   useTerminalStateFetch(taskSessionId, taskSessionState, hasAgentMessage, fetchRefs);

--- a/apps/web/hooks/domains/session/use-session-messages.ts
+++ b/apps/web/hooks/domains/session/use-session-messages.ts
@@ -4,7 +4,10 @@ import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import type { TaskSessionState, Message } from "@/lib/types/http";
 import { listTaskSessionMessages } from "@/lib/api";
 import { createDebugLogger, isDebug } from "@/lib/debug/log";
-import { useUnknownSessionSubscriptionRetry } from "./use-session-subscription-retry";
+import {
+  useUnknownSessionSubscriptionRetry,
+  useUnknownSessionSubscriptionRetryEffect,
+} from "./use-session-subscription-retry";
 
 export { shouldRetryUnknownSessionSubscription } from "./use-session-subscription-retry";
 
@@ -426,7 +429,6 @@ function useSessionSubscription(
   taskSessionId: string | null,
   connectionStatus: string,
   isSessionStartingOrUnknown: boolean,
-  retryToken: number,
   store: ReturnType<typeof useAppStoreApi>,
 ) {
   useEffect(() => {
@@ -458,7 +460,7 @@ function useSessionSubscription(
       debug("subscription: unsubscribing", { sessionId: taskSessionId });
       unsubscribe();
     };
-  }, [taskSessionId, connectionStatus, store, isSessionStartingOrUnknown, retryToken]);
+  }, [taskSessionId, connectionStatus, store, isSessionStartingOrUnknown]);
 }
 
 /**
@@ -588,13 +590,12 @@ function useSessionLifecycleSubscriptions(params: {
     connectionStatus,
   });
 
-  useSessionSubscription(
+  useSessionSubscription(taskSessionId, connectionStatus, isSessionStartingOrUnknown, store);
+  useUnknownSessionSubscriptionRetryEffect({
     taskSessionId,
     connectionStatus,
-    isSessionStartingOrUnknown,
-    unknownSessionRetryToken,
-    store,
-  );
+    retryToken: unknownSessionRetryToken,
+  });
   useResyncOnTurnSettle(taskSessionId, taskSessionState, connectionStatus, store);
   useRunningMessageBackfill(
     taskSessionId,

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
@@ -128,6 +128,25 @@ describe("useUnknownSessionSubscriptionRetry", () => {
 
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it("does not recreate retry timers after unmount", () => {
+    vi.useFakeTimers();
+
+    const { unmount } = renderHook(() =>
+      useUnknownSessionSubscriptionRetry({
+        taskSessionId: "sess-1",
+        connectionStatus: "connected",
+        taskSessionState: null,
+      }),
+    );
+
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+    act(() => vi.runOnlyPendingTimers());
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });
 
 describe("useUnknownSessionSubscriptionRetryEffect", () => {

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
@@ -1,0 +1,124 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getUnknownSessionRetryDelay,
+  shouldRetryUnknownSessionSubscription,
+  useUnknownSessionSubscriptionRetry,
+} from "./use-session-subscription-retry";
+
+describe("shouldRetryUnknownSessionSubscription", () => {
+  it("returns true only for a connected unknown session", () => {
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: "sess-1",
+        connectionStatus: "connected",
+        taskSessionState: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: null,
+        connectionStatus: "connected",
+        taskSessionState: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: "sess-1",
+        connectionStatus: "disconnected",
+        taskSessionState: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryUnknownSessionSubscription({
+        taskSessionId: "sess-1",
+        connectionStatus: "connected",
+        taskSessionState: "RUNNING",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("getUnknownSessionRetryDelay", () => {
+  it("backs off retries up to a maximum delay", () => {
+    expect(getUnknownSessionRetryDelay(0)).toBe(1000);
+    expect(getUnknownSessionRetryDelay(1)).toBe(2000);
+    expect(getUnknownSessionRetryDelay(5)).toBe(30000);
+    expect(getUnknownSessionRetryDelay(20)).toBe(30000);
+  });
+});
+
+describe("useUnknownSessionSubscriptionRetry", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("advances the retry token on the backoff schedule while retrying", () => {
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() =>
+      useUnknownSessionSubscriptionRetry({
+        taskSessionId: "sess-1",
+        connectionStatus: "connected",
+        taskSessionState: null,
+      }),
+    );
+
+    expect(result.current).toBe(0);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+
+    act(() => vi.advanceTimersByTime(1999));
+    expect(result.current).toBe(1);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe(2);
+  });
+
+  it("resets the returned token when the session id changes", () => {
+    vi.useFakeTimers();
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        useUnknownSessionSubscriptionRetry({
+          taskSessionId: sessionId,
+          connectionStatus: "connected",
+          taskSessionState: null,
+        }),
+      { initialProps: { sessionId: "sess-1" } },
+    );
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+
+    rerender({ sessionId: "sess-2" });
+    expect(result.current).toBe(0);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(1);
+  });
+
+  it("clears the scheduled retry when retrying stops", () => {
+    vi.useFakeTimers();
+
+    const { rerender } = renderHook(
+      ({ taskSessionState }: { taskSessionState: null | "RUNNING" }) =>
+        useUnknownSessionSubscriptionRetry({
+          taskSessionId: "sess-1",
+          connectionStatus: "connected",
+          taskSessionState,
+        }),
+      { initialProps: { taskSessionState: null as null | "RUNNING" } },
+    );
+
+    expect(vi.getTimerCount()).toBe(1);
+
+    rerender({ taskSessionState: "RUNNING" });
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
@@ -1,11 +1,17 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { getWebSocketClient } from "@/lib/ws/connection";
 import {
   getUnknownSessionRetryDelay,
   shouldRetryUnknownSessionSubscription,
   useUnknownSessionSubscriptionRetry,
+  useUnknownSessionSubscriptionRetryEffect,
 } from "./use-session-subscription-retry";
+
+vi.mock("@/lib/ws/connection", () => ({
+  getWebSocketClient: vi.fn(),
+}));
 
 describe("shouldRetryUnknownSessionSubscription", () => {
   it("returns true only for a connected unknown session", () => {
@@ -54,6 +60,7 @@ describe("useUnknownSessionSubscriptionRetry", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.mocked(getWebSocketClient).mockReset();
   });
 
   it("advances the retry token on the backoff schedule while retrying", () => {
@@ -120,5 +127,117 @@ describe("useUnknownSessionSubscriptionRetry", () => {
     rerender({ taskSessionState: "RUNNING" });
 
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("useUnknownSessionSubscriptionRetryEffect", () => {
+  afterEach(() => {
+    cleanup();
+    vi.mocked(getWebSocketClient).mockReset();
+  });
+
+  it("skips when the retry is not actionable", () => {
+    const send = vi.fn();
+    vi.mocked(getWebSocketClient).mockReturnValue({ send } as never);
+
+    renderHook(
+      ({ taskSessionId, connectionStatus, retryToken }) =>
+        useUnknownSessionSubscriptionRetryEffect({
+          taskSessionId,
+          connectionStatus,
+          retryToken,
+        }),
+      {
+        initialProps: {
+          taskSessionId: "sess-1" as string | null,
+          connectionStatus: "connected",
+          retryToken: 0,
+        },
+      },
+    );
+
+    expect(send).not.toHaveBeenCalled();
+
+    cleanup();
+    renderHook(() =>
+      useUnknownSessionSubscriptionRetryEffect({
+        taskSessionId: null,
+        connectionStatus: "connected",
+        retryToken: 1,
+      }),
+    );
+
+    expect(send).not.toHaveBeenCalled();
+
+    cleanup();
+    renderHook(() =>
+      useUnknownSessionSubscriptionRetryEffect({
+        taskSessionId: "sess-1",
+        connectionStatus: "disconnected",
+        retryToken: 1,
+      }),
+    );
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("sends one subscribe frame per retry-token change", () => {
+    const send = vi.fn();
+    vi.mocked(getWebSocketClient).mockReturnValue({ send } as never);
+
+    const { rerender } = renderHook(
+      ({ retryToken }: { retryToken: number }) =>
+        useUnknownSessionSubscriptionRetryEffect({
+          taskSessionId: "sess-1",
+          connectionStatus: "connected",
+          retryToken,
+        }),
+      { initialProps: { retryToken: 1 } },
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: "session.subscribe",
+        payload: { session_id: "sess-1" },
+      }),
+    );
+
+    rerender({ retryToken: 2 });
+
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips when the websocket client is unavailable", () => {
+    vi.mocked(getWebSocketClient).mockReturnValue(null);
+
+    renderHook(() =>
+      useUnknownSessionSubscriptionRetryEffect({
+        taskSessionId: "sess-1",
+        connectionStatus: "connected",
+        retryToken: 1,
+      }),
+    );
+
+    expect(getWebSocketClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call unsubscribe paths", () => {
+    const send = vi.fn();
+    const unsubscribeSession = vi.fn();
+    vi.mocked(getWebSocketClient).mockReturnValue({ send, unsubscribeSession } as never);
+
+    const { unmount } = renderHook(() =>
+      useUnknownSessionSubscriptionRetryEffect({
+        taskSessionId: "sess-1",
+        connectionStatus: "connected",
+        retryToken: 1,
+      }),
+    );
+
+    unmount();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(unsubscribeSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.test.ts
@@ -136,29 +136,25 @@ describe("useUnknownSessionSubscriptionRetryEffect", () => {
     vi.mocked(getWebSocketClient).mockReset();
   });
 
-  it("skips when the retry is not actionable", () => {
+  it("skips when the retry token is zero", () => {
     const send = vi.fn();
     vi.mocked(getWebSocketClient).mockReturnValue({ send } as never);
 
-    renderHook(
-      ({ taskSessionId, connectionStatus, retryToken }) =>
-        useUnknownSessionSubscriptionRetryEffect({
-          taskSessionId,
-          connectionStatus,
-          retryToken,
-        }),
-      {
-        initialProps: {
-          taskSessionId: "sess-1" as string | null,
-          connectionStatus: "connected",
-          retryToken: 0,
-        },
-      },
+    renderHook(() =>
+      useUnknownSessionSubscriptionRetryEffect({
+        taskSessionId: "sess-1",
+        connectionStatus: "connected",
+        retryToken: 0,
+      }),
     );
 
     expect(send).not.toHaveBeenCalled();
+  });
 
-    cleanup();
+  it("skips when the session id is missing", () => {
+    const send = vi.fn();
+    vi.mocked(getWebSocketClient).mockReturnValue({ send } as never);
+
     renderHook(() =>
       useUnknownSessionSubscriptionRetryEffect({
         taskSessionId: null,
@@ -168,8 +164,12 @@ describe("useUnknownSessionSubscriptionRetryEffect", () => {
     );
 
     expect(send).not.toHaveBeenCalled();
+  });
 
-    cleanup();
+  it("skips when the websocket is disconnected", () => {
+    const send = vi.fn();
+    vi.mocked(getWebSocketClient).mockReturnValue({ send } as never);
+
     renderHook(() =>
       useUnknownSessionSubscriptionRetryEffect({
         taskSessionId: "sess-1",

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.ts
@@ -4,8 +4,8 @@ import type { TaskSessionState } from "@/lib/types/http";
 import { generateUUID } from "@/lib/utils";
 import { getWebSocketClient } from "@/lib/ws/connection";
 
-const UNKNOWN_SESSION_RESUBSCRIBE_MS = 1000;
-const MAX_UNKNOWN_SESSION_RESUBSCRIBE_ATTEMPTS = 15;
+const UNKNOWN_SESSION_INITIAL_RESUBSCRIBE_MS = 1000;
+const UNKNOWN_SESSION_MAX_RESUBSCRIBE_MS = 30000;
 
 type RetryState = {
   sessionId: string | null;
@@ -36,18 +36,30 @@ export function useUnknownSessionSubscriptionRetry(params: {
   useEffect(() => {
     if (!shouldRetry) return;
     let attempts = 0;
-    const id = window.setInterval(() => {
-      attempts += 1;
-      setRetryState({ sessionId, count: attempts });
-      if (attempts >= MAX_UNKNOWN_SESSION_RESUBSCRIBE_ATTEMPTS) {
-        window.clearInterval(id);
-      }
-    }, UNKNOWN_SESSION_RESUBSCRIBE_MS);
-    return () => window.clearInterval(id);
+    let timeoutId: number | null = null;
+    const schedule = () => {
+      timeoutId = window.setTimeout(() => {
+        const nextAttempts = attempts + 1;
+        attempts = nextAttempts;
+        setRetryState({ sessionId, count: nextAttempts });
+        schedule();
+      }, getUnknownSessionRetryDelay(attempts));
+    };
+    schedule();
+    return () => {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    };
   }, [sessionId, shouldRetry]);
 
   if (!shouldRetry || retryState.sessionId !== sessionId) return 0;
   return retryState.count;
+}
+
+export function getUnknownSessionRetryDelay(attempts: number) {
+  return Math.min(
+    UNKNOWN_SESSION_INITIAL_RESUBSCRIBE_MS * 2 ** attempts,
+    UNKNOWN_SESSION_MAX_RESUBSCRIBE_MS,
+  );
 }
 
 export function useUnknownSessionSubscriptionRetryEffect(params: {

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.ts
@@ -3,6 +3,12 @@ import { useEffect, useState } from "react";
 import type { TaskSessionState } from "@/lib/types/http";
 
 const UNKNOWN_SESSION_RESUBSCRIBE_MS = 1000;
+const MAX_UNKNOWN_SESSION_RESUBSCRIBE_ATTEMPTS = 15;
+
+type RetryState = {
+  sessionId: string | null;
+  count: number;
+};
 
 export function shouldRetryUnknownSessionSubscription(params: {
   taskSessionId: string | null;
@@ -21,17 +27,23 @@ export function useUnknownSessionSubscriptionRetry(params: {
   taskSessionState: TaskSessionState | null;
   connectionStatus: string;
 }) {
-  const [retryToken, setRetryToken] = useState(0);
+  const [retryState, setRetryState] = useState<RetryState>({ sessionId: null, count: 0 });
   const shouldRetry = shouldRetryUnknownSessionSubscription(params);
+  const sessionId = params.taskSessionId;
 
   useEffect(() => {
     if (!shouldRetry) return;
-    const id = window.setInterval(
-      () => setRetryToken((value) => value + 1),
-      UNKNOWN_SESSION_RESUBSCRIBE_MS,
-    );
+    let attempts = 0;
+    const id = window.setInterval(() => {
+      attempts += 1;
+      setRetryState({ sessionId, count: attempts });
+      if (attempts >= MAX_UNKNOWN_SESSION_RESUBSCRIBE_ATTEMPTS) {
+        window.clearInterval(id);
+      }
+    }, UNKNOWN_SESSION_RESUBSCRIBE_MS);
     return () => window.clearInterval(id);
-  }, [shouldRetry]);
+  }, [sessionId, shouldRetry]);
 
-  return shouldRetry ? retryToken : 0;
+  if (!shouldRetry || retryState.sessionId !== sessionId) return 0;
+  return retryState.count;
 }

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.ts
@@ -39,8 +39,11 @@ export function useUnknownSessionSubscriptionRetry(params: {
     if (!shouldRetry) return;
     let attempts = 0;
     let timeoutId: number | null = null;
+    let cancelled = false;
     const schedule = () => {
+      if (cancelled) return;
       timeoutId = window.setTimeout(() => {
+        if (cancelled) return;
         const nextAttempts = attempts + 1;
         attempts = nextAttempts;
         setRetryState({ sessionId, count: nextAttempts });
@@ -49,6 +52,7 @@ export function useUnknownSessionSubscriptionRetry(params: {
     };
     schedule();
     return () => {
+      cancelled = true;
       if (timeoutId !== null) window.clearTimeout(timeoutId);
     };
   }, [sessionId, shouldRetry]);

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 
+import { createDebugLogger } from "@/lib/debug/log";
 import type { TaskSessionState } from "@/lib/types/http";
 import { generateUUID } from "@/lib/utils";
 import { getWebSocketClient } from "@/lib/ws/connection";
 
 const UNKNOWN_SESSION_INITIAL_RESUBSCRIBE_MS = 1000;
 const UNKNOWN_SESSION_MAX_RESUBSCRIBE_MS = 30000;
+const debug = createDebugLogger("messages:fetch");
 
 type RetryState = {
   sessionId: string | null;
@@ -70,9 +72,23 @@ export function useUnknownSessionSubscriptionRetryEffect(params: {
   const { taskSessionId, connectionStatus, retryToken } = params;
 
   useEffect(() => {
-    if (!taskSessionId || connectionStatus !== "connected" || retryToken === 0) return;
+    if (!taskSessionId || connectionStatus !== "connected" || retryToken === 0) {
+      debug("unknown-session retry: skipped", { taskSessionId, connectionStatus, retryToken });
+      return;
+    }
     const client = getWebSocketClient();
-    if (!client) return;
+    if (!client) {
+      debug("unknown-session retry: skipped (no ws client)", { sessionId: taskSessionId });
+      return;
+    }
+    // The durable subscription effect owns the client's ref-counted
+    // subscribe/unsubscribe lifecycle. This retry only re-sends the subscribe
+    // frame to cover the backend race where the first subscribe arrived before
+    // the session was fully constructed.
+    debug("unknown-session retry: sending session.subscribe", {
+      sessionId: taskSessionId,
+      retryToken,
+    });
     client.send({
       id: generateUUID(),
       type: "request",

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.ts
@@ -7,7 +7,7 @@ import { getWebSocketClient } from "@/lib/ws/connection";
 
 const UNKNOWN_SESSION_INITIAL_RESUBSCRIBE_MS = 1000;
 const UNKNOWN_SESSION_MAX_RESUBSCRIBE_MS = 30000;
-const debug = createDebugLogger("messages:fetch");
+const debug = createDebugLogger("messages:resubscribe");
 
 type RetryState = {
   sessionId: string | null;

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 
 import type { TaskSessionState } from "@/lib/types/http";
+import { generateUUID } from "@/lib/utils";
+import { getWebSocketClient } from "@/lib/ws/connection";
 
 const UNKNOWN_SESSION_RESUBSCRIBE_MS = 1000;
 const MAX_UNKNOWN_SESSION_RESUBSCRIBE_ATTEMPTS = 15;
@@ -46,4 +48,24 @@ export function useUnknownSessionSubscriptionRetry(params: {
 
   if (!shouldRetry || retryState.sessionId !== sessionId) return 0;
   return retryState.count;
+}
+
+export function useUnknownSessionSubscriptionRetryEffect(params: {
+  taskSessionId: string | null;
+  connectionStatus: string;
+  retryToken: number;
+}) {
+  const { taskSessionId, connectionStatus, retryToken } = params;
+
+  useEffect(() => {
+    if (!taskSessionId || connectionStatus !== "connected" || retryToken === 0) return;
+    const client = getWebSocketClient();
+    if (!client) return;
+    client.send({
+      id: generateUUID(),
+      type: "request",
+      action: "session.subscribe",
+      payload: { session_id: taskSessionId },
+    });
+  }, [taskSessionId, connectionStatus, retryToken]);
 }

--- a/apps/web/hooks/domains/session/use-session-subscription-retry.ts
+++ b/apps/web/hooks/domains/session/use-session-subscription-retry.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+import type { TaskSessionState } from "@/lib/types/http";
+
+const UNKNOWN_SESSION_RESUBSCRIBE_MS = 1000;
+
+export function shouldRetryUnknownSessionSubscription(params: {
+  taskSessionId: string | null;
+  taskSessionState: TaskSessionState | null;
+  connectionStatus: string;
+}) {
+  return (
+    !!params.taskSessionId &&
+    params.connectionStatus === "connected" &&
+    params.taskSessionState === null
+  );
+}
+
+export function useUnknownSessionSubscriptionRetry(params: {
+  taskSessionId: string | null;
+  taskSessionState: TaskSessionState | null;
+  connectionStatus: string;
+}) {
+  const [retryToken, setRetryToken] = useState(0);
+  const shouldRetry = shouldRetryUnknownSessionSubscription(params);
+
+  useEffect(() => {
+    if (!shouldRetry) return;
+    const id = window.setInterval(
+      () => setRetryToken((value) => value + 1),
+      UNKNOWN_SESSION_RESUBSCRIBE_MS,
+    );
+    return () => window.clearInterval(id);
+  }, [shouldRetry]);
+
+  return shouldRetry ? retryToken : 0;
+}


### PR DESCRIPTION
Quick chat could open the model selector before session-scoped model config arrived, hiding options like effort. The chat session subscription now retries while the session state is still unknown, so the selector converges on the same dynamic options task chat shows.

## Validation

- `make fmt && make typecheck && make test && make lint`
- `pnpm e2e:run --host -- tests/chat/quick-chat.spec.ts --grep "model selector shows dynamic session options before first message"`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->