### PR TITLE
fix: handle windows desktop runtime helper mode

### DIFF
--- a/scripts/release-desktop.test.sh
+++ b/scripts/release-desktop.test.sh
@@ -58,6 +58,24 @@ fi
 grep -q "Missing agentctl linux/amd64 helper" "$ERR_FILE" || fail "verify-desktop-runtime did not explain missing helper"
 pass "verify-desktop-runtime requires helper for linux-x64 runtime"
 
+nonexec_helper_runtime_dir="$TMP_DIR/nonexec-helper-runtime"
+write_runtime "$nonexec_helper_runtime_dir"
+chmod +x "$nonexec_helper_runtime_dir/bin/kandev" "$nonexec_helper_runtime_dir/bin/agentctl"
+if "$ROOT_DIR/scripts/release/verify-desktop-runtime.sh" --platform linux-x64 "$nonexec_helper_runtime_dir" >"$OUT_FILE" 2>"$ERR_FILE"; then
+  fail "verify-desktop-runtime should require executable helper on POSIX hosts"
+fi
+grep -q "agentctl linux/amd64 helper is not executable" "$ERR_FILE" || fail "verify-desktop-runtime did not explain non-executable helper"
+pass "verify-desktop-runtime requires executable helper on POSIX hosts"
+
+windows_runtime_dir="$TMP_DIR/windows-runtime"
+mkdir -p "$windows_runtime_dir/bin"
+printf 'stub\n' > "$windows_runtime_dir/bin/kandev.exe"
+printf 'stub\n' > "$windows_runtime_dir/bin/agentctl.exe"
+printf 'stub\n' > "$windows_runtime_dir/bin/agentctl-linux-amd64"
+OS=Windows_NT "$ROOT_DIR/scripts/release/verify-desktop-runtime.sh" --platform windows-x64 "$windows_runtime_dir" >"$OUT_FILE"
+grep -q "verified for windows-x64" "$OUT_FILE" || fail "verify-desktop-runtime did not accept Windows-host runtime"
+pass "verify-desktop-runtime accepts Windows-host helper without POSIX mode bits"
+
 linux_output_dir="$TMP_DIR/linux-output"
 "$ROOT_DIR/scripts/release/prepare-desktop-runtime.sh" \
   --bundle-dir "$runtime_dir" \

--- a/scripts/release-desktop.test.sh
+++ b/scripts/release-desktop.test.sh
@@ -61,7 +61,7 @@ pass "verify-desktop-runtime requires helper for linux-x64 runtime"
 nonexec_helper_runtime_dir="$TMP_DIR/nonexec-helper-runtime"
 write_runtime "$nonexec_helper_runtime_dir"
 chmod +x "$nonexec_helper_runtime_dir/bin/kandev" "$nonexec_helper_runtime_dir/bin/agentctl"
-if "$ROOT_DIR/scripts/release/verify-desktop-runtime.sh" --platform linux-x64 "$nonexec_helper_runtime_dir" >"$OUT_FILE" 2>"$ERR_FILE"; then
+if env -u OS "$ROOT_DIR/scripts/release/verify-desktop-runtime.sh" --platform linux-x64 "$nonexec_helper_runtime_dir" >"$OUT_FILE" 2>"$ERR_FILE"; then
   fail "verify-desktop-runtime should require executable helper on POSIX hosts"
 fi
 grep -q "agentctl linux/amd64 helper is not executable" "$ERR_FILE" || fail "verify-desktop-runtime did not explain non-executable helper"

--- a/scripts/release/verify-desktop-runtime.sh
+++ b/scripts/release/verify-desktop-runtime.sh
@@ -59,7 +59,12 @@ is_executable_file() {
     return 0
   fi
   # MSYS/Git Bash can report Windows executables differently from Unix mode bits.
-  [ "${OS:-}" = "Windows_NT" ] && [[ "$path" == *.exe ]]
+  if [ "${OS:-}" = "Windows_NT" ]; then
+    case "$(basename "$path")" in
+      *.exe|agentctl-linux-amd64) return 0 ;;
+    esac
+  fi
+  return 1
 }
 
 require_one() {


### PR DESCRIPTION
Windows desktop release packaging failed because Git Bash/NTFS does not reliably preserve POSIX executable bits for the embedded Linux helper. The verifier now treats that Windows-host check as file presence while keeping POSIX runners strict.

## Validation

- Reproduced the failing Windows-host verifier shape before the fix.
- Confirmed the same reproduction passes after the fix.
- `make test-scripts`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->