### PR TITLE
fix: wait for task create last-used settings

### DIFF
--- a/apps/web/components/task-create-dialog-autopick.ts
+++ b/apps/web/components/task-create-dialog-autopick.ts
@@ -141,8 +141,9 @@ export function useWorkflowAgentProfileEffect(
   workflows: Array<{ id: string; agent_profile_id?: string }>,
   agentProfiles: AgentProfileOption[],
   compatibleAgentProfiles: AgentProfileOption[],
-  lastUsedAgentProfileId?: string | null,
+  options: { lastUsedAgentProfileId?: string | null; authLoaded?: boolean } = {},
 ) {
+  const { lastUsedAgentProfileId, authLoaded = true } = options;
   const { selectedWorkflowId, executorProfileId, setAgentProfileId, setWorkflowAgentProfileId } =
     fs;
   useEffect(() => {
@@ -179,6 +180,13 @@ export function useWorkflowAgentProfileEffect(
         });
         return;
       }
+      if (!authLoaded) {
+        setAgentProfileId("");
+        workflowAutopickDebug("workflow-no-override-defer", {
+          reason: "auth-not-loaded",
+        });
+        return;
+      }
       // Restore the user's last-used agent profile when unlocking. Filter
       // against `compatibleAgentProfiles` (not the full `agentProfiles` list)
       // so an executor-incompatible id from a previous session - including
@@ -203,6 +211,7 @@ export function useWorkflowAgentProfileEffect(
     agentProfiles,
     compatibleAgentProfiles,
     lastUsedAgentProfileId,
+    authLoaded,
     setAgentProfileId,
     setWorkflowAgentProfileId,
   ]);

--- a/apps/web/components/task-create-dialog-autopick.ts
+++ b/apps/web/components/task-create-dialog-autopick.ts
@@ -173,6 +173,7 @@ export function useWorkflowAgentProfileEffect(
     } else {
       setWorkflowAgentProfileId("");
       if (!executorProfileId) {
+        setAgentProfileId("");
         workflowAutopickDebug("workflow-no-override-defer", {
           reason: "executor-not-selected",
         });

--- a/apps/web/components/task-create-dialog-autopick.ts
+++ b/apps/web/components/task-create-dialog-autopick.ts
@@ -33,7 +33,7 @@ export type AutopickDecision =
   | { kind: "defer"; reason: string }
   | { kind: "pick"; source: "lastId" | "defId" | "first"; id: string };
 
-export function decideAgentProfileAutopick(input: {
+type AgentProfileAutopickInput = {
   open: boolean;
   agentProfileId: string;
   workflowAgentProfileId: string;
@@ -44,8 +44,11 @@ export function decideAgentProfileAutopick(input: {
   executorProfileId: string;
   hasExecutors: boolean;
   lastAgentProfileId: string | null;
+  userSettingsLoaded?: boolean;
   defaultAgentProfileId: string | null;
-}): AutopickDecision {
+};
+
+function getAgentAutopickGate(input: AgentProfileAutopickInput): AutopickDecision | null {
   if (!input.open) return { kind: "skip", reason: "closed" };
   if (input.agentProfileId) return { kind: "skip", reason: "already-set" };
   if (input.workflowAgentProfileId) return { kind: "skip", reason: "workflow-locked" };
@@ -63,7 +66,15 @@ export function decideAgentProfileAutopick(input: {
     return { kind: "defer", reason: "executor-not-selected" };
   }
   if (input.compatibleAgentProfiles.length === 0) return { kind: "skip", reason: "no-compatible" };
+  if (!input.lastAgentProfileId && input.userSettingsLoaded === false) {
+    return { kind: "defer", reason: "user-settings-not-loaded" };
+  }
+  return null;
+}
 
+export function decideAgentProfileAutopick(input: AgentProfileAutopickInput): AutopickDecision {
+  const gate = getAgentAutopickGate(input);
+  if (gate) return gate;
   const lastId = input.lastAgentProfileId;
   if (lastId && input.compatibleAgentProfiles.some((p) => p.id === lastId)) {
     return { kind: "pick", source: "lastId", id: lastId };
@@ -84,6 +95,7 @@ function buildAgentAutopickDebugFields(input: {
   compatibleAgentProfiles: AgentProfileOption[];
   authLoaded: boolean;
   lastAgentProfileId: string | null;
+  userSettingsLoaded?: boolean;
   defaultAgentProfileId: string | null;
 }) {
   const lastId = input.lastAgentProfileId;
@@ -105,7 +117,23 @@ function buildAgentAutopickDebugFields(input: {
     agent_count: input.agentProfiles.length,
     compat_count: input.compatibleAgentProfiles.length,
     auth_loaded: input.authLoaded,
+    user_settings_loaded: input.userSettingsLoaded ?? true,
   };
+}
+
+function resolveLastUsedAgentProfileId(
+  compatibleAgentProfiles: AgentProfileOption[],
+  settingsAgentProfileId?: string | null,
+) {
+  const localId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_AGENT_PROFILE_ID, null);
+  if (localId && compatibleAgentProfiles.some((p) => p.id === localId)) return localId;
+  if (
+    settingsAgentProfileId &&
+    compatibleAgentProfiles.some((p) => p.id === settingsAgentProfileId)
+  ) {
+    return settingsAgentProfileId;
+  }
+  return null;
 }
 
 export function useWorkflowAgentProfileEffect(
@@ -113,6 +141,7 @@ export function useWorkflowAgentProfileEffect(
   workflows: Array<{ id: string; agent_profile_id?: string }>,
   agentProfiles: AgentProfileOption[],
   compatibleAgentProfiles: AgentProfileOption[],
+  lastUsedAgentProfileId?: string | null,
 ) {
   const { selectedWorkflowId, setAgentProfileId, setWorkflowAgentProfileId } = fs;
   useEffect(() => {
@@ -149,9 +178,9 @@ export function useWorkflowAgentProfileEffect(
       // useDefaultSelectionsEffect would otherwise see agentProfileId become
       // truthy, early-exit on "already-set", and leave the dialog stuck on
       // "No compatible agent profiles".
-      const lastId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_AGENT_PROFILE_ID, null);
-      const isValidLastId = Boolean(lastId && compatibleAgentProfiles.some((p) => p.id === lastId));
-      const finalId = isValidLastId && lastId ? lastId : "";
+      const lastId = resolveLastUsedAgentProfileId(compatibleAgentProfiles, lastUsedAgentProfileId);
+      const isValidLastId = Boolean(lastId);
+      const finalId = lastId ?? "";
       setAgentProfileId(finalId);
       workflowAutopickDebug("workflow-no-override", {
         last_id: lastId ?? "-",
@@ -164,6 +193,7 @@ export function useWorkflowAgentProfileEffect(
     workflows,
     agentProfiles,
     compatibleAgentProfiles,
+    lastUsedAgentProfileId,
     setAgentProfileId,
     setWorkflowAgentProfileId,
   ]);
@@ -190,9 +220,9 @@ export function useAgentProfileAutopickEffect(
     const workflowHasAgent = selectedWorkflowId
       ? workflows.some((w) => w.id === selectedWorkflowId && w.agent_profile_id)
       : false;
-    const lastAgentProfileId = getLocalStorage<string | null>(
-      STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
-      null,
+    const lastAgentProfileId = resolveLastUsedAgentProfileId(
+      compatibleAgentProfiles,
+      sel.lastUsedAgentProfileId,
     );
     const defaultAgentProfileId = workspaceDefaults?.default_agent_profile_id ?? null;
     const decision = decideAgentProfileAutopick({
@@ -206,6 +236,7 @@ export function useAgentProfileAutopickEffect(
       executorProfileId,
       hasExecutors: executors.length > 0,
       lastAgentProfileId,
+      userSettingsLoaded: sel.userSettingsLoaded,
       defaultAgentProfileId,
     });
     if (isDebug()) {
@@ -220,6 +251,7 @@ export function useAgentProfileAutopickEffect(
           compatibleAgentProfiles,
           authLoaded,
           lastAgentProfileId,
+          userSettingsLoaded: sel.userSettingsLoaded,
           defaultAgentProfileId,
         }),
       );
@@ -240,6 +272,8 @@ export function useAgentProfileAutopickEffect(
     executorProfileId,
     executors,
     workspaceDefaults,
+    sel.lastUsedAgentProfileId,
+    sel.userSettingsLoaded,
     setAgentProfileId,
   ]);
 }

--- a/apps/web/components/task-create-dialog-autopick.ts
+++ b/apps/web/components/task-create-dialog-autopick.ts
@@ -144,8 +144,14 @@ export function useWorkflowAgentProfileEffect(
   options: { lastUsedAgentProfileId?: string | null; authLoaded?: boolean } = {},
 ) {
   const { lastUsedAgentProfileId, authLoaded = true } = options;
-  const { selectedWorkflowId, executorProfileId, setAgentProfileId, setWorkflowAgentProfileId } =
-    fs;
+  const {
+    agentProfileId,
+    workflowAgentProfileId,
+    selectedWorkflowId,
+    executorProfileId,
+    setAgentProfileId,
+    setWorkflowAgentProfileId,
+  } = fs;
   useEffect(() => {
     if (!selectedWorkflowId) {
       setWorkflowAgentProfileId("");
@@ -173,6 +179,13 @@ export function useWorkflowAgentProfileEffect(
       }
     } else {
       setWorkflowAgentProfileId("");
+      if (agentProfileId && !workflowAgentProfileId) {
+        workflowAutopickDebug("workflow-no-override-skip", {
+          reason: "already-set",
+          current: agentProfileId,
+        });
+        return;
+      }
       if (!executorProfileId) {
         setAgentProfileId("");
         workflowAutopickDebug("workflow-no-override-defer", {
@@ -206,6 +219,8 @@ export function useWorkflowAgentProfileEffect(
     }
   }, [
     selectedWorkflowId,
+    agentProfileId,
+    workflowAgentProfileId,
     executorProfileId,
     workflows,
     agentProfiles,

--- a/apps/web/components/task-create-dialog-autopick.ts
+++ b/apps/web/components/task-create-dialog-autopick.ts
@@ -143,7 +143,8 @@ export function useWorkflowAgentProfileEffect(
   compatibleAgentProfiles: AgentProfileOption[],
   lastUsedAgentProfileId?: string | null,
 ) {
-  const { selectedWorkflowId, setAgentProfileId, setWorkflowAgentProfileId } = fs;
+  const { selectedWorkflowId, executorProfileId, setAgentProfileId, setWorkflowAgentProfileId } =
+    fs;
   useEffect(() => {
     if (!selectedWorkflowId) {
       setWorkflowAgentProfileId("");
@@ -171,6 +172,12 @@ export function useWorkflowAgentProfileEffect(
       }
     } else {
       setWorkflowAgentProfileId("");
+      if (!executorProfileId) {
+        workflowAutopickDebug("workflow-no-override-defer", {
+          reason: "executor-not-selected",
+        });
+        return;
+      }
       // Restore the user's last-used agent profile when unlocking. Filter
       // against `compatibleAgentProfiles` (not the full `agentProfiles` list)
       // so an executor-incompatible id from a previous session - including
@@ -190,6 +197,7 @@ export function useWorkflowAgentProfileEffect(
     }
   }, [
     selectedWorkflowId,
+    executorProfileId,
     workflows,
     agentProfiles,
     compatibleAgentProfiles,

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -20,11 +20,12 @@ import { STORAGE_KEYS } from "@/lib/settings/constants";
 // so the rest can be undefined behind an `as` cast and never read.
 type Fake = Pick<
   DialogFormState,
-  "selectedWorkflowId" | "setAgentProfileId" | "setWorkflowAgentProfileId"
+  "selectedWorkflowId" | "executorProfileId" | "setAgentProfileId" | "setWorkflowAgentProfileId"
 >;
 function makeFs(overrides: Partial<Fake> = {}): DialogFormState {
   return {
     selectedWorkflowId: null,
+    executorProfileId: "profile-1",
     setAgentProfileId: vi.fn(),
     setWorkflowAgentProfileId: vi.fn(),
     ...overrides,
@@ -275,6 +276,30 @@ describe("useWorkflowAgentProfileEffect", () => {
   });
 });
 
+describe("useWorkflowAgentProfileEffect — settings fallback readiness", () => {
+  it("defers workflow last-used restore until executor compatibility is ready", async () => {
+    const claude = makeProfile("claude");
+    const cursor = makeProfile("cursor");
+    const workflows = [{ id: "wf-1" /* no agent_profile_id */ }];
+    const fsBefore = makeFs({ selectedWorkflowId: "wf-1", executorProfileId: "" });
+
+    const { rerender } = renderHook(
+      ({ fs, compatible }) =>
+        useWorkflowAgentProfileEffect(fs, workflows, [claude, cursor], compatible, claude.id),
+      { initialProps: { fs: fsBefore, compatible: [claude, cursor] } },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalled();
+
+    const fsAfter = makeFs({ selectedWorkflowId: "wf-1", executorProfileId: "profile-1" });
+    rerender({ fs: fsAfter, compatible: [cursor] });
+
+    await waitFor(() => expect(fsAfter.setAgentProfileId).toHaveBeenCalledWith(""));
+    expect(fsAfter.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
+  });
+});
+
 type DefaultSelFake = Pick<
   DialogFormState,
   | "agentProfileId"
@@ -334,6 +359,14 @@ function makeWorktreeExecutor(): StoreSelections["executors"][number] {
       { id: "profile-a", executor_id: WORKTREE_EXECUTOR_ID, name: "A" },
       { id: "profile-b", executor_id: WORKTREE_EXECUTOR_ID, name: "B" },
     ],
+  } as unknown as StoreSelections["executors"][number];
+}
+
+function makeLocalExecutor(): StoreSelections["executors"][number] {
+  return {
+    id: "exec-local",
+    type: "local",
+    profiles: [{ id: "profile-local", executor_id: "exec-local", name: "Local" }],
   } as unknown as StoreSelections["executors"][number];
 }
 
@@ -516,6 +549,20 @@ describe("useDefaultSelectionsEffect — executor profile restoration", () => {
     rerender({ sel: selAfter });
 
     await waitFor(() => expect(fs.setExecutorProfileId).toHaveBeenCalledWith("profile-a"));
+  });
+
+  it("keeps deferring when cached executor profile is ineligible for the source mode", async () => {
+    window.localStorage.setItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID, JSON.stringify("profile-a"));
+    const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "", noRepository: true });
+    const sel = makeSel({
+      executors: [makeWorktreeExecutor(), makeLocalExecutor()],
+      userSettingsLoaded: false,
+    } as Partial<StoreSelections>);
+
+    renderHook(() => useDefaultSelectionsEffect(fs, true, sel, []));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fs.setExecutorProfileId).not.toHaveBeenCalled();
   });
 
   it("restores executor profile from store-backed settings when localStorage is not primed", async () => {

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import {
-  shouldWaitForLastUsedExecutorProfile,
   useDefaultSelectionsEffect,
   useRepositoryAutoSelectEffect,
   useWorkflowAgentProfileEffect,
@@ -20,10 +19,17 @@ import { STORAGE_KEYS } from "@/lib/settings/constants";
 // so the rest can be undefined behind an `as` cast and never read.
 type Fake = Pick<
   DialogFormState,
-  "selectedWorkflowId" | "executorProfileId" | "setAgentProfileId" | "setWorkflowAgentProfileId"
+  | "agentProfileId"
+  | "workflowAgentProfileId"
+  | "selectedWorkflowId"
+  | "executorProfileId"
+  | "setAgentProfileId"
+  | "setWorkflowAgentProfileId"
 >;
 function makeFs(overrides: Partial<Fake> = {}): DialogFormState {
   return {
+    agentProfileId: "",
+    workflowAgentProfileId: "",
     selectedWorkflowId: null,
     executorProfileId: "profile-1",
     setAgentProfileId: vi.fn(),
@@ -556,30 +562,6 @@ describe("useDefaultSelectionsEffect — executor-aware agent restoration", () =
 });
 
 describe("useDefaultSelectionsEffect — executor profile restoration", () => {
-  it("waits while a valid last-used executor profile can restore", () => {
-    window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
-    const worktreeExecutor = makeWorktreeExecutor();
-
-    expect(
-      shouldWaitForLastUsedExecutorProfile({
-        executors: [worktreeExecutor],
-        workspaceDefaults: null,
-        lastUsedExecutorProfileId: WORKTREE_PROFILE_B,
-        noRepository: false,
-        preferLocalExecutor: false,
-      }),
-    ).toBe(true);
-    expect(
-      shouldWaitForLastUsedExecutorProfile({
-        executors: [worktreeExecutor],
-        workspaceDefaults: null,
-        lastUsedExecutorProfileId: "missing-profile",
-        noRepository: false,
-        preferLocalExecutor: false,
-      }),
-    ).toBe(false);
-  });
-
   it("defers executor profile fallback until user settings have loaded or settled", async () => {
     window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
     const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "" });
@@ -637,7 +619,6 @@ describe("useDefaultSelectionsEffect — executor profile restoration", () => {
 
   it("does not pick a fallback executor id while a valid last-used profile is restoring", async () => {
     window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
-    const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "" });
     const localExecutor = makeLocalExecutor();
     const worktreeExecutor = makeWorktreeExecutor();
     const sel = makeSel({
@@ -647,10 +628,34 @@ describe("useDefaultSelectionsEffect — executor profile restoration", () => {
       userSettingsLoaded: true,
     } as Partial<StoreSelections>);
 
-    renderHook(() => useDefaultSelectionsEffect(fs, true, sel, []));
+    const setExecutorId = vi.fn();
+    const setExecutorProfileId = vi.fn();
+    const { rerender } = renderHook(
+      ({ formState }) => useDefaultSelectionsEffect(formState, true, sel, []),
+      {
+        initialProps: {
+          formState: makeDefaultSelFs({
+            executorProfileId: "",
+            executorId: "",
+            setExecutorId,
+            setExecutorProfileId,
+          }),
+        },
+      },
+    );
 
-    await waitFor(() => expect(fs.setExecutorProfileId).toHaveBeenCalledWith(WORKTREE_PROFILE_B));
-    expect(fs.setExecutorId).not.toHaveBeenCalledWith(LOCAL_EXECUTOR_ID);
+    await waitFor(() => expect(setExecutorProfileId).toHaveBeenCalledWith(WORKTREE_PROFILE_B));
+    rerender({
+      formState: makeDefaultSelFs({
+        executorProfileId: WORKTREE_PROFILE_B,
+        executorId: "",
+        setExecutorId,
+        setExecutorProfileId,
+      }),
+    });
+
+    await waitFor(() => expect(setExecutorId).toHaveBeenCalledWith(WORKTREE_EXECUTOR_ID));
+    expect(setExecutorId).not.toHaveBeenCalledWith(LOCAL_EXECUTOR_ID);
   });
 });
 

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -69,6 +69,36 @@ function makeRepoAutoSelectFs(
 }
 
 describe("useRepositoryAutoSelectEffect", () => {
+  it("waits for store-backed settings before falling back to an empty row", async () => {
+    window.localStorage.removeItem(STORAGE_KEYS.LAST_REPOSITORY_ID);
+    const setRepositories = vi.fn();
+    const fs = makeRepoAutoSelectFs([], setRepositories);
+
+    const { rerender } = renderHook(
+      ({ loaded, lastUsedRepositoryId }) =>
+        useRepositoryAutoSelectEffect(
+          fs,
+          true,
+          "ws-1",
+          [makeRepository("repo-1"), makeRepository("repo-2")],
+          {
+            lastUsedRepositoryId,
+            userSettingsLoaded: loaded,
+          },
+        ),
+      { initialProps: { loaded: false, lastUsedRepositoryId: null as string | null } },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(setRepositories).not.toHaveBeenCalled();
+
+    rerender({ loaded: true, lastUsedRepositoryId: "repo-2" });
+
+    await waitFor(() => expect(setRepositories).toHaveBeenCalled());
+    const updater = setRepositories.mock.calls[0]![0] as (prev: TaskRepoRow[]) => TaskRepoRow[];
+    expect(updater([])).toEqual([{ key: "row-0", repositoryId: "repo-2", branch: "" }]);
+  });
+
   it("fills an untouched placeholder row from store-backed settings when localStorage is not primed", async () => {
     window.localStorage.removeItem(STORAGE_KEYS.LAST_REPOSITORY_ID);
     const setRepositories = vi.fn();
@@ -80,7 +110,7 @@ describe("useRepositoryAutoSelectEffect", () => {
         true,
         "ws-1",
         [makeRepository("repo-1"), makeRepository("repo-2")],
-        "repo-2",
+        { lastUsedRepositoryId: "repo-2" },
       ),
     );
 
@@ -103,7 +133,7 @@ describe("useRepositoryAutoSelectEffect", () => {
         true,
         "ws-1",
         [makeRepository("repo-1"), makeRepository("repo-2")],
-        "repo-1",
+        { lastUsedRepositoryId: "repo-1" },
       ),
     );
 
@@ -406,6 +436,30 @@ describe("useDefaultSelectionsEffect — executor-aware agent restoration", () =
 
     await new Promise((resolve) => setTimeout(resolve, 10));
     expect(fs.setAgentProfileId).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDefaultSelectionsEffect — executor profile restoration", () => {
+  it("restores executor profile from store-backed settings when localStorage is not primed", async () => {
+    window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
+    const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "" });
+    const worktreeExecutor = {
+      id: "exec-worktree",
+      type: "worktree",
+      profiles: [
+        { id: "profile-a", executor_id: "exec-worktree", name: "A" },
+        { id: "profile-b", executor_id: "exec-worktree", name: "B" },
+      ],
+    } as unknown as StoreSelections["executors"][number];
+    const sel = makeSel({
+      executors: [worktreeExecutor],
+      lastUsedExecutorProfileId: "profile-b",
+      userSettingsLoaded: true,
+    } as Partial<StoreSelections>);
+
+    renderHook(() => useDefaultSelectionsEffect(fs, true, sel, []));
+
+    await waitFor(() => expect(fs.setExecutorProfileId).toHaveBeenCalledWith("profile-b"));
   });
 });
 

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -277,7 +277,7 @@ describe("useWorkflowAgentProfileEffect", () => {
 });
 
 describe("useWorkflowAgentProfileEffect — settings fallback readiness", () => {
-  it("defers workflow last-used restore until executor compatibility is ready", async () => {
+  it("clears stale workflow agents before deferring last-used restore", async () => {
     const claude = makeProfile("claude");
     const cursor = makeProfile("cursor");
     const workflows = [{ id: "wf-1" /* no agent_profile_id */ }];
@@ -290,7 +290,8 @@ describe("useWorkflowAgentProfileEffect — settings fallback readiness", () => 
     );
 
     await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalled();
+    expect(fsBefore.setAgentProfileId).toHaveBeenCalledWith("");
+    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
 
     const fsAfter = makeFs({ selectedWorkflowId: "wf-1", executorProfileId: "profile-1" });
     rerender({ fs: fsAfter, compatible: [cursor] });

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import {
   useDefaultSelectionsEffect,
-  useGitHubUrlErrorEffect,
   useRepositoryAutoSelectEffect,
   useWorkflowAgentProfileEffect,
 } from "./task-create-dialog-effects";
@@ -285,7 +284,9 @@ describe("useWorkflowAgentProfileEffect — settings fallback readiness", () => 
 
     const { rerender } = renderHook(
       ({ fs, compatible }) =>
-        useWorkflowAgentProfileEffect(fs, workflows, [claude, cursor], compatible, claude.id),
+        useWorkflowAgentProfileEffect(fs, workflows, [claude, cursor], compatible, {
+          lastUsedAgentProfileId: claude.id,
+        }),
       { initialProps: { fs: fsBefore, compatible: [claude, cursor] } },
     );
 
@@ -298,6 +299,30 @@ describe("useWorkflowAgentProfileEffect — settings fallback readiness", () => 
 
     await waitFor(() => expect(fsAfter.setAgentProfileId).toHaveBeenCalledWith(""));
     expect(fsAfter.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
+  });
+
+  it("defers workflow last-used restore until auth compatibility is ready", async () => {
+    const claude = makeProfile("claude");
+    const workflows = [{ id: "wf-1" /* no agent_profile_id */ }];
+    const fsBefore = makeFs({ selectedWorkflowId: "wf-1", executorProfileId: "profile-1" });
+
+    const { rerender } = renderHook(
+      ({ fs, authLoaded }) =>
+        useWorkflowAgentProfileEffect(fs, workflows, [claude], [claude], {
+          lastUsedAgentProfileId: claude.id,
+          authLoaded,
+        }),
+      { initialProps: { fs: fsBefore, authLoaded: false } },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fsBefore.setAgentProfileId).toHaveBeenCalledWith("");
+    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
+
+    const fsAfter = makeFs({ selectedWorkflowId: "wf-1", executorProfileId: "profile-1" });
+    rerender({ fs: fsAfter, authLoaded: true });
+
+    await waitFor(() => expect(fsAfter.setAgentProfileId).toHaveBeenCalledWith(claude.id));
   });
 });
 
@@ -351,6 +376,9 @@ function makeSel(overrides: Partial<StoreSelections> = {}): StoreSelections {
 }
 
 const WORKTREE_EXECUTOR_ID = "exec-worktree";
+const WORKTREE_PROFILE_B = "profile-b";
+const LOCAL_EXECUTOR_ID = "exec-local";
+const LOCAL_PROFILE_ID = "profile-local";
 
 function makeWorktreeExecutor(): StoreSelections["executors"][number] {
   return {
@@ -358,16 +386,16 @@ function makeWorktreeExecutor(): StoreSelections["executors"][number] {
     type: "worktree",
     profiles: [
       { id: "profile-a", executor_id: WORKTREE_EXECUTOR_ID, name: "A" },
-      { id: "profile-b", executor_id: WORKTREE_EXECUTOR_ID, name: "B" },
+      { id: WORKTREE_PROFILE_B, executor_id: WORKTREE_EXECUTOR_ID, name: "B" },
     ],
   } as unknown as StoreSelections["executors"][number];
 }
 
 function makeLocalExecutor(): StoreSelections["executors"][number] {
   return {
-    id: "exec-local",
+    id: LOCAL_EXECUTOR_ID,
     type: "local",
-    profiles: [{ id: "profile-local", executor_id: "exec-local", name: "Local" }],
+    profiles: [{ id: LOCAL_PROFILE_ID, executor_id: LOCAL_EXECUTOR_ID, name: "Local" }],
   } as unknown as StoreSelections["executors"][number];
 }
 
@@ -573,13 +601,31 @@ describe("useDefaultSelectionsEffect — executor profile restoration", () => {
     const worktreeExecutor = makeWorktreeExecutor();
     const sel = makeSel({
       executors: [worktreeExecutor],
-      lastUsedExecutorProfileId: "profile-b",
+      lastUsedExecutorProfileId: WORKTREE_PROFILE_B,
       userSettingsLoaded: true,
     } as Partial<StoreSelections>);
 
     renderHook(() => useDefaultSelectionsEffect(fs, true, sel, []));
 
-    await waitFor(() => expect(fs.setExecutorProfileId).toHaveBeenCalledWith("profile-b"));
+    await waitFor(() => expect(fs.setExecutorProfileId).toHaveBeenCalledWith(WORKTREE_PROFILE_B));
+  });
+
+  it("does not pick a fallback executor id while a valid last-used profile is restoring", async () => {
+    window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
+    const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "" });
+    const localExecutor = makeLocalExecutor();
+    const worktreeExecutor = makeWorktreeExecutor();
+    const sel = makeSel({
+      executors: [localExecutor, worktreeExecutor],
+      workspaceDefaults: { default_executor_id: LOCAL_EXECUTOR_ID },
+      lastUsedExecutorProfileId: WORKTREE_PROFILE_B,
+      userSettingsLoaded: true,
+    } as Partial<StoreSelections>);
+
+    renderHook(() => useDefaultSelectionsEffect(fs, true, sel, []));
+
+    await waitFor(() => expect(fs.setExecutorProfileId).toHaveBeenCalledWith(WORKTREE_PROFILE_B));
+    expect(fs.setExecutorId).not.toHaveBeenCalledWith(LOCAL_EXECUTOR_ID);
   });
 });
 
@@ -664,68 +710,5 @@ describe("useDefaultSelectionsEffect — auth-spec load race", () => {
     rerender({ sel: selAfter });
     await waitFor(() => expect(fs.setAgentProfileId).toHaveBeenCalledWith(cursor.id));
     expect(fs.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
-  });
-});
-type UrlErrorFake = {
-  useRemote?: boolean;
-  remoteRepos?: Array<{ key: string; url: string; branch: string; source: "paste" | "picker" }>;
-  setGitHubUrlError?: ReturnType<typeof vi.fn>;
-};
-function makeUrlErrorFs(overrides: UrlErrorFake = {}): DialogFormState {
-  const remoteRepos = overrides.remoteRepos ?? [
-    { key: "remote-0", url: "", branch: "", source: "paste" as const },
-  ];
-  return {
-    useRemote: overrides.useRemote ?? true,
-    setGitHubUrlError: overrides.setGitHubUrlError ?? vi.fn(),
-    remoteRepos,
-  } as unknown as DialogFormState;
-}
-
-describe("useGitHubUrlErrorEffect", () => {
-  it("surfaces 'Invalid GitHub URL' for an unparseable first-row URL", () => {
-    const setGitHubUrlError = vi.fn();
-    const fs = makeUrlErrorFs({
-      remoteRepos: [{ key: "remote-0", url: "not a url", branch: "", source: "paste" }],
-      setGitHubUrlError,
-    });
-    renderHook(() => useGitHubUrlErrorEffect(fs, true));
-    expect(setGitHubUrlError).toHaveBeenCalledWith(expect.stringContaining("Invalid GitHub URL"));
-  });
-
-  it("clears the error for a valid repo URL", () => {
-    const setGitHubUrlError = vi.fn();
-    const fs = makeUrlErrorFs({
-      remoteRepos: [
-        { key: "remote-0", url: "https://github.com/acme/site", branch: "", source: "paste" },
-      ],
-      setGitHubUrlError,
-    });
-    renderHook(() => useGitHubUrlErrorEffect(fs, true));
-    expect(setGitHubUrlError).toHaveBeenLastCalledWith(null);
-  });
-
-  it("clears the error for an empty URL (rows the user hasn't completed)", () => {
-    const setGitHubUrlError = vi.fn();
-    const fs = makeUrlErrorFs({
-      remoteRepos: [{ key: "remote-0", url: "", branch: "", source: "paste" }],
-      setGitHubUrlError,
-    });
-    renderHook(() => useGitHubUrlErrorEffect(fs, true));
-    expect(setGitHubUrlError).toHaveBeenCalledWith(null);
-  });
-
-  it("clears the error when useRemote is false (stale error from a prior Remote-mode pass)", () => {
-    // Regression: the early return on !useRemote used to skip clearing the
-    // error, so a banner produced while the user was in Remote mode would
-    // stick around after they switched back to workspace mode.
-    const setGitHubUrlError = vi.fn();
-    const fs = makeUrlErrorFs({
-      useRemote: false,
-      remoteRepos: [{ key: "remote-0", url: "not a url", branch: "", source: "paste" }],
-      setGitHubUrlError,
-    });
-    renderHook(() => useGitHubUrlErrorEffect(fs, true));
-    expect(setGitHubUrlError).toHaveBeenCalledWith(null);
   });
 });

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import {
+  shouldWaitForLastUsedExecutorProfile,
   useDefaultSelectionsEffect,
   useRepositoryAutoSelectEffect,
   useWorkflowAgentProfileEffect,
@@ -555,6 +556,30 @@ describe("useDefaultSelectionsEffect — executor-aware agent restoration", () =
 });
 
 describe("useDefaultSelectionsEffect — executor profile restoration", () => {
+  it("waits while a valid last-used executor profile can restore", () => {
+    window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
+    const worktreeExecutor = makeWorktreeExecutor();
+
+    expect(
+      shouldWaitForLastUsedExecutorProfile({
+        executors: [worktreeExecutor],
+        workspaceDefaults: null,
+        lastUsedExecutorProfileId: WORKTREE_PROFILE_B,
+        noRepository: false,
+        preferLocalExecutor: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldWaitForLastUsedExecutorProfile({
+        executors: [worktreeExecutor],
+        workspaceDefaults: null,
+        lastUsedExecutorProfileId: "missing-profile",
+        noRepository: false,
+        preferLocalExecutor: false,
+      }),
+    ).toBe(false);
+  });
+
   it("defers executor profile fallback until user settings have loaded or settled", async () => {
     window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
     const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "" });

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -6,6 +6,7 @@ import {
   useRepositoryAutoSelectEffect,
   useWorkflowAgentProfileEffect,
 } from "./task-create-dialog-effects";
+import { decideAgentProfileAutopick } from "./task-create-dialog-autopick";
 import type {
   DialogFormState,
   StoreSelections,
@@ -323,6 +324,58 @@ function makeSel(overrides: Partial<StoreSelections> = {}): StoreSelections {
   };
 }
 
+const WORKTREE_EXECUTOR_ID = "exec-worktree";
+
+function makeWorktreeExecutor(): StoreSelections["executors"][number] {
+  return {
+    id: WORKTREE_EXECUTOR_ID,
+    type: "worktree",
+    profiles: [
+      { id: "profile-a", executor_id: WORKTREE_EXECUTOR_ID, name: "A" },
+      { id: "profile-b", executor_id: WORKTREE_EXECUTOR_ID, name: "B" },
+    ],
+  } as unknown as StoreSelections["executors"][number];
+}
+
+describe("useDefaultSelectionsEffect — agent settings deferral", () => {
+  it("defers agent auto-pick until user settings have loaded or settled", () => {
+    const cursor = makeProfile("cursor");
+    const deferred = decideAgentProfileAutopick({
+      open: true,
+      agentProfileId: "",
+      workflowAgentProfileId: "",
+      workflowHasAgent: false,
+      agentProfiles: [cursor],
+      compatibleAgentProfiles: [cursor],
+      authLoaded: true,
+      executorProfileId: "",
+      hasExecutors: false,
+      lastAgentProfileId: null,
+      userSettingsLoaded: false,
+      defaultAgentProfileId: null,
+    });
+
+    expect(deferred).toEqual({ kind: "defer", reason: "user-settings-not-loaded" });
+
+    const picked = decideAgentProfileAutopick({
+      open: true,
+      agentProfileId: "",
+      workflowAgentProfileId: "",
+      workflowHasAgent: false,
+      agentProfiles: [cursor],
+      compatibleAgentProfiles: [cursor],
+      authLoaded: true,
+      executorProfileId: "",
+      hasExecutors: false,
+      lastAgentProfileId: null,
+      userSettingsLoaded: true,
+      defaultAgentProfileId: null,
+    });
+
+    expect(picked).toEqual({ kind: "pick", source: "first", id: cursor.id });
+  });
+});
+
 describe("useDefaultSelectionsEffect — executor-aware agent restoration", () => {
   it("restores lastId when it is compatible with the current executor", async () => {
     const claude = makeProfile("claude");
@@ -440,17 +493,35 @@ describe("useDefaultSelectionsEffect — executor-aware agent restoration", () =
 });
 
 describe("useDefaultSelectionsEffect — executor profile restoration", () => {
+  it("defers executor profile fallback until user settings have loaded or settled", async () => {
+    window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
+    const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "" });
+    const worktreeExecutor = makeWorktreeExecutor();
+    const selBefore = makeSel({
+      executors: [worktreeExecutor],
+      userSettingsLoaded: false,
+    } as Partial<StoreSelections>);
+
+    const { rerender } = renderHook(({ sel }) => useDefaultSelectionsEffect(fs, true, sel, []), {
+      initialProps: { sel: selBefore },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fs.setExecutorProfileId).not.toHaveBeenCalled();
+
+    const selAfter = makeSel({
+      executors: [worktreeExecutor],
+      userSettingsLoaded: true,
+    } as Partial<StoreSelections>);
+    rerender({ sel: selAfter });
+
+    await waitFor(() => expect(fs.setExecutorProfileId).toHaveBeenCalledWith("profile-a"));
+  });
+
   it("restores executor profile from store-backed settings when localStorage is not primed", async () => {
     window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
     const fs = makeDefaultSelFs({ executorProfileId: "", executorId: "" });
-    const worktreeExecutor = {
-      id: "exec-worktree",
-      type: "worktree",
-      profiles: [
-        { id: "profile-a", executor_id: "exec-worktree", name: "A" },
-        { id: "profile-b", executor_id: "exec-worktree", name: "B" },
-      ],
-    } as unknown as StoreSelections["executors"][number];
+    const worktreeExecutor = makeWorktreeExecutor();
     const sel = makeSel({
       executors: [worktreeExecutor],
       lastUsedExecutorProfileId: "profile-b",

--- a/apps/web/components/task-create-dialog-effects.test.ts
+++ b/apps/web/components/task-create-dialog-effects.test.ts
@@ -370,7 +370,7 @@ function makeLocalExecutor(): StoreSelections["executors"][number] {
   } as unknown as StoreSelections["executors"][number];
 }
 
-describe("useDefaultSelectionsEffect — agent settings deferral", () => {
+describe("decideAgentProfileAutopick — user settings deferral", () => {
   it("defers agent auto-pick until user settings have loaded or settled", () => {
     const cursor = makeProfile("cursor");
     const deferred = decideAgentProfileAutopick({
@@ -540,6 +540,7 @@ describe("useDefaultSelectionsEffect — executor profile restoration", () => {
     });
 
     await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fs.setExecutorId).not.toHaveBeenCalled();
     expect(fs.setExecutorProfileId).not.toHaveBeenCalled();
 
     const selAfter = makeSel({

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -16,30 +16,22 @@ import type {
   DialogFormState,
   StoreSelections,
   TaskCreateEffectsArgs,
-  TaskRepoRow,
 } from "@/components/task-create-dialog-types";
 import {
   useAgentProfileAutopickEffect,
   useWorkflowAgentProfileEffect,
 } from "@/components/task-create-dialog-autopick";
+import { useRepositoryAutoSelectEffect } from "@/components/task-create-dialog-repository-autopick";
 import { computeSelectedRepoCount } from "@/components/task-create-dialog-computed";
 import { createDebugLogger, isDebug } from "@/lib/debug/log";
 
 // Re-export autopick hooks for callers that imported them from this module.
 export { useWorkflowAgentProfileEffect };
+export { useRepositoryAutoSelectEffect } from "@/components/task-create-dialog-repository-autopick";
 // Also re-exported for the test file, which expects the symbol to live here.
 export { decideAgentProfileAutopick } from "@/components/task-create-dialog-autopick";
 
 const selectionDebug = createDebugLogger("task-create:selection");
-
-type RepositoryAutoPickDecision = {
-  pickId: string | null;
-  source: string;
-  localStorageRepoId: string | null;
-  localStorageValid: boolean;
-  settingsRepoId: string | null;
-  settingsValid: boolean;
-};
 
 export function useWorkflowStepsEffect(fs: DialogFormState, workflowId: string | null) {
   const { selectedWorkflowId, setFetchedSteps } = fs;
@@ -62,122 +54,6 @@ export function useWorkflowStepsEffect(fs: DialogFormState, workflowId: string |
       cancelled = true;
     };
   }, [selectedWorkflowId, workflowId, setFetchedSteps]);
-}
-
-export function useRepositoryAutoSelectEffect(
-  fs: DialogFormState,
-  open: boolean,
-  workspaceId: string | null,
-  repositories: Repository[],
-  lastUsedRepositoryId?: string | null,
-) {
-  // On open, ensure there's always at least one chip rendered: prefer the
-  // user's last-used repo (or the workspace's only repo) so the chip lands
-  // pre-filled, but fall back to an empty row so the picker is visible
-  // instead of just the "+" button. URL mode is excluded — that flow swaps
-  // the chip row for a URL input.
-  const { repositories: rows, useRemote, setRepositories } = fs;
-  useEffect(() => {
-    if (!open || !workspaceId || useRemote) return;
-    const decision = decideRepositoryAutoPick(repositories, lastUsedRepositoryId);
-    const { pickId } = decision;
-    if (rows.length > 0 && !canReplaceEmptyRepositoryPlaceholder(rows, pickId)) return;
-    logRepositoryAutoPick(workspaceId, repositories.length, decision);
-    // Use the functional setter so the deferred microtask sees fresh state.
-    // Without this, a sibling effect (resetTaskForm / useLockedFieldSync) that
-    // seeds rows from `initialValues.repositoryId` synchronously races with
-    // this microtask — the microtask captured rows.length === 0 at queue time
-    // and would blindly clobber the initialValues-seeded row.
-    void Promise.resolve().then(() => {
-      setRepositories((prev) => {
-        if (prev.length > 0) {
-          if (canReplaceEmptyRepositoryPlaceholder(prev, pickId)) {
-            return [buildRepositoryAutoPickRow(prev[0]?.key ?? "row-0", pickId!)];
-          }
-          if (isDebug()) {
-            selectionDebug("repository-autopick-skip", {
-              reason: "rows-seeded-before-microtask",
-              row_count: prev.length,
-            });
-          }
-          return prev;
-        }
-        return [
-          pickId ? buildRepositoryAutoPickRow("row-0", pickId) : { key: "row-0", branch: "" },
-        ];
-      });
-    });
-  }, [open, repositories, rows, useRemote, workspaceId, setRepositories, lastUsedRepositoryId]);
-}
-
-function decideRepositoryAutoPick(
-  repositories: Repository[],
-  lastUsedRepositoryId?: string | null,
-): RepositoryAutoPickDecision {
-  const localStorageRepoId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_REPOSITORY_ID, null);
-  const settingsRepoId = lastUsedRepositoryId ?? null;
-  const localStorageValid = isRepositoryIdValid(localStorageRepoId, repositories);
-  const settingsValid = isRepositoryIdValid(settingsRepoId, repositories);
-  if (localStorageRepoId && localStorageValid) {
-    return {
-      pickId: localStorageRepoId,
-      source: "localStorage:lastRepositoryId",
-      localStorageRepoId,
-      localStorageValid,
-      settingsRepoId,
-      settingsValid,
-    };
-  }
-  if (settingsRepoId && settingsValid) {
-    return {
-      pickId: settingsRepoId,
-      source: "settings:taskCreateLastUsed",
-      localStorageRepoId,
-      localStorageValid,
-      settingsRepoId,
-      settingsValid,
-    };
-  }
-  return {
-    pickId: repositories.length === 1 ? repositories[0].id : null,
-    source: repositories.length === 1 ? "single-workspace-repo" : "empty-row",
-    localStorageRepoId,
-    localStorageValid,
-    settingsRepoId,
-    settingsValid,
-  };
-}
-
-function isRepositoryIdValid(repositoryId: string | null, repositories: Repository[]): boolean {
-  return Boolean(repositoryId && repositories.some((r: Repository) => r.id === repositoryId));
-}
-
-function logRepositoryAutoPick(
-  workspaceId: string,
-  repoCount: number,
-  decision: RepositoryAutoPickDecision,
-) {
-  if (!isDebug()) return;
-  selectionDebug("repository-autopick", {
-    workspace_id: workspaceId,
-    local_storage_id: decision.localStorageRepoId ?? "-",
-    local_storage_valid: decision.localStorageValid,
-    settings_id: decision.settingsRepoId ?? "-",
-    settings_valid: decision.settingsValid,
-    repo_count: repoCount,
-    source: decision.source,
-    pick: decision.pickId ?? "-",
-  });
-}
-
-function buildRepositoryAutoPickRow(key: string, repositoryId: string): TaskRepoRow {
-  return { key, repositoryId, branch: "" };
-}
-
-function canReplaceEmptyRepositoryPlaceholder(rows: TaskRepoRow[], pickId: string | null): boolean {
-  if (!pickId || rows.length !== 1) return false;
-  const row = rows[0];
-  return Boolean(row && !row.repositoryId && !row.localPath && !row.branch);
 }
 
 export function useDiscoverReposEffect(
@@ -342,6 +218,7 @@ function pickDefaultExecutorProfileId(
   workspaceDefaults: { default_executor_id?: string | null } | null | undefined,
   noRepository: boolean,
   preferLocalExecutor: boolean,
+  lastUsedExecutorProfileId?: string | null,
 ): string | null {
   const allProfiles = flattenExecutorProfiles(executors);
   if (allProfiles.length === 0) return null;
@@ -353,6 +230,12 @@ function pickDefaultExecutorProfileId(
 
   const lastId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID, null);
   if (lastId && eligibleProfiles.some((p) => p.id === lastId)) return lastId;
+  if (
+    lastUsedExecutorProfileId &&
+    eligibleProfiles.some((p) => p.id === lastUsedExecutorProfileId)
+  ) {
+    return lastUsedExecutorProfileId;
+  }
 
   const executorId = pickDefaultExecutorId(
     executors,
@@ -367,9 +250,68 @@ function pickDefaultExecutorProfileId(
 type ExecutorAutopickContext = {
   executors: Executor[];
   workspaceDefaults: StoreSelections["workspaceDefaults"];
+  userSettingsLoaded?: boolean;
+  lastUsedExecutorProfileId?: string | null;
   noRepository: boolean;
   preferLocalExecutor: boolean;
 };
+
+type ExecutorProfileLastUsedState = {
+  allProfiles: ExecutorProfileCandidate[];
+  localStorageId: string | null;
+  localStorageValid: boolean;
+  settingsId: string | null;
+  settingsValid: boolean;
+};
+
+function getExecutorProfileLastUsedState(
+  executors: Executor[],
+  settingsId: string | null,
+): ExecutorProfileLastUsedState {
+  const allProfiles = flattenExecutorProfiles(executors);
+  const localStorageId = getLocalStorage<string | null>(
+    STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
+    null,
+  );
+  return {
+    allProfiles,
+    localStorageId,
+    localStorageValid: Boolean(localStorageId && allProfiles.some((p) => p.id === localStorageId)),
+    settingsId,
+    settingsValid: Boolean(settingsId && allProfiles.some((p) => p.id === settingsId)),
+  };
+}
+
+function shouldDeferExecutorProfileAutopick(
+  context: ExecutorAutopickContext,
+  lastUsed: ExecutorProfileLastUsedState,
+) {
+  return (
+    context.userSettingsLoaded === false && !lastUsed.localStorageValid && !lastUsed.settingsValid
+  );
+}
+
+function logExecutorProfileAutopick(
+  pick: string | null,
+  context: ExecutorAutopickContext,
+  lastUsed: ExecutorProfileLastUsedState,
+  source?: string,
+) {
+  if (!isDebug()) return;
+  selectionDebug("executor-profile-autopick", {
+    current: "-",
+    pick: pick ?? "-",
+    local_storage_id: lastUsed.localStorageId ?? "-",
+    local_storage_valid: lastUsed.localStorageValid,
+    settings_id: lastUsed.settingsId ?? "-",
+    settings_valid: lastUsed.settingsValid,
+    profile_count: lastUsed.allProfiles.length,
+    workspace_default_executor: context.workspaceDefaults?.default_executor_id ?? "-",
+    no_repository: context.noRepository,
+    prefer_local_executor: context.preferLocalExecutor,
+    ...(source ? { source } : {}),
+  });
+}
 
 function useMultiRepoGuardEffect(
   open: boolean,
@@ -461,26 +403,22 @@ function useExecutorProfileAutopickEffect({
     // Auto-select executor profile: last used (localStorage) → source-aware
     // executor default → first eligible profile.
     if (!open || executorProfileId || executors.length === 0) return;
+    const lastUsed = getExecutorProfileLastUsedState(
+      executors,
+      context.lastUsedExecutorProfileId ?? null,
+    );
+    if (shouldDeferExecutorProfileAutopick(context, lastUsed)) {
+      logExecutorProfileAutopick(null, context, lastUsed, "user-settings-loading");
+      return;
+    }
     const pick = pickDefaultExecutorProfileId(
       executors,
       workspaceDefaults,
       noRepository,
       preferLocalExecutor,
+      context.lastUsedExecutorProfileId,
     );
-    if (isDebug()) {
-      const lastId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID, null);
-      const allProfiles = flattenExecutorProfiles(executors);
-      selectionDebug("executor-profile-autopick", {
-        current: "-",
-        pick: pick ?? "-",
-        local_storage_id: lastId ?? "-",
-        local_storage_valid: Boolean(lastId && allProfiles.some((p) => p.id === lastId)),
-        profile_count: allProfiles.length,
-        workspace_default_executor: workspaceDefaults?.default_executor_id ?? "-",
-        no_repository: noRepository,
-        prefer_local_executor: preferLocalExecutor,
-      });
-    }
+    logExecutorProfileAutopick(pick, context, lastUsed);
     if (pick) void Promise.resolve().then(() => setExecutorProfileId(pick));
   }, [
     open,
@@ -490,6 +428,8 @@ function useExecutorProfileAutopickEffect({
     setExecutorProfileId,
     noRepository,
     preferLocalExecutor,
+    context.lastUsedExecutorProfileId,
+    context.userSettingsLoaded,
   ]);
 }
 
@@ -513,8 +453,22 @@ export function useDefaultSelectionsEffect(
   const preferLocalExecutor =
     !noRepository && !useRemote && repositories.some((row) => Boolean(row.localPath));
   const executorAutopickContext = useMemo(
-    () => ({ executors, workspaceDefaults, noRepository, preferLocalExecutor }),
-    [executors, workspaceDefaults, noRepository, preferLocalExecutor],
+    () => ({
+      executors,
+      workspaceDefaults,
+      userSettingsLoaded: sel.userSettingsLoaded,
+      lastUsedExecutorProfileId: sel.lastUsedExecutorProfileId,
+      noRepository,
+      preferLocalExecutor,
+    }),
+    [
+      executors,
+      workspaceDefaults,
+      sel.userSettingsLoaded,
+      sel.lastUsedExecutorProfileId,
+      noRepository,
+      preferLocalExecutor,
+    ],
   );
   useAgentProfileAutopickEffect(fs, open, sel, workflows);
   useExecutorIdAutopickEffect({
@@ -624,15 +578,33 @@ export function useTaskCreateDialogEffects(fs: DialogFormState, args: TaskCreate
     isLocalExecutor,
   } = args;
   useWorkflowStepsEffect(fs, workflowId);
-  useWorkflowAgentProfileEffect(fs, workflows, agentProfiles, compatibleAgentProfiles);
-  useRepositoryAutoSelectEffect(fs, open, workspaceId, repositories, args.lastUsedRepositoryId);
+  useWorkflowAgentProfileEffect(
+    fs,
+    workflows,
+    agentProfiles,
+    compatibleAgentProfiles,
+    args.lastUsedAgentProfileId,
+  );
+  useRepositoryAutoSelectEffect(fs, open, workspaceId, repositories, {
+    lastUsedRepositoryId: args.lastUsedRepositoryId,
+    userSettingsLoaded: args.userSettingsLoaded,
+  });
   useDiscoverReposEffect(fs, open, workspaceId, repositoriesLoading, toast);
   useCurrentLocalBranchEffect(fs, open, workspaceId, repositories);
   useResetBranchOnLocalSwitchEffect(fs, isLocalExecutor, args.preserveBranch);
   useDefaultSelectionsEffect(
     fs,
     open,
-    { agentProfiles, compatibleAgentProfiles, authLoaded, executors, workspaceDefaults },
+    {
+      agentProfiles,
+      compatibleAgentProfiles,
+      authLoaded,
+      executors,
+      workspaceDefaults,
+      userSettingsLoaded: args.userSettingsLoaded,
+      lastUsedAgentProfileId: args.lastUsedAgentProfileId,
+      lastUsedExecutorProfileId: args.lastUsedExecutorProfileId,
+    },
     workflows,
   );
   useGitHubUrlErrorEffect(fs, open);

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -301,6 +301,26 @@ function shouldDeferExecutorProfileAutopick(
   );
 }
 
+export function shouldWaitForLastUsedExecutorProfile(context: ExecutorAutopickContext) {
+  const lastUsedProfile = getExecutorProfileLastUsedState(
+    context,
+    context.lastUsedExecutorProfileId ?? null,
+  );
+  if (!lastUsedProfile.localStorageValid && !lastUsedProfile.settingsValid) return false;
+  if (isDebug()) {
+    selectionDebug("executor-autopick", {
+      current: "-",
+      pick: "-",
+      executor_count: context.executors.length,
+      workspace_default: context.workspaceDefaults?.default_executor_id ?? "-",
+      no_repository: context.noRepository,
+      prefer_local_executor: context.preferLocalExecutor,
+      source: "executor-profile-last-used",
+    });
+  }
+  return true;
+}
+
 function logExecutorProfileAutopick(
   pick: string | null,
   context: ExecutorAutopickContext,
@@ -369,27 +389,6 @@ function useExecutorIdAutopickEffect({
         no_repository: noRepository,
         prefer_local_executor: preferLocalExecutor,
       });
-    }
-
-    function shouldWaitForLastUsedExecutorProfile(context: ExecutorAutopickContext) {
-      const { executors, workspaceDefaults, noRepository, preferLocalExecutor } = context;
-      const lastUsedProfile = getExecutorProfileLastUsedState(
-        context,
-        context.lastUsedExecutorProfileId ?? null,
-      );
-      if (!lastUsedProfile.localStorageValid && !lastUsedProfile.settingsValid) return false;
-      if (isDebug()) {
-        selectionDebug("executor-autopick", {
-          current: "-",
-          pick: "-",
-          executor_count: executors.length,
-          workspace_default: workspaceDefaults?.default_executor_id ?? "-",
-          no_repository: noRepository,
-          prefer_local_executor: preferLocalExecutor,
-          source: "executor-profile-last-used",
-        });
-      }
-      return true;
     }
     if (pick) void Promise.resolve().then(() => setExecutorId(pick));
   }, [

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -258,6 +258,7 @@ type ExecutorAutopickContext = {
 
 type ExecutorProfileLastUsedState = {
   allProfiles: ExecutorProfileCandidate[];
+  eligibleProfiles: ExecutorProfileCandidate[];
   localStorageId: string | null;
   localStorageValid: boolean;
   settingsId: string | null;
@@ -265,20 +266,28 @@ type ExecutorProfileLastUsedState = {
 };
 
 function getExecutorProfileLastUsedState(
-  executors: Executor[],
+  context: ExecutorAutopickContext,
   settingsId: string | null,
 ): ExecutorProfileLastUsedState {
+  const { executors, noRepository, preferLocalExecutor } = context;
   const allProfiles = flattenExecutorProfiles(executors);
+  const eligibleProfiles =
+    noRepository || preferLocalExecutor
+      ? allProfiles.filter((p) => !isWorktreeExecutorType(p._executorType))
+      : allProfiles;
   const localStorageId = getLocalStorage<string | null>(
     STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
     null,
   );
   return {
     allProfiles,
+    eligibleProfiles,
     localStorageId,
-    localStorageValid: Boolean(localStorageId && allProfiles.some((p) => p.id === localStorageId)),
+    localStorageValid: Boolean(
+      localStorageId && eligibleProfiles.some((p) => p.id === localStorageId),
+    ),
     settingsId,
-    settingsValid: Boolean(settingsId && allProfiles.some((p) => p.id === settingsId)),
+    settingsValid: Boolean(settingsId && eligibleProfiles.some((p) => p.id === settingsId)),
   };
 }
 
@@ -404,7 +413,7 @@ function useExecutorProfileAutopickEffect({
     // executor default → first eligible profile.
     if (!open || executorProfileId || executors.length === 0) return;
     const lastUsed = getExecutorProfileLastUsedState(
-      executors,
+      context,
       context.lastUsedExecutorProfileId ?? null,
     );
     if (shouldDeferExecutorProfileAutopick(context, lastUsed)) {

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -368,6 +368,20 @@ function useExecutorIdAutopickEffect({
   const { executors, workspaceDefaults, noRepository, preferLocalExecutor } = context;
   useEffect(() => {
     if (!open || executorId || executors.length === 0) return;
+    if (context.userSettingsLoaded === false) {
+      if (isDebug()) {
+        selectionDebug("executor-autopick", {
+          current: "-",
+          pick: "-",
+          executor_count: executors.length,
+          workspace_default: workspaceDefaults?.default_executor_id ?? "-",
+          no_repository: noRepository,
+          prefer_local_executor: preferLocalExecutor,
+          source: "user-settings-loading",
+        });
+      }
+      return;
+    }
     const pick = pickDefaultExecutorId(
       executors,
       workspaceDefaults,
@@ -393,6 +407,7 @@ function useExecutorIdAutopickEffect({
     setExecutorId,
     noRepository,
     preferLocalExecutor,
+    context.userSettingsLoaded,
   ]);
 }
 

--- a/apps/web/components/task-create-dialog-effects.ts
+++ b/apps/web/components/task-create-dialog-effects.ts
@@ -21,6 +21,7 @@ import {
   useAgentProfileAutopickEffect,
   useWorkflowAgentProfileEffect,
 } from "@/components/task-create-dialog-autopick";
+import { useMultiRepoGuardEffect } from "@/components/task-create-dialog-multi-repo-guard";
 import { useRepositoryAutoSelectEffect } from "@/components/task-create-dialog-repository-autopick";
 import { computeSelectedRepoCount } from "@/components/task-create-dialog-computed";
 import { createDebugLogger, isDebug } from "@/lib/debug/log";
@@ -322,38 +323,6 @@ function logExecutorProfileAutopick(
   });
 }
 
-function useMultiRepoGuardEffect(
-  open: boolean,
-  executorProfileId: string,
-  setExecutorProfileId: (id: string) => void,
-  executors: Executor[],
-  selectedRepoCount: number,
-) {
-  // Multi-repo guard: when 2+ repos are selected, only worktree profiles can
-  // run the task (Docker / Sprites / standalone don't yet provision sibling
-  // repos under one task root). If the current profile is non-worktree, swap
-  // to a worktree profile — preferring the last-used worktree, otherwise the
-  // first one available. Single-repo selections leave the profile alone.
-  useEffect(() => {
-    if (!open || !executorProfileId || executors.length === 0) return;
-    if (selectedRepoCount <= 1) return;
-    const profileToType = new Map<string, string | undefined>();
-    const worktreeProfileIds: string[] = [];
-    for (const e of executors) {
-      for (const p of e.profiles ?? []) {
-        const type = p.executor_type ?? e.type;
-        profileToType.set(p.id, type);
-        if (type === "worktree") worktreeProfileIds.push(p.id);
-      }
-    }
-    if (worktreeProfileIds.length === 0) return;
-    if (profileToType.get(executorProfileId) === "worktree") return;
-    const lastId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID, null);
-    const pick = lastId && worktreeProfileIds.includes(lastId) ? lastId : worktreeProfileIds[0];
-    void Promise.resolve().then(() => setExecutorProfileId(pick));
-  }, [open, executorProfileId, executors, selectedRepoCount, setExecutorProfileId]);
-}
-
 function useExecutorIdAutopickEffect({
   open,
   executorId,
@@ -382,6 +351,9 @@ function useExecutorIdAutopickEffect({
       }
       return;
     }
+    if (shouldWaitForLastUsedExecutorProfile(context)) {
+      return;
+    }
     const pick = pickDefaultExecutorId(
       executors,
       workspaceDefaults,
@@ -398,6 +370,27 @@ function useExecutorIdAutopickEffect({
         prefer_local_executor: preferLocalExecutor,
       });
     }
+
+    function shouldWaitForLastUsedExecutorProfile(context: ExecutorAutopickContext) {
+      const { executors, workspaceDefaults, noRepository, preferLocalExecutor } = context;
+      const lastUsedProfile = getExecutorProfileLastUsedState(
+        context,
+        context.lastUsedExecutorProfileId ?? null,
+      );
+      if (!lastUsedProfile.localStorageValid && !lastUsedProfile.settingsValid) return false;
+      if (isDebug()) {
+        selectionDebug("executor-autopick", {
+          current: "-",
+          pick: "-",
+          executor_count: executors.length,
+          workspace_default: workspaceDefaults?.default_executor_id ?? "-",
+          no_repository: noRepository,
+          prefer_local_executor: preferLocalExecutor,
+          source: "executor-profile-last-used",
+        });
+      }
+      return true;
+    }
     if (pick) void Promise.resolve().then(() => setExecutorId(pick));
   }, [
     open,
@@ -408,6 +401,7 @@ function useExecutorIdAutopickEffect({
     noRepository,
     preferLocalExecutor,
     context.userSettingsLoaded,
+    context.lastUsedExecutorProfileId,
   ]);
 }
 
@@ -526,14 +520,6 @@ export function useDefaultSelectionsEffect(
     }
   }, [executorProfileId, executors, setExecutorId]);
 
-  // Count is mode-aware: Remote mode counts non-empty URL rows, workspace
-  // mode counts rows with a repo/path. Without this, 2 Remote rows + 0
-  // workspace rows would slip past the guard because the legacy check only
-  // inspected `fs.repositories` — `computeSelectedRepoCount` handles both.
-  // Depend on the count primitive, not the whole `fs` object. `fs` is a fresh
-  // literal every render, so listing it in the dep array would re-run this
-  // effect on every render. computeSelectedRepoCount only reads noRepository /
-  // useRemote / remoteRepos / repositories, so memoize over exactly those.
   const selectedRepoCount = useMemo(
     () =>
       computeSelectedRepoCount({
@@ -602,13 +588,10 @@ export function useTaskCreateDialogEffects(fs: DialogFormState, args: TaskCreate
     isLocalExecutor,
   } = args;
   useWorkflowStepsEffect(fs, workflowId);
-  useWorkflowAgentProfileEffect(
-    fs,
-    workflows,
-    agentProfiles,
-    compatibleAgentProfiles,
-    args.lastUsedAgentProfileId,
-  );
+  useWorkflowAgentProfileEffect(fs, workflows, agentProfiles, compatibleAgentProfiles, {
+    lastUsedAgentProfileId: args.lastUsedAgentProfileId,
+    authLoaded,
+  });
   useRepositoryAutoSelectEffect(fs, open, workspaceId, repositories, {
     lastUsedRepositoryId: args.lastUsedRepositoryId,
     userSettingsLoaded: args.userSettingsLoaded,

--- a/apps/web/components/task-create-dialog-executor-wait.test.ts
+++ b/apps/web/components/task-create-dialog-executor-wait.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { shouldWaitForLastUsedExecutorProfile } from "./task-create-dialog-effects";
+import { STORAGE_KEYS } from "@/lib/settings/constants";
+import type { StoreSelections } from "@/components/task-create-dialog-types";
+
+const WORKTREE_EXECUTOR_ID = "exec-worktree";
+const WORKTREE_PROFILE_ID = "profile-b";
+
+function makeWorktreeExecutor(): StoreSelections["executors"][number] {
+  return {
+    id: WORKTREE_EXECUTOR_ID,
+    type: "worktree",
+    profiles: [{ id: WORKTREE_PROFILE_ID, executor_id: WORKTREE_EXECUTOR_ID, name: "B" }],
+  } as unknown as StoreSelections["executors"][number];
+}
+
+beforeEach(() => {
+  window.localStorage.removeItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID);
+});
+
+describe("shouldWaitForLastUsedExecutorProfile", () => {
+  it("waits only while a valid last-used executor profile can restore", () => {
+    const worktreeExecutor = makeWorktreeExecutor();
+
+    expect(
+      shouldWaitForLastUsedExecutorProfile({
+        executors: [worktreeExecutor],
+        workspaceDefaults: null,
+        lastUsedExecutorProfileId: WORKTREE_PROFILE_ID,
+        noRepository: false,
+        preferLocalExecutor: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldWaitForLastUsedExecutorProfile({
+        executors: [worktreeExecutor],
+        workspaceDefaults: null,
+        lastUsedExecutorProfileId: "missing-profile",
+        noRepository: false,
+        preferLocalExecutor: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/components/task-create-dialog-github-url-error-effect.test.ts
+++ b/apps/web/components/task-create-dialog-github-url-error-effect.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGitHubUrlErrorEffect } from "./task-create-dialog-effects";
+import type { DialogFormState } from "./task-create-dialog-types";
+
+type UrlErrorFake = {
+  useRemote?: boolean;
+  remoteRepos?: Array<{ key: string; url: string; branch: string; source: "paste" | "picker" }>;
+  setGitHubUrlError?: ReturnType<typeof vi.fn>;
+};
+
+function makeUrlErrorFs(overrides: UrlErrorFake = {}): DialogFormState {
+  const remoteRepos = overrides.remoteRepos ?? [
+    { key: "remote-0", url: "", branch: "", source: "paste" as const },
+  ];
+  return {
+    useRemote: overrides.useRemote ?? true,
+    setGitHubUrlError: overrides.setGitHubUrlError ?? vi.fn(),
+    remoteRepos,
+  } as unknown as DialogFormState;
+}
+
+describe("useGitHubUrlErrorEffect", () => {
+  it("surfaces 'Invalid GitHub URL' for an unparseable first-row URL", () => {
+    const setGitHubUrlError = vi.fn();
+    const fs = makeUrlErrorFs({
+      remoteRepos: [{ key: "remote-0", url: "not a url", branch: "", source: "paste" }],
+      setGitHubUrlError,
+    });
+    renderHook(() => useGitHubUrlErrorEffect(fs, true));
+    expect(setGitHubUrlError).toHaveBeenCalledWith(expect.stringContaining("Invalid GitHub URL"));
+  });
+
+  it("clears the error for a valid repo URL", () => {
+    const setGitHubUrlError = vi.fn();
+    const fs = makeUrlErrorFs({
+      remoteRepos: [
+        { key: "remote-0", url: "https://github.com/acme/site", branch: "", source: "paste" },
+      ],
+      setGitHubUrlError,
+    });
+    renderHook(() => useGitHubUrlErrorEffect(fs, true));
+    expect(setGitHubUrlError).toHaveBeenLastCalledWith(null);
+  });
+
+  it("clears the error for an empty URL", () => {
+    const setGitHubUrlError = vi.fn();
+    const fs = makeUrlErrorFs({
+      remoteRepos: [{ key: "remote-0", url: "", branch: "", source: "paste" }],
+      setGitHubUrlError,
+    });
+    renderHook(() => useGitHubUrlErrorEffect(fs, true));
+    expect(setGitHubUrlError).toHaveBeenCalledWith(null);
+  });
+
+  it("clears stale errors when useRemote is false", () => {
+    const setGitHubUrlError = vi.fn();
+    const fs = makeUrlErrorFs({
+      useRemote: false,
+      remoteRepos: [{ key: "remote-0", url: "not a url", branch: "", source: "paste" }],
+      setGitHubUrlError,
+    });
+    renderHook(() => useGitHubUrlErrorEffect(fs, true));
+    expect(setGitHubUrlError).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/web/components/task-create-dialog-handlers.test.ts
+++ b/apps/web/components/task-create-dialog-handlers.test.ts
@@ -20,7 +20,7 @@ describe("syncTaskCreateLastUsed", () => {
     vi.mocked(updateUserSettings).mockReset();
   });
 
-  it("persists failed last-used patches and retries them after an in-memory reset", async () => {
+  it("persists failed last-used patches and retries them on the next sync", async () => {
     vi.mocked(updateUserSettings).mockRejectedValueOnce(new Error("network"));
 
     syncTaskCreateLastUsed({ branch: "feature" });
@@ -34,7 +34,6 @@ describe("syncTaskCreateLastUsed", () => {
       branch: "feature",
     });
 
-    resetTaskCreateLastUsedSync({ clearQueued: true });
     vi.mocked(updateUserSettings).mockResolvedValueOnce({ settings: {} } as Awaited<
       ReturnType<typeof updateUserSettings>
     >);
@@ -73,9 +72,12 @@ describe("syncTaskCreateLastUsed", () => {
   });
 
   it("keeps queued fields when dialog close resets pending sync state", async () => {
-    vi.mocked(updateUserSettings).mockResolvedValue({ settings: {} } as Awaited<
-      ReturnType<typeof updateUserSettings>
-    >);
+    let resolveSync!: (response: Awaited<ReturnType<typeof updateUserSettings>>) => void;
+    vi.mocked(updateUserSettings).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSync = resolve;
+      }),
+    );
 
     syncTaskCreateLastUsed({ branch: "feature" });
     await waitFor(() => {
@@ -83,12 +85,21 @@ describe("syncTaskCreateLastUsed", () => {
         task_create_last_used: { branch: "feature" },
       });
     });
+    expect(JSON.parse(window.localStorage.getItem(PENDING_LAST_USED_SYNC_KEY) ?? "null")).toEqual({
+      branch: "feature",
+    });
 
     resetTaskCreateLastUsedSync();
 
+    expect(window.localStorage.getItem(PENDING_LAST_USED_SYNC_KEY)).toBeNull();
     expect(readQueuedTaskCreateLastUsedState()).toMatchObject({
       branch: "feature",
     });
     expect(readQueuedTaskCreateLastUsedState().agentProfileId).toBeUndefined();
+
+    resolveSync({ settings: {} } as Awaited<ReturnType<typeof updateUserSettings>>);
+    await waitFor(() => {
+      expect(window.localStorage.getItem(PENDING_LAST_USED_SYNC_KEY)).toBeNull();
+    });
   });
 });

--- a/apps/web/components/task-create-dialog-handlers.test.ts
+++ b/apps/web/components/task-create-dialog-handlers.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
 import { updateUserSettings } from "@/lib/api/domains/settings-api";
-import { resetTaskCreateLastUsedSync, syncTaskCreateLastUsed } from "./task-create-dialog-handlers";
+import {
+  readQueuedTaskCreateLastUsedState,
+  resetTaskCreateLastUsedSync,
+  syncTaskCreateLastUsed,
+} from "./task-create-dialog-handlers";
 
 const PENDING_LAST_USED_SYNC_KEY = "kandev.taskCreateLastUsed.pendingSync";
 
@@ -42,6 +46,29 @@ describe("syncTaskCreateLastUsed", () => {
         task_create_last_used: { branch: "feature" },
       });
       expect(window.localStorage.getItem(PENDING_LAST_USED_SYNC_KEY)).toBeNull();
+    });
+  });
+
+  it("retains prior queued fields after a successful sync clears pending state", async () => {
+    vi.mocked(updateUserSettings).mockResolvedValue({ settings: {} } as Awaited<
+      ReturnType<typeof updateUserSettings>
+    >);
+
+    syncTaskCreateLastUsed({ branch: "feature" });
+    await waitFor(() => {
+      expect(window.localStorage.getItem(PENDING_LAST_USED_SYNC_KEY)).toBeNull();
+    });
+
+    syncTaskCreateLastUsed({ agent_profile_id: "agent-2" });
+    await waitFor(() => {
+      expect(updateUserSettings).toHaveBeenLastCalledWith({
+        task_create_last_used: { agent_profile_id: "agent-2" },
+      });
+    });
+
+    expect(readQueuedTaskCreateLastUsedState()).toMatchObject({
+      branch: "feature",
+      agentProfileId: "agent-2",
     });
   });
 });

--- a/apps/web/components/task-create-dialog-handlers.test.ts
+++ b/apps/web/components/task-create-dialog-handlers.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/api/domains/settings-api", () => ({
 describe("syncTaskCreateLastUsed", () => {
   beforeEach(() => {
     window.localStorage.clear();
-    resetTaskCreateLastUsedSync();
+    resetTaskCreateLastUsedSync({ clearQueued: true });
     vi.mocked(updateUserSettings).mockReset();
   });
 
@@ -34,7 +34,7 @@ describe("syncTaskCreateLastUsed", () => {
       branch: "feature",
     });
 
-    resetTaskCreateLastUsedSync();
+    resetTaskCreateLastUsedSync({ clearQueued: true });
     vi.mocked(updateUserSettings).mockResolvedValueOnce({ settings: {} } as Awaited<
       ReturnType<typeof updateUserSettings>
     >);
@@ -70,5 +70,25 @@ describe("syncTaskCreateLastUsed", () => {
       branch: "feature",
       agentProfileId: "agent-2",
     });
+  });
+
+  it("keeps queued fields when dialog close resets pending sync state", async () => {
+    vi.mocked(updateUserSettings).mockResolvedValue({ settings: {} } as Awaited<
+      ReturnType<typeof updateUserSettings>
+    >);
+
+    syncTaskCreateLastUsed({ branch: "feature" });
+    await waitFor(() => {
+      expect(updateUserSettings).toHaveBeenCalledWith({
+        task_create_last_used: { branch: "feature" },
+      });
+    });
+
+    resetTaskCreateLastUsedSync();
+
+    expect(readQueuedTaskCreateLastUsedState()).toMatchObject({
+      branch: "feature",
+    });
+    expect(readQueuedTaskCreateLastUsedState().agentProfileId).toBeUndefined();
   });
 });

--- a/apps/web/components/task-create-dialog-handlers.test.ts
+++ b/apps/web/components/task-create-dialog-handlers.test.ts
@@ -91,7 +91,9 @@ describe("syncTaskCreateLastUsed", () => {
 
     resetTaskCreateLastUsedSync();
 
-    expect(window.localStorage.getItem(PENDING_LAST_USED_SYNC_KEY)).toBeNull();
+    expect(JSON.parse(window.localStorage.getItem(PENDING_LAST_USED_SYNC_KEY) ?? "null")).toEqual({
+      branch: "feature",
+    });
     expect(readQueuedTaskCreateLastUsedState()).toMatchObject({
       branch: "feature",
     });

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -24,13 +24,13 @@ const LOCAL_STORAGE_WRITE_EVENT = "localStorage-write";
 const lastUsedDebug = createDebugLogger("task-create:last-used");
 
 /**
- * Clears pending in-flight last-used sync state and its persisted retry payload.
+ * Clears pending in-flight last-used sync state while preserving its persisted
+ * retry payload until the matching PATCH succeeds.
  * Pass `clearQueued` when test setup or teardown should also wipe the queued
  * overlay that protects settings fetches from stale server values.
  */
 export function resetTaskCreateLastUsedSync(options: { clearQueued?: boolean } = {}) {
   pendingLastUsed = {};
-  removeLocalStorage(PENDING_LAST_USED_SYNC_KEY);
   if (options.clearQueued) lastQueuedLastUsed = {};
   lastUsedDebug("pending-reset");
 }
@@ -102,8 +102,11 @@ export function syncTaskCreateLastUsed(patch: TaskCreateLastUsedPatch) {
       updateUserSettings({ task_create_last_used: payload })
         .then(() => {
           lastUsedDebug("sync-success", { payload });
+          const persistedPending = readPendingLastUsedSync();
           if (JSON.stringify(pendingLastUsed) === JSON.stringify(payload)) {
             pendingLastUsed = {};
+          }
+          if (JSON.stringify(persistedPending) === JSON.stringify(payload)) {
             removeLocalStorage(PENDING_LAST_USED_SYNC_KEY);
           }
         })

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -18,12 +18,14 @@ type TaskCreateLastUsedPatch = {
 
 let pendingLastUsed: TaskCreateLastUsedPatch = {};
 let lastUsedSync = Promise.resolve();
+let lastSyncedLastUsed: Partial<TaskCreateLastUsedState> = {};
 const PENDING_LAST_USED_SYNC_KEY = "kandev.taskCreateLastUsed.pendingSync";
 const LOCAL_STORAGE_WRITE_EVENT = "localStorage-write";
 const lastUsedDebug = createDebugLogger("task-create:last-used");
 
 export function resetTaskCreateLastUsedSync() {
   pendingLastUsed = {};
+  lastSyncedLastUsed = {};
   lastUsedDebug("pending-reset");
 }
 
@@ -55,6 +57,16 @@ function persistPendingLastUsedSync(patch: TaskCreateLastUsedPatch) {
 
 export function readPendingTaskCreateLastUsedState(): Partial<TaskCreateLastUsedState> {
   const pending = { ...readPendingLastUsedSync(), ...pendingLastUsed };
+  return mapTaskCreateLastUsedPatch(pending);
+}
+
+export function readSyncedTaskCreateLastUsedState(): Partial<TaskCreateLastUsedState> {
+  return lastSyncedLastUsed;
+}
+
+function mapTaskCreateLastUsedPatch(
+  pending: TaskCreateLastUsedPatch,
+): Partial<TaskCreateLastUsedState> {
   return {
     repositoryId: pending.repository_id,
     branch: pending.branch,
@@ -66,6 +78,7 @@ export function readPendingTaskCreateLastUsedState(): Partial<TaskCreateLastUsed
 export function syncTaskCreateLastUsed(patch: TaskCreateLastUsedPatch) {
   pendingLastUsed = { ...readPendingLastUsedSync(), ...pendingLastUsed, ...patch };
   const payload = { ...pendingLastUsed };
+  lastSyncedLastUsed = mapTaskCreateLastUsedPatch(payload);
   lastUsedDebug("sync-queued", { patch, payload });
   persistPendingLastUsedSync(payload);
   lastUsedSync = lastUsedSync

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -23,9 +23,9 @@ const PENDING_LAST_USED_SYNC_KEY = "kandev.taskCreateLastUsed.pendingSync";
 const LOCAL_STORAGE_WRITE_EVENT = "localStorage-write";
 const lastUsedDebug = createDebugLogger("task-create:last-used");
 
-export function resetTaskCreateLastUsedSync() {
+export function resetTaskCreateLastUsedSync(options: { clearQueued?: boolean } = {}) {
   pendingLastUsed = {};
-  lastQueuedLastUsed = {};
+  if (options.clearQueued) lastQueuedLastUsed = {};
   lastUsedDebug("pending-reset");
 }
 

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -75,10 +75,19 @@ function mapTaskCreateLastUsedPatch(
   };
 }
 
+function compactTaskCreateLastUsedState(state: Partial<TaskCreateLastUsedState>) {
+  return Object.fromEntries(
+    Object.entries(state).filter(([, value]) => value !== undefined),
+  ) as Partial<TaskCreateLastUsedState>;
+}
+
 export function syncTaskCreateLastUsed(patch: TaskCreateLastUsedPatch) {
   pendingLastUsed = { ...readPendingLastUsedSync(), ...pendingLastUsed, ...patch };
   const payload = { ...pendingLastUsed };
-  lastQueuedLastUsed = mapTaskCreateLastUsedPatch(payload);
+  lastQueuedLastUsed = {
+    ...lastQueuedLastUsed,
+    ...compactTaskCreateLastUsedState(mapTaskCreateLastUsedPatch(payload)),
+  };
   lastUsedDebug("sync-queued", { patch, payload });
   persistPendingLastUsedSync(payload);
   lastUsedSync = lastUsedSync

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -7,6 +7,7 @@ import { removeLocalStorage, setLocalStorage } from "@/lib/local-storage";
 import { STORAGE_KEYS } from "@/lib/settings/constants";
 import { updateUserSettings } from "@/lib/api/domains/settings-api";
 import { createDebugLogger } from "@/lib/debug/log";
+import type { TaskCreateLastUsedState } from "@/lib/state/slices/settings/types";
 
 type TaskCreateLastUsedPatch = {
   repository_id?: string;
@@ -50,6 +51,16 @@ function readPendingLastUsedSync(): TaskCreateLastUsedPatch {
 
 function persistPendingLastUsedSync(patch: TaskCreateLastUsedPatch) {
   setLocalStorage(PENDING_LAST_USED_SYNC_KEY, patch as Record<string, string>);
+}
+
+export function readPendingTaskCreateLastUsedState(): Partial<TaskCreateLastUsedState> {
+  const pending = { ...readPendingLastUsedSync(), ...pendingLastUsed };
+  return {
+    repositoryId: pending.repository_id,
+    branch: pending.branch,
+    agentProfileId: pending.agent_profile_id,
+    executorProfileId: pending.executor_profile_id,
+  };
 }
 
 export function syncTaskCreateLastUsed(patch: TaskCreateLastUsedPatch) {

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -23,8 +23,14 @@ const PENDING_LAST_USED_SYNC_KEY = "kandev.taskCreateLastUsed.pendingSync";
 const LOCAL_STORAGE_WRITE_EVENT = "localStorage-write";
 const lastUsedDebug = createDebugLogger("task-create:last-used");
 
+/**
+ * Clears pending in-flight last-used sync state and its persisted retry payload.
+ * Pass `clearQueued` when test setup or teardown should also wipe the queued
+ * overlay that protects settings fetches from stale server values.
+ */
 export function resetTaskCreateLastUsedSync(options: { clearQueued?: boolean } = {}) {
   pendingLastUsed = {};
+  removeLocalStorage(PENDING_LAST_USED_SYNC_KEY);
   if (options.clearQueued) lastQueuedLastUsed = {};
   lastUsedDebug("pending-reset");
 }

--- a/apps/web/components/task-create-dialog-handlers.ts
+++ b/apps/web/components/task-create-dialog-handlers.ts
@@ -18,14 +18,14 @@ type TaskCreateLastUsedPatch = {
 
 let pendingLastUsed: TaskCreateLastUsedPatch = {};
 let lastUsedSync = Promise.resolve();
-let lastSyncedLastUsed: Partial<TaskCreateLastUsedState> = {};
+let lastQueuedLastUsed: Partial<TaskCreateLastUsedState> = {};
 const PENDING_LAST_USED_SYNC_KEY = "kandev.taskCreateLastUsed.pendingSync";
 const LOCAL_STORAGE_WRITE_EVENT = "localStorage-write";
 const lastUsedDebug = createDebugLogger("task-create:last-used");
 
 export function resetTaskCreateLastUsedSync() {
   pendingLastUsed = {};
-  lastSyncedLastUsed = {};
+  lastQueuedLastUsed = {};
   lastUsedDebug("pending-reset");
 }
 
@@ -60,8 +60,8 @@ export function readPendingTaskCreateLastUsedState(): Partial<TaskCreateLastUsed
   return mapTaskCreateLastUsedPatch(pending);
 }
 
-export function readSyncedTaskCreateLastUsedState(): Partial<TaskCreateLastUsedState> {
-  return lastSyncedLastUsed;
+export function readQueuedTaskCreateLastUsedState(): Partial<TaskCreateLastUsedState> {
+  return lastQueuedLastUsed;
 }
 
 function mapTaskCreateLastUsedPatch(
@@ -78,7 +78,7 @@ function mapTaskCreateLastUsedPatch(
 export function syncTaskCreateLastUsed(patch: TaskCreateLastUsedPatch) {
   pendingLastUsed = { ...readPendingLastUsedSync(), ...pendingLastUsed, ...patch };
   const payload = { ...pendingLastUsed };
-  lastSyncedLastUsed = mapTaskCreateLastUsedPatch(payload);
+  lastQueuedLastUsed = mapTaskCreateLastUsedPatch(payload);
   lastUsedDebug("sync-queued", { patch, payload });
   persistPendingLastUsedSync(payload);
   lastUsedSync = lastUsedSync

--- a/apps/web/components/task-create-dialog-helpers.test.ts
+++ b/apps/web/components/task-create-dialog-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { autoSelectBranch } from "./task-create-dialog-helpers";
+import { STORAGE_KEYS } from "@/lib/settings/constants";
 
 beforeEach(() => {
   localStorage.clear();
@@ -10,6 +11,15 @@ describe("autoSelectBranch", () => {
     { name: "main", type: "local" as const },
     { name: "feature", type: "local" as const },
   ];
+
+  it("prefers a valid localStorage branch over a store-backed branch", () => {
+    const setBranch = vi.fn();
+    localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify("feature"));
+
+    autoSelectBranch(branches, setBranch, { lastUsedBranch: "main" });
+
+    expect(setBranch).toHaveBeenCalledWith("feature");
+  });
 
   it("uses store-backed last-used branch when localStorage is not primed", () => {
     const setBranch = vi.fn();
@@ -22,10 +32,58 @@ describe("autoSelectBranch", () => {
     expect(setBranch).toHaveBeenCalledWith("feature");
   });
 
+  it("uses store-backed last-used branch when localStorage branch is stale", () => {
+    const setBranch = vi.fn();
+    localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify("deleted"));
+
+    autoSelectBranch(branches, setBranch, {
+      lastUsedBranch: "feature",
+      userSettingsLoaded: true,
+    });
+
+    expect(setBranch).toHaveBeenCalledWith("feature");
+  });
+
   it("defers preferred fallback while user settings are still loading", () => {
     const setBranch = vi.fn();
 
     autoSelectBranch(branches, setBranch, { userSettingsLoaded: false });
+
+    expect(setBranch).not.toHaveBeenCalled();
+  });
+
+  it("defers when localStorage branch is stale and user settings are still loading", () => {
+    const setBranch = vi.fn();
+    localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify("deleted"));
+
+    autoSelectBranch(branches, setBranch, { userSettingsLoaded: false });
+
+    expect(setBranch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to preferred branch after user settings have loaded without a valid last-used branch", () => {
+    const setBranch = vi.fn();
+
+    autoSelectBranch(branches, setBranch, { userSettingsLoaded: true });
+
+    expect(setBranch).toHaveBeenCalledWith("main");
+  });
+
+  it("matches remote branch display names for store-backed last-used branch", () => {
+    const setBranch = vi.fn();
+
+    autoSelectBranch([{ name: "feature", type: "remote" as const, remote: "origin" }], setBranch, {
+      lastUsedBranch: "origin/feature",
+      userSettingsLoaded: true,
+    });
+
+    expect(setBranch).toHaveBeenCalledWith("origin/feature");
+  });
+
+  it("does not pick a branch from an empty branch list", () => {
+    const setBranch = vi.fn();
+
+    autoSelectBranch([], setBranch, { lastUsedBranch: "main", userSettingsLoaded: true });
 
     expect(setBranch).not.toHaveBeenCalled();
   });

--- a/apps/web/components/task-create-dialog-helpers.test.ts
+++ b/apps/web/components/task-create-dialog-helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { autoSelectBranch } from "./task-create-dialog-helpers";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("autoSelectBranch", () => {
+  const branches = [
+    { name: "main", type: "local" as const },
+    { name: "feature", type: "local" as const },
+  ];
+
+  it("uses store-backed last-used branch when localStorage is not primed", () => {
+    const setBranch = vi.fn();
+
+    autoSelectBranch(branches, setBranch, {
+      lastUsedBranch: "feature",
+      userSettingsLoaded: false,
+    });
+
+    expect(setBranch).toHaveBeenCalledWith("feature");
+  });
+
+  it("defers preferred fallback while user settings are still loading", () => {
+    const setBranch = vi.fn();
+
+    autoSelectBranch(branches, setBranch, { userSettingsLoaded: false });
+
+    expect(setBranch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task-create-dialog-helpers.ts
+++ b/apps/web/components/task-create-dialog-helpers.ts
@@ -22,6 +22,7 @@ import type { MessageAttachment } from "@/lib/services/session-launch-service";
 
 type CreateTaskParams = Parameters<typeof createTask>[0];
 const selectionDebug = createDebugLogger("task-create:selection");
+const BRANCH_AUTOPICK_DEBUG = "branch-autopick";
 
 export type { CreateTaskParams };
 
@@ -55,44 +56,60 @@ export function autoSelectBranch(
   options: { lastUsedBranch?: string | null; userSettingsLoaded?: boolean } = {},
 ): void {
   const localStorageBranch = getLocalStorage<string | null>(STORAGE_KEYS.LAST_BRANCH, null);
-  const lastUsedBranch = localStorageBranch ?? options.lastUsedBranch ?? null;
-  const lastUsedValid = Boolean(
-    lastUsedBranch &&
-    branchList.some((b) => {
-      const displayName = b.type === "remote" && b.remote ? `${b.remote}/${b.name}` : b.name;
-      return displayName === lastUsedBranch;
-    }),
-  );
-  if (lastUsedBranch && lastUsedValid) {
-    selectionDebug("branch-autopick", {
+  const settingsBranch = options.lastUsedBranch ?? null;
+  const localStorageValid = isBranchSelectable(branchList, localStorageBranch);
+  const settingsValid = isBranchSelectable(branchList, settingsBranch);
+  if (localStorageBranch && localStorageValid) {
+    selectionDebug(BRANCH_AUTOPICK_DEBUG, {
       source: "localStorage:lastBranch",
-      pick: lastUsedBranch,
-      local_storage_value: lastUsedBranch,
+      pick: localStorageBranch,
+      local_storage_value: localStorageBranch,
       local_storage_valid: true,
       branch_count: branchList.length,
     });
-    setBranch(lastUsedBranch);
+    setBranch(localStorageBranch);
     return;
   }
-  if (!lastUsedBranch && options.userSettingsLoaded === false) {
-    selectionDebug("branch-autopick", {
+  if (settingsBranch && settingsValid) {
+    selectionDebug(BRANCH_AUTOPICK_DEBUG, {
+      source: "settings:taskCreateLastUsed",
+      pick: settingsBranch,
+      local_storage_value: localStorageBranch ?? "-",
+      local_storage_valid: localStorageValid,
+      branch_count: branchList.length,
+    });
+    setBranch(settingsBranch);
+    return;
+  }
+  if (options.userSettingsLoaded === false) {
+    selectionDebug(BRANCH_AUTOPICK_DEBUG, {
       source: "user-settings-loading",
       pick: "-",
-      local_storage_value: "-",
-      local_storage_valid: false,
+      local_storage_value: localStorageBranch ?? "-",
+      local_storage_valid: localStorageValid,
       branch_count: branchList.length,
     });
     return;
   }
   const preferredBranch = selectPreferredBranch(branchList);
-  selectionDebug("branch-autopick", {
+  selectionDebug(BRANCH_AUTOPICK_DEBUG, {
     source: preferredBranch ? "preferred" : "none",
     pick: preferredBranch ?? "-",
-    local_storage_value: lastUsedBranch ?? "-",
-    local_storage_valid: lastUsedValid,
+    local_storage_value: localStorageBranch ?? "-",
+    local_storage_valid: localStorageValid,
     branch_count: branchList.length,
   });
   if (preferredBranch) setBranch(preferredBranch);
+}
+
+function isBranchSelectable(branchList: Branch[], value: string | null | undefined) {
+  return Boolean(value && branchList.some((branch) => branchDisplayName(branch) === value));
+}
+
+function branchDisplayName(branch: Branch) {
+  return branch.type === "remote" && branch.remote
+    ? `${branch.remote}/${branch.name}`
+    : branch.name;
 }
 
 export function computePassthroughProfile(

--- a/apps/web/components/task-create-dialog-helpers.ts
+++ b/apps/web/components/task-create-dialog-helpers.ts
@@ -49,8 +49,13 @@ export function toMessageAttachments(
   );
 }
 
-export function autoSelectBranch(branchList: Branch[], setBranch: (value: string) => void): void {
-  const lastUsedBranch = getLocalStorage<string | null>(STORAGE_KEYS.LAST_BRANCH, null);
+export function autoSelectBranch(
+  branchList: Branch[],
+  setBranch: (value: string) => void,
+  options: { lastUsedBranch?: string | null; userSettingsLoaded?: boolean } = {},
+): void {
+  const localStorageBranch = getLocalStorage<string | null>(STORAGE_KEYS.LAST_BRANCH, null);
+  const lastUsedBranch = localStorageBranch ?? options.lastUsedBranch ?? null;
   const lastUsedValid = Boolean(
     lastUsedBranch &&
     branchList.some((b) => {
@@ -67,6 +72,16 @@ export function autoSelectBranch(branchList: Branch[], setBranch: (value: string
       branch_count: branchList.length,
     });
     setBranch(lastUsedBranch);
+    return;
+  }
+  if (!lastUsedBranch && options.userSettingsLoaded === false) {
+    selectionDebug("branch-autopick", {
+      source: "user-settings-loading",
+      pick: "-",
+      local_storage_value: "-",
+      local_storage_valid: false,
+      branch_count: branchList.length,
+    });
     return;
   }
   const preferredBranch = selectPreferredBranch(branchList);

--- a/apps/web/components/task-create-dialog-multi-repo-guard.ts
+++ b/apps/web/components/task-create-dialog-multi-repo-guard.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { getLocalStorage } from "@/lib/local-storage";
+import { STORAGE_KEYS } from "@/lib/settings/constants";
+import type { Executor } from "@/lib/types/http";
+
+export function useMultiRepoGuardEffect(
+  open: boolean,
+  executorProfileId: string,
+  setExecutorProfileId: (id: string) => void,
+  executors: Executor[],
+  selectedRepoCount: number,
+) {
+  useEffect(() => {
+    if (!open || !executorProfileId || executors.length === 0) return;
+    if (selectedRepoCount <= 1) return;
+    const profileToType = new Map<string, string | undefined>();
+    const worktreeProfileIds: string[] = [];
+    for (const e of executors) {
+      for (const p of e.profiles ?? []) {
+        const type = p.executor_type ?? e.type;
+        profileToType.set(p.id, type);
+        if (type === "worktree") worktreeProfileIds.push(p.id);
+      }
+    }
+    if (worktreeProfileIds.length === 0) return;
+    if (profileToType.get(executorProfileId) === "worktree") return;
+    const lastId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID, null);
+    const pick = lastId && worktreeProfileIds.includes(lastId) ? lastId : worktreeProfileIds[0];
+    void Promise.resolve().then(() => setExecutorProfileId(pick));
+  }, [open, executorProfileId, executors, selectedRepoCount, setExecutorProfileId]);
+}

--- a/apps/web/components/task-create-dialog-prop-builders.ts
+++ b/apps/web/components/task-create-dialog-prop-builders.ts
@@ -62,6 +62,8 @@ export function buildDialogFormBodyProps(
     enhance: setup.enhance,
     workflowAgentLocked: computed.workflowAgentLocked,
     repositories: setup.repositories,
+    lastUsedBranch: setup.taskCreateLastUsed.branch,
+    userSettingsLoaded: setup.userSettingsLoaded,
     freshBranchAvailable: setup.freshBranchAvailable,
     isLocalExecutor: computed.isLocalExecutor,
     noCompatibleAgent: computed.noCompatibleAgent,

--- a/apps/web/components/task-create-dialog-repo-branch-autoselect.ts
+++ b/apps/web/components/task-create-dialog-repo-branch-autoselect.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect } from "react";
+import { autoSelectBranch } from "@/components/task-create-dialog-helpers";
+import type { BranchSource } from "@/hooks/domains/workspace/use-repository-branches";
+
+export function useRepoBranchAutoselect({
+  branchSource,
+  branchesLoading,
+  branches,
+  rowBranch,
+  onBranchChange,
+  preferredDefaultBranch,
+  preferredDefaultBranchLoading,
+  lastUsedBranch,
+  userSettingsLoaded,
+}: {
+  branchSource: BranchSource | null;
+  branchesLoading: boolean;
+  branches: Parameters<typeof autoSelectBranch>[0];
+  rowBranch?: string;
+  onBranchChange: (value: string) => void;
+  preferredDefaultBranch?: string;
+  preferredDefaultBranchLoading?: boolean;
+  lastUsedBranch?: string | null;
+  userSettingsLoaded?: boolean;
+}) {
+  useEffect(() => {
+    if (!branchSource || branchesLoading || branches.length === 0 || rowBranch) return;
+    runAutoselect({
+      branches,
+      preferredDefaultBranch,
+      preferredDefaultBranchLoading: !!preferredDefaultBranchLoading,
+      lastUsedBranch,
+      userSettingsLoaded,
+      onBranchChange,
+    });
+  }, [
+    branchSource,
+    branchesLoading,
+    branches,
+    rowBranch,
+    onBranchChange,
+    preferredDefaultBranch,
+    preferredDefaultBranchLoading,
+    lastUsedBranch,
+    userSettingsLoaded,
+  ]);
+}
+
+function runAutoselect({
+  branches,
+  preferredDefaultBranch,
+  preferredDefaultBranchLoading,
+  lastUsedBranch,
+  userSettingsLoaded,
+  onBranchChange,
+}: {
+  branches: Parameters<typeof autoSelectBranch>[0];
+  preferredDefaultBranch: string | undefined;
+  preferredDefaultBranchLoading: boolean;
+  lastUsedBranch?: string | null;
+  userSettingsLoaded?: boolean;
+  onBranchChange: (value: string) => void;
+}) {
+  if (preferredDefaultBranchLoading) return;
+  if (preferredDefaultBranch) {
+    onBranchChange(preferredDefaultBranch);
+    return;
+  }
+  autoSelectBranch(branches, onBranchChange, { lastUsedBranch, userSettingsLoaded });
+}

--- a/apps/web/components/task-create-dialog-repo-chips.tsx
+++ b/apps/web/components/task-create-dialog-repo-chips.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { IconPlus, IconX, IconCode, IconGitBranch, IconGitFork } from "@tabler/icons-react";
 import { cn, formatUserHomePath } from "@/lib/utils";
 import { Badge } from "@kandev/ui/badge";
@@ -8,7 +8,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useBranches, type BranchSource } from "@/hooks/domains/workspace/use-repository-branches";
 import type { LocalRepository, Repository } from "@/lib/types/http";
 import type { DialogFormState, TaskRepoRow } from "@/components/task-create-dialog-types";
-import { autoSelectBranch } from "@/components/task-create-dialog-helpers";
 import { scoreBranch } from "@/lib/utils/branch-filter";
 import { scoreRepo } from "@/lib/utils/repo-filter";
 import {
@@ -26,45 +25,8 @@ import {
   computeBranchTooltip,
   computeBranchDisabledReason,
 } from "@/components/task-create-dialog-branch-utils";
+import { useRepoBranchAutoselect } from "@/components/task-create-dialog-repo-branch-autoselect";
 
-function runAutoselect({
-  branches,
-  preferredDefaultBranch,
-  preferredDefaultBranchLoading,
-  onBranchChange,
-}: {
-  branches: Array<{ name: string; type: "local" | "remote"; remote?: string }>;
-  preferredDefaultBranch: string | undefined;
-  preferredDefaultBranchLoading: boolean;
-  onBranchChange: (value: string) => void;
-}) {
-  if (preferredDefaultBranchLoading) return;
-  // Local-executor flow: preferredDefaultBranch is the workspace's current
-  // ref (branch name OR detached-HEAD short SHA). Seed row.branch with it
-  // unconditionally so the chip displays "current: <ref>". When the ref is a
-  // SHA (detached HEAD) it won't appear in the branches list, but falling
-  // through to autoSelectBranch would pick main/master and surface "will
-  // switch to: master", which contradicts what the user actually has checked
-  // out. Sending the SHA back on submit is a no-op because the backend's
-  // skip-when-equal check compares against the same SHA.
-  if (preferredDefaultBranch) {
-    onBranchChange(preferredDefaultBranch);
-    return;
-  }
-  autoSelectBranch(branches, onBranchChange);
-}
-
-/**
- * Chip row for the task-create dialog. Renders one chip per row in
- * `fs.repositories`, plus a trailing "+" to add another. Each chip is two
- * pills (repo, branch) and a remove (×). All chips are equivalent — there
- * is no "primary" — and any row can hold either a workspace repo or a
- * discovered on-machine path.
- *
- * In Remote mode the chips are replaced by `RemoteRepoChipsRow`, which
- * renders its own chip row backed by `fs.remoteRepos`; the trailing toggle
- * flips between the two modes.
- */
 type RepoChipsRowProps = {
   fs: DialogFormState;
   repositories: Repository[];
@@ -102,6 +64,8 @@ type RepoChipsRowProps = {
   /** "No repository" mode: replace the chip row with a folder picker. */
   onToggleNoRepository?: () => void;
   onWorkspacePathChange?: (value: string) => void;
+  lastUsedBranch?: string | null;
+  userSettingsLoaded?: boolean;
 };
 
 export function RepoChipsRow({
@@ -118,6 +82,8 @@ export function RepoChipsRow({
   isLocalExecutor,
   onToggleNoRepository,
   onWorkspacePathChange,
+  lastUsedBranch,
+  userSettingsLoaded,
 }: RepoChipsRowProps) {
   // Local executor branch behavior:
   //   - chip is clickable (user can switch to any existing branch on disk)
@@ -163,6 +129,8 @@ export function RepoChipsRow({
         onRowBranchChange={onRowBranchChange}
         onToggleFreshBranch={onToggleFreshBranch}
         onWorkspacePathChange={onWorkspacePathChange}
+        lastUsedBranch={lastUsedBranch}
+        userSettingsLoaded={userSettingsLoaded}
       />
       <SourceModeSwitch
         useRemote={fs.useRemote}
@@ -188,6 +156,8 @@ function ModeBody({
   onRowBranchChange,
   onToggleFreshBranch,
   onWorkspacePathChange,
+  lastUsedBranch,
+  userSettingsLoaded,
 }: {
   fs: DialogFormState;
   repositories: Repository[];
@@ -202,6 +172,8 @@ function ModeBody({
   onRowBranchChange: (key: string, value: string) => void;
   onToggleFreshBranch?: (enabled: boolean) => void;
   onWorkspacePathChange?: (value: string) => void;
+  lastUsedBranch?: string | null;
+  userSettingsLoaded?: boolean;
 }) {
   if (fs.noRepository) {
     return (
@@ -233,6 +205,8 @@ function ModeBody({
       addHint={addHint}
       onRowRepositoryChange={onRowRepositoryChange}
       onRowBranchChange={onRowBranchChange}
+      lastUsedBranch={lastUsedBranch}
+      userSettingsLoaded={userSettingsLoaded}
       freshBranchToggle={
         // Multi-repo runs use worktrees, so the existing-vs-fork choice
         // is irrelevant — only surface the toggle for single-repo flows.
@@ -260,6 +234,8 @@ function ChipsList({
   freshBranchToggle,
   onRowRepositoryChange,
   onRowBranchChange,
+  lastUsedBranch,
+  userSettingsLoaded,
 }: {
   fs: DialogFormState;
   repositories: Repository[];
@@ -271,6 +247,8 @@ function ChipsList({
   freshBranchToggle?: React.ReactNode;
   onRowRepositoryChange: (key: string, value: string) => void;
   onRowBranchChange: (key: string, value: string) => void;
+  lastUsedBranch?: string | null;
+  userSettingsLoaded?: boolean;
 }) {
   return (
     <>
@@ -293,6 +271,8 @@ function ChipsList({
           // autoselect path.
           preferredDefaultBranch={isLocalExecutor ? fs.currentLocalBranch : undefined}
           preferredDefaultBranchLoading={isLocalExecutor ? fs.currentLocalBranchLoading : false}
+          lastUsedBranch={lastUsedBranch}
+          userSettingsLoaded={userSettingsLoaded}
           branchPrefix={computeBranchPrefix({
             isLocalExecutor,
             rowBranch: row.branch,
@@ -427,6 +407,8 @@ type RepoChipProps = {
    * default autoselect (main / master / develop, etc.).
    */
   preferredDefaultBranch?: string;
+  lastUsedBranch?: string | null;
+  userSettingsLoaded?: boolean;
   /**
    * True while preferredDefaultBranch is being resolved. Renders a
    * "Loading branch…" placeholder so the chip doesn't briefly show an empty
@@ -456,6 +438,8 @@ function useRepoChipData({
   onBranchChange,
   preferredDefaultBranch,
   preferredDefaultBranchLoading,
+  lastUsedBranch,
+  userSettingsLoaded,
 }: Pick<
   RepoChipProps,
   | "row"
@@ -466,14 +450,13 @@ function useRepoChipData({
   | "onBranchChange"
   | "preferredDefaultBranch"
   | "preferredDefaultBranchLoading"
+  | "lastUsedBranch"
+  | "userSettingsLoaded"
 >) {
   const filteredRepos = useMemo(
     () => repositories.filter((r) => !excludedRepoIds.has(r.id) || r.id === row.repositoryId),
     [repositories, excludedRepoIds, row.repositoryId],
   );
-  // Discovered (on-machine) repos not yet imported into the workspace. Drop
-  // ones whose path is already a workspace repo so the dropdown doesn't show
-  // the same folder twice.
   const filteredDiscovered = useMemo(() => {
     const workspaceRepoPaths = new Set(
       filteredRepos
@@ -488,10 +471,6 @@ function useRepoChipData({
     );
   }, [filteredRepos, discoveredRepositories, excludedRepoIds, row.localPath]);
 
-  // One hook for both row sources (workspace repo by id OR on-machine path).
-  // Backend resolves either to an absolute path; the Zustand cache keys
-  // path-based entries with a synthetic key so workspace + discovered share
-  // one slice (and the same fetch dedupe).
   const branchSource = useMemo<BranchSource | null>(() => {
     if (!workspaceId) return null;
     if (row.repositoryId) {
@@ -507,38 +486,17 @@ function useRepoChipData({
     isLoading: branchesLoading,
     refresh: refreshBranches,
   } = useBranches(branchSource, !!branchSource);
-
-  // Once branches load for this row, pre-fill the branch pill. For
-  // local-executor rows we prefer the workspace's actual current branch
-  // (preferredDefaultBranch) so the chip shows what's on disk and the
-  // submit always carries an explicit branch. Otherwise fall back to the
-  // user's last-used branch / main / master / develop. Skipped if the user
-  // already picked a branch on this row.
-  //
-  // The `preferredDefaultBranchLoading` gate closes a race: without it,
-  // autoSelectBranch's last-used localStorage pick (e.g. "origin/master")
-  // would land in row.branch before currentLocalBranch resolved, then the
-  // row.branch guard above would short-circuit forever and the chip would
-  // render "will switch to: origin/master" even though the user just opened
-  // the dialog. With the gate, autoselect waits until local-status finishes
-  // so the current-branch preference gets first crack at row.branch.
-  useEffect(() => {
-    if (!branchSource || branchesLoading || branches.length === 0 || row.branch) return;
-    runAutoselect({
-      branches,
-      preferredDefaultBranch,
-      preferredDefaultBranchLoading: !!preferredDefaultBranchLoading,
-      onBranchChange,
-    });
-  }, [
+  useRepoBranchAutoselect({
     branchSource,
     branchesLoading,
     branches,
-    row.branch,
+    rowBranch: row.branch,
     onBranchChange,
     preferredDefaultBranch,
     preferredDefaultBranchLoading,
-  ]);
+    lastUsedBranch,
+    userSettingsLoaded,
+  });
 
   const repoOptions: PillOption[] = useMemo(
     () => [
@@ -588,6 +546,8 @@ function RepoChip({
   branchLocked,
   preferredDefaultBranch,
   preferredDefaultBranchLoading,
+  lastUsedBranch,
+  userSettingsLoaded,
   branchPrefix,
   onRepositoryChange,
   onBranchChange,
@@ -602,15 +562,14 @@ function RepoChip({
     onBranchChange,
     preferredDefaultBranch,
     preferredDefaultBranchLoading,
+    lastUsedBranch,
+    userSettingsLoaded,
   });
   const { repoLabel, repoTooltip } = computeRepoChipDisplay(
     row,
     repositories,
     discoveredRepositories,
   );
-  // Hide the value while the preferred-default-branch fetch is in flight to
-  // avoid the chip briefly rendering an empty placeholder before autoselect
-  // seeds row.branch with the workspace's current branch.
   const branchValue = preferredDefaultBranchLoading ? "" : row.branch;
   const hasRepo = !!(row.repositoryId || row.localPath);
   const branchPlaceholder = computeBranchPlaceholder(

--- a/apps/web/components/task-create-dialog-repository-autopick.ts
+++ b/apps/web/components/task-create-dialog-repository-autopick.ts
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect } from "react";
+import type { Repository } from "@/lib/types/http";
+import type { DialogFormState, TaskRepoRow } from "@/components/task-create-dialog-types";
+import { getLocalStorage } from "@/lib/local-storage";
+import { STORAGE_KEYS } from "@/lib/settings/constants";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
+
+const selectionDebug = createDebugLogger("task-create:selection");
+
+type RepositoryAutoPickDecision = {
+  pickId: string | null;
+  source: string;
+  defer: boolean;
+  localStorageRepoId: string | null;
+  localStorageValid: boolean;
+  settingsRepoId: string | null;
+  settingsValid: boolean;
+};
+
+type RepositoryAutoSelectSettings = {
+  lastUsedRepositoryId?: string | null;
+  userSettingsLoaded?: boolean;
+};
+
+export function useRepositoryAutoSelectEffect(
+  fs: DialogFormState,
+  open: boolean,
+  workspaceId: string | null,
+  repositories: Repository[],
+  settings: RepositoryAutoSelectSettings = {},
+) {
+  // On open, ensure there's always at least one chip rendered: prefer the
+  // user's last-used repo (or the workspace's only repo) so the chip lands
+  // pre-filled, but fall back to an empty row so the picker is visible
+  // instead of just the "+" button. URL mode is excluded - that flow swaps
+  // the chip row for a URL input.
+  const { repositories: rows, useRemote, setRepositories } = fs;
+  const { lastUsedRepositoryId, userSettingsLoaded = true } = settings;
+  useEffect(() => {
+    if (!open || !workspaceId || useRemote) return;
+    const decision = decideRepositoryAutoPick(
+      repositories,
+      lastUsedRepositoryId,
+      userSettingsLoaded,
+    );
+    logRepositoryAutoPick(workspaceId, repositories.length, decision);
+    if (decision.defer) return;
+    const { pickId } = decision;
+    if (rows.length > 0 && !canReplaceEmptyRepositoryPlaceholder(rows, pickId)) return;
+    void Promise.resolve().then(() => {
+      setRepositories((prev) => {
+        if (prev.length > 0) return replaceSeededRepositoryRows(prev, pickId);
+        return [
+          pickId ? buildRepositoryAutoPickRow("row-0", pickId) : { key: "row-0", branch: "" },
+        ];
+      });
+    });
+  }, [
+    open,
+    repositories,
+    rows,
+    useRemote,
+    workspaceId,
+    setRepositories,
+    lastUsedRepositoryId,
+    userSettingsLoaded,
+  ]);
+}
+
+function replaceSeededRepositoryRows(rows: TaskRepoRow[], pickId: string | null): TaskRepoRow[] {
+  if (canReplaceEmptyRepositoryPlaceholder(rows, pickId)) {
+    return [buildRepositoryAutoPickRow(rows[0]?.key ?? "row-0", pickId!)];
+  }
+  if (isDebug()) {
+    selectionDebug("repository-autopick-skip", {
+      reason: "rows-seeded-before-microtask",
+      row_count: rows.length,
+    });
+  }
+  return rows;
+}
+
+function decideRepositoryAutoPick(
+  repositories: Repository[],
+  lastUsedRepositoryId?: string | null,
+  userSettingsLoaded = true,
+): RepositoryAutoPickDecision {
+  const localStorageRepoId = getLocalStorage<string | null>(STORAGE_KEYS.LAST_REPOSITORY_ID, null);
+  const settingsRepoId = lastUsedRepositoryId ?? null;
+  const localStorageValid = isRepositoryIdValid(localStorageRepoId, repositories);
+  const settingsValid = isRepositoryIdValid(settingsRepoId, repositories);
+  if (localStorageRepoId && localStorageValid) {
+    return buildRepositoryAutoPickDecision("localStorage:lastRepositoryId", localStorageRepoId, {
+      localStorageRepoId,
+      localStorageValid,
+      settingsRepoId,
+      settingsValid,
+    });
+  }
+  if (settingsRepoId && settingsValid) {
+    return buildRepositoryAutoPickDecision("settings:taskCreateLastUsed", settingsRepoId, {
+      localStorageRepoId,
+      localStorageValid,
+      settingsRepoId,
+      settingsValid,
+    });
+  }
+  if (!userSettingsLoaded && repositories.length !== 1) {
+    return buildRepositoryAutoPickDecision("user-settings-loading", null, {
+      defer: true,
+      localStorageRepoId,
+      localStorageValid,
+      settingsRepoId,
+      settingsValid,
+    });
+  }
+  return buildRepositoryAutoPickDecision(
+    repositories.length === 1 ? "single-workspace-repo" : "empty-row",
+    repositories.length === 1 ? repositories[0].id : null,
+    { localStorageRepoId, localStorageValid, settingsRepoId, settingsValid },
+  );
+}
+
+function buildRepositoryAutoPickDecision(
+  source: string,
+  pickId: string | null,
+  fields: Omit<RepositoryAutoPickDecision, "source" | "pickId" | "defer"> & {
+    defer?: boolean;
+  },
+): RepositoryAutoPickDecision {
+  return {
+    pickId,
+    source,
+    defer: fields.defer ?? false,
+    localStorageRepoId: fields.localStorageRepoId,
+    localStorageValid: fields.localStorageValid,
+    settingsRepoId: fields.settingsRepoId,
+    settingsValid: fields.settingsValid,
+  };
+}
+
+function isRepositoryIdValid(repositoryId: string | null, repositories: Repository[]): boolean {
+  return Boolean(repositoryId && repositories.some((r: Repository) => r.id === repositoryId));
+}
+
+function logRepositoryAutoPick(
+  workspaceId: string,
+  repoCount: number,
+  decision: RepositoryAutoPickDecision,
+) {
+  if (!isDebug()) return;
+  selectionDebug("repository-autopick", {
+    workspace_id: workspaceId,
+    local_storage_id: decision.localStorageRepoId ?? "-",
+    local_storage_valid: decision.localStorageValid,
+    settings_id: decision.settingsRepoId ?? "-",
+    settings_valid: decision.settingsValid,
+    repo_count: repoCount,
+    source: decision.source,
+    pick: decision.pickId ?? "-",
+  });
+}
+
+function buildRepositoryAutoPickRow(key: string, repositoryId: string): TaskRepoRow {
+  return { key, repositoryId, branch: "" };
+}
+
+function canReplaceEmptyRepositoryPlaceholder(rows: TaskRepoRow[], pickId: string | null): boolean {
+  if (!pickId || rows.length !== 1) return false;
+  const row = rows[0];
+  return Boolean(row && !row.repositoryId && !row.localPath && !row.branch);
+}

--- a/apps/web/components/task-create-dialog-state.ts
+++ b/apps/web/components/task-create-dialog-state.ts
@@ -568,9 +568,7 @@ export function useTaskCreateDialogData(
   const settingsData = useAppStore((state) => state.settingsData);
   const availableAgentsLoaded = useAppStore((state) => state.availableAgents.loaded);
   const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
-  const taskCreateUserSettings = useEnsureUserSettings(open, {
-    preserveTaskCreatePending: true,
-  });
+  const taskCreateUserSettings = useEnsureUserSettings(open);
 
   useSettingsData(open);
   const { repositories, isLoading: repositoriesLoading } = useRepositories(workspaceId, open);

--- a/apps/web/components/task-create-dialog-state.ts
+++ b/apps/web/components/task-create-dialog-state.ts
@@ -11,8 +11,7 @@ import { usePRInfoByURL } from "@/hooks/domains/github/use-pr-info-by-url";
 import { useAppStore } from "@/components/state-provider";
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
-import { fetchUserSettings } from "@/lib/api/domains/settings-api";
-import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { useEnsureUserSettings } from "@/hooks/use-ensure-user-settings";
 import { getTaskCreateDraft, setTaskCreateDraft, removeTaskCreateDraft } from "@/lib/local-storage";
 import type {
   StepType,
@@ -555,45 +554,6 @@ export function useSessionRepoName(isSessionMode: boolean) {
   }, [isSessionMode, activeTaskId, kanbanTasks, reposByWorkspace]);
 }
 
-function useTaskCreateUserSettings(open: boolean) {
-  const userSettings = useAppStore((state) => state.userSettings);
-  const setUserSettings = useAppStore((state) => state.setUserSettings);
-  const [fetchSettled, setFetchSettled] = useState(false);
-
-  useEffect(() => {
-    if (!open) {
-      setFetchSettled(false);
-      return;
-    }
-    if (userSettings.loaded) {
-      setFetchSettled(true);
-      return;
-    }
-    let cancelled = false;
-    setFetchSettled(false);
-    fetchUserSettings({ cache: "no-store" })
-      .then((response) => {
-        if (cancelled || !response?.settings) return;
-        const mapped = mapUserSettingsResponse(response);
-        if (mapped.loaded) setUserSettings(mapped);
-      })
-      .catch(() => {
-        /* Allow normal fallbacks if settings cannot be loaded. */
-      })
-      .finally(() => {
-        if (!cancelled) setFetchSettled(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, setUserSettings, userSettings.loaded]);
-
-  return {
-    loaded: userSettings.loaded || fetchSettled,
-    taskCreateLastUsed: userSettings.taskCreateLastUsed,
-  };
-}
-
 export function useTaskCreateDialogData(
   open: boolean,
   workspaceId: string | null,
@@ -608,7 +568,9 @@ export function useTaskCreateDialogData(
   const settingsData = useAppStore((state) => state.settingsData);
   const availableAgentsLoaded = useAppStore((state) => state.availableAgents.loaded);
   const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
-  const taskCreateUserSettings = useTaskCreateUserSettings(open);
+  const taskCreateUserSettings = useEnsureUserSettings(open, {
+    preserveTaskCreatePending: true,
+  });
 
   useSettingsData(open);
   const { repositories, isLoading: repositoriesLoading } = useRepositories(workspaceId, open);
@@ -643,7 +605,7 @@ export function useTaskCreateDialogData(
     repositories,
     repositoriesLoading,
     branchesLoading,
-    taskCreateLastUsed: taskCreateUserSettings.taskCreateLastUsed,
+    taskCreateLastUsed: taskCreateUserSettings.userSettings.taskCreateLastUsed,
     userSettingsLoaded: taskCreateUserSettings.loaded,
     computed,
   };

--- a/apps/web/components/task-create-dialog-state.ts
+++ b/apps/web/components/task-create-dialog-state.ts
@@ -561,7 +561,10 @@ function useTaskCreateUserSettings(open: boolean) {
   const [fetchSettled, setFetchSettled] = useState(false);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setFetchSettled(false);
+      return;
+    }
     if (userSettings.loaded) {
       setFetchSettled(true);
       return;

--- a/apps/web/components/task-create-dialog-state.ts
+++ b/apps/web/components/task-create-dialog-state.ts
@@ -11,6 +11,8 @@ import { usePRInfoByURL } from "@/hooks/domains/github/use-pr-info-by-url";
 import { useAppStore } from "@/components/state-provider";
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
 import { useSettingsData } from "@/hooks/domains/settings/use-settings-data";
+import { fetchUserSettings } from "@/lib/api/domains/settings-api";
+import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import { getTaskCreateDraft, setTaskCreateDraft, removeTaskCreateDraft } from "@/lib/local-storage";
 import type {
   StepType,
@@ -553,6 +555,42 @@ export function useSessionRepoName(isSessionMode: boolean) {
   }, [isSessionMode, activeTaskId, kanbanTasks, reposByWorkspace]);
 }
 
+function useTaskCreateUserSettings(open: boolean) {
+  const userSettings = useAppStore((state) => state.userSettings);
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const [fetchSettled, setFetchSettled] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    if (userSettings.loaded) {
+      setFetchSettled(true);
+      return;
+    }
+    let cancelled = false;
+    setFetchSettled(false);
+    fetchUserSettings({ cache: "no-store" })
+      .then((response) => {
+        if (cancelled || !response?.settings) return;
+        const mapped = mapUserSettingsResponse(response);
+        if (mapped.loaded) setUserSettings(mapped);
+      })
+      .catch(() => {
+        /* Allow normal fallbacks if settings cannot be loaded. */
+      })
+      .finally(() => {
+        if (!cancelled) setFetchSettled(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, setUserSettings, userSettings.loaded]);
+
+  return {
+    loaded: userSettings.loaded || fetchSettled,
+    taskCreateLastUsed: userSettings.taskCreateLastUsed,
+  };
+}
+
 export function useTaskCreateDialogData(
   open: boolean,
   workspaceId: string | null,
@@ -565,9 +603,9 @@ export function useTaskCreateDialogData(
   const agentProfiles = useAppStore((state) => state.agentProfiles.items);
   const executors = useAppStore((state) => state.executors.items);
   const settingsData = useAppStore((state) => state.settingsData);
-  const taskCreateLastUsed = useAppStore((state) => state.userSettings.taskCreateLastUsed);
   const availableAgentsLoaded = useAppStore((state) => state.availableAgents.loaded);
   const snapshots = useAppStore((state) => state.kanbanMulti.snapshots);
+  const taskCreateUserSettings = useTaskCreateUserSettings(open);
 
   useSettingsData(open);
   const { repositories, isLoading: repositoriesLoading } = useRepositories(workspaceId, open);
@@ -602,7 +640,8 @@ export function useTaskCreateDialogData(
     repositories,
     repositoriesLoading,
     branchesLoading,
-    taskCreateLastUsed,
+    taskCreateLastUsed: taskCreateUserSettings.taskCreateLastUsed,
+    userSettingsLoaded: taskCreateUserSettings.loaded,
     computed,
   };
 }

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -175,6 +175,8 @@ export type TaskCreateEffectsArgs = {
   lastUsedAgentProfileId?: string | null;
   /** Store-backed last-used executor profile. Used when the localStorage mirror has not been primed yet. */
   lastUsedExecutorProfileId?: string | null;
+  /** Store-backed last-used branch. Used when the localStorage mirror has not been primed yet. */
+  lastUsedBranch?: string | null;
   /**
    * True when the currently-selected executor is the local-host one (no
    * worktree, no container). Drives the "reset row.branch on local switch"
@@ -416,6 +418,8 @@ export type DialogFormBodyProps = {
   workflowAgentLocked: boolean;
   /** Workspace repositories — driven into the chip row for repo + branch picks. */
   repositories: Repository[];
+  lastUsedBranch?: string | null;
+  userSettingsLoaded?: boolean;
   /** Computed in the parent: single-row + local executor + not URL mode. */
   freshBranchAvailable: boolean;
   /**

--- a/apps/web/components/task-create-dialog-types.ts
+++ b/apps/web/components/task-create-dialog-types.ts
@@ -100,6 +100,9 @@ export type StoreSelections = {
   authLoaded: boolean;
   executors: Executor[];
   workspaceDefaults: Workspace | null | undefined;
+  userSettingsLoaded?: boolean;
+  lastUsedAgentProfileId?: string | null;
+  lastUsedExecutorProfileId?: string | null;
 };
 
 export type DialogComputedValues = {
@@ -166,6 +169,12 @@ export type TaskCreateEffectsArgs = {
   workflows: Array<{ id: string; agent_profile_id?: string }>;
   /** Store-backed last-used repository. Used when the localStorage mirror has not been primed yet. */
   lastUsedRepositoryId?: string | null;
+  /** Whether DB-backed user settings are loaded, or a best-effort fetch has settled. */
+  userSettingsLoaded?: boolean;
+  /** Store-backed last-used agent profile. Used when the localStorage mirror has not been primed yet. */
+  lastUsedAgentProfileId?: string | null;
+  /** Store-backed last-used executor profile. Used when the localStorage mirror has not been primed yet. */
+  lastUsedExecutorProfileId?: string | null;
   /**
    * True when the currently-selected executor is the local-host one (no
    * worktree, no container). Drives the "reset row.branch on local switch"

--- a/apps/web/components/task-create-dialog-workflow-agent-effect.test.ts
+++ b/apps/web/components/task-create-dialog-workflow-agent-effect.test.ts
@@ -57,8 +57,7 @@ describe("useWorkflowAgentProfileEffect - user selections", () => {
     );
 
     await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalledWith("");
-    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
+    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalled();
 
     const fsAfter = makeFs({
       agentProfileId: cursor.id,
@@ -68,7 +67,6 @@ describe("useWorkflowAgentProfileEffect - user selections", () => {
     rerender({ fs: fsAfter, authLoaded: true });
 
     await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(fsAfter.setAgentProfileId).not.toHaveBeenCalledWith("");
-    expect(fsAfter.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
+    expect(fsAfter.setAgentProfileId).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/task-create-dialog-workflow-agent-effect.test.ts
+++ b/apps/web/components/task-create-dialog-workflow-agent-effect.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useWorkflowAgentProfileEffect } from "./task-create-dialog-effects";
+import type { DialogFormState } from "@/components/task-create-dialog-types";
+import type { AgentProfileOption } from "@/lib/state/slices";
+
+type Fake = Pick<
+  DialogFormState,
+  | "agentProfileId"
+  | "workflowAgentProfileId"
+  | "selectedWorkflowId"
+  | "executorProfileId"
+  | "setAgentProfileId"
+  | "setWorkflowAgentProfileId"
+>;
+
+function makeFs(overrides: Partial<Fake> = {}): DialogFormState {
+  return {
+    agentProfileId: "",
+    workflowAgentProfileId: "",
+    selectedWorkflowId: null,
+    executorProfileId: "profile-1",
+    setAgentProfileId: vi.fn(),
+    setWorkflowAgentProfileId: vi.fn(),
+    ...overrides,
+  } as unknown as DialogFormState;
+}
+
+function makeProfile(id: string): AgentProfileOption {
+  return {
+    id,
+    label: `agent - ${id}`,
+    agent_id: `agent-${id}`,
+    agent_name: "agent",
+    cli_passthrough: false,
+  };
+}
+
+describe("useWorkflowAgentProfileEffect - user selections", () => {
+  it("preserves a user-picked agent while workflow last-used restore is deferred", async () => {
+    const claude = makeProfile("claude");
+    const cursor = makeProfile("cursor");
+    const workflows = [{ id: "wf-1" }];
+    const fsBefore = makeFs({
+      agentProfileId: cursor.id,
+      selectedWorkflowId: "wf-1",
+      executorProfileId: "profile-1",
+    });
+
+    const { rerender } = renderHook(
+      ({ fs, authLoaded }) =>
+        useWorkflowAgentProfileEffect(fs, workflows, [claude, cursor], [claude, cursor], {
+          lastUsedAgentProfileId: claude.id,
+          authLoaded,
+        }),
+      { initialProps: { fs: fsBefore, authLoaded: false } },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalledWith("");
+    expect(fsBefore.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
+
+    const fsAfter = makeFs({
+      agentProfileId: cursor.id,
+      selectedWorkflowId: "wf-1",
+      executorProfileId: "profile-1",
+    });
+    rerender({ fs: fsAfter, authLoaded: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fsAfter.setAgentProfileId).not.toHaveBeenCalledWith("");
+    expect(fsAfter.setAgentProfileId).not.toHaveBeenCalledWith(claude.id);
+  });
+});

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -146,6 +146,8 @@ function CreateModeBody(props: DialogFormBodyProps) {
         freshBranchEnabled={fs.freshBranchEnabled}
         onToggleFreshBranch={onToggleFreshBranch}
         isLocalExecutor={isLocalExecutor}
+        lastUsedBranch={props.lastUsedBranch}
+        userSettingsLoaded={props.userSettingsLoaded}
         onToggleNoRepository={props.onToggleNoRepository}
         onWorkspacePathChange={props.onWorkspacePathChange}
       />
@@ -413,6 +415,7 @@ export function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     userSettingsLoaded,
     lastUsedAgentProfileId: taskCreateLastUsed.agentProfileId,
     lastUsedExecutorProfileId: taskCreateLastUsed.executorProfileId,
+    lastUsedBranch: taskCreateLastUsed.branch,
     preserveBranch: initialValues?.checkoutBranch || initialValues?.branch,
   });
   useLockedFieldSync(open, workflowId, initialValues, fs);
@@ -455,6 +458,8 @@ export function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     submitHandlers,
     handleKeyDown,
     freshBranchAvailable,
+    taskCreateLastUsed,
+    userSettingsLoaded,
     guardedHandleSubmit,
     enhance: useEnhanceForDialog(fs),
     handleJiraImport: useJiraImportHandler(fs),

--- a/apps/web/components/task-create-dialog.tsx
+++ b/apps/web/components/task-create-dialog.tsx
@@ -391,6 +391,7 @@ export function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     repositories,
     repositoriesLoading,
     taskCreateLastUsed,
+    userSettingsLoaded,
     computed,
   } = useTaskCreateDialogData(open, workspaceId, workflowId, defaultStepId, fs);
   const repositoryLocalPath = resolveSingleRowLocalPath(fs, repositories);
@@ -409,6 +410,9 @@ export function useTaskCreateDialogSetup(props: TaskCreateDialogProps) {
     workflows,
     isLocalExecutor: computed.isLocalExecutor,
     lastUsedRepositoryId: taskCreateLastUsed.repositoryId,
+    userSettingsLoaded,
+    lastUsedAgentProfileId: taskCreateLastUsed.agentProfileId,
+    lastUsedExecutorProfileId: taskCreateLastUsed.executorProfileId,
     preserveBranch: initialValues?.checkoutBranch || initialValues?.branch,
   });
   useLockedFieldSync(open, workflowId, initialValues, fs);

--- a/apps/web/hooks/domains/settings/use-editors.ts
+++ b/apps/web/hooks/domains/settings/use-editors.ts
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
-import { fetchUserSettings, listEditors } from "@/lib/api";
+import { listEditors } from "@/lib/api";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import { useAppStore } from "@/components/state-provider";
-import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { useEnsureUserSettings } from "@/hooks/use-ensure-user-settings";
 
 export function useEditors() {
   const editors = useAppStore((state) => state.editors.items);
@@ -12,8 +12,7 @@ export function useEditors() {
   const loading = useAppStore((state) => state.editors.loading);
   const setEditors = useAppStore((state) => state.setEditors);
   const setEditorsLoading = useAppStore((state) => state.setEditorsLoading);
-  const userSettingsLoaded = useAppStore((state) => state.userSettings.loaded);
-  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  useEnsureUserSettings();
 
   useEffect(() => {
     const client = getWebSocketClient();
@@ -36,18 +35,6 @@ export function useEditors() {
         setEditorsLoading(false);
       });
   }, [loaded, loading, setEditors, setEditorsLoading]);
-
-  useEffect(() => {
-    if (userSettingsLoaded) return;
-    fetchUserSettings({ cache: "no-store" })
-      .then((data) => {
-        if (!data?.settings) return;
-        setUserSettings(mapUserSettingsResponse(data));
-      })
-      .catch(() => {
-        // Ignore settings fetch errors for now.
-      });
-  }, [setUserSettings, userSettingsLoaded]);
 
   return { editors, loaded, loading };
 }

--- a/apps/web/hooks/use-ensure-user-settings.test.ts
+++ b/apps/web/hooks/use-ensure-user-settings.test.ts
@@ -163,7 +163,7 @@ describe("useEnsureUserSettings", () => {
       }),
     );
 
-    renderHook(() => useEnsureUserSettings(true, { preserveTaskCreatePending: true }));
+    renderHook(() => useEnsureUserSettings(true));
 
     await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalled());
     expect(mockSetUserSettings.mock.calls[0]![0].taskCreateLastUsed).toEqual({
@@ -171,6 +171,38 @@ describe("useEnsureUserSettings", () => {
       branch: "main",
       agentProfileId: "agent-2",
       executorProfileId: "exec-profile-1",
+    });
+  });
+
+  it("preserves pending task-create fields when multiple callers join the same fetch", async () => {
+    let resolveFetch: (value: unknown) => void = () => undefined;
+    mockReadPendingTaskCreateLastUsedState.mockReturnValue({
+      repositoryId: undefined,
+      branch: "feature",
+      agentProfileId: undefined,
+      executorProfileId: undefined,
+    });
+    mockFetchUserSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderHook(() => useEnsureUserSettings(true));
+    renderHook(() => useEnsureUserSettings(true));
+    resolveFetch(
+      userSettingsResponse({
+        repository_id: "repo-1",
+        branch: "main",
+        agent_profile_id: "agent-1",
+      }),
+    );
+
+    await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalledTimes(2));
+    expect(mockSetUserSettings.mock.calls.at(-1)![0].taskCreateLastUsed).toMatchObject({
+      repositoryId: "repo-1",
+      branch: "feature",
+      agentProfileId: "agent-1",
     });
   });
 

--- a/apps/web/hooks/use-ensure-user-settings.test.ts
+++ b/apps/web/hooks/use-ensure-user-settings.test.ts
@@ -1,0 +1,201 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserSettingsState } from "@/lib/state/slices/settings/types";
+
+type PendingTaskCreateLastUsed = {
+  repositoryId?: string;
+  branch?: string;
+  agentProfileId?: string;
+  executorProfileId?: string;
+};
+
+const mockFetchUserSettings = vi.fn();
+const mockSetUserSettings = vi.fn((settings: UserSettingsState) => {
+  mockState.userSettings = settings;
+});
+const mockReadPendingTaskCreateLastUsedState = vi.fn<[], PendingTaskCreateLastUsed>(() => ({
+  repositoryId: undefined,
+  branch: undefined,
+  agentProfileId: undefined,
+  executorProfileId: undefined,
+}));
+
+type MockState = {
+  userSettings: UserSettingsState;
+  setUserSettings: typeof mockSetUserSettings;
+};
+
+let mockState: MockState;
+
+vi.mock("@/components/state-provider", () => ({
+  useAppStore: (selector: (state: MockState) => unknown) => selector(mockState),
+}));
+
+vi.mock("@/lib/api/domains/settings-api", () => ({
+  fetchUserSettings: (...args: unknown[]) => mockFetchUserSettings(...args),
+}));
+
+vi.mock("@/components/task-create-dialog-handlers", () => ({
+  readPendingTaskCreateLastUsedState: () => mockReadPendingTaskCreateLastUsedState(),
+}));
+
+import {
+  __resetEnsureUserSettingsForTests,
+  useEnsureUserSettings,
+} from "./use-ensure-user-settings";
+
+function makeUnloadedSettings(): UserSettingsState {
+  return {
+    workspaceId: null,
+    workflowId: null,
+    kanbanViewMode: null,
+    repositoryIds: [],
+    preferredShell: null,
+    shellOptions: [],
+    defaultEditorId: null,
+    enablePreviewOnClick: false,
+    chatSubmitKey: "cmd_enter",
+    reviewAutoMarkOnScroll: true,
+    showReleaseNotification: true,
+    releaseNotesLastSeenVersion: null,
+    savedLayouts: [],
+    sidebarViews: [],
+    sidebarActiveViewId: null,
+    sidebarDraft: null,
+    sidebarTaskPrefs: { pinnedTaskIds: [], orderedTaskIds: [], subtaskOrderByParentId: {} },
+    taskCreateLastUsed: {
+      repositoryId: null,
+      branch: null,
+      agentProfileId: null,
+      executorProfileId: null,
+    },
+    jiraSavedViews: undefined,
+    jiraTaskPresets: undefined,
+    githubSavedPresets: undefined,
+    githubDefaultQueryPresets: undefined,
+    gitlabSavedPresets: undefined,
+    defaultUtilityAgentId: null,
+    keyboardShortcuts: {},
+    terminalLinkBehavior: "new_tab",
+    terminalFontFamily: null,
+    terminalFontSize: null,
+    changesPanelLayout: "tree",
+    systemMetricsDisplay: { showInTopbar: false },
+    voiceMode: {
+      enabled: true,
+      engine: "auto",
+      language: "auto",
+      mode: "toggle",
+      autoSend: false,
+      whisperWebModel: "base",
+    },
+    lspAutoStartLanguages: [],
+    lspAutoInstallLanguages: [],
+    lspServerConfigs: {},
+    loaded: false,
+  };
+}
+
+function userSettingsResponse(taskCreateLastUsed = {}) {
+  return {
+    shell_options: [],
+    settings: {
+      task_create_last_used: taskCreateLastUsed,
+    },
+  };
+}
+
+beforeEach(() => {
+  __resetEnsureUserSettingsForTests();
+  vi.clearAllMocks();
+  mockState = {
+    userSettings: makeUnloadedSettings(),
+    setUserSettings: mockSetUserSettings,
+  };
+});
+
+describe("useEnsureUserSettings", () => {
+  it("fetches and stores user settings on first enabled mount", async () => {
+    mockFetchUserSettings.mockResolvedValue(
+      userSettingsResponse({ repository_id: "repo-1", branch: "main" }),
+    );
+
+    renderHook(() => useEnsureUserSettings(true));
+
+    await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalled());
+    expect(mockFetchUserSettings).toHaveBeenCalledWith({ cache: "no-store" });
+    expect(mockSetUserSettings.mock.calls[0]![0].loaded).toBe(true);
+    expect(mockSetUserSettings.mock.calls[0]![0].taskCreateLastUsed).toMatchObject({
+      repositoryId: "repo-1",
+      branch: "main",
+    });
+  });
+
+  it("joins an in-flight settings fetch instead of starting a duplicate request", async () => {
+    let resolveFetch: (value: unknown) => void = () => undefined;
+    mockFetchUserSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderHook(() => useEnsureUserSettings(true));
+    renderHook(() => useEnsureUserSettings(true));
+
+    await waitFor(() => expect(mockFetchUserSettings).toHaveBeenCalledTimes(1));
+    resolveFetch(userSettingsResponse());
+    await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalled());
+  });
+
+  it("merges only defined pending task-create fields over fetched settings", async () => {
+    mockReadPendingTaskCreateLastUsedState.mockReturnValue({
+      repositoryId: undefined,
+      branch: undefined,
+      agentProfileId: "agent-2",
+      executorProfileId: undefined,
+    });
+    mockFetchUserSettings.mockResolvedValue(
+      userSettingsResponse({
+        repository_id: "repo-1",
+        branch: "main",
+        agent_profile_id: "agent-1",
+        executor_profile_id: "exec-profile-1",
+      }),
+    );
+
+    renderHook(() => useEnsureUserSettings(true, { preserveTaskCreatePending: true }));
+
+    await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalled());
+    expect(mockSetUserSettings.mock.calls[0]![0].taskCreateLastUsed).toEqual({
+      repositoryId: "repo-1",
+      branch: "main",
+      agentProfileId: "agent-2",
+      executorProfileId: "exec-profile-1",
+    });
+  });
+
+  it("does not fetch while disabled", () => {
+    const { result } = renderHook(() => useEnsureUserSettings(false));
+
+    expect(mockFetchUserSettings).not.toHaveBeenCalled();
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it("settles a failed fetch for the current mount but retries on the next mount", async () => {
+    mockFetchUserSettings
+      .mockRejectedValueOnce(new Error("temporary"))
+      .mockResolvedValueOnce(userSettingsResponse({ repository_id: "repo-2" }));
+
+    const first = renderHook(() => useEnsureUserSettings(true));
+
+    await waitFor(() => expect(first.result.current.loaded).toBe(true));
+    expect(mockSetUserSettings).not.toHaveBeenCalled();
+    first.unmount();
+
+    renderHook(() => useEnsureUserSettings(true));
+
+    await waitFor(() => expect(mockFetchUserSettings).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalled());
+    expect(mockSetUserSettings.mock.calls[0]![0].taskCreateLastUsed.repositoryId).toBe("repo-2");
+  });
+});

--- a/apps/web/hooks/use-ensure-user-settings.test.ts
+++ b/apps/web/hooks/use-ensure-user-settings.test.ts
@@ -19,7 +19,7 @@ const mockReadPendingTaskCreateLastUsedState = vi.fn<[], PendingTaskCreateLastUs
   agentProfileId: undefined,
   executorProfileId: undefined,
 }));
-const mockReadSyncedTaskCreateLastUsedState = vi.fn<[], PendingTaskCreateLastUsed>(() => ({
+const mockReadQueuedTaskCreateLastUsedState = vi.fn<[], PendingTaskCreateLastUsed>(() => ({
   repositoryId: undefined,
   branch: undefined,
   agentProfileId: undefined,
@@ -43,7 +43,7 @@ vi.mock("@/lib/api/domains/settings-api", () => ({
 
 vi.mock("@/components/task-create-dialog-handlers", () => ({
   readPendingTaskCreateLastUsedState: () => mockReadPendingTaskCreateLastUsedState(),
-  readSyncedTaskCreateLastUsedState: () => mockReadSyncedTaskCreateLastUsedState(),
+  readQueuedTaskCreateLastUsedState: () => mockReadQueuedTaskCreateLastUsedState(),
 }));
 
 import {
@@ -251,7 +251,7 @@ describe("useEnsureUserSettings — stale settings fetches", () => {
     renderHook(() => useEnsureUserSettings(true));
     await waitFor(() => expect(mockFetchUserSettings).toHaveBeenCalledTimes(1));
 
-    mockReadSyncedTaskCreateLastUsedState.mockReturnValue({
+    mockReadQueuedTaskCreateLastUsedState.mockReturnValue({
       repositoryId: "repo-2",
       branch: "feature",
       agentProfileId: undefined,

--- a/apps/web/hooks/use-ensure-user-settings.test.ts
+++ b/apps/web/hooks/use-ensure-user-settings.test.ts
@@ -19,6 +19,12 @@ const mockReadPendingTaskCreateLastUsedState = vi.fn<[], PendingTaskCreateLastUs
   agentProfileId: undefined,
   executorProfileId: undefined,
 }));
+const mockReadSyncedTaskCreateLastUsedState = vi.fn<[], PendingTaskCreateLastUsed>(() => ({
+  repositoryId: undefined,
+  branch: undefined,
+  agentProfileId: undefined,
+  executorProfileId: undefined,
+}));
 
 type MockState = {
   userSettings: UserSettingsState;
@@ -37,6 +43,7 @@ vi.mock("@/lib/api/domains/settings-api", () => ({
 
 vi.mock("@/components/task-create-dialog-handlers", () => ({
   readPendingTaskCreateLastUsedState: () => mockReadPendingTaskCreateLastUsedState(),
+  readSyncedTaskCreateLastUsedState: () => mockReadSyncedTaskCreateLastUsedState(),
 }));
 
 import {
@@ -229,5 +236,38 @@ describe("useEnsureUserSettings", () => {
     await waitFor(() => expect(mockFetchUserSettings).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalled());
     expect(mockSetUserSettings.mock.calls[0]![0].taskCreateLastUsed.repositoryId).toBe("repo-2");
+  });
+});
+
+describe("useEnsureUserSettings — stale settings fetches", () => {
+  it("keeps task-create edits made while a settings fetch is in flight", async () => {
+    let resolveFetch: (value: unknown) => void = () => undefined;
+    mockFetchUserSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    renderHook(() => useEnsureUserSettings(true));
+    await waitFor(() => expect(mockFetchUserSettings).toHaveBeenCalledTimes(1));
+
+    mockReadSyncedTaskCreateLastUsedState.mockReturnValue({
+      repositoryId: "repo-2",
+      branch: "feature",
+      agentProfileId: undefined,
+      executorProfileId: undefined,
+    });
+    resolveFetch(
+      userSettingsResponse({
+        repository_id: "repo-1",
+        branch: "main",
+      }),
+    );
+
+    await waitFor(() => expect(mockSetUserSettings).toHaveBeenCalled());
+    expect(mockSetUserSettings.mock.calls[0]![0].taskCreateLastUsed).toMatchObject({
+      repositoryId: "repo-2",
+      branch: "feature",
+    });
   });
 });

--- a/apps/web/hooks/use-ensure-user-settings.ts
+++ b/apps/web/hooks/use-ensure-user-settings.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAppStore } from "@/components/state-provider";
+import { readPendingTaskCreateLastUsedState } from "@/components/task-create-dialog-handlers";
+import { fetchUserSettings } from "@/lib/api/domains/settings-api";
+import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import type { UserSettingsState } from "@/lib/state/slices/settings/types";
+
+let userSettingsFetchPromise: Promise<UserSettingsState | null> | null = null;
+let userSettingsLoadAttempted = false;
+
+function loadUserSettingsOnce() {
+  if (!userSettingsFetchPromise) {
+    userSettingsLoadAttempted = true;
+    userSettingsFetchPromise = fetchUserSettings({ cache: "no-store" })
+      .then((response) => {
+        if (!response?.settings) return null;
+        const mapped = mapUserSettingsResponse(response);
+        return mapped.loaded ? mapped : null;
+      })
+      .catch(() => null)
+      .finally(() => {
+        userSettingsFetchPromise = null;
+      });
+  }
+  return userSettingsFetchPromise;
+}
+
+function mergePendingTaskCreateLastUsed(settings: UserSettingsState): UserSettingsState {
+  const pending = readPendingTaskCreateLastUsedState();
+  if (Object.values(pending).every((value) => value === undefined)) return settings;
+  return {
+    ...settings,
+    taskCreateLastUsed: {
+      ...settings.taskCreateLastUsed,
+      ...pending,
+    },
+  };
+}
+
+export function useEnsureUserSettings(
+  enabled = true,
+  options: { preserveTaskCreatePending?: boolean } = {},
+) {
+  const userSettings = useAppStore((state) => state.userSettings);
+  const setUserSettings = useAppStore((state) => state.setUserSettings);
+  const [fetchSettled, setFetchSettled] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setFetchSettled(false);
+      return;
+    }
+    if (userSettings.loaded) {
+      setFetchSettled(true);
+      return;
+    }
+    if (userSettingsLoadAttempted && !userSettingsFetchPromise) {
+      setFetchSettled(true);
+      return;
+    }
+
+    let cancelled = false;
+    setFetchSettled(false);
+    loadUserSettingsOnce()
+      .then((mapped) => {
+        if (cancelled || !mapped) return;
+        const next = options.preserveTaskCreatePending
+          ? mergePendingTaskCreateLastUsed(mapped)
+          : mapped;
+        setUserSettings(next);
+      })
+      .finally(() => {
+        if (!cancelled) setFetchSettled(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, options.preserveTaskCreatePending, setUserSettings, userSettings.loaded]);
+
+  return {
+    loaded: userSettings.loaded || fetchSettled,
+    userSettings,
+  };
+}

--- a/apps/web/hooks/use-ensure-user-settings.ts
+++ b/apps/web/hooks/use-ensure-user-settings.ts
@@ -2,20 +2,29 @@
 
 import { useEffect, useState } from "react";
 import { useAppStore } from "@/components/state-provider";
-import { readPendingTaskCreateLastUsedState } from "@/components/task-create-dialog-handlers";
+import {
+  readPendingTaskCreateLastUsedState,
+  readSyncedTaskCreateLastUsedState,
+} from "@/components/task-create-dialog-handlers";
 import { fetchUserSettings } from "@/lib/api/domains/settings-api";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
 import type { TaskCreateLastUsedState, UserSettingsState } from "@/lib/state/slices/settings/types";
 
-let userSettingsFetchPromise: Promise<UserSettingsState | null> | null = null;
+type LoadedUserSettings = {
+  settings: UserSettingsState;
+  startedPending: Partial<TaskCreateLastUsedState>;
+};
+
+let userSettingsFetchPromise: Promise<LoadedUserSettings | null> | null = null;
 
 function loadUserSettingsOnce() {
   if (!userSettingsFetchPromise) {
+    const startedPending = readPendingTaskCreateLastUsedState();
     userSettingsFetchPromise = fetchUserSettings({ cache: "no-store" })
       .then((response) => {
         if (!response?.settings) return null;
         const mapped = mapUserSettingsResponse(response);
-        return mapped.loaded ? mapped : null;
+        return mapped.loaded ? { settings: mapped, startedPending } : null;
       })
       .catch(() => null)
       .finally(() => {
@@ -25,11 +34,11 @@ function loadUserSettingsOnce() {
   return userSettingsFetchPromise;
 }
 
-function mergePendingTaskCreateLastUsed(settings: UserSettingsState): UserSettingsState {
-  const pending = readPendingTaskCreateLastUsedState();
-  const definedPending = Object.fromEntries(
-    Object.entries(pending).filter(([, value]) => value !== undefined),
-  ) as Partial<TaskCreateLastUsedState>;
+function mergeTaskCreateLastUsedOverlay(
+  settings: UserSettingsState,
+  pending: Partial<TaskCreateLastUsedState>,
+): UserSettingsState {
+  const definedPending = compactTaskCreateLastUsedOverlay(pending);
   if (Object.keys(definedPending).length === 0) return settings;
   return {
     ...settings,
@@ -38,6 +47,20 @@ function mergePendingTaskCreateLastUsed(settings: UserSettingsState): UserSettin
       ...definedPending,
     },
   };
+}
+
+function compactTaskCreateLastUsedOverlay(pending: Partial<TaskCreateLastUsedState>) {
+  return Object.fromEntries(
+    Object.entries(pending).filter(([, value]) => value !== undefined),
+  ) as Partial<TaskCreateLastUsedState>;
+}
+
+function mergeTaskCreateLastUsedForFetch(result: LoadedUserSettings): UserSettingsState {
+  return mergeTaskCreateLastUsedOverlay(result.settings, {
+    ...compactTaskCreateLastUsedOverlay(result.startedPending),
+    ...compactTaskCreateLastUsedOverlay(readSyncedTaskCreateLastUsedState()),
+    ...compactTaskCreateLastUsedOverlay(readPendingTaskCreateLastUsedState()),
+  });
 }
 
 export function __resetEnsureUserSettingsForTests() {
@@ -61,9 +84,9 @@ export function useEnsureUserSettings(enabled = true) {
     let cancelled = false;
     setFetchSettled(false);
     loadUserSettingsOnce()
-      .then((mapped) => {
-        if (cancelled || !mapped) return;
-        const next = mergePendingTaskCreateLastUsed(mapped);
+      .then((result) => {
+        if (cancelled || !result) return;
+        const next = mergeTaskCreateLastUsedForFetch(result);
         setUserSettings(next);
       })
       .finally(() => {

--- a/apps/web/hooks/use-ensure-user-settings.ts
+++ b/apps/web/hooks/use-ensure-user-settings.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useAppStore } from "@/components/state-provider";
 import {
   readPendingTaskCreateLastUsedState,
-  readSyncedTaskCreateLastUsedState,
+  readQueuedTaskCreateLastUsedState,
 } from "@/components/task-create-dialog-handlers";
 import { fetchUserSettings } from "@/lib/api/domains/settings-api";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
@@ -12,19 +12,17 @@ import type { TaskCreateLastUsedState, UserSettingsState } from "@/lib/state/sli
 
 type LoadedUserSettings = {
   settings: UserSettingsState;
-  startedPending: Partial<TaskCreateLastUsedState>;
 };
 
 let userSettingsFetchPromise: Promise<LoadedUserSettings | null> | null = null;
 
 function loadUserSettingsOnce() {
   if (!userSettingsFetchPromise) {
-    const startedPending = readPendingTaskCreateLastUsedState();
     userSettingsFetchPromise = fetchUserSettings({ cache: "no-store" })
       .then((response) => {
         if (!response?.settings) return null;
         const mapped = mapUserSettingsResponse(response);
-        return mapped.loaded ? { settings: mapped, startedPending } : null;
+        return mapped.loaded ? { settings: mapped } : null;
       })
       .catch(() => null)
       .finally(() => {
@@ -57,8 +55,7 @@ function compactTaskCreateLastUsedOverlay(pending: Partial<TaskCreateLastUsedSta
 
 function mergeTaskCreateLastUsedForFetch(result: LoadedUserSettings): UserSettingsState {
   return mergeTaskCreateLastUsedOverlay(result.settings, {
-    ...compactTaskCreateLastUsedOverlay(result.startedPending),
-    ...compactTaskCreateLastUsedOverlay(readSyncedTaskCreateLastUsedState()),
+    ...compactTaskCreateLastUsedOverlay(readQueuedTaskCreateLastUsedState()),
     ...compactTaskCreateLastUsedOverlay(readPendingTaskCreateLastUsedState()),
   });
 }

--- a/apps/web/hooks/use-ensure-user-settings.ts
+++ b/apps/web/hooks/use-ensure-user-settings.ts
@@ -44,10 +44,7 @@ export function __resetEnsureUserSettingsForTests() {
   userSettingsFetchPromise = null;
 }
 
-export function useEnsureUserSettings(
-  enabled = true,
-  options: { preserveTaskCreatePending?: boolean } = {},
-) {
+export function useEnsureUserSettings(enabled = true) {
   const userSettings = useAppStore((state) => state.userSettings);
   const setUserSettings = useAppStore((state) => state.setUserSettings);
   const [fetchSettled, setFetchSettled] = useState(false);
@@ -66,9 +63,7 @@ export function useEnsureUserSettings(
     loadUserSettingsOnce()
       .then((mapped) => {
         if (cancelled || !mapped) return;
-        const next = options.preserveTaskCreatePending
-          ? mergePendingTaskCreateLastUsed(mapped)
-          : mapped;
+        const next = mergePendingTaskCreateLastUsed(mapped);
         setUserSettings(next);
       })
       .finally(() => {
@@ -78,7 +73,7 @@ export function useEnsureUserSettings(
     return () => {
       cancelled = true;
     };
-  }, [enabled, options.preserveTaskCreatePending, setUserSettings, userSettings.loaded]);
+  }, [enabled, setUserSettings, userSettings.loaded]);
 
   return {
     loaded: userSettings.loaded || fetchSettled,

--- a/apps/web/hooks/use-ensure-user-settings.ts
+++ b/apps/web/hooks/use-ensure-user-settings.ts
@@ -5,14 +5,12 @@ import { useAppStore } from "@/components/state-provider";
 import { readPendingTaskCreateLastUsedState } from "@/components/task-create-dialog-handlers";
 import { fetchUserSettings } from "@/lib/api/domains/settings-api";
 import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
-import type { UserSettingsState } from "@/lib/state/slices/settings/types";
+import type { TaskCreateLastUsedState, UserSettingsState } from "@/lib/state/slices/settings/types";
 
 let userSettingsFetchPromise: Promise<UserSettingsState | null> | null = null;
-let userSettingsLoadAttempted = false;
 
 function loadUserSettingsOnce() {
   if (!userSettingsFetchPromise) {
-    userSettingsLoadAttempted = true;
     userSettingsFetchPromise = fetchUserSettings({ cache: "no-store" })
       .then((response) => {
         if (!response?.settings) return null;
@@ -29,14 +27,21 @@ function loadUserSettingsOnce() {
 
 function mergePendingTaskCreateLastUsed(settings: UserSettingsState): UserSettingsState {
   const pending = readPendingTaskCreateLastUsedState();
-  if (Object.values(pending).every((value) => value === undefined)) return settings;
+  const definedPending = Object.fromEntries(
+    Object.entries(pending).filter(([, value]) => value !== undefined),
+  ) as Partial<TaskCreateLastUsedState>;
+  if (Object.keys(definedPending).length === 0) return settings;
   return {
     ...settings,
     taskCreateLastUsed: {
       ...settings.taskCreateLastUsed,
-      ...pending,
+      ...definedPending,
     },
   };
+}
+
+export function __resetEnsureUserSettingsForTests() {
+  userSettingsFetchPromise = null;
 }
 
 export function useEnsureUserSettings(
@@ -56,11 +61,6 @@ export function useEnsureUserSettings(
       setFetchSettled(true);
       return;
     }
-    if (userSettingsLoadAttempted && !userSettingsFetchPromise) {
-      setFetchSettled(true);
-      return;
-    }
-
     let cancelled = false;
     setFetchSettled(false);
     loadUserSettingsOnce()

--- a/apps/web/hooks/use-user-display-settings.ts
+++ b/apps/web/hooks/use-user-display-settings.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
-import { fetchUserSettings, updateUserSettings } from "@/lib/api";
+import { updateUserSettings } from "@/lib/api";
 import { useSearchParams } from "@/lib/routing/client-router";
 import { mapSelectedRepositoryIds } from "@/lib/kanban/filters";
 import { useAppStore } from "@/components/state-provider";
 import { useRepositories } from "@/hooks/domains/workspace/use-repositories";
-import { mapUserSettingsResponse } from "@/lib/ssr/user-settings";
+import { useEnsureUserSettings } from "@/hooks/use-ensure-user-settings";
 import { repositoryId, type Repository } from "@/lib/types/http";
 import {
   DEFAULT_VOICE_MODE_STATE,
@@ -153,25 +153,6 @@ function useUserSettingsRef(userSettings: DisplaySettings) {
   return userSettingsRef;
 }
 
-function useLoadUserSettings(
-  loaded: boolean,
-  setUserSettings: (settings: DisplaySettings) => void,
-) {
-  useEffect(() => {
-    if (loaded) return;
-    fetchUserSettings({ cache: "no-store" })
-      .then((data) => {
-        if (!data?.settings) return;
-        const mapped = mapUserSettingsResponse(data);
-        if (!mapped.loaded) return;
-        setUserSettings(mapped);
-      })
-      .catch(() => {
-        /* Ignore settings fetch errors for now. */
-      });
-  }, [loaded, setUserSettings]);
-}
-
 function usePruneStaleRepositoryIds(
   userSettings: DisplaySettings,
   repositories: Repository[],
@@ -237,7 +218,7 @@ export function useUserDisplaySettings({
     [setUserSettings, userSettingsRef],
   );
 
-  useLoadUserSettings(userSettings.loaded, setUserSettings);
+  useEnsureUserSettings();
 
   useEffect(() => {
     if (!userSettings.loaded) return;


### PR DESCRIPTION
Task creation could fall back to empty/default selections when the dialog opened before
DB-backed user settings had hydrated. The dialog now waits for last-used settings or
fetches them on open before applying fallback auto-picks.

## Important Changes

- Fetch user settings on task-create dialog open when the store is not yet hydrated.
- Defer repository, agent profile, and executor profile fallback auto-picks until
  last-used settings are loaded or the fetch has settled.
- Restore executor and agent choices from store-backed last-used settings when the
  localStorage mirror is not yet primed.

## Validation

- `rtk make fmt typecheck test lint`
- `cd apps && pnpm --filter @kandev/web test -- --run components/task-create-dialog-effects.test.ts`
- `cd apps && pnpm --filter @kandev/web test -- --run components/task-create-dialog-effects-executor.test.ts`
- `cd apps && pnpm --filter @kandev/web test`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->