### PR TITLE
fix: focus changes panel on git updates

### DIFF
--- a/apps/web/components/task/changes-tab.tsx
+++ b/apps/web/components/task/changes-tab.tsx
@@ -100,6 +100,8 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
     if (!initializedRef.current) {
       if (gitStatusLoaded) initializedRef.current = true;
     } else if (increased) {
+      // The product behavior is to surface every new git update unless the
+      // changes panel shares a group with agent session panels.
       autoActivateChangesPanel();
     }
 

--- a/apps/web/components/task/changes-tab.tsx
+++ b/apps/web/components/task/changes-tab.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
+import {
+  DockviewDefaultTab,
+  type DockviewApi,
+  type IDockviewPanelHeaderProps,
+} from "dockview-react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -15,18 +19,20 @@ import { useDockviewStore } from "@/lib/state/dockview-store";
 import { cn } from "@kandev/ui/lib/utils";
 import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 
-/** Auto-activate the changes panel only when it lives in the right sidebar. */
+type DockviewPanel = NonNullable<ReturnType<DockviewApi["getPanel"]>>;
+
+function groupContainsAgentSessionPanel(panel: DockviewPanel): boolean {
+  return panel?.group.panels.some((p) => p.id === "chat" || p.id.startsWith("session:")) ?? false;
+}
+
+/** Auto-activate the changes panel unless it shares a group with agent sessions. */
 function autoActivateChangesPanel(): void {
-  const { api, rightTopGroupId } = useDockviewStore.getState();
+  const { api } = useDockviewStore.getState();
   if (!api) return;
 
   const panel = api.getPanel("changes");
-  // Only auto-focus when the panel is in the right sidebar.
-  // When it's in the center group (e.g. plan mode layout), never steal focus
-  // from the active chat/session panel.
-  if (panel && panel.group.id === rightTopGroupId) {
-    panel.api.setActive();
-  }
+  if (!panel || groupContainsAgentSessionPanel(panel)) return;
+  panel.api.setActive();
 }
 
 /**
@@ -79,13 +85,12 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
     const increased = totalCount > prev && totalCount > 0;
     const decreased = totalCount < prev;
 
-    // Auto-activate when changes appear for the first time (0 → N), but only
-    // after initial git data has settled.  gitStatusLoaded is false until the
-    // first WS git-status event arrives, guaranteeing data has loaded before we
-    // arm auto-activate (handles both page-refresh and clean-session cases).
+    // Auto-activate on real post-load updates, but only after initial git data
+    // has settled. gitStatusLoaded is false until the first WS git-status event
+    // arrives, guaranteeing existing changes on page refresh do not steal focus.
     if (!initializedRef.current) {
       if (gitStatusLoaded) initializedRef.current = true;
-    } else if (increased && prev === 0) {
+    } else if (increased) {
       autoActivateChangesPanel();
     }
 

--- a/apps/web/components/task/changes-tab.tsx
+++ b/apps/web/components/task/changes-tab.tsx
@@ -22,7 +22,7 @@ import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
 type DockviewPanel = NonNullable<ReturnType<DockviewApi["getPanel"]>>;
 
 function groupContainsAgentSessionPanel(panel: DockviewPanel): boolean {
-  return panel?.group.panels.some((p) => p.id === "chat" || p.id.startsWith("session:")) ?? false;
+  return panel.group.panels.some((p) => p.id === "chat" || p.id.startsWith("session:"));
 }
 
 /** Auto-activate the changes panel unless it shares a group with agent sessions. */
@@ -54,6 +54,7 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
 
   const prevTotalRef = useRef(totalCount);
   const seenCountRef = useRef(api.isActive ? totalCount : 0);
+  const activeSessionRef = useRef(activeSessionId);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Armed once we know the initial git data has settled. Until then, any
   // 0→N transition is treated as an initial load, not a real new change.
@@ -75,6 +76,13 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
 
   // React to totalCount changes: auto-activate, flash, badge
   useEffect(() => {
+    if (activeSessionRef.current !== activeSessionId) {
+      activeSessionRef.current = activeSessionId;
+      prevTotalRef.current = totalCount;
+      seenCountRef.current = api.isActive ? totalCount : 0;
+      initializedRef.current = false;
+    }
+
     if (api.isActive) {
       seenCountRef.current = totalCount;
     }
@@ -105,7 +113,7 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
       const unseen = Math.max(0, totalCount - seenCountRef.current);
       requestAnimationFrame(() => setBadgeCount(unseen));
     }
-  }, [totalCount, api, gitStatusLoaded]);
+  }, [totalCount, api, gitStatusLoaded, activeSessionId]);
 
   // Cleanup flash timer on unmount
   useEffect(() => {

--- a/apps/web/components/task/changes-tab.tsx
+++ b/apps/web/components/task/changes-tab.tsx
@@ -81,6 +81,7 @@ export function ChangesTab(props: IDockviewPanelHeaderProps) {
       prevTotalRef.current = totalCount;
       seenCountRef.current = api.isActive ? totalCount : 0;
       initializedRef.current = false;
+      setBadgeCount(0);
     }
 
     if (api.isActive) {

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -56,6 +56,27 @@ async function moveChangesToTerminalGroupAndFocusTerminal(testPage: Page) {
   });
 }
 
+async function moveChangesToChatGroupAndFocusChat(testPage: Page) {
+  await testPage.evaluate(() => {
+    type Group = { id: string };
+    type PanelApi = {
+      moveTo: (opts: { group: Group }) => void;
+      setActive: () => void;
+    };
+    type Panel = { id: string; api: PanelApi; group?: Group };
+    type Api = { panels: Panel[]; getPanel: (id: string) => Panel | undefined };
+    const dockview = (window as unknown as { __dockviewApi__?: Api }).__dockviewApi__;
+    const changes = dockview?.getPanel("changes");
+    const chat =
+      dockview?.getPanel("chat") ?? dockview?.panels.find((p) => p.id.startsWith("session:"));
+    if (!changes || !chat?.group) {
+      throw new Error("Dockview changes or chat panel was not available");
+    }
+    changes.api.moveTo({ group: chat.group });
+    chat.api.setActive();
+  });
+}
+
 test.describe("Changes panel focus behavior", () => {
   /**
    * Verifies the changes panel does NOT steal focus from the chat tab
@@ -126,12 +147,7 @@ test.describe("Changes panel focus behavior", () => {
     await expect(session.chat).toBeVisible({ timeout: 5_000 });
   });
 
-  /**
-   * Verifies the changes panel does NOT auto-focus when it is in the center
-   * group (e.g. plan mode layout). Even when new changes appear, the chat
-   * panel should stay focused.
-   */
-  test("changes panel does not auto-focus when in center group", async ({
+  test("changes panel does not auto-focus when grouped with agent session panels", async ({
     testPage,
     apiClient,
     seedData,
@@ -157,17 +173,13 @@ test.describe("Changes panel focus behavior", () => {
     const session = new SessionPage(testPage);
     await session.waitForLoad();
     await session.waitForChatIdle({ timeout: 30_000 });
+    await session.waitForDockviewReady();
 
-    // Toggle plan mode — this moves changes into the center group
-    await session.togglePlanMode();
-    await expect(session.planPanel).toBeVisible({ timeout: 10_000 });
+    await moveChangesToChatGroupAndFocusChat(testPage);
     await expect(session.chat).toBeVisible();
 
-    // Verify the chat/session tab is active, not changes
-    const changesTab = testPage.locator(".dv-default-tab:has-text('Changes')");
-    await expect(changesTab).not.toHaveClass(/dv-active-tab/, { timeout: 5_000 });
+    await expect(changesTab(testPage)).not.toHaveClass(/dv-active-tab/, { timeout: 5_000 });
 
-    // Create new changes — this would previously trigger auto-activate
     git.createFile("new-file.txt", "new content");
     git.stageAll();
     git.commit("new commit");
@@ -180,10 +192,8 @@ test.describe("Changes panel focus behavior", () => {
     // Wait a bit for any async auto-activate to fire
     await testPage.waitForTimeout(2_000);
 
-    // Changes tab should NOT have stolen focus
-    await expect(changesTab).not.toHaveClass(/dv-active-tab/, { timeout: 5_000 });
+    await expect(changesTab(testPage)).not.toHaveClass(/dv-active-tab/, { timeout: 5_000 });
 
-    // Chat should still be visible (active)
     await expect(session.chat).toBeVisible();
   });
 

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../../fixtures/test-base";
+import type { Page } from "@playwright/test";
 import { SessionPage } from "../../pages/session-page";
 import { makeGitEnv } from "../../helpers/git-helper";
 import fs from "node:fs";
@@ -27,6 +28,32 @@ class GitHelper {
   commit(message: string) {
     this.exec(`git commit -m "${message}"`);
   }
+}
+
+function changesTab(testPage: Page) {
+  return testPage.locator(".dv-tab", {
+    has: testPage.locator(".dv-default-tab").filter({ hasText: /^Changes/ }),
+  });
+}
+
+async function moveChangesToTerminalGroupAndFocusTerminal(testPage: Page) {
+  await testPage.evaluate(() => {
+    type Group = { id: string };
+    type PanelApi = {
+      moveTo: (opts: { group: Group }) => void;
+      setActive: () => void;
+    };
+    type Panel = { id: string; api: PanelApi; group?: Group };
+    type Api = { getPanel: (id: string) => Panel | undefined };
+    const dockview = (window as unknown as { __dockviewApi__?: Api }).__dockviewApi__;
+    const changes = dockview?.getPanel("changes");
+    const terminal = dockview?.getPanel("terminal-default");
+    if (!changes || !terminal?.group) {
+      throw new Error("Dockview changes or terminal panel was not available");
+    }
+    changes.api.moveTo({ group: terminal.group });
+    terminal.api.setActive();
+  });
 }
 
 test.describe("Changes panel focus behavior", () => {
@@ -158,5 +185,50 @@ test.describe("Changes panel focus behavior", () => {
 
     // Chat should still be visible (active)
     await expect(session.chat).toBeVisible();
+  });
+
+  test("new git updates focus the changes tab in its current non-agent group", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    test.setTimeout(90_000);
+
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    const gitEnv = makeGitEnv(backend.tmpDir);
+    const git = new GitHelper(repoDir, gitEnv);
+
+    const task = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Moved changes panel focus test",
+      seedData.agentProfileId,
+      {
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 30_000 });
+    await session.waitForDockviewReady();
+
+    git.createFile("first-change.txt", "one");
+    await expect(
+      testPage.locator(".dv-default-tab").filter({ hasText: /^Changes \(1\)$/ }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await moveChangesToTerminalGroupAndFocusTerminal(testPage);
+    await expect(changesTab(testPage)).not.toHaveClass(/dv-active-tab/, { timeout: 5_000 });
+
+    git.createFile("second-change.txt", "two");
+    await expect(
+      testPage.locator(".dv-default-tab").filter({ hasText: /^Changes \(2\)$/ }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(changesTab(testPage)).toHaveClass(/dv-active-tab/, { timeout: 5_000 });
+    await expect(session.changesFileRow("second-change.txt")).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
Changes panel updates were easy to miss when the tab lived outside the default right group or already had existing changes. Updated the focus rule so real git activity reveals the existing Changes panel unless it shares a group with agent session tabs.

## Validation

- `pnpm e2e:run tests/layout/changes-panel-focus.spec.ts -- --grep "new git updates focus"` failed before the fix and passed after.
- `pnpm e2e:run --no-build tests/layout/changes-panel-focus.spec.ts`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `make fmt && node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs && make typecheck && make test && make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->