### PR TITLE
fix: preserve pinned task sessions

### DIFF
--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -621,9 +621,13 @@ describe("runAutoSessionTabEffect", () => {
       prevSessionIdRef: { current: "session-old" as string | null },
     };
 
+    const previousApi = useDockviewStore.getState().api;
     useDockviewStore.setState({ api });
-    runAutoSessionTabEffect("session-pending", appStore as never, refs as never);
-    useDockviewStore.setState({ api: null });
+    try {
+      runAutoSessionTabEffect("session-pending", appStore as never, refs as never);
+    } finally {
+      useDockviewStore.setState({ api: previousApi });
+    }
 
     expect(refs.prevTaskIdRef.current).toBe("task-A");
     expect(refs.prevSessionIdRef.current).toBe("session-pending");

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -38,6 +38,8 @@ const PENDING_SESSION_ID = "session-new";
 const TEST_GROUP_CENTER = "group-center";
 const CENTER_POSITION = "center";
 const SIBLING_PANEL = "session:sibling";
+const AUTO_TASK_ID = "task-A";
+const PENDING_EFFECT_SESSION_ID = "session-pending";
 
 /**
  * Builds a fake DockviewApi where `panel.api.close()` mutates the underlying
@@ -64,6 +66,48 @@ function makeApi(panelIds: string[]): { api: DockviewApi; panels: FakePanel[] } 
     getPanel: (id: string) => panels.find((p) => p.id === id) ?? null,
   } as unknown as DockviewApi;
   return { api, panels };
+}
+
+function makeAutoSessionAppStore(taskId: string | null, sessionIds: string[]) {
+  const itemsByTaskId = taskId ? { [taskId]: sessionIds.map((id) => ({ id })) } : {};
+  return {
+    getState: () => ({
+      tasks: { activeTaskId: taskId },
+      taskSessionsByTask: { itemsByTaskId },
+    }),
+  };
+}
+
+function makeAutoSessionRefs(
+  prevTaskId = "task-old",
+  prevSessionId: string | null = "session-old",
+) {
+  return {
+    sessionTabCreatedRef: { current: new Set<string>() },
+    prevTaskIdRef: { current: prevTaskId as string | null },
+    prevSessionIdRef: { current: prevSessionId },
+  };
+}
+
+function withDockviewState<T>(
+  updates: Partial<ReturnType<typeof useDockviewStore.getState>>,
+  callback: () => T,
+): T {
+  const previous = useDockviewStore.getState();
+  useDockviewStore.setState(updates);
+  try {
+    return callback();
+  } finally {
+    useDockviewStore.setState({
+      api: previous.api,
+      buildDefaultLayout: previous.buildDefaultLayout,
+      currentLayoutEnvId: previous.currentLayoutEnvId,
+      preMaximizeLayout: previous.preMaximizeLayout,
+      pinnedWidths: previous.pinnedWidths,
+      maximizedGroupId: previous.maximizedGroupId,
+      isRestoringLayout: previous.isRestoringLayout,
+    });
+  }
 }
 
 function makePositionApi(args: {
@@ -609,27 +653,59 @@ describe("runAutoSessionTabEffect", () => {
       panels: [{ id: "chat" }],
       getPanel: (id: string) => (id === "chat" ? { id: "chat" } : null),
     } as unknown as DockviewApi;
-    const appStore = {
-      getState: () => ({
-        tasks: { activeTaskId: "task-A" },
-        taskSessionsByTask: { itemsByTaskId: { "task-A": [] } },
-      }),
-    };
-    const refs = {
-      sessionTabCreatedRef: { current: new Set<string>() },
-      prevTaskIdRef: { current: "task-old" as string | null },
-      prevSessionIdRef: { current: "session-old" as string | null },
-    };
+    const appStore = makeAutoSessionAppStore(AUTO_TASK_ID, []);
+    const refs = makeAutoSessionRefs();
 
-    const previousApi = useDockviewStore.getState().api;
-    useDockviewStore.setState({ api });
-    try {
-      runAutoSessionTabEffect("session-pending", appStore as never, refs as never);
-    } finally {
-      useDockviewStore.setState({ api: previousApi });
-    }
+    withDockviewState({ api }, () => {
+      runAutoSessionTabEffect(PENDING_EFFECT_SESSION_ID, appStore as never, refs as never);
+    });
 
-    expect(refs.prevTaskIdRef.current).toBe("task-A");
-    expect(refs.prevSessionIdRef.current).toBe("session-pending");
+    expect(refs.prevTaskIdRef.current).toBe(AUTO_TASK_ID);
+    expect(refs.prevSessionIdRef.current).toBe(PENDING_EFFECT_SESSION_ID);
+  });
+
+  it("updates previous refs when releasing default layout for a pending session", () => {
+    const api = {
+      panels: [],
+      getPanel: () => null,
+    } as unknown as DockviewApi;
+    const buildDefaultLayout = vi.fn();
+    const appStore = makeAutoSessionAppStore(AUTO_TASK_ID, []);
+    const refs = makeAutoSessionRefs();
+
+    withDockviewState(
+      {
+        api,
+        buildDefaultLayout,
+        currentLayoutEnvId: null,
+        preMaximizeLayout: null,
+        pinnedWidths: new Map(),
+        maximizedGroupId: null,
+        isRestoringLayout: false,
+      },
+      () => {
+        runAutoSessionTabEffect(PENDING_EFFECT_SESSION_ID, appStore as never, refs as never);
+      },
+    );
+
+    expect(buildDefaultLayout).toHaveBeenCalledWith(api);
+    expect(refs.prevTaskIdRef.current).toBe(AUTO_TASK_ID);
+    expect(refs.prevSessionIdRef.current).toBe(PENDING_EFFECT_SESSION_ID);
+  });
+
+  it("updates previous refs when there is no effective session", () => {
+    const api = {
+      panels: [],
+      getPanel: () => null,
+    } as unknown as DockviewApi;
+    const appStore = makeAutoSessionAppStore(AUTO_TASK_ID, []);
+    const refs = makeAutoSessionRefs();
+
+    withDockviewState({ api }, () => {
+      runAutoSessionTabEffect(null, appStore as never, refs as never);
+    });
+
+    expect(refs.prevTaskIdRef.current).toBe(AUTO_TASK_ID);
+    expect(refs.prevSessionIdRef.current).toBeNull();
   });
 });

--- a/apps/web/components/task/dockview-session-tabs.test.ts
+++ b/apps/web/components/task/dockview-session-tabs.test.ts
@@ -7,6 +7,7 @@ import {
   reconcileRemovedSessionPanels,
   resolveInitialPosition,
   resolveSessionTabSyncTarget,
+  runAutoSessionTabEffect,
   shouldActivateSessionPanel,
   shouldRebuildDefaultForPendingSession,
 } from "./dockview-session-tabs";
@@ -599,5 +600,32 @@ describe("shouldActivateSessionPanel", () => {
         currentActivePanelId: "preview:commit-detail",
       }),
     ).toBe(false);
+  });
+});
+
+describe("runAutoSessionTabEffect", () => {
+  it("updates previous refs when panel ensure is skipped for an unhydrated session", () => {
+    const api = {
+      panels: [{ id: "chat" }],
+      getPanel: (id: string) => (id === "chat" ? { id: "chat" } : null),
+    } as unknown as DockviewApi;
+    const appStore = {
+      getState: () => ({
+        tasks: { activeTaskId: "task-A" },
+        taskSessionsByTask: { itemsByTaskId: { "task-A": [] } },
+      }),
+    };
+    const refs = {
+      sessionTabCreatedRef: { current: new Set<string>() },
+      prevTaskIdRef: { current: "task-old" as string | null },
+      prevSessionIdRef: { current: "session-old" as string | null },
+    };
+
+    useDockviewStore.setState({ api });
+    runAutoSessionTabEffect("session-pending", appStore as never, refs as never);
+    useDockviewStore.setState({ api: null });
+
+    expect(refs.prevTaskIdRef.current).toBe("task-A");
+    expect(refs.prevSessionIdRef.current).toBe("session-pending");
   });
 });

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -662,11 +662,20 @@ function logAutoSessionTabEffectEntry(
   });
 }
 
+function updateAutoSessionTabRefs(
+  refs: AutoSessionTabRefs,
+  tid: string | null,
+  effectiveSessionId: string | null,
+): void {
+  refs.prevTaskIdRef.current = tid;
+  refs.prevSessionIdRef.current = effectiveSessionId;
+}
+
 /**
  * Core effect body for useAutoSessionTab — extracted to reduce complexity of
  * the hook itself.
  */
-function runAutoSessionTabEffect(
+export function runAutoSessionTabEffect(
   effectiveSessionId: string | null,
   appStore: ReturnType<typeof useAppStoreApi>,
   refs: AutoSessionTabRefs,
@@ -688,6 +697,7 @@ function runAutoSessionTabEffect(
       });
     }
     releaseLayoutToDefault(useDockviewStore.getState().currentLayoutEnvId);
+    updateAutoSessionTabRefs(refs, tid, effectiveSessionId);
     return;
   }
 
@@ -700,6 +710,7 @@ function runAutoSessionTabEffect(
 
   if (!effectiveSessionId) {
     if (isDebug()) debug("useAutoSessionTab: no effectiveSessionId, returning");
+    updateAutoSessionTabRefs(refs, tid, effectiveSessionId);
     return;
   }
 
@@ -711,6 +722,7 @@ function runAutoSessionTabEffect(
       refs.sessionTabCreatedRef.current,
     )
   ) {
+    updateAutoSessionTabRefs(refs, tid, effectiveSessionId);
     return;
   }
 
@@ -769,8 +781,7 @@ function runAutoSessionTabEffect(
     });
   }
 
-  refs.prevTaskIdRef.current = tid;
-  refs.prevSessionIdRef.current = effectiveSessionId;
+  updateAutoSessionTabRefs(refs, tid, effectiveSessionId);
 }
 
 /**

--- a/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
+++ b/apps/web/e2e/tests/workflow/workflow-agent-switch.spec.ts
@@ -571,9 +571,9 @@ test.describe("Workflow agent profile switching", () => {
    * Verifies that an on_turn_complete cascade that switches agent profiles
    * promotes the new session to primary.
    *
-   * Note: Per PR #743 (pinnedSessionId), the user's pinned tab is preserved.
-   * The active dockview tab stays on the pinned session; this test asserts on
-   * the primary star marker.
+   * Note: pinned tabs are preserved while their session is non-terminal; this
+   * cascade can terminal-handoff to the replacement, so assert the durable
+   * primary star marker rather than active-tab timing.
    */
   test("on_turn_complete cascade promotes new agent session to primary", async ({
     testPage,
@@ -688,8 +688,8 @@ test.describe("Workflow agent profile switching", () => {
     await apiClient.moveTask(task.id, workflow.id, step2.id);
 
     // The Profile B tab should appear and own the primary star (no reload needed).
-    // Per PR #743, the active dockview tab stays pinned to Profile A — the star
-    // moving is what proves SetPrimarySession's WS broadcast landed.
+    // The non-terminal Profile A tab stays user-pinned, so the star moving is
+    // what proves SetPrimarySession's WS broadcast landed.
     const profileBTab = session.sessionTabByText("Profile B");
     await expect(profileBTab).toBeVisible({ timeout: 60_000 });
     await expect(session.primaryStarInTab("Profile B")).toBeVisible({ timeout: 60_000 });

--- a/apps/web/lib/state/slices/kanban/kanban-slice.test.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { createKanbanSlice } from "./kanban-slice";
+import type { KanbanSlice } from "./types";
+
+function makeStore() {
+  return create<KanbanSlice>()(immer(createKanbanSlice));
+}
+
+describe("kanban slice active session selection", () => {
+  it("clears a stale user pin when an automatic session switch takes over", () => {
+    const store = makeStore();
+
+    store.getState().setActiveSession("task-1", "session-pinned");
+    store.getState().setActiveSessionAuto("task-1", "session-auto");
+
+    expect(store.getState().tasks).toMatchObject({
+      activeTaskId: "task-1",
+      activeSessionId: "session-auto",
+      pinnedSessionId: null,
+      lastSessionByTaskId: { "task-1": "session-auto" },
+    });
+  });
+});

--- a/apps/web/lib/state/slices/kanban/kanban-slice.test.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.test.ts
@@ -4,22 +4,53 @@ import { immer } from "zustand/middleware/immer";
 import { createKanbanSlice } from "./kanban-slice";
 import type { KanbanSlice } from "./types";
 
+const TASK_ID = "task-1";
+const AUTO_SESSION_ID = "session-auto";
+const PINNED_SESSION_ID = "session-pinned";
+
 function makeStore() {
   return create<KanbanSlice>()(immer(createKanbanSlice));
 }
 
 describe("kanban slice active session selection", () => {
-  it("clears a stale user pin when an automatic session switch takes over", () => {
+  it("updates active session state without creating a user pin", () => {
     const store = makeStore();
 
-    store.getState().setActiveSession("task-1", "session-pinned");
-    store.getState().setActiveSessionAuto("task-1", "session-auto");
+    store.getState().setActiveSessionAuto(TASK_ID, AUTO_SESSION_ID);
 
     expect(store.getState().tasks).toMatchObject({
-      activeTaskId: "task-1",
-      activeSessionId: "session-auto",
+      activeTaskId: TASK_ID,
+      activeSessionId: AUTO_SESSION_ID,
       pinnedSessionId: null,
-      lastSessionByTaskId: { "task-1": "session-auto" },
+      lastSessionByTaskId: { [TASK_ID]: AUTO_SESSION_ID },
+    });
+  });
+
+  it("preserves an existing pin when auto-selecting the pinned session", () => {
+    const store = makeStore();
+
+    store.getState().setActiveSession(TASK_ID, PINNED_SESSION_ID);
+    store.getState().setActiveSessionAuto(TASK_ID, PINNED_SESSION_ID);
+
+    expect(store.getState().tasks).toMatchObject({
+      activeTaskId: TASK_ID,
+      activeSessionId: PINNED_SESSION_ID,
+      pinnedSessionId: PINNED_SESSION_ID,
+      lastSessionByTaskId: { [TASK_ID]: PINNED_SESSION_ID },
+    });
+  });
+
+  it("leaves non-matching pins for callers to resolve", () => {
+    const store = makeStore();
+
+    store.getState().setActiveSession(TASK_ID, PINNED_SESSION_ID);
+    store.getState().setActiveSessionAuto(TASK_ID, AUTO_SESSION_ID);
+
+    expect(store.getState().tasks).toMatchObject({
+      activeTaskId: TASK_ID,
+      activeSessionId: AUTO_SESSION_ID,
+      pinnedSessionId: PINNED_SESSION_ID,
+      lastSessionByTaskId: { [TASK_ID]: AUTO_SESSION_ID },
     });
   });
 });

--- a/apps/web/lib/state/slices/kanban/kanban-slice.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.ts
@@ -60,9 +60,6 @@ export const createKanbanSlice: StateCreator<
     set((draft) => {
       draft.tasks.activeTaskId = taskId;
       draft.tasks.activeSessionId = sessionId;
-      if (draft.tasks.pinnedSessionId !== sessionId) {
-        draft.tasks.pinnedSessionId = null;
-      }
       draft.tasks.lastSessionByTaskId[taskId] = sessionId;
     }),
   clearActiveSession: () =>

--- a/apps/web/lib/state/slices/kanban/kanban-slice.ts
+++ b/apps/web/lib/state/slices/kanban/kanban-slice.ts
@@ -60,7 +60,9 @@ export const createKanbanSlice: StateCreator<
     set((draft) => {
       draft.tasks.activeTaskId = taskId;
       draft.tasks.activeSessionId = sessionId;
-      // Auto-driven (WS) selection: don't touch pinnedSessionId.
+      if (draft.tasks.pinnedSessionId !== sessionId) {
+        draft.tasks.pinnedSessionId = null;
+      }
       draft.tasks.lastSessionByTaskId[taskId] = sessionId;
     }),
   clearActiveSession: () =>

--- a/apps/web/lib/state/slices/kanban/types.ts
+++ b/apps/web/lib/state/slices/kanban/types.ts
@@ -110,9 +110,8 @@ export type TaskState = {
   activeSessionId: string | null;
   // pinnedSessionId tracks the session the USER explicitly selected.
   // Set by setActiveSession (user-initiated). Cleared when navigating to a
-  // different task. WS auto-adopt paths use setActiveSessionAuto which leaves
-  // pinnedSessionId alone — and skip auto-replace when the terminating session
-  // matches the pin (the user wants to stay even though the workflow moved on).
+  // different task or when an automatic handoff explicitly takes over. WS
+  // auto-adopt paths must not override a non-terminal pin for the active task.
   pinnedSessionId: string | null;
   // lastSessionByTaskId remembers the most-recent active session for each task.
   // Unlike pinnedSessionId (single global slot, cleared on task change), this
@@ -134,9 +133,9 @@ export type KanbanSliceActions = {
   reorderWorkflowItems: (workflowIds: string[]) => void;
   setActiveTask: (taskId: string) => void;
   setActiveSession: (taskId: string, sessionId: string) => void;
-  // setActiveSessionAuto is the same as setActiveSession but doesn't update
-  // pinnedSessionId. Used by WS handlers to follow workflow-driven session
-  // switches without overriding a user's manual selection.
+  // setActiveSessionAuto updates the active session without creating a user
+  // pin. Used by WS handlers to follow workflow-driven session switches after
+  // they have checked that no non-terminal manual pin should be preserved.
   setActiveSessionAuto: (taskId: string, sessionId: string) => void;
   clearActiveSession: () => void;
   setWorkflowSnapshot: (workflowId: string, data: WorkflowSnapshotData) => void;

--- a/apps/web/lib/state/slices/kanban/types.ts
+++ b/apps/web/lib/state/slices/kanban/types.ts
@@ -133,9 +133,9 @@ export type KanbanSliceActions = {
   reorderWorkflowItems: (workflowIds: string[]) => void;
   setActiveTask: (taskId: string) => void;
   setActiveSession: (taskId: string, sessionId: string) => void;
-  // setActiveSessionAuto updates the active session without creating a user
-  // pin. Used by WS handlers to follow workflow-driven session switches after
-  // they have checked that no non-terminal manual pin should be preserved.
+  // setActiveSessionAuto updates the active session without creating or
+  // clearing a user pin. Callers that intentionally override a pin must clear
+  // it explicitly after checking no non-terminal manual pin should be preserved.
   setActiveSessionAuto: (taskId: string, sessionId: string) => void;
   clearActiveSession: () => void;
   setWorkflowSnapshot: (workflowId: string, data: WorkflowSnapshotData) => void;

--- a/apps/web/lib/ws/handlers/agent-session-pure.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session-pure.test.ts
@@ -222,4 +222,27 @@ describe("shouldPreservePinnedSessionForTask", () => {
 
     expect(shouldPreservePinnedSessionForTask(state, "t-1")).toBe(false);
   });
+
+  it("does not preserve a stale by-id row when a loaded per-task list omits the pin", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-drifted",
+        pinnedSessionId: "s-pinned",
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: {
+          "s-pinned": { id: "s-pinned", task_id: "t-1", state: "RUNNING" },
+        },
+      } as unknown as AppState["taskSessions"],
+      taskSessionsByTask: {
+        itemsByTaskId: { "t-1": [] },
+        loadedByTaskId: { "t-1": true },
+        loadingByTaskId: {},
+      } as unknown as AppState["taskSessionsByTask"],
+    });
+
+    expect(shouldPreservePinnedSessionForTask(state, "t-1")).toBe(false);
+  });
 });

--- a/apps/web/lib/ws/handlers/agent-session-pure.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session-pure.test.ts
@@ -4,6 +4,7 @@ import {
   isStaleSessionStateEvent,
   pickReplacementSessionId,
   shouldAdoptNewSession,
+  shouldPreservePinnedSessionForTask,
 } from "./agent-session";
 import type { AppState } from "@/lib/state/store";
 import type { TaskSessionState } from "@/lib/types/http";
@@ -182,5 +183,43 @@ describe("pickReplacementSessionId", () => {
 
   it("returns null when the task has no sessions tracked", () => {
     expect(pickReplacementSessionId(makeAppState({}), "t-missing")).toBeNull();
+  });
+});
+
+describe("shouldPreservePinnedSessionForTask", () => {
+  it("preserves a missing pinned session while the per-task list is hydrating", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-drifted",
+        pinnedSessionId: "s-pinned",
+        lastSessionByTaskId: {},
+      },
+      taskSessionsByTask: {
+        itemsByTaskId: { "t-1": [] },
+        loadedByTaskId: {},
+        loadingByTaskId: { "t-1": true },
+      } as unknown as AppState["taskSessionsByTask"],
+    });
+
+    expect(shouldPreservePinnedSessionForTask(state, "t-1")).toBe(true);
+  });
+
+  it("does not preserve a missing pinned session once the per-task list is loaded", () => {
+    const state = makeAppState({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-drifted",
+        pinnedSessionId: "s-pinned",
+        lastSessionByTaskId: {},
+      },
+      taskSessionsByTask: {
+        itemsByTaskId: { "t-1": [] },
+        loadedByTaskId: { "t-1": true },
+        loadingByTaskId: {},
+      } as unknown as AppState["taskSessionsByTask"],
+    });
+
+    expect(shouldPreservePinnedSessionForTask(state, "t-1")).toBe(false);
   });
 });

--- a/apps/web/lib/ws/handlers/agent-session.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session.test.ts
@@ -288,15 +288,14 @@ describe("session.state_changed → active session switching", () => {
 
     expect(store.getState().setActiveSessionAuto).not.toHaveBeenCalled();
   });
+});
 
-  // Regression for the reverse-event-ordering race: if the OLD pinned session's
-  // COMPLETED event arrives before the NEW session's STARTING event, the
-  // terminal-handoff guard (which protects pinning) doesn't run on the COMPLETED
-  // event because s-new isn't yet in the store. When the STARTING event
-  // arrives, shouldAdoptNewSession returns true (old is now terminal) and would
-  // auto-yank the user off their pinned session — unless we re-check pinning on
-  // this path too.
-  it("does not yank a pinned session on reverse event ordering (old COMPLETED, then new STARTING)", () => {
+describe("session.state_changed → active session switching with pins", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adopts the replacement when the pinned active session is already terminal", () => {
     const store = makeStore({
       tasks: {
         activeTaskId: "t-1",
@@ -315,6 +314,33 @@ describe("session.state_changed → active session switching", () => {
       type: "notification",
       action: STATE_CHANGED_EVENT,
       payload: { task_id: "t-1", session_id: "s-new", new_state: "STARTING" },
+    });
+
+    expect(store.getState().setActiveSessionAuto).toHaveBeenCalledWith("t-1", "s-new");
+  });
+
+  it("does not adopt another session when a non-terminal pin was orphaned by active-session drift", () => {
+    const store = makeStore({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-drifted",
+        pinnedSessionId: "s-pinned",
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: {
+          "s-drifted": { id: "s-drifted", task_id: "t-1", state: "COMPLETED" },
+          "s-pinned": { id: "s-pinned", task_id: "t-1", state: "RUNNING" },
+        },
+      },
+    });
+    const handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
+
+    handler({
+      id: "m",
+      type: "notification",
+      action: STATE_CHANGED_EVENT,
+      payload: { task_id: "t-1", session_id: "s-background", new_state: "STARTING" },
     });
 
     expect(store.getState().setActiveSessionAuto).not.toHaveBeenCalled();
@@ -432,9 +458,7 @@ describe("session.state_changed → respects user-pinned session", () => {
     vi.clearAllMocks();
   });
 
-  it("does NOT hand off when the user pinned the session that just terminated", () => {
-    // User manually clicked s-old, so pinnedSessionId === "s-old".
-    // When s-old terminates we should respect the pin and stay on it.
+  it("hands off when the pinned active session reaches a terminal state", () => {
     const store = makeStore({
       tasks: {
         activeTaskId: "t-1",
@@ -463,7 +487,7 @@ describe("session.state_changed → respects user-pinned session", () => {
       payload: { task_id: "t-1", session_id: "s-old", new_state: "COMPLETED" },
     });
 
-    expect(store.getState().setActiveSessionAuto).not.toHaveBeenCalled();
+    expect(store.getState().setActiveSessionAuto).toHaveBeenCalledWith("t-1", "s-new");
     expect(store.getState().setActiveSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -29,6 +29,45 @@ export function isTerminalSessionState(state: TaskSessionState | undefined): boo
   return !!state && TERMINAL_SESSION_STATES.has(state);
 }
 
+function findSessionForTask(state: AppState, taskId: string, sessionId: string) {
+  const byId = state.taskSessions?.items?.[sessionId];
+  if (byId) return byId.task_id === taskId ? byId : null;
+  return (
+    state.taskSessionsByTask?.itemsByTaskId?.[taskId]?.find(
+      (session) => session.id === sessionId,
+    ) ?? null
+  );
+}
+
+/**
+ * Manual session selection pins a task-scoped session. Background WS events
+ * may only override that pin once the pinned session is known terminal, or
+ * when the terminal event is for the pinned session itself.
+ */
+export function shouldPreservePinnedSessionForTask(
+  state: AppState,
+  taskId: string,
+  incoming?: { sessionId: string; newState: TaskSessionState | undefined },
+): boolean {
+  const pinnedSessionId = state.tasks.pinnedSessionId;
+  if (!pinnedSessionId || state.tasks.activeTaskId !== taskId) return false;
+  if (
+    incoming?.sessionId === pinnedSessionId &&
+    incoming.newState &&
+    isTerminalSessionState(incoming.newState)
+  ) {
+    return false;
+  }
+
+  const pinnedSession = findSessionForTask(state, taskId, pinnedSessionId);
+  if (!pinnedSession) {
+    // Manual pins are created for the active task. If hydration briefly drops
+    // the row, preserve the pin instead of treating the session as replaceable.
+    return true;
+  }
+  return !isTerminalSessionState(pinnedSession.state);
+}
+
 /** Promote agentctl status to "ready" when the session enters a live state.
  *  Acts as a fallback for missed/late agentctl_ready WS events — the backend
  *  cannot reach RUNNING/WAITING_FOR_INPUT without a live agentctl. Never
@@ -281,17 +320,15 @@ function maybeAdoptSessionOnTransition(
   wasKnownToStore: boolean,
 ): void {
   const state = store.getState();
+  if (
+    state.tasks.pinnedSessionId !== sessionId &&
+    shouldPreservePinnedSessionForTask(state, taskId, { sessionId, newState })
+  ) {
+    return;
+  }
 
   if (!wasKnownToStore && shouldAdoptNewSession(state, taskId, newState)) {
     const oldSessionId = state.tasks.activeSessionId;
-    // Reverse-ordering guard: if the events arrive as old=COMPLETED then
-    // new=STARTING (instead of the typical new=STARTING then old=COMPLETED),
-    // shouldAdoptNewSession returns true on the second event because the old
-    // session is now terminal. But the user may have pinned the old session —
-    // in that case the symmetric guard below was skipped (no terminal event
-    // for the new session), and we'd auto-yank them off their pinned session
-    // here. Match the terminal-handoff path's pinning check.
-    if (oldSessionId && state.tasks.pinnedSessionId === oldSessionId) return;
     if (oldSessionId) inheritAgentctlStatus(state, oldSessionId, sessionId);
     state.setActiveSessionAuto(taskId, sessionId);
     return;
@@ -299,9 +336,6 @@ function maybeAdoptSessionOnTransition(
 
   const isActive = state.tasks.activeSessionId === sessionId;
   if (isActive && newState && isTerminalSessionState(newState)) {
-    // If the user explicitly pinned this session (manual click), don't yank
-    // them away just because the workflow moved it to a terminal state.
-    if (state.tasks.pinnedSessionId === sessionId) return;
     const replacement = pickReplacementSessionId(state, taskId);
     if (replacement && replacement !== sessionId) {
       inheritAgentctlStatus(state, sessionId, replacement);

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -30,14 +30,15 @@ export function isTerminalSessionState(state: TaskSessionState | undefined): boo
 }
 
 function findSessionForTask(state: AppState, taskId: string, sessionId: string) {
+  const byTask = state.taskSessionsByTask;
+  const sessionsForTask = byTask?.itemsByTaskId?.[taskId];
+  if (byTask?.loadedByTaskId?.[taskId]) {
+    return sessionsForTask?.find((session) => session.id === sessionId) ?? null;
+  }
   // Some task-update call sites use partial stores before taskSessions hydrates.
   const byId = state.taskSessions?.items?.[sessionId];
   if (byId) return byId.task_id === taskId ? byId : null;
-  return (
-    state.taskSessionsByTask?.itemsByTaskId?.[taskId]?.find(
-      (session) => session.id === sessionId,
-    ) ?? null
-  );
+  return sessionsForTask?.find((session) => session.id === sessionId) ?? null;
 }
 
 function isTaskSessionListHydrating(state: AppState, taskId: string): boolean {

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -40,6 +40,13 @@ function findSessionForTask(state: AppState, taskId: string, sessionId: string) 
   );
 }
 
+function isTaskSessionListHydrating(state: AppState, taskId: string): boolean {
+  const byTask = state.taskSessionsByTask;
+  if (!byTask) return true;
+  if (byTask.loadingByTaskId?.[taskId]) return true;
+  return !byTask.loadedByTaskId?.[taskId];
+}
+
 /**
  * Manual session selection pins a task-scoped session. Background WS events
  * may only override that pin once the pinned session is known terminal, or
@@ -62,9 +69,9 @@ export function shouldPreservePinnedSessionForTask(
 
   const pinnedSession = findSessionForTask(state, taskId, pinnedSessionId);
   if (!pinnedSession) {
-    // Manual pins are created for the active task. If hydration briefly drops
-    // the row, preserve the pin instead of treating the session as replaceable.
-    return true;
+    // Preserve missing rows only while the per-task list is still hydrating.
+    // Once loaded, absence means the pinned session was deleted or went stale.
+    return isTaskSessionListHydrating(state, taskId);
   }
   return !isTerminalSessionState(pinnedSession.state);
 }

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -30,6 +30,7 @@ export function isTerminalSessionState(state: TaskSessionState | undefined): boo
 }
 
 function findSessionForTask(state: AppState, taskId: string, sessionId: string) {
+  // Some task-update call sites use partial stores before taskSessions hydrates.
   const byId = state.taskSessions?.items?.[sessionId];
   if (byId) return byId.task_id === taskId ? byId : null;
   return (
@@ -66,6 +67,15 @@ export function shouldPreservePinnedSessionForTask(
     return true;
   }
   return !isTerminalSessionState(pinnedSession.state);
+}
+
+export function clearPinnedSessionIfOverridden(store: StoreApi<AppState>, sessionId: string): void {
+  const pinnedSessionId = store.getState().tasks.pinnedSessionId;
+  if (!pinnedSessionId || pinnedSessionId === sessionId) return;
+  store.setState((state) => ({
+    ...state,
+    tasks: { ...state.tasks, pinnedSessionId: null },
+  }));
 }
 
 /** Promote agentctl status to "ready" when the session enters a live state.
@@ -330,6 +340,7 @@ function maybeAdoptSessionOnTransition(
   if (!wasKnownToStore && shouldAdoptNewSession(state, taskId, newState)) {
     const oldSessionId = state.tasks.activeSessionId;
     if (oldSessionId) inheritAgentctlStatus(state, oldSessionId, sessionId);
+    clearPinnedSessionIfOverridden(store, sessionId);
     state.setActiveSessionAuto(taskId, sessionId);
     return;
   }
@@ -339,6 +350,7 @@ function maybeAdoptSessionOnTransition(
     const replacement = pickReplacementSessionId(state, taskId);
     if (replacement && replacement !== sessionId) {
       inheritAgentctlStatus(state, sessionId, replacement);
+      clearPinnedSessionIfOverridden(store, replacement);
       state.setActiveSessionAuto(taskId, replacement);
     }
   }

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -239,6 +239,34 @@ describe("task.updated primary-session focus follow (pinning)", () => {
 
     expect(setActiveSessionAuto).not.toHaveBeenCalled();
   });
+
+  it("does NOT follow focus when active-session drift orphaned a non-terminal pin", () => {
+    store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [{ id: "t1", primarySessionId: "sess-drifted", workflowId: "wf1" }],
+      } as unknown as AppState["kanban"],
+      tasks: {
+        activeTaskId: "t1",
+        activeSessionId: "sess-drifted",
+        pinnedSessionId: "sess-pinned",
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: {
+          "sess-pinned": { id: "sess-pinned", task_id: "t1", state: "RUNNING" },
+          "sess-drifted": { id: "sess-drifted", task_id: "t1", state: "COMPLETED" },
+        },
+      } as unknown as AppState["taskSessions"],
+      setActiveSessionAuto,
+    });
+
+    const handlers = registerTasksHandlers(store);
+    handlers["task.updated"]!(makeMessage(makeTask("t1", "sess-new")));
+
+    expect(setActiveSessionAuto).not.toHaveBeenCalled();
+  });
 });
 
 describe("task.updated cross-workflow placement", () => {

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -269,6 +269,16 @@ describe("task.updated primary-session focus follow (pinning)", () => {
 
     expect(setActiveSessionAuto).not.toHaveBeenCalled();
   });
+});
+
+describe("task.updated primary-session focus follow (stale pin cleanup)", () => {
+  let store: ReturnType<typeof makeStore>;
+  let setActiveSessionAuto: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActiveSessionAuto = vi.fn();
+    vi.mocked(removeRecentTask).mockClear();
+  });
 
   it("clears a terminal orphaned pin when following focus to the new primary", () => {
     store = makeStore({
@@ -289,6 +299,41 @@ describe("task.updated primary-session focus follow (pinning)", () => {
           [SESS_DRIFTED]: { id: SESS_DRIFTED, task_id: "t1", state: "COMPLETED" },
         },
       } as unknown as AppState["taskSessions"],
+      setActiveSessionAuto,
+    });
+
+    const handlers = registerTasksHandlers(store);
+    handlers["task.updated"]!(makeMessage(makeTask("t1", "sess-new")));
+
+    expect(setActiveSessionAuto).toHaveBeenCalledWith("t1", "sess-new");
+    expect(store.getState().tasks.pinnedSessionId).toBeNull();
+  });
+
+  it("clears a deleted orphaned pin when following focus to the new primary", () => {
+    store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [{ id: "t1", primarySessionId: SESS_DRIFTED, workflowId: "wf1" }],
+      } as unknown as AppState["kanban"],
+      tasks: {
+        activeTaskId: "t1",
+        activeSessionId: SESS_DRIFTED,
+        pinnedSessionId: SESS_PINNED,
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: {
+          [SESS_DRIFTED]: { id: SESS_DRIFTED, task_id: "t1", state: "COMPLETED" },
+        },
+      } as unknown as AppState["taskSessions"],
+      taskSessionsByTask: {
+        itemsByTaskId: {
+          t1: [{ id: SESS_DRIFTED, task_id: "t1", state: "COMPLETED" }],
+        },
+        loadedByTaskId: { t1: true },
+        loadingByTaskId: {},
+      } as unknown as AppState["taskSessionsByTask"],
       setActiveSessionAuto,
     });
 

--- a/apps/web/lib/ws/handlers/tasks.test.ts
+++ b/apps/web/lib/ws/handlers/tasks.test.ts
@@ -9,6 +9,8 @@ vi.mock("@/lib/recent-tasks", () => ({
 }));
 
 const SESS_OTHER = "sess-other";
+const SESS_DRIFTED = "sess-drifted";
+const SESS_PINNED = "sess-pinned";
 
 type Listener = (state: AppState) => void;
 
@@ -245,18 +247,18 @@ describe("task.updated primary-session focus follow (pinning)", () => {
       kanban: {
         workflowId: "wf1",
         steps: [],
-        tasks: [{ id: "t1", primarySessionId: "sess-drifted", workflowId: "wf1" }],
+        tasks: [{ id: "t1", primarySessionId: SESS_DRIFTED, workflowId: "wf1" }],
       } as unknown as AppState["kanban"],
       tasks: {
         activeTaskId: "t1",
-        activeSessionId: "sess-drifted",
-        pinnedSessionId: "sess-pinned",
+        activeSessionId: SESS_DRIFTED,
+        pinnedSessionId: SESS_PINNED,
         lastSessionByTaskId: {},
       },
       taskSessions: {
         items: {
-          "sess-pinned": { id: "sess-pinned", task_id: "t1", state: "RUNNING" },
-          "sess-drifted": { id: "sess-drifted", task_id: "t1", state: "COMPLETED" },
+          [SESS_PINNED]: { id: SESS_PINNED, task_id: "t1", state: "RUNNING" },
+          [SESS_DRIFTED]: { id: SESS_DRIFTED, task_id: "t1", state: "COMPLETED" },
         },
       } as unknown as AppState["taskSessions"],
       setActiveSessionAuto,
@@ -266,6 +268,35 @@ describe("task.updated primary-session focus follow (pinning)", () => {
     handlers["task.updated"]!(makeMessage(makeTask("t1", "sess-new")));
 
     expect(setActiveSessionAuto).not.toHaveBeenCalled();
+  });
+
+  it("clears a terminal orphaned pin when following focus to the new primary", () => {
+    store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [{ id: "t1", primarySessionId: SESS_DRIFTED, workflowId: "wf1" }],
+      } as unknown as AppState["kanban"],
+      tasks: {
+        activeTaskId: "t1",
+        activeSessionId: SESS_DRIFTED,
+        pinnedSessionId: SESS_PINNED,
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: {
+          [SESS_PINNED]: { id: SESS_PINNED, task_id: "t1", state: "COMPLETED" },
+          [SESS_DRIFTED]: { id: SESS_DRIFTED, task_id: "t1", state: "COMPLETED" },
+        },
+      } as unknown as AppState["taskSessions"],
+      setActiveSessionAuto,
+    });
+
+    const handlers = registerTasksHandlers(store);
+    handlers["task.updated"]!(makeMessage(makeTask("t1", "sess-new")));
+
+    expect(setActiveSessionAuto).toHaveBeenCalledWith("t1", "sess-new");
+    expect(store.getState().tasks.pinnedSessionId).toBeNull();
   });
 });
 

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -8,7 +8,10 @@ import { useContextFilesStore } from "@/lib/state/context-files-store";
 import { toKanbanTask, type TaskLike } from "@/lib/kanban/map-task";
 import { sessionId as toSessionId } from "@/lib/types/http";
 import { mergeTaskRepositoryFields } from "@/lib/ws/handlers/task-repositories";
-import { shouldPreservePinnedSessionForTask } from "@/lib/ws/handlers/agent-session";
+import {
+  clearPinnedSessionIfOverridden,
+  shouldPreservePinnedSessionForTask,
+} from "@/lib/ws/handlers/agent-session";
 
 type KanbanTask = KanbanState["tasks"][number];
 
@@ -166,6 +169,7 @@ export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
         afterState.tasks.activeSessionId === previousPrimary &&
         !shouldPreservePinnedSessionForTask(afterState, taskId)
       ) {
+        clearPinnedSessionIfOverridden(store, newPrimary);
         afterState.setActiveSessionAuto(taskId, newPrimary);
       }
     },

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -8,6 +8,7 @@ import { useContextFilesStore } from "@/lib/state/context-files-store";
 import { toKanbanTask, type TaskLike } from "@/lib/kanban/map-task";
 import { sessionId as toSessionId } from "@/lib/types/http";
 import { mergeTaskRepositoryFields } from "@/lib/ws/handlers/task-repositories";
+import { shouldPreservePinnedSessionForTask } from "@/lib/ws/handlers/agent-session";
 
 type KanbanTask = KanbanState["tasks"][number];
 
@@ -152,11 +153,10 @@ export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
       // Follow focus to the new primary when:
       //  - the user is currently viewing this task,
       //  - the user was sitting on the previous primary,
-      //  - they did NOT explicitly pin that previous primary (a manual click
-      //    sets pinnedSessionId; pinned sessions must be left alone), and
+      //  - they do NOT have a non-terminal pinned session for this task, and
       //  - the primary actually changed.
       // This makes workflow profile switches transparent for unpinned users
-      // without yanking pinned ones off their deliberate selection.
+      // without yanking users off a live session they deliberately selected.
       const afterState = store.getState();
       const newPrimary = findTaskInState(afterState, taskId)?.primarySessionId ?? null;
       if (
@@ -164,7 +164,7 @@ export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
         newPrimary !== previousPrimary &&
         afterState.tasks.activeTaskId === taskId &&
         afterState.tasks.activeSessionId === previousPrimary &&
-        afterState.tasks.pinnedSessionId !== previousPrimary
+        !shouldPreservePinnedSessionForTask(afterState, taskId)
       ) {
         afterState.setActiveSessionAuto(taskId, newPrimary);
       }


### PR DESCRIPTION
Multiple live sessions for one task could steal focus from the user-selected session whenever a background session emitted WebSocket state updates. The session-selection guards now preserve a non-terminal task-scoped pin, clear stale pins on explicit automatic handoff, and keep dockview tab refs current so the UI stays on the chosen session.

## Important Changes

- Added a task-scoped pin guard for `session.state_changed` and `task.updated` auto-selection paths.
- Clear stale `pinnedSessionId` when `setActiveSessionAuto` performs an automatic takeover.
- Update dockview session-tab previous refs before early returns to avoid stale activation decisions.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps/web && pnpm e2e:run tests/session/session-flicker.spec.ts`

## Possible Improvements

Low risk: the behavior is covered at store/WS/dockview levels plus focused E2E; future work could add a browser-level synthetic WS event test if the harness grows cheaper controls for live session events.

Closes #1516

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->