### PR TITLE
fix: persist profiles for deferred MCP tasks

### DIFF
--- a/apps/backend/internal/integration/mcp_integration_test.go
+++ b/apps/backend/internal/integration/mcp_integration_test.go
@@ -1,12 +1,14 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	mcphandlers "github.com/kandev/kandev/internal/mcp/handlers"
+	taskservice "github.com/kandev/kandev/internal/task/service"
 	ws "github.com/kandev/kandev/pkg/websocket"
 )
 
@@ -25,6 +27,11 @@ func setupMCPTestServer(t *testing.T) (*TestServer, string, string, string, stri
 	t.Cleanup(func() { client.Close() })
 
 	workspaceID := createWorkspace(t, client)
+	defaultProfileID := "default-agent-profile"
+	_, err := ts.TaskSvc.UpdateWorkspace(context.Background(), workspaceID, &taskservice.UpdateWorkspaceRequest{
+		DefaultAgentProfileID: &defaultProfileID,
+	})
+	require.NoError(t, err)
 
 	// Create workflow
 	workflowResp, err := client.SendRequest("wf-1", ws.ActionWorkflowCreate, map[string]interface{}{

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -466,24 +466,13 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		WorkflowID:     req.WorkflowID,
 		WorkflowStepID: req.WorkflowStepID,
 	}
-	launchConfig, err := h.resolveMCPAutoStartConfigWithError(ctx, pendingTask, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
+	launchConfig, metadata, err := h.resolveMCPLaunchMetadata(ctx, pendingTask, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
 	if err != nil {
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
-			"failed to resolve launch profile: "+err.Error(), nil)
-	}
-	if launchConfig.AgentProfileID == "" {
-		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation,
-			"agent_profile_id is required because no agent profile can be resolved from the parent task, source task, workflow, or workspace defaults",
-			nil)
-	}
-	metadata := map[string]interface{}{
-		models.MetaKeyAgentProfileID: launchConfig.AgentProfileID,
-	}
-	if launchConfig.ExecutorID != "" {
-		metadata[models.MetaKeyExecutorID] = launchConfig.ExecutorID
-	}
-	if launchConfig.ExecutorProfileID != "" {
-		metadata[models.MetaKeyExecutorProfileID] = launchConfig.ExecutorProfileID
+		code := ws.ErrorCodeInternalError
+		if errors.Is(err, errMCPAgentProfileRequired) {
+			code = ws.ErrorCodeValidation
+		}
+		return ws.NewError(msg.ID, msg.Action, code, err.Error(), nil)
 	}
 
 	task, err := h.taskSvc.CreateTask(ctx, &service.CreateTaskRequest{
@@ -659,6 +648,8 @@ type mcpAutoStartConfig struct {
 	ExecutorProfileID string
 }
 
+var errMCPAgentProfileRequired = errors.New("agent_profile_id is required because no agent profile can be resolved from the parent task, source task, workflow, or workspace defaults")
+
 // autoStartTask launches an agent session for a newly created task in the background.
 // It is kept as a small compatibility wrapper for direct tests; handleCreateTask
 // uses resolveMCPAutoStartConfig before persisting so invalid auto-start
@@ -677,6 +668,26 @@ func (h *Handlers) autoStartTask(task *models.Task, agentProfileID, executorProf
 func (h *Handlers) resolveMCPAutoStartConfig(ctx context.Context, task *models.Task, agentProfileID, executorProfileID, sourceTaskID string) mcpAutoStartConfig {
 	config, _ := h.resolveMCPAutoStartConfigWithError(ctx, task, agentProfileID, executorProfileID, sourceTaskID)
 	return config
+}
+
+func (h *Handlers) resolveMCPLaunchMetadata(ctx context.Context, task *models.Task, agentProfileID, executorProfileID, sourceTaskID string) (mcpAutoStartConfig, map[string]interface{}, error) {
+	launchConfig, err := h.resolveMCPAutoStartConfigWithError(ctx, task, agentProfileID, executorProfileID, sourceTaskID)
+	if err != nil {
+		return mcpAutoStartConfig{}, nil, fmt.Errorf("failed to resolve launch profile: %w", err)
+	}
+	if launchConfig.AgentProfileID == "" {
+		return mcpAutoStartConfig{}, nil, errMCPAgentProfileRequired
+	}
+	metadata := map[string]interface{}{
+		models.MetaKeyAgentProfileID: launchConfig.AgentProfileID,
+	}
+	if launchConfig.ExecutorID != "" {
+		metadata[models.MetaKeyExecutorID] = launchConfig.ExecutorID
+	}
+	if launchConfig.ExecutorProfileID != "" {
+		metadata[models.MetaKeyExecutorProfileID] = launchConfig.ExecutorProfileID
+	}
+	return launchConfig, metadata, nil
 }
 
 func (h *Handlers) resolveMCPAutoStartConfigWithError(ctx context.Context, task *models.Task, agentProfileID, executorProfileID, sourceTaskID string) (mcpAutoStartConfig, error) {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -460,21 +460,23 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation, "workflow_id is required", nil)
 	}
 
-	var autoStartConfig *mcpAutoStartConfig
-	if startAgent && h.sessionLauncher != nil {
-		pendingTask := &models.Task{
-			ParentID:       req.ParentID,
-			WorkspaceID:    req.WorkspaceID,
-			WorkflowID:     req.WorkflowID,
-			WorkflowStepID: req.WorkflowStepID,
-		}
-		config := h.resolveMCPAutoStartConfig(ctx, pendingTask, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
-		if config.AgentProfileID == "" {
-			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation,
-				"agent_profile_id is required when start_agent is true and no agent profile can be resolved from the parent task, source task, workflow, or workspace defaults; pass agent_profile_id or set start_agent=false",
-				nil)
-		}
-		autoStartConfig = &config
+	pendingTask := &models.Task{
+		ParentID:       req.ParentID,
+		WorkspaceID:    req.WorkspaceID,
+		WorkflowID:     req.WorkflowID,
+		WorkflowStepID: req.WorkflowStepID,
+	}
+	launchConfig := h.resolveMCPAutoStartConfig(ctx, pendingTask, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
+	if launchConfig.AgentProfileID == "" {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation,
+			"agent_profile_id is required because no agent profile can be resolved from the parent task, source task, workflow, or workspace defaults",
+			nil)
+	}
+	metadata := map[string]interface{}{
+		models.MetaKeyAgentProfileID: launchConfig.AgentProfileID,
+	}
+	if launchConfig.ExecutorProfileID != "" {
+		metadata[models.MetaKeyExecutorProfileID] = launchConfig.ExecutorProfileID
 	}
 
 	task, err := h.taskSvc.CreateTask(ctx, &service.CreateTaskRequest{
@@ -487,6 +489,7 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		Repositories:           repos,
 		BlockedBy:              req.BlockedBy,
 		AssigneeAgentProfileID: req.AssigneeAgentProfileID,
+		Metadata:               metadata,
 	})
 	if err != nil {
 		h.logger.Error("failed to create task", zap.Error(err))
@@ -500,11 +503,7 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 
 	// Auto-start agent session asynchronously only if requested
 	if startAgent && h.sessionLauncher != nil {
-		if autoStartConfig == nil {
-			config := h.resolveMCPAutoStartConfig(ctx, task, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
-			autoStartConfig = &config
-		}
-		h.launchAutoStartTask(ctx, task, *autoStartConfig)
+		h.launchAutoStartTask(ctx, task, launchConfig)
 	}
 
 	return ws.NewResponse(msg.ID, msg.Action, dto.FromTask(task))

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -475,6 +475,9 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 	metadata := map[string]interface{}{
 		models.MetaKeyAgentProfileID: launchConfig.AgentProfileID,
 	}
+	if launchConfig.ExecutorID != "" {
+		metadata[models.MetaKeyExecutorID] = launchConfig.ExecutorID
+	}
 	if launchConfig.ExecutorProfileID != "" {
 		metadata[models.MetaKeyExecutorProfileID] = launchConfig.ExecutorProfileID
 	}

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -466,7 +466,11 @@ func (h *Handlers) handleCreateTask(ctx context.Context, msg *ws.Message) (*ws.M
 		WorkflowID:     req.WorkflowID,
 		WorkflowStepID: req.WorkflowStepID,
 	}
-	launchConfig := h.resolveMCPAutoStartConfig(ctx, pendingTask, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
+	launchConfig, err := h.resolveMCPAutoStartConfigWithError(ctx, pendingTask, req.AgentProfileID, req.ExecutorProfileID, req.SourceTaskID)
+	if err != nil {
+		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError,
+			"failed to resolve launch profile: "+err.Error(), nil)
+	}
 	if launchConfig.AgentProfileID == "" {
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeValidation,
 			"agent_profile_id is required because no agent profile can be resolved from the parent task, source task, workflow, or workspace defaults",
@@ -671,7 +675,15 @@ func (h *Handlers) autoStartTask(task *models.Task, agentProfileID, executorProf
 // defaults used by task opening where this handler can see them (workflow step
 // when a workflow controller is wired, workflow default, workspace default).
 func (h *Handlers) resolveMCPAutoStartConfig(ctx context.Context, task *models.Task, agentProfileID, executorProfileID, sourceTaskID string) mcpAutoStartConfig {
+	config, _ := h.resolveMCPAutoStartConfigWithError(ctx, task, agentProfileID, executorProfileID, sourceTaskID)
+	return config
+}
+
+func (h *Handlers) resolveMCPAutoStartConfigWithError(ctx context.Context, task *models.Task, agentProfileID, executorProfileID, sourceTaskID string) (mcpAutoStartConfig, error) {
 	executorID := h.inheritFromTaskSession(ctx, task.ParentID, &agentProfileID, &executorProfileID)
+	if metadataExecutorID := h.inheritFromTaskMetadata(ctx, task.ParentID, &agentProfileID, &executorProfileID); executorID == "" {
+		executorID = metadataExecutorID
+	}
 
 	// For top-level tasks, inherit from the source task (the calling agent's task).
 	if task.ParentID == "" && sourceTaskID != "" {
@@ -679,14 +691,24 @@ func (h *Handlers) resolveMCPAutoStartConfig(ctx context.Context, task *models.T
 		if executorID == "" {
 			executorID = sourceExecutorID
 		}
+		if metadataExecutorID := h.inheritFromTaskMetadata(ctx, sourceTaskID, &agentProfileID, &executorProfileID); executorID == "" {
+			executorID = metadataExecutorID
+		}
 	}
 
 	if agentProfileID == "" {
-		agentProfileID = h.resolveWorkflowAgentProfile(ctx, task.WorkflowStepID, task.WorkflowID)
+		var err error
+		agentProfileID, err = h.resolveWorkflowAgentProfileWithError(ctx, task.WorkflowStepID, task.WorkflowID)
+		if err != nil {
+			return mcpAutoStartConfig{}, fmt.Errorf("resolve workflow agent profile: %w", err)
+		}
 	}
 	if agentProfileID == "" && h.taskSvc != nil {
 		workspace, err := h.taskSvc.GetWorkspace(ctx, task.WorkspaceID)
-		if err == nil && workspace.DefaultAgentProfileID != nil {
+		if err != nil {
+			return mcpAutoStartConfig{}, fmt.Errorf("get workspace %s: %w", task.WorkspaceID, err)
+		}
+		if workspace != nil && workspace.DefaultAgentProfileID != nil {
 			agentProfileID = *workspace.DefaultAgentProfileID
 		}
 	}
@@ -698,18 +720,27 @@ func (h *Handlers) resolveMCPAutoStartConfig(ctx context.Context, task *models.T
 		AgentProfileID:    agentProfileID,
 		ExecutorID:        executorID,
 		ExecutorProfileID: executorProfileID,
-	}
+	}, nil
 }
 
 func (h *Handlers) resolveWorkflowAgentProfile(ctx context.Context, workflowStepID, workflowID string) string {
+	profileID, _ := h.resolveWorkflowAgentProfileWithError(ctx, workflowStepID, workflowID)
+	return profileID
+}
+
+func (h *Handlers) resolveWorkflowAgentProfileWithError(ctx context.Context, workflowStepID, workflowID string) (string, error) {
 	profileID, resolvedWorkflowID := h.resolveWorkflowControllerAgentProfile(ctx, workflowStepID, workflowID)
 	if profileID != "" {
-		return profileID
+		return profileID, nil
 	}
 	if workflowID == "" {
 		workflowID = resolvedWorkflowID
 	}
-	return h.workflowDefaultAgentProfile(ctx, workflowID)
+	profileID, err := h.workflowDefaultAgentProfileWithError(ctx, workflowID)
+	if err != nil {
+		return "", err
+	}
+	return profileID, nil
 }
 
 func (h *Handlers) resolveWorkflowControllerAgentProfile(ctx context.Context, workflowStepID, workflowID string) (string, string) {
@@ -745,14 +776,19 @@ func (h *Handlers) resolveWorkflowStartStepAgentProfile(ctx context.Context, wor
 }
 
 func (h *Handlers) workflowDefaultAgentProfile(ctx context.Context, workflowID string) string {
+	profileID, _ := h.workflowDefaultAgentProfileWithError(ctx, workflowID)
+	return profileID
+}
+
+func (h *Handlers) workflowDefaultAgentProfileWithError(ctx context.Context, workflowID string) (string, error) {
 	if workflowID == "" || h.taskSvc == nil {
-		return ""
+		return "", nil
 	}
 	workflow, err := h.taskSvc.GetWorkflow(ctx, workflowID)
 	if err != nil || workflow == nil {
-		return ""
+		return "", err
 	}
-	return workflow.AgentProfileID
+	return workflow.AgentProfileID, nil
 }
 
 func startStepAgentProfile(steps []*workflowmodels.WorkflowStep) string {
@@ -837,6 +873,32 @@ func (h *Handlers) inheritFromTaskSession(ctx context.Context, parentID string, 
 	// An executor profile already encodes its executor reference.
 	if *executorProfileID == "" {
 		return parent.ExecutorID
+	}
+	return ""
+}
+
+func (h *Handlers) inheritFromTaskMetadata(ctx context.Context, taskID string, agentProfileID, executorProfileID *string) string {
+	if taskID == "" || h.taskSvc == nil {
+		return ""
+	}
+	task, err := h.taskSvc.GetTask(ctx, taskID)
+	if err != nil || task == nil {
+		return ""
+	}
+	if *agentProfileID == "" {
+		if v, ok := task.Metadata[models.MetaKeyAgentProfileID].(string); ok && v != "" {
+			*agentProfileID = v
+		}
+	}
+	if *executorProfileID == "" {
+		if v, ok := task.Metadata[models.MetaKeyExecutorProfileID].(string); ok && v != "" {
+			*executorProfileID = v
+		}
+	}
+	if *executorProfileID == "" {
+		if v, ok := task.Metadata[models.MetaKeyExecutorID].(string); ok && v != "" {
+			return v
+		}
 	}
 	return ""
 }

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -691,19 +691,13 @@ func (h *Handlers) resolveMCPLaunchMetadata(ctx context.Context, task *models.Ta
 }
 
 func (h *Handlers) resolveMCPAutoStartConfigWithError(ctx context.Context, task *models.Task, agentProfileID, executorProfileID, sourceTaskID string) (mcpAutoStartConfig, error) {
-	executorID := h.inheritFromTaskSession(ctx, task.ParentID, &agentProfileID, &executorProfileID)
-	if metadataExecutorID := h.inheritFromTaskMetadata(ctx, task.ParentID, &agentProfileID, &executorProfileID); executorID == "" {
-		executorID = metadataExecutorID
-	}
+	executorID := h.inheritFromTask(ctx, task.ParentID, &agentProfileID, &executorProfileID)
 
 	// For top-level tasks, inherit from the source task (the calling agent's task).
 	if task.ParentID == "" && sourceTaskID != "" {
-		sourceExecutorID := h.inheritFromTaskSession(ctx, sourceTaskID, &agentProfileID, &executorProfileID)
+		sourceExecutorID := h.inheritFromTask(ctx, sourceTaskID, &agentProfileID, &executorProfileID)
 		if executorID == "" {
 			executorID = sourceExecutorID
-		}
-		if metadataExecutorID := h.inheritFromTaskMetadata(ctx, sourceTaskID, &agentProfileID, &executorProfileID); executorID == "" {
-			executorID = metadataExecutorID
 		}
 	}
 
@@ -858,58 +852,67 @@ func (h *Handlers) launchAutoStartTask(ctx context.Context, task *models.Task, c
 	}()
 }
 
-// inheritFromTaskSession fills agentProfileID and executorProfileID from another
-// task's primary session when not explicitly provided. It returns that session's ExecutorID
-// as a fallback for when the parent session has no executor profile (common for
-// UI-created sessions). If ExecutorProfileID is resolved, ExecutorID is redundant
-// since the profile already encodes the executor reference.
-func (h *Handlers) inheritFromTaskSession(ctx context.Context, parentID string, agentProfileID, executorProfileID *string) string {
-	if parentID == "" {
-		return ""
-	}
-	if h.taskSvc == nil {
-		return ""
-	}
-	parent, err := h.taskSvc.GetPrimarySession(ctx, parentID)
-	if err != nil || parent == nil {
-		return ""
-	}
-	if *agentProfileID == "" {
-		*agentProfileID = parent.AgentProfileID
-	}
-	if *executorProfileID == "" {
-		*executorProfileID = parent.ExecutorProfileID
-	}
-	// Only return ExecutorID as fallback when no profile was resolved.
-	// An executor profile already encodes its executor reference.
-	if *executorProfileID == "" {
-		return parent.ExecutorID
-	}
-	return ""
-}
-
-func (h *Handlers) inheritFromTaskMetadata(ctx context.Context, taskID string, agentProfileID, executorProfileID *string) string {
+// inheritFromTask fills agentProfileID and executorProfileID from another task's
+// primary session or durable metadata when not explicitly provided. It returns a
+// bare ExecutorID only when no executor profile was resolved, because an
+// executor profile already encodes its executor reference.
+func (h *Handlers) inheritFromTask(ctx context.Context, taskID string, agentProfileID, executorProfileID *string) string {
 	if taskID == "" || h.taskSvc == nil {
 		return ""
 	}
-	task, err := h.taskSvc.GetTask(ctx, taskID)
-	if err != nil || task == nil {
+
+	executorID := h.inheritFromPrimarySession(ctx, taskID, agentProfileID, executorProfileID)
+	needsMetadata := *agentProfileID == "" || *executorProfileID == "" || executorID != ""
+	if needsMetadata {
+		executorID = h.inheritFromTaskMetadata(ctx, taskID, agentProfileID, executorProfileID, executorID)
+	}
+
+	if *executorProfileID != "" {
+		return ""
+	}
+	return executorID
+}
+
+func (h *Handlers) inheritFromPrimarySession(ctx context.Context, taskID string, agentProfileID, executorProfileID *string) string {
+	session, err := h.taskSvc.GetPrimarySession(ctx, taskID)
+	if err != nil || session == nil {
 		return ""
 	}
 	if *agentProfileID == "" {
-		if v, ok := task.Metadata[models.MetaKeyAgentProfileID].(string); ok && v != "" {
-			*agentProfileID = v
-		}
+		*agentProfileID = session.AgentProfileID
 	}
 	if *executorProfileID == "" {
-		if v, ok := task.Metadata[models.MetaKeyExecutorProfileID].(string); ok && v != "" {
-			*executorProfileID = v
-		}
+		*executorProfileID = session.ExecutorProfileID
 	}
-	if *executorProfileID == "" {
-		if v, ok := task.Metadata[models.MetaKeyExecutorID].(string); ok && v != "" {
-			return v
-		}
+	if *executorProfileID != "" {
+		return ""
+	}
+	return session.ExecutorID
+}
+
+func (h *Handlers) inheritFromTaskMetadata(ctx context.Context, taskID string, agentProfileID, executorProfileID *string, executorID string) string {
+	task, err := h.taskSvc.GetTask(ctx, taskID)
+	if err != nil || task == nil {
+		return executorID
+	}
+	inheritMetadataValue(task.Metadata, models.MetaKeyAgentProfileID, agentProfileID)
+	inheritMetadataValue(task.Metadata, models.MetaKeyExecutorProfileID, executorProfileID)
+	if executorID == "" && *executorProfileID == "" {
+		executorID = metadataString(task.Metadata, models.MetaKeyExecutorID)
+	}
+	return executorID
+}
+
+func inheritMetadataValue(metadata map[string]interface{}, key string, target *string) {
+	if *target != "" {
+		return
+	}
+	*target = metadataString(metadata, key)
+}
+
+func metadataString(metadata map[string]interface{}, key string) string {
+	if v, ok := metadata[key].(string); ok && v != "" {
+		return v
 	}
 	return ""
 }

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -531,6 +531,112 @@ func TestHandleCreateTask_InheritsDeferredSourceTaskMetadata(t *testing.T) {
 	assert.Equal(t, "metadata-executor", task.Metadata[models.MetaKeyExecutorID])
 }
 
+func TestHandleCreateTask_InheritsDeferredParentTaskMetadata(t *testing.T) {
+	svc, _ := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
+	require.NoError(t, err)
+	require.Len(t, workflows, 1)
+
+	parent, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: workspaces[0].ID,
+		WorkflowID:  workflows[0].ID,
+		Title:       "Deferred parent",
+		Metadata: map[string]interface{}{
+			models.MetaKeyAgentProfileID: "parent-profile",
+			models.MetaKeyExecutorID:     "parent-executor",
+		},
+	})
+	require.NoError(t, err)
+
+	h := &Handlers{
+		taskSvc: svc,
+		logger:  testLogger(t).WithFields(),
+	}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"parent_id":   parent.ID,
+		"title":       "Child from deferred parent",
+		"start_agent": false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	require.Equalf(t, ws.MessageTypeResponse, resp.Type, "create_task should succeed; payload: %s", string(resp.Payload))
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &created))
+	require.NotEmpty(t, created.ID)
+
+	task, err := svc.GetTask(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, task.Metadata)
+	assert.Equal(t, "parent-profile", task.Metadata[models.MetaKeyAgentProfileID])
+	assert.Equal(t, "parent-executor", task.Metadata[models.MetaKeyExecutorID])
+}
+
+func TestHandleCreateTask_MetadataExecutorProfileClearsSessionExecutorID(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
+	require.NoError(t, err)
+	require.Len(t, workflows, 1)
+
+	source, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: workspaces[0].ID,
+		WorkflowID:  workflows[0].ID,
+		Title:       "Source with mixed launch metadata",
+		Metadata: map[string]interface{}{
+			models.MetaKeyExecutorProfileID: "metadata-executor-profile",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:             "mixed-source-session",
+		TaskID:         source.ID,
+		AgentProfileID: "source-profile",
+		ExecutorID:     "session-executor",
+		State:          models.TaskSessionStateWaitingForInput,
+		IsPrimary:      true,
+	}))
+
+	h := &Handlers{
+		taskSvc: svc,
+		logger:  testLogger(t).WithFields(),
+	}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"source_task_id": source.ID,
+		"workspace_id":   workspaces[0].ID,
+		"workflow_id":    workflows[0].ID,
+		"title":          "Child without mixed executor metadata",
+		"start_agent":    false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	require.Equalf(t, ws.MessageTypeResponse, resp.Type, "create_task should succeed; payload: %s", string(resp.Payload))
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &created))
+	require.NotEmpty(t, created.ID)
+
+	task, err := svc.GetTask(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, task.Metadata)
+	assert.Equal(t, "source-profile", task.Metadata[models.MetaKeyAgentProfileID])
+	assert.Equal(t, "metadata-executor-profile", task.Metadata[models.MetaKeyExecutorProfileID])
+	assert.Empty(t, task.Metadata[models.MetaKeyExecutorID])
+}
+
 func TestHandleCreateTask_InvalidWorkflowProfileLookupReturnsInternalError(t *testing.T) {
 	svc, _ := newTestTaskService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -338,6 +338,92 @@ func TestHandleCreateTask_StartAgentRequiresResolvableAgentProfile(t *testing.T)
 	assert.Empty(t, tasks, "failed auto-start preflight must not leave a broken task behind")
 }
 
+func TestHandleCreateTask_StartAgentFalseRequiresResolvableAgentProfile(t *testing.T) {
+	svc, _ := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
+	require.NoError(t, err)
+	require.Len(t, workflows, 1)
+
+	h := &Handlers{
+		taskSvc: svc,
+		logger:  testLogger(t).WithFields(),
+	}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"workspace_id": workspaces[0].ID,
+		"workflow_id":  workflows[0].ID,
+		"title":        "Invalid deferred task",
+		"description":  "This should not be persisted without a profile.",
+		"start_agent":  false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeValidation)
+
+	tasks, err := svc.ListTasks(ctx, workflows[0].ID)
+	require.NoError(t, err)
+	assert.Empty(t, tasks, "failed deferred preflight must not leave a broken task behind")
+}
+
+func TestHandleCreateTask_StartAgentFalsePersistsInheritedAgentProfile(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
+	require.NoError(t, err)
+	require.Len(t, workflows, 1)
+
+	source, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: workspaces[0].ID,
+		WorkflowID:  workflows[0].ID,
+		Title:       "Source task",
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:                "source-session",
+		TaskID:            source.ID,
+		AgentProfileID:    "source-profile",
+		ExecutorProfileID: "source-executor-profile",
+		State:             models.TaskSessionStateWaitingForInput,
+		IsPrimary:         true,
+	}))
+
+	h := &Handlers{
+		taskSvc: svc,
+		logger:  testLogger(t).WithFields(),
+	}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"source_task_id": source.ID,
+		"workspace_id":   workspaces[0].ID,
+		"workflow_id":    workflows[0].ID,
+		"title":          "Deferred child of context",
+		"description":    "This should open later with the inherited profile.",
+		"start_agent":    false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	require.Equalf(t, ws.MessageTypeResponse, resp.Type, "create_task should succeed; payload: %s", string(resp.Payload))
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &created))
+	require.NotEmpty(t, created.ID)
+
+	task, err := svc.GetTask(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, task.Metadata)
+	assert.Equal(t, "source-profile", task.Metadata[models.MetaKeyAgentProfileID])
+	assert.Equal(t, "source-executor-profile", task.Metadata[models.MetaKeyExecutorProfileID])
+}
+
 func TestHandleCreateTask_StartAgentUsesWorkspaceDefaultAgentProfile(t *testing.T) {
 	svc, _ := newTestTaskService(t)
 	ctx := context.Background()
@@ -830,11 +916,12 @@ func TestHandleCreateTask_SubtaskBaseBranchOverride(t *testing.T) {
 	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
 
 	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
-		"title":       "Child",
-		"description": "do the thing",
-		"parent_id":   parentID,
-		"base_branch": "feature/create-new-page-endp-05z",
-		"start_agent": false,
+		"title":            "Child",
+		"description":      "do the thing",
+		"parent_id":        parentID,
+		"base_branch":      "feature/create-new-page-endp-05z",
+		"agent_profile_id": "profile-1",
+		"start_agent":      false,
 	})
 
 	resp, err := h.handleCreateTask(ctx, msg)
@@ -873,9 +960,10 @@ func TestHandleCreateTask_SubtaskBaseBranchOverride_ExplicitReposWin(t *testing.
 	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
 
 	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
-		"title":       "Cross-repo child",
-		"description": "do the thing",
-		"parent_id":   parentID,
+		"title":            "Cross-repo child",
+		"description":      "do the thing",
+		"parent_id":        parentID,
+		"agent_profile_id": "profile-1",
 		// Explicit per-repo entry with its own base_branch.
 		"repositories": []map[string]interface{}{
 			{"repository_id": "repo-sibling", "base_branch": "develop"},
@@ -1080,8 +1168,9 @@ func TestHandleCreateTask_AutoResolvesWorkspaceAndWorkflow(t *testing.T) {
 	h := &Handlers{taskSvc: svc, logger: log.WithFields()}
 	// No workspace_id or workflow_id provided — should auto-resolve from defaults
 	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
-		"title":       "Auto-resolved task",
-		"start_agent": false,
+		"title":            "Auto-resolved task",
+		"agent_profile_id": "profile-1",
+		"start_agent":      false,
 	})
 
 	resp, err := h.handleCreateTask(ctx, msg)

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -480,6 +480,84 @@ func TestHandleCreateTask_StartAgentFalsePersistsInheritedExecutorID(t *testing.
 	assert.Empty(t, task.Metadata[models.MetaKeyExecutorProfileID])
 }
 
+func TestHandleCreateTask_InheritsDeferredSourceTaskMetadata(t *testing.T) {
+	svc, _ := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
+	require.NoError(t, err)
+	require.Len(t, workflows, 1)
+
+	source, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: workspaces[0].ID,
+		WorkflowID:  workflows[0].ID,
+		Title:       "Deferred source",
+		Metadata: map[string]interface{}{
+			models.MetaKeyAgentProfileID: "metadata-profile",
+			models.MetaKeyExecutorID:     "metadata-executor",
+		},
+	})
+	require.NoError(t, err)
+
+	h := &Handlers{
+		taskSvc: svc,
+		logger:  testLogger(t).WithFields(),
+	}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"source_task_id": source.ID,
+		"workspace_id":   workspaces[0].ID,
+		"workflow_id":    workflows[0].ID,
+		"title":          "Child from deferred source",
+		"description":    "This should inherit metadata without a source session.",
+		"start_agent":    false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	require.Equalf(t, ws.MessageTypeResponse, resp.Type, "create_task should succeed; payload: %s", string(resp.Payload))
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &created))
+	require.NotEmpty(t, created.ID)
+
+	task, err := svc.GetTask(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, task.Metadata)
+	assert.Equal(t, "metadata-profile", task.Metadata[models.MetaKeyAgentProfileID])
+	assert.Equal(t, "metadata-executor", task.Metadata[models.MetaKeyExecutorID])
+}
+
+func TestHandleCreateTask_InvalidWorkflowProfileLookupReturnsInternalError(t *testing.T) {
+	svc, _ := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+
+	h := &Handlers{
+		taskSvc: svc,
+		logger:  testLogger(t).WithFields(),
+	}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"workspace_id": workspaces[0].ID,
+		"workflow_id":  "missing-workflow",
+		"title":        "Task with broken workflow lookup",
+		"start_agent":  false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+
+	var ep ws.ErrorPayload
+	require.NoError(t, json.Unmarshal(resp.Payload, &ep))
+	assert.Contains(t, ep.Message, "failed to resolve launch profile")
+}
+
 func TestHandleCreateTask_StartAgentUsesWorkspaceDefaultAgentProfile(t *testing.T) {
 	svc, _ := newTestTaskService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -424,6 +424,62 @@ func TestHandleCreateTask_StartAgentFalsePersistsInheritedAgentProfile(t *testin
 	assert.Equal(t, "source-executor-profile", task.Metadata[models.MetaKeyExecutorProfileID])
 }
 
+func TestHandleCreateTask_StartAgentFalsePersistsInheritedExecutorID(t *testing.T) {
+	svc, repo := newTestTaskService(t)
+	ctx := context.Background()
+	workspaces, err := svc.ListWorkspaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, workspaces, 1)
+	workflows, err := svc.ListWorkflows(ctx, workspaces[0].ID, false)
+	require.NoError(t, err)
+	require.Len(t, workflows, 1)
+
+	source, err := svc.CreateTask(ctx, &service.CreateTaskRequest{
+		WorkspaceID: workspaces[0].ID,
+		WorkflowID:  workflows[0].ID,
+		Title:       "Source task",
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:             "source-session",
+		TaskID:         source.ID,
+		AgentProfileID: "source-profile",
+		ExecutorID:     "exec-special",
+		State:          models.TaskSessionStateWaitingForInput,
+		IsPrimary:      true,
+	}))
+
+	h := &Handlers{
+		taskSvc: svc,
+		logger:  testLogger(t).WithFields(),
+	}
+	msg := makeWSMessage(t, ws.ActionMCPCreateTask, map[string]interface{}{
+		"source_task_id": source.ID,
+		"workspace_id":   workspaces[0].ID,
+		"workflow_id":    workflows[0].ID,
+		"title":          "Deferred task with bare executor",
+		"description":    "This should open later with the inherited executor.",
+		"start_agent":    false,
+	})
+
+	resp, err := h.handleCreateTask(ctx, msg)
+	require.NoError(t, err)
+	require.Equalf(t, ws.MessageTypeResponse, resp.Type, "create_task should succeed; payload: %s", string(resp.Payload))
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &created))
+	require.NotEmpty(t, created.ID)
+
+	task, err := svc.GetTask(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, task.Metadata)
+	assert.Equal(t, "source-profile", task.Metadata[models.MetaKeyAgentProfileID])
+	assert.Equal(t, "exec-special", task.Metadata[models.MetaKeyExecutorID])
+	assert.Empty(t, task.Metadata[models.MetaKeyExecutorProfileID])
+}
+
 func TestHandleCreateTask_StartAgentUsesWorkspaceDefaultAgentProfile(t *testing.T) {
 	svc, _ := newTestTaskService(t)
 	ctx := context.Background()

--- a/apps/backend/internal/mcp/server/server.go
+++ b/apps/backend/internal/mcp/server/server.go
@@ -525,6 +525,7 @@ WHEN TO OMIT parent_id (top-level task):
 
 IMPORTANT:
 - Subtasks inherit workspace, workflow, agent profile, and executor from the parent
+- Every created task must have a resolvable agent profile. start_agent=false still records the profile for a later manual start.
 - Subtasks inherit the parent's repository unless you supply repository_url, repository_id, or local_path — in which case the subtask targets that repo instead (must live in the parent's workspace)
 - base_branch behaviour:
   - Same repo as parent (no repo args): subtask inherits the parent's base_branch (sibling branches off the same starting point — useful for PR stacks)
@@ -532,7 +533,7 @@ IMPORTANT:
   - Pass base_branch explicitly to override either default. Use list_repositories_kandev to see each repo's default_branch.
 - Top-level tasks need a repository via repository_url, repository_id, or local_path
 - 'description' is the sub-agent's initial prompt — be specific and detailed
-- start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the description. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later, or creating a tracking task with no immediate work). When in doubt, leave it true.
+- start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the description. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later, or creating a tracking task with no immediate work), and still pass agent_profile_id unless it can be inherited. When in doubt, leave it true.
 - Kanban subtasks cannot have their own subtasks (max nesting depth is 1). To break work down further, create a sibling under the same parent. (Office task trees are exempt.)`
 	parentDesc := "Parent task ID for subtasks. Use 'self' to create a subtask of your current task (RECOMMENDED for plan phases, delegated work). Omit only for unrelated top-level tasks."
 
@@ -542,8 +543,9 @@ IMPORTANT:
 IMPORTANT:
 - Provide a repository via repository_url, repository_id, or local_path
 - workspace_id and workflow_id are auto-resolved if only one exists; provide explicitly if ambiguous
+- Every created task must have a resolvable agent profile. start_agent=false still records the profile for a later manual start.
 - 'description' is the agent's initial prompt — be specific and detailed
-- start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the description. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later). When in doubt, leave it true.
+- start_agent defaults to true and is what you want in nearly every case — the new task auto-launches an agent that immediately works on the description. Pass start_agent=false ONLY for an explicit placeholder (e.g. queuing work the user will start later), and still pass agent_profile_id unless a default exists. When in doubt, leave it true.
 - Use parent_id only when delegating to a known existing task by its ID`
 		parentDesc = "Optional parent task ID. Omit for top-level tasks; provide an existing task ID only to create a subtask of that task."
 	}
@@ -557,7 +559,7 @@ IMPORTANT:
 			mcp.WithString("workflow_step_id", mcp.Description("The workflow step ID (optional, auto-resolved if omitted)")),
 			mcp.WithString("title", mcp.Required(), mcp.Description("The task title")),
 			mcp.WithString("description", mcp.Description("The initial prompt for the sub-agent. This is the ONLY context the agent receives when it starts — treat it as the agent's first user message. REQUIRED for subtasks: without a description the sub-agent starts with no context and cannot do useful work. Be specific and detailed.")),
-			mcp.WithString("agent_profile_id", mcp.Description("Agent profile ID to use. For subtasks, inherited from the parent session. For top-level tasks, ask the user which agent profile they want (e.g. Claude Code, OpenCode) if not already known.")),
+			mcp.WithString("agent_profile_id", mcp.Description("Agent profile ID to use. Required unless it can be inherited from the parent/source task, workflow, or workspace defaults. start_agent=false still needs a profile for later manual start.")),
 			mcp.WithString("executor_profile_id", mcp.Description("Executor profile ID to use (determines the runtime environment: local, worktree, docker, etc.). For subtasks, inherited from the parent session. For top-level tasks, ask the user which executor profile they want if not already known.")),
 			mcp.WithBoolean("start_agent", mcp.Description("Whether to auto-start an agent on the created task. Default: true — leave it true unless you specifically want a placeholder task with no agent running. Setting false leaves the task waiting for the user to click 'Start agent' in the UI; the description is preserved but no work happens automatically.")),
 			mcp.WithString("repository_id", mcp.Description("Repository ID. Required for top-level tasks unless local_path or repository_url is provided. For subtasks: optional — supply only when the subtask should target a different repo than the parent.")),

--- a/apps/backend/internal/orchestrator/event_handlers_workflow.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow.go
@@ -364,6 +364,7 @@ func (s *Service) handleTaskMovedNoSession(ctx context.Context, data watcher.Tas
 	if agentProfileID == "" {
 		agentProfileID, _ = task.Metadata[models.MetaKeyAgentProfileID].(string)
 	}
+	executorID, _ := task.Metadata[models.MetaKeyExecutorID].(string)
 	executorProfileID, _ := task.Metadata[models.MetaKeyExecutorProfileID].(string)
 	planMode := step.HasOnEnterAction(wfmodels.OnEnterEnablePlanMode)
 
@@ -371,13 +372,14 @@ func (s *Service) handleTaskMovedNoSession(ctx context.Context, data watcher.Tas
 		zap.String("task_id", data.TaskID),
 		zap.String("to_step_id", data.ToStepID),
 		zap.String("agent_profile_id", agentProfileID),
+		zap.String("executor_id", executorID),
 		zap.String("executor_profile_id", executorProfileID),
 		zap.Bool("plan_mode", planMode))
 
 	// Async: event bus delivers synchronously; blocking here → HTTP timeout (see handleTaskMovedWithSession doc).
 	go func() {
 		asyncCtx := context.WithoutCancel(ctx)
-		_, err := s.StartTask(asyncCtx, task.ID, agentProfileID, "", executorProfileID, "", task.Description, data.ToStepID, planMode, true, nil)
+		_, err := s.StartTask(asyncCtx, task.ID, agentProfileID, executorID, executorProfileID, "", task.Description, data.ToStepID, planMode, true, nil)
 		if err != nil {
 			s.logger.Error("task.moved: failed to auto-start task",
 				zap.String("task_id", data.TaskID),

--- a/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_workflow_moved_test.go
@@ -6,10 +6,12 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
 	"github.com/kandev/kandev/internal/orchestrator/watcher"
 	"github.com/kandev/kandev/internal/task/models"
 	wfmodels "github.com/kandev/kandev/internal/workflow/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 func TestHandleTaskMoved(t *testing.T) {
@@ -151,6 +153,72 @@ func TestHandleTaskMovedNoSession(t *testing.T) {
 			FromStepID: "step1",
 			ToStepID:   "step2",
 		})
+	})
+
+	t.Run("auto-start uses executor_id from task metadata", func(t *testing.T) {
+		repo := setupTestRepo(t)
+		now := time.Now().UTC()
+		requireNoError(t, repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}))
+		requireNoError(t, repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "WF", CreatedAt: now, UpdatedAt: now}))
+		metadata := map[string]interface{}{
+			models.MetaKeyAgentProfileID: "profile-1",
+			models.MetaKeyExecutorID:     "exec-special",
+		}
+		requireNoError(t, repo.CreateTask(ctx, &models.Task{
+			ID:             "t1",
+			WorkspaceID:    "ws1",
+			WorkflowID:     "wf1",
+			WorkflowStepID: "step1",
+			Title:          "Task",
+			Description:    "prompt",
+			State:          v1.TaskStateCreated,
+			Metadata:       metadata,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}))
+
+		stepGetter := newMockStepGetter()
+		stepGetter.steps["step2"] = &wfmodels.WorkflowStep{
+			ID: "step2", WorkflowID: "wf1", Name: "Auto Start Step", Position: 1,
+			Events: wfmodels.StepEvents{
+				OnEnter: []wfmodels.OnEnterAction{
+					{Type: wfmodels.OnEnterAutoStartAgent},
+				},
+			},
+		}
+
+		taskRepo := newMockTaskRepo()
+		taskRepo.tasks["t1"] = &v1.Task{
+			ID:          "t1",
+			WorkspaceID: "ws1",
+			WorkflowID:  "wf1",
+			Description: "prompt",
+			State:       v1.TaskStateCreated,
+			Metadata:    metadata,
+		}
+		launched := make(chan string, 1)
+		agentMgr := &mockAgentManager{
+			launchAgentFunc: func(_ context.Context, req *executor.LaunchAgentRequest) (*executor.LaunchAgentResponse, error) {
+				executorID, _ := req.Metadata[models.MetaKeyExecutorID].(string)
+				launched <- executorID
+				return &executor.LaunchAgentResponse{AgentExecutionID: "exec-1"}, nil
+			},
+		}
+		svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+
+		svc.handleTaskMovedNoSession(ctx, watcher.TaskMovedEventData{
+			TaskID:   "t1",
+			ToStepID: "step2",
+		})
+
+		select {
+		case got := <-launched:
+			if got != "exec-special" {
+				t.Fatalf("ExecutorID = %q, want exec-special", got)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for auto-start launch")
+		}
 	})
 }
 

--- a/apps/backend/internal/orchestrator/session_ensure_test.go
+++ b/apps/backend/internal/orchestrator/session_ensure_test.go
@@ -203,6 +203,53 @@ func TestAcquireEnsureLock_AllowsConcurrencyAcrossTaskIDs(t *testing.T) {
 	}
 }
 
+func TestPrepareTaskSession_UsesExecutorIDFromTaskMetadata(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	taskRepo := newMockTaskRepo()
+	svc := createTestServiceWithScheduler(repo, newMockStepGetter(), taskRepo, &mockAgentManager{})
+
+	now := time.Now().UTC()
+	if err := repo.CreateWorkspace(ctx, &models.Workspace{ID: "ws1", Name: "Test", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if err := repo.CreateWorkflow(ctx, &models.Workflow{ID: "wf1", WorkspaceID: "ws1", Name: "Test Workflow", CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("seed workflow: %v", err)
+	}
+	metadata := map[string]interface{}{
+		models.MetaKeyAgentProfileID: "profile1",
+		models.MetaKeyExecutorID:     "exec-special",
+	}
+	if err := repo.CreateTask(ctx, &models.Task{
+		ID:          "task1",
+		WorkflowID:  "wf1",
+		WorkspaceID: "ws1",
+		Title:       "T",
+		Metadata:    metadata,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	taskRepo.tasks["task1"] = &v1.Task{
+		ID:          "task1",
+		WorkspaceID: "ws1",
+		Metadata:    metadata,
+	}
+
+	sessionID, err := svc.PrepareTaskSession(ctx, "task1", "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("PrepareTaskSession: %v", err)
+	}
+	session, err := repo.GetTaskSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetTaskSession: %v", err)
+	}
+	if session.ExecutorID != "exec-special" {
+		t.Fatalf("ExecutorID = %q, want exec-special", session.ExecutorID)
+	}
+}
+
 // Service-level companion to the lock primitive tests: with no pre-existing
 // session, N concurrent EnsureSession calls must converge on exactly one
 // created session. This catches regressions in findExistingSession or

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -144,12 +144,17 @@ func (s *Service) PrepareTaskSession(ctx context.Context, taskID string, agentPr
 
 	// Resolve agent/executor profile from task metadata if not explicitly provided
 	if agentProfileID == "" {
-		if v, ok := task.Metadata["agent_profile_id"].(string); ok && v != "" {
+		if v, ok := task.Metadata[models.MetaKeyAgentProfileID].(string); ok && v != "" {
 			agentProfileID = v
 		}
 	}
+	if executorID == "" {
+		if v, ok := task.Metadata[models.MetaKeyExecutorID].(string); ok && v != "" {
+			executorID = v
+		}
+	}
 	if executorProfileID == "" {
-		if v, ok := task.Metadata["executor_profile_id"].(string); ok && v != "" {
+		if v, ok := task.Metadata[models.MetaKeyExecutorProfileID].(string); ok && v != "" {
 			executorProfileID = v
 		}
 	}
@@ -581,6 +586,16 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 			zap.String("task_id", taskID),
 			zap.Error(err))
 		return nil, err
+	}
+	if executorID == "" {
+		if v, ok := task.Metadata[models.MetaKeyExecutorID].(string); ok && v != "" {
+			executorID = v
+		}
+	}
+	if executorProfileID == "" {
+		if v, ok := task.Metadata[models.MetaKeyExecutorProfileID].(string); ok && v != "" {
+			executorProfileID = v
+		}
 	}
 
 	// Override priority if provided in the request

--- a/apps/backend/internal/task/handlers/task_http_handlers.go
+++ b/apps/backend/internal/task/handlers/task_http_handlers.go
@@ -1183,10 +1183,10 @@ func (body *httpStartQuickChatRequest) resolveParams(workspace *models.Workspace
 
 	metadata := make(map[string]interface{})
 	if agentProfileID != "" {
-		metadata["agent_profile_id"] = agentProfileID
+		metadata[models.MetaKeyAgentProfileID] = agentProfileID
 	}
 	if executorID != "" {
-		metadata["executor_id"] = executorID
+		metadata[models.MetaKeyExecutorID] = executorID
 	}
 
 	title := body.Title
@@ -1304,11 +1304,11 @@ func resolveConfigChatDefaults(body httpStartConfigChatRequest, ws *models.Works
 		executorID = *ws.DefaultExecutorID
 	}
 	metadata = map[string]interface{}{
-		"config_mode":      true,
-		"agent_profile_id": agentProfileID,
+		"config_mode":                true,
+		models.MetaKeyAgentProfileID: agentProfileID,
 	}
 	if executorID != "" {
-		metadata["executor_id"] = executorID
+		metadata[models.MetaKeyExecutorID] = executorID
 	}
 	return agentProfileID, executorID, metadata
 }

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -59,6 +59,7 @@ type SearchMessagesOptions struct {
 // Task metadata keys used for deferred agent start (e.g., task.moved → handleTaskMovedNoSession).
 const (
 	MetaKeyAgentProfileID    = "agent_profile_id"
+	MetaKeyExecutorID        = "executor_id"
 	MetaKeyExecutorProfileID = "executor_profile_id"
 	// MetaKeyWorkspacePath is the optional host folder for repo-less tasks
 	// (set by CreateTask, read by the orchestrator when building a session).


### PR DESCRIPTION
MCP-created placeholder tasks could be saved without a durable launch profile, which made them fail later when the UI tried to ensure a session. Deferred task creation now resolves and records the profile up front, or rejects the request before saving an invalid task.

## Important Changes

- `create_task_kandev` now validates that an agent profile can be resolved even when `start_agent=false`.
- Resolved agent and executor profiles are persisted in task metadata so later manual starts use the same launch context.
- The MCP tool description now documents that deferred tasks still need a resolvable agent profile.

## Validation

- `make fmt` from `apps/backend`
- `make test` from `apps/backend`
- `make lint` from `apps/backend`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->