### PR TITLE
fix: load feature toggles on mount

### DIFF
--- a/apps/web/components/settings/system/feature-toggles-settings.test.tsx
+++ b/apps/web/components/settings/system/feature-toggles-settings.test.tsx
@@ -1,8 +1,13 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { TooltipProvider } from "@kandev/ui/tooltip";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeFlagState } from "@/lib/types/runtime-flags";
 import { FeatureTogglesSettings } from "./feature-toggles-settings";
+
+const fetchRuntimeFlagsMock = vi.fn();
+const toastMock = vi.fn();
+const DEBUG_MODE_LABEL = "Debug mode";
+const FEATURE_TOGGLES_LOAD_FAILURE = "Feature toggles could not be loaded.";
 
 vi.mock("@kandev/ui/switch", () => ({
   Switch: ({
@@ -17,10 +22,23 @@ vi.mock("@kandev/ui/switch", () => ({
 }));
 
 vi.mock("@/components/toast-provider", () => ({
-  useToast: () => ({ toast: vi.fn() }),
+  useToast: () => ({ toast: toastMock }),
 }));
 
-afterEach(cleanup);
+vi.mock("@/lib/api/domains/runtime-flags-api", () => ({
+  fetchRuntimeFlags: (...args: unknown[]) => fetchRuntimeFlagsMock(...args),
+  updateRuntimeFlag: vi.fn(),
+}));
+
+beforeEach(() => {
+  fetchRuntimeFlagsMock.mockReset();
+  toastMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe("FeatureTogglesSettings", () => {
   it("shows restart support details without offering restart when unsupported", () => {
@@ -42,13 +60,112 @@ describe("FeatureTogglesSettings", () => {
     expect(screen.queryByRole("button", { name: "Restart" })).toBeNull();
     expect(screen.getByText(/terminal or service manager/)).not.toBeNull();
   });
+
+  it("automatically reloads when the initial runtime flags payload is empty", async () => {
+    fetchRuntimeFlagsMock.mockResolvedValueOnce({
+      flags: [flagState({ requires_restart_to_apply: false })],
+    });
+
+    render(
+      <TooltipProvider>
+        <FeatureTogglesSettings initialFlags={[]} restartCapability={null} />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => expect(fetchRuntimeFlagsMock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(DEBUG_MODE_LABEL)).not.toBeNull();
+    expect(screen.queryByText(FEATURE_TOGGLES_LOAD_FAILURE)).toBeNull();
+  });
+
+  it("shows a loading state while the empty initial runtime flags payload reloads", async () => {
+    let resolveFlags: (value: { flags: RuntimeFlagState[] }) => void = () => {};
+    fetchRuntimeFlagsMock.mockReturnValueOnce(
+      new Promise<{ flags: RuntimeFlagState[] }>((resolve) => {
+        resolveFlags = resolve;
+      }),
+    );
+
+    render(
+      <TooltipProvider>
+        <FeatureTogglesSettings initialFlags={[]} restartCapability={null} />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => expect(fetchRuntimeFlagsMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Loading feature toggles...")).not.toBeNull();
+    expect(screen.queryByText(FEATURE_TOGGLES_LOAD_FAILURE)).toBeNull();
+
+    resolveFlags({ flags: [flagState({ requires_restart_to_apply: false })] });
+
+    expect(await screen.findByText(DEBUG_MODE_LABEL)).not.toBeNull();
+  });
+
+  it("keeps the retry state and shows a toast when the empty initial reload fails", async () => {
+    fetchRuntimeFlagsMock.mockRejectedValueOnce(new Error("boom"));
+
+    render(
+      <TooltipProvider>
+        <FeatureTogglesSettings initialFlags={[]} restartCapability={null} />
+      </TooltipProvider>,
+    );
+
+    expect(await screen.findByText(FEATURE_TOGGLES_LOAD_FAILURE)).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Retry" })).not.toBeNull();
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Failed to load feature toggles",
+      description: "boom",
+      variant: "error",
+    });
+  });
+
+  it("keeps the retry state without a toast when the empty initial reload returns no flags", async () => {
+    fetchRuntimeFlagsMock.mockResolvedValueOnce({ flags: [] });
+
+    render(
+      <TooltipProvider>
+        <FeatureTogglesSettings initialFlags={[]} restartCapability={null} />
+      </TooltipProvider>,
+    );
+
+    expect(await screen.findByText(FEATURE_TOGGLES_LOAD_FAILURE)).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Retry" })).not.toBeNull();
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates the empty initial reload across remounts while the request is in flight", async () => {
+    let resolveFlags: (value: { flags: RuntimeFlagState[] }) => void = () => {};
+    fetchRuntimeFlagsMock.mockReturnValueOnce(
+      new Promise<{ flags: RuntimeFlagState[] }>((resolve) => {
+        resolveFlags = resolve;
+      }),
+    );
+
+    const firstRender = render(
+      <TooltipProvider>
+        <FeatureTogglesSettings initialFlags={[]} restartCapability={null} />
+      </TooltipProvider>,
+    );
+    await waitFor(() => expect(fetchRuntimeFlagsMock).toHaveBeenCalledTimes(1));
+    firstRender.unmount();
+
+    render(
+      <TooltipProvider>
+        <FeatureTogglesSettings initialFlags={[]} restartCapability={null} />
+      </TooltipProvider>,
+    );
+    expect(fetchRuntimeFlagsMock).toHaveBeenCalledTimes(1);
+
+    resolveFlags({ flags: [flagState({ requires_restart_to_apply: false })] });
+
+    expect(await screen.findByText(DEBUG_MODE_LABEL)).not.toBeNull();
+  });
 });
 
 function flagState(overrides: Partial<RuntimeFlagState> = {}): RuntimeFlagState {
   return {
     key: "debug.devMode",
     env_var: "KANDEV_DEBUG_DEV_MODE",
-    label: "Debug mode",
+    label: DEBUG_MODE_LABEL,
     description: "Enables diagnostic tools for troubleshooting.",
     kind: "debug",
     stability: "stable",

--- a/apps/web/components/settings/system/feature-toggles-settings.tsx
+++ b/apps/web/components/settings/system/feature-toggles-settings.tsx
@@ -2,6 +2,7 @@
 
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -12,6 +13,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@kandev/ui/alert";
 import { Button } from "@kandev/ui/button";
 import { Card, CardContent } from "@kandev/ui/card";
+import { Spinner } from "@kandev/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { IconInfoCircle, IconPower, IconRotateClockwise } from "@tabler/icons-react";
 import { useToast } from "@/components/toast-provider";
@@ -27,32 +29,50 @@ type Props = {
   restartCapability: RestartCapability | null;
 };
 
+let bootstrapRuntimeFlagsRequest: ReturnType<typeof fetchRuntimeFlags> | null = null;
+
 export function FeatureTogglesSettings({ initialFlags, restartCapability }: Props) {
   const [flags, setFlags] = useState(initialFlags);
+  const [isLoadingFlags, setIsLoadingFlags] = useState(initialFlags.length === 0);
   const [savingKeys, setSavingKeys] = useState<Set<string>>(() => new Set());
   const requestSeqRef = useRef(0);
+  const attemptedEmptyInitialReloadRef = useRef(false);
   const { toast } = useToast();
   const pendingRestart = useMemo(
     () => flags.some((flag) => flag.requires_restart_to_apply),
     [flags],
   );
 
-  const reload = useCallback(async () => {
-    const seq = nextRequestSeq(requestSeqRef);
-    try {
-      const res = await fetchRuntimeFlags();
-      setFlagsIfLatest(requestSeqRef, seq, res.flags, setFlags);
-    } catch (err) {
-      toast({
-        title: "Failed to load feature toggles",
-        description: errorMessage(err),
-        variant: "error",
-      });
-    }
-  }, [toast]);
+  const reload = useCallback(
+    async (options?: { bootstrap?: boolean }) => {
+      const seq = nextRequestSeq(requestSeqRef);
+      setIsLoadingFlags(true);
+      try {
+        const res = await fetchRuntimeFlagsForReload(options?.bootstrap === true);
+        setFlagsIfLatest(requestSeqRef, seq, res.flags, setFlags);
+      } catch (err) {
+        toast({
+          title: "Failed to load feature toggles",
+          description: errorMessage(err),
+          variant: "error",
+        });
+      } finally {
+        if (seq === requestSeqRef.current) {
+          setIsLoadingFlags(false);
+        }
+      }
+    },
+    [toast],
+  );
 
   const onRestartComplete = useCallback(() => void reload(), [reload]);
   const restart = useKandevRestart({ onComplete: onRestartComplete });
+
+  useEffect(() => {
+    if (flags.length > 0 || attemptedEmptyInitialReloadRef.current) return;
+    attemptedEmptyInitialReloadRef.current = true;
+    void reload({ bootstrap: true });
+  }, [flags.length, reload]);
 
   const setOverride = async (flag: RuntimeFlagState, override: boolean | null) => {
     const seq = nextRequestSeq(requestSeqRef);
@@ -99,18 +119,7 @@ export function FeatureTogglesSettings({ initialFlags, restartCapability }: Prop
         />
       ))}
       {flags.length === 0 && (
-        <Card>
-          <CardContent className="py-6 text-sm text-muted-foreground">
-            Feature toggles could not be loaded.
-            <Button
-              variant="link"
-              className="h-auto px-1 cursor-pointer"
-              onClick={() => void reload()}
-            >
-              Retry
-            </Button>
-          </CardContent>
-        </Card>
+        <FeatureTogglesEmptyState isLoading={isLoadingFlags} onRetry={() => void reload()} />
       )}
       <RestartProgressDialog
         phase={restart.phase}
@@ -118,6 +127,45 @@ export function FeatureTogglesSettings({ initialFlags, restartCapability }: Prop
         onDismiss={restart.dismiss}
       />
     </div>
+  );
+}
+
+function fetchRuntimeFlagsForReload(bootstrap: boolean): ReturnType<typeof fetchRuntimeFlags> {
+  if (!bootstrap) return fetchRuntimeFlags();
+  if (bootstrapRuntimeFlagsRequest === null) {
+    bootstrapRuntimeFlagsRequest = fetchRuntimeFlags().finally(() => {
+      bootstrapRuntimeFlagsRequest = null;
+    });
+  }
+  return bootstrapRuntimeFlagsRequest;
+}
+
+function FeatureTogglesEmptyState({
+  isLoading,
+  onRetry,
+}: {
+  isLoading: boolean;
+  onRetry: () => void;
+}) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+          <Spinner className="size-4" />
+          Loading feature toggles...
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <Card>
+      <CardContent className="py-6 text-sm text-muted-foreground">
+        Feature toggles could not be loaded.
+        <Button variant="link" className="h-auto px-1 cursor-pointer" onClick={onRetry}>
+          Retry
+        </Button>
+      </CardContent>
+    </Card>
   );
 }
 


### PR DESCRIPTION
Feature Toggles could open with an empty state because the SPA route bootstraps it without initial runtime flag data. The settings component now performs a one-time client reload so the page populates without requiring Retry.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->