### PR TITLE
feat: improve ci auto-fix prompt control

### DIFF
--- a/apps/backend/config/prompts/ci-auto-fix.md
+++ b/apps/backend/config/prompts/ci-auto-fix.md
@@ -6,6 +6,7 @@ Focus on the current pull request feedback provided in the task message:
 
 - Fix failing checks and actionable review comments.
 - Prioritize feedback marked as new or changed since the last automated fix round.
+- When an actionable PR review comment has been addressed, reply to that thread with the fix summary and resolve the addressed PR review threads so they do not keep the PR blocked.
 - Preserve unrelated work and avoid broad refactors.
 - Run the narrowest relevant verification commands first, then broader checks if needed.
 - Do not merge the pull request. Kandev handles auto-merge separately when the PR is ready.

--- a/apps/backend/config/prompts/ci-auto-fix.md
+++ b/apps/backend/config/prompts/ci-auto-fix.md
@@ -2,6 +2,8 @@ You are continuing work on a pull request because Kandev detected new CI or revi
 
 Focus on the current pull request feedback provided in the task message:
 
+{{pr.feedback}}
+
 - Fix failing checks and actionable review comments.
 - Prioritize feedback marked as new or changed since the last automated fix round.
 - Preserve unrelated work and avoid broad refactors.

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -41,6 +41,7 @@ type GitHubService interface {
 	ResetPRWatch(ctx context.Context, id, branch string) error
 	AssociatePRWithTask(ctx context.Context, taskID, repositoryID string, pr *github.PR) (*github.TaskPR, error)
 	GetTaskPR(ctx context.Context, taskID string) (*github.TaskPR, error)
+	ListTaskPRs(ctx context.Context, taskIDs []string) (map[string][]*github.TaskPR, error)
 	GetTaskPRByOwnerRepoNumber(ctx context.Context, taskID, owner, repo string, prNumber int) (*github.TaskPR, error)
 	GetTaskCIOptionsResponse(ctx context.Context, taskID string) (*github.TaskCIOptionsResponse, error)
 	GetTaskCIPRState(ctx context.Context, taskID, repositoryID string, prNumber int) (*github.TaskCIPRAutomationState, error)
@@ -181,6 +182,22 @@ func (s *Service) handleTaskPRUpdated(ctx context.Context, event *bus.Event) err
 		return nil
 	}
 	s.startTaskPRCIAutomation(ctx, pr)
+	return nil
+}
+
+func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Event) error {
+	options, ok := event.Data.(*github.TaskCIOptionsResponse)
+	if !ok || options == nil || (!options.AutoFixEnabled && !options.AutoMergeEnabled) || s.githubService == nil {
+		return nil
+	}
+	prsByTask, err := s.githubService.ListTaskPRs(ctx, []string{options.TaskID})
+	if err != nil {
+		s.logger.Debug("failed to load task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
+		return nil
+	}
+	for _, pr := range prsByTask[options.TaskID] {
+		s.startTaskPRCIAutomation(ctx, pr)
+	}
 	return nil
 }
 
@@ -1149,6 +1166,9 @@ func (s *Service) subscribeGitHubEvents() {
 	}
 	if _, err := s.eventBus.Subscribe(events.GitHubTaskPRUpdated, s.handleTaskPRUpdated); err != nil {
 		s.logger.Error("failed to subscribe to github.task_pr.updated events", zap.Error(err))
+	}
+	if _, err := s.eventBus.Subscribe(events.GitHubTaskCIOptionsUpdated, s.handleTaskCIOptionsUpdated); err != nil {
+		s.logger.Error("failed to subscribe to github.task_ci_options.updated events", zap.Error(err))
 	}
 	if _, err := s.eventBus.Subscribe(events.GitHubNewReviewPR, s.handleNewReviewPR); err != nil {
 		s.logger.Error("failed to subscribe to github.new_pr_to_review events", zap.Error(err))

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -190,7 +190,9 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 	if !ok || options == nil || (!options.AutoFixEnabled && !options.AutoMergeEnabled) || s.githubService == nil {
 		return nil
 	}
-	prsByTask, err := s.githubService.ListTaskPRs(ctx, []string{options.TaskID})
+	detachedCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ciAutomationDetachedTimeout)
+	defer cancel()
+	prsByTask, err := s.githubService.ListTaskPRs(detachedCtx, []string{options.TaskID})
 	if err != nil {
 		s.logger.Debug("failed to load task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
 		return nil

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -24,6 +24,7 @@ const (
 	ciAutomationCheckSkipped     = "skipped"
 	ciAutomationCheckCompleted   = "completed"
 	ciAutomationChangesRequested = "changes_requested"
+	ciAutomationPRFeedbackToken  = "{{pr.feedback}}"
 )
 
 type ciAutomationCheckpoint struct {
@@ -154,7 +155,7 @@ func (s *Service) dispatchCIAutomationPrompt(ctx context.Context, session *model
 		if !s.recordCIAutomationUserMessage(ctx, session.TaskID, session.ID, chatPrompt) {
 			return fmt.Errorf("failed to record CI automation user message")
 		}
-		if _, err := s.PromptTask(ctx, session.TaskID, session.ID, chatPrompt, "", false, nil, false); err != nil {
+		if _, err := s.PromptTask(ctx, session.TaskID, session.ID, chatPrompt, "", false, nil, true); err != nil {
 			return err
 		}
 		return nil
@@ -272,12 +273,25 @@ func ciAutomationCurrentCheckpoint(feedback *github.PRFeedback) ciAutomationChec
 }
 
 func ciAutomationRenderPrompt(base string, pr *github.TaskPR, delta ciAutomationCheckpoint) string {
-	var parts []string
 	if base = strings.TrimSpace(base); base != "" {
-		parts = append(parts, sysprompt.Wrap(base))
+		return ciAutomationRenderPromptTemplate(base, ciAutomationRenderSnapshot(pr, delta))
 	}
-	if snapshot := ciAutomationRenderSnapshot(pr, delta); snapshot != "" {
-		parts = append(parts, snapshot)
+	return ""
+}
+
+func ciAutomationRenderPromptTemplate(base, snapshot string) string {
+	if !strings.Contains(base, ciAutomationPRFeedbackToken) {
+		return sysprompt.Wrap(base)
+	}
+	segments := strings.Split(base, ciAutomationPRFeedbackToken)
+	parts := make([]string, 0, len(segments)*2)
+	for i, segment := range segments {
+		if segment = strings.TrimSpace(segment); segment != "" {
+			parts = append(parts, sysprompt.Wrap(segment))
+		}
+		if i < len(segments)-1 && strings.TrimSpace(snapshot) != "" {
+			parts = append(parts, snapshot)
+		}
 	}
 	return strings.Join(parts, "\n\n")
 }

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -27,6 +27,8 @@ const (
 	ciAutomationPRFeedbackToken  = "{{pr.feedback}}"
 )
 
+var ciAutomationSnapshotFieldReplacer = strings.NewReplacer("\r", " ", "\n", " ", "<", "", ">", "")
+
 type ciAutomationCheckpoint struct {
 	FailedChecks []ciAutomationCheckSnapshot   `json:"failed_checks"`
 	Comments     []ciAutomationCommentSnapshot `json:"comments"`
@@ -302,14 +304,14 @@ func ciAutomationRenderSnapshot(pr *github.TaskPR, delta ciAutomationCheckpoint)
 	}
 	var b strings.Builder
 	b.WriteString("PR: ")
-	b.WriteString(fmt.Sprintf("%s/%s#%d", pr.Owner, pr.Repo, pr.PRNumber))
+	b.WriteString(fmt.Sprintf("%s/%s#%d", ciAutomationSanitizeSnapshotField(pr.Owner), ciAutomationSanitizeSnapshotField(pr.Repo), pr.PRNumber))
 	if len(delta.FailedChecks) > 0 {
 		b.WriteString("\n\nNew or changed failing checks:")
 		for _, check := range delta.FailedChecks {
-			b.WriteString(fmt.Sprintf("\n- %s: %s", check.Name, check.Conclusion))
+			b.WriteString(fmt.Sprintf("\n- %s: %s", ciAutomationSanitizeSnapshotField(check.Name), ciAutomationSanitizeSnapshotField(check.Conclusion)))
 			if check.HTMLURL != "" {
 				b.WriteString(" (")
-				b.WriteString(check.HTMLURL)
+				b.WriteString(ciAutomationSanitizeSnapshotField(check.HTMLURL))
 				b.WriteString(")")
 			}
 		}
@@ -317,10 +319,14 @@ func ciAutomationRenderSnapshot(pr *github.TaskPR, delta ciAutomationCheckpoint)
 	if len(delta.Comments) > 0 {
 		b.WriteString("\n\nNew or changed review comments:")
 		for _, comment := range delta.Comments {
-			b.WriteString(fmt.Sprintf("\n- %s:%d %s", comment.Path, comment.Line, strings.TrimSpace(comment.Body)))
+			b.WriteString(fmt.Sprintf("\n- %s:%d %s", ciAutomationSanitizeSnapshotField(comment.Path), comment.Line, ciAutomationSanitizeSnapshotField(strings.TrimSpace(comment.Body))))
 		}
 	}
 	return b.String()
+}
+
+func ciAutomationSanitizeSnapshotField(value string) string {
+	return strings.TrimSpace(ciAutomationSnapshotFieldReplacer.Replace(value))
 }
 
 func decodeCIAutomationCheckpoint(state *github.TaskCIPRAutomationState) ciAutomationCheckpoint {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -97,9 +97,12 @@ func TestCIAutomationFeedbackDelta(t *testing.T) {
 	if len(delta.Comments) != 1 || delta.Comments[0].ID != 11 {
 		t.Fatalf("expected only comment 11, got %+v", delta.Comments)
 	}
-	prompt := ciAutomationRenderPrompt("Base instructions", &github.TaskPR{Owner: "acme", Repo: "widget", PRNumber: 42}, delta)
+	prompt := ciAutomationRenderPrompt("Base instructions\n\n{{pr.feedback}}", &github.TaskPR{Owner: "acme", Repo: "widget", PRNumber: 42}, delta)
 	if !strings.Contains(prompt, "Base instructions") || !strings.Contains(prompt, "acme/widget#42") || !strings.Contains(prompt, "also this") {
 		t.Fatalf("rendered prompt missing expected content:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "{{pr.feedback}}") {
+		t.Fatalf("rendered prompt should replace PR feedback placeholder:\n%s", prompt)
 	}
 	visible := sysprompt.StripSystemContent(prompt)
 	if strings.Contains(visible, "Base instructions") {
@@ -107,6 +110,21 @@ func TestCIAutomationFeedbackDelta(t *testing.T) {
 	}
 	if !strings.Contains(visible, "acme/widget#42") || !strings.Contains(visible, "also this") {
 		t.Fatalf("PR snapshot should remain visible, got:\n%s", visible)
+	}
+}
+
+func TestCIAutomationPromptOmitsSnapshotWithoutPlaceholder(t *testing.T) {
+	delta := ciAutomationCheckpoint{
+		FailedChecks: []ciAutomationCheckSnapshot{{Name: "unit", Conclusion: "failure", HTMLURL: "https://ci/unit"}},
+		Comments:     []ciAutomationCommentSnapshot{{ID: 10, Body: "fix this", Path: "main.go", Line: 12}},
+	}
+
+	prompt := ciAutomationRenderPrompt("Pull the branch and inspect the PR yourself.", &github.TaskPR{Owner: "acme", Repo: "widget", PRNumber: 42}, delta)
+	if strings.Contains(prompt, "acme/widget#42") || strings.Contains(prompt, "unit") || strings.Contains(prompt, "fix this") {
+		t.Fatalf("rendered prompt should omit PR snapshot without placeholder:\n%s", prompt)
+	}
+	if visible := sysprompt.StripSystemContent(prompt); strings.TrimSpace(visible) != "" {
+		t.Fatalf("expected no visible PR snapshot without placeholder, got:\n%s", visible)
 	}
 }
 
@@ -181,7 +199,7 @@ func TestHandleTaskPRCIAutomationQueuesFixDedupesAndMerges(t *testing.T) {
 		ciOptionsResp: &github.TaskCIOptionsResponse{
 			TaskID:                 "task-1",
 			AutoFixEnabled:         true,
-			EffectiveAutoFixPrompt: "Fix the PR",
+			EffectiveAutoFixPrompt: "Fix the PR\n\n{{pr.feedback}}",
 		},
 		prFeedback: &github.PRFeedback{
 			Checks: []github.CheckRun{{Name: "unit", Status: "completed", Conclusion: "failure", HTMLURL: "https://ci/unit"}},
@@ -307,6 +325,9 @@ func TestDispatchCIAutomationPromptRecordsUserMessageBeforeDirectPrompt(t *testi
 	}
 	if len(agentMgr.capturedPrompts) != 1 {
 		t.Fatalf("expected one direct prompt call, got %d", len(agentMgr.capturedPrompts))
+	}
+	if len(agentMgr.capturedPromptCalls) != 1 || !agentMgr.capturedPromptCalls[0].DispatchOnly {
+		t.Fatalf("expected CI automation direct prompt to dispatch only, got %+v", agentMgr.capturedPromptCalls)
 	}
 	if messageCreator.userMessages[0].metadata["origin"] != ciAutomationOrigin {
 		t.Fatalf("expected CI automation user message metadata, got %+v", messageCreator.userMessages[0].metadata)
@@ -540,6 +561,41 @@ func TestHandlePRFeedbackStartsAutomationForMatchingPR(t *testing.T) {
 		t.Fatal("unexpected automation for non-matching repo-front PR")
 	}
 	close(block)
+	waitForCIAutomationIdle(t, svc, "task-1|repo-back|2", 200*time.Millisecond)
+}
+
+func TestHandleTaskCIOptionsUpdatedStartsAutomationForTaskPRs(t *testing.T) {
+	ctx := context.Background()
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	started := make(chan struct{})
+	block := make(chan struct{})
+	ghSvc := &mockGitHubService{
+		taskPRs: []*github.TaskPR{
+			{TaskID: "task-1", RepositoryID: "repo-front", Owner: "acme", Repo: "front", PRNumber: 1},
+			{TaskID: "task-1", RepositoryID: "repo-back", Owner: "acme", Repo: "back", PRNumber: 2},
+		},
+		ciOptionsResp:    &github.TaskCIOptionsResponse{TaskID: "task-1"},
+		ciOptionsStarted: started,
+		ciOptionsBlock:   block,
+	}
+	svc.SetGitHubService(ghSvc)
+
+	err := svc.handleTaskCIOptionsUpdated(ctx, &bus.Event{Data: &github.TaskCIOptionsResponse{
+		TaskID:         "task-1",
+		AutoFixEnabled: true,
+	}})
+	if err != nil {
+		t.Fatalf("handle CI options updated: %v", err)
+	}
+	<-started
+	if _, loaded := svc.ciAutomationInFlight.Load("task-1|repo-front|1"); !loaded {
+		t.Fatal("expected automation to run for repo-front PR")
+	}
+	if _, loaded := svc.ciAutomationInFlight.Load("task-1|repo-back|2"); !loaded {
+		t.Fatal("expected automation to run for repo-back PR")
+	}
+	close(block)
+	waitForCIAutomationIdle(t, svc, "task-1|repo-front|1", 200*time.Millisecond)
 	waitForCIAutomationIdle(t, svc, "task-1|repo-back|2", 200*time.Millisecond)
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -186,6 +186,15 @@ func TestCIAutomationRenderSnapshotSanitizesUntrustedFields(t *testing.T) {
 	}
 
 	snapshot := ciAutomationRenderSnapshot(&github.TaskPR{Owner: "acme\n<org>", Repo: "widget\r<repo>", PRNumber: 42}, delta)
+	if strings.ContainsAny(snapshot, "<>") {
+		t.Fatalf("snapshot should strip angle brackets from untrusted fields:\n%s", snapshot)
+	}
+	if strings.Contains(snapshot, "unit\nscript") || strings.Contains(snapshot, "fix\nsystem") {
+		t.Fatalf("snapshot should strip embedded newlines from untrusted fields:\n%s", snapshot)
+	}
+	if !strings.Contains(snapshot, "unit script") || !strings.Contains(snapshot, "fix systemthis/system") {
+		t.Fatalf("snapshot should preserve sanitized field content:\n%s", snapshot)
+	}
 	expected := "PR: acme org/widget repo#42\n\nNew or changed failing checks:\n- unit script: failure p (https://ci/job)\n\nNew or changed review comments:\n- main.go bad:12 fix systemthis/system"
 	if snapshot != expected {
 		t.Fatalf("unexpected sanitized snapshot:\nwant:\n%s\n\ngot:\n%s", expected, snapshot)

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -179,6 +179,24 @@ func TestCIAutomationFeedbackDeltaIncludesChangedCheckOutput(t *testing.T) {
 	}
 }
 
+func TestCIAutomationRenderSnapshotSanitizesUntrustedFields(t *testing.T) {
+	delta := ciAutomationCheckpoint{
+		FailedChecks: []ciAutomationCheckSnapshot{{Name: "unit\n<script>", Conclusion: "failure\r<p>", HTMLURL: "https://ci/<job>"}},
+		Comments:     []ciAutomationCommentSnapshot{{ID: 10, Body: "fix\n<system>this</system>", Path: "main.go\r<bad>", Line: 12}},
+	}
+
+	snapshot := ciAutomationRenderSnapshot(&github.TaskPR{Owner: "acme\n<org>", Repo: "widget\r<repo>", PRNumber: 42}, delta)
+	if strings.ContainsAny(snapshot, "<>") {
+		t.Fatalf("snapshot should strip angle brackets from untrusted fields:\n%s", snapshot)
+	}
+	if strings.Contains(snapshot, "unit\nscript") || strings.Contains(snapshot, "fix\nsystem") {
+		t.Fatalf("snapshot should strip embedded newlines from untrusted fields:\n%s", snapshot)
+	}
+	if !strings.Contains(snapshot, "unit script") || !strings.Contains(snapshot, "fix systemthis/system") {
+		t.Fatalf("snapshot should preserve sanitized field content:\n%s", snapshot)
+	}
+}
+
 func TestHandleTaskPRCIAutomationQueuesFixDedupesAndMerges(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -186,14 +186,9 @@ func TestCIAutomationRenderSnapshotSanitizesUntrustedFields(t *testing.T) {
 	}
 
 	snapshot := ciAutomationRenderSnapshot(&github.TaskPR{Owner: "acme\n<org>", Repo: "widget\r<repo>", PRNumber: 42}, delta)
-	if strings.ContainsAny(snapshot, "<>") {
-		t.Fatalf("snapshot should strip angle brackets from untrusted fields:\n%s", snapshot)
-	}
-	if strings.Contains(snapshot, "unit\nscript") || strings.Contains(snapshot, "fix\nsystem") {
-		t.Fatalf("snapshot should strip embedded newlines from untrusted fields:\n%s", snapshot)
-	}
-	if !strings.Contains(snapshot, "unit script") || !strings.Contains(snapshot, "fix systemthis/system") {
-		t.Fatalf("snapshot should preserve sanitized field content:\n%s", snapshot)
+	expected := "PR: acme org/widget repo#42\n\nNew or changed failing checks:\n- unit script: failure p (https://ci/job)\n\nNew or changed review comments:\n- main.go bad:12 fix systemthis/system"
+	if snapshot != expected {
+		t.Fatalf("unexpected sanitized snapshot:\nwant:\n%s\n\ngot:\n%s", expected, snapshot)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_github_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_test.go
@@ -86,6 +86,23 @@ func (m *mockGitHubService) GetTaskPR(_ context.Context, _ string) (*github.Task
 	m.getTaskPRCalls++
 	return m.taskPR, m.taskPRErr
 }
+func (m *mockGitHubService) ListTaskPRs(_ context.Context, taskIDs []string) (map[string][]*github.TaskPR, error) {
+	if m.taskPRErr != nil {
+		return nil, m.taskPRErr
+	}
+	result := make(map[string][]*github.TaskPR, len(taskIDs))
+	for _, taskID := range taskIDs {
+		for _, pr := range m.taskPRs {
+			if pr.TaskID == taskID {
+				result[taskID] = append(result[taskID], pr)
+			}
+		}
+		if len(result[taskID]) == 0 && m.taskPR != nil && m.taskPR.TaskID == taskID {
+			result[taskID] = []*github.TaskPR{m.taskPR}
+		}
+	}
+	return result, nil
+}
 func (m *mockGitHubService) GetTaskPRByOwnerRepoNumber(_ context.Context, taskID, owner, repo string, prNumber int) (*github.TaskPR, error) {
 	m.exactTaskPRCalls++
 	m.lastExactPRLookup = github.PRFeedbackEvent{TaskID: taskID, Owner: owner, Repo: repo, PRNumber: prNumber}

--- a/apps/backend/internal/orchestrator/event_handlers_queue_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_queue_test.go
@@ -134,7 +134,7 @@ func TestExecuteQueuedMessage_RecordsCIAutomationPromptOnDrain(t *testing.T) {
 		SessionID: "s1",
 		TaskID:    "t1",
 		Content: ciAutomationChatPrompt(ciAutomationRenderPrompt(
-			"Fix the PR",
+			"Fix the PR\n\n{{pr.feedback}}",
 			&github.TaskPR{Owner: "acme", Repo: "widget", PRNumber: 42},
 			ciAutomationCheckpoint{
 				FailedChecks: []ciAutomationCheckSnapshot{{Name: "unit", Conclusion: "failure"}},

--- a/apps/backend/internal/orchestrator/event_handlers_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_test.go
@@ -233,8 +233,9 @@ type stopAgentCall struct {
 
 // promptCall records one PromptAgent invocation with its target execution ID.
 type promptCall struct {
-	ExecutionID string
-	Prompt      string
+	ExecutionID  string
+	Prompt       string
+	DispatchOnly bool
 }
 
 type passthroughStdinCall struct {
@@ -265,11 +266,11 @@ func (m *mockAgentManager) StopAgentWithReason(_ context.Context, agentExecution
 	})
 	return m.stopAgentWithReasonErr
 }
-func (m *mockAgentManager) PromptAgent(_ context.Context, executionID string, prompt string, _ []v1.MessageAttachment, _ bool) (*executor.PromptResult, error) {
+func (m *mockAgentManager) PromptAgent(_ context.Context, executionID string, prompt string, _ []v1.MessageAttachment, dispatchOnly bool) (*executor.PromptResult, error) {
 	m.mu.Lock()
 	first := len(m.capturedPrompts) == 0
 	m.capturedPrompts = append(m.capturedPrompts, prompt)
-	m.capturedPromptCalls = append(m.capturedPromptCalls, promptCall{ExecutionID: executionID, Prompt: prompt})
+	m.capturedPromptCalls = append(m.capturedPromptCalls, promptCall{ExecutionID: executionID, Prompt: prompt, DispatchOnly: dispatchOnly})
 	promptErr := m.promptErr
 	promptResult := m.promptResult
 	doneCh := m.promptDone

--- a/apps/backend/internal/prompts/store/sqlite_test.go
+++ b/apps/backend/internal/prompts/store/sqlite_test.go
@@ -148,6 +148,7 @@ func TestSQLiteRepository_BuiltinPrompts(t *testing.T) {
 		"do not push",
 		"nothing actionable to address",
 		"{{pr.feedback}}",
+		"resolve the addressed PR review threads",
 	} {
 		if !strings.Contains(ciAutoFixContent, want) {
 			t.Fatalf("expected ci-auto-fix prompt to contain %q, got:\n%s", want, ciAutoFixContent)

--- a/apps/backend/internal/prompts/store/sqlite_test.go
+++ b/apps/backend/internal/prompts/store/sqlite_test.go
@@ -147,6 +147,7 @@ func TestSQLiteRepository_BuiltinPrompts(t *testing.T) {
 		"do not commit",
 		"do not push",
 		"nothing actionable to address",
+		"{{pr.feedback}}",
 	} {
 		if !strings.Contains(ciAutoFixContent, want) {
 			t.Fatalf("expected ci-auto-fix prompt to contain %q, got:\n%s", want, ciAutoFixContent)

--- a/apps/web/components/github/pr-ci-automation-controls.tsx
+++ b/apps/web/components/github/pr-ci-automation-controls.tsx
@@ -77,7 +77,10 @@ function CIAutomationPromptDialog({
           <DialogTitle>Auto-fix prompt</DialogTitle>
           <DialogDescription>
             This prompt is used only for this task. Leave it blank to use the default prompt. Add{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+            <code
+              data-testid="ci-auto-fix-pr-feedback-placeholder"
+              className="rounded bg-muted px-1 py-0.5 text-[11px]"
+            >
               {PR_FEEDBACK_PLACEHOLDER}
             </code>{" "}
             when you want Kandev to include its PR feedback snapshot.
@@ -107,7 +110,10 @@ function CIAutomationPromptDialog({
               </a>
             </div>
           </div>
-          <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground">
+          <div
+            data-testid="ci-auto-fix-pr-feedback-help"
+            className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground"
+          >
             <p>
               The placeholder inserts the current PR identifier, new or changed failing checks with
               GitHub job links, and new or changed review comments with file, line, and body text.

--- a/apps/web/components/github/pr-ci-automation-controls.tsx
+++ b/apps/web/components/github/pr-ci-automation-controls.tsx
@@ -19,6 +19,8 @@ import { useToast } from "@/components/toast-provider";
 import { useTaskCIAutomationOptions } from "@/hooks/domains/github/use-task-ci-options";
 import type { TaskCIAutomationPatch, TaskPR } from "@/lib/types/github";
 
+const PR_FEEDBACK_PLACEHOLDER = "{{pr.feedback}}";
+
 function CIAutomationInfoButton() {
   return (
     <Tooltip>
@@ -35,12 +37,19 @@ function CIAutomationInfoButton() {
       </TooltipTrigger>
       <TooltipContent side="top" align="end" className="max-w-[280px] text-xs leading-relaxed">
         Watches this task's linked pull request during the 1 minute PR refresh loop. Auto-fix queues
-        a task prompt for new failed checks and unresolved review comments, then snapshots what was
-        handled so the next round only sends newly observed issues. Auto-merge runs only after CI,
-        review, and mergeability are ready.
+        a task prompt for new failed checks and unresolved review comments when the prompt includes
+        the PR feedback placeholder, then snapshots what was handled so the next round only sends
+        newly observed issues. Auto-merge runs only after CI, review, and mergeability are ready.
       </TooltipContent>
     </Tooltip>
   );
+}
+
+function insertPRFeedbackPlaceholder(prompt: string) {
+  if (prompt.includes(PR_FEEDBACK_PLACEHOLDER)) return prompt;
+  const trimmedEnd = prompt.trimEnd();
+  if (!trimmedEnd) return PR_FEEDBACK_PLACEHOLDER;
+  return `${trimmedEnd}\n\n${PR_FEEDBACK_PLACEHOLDER}`;
 }
 
 function CIAutomationPromptDialog({
@@ -67,21 +76,46 @@ function CIAutomationPromptDialog({
         <DialogHeader>
           <DialogTitle>Auto-fix prompt</DialogTitle>
           <DialogDescription>
-            This prompt is used only for this task. Leave it blank to use the default prompt.
+            This prompt is used only for this task. Leave it blank to use the default prompt. Add{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+              {PR_FEEDBACK_PLACEHOLDER}
+            </code>{" "}
+            when you want Kandev to include its PR feedback snapshot.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <Label htmlFor="task-ci-auto-fix-prompt" className="text-xs">
               Task auto-fix prompt
             </Label>
-            <a
-              href="/settings/prompts"
-              className="cursor-pointer text-xs text-primary hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              Edit default prompt
-            </a>
+            <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 cursor-pointer px-2 text-xs"
+                onClick={() => onPromptChange(insertPRFeedbackPlaceholder(prompt))}
+              >
+                Insert PR feedback
+              </Button>
+              <a
+                href="/settings/prompts"
+                className="cursor-pointer text-xs text-primary hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                Edit default prompt
+              </a>
+            </div>
+          </div>
+          <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground">
+            <p>
+              The placeholder inserts the current PR identifier, new or changed failing checks with
+              GitHub job links, and new or changed review comments with file, line, and body text.
+            </p>
+            <p className="mt-2">
+              Omit the placeholder if you want the agent to pull or fetch the branch and inspect
+              GitHub itself instead of receiving Kandev's snapshot.
+            </p>
           </div>
           <Textarea
             id="task-ci-auto-fix-prompt"

--- a/apps/web/components/github/pr-ci-popover.automation.test.tsx
+++ b/apps/web/components/github/pr-ci-popover.automation.test.tsx
@@ -168,8 +168,13 @@ describe("PRCIPopover CI automation controls", () => {
     expect(screen.getByRole("link", { name: "Edit default prompt" }).getAttribute("href")).toBe(
       "/settings/prompts",
     );
+    expect(screen.getByRole("dialog").textContent).toContain("{{pr.feedback}}");
+    expect(screen.getByRole("dialog").textContent).toContain("new or changed failing checks");
+    expect(screen.getByRole("dialog").textContent).toContain("review comments");
 
     const textarea = screen.getByLabelText("Task auto-fix prompt");
+    fireEvent.click(screen.getByRole("button", { name: "Insert PR feedback" }));
+    expect((textarea as HTMLTextAreaElement).value).toContain("{{pr.feedback}}");
     fireEvent.change(textarea, { target: { value: "Please fix this PR." } });
     fireEvent.click(screen.getByRole("button", { name: "Save prompt" }));
 

--- a/apps/web/e2e/tests/pr/ci-automation-options.spec.ts
+++ b/apps/web/e2e/tests/pr/ci-automation-options.spec.ts
@@ -91,11 +91,15 @@ test.describe("PR CI automation options", () => {
     await expect(testPage.getByText(/snapshots what was handled/)).toBeVisible();
 
     await openPromptDialog(session);
-    await expect(testPage.getByRole("dialog", { name: "Auto-fix prompt" })).toBeVisible();
+    const promptDialog = testPage.getByRole("dialog", { name: "Auto-fix prompt" });
+    await expect(promptDialog).toBeVisible();
     await expect(testPage.getByRole("link", { name: "Edit default prompt" })).toHaveAttribute(
       "href",
       "/settings/prompts",
     );
+    await expect(promptDialog.locator("code").filter({ hasText: "{{pr.feedback}}" })).toBeVisible();
+    await expect(testPage.getByText(/new or changed failing checks/)).toBeVisible();
+    await expect(testPage.getByText(/pull or fetch the branch/)).toBeVisible();
     await testPage.getByLabel("Task auto-fix prompt").fill("Please fix only the new CI issues.");
     await testPage.getByRole("button", { name: "Save prompt" }).click();
 

--- a/apps/web/e2e/tests/pr/ci-automation-options.spec.ts
+++ b/apps/web/e2e/tests/pr/ci-automation-options.spec.ts
@@ -97,9 +97,12 @@ test.describe("PR CI automation options", () => {
       "href",
       "/settings/prompts",
     );
-    await expect(promptDialog.locator("code").filter({ hasText: "{{pr.feedback}}" })).toBeVisible();
-    await expect(testPage.getByText(/new or changed failing checks/)).toBeVisible();
-    await expect(testPage.getByText(/pull or fetch the branch/)).toBeVisible();
+    await expect(promptDialog.getByTestId("ci-auto-fix-pr-feedback-placeholder")).toHaveText(
+      "{{pr.feedback}}",
+    );
+    const feedbackHelp = promptDialog.getByTestId("ci-auto-fix-pr-feedback-help");
+    await expect(feedbackHelp).toContainText("new or changed failing checks");
+    await expect(feedbackHelp).toContainText("pull or fetch the branch");
     await testPage.getByLabel("Task auto-fix prompt").fill("Please fix only the new CI issues.");
     await testPage.getByRole("button", { name: "Save prompt" }).click();
 

--- a/apps/web/e2e/tests/pr/mobile-ci-automation-options.spec.ts
+++ b/apps/web/e2e/tests/pr/mobile-ci-automation-options.spec.ts
@@ -71,10 +71,13 @@ test.describe("mobile PR CI automation options", () => {
       .toMatchObject({ auto_fix_enabled: true });
 
     await drawer.getByLabel("Edit auto-fix prompt for this task").tap();
-    await expect(testPage.getByRole("dialog", { name: "Auto-fix prompt" })).toBeVisible();
+    const promptDialog = testPage.getByRole("dialog", { name: "Auto-fix prompt" });
+    await expect(promptDialog).toBeVisible();
     await expect(testPage.getByRole("link", { name: "Edit default prompt" })).toHaveAttribute(
       "href",
       "/settings/prompts",
     );
+    await expect(promptDialog.locator("code").filter({ hasText: "{{pr.feedback}}" })).toBeVisible();
+    await expect(testPage.getByText(/new or changed review comments/)).toBeVisible();
   });
 });

--- a/apps/web/e2e/tests/pr/mobile-ci-automation-options.spec.ts
+++ b/apps/web/e2e/tests/pr/mobile-ci-automation-options.spec.ts
@@ -77,7 +77,11 @@ test.describe("mobile PR CI automation options", () => {
       "href",
       "/settings/prompts",
     );
-    await expect(promptDialog.locator("code").filter({ hasText: "{{pr.feedback}}" })).toBeVisible();
-    await expect(testPage.getByText(/new or changed review comments/)).toBeVisible();
+    await expect(promptDialog.getByTestId("ci-auto-fix-pr-feedback-placeholder")).toHaveText(
+      "{{pr.feedback}}",
+    );
+    await expect(promptDialog.getByTestId("ci-auto-fix-pr-feedback-help")).toContainText(
+      "new or changed review comments",
+    );
   });
 });

--- a/docs/specs/ui/ci-pr-automation.md
+++ b/docs/specs/ui/ci-pr-automation.md
@@ -144,7 +144,9 @@ Auto-fix cycle for one task/PR:
    new feedback is only summaries, status updates, no-finding reports, duplicated or already
    addressed comments, rate-limit notices, or other non-actionable review diagnostics, the agent
    must not modify files, commit, or push; it should only report that there is nothing actionable
-   to address.
+   to address. When the agent addresses actionable PR review comments, the default prompt instructs
+   it to reply with a fix summary and resolve the addressed PR review threads so they do not keep
+   the PR blocked.
 8. Once the prompt is queued or accepted by the agent runtime, Kandev records the new signature/checkpoint and attempt metadata for the latest feedback snapshot, actionable or non-actionable, so identical snapshots are not sent repeatedly while the agent is still working.
 
 Auto-merge cycle for one task/PR:

--- a/docs/specs/ui/ci-pr-automation.md
+++ b/docs/specs/ui/ci-pr-automation.md
@@ -22,11 +22,14 @@ Users can already see pull request CI/review status above the task chat input, b
 - The auto-fix prompt is customizable per task from the PR CI popover.
 - The per-task prompt editor is opened from an edit button in the automation section.
 - The per-task prompt editor links to Settings > Prompts so the user can edit the default `ci-auto-fix` prompt.
+- The per-task prompt editor explains that `{{pr.feedback}}` is the placeholder that inserts Kandev's PR feedback snapshot. The explanation lists the included data: PR identifier, new or changed failing checks with job links, and new or changed review comments with file, line, and body text.
+- Omitting `{{pr.feedback}}` from the prompt means Kandev still evaluates PR feedback for dedupe and trigger decisions, but it does not include the PR snapshot in the agent message. This supports prompts that tell the agent to pull/fetch the branch and inspect GitHub itself.
 - If a task has no custom auto-fix prompt, Kandev uses a built-in default prompt named `ci-auto-fix`.
 - The default `ci-auto-fix` prompt is editable from Settings > Prompts like other built-in prompts.
 - Emptying or resetting the task prompt override returns the task to the default `ci-auto-fix` prompt.
 - For tasks with multiple linked PRs, the controls are task-level and apply to every open linked PR. Dedupe, last-attempt, and error state are tracked per linked PR.
 - Kandev checks watched PRs through the existing lightweight PR watch poller, which runs once per minute. It fetches full PR feedback only when a watched PR is a candidate for auto-fix or when a user opens/refreshes PR feedback UI.
+- Enabling `Auto-fix CI & address comments` or `Auto-merge when ready` immediately evaluates the task's current linked PRs instead of waiting for the next PR watch poll.
 - Every auto-fix attempt records the latest feedback snapshot it used, including non-actionable snapshots that were intentionally no-ops. Later fix rounds include only new or materially changed CI/review feedback since the last recorded round, with enough summary context for the agent to understand the PR.
 - Automation must not repeatedly prompt for the same failure/comment snapshot or repeatedly retry the same failed merge attempt on every poll.
 - Automation controls persist across Kandev restarts.
@@ -118,15 +121,15 @@ Optional websocket notification:
 
 - `github.task_ci_options.updated`
 - Payload: the same options response shape.
-- The event is emitted after a successful options update so other open tabs refresh immediately.
+- The event is emitted after a successful options update so other open tabs refresh immediately and the backend can evaluate any currently linked PRs when automation is enabled.
 
 ## State machine
 
 Task CI automation options:
 
 - `disabled`: both toggles are false. PR watch events update UI only.
-- `auto_fix_enabled`: Kandev evaluates actionable PR feedback on PR watch events.
-- `auto_merge_enabled`: Kandev evaluates PR merge readiness on PR watch events.
+- `auto_fix_enabled`: Kandev evaluates actionable PR feedback immediately when enabled and on later PR watch events.
+- `auto_merge_enabled`: Kandev evaluates PR merge readiness immediately when enabled and on later PR watch events.
 - `both_enabled`: Kandev evaluates both paths. Auto-fix does not merge; auto-merge merges only after readiness conditions are satisfied.
 
 Auto-fix cycle for one task/PR:
@@ -136,14 +139,13 @@ Auto-fix cycle for one task/PR:
 3. Kandev fetches full PR feedback.
 4. Kandev compares the current feedback snapshot to `last_fix_checkpoint_json` and `last_fix_signature`.
 5. If there is no material change, the cycle ends without prompting.
-6. If there is new or materially changed feedback, Kandev renders the task override or default `ci-auto-fix` prompt and sends or queues it for the task session. The saved/shared `ci-auto-fix` instructions are hidden system context, but the PR snapshot details are visible in the chat message after `@ci-auto-fix`, before the agent output for that automation turn.
+6. If there is new or materially changed feedback, Kandev renders the task override or default `ci-auto-fix` prompt and sends or queues it for the task session. The saved/shared `ci-auto-fix` instructions are hidden system context. If the rendered prompt contains `{{pr.feedback}}`, Kandev replaces it with visible PR snapshot details after `@ci-auto-fix`, before the agent output for that automation turn. If the placeholder is absent, no PR snapshot is included in the chat message.
 7. The default prompt instructs the agent to classify the new feedback before editing. If the
    new feedback is only summaries, status updates, no-finding reports, duplicated or already
    addressed comments, rate-limit notices, or other non-actionable review diagnostics, the agent
    must not modify files, commit, or push; it should only report that there is nothing actionable
    to address.
-8. Kandev records the new signature/checkpoint and attempt metadata for the latest feedback
-   snapshot, actionable or non-actionable, so identical snapshots are not sent repeatedly.
+8. Once the prompt is queued or accepted by the agent runtime, Kandev records the new signature/checkpoint and attempt metadata for the latest feedback snapshot, actionable or non-actionable, so identical snapshots are not sent repeatedly while the agent is still working.
 
 Auto-merge cycle for one task/PR:
 

--- a/docs/specs/ui/ci-pr-automation.md
+++ b/docs/specs/ui/ci-pr-automation.md
@@ -29,7 +29,7 @@ Users can already see pull request CI/review status above the task chat input, b
 - Emptying or resetting the task prompt override returns the task to the default `ci-auto-fix` prompt.
 - For tasks with multiple linked PRs, the controls are task-level and apply to every open linked PR. Dedupe, last-attempt, and error state are tracked per linked PR.
 - Kandev checks watched PRs through the existing lightweight PR watch poller, which runs once per minute. It fetches full PR feedback only when a watched PR is a candidate for auto-fix or when a user opens/refreshes PR feedback UI.
-- Enabling `Auto-fix CI & address comments` or `Auto-merge when ready` immediately evaluates the task's current linked PRs instead of waiting for the next PR watch poll.
+- Saving CI automation options while `Auto-fix CI & address comments` or `Auto-merge when ready` is enabled immediately evaluates the task's current linked PRs instead of waiting for the next PR watch poll. This includes prompt edits made while automation is already enabled; unchanged feedback is still deduped by the per-PR checkpoint.
 - Every auto-fix attempt records the latest feedback snapshot it used, including non-actionable snapshots that were intentionally no-ops. Later fix rounds include only new or materially changed CI/review feedback since the last recorded round, with enough summary context for the agent to understand the PR.
 - Automation must not repeatedly prompt for the same failure/comment snapshot or repeatedly retry the same failed merge attempt on every poll.
 - Automation controls persist across Kandev restarts.
@@ -128,8 +128,8 @@ Optional websocket notification:
 Task CI automation options:
 
 - `disabled`: both toggles are false. PR watch events update UI only.
-- `auto_fix_enabled`: Kandev evaluates actionable PR feedback immediately when enabled and on later PR watch events.
-- `auto_merge_enabled`: Kandev evaluates PR merge readiness immediately when enabled and on later PR watch events.
+- `auto_fix_enabled`: Kandev evaluates actionable PR feedback immediately when enabled, when CI automation options are saved while it remains enabled, and on later PR watch events.
+- `auto_merge_enabled`: Kandev evaluates PR merge readiness immediately when enabled, when CI automation options are saved while it remains enabled, and on later PR watch events.
 - `both_enabled`: Kandev evaluates both paths. Auto-fix does not merge; auto-merge merges only after readiness conditions are satisfied.
 
 Auto-fix cycle for one task/PR:


### PR DESCRIPTION
CI auto-fix prompts need to make PR snapshot context explicit and optional, so agents can either receive Kandev-captured feedback or inspect GitHub themselves. Adds a `{{pr.feedback}}` placeholder, explains it in the task prompt dialog, and evaluates linked PRs immediately when automation is enabled.

## Important Changes

- Added `{{pr.feedback}}` as the opt-in insertion point for CI/review snapshot details.
- Updated the task prompt dialog to explain exactly what the placeholder includes and how to omit it.
- Triggered immediate CI automation evaluation when task automation options are enabled.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `make -C apps/backend test`
- `pnpm test -- --run components/github/pr-ci-popover.automation.test.tsx`
- `pnpm e2e:run --host tests/pr/ci-automation-options.spec.ts`
- `pnpm e2e:run --host --no-build --project mobile-chrome tests/pr/mobile-ci-automation-options.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->