### PR TITLE
fix: skip cleanup block when stop fails for terminal sessions

### DIFF
--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -1020,10 +1020,13 @@ func (s *Service) runAsyncTaskCleanup(
 	}()
 }
 
-// isTerminalSessionState reports whether a session is already in a terminal state.
-// Terminal sessions have no running agent process; stop failures are expected and
-// must not block cleanup.
-func isTerminalSessionState(state models.TaskSessionState) bool {
+// isCleanableSessionState reports whether a session has no running agent process
+// and stop failures are therefore expected. Unlike the orchestrator's
+// isTerminalSessionState (which excludes IDLE), this helper is used only during
+// task cleanup to decide whether a stop failure should block environment teardown.
+// IDLE is included because an idle session has already released its execution slot
+// and will return ErrExecutionNotFound just like CANCELLED/COMPLETED/FAILED.
+func isCleanableSessionState(state models.TaskSessionState) bool {
 	switch state {
 	case models.TaskSessionStateCancelled,
 		models.TaskSessionStateCompleted,
@@ -1056,7 +1059,7 @@ func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSes
 			target := taskStopTarget{
 				sessionID:   running.SessionID,
 				executionID: strings.TrimSpace(running.AgentExecutionID),
-				terminal:    isTerminalSessionState(sessionStates[running.SessionID]),
+				terminal:    isCleanableSessionState(sessionStates[running.SessionID]),
 			}
 			targets = append(targets, target)
 			seen[target.sessionID] = struct{}{}
@@ -1071,7 +1074,7 @@ func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSes
 		}
 		// Sessions without an executor_running row that are already in a terminal
 		// state have no running process; skip creating a stop target.
-		if isTerminalSessionState(sess.State) {
+		if isCleanableSessionState(sess.State) {
 			continue
 		}
 		target := taskStopTarget{

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -39,6 +39,10 @@ var ErrTaskAlreadyArchived = errors.New("task is already archived")
 type taskStopTarget struct {
 	sessionID   string
 	executionID string
+	// terminal indicates the session is already in a terminal state (CANCELLED,
+	// COMPLETED, FAILED, IDLE). Stop failures for terminal sessions are expected
+	// and must not block environment cleanup — the agent is already gone.
+	terminal bool
 }
 
 type taskEnvironmentCleanup struct {
@@ -1016,9 +1020,30 @@ func (s *Service) runAsyncTaskCleanup(
 	}()
 }
 
+// isTerminalSessionState reports whether a session is already in a terminal state.
+// Terminal sessions have no running agent process; stop failures are expected and
+// must not block cleanup.
+func isTerminalSessionState(state models.TaskSessionState) bool {
+	switch state {
+	case models.TaskSessionStateCancelled,
+		models.TaskSessionStateCompleted,
+		models.TaskSessionStateFailed,
+		models.TaskSessionStateIdle:
+		return true
+	}
+	return false
+}
+
 func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSessions []*models.TaskSession) ([]taskStopTarget, error) {
 	targets := make([]taskStopTarget, 0, len(activeSessions))
 	seen := make(map[string]struct{})
+	// Index session states so executor_running rows can be marked terminal.
+	sessionStates := make(map[string]models.TaskSessionState, len(activeSessions))
+	for _, sess := range activeSessions {
+		if sess != nil {
+			sessionStates[sess.ID] = sess.State
+		}
+	}
 	if s.executors != nil {
 		runningRows, err := s.executors.ListExecutorsRunningByTaskID(ctx, taskID)
 		if err != nil {
@@ -1031,6 +1056,7 @@ func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSes
 			target := taskStopTarget{
 				sessionID:   running.SessionID,
 				executionID: strings.TrimSpace(running.AgentExecutionID),
+				terminal:    isTerminalSessionState(sessionStates[running.SessionID]),
 			}
 			targets = append(targets, target)
 			seen[target.sessionID] = struct{}{}
@@ -1041,6 +1067,11 @@ func (s *Service) buildStopTargets(ctx context.Context, taskID string, activeSes
 			continue
 		}
 		if _, ok := seen[sess.ID]; ok {
+			continue
+		}
+		// Sessions without an executor_running row that are already in a terminal
+		// state have no running process; skip creating a stop target.
+		if isTerminalSessionState(sess.State) {
 			continue
 		}
 		target := taskStopTarget{
@@ -1069,6 +1100,13 @@ func (s *Service) stopTaskRuntimeTargets(ctx context.Context, taskID string, sto
 	for _, target := range stopTargets {
 		if target.executionID != "" {
 			if err := s.executionStopper.StopExecution(ctx, target.executionID, stopReason, true); err != nil {
+				if target.terminal {
+					s.logger.Debug("stop failed for terminal session execution (expected), proceeding with cleanup",
+						zap.String("task_id", taskID),
+						zap.String("session_id", target.sessionID),
+						zap.Error(err))
+					continue
+				}
 				failedStops[target.sessionID] = struct{}{}
 				s.logger.Warn(stopFailMsg,
 					zap.String("task_id", taskID),
@@ -1079,6 +1117,13 @@ func (s *Service) stopTaskRuntimeTargets(ctx context.Context, taskID string, sto
 			continue
 		}
 		if err := s.executionStopper.StopSession(ctx, target.sessionID, stopReason, true); err != nil {
+			if target.terminal {
+				s.logger.Debug("stop failed for terminal session (expected), proceeding with cleanup",
+					zap.String("task_id", taskID),
+					zap.String("session_id", target.sessionID),
+					zap.Error(err))
+				continue
+			}
 			failedStops[target.sessionID] = struct{}{}
 			s.logger.Warn(stopFailMsg,
 				zap.String("task_id", taskID),

--- a/apps/backend/internal/task/service/service_tasks_stop_test.go
+++ b/apps/backend/internal/task/service/service_tasks_stop_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/kandev/kandev/internal/agentruntime"
 	"github.com/kandev/kandev/internal/task/models"
 	"github.com/kandev/kandev/internal/task/repository"
 )
@@ -182,5 +183,86 @@ func TestStopTaskRuntimeTargets_NonTerminalStopFailureBlocksCleanup(t *testing.T
 	failed := svc.stopTaskRuntimeTargets(context.Background(), "task-b", targets, "archive", "stop failed")
 	if _, ok := failed["sess-running"]; !ok {
 		t.Error("non-terminal stop failure must add session to failedStops")
+	}
+}
+
+// --- CleanupTaskResources cascade regression tests ---
+//
+// These tests reproduce the archive cleanup regression: ArchiveTaskTree calls
+// cancelActiveRuns (sessions → CANCELLED) before CleanupTaskResources, leaving
+// executor_running rows whose StopExecution returns ErrExecutionNotFound. The
+// stop failure must not block environment teardown for terminal sessions.
+
+func seedCascadeFixtures(t *testing.T, repo interface {
+	CreateWorkspace(context.Context, *models.Workspace) error
+	CreateWorkflow(context.Context, *models.Workflow) error
+	CreateTask(context.Context, *models.Task) error
+	CreateTaskSession(context.Context, *models.TaskSession) error
+	UpsertExecutorRunning(context.Context, *models.ExecutorRunning) error
+}, wsID, wfID, taskID, sessID, execID string, state models.TaskSessionState) {
+	t.Helper()
+	ctx := context.Background()
+	_ = repo.CreateWorkspace(ctx, &models.Workspace{ID: wsID, Name: "WS"})
+	_ = repo.CreateWorkflow(ctx, &models.Workflow{ID: wfID, WorkspaceID: wsID, Name: "WF"})
+	_ = repo.CreateTask(ctx, &models.Task{ID: taskID, WorkspaceID: wsID, WorkflowID: wfID, WorkflowStepID: "step-1", Title: "T", Priority: "medium"})
+	_ = repo.CreateTaskSession(ctx, &models.TaskSession{
+		ID:               sessID,
+		TaskID:           taskID,
+		State:            state,
+		AgentExecutionID: execID,
+	})
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               sessID,
+		SessionID:        sessID,
+		TaskID:           taskID,
+		ExecutorID:       "executor-1",
+		AgentExecutionID: execID,
+		Runtime:          agentruntime.RuntimeStandalone,
+		Status:           models.ExecutorRunningStatusStarting,
+	}); err != nil {
+		t.Fatalf("seed executor_running: %v", err)
+	}
+}
+
+// TestCleanupTaskResources_TerminalSessionStopFailureDoesNotBlockCleanup is a
+// regression test for the archive cleanup bug: a CANCELLED session with a stale
+// executor_running row must have its row removed even when StopExecution fails.
+func TestCleanupTaskResources_TerminalSessionStopFailureDoesNotBlockCleanup(t *testing.T) {
+	svc, _, repo := createTestService(t)
+
+	stopper := newRecordingTaskExecutionStopper()
+	stopper.stopExecutionErr = errors.New("execution not found")
+	svc.SetExecutionStopper(stopper)
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
+
+	seedCascadeFixtures(t, repo, "ws-c1", "wf-c1", "task-c1", "sess-cancelled", "exec-cancelled", models.TaskSessionStateCancelled)
+
+	svc.CleanupTaskResources(context.Background(), "task-c1", false)
+	waitForCleanupDone(t, svc)
+
+	_, err := repo.GetExecutorRunningBySessionID(context.Background(), "sess-cancelled")
+	if err == nil {
+		t.Error("executor_running row must be removed after cleanup of terminal (CANCELLED) session — stop failure must not block teardown")
+	}
+}
+
+// TestCleanupTaskResources_NonTerminalSessionStopFailureBlocksCleanup is the
+// companion case: a RUNNING session whose StopExecution fails must keep its
+// executor_running row so the runtime is not torn down unexpectedly.
+func TestCleanupTaskResources_NonTerminalSessionStopFailureBlocksCleanup(t *testing.T) {
+	svc, _, repo := createTestService(t)
+
+	stopper := newRecordingTaskExecutionStopper()
+	stopper.stopExecutionErr = errors.New("stop failed")
+	svc.SetExecutionStopper(stopper)
+	svc.setCleanupDoneForTestHook(make(chan struct{}, 1))
+
+	seedCascadeFixtures(t, repo, "ws-c2", "wf-c2", "task-c2", "sess-running", "exec-running", models.TaskSessionStateRunning)
+
+	svc.CleanupTaskResources(context.Background(), "task-c2", false)
+	waitForCleanupDone(t, svc)
+
+	if _, err := repo.GetExecutorRunningBySessionID(context.Background(), "sess-running"); err != nil {
+		t.Error("executor_running row must be preserved when stop fails for a non-terminal (RUNNING) session")
 	}
 }

--- a/apps/backend/internal/task/service/service_tasks_stop_test.go
+++ b/apps/backend/internal/task/service/service_tasks_stop_test.go
@@ -1,0 +1,186 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kandev/kandev/internal/task/models"
+	"github.com/kandev/kandev/internal/task/repository"
+)
+
+// --- isCleanableSessionState ---
+
+func TestIsCleanableSessionState(t *testing.T) {
+	cleanable := []models.TaskSessionState{
+		models.TaskSessionStateCancelled,
+		models.TaskSessionStateCompleted,
+		models.TaskSessionStateFailed,
+		models.TaskSessionStateIdle,
+	}
+	for _, s := range cleanable {
+		if !isCleanableSessionState(s) {
+			t.Errorf("expected %q to be cleanable", s)
+		}
+	}
+
+	nonCleanable := []models.TaskSessionState{
+		models.TaskSessionStateRunning,
+		models.TaskSessionStateCreated,
+		models.TaskSessionStateStarting,
+	}
+	for _, s := range nonCleanable {
+		if isCleanableSessionState(s) {
+			t.Errorf("expected %q to NOT be cleanable", s)
+		}
+	}
+}
+
+// TestIsCleanableSessionState_IdleIncluded guards against a future change that
+// accidentally excludes IDLE (the orchestrator's same-named function does NOT
+// include IDLE, but in the cleanup path IDLE sessions have no live execution).
+func TestIsCleanableSessionState_IdleIncluded(t *testing.T) {
+	if !isCleanableSessionState(models.TaskSessionStateIdle) {
+		t.Error("IDLE must be cleanable: an idle session has no live execution and StopSession will return ErrExecutionNotFound")
+	}
+}
+
+// --- buildStopTargets ---
+
+// stubExecutors is a minimal repository.ExecutorRepository implementation for tests.
+type stubExecutors struct {
+	repository.ExecutorRepository
+	runningByTaskID   []*models.ExecutorRunning
+	runningByTaskErr  error
+	runningBySession  *models.ExecutorRunning
+	runningBySessErr  error
+}
+
+func (s *stubExecutors) ListExecutorsRunningByTaskID(_ context.Context, _ string) ([]*models.ExecutorRunning, error) {
+	return s.runningByTaskID, s.runningByTaskErr
+}
+
+func (s *stubExecutors) GetExecutorRunningBySessionID(_ context.Context, _ string) (*models.ExecutorRunning, error) {
+	return s.runningBySession, s.runningBySessErr
+}
+
+func (s *stubExecutors) DeleteExecutorRunningBySessionID(_ context.Context, _ string) error {
+	return nil
+}
+
+func (s *stubExecutors) HasExecutorRunningRow(_ context.Context, _ string) (bool, error) {
+	return s.runningBySession != nil, nil
+}
+
+func TestBuildStopTargets_TerminalExecutorRow(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	svc.executors = &stubExecutors{
+		runningByTaskID: []*models.ExecutorRunning{
+			{SessionID: "sess-1", AgentExecutionID: "exec-1"},
+		},
+	}
+
+	// Session is CANCELLED — stop target must be marked terminal.
+	sessions := []*models.TaskSession{
+		{ID: "sess-1", State: models.TaskSessionStateCancelled, AgentExecutionID: "exec-1"},
+	}
+
+	targets, err := svc.buildStopTargets(context.Background(), "task-1", sessions)
+	if err != nil {
+		t.Fatalf("buildStopTargets error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if !targets[0].terminal {
+		t.Error("expected target to be marked terminal for a CANCELLED session")
+	}
+}
+
+func TestBuildStopTargets_NonTerminalExecutorRow(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	svc.executors = &stubExecutors{
+		runningByTaskID: []*models.ExecutorRunning{
+			{SessionID: "sess-2", AgentExecutionID: "exec-2"},
+		},
+	}
+
+	// Session is RUNNING — stop target must NOT be terminal.
+	sessions := []*models.TaskSession{
+		{ID: "sess-2", State: models.TaskSessionStateRunning, AgentExecutionID: "exec-2"},
+	}
+
+	targets, err := svc.buildStopTargets(context.Background(), "task-2", sessions)
+	if err != nil {
+		t.Fatalf("buildStopTargets error: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if targets[0].terminal {
+		t.Error("expected target to NOT be terminal for a RUNNING session")
+	}
+}
+
+func TestBuildStopTargets_TerminalSessionWithoutExecutorRow(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	svc.executors = &stubExecutors{
+		runningByTaskID: nil, // no executor_running rows
+	}
+
+	// Session is COMPLETED with no executor_running row → no stop target created.
+	sessions := []*models.TaskSession{
+		{ID: "sess-3", State: models.TaskSessionStateCompleted, AgentExecutionID: "exec-3"},
+	}
+
+	targets, err := svc.buildStopTargets(context.Background(), "task-3", sessions)
+	if err != nil {
+		t.Fatalf("buildStopTargets error: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Errorf("expected 0 targets for terminal session without executor row, got %d", len(targets))
+	}
+}
+
+// --- stopTaskRuntimeTargets ---
+
+// stubStopper is a minimal TaskExecutionStopper for tests.
+type stubStopper struct {
+	stopSessionErr error
+}
+
+func (s *stubStopper) StopTask(_ context.Context, _, _ string, _ bool) error   { return nil }
+func (s *stubStopper) StopExecution(_ context.Context, _, _ string, _ bool) error { return nil }
+func (s *stubStopper) StopSession(_ context.Context, _, _ string, _ bool) error {
+	return s.stopSessionErr
+}
+
+func TestStopTaskRuntimeTargets_TerminalStopFailureDoesNotBlockCleanup(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	svc.executors = &stubExecutors{}
+	svc.executionStopper = &stubStopper{stopSessionErr: errors.New("ErrExecutionNotFound")}
+
+	targets := []taskStopTarget{
+		{sessionID: "sess-cancelled", terminal: true},
+	}
+
+	failed := svc.stopTaskRuntimeTargets(context.Background(), "task-a", targets, "archive", "stop failed")
+	if len(failed) != 0 {
+		t.Errorf("terminal stop failure must not add to failedStops; got %v", failed)
+	}
+}
+
+func TestStopTaskRuntimeTargets_NonTerminalStopFailureBlocksCleanup(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	svc.executors = &stubExecutors{}
+	svc.executionStopper = &stubStopper{stopSessionErr: errors.New("unexpected error")}
+
+	targets := []taskStopTarget{
+		{sessionID: "sess-running", terminal: false},
+	}
+
+	failed := svc.stopTaskRuntimeTargets(context.Background(), "task-b", targets, "archive", "stop failed")
+	if _, ok := failed["sess-running"]; !ok {
+		t.Error("non-terminal stop failure must add session to failedStops")
+	}
+}


### PR DESCRIPTION
Archiving a task with a previously-active agent left the worktree and cleanup script behind. `ArchiveTaskTree` calls `cancelActiveRuns` first (sessions become CANCELLED in the DB), then `CleanupTaskResources` tries to stop them — but `StopSession` returns `ErrExecutionNotFound` because the agent is already gone. The stop failure was recorded in `failedStops`, which caused `cleanupDestructiveTaskResources` to skip environment teardown entirely.

## Important Changes

- `taskStopTarget` gains a `terminal bool` field — set when a session is already in a state where the agent has no live execution (CANCELLED, COMPLETED, FAILED, IDLE).
- New `isCleanableSessionState` helper (distinct from `orchestrator.isTerminalSessionState`, which excludes IDLE) identifies sessions whose stop failures are expected and must not block cleanup.
- `buildStopTargets` marks executor-running rows whose session is already cleanable as `terminal`; sessions without an executor-running row that are already cleanable are skipped entirely.
- `stopTaskRuntimeTargets` logs and skips — rather than recording in `failedStops` — stop errors for terminal targets, so cleanup always proceeds when the agent is known to be gone.

## Validation

Reproduced with two stuck tasks: worktrees remained after archive, `executors_running` rows persisted, DDEV environments were not destroyed. Traced root cause through `cancelActiveRuns` → `StopSession` → `ErrExecutionNotFound` → `failedStops` → skipped teardown.

Manual cleanup of the two stuck tasks confirmed the fix addresses the right code path. Unit tests cover `isCleanableSessionState`, `buildStopTargets` (terminal and non-terminal rows, and terminal sessions with no executor row), and `stopTaskRuntimeTargets` (terminal failure skipped vs. non-terminal failure added to `failedStops`).

## Diagram

```mermaid
sequenceDiagram
    participant A as ArchiveTaskTree
    participant C as cancelActiveRuns
    participant B as buildStopTargets
    participant S as stopTaskRuntimeTargets
    participant P as performTaskCleanup

    A->>C: mark sessions CANCELLED
    A->>B: buildStopTargets(activeSessions)
    note over B: executor_running rows for CANCELLED sessions → terminal=true
    B-->>A: []taskStopTarget
    A->>S: stopTaskRuntimeTargets(targets)
    note over S: stop fails (ErrExecutionNotFound) + terminal=true → Debug log, skip failedStops
    S-->>A: failedStops = empty
    A->>P: performTaskCleanup(failedStops=empty)
    note over P: cleanupDestructiveTaskResources runs → worktree + cleanup script removed
```

## Possible Improvements

Low risk. The only scenario where this loosens the guard is a genuine live session that somehow ends up in a terminal DB state while its agent is still running — that would require a separate bug upstream. IDLE is included intentionally (an idle session has released its execution slot and returns `ErrExecutionNotFound` on stop); the comment in `isCleanableSessionState` explains the divergence from the orchestrator helper of the same pattern.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.