### PR TITLE
fix: improve macos desktop startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 BACKEND_DIR := apps/backend
 WEB_DIR := apps/web
 APPS_DIR := apps
+DESKTOP_DIR := apps/desktop
+DESKTOP_RUNTIME_DIR := $(DESKTOP_DIR)/src-tauri/resources/kandev
 EMBEDDED_WEB_DIR := $(BACKEND_DIR)/internal/webapp/embedded/generated
 
 # Tools
@@ -40,6 +42,7 @@ SERVICE_PORT_FLAG := $(if $(PORT),--port $(PORT),)
 SERVICE_HOME_DIR_FLAG := $(if $(HOME_DIR),--home-dir "$(HOME_DIR)",)
 SERVICE_NO_BOOT_START_FLAG := $(if $(filter 1 true yes,$(NO_BOOT_START)),--no-boot-start,)
 SERVICE_INSTALL_FLAGS := $(SERVICE_PORT_FLAG) $(SERVICE_HOME_DIR_FLAG) $(SERVICE_NO_BOOT_START_FLAG)
+DESKTOP_BUNDLES ?= dmg
 
 # Phase headers
 define phase
@@ -69,6 +72,7 @@ help:
 	@echo "  dev-prod-db      Run dev mode against the production db at ~/.kandev"
 	@echo "  dev-backend      Run backend in development mode (port 38429)"
 	@echo "  dev-web          Run web app in development mode (port 37429)"
+	@echo "  desktop-dev      Run macOS Tauri app in dev mode with bundled runtime"
 	@echo "  dev              Note: Uses local development launcher (auto ports)"
 	@echo "  doctor           Idempotently wire up pre-commit hooks (runs automatically before dev)"
 	@echo ""
@@ -95,6 +99,10 @@ help:
 	@echo "  build            Build backend and web app"
 	@echo "  build-backend    Build backend binary"
 	@echo "  build-web        Build web app for production"
+	@echo "  desktop-runtime  Build/copy runtime resources for the macOS desktop app"
+	@echo "  desktop-build    Build the macOS Tauri app bundle/DMG"
+	@echo "  desktop-open     Build and open the macOS app"
+	@echo "  desktop-launch   Alias for desktop-open"
 	@echo ""
 	@echo "Installation:"
 	@echo "  install          Install all dependencies (backend + web)"
@@ -189,6 +197,44 @@ dev-backend:
 dev-web:
 	@echo "Starting web app on http://localhost:37429"
 	@cd $(APPS_DIR) && PORT=37429 $(PNPM) --filter @kandev/web dev
+
+.PHONY: desktop-runtime
+desktop-runtime:
+	@test "$$(uname -s)" = "Darwin" || { echo "desktop-* targets require macOS."; exit 1; }
+	@$(MAKE) -s service-bundle
+	@platform="$(DESKTOP_PLATFORM)"; \
+	if [ -z "$$platform" ]; then \
+		case "$$(uname -m)" in \
+			arm64|aarch64) platform="macos-arm64" ;; \
+			x86_64|amd64) platform="macos-x64" ;; \
+			*) echo "Unsupported macOS architecture: $$(uname -m)" >&2; exit 1 ;; \
+		esac; \
+	fi; \
+	scripts/release/prepare-desktop-runtime.sh \
+		--bundle-dir "$(SERVICE_BUNDLE_DIR)" \
+		--platform "$$platform" \
+		--output-dir "$(DESKTOP_RUNTIME_DIR)"
+
+.PHONY: desktop-dev
+desktop-dev: desktop-runtime
+	@KANDEV_DESKTOP_RUNTIME_DIR="$(CURDIR)/$(DESKTOP_RUNTIME_DIR)" \
+		$(PNPM) -C $(APPS_DIR) --filter @kandev/desktop dev
+
+.PHONY: desktop-build
+desktop-build: desktop-runtime
+	@cd $(DESKTOP_DIR) && $(PNPM) tauri build --features desktop-runtime --bundles "$(DESKTOP_BUNDLES)"
+
+.PHONY: desktop-open
+desktop-open: desktop-build
+	@app_path="$$(find "$(DESKTOP_DIR)/src-tauri/target" -path '*/release/bundle/macos/Kandev.app' -print -quit)"; \
+	if [ -z "$$app_path" ]; then \
+		echo "Missing built app under $(DESKTOP_DIR)/src-tauri/target"; \
+		exit 1; \
+	fi; \
+	open "$$app_path"
+
+.PHONY: desktop-launch
+desktop-launch: desktop-open
 
 #
 # Build

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ help:
 	@echo "  dev-backend      Run backend in development mode (port 38429)"
 	@echo "  dev-web          Run web app in development mode (port 37429)"
 	@echo "  desktop-dev      Run macOS Tauri app in dev mode with bundled runtime"
-	@echo "  dev              Note: Uses local development launcher (auto ports)"
 	@echo "  doctor           Idempotently wire up pre-commit hooks (runs automatically before dev)"
 	@echo ""
 	@echo "Production Commands:"

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -13,26 +13,48 @@
 
       body {
         margin: 0;
+        min-height: 100vh;
       }
 
       .startup-shell {
         align-items: center;
+        background: #f5f7f6;
+        display: flex;
+        min-height: 100vh;
+        padding: 32px;
+      }
+
+      .startup-panel {
+        align-items: center;
         display: flex;
         justify-content: center;
-        min-height: 100vh;
+        margin: 0 auto;
+        min-height: 88px;
+        min-width: 88px;
       }
 
       .status-spinner {
         animation: startup-spin 960ms linear infinite;
-        border: 4px solid #d8dfdc;
+        background:
+          linear-gradient(#f5f7f6, #f5f7f6) padding-box,
+          conic-gradient(from 0deg, #16875f, #c48a2a, #d8dfdc, #16875f) border-box;
+        border: 4px solid transparent;
         border-radius: 999px;
-        border-top-color: #16875f;
         height: 52px;
         width: 52px;
       }
 
       .startup-copy {
-        display: none;
+        border: 0;
+        clip: rect(0 0 0 0);
+        display: block;
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        white-space: nowrap;
+        width: 1px;
       }
 
       @keyframes startup-spin {
@@ -47,9 +69,14 @@
           background: #0f1413;
         }
 
+        .startup-shell {
+          background: #0f1413;
+        }
+
         .status-spinner {
-          border-color: #27322e;
-          border-top-color: #2aa876;
+          background:
+            linear-gradient(#0f1413, #0f1413) padding-box,
+            conic-gradient(from 0deg, #2aa876, #d6a348, #27322e, #2aa876) border-box;
         }
       }
 
@@ -62,7 +89,12 @@
     <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
-    <main class="startup-shell" aria-busy="true" aria-live="polite" aria-label="Kandev is starting">
+    <main
+      class="startup-shell"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="Kandev startup status"
+    >
       <section class="startup-panel">
         <div class="status-spinner" aria-hidden="true"></div>
         <div class="startup-copy">

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -3,13 +3,68 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Kandev</title>
+    <style>
+      html,
+      body {
+        background: #f5f7f6;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      .startup-shell {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+        min-height: 100vh;
+      }
+
+      .status-spinner {
+        animation: startup-spin 960ms linear infinite;
+        border: 4px solid #d8dfdc;
+        border-radius: 999px;
+        border-top-color: #16875f;
+        height: 52px;
+        width: 52px;
+      }
+
+      .startup-copy {
+        display: none;
+      }
+
+      @keyframes startup-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (prefers-color-scheme: dark) {
+        html,
+        body {
+          background: #0f1413;
+        }
+
+        .status-spinner {
+          border-color: #27322e;
+          border-top-color: #2aa876;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .status-spinner {
+          animation: none;
+        }
+      }
+    </style>
     <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
-    <main class="startup-shell" aria-live="polite">
+    <main class="startup-shell" aria-busy="true" aria-live="polite" aria-label="Kandev is starting">
       <section class="startup-panel">
-        <div class="status-mark" aria-hidden="true"></div>
+        <div class="status-spinner" aria-hidden="true"></div>
         <div class="startup-copy">
           <p class="eyebrow">Kandev</p>
           <h1 id="status-title">Starting backend</h1>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -24,6 +24,7 @@ const applyStatus = (status: DesktopStatus) => {
   if (detail) {
     detail.textContent = status.detail;
   }
+  shell?.setAttribute("aria-busy", status.failed === true ? "false" : "true");
   shell?.classList.toggle("is-failed", status.failed === true);
 };
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,12 +1,45 @@
 :root {
-  color: #18201f;
-  background: #f5f7f6;
+  --startup-bg: #f5f7f6;
+  --startup-panel: #ffffff;
+  --startup-panel-border: #d8dfdc;
+  --startup-text: #18201f;
+  --startup-muted: #53625e;
+  --startup-shadow: rgba(24, 32, 31, 0.14);
+  --spinner-track: #d8dfdc;
+  --spinner-primary: #16875f;
+  --spinner-accent: #c48a2a;
+  --error-text: #9d241b;
+
+  color: var(--startup-text);
+  background: var(--startup-bg);
+  color-scheme: light dark;
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --startup-bg: #0f1413;
+    --startup-panel: #151c1a;
+    --startup-panel-border: #27322e;
+    --startup-text: #edf5f2;
+    --startup-muted: #9ca8a4;
+    --startup-shadow: rgba(0, 0, 0, 0.36);
+    --spinner-track: #27322e;
+    --spinner-primary: #2aa876;
+    --spinner-accent: #d6a348;
+    --error-text: #ffb4ab;
+  }
 }
 
 * {
@@ -14,6 +47,7 @@
 }
 
 body {
+  background: var(--startup-bg);
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
@@ -21,9 +55,7 @@ body {
 
 .startup-shell {
   align-items: center;
-  background:
-    linear-gradient(135deg, rgba(18, 117, 82, 0.08), transparent 34%),
-    linear-gradient(315deg, rgba(117, 85, 18, 0.08), transparent 38%), #f5f7f6;
+  background: var(--startup-bg);
   display: flex;
   min-height: 100vh;
   padding: 32px;
@@ -31,43 +63,81 @@ body {
 
 .startup-panel {
   align-items: center;
-  background: #ffffff;
-  border: 1px solid #d8dfdc;
+  display: flex;
+  justify-content: center;
+  margin: 0 auto;
+  min-height: 88px;
+  min-width: 88px;
+}
+
+.status-spinner {
+  animation: startup-spin 960ms linear infinite;
+  background:
+    linear-gradient(var(--startup-bg), var(--startup-bg)) padding-box,
+    conic-gradient(
+        from 0deg,
+        var(--spinner-primary),
+        var(--spinner-accent),
+        var(--spinner-track),
+        var(--spinner-primary)
+      )
+      border-box;
+  border: 4px solid transparent;
+  border-radius: 999px;
+  height: 52px;
+  width: 52px;
+}
+
+.startup-copy {
+  border: 0;
+  clip: rect(0 0 0 0);
+  display: block;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.startup-shell.is-failed .startup-panel {
+  background: var(--startup-panel);
+  border: 1px solid var(--startup-panel-border);
   border-radius: 8px;
-  box-shadow: 0 24px 70px rgba(24, 32, 31, 0.14);
+  box-shadow: 0 24px 70px var(--startup-shadow);
   display: grid;
   gap: 20px;
   grid-template-columns: 56px minmax(0, 1fr);
-  margin: 0 auto;
   max-width: 560px;
   min-height: 168px;
   padding: 28px;
   width: min(100%, 560px);
 }
 
-.status-mark {
-  align-self: start;
-  background: conic-gradient(from 90deg, #16875f, #c48a2a, #16875f);
-  border-radius: 999px;
+.startup-shell.is-failed .status-spinner {
+  animation: none;
+  background:
+    linear-gradient(var(--startup-panel), var(--startup-panel)) padding-box,
+    conic-gradient(from 90deg, var(--error-text), var(--spinner-accent), var(--error-text))
+      border-box;
   height: 44px;
-  position: relative;
   width: 44px;
 }
 
-.status-mark::after {
-  background: #ffffff;
-  border-radius: inherit;
-  content: "";
-  inset: 6px;
-  position: absolute;
-}
-
-.startup-copy {
+.startup-shell.is-failed .startup-copy {
+  clip: auto;
+  height: auto;
+  margin: 0;
   min-width: 0;
+  overflow: visible;
+  position: static;
+  white-space: normal;
+  width: auto;
 }
 
 .eyebrow {
-  color: #53625e;
+  color: var(--startup-muted);
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0;
@@ -77,7 +147,7 @@ body {
 }
 
 h1 {
-  color: #18201f;
+  color: var(--startup-text);
   font-size: 1.55rem;
   line-height: 1.2;
   margin: 0;
@@ -85,19 +155,27 @@ h1 {
 }
 
 #status-detail {
-  color: #53625e;
+  color: var(--startup-muted);
   font-size: 0.96rem;
   line-height: 1.55;
   margin: 10px 0 0;
   overflow-wrap: anywhere;
 }
 
-.startup-shell.is-failed .status-mark {
-  background: conic-gradient(from 90deg, #b42318, #c48a2a, #b42318);
+.startup-shell.is-failed h1 {
+  color: var(--error-text);
 }
 
-.startup-shell.is-failed h1 {
-  color: #9d241b;
+@keyframes startup-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-spinner {
+    animation: none;
+  }
 }
 
 @media (max-width: 520px) {
@@ -106,7 +184,7 @@ h1 {
     padding: 16px;
   }
 
-  .startup-panel {
+  .startup-shell.is-failed .startup-panel {
     align-content: center;
     grid-template-columns: 1fr;
     justify-items: start;


### PR DESCRIPTION
macOS desktop launches showed a visible backend-loading screen that ignored dark system theme, making unsigned release testing feel broken before the app was ready. The startup shell now uses a spinner-only theme-aware loading state, preserves diagnostic text for failures, and adds Makefile targets to build and launch the desktop app consistently.

## Important Changes

- Replaced visible startup copy with a spinner-only loading surface that respects light and dark macOS themes.
- Added `desktop-runtime`, `desktop-dev`, `desktop-build`, `desktop-open`, and `desktop-launch` root Makefile targets for macOS desktop testing.

## Validation

- `pnpm -C apps --filter @kandev/desktop typecheck`
- `pnpm -C apps --filter @kandev/desktop build:vite`
- Rendered Playwright check for light, dark, and mobile-width dark failure states
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test` (passed on rerun after one transient backend test failure)
- `make lint`
- `make help`
- `make -n desktop-launch`
- `make desktop-runtime` on Linux to verify the macOS-only guard
- `git diff --check`

## Possible Improvements

Low risk: the actual macOS Tauri app build still needs to be exercised on macOS because this workspace is Linux.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->