### PR TITLE
fix: enforce single workflow start step

### DIFF
--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
@@ -170,7 +170,7 @@ func (h *Handlers) handleCreateWorkflowStep(ctx context.Context, msg *ws.Message
 		h.logger.Error("failed to create workflow step", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to create workflow step", nil)
 	}
-	h.publishWorkflowStepEvents(ctx, events.WorkflowStepUpdated, resp.UpdatedSteps)
+	h.publishWorkflowStepEvents(ctx, events.WorkflowStepUpdated, resp.DemotedStartSteps)
 	h.publishWorkflowStepEvent(ctx, events.WorkflowStepCreated, resp.Step)
 	return ws.NewResponse(msg.ID, msg.Action, resp)
 }
@@ -211,7 +211,7 @@ func (h *Handlers) handleUpdateWorkflowStep(ctx context.Context, msg *ws.Message
 		h.logger.Error("failed to update workflow step", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to update workflow step", nil)
 	}
-	h.publishWorkflowStepEvents(ctx, events.WorkflowStepUpdated, resp.UpdatedSteps)
+	h.publishWorkflowStepEvents(ctx, events.WorkflowStepUpdated, resp.DemotedStartSteps)
 	h.publishWorkflowStepEvent(ctx, events.WorkflowStepUpdated, resp.Step)
 	return ws.NewResponse(msg.ID, msg.Action, resp)
 }

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
@@ -270,17 +270,22 @@ func (h *Handlers) publishWorkflowStepEvent(ctx context.Context, eventType strin
 	}
 	data := map[string]interface{}{
 		"step": map[string]interface{}{
-			"id":                       step.ID,
-			"workflow_id":              step.WorkflowID,
-			"name":                     step.Name,
-			"position":                 step.Position,
-			"color":                    step.Color,
-			"prompt":                   step.Prompt,
-			"events":                   step.Events,
-			"show_in_command_panel":    step.ShowInCommandPanel,
-			"allow_manual_move":        step.AllowManualMove,
-			"is_start_step":            step.IsStartStep,
-			"auto_archive_after_hours": step.AutoArchiveAfterHours,
+			"id":                           step.ID,
+			"workflow_id":                  step.WorkflowID,
+			"name":                         step.Name,
+			"position":                     step.Position,
+			"color":                        step.Color,
+			"prompt":                       step.Prompt,
+			"events":                       step.Events,
+			"show_in_command_panel":        step.ShowInCommandPanel,
+			"allow_manual_move":            step.AllowManualMove,
+			"is_start_step":                step.IsStartStep,
+			"auto_archive_after_hours":     step.AutoArchiveAfterHours,
+			"agent_profile_id":             step.AgentProfileID,
+			"stage_type":                   string(step.StageType),
+			"auto_advance_requires_signal": step.AutoAdvanceRequiresSignal,
+			"created_at":                   step.CreatedAt,
+			"updated_at":                   step.UpdatedAt,
 		},
 	}
 	if err := h.eventBus.Publish(ctx, eventType, bus.NewEvent(eventType, "mcp-handlers", data)); err != nil {

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers.go
@@ -170,6 +170,7 @@ func (h *Handlers) handleCreateWorkflowStep(ctx context.Context, msg *ws.Message
 		h.logger.Error("failed to create workflow step", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to create workflow step", nil)
 	}
+	h.publishWorkflowStepEvents(ctx, events.WorkflowStepUpdated, resp.UpdatedSteps)
 	h.publishWorkflowStepEvent(ctx, events.WorkflowStepCreated, resp.Step)
 	return ws.NewResponse(msg.ID, msg.Action, resp)
 }
@@ -210,6 +211,7 @@ func (h *Handlers) handleUpdateWorkflowStep(ctx context.Context, msg *ws.Message
 		h.logger.Error("failed to update workflow step", zap.Error(err))
 		return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, "Failed to update workflow step", nil)
 	}
+	h.publishWorkflowStepEvents(ctx, events.WorkflowStepUpdated, resp.UpdatedSteps)
 	h.publishWorkflowStepEvent(ctx, events.WorkflowStepUpdated, resp.Step)
 	return ws.NewResponse(msg.ID, msg.Action, resp)
 }
@@ -286,5 +288,11 @@ func (h *Handlers) publishWorkflowStepEvent(ctx context.Context, eventType strin
 			zap.String("event_type", eventType),
 			zap.String("step_id", step.ID),
 			zap.Error(err))
+	}
+}
+
+func (h *Handlers) publishWorkflowStepEvents(ctx context.Context, eventType string, steps []*wfmodels.WorkflowStep) {
+	for _, step := range steps {
+		h.publishWorkflowStepEvent(ctx, eventType, step)
 	}
 }

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
@@ -139,12 +139,15 @@ func TestHandleCreateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
 	published := collectWorkflowStepEvents(t, eb, eventtypes.WorkflowStepUpdated, eventtypes.WorkflowStepCreated)
 
 	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
-		ID:                 "old-start",
-		WorkflowID:         "wf-test",
-		Name:               "Old Start",
-		Position:           0,
-		IsStartStep:        true,
-		ShowInCommandPanel: true,
+		ID:                        "old-start",
+		WorkflowID:                "wf-test",
+		Name:                      "Old Start",
+		Position:                  0,
+		IsStartStep:               true,
+		ShowInCommandPanel:        true,
+		AgentProfileID:            "agent-old",
+		StageType:                 wfmodels.StageTypeReview,
+		AutoAdvanceRequiresSignal: true,
 	}))
 	isStart := true
 	msg := makeWSMessage(t, ws.ActionMCPCreateWorkflowStep, map[string]interface{}{
@@ -162,6 +165,9 @@ func TestHandleCreateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
 	assert.Equal(t, eventtypes.WorkflowStepUpdated, (*published)[0].subject)
 	assert.Equal(t, "old-start", (*published)[0].step["id"])
 	assert.False(t, (*published)[0].step["is_start_step"].(bool))
+	assert.Equal(t, "agent-old", (*published)[0].step["agent_profile_id"])
+	assert.Equal(t, string(wfmodels.StageTypeReview), (*published)[0].step["stage_type"])
+	assert.True(t, (*published)[0].step["auto_advance_requires_signal"].(bool))
 	assert.Equal(t, eventtypes.WorkflowStepCreated, (*published)[1].subject)
 	assert.True(t, (*published)[1].step["is_start_step"].(bool))
 }
@@ -175,12 +181,15 @@ func TestHandleUpdateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
 
 	published := collectWorkflowStepEvents(t, eb, eventtypes.WorkflowStepUpdated)
 	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
-		ID:                 "old-start",
-		WorkflowID:         "wf-test",
-		Name:               "Old Start",
-		Position:           0,
-		IsStartStep:        true,
-		ShowInCommandPanel: true,
+		ID:                        "old-start",
+		WorkflowID:                "wf-test",
+		Name:                      "Old Start",
+		Position:                  0,
+		IsStartStep:               true,
+		ShowInCommandPanel:        true,
+		AgentProfileID:            "agent-old",
+		StageType:                 wfmodels.StageTypeApproval,
+		AutoAdvanceRequiresSignal: true,
 	}))
 	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
 		ID:                 "new-start",
@@ -203,6 +212,9 @@ func TestHandleUpdateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
 
 	assert.Equal(t, "old-start", (*published)[0].step["id"])
 	assert.False(t, (*published)[0].step["is_start_step"].(bool))
+	assert.Equal(t, "agent-old", (*published)[0].step["agent_profile_id"])
+	assert.Equal(t, string(wfmodels.StageTypeApproval), (*published)[0].step["stage_type"])
+	assert.True(t, (*published)[0].step["auto_advance_requires_signal"].(bool))
 	assert.Equal(t, "new-start", (*published)[1].step["id"])
 	assert.True(t, (*published)[1].step["is_start_step"].(bool))
 }

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
@@ -106,6 +106,29 @@ func setupImportHandlers(t *testing.T) (*Handlers, *memWorkflowProvider, *reposi
 	return h, provider, repo
 }
 
+type publishedStepEvent struct {
+	subject string
+	step    map[string]interface{}
+}
+
+func collectWorkflowStepEvents(t *testing.T, eb *eventbus.MemoryEventBus, subjects ...string) *[]publishedStepEvent {
+	t.Helper()
+	var published []publishedStepEvent
+	for _, subject := range subjects {
+		subject := subject
+		_, err := eb.Subscribe(subject, func(_ context.Context, ev *eventbus.Event) error {
+			data, ok := ev.Data.(map[string]interface{})
+			require.True(t, ok)
+			step, ok := data["step"].(map[string]interface{})
+			require.True(t, ok)
+			published = append(published, publishedStepEvent{subject: subject, step: step})
+			return nil
+		})
+		require.NoError(t, err)
+	}
+	return &published
+}
+
 func TestHandleCreateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
 	h, _, repo := setupImportHandlers(t)
 	ctx := context.Background()
@@ -113,25 +136,7 @@ func TestHandleCreateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
 	eb := eventbus.NewMemoryEventBus(testLogger(t))
 	h.eventBus = eb
 
-	type publishedStepEvent struct {
-		subject string
-		step    map[string]interface{}
-	}
-	var published []publishedStepEvent
-	capture := func(subject string) func(context.Context, *eventbus.Event) error {
-		return func(_ context.Context, ev *eventbus.Event) error {
-			data, ok := ev.Data.(map[string]interface{})
-			require.True(t, ok)
-			step, ok := data["step"].(map[string]interface{})
-			require.True(t, ok)
-			published = append(published, publishedStepEvent{subject: subject, step: step})
-			return nil
-		}
-	}
-	_, err := eb.Subscribe(eventtypes.WorkflowStepUpdated, capture(eventtypes.WorkflowStepUpdated))
-	require.NoError(t, err)
-	_, err = eb.Subscribe(eventtypes.WorkflowStepCreated, capture(eventtypes.WorkflowStepCreated))
-	require.NoError(t, err)
+	published := collectWorkflowStepEvents(t, eb, eventtypes.WorkflowStepUpdated, eventtypes.WorkflowStepCreated)
 
 	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
 		ID:                 "old-start",
@@ -152,13 +157,54 @@ func TestHandleCreateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
 	resp, err := h.handleCreateWorkflowStep(ctx, msg)
 	require.NoError(t, err)
 	require.Equal(t, ws.MessageTypeResponse, resp.Type)
-	require.Len(t, published, 2)
+	require.Len(t, *published, 2)
 
-	assert.Equal(t, eventtypes.WorkflowStepUpdated, published[0].subject)
-	assert.Equal(t, "old-start", published[0].step["id"])
-	assert.False(t, published[0].step["is_start_step"].(bool))
-	assert.Equal(t, eventtypes.WorkflowStepCreated, published[1].subject)
-	assert.True(t, published[1].step["is_start_step"].(bool))
+	assert.Equal(t, eventtypes.WorkflowStepUpdated, (*published)[0].subject)
+	assert.Equal(t, "old-start", (*published)[0].step["id"])
+	assert.False(t, (*published)[0].step["is_start_step"].(bool))
+	assert.Equal(t, eventtypes.WorkflowStepCreated, (*published)[1].subject)
+	assert.True(t, (*published)[1].step["is_start_step"].(bool))
+}
+
+func TestHandleUpdateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
+	h, _, repo := setupImportHandlers(t)
+	ctx := context.Background()
+	h.workflowCtrl = workflowctrl.NewController(h.workflowSvc)
+	eb := eventbus.NewMemoryEventBus(testLogger(t))
+	h.eventBus = eb
+
+	published := collectWorkflowStepEvents(t, eb, eventtypes.WorkflowStepUpdated)
+	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
+		ID:                 "old-start",
+		WorkflowID:         "wf-test",
+		Name:               "Old Start",
+		Position:           0,
+		IsStartStep:        true,
+		ShowInCommandPanel: true,
+	}))
+	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
+		ID:                 "new-start",
+		WorkflowID:         "wf-test",
+		Name:               "New Start",
+		Position:           1,
+		ShowInCommandPanel: true,
+	}))
+
+	isStart := true
+	msg := makeWSMessage(t, ws.ActionMCPUpdateWorkflowStep, map[string]interface{}{
+		"step_id":       "new-start",
+		"is_start_step": isStart,
+	})
+
+	resp, err := h.handleUpdateWorkflowStep(ctx, msg)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	require.Len(t, *published, 2)
+
+	assert.Equal(t, "old-start", (*published)[0].step["id"])
+	assert.False(t, (*published)[0].step["is_start_step"].(bool))
+	assert.Equal(t, "new-start", (*published)[1].step["id"])
+	assert.True(t, (*published)[1].step["is_start_step"].(bool))
 }
 
 func TestHandleImportWorkflow_PersistsWorkflow(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/config_workflow_handlers_test.go
@@ -12,7 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	eventtypes "github.com/kandev/kandev/internal/events"
+	eventbus "github.com/kandev/kandev/internal/events/bus"
 	taskmodels "github.com/kandev/kandev/internal/task/models"
+	workflowctrl "github.com/kandev/kandev/internal/workflow/controller"
+	wfmodels "github.com/kandev/kandev/internal/workflow/models"
 	workflowsvc "github.com/kandev/kandev/internal/workflow/service"
 
 	"github.com/kandev/kandev/internal/workflow/repository"
@@ -100,6 +104,61 @@ func setupImportHandlers(t *testing.T) (*Handlers, *memWorkflowProvider, *reposi
 
 	h := &Handlers{workflowSvc: svc, logger: testLogger(t).WithFields()}
 	return h, provider, repo
+}
+
+func TestHandleCreateWorkflowStep_PublishesDemotedStartStep(t *testing.T) {
+	h, _, repo := setupImportHandlers(t)
+	ctx := context.Background()
+	h.workflowCtrl = workflowctrl.NewController(h.workflowSvc)
+	eb := eventbus.NewMemoryEventBus(testLogger(t))
+	h.eventBus = eb
+
+	type publishedStepEvent struct {
+		subject string
+		step    map[string]interface{}
+	}
+	var published []publishedStepEvent
+	capture := func(subject string) func(context.Context, *eventbus.Event) error {
+		return func(_ context.Context, ev *eventbus.Event) error {
+			data, ok := ev.Data.(map[string]interface{})
+			require.True(t, ok)
+			step, ok := data["step"].(map[string]interface{})
+			require.True(t, ok)
+			published = append(published, publishedStepEvent{subject: subject, step: step})
+			return nil
+		}
+	}
+	_, err := eb.Subscribe(eventtypes.WorkflowStepUpdated, capture(eventtypes.WorkflowStepUpdated))
+	require.NoError(t, err)
+	_, err = eb.Subscribe(eventtypes.WorkflowStepCreated, capture(eventtypes.WorkflowStepCreated))
+	require.NoError(t, err)
+
+	require.NoError(t, repo.CreateStep(ctx, &wfmodels.WorkflowStep{
+		ID:                 "old-start",
+		WorkflowID:         "wf-test",
+		Name:               "Old Start",
+		Position:           0,
+		IsStartStep:        true,
+		ShowInCommandPanel: true,
+	}))
+	isStart := true
+	msg := makeWSMessage(t, ws.ActionMCPCreateWorkflowStep, map[string]interface{}{
+		"workflow_id":   "wf-test",
+		"name":          "New Start",
+		"position":      1,
+		"is_start_step": isStart,
+	})
+
+	resp, err := h.handleCreateWorkflowStep(ctx, msg)
+	require.NoError(t, err)
+	require.Equal(t, ws.MessageTypeResponse, resp.Type)
+	require.Len(t, published, 2)
+
+	assert.Equal(t, eventtypes.WorkflowStepUpdated, published[0].subject)
+	assert.Equal(t, "old-start", published[0].step["id"])
+	assert.False(t, published[0].step["is_start_step"].(bool))
+	assert.Equal(t, eventtypes.WorkflowStepCreated, published[1].subject)
+	assert.True(t, published[1].step["is_start_step"].(bool))
 }
 
 func TestHandleImportWorkflow_PersistsWorkflow(t *testing.T) {

--- a/apps/backend/internal/workflow/controller/controller.go
+++ b/apps/backend/internal/workflow/controller/controller.go
@@ -55,8 +55,8 @@ type ListStepsResponse struct {
 }
 
 type GetStepResponse struct {
-	Step         *models.WorkflowStep   `json:"step"`
-	UpdatedSteps []*models.WorkflowStep `json:"updated_steps,omitempty"`
+	Step              *models.WorkflowStep   `json:"step"`
+	DemotedStartSteps []*models.WorkflowStep `json:"demoted_start_steps,omitempty"`
 }
 
 type CreateStepsFromTemplateRequest struct {
@@ -131,11 +131,11 @@ func (c *Controller) CreateStep(ctx context.Context, req CreateStepRequest) (*Ge
 	if req.AutoAdvanceRequiresSignal != nil {
 		step.AutoAdvanceRequiresSignal = *req.AutoAdvanceRequiresSignal
 	}
-	updatedSteps, err := c.svc.CreateStepWithStartStepUpdates(ctx, step)
+	demotedStartSteps, err := c.svc.CreateStepWithStartStepUpdates(ctx, step)
 	if err != nil {
 		return nil, err
 	}
-	return &GetStepResponse{Step: step, UpdatedSteps: updatedSteps}, nil
+	return &GetStepResponse{Step: step, DemotedStartSteps: demotedStartSteps}, nil
 }
 
 // UpdateStepRequest is the request for updating a workflow step.
@@ -193,11 +193,11 @@ func (c *Controller) UpdateStep(ctx context.Context, req UpdateStepRequest) (*Ge
 	if req.AutoAdvanceRequiresSignal != nil {
 		step.AutoAdvanceRequiresSignal = *req.AutoAdvanceRequiresSignal
 	}
-	updatedSteps, err := c.svc.UpdateStepWithStartStepUpdates(ctx, step)
+	demotedStartSteps, err := c.svc.UpdateStepWithStartStepUpdates(ctx, step)
 	if err != nil {
 		return nil, err
 	}
-	return &GetStepResponse{Step: step, UpdatedSteps: updatedSteps}, nil
+	return &GetStepResponse{Step: step, DemotedStartSteps: demotedStartSteps}, nil
 }
 
 // DeleteStep deletes a workflow step.

--- a/apps/backend/internal/workflow/controller/controller.go
+++ b/apps/backend/internal/workflow/controller/controller.go
@@ -55,7 +55,8 @@ type ListStepsResponse struct {
 }
 
 type GetStepResponse struct {
-	Step *models.WorkflowStep `json:"step"`
+	Step         *models.WorkflowStep   `json:"step"`
+	UpdatedSteps []*models.WorkflowStep `json:"updated_steps,omitempty"`
 }
 
 type CreateStepsFromTemplateRequest struct {
@@ -130,10 +131,11 @@ func (c *Controller) CreateStep(ctx context.Context, req CreateStepRequest) (*Ge
 	if req.AutoAdvanceRequiresSignal != nil {
 		step.AutoAdvanceRequiresSignal = *req.AutoAdvanceRequiresSignal
 	}
-	if err := c.svc.CreateStep(ctx, step); err != nil {
+	updatedSteps, err := c.svc.CreateStepWithStartStepUpdates(ctx, step)
+	if err != nil {
 		return nil, err
 	}
-	return &GetStepResponse{Step: step}, nil
+	return &GetStepResponse{Step: step, UpdatedSteps: updatedSteps}, nil
 }
 
 // UpdateStepRequest is the request for updating a workflow step.
@@ -191,10 +193,11 @@ func (c *Controller) UpdateStep(ctx context.Context, req UpdateStepRequest) (*Ge
 	if req.AutoAdvanceRequiresSignal != nil {
 		step.AutoAdvanceRequiresSignal = *req.AutoAdvanceRequiresSignal
 	}
-	if err := c.svc.UpdateStep(ctx, step); err != nil {
+	updatedSteps, err := c.svc.UpdateStepWithStartStepUpdates(ctx, step)
+	if err != nil {
 		return nil, err
 	}
-	return &GetStepResponse{Step: step}, nil
+	return &GetStepResponse{Step: step, UpdatedSteps: updatedSteps}, nil
 }
 
 // DeleteStep deletes a workflow step.

--- a/apps/backend/internal/workflow/repository/sqlite.go
+++ b/apps/backend/internal/workflow/repository/sqlite.go
@@ -134,6 +134,15 @@ func (r *Repository) initSchema() error {
 		return fmt.Errorf("failed to seed default workflow steps: %w", err)
 	}
 
+	if err := r.normalizeDuplicateStartSteps(); err != nil {
+		return fmt.Errorf("failed to normalize duplicate start steps: %w", err)
+	}
+	r.migrate.Apply("idx_workflow_steps_single_start", `
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_workflow_steps_single_start
+		ON workflow_steps(workflow_id)
+		WHERE is_start_step = 1
+	`)
+
 	// Repair step_id references that were incorrectly saved as template aliases
 	// instead of UUIDs. This was caused by a frontend bug (fixed in PR #XXX).
 	if err := r.repairBrokenStepIDReferences(); err != nil {
@@ -141,6 +150,25 @@ func (r *Repository) initSchema() error {
 	}
 
 	return nil
+}
+
+func (r *Repository) normalizeDuplicateStartSteps() error {
+	_, err := r.db.Exec(`
+		WITH ranked AS (
+			SELECT
+				id,
+				ROW_NUMBER() OVER (
+					PARTITION BY workflow_id
+					ORDER BY position DESC, updated_at DESC, id DESC
+				) AS start_rank
+			FROM workflow_steps
+			WHERE is_start_step = 1
+		)
+		UPDATE workflow_steps
+		SET is_start_step = 0
+		WHERE id IN (SELECT id FROM ranked WHERE start_rank > 1)
+	`)
+	return err
 }
 
 // seedDefaultWorkflowSteps creates default workflow steps for workflows that don't have any.

--- a/apps/backend/internal/workflow/repository/sqlite.go
+++ b/apps/backend/internal/workflow/repository/sqlite.go
@@ -159,6 +159,8 @@ func (r *Repository) normalizeDuplicateStartSteps() error {
 				id,
 				ROW_NUMBER() OVER (
 					PARTITION BY workflow_id
+					-- Legacy repair follows last-writer-wins: keep the row
+					-- most recently marked/changed as the workflow start step.
 					ORDER BY updated_at DESC, position DESC, id DESC
 				) AS start_rank
 			FROM workflow_steps

--- a/apps/backend/internal/workflow/repository/sqlite.go
+++ b/apps/backend/internal/workflow/repository/sqlite.go
@@ -159,7 +159,7 @@ func (r *Repository) normalizeDuplicateStartSteps() error {
 				id,
 				ROW_NUMBER() OVER (
 					PARTITION BY workflow_id
-					ORDER BY position DESC, updated_at DESC, id DESC
+					ORDER BY updated_at DESC, position DESC, id DESC
 				) AS start_rank
 			FROM workflow_steps
 			WHERE is_start_step = 1
@@ -575,6 +575,13 @@ func (r *Repository) GetSystemTemplates(ctx context.Context) ([]*models.Workflow
 
 // CreateStep creates a new workflow step.
 func (r *Repository) CreateStep(ctx context.Context, step *models.WorkflowStep) error {
+	_, err := r.CreateStepWithDemotedStartSteps(ctx, step)
+	return err
+}
+
+// CreateStepWithDemotedStartSteps creates a new workflow step and returns any
+// previously-start steps demoted as part of the same transaction.
+func (r *Repository) CreateStepWithDemotedStartSteps(ctx context.Context, step *models.WorkflowStep) ([]*models.WorkflowStep, error) {
 	if step.ID == "" {
 		step.ID = uuid.New().String()
 	}
@@ -584,10 +591,24 @@ func (r *Repository) CreateStep(ctx context.Context, step *models.WorkflowStep) 
 
 	eventsJSON, err := json.Marshal(step.Events)
 	if err != nil {
-		return fmt.Errorf("failed to marshal events: %w", err)
+		return nil, fmt.Errorf("failed to marshal events: %w", err)
 	}
 
-	_, err = r.db.ExecContext(ctx, r.db.Rebind(`
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var demoted []*models.WorkflowStep
+	if step.IsStartStep {
+		demoted, err = r.demoteOtherStartSteps(ctx, tx, step.WorkflowID, step.ID, now)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	_, err = tx.ExecContext(ctx, tx.Rebind(`
 		INSERT INTO workflow_steps (
 			id, workflow_id, name, position, color,
 			prompt, events, allow_manual_move, is_start_step, show_in_command_panel, auto_archive_after_hours, agent_profile_id, stage_type, auto_advance_requires_signal, created_at, updated_at
@@ -595,8 +616,14 @@ func (r *Repository) CreateStep(ctx context.Context, step *models.WorkflowStep) 
 	`), step.ID, step.WorkflowID, step.Name, step.Position, step.Color,
 		step.Prompt, string(eventsJSON), dialect.BoolToInt(step.AllowManualMove),
 		dialect.BoolToInt(step.IsStartStep), dialect.BoolToInt(step.ShowInCommandPanel), step.AutoArchiveAfterHours, step.AgentProfileID, normalizeStageType(step.StageType), dialect.BoolToInt(step.AutoAdvanceRequiresSignal), step.CreatedAt, step.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
 
-	return err
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return demoted, nil
 }
 
 // normalizeStageType returns a string fit for the workflow_steps.stage_type
@@ -677,14 +704,35 @@ func (r *Repository) GetStep(ctx context.Context, id string) (*models.WorkflowSt
 
 // UpdateStep updates an existing workflow step.
 func (r *Repository) UpdateStep(ctx context.Context, step *models.WorkflowStep) error {
+	_, err := r.UpdateStepWithDemotedStartSteps(ctx, step)
+	return err
+}
+
+// UpdateStepWithDemotedStartSteps updates a workflow step and returns any
+// previously-start steps demoted as part of the same transaction.
+func (r *Repository) UpdateStepWithDemotedStartSteps(ctx context.Context, step *models.WorkflowStep) ([]*models.WorkflowStep, error) {
 	step.UpdatedAt = time.Now().UTC()
 
 	eventsJSON, err := json.Marshal(step.Events)
 	if err != nil {
-		return fmt.Errorf("failed to marshal events: %w", err)
+		return nil, fmt.Errorf("failed to marshal events: %w", err)
 	}
 
-	result, err := r.db.ExecContext(ctx, r.db.Rebind(`
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var demoted []*models.WorkflowStep
+	if step.IsStartStep {
+		demoted, err = r.demoteOtherStartSteps(ctx, tx, step.WorkflowID, step.ID, step.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	result, err := tx.ExecContext(ctx, tx.Rebind(`
 		UPDATE workflow_steps SET
 			name = ?, position = ?, color = ?,
 			prompt = ?, events = ?,
@@ -694,23 +742,56 @@ func (r *Repository) UpdateStep(ctx context.Context, step *models.WorkflowStep) 
 		step.Prompt, string(eventsJSON),
 		dialect.BoolToInt(step.AllowManualMove), dialect.BoolToInt(step.IsStartStep), dialect.BoolToInt(step.ShowInCommandPanel), step.AutoArchiveAfterHours, step.AgentProfileID, normalizeStageType(step.StageType), dialect.BoolToInt(step.AutoAdvanceRequiresSignal), step.UpdatedAt, step.ID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	rows, _ := result.RowsAffected()
 	if rows == 0 {
-		return fmt.Errorf("workflow step not found: %s", step.ID)
+		return nil, fmt.Errorf("workflow step not found: %s", step.ID)
 	}
-	return nil
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return demoted, nil
 }
 
 // ClearStartStepFlag clears the is_start_step flag for all steps in a workflow except the given step.
 func (r *Repository) ClearStartStepFlag(ctx context.Context, workflowID, exceptStepID string) error {
 	_, err := r.db.ExecContext(ctx, r.db.Rebind(`
-		UPDATE workflow_steps SET is_start_step = 0
-		WHERE workflow_id = ? AND id != ?
-	`), workflowID, exceptStepID)
+		UPDATE workflow_steps SET is_start_step = 0, updated_at = ?
+		WHERE workflow_id = ? AND id != ? AND is_start_step = 1
+	`), time.Now().UTC(), workflowID, exceptStepID)
 	return err
+}
+
+func (r *Repository) demoteOtherStartSteps(ctx context.Context, tx *sqlx.Tx, workflowID, exceptStepID string, updatedAt time.Time) ([]*models.WorkflowStep, error) {
+	rows, err := tx.QueryContext(ctx, tx.Rebind(`
+		SELECT `+stepSelectColumns+`
+		FROM workflow_steps
+		WHERE workflow_id = ? AND id != ? AND is_start_step = 1
+		ORDER BY position ASC, id ASC
+	`), workflowID, exceptStepID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	demoted, err := r.scanSteps(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := tx.ExecContext(ctx, tx.Rebind(`
+		UPDATE workflow_steps SET is_start_step = 0, updated_at = ?
+		WHERE workflow_id = ? AND id != ? AND is_start_step = 1
+	`), updatedAt, workflowID, exceptStepID); err != nil {
+		return nil, err
+	}
+
+	for _, step := range demoted {
+		step.IsStartStep = false
+		step.UpdatedAt = updatedAt
+	}
+	return demoted, nil
 }
 
 // GetStartStep returns the step marked as is_start_step for a workflow.

--- a/apps/backend/internal/workflow/repository/sqlite_test.go
+++ b/apps/backend/internal/workflow/repository/sqlite_test.go
@@ -12,6 +12,11 @@ import (
 )
 
 func setupTestRepo(t *testing.T) *Repository {
+	repo, _ := setupTestRepoWithDB(t)
+	return repo
+}
+
+func setupTestRepoWithDB(t *testing.T) (*Repository, *sqlx.DB) {
 	t.Helper()
 	rawDB, err := sql.Open("sqlite3", ":memory:?_foreign_keys=on")
 	if err != nil {
@@ -54,7 +59,7 @@ func setupTestRepo(t *testing.T) *Repository {
 	if err != nil {
 		t.Fatalf("failed to create repo: %v", err)
 	}
-	return repo
+	return repo, sqlxDB
 }
 
 func TestStepAgentProfileID_CreateAndGet(t *testing.T) {
@@ -188,5 +193,72 @@ func TestStepAgentProfileID_EmptyByDefault(t *testing.T) {
 	}
 	if retrieved.AgentProfileID != "" {
 		t.Errorf("expected empty agent_profile_id by default, got %q", retrieved.AgentProfileID)
+	}
+}
+
+func TestInitSchema_NormalizesDuplicateStartSteps(t *testing.T) {
+	rawDB, err := sql.Open("sqlite3", ":memory:?_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	db := sqlx.NewDb(rawDB, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+
+	_, err = db.Exec(`
+		CREATE TABLE workflows (
+			id TEXT PRIMARY KEY, workspace_id TEXT NOT NULL DEFAULT '',
+			workflow_template_id TEXT DEFAULT '', name TEXT NOT NULL,
+			description TEXT DEFAULT '', created_at TIMESTAMP NOT NULL, updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE task_sessions (id TEXT PRIMARY KEY);
+		CREATE TABLE workflow_steps (
+			id TEXT PRIMARY KEY,
+			workflow_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			position INTEGER NOT NULL,
+			color TEXT,
+			prompt TEXT,
+			events TEXT,
+			allow_manual_move INTEGER DEFAULT 1,
+			is_start_step INTEGER DEFAULT 0,
+			show_in_command_panel INTEGER DEFAULT 1,
+			auto_archive_after_hours INTEGER DEFAULT 0,
+			agent_profile_id TEXT DEFAULT '',
+			stage_type TEXT NOT NULL DEFAULT 'custom',
+			auto_advance_requires_signal INTEGER NOT NULL DEFAULT 0,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL,
+			FOREIGN KEY (workflow_id) REFERENCES workflows(id) ON DELETE CASCADE
+		);
+		INSERT INTO workflows (id, workspace_id, name, created_at, updated_at)
+			VALUES ('wf-test', '', 'Test', datetime('now'), datetime('now'));
+		INSERT INTO workflow_steps (
+			id, workflow_id, name, position, is_start_step, created_at, updated_at
+		) VALUES
+			('first-start', 'wf-test', 'First Start', 0, 1, datetime('now'), datetime('now')),
+			('latest-start', 'wf-test', 'Latest Start', 1, 1, datetime('now'), datetime('now'));
+	`)
+	if err != nil {
+		t.Fatalf("seed pre-repair database: %v", err)
+	}
+
+	reopened, err := NewWithDB(db, db, nil)
+	if err != nil {
+		t.Fatalf("reopen repo: %v", err)
+	}
+	steps, err := reopened.ListStepsByWorkflow(ctx, "wf-test")
+	if err != nil {
+		t.Fatalf("list steps: %v", err)
+	}
+
+	var starts []string
+	for _, step := range steps {
+		if step.IsStartStep {
+			starts = append(starts, step.Name)
+		}
+	}
+	if len(starts) != 1 || starts[0] != "Latest Start" {
+		t.Fatalf("expected only Latest Start to remain start, got %v", starts)
 	}
 }

--- a/apps/backend/internal/workflow/repository/sqlite_test.go
+++ b/apps/backend/internal/workflow/repository/sqlite_test.go
@@ -236,8 +236,8 @@ func TestInitSchema_NormalizesDuplicateStartSteps(t *testing.T) {
 		INSERT INTO workflow_steps (
 			id, workflow_id, name, position, is_start_step, created_at, updated_at
 		) VALUES
-			('first-start', 'wf-test', 'First Start', 0, 1, datetime('now'), datetime('now')),
-			('latest-start', 'wf-test', 'Latest Start', 1, 1, datetime('now'), datetime('now'));
+			('latest-position-start', 'wf-test', 'Latest Position Start', 2, 1, datetime('2026-01-01T00:00:00Z'), datetime('2026-01-01T00:00:00Z')),
+			('latest-updated-start', 'wf-test', 'Latest Updated Start', 0, 1, datetime('2026-01-01T00:00:00Z'), datetime('2026-01-02T00:00:00Z'));
 	`)
 	if err != nil {
 		t.Fatalf("seed pre-repair database: %v", err)
@@ -258,7 +258,49 @@ func TestInitSchema_NormalizesDuplicateStartSteps(t *testing.T) {
 			starts = append(starts, step.Name)
 		}
 	}
-	if len(starts) != 1 || starts[0] != "Latest Start" {
-		t.Fatalf("expected only Latest Start to remain start, got %v", starts)
+	if len(starts) != 1 || starts[0] != "Latest Updated Start" {
+		t.Fatalf("expected only Latest Updated Start to remain start, got %v", starts)
+	}
+}
+
+func TestCreateStep_RollsBackStartDemotionWhenInsertFails(t *testing.T) {
+	repo := setupTestRepo(t)
+	ctx := context.Background()
+
+	steps, err := repo.ListStepsByWorkflow(ctx, "wf-test")
+	if err != nil {
+		t.Fatalf("list seeded steps: %v", err)
+	}
+	var originalStartID, duplicateID string
+	for _, step := range steps {
+		if step.IsStartStep {
+			originalStartID = step.ID
+			continue
+		}
+		if duplicateID == "" {
+			duplicateID = step.ID
+		}
+	}
+	if originalStartID == "" || duplicateID == "" {
+		t.Fatalf("expected seeded workflow to have a start and non-start step, got start=%q duplicate=%q", originalStartID, duplicateID)
+	}
+
+	err = repo.CreateStep(ctx, &models.WorkflowStep{
+		ID:          duplicateID,
+		WorkflowID:  "wf-test",
+		Name:        "Duplicate ID Start",
+		Position:    99,
+		IsStartStep: true,
+	})
+	if err == nil {
+		t.Fatal("expected duplicate ID insert to fail")
+	}
+
+	start, err := repo.GetStartStep(ctx, "wf-test")
+	if err != nil {
+		t.Fatalf("get start step: %v", err)
+	}
+	if start == nil || start.ID != originalStartID {
+		t.Fatalf("expected original start step %q to remain after rollback, got %#v", originalStartID, start)
 	}
 }

--- a/apps/backend/internal/workflow/repository/sqlite_test.go
+++ b/apps/backend/internal/workflow/repository/sqlite_test.go
@@ -264,29 +264,22 @@ func TestInitSchema_NormalizesDuplicateStartSteps(t *testing.T) {
 }
 
 func TestCreateStep_RollsBackStartDemotionWhenInsertFails(t *testing.T) {
-	repo := setupTestRepo(t)
+	repo, db := setupTestRepoWithDB(t)
 	ctx := context.Background()
 
-	steps, err := repo.ListStepsByWorkflow(ctx, "wf-test")
-	if err != nil {
-		t.Fatalf("list seeded steps: %v", err)
-	}
-	var originalStartID, duplicateID string
-	for _, step := range steps {
-		if step.IsStartStep {
-			originalStartID = step.ID
-			continue
-		}
-		if duplicateID == "" {
-			duplicateID = step.ID
-		}
-	}
-	if originalStartID == "" || duplicateID == "" {
-		t.Fatalf("expected seeded workflow to have a start and non-start step, got start=%q duplicate=%q", originalStartID, duplicateID)
+	if _, err := db.Exec(`
+		DELETE FROM workflow_steps WHERE workflow_id = 'wf-test';
+		INSERT INTO workflow_steps (
+			id, workflow_id, name, position, is_start_step, created_at, updated_at
+		) VALUES
+			('old-start', 'wf-test', 'Old Start', 0, 1, datetime('now'), datetime('now')),
+			('duplicate-target', 'wf-test', 'Duplicate Target', 1, 0, datetime('now'), datetime('now'));
+	`); err != nil {
+		t.Fatalf("seed rollback workflow steps: %v", err)
 	}
 
-	err = repo.CreateStep(ctx, &models.WorkflowStep{
-		ID:          duplicateID,
+	err := repo.CreateStep(ctx, &models.WorkflowStep{
+		ID:          "duplicate-target",
 		WorkflowID:  "wf-test",
 		Name:        "Duplicate ID Start",
 		Position:    99,
@@ -300,7 +293,7 @@ func TestCreateStep_RollsBackStartDemotionWhenInsertFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get start step: %v", err)
 	}
-	if start == nil || start.ID != originalStartID {
-		t.Fatalf("expected original start step %q to remain after rollback, got %#v", originalStartID, start)
+	if start == nil || start.ID != "old-start" {
+		t.Fatalf("expected original start step %q to remain after rollback, got %#v", "old-start", start)
 	}
 }

--- a/apps/backend/internal/workflow/service/service.go
+++ b/apps/backend/internal/workflow/service/service.go
@@ -222,9 +222,6 @@ func (s *Service) CreateStepsFromTemplate(ctx context.Context, workflowID, templ
 			StageType:             stepDef.StageType,
 		}
 
-		if err := s.ensureOnlyStartStep(ctx, step); err != nil {
-			return err
-		}
 		if err := s.repo.CreateStep(ctx, step); err != nil {
 			s.logger.Error("failed to create step from template",
 				zap.String("workflow_id", workflowID),
@@ -273,43 +270,41 @@ func (s *Service) ResolveFirstStep(ctx context.Context, workflowID string) (*mod
 
 // CreateStep creates a new workflow step.
 func (s *Service) CreateStep(ctx context.Context, step *models.WorkflowStep) error {
-	step.ID = uuid.New().String()
-	if err := s.ensureOnlyStartStep(ctx, step); err != nil {
-		return err
+	_, err := s.CreateStepWithStartStepUpdates(ctx, step)
+	return err
+}
+
+// CreateStepWithStartStepUpdates creates a new workflow step and returns any
+// other workflow steps whose start-step flag was cleared.
+func (s *Service) CreateStepWithStartStepUpdates(ctx context.Context, step *models.WorkflowStep) ([]*models.WorkflowStep, error) {
+	if step.ID == "" {
+		step.ID = uuid.New().String()
 	}
-	if err := s.repo.CreateStep(ctx, step); err != nil {
+	demoted, err := s.repo.CreateStepWithDemotedStartSteps(ctx, step)
+	if err != nil {
 		s.logger.Error("failed to create step", zap.String("workflow_id", step.WorkflowID), zap.Error(err))
-		return err
+		return nil, err
 	}
 	s.logger.Info("created workflow step", zap.String("step_id", step.ID), zap.String("workflow_id", step.WorkflowID))
-	return nil
+	return demoted, nil
 }
 
 // UpdateStep updates an existing workflow step.
 func (s *Service) UpdateStep(ctx context.Context, step *models.WorkflowStep) error {
-	if err := s.ensureOnlyStartStep(ctx, step); err != nil {
-		return err
-	}
-	if err := s.repo.UpdateStep(ctx, step); err != nil {
-		s.logger.Error("failed to update step", zap.String("step_id", step.ID), zap.Error(err))
-		return err
-	}
-	s.logger.Info("updated workflow step", zap.String("step_id", step.ID))
-	return nil
+	_, err := s.UpdateStepWithStartStepUpdates(ctx, step)
+	return err
 }
 
-func (s *Service) ensureOnlyStartStep(ctx context.Context, step *models.WorkflowStep) error {
-	if !step.IsStartStep {
-		return nil
+// UpdateStepWithStartStepUpdates updates a workflow step and returns any other
+// workflow steps whose start-step flag was cleared.
+func (s *Service) UpdateStepWithStartStepUpdates(ctx context.Context, step *models.WorkflowStep) ([]*models.WorkflowStep, error) {
+	demoted, err := s.repo.UpdateStepWithDemotedStartSteps(ctx, step)
+	if err != nil {
+		s.logger.Error("failed to update step", zap.String("step_id", step.ID), zap.Error(err))
+		return nil, err
 	}
-	if err := s.repo.ClearStartStepFlag(ctx, step.WorkflowID, step.ID); err != nil {
-		s.logger.Error("failed to clear start step flag",
-			zap.String("workflow_id", step.WorkflowID),
-			zap.String("step_id", step.ID),
-			zap.Error(err))
-		return err
-	}
-	return nil
+	s.logger.Info("updated workflow step", zap.String("step_id", step.ID))
+	return demoted, nil
 }
 
 // DeleteStep deletes a workflow step and clears any references to it from other steps.
@@ -550,9 +545,6 @@ func (s *Service) importSingleWorkflow(ctx context.Context, workspaceID string, 
 		// Match step-level agent profile if present.
 		if sp.AgentProfile != nil && s.matchProfile != nil {
 			step.AgentProfileID = s.matchProfile(sp.AgentProfile.AgentName, sp.AgentProfile.Model, sp.AgentProfile.Mode)
-		}
-		if err := s.ensureOnlyStartStep(ctx, step); err != nil {
-			return err
 		}
 		if err := s.repo.CreateStep(ctx, step); err != nil {
 			return fmt.Errorf("create step %q: %w", sp.Name, err)

--- a/apps/backend/internal/workflow/service/service.go
+++ b/apps/backend/internal/workflow/service/service.go
@@ -222,6 +222,9 @@ func (s *Service) CreateStepsFromTemplate(ctx context.Context, workflowID, templ
 			StageType:             stepDef.StageType,
 		}
 
+		if err := s.ensureOnlyStartStep(ctx, step); err != nil {
+			return err
+		}
 		if err := s.repo.CreateStep(ctx, step); err != nil {
 			s.logger.Error("failed to create step from template",
 				zap.String("workflow_id", workflowID),
@@ -271,6 +274,9 @@ func (s *Service) ResolveFirstStep(ctx context.Context, workflowID string) (*mod
 // CreateStep creates a new workflow step.
 func (s *Service) CreateStep(ctx context.Context, step *models.WorkflowStep) error {
 	step.ID = uuid.New().String()
+	if err := s.ensureOnlyStartStep(ctx, step); err != nil {
+		return err
+	}
 	if err := s.repo.CreateStep(ctx, step); err != nil {
 		s.logger.Error("failed to create step", zap.String("workflow_id", step.WorkflowID), zap.Error(err))
 		return err
@@ -281,18 +287,28 @@ func (s *Service) CreateStep(ctx context.Context, step *models.WorkflowStep) err
 
 // UpdateStep updates an existing workflow step.
 func (s *Service) UpdateStep(ctx context.Context, step *models.WorkflowStep) error {
-	// If marking as start step, clear the flag on all other steps first
-	if step.IsStartStep {
-		if err := s.repo.ClearStartStepFlag(ctx, step.WorkflowID, step.ID); err != nil {
-			s.logger.Error("failed to clear start step flag", zap.String("workflow_id", step.WorkflowID), zap.Error(err))
-			return err
-		}
+	if err := s.ensureOnlyStartStep(ctx, step); err != nil {
+		return err
 	}
 	if err := s.repo.UpdateStep(ctx, step); err != nil {
 		s.logger.Error("failed to update step", zap.String("step_id", step.ID), zap.Error(err))
 		return err
 	}
 	s.logger.Info("updated workflow step", zap.String("step_id", step.ID))
+	return nil
+}
+
+func (s *Service) ensureOnlyStartStep(ctx context.Context, step *models.WorkflowStep) error {
+	if !step.IsStartStep {
+		return nil
+	}
+	if err := s.repo.ClearStartStepFlag(ctx, step.WorkflowID, step.ID); err != nil {
+		s.logger.Error("failed to clear start step flag",
+			zap.String("workflow_id", step.WorkflowID),
+			zap.String("step_id", step.ID),
+			zap.Error(err))
+		return err
+	}
 	return nil
 }
 
@@ -534,6 +550,9 @@ func (s *Service) importSingleWorkflow(ctx context.Context, workspaceID string, 
 		// Match step-level agent profile if present.
 		if sp.AgentProfile != nil && s.matchProfile != nil {
 			step.AgentProfileID = s.matchProfile(sp.AgentProfile.AgentName, sp.AgentProfile.Model, sp.AgentProfile.Mode)
+		}
+		if err := s.ensureOnlyStartStep(ctx, step); err != nil {
+			return err
 		}
 		if err := s.repo.CreateStep(ctx, step); err != nil {
 			return fmt.Errorf("create step %q: %w", sp.Name, err)

--- a/apps/backend/internal/workflow/service/service_test.go
+++ b/apps/backend/internal/workflow/service/service_test.go
@@ -269,6 +269,22 @@ func TestGetPreviousStepByPosition(t *testing.T) {
 }
 
 func TestResolveStartStep(t *testing.T) {
+	t.Run("create step keeps only the latest explicit start step", func(t *testing.T) {
+		svc, db := setupTestService(t)
+		ctx := context.Background()
+
+		insertWorkflow(t, db, "wf-1", "Test Workflow")
+
+		createStep(t, svc, &models.WorkflowStep{WorkflowID: "wf-1", Name: "First Start", Position: 0, IsStartStep: true})
+		createStep(t, svc, &models.WorkflowStep{WorkflowID: "wf-1", Name: "Latest Start", Position: 1, IsStartStep: true})
+		createStep(t, svc, &models.WorkflowStep{WorkflowID: "wf-1", Name: "Done", Position: 2})
+
+		steps, err := svc.ListStepsByWorkflow(ctx, "wf-1")
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"Latest Start"}, startStepNames(steps))
+	})
+
 	t.Run("explicit is_start_step returns that step", func(t *testing.T) {
 		svc, db := setupTestService(t)
 		ctx := context.Background()
@@ -414,6 +430,30 @@ func TestCreateStepsFromTemplate_RemapsStepIDs(t *testing.T) {
 	assert.Equal(t, nameToID["In Progress"], done.Events.OnTurnStart[0].Config["step_id"])
 }
 
+func TestCreateStepsFromTemplate_NormalizesDuplicateStartSteps(t *testing.T) {
+	svc, db := setupTestService(t)
+	ctx := context.Background()
+
+	insertWorkflow(t, db, "wf-1", "Test Workflow")
+	err := svc.repo.CreateTemplate(ctx, &models.WorkflowTemplate{
+		ID:   "duplicate-starts",
+		Name: "Duplicate Starts",
+		Steps: []models.StepDefinition{
+			{ID: "first", Name: "First Start", Position: 0, Color: "gray", IsStartStep: true},
+			{ID: "second", Name: "Latest Start", Position: 1, Color: "blue", IsStartStep: true},
+			{ID: "done", Name: "Done", Position: 2, Color: "green"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = svc.CreateStepsFromTemplate(ctx, "wf-1", "duplicate-starts")
+	require.NoError(t, err)
+
+	steps, err := svc.repo.ListStepsByWorkflow(ctx, "wf-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Latest Start"}, startStepNames(steps))
+}
+
 func findStepByName(steps []*models.WorkflowStep, name string) *models.WorkflowStep {
 	for _, s := range steps {
 		if s.Name == name {
@@ -421,6 +461,16 @@ func findStepByName(steps []*models.WorkflowStep, name string) *models.WorkflowS
 		}
 	}
 	return nil
+}
+
+func startStepNames(steps []*models.WorkflowStep) []string {
+	names := make([]string, 0)
+	for _, step := range steps {
+		if step.IsStartStep {
+			names = append(names, step.Name)
+		}
+	}
+	return names
 }
 
 func setupTestServiceWithProvider(t *testing.T) (*Service, *sqlx.DB, *mockWorkflowProvider) {
@@ -580,6 +630,34 @@ func TestImportWorkflows(t *testing.T) {
 		steps, err := svc.repo.ListStepsByWorkflow(ctx, "imported-Imported WF")
 		require.NoError(t, err)
 		assert.Len(t, steps, 2)
+	})
+
+	t.Run("normalizes duplicate start steps on import", func(t *testing.T) {
+		svc, _, _ := setupTestServiceWithProvider(t)
+		ctx := context.Background()
+
+		export := &models.WorkflowExport{
+			Version: models.ExportVersion,
+			Type:    models.ExportType,
+			Workflows: []models.WorkflowPortable{
+				{
+					Name: "Duplicate Starts",
+					Steps: []models.StepPortable{
+						{Name: "First Start", Position: 0, Color: "gray", IsStartStep: true},
+						{Name: "Latest Start", Position: 1, Color: "blue", IsStartStep: true},
+						{Name: "Done", Position: 2, Color: "green"},
+					},
+				},
+			},
+		}
+
+		result, err := svc.ImportWorkflows(ctx, "ws-1", export)
+		require.NoError(t, err)
+		require.Len(t, result.Created, 1)
+
+		steps, err := svc.repo.ListStepsByWorkflow(ctx, "imported-Duplicate Starts")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Latest Start"}, startStepNames(steps))
 	})
 
 	t.Run("skips workflows that already exist by name", func(t *testing.T) {

--- a/apps/web/components/settings/workflow-card-actions.test.ts
+++ b/apps/web/components/settings/workflow-card-actions.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Workflow, WorkflowStep } from "@/lib/types/http";
+import { useWorkflowStepActions } from "./workflow-card-actions";
+
+vi.mock("@/app/actions/workspaces", () => ({
+  createWorkflowAction: vi.fn(),
+  createWorkflowStepAction: vi.fn(),
+  updateWorkflowStepAction: vi.fn(),
+  deleteWorkflowStepAction: vi.fn(),
+  reorderWorkflowStepsAction: vi.fn(),
+  listWorkflowStepsAction: vi.fn(),
+  getStepTaskCount: vi.fn(),
+  getWorkflowTaskCount: vi.fn(),
+  exportWorkflowAction: vi.fn(),
+  bulkMoveTasks: vi.fn(),
+}));
+
+const workflow = {
+  id: "wf-1",
+  workspace_id: "ws-1",
+  name: "Workflow",
+  created_at: "",
+  updated_at: "",
+} as Workflow;
+
+function step(id: string, name: string, position: number, isStartStep: boolean): WorkflowStep {
+  return {
+    id,
+    workflow_id: workflow.id,
+    name,
+    position,
+    color: "bg-slate-500",
+    allow_manual_move: true,
+    is_start_step: isStartStep,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+function renderNewWorkflowStepActions(initialSteps: WorkflowStep[]) {
+  let steps = initialSteps;
+  const setWorkflowSteps = vi.fn(
+    (updater: ((prev: WorkflowStep[]) => WorkflowStep[]) | WorkflowStep[]) => {
+      steps = typeof updater === "function" ? updater(steps) : updater;
+    },
+  );
+  const view = renderHook(() =>
+    useWorkflowStepActions({
+      workflow,
+      isNewWorkflow: true,
+      workflowSteps: steps,
+      setWorkflowSteps,
+      refreshWorkflowSteps: vi.fn(),
+      setStepToDelete: vi.fn(),
+      setStepTaskCount: vi.fn(),
+      setTargetStepForMigration: vi.fn(),
+      setStepDeleteOpen: vi.fn(),
+      toast: vi.fn(),
+    }),
+  );
+  return { ...view, getSteps: () => steps };
+}
+
+describe("useWorkflowStepActions", () => {
+  it("keeps one start step while editing a new workflow locally", async () => {
+    const { result, getSteps } = renderNewWorkflowStepActions([
+      step("step-1", "Todo", 0, true),
+      step("step-2", "Plan", 1, false),
+    ]);
+
+    await act(async () => {
+      await result.current.handleUpdateWorkflowStep("step-2", { is_start_step: true });
+    });
+
+    expect(
+      getSteps()
+        .filter((s) => s.is_start_step)
+        .map((s) => s.id),
+    ).toEqual(["step-2"]);
+  });
+});

--- a/apps/web/components/settings/workflow-card-actions.ts
+++ b/apps/web/components/settings/workflow-card-actions.ts
@@ -117,6 +117,19 @@ async function addRemoteStep(
   }
 }
 
+function applyWorkflowStepUpdates(
+  steps: WorkflowStep[],
+  stepId: string,
+  updates: Partial<WorkflowStep>,
+): WorkflowStep[] {
+  const isSettingStartStep = updates.is_start_step === true;
+  return steps.map((step) => {
+    if (step.id === stepId) return { ...step, ...updates };
+    if (isSettingStartStep) return { ...step, is_start_step: false };
+    return step;
+  });
+}
+
 export function useWorkflowStepActions({
   workflow,
   isNewWorkflow,
@@ -131,7 +144,7 @@ export function useWorkflowStepActions({
 }: WorkflowStepActionsParams) {
   const handleUpdateWorkflowStep = async (stepId: string, updates: Partial<WorkflowStep>) => {
     if (isNewWorkflow) {
-      setWorkflowSteps((prev) => prev.map((s) => (s.id === stepId ? { ...s, ...updates } : s)));
+      setWorkflowSteps((prev) => applyWorkflowStepUpdates(prev, stepId, updates));
       return;
     }
     try {


### PR DESCRIPTION
Workflow steps could persist multiple start flags from create/import paths, which made task placement ambiguous. Start-step uniqueness is now enforced across backend writes, repaired for existing databases, and mirrored in the workflow creation UI.

## Important Changes

- Added a boot-time cleanup and partial unique index so each workflow has at most one start step.
- Legacy duplicate-start repair keeps the most recently updated start step; position and ID are tie-breakers.
- Normalized start-step selection on service create, template creation, and workflow import paths.
- Updated new-workflow editor state so choosing a new start step clears the previous one before save.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `go test ./internal/workflow/...`
- `go test ./internal/task/repository/sqlite -run 'Workflow|Schema|Builtin'`
- `pnpm --filter @kandev/web test -- --run components/settings/workflow-card-actions.test.ts`
- `cd apps/web && pnpm typecheck`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
