### PR TITLE
fix: show loading states for task detail

### DIFF
--- a/apps/web/components/task/chat/message-list-native.tsx
+++ b/apps/web/components/task/chat/message-list-native.tsx
@@ -191,6 +191,7 @@ export const NativeMessageList = memo(function NativeMessageList({
     messagesLoading,
     messagesCount: messages.length,
     isWorking,
+    sessionState,
   });
   const { loadMore, hasMore, isLoading: isLoadingMore } = useLazyLoadMessages(sessionId);
   const isRunning = getSessionRunningState(sessionState);

--- a/apps/web/components/task/chat/message-list-native.tsx
+++ b/apps/web/components/task/chat/message-list-native.tsx
@@ -12,6 +12,7 @@ import {
   MessageListStatus,
   MessageItem,
   getItemKey,
+  getConversationLoadingState,
   getSessionRunningState,
   getLastTurnGroupId,
 } from "./message-list-shared";
@@ -186,10 +187,11 @@ export const NativeMessageList = memo(function NativeMessageList({
 }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const isInitialLoading = messagesLoading && messages.length === 0;
-  const isNonLoadableSession =
-    !sessionState || ["CREATED", "FAILED", "COMPLETED", "CANCELLED"].includes(sessionState);
-  const showLoadingState = isInitialLoading && !isWorking && !isNonLoadableSession;
+  const { isInitialLoading, showLoadingState } = getConversationLoadingState({
+    messagesLoading,
+    messagesCount: messages.length,
+    isWorking,
+  });
   const { loadMore, hasMore, isLoading: isLoadingMore } = useLazyLoadMessages(sessionId);
   const isRunning = getSessionRunningState(sessionState);
   const lastTurnGroupId = useMemo(() => getLastTurnGroupId(items), [items]);

--- a/apps/web/components/task/chat/message-list-shared.test.tsx
+++ b/apps/web/components/task/chat/message-list-shared.test.tsx
@@ -151,6 +151,7 @@ describe("getConversationLoadingState", () => {
         messagesLoading: true,
         messagesCount: 1,
         isWorking: false,
+        sessionState: "COMPLETED",
       }),
     ).toEqual({ isInitialLoading: false, showLoadingState: true });
   });
@@ -161,6 +162,7 @@ describe("getConversationLoadingState", () => {
         messagesLoading: true,
         messagesCount: 0,
         isWorking: false,
+        sessionState: "RUNNING",
       }),
     ).toEqual({ isInitialLoading: true, showLoadingState: true });
   });
@@ -171,8 +173,29 @@ describe("getConversationLoadingState", () => {
         messagesLoading: true,
         messagesCount: 1,
         isWorking: true,
+        sessionState: "RUNNING",
       }),
     ).toEqual({ isInitialLoading: false, showLoadingState: false });
+  });
+
+  it("suppresses loading for empty sessions that cannot load conversation history", () => {
+    expect(
+      getConversationLoadingState({
+        messagesLoading: true,
+        messagesCount: 0,
+        isWorking: false,
+        sessionState: "FAILED",
+      }),
+    ).toEqual({ isInitialLoading: true, showLoadingState: false });
+
+    expect(
+      getConversationLoadingState({
+        messagesLoading: true,
+        messagesCount: 0,
+        isWorking: false,
+        sessionState: null,
+      }),
+    ).toEqual({ isInitialLoading: true, showLoadingState: false });
   });
 });
 

--- a/apps/web/components/task/chat/message-list-shared.test.tsx
+++ b/apps/web/components/task/chat/message-list-shared.test.tsx
@@ -61,7 +61,7 @@ vi.mock("@/lib/api/domains/session-api", () => ({
   dismissLastAgentError: vi.fn(),
 }));
 
-import { MessageItem } from "./message-list-shared";
+import { MessageItem, MessageListStatus, getConversationLoadingState } from "./message-list-shared";
 
 const item: RenderItem = { type: "message", message: { id: "m1" } as Message };
 const noop = () => {};
@@ -141,5 +141,55 @@ describe("MessageItem agent error notice", () => {
 
     expect(screen.getByTestId("last-agent-error-notice").getAttribute("role")).toBe("alert");
     expect(screen.queryByText("agent process exited")).not.toBeNull();
+  });
+});
+
+describe("getConversationLoadingState", () => {
+  it("shows loading while conversation history is still fetching with initial content rendered", () => {
+    expect(
+      getConversationLoadingState({
+        messagesLoading: true,
+        messagesCount: 1,
+        isWorking: false,
+      }),
+    ).toEqual({ isInitialLoading: false, showLoadingState: true });
+  });
+
+  it("shows an initial loading state when no messages are rendered yet", () => {
+    expect(
+      getConversationLoadingState({
+        messagesLoading: true,
+        messagesCount: 0,
+        isWorking: false,
+      }),
+    ).toEqual({ isInitialLoading: true, showLoadingState: true });
+  });
+
+  it("does not compete with the active agent status while the session is working", () => {
+    expect(
+      getConversationLoadingState({
+        messagesLoading: true,
+        messagesCount: 1,
+        isWorking: true,
+      }),
+    ).toEqual({ isInitialLoading: false, showLoadingState: false });
+  });
+});
+
+describe("MessageListStatus", () => {
+  it("renders a conversation loading indicator while existing content remains visible", () => {
+    render(
+      <MessageListStatus
+        isLoadingMore={false}
+        hasMore={false}
+        showLoadingState
+        messagesLoading
+        isInitialLoading={false}
+        messagesCount={1}
+      />,
+    );
+
+    expect(screen.queryByTestId("conversation-loading-state")).not.toBeNull();
+    expect(screen.queryByText("Loading conversation...")).not.toBeNull();
   });
 });

--- a/apps/web/components/task/chat/message-list-shared.tsx
+++ b/apps/web/components/task/chat/message-list-shared.tsx
@@ -55,6 +55,18 @@ export function getLastTurnGroupId(items: RenderItem[]) {
   return null;
 }
 
+export function getConversationLoadingState(params: {
+  messagesLoading: boolean;
+  messagesCount: number;
+  isWorking: boolean;
+}) {
+  const isInitialLoading = params.messagesLoading && params.messagesCount === 0;
+  return {
+    isInitialLoading,
+    showLoadingState: params.messagesLoading && !params.isWorking,
+  };
+}
+
 // The chat banner stays visible until the user explicitly dismisses it, even
 // after the agent resumes — so the user can read the full error message at
 // their own pace. The sidebar icon, by contrast, also auto-hides once the
@@ -163,9 +175,12 @@ export function MessageListStatus({
         </div>
       )}
       {showLoadingState && (
-        <div className="flex items-center justify-center py-8 text-muted-foreground">
+        <div
+          className="flex items-center justify-center py-8 text-muted-foreground"
+          data-testid="conversation-loading-state"
+        >
           <GridSpinner className="text-primary mr-2" />
-          <span>Loading messages...</span>
+          <span>Loading conversation...</span>
         </div>
       )}
       {!messagesLoading && !isInitialLoading && messagesCount === 0 && (

--- a/apps/web/components/task/chat/message-list-shared.tsx
+++ b/apps/web/components/task/chat/message-list-shared.tsx
@@ -59,11 +59,21 @@ export function getConversationLoadingState(params: {
   messagesLoading: boolean;
   messagesCount: number;
   isWorking: boolean;
+  sessionState?: TaskSessionState | null;
 }) {
   const isInitialLoading = params.messagesLoading && params.messagesCount === 0;
+  const isNonLoadableSession =
+    !params.sessionState ||
+    params.sessionState === "CREATED" ||
+    params.sessionState === "FAILED" ||
+    params.sessionState === "COMPLETED" ||
+    params.sessionState === "CANCELLED";
   return {
     isInitialLoading,
-    showLoadingState: params.messagesLoading && !params.isWorking,
+    showLoadingState:
+      params.messagesLoading &&
+      !params.isWorking &&
+      (params.messagesCount > 0 || !isNonLoadableSession),
   };
 }
 

--- a/apps/web/components/task/chat/message-list-virtuoso.tsx
+++ b/apps/web/components/task/chat/message-list-virtuoso.tsx
@@ -448,6 +448,7 @@ export const VirtuosoMessageList = memo(function VirtuosoMessageList(props: Mess
     messagesLoading,
     messagesCount: messages.length,
     isWorking,
+    sessionState,
   });
   const { loadMore, hasMore, isLoading: isLoadingMore } = useLazyLoadMessages(sessionId);
   const isRunning = getSessionRunningState(sessionState);

--- a/apps/web/components/task/chat/message-list-virtuoso.tsx
+++ b/apps/web/components/task/chat/message-list-virtuoso.tsx
@@ -14,6 +14,7 @@ import {
   MessageListStatus,
   MessageItem,
   getItemKey,
+  getConversationLoadingState,
   getSessionRunningState,
   getLastTurnGroupId,
 } from "./message-list-shared";
@@ -443,11 +444,11 @@ export const VirtuosoMessageList = memo(function VirtuosoMessageList(props: Mess
     sessionState,
   } = props;
   const { scrollParent, setScrollRef } = useVisibleScrollParent();
-  const isInitialLoading = messagesLoading && messages.length === 0;
-  const isNonLoadableSession =
-    !sessionState || ["CREATED", "FAILED", "COMPLETED", "CANCELLED"].includes(sessionState);
-  const showLoadingState =
-    (messagesLoading || isInitialLoading) && !isWorking && !isNonLoadableSession;
+  const { isInitialLoading, showLoadingState } = getConversationLoadingState({
+    messagesLoading,
+    messagesCount: messages.length,
+    isWorking,
+  });
   const { loadMore, hasMore, isLoading: isLoadingMore } = useLazyLoadMessages(sessionId);
   const isRunning = getSessionRunningState(sessionState);
   const lastTurnGroupId = useMemo(() => getLastTurnGroupId(items), [items]);

--- a/apps/web/components/task/task-page-content-helpers.test.ts
+++ b/apps/web/components/task/task-page-content-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Task } from "@/lib/types/http";
 import {
   buildDebugEntries,
+  hasResolvedTaskDetails,
   resolveTaskContentState,
   resolveTaskProps,
 } from "./task-page-content-helpers";
@@ -87,13 +88,55 @@ describe("resolveTaskContentState", () => {
     ).toBe("error");
   });
 
-  it("treats a resolved task as ready", () => {
+  it("surfaces task load failures even when a placeholder task exists", () => {
     expect(
       resolveTaskContentState({
         isMounted: true,
         hasTask: true,
         hasTaskLoadError: true,
       }),
+    ).toBe("error");
+  });
+
+  it("treats a resolved task as ready", () => {
+    expect(
+      resolveTaskContentState({
+        isMounted: true,
+        hasTask: true,
+        hasTaskLoadError: false,
+      }),
     ).toBe("ready");
+  });
+});
+
+describe("hasResolvedTaskDetails", () => {
+  it("returns true when fetched details match the effective task", () => {
+    expect(
+      hasResolvedTaskDetails({
+        effectiveTaskId: "task-1",
+        taskDetailsId: "task-1",
+        initialTaskId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when SSR task details match the effective task", () => {
+    expect(
+      hasResolvedTaskDetails({
+        effectiveTaskId: "task-1",
+        taskDetailsId: null,
+        initialTaskId: "task-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for kanban-only placeholder tasks", () => {
+    expect(
+      hasResolvedTaskDetails({
+        effectiveTaskId: "task-1",
+        taskDetailsId: "task-2",
+        initialTaskId: null,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/components/task/task-page-content-helpers.test.ts
+++ b/apps/web/components/task/task-page-content-helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Task } from "@/lib/types/http";
-import { buildDebugEntries, resolveTaskProps } from "./task-page-content-helpers";
+import {
+  buildDebugEntries,
+  resolveTaskContentState,
+  resolveTaskProps,
+} from "./task-page-content-helpers";
 
 function baseParams(overrides: Partial<Parameters<typeof buildDebugEntries>[0]> = {}) {
   return {
@@ -59,5 +63,37 @@ describe("resolveTaskProps", () => {
 
     expect(props.issueUrl).toBe("https://github.com/kdlbs/kandev/issues/1470");
     expect(props.issueNumber).toBe(1470);
+  });
+});
+
+describe("resolveTaskContentState", () => {
+  it("keeps showing the loading state until the component mounts", () => {
+    expect(
+      resolveTaskContentState({
+        isMounted: false,
+        hasTask: false,
+        hasTaskLoadError: true,
+      }),
+    ).toBe("loading");
+  });
+
+  it("surfaces task load failures after mount", () => {
+    expect(
+      resolveTaskContentState({
+        isMounted: true,
+        hasTask: false,
+        hasTaskLoadError: true,
+      }),
+    ).toBe("error");
+  });
+
+  it("treats a resolved task as ready", () => {
+    expect(
+      resolveTaskContentState({
+        isMounted: true,
+        hasTask: true,
+        hasTaskLoadError: true,
+      }),
+    ).toBe("ready");
   });
 });

--- a/apps/web/components/task/task-page-content-helpers.test.ts
+++ b/apps/web/components/task/task-page-content-helpers.test.ts
@@ -139,4 +139,14 @@ describe("hasResolvedTaskDetails", () => {
       }),
     ).toBe(false);
   });
+
+  it("returns false when there is no effective task", () => {
+    expect(
+      hasResolvedTaskDetails({
+        effectiveTaskId: null,
+        taskDetailsId: "task-1",
+        initialTaskId: "task-1",
+      }),
+    ).toBe(false);
+  });
 });

--- a/apps/web/components/task/task-page-content-helpers.ts
+++ b/apps/web/components/task/task-page-content-helpers.ts
@@ -104,6 +104,17 @@ export function buildArchivedValue(task: Task | null, repository: Repository | n
   };
 }
 
+export function resolveTaskContentState(params: {
+  isMounted: boolean;
+  hasTask: boolean;
+  hasTaskLoadError: boolean;
+}) {
+  if (!params.isMounted) return "loading";
+  if (params.hasTask) return "ready";
+  if (params.hasTaskLoadError) return "error";
+  return "loading";
+}
+
 export function resolveTaskIds(task: Task | null) {
   return {
     taskId: task?.id ?? null,

--- a/apps/web/components/task/task-page-content-helpers.ts
+++ b/apps/web/components/task/task-page-content-helpers.ts
@@ -110,9 +110,21 @@ export function resolveTaskContentState(params: {
   hasTaskLoadError: boolean;
 }) {
   if (!params.isMounted) return "loading";
-  if (params.hasTask) return "ready";
   if (params.hasTaskLoadError) return "error";
+  if (params.hasTask) return "ready";
   return "loading";
+}
+
+export function hasResolvedTaskDetails(params: {
+  effectiveTaskId: string | null;
+  taskDetailsId?: string | null;
+  initialTaskId?: string | null;
+}) {
+  if (!params.effectiveTaskId) return false;
+  return (
+    params.taskDetailsId === params.effectiveTaskId ||
+    params.initialTaskId === params.effectiveTaskId
+  );
 }
 
 export function resolveTaskIds(task: Task | null) {

--- a/apps/web/components/task/task-page-content.tsx
+++ b/apps/web/components/task/task-page-content.tsx
@@ -27,6 +27,7 @@ import {
   buildArchivedValue,
 } from "@/components/task/task-page-content-helpers";
 import { TaskPageInner } from "@/components/task/task-page-inner";
+import { GridSpinner } from "@/components/grid-spinner";
 
 type TaskPageContentProps = {
   task: Task | null;
@@ -321,7 +322,19 @@ export function TaskPageContent({
     queueMicrotask(() => setIsMounted(true));
   }, []);
 
-  if (!isMounted || !task) return <div className="h-screen w-full bg-background" />;
+  if (!isMounted || !task) {
+    return (
+      <div
+        className="flex h-screen w-full items-center justify-center bg-background px-4"
+        data-testid="task-loading-state"
+      >
+        <div className="flex min-h-24 min-w-0 flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
+          <GridSpinner className="text-primary" />
+          <span>Loading task...</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <TaskPageInner

--- a/apps/web/components/task/task-page-content.tsx
+++ b/apps/web/components/task/task-page-content.tsx
@@ -26,6 +26,7 @@ import type { Layout } from "react-resizable-panels";
 import {
   deriveIsAgentWorking,
   buildArchivedValue,
+  hasResolvedTaskDetails,
   resolveTaskContentState,
 } from "@/components/task/task-page-content-helpers";
 import { TaskPageInner } from "@/components/task/task-page-inner";
@@ -253,6 +254,11 @@ function useTaskDetails(activeTaskId: string | null, initialTask: Task | null) {
     () => resolveEffectiveTask(taskDetails, initialTask, kanbanTask, effectiveTaskId),
     [taskDetails, initialTask, kanbanTask, effectiveTaskId],
   );
+  const hasTaskDetails = hasResolvedTaskDetails({
+    effectiveTaskId,
+    taskDetailsId: taskDetails?.id ?? null,
+    initialTaskId: initialTask?.id ?? null,
+  });
   useTasks(task?.workflow_id ?? null);
 
   useEffect(() => {
@@ -285,7 +291,7 @@ function useTaskDetails(activeTaskId: string | null, initialTask: Task | null) {
     setTaskDetails,
   ]);
 
-  return { task, kanbanTask, taskLoadError: task ? null : taskLoadError };
+  return { task, kanbanTask, taskLoadError: hasTaskDetails ? null : taskLoadError };
 }
 
 function useTaskPageData(

--- a/apps/web/components/task/task-page-content.tsx
+++ b/apps/web/components/task/task-page-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { IconAlertTriangle } from "@tabler/icons-react";
 import {
   taskId as toTaskId,
   workflowId as toWorkflowId,
@@ -25,6 +26,7 @@ import type { Layout } from "react-resizable-panels";
 import {
   deriveIsAgentWorking,
   buildArchivedValue,
+  resolveTaskContentState,
 } from "@/components/task/task-page-content-helpers";
 import { TaskPageInner } from "@/components/task/task-page-inner";
 import { GridSpinner } from "@/components/grid-spinner";
@@ -203,8 +205,42 @@ function syncActiveTaskSession(params: {
   else params.setActiveTask(taskId);
 }
 
+function TaskLoadingState() {
+  return (
+    <div
+      className="flex h-screen w-full items-center justify-center bg-background px-4"
+      data-testid="task-loading-state"
+    >
+      <div className="flex min-h-24 min-w-0 flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
+        <GridSpinner className="text-primary" />
+        <span>Loading task...</span>
+      </div>
+    </div>
+  );
+}
+
+function TaskLoadErrorState() {
+  return (
+    <div
+      className="flex h-screen w-full items-center justify-center bg-background px-4"
+      data-testid="task-load-error-state"
+    >
+      <div className="flex min-h-24 max-w-sm min-w-0 flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
+        <IconAlertTriangle className="h-5 w-5 text-destructive" aria-hidden="true" />
+        <div className="space-y-1">
+          <div className="font-medium text-foreground">Task unavailable</div>
+          <div>
+            We could not load this task. It may have been deleted or you may not have access.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function useTaskDetails(activeTaskId: string | null, initialTask: Task | null) {
   const [taskDetails, setTaskDetails] = useState<Task | null>(initialTask);
+  const [taskLoadError, setTaskLoadError] = useState<unknown | null>(null);
   const kanbanTask = useAppStore((state) =>
     activeTaskId
       ? (state.kanban.tasks.find(
@@ -220,10 +256,26 @@ function useTaskDetails(activeTaskId: string | null, initialTask: Task | null) {
   useTasks(task?.workflow_id ?? null);
 
   useEffect(() => {
-    if (!activeTaskId || taskDetails?.id === activeTaskId) return;
+    if (!activeTaskId || taskDetails?.id === activeTaskId) {
+      setTaskLoadError(null);
+      return;
+    }
+    let cancelled = false;
+    setTaskLoadError(null);
     fetchTask(activeTaskId, { cache: "no-store" })
-      .then((response) => setTaskDetails(response))
-      .catch((error) => console.error("[TaskPageContent] Failed to load task details:", error));
+      .then((response) => {
+        if (cancelled) return;
+        setTaskDetails(response);
+        setTaskLoadError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error("[TaskPageContent] Failed to load task details:", error);
+        setTaskLoadError(error);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [
     activeTaskId,
     taskDetails?.id,
@@ -233,7 +285,7 @@ function useTaskDetails(activeTaskId: string | null, initialTask: Task | null) {
     setTaskDetails,
   ]);
 
-  return { task, kanbanTask };
+  return { task, kanbanTask, taskLoadError: task ? null : taskLoadError };
 }
 
 function useTaskPageData(
@@ -255,7 +307,7 @@ function useTaskPageData(
     return session?.task_id === activeTaskId ? sid : null;
   });
 
-  const { task } = useTaskDetails(activeTaskId, initialTask);
+  const { task, taskLoadError } = useTaskDetails(activeTaskId, initialTask);
 
   const agent = useSessionAgent(task);
   const ensureSession = useEnsureTaskSession(task);
@@ -282,7 +334,7 @@ function useTaskPageData(
     [effectiveRepositories, task?.repositories],
   );
 
-  return { task, agent, effectiveSessionId, repository, ensureSession };
+  return { task, taskLoadError, agent, effectiveSessionId, repository, ensureSession };
 }
 
 export function TaskPageContent({
@@ -301,12 +353,8 @@ export function TaskPageContent({
   const { isMobile } = useResponsiveBreakpoint();
   const connectionStatus = useAppStore((state) => state.connection.status);
 
-  const { task, agent, effectiveSessionId, repository, ensureSession } = useTaskPageData(
-    initialTask,
-    initialTaskId,
-    sessionId,
-    initialRepositories,
-  );
+  const { task, taskLoadError, agent, effectiveSessionId, repository, ensureSession } =
+    useTaskPageData(initialTask, initialTaskId, sessionId, initialRepositories);
 
   const workflowSteps = useWorkflowStepsMapped();
   const sessionPanel = useSessionPanelState(effectiveSessionId);
@@ -322,19 +370,15 @@ export function TaskPageContent({
     queueMicrotask(() => setIsMounted(true));
   }, []);
 
-  if (!isMounted || !task) {
-    return (
-      <div
-        className="flex h-screen w-full items-center justify-center bg-background px-4"
-        data-testid="task-loading-state"
-      >
-        <div className="flex min-h-24 min-w-0 flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
-          <GridSpinner className="text-primary" />
-          <span>Loading task...</span>
-        </div>
-      </div>
-    );
-  }
+  const contentState = resolveTaskContentState({
+    isMounted,
+    hasTask: Boolean(task),
+    hasTaskLoadError: Boolean(taskLoadError),
+  });
+
+  if (contentState === "loading") return <TaskLoadingState />;
+  if (contentState === "error") return <TaskLoadErrorState />;
+  if (!task) return <TaskLoadErrorState />;
 
   return (
     <TaskPageInner

--- a/apps/web/e2e/tests/task/mobile-task-loading-state.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-task-loading-state.spec.ts
@@ -1,0 +1,48 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+
+type E2EStoreWindow = Window & {
+  __KANDEV_E2E_STORE__?: {
+    getState: () => {
+      tasks: { activeTaskId: string | null };
+      setActiveTask: (taskId: string) => void;
+    };
+  };
+};
+
+async function waitForActiveTask(testPage: Page, taskId: string) {
+  await testPage.waitForFunction((expectedTaskId) => {
+    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+    return store?.getState().tasks.activeTaskId === expectedTaskId;
+  }, taskId);
+}
+
+async function switchToUnresolvedTask(testPage: Page, taskId: string) {
+  await testPage.evaluate((unresolvedTaskId) => {
+    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+    if (!store) throw new Error("E2E store bridge missing");
+    store.getState().setActiveTask(unresolvedTaskId);
+  }, taskId);
+}
+
+test.describe("Mobile task loading state", () => {
+  test("shows a spinner instead of a blank task detail pane while task data loads", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const title = "Mobile Task Loading State Anchor";
+    const task = await apiClient.createTask(seedData.workspaceId, title, {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    await waitForActiveTask(testPage, task.id);
+    await switchToUnresolvedTask(testPage, "unresolved-task-detail-mobile");
+
+    await expect(testPage.getByTestId("task-loading-state")).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByText("Loading task...")).toBeVisible();
+  });
+});

--- a/apps/web/e2e/tests/task/mobile-task-loading-state.spec.ts
+++ b/apps/web/e2e/tests/task/mobile-task-loading-state.spec.ts
@@ -1,28 +1,19 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
+import { openBlockedTaskLoadingState } from "./task-loading-state-helpers";
 
-type E2EStoreWindow = Window & {
-  __KANDEV_E2E_STORE__?: {
-    getState: () => {
-      tasks: { activeTaskId: string | null };
-      setActiveTask: (taskId: string) => void;
-    };
-  };
-};
+async function expectLoadingStateFitsViewport(testPage: Page) {
+  const loadingState = testPage.getByTestId("task-loading-state");
+  const box = await loadingState.boundingBox();
+  const viewport = testPage.viewportSize();
 
-async function waitForActiveTask(testPage: Page, taskId: string) {
-  await testPage.waitForFunction((expectedTaskId) => {
-    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
-    return store?.getState().tasks.activeTaskId === expectedTaskId;
-  }, taskId);
-}
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  if (!box || !viewport) return;
 
-async function switchToUnresolvedTask(testPage: Page, taskId: string) {
-  await testPage.evaluate((unresolvedTaskId) => {
-    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
-    if (!store) throw new Error("E2E store bridge missing");
-    store.getState().setActiveTask(unresolvedTaskId);
-  }, taskId);
+  await expect(loadingState).toBeInViewport();
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.width).toBeLessThanOrEqual(viewport.width + 1);
 }
 
 test.describe("Mobile task loading state", () => {
@@ -31,18 +22,20 @@ test.describe("Mobile task loading state", () => {
     apiClient,
     seedData,
   }) => {
-    const title = "Mobile Task Loading State Anchor";
-    const task = await apiClient.createTask(seedData.workspaceId, title, {
-      workflow_id: seedData.workflowId,
-      workflow_step_id: seedData.startStepId,
-      repository_ids: [seedData.repositoryId],
+    const unblockTaskDetailRequest = await openBlockedTaskLoadingState({
+      testPage,
+      apiClient,
+      seedData,
+      title: "Mobile Task Loading State Anchor",
+      unresolvedTaskId: "unresolved-task-detail-mobile",
     });
 
-    await testPage.goto(`/t/${task.id}`);
-    await waitForActiveTask(testPage, task.id);
-    await switchToUnresolvedTask(testPage, "unresolved-task-detail-mobile");
-
-    await expect(testPage.getByTestId("task-loading-state")).toBeVisible({ timeout: 10_000 });
-    await expect(testPage.getByText("Loading task...")).toBeVisible();
+    try {
+      await expect(testPage.getByTestId("task-loading-state")).toBeVisible({ timeout: 10_000 });
+      await expect(testPage.getByText("Loading task...")).toBeVisible();
+      await expectLoadingStateFitsViewport(testPage);
+    } finally {
+      await unblockTaskDetailRequest();
+    }
   });
 });

--- a/apps/web/e2e/tests/task/task-loading-state-helpers.ts
+++ b/apps/web/e2e/tests/task/task-loading-state-helpers.ts
@@ -1,0 +1,93 @@
+import type { Page, Route } from "@playwright/test";
+import type { ApiClient } from "../../helpers/api-client";
+
+type SeedData = {
+  workspaceId: string;
+  workflowId: string;
+  startStepId: string;
+  repositoryId: string;
+};
+
+type E2EStoreWindow = Window & {
+  __KANDEV_E2E_STORE__?: {
+    getState: () => {
+      tasks: { activeTaskId: string | null };
+      setActiveTask: (taskId: string) => void;
+    };
+  };
+};
+
+type OpenBlockedTaskLoadingStateParams = {
+  testPage: Page;
+  apiClient: ApiClient;
+  seedData: SeedData;
+  title: string;
+  unresolvedTaskId: string;
+};
+
+async function waitForActiveTask(testPage: Page, taskId: string) {
+  await testPage.waitForFunction((expectedTaskId) => {
+    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+    return store?.getState().tasks.activeTaskId === expectedTaskId;
+  }, taskId);
+}
+
+async function switchToUnresolvedTask(testPage: Page, taskId: string) {
+  await testPage.evaluate((unresolvedTaskId) => {
+    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+    if (!store) throw new Error("E2E store bridge missing");
+    store.getState().setActiveTask(unresolvedTaskId);
+  }, taskId);
+}
+
+async function blockTaskDetailRequest(testPage: Page, taskId: string) {
+  const routePattern = `**/api/v1/tasks/${taskId}`;
+  let unblock: () => void = () => {};
+  const blocked = new Promise<void>((resolve) => {
+    unblock = resolve;
+  });
+  let requestStarted = false;
+  let markHandled: () => void = () => {};
+  const handled = new Promise<void>((resolve) => {
+    markHandled = resolve;
+  });
+
+  const handler = async (route: Route) => {
+    requestStarted = true;
+    await blocked;
+    try {
+      await route.abort("failed").catch(() => {});
+    } finally {
+      markHandled();
+    }
+  };
+
+  await testPage.route(routePattern, handler);
+
+  return async () => {
+    unblock();
+    if (requestStarted) await handled;
+    await testPage.unroute(routePattern, handler);
+  };
+}
+
+export async function openBlockedTaskLoadingState({
+  testPage,
+  apiClient,
+  seedData,
+  title,
+  unresolvedTaskId,
+}: OpenBlockedTaskLoadingStateParams) {
+  const unblockTaskDetailRequest = await blockTaskDetailRequest(testPage, unresolvedTaskId);
+  const task = await apiClient.createTask(seedData.workspaceId, title, {
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    repository_ids: [seedData.repositoryId],
+  });
+
+  await testPage.goto(`/t/${task.id}`);
+  await waitForActiveTask(testPage, task.id);
+  await switchToUnresolvedTask(testPage, unresolvedTaskId);
+
+  return unblockTaskDetailRequest;
+}

--- a/apps/web/e2e/tests/task/task-loading-state.spec.ts
+++ b/apps/web/e2e/tests/task/task-loading-state.spec.ts
@@ -1,29 +1,5 @@
-import type { Page } from "@playwright/test";
 import { test, expect } from "../../fixtures/test-base";
-
-type E2EStoreWindow = Window & {
-  __KANDEV_E2E_STORE__?: {
-    getState: () => {
-      tasks: { activeTaskId: string | null };
-      setActiveTask: (taskId: string) => void;
-    };
-  };
-};
-
-async function waitForActiveTask(testPage: Page, taskId: string) {
-  await testPage.waitForFunction((expectedTaskId) => {
-    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
-    return store?.getState().tasks.activeTaskId === expectedTaskId;
-  }, taskId);
-}
-
-async function switchToUnresolvedTask(testPage: Page, taskId: string) {
-  await testPage.evaluate((unresolvedTaskId) => {
-    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
-    if (!store) throw new Error("E2E store bridge missing");
-    store.getState().setActiveTask(unresolvedTaskId);
-  }, taskId);
-}
+import { openBlockedTaskLoadingState } from "./task-loading-state-helpers";
 
 test.describe("Task loading state", () => {
   test("shows a spinner instead of a blank task detail pane while task data loads", async ({
@@ -31,18 +7,19 @@ test.describe("Task loading state", () => {
     apiClient,
     seedData,
   }) => {
-    const title = "Task Loading State Anchor";
-    const task = await apiClient.createTask(seedData.workspaceId, title, {
-      workflow_id: seedData.workflowId,
-      workflow_step_id: seedData.startStepId,
-      repository_ids: [seedData.repositoryId],
+    const unblockTaskDetailRequest = await openBlockedTaskLoadingState({
+      testPage,
+      apiClient,
+      seedData,
+      title: "Task Loading State Anchor",
+      unresolvedTaskId: "unresolved-task-detail-desktop",
     });
 
-    await testPage.goto(`/t/${task.id}`);
-    await waitForActiveTask(testPage, task.id);
-    await switchToUnresolvedTask(testPage, "unresolved-task-detail-desktop");
-
-    await expect(testPage.getByTestId("task-loading-state")).toBeVisible({ timeout: 10_000 });
-    await expect(testPage.getByText("Loading task...")).toBeVisible();
+    try {
+      await expect(testPage.getByTestId("task-loading-state")).toBeVisible({ timeout: 10_000 });
+      await expect(testPage.getByText("Loading task...")).toBeVisible();
+    } finally {
+      await unblockTaskDetailRequest();
+    }
   });
 });

--- a/apps/web/e2e/tests/task/task-loading-state.spec.ts
+++ b/apps/web/e2e/tests/task/task-loading-state.spec.ts
@@ -1,0 +1,48 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../../fixtures/test-base";
+
+type E2EStoreWindow = Window & {
+  __KANDEV_E2E_STORE__?: {
+    getState: () => {
+      tasks: { activeTaskId: string | null };
+      setActiveTask: (taskId: string) => void;
+    };
+  };
+};
+
+async function waitForActiveTask(testPage: Page, taskId: string) {
+  await testPage.waitForFunction((expectedTaskId) => {
+    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+    return store?.getState().tasks.activeTaskId === expectedTaskId;
+  }, taskId);
+}
+
+async function switchToUnresolvedTask(testPage: Page, taskId: string) {
+  await testPage.evaluate((unresolvedTaskId) => {
+    const store = (window as E2EStoreWindow).__KANDEV_E2E_STORE__;
+    if (!store) throw new Error("E2E store bridge missing");
+    store.getState().setActiveTask(unresolvedTaskId);
+  }, taskId);
+}
+
+test.describe("Task loading state", () => {
+  test("shows a spinner instead of a blank task detail pane while task data loads", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const title = "Task Loading State Anchor";
+    const task = await apiClient.createTask(seedData.workspaceId, title, {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+      repository_ids: [seedData.repositoryId],
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    await waitForActiveTask(testPage, task.id);
+    await switchToUnresolvedTask(testPage, "unresolved-task-detail-desktop");
+
+    await expect(testPage.getByTestId("task-loading-state")).toBeVisible({ timeout: 10_000 });
+    await expect(testPage.getByText("Loading task...")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Task creation and task entry could briefly show an empty detail pane or partial conversation while client state caught up. The loading gaps now show explicit task and conversation spinners so slower machines get clear progress feedback instead of blank space.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `make -C apps/backend build`
- `make build-web`
- `cd apps/web && pnpm e2e --project=chromium tests/task/task-loading-state.spec.ts --project=mobile-chrome tests/task/mobile-task-loading-state.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->