### PR TITLE
fix: preserve github workspace context

### DIFF
--- a/apps/backend/internal/backendapp/helpers_test.go
+++ b/apps/backend/internal/backendapp/helpers_test.go
@@ -633,6 +633,78 @@ func TestBootRouteDataIntegrationRouteUsesActiveWorkspaceCookie(t *testing.T) {
 	}
 }
 
+func TestBootRouteDataIntegrationRouteCookieWinsOverSettingsWorkspace(t *testing.T) {
+	harness := newBootStateTestHarness(t)
+	ctx := context.Background()
+	workspaces, err := harness.taskSvc.ListWorkspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkspaces: %v", err)
+	}
+	if len(workspaces) == 0 {
+		t.Fatal("expected seeded default workspace")
+	}
+	settingsWorkspaceID := workspaces[0].ID
+	cookieWorkspace, err := harness.taskSvc.CreateWorkspace(ctx, &taskservice.CreateWorkspaceRequest{
+		Name: "Cookie Workspace",
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if _, err := harness.taskSvc.CreateWorkflow(ctx, &taskservice.CreateWorkflowRequest{
+		WorkspaceID: cookieWorkspace.ID,
+		Name:        "Cookie Workflow",
+	}); err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	if _, err := harness.userSvc.UpdateUserSettings(ctx, &userservice.UpdateUserSettingsRequest{
+		WorkspaceID: &settingsWorkspaceID,
+	}); err != nil {
+		t.Fatalf("UpdateUserSettings: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/app-state?path=%2Fgithub", nil)
+	req.AddCookie(&http.Cookie{Name: "kandev-active-workspace", Value: cookieWorkspace.ID})
+	payload := bootPayload(ctx, req, routeParams{
+		taskSvc:  harness.taskSvc,
+		userCtrl: harness.userCtrl,
+		services: &Services{
+			Workflow: harness.workflowSvc,
+		},
+	}, webapp.ClassifyRoute("/github"))
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal payload: %v", err)
+	}
+	var decoded struct {
+		InitialState struct {
+			Workspaces struct {
+				ActiveID string `json:"activeId"`
+			} `json:"workspaces"`
+			UserSettings struct {
+				WorkspaceID string `json:"workspaceId"`
+			} `json:"userSettings"`
+		} `json:"initialState"`
+		RouteData struct {
+			RouteContext struct {
+				ActiveWorkspaceID string `json:"activeWorkspaceId"`
+			} `json:"routeContext"`
+		} `json:"routeData"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal payload: %v", err)
+	}
+	if decoded.InitialState.Workspaces.ActiveID != cookieWorkspace.ID {
+		t.Fatalf("initial active workspace = %q, want %q", decoded.InitialState.Workspaces.ActiveID, cookieWorkspace.ID)
+	}
+	if decoded.InitialState.UserSettings.WorkspaceID != cookieWorkspace.ID {
+		t.Fatalf("user settings workspace = %q, want %q", decoded.InitialState.UserSettings.WorkspaceID, cookieWorkspace.ID)
+	}
+	if decoded.RouteData.RouteContext.ActiveWorkspaceID != cookieWorkspace.ID {
+		t.Fatalf("route active workspace = %q, want %q", decoded.RouteData.RouteContext.ActiveWorkspaceID, cookieWorkspace.ID)
+	}
+}
+
 func nonFallbackWorkspace(t *testing.T, ctx context.Context, taskSvc *taskservice.Service) *models.Workspace {
 	t.Helper()
 	workspaces, err := taskSvc.ListWorkspaces(ctx)

--- a/apps/web/app/github/page.tsx
+++ b/apps/web/app/github/page.tsx
@@ -7,12 +7,6 @@ import {
 import { fetchUserSettings } from "@/lib/api";
 import { StateHydrator } from "@/components/state-hydrator";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
-import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
-import { readCookies } from "@/lib/server/cookies";
-import {
-  ACTIVE_WORKSPACE_COOKIE,
-  LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE,
-} from "@/lib/routing/route-bootstrap";
 import { GitHubPageClient } from "./github-page-client";
 import type {
   Workflow,
@@ -23,79 +17,38 @@ import type {
 } from "@/lib/types/http";
 import type { AppState } from "@/lib/state/store";
 
-type GitHubPageData = {
-  workspaces: Workspace[];
-  workflows: Workflow[];
-  steps: WorkflowStep[];
-  repositories: Repository[];
-  workspaceId: string | undefined;
-  workspaceDataLoaded: boolean;
-  userSettingsResponse: UserSettingsResponse | null;
-};
+export default async function GitHubPage() {
+  let workspaces: Workspace[] = [];
+  let workflows: Workflow[] = [];
+  let steps: WorkflowStep[] = [];
+  let repositories: Repository[] = [];
+  let workspaceId: string | undefined;
+  let workspaceDataLoaded = false;
+  let userSettingsResponse: UserSettingsResponse | null = null;
 
-const EMPTY_GITHUB_PAGE_DATA: GitHubPageData = {
-  workspaces: [],
-  workflows: [],
-  steps: [],
-  repositories: [],
-  workspaceId: undefined,
-  workspaceDataLoaded: false,
-  userSettingsResponse: null,
-};
-
-async function loadGitHubPageData(): Promise<GitHubPageData> {
   try {
-    const [workspacesResponse, settingsResponse, cookieStore] = await Promise.all([
+    const [workspacesResponse, settingsResponse] = await Promise.all([
       listWorkspacesAction(),
       fetchUserSettings({ cache: "no-store" }).catch(() => null),
-      readCookies().catch((error) => {
-        console.error("Failed to read cookies on GitHub page:", error);
-        return null;
-      }),
     ]);
-    const workspaces = workspacesResponse.workspaces;
-    const cookieWorkspaceId =
-      cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value ??
-      cookieStore?.get(LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE)?.value ??
-      null;
-    const workspaceId =
-      resolveActiveId(workspaces, cookieWorkspaceId, settingsResponse?.settings?.workspace_id) ??
-      undefined;
+    workspaces = workspacesResponse.workspaces;
+    userSettingsResponse = settingsResponse;
+    workspaceId = settingsResponse?.settings?.workspace_id || workspaces[0]?.id;
 
-    if (!workspaceId) {
-      return { ...EMPTY_GITHUB_PAGE_DATA, workspaces, userSettingsResponse: settingsResponse };
+    if (workspaceId) {
+      const [workflowsRes, reposRes, stepsRes] = await Promise.all([
+        listWorkflowsAction(workspaceId),
+        listRepositoriesAction(workspaceId),
+        listWorkspaceWorkflowStepsAction(workspaceId),
+      ]);
+      workflows = workflowsRes.workflows;
+      repositories = reposRes.repositories;
+      steps = stepsRes.steps;
+      workspaceDataLoaded = true;
     }
-
-    const [workflowsRes, reposRes, stepsRes] = await Promise.all([
-      listWorkflowsAction(workspaceId),
-      listRepositoriesAction(workspaceId),
-      listWorkspaceWorkflowStepsAction(workspaceId),
-    ]);
-    return {
-      workspaces,
-      workflows: workflowsRes.workflows,
-      steps: stepsRes.steps,
-      repositories: reposRes.repositories,
-      workspaceId,
-      workspaceDataLoaded: true,
-      userSettingsResponse: settingsResponse,
-    };
   } catch (error) {
     console.error("Failed to load GitHub page data:", error);
-    return EMPTY_GITHUB_PAGE_DATA;
   }
-}
-
-export default async function GitHubPage() {
-  const {
-    workspaces,
-    workflows,
-    steps,
-    repositories,
-    workspaceId,
-    workspaceDataLoaded,
-    userSettingsResponse,
-  } = await loadGitHubPageData();
 
   const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
 

--- a/apps/web/app/github/page.tsx
+++ b/apps/web/app/github/page.tsx
@@ -7,6 +7,12 @@ import {
 import { fetchUserSettings } from "@/lib/api";
 import { StateHydrator } from "@/components/state-hydrator";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { resolveActiveId } from "@/lib/ssr/resolve-active-id";
+import { readCookies } from "@/lib/server/cookies";
+import {
+  ACTIVE_WORKSPACE_COOKIE,
+  LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE,
+} from "@/lib/routing/route-bootstrap";
 import { GitHubPageClient } from "./github-page-client";
 import type {
   Workflow,
@@ -17,38 +23,79 @@ import type {
 } from "@/lib/types/http";
 import type { AppState } from "@/lib/state/store";
 
-export default async function GitHubPage() {
-  let workspaces: Workspace[] = [];
-  let workflows: Workflow[] = [];
-  let steps: WorkflowStep[] = [];
-  let repositories: Repository[] = [];
-  let workspaceId: string | undefined;
-  let workspaceDataLoaded = false;
-  let userSettingsResponse: UserSettingsResponse | null = null;
+type GitHubPageData = {
+  workspaces: Workspace[];
+  workflows: Workflow[];
+  steps: WorkflowStep[];
+  repositories: Repository[];
+  workspaceId: string | undefined;
+  workspaceDataLoaded: boolean;
+  userSettingsResponse: UserSettingsResponse | null;
+};
 
+const EMPTY_GITHUB_PAGE_DATA: GitHubPageData = {
+  workspaces: [],
+  workflows: [],
+  steps: [],
+  repositories: [],
+  workspaceId: undefined,
+  workspaceDataLoaded: false,
+  userSettingsResponse: null,
+};
+
+async function loadGitHubPageData(): Promise<GitHubPageData> {
   try {
-    const [workspacesResponse, settingsResponse] = await Promise.all([
+    const [workspacesResponse, settingsResponse, cookieStore] = await Promise.all([
       listWorkspacesAction(),
       fetchUserSettings({ cache: "no-store" }).catch(() => null),
+      readCookies().catch((error) => {
+        console.error("Failed to read cookies on GitHub page:", error);
+        return null;
+      }),
     ]);
-    workspaces = workspacesResponse.workspaces;
-    userSettingsResponse = settingsResponse;
-    workspaceId = settingsResponse?.settings?.workspace_id || workspaces[0]?.id;
+    const workspaces = workspacesResponse.workspaces;
+    const cookieWorkspaceId =
+      cookieStore?.get(ACTIVE_WORKSPACE_COOKIE)?.value ??
+      cookieStore?.get(LEGACY_OFFICE_ACTIVE_WORKSPACE_COOKIE)?.value ??
+      null;
+    const workspaceId =
+      resolveActiveId(workspaces, cookieWorkspaceId, settingsResponse?.settings?.workspace_id) ??
+      undefined;
 
-    if (workspaceId) {
-      const [workflowsRes, reposRes, stepsRes] = await Promise.all([
-        listWorkflowsAction(workspaceId),
-        listRepositoriesAction(workspaceId),
-        listWorkspaceWorkflowStepsAction(workspaceId),
-      ]);
-      workflows = workflowsRes.workflows;
-      repositories = reposRes.repositories;
-      steps = stepsRes.steps;
-      workspaceDataLoaded = true;
+    if (!workspaceId) {
+      return { ...EMPTY_GITHUB_PAGE_DATA, workspaces, userSettingsResponse: settingsResponse };
     }
+
+    const [workflowsRes, reposRes, stepsRes] = await Promise.all([
+      listWorkflowsAction(workspaceId),
+      listRepositoriesAction(workspaceId),
+      listWorkspaceWorkflowStepsAction(workspaceId),
+    ]);
+    return {
+      workspaces,
+      workflows: workflowsRes.workflows,
+      steps: stepsRes.steps,
+      repositories: reposRes.repositories,
+      workspaceId,
+      workspaceDataLoaded: true,
+      userSettingsResponse: settingsResponse,
+    };
   } catch (error) {
     console.error("Failed to load GitHub page data:", error);
+    return EMPTY_GITHUB_PAGE_DATA;
   }
+}
+
+export default async function GitHubPage() {
+  const {
+    workspaces,
+    workflows,
+    steps,
+    repositories,
+    workspaceId,
+    workspaceDataLoaded,
+    userSettingsResponse,
+  } = await loadGitHubPageData();
 
   const mappedUserSettings = mapUserSettingsResponse(userSettingsResponse);
 

--- a/apps/web/src/spa-routes.tsx
+++ b/apps/web/src/spa-routes.tsx
@@ -367,21 +367,26 @@ function useRouteData({
 
     async function bootstrap() {
       const [workspacesResponse, settingsResponse] = await Promise.all([
-        listWorkspaces({ cache: "no-store" }).catch(() => ({ workspaces: [] })),
+        listWorkspaces({ cache: "no-store" }).catch(() => null),
         fetchUserSettings({ cache: "no-store" }).catch(() => null),
       ]);
       if (cancelled) return;
 
-      const workspaces = workspacesResponse.workspaces;
       const settingsWorkspaceId = settingsResponse?.settings?.workspace_id || null;
       const settingsWorkflowId = settingsResponse?.settings?.workflow_filter_id || null;
-      const workspaceItems = workspaces.map(mapWorkspaceItem);
-      const workspaceId = resolveActiveId(
-        workspaceItems,
-        store.getState().workspaces.activeId,
-        readActiveWorkspaceCookie(),
-        settingsWorkspaceId,
-      );
+      const storeWorkspaceId = store.getState().workspaces.activeId;
+      const cookieWorkspaceId = readActiveWorkspaceCookie();
+      const workspaceItems =
+        workspacesResponse?.workspaces.map(mapWorkspaceItem) ?? store.getState().workspaces.items;
+      const workspaceId =
+        workspaceItems.length > 0
+          ? resolveActiveId(
+              workspaceItems,
+              storeWorkspaceId,
+              cookieWorkspaceId,
+              settingsWorkspaceId,
+            )
+          : firstKnownWorkspaceId(storeWorkspaceId, cookieWorkspaceId, settingsWorkspaceId);
       store.getState().hydrate({
         workspaces: { items: workspaceItems, activeId: workspaceId },
         workflows: { items: store.getState().workflows.items, activeId: settingsWorkflowId },
@@ -427,6 +432,14 @@ function listWorkspaceWorkflowSteps(workspaceId: string) {
   return fetchJson<ListWorkflowStepsResponse>(`/api/v1/workspaces/${workspaceId}/workflow-steps`, {
     cache: "no-store",
   });
+}
+
+function firstKnownWorkspaceId(...ids: (string | null | undefined)[]): string | null {
+  for (const id of ids) {
+    const value = id?.trim();
+    if (value) return value;
+  }
+  return null;
 }
 
 function mapWorkflowItem(workflow: Workflow) {

--- a/apps/web/src/spa-routes.tsx
+++ b/apps/web/src/spa-routes.tsx
@@ -373,10 +373,17 @@ function useRouteData({
       if (cancelled) return;
 
       const workspaces = workspacesResponse.workspaces;
-      const workspaceId = settingsResponse?.settings?.workspace_id || workspaces[0]?.id || null;
+      const settingsWorkspaceId = settingsResponse?.settings?.workspace_id || null;
       const settingsWorkflowId = settingsResponse?.settings?.workflow_filter_id || null;
+      const workspaceItems = workspaces.map(mapWorkspaceItem);
+      const workspaceId = resolveActiveId(
+        workspaceItems,
+        store.getState().workspaces.activeId,
+        readActiveWorkspaceCookie(),
+        settingsWorkspaceId,
+      );
       store.getState().hydrate({
-        workspaces: { items: workspaces, activeId: workspaceId },
+        workspaces: { items: workspaceItems, activeId: workspaceId },
         workflows: { items: store.getState().workflows.items, activeId: settingsWorkflowId },
         userSettings: { ...mapUserSettingsResponse(settingsResponse), workspaceId },
       });

--- a/apps/web/src/spa-routes.workspace.test.tsx
+++ b/apps/web/src/spa-routes.workspace.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StateProvider } from "@/components/state-provider";
+import { SpaRoutes } from "./spa-routes";
+
+const mocks = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  listRepositories: vi.fn(),
+  listWorkflows: vi.fn(),
+  fetchUserSettings: vi.fn(),
+  fetchJson: vi.fn(),
+}));
+
+const DEFAULT_WORKSPACE_ID = "ws-default";
+const SELECTED_WORKSPACE_ID = "ws-selected";
+const TEST_TIMESTAMP = "2026-06-24T00:00:00Z";
+
+vi.mock("@/app/github/github-page-client", () => ({
+  GitHubPageClient: ({ workspaceId }: { workspaceId?: string }) => (
+    <div data-testid="github-page" data-workspace-id={workspaceId ?? ""} />
+  ),
+}));
+
+vi.mock("@/lib/api/domains/workspace-api", () => ({
+  listWorkspaces: mocks.listWorkspaces,
+  listRepositories: mocks.listRepositories,
+}));
+
+vi.mock("@/lib/api/domains/kanban-api", () => ({
+  listWorkflows: mocks.listWorkflows,
+}));
+
+vi.mock("@/lib/api/domains/settings-api", () => ({
+  fetchUserSettings: mocks.fetchUserSettings,
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  fetchJson: mocks.fetchJson,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("SpaRoutes data-backed workspace context", () => {
+  it("keeps the currently active workspace when opening GitHub from another workspace", async () => {
+    window.history.replaceState({}, "", "/github");
+    mocks.listWorkspaces.mockResolvedValue({
+      workspaces: [workspace(DEFAULT_WORKSPACE_ID), workspace(SELECTED_WORKSPACE_ID)],
+    });
+    mocks.fetchUserSettings.mockResolvedValue({
+      settings: {
+        workspace_id: DEFAULT_WORKSPACE_ID,
+        workflow_filter_id: "",
+        repository_ids: [],
+        updated_at: TEST_TIMESTAMP,
+      },
+    });
+    mocks.listWorkflows.mockResolvedValue({
+      workflows: [workflow("wf-selected", SELECTED_WORKSPACE_ID)],
+    });
+    mocks.listRepositories.mockResolvedValue({ repositories: [] });
+    mocks.fetchJson.mockResolvedValue({ steps: [], total: 0 });
+
+    render(
+      <StateProvider
+        initialState={{
+          workspaces: {
+            items: [workspaceState(DEFAULT_WORKSPACE_ID), workspaceState(SELECTED_WORKSPACE_ID)],
+            activeId: SELECTED_WORKSPACE_ID,
+          },
+        }}
+      >
+        <SpaRoutes />
+      </StateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("github-page").getAttribute("data-workspace-id")).toBe(
+        SELECTED_WORKSPACE_ID,
+      );
+    });
+    expect(mocks.listWorkflows).toHaveBeenCalledWith(SELECTED_WORKSPACE_ID, {
+      cache: "no-store",
+    });
+  });
+});
+
+function workspace(id: string) {
+  return {
+    id,
+    name: id,
+    description: null,
+    owner_id: "owner-1",
+    default_executor_id: null,
+    default_environment_id: null,
+    default_agent_profile_id: null,
+    default_config_agent_profile_id: null,
+    office_workflow_id: null,
+    created_at: TEST_TIMESTAMP,
+    updated_at: TEST_TIMESTAMP,
+  };
+}
+
+function workspaceState(id: string) {
+  return workspace(id);
+}
+
+function workflow(id: string, workspaceId: string) {
+  return {
+    id,
+    workspace_id: workspaceId,
+    name: id,
+    description: null,
+    sort_order: 0,
+    created_at: TEST_TIMESTAMP,
+    updated_at: TEST_TIMESTAMP,
+  };
+}

--- a/apps/web/src/spa-routes.workspace.test.tsx
+++ b/apps/web/src/spa-routes.workspace.test.tsx
@@ -42,6 +42,8 @@ vi.mock("@/lib/api/client", () => ({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  document.cookie = "kandev-active-workspace=; path=/; max-age=0";
+  document.cookie = "office-active-workspace=; path=/; max-age=0";
   window.history.replaceState({}, "", "/");
 });
 
@@ -74,6 +76,42 @@ describe("SpaRoutes data-backed workspace context", () => {
           },
         }}
       >
+        <SpaRoutes />
+      </StateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("github-page").getAttribute("data-workspace-id")).toBe(
+        SELECTED_WORKSPACE_ID,
+      );
+    });
+    expect(mocks.listWorkflows).toHaveBeenCalledWith(SELECTED_WORKSPACE_ID, {
+      cache: "no-store",
+    });
+  });
+
+  it("uses the active workspace cookie when the store has no active workspace yet", async () => {
+    window.history.replaceState({}, "", "/github");
+    document.cookie = `kandev-active-workspace=${SELECTED_WORKSPACE_ID}; path=/`;
+    mocks.listWorkspaces.mockResolvedValue({
+      workspaces: [workspace(DEFAULT_WORKSPACE_ID), workspace(SELECTED_WORKSPACE_ID)],
+    });
+    mocks.fetchUserSettings.mockResolvedValue({
+      settings: {
+        workspace_id: DEFAULT_WORKSPACE_ID,
+        workflow_filter_id: "",
+        repository_ids: [],
+        updated_at: TEST_TIMESTAMP,
+      },
+    });
+    mocks.listWorkflows.mockResolvedValue({
+      workflows: [workflow("wf-selected", SELECTED_WORKSPACE_ID)],
+    });
+    mocks.listRepositories.mockResolvedValue({ repositories: [] });
+    mocks.fetchJson.mockResolvedValue({ steps: [], total: 0 });
+
+    render(
+      <StateProvider>
         <SpaRoutes />
       </StateProvider>,
     );

--- a/apps/web/src/spa-routes.workspace.test.tsx
+++ b/apps/web/src/spa-routes.workspace.test.tsx
@@ -49,23 +49,7 @@ afterEach(() => {
 
 describe("SpaRoutes data-backed workspace context", () => {
   it("keeps the currently active workspace when opening GitHub from another workspace", async () => {
-    window.history.replaceState({}, "", "/github");
-    mocks.listWorkspaces.mockResolvedValue({
-      workspaces: [workspace(DEFAULT_WORKSPACE_ID), workspace(SELECTED_WORKSPACE_ID)],
-    });
-    mocks.fetchUserSettings.mockResolvedValue({
-      settings: {
-        workspace_id: DEFAULT_WORKSPACE_ID,
-        workflow_filter_id: "",
-        repository_ids: [],
-        updated_at: TEST_TIMESTAMP,
-      },
-    });
-    mocks.listWorkflows.mockResolvedValue({
-      workflows: [workflow("wf-selected", SELECTED_WORKSPACE_ID)],
-    });
-    mocks.listRepositories.mockResolvedValue({ repositories: [] });
-    mocks.fetchJson.mockResolvedValue({ steps: [], total: 0 });
+    mockGitHubWorkspaceBootstrap();
 
     render(
       <StateProvider
@@ -80,35 +64,12 @@ describe("SpaRoutes data-backed workspace context", () => {
       </StateProvider>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("github-page").getAttribute("data-workspace-id")).toBe(
-        SELECTED_WORKSPACE_ID,
-      );
-    });
-    expect(mocks.listWorkflows).toHaveBeenCalledWith(SELECTED_WORKSPACE_ID, {
-      cache: "no-store",
-    });
+    await expectSelectedWorkspace();
   });
 
   it("uses the active workspace cookie when the store has no active workspace yet", async () => {
-    window.history.replaceState({}, "", "/github");
     document.cookie = `kandev-active-workspace=${SELECTED_WORKSPACE_ID}; path=/`;
-    mocks.listWorkspaces.mockResolvedValue({
-      workspaces: [workspace(DEFAULT_WORKSPACE_ID), workspace(SELECTED_WORKSPACE_ID)],
-    });
-    mocks.fetchUserSettings.mockResolvedValue({
-      settings: {
-        workspace_id: DEFAULT_WORKSPACE_ID,
-        workflow_filter_id: "",
-        repository_ids: [],
-        updated_at: TEST_TIMESTAMP,
-      },
-    });
-    mocks.listWorkflows.mockResolvedValue({
-      workflows: [workflow("wf-selected", SELECTED_WORKSPACE_ID)],
-    });
-    mocks.listRepositories.mockResolvedValue({ repositories: [] });
-    mocks.fetchJson.mockResolvedValue({ steps: [], total: 0 });
+    mockGitHubWorkspaceBootstrap();
 
     render(
       <StateProvider>
@@ -116,16 +77,57 @@ describe("SpaRoutes data-backed workspace context", () => {
       </StateProvider>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("github-page").getAttribute("data-workspace-id")).toBe(
-        SELECTED_WORKSPACE_ID,
-      );
-    });
-    expect(mocks.listWorkflows).toHaveBeenCalledWith(SELECTED_WORKSPACE_ID, {
-      cache: "no-store",
-    });
+    await expectSelectedWorkspace();
+  });
+
+  it("keeps a known active workspace when the workspace list request fails", async () => {
+    document.cookie = `kandev-active-workspace=${SELECTED_WORKSPACE_ID}; path=/`;
+    mockGitHubWorkspaceBootstrap({ workspacesError: new Error("network down") });
+
+    render(
+      <StateProvider>
+        <SpaRoutes />
+      </StateProvider>,
+    );
+
+    await expectSelectedWorkspace();
   });
 });
+
+function mockGitHubWorkspaceBootstrap({ workspacesError }: { workspacesError?: Error } = {}) {
+  window.history.replaceState({}, "", "/github");
+  if (workspacesError) {
+    mocks.listWorkspaces.mockRejectedValue(workspacesError);
+  } else {
+    mocks.listWorkspaces.mockResolvedValue({
+      workspaces: [workspace(DEFAULT_WORKSPACE_ID), workspace(SELECTED_WORKSPACE_ID)],
+    });
+  }
+  mocks.fetchUserSettings.mockResolvedValue({
+    settings: {
+      workspace_id: DEFAULT_WORKSPACE_ID,
+      workflow_filter_id: "",
+      repository_ids: [],
+      updated_at: TEST_TIMESTAMP,
+    },
+  });
+  mocks.listWorkflows.mockResolvedValue({
+    workflows: [workflow("wf-selected", SELECTED_WORKSPACE_ID)],
+  });
+  mocks.listRepositories.mockResolvedValue({ repositories: [] });
+  mocks.fetchJson.mockResolvedValue({ steps: [], total: 0 });
+}
+
+async function expectSelectedWorkspace() {
+  await waitFor(() => {
+    expect(screen.getByTestId("github-page").getAttribute("data-workspace-id")).toBe(
+      SELECTED_WORKSPACE_ID,
+    );
+  });
+  expect(mocks.listWorkflows).toHaveBeenCalledWith(SELECTED_WORKSPACE_ID, {
+    cache: "no-store",
+  });
+}
 
 function workspace(id: string) {
   return {


### PR DESCRIPTION
Opening the GitHub integration from a non-default workspace could silently fall back to the saved/default workspace, so issue and PR task creation inherited the wrong workspace context. The GitHub route bootstrap now resolves the active workspace from the current store/cookie before saved settings, keeping GitHub-created tasks in the selected workspace.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm test -- --run src/spa-routes.workspace.test.tsx`
- `pnpm typecheck`
- `pnpm lint`

Closes #1482

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->