### PR TITLE
fix: prevent automatic session tab pinning

### DIFF
--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -47,8 +47,8 @@ import { PreviewFileTab, PreviewDiffTab, PreviewCommitTab, PinnedDefaultTab } fr
 import { SessionTab } from "./session-tab";
 import { TerminalTab } from "./terminal-tab";
 import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
+import { setupSessionTabSync } from "./dockview-session-tab-sync";
 import {
-  setupSessionTabSync,
   setupChatPanelSafetyNet,
   useAutoSessionTab,
   useAutoPRPanel,

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -583,8 +583,10 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
       useDockviewStore.setState({ currentLayoutEnvId: currentEnvId });
 
       readyDisposersRef.current.push(setupGroupTracking(api));
-      setupSessionTabSync(api, appStore);
-      setupChatPanelSafetyNet(api, appStore);
+      const sessionTabSyncDisposable = setupSessionTabSync(api, appStore);
+      readyDisposersRef.current.push(() => sessionTabSyncDisposable.dispose());
+      const chatPanelSafetyNetDisposable = setupChatPanelSafetyNet(api, appStore);
+      readyDisposersRef.current.push(() => chatPanelSafetyNetDisposable.dispose());
       readyDisposersRef.current.push(setupLayoutPersistence(api, saveTimerRef, envIdRef));
       setupPortalCleanup(api, appStore);
       readyDisposersRef.current.push(setupContainerResizeSync(api));

--- a/apps/web/components/task/dockview-session-tab-sync.test.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.test.ts
@@ -1,20 +1,61 @@
-import { describe, expect, it, vi } from "vitest";
-import { markSessionTabUserActivationIntent } from "./session-tab-activation-intent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DockviewReadyEvent } from "dockview-react";
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+import {
+  clearSessionTabUserActivationIntentsForTest,
+  markSessionTabUserActivationIntent,
+} from "./session-tab-activation-intent";
 import { setupSessionTabSync } from "./dockview-session-tab-sync";
+
+const TASK_ID = "task-A";
+const ACTIVE_SESSION_ID = "s-active";
+const OTHER_SESSION_ID = "s-other";
+const OTHER_SESSION_PANEL_ID = `session:${OTHER_SESSION_ID}`;
+
+type SessionTabSyncPanel = {
+  id: string;
+  api: { setActive: ReturnType<typeof vi.fn<[], void>> };
+};
+
+type SessionTabSyncApi = {
+  panels: SessionTabSyncPanel[];
+  getPanel: (id: string) => SessionTabSyncPanel | null;
+  onDidActivePanelChange: (callback: (panel: { id: string } | null) => void) => {
+    dispose: ReturnType<typeof vi.fn<[], void>>;
+  };
+};
+
+type SessionTabSyncStore = {
+  getState: () => {
+    tasks: { activeTaskId: string; activeSessionId: string };
+    taskSessions: {
+      items: Record<string, { id: string; task_id: string }>;
+    };
+    environmentIdBySessionId: Record<string, string>;
+    setActiveSession: ReturnType<typeof vi.fn<[string, string], void>>;
+  };
+};
+
+type SessionTabSyncHarness = ReturnType<typeof makeSessionTabSyncHarness>;
 
 function makeSessionTabSyncHarness(args: {
   activeTaskId: string;
   activeSessionId: string;
   otherSessionId: string;
+  includeOtherEnv?: boolean;
 }) {
   let activePanelChange: ((panel: { id: string } | null) => void) | null = null;
-  const activePanelSetActive = vi.fn();
+  const activePanelSetActive = vi.fn(() => {
+    activePanelChange?.({ id: `session:${args.activeSessionId}` });
+  });
   const otherPanelSetActive = vi.fn();
-  const panels = [
+  const panels: SessionTabSyncPanel[] = [
     { id: `session:${args.activeSessionId}`, api: { setActive: activePanelSetActive } },
     { id: `session:${args.otherSessionId}`, api: { setActive: otherPanelSetActive } },
   ];
-  const api = {
+  const api: SessionTabSyncApi = {
     panels,
     getPanel: (id: string) => panels.find((panel) => panel.id === id) ?? null,
     onDidActivePanelChange: (callback: (panel: { id: string } | null) => void) => {
@@ -23,7 +64,11 @@ function makeSessionTabSyncHarness(args: {
     },
   };
   const setActiveSession = vi.fn();
-  const appStore = {
+  const environmentIdBySessionId = {
+    [args.activeSessionId]: "env-A",
+    ...(args.includeOtherEnv === false ? {} : { [args.otherSessionId]: "env-A" }),
+  };
+  const appStore: SessionTabSyncStore = {
     getState: () => ({
       tasks: {
         activeTaskId: args.activeTaskId,
@@ -35,10 +80,7 @@ function makeSessionTabSyncHarness(args: {
           [args.otherSessionId]: { id: args.otherSessionId, task_id: args.activeTaskId },
         },
       },
-      environmentIdBySessionId: {
-        [args.activeSessionId]: "env-A",
-        [args.otherSessionId]: "env-A",
-      },
+      environmentIdBySessionId,
       setActiveSession,
     }),
   };
@@ -48,39 +90,107 @@ function makeSessionTabSyncHarness(args: {
     appStore,
     setActiveSession,
     activePanelSetActive,
-    fireActivePanelChange: (panelId: string) => {
-      activePanelChange?.({ id: panelId });
+    otherPanelSetActive,
+    fireActivePanelChange: (panelId: string | null) => {
+      activePanelChange?.(panelId ? { id: panelId } : null);
     },
   };
 }
 
-describe("setupSessionTabSync", () => {
-  it("does not pin a session when Dockview activates another session panel without user intent", () => {
-    const harness = makeSessionTabSyncHarness({
-      activeTaskId: "task-A",
-      activeSessionId: "s-active",
-      otherSessionId: "s-other",
-    });
+function makeDefaultSessionTabSyncHarness(args?: { includeOtherEnv?: boolean }) {
+  return makeSessionTabSyncHarness({
+    activeTaskId: TASK_ID,
+    activeSessionId: ACTIVE_SESSION_ID,
+    otherSessionId: OTHER_SESSION_ID,
+    includeOtherEnv: args?.includeOtherEnv,
+  });
+}
 
-    setupSessionTabSync(harness.api as never, harness.appStore as never);
-    harness.fireActivePanelChange("session:s-other");
+function startSessionTabSync(harness: SessionTabSyncHarness) {
+  setupSessionTabSync(
+    harness.api as unknown as DockviewReadyEvent["api"],
+    harness.appStore as unknown as StoreApi<AppState>,
+  );
+}
+
+describe("setupSessionTabSync", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    clearSessionTabUserActivationIntentsForTest();
+    useDockviewStore.setState({ isRestoringLayout: false });
+  });
+
+  afterEach(() => {
+    clearSessionTabUserActivationIntentsForTest();
+    useDockviewStore.setState({ isRestoringLayout: false });
+    vi.useRealTimers();
+  });
+
+  it("does not pin a session when Dockview activates another session panel without user intent", () => {
+    const harness = makeDefaultSessionTabSyncHarness();
+
+    startSessionTabSync(harness);
+    harness.fireActivePanelChange(OTHER_SESSION_PANEL_ID);
 
     expect(harness.setActiveSession).not.toHaveBeenCalled();
     expect(harness.activePanelSetActive).toHaveBeenCalledTimes(1);
   });
 
   it("pins the session when the active panel change follows explicit session-tab user intent", () => {
-    const harness = makeSessionTabSyncHarness({
-      activeTaskId: "task-A",
-      activeSessionId: "s-active",
-      otherSessionId: "s-other",
-    });
+    const harness = makeDefaultSessionTabSyncHarness();
 
-    setupSessionTabSync(harness.api as never, harness.appStore as never);
-    markSessionTabUserActivationIntent("s-other");
-    harness.fireActivePanelChange("session:s-other");
+    startSessionTabSync(harness);
+    markSessionTabUserActivationIntent(OTHER_SESSION_ID);
+    harness.fireActivePanelChange(OTHER_SESSION_PANEL_ID);
 
-    expect(harness.setActiveSession).toHaveBeenCalledWith("task-A", "s-other");
+    expect(harness.setActiveSession).toHaveBeenCalledWith(TASK_ID, OTHER_SESSION_ID);
+    expect(harness.activePanelSetActive).not.toHaveBeenCalled();
+  });
+
+  it("ignores active panel changes while Dockview is restoring layout", () => {
+    const harness = makeDefaultSessionTabSyncHarness();
+
+    useDockviewStore.setState({ isRestoringLayout: true });
+    startSessionTabSync(harness);
+    markSessionTabUserActivationIntent(OTHER_SESSION_ID);
+    harness.fireActivePanelChange(OTHER_SESSION_PANEL_ID);
+
+    expect(harness.setActiveSession).not.toHaveBeenCalled();
+    expect(harness.activePanelSetActive).not.toHaveBeenCalled();
+  });
+
+  it("restores the active panel when intent exists for a different session", () => {
+    const harness = makeDefaultSessionTabSyncHarness();
+
+    startSessionTabSync(harness);
+    markSessionTabUserActivationIntent(ACTIVE_SESSION_ID);
+    harness.fireActivePanelChange(OTHER_SESSION_PANEL_ID);
+
+    expect(harness.setActiveSession).not.toHaveBeenCalled();
+    expect(harness.activePanelSetActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores null and non-session panel changes", () => {
+    const harness = makeDefaultSessionTabSyncHarness();
+
+    startSessionTabSync(harness);
+    harness.fireActivePanelChange(null);
+    harness.fireActivePanelChange("files");
+
+    expect(harness.setActiveSession).not.toHaveBeenCalled();
+    expect(harness.activePanelSetActive).not.toHaveBeenCalled();
+    expect(harness.otherPanelSetActive).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale session panels without an environment mapping", () => {
+    const harness = makeDefaultSessionTabSyncHarness({ includeOtherEnv: false });
+
+    startSessionTabSync(harness);
+    markSessionTabUserActivationIntent(OTHER_SESSION_ID);
+    harness.fireActivePanelChange(OTHER_SESSION_PANEL_ID);
+
+    expect(harness.setActiveSession).not.toHaveBeenCalled();
     expect(harness.activePanelSetActive).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/task/dockview-session-tab-sync.test.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { markSessionTabUserActivationIntent } from "./session-tab-activation-intent";
+import { setupSessionTabSync } from "./dockview-session-tab-sync";
+
+function makeSessionTabSyncHarness(args: {
+  activeTaskId: string;
+  activeSessionId: string;
+  otherSessionId: string;
+}) {
+  let activePanelChange: ((panel: { id: string } | null) => void) | null = null;
+  const activePanelSetActive = vi.fn();
+  const otherPanelSetActive = vi.fn();
+  const panels = [
+    { id: `session:${args.activeSessionId}`, api: { setActive: activePanelSetActive } },
+    { id: `session:${args.otherSessionId}`, api: { setActive: otherPanelSetActive } },
+  ];
+  const api = {
+    panels,
+    getPanel: (id: string) => panels.find((panel) => panel.id === id) ?? null,
+    onDidActivePanelChange: (callback: (panel: { id: string } | null) => void) => {
+      activePanelChange = callback;
+      return { dispose: vi.fn() };
+    },
+  };
+  const setActiveSession = vi.fn();
+  const appStore = {
+    getState: () => ({
+      tasks: {
+        activeTaskId: args.activeTaskId,
+        activeSessionId: args.activeSessionId,
+      },
+      taskSessions: {
+        items: {
+          [args.activeSessionId]: { id: args.activeSessionId, task_id: args.activeTaskId },
+          [args.otherSessionId]: { id: args.otherSessionId, task_id: args.activeTaskId },
+        },
+      },
+      environmentIdBySessionId: {
+        [args.activeSessionId]: "env-A",
+        [args.otherSessionId]: "env-A",
+      },
+      setActiveSession,
+    }),
+  };
+
+  return {
+    api,
+    appStore,
+    setActiveSession,
+    activePanelSetActive,
+    fireActivePanelChange: (panelId: string) => {
+      activePanelChange?.({ id: panelId });
+    },
+  };
+}
+
+describe("setupSessionTabSync", () => {
+  it("does not pin a session when Dockview activates another session panel without user intent", () => {
+    const harness = makeSessionTabSyncHarness({
+      activeTaskId: "task-A",
+      activeSessionId: "s-active",
+      otherSessionId: "s-other",
+    });
+
+    setupSessionTabSync(harness.api as never, harness.appStore as never);
+    harness.fireActivePanelChange("session:s-other");
+
+    expect(harness.setActiveSession).not.toHaveBeenCalled();
+    expect(harness.activePanelSetActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins the session when the active panel change follows explicit session-tab user intent", () => {
+    const harness = makeSessionTabSyncHarness({
+      activeTaskId: "task-A",
+      activeSessionId: "s-active",
+      otherSessionId: "s-other",
+    });
+
+    setupSessionTabSync(harness.api as never, harness.appStore as never);
+    markSessionTabUserActivationIntent("s-other");
+    harness.fireActivePanelChange("session:s-other");
+
+    expect(harness.setActiveSession).toHaveBeenCalledWith("task-A", "s-other");
+    expect(harness.activePanelSetActive).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/task/dockview-session-tab-sync.test.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.test.ts
@@ -183,7 +183,7 @@ describe("setupSessionTabSync", () => {
     expect(harness.otherPanelSetActive).not.toHaveBeenCalled();
   });
 
-  it("ignores stale session panels without an environment mapping", () => {
+  it("restores active panel for stale session panels without an environment mapping", () => {
     const harness = makeDefaultSessionTabSyncHarness({ includeOtherEnv: false });
 
     startSessionTabSync(harness);
@@ -191,6 +191,6 @@ describe("setupSessionTabSync", () => {
     harness.fireActivePanelChange(OTHER_SESSION_PANEL_ID);
 
     expect(harness.setActiveSession).not.toHaveBeenCalled();
-    expect(harness.activePanelSetActive).not.toHaveBeenCalled();
+    expect(harness.activePanelSetActive).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/components/task/dockview-session-tab-sync.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.ts
@@ -16,6 +16,10 @@ function restoreActiveSessionPanel(
   api.getPanel(`session:${activeSessionId}`)?.api.setActive();
 }
 
+function isDifferentSessionPanel(panelId: string, activeSessionId: string | null): boolean {
+  return panelId.startsWith("session:") && panelId !== `session:${activeSessionId}`;
+}
+
 /**
  * Sync `activeSessionId` in the store when the user explicitly activates a
  * session tab. Dockview can also activate panels internally while restoring
@@ -45,12 +49,17 @@ export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: St
       environmentIdBySessionId: state.environmentIdBySessionId,
     });
     if (!target) {
+      const shouldRestoreActiveSession = isDifferentSessionPanel(
+        panel.id,
+        state.tasks.activeSessionId,
+      );
       if (isDebug() && panel.id.startsWith("session:")) {
         debug("setupSessionTabSync: skip (stale or cross-task panel)", {
           panelId: panel.id,
           activeTaskId: state.tasks.activeTaskId,
         });
       }
+      if (shouldRestoreActiveSession) restoreActiveSessionPanel(api, state.tasks.activeSessionId);
       return;
     }
     if (!consumeSessionTabUserActivationIntent(target.sessionId)) {

--- a/apps/web/components/task/dockview-session-tab-sync.ts
+++ b/apps/web/components/task/dockview-session-tab-sync.ts
@@ -1,0 +1,74 @@
+import type { DockviewReadyEvent } from "dockview-react";
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
+import { consumeSessionTabUserActivationIntent } from "./session-tab-activation-intent";
+import { resolveSessionTabSyncTarget } from "./dockview-session-tabs";
+
+const debug = createDebugLogger("dockview:session-tabs");
+
+function restoreActiveSessionPanel(
+  api: DockviewReadyEvent["api"],
+  activeSessionId: string | null,
+): void {
+  if (!activeSessionId) return;
+  api.getPanel(`session:${activeSessionId}`)?.api.setActive();
+}
+
+/**
+ * Sync `activeSessionId` in the store when the user explicitly activates a
+ * session tab. Dockview can also activate panels internally while restoring
+ * layout or reconciling tabs; those activations must not pin a different
+ * session or they create an app-level feedback loop.
+ */
+export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: StoreApi<AppState>) {
+  return api.onDidActivePanelChange((panel) => {
+    if (!panel) return;
+    const isRestoring = useDockviewStore.getState().isRestoringLayout;
+    if (isDebug()) {
+      debug("setupSessionTabSync: onDidActivePanelChange", {
+        panelId: panel.id,
+        isRestoring,
+        currentActiveSessionId: appStore.getState().tasks.activeSessionId,
+        currentActiveTaskId: appStore.getState().tasks.activeTaskId,
+        livePanelIds: api.panels.map((p) => p.id),
+      });
+    }
+    if (isRestoring) return;
+    const state = appStore.getState();
+    const target = resolveSessionTabSyncTarget({
+      panelId: panel.id,
+      activeTaskId: state.tasks.activeTaskId,
+      activeSessionId: state.tasks.activeSessionId,
+      taskSessionsById: state.taskSessions.items,
+      environmentIdBySessionId: state.environmentIdBySessionId,
+    });
+    if (!target) {
+      if (isDebug() && panel.id.startsWith("session:")) {
+        debug("setupSessionTabSync: skip (stale or cross-task panel)", {
+          panelId: panel.id,
+          activeTaskId: state.tasks.activeTaskId,
+        });
+      }
+      return;
+    }
+    if (!consumeSessionTabUserActivationIntent(target.sessionId)) {
+      if (isDebug()) {
+        debug("setupSessionTabSync: skip (no user activation intent)", {
+          panelId: panel.id,
+          activeSessionId: state.tasks.activeSessionId,
+        });
+      }
+      restoreActiveSessionPanel(api, state.tasks.activeSessionId);
+      return;
+    }
+    if (isDebug()) {
+      debug("setupSessionTabSync: setActiveSession", {
+        taskId: target.taskId,
+        newSessionId: target.sessionId,
+      });
+    }
+    state.setActiveSession(target.taskId, target.sessionId);
+  });
+}

--- a/apps/web/components/task/dockview-session-tabs.ts
+++ b/apps/web/components/task/dockview-session-tabs.ts
@@ -59,53 +59,6 @@ export function resolveSessionTabSyncTarget(args: {
 }
 
 /**
- * Sync `activeSessionId` in the store when the user clicks a session tab.
- * Layouts are env-keyed, so switching between sessions of the same task is
- * a no-op at the layout level — the env switch action short-circuits when
- * old==new env. No manual skip flag needed.
- */
-export function setupSessionTabSync(api: DockviewReadyEvent["api"], appStore: StoreApi<AppState>) {
-  return api.onDidActivePanelChange((panel) => {
-    if (!panel) return;
-    const isRestoring = useDockviewStore.getState().isRestoringLayout;
-    if (isDebug()) {
-      debug("setupSessionTabSync: onDidActivePanelChange", {
-        panelId: panel.id,
-        isRestoring,
-        currentActiveSessionId: appStore.getState().tasks.activeSessionId,
-        currentActiveTaskId: appStore.getState().tasks.activeTaskId,
-        livePanelIds: api.panels.map((p) => p.id),
-      });
-    }
-    if (isRestoring) return;
-    const state = appStore.getState();
-    const target = resolveSessionTabSyncTarget({
-      panelId: panel.id,
-      activeTaskId: state.tasks.activeTaskId,
-      activeSessionId: state.tasks.activeSessionId,
-      taskSessionsById: state.taskSessions.items,
-      environmentIdBySessionId: state.environmentIdBySessionId,
-    });
-    if (!target) {
-      if (isDebug() && panel.id.startsWith("session:")) {
-        debug("setupSessionTabSync: skip (stale or cross-task panel)", {
-          panelId: panel.id,
-          activeTaskId: state.tasks.activeTaskId,
-        });
-      }
-      return;
-    }
-    if (isDebug()) {
-      debug("setupSessionTabSync: setActiveSession", {
-        taskId: target.taskId,
-        newSessionId: target.sessionId,
-      });
-    }
-    state.setActiveSession(target.taskId, target.sessionId);
-  });
-}
-
-/**
  * Re-create a chat or session panel if the last one is removed.
  * Prevents the user from ending up with no chat panel at all.
  *

--- a/apps/web/components/task/session-reopen-menu.tsx
+++ b/apps/web/components/task/session-reopen-menu.tsx
@@ -13,6 +13,7 @@ import { useTaskSessions } from "@/hooks/use-task-sessions";
 import { addSessionPanel } from "@/lib/state/dockview-panel-actions";
 import { getSessionStateIcon } from "@/lib/ui/state-icons";
 import { AgentLogo } from "@/components/agent-logo";
+import { markSessionTabUserActivationIntent } from "@/components/task/session-tab-activation-intent";
 import type { TaskSession } from "@/lib/types/http";
 import type { AgentProfileOption } from "@/lib/state/slices";
 
@@ -73,6 +74,7 @@ export function SessionReopenMenuItems({
       if (!api) return;
       // Reopening a session within the same task = same env, so the env switch
       // action no-ops naturally. We just create the chat panel.
+      markSessionTabUserActivationIntent(sessionId);
       addSessionPanel(api, groupId ?? centerGroupId, sessionId, label);
     },
     [api, centerGroupId],

--- a/apps/web/components/task/session-tab-activation-intent.test.ts
+++ b/apps/web/components/task/session-tab-activation-intent.test.ts
@@ -3,6 +3,7 @@ import {
   clearSessionTabUserActivationIntentsForTest,
   consumeSessionTabUserActivationIntent,
   markSessionTabUserActivationIntent,
+  shouldMarkSessionTabUserActivationIntent,
 } from "./session-tab-activation-intent";
 
 describe("session tab activation intent", () => {
@@ -52,5 +53,39 @@ describe("session tab activation intent", () => {
 
     expect(consumeSessionTabUserActivationIntent("s-first")).toBe(true);
     expect(consumeSessionTabUserActivationIntent("s-second")).toBe(true);
+  });
+
+  it("does not mark intent for already-active tabs", () => {
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: "s-active",
+        isActive: true,
+        target: document.createElement("span"),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not mark intent from nested interactive controls", () => {
+    const button = document.createElement("button");
+    const label = document.createElement("span");
+    button.append(label);
+
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: "s-inactive",
+        isActive: false,
+        target: label,
+      }),
+    ).toBe(false);
+  });
+
+  it("marks intent for inactive tab activation surfaces", () => {
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: "s-inactive",
+        isActive: false,
+        target: document.createElement("span"),
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/components/task/session-tab-activation-intent.test.ts
+++ b/apps/web/components/task/session-tab-activation-intent.test.ts
@@ -6,6 +6,8 @@ import {
   shouldMarkSessionTabUserActivationIntent,
 } from "./session-tab-activation-intent";
 
+const INACTIVE_SESSION_ID = "s-inactive";
+
 describe("session tab activation intent", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -65,6 +67,16 @@ describe("session tab activation intent", () => {
     ).toBe(false);
   });
 
+  it("does not mark intent without a session id", () => {
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: null,
+        isActive: false,
+        target: document.createElement("span"),
+      }),
+    ).toBe(false);
+  });
+
   it("does not mark intent from nested interactive controls", () => {
     const button = document.createElement("button");
     const label = document.createElement("span");
@@ -72,17 +84,42 @@ describe("session tab activation intent", () => {
 
     expect(
       shouldMarkSessionTabUserActivationIntent({
-        sessionId: "s-inactive",
+        sessionId: INACTIVE_SESSION_ID,
         isActive: false,
         target: label,
       }),
     ).toBe(false);
   });
 
+  it("does not mark intent from role-based nested interactive controls", () => {
+    const button = document.createElement("span");
+    button.setAttribute("role", "button");
+    const label = document.createElement("span");
+    button.append(label);
+
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: INACTIVE_SESSION_ID,
+        isActive: false,
+        target: label,
+      }),
+    ).toBe(false);
+  });
+
+  it("marks intent for non-element targets on inactive tabs", () => {
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: INACTIVE_SESSION_ID,
+        isActive: false,
+        target: null,
+      }),
+    ).toBe(true);
+  });
+
   it("marks intent for inactive tab activation surfaces", () => {
     expect(
       shouldMarkSessionTabUserActivationIntent({
-        sessionId: "s-inactive",
+        sessionId: INACTIVE_SESSION_ID,
         isActive: false,
         target: document.createElement("span"),
       }),

--- a/apps/web/components/task/session-tab-activation-intent.test.ts
+++ b/apps/web/components/task/session-tab-activation-intent.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionTabUserActivationIntentsForTest,
+  consumeSessionTabUserActivationIntent,
+  markSessionTabUserActivationIntent,
+} from "./session-tab-activation-intent";
+
+describe("session tab activation intent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    clearSessionTabUserActivationIntentsForTest();
+  });
+
+  afterEach(() => {
+    clearSessionTabUserActivationIntentsForTest();
+    vi.useRealTimers();
+  });
+
+  it("ignores null and undefined session ids", () => {
+    markSessionTabUserActivationIntent(null);
+    markSessionTabUserActivationIntent(undefined);
+
+    expect(consumeSessionTabUserActivationIntent("s-active")).toBe(false);
+  });
+
+  it("expires marked intent after the TTL", () => {
+    markSessionTabUserActivationIntent("s-active");
+
+    vi.advanceTimersByTime(1501);
+
+    expect(consumeSessionTabUserActivationIntent("s-active")).toBe(false);
+  });
+
+  it("preserves one session intent when another session is consumed", () => {
+    markSessionTabUserActivationIntent("s-active");
+
+    expect(consumeSessionTabUserActivationIntent("s-other")).toBe(false);
+    expect(consumeSessionTabUserActivationIntent("s-active")).toBe(true);
+  });
+
+  it("consumes a matching intent once", () => {
+    markSessionTabUserActivationIntent("s-active");
+
+    expect(consumeSessionTabUserActivationIntent("s-active")).toBe(true);
+    expect(consumeSessionTabUserActivationIntent("s-active")).toBe(false);
+  });
+
+  it("keeps independent intents for fast successive tab activations", () => {
+    markSessionTabUserActivationIntent("s-first");
+    markSessionTabUserActivationIntent("s-second");
+
+    expect(consumeSessionTabUserActivationIntent("s-first")).toBe(true);
+    expect(consumeSessionTabUserActivationIntent("s-second")).toBe(true);
+  });
+});

--- a/apps/web/components/task/session-tab-activation-intent.test.ts
+++ b/apps/web/components/task/session-tab-activation-intent.test.ts
@@ -2,24 +2,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearSessionTabUserActivationIntentsForTest,
   consumeSessionTabUserActivationIntent,
+  markSessionPanelUserActivationIntent,
   markSessionTabUserActivationIntent,
   shouldMarkSessionTabUserActivationIntent,
 } from "./session-tab-activation-intent";
 
 const INACTIVE_SESSION_ID = "s-inactive";
 
-describe("session tab activation intent", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
-    clearSessionTabUserActivationIntentsForTest();
-  });
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  clearSessionTabUserActivationIntentsForTest();
+});
 
-  afterEach(() => {
-    clearSessionTabUserActivationIntentsForTest();
-    vi.useRealTimers();
-  });
+afterEach(() => {
+  clearSessionTabUserActivationIntentsForTest();
+  vi.useRealTimers();
+});
 
+describe("session tab activation intent lifecycle", () => {
   it("ignores null and undefined session ids", () => {
     markSessionTabUserActivationIntent(null);
     markSessionTabUserActivationIntent(undefined);
@@ -57,11 +58,33 @@ describe("session tab activation intent", () => {
     expect(consumeSessionTabUserActivationIntent("s-second")).toBe(true);
   });
 
+  it("marks session intent from a session panel id", () => {
+    markSessionPanelUserActivationIntent("session:s-active");
+    markSessionPanelUserActivationIntent("files");
+
+    expect(consumeSessionTabUserActivationIntent("s-active")).toBe(true);
+    expect(consumeSessionTabUserActivationIntent("files")).toBe(false);
+  });
+});
+
+describe("session tab activation intent guard", () => {
   it("does not mark intent for already-active tabs", () => {
     expect(
       shouldMarkSessionTabUserActivationIntent({
         sessionId: "s-active",
+        activeSessionId: "s-other",
         isActive: true,
+        target: document.createElement("span"),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not mark intent for the current active session when another panel is active", () => {
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: "s-active",
+        activeSessionId: "s-active",
+        isActive: false,
         target: document.createElement("span"),
       }),
     ).toBe(false);
@@ -71,6 +94,7 @@ describe("session tab activation intent", () => {
     expect(
       shouldMarkSessionTabUserActivationIntent({
         sessionId: null,
+        activeSessionId: "s-active",
         isActive: false,
         target: document.createElement("span"),
       }),
@@ -85,6 +109,7 @@ describe("session tab activation intent", () => {
     expect(
       shouldMarkSessionTabUserActivationIntent({
         sessionId: INACTIVE_SESSION_ID,
+        activeSessionId: "s-active",
         isActive: false,
         target: label,
       }),
@@ -100,6 +125,23 @@ describe("session tab activation intent", () => {
     expect(
       shouldMarkSessionTabUserActivationIntent({
         sessionId: INACTIVE_SESSION_ID,
+        activeSessionId: "s-active",
+        isActive: false,
+        target: label,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not mark intent from Dockview close actions", () => {
+    const closeAction = document.createElement("div");
+    closeAction.className = "dv-default-tab-action";
+    const label = document.createElement("span");
+    closeAction.append(label);
+
+    expect(
+      shouldMarkSessionTabUserActivationIntent({
+        sessionId: INACTIVE_SESSION_ID,
+        activeSessionId: "s-active",
         isActive: false,
         target: label,
       }),
@@ -110,6 +152,7 @@ describe("session tab activation intent", () => {
     expect(
       shouldMarkSessionTabUserActivationIntent({
         sessionId: INACTIVE_SESSION_ID,
+        activeSessionId: "s-active",
         isActive: false,
         target: null,
       }),
@@ -120,6 +163,7 @@ describe("session tab activation intent", () => {
     expect(
       shouldMarkSessionTabUserActivationIntent({
         sessionId: INACTIVE_SESSION_ID,
+        activeSessionId: "s-active",
         isActive: false,
         target: document.createElement("span"),
       }),

--- a/apps/web/components/task/session-tab-activation-intent.ts
+++ b/apps/web/components/task/session-tab-activation-intent.ts
@@ -1,29 +1,30 @@
 const SESSION_TAB_USER_ACTIVATION_TTL_MS = 1500;
 
 type SessionTabActivationIntent = {
-  sessionId: string;
   expiresAt: number;
 };
 
-let sessionTabActivationIntent: SessionTabActivationIntent | null = null;
+const sessionTabActivationIntents = new Map<string, SessionTabActivationIntent>();
 
 export function markSessionTabUserActivationIntent(sessionId: string | null | undefined): void {
   if (!sessionId) return;
-  sessionTabActivationIntent = {
-    sessionId,
+  sessionTabActivationIntents.set(sessionId, {
     expiresAt: Date.now() + SESSION_TAB_USER_ACTIVATION_TTL_MS,
-  };
+  });
 }
 
 export function consumeSessionTabUserActivationIntent(sessionId: string): boolean {
-  const intent = sessionTabActivationIntent;
+  const intent = sessionTabActivationIntents.get(sessionId);
   if (!intent) return false;
   const now = Date.now();
   if (intent.expiresAt < now) {
-    sessionTabActivationIntent = null;
+    sessionTabActivationIntents.delete(sessionId);
     return false;
   }
-  if (intent.sessionId !== sessionId) return false;
-  sessionTabActivationIntent = null;
+  sessionTabActivationIntents.delete(sessionId);
   return true;
+}
+
+export function clearSessionTabUserActivationIntentsForTest(): void {
+  sessionTabActivationIntents.clear();
 }

--- a/apps/web/components/task/session-tab-activation-intent.ts
+++ b/apps/web/components/task/session-tab-activation-intent.ts
@@ -1,0 +1,29 @@
+const SESSION_TAB_USER_ACTIVATION_TTL_MS = 1500;
+
+type SessionTabActivationIntent = {
+  sessionId: string;
+  expiresAt: number;
+};
+
+let sessionTabActivationIntent: SessionTabActivationIntent | null = null;
+
+export function markSessionTabUserActivationIntent(sessionId: string | null | undefined): void {
+  if (!sessionId) return;
+  sessionTabActivationIntent = {
+    sessionId,
+    expiresAt: Date.now() + SESSION_TAB_USER_ACTIVATION_TTL_MS,
+  };
+}
+
+export function consumeSessionTabUserActivationIntent(sessionId: string): boolean {
+  const intent = sessionTabActivationIntent;
+  if (!intent) return false;
+  const now = Date.now();
+  if (intent.expiresAt < now) {
+    sessionTabActivationIntent = null;
+    return false;
+  }
+  if (intent.sessionId !== sessionId) return false;
+  sessionTabActivationIntent = null;
+  return true;
+}

--- a/apps/web/components/task/session-tab-activation-intent.ts
+++ b/apps/web/components/task/session-tab-activation-intent.ts
@@ -1,6 +1,6 @@
 const SESSION_TAB_USER_ACTIVATION_TTL_MS = 1500;
 const NESTED_INTERACTIVE_SELECTOR =
-  "button, a, input, select, textarea, [role='button'], [role='menuitem']";
+  ".dv-default-tab-action, button, a, input, select, textarea, [role='button'], [role='menuitem']";
 
 type SessionTabActivationIntent = {
   expiresAt: number;
@@ -10,10 +10,11 @@ const sessionTabActivationIntents = new Map<string, SessionTabActivationIntent>(
 
 export function shouldMarkSessionTabUserActivationIntent(args: {
   sessionId: string | null | undefined;
+  activeSessionId: string | null | undefined;
   isActive: boolean;
   target: EventTarget | null;
 }): boolean {
-  if (!args.sessionId || args.isActive) return false;
+  if (!args.sessionId || args.isActive || args.sessionId === args.activeSessionId) return false;
   if (typeof Element === "undefined" || !(args.target instanceof Element)) return true;
   return !args.target.closest(NESTED_INTERACTIVE_SELECTOR);
 }
@@ -23,6 +24,11 @@ export function markSessionTabUserActivationIntent(sessionId: string | null | un
   sessionTabActivationIntents.set(sessionId, {
     expiresAt: Date.now() + SESSION_TAB_USER_ACTIVATION_TTL_MS,
   });
+}
+
+export function markSessionPanelUserActivationIntent(panelId: string | null | undefined): void {
+  if (!panelId?.startsWith("session:")) return;
+  markSessionTabUserActivationIntent(panelId.slice("session:".length));
 }
 
 export function consumeSessionTabUserActivationIntent(sessionId: string): boolean {

--- a/apps/web/components/task/session-tab-activation-intent.ts
+++ b/apps/web/components/task/session-tab-activation-intent.ts
@@ -1,10 +1,22 @@
 const SESSION_TAB_USER_ACTIVATION_TTL_MS = 1500;
+const NESTED_INTERACTIVE_SELECTOR =
+  "button, a, input, select, textarea, [role='button'], [role='menuitem']";
 
 type SessionTabActivationIntent = {
   expiresAt: number;
 };
 
 const sessionTabActivationIntents = new Map<string, SessionTabActivationIntent>();
+
+export function shouldMarkSessionTabUserActivationIntent(args: {
+  sessionId: string | null | undefined;
+  isActive: boolean;
+  target: EventTarget | null;
+}): boolean {
+  if (!args.sessionId || args.isActive) return false;
+  if (typeof Element === "undefined" || !(args.target instanceof Element)) return true;
+  return !args.target.closest(NESTED_INTERACTIVE_SELECTOR);
+}
 
 export function markSessionTabUserActivationIntent(sessionId: string | null | undefined): void {
   if (!sessionId) return;

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -42,7 +42,10 @@ import { HandoffContextMenuSub } from "@/components/task/handoff-profile-menu-it
 import { NewSessionDialog, type HandoffPreset } from "@/components/task/new-session-dialog";
 import { usableConfigOptions } from "@/components/model-config-selector";
 import type { TaskSessionState } from "@/lib/types/http";
-import { markSessionTabUserActivationIntent } from "./session-tab-activation-intent";
+import {
+  markSessionTabUserActivationIntent,
+  shouldMarkSessionTabUserActivationIntent,
+} from "./session-tab-activation-intent";
 import { isSessionActive } from "./session-sort";
 import { resolveSessionTabTitle } from "./session-tab-title";
 import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
@@ -147,23 +150,36 @@ function useSessionTabActions(
   return { handleSetPrimary, handleStop, handleResume, handleDelete, handleCloseOthers };
 }
 
-function useSessionTabUserActivationIntent(sessionId: string | undefined) {
-  const markUserActivationIntent = useCallback(() => {
-    markSessionTabUserActivationIntent(sessionId);
-  }, [sessionId]);
+function useSessionTabUserActivationIntent(sessionId: string | undefined, isActive: boolean) {
+  const markUserActivationIntent = useCallback(
+    (target: EventTarget | null) => {
+      if (!shouldMarkSessionTabUserActivationIntent({ sessionId, isActive, target })) return;
+      markSessionTabUserActivationIntent(sessionId);
+    },
+    [isActive, sessionId],
+  );
   const handlePointerDownCapture = useCallback(
     (event: ReactPointerEvent) => {
-      if (event.button === 0) markUserActivationIntent();
+      if (event.button === 0) markUserActivationIntent(event.target);
     },
     [markUserActivationIntent],
   );
   const handleKeyDownCapture = useCallback(
     (event: ReactKeyboardEvent) => {
-      if (event.key === "Enter" || event.key === " ") markUserActivationIntent();
+      if (event.key === "Enter" || event.key === " ") markUserActivationIntent(event.target);
     },
     [markUserActivationIntent],
   );
   return { handlePointerDownCapture, handleKeyDownCapture };
+}
+
+function useDockviewTabActiveState(api: IDockviewPanelHeaderProps["api"]) {
+  const [isActive, setIsActive] = useState(api.isActive);
+  useEffect(() => {
+    const disposable = api.onDidActiveChange((e) => setIsActive(e.isActive));
+    return () => disposable.dispose();
+  }, [api]);
+  return isActive;
 }
 
 function DeleteSessionDialog({
@@ -362,7 +378,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const [shareOpen, setShareOpen] = useState(false);
   const [handoffOpen, setHandoffOpen] = useState(false);
   const [handoffPreset, setHandoffPreset] = useState<HandoffPreset | null>(null);
-  const [isActive, setIsActive] = useState(api.isActive);
+  const isActive = useDockviewTabActiveState(api);
   const canShare = !!taskId && !!sessionId && shareableSessionStateClient(sessionState);
   const handleHandoffProfile = useCallback(
     (profileId: string) => {
@@ -372,11 +388,6 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
     },
     [sessionId],
   );
-
-  useEffect(() => {
-    const disposable = api.onDidActiveChange((e) => setIsActive(e.isActive));
-    return () => disposable.dispose();
-  }, [api]);
 
   useEffect(() => {
     if (tabTitle && api.title !== tabTitle) api.setTitle(tabTitle);
@@ -389,8 +400,10 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const handleCloseTab = useCallback(() => {
     setConfirmDelete(true);
   }, []);
-  const { handlePointerDownCapture, handleKeyDownCapture } =
-    useSessionTabUserActivationIntent(sessionId);
+  const { handlePointerDownCapture, handleKeyDownCapture } = useSessionTabUserActivationIntent(
+    sessionId,
+    isActive,
+  );
 
   return (
     <>

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -150,13 +150,20 @@ function useSessionTabActions(
   return { handleSetPrimary, handleStop, handleResume, handleDelete, handleCloseOthers };
 }
 
-function useSessionTabUserActivationIntent(sessionId: string | undefined, isActive: boolean) {
+function useSessionTabUserActivationIntent(
+  sessionId: string | undefined,
+  activeSessionId: string | null,
+  isActive: boolean,
+) {
   const markUserActivationIntent = useCallback(
     (target: EventTarget | null) => {
-      if (!shouldMarkSessionTabUserActivationIntent({ sessionId, isActive, target })) return;
+      if (
+        !shouldMarkSessionTabUserActivationIntent({ sessionId, activeSessionId, isActive, target })
+      )
+        return;
       markSessionTabUserActivationIntent(sessionId);
     },
-    [isActive, sessionId],
+    [activeSessionId, isActive, sessionId],
   );
   const handlePointerDownCapture = useCallback(
     (event: ReactPointerEvent) => {
@@ -379,6 +386,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const [handoffOpen, setHandoffOpen] = useState(false);
   const [handoffPreset, setHandoffPreset] = useState<HandoffPreset | null>(null);
   const isActive = useDockviewTabActiveState(api);
+  const activeSessionId = useAppStore((state) => state.tasks.activeSessionId);
   const canShare = !!taskId && !!sessionId && shareableSessionStateClient(sessionState);
   const handleHandoffProfile = useCallback(
     (profileId: string) => {
@@ -402,6 +410,7 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   }, []);
   const { handlePointerDownCapture, handleKeyDownCapture } = useSessionTabUserActivationIntent(
     sessionId,
+    activeSessionId,
     isActive,
   );
 

--- a/apps/web/components/task/session-tab.tsx
+++ b/apps/web/components/task/session-tab.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import { IconStar } from "@tabler/icons-react";
 import { AgentLogo } from "@/components/agent-logo";
@@ -35,6 +42,7 @@ import { HandoffContextMenuSub } from "@/components/task/handoff-profile-menu-it
 import { NewSessionDialog, type HandoffPreset } from "@/components/task/new-session-dialog";
 import { usableConfigOptions } from "@/components/model-config-selector";
 import type { TaskSessionState } from "@/lib/types/http";
+import { markSessionTabUserActivationIntent } from "./session-tab-activation-intent";
 import { isSessionActive } from "./session-sort";
 import { resolveSessionTabTitle } from "./session-tab-title";
 import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
@@ -137,6 +145,25 @@ function useSessionTabActions(
     for (const panel of toClose) containerApi.removePanel(panel);
   }, [api, containerApi]);
   return { handleSetPrimary, handleStop, handleResume, handleDelete, handleCloseOthers };
+}
+
+function useSessionTabUserActivationIntent(sessionId: string | undefined) {
+  const markUserActivationIntent = useCallback(() => {
+    markSessionTabUserActivationIntent(sessionId);
+  }, [sessionId]);
+  const handlePointerDownCapture = useCallback(
+    (event: ReactPointerEvent) => {
+      if (event.button === 0) markUserActivationIntent();
+    },
+    [markUserActivationIntent],
+  );
+  const handleKeyDownCapture = useCallback(
+    (event: ReactKeyboardEvent) => {
+      if (event.key === "Enter" || event.key === " ") markUserActivationIntent();
+    },
+    [markUserActivationIntent],
+  );
+  return { handlePointerDownCapture, handleKeyDownCapture };
 }
 
 function DeleteSessionDialog({
@@ -362,6 +389,8 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
   const handleCloseTab = useCallback(() => {
     setConfirmDelete(true);
   }, []);
+  const { handlePointerDownCapture, handleKeyDownCapture } =
+    useSessionTabUserActivationIntent(sessionId);
 
   return (
     <>
@@ -369,6 +398,8 @@ export function SessionTab(props: IDockviewPanelHeaderProps) {
         <ContextMenuTrigger
           className="flex h-full items-center cursor-pointer select-none"
           data-testid={sessionId ? `session-tab-${sessionId}` : undefined}
+          onPointerDownCapture={handlePointerDownCapture}
+          onKeyDownCapture={handleKeyDownCapture}
           onDoubleClick={onDoubleClick}
         >
           <SessionTabTriggerContent

--- a/apps/web/hooks/use-editor-keybinds.ts
+++ b/apps/web/hooks/use-editor-keybinds.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import { useAppStoreApi } from "@/components/state-provider";
+import { markSessionPanelUserActivationIntent } from "@/components/task/session-tab-activation-intent";
 import { createUserShell } from "@/lib/api/domains/user-shell-api";
 import { matchesShortcut } from "@/lib/keyboard/utils";
 import { getShortcut, type StoredShortcutOverrides } from "@/lib/keyboard/shortcut-overrides";
@@ -23,7 +24,9 @@ function handleTabNavigation(e: KeyboardEvent, api: DockviewApi) {
 
   const direction = e.code === "BracketLeft" ? -1 : 1;
   const nextIndex = (currentIndex + direction + panels.length) % panels.length;
-  panels[nextIndex].api.setActive();
+  const nextPanel = panels[nextIndex];
+  markSessionPanelUserActivationIntent(nextPanel.id);
+  nextPanel.api.setActive();
 }
 
 function handleTerminalToggle(


### PR DESCRIPTION
Dockview can activate session panels internally while reconciling layout, which made multi-session tasks bounce between tabs. Session pinning now only follows explicit tab activation, while internal panel changes restore the current active session instead.

## Important Changes

- Split session-tab sync into a focused module so the listener can gate store writes on user activation intent.
- Added regression coverage for unsolicited Dockview panel activation and real user tab activation.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Possible Improvements

Low risk: browser-level coverage remains targeted unit coverage because the failure was a Dockview listener feedback loop without a deterministic E2E repro.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->