### PR TITLE
feat: add subtask completion trigger

### DIFF
--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -1,0 +1,209 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/kandev/kandev/internal/orchestrator/watcher"
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/workflow/engine"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func (s *Service) handleTaskStateChanged(ctx context.Context, data watcher.TaskEventData) {
+	if data.NewState == nil || !models.IsTerminalTaskState(*data.NewState) {
+		return
+	}
+
+	s.processParentChildrenCompletedForTaskState(ctx, data.TaskID, *data.NewState)
+}
+
+func (s *Service) processParentChildrenCompletedForTaskState(ctx context.Context, taskID string, state v1.TaskState) {
+	if !models.IsTerminalTaskState(state) {
+		return
+	}
+
+	child, err := s.repo.GetTask(ctx, taskID)
+	if err != nil {
+		s.logger.Warn("on_children_completed: failed to load changed child task",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		return
+	}
+	if child.ParentID == "" {
+		return
+	}
+
+	s.processOnChildrenCompleted(ctx, child.ParentID)
+}
+
+func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID string) bool {
+	if parentID == "" || s.workflowEngine == nil || s.workflowStore == nil || s.workflowStepGetter == nil {
+		return false
+	}
+
+	rows, ok := s.readyChildCompletionRows(ctx, parentID)
+	if !ok {
+		return false
+	}
+
+	parent, session, ok := s.parentCompletionContext(ctx, parentID)
+	if !ok {
+		return false
+	}
+
+	operationID := childCompletionOperationID(parentID, rows)
+	if s.childCompletionAlreadyApplied(ctx, parentID, operationID) {
+		return false
+	}
+
+	result, ok := s.evaluateChildrenCompleted(ctx, parent, session, rows)
+	if !ok {
+		return false
+	}
+
+	if !result.Transitioned {
+		s.markChildCompletionApplied(ctx, parentID, operationID, "non-transition")
+		return false
+	}
+
+	appliedTransition := s.applyEngineTransition(
+		ctx,
+		parentID,
+		session,
+		result,
+		engine.TriggerOnChildrenCompleted,
+		parent.Description,
+		true,
+	)
+	if !appliedTransition {
+		return false
+	}
+	s.markChildCompletionApplied(ctx, parentID, operationID, "transition")
+	return true
+}
+
+func (s *Service) readyChildCompletionRows(ctx context.Context, parentID string) ([]models.ChildCompletionRow, bool) {
+	rows, err := s.repo.ListChildCompletionRows(ctx, parentID)
+	if err != nil {
+		s.logger.Warn("on_children_completed: failed to list active children",
+			zap.String("parent_task_id", parentID),
+			zap.Error(err))
+		return nil, false
+	}
+	if len(rows) == 0 || !allChildrenTerminal(rows) {
+		return nil, false
+	}
+	return rows, true
+}
+
+func (s *Service) parentCompletionContext(ctx context.Context, parentID string) (*models.Task, *models.TaskSession, bool) {
+	parent, err := s.repo.GetTask(ctx, parentID)
+	if err != nil {
+		s.logger.Warn("on_children_completed: failed to load parent task",
+			zap.String("parent_task_id", parentID),
+			zap.Error(err))
+		return nil, nil, false
+	}
+	if parent.WorkflowStepID == "" || parent.IsEphemeral {
+		return nil, nil, false
+	}
+
+	session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, parentID)
+	if err != nil {
+		s.logger.Debug("on_children_completed: parent has no active session",
+			zap.String("parent_task_id", parentID),
+			zap.Error(err))
+		return nil, nil, false
+	}
+	return parent, session, true
+}
+
+func (s *Service) childCompletionAlreadyApplied(ctx context.Context, parentID, operationID string) bool {
+	applied, err := s.workflowStore.IsOperationApplied(ctx, operationID)
+	if err != nil {
+		s.logger.Warn("on_children_completed: failed to check operation idempotency",
+			zap.String("parent_task_id", parentID),
+			zap.String("operation_id", operationID),
+			zap.Error(err))
+		return true
+	}
+	return applied
+}
+
+func (s *Service) evaluateChildrenCompleted(
+	ctx context.Context,
+	parent *models.Task,
+	session *models.TaskSession,
+	rows []models.ChildCompletionRow,
+) (engine.HandleResult, bool) {
+	state := s.buildMachineState(ctx, parent, session)
+	result, err := s.workflowEngine.HandleTrigger(ctx, engine.HandleInput{
+		TaskID:         parent.ID,
+		SessionID:      session.ID,
+		Trigger:        engine.TriggerOnChildrenCompleted,
+		EvaluateOnly:   true,
+		PreloadedState: &state,
+		Payload:        childCompletionPayload(rows),
+	})
+	if err != nil {
+		s.logger.Warn("on_children_completed: workflow engine error",
+			zap.String("parent_task_id", parent.ID),
+			zap.String("session_id", session.ID),
+			zap.Error(err))
+		return engine.HandleResult{}, false
+	}
+	return result, true
+}
+
+func (s *Service) markChildCompletionApplied(ctx context.Context, parentID, operationID, phase string) {
+	if err := s.workflowStore.MarkOperationApplied(ctx, operationID); err != nil {
+		s.logger.Warn("on_children_completed: failed to mark operation",
+			zap.String("parent_task_id", parentID),
+			zap.String("operation_id", operationID),
+			zap.String("phase", phase),
+			zap.Error(err))
+	}
+}
+
+func allChildrenTerminal(rows []models.ChildCompletionRow) bool {
+	for _, row := range rows {
+		if !models.IsTerminalTaskState(row.State) {
+			return false
+		}
+	}
+	return true
+}
+
+func childCompletionPayload(rows []models.ChildCompletionRow) engine.OnChildrenCompletedPayload {
+	summaries := make([]engine.ChildSummary, 0, len(rows))
+	for _, row := range rows {
+		summaries = append(summaries, engine.ChildSummary{
+			TaskID:  row.ID,
+			Status:  string(row.State),
+			Summary: row.Title,
+		})
+	}
+	return engine.OnChildrenCompletedPayload{ChildSummaries: summaries}
+}
+
+func childCompletionOperationID(parentID string, rows []models.ChildCompletionRow) string {
+	var b strings.Builder
+	b.WriteString(parentID)
+	for _, row := range rows {
+		b.WriteString("|")
+		b.WriteString(row.ID)
+		b.WriteString(":")
+		b.WriteString(string(row.State))
+		b.WriteString(":")
+		b.WriteString(row.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return fmt.Sprintf("on_children_completed:%s:%s", parentID, hex.EncodeToString(sum[:]))
+}

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -59,6 +60,9 @@ func (s *Service) processOnChildrenCompleted(ctx context.Context, parentID strin
 	}
 
 	operationID := childCompletionOperationID(parentID, rows)
+	unlock := s.lockChildCompletionOperation(operationID)
+	defer unlock()
+
 	if s.childCompletionAlreadyApplied(ctx, parentID, operationID) {
 		return false
 	}
@@ -135,6 +139,16 @@ func (s *Service) childCompletionAlreadyApplied(ctx context.Context, parentID, o
 		return true
 	}
 	return applied
+}
+
+func (s *Service) lockChildCompletionOperation(operationID string) func() {
+	value, _ := s.childCompletionLocks.LoadOrStore(operationID, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return func() {
+		mu.Unlock()
+		s.childCompletionLocks.Delete(operationID)
+	}
 }
 
 func (s *Service) evaluateChildrenCompleted(

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed.go
@@ -141,13 +141,33 @@ func (s *Service) childCompletionAlreadyApplied(ctx context.Context, parentID, o
 	return applied
 }
 
+type childCompletionOperationLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
 func (s *Service) lockChildCompletionOperation(operationID string) func() {
-	value, _ := s.childCompletionLocks.LoadOrStore(operationID, &sync.Mutex{})
-	mu := value.(*sync.Mutex)
-	mu.Lock()
+	s.childCompletionLocksMu.Lock()
+	if s.childCompletionLocks == nil {
+		s.childCompletionLocks = make(map[string]*childCompletionOperationLock)
+	}
+	entry := s.childCompletionLocks[operationID]
+	if entry == nil {
+		entry = &childCompletionOperationLock{}
+		s.childCompletionLocks[operationID] = entry
+	}
+	entry.refs++
+	s.childCompletionLocksMu.Unlock()
+
+	entry.mu.Lock()
 	return func() {
-		mu.Unlock()
-		s.childCompletionLocks.Delete(operationID)
+		s.childCompletionLocksMu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(s.childCompletionLocks, operationID)
+		}
+		s.childCompletionLocksMu.Unlock()
+		entry.mu.Unlock()
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
@@ -36,6 +36,13 @@ func TestProcessOnChildrenCompleted_TransitionsParentWhenAllActiveChildrenTermin
 
 	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
 	svc := createEngineService(t, repo, stepGetter, agentMgr)
+	onEnterDone := make(chan struct{}, 1)
+	svc.onProcessOnEnterComplete = func() {
+		select {
+		case onEnterDone <- struct{}{}:
+		default:
+		}
+	}
 
 	now := time.Now().UTC()
 	for _, child := range []*models.Task{
@@ -80,6 +87,7 @@ func TestProcessOnChildrenCompleted_TransitionsParentWhenAllActiveChildrenTermin
 	if transitioned := svc.processOnChildrenCompleted(ctx, "parent"); !transitioned {
 		t.Fatalf("expected all-terminal active children to transition parent")
 	}
+	waitForChildrenCompletedOnEnter(t, onEnterDone)
 
 	parent, err = repo.GetTask(ctx, "parent")
 	if err != nil {
@@ -87,5 +95,24 @@ func TestProcessOnChildrenCompleted_TransitionsParentWhenAllActiveChildrenTermin
 	}
 	if parent.WorkflowStepID != "step_done" {
 		t.Fatalf("expected parent to move to step_done, got %q", parent.WorkflowStepID)
+	}
+	if transitioned := svc.processOnChildrenCompleted(ctx, "parent"); transitioned {
+		t.Fatalf("expected duplicate all-terminal evaluation not to transition parent again")
+	}
+	parent, err = repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent after duplicate evaluation: %v", err)
+	}
+	if parent.WorkflowStepID != "step_done" {
+		t.Fatalf("expected parent to remain on step_done after duplicate evaluation, got %q", parent.WorkflowStepID)
+	}
+}
+
+func waitForChildrenCompletedOnEnter(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for processOnEnter goroutine")
 	}
 }

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
@@ -1,0 +1,91 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kandev/kandev/internal/task/models"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+func TestProcessOnChildrenCompleted_TransitionsParentWhenAllActiveChildrenTerminal(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedSession(t, repo, "parent", "parent-session", "step_wait")
+
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step_wait"] = &wfmodels.WorkflowStep{
+		ID:         "step_wait",
+		WorkflowID: "wf1",
+		Name:       "Wait for Subtasks",
+		Position:   0,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{
+				{Type: wfmodels.GenericActionMoveToNext},
+			},
+		},
+	}
+	stepGetter.steps["step_done"] = &wfmodels.WorkflowStep{
+		ID:         "step_done",
+		WorkflowID: "wf1",
+		Name:       "Done",
+		Position:   1,
+	}
+
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	svc := createEngineService(t, repo, stepGetter, agentMgr)
+
+	now := time.Now().UTC()
+	for _, child := range []*models.Task{
+		{
+			ID:         "child-complete",
+			WorkflowID: "wf1",
+			Title:      "Complete child",
+			State:      v1.TaskStateCompleted,
+			ParentID:   "parent",
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+		{
+			ID:         "child-open",
+			WorkflowID: "wf1",
+			Title:      "Open child",
+			State:      v1.TaskStateInProgress,
+			ParentID:   "parent",
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	} {
+		if err := repo.CreateTask(ctx, child); err != nil {
+			t.Fatalf("create child %s: %v", child.ID, err)
+		}
+	}
+
+	if transitioned := svc.processOnChildrenCompleted(ctx, "parent"); transitioned {
+		t.Fatalf("expected mixed terminal/non-terminal children not to transition")
+	}
+	parent, err := repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	if parent.WorkflowStepID != "step_wait" {
+		t.Fatalf("expected parent to stay on step_wait, got %q", parent.WorkflowStepID)
+	}
+
+	if err := repo.UpdateTaskState(ctx, "child-open", v1.TaskStateCompleted); err != nil {
+		t.Fatalf("complete child-open: %v", err)
+	}
+	if transitioned := svc.processOnChildrenCompleted(ctx, "parent"); !transitioned {
+		t.Fatalf("expected all-terminal active children to transition parent")
+	}
+
+	parent, err = repo.GetTask(ctx, "parent")
+	if err != nil {
+		t.Fatalf("load parent after transition: %v", err)
+	}
+	if parent.WorkflowStepID != "step_done" {
+		t.Fatalf("expected parent to move to step_done, got %q", parent.WorkflowStepID)
+	}
+}

--- a/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_children_completed_test.go
@@ -116,3 +116,59 @@ func waitForChildrenCompletedOnEnter(t *testing.T, done <-chan struct{}) {
 		t.Fatal("timed out waiting for processOnEnter goroutine")
 	}
 }
+
+func TestLockChildCompletionOperationKeepsEntryUntilWaitersExit(t *testing.T) {
+	svc := &Service{}
+	unlockFirst := svc.lockChildCompletionOperation("op")
+
+	secondAcquired := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		unlockSecond := svc.lockChildCompletionOperation("op")
+		close(secondAcquired)
+		<-releaseSecond
+		unlockSecond()
+		close(done)
+	}()
+
+	waitForChildCompletionLockRefs(t, svc, "op", 2)
+	unlockFirst()
+	select {
+	case <-secondAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second lock holder")
+	}
+	waitForChildCompletionLockRefs(t, svc, "op", 1)
+	close(releaseSecond)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second lock release")
+	}
+
+	svc.childCompletionLocksMu.Lock()
+	_, exists := svc.childCompletionLocks["op"]
+	svc.childCompletionLocksMu.Unlock()
+	if exists {
+		t.Fatal("expected lock entry to be deleted after all holders exit")
+	}
+}
+
+func waitForChildCompletionLockRefs(t *testing.T, svc *Service, operationID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		svc.childCompletionLocksMu.Lock()
+		got := 0
+		if entry := svc.childCompletionLocks[operationID]; entry != nil {
+			got = entry.refs
+		}
+		svc.childCompletionLocksMu.Unlock()
+		if got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for lock refs %d", want)
+}

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -2164,8 +2164,25 @@ func (s *Service) applyEngineTransition(
 	// ResetAgentContext → sendStreamRequest, which blocks G_reader waiting for a response
 	// that can only be delivered by G_reader reading from the same WebSocket — a deadlock.
 	// The DB transition is already persisted above, so it's safe to process on_enter async.
-	go s.processOnEnter(context.WithoutCancel(ctx), taskID, session, targetStep, taskDescription)
+	s.launchProcessOnEnter(context.WithoutCancel(ctx), taskID, session, targetStep, taskDescription)
 	return true
+}
+
+func (s *Service) launchProcessOnEnter(
+	ctx context.Context,
+	taskID string,
+	session *models.TaskSession,
+	targetStep *wfmodels.WorkflowStep,
+	taskDescription string,
+) {
+	go func() {
+		defer func() {
+			if s.onProcessOnEnterComplete != nil {
+				s.onProcessOnEnterComplete()
+			}
+		}()
+		s.processOnEnter(ctx, taskID, session, targetStep, taskDescription)
+	}()
 }
 
 // processOnTurnStartViaEngine uses the workflow engine to evaluate on_turn_start

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -171,6 +171,7 @@ type sessionExecutorStore interface {
 	// Task
 	GetTask(ctx context.Context, id string) (*models.Task, error)
 	UpdateTask(ctx context.Context, task *models.Task) error
+	ListChildCompletionRows(ctx context.Context, parentID string) ([]models.ChildCompletionRow, error)
 	// Git snapshots and commits
 	GetLatestGitSnapshot(ctx context.Context, sessionID string) (*models.GitSnapshot, error)
 	CreateGitSnapshot(ctx context.Context, snapshot *models.GitSnapshot) error
@@ -457,7 +458,11 @@ func NewService(
 	// (e.g. WebSocket notifications to the frontend). Must be set after service
 	// construction so the session callback can reference s.updateTaskSessionState.
 	exec.SetOnTaskStateChange(func(ctx context.Context, taskID string, state v1.TaskState) error {
-		return taskRepo.UpdateTaskState(ctx, taskID, state)
+		if err := taskRepo.UpdateTaskState(ctx, taskID, state); err != nil {
+			return err
+		}
+		s.processParentChildrenCompletedForTaskState(ctx, taskID, state)
+		return nil
 	})
 	exec.SetOnSessionStateChange(func(ctx context.Context, taskID, sessionID string, state models.TaskSessionState, errorMessage string) error {
 		s.updateTaskSessionState(ctx, taskID, sessionID, state, errorMessage, true)
@@ -472,6 +477,7 @@ func NewService(
 	// Create the watcher with event handlers that wire everything together
 	handlers := watcher.EventHandlers{
 		OnTaskDeleted:          s.handleTaskDeleted,
+		OnTaskStateChanged:     s.handleTaskStateChanged,
 		OnAgentRunning:         s.handleAgentRunning,
 		OnAgentBootReady:       s.handleAgentBootReady,
 		OnAgentReady:           s.handleAgentReady,

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -232,9 +232,9 @@ type Service struct {
 	// Workflow engine for typed state-machine evaluation of step transitions
 	workflowEngine *engine.Engine
 	workflowStore  *workflowStore
-	// childCompletionLocks serializes duplicate on_children_completed deliveries
-	// for the same completed child set across watcher and executor callbacks.
-	childCompletionLocks sync.Map
+	// childCompletionLocks serializes duplicate on_children_completed deliveries.
+	childCompletionLocksMu sync.Mutex
+	childCompletionLocks   map[string]*childCompletionOperationLock
 	// onProcessOnEnterComplete is a package-test hook for synchronizing with
 	// applyEngineTransition's asynchronous processOnEnter goroutine.
 	onProcessOnEnterComplete func()

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -232,6 +232,12 @@ type Service struct {
 	// Workflow engine for typed state-machine evaluation of step transitions
 	workflowEngine *engine.Engine
 	workflowStore  *workflowStore
+	// childCompletionLocks serializes duplicate on_children_completed deliveries
+	// for the same completed child set across watcher and executor callbacks.
+	childCompletionLocks sync.Map
+	// onProcessOnEnterComplete is a package-test hook for synchronizing with
+	// applyEngineTransition's asynchronous processOnEnter goroutine.
+	onProcessOnEnterComplete func()
 	// engineOptions are applied each time initWorkflowEngine runs. Wired
 	// from cmd/kandev (Phase 3.2) to plug Phase 2 ADR-0004 dependencies
 	// — RunQueueAdapter, ParticipantStore, DecisionStore, and the CEO /

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -2481,6 +2481,7 @@ func (s *Service) CompleteTask(ctx context.Context, taskID string) error {
 	if err := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateCompleted); err != nil {
 		return fmt.Errorf("failed to update task state: %w", err)
 	}
+	s.processParentChildrenCompletedForTaskState(ctx, taskID, v1.TaskStateCompleted)
 
 	s.logger.Info("task marked as COMPLETED",
 		zap.String("task_id", taskID))

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1045,6 +1045,8 @@ func (s *Service) ResumeTaskSession(ctx context.Context, taskID, sessionID strin
 				zap.String("task_id", taskID),
 				zap.String("session_id", sessionID),
 				zap.Error(stateErr))
+		} else {
+			s.processParentChildrenCompletedForTaskState(resumeCtx, taskID, v1.TaskStateFailed)
 		}
 		return nil, err
 	}
@@ -1251,6 +1253,8 @@ func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, se
 				zap.String("task_id", session.TaskID),
 				zap.String("session_id", sessionID),
 				zap.Error(stateErr))
+		} else {
+			s.processParentChildrenCompletedForTaskState(ctx, session.TaskID, v1.TaskStateFailed)
 		}
 		return fmt.Errorf("failed to resume session: %w", err)
 	}

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -1254,7 +1254,7 @@ func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, se
 				zap.String("session_id", sessionID),
 				zap.Error(stateErr))
 		} else {
-			s.processParentChildrenCompletedForTaskState(ctx, session.TaskID, v1.TaskStateFailed)
+			s.processParentChildrenCompletedForTaskState(resumeCtx, session.TaskID, v1.TaskStateFailed)
 		}
 		return fmt.Errorf("failed to resume session: %w", err)
 	}

--- a/apps/backend/internal/task/dto/converters.go
+++ b/apps/backend/internal/task/dto/converters.go
@@ -22,10 +22,16 @@ func FromWorkflowStep(step *wfmodels.WorkflowStep) WorkflowStepDTO {
 		AgentProfileID:        step.AgentProfileID,
 		StageType:             string(step.StageType),
 	}
-	if len(step.Events.OnEnter) > 0 || len(step.Events.OnTurnComplete) > 0 {
+	if hasStepEvents(step.Events) {
 		events := &StepEventsDTO{}
 		for _, a := range step.Events.OnEnter {
 			events.OnEnter = append(events.OnEnter, StepActionDTO{
+				Type:   string(a.Type),
+				Config: a.Config,
+			})
+		}
+		for _, a := range step.Events.OnTurnStart {
+			events.OnTurnStart = append(events.OnTurnStart, StepActionDTO{
 				Type:   string(a.Type),
 				Config: a.Config,
 			})
@@ -36,9 +42,47 @@ func FromWorkflowStep(step *wfmodels.WorkflowStep) WorkflowStepDTO {
 				Config: a.Config,
 			})
 		}
+		for _, a := range step.Events.OnExit {
+			events.OnExit = append(events.OnExit, StepActionDTO{
+				Type:   string(a.Type),
+				Config: a.Config,
+			})
+		}
+		events.OnComment = appendGenericActions(step.Events.OnComment)
+		events.OnBlockerResolved = appendGenericActions(step.Events.OnBlockerResolved)
+		events.OnChildrenCompleted = appendGenericActions(step.Events.OnChildrenCompleted)
+		events.OnApprovalResolved = appendGenericActions(step.Events.OnApprovalResolved)
+		events.OnHeartbeat = appendGenericActions(step.Events.OnHeartbeat)
+		events.OnBudgetAlert = appendGenericActions(step.Events.OnBudgetAlert)
+		events.OnAgentError = appendGenericActions(step.Events.OnAgentError)
 		result.Events = events
 	}
 	return result
+}
+
+func hasStepEvents(events wfmodels.StepEvents) bool {
+	return len(events.OnEnter) > 0 ||
+		len(events.OnTurnStart) > 0 ||
+		len(events.OnTurnComplete) > 0 ||
+		len(events.OnExit) > 0 ||
+		len(events.OnComment) > 0 ||
+		len(events.OnBlockerResolved) > 0 ||
+		len(events.OnChildrenCompleted) > 0 ||
+		len(events.OnApprovalResolved) > 0 ||
+		len(events.OnHeartbeat) > 0 ||
+		len(events.OnBudgetAlert) > 0 ||
+		len(events.OnAgentError) > 0
+}
+
+func appendGenericActions(actions []wfmodels.GenericAction) []StepActionDTO {
+	out := make([]StepActionDTO, 0, len(actions))
+	for _, a := range actions {
+		out = append(out, StepActionDTO{
+			Type:   string(a.Type),
+			Config: a.Config,
+		})
+	}
+	return out
 }
 
 // FromWorkflowStepWithTimestamps converts a workflow step model to a WorkflowStepDTO,

--- a/apps/backend/internal/task/dto/converters_test.go
+++ b/apps/backend/internal/task/dto/converters_test.go
@@ -1,0 +1,39 @@
+package dto
+
+import (
+	"testing"
+
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+)
+
+func TestFromWorkflowStep_PreservesGenericEvents(t *testing.T) {
+	step := &wfmodels.WorkflowStep{
+		ID:         "step-1",
+		WorkflowID: "wf-1",
+		Name:       "Work",
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{{
+				Type: wfmodels.GenericActionQueueRun,
+				Config: map[string]interface{}{
+					"target": "primary",
+					"reason": "children_completed",
+				},
+			}},
+		},
+	}
+
+	got := FromWorkflowStep(step)
+	if got.Events == nil {
+		t.Fatal("Events nil, want on_children_completed")
+	}
+	if len(got.Events.OnChildrenCompleted) != 1 {
+		t.Fatalf("OnChildrenCompleted len = %d, want 1", len(got.Events.OnChildrenCompleted))
+	}
+	action := got.Events.OnChildrenCompleted[0]
+	if action.Type != "queue_run" {
+		t.Fatalf("action type = %q, want queue_run", action.Type)
+	}
+	if action.Config["reason"] != "children_completed" {
+		t.Fatalf("action reason = %v, want children_completed", action.Config["reason"])
+	}
+}

--- a/apps/backend/internal/task/dto/dto.go
+++ b/apps/backend/internal/task/dto/dto.go
@@ -700,8 +700,17 @@ type WorkflowStepDTO struct {
 
 // StepEventsDTO represents step events for API responses
 type StepEventsDTO struct {
-	OnEnter        []StepActionDTO `json:"on_enter,omitempty"`
-	OnTurnComplete []StepActionDTO `json:"on_turn_complete,omitempty"`
+	OnEnter             []StepActionDTO `json:"on_enter,omitempty"`
+	OnTurnStart         []StepActionDTO `json:"on_turn_start,omitempty"`
+	OnTurnComplete      []StepActionDTO `json:"on_turn_complete,omitempty"`
+	OnExit              []StepActionDTO `json:"on_exit,omitempty"`
+	OnComment           []StepActionDTO `json:"on_comment,omitempty"`
+	OnBlockerResolved   []StepActionDTO `json:"on_blocker_resolved,omitempty"`
+	OnChildrenCompleted []StepActionDTO `json:"on_children_completed,omitempty"`
+	OnApprovalResolved  []StepActionDTO `json:"on_approval_resolved,omitempty"`
+	OnHeartbeat         []StepActionDTO `json:"on_heartbeat,omitempty"`
+	OnBudgetAlert       []StepActionDTO `json:"on_budget_alert,omitempty"`
+	OnAgentError        []StepActionDTO `json:"on_agent_error,omitempty"`
 }
 
 // StepActionDTO represents a step action for API responses

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -352,6 +352,26 @@ type Task struct {
 	IsFromOffice bool `json:"is_from_office,omitempty"`
 }
 
+// ChildCompletionRow is the compact active-child projection used to decide
+// whether a parent task's on_children_completed trigger is ready to fire.
+type ChildCompletionRow struct {
+	ID        string       `json:"id" db:"id"`
+	State     v1.TaskState `json:"state" db:"state"`
+	Title     string       `json:"title" db:"title"`
+	UpdatedAt time.Time    `json:"updated_at" db:"updated_at"`
+}
+
+// IsTerminalTaskState reports whether a task state means no further child work
+// is expected from that task.
+func IsTerminalTaskState(state v1.TaskState) bool {
+	switch state {
+	case v1.TaskStateCompleted, v1.TaskStateFailed, v1.TaskStateCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
 // TaskTreeFilters provides filter options for the task tree query.
 type TaskTreeFilters struct {
 	ProjectID  string

--- a/apps/backend/internal/task/models/models_test.go
+++ b/apps/backend/internal/task/models/models_test.go
@@ -63,6 +63,29 @@ func TestTaskStateConstants(t *testing.T) {
 	}
 }
 
+func TestIsTerminalTaskState(t *testing.T) {
+	tests := []struct {
+		state v1.TaskState
+		want  bool
+	}{
+		{v1.TaskStateCompleted, true},
+		{v1.TaskStateFailed, true},
+		{v1.TaskStateCancelled, true},
+		{v1.TaskStateTODO, false},
+		{v1.TaskStateCreated, false},
+		{v1.TaskStateScheduling, false},
+		{v1.TaskStateInProgress, false},
+		{v1.TaskStateReview, false},
+		{v1.TaskStateBlocked, false},
+		{v1.TaskStateWaitingForInput, false},
+	}
+	for _, tt := range tests {
+		if got := IsTerminalTaskState(tt.state); got != tt.want {
+			t.Errorf("IsTerminalTaskState(%s) = %v, want %v", tt.state, got, tt.want)
+		}
+	}
+}
+
 func TestTaskStructInitialization(t *testing.T) {
 	now := time.Now().UTC()
 	repos := []*TaskRepository{

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -79,6 +79,12 @@ type TaskRepository interface {
 	GetWorkspaceTaskPrefix(ctx context.Context, workspaceID string) (prefix, officeWorkflowID string, err error)
 }
 
+// IsTerminalTaskState reports whether a task state is terminal for
+// parent-child completion detection.
+func IsTerminalTaskState(state v1.TaskState) bool {
+	return models.IsTerminalTaskState(state)
+}
+
 // TaskRepoRepository handles the task↔repository junction table (models.TaskRepository rows).
 // Named TaskRepoRepository to reduce reader confusion with the TaskRepository sub-interface above.
 type TaskRepoRepository interface {

--- a/apps/backend/internal/task/repository/interface.go
+++ b/apps/backend/internal/task/repository/interface.go
@@ -79,12 +79,6 @@ type TaskRepository interface {
 	GetWorkspaceTaskPrefix(ctx context.Context, workspaceID string) (prefix, officeWorkflowID string, err error)
 }
 
-// IsTerminalTaskState reports whether a task state is terminal for
-// parent-child completion detection.
-func IsTerminalTaskState(state v1.TaskState) bool {
-	return models.IsTerminalTaskState(state)
-}
-
 // TaskRepoRepository handles the task↔repository junction table (models.TaskRepository rows).
 // Named TaskRepoRepository to reduce reader confusion with the TaskRepository sub-interface above.
 type TaskRepoRepository interface {

--- a/apps/backend/internal/task/repository/sqlite/task.go
+++ b/apps/backend/internal/task/repository/sqlite/task.go
@@ -310,6 +310,25 @@ func (r *Repository) ListChildren(ctx context.Context, parentID string) ([]*mode
 	return r.scanTasks(rows)
 }
 
+// ListChildCompletionRows returns active direct children with the compact
+// fields needed for on_children_completed readiness and operation idempotency.
+func (r *Repository) ListChildCompletionRows(ctx context.Context, parentID string) ([]models.ChildCompletionRow, error) {
+	if parentID == "" {
+		return []models.ChildCompletionRow{}, nil
+	}
+	var rows []models.ChildCompletionRow
+	err := r.ro.SelectContext(ctx, &rows, r.ro.Rebind(`
+		SELECT id, state, title, updated_at
+		FROM tasks
+		WHERE parent_id = ? AND archived_at IS NULL AND is_ephemeral = 0
+		ORDER BY created_at ASC, id ASC
+	`), parentID)
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
 // ListChildrenIncludingArchived returns every child task of parentID
 // regardless of archived state. Used by the office task-handoffs
 // unarchive cascade (phase 6) to walk a previously-archived descendant

--- a/apps/backend/internal/task/repository/task_repository_test.go
+++ b/apps/backend/internal/task/repository/task_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/kandev/kandev/internal/db"
@@ -176,6 +177,116 @@ func TestSQLiteRepository_UpdateTaskStateIfCurrentIn(t *testing.T) {
 	}
 	if updated {
 		t.Fatal("expected no update for missing task")
+	}
+}
+
+func TestSQLiteRepository_ListChildCompletionRows_ActiveChildren(t *testing.T) {
+	repo, cleanup := createTestSQLiteRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws-1", Name: "Workspace"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf-1", WorkspaceID: "ws-1", Name: "Workflow"})
+
+	now := time.Now().UTC()
+	parent := &models.Task{
+		ID:             "parent-1",
+		WorkspaceID:    "ws-1",
+		WorkflowID:     "wf-1",
+		WorkflowStepID: "step-1",
+		Title:          "Parent",
+		State:          v1.TaskStateInProgress,
+		Priority:       "medium",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := repo.CreateTask(ctx, parent); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	createChild := func(id string, state v1.TaskState, archived, ephemeral bool) {
+		t.Helper()
+		child := &models.Task{
+			ID:             id,
+			WorkspaceID:    "ws-1",
+			WorkflowID:     "wf-1",
+			WorkflowStepID: "step-1",
+			Title:          id,
+			State:          state,
+			Priority:       "medium",
+			ParentID:       parent.ID,
+			IsEphemeral:    ephemeral,
+			CreatedAt:      now.Add(time.Duration(len(id)) * time.Second),
+			UpdatedAt:      now.Add(time.Duration(len(id)) * time.Minute),
+		}
+		if err := repo.CreateTask(ctx, child); err != nil {
+			t.Fatalf("create child %s: %v", id, err)
+		}
+		if archived {
+			if err := repo.ArchiveTask(ctx, id); err != nil {
+				t.Fatalf("archive child %s: %v", id, err)
+			}
+		}
+	}
+
+	createChild("child-completed", v1.TaskStateCompleted, false, false)
+	createChild("child-failed", v1.TaskStateFailed, false, false)
+	createChild("child-cancelled", v1.TaskStateCancelled, false, false)
+	createChild("child-open", v1.TaskStateInProgress, false, false)
+	createChild("child-archived", v1.TaskStateTODO, true, false)
+	createChild("child-ephemeral", v1.TaskStateTODO, false, true)
+
+	rows, err := repo.ListChildCompletionRows(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("ListChildCompletionRows: %v", err)
+	}
+	gotIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		gotIDs = append(gotIDs, row.ID)
+		if row.Title == "" {
+			t.Errorf("row %s missing title", row.ID)
+		}
+		if row.UpdatedAt.IsZero() {
+			t.Errorf("row %s missing updated_at", row.ID)
+		}
+	}
+	wantIDs := []string{"child-archived", "child-cancelled", "child-completed", "child-ephemeral", "child-failed", "child-open"}
+	if len(gotIDs) != 4 {
+		t.Fatalf("active child rows = %v, want 4 active rows (excluding archived/ephemeral), all created IDs were %v", gotIDs, wantIDs)
+	}
+	for _, want := range []string{"child-cancelled", "child-completed", "child-failed", "child-open"} {
+		found := false
+		for _, got := range gotIDs {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing active child %s in %v", want, gotIDs)
+		}
+	}
+}
+
+func TestIsTerminalTaskState(t *testing.T) {
+	tests := []struct {
+		state v1.TaskState
+		want  bool
+	}{
+		{v1.TaskStateCompleted, true},
+		{v1.TaskStateFailed, true},
+		{v1.TaskStateCancelled, true},
+		{v1.TaskStateTODO, false},
+		{v1.TaskStateCreated, false},
+		{v1.TaskStateScheduling, false},
+		{v1.TaskStateInProgress, false},
+		{v1.TaskStateReview, false},
+		{v1.TaskStateBlocked, false},
+		{v1.TaskStateWaitingForInput, false},
+	}
+	for _, tt := range tests {
+		if got := IsTerminalTaskState(tt.state); got != tt.want {
+			t.Errorf("IsTerminalTaskState(%s) = %v, want %v", tt.state, got, tt.want)
+		}
 	}
 }
 

--- a/apps/backend/internal/task/repository/task_repository_test.go
+++ b/apps/backend/internal/task/repository/task_repository_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -250,43 +251,10 @@ func TestSQLiteRepository_ListChildCompletionRows_ActiveChildren(t *testing.T) {
 			t.Errorf("row %s missing updated_at", row.ID)
 		}
 	}
-	wantIDs := []string{"child-archived", "child-cancelled", "child-completed", "child-ephemeral", "child-failed", "child-open"}
-	if len(gotIDs) != 4 {
-		t.Fatalf("active child rows = %v, want 4 active rows (excluding archived/ephemeral), all created IDs were %v", gotIDs, wantIDs)
-	}
-	for _, want := range []string{"child-cancelled", "child-completed", "child-failed", "child-open"} {
-		found := false
-		for _, got := range gotIDs {
-			if got == want {
-				found = true
-			}
-		}
-		if !found {
-			t.Errorf("missing active child %s in %v", want, gotIDs)
-		}
-	}
-}
-
-func TestIsTerminalTaskState(t *testing.T) {
-	tests := []struct {
-		state v1.TaskState
-		want  bool
-	}{
-		{v1.TaskStateCompleted, true},
-		{v1.TaskStateFailed, true},
-		{v1.TaskStateCancelled, true},
-		{v1.TaskStateTODO, false},
-		{v1.TaskStateCreated, false},
-		{v1.TaskStateScheduling, false},
-		{v1.TaskStateInProgress, false},
-		{v1.TaskStateReview, false},
-		{v1.TaskStateBlocked, false},
-		{v1.TaskStateWaitingForInput, false},
-	}
-	for _, tt := range tests {
-		if got := IsTerminalTaskState(tt.state); got != tt.want {
-			t.Errorf("IsTerminalTaskState(%s) = %v, want %v", tt.state, got, tt.want)
-		}
+	wantIDs := []string{"child-cancelled", "child-completed", "child-failed", "child-open"}
+	slices.Sort(gotIDs)
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Fatalf("active child rows = %v, want %v", gotIDs, wantIDs)
 	}
 }
 

--- a/apps/backend/internal/workflow/engine/quorum_test.go
+++ b/apps/backend/internal/workflow/engine/quorum_test.go
@@ -395,6 +395,24 @@ func TestEngine_RecordParticipantDecision_RequiresIDs(t *testing.T) {
 
 func TestConfigTransitionGuard_ParsesWaitForQuorum(t *testing.T) {
 	cfg := map[string]any{
+		"if": map[string]any{
+			"wait_for_quorum": map[string]any{
+				"role":      "reviewer",
+				"threshold": "all_approve",
+			},
+		},
+	}
+	g := ConfigTransitionGuard(cfg)
+	if g == nil || g.WaitForQuorum == nil {
+		t.Fatalf("expected wait_for_quorum guard")
+	}
+	if g.WaitForQuorum.Role != "reviewer" || g.WaitForQuorum.Threshold != "all_approve" {
+		t.Fatalf("unexpected guard: %+v", g.WaitForQuorum)
+	}
+}
+
+func TestConfigTransitionGuard_ParsesLegacyTopLevelWaitForQuorum(t *testing.T) {
+	cfg := map[string]any{
 		"wait_for_quorum": map[string]any{
 			"role":      "reviewer",
 			"threshold": "all_approve",

--- a/apps/backend/internal/workflow/engine/types.go
+++ b/apps/backend/internal/workflow/engine/types.go
@@ -376,6 +376,18 @@ func compileGenericActions(actions []wfmodels.GenericAction) []Action {
 	out := make([]Action, 0, len(actions))
 	for _, a := range actions {
 		switch a.Type {
+		case wfmodels.GenericActionMoveToNext:
+			out = append(out, Action{Kind: ActionMoveToNext})
+		case wfmodels.GenericActionMoveToPrevious:
+			out = append(out, Action{Kind: ActionMoveToPrevious})
+		case wfmodels.GenericActionMoveToStep:
+			stepID, err := readStepID(a.Config)
+			if err != nil {
+				continue // skip malformed move_to_step actions
+			}
+			out = append(out, Action{Kind: ActionMoveToStep, MoveToStep: &MoveToStepAction{StepID: stepID}})
+		case wfmodels.GenericActionAutoStartAgent:
+			out = append(out, Action{Kind: ActionAutoStartAgent, AutoStartAgent: &AutoStartAgentAction{QueueIfBusy: true}})
 		case wfmodels.GenericActionQueueRun:
 			out = append(out, Action{
 				Kind:     ActionQueueRun,

--- a/apps/backend/internal/workflow/engine/types.go
+++ b/apps/backend/internal/workflow/engine/types.go
@@ -375,17 +375,24 @@ func compileOnExit(step *wfmodels.WorkflowStep) []Action {
 func compileGenericActions(actions []wfmodels.GenericAction) []Action {
 	out := make([]Action, 0, len(actions))
 	for _, a := range actions {
+		ra := ConfigRequiresApproval(a.Config)
+		guard := ConfigTransitionGuard(a.Config)
 		switch a.Type {
 		case wfmodels.GenericActionMoveToNext:
-			out = append(out, Action{Kind: ActionMoveToNext})
+			out = append(out, Action{Kind: ActionMoveToNext, RequiresApproval: ra, Guard: guard})
 		case wfmodels.GenericActionMoveToPrevious:
-			out = append(out, Action{Kind: ActionMoveToPrevious})
+			out = append(out, Action{Kind: ActionMoveToPrevious, RequiresApproval: ra, Guard: guard})
 		case wfmodels.GenericActionMoveToStep:
 			stepID, err := readStepID(a.Config)
 			if err != nil {
 				continue // skip malformed move_to_step actions
 			}
-			out = append(out, Action{Kind: ActionMoveToStep, MoveToStep: &MoveToStepAction{StepID: stepID}})
+			out = append(out, Action{
+				Kind:             ActionMoveToStep,
+				RequiresApproval: ra,
+				Guard:            guard,
+				MoveToStep:       &MoveToStepAction{StepID: stepID},
+			})
 		case wfmodels.GenericActionAutoStartAgent:
 			out = append(out, Action{Kind: ActionAutoStartAgent, AutoStartAgent: &AutoStartAgentAction{QueueIfBusy: true}})
 		case wfmodels.GenericActionQueueRun:
@@ -486,18 +493,29 @@ func ConfigRequiresApproval(config map[string]any) bool {
 // Expected shape:
 //
 //	{
-//	    "wait_for_quorum": {
-//	        "role":      "reviewer",
-//	        "threshold": "all_approve"
+//	    "if": {
+//	        "wait_for_quorum": {
+//	            "role":      "reviewer",
+//	            "threshold": "all_approve"
+//	        }
 //	    }
 //	}
+//
+// Legacy top-level `wait_for_quorum` is also accepted.
 func ConfigTransitionGuard(config map[string]any) *TransitionGuard {
 	if config == nil {
 		return nil
 	}
 	raw, ok := config["wait_for_quorum"].(map[string]any)
 	if !ok {
-		return nil
+		guard, ok := config["if"].(map[string]any)
+		if !ok {
+			return nil
+		}
+		raw, ok = guard["wait_for_quorum"].(map[string]any)
+		if !ok {
+			return nil
+		}
 	}
 	role, _ := raw["role"].(string)
 	threshold, _ := raw["threshold"].(string)

--- a/apps/backend/internal/workflow/engine/types_test.go
+++ b/apps/backend/internal/workflow/engine/types_test.go
@@ -54,7 +54,7 @@ func TestCompileStep_CompilesGenericTransitionActions(t *testing.T) {
 		Position:   0,
 		Events: wfmodels.StepEvents{
 			OnChildrenCompleted: []wfmodels.GenericAction{
-				{Type: wfmodels.GenericActionMoveToNext},
+				{Type: wfmodels.GenericActionMoveToNext, Config: map[string]any{"requires_approval": true}},
 				{Type: wfmodels.GenericActionMoveToStep, Config: map[string]any{"step_id": "s3"}},
 				{Type: wfmodels.GenericActionAutoStartAgent},
 			},
@@ -69,6 +69,9 @@ func TestCompileStep_CompilesGenericTransitionActions(t *testing.T) {
 	if actions[0].Kind != ActionMoveToNext {
 		t.Fatalf("expected first action to move_to_next, got %s", actions[0].Kind)
 	}
+	if !actions[0].RequiresApproval {
+		t.Fatalf("expected generic move_to_next to preserve requires_approval")
+	}
 	if actions[1].Kind != ActionMoveToStep {
 		t.Fatalf("expected second action to move_to_step, got %s", actions[1].Kind)
 	}
@@ -77,6 +80,39 @@ func TestCompileStep_CompilesGenericTransitionActions(t *testing.T) {
 	}
 	if actions[2].Kind != ActionAutoStartAgent {
 		t.Fatalf("expected third action to auto_start_agent, got %s", actions[2].Kind)
+	}
+}
+
+func TestCompileStep_CompilesGenericTransitionGuards(t *testing.T) {
+	step := &wfmodels.WorkflowStep{
+		ID:         "s1",
+		WorkflowID: "wf1",
+		Name:       "Review",
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{
+				{
+					Type: wfmodels.GenericActionMoveToStep,
+					Config: map[string]any{
+						"step_id": "s2",
+						"if": map[string]any{
+							"wait_for_quorum": map[string]any{
+								"role":      "reviewer",
+								"threshold": "all_approve",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	spec := CompileStep(step)
+	action := spec.Events[TriggerOnChildrenCompleted][0]
+	if action.Guard == nil || action.Guard.WaitForQuorum == nil {
+		t.Fatalf("expected generic move_to_step to preserve transition guard")
+	}
+	if action.Guard.WaitForQuorum.Role != "reviewer" {
+		t.Fatalf("guard role = %q, want reviewer", action.Guard.WaitForQuorum.Role)
 	}
 }
 

--- a/apps/backend/internal/workflow/engine/types_test.go
+++ b/apps/backend/internal/workflow/engine/types_test.go
@@ -114,6 +114,9 @@ func TestCompileStep_CompilesGenericTransitionGuards(t *testing.T) {
 	if action.Guard.WaitForQuorum.Role != "reviewer" {
 		t.Fatalf("guard role = %q, want reviewer", action.Guard.WaitForQuorum.Role)
 	}
+	if action.Guard.WaitForQuorum.Threshold != "all_approve" {
+		t.Fatalf("guard threshold = %q, want all_approve", action.Guard.WaitForQuorum.Threshold)
+	}
 }
 
 func TestCompileStep_SetSessionMode(t *testing.T) {

--- a/apps/backend/internal/workflow/engine/types_test.go
+++ b/apps/backend/internal/workflow/engine/types_test.go
@@ -46,6 +46,40 @@ func TestCompileStep_CompilesLegacyActionsToTypedActions(t *testing.T) {
 	}
 }
 
+func TestCompileStep_CompilesGenericTransitionActions(t *testing.T) {
+	step := &wfmodels.WorkflowStep{
+		ID:         "s1",
+		WorkflowID: "wf1",
+		Name:       "Parent Wait",
+		Position:   0,
+		Events: wfmodels.StepEvents{
+			OnChildrenCompleted: []wfmodels.GenericAction{
+				{Type: wfmodels.GenericActionMoveToNext},
+				{Type: wfmodels.GenericActionMoveToStep, Config: map[string]any{"step_id": "s3"}},
+				{Type: wfmodels.GenericActionAutoStartAgent},
+			},
+		},
+	}
+
+	spec := CompileStep(step)
+	actions := spec.Events[TriggerOnChildrenCompleted]
+	if len(actions) != 3 {
+		t.Fatalf("expected 3 on_children_completed actions, got %d", len(actions))
+	}
+	if actions[0].Kind != ActionMoveToNext {
+		t.Fatalf("expected first action to move_to_next, got %s", actions[0].Kind)
+	}
+	if actions[1].Kind != ActionMoveToStep {
+		t.Fatalf("expected second action to move_to_step, got %s", actions[1].Kind)
+	}
+	if actions[1].MoveToStep == nil || actions[1].MoveToStep.StepID != "s3" {
+		t.Fatalf("expected move_to_step target s3, got %+v", actions[1].MoveToStep)
+	}
+	if actions[2].Kind != ActionAutoStartAgent {
+		t.Fatalf("expected third action to auto_start_agent, got %s", actions[2].Kind)
+	}
+}
+
 func TestCompileStep_SetSessionMode(t *testing.T) {
 	t.Run("compiles set_session_mode with mode config", func(t *testing.T) {
 		step := &wfmodels.WorkflowStep{

--- a/apps/backend/internal/workflow/models/models.go
+++ b/apps/backend/internal/workflow/models/models.go
@@ -263,40 +263,53 @@ func RemapStepEvents(events StepEvents, idMap map[string]string) StepEvents {
 	result := StepEvents{}
 	result.OnEnter = append(result.OnEnter, events.OnEnter...)
 	for _, a := range events.OnTurnStart {
-		if a.Type == OnTurnStartMoveToStep && a.Config != nil {
-			if stepID, ok := a.Config["step_id"].(string); ok {
-				if newID, found := idMap[stepID]; found {
-					cfg := make(map[string]any, len(a.Config))
-					maps.Copy(cfg, a.Config)
-					cfg["step_id"] = newID
-					a.Config = cfg
-				}
-			}
+		if a.Type == OnTurnStartMoveToStep {
+			a.Config = remapActionStepID(a.Config, idMap)
 		}
 		result.OnTurnStart = append(result.OnTurnStart, a)
 	}
 	for _, a := range events.OnTurnComplete {
-		if a.Type == OnTurnCompleteMoveToStep && a.Config != nil {
-			if stepID, ok := a.Config["step_id"].(string); ok {
-				if newID, found := idMap[stepID]; found {
-					cfg := make(map[string]any, len(a.Config))
-					maps.Copy(cfg, a.Config)
-					cfg["step_id"] = newID
-					a.Config = cfg
-				}
-			}
+		if a.Type == OnTurnCompleteMoveToStep {
+			a.Config = remapActionStepID(a.Config, idMap)
 		}
 		result.OnTurnComplete = append(result.OnTurnComplete, a)
 	}
 	result.OnExit = append(result.OnExit, events.OnExit...)
-	// Phase 2 (ADR-0004) — copy generic-action lists through. None of these
-	// actions carry step_id references today, so a shallow copy suffices.
-	result.OnComment = append(result.OnComment, events.OnComment...)
-	result.OnBlockerResolved = append(result.OnBlockerResolved, events.OnBlockerResolved...)
-	result.OnChildrenCompleted = append(result.OnChildrenCompleted, events.OnChildrenCompleted...)
-	result.OnApprovalResolved = append(result.OnApprovalResolved, events.OnApprovalResolved...)
-	result.OnHeartbeat = append(result.OnHeartbeat, events.OnHeartbeat...)
-	result.OnBudgetAlert = append(result.OnBudgetAlert, events.OnBudgetAlert...)
-	result.OnAgentError = append(result.OnAgentError, events.OnAgentError...)
+	result.OnComment = remapGenericStepEvents(events.OnComment, idMap)
+	result.OnBlockerResolved = remapGenericStepEvents(events.OnBlockerResolved, idMap)
+	result.OnChildrenCompleted = remapGenericStepEvents(events.OnChildrenCompleted, idMap)
+	result.OnApprovalResolved = remapGenericStepEvents(events.OnApprovalResolved, idMap)
+	result.OnHeartbeat = remapGenericStepEvents(events.OnHeartbeat, idMap)
+	result.OnBudgetAlert = remapGenericStepEvents(events.OnBudgetAlert, idMap)
+	result.OnAgentError = remapGenericStepEvents(events.OnAgentError, idMap)
 	return result
+}
+
+func remapGenericStepEvents(actions []GenericAction, idMap map[string]string) []GenericAction {
+	result := make([]GenericAction, 0, len(actions))
+	for _, action := range actions {
+		if action.Type == GenericActionMoveToStep {
+			action.Config = remapActionStepID(action.Config, idMap)
+		}
+		result = append(result, action)
+	}
+	return result
+}
+
+func remapActionStepID(config map[string]any, idMap map[string]string) map[string]any {
+	if config == nil {
+		return nil
+	}
+	stepID, ok := config["step_id"].(string)
+	if !ok {
+		return config
+	}
+	newID, found := idMap[stepID]
+	if !found {
+		return config
+	}
+	cfg := make(map[string]any, len(config))
+	maps.Copy(cfg, config)
+	cfg["step_id"] = newID
+	return cfg
 }

--- a/apps/backend/internal/workflow/models/models.go
+++ b/apps/backend/internal/workflow/models/models.go
@@ -83,6 +83,14 @@ type OnExitAction struct {
 type GenericActionType string
 
 const (
+	// GenericActionMoveToNext transitions to the next workflow step.
+	GenericActionMoveToNext GenericActionType = "move_to_next"
+	// GenericActionMoveToPrevious transitions to the previous workflow step.
+	GenericActionMoveToPrevious GenericActionType = "move_to_previous"
+	// GenericActionMoveToStep transitions to a configured workflow step.
+	GenericActionMoveToStep GenericActionType = "move_to_step"
+	// GenericActionAutoStartAgent starts the step's agent.
+	GenericActionAutoStartAgent GenericActionType = "auto_start_agent"
 	// GenericActionQueueRun queues a run on a target task/agent.
 	GenericActionQueueRun GenericActionType = "queue_run"
 	// GenericActionClearDecisions clears recorded decisions for the

--- a/apps/backend/internal/workflow/models/models_test.go
+++ b/apps/backend/internal/workflow/models/models_test.go
@@ -1,0 +1,21 @@
+package models
+
+import "testing"
+
+func TestRemapStepEvents_RemapGenericMoveToStep(t *testing.T) {
+	events := StepEvents{
+		OnChildrenCompleted: []GenericAction{
+			{Type: GenericActionMoveToStep, Config: map[string]any{"step_id": "old-step"}},
+			{Type: GenericActionMoveToNext},
+		},
+	}
+
+	remapped := RemapStepEvents(events, map[string]string{"old-step": "new-step"})
+
+	if got := remapped.OnChildrenCompleted[0].Config["step_id"]; got != "new-step" {
+		t.Fatalf("generic move_to_step step_id = %v, want new-step", got)
+	}
+	if got := events.OnChildrenCompleted[0].Config["step_id"]; got != "old-step" {
+		t.Fatalf("source events mutated, step_id = %v", got)
+	}
+}

--- a/apps/web/components/settings/workflow-pipeline-editor-helpers.test.ts
+++ b/apps/web/components/settings/workflow-pipeline-editor-helpers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import type { WorkflowStep } from "@/lib/types/http";
+import { getChildrenCompletedTransitionType } from "./workflow-pipeline-editor-helpers";
+
+describe("workflow pipeline editor helpers", () => {
+  it("reads the all child tasks complete transition from workflow step events", () => {
+    const step = {
+      events: {
+        on_children_completed: [{ type: "move_to_step", config: { step_id: "done-step" } }],
+      },
+    } as WorkflowStep;
+
+    expect(getChildrenCompletedTransitionType(step)).toBe("move_to_step");
+  });
+
+  it("defaults all child tasks complete to none when no transition is configured", () => {
+    expect(getChildrenCompletedTransitionType({ events: {} } as WorkflowStep)).toBe("none");
+  });
+});

--- a/apps/web/components/settings/workflow-pipeline-editor-helpers.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-helpers.tsx
@@ -19,7 +19,7 @@ export function HelpTip({
         <TooltipTrigger asChild>
           <button
             type="button"
-            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground/50 hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground/50 hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={ariaLabel}
             data-testid={testId}
           >

--- a/apps/web/components/settings/workflow-pipeline-editor-helpers.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-helpers.tsx
@@ -4,12 +4,27 @@ import { IconInfoCircle } from "@tabler/icons-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@kandev/ui/tooltip";
 import type { WorkflowStep } from "@/lib/types/http";
 
-export function HelpTip({ text }: { text: string }) {
+export function HelpTip({
+  text,
+  testId,
+  ariaLabel = "More information",
+}: {
+  text: string;
+  testId?: string;
+  ariaLabel?: string;
+}) {
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <IconInfoCircle className="h-3.5 w-3.5 text-muted-foreground/50 hover:text-muted-foreground cursor-help shrink-0" />
+          <button
+            type="button"
+            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground/50 hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={ariaLabel}
+            data-testid={testId}
+          >
+            <IconInfoCircle className="h-3.5 w-3.5" />
+          </button>
         </TooltipTrigger>
         <TooltipContent className="max-w-xs">{text}</TooltipContent>
       </Tooltip>
@@ -121,6 +136,13 @@ export function getTransitionType(step: WorkflowStep): string {
 
 export function getOnTurnStartTransitionType(step: WorkflowStep): string {
   const action = step.events?.on_turn_start?.find((a) =>
+    ["move_to_next", "move_to_previous", "move_to_step"].includes(a.type),
+  );
+  return action?.type ?? "none";
+}
+
+export function getChildrenCompletedTransitionType(step: WorkflowStep): string {
+  const action = step.events?.on_children_completed?.find((a) =>
     ["move_to_next", "move_to_previous", "move_to_step"].includes(a.type),
   );
   return action?.type ?? "none";

--- a/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-panels.tsx
@@ -28,6 +28,7 @@ import {
   useStepActions,
   TurnStartSelect,
   TurnCompleteSelect,
+  ChildrenCompletedSelect,
 } from "./workflow-pipeline-editor-step-actions";
 
 const STEP_PROMPT_PLACEHOLDERS: ScriptPlaceholder[] = [
@@ -335,6 +336,7 @@ type StepTransitionsSectionProps = {
   onUpdate: (updates: Partial<WorkflowStep>) => void;
   setTransition: (type: string) => void;
   setOnTurnStartTransition: (type: string) => void;
+  setChildrenCompletedTransition: (type: string) => void;
   toggleDisablePlanMode: () => void;
   toggleOnExitAction: (type: string) => void;
   readOnly: boolean;
@@ -346,6 +348,7 @@ function StepTransitionsSection({
   onUpdate,
   setTransition,
   setOnTurnStartTransition,
+  setChildrenCompletedTransition,
   toggleDisablePlanMode,
   toggleOnExitAction,
   readOnly,
@@ -360,7 +363,7 @@ function StepTransitionsSection({
           Transitions
         </Label>
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
         <TurnStartSelect
           step={step}
           otherSteps={otherSteps}
@@ -375,6 +378,13 @@ function StepTransitionsSection({
           setTransition={setTransition}
           toggleDisablePlanMode={toggleDisablePlanMode}
           planModeEnabled={planModeEnabled}
+          readOnly={readOnly}
+        />
+        <ChildrenCompletedSelect
+          step={step}
+          otherSteps={otherSteps}
+          onUpdate={onUpdate}
+          setChildrenCompletedTransition={setChildrenCompletedTransition}
           readOnly={readOnly}
         />
       </div>
@@ -531,6 +541,7 @@ export function StepConfigPanel({
           onUpdate={onUpdate}
           setTransition={actions.setTransition}
           setOnTurnStartTransition={actions.setOnTurnStartTransition}
+          setChildrenCompletedTransition={actions.setChildrenCompletedTransition}
           toggleDisablePlanMode={actions.toggleDisablePlanMode}
           toggleOnExitAction={actions.toggleOnExitAction}
           readOnly={readOnly}

--- a/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
@@ -10,11 +10,13 @@ import type {
   OnTurnCompleteAction,
   OnExitAction,
 } from "@/lib/types/http";
+import type { GenericAction } from "@/lib/types/workflow-actions";
 import { cn } from "@/lib/utils";
 import {
   HelpTip,
   getTransitionType,
   getOnTurnStartTransitionType,
+  getChildrenCompletedTransitionType,
   hasDisablePlanMode,
 } from "./workflow-pipeline-editor-helpers";
 
@@ -54,6 +56,15 @@ export function useStepActions({ step, onUpdate }: UseStepActionsArgs) {
     onUpdate({ events: { ...currentEvents, on_turn_start: onTurnStart } });
   };
 
+  const setChildrenCompletedTransition = (type: string) => {
+    const currentEvents = step.events ?? {};
+    const onChildrenCompleted = (currentEvents.on_children_completed ?? []).filter(
+      (a) => !["move_to_next", "move_to_previous", "move_to_step"].includes(a.type),
+    );
+    if (type !== "none") onChildrenCompleted.push({ type } as GenericAction);
+    onUpdate({ events: { ...currentEvents, on_children_completed: onChildrenCompleted } });
+  };
+
   const toggleDisablePlanMode = () => {
     const currentEvents = step.events ?? {};
     const onTurnComplete = currentEvents.on_turn_complete ?? [];
@@ -78,6 +89,7 @@ export function useStepActions({ step, onUpdate }: UseStepActionsArgs) {
     toggleOnEnterAction,
     setTransition,
     setOnTurnStartTransition,
+    setChildrenCompletedTransition,
     toggleDisablePlanMode,
     toggleOnExitAction,
   };
@@ -251,6 +263,91 @@ export function TurnCompleteSelect({
       )}
       {transitionType !== "none" && (
         <ExplicitCompletionToggle step={step} onUpdate={onUpdate} readOnly={readOnly} />
+      )}
+    </div>
+  );
+}
+
+// --- ChildrenCompletedSelect ---
+
+type ChildrenCompletedSelectProps = StepSelectProps & {
+  setChildrenCompletedTransition: (t: string) => void;
+};
+
+export function ChildrenCompletedSelect({
+  step,
+  otherSteps,
+  onUpdate,
+  setChildrenCompletedTransition,
+  readOnly,
+}: ChildrenCompletedSelectProps) {
+  const transitionType = getChildrenCompletedTransitionType(step);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Label className="text-xs font-medium">When Child Tasks Complete</Label>
+        <HelpTip
+          testId={`${step.id}-children-completed-help`}
+          ariaLabel="How child task completion transitions work"
+          text="Use this on a parent task step. When every active direct child task is COMPLETED, FAILED, or CANCELLED, Kandev runs this transition once. Archived and ephemeral child tasks are ignored. Grandchildren do not count here, and nothing runs if the parent has no child tasks."
+        />
+      </div>
+      <Select
+        value={transitionType}
+        onValueChange={(value) => {
+          if (readOnly) return;
+          setChildrenCompletedTransition(value);
+        }}
+        disabled={readOnly}
+      >
+        <SelectTrigger
+          className="w-full h-8"
+          data-testid={`${step.id}-children-completed-transition-select`}
+        >
+          <SelectValue placeholder="Select action" />
+        </SelectTrigger>
+        <SelectContent position="popper" side="bottom" align="start">
+          <SelectItem value="none">Do nothing</SelectItem>
+          <SelectItem value="move_to_next">Move to next step</SelectItem>
+          <SelectItem value="move_to_previous">Move to previous step</SelectItem>
+          <SelectItem value="move_to_step">Move to specific step</SelectItem>
+        </SelectContent>
+      </Select>
+      {transitionType === "move_to_step" && (
+        <Select
+          value={
+            (step.events?.on_children_completed?.find((a) => a.type === "move_to_step")?.config
+              ?.step_id as string) ?? ""
+          }
+          onValueChange={(value) => {
+            if (readOnly) return;
+            const currentEvents = step.events ?? {};
+            const onChildrenCompleted = (currentEvents.on_children_completed ?? []).map((a) =>
+              a.type === "move_to_step" ? { ...a, config: { step_id: value } } : a,
+            );
+            onUpdate({
+              events: { ...currentEvents, on_children_completed: onChildrenCompleted },
+            });
+          }}
+          disabled={readOnly}
+        >
+          <SelectTrigger
+            className="w-full h-8"
+            data-testid={`${step.id}-children-completed-step-select`}
+          >
+            <SelectValue placeholder="Select step" />
+          </SelectTrigger>
+          <SelectContent position="popper" side="bottom" align="start">
+            {otherSteps.map((s) => (
+              <SelectItem key={s.id} value={s.id}>
+                <div className="flex items-center gap-2">
+                  <div className={cn("w-2 h-2 rounded-full", s.color)} />
+                  {s.name}
+                </div>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       )}
     </div>
   );

--- a/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
@@ -56,12 +56,17 @@ export function useStepActions({ step, onUpdate }: UseStepActionsArgs) {
     onUpdate({ events: { ...currentEvents, on_turn_start: onTurnStart } });
   };
 
-  const setChildrenCompletedTransition = (type: string) => {
+  const setChildrenCompletedTransition = (type: string, targetStepId?: string) => {
     const currentEvents = step.events ?? {};
     const onChildrenCompleted = (currentEvents.on_children_completed ?? []).filter(
       (a) => !["move_to_next", "move_to_previous", "move_to_step"].includes(a.type),
     );
-    if (type !== "none") onChildrenCompleted.push({ type } as GenericAction);
+    if (type === "move_to_step") {
+      if (!targetStepId) return;
+      onChildrenCompleted.push({ type, config: { step_id: targetStepId } } as GenericAction);
+    } else if (type !== "none") {
+      onChildrenCompleted.push({ type } as GenericAction);
+    }
     onUpdate({ events: { ...currentEvents, on_children_completed: onChildrenCompleted } });
   };
 
@@ -271,7 +276,7 @@ export function TurnCompleteSelect({
 // --- ChildrenCompletedSelect ---
 
 type ChildrenCompletedSelectProps = StepSelectProps & {
-  setChildrenCompletedTransition: (t: string) => void;
+  setChildrenCompletedTransition: (t: string, targetStepId?: string) => void;
 };
 
 export function ChildrenCompletedSelect({
@@ -282,6 +287,10 @@ export function ChildrenCompletedSelect({
   readOnly,
 }: ChildrenCompletedSelectProps) {
   const transitionType = getChildrenCompletedTransitionType(step);
+  const configuredTargetStepId =
+    (step.events?.on_children_completed?.find((a) => a.type === "move_to_step")?.config
+      ?.step_id as string) ?? "";
+  const defaultTargetStepId = configuredTargetStepId || otherSteps[0]?.id || "";
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-1.5">
@@ -296,7 +305,10 @@ export function ChildrenCompletedSelect({
         value={transitionType}
         onValueChange={(value) => {
           if (readOnly) return;
-          setChildrenCompletedTransition(value);
+          setChildrenCompletedTransition(
+            value,
+            value === "move_to_step" ? defaultTargetStepId : undefined,
+          );
         }}
         disabled={readOnly}
       >
@@ -310,15 +322,14 @@ export function ChildrenCompletedSelect({
           <SelectItem value="none">Do nothing</SelectItem>
           <SelectItem value="move_to_next">Move to next step</SelectItem>
           <SelectItem value="move_to_previous">Move to previous step</SelectItem>
-          <SelectItem value="move_to_step">Move to specific step</SelectItem>
+          <SelectItem value="move_to_step" disabled={!defaultTargetStepId}>
+            Move to specific step
+          </SelectItem>
         </SelectContent>
       </Select>
       {transitionType === "move_to_step" && (
         <Select
-          value={
-            (step.events?.on_children_completed?.find((a) => a.type === "move_to_step")?.config
-              ?.step_id as string) ?? ""
-          }
+          value={configuredTargetStepId}
           onValueChange={(value) => {
             if (readOnly) return;
             const currentEvents = step.events ?? {};

--- a/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
+++ b/apps/web/components/settings/workflow-pipeline-editor-step-actions.tsx
@@ -290,7 +290,8 @@ export function ChildrenCompletedSelect({
   const configuredTargetStepId =
     (step.events?.on_children_completed?.find((a) => a.type === "move_to_step")?.config
       ?.step_id as string) ?? "";
-  const defaultTargetStepId = configuredTargetStepId || otherSteps[0]?.id || "";
+  const validConfiguredTargetStepId = otherSteps.find((s) => s.id === configuredTargetStepId)?.id;
+  const defaultTargetStepId = validConfiguredTargetStepId || otherSteps[0]?.id || "";
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-1.5">
@@ -329,7 +330,7 @@ export function ChildrenCompletedSelect({
       </Select>
       {transitionType === "move_to_step" && (
         <Select
-          value={configuredTargetStepId}
+          value={defaultTargetStepId}
           onValueChange={(value) => {
             if (readOnly) return;
             const currentEvents = step.events ?? {};

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -313,7 +313,7 @@ export class ApiClient {
 
   async updateTaskState(
     taskId: string,
-    state: "BACKLOG" | "IN_PROGRESS" | "REVIEW" | "COMPLETED",
+    state: "BACKLOG" | "IN_PROGRESS" | "REVIEW" | "COMPLETED" | "FAILED" | "CANCELLED",
   ): Promise<void> {
     await this.request("PATCH", `/api/v1/tasks/${taskId}`, { state });
   }
@@ -675,6 +675,13 @@ export class ApiClient {
         on_turn_start?: Array<{ type: string; config?: Record<string, unknown> }>;
         on_turn_complete?: Array<{ type: string; config?: Record<string, unknown> }>;
         on_exit?: Array<{ type: string; config?: Record<string, unknown> }>;
+        on_comment?: Array<{ type: string; config?: Record<string, unknown> }>;
+        on_blocker_resolved?: Array<{ type: string; config?: Record<string, unknown> }>;
+        on_children_completed?: Array<{ type: string; config?: Record<string, unknown> }>;
+        on_approval_resolved?: Array<{ type: string; config?: Record<string, unknown> }>;
+        on_heartbeat?: Array<{ type: string; config?: Record<string, unknown> }>;
+        on_budget_alert?: Array<{ type: string; config?: Record<string, unknown> }>;
+        on_agent_error?: Array<{ type: string; config?: Record<string, unknown> }>;
       };
     },
   ): Promise<void> {

--- a/apps/web/e2e/tests/workflow/mobile-workflow-settings.spec.ts
+++ b/apps/web/e2e/tests/workflow/mobile-workflow-settings.spec.ts
@@ -29,10 +29,11 @@ test.describe("Workflow settings on mobile", () => {
     await testPage.getByRole("option", { name: "Move to next step" }).click();
 
     await page.saveButton(card).click();
-    await testPage.waitForTimeout(1000);
-
-    const { steps } = await apiClient.listWorkflowSteps(workflow.id);
-    const savedWaitStep = steps.find((step) => step.id === waitStep.id);
-    expect(savedWaitStep?.events?.on_children_completed).toEqual([{ type: "move_to_next" }]);
+    await expect
+      .poll(async () => {
+        const { steps } = await apiClient.listWorkflowSteps(workflow.id);
+        return steps.find((step) => step.id === waitStep.id)?.events?.on_children_completed;
+      })
+      .toEqual([{ type: "move_to_next" }]);
   });
 });

--- a/apps/web/e2e/tests/workflow/mobile-workflow-settings.spec.ts
+++ b/apps/web/e2e/tests/workflow/mobile-workflow-settings.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "../../fixtures/test-base";
+import { WorkflowSettingsPage } from "../../pages/workflow-settings-page";
+
+test.describe("Workflow settings on mobile", () => {
+  test("configures an all child tasks complete transition", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const workflow = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Mobile Child Completion Settings",
+    );
+    const waitStep = await apiClient.createWorkflowStep(workflow.id, "Waiting", 0);
+    await apiClient.createWorkflowStep(workflow.id, "Done", 1);
+
+    const page = new WorkflowSettingsPage(testPage);
+    await page.goto(seedData.workspaceId);
+
+    const card = await page.findWorkflowCard("Mobile Child Completion Settings");
+    await expect(card).toBeVisible();
+    await page.stepNodeByName(card, "Waiting").click();
+
+    const childCompletionSelect = card.getByTestId(
+      `${waitStep.id}-children-completed-transition-select`,
+    );
+    await expect(childCompletionSelect).toBeVisible();
+    await childCompletionSelect.click();
+    await testPage.getByRole("option", { name: "Move to next step" }).click();
+
+    await page.saveButton(card).click();
+    await testPage.waitForTimeout(1000);
+
+    const { steps } = await apiClient.listWorkflowSteps(workflow.id);
+    const savedWaitStep = steps.find((step) => step.id === waitStep.id);
+    expect(savedWaitStep?.events?.on_children_completed).toEqual([{ type: "move_to_next" }]);
+  });
+});

--- a/apps/web/e2e/tests/workflow/workflow-children-completed.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-children-completed.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+
+test.describe("Workflow children completed trigger", () => {
+  test("moves parent only after every active child reaches a terminal state", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const workflow = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Children Completed Workflow",
+    );
+
+    const waitStep = await apiClient.createWorkflowStep(workflow.id, "Waiting on Children", 0);
+    const doneStep = await apiClient.createWorkflowStep(workflow.id, "Parent Done", 1);
+
+    await apiClient.updateWorkflowStep(waitStep.id, {
+      events: {
+        on_children_completed: [{ type: "move_to_step", config: { step_id: doneStep.id } }],
+      },
+    });
+
+    await apiClient.saveUserSettings({
+      workspace_id: seedData.workspaceId,
+      workflow_filter_id: workflow.id,
+      enable_preview_on_click: false,
+    });
+
+    const parent = await apiClient.createTask(seedData.workspaceId, "Parent waits for children", {
+      workflow_id: workflow.id,
+      workflow_step_id: waitStep.id,
+      agent_profile_id: seedData.agentProfileId,
+      repository_ids: [seedData.repositoryId],
+    });
+    await apiClient.seedTaskSession(parent.id, {
+      state: "WAITING_FOR_INPUT",
+      agentProfileId: seedData.agentProfileId,
+    });
+
+    const firstChild = await apiClient.createTask(seedData.workspaceId, "First child task", {
+      workflow_id: workflow.id,
+      workflow_step_id: waitStep.id,
+      parent_id: parent.id,
+      repository_ids: [seedData.repositoryId],
+    });
+    const secondChild = await apiClient.createTask(seedData.workspaceId, "Second child task", {
+      workflow_id: workflow.id,
+      workflow_step_id: waitStep.id,
+      parent_id: parent.id,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+    await expect(kanban.taskCardInColumn("Parent waits for children", waitStep.id)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await apiClient.updateTaskState(firstChild.id, "COMPLETED");
+    await expect(kanban.taskCardInColumn("Parent waits for children", waitStep.id)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(kanban.taskCardInColumn("Parent waits for children", doneStep.id)).toHaveCount(0);
+
+    await apiClient.updateTaskState(secondChild.id, "COMPLETED");
+    await expect(kanban.taskCardInColumn("Parent waits for children", doneStep.id)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/web/e2e/tests/workflow/workflow-children-completed.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-children-completed.spec.ts
@@ -33,10 +33,15 @@ test.describe("Workflow children completed trigger", () => {
       agent_profile_id: seedData.agentProfileId,
       repository_ids: [seedData.repositoryId],
     });
-    await apiClient.seedTaskSession(parent.id, {
+    const { session_id: parentSessionId } = await apiClient.seedTaskSession(parent.id, {
       state: "WAITING_FOR_INPUT",
+      sessionId: `children-completed-parent-${parent.id}`,
       agentProfileId: seedData.agentProfileId,
     });
+    const parentSessions = await apiClient.listTaskSessions(parent.id);
+    expect(parentSessions.sessions).toContainEqual(
+      expect.objectContaining({ id: parentSessionId, task_id: parent.id }),
+    );
 
     const firstChild = await apiClient.createTask(seedData.workspaceId, "First child task", {
       workflow_id: workflow.id,

--- a/apps/web/e2e/tests/workflow/workflow-settings.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-settings.spec.ts
@@ -123,17 +123,17 @@ test.describe("Workflow settings", () => {
 
     await card.getByTestId(`${waitStep.id}-children-completed-transition-select`).click();
     await testPage.getByRole("option", { name: "Move to specific step" }).click();
-    await card.getByTestId(`${waitStep.id}-children-completed-step-select`).click();
-    await testPage.getByRole("option", { name: "All Children Done" }).click();
+    await expect(card.getByTestId(`${waitStep.id}-children-completed-step-select`)).toContainText(
+      "All Children Done",
+    );
 
     await page.saveButton(card).click();
-    await testPage.waitForTimeout(1000);
-
-    const { steps } = await apiClient.listWorkflowSteps(workflow.id);
-    const savedWaitStep = steps.find((step) => step.id === waitStep.id);
-    expect(savedWaitStep?.events?.on_children_completed).toEqual([
-      { type: "move_to_step", config: { step_id: doneStep.id } },
-    ]);
+    await expect
+      .poll(async () => {
+        const { steps } = await apiClient.listWorkflowSteps(workflow.id);
+        return steps.find((step) => step.id === waitStep.id)?.events?.on_children_completed;
+      })
+      .toEqual([{ type: "move_to_step", config: { step_id: doneStep.id } }]);
   });
 
   test("modifies a template step name and persists after save", async ({ testPage, seedData }) => {

--- a/apps/web/e2e/tests/workflow/workflow-settings.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-settings.spec.ts
@@ -97,6 +97,45 @@ test.describe("Workflow settings", () => {
     await expect(reloadedCard.getByText("New Step")).toBeVisible();
   });
 
+  test("configures an all child tasks complete transition", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const workflow = await apiClient.createWorkflow(
+      seedData.workspaceId,
+      "Child Completion Settings",
+    );
+    const waitStep = await apiClient.createWorkflowStep(workflow.id, "Waiting for Children", 0);
+    const doneStep = await apiClient.createWorkflowStep(workflow.id, "All Children Done", 1);
+
+    const page = new WorkflowSettingsPage(testPage);
+    await page.goto(seedData.workspaceId);
+
+    const card = await page.findWorkflowCard("Child Completion Settings");
+    await expect(card).toBeVisible();
+    await page.stepNodeByName(card, "Waiting for Children").click();
+
+    await card.getByTestId(`${waitStep.id}-children-completed-help`).hover();
+    await expect(
+      testPage.getByText("When every active direct child task is COMPLETED, FAILED, or CANCELLED"),
+    ).toBeVisible();
+
+    await card.getByTestId(`${waitStep.id}-children-completed-transition-select`).click();
+    await testPage.getByRole("option", { name: "Move to specific step" }).click();
+    await card.getByTestId(`${waitStep.id}-children-completed-step-select`).click();
+    await testPage.getByRole("option", { name: "All Children Done" }).click();
+
+    await page.saveButton(card).click();
+    await testPage.waitForTimeout(1000);
+
+    const { steps } = await apiClient.listWorkflowSteps(workflow.id);
+    const savedWaitStep = steps.find((step) => step.id === waitStep.id);
+    expect(savedWaitStep?.events?.on_children_completed).toEqual([
+      { type: "move_to_step", config: { step_id: doneStep.id } },
+    ]);
+  });
+
   test("modifies a template step name and persists after save", async ({ testPage, seedData }) => {
     const page = new WorkflowSettingsPage(testPage);
     await page.goto(seedData.workspaceId);

--- a/apps/web/lib/state/slices/kanban/types.ts
+++ b/apps/web/lib/state/slices/kanban/types.ts
@@ -5,6 +5,13 @@ export type KanbanStepEvents = {
   on_turn_start?: Array<{ type: string; config?: Record<string, unknown> }>;
   on_turn_complete?: Array<{ type: string; config?: Record<string, unknown> }>;
   on_exit?: Array<{ type: string; config?: Record<string, unknown> }>;
+  on_comment?: Array<{ type: string; config?: Record<string, unknown> }>;
+  on_blocker_resolved?: Array<{ type: string; config?: Record<string, unknown> }>;
+  on_children_completed?: Array<{ type: string; config?: Record<string, unknown> }>;
+  on_approval_resolved?: Array<{ type: string; config?: Record<string, unknown> }>;
+  on_heartbeat?: Array<{ type: string; config?: Record<string, unknown> }>;
+  on_budget_alert?: Array<{ type: string; config?: Record<string, unknown> }>;
+  on_agent_error?: Array<{ type: string; config?: Record<string, unknown> }>;
 };
 
 export type KanbanState = {

--- a/apps/web/lib/types/workflow-actions.ts
+++ b/apps/web/lib/types/workflow-actions.ts
@@ -87,9 +87,51 @@ export type OnTurnCompleteAction =
 
 export type OnExitAction = { type: "disable_plan_mode" };
 
+export type GenericActionType =
+  | "move_to_next"
+  | "move_to_previous"
+  | "move_to_step"
+  | "auto_start_agent"
+  | "queue_run"
+  | "clear_decisions"
+  | "queue_run_for_each_participant";
+
+export type QueueRunConfig = {
+  target?:
+    | "primary"
+    | `participant_role:${string}`
+    | `agent_profile_id:${string}`
+    | "workspace.ceo_agent";
+  task_id?: "this" | string;
+  reason?: string;
+  payload?: Record<string, unknown>;
+};
+
+export type QueueRunForEachParticipantConfig = {
+  role: string;
+  reason?: string;
+  payload?: Record<string, unknown>;
+};
+
+export type GenericAction =
+  | { type: "move_to_next"; config?: TransitionConfig }
+  | { type: "move_to_previous"; config?: TransitionConfig }
+  | { type: "move_to_step"; config: MoveToStepConfig }
+  | { type: "auto_start_agent"; config?: { prompt_override?: string; queue_if_busy?: boolean } }
+  | { type: "queue_run"; config?: QueueRunConfig }
+  | { type: "clear_decisions"; config?: Record<string, never> }
+  | { type: "queue_run_for_each_participant"; config: QueueRunForEachParticipantConfig };
+
 export type StepEvents = {
   on_enter?: OnEnterAction[];
   on_turn_start?: OnTurnStartAction[];
   on_turn_complete?: OnTurnCompleteAction[];
   on_exit?: OnExitAction[];
+  on_comment?: GenericAction[];
+  on_blocker_resolved?: GenericAction[];
+  on_children_completed?: GenericAction[];
+  on_approval_resolved?: GenericAction[];
+  on_heartbeat?: GenericAction[];
+  on_budget_alert?: GenericAction[];
+  on_agent_error?: GenericAction[];
 };

--- a/docs/plans/subtask-completion-trigger/plan.md
+++ b/docs/plans/subtask-completion-trigger/plan.md
@@ -190,7 +190,7 @@ make fmt
 Targeted backend tests:
 
 ```bash
-go test ./internal/task/repository ./internal/task/dto ./internal/orchestrator ./internal/workflow/engine
+cd apps/backend && go test ./internal/task/repository/... ./internal/task/dto/... ./internal/orchestrator/... ./internal/workflow/engine/...
 ```
 
 Frontend typecheck:

--- a/docs/plans/subtask-completion-trigger/plan.md
+++ b/docs/plans/subtask-completion-trigger/plan.md
@@ -190,7 +190,7 @@ make fmt
 Targeted backend tests:
 
 ```bash
-make -C apps/backend test ARGS="./internal/task/repository/... ./internal/task/dto/... ./internal/orchestrator/... ./internal/workflow/engine/..."
+go test ./internal/task/repository ./internal/task/dto ./internal/orchestrator ./internal/workflow/engine
 ```
 
 Frontend typecheck:

--- a/docs/plans/subtask-completion-trigger/plan.md
+++ b/docs/plans/subtask-completion-trigger/plan.md
@@ -1,0 +1,220 @@
+---
+spec: docs/specs/tasks/subtask-completion-trigger.md
+created: 2026-06-23
+status: implemented
+---
+
+# Implementation Plan: Subtask Completion Trigger
+
+## Overview
+
+The workflow model already contains `on_children_completed`, but generic
+MCP/kanban subtasks do not synthesize that trigger when their task state reaches
+terminal. Implement this by adding active-child completion helpers, preserving
+the event shape through API/frontend types, and wiring `task.state_changed` into
+an orchestrator trigger path that applies workflow transitions with normal
+`on_exit`/`on_enter` behavior. Finish with focused backend tests and one E2E
+that proves child task completion advances the parent without polling.
+
+---
+
+## Backend
+
+### Task Repository
+
+Files:
+- `apps/backend/internal/task/repository/interface.go`
+- `apps/backend/internal/task/repository/sqlite/task.go`
+- `apps/backend/internal/task/repository/task_repository_test.go`
+
+Changes:
+- Add a repository helper that returns active direct children with fields needed
+  for completion checks and idempotency, for example:
+  `ListChildCompletionRows(ctx, parentID string) ([]ChildCompletionRow, error)`.
+- `ChildCompletionRow` should include `ID`, `State`, `Title`, and `UpdatedAt`.
+- Match `ListChildren` active semantics: `parent_id = ?`, `archived_at IS NULL`,
+  and `is_ephemeral = 0`.
+- Treat `COMPLETED`, `FAILED`, and `CANCELLED` as terminal.
+
+Reason:
+- The generic task layer must not import Office repository helpers, and Office's
+  current helper omits `FAILED` from terminal states.
+
+### Workflow Trigger Dispatch
+
+Files:
+- `apps/backend/internal/orchestrator/service.go`
+- `apps/backend/internal/orchestrator/event_handlers_children_completed.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow.go`
+- `apps/backend/internal/orchestrator/workflow_store.go`
+
+Changes:
+- Wire `watcher.EventHandlers.OnTaskStateChanged` to a new orchestrator handler.
+- In the handler, ignore events where `parent_id` is empty or `new_state` is
+  not terminal.
+- Load active direct children of the parent and return early until all are
+  terminal.
+- Build `engine.OnChildrenCompletedPayload` from child rows.
+- Build a deterministic operation id such as
+  `children_completed:<parentID>:<sorted child id/state/updated_at digest>`.
+- Resolve the parent active session with the existing repository session lookup.
+- Evaluate `engine.TriggerOnChildrenCompleted` in `EvaluateOnly` mode and apply
+  transition results through the same transition helper used by
+  `on_turn_complete`, so `on_exit`, data persistence, DB step change, and
+  `on_enter` fire correctly.
+- If the trigger has only side-effect actions and no transition, mark the
+  derived operation as applied after the engine evaluates callbacks.
+
+Reason:
+- `office/engine_dispatcher.Dispatcher` calls `engine.HandleTrigger` directly
+  and does not apply returned transitions. Parent step movement must use the
+  orchestrator transition lifecycle.
+
+### Workflow Event DTOs
+
+Files:
+- `apps/backend/internal/task/dto/dto.go`
+- `apps/backend/internal/task/dto/converters.go`
+- `apps/backend/internal/task/dto/converters_test.go`
+
+Changes:
+- Extend `StepEventsDTO` to include `on_turn_start`, `on_exit`, and all generic
+  trigger slices, especially `on_children_completed`.
+- Update `FromWorkflowStep` so API responses preserve every non-empty event
+  slice in `workflow_step.events`.
+
+Reason:
+- Existing converters only return `on_enter` and `on_turn_complete`, which would
+  make configured generic triggers disappear from API consumers.
+
+---
+
+## Frontend
+
+### Type Parity
+
+Files:
+- `apps/web/lib/types/workflow-actions.ts`
+- `apps/web/lib/state/slices/kanban/types.ts`
+- `apps/web/e2e/helpers/api-client.ts`
+
+Changes:
+- Add generic workflow action types for `move_to_next`, `move_to_previous`,
+  `move_to_step`, `auto_start_agent`, `queue_run`,
+  `queue_run_for_each_participant`, and `clear_decisions`.
+- Extend `StepEvents` and `KanbanStepEvents` with
+  `on_children_completed?: GenericAction[]` plus the other already-supported
+  generic trigger names where useful for parity.
+- Extend E2E API helper workflow-step update typings so tests can configure
+  `on_children_completed`.
+
+Reason:
+- This feature does not require new visible UI, but TypeScript should accept and
+  preserve workflow event JSON that the backend already supports.
+
+---
+
+## Tests
+
+- **What:** active children terminal detection includes `COMPLETED`, `FAILED`,
+  and `CANCELLED`; non-terminal states block; archived/ephemeral rows are
+  ignored.
+  **File:** `apps/backend/internal/task/repository/task_repository_test.go`
+  **How:** SQLite-backed table-driven repository test.
+
+- **What:** workflow-step DTO conversion preserves `on_children_completed`.
+  **File:** `apps/backend/internal/task/dto/converters_test.go`
+  **How:** unit test on `dto.FromWorkflowStep`.
+
+- **What:** last direct child terminal state fires one parent
+  `on_children_completed` trigger.
+  **File:** `apps/backend/internal/orchestrator/event_handlers_children_completed_test.go`
+  **How:** orchestrator unit/integration test with fake engine/repository.
+
+- **What:** first child terminal state does not fire while siblings remain
+  non-terminal.
+  **File:** `apps/backend/internal/orchestrator/event_handlers_children_completed_test.go`
+  **How:** table-driven orchestrator test.
+
+- **What:** duplicate terminal updates do not duplicate parent actions.
+  **File:** `apps/backend/internal/orchestrator/event_handlers_children_completed_test.go`
+  **How:** invoke handler twice with same operation inputs and assert one engine
+  action/transition.
+
+- **What:** parent `move_to_next` action uses normal workflow transition
+  lifecycle.
+  **File:** `apps/backend/internal/orchestrator/event_handlers_children_completed_test.go`
+  **How:** integration-style test asserts persisted parent step and `on_enter`
+  side effect.
+
+- **What:** frontend workflow event typings accept `on_children_completed`.
+  **File:** no dedicated unit test unless a nearby type helper exists.
+  **How:** `cd apps && pnpm --filter @kandev/web typecheck`.
+
+---
+
+## E2E Tests
+
+- **Scenario:** GIVEN a parent task has two active children and its current
+  workflow step defines `on_children_completed`, WHEN the first child completes
+  and the second remains non-terminal, THEN the parent stays put. WHEN the
+  second child completes, THEN the parent moves to the configured done step.
+  **File:** `apps/web/e2e/tests/workflow/workflow-children-completed.spec.ts`
+  **What to verify:** parent task workflow step changes only after every active
+  direct child is terminal.
+
+---
+
+## Implementation Waves
+
+Wave 1 (parallel):
+- [x] [task-01-backend-child-completion-repository](task-01-backend-child-completion-repository.md)
+- [x] [task-02-workflow-event-contracts](task-02-workflow-event-contracts.md)
+
+Wave 2:
+- [x] [task-03-orchestrator-trigger-dispatch](task-03-orchestrator-trigger-dispatch.md)
+
+Wave 3:
+- [x] [task-04-e2e-verification](task-04-e2e-verification.md)
+
+---
+
+## Verification Commands
+
+Format first:
+
+```bash
+make fmt
+```
+
+Targeted backend tests:
+
+```bash
+make -C apps/backend test ARGS="./internal/task/repository/... ./internal/task/dto/... ./internal/orchestrator/... ./internal/workflow/engine/..."
+```
+
+Frontend typecheck:
+
+```bash
+cd apps && pnpm --filter @kandev/web typecheck
+```
+
+Focused E2E:
+
+```bash
+cd apps/web && pnpm e2e workflow-children-completed.spec.ts
+```
+
+Full verification:
+
+```bash
+make typecheck test lint
+```
+
+---
+
+## Open Questions
+
+None for the first implementation pass. The spec intentionally fixes direct
+children only, best-effort child summaries, and no automatic parent session
+creation.

--- a/docs/plans/subtask-completion-trigger/task-01-backend-child-completion-repository.md
+++ b/docs/plans/subtask-completion-trigger/task-01-backend-child-completion-repository.md
@@ -21,7 +21,7 @@ spec: "../../specs/tasks/subtask-completion-trigger.md"
 ## Verification
 
 ```bash
-make -C apps/backend test ARGS="./internal/task/repository/..."
+go test ./internal/task/repository/...
 ```
 
 ## Files Likely Touched

--- a/docs/plans/subtask-completion-trigger/task-01-backend-child-completion-repository.md
+++ b/docs/plans/subtask-completion-trigger/task-01-backend-child-completion-repository.md
@@ -21,7 +21,7 @@ spec: "../../specs/tasks/subtask-completion-trigger.md"
 ## Verification
 
 ```bash
-go test ./internal/task/repository/...
+cd apps/backend && go test ./internal/task/repository/...
 ```
 
 ## Files Likely Touched

--- a/docs/plans/subtask-completion-trigger/task-01-backend-child-completion-repository.md
+++ b/docs/plans/subtask-completion-trigger/task-01-backend-child-completion-repository.md
@@ -1,0 +1,53 @@
+---
+id: "01-backend-child-completion-repository"
+title: "Backend child completion repository"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/subtask-completion-trigger.md"
+---
+
+# Task 01: Backend child completion repository
+
+## Acceptance
+
+- The task repository exposes active direct child completion rows for a parent
+  task without importing Office repository code.
+- Terminal-state evaluation treats `COMPLETED`, `FAILED`, and `CANCELLED` as
+  terminal.
+- Archived and ephemeral children do not block the parent completion check.
+
+## Verification
+
+```bash
+make -C apps/backend test ARGS="./internal/task/repository/..."
+```
+
+## Files Likely Touched
+
+- `apps/backend/internal/task/repository/interface.go`
+- `apps/backend/internal/task/repository/sqlite/task.go`
+- `apps/backend/internal/task/repository/task_repository_test.go`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec: `docs/specs/tasks/subtask-completion-trigger.md`, sections `What`,
+  `Data model`, `Scenarios`.
+- Existing patterns: `TaskRepository.ListChildren`,
+  `office/repository/sqlite.AreAllChildrenTerminal`, and
+  `CountOpenWatcherCreatedTasks` terminal-state SQL.
+
+## Output Contract
+
+When finished, update this task frontmatter to `status: done`, update the
+checkbox in `plan.md`, and report:
+
+- Summary of repository API and SQL changes.
+- Files changed.
+- Tests run and their result.
+- Any blockers or follow-up risks.

--- a/docs/plans/subtask-completion-trigger/task-02-workflow-event-contracts.md
+++ b/docs/plans/subtask-completion-trigger/task-02-workflow-event-contracts.md
@@ -1,0 +1,55 @@
+---
+id: "02-workflow-event-contracts"
+title: "Workflow event contracts"
+status: done
+wave: 1
+depends_on: []
+plan: "plan.md"
+spec: "../../specs/tasks/subtask-completion-trigger.md"
+---
+
+# Task 02: Workflow event contracts
+
+## Acceptance
+
+- Workflow step API responses preserve `on_children_completed` and other
+  existing generic trigger fields instead of dropping them.
+- Frontend workflow event types accept `on_children_completed` generic actions.
+- E2E API helpers can configure `on_children_completed` without type escapes.
+
+## Verification
+
+```bash
+make -C apps/backend test ARGS="./internal/task/dto/..."
+cd apps && pnpm --filter @kandev/web typecheck
+```
+
+## Files Likely Touched
+
+- `apps/backend/internal/task/dto/dto.go`
+- `apps/backend/internal/task/dto/converters.go`
+- `apps/backend/internal/task/dto/converters_test.go`
+- `apps/web/lib/types/workflow-actions.ts`
+- `apps/web/lib/state/slices/kanban/types.ts`
+- `apps/web/e2e/helpers/api-client.ts`
+
+## Dependencies
+
+None.
+
+## Inputs
+
+- Spec: `docs/specs/tasks/subtask-completion-trigger.md`, section
+  `API surface`.
+- Existing backend model: `apps/backend/internal/workflow/models/models.go`.
+- Existing frontend type file: `apps/web/lib/types/workflow-actions.ts`.
+
+## Output Contract
+
+When finished, update this task frontmatter to `status: done`, update the
+checkbox in `plan.md`, and report:
+
+- Summary of backend DTO and frontend type changes.
+- Files changed.
+- Tests/typechecks run and their result.
+- Any blockers or follow-up risks.

--- a/docs/plans/subtask-completion-trigger/task-02-workflow-event-contracts.md
+++ b/docs/plans/subtask-completion-trigger/task-02-workflow-event-contracts.md
@@ -20,7 +20,7 @@ spec: "../../specs/tasks/subtask-completion-trigger.md"
 ## Verification
 
 ```bash
-make -C apps/backend test ARGS="./internal/task/dto/..."
+go test ./internal/task/dto/...
 cd apps && pnpm --filter @kandev/web typecheck
 ```
 

--- a/docs/plans/subtask-completion-trigger/task-03-orchestrator-trigger-dispatch.md
+++ b/docs/plans/subtask-completion-trigger/task-03-orchestrator-trigger-dispatch.md
@@ -23,7 +23,7 @@ spec: "../../specs/tasks/subtask-completion-trigger.md"
 ## Verification
 
 ```bash
-make -C apps/backend test ARGS="./internal/orchestrator/..."
+go test ./internal/orchestrator/...
 ```
 
 ## Files Likely Touched

--- a/docs/plans/subtask-completion-trigger/task-03-orchestrator-trigger-dispatch.md
+++ b/docs/plans/subtask-completion-trigger/task-03-orchestrator-trigger-dispatch.md
@@ -1,0 +1,59 @@
+---
+id: "03-orchestrator-trigger-dispatch"
+title: "Orchestrator trigger dispatch"
+status: done
+wave: 2
+depends_on: ["01-backend-child-completion-repository", "02-workflow-event-contracts"]
+plan: "plan.md"
+spec: "../../specs/tasks/subtask-completion-trigger.md"
+---
+
+# Task 03: Orchestrator trigger dispatch
+
+## Acceptance
+
+- A child task state transition from non-terminal to terminal evaluates the
+  parent only when every active direct child is terminal.
+- The parent receives exactly one `engine.TriggerOnChildrenCompleted` for the
+  same completed child set.
+- Transition actions from `on_children_completed` apply the normal workflow
+  lifecycle: `on_exit`, persisted parent step change, data patch persistence,
+  and `on_enter`.
+
+## Verification
+
+```bash
+make -C apps/backend test ARGS="./internal/orchestrator/..."
+```
+
+## Files Likely Touched
+
+- `apps/backend/internal/orchestrator/service.go`
+- `apps/backend/internal/orchestrator/event_handlers_children_completed.go`
+- `apps/backend/internal/orchestrator/event_handlers_children_completed_test.go`
+- `apps/backend/internal/orchestrator/event_handlers_workflow.go`
+- `apps/backend/internal/orchestrator/workflow_store.go`
+
+## Dependencies
+
+- `01-backend-child-completion-repository`
+- `02-workflow-event-contracts`
+
+## Inputs
+
+- Spec: `docs/specs/tasks/subtask-completion-trigger.md`, sections `State
+  machine`, `Failure modes`, `Persistence guarantees`, `Scenarios`.
+- Plan: Backend `Workflow Trigger Dispatch`.
+- Existing patterns: `processOnTurnCompleteViaEngine`,
+  `applyEngineTransition`, `office/engine_dispatcher.Dispatcher`, and watcher
+  task event subscription wiring.
+
+## Output Contract
+
+When finished, update this task frontmatter to `status: done`, update the
+checkbox in `plan.md`, and report:
+
+- Summary of trigger dispatch and idempotency behavior.
+- Files changed.
+- Tests run and their result.
+- Any blockers or follow-up risks.

--- a/docs/plans/subtask-completion-trigger/task-04-e2e-verification.md
+++ b/docs/plans/subtask-completion-trigger/task-04-e2e-verification.md
@@ -1,0 +1,53 @@
+---
+id: "04-e2e-verification"
+title: "E2E verification"
+status: done
+wave: 3
+depends_on: ["03-orchestrator-trigger-dispatch"]
+plan: "plan.md"
+spec: "../../specs/tasks/subtask-completion-trigger.md"
+---
+
+# Task 04: E2E verification
+
+## Acceptance
+
+- An E2E test creates a parent task whose workflow step defines
+  `on_children_completed`.
+- At least two child tasks are created with `parent_id` pointing at the parent.
+- The parent stays on its current step after the first child completes while a
+  sibling remains non-terminal.
+- When all children complete, the parent advances according to the configured
+  `on_children_completed` action without any parent polling loop.
+
+## Verification
+
+```bash
+cd apps/web && pnpm e2e workflow-children-completed.spec.ts
+make fmt
+make typecheck test lint
+```
+
+## Files Likely Touched
+
+- `apps/web/e2e/tests/workflow/workflow-children-completed.spec.ts`
+
+## Dependencies
+
+- `03-orchestrator-trigger-dispatch`
+
+## Inputs
+
+- Spec: `docs/specs/tasks/subtask-completion-trigger.md`, `Scenarios`.
+- Existing E2E patterns: `apps/web/e2e/tests/task/subtask.spec.ts`,
+  `apps/web/e2e/helpers/api-client.ts`, and mock-agent MCP script examples.
+
+## Output Contract
+
+When finished, update this task frontmatter to `status: done`, update the
+checkbox in `plan.md`, and report:
+
+- Summary of E2E coverage.
+- Files changed.
+- Tests run and their result.
+- Any blockers or follow-up risks.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -43,6 +43,7 @@ Kandev's task model: documents, execution stages, labels, blocker escalation, su
 | [model-unification](tasks/model-unification.md) | draft |
 | [without-repositories](tasks/without-repositories.md) | draft |
 | [subtask-checklist](tasks/subtask-checklist.md) | shipped |
+| [subtask-completion-trigger](tasks/subtask-completion-trigger.md) | draft |
 | [subtree-controls](tasks/subtree-controls.md) | shipped |
 | [blocked-task-escalation](tasks/blocked-task-escalation.md) | draft |
 | [runtime-cleanup](tasks/runtime-cleanup.md) | draft |

--- a/docs/specs/tasks/subtask-completion-trigger.md
+++ b/docs/specs/tasks/subtask-completion-trigger.md
@@ -1,0 +1,199 @@
+---
+status: draft
+created: 2026-06-23
+owner: cfl
+---
+
+# Subtask Completion Trigger
+
+## Why
+
+Parent agents can delegate work by creating subtasks with `create_task_kandev`
+and `parent_id`, but today they must poll `list_related_tasks_kandev` to learn
+when all delegated workstreams are done. Polling burns agent turns and pushes
+orchestration logic into the parent prompt instead of the workflow system.
+
+## What
+
+- A workflow step can define an `on_children_completed` event.
+- The event fires on a parent task's current workflow step when every direct,
+  active child task has reached a terminal task state.
+- Terminal task states are `COMPLETED`, `FAILED`, and `CANCELLED`.
+- The event is driven by task state changes, including subtasks created through
+  `create_task_kandev` with `parent_id`.
+- The event runs the step actions configured on `on_children_completed`, such as
+  queueing a parent-agent run or moving the parent to a verification step.
+- The event fires at most once for the same completed child set. If a child is
+  reopened and later returns to a terminal state, the parent can receive a new
+  event for the new completion cycle.
+- The trigger considers direct children only. Grandchildren complete their own
+  parent before any higher-level parent can react.
+- Parent tasks with no active or primary session do not auto-create a session
+  for this event; the event is skipped and logged.
+- Existing workflows that do not configure `on_children_completed` behave
+  unchanged.
+
+## Data model
+
+No new persistent table is required.
+
+### `tasks`
+
+The existing `tasks.parent_id` relationship defines the direct child set.
+Children with `archived_at` set or `is_ephemeral = 1` are ignored by this
+feature, matching existing active-child listing semantics.
+
+The existing `tasks.state` field defines terminal child completion. The terminal
+set for this feature is:
+
+```text
+COMPLETED
+FAILED
+CANCELLED
+```
+
+### Workflow operation idempotency
+
+The existing workflow engine operation-id store records each synthesized
+`on_children_completed` trigger. The operation id is deterministic for the
+parent and completed direct-child set, including enough child completion version
+data to let a reopen-and-complete cycle fire again.
+
+## API surface
+
+No new HTTP route, WebSocket event, MCP tool, or CLI command is introduced.
+
+Workflow step event JSON accepts and returns `on_children_completed` in the
+existing `events` object:
+
+```json
+{
+  "events": {
+    "on_children_completed": [
+      {
+        "type": "queue_run",
+        "config": {
+          "target": "primary",
+          "task_id": "this",
+          "reason": "children_completed"
+        }
+      }
+    ]
+  }
+}
+```
+
+The event uses the existing workflow-engine trigger payload:
+
+```json
+{
+  "child_summaries": [
+    {
+      "task_id": "child-task-id",
+      "status": "COMPLETED",
+      "summary": "optional child completion summary",
+      "pr_links": ["https://github.com/org/repo/pull/123"]
+    }
+  ]
+}
+```
+
+`summary` and `pr_links` are best-effort enrichment. A missing summary or PR link
+does not block the trigger.
+
+## State machine
+
+- A child enters a terminal state when its task state changes from a
+  non-terminal state to `COMPLETED`, `FAILED`, or `CANCELLED`.
+- On that transition, the system checks the child's parent.
+- If the child has no parent, no parent event is considered.
+- If any active direct child of the parent is still non-terminal, no parent event
+  fires.
+- If every active direct child is terminal, the parent task receives
+  `on_children_completed` at its current workflow step.
+- If configured actions transition the parent step, the normal workflow
+  transition lifecycle applies: `on_exit`, persisted step change, data patch
+  persistence, then `on_enter`.
+- If a child later moves from terminal to non-terminal, the parent is considered
+  waiting again. A later transition of that child back to terminal can produce a
+  new event.
+
+## Permissions
+
+This feature adds no new permission boundary.
+
+- Agents and users can only create child tasks through existing task creation
+  permissions and MCP tool exposure.
+- Agents cannot fire `on_children_completed` directly; they can only cause it by
+  changing task state through existing task completion paths.
+- Workflow authors control the parent reaction by configuring
+  `on_children_completed` actions on the parent step.
+
+## Failure modes
+
+- If the child-state event cannot be decoded, the event is dropped and a warning
+  is logged.
+- If sibling lookup fails, no parent trigger fires for that event and a warning
+  is logged. A later child state transition can retry the check.
+- If the parent has no active or primary session, no new parent session is
+  created. The skip is logged at debug/info level.
+- If the workflow engine rejects or fails a configured action, the error is
+  logged and the child task's terminal state remains unchanged.
+- If multiple children finish concurrently, engine operation idempotency prevents
+  duplicate parent actions for the same completed child set.
+
+## Persistence guarantees
+
+- Child task state, parent-child relationships, workflow step configuration, and
+  workflow operation ids survive backend restarts.
+- A child completion event that was already applied before restart is not
+  re-applied for the same completed child set.
+- In-memory event delivery itself is not replayed after restart. A future child
+  state transition or reopen-and-complete cycle can synthesize the trigger again.
+
+## Scenarios
+
+- **GIVEN** a parent task has two direct children and one child is still
+  `IN_PROGRESS`, **WHEN** the first child changes to `COMPLETED`, **THEN** the
+  parent's `on_children_completed` event does not fire.
+
+- **GIVEN** a parent task has two direct children and the first child is
+  `COMPLETED`, **WHEN** the second child changes from `IN_PROGRESS` to
+  `COMPLETED`, **THEN** the parent receives one `on_children_completed` trigger.
+
+- **GIVEN** a parent step configures `on_children_completed` with `move_to_next`,
+  **WHEN** all direct children are terminal, **THEN** the parent moves to the
+  next workflow step and that step's `on_enter` actions run normally.
+
+- **GIVEN** a parent step configures `on_children_completed` with `queue_run` for
+  the primary agent, **WHEN** all direct children are terminal, **THEN** a parent
+  run is queued with the children-completed reason and child summary context.
+
+- **GIVEN** one child finishes as `FAILED` and all other direct children are
+  terminal, **WHEN** the failed child transitions from non-terminal to `FAILED`,
+  **THEN** the parent receives `on_children_completed`.
+
+- **GIVEN** a child is already `COMPLETED`, **WHEN** a duplicate update attempts
+  to set it to `COMPLETED` again, **THEN** no duplicate parent trigger fires.
+
+- **GIVEN** all direct children are terminal and the parent trigger has fired,
+  **WHEN** one child is reopened to `IN_PROGRESS` and later changes back to
+  `COMPLETED`, **THEN** the parent can receive a new `on_children_completed`
+  trigger for the new completion cycle.
+
+- **GIVEN** a child has its own child, **WHEN** the grandchild completes, **THEN**
+  only the direct parent of that grandchild is evaluated for
+  `on_children_completed`.
+
+- **GIVEN** a parent has no active or primary session, **WHEN** all direct
+  children become terminal, **THEN** no session is created automatically and the
+  skip is logged.
+
+## Out of scope
+
+- Adding a second event name such as `on_all_children_complete` or
+  `on_subtasks_done`.
+- Recursive descendant aggregation.
+- Creating parent sessions automatically when no parent session exists.
+- Adding a new MCP wait primitive or long-poll API.
+- Requiring every child agent to know whether it is the last sibling.

--- a/docs/specs/tasks/subtask-completion-trigger.md
+++ b/docs/specs/tasks/subtask-completion-trigger.md
@@ -23,6 +23,11 @@ orchestration logic into the parent prompt instead of the workflow system.
   `create_task_kandev` with `parent_id`.
 - The event runs the step actions configured on `on_children_completed`, such as
   queueing a parent-agent run or moving the parent to a verification step.
+- Workflow authors can configure the event from the workflow step editor with
+  the "When Child Tasks Complete" transition selector. The editor explains that
+  the trigger belongs on the parent step, waits for direct active children only,
+  treats `COMPLETED`, `FAILED`, and `CANCELLED` as terminal, and ignores
+  archived or ephemeral child tasks.
 - The event fires at most once for the same completed child set. If a child is
   reopened and later returns to a terminal state, the parent can receive a new
   event for the new completion cycle.
@@ -76,6 +81,23 @@ existing `events` object:
           "target": "primary",
           "task_id": "this",
           "reason": "children_completed"
+        }
+      }
+    ]
+  }
+}
+```
+
+The workflow settings UI exposes the transition-oriented subset of this event:
+
+```json
+{
+  "events": {
+    "on_children_completed": [
+      {
+        "type": "move_to_step",
+        "config": {
+          "step_id": "verification-step-id"
         }
       }
     ]


### PR DESCRIPTION
Workflows need a first-class way to react when every active child task finishes, so parent tasks can progress without manual cleanup. This adds a subtask-completion trigger path that evaluates existing workflow actions once all active children have reached terminal states.

## Important Changes

- Added repository support for listing active child completion state so the orchestrator can make a complete all-children-terminal decision.
- Added orchestrator dispatch for `children_completed` workflow triggers with idempotent action execution on child terminal transitions.
- Preserved generic workflow triggers/actions through backend DTOs and frontend types so imported workflows can define the new behavior.
- Added backend unit coverage and a Playwright workflow regression for the parent transition behavior.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `make build-backend`
- `make build-web`
- `pnpm e2e workflow-children-completed.spec.ts`

## Possible Improvements

Low risk: the trigger currently evaluates after terminal child state changes, so future bulk state transitions should continue to route through the same task state update path.

Closes #1238

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->