### PR TITLE
fix(workflow): gate default Kanban In Progress on completion signal

### DIFF
--- a/apps/backend/config/workflows/kanban.yml
+++ b/apps/backend/config/workflows/kanban.yml
@@ -30,6 +30,12 @@ steps:
     is_start_step: true
     show_in_command_panel: true
     allow_manual_move: true
+    # The agent auto-starts here and the description promises a move to Review
+    # "when done". Gate the on_turn_complete move on an explicit completion
+    # signal (step_complete_kandev) so the task is not promoted on the agent's
+    # first bare turn-end — e.g. an auto-started agent that has barely read its
+    # prompt — which would land work-in-progress tasks in Review prematurely.
+    auto_advance_requires_signal: true
     events:
       on_enter:
         - type: auto_start_agent

--- a/apps/backend/config/workflows/kanban_signal_test.go
+++ b/apps/backend/config/workflows/kanban_signal_test.go
@@ -1,0 +1,24 @@
+package workflows
+
+import "testing"
+
+// TestKanbanInProgress_GatesOnCompletionSignal pins that the default ("simple")
+// Kanban workflow advances In Progress -> Review only on an explicit completion
+// signal, not on the agent's first bare turn-end.
+//
+// The template's own description states the agent "runs automatically, then
+// move to Review when done". Without auto_advance_requires_signal the
+// on_turn_complete move fires on the first turn-end (e.g. an auto-started
+// agent that has barely read its prompt), promoting the task to Review before
+// any real work — which contradicts "when done". Gating on the
+// step_complete_kandev signal makes the behaviour match the description.
+func TestKanbanInProgress_GatesOnCompletionSignal(t *testing.T) {
+	tmpl := loadTemplateForTest(t, "simple")
+	step := findStep(tmpl.Steps, "In Progress")
+	if step == nil {
+		t.Fatal("In Progress step not present in kanban template")
+	}
+	if !step.AutoAdvanceRequiresSignal {
+		t.Error("In Progress must set auto_advance_requires_signal=true so it advances on the completion signal, not on the first bare turn-end")
+	}
+}

--- a/apps/backend/config/workflows/loader.go
+++ b/apps/backend/config/workflows/loader.go
@@ -23,17 +23,18 @@ type templateYAML struct {
 
 // stepDefYAML is the YAML-friendly representation of a step definition.
 type stepDefYAML struct {
-	ID                    string         `yaml:"id"`
-	Name                  string         `yaml:"name"`
-	Position              int            `yaml:"position"`
-	Color                 string         `yaml:"color"`
-	Prompt                string         `yaml:"prompt,omitempty"`
-	StageType             string         `yaml:"stage_type,omitempty"`
-	IsStartStep           bool           `yaml:"is_start_step,omitempty"`
-	ShowInCommandPanel    bool           `yaml:"show_in_command_panel,omitempty"`
-	AllowManualMove       bool           `yaml:"allow_manual_move,omitempty"`
-	AutoArchiveAfterHours int            `yaml:"auto_archive_after_hours,omitempty"`
-	Events                stepEventsYAML `yaml:"events,omitempty"`
+	ID                        string         `yaml:"id"`
+	Name                      string         `yaml:"name"`
+	Position                  int            `yaml:"position"`
+	Color                     string         `yaml:"color"`
+	Prompt                    string         `yaml:"prompt,omitempty"`
+	StageType                 string         `yaml:"stage_type,omitempty"`
+	IsStartStep               bool           `yaml:"is_start_step,omitempty"`
+	ShowInCommandPanel        bool           `yaml:"show_in_command_panel,omitempty"`
+	AllowManualMove           bool           `yaml:"allow_manual_move,omitempty"`
+	AutoArchiveAfterHours     int            `yaml:"auto_archive_after_hours,omitempty"`
+	AutoAdvanceRequiresSignal bool           `yaml:"auto_advance_requires_signal,omitempty"`
+	Events                    stepEventsYAML `yaml:"events,omitempty"`
 }
 
 // stepEventsYAML is the YAML-friendly representation of step events.
@@ -162,17 +163,18 @@ func convertStep(s stepDefYAML) (models.StepDefinition, error) {
 		return models.StepDefinition{}, fmt.Errorf("step %q: %w", s.ID, err)
 	}
 	return models.StepDefinition{
-		ID:                    s.ID,
-		Name:                  s.Name,
-		Position:              s.Position,
-		Color:                 s.Color,
-		Prompt:                strings.TrimSpace(s.Prompt),
-		Events:                events,
-		AllowManualMove:       s.AllowManualMove,
-		IsStartStep:           s.IsStartStep,
-		ShowInCommandPanel:    s.ShowInCommandPanel,
-		AutoArchiveAfterHours: s.AutoArchiveAfterHours,
-		StageType:             stage,
+		ID:                        s.ID,
+		Name:                      s.Name,
+		Position:                  s.Position,
+		Color:                     s.Color,
+		Prompt:                    strings.TrimSpace(s.Prompt),
+		Events:                    events,
+		AllowManualMove:           s.AllowManualMove,
+		IsStartStep:               s.IsStartStep,
+		ShowInCommandPanel:        s.ShowInCommandPanel,
+		AutoArchiveAfterHours:     s.AutoArchiveAfterHours,
+		AutoAdvanceRequiresSignal: s.AutoAdvanceRequiresSignal,
+		StageType:                 stage,
 	}, nil
 }
 

--- a/apps/backend/internal/workflow/repository/seed_signal_test.go
+++ b/apps/backend/internal/workflow/repository/seed_signal_test.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/workflow/models"
+)
+
+// TestSeedDefaultWorkflowSteps_InProgressGatesOnSignal verifies that the kanban
+// steps seeded into a step-less workflow carry auto_advance_requires_signal=true
+// on In Progress, so the default workflow advances to Review on an explicit
+// completion signal rather than the agent's first bare turn-end. Guards the
+// hand-rolled seed INSERT against silently dropping the column.
+func TestSeedDefaultWorkflowSteps_InProgressGatesOnSignal(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	steps, err := repo.ListStepsByWorkflow(context.Background(), "wf-test")
+	if err != nil {
+		t.Fatalf("ListStepsByWorkflow: %v", err)
+	}
+
+	var inProgress *models.WorkflowStep
+	for _, s := range steps {
+		if s.Name == "In Progress" {
+			inProgress = s
+			break
+		}
+	}
+	if inProgress == nil {
+		t.Fatal("seeded kanban workflow has no In Progress step")
+	}
+	if !inProgress.AutoAdvanceRequiresSignal {
+		t.Error("seeded In Progress must have auto_advance_requires_signal=true so it advances on the completion signal, not the first bare turn-end")
+	}
+}

--- a/apps/backend/internal/workflow/repository/sqlite.go
+++ b/apps/backend/internal/workflow/repository/sqlite.go
@@ -193,12 +193,14 @@ func (r *Repository) seedDefaultWorkflowSteps() error {
 			if _, err := r.db.Exec(r.db.Rebind(`
 				INSERT INTO workflow_steps (
 					id, workflow_id, name, position, color,
-					prompt, events, allow_manual_move, is_start_step, show_in_command_panel, created_at, updated_at
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+					prompt, events, allow_manual_move, is_start_step, show_in_command_panel,
+					auto_advance_requires_signal, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			`),
 				idMap[stepDef.ID], workflowID, stepDef.Name, stepDef.Position, stepDef.Color,
 				stepDef.Prompt, string(eventsJSON), dialect.BoolToInt(stepDef.AllowManualMove),
-				dialect.BoolToInt(stepDef.IsStartStep), dialect.BoolToInt(stepDef.ShowInCommandPanel), now, now,
+				dialect.BoolToInt(stepDef.IsStartStep), dialect.BoolToInt(stepDef.ShowInCommandPanel),
+				dialect.BoolToInt(stepDef.AutoAdvanceRequiresSignal), now, now,
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
## What

Gate the default **Kanban** workflow's *In Progress* step on an explicit completion signal so it advances to *Review* when the agent signals done — not on the agent's first bare turn-end.

Fixes the premature-promotion bug from #1444 for the shipped default workflow.

## Why

The `simple` (Kanban) template — seeded as the default workflow for new workspaces — auto-starts an agent on *In Progress* and moves to *Review* on `on_turn_complete`. With `auto_advance_requires_signal` unset, that move fires on the **first** turn-end. For an auto-started agent (e.g. a Linear-dispatched task) the first turn can be ~4 s of just reading the prompt, so the task lands in *Review* before any real work.

The template's own description already promises the right behavior — *"the agent runs automatically, then move to Review **when done**"* — so this gates the transition on the `step_complete_kandev` signal (ADR-0015) to match that contract. The agent advances when it signals completion, or via the manual "Mark complete & advance" fallback.

## Changes

- `config/workflows/kanban.yml` — set `auto_advance_requires_signal: true` on *In Progress* (with an explanatory comment).
- `config/workflows/loader.go` — the strict YAML DTO (`stepDefYAML`) didn't carry the field, so the config couldn't even be parsed (`KnownFields(true)` rejects unknown keys). Added the field + mapping.
- `internal/workflow/repository/sqlite.go` — the hand-rolled default-seed `INSERT` omitted the `auto_advance_requires_signal` column, so the flag wouldn't persist for seeded default workflows. Added it. (The template-picker path already writes the column via `CreateStep`.)
- Tests: template-level (`kanban_signal_test.go`) and end-to-end seed (`seed_signal_test.go`).

## Scope

Backward compatible: default-workflow seeding only applies to workflows that have **no** steps, so existing workspaces are untouched. Autonomous `office-default`/`routine` workflows are intentionally left unchanged — the broader "should the unsafe default be inverted?" question is tracked in #1444.

## Test

```
go test ./config/workflows/... ./internal/workflow/... ./internal/orchestrator/...
```
All green; `go vet`, `gofmt`, and `golangci-lint` (changed-file, base `origin/main`) clean.

Refs #1444


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

