### PR TITLE
fix: stop iOS focus-zoom on mobile text fields

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -202,18 +202,19 @@
   }
 }
 
-/* iOS Safari auto-zooms a focused text field whose computed font-size is
-   < 16px. Force 16px on coarse-pointer (touch) devices to stop focus-zoom.
-   !important because some controls are styled by more specific selectors that
-   would otherwise win on specificity. Only true editing hosts are targeted:
-   `[contenteditable="false"]` decorations (TipTap mention chips, code-block
-   views) are excluded, and the decorative `.code-block-language` <select> is
-   left at its compact size — native selects open a picker rather than zooming
-   the viewport, so they don't need the 16px floor. */
+/* iOS Safari auto-zooms a focused form control whose computed font-size is
+   < 16px (native <select> included). Force 16px on coarse-pointer (touch)
+   devices to stop focus-zoom. !important because some controls are styled by
+   more specific selectors that would otherwise win on specificity — e.g. the
+   compact `.tiptap pre .code-block-language` picker (0.625rem). Bumping that
+   picker to 16px only happens on touch, where a larger tap target is an
+   improvement; desktop (fine pointer) keeps the compact size. Only true
+   editing hosts get the contenteditable rule — `[contenteditable="false"]`
+   decorations (mention chips, code-block views) are excluded. */
 @media (pointer: coarse) {
   input,
   textarea,
-  select:not(.code-block-language),
+  select,
   [contenteditable="true"],
   [contenteditable="plaintext-only"] {
     font-size: 16px !important;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -202,6 +202,20 @@
   }
 }
 
+/* iOS Safari auto-zooms a focused form control whose computed font-size is
+   < 16px. Force 16px on coarse-pointer (touch) devices to stop focus-zoom.
+   Kept unlayered on purpose so it overrides Tailwind's text-size utilities
+   (e.g. text-sm/text-xs) — moving it into @layer base would let those win
+   and silently break the fix. */
+@media (pointer: coarse) {
+  input,
+  textarea,
+  select,
+  [contenteditable] {
+    font-size: 16px;
+  }
+}
+
 *::-webkit-scrollbar {
   width: 10px;
   height: 10px;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -210,8 +210,11 @@
    picker to 16px only happens on touch, where a larger tap target is an
    improvement; desktop (fine pointer) keeps the compact size. Only true
    editing hosts get the contenteditable rule — `[contenteditable="false"]`
-   decorations (mention chips, code-block views) are excluded. */
-@media (pointer: coarse) {
+   decorations (mention chips, code-block views) are excluded.
+   `any-pointer` (not `pointer`) so the floor also applies on hybrid devices
+   whose primary pointer is fine (e.g. a touchscreen laptop with a mouse),
+   where a touch tap can still focus a field. */
+@media (any-pointer: coarse) {
   input,
   textarea,
   select,

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -204,15 +204,18 @@
 
 /* iOS Safari auto-zooms a focused form control whose computed font-size is
    < 16px. Force 16px on coarse-pointer (touch) devices to stop focus-zoom.
-   Kept unlayered on purpose so it overrides Tailwind's text-size utilities
-   (e.g. text-sm/text-xs) — moving it into @layer base would let those win
-   and silently break the fix. */
+   !important because some controls are styled by more specific selectors
+   (e.g. `.tiptap pre .code-block-language` at 0.625rem) that would otherwise
+   win on specificity and keep the field under 16px. Only true editing hosts
+   are targeted — `[contenteditable="false"]` decorations (TipTap mention
+   chips, code-block views) are deliberately excluded. */
 @media (pointer: coarse) {
   input,
   textarea,
   select,
-  [contenteditable] {
-    font-size: 16px;
+  [contenteditable="true"],
+  [contenteditable="plaintext-only"] {
+    font-size: 16px !important;
   }
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -202,17 +202,18 @@
   }
 }
 
-/* iOS Safari auto-zooms a focused form control whose computed font-size is
+/* iOS Safari auto-zooms a focused text field whose computed font-size is
    < 16px. Force 16px on coarse-pointer (touch) devices to stop focus-zoom.
-   !important because some controls are styled by more specific selectors
-   (e.g. `.tiptap pre .code-block-language` at 0.625rem) that would otherwise
-   win on specificity and keep the field under 16px. Only true editing hosts
-   are targeted — `[contenteditable="false"]` decorations (TipTap mention
-   chips, code-block views) are deliberately excluded. */
+   !important because some controls are styled by more specific selectors that
+   would otherwise win on specificity. Only true editing hosts are targeted:
+   `[contenteditable="false"]` decorations (TipTap mention chips, code-block
+   views) are excluded, and the decorative `.code-block-language` <select> is
+   left at its compact size — native selects open a picker rather than zooming
+   the viewport, so they don't need the 16px floor. */
 @media (pointer: coarse) {
   input,
   textarea,
-  select,
+  select:not(.code-block-language),
   [contenteditable="true"],
   [contenteditable="plaintext-only"] {
     font-size: 16px !important;

--- a/apps/web/e2e/tests/mobile-zoom.spec.ts
+++ b/apps/web/e2e/tests/mobile-zoom.spec.ts
@@ -12,7 +12,10 @@ test.describe("Mobile zoom hardening", () => {
     await mobile.goto();
 
     const content = await testPage.locator('meta[name="viewport"]').getAttribute("content");
-    expect(content).toContain("maximum-scale=1");
+    // Split into tokens so the assertion pins the exact value — a plain
+    // substring check would also pass for a typo like `maximum-scale=10`.
+    const tokens = content?.split(",").map((token) => token.trim()) ?? [];
+    expect(tokens).toContain("maximum-scale=1");
   });
 
   test("form fields render at >= 16px to prevent iOS focus-zoom", async ({ testPage }) => {

--- a/apps/web/e2e/tests/mobile-zoom.spec.ts
+++ b/apps/web/e2e/tests/mobile-zoom.spec.ts
@@ -19,6 +19,14 @@ test.describe("Mobile zoom hardening", () => {
     const mobile = new MobileKanbanPage(testPage);
     await mobile.goto();
 
+    // Guard: the 16px rule is gated on `@media (pointer: coarse)`. The
+    // mobile-chrome project (Pixel 5) emulates touch, so the testPage context
+    // resolves to a coarse pointer. Assert it here so a future fixture change
+    // that drops touch emulation fails loudly instead of silently skipping the
+    // rule under test.
+    const coarse = await testPage.evaluate(() => matchMedia("(pointer: coarse)").matches);
+    expect(coarse).toBe(true);
+
     await mobile.openSearch();
     const input = mobile.searchInput();
     await input.focus();

--- a/apps/web/e2e/tests/mobile-zoom.spec.ts
+++ b/apps/web/e2e/tests/mobile-zoom.spec.ts
@@ -2,22 +2,10 @@ import { test, expect } from "../fixtures/test-base";
 import { MobileKanbanPage } from "../pages/mobile-kanban-page";
 
 // Runs on the mobile-chrome Playwright project (Pixel 5 emulation, touch →
-// pointer: coarse) — see e2e/playwright.config.ts. Guards the two iOS-zoom
-// fixes: the 16px coarse-pointer form-control rule (globals.css) that stops
-// focus-zoom, and the maximum-scale=1 viewport meta (index.html) that blocks
-// casual page pinch-zoom.
+// any-pointer: coarse) — see e2e/playwright.config.ts. Guards the iOS focus-zoom
+// fix: the 16px coarse-pointer form-control rule (globals.css) that stops Safari
+// from auto-zooming when a sub-16px field is focused.
 test.describe("Mobile zoom hardening", () => {
-  test("viewport meta pins maximum-scale=1", async ({ testPage }) => {
-    const mobile = new MobileKanbanPage(testPage);
-    await mobile.goto();
-
-    const content = await testPage.locator('meta[name="viewport"]').getAttribute("content");
-    // Split into tokens so the assertion pins the exact value — a plain
-    // substring check would also pass for a typo like `maximum-scale=10`.
-    const tokens = content?.split(",").map((token) => token.trim()) ?? [];
-    expect(tokens).toContain("maximum-scale=1");
-  });
-
   test("form fields render at >= 16px to prevent iOS focus-zoom", async ({ testPage }) => {
     const mobile = new MobileKanbanPage(testPage);
     await mobile.goto();

--- a/apps/web/e2e/tests/mobile-zoom.spec.ts
+++ b/apps/web/e2e/tests/mobile-zoom.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "../fixtures/test-base";
+import { MobileKanbanPage } from "../pages/mobile-kanban-page";
+
+// Runs on the mobile-chrome Playwright project (Pixel 5 emulation, touch →
+// pointer: coarse) — see e2e/playwright.config.ts. Guards the two iOS-zoom
+// fixes: the 16px coarse-pointer form-control rule (globals.css) that stops
+// focus-zoom, and the maximum-scale=1 viewport meta (index.html) that blocks
+// casual page pinch-zoom.
+test.describe("Mobile zoom hardening", () => {
+  test("viewport meta pins maximum-scale=1", async ({ testPage }) => {
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    const content = await testPage.locator('meta[name="viewport"]').getAttribute("content");
+    expect(content).toContain("maximum-scale=1");
+  });
+
+  test("form fields render at >= 16px to prevent iOS focus-zoom", async ({ testPage }) => {
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    await mobile.openSearch();
+    const input = mobile.searchInput();
+    await input.focus();
+
+    const fontSize = await input.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+    expect(fontSize).toBeGreaterThanOrEqual(16);
+  });
+});

--- a/apps/web/e2e/tests/mobile-zoom.spec.ts
+++ b/apps/web/e2e/tests/mobile-zoom.spec.ts
@@ -22,12 +22,12 @@ test.describe("Mobile zoom hardening", () => {
     const mobile = new MobileKanbanPage(testPage);
     await mobile.goto();
 
-    // Guard: the 16px rule is gated on `@media (pointer: coarse)`. The
+    // Guard: the 16px rule is gated on `@media (any-pointer: coarse)`. The
     // mobile-chrome project (Pixel 5) emulates touch, so the testPage context
-    // resolves to a coarse pointer. Assert it here so a future fixture change
-    // that drops touch emulation fails loudly instead of silently skipping the
-    // rule under test.
-    const coarse = await testPage.evaluate(() => matchMedia("(pointer: coarse)").matches);
+    // exposes a coarse pointer. Assert it here so a future fixture change that
+    // drops touch emulation fails loudly instead of silently skipping the rule
+    // under test.
+    const coarse = await testPage.evaluate(() => matchMedia("(any-pointer: coarse)").matches);
     expect(coarse).toBe(true);
 
     await mobile.openSearch();

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="color-scheme" content="light dark" />
+    <!-- maximum-scale=1 intentionally blocks casual page pinch-zoom for an app-like
+         feel. This does NOT disable OS-level accessibility zoom (iOS triple-tap /
+         AssistiveTouch, Android magnification), which is independent of the page
+         viewport. Focus-zoom is handled separately by the 16px coarse-pointer rule
+         in globals.css, not by this attribute. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, viewport-fit=cover" />
     <meta name="description" content="AI-powered workflow management for developers" />
     <meta name="theme-color" content="#f8fafc" media="(prefers-color-scheme: light)" />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,12 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="color-scheme" content="light dark" />
-    <!-- maximum-scale=1 intentionally blocks casual page pinch-zoom for an app-like
-         feel. This does NOT disable OS-level accessibility zoom (iOS triple-tap /
-         AssistiveTouch, Android magnification), which is independent of the page
-         viewport. Focus-zoom is handled separately by the 16px coarse-pointer rule
-         in globals.css, not by this attribute. -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="AI-powered workflow management for developers" />
     <meta name="theme-color" content="#f8fafc" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="color-scheme" content="light dark" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, viewport-fit=cover" />
     <meta name="description" content="AI-powered workflow management for developers" />
     <meta name="theme-color" content="#f8fafc" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />


### PR DESCRIPTION
iOS Safari zoomed the page in on every text-field focus, making the app feel like a webpage rather than an app. Fields now stay put on focus.

## Important Changes

- `globals.css` adds an `@media (any-pointer: coarse)` rule forcing form controls to 16px — iOS only auto-zooms focused fields under 16px (our `text-sm`/`text-xs` controls were 12–14px). `any-pointer` so it also covers hybrid touch devices; the decorative code-block language `<select>` is included so its picker can't trigger zoom either. `!important` to beat more-specific editor selectors.

## Validation

- `pnpm --filter @kandev/web typecheck` / `lint` — pass
- `e2e/tests/mobile-zoom.spec.ts` (Pixel 5 project): asserts the context is coarse-pointer and focused fields compute ≥16px — passing in CI across all E2E shards
- Manually verified on a real iPhone: tapping the New Task title no longer zooms

## Possible Improvements

Low risk. 16px fields are slightly denser inside the fixed `h-7` inputs on touch; intended tradeoff. Casual pinch-zoom is intentionally left enabled — blocking it on iOS would require a JS gesture handler that also disables legitimate accessibility zoom (WCAG 1.4.4).

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.