### PR TITLE
fix: prime task create last-used cache before dialog effects

### DIFF
--- a/apps/web/components/settings/system/licenses-list.test.tsx
+++ b/apps/web/components/settings/system/licenses-list.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { LicensesList } from "./licenses-list";
+import type { LicenseEntry } from "@/lib/types/system";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LicensesList", () => {
+  it("shows a stale warning when Go entries were reused from the existing manifest", () => {
+    const entries: LicenseEntry[] = [
+      {
+        name: "github.com/example/module",
+        version: "v1.0.0",
+        license: "MIT",
+        stale: true,
+        ecosystem: "go",
+      },
+    ];
+
+    const { getByTestId } = render(<LicensesList entries={entries} />);
+
+    expect(getByTestId("system-licenses-stale-warning").textContent).toContain(
+      "Go license entries were reused",
+    );
+  });
+
+  it("does not show a stale warning for fresh entries", () => {
+    const entries: LicenseEntry[] = [
+      {
+        name: "github.com/example/module",
+        version: "v1.0.0",
+        license: "MIT",
+        ecosystem: "go",
+      },
+    ];
+
+    const { queryByTestId } = render(<LicensesList entries={entries} />);
+
+    expect(queryByTestId("system-licenses-stale-warning")).toBeNull();
+  });
+});

--- a/apps/web/components/settings/system/licenses-list.tsx
+++ b/apps/web/components/settings/system/licenses-list.tsx
@@ -5,11 +5,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@kandev/ui/card";
 import { Input } from "@kandev/ui/input";
 import { Badge } from "@kandev/ui/badge";
 import { Button } from "@kandev/ui/button";
+import { Alert, AlertDescription } from "@kandev/ui/alert";
 import {
   IconScale,
   IconChevronDown,
   IconChevronRight,
   IconExternalLink,
+  IconAlertTriangle,
 } from "@tabler/icons-react";
 import type { LicenseEntry } from "@/lib/types/system";
 
@@ -100,6 +102,10 @@ function filterEntries(entries: LicenseEntry[], query: string): LicenseEntry[] {
 export function LicensesList({ entries }: Props) {
   const [query, setQuery] = useState("");
   const visible = useMemo(() => filterEntries(entries, query), [entries, query]);
+  const hasStaleGoEntries = useMemo(
+    () => entries.some((entry) => entry.ecosystem === "go" && entry.stale),
+    [entries],
+  );
 
   return (
     <Card data-testid="system-licenses-card">
@@ -109,6 +115,15 @@ export function LicensesList({ entries }: Props) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        {hasStaleGoEntries && (
+          <Alert data-testid="system-licenses-stale-warning">
+            <IconAlertTriangle className="h-3.5 w-3.5" />
+            <AlertDescription>
+              Go license entries were reused from the committed manifest because generation failed.
+              Regenerate licenses when go-licenses is healthy to refresh Go dependency data.
+            </AlertDescription>
+          </Alert>
+        )}
         <div className="flex items-center justify-between gap-3">
           <Input
             placeholder="Filter by name, license, or ecosystem..."

--- a/apps/web/components/state-provider.test.tsx
+++ b/apps/web/components/state-provider.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultSettingsState } from "@/lib/state/slices/settings/settings-slice";
 import { STORAGE_KEYS } from "@/lib/settings/constants";
@@ -30,6 +31,13 @@ function EnableMetricsFromNestedProvider() {
       Enable metrics
     </button>
   );
+}
+
+function ObserveLastUsedCache({ onSeen }: { onSeen: (value: string | null) => void }) {
+  useEffect(() => {
+    onSeen(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID));
+  }, [onSeen]);
+  return null;
 }
 
 describe("StateProvider", () => {
@@ -113,5 +121,29 @@ describe("StateProvider", () => {
       expect(screen.getByRole("button", { name: "Toggle unrelated" })).toBeTruthy();
     });
     expect(setItemSpy).toHaveBeenCalledTimes(writesAfterInitialSync);
+  });
+
+  it("primes task-create last-used localStorage before child effects run", () => {
+    const onSeen = vi.fn();
+    render(
+      <StateProvider
+        initialState={{
+          userSettings: {
+            ...defaultSettingsState.userSettings,
+            loaded: true,
+            taskCreateLastUsed: {
+              repositoryId: "repo-1",
+              branch: "main",
+              agentProfileId: "agent-1",
+              executorProfileId: "exec-1",
+            },
+          },
+        }}
+      >
+        <ObserveLastUsedCache onSeen={onSeen} />
+      </StateProvider>,
+    );
+
+    expect(onSeen).toHaveBeenCalledWith(JSON.stringify("repo-1"));
   });
 });

--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -33,7 +33,7 @@ export function StateProvider({ children, initialState }: StoreProviderProps) {
     }
   }, [store]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     syncTaskCreateLastUsedCache(store.getState());
     return store.subscribe((state, prevState) => {
       if (

--- a/apps/web/lib/types/system.ts
+++ b/apps/web/lib/types/system.ts
@@ -178,5 +178,6 @@ export interface LicenseEntry {
   license: string;
   repository?: string;
   license_text?: string;
+  stale?: boolean;
   ecosystem?: LicenseEcosystem;
 }

--- a/apps/web/scripts/generate-licenses-fallback.test.ts
+++ b/apps/web/scripts/generate-licenses-fallback.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { readGoEntriesFromManifest, recoverGoEntriesAfterReportFailure } from "./generate-licenses";
+
+const APACHE_2 = "Apache-2.0";
+const EXISTING_GO_MODULE = "github.com/example/existing";
+const MODULE_VERSION = "v1.2.3";
+const OLD_MODULE_VERSION = "v1.0.0";
+
+describe("readGoEntriesFromManifest", () => {
+  it("returns valid Go entries from an existing manifest", () => {
+    const raw = JSON.stringify([
+      {
+        name: "left-pad",
+        version: "1.0.0",
+        license: "MIT",
+        ecosystem: "npm",
+      },
+      {
+        name: "github.com/example/module",
+        version: MODULE_VERSION,
+        license: APACHE_2,
+        repository: "https://github.com/example/module",
+        license_text: "license text",
+        ecosystem: "go",
+      },
+      {
+        name: "github.com/example/broken",
+        version: MODULE_VERSION,
+        ecosystem: "go",
+      },
+    ]);
+
+    expect(readGoEntriesFromManifest(raw)).toEqual([
+      {
+        name: "github.com/example/module",
+        version: MODULE_VERSION,
+        license: APACHE_2,
+        repository: "https://github.com/example/module",
+        license_text: "license text",
+        ecosystem: "go",
+      },
+    ]);
+  });
+
+  it("returns an empty list for invalid or non-array JSON", () => {
+    expect(readGoEntriesFromManifest("{")).toEqual([]);
+    expect(readGoEntriesFromManifest("{}")).toEqual([]);
+    expect(readGoEntriesFromManifest("null")).toEqual([]);
+    expect(readGoEntriesFromManifest('""')).toEqual([]);
+  });
+
+  it("returns an empty list when the manifest contains only npm entries", () => {
+    const raw = JSON.stringify([
+      {
+        name: "left-pad",
+        version: "1.0.0",
+        license: "MIT",
+        ecosystem: "npm",
+      },
+    ]);
+
+    expect(readGoEntriesFromManifest(raw)).toEqual([]);
+  });
+
+  it("filters malformed Go entries", () => {
+    const raw = JSON.stringify([
+      {
+        name: "github.com/example/missing-license",
+        version: "v1.0.0",
+        ecosystem: "go",
+      },
+      {
+        version: "v1.0.0",
+        license: "MIT",
+        ecosystem: "go",
+      },
+    ]);
+
+    expect(readGoEntriesFromManifest(raw)).toEqual([]);
+  });
+});
+
+describe("recoverGoEntriesAfterReportFailure", () => {
+  it("prefers parseable go-licenses stdout over existing manifest entries", () => {
+    const stdout =
+      "github.com/example/stdout|||/missing/LICENSE|||https://github.com/example/stdout/blob/v1.2.3/LICENSE|||MIT\n";
+    const existingManifest = JSON.stringify([
+      {
+        name: EXISTING_GO_MODULE,
+        version: OLD_MODULE_VERSION,
+        license: APACHE_2,
+        ecosystem: "go",
+      },
+    ]);
+
+    expect(recoverGoEntriesAfterReportFailure(stdout, existingManifest)).toEqual({
+      source: "go-licenses-stdout",
+      entries: [
+        {
+          name: "github.com/example/stdout",
+          version: "v1.2.3",
+          license: "MIT",
+          repository: "https://github.com/example/stdout",
+          ecosystem: "go",
+        },
+      ],
+    });
+  });
+
+  it("reuses existing Go entries with a stale marker when stdout has no entries", () => {
+    const existingManifest = JSON.stringify([
+      {
+        name: EXISTING_GO_MODULE,
+        version: OLD_MODULE_VERSION,
+        license: APACHE_2,
+        ecosystem: "go",
+      },
+    ]);
+
+    expect(recoverGoEntriesAfterReportFailure("", existingManifest)).toEqual({
+      source: "existing-manifest",
+      entries: [
+        {
+          name: EXISTING_GO_MODULE,
+          version: OLD_MODULE_VERSION,
+          license: APACHE_2,
+          stale: true,
+          ecosystem: "go",
+        },
+      ],
+    });
+  });
+
+  it("returns null when neither stdout nor the existing manifest has Go entries", () => {
+    expect(recoverGoEntriesAfterReportFailure("", JSON.stringify([]))).toBeNull();
+    expect(recoverGoEntriesAfterReportFailure("")).toBeNull();
+  });
+});

--- a/apps/web/scripts/generate-licenses.test.ts
+++ b/apps/web/scripts/generate-licenses.test.ts
@@ -10,6 +10,7 @@ type LicenseEntry = {
   license: string;
   repository?: string;
   license_text?: string;
+  stale?: boolean;
   ecosystem: "npm" | "go";
 };
 
@@ -56,6 +57,9 @@ describe("generated/licenses.json", () => {
       }
       if (entry.license_text !== undefined) {
         expect(typeof entry.license_text).toBe("string");
+      }
+      if (entry.stale !== undefined) {
+        expect(typeof entry.stale).toBe("boolean");
       }
     }
   });

--- a/apps/web/scripts/generate-licenses.ts
+++ b/apps/web/scripts/generate-licenses.ts
@@ -17,7 +17,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 type Ecosystem = "npm" | "go";
 
@@ -27,6 +27,7 @@ interface LicenseEntry {
   license: string;
   repository?: string;
   license_text?: string;
+  stale?: boolean;
   ecosystem: Ecosystem;
 }
 
@@ -216,13 +217,96 @@ function collectGoEntries(): LicenseEntry[] {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`[licenses] warning: go-licenses failed: ${message}\n`);
-    return [];
+    const recovery = recoverGoEntriesAfterReportFailure(execStdout(err), readExistingManifest());
+    if (recovery?.source === "go-licenses-stdout") {
+      process.stderr.write(
+        `[licenses] warning: recovered ${recovery.entries.length} Go entries from go-licenses stdout.\n`,
+      );
+      return recovery.entries;
+    }
+    if (recovery?.source === "existing-manifest") {
+      process.stderr.write(
+        `[licenses] warning: reusing ${recovery.entries.length} stale Go entries from the existing manifest.\n`,
+      );
+      return recovery.entries;
+    }
+    throw new Error("go-licenses failed and no existing Go entries are available");
   } finally {
     rmSync(tmplPath, { force: true });
   }
 
-  const rows = parseGoRows(raw);
-  return rows.filter(isThirdPartyGoRow).map(toGoEntry);
+  return goEntriesFromReport(raw);
+}
+
+type GoEntryRecoverySource = "go-licenses-stdout" | "existing-manifest";
+
+interface GoEntryRecovery {
+  entries: LicenseEntry[];
+  source: GoEntryRecoverySource;
+}
+
+export function recoverGoEntriesAfterReportFailure(
+  stdout: string,
+  existingManifestRaw?: string,
+): GoEntryRecovery | null {
+  const recoveredEntries = goEntriesFromReport(stdout);
+  if (recoveredEntries.length > 0) {
+    return { entries: recoveredEntries, source: "go-licenses-stdout" };
+  }
+  const existingEntries = existingManifestRaw
+    ? markStaleGoEntries(readGoEntriesFromManifest(existingManifestRaw))
+    : [];
+  if (existingEntries.length > 0) {
+    return { entries: existingEntries, source: "existing-manifest" };
+  }
+  return null;
+}
+
+function goEntriesFromReport(raw: string): LicenseEntry[] {
+  return parseGoRows(raw).filter(isThirdPartyGoRow).map(toGoEntry);
+}
+
+function execStdout(err: unknown): string {
+  const stdout = (err as { stdout?: Buffer | string }).stdout;
+  if (typeof stdout === "string") return stdout;
+  if (Buffer.isBuffer(stdout)) return stdout.toString("utf-8");
+  return "";
+}
+
+function readExistingManifest(): string | undefined {
+  try {
+    return readFileSync(OUTPUT_FILE, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+export function readGoEntriesFromManifest(raw: string): LicenseEntry[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isLicenseEntry).filter((entry) => entry.ecosystem === "go");
+  } catch {
+    return [];
+  }
+}
+
+function isLicenseEntry(value: unknown): value is LicenseEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<Record<keyof LicenseEntry, unknown>>;
+  return (
+    typeof entry.name === "string" &&
+    typeof entry.version === "string" &&
+    typeof entry.license === "string" &&
+    (entry.ecosystem === "npm" || entry.ecosystem === "go") &&
+    (entry.repository === undefined || typeof entry.repository === "string") &&
+    (entry.license_text === undefined || typeof entry.license_text === "string") &&
+    (entry.stale === undefined || typeof entry.stale === "boolean")
+  );
+}
+
+function markStaleGoEntries(entries: LicenseEntry[]): LicenseEntry[] {
+  return entries.map((entry) => ({ ...entry, stale: true }));
 }
 
 function parseGoRows(raw: string): GoRow[] {
@@ -320,6 +404,7 @@ function mergeEntries(a: LicenseEntry, b: LicenseEntry): LicenseEntry {
     license: a.license !== UNKNOWN_LICENSE ? a.license : b.license,
     repository: a.repository ?? b.repository,
     license_text: a.license_text ?? b.license_text,
+    ...(a.stale || b.stale ? { stale: true } : {}),
     ecosystem: a.ecosystem,
   };
 }
@@ -357,4 +442,6 @@ function main(): void {
   process.stderr.write(`[licenses] wrote ${merged.length} entries -> ${OUTPUT_FILE}\n`);
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/docs/specs/system-page/spec.md
+++ b/docs/specs/system-page/spec.md
@@ -108,9 +108,10 @@ Generation is **lockfile-driven and committed to the repo**. The file is read st
 - **Generator:** `apps/web/scripts/generate-licenses.ts` — pure function of two inputs.
   - npm side: walks `pnpm-lock.yaml` via `license-checker-rseidelsohn` (or equivalent), capturing `{ name, version, licenses, repository, licenseFile }` per package.
   - Go side: resolves modules from `apps/backend/go.sum` via `go-licenses report` (or by reading vendored LICENSE files), captured into the same shape.
+  - If `go-licenses` is present but fails without producing a usable report, the generator reuses valid committed Go entries and marks them with `stale: true`; the Licenses page surfaces a stale-data warning for those entries.
   - Output: `apps/web/generated/licenses.json`, **committed to git**.
 - **Local trigger:** `pnpm licenses:gen` — devs run it after a dep bump.
-- **CI gate:** A workflow step in `.github/workflows/` runs the generator and fails the build if the result differs from the committed file. This guarantees the artifact is up to date whenever `pnpm-lock.yaml` or `go.sum` changes, without requiring it to run on every `pnpm build`.
+- **CI gate:** A workflow step in `.github/workflows/` runs the generator and warns if the result differs from the committed file. This surfaces license drift whenever `pnpm-lock.yaml` or `go.sum` changes, without requiring it to run on every `pnpm build`.
 
 The page reads the JSON statically; no backend endpoint is needed.
 


### PR DESCRIPTION
The create task dialog could read an empty last-used cache before backend settings were mirrored locally, so selectors fell back to defaults. The cache now primes before child dialog effects run, keeping the last repo, branch, executor, and agent choices intact.

## Important Changes

- Use a layout effect to mirror backend task-create defaults before dialog selection effects run.
- Harden license generation so go-licenses failures reuse valid committed Go entries with a stale marker instead of dropping the Go ecosystem from the manifest.

## Validation

- `pnpm --filter @kandev/web test -- --run components/state-provider.test.tsx`
- `pnpm --filter @kandev/web test -- --run components/task-create-dialog-effects.test.ts components/task-create-dialog-effects-executor.test.ts components/task-create-dialog-handlers.test.ts`
- `pnpm --filter @kandev/web test -- --run scripts/generate-licenses-fallback.test.ts scripts/generate-licenses.test.ts components/settings/system/licenses-list.test.tsx components/state-provider.test.tsx`
- `pnpm --filter @kandev/web licenses:gen` verified the fallback writes 84 stale Go entries; generated JSON restored afterward.
- `make fmt`
- `make typecheck test lint`
- GitHub CI: Frontend, CodeQL, Preview Environment, E2E shards, and E2E container shards passed.

## Possible Improvements

Low risk: Playwright coverage was not expanded because the dialog behavior change is effect-ordering state sync covered by component tests.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.

## Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1509-bwo7.sprites.app |
| **Commit** | `c7a972e` |
| **Agent** | Mock agent |
