### PR TITLE
fix: improve mobile kanban controls

### DIFF
--- a/apps/web/components/kanban/mobile-menu-sheet.tsx
+++ b/apps/web/components/kanban/mobile-menu-sheet.tsx
@@ -1,12 +1,20 @@
 "use client";
 
+import { useRef } from "react";
 import { useRouter } from "@/lib/routing/client-router";
+import Link from "@/components/routing/app-link";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@kandev/ui/sheet";
 import { Button } from "@kandev/ui/button";
 import { Checkbox } from "@kandev/ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@kandev/ui/toggle-group";
-import { IconAlertTriangle, IconLayoutKanban, IconList, IconTimeline } from "@tabler/icons-react";
+import {
+  IconAlertTriangle,
+  IconLayoutKanban,
+  IconList,
+  IconSettings,
+  IconTimeline,
+} from "@tabler/icons-react";
 import { TaskSearchInput } from "./task-search-input";
 import { useKanbanDisplaySettings } from "@/hooks/use-kanban-display-settings";
 import { linkToTasks } from "@/lib/links";
@@ -210,20 +218,26 @@ function MobileUtilityActions({
     onOpenHealthDialog();
   };
 
-  if (!showHealthIndicator) return null;
-
   return (
     <div className="mt-auto flex flex-col gap-3 pt-4 border-t border-border">
       <div className="text-sm font-medium">Utilities</div>
-      <Button
-        type="button"
-        variant="outline"
-        className="w-full cursor-pointer justify-start gap-2"
-        onClick={openHealth}
-      >
-        <IconAlertTriangle className="h-4 w-4 text-warning" />
-        Health issues
+      <Button asChild variant="outline" className="w-full cursor-pointer justify-start gap-2">
+        <Link href="/settings" onClick={closeSheet}>
+          <IconSettings className="h-4 w-4" />
+          Settings
+        </Link>
       </Button>
+      {showHealthIndicator && (
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full cursor-pointer justify-start gap-2"
+          onClick={openHealth}
+        >
+          <IconAlertTriangle className="h-4 w-4 text-warning" />
+          Health issues
+        </Button>
+      )}
     </div>
   );
 }
@@ -239,6 +253,7 @@ export function MobileMenuSheet({
   showHealthIndicator,
   onOpenHealthDialog,
 }: MobileMenuSheetProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
   const {
     workflows,
@@ -276,7 +291,16 @@ export function MobileMenuSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full sm:max-w-sm overflow-y-auto">
+      <SheetContent
+        ref={contentRef}
+        side="right"
+        tabIndex={-1}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          contentRef.current?.focus({ preventScroll: true });
+        }}
+        className="w-full sm:max-w-sm overflow-y-auto outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
         <SheetHeader>
           <SheetTitle>Menu</SheetTitle>
         </SheetHeader>

--- a/apps/web/components/kanban/task-search-input.tsx
+++ b/apps/web/components/kanban/task-search-input.tsx
@@ -88,7 +88,7 @@ export function TaskSearchInput({
         value={localValue}
         onChange={handleChange}
         placeholder={placeholder}
-        className="pl-8 pr-8 w-full border border-border"
+        className="pl-8 pr-8 w-full border border-border text-[16px] md:text-[16px] lg:text-xs/relaxed"
       />
       {localValue && !isLoading && (
         <button

--- a/apps/web/components/system-metrics/topbar-metrics.test.tsx
+++ b/apps/web/components/system-metrics/topbar-metrics.test.tsx
@@ -119,7 +119,10 @@ describe("TopbarMetrics", () => {
   it("renders a compact metrics pill on mobile when enabled", () => {
     renderMetrics(initialState(true));
 
-    expect(screen.getByTestId("mobile-topbar-metrics")).toBeTruthy();
+    const metrics = screen.getByTestId("mobile-topbar-metrics");
+    expect(metrics).toBeTruthy();
+    expect(metrics.className.split(/\s+/)).not.toContain("border");
+    expect(metrics.className.split(/\s+/)).not.toContain("border-border");
     expect(screen.getByLabelText("CPU 42%")).toBeTruthy();
     expect(screen.getByLabelText("Memory 68%")).toBeTruthy();
     expect(screen.queryByLabelText("Disk 12%")).toBeNull();

--- a/apps/web/components/system-metrics/topbar-metrics.tsx
+++ b/apps/web/components/system-metrics/topbar-metrics.tsx
@@ -32,7 +32,7 @@ export function TopbarMetrics({ activeSessionId }: TopbarMetricsProps) {
   const sources = selectSources(snapshot?.sources ?? [], activeSessionId);
   if (sources.length === 0) {
     return (
-      <div className="flex h-8 items-center gap-1 rounded border border-border px-2 text-xs text-muted-foreground md:h-7">
+      <div className="flex h-8 items-center gap-1 rounded px-2 text-xs text-muted-foreground md:h-7 md:border md:border-border">
         <IconActivity className="h-3.5 w-3.5" />
         <span className="hidden sm:inline">Metrics</span>
       </div>
@@ -107,7 +107,7 @@ function CompactSourceMetrics({
 
   return (
     <div
-      className="flex h-9 max-w-[34vw] items-center gap-1 overflow-hidden rounded border border-border px-1.5 text-xs"
+      className="flex h-9 max-w-[34vw] items-center gap-1 overflow-hidden rounded px-1.5 text-xs"
       data-testid="mobile-topbar-metrics"
     >
       <SourceBadge source={source} updatedAt={updatedAt} />

--- a/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
+++ b/apps/web/e2e/tests/kanban/mobile-kanban.spec.ts
@@ -88,6 +88,29 @@ test.describe("Mobile kanban view", () => {
     await expect(testPage.getByText("Display Options")).toBeVisible();
   });
 
+  test("mobile menu exposes settings navigation", async ({ testPage }) => {
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    await mobile.mobileMenuButton.click();
+    await testPage.getByRole("link", { name: "Settings" }).click();
+
+    await expect(testPage).toHaveURL(/\/settings(?:\/general)?$/);
+    await expect(testPage.getByRole("link", { name: /Appearance/ })).toBeVisible();
+  });
+
+  test("opening mobile menu does not focus task search", async ({ testPage }) => {
+    const mobile = new MobileKanbanPage(testPage);
+    await mobile.goto();
+
+    await mobile.mobileMenuButton.click();
+    const dialog = testPage.getByRole("dialog", { name: "Menu" });
+    const searchInput = dialog.getByPlaceholder("Search tasks...");
+
+    await expect(searchInput).toBeVisible();
+    await expect(searchInput).not.toBeFocused();
+  });
+
   test("opens missing git health issue from mobile menu", async ({ testPage, backend }) => {
     await testPage.route(`${backend.baseUrl}/api/v1/system/health`, (route) =>
       route.fulfill({


### PR DESCRIPTION
Mobile kanban controls were missing settings access and had a few iOS-specific visual/focus regressions, making the mobile task workflow feel cramped and unstable. The mobile menu now exposes Settings without opening the keyboard, search avoids iOS focus zoom, and topbar resource metrics no longer draw the crowded mobile border.

## Validation

- `pnpm --filter @kandev/web test -- components/system-metrics/topbar-metrics.test.tsx`
- `pnpm --filter @kandev/web lint -- components/system-metrics/topbar-metrics.tsx components/system-metrics/topbar-metrics.test.tsx`
- `pnpm e2e:run tests/kanban/mobile-kanban.spec.ts -- --project=mobile-chrome --grep "mobile menu exposes settings navigation|opening mobile menu does not focus task search"`
- `pnpm --filter @kandev/web lint -- components/kanban/mobile-menu-sheet.tsx e2e/tests/kanban/mobile-kanban.spec.ts`
- `pnpm --filter @kandev/web lint -- components/kanban/task-search-input.tsx e2e/tests/mobile-zoom.spec.ts`
- `pnpm e2e:run tests/mobile-zoom.spec.ts -- --project=mobile-chrome`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->