### PR TITLE
fix: improve pr ci automation reliability

### DIFF
--- a/apps/backend/internal/github/gh_client.go
+++ b/apps/backend/internal/github/gh_client.go
@@ -647,6 +647,8 @@ func (c *GHClient) ListCheckRuns(ctx context.Context, owner, repo, ref string) (
 	return mergeChecks(convertRawCheckRuns(checkRunsRaw), convertRawStatusContexts(statusRaw)), nil
 }
 
+// decodeGHCheckRuns decodes whitespace-separated JSON check-run objects
+// emitted by gh --paginate --jq '.check_runs[]'.
 func decodeGHCheckRuns(out string) ([]ghCheckRun, error) {
 	if strings.TrimSpace(out) == "" {
 		return nil, nil

--- a/apps/backend/internal/github/gh_client_test.go
+++ b/apps/backend/internal/github/gh_client_test.go
@@ -173,6 +173,46 @@ esac
 	}
 }
 
+func TestDecodeGHCheckRuns(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantNames []string
+		wantErr   bool
+	}{
+		{name: "empty", input: "", wantNames: nil},
+		{name: "single object", input: `{"name":"unit","status":"completed","conclusion":"success"}`, wantNames: []string{"unit"}},
+		{
+			name:      "multiple objects with whitespace",
+			input:     "\n  {\"name\":\"unit\",\"status\":\"completed\",\"conclusion\":\"success\"}\n{\"name\":\"lint\",\"status\":\"completed\",\"conclusion\":\"failure\"}\t",
+			wantNames: []string{"unit", "lint"},
+		},
+		{name: "invalid json", input: `{"name":"unit"`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeGHCheckRuns(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decodeGHCheckRuns: %v", err)
+			}
+			if len(got) != len(tt.wantNames) {
+				t.Fatalf("runs = %d, want %d: %+v", len(got), len(tt.wantNames), got)
+			}
+			for i, name := range tt.wantNames {
+				if got[i].Name != name {
+					t.Fatalf("run[%d].Name = %q, want %q", i, got[i].Name, name)
+				}
+			}
+		})
+	}
+}
+
 func TestParseRepoURL(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/apps/backend/internal/github/gh_client_test.go
+++ b/apps/backend/internal/github/gh_client_test.go
@@ -136,7 +136,8 @@ printf '%s\n' "$*" >> "$GH_ARGS_LOG"
 case "$*" in
   *check-runs*)
     case "$*" in
-      *--paginate*) printf '%s\n' '[{"name":"unit","status":"completed","conclusion":"success","html_url":"https://ci/unit"},{"name":"lint","status":"completed","conclusion":"failure","html_url":"https://ci/lint"}]' ;;
+      *--slurp*) printf '%s\n' 'unsupported slurp' >&2; exit 1 ;;
+      *--paginate*) printf '%s\n' '{"name":"unit","status":"completed","conclusion":"success","html_url":"https://ci/unit"}' '{"name":"lint","status":"completed","conclusion":"failure","html_url":"https://ci/lint"}' ;;
       *) printf '%s\n' '[{"name":"unit","status":"completed","conclusion":"success","html_url":"https://ci/unit"}]' ;;
     esac
     ;;
@@ -166,6 +167,9 @@ esac
 	}
 	if !strings.Contains(string(logged), "--paginate") {
 		t.Fatalf("ListCheckRuns should call gh api with --paginate, got:\n%s", logged)
+	}
+	if strings.Contains(string(logged), "--slurp") {
+		t.Fatalf("ListCheckRuns should not combine gh api --slurp with --jq, got:\n%s", logged)
 	}
 }
 

--- a/apps/backend/internal/github/gh_client_test.go
+++ b/apps/backend/internal/github/gh_client_test.go
@@ -158,8 +158,15 @@ esac
 	if len(checks) != 2 {
 		t.Fatalf("checks = %d, want 2: %+v", len(checks), checks)
 	}
-	if checks[1].Name != "lint" || checks[1].Conclusion != "failure" {
-		t.Fatalf("expected failed lint check from paginated output, got %+v", checks[1])
+	var lint *CheckRun
+	for i := range checks {
+		if checks[i].Name == "lint" {
+			lint = &checks[i]
+			break
+		}
+	}
+	if lint == nil || lint.Conclusion != "failure" {
+		t.Fatalf("expected failed lint check from paginated output, got %+v", checks)
 	}
 	logged, err := os.ReadFile(logPath)
 	if err != nil {

--- a/apps/backend/internal/github/gh_client_test.go
+++ b/apps/backend/internal/github/gh_client_test.go
@@ -1,7 +1,10 @@
 package github
 
 import (
+	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -121,6 +124,48 @@ func TestParseTimePtrValue(t *testing.T) {
 	expected := time.Date(2025, 6, 15, 14, 30, 0, 0, time.UTC)
 	if !got.Equal(expected) {
 		t.Errorf("got %v, want %v", *got, expected)
+	}
+}
+
+func TestGHClient_ListCheckRuns_PaginatesCheckRuns(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "gh-args.log")
+	ghPath := filepath.Join(binDir, "gh")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_ARGS_LOG"
+case "$*" in
+  *check-runs*)
+    case "$*" in
+      *--paginate*) printf '%s\n' '[{"name":"unit","status":"completed","conclusion":"success","html_url":"https://ci/unit"},{"name":"lint","status":"completed","conclusion":"failure","html_url":"https://ci/lint"}]' ;;
+      *) printf '%s\n' '[{"name":"unit","status":"completed","conclusion":"success","html_url":"https://ci/unit"}]' ;;
+    esac
+    ;;
+  *status*) printf '%s\n' '[]' ;;
+  *) printf '%s\n' '[]' ;;
+esac
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GH_ARGS_LOG", logPath)
+
+	checks, err := NewGHClient().ListCheckRuns(context.Background(), "acme", "widget", "sha")
+	if err != nil {
+		t.Fatalf("ListCheckRuns: %v", err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("checks = %d, want 2: %+v", len(checks), checks)
+	}
+	if checks[1].Name != "lint" || checks[1].Conclusion != "failure" {
+		t.Fatalf("expected failed lint check from paginated output, got %+v", checks[1])
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read gh args log: %v", err)
+	}
+	if !strings.Contains(string(logged), "--paginate") {
+		t.Fatalf("ListCheckRuns should call gh api with --paginate, got:\n%s", logged)
 	}
 }
 

--- a/apps/backend/internal/github/handlers.go
+++ b/apps/backend/internal/github/handlers.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -261,7 +262,10 @@ func wsSyncTaskPR(svc *Service, _ *logger.Logger) func(ctx context.Context, msg 
 	return wsWithField("task_id", func(ctx context.Context, taskID string) (interface{}, error) {
 		prs, permanent, err := svc.TriggerPRSyncAllPermanent(ctx, taskID)
 		if err != nil {
-			return nil, err
+			var partial *PartialPRSyncError
+			if !errors.As(err, &partial) || len(prs) == 0 {
+				return nil, err
+			}
 		}
 		// Return an envelope so the frontend always gets a deterministic
 		// shape even on empty results (`{prs: []}`); a bare `nil` slice

--- a/apps/backend/internal/github/handlers.go
+++ b/apps/backend/internal/github/handlers.go
@@ -263,7 +263,7 @@ func wsSyncTaskPR(svc *Service, _ *logger.Logger) func(ctx context.Context, msg 
 		prs, permanent, err := svc.TriggerPRSyncAllPermanent(ctx, taskID)
 		if err != nil {
 			var partial *PartialPRSyncError
-			if !errors.As(err, &partial) || len(prs) == 0 {
+			if !permanent && (!errors.As(err, &partial) || len(prs) == 0) {
 				return nil, err
 			}
 		}

--- a/apps/backend/internal/github/pat_client_test.go
+++ b/apps/backend/internal/github/pat_client_test.go
@@ -196,6 +196,50 @@ func TestConvertPatPR_MergeableState(t *testing.T) {
 	}
 }
 
+func TestPATClient_ListCheckRuns_PaginatesCheckRuns(t *testing.T) {
+	var checkRunQueries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/acme/widget/commits/sha/check-runs":
+			checkRunQueries = append(checkRunQueries, r.URL.RawQuery)
+			switch r.URL.Query().Get("page") {
+			case "", "1":
+				w.Header().Set("Link", `<`+githubAPIBase+`/repos/acme/widget/commits/sha/check-runs?per_page=100&page=2>; rel="next"`)
+				_, _ = w.Write([]byte(`{"check_runs":[{"name":"unit","status":"completed","conclusion":"success","html_url":"https://ci/unit"}]}`))
+			case "2":
+				_, _ = w.Write([]byte(`{"check_runs":[{"name":"lint","status":"completed","conclusion":"failure","html_url":"https://ci/lint"}]}`))
+			default:
+				t.Errorf("unexpected check-runs page %q", r.URL.Query().Get("page"))
+				http.Error(w, "unexpected page", http.StatusInternalServerError)
+			}
+		case "/repos/acme/widget/commits/sha/status":
+			_, _ = w.Write([]byte(`{"statuses":[]}`))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newPATClientPointingAt(t, srv.URL)
+	checks, err := c.ListCheckRuns(context.Background(), "acme", "widget", "sha")
+	if err != nil {
+		t.Fatalf("ListCheckRuns: %v", err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("checks = %d, want 2: %+v", len(checks), checks)
+	}
+	if checks[1].Name != "lint" || checks[1].Conclusion != "failure" {
+		t.Fatalf("expected failed lint check from page 2, got %+v", checks[1])
+	}
+	if len(checkRunQueries) != 2 {
+		t.Fatalf("check-runs requests = %d, want 2 (%v)", len(checkRunQueries), checkRunQueries)
+	}
+	if !strings.Contains(checkRunQueries[0], "per_page=100") {
+		t.Fatalf("first check-runs request should request per_page=100, got %q", checkRunQueries[0])
+	}
+}
+
 func TestPATClient_FindPRByBranch_UsesGraphQLHeadRefName(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/graphql" {

--- a/apps/backend/internal/github/poller.go
+++ b/apps/backend/internal/github/poller.go
@@ -221,24 +221,11 @@ func (p *Poller) tryBatchedPRWatchCheck(ctx context.Context, watches []*PRWatch)
 			p.publishPRStatusEvent(ctx, r.Watch, r.Status)
 			continue
 		}
-		commentsChanged := p.refreshPRWatchComments(ctx, r.Watch)
-		if r.Changed || commentsChanged {
+		if r.Changed {
 			p.publishPRStatusEvent(ctx, r.Watch, r.Status)
 		}
 	}
 	return true
-}
-
-func (p *Poller) refreshPRWatchComments(ctx context.Context, watch *PRWatch) bool {
-	if watch == nil || watch.PRNumber == 0 {
-		return false
-	}
-	changed, err := p.service.RefreshPRWatchCommentTimestamp(ctx, watch)
-	if err != nil {
-		p.logger.Debug("failed to refresh PR watch comments", zap.String("id", watch.ID), zap.Error(err))
-		return false
-	}
-	return changed
 }
 
 // splitPRWatches partitions watches into "we know the PR number" and "still

--- a/apps/backend/internal/github/poller.go
+++ b/apps/backend/internal/github/poller.go
@@ -221,11 +221,24 @@ func (p *Poller) tryBatchedPRWatchCheck(ctx context.Context, watches []*PRWatch)
 			p.publishPRStatusEvent(ctx, r.Watch, r.Status)
 			continue
 		}
-		if r.Changed {
+		commentsChanged := p.refreshPRWatchComments(ctx, r.Watch)
+		if r.Changed || commentsChanged {
 			p.publishPRStatusEvent(ctx, r.Watch, r.Status)
 		}
 	}
 	return true
+}
+
+func (p *Poller) refreshPRWatchComments(ctx context.Context, watch *PRWatch) bool {
+	if watch == nil || watch.PRNumber == 0 {
+		return false
+	}
+	changed, err := p.service.RefreshPRWatchCommentTimestamp(ctx, watch)
+	if err != nil {
+		p.logger.Debug("failed to refresh PR watch comments", zap.String("id", watch.ID), zap.Error(err))
+		return false
+	}
+	return changed
 }
 
 // splitPRWatches partitions watches into "we know the PR number" and "still

--- a/apps/backend/internal/github/poller_test.go
+++ b/apps/backend/internal/github/poller_test.go
@@ -643,11 +643,10 @@ func TestTryBatchedPRWatchCheck_NumberedWatch_AppliesStatus(t *testing.T) {
 	}
 }
 
-func TestTryBatchedPRWatchCheck_PublishesOnPlainCommentChange(t *testing.T) {
+func TestTryBatchedPRWatchCheck_PublishesOnPRFeedbackWatermarkChange(t *testing.T) {
 	poller, _, gh, store := setupBatchedPollerTest(t)
 	ctx := context.Background()
-	oldCommentAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	newCommentAt := oldCommentAt.Add(time.Hour)
+	prUpdatedAt := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	gh.prResponses = []string{`{
 		"data": {
 			"repo0": {
@@ -664,12 +663,6 @@ func TestTryBatchedPRWatchCheck_PublishesOnPlainCommentChange(t *testing.T) {
 			}
 		}
 	}`}
-	gh.AddComments("o", "r", 42, []PRComment{{
-		ID:        100,
-		Body:      "plain comment",
-		CreatedAt: newCommentAt,
-		UpdatedAt: newCommentAt,
-	}})
 
 	gotEvent := make(chan *bus.Event, 1)
 	if _, err := poller.eventBus.Subscribe(events.GitHubPRFeedback, func(_ context.Context, event *bus.Event) error {
@@ -688,7 +681,6 @@ func TestTryBatchedPRWatchCheck_PublishesOnPlainCommentChange(t *testing.T) {
 		Branch:          "feat",
 		LastCheckStatus: "success",
 		LastReviewState: "",
-		LastCommentAt:   &oldCommentAt,
 	}
 	if err := store.CreatePRWatch(ctx, watch); err != nil {
 		t.Fatalf("create PR watch: %v", err)
@@ -713,14 +705,41 @@ func TestTryBatchedPRWatchCheck_PublishesOnPlainCommentChange(t *testing.T) {
 	select {
 	case <-gotEvent:
 	default:
-		t.Fatal("expected plain comment change to publish PR feedback event")
+		t.Fatal("expected PR feedback watermark change to publish PR feedback event")
 	}
 	updated, err := store.GetPRWatchBySession(ctx, "s1")
 	if err != nil || updated == nil {
 		t.Fatalf("get PR watch: err=%v, w=%v", err, updated)
 	}
-	if updated.LastCommentAt == nil || !updated.LastCommentAt.Equal(newCommentAt) {
-		t.Fatalf("LastCommentAt = %v, want %v", updated.LastCommentAt, newCommentAt)
+	if updated.LastCommentAt == nil || !updated.LastCommentAt.Equal(prUpdatedAt) {
+		t.Fatalf("LastCommentAt = %v, want %v", updated.LastCommentAt, prUpdatedAt)
+	}
+}
+
+func TestTriggerPRSyncAll_ReturnsPerWatchFallbackErrors(t *testing.T) {
+	_, svc, _, store := setupPollerTest(t)
+	ctx := context.Background()
+	watch := &PRWatch{
+		SessionID: "s1",
+		TaskID:    "t1",
+		Owner:     "o",
+		Repo:      "r",
+		PRNumber:  42,
+		Branch:    "feat",
+	}
+	if err := store.CreatePRWatch(ctx, watch); err != nil {
+		t.Fatalf("create PR watch: %v", err)
+	}
+
+	prs, err := svc.TriggerPRSyncAll(ctx, "t1")
+	if err == nil {
+		t.Fatal("expected per-watch fallback error")
+	}
+	if len(prs) != 0 {
+		t.Fatalf("prs = %d, want 0: %+v", len(prs), prs)
+	}
+	if !strings.Contains(err.Error(), "o/r#42") {
+		t.Fatalf("expected aggregate error to identify failed PR, got %v", err)
 	}
 }
 

--- a/apps/backend/internal/github/poller_test.go
+++ b/apps/backend/internal/github/poller_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/kandev/kandev/internal/common/logger"
+	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
 )
 
@@ -639,6 +640,87 @@ func TestTryBatchedPRWatchCheck_NumberedWatch_AppliesStatus(t *testing.T) {
 	}
 	if updated.ReviewState != "approved" {
 		t.Errorf("ReviewState = %q, want approved", updated.ReviewState)
+	}
+}
+
+func TestTryBatchedPRWatchCheck_PublishesOnPlainCommentChange(t *testing.T) {
+	poller, _, gh, store := setupBatchedPollerTest(t)
+	ctx := context.Background()
+	oldCommentAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newCommentAt := oldCommentAt.Add(time.Hour)
+	gh.prResponses = []string{`{
+		"data": {
+			"repo0": {
+				"pr0": {
+					"state": "OPEN", "title": "Test PR", "url": "https://x/1",
+					"isDraft": false, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+					"headRefName": "feat", "baseRefName": "main", "headRefOid": "abc",
+					"author": {"login": "alice"},
+					"createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-02T00:00:00Z",
+					"reviews": {"nodes": []},
+					"reviewRequests": {"totalCount": 0},
+					"commits": {"nodes": [{"commit": {"statusCheckRollup": {"state": "SUCCESS"}}}]}
+				}
+			}
+		}
+	}`}
+	gh.AddComments("o", "r", 42, []PRComment{{
+		ID:        100,
+		Body:      "plain comment",
+		CreatedAt: newCommentAt,
+		UpdatedAt: newCommentAt,
+	}})
+
+	gotEvent := make(chan *bus.Event, 1)
+	if _, err := poller.eventBus.Subscribe(events.GitHubPRFeedback, func(_ context.Context, event *bus.Event) error {
+		gotEvent <- event
+		return nil
+	}); err != nil {
+		t.Fatalf("subscribe PR feedback: %v", err)
+	}
+
+	watch := &PRWatch{
+		SessionID:       "s1",
+		TaskID:          "t1",
+		Owner:           "o",
+		Repo:            "r",
+		PRNumber:        42,
+		Branch:          "feat",
+		LastCheckStatus: "success",
+		LastReviewState: "",
+		LastCommentAt:   &oldCommentAt,
+	}
+	if err := store.CreatePRWatch(ctx, watch); err != nil {
+		t.Fatalf("create PR watch: %v", err)
+	}
+	if err := store.CreateTaskPR(ctx, &TaskPR{
+		TaskID:     "t1",
+		Owner:      "o",
+		Repo:       "r",
+		PRNumber:   42,
+		PRURL:      "https://github.com/o/r/pull/42",
+		PRTitle:    "Test PR",
+		HeadBranch: "feat",
+		BaseBranch: "main",
+		State:      "open",
+	}); err != nil {
+		t.Fatalf("create task PR: %v", err)
+	}
+
+	if !poller.tryBatchedPRWatchCheck(ctx, []*PRWatch{watch}) {
+		t.Fatalf("expected batched path to succeed")
+	}
+	select {
+	case <-gotEvent:
+	default:
+		t.Fatal("expected plain comment change to publish PR feedback event")
+	}
+	updated, err := store.GetPRWatchBySession(ctx, "s1")
+	if err != nil || updated == nil {
+		t.Fatalf("get PR watch: err=%v, w=%v", err, updated)
+	}
+	if updated.LastCommentAt == nil || !updated.LastCommentAt.Equal(newCommentAt) {
+		t.Fatalf("LastCommentAt = %v, want %v", updated.LastCommentAt, newCommentAt)
 	}
 }
 

--- a/apps/backend/internal/github/poller_test.go
+++ b/apps/backend/internal/github/poller_test.go
@@ -716,6 +716,40 @@ func TestTryBatchedPRWatchCheck_PublishesOnPRFeedbackWatermarkChange(t *testing.
 	}
 }
 
+func TestPRWatchFeedbackHelpers(t *testing.T) {
+	now := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	older := now.Add(-time.Hour)
+	newer := now.Add(time.Hour)
+	status := &PRStatus{PR: &PR{UpdatedAt: now}}
+	if prWatchFeedbackUpdatedSinceWatch(nil, status) {
+		t.Fatal("nil watch should not report changed")
+	}
+	if prWatchFeedbackUpdatedSinceWatch(&PRWatch{}, nil) {
+		t.Fatal("nil status should not report changed")
+	}
+	if prWatchFeedbackUpdatedSinceWatch(&PRWatch{}, &PRStatus{PR: &PR{}}) {
+		t.Fatal("zero PR updated_at should not report changed")
+	}
+	if !prWatchFeedbackUpdatedSinceWatch(&PRWatch{}, status) {
+		t.Fatal("nil watermark should report changed for non-zero PR updated_at")
+	}
+	if !prWatchFeedbackUpdatedSinceWatch(&PRWatch{LastCommentAt: &older}, status) {
+		t.Fatal("newer PR updated_at should report changed")
+	}
+	if prWatchFeedbackUpdatedSinceWatch(&PRWatch{LastCommentAt: &newer}, status) {
+		t.Fatal("older PR updated_at should not report changed")
+	}
+	if got := prWatchFeedbackWatermark(&PRWatch{LastCommentAt: &newer}, status); got == nil || !got.Equal(newer) {
+		t.Fatalf("watermark should not move backward, got %v want %v", got, newer)
+	}
+	if got := prWatchFeedbackWatermark(&PRWatch{LastCommentAt: &older}, status); got == nil || !got.Equal(now) {
+		t.Fatalf("watermark should advance to PR updated_at, got %v want %v", got, now)
+	}
+	if got := prWatchFeedbackWatermark(&PRWatch{LastCommentAt: &older}, &PRStatus{}); got == nil || !got.Equal(older) {
+		t.Fatalf("watermark should preserve existing value without PR updated_at, got %v want %v", got, older)
+	}
+}
+
 func TestTriggerPRSyncAll_ReturnsPerWatchFallbackErrors(t *testing.T) {
 	_, svc, _, store := setupPollerTest(t)
 	ctx := context.Background()
@@ -740,6 +774,53 @@ func TestTriggerPRSyncAll_ReturnsPerWatchFallbackErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "o/r#42") {
 		t.Fatalf("expected aggregate error to identify failed PR, got %v", err)
+	}
+}
+
+func TestTriggerPRSyncAll_ReturnsPartialErrorWithSuccessfulPRs(t *testing.T) {
+	_, svc, mockClient, store := setupPollerTest(t)
+	ctx := context.Background()
+	mockClient.AddPR(&PR{
+		Number:     1,
+		Title:      "live",
+		State:      "open",
+		HeadSHA:    "sha-live",
+		HeadBranch: "feat-live",
+		BaseBranch: "main",
+		RepoOwner:  "o",
+		RepoName:   "r",
+		UpdatedAt:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	})
+	for _, watch := range []*PRWatch{
+		{SessionID: "s1", TaskID: "t1", RepositoryID: "repo-live", Owner: "o", Repo: "r", PRNumber: 1, Branch: "feat-live"},
+		{SessionID: "s2", TaskID: "t1", RepositoryID: "repo-dead", Owner: "o", Repo: "r", PRNumber: 2, Branch: "feat-dead"},
+	} {
+		if err := store.CreatePRWatch(ctx, watch); err != nil {
+			t.Fatalf("create PR watch: %v", err)
+		}
+	}
+	if err := store.CreateTaskPR(ctx, &TaskPR{
+		TaskID:       "t1",
+		RepositoryID: "repo-live",
+		Owner:        "o",
+		Repo:         "r",
+		PRNumber:     1,
+		PRURL:        "https://github.com/o/r/pull/1",
+		PRTitle:      "live",
+		HeadBranch:   "feat-live",
+		BaseBranch:   "main",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("create task PR: %v", err)
+	}
+
+	prs, err := svc.TriggerPRSyncAll(ctx, "t1")
+	var partial *PartialPRSyncError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected PartialPRSyncError, got %v", err)
+	}
+	if len(prs) != 1 || prs[0].RepositoryID != "repo-live" {
+		t.Fatalf("expected successful live PR result, got %+v", prs)
 	}
 }
 

--- a/apps/backend/internal/github/service.go
+++ b/apps/backend/internal/github/service.go
@@ -33,8 +33,8 @@ const (
 // service's self-approval guard, and tests.
 const reviewEventApprove = "APPROVE"
 
-// prSyncFreshnessWindow is how long PR data is considered fresh (skip GitHub API).
-const prSyncFreshnessWindow = 30 * time.Second
+// PRSyncFreshnessWindow is how long PR data is considered fresh.
+const PRSyncFreshnessWindow = 30 * time.Second
 
 // cleanupFetchFailureThreshold is the number of consecutive GetPRFeedback /
 // GetIssueState errors a single dedup row may accumulate before the cleanup

--- a/apps/backend/internal/github/service_pr_sync_test.go
+++ b/apps/backend/internal/github/service_pr_sync_test.go
@@ -118,7 +118,7 @@ func TestTriggerPRSync_NoWatch(t *testing.T) {
 // last_checked_at. The frontend re-syncs every 5s while no PR is found, so
 // each repeated sync hit `gh` again and logged a warning. After the fix the
 // first sync probes once and stamps the watch; the immediate second sync is
-// throttled within prSyncFreshnessWindow and must NOT probe again.
+// throttled within PRSyncFreshnessWindow and must NOT probe again.
 func TestTriggerPRSyncAll_ThrottlesDetectionProbe(t *testing.T) {
 	_, svc, mockClient, store := setupPollerTest(t)
 	ctx := context.Background()
@@ -144,7 +144,7 @@ func TestTriggerPRSyncAll_ThrottlesDetectionProbe(t *testing.T) {
 		t.Fatalf("expected exactly 1 detection probe on first sync, got %d", got)
 	}
 
-	// Second sync immediately after — well within prSyncFreshnessWindow.
+	// Second sync immediately after — well within PRSyncFreshnessWindow.
 	if _, err := svc.TriggerPRSyncAll(ctx, "t1"); err != nil {
 		t.Fatalf("second TriggerPRSyncAll: %v", err)
 	}

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -432,7 +432,7 @@ func (s *Service) ListWorkspaceTaskPRs(ctx context.Context, workspaceID string) 
 	staleTasks := make(map[string]struct{})
 	for taskID, prs := range result {
 		for _, tp := range prs {
-			if tp.LastSyncedAt == nil || time.Since(*tp.LastSyncedAt) >= prSyncFreshnessWindow {
+			if tp.LastSyncedAt == nil || time.Since(*tp.LastSyncedAt) >= PRSyncFreshnessWindow {
 				staleTasks[taskID] = struct{}{}
 				break
 			}
@@ -837,7 +837,7 @@ func (s *Service) detectPRForWatchOnce(ctx context.Context, watch *PRWatch, task
 	// Without this, a branch whose PR never appears (e.g. an unresolvable repo)
 	// re-hits `gh` on every on-demand sync, and the frontend re-syncs every 5s
 	// while no PR is found — flooding the logs with identical failures.
-	if watch.LastCheckedAt != nil && time.Since(*watch.LastCheckedAt) < prSyncFreshnessWindow {
+	if watch.LastCheckedAt != nil && time.Since(*watch.LastCheckedAt) < PRSyncFreshnessWindow {
 		return s.store.GetTaskPRByRepository(ctx, taskID, watch.RepositoryID)
 	}
 
@@ -858,7 +858,7 @@ func (s *Service) detectPRForWatchOnce(ctx context.Context, watch *PRWatch, task
 	// flood this fixes IS the error path (an unresolvable repo makes `gh` exit
 	// non-zero), so stamping only on success would leave the bug unfixed. The
 	// tradeoff: a transient GitHub error throttles the next on-demand probe for
-	// prSyncFreshnessWindow, which is fine — it stops hammering a failing
+	// PRSyncFreshnessWindow, which is fine — it stops hammering a failing
 	// endpoint, and the 60s background poller still retries. This diverges
 	// intentionally from poller.detectPRForWatch, which stamps only on success.
 	// The empty-string check/review args clear last_check_status /
@@ -909,7 +909,7 @@ func (s *Service) triggerPRStatusSync(ctx context.Context, watch *PRWatch, taskI
 		return s.store.GetTaskPR(c, taskID)
 	}
 	if tp, _ := loadTaskPR(ctx); tp != nil && tp.LastSyncedAt != nil {
-		if time.Since(*tp.LastSyncedAt) < prSyncFreshnessWindow {
+		if time.Since(*tp.LastSyncedAt) < PRSyncFreshnessWindow {
 			return tp, nil
 		}
 	}

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -122,14 +122,55 @@ func (s *Service) CheckPRWatch(ctx context.Context, watch *PRWatch) (*PRStatus, 
 
 	// Check for check status or review state changes
 	hasNew := status.ChecksState != watch.LastCheckStatus || status.ReviewState != watch.LastReviewState
+	commentAt, commentsChanged, commentErr := s.latestPRWatchCommentTime(ctx, watch)
+	if commentErr != nil {
+		s.logger.Debug("failed to check PR watch comments", zap.String("id", watch.ID), zap.Error(commentErr))
+	}
+	hasNew = hasNew || commentsChanged
 
 	// Update watch timestamps
 	now := time.Now().UTC()
-	if err := s.store.UpdatePRWatchTimestamps(ctx, watch.ID, now, nil, status.ChecksState, status.ReviewState); err != nil {
+	if err := s.store.UpdatePRWatchTimestamps(ctx, watch.ID, now, commentAt, status.ChecksState, status.ReviewState); err != nil {
 		s.logger.Error("failed to update PR watch timestamps", zap.String("id", watch.ID), zap.Error(err))
 	}
 
 	return status, hasNew, nil
+}
+
+func (s *Service) RefreshPRWatchCommentTimestamp(ctx context.Context, watch *PRWatch) (bool, error) {
+	commentAt, changed, err := s.latestPRWatchCommentTime(ctx, watch)
+	if err != nil || timeEqual(commentAt, watch.LastCommentAt) {
+		return false, err
+	}
+	if err := s.store.UpdatePRWatchCommentTimestamp(ctx, watch.ID, commentAt); err != nil {
+		return false, err
+	}
+	watch.LastCommentAt = commentAt
+	return changed, nil
+}
+
+func (s *Service) latestPRWatchCommentTime(ctx context.Context, watch *PRWatch) (*time.Time, bool, error) {
+	if s.client == nil {
+		return watch.LastCommentAt, false, fmt.Errorf("github client not available")
+	}
+	if watch == nil || watch.PRNumber == 0 {
+		return nil, false, nil
+	}
+	comments, err := s.client.ListPRComments(ctx, watch.Owner, watch.Repo, watch.PRNumber, watch.LastCommentAt)
+	if err != nil {
+		return watch.LastCommentAt, false, err
+	}
+	latest := findLatestCommentTime(comments)
+	if latest == nil {
+		return watch.LastCommentAt, false, nil
+	}
+	if watch.LastCommentAt == nil {
+		return latest, false, nil
+	}
+	if latest.After(*watch.LastCommentAt) {
+		return latest, true, nil
+	}
+	return watch.LastCommentAt, false, nil
 }
 
 // EnsurePRWatch creates a PRWatch with pr_number=0 for a

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -145,6 +145,9 @@ func prWatchFeedbackUpdatedSinceWatch(watch *PRWatch, status *PRStatus) bool {
 func prWatchFeedbackWatermark(watch *PRWatch, status *PRStatus) *time.Time {
 	if status != nil && status.PR != nil && !status.PR.UpdatedAt.IsZero() {
 		updatedAt := status.PR.UpdatedAt
+		if watch != nil && watch.LastCommentAt != nil && watch.LastCommentAt.After(updatedAt) {
+			return watch.LastCommentAt
+		}
 		return &updatedAt
 	}
 	if watch == nil {
@@ -775,7 +778,33 @@ func (s *Service) triggerPRSyncAllPerWatch(ctx context.Context, taskID string, w
 			results = append(results, tp)
 		}
 	}
-	return results, errors.Join(syncErrs...)
+	if len(syncErrs) == 0 {
+		return results, nil
+	}
+	err := errors.Join(syncErrs...)
+	if len(results) > 0 {
+		return results, &PartialPRSyncError{Err: err}
+	}
+	return results, err
+}
+
+// PartialPRSyncError reports that some PR watches failed while others synced.
+type PartialPRSyncError struct {
+	Err error
+}
+
+func (e *PartialPRSyncError) Error() string {
+	if e == nil || e.Err == nil {
+		return "partial PR sync failure"
+	}
+	return e.Err.Error()
+}
+
+func (e *PartialPRSyncError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
 }
 
 func (s *Service) triggerPRDetection(ctx context.Context, watch *PRWatch, taskID string) (*TaskPR, error) {

--- a/apps/backend/internal/github/service_pr_watch.go
+++ b/apps/backend/internal/github/service_pr_watch.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -122,11 +123,8 @@ func (s *Service) CheckPRWatch(ctx context.Context, watch *PRWatch) (*PRStatus, 
 
 	// Check for check status or review state changes
 	hasNew := status.ChecksState != watch.LastCheckStatus || status.ReviewState != watch.LastReviewState
-	commentAt, commentsChanged, commentErr := s.latestPRWatchCommentTime(ctx, watch)
-	if commentErr != nil {
-		s.logger.Debug("failed to check PR watch comments", zap.String("id", watch.ID), zap.Error(commentErr))
-	}
-	hasNew = hasNew || commentsChanged
+	commentAt := prWatchFeedbackWatermark(watch, status)
+	hasNew = hasNew || prWatchFeedbackUpdatedSinceWatch(watch, status)
 
 	// Update watch timestamps
 	now := time.Now().UTC()
@@ -137,40 +135,22 @@ func (s *Service) CheckPRWatch(ctx context.Context, watch *PRWatch) (*PRStatus, 
 	return status, hasNew, nil
 }
 
-func (s *Service) RefreshPRWatchCommentTimestamp(ctx context.Context, watch *PRWatch) (bool, error) {
-	commentAt, changed, err := s.latestPRWatchCommentTime(ctx, watch)
-	if err != nil || timeEqual(commentAt, watch.LastCommentAt) {
-		return false, err
+func prWatchFeedbackUpdatedSinceWatch(watch *PRWatch, status *PRStatus) bool {
+	if watch == nil || status == nil || status.PR == nil || status.PR.UpdatedAt.IsZero() {
+		return false
 	}
-	if err := s.store.UpdatePRWatchCommentTimestamp(ctx, watch.ID, commentAt); err != nil {
-		return false, err
-	}
-	watch.LastCommentAt = commentAt
-	return changed, nil
+	return watch.LastCommentAt == nil || status.PR.UpdatedAt.After(*watch.LastCommentAt)
 }
 
-func (s *Service) latestPRWatchCommentTime(ctx context.Context, watch *PRWatch) (*time.Time, bool, error) {
-	if s.client == nil {
-		return watch.LastCommentAt, false, fmt.Errorf("github client not available")
+func prWatchFeedbackWatermark(watch *PRWatch, status *PRStatus) *time.Time {
+	if status != nil && status.PR != nil && !status.PR.UpdatedAt.IsZero() {
+		updatedAt := status.PR.UpdatedAt
+		return &updatedAt
 	}
-	if watch == nil || watch.PRNumber == 0 {
-		return nil, false, nil
+	if watch == nil {
+		return nil
 	}
-	comments, err := s.client.ListPRComments(ctx, watch.Owner, watch.Repo, watch.PRNumber, watch.LastCommentAt)
-	if err != nil {
-		return watch.LastCommentAt, false, err
-	}
-	latest := findLatestCommentTime(comments)
-	if latest == nil {
-		return watch.LastCommentAt, false, nil
-	}
-	if watch.LastCommentAt == nil {
-		return latest, false, nil
-	}
-	if latest.After(*watch.LastCommentAt) {
-		return latest, true, nil
-	}
-	return watch.LastCommentAt, false, nil
+	return watch.LastCommentAt
 }
 
 // EnsurePRWatch creates a PRWatch with pr_number=0 for a
@@ -767,6 +747,7 @@ func (s *Service) areAllWatchesPermanentlyMissing(watches []*PRWatch) bool {
 // single bad cycle doesn't leave the UI staring at stale data.
 func (s *Service) triggerPRSyncAllPerWatch(ctx context.Context, taskID string, watches []*PRWatch) ([]*TaskPR, error) {
 	results := make([]*TaskPR, 0, len(watches))
+	var syncErrs []error
 	for _, w := range watches {
 		var tp *TaskPR
 		var syncErr error
@@ -787,13 +768,14 @@ func (s *Service) triggerPRSyncAllPerWatch(ctx context.Context, taskID string, w
 				zap.String("repository_id", w.RepositoryID),
 				zap.Int("pr_number", w.PRNumber),
 				zap.Error(syncErr))
+			syncErrs = append(syncErrs, fmt.Errorf("%s/%s#%d: %w", w.Owner, w.Repo, w.PRNumber, syncErr))
 			continue
 		}
 		if tp != nil {
 			results = append(results, tp)
 		}
 	}
-	return results, nil
+	return results, errors.Join(syncErrs...)
 }
 
 func (s *Service) triggerPRDetection(ctx context.Context, watch *PRWatch, taskID string) (*TaskPR, error) {

--- a/apps/backend/internal/github/service_pr_watch_batched.go
+++ b/apps/backend/internal/github/service_pr_watch_batched.go
@@ -228,17 +228,17 @@ func (s *Service) applyBatchedNumberedWatch(
 	// Bump last_checked_at to suppress retry storms and surface SyncFailed
 	// so the WS handler can flag the result as permanent for the frontend.
 	if s.isRepoCachedAsMissing(w.Owner, w.Repo) {
-		_ = s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, nil, "", "")
+		_ = s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, w.LastCommentAt, "", "")
 		return PRWatchSyncResult{Watch: w, SyncFailed: true}
 	}
 	status, ok := statusByKey[prStatusCacheKey(w.Owner, w.Repo, w.PRNumber)]
 	if !ok || status == nil {
 		// Alias missing — best-effort liveness bump so we don't immediately re-probe.
-		_ = s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, nil, "", "")
+		_ = s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, w.LastCommentAt, "", "")
 		return PRWatchSyncResult{Watch: w}
 	}
 	changed := status.ChecksState != w.LastCheckStatus || status.ReviewState != w.LastReviewState
-	if err := s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, nil, status.ChecksState, status.ReviewState); err != nil {
+	if err := s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, w.LastCommentAt, status.ChecksState, status.ReviewState); err != nil {
 		s.logger.Error("failed to update PR watch timestamps", zap.String("id", w.ID), zap.Error(err))
 	}
 	// Gap-fill: a numbered watch can exist even when its exact task_pr row was

--- a/apps/backend/internal/github/service_pr_watch_batched.go
+++ b/apps/backend/internal/github/service_pr_watch_batched.go
@@ -237,8 +237,11 @@ func (s *Service) applyBatchedNumberedWatch(
 		_ = s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, w.LastCommentAt, "", "")
 		return PRWatchSyncResult{Watch: w}
 	}
-	changed := status.ChecksState != w.LastCheckStatus || status.ReviewState != w.LastReviewState
-	if err := s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, w.LastCommentAt, status.ChecksState, status.ReviewState); err != nil {
+	changed := status.ChecksState != w.LastCheckStatus ||
+		status.ReviewState != w.LastReviewState ||
+		prWatchFeedbackUpdatedSinceWatch(w, status)
+	commentAt := prWatchFeedbackWatermark(w, status)
+	if err := s.store.UpdatePRWatchTimestamps(ctx, w.ID, now, commentAt, status.ChecksState, status.ReviewState); err != nil {
 		s.logger.Error("failed to update PR watch timestamps", zap.String("id", w.ID), zap.Error(err))
 	}
 	// Gap-fill: a numbered watch can exist even when its exact task_pr row was

--- a/apps/backend/internal/github/service_repo_negative_cache_test.go
+++ b/apps/backend/internal/github/service_repo_negative_cache_test.go
@@ -2,11 +2,14 @@ package github
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	ws "github.com/kandev/kandev/pkg/websocket"
 )
 
 // TestSyncWatchesBatched_NegativeCache_ShortCircuits is the regression
@@ -318,5 +321,47 @@ func TestService_TriggerPRSyncAllPermanent_FlagsDeadRepos(t *testing.T) {
 		if strings.Contains(q, w1.Owner) {
 			t.Errorf("dead repo leaked into branch query: %q", q)
 		}
+	}
+}
+
+func TestWSSyncTaskPR_ReturnsPermanentEnvelopeWhenSyncErrors(t *testing.T) {
+	_, svc, gh, store := setupBatchedPollerTest(t)
+	ctx := context.Background()
+
+	w := &PRWatch{SessionID: "s1", TaskID: "t1", Owner: "Dead", Repo: "Repo", PRNumber: 0, Branch: "x"}
+	if err := store.CreatePRWatch(ctx, w); err != nil {
+		t.Fatalf("create watch: %v", err)
+	}
+	gh.branchErr = &batchedMissingReposErr{
+		Repos: []repoRef{{Owner: w.Owner, Repo: w.Repo}},
+		Inner: errors.New("sibling repo unavailable"),
+	}
+
+	msg, err := ws.NewRequest("req-1", ws.ActionGitHubTaskPRSync, map[string]string{"task_id": "t1"})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := wsSyncTaskPR(svc, nil)(ctx, msg)
+	if err != nil {
+		t.Fatalf("wsSyncTaskPR returned transport error: %v", err)
+	}
+	if resp.Type != ws.MessageTypeResponse {
+		t.Fatalf("response type = %q, want %q; payload=%s", resp.Type, ws.MessageTypeResponse, string(resp.Payload))
+	}
+	var payload struct {
+		PRs       []*TaskPR `json:"prs"`
+		Permanent bool      `json:"permanent"`
+	}
+	if err := resp.ParsePayload(&payload); err != nil {
+		t.Fatalf("ParsePayload: %v", err)
+	}
+	if !payload.Permanent {
+		t.Fatalf("permanent = false, want true")
+	}
+	if payload.PRs == nil {
+		t.Fatalf("prs = nil, want empty slice")
+	}
+	if len(payload.PRs) != 0 {
+		t.Fatalf("prs length = %d, want 0", len(payload.PRs))
 	}
 }

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -672,6 +672,15 @@ func (s *Store) UpdatePRWatchTimestamps(ctx context.Context, id string, checkedA
 	return err
 }
 
+// UpdatePRWatchCommentTimestamp updates only the last observed PR comment time.
+func (s *Store) UpdatePRWatchCommentTimestamp(ctx context.Context, id string, commentAt *time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE github_pr_watches SET last_comment_at = ?, updated_at = ?
+		WHERE id = ?`,
+		commentAt, time.Now().UTC(), id)
+	return err
+}
+
 // DeletePRWatch deletes a PR watch by ID.
 func (s *Store) DeletePRWatch(ctx context.Context, id string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM github_pr_watches WHERE id = ?`, id)

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -672,15 +672,6 @@ func (s *Store) UpdatePRWatchTimestamps(ctx context.Context, id string, checkedA
 	return err
 }
 
-// UpdatePRWatchCommentTimestamp updates only the last observed PR comment time.
-func (s *Store) UpdatePRWatchCommentTimestamp(ctx context.Context, id string, commentAt *time.Time) error {
-	_, err := s.db.ExecContext(ctx, `
-		UPDATE github_pr_watches SET last_comment_at = ?, updated_at = ?
-		WHERE id = ?`,
-		commentAt, time.Now().UTC(), id)
-	return err
-}
-
 // DeletePRWatch deletes a PR watch by ID.
 func (s *Store) DeletePRWatch(ctx context.Context, id string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM github_pr_watches WHERE id = ?`, id)

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -1121,6 +1121,8 @@ func (s *Store) RefreshTaskCIFixCheckpoint(ctx context.Context, taskID, reposito
 		ON CONFLICT(task_id, repository_id, pr_number) DO UPDATE SET
 			last_fix_signature = excluded.last_fix_signature,
 			last_fix_checkpoint_json = excluded.last_fix_checkpoint_json,
+			last_fix_enqueued_at = NULL,
+			last_fix_session_id = NULL,
 			last_error = NULL,
 			updated_at = excluded.updated_at`,
 		taskID, repositoryID, prNumber, signature, checkpointJSON, now, now)

--- a/apps/backend/internal/github/store_ci_automation_test.go
+++ b/apps/backend/internal/github/store_ci_automation_test.go
@@ -131,7 +131,7 @@ func TestStoreTaskCIPRState_RecordAttemptsAndError(t *testing.T) {
 	}
 }
 
-func TestStoreTaskCIPRState_RefreshCheckpointPreservesPromptDispatchMetadata(t *testing.T) {
+func TestStoreTaskCIPRState_RefreshCheckpointClearsPromptDispatchMetadata(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	enqueuedAt := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
@@ -158,11 +158,11 @@ func TestStoreTaskCIPRState_RefreshCheckpointPreservesPromptDispatchMetadata(t *
 	if state.LastFixSignature != "after" || state.LastFixCheckpointJSON != `{"failed_checks":[]}` {
 		t.Fatalf("checkpoint was not refreshed: %+v", state)
 	}
-	if state.LastFixSessionID == nil || *state.LastFixSessionID != "session-1" {
-		t.Fatalf("LastFixSessionID=%v, want session-1", state.LastFixSessionID)
+	if state.LastFixSessionID != nil {
+		t.Fatalf("LastFixSessionID=%v, want nil", state.LastFixSessionID)
 	}
-	if state.LastFixEnqueuedAt == nil || !state.LastFixEnqueuedAt.Equal(enqueuedAt) {
-		t.Fatalf("LastFixEnqueuedAt=%v, want %v", state.LastFixEnqueuedAt, enqueuedAt)
+	if state.LastFixEnqueuedAt != nil {
+		t.Fatalf("LastFixEnqueuedAt=%v, want nil", state.LastFixEnqueuedAt)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -196,7 +196,7 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 	prs, err := s.githubService.TriggerPRSyncAll(detachedCtx, options.TaskID)
 	if err != nil {
 		s.logger.Warn("failed to sync task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
-		s.recordTaskCIOptionsSyncError(detachedCtx, options.TaskID, err)
+		s.recordTaskCIOptionsSyncError(detachedCtx, options.TaskID, prs, err)
 	}
 	for _, pr := range prs {
 		s.startTaskPRCIAutomationWithoutRefresh(ctx, pr)
@@ -204,14 +204,43 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 	return nil
 }
 
-func (s *Service) recordTaskCIOptionsSyncError(ctx context.Context, taskID string, syncErr error) {
+func (s *Service) recordTaskCIOptionsSyncError(ctx context.Context, taskID string, synced []*github.TaskPR, syncErr error) {
+	syncedKeys := make(map[ciAutomationTaskPRSyncKey]struct{}, len(synced))
+	for _, pr := range synced {
+		if pr == nil {
+			continue
+		}
+		syncedKeys[ciAutomationTaskPRSyncKeyFor(pr)] = struct{}{}
+	}
 	prsByTask, err := s.githubService.ListTaskPRs(ctx, []string{taskID})
 	if err != nil {
 		s.logger.Warn("failed to load task PRs after CI automation sync failure", zap.String("task_id", taskID), zap.Error(err))
 		return
 	}
 	for _, pr := range prsByTask[taskID] {
+		if _, ok := syncedKeys[ciAutomationTaskPRSyncKeyFor(pr)]; ok {
+			continue
+		}
 		s.recordCIAutomationError(ctx, pr, fmt.Sprintf("sync PR status: %v", syncErr))
+	}
+}
+
+type ciAutomationTaskPRSyncKey struct {
+	repositoryID string
+	owner        string
+	repo         string
+	prNumber     int
+}
+
+func ciAutomationTaskPRSyncKeyFor(pr *github.TaskPR) ciAutomationTaskPRSyncKey {
+	if pr == nil {
+		return ciAutomationTaskPRSyncKey{}
+	}
+	return ciAutomationTaskPRSyncKey{
+		repositoryID: pr.RepositoryID,
+		owner:        strings.ToLower(pr.Owner),
+		repo:         strings.ToLower(pr.Repo),
+		prNumber:     pr.PRNumber,
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -197,7 +197,6 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 	if err != nil {
 		s.logger.Warn("failed to sync task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
 		s.recordTaskCIOptionsSyncError(detachedCtx, options.TaskID, err)
-		return nil
 	}
 	for _, pr := range prs {
 		s.startTaskPRCIAutomationWithoutRefresh(ctx, pr)

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -195,13 +195,25 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 	defer cancel()
 	prs, err := s.githubService.TriggerPRSyncAll(detachedCtx, options.TaskID)
 	if err != nil {
-		s.logger.Debug("failed to sync task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
+		s.logger.Warn("failed to sync task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
+		s.recordTaskCIOptionsSyncError(detachedCtx, options.TaskID, err)
 		return nil
 	}
 	for _, pr := range prs {
 		s.startTaskPRCIAutomation(ctx, pr)
 	}
 	return nil
+}
+
+func (s *Service) recordTaskCIOptionsSyncError(ctx context.Context, taskID string, syncErr error) {
+	prsByTask, err := s.githubService.ListTaskPRs(ctx, []string{taskID})
+	if err != nil {
+		s.logger.Debug("failed to load task PRs after CI automation sync failure", zap.String("task_id", taskID), zap.Error(err))
+		return
+	}
+	for _, pr := range prsByTask[taskID] {
+		s.recordCIAutomationError(ctx, pr, fmt.Sprintf("sync PR status: %v", syncErr))
+	}
 }
 
 func (s *Service) startTaskPRCIAutomation(ctx context.Context, pr *github.TaskPR) {

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -42,6 +42,7 @@ type GitHubService interface {
 	AssociatePRWithTask(ctx context.Context, taskID, repositoryID string, pr *github.PR) (*github.TaskPR, error)
 	GetTaskPR(ctx context.Context, taskID string) (*github.TaskPR, error)
 	ListTaskPRs(ctx context.Context, taskIDs []string) (map[string][]*github.TaskPR, error)
+	TriggerPRSyncAll(ctx context.Context, taskID string) ([]*github.TaskPR, error)
 	GetTaskPRByOwnerRepoNumber(ctx context.Context, taskID, owner, repo string, prNumber int) (*github.TaskPR, error)
 	GetTaskCIOptionsResponse(ctx context.Context, taskID string) (*github.TaskCIOptionsResponse, error)
 	GetTaskCIPRState(ctx context.Context, taskID, repositoryID string, prNumber int) (*github.TaskCIPRAutomationState, error)
@@ -192,12 +193,12 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 	}
 	detachedCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ciAutomationDetachedTimeout)
 	defer cancel()
-	prsByTask, err := s.githubService.ListTaskPRs(detachedCtx, []string{options.TaskID})
+	prs, err := s.githubService.TriggerPRSyncAll(detachedCtx, options.TaskID)
 	if err != nil {
-		s.logger.Debug("failed to load task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
+		s.logger.Debug("failed to sync task PRs for CI automation options update", zap.String("task_id", options.TaskID), zap.Error(err))
 		return nil
 	}
-	for _, pr := range prsByTask[options.TaskID] {
+	for _, pr := range prs {
 		s.startTaskPRCIAutomation(ctx, pr)
 	}
 	return nil

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -200,7 +200,7 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 		return nil
 	}
 	for _, pr := range prs {
-		s.startTaskPRCIAutomation(ctx, pr)
+		s.startTaskPRCIAutomationWithoutRefresh(ctx, pr)
 	}
 	return nil
 }
@@ -217,6 +217,14 @@ func (s *Service) recordTaskCIOptionsSyncError(ctx context.Context, taskID strin
 }
 
 func (s *Service) startTaskPRCIAutomation(ctx context.Context, pr *github.TaskPR) {
+	s.startTaskPRCIAutomationWithRefresh(ctx, pr, true)
+}
+
+func (s *Service) startTaskPRCIAutomationWithoutRefresh(ctx context.Context, pr *github.TaskPR) {
+	s.startTaskPRCIAutomationWithRefresh(ctx, pr, false)
+}
+
+func (s *Service) startTaskPRCIAutomationWithRefresh(ctx context.Context, pr *github.TaskPR, refresh bool) {
 	if pr == nil {
 		return
 	}
@@ -232,7 +240,7 @@ func (s *Service) startTaskPRCIAutomation(ctx context.Context, pr *github.TaskPR
 		defer s.ciAutomationInFlight.Delete(key)
 		automationCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ciAutomationDetachedTimeout)
 		defer cancel()
-		if err := s.handleTaskPRCIAutomation(automationCtx, pr); err != nil {
+		if err := s.handleTaskPRCIAutomationWithRefresh(automationCtx, pr, refresh); err != nil {
 			s.logger.Debug("CI automation handling failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 		}
 	}()

--- a/apps/backend/internal/orchestrator/event_handlers_github.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github.go
@@ -208,7 +208,7 @@ func (s *Service) handleTaskCIOptionsUpdated(ctx context.Context, event *bus.Eve
 func (s *Service) recordTaskCIOptionsSyncError(ctx context.Context, taskID string, syncErr error) {
 	prsByTask, err := s.githubService.ListTaskPRs(ctx, []string{taskID})
 	if err != nil {
-		s.logger.Debug("failed to load task PRs after CI automation sync failure", zap.String("task_id", taskID), zap.Error(err))
+		s.logger.Warn("failed to load task PRs after CI automation sync failure", zap.String("task_id", taskID), zap.Error(err))
 		return
 	}
 	for _, pr := range prsByTask[taskID] {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -145,18 +145,20 @@ func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, 
 	previous := decodeCIAutomationCheckpoint(state)
 	delta := ciAutomationBuildDelta(feedback, previous)
 	checkpoint := ciAutomationCurrentCheckpoint(feedback)
+	checkpointJSON, signature := encodeCIAutomationCheckpoint(checkpoint)
 	if len(delta.FailedChecks) == 0 && len(delta.Comments) == 0 {
+		if state != nil && state.LastFixSignature == signature && ciAutomationDuplicateFixAttemptBlocksMerge(state) {
+			return true
+		}
 		if state != nil && len(previous.FailedChecks)+len(previous.Comments) > 0 {
-			checkpointJSON, signature := encodeCIAutomationCheckpoint(checkpoint)
 			if err := s.githubService.RefreshTaskCIFixCheckpoint(context.WithoutCancel(ctx), pr.TaskID, pr.RepositoryID, pr.PRNumber, signature, checkpointJSON); err != nil {
 				s.logger.Debug("record CI auto-fix checkpoint refresh failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 			}
 		}
 		return false
 	}
-	checkpointJSON, signature := encodeCIAutomationCheckpoint(checkpoint)
 	if state != nil && state.LastFixSignature == signature {
-		return false
+		return ciAutomationDuplicateFixAttemptBlocksMerge(state)
 	}
 	prompt := ciAutomationRenderPrompt(options.EffectiveAutoFixPrompt, pr, delta)
 	session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, pr.TaskID)
@@ -323,7 +325,7 @@ func ciAutomationBuildDelta(feedback *github.PRFeedback, previous ciAutomationCh
 		return delta
 	}
 	for _, check := range feedback.Checks {
-		if check.Status != ciAutomationCheckCompleted || ciAutomationCheckConclusionDoesNotNeedFix(check.Conclusion) {
+		if check.Status != ciAutomationCheckCompleted || !ciAutomationCheckConclusionNeedsFix(check.Conclusion) {
 			continue
 		}
 		snap := ciAutomationCheckSnapshot{Name: check.Name, Conclusion: check.Conclusion, HTMLURL: check.HTMLURL, Output: check.Output}
@@ -343,10 +345,15 @@ func ciAutomationBuildDelta(feedback *github.PRFeedback, previous ciAutomationCh
 	return delta
 }
 
-func ciAutomationCheckConclusionDoesNotNeedFix(conclusion string) bool {
-	return conclusion == ciAutomationCheckSuccess ||
-		conclusion == ciAutomationCheckSkipped ||
-		conclusion == "neutral"
+func ciAutomationCheckConclusionNeedsFix(conclusion string) bool {
+	return conclusion == ciAutomationCheckFailure ||
+		conclusion == "timed_out" ||
+		conclusion == "cancelled" ||
+		conclusion == "action_required"
+}
+
+func ciAutomationDuplicateFixAttemptBlocksMerge(state *github.TaskCIPRAutomationState) bool {
+	return state != nil && (state.LastFixEnqueuedAt != nil || state.LastFixSessionID != nil)
 }
 
 func ciAutomationCheckKey(check ciAutomationCheckSnapshot) string {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -102,9 +102,6 @@ func ciAutomationFindMatchingPR(prs []*github.TaskPR, target *github.TaskPR) *gi
 		if target.RepositoryID == "" && pr.Owner == target.Owner && pr.Repo == target.Repo {
 			return pr
 		}
-		if pr.Owner == target.Owner && pr.Repo == target.Repo {
-			return pr
-		}
 	}
 	return nil
 }

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -50,6 +50,10 @@ type ciAutomationCommentSnapshot struct {
 }
 
 func (s *Service) handleTaskPRCIAutomation(ctx context.Context, pr *github.TaskPR) error {
+	return s.handleTaskPRCIAutomationWithRefresh(ctx, pr, true)
+}
+
+func (s *Service) handleTaskPRCIAutomationWithRefresh(ctx context.Context, pr *github.TaskPR, refresh bool) error {
 	if s.githubService == nil || pr == nil {
 		return nil
 	}
@@ -58,8 +62,8 @@ func (s *Service) handleTaskPRCIAutomation(ctx context.Context, pr *github.TaskP
 		s.logger.Debug("load CI automation options failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 		return nil
 	}
-	freshlySynced := false
-	if options.AutoFixEnabled || options.AutoMergeEnabled {
+	freshlySynced := ciAutomationHasFreshPRStatus(pr)
+	if refresh && (options.AutoFixEnabled || options.AutoMergeEnabled) {
 		refreshed, synced, syncErr := s.refreshTaskPRForCIAutomation(ctx, pr)
 		if syncErr != nil {
 			s.recordCIAutomationError(ctx, pr, fmt.Sprintf("sync PR status: %v", syncErr))
@@ -316,7 +320,7 @@ func ciAutomationBuildDelta(feedback *github.PRFeedback, previous ciAutomationCh
 		return delta
 	}
 	for _, check := range feedback.Checks {
-		if check.Status != ciAutomationCheckCompleted || check.Conclusion == ciAutomationCheckSuccess || check.Conclusion == ciAutomationCheckSkipped {
+		if check.Status != ciAutomationCheckCompleted || ciAutomationCheckConclusionDoesNotNeedFix(check.Conclusion) {
 			continue
 		}
 		snap := ciAutomationCheckSnapshot{Name: check.Name, Conclusion: check.Conclusion, HTMLURL: check.HTMLURL, Output: check.Output}
@@ -334,6 +338,12 @@ func ciAutomationBuildDelta(feedback *github.PRFeedback, previous ciAutomationCh
 		delta.Comments = append(delta.Comments, snap)
 	}
 	return delta
+}
+
+func ciAutomationCheckConclusionDoesNotNeedFix(conclusion string) bool {
+	return conclusion == ciAutomationCheckSuccess ||
+		conclusion == ciAutomationCheckSkipped ||
+		conclusion == "neutral"
 }
 
 func ciAutomationCheckKey(check ciAutomationCheckSnapshot) string {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -25,7 +25,6 @@ const (
 	ciAutomationCheckCompleted   = "completed"
 	ciAutomationChangesRequested = "changes_requested"
 	ciAutomationPRFeedbackToken  = "{{pr.feedback}}"
-	ciAutomationFreshSyncWindow  = 30 * time.Second
 )
 
 var ciAutomationSnapshotFieldReplacer = strings.NewReplacer("\r", " ", "\n", " ", "<", "", ">", "")
@@ -122,10 +121,14 @@ func ciAutomationFindMatchingPR(prs []*github.TaskPR, target *github.TaskPR) *gi
 }
 
 func ciAutomationHasFreshPRStatus(pr *github.TaskPR) bool {
+	return ciAutomationHasFreshPRStatusAt(pr, time.Now())
+}
+
+func ciAutomationHasFreshPRStatusAt(pr *github.TaskPR, now time.Time) bool {
 	if pr == nil || pr.LastSyncedAt == nil {
 		return false
 	}
-	return time.Since(*pr.LastSyncedAt) <= ciAutomationFreshSyncWindow
+	return now.Sub(*pr.LastSyncedAt) <= github.PRSyncFreshnessWindow
 }
 
 func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, options *github.TaskCIOptionsResponse) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -57,11 +57,54 @@ func (s *Service) handleTaskPRCIAutomation(ctx context.Context, pr *github.TaskP
 		s.logger.Debug("load CI automation options failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 		return nil
 	}
-	if options.AutoFixEnabled && ciAutomationShouldAutoFix(pr) {
+	if options.AutoFixEnabled || options.AutoMergeEnabled {
+		refreshed, syncErr := s.refreshTaskPRForCIAutomation(ctx, pr)
+		if syncErr != nil {
+			s.recordCIAutomationError(ctx, pr, fmt.Sprintf("sync PR status: %v", syncErr))
+			return nil
+		}
+		pr = refreshed
+	}
+	if options.AutoFixEnabled && ciAutomationCanAutoFixFromFeedback(pr) {
 		s.handleTaskPRCIAutoFix(ctx, pr, options)
 	}
 	if options.AutoMergeEnabled && ciAutomationReadyToMerge(pr) {
 		s.handleTaskPRCIAutoMerge(ctx, pr)
+	}
+	return nil
+}
+
+func (s *Service) refreshTaskPRForCIAutomation(ctx context.Context, pr *github.TaskPR) (*github.TaskPR, error) {
+	if pr == nil {
+		return nil, nil
+	}
+	prs, err := s.githubService.TriggerPRSyncAll(ctx, pr.TaskID)
+	if err != nil {
+		return nil, err
+	}
+	if refreshed := ciAutomationFindMatchingPR(prs, pr); refreshed != nil {
+		return refreshed, nil
+	}
+	return pr, nil
+}
+
+func ciAutomationFindMatchingPR(prs []*github.TaskPR, target *github.TaskPR) *github.TaskPR {
+	if target == nil {
+		return nil
+	}
+	for _, pr := range prs {
+		if pr == nil || pr.TaskID != target.TaskID || pr.PRNumber != target.PRNumber {
+			continue
+		}
+		if target.RepositoryID != "" && pr.RepositoryID == target.RepositoryID {
+			return pr
+		}
+		if target.RepositoryID == "" && pr.Owner == target.Owner && pr.Repo == target.Repo {
+			return pr
+		}
+		if pr.Owner == target.Owner && pr.Repo == target.Repo {
+			return pr
+		}
 	}
 	return nil
 }
@@ -204,6 +247,13 @@ func ciAutomationChatPrompt(prompt string) string {
 }
 
 func (s *Service) recordCIAutomationError(ctx context.Context, pr *github.TaskPR, message string) {
+	s.logger.Warn("CI automation error",
+		zap.String("task_id", pr.TaskID),
+		zap.String("repository_id", pr.RepositoryID),
+		zap.String("owner", pr.Owner),
+		zap.String("repo", pr.Repo),
+		zap.Int("pr_number", pr.PRNumber),
+		zap.String("error", message))
 	if err := s.githubService.RecordTaskCIError(context.WithoutCancel(ctx), pr.TaskID, pr.RepositoryID, pr.PRNumber, message); err != nil {
 		s.logger.Debug("record CI automation error failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 	}
@@ -214,6 +264,10 @@ func ciAutomationShouldAutoFix(pr *github.TaskPR) bool {
 		return false
 	}
 	return pr.ChecksState == ciAutomationCheckFailure || pr.ReviewState == ciAutomationChangesRequested || pr.UnresolvedReviewThreads > 0
+}
+
+func ciAutomationCanAutoFixFromFeedback(pr *github.TaskPR) bool {
+	return pr != nil && pr.State != "closed" && pr.State != "merged"
 }
 
 func ciAutomationReadyToMerge(pr *github.TaskPR) bool {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -21,10 +21,10 @@ const (
 	ciAutomationOrigin           = "ci_automation"
 	ciAutomationCheckSuccess     = "success"
 	ciAutomationCheckFailure     = "failure"
-	ciAutomationCheckSkipped     = "skipped"
 	ciAutomationCheckCompleted   = "completed"
 	ciAutomationChangesRequested = "changes_requested"
 	ciAutomationPRFeedbackToken  = "{{pr.feedback}}"
+	ciAutomationFixBlockWindow   = time.Hour
 )
 
 var ciAutomationSnapshotFieldReplacer = strings.NewReplacer("\r", " ", "\n", " ", "<", "", ">", "")
@@ -93,11 +93,11 @@ func (s *Service) refreshTaskPRForCIAutomation(ctx context.Context, pr *github.T
 		return nil, false, nil
 	}
 	prs, err := s.githubService.TriggerPRSyncAll(ctx, pr.TaskID)
-	if err != nil {
-		return nil, false, err
-	}
 	if refreshed := ciAutomationFindMatchingPR(prs, pr); refreshed != nil {
 		return refreshed, ciAutomationHasFreshPRStatus(refreshed), nil
+	}
+	if err != nil {
+		return nil, false, err
 	}
 	return pr, false, nil
 }
@@ -137,6 +137,10 @@ func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, 
 		s.recordCIAutomationError(ctx, pr, fmt.Sprintf("fetch PR feedback: %v", err))
 		return true
 	}
+	if !ciAutomationCanAutoFixFromFeedbackPR(feedback) {
+		return false
+	}
+	feedback = ciAutomationFilterFeedbackForPR(pr, feedback)
 	state, err := s.githubService.GetTaskCIPRState(ctx, pr.TaskID, pr.RepositoryID, pr.PRNumber)
 	if err != nil {
 		s.recordCIAutomationError(ctx, pr, fmt.Sprintf("load CI automation state: %v", err))
@@ -147,15 +151,7 @@ func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, 
 	checkpoint := ciAutomationCurrentCheckpoint(feedback)
 	checkpointJSON, signature := encodeCIAutomationCheckpoint(checkpoint)
 	if len(delta.FailedChecks) == 0 && len(delta.Comments) == 0 {
-		if state != nil && state.LastFixSignature == signature && ciAutomationDuplicateFixAttemptBlocksMerge(state) {
-			return true
-		}
-		if state != nil && len(previous.FailedChecks)+len(previous.Comments) > 0 {
-			if err := s.githubService.RefreshTaskCIFixCheckpoint(context.WithoutCancel(ctx), pr.TaskID, pr.RepositoryID, pr.PRNumber, signature, checkpointJSON); err != nil {
-				s.logger.Debug("record CI auto-fix checkpoint refresh failed", zap.String("task_id", pr.TaskID), zap.Error(err))
-			}
-		}
-		return false
+		return s.handleTaskPRCIAutoFixEmptyDelta(ctx, pr, state, previous, signature, checkpointJSON)
 	}
 	if state != nil && state.LastFixSignature == signature {
 		return ciAutomationDuplicateFixAttemptBlocksMerge(state)
@@ -182,6 +178,18 @@ func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, 
 		s.logger.Debug("record CI auto-fix attempt failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 	}
 	return true
+}
+
+func (s *Service) handleTaskPRCIAutoFixEmptyDelta(ctx context.Context, pr *github.TaskPR, state *github.TaskCIPRAutomationState, previous ciAutomationCheckpoint, signature, checkpointJSON string) bool {
+	if state != nil && state.LastFixSignature == signature && ciAutomationDuplicateFixAttemptBlocksMerge(state) {
+		return true
+	}
+	if state != nil && len(previous.FailedChecks)+len(previous.Comments) > 0 {
+		if err := s.githubService.RefreshTaskCIFixCheckpoint(context.WithoutCancel(ctx), pr.TaskID, pr.RepositoryID, pr.PRNumber, signature, checkpointJSON); err != nil {
+			s.logger.Debug("record CI auto-fix checkpoint refresh failed", zap.String("task_id", pr.TaskID), zap.Error(err))
+		}
+	}
+	return false
 }
 
 func (s *Service) handleTaskPRCIAutoMerge(ctx context.Context, pr *github.TaskPR) {
@@ -284,15 +292,29 @@ func (s *Service) recordCIAutomationError(ctx context.Context, pr *github.TaskPR
 	}
 }
 
-func ciAutomationShouldAutoFix(pr *github.TaskPR) bool {
-	if pr == nil || pr.State == "closed" || pr.State == "merged" {
-		return false
-	}
-	return pr.ChecksState == ciAutomationCheckFailure || pr.ReviewState == ciAutomationChangesRequested || pr.UnresolvedReviewThreads > 0
-}
-
 func ciAutomationCanAutoFixFromFeedback(pr *github.TaskPR) bool {
 	return pr != nil && pr.State != "closed" && pr.State != "merged"
+}
+
+func ciAutomationCanAutoFixFromFeedbackPR(feedback *github.PRFeedback) bool {
+	if feedback == nil || feedback.PR == nil {
+		return true
+	}
+	return feedback.PR.State != "closed" && feedback.PR.State != "merged"
+}
+
+func ciAutomationFilterFeedbackForPR(pr *github.TaskPR, feedback *github.PRFeedback) *github.PRFeedback {
+	if feedback == nil || pr == nil || pr.UnresolvedReviewThreads > 0 {
+		return feedback
+	}
+	filtered := *feedback
+	filtered.Comments = make([]github.PRComment, 0, len(feedback.Comments))
+	for _, comment := range feedback.Comments {
+		if comment.Path == "" && comment.Line == 0 {
+			filtered.Comments = append(filtered.Comments, comment)
+		}
+	}
+	return &filtered
 }
 
 func ciAutomationReadyToMerge(pr *github.TaskPR) bool {
@@ -353,7 +375,14 @@ func ciAutomationCheckConclusionNeedsFix(conclusion string) bool {
 }
 
 func ciAutomationDuplicateFixAttemptBlocksMerge(state *github.TaskCIPRAutomationState) bool {
-	return state != nil && (state.LastFixEnqueuedAt != nil || state.LastFixSessionID != nil)
+	return ciAutomationDuplicateFixAttemptBlocksMergeAt(state, time.Now())
+}
+
+func ciAutomationDuplicateFixAttemptBlocksMergeAt(state *github.TaskCIPRAutomationState, now time.Time) bool {
+	if state == nil || state.LastFixEnqueuedAt == nil {
+		return false
+	}
+	return now.Sub(*state.LastFixEnqueuedAt) <= ciAutomationFixBlockWindow
 }
 
 func ciAutomationCheckKey(check ciAutomationCheckSnapshot) string {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation.go
@@ -25,6 +25,7 @@ const (
 	ciAutomationCheckCompleted   = "completed"
 	ciAutomationChangesRequested = "changes_requested"
 	ciAutomationPRFeedbackToken  = "{{pr.feedback}}"
+	ciAutomationFreshSyncWindow  = 30 * time.Second
 )
 
 var ciAutomationSnapshotFieldReplacer = strings.NewReplacer("\r", " ", "\n", " ", "<", "", ">", "")
@@ -57,35 +58,45 @@ func (s *Service) handleTaskPRCIAutomation(ctx context.Context, pr *github.TaskP
 		s.logger.Debug("load CI automation options failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 		return nil
 	}
+	freshlySynced := false
 	if options.AutoFixEnabled || options.AutoMergeEnabled {
-		refreshed, syncErr := s.refreshTaskPRForCIAutomation(ctx, pr)
+		refreshed, synced, syncErr := s.refreshTaskPRForCIAutomation(ctx, pr)
 		if syncErr != nil {
 			s.recordCIAutomationError(ctx, pr, fmt.Sprintf("sync PR status: %v", syncErr))
 			return nil
 		}
 		pr = refreshed
+		freshlySynced = synced
 	}
+	autoFixBlockedMerge := false
 	if options.AutoFixEnabled && ciAutomationCanAutoFixFromFeedback(pr) {
-		s.handleTaskPRCIAutoFix(ctx, pr, options)
+		autoFixBlockedMerge = s.handleTaskPRCIAutoFix(ctx, pr, options)
+	}
+	if autoFixBlockedMerge {
+		return nil
 	}
 	if options.AutoMergeEnabled && ciAutomationReadyToMerge(pr) {
+		if !freshlySynced {
+			s.recordCIAutomationError(ctx, pr, "PR status is not freshly synced for auto-merge")
+			return nil
+		}
 		s.handleTaskPRCIAutoMerge(ctx, pr)
 	}
 	return nil
 }
 
-func (s *Service) refreshTaskPRForCIAutomation(ctx context.Context, pr *github.TaskPR) (*github.TaskPR, error) {
+func (s *Service) refreshTaskPRForCIAutomation(ctx context.Context, pr *github.TaskPR) (*github.TaskPR, bool, error) {
 	if pr == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 	prs, err := s.githubService.TriggerPRSyncAll(ctx, pr.TaskID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if refreshed := ciAutomationFindMatchingPR(prs, pr); refreshed != nil {
-		return refreshed, nil
+		return refreshed, ciAutomationHasFreshPRStatus(refreshed), nil
 	}
-	return pr, nil
+	return pr, false, nil
 }
 
 func ciAutomationFindMatchingPR(prs []*github.TaskPR, target *github.TaskPR) *github.TaskPR {
@@ -106,16 +117,23 @@ func ciAutomationFindMatchingPR(prs []*github.TaskPR, target *github.TaskPR) *gi
 	return nil
 }
 
-func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, options *github.TaskCIOptionsResponse) {
+func ciAutomationHasFreshPRStatus(pr *github.TaskPR) bool {
+	if pr == nil || pr.LastSyncedAt == nil {
+		return false
+	}
+	return time.Since(*pr.LastSyncedAt) <= ciAutomationFreshSyncWindow
+}
+
+func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, options *github.TaskCIOptionsResponse) bool {
 	feedback, err := s.githubService.GetPRFeedback(ctx, pr.Owner, pr.Repo, pr.PRNumber)
 	if err != nil {
 		s.recordCIAutomationError(ctx, pr, fmt.Sprintf("fetch PR feedback: %v", err))
-		return
+		return true
 	}
 	state, err := s.githubService.GetTaskCIPRState(ctx, pr.TaskID, pr.RepositoryID, pr.PRNumber)
 	if err != nil {
 		s.recordCIAutomationError(ctx, pr, fmt.Sprintf("load CI automation state: %v", err))
-		return
+		return true
 	}
 	previous := decodeCIAutomationCheckpoint(state)
 	delta := ciAutomationBuildDelta(feedback, previous)
@@ -127,21 +145,21 @@ func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, 
 				s.logger.Debug("record CI auto-fix checkpoint refresh failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 			}
 		}
-		return
+		return false
 	}
 	checkpointJSON, signature := encodeCIAutomationCheckpoint(checkpoint)
 	if state != nil && state.LastFixSignature == signature {
-		return
+		return false
 	}
 	prompt := ciAutomationRenderPrompt(options.EffectiveAutoFixPrompt, pr, delta)
 	session, err := s.repo.GetActiveTaskSessionByTaskID(ctx, pr.TaskID)
 	if err != nil || session == nil {
 		s.recordCIAutomationError(ctx, pr, "no promptable task session for CI auto-fix")
-		return
+		return true
 	}
 	if err := s.dispatchCIAutomationPrompt(ctx, session, prompt); err != nil {
 		s.recordCIAutomationError(ctx, pr, err.Error())
-		return
+		return true
 	}
 	if err := s.githubService.RecordTaskCIFixAttempt(context.WithoutCancel(ctx), github.TaskCIFixAttempt{
 		TaskID:         pr.TaskID,
@@ -154,6 +172,7 @@ func (s *Service) handleTaskPRCIAutoFix(ctx context.Context, pr *github.TaskPR, 
 	}); err != nil {
 		s.logger.Debug("record CI auto-fix attempt failed", zap.String("task_id", pr.TaskID), zap.Error(err))
 	}
+	return true
 }
 
 func (s *Service) handleTaskPRCIAutoMerge(ctx context.Context, pr *github.TaskPR) {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -261,8 +261,11 @@ func TestHandleTaskPRCIAutomationQueuesFixDedupesAndMerges(t *testing.T) {
 	pr.ChecksState = "success"
 	pr.ReviewState = "approved"
 	pr.MergeableState = "clean"
+	now := time.Now().UTC()
+	pr.LastSyncedAt = &now
 	ghSvc.ciOptionsResp.AutoFixEnabled = false
 	ghSvc.ciOptionsResp.AutoMergeEnabled = true
+	ghSvc.triggerPRSyncAllPRs = []*github.TaskPR{pr}
 	if err := svc.handleTaskPRCIAutomation(ctx, pr); err != nil {
 		t.Fatalf("handle auto-merge: %v", err)
 	}
@@ -337,6 +340,8 @@ func TestHandleTaskPRCIAutomationAutoMergeUsesFreshSync(t *testing.T) {
 	fresh.ChecksState = "success"
 	fresh.ReviewState = "approved"
 	fresh.MergeableState = "clean"
+	now := time.Now().UTC()
+	fresh.LastSyncedAt = &now
 	ghSvc := &mockGitHubService{
 		ciOptionsResp: &github.TaskCIOptionsResponse{
 			TaskID:           "task-1",
@@ -354,6 +359,86 @@ func TestHandleTaskPRCIAutomationAutoMergeUsesFreshSync(t *testing.T) {
 	}
 	if ghSvc.mergeCalls != 1 {
 		t.Fatalf("expected merge from fresh synced PR state, got %d", ghSvc.mergeCalls)
+	}
+}
+
+func TestHandleTaskPRCIAutomationAutoMergeRequiresFreshSync(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task-1", "session-1", models.TaskSessionStateRunning)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	staleReady := &github.TaskPR{
+		TaskID:         "task-1",
+		RepositoryID:   "repo-1",
+		Owner:          "acme",
+		Repo:           "widget",
+		PRNumber:       42,
+		State:          "open",
+		ChecksState:    "success",
+		ReviewState:    "approved",
+		MergeableState: "clean",
+	}
+	ghSvc := &mockGitHubService{
+		ciOptionsResp: &github.TaskCIOptionsResponse{
+			TaskID:           "task-1",
+			AutoMergeEnabled: true,
+		},
+		triggerPRSyncAllPRs: []*github.TaskPR{staleReady},
+	}
+	svc.SetGitHubService(ghSvc)
+
+	if err := svc.handleTaskPRCIAutomation(ctx, staleReady); err != nil {
+		t.Fatalf("handle auto-merge: %v", err)
+	}
+	if ghSvc.mergeCalls != 0 {
+		t.Fatalf("expected stale synced state not to merge, got %d merge calls", ghSvc.mergeCalls)
+	}
+	if len(ghSvc.ciErrors) != 1 || ghSvc.ciErrors[0].LastError == nil || !strings.Contains(*ghSvc.ciErrors[0].LastError, "not freshly synced") {
+		t.Fatalf("expected stale sync error to be recorded, got %+v", ghSvc.ciErrors)
+	}
+}
+
+func TestHandleTaskPRCIAutomationAutoFixBlocksSameCycleMerge(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task-1", "session-1", models.TaskSessionStateRunning)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	now := time.Now().UTC()
+	pr := &github.TaskPR{
+		TaskID:         "task-1",
+		RepositoryID:   "repo-1",
+		Owner:          "acme",
+		Repo:           "widget",
+		PRNumber:       42,
+		State:          "open",
+		ChecksState:    "success",
+		ReviewState:    "approved",
+		MergeableState: "clean",
+		LastSyncedAt:   &now,
+	}
+	ghSvc := &mockGitHubService{
+		ciOptionsResp: &github.TaskCIOptionsResponse{
+			TaskID:                 "task-1",
+			AutoFixEnabled:         true,
+			AutoMergeEnabled:       true,
+			EffectiveAutoFixPrompt: "Fix the PR\n\n{{pr.feedback}}",
+		},
+		triggerPRSyncAllPRs: []*github.TaskPR{pr},
+		prFeedback: &github.PRFeedback{
+			Comments: []github.PRComment{{ID: 100, Body: "please address before merge"}},
+		},
+	}
+	svc.SetGitHubService(ghSvc)
+
+	if err := svc.handleTaskPRCIAutomation(ctx, pr); err != nil {
+		t.Fatalf("handle CI automation: %v", err)
+	}
+	status := svc.messageQueue.GetStatus(ctx, "session-1")
+	if status.Count != 1 {
+		t.Fatalf("expected auto-fix prompt to be queued, got %+v", status)
+	}
+	if ghSvc.mergeCalls != 0 {
+		t.Fatalf("expected auto-merge to wait for a later cycle after auto-fix prompt, got %d merge calls", ghSvc.mergeCalls)
 	}
 }
 
@@ -601,7 +686,8 @@ func TestHandleTaskPRCIAutomationMergesWhenStateReadFails(t *testing.T) {
 	}
 	svc.SetGitHubService(ghSvc)
 
-	err := svc.handleTaskPRCIAutomation(ctx, &github.TaskPR{
+	now := time.Now().UTC()
+	pr := &github.TaskPR{
 		TaskID:         "task-1",
 		RepositoryID:   "repo-1",
 		Owner:          "acme",
@@ -611,7 +697,11 @@ func TestHandleTaskPRCIAutomationMergesWhenStateReadFails(t *testing.T) {
 		ChecksState:    "success",
 		ReviewState:    "approved",
 		MergeableState: "clean",
-	})
+		LastSyncedAt:   &now,
+	}
+	ghSvc.triggerPRSyncAllPRs = []*github.TaskPR{pr}
+
+	err := svc.handleTaskPRCIAutomation(ctx, pr)
 	if err != nil {
 		t.Fatalf("handle auto-merge: %v", err)
 	}
@@ -644,6 +734,9 @@ func TestHandleTaskPRCIAutomationRetriesMergeAfterTransientFailure(t *testing.T)
 		ReviewState:    "approved",
 		MergeableState: "clean",
 	}
+	now := time.Now().UTC()
+	pr.LastSyncedAt = &now
+	ghSvc.triggerPRSyncAllPRs = []*github.TaskPR{pr}
 
 	if err := svc.handleTaskPRCIAutomation(ctx, pr); err != nil {
 		t.Fatalf("handle failed auto-merge: %v", err)
@@ -739,6 +832,33 @@ func TestHandleTaskCIOptionsUpdatedStartsAutomationForTaskPRs(t *testing.T) {
 	close(block)
 	waitForCIAutomationIdle(t, svc, "task-1|repo-front|1", 200*time.Millisecond)
 	waitForCIAutomationIdle(t, svc, "task-1|repo-back|2", 200*time.Millisecond)
+}
+
+func TestHandleTaskCIOptionsUpdatedRecordsSyncFailureForLinkedPRs(t *testing.T) {
+	ctx := context.Background()
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	ghSvc := &mockGitHubService{
+		taskPRs: []*github.TaskPR{{
+			TaskID:       "task-1",
+			RepositoryID: "repo-1",
+			Owner:        "acme",
+			Repo:         "widget",
+			PRNumber:     42,
+		}},
+		triggerPRSyncAllErr: errors.New("gh unavailable"),
+	}
+	svc.SetGitHubService(ghSvc)
+
+	err := svc.handleTaskCIOptionsUpdated(ctx, &bus.Event{Data: &github.TaskCIOptionsResponse{
+		TaskID:           "task-1",
+		AutoMergeEnabled: true,
+	}})
+	if err != nil {
+		t.Fatalf("handle CI options updated: %v", err)
+	}
+	if len(ghSvc.ciErrors) != 1 || ghSvc.ciErrors[0].LastError == nil || !strings.Contains(*ghSvc.ciErrors[0].LastError, "sync PR status: gh unavailable") {
+		t.Fatalf("expected sync failure to be recorded on linked PR, got %+v", ghSvc.ciErrors)
+	}
 }
 
 func TestStartTaskPRCIAutomationSkipsDuplicateInFlightPR(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -412,6 +412,31 @@ func TestHandleTaskPRCIAutomationAutoMergeRequiresFreshSync(t *testing.T) {
 	}
 }
 
+func TestCIAutomationHasFreshPRStatusAt(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	exactEdge := now.Add(-github.PRSyncFreshnessWindow)
+	stale := exactEdge.Add(-time.Nanosecond)
+	fresh := now.Add(-github.PRSyncFreshnessWindow + time.Nanosecond)
+	tests := []struct {
+		name string
+		pr   *github.TaskPR
+		want bool
+	}{
+		{name: "nil PR", pr: nil, want: false},
+		{name: "nil last synced", pr: &github.TaskPR{}, want: false},
+		{name: "fresh within window", pr: &github.TaskPR{LastSyncedAt: &fresh}, want: true},
+		{name: "fresh at exact edge", pr: &github.TaskPR{LastSyncedAt: &exactEdge}, want: true},
+		{name: "stale older than edge", pr: &github.TaskPR{LastSyncedAt: &stale}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ciAutomationHasFreshPRStatusAt(tt.pr, now); got != tt.want {
+				t.Fatalf("ciAutomationHasFreshPRStatusAt=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandleTaskPRCIAutomationAutoFixBlocksSameCycleMerge(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -357,6 +357,40 @@ func TestHandleTaskPRCIAutomationAutoMergeUsesFreshSync(t *testing.T) {
 	}
 }
 
+func TestCIAutomationFindMatchingPRRequiresRepositoryIDWhenPresent(t *testing.T) {
+	target := &github.TaskPR{
+		TaskID:       "task-1",
+		RepositoryID: "repo-back",
+		Owner:        "acme",
+		Repo:         "widget",
+		PRNumber:     42,
+	}
+	wrongRepo := &github.TaskPR{
+		TaskID:       "task-1",
+		RepositoryID: "repo-front",
+		Owner:        "acme",
+		Repo:         "widget",
+		PRNumber:     42,
+	}
+	matchingRepo := &github.TaskPR{
+		TaskID:       "task-1",
+		RepositoryID: "repo-back",
+		Owner:        "acme",
+		Repo:         "widget",
+		PRNumber:     42,
+	}
+
+	got := ciAutomationFindMatchingPR([]*github.TaskPR{wrongRepo, matchingRepo}, target)
+	if got != matchingRepo {
+		t.Fatalf("expected repository_id match, got %+v", got)
+	}
+
+	got = ciAutomationFindMatchingPR([]*github.TaskPR{wrongRepo}, target)
+	if got != nil {
+		t.Fatalf("expected no owner/repo fallback when target repository_id is set, got %+v", got)
+	}
+}
+
 func TestDispatchCIAutomationPromptDoesNotRecordUserMessageWhenQueueFails(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -183,6 +183,7 @@ func TestCIAutomationFeedbackDeltaIgnoresNeutralChecks(t *testing.T) {
 	feedback := &github.PRFeedback{
 		Checks: []github.CheckRun{
 			{Name: "optional", Status: "completed", Conclusion: "neutral", HTMLURL: "https://ci/optional"},
+			{Name: "future", Status: "completed", Conclusion: "stale", HTMLURL: "https://ci/future"},
 			{Name: "unit", Status: "completed", Conclusion: "failure", HTMLURL: "https://ci/unit"},
 		},
 	}
@@ -190,6 +191,22 @@ func TestCIAutomationFeedbackDeltaIgnoresNeutralChecks(t *testing.T) {
 	delta := ciAutomationBuildDelta(feedback, ciAutomationCheckpoint{})
 	if len(delta.FailedChecks) != 1 || delta.FailedChecks[0].Name != "unit" {
 		t.Fatalf("expected only failing check in delta, got %+v", delta.FailedChecks)
+	}
+}
+
+func TestCIAutomationFeedbackDeltaIncludesKnownFailingConclusions(t *testing.T) {
+	feedback := &github.PRFeedback{
+		Checks: []github.CheckRun{
+			{Name: "failure", Status: "completed", Conclusion: "failure", HTMLURL: "https://ci/failure"},
+			{Name: "timed out", Status: "completed", Conclusion: "timed_out", HTMLURL: "https://ci/timed-out"},
+			{Name: "cancelled", Status: "completed", Conclusion: "cancelled", HTMLURL: "https://ci/cancelled"},
+			{Name: "action required", Status: "completed", Conclusion: "action_required", HTMLURL: "https://ci/action-required"},
+		},
+	}
+
+	delta := ciAutomationBuildDelta(feedback, ciAutomationCheckpoint{})
+	if len(delta.FailedChecks) != 4 {
+		t.Fatalf("failed checks = %d, want 4: %+v", len(delta.FailedChecks), delta.FailedChecks)
 	}
 }
 
@@ -478,6 +495,56 @@ func TestHandleTaskPRCIAutomationAutoFixBlocksSameCycleMerge(t *testing.T) {
 	}
 	if ghSvc.mergeCalls != 0 {
 		t.Fatalf("expected auto-merge to wait for a later cycle after auto-fix prompt, got %d merge calls", ghSvc.mergeCalls)
+	}
+}
+
+func TestHandleTaskPRCIAutomationDuplicateFixAttemptBlocksMerge(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task-1", "session-1", models.TaskSessionStateRunning)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	now := time.Now().UTC()
+	pr := &github.TaskPR{
+		TaskID:         "task-1",
+		RepositoryID:   "repo-1",
+		Owner:          "acme",
+		Repo:           "widget",
+		PRNumber:       42,
+		State:          "open",
+		ChecksState:    "success",
+		ReviewState:    "approved",
+		MergeableState: "clean",
+		LastSyncedAt:   &now,
+	}
+	feedback := &github.PRFeedback{
+		Comments: []github.PRComment{{ID: 100, Body: "please address before merge"}},
+	}
+	_, signature := encodeCIAutomationCheckpoint(ciAutomationCurrentCheckpoint(feedback))
+	ghSvc := &mockGitHubService{
+		ciOptionsResp: &github.TaskCIOptionsResponse{
+			TaskID:                 "task-1",
+			AutoFixEnabled:         true,
+			AutoMergeEnabled:       true,
+			EffectiveAutoFixPrompt: "Fix the PR\n\n{{pr.feedback}}",
+		},
+		triggerPRSyncAllPRs: []*github.TaskPR{pr},
+		prFeedback:          feedback,
+		ciPRState: &github.TaskCIPRAutomationState{
+			LastFixSignature:      signature,
+			LastFixCheckpointJSON: `{"comments":[{"id":100,"body":"please address before merge"}]}`,
+			LastFixEnqueuedAt:     &now,
+		},
+	}
+	svc.SetGitHubService(ghSvc)
+
+	if err := svc.handleTaskPRCIAutomation(ctx, pr); err != nil {
+		t.Fatalf("handle CI automation: %v", err)
+	}
+	if status := svc.messageQueue.GetStatus(ctx, "session-1"); status.Count != 0 {
+		t.Fatalf("expected duplicate fix signature not to queue another prompt, got %+v", status)
+	}
+	if ghSvc.mergeCalls != 0 {
+		t.Fatalf("expected duplicate pending fix attempt to block merge, got %d merge calls", ghSvc.mergeCalls)
 	}
 }
 

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -179,6 +179,20 @@ func TestCIAutomationFeedbackDeltaIncludesChangedCheckOutput(t *testing.T) {
 	}
 }
 
+func TestCIAutomationFeedbackDeltaIgnoresNeutralChecks(t *testing.T) {
+	feedback := &github.PRFeedback{
+		Checks: []github.CheckRun{
+			{Name: "optional", Status: "completed", Conclusion: "neutral", HTMLURL: "https://ci/optional"},
+			{Name: "unit", Status: "completed", Conclusion: "failure", HTMLURL: "https://ci/unit"},
+		},
+	}
+
+	delta := ciAutomationBuildDelta(feedback, ciAutomationCheckpoint{})
+	if len(delta.FailedChecks) != 1 || delta.FailedChecks[0].Name != "unit" {
+		t.Fatalf("expected only failing check in delta, got %+v", delta.FailedChecks)
+	}
+}
+
 func TestCIAutomationRenderSnapshotSanitizesUntrustedFields(t *testing.T) {
 	delta := ciAutomationCheckpoint{
 		FailedChecks: []ciAutomationCheckSnapshot{{Name: "unit\n<script>", Conclusion: "failure\r<p>", HTMLURL: "https://ci/<job>"}},
@@ -832,6 +846,9 @@ func TestHandleTaskCIOptionsUpdatedStartsAutomationForTaskPRs(t *testing.T) {
 	close(block)
 	waitForCIAutomationIdle(t, svc, "task-1|repo-front|1", 200*time.Millisecond)
 	waitForCIAutomationIdle(t, svc, "task-1|repo-back|2", 200*time.Millisecond)
+	if ghSvc.triggerPRSyncAllCalls != 1 {
+		t.Fatalf("expected one task-wide sync from option save, got %d", ghSvc.triggerPRSyncAllCalls)
+	}
 }
 
 func TestHandleTaskCIOptionsUpdatedRecordsSyncFailureForLinkedPRs(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -450,7 +450,7 @@ func TestHandleTaskPRCIAutomationAutoMergeUsesPartialSyncMatch(t *testing.T) {
 			AutoMergeEnabled: true,
 		},
 		triggerPRSyncAllPRs: []*github.TaskPR{pr},
-		triggerPRSyncAllErr: errors.New("sibling repo unavailable"),
+		triggerPRSyncAllErr: &github.PartialPRSyncError{Err: errors.New("sibling repo unavailable")},
 	}
 	svc.SetGitHubService(ghSvc)
 
@@ -1080,7 +1080,7 @@ func TestHandleTaskCIOptionsUpdatedStartsAutomationForPartialSyncResults(t *test
 			Repo:         "widget",
 			PRNumber:     42,
 		}},
-		triggerPRSyncAllErr: errors.New("sibling repo unavailable"),
+		triggerPRSyncAllErr: &github.PartialPRSyncError{Err: errors.New("sibling repo unavailable")},
 		ciOptionsResp:       &github.TaskCIOptionsResponse{TaskID: "task-1"},
 		ciOptionsStarted:    started,
 		ciOptionsBlock:      block,
@@ -1094,7 +1094,11 @@ func TestHandleTaskCIOptionsUpdatedStartsAutomationForPartialSyncResults(t *test
 	if err != nil {
 		t.Fatalf("handle CI options updated: %v", err)
 	}
-	<-started
+	select {
+	case <-started:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for CI automation to start")
+	}
 	if _, loaded := svc.ciAutomationInFlight.Load("task-1|repo-1|42"); !loaded {
 		t.Fatal("expected automation to run for partial sync result")
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -1102,11 +1102,55 @@ func TestHandleTaskCIOptionsUpdatedStartsAutomationForPartialSyncResults(t *test
 	if _, loaded := svc.ciAutomationInFlight.Load("task-1|repo-1|42"); !loaded {
 		t.Fatal("expected automation to run for partial sync result")
 	}
-	if len(ghSvc.ciErrors) != 1 || ghSvc.ciErrors[0].LastError == nil || !strings.Contains(*ghSvc.ciErrors[0].LastError, "sibling repo unavailable") {
-		t.Fatalf("expected partial sync error to be recorded, got %+v", ghSvc.ciErrors)
+	if len(ghSvc.ciErrors) != 0 {
+		t.Fatalf("expected synced PR not to receive sibling sync error, got %+v", ghSvc.ciErrors)
 	}
 	close(block)
 	waitForCIAutomationIdle(t, svc, "task-1|repo-1|42", 200*time.Millisecond)
+}
+
+func TestHandleTaskCIOptionsUpdatedRecordsPartialSyncFailureOnlyForUnsyncedPRs(t *testing.T) {
+	ctx := context.Background()
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	synced := &github.TaskPR{
+		TaskID:       "task-1",
+		RepositoryID: "repo-front",
+		Owner:        "acme",
+		Repo:         "front",
+		PRNumber:     1,
+	}
+	unsynced := &github.TaskPR{
+		TaskID:       "task-1",
+		RepositoryID: "repo-back",
+		Owner:        "acme",
+		Repo:         "back",
+		PRNumber:     2,
+	}
+	ghSvc := &mockGitHubService{
+		taskPRs:             []*github.TaskPR{synced, unsynced},
+		triggerPRSyncAllPRs: []*github.TaskPR{synced},
+		triggerPRSyncAllErr: &github.PartialPRSyncError{Err: errors.New("back repo unavailable")},
+		ciOptionsResp:       &github.TaskCIOptionsResponse{TaskID: "task-1"},
+	}
+	svc.SetGitHubService(ghSvc)
+
+	err := svc.handleTaskCIOptionsUpdated(ctx, &bus.Event{Data: &github.TaskCIOptionsResponse{
+		TaskID:           "task-1",
+		AutoMergeEnabled: true,
+	}})
+	if err != nil {
+		t.Fatalf("handle CI options updated: %v", err)
+	}
+	if len(ghSvc.ciErrors) != 1 {
+		t.Fatalf("expected one sync error for unsynced PR, got %+v", ghSvc.ciErrors)
+	}
+	got := ghSvc.ciErrors[0]
+	if got.RepositoryID != "repo-back" || got.PRNumber != 2 {
+		t.Fatalf("expected sync error on repo-back#2, got %+v", got)
+	}
+	if got.LastError == nil || !strings.Contains(*got.LastError, "back repo unavailable") {
+		t.Fatalf("expected sibling sync error message, got %+v", got.LastError)
+	}
 }
 
 func TestStartTaskPRCIAutomationSkipsDuplicateInFlightPR(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -15,28 +15,6 @@ import (
 	"github.com/kandev/kandev/internal/task/models"
 )
 
-func TestCIAutomationShouldAutoFix(t *testing.T) {
-	tests := []struct {
-		name string
-		pr   *github.TaskPR
-		want bool
-	}{
-		{name: "failed checks", pr: &github.TaskPR{ChecksState: "failure"}, want: true},
-		{name: "changes requested", pr: &github.TaskPR{ReviewState: "changes_requested"}, want: true},
-		{name: "unresolved threads", pr: &github.TaskPR{UnresolvedReviewThreads: 1}, want: true},
-		{name: "passing approved", pr: &github.TaskPR{ChecksState: "success", ReviewState: "approved"}, want: false},
-		{name: "closed ignored", pr: &github.TaskPR{State: "closed", ChecksState: "failure"}, want: false},
-		{name: "merged ignored", pr: &github.TaskPR{State: "merged", ReviewState: "changes_requested"}, want: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ciAutomationShouldAutoFix(tt.pr); got != tt.want {
-				t.Fatalf("ciAutomationShouldAutoFix=%v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestCIAutomationReadyToMerge(t *testing.T) {
 	required := 1
 	ready := github.TaskPR{
@@ -162,6 +140,23 @@ func TestCIAutomationFeedbackDeltaIncludesEditedComments(t *testing.T) {
 	delta := ciAutomationBuildDelta(feedback, previous)
 	if len(delta.Comments) != 1 || delta.Comments[0].Body != "new body" {
 		t.Fatalf("expected edited comment in delta, got %+v", delta.Comments)
+	}
+}
+
+func TestCIAutomationFilterFeedbackForPRSkipsReviewCommentsWithoutUnresolvedThreads(t *testing.T) {
+	feedback := &github.PRFeedback{
+		Comments: []github.PRComment{
+			{ID: 1, Body: "resolved review comment", Path: "main.go", Line: 12},
+			{ID: 2, Body: "plain PR comment"},
+		},
+	}
+	filtered := ciAutomationFilterFeedbackForPR(&github.TaskPR{}, feedback)
+	if len(filtered.Comments) != 1 || filtered.Comments[0].ID != 2 {
+		t.Fatalf("expected only plain PR comment, got %+v", filtered.Comments)
+	}
+	withThreads := ciAutomationFilterFeedbackForPR(&github.TaskPR{UnresolvedReviewThreads: 1}, feedback)
+	if len(withThreads.Comments) != 2 {
+		t.Fatalf("expected unresolved review threads to keep review comments, got %+v", withThreads.Comments)
 	}
 }
 
@@ -352,6 +347,44 @@ func TestHandleTaskPRCIAutomationAutoFixUsesFreshSyncAndFullFeedback(t *testing.
 	}
 }
 
+func TestHandleTaskPRCIAutomationAutoFixSkipsClosedFetchedPR(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task-1", "session-1", models.TaskSessionStateRunning)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	now := time.Now().UTC()
+	pr := &github.TaskPR{
+		TaskID:       "task-1",
+		RepositoryID: "repo-1",
+		Owner:        "acme",
+		Repo:         "widget",
+		PRNumber:     42,
+		State:        "open",
+		ChecksState:  "success",
+		LastSyncedAt: &now,
+	}
+	ghSvc := &mockGitHubService{
+		ciOptionsResp: &github.TaskCIOptionsResponse{
+			TaskID:                 "task-1",
+			AutoFixEnabled:         true,
+			EffectiveAutoFixPrompt: "Fix the PR\n\n{{pr.feedback}}",
+		},
+		triggerPRSyncAllPRs: []*github.TaskPR{pr},
+		prFeedback: &github.PRFeedback{
+			PR:       &github.PR{State: "closed"},
+			Comments: []github.PRComment{{ID: 99, Body: "plain PR comment"}},
+		},
+	}
+	svc.SetGitHubService(ghSvc)
+
+	if err := svc.handleTaskPRCIAutomation(ctx, pr); err != nil {
+		t.Fatalf("handle auto-fix: %v", err)
+	}
+	if status := svc.messageQueue.GetStatus(ctx, "session-1"); status.Count != 0 {
+		t.Fatalf("expected no prompt for closed fetched PR, got %+v", status)
+	}
+}
+
 func TestHandleTaskPRCIAutomationAutoMergeUsesFreshSync(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)
@@ -390,6 +423,45 @@ func TestHandleTaskPRCIAutomationAutoMergeUsesFreshSync(t *testing.T) {
 	}
 	if ghSvc.mergeCalls != 1 {
 		t.Fatalf("expected merge from fresh synced PR state, got %d", ghSvc.mergeCalls)
+	}
+}
+
+func TestHandleTaskPRCIAutomationAutoMergeUsesPartialSyncMatch(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task-1", "session-1", models.TaskSessionStateRunning)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	now := time.Now().UTC()
+	pr := &github.TaskPR{
+		TaskID:         "task-1",
+		RepositoryID:   "repo-1",
+		Owner:          "acme",
+		Repo:           "widget",
+		PRNumber:       42,
+		State:          "open",
+		ChecksState:    "success",
+		ReviewState:    "approved",
+		MergeableState: "clean",
+		LastSyncedAt:   &now,
+	}
+	ghSvc := &mockGitHubService{
+		ciOptionsResp: &github.TaskCIOptionsResponse{
+			TaskID:           "task-1",
+			AutoMergeEnabled: true,
+		},
+		triggerPRSyncAllPRs: []*github.TaskPR{pr},
+		triggerPRSyncAllErr: errors.New("sibling repo unavailable"),
+	}
+	svc.SetGitHubService(ghSvc)
+
+	if err := svc.handleTaskPRCIAutomation(ctx, pr); err != nil {
+		t.Fatalf("handle auto-merge: %v", err)
+	}
+	if ghSvc.mergeCalls != 1 {
+		t.Fatalf("expected matching partial sync result to merge, got %d calls", ghSvc.mergeCalls)
+	}
+	if len(ghSvc.ciErrors) != 0 {
+		t.Fatalf("expected no CI error on matching partial result, got %+v", ghSvc.ciErrors)
 	}
 }
 
@@ -451,6 +523,24 @@ func TestCIAutomationHasFreshPRStatusAt(t *testing.T) {
 				t.Fatalf("ciAutomationHasFreshPRStatusAt=%v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCIAutomationDuplicateFixAttemptBlocksMergeAt(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	fresh := now.Add(-ciAutomationFixBlockWindow)
+	stale := fresh.Add(-time.Nanosecond)
+	if ciAutomationDuplicateFixAttemptBlocksMergeAt(nil, now) {
+		t.Fatal("nil state should not block")
+	}
+	if ciAutomationDuplicateFixAttemptBlocksMergeAt(&github.TaskCIPRAutomationState{}, now) {
+		t.Fatal("state without enqueue time should not block")
+	}
+	if !ciAutomationDuplicateFixAttemptBlocksMergeAt(&github.TaskCIPRAutomationState{LastFixEnqueuedAt: &fresh}, now) {
+		t.Fatal("fresh duplicate fix attempt should block")
+	}
+	if ciAutomationDuplicateFixAttemptBlocksMergeAt(&github.TaskCIPRAutomationState{LastFixEnqueuedAt: &stale}, now) {
+		t.Fatal("stale duplicate fix attempt should not block")
 	}
 }
 
@@ -968,6 +1058,51 @@ func TestHandleTaskCIOptionsUpdatedRecordsSyncFailureForLinkedPRs(t *testing.T) 
 	if len(ghSvc.ciErrors) != 1 || ghSvc.ciErrors[0].LastError == nil || !strings.Contains(*ghSvc.ciErrors[0].LastError, "sync PR status: gh unavailable") {
 		t.Fatalf("expected sync failure to be recorded on linked PR, got %+v", ghSvc.ciErrors)
 	}
+}
+
+func TestHandleTaskCIOptionsUpdatedStartsAutomationForPartialSyncResults(t *testing.T) {
+	ctx := context.Background()
+	svc := createTestService(setupTestRepo(t), newMockStepGetter(), newMockTaskRepo())
+	started := make(chan struct{})
+	block := make(chan struct{})
+	ghSvc := &mockGitHubService{
+		taskPRs: []*github.TaskPR{{
+			TaskID:       "task-1",
+			RepositoryID: "repo-1",
+			Owner:        "acme",
+			Repo:         "widget",
+			PRNumber:     42,
+		}},
+		triggerPRSyncAllPRs: []*github.TaskPR{{
+			TaskID:       "task-1",
+			RepositoryID: "repo-1",
+			Owner:        "acme",
+			Repo:         "widget",
+			PRNumber:     42,
+		}},
+		triggerPRSyncAllErr: errors.New("sibling repo unavailable"),
+		ciOptionsResp:       &github.TaskCIOptionsResponse{TaskID: "task-1"},
+		ciOptionsStarted:    started,
+		ciOptionsBlock:      block,
+	}
+	svc.SetGitHubService(ghSvc)
+
+	err := svc.handleTaskCIOptionsUpdated(ctx, &bus.Event{Data: &github.TaskCIOptionsResponse{
+		TaskID:           "task-1",
+		AutoMergeEnabled: true,
+	}})
+	if err != nil {
+		t.Fatalf("handle CI options updated: %v", err)
+	}
+	<-started
+	if _, loaded := svc.ciAutomationInFlight.Load("task-1|repo-1|42"); !loaded {
+		t.Fatal("expected automation to run for partial sync result")
+	}
+	if len(ghSvc.ciErrors) != 1 || ghSvc.ciErrors[0].LastError == nil || !strings.Contains(*ghSvc.ciErrors[0].LastError, "sibling repo unavailable") {
+		t.Fatalf("expected partial sync error to be recorded, got %+v", ghSvc.ciErrors)
+	}
+	close(block)
+	waitForCIAutomationIdle(t, svc, "task-1|repo-1|42", 200*time.Millisecond)
 }
 
 func TestStartTaskPRCIAutomationSkipsDuplicateInFlightPR(t *testing.T) {

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -271,6 +271,92 @@ func TestHandleTaskPRCIAutomationQueuesFixDedupesAndMerges(t *testing.T) {
 	}
 }
 
+func TestHandleTaskPRCIAutomationAutoFixUsesFreshSyncAndFullFeedback(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task-1", "session-1", models.TaskSessionStateRunning)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	pr := &github.TaskPR{
+		TaskID:       "task-1",
+		RepositoryID: "repo-1",
+		Owner:        "acme",
+		Repo:         "widget",
+		PRNumber:     42,
+		State:        "open",
+		ChecksState:  "success",
+	}
+	ghSvc := &mockGitHubService{
+		ciOptionsResp: &github.TaskCIOptionsResponse{
+			TaskID:                 "task-1",
+			AutoFixEnabled:         true,
+			EffectiveAutoFixPrompt: "Fix the PR\n\n{{pr.feedback}}",
+		},
+		triggerPRSyncAllPRs: []*github.TaskPR{{
+			TaskID:       "task-1",
+			RepositoryID: "repo-1",
+			Owner:        "acme",
+			Repo:         "widget",
+			PRNumber:     42,
+			State:        "open",
+			ChecksState:  "success",
+		}},
+		prFeedback: &github.PRFeedback{
+			Comments: []github.PRComment{{ID: 99, Body: "plain PR comment should trigger auto-fix"}},
+		},
+	}
+	svc.SetGitHubService(ghSvc)
+
+	if err := svc.handleTaskPRCIAutomation(ctx, pr); err != nil {
+		t.Fatalf("handle auto-fix: %v", err)
+	}
+	if ghSvc.triggerPRSyncAllCalls != 1 {
+		t.Fatalf("TriggerPRSyncAll calls = %d, want 1", ghSvc.triggerPRSyncAllCalls)
+	}
+	status := svc.messageQueue.GetStatus(ctx, "session-1")
+	if status.Count != 1 || !strings.Contains(status.Entries[0].Content, "plain PR comment should trigger auto-fix") {
+		t.Fatalf("expected queued auto-fix prompt from full feedback, got %+v", status)
+	}
+}
+
+func TestHandleTaskPRCIAutomationAutoMergeUsesFreshSync(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task-1", "session-1", models.TaskSessionStateRunning)
+	svc := createTestService(repo, newMockStepGetter(), newMockTaskRepo())
+	stale := &github.TaskPR{
+		TaskID:         "task-1",
+		RepositoryID:   "repo-1",
+		Owner:          "acme",
+		Repo:           "widget",
+		PRNumber:       42,
+		State:          "open",
+		ChecksState:    "failure",
+		MergeableState: "dirty",
+	}
+	fresh := *stale
+	fresh.ChecksState = "success"
+	fresh.ReviewState = "approved"
+	fresh.MergeableState = "clean"
+	ghSvc := &mockGitHubService{
+		ciOptionsResp: &github.TaskCIOptionsResponse{
+			TaskID:           "task-1",
+			AutoMergeEnabled: true,
+		},
+		triggerPRSyncAllPRs: []*github.TaskPR{&fresh},
+	}
+	svc.SetGitHubService(ghSvc)
+
+	if err := svc.handleTaskPRCIAutomation(ctx, stale); err != nil {
+		t.Fatalf("handle auto-merge: %v", err)
+	}
+	if ghSvc.triggerPRSyncAllCalls != 1 {
+		t.Fatalf("TriggerPRSyncAll calls = %d, want 1", ghSvc.triggerPRSyncAllCalls)
+	}
+	if ghSvc.mergeCalls != 1 {
+		t.Fatalf("expected merge from fresh synced PR state, got %d", ghSvc.mergeCalls)
+	}
+}
+
 func TestDispatchCIAutomationPromptDoesNotRecordUserMessageWhenQueueFails(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_ci_automation_test.go
@@ -1141,6 +1141,7 @@ func TestHandleTaskCIOptionsUpdatedRecordsPartialSyncFailureOnlyForUnsyncedPRs(t
 	if err != nil {
 		t.Fatalf("handle CI options updated: %v", err)
 	}
+	waitForCIAutomationIdle(t, svc, "task-1|repo-front|1", 200*time.Millisecond)
 	if len(ghSvc.ciErrors) != 1 {
 		t.Fatalf("expected one sync error for unsynced PR, got %+v", ghSvc.ciErrors)
 	}

--- a/apps/backend/internal/orchestrator/event_handlers_github_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_test.go
@@ -16,25 +16,28 @@ import (
 type mockGitHubService struct {
 	mu sync.Mutex
 
-	client              github.Client
-	taskPR              *github.TaskPR
-	taskPRs             []*github.TaskPR
-	taskPRErr           error
-	getTaskPRCalls      int
-	exactTaskPRCalls    int
-	lastExactPRLookup   github.PRFeedbackEvent
-	prWatch             *github.PRWatch // returned by GetPRWatchBySession (nil = no watch)
-	ensureWatchCalls    int
-	createWatchCalls    int
-	associateCalls      int
-	updateBranchCalls   int
-	updatePRNumberCalls int
-	resetWatchCalls     int
-	resetWatchBranch    string
-	ensureWatchBranch   string
-	createWatchBranch   string
-	updatedBranch       string
-	updatedPRNumber     int
+	client                github.Client
+	taskPR                *github.TaskPR
+	taskPRs               []*github.TaskPR
+	taskPRErr             error
+	triggerPRSyncAllPRs   []*github.TaskPR
+	triggerPRSyncAllErr   error
+	triggerPRSyncAllCalls int
+	getTaskPRCalls        int
+	exactTaskPRCalls      int
+	lastExactPRLookup     github.PRFeedbackEvent
+	prWatch               *github.PRWatch // returned by GetPRWatchBySession (nil = no watch)
+	ensureWatchCalls      int
+	createWatchCalls      int
+	associateCalls        int
+	updateBranchCalls     int
+	updatePRNumberCalls   int
+	resetWatchCalls       int
+	resetWatchBranch      string
+	ensureWatchBranch     string
+	createWatchBranch     string
+	updatedBranch         string
+	updatedPRNumber       int
 	// repository_id captured by the most recent CreatePRWatch /
 	// AssociatePRWithTask call. Used by the multi-repo push tests to assert
 	// the per-repo scoping (an empty value indicates the legacy single-repo
@@ -102,6 +105,20 @@ func (m *mockGitHubService) ListTaskPRs(_ context.Context, taskIDs []string) (ma
 		}
 	}
 	return result, nil
+}
+func (m *mockGitHubService) TriggerPRSyncAll(ctx context.Context, taskID string) ([]*github.TaskPR, error) {
+	m.triggerPRSyncAllCalls++
+	if m.triggerPRSyncAllErr != nil {
+		return nil, m.triggerPRSyncAllErr
+	}
+	if m.triggerPRSyncAllPRs != nil {
+		return m.triggerPRSyncAllPRs, nil
+	}
+	prsByTask, err := m.ListTaskPRs(ctx, []string{taskID})
+	if err != nil {
+		return nil, err
+	}
+	return prsByTask[taskID], nil
 }
 func (m *mockGitHubService) GetTaskPRByOwnerRepoNumber(_ context.Context, taskID, owner, repo string, prNumber int) (*github.TaskPR, error) {
 	m.exactTaskPRCalls++

--- a/apps/backend/internal/orchestrator/event_handlers_github_test.go
+++ b/apps/backend/internal/orchestrator/event_handlers_github_test.go
@@ -108,11 +108,11 @@ func (m *mockGitHubService) ListTaskPRs(_ context.Context, taskIDs []string) (ma
 }
 func (m *mockGitHubService) TriggerPRSyncAll(ctx context.Context, taskID string) ([]*github.TaskPR, error) {
 	m.triggerPRSyncAllCalls++
+	if m.triggerPRSyncAllPRs != nil {
+		return m.triggerPRSyncAllPRs, m.triggerPRSyncAllErr
+	}
 	if m.triggerPRSyncAllErr != nil {
 		return nil, m.triggerPRSyncAllErr
-	}
-	if m.triggerPRSyncAllPRs != nil {
-		return m.triggerPRSyncAllPRs, nil
 	}
 	prsByTask, err := m.ListTaskPRs(ctx, []string{taskID})
 	if err != nil {

--- a/docs/specs/ui/ci-pr-automation.md
+++ b/docs/specs/ui/ci-pr-automation.md
@@ -28,7 +28,7 @@ Users can already see pull request CI/review status above the task chat input, b
 - The default `ci-auto-fix` prompt is editable from Settings > Prompts like other built-in prompts.
 - Emptying or resetting the task prompt override returns the task to the default `ci-auto-fix` prompt.
 - For tasks with multiple linked PRs, the controls are task-level and apply to every open linked PR. Dedupe, last-attempt, and error state are tracked per linked PR.
-- Kandev checks watched PRs through the existing lightweight PR watch poller, which runs once per minute. It fetches full PR feedback only when a watched PR is a candidate for auto-fix or when a user opens/refreshes PR feedback UI.
+- Kandev checks watched PRs through the existing lightweight PR watch poller, which runs once per minute. Automation wakeups sync the latest lightweight PR state before evaluating gates. When auto-fix is enabled, Kandev fetches full PR feedback so failing checks, requested changes, unresolved threads, and plain PR comments can trigger deduped prompts even when the persisted lightweight row was stale.
 - Saving CI automation options while `Auto-fix CI & address comments` or `Auto-merge when ready` is enabled immediately evaluates the task's current linked PRs instead of waiting for the next PR watch poll. This includes prompt edits made while automation is already enabled; unchanged feedback is still deduped by the per-PR checkpoint.
 - Every auto-fix attempt records the latest feedback snapshot it used, including non-actionable snapshots that were intentionally no-ops. Later fix rounds include only new or materially changed CI/review feedback since the last recorded round, with enough summary context for the agent to understand the PR.
 - Automation must not repeatedly prompt for the same failure/comment snapshot or repeatedly retry the same failed merge attempt on every poll.
@@ -134,8 +134,8 @@ Task CI automation options:
 
 Auto-fix cycle for one task/PR:
 
-1. Existing PR watch poll updates lightweight PR state.
-2. Kandev sees a candidate state: failed checks, requested changes, unresolved review threads, or new actionable review feedback.
+1. Existing PR watch poll, PR feedback event, or CI options save wakes automation.
+2. Kandev syncs the latest lightweight PR state for the task's linked PRs, including linked PR rows that do not currently have an active watch.
 3. Kandev fetches full PR feedback.
 4. Kandev compares the current feedback snapshot to `last_fix_checkpoint_json` and `last_fix_signature`.
 5. If there is no material change, the cycle ends without prompting.


### PR DESCRIPTION
PR CI automation could miss failures and ready merges when GitHub state exceeded first-page API responses or persisted TaskPR rows were stale. It now syncs PR state before automation gates and evaluates full feedback so failures, comments, and merge readiness are handled reliably.

## Important Changes

- Paginated check-run fetches for both PAT and `gh` clients so failures beyond GitHub's first page are visible.
- Refreshed linked PR state before CI automation gates, including option-triggered runs and associated PR rows without active watches.
- Evaluated auto-fix from full PR feedback and logged persisted CI automation errors so failed automation attempts are easier to diagnose.

## Validation

- `go test -run 'TestPATClient_ListCheckRuns_PaginatesCheckRuns|TestGHClient_ListCheckRuns_PaginatesCheckRuns' ./internal/github`
- `go test -run 'TestHandleTaskPRCIAutomationAutoFixUsesFreshSyncAndFullFeedback|TestHandleTaskPRCIAutomationAutoMergeUsesFreshSync|TestHandleTaskCIOptionsUpdatedStartsAutomationForTaskPRs' ./internal/orchestrator`
- `go test ./internal/github`
- `go test ./internal/orchestrator`
- `make -C apps/backend test`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->