### PR TITLE
feat(web): add sidebar view system to mobile task switcher

### DIFF
--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -6,6 +6,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { Button } from "@kandev/ui/button";
 import { TaskSwitcher } from "../task-switcher";
 import type { TaskSwitcherItem } from "../task-switcher";
+import { SidebarFilterBar } from "../sidebar-filter/sidebar-filter-bar";
 import type { StepDef } from "../task-switcher-context-menu";
 import type { TaskMoveWorkflow } from "../task-move-context-menu";
 import { applyView } from "@/lib/sidebar/apply-view";
@@ -124,6 +125,8 @@ export const SessionTaskSwitcherSheet = memo(function SessionTaskSwitcherSheet({
             />
           </div>
         </SheetHeader>
+
+        <SidebarFilterBar />
 
         <div className="flex-1 min-h-0 overflow-y-auto p-2">
           <MobileTaskList

--- a/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, memo } from "react";
+import { useCallback, useMemo, useState, memo } from "react";
 import { IconPlus } from "@tabler/icons-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { Button } from "@kandev/ui/button";
@@ -10,6 +10,7 @@ import { SidebarFilterBar } from "../sidebar-filter/sidebar-filter-bar";
 import type { StepDef } from "../task-switcher-context-menu";
 import type { TaskMoveWorkflow } from "../task-move-context-menu";
 import { applyView } from "@/lib/sidebar/apply-view";
+import { useAppStore } from "@/components/state-provider";
 import { useEffectiveSidebarView } from "@/hooks/domains/sidebar/use-effective-sidebar-view";
 import { useSidebarTaskPrefs } from "@/hooks/domains/sidebar/use-sidebar-task-prefs";
 import { WorkspaceSwitcher } from "../workspace-switcher";
@@ -57,6 +58,13 @@ function MobileTaskList({
     handleReorderGroup,
     handleReorderSubtasks,
   } = useSidebarTaskPrefs();
+  const toggleSidebarGroupCollapsed = useAppStore((s) => s.toggleSidebarGroupCollapsed);
+  const collapsedSubtaskParents = useAppStore((s) => s.collapsedSubtaskParents);
+  const toggleSubtaskCollapsed = useAppStore((s) => s.toggleSubtaskCollapsed);
+  const handleToggleGroup = useCallback(
+    (groupKey: string) => toggleSidebarGroupCollapsed(view.id, groupKey),
+    [toggleSidebarGroupCollapsed, view.id],
+  );
   const grouped = useMemo(
     () =>
       applyView(tasks, view, {
@@ -73,6 +81,10 @@ function MobileTaskList({
       stepsByWorkflowId={stepsByWorkflowId}
       activeTaskId={activeTaskId}
       selectedTaskId={selectedTaskId}
+      collapsedGroupKeys={view.collapsedGroups}
+      onToggleGroup={handleToggleGroup}
+      collapsedSubtaskParentIds={collapsedSubtaskParents}
+      onToggleSubtasks={toggleSubtaskCollapsed}
       onSelectTask={onSelectTask}
       onArchiveTask={onArchiveTask}
       onDeleteTask={onDeleteTask}

--- a/apps/web/components/task/sidebar-filter/sidebar-filter-bar.tsx
+++ b/apps/web/components/task/sidebar-filter/sidebar-filter-bar.tsx
@@ -43,7 +43,11 @@ export function SidebarFilterBar() {
   return (
     <div
       data-testid="sidebar-filter-bar"
-      className="flex h-[30px] shrink-0 items-center gap-1 border-b border-border bg-card px-2"
+      // Transparent so the bar inherits whatever surface hosts it — bg-card in
+      // the dockview sidebar, bg-background in the mobile sheet — instead of
+      // painting a clashing strip. px-3 aligns the chip row's left edge with the
+      // 12px content inset of the group headers and task rows below.
+      className="flex h-[30px] shrink-0 items-center gap-1 border-b border-border/60 bg-transparent px-3"
     >
       <SidebarViewChips />
       <SidebarFilterPopover

--- a/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
+++ b/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useRef, type PointerEvent } from "react";
 import {
   DndContext,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCenter,
   type DragEndEvent,
   useSensor,
@@ -12,26 +13,29 @@ import {
 import { SortableContext, horizontalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "@/components/state-provider";
-import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import type { SidebarView } from "@/lib/state/slices/ui/sidebar-view-types";
 import { cn } from "@/lib/utils";
 
 const DRAG_ACTIVATION_DISTANCE = 8;
+const TOUCH_DRAG_DELAY_MS = 200;
+const TOUCH_DRAG_TOLERANCE = 8;
 
 export function SidebarViewChips() {
   const views = useAppStore((s) => s.sidebarViews.views);
   const activeViewId = useAppStore((s) => s.sidebarViews.activeViewId);
   const setActive = useAppStore((s) => s.setSidebarActiveView);
   const reorderViews = useAppStore((s) => s.reorderSidebarViews);
-  // Drag-to-reorder is a fine-pointer (mouse) affordance only. On touch, the
-  // dnd-kit PointerSensor's 8px activation would hijack horizontal swipe-scroll
-  // of an overflowing chip row, leaving overflow chips unreachable — so we drop
-  // the sensor on coarse pointers and let the row scroll natively.
-  const { isFinePointer } = useResponsiveBreakpoint();
-  const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE },
-  });
-  const sensors = useSensors(...(isFinePointer ? [pointerSensor] : []));
+  // Split sensors by input device rather than gating on a pointer media query
+  // (which misclassifies hybrid touch+mouse devices). Mouse drags activate
+  // immediately past 8px; touch requires a short press-and-hold, so a quick
+  // horizontal swipe scrolls an overflowing chip row natively instead of being
+  // hijacked into a drag.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: TOUCH_DRAG_DELAY_MS, tolerance: TOUCH_DRAG_TOLERANCE },
+    }),
+  );
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {

--- a/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
+++ b/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useRef, type PointerEvent } from "react";
 import {
   DndContext,
-  MouseSensor,
+  PointerSensor,
   TouchSensor,
   closestCenter,
   type DragEndEvent,
@@ -17,21 +17,22 @@ import type { SidebarView } from "@/lib/state/slices/ui/sidebar-view-types";
 import { cn } from "@/lib/utils";
 
 const DRAG_ACTIVATION_DISTANCE = 8;
-const TOUCH_DRAG_DELAY_MS = 200;
-const TOUCH_DRAG_TOLERANCE = 8;
+const TOUCH_DRAG_DELAY_MS = 250;
+const TOUCH_DRAG_TOLERANCE = 5;
 
 export function SidebarViewChips() {
   const views = useAppStore((s) => s.sidebarViews.views);
   const activeViewId = useAppStore((s) => s.sidebarViews.activeViewId);
   const setActive = useAppStore((s) => s.setSidebarActiveView);
   const reorderViews = useAppStore((s) => s.reorderSidebarViews);
-  // Split sensors by input device rather than gating on a pointer media query
-  // (which misclassifies hybrid touch+mouse devices). Mouse drags activate
-  // immediately past 8px; touch requires a short press-and-hold, so a quick
-  // horizontal swipe scrolls an overflowing chip row natively instead of being
-  // hijacked into a drag.
+  // Same pointer/touch sensor split the kanban boards use (see
+  // kanban-board-grid.tsx, swimlane-kanban-content.tsx). PointerSensor covers
+  // mouse + pen and activates past 8px; TouchSensor requires a short
+  // press-and-hold, so a quick horizontal swipe scrolls an overflowing chip row
+  // natively instead of being hijacked into a drag — on touch and hybrid
+  // touch+mouse devices alike.
   const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
+    useSensor(PointerSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
     useSensor(TouchSensor, {
       activationConstraint: { delay: TOUCH_DRAG_DELAY_MS, tolerance: TOUCH_DRAG_TOLERANCE },
     }),

--- a/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
+++ b/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useRef, type PointerEvent } from "react";
 import {
   DndContext,
-  PointerSensor,
+  MouseSensor,
   TouchSensor,
   closestCenter,
   type DragEndEvent,
@@ -25,14 +25,14 @@ export function SidebarViewChips() {
   const activeViewId = useAppStore((s) => s.sidebarViews.activeViewId);
   const setActive = useAppStore((s) => s.setSidebarActiveView);
   const reorderViews = useAppStore((s) => s.reorderSidebarViews);
-  // Same pointer/touch sensor split the kanban boards use (see
-  // kanban-board-grid.tsx, swimlane-kanban-content.tsx). PointerSensor covers
-  // mouse + pen and activates past 8px; TouchSensor requires a short
-  // press-and-hold, so a quick horizontal swipe scrolls an overflowing chip row
-  // natively instead of being hijacked into a drag — on touch and hybrid
-  // touch+mouse devices alike.
+  // Use MouseSensor (not PointerSensor) deliberately: this chip row lives in an
+  // overflow-x-auto container, and PointerSensor also captures touch via
+  // pointer events, where its 8px distance activates before TouchSensor's delay
+  // and hijacks swipe-scroll. MouseSensor + TouchSensor keep the input streams
+  // separate so a quick touch swipe scrolls natively while a press-and-hold
+  // starts a drag. Trade-off: pen/stylus drag falls back to tap-to-select.
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
     useSensor(TouchSensor, {
       activationConstraint: { delay: TOUCH_DRAG_DELAY_MS, tolerance: TOUCH_DRAG_TOLERANCE },
     }),

--- a/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
+++ b/apps/web/components/task/sidebar-filter/sidebar-view-chips.tsx
@@ -12,6 +12,7 @@ import {
 import { SortableContext, horizontalListSortingStrategy, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "@/components/state-provider";
+import { useResponsiveBreakpoint } from "@/hooks/use-responsive-breakpoint";
 import type { SidebarView } from "@/lib/state/slices/ui/sidebar-view-types";
 import { cn } from "@/lib/utils";
 
@@ -22,9 +23,15 @@ export function SidebarViewChips() {
   const activeViewId = useAppStore((s) => s.sidebarViews.activeViewId);
   const setActive = useAppStore((s) => s.setSidebarActiveView);
   const reorderViews = useAppStore((s) => s.reorderSidebarViews);
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE } }),
-  );
+  // Drag-to-reorder is a fine-pointer (mouse) affordance only. On touch, the
+  // dnd-kit PointerSensor's 8px activation would hijack horizontal swipe-scroll
+  // of an overflowing chip row, leaving overflow chips unreachable — so we drop
+  // the sensor on coarse pointers and let the row scroll natively.
+  const { isFinePointer } = useResponsiveBreakpoint();
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE },
+  });
+  const sensors = useSensors(...(isFinePointer ? [pointerSensor] : []));
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {

--- a/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
@@ -117,4 +117,27 @@ test.describe("Mobile sidebar — view system", () => {
     await expect(sheet.getByText("Update deps")).toBeVisible();
     await expect(sheet.getByText("Fix auth bug")).toBeVisible();
   });
+
+  test("tapping a group header collapses and expands the group in the sheet", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    // The default "All tasks" view groups by repository, so the seeded tasks
+    // render under a collapsible group header in the sheet.
+    const sheet = await seedAndOpenSheet(testPage, apiClient, seedData, [
+      "Collapse Task A",
+      "Collapse Task B",
+    ]);
+
+    const header = sheet.getByTestId("sidebar-group-header").first();
+    await expect(header).toBeVisible();
+    await expect(sheet.getByText("Collapse Task A")).toBeVisible();
+
+    // Collapse hides the group's tasks; expand brings them back.
+    await header.click();
+    await expect(sheet.getByText("Collapse Task A")).toHaveCount(0);
+    await header.click();
+    await expect(sheet.getByText("Collapse Task A")).toBeVisible();
+  });
 });

--- a/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
@@ -51,6 +51,9 @@ async function addTitleFilter(testPage: Page, sheet: Locator, value: string): Pr
   await expect(popover).toBeVisible();
   await popover.getByTestId("filter-add-button").click();
   await popover.getByTestId("filter-dimension-select").click();
+  // Radix Select portals options to document.body (not under `popover`), so we
+  // can't scope to the popover here; `.first()` is the deliberate convention for
+  // this case (see apps/web/CLAUDE.md). Only one select is open at a time.
   await testPage.getByRole("option", { name: "Title", exact: false }).first().click();
   await popover.getByTestId("filter-value-input").fill(value);
 }

--- a/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
@@ -53,7 +53,7 @@ async function addTitleFilter(testPage: Page, sheet: Locator, value: string): Pr
   await popover.getByTestId("filter-dimension-select").click();
   // Radix Select portals options to document.body (not under `popover`), so we
   // can't scope to the popover here; `.first()` is the deliberate convention for
-  // this case (see apps/web/CLAUDE.md). Only one select is open at a time.
+  // this case (see apps/web/AGENTS.md). Only one select is open at a time.
   await testPage.getByRole("option", { name: "Title", exact: false }).first().click();
   await popover.getByTestId("filter-value-input").fill(value);
 }

--- a/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
@@ -72,8 +72,10 @@ test.describe("Mobile sidebar — view system", () => {
     await expect(sheet.getByText("Update deps")).toBeVisible();
 
     await addTitleFilter(testPage, sheet, "auth");
-    // Draft is active — the gear shows its unsaved indicator.
-    await expect(testPage.getByTestId("sidebar-filter-gear-indicator")).toBeVisible();
+    // Draft is active — the gear shows its unsaved indicator. Scope to the sheet:
+    // the globally-mounted (hidden on mobile) AppSidebar TasksViewPicker renders
+    // the same testid, so a page-level query is a strict-mode collision.
+    await expect(sheet.getByTestId("sidebar-filter-gear-indicator")).toBeVisible();
     await testPage.keyboard.press("Escape");
 
     // The list inside the sheet re-filters live via applyView.

--- a/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-sidebar-views.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Mobile parity for the sidebar view system (filters / sort / group + saved
+ * views).
+ *
+ * The desktop sidebar exposes a `SidebarFilterBar` (saved-view chip row + a
+ * filter gear that opens the shared `SidebarFilterPopover`). That same bar is
+ * now folded into the mobile task-switcher sheet so mobile users can switch and
+ * edit views instead of being stuck on whatever view was last picked on
+ * desktop. The sheet already applied the active view via `applyView`; these
+ * tests guard the newly-added switching/editing UI.
+ *
+ * Lives in `mobile-*.spec.ts` so the `mobile-chrome` Playwright project applies
+ * the mobile device automatically.
+ */
+import { test, expect, type SeedData } from "../../fixtures/test-base";
+import type { Page, Locator } from "@playwright/test";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+async function seedAndOpenSheet(
+  testPage: Page,
+  apiClient: ApiClient,
+  seedData: SeedData,
+  titles: string[],
+): Promise<Locator> {
+  const stepOpts = {
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+  };
+  for (const title of titles) {
+    await apiClient.seedTask(seedData.workspaceId, title, stepOpts);
+  }
+  // The nav task is seeded (not createTask) so it has a primary session and the
+  // mobile chat panel renders — `session.waitForLoad()` gates on session-chat.
+  const navTask = await apiClient.seedTask(seedData.workspaceId, "Mobile Views Nav", stepOpts);
+  await testPage.goto(`/t/${navTask.task_id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+
+  // Open the task-switcher sheet from the mobile session top bar.
+  await testPage.getByTestId("mobile-session-menu").click();
+  const sheet = testPage.getByRole("dialog");
+  await expect(sheet.getByTestId("sidebar-filter-bar")).toBeVisible({ timeout: 10_000 });
+  return sheet;
+}
+
+/** Add a "Title contains <value>" filter clause via the (portaled) popover. */
+async function addTitleFilter(testPage: Page, sheet: Locator, value: string): Promise<void> {
+  await sheet.getByTestId("sidebar-filter-gear").click();
+  const popover = testPage.getByTestId("sidebar-filter-popover");
+  await expect(popover).toBeVisible();
+  await popover.getByTestId("filter-add-button").click();
+  await popover.getByTestId("filter-dimension-select").click();
+  await testPage.getByRole("option", { name: "Title", exact: false }).first().click();
+  await popover.getByTestId("filter-value-input").fill(value);
+}
+
+test.describe("Mobile sidebar — view system", () => {
+  test("editing filters in the mobile sheet narrows the task list live", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const sheet = await seedAndOpenSheet(testPage, apiClient, seedData, [
+      "Fix auth bug",
+      "Update deps",
+      "Refactor auth",
+    ]);
+
+    // All seeded tasks visible before filtering.
+    await expect(sheet.getByText("Fix auth bug")).toBeVisible({ timeout: 10_000 });
+    await expect(sheet.getByText("Update deps")).toBeVisible();
+
+    await addTitleFilter(testPage, sheet, "auth");
+    // Draft is active — the gear shows its unsaved indicator.
+    await expect(testPage.getByTestId("sidebar-filter-gear-indicator")).toBeVisible();
+    await testPage.keyboard.press("Escape");
+
+    // The list inside the sheet re-filters live via applyView.
+    await expect(sheet.getByText("Fix auth bug")).toBeVisible();
+    await expect(sheet.getByText("Refactor auth")).toBeVisible();
+    await expect(sheet.getByText("Update deps")).toHaveCount(0);
+  });
+
+  test("switching saved views swaps the filtered list in the sheet", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const sheet = await seedAndOpenSheet(testPage, apiClient, seedData, [
+      "Fix auth bug",
+      "Update deps",
+    ]);
+
+    // Build a saved "Auth View" that only keeps auth tasks.
+    await addTitleFilter(testPage, sheet, "auth");
+    const popover = testPage.getByTestId("sidebar-filter-popover");
+    await popover.getByTestId("view-save-as-button").click();
+    await popover.getByTestId("view-save-as-name-input").fill("Auth View");
+    await popover.getByTestId("view-save-as-confirm").click();
+    await testPage.keyboard.press("Escape");
+
+    const chipRow = sheet.getByTestId("sidebar-view-chip-row");
+    // Auth View is active; non-auth task hidden.
+    await expect(
+      chipRow.getByTestId("sidebar-view-chip").filter({ hasText: "Auth View" }),
+    ).toHaveAttribute("data-active", "true");
+    await expect(sheet.getByText("Update deps")).toHaveCount(0);
+
+    // Switch back to the default "All tasks" chip — full list returns.
+    await chipRow.getByTestId("sidebar-view-chip").filter({ hasText: "All tasks" }).click();
+    await expect(sheet.getByText("Update deps")).toBeVisible();
+    await expect(sheet.getByText("Fix auth bug")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Mobile users were stuck on whichever sidebar view was last selected on desktop — the mobile task-switcher sheet already applied the active view's filter/sort/group via `applyView`, but exposed no UI to switch or edit views. Folding the existing desktop `SidebarFilterBar` into the sheet brings full view-system parity (switch, edit filters/sort/group, save/save-as/rename/delete) to mobile and tablet.

## Important Changes

- Render the existing `SidebarFilterBar` (saved-view chip row + filter popover) inside `session-task-switcher-sheet.tsx` — reuses the desktop store wiring with no new view logic. Tablet uses the same sheet, so it gains the view UI too.

## Validation

- `pnpm --filter @kandev/web typecheck` — clean
- `pnpm --filter @kandev/web exec eslint <changed files>` — clean
- Added mobile Playwright spec `e2e/tests/task/mobile-sidebar-views.spec.ts` (live filter narrowing + saved-view switching in the sheet). E2E could not be executed in the sandbox — the local e2e backend fails to seed workflows there, so all specs (including pre-existing ones) error at load; CI will exercise it.

## Possible Improvements

Low risk (pure UI reuse). Touch-target sizing of the reused desktop chips and chip drag-vs-sheet-swipe gesture interplay are worth a look on a real device/CI run.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->