### PR TITLE
fix: repair postgres schema migration coverage

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -153,7 +153,7 @@ jobs:
           retention-days: 30
 
   postgres-boot:
-    name: Backend Postgres boot
+    name: Backend Postgres
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container: ghcr.io/kdlbs/kandev-ci:build-latest
@@ -173,15 +173,44 @@ jobs:
       run:
         shell: bash
         working-directory: apps/backend
+    env:
+      KANDEV_TEST_POSTGRES_DSN: host=postgres port=5432 user=kandev password=kandev dbname=kandev_admin sslmode=disable
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Run Postgres boot smoke test
-        env:
-          KANDEV_TEST_POSTGRES_DSN: host=postgres port=5432 user=kandev password=kandev dbname=kandev_admin sslmode=disable
-        run: go test -v -race -run TestPostgresBootInitializesRepositories ./cmd/kandev
+        run: |
+          set -euo pipefail
+
+          output_file="$(mktemp)"
+          go test -v -race -run '^TestPostgresBootInitializesRepositories$' ./internal/backendapp 2>&1 | tee "${output_file}"
+
+          if ! grep -q '^=== RUN   TestPostgresBootInitializesRepositories$' "${output_file}"; then
+            echo "::error::Postgres boot smoke test matched no tests"
+            exit 1
+          fi
+
+      - name: Run env-gated Postgres tests
+        run: |
+          set -euo pipefail
+
+          mapfile -t postgres_packages < <(
+            grep -RIl 'PostgresDSNFromEnv' . --include='*_test.go' \
+              | xargs -r dirname \
+              | sort -u
+          )
+
+          if [[ "${#postgres_packages[@]}" -eq 0 ]]; then
+            echo "::error::No Postgres test packages found"
+            exit 1
+          fi
+
+          printf 'Running Postgres tests in:\n'
+          printf '  %s\n' "${postgres_packages[@]}"
+
+          go test -v -race "${postgres_packages[@]}"
 
   test-windows:
     name: Backend (windows)

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -155,6 +155,9 @@ jobs:
   postgres-boot:
     name: Backend Postgres
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     timeout-minutes: 10
     container: ghcr.io/kdlbs/kandev-ci:build-latest
     services:
@@ -179,18 +182,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Run Postgres boot smoke test
-        run: |
-          set -euo pipefail
-
-          output_file="$(mktemp)"
-          go test -v -race -run '^TestPostgresBootInitializesRepositories$' ./internal/backendapp 2>&1 | tee "${output_file}"
-
-          if ! grep -q '^=== RUN   TestPostgresBootInitializesRepositories$' "${output_file}"; then
-            echo "::error::Postgres boot smoke test matched no tests"
-            exit 1
-          fi
+        with:
+          persist-credentials: false
 
       - name: Run env-gated Postgres tests
         run: |
@@ -210,7 +203,13 @@ jobs:
           printf 'Running Postgres tests in:\n'
           printf '  %s\n' "${postgres_packages[@]}"
 
-          go test -v -race "${postgres_packages[@]}"
+          output_file="$(mktemp)"
+          go test -v -race "${postgres_packages[@]}" 2>&1 | tee "${output_file}"
+
+          if ! grep -q '^=== RUN   TestPostgresBootInitializesRepositories$' "${output_file}"; then
+            echo "::error::Postgres boot smoke test matched no tests"
+            exit 1
+          fi
 
   test-windows:
     name: Backend (windows)

--- a/apps/backend/internal/task/repository/sqlite/base_migrations.go
+++ b/apps/backend/internal/task/repository/sqlite/base_migrations.go
@@ -452,7 +452,7 @@ BEGIN
 		AND nsp.nspname = current_schema()
 		AND con.contype = 'u'
 		AND (
-			SELECT array_agg(attr.attname ORDER BY cols.ordinality)
+			SELECT array_agg(attr.attname::text ORDER BY cols.ordinality)
 			FROM unnest(con.conkey) WITH ORDINALITY AS cols(attnum, ordinality)
 			JOIN pg_attribute attr ON attr.attrelid = con.conrelid AND attr.attnum = cols.attnum
 		) = ARRAY['task_environment_id', 'repository_id'];
@@ -470,7 +470,7 @@ BEGIN
 			AND nsp.nspname = current_schema()
 			AND con.contype = 'u'
 			AND (
-				SELECT array_agg(attr.attname ORDER BY cols.ordinality)
+				SELECT array_agg(attr.attname::text ORDER BY cols.ordinality)
 				FROM unnest(con.conkey) WITH ORDINALITY AS cols(attnum, ordinality)
 				JOIN pg_attribute attr ON attr.attrelid = con.conrelid AND attr.attnum = cols.attnum
 			) = ARRAY['task_environment_id', 'repository_id', 'branch_slug']


### PR DESCRIPTION
Postgres startup migrations were still able to fail after release because the
CI job intended to catch them was not exercising the env-gated Postgres tests.
The migration now uses compatible catalog array types, and CI now runs the real
Postgres boot and schema coverage.

## Important Changes

- Cast Postgres catalog column names to `text` before comparing constraint
  column arrays.
- Point the Postgres boot smoke test at the package that owns the test and fail
  the job if the focused run matches zero tests.
- Discover and run every backend test package that opts into
  `PostgresDSNFromEnv` against the CI Postgres service.

## Validation

- `pnpm install --frozen-lockfile` from `apps/`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- Corrected Postgres boot smoke snippet against a temporary `postgres:16-alpine`
  container.
- New env-gated Postgres package test snippet against a temporary
  `postgres:16-alpine` container.
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->