### PR TITLE
fix: show repo slugs on kanban cards

### DIFF
--- a/apps/web/components/kanban-card-content.tsx
+++ b/apps/web/components/kanban-card-content.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/lib/ui/state-icons";
 import { cn } from "@/lib/utils";
 import { needsAction } from "@/lib/utils/needs-action";
-import type { Task } from "@/components/kanban-card";
+import type { RepositoryChip, Task } from "@/components/kanban-card";
 
 type KanbanCardActionProps = {
   task: Task;
@@ -51,7 +51,7 @@ type DraggableCardState = {
 
 export type KanbanCardShellProps = KanbanCardActionProps &
   DraggableCardState & {
-    repositoryNames?: string[];
+    repositoryChips?: RepositoryChip[];
     isSelected?: boolean;
     isMultiSelectMode?: boolean;
     isPreviewed: boolean;
@@ -61,56 +61,78 @@ export type KanbanCardShellProps = KanbanCardActionProps &
 
 const REPO_CHIPS_VISIBLE = 2;
 
-function RepoChipRow({ repoNames }: { repoNames: string[] }) {
-  if (repoNames.length === 0) return null;
-  const visible = repoNames.slice(0, REPO_CHIPS_VISIBLE);
-  const overflow = repoNames.slice(REPO_CHIPS_VISIBLE);
-  const row = (
-    <div className="mb-1 flex items-center gap-1 min-w-0 overflow-hidden">
-      {visible.map((name) => (
-        <span
-          key={name}
-          className="shrink-0 rounded-sm bg-muted/60 px-1 py-px text-[9px] font-medium text-muted-foreground leading-tight max-w-[8rem] truncate"
-        >
-          {name}
-        </span>
-      ))}
-      {overflow.length > 0 && (
-        <span className="shrink-0 rounded-sm bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground/80">
-          +{overflow.length}
-        </span>
-      )}
-    </div>
+function RepoChip({ chip }: { chip: RepositoryChip }) {
+  const badge = (
+    <span
+      title={chip.path}
+      className="shrink-0 rounded-sm bg-muted/60 px-1 py-px text-[9px] font-medium text-muted-foreground leading-tight max-w-[8rem] truncate"
+    >
+      {chip.label}
+    </span>
   );
-  if (repoNames.length <= 1) return row;
+  if (!chip.path) return badge;
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{row}</TooltipTrigger>
+      <TooltipTrigger asChild>{badge}</TooltipTrigger>
       <TooltipContent side="top" align="start">
-        <div className="flex flex-col gap-0.5 text-xs">
-          {repoNames.map((name) => (
-            <span key={name}>{name}</span>
-          ))}
-        </div>
+        <span className="max-w-[22rem] break-all text-xs">{chip.path}</span>
       </TooltipContent>
     </Tooltip>
   );
 }
 
+function OverflowRepoTooltip({ chips }: { chips: RepositoryChip[] }) {
+  return (
+    <div className="flex max-w-[24rem] flex-col gap-1 text-xs">
+      {chips.map((chip) => (
+        <div key={`${chip.label}:${chip.path ?? ""}`} className="min-w-0">
+          <div className="font-medium">{chip.label}</div>
+          {chip.path && <div className="break-all text-muted-foreground">{chip.path}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RepoChipRow({ chips }: { chips: RepositoryChip[] }) {
+  if (chips.length === 0) return null;
+  const visible = chips.slice(0, REPO_CHIPS_VISIBLE);
+  const overflow = chips.slice(REPO_CHIPS_VISIBLE);
+  return (
+    <div className="mb-1 flex items-center gap-1 min-w-0 overflow-hidden">
+      {visible.map((chip) => (
+        <RepoChip key={`${chip.label}:${chip.path ?? ""}`} chip={chip} />
+      ))}
+      {overflow.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="shrink-0 rounded-sm bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground/80">
+              +{overflow.length}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" align="start">
+            <OverflowRepoTooltip chips={overflow} />
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+
 export function KanbanCardBody({
   task,
-  repoNames,
+  repositoryChips,
   actions,
 }: {
   task: Task;
-  repoNames: string[];
+  repositoryChips: RepositoryChip[];
   actions?: React.ReactNode;
 }) {
   return (
     <>
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
-          <RepoChipRow repoNames={repoNames} />
+          <RepoChipRow chips={repositoryChips} />
           <div className="flex items-center gap-1 min-w-0">
             <p
               data-testid="task-card-title"
@@ -324,7 +346,7 @@ function KanbanCardActionSlot({
 
 export function KanbanCardShell({
   task,
-  repositoryNames,
+  repositoryChips,
   attributes,
   listeners,
   setNodeRef,
@@ -378,7 +400,7 @@ export function KanbanCardShell({
           <div className="min-w-0 flex-1">
             <KanbanCardBody
               task={task}
-              repoNames={repositoryNames ?? []}
+              repositoryChips={repositoryChips ?? []}
               actions={
                 <KanbanCardActionSlot
                   isMultiSelectMode={isMultiSelectMode}

--- a/apps/web/components/kanban-card-preview.tsx
+++ b/apps/web/components/kanban-card-preview.tsx
@@ -3,16 +3,20 @@
 import { useMemo } from "react";
 import { Card, CardContent } from "@kandev/ui/card";
 import { KanbanCardBody } from "@/components/kanban-card-content";
-import { resolveTaskRepositoryNames, type Task } from "@/components/kanban-card";
+import {
+  resolveTaskRepositoryChips,
+  type RepositoryChip,
+  type Task,
+} from "@/components/kanban-card";
 import { useAppStore } from "@/components/state-provider";
 import type { Repository } from "@/lib/types/http";
 
 function KanbanCardPreviewLayout({
   task,
-  repositoryNames,
+  repositoryChips,
 }: {
   task: Task;
-  repositoryNames: string[];
+  repositoryChips: RepositoryChip[];
 }) {
   return (
     <Card
@@ -20,7 +24,7 @@ function KanbanCardPreviewLayout({
       className="w-full py-0 cursor-grabbing shadow-lg ring-0 pointer-events-none border border-border"
     >
       <CardContent className="px-2 py-1">
-        <KanbanCardBody task={task} repoNames={repositoryNames} />
+        <KanbanCardBody task={task} repositoryChips={repositoryChips} />
       </CardContent>
     </Card>
   );
@@ -28,14 +32,14 @@ function KanbanCardPreviewLayout({
 
 export function KanbanCardPreview({ task }: { task: Task }) {
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
-  const repositoryNames = useMemo(
+  const repositoryChips = useMemo(
     () =>
-      resolveTaskRepositoryNames(
+      resolveTaskRepositoryChips(
         task,
         Object.values(repositoriesByWorkspace).flat() as Repository[],
       ),
     [repositoriesByWorkspace, task],
   );
 
-  return <KanbanCardPreviewLayout task={task} repositoryNames={repositoryNames} />;
+  return <KanbanCardPreviewLayout task={task} repositoryChips={repositoryChips} />;
 }

--- a/apps/web/components/kanban-card.test.ts
+++ b/apps/web/components/kanban-card.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { resolveTaskRepositoryChips, type Task } from "./kanban-card";
+import { repositoryId, workspaceId, type Repository } from "@/lib/types/http";
+
+function repo(overrides: Partial<Repository>): Repository {
+  return {
+    id: repositoryId("repo-1"),
+    workspace_id: workspaceId("workspace-1"),
+    name: "",
+    source_type: "github",
+    local_path: "/home/carlos/.kandev/repos/NBCUDTC/olisipo-jenkins-job-dsl",
+    provider: "github",
+    provider_repo_id: "123",
+    provider_owner: "NBCUDTC",
+    provider_name: "olisipo-jenkins-job-dsl",
+    default_branch: "main",
+    scripts: [],
+    worktree_branch_prefix: "",
+    pull_before_worktree: false,
+    setup_script: "",
+    cleanup_script: "",
+    dev_script: "",
+    copy_files: "",
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+function task(overrides: Partial<Task>): Task {
+  return {
+    id: "task-1",
+    title: "Review Pull Request",
+    workflowStepId: "step-1",
+    repositoryId: "repo-1",
+    repositories: [],
+    ...overrides,
+  };
+}
+
+describe("resolveTaskRepositoryChips", () => {
+  it("uses the provider owner/name slug instead of the local clone path", () => {
+    expect(resolveTaskRepositoryChips(task({}), [repo({})])).toEqual([
+      {
+        label: "NBCUDTC/olisipo-jenkins-job-dsl",
+        path: "~/.kandev/repos/NBCUDTC/olisipo-jenkins-job-dsl",
+      },
+    ]);
+  });
+
+  it("falls back to the configured repository name for local repos", () => {
+    expect(
+      resolveTaskRepositoryChips(task({}), [
+        repo({
+          name: "olisipo-jenkins-job-dsl",
+          source_type: "local",
+          provider: "",
+          provider_repo_id: "",
+          provider_owner: "",
+          provider_name: "",
+        }),
+      ]),
+    ).toEqual([
+      {
+        label: "olisipo-jenkins-job-dsl",
+        path: "~/.kandev/repos/NBCUDTC/olisipo-jenkins-job-dsl",
+      },
+    ]);
+  });
+
+  it("keeps multiple repositories in task order", () => {
+    expect(
+      resolveTaskRepositoryChips(
+        task({
+          repositoryId: "repo-1",
+          repositories: [
+            { id: "link-2", repository_id: "repo-2", position: 2 },
+            { id: "link-1", repository_id: "repo-1", position: 1 },
+          ],
+        }),
+        [
+          repo({}),
+          repo({
+            id: repositoryId("repo-2"),
+            local_path: "/home/carlos/src/api",
+            provider_owner: "NBCUDTC",
+            provider_name: "api",
+          }),
+        ],
+      ),
+    ).toEqual([
+      {
+        label: "NBCUDTC/olisipo-jenkins-job-dsl",
+        path: "~/.kandev/repos/NBCUDTC/olisipo-jenkins-job-dsl",
+      },
+      { label: "NBCUDTC/api", path: "~/src/api" },
+    ]);
+  });
+
+  it("renders no repo chips for repo-less local-folder tasks", () => {
+    expect(
+      resolveTaskRepositoryChips(
+        task({
+          repositoryId: undefined,
+          repositories: [],
+        }),
+        [repo({})],
+      ),
+    ).toEqual([]);
+  });
+
+  it("renders no repo chips when the task has no repository information", () => {
+    expect(resolveTaskRepositoryChips(task({ repositoryId: undefined }), [])).toEqual([]);
+  });
+});

--- a/apps/web/components/kanban-card.tsx
+++ b/apps/web/components/kanban-card.tsx
@@ -14,7 +14,8 @@ import { TaskDeleteConfirmDialog } from "@/components/task/task-delete-confirm-d
 import { TaskGitHubIssueDialog } from "@/components/task/task-github-issue-dialog";
 import { TaskGitHubPRDialog } from "@/components/task/task-github-pr-dialog";
 import { useTaskWorkflowMove } from "@/hooks/use-task-workflow-move";
-import { getRepositoryDisplayName } from "@/lib/utils";
+import { repositorySlug } from "@/lib/repository-slug";
+import { formatUserHomePath } from "@/lib/utils";
 import { repositoryId as toRepositoryId, type Repository, type TaskState } from "@/lib/types/http";
 
 export interface Task {
@@ -47,6 +48,11 @@ export interface Task {
   issueNumber?: number;
 }
 
+export type RepositoryChip = {
+  label: string;
+  path?: string;
+};
+
 export interface WorkflowStep {
   id: string;
   title: string;
@@ -61,8 +67,8 @@ export interface WorkflowStep {
 
 interface KanbanCardProps {
   task: Task;
-  /** Display names of every repository linked to the task, primary first. */
-  repositoryNames?: string[];
+  /** Display labels and hover paths of every repository linked to the task, primary first. */
+  repositoryChips?: RepositoryChip[];
   onClick?: (task: Task) => void;
   onEdit?: (task: Task) => void;
   onDelete?: (task: Task, opts?: { cascade?: boolean }) => void;
@@ -254,7 +260,7 @@ function useActiveWorkspaceRepositories() {
 
 export function KanbanCard({
   task,
-  repositoryNames,
+  repositoryChips,
   onClick,
   onEdit,
   onDelete,
@@ -318,7 +324,7 @@ export function KanbanCard({
       <KanbanCardContextMenu entries={contextMenuEntries}>
         <KanbanCardShell
           task={task}
-          repositoryNames={repositoryNames}
+          repositoryChips={repositoryChips}
           attributes={attributes}
           listeners={listeners}
           setNodeRef={setNodeRef}
@@ -357,26 +363,37 @@ export function KanbanCard({
 }
 
 /**
- * Resolves a task's linked repositories to display names. Primary first
+ * Resolves a task's linked repositories to card chip data. Primary first
  * (`task.repositoryId`), then any others ordered by `task.repositories[].position`.
  * Skips unresolved IDs (repo deleted / not yet hydrated).
  */
-export function resolveTaskRepositoryNames(task: Task, repositories: Repository[]): string[] {
+export function resolveTaskRepositoryChips(
+  task: Task,
+  repositories: Repository[],
+): RepositoryChip[] {
   const byId = new Map(repositories.map((repo) => [repo.id, repo]));
   const seen = new Set<string>();
-  const names: string[] = [];
+  const chips: RepositoryChip[] = [];
 
   const push = (id: string | undefined) => {
     if (!id || seen.has(id)) return;
     const repo = byId.get(toRepositoryId(id));
     if (!repo) return;
     seen.add(id);
-    const display = getRepositoryDisplayName(repo.local_path);
-    if (display) names.push(display);
+    const label = repositorySlug(repo);
+    if (!label) return;
+    chips.push({
+      label,
+      ...(repo.local_path ? { path: formatUserHomePath(repo.local_path) } : {}),
+    });
   };
 
   push(task.repositoryId);
   const ordered = [...(task.repositories ?? [])].sort((a, b) => a.position - b.position);
   for (const link of ordered) push(link.repository_id);
-  return names;
+  return chips;
+}
+
+export function resolveTaskRepositoryNames(task: Task, repositories: Repository[]): string[] {
+  return resolveTaskRepositoryChips(task, repositories).map((chip) => chip.label);
 }

--- a/apps/web/components/kanban-column.tsx
+++ b/apps/web/components/kanban-column.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { useDroppable } from "@dnd-kit/core";
-import { KanbanCard, resolveTaskRepositoryNames, Task } from "./kanban-card";
+import { KanbanCard, resolveTaskRepositoryChips, Task } from "./kanban-card";
 import { Badge } from "@kandev/ui/badge";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/components/state-provider";
@@ -95,7 +95,7 @@ export function KanbanColumn({
           <KanbanCard
             key={task.id}
             task={task}
-            repositoryNames={resolveTaskRepositoryNames(task, repositories)}
+            repositoryChips={resolveTaskRepositoryChips(task, repositories)}
             onClick={onPreviewTask}
             onOpenFullPage={onOpenTask}
             onEdit={onEditTask}


### PR DESCRIPTION
Kanban cards were showing local clone paths for repository chips, which made remote/provider-backed tasks hard to scan. Cards now use the canonical repo slug for linked repositories while preserving the local path in hover details.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->