### PR TITLE
fix: repair workspace deletion and github context

### DIFF
--- a/apps/backend/internal/office/repository/sqlite/workspace_deletion.go
+++ b/apps/backend/internal/office/repository/sqlite/workspace_deletion.go
@@ -51,7 +51,10 @@ func (r *Repository) deleteWorkspaceDataTx(ctx context.Context, tx *sqlx.Tx, wor
 	// We delete them via the merged table; shallow kanban profiles
 	// (workspace_id = '') are unaffected.
 	statements := []string{
+		`DELETE FROM office_run_route_attempts WHERE run_id IN (SELECT id FROM runs WHERE agent_profile_id IN (SELECT id FROM agent_profiles WHERE workspace_id = ?))`,
 		`DELETE FROM runs WHERE agent_profile_id IN (SELECT id FROM agent_profiles WHERE workspace_id = ?)`,
+		`DELETE FROM office_provider_health WHERE workspace_id = ?`,
+		`DELETE FROM office_workspace_routing WHERE workspace_id = ?`,
 		`DELETE FROM office_agent_memory WHERE agent_profile_id IN (SELECT id FROM agent_profiles WHERE workspace_id = ?)`,
 		`DELETE FROM office_agent_instructions WHERE agent_profile_id IN (SELECT id FROM agent_profiles WHERE workspace_id = ?)`,
 		`DELETE FROM office_agent_runtime WHERE agent_id IN (SELECT id FROM agent_profiles WHERE workspace_id = ?)`,

--- a/apps/backend/internal/office/repository/sqlite/workspace_deletion_test.go
+++ b/apps/backend/internal/office/repository/sqlite/workspace_deletion_test.go
@@ -32,6 +32,9 @@ func TestDeleteWorkspaceDataDeletesOwnedOfficeRows(t *testing.T) {
 		"office_agent_instructions",
 		"office_agent_runtime",
 		"runs",
+		"office_run_route_attempts",
+		"office_provider_health",
+		"office_workspace_routing",
 		"office_routine_triggers",
 		"office_routine_runs",
 		"office_task_labels",
@@ -99,6 +102,9 @@ func seedWorkspaceDeletionRows(t *testing.T, repo *sqlite.Repository, workspaceI
 	execRaw(t, repo, `INSERT INTO office_agent_memory (id, agent_profile_id, layer, key, created_at, updated_at) VALUES (?, ?, 'project', 'note', ?, ?)`, workspaceID+"-memory", agentID, now, now)
 	execRaw(t, repo, `INSERT INTO office_agent_instructions (id, agent_profile_id, filename, content, created_at, updated_at) VALUES (?, ?, 'guide.md', 'content', ?, ?)`, workspaceID+"-instruction", agentID, now, now)
 	execRaw(t, repo, `INSERT INTO runs (id, agent_profile_id, reason, requested_at) VALUES (?, ?, 'test', ?)`, workspaceID+"-run", agentID, now)
+	execRaw(t, repo, `INSERT INTO office_run_route_attempts (run_id, seq, provider_id, model, tier, outcome, started_at) VALUES (?, 1, 'codex', 'gpt-5', 'balanced', 'launched', ?)`, workspaceID+"-run", now)
+	execRaw(t, repo, `INSERT INTO office_provider_health (workspace_id, provider_id, scope, scope_value, state) VALUES (?, 'codex', 'workspace', ?, 'degraded')`, workspaceID, workspaceID)
+	execRaw(t, repo, `INSERT INTO office_workspace_routing (workspace_id, enabled, default_tier, provider_order, provider_profiles, tier_per_reason) VALUES (?, 1, 'balanced', '[]', '{}', '{}')`, workspaceID)
 	execRaw(t, repo, `INSERT INTO office_cost_events (id, agent_profile_id, project_id, occurred_at, created_at) VALUES (?, ?, ?, ?, ?)`, workspaceID+"-cost", agentID, projectID, now, now)
 	execRaw(t, repo, `INSERT INTO office_budget_policies (id, workspace_id, scope_type, scope_id, limit_subcents, period, created_at, updated_at) VALUES (?, ?, 'workspace', ?, 100, 'month', ?, ?)`, workspaceID+"-budget", workspaceID, workspaceID, now, now)
 	execRaw(t, repo, `INSERT INTO office_routines (id, workspace_id, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`, routineID, workspaceID, "Routine "+workspaceID, now, now)
@@ -169,6 +175,8 @@ func workspaceDeletionTableSpec(table string) workspaceDeletionCountSpec {
 		return workspaceDeletionCountSpec{column: "id", operator: "LIKE", value: likeID}
 	case "office_agent_memory", "office_agent_instructions", "runs":
 		return workspaceDeletionCountSpec{column: "agent_profile_id", operator: "LIKE", value: likeID}
+	case "office_run_route_attempts":
+		return workspaceDeletionCountSpec{column: "run_id", operator: "LIKE", value: likeID}
 	case "office_agent_runtime":
 		return workspaceDeletionCountSpec{column: "agent_id", operator: "LIKE", value: likeID}
 	case "office_routine_triggers", "office_routine_runs":

--- a/apps/web/app/github/page.test.tsx
+++ b/apps/web/app/github/page.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listWorkspacesAction: vi.fn(),
+  listWorkflowsAction: vi.fn(),
+  listRepositoriesAction: vi.fn(),
+  listWorkspaceWorkflowStepsAction: vi.fn(),
+  fetchUserSettings: vi.fn(),
+  readCookies: vi.fn(),
+  stateHydrator: vi.fn(),
+  pageClient: vi.fn(),
+}));
+
+vi.mock("@/app/actions/workspaces", () => ({
+  listWorkspacesAction: mocks.listWorkspacesAction,
+  listWorkflowsAction: mocks.listWorkflowsAction,
+  listRepositoriesAction: mocks.listRepositoriesAction,
+  listWorkspaceWorkflowStepsAction: mocks.listWorkspaceWorkflowStepsAction,
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchUserSettings: mocks.fetchUserSettings,
+}));
+
+vi.mock("@/lib/server/cookies", () => ({
+  readCookies: mocks.readCookies,
+}));
+
+vi.mock("@/components/state-hydrator", () => ({
+  StateHydrator: (props: { initialState: unknown }) => {
+    mocks.stateHydrator(props);
+    return <div data-testid="state-hydrator" />;
+  },
+}));
+
+vi.mock("./github-page-client", () => ({
+  GitHubPageClient: (props: { workspaceId?: string }) => {
+    mocks.pageClient(props);
+    return <div data-testid="github-page-client" />;
+  },
+}));
+
+import GitHubPage from "./page";
+
+const ACTIVE_WORKSPACE_COOKIE = "kandev-active-workspace";
+const WORKSPACE_TIMESTAMP = "2026-01-01T00:00:00Z";
+
+const defaultWorkspace = {
+  id: "ws-default",
+  name: "Default",
+  created_at: WORKSPACE_TIMESTAMP,
+  updated_at: WORKSPACE_TIMESTAMP,
+};
+
+const activeWorkspace = {
+  id: "ws-active",
+  name: "Active",
+  created_at: WORKSPACE_TIMESTAMP,
+  updated_at: WORKSPACE_TIMESTAMP,
+};
+
+describe("GitHubPage", () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((mock) => mock.mockReset());
+    mocks.listWorkspacesAction.mockResolvedValue({
+      workspaces: [defaultWorkspace, activeWorkspace],
+    });
+    mocks.fetchUserSettings.mockResolvedValue({
+      settings: { workspace_id: defaultWorkspace.id },
+    });
+    mocks.readCookies.mockResolvedValue({
+      get: (name: string) =>
+        name === ACTIVE_WORKSPACE_COOKIE ? { value: activeWorkspace.id } : undefined,
+    });
+    mocks.listWorkflowsAction.mockResolvedValue({ workflows: [] });
+    mocks.listRepositoriesAction.mockResolvedValue({ repositories: [] });
+    mocks.listWorkspaceWorkflowStepsAction.mockResolvedValue({ steps: [] });
+  });
+
+  it("loads local GitHub context for the active workspace cookie", async () => {
+    const result = (await GitHubPage()) as {
+      props: { children: { props: { workspaceId?: string } }[] };
+    };
+
+    expect(mocks.listWorkflowsAction).toHaveBeenCalledWith(activeWorkspace.id);
+    expect(mocks.listRepositoriesAction).toHaveBeenCalledWith(activeWorkspace.id);
+    expect(mocks.listWorkspaceWorkflowStepsAction).toHaveBeenCalledWith(activeWorkspace.id);
+    expect(result.props.children[1]?.props.workspaceId).toBe(activeWorkspace.id);
+  });
+});

--- a/apps/web/app/github/page.tsx
+++ b/apps/web/app/github/page.tsx
@@ -6,7 +6,13 @@ import {
 } from "@/app/actions/workspaces";
 import { fetchUserSettings } from "@/lib/api";
 import { StateHydrator } from "@/components/state-hydrator";
+import {
+  ACTIVE_WORKSPACE_COOKIE,
+  LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE,
+} from "@/lib/routing/route-bootstrap";
+import { readCookies, type CookieStore } from "@/lib/server/cookies";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
 import { GitHubPageClient } from "./github-page-client";
 import type {
   Workflow,
@@ -16,6 +22,21 @@ import type {
   UserSettingsResponse,
 } from "@/lib/types/http";
 import type { AppState } from "@/lib/state/store";
+
+function resolveGithubWorkspaceId(
+  workspaces: Workspace[],
+  settingsResponse: UserSettingsResponse | null,
+  cookieStore: CookieStore | null,
+): string | undefined {
+  return (
+    resolveActiveId(
+      workspaces,
+      cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value,
+      cookieStore?.get(LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE)?.value,
+      settingsResponse?.settings?.workspace_id,
+    ) ?? undefined
+  );
+}
 
 export default async function GitHubPage() {
   let workspaces: Workspace[] = [];
@@ -31,9 +52,10 @@ export default async function GitHubPage() {
       listWorkspacesAction(),
       fetchUserSettings({ cache: "no-store" }).catch(() => null),
     ]);
+    const cookieStore = await readCookies().catch(() => null);
     workspaces = workspacesResponse.workspaces;
     userSettingsResponse = settingsResponse;
-    workspaceId = settingsResponse?.settings?.workspace_id || workspaces[0]?.id;
+    workspaceId = resolveGithubWorkspaceId(workspaces, settingsResponse, cookieStore);
 
     if (workspaceId) {
       const [workflowsRes, reposRes, stepsRes] = await Promise.all([


### PR DESCRIPTION
Workspace deletion could fail when newer office routing rows survived the destructive cleanup, and the GitHub screen could hydrate with the saved/default workspace instead of the user’s active workspace. The cleanup now removes routing/provider rows explicitly, and GitHub page hydration follows the active workspace cookie before saved settings.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

Closes #1480
Closes #1482

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->