### PR TITLE
fix(ssh-executor): restore linux/arm64 + enforce signed darwin helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,9 @@ jobs:
         run: |
           cd apps/backend
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 CC= go build -ldflags "${LDFLAGS}" -o bin/agentctl-linux-amd64 ./cmd/agentctl
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 CC= go build -ldflags "${LDFLAGS}" -o bin/agentctl-linux-arm64 ./cmd/agentctl
+          # darwin/arm64 is ad-hoc-signed by the Go linker at link time, which is
+          # what Apple Silicon (AMFI) requires; bundle validation enforces it.
           GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 CC= go build -ldflags "${LDFLAGS}" -o bin/agentctl-darwin-arm64 ./cmd/agentctl
           GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 CC= go build -ldflags "${LDFLAGS}" -o bin/agentctl-darwin-amd64 ./cmd/agentctl
 
@@ -432,6 +435,7 @@ jobs:
           cp apps/backend/bin/kandev${EXT} dist/kandev/bin/
           cp apps/backend/bin/agentctl${EXT} dist/kandev/bin/
           cp apps/backend/bin/agentctl-linux-amd64 dist/kandev/bin/
+          cp apps/backend/bin/agentctl-linux-arm64 dist/kandev/bin/
           cp apps/backend/bin/agentctl-darwin-arm64 dist/kandev/bin/
           cp apps/backend/bin/agentctl-darwin-amd64 dist/kandev/bin/
           cd dist

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -31,6 +31,7 @@ ifeq ($(OS),Windows_NT)
   # cmd has no Unix env-var-prefix syntax; `set X=Y&` chains `set` and the next
   # command in the same shell.
   GO_LINUX_AMD64 = set CGO_ENABLED=0& set GOOS=linux& set GOARCH=amd64&
+  GO_LINUX_ARM64 = set CGO_ENABLED=0& set GOOS=linux& set GOARCH=arm64&
   GO_DARWIN_ARM64 = set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=arm64&
   GO_DARWIN_AMD64 = set CGO_ENABLED=0& set GOOS=darwin& set GOARCH=amd64&
   EXE = .exe
@@ -40,6 +41,7 @@ else
   MKDIR = mkdir -p
   CGO_PREFIX = CGO_ENABLED=1
   GO_LINUX_AMD64 = CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  GO_LINUX_ARM64 = CGO_ENABLED=0 GOOS=linux GOARCH=arm64
   GO_DARWIN_ARM64 = CGO_ENABLED=0 GOOS=darwin GOARCH=arm64
   GO_DARWIN_AMD64 = CGO_ENABLED=0 GOOS=darwin GOARCH=amd64
   EXE =
@@ -52,7 +54,7 @@ BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || powershell -c
 
 LDFLAGS += -X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.BuildTime=$(BUILD_TIME)
 
-.PHONY: all build build-all build-agentctl build-agentctl-remote build-agentctl-linux build-agentctl-darwin-arm64 build-agentctl-darwin-amd64 build-acpdbg acpdbg build-mock-agent build-mock-agent-linux build-preview build-winjob clean run dev start-debug test test-e2e test-sprites-e2e test-lifecycle-goleak lint fmt vet help
+.PHONY: all build build-all build-agentctl build-agentctl-remote build-agentctl-linux build-agentctl-linux-arm64 build-agentctl-darwin-arm64 build-agentctl-darwin-amd64 build-acpdbg acpdbg build-mock-agent build-mock-agent-linux build-preview build-winjob clean run dev start-debug test test-e2e test-sprites-e2e test-lifecycle-goleak lint fmt vet help
 
 ## Default target
 all: build
@@ -108,7 +110,7 @@ build-agentctl:
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agentctl$(EXE) ./cmd/agentctl
 
 ## Build all remote agentctl helpers used by SSH/Docker/Sprites executors.
-build-agentctl-remote: build-agentctl-linux build-agentctl-darwin-arm64 build-agentctl-darwin-amd64
+build-agentctl-remote: build-agentctl-linux build-agentctl-linux-arm64 build-agentctl-darwin-arm64 build-agentctl-darwin-amd64
 
 ## Build agentctl for linux/amd64 (used by Docker/Sprites and Linux SSH hosts)
 build-agentctl-linux:
@@ -116,17 +118,40 @@ build-agentctl-linux:
 	-@$(MKDIR) $(BUILD_DIR)
 	$(GO_LINUX_AMD64) $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agentctl-linux-amd64 ./cmd/agentctl
 
+## Build agentctl for linux/arm64 (used by ARM Linux SSH hosts, e.g. Graviton)
+build-agentctl-linux-arm64:
+	@echo "Building agentctl for linux/arm64..."
+	-@$(MKDIR) $(BUILD_DIR)
+	$(GO_LINUX_ARM64) $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agentctl-linux-arm64 ./cmd/agentctl
+
+# Ad-hoc sign a darwin Mach-O so Apple Silicon (AMFI) will run it; ad-hoc needs
+# no Apple identity. Go already ad-hoc-signs darwin/arm64 at link time, so this
+# is mainly to (a) sign darwin/amd64 too and (b) re-sign uniformly. Prefer
+# codesign on macOS, fall back to rcodesign on Linux/CI. If neither is present,
+# warn but don't fail (darwin/arm64 stays Go-signed; darwin/amd64 runs on Intel).
+define adhoc_sign_darwin
+	@if command -v codesign >/dev/null 2>&1; then \
+		echo "  codesign --sign - $(1)"; codesign --force --sign - "$(1)"; \
+	elif command -v rcodesign >/dev/null 2>&1; then \
+		echo "  rcodesign sign (ad-hoc) $(1)"; rcodesign sign "$(1)"; \
+	else \
+		echo "  WARNING: no codesign/rcodesign found; $(1) left as-is (darwin/arm64 is Go-signed; darwin/amd64 runs only on Intel Macs)" >&2; \
+	fi
+endef
+
 ## Build agentctl for darwin/arm64 (used by Apple Silicon SSH hosts)
 build-agentctl-darwin-arm64:
 	@echo "Building agentctl for darwin/arm64..."
 	-@$(MKDIR) $(BUILD_DIR)
 	$(GO_DARWIN_ARM64) $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agentctl-darwin-arm64 ./cmd/agentctl
+	$(call adhoc_sign_darwin,$(BUILD_DIR)/agentctl-darwin-arm64)
 
 ## Build agentctl for darwin/amd64 (used by Intel Mac SSH hosts)
 build-agentctl-darwin-amd64:
 	@echo "Building agentctl for darwin/amd64..."
 	-@$(MKDIR) $(BUILD_DIR)
 	$(GO_DARWIN_AMD64) $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/agentctl-darwin-amd64 ./cmd/agentctl
+	$(call adhoc_sign_darwin,$(BUILD_DIR)/agentctl-darwin-amd64)
 
 ## Build mock-agent for linux/amd64 (used by Docker E2E tests)
 build-mock-agent-linux:

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_connection_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_connection_test.go
@@ -142,7 +142,7 @@ func TestNormalizeSSHRemotePlatform(t *testing.T) {
 		{"linux amd64", "Linux", "x86_64", "linux", "amd64", true},
 		{"darwin arm64", "Darwin", "arm64", "darwin", "arm64", true},
 		{"darwin amd64", "Darwin", "x86_64", "darwin", "amd64", true},
-		{"linux arm64 currently unsupported", "Linux", "aarch64", "linux", "arm64", false},
+		{"linux arm64", "Linux", "aarch64", "linux", "arm64", true},
 		{"freebsd amd64 unsupported", "FreeBSD", "x86_64", "", "amd64", false},
 	}
 	for _, tc := range cases {
@@ -162,6 +162,7 @@ func TestNormalizeSSHRemotePlatform(t *testing.T) {
 func TestRequireSupportedRemotePlatform(t *testing.T) {
 	for _, platform := range []SSHRemotePlatform{
 		{GOOS: "linux", GOARCH: "amd64", UnameOS: "Linux", UnameArch: "x86_64"},
+		{GOOS: "linux", GOARCH: "arm64", UnameOS: "Linux", UnameArch: "aarch64"},
 		{GOOS: "darwin", GOARCH: "arm64", UnameOS: "Darwin", UnameArch: "arm64"},
 		{GOOS: "darwin", GOARCH: "amd64", UnameOS: "Darwin", UnameArch: "x86_64"},
 	} {
@@ -169,12 +170,12 @@ func TestRequireSupportedRemotePlatform(t *testing.T) {
 			t.Errorf("%s should be supported, got %v", platform.String(), err)
 		}
 	}
-	unsupported := SSHRemotePlatform{GOOS: "linux", GOARCH: "arm64", UnameOS: "Linux", UnameArch: "aarch64"}
+	unsupported := SSHRemotePlatform{GOOS: "", GOARCH: "amd64", UnameOS: "FreeBSD", UnameArch: "x86_64"}
 	err := requireSupportedRemotePlatform(unsupported)
 	if err == nil {
-		t.Fatal("linux/arm64 should not be supported yet")
+		t.Fatal("freebsd/amd64 should not be supported")
 	}
-	for _, want := range []string{"linux/arm64", "linux/amd64", "darwin/arm64", "darwin/amd64"} {
+	for _, want := range []string{"unsupported remote platform", "linux/{amd64,arm64}", "darwin/{amd64,arm64}", "FreeBSD"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q missing %q", err.Error(), want)
 		}

--- a/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/executor_ssh_operations.go
@@ -204,6 +204,7 @@ func normalizeSSHRemoteArch(arch string) string {
 func requireSupportedRemotePlatform(platform SSHRemotePlatform) error {
 	switch platform.String() {
 	case sshRemoteGOOSLinux + "/" + sshRemoteGOARCHAMD64,
+		sshRemoteGOOSLinux + "/" + sshRemoteGOARCHARM64,
 		sshRemoteGOOSDarwin + "/" + sshRemoteGOARCHARM64,
 		sshRemoteGOOSDarwin + "/" + sshRemoteGOARCHAMD64:
 		return nil
@@ -213,7 +214,7 @@ func requireSupportedRemotePlatform(platform SSHRemotePlatform) error {
 			reported = fmt.Sprintf("%s/%s", platform.UnameOS, platform.UnameArch)
 		}
 		return fmt.Errorf(
-			"unsupported remote platform %q — SSH executor supports linux/amd64, darwin/arm64, and darwin/amd64",
+			"unsupported remote platform %q — SSH executor supports linux/{amd64,arm64} and darwin/{amd64,arm64}",
 			reported,
 		)
 	}

--- a/apps/backend/internal/launcher/bundle.go
+++ b/apps/backend/internal/launcher/bundle.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,11 +16,19 @@ type runtimeBundle struct {
 type agentctlRemoteHelper struct {
 	Name  string
 	Label string
+	// MustBeSigned requires the Mach-O helper to carry an ad-hoc (or real) code
+	// signature. Apple Silicon (AMFI) SIGKILLs unsigned darwin/arm64 binaries on
+	// launch, so an unsigned arm64 helper would fail on every Mac it's uploaded
+	// to — catch that at bundle-validation time, not at remote-launch time.
+	// darwin/amd64 is intentionally exempt: Intel macOS does not enforce code
+	// signing at exec, and Go's linker does not ad-hoc-sign amd64 cross-builds.
+	MustBeSigned bool
 }
 
 var requiredAgentctlRemoteHelpers = []agentctlRemoteHelper{
 	{Name: "agentctl-linux-amd64", Label: "agentctl linux/amd64 helper"},
-	{Name: "agentctl-darwin-arm64", Label: "agentctl darwin/arm64 helper"},
+	{Name: "agentctl-linux-arm64", Label: "agentctl linux/arm64 helper"},
+	{Name: "agentctl-darwin-arm64", Label: "agentctl darwin/arm64 helper", MustBeSigned: true},
 	{Name: "agentctl-darwin-amd64", Label: "agentctl darwin/amd64 helper"},
 }
 
@@ -45,8 +54,53 @@ func validateRuntimeBundle(dir, source string) (runtimeBundle, error) {
 		if !exists(path) {
 			return runtimeBundle{}, fmt.Errorf("%s not found in bundle at %s", helper.Label, path)
 		}
+		if helper.MustBeSigned {
+			if signed, ok := machoHasCodeSignature(path); ok && !signed {
+				return runtimeBundle{}, fmt.Errorf(
+					"%s at %s is not code-signed; Apple Silicon will refuse to run it "+
+						"(build it via 'make -C apps/backend build-agentctl-remote', which ad-hoc-signs darwin helpers)",
+					helper.Label, path)
+			}
+		}
 	}
 	return runtimeBundle{Dir: dir, Launcher: launcher, Source: source}, nil
+}
+
+// machoHasCodeSignature reports whether a thin 64-bit Mach-O carries an
+// LC_CODE_SIGNATURE load command. The second return is false when the file
+// can't be parsed as a thin Mach-O (e.g. unexpected format) so callers can
+// treat "undeterminable" as non-fatal rather than failing on a parse quirk.
+func machoHasCodeSignature(path string) (signed bool, ok bool) {
+	const (
+		machoMagic64LE     = 0xfeedfacf // MH_MAGIC_64, written little-endian on disk
+		lcCodeSignature    = 0x1d       // LC_CODE_SIGNATURE
+		machoHeaderSize64  = 32
+		loadCommandHdrSize = 8
+	)
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) < machoHeaderSize64 {
+		return false, false
+	}
+	if binary.LittleEndian.Uint32(data[0:4]) != machoMagic64LE {
+		return false, false // not a thin LE 64-bit Mach-O (fat/other) — don't judge
+	}
+	ncmds := binary.LittleEndian.Uint32(data[16:20])
+	off := machoHeaderSize64
+	for i := uint32(0); i < ncmds; i++ {
+		if off+loadCommandHdrSize > len(data) {
+			return false, false // truncated load-command table
+		}
+		cmd := binary.LittleEndian.Uint32(data[off : off+4])
+		cmdSize := binary.LittleEndian.Uint32(data[off+4 : off+8])
+		if cmd == lcCodeSignature {
+			return true, true
+		}
+		if cmdSize < loadCommandHdrSize {
+			return false, false // malformed
+		}
+		off += int(cmdSize)
+	}
+	return false, true
 }
 
 func executableName(name string) string {

--- a/apps/backend/internal/launcher/bundle_test.go
+++ b/apps/backend/internal/launcher/bundle_test.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,7 @@ func TestValidateRuntimeBundleRejectsMissingRemoteHelper(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "bin", "kandev"))
 	writeFile(t, filepath.Join(dir, "bin", "agentctl"))
 	writeFile(t, filepath.Join(dir, "bin", "agentctl-linux-amd64"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl-linux-arm64"))
 	writeFile(t, filepath.Join(dir, "bin", "agentctl-darwin-amd64"))
 
 	_, err := validateRuntimeBundle(dir, "test")
@@ -47,6 +49,86 @@ func TestValidateRuntimeBundleRejectsMissingRemoteHelper(t *testing.T) {
 	}
 }
 
+func TestValidateRuntimeBundleRejectsUnsignedDarwinArm64(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bin", "kandev"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl-linux-amd64"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl-linux-arm64"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl-darwin-amd64"))
+	// A real-shaped but unsigned Mach-O must be rejected for darwin/arm64.
+	writeMachO(t, filepath.Join(dir, "bin", "agentctl-darwin-arm64"), false)
+
+	_, err := validateRuntimeBundle(dir, "test")
+	if err == nil {
+		t.Fatal("expected error for unsigned darwin/arm64 helper")
+	}
+	if got, want := err.Error(), "not code-signed"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want substring %q", got, want)
+	}
+}
+
+func TestValidateRuntimeBundleAcceptsSignedDarwinArm64(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bin", "kandev"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl-linux-amd64"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl-linux-arm64"))
+	writeFile(t, filepath.Join(dir, "bin", "agentctl-darwin-amd64"))
+	writeMachO(t, filepath.Join(dir, "bin", "agentctl-darwin-arm64"), true)
+
+	if _, err := validateRuntimeBundle(dir, "test"); err != nil {
+		t.Fatalf("unexpected error for signed darwin/arm64 helper: %v", err)
+	}
+}
+
+func TestMachoHasCodeSignature(t *testing.T) {
+	dir := t.TempDir()
+	signed := filepath.Join(dir, "signed")
+	unsigned := filepath.Join(dir, "unsigned")
+	writeMachO(t, signed, true)
+	writeMachO(t, unsigned, false)
+
+	if got, ok := machoHasCodeSignature(signed); !ok || !got {
+		t.Fatalf("signed: got=%v ok=%v, want true true", got, ok)
+	}
+	if got, ok := machoHasCodeSignature(unsigned); !ok || got {
+		t.Fatalf("unsigned: got=%v ok=%v, want false true", got, ok)
+	}
+	// A non-Mach-O (e.g. an ELF or stub) must be reported as undeterminable.
+	if _, ok := machoHasCodeSignature(filepath.Join(dir, "missing")); ok {
+		t.Fatal("missing file: ok=true, want false")
+	}
+}
+
+// writeMachO writes a minimal thin LE 64-bit Mach-O with a single load command
+// that is either LC_CODE_SIGNATURE (signed) or LC_UUID (unsigned).
+func writeMachO(t *testing.T, path string, signed bool) {
+	t.Helper()
+	const (
+		magic64LE       = 0xfeedfacf
+		lcCodeSignature = 0x1d
+		lcUUID          = 0x1b
+		hdrSize         = 32
+		lcSize          = 16
+	)
+	buf := make([]byte, hdrSize+lcSize)
+	binary.LittleEndian.PutUint32(buf[0:4], magic64LE)
+	binary.LittleEndian.PutUint32(buf[16:20], 1) // ncmds = 1
+	cmd := uint32(lcUUID)
+	if signed {
+		cmd = lcCodeSignature
+	}
+	binary.LittleEndian.PutUint32(buf[hdrSize:hdrSize+4], cmd)
+	binary.LittleEndian.PutUint32(buf[hdrSize+4:hdrSize+8], lcSize)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRequiredAgentctlRemoteHelpers(t *testing.T) {
 	got := make([]string, 0, len(requiredAgentctlRemoteHelpers))
 	for _, helper := range requiredAgentctlRemoteHelpers {
@@ -54,6 +136,7 @@ func TestRequiredAgentctlRemoteHelpers(t *testing.T) {
 	}
 	want := []string{
 		"agentctl-linux-amd64",
+		"agentctl-linux-arm64",
 		"agentctl-darwin-arm64",
 		"agentctl-darwin-amd64",
 	}

--- a/apps/desktop/e2e/desktop-launch-smoke.mjs
+++ b/apps/desktop/e2e/desktop-launch-smoke.mjs
@@ -76,6 +76,7 @@ async function writeFakeRuntime(runtimeDir, stateDir) {
   const agentctl = join(runtimeDir, "bin", process.platform === "win32" ? "agentctl.cmd" : "agentctl");
   const remoteHelpers = [
     ["agentctl-linux-amd64", "linux/amd64"],
+    ["agentctl-linux-arm64", "linux/arm64"],
     ["agentctl-darwin-arm64", "darwin/arm64"],
     ["agentctl-darwin-amd64", "darwin/amd64"],
   ];

--- a/apps/desktop/src-tauri/src/backend.rs
+++ b/apps/desktop/src-tauri/src/backend.rs
@@ -25,8 +25,9 @@ const DESKTOP_HEALTH_TOKEN_ENV: &str = "KANDEV_DESKTOP_HEALTH_TOKEN";
 const DESKTOP_HEALTH_TOKEN_HEADER: &str = "x-kandev-desktop-health-token";
 const STARTUP_OUTPUT_LIMIT: usize = 12 * 1024;
 const HEALTH_READY_SETTLE: Duration = Duration::from_millis(100);
-const REMOTE_AGENTCTL_HELPERS: [(&str, &str); 3] = [
+const REMOTE_AGENTCTL_HELPERS: [(&str, &str); 4] = [
     ("agentctl-linux-amd64", "agentctl linux/amd64 helper"),
+    ("agentctl-linux-arm64", "agentctl linux/arm64 helper"),
     ("agentctl-darwin-arm64", "agentctl darwin/arm64 helper"),
     ("agentctl-darwin-amd64", "agentctl darwin/amd64 helper"),
 ];
@@ -728,6 +729,7 @@ mod tests {
         fs::write(bin.join(executable_name("kandev")), b"stub").expect("write launcher");
         fs::write(bin.join(executable_name("agentctl")), b"stub").expect("write agentctl");
         fs::write(bin.join("agentctl-linux-amd64"), b"stub").expect("write linux helper");
+        fs::write(bin.join("agentctl-linux-arm64"), b"stub").expect("write linux arm64 helper");
         fs::write(bin.join("agentctl-darwin-amd64"), b"stub").expect("write darwin amd64 helper");
 
         let err =

--- a/docs/specs/ssh-executor/spec.md
+++ b/docs/specs/ssh-executor/spec.md
@@ -81,8 +81,8 @@ Multiple sessions in the *same* task share the same worktree on disk (same files
 ### agentctl binary upload with content-hash cache
 
 - On `CreateInstance`, detect the remote platform via `uname -s` and `uname -m`, normalize it to a Go `GOOS/GOARCH` tuple, and resolve the matching agentctl helper via `AgentctlResolver`.
-- Supported remote platforms are `linux/amd64`, `darwin/arm64`, and `darwin/amd64`. Unsupported platforms fail with a clear error: `unsupported remote platform "<platform>" — SSH executor supports linux/amd64, darwin/arm64, and darwin/amd64`.
-- Runtime bundles include `agentctl-linux-amd64`, `agentctl-darwin-arm64`, and `agentctl-darwin-amd64`; development builds produce them with `make -C apps/backend build-agentctl-remote`.
+- Supported remote platforms are `linux/amd64`, `linux/arm64`, `darwin/arm64`, and `darwin/amd64`. Unsupported platforms fail with a clear error: `unsupported remote platform "<platform>" — SSH executor supports linux/{amd64,arm64} and darwin/{amd64,arm64}`.
+- Runtime bundles include `agentctl-linux-amd64`, `agentctl-linux-arm64`, `agentctl-darwin-arm64`, and `agentctl-darwin-amd64`; development builds produce them with `make -C apps/backend build-agentctl-remote`. The darwin helpers are ad-hoc-signed (Go signs darwin/arm64 at link time; `make` re-signs both via `codesign`/`rcodesign`); bundle validation rejects an unsigned `agentctl-darwin-arm64` because Apple Silicon refuses to run it.
 - Compute SHA256 locally; check `~/.kandev/bin/agentctl.sha256` on the remote via `sha256sum`. Upload only if missing or mismatched.
 - Upload via SFTP to `~/.kandev/bin/agentctl` (chmod 755), then write the sha256 sidecar.
 - Binary is shared across all tasks and sessions on the host.

--- a/scripts/release-desktop.test.sh
+++ b/scripts/release-desktop.test.sh
@@ -21,6 +21,7 @@ SIGNING_SECRET_ENV=(
 )
 REMOTE_AGENTCTL_HELPERS=(
   agentctl-linux-amd64
+  agentctl-linux-arm64
   agentctl-darwin-arm64
   agentctl-darwin-amd64
 )

--- a/scripts/release/package-bundle.sh
+++ b/scripts/release/package-bundle.sh
@@ -10,6 +10,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BUNDLE="$ROOT_DIR/dist/kandev"
 REMOTE_AGENTCTL_HELPERS=(
   agentctl-linux-amd64
+  agentctl-linux-arm64
   agentctl-darwin-arm64
   agentctl-darwin-amd64
 )

--- a/scripts/release/prepare-desktop-runtime.sh
+++ b/scripts/release/prepare-desktop-runtime.sh
@@ -12,6 +12,7 @@ runtime bundle. The input bundle must contain:
   bin/kandev[.exe]
   bin/agentctl[.exe]
   bin/agentctl-linux-amd64
+  bin/agentctl-linux-arm64
   bin/agentctl-darwin-arm64
   bin/agentctl-darwin-amd64
 
@@ -31,6 +32,7 @@ VERIFY_SCRIPT="${ROOT_DIR}/scripts/release/verify-desktop-runtime.sh"
 PLATFORM=""
 REMOTE_AGENTCTL_HELPERS=(
   agentctl-linux-amd64
+  agentctl-linux-arm64
   agentctl-darwin-arm64
   agentctl-darwin-amd64
 )

--- a/scripts/release/verify-desktop-runtime.sh
+++ b/scripts/release/verify-desktop-runtime.sh
@@ -13,6 +13,7 @@ Validate a desktop runtime directory with this layout:
       kandev[.exe]
       agentctl[.exe]
       agentctl-linux-amd64
+      agentctl-linux-arm64
       agentctl-darwin-arm64
       agentctl-darwin-amd64
 
@@ -26,6 +27,7 @@ RUNTIME_DIR_SET=false
 PLATFORM=""
 REMOTE_AGENTCTL_HELPERS=(
   "agentctl-linux-amd64:agentctl linux/amd64 helper"
+  "agentctl-linux-arm64:agentctl linux/arm64 helper"
   "agentctl-darwin-arm64:agentctl darwin/arm64 helper"
   "agentctl-darwin-amd64:agentctl darwin/amd64 helper"
 )
@@ -68,7 +70,7 @@ is_executable_file() {
   # MSYS/Git Bash can report Windows executables differently from Unix mode bits.
   if [ "${OS:-}" = "Windows_NT" ]; then
     case "$(basename "$path")" in
-      *.exe|agentctl-linux-amd64|agentctl-darwin-arm64|agentctl-darwin-amd64) return 0 ;;
+      *.exe|agentctl-linux-amd64|agentctl-linux-arm64|agentctl-darwin-arm64|agentctl-darwin-amd64) return 0 ;;
     esac
   fi
   return 1


### PR DESCRIPTION
Follow-ups to #1534 (remote macOS SSH hosts). Stacks onto that branch — please merge into it (or cherry-pick) before #1534 lands.

## What & why

**1. Restore `linux/arm64` SSH-host support (regression).** #1534's platform gate allows only `linux/amd64`, `darwin/arm64`, `darwin/amd64`, dropping `linux/arm64` that the predecessor branch supported. ARM Linux remotes (Graviton, etc.) now fail with *"unsupported remote platform linux/arm64"*. This re-adds it consistently across every place the helper list lives:
- platform gate (`requireSupportedRemotePlatform`)
- `build-agentctl-linux-arm64` Make target + `build-agentctl-remote`
- release.yml build + copy steps
- `requiredAgentctlRemoteHelpers` (runtime bundle validation)
- desktop runtime validators: `backend.rs`, `verify-/prepare-desktop-runtime.sh`, `desktop-launch-smoke.mjs`, `release-desktop.test.sh`

**2. Re-add ad-hoc signing of the darwin helpers in `make`.** Go's linker ad-hoc-signs `darwin/arm64` at link time (so it runs on Apple Silicon), but **not** `darwin/amd64`. The Makefile now ad-hoc-signs both via `codesign` (macOS) or `rcodesign` (Linux/CI), warning if neither is present. Keeps the chain uniform and notarization-ready.

**3. Enforce a signed `agentctl-darwin-arm64` at bundle-validation time.** An unsigned darwin/arm64 binary is SIGKILLed by Apple Silicon (AMFI) on launch — i.e. it would fail on *every* Mac it's uploaded to. Bundle validation now scans for `LC_CODE_SIGNATURE` and fails fast at packaging instead. `darwin/amd64` is intentionally exempt (Intel doesn't enforce signing; Go doesn't sign amd64 cross-builds).

## Verification
- `go build ./...`, `go vet`, `go test ./internal/agent/runtime/lifecycle ./internal/launcher ./internal/ssh ./internal/system/metrics` — all green (added tests for the signature scanner + signed/unsigned bundle cases; updated the gate tests for linux/arm64).
- `bash scripts/release-desktop.test.sh` — all PASS.
- **Live SSH run to a real Apple Silicon Mac** (macOS 26.5.1): rcodesign-signed `agentctl-darwin-arm64` uploaded to `~/.kandev/bin/agentctl`, launched natively, `HTTP server bound successfully`, reachable over the SSH port-forward — no SIGKILL.

> Note: I empirically confirmed Go auto-signs darwin/arm64 cross-builds from Linux but leaves darwin/amd64 unsigned, which is why the bundle check targets arm64 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

