### PR TITLE
fix(web): restore diff expansion for committed-source review rows

### DIFF
--- a/apps/web/components/review/review-diff-expansion.test.ts
+++ b/apps/web/components/review/review-diff-expansion.test.ts
@@ -56,6 +56,17 @@ describe("resolveDiffExpansion", () => {
     });
   });
 
+  // Multi-repo guard, unnamed-file case: ReviewDiffList passes an undefined
+  // fallback when the task has multiple repos, so a committed file with no
+  // repository_name disables expansion rather than borrowing an arbitrary base.
+  it("disables expansion for an unnamed committed file when the fallback is undefined", () => {
+    const f = file({ source: "committed", repository_name: undefined });
+    expect(resolveDiffExpansion(f, MULTI_REPO_BASES, undefined)).toEqual({
+      enableExpansion: false,
+      baseRef: "HEAD",
+    });
+  });
+
   // Single-repo files carry no repository_name; the map is keyed by the real
   // repo name, so the lookup misses and the sole-base fallback applies.
   it("uses the fallback base branch for a single-repo committed file", () => {

--- a/apps/web/components/review/review-diff-expansion.test.ts
+++ b/apps/web/components/review/review-diff-expansion.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDiffExpansion } from "./review-diff-list";
+import type { ReviewFile } from "./types";
+
+const BACKEND_BASE = "release/24.x";
+const MULTI_REPO_BASES = { frontend: "main", backend: BACKEND_BASE };
+
+function file(partial: Partial<ReviewFile>): ReviewFile {
+  return {
+    path: "src/example.ts",
+    diff: "@@ -1 +1 @@\n-a\n+b\n",
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    staged: false,
+    source: "uncommitted",
+    ...partial,
+  };
+}
+
+describe("resolveDiffExpansion", () => {
+  it("enables expansion for uncommitted (working-tree) files against HEAD", () => {
+    expect(resolveDiffExpansion(file({ source: "uncommitted" }), {})).toEqual({
+      enableExpansion: true,
+      baseRef: "HEAD",
+    });
+  });
+
+  // Regression: #1097 narrowed the gate to `source === "uncommitted"`, which
+  // dropped expansion for committed-source rows — the bulk of a review. They
+  // must expand against the repo's base branch (not HEAD, which already
+  // contains the committed changes).
+  it("enables expansion for committed files against the repo base branch", () => {
+    expect(
+      resolveDiffExpansion(file({ source: "committed", repository_name: undefined }), {}, "main"),
+    ).toEqual({ enableExpansion: true, baseRef: "main" });
+  });
+
+  it("uses the per-repo base branch for committed multi-repo files", () => {
+    const f = file({ source: "committed", repository_name: "backend" });
+    expect(resolveDiffExpansion(f, MULTI_REPO_BASES, "main")).toEqual({
+      enableExpansion: true,
+      baseRef: BACKEND_BASE,
+    });
+  });
+
+  // Multi-repo guard: a committed file whose repo isn't in the map must NOT
+  // borrow the single-repo fallback (another repo's base branch) — that would
+  // fetch the wrong "old" content and silently drop expansion. Disable instead.
+  it("does not borrow another repo's base branch for an unmapped multi-repo file", () => {
+    const f = file({ source: "committed", repository_name: "infra" });
+    expect(resolveDiffExpansion(f, MULTI_REPO_BASES, "main")).toEqual({
+      enableExpansion: false,
+      baseRef: "HEAD",
+    });
+  });
+
+  // Single-repo files carry no repository_name; the map is keyed by the real
+  // repo name, so the lookup misses and the sole-base fallback applies.
+  it("uses the fallback base branch for a single-repo committed file", () => {
+    const f = file({ source: "committed", repository_name: undefined });
+    expect(resolveDiffExpansion(f, { "E2E Repo": "main" }, "main")).toEqual({
+      enableExpansion: true,
+      baseRef: "main",
+    });
+  });
+
+  // Uncommitted files always diff against HEAD regardless of repo; the repo
+  // scoping for content fetches happens via the separate `repo` prop.
+  it("expands uncommitted multi-repo files against HEAD", () => {
+    const f = file({ source: "uncommitted", repository_name: "backend" });
+    expect(resolveDiffExpansion(f, MULTI_REPO_BASES)).toEqual({
+      enableExpansion: true,
+      baseRef: "HEAD",
+    });
+  });
+
+  it("disables expansion for committed files when no base branch is known", () => {
+    expect(resolveDiffExpansion(file({ source: "committed" }), {})).toEqual({
+      enableExpansion: false,
+      baseRef: "HEAD",
+    });
+  });
+
+  it("disables expansion for PR files (working tree is not the PR head)", () => {
+    expect(resolveDiffExpansion(file({ source: "pr" }), {}, "main")).toEqual({
+      enableExpansion: false,
+      baseRef: "HEAD",
+    });
+  });
+
+  it("disables expansion for untracked files (synthetic /dev/null hunk)", () => {
+    expect(resolveDiffExpansion(file({ source: "uncommitted", status: "untracked" }), {})).toEqual({
+      enableExpansion: false,
+      baseRef: "HEAD",
+    });
+  });
+});

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -49,6 +49,16 @@ export const ReviewDiffList = memo(function ReviewDiffList({
   fileRefs,
 }: ReviewDiffListProps) {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  // Resolve base branches once per list (not per row) — the value is identical
+  // for every file. Only a single-repo task has an unambiguous fallback; with
+  // multiple repos a committed file lacking `repository_name` must NOT borrow
+  // an arbitrary repo's base branch, so the fallback stays undefined there.
+  const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
+  const baseBranchByRepo = useBaseBranchByRepo(activeTaskId);
+  const fallbackBaseBranch = useMemo(() => {
+    const branches = Object.values(baseBranchByRepo);
+    return branches.length === 1 ? branches[0] : undefined;
+  }, [baseBranchByRepo]);
   // All in-memory state (selectedFile, reviewedFiles, staleFiles, fileRefs)
   // is keyed by `reviewFileKey(file)` so two files at the same path in
   // different repos (e.g. `kandev/README.md` + `lvc/README.md`) get
@@ -93,6 +103,8 @@ export const ReviewDiffList = memo(function ReviewDiffList({
                 onPreviewMarkdown={onPreviewMarkdown}
                 sectionRef={fileRefs.get(key)}
                 scrollContainer={scrollContainerRef}
+                baseBranchByRepo={baseBranchByRepo}
+                fallbackBaseBranch={fallbackBaseBranch}
               />
             );
           })}
@@ -124,6 +136,10 @@ type FileDiffSectionProps = {
   onPreviewMarkdown?: (filePath: string) => void;
   sectionRef?: React.RefObject<HTMLDivElement | null>;
   scrollContainer: React.RefObject<HTMLDivElement | null>;
+  /** Per-repo base branches + single-repo fallback, resolved once by the list
+   *  and shared across rows so diff expansion can fetch the correct old side. */
+  baseBranchByRepo: Record<string, string>;
+  fallbackBaseBranch?: string;
 };
 
 function useLazyVisible(scrollContainer: React.RefObject<HTMLDivElement | null>) {
@@ -474,6 +490,8 @@ function FileDiffSection({
   onPreviewMarkdown,
   sectionRef,
   scrollContainer,
+  baseBranchByRepo,
+  fallbackBaseBranch,
 }: FileDiffSectionProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [expandUnchanged, setExpandUnchanged] = useState(false);
@@ -518,12 +536,6 @@ function FileDiffSection({
 
   const handleCommentRun = useCommentRunHandler(sessionId);
 
-  const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
-  const baseBranchByRepo = useBaseBranchByRepo(activeTaskId);
-  // Single-repo tasks key the base branch under the real repo name while a
-  // review file carries an empty `repository_name`; fall back to the task's
-  // sole base branch so committed-row expansion still resolves a ref.
-  const fallbackBaseBranch = useMemo(() => Object.values(baseBranchByRepo)[0], [baseBranchByRepo]);
   const { enableExpansion, baseRef } = resolveDiffExpansion(
     file,
     baseBranchByRepo,

--- a/apps/web/components/review/review-diff-list.tsx
+++ b/apps/web/components/review/review-diff-list.tsx
@@ -11,6 +11,7 @@ import { generateUnifiedDiff, calculateHash } from "@/lib/utils/file-diff";
 import { useAppStore } from "@/components/state-provider";
 import { useToast } from "@/components/toast-provider";
 import { useRunComment } from "@/hooks/domains/comments/use-run-comment";
+import { useBaseBranchByRepo } from "@/hooks/domains/session/use-base-branch-by-repo";
 import type { DiffComment } from "@/lib/diff/types";
 import { diffSkipReasonLabel, reviewFileKey } from "./types";
 import type { ReviewFile } from "./types";
@@ -348,12 +349,62 @@ function useScrollIntoViewOnSelect(
   }, [isSelected, sectionRef, setCollapsed]);
 }
 
+/**
+ * Decide whether a review row can expand its collapsed context, and which git
+ * ref supplies the "old" side when reconstructing full file context.
+ *
+ * Expansion reveals the *unmodified* lines hidden between hunks. @pierre/diffs
+ * needs the full old+new file contents (paired with the patch) to render those
+ * controls; we fetch the new side from the working tree and the old side from
+ * `baseRef`. The ref has to match the base the diff was computed against, or
+ * the reparse comes out inconsistent and silently falls back to a partial
+ * (controls-less) render:
+ *
+ *  - uncommitted rows: diff is working-tree-vs-HEAD, so baseRef="HEAD".
+ *  - committed rows: diff is base-branch-vs-HEAD, so baseRef is the repo's
+ *    base branch. HEAD already contains the commits, so expanding against it
+ *    pairs identical old/new content and yields no controls (the bug behind
+ *    "expansion stopped working in the review screen"). With no known base
+ *    branch we can't fetch the pre-change content, so expansion is disabled
+ *    rather than rendering dead separators.
+ *  - PR rows: the working tree belongs to the local branch, not the PR head,
+ *    so the fetched content would be paired with the wrong patch — disabled.
+ *  - untracked files: a synthetic all-additions hunk against /dev/null with no
+ *    real context to expand — disabled.
+ *
+ * The @pierre/diffs trailing-context guard in `useExpandableDiff` keeps any
+ * mismatch (stale snapshot, wrong base, file edited mid-flight) from crashing
+ * the renderer, so enabling expansion here is always safe.
+ */
+export function resolveDiffExpansion(
+  file: Pick<ReviewFile, "source" | "status" | "repository_name">,
+  baseBranchByRepo: Record<string, string>,
+  fallbackBaseBranch?: string,
+): { enableExpansion: boolean; baseRef: string } {
+  if (file.source === "pr" || file.status === "untracked") {
+    return { enableExpansion: false, baseRef: "HEAD" };
+  }
+  if (file.source === "committed") {
+    const repoName = file.repository_name ?? "";
+    // Exact per-repo base wins. Fall back to the task's sole base branch ONLY
+    // for single-repo files (no repository_name) — a multi-repo file whose repo
+    // isn't in the map must NOT borrow another repo's base branch, which would
+    // fetch the wrong "old" content and silently drop expansion.
+    const base = baseBranchByRepo[repoName] ?? (repoName === "" ? fallbackBaseBranch : undefined);
+    if (!base) return { enableExpansion: false, baseRef: "HEAD" };
+    return { enableExpansion: true, baseRef: base };
+  }
+  return { enableExpansion: true, baseRef: "HEAD" };
+}
+
 function renderDiffContent(opts: {
   shouldRender: boolean;
   file: ReviewFile;
   sessionId: string;
   wordWrap: boolean;
   expandUnchanged: boolean;
+  enableExpansion: boolean;
+  baseRef: string;
   onRevertBlock: (filePath: string, info: RevertBlockInfo) => void;
   onCommentRun: (comment: DiffComment) => void;
   onToggleExpandUnchanged: () => void;
@@ -364,33 +415,13 @@ function renderDiffContent(opts: {
     sessionId,
     wordWrap,
     expandUnchanged,
+    enableExpansion,
+    baseRef,
     onRevertBlock,
     onCommentRun,
     onToggleExpandUnchanged,
   } = opts;
   if (shouldRender && file.diff) {
-    // Expansion fetches the file content from the working tree to reconstruct
-    // full context around hunks. For PR files the working tree's content
-    // belongs to the local branch, not the PR head — when the same file has
-    // both PR and local changes, the wrong content gets paired with the PR
-    // patch and @pierre/diffs 1.1.x renders nothing/errors. Disable expansion
-    // for PR-sourced rows.
-    //
-    // Also disable expansion for committed-source rows: the backend computes
-    // the diff against the session's stored base commit, not HEAD. HEAD
-    // already contains the committed changes, so fetching old content at
-    // baseRef="HEAD" returns the same content as the working tree, leaving
-    // processFile's trailing-context counts inconsistent and crashing the
-    // renderer. Using the right base would need the session's base SHA
-    // plumbed in here; that's a follow-up.
-    //
-    // Also disable expansion for untracked files: the backend synthesizes a
-    // single all-additions hunk against /dev/null, so there is no real
-    // context to expand. Re-parsing with the live working-tree content
-    // races with concurrent edits — if the file shrinks after the snapshot,
-    // the cached hunk header advertises more lines than the fetched content
-    // has and @pierre/diffs' DiffHunksRenderer throws.
-    const enableExpansion = file.source === "uncommitted" && file.status !== "untracked";
     return (
       <>
         <DiffErrorBoundary filePath={file.path}>
@@ -405,7 +436,7 @@ function renderDiffContent(opts: {
             sessionId={sessionId}
             wordWrap={wordWrap}
             enableExpansion={enableExpansion}
-            baseRef="HEAD"
+            baseRef={baseRef}
             hideHeader
             expandUnchanged={expandUnchanged}
             onToggleExpandUnchanged={onToggleExpandUnchanged}
@@ -487,6 +518,18 @@ function FileDiffSection({
 
   const handleCommentRun = useCommentRunHandler(sessionId);
 
+  const activeTaskId = useAppStore((state) => state.tasks.activeTaskId);
+  const baseBranchByRepo = useBaseBranchByRepo(activeTaskId);
+  // Single-repo tasks key the base branch under the real repo name while a
+  // review file carries an empty `repository_name`; fall back to the task's
+  // sole base branch so committed-row expansion still resolves a ref.
+  const fallbackBaseBranch = useMemo(() => Object.values(baseBranchByRepo)[0], [baseBranchByRepo]);
+  const { enableExpansion, baseRef } = resolveDiffExpansion(
+    file,
+    baseBranchByRepo,
+    fallbackBaseBranch,
+  );
+
   return (
     <div ref={sectionRef} className="border-b border-border">
       <div ref={scrollSentinelRef} className="h-0" />
@@ -514,6 +557,8 @@ function FileDiffSection({
           sessionId,
           wordWrap: effectiveWordWrap,
           expandUnchanged,
+          enableExpansion,
+          baseRef,
           onRevertBlock: handleRevertBlock,
           onCommentRun: handleCommentRun,
           onToggleExpandUnchanged: handleToggleExpandUnchanged,


### PR DESCRIPTION
Line-expansion controls stopped appearing for committed-source files in the review screen — #1097 narrowed the gate to `source === "uncommitted"` to avoid a trailing-context crash, which also killed expansion for committed rows (the bulk of a review). The crash is already caught by the reparse guard in `useExpandableDiff`, so committed rows are re-enabled, expanding against the repo's base branch instead of `HEAD` (which already contains the commits).

## Important Changes

- Extract the gate into a pure `resolveDiffExpansion(file, baseBranchByRepo, fallback)` helper.
- Committed rows now fetch the "old" side at the repo's base branch; multi-repo files require an exact per-repo match so they never borrow another repo's base branch.

## Validation

- `pnpm vitest run components/review` — 37 passing, incl. 9-case `review-diff-expansion.test.ts` (single + multi-repo + edges).
- `pnpm typecheck`, `pnpm eslint` (changed files) — clean.
- Verified the fix end-to-end with real `processFile` probes (committed diff + baseRef=base branch → `isPartial=false`, expand controls render); existing Playwright `diff-expansion.spec.ts` (8 tests) still green.

## Possible Improvements

- Low risk. A committed-source e2e is not included: the review file list is seeded from `git status`, so a clean-working-tree committed file can't be surfaced via a mock scenario — covered by unit tests instead.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->