### PR TITLE
fix: render er diagrams in task plans

### DIFF
--- a/apps/web/components/shared/mermaid-utils.test.ts
+++ b/apps/web/components/shared/mermaid-utils.test.ts
@@ -80,4 +80,14 @@ describe("sanitizeMermaidCode", () => {
     const out = sanitizeMermaidCode(input);
     expect(out).toContain(`B["/api/x"]`);
   });
+
+  it("does not quote ER diagram cardinality bars as flowchart edge labels", () => {
+    const input = [
+      "erDiagram",
+      "workspaces ||--o{ workflows : owns",
+      "workflows ||--o{ workflow_steps : contains",
+    ].join("\n");
+
+    expect(sanitizeMermaidCode(input)).toBe(input);
+  });
 });

--- a/apps/web/components/shared/mermaid-utils.test.ts
+++ b/apps/web/components/shared/mermaid-utils.test.ts
@@ -81,6 +81,21 @@ describe("sanitizeMermaidCode", () => {
     expect(out).toContain(`B["/api/x"]`);
   });
 
+  it("does not match an edge label that spans a newline", () => {
+    const input = `A -->|open\nB | C`;
+    expect(sanitizeMermaidCode(input)).toBe(input);
+  });
+
+  it("does not match a bracket label that spans a newline", () => {
+    const input = `A[open\nB]`;
+    expect(sanitizeMermaidCode(input)).toBe(input);
+  });
+
+  it("does not match a parenthesis label that spans a newline", () => {
+    const input = `A(open\n/path)`;
+    expect(sanitizeMermaidCode(input)).toBe(input);
+  });
+
   it("does not quote ER diagram cardinality bars as flowchart edge labels", () => {
     const input = [
       "erDiagram",

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -95,7 +95,7 @@ export function sanitizeMermaidCode(code: string): string {
 
   // Quote edge labels: |text|
   quoted = findQuotedRanges(result);
-  result = result.replace(/\|([^|"]+?)\|/g, (match, text, offset) => {
+  result = result.replace(/\|([^|\n"]+?)\|/g, (match, text, offset) => {
     if (inAnyRange(offset, quoted)) return match;
     if (SPECIAL_CHARS_RE.test(text)) {
       return `|"${text}"|`;

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -85,7 +85,7 @@ const inAnyRange = (offset: number, ranges: Array<[number, number]>): boolean =>
 export function sanitizeMermaidCode(code: string): string {
   // Quote node labels: [text] or [[text]] etc. Match brackets that aren't already quoted.
   let quoted = findQuotedRanges(code);
-  let result = code.replace(/(\[+)([^\]"]+?)(\]+)/g, (match, open, text, close, offset) => {
+  let result = code.replace(/(\[+)([^\]\n"]+?)(\]+)/g, (match, open, text, close, offset) => {
     if (inAnyRange(offset, quoted)) return match;
     if (BRACKET_TRIGGER_RE.test(text)) {
       return `${open}"${text}"${close}`;
@@ -105,7 +105,7 @@ export function sanitizeMermaidCode(code: string): string {
 
   // Quote parentheses labels: (text) for stadium/circle nodes
   quoted = findQuotedRanges(result);
-  result = result.replace(/(\(+)([^)"]+?)(\)+)/g, (match, open, text, close, offset) => {
+  result = result.replace(/(\(+)([^)\n"]+?)(\)+)/g, (match, open, text, close, offset) => {
     if (inAnyRange(offset, quoted)) return match;
     // Skip if it looks like a subgraph or keyword
     if (/^(subgraph|end|graph|flowchart|sequenceDiagram)\b/.test(text.trim())) {


### PR DESCRIPTION
Task-plan Mermaid rendering failed on valid multi-line ER diagrams because the sanitizer could quote cardinality bars across lines. The sanitizer now preserves ER relationships while keeping flowchart edge-label quoting intact.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs && make typecheck`
- `make test`
- `make lint`
- Focused direct Mermaid parse repro for the reported ER diagram pattern

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->