### PR TITLE
fix: split multi-file agent read links and strip line-range selectors

### DIFF
--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -329,9 +329,13 @@ func updateReadFileInput(rf *streams.ReadFilePayload, supplemental, inputMap map
 	// Multiple comma-joined files can't share one Offset/Limit; keep the raw path
 	// for the UI to split (mirrors normalizeRead).
 	if len(files) > 1 {
-		if rf.FilePath == "" {
-			rf.FilePath = path
-		}
+		// Mirror normalizeRead: a multi-file read keeps the raw comma-joined path
+		// (the UI splits it) and carries no single Offset/Limit. Overwrite any
+		// stale single-file state from an earlier update that streamed a partial,
+		// single-file path before the full multi-file path arrived.
+		rf.FilePath = path
+		rf.Offset = 0
+		rf.Limit = 0
 		return
 	}
 	if rf.FilePath == "" {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -321,17 +321,27 @@ func updateReadFileInput(rf *streams.ReadFilePayload, supplemental, inputMap map
 	// Parse the selector on every update — a later tool_call_update can carry the
 	// line range (e.g. "main.go:50+150") even when an earlier frame already set
 	// FilePath, so range metadata must not be gated on FilePath being empty.
-	if path := pathFromArgs(supplemental, inputMap); path != "" {
-		clean, startLine, lineCount := readselector.Split(path)
+	path := pathFromArgs(supplemental, inputMap)
+	if path == "" {
+		return
+	}
+	files := readselector.SplitFiles(path)
+	// Multiple comma-joined files can't share one Offset/Limit; keep the raw path
+	// for the UI to split (mirrors normalizeRead).
+	if len(files) > 1 {
 		if rf.FilePath == "" {
-			rf.FilePath = clean
+			rf.FilePath = path
 		}
-		if rf.Offset == 0 {
-			rf.Offset = startLine
-		}
-		if rf.Limit == 0 {
-			rf.Limit = lineCount
-		}
+		return
+	}
+	if rf.FilePath == "" {
+		rf.FilePath = files[0].Path
+	}
+	if rf.Offset == 0 {
+		rf.Offset = files[0].StartLine
+	}
+	if rf.Limit == 0 {
+		rf.Limit = files[0].LineCount
 	}
 }
 
@@ -439,16 +449,24 @@ func (n *Normalizer) normalizeRead(args map[string]any) *streams.NormalizedPaylo
 
 	path := pathFromArgs(args, rawInput)
 	// OMP's read tool embeds a line/range/mode selector in the path
-	// (e.g. "foo.go:43-94"); strip it so the file link stays openable and
-	// carry the parsed range via offset/limit. No-op for other agents.
-	path, startLine, lineCount := readselector.Split(path)
+	// (e.g. "foo.go:43-94"), and can reference several comma-joined files in a
+	// single read ("a.yaml:1-80,b.yaml:1-80"). Split into one entry per file so
+	// links stay openable; the range is carried via offset/limit. No-op for
+	// other agents.
+	files := readselector.SplitFiles(path)
 
-	// Check if this is a directory read - treat as code search (file listing)
+	// Check if this is a directory read - treat as code search (file listing).
 	if readType := shared.GetString(rawInput, "type"); readType == readTypeDirectory {
-		return streams.NewCodeSearch("", "", path, "")
+		return streams.NewCodeSearch("", "", files[0].Path, "")
 	}
 
-	return streams.NewReadFile(path, startLine, lineCount)
+	// A single Offset/Limit cannot describe multiple files, so for a multi-file
+	// read keep the raw comma-joined path verbatim and let the UI split it into
+	// one link per file.
+	if len(files) > 1 {
+		return streams.NewReadFile(path, 0, 0)
+	}
+	return streams.NewReadFile(files[0].Path, files[0].StartLine, files[0].LineCount)
 }
 
 // normalizeExecute converts ACP execute/bash tool data.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
@@ -1062,6 +1062,32 @@ func TestUpdatePayloadInput_ReadFile(t *testing.T) {
 			t.Errorf("expected FilePath '/workspace/README.md', got %q", payload.ReadFile().FilePath)
 		}
 	})
+
+	t.Run("switches stale single-file state to raw multi-file path", func(t *testing.T) {
+		// An earlier update streamed a single-file path with a range; a later
+		// update carries the full multi-file path. The payload must drop the
+		// stale single-file Offset/Limit and keep the raw comma-joined path for
+		// the UI to split (mirrors normalizeRead).
+		payload := normalizer.NormalizeToolCall("read", map[string]any{
+			"kind": "read",
+			"raw_input": map[string]any{
+				"path": "a.go:1-10",
+			},
+		})
+		if rf := payload.ReadFile(); rf.FilePath != "a.go" || rf.Offset != 1 || rf.Limit != 10 {
+			t.Fatalf("unexpected initial state: %+v", rf)
+		}
+		normalizer.UpdatePayloadInput(payload, map[string]any{
+			"file_path": "a.go:1-10,b.go:1-10",
+		}, nil)
+		rf := payload.ReadFile()
+		if rf.FilePath != "a.go:1-10,b.go:1-10" {
+			t.Errorf("expected raw multi-file FilePath, got %q", rf.FilePath)
+		}
+		if rf.Offset != 0 || rf.Limit != 0 {
+			t.Errorf("expected Offset/Limit cleared, got Offset=%d Limit=%d", rf.Offset, rf.Limit)
+		}
+	})
 }
 
 // TestSplitLines tests the line splitting utility.

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
@@ -540,6 +540,40 @@ func TestNormalizerRead(t *testing.T) {
 			t.Errorf("expected Offset=50 Limit=150 from update, got Offset=%d Limit=%d", rf.Offset, rf.Limit)
 		}
 	})
+
+	t.Run("keeps multi-file read path raw so the UI can split it", func(t *testing.T) {
+		args := map[string]any{
+			"kind": "read",
+			"raw_input": map[string]any{
+				"path": "deployments/values.backupprod.yaml:1-80,deployments/values.au-backupprod.yaml:1-80",
+			},
+		}
+		rf := normalizer.NormalizeToolCall("read", args).ReadFile()
+		if rf == nil {
+			t.Fatal("expected ReadFile to be set")
+		}
+		// Multiple files cannot be represented by a single Offset/Limit; keep the
+		// raw comma-joined path verbatim and let the frontend render one link per
+		// file. Offset/Limit stay zero (no single top-level range).
+		if rf.FilePath != "deployments/values.backupprod.yaml:1-80,deployments/values.au-backupprod.yaml:1-80" {
+			t.Errorf("expected raw multi-file FilePath preserved, got %q", rf.FilePath)
+		}
+		if rf.Offset != 0 || rf.Limit != 0 {
+			t.Errorf("expected Offset=0 Limit=0 for multi-file read, got Offset=%d Limit=%d", rf.Offset, rf.Limit)
+		}
+	})
+
+	t.Run("keeps multi-file read path raw arriving on a tool_call_update", func(t *testing.T) {
+		payload := normalizer.NormalizeToolCall("read", map[string]any{"kind": "read"})
+		normalizer.UpdatePayloadInput(payload, map[string]any{"path": "a/x.go:1-10,a/y.go:1-10"}, nil)
+		rf := payload.ReadFile()
+		if rf.FilePath != "a/x.go:1-10,a/y.go:1-10" {
+			t.Errorf("expected raw multi-file FilePath preserved, got %q", rf.FilePath)
+		}
+		if rf.Offset != 0 || rf.Limit != 0 {
+			t.Errorf("expected Offset=0 Limit=0 for multi-file read, got Offset=%d Limit=%d", rf.Offset, rf.Limit)
+		}
+	})
 }
 
 // TestNormalizerResult tests the normalizer's result handling.

--- a/apps/backend/internal/common/readselector/readselector.go
+++ b/apps/backend/internal/common/readselector/readselector.go
@@ -54,6 +54,70 @@ func Split(raw string) (path string, startLine, lineCount int) {
 	return base, start, count
 }
 
+// File is one file reference parsed out of a (possibly multi-file) read path.
+type File struct {
+	Path      string
+	StartLine int
+	LineCount int
+}
+
+// SplitFiles splits an omp read path that may reference several comma-joined
+// files ("a.yaml:1-80,b.yaml:1-80") into one File per file, each with its own
+// parsed line range. A comma segment that is purely a line-spec list ("960-973")
+// or a mode keyword ("raw"/"conflicts") is treated as an additional range of the
+// preceding file — so a single file's multi-range selector ("main.go:5-16,40-80")
+// stays one File, matching Split (first range wins).
+//
+// Multiple files are only reported when every parsed segment yields a real file
+// path (one containing a path separator or a filename extension); otherwise —
+// e.g. a directory name that legitimately contains a comma — it returns the
+// single Split result, so single-file behavior is never disturbed.
+func SplitFiles(raw string) []File {
+	parts := strings.Split(raw, ",")
+	files := make([]File, 0, len(parts))
+	for i, part := range parts {
+		if i > 0 && isContinuationRange(part) {
+			continue
+		}
+		path, start, count := Split(part)
+		files = append(files, File{Path: path, StartLine: start, LineCount: count})
+	}
+	if len(files) > 1 && allFileish(files) {
+		return files
+	}
+	path, start, count := Split(raw)
+	return []File{{Path: path, StartLine: start, LineCount: count}}
+}
+
+// isContinuationRange reports whether a comma segment is an extra range of the
+// preceding file rather than a new file: a bare line-spec list or a mode keyword.
+func isContinuationRange(part string) bool {
+	if part == "raw" || part == "conflicts" {
+		return true
+	}
+	_, _, ok := parseLineSpecList(part)
+	return ok
+}
+
+func allFileish(files []File) bool {
+	for _, f := range files {
+		if !isFileish(f.Path) {
+			return false
+		}
+	}
+	return true
+}
+
+// isFileish reports whether a path looks like a concrete file: it has a path
+// separator or a "." in its final segment. Used to distinguish a real second
+// file from a comma that merely lives inside a single path.
+func isFileish(path string) bool {
+	if strings.ContainsAny(path, `/\`) {
+		return true
+	}
+	return strings.Contains(path, ".")
+}
+
 func isWindowsDrivePrefix(raw string, colon int) bool {
 	return colon == 1 && len(raw) >= 2 && isASCIIAlpha(raw[0])
 }

--- a/apps/backend/internal/common/readselector/readselector.go
+++ b/apps/backend/internal/common/readselector/readselector.go
@@ -68,21 +68,26 @@ type File struct {
 // preceding file — so a single file's multi-range selector ("main.go:5-16,40-80")
 // stays one File, matching Split (first range wins).
 //
-// Multiple files are only reported when every parsed segment yields a real file
-// path (one containing a path separator or a filename extension); otherwise —
-// e.g. a directory name that legitimately contains a comma — it returns the
-// single Split result, so single-file behavior is never disturbed.
+// Multiple files are only reported when every segment is a self-contained file
+// reference — it carries a read selector or its basename has an extension.
+// Otherwise it returns the single Split result, so single-file behavior is never
+// disturbed: a comma inside a directory name ("a,b/foo.go") or inside a filename
+// ("src/foo,bar.go:1-20") stays one File rather than splitting into phantoms.
 func SplitFiles(raw string) []File {
 	parts := strings.Split(raw, ",")
 	files := make([]File, 0, len(parts))
+	multi := true
 	for i, part := range parts {
 		if i > 0 && isContinuationRange(part) {
 			continue
 		}
+		if !isStrongFile(part) {
+			multi = false
+		}
 		path, start, count := Split(part)
 		files = append(files, File{Path: path, StartLine: start, LineCount: count})
 	}
-	if len(files) > 1 && allFileish(files) {
+	if multi && len(files) > 1 {
 		return files
 	}
 	path, start, count := Split(raw)
@@ -99,23 +104,20 @@ func isContinuationRange(part string) bool {
 	return ok
 }
 
-func allFileish(files []File) bool {
-	for _, f := range files {
-		if !isFileish(f.Path) {
-			return false
-		}
-	}
-	return true
-}
-
-// isFileish reports whether a path looks like a concrete file: it has a path
-// separator or a "." in its final segment. Used to distinguish a real second
-// file from a comma that merely lives inside a single path.
-func isFileish(path string) bool {
-	if strings.ContainsAny(path, `/\`) {
+// isStrongFile reports whether a comma segment is a self-contained file
+// reference: it carries a read selector (Split strips it) or its basename has an
+// extension. A segment that looks fileish only via a path separator ("src/foo"
+// in the single filename "src/foo,bar.go") is NOT a file boundary, so a comma
+// inside a filename is not mistaken for a multi-file bundle.
+func isStrongFile(part string) bool {
+	if path, _, _ := Split(part); path != part {
 		return true
 	}
-	return strings.Contains(path, ".")
+	base := part
+	if i := strings.LastIndexAny(part, `/\`); i >= 0 {
+		base = part[i+1:]
+	}
+	return strings.Contains(base, ".")
 }
 
 func isWindowsDrivePrefix(raw string, colon int) bool {

--- a/apps/backend/internal/common/readselector/readselector_test.go
+++ b/apps/backend/internal/common/readselector/readselector_test.go
@@ -80,3 +80,55 @@ func TestSplit_NoFalsePositives(t *testing.T) {
 		})
 	}
 }
+
+// TestSplitFiles covers omp reads that reference several comma-joined files in a
+// single read call (e.g. "a.yaml:1-80,b.yaml:1-80"). Each file becomes its own
+// entry so the UI can render a separate, openable link per file. A comma segment
+// that is purely a line spec ("960-973") stays an extra range of the preceding
+// file, and a comma that merely lives inside a directory name falls back to the
+// single-file Split result.
+func TestSplitFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []File
+	}{
+		{"single no selector", "config.json", []File{{Path: "config.json"}}},
+		{
+			"single with range",
+			"apps/backend/internal/sentry/handlers.go:43-94",
+			[]File{{Path: "apps/backend/internal/sentry/handlers.go", StartLine: 43, LineCount: 52}},
+		},
+		{"single multi-range stays one file", "main.go:5-16,960-973", []File{{Path: "main.go", StartLine: 5, LineCount: 12}}},
+		{
+			"two files with ranges",
+			"deployments/cluster-tools/values.backupprod.yaml:1-80,deployments/cluster-tools/values.au-backupprod.yaml:1-80",
+			[]File{
+				{Path: "deployments/cluster-tools/values.backupprod.yaml", StartLine: 1, LineCount: 80},
+				{Path: "deployments/cluster-tools/values.au-backupprod.yaml", StartLine: 1, LineCount: 80},
+			},
+		},
+		{"two bare-extension files", "a.go:1,b.go:2", []File{{Path: "a.go", StartLine: 1}, {Path: "b.go", StartLine: 2}}},
+		{
+			"multi-range first file then second file",
+			"a.go:5-16,40-80,b.go:10",
+			[]File{{Path: "a.go", StartLine: 5, LineCount: 12}, {Path: "b.go", StartLine: 10}},
+		},
+		{"files with mode selectors", "a.go:2-4:raw,b.go:raw", []File{{Path: "a.go", StartLine: 2, LineCount: 3}, {Path: "b.go"}}},
+		{"second file without range still openable", "a/x.yaml:1-80,b/y.yaml", []File{{Path: "a/x.yaml", StartLine: 1, LineCount: 80}, {Path: "b/y.yaml"}}},
+		{"comma inside directory name falls back to single", "a,b/foo.go:1-80", []File{{Path: "a,b/foo.go", StartLine: 1, LineCount: 80}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SplitFiles(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("SplitFiles(%q) = %+v (%d files), want %d", tt.raw, got, len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("file[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/apps/backend/internal/common/readselector/readselector_test.go
+++ b/apps/backend/internal/common/readselector/readselector_test.go
@@ -117,6 +117,22 @@ func TestSplitFiles(t *testing.T) {
 		{"files with mode selectors", "a.go:2-4:raw,b.go:raw", []File{{Path: "a.go", StartLine: 2, LineCount: 3}, {Path: "b.go"}}},
 		{"second file without range still openable", "a/x.yaml:1-80,b/y.yaml", []File{{Path: "a/x.yaml", StartLine: 1, LineCount: 80}, {Path: "b/y.yaml"}}},
 		{"comma inside directory name falls back to single", "a,b/foo.go:1-80", []File{{Path: "a,b/foo.go", StartLine: 1, LineCount: 80}}},
+		{
+			"hyphenated dirs two files",
+			"deployments/tailscale-ingress-extras/values.prod.yaml:1-180,deployments/tailscale-ingress-extras/values.staging.yaml:1-180",
+			[]File{
+				{Path: "deployments/tailscale-ingress-extras/values.prod.yaml", StartLine: 1, LineCount: 180},
+				{Path: "deployments/tailscale-ingress-extras/values.staging.yaml", StartLine: 1, LineCount: 180},
+			},
+		},
+		{
+			"hyphenated dirs legacy half-stripped trailing range",
+			"deployments/tailscale-ingress-extras/values.prod.yaml:1-180,deployments/tailscale-ingress-extras/values.staging.yaml",
+			[]File{
+				{Path: "deployments/tailscale-ingress-extras/values.prod.yaml", StartLine: 1, LineCount: 180},
+				{Path: "deployments/tailscale-ingress-extras/values.staging.yaml"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/apps/backend/internal/common/readselector/readselector_test.go
+++ b/apps/backend/internal/common/readselector/readselector_test.go
@@ -133,6 +133,16 @@ func TestSplitFiles(t *testing.T) {
 				{Path: "deployments/tailscale-ingress-extras/values.staging.yaml"},
 			},
 		},
+		// A comma inside a single filename must not be split into phantom files:
+		// "src/foo" is fileish only via its separator (no selector, no extension),
+		// so it is not a file boundary and the whole path stays one File.
+		{"comma inside filename falls back to single", "src/foo,bar.go:1-20", []File{{Path: "src/foo,bar.go", StartLine: 1, LineCount: 20}}},
+		{
+			"two files first with extension still splits",
+			"src/a.go,src/b.go:1-20",
+			[]File{{Path: "src/a.go"}, {Path: "src/b.go", StartLine: 1, LineCount: 20}},
+		},
+		{"extensionless first file with selector still splits", "Makefile:10,foo.go:20", []File{{Path: "Makefile", StartLine: 10}, {Path: "foo.go", StartLine: 20}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/apps/web/components/task/chat/messages/tool-read-message.test.tsx
+++ b/apps/web/components/task/chat/messages/tool-read-message.test.tsx
@@ -36,6 +36,26 @@ describe("ToolReadMessage", () => {
     expect(openFile).toHaveBeenCalledWith("apps/web/lib/utils.ts");
   });
 
+  it("opens a single-file link whose path still carries a line-range selector", () => {
+    // Legacy / not-yet-normalized reads keep the selector glued to file_path
+    // (e.g. "scripts/au/setup-au-sentry-secrets.sh:88-137"). The card must strip
+    // it so the link opens the bare path rather than a non-existent file.
+    const openFile = vi.fn();
+    render(
+      <ToolReadMessage
+        comment={readComment("scripts/au/setup-au-sentry-secrets.sh:88-137")}
+        onOpenFile={openFile}
+      />,
+    );
+
+    const links = screen.getAllByRole("button");
+    expect(links).toHaveLength(1);
+    expect(screen.getByText("scripts/au/setup-au-sentry-secrets.sh")).toBeTruthy();
+    fireEvent.click(links[0]);
+    expect(openFile).toHaveBeenCalledWith("scripts/au/setup-au-sentry-secrets.sh");
+    expect(openFile).not.toHaveBeenCalledWith("scripts/au/setup-au-sentry-secrets.sh:88-137");
+  });
+
   it("splits a comma-joined multi-file read into one link per file", () => {
     const openFile = vi.fn();
     render(

--- a/apps/web/components/task/chat/messages/tool-read-message.test.tsx
+++ b/apps/web/components/task/chat/messages/tool-read-message.test.tsx
@@ -75,4 +75,30 @@ describe("ToolReadMessage", () => {
     expect(openFile).toHaveBeenCalledWith("deployments/values.au-backupprod.yaml");
     expect(openFile).not.toHaveBeenCalledWith("deployments/values.au-backupprod.yaml:1-80");
   });
+
+  it("splits the hyphenated multi-file example into separate openable links", () => {
+    // Exact shape seen in a real session: hyphenated dirs + per-file ranges.
+    const openFile = vi.fn();
+    render(
+      <ToolReadMessage
+        comment={readComment(
+          "deployments/tailscale-ingress-extras/values.prod.yaml:1-180,deployments/tailscale-ingress-extras/values.staging.yaml:1-180",
+        )}
+        onOpenFile={openFile}
+      />,
+    );
+
+    const prod = screen.getByText("deployments/tailscale-ingress-extras/values.prod.yaml");
+    const staging = screen.getByText("deployments/tailscale-ingress-extras/values.staging.yaml");
+    expect(prod).toBeTruthy();
+    expect(staging).toBeTruthy();
+
+    fireEvent.click(staging);
+    expect(openFile).toHaveBeenCalledWith(
+      "deployments/tailscale-ingress-extras/values.staging.yaml",
+    );
+    expect(openFile).not.toHaveBeenCalledWith(
+      "deployments/tailscale-ingress-extras/values.staging.yaml:1-180",
+    );
+  });
 });

--- a/apps/web/components/task/chat/messages/tool-read-message.test.tsx
+++ b/apps/web/components/task/chat/messages/tool-read-message.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Message } from "@/lib/types/http";
+
+// useOpenFileAtLine pulls in Monaco; stub it with a passthrough that forwards the
+// (already selector-stripped) path so we can assert what gets opened.
+vi.mock("@/hooks/use-file-editors", () => ({
+  useOpenFileAtLine: (onOpenFile: ((path: string) => void) | undefined) => (path: string) =>
+    onOpenFile?.(path),
+}));
+
+import { ToolReadMessage } from "./tool-read-message";
+
+function readComment(filePath: string, offset?: number, limit?: number): Message {
+  return {
+    id: "m1",
+    metadata: {
+      status: "complete",
+      normalized: { read_file: { file_path: filePath, offset, limit } },
+    },
+  } as unknown as Message;
+}
+
+describe("ToolReadMessage", () => {
+  afterEach(cleanup);
+
+  it("renders one openable link for a single-file read", () => {
+    const openFile = vi.fn();
+    render(
+      <ToolReadMessage comment={readComment("apps/web/lib/utils.ts", 50)} onOpenFile={openFile} />,
+    );
+
+    const links = screen.getAllByRole("button");
+    expect(links).toHaveLength(1);
+    fireEvent.click(links[0]);
+    expect(openFile).toHaveBeenCalledWith("apps/web/lib/utils.ts");
+  });
+
+  it("splits a comma-joined multi-file read into one link per file", () => {
+    const openFile = vi.fn();
+    render(
+      <ToolReadMessage
+        comment={readComment(
+          "deployments/values.backupprod.yaml:1-80,deployments/values.au-backupprod.yaml:1-80",
+        )}
+        onOpenFile={openFile}
+      />,
+    );
+
+    expect(screen.getByText("deployments/values.backupprod.yaml")).toBeTruthy();
+    expect(screen.getByText("deployments/values.au-backupprod.yaml")).toBeTruthy();
+
+    // Each link opens its bare path (no embedded line numbers).
+    fireEvent.click(screen.getByText("deployments/values.au-backupprod.yaml"));
+    expect(openFile).toHaveBeenCalledWith("deployments/values.au-backupprod.yaml");
+    expect(openFile).not.toHaveBeenCalledWith("deployments/values.au-backupprod.yaml:1-80");
+  });
+});

--- a/apps/web/components/task/chat/messages/tool-read-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-read-message.tsx
@@ -8,6 +8,7 @@ import type { Message } from "@/lib/types/http";
 import { ExpandableRow } from "./expandable-row";
 import { useExpandState } from "./use-expand-state";
 import { useOpenFileAtLine } from "@/hooks/use-file-editors";
+import { splitReadFiles, type ReadFileRef } from "@/lib/read-selector";
 
 type ReadFileOutput = {
   content?: string;
@@ -75,6 +76,34 @@ function parseReadMetadata(comment: Message) {
   return { status, readOutput, filePath, startLine, lineRange, hasOutput, isSuccess };
 }
 
+// ReadFileLink renders one openable file link plus its line-range badge. Used
+// for each file when a single read references several comma-joined files; the
+// per-file startLine drives the scroll-to-line on open.
+function ReadFileLink({
+  file,
+  worktreePath,
+  onOpenFile,
+}: {
+  file: ReadFileRef;
+  worktreePath?: string;
+  onOpenFile?: (path: string) => void;
+}) {
+  const handleOpenFile = useOpenFileAtLine(onOpenFile, file.startLine, worktreePath);
+  const lineRange = formatLineRange(file.startLine, file.lineCount);
+  return (
+    <span className="inline-flex items-baseline min-w-0">
+      <FilePathButton
+        filePath={file.path}
+        worktreePath={worktreePath}
+        onOpenFile={onOpenFile ? handleOpenFile : undefined}
+      />
+      {lineRange && (
+        <span className="font-mono text-xs text-muted-foreground/70 shrink-0">{lineRange}</span>
+      )}
+    </span>
+  );
+}
+
 // ToolReadMessage renders a read tool call: the file link, line-range badge, and
 // the (expandable) read output.
 export const ToolReadMessage = memo(function ToolReadMessage({
@@ -87,6 +116,8 @@ export const ToolReadMessage = memo(function ToolReadMessage({
   const autoExpanded = status === "running";
   const { isExpanded, handleToggle } = useExpandState(status, autoExpanded);
   const handleOpenFile = useOpenFileAtLine(onOpenFile, startLine, worktreePath);
+  // splitReadFiles is pure and cheap; the React Compiler memoizes the render.
+  const multiFiles = filePath ? splitReadFiles(filePath) : [];
 
   return (
     <ExpandableRow
@@ -99,20 +130,32 @@ export const ToolReadMessage = memo(function ToolReadMessage({
             </span>
             {!isSuccess && <ReadStatusIcon status={status} />}
           </span>
-          {filePath && (
-            <span className="inline-flex items-baseline min-w-0">
-              <FilePathButton
-                filePath={filePath}
-                worktreePath={worktreePath}
-                onOpenFile={onOpenFile ? handleOpenFile : undefined}
-              />
-              {lineRange && (
-                <span className="font-mono text-xs text-muted-foreground/70 shrink-0">
-                  {lineRange}
-                </span>
-              )}
-            </span>
-          )}
+          {filePath &&
+            (multiFiles.length > 1 ? (
+              <span className="inline-flex flex-wrap items-baseline gap-x-1 min-w-0">
+                {multiFiles.map((file, idx) => (
+                  <span key={`${file.path}-${idx}`} className="inline-flex items-baseline min-w-0">
+                    <ReadFileLink file={file} worktreePath={worktreePath} onOpenFile={onOpenFile} />
+                    {idx < multiFiles.length - 1 && (
+                      <span className="text-muted-foreground/50">,</span>
+                    )}
+                  </span>
+                ))}
+              </span>
+            ) : (
+              <span className="inline-flex items-baseline min-w-0">
+                <FilePathButton
+                  filePath={filePath}
+                  worktreePath={worktreePath}
+                  onOpenFile={onOpenFile ? handleOpenFile : undefined}
+                />
+                {lineRange && (
+                  <span className="font-mono text-xs text-muted-foreground/70 shrink-0">
+                    {lineRange}
+                  </span>
+                )}
+              </span>
+            ))}
           {readOutput?.truncated && (
             <span className="text-xs text-amber-500/80 shrink-0">(truncated)</span>
           )}

--- a/apps/web/components/task/chat/messages/tool-read-message.tsx
+++ b/apps/web/components/task/chat/messages/tool-read-message.tsx
@@ -69,11 +69,11 @@ function parseReadMetadata(comment: Message) {
   const readFile = metadata?.normalized?.read_file;
   const readOutput = readFile?.output;
   const filePath = readFile?.file_path;
-  const startLine = readFile?.offset;
-  const lineRange = formatLineRange(readFile?.offset, readFile?.limit);
+  const offset = readFile?.offset;
+  const limit = readFile?.limit;
   const hasOutput = !!readOutput?.content;
   const isSuccess = status === "complete";
-  return { status, readOutput, filePath, startLine, lineRange, hasOutput, isSuccess };
+  return { status, readOutput, filePath, offset, limit, hasOutput, isSuccess };
 }
 
 // ReadFileLink renders one openable file link plus its line-range badge. Used
@@ -111,13 +111,26 @@ export const ToolReadMessage = memo(function ToolReadMessage({
   worktreePath,
   onOpenFile,
 }: ToolReadMessageProps) {
-  const { status, readOutput, filePath, startLine, lineRange, hasOutput, isSuccess } =
+  const { status, readOutput, filePath, offset, limit, hasOutput, isSuccess } =
     parseReadMetadata(comment);
   const autoExpanded = status === "running";
   const { isExpanded, handleToggle } = useExpandState(status, autoExpanded);
-  const handleOpenFile = useOpenFileAtLine(onOpenFile, startLine, worktreePath);
-  // splitReadFiles is pure and cheap; the React Compiler memoizes the render.
-  const multiFiles = filePath ? splitReadFiles(filePath) : [];
+  // splitReadFiles (pure, cheap — the React Compiler memoizes) yields the clean,
+  // openable path + parsed range for every file. This also fixes legacy/raw
+  // reads whose selector is still glued to the path ("foo.sh:88-137"). For a
+  // single file the backend may instead carry the range in offset/limit, so
+  // merge that in as a fallback.
+  const files = filePath ? splitReadFiles(filePath) : [];
+  const resolvedFiles =
+    files.length === 1
+      ? [
+          {
+            path: files[0].path,
+            startLine: files[0].startLine || offset || 0,
+            lineCount: files[0].lineCount || limit || 0,
+          },
+        ]
+      : files;
 
   return (
     <ExpandableRow
@@ -130,32 +143,18 @@ export const ToolReadMessage = memo(function ToolReadMessage({
             </span>
             {!isSuccess && <ReadStatusIcon status={status} />}
           </span>
-          {filePath &&
-            (multiFiles.length > 1 ? (
-              <span className="inline-flex flex-wrap items-baseline gap-x-1 min-w-0">
-                {multiFiles.map((file, idx) => (
-                  <span key={`${file.path}-${idx}`} className="inline-flex items-baseline min-w-0">
-                    <ReadFileLink file={file} worktreePath={worktreePath} onOpenFile={onOpenFile} />
-                    {idx < multiFiles.length - 1 && (
-                      <span className="text-muted-foreground/50">,</span>
-                    )}
-                  </span>
-                ))}
-              </span>
-            ) : (
-              <span className="inline-flex items-baseline min-w-0">
-                <FilePathButton
-                  filePath={filePath}
-                  worktreePath={worktreePath}
-                  onOpenFile={onOpenFile ? handleOpenFile : undefined}
-                />
-                {lineRange && (
-                  <span className="font-mono text-xs text-muted-foreground/70 shrink-0">
-                    {lineRange}
-                  </span>
-                )}
-              </span>
-            ))}
+          {filePath && (
+            <span className="inline-flex flex-wrap items-baseline gap-x-1 min-w-0">
+              {resolvedFiles.map((file, idx) => (
+                <span key={`${file.path}-${idx}`} className="inline-flex items-baseline min-w-0">
+                  <ReadFileLink file={file} worktreePath={worktreePath} onOpenFile={onOpenFile} />
+                  {idx < resolvedFiles.length - 1 && (
+                    <span className="text-muted-foreground/50">,</span>
+                  )}
+                </span>
+              ))}
+            </span>
+          )}
           {readOutput?.truncated && (
             <span className="text-xs text-amber-500/80 shrink-0">(truncated)</span>
           )}

--- a/apps/web/e2e/tests/task/chat-read-multi-file.spec.ts
+++ b/apps/web/e2e/tests/task/chat-read-multi-file.spec.ts
@@ -1,0 +1,88 @@
+// Regression guard for multi-file agent read links. OMP can read several
+// comma-joined files in one read call ("a.ts:1-40,b.ts:1-40"); the backend keeps
+// that path raw and the chat read card must split it into one openable link per
+// file (selector excluded) instead of a single combined, un-openable link that
+// fails with "file not found". Companion to the single-file open-and-scroll
+// coverage in mobile-file-viewer.spec.ts.
+import path from "node:path";
+import { test, expect } from "../../fixtures/test-base";
+import { GitHelper, makeGitEnv, createStandardProfile } from "../../helpers/git-helper";
+import { SessionPage } from "../../pages/session-page";
+
+test.describe("Chat multi-file read links", () => {
+  test("splits a comma-joined read into one openable link per file", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(90_000);
+
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const fileA = `alpha-${suffix}.ts`;
+    const fileB = `beta-${suffix}.ts`;
+    const git = new GitHelper(
+      path.join(backend.tmpDir, "repos", "e2e-repo"),
+      makeGitEnv(backend.tmpDir),
+    );
+    git.createFile(fileA, 'export const alpha = "alpha";');
+    git.createFile(fileB, 'export const beta = "beta";');
+    git.stageAll();
+    git.commit(`add ${fileA} and ${fileB}`);
+
+    const profile = await createStandardProfile(apiClient, `multi-read-${Date.now()}`);
+    // `e2e:message(...)` emits a single non-activity text message, so the seeded
+    // read card is the only activity message and renders as a standalone card.
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Chat Multi-File Read",
+      profile.id,
+      {
+        description: 'e2e:message("ready")',
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+
+    // Seed a read card whose file_path bundles two files with line selectors,
+    // exactly as the backend stores a multi-file omp read.
+    await apiClient.seedSessionMessage(task.session_id, {
+      type: "tool_read",
+      content: "Read files",
+      metadata: {
+        status: "complete",
+        tool_call_id: "tc-multi-file-read",
+        normalized: {
+          read_file: {
+            file_path: `${fileA}:1-40,${fileB}:1-40`,
+            output: { content: 'export const alpha = "alpha";', line_count: 40 },
+          },
+        },
+      },
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 45_000 });
+
+    // Each file is its own openable link (FilePathButton renders the bare path as
+    // both the title and the button text) — never a single combined link.
+    const chat = session.activeChat();
+    const linkA = chat.locator(`button[title="${fileA}"]`);
+    const linkB = chat.locator(`button[title="${fileB}"]`);
+    await expect(linkA).toBeVisible({ timeout: 15_000 });
+    await expect(linkB).toBeVisible({ timeout: 15_000 });
+    // The combined path with embedded line numbers must NOT be a link.
+    await expect(chat.locator(`button[title="${fileA}:1-40,${fileB}:1-40"]`)).toHaveCount(0);
+
+    // Clicking the second link opens its bare path in the editor (the original
+    // bug failed here with "file not found" because the line numbers stayed on
+    // the path).
+    await linkB.click();
+    await expect(testPage.getByTestId("preview-tab-file-editor")).toBeVisible({ timeout: 15_000 });
+    await expect(testPage.locator(".dv-tab", { hasText: fileB })).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/web/lib/read-selector.test.ts
+++ b/apps/web/lib/read-selector.test.ts
@@ -70,6 +70,32 @@ describe("splitReadFiles", () => {
     expect(splitReadFiles("a,b/foo.go:1-80")).toEqual([ref("a,b/foo.go", 1, 80)]);
   });
 
+  it("splits the hyphenated multi-file example each with its own range", () => {
+    // The hyphens in "tailscale-ingress-extras" must not be mistaken for a line
+    // range separator when deciding a segment is a new file.
+    expect(
+      splitReadFiles(
+        "deployments/tailscale-ingress-extras/values.prod.yaml:1-180,deployments/tailscale-ingress-extras/values.staging.yaml:1-180",
+      ),
+    ).toEqual([
+      ref("deployments/tailscale-ingress-extras/values.prod.yaml", 1, 180),
+      ref("deployments/tailscale-ingress-extras/values.staging.yaml", 1, 180),
+    ]);
+  });
+
+  it("splits a legacy half-stripped multi-file path (trailing file's range moved to offset)", () => {
+    // Pre-fix backend stored the bundle with only the LAST file's range stripped;
+    // both files must still split into openable links.
+    expect(
+      splitReadFiles(
+        "deployments/tailscale-ingress-extras/values.prod.yaml:1-180,deployments/tailscale-ingress-extras/values.staging.yaml",
+      ),
+    ).toEqual([
+      ref("deployments/tailscale-ingress-extras/values.prod.yaml", 1, 180),
+      ref("deployments/tailscale-ingress-extras/values.staging.yaml"),
+    ]);
+  });
+
   it("falls back to a single entry when a segment is not file-like", () => {
     // "5" alone is a line spec, not a file, so this is not a real multi-file read.
     expect(splitReadFiles("main.go:1,5")).toEqual([ref("main.go", 1)]);

--- a/apps/web/lib/read-selector.test.ts
+++ b/apps/web/lib/read-selector.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { splitReadFiles, type ReadFileRef } from "./read-selector";
+
+const ref = (path: string, startLine = 0, lineCount = 0): ReadFileRef => ({
+  path,
+  startLine,
+  lineCount,
+});
+
+describe("splitReadFiles", () => {
+  // Single-file inputs must behave exactly like the Go `Split`: one entry with
+  // the selector stripped and the range parsed.
+  it.each([
+    ["no selector", "config.json", [ref("config.json")]],
+    ["single line", "apps/web/lib/utils.ts:50", [ref("apps/web/lib/utils.ts", 50)]],
+    ["open-ended range", "main.go:50-", [ref("main.go", 50)]],
+    [
+      "closed range",
+      "apps/backend/internal/sentry/handlers.go:43-94",
+      [ref("apps/backend/internal/sentry/handlers.go", 43, 52)],
+    ],
+    ["plus span", "main.go:50+150", [ref("main.go", 50, 150)]],
+    ["multi-range stays one file", "main.go:5-16,960-973", [ref("main.go", 5, 12)]],
+    ["raw mode", "main.go:raw", [ref("main.go")]],
+    ["range then raw combo", "main.go:2-4:raw", [ref("main.go", 2, 3)]],
+    [
+      "windows absolute",
+      "C:\\Users\\me\\handlers.go:43-94",
+      [ref("C:\\Users\\me\\handlers.go", 43, 52)],
+    ],
+    ["no extension single line", "Makefile:10", [ref("Makefile", 10)]],
+  ])("keeps %s as a single file", (_name, raw, want) => {
+    expect(splitReadFiles(raw as string)).toEqual(want);
+  });
+
+  it("splits two comma-joined files each with its own range", () => {
+    expect(
+      splitReadFiles(
+        "deployments/cluster-tools/values.backupprod.yaml:1-80,deployments/cluster-tools/values.au-backupprod.yaml:1-80",
+      ),
+    ).toEqual([
+      ref("deployments/cluster-tools/values.backupprod.yaml", 1, 80),
+      ref("deployments/cluster-tools/values.au-backupprod.yaml", 1, 80),
+    ]);
+  });
+
+  it("splits two bare-extension files", () => {
+    expect(splitReadFiles("a.go:1,b.go:2")).toEqual([ref("a.go", 1), ref("b.go", 2)]);
+  });
+
+  it("attaches a trailing multi-range to the first file, not a new file", () => {
+    expect(splitReadFiles("a.go:5-16,40-80,b.go:10")).toEqual([
+      ref("a.go", 5, 12),
+      ref("b.go", 10),
+    ]);
+  });
+
+  it("splits files carrying mode selectors", () => {
+    expect(splitReadFiles("a.go:2-4:raw,b.go:raw")).toEqual([ref("a.go", 2, 3), ref("b.go")]);
+  });
+
+  it("keeps a second file openable even without a range", () => {
+    expect(splitReadFiles("a/x.yaml:1-80,b/y.yaml")).toEqual([
+      ref("a/x.yaml", 1, 80),
+      ref("b/y.yaml"),
+    ]);
+  });
+
+  it("treats a comma inside a directory name as a single file", () => {
+    expect(splitReadFiles("a,b/foo.go:1-80")).toEqual([ref("a,b/foo.go", 1, 80)]);
+  });
+
+  it("falls back to a single entry when a segment is not file-like", () => {
+    // "5" alone is a line spec, not a file, so this is not a real multi-file read.
+    expect(splitReadFiles("main.go:1,5")).toEqual([ref("main.go", 1)]);
+  });
+});

--- a/apps/web/lib/read-selector.test.ts
+++ b/apps/web/lib/read-selector.test.ts
@@ -100,4 +100,24 @@ describe("splitReadFiles", () => {
     // "5" alone is a line spec, not a file, so this is not a real multi-file read.
     expect(splitReadFiles("main.go:1,5")).toEqual([ref("main.go", 1)]);
   });
+
+  it("treats a comma inside a filename as a single file", () => {
+    // "src/foo" is file-like only via its separator (no selector, no extension),
+    // so it is not a file boundary and the whole path stays one entry.
+    expect(splitReadFiles("src/foo,bar.go:1-20")).toEqual([ref("src/foo,bar.go", 1, 20)]);
+  });
+
+  it("still splits two files when the first carries an extension", () => {
+    expect(splitReadFiles("src/a.go,src/b.go:1-20")).toEqual([
+      ref("src/a.go"),
+      ref("src/b.go", 1, 20),
+    ]);
+  });
+
+  it("still splits an extensionless first file that carries a selector", () => {
+    expect(splitReadFiles("Makefile:10,foo.go:20")).toEqual([
+      ref("Makefile", 10),
+      ref("foo.go", 20),
+    ]);
+  });
 });

--- a/apps/web/lib/read-selector.ts
+++ b/apps/web/lib/read-selector.ts
@@ -1,0 +1,126 @@
+// Mirror of the Go `readselector` package
+// (apps/backend/internal/common/readselector). OMP's read tool embeds a
+// line/range/mode selector in the path ("foo.go:43-94") and can reference
+// several comma-joined files in a single read ("a.yaml:1-80,b.yaml:1-80"). The
+// backend keeps a multi-file read's path raw; this splits it into one openable
+// entry per file (selector stripped, line range parsed) so the chat can render a
+// separate link per file. Keep in sync with the Go implementation and its tests.
+
+export type ReadFileRef = {
+  /** Bare, openable file path with any read selector stripped. */
+  path: string;
+  /** 1-based first line referenced by the selector, or 0 when none. */
+  startLine: number;
+  /** Contiguous line span for a closed range ("N-M" / "N+K"), else 0. */
+  lineCount: number;
+};
+
+type LineSpec = { startLine: number; lineCount: number };
+
+// atoi mirrors Go strconv.Atoi for our needs: an optionally-signed decimal
+// integer only (no hex, exponent, or surrounding whitespace).
+function atoi(s: string): number | null {
+  if (!/^-?\d+$/.test(s)) return null;
+  return Number(s);
+}
+
+// parseLineSpec parses a single line spec: "N", "N-", "N-M", or "N+K".
+function parseLineSpec(seg: string): LineSpec | null {
+  const plus = seg.indexOf("+");
+  if (plus >= 0) {
+    const start = atoi(seg.slice(0, plus));
+    const count = atoi(seg.slice(plus + 1));
+    if (start === null || count === null || start <= 0 || count < 0) return null;
+    return { startLine: start, lineCount: count };
+  }
+  const dash = seg.indexOf("-");
+  if (dash >= 0) {
+    const start = atoi(seg.slice(0, dash));
+    if (start === null || start <= 0) return null;
+    const rest = seg.slice(dash + 1);
+    if (rest === "") return { startLine: start, lineCount: 0 }; // "N-" open-ended
+    const end = atoi(rest);
+    if (end === null || end < start) return null;
+    return { startLine: start, lineCount: end - start + 1 };
+  }
+  const start = atoi(seg);
+  if (start === null || start <= 0) return null;
+  return { startLine: start, lineCount: 0 };
+}
+
+// parseLineSpecList parses a comma-separated list ("5-16,960-973"); the first
+// spec drives the result.
+function parseLineSpecList(part: string): LineSpec | null {
+  const segs = part.split(",");
+  let first: LineSpec | null = null;
+  for (let i = 0; i < segs.length; i++) {
+    const spec = parseLineSpec(segs[i] ?? "");
+    if (!spec) return null;
+    if (i === 0) first = spec;
+  }
+  return first;
+}
+
+// parseReadSelector validates the selector tail (everything after the file's
+// first ':'). Parts joined by ':' accept combos such as "2-4:raw"; the first
+// line-spec encountered drives the range. Returns a zero range (still valid) for
+// mode-only selectors like "raw".
+function parseReadSelector(suffix: string): LineSpec | null {
+  let result: LineSpec = { startLine: 0, lineCount: 0 };
+  let gotLine = false;
+  for (const part of suffix.split(":")) {
+    if (part === "raw" || part === "conflicts") continue;
+    const spec = parseLineSpecList(part);
+    if (!spec) return null;
+    if (!gotLine) {
+      result = spec;
+      gotLine = true;
+    }
+  }
+  return result;
+}
+
+// splitOne mirrors Go readselector.Split for a single file reference. A colon in
+// the file's final segment that isn't a Windows drive letter ("C:\...") begins
+// the selector.
+function splitOne(raw: string): ReadFileRef {
+  const unchanged: ReadFileRef = { path: raw, startLine: 0, lineCount: 0 };
+  let lastSep = raw.lastIndexOf("/");
+  const back = raw.lastIndexOf("\\");
+  if (back > lastSep) lastSep = back;
+  const rel = raw.slice(lastSep + 1).indexOf(":");
+  if (rel < 0) return unchanged;
+  const colon = lastSep + 1 + rel;
+  const isWindowsDrivePrefix = colon === 1 && raw.length >= 2 && /^[A-Za-z]$/.test(raw[0] ?? "");
+  if (lastSep < 0 && isWindowsDrivePrefix) return unchanged;
+  const base = raw.slice(0, colon);
+  const suffix = raw.slice(colon + 1);
+  if (base === "" || suffix === "") return unchanged;
+  const parsed = parseReadSelector(suffix);
+  if (!parsed) return unchanged;
+  return { path: base, startLine: parsed.startLine, lineCount: parsed.lineCount };
+}
+
+/**
+ * Split an omp read path that may reference several comma-joined files into one
+ * {@link ReadFileRef} per file. A single file (with or without a multi-range
+ * selector) returns exactly one entry identical to the Go `Split`; multiple
+ * files are only reported when every segment yields a real file path (one with a
+ * path separator or a filename extension), so a comma living inside a directory
+ * name is preserved as a single entry.
+ */
+export function splitReadFiles(raw: string): ReadFileRef[] {
+  const parts = raw.split(",");
+  const files: ReadFileRef[] = [];
+  parts.forEach((part, i) => {
+    // A bare line-spec list or mode keyword is an extra range of the preceding
+    // file, not a new file.
+    const isContinuationRange =
+      part === "raw" || part === "conflicts" || parseLineSpecList(part) !== null;
+    if (i > 0 && isContinuationRange) return;
+    files.push(splitOne(part));
+  });
+  const allFileish = files.every((f) => /[/\\]/.test(f.path) || f.path.includes("."));
+  if (files.length > 1 && allFileish) return files;
+  return [splitOne(raw)];
+}

--- a/apps/web/lib/read-selector.ts
+++ b/apps/web/lib/read-selector.ts
@@ -101,26 +101,40 @@ function splitOne(raw: string): ReadFileRef {
   return { path: base, startLine: parsed.startLine, lineCount: parsed.lineCount };
 }
 
+// isStrongFile reports whether a comma segment is a self-contained file
+// reference: it carries a read selector (splitOne strips it) or its basename has
+// an extension. A segment that looks fileish only via a path separator ("src/foo"
+// in the single filename "src/foo,bar.go") is NOT a file boundary, so a comma
+// inside a filename is not mistaken for a multi-file bundle.
+function isStrongFile(part: string): boolean {
+  if (splitOne(part).path !== part) return true;
+  const sep = Math.max(part.lastIndexOf("/"), part.lastIndexOf("\\"));
+  const base = sep >= 0 ? part.slice(sep + 1) : part;
+  return base.includes(".");
+}
+
 /**
  * Split an omp read path that may reference several comma-joined files into one
  * {@link ReadFileRef} per file. A single file (with or without a multi-range
  * selector) returns exactly one entry identical to the Go `Split`; multiple
- * files are only reported when every segment yields a real file path (one with a
- * path separator or a filename extension), so a comma living inside a directory
- * name is preserved as a single entry.
+ * files are only reported when every segment is a self-contained file reference
+ * (it carries a read selector or its basename has an extension), so a comma
+ * inside a directory name ("a,b/foo.go") or a filename ("src/foo,bar.go:1-20")
+ * stays a single entry rather than splitting into phantom files.
  */
 export function splitReadFiles(raw: string): ReadFileRef[] {
   const parts = raw.split(",");
   const files: ReadFileRef[] = [];
+  let multi = true;
   parts.forEach((part, i) => {
     // A bare line-spec list or mode keyword is an extra range of the preceding
     // file, not a new file.
     const isContinuationRange =
       part === "raw" || part === "conflicts" || parseLineSpecList(part) !== null;
     if (i > 0 && isContinuationRange) return;
+    if (!isStrongFile(part)) multi = false;
     files.push(splitOne(part));
   });
-  const allFileish = files.every((f) => /[/\\]/.test(f.path) || f.path.includes("."));
-  if (files.length > 1 && allFileish) return files;
+  if (multi && files.length > 1) return files;
   return [splitOne(raw)];
 }


### PR DESCRIPTION
Agent (omp) reads can bundle several comma-joined files in one read call (e.g. `a.yaml:1-180,b.yaml:1-180`), and legacy reads still carry a line-range selector on the path (`foo.sh:88-137`); both rendered as a single un-openable chat link that failed with "file not found". Each referenced file now renders as its own link that opens the bare path and scrolls to its line.

## Important Changes

- `readselector.SplitFiles` (Go) parses a read path into one entry per file; a bare trailing line-spec stays an extra range of the preceding file, and multiple files are only reported when every segment looks like a real file, so a comma inside a directory name is preserved.
- The ACP normalizer keeps a multi-file read's path raw (offset/limit 0) so the UI can split it; single-file reads are normalized to a clean path + offset/limit as before.
- The chat read card derives the clean, openable path and line range for every file via a frontend `splitReadFiles` mirror, fixing both multi-file bundles and legacy/raw single-file selectors regardless of whether the backend already cleaned the path.

## Validation

- `go test ./internal/common/readselector/ ./internal/agentctl/server/adapter/transport/acp/` — pass
- `make lint` (backend golangci-lint) — 0 issues
- Web: `tsc --noEmit` clean, `eslint --max-warnings 0` clean, full `vitest run` — 424 files / 3558 tests pass
- Added unit (`read-selector`), component (`tool-read-message`), and Playwright e2e (`chat-read-multi-file.spec.ts`) coverage, including the real hyphenated-directory shape `deployments/tailscale-ingress-extras/values.prod.yaml:1-180,…/values.staging.yaml:1-180`

## Possible Improvements

Low risk. Multi-file splitting is gated on every segment looking file-like, so an unusual multi-file read whose first entry is an extensionless root file (e.g. `Makefile:1-10,src/foo.go:1-20`) falls back to a single link rather than splitting.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

