### PR TITLE
fix: restore create task selector scrolling

### DIFF
--- a/apps/web/components/combobox.tsx
+++ b/apps/web/components/combobox.tsx
@@ -16,6 +16,7 @@ import {
 } from "@kandev/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@kandev/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
+import { useTaskCreateDialogPopoverContainer } from "@/hooks/use-task-create-dialog-popover-container";
 
 export type ComboboxOption = {
   value: string;
@@ -159,6 +160,7 @@ export const Combobox = memo(function Combobox({
   loading = false,
 }: ComboboxProps) {
   const [open, setOpen] = useState(false);
+  const portalContainer = useTaskCreateDialogPopoverContainer();
   // Track the highlighted item. Defaults to the selected value so the current
   // selection is highlighted when the popover opens (not the first item).
   const [highlighted, setHighlighted] = useState("");
@@ -204,6 +206,7 @@ export const Combobox = memo(function Combobox({
         side={popoverSide}
         align={popoverAlign}
         portal={popoverPortal}
+        portalContainer={portalContainer}
       >
         <Command
           value={highlighted}

--- a/apps/web/e2e/tests/task/repository-selector-scroll.spec.ts
+++ b/apps/web/e2e/tests/task/repository-selector-scroll.spec.ts
@@ -3,17 +3,46 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { test, expect } from "../../fixtures/test-base";
+import type { Page } from "@playwright/test";
 import { useRegularMode } from "../../helpers/regular-mode";
 import { KanbanPage } from "../../pages/kanban-page";
 
-// Regression: the task creation repository selector portals out of the clipped
-// form subtree, but remains inside the dialog so modal scroll locking still
+// Regression: task creation selectors portal out of the clipped
+// form subtree, but remain inside the dialog so modal scroll locking still
 // permits wheel scrolling.
 
 // Exercises the regular task-create dialog (New Task in the sidebar); run with office off.
 useRegularMode();
 
-test.describe("repository selector scroll", () => {
+async function expectWheelScrollsListInsideDialog(testPage: Page) {
+  const list = testPage.locator("[cmdk-list]").first();
+  await expect(list).toBeVisible();
+  await expect
+    .poll(() => list.evaluate((el) => Boolean(el.closest('[data-testid="create-task-dialog"]'))))
+    .toBe(true);
+
+  const { clientHeight, scrollHeight } = await list.evaluate((el) => ({
+    clientHeight: el.clientHeight,
+    scrollHeight: el.scrollHeight,
+  }));
+  expect(scrollHeight).toBeGreaterThan(clientHeight);
+
+  await list.evaluate((el) => {
+    el.scrollTop = 0;
+  });
+  expect(await list.evaluate((el) => el.scrollTop)).toBe(0);
+
+  const box = await list.boundingBox();
+  if (!box) throw new Error("selector list has no bounding box");
+  await testPage.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await testPage.mouse.wheel(0, 400);
+
+  await expect
+    .poll(() => list.evaluate((el) => el.scrollTop), { timeout: 2000 })
+    .toBeGreaterThan(0);
+}
+
+test.describe("create task selector scroll", () => {
   test("wheel scrolls the repository list portaled inside the dialog", async ({
     testPage,
     apiClient,
@@ -50,34 +79,61 @@ test.describe("repository selector scroll", () => {
     // (the dialog now uses the multi-repo chip layout, not the legacy
     // single repository-selector combobox).
     await testPage.getByTestId("repo-chip-trigger").first().click();
+    await expectWheelScrollsListInsideDialog(testPage);
+  });
 
-    const list = testPage.locator("[cmdk-list]").first();
-    await expect(list).toBeVisible();
-    await expect
-      .poll(() => list.evaluate((el) => Boolean(el.closest('[data-testid="create-task-dialog"]'))))
-      .toBe(true);
+  test("wheel scrolls the branch list portaled inside the dialog", async ({
+    testPage,
+    backend,
+  }) => {
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    const gitEnv = {
+      ...process.env,
+      HOME: backend.tmpDir,
+      GIT_AUTHOR_NAME: "E2E Test",
+      GIT_AUTHOR_EMAIL: "e2e@test.local",
+      GIT_COMMITTER_NAME: "E2E Test",
+      GIT_COMMITTER_EMAIL: "e2e@test.local",
+    };
+    for (let i = 0; i < 20; i++) {
+      execSync(`git branch -f scroll-branch-${i} main`, { cwd: repoDir, env: gitEnv });
+    }
 
-    // Sanity: the list is actually overflowing.
-    const { clientHeight, scrollHeight } = await list.evaluate((el) => ({
-      clientHeight: el.clientHeight,
-      scrollHeight: el.scrollHeight,
-    }));
-    expect(scrollHeight).toBeGreaterThan(clientHeight);
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
 
-    // Force the list to the top so we can reliably detect a downward wheel.
-    await list.evaluate((el) => {
-      el.scrollTop = 0;
-    });
-    expect(await list.evaluate((el) => el.scrollTop)).toBe(0);
+    await kanban.createTaskButton.first().click();
+    await expect(testPage.getByTestId("create-task-dialog")).toBeVisible();
 
-    // Dispatch a real wheel event via the mouse at the center of the list.
-    const box = await list.boundingBox();
-    if (!box) throw new Error("repository list has no bounding box");
-    await testPage.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    await testPage.mouse.wheel(0, 400);
+    await testPage.getByTestId("repo-chip-trigger").first().click();
+    await testPage.getByRole("option", { name: /E2E Repo/ }).click();
 
-    await expect
-      .poll(() => list.evaluate((el) => el.scrollTop), { timeout: 2000 })
-      .toBeGreaterThan(0);
+    const branchSelector = testPage.getByTestId("branch-chip-trigger").first();
+    await expect(branchSelector).toBeEnabled({ timeout: 5_000 });
+    await branchSelector.click();
+    await expectWheelScrollsListInsideDialog(testPage);
+  });
+
+  test("wheel scrolls the agent profile list portaled inside the dialog", async ({
+    testPage,
+    apiClient,
+  }) => {
+    const { agents } = await apiClient.listAgents();
+    const agentId = agents[0]?.id;
+    if (!agentId) throw new Error("no agent available in test fixtures");
+    for (let i = 0; i < 20; i++) {
+      await apiClient.createAgentProfile(agentId, `Scroll Agent Profile ${i}`, {
+        model: "mock-fast",
+      });
+    }
+
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await kanban.createTaskButton.first().click();
+    await expect(testPage.getByTestId("create-task-dialog")).toBeVisible();
+
+    await testPage.getByTestId("agent-profile-selector").click();
+    await expectWheelScrollsListInsideDialog(testPage);
   });
 });


### PR DESCRIPTION
Create-task selector popovers could sit outside the dialog scroll boundary, which made touchpad wheel scrolling unreliable in the agent/profile dropdown. The shared combobox now uses the dialog popover container when available, so selector lists scroll normally without clipping the dialog.

## Validation

- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- `make build-backend`
- `make build-web`
- `pnpm e2e tests/task/repository-selector-scroll.spec.ts --project=chromium`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test` (initial backend ACP replay timeout passed on focused rerun; full rerun passed)
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->