### PR TITLE
fix: stop run-mode automation agents

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -504,6 +505,12 @@ func (s *Service) reapAutomationWorktree(ctx context.Context, taskID, sessionID 
 		return
 	}
 	if err := s.worktreeMgr.RemoveByID(ctx, running.WorktreeID, true); err != nil {
+		if errors.Is(err, worktree.ErrWorktreeNotFound) {
+			s.logger.Debug("automation worktree already reaped",
+				zap.String("task_id", taskID),
+				zap.String("worktree_id", running.WorktreeID))
+			return
+		}
 		s.logger.Warn("failed to reap automation worktree",
 			zap.String("task_id", taskID),
 			zap.String("worktree_id", running.WorktreeID),

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -396,6 +396,31 @@ func (s *Service) recordSuccessRun(ctx context.Context, evt *automation.Automati
 	}
 }
 
+// handleAutomationTurnComplete closes out a run-mode automation on the stream
+// complete event. ACP agents can stay alive after stop_reason=end_turn, so
+// waiting for agent.completed would leave the AutomationRun stuck at
+// task_created and keep the executor alive.
+func (s *Service) handleAutomationTurnComplete(
+	ctx context.Context, taskID, sessionID string, session *models.TaskSession, stopReason string, isError bool, errMsg string,
+) bool {
+	if taskID == "" || sessionID == "" || stopReason == stopReasonCancelled {
+		return false
+	}
+	task, err := s.repo.GetTask(ctx, taskID)
+	if err != nil || task == nil {
+		return false
+	}
+	if !task.IsEphemeral || task.Origin != models.TaskOriginAutomationRun {
+		return false
+	}
+
+	success := !isError && stopReason != "error"
+	s.markAutomationRunTerminal(ctx, taskID, success, errMsg)
+	s.stopAutomationAgent(ctx, taskID, sessionID, session)
+	s.reapAutomationWorktree(ctx, taskID, sessionID)
+	return true
+}
+
 // finalizeAutomationRunIfEphemeral closes out a run-mode automation run when
 // its agent terminates. For ephemeral automation tasks it (a) flips the
 // AutomationRun row from task_created → succeeded|failed, and (b) reaps the
@@ -412,6 +437,11 @@ func (s *Service) finalizeAutomationRunIfEphemeral(ctx context.Context, taskID, 
 		return
 	}
 
+	s.markAutomationRunTerminal(ctx, taskID, success, errMsg)
+	s.reapAutomationWorktree(ctx, taskID, sessionID)
+}
+
+func (s *Service) markAutomationRunTerminal(ctx context.Context, taskID string, success bool, errMsg string) {
 	if s.automationService != nil {
 		var markErr error
 		if success {
@@ -426,8 +456,41 @@ func (s *Service) finalizeAutomationRunIfEphemeral(ctx context.Context, taskID, 
 				zap.Error(markErr))
 		}
 	}
+}
 
-	s.reapAutomationWorktree(ctx, taskID, sessionID)
+func (s *Service) stopAutomationAgent(
+	ctx context.Context, taskID, sessionID string, session *models.TaskSession,
+) {
+	if s.agentManager == nil {
+		return
+	}
+	executionID := ""
+	if session != nil {
+		executionID = session.AgentExecutionID
+	}
+	if executionID == "" {
+		running, err := s.repo.GetExecutorRunningBySessionID(ctx, sessionID)
+		if err != nil {
+			s.logger.Warn("failed to resolve automation execution for turn-complete stop",
+				zap.String("task_id", taskID),
+				zap.String("session_id", sessionID),
+				zap.Error(err))
+			return
+		}
+		if running != nil {
+			executionID = running.AgentExecutionID
+		}
+	}
+	if executionID == "" {
+		return
+	}
+	if err := s.agentManager.StopAgent(ctx, executionID, false); err != nil {
+		s.logger.Warn("failed to stop automation agent on turn complete",
+			zap.String("task_id", taskID),
+			zap.String("session_id", sessionID),
+			zap.String("agent_execution_id", executionID),
+			zap.Error(err))
+	}
 }
 
 // reapAutomationWorktree removes the ephemeral worktree (and its branch)

--- a/apps/backend/internal/orchestrator/event_handlers_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_automation.go
@@ -404,7 +404,7 @@ func (s *Service) recordSuccessRun(ctx context.Context, evt *automation.Automati
 func (s *Service) handleAutomationTurnComplete(
 	ctx context.Context, taskID, sessionID string, session *models.TaskSession, stopReason string, isError bool, errMsg string,
 ) bool {
-	if taskID == "" || sessionID == "" || stopReason == stopReasonCancelled {
+	if taskID == "" || sessionID == "" {
 		return false
 	}
 	task, err := s.repo.GetTask(ctx, taskID)
@@ -415,7 +415,18 @@ func (s *Service) handleAutomationTurnComplete(
 		return false
 	}
 
-	success := !isError && stopReason != "error"
+	cancelled := stopReason == stopReasonCancelled
+	success := !isError && stopReason != "error" && !cancelled
+	if cancelled && errMsg == "" {
+		errMsg = stopReasonCancelled
+	}
+	nextState := models.TaskSessionStateCompleted
+	if cancelled {
+		nextState = models.TaskSessionStateCancelled
+	} else if !success {
+		nextState = models.TaskSessionStateFailed
+	}
+	s.updateTaskSessionState(ctx, taskID, sessionID, nextState, errMsg, false, session)
 	s.markAutomationRunTerminal(ctx, taskID, success, errMsg)
 	s.stopAutomationAgent(ctx, taskID, sessionID, session)
 	s.reapAutomationWorktree(ctx, taskID, sessionID)

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -845,6 +845,8 @@ func extractCompleteErrorMessage(payload *lifecycle.AgentStreamEventPayload) str
 	if payload.Data.Error != "" {
 		return payload.Data.Error
 	}
+	// Complete-event text is user-facing agent output; only structured error
+	// fields should become AutomationRun.error_message.
 	data, ok := payload.Data.Data.(map[string]interface{})
 	if !ok {
 		return ""

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -845,9 +845,6 @@ func extractCompleteErrorMessage(payload *lifecycle.AgentStreamEventPayload) str
 	if payload.Data.Error != "" {
 		return payload.Data.Error
 	}
-	if payload.Data.Text != "" {
-		return payload.Data.Text
-	}
 	data, ok := payload.Data.Data.(map[string]interface{})
 	if !ok {
 		return ""

--- a/apps/backend/internal/orchestrator/event_handlers_streaming.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming.go
@@ -767,6 +767,17 @@ func (s *Service) handleCompleteStreamEvent(ctx context.Context, payload *lifecy
 	if session != nil && s.handleOfficeTurnComplete(ctx, payload.TaskID, payload.SessionID, session, stopReason) {
 		return
 	}
+	if session != nil && s.handleAutomationTurnComplete(
+		ctx,
+		payload.TaskID,
+		payload.SessionID,
+		session,
+		stopReason,
+		extractCompleteIsError(payload),
+		extractCompleteErrorMessage(payload),
+	) {
+		return
+	}
 
 	// READY events own workflow transitions and queued prompt execution.
 	// If we're still RUNNING here, avoid racing READY by forcing WAITING/REVIEW.
@@ -813,6 +824,41 @@ func extractStopReason(payload *lifecycle.AgentStreamEventPayload) string {
 	}
 	sr, _ := data["stop_reason"].(string)
 	return sr
+}
+
+func extractCompleteIsError(payload *lifecycle.AgentStreamEventPayload) bool {
+	if payload == nil || payload.Data == nil {
+		return false
+	}
+	data, ok := payload.Data.Data.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	isError, _ := data["is_error"].(bool)
+	return isError
+}
+
+func extractCompleteErrorMessage(payload *lifecycle.AgentStreamEventPayload) string {
+	if payload == nil || payload.Data == nil {
+		return ""
+	}
+	if payload.Data.Error != "" {
+		return payload.Data.Error
+	}
+	if payload.Data.Text != "" {
+		return payload.Data.Text
+	}
+	data, ok := payload.Data.Data.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	if message, ok := data["error"].(string); ok {
+		return message
+	}
+	if message, ok := data["message"].(string); ok {
+		return message
+	}
+	return ""
 }
 
 // Mirrors the "cancelled" literal in lifecycle/manager_events.go — not extracted to avoid cross-package coupling.

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kandev/kandev/internal/agent/runtime/lifecycle"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
+	"github.com/kandev/kandev/internal/automation"
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
@@ -28,6 +29,29 @@ type recordedEvent struct {
 
 type failSetSessionMetadataRepo struct {
 	repoStore
+}
+
+type mockAutomationRunService struct {
+	succeededTaskIDs []string
+	failedTaskIDs    []string
+}
+
+func (m *mockAutomationRunService) GetAutomation(context.Context, string) (*automation.Automation, error) {
+	return nil, nil
+}
+
+func (m *mockAutomationRunService) RecordRun(context.Context, *automation.AutomationRun) error {
+	return nil
+}
+
+func (m *mockAutomationRunService) MarkRunFailedByTaskID(_ context.Context, taskID, _ string) error {
+	m.failedTaskIDs = append(m.failedTaskIDs, taskID)
+	return nil
+}
+
+func (m *mockAutomationRunService) MarkRunSucceededByTaskID(_ context.Context, taskID string) error {
+	m.succeededTaskIDs = append(m.succeededTaskIDs, taskID)
+	return nil
 }
 
 func (r failSetSessionMetadataRepo) SetSessionMetadataKey(
@@ -612,6 +636,67 @@ func TestHandleCompleteStreamEvent_NaturalOfficeCompleteStillIdle(t *testing.T) 
 	mgr.mu.Unlock()
 	require.Equal(t, 1, stopCalls,
 		"natural office turn completion must still call StopAgent to tear down the executor")
+}
+
+func TestHandleCompleteStreamEvent_RunModeAutomationStopsAndFinalizes(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	now := time.Now().UTC()
+	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{
+		ID:        "ws-automation",
+		Name:      "Automation",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}))
+	require.NoError(t, repo.CreateTask(ctx, &models.Task{
+		ID:          "t-auto-run",
+		WorkspaceID: "ws-automation",
+		Title:       "Automation run",
+		Description: "run this",
+		State:       v1.TaskStateInProgress,
+		IsEphemeral: true,
+		Origin:      models.TaskOriginAutomationRun,
+		Metadata: map[string]interface{}{
+			"execution_mode": string(automation.ExecutionModeRun),
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}))
+	require.NoError(t, repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:        "s-auto-run",
+		TaskID:    "t-auto-run",
+		State:     models.TaskSessionStateRunning,
+		StartedAt: now,
+		UpdatedAt: now,
+	}))
+	seedExecutorRunning(t, repo, "s-auto-run", "t-auto-run", "exec-auto-run")
+
+	mgr := &mockAgentManager{}
+	automationSvc := &mockAutomationRunService{}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
+	svc.SetAutomationService(automationSvc)
+
+	payload := &lifecycle.AgentStreamEventPayload{
+		TaskID:      "t-auto-run",
+		SessionID:   "s-auto-run",
+		ExecutionID: "exec-auto-run",
+		Data: &lifecycle.AgentStreamEventData{
+			Type: agentEventComplete,
+			Data: map[string]interface{}{
+				"stop_reason": "end_turn",
+			},
+		},
+	}
+
+	svc.handleCompleteStreamEvent(ctx, payload)
+
+	require.Equal(t, []string{"t-auto-run"}, automationSvc.succeededTaskIDs)
+	require.Empty(t, automationSvc.failedTaskIDs)
+
+	mgr.mu.Lock()
+	stopCalls := append([]stopAgentCall(nil), mgr.stopAgentArgs...)
+	mgr.mu.Unlock()
+	require.Equal(t, []stopAgentCall{{ExecutionID: "exec-auto-run"}}, stopCalls)
 }
 
 // TestSetSessionWaitingForInput_WritesOnTransition is the symmetric counterpart

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/task/models"
+	sqliterepo "github.com/kandev/kandev/internal/task/repository/sqlite"
 	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
@@ -32,8 +33,9 @@ type failSetSessionMetadataRepo struct {
 }
 
 type mockAutomationRunService struct {
-	succeededTaskIDs []string
-	failedTaskIDs    []string
+	succeededTaskIDs  []string
+	failedTaskIDs     []string
+	failedErrorByTask map[string]string
 }
 
 func (m *mockAutomationRunService) GetAutomation(context.Context, string) (*automation.Automation, error) {
@@ -44,8 +46,12 @@ func (m *mockAutomationRunService) RecordRun(context.Context, *automation.Automa
 	return nil
 }
 
-func (m *mockAutomationRunService) MarkRunFailedByTaskID(_ context.Context, taskID, _ string) error {
+func (m *mockAutomationRunService) MarkRunFailedByTaskID(_ context.Context, taskID, errMsg string) error {
 	m.failedTaskIDs = append(m.failedTaskIDs, taskID)
+	if m.failedErrorByTask == nil {
+		m.failedErrorByTask = make(map[string]string)
+	}
+	m.failedErrorByTask[taskID] = errMsg
 	return nil
 }
 
@@ -638,19 +644,23 @@ func TestHandleCompleteStreamEvent_NaturalOfficeCompleteStillIdle(t *testing.T) 
 		"natural office turn completion must still call StopAgent to tear down the executor")
 }
 
-func TestHandleCompleteStreamEvent_RunModeAutomationStopsAndFinalizes(t *testing.T) {
+func seedRunModeAutomationSession(
+	t *testing.T,
+	repo *sqliterepo.Repository,
+	taskID, sessionID, executionID string,
+) {
+	t.Helper()
 	ctx := context.Background()
-	repo := setupTestRepo(t)
 	now := time.Now().UTC()
 	require.NoError(t, repo.CreateWorkspace(ctx, &models.Workspace{
-		ID:        "ws-automation",
+		ID:        "ws-" + taskID,
 		Name:      "Automation",
 		CreatedAt: now,
 		UpdatedAt: now,
 	}))
 	require.NoError(t, repo.CreateTask(ctx, &models.Task{
-		ID:          "t-auto-run",
-		WorkspaceID: "ws-automation",
+		ID:          taskID,
+		WorkspaceID: "ws-" + taskID,
 		Title:       "Automation run",
 		Description: "run this",
 		State:       v1.TaskStateInProgress,
@@ -663,13 +673,19 @@ func TestHandleCompleteStreamEvent_RunModeAutomationStopsAndFinalizes(t *testing
 		UpdatedAt: now,
 	}))
 	require.NoError(t, repo.CreateTaskSession(ctx, &models.TaskSession{
-		ID:        "s-auto-run",
-		TaskID:    "t-auto-run",
+		ID:        sessionID,
+		TaskID:    taskID,
 		State:     models.TaskSessionStateRunning,
 		StartedAt: now,
 		UpdatedAt: now,
 	}))
-	seedExecutorRunning(t, repo, "s-auto-run", "t-auto-run", "exec-auto-run")
+	seedExecutorRunning(t, repo, sessionID, taskID, executionID)
+}
+
+func TestHandleCompleteStreamEvent_RunModeAutomationStopsAndFinalizes(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedRunModeAutomationSession(t, repo, "t-auto-run", "s-auto-run", "exec-auto-run")
 
 	mgr := &mockAgentManager{}
 	automationSvc := &mockAutomationRunService{}
@@ -692,11 +708,90 @@ func TestHandleCompleteStreamEvent_RunModeAutomationStopsAndFinalizes(t *testing
 
 	require.Equal(t, []string{"t-auto-run"}, automationSvc.succeededTaskIDs)
 	require.Empty(t, automationSvc.failedTaskIDs)
+	gotSession, err := repo.GetTaskSession(ctx, "s-auto-run")
+	require.NoError(t, err)
+	require.Equal(t, models.TaskSessionStateCompleted, gotSession.State)
 
 	mgr.mu.Lock()
 	stopCalls := append([]stopAgentCall(nil), mgr.stopAgentArgs...)
 	mgr.mu.Unlock()
 	require.Equal(t, []stopAgentCall{{ExecutionID: "exec-auto-run"}}, stopCalls)
+}
+
+func TestHandleCompleteStreamEvent_RunModeAutomationFailureStopsAndFinalizes(t *testing.T) {
+	cases := []struct {
+		name        string
+		data        map[string]interface{}
+		wantErrMsg  string
+		wantSession models.TaskSessionState
+	}{
+		{
+			name: "stop_reason_error",
+			data: map[string]interface{}{
+				"stop_reason": "error",
+				"error":       "agent failed",
+			},
+			wantErrMsg:  "agent failed",
+			wantSession: models.TaskSessionStateFailed,
+		},
+		{
+			name: "is_error_true",
+			data: map[string]interface{}{
+				"is_error": true,
+				"message":  "adapter failed",
+			},
+			wantErrMsg:  "adapter failed",
+			wantSession: models.TaskSessionStateFailed,
+		},
+		{
+			name: "cancelled",
+			data: map[string]interface{}{
+				"stop_reason": "cancelled",
+			},
+			wantErrMsg:  "cancelled",
+			wantSession: models.TaskSessionStateCancelled,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := setupTestRepo(t)
+			taskID := "t-auto-" + tc.name
+			sessionID := "s-auto-" + tc.name
+			executionID := "exec-auto-" + tc.name
+			seedRunModeAutomationSession(t, repo, taskID, sessionID, executionID)
+
+			mgr := &mockAgentManager{}
+			automationSvc := &mockAutomationRunService{}
+			svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), mgr)
+			svc.SetAutomationService(automationSvc)
+
+			payload := &lifecycle.AgentStreamEventPayload{
+				TaskID:      taskID,
+				SessionID:   sessionID,
+				ExecutionID: executionID,
+				Data: &lifecycle.AgentStreamEventData{
+					Type: agentEventComplete,
+					Data: tc.data,
+				},
+			}
+
+			svc.handleCompleteStreamEvent(ctx, payload)
+
+			require.Empty(t, automationSvc.succeededTaskIDs)
+			require.Equal(t, []string{taskID}, automationSvc.failedTaskIDs)
+			require.Equal(t, tc.wantErrMsg, automationSvc.failedErrorByTask[taskID])
+			gotSession, err := repo.GetTaskSession(ctx, sessionID)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantSession, gotSession.State)
+
+			mgr.mu.Lock()
+			stopCalls := append([]stopAgentCall(nil), mgr.stopAgentArgs...)
+			mgr.mu.Unlock()
+			require.Equal(t, []stopAgentCall{{ExecutionID: executionID}}, stopCalls)
+		})
+	}
 }
 
 // TestSetSessionWaitingForInput_WritesOnTransition is the symmetric counterpart

--- a/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_streaming_test.go
@@ -794,6 +794,43 @@ func TestHandleCompleteStreamEvent_RunModeAutomationFailureStopsAndFinalizes(t *
 	}
 }
 
+func TestExtractCompleteErrorMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		data *lifecycle.AgentStreamEventData
+		want string
+	}{
+		{name: "nil_data", data: nil, want: ""},
+		{
+			name: "data_error",
+			data: &lifecycle.AgentStreamEventData{Error: "top-level error"},
+			want: "top-level error",
+		},
+		{
+			name: "structured_error",
+			data: &lifecycle.AgentStreamEventData{Data: map[string]interface{}{"error": "structured error"}},
+			want: "structured error",
+		},
+		{
+			name: "structured_message",
+			data: &lifecycle.AgentStreamEventData{Data: map[string]interface{}{"message": "structured message"}},
+			want: "structured message",
+		},
+		{
+			name: "agent_text_ignored",
+			data: &lifecycle.AgentStreamEventData{Text: "agent output"},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractCompleteErrorMessage(&lifecycle.AgentStreamEventPayload{Data: tc.data})
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TestSetSessionWaitingForInput_WritesOnTransition is the symmetric counterpart
 // to TestSetSessionRunning_WritesOnTransition: when the session is NOT already
 // WAITING_FOR_INPUT, setSessionWaitingForInput MUST still fire the task write.

--- a/docs/specs/office/automations-settings.md
+++ b/docs/specs/office/automations-settings.md
@@ -75,7 +75,7 @@ Inherits PR #406's model (no per-action authorization gates). The flat `/setting
 | `listWorkspaces` fails on the flat page | Page renders the empty state (treating "couldn't load" as "no workspaces"). |
 | Run-mode automation's task starts but agent fails | AutomationRun transitions from `task_created` to `failed`; the row surfaces the failure instead of remaining "Running". |
 | Run-mode automation's agent completes its turn successfully | AutomationRun transitions from `task_created` to `succeeded`; the agent execution and ephemeral worktree are torn down. |
-| Run-mode automation's turn is cancelled by the user | The stream-complete handler defers to the cancel path instead of marking the run `succeeded` or `failed`; cancellation-owned lifecycle cleanup remains responsible for the final outcome. |
+| Run-mode automation's turn is cancelled by the user | AutomationRun transitions from `task_created` to `failed` with a cancellation error; the hidden session is marked `CANCELLED` and the agent execution is torn down. |
 | User manually drags a run-mode task on the kanban | Cannot happen — ephemeral tasks are hidden from the kanban. The "auto-start" rule fires once at trigger time; no manual recovery path. |
 | Existing automation upgraded from pre-execution_mode version | Migration sets `execution_mode = 'task'` for all existing rows. UI shows them with "Task" badge. |
 | User edits `execution_mode` from `task` to `run` on an enabled automation | Next firing uses the new mode. In-flight runs are unaffected. |

--- a/docs/specs/office/automations-settings.md
+++ b/docs/specs/office/automations-settings.md
@@ -61,6 +61,7 @@ trigger fires
   → record AutomationRun (status=task_created, task_id set)
   → associate PR if github_pr trigger
   → if mode==run OR step.auto_start_agent: StartTask
+  → for mode==run: agent terminal turn outcome marks AutomationRun succeeded/failed and tears down the execution/worktree
 ```
 
 ## Permissions
@@ -72,7 +73,8 @@ Inherits PR #406's model (no per-action authorization gates). The flat `/setting
 | Dependency / invariant | Behavior |
 |---|---|
 | `listWorkspaces` fails on the flat page | Page renders the empty state (treating "couldn't load" as "no workspaces"). |
-| Run-mode automation's task starts but agent fails | AutomationRun stays at `task_created` status; task error_message reflects the failure. User sees the failed AutomationRun row. |
+| Run-mode automation's task starts but agent fails | AutomationRun transitions from `task_created` to `failed`; the row surfaces the failure instead of remaining "Running". |
+| Run-mode automation's agent completes its turn successfully | AutomationRun transitions from `task_created` to `succeeded`; the agent execution and ephemeral worktree are torn down. |
 | User manually drags a run-mode task on the kanban | Cannot happen — ephemeral tasks are hidden from the kanban. The "auto-start" rule fires once at trigger time; no manual recovery path. |
 | Existing automation upgraded from pre-execution_mode version | Migration sets `execution_mode = 'task'` for all existing rows. UI shows them with "Task" badge. |
 | User edits `execution_mode` from `task` to `run` on an enabled automation | Next firing uses the new mode. In-flight runs are unaffected. |
@@ -85,6 +87,7 @@ Inherits PR #406's model (no per-action authorization gates). The flat `/setting
 
 - **GIVEN** a user creates an automation with `execution_mode = "task"` and a cron trigger, **WHEN** the cron fires, **THEN** a normal kanban task appears with the rendered title; the user can click it, drag it, comment on it.
 - **GIVEN** a user creates an automation with `execution_mode = "run"` and a cron trigger, **WHEN** the cron fires, **THEN** an ephemeral task is created (not visible on the kanban), the agent starts automatically, and the AutomationRun row in the automation's history shows the result.
+- **GIVEN** a run-mode automation agent finishes a turn with `stop_reason = "end_turn"`, **WHEN** the complete event is handled, **THEN** the AutomationRun row is marked `succeeded` and the agent execution is stopped instead of waiting for process exit.
 - **GIVEN** a user opens `/settings/automations` in an install with one workspace, **WHEN** the page loads, **THEN** the browser redirects to `/settings/workspace/<id>/automations`.
 - **GIVEN** a user opens `/settings/automations` in an install with three workspaces, **WHEN** the page loads, **THEN** a workspace picker is shown; clicking one navigates to its automations.
 - **GIVEN** a user opens `/settings/automations` in a fresh install with zero workspaces, **WHEN** the page loads, **THEN** an empty-state card explains "create a workspace first" with a CTA.

--- a/docs/specs/office/automations-settings.md
+++ b/docs/specs/office/automations-settings.md
@@ -75,6 +75,7 @@ Inherits PR #406's model (no per-action authorization gates). The flat `/setting
 | `listWorkspaces` fails on the flat page | Page renders the empty state (treating "couldn't load" as "no workspaces"). |
 | Run-mode automation's task starts but agent fails | AutomationRun transitions from `task_created` to `failed`; the row surfaces the failure instead of remaining "Running". |
 | Run-mode automation's agent completes its turn successfully | AutomationRun transitions from `task_created` to `succeeded`; the agent execution and ephemeral worktree are torn down. |
+| Run-mode automation's turn is cancelled by the user | The stream-complete handler defers to the cancel path instead of marking the run `succeeded` or `failed`; cancellation-owned lifecycle cleanup remains responsible for the final outcome. |
 | User manually drags a run-mode task on the kanban | Cannot happen — ephemeral tasks are hidden from the kanban. The "auto-start" rule fires once at trigger time; no manual recovery path. |
 | Existing automation upgraded from pre-execution_mode version | Migration sets `execution_mode = 'task'` for all existing rows. UI shows them with "Task" badge. |
 | User edits `execution_mode` from `task` to `run` on an enabled automation | Next firing uses the new mode. In-flight runs are unaffected. |


### PR DESCRIPTION
Run-mode automations could stay marked as running because ACP agents may remain alive after `end_turn`; the completion path now finalizes the run and tears down the execution immediately.

## Important Changes

- Added stream-complete handling for ephemeral automation-run tasks so successful turns mark the run `succeeded`, failures mark it `failed`, and the active agent/worktree are cleaned up.
- Updated the automations settings spec to document terminal run-mode status and teardown behavior.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `go test -run TestHandleCompleteStreamEvent_RunModeAutomationStopsAndFinalizes ./internal/orchestrator`
- `git diff --check`

Closes #1456

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->