### PR TITLE
fix: keep start-agent tasks scheduling

### DIFF
--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -854,6 +854,14 @@ func (h *TaskHandlers) startAgentForNewTask(
 	}
 	sessionID := prepResp.SessionID
 	response.TaskSessionID = sessionID
+	if updatedTask, updateErr := h.service.UpdateTaskState(ctx, taskID, v1.TaskStateScheduling); updateErr != nil {
+		h.logger.Warn("failed to mark task scheduling after preparing start session",
+			zap.Error(updateErr),
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID))
+	} else {
+		response.State = updatedTask.State
+	}
 
 	// Launch agent asynchronously so the HTTP request can return immediately.
 	// The frontend will receive WebSocket updates when the agent actually starts.

--- a/apps/backend/internal/task/handlers/task_http_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers_test.go
@@ -148,6 +148,21 @@ func (m *captureCreateTaskRepo) CreateTask(_ context.Context, task *models.Task)
 	return nil
 }
 
+func (m *captureCreateTaskRepo) GetTask(_ context.Context, id string) (*models.Task, error) {
+	if m.captured == nil || m.captured.ID != id {
+		return nil, errors.New("task not found")
+	}
+	return m.captured, nil
+}
+
+func (m *captureCreateTaskRepo) UpdateTaskState(_ context.Context, id string, state v1.TaskState) error {
+	if m.captured == nil || m.captured.ID != id {
+		return errors.New("task not found")
+	}
+	m.captured.State = state
+	return nil
+}
+
 // TestHTTPCreateTask_ProjectIDReachesOfficePath guards the wiring that broke
 // the office "New Task" dialog: when the request body sets project_id (and
 // omits workflow_id), the handler must forward it to the service so
@@ -184,6 +199,41 @@ func TestHTTPCreateTask_ProjectIDReachesOfficePath(t *testing.T) {
 	require.NotNil(t, repo.captured, "service.CreateTask was not called")
 	assert.Equal(t, "proj-1", repo.captured.ProjectID)
 	assert.Equal(t, "wf-office", repo.captured.WorkflowID, "office workflow should be auto-resolved")
+}
+
+func TestHTTPCreateTask_StartAgentReturnsSchedulingTask(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	log := newTestLogger(t)
+
+	repo := &captureCreateTaskRepo{}
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	h := &TaskHandlers{service: svc, orchestrator: &captureOrchestrator{}, logger: log}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(`{
+		"workspace_id": "ws-1",
+		"workflow_id": "wf-1",
+		"workflow_step_id": "step-1",
+		"title": "Boot an agent",
+		"description": "Do the thing",
+		"priority": "medium",
+		"agent_profile_id": "profile-1",
+		"start_agent": true
+	}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.httpCreateTask(c)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	assert.Equal(t, v1.TaskStateScheduling, repo.captured.State)
+	assert.Contains(t, rec.Body.String(), `"state":"SCHEDULING"`)
 }
 
 func TestValidateAttachments_DeliveryMode(t *testing.T) {

--- a/apps/backend/internal/task/handlers/task_http_handlers_test.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -27,15 +28,22 @@ import (
 // LaunchSession to short-circuit the two-phase create flow before its async
 // start goroutine spawns (keeping assertions race-free).
 type captureOrchestrator struct {
-	mu       sync.Mutex
-	requests []*orchestrator.LaunchSessionRequest
-	prepErr  error
+	mu                 sync.Mutex
+	requests           []*orchestrator.LaunchSessionRequest
+	prepErr            error
+	startCreatedCalled chan struct{}
 }
 
 func (m *captureOrchestrator) LaunchSession(_ context.Context, req *orchestrator.LaunchSessionRequest) (*orchestrator.LaunchSessionResponse, error) {
 	m.mu.Lock()
 	m.requests = append(m.requests, req)
 	m.mu.Unlock()
+	if req.Intent == orchestrator.IntentStartCreated && m.startCreatedCalled != nil {
+		select {
+		case m.startCreatedCalled <- struct{}{}:
+		default:
+		}
+	}
 	if m.prepErr != nil {
 		return nil, m.prepErr
 	}
@@ -136,7 +144,8 @@ func TestHttpStartConfigChat_SetsDeferredStart(t *testing.T) {
 
 type captureCreateTaskRepo struct {
 	mockRepository
-	captured *models.Task
+	captured       *models.Task
+	updateStateErr error
 }
 
 func (m *captureCreateTaskRepo) GetWorkspaceTaskPrefix(_ context.Context, _ string) (string, string, error) {
@@ -158,6 +167,9 @@ func (m *captureCreateTaskRepo) GetTask(_ context.Context, id string) (*models.T
 func (m *captureCreateTaskRepo) UpdateTaskState(_ context.Context, id string, state v1.TaskState) error {
 	if m.captured == nil || m.captured.ID != id {
 		return errors.New("task not found")
+	}
+	if m.updateStateErr != nil {
+		return m.updateStateErr
 	}
 	m.captured.State = state
 	return nil
@@ -213,7 +225,9 @@ func TestHTTPCreateTask_StartAgentReturnsSchedulingTask(t *testing.T) {
 		Executors: repo, Environments: repo, TaskEnvironments: repo,
 		Reviews: repo,
 	}, nil, log, service.RepositoryDiscoveryConfig{})
-	h := &TaskHandlers{service: svc, orchestrator: &captureOrchestrator{}, logger: log}
+	startCreatedCalled := make(chan struct{}, 1)
+	orch := &captureOrchestrator{startCreatedCalled: startCreatedCalled}
+	h := &TaskHandlers{service: svc, orchestrator: orch, logger: log}
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -232,8 +246,62 @@ func TestHTTPCreateTask_StartAgentReturnsSchedulingTask(t *testing.T) {
 	h.httpCreateTask(c)
 
 	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	var response createTaskResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 	assert.Equal(t, v1.TaskStateScheduling, repo.captured.State)
-	assert.Contains(t, rec.Body.String(), `"state":"SCHEDULING"`)
+	assert.Equal(t, v1.TaskStateScheduling, response.State)
+	assert.Equal(t, "sess-1", response.TaskSessionID)
+	requireStartCreatedLaunch(t, startCreatedCalled)
+}
+
+func TestHTTPCreateTask_StartAgentKeepsCreatedStateWhenSchedulingUpdateFails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	log := newTestLogger(t)
+
+	repo := &captureCreateTaskRepo{updateStateErr: errors.New("database locked")}
+	svc := service.NewService(service.Repos{
+		Workspaces: repo, Tasks: repo, TaskRepos: repo,
+		Workflows: repo, Messages: repo, Turns: repo,
+		Sessions: repo, GitSnapshots: repo, RepoEntities: repo,
+		Executors: repo, Environments: repo, TaskEnvironments: repo,
+		Reviews: repo,
+	}, nil, log, service.RepositoryDiscoveryConfig{})
+	startCreatedCalled := make(chan struct{}, 1)
+	orch := &captureOrchestrator{startCreatedCalled: startCreatedCalled}
+	h := &TaskHandlers{service: svc, orchestrator: orch, logger: log}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/tasks", strings.NewReader(`{
+		"workspace_id": "ws-1",
+		"workflow_id": "wf-1",
+		"workflow_step_id": "step-1",
+		"title": "Boot an agent",
+		"description": "Do the thing",
+		"priority": "medium",
+		"agent_profile_id": "profile-1",
+		"start_agent": true
+	}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.httpCreateTask(c)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	var response createTaskResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	assert.Equal(t, v1.TaskStateCreated, repo.captured.State)
+	assert.Equal(t, v1.TaskStateCreated, response.State)
+	assert.Equal(t, "sess-1", response.TaskSessionID)
+	requireStartCreatedLaunch(t, startCreatedCalled)
+}
+
+func requireStartCreatedLaunch(t *testing.T, started <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-started:
+	case <-time.After(1 * time.Second):
+		t.Fatal("async IntentStartCreated launch did not complete")
+	}
 }
 
 func TestValidateAttachments_DeliveryMode(t *testing.T) {


### PR DESCRIPTION
Create-with-agent briefly returned a plain `CREATED` task while the prompt-bearing launch booted asynchronously, leaving the sidebar without a busy indicator. Successful create-with-start now returns and publishes `SCHEDULING` as soon as the session is prepared.

## Validation

- `pnpm install --frozen-lockfile` from `apps/` to hydrate the fresh worktree dependencies.
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `go test ./internal/task/handlers`
- `make -C apps/backend test`
- `make -C apps/backend lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->