### PR TITLE
fix: persist self-managed gitlab host

### DIFF
--- a/apps/backend/internal/backendapp/gitlab_service_test.go
+++ b/apps/backend/internal/backendapp/gitlab_service_test.go
@@ -1,0 +1,76 @@
+package backendapp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/secrets"
+)
+
+type emptySecretStore struct{}
+
+func (emptySecretStore) Create(context.Context, *secrets.SecretWithValue) error { return nil }
+func (emptySecretStore) Get(context.Context, string) (*secrets.Secret, error)   { return nil, nil }
+func (emptySecretStore) Reveal(context.Context, string) (string, error)         { return "", nil }
+func (emptySecretStore) Update(context.Context, string, *secrets.UpdateSecretRequest) error {
+	return nil
+}
+func (emptySecretStore) Delete(context.Context, string) error { return nil }
+func (emptySecretStore) List(context.Context) ([]*secrets.SecretListItem, error) {
+	return nil, nil
+}
+func (emptySecretStore) Close() error { return nil }
+
+func TestInitGitLabServiceLoadsConfiguredHostAfterRestart(t *testing.T) {
+	t.Setenv("KANDEV_MOCK_GITLAB", "true")
+	t.Setenv("GITLAB_TOKEN", "")
+
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v4/version" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"version":"16.0.0"}`))
+	}))
+	t.Cleanup(gitlabServer.Close)
+
+	pool := newGitLabServiceTestPool(t)
+	log := newTestLogger()
+	secretsStore := emptySecretStore{}
+
+	first := initGitLabService(pool, nil, secretsStore, log)
+	if first == nil {
+		t.Fatal("first GitLab service is nil")
+	}
+	if err := first.ConfigureHost(context.Background(), gitlabServer.URL+"/"); err != nil {
+		t.Fatalf("ConfigureHost: %v", err)
+	}
+
+	second := initGitLabService(pool, nil, secretsStore, log)
+	if second == nil {
+		t.Fatal("second GitLab service is nil")
+	}
+	if got := second.Host(); got != gitlabServer.URL {
+		t.Fatalf("Host after restart = %q, want %q", got, gitlabServer.URL)
+	}
+}
+
+func newGitLabServiceTestPool(t *testing.T) *db.Pool {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "kandev.db")
+	conn, err := sqlx.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	pool := db.NewPool(conn, conn)
+	t.Cleanup(func() { _ = pool.Close() })
+	return pool
+}

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -346,6 +346,7 @@ func initGitLabService(dbPool *db.Pool, eventBus bus.EventBus, secretsStore secr
 	hostStore, hostStoreErr := newGitLabHostStore(dbPool)
 	if hostStoreErr != nil {
 		log.Warn("GitLab host store unavailable (non-fatal)", zap.Error(hostStoreErr))
+		return nil
 	}
 	svc, _, err := gitlab.Provide(context.Background(), adapter, hostStore, log)
 	if err != nil {

--- a/apps/backend/internal/backendapp/services.go
+++ b/apps/backend/internal/backendapp/services.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kandev/kandev/internal/secrets"
 	"github.com/kandev/kandev/internal/sentry"
 	"github.com/kandev/kandev/internal/slack"
+	systemsettings "github.com/kandev/kandev/internal/system/settings"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
 	taskservice "github.com/kandev/kandev/internal/task/service"
 	"github.com/kandev/kandev/internal/task/share"
@@ -312,11 +313,41 @@ func (a *gitlabSecretAdapter) Delete(ctx context.Context, id string) error {
 	return a.store.Delete(ctx, id)
 }
 
+const gitlabHostSettingKey = "gitlab_host"
+
+type gitlabHostStore struct {
+	settings *systemsettings.Store
+}
+
+func newGitLabHostStore(dbPool *db.Pool) (gitlab.HostStore, error) {
+	settingsStore, err := systemsettings.NewStore(dbPool)
+	if err != nil {
+		return nil, err
+	}
+	return &gitlabHostStore{settings: settingsStore}, nil
+}
+
+func (s *gitlabHostStore) GetHost(ctx context.Context) (string, error) {
+	raw, found, err := s.settings.Get(ctx, gitlabHostSettingKey)
+	if err != nil || !found {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func (s *gitlabHostStore) SetHost(ctx context.Context, host string) error {
+	return s.settings.Save(ctx, gitlabHostSettingKey, []byte(host))
+}
+
 // initGitLabService wires up the GitLab integration. Failures are non-fatal:
 // the rest of the backend still boots without GitLab configured.
 func initGitLabService(dbPool *db.Pool, eventBus bus.EventBus, secretsStore secrets.SecretStore, log *logger.Logger) *gitlab.Service {
 	adapter := &gitlabSecretAdapter{store: secretsStore}
-	svc, _, err := gitlab.Provide(context.Background(), adapter, nil, log)
+	hostStore, hostStoreErr := newGitLabHostStore(dbPool)
+	if hostStoreErr != nil {
+		log.Warn("GitLab host store unavailable (non-fatal)", zap.Error(hostStoreErr))
+	}
+	svc, _, err := gitlab.Provide(context.Background(), adapter, hostStore, log)
 	if err != nil {
 		log.Warn("GitLab service initialization failed (non-fatal)", zap.Error(err))
 	}

--- a/apps/backend/internal/gitlab/provider.go
+++ b/apps/backend/internal/gitlab/provider.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kandev/kandev/internal/common/logger"
 )
@@ -21,7 +22,11 @@ func Provide(
 ) (*Service, func() error, error) {
 	host := DefaultHost
 	if hostStore != nil {
-		if persisted, err := hostStore.GetHost(ctx); err == nil && persisted != "" {
+		persisted, err := hostStore.GetHost(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load GitLab host: %w", err)
+		}
+		if persisted != "" {
 			host = persisted
 		}
 	}

--- a/apps/backend/internal/gitlab/provider_test.go
+++ b/apps/backend/internal/gitlab/provider_test.go
@@ -1,0 +1,37 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingHostStore struct{}
+
+func (failingHostStore) GetHost(context.Context) (string, error) {
+	return "", errors.New("settings unavailable")
+}
+
+func (failingHostStore) SetHost(context.Context, string) error {
+	return nil
+}
+
+func TestProvideFailsClosedWhenHostStoreCannotBeRead(t *testing.T) {
+	t.Setenv("KANDEV_MOCK_GITLAB", "true")
+	t.Setenv("GITLAB_TOKEN", "token-for-self-managed-host")
+
+	svc, cleanup, err := Provide(context.Background(), nil, failingHostStore{}, newTestLogger(t))
+	if err == nil {
+		t.Fatal("expected host store read error")
+	}
+	if !strings.Contains(err.Error(), "load GitLab host") {
+		t.Fatalf("err = %v, want load GitLab host context", err)
+	}
+	if svc != nil {
+		t.Fatalf("service = %#v, want nil", svc)
+	}
+	if cleanup != nil {
+		t.Fatalf("cleanup = %T, want nil", cleanup)
+	}
+}


### PR DESCRIPTION
Self-managed GitLab hosts were only kept in memory, so backend restarts sent the saved PAT to `gitlab.com`. Wiring the GitLab host store into service construction lets configured hosts persist and load on restart.

## Validation

- `go test -run TestInitGitLabServiceLoadsConfiguredHostAfterRestart ./internal/backendapp`
- `go test ./internal/backendapp ./internal/gitlab ./internal/system/settings`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

Closes #1485

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->