### PR TITLE
fix: show sidebar spinner for created boot sessions

### DIFF
--- a/apps/web/components/task/task-classify.ts
+++ b/apps/web/components/task/task-classify.ts
@@ -25,10 +25,11 @@ export function classifyTask(
     if (TASK_STATE_IN_PROGRESS.has(taskState)) return "in_progress";
     return "backlog";
   }
-  // STARTING is a transient session state (e.g. during auto-resume after a
-  // backend restart). Defer to the workflow task state so a task in REVIEW
-  // does not flicker out of the review bucket while the agent reattaches.
-  if (sessionState === "STARTING" && taskState) {
+  // CREATED/STARTING are transient session states while the agent process is
+  // booting or reattaching. Defer to the workflow task state so an
+  // IN_PROGRESS task keeps showing activity, while a REVIEW task does not
+  // flicker out of the review bucket during auto-resume.
+  if ((sessionState === "CREATED" || sessionState === "STARTING") && taskState) {
     if (TASK_STATE_REVIEW.has(taskState)) return "review";
     if (TASK_STATE_IN_PROGRESS.has(taskState)) return "in_progress";
     return "backlog";

--- a/apps/web/components/task/task-item.test.tsx
+++ b/apps/web/components/task/task-item.test.tsx
@@ -94,6 +94,29 @@ describe("TaskItem status icon", () => {
     expectPreparingSpinner();
   });
 
+  it("does not show a spinner for a created task waiting for manual start", () => {
+    renderTaskItem({ state: "CREATED" });
+
+    expect(screen.queryByTestId(RUNNING_ICON_TEST_ID)).toBeNull();
+    expect(screen.queryByTestId("task-state-backlog")).not.toBeNull();
+  });
+
+  it("does not show a spinner for a created task with a prepared CREATED session", () => {
+    renderTaskItem({ state: "CREATED", sessionState: "CREATED" });
+
+    expect(screen.queryByTestId(RUNNING_ICON_TEST_ID)).toBeNull();
+    expect(screen.queryByTestId("task-state-backlog")).not.toBeNull();
+  });
+
+  it("shows a running spinner while an in-progress session is created but not started", () => {
+    renderTaskItem({ state: "IN_PROGRESS", sessionState: "CREATED" });
+
+    const icon = screen.getByTestId(RUNNING_ICON_TEST_ID);
+    expect(icon.getAttribute("data-loading-phase")).toBe("running");
+    expect(icon.classList.contains("text-yellow-500")).toBe(true);
+    expect(icon.classList.contains(SPIN_CLASS)).toBe(true);
+  });
+
   it("does not show preparing spinner for a review task whose session transiently hits STARTING", () => {
     renderTaskItem({ state: "REVIEW", sessionState: "STARTING" });
 

--- a/apps/web/components/task/task-switcher.test.ts
+++ b/apps/web/components/task/task-switcher.test.ts
@@ -21,6 +21,14 @@ describe("classifyTask", () => {
   it("buckets STARTING with REVIEW task state as review", () => {
     expect(classifyTask("STARTING", "REVIEW")).toBe("review");
   });
+
+  it("uses task state while a CREATED session is booting", () => {
+    expect(classifyTask("CREATED", "IN_PROGRESS")).toBe("in_progress");
+    expect(classifyTask("CREATED", "SCHEDULING")).toBe("in_progress");
+    expect(classifyTask("CREATED", "REVIEW")).toBe("review");
+    expect(classifyTask("CREATED", "CREATED")).toBe("backlog");
+    expect(classifyTask("CREATED", "TODO")).toBe("backlog");
+  });
 });
 
 describe("applySort state (regression: silent resume reorder)", () => {


### PR DESCRIPTION
Tasks created by MCP or the UI can sit in a manual-start `CREATED` state, while auto-started tasks can briefly have a `CREATED` session after the task has moved to `IN_PROGRESS`. The sidebar now distinguishes those cases so booting agents show activity without making manual-start tasks look active.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->