### PR TITLE
fix: expose session mcp to cursor acp

### DIFF
--- a/apps/backend/internal/agent/agents/cursor_acp.go
+++ b/apps/backend/internal/agent/agents/cursor_acp.go
@@ -60,8 +60,8 @@ func NewCursorACP() *CursorACP {
 				ModelFlag:      NewParam("--model", "{model}"),
 				IdleTimeout:    3 * time.Second,
 				BufferMaxBytes: DefaultBufferMaxBytes,
-				// cursor-agent has no MCP flag/env; write a project-local
-				// .cursor/mcp.json into the worktree (only if absent).
+				// cursor-agent has no MCP flag/env; write or merge a
+				// project-local .cursor/mcp.json into the worktree.
 				MCPStrategy: mcpconfig.CursorStrategy{},
 			},
 		},
@@ -105,12 +105,13 @@ func (a *CursorACP) BuildCommand(opts CommandOptions) Command {
 func (a *CursorACP) Runtime() *RuntimeConfig {
 	canRecover := true
 	return &RuntimeConfig{
-		Cmd:            Cmd(cursorACPBin, "acp").Build(),
-		WorkingDir:     "{workspace}",
-		Env:            map[string]string{},
-		ResourceLimits: ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
-		Protocol:       agent.ProtocolACP,
-		UserSkillDir:   ".cursor/skills",
+		Cmd:                Cmd(cursorACPBin, "acp").Build(),
+		WorkingDir:         "{workspace}",
+		Env:                map[string]string{},
+		ResourceLimits:     ResourceLimits{MemoryMB: 4096, CPUCores: 2.0, Timeout: time.Hour},
+		Protocol:           agent.ProtocolACP,
+		UserSkillDir:       ".cursor/skills",
+		ProjectMCPStrategy: mcpconfig.CursorStrategy{},
 		SessionConfig: SessionConfig{
 			NativeSessionResume: true,
 			CanRecover:          &canRecover,

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_project_mcp_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_project_mcp_test.go
@@ -50,6 +50,44 @@ func TestMaterializeRuntimeProjectMCPForPiWritesProjectFile(t *testing.T) {
 	}
 }
 
+func TestMaterializeRuntimeProjectMCPForCursorWritesProjectFile(t *testing.T) {
+	mgr := newTestManager(t)
+	execution := &AgentExecution{
+		ID:             "exec-1",
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		AgentProfileID: "profile-1",
+		WorkspacePath:  t.TempDir(),
+		Metadata:       map[string]interface{}{},
+		standalonePort: 45678,
+	}
+	agentConfig, ok := mgr.registry.Get("cursor-acp")
+	if !ok {
+		t.Fatal("cursor-acp agent missing from test registry")
+	}
+
+	if err := mgr.materializeRuntimeProjectMCP(context.Background(), execution, agentConfig); err != nil {
+		t.Fatalf("materializeRuntimeProjectMCP: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(execution.WorkspacePath, ".cursor", "mcp.json"))
+	if err != nil {
+		t.Fatalf("cursor mcp.json not written: %v", err)
+	}
+	var payload struct {
+		MCPServers map[string]struct {
+			URL string `json:"url"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("cursor mcp.json not valid JSON: %v\n%s", err, data)
+	}
+	kandev := payload.MCPServers[kandevMCPServerName]
+	if kandev.URL != "http://localhost:45678/mcp" {
+		t.Fatalf("kandev URL = %q", kandev.URL)
+	}
+}
+
 func TestMaterializeRuntimeProjectMCPSkipsWhenPortUnavailable(t *testing.T) {
 	mgr := newTestManager(t)
 	execution := &AgentExecution{


### PR DESCRIPTION
Cursor ACP sessions need Kandev session-scoped MCP tools, but cursor-agent only discovers project-local MCP config. Cursor ACP now uses the existing project MCP materialization path so in-app sessions get a `.cursor/mcp.json` entry for the session agentctl MCP server.

## Validation

- `go test -v -run TestMaterializeRuntimeProjectMCPForCursorWritesProjectFile ./internal/agent/runtime/lifecycle`
- `go test ./internal/agent/agents ./internal/agent/mcpconfig ./internal/agent/runtime/lifecycle`
- `make -C apps/backend fmt`
- `make -C apps/backend lint`
- `git diff --check`
- `make -C apps/backend test` was run; unrelated `TestLoadReplayBurst_HandlesLargeReplay` in `internal/agentctl/server/adapter/transport/acp` timed out after 10m, while touched packages passed.

Closes #1457

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->