### PR TITLE
fix: stop task runtimes from leaking

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -160,6 +160,7 @@ type mockAgentManager struct {
 
 	mu                      sync.Mutex
 	stopAgentWithReasonArgs []stopAgentCall // tracks StopAgentWithReason calls
+	stopAgentWithReasonErr  error           // optional error to return from StopAgentWithReason
 	stopAgentArgs           []stopAgentCall // tracks StopAgent calls (no reason)
 	stopAgentErr            error           // optional error to return from StopAgent
 
@@ -262,7 +263,7 @@ func (m *mockAgentManager) StopAgentWithReason(_ context.Context, agentExecution
 		Reason:      reason,
 		Force:       force,
 	})
-	return nil
+	return m.stopAgentWithReasonErr
 }
 func (m *mockAgentManager) PromptAgent(_ context.Context, executionID string, prompt string, _ []v1.MessageAttachment, _ bool) (*executor.PromptResult, error) {
 	m.mu.Lock()

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1123,11 +1123,7 @@ func (s *Service) handleMissingSessionOnStartup(ctx context.Context, running *mo
 }
 
 func isTaskSessionNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "agent session not found") || strings.Contains(msg, "session not found")
+	return errors.Is(err, models.ErrTaskSessionNotFound)
 }
 
 // handleTerminalSessionOnStartup processes sessions in terminal states during startup.

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -960,7 +960,8 @@ func (s *Service) Stop() error {
 //
 // Strategy:
 //
-//  1. Terminal states (Completed/Cancelled/Failed) → clean up executor record
+//  1. Terminal states (Completed/Cancelled/Failed) → stop any persisted runtime handle,
+//     then clean up executor record only after a confirmed stop
 //  2. Never-started (Created) → clean up executor record
 //  3. Active states (Starting/Running/WaitingForInput) → set session to WAITING_FOR_INPUT,
 //     clear stale execution IDs, fix task state, preserve ExecutorRunning record
@@ -1009,7 +1010,11 @@ func (s *Service) reconcileOneSessionOnStartup(ctx context.Context, running *mod
 
 	session, err := s.repo.GetTaskSession(ctx, sessionID)
 	if err != nil {
-		s.logger.Warn("failed to load session for reconciliation",
+		if isTaskSessionNotFound(err) {
+			s.handleMissingSessionOnStartup(ctx, running)
+			return
+		}
+		s.logger.Warn("failed to load session for reconciliation; preserving executor record",
 			zap.String("session_id", sessionID),
 			zap.Error(err))
 		return
@@ -1092,16 +1097,59 @@ func (s *Service) reconcileOneSessionOnStartup(ctx context.Context, running *mod
 		zap.Bool("has_worktree", running.WorktreePath != ""))
 }
 
+func (s *Service) handleMissingSessionOnStartup(ctx context.Context, running *models.ExecutorRunning) {
+	sessionID := running.SessionID
+	executionID := strings.TrimSpace(running.AgentExecutionID)
+	if executionID == "" || s.agentManager == nil {
+		s.logger.Warn("executor record has no session and no stoppable runtime handle; preserving record",
+			zap.String("session_id", sessionID),
+			zap.String("task_id", running.TaskID))
+		return
+	}
+	if err := s.agentManager.StopAgentWithReason(ctx, executionID, "startup missing session cleanup", true); err != nil {
+		s.logger.Warn("failed to stop missing-session runtime; preserving executor record",
+			zap.String("session_id", sessionID),
+			zap.String("task_id", running.TaskID),
+			zap.String("execution_id", executionID),
+			zap.Error(err))
+		return
+	}
+	if err := s.repo.DeleteExecutorRunningBySessionID(ctx, sessionID); err != nil {
+		s.logger.Warn("failed to remove executor record for missing session",
+			zap.String("session_id", sessionID),
+			zap.String("task_id", running.TaskID),
+			zap.Error(err))
+	}
+}
+
+func isTaskSessionNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "agent session not found") || strings.Contains(msg, "session not found")
+}
+
 // handleTerminalSessionOnStartup processes sessions in terminal states during startup.
 // Returns true if the session should be skipped (no further processing needed).
 func (s *Service) handleTerminalSessionOnStartup(ctx context.Context, session *models.TaskSession, running *models.ExecutorRunning, previousState models.TaskSessionState) bool {
 	sessionID := session.ID
 	switch previousState {
 	case models.TaskSessionStateCompleted, models.TaskSessionStateCancelled:
-		s.logger.Info("session in terminal state; cleaning up executor record",
+		s.logger.Info("session in terminal state; stopping runtime before cleaning up executor record",
 			zap.String("session_id", sessionID),
 			zap.String("task_id", session.TaskID),
 			zap.String("state", string(previousState)))
+		executionID := strings.TrimSpace(running.AgentExecutionID)
+		if executionID != "" && s.agentManager != nil {
+			if err := s.agentManager.StopAgentWithReason(ctx, executionID, "startup terminal session cleanup", true); err != nil {
+				s.logger.Warn("failed to stop terminal session runtime; preserving executor record",
+					zap.String("session_id", sessionID),
+					zap.String("execution_id", executionID),
+					zap.Error(err))
+				return true
+			}
+		}
 		if err := s.repo.DeleteExecutorRunningBySessionID(ctx, sessionID); err != nil {
 			s.logger.Warn("failed to remove executor record for terminal session",
 				zap.String("session_id", sessionID),

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1165,7 +1165,7 @@ func (s *Service) handleFailedSessionOnStartup(ctx context.Context, session *mod
 	// If session failed, ensure task is in REVIEW state (not stuck IN_PROGRESS)
 	if session.TaskID != "" {
 		task, taskErr := s.taskRepo.GetTask(ctx, session.TaskID)
-		if taskErr == nil && task.State == v1.TaskStateInProgress {
+		if taskErr == nil && task != nil && task.State == v1.TaskStateInProgress {
 			s.logger.Info("fixing task state: session failed but task still IN_PROGRESS",
 				zap.String("task_id", session.TaskID),
 				zap.String("session_id", sessionID))
@@ -1181,9 +1181,19 @@ func (s *Service) handleFailedSessionOnStartup(ctx context.Context, session *mod
 			zap.String("session_id", sessionID),
 			zap.String("task_id", session.TaskID))
 	} else {
-		s.logger.Info("cleaning up executor record for non-resumable failed session",
+		s.logger.Info("stopping failed session runtime before cleaning up executor record",
 			zap.String("session_id", sessionID),
 			zap.String("task_id", session.TaskID))
+		executionID := strings.TrimSpace(running.AgentExecutionID)
+		if executionID != "" && s.agentManager != nil {
+			if err := s.agentManager.StopAgentWithReason(ctx, executionID, "startup failed session cleanup", true); err != nil {
+				s.logger.Warn("failed to stop failed session runtime; preserving executor record",
+					zap.String("session_id", sessionID),
+					zap.String("execution_id", executionID),
+					zap.Error(err))
+				return
+			}
+		}
 		if err := s.repo.DeleteExecutorRunningBySessionID(ctx, sessionID); err != nil {
 			s.logger.Warn("failed to remove executor record for failed session",
 				zap.String("session_id", sessionID),

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -1992,6 +1992,93 @@ func TestReconcileSessionsOnStartup(t *testing.T) {
 		}
 	})
 
+	t.Run("failed_session_without_resume_token_stops_runtime_before_cleanup", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		ctx := context.Background()
+		now := time.Now().UTC()
+
+		seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateFailed)
+
+		err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+			ID:               "er1",
+			SessionID:        "session1",
+			TaskID:           "task1",
+			AgentExecutionID: "exec-failed",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		if err != nil {
+			t.Fatalf("failed to upsert executor running: %v", err)
+		}
+
+		agentMgr := &mockAgentManager{}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+		svc.reconcileSessionsOnStartup(ctx)
+
+		_, err = repo.GetExecutorRunningBySessionID(ctx, "session1")
+		if err == nil {
+			t.Fatal("expected ExecutorRunning record to be deleted for failed session after stop")
+		}
+		agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), agentMgr.stopAgentWithReasonArgs...)
+		agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 {
+			t.Fatalf("expected one StopAgentWithReason call, got %d", len(stopCalls))
+		}
+		if stopCalls[0] != (stopAgentCall{
+			ExecutionID: "exec-failed",
+			Reason:      "startup failed session cleanup",
+			Force:       true,
+		}) {
+			t.Fatalf("unexpected StopAgentWithReason call: %#v", stopCalls[0])
+		}
+	})
+
+	t.Run("failed_session_stop_failure_preserves_executor_row", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		ctx := context.Background()
+		now := time.Now().UTC()
+
+		seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateFailed)
+
+		err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+			ID:               "er1",
+			SessionID:        "session1",
+			TaskID:           "task1",
+			AgentExecutionID: "exec-failed",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		if err != nil {
+			t.Fatalf("failed to upsert executor running: %v", err)
+		}
+
+		agentMgr := &mockAgentManager{stopAgentWithReasonErr: errors.New("runtime still running")}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+		svc.reconcileSessionsOnStartup(ctx)
+
+		running, err := repo.GetExecutorRunningBySessionID(ctx, "session1")
+		if err != nil {
+			t.Fatalf("expected ExecutorRunning record to be preserved after stop failure: %v", err)
+		}
+		if running.AgentExecutionID != "exec-failed" {
+			t.Fatalf("expected execution ID to be preserved, got %q", running.AgentExecutionID)
+		}
+		agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), agentMgr.stopAgentWithReasonArgs...)
+		agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 {
+			t.Fatalf("expected one StopAgentWithReason call, got %d", len(stopCalls))
+		}
+		if stopCalls[0] != (stopAgentCall{
+			ExecutionID: "exec-failed",
+			Reason:      "startup failed session cleanup",
+			Force:       true,
+		}) {
+			t.Fatalf("unexpected StopAgentWithReason call: %#v", stopCalls[0])
+		}
+	})
+
 	// Pins office IDLE preservation: an office session sitting in IDLE
 	// (agent torn down between turns, conversation parked for the next
 	// run) MUST stay IDLE after backend restart. The previous code

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -1756,22 +1756,139 @@ func TestReconcileSessionsOnStartup(t *testing.T) {
 		seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCompleted)
 
 		err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
-			ID:        "er1",
-			SessionID: "session1",
-			TaskID:    "task1",
-			CreatedAt: now,
-			UpdatedAt: now,
+			ID:               "er1",
+			SessionID:        "session1",
+			TaskID:           "task1",
+			AgentExecutionID: "exec-terminal",
+			CreatedAt:        now,
+			UpdatedAt:        now,
 		})
 		if err != nil {
 			t.Fatalf("failed to upsert executor running: %v", err)
 		}
 
-		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), &mockAgentManager{})
+		agentMgr := &mockAgentManager{}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
 		svc.reconcileSessionsOnStartup(ctx)
 
 		_, err = repo.GetExecutorRunningBySessionID(ctx, "session1")
 		if err == nil {
 			t.Fatal("expected ExecutorRunning record to be deleted for terminal session")
+		}
+		agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), agentMgr.stopAgentWithReasonArgs...)
+		agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 {
+			t.Fatalf("expected one StopAgentWithReason call, got %d", len(stopCalls))
+		}
+		if stopCalls[0] != (stopAgentCall{
+			ExecutionID: "exec-terminal",
+			Reason:      "startup terminal session cleanup",
+			Force:       true,
+		}) {
+			t.Fatalf("unexpected StopAgentWithReason call: %#v", stopCalls[0])
+		}
+	})
+
+	t.Run("terminal_session_stop_failure_preserves_executor_row", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		ctx := context.Background()
+		now := time.Now().UTC()
+
+		seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCompleted)
+
+		err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+			ID:               "er1",
+			SessionID:        "session1",
+			TaskID:           "task1",
+			AgentExecutionID: "exec-terminal",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		if err != nil {
+			t.Fatalf("failed to upsert executor running: %v", err)
+		}
+
+		agentMgr := &mockAgentManager{stopAgentWithReasonErr: errors.New("runtime still running")}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+		svc.reconcileSessionsOnStartup(ctx)
+
+		running, err := repo.GetExecutorRunningBySessionID(ctx, "session1")
+		if err != nil {
+			t.Fatalf("expected ExecutorRunning record to be preserved after stop failure: %v", err)
+		}
+		if running.AgentExecutionID != "exec-terminal" {
+			t.Fatalf("expected execution ID to be preserved, got %q", running.AgentExecutionID)
+		}
+	})
+
+	t.Run("missing_session_runtime_cleaned_up", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		ctx := context.Background()
+		now := time.Now().UTC()
+
+		err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+			ID:               "er1",
+			SessionID:        "session-deleted",
+			TaskID:           "task-deleted",
+			AgentExecutionID: "exec-deleted",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		if err != nil {
+			t.Fatalf("failed to upsert executor running: %v", err)
+		}
+
+		agentMgr := &mockAgentManager{}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+		svc.reconcileSessionsOnStartup(ctx)
+
+		_, err = repo.GetExecutorRunningBySessionID(ctx, "session-deleted")
+		if err == nil {
+			t.Fatal("expected ExecutorRunning record to be deleted for missing session after stop")
+		}
+		agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), agentMgr.stopAgentWithReasonArgs...)
+		agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 {
+			t.Fatalf("expected one StopAgentWithReason call, got %d", len(stopCalls))
+		}
+		if stopCalls[0] != (stopAgentCall{
+			ExecutionID: "exec-deleted",
+			Reason:      "startup missing session cleanup",
+			Force:       true,
+		}) {
+			t.Fatalf("unexpected StopAgentWithReason call: %#v", stopCalls[0])
+		}
+	})
+
+	t.Run("missing_session_stop_failure_preserves_executor_row", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		ctx := context.Background()
+		now := time.Now().UTC()
+
+		err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+			ID:               "er1",
+			SessionID:        "session-deleted",
+			TaskID:           "task-deleted",
+			AgentExecutionID: "exec-deleted",
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		})
+		if err != nil {
+			t.Fatalf("failed to upsert executor running: %v", err)
+		}
+
+		agentMgr := &mockAgentManager{stopAgentWithReasonErr: errors.New("runtime still running")}
+		svc := createTestServiceWithAgent(repo, newMockStepGetter(), newMockTaskRepo(), agentMgr)
+		svc.reconcileSessionsOnStartup(ctx)
+
+		running, err := repo.GetExecutorRunningBySessionID(ctx, "session-deleted")
+		if err != nil {
+			t.Fatalf("expected ExecutorRunning record to be preserved after stop failure: %v", err)
+		}
+		if running.AgentExecutionID != "exec-deleted" {
+			t.Fatalf("expected execution ID to be preserved, got %q", running.AgentExecutionID)
 		}
 	})
 

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -1820,6 +1820,19 @@ func TestReconcileSessionsOnStartup(t *testing.T) {
 		if running.AgentExecutionID != "exec-terminal" {
 			t.Fatalf("expected execution ID to be preserved, got %q", running.AgentExecutionID)
 		}
+		agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), agentMgr.stopAgentWithReasonArgs...)
+		agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 {
+			t.Fatalf("expected one StopAgentWithReason call, got %d", len(stopCalls))
+		}
+		if stopCalls[0] != (stopAgentCall{
+			ExecutionID: "exec-terminal",
+			Reason:      "startup terminal session cleanup",
+			Force:       true,
+		}) {
+			t.Fatalf("unexpected StopAgentWithReason call: %#v", stopCalls[0])
+		}
 	})
 
 	t.Run("missing_session_runtime_cleaned_up", func(t *testing.T) {
@@ -1889,6 +1902,19 @@ func TestReconcileSessionsOnStartup(t *testing.T) {
 		}
 		if running.AgentExecutionID != "exec-deleted" {
 			t.Fatalf("expected execution ID to be preserved, got %q", running.AgentExecutionID)
+		}
+		agentMgr.mu.Lock()
+		stopCalls := append([]stopAgentCall(nil), agentMgr.stopAgentWithReasonArgs...)
+		agentMgr.mu.Unlock()
+		if len(stopCalls) != 1 {
+			t.Fatalf("expected one StopAgentWithReason call, got %d", len(stopCalls))
+		}
+		if stopCalls[0] != (stopAgentCall{
+			ExecutionID: "exec-deleted",
+			Reason:      "startup missing session cleanup",
+			Force:       true,
+		}) {
+			t.Fatalf("unexpected StopAgentWithReason call: %#v", stopCalls[0])
 		}
 	})
 

--- a/apps/backend/internal/task/handlers/process_handlers_test.go
+++ b/apps/backend/internal/task/handlers/process_handlers_test.go
@@ -372,6 +372,9 @@ func (m *mockRepository) ListExecutors(ctx context.Context) ([]*models.Executor,
 func (m *mockRepository) ListExecutorsRunning(ctx context.Context) ([]*models.ExecutorRunning, error) {
 	return nil, nil
 }
+func (m *mockRepository) ListExecutorsRunningByTaskID(ctx context.Context, taskID string) ([]*models.ExecutorRunning, error) {
+	return nil, nil
+}
 func (m *mockRepository) UpsertExecutorRunning(ctx context.Context, running *models.ExecutorRunning) error {
 	return nil
 }

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -15,6 +15,9 @@ import (
 // ErrExecutorRunningNotFound is returned when no executor running record exists for a session.
 var ErrExecutorRunningNotFound = errors.New("executor running not found")
 
+// ErrTaskSessionNotFound is returned when no task session record exists.
+var ErrTaskSessionNotFound = errors.New("task session not found")
+
 // ErrExecutorNotFound is returned by the executor repository when no
 // executor row exists for the given ID. Callers should use errors.Is to
 // distinguish "row doesn't exist" (404 semantically) from transport-level

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -224,6 +224,7 @@ type ExecutorRepository interface {
 	ListExecutorProfiles(ctx context.Context, executorID string) ([]*models.ExecutorProfile, error)
 	ListAllExecutorProfiles(ctx context.Context) ([]*models.ExecutorProfile, error)
 	ListExecutorsRunning(ctx context.Context) ([]*models.ExecutorRunning, error)
+	ListExecutorsRunningByTaskID(ctx context.Context, taskID string) ([]*models.ExecutorRunning, error)
 	UpsertExecutorRunning(ctx context.Context, running *models.ExecutorRunning) error
 	GetExecutorRunningBySessionID(ctx context.Context, sessionID string) (*models.ExecutorRunning, error)
 	DeleteExecutorRunningBySessionID(ctx context.Context, sessionID string) error

--- a/apps/backend/internal/task/repository/sqlite/executor.go
+++ b/apps/backend/internal/task/repository/sqlite/executor.go
@@ -219,8 +219,9 @@ func (r *Repository) UpsertExecutorRunning(ctx context.Context, running *models.
 func (r *Repository) ListExecutorsRunning(ctx context.Context) ([]*models.ExecutorRunning, error) {
 	rows, err := r.ro.QueryContext(ctx, `
 		SELECT id, session_id, task_id, executor_id, runtime, status, resumable, resume_token,
-			last_message_uuid, agent_execution_id, container_id, agentctl_url, agentctl_port,
-			worktree_id, worktree_path, worktree_branch, metadata, created_at, updated_at
+			last_message_uuid, agent_execution_id, container_id, agentctl_url, agentctl_port, pid,
+			worktree_id, worktree_path, worktree_branch, last_seen_at, error_message, metadata,
+			created_at, updated_at
 		FROM executors_running
 		ORDER BY updated_at DESC
 	`)
@@ -229,44 +230,28 @@ func (r *Repository) ListExecutorsRunning(ctx context.Context) ([]*models.Execut
 	}
 	defer func() { _ = rows.Close() }()
 
-	var results []*models.ExecutorRunning
-	for rows.Next() {
-		running := &models.ExecutorRunning{}
-		var metadataJSON string
-		if scanErr := rows.Scan(
-			&running.ID,
-			&running.SessionID,
-			&running.TaskID,
-			&running.ExecutorID,
-			&running.Runtime,
-			&running.Status,
-			&running.Resumable,
-			&running.ResumeToken,
-			&running.LastMessageUUID,
-			&running.AgentExecutionID,
-			&running.ContainerID,
-			&running.AgentctlURL,
-			&running.AgentctlPort,
-			&running.WorktreeID,
-			&running.WorktreePath,
-			&running.WorktreeBranch,
-			&metadataJSON,
-			&running.CreatedAt,
-			&running.UpdatedAt,
-		); scanErr != nil {
-			return nil, scanErr
-		}
-		if metadataJSON != "" && metadataJSON != "{}" {
-			if jsonErr := json.Unmarshal([]byte(metadataJSON), &running.Metadata); jsonErr != nil {
-				return nil, fmt.Errorf("failed to deserialize executor running metadata: %w", jsonErr)
-			}
-		}
-		results = append(results, running)
+	return scanExecutorRunningRows(rows)
+}
+
+func (r *Repository) ListExecutorsRunningByTaskID(ctx context.Context, taskID string) ([]*models.ExecutorRunning, error) {
+	if taskID == "" {
+		return nil, fmt.Errorf("task_id is required")
 	}
-	if err := rows.Err(); err != nil {
+	rows, err := r.ro.QueryContext(ctx, r.ro.Rebind(`
+		SELECT id, session_id, task_id, executor_id, runtime, status, resumable, resume_token,
+			last_message_uuid, agent_execution_id, container_id, agentctl_url, agentctl_port, pid,
+			worktree_id, worktree_path, worktree_branch, last_seen_at, error_message, metadata,
+			created_at, updated_at
+		FROM executors_running
+		WHERE task_id = ?
+		ORDER BY updated_at DESC
+	`), taskID)
+	if err != nil {
 		return nil, err
 	}
-	return results, nil
+	defer func() { _ = rows.Close() }()
+
+	return scanExecutorRunningRows(rows)
 }
 
 func (r *Repository) GetExecutorRunningBySessionID(ctx context.Context, sessionID string) (*models.ExecutorRunning, error) {
@@ -325,6 +310,58 @@ func (r *Repository) GetExecutorRunningBySessionID(ctx context.Context, sessionI
 		}
 	}
 	return running, nil
+}
+
+func scanExecutorRunningRows(rows *sql.Rows) ([]*models.ExecutorRunning, error) {
+	var results []*models.ExecutorRunning
+	for rows.Next() {
+		running := &models.ExecutorRunning{}
+		var (
+			resumable    int
+			lastSeen     sql.NullTime
+			metadataJSON string
+		)
+		if scanErr := rows.Scan(
+			&running.ID,
+			&running.SessionID,
+			&running.TaskID,
+			&running.ExecutorID,
+			&running.Runtime,
+			&running.Status,
+			&resumable,
+			&running.ResumeToken,
+			&running.LastMessageUUID,
+			&running.AgentExecutionID,
+			&running.ContainerID,
+			&running.AgentctlURL,
+			&running.AgentctlPort,
+			&running.PID,
+			&running.WorktreeID,
+			&running.WorktreePath,
+			&running.WorktreeBranch,
+			&lastSeen,
+			&running.ErrorMessage,
+			&metadataJSON,
+			&running.CreatedAt,
+			&running.UpdatedAt,
+		); scanErr != nil {
+			return nil, scanErr
+		}
+		running.Resumable = resumable == 1
+		if lastSeen.Valid {
+			running.LastSeenAt = &lastSeen.Time
+		}
+		if metadataJSON != "" && metadataJSON != "{}" {
+			if jsonErr := json.Unmarshal([]byte(metadataJSON), &running.Metadata); jsonErr != nil {
+				return nil, fmt.Errorf("failed to deserialize executor running metadata: %w", jsonErr)
+			}
+		}
+		results = append(results, running)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 func (r *Repository) DeleteExecutorRunningBySessionID(ctx context.Context, sessionID string) error {

--- a/apps/backend/internal/task/repository/sqlite/executor_cleanup_test.go
+++ b/apps/backend/internal/task/repository/sqlite/executor_cleanup_test.go
@@ -1,0 +1,74 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kandev/kandev/internal/agentruntime"
+	"github.com/kandev/kandev/internal/task/models"
+)
+
+func TestListExecutorsRunningByTaskIDIncludesTerminalSessions(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	seedExecutorRunningCleanupTask(t, repo, "task-1")
+	seedExecutorRunningCleanupTask(t, repo, "task-2")
+	seedExecutorRunningCleanupSession(t, repo, "task-1", "session-running", models.TaskSessionStateRunning, "exec-running")
+	seedExecutorRunningCleanupSession(t, repo, "task-1", "session-completed", models.TaskSessionStateCompleted, "exec-completed")
+	seedExecutorRunningCleanupSession(t, repo, "task-2", "session-other", models.TaskSessionStateRunning, "exec-other")
+
+	rows, err := repo.ListExecutorsRunningByTaskID(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("ListExecutorsRunningByTaskID: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows for task-1, got %d", len(rows))
+	}
+
+	got := map[string]string{}
+	for _, row := range rows {
+		got[row.SessionID] = row.AgentExecutionID
+	}
+	if got["session-running"] != "exec-running" {
+		t.Fatalf("running session row missing or wrong: %#v", got)
+	}
+	if got["session-completed"] != "exec-completed" {
+		t.Fatalf("completed session row missing or wrong: %#v", got)
+	}
+}
+
+func seedExecutorRunningCleanupTask(t *testing.T, repo *Repository, taskID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-" + taskID, Name: "Workspace " + taskID}); err != nil {
+		t.Fatalf("CreateWorkspace(%s): %v", taskID, err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-" + taskID, WorkspaceID: "ws-" + taskID, Name: "Workflow " + taskID}); err != nil {
+		t.Fatalf("CreateWorkflow(%s): %v", taskID, err)
+	}
+	if err := repo.CreateTask(ctx, &models.Task{ID: taskID, WorkspaceID: "ws-" + taskID, WorkflowID: "wf-" + taskID, WorkflowStepID: "step-" + taskID, Title: taskID, Priority: "medium"}); err != nil {
+		t.Fatalf("CreateTask(%s): %v", taskID, err)
+	}
+}
+
+func seedExecutorRunningCleanupSession(t *testing.T, repo *Repository, taskID, sessionID string, state models.TaskSessionState, executionID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{ID: sessionID, TaskID: taskID, State: state}); err != nil {
+		t.Fatalf("CreateTaskSession(%s): %v", sessionID, err)
+	}
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               sessionID,
+		SessionID:        sessionID,
+		TaskID:           taskID,
+		ExecutorID:       "executor-1",
+		Runtime:          agentruntime.RuntimeStandalone,
+		Status:           models.ExecutorRunningStatusStarting,
+		AgentExecutionID: executionID,
+	}); err != nil {
+		t.Fatalf("UpsertExecutorRunning(%s): %v", sessionID, err)
+	}
+}

--- a/apps/backend/internal/task/repository/sqlite/executor_cleanup_test.go
+++ b/apps/backend/internal/task/repository/sqlite/executor_cleanup_test.go
@@ -3,10 +3,88 @@ package sqlite
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kandev/kandev/internal/agentruntime"
 	"github.com/kandev/kandev/internal/task/models"
 )
+
+func TestListExecutorsRunningScansMetadataAndRuntimeFields(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+	lastSeen := time.Now().UTC().Truncate(time.Second)
+
+	seedExecutorRunningCleanupTask(t, repo, "task-1")
+	seedExecutorRunningCleanupSession(t, repo, "task-1", "session-running", models.TaskSessionStateRunning, "exec-running")
+	if err := repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:     "session-completed",
+		TaskID: "task-1",
+		State:  models.TaskSessionStateCompleted,
+	}); err != nil {
+		t.Fatalf("CreateTaskSession(session-completed): %v", err)
+	}
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session-completed",
+		SessionID:        "session-completed",
+		TaskID:           "task-1",
+		ExecutorID:       "executor-1",
+		Runtime:          agentruntime.RuntimeDocker,
+		Status:           models.ExecutorRunningStatusPrepared,
+		Resumable:        true,
+		ResumeToken:      "resume-token",
+		LastMessageUUID:  "message-1",
+		AgentExecutionID: "exec-completed",
+		ContainerID:      "container-1",
+		AgentctlURL:      "http://127.0.0.1:1234",
+		AgentctlPort:     1234,
+		PID:              4321,
+		WorktreeID:       "worktree-1",
+		WorktreePath:     "/tmp/worktree-1",
+		WorktreeBranch:   "feature/test",
+		LastSeenAt:       &lastSeen,
+		ErrorMessage:     "last error",
+		Metadata: map[string]interface{}{
+			"kind": "terminal",
+		},
+	}); err != nil {
+		t.Fatalf("UpsertExecutorRunning(session-completed): %v", err)
+	}
+
+	rows, err := repo.ListExecutorsRunning(ctx)
+	if err != nil {
+		t.Fatalf("ListExecutorsRunning: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 running rows, got %d", len(rows))
+	}
+
+	got := map[string]*models.ExecutorRunning{}
+	for _, row := range rows {
+		got[row.SessionID] = row
+	}
+	row := got["session-completed"]
+	if row == nil {
+		t.Fatalf("session-completed row missing: %#v", got)
+	}
+	if row.Runtime != agentruntime.RuntimeDocker || row.Status != models.ExecutorRunningStatusPrepared || !row.Resumable {
+		t.Fatalf("runtime fields not scanned: %#v", row)
+	}
+	if row.ResumeToken != "resume-token" || row.LastMessageUUID != "message-1" || row.AgentExecutionID != "exec-completed" {
+		t.Fatalf("execution fields not scanned: %#v", row)
+	}
+	if row.ContainerID != "container-1" || row.AgentctlURL != "http://127.0.0.1:1234" || row.AgentctlPort != 1234 || row.PID != 4321 {
+		t.Fatalf("process fields not scanned: %#v", row)
+	}
+	if row.WorktreeID != "worktree-1" || row.WorktreePath != "/tmp/worktree-1" || row.WorktreeBranch != "feature/test" {
+		t.Fatalf("worktree fields not scanned: %#v", row)
+	}
+	if row.LastSeenAt == nil || !row.LastSeenAt.Equal(lastSeen) {
+		t.Fatalf("last_seen_at not scanned: got %v want %v", row.LastSeenAt, lastSeen)
+	}
+	if row.ErrorMessage != "last error" || row.Metadata["kind"] != "terminal" {
+		t.Fatalf("metadata fields not scanned: %#v", row)
+	}
+}
 
 func TestListExecutorsRunningByTaskIDIncludesTerminalSessions(t *testing.T) {
 	repo := newRepoForSessionTests(t)

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -315,9 +316,6 @@ func (r *Repository) scanTaskSession(ctx context.Context, row *sql.Row, noRowsEr
 	)
 
 	if err == sql.ErrNoRows {
-		if noRowsErr == sessionNotFoundMsg || noRowsErr == noPrimarySessionSentinel {
-			return nil, fmt.Errorf("%s", noRowsErr)
-		}
 		return nil, fmt.Errorf("%w: %s", models.ErrTaskSessionNotFound, noRowsErr)
 	}
 	if err != nil {
@@ -400,21 +398,12 @@ func (r *Repository) GetTaskSessionByTaskAndAgent(ctx context.Context, taskID, a
 		 WHERE ts.task_id = ? AND ts.agent_profile_id = ?
 		 ORDER BY ts.started_at DESC LIMIT 1`,
 	), taskID, agentInstanceID)
-	session, err := r.scanTaskSession(ctx, row, sessionNotFoundMsg)
-	if err != nil && err.Error() == sessionNotFoundMsg {
+	session, err := r.scanTaskSession(ctx, row, "task_sessions: no matching row")
+	if errors.Is(err, models.ErrTaskSessionNotFound) {
 		return nil, nil
 	}
 	return session, err
 }
-
-// sessionNotFoundMsg is the sentinel string used by GetTaskSessionByTaskAndAgent
-// to detect "no row found" so the caller gets nil, nil instead of an error.
-const sessionNotFoundMsg = "task_sessions: no matching row"
-
-// noPrimarySessionSentinel is the no-rows marker passed to scanTaskSession by
-// GetPrimarySessionByTaskID. Matching this exact string lets the function wrap
-// the result with ErrNoPrimarySession so callers can use errors.Is.
-const noPrimarySessionSentinel = "task_sessions: no primary session row"
 
 // ListNonTerminalSessionsByAgentInstance returns every office task_session row
 // for the given agent_profile_id whose state is NOT terminal
@@ -1231,8 +1220,8 @@ func (r *Repository) GetPrimarySessionByTaskID(ctx context.Context, taskID strin
 	row := r.ro.QueryRowContext(ctx, r.ro.Rebind(
 		`SELECT `+taskSessionSelectCols+` `+taskSessionFromClause+` WHERE ts.task_id = ? AND ts.is_primary = 1 LIMIT 1`,
 	), taskID)
-	session, err := r.scanTaskSession(ctx, row, noPrimarySessionSentinel)
-	if err != nil && err.Error() == noPrimarySessionSentinel {
+	session, err := r.scanTaskSession(ctx, row, "task_sessions: no primary session row")
+	if errors.Is(err, models.ErrTaskSessionNotFound) {
 		return nil, fmt.Errorf("%w: %s", ErrNoPrimarySession, taskID)
 	}
 	return session, err

--- a/apps/backend/internal/task/repository/sqlite/session.go
+++ b/apps/backend/internal/task/repository/sqlite/session.go
@@ -315,7 +315,10 @@ func (r *Repository) scanTaskSession(ctx context.Context, row *sql.Row, noRowsEr
 	)
 
 	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("%s", noRowsErr)
+		if noRowsErr == sessionNotFoundMsg || noRowsErr == noPrimarySessionSentinel {
+			return nil, fmt.Errorf("%s", noRowsErr)
+		}
+		return nil, fmt.Errorf("%w: %s", models.ErrTaskSessionNotFound, noRowsErr)
 	}
 	if err != nil {
 		return nil, err
@@ -523,7 +526,7 @@ func (r *Repository) updateTaskSession(
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("agent session not found: %s", session.ID)
+		return fmt.Errorf("%w: agent session not found: %s", models.ErrTaskSessionNotFound, session.ID)
 	}
 	return nil
 }
@@ -546,7 +549,7 @@ func (r *Repository) UpdateTaskSessionState(ctx context.Context, id string, stat
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("agent session not found: %s", id)
+		return fmt.Errorf("%w: agent session not found: %s", models.ErrTaskSessionNotFound, id)
 	}
 	return nil
 }
@@ -707,7 +710,7 @@ func (r *Repository) UpdateTaskSessionBaseCommit(ctx context.Context, id string,
 	}
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("agent session not found: %s", id)
+		return fmt.Errorf("%w: agent session not found: %s", models.ErrTaskSessionNotFound, id)
 	}
 	return nil
 }

--- a/apps/backend/internal/task/repository/sqlite/session_test.go
+++ b/apps/backend/internal/task/repository/sqlite/session_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -70,6 +71,43 @@ func insertAgentMsg(t *testing.T, repo *Repository, id, sessionID, turnID, autho
 	`), id, sessionID, turnID, authorType, content, ts)
 	if err != nil {
 		t.Fatalf("insert message %s: %v", id, err)
+	}
+}
+
+func TestTaskSessionNotFoundErrorsAreTyped(t *testing.T) {
+	repo := newRepoForSessionTests(t)
+	ctx := context.Background()
+
+	if _, err := repo.GetTaskSession(ctx, "missing-session"); !errors.Is(err, models.ErrTaskSessionNotFound) {
+		t.Fatalf("GetTaskSession error = %v, want ErrTaskSessionNotFound", err)
+	}
+	if err := repo.UpdateTaskSession(ctx, &models.TaskSession{ID: "missing-session"}); !errors.Is(err, models.ErrTaskSessionNotFound) {
+		t.Fatalf("UpdateTaskSession error = %v, want ErrTaskSessionNotFound", err)
+	}
+	if err := repo.UpdateTaskSessionState(ctx, "missing-session", models.TaskSessionStateCompleted, ""); !errors.Is(err, models.ErrTaskSessionNotFound) {
+		t.Fatalf("UpdateTaskSessionState error = %v, want ErrTaskSessionNotFound", err)
+	}
+	if err := repo.UpdateTaskSessionBaseCommit(ctx, "missing-session", "abc123"); !errors.Is(err, models.ErrTaskSessionNotFound) {
+		t.Fatalf("UpdateTaskSessionBaseCommit error = %v, want ErrTaskSessionNotFound", err)
+	}
+
+	session, err := repo.GetTaskSessionByTaskAndAgent(ctx, "task-missing", "agent-missing")
+	if err != nil {
+		t.Fatalf("GetTaskSessionByTaskAndAgent should translate not found to nil, nil: %v", err)
+	}
+	if session != nil {
+		t.Fatalf("GetTaskSessionByTaskAndAgent session = %#v, want nil", session)
+	}
+	if _, err := repo.GetPrimarySessionByTaskID(ctx, "task-missing"); !errors.Is(err, ErrNoPrimarySession) {
+		t.Fatalf("GetPrimarySessionByTaskID error = %v, want ErrNoPrimarySession", err)
+	}
+
+	seedForMsgTest(t, repo, "task-found", "session-found", "turn-found")
+	if _, err := repo.GetTaskSession(ctx, "session-found"); err != nil {
+		t.Fatalf("GetTaskSession existing row: %v", err)
+	}
+	if err := repo.UpdateTaskSessionState(ctx, "session-found", models.TaskSessionStateCompleted, ""); err != nil {
+		t.Fatalf("UpdateTaskSessionState existing row: %v", err)
 	}
 }
 

--- a/apps/backend/internal/task/service/service.go
+++ b/apps/backend/internal/task/service/service.go
@@ -194,6 +194,7 @@ type Service struct {
 	blockers              BlockerRepository
 	comments              CommentRepository
 	baseBranchPusher      AgentBaseBranchPusher
+	cleanupDoneForTest    chan struct{}
 }
 
 // NewService creates a new task service

--- a/apps/backend/internal/task/service/service.go
+++ b/apps/backend/internal/task/service/service.go
@@ -194,7 +194,8 @@ type Service struct {
 	blockers              BlockerRepository
 	comments              CommentRepository
 	baseBranchPusher      AgentBaseBranchPusher
-	cleanupDoneForTest    chan struct{}
+	// cleanupDoneForTest lets unit tests wait for async cleanup; nil in production.
+	cleanupDoneForTest chan struct{}
 }
 
 // NewService creates a new task service
@@ -223,6 +224,10 @@ func NewService(repos Repos, eventBus bus.EventBus, log *logger.Logger, discover
 // SetWorktreeCleanup sets the worktree cleanup handler for task deletion.
 func (s *Service) SetWorktreeCleanup(cleanup WorktreeCleanup) {
 	s.worktreeCleanup = cleanup
+}
+
+func (s *Service) setCleanupDoneForTestHook(ch chan struct{}) {
+	s.cleanupDoneForTest = ch
 }
 
 // SetBranchMaterializer wires the mid-session worktree materializer for

--- a/apps/backend/internal/task/service/service_task_environments_test.go
+++ b/apps/backend/internal/task/service/service_task_environments_test.go
@@ -289,7 +289,7 @@ func TestPerformTaskCleanup_TearsDownTaskEnvironmentAndDeletesRow(t *testing.T) 
 	errs := svc.performTaskCleanup(context.Background(), "task-1", nil, nil, nil, taskEnvironmentCleanup{
 		env:       env,
 		deleteRow: true,
-	}, false, nil)
+	}, nil)
 
 	if len(errs) != 0 {
 		t.Fatalf("unexpected cleanup errors: %v", errs)

--- a/apps/backend/internal/task/service/service_task_environments_test.go
+++ b/apps/backend/internal/task/service/service_task_environments_test.go
@@ -289,7 +289,7 @@ func TestPerformTaskCleanup_TearsDownTaskEnvironmentAndDeletesRow(t *testing.T) 
 	errs := svc.performTaskCleanup(context.Background(), "task-1", nil, nil, taskEnvironmentCleanup{
 		env:       env,
 		deleteRow: true,
-	}, false)
+	}, false, nil)
 
 	if len(errs) != 0 {
 		t.Fatalf("unexpected cleanup errors: %v", errs)

--- a/apps/backend/internal/task/service/service_task_environments_test.go
+++ b/apps/backend/internal/task/service/service_task_environments_test.go
@@ -286,7 +286,7 @@ func TestPerformTaskCleanup_TearsDownTaskEnvironmentAndDeletesRow(t *testing.T) 
 	svc := newResetTestService(t, repo)
 	svc.SetEnvironmentDestroyer(destroyer)
 
-	errs := svc.performTaskCleanup(context.Background(), "task-1", nil, nil, taskEnvironmentCleanup{
+	errs := svc.performTaskCleanup(context.Background(), "task-1", nil, nil, nil, taskEnvironmentCleanup{
 		env:       env,
 		deleteRow: true,
 	}, false, nil)

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -748,7 +748,10 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 			zap.Error(err))
 	}
 	if s.executionStopper != nil {
-		stopTargets = s.buildStopTargets(ctx, id, activeSessions)
+		stopTargets, err = s.buildStopTargets(ctx, id, activeSessions)
+		if err != nil {
+			return fmt.Errorf("list runtime cleanup inventory: %w", err)
+		}
 	}
 
 	// 2b. Capture git archive snapshot for active sessions BEFORE stopping agents
@@ -864,7 +867,10 @@ func (s *Service) DeleteTask(ctx context.Context, id string) error {
 				zap.String("task_id", id),
 				zap.Error(err))
 		}
-		stopTargets = s.buildStopTargets(ctx, id, activeSessions)
+		stopTargets, err = s.buildStopTargets(ctx, id, activeSessions)
+		if err != nil {
+			return fmt.Errorf("list runtime cleanup inventory: %w", err)
+		}
 	}
 
 	// 4. Delete from DB (sync, fast)
@@ -902,8 +908,10 @@ func (s *Service) DeleteTask(ctx context.Context, id string) error {
 // teardown those wrappers run via runAsyncTaskCleanup. Without this call the
 // agent gets stopped but its container/sandbox leaks indefinitely.
 //
-// The caller is expected to have cancelled active runs separately (cascade
-// does this via runCanceller before invoking us), so stopTargets is empty.
+// The caller may already have cancelled active runs separately (cascade does
+// this via runCanceller before invoking us), but terminal sessions can still
+// have executors_running rows. We still derive runtime stop targets from
+// executors_running here so cascade cleanup does not drop durable handles.
 // deleteEnvRow controls whether the task_environment row is removed (true
 // for delete cascade, false for archive — archive preserves the row).
 // Best-effort and idempotent; failures are logged.
@@ -914,17 +922,27 @@ func (s *Service) CleanupTaskResources(ctx context.Context, taskID string, delet
 			zap.String("task_id", taskID),
 			zap.Error(err))
 	}
+	var stopTargets []taskStopTarget
+	if s.executionStopper != nil {
+		stopTargets, err = s.buildStopTargets(ctx, taskID, sessions)
+		if err != nil {
+			s.logger.Warn("skipping cascade cleanup because runtime inventory failed",
+				zap.String("task_id", taskID),
+				zap.Error(err))
+			return
+		}
+	}
 	worktrees := s.gatherWorktreesForDelete(ctx, taskID)
 	taskEnv := s.gatherTaskEnvironmentForCleanup(ctx, taskID)
 	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: deleteEnvRow}
-	if len(sessions) == 0 && len(worktrees) == 0 && taskEnv == nil {
+	if len(sessions) == 0 && len(worktrees) == 0 && len(stopTargets) == 0 && taskEnv == nil {
 		return
 	}
 	reason := "cascade archive"
 	if deleteEnvRow {
 		reason = "cascade delete"
 	}
-	s.runAsyncTaskCleanup(taskID, sessions, worktrees, nil, envCleanup, false,
+	s.runAsyncTaskCleanup(taskID, sessions, worktrees, stopTargets, envCleanup, false,
 		reason, "failed to stop session on cascade cleanup", "cascade cleanup completed")
 }
 
@@ -982,28 +1000,9 @@ func (s *Service) runAsyncTaskCleanup(
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		if s.executionStopper != nil && len(stopTargets) > 0 {
-			for _, target := range stopTargets {
-				if target.executionID != "" {
-					if err := s.executionStopper.StopExecution(cleanupCtx, target.executionID, stopReason, true); err != nil {
-						s.logger.Warn(stopFailMsg,
-							zap.String("task_id", id),
-							zap.String("session_id", target.sessionID),
-							zap.String("execution_id", target.executionID),
-							zap.Error(err))
-					}
-					continue
-				}
-				if err := s.executionStopper.StopSession(cleanupCtx, target.sessionID, stopReason, true); err != nil {
-					s.logger.Warn(stopFailMsg,
-						zap.String("task_id", id),
-						zap.String("session_id", target.sessionID),
-						zap.Error(err))
-				}
-			}
-		}
+		failedStops := s.stopTaskRuntimeTargets(cleanupCtx, id, stopTargets, stopReason, stopFailMsg)
 
-		cleanupErrors := s.performTaskCleanup(cleanupCtx, id, sessions, worktrees, envCleanup, isEphemeral)
+		cleanupErrors := s.performTaskCleanup(cleanupCtx, id, sessions, worktrees, envCleanup, isEphemeral, failedStops)
 
 		if len(cleanupErrors) > 0 {
 			s.logger.Warn(cleanupMsg+" with errors",
@@ -1018,17 +1017,38 @@ func (s *Service) runAsyncTaskCleanup(
 	}()
 }
 
-func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSessions []*models.TaskSession) []taskStopTarget {
+func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSessions []*models.TaskSession) ([]taskStopTarget, error) {
 	targets := make([]taskStopTarget, 0, len(activeSessions))
+	seen := make(map[string]struct{})
+	if s.executors != nil {
+		runningRows, err := s.executors.ListExecutorsRunningByTaskID(ctx, taskID)
+		if err != nil {
+			return nil, err
+		}
+		for _, running := range runningRows {
+			if running == nil || running.SessionID == "" {
+				continue
+			}
+			target := taskStopTarget{
+				sessionID:   running.SessionID,
+				executionID: strings.TrimSpace(running.AgentExecutionID),
+			}
+			targets = append(targets, target)
+			seen[target.sessionID] = struct{}{}
+		}
+	}
 	for _, sess := range activeSessions {
 		if sess == nil || sess.ID == "" {
+			continue
+		}
+		if _, ok := seen[sess.ID]; ok {
 			continue
 		}
 		target := taskStopTarget{
 			sessionID:   sess.ID,
 			executionID: strings.TrimSpace(sess.AgentExecutionID),
 		}
-		if target.executionID == "" {
+		if target.executionID == "" && s.executors != nil {
 			running, err := s.executors.GetExecutorRunningBySessionID(ctx, sess.ID)
 			if err == nil && running != nil {
 				target.executionID = strings.TrimSpace(running.AgentExecutionID)
@@ -1039,7 +1059,35 @@ func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSes
 	s.logger.Debug("prepared task cleanup stop targets",
 		zap.String("task_id", taskID),
 		zap.Int("count", len(targets)))
-	return targets
+	return targets, nil
+}
+
+func (s *Service) stopTaskRuntimeTargets(ctx context.Context, taskID string, stopTargets []taskStopTarget, stopReason, stopFailMsg string) map[string]struct{} {
+	failedStops := make(map[string]struct{})
+	if s.executionStopper == nil || len(stopTargets) == 0 {
+		return failedStops
+	}
+	for _, target := range stopTargets {
+		if target.executionID != "" {
+			if err := s.executionStopper.StopExecution(ctx, target.executionID, stopReason, true); err != nil {
+				failedStops[target.sessionID] = struct{}{}
+				s.logger.Warn(stopFailMsg,
+					zap.String("task_id", taskID),
+					zap.String("session_id", target.sessionID),
+					zap.String("execution_id", target.executionID),
+					zap.Error(err))
+			}
+			continue
+		}
+		if err := s.executionStopper.StopSession(ctx, target.sessionID, stopReason, true); err != nil {
+			failedStops[target.sessionID] = struct{}{}
+			s.logger.Warn(stopFailMsg,
+				zap.String("task_id", taskID),
+				zap.String("session_id", target.sessionID),
+				zap.Error(err))
+		}
+	}
+	return failedStops
 }
 
 // performTaskCleanup handles post-deletion cleanup operations.
@@ -1053,27 +1101,28 @@ func (s *Service) performTaskCleanup(
 	worktrees []*worktree.Worktree,
 	envCleanup taskEnvironmentCleanup,
 	isEphemeral bool,
+	preserveExecutorRows map[string]struct{},
 ) []error {
 	var errs []error
+	hasPreservedRuntimes := len(preserveExecutorRows) > 0
 
-	errs = append(errs, s.cleanupTaskEnvironment(ctx, taskID, envCleanup)...)
-	worktrees = excludeEnvironmentWorktree(worktrees, envCleanup.env)
-
-	// Cleanup worktrees
-	if len(worktrees) > 0 {
-		if cleaner, ok := s.worktreeCleanup.(WorktreeBatchCleaner); ok {
-			if err := cleaner.CleanupWorktrees(ctx, worktrees); err != nil {
-				s.logger.Warn("failed to cleanup worktrees after delete",
-					zap.String("task_id", taskID),
-					zap.Error(err))
-				errs = append(errs, fmt.Errorf("cleanup worktrees: %w", err))
-			}
-		}
+	if hasPreservedRuntimes {
+		s.logger.Warn("skipping destructive task cleanup after failed runtime stop",
+			zap.String("task_id", taskID),
+			zap.Int("preserved_runtime_count", len(preserveExecutorRows)))
+	} else {
+		errs = append(errs, s.cleanupDestructiveTaskResources(ctx, taskID, worktrees, envCleanup)...)
 	}
 
 	// Delete executor running records for sessions
 	for _, session := range sessions {
 		if session == nil || session.ID == "" {
+			continue
+		}
+		if _, preserve := preserveExecutorRows[session.ID]; preserve {
+			s.logger.Warn("preserving executor runtime row after failed stop",
+				zap.String("task_id", taskID),
+				zap.String("session_id", session.ID))
 			continue
 		}
 		if err := s.executors.DeleteExecutorRunningBySessionID(ctx, session.ID); err != nil {
@@ -1088,7 +1137,7 @@ func (s *Service) performTaskCleanup(
 	// Cleanup quick-chat workspace directories for all tasks (not just ephemeral).
 	// Non-ephemeral office tasks also get quick-chat dirs allocated by manager_launch.go;
 	// both cases must be cleaned up to avoid a disk leak.
-	if s.quickChatDir != "" {
+	if s.quickChatDir != "" && !hasPreservedRuntimes {
 		for _, session := range sessions {
 			if session == nil || session.ID == "" {
 				continue
@@ -1114,6 +1163,31 @@ func (s *Service) performTaskCleanup(
 		}
 	}
 
+	return errs
+}
+
+func (s *Service) cleanupDestructiveTaskResources(
+	ctx context.Context,
+	taskID string,
+	worktrees []*worktree.Worktree,
+	envCleanup taskEnvironmentCleanup,
+) []error {
+	var errs []error
+	errs = append(errs, s.cleanupTaskEnvironment(ctx, taskID, envCleanup)...)
+	worktrees = excludeEnvironmentWorktree(worktrees, envCleanup.env)
+	if len(worktrees) == 0 {
+		return errs
+	}
+	cleaner, ok := s.worktreeCleanup.(WorktreeBatchCleaner)
+	if !ok {
+		return errs
+	}
+	if err := cleaner.CleanupWorktrees(ctx, worktrees); err != nil {
+		s.logger.Warn("failed to cleanup worktrees after delete",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		errs = append(errs, fmt.Errorf("cleanup worktrees: %w", err))
+	}
 	return errs
 }
 

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -1221,8 +1221,15 @@ func (s *Service) cleanupDestructiveTaskResources(
 	if len(preserveExecutorRows) == 0 {
 		errs = append(errs, s.cleanupTaskEnvironment(ctx, taskID, envCleanup)...)
 	}
+	originalWorktreeCount := len(worktrees)
 	worktrees = cleanupEligibleWorktrees(worktrees, envCleanup.env, preserveExecutorRows)
 	if len(worktrees) == 0 {
+		if originalWorktreeCount > 0 {
+			s.logger.Debug("no task worktrees eligible for cleanup",
+				zap.String("task_id", taskID),
+				zap.Int("input_count", originalWorktreeCount),
+				zap.Int("preserved_runtime_count", len(preserveExecutorRows)))
+		}
 		return errs
 	}
 	cleaner, ok := s.worktreeCleanup.(WorktreeBatchCleaner)

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -912,8 +912,8 @@ func (s *Service) DeleteTask(ctx context.Context, id string) error {
 // have executors_running rows. We still derive runtime stop targets from
 // executors_running here so cascade cleanup does not drop durable handles.
 // deleteEnvRow controls whether the task_environment row is removed (true
-// for delete cascade, false for archive — archive preserves the row).
-// Best-effort and idempotent; failures are logged.
+// for delete cascade, false for archive — archive preserves the row). Runtime
+// inventory failures abort cleanup so durable stop handles remain retryable.
 func (s *Service) CleanupTaskResources(ctx context.Context, taskID string, deleteEnvRow bool) {
 	sessions, err := s.sessions.ListTaskSessions(ctx, taskID)
 	if err != nil {

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -1107,12 +1107,11 @@ func (s *Service) performTaskCleanup(
 	hasPreservedRuntimes := len(preserveExecutorRows) > 0
 
 	if hasPreservedRuntimes {
-		s.logger.Warn("skipping destructive task cleanup after failed runtime stop",
+		s.logger.Warn("skipping shared environment cleanup after failed runtime stop",
 			zap.String("task_id", taskID),
 			zap.Int("preserved_runtime_count", len(preserveExecutorRows)))
-	} else {
-		errs = append(errs, s.cleanupDestructiveTaskResources(ctx, taskID, worktrees, envCleanup)...)
 	}
+	errs = append(errs, s.cleanupDestructiveTaskResources(ctx, taskID, worktrees, envCleanup, preserveExecutorRows)...)
 
 	// Delete executor running records for sessions
 	for _, session := range sessions {
@@ -1137,32 +1136,46 @@ func (s *Service) performTaskCleanup(
 	// Cleanup quick-chat workspace directories for all tasks (not just ephemeral).
 	// Non-ephemeral office tasks also get quick-chat dirs allocated by manager_launch.go;
 	// both cases must be cleaned up to avoid a disk leak.
-	if s.quickChatDir != "" && !hasPreservedRuntimes {
-		for _, session := range sessions {
-			if session == nil || session.ID == "" {
-				continue
-			}
-			sessionDir := filepath.Join(s.quickChatDir, session.ID)
-			if _, statErr := os.Stat(sessionDir); statErr != nil {
-				// Directory does not exist — nothing to remove.
-				continue
-			}
-			if err := os.RemoveAll(sessionDir); err != nil {
-				s.logger.Warn("failed to cleanup quick-chat workspace directory",
-					zap.String("task_id", taskID),
-					zap.String("session_id", session.ID),
-					zap.String("path", sessionDir),
-					zap.Error(err))
-				errs = append(errs, fmt.Errorf("cleanup quick-chat dir %s: %w", session.ID, err))
-			} else {
-				s.logger.Debug("cleaned up quick-chat workspace directory",
-					zap.String("task_id", taskID),
-					zap.String("session_id", session.ID),
-					zap.String("path", sessionDir))
-			}
-		}
-	}
+	errs = append(errs, s.cleanupQuickChatDirs(taskID, sessions, preserveExecutorRows)...)
 
+	return errs
+}
+
+func (s *Service) cleanupQuickChatDirs(
+	taskID string,
+	sessions []*models.TaskSession,
+	preserveExecutorRows map[string]struct{},
+) []error {
+	if s.quickChatDir == "" {
+		return nil
+	}
+	var errs []error
+	for _, session := range sessions {
+		if session == nil || session.ID == "" {
+			continue
+		}
+		if _, preserve := preserveExecutorRows[session.ID]; preserve {
+			continue
+		}
+		sessionDir := filepath.Join(s.quickChatDir, session.ID)
+		if _, statErr := os.Stat(sessionDir); statErr != nil {
+			// Directory does not exist — nothing to remove.
+			continue
+		}
+		if err := os.RemoveAll(sessionDir); err != nil {
+			s.logger.Warn("failed to cleanup quick-chat workspace directory",
+				zap.String("task_id", taskID),
+				zap.String("session_id", session.ID),
+				zap.String("path", sessionDir),
+				zap.Error(err))
+			errs = append(errs, fmt.Errorf("cleanup quick-chat dir %s: %w", session.ID, err))
+			continue
+		}
+		s.logger.Debug("cleaned up quick-chat workspace directory",
+			zap.String("task_id", taskID),
+			zap.String("session_id", session.ID),
+			zap.String("path", sessionDir))
+	}
 	return errs
 }
 
@@ -1171,10 +1184,13 @@ func (s *Service) cleanupDestructiveTaskResources(
 	taskID string,
 	worktrees []*worktree.Worktree,
 	envCleanup taskEnvironmentCleanup,
+	preserveExecutorRows map[string]struct{},
 ) []error {
 	var errs []error
-	errs = append(errs, s.cleanupTaskEnvironment(ctx, taskID, envCleanup)...)
-	worktrees = excludeEnvironmentWorktree(worktrees, envCleanup.env)
+	if len(preserveExecutorRows) == 0 {
+		errs = append(errs, s.cleanupTaskEnvironment(ctx, taskID, envCleanup)...)
+	}
+	worktrees = cleanupEligibleWorktrees(worktrees, envCleanup.env, preserveExecutorRows)
 	if len(worktrees) == 0 {
 		return errs
 	}
@@ -1189,6 +1205,24 @@ func (s *Service) cleanupDestructiveTaskResources(
 		errs = append(errs, fmt.Errorf("cleanup worktrees: %w", err))
 	}
 	return errs
+}
+
+func cleanupEligibleWorktrees(worktrees []*worktree.Worktree, env *models.TaskEnvironment, preserveExecutorRows map[string]struct{}) []*worktree.Worktree {
+	worktrees = excludeEnvironmentWorktree(worktrees, env)
+	if len(preserveExecutorRows) == 0 || len(worktrees) == 0 {
+		return worktrees
+	}
+	filtered := worktrees[:0]
+	for _, wt := range worktrees {
+		if wt == nil {
+			continue
+		}
+		if _, preserve := preserveExecutorRows[wt.SessionID]; preserve {
+			continue
+		}
+		filtered = append(filtered, wt)
+	}
+	return filtered
 }
 
 func (s *Service) cleanupTaskEnvironment(

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -824,10 +824,9 @@ func (s *Service) ArchiveTask(ctx context.Context, id string) error {
 		zap.Duration("duration", time.Since(start)))
 
 	// 6. Background: Stop agents and cleanup worktrees
-	// Note: isEphemeral=false for archive to preserve quick-chat directories
 	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: true}
 	if len(stopTargets) > 0 || s.worktreeCleanup != nil || len(sessions) > 0 || taskEnv != nil {
-		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup, false,
+		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup,
 			"task archived", "failed to stop session on task archive", "task archive cleanup completed")
 	}
 
@@ -892,7 +891,7 @@ func (s *Service) DeleteTask(ctx context.Context, id string) error {
 	envCleanup := taskEnvironmentCleanup{env: taskEnv, deleteRow: false}
 	hasCleanup := len(stopTargets) > 0 || s.worktreeCleanup != nil || len(sessions) > 0 || task.IsEphemeral || taskEnv != nil
 	if hasCleanup {
-		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup, task.IsEphemeral,
+		s.runAsyncTaskCleanup(id, sessions, worktrees, stopTargets, envCleanup,
 			"task deleted", "failed to stop session on task delete", "task cleanup completed")
 	}
 
@@ -926,9 +925,10 @@ func (s *Service) CleanupTaskResources(ctx context.Context, taskID string, delet
 	if s.executionStopper != nil {
 		stopTargets, err = s.buildStopTargets(ctx, taskID, sessions)
 		if err != nil {
-			s.logger.Warn("continuing cascade cleanup without runtime stop targets because runtime inventory failed",
+			s.logger.Warn("skipping cascade cleanup because runtime inventory failed",
 				zap.String("task_id", taskID),
 				zap.Error(err))
+			return
 		}
 	}
 	worktrees := s.gatherWorktreesForDelete(ctx, taskID)
@@ -941,7 +941,7 @@ func (s *Service) CleanupTaskResources(ctx context.Context, taskID string, delet
 	if deleteEnvRow {
 		reason = "cascade delete"
 	}
-	s.runAsyncTaskCleanup(taskID, sessions, worktrees, stopTargets, envCleanup, false,
+	s.runAsyncTaskCleanup(taskID, sessions, worktrees, stopTargets, envCleanup,
 		reason, "failed to stop session on cascade cleanup", "cascade cleanup completed")
 }
 
@@ -991,7 +991,6 @@ func (s *Service) runAsyncTaskCleanup(
 	worktrees []*worktree.Worktree,
 	stopTargets []taskStopTarget,
 	envCleanup taskEnvironmentCleanup,
-	isEphemeral bool,
 	stopReason, stopFailMsg, cleanupMsg string,
 ) {
 	go func() {
@@ -1001,7 +1000,7 @@ func (s *Service) runAsyncTaskCleanup(
 
 		failedStops := s.stopTaskRuntimeTargets(cleanupCtx, id, stopTargets, stopReason, stopFailMsg)
 
-		cleanupErrors := s.performTaskCleanup(cleanupCtx, id, sessions, worktrees, stopTargets, envCleanup, isEphemeral, failedStops)
+		cleanupErrors := s.performTaskCleanup(cleanupCtx, id, sessions, worktrees, stopTargets, envCleanup, failedStops)
 
 		if len(cleanupErrors) > 0 {
 			s.logger.Warn(cleanupMsg+" with errors",
@@ -1101,7 +1100,6 @@ func (s *Service) performTaskCleanup(
 	worktrees []*worktree.Worktree,
 	stopTargets []taskStopTarget,
 	envCleanup taskEnvironmentCleanup,
-	isEphemeral bool,
 	preserveExecutorRows map[string]struct{},
 ) []error {
 	var errs []error

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -926,10 +926,9 @@ func (s *Service) CleanupTaskResources(ctx context.Context, taskID string, delet
 	if s.executionStopper != nil {
 		stopTargets, err = s.buildStopTargets(ctx, taskID, sessions)
 		if err != nil {
-			s.logger.Warn("skipping cascade cleanup because runtime inventory failed",
+			s.logger.Warn("continuing cascade cleanup without runtime stop targets because runtime inventory failed",
 				zap.String("task_id", taskID),
 				zap.Error(err))
-			return
 		}
 	}
 	worktrees := s.gatherWorktreesForDelete(ctx, taskID)
@@ -1002,7 +1001,7 @@ func (s *Service) runAsyncTaskCleanup(
 
 		failedStops := s.stopTaskRuntimeTargets(cleanupCtx, id, stopTargets, stopReason, stopFailMsg)
 
-		cleanupErrors := s.performTaskCleanup(cleanupCtx, id, sessions, worktrees, envCleanup, isEphemeral, failedStops)
+		cleanupErrors := s.performTaskCleanup(cleanupCtx, id, sessions, worktrees, stopTargets, envCleanup, isEphemeral, failedStops)
 
 		if len(cleanupErrors) > 0 {
 			s.logger.Warn(cleanupMsg+" with errors",
@@ -1014,6 +1013,7 @@ func (s *Service) runAsyncTaskCleanup(
 				zap.String("task_id", id),
 				zap.Duration("duration", time.Since(cleanupStart)))
 		}
+		s.signalCleanupDoneForTest()
 	}()
 }
 
@@ -1099,6 +1099,7 @@ func (s *Service) performTaskCleanup(
 	taskID string,
 	sessions []*models.TaskSession,
 	worktrees []*worktree.Worktree,
+	stopTargets []taskStopTarget,
 	envCleanup taskEnvironmentCleanup,
 	isEphemeral bool,
 	preserveExecutorRows map[string]struct{},
@@ -1113,21 +1114,18 @@ func (s *Service) performTaskCleanup(
 	}
 	errs = append(errs, s.cleanupDestructiveTaskResources(ctx, taskID, worktrees, envCleanup, preserveExecutorRows)...)
 
-	// Delete executor running records for sessions
-	for _, session := range sessions {
-		if session == nil || session.ID == "" {
-			continue
-		}
-		if _, preserve := preserveExecutorRows[session.ID]; preserve {
+	sessionIDs := cleanupSessionIDs(sessions, stopTargets)
+	for _, sessionID := range sessionIDs {
+		if _, preserve := preserveExecutorRows[sessionID]; preserve {
 			s.logger.Warn("preserving executor runtime row after failed stop",
 				zap.String("task_id", taskID),
-				zap.String("session_id", session.ID))
+				zap.String("session_id", sessionID))
 			continue
 		}
-		if err := s.executors.DeleteExecutorRunningBySessionID(ctx, session.ID); err != nil {
+		if err := s.executors.DeleteExecutorRunningBySessionID(ctx, sessionID); err != nil {
 			s.logger.Debug("failed to delete executor runtime for session",
 				zap.String("task_id", taskID),
-				zap.String("session_id", session.ID),
+				zap.String("session_id", sessionID),
 				zap.Error(err))
 			// Don't add to errs - this is a debug-level issue
 		}
@@ -1136,28 +1134,61 @@ func (s *Service) performTaskCleanup(
 	// Cleanup quick-chat workspace directories for all tasks (not just ephemeral).
 	// Non-ephemeral office tasks also get quick-chat dirs allocated by manager_launch.go;
 	// both cases must be cleaned up to avoid a disk leak.
-	errs = append(errs, s.cleanupQuickChatDirs(taskID, sessions, preserveExecutorRows)...)
+	errs = append(errs, s.cleanupQuickChatDirs(taskID, sessionIDs, preserveExecutorRows)...)
 
 	return errs
 }
 
+func (s *Service) signalCleanupDoneForTest() {
+	if s.cleanupDoneForTest == nil {
+		return
+	}
+	select {
+	case s.cleanupDoneForTest <- struct{}{}:
+	default:
+	}
+}
+
+func cleanupSessionIDs(sessions []*models.TaskSession, stopTargets []taskStopTarget) []string {
+	sessionIDs := make([]string, 0, len(sessions)+len(stopTargets))
+	seen := make(map[string]struct{})
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		sessionIDs = appendUniqueSessionID(sessionIDs, seen, session.ID)
+	}
+	for _, target := range stopTargets {
+		sessionIDs = appendUniqueSessionID(sessionIDs, seen, target.sessionID)
+	}
+	return sessionIDs
+}
+
+func appendUniqueSessionID(sessionIDs []string, seen map[string]struct{}, sessionID string) []string {
+	if sessionID == "" {
+		return sessionIDs
+	}
+	if _, ok := seen[sessionID]; ok {
+		return sessionIDs
+	}
+	seen[sessionID] = struct{}{}
+	return append(sessionIDs, sessionID)
+}
+
 func (s *Service) cleanupQuickChatDirs(
 	taskID string,
-	sessions []*models.TaskSession,
+	sessionIDs []string,
 	preserveExecutorRows map[string]struct{},
 ) []error {
 	if s.quickChatDir == "" {
 		return nil
 	}
 	var errs []error
-	for _, session := range sessions {
-		if session == nil || session.ID == "" {
+	for _, sessionID := range sessionIDs {
+		if _, preserve := preserveExecutorRows[sessionID]; preserve {
 			continue
 		}
-		if _, preserve := preserveExecutorRows[session.ID]; preserve {
-			continue
-		}
-		sessionDir := filepath.Join(s.quickChatDir, session.ID)
+		sessionDir := filepath.Join(s.quickChatDir, sessionID)
 		if _, statErr := os.Stat(sessionDir); statErr != nil {
 			// Directory does not exist — nothing to remove.
 			continue
@@ -1165,15 +1196,15 @@ func (s *Service) cleanupQuickChatDirs(
 		if err := os.RemoveAll(sessionDir); err != nil {
 			s.logger.Warn("failed to cleanup quick-chat workspace directory",
 				zap.String("task_id", taskID),
-				zap.String("session_id", session.ID),
+				zap.String("session_id", sessionID),
 				zap.String("path", sessionDir),
 				zap.Error(err))
-			errs = append(errs, fmt.Errorf("cleanup quick-chat dir %s: %w", session.ID, err))
+			errs = append(errs, fmt.Errorf("cleanup quick-chat dir %s: %w", sessionID, err))
 			continue
 		}
 		s.logger.Debug("cleaned up quick-chat workspace directory",
 			zap.String("task_id", taskID),
-			zap.String("session_id", session.ID),
+			zap.String("session_id", sessionID),
 			zap.String("path", sessionDir))
 	}
 	return errs

--- a/apps/backend/internal/task/service/service_tasks_test.go
+++ b/apps/backend/internal/task/service/service_tasks_test.go
@@ -29,7 +29,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 			t.Fatalf("mkdir: %v", err)
 		}
 
-		errs := svc.performTaskCleanup(ctx, "task-eph", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, true, nil)
+		errs := svc.performTaskCleanup(ctx, "task-eph", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, true, nil)
 		if len(errs) != 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
@@ -45,7 +45,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 			t.Fatalf("mkdir: %v", err)
 		}
 
-		errs := svc.performTaskCleanup(ctx, "task-noeph", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, false, nil)
+		errs := svc.performTaskCleanup(ctx, "task-noeph", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, false, nil)
 		if len(errs) != 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
@@ -57,7 +57,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 	t.Run("task with no dir on disk — no error", func(t *testing.T) {
 		sessID := "sess-nodir"
 		// Do not create the directory.
-		errs := svc.performTaskCleanup(ctx, "task-nodir", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, true, nil)
+		errs := svc.performTaskCleanup(ctx, "task-nodir", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, true, nil)
 		if len(errs) != 0 {
 			t.Fatalf("expected no errors when dir absent, got: %v", errs)
 		}

--- a/apps/backend/internal/task/service/service_tasks_test.go
+++ b/apps/backend/internal/task/service/service_tasks_test.go
@@ -29,7 +29,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 			t.Fatalf("mkdir: %v", err)
 		}
 
-		errs := svc.performTaskCleanup(ctx, "task-eph", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, true, nil)
+		errs := svc.performTaskCleanup(ctx, "task-eph", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, nil)
 		if len(errs) != 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
@@ -45,7 +45,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 			t.Fatalf("mkdir: %v", err)
 		}
 
-		errs := svc.performTaskCleanup(ctx, "task-noeph", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, false, nil)
+		errs := svc.performTaskCleanup(ctx, "task-noeph", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, nil)
 		if len(errs) != 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
@@ -57,7 +57,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 	t.Run("task with no dir on disk — no error", func(t *testing.T) {
 		sessID := "sess-nodir"
 		// Do not create the directory.
-		errs := svc.performTaskCleanup(ctx, "task-nodir", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, true, nil)
+		errs := svc.performTaskCleanup(ctx, "task-nodir", []*models.TaskSession{makeSession(sessID)}, nil, nil, taskEnvironmentCleanup{}, nil)
 		if len(errs) != 0 {
 			t.Fatalf("expected no errors when dir absent, got: %v", errs)
 		}

--- a/apps/backend/internal/task/service/service_tasks_test.go
+++ b/apps/backend/internal/task/service/service_tasks_test.go
@@ -29,7 +29,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 			t.Fatalf("mkdir: %v", err)
 		}
 
-		errs := svc.performTaskCleanup(ctx, "task-eph", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, true)
+		errs := svc.performTaskCleanup(ctx, "task-eph", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, true, nil)
 		if len(errs) != 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
@@ -45,7 +45,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 			t.Fatalf("mkdir: %v", err)
 		}
 
-		errs := svc.performTaskCleanup(ctx, "task-noeph", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, false)
+		errs := svc.performTaskCleanup(ctx, "task-noeph", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, false, nil)
 		if len(errs) != 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
@@ -57,7 +57,7 @@ func TestPerformTaskCleanup_QuickChatDir(t *testing.T) {
 	t.Run("task with no dir on disk — no error", func(t *testing.T) {
 		sessID := "sess-nodir"
 		// Do not create the directory.
-		errs := svc.performTaskCleanup(ctx, "task-nodir", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, true)
+		errs := svc.performTaskCleanup(ctx, "task-nodir", []*models.TaskSession{makeSession(sessID)}, nil, taskEnvironmentCleanup{}, true, nil)
 		if len(errs) != 0 {
 			t.Fatalf("expected no errors when dir absent, got: %v", errs)
 		}

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -484,6 +484,7 @@ func TestService_DeleteTaskStopsExecutorRunningForTerminalSession(t *testing.T) 
 	ctx := context.Background()
 	stopper := newRecordingTaskExecutionStopper()
 	svc.SetExecutionStopper(stopper)
+	svc.cleanupDoneForTest = make(chan struct{}, 1)
 
 	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
 	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
@@ -519,6 +520,10 @@ func TestService_DeleteTaskStopsExecutorRunningForTerminalSession(t *testing.T) 
 	if !call.force {
 		t.Fatal("StopExecution force = false, want true")
 	}
+	waitForCleanupDone(t, svc)
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-completed"); !errors.Is(err, models.ErrExecutorRunningNotFound) {
+		t.Fatalf("executor row should be removed after successful stop, got %v", err)
+	}
 }
 
 func TestService_DeleteTaskPreservesExecutorRunningWhenStopFails(t *testing.T) {
@@ -527,6 +532,7 @@ func TestService_DeleteTaskPreservesExecutorRunningWhenStopFails(t *testing.T) {
 	stopper := newRecordingTaskExecutionStopper()
 	stopper.stopExecutionErr = errors.New("runtime still shutting down")
 	svc.SetExecutionStopper(stopper)
+	svc.cleanupDoneForTest = make(chan struct{}, 1)
 	quickChatDir := t.TempDir()
 	svc.SetQuickChatDir(quickChatDir)
 
@@ -558,7 +564,7 @@ func TestService_DeleteTaskPreservesExecutorRunningWhenStopFails(t *testing.T) {
 		t.Fatalf("DeleteTask: %v", err)
 	}
 	_ = stopper.waitForStopExecution(t)
-	time.Sleep(50 * time.Millisecond)
+	waitForCleanupDone(t, svc)
 
 	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-completed"); err != nil {
 		t.Fatalf("executor row should remain retryable after stop failure: %v", err)
@@ -576,6 +582,7 @@ func TestService_DeleteTaskCleansSuccessfulSessionResourcesOnPartialStopFailure(
 		"exec-failed": errors.New("runtime still shutting down"),
 	}
 	svc.SetExecutionStopper(stopper)
+	svc.cleanupDoneForTest = make(chan struct{}, 1)
 	quickChatDir := t.TempDir()
 	svc.SetQuickChatDir(quickChatDir)
 	cleanup := &recordingWorktreeCleanup{
@@ -635,6 +642,7 @@ func TestService_DeleteTaskCleansSuccessfulSessionResourcesOnPartialStopFailure(
 	if !calls["exec-failed"] || !calls["exec-ok"] {
 		t.Fatalf("unexpected StopExecution calls: %#v", calls)
 	}
+	waitForCleanupDone(t, svc)
 	waitForPathRemoved(t, filepath.Join(quickChatDir, "session-ok"))
 	if _, err := os.Stat(filepath.Join(quickChatDir, "session-failed")); err != nil {
 		t.Fatalf("failed session quick-chat directory should remain: %v", err)
@@ -650,11 +658,47 @@ func TestService_DeleteTaskCleansSuccessfulSessionResourcesOnPartialStopFailure(
 	}
 }
 
+func TestService_DeleteTaskCleansMissingSessionExecutorRowAfterStop(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	stopper := newRecordingTaskExecutionStopper()
+	svc.SetExecutionStopper(stopper)
+	svc.cleanupDoneForTest = make(chan struct{}, 1)
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session-missing",
+		SessionID:        "session-missing",
+		TaskID:           "task-123",
+		ExecutorID:       "executor-1",
+		Runtime:          agentruntime.RuntimeStandalone,
+		Status:           models.ExecutorRunningStatusStarting,
+		AgentExecutionID: "exec-missing",
+	}); err != nil {
+		t.Fatalf("seed executor running: %v", err)
+	}
+
+	if err := svc.DeleteTask(ctx, "task-123"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	call := stopper.waitForStopExecution(t)
+	if call.executionID != "exec-missing" {
+		t.Fatalf("StopExecution executionID = %q, want exec-missing", call.executionID)
+	}
+	waitForCleanupDone(t, svc)
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-missing"); !errors.Is(err, models.ErrExecutorRunningNotFound) {
+		t.Fatalf("missing-session executor row should be removed after successful stop, got %v", err)
+	}
+}
+
 func TestService_ArchiveTaskStopsExecutorRunningForTerminalSession(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()
 	stopper := newRecordingTaskExecutionStopper()
 	svc.SetExecutionStopper(stopper)
+	svc.cleanupDoneForTest = make(chan struct{}, 1)
 
 	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
 	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
@@ -689,6 +733,10 @@ func TestService_ArchiveTaskStopsExecutorRunningForTerminalSession(t *testing.T)
 	}
 	if !call.force {
 		t.Fatal("StopExecution force = false, want true")
+	}
+	waitForCleanupDone(t, svc)
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-completed"); !errors.Is(err, models.ErrExecutorRunningNotFound) {
+		t.Fatalf("executor row should be removed after successful stop, got %v", err)
 	}
 }
 
@@ -843,6 +891,15 @@ func waitForPathRemoved(t *testing.T, path string) {
 			t.Fatalf("timed out waiting for %s to be removed", path)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForCleanupDone(t *testing.T, svc *Service) {
+	t.Helper()
+	select {
+	case <-svc.cleanupDoneForTest:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for async task cleanup")
 	}
 }
 

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -643,7 +643,9 @@ func TestService_DeleteTaskCleansSuccessfulSessionResourcesOnPartialStopFailure(
 		t.Fatalf("unexpected StopExecution calls: %#v", calls)
 	}
 	waitForCleanupDone(t, svc)
-	waitForPathRemoved(t, filepath.Join(quickChatDir, "session-ok"))
+	if _, err := os.Stat(filepath.Join(quickChatDir, "session-ok")); !os.IsNotExist(err) {
+		t.Fatalf("successful session quick-chat directory should be removed, got %v", err)
+	}
 	if _, err := os.Stat(filepath.Join(quickChatDir, "session-failed")); err != nil {
 		t.Fatalf("failed session quick-chat directory should remain: %v", err)
 	}
@@ -878,20 +880,6 @@ func (c *recordingWorktreeCleanup) GetAllByTaskID(context.Context, string) ([]*w
 func (c *recordingWorktreeCleanup) CleanupWorktrees(_ context.Context, worktrees []*worktree.Worktree) error {
 	c.cleaned = append(c.cleaned, worktrees...)
 	return nil
-}
-
-func waitForPathRemoved(t *testing.T, path string) {
-	t.Helper()
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for %s to be removed", path)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 }
 
 func waitForCleanupDone(t *testing.T, svc *Service) {

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/kandev/kandev/internal/agentruntime"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/events/bus"
@@ -477,6 +479,187 @@ func TestService_DeleteTask(t *testing.T) {
 	}
 }
 
+func TestService_DeleteTaskStopsExecutorRunningForTerminalSession(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	stopper := newRecordingTaskExecutionStopper()
+	svc.SetExecutionStopper(stopper)
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+	_ = repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:     "session-completed",
+		TaskID: "task-123",
+		State:  models.TaskSessionStateCompleted,
+	})
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session-completed",
+		SessionID:        "session-completed",
+		TaskID:           "task-123",
+		ExecutorID:       "executor-1",
+		Runtime:          agentruntime.RuntimeStandalone,
+		Status:           models.ExecutorRunningStatusStarting,
+		AgentExecutionID: "exec-terminal",
+	}); err != nil {
+		t.Fatalf("seed executor running: %v", err)
+	}
+
+	if err := svc.DeleteTask(ctx, "task-123"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+
+	call := stopper.waitForStopExecution(t)
+	if call.executionID != "exec-terminal" {
+		t.Fatalf("StopExecution executionID = %q, want exec-terminal", call.executionID)
+	}
+	if call.reason != "task deleted" {
+		t.Fatalf("StopExecution reason = %q, want task deleted", call.reason)
+	}
+	if !call.force {
+		t.Fatal("StopExecution force = false, want true")
+	}
+}
+
+func TestService_DeleteTaskPreservesExecutorRunningWhenStopFails(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	stopper := newRecordingTaskExecutionStopper()
+	stopper.stopExecutionErr = errors.New("runtime still shutting down")
+	svc.SetExecutionStopper(stopper)
+	quickChatDir := t.TempDir()
+	svc.SetQuickChatDir(quickChatDir)
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+	_ = repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:     "session-completed",
+		TaskID: "task-123",
+		State:  models.TaskSessionStateCompleted,
+	})
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session-completed",
+		SessionID:        "session-completed",
+		TaskID:           "task-123",
+		ExecutorID:       "executor-1",
+		Runtime:          agentruntime.RuntimeStandalone,
+		Status:           models.ExecutorRunningStatusStarting,
+		AgentExecutionID: "exec-terminal",
+	}); err != nil {
+		t.Fatalf("seed executor running: %v", err)
+	}
+	sessionDir := filepath.Join(quickChatDir, "session-completed")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	if err := svc.DeleteTask(ctx, "task-123"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	_ = stopper.waitForStopExecution(t)
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-completed"); err != nil {
+		t.Fatalf("executor row should remain retryable after stop failure: %v", err)
+	}
+	if _, err := os.Stat(sessionDir); err != nil {
+		t.Fatalf("quick-chat directory should remain when stop fails: %v", err)
+	}
+}
+
+func TestService_ArchiveTaskStopsExecutorRunningForTerminalSession(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	stopper := newRecordingTaskExecutionStopper()
+	svc.SetExecutionStopper(stopper)
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+	_ = repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:     "session-completed",
+		TaskID: "task-123",
+		State:  models.TaskSessionStateCompleted,
+	})
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session-completed",
+		SessionID:        "session-completed",
+		TaskID:           "task-123",
+		ExecutorID:       "executor-1",
+		Runtime:          agentruntime.RuntimeStandalone,
+		Status:           models.ExecutorRunningStatusStarting,
+		AgentExecutionID: "exec-terminal",
+	}); err != nil {
+		t.Fatalf("seed executor running: %v", err)
+	}
+
+	if err := svc.ArchiveTask(ctx, "task-123"); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+
+	call := stopper.waitForStopExecution(t)
+	if call.executionID != "exec-terminal" {
+		t.Fatalf("StopExecution executionID = %q, want exec-terminal", call.executionID)
+	}
+	if call.reason != "task archived" {
+		t.Fatalf("StopExecution reason = %q, want task archived", call.reason)
+	}
+	if !call.force {
+		t.Fatal("StopExecution force = false, want true")
+	}
+}
+
+func TestService_DeleteTaskFailsClosedWhenRuntimeInventoryFails(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	inventoryErr := errors.New("inventory unavailable")
+	svc.SetExecutionStopper(newRecordingTaskExecutionStopper())
+	svc.executors = failingExecutorRepository{
+		ExecutorRepository: repo,
+		listByTaskErr:      inventoryErr,
+	}
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+
+	err := svc.DeleteTask(ctx, "task-123")
+	if !errors.Is(err, inventoryErr) {
+		t.Fatalf("DeleteTask error = %v, want inventory error", err)
+	}
+	if _, err := repo.GetTask(ctx, "task-123"); err != nil {
+		t.Fatalf("task should remain when runtime inventory fails: %v", err)
+	}
+}
+
+func TestService_ArchiveTaskFailsClosedWhenRuntimeInventoryFails(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	inventoryErr := errors.New("inventory unavailable")
+	svc.SetExecutionStopper(newRecordingTaskExecutionStopper())
+	svc.executors = failingExecutorRepository{
+		ExecutorRepository: repo,
+		listByTaskErr:      inventoryErr,
+	}
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+
+	err := svc.ArchiveTask(ctx, "task-123")
+	if !errors.Is(err, inventoryErr) {
+		t.Fatalf("ArchiveTask error = %v, want inventory error", err)
+	}
+	task, err := repo.GetTask(ctx, "task-123")
+	if err != nil {
+		t.Fatalf("task should remain when runtime inventory fails: %v", err)
+	}
+	if task.ArchivedAt != nil {
+		t.Fatal("task should not be archived when runtime inventory fails")
+	}
+}
+
 func TestService_ListTasks(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()
@@ -493,6 +676,54 @@ func TestService_ListTasks(t *testing.T) {
 	if len(tasks) != 2 {
 		t.Errorf("expected 2 tasks, got %d", len(tasks))
 	}
+}
+
+type stopExecutionCall struct {
+	executionID string
+	reason      string
+	force       bool
+}
+
+type recordingTaskExecutionStopper struct {
+	stopExecutionCh  chan stopExecutionCall
+	stopExecutionErr error
+}
+
+func newRecordingTaskExecutionStopper() *recordingTaskExecutionStopper {
+	return &recordingTaskExecutionStopper{stopExecutionCh: make(chan stopExecutionCall, 8)}
+}
+
+func (s *recordingTaskExecutionStopper) StopTask(context.Context, string, string, bool) error {
+	return nil
+}
+
+func (s *recordingTaskExecutionStopper) StopSession(context.Context, string, string, bool) error {
+	return nil
+}
+
+func (s *recordingTaskExecutionStopper) StopExecution(_ context.Context, executionID, reason string, force bool) error {
+	s.stopExecutionCh <- stopExecutionCall{executionID: executionID, reason: reason, force: force}
+	return s.stopExecutionErr
+}
+
+func (s *recordingTaskExecutionStopper) waitForStopExecution(t *testing.T) stopExecutionCall {
+	t.Helper()
+	select {
+	case call := <-s.stopExecutionCh:
+		return call
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for StopExecution")
+		return stopExecutionCall{}
+	}
+}
+
+type failingExecutorRepository struct {
+	repository.ExecutorRepository
+	listByTaskErr error
+}
+
+func (r failingExecutorRepository) ListExecutorsRunningByTaskID(context.Context, string) ([]*models.ExecutorRunning, error) {
+	return nil, r.listByTaskErr
 }
 
 func TestService_UpdateTaskState(t *testing.T) {

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -568,6 +568,88 @@ func TestService_DeleteTaskPreservesExecutorRunningWhenStopFails(t *testing.T) {
 	}
 }
 
+func TestService_DeleteTaskCleansSuccessfulSessionResourcesOnPartialStopFailure(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	stopper := newRecordingTaskExecutionStopper()
+	stopper.stopExecutionErrByID = map[string]error{
+		"exec-failed": errors.New("runtime still shutting down"),
+	}
+	svc.SetExecutionStopper(stopper)
+	quickChatDir := t.TempDir()
+	svc.SetQuickChatDir(quickChatDir)
+	cleanup := &recordingWorktreeCleanup{
+		worktrees: []*worktree.Worktree{
+			{ID: "wt-failed", TaskID: "task-123", SessionID: "session-failed"},
+			{ID: "wt-ok", TaskID: "task-123", SessionID: "session-ok"},
+		},
+	}
+	svc.SetWorktreeCleanup(cleanup)
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+	for _, sessionID := range []string{"session-failed", "session-ok"} {
+		_ = repo.CreateTaskSession(ctx, &models.TaskSession{
+			ID:     sessionID,
+			TaskID: "task-123",
+			State:  models.TaskSessionStateCompleted,
+		})
+		sessionDir := filepath.Join(quickChatDir, sessionID)
+		if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+			t.Fatalf("mkdir session dir: %v", err)
+		}
+	}
+	for _, row := range []*models.ExecutorRunning{
+		{
+			ID:               "session-failed",
+			SessionID:        "session-failed",
+			TaskID:           "task-123",
+			ExecutorID:       "executor-1",
+			Runtime:          agentruntime.RuntimeStandalone,
+			Status:           models.ExecutorRunningStatusStarting,
+			AgentExecutionID: "exec-failed",
+		},
+		{
+			ID:               "session-ok",
+			SessionID:        "session-ok",
+			TaskID:           "task-123",
+			ExecutorID:       "executor-1",
+			Runtime:          agentruntime.RuntimeStandalone,
+			Status:           models.ExecutorRunningStatusStarting,
+			AgentExecutionID: "exec-ok",
+		},
+	} {
+		if err := repo.UpsertExecutorRunning(ctx, row); err != nil {
+			t.Fatalf("seed executor running: %v", err)
+		}
+	}
+
+	if err := svc.DeleteTask(ctx, "task-123"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	calls := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		calls[stopper.waitForStopExecution(t).executionID] = true
+	}
+	if !calls["exec-failed"] || !calls["exec-ok"] {
+		t.Fatalf("unexpected StopExecution calls: %#v", calls)
+	}
+	waitForPathRemoved(t, filepath.Join(quickChatDir, "session-ok"))
+	if _, err := os.Stat(filepath.Join(quickChatDir, "session-failed")); err != nil {
+		t.Fatalf("failed session quick-chat directory should remain: %v", err)
+	}
+	if len(cleanup.cleaned) != 1 || cleanup.cleaned[0].ID != "wt-ok" {
+		t.Fatalf("expected only successful session worktree cleanup, got %#v", cleanup.cleaned)
+	}
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-failed"); err != nil {
+		t.Fatalf("failed session executor row should remain retryable: %v", err)
+	}
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-ok"); err == nil {
+		t.Fatal("successful session executor row should be removed")
+	}
+}
+
 func TestService_ArchiveTaskStopsExecutorRunningForTerminalSession(t *testing.T) {
 	svc, _, repo := createTestService(t)
 	ctx := context.Background()
@@ -685,8 +767,9 @@ type stopExecutionCall struct {
 }
 
 type recordingTaskExecutionStopper struct {
-	stopExecutionCh  chan stopExecutionCall
-	stopExecutionErr error
+	stopExecutionCh      chan stopExecutionCall
+	stopExecutionErr     error
+	stopExecutionErrByID map[string]error
 }
 
 func newRecordingTaskExecutionStopper() *recordingTaskExecutionStopper {
@@ -703,6 +786,11 @@ func (s *recordingTaskExecutionStopper) StopSession(context.Context, string, str
 
 func (s *recordingTaskExecutionStopper) StopExecution(_ context.Context, executionID, reason string, force bool) error {
 	s.stopExecutionCh <- stopExecutionCall{executionID: executionID, reason: reason, force: force}
+	if s.stopExecutionErrByID != nil {
+		if err := s.stopExecutionErrByID[executionID]; err != nil {
+			return err
+		}
+	}
 	return s.stopExecutionErr
 }
 
@@ -724,6 +812,38 @@ type failingExecutorRepository struct {
 
 func (r failingExecutorRepository) ListExecutorsRunningByTaskID(context.Context, string) ([]*models.ExecutorRunning, error) {
 	return nil, r.listByTaskErr
+}
+
+type recordingWorktreeCleanup struct {
+	worktrees []*worktree.Worktree
+	cleaned   []*worktree.Worktree
+}
+
+func (c *recordingWorktreeCleanup) OnTaskDeleted(context.Context, string) error {
+	return nil
+}
+
+func (c *recordingWorktreeCleanup) GetAllByTaskID(context.Context, string) ([]*worktree.Worktree, error) {
+	return c.worktrees, nil
+}
+
+func (c *recordingWorktreeCleanup) CleanupWorktrees(_ context.Context, worktrees []*worktree.Worktree) error {
+	c.cleaned = append(c.cleaned, worktrees...)
+	return nil
+}
+
+func waitForPathRemoved(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s to be removed", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestService_UpdateTaskState(t *testing.T) {

--- a/apps/backend/internal/task/service/service_test.go
+++ b/apps/backend/internal/task/service/service_test.go
@@ -484,7 +484,7 @@ func TestService_DeleteTaskStopsExecutorRunningForTerminalSession(t *testing.T) 
 	ctx := context.Background()
 	stopper := newRecordingTaskExecutionStopper()
 	svc.SetExecutionStopper(stopper)
-	svc.cleanupDoneForTest = make(chan struct{}, 1)
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
 
 	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
 	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
@@ -532,7 +532,7 @@ func TestService_DeleteTaskPreservesExecutorRunningWhenStopFails(t *testing.T) {
 	stopper := newRecordingTaskExecutionStopper()
 	stopper.stopExecutionErr = errors.New("runtime still shutting down")
 	svc.SetExecutionStopper(stopper)
-	svc.cleanupDoneForTest = make(chan struct{}, 1)
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
 	quickChatDir := t.TempDir()
 	svc.SetQuickChatDir(quickChatDir)
 
@@ -582,7 +582,7 @@ func TestService_DeleteTaskCleansSuccessfulSessionResourcesOnPartialStopFailure(
 		"exec-failed": errors.New("runtime still shutting down"),
 	}
 	svc.SetExecutionStopper(stopper)
-	svc.cleanupDoneForTest = make(chan struct{}, 1)
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
 	quickChatDir := t.TempDir()
 	svc.SetQuickChatDir(quickChatDir)
 	cleanup := &recordingWorktreeCleanup{
@@ -665,7 +665,7 @@ func TestService_DeleteTaskCleansMissingSessionExecutorRowAfterStop(t *testing.T
 	ctx := context.Background()
 	stopper := newRecordingTaskExecutionStopper()
 	svc.SetExecutionStopper(stopper)
-	svc.cleanupDoneForTest = make(chan struct{}, 1)
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
 
 	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
 	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
@@ -700,7 +700,7 @@ func TestService_ArchiveTaskStopsExecutorRunningForTerminalSession(t *testing.T)
 	ctx := context.Background()
 	stopper := newRecordingTaskExecutionStopper()
 	svc.SetExecutionStopper(stopper)
-	svc.cleanupDoneForTest = make(chan struct{}, 1)
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
 
 	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
 	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
@@ -789,6 +789,61 @@ func TestService_ArchiveTaskFailsClosedWhenRuntimeInventoryFails(t *testing.T) {
 	}
 	if task.ArchivedAt != nil {
 		t.Fatal("task should not be archived when runtime inventory fails")
+	}
+}
+
+func TestService_CleanupTaskResourcesFailsClosedWhenRuntimeInventoryFails(t *testing.T) {
+	svc, _, repo := createTestService(t)
+	ctx := context.Background()
+	inventoryErr := errors.New("inventory unavailable")
+	svc.SetExecutionStopper(newRecordingTaskExecutionStopper())
+	svc.executors = failingExecutorRepository{
+		ExecutorRepository: repo,
+		listByTaskErr:      inventoryErr,
+	}
+	quickChatDir := t.TempDir()
+	svc.SetQuickChatDir(quickChatDir)
+	cleanup := &recordingWorktreeCleanup{
+		worktrees: []*worktree.Worktree{
+			{ID: "wt-1", TaskID: "task-123", SessionID: "session-completed"},
+		},
+	}
+	svc.SetWorktreeCleanup(cleanup)
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-123", WorkspaceID: "ws-1", Name: "Workflow"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: "task-123", WorkspaceID: "ws-1", WorkflowID: "wf-123", WorkflowStepID: "step-123", Title: "Test", Priority: "medium"})
+	_ = repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:     "session-completed",
+		TaskID: "task-123",
+		State:  models.TaskSessionStateCompleted,
+	})
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session-completed",
+		SessionID:        "session-completed",
+		TaskID:           "task-123",
+		ExecutorID:       "executor-1",
+		Runtime:          agentruntime.RuntimeStandalone,
+		Status:           models.ExecutorRunningStatusStarting,
+		AgentExecutionID: "exec-terminal",
+	}); err != nil {
+		t.Fatalf("seed executor running: %v", err)
+	}
+	sessionDir := filepath.Join(quickChatDir, "session-completed")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	svc.CleanupTaskResources(ctx, "task-123", true)
+
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session-completed"); err != nil {
+		t.Fatalf("executor row should remain when runtime inventory fails: %v", err)
+	}
+	if _, err := os.Stat(sessionDir); err != nil {
+		t.Fatalf("quick-chat directory should remain when runtime inventory fails: %v", err)
+	}
+	if len(cleanup.cleaned) != 0 {
+		t.Fatalf("worktrees should not be cleaned when runtime inventory fails, got %#v", cleanup.cleaned)
 	}
 }
 

--- a/docs/decisions/0025-runtime-cleanup-uses-executors-running.md
+++ b/docs/decisions/0025-runtime-cleanup-uses-executors-running.md
@@ -1,0 +1,72 @@
+# 0025: Runtime Cleanup Uses `executors_running`
+
+**Status:** accepted
+**Date:** 2026-06-22
+**Area:** backend
+
+## Context
+
+Archiving and deleting tasks can remove task/worktree records while ACP agent
+processes remain alive. Process inspection in a dev LXC container found many
+`codex-acp` process trees reparented to PID 1 with current working directories
+under deleted task worktrees. Most of those process trees were no longer
+represented in the live `executors_running` table, which means Kandev had already
+discarded its durable cleanup handle.
+
+The existing archive/delete path builds stop targets from active
+`task_sessions`, while runtime ownership is stored in `executors_running`. A
+session can be terminal or missing from the active-session query while its runtime
+row still points at a live process.
+
+## Decision
+
+Task archive/delete cleanup must derive runtime stop targets from
+`executors_running` rows owned by the task before removing runtime tracking rows
+or worktrees. `task_sessions.state` is user-facing session state; it is not the
+source of truth for whether runtime resources still need cleanup.
+
+Cleanup follows a fail-closed ordering:
+
+1. Query the authoritative runtime inventory for the task from
+   `executors_running`.
+2. Attempt to stop every selected runtime by `agent_execution_id` or an available
+   runtime-specific persisted handle.
+3. Remove `executors_running` rows and worktrees only after stop succeeds or the
+   runtime is positively confirmed absent.
+4. Keep a retryable diagnostic row when stop cannot be confirmed.
+
+Agentctl shutdown must also kill the owned agent process group when graceful stdin
+EOF shutdown does not complete within the stop timeout, so agentctl cannot exit
+while leaving ACP children reparented to PID 1.
+
+## Consequences
+
+**Easier:**
+
+- Archive/delete cleanup no longer depends on active session state and catches
+  terminal sessions that still own runtime resources.
+- The durable runtime row remains available for retry and diagnosis when stop
+  fails.
+- Startup reconciliation can use the same inventory source to clean stale rows
+  after a backend crash.
+
+**Harder:**
+
+- Cleanup code must preserve enough row state to retry instead of deleting
+  `executors_running` unconditionally at the end of task cleanup.
+- Tests need to cover terminal-session runtime rows, missing-session rows, and
+  stop failures, not only active sessions.
+- Runtime-specific fallback cleanup needs bounded behavior when the in-memory
+  execution store no longer knows about the row.
+
+## Alternatives Considered
+
+- **Continue using active sessions and add more terminal cleanup hooks.** Rejected
+  because it leaves multiple paths responsible for deciding whether a runtime is
+  live. The durable ownership table is simpler and already exists.
+- **Add an OS process sweeper for `codex-acp`/`claude-acp`/`opencode`.** Rejected
+  as the primary fix because process-name scanning can kill unrelated user
+  processes and does not address losing durable ownership before cleanup.
+- **Delete runtime rows even when stop fails and rely on agentctl idle reaping.**
+  Rejected because deleting the row removes the only authoritative handle Kandev
+  has for retrying cleanup.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -30,3 +30,4 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0022 | [Embedded Vite assets](0022-embedded-vite-assets.md)                                                                                | accepted   | backend, frontend, cli      | 2026-06-17 |
 | 0023 | [Active workspace cookie for boot state](0023-active-workspace-cookie.md)                                                           | accepted   | backend, frontend           | 2026-06-18 |
 | 0024 | [Go-fronted Vite dev mode](0024-go-fronted-vite-dev-mode.md)                                                                        | accepted   | backend, frontend, cli      | 2026-06-18 |
+| 0025 | [Runtime cleanup uses `executors_running`](0025-runtime-cleanup-uses-executors-running.md)                                          | accepted   | backend                     | 2026-06-22 |

--- a/docs/plans/task-runtime-cleanup/plan.md
+++ b/docs/plans/task-runtime-cleanup/plan.md
@@ -1,0 +1,130 @@
+---
+spec: docs/specs/tasks/runtime-cleanup.md
+created: 2026-06-22
+status: implemented
+---
+
+# Implementation Plan: Task Runtime Cleanup
+
+## Overview
+
+Runtime cleanup moves from active-session discovery to durable
+`executors_running` ownership. The implementation starts with repository queries
+and service ordering, then hardens agentctl subprocess shutdown, then adds startup
+reconciliation and focused regression coverage.
+
+---
+
+## Backend
+
+### Runtime Inventory
+
+- Add `ListExecutorsRunningByTaskID(ctx, taskID string) ([]*models.ExecutorRunning, error)` to the task repository interface in `apps/backend/internal/task/repository/interface.go`.
+- Implement the query in `apps/backend/internal/task/repository/sqlite/executor.go`, ordered by `updated_at DESC` for deterministic tests.
+- Reuse the existing global `ListExecutorsRunning(ctx)` startup inventory for
+  reconciliation, and stop terminal or missing-session rows before removing
+  runtime tracking.
+
+### Task Cleanup Ordering
+
+- Update `apps/backend/internal/task/service/service_tasks.go` so archive/delete
+  builds stop targets from `executors_running` rows for the task, not only from
+  `ListActiveTaskSessionsByTaskID`.
+- Keep active-session cancellation for user-facing session state, but make runtime
+  stop target discovery independent from that session-state query.
+- Change cleanup ordering so `performTaskCleanup` removes executor rows only after
+  the stop attempts have completed.
+- When stop fails or cannot be confirmed, preserve the executor row with a
+  retryable diagnostic instead of deleting it in the same cleanup pass.
+
+### Orchestrator Stop Path
+
+- Reuse `TaskExecutionStopper.StopExecution` when `agent_execution_id` is present.
+- Add bounded fallback behavior for rows whose in-memory execution is missing but
+  whose runtime handle is still persisted.
+- Ensure task archive/delete cleanup logs the task ID, session ID, execution ID,
+  runtime, and failure reason for every failed stop attempt.
+
+### Agentctl Subprocess Shutdown
+
+- Audit `apps/backend/internal/agentctl/server/process/manager.go` so every
+  agentctl instance shutdown calls `Manager.Stop(ctx)`.
+- Ensure `waitForProcessExit` escalates to process-group kill for Codex/Claude ACP
+  children when graceful stdin EOF does not finish by timeout.
+- Add a Unix child-lifecycle guard where appropriate so ACP subprocess groups do
+  not survive an unexpected agentctl parent exit.
+
+### Startup Reconciliation
+
+- Update orchestrator startup reconciliation to scan persisted
+  `executors_running` rows and safely clean terminal or missing-session rows.
+- Apply fail-closed semantics from ADR-0009: if inventory queries fail, log and
+  skip destructive cleanup.
+- Remove rows only after the runtime is positively stopped or confirmed absent.
+
+---
+
+## Frontend
+
+No frontend changes are planned. Existing archive/delete/session controls keep the
+same UI and API behavior; the cleanup guarantee changes backend behavior.
+
+---
+
+## Tests
+
+- **What:** repository returns all runtime rows for a task regardless of session
+  state.
+  **File:** `apps/backend/internal/task/repository/sqlite/executor_test.go`
+  **How:** SQLite integration test seeding active and terminal sessions with
+  `executors_running` rows.
+
+- **What:** archive cleanup stops terminal-session runtime rows before deleting
+  runtime tracking.
+  **File:** `apps/backend/internal/task/service/service_tasks_test.go`
+  **How:** service test with a fake `TaskExecutionStopper` and a completed
+  session that still has an executor row.
+
+- **What:** delete cleanup preserves runtime tracking when stop fails.
+  **File:** `apps/backend/internal/task/service/service_tasks_test.go`
+  **How:** fake stopper returns an error; assert executor cleanup is not called
+  for that row and a warning path is exercised.
+
+- **What:** process manager kills the process group when graceful ACP shutdown
+  times out.
+  **File:** `apps/backend/internal/agentctl/server/process/manager_test.go`
+  **How:** subprocess fixture that ignores stdin EOF and spawns a child; assert no
+  child remains after stop timeout.
+
+- **What:** startup reconciliation stops terminal or missing-session runtime rows
+  before deleting tracking and preserves rows when stop fails.
+  **File:** `apps/backend/internal/orchestrator/task_operations_test.go`
+  **How:** SQLite-backed orchestrator test with a fake agent manager covering
+  terminal success/failure and missing-session success/failure.
+
+---
+
+## E2E Tests
+
+Skipped. The spec has no new user-visible UI flow; backend integration tests cover
+the observable cleanup guarantees.
+
+---
+
+## Implementation Waves
+
+Wave 1:
+- [x] [task-01-runtime-inventory](task-01-runtime-inventory.md)
+- [x] [task-02-task-cleanup-ordering](task-02-task-cleanup-ordering.md)
+
+Wave 2:
+- [x] [task-03-agentctl-process-group-shutdown](task-03-agentctl-process-group-shutdown.md)
+- [x] [task-04-startup-reconciliation](task-04-startup-reconciliation.md)
+
+Wave 3:
+- [x] [task-05-verification-and-doc-sync](task-05-verification-and-doc-sync.md)
+
+## Open Questions
+
+- Should retryable cleanup failures reuse `executors_running.status`/`error_message`,
+  or should they introduce a more explicit cleanup status column in a follow-up?

--- a/docs/plans/task-runtime-cleanup/task-01-runtime-inventory.md
+++ b/docs/plans/task-runtime-cleanup/task-01-runtime-inventory.md
@@ -1,0 +1,53 @@
+---
+id: "01-runtime-inventory"
+title: "Runtime inventory"
+status: completed
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/runtime-cleanup.md"
+---
+
+# Task 01: Runtime Inventory
+
+## Acceptance
+
+- `executors_running` can be listed by `task_id` without filtering on
+  `task_sessions.state`.
+- Startup reconciliation continues to use the global `ListExecutorsRunning`
+  inventory.
+- Repository tests cover active and terminal task-scoped runtime rows.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/task/repository/sqlite
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/repository/interface.go`
+- `apps/backend/internal/task/repository/sqlite/executor.go`
+- `apps/backend/internal/task/repository/sqlite/executor_test.go`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec: `docs/specs/tasks/runtime-cleanup.md`
+- ADR: `docs/decisions/0025-runtime-cleanup-uses-executors-running.md`
+- Existing repository patterns in `apps/backend/internal/task/repository/sqlite/executor.go`
+
+## Output contract
+
+Report repository methods added, tests run, and any schema/status-field limitation
+that affects retryable cleanup in later tasks.
+
+## Result
+
+- Added `ListExecutorsRunningByTaskID`.
+- Shared executor-row scanning so task-scoped and global runtime inventory include
+  the same fields.
+- Verified with `go test ./internal/task/repository/sqlite`.

--- a/docs/plans/task-runtime-cleanup/task-01-runtime-inventory.md
+++ b/docs/plans/task-runtime-cleanup/task-01-runtime-inventory.md
@@ -28,7 +28,7 @@ cd apps/backend && go test ./internal/task/repository/sqlite
 
 - `apps/backend/internal/task/repository/interface.go`
 - `apps/backend/internal/task/repository/sqlite/executor.go`
-- `apps/backend/internal/task/repository/sqlite/executor_test.go`
+- `apps/backend/internal/task/repository/sqlite/executor_cleanup_test.go`
 
 ## Dependencies
 

--- a/docs/plans/task-runtime-cleanup/task-02-task-cleanup-ordering.md
+++ b/docs/plans/task-runtime-cleanup/task-02-task-cleanup-ordering.md
@@ -1,0 +1,59 @@
+---
+id: "02-task-cleanup-ordering"
+title: "Task cleanup ordering"
+status: completed
+wave: 1
+depends_on: ["01-runtime-inventory"]
+plan: "plan.md"
+spec: "../../specs/tasks/runtime-cleanup.md"
+---
+
+# Task 02: Task Cleanup Ordering
+
+## Acceptance
+
+- Archive/delete cleanup builds runtime stop targets from `executors_running`
+  rows owned by the task.
+- Executor rows/worktrees are removed only after stop has been attempted for each
+  runtime row.
+- Failed or uncertain stops preserve enough durable information for retry and
+  diagnosis.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/task/service
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/service/service.go`
+- `apps/backend/internal/task/service/service_tasks.go`
+- `apps/backend/internal/task/service/service_tasks_test.go`
+- `apps/backend/internal/orchestrator/task_operations.go`
+- `apps/backend/internal/orchestrator/executor/executor_interaction.go`
+
+## Dependencies
+
+Task 01.
+
+## Inputs
+
+- Runtime inventory methods from Task 01
+- Existing `TaskExecutionStopper` contract
+- Existing archive/delete cleanup flow in `service_tasks.go`
+
+## Output contract
+
+Report cleanup ordering changes, which stop-failure state is persisted, files
+changed, and tests run.
+
+## Result
+
+- Archive/delete/cascade cleanup builds stop targets from `executors_running`
+  before falling back to active sessions.
+- Runtime inventory failure aborts archive/delete before task mutation and skips
+  cascade cleanup.
+- Stop failures preserve executor rows and skip destructive environment,
+  worktree, and quick-chat cleanup for retry.
+- Verified with `go test ./internal/task/service`.

--- a/docs/plans/task-runtime-cleanup/task-03-agentctl-process-group-shutdown.md
+++ b/docs/plans/task-runtime-cleanup/task-03-agentctl-process-group-shutdown.md
@@ -1,0 +1,55 @@
+---
+id: "03-agentctl-process-group-shutdown"
+title: "Agentctl process group shutdown"
+status: completed
+wave: 2
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/runtime-cleanup.md"
+---
+
+# Task 03: Agentctl Process Group Shutdown
+
+## Acceptance
+
+- Agentctl instance shutdown cannot leave an ACP subprocess group reparented to
+  PID 1.
+- Processes that ignore stdin EOF are killed by process group after the stop
+  timeout.
+- Regression tests prove child processes are reaped on Unix.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/agentctl/server/process
+```
+
+## Files likely touched
+
+- `apps/backend/internal/agentctl/server/process/manager.go`
+- `apps/backend/internal/agentctl/server/process/procattr_unix.go`
+- `apps/backend/internal/agentctl/server/process/manager_test.go`
+- `apps/backend/internal/agentctl/server/process/testmain_test.go`
+
+## Dependencies
+
+None. Can run in parallel with Task 01/02 because it is isolated to agentctl
+process shutdown.
+
+## Inputs
+
+- Existing process group setup and `waitForProcessExit` in `process.Manager`
+- Spec failure mode: ACP children must not survive agentctl shutdown
+
+## Output contract
+
+Report shutdown behavior, Unix-only guards if added, tests run, and any platform
+differences that remain.
+
+## Result
+
+- Existing Linux process attributes already start agentctl children in their own
+  process group with parent-death signaling.
+- Existing process manager coverage already verifies process-group kill on stop
+  timeout.
+- Verified with `go test ./internal/agentctl/server/process ./internal/agentctl/server/instance`.

--- a/docs/plans/task-runtime-cleanup/task-04-startup-reconciliation.md
+++ b/docs/plans/task-runtime-cleanup/task-04-startup-reconciliation.md
@@ -1,0 +1,55 @@
+---
+id: "04-startup-reconciliation"
+title: "Startup reconciliation"
+status: completed
+wave: 2
+depends_on: ["01-runtime-inventory", "02-task-cleanup-ordering"]
+plan: "plan.md"
+spec: "../../specs/tasks/runtime-cleanup.md"
+---
+
+# Task 04: Startup Reconciliation
+
+## Acceptance
+
+- Backend startup scans persisted `executors_running` rows.
+- Terminal and missing-session rows are stopped by `agent_execution_id` before
+  runtime tracking is removed.
+- Stop failures preserve runtime rows.
+
+## Verification
+
+```bash
+cd apps/backend && go test ./internal/task/service ./internal/orchestrator/...
+```
+
+## Files likely touched
+
+- `apps/backend/internal/task/service/service_tasks.go`
+- `apps/backend/internal/orchestrator/event_handlers.go`
+- `apps/backend/internal/agent/runtime/lifecycle/manager_lifecycle.go`
+- `apps/backend/cmd/kandev/*.go`
+
+## Dependencies
+
+Tasks 01 and 02.
+
+## Inputs
+
+- Stale runtime inventory method from Task 01
+- Cleanup service behavior from Task 02
+- ADR-0009 fail-closed cleanup semantics
+
+## Output contract
+
+Report where reconciliation is owned, startup order implications, files changed,
+tests run, and any rows intentionally left untouched.
+
+## Result
+
+- Orchestrator startup reconciliation owns this pass.
+- Terminal completed/cancelled sessions and rows with missing sessions now stop
+  through `StopAgentWithReason` before row deletion.
+- Rows without a stoppable execution handle are intentionally preserved with a
+  warning.
+- Verified with `go test -run TestReconcileSessionsOnStartup ./internal/orchestrator`.

--- a/docs/plans/task-runtime-cleanup/task-05-verification-and-doc-sync.md
+++ b/docs/plans/task-runtime-cleanup/task-05-verification-and-doc-sync.md
@@ -1,0 +1,56 @@
+---
+id: "05-verification-and-doc-sync"
+title: "Verification and doc sync"
+status: completed
+wave: 3
+depends_on: ["01-runtime-inventory", "02-task-cleanup-ordering", "03-agentctl-process-group-shutdown", "04-startup-reconciliation"]
+plan: "plan.md"
+spec: "../../specs/tasks/runtime-cleanup.md"
+---
+
+# Task 05: Verification and Doc Sync
+
+## Acceptance
+
+- Backend formatting, tests, lint, and build/type checks pass for touched areas.
+- The spec and ADR still match the implemented behavior.
+- Relevant `AGENTS.md` scoped guidance is updated if cleanup conventions changed.
+
+## Verification
+
+```bash
+make -C apps/backend fmt
+make -C apps/backend test
+make -C apps/backend lint
+make -C apps/backend build
+```
+
+## Files likely touched
+
+- `docs/specs/tasks/runtime-cleanup.md`
+- `docs/decisions/0025-runtime-cleanup-uses-executors-running.md`
+- `docs/plans/task-runtime-cleanup/plan.md`
+- `apps/backend/AGENTS.md`
+- `apps/backend/internal/agentctl/AGENTS.md`
+
+## Dependencies
+
+Tasks 01, 02, 03, and 04.
+
+## Inputs
+
+- All implementation tasks
+- Root and backend engineering guidance
+
+## Output contract
+
+Report final verification commands and results, any doc updates, remaining risks,
+and plan checkbox updates.
+
+## Result
+
+- Plan, task files, spec index, and decision index are in sync.
+- `make -C apps/backend fmt` passed.
+- `make -C apps/backend test` passed.
+- `make -C apps/backend lint` passed.
+- `make -C apps/backend build` passed.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -45,6 +45,7 @@ Kandev's task model: documents, execution stages, labels, blocker escalation, su
 | [subtask-checklist](tasks/subtask-checklist.md) | shipped |
 | [subtree-controls](tasks/subtree-controls.md) | shipped |
 | [blocked-task-escalation](tasks/blocked-task-escalation.md) | draft |
+| [runtime-cleanup](tasks/runtime-cleanup.md) | draft |
 | [multi-branch](tasks/multi-branch/spec.md) | shipped |
 
 ## agents/ — agent governance

--- a/docs/specs/tasks/runtime-cleanup.md
+++ b/docs/specs/tasks/runtime-cleanup.md
@@ -103,7 +103,8 @@ Allowed transitions:
 - `tracked` -> `stop_requested` by archive/delete/session stop/reconciliation.
 - `stop_requested` -> `stopped` when runtime shutdown succeeds or the runtime is
   confirmed absent.
-- `stopped` -> `tracking_removed` after worktree/environment cleanup finishes.
+- `stopped` -> `tracking_removed` after worktree/environment cleanup has been
+  attempted and the runtime row is no longer needed as the durable stop handle.
 - `stop_requested` -> `retryable_failure` on timeout or uncertain runtime state.
 - `retryable_failure` -> `stop_requested` on the next cleanup attempt.
 
@@ -119,6 +120,10 @@ Allowed transitions:
 - If a runtime row points at a missing in-memory execution, cleanup attempts the
   runtime-specific persisted handle when available. If no handle can be used, the
   row is preserved with a warning instead of being silently dropped.
+- If worktree or task environment cleanup fails after runtime shutdown is
+  confirmed, the runtime tracking row can still be removed because it no longer
+  identifies a live process. The resource cleanup error is logged and handled by
+  the resource-specific retry path.
 - If an agentctl process exits unexpectedly, its owned agent subprocess group is
   killed before agentctl shutdown completes.
 - If startup reconciliation finds rows for archived tasks, deleted tasks, missing

--- a/docs/specs/tasks/runtime-cleanup.md
+++ b/docs/specs/tasks/runtime-cleanup.md
@@ -1,0 +1,171 @@
+---
+status: draft
+created: 2026-06-22
+owner: cfl
+---
+
+# Task Runtime Cleanup
+
+## Why
+
+Operators archive and delete completed tasks to keep the board usable and the
+workspace tidy. Those actions must also release the task's runtime resources;
+otherwise completed work leaves hidden ACP processes, host utility processes,
+worktrees, or executor rows behind and the machine slowly runs out of memory.
+
+## What
+
+- Archiving a task stops every runtime execution that is still durably associated
+  with that task before the task's worktrees or runtime tracking rows are removed.
+- Deleting a task stops every runtime execution that is still durably associated
+  with that task before task records, worktrees, or runtime tracking rows are
+  removed.
+- Cleanup ownership is based on `executors_running`, not only on active
+  `task_sessions` state. A runtime row for a completed, cancelled, archived, or
+  otherwise terminal session is still a cleanup target until the runtime stop has
+  been attempted.
+- A cleanup path MUST NOT delete the last durable runtime handle for a task until
+  either the matching runtime execution has stopped successfully or the failure is
+  preserved for retry/diagnosis.
+- Agent subprocess shutdown kills the whole agent process group when graceful
+  shutdown does not finish within the configured stop timeout.
+- Agentctl instance shutdown never leaves an agent subprocess group alive as a
+  child of `init`/PID 1.
+- Backend startup reconciles stale runtime rows for archived/deleted/missing task
+  state and attempts safe cleanup instead of treating the rows as live sessions.
+- Cleanup is idempotent: repeating archive/delete cleanup, startup reconciliation,
+  or explicit session stop does not fail because the process, task, session, or
+  worktree was already removed.
+
+## Data Model
+
+### `executors_running`
+
+`executors_running` remains the durable runtime ownership table and the source of
+cleanup handles for task runtime teardown.
+
+- `session_id` identifies the task session that originally launched the runtime.
+- `task_id` identifies the owning task and is the primary lookup key for archive
+  and delete cleanup.
+- `agent_execution_id` is the preferred stop handle for in-memory runtime
+  shutdown through the lifecycle manager.
+- `runtime`, `container_id`, `agentctl_url`, `agentctl_port`, `pid`, and
+  `metadata` provide fallback handles for runtime-specific cleanup and
+  diagnostics.
+- `status`, `error_message`, and timestamps remain available for cleanup
+  diagnostics when stop fails and the row must remain retryable.
+
+Rows may temporarily reference archived tasks or terminal sessions while cleanup
+is in progress. Rows must not reference missing task/session state indefinitely.
+
+### `task_sessions`
+
+`task_sessions.state` remains the user-facing session state. Terminal states do
+not imply runtime resources have been released. Cleanup code must not use terminal
+session state as a reason to skip runtime teardown when an `executors_running`
+row exists.
+
+## API Surface
+
+No new user-facing HTTP or WebSocket action is required. Existing task archive,
+task delete, session stop, and backend startup behavior gain stronger cleanup
+guarantees.
+
+Internal contracts:
+
+```go
+type ExecutorRunningRepository interface {
+    ListExecutorsRunningByTaskID(ctx context.Context, taskID string) ([]*models.ExecutorRunning, error)
+    ListExecutorsRunning(ctx context.Context) ([]*models.ExecutorRunning, error)
+}
+```
+
+`TaskExecutionStopper.StopExecution(ctx, executionID, reason, force)` remains the
+primary stop operation when `agent_execution_id` is available. Fallback cleanup is
+runtime-specific and must be bounded by context.
+
+## State Machine
+
+Runtime cleanup for a task follows this lifecycle:
+
+- `tracked`: an `executors_running` row exists for the task.
+- `stop_requested`: archive, delete, explicit stop, terminal-agent cleanup, or
+  startup reconciliation has selected the row for cleanup.
+- `stopped`: the runtime instance and its subprocess group have exited or were
+  already absent.
+- `tracking_removed`: the `executors_running` row is deleted after the stop
+  result is known.
+- `retryable_failure`: stop could not be confirmed before the timeout. The row
+  remains durable with enough context to retry and diagnose.
+
+Allowed transitions:
+
+- `tracked` -> `stop_requested` by archive/delete/session stop/reconciliation.
+- `stop_requested` -> `stopped` when runtime shutdown succeeds or the runtime is
+  confirmed absent.
+- `stopped` -> `tracking_removed` after worktree/environment cleanup finishes.
+- `stop_requested` -> `retryable_failure` on timeout or uncertain runtime state.
+- `retryable_failure` -> `stop_requested` on the next cleanup attempt.
+
+## Failure Modes
+
+- If querying `executors_running` for a task fails, archive/delete still updates
+  the task only if existing product behavior requires it, but destructive runtime
+  cleanup must fail closed: do not remove runtime rows or worktrees based on an
+  empty or partial inventory.
+- If stopping a runtime execution times out, the process manager escalates to a
+  process-group kill and waits for confirmation. If confirmation still fails, the
+  runtime row remains retryable.
+- If a runtime row points at a missing in-memory execution, cleanup attempts the
+  runtime-specific persisted handle when available. If no handle can be used, the
+  row is preserved with a warning instead of being silently dropped.
+- If an agentctl process exits unexpectedly, its owned agent subprocess group is
+  killed before agentctl shutdown completes.
+- If startup reconciliation finds rows for archived tasks, deleted tasks, missing
+  sessions, or terminal sessions with no live runtime, it removes only rows that
+  are positively confirmed safe to remove.
+
+## Persistence Guarantees
+
+- Runtime cleanup intent survives backend restarts because `executors_running`
+  rows remain durable until cleanup succeeds or a retryable failure is recorded.
+- Worktrees and task environment rows are not removed before runtime stop has been
+  attempted for every runtime row owned by the task.
+- Startup reconciliation is allowed to recover from a previous backend crash by
+  reattempting cleanup for stale runtime rows.
+- Orphaned OS processes without any durable `executors_running` row are outside
+  normal cleanup guarantees; they may be handled by an explicit operator recovery
+  tool, but automatic task cleanup must not rely on process-name scanning.
+
+## Scenarios
+
+- **GIVEN** a task has a `WAITING_FOR_INPUT` session and an
+  `executors_running` row, **WHEN** the task is archived, **THEN** the runtime is
+  stopped by `agent_execution_id` before the row and worktrees are removed.
+- **GIVEN** a task has a `COMPLETED` session but still has an
+  `executors_running` row, **WHEN** the task is deleted, **THEN** cleanup still
+  selects that row and attempts runtime shutdown.
+- **GIVEN** runtime shutdown succeeds for every row owned by a deleted task,
+  **WHEN** cleanup finishes, **THEN** the task's `executors_running` rows and
+  worktrees are removed.
+- **GIVEN** runtime shutdown times out for one row owned by an archived task,
+  **WHEN** cleanup finishes, **THEN** the row remains retryable with a diagnostic
+  error and worktree deletion does not erase the only runtime handle.
+- **GIVEN** the backend restarts with an `executors_running` row for an archived
+  task, **WHEN** startup reconciliation runs, **THEN** it attempts cleanup for the
+  row instead of treating the archived task as active.
+- **GIVEN** agentctl is stopped while an ACP child process ignores stdin EOF,
+  **WHEN** the stop timeout expires, **THEN** the ACP process group is killed and
+  no ACP child is reparented to PID 1.
+- **GIVEN** the `executors_running` query fails during archive cleanup, **WHEN**
+  cleanup evaluates destructive actions, **THEN** it logs the failure and does not
+  delete runtime tracking rows based on incomplete information.
+
+## Out of Scope
+
+- A general-purpose OS process sweeper that kills every process named
+  `codex-acp`, `claude-acp`, or `opencode`.
+- UI changes for showing runtime cleanup failures.
+- New user-facing archive/delete controls.
+- Changing the task/session state model beyond the cleanup guarantees described
+  here.


### PR DESCRIPTION
Task archive/delete could lose durable runtime handles before ACP processes were stopped, allowing orphaned agent processes to survive deleted worktrees. Cleanup now uses `executors_running` as the runtime source of truth, preserves handles on uncertain stops, and reconciles stale rows on startup.

## Important Changes

- Task archive/delete/cascade cleanup builds stop targets from `executors_running` so terminal sessions still get stopped.
- Stop failures preserve executor rows and skip destructive environment, worktree, and quick-chat cleanup for retry.
- Startup reconciliation stops terminal or missing-session runtime rows before deleting tracking.
- Added a runtime-cleanup spec, implementation plan, and ADR documenting the cleanup ownership rule.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `pnpm --filter @kandev/web test -- components/github/pr-status-chip.test.tsx -t "constrains the aggregate hover popover to the available viewport height"`
- `make test`
- `make lint`

## Possible Improvements

Medium risk: retryable cleanup rows currently preserve the existing row state rather than writing a dedicated cleanup-failed status.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->