### PR TITLE
feat: add github repo filter search

### DIFF
--- a/apps/web/components/combobox.tsx
+++ b/apps/web/components/combobox.tsx
@@ -47,6 +47,7 @@ interface ComboboxProps {
   showSearch?: boolean;
   testId?: string;
   dropdownTestId?: string;
+  /** Backwards-compat alias rendered as data-legacy-testid for test id renames. */
   legacyDropdownTestId?: string;
   popoverSide?: "top" | "right" | "bottom" | "left";
   popoverAlign?: "start" | "center" | "end";

--- a/apps/web/components/combobox.tsx
+++ b/apps/web/components/combobox.tsx
@@ -46,6 +46,7 @@ interface ComboboxProps {
   triggerClassName?: string;
   showSearch?: boolean;
   testId?: string;
+  searchInputTestId?: string;
   popoverSide?: "top" | "right" | "bottom" | "left";
   popoverAlign?: "start" | "center" | "end";
   /** When true, the trigger always renders the plain label text instead of renderLabel. */
@@ -147,6 +148,7 @@ export const Combobox = memo(function Combobox({
   triggerClassName,
   showSearch = true,
   testId,
+  searchInputTestId,
   popoverSide,
   popoverAlign = "start",
   plainTrigger = false,
@@ -201,26 +203,28 @@ export const Combobox = memo(function Combobox({
         align={popoverAlign}
         portal={false}
       >
-        <Command value={highlighted} onValueChange={setHighlighted} filter={filter}>
-          {dropdownLabel || headerAction ? (
-            <div className="text-muted-foreground flex items-center justify-between gap-2 px-2 py-1 text-xs border-b">
-              <span>{dropdownLabel}</span>
-              {headerAction}
-            </div>
-          ) : null}
-          {showSearch && <CommandInput placeholder={searchPlaceholder} className="h-9" />}
-          <CommandList>
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
-            <OptionsList
-              options={options}
-              value={value}
-              onSelect={(v) => {
-                onValueChange(v === value ? "" : v);
-                setOpen(false);
-              }}
-            />
-          </CommandList>
-        </Command>
+        <div data-testid={searchInputTestId}>
+          <Command value={highlighted} onValueChange={setHighlighted} filter={filter}>
+            {dropdownLabel || headerAction ? (
+              <div className="text-muted-foreground flex items-center justify-between gap-2 px-2 py-1 text-xs border-b">
+                <span>{dropdownLabel}</span>
+                {headerAction}
+              </div>
+            ) : null}
+            {showSearch && <CommandInput placeholder={searchPlaceholder} className="h-9" />}
+            <CommandList>
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+              <OptionsList
+                options={options}
+                value={value}
+                onSelect={(v) => {
+                  onValueChange(v === value ? "" : v);
+                  setOpen(false);
+                }}
+              />
+            </CommandList>
+          </Command>
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/components/combobox.tsx
+++ b/apps/web/components/combobox.tsx
@@ -47,8 +47,6 @@ interface ComboboxProps {
   showSearch?: boolean;
   testId?: string;
   dropdownTestId?: string;
-  /** Backwards-compat alias rendered as data-legacy-testid for test id renames. */
-  legacyDropdownTestId?: string;
   popoverSide?: "top" | "right" | "bottom" | "left";
   popoverAlign?: "start" | "center" | "end";
   /** When true, the trigger always renders the plain label text instead of renderLabel. */
@@ -151,7 +149,6 @@ export const Combobox = memo(function Combobox({
   showSearch = true,
   testId,
   dropdownTestId,
-  legacyDropdownTestId,
   popoverSide,
   popoverAlign = "start",
   plainTrigger = false,
@@ -211,7 +208,6 @@ export const Combobox = memo(function Combobox({
           onValueChange={setHighlighted}
           filter={filter}
           data-testid={dropdownTestId}
-          data-legacy-testid={legacyDropdownTestId}
         >
           {dropdownLabel || headerAction ? (
             <div className="text-muted-foreground flex items-center justify-between gap-2 px-2 py-1 text-xs border-b">

--- a/apps/web/components/combobox.tsx
+++ b/apps/web/components/combobox.tsx
@@ -46,7 +46,7 @@ interface ComboboxProps {
   triggerClassName?: string;
   showSearch?: boolean;
   testId?: string;
-  searchInputTestId?: string;
+  dropdownTestId?: string;
   popoverSide?: "top" | "right" | "bottom" | "left";
   popoverAlign?: "start" | "center" | "end";
   /** When true, the trigger always renders the plain label text instead of renderLabel. */
@@ -148,7 +148,7 @@ export const Combobox = memo(function Combobox({
   triggerClassName,
   showSearch = true,
   testId,
-  searchInputTestId,
+  dropdownTestId,
   popoverSide,
   popoverAlign = "start",
   plainTrigger = false,
@@ -203,28 +203,31 @@ export const Combobox = memo(function Combobox({
         align={popoverAlign}
         portal={false}
       >
-        <div data-testid={searchInputTestId}>
-          <Command value={highlighted} onValueChange={setHighlighted} filter={filter}>
-            {dropdownLabel || headerAction ? (
-              <div className="text-muted-foreground flex items-center justify-between gap-2 px-2 py-1 text-xs border-b">
-                <span>{dropdownLabel}</span>
-                {headerAction}
-              </div>
-            ) : null}
-            {showSearch && <CommandInput placeholder={searchPlaceholder} className="h-9" />}
-            <CommandList>
-              <CommandEmpty>{emptyMessage}</CommandEmpty>
-              <OptionsList
-                options={options}
-                value={value}
-                onSelect={(v) => {
-                  onValueChange(v === value ? "" : v);
-                  setOpen(false);
-                }}
-              />
-            </CommandList>
-          </Command>
-        </div>
+        <Command
+          value={highlighted}
+          onValueChange={setHighlighted}
+          filter={filter}
+          data-testid={dropdownTestId}
+        >
+          {dropdownLabel || headerAction ? (
+            <div className="text-muted-foreground flex items-center justify-between gap-2 px-2 py-1 text-xs border-b">
+              <span>{dropdownLabel}</span>
+              {headerAction}
+            </div>
+          ) : null}
+          {showSearch && <CommandInput placeholder={searchPlaceholder} className="h-9" />}
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            <OptionsList
+              options={options}
+              value={value}
+              onSelect={(v) => {
+                onValueChange(v === value ? "" : v);
+                setOpen(false);
+              }}
+            />
+          </CommandList>
+        </Command>
       </PopoverContent>
     </Popover>
   );

--- a/apps/web/components/combobox.tsx
+++ b/apps/web/components/combobox.tsx
@@ -47,6 +47,7 @@ interface ComboboxProps {
   showSearch?: boolean;
   testId?: string;
   dropdownTestId?: string;
+  legacyDropdownTestId?: string;
   popoverSide?: "top" | "right" | "bottom" | "left";
   popoverAlign?: "start" | "center" | "end";
   /** When true, the trigger always renders the plain label text instead of renderLabel. */
@@ -149,6 +150,7 @@ export const Combobox = memo(function Combobox({
   showSearch = true,
   testId,
   dropdownTestId,
+  legacyDropdownTestId,
   popoverSide,
   popoverAlign = "start",
   plainTrigger = false,
@@ -208,6 +210,7 @@ export const Combobox = memo(function Combobox({
           onValueChange={setHighlighted}
           filter={filter}
           data-testid={dropdownTestId}
+          data-legacy-testid={legacyDropdownTestId}
         >
           {dropdownLabel || headerAction ? (
             <div className="text-muted-foreground flex items-center justify-between gap-2 px-2 py-1 text-xs border-b">

--- a/apps/web/components/github/my-github/list-toolbar.test.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.test.tsx
@@ -7,6 +7,7 @@ afterEach(() => cleanup());
 
 const ALL_REPOS_LABEL = "All repos";
 const REPO_SEARCH_PLACEHOLDER = "Filter repositories...";
+const REPO_SEARCH_TEST_ID = "github-repo-filter-search";
 const KANDEV_REPO = "kdlbs/kandev";
 
 function renderToolbar() {
@@ -39,6 +40,7 @@ describe("ListToolbar", () => {
     fireEvent.click(screen.getByText(ALL_REPOS_LABEL));
 
     expect(await screen.findByPlaceholderText(REPO_SEARCH_PLACEHOLDER)).toBeTruthy();
+    expect(screen.getByTestId(REPO_SEARCH_TEST_ID)).toBeTruthy();
     expect(screen.getByText(KANDEV_REPO)).toBeTruthy();
   });
 

--- a/apps/web/components/github/my-github/list-toolbar.test.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@kandev/ui/tooltip";
+import { ListToolbar } from "./list-toolbar";
+
+afterEach(() => cleanup());
+
+function renderToolbar() {
+  render(
+    <TooltipProvider>
+      <ListToolbar
+        title="Review requested"
+        count={2}
+        loading={false}
+        lastFetchedAt={null}
+        customQuery="is:open"
+        committedQuery="is:open"
+        onCustomQueryChange={vi.fn()}
+        onCommitCustomQuery={vi.fn()}
+        repoFilter=""
+        onRepoFilterChange={vi.fn()}
+        repoOptions={["acme/api", "kdlbs/kandev"]}
+        onRefresh={vi.fn()}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("ListToolbar", () => {
+  it("opens the repository filter with a search input", async () => {
+    renderToolbar();
+
+    fireEvent.click(screen.getByText("All repos"));
+
+    expect(await screen.findByPlaceholderText("Filter repositories...")).toBeTruthy();
+    expect(screen.getByText("kdlbs/kandev")).toBeTruthy();
+  });
+});

--- a/apps/web/components/github/my-github/list-toolbar.test.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.test.tsx
@@ -5,7 +5,12 @@ import { ListToolbar } from "./list-toolbar";
 
 afterEach(() => cleanup());
 
+const ALL_REPOS_LABEL = "All repos";
+const REPO_SEARCH_PLACEHOLDER = "Filter repositories...";
+const KANDEV_REPO = "kdlbs/kandev";
+
 function renderToolbar() {
+  const onRepoFilterChange = vi.fn();
   render(
     <TooltipProvider>
       <ListToolbar
@@ -18,21 +23,43 @@ function renderToolbar() {
         onCustomQueryChange={vi.fn()}
         onCommitCustomQuery={vi.fn()}
         repoFilter=""
-        onRepoFilterChange={vi.fn()}
-        repoOptions={["acme/api", "kdlbs/kandev"]}
+        onRepoFilterChange={onRepoFilterChange}
+        repoOptions={["acme/api", KANDEV_REPO]}
         onRefresh={vi.fn()}
       />
     </TooltipProvider>,
   );
+  return { onRepoFilterChange };
 }
 
 describe("ListToolbar", () => {
   it("opens the repository filter with a search input", async () => {
     renderToolbar();
 
-    fireEvent.click(screen.getByText("All repos"));
+    fireEvent.click(screen.getByText(ALL_REPOS_LABEL));
 
-    expect(await screen.findByPlaceholderText("Filter repositories...")).toBeTruthy();
-    expect(screen.getByText("kdlbs/kandev")).toBeTruthy();
+    expect(await screen.findByPlaceholderText(REPO_SEARCH_PLACEHOLDER)).toBeTruthy();
+    expect(screen.getByText(KANDEV_REPO)).toBeTruthy();
+  });
+
+  it("filters and selects a repository", async () => {
+    const { onRepoFilterChange } = renderToolbar();
+
+    fireEvent.click(screen.getByText(ALL_REPOS_LABEL));
+    fireEvent.change(await screen.findByPlaceholderText(REPO_SEARCH_PLACEHOLDER), {
+      target: { value: "kdlbs" },
+    });
+    fireEvent.click(await screen.findByRole("option", { name: KANDEV_REPO }));
+
+    expect(onRepoFilterChange).toHaveBeenCalledWith(KANDEV_REPO);
+  });
+
+  it("clears the repository filter from the All repos option", async () => {
+    const { onRepoFilterChange } = renderToolbar();
+
+    fireEvent.click(screen.getByText(ALL_REPOS_LABEL));
+    fireEvent.click(await screen.findByRole("option", { name: ALL_REPOS_LABEL }));
+
+    expect(onRepoFilterChange).toHaveBeenCalledWith("");
   });
 });

--- a/apps/web/components/github/my-github/list-toolbar.test.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.test.tsx
@@ -8,7 +8,6 @@ afterEach(() => cleanup());
 const ALL_REPOS_LABEL = "All repos";
 const REPO_SEARCH_PLACEHOLDER = "Filter repositories...";
 const REPO_DROPDOWN_TEST_ID = "github-repo-filter-dropdown";
-const LEGACY_REPO_DROPDOWN_TEST_ID = "github-repo-filter-search";
 const KANDEV_REPO = "kdlbs/kandev";
 
 function renderToolbar({ repoFilter = "" }: { repoFilter?: string } = {}) {
@@ -42,9 +41,6 @@ describe("ListToolbar", () => {
 
     expect(await screen.findByPlaceholderText(REPO_SEARCH_PLACEHOLDER)).toBeTruthy();
     expect(screen.getByTestId(REPO_DROPDOWN_TEST_ID)).toBeTruthy();
-    expect(screen.getByTestId(REPO_DROPDOWN_TEST_ID).dataset.legacyTestid).toBe(
-      LEGACY_REPO_DROPDOWN_TEST_ID,
-    );
     expect(screen.getByText(KANDEV_REPO)).toBeTruthy();
   });
 

--- a/apps/web/components/github/my-github/list-toolbar.test.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.test.tsx
@@ -8,6 +8,7 @@ afterEach(() => cleanup());
 const ALL_REPOS_LABEL = "All repos";
 const REPO_SEARCH_PLACEHOLDER = "Filter repositories...";
 const REPO_DROPDOWN_TEST_ID = "github-repo-filter-dropdown";
+const LEGACY_REPO_DROPDOWN_TEST_ID = "github-repo-filter-search";
 const KANDEV_REPO = "kdlbs/kandev";
 
 function renderToolbar({ repoFilter = "" }: { repoFilter?: string } = {}) {
@@ -41,6 +42,9 @@ describe("ListToolbar", () => {
 
     expect(await screen.findByPlaceholderText(REPO_SEARCH_PLACEHOLDER)).toBeTruthy();
     expect(screen.getByTestId(REPO_DROPDOWN_TEST_ID)).toBeTruthy();
+    expect(screen.getByTestId(REPO_DROPDOWN_TEST_ID).dataset.legacyTestid).toBe(
+      LEGACY_REPO_DROPDOWN_TEST_ID,
+    );
     expect(screen.getByText(KANDEV_REPO)).toBeTruthy();
   });
 

--- a/apps/web/components/github/my-github/list-toolbar.test.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.test.tsx
@@ -7,10 +7,10 @@ afterEach(() => cleanup());
 
 const ALL_REPOS_LABEL = "All repos";
 const REPO_SEARCH_PLACEHOLDER = "Filter repositories...";
-const REPO_SEARCH_TEST_ID = "github-repo-filter-search";
+const REPO_DROPDOWN_TEST_ID = "github-repo-filter-dropdown";
 const KANDEV_REPO = "kdlbs/kandev";
 
-function renderToolbar() {
+function renderToolbar({ repoFilter = "" }: { repoFilter?: string } = {}) {
   const onRepoFilterChange = vi.fn();
   render(
     <TooltipProvider>
@@ -23,7 +23,7 @@ function renderToolbar() {
         committedQuery="is:open"
         onCustomQueryChange={vi.fn()}
         onCommitCustomQuery={vi.fn()}
-        repoFilter=""
+        repoFilter={repoFilter}
         onRepoFilterChange={onRepoFilterChange}
         repoOptions={["acme/api", KANDEV_REPO]}
         onRefresh={vi.fn()}
@@ -40,7 +40,7 @@ describe("ListToolbar", () => {
     fireEvent.click(screen.getByText(ALL_REPOS_LABEL));
 
     expect(await screen.findByPlaceholderText(REPO_SEARCH_PLACEHOLDER)).toBeTruthy();
-    expect(screen.getByTestId(REPO_SEARCH_TEST_ID)).toBeTruthy();
+    expect(screen.getByTestId(REPO_DROPDOWN_TEST_ID)).toBeTruthy();
     expect(screen.getByText(KANDEV_REPO)).toBeTruthy();
   });
 
@@ -57,11 +57,20 @@ describe("ListToolbar", () => {
   });
 
   it("clears the repository filter from the All repos option", async () => {
-    const { onRepoFilterChange } = renderToolbar();
+    const { onRepoFilterChange } = renderToolbar({ repoFilter: KANDEV_REPO });
 
-    fireEvent.click(screen.getByText(ALL_REPOS_LABEL));
+    fireEvent.click(screen.getByText(KANDEV_REPO));
     fireEvent.click(await screen.findByRole("option", { name: ALL_REPOS_LABEL }));
 
     expect(onRepoFilterChange).toHaveBeenCalledWith("");
+  });
+
+  it("preserves the repository filter when the selected repository is reselected", async () => {
+    const { onRepoFilterChange } = renderToolbar({ repoFilter: KANDEV_REPO });
+
+    fireEvent.click(screen.getByText(KANDEV_REPO));
+    fireEvent.click(await screen.findByRole("option", { name: KANDEV_REPO }));
+
+    expect(onRepoFilterChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -111,7 +111,6 @@ export function ListToolbar({
         emptyMessage="No repositories found."
         triggerClassName="w-full md:w-[220px] h-8 border border-input bg-background hover:bg-secondary/50 px-2 py-1.5 text-xs/relaxed"
         className="md:min-w-[360px]"
-        plainTrigger
         testId="github-repo-filter-trigger"
       />
       <div className="w-full md:flex-1 md:min-w-[240px] relative">

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -112,6 +112,7 @@ export function ListToolbar({
         triggerClassName="w-full md:w-[220px] h-8 border border-input bg-background hover:bg-secondary/50 px-2 py-1.5 text-xs/relaxed"
         className="md:min-w-[360px]"
         testId="github-repo-filter-trigger"
+        searchInputTestId="github-repo-filter-search"
       />
       <div className="w-full md:flex-1 md:min-w-[240px] relative">
         <Input

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -117,7 +117,6 @@ export function ListToolbar({
         className="md:min-w-[360px]"
         testId="github-repo-filter-trigger"
         dropdownTestId="github-repo-filter-dropdown"
-        legacyDropdownTestId="github-repo-filter-search"
       />
       <div className="w-full md:flex-1 md:min-w-[240px] relative">
         <Input

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -104,7 +104,10 @@ export function ListToolbar({
       </div>
       <Combobox
         value={selectValue}
-        onValueChange={(v) => onRepoFilterChange(v === ALL_REPOS || !v ? "" : v)}
+        onValueChange={(v) => {
+          if (!v) return;
+          onRepoFilterChange(v === ALL_REPOS ? "" : v);
+        }}
         options={repoFilterOptions}
         placeholder="All repos"
         searchPlaceholder="Filter repositories..."
@@ -112,7 +115,7 @@ export function ListToolbar({
         triggerClassName="w-full md:w-[220px] h-8 border border-input bg-background hover:bg-secondary/50 px-2 py-1.5 text-xs/relaxed"
         className="md:min-w-[360px]"
         testId="github-repo-filter-trigger"
-        searchInputTestId="github-repo-filter-search"
+        dropdownTestId="github-repo-filter-dropdown"
       />
       <div className="w-full md:flex-1 md:min-w-[240px] relative">
         <Input

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -105,6 +105,7 @@ export function ListToolbar({
       <Combobox
         value={selectValue}
         onValueChange={(v) => {
+          // Combobox signals "toggle off" with ""; All repos is the explicit clear path.
           if (!v) return;
           onRepoFilterChange(v === ALL_REPOS ? "" : v);
         }}
@@ -116,6 +117,7 @@ export function ListToolbar({
         className="md:min-w-[360px]"
         testId="github-repo-filter-trigger"
         dropdownTestId="github-repo-filter-dropdown"
+        legacyDropdownTestId="github-repo-filter-search"
       />
       <div className="w-full md:flex-1 md:min-w-[240px] relative">
         <Input

--- a/apps/web/components/github/my-github/list-toolbar.tsx
+++ b/apps/web/components/github/my-github/list-toolbar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useMemo } from "react";
 import { IconRefresh } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Input } from "@kandev/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
+import { Combobox, type ComboboxOption } from "@/components/combobox";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/utils";
 
@@ -57,6 +58,13 @@ function RefreshControls({
   );
 }
 
+function buildRepoFilterOptions(repoOptions: string[]): ComboboxOption[] {
+  return [
+    { value: ALL_REPOS, label: "All repos", keywords: ["all", "repositories", "repos"] },
+    ...repoOptions.map((key) => ({ value: key, label: key, keywords: [key] })),
+  ];
+}
+
 export function ListToolbar({
   title,
   count,
@@ -73,6 +81,7 @@ export function ListToolbar({
 }: ListToolbarProps) {
   const selectValue = repoFilter || ALL_REPOS;
   const dirty = customQuery !== committedQuery;
+  const repoFilterOptions = useMemo(() => buildRepoFilterOptions(repoOptions), [repoOptions]);
   return (
     <div className="px-4 sm:px-6 py-2.5 border-b shrink-0 flex flex-col md:flex-row md:items-center md:flex-wrap gap-2 md:gap-3">
       <div className="flex items-center gap-2 min-w-0">
@@ -93,24 +102,18 @@ export function ListToolbar({
           />
         </div>
       </div>
-      <Select
+      <Combobox
         value={selectValue}
-        onValueChange={(v) => onRepoFilterChange(v === ALL_REPOS ? "" : v)}
-      >
-        <SelectTrigger className="w-full md:w-[220px] h-8 cursor-pointer">
-          <SelectValue placeholder="All repos" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={ALL_REPOS} className="cursor-pointer">
-            All repos
-          </SelectItem>
-          {repoOptions.map((key) => (
-            <SelectItem key={key} value={key} className="cursor-pointer">
-              {key}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        onValueChange={(v) => onRepoFilterChange(v === ALL_REPOS || !v ? "" : v)}
+        options={repoFilterOptions}
+        placeholder="All repos"
+        searchPlaceholder="Filter repositories..."
+        emptyMessage="No repositories found."
+        triggerClassName="w-full md:w-[220px] h-8 border border-input bg-background hover:bg-secondary/50 px-2 py-1.5 text-xs/relaxed"
+        className="md:min-w-[360px]"
+        plainTrigger
+        testId="github-repo-filter-trigger"
+      />
       <div className="w-full md:flex-1 md:min-w-[240px] relative">
         <Input
           value={customQuery}

--- a/apps/web/e2e/pages/mobile-github-page.ts
+++ b/apps/web/e2e/pages/mobile-github-page.ts
@@ -16,7 +16,7 @@ export class MobileGitHubPage {
     this.inlineSidebar = page.getByTestId("github-presets-scope-bar");
     this.toolbarTitle = page.getByTestId("github-list-toolbar-title");
     this.repoFilterTrigger = page.getByTestId("github-repo-filter-trigger");
-    this.repoSearchInput = page.getByTestId("github-repo-filter-search").getByRole("combobox");
+    this.repoSearchInput = page.getByTestId("github-repo-filter-dropdown").getByRole("combobox");
   }
 
   async goto() {

--- a/apps/web/e2e/pages/mobile-github-page.ts
+++ b/apps/web/e2e/pages/mobile-github-page.ts
@@ -5,6 +5,8 @@ export class MobileGitHubPage {
   readonly mobileSidebar: Locator;
   readonly inlineSidebar: Locator;
   readonly toolbarTitle: Locator;
+  readonly repoFilterTrigger: Locator;
+  readonly repoSearchInput: Locator;
 
   constructor(private page: Page) {
     this.mobileMenuButton = page.getByTestId("github-mobile-menu-button");
@@ -13,6 +15,8 @@ export class MobileGitHubPage {
     // mobile, where the presets live in the hamburger sheet instead.
     this.inlineSidebar = page.getByTestId("github-presets-scope-bar");
     this.toolbarTitle = page.getByTestId("github-list-toolbar-title");
+    this.repoFilterTrigger = page.getByTestId("github-repo-filter-trigger");
+    this.repoSearchInput = page.getByPlaceholder("Filter repositories...");
   }
 
   async goto() {

--- a/apps/web/e2e/pages/mobile-github-page.ts
+++ b/apps/web/e2e/pages/mobile-github-page.ts
@@ -16,7 +16,7 @@ export class MobileGitHubPage {
     this.inlineSidebar = page.getByTestId("github-presets-scope-bar");
     this.toolbarTitle = page.getByTestId("github-list-toolbar-title");
     this.repoFilterTrigger = page.getByTestId("github-repo-filter-trigger");
-    this.repoSearchInput = page.getByPlaceholder("Filter repositories...");
+    this.repoSearchInput = page.getByTestId("github-repo-filter-search").getByRole("combobox");
   }
 
   async goto() {

--- a/apps/web/e2e/tests/github/github-scope-bar.spec.ts
+++ b/apps/web/e2e/tests/github/github-scope-bar.spec.ts
@@ -74,7 +74,7 @@ test.describe("Desktop /github scope bar", () => {
     await testPage.goto("/github");
 
     await testPage.getByTestId("github-repo-filter-trigger").click();
-    const search = testPage.getByPlaceholder("Filter repositories...");
+    const search = testPage.getByTestId("github-repo-filter-search").getByRole("combobox");
     await expect(search).toBeVisible();
 
     await search.fill("testorg");

--- a/apps/web/e2e/tests/github/github-scope-bar.spec.ts
+++ b/apps/web/e2e/tests/github/github-scope-bar.spec.ts
@@ -44,4 +44,43 @@ test.describe("Desktop /github scope bar", () => {
     await scopeBar.getByRole("button", { name: "Issues" }).click();
     await expect(title).toContainText("Assigned");
   });
+
+  test("repo filter menu can be searched", async ({ testPage, apiClient }) => {
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 21,
+        title: "Searchable repo filter PR",
+        state: "open",
+        head_branch: "feat/search",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: "testorg",
+        repo_name: "testrepo",
+      },
+      {
+        number: 22,
+        title: "Searchable repo filter second PR",
+        state: "open",
+        head_branch: "feat/other",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: "anotherorg",
+        repo_name: "secondrepo",
+      },
+    ]);
+
+    await testPage.goto("/github");
+
+    await testPage.getByTestId("github-repo-filter-trigger").click();
+    const search = testPage.getByPlaceholder("Filter repositories...");
+    await expect(search).toBeVisible();
+
+    await search.fill("testorg");
+    await testPage.getByRole("option", { name: "testorg/testrepo" }).click();
+    await expect(testPage.getByTestId("github-repo-filter-trigger")).toContainText(
+      "testorg/testrepo",
+    );
+  });
 });

--- a/apps/web/e2e/tests/github/github-scope-bar.spec.ts
+++ b/apps/web/e2e/tests/github/github-scope-bar.spec.ts
@@ -74,7 +74,7 @@ test.describe("Desktop /github scope bar", () => {
     await testPage.goto("/github");
 
     await testPage.getByTestId("github-repo-filter-trigger").click();
-    const search = testPage.getByTestId("github-repo-filter-search").getByRole("combobox");
+    const search = testPage.getByTestId("github-repo-filter-dropdown").getByRole("combobox");
     await expect(search).toBeVisible();
 
     await search.fill("testorg");

--- a/apps/web/e2e/tests/github/mobile-github-sidebar.spec.ts
+++ b/apps/web/e2e/tests/github/mobile-github-sidebar.spec.ts
@@ -45,4 +45,41 @@ test.describe("Mobile /github sidebar", () => {
     await expect(page.mobileSidebar).toBeHidden();
     await expect(page.toolbarTitle).toContainText("Mentions");
   });
+
+  test("repo filter menu can be searched", async ({ testPage, apiClient }) => {
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 210,
+        title: "Mobile repo search PR",
+        state: "open",
+        head_branch: "feat/mobile-search",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: "testorg",
+        repo_name: "testrepo",
+      },
+      {
+        number: 211,
+        title: "Mobile repo search second PR",
+        state: "open",
+        head_branch: "feat/mobile-other",
+        base_branch: "main",
+        author_login: "test-user",
+        repo_owner: "anotherorg",
+        repo_name: "secondrepo",
+      },
+    ]);
+
+    const page = new MobileGitHubPage(testPage);
+    await page.goto();
+
+    await page.repoFilterTrigger.tap();
+    await expect(page.repoSearchInput).toBeVisible();
+
+    await page.repoSearchInput.fill("testorg");
+    await testPage.getByRole("option", { name: "testorg/testrepo" }).tap();
+    await expect(page.repoFilterTrigger).toContainText("testorg/testrepo");
+  });
 });


### PR DESCRIPTION
The GitHub repo filter was hard to use with large accessible-repo lists. The filter now uses the shared searchable combobox so users can type to find and select a repo on desktop and mobile.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e -- --project=chromium tests/github/github-scope-bar.spec.ts`
- `pnpm e2e -- --project=mobile-chrome tests/github/mobile-github-sidebar.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->