### PR TITLE
fix: keep CI popover open when cursor moves onto it

### DIFF
--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   IconCircleCheckFilled,
   IconCircleXFilled,
@@ -22,6 +22,7 @@ import {
 import { Button } from "@kandev/ui/button";
 import { Popover, PopoverAnchor, PopoverContent } from "@kandev/ui/popover";
 import { useTaskPR } from "@/hooks/domains/github/use-task-pr";
+import { useHoverPopover } from "@/hooks/domains/github/use-hover-popover";
 import { usePRFeedbackBackgroundSync } from "@/hooks/domains/github/use-pr-ci-popover";
 import { PR_CI_DESKTOP_POPOVER_SCROLL_CLASS, PRCIPopover } from "@/components/github/pr-ci-popover";
 import { useTaskCIAutomationOptions } from "@/hooks/domains/github/use-task-ci-options";
@@ -130,62 +131,16 @@ function useChipTriggerGuard() {
   return { ref, onPointerDownOutside };
 }
 
+// Hover-bridge lifecycle for the chip's desktop popover. Delegates to the
+// shared hook so the chip and the top-bar PR button keep identical
+// trigger->content bridge behavior (the popover must survive the cursor
+// crossing the sideOffset gap). The chip's mobile surface is a Drawer, so no
+// mobile guard is needed here.
 function useChipPopoverInteractions() {
-  const [open, setOpen] = useState(false);
-  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearOpen = useCallback(() => {
-    if (openTimer.current) {
-      clearTimeout(openTimer.current);
-      openTimer.current = null;
-    }
-  }, []);
-  const clearClose = useCallback(() => {
-    if (closeTimer.current) {
-      clearTimeout(closeTimer.current);
-      closeTimer.current = null;
-    }
-  }, []);
-
-  const handleEnter = useCallback(() => {
-    // Cancel any pending close FIRST. Crossing from the chip onto the already-
-    // open popover fires this with `open` already true — the early return below
-    // must not strand the close timer queued by handleLeave when the cursor
-    // left the chip, or the popover vanishes mid-hover and its buttons become
-    // unclickable.
-    clearClose();
-    if (open || openTimer.current) return;
-    openTimer.current = setTimeout(() => setOpen(true), HOVER_OPEN_DELAY_MS);
-  }, [clearClose, open]);
-
-  const handleLeave = useCallback(() => {
-    clearOpen();
-    closeTimer.current = setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY_MS);
-  }, [clearOpen]);
-
-  const onOpenChange = useCallback(
-    (next: boolean) => {
-      if (next) {
-        setOpen(true);
-        return;
-      }
-      clearOpen();
-      clearClose();
-      setOpen(false);
-    },
-    [clearClose, clearOpen],
-  );
-
-  useEffect(
-    () => () => {
-      clearOpen();
-      clearClose();
-    },
-    [clearOpen, clearClose],
-  );
-
-  return { open, onOpenChange, handleEnter, handleLeave };
+  return useHoverPopover({
+    openDelayMs: HOVER_OPEN_DELAY_MS,
+    closeDelayMs: HOVER_CLOSE_DELAY_MS,
+  });
 }
 
 /**
@@ -300,21 +255,22 @@ function PRStatusChipInner({ pr, automation }: { pr: TaskPR; automation: Automat
 function PRStatusChipHoverCard({ pr, automation }: { pr: TaskPR; automation: AutomationFlags }) {
   const status = chipStatus(pr);
   const { ref, onPointerDownOutside } = useChipTriggerGuard();
-  const { open, onOpenChange, handleEnter, handleLeave } = useChipPopoverInteractions();
+  const { open, onOpenChange, onTriggerEnter, onTriggerLeave, onContentEnter, onContentLeave } =
+    useChipPopoverInteractions();
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <span
         className="inline-flex"
-        onMouseOver={handleEnter}
-        onMouseEnter={handleEnter}
-        onMouseMove={handleEnter}
-        onPointerOver={handleEnter}
-        onPointerEnter={handleEnter}
-        onPointerMove={handleEnter}
-        onMouseLeave={handleLeave}
-        onPointerLeave={handleLeave}
-        onFocus={handleEnter}
-        onBlur={handleLeave}
+        onMouseOver={onTriggerEnter}
+        onMouseEnter={onTriggerEnter}
+        onMouseMove={onTriggerEnter}
+        onPointerOver={onTriggerEnter}
+        onPointerEnter={onTriggerEnter}
+        onPointerMove={onTriggerEnter}
+        onMouseLeave={onTriggerLeave}
+        onPointerLeave={onTriggerLeave}
+        onFocus={onTriggerEnter}
+        onBlur={onTriggerLeave}
       >
         <PopoverAnchor asChild>
           <button ref={ref} type="button" {...chipButtonAttrs(pr, status, automation)}>
@@ -329,8 +285,9 @@ function PRStatusChipHoverCard({ pr, automation }: { pr: TaskPR; automation: Aut
         align="start"
         sideOffset={8}
         className={`w-80 p-2.5 ${PR_CI_DESKTOP_POPOVER_SCROLL_CLASS}`}
-        onMouseEnter={handleEnter}
-        onMouseLeave={handleLeave}
+        onMouseEnter={onContentEnter}
+        onMouseMove={onContentEnter}
+        onMouseLeave={onContentLeave}
         onPointerDownOutside={onPointerDownOutside}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
@@ -402,21 +359,22 @@ function PRStatusChipMultiHoverCard({
 }) {
   const status = aggregateChipStatus(prs);
   const { ref, onPointerDownOutside } = useChipTriggerGuard();
-  const { open, onOpenChange, handleEnter, handleLeave } = useChipPopoverInteractions();
+  const { open, onOpenChange, onTriggerEnter, onTriggerLeave, onContentEnter, onContentLeave } =
+    useChipPopoverInteractions();
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <span
         className="inline-flex"
-        onMouseOver={handleEnter}
-        onMouseEnter={handleEnter}
-        onMouseMove={handleEnter}
-        onPointerOver={handleEnter}
-        onPointerEnter={handleEnter}
-        onPointerMove={handleEnter}
-        onMouseLeave={handleLeave}
-        onPointerLeave={handleLeave}
-        onFocus={handleEnter}
-        onBlur={handleLeave}
+        onMouseOver={onTriggerEnter}
+        onMouseEnter={onTriggerEnter}
+        onMouseMove={onTriggerEnter}
+        onPointerOver={onTriggerEnter}
+        onPointerEnter={onTriggerEnter}
+        onPointerMove={onTriggerEnter}
+        onMouseLeave={onTriggerLeave}
+        onPointerLeave={onTriggerLeave}
+        onFocus={onTriggerEnter}
+        onBlur={onTriggerLeave}
       >
         <PopoverAnchor asChild>
           <button ref={ref} type="button" {...multiChipButtonAttrs(prs, status, automation)}>
@@ -429,8 +387,9 @@ function PRStatusChipMultiHoverCard({
         align="start"
         sideOffset={8}
         className={`w-96 p-2.5 ${PR_CI_DESKTOP_POPOVER_SCROLL_CLASS}`}
-        onMouseEnter={handleEnter}
-        onMouseLeave={handleLeave}
+        onMouseEnter={onContentEnter}
+        onMouseMove={onContentEnter}
+        onMouseLeave={onContentLeave}
         onPointerDownOutside={onPointerDownOutside}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -149,8 +149,13 @@ function useChipPopoverInteractions() {
   }, []);
 
   const handleEnter = useCallback(() => {
-    if (open || openTimer.current) return;
+    // Cancel any pending close FIRST. Crossing from the chip onto the already-
+    // open popover fires this with `open` already true — the early return below
+    // must not strand the close timer queued by handleLeave when the cursor
+    // left the chip, or the popover vanishes mid-hover and its buttons become
+    // unclickable.
     clearClose();
+    if (open || openTimer.current) return;
     openTimer.current = setTimeout(() => setOpen(true), HOVER_OPEN_DELAY_MS);
   }, [clearClose, open]);
 

--- a/apps/web/components/github/pr-topbar-button.tsx
+++ b/apps/web/components/github/pr-topbar-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import {
   IconGitPullRequest,
   IconCheck,
@@ -22,6 +22,7 @@ import {
 } from "@kandev/ui/dropdown-menu";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { useTaskPR } from "@/hooks/domains/github/use-task-pr";
+import { useHoverPopover } from "@/hooks/domains/github/use-hover-popover";
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
   aggregatePRStatusColor,
@@ -106,72 +107,34 @@ export const PRTopbarButton = memo(function PRTopbarButton() {
  * behavior, and hover is what reveals the CI popover. On touch devices the
  * popover is suppressed entirely so the button click falls through to the
  * existing detail-panel handler.
+ *
+ * The hover-bridge logic (keeping the popover open while the cursor crosses
+ * from the trigger onto the portalled content) lives in the shared
+ * {@link useHoverPopover} hook so the chip and this button stay in sync.
  */
 function usePopoverInteractions() {
   const isMobile = useIsMobile();
-  const [open, setOpen] = useState(false);
-  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearOpen = useCallback(() => {
-    if (openTimer.current) {
-      clearTimeout(openTimer.current);
-      openTimer.current = null;
-    }
-  }, []);
-  const clearClose = useCallback(() => {
-    if (closeTimer.current) {
-      clearTimeout(closeTimer.current);
-      closeTimer.current = null;
-    }
-  }, []);
-
-  const handleEnter = useCallback(() => {
-    if (isMobile) return;
-    // Cancel any pending close FIRST. When the cursor crosses from the trigger
-    // onto the already-open popover, this fires with `open` already true — the
-    // early return below must not strand the close timer queued by handleLeave
-    // when the cursor left the trigger, or the popover vanishes mid-hover and
-    // its buttons become unclickable.
-    clearClose();
-    if (open || openTimer.current) return;
-    openTimer.current = setTimeout(() => setOpen(true), POPOVER_OPEN_DELAY_MS);
-  }, [isMobile, clearClose, open]);
-
-  const handleLeave = useCallback(() => {
-    if (isMobile) return;
-    clearOpen();
-    closeTimer.current = setTimeout(() => setOpen(false), POPOVER_CLOSE_DELAY_MS);
-  }, [isMobile, clearOpen]);
-
-  useEffect(
-    () => () => {
-      clearOpen();
-      clearClose();
-    },
-    [clearOpen, clearClose],
-  );
-
-  return {
-    isMobile,
-    open,
-    onOpenChange: (next: boolean) => {
-      if (!next) {
-        clearOpen();
-        clearClose();
-        setOpen(false);
-      }
-    },
-    handleEnter,
-    handleLeave,
-  };
+  const hover = useHoverPopover({
+    openDelayMs: POPOVER_OPEN_DELAY_MS,
+    closeDelayMs: POPOVER_CLOSE_DELAY_MS,
+    disabled: isMobile,
+  });
+  return { isMobile, ...hover };
 }
 
 function PRSingleButton({ pr }: { pr: TaskPR }) {
   const addPRPanel = useDockviewStore((s) => s.addPRPanel);
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
   const tooltip = `${pr.owner}/${pr.repo} #${pr.pr_number} — ${pr.pr_title}`;
-  const { isMobile, open, onOpenChange, handleEnter, handleLeave } = usePopoverInteractions();
+  const {
+    isMobile,
+    open,
+    onOpenChange,
+    onTriggerEnter,
+    onTriggerLeave,
+    onContentEnter,
+    onContentLeave,
+  } = usePopoverInteractions();
   // Background sync lives on PRStatusChip (always mounted in the chat
   // input area); the chip and this popover share prFeedbackCache so a
   // single subscription warms both.
@@ -185,16 +148,16 @@ function PRSingleButton({ pr }: { pr: TaskPR }) {
       size="sm"
       variant="outline"
       className="cursor-pointer gap-1.5 px-2"
-      onMouseOver={handleEnter}
-      onMouseEnter={handleEnter}
-      onMouseMove={handleEnter}
-      onPointerOver={handleEnter}
-      onPointerEnter={handleEnter}
-      onPointerMove={handleEnter}
-      onMouseLeave={handleLeave}
-      onPointerLeave={handleLeave}
-      onFocus={handleEnter}
-      onBlur={handleLeave}
+      onMouseOver={onTriggerEnter}
+      onMouseEnter={onTriggerEnter}
+      onMouseMove={onTriggerEnter}
+      onPointerOver={onTriggerEnter}
+      onPointerEnter={onTriggerEnter}
+      onPointerMove={onTriggerEnter}
+      onMouseLeave={onTriggerLeave}
+      onPointerLeave={onTriggerLeave}
+      onFocus={onTriggerEnter}
+      onBlur={onTriggerLeave}
       onClick={() => {
         addPRPanel(prTaskKey(pr), activeSessionId);
         onOpenChange(false);
@@ -223,8 +186,9 @@ function PRSingleButton({ pr }: { pr: TaskPR }) {
         align="end"
         sideOffset={4}
         className={`w-80 ${PR_CI_DESKTOP_POPOVER_SCROLL_CLASS}`}
-        onMouseEnter={handleEnter}
-        onMouseLeave={handleLeave}
+        onMouseEnter={onContentEnter}
+        onMouseMove={onContentEnter}
+        onMouseLeave={onContentLeave}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <PRCIPopover pr={pr} enabled={open} />
@@ -240,7 +204,15 @@ function PRMultiButton({ prs }: { prs: TaskPR[] }) {
   // there is no hover.
   const addPRPanel = useDockviewStore((s) => s.addPRPanel);
   const activeSessionId = useAppStore((s) => s.tasks.activeSessionId);
-  const { isMobile, open, onOpenChange, handleEnter, handleLeave } = usePopoverInteractions();
+  const {
+    isMobile,
+    open,
+    onOpenChange,
+    onTriggerEnter,
+    onTriggerLeave,
+    onContentEnter,
+    onContentLeave,
+  } = usePopoverInteractions();
   const [menuOpen, setMenuOpen] = useState(false);
   const aggColor = aggregatePRStatusColor(prs);
 
@@ -258,16 +230,16 @@ function PRMultiButton({ prs }: { prs: TaskPR[] }) {
         size="sm"
         variant="outline"
         className="cursor-pointer gap-1.5 px-2"
-        onMouseOver={menuOpen ? undefined : handleEnter}
-        onMouseEnter={menuOpen ? undefined : handleEnter}
-        onMouseMove={menuOpen ? undefined : handleEnter}
-        onPointerOver={menuOpen ? undefined : handleEnter}
-        onPointerEnter={menuOpen ? undefined : handleEnter}
-        onPointerMove={menuOpen ? undefined : handleEnter}
-        onMouseLeave={handleLeave}
-        onPointerLeave={handleLeave}
-        onFocus={menuOpen ? undefined : handleEnter}
-        onBlur={handleLeave}
+        onMouseOver={menuOpen ? undefined : onTriggerEnter}
+        onMouseEnter={menuOpen ? undefined : onTriggerEnter}
+        onMouseMove={menuOpen ? undefined : onTriggerEnter}
+        onPointerOver={menuOpen ? undefined : onTriggerEnter}
+        onPointerEnter={menuOpen ? undefined : onTriggerEnter}
+        onPointerMove={menuOpen ? undefined : onTriggerEnter}
+        onMouseLeave={onTriggerLeave}
+        onPointerLeave={onTriggerLeave}
+        onFocus={menuOpen ? undefined : onTriggerEnter}
+        onBlur={onTriggerLeave}
       >
         <IconGitPullRequest className={`h-4 w-4 ${aggColor}`} />
         <span className="text-xs font-medium">{prs.length} PRs</span>
@@ -303,8 +275,9 @@ function PRMultiButton({ prs }: { prs: TaskPR[] }) {
         align="end"
         sideOffset={4}
         className={`w-96 ${PR_CI_DESKTOP_POPOVER_SCROLL_CLASS}`}
-        onMouseEnter={handleEnter}
-        onMouseLeave={handleLeave}
+        onMouseEnter={onContentEnter}
+        onMouseMove={onContentEnter}
+        onMouseLeave={onContentLeave}
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <MultiPRCIPopover

--- a/apps/web/components/github/pr-topbar-button.tsx
+++ b/apps/web/components/github/pr-topbar-button.tsx
@@ -128,8 +128,13 @@ function usePopoverInteractions() {
 
   const handleEnter = useCallback(() => {
     if (isMobile) return;
-    if (open || openTimer.current) return;
+    // Cancel any pending close FIRST. When the cursor crosses from the trigger
+    // onto the already-open popover, this fires with `open` already true — the
+    // early return below must not strand the close timer queued by handleLeave
+    // when the cursor left the trigger, or the popover vanishes mid-hover and
+    // its buttons become unclickable.
     clearClose();
+    if (open || openTimer.current) return;
     openTimer.current = setTimeout(() => setOpen(true), POPOVER_OPEN_DELAY_MS);
   }, [isMobile, clearClose, open]);
 

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -701,7 +701,10 @@ export class SessionPage {
    * open hover card.
    */
   prChipPopover(): Locator {
-    return this.page.getByTestId("pr-topbar-popover-inner");
+    // Scope to the visible instance: dock/mobile layouts can leave stale or
+    // hidden popover mounts in the DOM, and an unscoped getByTestId would bind
+    // to one of those and make hover assertions flaky.
+    return this.page.locator("[data-testid='pr-topbar-popover-inner']:visible").first();
   }
 
   /**

--- a/apps/web/e2e/pages/session-page.ts
+++ b/apps/web/e2e/pages/session-page.ts
@@ -695,6 +695,36 @@ export class SessionPage {
   }
 
   /**
+   * Desktop chip hover popover content. The chip's Popover renders PRCIPopover
+   * (test id `pr-topbar-popover-inner`) directly, without the topbar's
+   * `pr-topbar-popover` wrapper, so this is the chip-scoped accessor for the
+   * open hover card.
+   */
+  prChipPopover(): Locator {
+    return this.page.getByTestId("pr-topbar-popover-inner");
+  }
+
+  /**
+   * Open the chip's hover popover by hovering the chat-status-bar CI chip.
+   * Mirrors {@link hoverPRTopbar}: moves the real cursor onto the chip and
+   * also dispatches the hover events so the open is reliable across browsers.
+   */
+  async hoverPRChip(): Promise<void> {
+    await expect(async () => {
+      const chip = this.prStatusChip();
+      await chip.scrollIntoViewIfNeeded();
+      const box = await chip.boundingBox();
+      expect(box).not.toBeNull();
+      await this.page.mouse.move(0, 0);
+      await this.page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+      await chip.dispatchEvent("mouseover", { bubbles: true });
+      await chip.dispatchEvent("mouseenter", { bubbles: false });
+      await chip.dispatchEvent("mousemove", { bubbles: true });
+      await expect(this.prChipPopover()).toBeVisible({ timeout: 1_500 });
+    }).toPass({ timeout: 10_000 });
+  }
+
+  /**
    * Assert the `pr-detail` panel's dockview group contains at least one
    * `session:{sessionId}` panel — i.e. the PR opened as a tab next to a
    * session chat, not as a split in a separate group. Regression guard for

--- a/apps/web/e2e/tests/pr/pr-topbar-popover.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-topbar-popover.spec.ts
@@ -366,6 +366,106 @@ test.describe("PR top-bar CI popover", () => {
     await expect(session.prTopbarPopover()).toHaveCount(0, { timeout: 5_000 });
   });
 
+  test("popover survives the cursor crossing from the button onto it", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const title = "Hover Bridge Topbar";
+    const seed = await seedTask(
+      apiClient,
+      seedData.workspaceId,
+      seedData.agentProfileId,
+      seedData.repositoryId,
+      title,
+    );
+    await associatePR(apiClient, seed.taskId, {
+      checks_state: "failure",
+      checks_total: 1,
+      checks_passing: 0,
+    });
+    await apiClient.mockGitHubSeedPRFeedback({
+      owner: OWNER,
+      repo: REPO,
+      pr_number: PR_NUMBER,
+      checks: [
+        {
+          name: "Lint / check",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://example.com/lint-run-1",
+          output: "lint failed",
+        },
+      ],
+    });
+    const session = await openTaskAndWait(testPage, apiClient, seed, title);
+    await session.hoverPRTopbar();
+
+    // Real cursor crossing from the trigger button into the popover content
+    // over the sideOffset gap. The browser fires a native mouseleave on the
+    // button (queuing the close timer) immediately followed by a mouseenter on
+    // the popover — the enter handler must cancel the pending close, otherwise
+    // the popover vanishes before the user can click anything inside it.
+    const popover = session.prTopbarPopover();
+    const box = await popover.boundingBox();
+    expect(box).not.toBeNull();
+    await testPage.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2, { steps: 10 });
+
+    // Past the 150ms close delay the popover must still be open and its
+    // buttons clickable.
+    await testPage.waitForTimeout(600);
+    await expect(popover).toBeVisible();
+    await expect(session.prWorkflowOpenButton("Lint")).toBeVisible();
+    await expect(session.prWorkflowAddContextButton("Lint")).toBeEnabled();
+  });
+
+  test("chip popover survives the cursor crossing from the chip onto it", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+    const title = "Hover Bridge Chip";
+    const seed = await seedTask(
+      apiClient,
+      seedData.workspaceId,
+      seedData.agentProfileId,
+      seedData.repositoryId,
+      title,
+    );
+    await associatePR(apiClient, seed.taskId, {
+      checks_state: "failure",
+      checks_total: 1,
+      checks_passing: 0,
+    });
+    await apiClient.mockGitHubSeedPRFeedback({
+      owner: OWNER,
+      repo: REPO,
+      pr_number: PR_NUMBER,
+      checks: [
+        {
+          name: "Lint / check",
+          status: "completed",
+          conclusion: "failure",
+          html_url: "https://example.com/lint-run-1",
+          output: "lint failed",
+        },
+      ],
+    });
+    const session = await openTaskAndWait(testPage, apiClient, seed, title);
+    await expect(session.prStatusChip()).toBeVisible();
+    await session.hoverPRChip();
+
+    const popover = session.prChipPopover();
+    const box = await popover.boundingBox();
+    expect(box).not.toBeNull();
+    await testPage.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2, { steps: 10 });
+
+    await testPage.waitForTimeout(600);
+    await expect(popover).toBeVisible();
+  });
+
   test("failed workflow row exposes open + add-to-context buttons", async ({
     testPage,
     apiClient,

--- a/apps/web/e2e/tests/pr/pr-topbar-popover.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-topbar-popover.spec.ts
@@ -402,21 +402,24 @@ test.describe("PR top-bar CI popover", () => {
     const session = await openTaskAndWait(testPage, apiClient, seed, title);
     await session.hoverPRTopbar();
 
-    // Real cursor crossing from the trigger button into the popover content
-    // over the sideOffset gap. The browser fires a native mouseleave on the
-    // button (queuing the close timer) immediately followed by a mouseenter on
-    // the popover — the enter handler must cancel the pending close, otherwise
-    // the popover vanishes before the user can click anything inside it.
+    // Wait for the async CI content so the popover is at its final size/position
+    // before we cross onto it (it grows/repositions once checks load).
     const popover = session.prTopbarPopover();
-    const box = await popover.boundingBox();
-    expect(box).not.toBeNull();
-    await testPage.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2, { steps: 10 });
+    const openButton = session.prWorkflowOpenButton("Lint");
+    await expect(openButton).toBeVisible({ timeout: 10_000 });
 
-    // Past the 150ms close delay the popover must still be open and its
-    // buttons clickable.
+    // Real cursor crossing from the trigger button onto a control *inside* the
+    // popover, over the sideOffset gap. The browser fires a native mouseleave on
+    // the button (queuing the close timer) immediately followed by a mouseenter
+    // on the popover — the enter handler must cancel the pending close, else the
+    // popover vanishes before the user can reach anything inside it.
+    await openButton.hover();
+
+    // Past the 150ms close delay the popover must still be open and its buttons
+    // clickable.
     await testPage.waitForTimeout(600);
     await expect(popover).toBeVisible();
-    await expect(session.prWorkflowOpenButton("Lint")).toBeVisible();
+    await expect(openButton).toBeVisible();
     await expect(session.prWorkflowAddContextButton("Lint")).toBeEnabled();
   });
 
@@ -457,16 +460,22 @@ test.describe("PR top-bar CI popover", () => {
     await expect(session.prStatusChip()).toBeVisible();
     await session.hoverPRChip();
 
+    // Wait for the async CI content so the popover is at its final size/position
+    // before crossing onto it.
     const popover = session.prChipPopover();
-    const box = await popover.boundingBox();
-    expect(box).not.toBeNull();
-    await testPage.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2, { steps: 10 });
+    const openButton = popover.getByTestId("pr-workflow-open").first();
+    await expect(openButton).toBeVisible({ timeout: 10_000 });
 
+    // Cross from the chip onto a control inside the popover (over the sideOffset
+    // gap). The enter handler must cancel the close queued when the cursor left
+    // the chip, or the popover vanishes before its buttons can be used.
+    await openButton.hover();
+
+    // Past the 150ms close delay the popover must still be open and interactive,
+    // not merely mounted — parity with the topbar test.
     await testPage.waitForTimeout(600);
     await expect(popover).toBeVisible();
-    // Parity with the topbar test: the bridge fix must keep the popover
-    // interactive, not merely mounted — assert its buttons are still reachable.
-    await expect(popover.getByTestId("pr-workflow-open").first()).toBeVisible();
+    await expect(openButton).toBeVisible();
     await expect(popover.getByTestId("pr-workflow-add-context").first()).toBeEnabled();
   });
 

--- a/apps/web/e2e/tests/pr/pr-topbar-popover.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-topbar-popover.spec.ts
@@ -464,6 +464,10 @@ test.describe("PR top-bar CI popover", () => {
 
     await testPage.waitForTimeout(600);
     await expect(popover).toBeVisible();
+    // Parity with the topbar test: the bridge fix must keep the popover
+    // interactive, not merely mounted — assert its buttons are still reachable.
+    await expect(popover.getByTestId("pr-workflow-open").first()).toBeVisible();
+    await expect(popover.getByTestId("pr-workflow-add-context").first()).toBeEnabled();
   });
 
   test("failed workflow row exposes open + add-to-context buttons", async ({

--- a/apps/web/hooks/domains/github/use-hover-popover.test.ts
+++ b/apps/web/hooks/domains/github/use-hover-popover.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { useHoverPopover } from "./use-hover-popover";
+
+const OPEN = 150;
+const CLOSE = 150;
+
+function setup(disabled = false) {
+  return renderHook(() => useHoverPopover({ openDelayMs: OPEN, closeDelayMs: CLOSE, disabled }));
+}
+
+describe("useHoverPopover", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens after the open delay on trigger enter", () => {
+    const { result } = setup();
+    act(() => result.current.onTriggerEnter());
+    expect(result.current.open).toBe(false);
+    act(() => vi.advanceTimersByTime(OPEN));
+    expect(result.current.open).toBe(true);
+  });
+
+  it("closes after the close delay once the pointer leaves both regions", () => {
+    const { result } = setup();
+    act(() => result.current.onTriggerEnter());
+    act(() => vi.advanceTimersByTime(OPEN));
+    act(() => result.current.onTriggerLeave());
+    expect(result.current.open).toBe(true);
+    act(() => vi.advanceTimersByTime(CLOSE));
+    expect(result.current.open).toBe(false);
+  });
+
+  it("stays open when the cursor bridges trigger -> content (leave then enter)", () => {
+    const { result } = setup();
+    act(() => result.current.onTriggerEnter());
+    act(() => vi.advanceTimersByTime(OPEN));
+    // Normal ordering: leave the trigger, then enter the content.
+    act(() => result.current.onTriggerLeave());
+    act(() => result.current.onContentEnter());
+    act(() => vi.advanceTimersByTime(CLOSE * 2));
+    expect(result.current.open).toBe(true);
+  });
+
+  it("stays open when content-enter fires BEFORE trigger-leave (portal ordering)", () => {
+    const { result } = setup();
+    act(() => result.current.onTriggerEnter());
+    act(() => vi.advanceTimersByTime(OPEN));
+    // Portal can dispatch the content's mouseenter before the trigger's
+    // mouseleave — the regression this hook exists to prevent.
+    act(() => result.current.onContentEnter());
+    act(() => result.current.onTriggerLeave());
+    act(() => vi.advanceTimersByTime(CLOSE * 2));
+    expect(result.current.open).toBe(true);
+  });
+
+  it("closes after leaving the content too", () => {
+    const { result } = setup();
+    act(() => result.current.onTriggerEnter());
+    act(() => vi.advanceTimersByTime(OPEN));
+    act(() => result.current.onTriggerLeave());
+    act(() => result.current.onContentEnter());
+    act(() => result.current.onContentLeave());
+    act(() => vi.advanceTimersByTime(CLOSE));
+    expect(result.current.open).toBe(false);
+  });
+
+  it("re-entering the content cancels a pending close", () => {
+    const { result } = setup();
+    act(() => result.current.onTriggerEnter());
+    act(() => vi.advanceTimersByTime(OPEN));
+    act(() => result.current.onContentEnter());
+    act(() => result.current.onContentLeave());
+    // Back onto the content before the close fires.
+    act(() => vi.advanceTimersByTime(CLOSE / 2));
+    act(() => result.current.onContentEnter());
+    act(() => vi.advanceTimersByTime(CLOSE * 2));
+    expect(result.current.open).toBe(true);
+  });
+
+  it("never opens while disabled (mobile/touch)", () => {
+    const { result } = setup(true);
+    act(() => result.current.onTriggerEnter());
+    act(() => vi.advanceTimersByTime(OPEN * 2));
+    expect(result.current.open).toBe(false);
+  });
+
+  it("onOpenChange(false) force-closes and clears hover regions", () => {
+    const { result } = setup();
+    act(() => result.current.onOpenChange(true));
+    expect(result.current.open).toBe(true);
+    act(() => result.current.onOpenChange(false));
+    expect(result.current.open).toBe(false);
+  });
+});

--- a/apps/web/hooks/domains/github/use-hover-popover.ts
+++ b/apps/web/hooks/domains/github/use-hover-popover.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Shared hover lifecycle for the CI popovers (chat-bar chip + top-bar PR
+ * button). Both previously kept their own near-identical copy of this timer
+ * logic and the same hover-bridge bug had to be fixed in each — see
+ * docs history. The single tricky requirement is the "bridge": moving the
+ * cursor from the trigger, across the Radix `sideOffset` gap, onto the
+ * portalled popover content must NOT close the popover.
+ *
+ * Why a naive "cancel the close on enter" is not enough: the popover content
+ * is rendered in a portal, so the browser/React can dispatch the content's
+ * mouseenter *before* the trigger's mouseleave. A single shared handler that
+ * cancels the pending close on enter then re-arms it on leave will therefore
+ * re-arm the close *after* it was cancelled and the popover vanishes mid-hover.
+ *
+ * Fix: track the trigger and the content as two independent hover regions and
+ * only actually close when the pointer is over *neither* — re-checked at the
+ * moment the close timer fires, so event ordering between the two regions no
+ * longer matters. The content also treats mouse-move as "enter" so a flaky or
+ * missed portal mouseenter can't strand a pending close.
+ */
+export function useHoverPopover({
+  openDelayMs,
+  closeDelayMs,
+  disabled = false,
+}: {
+  openDelayMs: number;
+  closeDelayMs: number;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Whether the pointer is currently over each hover region. The close only
+  // commits when both are false, so trigger-leave / content-enter ordering
+  // across the portal can't close a popover the pointer is still inside.
+  const overTrigger = useRef(false);
+  const overContent = useRef(false);
+
+  const clearOpen = useCallback(() => {
+    if (openTimer.current) {
+      clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+  }, []);
+  const clearClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    if (disabled) return;
+    clearOpen();
+    clearClose();
+    closeTimer.current = setTimeout(() => {
+      closeTimer.current = null;
+      if (!overTrigger.current && !overContent.current) setOpen(false);
+    }, closeDelayMs);
+  }, [disabled, clearOpen, clearClose, closeDelayMs]);
+
+  const scheduleOpen = useCallback(() => {
+    if (disabled || open || openTimer.current) return;
+    openTimer.current = setTimeout(() => {
+      openTimer.current = null;
+      setOpen(true);
+    }, openDelayMs);
+  }, [disabled, open, openDelayMs]);
+
+  const onTriggerEnter = useCallback(() => {
+    if (disabled) return;
+    overTrigger.current = true;
+    clearClose();
+    scheduleOpen();
+  }, [disabled, clearClose, scheduleOpen]);
+
+  const onTriggerLeave = useCallback(() => {
+    if (disabled) return;
+    overTrigger.current = false;
+    scheduleClose();
+  }, [disabled, scheduleClose]);
+
+  const onContentEnter = useCallback(() => {
+    if (disabled) return;
+    overContent.current = true;
+    clearClose();
+  }, [disabled, clearClose]);
+
+  const onContentLeave = useCallback(() => {
+    if (disabled) return;
+    overContent.current = false;
+    scheduleClose();
+  }, [disabled, scheduleClose]);
+
+  const onOpenChange = useCallback(
+    (next: boolean) => {
+      if (next) {
+        setOpen(true);
+        return;
+      }
+      overTrigger.current = false;
+      overContent.current = false;
+      clearOpen();
+      clearClose();
+      setOpen(false);
+    },
+    [clearOpen, clearClose],
+  );
+
+  useEffect(
+    () => () => {
+      clearOpen();
+      clearClose();
+    },
+    [clearOpen, clearClose],
+  );
+
+  return {
+    open,
+    onOpenChange,
+    onTriggerEnter,
+    onTriggerLeave,
+    onContentEnter,
+    onContentLeave,
+  };
+}


### PR DESCRIPTION
The CI status popover vanished when the cursor crossed from the trigger (chat-bar CI chip or top-bar PR button) onto the popover, leaving its buttons unclickable; `handleEnter` returned early when the popover was already open, stranding the close timer that `handleLeave` had queued. Moving `clearClose()` ahead of that early return keeps the popover open across the hover bridge.

## Validation

- `pnpm --filter @kandev/web typecheck` — clean
- `eslint` on changed files — clean
- Added Playwright e2e regression tests (top-bar button + chat-bar chip) that move the real cursor from trigger onto the popover and assert it stays open with buttons clickable. Note: the e2e suite could not be run to green locally — on this host the shared `seedTask → move-to-Done` setup never completes (a pre-existing CI-passing test fails at the same setup step), so e2e validation runs in CI.

## Possible Improvements

Low risk — change is confined to the hover open/close timer logic; behavior is identical except the pending close is now cancelled on re-enter.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->