### PR TITLE
fix: stop CI auto-fix on non-actionable feedback

### DIFF
--- a/apps/backend/config/prompts/ci-auto-fix.md
+++ b/apps/backend/config/prompts/ci-auto-fix.md
@@ -8,4 +8,15 @@ Focus on the current pull request feedback provided in the task message:
 - Run the narrowest relevant verification commands first, then broader checks if needed.
 - Do not merge the pull request. Kandev handles auto-merge separately when the PR is ready.
 
+First classify the new PR feedback as actionable or non-actionable.
+
+If the new feedback is not actionable, do not modify files, do not commit, and do not push.
+Non-actionable feedback includes summaries, status updates, no-finding reports, duplicated or
+previously addressed comments, rate-limit notices, and review diagnostics that do not request a
+concrete code or test change. In that case, reply only with a short summary that there is nothing
+actionable to address.
+
+Only make code changes when there is a concrete failing check, actionable review request, or
+reproducible issue that needs a fix. Do not push a commit merely to acknowledge feedback.
+
 When you finish, summarize what changed and which verification commands you ran.

--- a/apps/backend/config/prompts/ci-auto-fix.md
+++ b/apps/backend/config/prompts/ci-auto-fix.md
@@ -13,8 +13,7 @@ First classify the new PR feedback as actionable or non-actionable.
 If the new feedback is not actionable, do not modify files, do not commit, and do not push.
 Non-actionable feedback includes summaries, status updates, no-finding reports, duplicated or
 previously addressed comments, rate-limit notices, and review diagnostics that do not request a
-concrete code or test change. In that case, reply only with a short summary that there is nothing
-actionable to address.
+concrete code or test change. In that case, reply only with a short summary that there is nothing actionable to address.
 
 Only make code changes when there is a concrete failing check, actionable review request, or
 reproducible issue that needs a fix. Do not push a commit merely to acknowledge feedback.

--- a/apps/backend/internal/prompts/store/sqlite_test.go
+++ b/apps/backend/internal/prompts/store/sqlite_test.go
@@ -146,6 +146,7 @@ func TestSQLiteRepository_BuiltinPrompts(t *testing.T) {
 		"do not modify files",
 		"do not commit",
 		"do not push",
+		"nothing actionable to address",
 	} {
 		if !strings.Contains(ciAutoFixContent, want) {
 			t.Fatalf("expected ci-auto-fix prompt to contain %q, got:\n%s", want, ciAutoFixContent)

--- a/apps/backend/internal/prompts/store/sqlite_test.go
+++ b/apps/backend/internal/prompts/store/sqlite_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
@@ -124,20 +125,30 @@ func TestSQLiteRepository_BuiltinPrompts(t *testing.T) {
 
 	// Should include the CI auto-fix built-in prompt.
 	builtinCount := 0
-	var foundCIAutoFix bool
+	var ciAutoFixContent string
 	for _, p := range list {
 		if p.Builtin {
 			builtinCount++
 		}
 		if p.ID == "builtin-ci-auto-fix" && p.Name == "ci-auto-fix" && p.Content != "" {
-			foundCIAutoFix = true
+			ciAutoFixContent = p.Content
 		}
 	}
 
 	if builtinCount != 4 {
 		t.Fatalf("expected 4 built-in prompts, got %d", builtinCount)
 	}
-	if !foundCIAutoFix {
+	if ciAutoFixContent == "" {
 		t.Fatalf("expected ci-auto-fix built-in prompt")
+	}
+	for _, want := range []string{
+		"If the new feedback is not actionable",
+		"do not modify files",
+		"do not commit",
+		"do not push",
+	} {
+		if !strings.Contains(ciAutoFixContent, want) {
+			t.Fatalf("expected ci-auto-fix prompt to contain %q, got:\n%s", want, ciAutoFixContent)
+		}
 	}
 }

--- a/docs/specs/ui/ci-pr-automation.md
+++ b/docs/specs/ui/ci-pr-automation.md
@@ -27,7 +27,7 @@ Users can already see pull request CI/review status above the task chat input, b
 - Emptying or resetting the task prompt override returns the task to the default `ci-auto-fix` prompt.
 - For tasks with multiple linked PRs, the controls are task-level and apply to every open linked PR. Dedupe, last-attempt, and error state are tracked per linked PR.
 - Kandev checks watched PRs through the existing lightweight PR watch poller, which runs once per minute. It fetches full PR feedback only when a watched PR is a candidate for auto-fix or when a user opens/refreshes PR feedback UI.
-- Every auto-fix attempt records the actionable feedback snapshot it used. Later fix rounds include only new or materially changed CI/review feedback since the last recorded round, with enough summary context for the agent to understand the PR.
+- Every auto-fix attempt records the latest feedback snapshot it used, including non-actionable snapshots that were intentionally no-ops. Later fix rounds include only new or materially changed CI/review feedback since the last recorded round, with enough summary context for the agent to understand the PR.
 - Automation must not repeatedly prompt for the same failure/comment snapshot or repeatedly retry the same failed merge attempt on every poll.
 - Automation controls persist across Kandev restarts.
 
@@ -48,8 +48,8 @@ Users can already see pull request CI/review status above the task chat input, b
 - `task_id` string. References the Kandev task.
 - `repository_id` string. Identifies which linked repository/branch row produced the PR.
 - `pr_number` integer.
-- `last_fix_signature` string nullable. Deterministic hash of the last actionable feedback snapshot that produced an auto-fix prompt.
-- `last_fix_checkpoint_json` string nullable. JSON snapshot of actionable feedback used in the last fix round.
+- `last_fix_signature` string nullable. Deterministic hash of the latest feedback snapshot, actionable or non-actionable, that produced an auto-fix prompt.
+- `last_fix_checkpoint_json` string nullable. JSON snapshot of feedback used in the last fix round. This includes non-actionable no-op snapshots so identical bot summaries/status updates are not repeatedly sent.
 - `last_fix_enqueued_at` timestamp nullable.
 - `last_fix_session_id` string nullable.
 - `last_merge_signature` string nullable. Deterministic hash of the last readiness state used for a merge attempt.
@@ -134,7 +134,7 @@ Auto-fix cycle for one task/PR:
 1. Existing PR watch poll updates lightweight PR state.
 2. Kandev sees a candidate state: failed checks, requested changes, unresolved review threads, or new actionable review feedback.
 3. Kandev fetches full PR feedback.
-4. Kandev compares the current actionable snapshot to `last_fix_checkpoint_json` and `last_fix_signature`.
+4. Kandev compares the current feedback snapshot to `last_fix_checkpoint_json` and `last_fix_signature`.
 5. If there is no material change, the cycle ends without prompting.
 6. If there is new or materially changed feedback, Kandev renders the task override or default `ci-auto-fix` prompt and sends or queues it for the task session.
 7. The default prompt instructs the agent to classify the new feedback before editing. If the
@@ -142,8 +142,8 @@ Auto-fix cycle for one task/PR:
    addressed comments, rate-limit notices, or other non-actionable review diagnostics, the agent
    must not modify files, commit, or push; it should only report that there is nothing actionable
    to address.
-8. Kandev records the new signature/checkpoint and attempt metadata so the same non-actionable
-   snapshot is not sent repeatedly.
+8. Kandev records the new signature/checkpoint and attempt metadata for the latest feedback
+   snapshot, actionable or non-actionable, so identical snapshots are not sent repeatedly.
 
 Auto-merge cycle for one task/PR:
 

--- a/docs/specs/ui/ci-pr-automation.md
+++ b/docs/specs/ui/ci-pr-automation.md
@@ -137,7 +137,13 @@ Auto-fix cycle for one task/PR:
 4. Kandev compares the current actionable snapshot to `last_fix_checkpoint_json` and `last_fix_signature`.
 5. If there is no material change, the cycle ends without prompting.
 6. If there is new or materially changed feedback, Kandev renders the task override or default `ci-auto-fix` prompt and sends or queues it for the task session.
-7. Kandev records the new signature/checkpoint and attempt metadata.
+7. The default prompt instructs the agent to classify the new feedback before editing. If the
+   new feedback is only summaries, status updates, no-finding reports, duplicated or already
+   addressed comments, rate-limit notices, or other non-actionable review diagnostics, the agent
+   must not modify files, commit, or push; it should only report that there is nothing actionable
+   to address.
+8. Kandev records the new signature/checkpoint and attempt metadata so the same non-actionable
+   snapshot is not sent repeatedly.
 
 Auto-merge cycle for one task/PR:
 
@@ -189,6 +195,7 @@ Auto-merge cycle for one task/PR:
 - **GIVEN** auto-fix is enabled and a watched PR transitions from passing to failing CI, **WHEN** the 1-minute PR watch poll observes the failure, **THEN** Kandev fetches full PR feedback and sends or queues one auto-fix prompt for that failure snapshot.
 - **GIVEN** auto-fix already prompted for a failure snapshot, **WHEN** the same failure is observed again on a later poll, **THEN** no duplicate prompt is sent.
 - **GIVEN** auto-fix already prompted for a failure snapshot, **WHEN** a new failed check or new unresolved review comment appears, **THEN** Kandev sends or queues a new prompt containing the new or materially changed feedback.
+- **GIVEN** auto-fix sends a prompt for a snapshot that contains only non-actionable automation summaries or status updates, **WHEN** the agent reviews that prompt, **THEN** the agent does not modify files, commit, or push and only reports that there is nothing actionable to address.
 - **GIVEN** auto-fix is enabled and the task session is running, **WHEN** new actionable PR feedback appears, **THEN** the prompt is queued and delivered after the current turn rather than interrupting the running session.
 - **GIVEN** auto-merge is enabled and the PR has passing checks, required reviews, no unresolved threads, and clean mergeability, **WHEN** the PR watch poll observes the ready state, **THEN** Kandev merges the PR with the existing backend merge-method selection.
 - **GIVEN** auto-merge is enabled but the PR has requested changes, pending required review, failing checks, unresolved threads, or dirty mergeability, **WHEN** the PR watch poll observes the state, **THEN** Kandev does not merge.


### PR DESCRIPTION
Auto-fix can otherwise create a feedback loop when each push produces fresh review-summary comments, so the default prompt now tells the agent to no-op when the new snapshot has nothing actionable.

## Important Changes

- Added a default-prompt circuit breaker: classify feedback first, and do not edit, commit, or push for summaries, status updates, no-finding reports, duplicated comments, rate-limit notices, or non-actionable diagnostics.
- Updated the CI automation spec and prompt-store coverage so the no-op behavior remains documented and seeded.

## Validation

- `go test ./internal/prompts/store`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->