### PR TITLE
fix: focus changes panel for inactive task updates

### DIFF
--- a/apps/web/components/task/changes-panel-focus.test.ts
+++ b/apps/web/components/task/changes-panel-focus.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  markInactiveChangesCountIncreases,
+  selectChangesCountByEnvironment,
+} from "./changes-panel-focus";
+import type { GitStatusEntry, SessionCommit } from "@/lib/state/slices/session-runtime/types";
+
+function gitStatus(files: string[]): GitStatusEntry {
+  return {
+    branch: "main",
+    remote_branch: null,
+    modified: [],
+    added: [],
+    deleted: [],
+    untracked: files,
+    renamed: [],
+    ahead: 0,
+    behind: 0,
+    files: Object.fromEntries(
+      files.map((path) => [path, { path, status: "untracked", staged: false }]),
+    ),
+    timestamp: "2026-06-29T00:00:00Z",
+  };
+}
+
+function commit(sha: string): SessionCommit {
+  return {
+    id: `commit-${sha}`,
+    session_id: "sess-1",
+    commit_sha: sha,
+    parent_sha: `parent-${sha}`,
+    author_name: "Test User",
+    author_email: "test@example.com",
+    commit_message: `Commit ${sha}`,
+    committed_at: "2026-06-29T00:00:00Z",
+    files_changed: 1,
+    insertions: 1,
+    deletions: 0,
+    created_at: "2026-06-29T00:00:00Z",
+  };
+}
+
+describe("selectChangesCountByEnvironment", () => {
+  it("counts git files and commits per environment", () => {
+    const state = {
+      gitStatus: {
+        byEnvironmentId: {},
+        byEnvironmentRepo: {
+          envA: {
+            repo1: gitStatus(["one.ts", "two.ts"]),
+          },
+          envB: {
+            repo1: gitStatus([]),
+            repo2: gitStatus(["three.ts"]),
+          },
+        },
+      },
+      sessionCommits: {
+        loading: {},
+        refetchTrigger: {},
+        byEnvironmentId: {
+          envA: [commit("commit-1"), commit("commit-2")],
+          envC: [commit("commit-3")],
+        },
+      },
+    };
+
+    expect(selectChangesCountByEnvironment(state)).toEqual({
+      envA: 4,
+      envB: 1,
+      envC: 1,
+    });
+  });
+});
+
+describe("markInactiveChangesCountIncreases", () => {
+  it("baselines first observations and queues only inactive environment increases", () => {
+    const previousCounts: Record<string, number> = {};
+    const pendingEnvKeys = new Set<string>();
+
+    markInactiveChangesCountIncreases({
+      countsByEnv: { envA: 1, envB: 0 },
+      activeEnvKey: "envA",
+      previousCounts,
+      pendingEnvKeys,
+    });
+
+    expect(pendingEnvKeys.size).toBe(0);
+
+    markInactiveChangesCountIncreases({
+      countsByEnv: { envA: 2, envB: 1 },
+      activeEnvKey: "envA",
+      previousCounts,
+      pendingEnvKeys,
+    });
+
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+    expect(previousCounts).toEqual({ envA: 2, envB: 1 });
+  });
+});

--- a/apps/web/components/task/changes-panel-focus.test.ts
+++ b/apps/web/components/task/changes-panel-focus.test.ts
@@ -12,7 +12,7 @@ const TEST_TIMESTAMP = "2026-06-29T00:00:00Z";
 const INITIAL_FINGERPRINT = "repo:path:initial";
 const UPDATED_FINGERPRINT = "repo:path:updated";
 
-function gitStatus(files: string[], timestamp = TEST_TIMESTAMP): GitStatusEntry {
+function gitStatus(files: string[], timestamp = TEST_TIMESTAMP, diff = ""): GitStatusEntry {
   return {
     branch: "main",
     remote_branch: null,
@@ -24,14 +24,14 @@ function gitStatus(files: string[], timestamp = TEST_TIMESTAMP): GitStatusEntry 
     ahead: 0,
     behind: 0,
     files: Object.fromEntries(
-      files.map((path) => [path, { path, status: "untracked", staged: false }]),
+      files.map((path) => [path, { path, status: "untracked", staged: false, diff }]),
     ),
     timestamp,
   };
 }
 
 describe("selectChangesMarkerByEnvironment", () => {
-  it("changes fingerprint for meaningful git updates with the same count", () => {
+  it("ignores timestamp-only git refreshes", () => {
     const baseState = {
       gitStatus: {
         byEnvironmentId: {},
@@ -54,6 +54,41 @@ describe("selectChangesMarkerByEnvironment", () => {
         byEnvironmentRepo: {
           envA: {
             repo1: gitStatus(["one.ts"], "2026-06-29T00:01:00Z"),
+          },
+        },
+      },
+    };
+
+    const baseMarker = selectChangesMarkerByEnvironment(baseState).envA;
+    const nextMarker = selectChangesMarkerByEnvironment(nextState).envA;
+
+    expect(nextMarker.count).toBe(baseMarker.count);
+    expect(nextMarker.fingerprint).toBe(baseMarker.fingerprint);
+  });
+
+  it("changes fingerprint for diff-only git updates with the same count", () => {
+    const baseState = {
+      gitStatus: {
+        byEnvironmentId: {},
+        byEnvironmentRepo: {
+          envA: {
+            repo1: gitStatus(["one.ts"], TEST_TIMESTAMP, "old diff"),
+          },
+        },
+      },
+      sessionCommits: {
+        loading: {},
+        refetchTrigger: {},
+        byEnvironmentId: {},
+      },
+    };
+    const nextState = {
+      ...baseState,
+      gitStatus: {
+        byEnvironmentId: {},
+        byEnvironmentRepo: {
+          envA: {
+            repo1: gitStatus(["one.ts"], TEST_TIMESTAMP, "new diff"),
           },
         },
       },

--- a/apps/web/components/task/changes-panel-focus.test.ts
+++ b/apps/web/components/task/changes-panel-focus.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyChangesPanelAutoFocusState,
   markInactiveChangesIncreases,
@@ -6,11 +6,21 @@ import {
   selectChangesMarkerByEnvironment,
   shouldClearPendingChangesFocus,
 } from "./changes-panel-focus";
-import type { GitStatusEntry } from "@/lib/state/slices/session-runtime/types";
+import type { FileInfo, GitStatusEntry } from "@/lib/state/slices/session-runtime/types";
+
+const hashDiffMock = vi.hoisted(() => vi.fn((diff: string) => `hash:${diff}`));
+
+vi.mock("@/lib/utils/hash", () => ({
+  djb2Hash: hashDiffMock,
+}));
 
 const TEST_TIMESTAMP = "2026-06-29T00:00:00Z";
 const INITIAL_FINGERPRINT = "repo:path:initial";
 const UPDATED_FINGERPRINT = "repo:path:updated";
+
+beforeEach(() => {
+  hashDiffMock.mockClear();
+});
 
 function gitStatus(files: string[], timestamp = TEST_TIMESTAMP, diff = ""): GitStatusEntry {
   return {
@@ -29,6 +39,51 @@ function gitStatus(files: string[], timestamp = TEST_TIMESTAMP, diff = ""): GitS
     timestamp,
   };
 }
+
+describe("selectChangesMarkerByEnvironment cache", () => {
+  it("reuses cached fingerprints for unchanged git status objects", () => {
+    const file: FileInfo = {
+      path: "one.ts",
+      status: "modified",
+      staged: false,
+      diff: "large diff body",
+    };
+    const status: GitStatusEntry = {
+      branch: "main",
+      remote_branch: null,
+      modified: ["one.ts"],
+      added: [],
+      deleted: [],
+      untracked: [],
+      renamed: [],
+      ahead: 0,
+      behind: 0,
+      files: { "one.ts": file },
+      timestamp: TEST_TIMESTAMP,
+    };
+    const state = {
+      gitStatus: {
+        byEnvironmentId: {},
+        byEnvironmentRepo: {
+          envA: {
+            repo1: status,
+          },
+        },
+      },
+      sessionCommits: {
+        loading: {},
+        refetchTrigger: {},
+        byEnvironmentId: {},
+      },
+    };
+
+    const baseMarker = selectChangesMarkerByEnvironment(state).envA;
+    const nextMarker = selectChangesMarkerByEnvironment(state).envA;
+
+    expect(nextMarker).toEqual(baseMarker);
+    expect(hashDiffMock).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("selectChangesMarkerByEnvironment", () => {
   it("ignores timestamp-only git refreshes", () => {

--- a/apps/web/components/task/changes-panel-focus.test.ts
+++ b/apps/web/components/task/changes-panel-focus.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyChangesPanelAutoFocusState,
   markInactiveChangesIncreases,
   migrateEnvironmentKeys,
-  selectChangesCountByEnvironment,
   selectChangesMarkerByEnvironment,
   shouldClearPendingChangesFocus,
 } from "./changes-panel-focus";
-import type { GitStatusEntry, SessionCommit } from "@/lib/state/slices/session-runtime/types";
+import type { GitStatusEntry } from "@/lib/state/slices/session-runtime/types";
 
 const TEST_TIMESTAMP = "2026-06-29T00:00:00Z";
+const UPDATED_FINGERPRINT = "repo:path:updated";
 
 function gitStatus(files: string[], timestamp = TEST_TIMESTAMP): GitStatusEntry {
   return {
@@ -27,56 +28,6 @@ function gitStatus(files: string[], timestamp = TEST_TIMESTAMP): GitStatusEntry 
     timestamp,
   };
 }
-
-function commit(sha: string): SessionCommit {
-  return {
-    id: `commit-${sha}`,
-    session_id: "sess-1",
-    commit_sha: sha,
-    parent_sha: `parent-${sha}`,
-    author_name: "Test User",
-    author_email: "test@example.com",
-    commit_message: `Commit ${sha}`,
-    committed_at: TEST_TIMESTAMP,
-    files_changed: 1,
-    insertions: 1,
-    deletions: 0,
-    created_at: TEST_TIMESTAMP,
-  };
-}
-
-describe("selectChangesCountByEnvironment", () => {
-  it("counts git files and commits per environment", () => {
-    const state = {
-      gitStatus: {
-        byEnvironmentId: {},
-        byEnvironmentRepo: {
-          envA: {
-            repo1: gitStatus(["one.ts", "two.ts"]),
-          },
-          envB: {
-            repo1: gitStatus([]),
-            repo2: gitStatus(["three.ts"]),
-          },
-        },
-      },
-      sessionCommits: {
-        loading: {},
-        refetchTrigger: {},
-        byEnvironmentId: {
-          envA: [commit("commit-1"), commit("commit-2")],
-          envC: [commit("commit-3")],
-        },
-      },
-    };
-
-    expect(selectChangesCountByEnvironment(state)).toEqual({
-      envA: 4,
-      envB: 1,
-      envC: 1,
-    });
-  });
-});
 
 describe("selectChangesMarkerByEnvironment", () => {
   it("changes fingerprint for meaningful git updates with the same count", () => {
@@ -112,6 +63,97 @@ describe("selectChangesMarkerByEnvironment", () => {
 
     expect(nextMarker.count).toBe(baseMarker.count);
     expect(nextMarker.fingerprint).not.toBe(baseMarker.fingerprint);
+  });
+});
+
+function signal(count: number, fingerprint: string): string {
+  return `${count}\u0000${fingerprint}`;
+}
+
+describe("applyChangesPanelAutoFocusState", () => {
+  it("migrates keys before queuing, defers during restore, and clears after activation", () => {
+    const previousMarkers = {};
+    const pendingEnvKeys = new Set<string>();
+    let previousActiveEnvKey: string | null = "envA";
+    let activateCalls = 0;
+
+    previousActiveEnvKey = applyChangesPanelAutoFocusState({
+      signalsByEnv: {
+        "session-B": signal(1, "repo:path:initial"),
+      },
+      activeEnvKey: "envA",
+      previousActiveEnvKey,
+      environmentIdBySessionId: {},
+      previousMarkers,
+      pendingEnvKeys,
+      isRestoringLayout: false,
+      activate: () => {
+        activateCalls += 1;
+        return "activated";
+      },
+    });
+
+    expect(pendingEnvKeys.size).toBe(0);
+
+    previousActiveEnvKey = applyChangesPanelAutoFocusState({
+      signalsByEnv: {
+        envB: signal(12, UPDATED_FINGERPRINT),
+      },
+      activeEnvKey: "envA",
+      previousActiveEnvKey,
+      environmentIdBySessionId: { "session-B": "envB" },
+      previousMarkers,
+      pendingEnvKeys,
+      isRestoringLayout: false,
+      activate: () => {
+        activateCalls += 1;
+        return "activated";
+      },
+    });
+
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+    expect(previousMarkers).toEqual({
+      envB: { count: 12, fingerprint: UPDATED_FINGERPRINT },
+    });
+
+    previousActiveEnvKey = applyChangesPanelAutoFocusState({
+      signalsByEnv: {
+        envB: signal(12, UPDATED_FINGERPRINT),
+      },
+      activeEnvKey: "envB",
+      previousActiveEnvKey,
+      environmentIdBySessionId: { "session-B": "envB" },
+      previousMarkers,
+      pendingEnvKeys,
+      isRestoringLayout: true,
+      activate: () => {
+        activateCalls += 1;
+        return "activated";
+      },
+    });
+
+    expect(activateCalls).toBe(0);
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+
+    previousActiveEnvKey = applyChangesPanelAutoFocusState({
+      signalsByEnv: {
+        envB: signal(12, UPDATED_FINGERPRINT),
+      },
+      activeEnvKey: "envB",
+      previousActiveEnvKey,
+      environmentIdBySessionId: { "session-B": "envB" },
+      previousMarkers,
+      pendingEnvKeys,
+      isRestoringLayout: false,
+      activate: () => {
+        activateCalls += 1;
+        return "activated";
+      },
+    });
+
+    expect(previousActiveEnvKey).toBe("envB");
+    expect(activateCalls).toBe(1);
+    expect(pendingEnvKeys.size).toBe(0);
   });
 });
 

--- a/apps/web/components/task/changes-panel-focus.test.ts
+++ b/apps/web/components/task/changes-panel-focus.test.ts
@@ -9,6 +9,7 @@ import {
 import type { GitStatusEntry } from "@/lib/state/slices/session-runtime/types";
 
 const TEST_TIMESTAMP = "2026-06-29T00:00:00Z";
+const INITIAL_FINGERPRINT = "repo:path:initial";
 const UPDATED_FINGERPRINT = "repo:path:updated";
 
 function gitStatus(files: string[], timestamp = TEST_TIMESTAMP): GitStatusEntry {
@@ -70,6 +71,68 @@ function signal(count: number, fingerprint: string): string {
   return `${count}\u0000${fingerprint}`;
 }
 
+describe("applyChangesPanelAutoFocusState fallback session keys", () => {
+  it("activates pending fallback session keys before the env id mapping arrives", () => {
+    const previousMarkers = {
+      "session-B": { count: 1, fingerprint: INITIAL_FINGERPRINT },
+    };
+    const pendingEnvKeys = new Set(["session-B"]);
+    let activateCalls = 0;
+
+    const previousActiveEnvKey = applyChangesPanelAutoFocusState({
+      signalsByEnv: {
+        "session-B": signal(1, INITIAL_FINGERPRINT),
+      },
+      activeEnvKey: "session-B",
+      previousActiveEnvKey: "envA",
+      environmentIdBySessionId: {},
+      previousMarkers,
+      pendingEnvKeys,
+      isRestoringLayout: false,
+      activate: () => {
+        activateCalls += 1;
+        return "activated";
+      },
+    });
+
+    expect(previousActiveEnvKey).toBe("session-B");
+    expect(activateCalls).toBe(1);
+    expect(pendingEnvKeys.size).toBe(0);
+  });
+
+  it("does not queue updates for the active fallback session key", () => {
+    const previousMarkers = {
+      "session-A": { count: 1, fingerprint: INITIAL_FINGERPRINT },
+    };
+    const pendingEnvKeys = new Set<string>();
+    let activateCalls = 0;
+
+    const previousActiveEnvKey = applyChangesPanelAutoFocusState({
+      signalsByEnv: {
+        "session-A": signal(2, UPDATED_FINGERPRINT),
+      },
+      activeEnvKey: "session-A",
+      previousActiveEnvKey: "session-A",
+      environmentIdBySessionId: {},
+      previousMarkers,
+      pendingEnvKeys,
+      isRestoringLayout: false,
+      activate: () => {
+        activateCalls += 1;
+        return "activated";
+      },
+    });
+
+    expect(previousActiveEnvKey).toBe("session-A");
+    expect(activateCalls).toBe(0);
+    expect(pendingEnvKeys.size).toBe(0);
+    expect(previousMarkers["session-A"]).toEqual({
+      count: 2,
+      fingerprint: UPDATED_FINGERPRINT,
+    });
+  });
+});
+
 describe("applyChangesPanelAutoFocusState", () => {
   it("migrates keys before queuing, defers during restore, and clears after activation", () => {
     const previousMarkers = {};
@@ -79,7 +142,7 @@ describe("applyChangesPanelAutoFocusState", () => {
 
     previousActiveEnvKey = applyChangesPanelAutoFocusState({
       signalsByEnv: {
-        "session-B": signal(1, "repo:path:initial"),
+        "session-B": signal(1, INITIAL_FINGERPRINT),
       },
       activeEnvKey: "envA",
       previousActiveEnvKey,

--- a/apps/web/components/task/changes-panel-focus.test.ts
+++ b/apps/web/components/task/changes-panel-focus.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
-  markInactiveChangesCountIncreases,
+  markInactiveChangesIncreases,
+  migrateEnvironmentKeys,
   selectChangesCountByEnvironment,
+  selectChangesMarkerByEnvironment,
+  shouldClearPendingChangesFocus,
 } from "./changes-panel-focus";
 import type { GitStatusEntry, SessionCommit } from "@/lib/state/slices/session-runtime/types";
 
-function gitStatus(files: string[]): GitStatusEntry {
+const TEST_TIMESTAMP = "2026-06-29T00:00:00Z";
+
+function gitStatus(files: string[], timestamp = TEST_TIMESTAMP): GitStatusEntry {
   return {
     branch: "main",
     remote_branch: null,
@@ -19,7 +24,7 @@ function gitStatus(files: string[]): GitStatusEntry {
     files: Object.fromEntries(
       files.map((path) => [path, { path, status: "untracked", staged: false }]),
     ),
-    timestamp: "2026-06-29T00:00:00Z",
+    timestamp,
   };
 }
 
@@ -32,11 +37,11 @@ function commit(sha: string): SessionCommit {
     author_name: "Test User",
     author_email: "test@example.com",
     commit_message: `Commit ${sha}`,
-    committed_at: "2026-06-29T00:00:00Z",
+    committed_at: TEST_TIMESTAMP,
     files_changed: 1,
     insertions: 1,
     deletions: 0,
-    created_at: "2026-06-29T00:00:00Z",
+    created_at: TEST_TIMESTAMP,
   };
 }
 
@@ -73,28 +78,143 @@ describe("selectChangesCountByEnvironment", () => {
   });
 });
 
-describe("markInactiveChangesCountIncreases", () => {
+describe("selectChangesMarkerByEnvironment", () => {
+  it("changes fingerprint for meaningful git updates with the same count", () => {
+    const baseState = {
+      gitStatus: {
+        byEnvironmentId: {},
+        byEnvironmentRepo: {
+          envA: {
+            repo1: gitStatus(["one.ts"], "2026-06-29T00:00:00Z"),
+          },
+        },
+      },
+      sessionCommits: {
+        loading: {},
+        refetchTrigger: {},
+        byEnvironmentId: {},
+      },
+    };
+    const nextState = {
+      ...baseState,
+      gitStatus: {
+        byEnvironmentId: {},
+        byEnvironmentRepo: {
+          envA: {
+            repo1: gitStatus(["one.ts"], "2026-06-29T00:01:00Z"),
+          },
+        },
+      },
+    };
+
+    const baseMarker = selectChangesMarkerByEnvironment(baseState).envA;
+    const nextMarker = selectChangesMarkerByEnvironment(nextState).envA;
+
+    expect(nextMarker.count).toBe(baseMarker.count);
+    expect(nextMarker.fingerprint).not.toBe(baseMarker.fingerprint);
+  });
+});
+
+describe("markInactiveChangesIncreases", () => {
   it("baselines first observations and queues only inactive environment increases", () => {
-    const previousCounts: Record<string, number> = {};
+    const previousMarkers = {};
     const pendingEnvKeys = new Set<string>();
 
-    markInactiveChangesCountIncreases({
-      countsByEnv: { envA: 1, envB: 0 },
+    markInactiveChangesIncreases({
+      markersByEnv: {
+        envA: { count: 1, fingerprint: "a1" },
+        envB: { count: 0, fingerprint: "b0" },
+      },
       activeEnvKey: "envA",
-      previousCounts,
+      previousActiveEnvKey: "envA",
+      previousMarkers,
       pendingEnvKeys,
     });
 
     expect(pendingEnvKeys.size).toBe(0);
 
-    markInactiveChangesCountIncreases({
-      countsByEnv: { envA: 2, envB: 1 },
+    markInactiveChangesIncreases({
+      markersByEnv: {
+        envA: { count: 2, fingerprint: "a2" },
+        envB: { count: 1, fingerprint: "b1" },
+      },
       activeEnvKey: "envA",
-      previousCounts,
+      previousActiveEnvKey: "envA",
+      previousMarkers,
       pendingEnvKeys,
     });
 
     expect([...pendingEnvKeys]).toEqual(["envB"]);
-    expect(previousCounts).toEqual({ envA: 2, envB: 1 });
+    expect(previousMarkers).toEqual({
+      envA: { count: 2, fingerprint: "a2" },
+      envB: { count: 1, fingerprint: "b1" },
+    });
+  });
+
+  it("queues a same-batch update for the previously inactive environment", () => {
+    const previousMarkers = {
+      envB: { count: 0, fingerprint: "b0" },
+    };
+    const pendingEnvKeys = new Set<string>();
+
+    markInactiveChangesIncreases({
+      markersByEnv: {
+        envB: { count: 1, fingerprint: "b1" },
+      },
+      activeEnvKey: "envB",
+      previousActiveEnvKey: "envA",
+      previousMarkers,
+      pendingEnvKeys,
+    });
+
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+  });
+
+  it("queues count-neutral meaningful updates for inactive environments", () => {
+    const previousMarkers = {
+      envB: { count: 1, fingerprint: "b1" },
+    };
+    const pendingEnvKeys = new Set<string>();
+
+    markInactiveChangesIncreases({
+      markersByEnv: {
+        envB: { count: 1, fingerprint: "b2" },
+      },
+      activeEnvKey: "envA",
+      previousActiveEnvKey: "envA",
+      previousMarkers,
+      pendingEnvKeys,
+    });
+
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+  });
+});
+
+describe("migrateEnvironmentKeys", () => {
+  it("migrates pending and previous fallback session keys to environment keys", () => {
+    const previousMarkers = {
+      "session-B": { count: 1, fingerprint: "b1" },
+    };
+    const pendingEnvKeys = new Set(["session-B"]);
+
+    migrateEnvironmentKeys({
+      environmentIdBySessionId: { "session-B": "envB" },
+      previousMarkers,
+      pendingEnvKeys,
+    });
+
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+    expect(previousMarkers).toEqual({
+      envB: { count: 1, fingerprint: "b1" },
+    });
+  });
+});
+
+describe("shouldClearPendingChangesFocus", () => {
+  it("keeps retryable activation results pending", () => {
+    expect(shouldClearPendingChangesFocus("activated")).toBe(true);
+    expect(shouldClearPendingChangesFocus("no-panel")).toBe(true);
+    expect(shouldClearPendingChangesFocus("blocked-agent-group")).toBe(false);
+    expect(shouldClearPendingChangesFocus("no-api")).toBe(false);
   });
 });

--- a/apps/web/components/task/changes-panel-focus.test.ts
+++ b/apps/web/components/task/changes-panel-focus.test.ts
@@ -385,6 +385,82 @@ describe("markInactiveChangesIncreases", () => {
   });
 });
 
+describe("markInactiveChangesIncreases pending cleanup", () => {
+  it("queues first observed inactive changes after bootstrap", () => {
+    const previousMarkers = {
+      envA: { count: 0, fingerprint: "a0" },
+    };
+    const pendingEnvKeys = new Set<string>();
+
+    markInactiveChangesIncreases({
+      markersByEnv: {
+        envA: { count: 0, fingerprint: "a0" },
+        envB: { count: 1, fingerprint: "b1" },
+      },
+      activeEnvKey: "envA",
+      previousActiveEnvKey: "envA",
+      previousMarkers,
+      pendingEnvKeys,
+      queueFirstObservedInactiveChanges: true,
+    });
+
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+  });
+
+  it("clears pending focus when changes disappear or the environment disappears", () => {
+    const previousMarkers = {
+      envB: { count: 1, fingerprint: "b1" },
+      envC: { count: 1, fingerprint: "c1" },
+    };
+    const pendingEnvKeys = new Set(["envB", "envC"]);
+
+    markInactiveChangesIncreases({
+      markersByEnv: {
+        envB: { count: 0, fingerprint: "b0" },
+      },
+      activeEnvKey: "envA",
+      previousActiveEnvKey: "envA",
+      previousMarkers,
+      pendingEnvKeys,
+      queueFirstObservedInactiveChanges: true,
+    });
+
+    expect(pendingEnvKeys.size).toBe(0);
+    expect(previousMarkers).toEqual({
+      envB: { count: 0, fingerprint: "b0" },
+    });
+  });
+});
+
+describe("applyChangesPanelAutoFocusState restore races", () => {
+  it("keeps pending focus when a stale restore flag produces no panel", () => {
+    const previousMarkers = {
+      envB: { count: 1, fingerprint: "b1" },
+    };
+    const pendingEnvKeys = new Set(["envB"]);
+    let restoring = false;
+
+    applyChangesPanelAutoFocusState({
+      signalsByEnv: {
+        envB: signal(1, "b1"),
+      },
+      activeEnvKey: "envB",
+      previousActiveEnvKey: "envA",
+      environmentIdBySessionId: {},
+      previousMarkers,
+      pendingEnvKeys,
+      isRestoringLayout: false,
+      getIsRestoringLayout: () => restoring,
+      activate: () => {
+        restoring = true;
+        return "no-panel";
+      },
+    });
+
+    expect([...pendingEnvKeys]).toEqual(["envB"]);
+  });
+});
+
 describe("migrateEnvironmentKeys", () => {
   it("migrates pending and previous fallback session keys to environment keys", () => {
     const previousMarkers = {

--- a/apps/web/components/task/changes-panel-focus.ts
+++ b/apps/web/components/task/changes-panel-focus.ts
@@ -197,13 +197,34 @@ export function markInactiveChangesIncreases(args: {
   previousActiveEnvKey: string | null;
   previousMarkers: Record<string, ChangesMarker>;
   pendingEnvKeys: Set<string>;
+  queueFirstObservedInactiveChanges?: boolean;
 }): void {
-  const { markersByEnv, activeEnvKey, previousActiveEnvKey, previousMarkers, pendingEnvKeys } =
-    args;
+  const {
+    markersByEnv,
+    activeEnvKey,
+    previousActiveEnvKey,
+    previousMarkers,
+    pendingEnvKeys,
+    queueFirstObservedInactiveChanges = false,
+  } = args;
+  for (const envKey of Object.keys(previousMarkers)) {
+    if (markersByEnv[envKey] !== undefined) continue;
+    delete previousMarkers[envKey];
+    pendingEnvKeys.delete(envKey);
+  }
   for (const [envKey, marker] of Object.entries(markersByEnv)) {
     const previous = previousMarkers[envKey];
     previousMarkers[envKey] = marker;
-    if (previous === undefined) continue;
+    if (marker.count === 0) {
+      pendingEnvKeys.delete(envKey);
+      continue;
+    }
+    if (previous === undefined) {
+      if (queueFirstObservedInactiveChanges && envKey !== activeEnvKey) {
+        pendingEnvKeys.add(envKey);
+      }
+      continue;
+    }
     if (
       shouldQueueInactiveFocus({
         envKey,
@@ -230,6 +251,7 @@ export function applyChangesPanelAutoFocusState(args: {
   previousMarkers: Record<string, ChangesMarker>;
   pendingEnvKeys: Set<string>;
   isRestoringLayout: boolean;
+  getIsRestoringLayout?: () => boolean;
   activate: () => ActivateChangesPanelResult;
 }): string | null {
   const {
@@ -240,6 +262,7 @@ export function applyChangesPanelAutoFocusState(args: {
     previousMarkers,
     pendingEnvKeys,
     isRestoringLayout,
+    getIsRestoringLayout,
     activate,
   } = args;
 
@@ -249,17 +272,28 @@ export function applyChangesPanelAutoFocusState(args: {
     pendingEnvKeys,
   });
 
+  const markersByEnv = signalsToMarkers(signalsByEnv);
+  const hasPreviousMarkers = Object.keys(previousMarkers).length > 0;
+
   markInactiveChangesIncreases({
-    markersByEnv: signalsToMarkers(signalsByEnv),
+    markersByEnv,
     activeEnvKey,
     previousActiveEnvKey,
     previousMarkers,
     pendingEnvKeys,
+    queueFirstObservedInactiveChanges: hasPreviousMarkers,
   });
 
-  if (activeEnvKey && !isRestoringLayout && pendingEnvKeys.has(activeEnvKey)) {
+  const isCurrentlyRestoringLayout = () => isRestoringLayout || getIsRestoringLayout?.() === true;
+
+  if (activeEnvKey && !isCurrentlyRestoringLayout() && pendingEnvKeys.has(activeEnvKey)) {
     const result = activate();
-    if (shouldClearPendingChangesFocus(result)) pendingEnvKeys.delete(activeEnvKey);
+    if (
+      shouldClearPendingChangesFocus(result) &&
+      !(result === "no-panel" && isCurrentlyRestoringLayout())
+    ) {
+      pendingEnvKeys.delete(activeEnvKey);
+    }
   }
 
   return activeEnvKey;
@@ -283,6 +317,7 @@ export function useChangesPanelAutoFocus(activeEnvKey: string | null) {
       previousMarkers: previousMarkersRef.current,
       pendingEnvKeys: pendingEnvKeysRef.current,
       isRestoringLayout,
+      getIsRestoringLayout: () => useDockviewStore.getState().isRestoringLayout,
       activate: () => activateChangesPanel(api),
     });
   }, [signalsByEnv, activeEnvKey, api, isRestoringLayout, environmentIdBySessionId]);

--- a/apps/web/components/task/changes-panel-focus.ts
+++ b/apps/web/components/task/changes-panel-focus.ts
@@ -16,8 +16,6 @@ export type ChangesMarker = {
   fingerprint: string;
 };
 
-type ChangesSignalState = Pick<AppState, "gitStatus" | "sessionCommits">;
-
 export type ActivateChangesPanelResult =
   | "activated"
   | "blocked-agent-group"
@@ -104,14 +102,9 @@ export function selectChangesMarkerByEnvironment(
   return markers;
 }
 
-export function selectChangesCountByEnvironment(state: ChangesMarkerState): Record<string, number> {
-  const markers = selectChangesMarkerByEnvironment(state);
-  return Object.fromEntries(
-    Object.entries(markers).map(([envKey, marker]) => [envKey, marker.count]),
-  );
-}
-
 function markerToSignal(marker: ChangesMarker): string {
+  // Zustand shallow comparison is stable for primitive values; count always
+  // lives left of the first NUL and the full fingerprint lives to the right.
   return `${marker.count}\u0000${marker.fingerprint}`;
 }
 
@@ -130,7 +123,7 @@ function signalsToMarkers(signalsByEnv: Record<string, string>): Record<string, 
 }
 
 export function selectChangesSignalByEnvironment(
-  state: ChangesSignalState,
+  state: ChangesMarkerState,
 ): Record<string, string> {
   const markers = selectChangesMarkerByEnvironment(state);
   return Object.fromEntries(
@@ -201,6 +194,49 @@ export function shouldClearPendingChangesFocus(result: ActivateChangesPanelResul
   return result === "activated" || result === "no-panel";
 }
 
+export function applyChangesPanelAutoFocusState(args: {
+  signalsByEnv: Record<string, string>;
+  activeEnvKey: string | null;
+  previousActiveEnvKey: string | null;
+  environmentIdBySessionId: Record<string, string>;
+  previousMarkers: Record<string, ChangesMarker>;
+  pendingEnvKeys: Set<string>;
+  isRestoringLayout: boolean;
+  activate: () => ActivateChangesPanelResult;
+}): string | null {
+  const {
+    signalsByEnv,
+    activeEnvKey,
+    previousActiveEnvKey,
+    environmentIdBySessionId,
+    previousMarkers,
+    pendingEnvKeys,
+    isRestoringLayout,
+    activate,
+  } = args;
+
+  migrateEnvironmentKeys({
+    environmentIdBySessionId,
+    previousMarkers,
+    pendingEnvKeys,
+  });
+
+  markInactiveChangesIncreases({
+    markersByEnv: signalsToMarkers(signalsByEnv),
+    activeEnvKey,
+    previousActiveEnvKey,
+    previousMarkers,
+    pendingEnvKeys,
+  });
+
+  if (activeEnvKey && !isRestoringLayout && pendingEnvKeys.has(activeEnvKey)) {
+    const result = activate();
+    if (shouldClearPendingChangesFocus(result)) pendingEnvKeys.delete(activeEnvKey);
+  }
+
+  return activeEnvKey;
+}
+
 export function useChangesPanelAutoFocus(activeEnvKey: string | null) {
   const api = useDockviewStore((s) => s.api);
   const isRestoringLayout = useDockviewStore((s) => s.isRestoringLayout);
@@ -211,25 +247,15 @@ export function useChangesPanelAutoFocus(activeEnvKey: string | null) {
   const previousActiveEnvKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    migrateEnvironmentKeys({
+    previousActiveEnvKeyRef.current = applyChangesPanelAutoFocusState({
+      signalsByEnv,
+      activeEnvKey,
+      previousActiveEnvKey: previousActiveEnvKeyRef.current,
       environmentIdBySessionId,
       previousMarkers: previousMarkersRef.current,
       pendingEnvKeys: pendingEnvKeysRef.current,
+      isRestoringLayout,
+      activate: () => activateChangesPanel(api),
     });
-
-    markInactiveChangesIncreases({
-      markersByEnv: signalsToMarkers(signalsByEnv),
-      activeEnvKey,
-      previousActiveEnvKey: previousActiveEnvKeyRef.current,
-      previousMarkers: previousMarkersRef.current,
-      pendingEnvKeys: pendingEnvKeysRef.current,
-    });
-
-    if (activeEnvKey && !isRestoringLayout && pendingEnvKeysRef.current.has(activeEnvKey)) {
-      const result = activateChangesPanel(api);
-      if (shouldClearPendingChangesFocus(result)) pendingEnvKeysRef.current.delete(activeEnvKey);
-    }
-
-    previousActiveEnvKeyRef.current = activeEnvKey;
   }, [signalsByEnv, activeEnvKey, api, isRestoringLayout, environmentIdBySessionId]);
 }

--- a/apps/web/components/task/changes-panel-focus.ts
+++ b/apps/web/components/task/changes-panel-focus.ts
@@ -17,6 +17,12 @@ export type ChangesMarker = {
   fingerprint: string;
 };
 
+type GitStatusFingerprintCacheEntry = {
+  repoName: string;
+  fileCount: number;
+  fingerprint: string;
+};
+
 export type ActivateChangesPanelResult =
   | "activated"
   | "blocked-agent-group"
@@ -45,8 +51,14 @@ export function autoActivateChangesPanel(): ActivateChangesPanelResult {
   return activateChangesPanel(useDockviewStore.getState().api);
 }
 
+const fileFingerprintCache = new WeakMap<FileInfo, string>();
+const gitStatusFingerprintCache = new WeakMap<GitStatusEntry, GitStatusFingerprintCacheEntry>();
+
 function fileFingerprint(file: FileInfo): string {
-  return [
+  const cached = fileFingerprintCache.get(file);
+  if (cached !== undefined) return cached;
+
+  const fingerprint = [
     file.path,
     file.status,
     file.staged ? "1" : "0",
@@ -57,20 +69,34 @@ function fileFingerprint(file: FileInfo): string {
     file.diff_skip_reason ?? "",
     file.repository_name ?? "",
   ].join(":");
+  fileFingerprintCache.set(file, fingerprint);
+  return fingerprint;
 }
 
-function gitStatusFingerprint(repoName: string, status: GitStatusEntry): string {
+function gitStatusFingerprint(
+  repoName: string,
+  status: GitStatusEntry,
+): GitStatusFingerprintCacheEntry {
+  const cached = gitStatusFingerprintCache.get(status);
+  if (cached?.repoName === repoName) return cached;
+
   const fileKeys = Object.keys(status.files ?? {}).sort();
   const files = fileKeys.map((path) => fileFingerprint(status.files[path])).join(",");
-  return [
+  const entry = {
     repoName,
-    status.branch ?? "",
-    status.remote_branch ?? "",
-    status.ahead,
-    status.behind,
-    status.repository_name ?? "",
-    files,
-  ].join("|");
+    fileCount: fileKeys.length,
+    fingerprint: [
+      repoName,
+      status.branch ?? "",
+      status.remote_branch ?? "",
+      status.ahead,
+      status.behind,
+      status.repository_name ?? "",
+      files,
+    ].join("|"),
+  };
+  gitStatusFingerprintCache.set(status, entry);
+  return entry;
 }
 
 export function selectChangesMarkerByEnvironment(
@@ -89,8 +115,9 @@ export function selectChangesMarkerByEnvironment(
     const repoFingerprint = Object.entries(repoStatuses)
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([repoName, status]) => {
-        count += Object.keys(status.files ?? {}).length;
-        return gitStatusFingerprint(repoName, status);
+        const entry = gitStatusFingerprint(repoName, status);
+        count += entry.fileCount;
+        return entry.fingerprint;
       })
       .join(";");
     const commitFingerprint = commits.map((commit) => commit.commit_sha).join(",");

--- a/apps/web/components/task/changes-panel-focus.ts
+++ b/apps/web/components/task/changes-panel-focus.ts
@@ -6,9 +6,17 @@ import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "@/components/state-provider";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import type { AppState } from "@/lib/state/store";
+import type { FileInfo, GitStatusEntry } from "@/lib/state/slices/session-runtime/types";
 
 type DockviewPanel = NonNullable<ReturnType<DockviewApi["getPanel"]>>;
-type ChangesCountState = Pick<AppState, "gitStatus" | "sessionCommits">;
+type ChangesMarkerState = Pick<AppState, "gitStatus" | "sessionCommits">;
+
+export type ChangesMarker = {
+  count: number;
+  fingerprint: string;
+};
+
+type ChangesSignalState = Pick<AppState, "gitStatus" | "sessionCommits">;
 
 export type ActivateChangesPanelResult =
   | "activated"
@@ -38,72 +46,190 @@ export function autoActivateChangesPanel(): ActivateChangesPanelResult {
   return activateChangesPanel(useDockviewStore.getState().api);
 }
 
-export function selectChangesCountByEnvironment(state: ChangesCountState): Record<string, number> {
+function fileFingerprint(file: FileInfo): string {
+  return [
+    file.path,
+    file.status,
+    file.staged ? "1" : "0",
+    file.additions ?? 0,
+    file.deletions ?? 0,
+    file.old_path ?? "",
+    file.diff_skip_reason ?? "",
+    file.repository_name ?? "",
+  ].join(":");
+}
+
+function gitStatusFingerprint(repoName: string, status: GitStatusEntry): string {
+  const fileKeys = Object.keys(status.files ?? {}).sort();
+  const files = fileKeys.map((path) => fileFingerprint(status.files[path])).join(",");
+  return [
+    repoName,
+    status.branch ?? "",
+    status.remote_branch ?? "",
+    status.ahead,
+    status.behind,
+    status.timestamp ?? "",
+    status.repository_name ?? "",
+    files,
+  ].join("|");
+}
+
+export function selectChangesMarkerByEnvironment(
+  state: ChangesMarkerState,
+): Record<string, ChangesMarker> {
   const envKeys = new Set([
     ...Object.keys(state.gitStatus.byEnvironmentRepo),
     ...Object.keys(state.sessionCommits.byEnvironmentId),
   ]);
-  const counts: Record<string, number> = {};
+  const markers: Record<string, ChangesMarker> = {};
 
   for (const envKey of envKeys) {
-    let count = state.sessionCommits.byEnvironmentId[envKey]?.length ?? 0;
+    const commits = state.sessionCommits.byEnvironmentId[envKey] ?? [];
+    let count = commits.length;
     const repoStatuses = state.gitStatus.byEnvironmentRepo[envKey] ?? {};
-    for (const status of Object.values(repoStatuses)) {
-      count += Object.keys(status.files ?? {}).length;
-    }
-    counts[envKey] = count;
+    const repoFingerprint = Object.entries(repoStatuses)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([repoName, status]) => {
+        count += Object.keys(status.files ?? {}).length;
+        return gitStatusFingerprint(repoName, status);
+      })
+      .join(";");
+    const commitFingerprint = commits.map((commit) => commit.commit_sha).join(",");
+    markers[envKey] = {
+      count,
+      fingerprint: `${repoFingerprint}#${commitFingerprint}`,
+    };
   }
 
-  return counts;
+  return markers;
 }
 
-export function markInactiveChangesCountIncreases(args: {
-  countsByEnv: Record<string, number>;
+export function selectChangesCountByEnvironment(state: ChangesMarkerState): Record<string, number> {
+  const markers = selectChangesMarkerByEnvironment(state);
+  return Object.fromEntries(
+    Object.entries(markers).map(([envKey, marker]) => [envKey, marker.count]),
+  );
+}
+
+function markerToSignal(marker: ChangesMarker): string {
+  return `${marker.count}\u0000${marker.fingerprint}`;
+}
+
+function signalToMarker(signal: string): ChangesMarker {
+  const separatorIndex = signal.indexOf("\u0000");
+  return {
+    count: Number(signal.slice(0, separatorIndex)),
+    fingerprint: signal.slice(separatorIndex + 1),
+  };
+}
+
+function signalsToMarkers(signalsByEnv: Record<string, string>): Record<string, ChangesMarker> {
+  return Object.fromEntries(
+    Object.entries(signalsByEnv).map(([envKey, signal]) => [envKey, signalToMarker(signal)]),
+  );
+}
+
+export function selectChangesSignalByEnvironment(
+  state: ChangesSignalState,
+): Record<string, string> {
+  const markers = selectChangesMarkerByEnvironment(state);
+  return Object.fromEntries(
+    Object.entries(markers).map(([envKey, marker]) => [envKey, markerToSignal(marker)]),
+  );
+}
+
+function shouldQueueInactiveFocus(args: {
+  envKey: string;
   activeEnvKey: string | null;
-  previousCounts: Record<string, number>;
+  previousActiveEnvKey: string | null;
+  previous: ChangesMarker;
+  next: ChangesMarker;
+}): boolean {
+  const { envKey, activeEnvKey, previousActiveEnvKey, previous, next } = args;
+  const changed =
+    next.count > previous.count || (next.count > 0 && next.fingerprint !== previous.fingerprint);
+  if (!changed) return false;
+  return (
+    envKey !== activeEnvKey || (previousActiveEnvKey !== null && envKey !== previousActiveEnvKey)
+  );
+}
+
+export function migrateEnvironmentKeys(args: {
+  environmentIdBySessionId: Record<string, string>;
+  previousMarkers: Record<string, ChangesMarker>;
   pendingEnvKeys: Set<string>;
 }): void {
-  const { countsByEnv, activeEnvKey, previousCounts, pendingEnvKeys } = args;
-  for (const [envKey, count] of Object.entries(countsByEnv)) {
-    const previous = previousCounts[envKey];
-    previousCounts[envKey] = count;
-    if (previous === undefined) continue;
-    if (envKey !== activeEnvKey && count > previous) pendingEnvKeys.add(envKey);
+  const { environmentIdBySessionId, previousMarkers, pendingEnvKeys } = args;
+  for (const [sessionId, envKey] of Object.entries(environmentIdBySessionId)) {
+    if (sessionId === envKey) continue;
+    if (pendingEnvKeys.delete(sessionId)) pendingEnvKeys.add(envKey);
+    if (previousMarkers[sessionId] && !previousMarkers[envKey]) {
+      previousMarkers[envKey] = previousMarkers[sessionId];
+    }
+    delete previousMarkers[sessionId];
   }
 }
 
-function useActiveEnvironmentKey(): string | null {
-  return useAppStore((state) => {
-    const sessionId = state.tasks.activeSessionId;
-    if (!sessionId) return null;
-    return state.environmentIdBySessionId[sessionId] ?? sessionId;
-  });
+export function markInactiveChangesIncreases(args: {
+  markersByEnv: Record<string, ChangesMarker>;
+  activeEnvKey: string | null;
+  previousActiveEnvKey: string | null;
+  previousMarkers: Record<string, ChangesMarker>;
+  pendingEnvKeys: Set<string>;
+}): void {
+  const { markersByEnv, activeEnvKey, previousActiveEnvKey, previousMarkers, pendingEnvKeys } =
+    args;
+  for (const [envKey, marker] of Object.entries(markersByEnv)) {
+    const previous = previousMarkers[envKey];
+    previousMarkers[envKey] = marker;
+    if (previous === undefined) continue;
+    if (
+      shouldQueueInactiveFocus({
+        envKey,
+        activeEnvKey,
+        previousActiveEnvKey,
+        previous,
+        next: marker,
+      })
+    ) {
+      pendingEnvKeys.add(envKey);
+    }
+  }
 }
 
-/**
- * Queue a Changes-panel focus request when a background task/env receives new
- * changes, then consume it after the user switches into that environment.
- */
-export function useChangesPanelAutoFocus() {
+export function shouldClearPendingChangesFocus(result: ActivateChangesPanelResult): boolean {
+  return result === "activated" || result === "no-panel";
+}
+
+export function useChangesPanelAutoFocus(activeEnvKey: string | null) {
   const api = useDockviewStore((s) => s.api);
   const isRestoringLayout = useDockviewStore((s) => s.isRestoringLayout);
-  const activeEnvKey = useActiveEnvironmentKey();
-  const countsByEnv = useAppStore(useShallow(selectChangesCountByEnvironment));
-  const previousCountsRef = useRef<Record<string, number>>({});
+  const signalsByEnv = useAppStore(useShallow(selectChangesSignalByEnvironment));
+  const environmentIdBySessionId = useAppStore((state) => state.environmentIdBySessionId);
+  const previousMarkersRef = useRef<Record<string, ChangesMarker>>({});
   const pendingEnvKeysRef = useRef<Set<string>>(new Set());
+  const previousActiveEnvKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    markInactiveChangesCountIncreases({
-      countsByEnv,
-      activeEnvKey,
-      previousCounts: previousCountsRef.current,
+    migrateEnvironmentKeys({
+      environmentIdBySessionId,
+      previousMarkers: previousMarkersRef.current,
       pendingEnvKeys: pendingEnvKeysRef.current,
     });
 
-    if (!activeEnvKey || isRestoringLayout) return;
-    if (!pendingEnvKeysRef.current.has(activeEnvKey)) return;
+    markInactiveChangesIncreases({
+      markersByEnv: signalsToMarkers(signalsByEnv),
+      activeEnvKey,
+      previousActiveEnvKey: previousActiveEnvKeyRef.current,
+      previousMarkers: previousMarkersRef.current,
+      pendingEnvKeys: pendingEnvKeysRef.current,
+    });
 
-    const result = activateChangesPanel(api);
-    if (result !== "no-api") pendingEnvKeysRef.current.delete(activeEnvKey);
-  }, [countsByEnv, activeEnvKey, api, isRestoringLayout]);
+    if (activeEnvKey && !isRestoringLayout && pendingEnvKeysRef.current.has(activeEnvKey)) {
+      const result = activateChangesPanel(api);
+      if (shouldClearPendingChangesFocus(result)) pendingEnvKeysRef.current.delete(activeEnvKey);
+    }
+
+    previousActiveEnvKeyRef.current = activeEnvKey;
+  }, [signalsByEnv, activeEnvKey, api, isRestoringLayout, environmentIdBySessionId]);
 }

--- a/apps/web/components/task/changes-panel-focus.ts
+++ b/apps/web/components/task/changes-panel-focus.ts
@@ -7,6 +7,7 @@ import { useAppStore } from "@/components/state-provider";
 import { useDockviewStore } from "@/lib/state/dockview-store";
 import type { AppState } from "@/lib/state/store";
 import type { FileInfo, GitStatusEntry } from "@/lib/state/slices/session-runtime/types";
+import { djb2Hash } from "@/lib/utils/hash";
 
 type DockviewPanel = NonNullable<ReturnType<DockviewApi["getPanel"]>>;
 type ChangesMarkerState = Pick<AppState, "gitStatus" | "sessionCommits">;
@@ -52,6 +53,7 @@ function fileFingerprint(file: FileInfo): string {
     file.additions ?? 0,
     file.deletions ?? 0,
     file.old_path ?? "",
+    djb2Hash(file.diff ?? ""),
     file.diff_skip_reason ?? "",
     file.repository_name ?? "",
   ].join(":");
@@ -66,7 +68,6 @@ function gitStatusFingerprint(repoName: string, status: GitStatusEntry): string 
     status.remote_branch ?? "",
     status.ahead,
     status.behind,
-    status.timestamp ?? "",
     status.repository_name ?? "",
     files,
   ].join("|");

--- a/apps/web/components/task/changes-panel-focus.ts
+++ b/apps/web/components/task/changes-panel-focus.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { DockviewApi } from "dockview-react";
+import { useShallow } from "zustand/react/shallow";
+import { useAppStore } from "@/components/state-provider";
+import { useDockviewStore } from "@/lib/state/dockview-store";
+import type { AppState } from "@/lib/state/store";
+
+type DockviewPanel = NonNullable<ReturnType<DockviewApi["getPanel"]>>;
+type ChangesCountState = Pick<AppState, "gitStatus" | "sessionCommits">;
+
+export type ActivateChangesPanelResult =
+  | "activated"
+  | "blocked-agent-group"
+  | "no-api"
+  | "no-panel";
+
+function groupContainsAgentSessionPanel(panel: DockviewPanel): boolean {
+  return panel.group.panels.some((p) => p.id === "chat" || p.id.startsWith("session:"));
+}
+
+/** Activate the Changes panel unless it shares a group with agent sessions. */
+export function activateChangesPanel(
+  api: DockviewApi | null | undefined,
+): ActivateChangesPanelResult {
+  if (!api) return "no-api";
+
+  const panel = api.getPanel("changes");
+  if (!panel) return "no-panel";
+  if (groupContainsAgentSessionPanel(panel)) return "blocked-agent-group";
+
+  panel.api.setActive();
+  return "activated";
+}
+
+export function autoActivateChangesPanel(): ActivateChangesPanelResult {
+  return activateChangesPanel(useDockviewStore.getState().api);
+}
+
+export function selectChangesCountByEnvironment(state: ChangesCountState): Record<string, number> {
+  const envKeys = new Set([
+    ...Object.keys(state.gitStatus.byEnvironmentRepo),
+    ...Object.keys(state.sessionCommits.byEnvironmentId),
+  ]);
+  const counts: Record<string, number> = {};
+
+  for (const envKey of envKeys) {
+    let count = state.sessionCommits.byEnvironmentId[envKey]?.length ?? 0;
+    const repoStatuses = state.gitStatus.byEnvironmentRepo[envKey] ?? {};
+    for (const status of Object.values(repoStatuses)) {
+      count += Object.keys(status.files ?? {}).length;
+    }
+    counts[envKey] = count;
+  }
+
+  return counts;
+}
+
+export function markInactiveChangesCountIncreases(args: {
+  countsByEnv: Record<string, number>;
+  activeEnvKey: string | null;
+  previousCounts: Record<string, number>;
+  pendingEnvKeys: Set<string>;
+}): void {
+  const { countsByEnv, activeEnvKey, previousCounts, pendingEnvKeys } = args;
+  for (const [envKey, count] of Object.entries(countsByEnv)) {
+    const previous = previousCounts[envKey];
+    previousCounts[envKey] = count;
+    if (previous === undefined) continue;
+    if (envKey !== activeEnvKey && count > previous) pendingEnvKeys.add(envKey);
+  }
+}
+
+function useActiveEnvironmentKey(): string | null {
+  return useAppStore((state) => {
+    const sessionId = state.tasks.activeSessionId;
+    if (!sessionId) return null;
+    return state.environmentIdBySessionId[sessionId] ?? sessionId;
+  });
+}
+
+/**
+ * Queue a Changes-panel focus request when a background task/env receives new
+ * changes, then consume it after the user switches into that environment.
+ */
+export function useChangesPanelAutoFocus() {
+  const api = useDockviewStore((s) => s.api);
+  const isRestoringLayout = useDockviewStore((s) => s.isRestoringLayout);
+  const activeEnvKey = useActiveEnvironmentKey();
+  const countsByEnv = useAppStore(useShallow(selectChangesCountByEnvironment));
+  const previousCountsRef = useRef<Record<string, number>>({});
+  const pendingEnvKeysRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    markInactiveChangesCountIncreases({
+      countsByEnv,
+      activeEnvKey,
+      previousCounts: previousCountsRef.current,
+      pendingEnvKeys: pendingEnvKeysRef.current,
+    });
+
+    if (!activeEnvKey || isRestoringLayout) return;
+    if (!pendingEnvKeysRef.current.has(activeEnvKey)) return;
+
+    const result = activateChangesPanel(api);
+    if (result !== "no-api") pendingEnvKeysRef.current.delete(activeEnvKey);
+  }, [countsByEnv, activeEnvKey, api, isRestoringLayout]);
+}

--- a/apps/web/components/task/changes-tab.tsx
+++ b/apps/web/components/task/changes-tab.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  DockviewDefaultTab,
-  type DockviewApi,
-  type IDockviewPanelHeaderProps,
-} from "dockview-react";
+import { DockviewDefaultTab, type IDockviewPanelHeaderProps } from "dockview-react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -15,25 +11,9 @@ import {
 import { useAppStore } from "@/components/state-provider";
 import { useSessionGitStatus } from "@/hooks/domains/session/use-session-git-status";
 import { useSessionChangesCount } from "@/hooks/domains/session/use-session-changes-count";
-import { useDockviewStore } from "@/lib/state/dockview-store";
 import { cn } from "@kandev/ui/lib/utils";
 import { useTabMaximizeOnDoubleClick } from "./use-tab-maximize";
-
-type DockviewPanel = NonNullable<ReturnType<DockviewApi["getPanel"]>>;
-
-function groupContainsAgentSessionPanel(panel: DockviewPanel): boolean {
-  return panel.group.panels.some((p) => p.id === "chat" || p.id.startsWith("session:"));
-}
-
-/** Auto-activate the changes panel unless it shares a group with agent sessions. */
-function autoActivateChangesPanel(): void {
-  const { api } = useDockviewStore.getState();
-  if (!api) return;
-
-  const panel = api.getPanel("changes");
-  if (!panel || groupContainsAgentSessionPanel(panel)) return;
-  panel.api.setActive();
-}
+import { autoActivateChangesPanel } from "./changes-panel-focus";
 
 /**
  * Custom tab component for the Changes panel.

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -42,6 +42,7 @@ import { PassthroughToolbar } from "./passthrough-toolbar";
 import { PanelRoot, PanelBody } from "./panel-primitives";
 import { ContextMenuTab } from "./tab-context-menu";
 import { ChangesTab } from "./changes-tab";
+import { useChangesPanelAutoFocus } from "./changes-panel-focus";
 import { PlanTab } from "./plan-tab";
 import { PreviewFileTab, PreviewDiffTab, PreviewCommitTab, PinnedDefaultTab } from "./preview-tab";
 import { SessionTab } from "./session-tab";
@@ -601,6 +602,7 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
 
   // Auto-create a session tab when a session becomes active
   useAutoSessionTab(effectiveSessionId);
+  useChangesPanelAutoFocus();
 
   // Auto-show PR detail panel when the task has an associated PR
   useAutoPRPanel();

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -602,7 +602,7 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
 
   // Auto-create a session tab when a session becomes active
   useAutoSessionTab(effectiveSessionId);
-  useChangesPanelAutoFocus();
+  useChangesPanelAutoFocus(effectiveEnvId);
 
   // Auto-show PR detail panel when the task has an associated PR
   useAutoPRPanel();

--- a/apps/web/components/task/dockview-desktop-layout.tsx
+++ b/apps/web/components/task/dockview-desktop-layout.tsx
@@ -554,6 +554,7 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
   const effectiveEnvId = useAppStore((state) =>
     effectiveSessionId ? (state.environmentIdBySessionId[effectiveSessionId] ?? null) : null,
   );
+  const changesFocusKey = effectiveEnvId ?? effectiveSessionId;
   const envIdRef = useRef<string | null>(effectiveEnvId);
   const hasDevScript = Boolean(repository?.dev_script?.trim());
 
@@ -602,7 +603,7 @@ export const DockviewDesktopLayout = memo(function DockviewDesktopLayout({
 
   // Auto-create a session tab when a session becomes active
   useAutoSessionTab(effectiveSessionId);
-  useChangesPanelAutoFocus(effectiveEnvId);
+  useChangesPanelAutoFocus(changesFocusKey);
 
   // Auto-show PR detail panel when the task has an associated PR
   useAutoPRPanel();

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -57,6 +57,7 @@ async function changesCountForSession(testPage: Page, sessionId: string): Promis
     const hasCommits = envKey in state.sessionCommits.byEnvironmentId;
     if (!hasRepoStatuses && !hasCommits) return null;
     const repoStatuses = state.gitStatus.byEnvironmentRepo[envKey] ?? {};
+    // Keep this count in sync with selectChangesMarkerByEnvironment.
     let count = state.sessionCommits.byEnvironmentId[envKey]?.length ?? 0;
     for (const status of Object.values(repoStatuses)) {
       count += Object.keys(status.files ?? {}).length;

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -31,8 +31,8 @@ class GitHelper {
 }
 
 function changesTab(testPage: Page) {
-  return testPage.locator(".dv-tab", {
-    has: testPage.locator(".dv-default-tab").filter({ hasText: /^Changes/ }),
+  return testPage.locator(".dv-tab:visible", {
+    has: testPage.locator(".dv-default-tab:visible").filter({ hasText: /^Changes/ }),
   });
 }
 
@@ -53,8 +53,10 @@ async function changesCountForSession(testPage: Page, sessionId: string): Promis
     if (!store) throw new Error("E2E store bridge missing");
     const state = store.getState();
     const envKey = state.environmentIdBySessionId[sid] ?? sid;
-    const repoStatuses = state.gitStatus.byEnvironmentRepo[envKey];
-    if (!repoStatuses) return null;
+    const hasRepoStatuses = envKey in state.gitStatus.byEnvironmentRepo;
+    const hasCommits = envKey in state.sessionCommits.byEnvironmentId;
+    if (!hasRepoStatuses && !hasCommits) return null;
+    const repoStatuses = state.gitStatus.byEnvironmentRepo[envKey] ?? {};
     let count = state.sessionCommits.byEnvironmentId[envKey]?.length ?? 0;
     for (const status of Object.values(repoStatuses)) {
       count += Object.keys(status.files ?? {}).length;
@@ -374,6 +376,8 @@ test.describe("Changes panel focus behavior", () => {
     await expect
       .poll(() => changesCountForSession(testPage, taskB.session_id!), { timeout: 15_000 })
       .toBe(1);
+    await expect(session.activeChat()).toBeVisible();
+    await expect(changesTab(testPage)).not.toHaveClass(/dv-active-tab/);
 
     await session.taskInSidebar("Inactive Changes Focus B").click();
 

--- a/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
+++ b/apps/web/e2e/tests/layout/changes-panel-focus.spec.ts
@@ -36,6 +36,91 @@ function changesTab(testPage: Page) {
   });
 }
 
+async function changesCountForSession(testPage: Page, sessionId: string): Promise<number | null> {
+  return testPage.evaluate((sid) => {
+    type StoreWindow = Window & {
+      __KANDEV_E2E_STORE__?: {
+        getState: () => {
+          environmentIdBySessionId: Record<string, string>;
+          gitStatus: {
+            byEnvironmentRepo: Record<string, Record<string, { files?: Record<string, unknown> }>>;
+          };
+          sessionCommits: { byEnvironmentId: Record<string, unknown[]> };
+        };
+      };
+    };
+    const store = (window as StoreWindow).__KANDEV_E2E_STORE__;
+    if (!store) throw new Error("E2E store bridge missing");
+    const state = store.getState();
+    const envKey = state.environmentIdBySessionId[sid] ?? sid;
+    const repoStatuses = state.gitStatus.byEnvironmentRepo[envKey];
+    if (!repoStatuses) return null;
+    let count = state.sessionCommits.byEnvironmentId[envKey]?.length ?? 0;
+    for (const status of Object.values(repoStatuses)) {
+      count += Object.keys(status.files ?? {}).length;
+    }
+    return count;
+  }, sessionId);
+}
+
+async function setGitStatusForSession(testPage: Page, sessionId: string, changedFiles: string[]) {
+  await testPage.evaluate(
+    ({ sid, files }) => {
+      type FileInfo = {
+        path: string;
+        status: "modified" | "added" | "deleted" | "untracked" | "renamed";
+        staged: boolean;
+        additions?: number;
+        deletions?: number;
+      };
+      type StoreWindow = Window & {
+        __KANDEV_E2E_STORE__?: {
+          getState: () => {
+            setGitStatus: (
+              sessionId: string,
+              status: {
+                branch: string;
+                remote_branch: string | null;
+                modified: string[];
+                added: string[];
+                deleted: string[];
+                untracked: string[];
+                renamed: string[];
+                ahead: number;
+                behind: number;
+                files: Record<string, FileInfo>;
+                timestamp: string;
+              },
+            ) => boolean;
+          };
+        };
+      };
+      const store = (window as StoreWindow).__KANDEV_E2E_STORE__;
+      if (!store) throw new Error("E2E store bridge missing");
+      const fileMap = Object.fromEntries(
+        files.map((path): [string, FileInfo] => [
+          path,
+          { path, status: "untracked", staged: false, additions: 1, deletions: 0 },
+        ]),
+      );
+      store.getState().setGitStatus(sid, {
+        branch: "main",
+        remote_branch: null,
+        modified: [],
+        added: [],
+        deleted: [],
+        untracked: files,
+        renamed: [],
+        ahead: 0,
+        behind: 0,
+        files: fileMap,
+        timestamp: new Date().toISOString(),
+      });
+    },
+    { sid: sessionId, files: changedFiles },
+  );
+}
+
 async function moveChangesToTerminalGroupAndFocusTerminal(testPage: Page) {
   await testPage.evaluate(() => {
     type Group = { id: string };
@@ -240,5 +325,58 @@ test.describe("Changes panel focus behavior", () => {
 
     await expect(changesTab(testPage)).toHaveClass(/dv-active-tab/, { timeout: 5_000 });
     await expect(session.changesFileRow("second-change.txt")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("new git updates focus changes after switching to an inactive task", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(120_000);
+
+    const taskA = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Inactive Changes Focus A",
+      seedData.agentProfileId,
+      {
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    const taskB = await apiClient.createTaskWithAgent(
+      seedData.workspaceId,
+      "Inactive Changes Focus B",
+      seedData.agentProfileId,
+      {
+        workflow_id: seedData.workflowId,
+        workflow_step_id: seedData.startStepId,
+        repository_ids: [seedData.repositoryId],
+      },
+    );
+    if (!taskB.session_id) throw new Error("Task B did not start a session");
+
+    await testPage.goto(`/t/${taskA.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+    await session.waitForChatIdle({ timeout: 30_000 });
+    await session.waitForDockviewReady();
+
+    await expect(session.taskInSidebar("Inactive Changes Focus B")).toBeVisible({
+      timeout: 15_000,
+    });
+    await setGitStatusForSession(testPage, taskB.session_id, []);
+    await expect
+      .poll(() => changesCountForSession(testPage, taskB.session_id!), { timeout: 15_000 })
+      .toBe(0);
+
+    await setGitStatusForSession(testPage, taskB.session_id, ["background-change.txt"]);
+    await expect
+      .poll(() => changesCountForSession(testPage, taskB.session_id!), { timeout: 15_000 })
+      .toBe(1);
+
+    await session.taskInSidebar("Inactive Changes Focus B").click();
+
+    await expect(changesTab(testPage)).toHaveClass(/dv-active-tab/, { timeout: 5_000 });
   });
 });


### PR DESCRIPTION
The Changes panel could miss focus when a task received git updates while another task was active. Background env change counts are now queued and consumed when switching into that task, so the right sidebar focuses Changes only for genuinely new inactive-task updates.

## Important Changes

- Extracted Changes panel activation into a shared helper so active-task and background-task updates use the same dockview guard.
- Added environment-scoped pending focus state to preserve inactive-task updates until that task becomes active.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `rtk pnpm e2e:run --host tests/layout/changes-panel-focus.spec.ts`

## Possible Improvements

Low risk: this is desktop dockview-specific; mobile uses a separate Changes surface and was not changed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->