### PR TITLE
fix: restore debug flag in Vite shell

### DIFF
--- a/apps/backend/cmd/kandev/helpers.go
+++ b/apps/backend/cmd/kandev/helpers.go
@@ -639,7 +639,7 @@ func webAppHandlerOptions(p routeParams) []webapp.HandlerOption {
 func bootPayload(ctx context.Context, req *http.Request, p routeParams, route webapp.RouteClassification) webapp.BootPayload {
 	payload := webapp.NewBootPayload(
 		route,
-		webapp.RuntimeConfig{APIPrefix: "/api/v1", WebSocketPath: "/ws"},
+		webapp.RuntimeConfig{APIPrefix: "/api/v1", WebSocketPath: "/ws", Debug: p.devMode},
 		bootInitialState(ctx, req, p, route),
 	)
 	payload.RouteData = bootRouteData(ctx, req, p, route)

--- a/apps/backend/cmd/kandev/helpers_test.go
+++ b/apps/backend/cmd/kandev/helpers_test.go
@@ -517,6 +517,27 @@ func TestBootRouteDataTasksUsesActiveWorkspaceCookie(t *testing.T) {
 	}
 }
 
+func TestBootPayloadIncludesDebugRuntimeWhenDevMode(t *testing.T) {
+	t.Parallel()
+
+	payload := bootPayload(context.Background(), nil, routeParams{devMode: true}, webapp.ClassifyRoute("/"))
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal payload: %v", err)
+	}
+	var decoded struct {
+		Runtime struct {
+			Debug bool `json:"debug"`
+		} `json:"runtime"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal payload: %v", err)
+	}
+	if !decoded.Runtime.Debug {
+		t.Fatal("runtime.debug = false, want true when backend devMode is enabled")
+	}
+}
+
 func TestBootRouteDataIntegrationRouteIncludesOnlyLocalContext(t *testing.T) {
 	taskSvc, workflowSvc := newBootStateTestServices(t)
 	ctx := context.Background()

--- a/apps/backend/internal/webapp/payload.go
+++ b/apps/backend/internal/webapp/payload.go
@@ -17,6 +17,7 @@ type BootPayload struct {
 type RuntimeConfig struct {
 	APIPrefix     string `json:"apiPrefix"`
 	WebSocketPath string `json:"webSocketPath"`
+	Debug         bool   `json:"debug,omitempty"`
 }
 
 // BootError is a serializable non-fatal boot-data error for partial hydration.

--- a/apps/backend/internal/webapp/shell.go
+++ b/apps/backend/internal/webapp/shell.go
@@ -8,6 +8,7 @@ import (
 )
 
 const bootPayloadGlobal = "window.__KANDEV_BOOT_PAYLOAD__"
+const debugGlobalAssignment = "window.__KANDEV_DEBUG=true;"
 const maxInt = int(^uint(0) >> 1)
 
 var headCloseTag = []byte("</head>")
@@ -42,8 +43,13 @@ func BootPayloadScript(payload BootPayload) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal boot payload: %w", err)
 	}
-	script := make([]byte, 0, bytesCapacity(len(data), len(bootPayloadGlobal), 32))
+	debugPrefix := ""
+	if payload.Runtime.Debug {
+		debugPrefix = debugGlobalAssignment
+	}
+	script := make([]byte, 0, bytesCapacity(len(data), len(debugPrefix), len(bootPayloadGlobal), 32))
 	script = append(script, "<script>"...)
+	script = append(script, debugPrefix...)
 	script = append(script, bootPayloadGlobal...)
 	script = append(script, "="...)
 	script = append(script, data...)

--- a/apps/backend/internal/webapp/shell_test.go
+++ b/apps/backend/internal/webapp/shell_test.go
@@ -60,6 +60,30 @@ func TestBootPayloadScriptEscapesScriptTerminators(t *testing.T) {
 	}
 }
 
+func TestBootPayloadScriptSetsDebugGlobalBeforeBootPayload(t *testing.T) {
+	t.Parallel()
+
+	payload := NewBootPayload(
+		ClassifyRoute("/"),
+		RuntimeConfig{Debug: true},
+		nil,
+	)
+
+	script, err := BootPayloadScript(payload)
+	if err != nil {
+		t.Fatalf("BootPayloadScript: %v", err)
+	}
+	got := string(script)
+	debugIdx := strings.Index(got, "window.__KANDEV_DEBUG=true;")
+	payloadIdx := strings.Index(got, bootPayloadGlobal)
+	if debugIdx < 0 {
+		t.Fatalf("script missing debug global assignment: %s", got)
+	}
+	if payloadIdx < 0 || debugIdx > payloadIdx {
+		t.Fatalf("debug global should be assigned before boot payload: %s", got)
+	}
+}
+
 func TestRenderShellPrependsScriptWhenHeadCloseIsMissing(t *testing.T) {
 	t.Parallel()
 

--- a/apps/web/e2e/scripts/run-e2e.sh
+++ b/apps/web/e2e/scripts/run-e2e.sh
@@ -71,7 +71,7 @@ clean_artifacts() {
 
 build_fe() {
   log "building Vite web assets"
-  ( cd "$REPO_ROOT/apps" && NEXT_PUBLIC_KANDEV_E2E_MOCK=true pnpm --filter @kandev/web build ) \
+  ( cd "$REPO_ROOT/apps" && pnpm --filter @kandev/web build ) \
     || die "FE build failed"
 }
 

--- a/apps/web/global.d.ts
+++ b/apps/web/global.d.ts
@@ -4,7 +4,7 @@ declare global {
   interface Window {
     // Port injection for dev mode (browser on web port, API on backend port)
     __KANDEV_API_PORT?: string;
-    // Debug mode flag (injected at runtime by layout.tsx)
+    // Debug mode flag (injected by the Go shell or derived from boot payload runtime config)
     __KANDEV_DEBUG?: boolean;
   }
 }

--- a/apps/web/src/boot-payload.test.ts
+++ b/apps/web/src/boot-payload.test.ts
@@ -57,6 +57,19 @@ describe("readBootPayload", () => {
 
     expect(readBootPayload(win).route?.params).toBeUndefined();
   });
+
+  it("enables the runtime debug global when boot payload debug is true", () => {
+    const win = {
+      __KANDEV_BOOT_PAYLOAD__: {
+        runtime: {
+          debug: true,
+        },
+      },
+    } as unknown as Window;
+
+    expect(readBootPayload(win).runtime?.debug).toBe(true);
+    expect(win.__KANDEV_DEBUG).toBe(true);
+  });
 });
 
 describe("loadBootPayload", () => {

--- a/apps/web/src/boot-payload.ts
+++ b/apps/web/src/boot-payload.ts
@@ -13,6 +13,7 @@ export type BootRoute = {
 export type BootRuntime = {
   apiPrefix?: string;
   webSocketPath?: string;
+  debug?: boolean;
 };
 
 export type BootRouteData = {
@@ -43,16 +44,21 @@ export type BootPayload = {
 
 type BootWindow = Window & {
   __KANDEV_BOOT_PAYLOAD__?: unknown;
+  __KANDEV_DEBUG?: boolean;
 };
 
 export function readBootPayload(win: Window = window): BootPayload {
   const payload = (win as BootWindow).__KANDEV_BOOT_PAYLOAD__;
   if (!isRecord(payload)) return { initialState: {} };
+  const runtime = isRecord(payload.runtime) ? readRuntime(payload.runtime) : undefined;
+  if (runtime?.debug) {
+    (win as BootWindow).__KANDEV_DEBUG = true;
+  }
 
   return {
     version: typeof payload.version === "number" ? payload.version : undefined,
     route: isRecord(payload.route) ? readRoute(payload.route) : undefined,
-    runtime: isRecord(payload.runtime) ? readRuntime(payload.runtime) : undefined,
+    runtime,
     initialState: isRecord(payload.initialState) ? (payload.initialState as Partial<AppState>) : {},
     routeData: isRecord(payload.routeData) ? (payload.routeData as BootRouteData) : undefined,
   };
@@ -94,6 +100,7 @@ function readRuntime(value: Record<string, unknown>): BootRuntime {
   return {
     apiPrefix: readString(value.apiPrefix),
     webSocketPath: readString(value.webSocketPath),
+    debug: value.debug === true ? true : undefined,
   };
 }
 


### PR DESCRIPTION
`make start-debug` enabled backend debug mode after the Vite migration, but the Go-served SPA no longer exposed that state to browser code. The shell now propagates runtime debug state before the Vite app evaluates, and the stale Next-era E2E env flag is removed.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `go test ./internal/webapp ./cmd/kandev`
- `pnpm test -- --run src/boot-payload.test.ts`
- `pnpm typecheck` from `apps/web`
- `pnpm lint -- src/boot-payload.ts src/boot-payload.test.ts`
- `rg -n "NEXT_PUBLIC_" apps/web apps/cli docs -S` returned no matches

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->