### PR TITLE
fix: resync queued state on mobile resume

### DIFF
--- a/apps/web/hooks/domains/session/use-queue.test.ts
+++ b/apps/web/hooks/domains/session/use-queue.test.ts
@@ -1,0 +1,140 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { QueuedMessage } from "@/lib/state/slices/session/types";
+
+const queueApiMock = vi.hoisted(() => {
+  class QueueEntryNotFoundError extends Error {}
+  return {
+    QueueEntryNotFoundError,
+    queueMessage: vi.fn(),
+    clearQueue: vi.fn(),
+    drainQueuedMessage: vi.fn(),
+    getQueueStatus: vi.fn(),
+    updateQueuedMessage: vi.fn(),
+    removeQueuedEntry: vi.fn(),
+  };
+});
+
+type MockQueueState = {
+  queue: {
+    bySessionId: Record<string, QueuedMessage[]>;
+    metaBySessionId: Record<string, { count: number; max: number }>;
+    isLoading: Record<string, boolean>;
+  };
+  connection: { status: string };
+  setQueueEntries: ReturnType<typeof vi.fn>;
+  removeQueueEntry: ReturnType<typeof vi.fn>;
+  setQueueLoading: ReturnType<typeof vi.fn>;
+};
+
+let mockState: MockQueueState;
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: MockQueueState) => unknown) => selector(mockState),
+}));
+
+vi.mock("@/lib/api/domains/queue-api", () => queueApiMock);
+
+import { useQueue } from "./use-queue";
+
+const SESSION_ID = "sess-1";
+const TASK_ID = "task-1";
+
+function entry(overrides: Partial<QueuedMessage> = {}): QueuedMessage {
+  return {
+    id: "q-1",
+    session_id: SESSION_ID,
+    task_id: TASK_ID,
+    content: "queued prompt",
+    plan_mode: false,
+    queued_at: "2026-06-27T00:00:00Z",
+    queued_by: "user",
+    ...overrides,
+  };
+}
+
+function setDocumentVisibility(value: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value,
+  });
+}
+
+function resetMockState() {
+  mockState = {
+    queue: {
+      bySessionId: {},
+      metaBySessionId: {},
+      isLoading: {},
+    },
+    connection: { status: "connected" },
+    setQueueEntries: vi.fn(),
+    removeQueueEntry: vi.fn(),
+    setQueueLoading: vi.fn(),
+  };
+}
+
+describe("useQueue", () => {
+  beforeEach(() => {
+    resetMockState();
+    setDocumentVisibility("visible");
+    queueApiMock.getQueueStatus.mockResolvedValue({ entries: [], count: 0, max: 10 });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("refetches the queue snapshot when the WebSocket reconnects", async () => {
+    mockState.connection.status = "disconnected";
+    const { rerender } = renderHook(() => useQueue(SESSION_ID));
+
+    await act(async () => {});
+    expect(queueApiMock.getQueueStatus).not.toHaveBeenCalled();
+
+    mockState.connection.status = "connected";
+    rerender();
+
+    await waitFor(() => expect(queueApiMock.getQueueStatus).toHaveBeenCalledWith(SESSION_ID));
+    expect(mockState.setQueueEntries).toHaveBeenCalledWith(SESSION_ID, [], {
+      count: 0,
+      max: 10,
+    });
+  });
+
+  it("refetches a stale queue snapshot when a suspended tab becomes visible again", async () => {
+    mockState.queue.bySessionId[SESSION_ID] = [entry()];
+    mockState.queue.metaBySessionId[SESSION_ID] = { count: 1, max: 10 };
+    queueApiMock.getQueueStatus.mockResolvedValueOnce({
+      entries: [entry()],
+      count: 1,
+      max: 10,
+    });
+
+    renderHook(() => useQueue(SESSION_ID));
+    await waitFor(() => expect(queueApiMock.getQueueStatus).toHaveBeenCalledTimes(1));
+
+    queueApiMock.getQueueStatus.mockClear();
+    mockState.setQueueEntries.mockClear();
+    queueApiMock.getQueueStatus.mockResolvedValueOnce({ entries: [], count: 0, max: 10 });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => expect(queueApiMock.getQueueStatus).toHaveBeenCalledWith(SESSION_ID));
+    expect(mockState.setQueueEntries).toHaveBeenCalledWith(SESSION_ID, [], {
+      count: 0,
+      max: 10,
+    });
+  });
+
+  it("does not refetch on foreground visibility while disconnected", async () => {
+    mockState.connection.status = "disconnected";
+    renderHook(() => useQueue(SESSION_ID));
+
+    await act(async () => {});
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(queueApiMock.getQueueStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hooks/domains/session/use-queue.ts
+++ b/apps/web/hooks/domains/session/use-queue.ts
@@ -178,6 +178,7 @@ function useQueueActions({
 export function useQueue(sessionId: string | null) {
   const state = useQueueState(sessionId);
   const { entries, meta, isLoading } = state;
+  const connectionStatus = useAppStore((appState) => appState.connection.status);
   const { refetch, queue, clearAll, drainNext, editEntry, removeEntry } = useQueueActions({
     sessionId,
     setQueueEntries: state.setQueueEntries,
@@ -188,10 +189,24 @@ export function useQueue(sessionId: string | null) {
 
   useEffect(() => {
     if (!sessionId) return;
+    if (connectionStatus !== "connected") return;
     void refetch(sessionId).catch((err) => {
       console.error("Failed to fetch queue status:", err);
     });
-  }, [sessionId, refetch]);
+  }, [sessionId, connectionStatus, refetch]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    const refetchOnVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      if (connectionStatus !== "connected") return;
+      void refetch(sessionId).catch((err) => {
+        console.error("Failed to fetch queue status after visibility change:", err);
+      });
+    };
+    document.addEventListener("visibilitychange", refetchOnVisible);
+    return () => document.removeEventListener("visibilitychange", refetchOnVisible);
+  }, [sessionId, connectionStatus, refetch]);
 
   const refetchBound = useCallback(
     () => (sessionId ? refetch(sessionId) : Promise.resolve()),

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -60,6 +60,14 @@ function resetMockState() {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
 describe("useTaskSessions", () => {
   beforeEach(() => {
     resetMockState();
@@ -178,6 +186,38 @@ describe("useTaskSessions refreshes", () => {
     await waitFor(() => expect(resolved).toBe(true));
     await queuedReload;
     expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
+
+  it("waits for the follow-up forced reload when another forced reload is running", async () => {
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    mockState.setTaskSessionsLoading.mockImplementation((id: string, loading: boolean) => {
+      mockState.taskSessionsByTask.loadingByTaskId[id] = loading;
+    });
+    const firstResponse = deferred<{ sessions: TaskSession[] }>();
+    apiMock.listTaskSessions
+      .mockReturnValueOnce(firstResponse.promise)
+      .mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    const { result, rerender } = renderHook(() => useTaskSessions(TASK_ID));
+    const firstReload = result.current.loadSessions(true);
+    rerender();
+    let queuedResolved = false;
+    const queuedReload = result.current.loadSessions(true).then(() => {
+      queuedResolved = true;
+    });
+
+    firstResponse.resolve({ sessions: [session("old", "RUNNING")] });
+    await firstReload;
+    rerender();
+
+    expect(queuedResolved).toBe(false);
+    await waitFor(() => expect(queuedResolved).toBe(true));
+    await queuedReload;
+    expect(apiMock.listTaskSessions).toHaveBeenCalledTimes(2);
+    expect(mockState.setTaskSessionsForTask).toHaveBeenLastCalledWith(TASK_ID, [
       session("old", "COMPLETED"),
     ]);
   });

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -72,7 +72,20 @@ describe("useTaskSessions", () => {
     vi.clearAllMocks();
   });
 
-  it("loads sessions on mount once connected", async () => {
+  it("loads sessions on mount", async () => {
+    renderHook(() => useTaskSessions(TASK_ID));
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [session("sess-1")]);
+  });
+
+  it("loads sessions on mount when the WebSocket is disconnected", async () => {
+    mockState.connection.status = "disconnected";
+
     renderHook(() => useTaskSessions(TASK_ID));
 
     await waitFor(() =>

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -133,10 +133,12 @@ describe("useTaskSessions refreshes", () => {
   });
 
   it("preserves a loaded session list when a reconnect refetch fails", async () => {
+    const error = new Error("network down");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     mockState.connection.status = "disconnected";
     mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
     mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
-    apiMock.listTaskSessions.mockRejectedValueOnce(new Error("network down"));
+    apiMock.listTaskSessions.mockRejectedValueOnce(error);
 
     const { rerender } = renderHook(() => useTaskSessions(TASK_ID));
     await act(async () => {});
@@ -150,6 +152,7 @@ describe("useTaskSessions refreshes", () => {
       }),
     );
     expect(mockState.setTaskSessionsForTask).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith("Failed to load task sessions:", error);
   });
 });
 

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -95,6 +95,19 @@ describe("useTaskSessions", () => {
     );
     expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [session("sess-1")]);
   });
+});
+
+describe("useTaskSessions refreshes", () => {
+  beforeEach(() => {
+    resetMockState();
+    setDocumentVisibility("visible");
+    apiMock.listTaskSessions.mockResolvedValue({ sessions: [session("sess-1")] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
 
   it("refetches a loaded session list when the WebSocket reconnects", async () => {
     mockState.connection.status = "disconnected";
@@ -117,6 +130,39 @@ describe("useTaskSessions", () => {
     expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
       session("old", "COMPLETED"),
     ]);
+  });
+
+  it("preserves a loaded session list when a reconnect refetch fails", async () => {
+    mockState.connection.status = "disconnected";
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockRejectedValueOnce(new Error("network down"));
+
+    const { rerender } = renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+
+    mockState.connection.status = "connected";
+    rerender();
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("useTaskSessions foreground refreshes", () => {
+  beforeEach(() => {
+    resetMockState();
+    setDocumentVisibility("visible");
+    apiMock.listTaskSessions.mockResolvedValue({ sessions: [session("sess-1")] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
   });
 
   it("refetches a loaded session list when a suspended tab becomes visible again", async () => {
@@ -167,15 +213,23 @@ describe("useTaskSessions", () => {
     ]);
   });
 
-  it("does not refetch a loaded session list on foreground visibility while disconnected", async () => {
+  it("refetches a loaded session list on foreground visibility while disconnected", async () => {
     mockState.connection.status = "disconnected";
     mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
     mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
 
     renderHook(() => useTaskSessions(TASK_ID));
     await act(async () => {});
     document.dispatchEvent(new Event("visibilitychange"));
 
-    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
   });
 });

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -154,6 +154,33 @@ describe("useTaskSessions refreshes", () => {
     expect(mockState.setTaskSessionsForTask).not.toHaveBeenCalled();
     expect(consoleError).toHaveBeenCalledWith("Failed to load task sessions:", error);
   });
+
+  it("resolves a queued forced reload after the deferred request finishes", async () => {
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    const { result, rerender } = renderHook(() => useTaskSessions(TASK_ID));
+    let resolved = false;
+    const queuedReload = result.current.loadSessions(true).then(() => {
+      resolved = true;
+    });
+    await act(async () => {});
+    expect(resolved).toBe(false);
+    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = false;
+    await act(async () => {
+      rerender();
+    });
+
+    await waitFor(() => expect(resolved).toBe(true));
+    await queuedReload;
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
 });
 
 describe("useTaskSessions foreground refreshes", () => {

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -191,6 +191,33 @@ describe("useTaskSessions refreshes", () => {
       session("old", "COMPLETED"),
     ]);
   });
+
+  it("queues a reconnect resync while the initial load is still running", async () => {
+    mockState.connection.status = "disconnected";
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    const { rerender } = renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+    mockState.connection.status = "connected";
+    rerender();
+
+    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = false;
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    await act(async () => {
+      rerender();
+    });
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
 });
 
 describe("useTaskSessions queued refreshes", () => {

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -1,0 +1,141 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TaskSession } from "@/lib/types/http";
+import { sessionId, taskId } from "@/lib/types/ids";
+
+const apiMock = vi.hoisted(() => ({
+  listTaskSessions: vi.fn(),
+}));
+
+type MockTaskSessionsState = {
+  taskSessionsByTask: {
+    itemsByTaskId: Record<string, TaskSession[]>;
+    loadingByTaskId: Record<string, boolean>;
+    loadedByTaskId: Record<string, boolean>;
+  };
+  connection: { status: string };
+  setTaskSessionsForTask: ReturnType<typeof vi.fn>;
+  setTaskSessionsLoading: ReturnType<typeof vi.fn>;
+};
+
+let mockState: MockTaskSessionsState;
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: MockTaskSessionsState) => unknown) => selector(mockState),
+}));
+
+vi.mock("@/lib/api", () => apiMock);
+
+import { useTaskSessions } from "./use-task-sessions";
+
+const TASK_ID = taskId("task-1");
+
+function session(id: string, state: TaskSession["state"] = "RUNNING"): TaskSession {
+  return {
+    id: sessionId(id),
+    task_id: TASK_ID,
+    state,
+    started_at: "2026-06-27T00:00:00Z",
+    updated_at: "2026-06-27T00:00:00Z",
+  };
+}
+
+function setDocumentVisibility(value: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value,
+  });
+}
+
+function resetMockState() {
+  mockState = {
+    taskSessionsByTask: {
+      itemsByTaskId: {},
+      loadingByTaskId: {},
+      loadedByTaskId: {},
+    },
+    connection: { status: "connected" },
+    setTaskSessionsForTask: vi.fn(),
+    setTaskSessionsLoading: vi.fn(),
+  };
+}
+
+describe("useTaskSessions", () => {
+  beforeEach(() => {
+    resetMockState();
+    setDocumentVisibility("visible");
+    apiMock.listTaskSessions.mockResolvedValue({ sessions: [session("sess-1")] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("loads sessions on mount once connected", async () => {
+    renderHook(() => useTaskSessions(TASK_ID));
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [session("sess-1")]);
+  });
+
+  it("refetches a loaded session list when the WebSocket reconnects", async () => {
+    mockState.connection.status = "disconnected";
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    const { rerender } = renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+
+    mockState.connection.status = "connected";
+    rerender();
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
+
+  it("refetches a loaded session list when a suspended tab becomes visible again", async () => {
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
+
+  it("does not refetch a loaded session list on foreground visibility while disconnected", async () => {
+    mockState.connection.status = "disconnected";
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+
+    renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -77,6 +77,7 @@ describe("useTaskSessions", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -114,6 +115,7 @@ describe("useTaskSessions refreshes", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -189,6 +191,20 @@ describe("useTaskSessions refreshes", () => {
       session("old", "COMPLETED"),
     ]);
   });
+});
+
+describe("useTaskSessions queued refreshes", () => {
+  beforeEach(() => {
+    resetMockState();
+    setDocumentVisibility("visible");
+    apiMock.listTaskSessions.mockResolvedValue({ sessions: [session("sess-1")] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
 
   it("waits for the follow-up forced reload when another forced reload is running", async () => {
     mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
@@ -232,6 +248,7 @@ describe("useTaskSessions foreground refreshes", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -127,6 +127,33 @@ describe("useTaskSessions", () => {
     ]);
   });
 
+  it("runs a forced foreground refetch after an older request finishes", async () => {
+    mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    const { rerender } = renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+    document.dispatchEvent(new Event("visibilitychange"));
+    await act(async () => {});
+    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = false;
+    await act(async () => {
+      rerender();
+    });
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
+
   it("does not refetch a loaded session list on foreground visibility while disconnected", async () => {
     mockState.connection.status = "disconnected";
     mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];

--- a/apps/web/hooks/use-task-sessions.test.ts
+++ b/apps/web/hooks/use-task-sessions.test.ts
@@ -327,6 +327,32 @@ describe("useTaskSessions foreground refreshes", () => {
     ]);
   });
 
+  it("queues a foreground refetch while the initial load is running", async () => {
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = true;
+    apiMock.listTaskSessions.mockResolvedValueOnce({ sessions: [session("old", "COMPLETED")] });
+
+    const { rerender } = renderHook(() => useTaskSessions(TASK_ID));
+    await act(async () => {});
+    document.dispatchEvent(new Event("visibilitychange"));
+    await act(async () => {});
+    expect(apiMock.listTaskSessions).not.toHaveBeenCalled();
+
+    mockState.taskSessionsByTask.loadingByTaskId[TASK_ID] = false;
+    mockState.taskSessionsByTask.loadedByTaskId[TASK_ID] = true;
+    await act(async () => {
+      rerender();
+    });
+
+    await waitFor(() =>
+      expect(apiMock.listTaskSessions).toHaveBeenCalledWith(TASK_ID, {
+        cache: "no-store",
+      }),
+    );
+    expect(mockState.setTaskSessionsForTask).toHaveBeenCalledWith(TASK_ID, [
+      session("old", "COMPLETED"),
+    ]);
+  });
+
   it("refetches a loaded session list on foreground visibility while disconnected", async () => {
     mockState.connection.status = "disconnected";
     mockState.taskSessionsByTask.itemsByTaskId[TASK_ID] = [session("old", "RUNNING")];

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -34,7 +34,7 @@ export function useTaskSessions(taskId: string | null) {
         const sessions = response.sessions ?? [];
         setTaskSessionsForTask(taskId, sessions);
       } catch {
-        setTaskSessionsForTask(taskId, []);
+        if (!force) setTaskSessionsForTask(taskId, []);
       } finally {
         setTaskSessionsLoading(taskId, false);
       }
@@ -53,11 +53,11 @@ export function useTaskSessions(taskId: string | null) {
   }, [taskId]);
 
   useEffect(() => {
-    if (!taskId || isLoading || connectionStatus !== "connected") return;
+    if (!taskId || isLoading) return;
     if (!pendingForcedReloadRef.current) return;
     pendingForcedReloadRef.current = false;
     void loadSessions(true);
-  }, [connectionStatus, isLoading, loadSessions, taskId]);
+  }, [isLoading, loadSessions, taskId]);
 
   const previousConnectionStatusRef = useRef(connectionStatus);
   useEffect(() => {
@@ -73,13 +73,12 @@ export function useTaskSessions(taskId: string | null) {
     if (!taskId) return;
     const refetchOnVisible = () => {
       if (document.visibilityState !== "visible") return;
-      if (connectionStatus !== "connected") return;
       if (!isLoaded) return;
       void loadSessions(true);
     };
     document.addEventListener("visibilitychange", refetchOnVisible);
     return () => document.removeEventListener("visibilitychange", refetchOnVisible);
-  }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
+  }, [isLoaded, isLoading, loadSessions, taskId]);
 
   return { sessions, isLoading, isLoaded, loadSessions };
 }

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -18,11 +18,15 @@ export function useTaskSessions(taskId: string | null) {
   const setTaskSessionsForTask = useAppStore((state) => state.setTaskSessionsForTask);
   const setTaskSessionsLoading = useAppStore((state) => state.setTaskSessionsLoading);
   const connectionStatus = useAppStore((state) => state.connection.status);
+  const pendingForcedReloadRef = useRef(false);
 
   const loadSessions = useCallback(
     async (force = false) => {
       if (!taskId) return;
-      if (isLoading) return;
+      if (isLoading) {
+        if (force) pendingForcedReloadRef.current = true;
+        return;
+      }
       if (!force && isLoaded) return;
       setTaskSessionsLoading(taskId, true);
       try {
@@ -45,13 +49,24 @@ export function useTaskSessions(taskId: string | null) {
     loadSessions();
   }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
 
+  useEffect(() => {
+    pendingForcedReloadRef.current = false;
+  }, [taskId]);
+
+  useEffect(() => {
+    if (!taskId || isLoading || connectionStatus !== "connected") return;
+    if (!pendingForcedReloadRef.current) return;
+    pendingForcedReloadRef.current = false;
+    void loadSessions(true);
+  }, [connectionStatus, isLoading, loadSessions, taskId]);
+
   const previousConnectionStatusRef = useRef(connectionStatus);
   useEffect(() => {
     const previous = previousConnectionStatusRef.current;
     previousConnectionStatusRef.current = connectionStatus;
     if (!taskId) return;
     if (connectionStatus !== "connected" || previous === "connected") return;
-    if (!isLoaded || isLoading) return;
+    if (!isLoaded) return;
     void loadSessions(true);
   }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
 
@@ -60,7 +75,7 @@ export function useTaskSessions(taskId: string | null) {
     const refetchOnVisible = () => {
       if (document.visibilityState !== "visible") return;
       if (connectionStatus !== "connected") return;
-      if (!isLoaded || isLoading) return;
+      if (!isLoaded) return;
       void loadSessions(true);
     };
     document.addEventListener("visibilitychange", refetchOnVisible);

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -19,12 +19,18 @@ export function useTaskSessions(taskId: string | null) {
   const setTaskSessionsLoading = useAppStore((state) => state.setTaskSessionsLoading);
   const connectionStatus = useAppStore((state) => state.connection.status);
   const pendingForcedReloadRef = useRef(false);
+  const pendingForcedReloadWaitersRef = useRef<Array<() => void>>([]);
 
   const loadSessions = useCallback(
     async (force = false) => {
       if (!taskId) return;
       if (isLoading) {
-        if (force) pendingForcedReloadRef.current = true;
+        if (force) {
+          pendingForcedReloadRef.current = true;
+          return new Promise<void>((resolve) => {
+            pendingForcedReloadWaitersRef.current.push(resolve);
+          });
+        }
         return;
       }
       if (!force && isLoaded) return;
@@ -38,6 +44,10 @@ export function useTaskSessions(taskId: string | null) {
         if (!force) setTaskSessionsForTask(taskId, []);
       } finally {
         setTaskSessionsLoading(taskId, false);
+        if (force) {
+          const waiters = pendingForcedReloadWaitersRef.current.splice(0);
+          waiters.forEach((resolve) => resolve());
+        }
       }
     },
     [isLoaded, isLoading, setTaskSessionsForTask, setTaskSessionsLoading, taskId],
@@ -51,6 +61,8 @@ export function useTaskSessions(taskId: string | null) {
 
   useEffect(() => {
     pendingForcedReloadRef.current = false;
+    const waiters = pendingForcedReloadWaitersRef.current.splice(0);
+    waiters.forEach((resolve) => resolve());
   }, [taskId]);
 
   useEffect(() => {

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -89,7 +89,10 @@ export function useTaskSessions(taskId: string | null) {
     if (!taskId) return;
     const refetchOnVisible = () => {
       if (document.visibilityState !== "visible") return;
-      if (!isLoaded) return;
+      if (!isLoaded) {
+        if (isLoading) void loadSessions(true);
+        return;
+      }
       void loadSessions(true);
     };
     document.addEventListener("visibilitychange", refetchOnVisible);

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -33,7 +33,8 @@ export function useTaskSessions(taskId: string | null) {
         const response = await listTaskSessions(taskId, { cache: "no-store" });
         const sessions = response.sessions ?? [];
         setTaskSessionsForTask(taskId, sessions);
-      } catch {
+      } catch (error) {
+        console.error("Failed to load task sessions:", error);
         if (!force) setTaskSessionsForTask(taskId, []);
       } finally {
         setTaskSessionsLoading(taskId, false);

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -78,7 +78,10 @@ export function useTaskSessions(taskId: string | null) {
     previousConnectionStatusRef.current = connectionStatus;
     if (!taskId) return;
     if (connectionStatus !== "connected" || previous === "connected") return;
-    if (!isLoaded) return;
+    if (!isLoaded) {
+      if (isLoading) void loadSessions(true);
+      return;
+    }
     void loadSessions(true);
   }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
 

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -44,10 +44,9 @@ export function useTaskSessions(taskId: string | null) {
 
   useEffect(() => {
     if (!taskId) return;
-    if (connectionStatus !== "connected") return;
     if (isLoaded || isLoading) return;
     loadSessions();
-  }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
+  }, [isLoaded, isLoading, loadSessions, taskId]);
 
   useEffect(() => {
     pendingForcedReloadRef.current = false;

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useAppStore } from "@/components/state-provider";
 import { listTaskSessions } from "@/lib/api";
 import type { TaskSession } from "@/lib/types/http";
@@ -17,11 +17,13 @@ export function useTaskSessions(taskId: string | null) {
   );
   const setTaskSessionsForTask = useAppStore((state) => state.setTaskSessionsForTask);
   const setTaskSessionsLoading = useAppStore((state) => state.setTaskSessionsLoading);
+  const connectionStatus = useAppStore((state) => state.connection.status);
 
   const loadSessions = useCallback(
     async (force = false) => {
       if (!taskId) return;
-      if (!force && (isLoading || isLoaded)) return;
+      if (isLoading) return;
+      if (!force && isLoaded) return;
       setTaskSessionsLoading(taskId, true);
       try {
         const response = await listTaskSessions(taskId, { cache: "no-store" });
@@ -38,9 +40,32 @@ export function useTaskSessions(taskId: string | null) {
 
   useEffect(() => {
     if (!taskId) return;
+    if (connectionStatus !== "connected") return;
     if (isLoaded || isLoading) return;
     loadSessions();
-  }, [isLoaded, isLoading, loadSessions, taskId]);
+  }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
+
+  const previousConnectionStatusRef = useRef(connectionStatus);
+  useEffect(() => {
+    const previous = previousConnectionStatusRef.current;
+    previousConnectionStatusRef.current = connectionStatus;
+    if (!taskId) return;
+    if (connectionStatus !== "connected" || previous === "connected") return;
+    if (!isLoaded || isLoading) return;
+    void loadSessions(true);
+  }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
+
+  useEffect(() => {
+    if (!taskId) return;
+    const refetchOnVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      if (connectionStatus !== "connected") return;
+      if (!isLoaded || isLoading) return;
+      void loadSessions(true);
+    };
+    document.addEventListener("visibilitychange", refetchOnVisible);
+    return () => document.removeEventListener("visibilitychange", refetchOnVisible);
+  }, [connectionStatus, isLoaded, isLoading, loadSessions, taskId]);
 
   return { sessions, isLoading, isLoaded, loadSessions };
 }

--- a/apps/web/hooks/use-task-sessions.ts
+++ b/apps/web/hooks/use-task-sessions.ts
@@ -44,7 +44,7 @@ export function useTaskSessions(taskId: string | null) {
         if (!force) setTaskSessionsForTask(taskId, []);
       } finally {
         setTaskSessionsLoading(taskId, false);
-        if (force) {
+        if (force && !pendingForcedReloadRef.current) {
           const waiters = pendingForcedReloadWaitersRef.current.splice(0);
           waiters.forEach((resolve) => resolve());
         }


### PR DESCRIPTION
Mobile PWAs could miss session-scoped queue drain notifications while suspended, leaving stale queued-message badges after another client completed the turn. The affected queue and session-list hooks now refresh authoritative snapshots on reconnect and foreground resume.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm typecheck` from `apps/web`
- `pnpm lint` from `apps/web`
- `pnpm test -- hooks/domains/session/use-queue.test.ts hooks/use-task-sessions.test.ts components/task/chat/queued-ghost-list.test.tsx lib/ws/handlers/agent-session.test.ts lib/state/slices/session/session-slice.upsert.test.ts components/task/mobile/session-mobile-layout.test.tsx` from `apps/web`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->