### PR TITLE
fix: auto-fit wide mermaid diagrams

### DIFF
--- a/apps/web/components/shared/mermaid-block-hooks.test.ts
+++ b/apps/web/components/shared/mermaid-block-hooks.test.ts
@@ -14,6 +14,40 @@ function disableResizeObserver() {
   });
 }
 
+class MockResizeObserver implements ResizeObserver {
+  private readonly callback: ResizeObserverCallback;
+  observed: Element | null = null;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    mockObservers.push(this);
+  }
+
+  observe(element: Element) {
+    this.observed = element;
+  }
+
+  disconnect() {
+    this.observed = null;
+  }
+
+  unobserve() {
+    this.observed = null;
+  }
+
+  trigger() {
+    this.callback([], this);
+  }
+}
+
+let mockObservers: MockResizeObserver[] = [];
+
+function installMockResizeObserver() {
+  mockObservers = [];
+  window.ResizeObserver = MockResizeObserver;
+  return mockObservers;
+}
+
 describe("useMermaidViewportWidth", () => {
   const originalResizeObserver = window.ResizeObserver;
 
@@ -76,30 +110,7 @@ describe("useMermaidViewportWidth", () => {
   });
 
   it("observes a replacement scroll region after the element changes", () => {
-    window.ResizeObserver = class {
-      private readonly callback: ResizeObserverCallback;
-      observed: Element | null = null;
-
-      constructor(callback: ResizeObserverCallback) {
-        this.callback = callback;
-      }
-
-      observe(element: Element) {
-        this.observed = element;
-      }
-
-      disconnect() {
-        this.observed = null;
-      }
-
-      unobserve() {
-        this.observed = null;
-      }
-
-      trigger() {
-        this.callback([], this);
-      }
-    };
+    const observers = installMockResizeObserver();
 
     const first = document.createElement("div");
     const second = document.createElement("div");
@@ -113,10 +124,22 @@ describe("useMermaidViewportWidth", () => {
       });
 
       expect(result.current).toBe(200);
+      expect(observers).toHaveLength(1);
+      expect(observers[0].observed).toBe(first);
 
       rerender({ element: second });
 
       expect(result.current).toBe(320);
+      expect(observers).toHaveLength(2);
+      expect(observers[0].observed).toBeNull();
+      expect(observers[1].observed).toBe(second);
+
+      act(() => {
+        setClientWidth(second, 360);
+        observers[1].trigger();
+      });
+
+      expect(result.current).toBe(360);
     } finally {
       first.remove();
       second.remove();

--- a/apps/web/components/shared/mermaid-block-hooks.test.ts
+++ b/apps/web/components/shared/mermaid-block-hooks.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useMermaidScale, useMermaidViewportWidth } from "./mermaid-block-hooks";
+
+function setClientWidth(element: HTMLElement, width: number) {
+  Object.defineProperty(element, "clientWidth", { value: width, configurable: true });
+}
+
+function makeRef(element: HTMLElement | null) {
+  return { current: element };
+}
+
+function disableResizeObserver() {
+  Object.defineProperty(window, "ResizeObserver", {
+    configurable: true,
+    value: undefined,
+    writable: true,
+  });
+}
+
+describe("useMermaidViewportWidth", () => {
+  const originalResizeObserver = window.ResizeObserver;
+
+  afterEach(() => {
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: originalResizeObserver,
+      writable: true,
+    });
+  });
+
+  it("measures the scroll region content width on mount", () => {
+    disableResizeObserver();
+    const el = document.createElement("div");
+    el.style.paddingLeft = "12px";
+    el.style.paddingRight = "8px";
+    setClientWidth(el, 300);
+    document.body.appendChild(el);
+
+    try {
+      const { result } = renderHook(() => useMermaidViewportWidth(makeRef(el)));
+
+      expect(result.current).toBe(280);
+    } finally {
+      el.remove();
+    }
+  });
+
+  it("uses the window resize fallback when ResizeObserver is unavailable", () => {
+    disableResizeObserver();
+    const el = document.createElement("div");
+    setClientWidth(el, 300);
+    document.body.appendChild(el);
+    const { result } = renderHook(() => useMermaidViewportWidth(makeRef(el)));
+
+    act(() => {
+      setClientWidth(el, 240);
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current).toBe(240);
+    el.remove();
+  });
+
+  it("does not replace the last width while the scroll region is hidden", () => {
+    disableResizeObserver();
+    const el = document.createElement("div");
+    setClientWidth(el, 300);
+    document.body.appendChild(el);
+    const { result } = renderHook(() => useMermaidViewportWidth(makeRef(el)));
+
+    act(() => {
+      el.style.display = "none";
+      setClientWidth(el, 0);
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current).toBe(300);
+    el.remove();
+  });
+});
+
+describe("useMermaidScale", () => {
+  it("preserves manual zoom across viewport changes and reset returns to the latest fit", () => {
+    const { result, rerender } = renderHook(
+      ({ viewportWidth }) => useMermaidScale({ w: 1200, h: 400 }, viewportWidth),
+      { initialProps: { viewportWidth: 600 } },
+    );
+
+    expect(result.current.scale).toBe(0.5);
+
+    act(() => result.current.zoomIn());
+    expect(result.current.scale).toBe(0.6);
+
+    rerender({ viewportWidth: 300 });
+    expect(result.current.scale).toBe(0.6);
+
+    act(() => result.current.zoomReset());
+    expect(result.current.scale).toBe(0.25);
+  });
+
+  it("resetAutoScale returns subsequent measurements to auto-fit behavior", () => {
+    const { result, rerender } = renderHook(
+      ({ viewportWidth }) => useMermaidScale({ w: 1200, h: 400 }, viewportWidth),
+      { initialProps: { viewportWidth: 600 } },
+    );
+
+    act(() => result.current.zoomOut());
+    expect(result.current.scale).toBe(0.4);
+
+    act(() => result.current.resetAutoScale());
+    rerender({ viewportWidth: 300 });
+
+    expect(result.current.scale).toBe(0.25);
+  });
+});

--- a/apps/web/components/shared/mermaid-block-hooks.test.ts
+++ b/apps/web/components/shared/mermaid-block-hooks.test.ts
@@ -6,10 +6,6 @@ function setClientWidth(element: HTMLElement, width: number) {
   Object.defineProperty(element, "clientWidth", { value: width, configurable: true });
 }
 
-function makeRef(element: HTMLElement | null) {
-  return { current: element };
-}
-
 function disableResizeObserver() {
   Object.defineProperty(window, "ResizeObserver", {
     configurable: true,
@@ -38,7 +34,7 @@ describe("useMermaidViewportWidth", () => {
     document.body.appendChild(el);
 
     try {
-      const { result } = renderHook(() => useMermaidViewportWidth(makeRef(el)));
+      const { result } = renderHook(() => useMermaidViewportWidth(el));
 
       expect(result.current).toBe(280);
     } finally {
@@ -51,7 +47,7 @@ describe("useMermaidViewportWidth", () => {
     const el = document.createElement("div");
     setClientWidth(el, 300);
     document.body.appendChild(el);
-    const { result } = renderHook(() => useMermaidViewportWidth(makeRef(el)));
+    const { result } = renderHook(() => useMermaidViewportWidth(el));
 
     act(() => {
       setClientWidth(el, 240);
@@ -67,7 +63,7 @@ describe("useMermaidViewportWidth", () => {
     const el = document.createElement("div");
     setClientWidth(el, 300);
     document.body.appendChild(el);
-    const { result } = renderHook(() => useMermaidViewportWidth(makeRef(el)));
+    const { result } = renderHook(() => useMermaidViewportWidth(el));
 
     act(() => {
       el.style.display = "none";
@@ -77,6 +73,54 @@ describe("useMermaidViewportWidth", () => {
 
     expect(result.current).toBe(300);
     el.remove();
+  });
+
+  it("observes a replacement scroll region after the element changes", () => {
+    window.ResizeObserver = class {
+      private readonly callback: ResizeObserverCallback;
+      observed: Element | null = null;
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+      }
+
+      observe(element: Element) {
+        this.observed = element;
+      }
+
+      disconnect() {
+        this.observed = null;
+      }
+
+      unobserve() {
+        this.observed = null;
+      }
+
+      trigger() {
+        this.callback([], this);
+      }
+    };
+
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    setClientWidth(first, 200);
+    setClientWidth(second, 320);
+    document.body.append(first, second);
+
+    try {
+      const { result, rerender } = renderHook(({ element }) => useMermaidViewportWidth(element), {
+        initialProps: { element: first },
+      });
+
+      expect(result.current).toBe(200);
+
+      rerender({ element: second });
+
+      expect(result.current).toBe(320);
+    } finally {
+      first.remove();
+      second.remove();
+    }
   });
 });
 

--- a/apps/web/components/shared/mermaid-block-hooks.ts
+++ b/apps/web/components/shared/mermaid-block-hooks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { type RefObject, useCallback, useLayoutEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import {
   DEFAULT_SCALE,
   SCALE_STEP,
@@ -10,19 +10,18 @@ import {
   getElementContentWidth,
 } from "./mermaid-utils";
 
-export function useMermaidViewportWidth(scrollRegionRef: RefObject<HTMLElement | null>): number {
+export function useMermaidViewportWidth(scrollRegionElement: HTMLElement | null): number {
   const [viewportWidth, setViewportWidth] = useState(0);
 
   const measureViewport = useCallback(() => {
-    if (!scrollRegionRef.current) return;
-    if (window.getComputedStyle(scrollRegionRef.current).display === "none") return;
-    setViewportWidth(getElementContentWidth(scrollRegionRef.current));
-  }, [scrollRegionRef]);
+    if (!scrollRegionElement) return;
+    if (window.getComputedStyle(scrollRegionElement).display === "none") return;
+    setViewportWidth(getElementContentWidth(scrollRegionElement));
+  }, [scrollRegionElement]);
 
   useLayoutEffect(() => {
     measureViewport();
-    const element = scrollRegionRef.current;
-    if (!element) return;
+    if (!scrollRegionElement) return;
 
     if (typeof ResizeObserver === "undefined") {
       window.addEventListener("resize", measureViewport);
@@ -30,9 +29,9 @@ export function useMermaidViewportWidth(scrollRegionRef: RefObject<HTMLElement |
     }
 
     const observer = new ResizeObserver(measureViewport);
-    observer.observe(element);
+    observer.observe(scrollRegionElement);
     return () => observer.disconnect();
-  }, [measureViewport, scrollRegionRef]);
+  }, [measureViewport, scrollRegionElement]);
 
   return viewportWidth;
 }

--- a/apps/web/components/shared/mermaid-block-hooks.ts
+++ b/apps/web/components/shared/mermaid-block-hooks.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { type RefObject, useCallback, useLayoutEffect, useState } from "react";
+import {
+  DEFAULT_SCALE,
+  SCALE_STEP,
+  MIN_SCALE,
+  MAX_SCALE,
+  calculateMermaidFitScale,
+  getElementContentWidth,
+} from "./mermaid-utils";
+
+export function useMermaidViewportWidth(scrollRegionRef: RefObject<HTMLElement | null>): number {
+  const [viewportWidth, setViewportWidth] = useState(0);
+
+  const measureViewport = useCallback(() => {
+    if (!scrollRegionRef.current) return;
+    if (window.getComputedStyle(scrollRegionRef.current).display === "none") return;
+    setViewportWidth(getElementContentWidth(scrollRegionRef.current));
+  }, [scrollRegionRef]);
+
+  useLayoutEffect(() => {
+    measureViewport();
+    const element = scrollRegionRef.current;
+    if (!element) return;
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measureViewport);
+      return () => window.removeEventListener("resize", measureViewport);
+    }
+
+    const observer = new ResizeObserver(measureViewport);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [measureViewport, scrollRegionRef]);
+
+  return viewportWidth;
+}
+
+export function useMermaidScale(svgSize: { w: number; h: number } | null, viewportWidth: number) {
+  const [scale, setScale] = useState(DEFAULT_SCALE);
+  const [manualScale, setManualScale] = useState(false);
+  const fitScale = svgSize
+    ? calculateMermaidFitScale({ viewportWidth, svgWidth: svgSize.w })
+    : DEFAULT_SCALE;
+
+  useLayoutEffect(() => {
+    if (!manualScale) {
+      setScale(fitScale);
+    }
+  }, [fitScale, manualScale]);
+
+  const zoomIn = useCallback(() => {
+    setManualScale(true);
+    setScale((s) => Math.min(s + SCALE_STEP, MAX_SCALE));
+  }, []);
+  const zoomOut = useCallback(() => {
+    setManualScale(true);
+    setScale((s) => Math.max(s - SCALE_STEP, MIN_SCALE));
+  }, []);
+  const zoomReset = useCallback(() => {
+    setManualScale(false);
+    setScale(fitScale);
+  }, [fitScale]);
+  const resetAutoScale = useCallback(() => setManualScale(false), []);
+
+  return { scale, zoomIn, zoomOut, zoomReset, resetAutoScale };
+}

--- a/apps/web/components/shared/mermaid-block.tsx
+++ b/apps/web/components/shared/mermaid-block.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
+import { type RefObject, useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
 import { useTheme } from "@/components/theme/app-theme";
 import { IconZoomIn, IconZoomOut, IconCode } from "@tabler/icons-react";
 import {
@@ -8,6 +8,7 @@ import {
   SCALE_STEP,
   MIN_SCALE,
   MAX_SCALE,
+  calculateMermaidFitScale,
   getSvgDimensions,
   sanitizeMermaidCode,
   cleanupMermaidOrphans,
@@ -40,6 +41,69 @@ type MermaidBlockProps = {
 };
 
 type ToastFn = ReturnType<typeof useToast>["toast"];
+
+function getElementContentWidth(element: HTMLElement): number {
+  const style = window.getComputedStyle(element);
+  const padding =
+    Number.parseFloat(style.paddingLeft || "0") + Number.parseFloat(style.paddingRight || "0");
+  return Math.max(0, element.clientWidth - padding);
+}
+
+function useMermaidViewportWidth(scrollRegionRef: RefObject<HTMLElement | null>): number {
+  const [viewportWidth, setViewportWidth] = useState(0);
+
+  const measureViewport = useCallback(() => {
+    if (!scrollRegionRef.current) return;
+    setViewportWidth(getElementContentWidth(scrollRegionRef.current));
+  }, [scrollRegionRef]);
+
+  useLayoutEffect(() => {
+    measureViewport();
+    const element = scrollRegionRef.current;
+    if (!element) return;
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measureViewport);
+      return () => window.removeEventListener("resize", measureViewport);
+    }
+
+    const observer = new ResizeObserver(measureViewport);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [measureViewport, scrollRegionRef]);
+
+  return viewportWidth;
+}
+
+function useMermaidScale(svgSize: { w: number; h: number } | null, viewportWidth: number) {
+  const [scale, setScale] = useState(DEFAULT_SCALE);
+  const [manualScale, setManualScale] = useState(false);
+  const fitScale = svgSize
+    ? calculateMermaidFitScale({ viewportWidth, svgWidth: svgSize.w })
+    : DEFAULT_SCALE;
+
+  useEffect(() => {
+    if (!manualScale) {
+      setScale(fitScale);
+    }
+  }, [fitScale, manualScale]);
+
+  const zoomIn = useCallback(() => {
+    setManualScale(true);
+    setScale((s) => Math.min(s + SCALE_STEP, MAX_SCALE));
+  }, []);
+  const zoomOut = useCallback(() => {
+    setManualScale(true);
+    setScale((s) => Math.max(s - SCALE_STEP, MIN_SCALE));
+  }, []);
+  const zoomReset = useCallback(() => {
+    setManualScale(false);
+    setScale(fitScale);
+  }, [fitScale]);
+  const resetAutoScale = useCallback(() => setManualScale(false), []);
+
+  return { scale, zoomIn, zoomOut, zoomReset, resetAutoScale };
+}
 
 /**
  * Debounced mermaid render. Owns the timer, the in-flight cancellation flag,
@@ -110,12 +174,17 @@ function useMermaidRender(code: string, resolvedTheme: string | undefined, toast
 
 export function MermaidBlock({ code }: MermaidBlockProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(DEFAULT_SCALE);
+  const scrollRegionRef = useRef<HTMLDivElement>(null);
   const [svgSize, setSvgSize] = useState<{ w: number; h: number } | null>(null);
   const [showCode, setShowCode] = useState(false);
   const { resolvedTheme } = useTheme();
   const { toast } = useToast();
   const { svg, error } = useMermaidRender(code, resolvedTheme, toast);
+  const viewportWidth = useMermaidViewportWidth(scrollRegionRef);
+  const { scale, zoomIn, zoomOut, zoomReset, resetAutoScale } = useMermaidScale(
+    svgSize,
+    viewportWidth,
+  );
 
   // Read intrinsic SVG dimensions once the rendered markup is in the DOM so
   // the zoom transform scales the correct box. Runs after every successful
@@ -123,16 +192,15 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
   useLayoutEffect(() => {
     if (svg && containerRef.current) {
       setSvgSize(getSvgDimensions(containerRef.current));
+      resetAutoScale();
       return;
     }
     // svg reset back to null — drop the stale footprint so the wrapper
     // doesn't reserve space for a diagram that's no longer rendered.
     setSvgSize(null);
-  }, [svg]);
+    resetAutoScale();
+  }, [svg, resetAutoScale]);
 
-  const zoomIn = useCallback(() => setScale((s) => Math.min(s + SCALE_STEP, MAX_SCALE)), []);
-  const zoomOut = useCallback(() => setScale((s) => Math.max(s - SCALE_STEP, MIN_SCALE)), []);
-  const zoomReset = useCallback(() => setScale(DEFAULT_SCALE), []);
   const toggleCode = useCallback(() => setShowCode((v) => !v), []);
 
   // Surface the error only when we have no previously-rendered svg to fall
@@ -161,6 +229,7 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
   return (
     <div className="mermaid-block group/mermaid relative my-3 block w-full max-w-full min-w-0 rounded-md border border-border/50 bg-muted/20">
       <div
+        ref={scrollRegionRef}
         className="mermaid-scroll-region w-full overflow-x-auto overflow-y-hidden p-3"
         style={{ display: showCode ? "none" : undefined }}
       >

--- a/apps/web/components/shared/mermaid-block.tsx
+++ b/apps/web/components/shared/mermaid-block.tsx
@@ -9,6 +9,7 @@ import {
   MIN_SCALE,
   MAX_SCALE,
   calculateMermaidFitScale,
+  getElementContentWidth,
   getSvgDimensions,
   sanitizeMermaidCode,
   cleanupMermaidOrphans,
@@ -42,11 +43,11 @@ type MermaidBlockProps = {
 
 type ToastFn = ReturnType<typeof useToast>["toast"];
 
-function getElementContentWidth(element: HTMLElement): number {
-  const style = window.getComputedStyle(element);
-  const padding =
-    Number.parseFloat(style.paddingLeft || "0") + Number.parseFloat(style.paddingRight || "0");
-  return Math.max(0, element.clientWidth - padding);
+function sameSvgSize(
+  a: { w: number; h: number } | null,
+  b: { w: number; h: number } | null,
+): boolean {
+  return a?.w === b?.w && a?.h === b?.h;
 }
 
 function useMermaidViewportWidth(scrollRegionRef: RefObject<HTMLElement | null>): number {
@@ -54,6 +55,7 @@ function useMermaidViewportWidth(scrollRegionRef: RefObject<HTMLElement | null>)
 
   const measureViewport = useCallback(() => {
     if (!scrollRegionRef.current) return;
+    if (window.getComputedStyle(scrollRegionRef.current).display === "none") return;
     setViewportWidth(getElementContentWidth(scrollRegionRef.current));
   }, [scrollRegionRef]);
 
@@ -82,7 +84,7 @@ function useMermaidScale(svgSize: { w: number; h: number } | null, viewportWidth
     ? calculateMermaidFitScale({ viewportWidth, svgWidth: svgSize.w })
     : DEFAULT_SCALE;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!manualScale) {
       setScale(fitScale);
     }
@@ -191,8 +193,12 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
   // render (svg state change).
   useLayoutEffect(() => {
     if (svg && containerRef.current) {
-      setSvgSize(getSvgDimensions(containerRef.current));
-      resetAutoScale();
+      const nextSize = getSvgDimensions(containerRef.current);
+      setSvgSize((prevSize) => {
+        if (sameSvgSize(prevSize, nextSize)) return prevSize;
+        resetAutoScale();
+        return nextSize;
+      });
       return;
     }
     // svg reset back to null — drop the stale footprint so the wrapper

--- a/apps/web/components/shared/mermaid-block.tsx
+++ b/apps/web/components/shared/mermaid-block.tsx
@@ -110,13 +110,14 @@ function useMermaidRender(code: string, resolvedTheme: string | undefined, toast
 
 export function MermaidBlock({ code }: MermaidBlockProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const scrollRegionRef = useRef<HTMLDivElement>(null);
+  const svgSizeRef = useRef<{ w: number; h: number } | null>(null);
   const [svgSize, setSvgSize] = useState<{ w: number; h: number } | null>(null);
+  const [scrollRegionElement, setScrollRegionElement] = useState<HTMLDivElement | null>(null);
   const [showCode, setShowCode] = useState(false);
   const { resolvedTheme } = useTheme();
   const { toast } = useToast();
   const { svg, error } = useMermaidRender(code, resolvedTheme, toast);
-  const viewportWidth = useMermaidViewportWidth(scrollRegionRef);
+  const viewportWidth = useMermaidViewportWidth(scrollRegionElement);
   const { scale, zoomIn, zoomOut, zoomReset, resetAutoScale } = useMermaidScale(
     svgSize,
     viewportWidth,
@@ -128,17 +129,20 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
   useLayoutEffect(() => {
     if (svg && containerRef.current) {
       const nextSize = getSvgDimensions(containerRef.current);
-      setSvgSize((prevSize) => {
-        if (sameSvgSize(prevSize, nextSize)) return prevSize;
+      if (!sameSvgSize(svgSizeRef.current, nextSize)) {
+        svgSizeRef.current = nextSize;
+        setSvgSize(nextSize);
         resetAutoScale();
-        return nextSize;
-      });
+      }
       return;
     }
     // svg reset back to null — drop the stale footprint so the wrapper
     // doesn't reserve space for a diagram that's no longer rendered.
-    setSvgSize(null);
-    resetAutoScale();
+    if (svgSizeRef.current !== null) {
+      svgSizeRef.current = null;
+      setSvgSize(null);
+      resetAutoScale();
+    }
   }, [svg, resetAutoScale]);
 
   const toggleCode = useCallback(() => setShowCode((v) => !v), []);
@@ -169,7 +173,7 @@ export function MermaidBlock({ code }: MermaidBlockProps) {
   return (
     <div className="mermaid-block group/mermaid relative my-3 block w-full max-w-full min-w-0 rounded-md border border-border/50 bg-muted/20">
       <div
-        ref={scrollRegionRef}
+        ref={setScrollRegionElement}
         className="mermaid-scroll-region w-full overflow-x-auto overflow-y-hidden p-3"
         style={{ display: showCode ? "none" : undefined }}
       >

--- a/apps/web/components/shared/mermaid-block.tsx
+++ b/apps/web/components/shared/mermaid-block.tsx
@@ -1,19 +1,10 @@
 "use client";
 
-import { type RefObject, useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
 import { useTheme } from "@/components/theme/app-theme";
 import { IconZoomIn, IconZoomOut, IconCode } from "@tabler/icons-react";
-import {
-  DEFAULT_SCALE,
-  SCALE_STEP,
-  MIN_SCALE,
-  MAX_SCALE,
-  calculateMermaidFitScale,
-  getElementContentWidth,
-  getSvgDimensions,
-  sanitizeMermaidCode,
-  cleanupMermaidOrphans,
-} from "./mermaid-utils";
+import { getSvgDimensions, sanitizeMermaidCode, cleanupMermaidOrphans } from "./mermaid-utils";
+import { useMermaidScale, useMermaidViewportWidth } from "./mermaid-block-hooks";
 import { useToast } from "@/components/toast-provider";
 
 type MermaidAPI = typeof import("mermaid").default;
@@ -48,63 +39,6 @@ function sameSvgSize(
   b: { w: number; h: number } | null,
 ): boolean {
   return a?.w === b?.w && a?.h === b?.h;
-}
-
-function useMermaidViewportWidth(scrollRegionRef: RefObject<HTMLElement | null>): number {
-  const [viewportWidth, setViewportWidth] = useState(0);
-
-  const measureViewport = useCallback(() => {
-    if (!scrollRegionRef.current) return;
-    if (window.getComputedStyle(scrollRegionRef.current).display === "none") return;
-    setViewportWidth(getElementContentWidth(scrollRegionRef.current));
-  }, [scrollRegionRef]);
-
-  useLayoutEffect(() => {
-    measureViewport();
-    const element = scrollRegionRef.current;
-    if (!element) return;
-
-    if (typeof ResizeObserver === "undefined") {
-      window.addEventListener("resize", measureViewport);
-      return () => window.removeEventListener("resize", measureViewport);
-    }
-
-    const observer = new ResizeObserver(measureViewport);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [measureViewport, scrollRegionRef]);
-
-  return viewportWidth;
-}
-
-function useMermaidScale(svgSize: { w: number; h: number } | null, viewportWidth: number) {
-  const [scale, setScale] = useState(DEFAULT_SCALE);
-  const [manualScale, setManualScale] = useState(false);
-  const fitScale = svgSize
-    ? calculateMermaidFitScale({ viewportWidth, svgWidth: svgSize.w })
-    : DEFAULT_SCALE;
-
-  useLayoutEffect(() => {
-    if (!manualScale) {
-      setScale(fitScale);
-    }
-  }, [fitScale, manualScale]);
-
-  const zoomIn = useCallback(() => {
-    setManualScale(true);
-    setScale((s) => Math.min(s + SCALE_STEP, MAX_SCALE));
-  }, []);
-  const zoomOut = useCallback(() => {
-    setManualScale(true);
-    setScale((s) => Math.max(s - SCALE_STEP, MIN_SCALE));
-  }, []);
-  const zoomReset = useCallback(() => {
-    setManualScale(false);
-    setScale(fitScale);
-  }, [fitScale]);
-  const resetAutoScale = useCallback(() => setManualScale(false), []);
-
-  return { scale, zoomIn, zoomOut, zoomReset, resetAutoScale };
 }
 
 /**

--- a/apps/web/components/shared/mermaid-utils.test.ts
+++ b/apps/web/components/shared/mermaid-utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SCALE,
-  MAX_SCALE,
   calculateMermaidFitScale,
   getElementContentWidth,
   sanitizeMermaidCode,
@@ -23,21 +22,6 @@ describe("calculateMermaidFitScale", () => {
   it("uses the default scale until valid measurements are available", () => {
     expect(calculateMermaidFitScale({ viewportWidth: 0, svgWidth: 1200 })).toBe(DEFAULT_SCALE);
     expect(calculateMermaidFitScale({ viewportWidth: 600, svgWidth: 0 })).toBe(DEFAULT_SCALE);
-  });
-
-  it("honors an explicit default scale as the maximum fitted scale", () => {
-    expect(calculateMermaidFitScale({ viewportWidth: 900, svgWidth: 800, defaultScale: 1 })).toBe(
-      1,
-    );
-    expect(calculateMermaidFitScale({ viewportWidth: 600, svgWidth: 800, defaultScale: 1 })).toBe(
-      0.75,
-    );
-  });
-
-  it("clamps explicit default scales before using them", () => {
-    expect(calculateMermaidFitScale({ viewportWidth: 0, svgWidth: 1200, defaultScale: 99 })).toBe(
-      MAX_SCALE,
-    );
   });
 });
 

--- a/apps/web/components/shared/mermaid-utils.test.ts
+++ b/apps/web/components/shared/mermaid-utils.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeMermaidCode } from "./mermaid-utils";
+import { DEFAULT_SCALE, calculateMermaidFitScale, sanitizeMermaidCode } from "./mermaid-utils";
+
+describe("calculateMermaidFitScale", () => {
+  it("keeps the default scale when the diagram already fits", () => {
+    expect(calculateMermaidFitScale({ viewportWidth: 900, svgWidth: 800 })).toBe(DEFAULT_SCALE);
+  });
+
+  it("shrinks below the default scale when the diagram is wider than the viewport", () => {
+    expect(calculateMermaidFitScale({ viewportWidth: 600, svgWidth: 1200 })).toBe(0.5);
+  });
+
+  it("clamps to the minimum scale for extremely wide diagrams", () => {
+    expect(calculateMermaidFitScale({ viewportWidth: 100, svgWidth: 4000 })).toBe(0.1);
+  });
+
+  it("uses the default scale until valid measurements are available", () => {
+    expect(calculateMermaidFitScale({ viewportWidth: 0, svgWidth: 1200 })).toBe(DEFAULT_SCALE);
+    expect(calculateMermaidFitScale({ viewportWidth: 600, svgWidth: 0 })).toBe(DEFAULT_SCALE);
+  });
+});
 
 describe("sanitizeMermaidCode", () => {
   it("leaves a pre-quoted bracket label with parens inside untouched", () => {

--- a/apps/web/components/shared/mermaid-utils.test.ts
+++ b/apps/web/components/shared/mermaid-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SCALE, calculateMermaidFitScale, sanitizeMermaidCode } from "./mermaid-utils";
+import {
+  DEFAULT_SCALE,
+  MAX_SCALE,
+  calculateMermaidFitScale,
+  getElementContentWidth,
+  sanitizeMermaidCode,
+} from "./mermaid-utils";
 
 describe("calculateMermaidFitScale", () => {
   it("keeps the default scale when the diagram already fits", () => {
@@ -17,6 +23,37 @@ describe("calculateMermaidFitScale", () => {
   it("uses the default scale until valid measurements are available", () => {
     expect(calculateMermaidFitScale({ viewportWidth: 0, svgWidth: 1200 })).toBe(DEFAULT_SCALE);
     expect(calculateMermaidFitScale({ viewportWidth: 600, svgWidth: 0 })).toBe(DEFAULT_SCALE);
+  });
+
+  it("honors an explicit default scale as the maximum fitted scale", () => {
+    expect(calculateMermaidFitScale({ viewportWidth: 900, svgWidth: 800, defaultScale: 1 })).toBe(
+      1,
+    );
+    expect(calculateMermaidFitScale({ viewportWidth: 600, svgWidth: 800, defaultScale: 1 })).toBe(
+      0.75,
+    );
+  });
+
+  it("clamps explicit default scales before using them", () => {
+    expect(calculateMermaidFitScale({ viewportWidth: 0, svgWidth: 1200, defaultScale: 99 })).toBe(
+      MAX_SCALE,
+    );
+  });
+});
+
+describe("getElementContentWidth", () => {
+  it("subtracts horizontal padding from the element client width", () => {
+    const el = document.createElement("div");
+    el.style.paddingLeft = "10px";
+    el.style.paddingRight = "5px";
+    Object.defineProperty(el, "clientWidth", { value: 100, configurable: true });
+
+    document.body.appendChild(el);
+    try {
+      expect(getElementContentWidth(el)).toBe(85);
+    } finally {
+      el.remove();
+    }
   });
 });
 

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -12,6 +12,22 @@ export function cleanupMermaidOrphans(id: string): void {
   document.getElementById(`d${id}`)?.remove();
 }
 
+type MermaidFitScaleInput = {
+  viewportWidth: number;
+  svgWidth: number;
+  defaultScale?: number;
+};
+
+export function calculateMermaidFitScale({
+  viewportWidth,
+  svgWidth,
+  defaultScale = DEFAULT_SCALE,
+}: MermaidFitScaleInput): number {
+  if (viewportWidth <= 0 || svgWidth <= 0) return defaultScale;
+  const fitScale = Math.min(defaultScale, viewportWidth / svgWidth);
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, fitScale));
+}
+
 export function emitMermaidRenderError(message: string): void {
   document.dispatchEvent(new CustomEvent(MERMAID_ERROR_EVENT, { detail: { message } }));
 }

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -18,14 +18,26 @@ type MermaidFitScaleInput = {
   defaultScale?: number;
 };
 
+function clampScale(scale: number): number {
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));
+}
+
 export function calculateMermaidFitScale({
   viewportWidth,
   svgWidth,
   defaultScale = DEFAULT_SCALE,
 }: MermaidFitScaleInput): number {
-  if (viewportWidth <= 0 || svgWidth <= 0) return defaultScale;
-  const fitScale = Math.min(defaultScale, viewportWidth / svgWidth);
-  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, fitScale));
+  const clampedDefault = clampScale(defaultScale);
+  if (viewportWidth <= 0 || svgWidth <= 0) return clampedDefault;
+  const fitScale = Math.min(clampedDefault, viewportWidth / svgWidth);
+  return clampScale(fitScale);
+}
+
+export function getElementContentWidth(element: HTMLElement): number {
+  const style = window.getComputedStyle(element);
+  const padding =
+    Number.parseFloat(style.paddingLeft || "0") + Number.parseFloat(style.paddingRight || "0");
+  return Math.max(0, element.clientWidth - padding);
 }
 
 export function emitMermaidRenderError(message: string): void {

--- a/apps/web/components/shared/mermaid-utils.ts
+++ b/apps/web/components/shared/mermaid-utils.ts
@@ -15,7 +15,6 @@ export function cleanupMermaidOrphans(id: string): void {
 type MermaidFitScaleInput = {
   viewportWidth: number;
   svgWidth: number;
-  defaultScale?: number;
 };
 
 function clampScale(scale: number): number {
@@ -25,11 +24,9 @@ function clampScale(scale: number): number {
 export function calculateMermaidFitScale({
   viewportWidth,
   svgWidth,
-  defaultScale = DEFAULT_SCALE,
 }: MermaidFitScaleInput): number {
-  const clampedDefault = clampScale(defaultScale);
-  if (viewportWidth <= 0 || svgWidth <= 0) return clampedDefault;
-  const fitScale = Math.min(clampedDefault, viewportWidth / svgWidth);
+  if (viewportWidth <= 0 || svgWidth <= 0) return DEFAULT_SCALE;
+  const fitScale = Math.min(DEFAULT_SCALE, viewportWidth / svgWidth);
   return clampScale(fitScale);
 }
 

--- a/apps/web/e2e/tests/chat/mermaid-fit-helpers.ts
+++ b/apps/web/e2e/tests/chat/mermaid-fit-helpers.ts
@@ -1,0 +1,70 @@
+import { expect, type Page } from "@playwright/test";
+import type { SeedData } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import { SessionPage } from "../../pages/session-page";
+
+const WIDE_MERMAID_MESSAGE = [
+  "Wide diagram:",
+  "",
+  "```mermaid",
+  "sequenceDiagram",
+  "  participant Runner as Runner (in-job)",
+  "  participant Collector as OTel Collector (internal)",
+  "  participant Poller as Poller (cron, outbound)",
+  "  participant GitHub as GitHub Actions API",
+  "  participant Tempo as Tempo Trace Store",
+  "  Runner->>Collector: OTLP push lock/determinator spans (live, trace=hash(run_id))",
+  "  Poller->>GitHub: GET /actions/runs + /jobs (outbound polling)",
+  "  GitHub-->>Poller: run/job/step timestamps",
+  "  Poller->>Collector: OTLP emit workflow+job+step spans (same trace=hash(run_id))",
+  "  Collector->>Tempo: forward both sources",
+  "```",
+].join("\n");
+
+export async function seedTaskWithWideMermaidMessage(
+  testPage: Page,
+  apiClient: ApiClient,
+  seedData: SeedData,
+  title: string,
+): Promise<SessionPage> {
+  const task = await apiClient.createTaskWithAgent(
+    seedData.workspaceId,
+    title,
+    seedData.agentProfileId,
+    {
+      description: "/e2e:simple-message",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    },
+  );
+  if (!task.session_id) throw new Error("createTaskWithAgent did not return a session_id");
+
+  await apiClient.seedSessionMessage(task.session_id, {
+    type: "message",
+    content: WIDE_MERMAID_MESSAGE,
+  });
+
+  await testPage.goto(`/t/${task.id}`);
+  const session = new SessionPage(testPage);
+  await session.waitForLoad();
+  return session;
+}
+
+export async function expectMermaidDiagramFitsViewport(session: SessionPage): Promise<void> {
+  const block = session.chat.locator(".mermaid-block").last();
+  await expect(block).toBeVisible({ timeout: 30_000 });
+  await expect(block.locator(".mermaid-scroll-region svg")).toBeVisible({ timeout: 30_000 });
+
+  await expect
+    .poll(
+      async () =>
+        block.evaluate((element) => {
+          const scrollRegion = element.querySelector<HTMLElement>(".mermaid-scroll-region");
+          if (!scrollRegion) return false;
+          return scrollRegion.scrollWidth <= scrollRegion.clientWidth + 1;
+        }),
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+}

--- a/apps/web/e2e/tests/chat/mermaid-fit-helpers.ts
+++ b/apps/web/e2e/tests/chat/mermaid-fit-helpers.ts
@@ -52,7 +52,7 @@ export async function seedTaskWithWideMermaidMessage(
 }
 
 export async function expectMermaidDiagramFitsViewport(session: SessionPage): Promise<void> {
-  const block = session.chat.locator(".mermaid-block").last();
+  const block = session.activeChat().locator(".mermaid-block").last();
   await expect(block).toBeVisible({ timeout: 30_000 });
   await expect(block.locator(".mermaid-scroll-region svg")).toBeVisible({ timeout: 30_000 });
 

--- a/apps/web/e2e/tests/chat/mermaid-fit.spec.ts
+++ b/apps/web/e2e/tests/chat/mermaid-fit.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "../../fixtures/test-base";
+import {
+  expectMermaidDiagramFitsViewport,
+  seedTaskWithWideMermaidMessage,
+} from "./mermaid-fit-helpers";
+
+test.describe("Mermaid diagram fit", () => {
+  test("auto-scales wide diagrams to the chat viewport", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const session = await seedTaskWithWideMermaidMessage(
+      testPage,
+      apiClient,
+      seedData,
+      "Mermaid Fit Desktop",
+    );
+
+    await expectMermaidDiagramFitsViewport(session);
+  });
+});

--- a/apps/web/e2e/tests/chat/mobile-mermaid-fit.spec.ts
+++ b/apps/web/e2e/tests/chat/mobile-mermaid-fit.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "../../fixtures/test-base";
+import {
+  expectMermaidDiagramFitsViewport,
+  seedTaskWithWideMermaidMessage,
+} from "./mermaid-fit-helpers";
+
+test.describe("Mobile Mermaid diagram fit", () => {
+  test("auto-scales wide diagrams to the mobile chat viewport", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    const session = await seedTaskWithWideMermaidMessage(
+      testPage,
+      apiClient,
+      seedData,
+      "Mermaid Fit Mobile",
+    );
+
+    await expectMermaidDiagramFitsViewport(session);
+  });
+});


### PR DESCRIPTION
Wide Mermaid diagrams in chat could overflow into horizontal scrolling on narrow panes. They now auto-scale to the available chat viewport while preserving manual zoom controls.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs && make typecheck`
- `make test`
- `make lint`
- `make build-web`
- `cd apps/web && pnpm exec playwright test --config e2e/playwright.config.ts --project=chromium --project=mobile-chrome tests/chat/mermaid-fit.spec.ts tests/chat/mobile-mermaid-fit.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->