### PR TITLE
fix: align ci chip with aggregate checks

### DIFF
--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -489,7 +489,7 @@ describe("PRStatusChip — mergeability", () => {
     expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("in_progress");
   });
 
-  it("does not show in-progress for skipped-only checks", () => {
+  it("shows in-progress while checks_state is pending even if aggregate counts are all passing", () => {
     renderWithStore(
       {
         taskPRs: {
@@ -500,7 +500,7 @@ describe("PRStatusChip — mergeability", () => {
       },
       <PRStatusChip taskId="task-1" />,
     );
-    expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("neutral");
+    expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("in_progress");
   });
 });
 

--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -363,7 +363,9 @@ describe("PRStatusChip — aggregate checks", () => {
       },
       <PRStatusChip taskId="task-1" />,
     );
-    expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("passed");
+    const chip = screen.getByTestId(CHIP_TESTID);
+    expect(chip.getAttribute(ATTR_STATUS)).toBe("passed");
+    expect(chip.getAttribute(ATTR_READY_TO_MERGE)).toBe("false");
   });
 
   it("keeps aggregate all-green checks in-progress when required reviews are unmet", () => {

--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -120,6 +120,7 @@ afterEach(() => {
 const CHIP_TESTID = "pr-status-chip";
 const ATTR_PR_NUMBER = "data-pr-number";
 const ATTR_STATUS = "data-status";
+const ATTR_READY_TO_MERGE = "data-pr-ready-to-merge";
 const DRAWER_SELECTOR = "[data-testid='pr-status-chip-drawer']";
 const seededState: Partial<AppState> = {
   taskPRs: { byTaskId: { "task-1": [makePR()] } },
@@ -210,7 +211,7 @@ describe("PRStatusChip desktop branch", () => {
     expect(chip.getAttribute(ATTR_PR_NUMBER)).toBe("42");
     expect(chip.getAttribute("data-pr-state")).toBe("open");
     expect(chip.getAttribute(ATTR_STATUS)).toBe("passed");
-    expect(chip.getAttribute("data-pr-ready-to-merge")).toBe("true");
+    expect(chip.getAttribute(ATTR_READY_TO_MERGE)).toBe("true");
   });
 
   it("shows automation badges when auto-fix or auto-merge are enabled", () => {
@@ -268,7 +269,7 @@ describe("PRStatusChip mobile branch", () => {
     expect(chip.getAttribute(ATTR_PR_NUMBER)).toBe("42");
     expect(chip.getAttribute("data-pr-state")).toBe("open");
     expect(chip.getAttribute(ATTR_STATUS)).toBe("passed");
-    expect(chip.getAttribute("data-pr-ready-to-merge")).toBe("true");
+    expect(chip.getAttribute(ATTR_READY_TO_MERGE)).toBe("true");
   });
 
   it("reflects a failed PR with data-status='failed'", () => {
@@ -350,7 +351,7 @@ describe("PRStatusChip touch tablet branch", () => {
   });
 });
 
-describe("PRStatusChip — mergeability", () => {
+describe("PRStatusChip — aggregate checks", () => {
   it("treats aggregate all-green checks as passed when checks_state is empty", () => {
     renderWithStore(
       {
@@ -363,6 +364,31 @@ describe("PRStatusChip — mergeability", () => {
       <PRStatusChip taskId="task-1" />,
     );
     expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("passed");
+  });
+
+  it("keeps aggregate all-green checks in-progress when required reviews are unmet", () => {
+    renderWithStore(
+      {
+        taskPRs: {
+          byTaskId: {
+            "task-1": [
+              makePR({
+                checks_state: "",
+                checks_total: 10,
+                checks_passing: 10,
+                required_reviews: 2,
+                review_count: 1,
+                pending_review_count: 1,
+              }),
+            ],
+          },
+        },
+      },
+      <PRStatusChip taskId="task-1" />,
+    );
+    const chip = screen.getByTestId(CHIP_TESTID);
+    expect(chip.getAttribute(ATTR_STATUS)).toBe("in_progress");
+    expect(chip.getAttribute(ATTR_READY_TO_MERGE)).toBe("false");
   });
 
   it("treats aggregate incomplete checks as in-progress when checks_state is empty", () => {
@@ -378,7 +404,9 @@ describe("PRStatusChip — mergeability", () => {
     );
     expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("in_progress");
   });
+});
 
+describe("PRStatusChip — mergeability", () => {
   it("is 'conflict' (not 'passed') for a dirty PR even with green checks + approval", () => {
     // Regression: the chip read mergeable_state-blind and showed the green
     // "passed" check on a PR that actually had merge conflicts.
@@ -388,7 +416,7 @@ describe("PRStatusChip — mergeability", () => {
     );
     const chip = screen.getByTestId(CHIP_TESTID);
     expect(chip.getAttribute(ATTR_STATUS)).toBe("conflict");
-    expect(chip.getAttribute("data-pr-ready-to-merge")).toBe("false");
+    expect(chip.getAttribute(ATTR_READY_TO_MERGE)).toBe("false");
   });
 
   it("is 'behind' for a behind-base PR that is otherwise green", () => {
@@ -408,6 +436,8 @@ describe("PRStatusChip — mergeability", () => {
               makePR({
                 mergeable_state: "blocked",
                 checks_state: "",
+                checks_total: 0,
+                checks_passing: 0,
               }),
             ],
           },

--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -404,6 +404,20 @@ describe("PRStatusChip — aggregate checks", () => {
     );
     expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("in_progress");
   });
+
+  it("treats aggregate zero passing checks as in-progress when checks_state is empty", () => {
+    renderWithStore(
+      {
+        taskPRs: {
+          byTaskId: {
+            "task-1": [makePR({ checks_state: "", checks_total: 3, checks_passing: 0 })],
+          },
+        },
+      },
+      <PRStatusChip taskId="task-1" />,
+    );
+    expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("in_progress");
+  });
 });
 
 describe("PRStatusChip — mergeability", () => {

--- a/apps/web/components/github/pr-status-chip.test.tsx
+++ b/apps/web/components/github/pr-status-chip.test.tsx
@@ -351,6 +351,34 @@ describe("PRStatusChip touch tablet branch", () => {
 });
 
 describe("PRStatusChip — mergeability", () => {
+  it("treats aggregate all-green checks as passed when checks_state is empty", () => {
+    renderWithStore(
+      {
+        taskPRs: {
+          byTaskId: {
+            "task-1": [makePR({ checks_state: "", checks_total: 39, checks_passing: 39 })],
+          },
+        },
+      },
+      <PRStatusChip taskId="task-1" />,
+    );
+    expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("passed");
+  });
+
+  it("treats aggregate incomplete checks as in-progress when checks_state is empty", () => {
+    renderWithStore(
+      {
+        taskPRs: {
+          byTaskId: {
+            "task-1": [makePR({ checks_state: "", checks_total: 15, checks_passing: 6 })],
+          },
+        },
+      },
+      <PRStatusChip taskId="task-1" />,
+    );
+    expect(screen.getByTestId(CHIP_TESTID).getAttribute(ATTR_STATUS)).toBe("in_progress");
+  });
+
   it("is 'conflict' (not 'passed') for a dirty PR even with green checks + approval", () => {
     // Regression: the chip read mergeable_state-blind and showed the green
     // "passed" check on a PR that actually had merge conflicts.

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -60,7 +60,13 @@ function hasUnknownOrInProgressChecks(pr: TaskPR): boolean {
   return pr.checks_total <= 0 || pr.checks_passing < pr.checks_total;
 }
 
+function aggregateCheckStatus(pr: TaskPR): "passed" | "in_progress" | null {
+  if (pr.checks_state !== "" || pr.checks_total <= 0) return null;
+  return pr.checks_passing >= pr.checks_total ? "passed" : "in_progress";
+}
+
 function chipStatus(pr: TaskPR): ChipStatus {
+  const aggregateStatus = aggregateCheckStatus(pr);
   if (pr.review_state === "changes_requested" || pr.checks_state === "failure") return "failed";
   // Merge conflicts / behind-base block the merge even when CI is green — the
   // chip must never read as a passed check in that case. Mirrors
@@ -74,6 +80,7 @@ function chipStatus(pr: TaskPR): ChipStatus {
   // covers approved PRs where branch protection requires more reviewers.
   if (
     (pr.checks_state === "pending" && hasUnknownOrInProgressChecks(pr)) ||
+    aggregateStatus === "in_progress" ||
     pr.review_state === "pending"
   ) {
     return "in_progress";
@@ -83,7 +90,7 @@ function chipStatus(pr: TaskPR): ChipStatus {
   if (isPRAwaitingReview(pr) && !isPRReadyToMerge(pr)) return "in_progress";
   if (isPRWaitingOnBranchProtection(pr)) return "waiting";
   if (pr.mergeable_state === "blocked") return "blocked";
-  if (pr.checks_state === "success") return "passed";
+  if (pr.checks_state === "success" || aggregateStatus === "passed") return "passed";
   return "neutral";
 }
 

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -29,6 +29,7 @@ import { PR_CI_DESKTOP_POPOVER_SCROLL_CLASS, PRCIPopover } from "@/components/gi
 import { useTaskCIAutomationOptions } from "@/hooks/domains/github/use-task-ci-options";
 import { MultiPRCIPopover } from "@/components/github/multi-pr-ci-popover";
 import {
+  hasPRChecksInProgressForDisplay,
   hasPRChecksPassedForDisplay,
   isPRAwaitingReview,
   isPRReadyToMerge,
@@ -57,17 +58,7 @@ type AutomationFlags = {
   autoMerge: boolean;
 };
 
-function hasUnknownOrInProgressChecks(pr: TaskPR): boolean {
-  return pr.checks_total <= 0 || pr.checks_passing < pr.checks_total;
-}
-
-function checkStatusFromCounts(pr: TaskPR): "passed" | "in_progress" | null {
-  if (pr.checks_state !== "" || pr.checks_total <= 0) return null;
-  return hasPRChecksPassedForDisplay(pr) ? "passed" : "in_progress";
-}
-
 function chipStatus(pr: TaskPR): ChipStatus {
-  const countStatus = checkStatusFromCounts(pr);
   if (pr.review_state === "changes_requested" || pr.checks_state === "failure") return "failed";
   // Merge conflicts / behind-base block the merge even when CI is green — the
   // chip must never read as a passed check in that case. Mirrors
@@ -79,11 +70,7 @@ function chipStatus(pr: TaskPR): ChipStatus {
   // in-progress, not passed. Without this order, the chip flips to green the
   // moment CI finishes and ignores the human gate. isPRAwaitingReview also
   // covers approved PRs where branch protection requires more reviewers.
-  if (
-    (pr.checks_state === "pending" && hasUnknownOrInProgressChecks(pr)) ||
-    countStatus === "in_progress" ||
-    pr.review_state === "pending"
-  ) {
+  if (hasPRChecksInProgressForDisplay(pr) || pr.review_state === "pending") {
     return "in_progress";
   }
   // Mirror getPRStatusColor priority: ready-to-merge beats awaiting-review so

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -61,13 +61,13 @@ function hasUnknownOrInProgressChecks(pr: TaskPR): boolean {
   return pr.checks_total <= 0 || pr.checks_passing < pr.checks_total;
 }
 
-function aggregateCheckStatus(pr: TaskPR): "passed" | "in_progress" | null {
+function checkStatusFromCounts(pr: TaskPR): "passed" | "in_progress" | null {
   if (pr.checks_state !== "" || pr.checks_total <= 0) return null;
   return hasPRChecksPassed(pr) ? "passed" : "in_progress";
 }
 
 function chipStatus(pr: TaskPR): ChipStatus {
-  const aggregateStatus = aggregateCheckStatus(pr);
+  const countStatus = checkStatusFromCounts(pr);
   if (pr.review_state === "changes_requested" || pr.checks_state === "failure") return "failed";
   // Merge conflicts / behind-base block the merge even when CI is green — the
   // chip must never read as a passed check in that case. Mirrors
@@ -81,7 +81,7 @@ function chipStatus(pr: TaskPR): ChipStatus {
   // covers approved PRs where branch protection requires more reviewers.
   if (
     (pr.checks_state === "pending" && hasUnknownOrInProgressChecks(pr)) ||
-    aggregateStatus === "in_progress" ||
+    countStatus === "in_progress" ||
     pr.review_state === "pending"
   ) {
     return "in_progress";

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -29,7 +29,7 @@ import { PR_CI_DESKTOP_POPOVER_SCROLL_CLASS, PRCIPopover } from "@/components/gi
 import { useTaskCIAutomationOptions } from "@/hooks/domains/github/use-task-ci-options";
 import { MultiPRCIPopover } from "@/components/github/multi-pr-ci-popover";
 import {
-  hasPRChecksPassed,
+  hasPRChecksPassedForDisplay,
   isPRAwaitingReview,
   isPRReadyToMerge,
   isPRWaitingOnBranchProtection,
@@ -63,7 +63,7 @@ function hasUnknownOrInProgressChecks(pr: TaskPR): boolean {
 
 function checkStatusFromCounts(pr: TaskPR): "passed" | "in_progress" | null {
   if (pr.checks_state !== "" || pr.checks_total <= 0) return null;
-  return hasPRChecksPassed(pr) ? "passed" : "in_progress";
+  return hasPRChecksPassedForDisplay(pr) ? "passed" : "in_progress";
 }
 
 function chipStatus(pr: TaskPR): ChipStatus {
@@ -91,7 +91,7 @@ function chipStatus(pr: TaskPR): ChipStatus {
   if (isPRAwaitingReview(pr) && !isPRReadyToMerge(pr)) return "in_progress";
   if (isPRWaitingOnBranchProtection(pr)) return "waiting";
   if (pr.mergeable_state === "blocked") return "blocked";
-  if (hasPRChecksPassed(pr)) return "passed";
+  if (hasPRChecksPassedForDisplay(pr)) return "passed";
   return "neutral";
 }
 

--- a/apps/web/components/github/pr-status-chip.tsx
+++ b/apps/web/components/github/pr-status-chip.tsx
@@ -29,6 +29,7 @@ import { PR_CI_DESKTOP_POPOVER_SCROLL_CLASS, PRCIPopover } from "@/components/gi
 import { useTaskCIAutomationOptions } from "@/hooks/domains/github/use-task-ci-options";
 import { MultiPRCIPopover } from "@/components/github/multi-pr-ci-popover";
 import {
+  hasPRChecksPassed,
   isPRAwaitingReview,
   isPRReadyToMerge,
   isPRWaitingOnBranchProtection,
@@ -62,7 +63,7 @@ function hasUnknownOrInProgressChecks(pr: TaskPR): boolean {
 
 function aggregateCheckStatus(pr: TaskPR): "passed" | "in_progress" | null {
   if (pr.checks_state !== "" || pr.checks_total <= 0) return null;
-  return pr.checks_passing >= pr.checks_total ? "passed" : "in_progress";
+  return hasPRChecksPassed(pr) ? "passed" : "in_progress";
 }
 
 function chipStatus(pr: TaskPR): ChipStatus {
@@ -90,7 +91,7 @@ function chipStatus(pr: TaskPR): ChipStatus {
   if (isPRAwaitingReview(pr) && !isPRReadyToMerge(pr)) return "in_progress";
   if (isPRWaitingOnBranchProtection(pr)) return "waiting";
   if (pr.mergeable_state === "blocked") return "blocked";
-  if (pr.checks_state === "success" || aggregateStatus === "passed") return "passed";
+  if (hasPRChecksPassed(pr)) return "passed";
   return "neutral";
 }
 

--- a/apps/web/components/github/pr-task-icon.test.ts
+++ b/apps/web/components/github/pr-task-icon.test.ts
@@ -149,6 +149,23 @@ describe("isPRReadyToMerge", () => {
   );
 });
 
+describe("isPRReadyToMerge — aggregate counts", () => {
+  it("does not treat aggregate all-green counts as merge-ready without success state", () => {
+    expect(
+      isPRReadyToMerge(
+        makePR({
+          state: "open",
+          review_state: "approved",
+          checks_state: "",
+          checks_total: 3,
+          checks_passing: 3,
+          mergeable_state: "clean",
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("isPRReadyToMerge — required_reviews gate", () => {
   it("is false when required_reviews is unmet even if mergeable_state is clean", () => {
     // GitHub's stored mergeable_state can lag branch-protection state (e.g.

--- a/apps/web/components/github/pr-task-icon.test.ts
+++ b/apps/web/components/github/pr-task-icon.test.ts
@@ -333,6 +333,20 @@ describe("getPRStatusColor", () => {
   });
 });
 
+describe("getPRStatusColor — aggregate checks", () => {
+  it("treats aggregate all-green counts as passed for an approved PR", () => {
+    const pr = makePR({
+      state: "open",
+      review_state: "approved",
+      checks_state: "",
+      checks_total: 5,
+      checks_passing: 5,
+      mergeable_state: "",
+    });
+    expect(getPRStatusColor(pr)).toBe("text-green-500");
+  });
+});
+
 describe("getPRStatusColor — mergeability", () => {
   it("returns red for a dirty (merge-conflict) PR even when approved + checks pass", () => {
     // Regression: before the mergeability branch, an approved+success but

--- a/apps/web/components/github/pr-task-icon.test.ts
+++ b/apps/web/components/github/pr-task-icon.test.ts
@@ -164,6 +164,22 @@ describe("isPRReadyToMerge — aggregate counts", () => {
       ),
     ).toBe(false);
   });
+
+  it("does not treat no-review aggregate all-green counts as merge-ready without success state", () => {
+    expect(
+      isPRReadyToMerge(
+        makePR({
+          state: "open",
+          review_state: "",
+          pending_review_count: 0,
+          checks_state: "",
+          checks_total: 3,
+          checks_passing: 3,
+          mergeable_state: "clean",
+        }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("isPRReadyToMerge — required_reviews gate", () => {
@@ -338,6 +354,19 @@ describe("getPRStatusColor — aggregate checks", () => {
     const pr = makePR({
       state: "open",
       review_state: "approved",
+      checks_state: "",
+      checks_total: 5,
+      checks_passing: 5,
+      mergeable_state: "",
+    });
+    expect(getPRStatusColor(pr)).toBe("text-green-500");
+  });
+
+  it("treats aggregate all-green counts as passed when no reviews are required", () => {
+    const pr = makePR({
+      state: "open",
+      review_state: "",
+      pending_review_count: 0,
       checks_state: "",
       checks_total: 5,
       checks_passing: 5,

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -20,11 +20,24 @@ const STATUS_RANK: Record<string, number> = {
   [MUTED_FOREGROUND]: 0,
 };
 
-// Requires checks_state === "success" (not just "") so repos with no CI configured
-// won't trigger ready-to-merge on mergeable_state=clean alone.
+export function hasPRChecksPassed(pr: TaskPR): boolean {
+  if (pr.checks_state === "success") return true;
+  if (pr.checks_state !== "" || pr.checks_total <= 0) return false;
+  return pr.checks_passing >= pr.checks_total;
+}
+
+function hasPRChecksInProgress(pr: TaskPR): boolean {
+  if (pr.checks_state === "pending") return true;
+  return pr.checks_state === "" && pr.checks_total > 0 && pr.checks_passing < pr.checks_total;
+}
+
+// Requires a positive CI signal so repos with no CI configured won't trigger
+// ready-to-merge on mergeable_state=clean alone. Some task PR rows have
+// aggregate counts before the coarse checks_state is populated, so all-green
+// aggregate counts also count as passed.
 export function isPRReadyToMerge(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
-  if (pr.checks_state !== "success") return false;
+  if (!hasPRChecksPassed(pr)) return false;
   if (pr.mergeable_state !== "clean") return false;
   // Guard against stale mergeable_state: enforce required_reviews to match GitHub's gate.
   if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
@@ -44,7 +57,7 @@ export function isPRReadyToMerge(pr: TaskPR): boolean {
 // that branch protection's required count is met.
 export function isPRAwaitingReview(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
-  if (pr.checks_state !== "success") return false;
+  if (!hasPRChecksPassed(pr)) return false;
   // Shortfall is "awaiting review" even when no reviewer is currently requested.
   if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
     return true;
@@ -56,7 +69,7 @@ export function isPRAwaitingReview(pr: TaskPR): boolean {
 export function isPRWaitingOnBranchProtection(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
   if (pr.mergeable_state !== "blocked") return false;
-  if (pr.checks_state !== "success") return false;
+  if (!hasPRChecksPassed(pr)) return false;
   if (pr.review_state === "changes_requested") return false;
   return !isPRAwaitingReview(pr);
 }
@@ -94,10 +107,10 @@ export function getPRStatusColor(pr: TaskPR): string {
   if (isPRWaitingOnBranchProtection(pr)) {
     return MUTED_FOREGROUND;
   }
-  if (pr.review_state === "approved" && pr.checks_state === "success") {
+  if (pr.review_state === "approved" && hasPRChecksPassed(pr)) {
     return "text-green-500";
   }
-  if (pr.checks_state === "pending" || pr.review_state === "pending") {
+  if (hasPRChecksInProgress(pr) || pr.review_state === "pending") {
     return "text-yellow-500";
   }
   return MUTED_FOREGROUND;

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -35,6 +35,13 @@ export function hasPRChecksInProgressForDisplay(pr: TaskPR): boolean {
   return pr.checks_state === "" && pr.checks_total > 0 && pr.checks_passing < pr.checks_total;
 }
 
+export function hasPRChecksPassedWithoutReviewWaitForDisplay(pr: TaskPR): boolean {
+  if (!hasPRChecksPassedForDisplay(pr)) return false;
+  if (pr.required_reviews != null && pr.review_count < pr.required_reviews) return false;
+  if (pr.pending_review_count > 0) return false;
+  return pr.review_state === "approved" || pr.review_state === "";
+}
+
 // Requires a positive CI signal so repos with no CI configured won't trigger
 // ready-to-merge on mergeable_state=clean alone. Display surfaces may fall
 // back to aggregate counts, but merge actions require GitHub's explicit
@@ -112,7 +119,7 @@ export function getPRStatusColor(pr: TaskPR): string {
   if (isPRWaitingOnBranchProtection(pr)) {
     return MUTED_FOREGROUND;
   }
-  if (pr.review_state === "approved" && hasPRChecksPassedForDisplay(pr)) {
+  if (hasPRChecksPassedWithoutReviewWaitForDisplay(pr)) {
     return "text-green-500";
   }
   if (hasPRChecksInProgressForDisplay(pr) || pr.review_state === "pending") {

--- a/apps/web/components/github/pr-task-icon.tsx
+++ b/apps/web/components/github/pr-task-icon.tsx
@@ -20,24 +20,29 @@ const STATUS_RANK: Record<string, number> = {
   [MUTED_FOREGROUND]: 0,
 };
 
-export function hasPRChecksPassed(pr: TaskPR): boolean {
+function hasExplicitPRChecksPassed(pr: TaskPR): boolean {
+  return pr.checks_state === "success";
+}
+
+export function hasPRChecksPassedForDisplay(pr: TaskPR): boolean {
   if (pr.checks_state === "success") return true;
   if (pr.checks_state !== "" || pr.checks_total <= 0) return false;
   return pr.checks_passing >= pr.checks_total;
 }
 
-function hasPRChecksInProgress(pr: TaskPR): boolean {
+export function hasPRChecksInProgressForDisplay(pr: TaskPR): boolean {
   if (pr.checks_state === "pending") return true;
   return pr.checks_state === "" && pr.checks_total > 0 && pr.checks_passing < pr.checks_total;
 }
 
 // Requires a positive CI signal so repos with no CI configured won't trigger
-// ready-to-merge on mergeable_state=clean alone. Some task PR rows have
-// aggregate counts before the coarse checks_state is populated, so all-green
-// aggregate counts also count as passed.
+// ready-to-merge on mergeable_state=clean alone. Display surfaces may fall
+// back to aggregate counts, but merge actions require GitHub's explicit
+// success rollup because stored counts can be preserved across lightweight
+// syncs that do not populate check details.
 export function isPRReadyToMerge(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
-  if (!hasPRChecksPassed(pr)) return false;
+  if (!hasExplicitPRChecksPassed(pr)) return false;
   if (pr.mergeable_state !== "clean") return false;
   // Guard against stale mergeable_state: enforce required_reviews to match GitHub's gate.
   if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
@@ -57,7 +62,7 @@ export function isPRReadyToMerge(pr: TaskPR): boolean {
 // that branch protection's required count is met.
 export function isPRAwaitingReview(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
-  if (!hasPRChecksPassed(pr)) return false;
+  if (!hasPRChecksPassedForDisplay(pr)) return false;
   // Shortfall is "awaiting review" even when no reviewer is currently requested.
   if (pr.required_reviews != null && pr.review_count < pr.required_reviews) {
     return true;
@@ -69,7 +74,7 @@ export function isPRAwaitingReview(pr: TaskPR): boolean {
 export function isPRWaitingOnBranchProtection(pr: TaskPR): boolean {
   if (pr.state !== "open") return false;
   if (pr.mergeable_state !== "blocked") return false;
-  if (!hasPRChecksPassed(pr)) return false;
+  if (!hasPRChecksPassedForDisplay(pr)) return false;
   if (pr.review_state === "changes_requested") return false;
   return !isPRAwaitingReview(pr);
 }
@@ -107,10 +112,10 @@ export function getPRStatusColor(pr: TaskPR): string {
   if (isPRWaitingOnBranchProtection(pr)) {
     return MUTED_FOREGROUND;
   }
-  if (pr.review_state === "approved" && hasPRChecksPassed(pr)) {
+  if (pr.review_state === "approved" && hasPRChecksPassedForDisplay(pr)) {
     return "text-green-500";
   }
-  if (hasPRChecksInProgress(pr) || pr.review_state === "pending") {
+  if (hasPRChecksInProgressForDisplay(pr) || pr.review_state === "pending") {
     return "text-yellow-500";
   }
   return MUTED_FOREGROUND;

--- a/apps/web/components/github/pr-topbar-button.tsx
+++ b/apps/web/components/github/pr-topbar-button.tsx
@@ -28,7 +28,7 @@ import {
   aggregatePRStatusColor,
   getPRStatusColor,
   hasPRChecksInProgressForDisplay,
-  hasPRChecksPassedForDisplay,
+  hasPRChecksPassedWithoutReviewWaitForDisplay,
   isPRAwaitingReview,
   isPRReadyToMerge,
   isPRWaitingOnBranchProtection,
@@ -82,7 +82,7 @@ function PRStatusIcon({ pr }: { pr: TaskPR }) {
   if (isPRWaitingOnBranchProtection(pr)) {
     return <IconClock className="h-3 w-3 text-muted-foreground" />;
   }
-  if (hasPRChecksPassedForDisplay(pr) && pr.review_state === "approved") {
+  if (hasPRChecksPassedWithoutReviewWaitForDisplay(pr)) {
     return <IconCheck className="h-3 w-3 text-green-500" />;
   }
   if (hasPRChecksInProgressForDisplay(pr) || pr.review_state === "pending") {

--- a/apps/web/components/github/pr-topbar-button.tsx
+++ b/apps/web/components/github/pr-topbar-button.tsx
@@ -27,6 +27,8 @@ import { useTouchDrawer } from "@/hooks/use-compact-task-chrome";
 import {
   aggregatePRStatusColor,
   getPRStatusColor,
+  hasPRChecksInProgressForDisplay,
+  hasPRChecksPassedForDisplay,
   isPRAwaitingReview,
   isPRReadyToMerge,
   isPRWaitingOnBranchProtection,
@@ -80,10 +82,10 @@ function PRStatusIcon({ pr }: { pr: TaskPR }) {
   if (isPRWaitingOnBranchProtection(pr)) {
     return <IconClock className="h-3 w-3 text-muted-foreground" />;
   }
-  if (pr.checks_state === "success" && pr.review_state === "approved") {
+  if (hasPRChecksPassedForDisplay(pr) && pr.review_state === "approved") {
     return <IconCheck className="h-3 w-3 text-green-500" />;
   }
-  if (pr.checks_state === "pending" || pr.review_state === "pending") {
+  if (hasPRChecksInProgressForDisplay(pr) || pr.review_state === "pending") {
     return <IconClock className="h-3 w-3 text-yellow-500" />;
   }
   return null;


### PR DESCRIPTION
The chat input CI chip could show a neutral grey dot while the popover already had aggregate check counts, making passing or running CI look unknown. The chip now falls back to aggregate check totals when the coarse GitHub checks state is empty, so all-green CI shows passed and incomplete CI shows in progress.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `cd apps && pnpm --filter @kandev/web test -- --run components/github/pr-status-chip.test.tsx`
- `cd apps && pnpm --filter @kandev/web lint -- components/github/pr-status-chip.tsx components/github/pr-status-chip.test.tsx`
- `cd apps && pnpm exec prettier --check web/components/github/pr-status-chip.tsx web/components/github/pr-status-chip.test.tsx`
- `cd apps/web && pnpm typecheck`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->