### PR TITLE
fix: recreate stale host utility instances (#1500)

### DIFF
--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -346,6 +346,7 @@ func (m *Manager) createInstance(ctx context.Context, agentType string) (*instan
 	}
 
 	client := agentctlclient.NewClient(m.controlHost, resp.Port, m.log,
+		agentctlclient.WithExecutionID(resp.ID),
 		agentctlclient.WithAuthToken(m.authToken))
 
 	// Wait a moment for the instance HTTP server to come up.
@@ -422,12 +423,10 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 	parentTmpDir := m.parentTmpDir
 	m.mu.RUnlock()
 	if inst != nil {
-		if err := m.checkInstanceHealthy(ctx, inst); err == nil {
+		if err := m.staleInstanceCause(ctx, inst); err == nil {
 			return inst, ia, nil
 		} else if ctx.Err() != nil {
 			return nil, nil, ctx.Err()
-		} else {
-			m.dropStaleInstance(ctx, agentType, inst, err)
 		}
 	}
 
@@ -444,7 +443,7 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 		existing := m.instances[agentType]
 		m.mu.RUnlock()
 		if existing != nil {
-			if err := m.checkInstanceHealthy(ctx, existing); err == nil {
+			if err := m.staleInstanceCause(ctx, existing); err == nil {
 				return existing, nil
 			} else if ctx.Err() != nil {
 				return nil, ctx.Err()
@@ -481,24 +480,23 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 
 const instanceHealthCheckTimeout = 500 * time.Millisecond
 
-func (m *Manager) checkInstanceHealthy(ctx context.Context, inst *instance) error {
+func (m *Manager) staleInstanceCause(ctx context.Context, inst *instance) error {
 	if inst == nil || inst.client == nil {
 		return errors.New("host utility instance client missing")
 	}
 	healthCtx, cancel := context.WithTimeout(ctx, instanceHealthCheckTimeout)
 	defer cancel()
-	return inst.client.Health(healthCtx)
+	err := inst.client.Health(healthCtx)
+	if err == nil {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func (m *Manager) dropStaleInstance(ctx context.Context, agentType string, inst *instance, cause error) {
-	m.mu.Lock()
-	if current := m.instances[agentType]; current != inst {
-		m.mu.Unlock()
-		return
-	}
-	delete(m.instances, agentType)
-	m.mu.Unlock()
-
 	m.log.Warn("host utility instance unhealthy; recreating",
 		zap.String("agent_type", agentType),
 		zap.String("instance_id", inst.instanceID),
@@ -506,6 +504,12 @@ func (m *Manager) dropStaleInstance(ctx context.Context, agentType string, inst 
 	deleteCtx, cancel := hostUtilityDeleteContext(ctx)
 	m.deleteInstance(deleteCtx, inst)
 	cancel()
+
+	m.mu.Lock()
+	if current := m.instances[agentType]; current == inst {
+		delete(m.instances, agentType)
+	}
+	m.mu.Unlock()
 }
 
 // probeTimeout caps each ACP probe so an agent that hangs (e.g. one that

--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -479,7 +479,7 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 	return v.(*instance), ia, nil
 }
 
-const instanceHealthCheckTimeout = time.Second
+const instanceHealthCheckTimeout = 500 * time.Millisecond
 
 func (m *Manager) checkInstanceHealthy(ctx context.Context, inst *instance) error {
 	if inst == nil || inst.client == nil {

--- a/apps/backend/internal/agent/hostutility/manager.go
+++ b/apps/backend/internal/agent/hostutility/manager.go
@@ -422,7 +422,13 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 	parentTmpDir := m.parentTmpDir
 	m.mu.RUnlock()
 	if inst != nil {
-		return inst, ia, nil
+		if err := m.checkInstanceHealthy(ctx, inst); err == nil {
+			return inst, ia, nil
+		} else if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		} else {
+			m.dropStaleInstance(ctx, agentType, inst, err)
+		}
 	}
 
 	if parentTmpDir == "" {
@@ -438,7 +444,13 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 		existing := m.instances[agentType]
 		m.mu.RUnlock()
 		if existing != nil {
-			return existing, nil
+			if err := m.checkInstanceHealthy(ctx, existing); err == nil {
+				return existing, nil
+			} else if ctx.Err() != nil {
+				return nil, ctx.Err()
+			} else {
+				m.dropStaleInstance(ctx, agentType, existing, err)
+			}
 		}
 		// Pre-check installation so Refresh surfaces `not_installed`
 		// instead of collapsing it into `failed` via createInstance errors.
@@ -465,6 +477,35 @@ func (m *Manager) getInstance(ctx context.Context, agentType string) (*instance,
 		return nil, nil, err
 	}
 	return v.(*instance), ia, nil
+}
+
+const instanceHealthCheckTimeout = time.Second
+
+func (m *Manager) checkInstanceHealthy(ctx context.Context, inst *instance) error {
+	if inst == nil || inst.client == nil {
+		return errors.New("host utility instance client missing")
+	}
+	healthCtx, cancel := context.WithTimeout(ctx, instanceHealthCheckTimeout)
+	defer cancel()
+	return inst.client.Health(healthCtx)
+}
+
+func (m *Manager) dropStaleInstance(ctx context.Context, agentType string, inst *instance, cause error) {
+	m.mu.Lock()
+	if current := m.instances[agentType]; current != inst {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.instances, agentType)
+	m.mu.Unlock()
+
+	m.log.Warn("host utility instance unhealthy; recreating",
+		zap.String("agent_type", agentType),
+		zap.String("instance_id", inst.instanceID),
+		zap.Error(cause))
+	deleteCtx, cancel := hostUtilityDeleteContext(ctx)
+	m.deleteInstance(deleteCtx, inst)
+	cancel()
 }
 
 // probeTimeout caps each ACP probe so an agent that hangs (e.g. one that

--- a/apps/backend/internal/agent/hostutility/manager_test.go
+++ b/apps/backend/internal/agent/hostutility/manager_test.go
@@ -287,6 +287,58 @@ func TestRefreshRecreatesStaleCachedInstance(t *testing.T) {
 	require.Equal(t, int32(2), deleteCalls.Load())
 }
 
+func TestExecutePromptDoesNotRecreateWhenParentContextCanceled(t *testing.T) {
+	log := newTestLogger(t)
+	reg := registry.NewRegistry(log)
+	const agentType = "canceled-acp"
+	require.NoError(t, reg.Register(&installedInferenceAgent{id: agentType}))
+
+	instanceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer instanceServer.Close()
+	instanceHost, instancePort := serverHostPort(t, instanceServer)
+
+	var createCalls atomic.Int32
+	var deleteCalls atomic.Int32
+	controlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/instances":
+			createCalls.Add(1)
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/instances/"):
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer controlServer.Close()
+	controlHost, controlPort := serverHostPort(t, controlServer)
+
+	mgr := NewManager(reg, controlHost, controlPort, agentctlclient.NewControlClient(controlHost, controlPort, log), log)
+	mgr.parentTmpDir = t.TempDir()
+	cached := &instance{
+		agentType:  agentType,
+		instanceID: "cached-instance",
+		workDir:    filepath.Join(mgr.parentTmpDir, agentType),
+		client:     agentctlclient.NewClient(instanceHost, instancePort, log),
+	}
+	mgr.instances[agentType] = cached
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := mgr.ExecutePrompt(ctx, agentType, "test-model", "", "Summarize this")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, int32(0), createCalls.Load())
+	require.Equal(t, int32(0), deleteCalls.Load())
+
+	mgr.mu.RLock()
+	current := mgr.instances[agentType]
+	mgr.mu.RUnlock()
+	require.Same(t, cached, current)
+}
+
 func serverHostPort(t *testing.T, server *httptest.Server) (string, int) {
 	t.Helper()
 	host, portText, err := net.SplitHostPort(server.Listener.Addr().String())

--- a/apps/backend/internal/agent/hostutility/manager_test.go
+++ b/apps/backend/internal/agent/hostutility/manager_test.go
@@ -106,8 +106,16 @@ func TestExecutePromptRecreatesStaleCachedInstance(t *testing.T) {
 	instanceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/health":
+			if got := r.Header.Get("X-Instance-ID"); got != "fresh-instance" {
+				http.Error(w, "wrong instance id", http.StatusNotFound)
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 		case "/api/v1/inference/prompt":
+			if got := r.Header.Get("X-Instance-ID"); got != "fresh-instance" {
+				http.Error(w, "wrong instance id", http.StatusNotFound)
+				return
+			}
 			promptCalls.Add(1)
 			w.Header().Set("Content-Type", "application/json")
 			err := json.NewEncoder(w).Encode(agentctlutil.PromptResponse{
@@ -123,7 +131,7 @@ func TestExecutePromptRecreatesStaleCachedInstance(t *testing.T) {
 		}
 	}))
 	defer instanceServer.Close()
-	_, instancePort := serverHostPort(t, instanceServer)
+	instanceHost, instancePort := serverHostPort(t, instanceServer)
 
 	var createCalls atomic.Int32
 	var deleteCalls atomic.Int32
@@ -153,19 +161,16 @@ func TestExecutePromptRecreatesStaleCachedInstance(t *testing.T) {
 	mgr := NewManager(reg, controlHost, controlPort, agentctlclient.NewControlClient(controlHost, controlPort, log), log)
 	mgr.parentTmpDir = t.TempDir()
 
-	deadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	deadHost, deadPort := serverHostPort(t, deadServer)
-	deadServer.Close()
-
 	staleWorkDir := filepath.Join(mgr.parentTmpDir, agentType)
 	require.NoError(t, os.MkdirAll(staleWorkDir, 0o755))
+	staleMarker := filepath.Join(staleWorkDir, "stale-marker")
+	require.NoError(t, os.WriteFile(staleMarker, []byte("stale"), 0o644))
 	mgr.instances[agentType] = &instance{
 		agentType:  agentType,
 		instanceID: "stale-instance",
 		workDir:    staleWorkDir,
-		client:     agentctlclient.NewClient(deadHost, deadPort, log),
+		client: agentctlclient.NewClient(instanceHost, instancePort, log,
+			agentctlclient.WithExecutionID("stale-instance")),
 	}
 
 	result, err := mgr.ExecutePrompt(context.Background(), agentType, "test-model", "", "Summarize this")
@@ -180,6 +185,106 @@ func TestExecutePromptRecreatesStaleCachedInstance(t *testing.T) {
 	mgr.mu.RUnlock()
 	require.NotNil(t, fresh)
 	require.Equal(t, "fresh-instance", fresh.instanceID)
+
+	_, err = os.Stat(staleMarker)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	mgr.Stop(context.Background())
+	require.Equal(t, int32(2), deleteCalls.Load())
+}
+
+func TestRefreshRecreatesStaleCachedInstance(t *testing.T) {
+	log := newTestLogger(t)
+	reg := registry.NewRegistry(log)
+	const agentType = "refresh-acp"
+	require.NoError(t, reg.Register(&installedInferenceAgent{id: agentType}))
+
+	var probeCalls atomic.Int32
+	instanceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			if got := r.Header.Get("X-Instance-ID"); got != "fresh-refresh-instance" {
+				http.Error(w, "wrong instance id", http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/api/v1/inference/probe":
+			if got := r.Header.Get("X-Instance-ID"); got != "fresh-refresh-instance" {
+				http.Error(w, "wrong instance id", http.StatusNotFound)
+				return
+			}
+			probeCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(agentctlutil.ProbeResponse{
+				Success:        true,
+				AgentName:      "Refresh ACP",
+				AgentVersion:   "test",
+				CurrentModelID: "test-model",
+			})
+			if err != nil {
+				t.Errorf("encode probe response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer instanceServer.Close()
+	instanceHost, instancePort := serverHostPort(t, instanceServer)
+
+	var createCalls atomic.Int32
+	var deleteCalls atomic.Int32
+	controlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/instances":
+			createCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			err := json.NewEncoder(w).Encode(agentctlclient.CreateInstanceResponse{
+				ID:   "fresh-refresh-instance",
+				Port: instancePort,
+			})
+			if err != nil {
+				t.Errorf("encode create instance response: %v", err)
+			}
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/instances/"):
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer controlServer.Close()
+	controlHost, controlPort := serverHostPort(t, controlServer)
+
+	mgr := NewManager(reg, controlHost, controlPort, agentctlclient.NewControlClient(controlHost, controlPort, log), log)
+	mgr.parentTmpDir = t.TempDir()
+
+	staleWorkDir := filepath.Join(mgr.parentTmpDir, agentType)
+	require.NoError(t, os.MkdirAll(staleWorkDir, 0o755))
+	mgr.instances[agentType] = &instance{
+		agentType:  agentType,
+		instanceID: "stale-refresh-instance",
+		workDir:    staleWorkDir,
+		client: agentctlclient.NewClient(instanceHost, instancePort, log,
+			agentctlclient.WithExecutionID("stale-refresh-instance")),
+	}
+
+	caps, err := mgr.Refresh(context.Background(), agentType)
+	require.NoError(t, err)
+	require.Equal(t, StatusOK, caps.Status)
+	require.Equal(t, "test-model", caps.CurrentModelID)
+	require.Equal(t, int32(1), createCalls.Load())
+	require.Equal(t, int32(1), deleteCalls.Load())
+	require.Equal(t, int32(1), probeCalls.Load())
+
+	mgr.mu.RLock()
+	fresh := mgr.instances[agentType]
+	mgr.mu.RUnlock()
+	require.NotNil(t, fresh)
+	require.Equal(t, "fresh-refresh-instance", fresh.instanceID)
+
+	mgr.Stop(context.Background())
+	require.Equal(t, int32(2), deleteCalls.Load())
 }
 
 func serverHostPort(t *testing.T, server *httptest.Server) (string, int) {

--- a/apps/backend/internal/agent/hostutility/manager_test.go
+++ b/apps/backend/internal/agent/hostutility/manager_test.go
@@ -2,15 +2,24 @@ package hostutility
 
 import (
 	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/kandev/kandev/internal/agent/agents"
 	"github.com/kandev/kandev/internal/agent/registry"
+	agentctlclient "github.com/kandev/kandev/internal/agent/runtime/agentctl"
 	"github.com/kandev/kandev/internal/agent/usage"
+	agentctlutil "github.com/kandev/kandev/internal/agentctl/server/utility"
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/pkg/agent"
 	"github.com/stretchr/testify/require"
@@ -87,6 +96,101 @@ func TestHostUtilityDeleteContextIgnoresParentCancellation(t *testing.T) {
 	}
 }
 
+func TestExecutePromptRecreatesStaleCachedInstance(t *testing.T) {
+	log := newTestLogger(t)
+	reg := registry.NewRegistry(log)
+	const agentType = "recreate-acp"
+	require.NoError(t, reg.Register(&installedInferenceAgent{id: agentType}))
+
+	var promptCalls atomic.Int32
+	instanceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/api/v1/inference/prompt":
+			promptCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(agentctlutil.PromptResponse{
+				Success:  true,
+				Response: "summary",
+				Model:    "test-model",
+			})
+			if err != nil {
+				t.Errorf("encode prompt response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer instanceServer.Close()
+	_, instancePort := serverHostPort(t, instanceServer)
+
+	var createCalls atomic.Int32
+	var deleteCalls atomic.Int32
+	controlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/instances":
+			createCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			err := json.NewEncoder(w).Encode(agentctlclient.CreateInstanceResponse{
+				ID:   "fresh-instance",
+				Port: instancePort,
+			})
+			if err != nil {
+				t.Errorf("encode create instance response: %v", err)
+			}
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/instances/"):
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer controlServer.Close()
+	controlHost, controlPort := serverHostPort(t, controlServer)
+
+	mgr := NewManager(reg, controlHost, controlPort, agentctlclient.NewControlClient(controlHost, controlPort, log), log)
+	mgr.parentTmpDir = t.TempDir()
+
+	deadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	deadHost, deadPort := serverHostPort(t, deadServer)
+	deadServer.Close()
+
+	staleWorkDir := filepath.Join(mgr.parentTmpDir, agentType)
+	require.NoError(t, os.MkdirAll(staleWorkDir, 0o755))
+	mgr.instances[agentType] = &instance{
+		agentType:  agentType,
+		instanceID: "stale-instance",
+		workDir:    staleWorkDir,
+		client:     agentctlclient.NewClient(deadHost, deadPort, log),
+	}
+
+	result, err := mgr.ExecutePrompt(context.Background(), agentType, "test-model", "", "Summarize this")
+	require.NoError(t, err)
+	require.Equal(t, "summary", result.Response)
+	require.Equal(t, int32(1), createCalls.Load())
+	require.Equal(t, int32(1), deleteCalls.Load())
+	require.Equal(t, int32(1), promptCalls.Load())
+
+	mgr.mu.RLock()
+	fresh := mgr.instances[agentType]
+	mgr.mu.RUnlock()
+	require.NotNil(t, fresh)
+	require.Equal(t, "fresh-instance", fresh.instanceID)
+}
+
+func serverHostPort(t *testing.T, server *httptest.Server) (string, int) {
+	t.Helper()
+	host, portText, err := net.SplitHostPort(server.Listener.Addr().String())
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	return host, port
+}
+
 func newTestLogger(t *testing.T) *logger.Logger {
 	t.Helper()
 	log, err := logger.NewLogger(logger.LoggingConfig{
@@ -97,6 +201,43 @@ func newTestLogger(t *testing.T) *logger.Logger {
 		t.Fatalf("failed to create logger: %v", err)
 	}
 	return log
+}
+
+type installedInferenceAgent struct {
+	id string
+}
+
+func (a *installedInferenceAgent) ID() string          { return a.id }
+func (a *installedInferenceAgent) Name() string        { return "Installed ACP" }
+func (a *installedInferenceAgent) DisplayName() string { return "Installed ACP" }
+func (a *installedInferenceAgent) Description() string { return "installed test agent" }
+func (a *installedInferenceAgent) Enabled() bool       { return true }
+func (a *installedInferenceAgent) DisplayOrder() int   { return 1 }
+func (a *installedInferenceAgent) Logo(agents.LogoVariant) []byte {
+	return nil
+}
+func (a *installedInferenceAgent) IsInstalled(context.Context) (*agents.DiscoveryResult, error) {
+	return &agents.DiscoveryResult{Available: true}, nil
+}
+func (a *installedInferenceAgent) BuildCommand(agents.CommandOptions) agents.Command {
+	return agents.NewCommand(a.id)
+}
+func (a *installedInferenceAgent) PermissionSettings() map[string]agents.PermissionSetting {
+	return nil
+}
+func (a *installedInferenceAgent) Runtime() *agents.RuntimeConfig {
+	return &agents.RuntimeConfig{Protocol: agent.ProtocolACP}
+}
+func (a *installedInferenceAgent) BillingType() usage.BillingType {
+	return usage.BillingTypeSubscription
+}
+func (a *installedInferenceAgent) RemoteAuth() *agents.RemoteAuth { return nil }
+func (a *installedInferenceAgent) InstallScript() string          { return "" }
+func (a *installedInferenceAgent) InferenceConfig() *agents.InferenceConfig {
+	return &agents.InferenceConfig{
+		Supported: true,
+		Command:   agents.NewCommand(a.id),
+	}
 }
 
 type blockingInferenceAgent struct {


### PR DESCRIPTION
Sessionless summarization could reuse a dead host utility agentctl instance and fail against a stale localhost port. Host utility now validates cached instances before use and recreates stale ones, so summarization can recover after the warm instance dies.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

Closes #1500

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->