### PR TITLE
ci: fix opencode fork review merge base

### DIFF
--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -286,7 +286,7 @@ jobs:
           REVIEW_DIR=.opencode-review
           rm -rf "$REVIEW_DIR"
           mkdir -p "$REVIEW_DIR"
-          git fetch --no-tags --prune --depth=1 origin "$BASE_SHA"
+          git fetch --no-tags --prune origin "$BASE_SHA"
 
           if [[ "$ACTION" == "synchronize" ]] &&
              [[ -n "${BEFORE:-}" ]] &&

--- a/scripts/opencode-code-review.test.sh
+++ b/scripts/opencode-code-review.test.sh
@@ -46,6 +46,18 @@ if [[ "$relative_patch_count" != "2" ]]; then
 fi
 pass "OpenCode patches are passed as relative workspace files in both workflow paths"
 
+fork_base_fetch_count="$(count_occurrences 'git fetch --no-tags --prune origin "$BASE_SHA"')"
+if [[ "$fork_base_fetch_count" != "1" ]]; then
+  fail "Fork review fetches the trusted base commit before building the diff"
+fi
+pass "Fork review fetches the trusted base commit before building the diff"
+
+shallow_base_fetch_count="$(count_occurrences 'git fetch --no-tags --prune --depth=1 origin "$BASE_SHA"')"
+if [[ "$shallow_base_fetch_count" != "0" ]]; then
+  fail "Fork review does not shallow-fetch the base commit before a three-dot diff"
+fi
+pass "Fork review does not shallow-fetch the base commit before a three-dot diff"
+
 recreate_config_count="$(count_occurrences 'rm -rf .opencode')"
 if [[ "$recreate_config_count" != "2" ]]; then
   fail "OpenCode project config is recreated before writing the review agent"


### PR DESCRIPTION
Fork OpenCode review jobs could fail before review when the base commit was fetched shallowly and Git could not resolve the merge base for a three-dot diff. Fetch the trusted base commit without shallow history so fork reviews can build patch inputs reliably.

## Validation

- `bash scripts/opencode-code-review.test.sh`
- `python3 scripts/opencode-code-review.test.py`
- `git diff --check`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->