### PR TITLE
fix: trigger workflow on agent task messages

### DIFF
--- a/apps/backend/internal/events/types.go
+++ b/apps/backend/internal/events/types.go
@@ -47,6 +47,7 @@ const (
 const (
 	MessageAdded   = "message.added"
 	MessageUpdated = "message.updated"
+	MessageDeleted = "message.deleted"
 )
 
 // Event types for message queue

--- a/apps/backend/internal/gateway/websocket/task_notifications.go
+++ b/apps/backend/internal/gateway/websocket/task_notifications.go
@@ -66,6 +66,7 @@ func RegisterTaskNotifications(ctx context.Context, eventBus bus.EventBus, hub *
 	b.subscribe(eventBus, events.TaskSessionStateChanged, ws.ActionSessionStateChanged)
 	b.subscribe(eventBus, events.MessageAdded, ws.ActionSessionMessageAdded)
 	b.subscribe(eventBus, events.MessageUpdated, ws.ActionSessionMessageUpdated)
+	b.subscribe(eventBus, events.MessageDeleted, ws.ActionSessionMessageDeleted)
 	b.subscribe(eventBus, events.AgentctlStarting, ws.ActionSessionAgentctlStarting)
 	b.subscribe(eventBus, events.AgentctlReady, ws.ActionSessionAgentctlReady)
 	b.subscribe(eventBus, events.AgentctlError, ws.ActionSessionAgentctlError)
@@ -131,7 +132,7 @@ func (b *TaskEventBroadcaster) subscribe(eventBus bus.EventBus, subject, action 
 			// session state changes for all tasks, not just the active one.
 			b.hub.Broadcast(msg)
 			return nil
-		case ws.ActionSessionMessageAdded, ws.ActionSessionMessageUpdated:
+		case ws.ActionSessionMessageAdded, ws.ActionSessionMessageUpdated, ws.ActionSessionMessageDeleted:
 			if sessionID != "" {
 				b.hub.BroadcastToSession(sessionID, msg)
 				return nil

--- a/apps/backend/internal/gateway/websocket/task_notifications_test.go
+++ b/apps/backend/internal/gateway/websocket/task_notifications_test.go
@@ -39,7 +39,7 @@ func TestTaskEventBroadcaster_NoDuplicateSubscriptions(t *testing.T) {
 	//
 	// Update this number when adding or removing event subscriptions in
 	// RegisterTaskNotifications — it is intentionally exact.
-	const wantSubscriptions = 50
+	const wantSubscriptions = 51
 	if got := len(b.subscriptions); got != wantSubscriptions {
 		t.Errorf("RegisterTaskNotifications created %d subscriptions, want %d — "+
 			"did an event get subscribed twice?", got, wantSubscriptions)

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1639,16 +1639,22 @@ type taskMessageReviewRollback struct {
 	sessions       []taskMessageSessionRollback
 	sessionIDs     map[string]struct{}
 	selectedID     string
+	queues         map[string]taskMessageQueueRollback
 }
 
 type taskMessageSessionRollback struct {
-	sessionID      string
-	state          models.TaskSessionState
-	error          string
-	completedAt    *time.Time
-	isPrimary      bool
-	hadPendingStep bool
-	pendingStep    interface{}
+	sessionID   string
+	state       models.TaskSessionState
+	error       string
+	completedAt *time.Time
+	isPrimary   bool
+	metadata    map[string]interface{}
+}
+
+type taskMessageQueueRollback struct {
+	entries        []messagequeue.QueuedMessage
+	hadPendingMove bool
+	pendingMove    *messagequeue.PendingMove
 }
 
 type taskMessageSessionRollbackRepository interface {
@@ -1657,7 +1663,7 @@ type taskMessageSessionRollbackRepository interface {
 	UpdateTaskSession(ctx context.Context, session *models.TaskSession) error
 	SetSessionPrimary(ctx context.Context, sessionID string) error
 	DeleteTaskSession(ctx context.Context, id string) error
-	SetSessionMetadataKey(ctx context.Context, sessionID, key string, value interface{}) error
+	UpdateSessionMetadata(ctx context.Context, sessionID string, metadata map[string]interface{}) error
 }
 
 type taskMessageExecutorReader interface {
@@ -1690,6 +1696,24 @@ func (r *taskMessageReviewRollback) captureSessions(ctx context.Context, repo Se
 	return nil
 }
 
+func (r *taskMessageReviewRollback) captureQueues(ctx context.Context, queue *messagequeue.Service) {
+	if !r.changed || queue == nil || len(r.sessions) == 0 {
+		return
+	}
+	r.queues = make(map[string]taskMessageQueueRollback, len(r.sessions))
+	for _, session := range r.sessions {
+		status := queue.GetStatus(ctx, session.sessionID)
+		snapshot := taskMessageQueueRollback{
+			entries: cloneTaskMessageQueuedMessages(status.Entries),
+		}
+		if move, ok := queue.GetPendingMove(ctx, session.sessionID); ok {
+			snapshot.hadPendingMove = true
+			snapshot.pendingMove = cloneTaskMessagePendingMove(move)
+		}
+		r.queues[session.sessionID] = snapshot
+	}
+}
+
 func (r *taskMessageReviewRollback) captureSelectedSession(session *models.TaskSession) {
 	if !r.changed || session == nil {
 		return
@@ -1711,12 +1735,20 @@ func captureTaskMessageSession(session *models.TaskSession) taskMessageSessionRo
 		isPrimary:   session.IsPrimary,
 	}
 	if session.Metadata != nil {
-		if pendingStep, ok := session.Metadata[models.SessionMetaKeyPendingStepCompletion]; ok {
-			snapshot.hadPendingStep = true
-			snapshot.pendingStep = cloneTaskMessageMetadataValue(pendingStep)
-		}
+		snapshot.metadata = cloneTaskMessageMetadataMap(session.Metadata)
 	}
 	return snapshot
+}
+
+func cloneTaskMessageMetadataMap(metadata map[string]interface{}) map[string]interface{} {
+	if metadata == nil {
+		return nil
+	}
+	cloned := make(map[string]interface{}, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = cloneTaskMessageMetadataValue(value)
+	}
+	return cloned
 }
 
 func cloneTaskMessageMetadataValue(value interface{}) interface{} {
@@ -1729,6 +1761,28 @@ func cloneTaskMessageMetadataValue(value interface{}) interface{} {
 		return value
 	}
 	return cloned
+}
+
+func cloneTaskMessageQueuedMessages(entries []messagequeue.QueuedMessage) []messagequeue.QueuedMessage {
+	if len(entries) == 0 {
+		return nil
+	}
+	cloned := make([]messagequeue.QueuedMessage, 0, len(entries))
+	for _, entry := range entries {
+		copy := entry
+		copy.Metadata = cloneTaskMessageMetadataMap(entry.Metadata)
+		copy.Attachments = append([]messagequeue.MessageAttachment(nil), entry.Attachments...)
+		cloned = append(cloned, copy)
+	}
+	return cloned
+}
+
+func cloneTaskMessagePendingMove(move *messagequeue.PendingMove) *messagequeue.PendingMove {
+	if move == nil {
+		return nil
+	}
+	copy := *move
+	return &copy
 }
 
 // dispatchTaskMessage routes a message to the right delivery path based on session state.
@@ -1759,6 +1813,7 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
 			return taskMessageDispatchResult{}, err
 		}
+		reviewRollback.captureQueues(ctx, h.sessionLauncher.GetMessageQueue())
 		session, err := h.prepareSessionForTaskMessage(ctx, taskID, session)
 		if err != nil {
 			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
@@ -1923,6 +1978,9 @@ func (h *Handlers) restoreTaskMessageSessions(ctx context.Context, rollback task
 			return err
 		}
 	}
+	if err := h.restoreTaskMessageQueues(ctx, rollback); err != nil {
+		return err
+	}
 	return h.restoreSelectedTaskMessageSession(ctx, repo, rollback)
 }
 
@@ -1931,15 +1989,11 @@ func (h *Handlers) restoreSelectedTaskMessageSession(ctx context.Context, repo t
 		return nil
 	}
 	primaryID := rollback.primarySessionID()
-	if primaryID != "" && rollback.selectedID != primaryID {
-		if queue := h.sessionLauncher.GetMessageQueue(); queue != nil {
-			if err := queue.TransferSession(ctx, rollback.selectedID, primaryID); err != nil {
-				return err
-			}
-		}
-	}
 	if _, ok := rollback.sessionIDs[rollback.selectedID]; ok {
 		return nil
+	}
+	if primaryID != "" && rollback.selectedID != primaryID {
+		h.clearTaskMessageQueue(ctx, rollback.selectedID)
 	}
 	return repo.DeleteTaskSession(ctx, rollback.selectedID)
 }
@@ -1951,6 +2005,61 @@ func (r taskMessageReviewRollback) primarySessionID() string {
 		}
 	}
 	return ""
+}
+
+func (h *Handlers) restoreTaskMessageQueues(ctx context.Context, rollback taskMessageReviewRollback) error {
+	if len(rollback.queues) == 0 {
+		return nil
+	}
+	queue := h.sessionLauncher.GetMessageQueue()
+	if queue == nil {
+		return nil
+	}
+	for sessionID, snapshot := range rollback.queues {
+		if err := h.restoreTaskMessageQueue(ctx, queue, sessionID, snapshot); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *Handlers) restoreTaskMessageQueue(ctx context.Context, queue *messagequeue.Service, sessionID string, snapshot taskMessageQueueRollback) error {
+	if _, err := queue.CancelAll(ctx, sessionID); err != nil {
+		return err
+	}
+	_, _ = queue.TakePendingMove(ctx, sessionID)
+	for _, entry := range snapshot.entries {
+		if _, err := queue.QueueMessageWithMetadata(
+			ctx,
+			sessionID,
+			entry.TaskID,
+			entry.Content,
+			entry.Model,
+			entry.QueuedBy,
+			entry.PlanMode,
+			entry.Attachments,
+			entry.Metadata,
+		); err != nil {
+			return err
+		}
+	}
+	if snapshot.hadPendingMove {
+		queue.SetPendingMove(ctx, sessionID, cloneTaskMessagePendingMove(snapshot.pendingMove))
+	}
+	return nil
+}
+
+func (h *Handlers) clearTaskMessageQueue(ctx context.Context, sessionID string) {
+	queue := h.sessionLauncher.GetMessageQueue()
+	if queue == nil {
+		return
+	}
+	if _, err := queue.CancelAll(ctx, sessionID); err != nil {
+		h.logger.Warn("failed to clear task message queue during rollback",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+	}
+	_, _ = queue.TakePendingMove(ctx, sessionID)
 }
 
 func restoreTaskMessageSessionSnapshot(ctx context.Context, repo taskMessageSessionRollbackRepository, rollback taskMessageSessionRollback) error {
@@ -1970,11 +2079,7 @@ func restoreTaskMessageSessionSnapshot(ctx context.Context, repo taskMessageSess
 			return err
 		}
 	}
-	pendingStep := interface{}(nil)
-	if rollback.hadPendingStep {
-		pendingStep = rollback.pendingStep
-	}
-	if err := repo.SetSessionMetadataKey(ctx, rollback.sessionID, models.SessionMetaKeyPendingStepCompletion, pendingStep); err != nil {
+	if err := repo.UpdateSessionMetadata(ctx, rollback.sessionID, cloneTaskMessageMetadataMap(rollback.metadata)); err != nil {
 		return err
 	}
 	return nil

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1923,22 +1923,25 @@ func (h *Handlers) restoreTaskMessageSessions(ctx context.Context, rollback task
 			return err
 		}
 	}
-	if rollback.selectedID != "" {
-		primaryID := rollback.primarySessionID()
-		if primaryID != "" && rollback.selectedID != primaryID {
-			if queue := h.sessionLauncher.GetMessageQueue(); queue != nil {
-				if err := queue.TransferSession(ctx, rollback.selectedID, primaryID); err != nil {
-					return err
-				}
-			}
-		}
-		if _, ok := rollback.sessionIDs[rollback.selectedID]; !ok {
-			if err := repo.DeleteTaskSession(ctx, rollback.selectedID); err != nil {
+	return h.restoreSelectedTaskMessageSession(ctx, repo, rollback)
+}
+
+func (h *Handlers) restoreSelectedTaskMessageSession(ctx context.Context, repo taskMessageSessionRollbackRepository, rollback taskMessageReviewRollback) error {
+	if rollback.selectedID == "" {
+		return nil
+	}
+	primaryID := rollback.primarySessionID()
+	if primaryID != "" && rollback.selectedID != primaryID {
+		if queue := h.sessionLauncher.GetMessageQueue(); queue != nil {
+			if err := queue.TransferSession(ctx, rollback.selectedID, primaryID); err != nil {
 				return err
 			}
 		}
 	}
-	return nil
+	if _, ok := rollback.sessionIDs[rollback.selectedID]; ok {
+		return nil
+	}
+	return repo.DeleteTaskSession(ctx, rollback.selectedID)
 }
 
 func (r taskMessageReviewRollback) primarySessionID() string {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1728,11 +1728,11 @@ func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID strin
 			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 			return taskMessageDispatchResult{status: "started", sessionID: session.ID}, nil
 		}
-		h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 		status, err := h.promptWithAutoResume(ctx, taskID, session.ID, prompt)
 		if err != nil {
 			return taskMessageDispatchResult{}, err
 		}
+		h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 		return taskMessageDispatchResult{status: status, sessionID: session.ID}, nil
 	}
 }

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1426,7 +1426,7 @@ func (h *Handlers) handleMessageTask(ctx context.Context, msg *ws.Message) (*ws.
 
 	wrappedPrompt, senderMeta := wrapAgentMessage(req.Prompt, senderTask, req.SenderSessionID)
 
-	status, err := h.dispatchTaskMessage(ctx, req.TaskID, session, wrappedPrompt, senderMeta)
+	result, err := h.dispatchTaskMessage(ctx, req.TaskID, session, wrappedPrompt, senderMeta)
 	if err != nil {
 		var qfErr *queueFullDispatchError
 		if errors.As(err, &qfErr) {
@@ -1439,8 +1439,8 @@ func (h *Handlers) handleMessageTask(ctx context.Context, msg *ws.Message) (*ws.
 
 	return ws.NewResponse(msg.ID, msg.Action, map[string]interface{}{
 		"task_id":    req.TaskID,
-		"session_id": session.ID,
-		"status":     status,
+		"session_id": result.sessionID,
+		"status":     result.status,
 	})
 }
 
@@ -1626,6 +1626,11 @@ const (
 	keyPosition         = "position"
 )
 
+type taskMessageDispatchResult struct {
+	status    string
+	sessionID string
+}
+
 // dispatchTaskMessage routes a message to the right delivery path based on session state.
 // Returns the action taken: "queued", "sent", or "started".
 //
@@ -1633,113 +1638,152 @@ const (
 // row (sender_task_id, sender_task_title, sender_session_id when called from
 // handleMessageTask). It is propagated to all three delivery paths so the
 // receiving task's chat displays the sender badge consistently.
-func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, prompt string, metadata map[string]interface{}) (string, error) {
+func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, prompt string, metadata map[string]interface{}) (taskMessageDispatchResult, error) {
 	if h.sessionLauncher == nil {
-		return "", errors.New("orchestrator not available")
+		return taskMessageDispatchResult{}, errors.New("orchestrator not available")
 	}
 
 	switch session.State {
 	case models.TaskSessionStateFailed, models.TaskSessionStateCancelled:
-		return "", fmt.Errorf("session is %s — cannot send message", session.State)
+		return taskMessageDispatchResult{}, fmt.Errorf("session is %s — cannot send message", session.State)
 
 	case models.TaskSessionStateRunning, models.TaskSessionStateStarting:
 		return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
 
 	default:
+		originalState := session.State
+		reviewStateChanged, err := h.ensureTaskInProgressForTaskMessage(ctx, taskID)
+		if err != nil {
+			return taskMessageDispatchResult{}, err
+		}
 		session, err := h.prepareSessionForTaskMessage(ctx, taskID, session)
 		if err != nil {
-			return "", err
+			if reviewStateChanged {
+				h.restoreTaskReviewForTaskMessage(ctx, taskID)
+			}
+			return taskMessageDispatchResult{}, err
 		}
-		switch session.State {
-		case models.TaskSessionStateFailed, models.TaskSessionStateCancelled:
-			return "", fmt.Errorf("session is %s — cannot send message", session.State)
-		case models.TaskSessionStateRunning, models.TaskSessionStateStarting:
-			return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
-		case models.TaskSessionStateCreated:
+		result, err := h.dispatchPreparedTaskMessage(ctx, taskID, session, originalState, prompt, metadata)
+		if err != nil && reviewStateChanged {
+			h.restoreTaskReviewForTaskMessage(ctx, taskID)
+		}
+		return result, err
+	}
+}
+
+func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, originalState models.TaskSessionState, prompt string, metadata map[string]interface{}) (taskMessageDispatchResult, error) {
+	switch session.State {
+	case models.TaskSessionStateFailed, models.TaskSessionStateCancelled:
+		return taskMessageDispatchResult{}, fmt.Errorf("session is %s — cannot send message", session.State)
+	case models.TaskSessionStateRunning, models.TaskSessionStateStarting:
+		return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
+	default:
+		if shouldStartTaskMessageSession(originalState, session) {
 			// Start first, then record the user message ourselves with sender
 			// metadata. This avoids leaving an orphaned attributed chat row when
 			// StartCreatedSession fails (the previous order wrote the row up-front
 			// regardless of launch outcome). skipMessageRecord=true keeps
 			// postLaunchCreated from writing its own duplicate row.
 			if _, err := h.sessionLauncher.StartCreatedSession(ctx, taskID, session.ID, session.AgentProfileID, prompt, true, false, true, nil); err != nil {
-				return "", fmt.Errorf("failed to start session: %w", err)
+				return taskMessageDispatchResult{}, fmt.Errorf("failed to start session: %w", err)
 			}
 			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
-			return "started", nil
-		default: // WAITING_FOR_INPUT, COMPLETED, IDLE, or any other promptable state
-			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
-			return h.promptWithAutoResume(ctx, taskID, session.ID, prompt)
+			return taskMessageDispatchResult{status: "started", sessionID: session.ID}, nil
 		}
+		h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
+		status, err := h.promptWithAutoResume(ctx, taskID, session.ID, prompt)
+		if err != nil {
+			return taskMessageDispatchResult{}, err
+		}
+		return taskMessageDispatchResult{status: status, sessionID: session.ID}, nil
 	}
 }
 
-func (h *Handlers) queueTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, prompt string, metadata map[string]interface{}) (string, error) {
+func shouldStartTaskMessageSession(originalState models.TaskSessionState, session *models.TaskSession) bool {
+	if session.State == models.TaskSessionStateCreated {
+		return true
+	}
+	return originalState == models.TaskSessionStateCreated &&
+		session.State == models.TaskSessionStateWaitingForInput &&
+		session.AgentExecutionID == ""
+}
+
+func (h *Handlers) queueTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, prompt string, metadata map[string]interface{}) (taskMessageDispatchResult, error) {
 	queue := h.sessionLauncher.GetMessageQueue()
 	if queue == nil {
-		return "", errors.New("message queue not available")
+		return taskMessageDispatchResult{}, errors.New("message queue not available")
 	}
 	if _, err := queue.QueueMessageWithMetadata(ctx, session.ID, taskID, prompt, "", messagequeue.QueuedByAgent, false, nil, metadata); err != nil {
 		if errors.Is(err, messagequeue.ErrQueueFull) {
 			status := queue.GetStatus(ctx, session.ID)
-			return "", &queueFullDispatchError{
+			return taskMessageDispatchResult{}, &queueFullDispatchError{
 				sessionID: session.ID,
 				queueSize: status.Count,
 				max:       status.Max,
 				entries:   status.Entries,
 			}
 		}
-		return "", fmt.Errorf("failed to queue message: %w", err)
+		return taskMessageDispatchResult{}, fmt.Errorf("failed to queue message: %w", err)
 	}
 	h.publishQueueStatusEvent(ctx, session.ID, queue)
-	return "queued", nil
+	return taskMessageDispatchResult{status: "queued", sessionID: session.ID}, nil
 }
 
 func (h *Handlers) prepareSessionForTaskMessage(ctx context.Context, taskID string, session *models.TaskSession) (*models.TaskSession, error) {
-	if err := h.ensureTaskInProgressForTaskMessage(ctx, taskID); err != nil {
+	if err := h.sessionLauncher.ProcessOnTurnStart(ctx, taskID, session.ID); err != nil {
+		return nil, fmt.Errorf("failed to process on_turn_start for task message: %w", err)
+	}
+	resolved, err := h.resolveSessionAfterTaskMessageTurnStart(ctx, taskID, session)
+	if err != nil {
 		return nil, err
 	}
-	if err := h.sessionLauncher.ProcessOnTurnStart(ctx, taskID, session.ID); err != nil {
-		h.logger.Warn("failed to process on_turn_start for task message",
-			zap.String("task_id", taskID),
-			zap.String("session_id", session.ID),
-			zap.Error(err))
-	}
-	return h.resolveSessionAfterTaskMessageTurnStart(ctx, taskID, session)
+	return resolved, nil
 }
 
-func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskID string) error {
+func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskID string) (bool, error) {
 	if h.taskSvc == nil {
-		return nil
+		return false, errors.New("task service not available")
 	}
 	task, err := h.taskSvc.GetTask(ctx, taskID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if task.State != v1.TaskStateReview {
-		return nil
+		return false, nil
 	}
 	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
-		h.logger.Error("failed to transition task from REVIEW to IN_PROGRESS for task message",
+		return false, fmt.Errorf("failed to transition task from REVIEW to IN_PROGRESS for task message: %w", err)
+	}
+	h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
+		zap.String("task_id", taskID))
+	return true, nil
+}
+
+func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID string) {
+	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateReview); err != nil {
+		h.logger.Warn("failed to restore task to REVIEW after task message dispatch failure",
 			zap.String("task_id", taskID),
 			zap.Error(err))
-	} else {
-		h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
-			zap.String("task_id", taskID))
 	}
-	return nil
 }
 
 func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, taskID string, submitted *models.TaskSession) (*models.TaskSession, error) {
+	if h.taskSvc == nil {
+		return nil, errors.New("task service not available")
+	}
 	reloaded, err := h.taskSvc.GetTaskSession(ctx, submitted.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reload session after on_turn_start: %w", err)
 	}
-	if reloaded.State != models.TaskSessionStateCompleted || submitted.State == models.TaskSessionStateCompleted {
+	if reloaded.State != models.TaskSessionStateCompleted {
 		return reloaded, nil
 	}
 	primary, err := h.taskSvc.GetPrimarySession(ctx, taskID)
-	if err != nil || primary == nil {
+	if err != nil {
 		return nil, fmt.Errorf("session was switched but no active session found: %w", err)
+	}
+	if primary == nil {
+		return nil, errors.New("session was switched but no active session found")
 	}
 	if primary.ID == submitted.ID {
 		return nil, errors.New("session was switched but submitted session remains primary")

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -64,6 +64,7 @@ type SessionRepository interface {
 // TaskRepository interface for updating task state.
 type TaskRepository interface {
 	UpdateTaskState(ctx context.Context, taskID string, state v1.TaskState) error
+	UpdateTask(ctx context.Context, task *models.Task) error
 }
 
 // EventBus interface for publishing events.
@@ -1631,6 +1632,11 @@ type taskMessageDispatchResult struct {
 	sessionID string
 }
 
+type taskMessageReviewRollback struct {
+	changed        bool
+	workflowStepID string
+}
+
 // dispatchTaskMessage routes a message to the right delivery path based on session state.
 // Returns the action taken: "queued", "sent", or "started".
 //
@@ -1652,20 +1658,18 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 
 	default:
 		originalState := session.State
-		reviewStateChanged, err := h.ensureTaskInProgressForTaskMessage(ctx, taskID)
+		reviewRollback, err := h.ensureTaskInProgressForTaskMessage(ctx, taskID)
 		if err != nil {
 			return taskMessageDispatchResult{}, err
 		}
 		session, err := h.prepareSessionForTaskMessage(ctx, taskID, session)
 		if err != nil {
-			if reviewStateChanged {
-				h.restoreTaskReviewForTaskMessage(ctx, taskID)
-			}
+			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
 			return taskMessageDispatchResult{}, err
 		}
 		result, err := h.dispatchPreparedTaskMessage(ctx, taskID, session, originalState, prompt, metadata)
-		if err != nil && reviewStateChanged {
-			h.restoreTaskReviewForTaskMessage(ctx, taskID)
+		if err != nil {
+			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
 		}
 		return result, err
 	}
@@ -1703,6 +1707,10 @@ func shouldStartTaskMessageSession(originalState models.TaskSessionState, sessio
 	if session.State == models.TaskSessionStateCreated {
 		return true
 	}
+	// on_turn_start may mark a never-launched CREATED session as
+	// WAITING_FOR_INPUT before an executor row exists. In that case the first
+	// message still needs the launch path; already-bound waiting sessions use
+	// the normal prompt/resume path.
 	return originalState == models.TaskSessionStateCreated &&
 		session.State == models.TaskSessionStateWaitingForInput &&
 		session.AgentExecutionID == ""
@@ -1740,26 +1748,46 @@ func (h *Handlers) prepareSessionForTaskMessage(ctx context.Context, taskID stri
 	return resolved, nil
 }
 
-func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskID string) (bool, error) {
+func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskID string) (taskMessageReviewRollback, error) {
 	if h.taskSvc == nil {
-		return false, errors.New("task service not available")
+		return taskMessageReviewRollback{}, errors.New("task service not available")
 	}
 	task, err := h.taskSvc.GetTask(ctx, taskID)
 	if err != nil {
-		return false, err
+		return taskMessageReviewRollback{}, err
 	}
 	if task.State != v1.TaskStateReview {
-		return false, nil
+		return taskMessageReviewRollback{}, nil
 	}
 	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
-		return false, fmt.Errorf("failed to transition task from REVIEW to IN_PROGRESS for task message: %w", err)
+		return taskMessageReviewRollback{}, fmt.Errorf("failed to transition task from REVIEW to IN_PROGRESS for task message: %w", err)
 	}
 	h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
 		zap.String("task_id", taskID))
-	return true, nil
+	return taskMessageReviewRollback{changed: true, workflowStepID: task.WorkflowStepID}, nil
 }
 
-func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID string) {
+func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID string, rollback taskMessageReviewRollback) {
+	if !rollback.changed {
+		return
+	}
+	if h.taskRepo != nil {
+		task, err := h.taskSvc.GetTask(ctx, taskID)
+		if err == nil {
+			task.State = v1.TaskStateReview
+			task.WorkflowStepID = rollback.workflowStepID
+			if err := h.taskRepo.UpdateTask(ctx, task); err == nil {
+				return
+			}
+			h.logger.Warn("failed to restore task row after task message dispatch failure",
+				zap.String("task_id", taskID),
+				zap.Error(err))
+		} else {
+			h.logger.Warn("failed to load task for REVIEW rollback after task message dispatch failure",
+				zap.String("task_id", taskID),
+				zap.Error(err))
+		}
+	}
 	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateReview); err != nil {
 		h.logger.Warn("failed to restore task to REVIEW after task message dispatch failure",
 			zap.String("task_id", taskID),

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1634,6 +1634,41 @@ type taskMessageDispatchResult struct {
 type taskMessageReviewRollback struct {
 	changed        bool
 	workflowStepID string
+	session        taskMessageSessionRollback
+}
+
+type taskMessageSessionRollback struct {
+	captured    bool
+	sessionID   string
+	state       models.TaskSessionState
+	error       string
+	completedAt *time.Time
+	isPrimary   bool
+}
+
+type taskMessageSessionRollbackRepository interface {
+	GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error)
+	UpdateTaskSession(ctx context.Context, session *models.TaskSession) error
+	SetSessionPrimary(ctx context.Context, sessionID string) error
+}
+
+func (r *taskMessageReviewRollback) captureSession(session *models.TaskSession) {
+	if !r.changed || session == nil {
+		return
+	}
+	var completedAt *time.Time
+	if session.CompletedAt != nil {
+		copy := *session.CompletedAt
+		completedAt = &copy
+	}
+	r.session = taskMessageSessionRollback{
+		captured:    true,
+		sessionID:   session.ID,
+		state:       session.State,
+		error:       session.ErrorMessage,
+		completedAt: completedAt,
+		isPrimary:   session.IsPrimary,
+	}
 }
 
 // dispatchTaskMessage routes a message to the right delivery path based on session state.
@@ -1656,17 +1691,17 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 		return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
 
 	default:
-		originalState := session.State
 		reviewRollback, err := h.ensureTaskInProgressForTaskMessage(ctx, taskID)
 		if err != nil {
 			return taskMessageDispatchResult{}, err
 		}
+		reviewRollback.captureSession(session)
 		session, err := h.prepareSessionForTaskMessage(ctx, taskID, session)
 		if err != nil {
 			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
 			return taskMessageDispatchResult{}, err
 		}
-		result, err := h.dispatchPreparedTaskMessage(ctx, taskID, session, originalState, prompt, metadata)
+		result, err := h.dispatchPreparedTaskMessage(ctx, taskID, session, prompt, metadata)
 		if err != nil {
 			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
 		}
@@ -1674,14 +1709,14 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 	}
 }
 
-func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, originalState models.TaskSessionState, prompt string, metadata map[string]interface{}) (taskMessageDispatchResult, error) {
+func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, prompt string, metadata map[string]interface{}) (taskMessageDispatchResult, error) {
 	switch session.State {
 	case models.TaskSessionStateFailed, models.TaskSessionStateCancelled:
 		return taskMessageDispatchResult{}, fmt.Errorf("session is %s — cannot send message", session.State)
 	case models.TaskSessionStateRunning, models.TaskSessionStateStarting:
 		return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
 	default:
-		if shouldStartTaskMessageSession(originalState, session) {
+		if shouldStartTaskMessageSession(session) {
 			// Start first, then record the user message ourselves with sender
 			// metadata. This avoids leaving an orphaned attributed chat row when
 			// StartCreatedSession fails (the previous order wrote the row up-front
@@ -1702,16 +1737,15 @@ func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID strin
 	}
 }
 
-func shouldStartTaskMessageSession(originalState models.TaskSessionState, session *models.TaskSession) bool {
+func shouldStartTaskMessageSession(session *models.TaskSession) bool {
 	if session.State == models.TaskSessionStateCreated {
 		return true
 	}
 	// on_turn_start may mark a never-launched CREATED session as
-	// WAITING_FOR_INPUT before an executor row exists. In that case the first
-	// message still needs the launch path; already-bound waiting sessions use
-	// the normal prompt/resume path.
-	return originalState == models.TaskSessionStateCreated &&
-		session.State == models.TaskSessionStateWaitingForInput &&
+	// WAITING_FOR_INPUT before an executor row exists. It may also switch to a
+	// fresh waiting primary session. In both cases the first message still needs
+	// the launch path; already-bound waiting sessions use prompt/resume.
+	return session.State == models.TaskSessionStateWaitingForInput &&
 		session.AgentExecutionID == ""
 }
 
@@ -1770,6 +1804,11 @@ func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID s
 	if !rollback.changed {
 		return
 	}
+	if err := h.restoreTaskMessageSession(ctx, rollback.session); err != nil {
+		h.logger.Warn("failed to restore task session after task message dispatch failure",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+	}
 	reviewState := v1.TaskStateReview
 	if _, err := h.taskSvc.UpdateTask(ctx, taskID, &service.UpdateTaskRequest{
 		State:          &reviewState,
@@ -1779,6 +1818,33 @@ func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID s
 			zap.String("task_id", taskID),
 			zap.Error(err))
 	}
+}
+
+func (h *Handlers) restoreTaskMessageSession(ctx context.Context, rollback taskMessageSessionRollback) error {
+	if !rollback.captured {
+		return nil
+	}
+	repo, ok := h.sessionRepo.(taskMessageSessionRollbackRepository)
+	if !ok {
+		return errors.New("session rollback repository not available")
+	}
+	session, err := repo.GetTaskSession(ctx, rollback.sessionID)
+	if err != nil {
+		return err
+	}
+	session.State = rollback.state
+	session.ErrorMessage = rollback.error
+	session.CompletedAt = rollback.completedAt
+	session.IsPrimary = rollback.isPrimary
+	if err := repo.UpdateTaskSession(ctx, session); err != nil {
+		return err
+	}
+	if rollback.isPrimary {
+		if err := repo.SetSessionPrimary(ctx, rollback.sessionID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, taskID string, submitted *models.TaskSession) (*models.TaskSession, error) {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -64,7 +64,6 @@ type SessionRepository interface {
 // TaskRepository interface for updating task state.
 type TaskRepository interface {
 	UpdateTaskState(ctx context.Context, taskID string, state v1.TaskState) error
-	UpdateTask(ctx context.Context, task *models.Task) error
 }
 
 // EventBus interface for publishing events.
@@ -1771,24 +1770,11 @@ func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID s
 	if !rollback.changed {
 		return
 	}
-	if h.taskRepo != nil {
-		task, err := h.taskSvc.GetTask(ctx, taskID)
-		if err == nil {
-			task.State = v1.TaskStateReview
-			task.WorkflowStepID = rollback.workflowStepID
-			if err := h.taskRepo.UpdateTask(ctx, task); err == nil {
-				return
-			}
-			h.logger.Warn("failed to restore task row after task message dispatch failure",
-				zap.String("task_id", taskID),
-				zap.Error(err))
-		} else {
-			h.logger.Warn("failed to load task for REVIEW rollback after task message dispatch failure",
-				zap.String("task_id", taskID),
-				zap.Error(err))
-		}
-	}
-	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateReview); err != nil {
+	reviewState := v1.TaskStateReview
+	if _, err := h.taskSvc.UpdateTask(ctx, taskID, &service.UpdateTaskRequest{
+		State:          &reviewState,
+		WorkflowStepID: &rollback.workflowStepID,
+	}); err != nil {
 		h.logger.Warn("failed to restore task to REVIEW after task message dispatch failure",
 			zap.String("task_id", taskID),
 			zap.Error(err))

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1728,6 +1728,8 @@ func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID strin
 			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 			return taskMessageDispatchResult{status: "started", sessionID: session.ID}, nil
 		}
+		// Record only after the prompt is accepted; otherwise a failed dispatch
+		// leaves a REVIEW rollback with a user message the agent never saw.
 		status, err := h.promptWithAutoResume(ctx, taskID, session.ID, prompt)
 		if err != nil {
 			return taskMessageDispatchResult{}, err

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1785,10 +1785,13 @@ func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, 
 	if primary == nil {
 		return nil, errors.New("session was switched but no active session found")
 	}
-	if primary.ID == submitted.ID {
-		return nil, errors.New("session was switched but submitted session remains primary")
+	if primary.ID != submitted.ID {
+		return primary, nil
 	}
-	return primary, nil
+	if submitted.State == models.TaskSessionStateCompleted {
+		return reloaded, nil
+	}
+	return nil, errors.New("session was switched but submitted session remains primary")
 }
 
 // recordUserMessage writes the prompt to the task's chat as a user message so it

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1643,12 +1643,15 @@ type taskMessageReviewRollback struct {
 }
 
 type taskMessageSessionRollback struct {
-	sessionID   string
-	state       models.TaskSessionState
-	error       string
-	completedAt *time.Time
-	isPrimary   bool
-	metadata    map[string]interface{}
+	sessionID            string
+	state                models.TaskSessionState
+	error                string
+	completedAt          *time.Time
+	isPrimary            bool
+	agentProfileID       string
+	executorProfileID    string
+	agentProfileSnapshot map[string]interface{}
+	metadata             map[string]interface{}
 }
 
 type taskMessageQueueRollback struct {
@@ -1728,11 +1731,14 @@ func captureTaskMessageSession(session *models.TaskSession) taskMessageSessionRo
 		completedAt = &copy
 	}
 	snapshot := taskMessageSessionRollback{
-		sessionID:   session.ID,
-		state:       session.State,
-		error:       session.ErrorMessage,
-		completedAt: completedAt,
-		isPrimary:   session.IsPrimary,
+		sessionID:            session.ID,
+		state:                session.State,
+		error:                session.ErrorMessage,
+		completedAt:          completedAt,
+		isPrimary:            session.IsPrimary,
+		agentProfileID:       session.AgentProfileID,
+		executorProfileID:    session.ExecutorProfileID,
+		agentProfileSnapshot: cloneTaskMessageMetadataMap(session.AgentProfileSnapshot),
 	}
 	if session.Metadata != nil {
 		snapshot.metadata = cloneTaskMessageMetadataMap(session.Metadata)
@@ -1920,23 +1926,24 @@ func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskI
 	if err != nil {
 		return taskMessageReviewRollback{}, err
 	}
+	rollback := taskMessageReviewRollback{
+		changed:        true,
+		restoreTask:    true,
+		taskState:      task.State,
+		workflowStepID: task.WorkflowStepID,
+	}
 	if task.State != v1.TaskStateReview {
-		return taskMessageReviewRollback{}, nil
+		return rollback, nil
 	}
 	if task.AssigneeAgentProfileID != "" {
-		return taskMessageReviewRollback{
-			changed:        true,
-			restoreTask:    true,
-			taskState:      task.State,
-			workflowStepID: task.WorkflowStepID,
-		}, nil
+		return rollback, nil
 	}
 	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
 		return taskMessageReviewRollback{}, fmt.Errorf("failed to transition task from REVIEW to IN_PROGRESS for task message: %w", err)
 	}
 	h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
 		zap.String("task_id", taskID))
-	return taskMessageReviewRollback{changed: true, restoreTask: true, taskState: task.State, workflowStepID: task.WorkflowStepID}, nil
+	return rollback, nil
 }
 
 func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID string, rollback taskMessageReviewRollback) {
@@ -2071,6 +2078,9 @@ func restoreTaskMessageSessionSnapshot(ctx context.Context, repo taskMessageSess
 	session.ErrorMessage = rollback.error
 	session.CompletedAt = rollback.completedAt
 	session.IsPrimary = rollback.isPrimary
+	session.AgentProfileID = rollback.agentProfileID
+	session.ExecutorProfileID = rollback.executorProfileID
+	session.AgentProfileSnapshot = cloneTaskMessageMetadataMap(rollback.agentProfileSnapshot)
 	if err := repo.UpdateTaskSession(ctx, session); err != nil {
 		return err
 	}

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1819,7 +1819,7 @@ func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, 
 	if submitted.State == models.TaskSessionStateCompleted {
 		return reloaded, nil
 	}
-	return nil, errors.New("session was switched but submitted session remains primary")
+	return nil, errors.New("session was marked completed by on_turn_start but primary was not switched")
 }
 
 // recordUserMessage writes the prompt to the task's chat as a user message so it

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1756,6 +1756,7 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 			return taskMessageDispatchResult{}, err
 		}
 		if err := reviewRollback.captureSessions(ctx, h.sessionRepo, taskID, session); err != nil {
+			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
 			return taskMessageDispatchResult{}, err
 		}
 		session, err := h.prepareSessionForTaskMessage(ctx, taskID, session)

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -72,12 +72,13 @@ type EventBus interface {
 }
 
 // SessionLauncher provides session launch and prompt-dispatch capabilities.
-// Both methods are implemented by *orchestrator.Service.
+// Implemented by *orchestrator.Service.
 type SessionLauncher interface {
 	LaunchSession(ctx context.Context, req *orchestrator.LaunchSessionRequest) (*orchestrator.LaunchSessionResponse, error)
 	PromptTask(ctx context.Context, taskID, sessionID, prompt, model string, planMode bool, attachments []v1.MessageAttachment, dispatchOnly bool) (*orchestrator.PromptResult, error)
 	StartCreatedSession(ctx context.Context, taskID, sessionID, agentProfileID, prompt string, skipMessageRecord, planMode, autoStart bool, attachments []v1.MessageAttachment) (*executor.TaskExecution, error)
 	ResumeTaskSession(ctx context.Context, taskID, sessionID string) (*executor.TaskExecution, error)
+	ProcessOnTurnStart(ctx context.Context, taskID, sessionID string) error
 	GetMessageQueue() *messagequeue.Service
 }
 
@@ -1642,41 +1643,108 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 		return "", fmt.Errorf("session is %s — cannot send message", session.State)
 
 	case models.TaskSessionStateRunning, models.TaskSessionStateStarting:
-		queue := h.sessionLauncher.GetMessageQueue()
-		if queue == nil {
-			return "", errors.New("message queue not available")
+		return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
+
+	default:
+		session, err := h.prepareSessionForTaskMessage(ctx, taskID, session)
+		if err != nil {
+			return "", err
 		}
-		if _, err := queue.QueueMessageWithMetadata(ctx, session.ID, taskID, prompt, "", messagequeue.QueuedByAgent, false, nil, metadata); err != nil {
-			if errors.Is(err, messagequeue.ErrQueueFull) {
-				status := queue.GetStatus(ctx, session.ID)
-				return "", &queueFullDispatchError{
-					sessionID: session.ID,
-					queueSize: status.Count,
-					max:       status.Max,
-					entries:   status.Entries,
-				}
+		switch session.State {
+		case models.TaskSessionStateFailed, models.TaskSessionStateCancelled:
+			return "", fmt.Errorf("session is %s — cannot send message", session.State)
+		case models.TaskSessionStateRunning, models.TaskSessionStateStarting:
+			return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
+		case models.TaskSessionStateCreated:
+			// Start first, then record the user message ourselves with sender
+			// metadata. This avoids leaving an orphaned attributed chat row when
+			// StartCreatedSession fails (the previous order wrote the row up-front
+			// regardless of launch outcome). skipMessageRecord=true keeps
+			// postLaunchCreated from writing its own duplicate row.
+			if _, err := h.sessionLauncher.StartCreatedSession(ctx, taskID, session.ID, session.AgentProfileID, prompt, true, false, true, nil); err != nil {
+				return "", fmt.Errorf("failed to start session: %w", err)
 			}
-			return "", fmt.Errorf("failed to queue message: %w", err)
+			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
+			return "started", nil
+		default: // WAITING_FOR_INPUT, COMPLETED, IDLE, or any other promptable state
+			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
+			return h.promptWithAutoResume(ctx, taskID, session.ID, prompt)
 		}
-		h.publishQueueStatusEvent(ctx, session.ID, queue)
-		return "queued", nil
-
-	case models.TaskSessionStateCreated:
-		// Start first, then record the user message ourselves with sender
-		// metadata. This avoids leaving an orphaned attributed chat row when
-		// StartCreatedSession fails (the previous order wrote the row up-front
-		// regardless of launch outcome). skipMessageRecord=true keeps
-		// postLaunchCreated from writing its own duplicate row.
-		if _, err := h.sessionLauncher.StartCreatedSession(ctx, taskID, session.ID, session.AgentProfileID, prompt, true, false, true, nil); err != nil {
-			return "", fmt.Errorf("failed to start session: %w", err)
-		}
-		h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
-		return "started", nil
-
-	default: // WAITING_FOR_INPUT, COMPLETED, or any other promptable state
-		h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
-		return h.promptWithAutoResume(ctx, taskID, session.ID, prompt)
 	}
+}
+
+func (h *Handlers) queueTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, prompt string, metadata map[string]interface{}) (string, error) {
+	queue := h.sessionLauncher.GetMessageQueue()
+	if queue == nil {
+		return "", errors.New("message queue not available")
+	}
+	if _, err := queue.QueueMessageWithMetadata(ctx, session.ID, taskID, prompt, "", messagequeue.QueuedByAgent, false, nil, metadata); err != nil {
+		if errors.Is(err, messagequeue.ErrQueueFull) {
+			status := queue.GetStatus(ctx, session.ID)
+			return "", &queueFullDispatchError{
+				sessionID: session.ID,
+				queueSize: status.Count,
+				max:       status.Max,
+				entries:   status.Entries,
+			}
+		}
+		return "", fmt.Errorf("failed to queue message: %w", err)
+	}
+	h.publishQueueStatusEvent(ctx, session.ID, queue)
+	return "queued", nil
+}
+
+func (h *Handlers) prepareSessionForTaskMessage(ctx context.Context, taskID string, session *models.TaskSession) (*models.TaskSession, error) {
+	if err := h.ensureTaskInProgressForTaskMessage(ctx, taskID); err != nil {
+		return nil, err
+	}
+	if err := h.sessionLauncher.ProcessOnTurnStart(ctx, taskID, session.ID); err != nil {
+		h.logger.Warn("failed to process on_turn_start for task message",
+			zap.String("task_id", taskID),
+			zap.String("session_id", session.ID),
+			zap.Error(err))
+	}
+	return h.resolveSessionAfterTaskMessageTurnStart(ctx, taskID, session)
+}
+
+func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskID string) error {
+	if h.taskSvc == nil {
+		return nil
+	}
+	task, err := h.taskSvc.GetTask(ctx, taskID)
+	if err != nil {
+		return err
+	}
+	if task.State != v1.TaskStateReview {
+		return nil
+	}
+	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
+		h.logger.Error("failed to transition task from REVIEW to IN_PROGRESS for task message",
+			zap.String("task_id", taskID),
+			zap.Error(err))
+	} else {
+		h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
+			zap.String("task_id", taskID))
+	}
+	return nil
+}
+
+func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, taskID string, submitted *models.TaskSession) (*models.TaskSession, error) {
+	reloaded, err := h.taskSvc.GetTaskSession(ctx, submitted.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reload session after on_turn_start: %w", err)
+	}
+	if reloaded.State != models.TaskSessionStateCompleted || submitted.State == models.TaskSessionStateCompleted {
+		return reloaded, nil
+	}
+	primary, err := h.taskSvc.GetPrimarySession(ctx, taskID)
+	if err != nil || primary == nil {
+		return nil, fmt.Errorf("session was switched but no active session found: %w", err)
+	}
+	if primary.ID == submitted.ID {
+		return nil, errors.New("session was switched but submitted session remains primary")
+	}
+	return primary, nil
 }
 
 // recordUserMessage writes the prompt to the task's chat as a user message so it

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1634,6 +1634,7 @@ type taskMessageDispatchResult struct {
 type taskMessageReviewRollback struct {
 	changed        bool
 	restoreTask    bool
+	taskState      v1.TaskState
 	workflowStepID string
 	sessions       []taskMessageSessionRollback
 	sessionIDs     map[string]struct{}
@@ -1869,6 +1870,8 @@ func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskI
 	if task.AssigneeAgentProfileID != "" {
 		return taskMessageReviewRollback{
 			changed:        true,
+			restoreTask:    true,
+			taskState:      task.State,
 			workflowStepID: task.WorkflowStepID,
 		}, nil
 	}
@@ -1877,7 +1880,7 @@ func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskI
 	}
 	h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
 		zap.String("task_id", taskID))
-	return taskMessageReviewRollback{changed: true, restoreTask: true, workflowStepID: task.WorkflowStepID}, nil
+	return taskMessageReviewRollback{changed: true, restoreTask: true, taskState: task.State, workflowStepID: task.WorkflowStepID}, nil
 }
 
 func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID string, rollback taskMessageReviewRollback) {
@@ -1890,18 +1893,14 @@ func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID s
 			zap.Error(err))
 	}
 	if !rollback.restoreTask {
-		if _, err := h.taskSvc.UpdateTask(ctx, taskID, &service.UpdateTaskRequest{
-			WorkflowStepID: &rollback.workflowStepID,
-		}); err != nil {
-			h.logger.Warn("failed to restore task workflow step after task message dispatch failure",
-				zap.String("task_id", taskID),
-				zap.Error(err))
-		}
 		return
 	}
-	reviewState := v1.TaskStateReview
+	taskState := rollback.taskState
+	if taskState == "" {
+		taskState = v1.TaskStateReview
+	}
 	if _, err := h.taskSvc.UpdateTask(ctx, taskID, &service.UpdateTaskRequest{
-		State:          &reviewState,
+		State:          &taskState,
 		WorkflowStepID: &rollback.workflowStepID,
 	}); err != nil {
 		h.logger.Warn("failed to restore task to REVIEW after task message dispatch failure",
@@ -1924,14 +1923,15 @@ func (h *Handlers) restoreTaskMessageSessions(ctx context.Context, rollback task
 		}
 	}
 	if rollback.selectedID != "" {
-		if _, ok := rollback.sessionIDs[rollback.selectedID]; !ok {
-			if primaryID := rollback.primarySessionID(); primaryID != "" {
-				if queue := h.sessionLauncher.GetMessageQueue(); queue != nil {
-					if err := queue.TransferSession(ctx, rollback.selectedID, primaryID); err != nil {
-						return err
-					}
+		primaryID := rollback.primarySessionID()
+		if primaryID != "" && rollback.selectedID != primaryID {
+			if queue := h.sessionLauncher.GetMessageQueue(); queue != nil {
+				if err := queue.TransferSession(ctx, rollback.selectedID, primaryID); err != nil {
+					return err
 				}
 			}
+		}
+		if _, ok := rollback.sessionIDs[rollback.selectedID]; !ok {
 			if err := repo.DeleteTaskSession(ctx, rollback.selectedID); err != nil {
 				return err
 			}
@@ -1984,10 +1984,13 @@ func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to reload session after on_turn_start: %w", err)
 	}
+	primary, err := h.taskSvc.GetPrimarySession(ctx, taskID)
+	if err == nil && primary != nil && primary.ID != submitted.ID {
+		return primary, nil
+	}
 	if reloaded.State != models.TaskSessionStateCompleted {
 		return reloaded, nil
 	}
-	primary, err := h.taskSvc.GetPrimarySession(ctx, taskID)
 	if err != nil {
 		return nil, fmt.Errorf("session was switched but no active session found: %w", err)
 	}
@@ -2034,6 +2037,13 @@ func (h *Handlers) deleteRecordedUserMessage(ctx context.Context, message *model
 	}
 	if err := h.taskSvc.DeleteMessage(ctx, message.ID); err != nil {
 		h.logger.Warn("failed to delete rejected user message for message_task",
+			zap.String("message_id", message.ID),
+			zap.String("task_id", message.TaskID),
+			zap.String("session_id", message.TaskSessionID),
+			zap.Error(err))
+	}
+	if err := h.taskSvc.AbandonOpenTurns(ctx, message.TaskSessionID); err != nil {
+		h.logger.Warn("failed to abandon rejected user message turn for message_task",
 			zap.String("message_id", message.ID),
 			zap.String("task_id", message.TaskID),
 			zap.String("session_id", message.TaskSessionID),

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1633,42 +1633,97 @@ type taskMessageDispatchResult struct {
 
 type taskMessageReviewRollback struct {
 	changed        bool
+	restoreTask    bool
 	workflowStepID string
-	session        taskMessageSessionRollback
+	sessions       []taskMessageSessionRollback
+	sessionIDs     map[string]struct{}
+	selectedID     string
 }
 
 type taskMessageSessionRollback struct {
-	captured    bool
-	sessionID   string
-	state       models.TaskSessionState
-	error       string
-	completedAt *time.Time
-	isPrimary   bool
+	sessionID      string
+	state          models.TaskSessionState
+	error          string
+	completedAt    *time.Time
+	isPrimary      bool
+	hadPendingStep bool
+	pendingStep    interface{}
 }
 
 type taskMessageSessionRollbackRepository interface {
 	GetTaskSession(ctx context.Context, id string) (*models.TaskSession, error)
+	ListTaskSessions(ctx context.Context, taskID string) ([]*models.TaskSession, error)
 	UpdateTaskSession(ctx context.Context, session *models.TaskSession) error
 	SetSessionPrimary(ctx context.Context, sessionID string) error
+	DeleteTaskSession(ctx context.Context, id string) error
+	SetSessionMetadataKey(ctx context.Context, sessionID, key string, value interface{}) error
 }
 
-func (r *taskMessageReviewRollback) captureSession(session *models.TaskSession) {
+func (r *taskMessageReviewRollback) captureSessions(ctx context.Context, repo SessionRepository, taskID string, fallback *models.TaskSession) error {
+	if !r.changed || fallback == nil {
+		return nil
+	}
+	sessions := []*models.TaskSession{fallback}
+	if snapshotRepo, ok := repo.(interface {
+		ListTaskSessions(ctx context.Context, taskID string) ([]*models.TaskSession, error)
+	}); ok {
+		listed, err := snapshotRepo.ListTaskSessions(ctx, taskID)
+		if err != nil {
+			return err
+		}
+		sessions = listed
+	}
+	r.sessionIDs = make(map[string]struct{}, len(sessions))
+	r.sessions = make([]taskMessageSessionRollback, 0, len(sessions))
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		r.sessionIDs[session.ID] = struct{}{}
+		r.sessions = append(r.sessions, captureTaskMessageSession(session))
+	}
+	return nil
+}
+
+func (r *taskMessageReviewRollback) captureSelectedSession(session *models.TaskSession) {
 	if !r.changed || session == nil {
 		return
 	}
+	r.selectedID = session.ID
+}
+
+func captureTaskMessageSession(session *models.TaskSession) taskMessageSessionRollback {
 	var completedAt *time.Time
 	if session.CompletedAt != nil {
 		copy := *session.CompletedAt
 		completedAt = &copy
 	}
-	r.session = taskMessageSessionRollback{
-		captured:    true,
+	snapshot := taskMessageSessionRollback{
 		sessionID:   session.ID,
 		state:       session.State,
 		error:       session.ErrorMessage,
 		completedAt: completedAt,
 		isPrimary:   session.IsPrimary,
 	}
+	if session.Metadata != nil {
+		if pendingStep, ok := session.Metadata[models.SessionMetaKeyPendingStepCompletion]; ok {
+			snapshot.hadPendingStep = true
+			snapshot.pendingStep = cloneTaskMessageMetadataValue(pendingStep)
+		}
+	}
+	return snapshot
+}
+
+func cloneTaskMessageMetadataValue(value interface{}) interface{} {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var cloned interface{}
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return value
+	}
+	return cloned
 }
 
 // dispatchTaskMessage routes a message to the right delivery path based on session state.
@@ -1695,12 +1750,15 @@ func (h *Handlers) dispatchTaskMessage(ctx context.Context, taskID string, sessi
 		if err != nil {
 			return taskMessageDispatchResult{}, err
 		}
-		reviewRollback.captureSession(session)
+		if err := reviewRollback.captureSessions(ctx, h.sessionRepo, taskID, session); err != nil {
+			return taskMessageDispatchResult{}, err
+		}
 		session, err := h.prepareSessionForTaskMessage(ctx, taskID, session)
 		if err != nil {
 			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
 			return taskMessageDispatchResult{}, err
 		}
+		reviewRollback.captureSelectedSession(session)
 		result, err := h.dispatchPreparedTaskMessage(ctx, taskID, session, prompt, metadata)
 		if err != nil {
 			h.restoreTaskReviewForTaskMessage(ctx, taskID, reviewRollback)
@@ -1728,13 +1786,15 @@ func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID strin
 			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 			return taskMessageDispatchResult{status: "started", sessionID: session.ID}, nil
 		}
-		// Record only after the prompt is accepted; otherwise a failed dispatch
-		// leaves a REVIEW rollback with a user message the agent never saw.
+		// Record before prompting so the message is tied to the turn that
+		// PromptTask dispatches. If dispatch fails, delete the row below so a
+		// REVIEW rollback does not keep a prompt the agent never saw.
+		recorded := h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 		status, err := h.promptWithAutoResume(ctx, taskID, session.ID, prompt)
 		if err != nil {
+			h.deleteRecordedUserMessage(ctx, recorded)
 			return taskMessageDispatchResult{}, err
 		}
-		h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 		return taskMessageDispatchResult{status: status, sessionID: session.ID}, nil
 	}
 }
@@ -1794,22 +1854,31 @@ func (h *Handlers) ensureTaskInProgressForTaskMessage(ctx context.Context, taskI
 	if task.State != v1.TaskStateReview {
 		return taskMessageReviewRollback{}, nil
 	}
+	if task.AssigneeAgentProfileID != "" {
+		return taskMessageReviewRollback{
+			changed:        true,
+			workflowStepID: task.WorkflowStepID,
+		}, nil
+	}
 	if _, err := h.taskSvc.UpdateTaskState(ctx, taskID, v1.TaskStateInProgress); err != nil {
 		return taskMessageReviewRollback{}, fmt.Errorf("failed to transition task from REVIEW to IN_PROGRESS for task message: %w", err)
 	}
 	h.logger.Info("task transitioned from REVIEW to IN_PROGRESS for task message",
 		zap.String("task_id", taskID))
-	return taskMessageReviewRollback{changed: true, workflowStepID: task.WorkflowStepID}, nil
+	return taskMessageReviewRollback{changed: true, restoreTask: true, workflowStepID: task.WorkflowStepID}, nil
 }
 
 func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID string, rollback taskMessageReviewRollback) {
 	if !rollback.changed {
 		return
 	}
-	if err := h.restoreTaskMessageSession(ctx, rollback.session); err != nil {
+	if err := h.restoreTaskMessageSessions(ctx, rollback); err != nil {
 		h.logger.Warn("failed to restore task session after task message dispatch failure",
 			zap.String("task_id", taskID),
 			zap.Error(err))
+	}
+	if !rollback.restoreTask {
+		return
 	}
 	reviewState := v1.TaskStateReview
 	if _, err := h.taskSvc.UpdateTask(ctx, taskID, &service.UpdateTaskRequest{
@@ -1822,14 +1891,30 @@ func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID s
 	}
 }
 
-func (h *Handlers) restoreTaskMessageSession(ctx context.Context, rollback taskMessageSessionRollback) error {
-	if !rollback.captured {
+func (h *Handlers) restoreTaskMessageSessions(ctx context.Context, rollback taskMessageReviewRollback) error {
+	if len(rollback.sessions) == 0 {
 		return nil
 	}
 	repo, ok := h.sessionRepo.(taskMessageSessionRollbackRepository)
 	if !ok {
 		return errors.New("session rollback repository not available")
 	}
+	for _, snapshot := range rollback.sessions {
+		if err := restoreTaskMessageSessionSnapshot(ctx, repo, snapshot); err != nil {
+			return err
+		}
+	}
+	if rollback.selectedID != "" {
+		if _, ok := rollback.sessionIDs[rollback.selectedID]; !ok {
+			if err := repo.DeleteTaskSession(ctx, rollback.selectedID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func restoreTaskMessageSessionSnapshot(ctx context.Context, repo taskMessageSessionRollbackRepository, rollback taskMessageSessionRollback) error {
 	session, err := repo.GetTaskSession(ctx, rollback.sessionID)
 	if err != nil {
 		return err
@@ -1845,6 +1930,13 @@ func (h *Handlers) restoreTaskMessageSession(ctx context.Context, rollback taskM
 		if err := repo.SetSessionPrimary(ctx, rollback.sessionID); err != nil {
 			return err
 		}
+	}
+	pendingStep := interface{}(nil)
+	if rollback.hadPendingStep {
+		pendingStep = rollback.pendingStep
+	}
+	if err := repo.SetSessionMetadataKey(ctx, rollback.sessionID, models.SessionMetaKeyPendingStepCompletion, pendingStep); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1880,20 +1972,36 @@ func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, 
 // is visible in the conversation. Mirrors the message.add path used by the UI.
 // metadata is attached to the resulting Message row (used for sender_task_id /
 // sender_task_title / sender_session_id when called from handleMessageTask).
-func (h *Handlers) recordUserMessage(ctx context.Context, taskID, sessionID, prompt string, metadata map[string]interface{}) {
+func (h *Handlers) recordUserMessage(ctx context.Context, taskID, sessionID, prompt string, metadata map[string]interface{}) *models.Message {
 	if h.taskSvc == nil {
-		return
+		return nil
 	}
-	if _, err := h.taskSvc.CreateMessage(ctx, &service.CreateMessageRequest{
+	message, err := h.taskSvc.CreateMessage(ctx, &service.CreateMessageRequest{
 		TaskSessionID: sessionID,
 		TaskID:        taskID,
 		Content:       prompt,
 		AuthorType:    "user",
 		Metadata:      metadata,
-	}); err != nil {
+	})
+	if err != nil {
 		h.logger.Warn("failed to record user message for message_task",
 			zap.String("task_id", taskID),
 			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return nil
+	}
+	return message
+}
+
+func (h *Handlers) deleteRecordedUserMessage(ctx context.Context, message *models.Message) {
+	if h.taskSvc == nil || message == nil {
+		return
+	}
+	if err := h.taskSvc.DeleteMessage(ctx, message.ID); err != nil {
+		h.logger.Warn("failed to delete rejected user message for message_task",
+			zap.String("message_id", message.ID),
+			zap.String("task_id", message.TaskID),
+			zap.String("session_id", message.TaskSessionID),
 			zap.Error(err))
 	}
 }

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -1659,6 +1659,10 @@ type taskMessageSessionRollbackRepository interface {
 	SetSessionMetadataKey(ctx context.Context, sessionID, key string, value interface{}) error
 }
 
+type taskMessageExecutorReader interface {
+	GetExecutorRunningBySessionID(ctx context.Context, sessionID string) (*models.ExecutorRunning, error)
+}
+
 func (r *taskMessageReviewRollback) captureSessions(ctx context.Context, repo SessionRepository, taskID string, fallback *models.TaskSession) error {
 	if !r.changed || fallback == nil {
 		return nil
@@ -1774,16 +1778,14 @@ func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID strin
 	case models.TaskSessionStateRunning, models.TaskSessionStateStarting:
 		return h.queueTaskMessage(ctx, taskID, session, prompt, metadata)
 	default:
-		if shouldStartTaskMessageSession(session) {
-			// Start first, then record the user message ourselves with sender
-			// metadata. This avoids leaving an orphaned attributed chat row when
-			// StartCreatedSession fails (the previous order wrote the row up-front
-			// regardless of launch outcome). skipMessageRecord=true keeps
-			// postLaunchCreated from writing its own duplicate row.
+		if h.shouldStartTaskMessageSession(ctx, session) {
+			// Record before starting so the message is tied to the turn produced
+			// by launch. If launch fails, delete the row below.
+			recorded := h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 			if _, err := h.sessionLauncher.StartCreatedSession(ctx, taskID, session.ID, session.AgentProfileID, prompt, true, false, true, nil); err != nil {
+				h.deleteRecordedUserMessage(ctx, recorded)
 				return taskMessageDispatchResult{}, fmt.Errorf("failed to start session: %w", err)
 			}
-			h.recordUserMessage(ctx, taskID, session.ID, prompt, metadata)
 			return taskMessageDispatchResult{status: "started", sessionID: session.ID}, nil
 		}
 		// Record before prompting so the message is tied to the turn that
@@ -1799,7 +1801,7 @@ func (h *Handlers) dispatchPreparedTaskMessage(ctx context.Context, taskID strin
 	}
 }
 
-func shouldStartTaskMessageSession(session *models.TaskSession) bool {
+func (h *Handlers) shouldStartTaskMessageSession(ctx context.Context, session *models.TaskSession) bool {
 	if session.State == models.TaskSessionStateCreated {
 		return true
 	}
@@ -1807,8 +1809,18 @@ func shouldStartTaskMessageSession(session *models.TaskSession) bool {
 	// WAITING_FOR_INPUT before an executor row exists. It may also switch to a
 	// fresh waiting primary session. In both cases the first message still needs
 	// the launch path; already-bound waiting sessions use prompt/resume.
-	return session.State == models.TaskSessionStateWaitingForInput &&
-		session.AgentExecutionID == ""
+	if session.State != models.TaskSessionStateWaitingForInput {
+		return false
+	}
+	if session.AgentExecutionID == "" {
+		return true
+	}
+	reader, ok := h.sessionRepo.(taskMessageExecutorReader)
+	if !ok {
+		return false
+	}
+	running, err := reader.GetExecutorRunningBySessionID(ctx, session.ID)
+	return err == nil && running != nil && running.Status == models.ExecutorRunningStatusPrepared
 }
 
 func (h *Handlers) queueTaskMessage(ctx context.Context, taskID string, session *models.TaskSession, prompt string, metadata map[string]interface{}) (taskMessageDispatchResult, error) {
@@ -1878,6 +1890,13 @@ func (h *Handlers) restoreTaskReviewForTaskMessage(ctx context.Context, taskID s
 			zap.Error(err))
 	}
 	if !rollback.restoreTask {
+		if _, err := h.taskSvc.UpdateTask(ctx, taskID, &service.UpdateTaskRequest{
+			WorkflowStepID: &rollback.workflowStepID,
+		}); err != nil {
+			h.logger.Warn("failed to restore task workflow step after task message dispatch failure",
+				zap.String("task_id", taskID),
+				zap.Error(err))
+		}
 		return
 	}
 	reviewState := v1.TaskStateReview
@@ -1906,12 +1925,28 @@ func (h *Handlers) restoreTaskMessageSessions(ctx context.Context, rollback task
 	}
 	if rollback.selectedID != "" {
 		if _, ok := rollback.sessionIDs[rollback.selectedID]; !ok {
+			if primaryID := rollback.primarySessionID(); primaryID != "" {
+				if queue := h.sessionLauncher.GetMessageQueue(); queue != nil {
+					if err := queue.TransferSession(ctx, rollback.selectedID, primaryID); err != nil {
+						return err
+					}
+				}
+			}
 			if err := repo.DeleteTaskSession(ctx, rollback.selectedID); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func (r taskMessageReviewRollback) primarySessionID() string {
+	for _, session := range r.sessions {
+		if session.isPrimary {
+			return session.sessionID
+		}
+	}
+	return ""
 }
 
 func restoreTaskMessageSessionSnapshot(ctx context.Context, repo taskMessageSessionRollbackRepository, rollback taskMessageSessionRollback) error {

--- a/apps/backend/internal/mcp/handlers/handlers.go
+++ b/apps/backend/internal/mcp/handlers/handlers.go
@@ -2031,29 +2031,11 @@ func (h *Handlers) restoreTaskMessageQueues(ctx context.Context, rollback taskMe
 }
 
 func (h *Handlers) restoreTaskMessageQueue(ctx context.Context, queue *messagequeue.Service, sessionID string, snapshot taskMessageQueueRollback) error {
-	if _, err := queue.CancelAll(ctx, sessionID); err != nil {
-		return err
-	}
-	_, _ = queue.TakePendingMove(ctx, sessionID)
-	for _, entry := range snapshot.entries {
-		if _, err := queue.QueueMessageWithMetadata(
-			ctx,
-			sessionID,
-			entry.TaskID,
-			entry.Content,
-			entry.Model,
-			entry.QueuedBy,
-			entry.PlanMode,
-			entry.Attachments,
-			entry.Metadata,
-		); err != nil {
-			return err
-		}
-	}
+	var pendingMove *messagequeue.PendingMove
 	if snapshot.hadPendingMove {
-		queue.SetPendingMove(ctx, sessionID, cloneTaskMessagePendingMove(snapshot.pendingMove))
+		pendingMove = cloneTaskMessagePendingMove(snapshot.pendingMove)
 	}
-	return nil
+	return queue.RestoreSession(ctx, sessionID, cloneTaskMessageQueuedMessages(snapshot.entries), pendingMove)
 }
 
 func (h *Handlers) clearTaskMessageQueue(ctx context.Context, sessionID string) {
@@ -2104,14 +2086,14 @@ func (h *Handlers) resolveSessionAfterTaskMessageTurnStart(ctx context.Context, 
 		return nil, fmt.Errorf("failed to reload session after on_turn_start: %w", err)
 	}
 	primary, err := h.taskSvc.GetPrimarySession(ctx, taskID)
-	if err == nil && primary != nil && primary.ID != submitted.ID {
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve primary session after on_turn_start: %w", err)
+	}
+	if primary != nil && primary.ID != submitted.ID {
 		return primary, nil
 	}
 	if reloaded.State != models.TaskSessionStateCompleted {
 		return reloaded, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("session was switched but no active session found: %w", err)
 	}
 	if primary == nil {
 		return nil, errors.New("session was switched but no active session found")

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -1182,6 +1182,9 @@ func (m *mockSessionLauncher) StartCreatedSession(context.Context, string, strin
 func (m *mockSessionLauncher) ResumeTaskSession(context.Context, string, string) (*executor.TaskExecution, error) {
 	return nil, nil
 }
+func (m *mockSessionLauncher) ProcessOnTurnStart(context.Context, string, string) error {
+	return nil
+}
 func (m *mockSessionLauncher) GetMessageQueue() *messagequeue.Service { return nil }
 
 func TestAutoStartTask_DefaultsToWorktreeExecutor(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/handlers_test.go
+++ b/apps/backend/internal/mcp/handlers/handlers_test.go
@@ -35,6 +35,11 @@ import (
 // newTestTaskService creates a real task service with a temporary file-backed SQLite DB for integration tests.
 // Returns the service and the raw repo (for seeding data).
 func newTestTaskService(t *testing.T) (*service.Service, *sqliterepo.Repository) {
+	svc, repo, _ := newTestTaskServiceWithEventBus(t)
+	return svc, repo
+}
+
+func newTestTaskServiceWithEventBus(t *testing.T) (*service.Service, *sqliterepo.Repository, *bus.MemoryEventBus) {
 	t.Helper()
 	dbConn, err := db.OpenSQLite(filepath.Join(t.TempDir(), "test.db"))
 	require.NoError(t, err)
@@ -65,7 +70,7 @@ func newTestTaskService(t *testing.T) (*service.Service, *sqliterepo.Repository)
 		Environments: repo,
 		Reviews:      repo,
 	}, eventBus, log, service.RepositoryDiscoveryConfig{})
-	return svc, repo
+	return svc, repo, eventBus
 }
 
 func newTestTaskServiceWithWorkflow(t *testing.T) (*service.Service, *sqliterepo.Repository, *workflowcontroller.Controller, *workflowrepo.Repository) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -742,6 +742,15 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	}
 	require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, models.SessionMetaKeyPendingStepCompletion, pendingSignal))
 	require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, "plan_mode", true))
+	require.NoError(t, repo.UpdateTaskSession(ctx, &models.TaskSession{
+		ID:                   sess.ID,
+		TaskID:               target.ID,
+		AgentProfileID:       "agent-profile-1",
+		ExecutorProfileID:    "executor-profile-1",
+		AgentProfileSnapshot: map[string]interface{}{"id": "agent-profile-1", "name": "Agent One"},
+		State:                models.TaskSessionStateWaitingForInput,
+		IsPrimary:            true,
+	}))
 
 	h, orch := newMessageTaskHandler(t, svc, repo)
 	_, err = orch.queue.QueueMessageWithMetadata(ctx, sess.ID, target.ID, "queued before switch", "", "agent", false, nil, nil)
@@ -763,6 +772,9 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 		require.NoError(t, err)
 		oldSession.State = models.TaskSessionStateCompleted
 		oldSession.IsPrimary = false
+		oldSession.AgentProfileID = "agent-profile-mutated"
+		oldSession.ExecutorProfileID = "executor-profile-mutated"
+		oldSession.AgentProfileSnapshot = map[string]interface{}{"id": "agent-profile-mutated", "name": "Mutated"}
 		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
 		replacement := &models.TaskSession{
 			ID:             replacementID,
@@ -797,6 +809,9 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	assert.Equal(t, sess.ID, primary.ID)
 	assert.Equal(t, models.TaskSessionStateWaitingForInput, primary.State)
 	assert.True(t, primary.IsPrimary)
+	assert.Equal(t, "agent-profile-1", primary.AgentProfileID)
+	assert.Equal(t, "executor-profile-1", primary.ExecutorProfileID)
+	assert.Equal(t, "Agent One", primary.AgentProfileSnapshot["name"])
 	_, ok := models.LoadPendingStepSignal(primary.Metadata)
 	require.True(t, ok)
 	assert.Equal(t, true, primary.Metadata["plan_mode"])
@@ -882,6 +897,66 @@ func TestHandleMessageTask_DispatchErrorAfterExistingSessionSwitchRestoresQueues
 	move, ok := orch.queue.TakePendingMove(ctx, replacementID)
 	require.True(t, ok)
 	assert.Equal(t, "replacement-step", move.WorkflowStepID)
+}
+
+func TestHandleMessageTask_DispatchErrorRollsBackTurnStartOutsideReview(t *testing.T) {
+	ctx := context.Background()
+	svc, repo, _ := newTestTaskServiceWithEventBus(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateInProgress
+	task.WorkflowStepID = "step-in-progress"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc, repo)
+	_, err = orch.queue.QueueMessageWithMetadata(ctx, sess.ID, target.ID, "original queued", "", "agent", false, nil, nil)
+	require.NoError(t, err)
+	replacementID := "sess-2"
+	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
+		updatedTask, err := svc.GetTask(ctx, taskID)
+		require.NoError(t, err)
+		updatedTask.WorkflowStepID = "step-next"
+		require.NoError(t, repo.UpdateTask(ctx, updatedTask))
+
+		oldSession, err := svc.GetTaskSession(ctx, sess.ID)
+		require.NoError(t, err)
+		oldSession.State = models.TaskSessionStateCompleted
+		oldSession.IsPrimary = false
+		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
+		replacement := &models.TaskSession{
+			ID:             replacementID,
+			TaskID:         target.ID,
+			AgentProfileID: "agent-profile-2",
+			State:          models.TaskSessionStateWaitingForInput,
+		}
+		require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+		require.NoError(t, orch.queue.TransferSession(ctx, sess.ID, replacementID))
+		require.NoError(t, repo.SetSessionPrimary(ctx, replacementID))
+		return nil
+	}
+	orch.startCreatedErr = errors.New("start failed")
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "fails after non-review switch", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
+	assert.Equal(t, "step-in-progress", updatedTask.WorkflowStepID)
+
+	primary, err := svc.GetPrimarySession(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sess.ID, primary.ID)
+	assert.Equal(t, models.TaskSessionStateWaitingForInput, primary.State)
+	_, err = svc.GetTaskSession(ctx, replacementID)
+	assert.ErrorIs(t, err, models.ErrTaskSessionNotFound)
+	status := orch.queue.GetStatus(ctx, sess.ID)
+	require.Equal(t, 1, status.Count)
+	assert.Equal(t, "original queued", status.Entries[0].Content)
 }
 
 func TestHandleMessageTask_OfficeReviewDoesNotTransitionTaskState(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/kandev/kandev/internal/events"
 	"github.com/kandev/kandev/internal/events/bus"
@@ -661,16 +662,16 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	task.WorkflowStepID = "step-review"
 	require.NoError(t, repo.UpdateTask(ctx, task))
 
-	replacement := &models.TaskSession{
-		ID:             "sess-2",
-		TaskID:         target.ID,
-		AgentProfileID: "agent-profile-2",
-		State:          models.TaskSessionStateWaitingForInput,
-		IsPrimary:      false,
+	pendingSignal := models.PendingStepCompletionSignal{
+		StepID:     "step-review",
+		Source:     models.StepCompletionSourceAgent,
+		Summary:    "ready",
+		SignaledAt: time.Now().UTC(),
 	}
-	require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+	require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, models.SessionMetaKeyPendingStepCompletion, pendingSignal))
 
 	h, orch := newMessageTaskHandler(t, svc, repo)
+	replacementID := "sess-2"
 	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
 		updatedTask, err := svc.GetTask(ctx, taskID)
 		require.NoError(t, err)
@@ -682,7 +683,16 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 		oldSession.State = models.TaskSessionStateCompleted
 		oldSession.IsPrimary = false
 		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
-		require.NoError(t, repo.SetSessionPrimary(ctx, replacement.ID))
+		replacement := &models.TaskSession{
+			ID:             replacementID,
+			TaskID:         target.ID,
+			AgentProfileID: "agent-profile-2",
+			State:          models.TaskSessionStateWaitingForInput,
+			IsPrimary:      false,
+		}
+		require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+		require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, models.SessionMetaKeyPendingStepCompletion, nil))
+		require.NoError(t, repo.SetSessionPrimary(ctx, replacementID))
 		return nil
 	}
 	orch.startCreatedErr = errors.New("start failed")
@@ -704,16 +714,46 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	assert.Equal(t, sess.ID, primary.ID)
 	assert.Equal(t, models.TaskSessionStateWaitingForInput, primary.State)
 	assert.True(t, primary.IsPrimary)
+	_, ok := models.LoadPendingStepSignal(primary.Metadata)
+	require.True(t, ok)
 
-	switched, err := svc.GetTaskSession(ctx, replacement.ID)
-	require.NoError(t, err)
-	assert.False(t, switched.IsPrimary)
+	_, err = svc.GetTaskSession(ctx, replacementID)
+	assert.ErrorIs(t, err, models.ErrTaskSessionNotFound)
 
 	assert.Empty(t, orch.promptCalls)
 	require.Len(t, orch.startCreatedCalls, 1)
-	messages, err := svc.ListMessages(ctx, replacement.ID)
+	messages, err := svc.ListMessages(ctx, replacementID)
 	require.NoError(t, err)
 	assert.Empty(t, messages)
+}
+
+func TestHandleMessageTask_OfficeReviewDoesNotTransitionTaskState(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
+	task.AssigneeAgentProfileID = "agent-profile-1"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc, repo)
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "office review follow-up", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
+	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
+
+	require.Len(t, orch.promptCalls, 1)
+	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
 }
 
 func TestHandleMessageTask_PromptFailsWithExecutionNotFound_AutoResumes(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -446,6 +446,44 @@ func TestHandleMessageTask_WaitingForInput_UsesSessionSelectedByTurnStart(t *tes
 	assert.Contains(t, newMessages[0].Content, "handoff after switch")
 }
 
+func TestHandleMessageTask_WaitingForInput_UsesPrimarySwitchWithoutCompletion(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	replacement := &models.TaskSession{
+		ID:             "sess-2",
+		TaskID:         target.ID,
+		AgentProfileID: "agent-profile-2",
+		State:          models.TaskSessionStateWaitingForInput,
+		IsPrimary:      false,
+	}
+	require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+
+	h, orch := newMessageTaskHandler(t, svc, repo)
+	orch.onTurnStart = func(ctx context.Context, _, _ string) error {
+		oldSession, err := svc.GetTaskSession(ctx, sess.ID)
+		require.NoError(t, err)
+		oldSession.IsPrimary = false
+		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
+		require.NoError(t, repo.SetSessionPrimary(ctx, replacement.ID))
+		return nil
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "primary moved", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, "started", payload["status"])
+	assert.Equal(t, replacement.ID, payload["session_id"])
+	require.Len(t, orch.startCreatedCalls, 1)
+	assert.Equal(t, replacement.ID, orch.startCreatedCalls[0].sessionID)
+}
+
 func TestHandleMessageTask_CompletedSessionWithoutSwitch_PromptsSameSession(t *testing.T) {
 	ctx := context.Background()
 	svc, repo := newTestTaskService(t)
@@ -547,6 +585,9 @@ func TestHandleMessageTask_WaitingForInputCompletedWithoutPrimarySwitchRejects(t
 	messages, err := svc.ListMessages(ctx, sess.ID)
 	require.NoError(t, err)
 	assert.Empty(t, messages)
+	activeTurn, err := svc.GetActiveTurn(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Nil(t, activeTurn)
 }
 
 func TestHandleMessageTask_CreatedSessionStartsAfterTurnStartChangesState(t *testing.T) {
@@ -659,6 +700,7 @@ func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
 		updatedTask, err := svc.GetTask(ctx, taskID)
 		require.NoError(t, err)
+		updatedTask.State = v1.TaskStateFailed
 		updatedTask.WorkflowStepID = "step-in-progress"
 		return repo.UpdateTask(ctx, updatedTask)
 	}
@@ -808,6 +850,7 @@ func TestHandleMessageTask_OfficeDispatchErrorRestoresWorkflowStep(t *testing.T)
 	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
 		updatedTask, err := svc.GetTask(ctx, taskID)
 		require.NoError(t, err)
+		updatedTask.State = v1.TaskStateFailed
 		updatedTask.WorkflowStepID = "step-in-progress"
 		return repo.UpdateTask(ctx, updatedTask)
 	}

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -375,6 +376,11 @@ func TestHandleMessageTask_WaitingForInput_UsesSessionSelectedByTurnStart(t *tes
 	require.NotNil(t, resp)
 	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
 
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, "sent", payload["status"])
+	assert.Equal(t, replacement.ID, payload["session_id"])
+
 	require.Len(t, orch.promptCalls, 1)
 	assert.Equal(t, replacement.ID, orch.promptCalls[0].sessionID)
 
@@ -385,6 +391,86 @@ func TestHandleMessageTask_WaitingForInput_UsesSessionSelectedByTurnStart(t *tes
 	require.NoError(t, err)
 	require.Len(t, newMessages, 1)
 	assert.Contains(t, newMessages[0].Content, "handoff after switch")
+}
+
+func TestHandleMessageTask_CreatedSessionStartsAfterTurnStartChangesState(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateCreated)
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(ctx context.Context, _, sessionID string) error {
+		require.Equal(t, sess.ID, sessionID)
+		return repo.UpdateTaskSessionState(ctx, sess.ID, models.TaskSessionStateWaitingForInput, "")
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "start after trigger", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, "started", payload["status"])
+	assert.Equal(t, sess.ID, payload["session_id"])
+
+	require.Len(t, orch.startCreatedCalls, 1)
+	assert.Equal(t, sess.ID, orch.startCreatedCalls[0].sessionID)
+	assert.Empty(t, orch.promptCalls)
+}
+
+func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(context.Context, string, string) error {
+		return errors.New("turn start failed")
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "cannot send", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
+	assert.Empty(t, orch.promptCalls)
+	messages, err := svc.ListMessages(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, messages)
+}
+
+func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, _ := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.promptErrFirst = errors.New("send failed")
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "fails during dispatch", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
+	require.Len(t, orch.promptCalls, 1)
 }
 
 func TestHandleMessageTask_PromptFailsWithExecutionNotFound_AutoResumes(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -576,6 +576,36 @@ func TestHandleMessageTask_CreatedSessionStartsAfterTurnStartChangesState(t *tes
 	assert.Empty(t, orch.promptCalls)
 }
 
+func TestHandleMessageTask_PreparedWaitingSessionStartsAgent(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateCreated)
+	require.NoError(t, repo.UpdateTaskSessionState(ctx, sess.ID, models.TaskSessionStateWaitingForInput, ""))
+	require.NoError(t, repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "exec-row-" + sess.ID,
+		SessionID:        sess.ID,
+		TaskID:           target.ID,
+		Status:           models.ExecutorRunningStatusPrepared,
+		Resumable:        true,
+		AgentExecutionID: "exec-" + sess.ID,
+	}))
+
+	h, orch := newMessageTaskHandler(t, svc, repo)
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "start prepared", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, "started", payload["status"])
+	assert.Equal(t, sess.ID, payload["session_id"])
+	require.Len(t, orch.startCreatedCalls, 1)
+	assert.Empty(t, orch.promptCalls)
+}
+
 func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) {
 	ctx := context.Background()
 	svc, repo, eventBus := newTestTaskServiceWithEventBus(t)
@@ -671,6 +701,8 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, models.SessionMetaKeyPendingStepCompletion, pendingSignal))
 
 	h, orch := newMessageTaskHandler(t, svc, repo)
+	_, err = orch.queue.QueueMessageWithMetadata(ctx, sess.ID, target.ID, "queued before switch", "", "agent", false, nil, nil)
+	require.NoError(t, err)
 	replacementID := "sess-2"
 	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
 		updatedTask, err := svc.GetTask(ctx, taskID)
@@ -692,6 +724,7 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 		}
 		require.NoError(t, repo.CreateTaskSession(ctx, replacement))
 		require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, models.SessionMetaKeyPendingStepCompletion, nil))
+		require.NoError(t, orch.queue.TransferSession(ctx, sess.ID, replacementID))
 		require.NoError(t, repo.SetSessionPrimary(ctx, replacementID))
 		return nil
 	}
@@ -725,6 +758,9 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	messages, err := svc.ListMessages(ctx, replacementID)
 	require.NoError(t, err)
 	assert.Empty(t, messages)
+	status := orch.queue.GetStatus(ctx, sess.ID)
+	require.Equal(t, 1, status.Count)
+	assert.Equal(t, "queued before switch", status.Entries[0].Content)
 }
 
 func TestHandleMessageTask_OfficeReviewDoesNotTransitionTaskState(t *testing.T) {
@@ -754,6 +790,38 @@ func TestHandleMessageTask_OfficeReviewDoesNotTransitionTaskState(t *testing.T) 
 
 	require.Len(t, orch.promptCalls, 1)
 	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
+}
+
+func TestHandleMessageTask_OfficeDispatchErrorRestoresWorkflowStep(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, _ := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
+	task.AssigneeAgentProfileID = "agent-profile-1"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc, repo)
+	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
+		updatedTask, err := svc.GetTask(ctx, taskID)
+		require.NoError(t, err)
+		updatedTask.WorkflowStepID = "step-in-progress"
+		return repo.UpdateTask(ctx, updatedTask)
+	}
+	orch.promptErrFirst = errors.New("send failed")
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "office failure", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
+	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
 }
 
 func TestHandleMessageTask_PromptFailsWithExecutionNotFound_AutoResumes(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -37,7 +37,8 @@ type fakeOrchestrator struct {
 
 	// Configurable: error returned by PromptTask. Cleared after first call so
 	// the retry-after-resume path can succeed on the second call.
-	promptErrFirst error
+	promptErrFirst  error
+	startCreatedErr error
 }
 
 type promptCall struct {
@@ -78,6 +79,9 @@ func (f *fakeOrchestrator) StartCreatedSession(_ context.Context, taskID, sessio
 		prompt:            prompt,
 		skipMessageRecord: skipMessageRecord,
 	})
+	if f.startCreatedErr != nil {
+		return nil, f.startCreatedErr
+	}
 	return &executor.TaskExecution{SessionID: sessionID}, nil
 }
 
@@ -115,6 +119,9 @@ func newMessageTaskHandler(t *testing.T, svc *service.Service, taskRepo ...TaskR
 		sessionLauncher: orch,
 		logger:          log.WithFields(),
 	}
+	if sessionRepo, ok := repo.(SessionRepository); ok {
+		h.sessionRepo = sessionRepo
+	}
 	return h, orch
 }
 
@@ -149,6 +156,7 @@ type seedRepo interface {
 	CreateWorkflow(context.Context, *models.Workflow) error
 	CreateTaskSession(context.Context, *models.TaskSession) error
 	UpdateTaskSessionState(context.Context, string, models.TaskSessionState, string) error
+	UpsertExecutorRunning(context.Context, *models.ExecutorRunning) error
 }
 
 // seedTaskWithSession creates a workspace, workflow, target task with a primary
@@ -183,6 +191,16 @@ func seedTaskWithSession(t *testing.T, svc *service.Service, repo seedRepo, stat
 	require.NoError(t, repo.CreateTaskSession(ctx, sess))
 	if state != models.TaskSessionStateCreated {
 		require.NoError(t, repo.UpdateTaskSessionState(ctx, sess.ID, state, ""))
+	}
+	if state == models.TaskSessionStateWaitingForInput {
+		require.NoError(t, repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+			ID:               "exec-row-" + sess.ID,
+			SessionID:        sess.ID,
+			TaskID:           target.ID,
+			Status:           "running",
+			Resumable:        true,
+			AgentExecutionID: "exec-" + sess.ID,
+		}))
 	}
 	loaded, err := svc.GetTaskSession(ctx, sess.ID)
 	require.NoError(t, err)
@@ -411,11 +429,12 @@ func TestHandleMessageTask_WaitingForInput_UsesSessionSelectedByTurnStart(t *tes
 
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
-	assert.Equal(t, "sent", payload["status"])
+	assert.Equal(t, "started", payload["status"])
 	assert.Equal(t, replacement.ID, payload["session_id"])
 
-	require.Len(t, orch.promptCalls, 1)
-	assert.Equal(t, replacement.ID, orch.promptCalls[0].sessionID)
+	require.Len(t, orch.startCreatedCalls, 1)
+	assert.Equal(t, replacement.ID, orch.startCreatedCalls[0].sessionID)
+	assert.Empty(t, orch.promptCalls)
 
 	oldMessages, err := svc.ListMessages(ctx, sess.ID)
 	require.NoError(t, err)
@@ -486,11 +505,12 @@ func TestHandleMessageTask_CompletedSession_UsesSessionSelectedByTurnStart(t *te
 
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
-	assert.Equal(t, "sent", payload["status"])
+	assert.Equal(t, "started", payload["status"])
 	assert.Equal(t, replacement.ID, payload["session_id"])
 
-	require.Len(t, orch.promptCalls, 1)
-	assert.Equal(t, replacement.ID, orch.promptCalls[0].sessionID)
+	require.Len(t, orch.startCreatedCalls, 1)
+	assert.Equal(t, replacement.ID, orch.startCreatedCalls[0].sessionID)
+	assert.Empty(t, orch.promptCalls)
 
 	oldMessages, err := svc.ListMessages(ctx, sess.ID)
 	require.NoError(t, err)
@@ -624,6 +644,73 @@ func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
 	assertTaskStateChangedEvent(t, stateEvents, target.ID, v1.TaskStateReview, "step-review")
 	require.Len(t, orch.promptCalls, 1)
+}
+
+func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(t *testing.T) {
+	ctx := context.Background()
+	svc, repo, eventBus := newTestTaskServiceWithEventBus(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	stateEvents := subscribeTaskStateChanged(t, eventBus)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	replacement := &models.TaskSession{
+		ID:             "sess-2",
+		TaskID:         target.ID,
+		AgentProfileID: "agent-profile-2",
+		State:          models.TaskSessionStateWaitingForInput,
+		IsPrimary:      false,
+	}
+	require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+
+	h, orch := newMessageTaskHandler(t, svc, repo)
+	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
+		updatedTask, err := svc.GetTask(ctx, taskID)
+		require.NoError(t, err)
+		updatedTask.WorkflowStepID = "step-in-progress"
+		require.NoError(t, repo.UpdateTask(ctx, updatedTask))
+
+		oldSession, err := svc.GetTaskSession(ctx, sess.ID)
+		require.NoError(t, err)
+		oldSession.State = models.TaskSessionStateCompleted
+		oldSession.IsPrimary = false
+		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
+		require.NoError(t, repo.SetSessionPrimary(ctx, replacement.ID))
+		return nil
+	}
+	orch.startCreatedErr = errors.New("start failed")
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "fails after switch", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
+	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
+	assertTaskStateChangedEvent(t, stateEvents, target.ID, v1.TaskStateReview, "step-review")
+
+	primary, err := svc.GetPrimarySession(ctx, target.ID)
+	require.NoError(t, err)
+	require.NotNil(t, primary)
+	assert.Equal(t, sess.ID, primary.ID)
+	assert.Equal(t, models.TaskSessionStateWaitingForInput, primary.State)
+	assert.True(t, primary.IsPrimary)
+
+	switched, err := svc.GetTaskSession(ctx, replacement.ID)
+	require.NoError(t, err)
+	assert.False(t, switched.IsPrimary)
+
+	assert.Empty(t, orch.promptCalls)
+	require.Len(t, orch.startCreatedCalls, 1)
+	messages, err := svc.ListMessages(ctx, replacement.ID)
+	require.NoError(t, err)
+	assert.Empty(t, messages)
 }
 
 func TestHandleMessageTask_PromptFailsWithExecutionNotFound_AutoResumes(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -393,6 +393,67 @@ func TestHandleMessageTask_WaitingForInput_UsesSessionSelectedByTurnStart(t *tes
 	assert.Contains(t, newMessages[0].Content, "handoff after switch")
 }
 
+func TestHandleMessageTask_CompletedSessionWithoutSwitch_PromptsSameSession(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateCompleted)
+
+	h, orch := newMessageTaskHandler(t, svc)
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "follow up completed", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, "sent", payload["status"])
+	assert.Equal(t, sess.ID, payload["session_id"])
+
+	require.Len(t, orch.promptCalls, 1)
+	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
+}
+
+func TestHandleMessageTask_CompletedSession_UsesSessionSelectedByTurnStart(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateCompleted)
+
+	replacement := &models.TaskSession{
+		ID:             "sess-2",
+		TaskID:         target.ID,
+		AgentProfileID: "agent-profile-2",
+		State:          models.TaskSessionStateWaitingForInput,
+		IsPrimary:      false,
+	}
+	require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(ctx context.Context, _, _ string) error {
+		oldSession, err := svc.GetTaskSession(ctx, sess.ID)
+		require.NoError(t, err)
+		oldSession.IsPrimary = false
+		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
+		require.NoError(t, repo.SetSessionPrimary(ctx, replacement.ID))
+		return nil
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "handoff from completed", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, "sent", payload["status"])
+	assert.Equal(t, replacement.ID, payload["session_id"])
+
+	require.Len(t, orch.promptCalls, 1)
+	assert.Equal(t, replacement.ID, orch.promptCalls[0].sessionID)
+}
+
 func TestHandleMessageTask_CreatedSessionStartsAfterTurnStartChangesState(t *testing.T) {
 	ctx := context.Background()
 	svc, repo := newTestTaskService(t)

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"testing/synctest"
 
+	"github.com/kandev/kandev/internal/events"
+	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/orchestrator"
 	"github.com/kandev/kandev/internal/orchestrator/executor"
 	"github.com/kandev/kandev/internal/orchestrator/messagequeue"
@@ -114,6 +116,32 @@ func newMessageTaskHandler(t *testing.T, svc *service.Service, taskRepo ...TaskR
 		logger:          log.WithFields(),
 	}
 	return h, orch
+}
+
+func subscribeTaskStateChanged(t *testing.T, eventBus *bus.MemoryEventBus) <-chan *bus.Event {
+	t.Helper()
+	ch := make(chan *bus.Event, 10)
+	sub, err := eventBus.Subscribe(events.TaskStateChanged, func(_ context.Context, event *bus.Event) error {
+		ch <- event
+		return nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return ch
+}
+
+func assertTaskStateChangedEvent(t *testing.T, ch <-chan *bus.Event, taskID string, state v1.TaskState, workflowStepID string) {
+	t.Helper()
+	for len(ch) > 0 {
+		event := <-ch
+		data, ok := event.Data.(map[string]interface{})
+		require.True(t, ok)
+		if data["task_id"] == taskID && data["state"] == string(state) {
+			assert.Equal(t, workflowStepID, data["workflow_step_id"])
+			return
+		}
+	}
+	t.Fatalf("expected task.state_changed event for task %s state %s", taskID, state)
 }
 
 type seedRepo interface {
@@ -529,8 +557,9 @@ func TestHandleMessageTask_CreatedSessionStartsAfterTurnStartChangesState(t *tes
 
 func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) {
 	ctx := context.Background()
-	svc, repo := newTestTaskService(t)
+	svc, repo, eventBus := newTestTaskServiceWithEventBus(t)
 	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	stateEvents := subscribeTaskStateChanged(t, eventBus)
 
 	task, err := svc.GetTask(ctx, target.ID)
 	require.NoError(t, err)
@@ -556,6 +585,7 @@ func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
 	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
+	assertTaskStateChangedEvent(t, stateEvents, target.ID, v1.TaskStateReview, "step-review")
 	assert.Empty(t, orch.promptCalls)
 	messages, err := svc.ListMessages(ctx, sess.ID)
 	require.NoError(t, err)
@@ -564,8 +594,9 @@ func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) 
 
 func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	ctx := context.Background()
-	svc, repo := newTestTaskService(t)
+	svc, repo, eventBus := newTestTaskServiceWithEventBus(t)
 	sender, target, _ := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	stateEvents := subscribeTaskStateChanged(t, eventBus)
 
 	task, err := svc.GetTask(ctx, target.ID)
 	require.NoError(t, err)
@@ -591,6 +622,7 @@ func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
 	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
+	assertTaskStateChangedEvent(t, stateEvents, target.ID, v1.TaskStateReview, "step-review")
 	require.Len(t, orch.promptCalls, 1)
 }
 

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -753,7 +753,7 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	}))
 
 	h, orch := newMessageTaskHandler(t, svc, repo)
-	_, err = orch.queue.QueueMessageWithMetadata(ctx, sess.ID, target.ID, "queued before switch", "", "agent", false, nil, nil)
+	queuedBeforeSwitch, err := orch.queue.QueueMessageWithMetadata(ctx, sess.ID, target.ID, "queued before switch", "", "agent", false, nil, nil)
 	require.NoError(t, err)
 	orch.queue.SetPendingMove(ctx, sess.ID, &messagequeue.PendingMove{
 		TaskID:         target.ID,
@@ -827,6 +827,9 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	status := orch.queue.GetStatus(ctx, sess.ID)
 	require.Equal(t, 1, status.Count)
 	assert.Equal(t, "queued before switch", status.Entries[0].Content)
+	assert.Equal(t, queuedBeforeSwitch.ID, status.Entries[0].ID)
+	assert.Equal(t, queuedBeforeSwitch.Position, status.Entries[0].Position)
+	assert.Equal(t, queuedBeforeSwitch.QueuedAt, status.Entries[0].QueuedAt)
 	move, ok := orch.queue.TakePendingMove(ctx, sess.ID)
 	require.True(t, ok)
 	assert.Equal(t, "step-review", move.WorkflowStepID)

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -615,7 +615,7 @@ func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) 
 func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	ctx := context.Background()
 	svc, repo, eventBus := newTestTaskServiceWithEventBus(t)
-	sender, target, _ := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
 	stateEvents := subscribeTaskStateChanged(t, eventBus)
 
 	task, err := svc.GetTask(ctx, target.ID)
@@ -644,6 +644,9 @@ func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
 	assertTaskStateChangedEvent(t, stateEvents, target.ID, v1.TaskStateReview, "step-review")
 	require.Len(t, orch.promptCalls, 1)
+	messages, err := svc.ListMessages(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, messages)
 }
 
 func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -99,12 +99,17 @@ func (f *fakeOrchestrator) ProcessOnTurnStart(ctx context.Context, taskID, sessi
 
 func (f *fakeOrchestrator) GetMessageQueue() *messagequeue.Service { return f.queue }
 
-func newMessageTaskHandler(t *testing.T, svc *service.Service) (*Handlers, *fakeOrchestrator) {
+func newMessageTaskHandler(t *testing.T, svc *service.Service, taskRepo ...TaskRepository) (*Handlers, *fakeOrchestrator) {
 	t.Helper()
 	log := testLogger(t)
 	orch := &fakeOrchestrator{queue: messagequeue.NewServiceMemory(log)}
+	var repo TaskRepository
+	if len(taskRepo) > 0 {
+		repo = taskRepo[0]
+	}
 	h := &Handlers{
 		taskSvc:         svc,
+		taskRepo:        repo,
 		sessionLauncher: orch,
 		logger:          log.WithFields(),
 	}
@@ -489,10 +494,15 @@ func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) 
 	task, err := svc.GetTask(ctx, target.ID)
 	require.NoError(t, err)
 	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
 	require.NoError(t, repo.UpdateTask(ctx, task))
 
-	h, orch := newMessageTaskHandler(t, svc)
-	orch.onTurnStart = func(context.Context, string, string) error {
+	h, orch := newMessageTaskHandler(t, svc, repo)
+	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
+		updatedTask, err := svc.GetTask(ctx, taskID)
+		require.NoError(t, err)
+		updatedTask.WorkflowStepID = "step-in-progress"
+		require.NoError(t, repo.UpdateTask(ctx, updatedTask))
 		return errors.New("turn start failed")
 	}
 
@@ -504,6 +514,7 @@ func TestHandleMessageTask_TurnStartErrorRejectsAndRestoresReview(t *testing.T) 
 	updatedTask, err := svc.GetTask(ctx, target.ID)
 	require.NoError(t, err)
 	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
+	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
 	assert.Empty(t, orch.promptCalls)
 	messages, err := svc.ListMessages(ctx, sess.ID)
 	require.NoError(t, err)
@@ -518,9 +529,16 @@ func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	task, err := svc.GetTask(ctx, target.ID)
 	require.NoError(t, err)
 	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
 	require.NoError(t, repo.UpdateTask(ctx, task))
 
-	h, orch := newMessageTaskHandler(t, svc)
+	h, orch := newMessageTaskHandler(t, svc, repo)
+	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
+		updatedTask, err := svc.GetTask(ctx, taskID)
+		require.NoError(t, err)
+		updatedTask.WorkflowStepID = "step-in-progress"
+		return repo.UpdateTask(ctx, updatedTask)
+	}
 	orch.promptErrFirst = errors.New("send failed")
 
 	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "fails during dispatch", sender.ID))
@@ -531,6 +549,7 @@ func TestHandleMessageTask_DispatchErrorRestoresReview(t *testing.T) {
 	updatedTask, err := svc.GetTask(ctx, target.ID)
 	require.NoError(t, err)
 	assert.Equal(t, v1.TaskStateReview, updatedTask.State)
+	assert.Equal(t, "step-review", updatedTask.WorkflowStepID)
 	require.Len(t, orch.promptCalls, 1)
 }
 

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -741,10 +741,17 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 		SignaledAt: time.Now().UTC(),
 	}
 	require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, models.SessionMetaKeyPendingStepCompletion, pendingSignal))
+	require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, "plan_mode", true))
 
 	h, orch := newMessageTaskHandler(t, svc, repo)
 	_, err = orch.queue.QueueMessageWithMetadata(ctx, sess.ID, target.ID, "queued before switch", "", "agent", false, nil, nil)
 	require.NoError(t, err)
+	orch.queue.SetPendingMove(ctx, sess.ID, &messagequeue.PendingMove{
+		TaskID:         target.ID,
+		WorkflowID:     "workflow-1",
+		WorkflowStepID: "step-review",
+		Position:       2,
+	})
 	replacementID := "sess-2"
 	orch.onTurnStart = func(ctx context.Context, taskID, _ string) error {
 		updatedTask, err := svc.GetTask(ctx, taskID)
@@ -766,6 +773,7 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 		}
 		require.NoError(t, repo.CreateTaskSession(ctx, replacement))
 		require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, models.SessionMetaKeyPendingStepCompletion, nil))
+		require.NoError(t, repo.SetSessionMetadataKey(ctx, sess.ID, "plan_mode", nil))
 		require.NoError(t, orch.queue.TransferSession(ctx, sess.ID, replacementID))
 		require.NoError(t, repo.SetSessionPrimary(ctx, replacementID))
 		return nil
@@ -791,6 +799,7 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	assert.True(t, primary.IsPrimary)
 	_, ok := models.LoadPendingStepSignal(primary.Metadata)
 	require.True(t, ok)
+	assert.Equal(t, true, primary.Metadata["plan_mode"])
 
 	_, err = svc.GetTaskSession(ctx, replacementID)
 	assert.ErrorIs(t, err, models.ErrTaskSessionNotFound)
@@ -803,6 +812,76 @@ func TestHandleMessageTask_DispatchErrorAfterSessionSwitchRestoresReviewSession(
 	status := orch.queue.GetStatus(ctx, sess.ID)
 	require.Equal(t, 1, status.Count)
 	assert.Equal(t, "queued before switch", status.Entries[0].Content)
+	move, ok := orch.queue.TakePendingMove(ctx, sess.ID)
+	require.True(t, ok)
+	assert.Equal(t, "step-review", move.WorkflowStepID)
+	assert.Equal(t, 2, move.Position)
+	replacementStatus := orch.queue.GetStatus(ctx, replacementID)
+	assert.Zero(t, replacementStatus.Count)
+	_, ok = orch.queue.TakePendingMove(ctx, replacementID)
+	assert.False(t, ok)
+}
+
+func TestHandleMessageTask_DispatchErrorAfterExistingSessionSwitchRestoresQueues(t *testing.T) {
+	ctx := context.Background()
+	svc, repo, _ := newTestTaskServiceWithEventBus(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	replacementID := "sess-2"
+	replacement := &models.TaskSession{
+		ID:             replacementID,
+		TaskID:         target.ID,
+		AgentProfileID: "agent-profile-2",
+		State:          models.TaskSessionStateWaitingForInput,
+		IsPrimary:      false,
+	}
+	require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+
+	h, orch := newMessageTaskHandler(t, svc, repo)
+	_, err = orch.queue.QueueMessageWithMetadata(ctx, sess.ID, target.ID, "original queued", "", "agent", false, nil, nil)
+	require.NoError(t, err)
+	_, err = orch.queue.QueueMessageWithMetadata(ctx, replacementID, target.ID, "replacement queued", "", "user", false, nil, nil)
+	require.NoError(t, err)
+	orch.queue.SetPendingMove(ctx, replacementID, &messagequeue.PendingMove{
+		TaskID:         target.ID,
+		WorkflowID:     "workflow-1",
+		WorkflowStepID: "replacement-step",
+		Position:       5,
+	})
+
+	orch.onTurnStart = func(ctx context.Context, _, _ string) error {
+		oldSession, err := svc.GetTaskSession(ctx, sess.ID)
+		require.NoError(t, err)
+		oldSession.State = models.TaskSessionStateCompleted
+		oldSession.IsPrimary = false
+		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
+		require.NoError(t, orch.queue.TransferSession(ctx, sess.ID, replacementID))
+		require.NoError(t, repo.SetSessionPrimary(ctx, replacementID))
+		return nil
+	}
+	orch.startCreatedErr = errors.New("start failed")
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "fails after switch", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+
+	primaryStatus := orch.queue.GetStatus(ctx, sess.ID)
+	require.Equal(t, 1, primaryStatus.Count)
+	assert.Equal(t, "original queued", primaryStatus.Entries[0].Content)
+
+	replacementStatus := orch.queue.GetStatus(ctx, replacementID)
+	require.Equal(t, 1, replacementStatus.Count)
+	assert.Equal(t, "replacement queued", replacementStatus.Entries[0].Content)
+	move, ok := orch.queue.TakePendingMove(ctx, replacementID)
+	require.True(t, ok)
+	assert.Equal(t, "replacement-step", move.WorkflowStepID)
 }
 
 func TestHandleMessageTask_OfficeReviewDoesNotTransitionTaskState(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -418,6 +418,12 @@ func TestHandleMessageTask_CompletedSessionWithoutSwitch_PromptsSameSession(t *t
 
 	require.Len(t, orch.promptCalls, 1)
 	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
+
+	messages, err := svc.ListMessages(ctx, sess.ID)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0].Content, "follow up completed")
+	assert.Equal(t, sender.ID, messages[0].Metadata["sender_task_id"])
 }
 
 func TestHandleMessageTask_CompletedSession_UsesSessionSelectedByTurnStart(t *testing.T) {
@@ -457,6 +463,41 @@ func TestHandleMessageTask_CompletedSession_UsesSessionSelectedByTurnStart(t *te
 
 	require.Len(t, orch.promptCalls, 1)
 	assert.Equal(t, replacement.ID, orch.promptCalls[0].sessionID)
+
+	oldMessages, err := svc.ListMessages(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, oldMessages)
+	newMessages, err := svc.ListMessages(ctx, replacement.ID)
+	require.NoError(t, err)
+	require.Len(t, newMessages, 1)
+	assert.Contains(t, newMessages[0].Content, "handoff from completed")
+	assert.Equal(t, sender.ID, newMessages[0].Metadata["sender_task_id"])
+}
+
+func TestHandleMessageTask_WaitingForInputCompletedWithoutPrimarySwitchRejects(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(ctx context.Context, _, _ string) error {
+		oldSession, err := svc.GetTaskSession(ctx, sess.ID)
+		require.NoError(t, err)
+		oldSession.State = models.TaskSessionStateCompleted
+		oldSession.IsPrimary = true
+		return repo.UpdateTaskSession(ctx, oldSession)
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "no handoff", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	assertWSError(t, resp, ws.ErrorCodeInternalError)
+	assert.Contains(t, string(resp.Payload), "marked completed")
+
+	assert.Empty(t, orch.promptCalls)
+	messages, err := svc.ListMessages(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, messages)
 }
 
 func TestHandleMessageTask_CreatedSessionStartsAfterTurnStartChangesState(t *testing.T) {

--- a/apps/backend/internal/mcp/handlers/message_task_test.go
+++ b/apps/backend/internal/mcp/handlers/message_task_test.go
@@ -29,6 +29,8 @@ type fakeOrchestrator struct {
 	promptCalls       []promptCall
 	startCreatedCalls []startCreatedCall
 	resumeCalls       int
+	turnStartCalls    []turnStartCall
+	onTurnStart       func(context.Context, string, string) error
 
 	// Configurable: error returned by PromptTask. Cleared after first call so
 	// the retry-after-resume path can succeed on the second call.
@@ -42,6 +44,9 @@ type promptCall struct {
 type startCreatedCall struct {
 	taskID, sessionID, agentProfileID, prompt string
 	skipMessageRecord                         bool
+}
+type turnStartCall struct {
+	taskID, sessionID string
 }
 
 func (f *fakeOrchestrator) LaunchSession(context.Context, *orchestrator.LaunchSessionRequest) (*orchestrator.LaunchSessionResponse, error) {
@@ -78,6 +83,17 @@ func (f *fakeOrchestrator) ResumeTaskSession(_ context.Context, _, _ string) (*e
 	defer f.mu.Unlock()
 	f.resumeCalls++
 	return &executor.TaskExecution{}, nil
+}
+
+func (f *fakeOrchestrator) ProcessOnTurnStart(ctx context.Context, taskID, sessionID string) error {
+	f.mu.Lock()
+	f.turnStartCalls = append(f.turnStartCalls, turnStartCall{taskID: taskID, sessionID: sessionID})
+	fn := f.onTurnStart
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, taskID, sessionID)
+	}
+	return nil
 }
 
 func (f *fakeOrchestrator) GetMessageQueue() *messagequeue.Service { return f.queue }
@@ -285,6 +301,90 @@ func TestHandleMessageTask_WaitingForInput_PromptsAgent(t *testing.T) {
 	// Sender metadata persists on the recorded row.
 	assert.Equal(t, sender.ID, messages[0].Metadata["sender_task_id"])
 	assert.Equal(t, "Sender task", messages[0].Metadata["sender_task_title"])
+}
+
+func TestHandleMessageTask_WaitingForInput_FiresTurnStart(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	task, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	task.State = v1.TaskStateReview
+	task.WorkflowStepID = "step-review"
+	require.NoError(t, repo.UpdateTask(ctx, task))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(ctx context.Context, taskID, sessionID string) error {
+		assert.Equal(t, target.ID, taskID)
+		assert.Equal(t, sess.ID, sessionID)
+		updatedTask, err := svc.GetTask(ctx, taskID)
+		require.NoError(t, err)
+		assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
+		updatedTask.WorkflowStepID = "step-in-progress"
+		return repo.UpdateTask(ctx, updatedTask)
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "review follow-up", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	require.Len(t, orch.turnStartCalls, 1)
+	assert.Equal(t, target.ID, orch.turnStartCalls[0].taskID)
+	assert.Equal(t, sess.ID, orch.turnStartCalls[0].sessionID)
+
+	updatedTask, err := svc.GetTask(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, v1.TaskStateInProgress, updatedTask.State)
+	assert.Equal(t, "step-in-progress", updatedTask.WorkflowStepID)
+
+	require.Len(t, orch.promptCalls, 1)
+	assert.Equal(t, sess.ID, orch.promptCalls[0].sessionID)
+}
+
+func TestHandleMessageTask_WaitingForInput_UsesSessionSelectedByTurnStart(t *testing.T) {
+	ctx := context.Background()
+	svc, repo := newTestTaskService(t)
+	sender, target, sess := seedTaskWithSession(t, svc, repo, models.TaskSessionStateWaitingForInput)
+
+	replacement := &models.TaskSession{
+		ID:             "sess-2",
+		TaskID:         target.ID,
+		AgentProfileID: "agent-profile-2",
+		State:          models.TaskSessionStateWaitingForInput,
+		IsPrimary:      false,
+	}
+	require.NoError(t, repo.CreateTaskSession(ctx, replacement))
+
+	h, orch := newMessageTaskHandler(t, svc)
+	orch.onTurnStart = func(ctx context.Context, _, _ string) error {
+		oldSession, err := svc.GetTaskSession(ctx, sess.ID)
+		require.NoError(t, err)
+		oldSession.State = models.TaskSessionStateCompleted
+		oldSession.IsPrimary = false
+		require.NoError(t, repo.UpdateTaskSession(ctx, oldSession))
+		require.NoError(t, repo.SetSessionPrimary(ctx, replacement.ID))
+		return nil
+	}
+
+	msg := makeWSMessage(t, ws.ActionMCPMessageTask, senderPayload(target.ID, "handoff after switch", sender.ID))
+	resp, err := h.handleMessageTask(ctx, msg)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, ws.MessageTypeResponse, resp.Type)
+
+	require.Len(t, orch.promptCalls, 1)
+	assert.Equal(t, replacement.ID, orch.promptCalls[0].sessionID)
+
+	oldMessages, err := svc.ListMessages(ctx, sess.ID)
+	require.NoError(t, err)
+	assert.Empty(t, oldMessages)
+	newMessages, err := svc.ListMessages(ctx, replacement.ID)
+	require.NoError(t, err)
+	require.Len(t, newMessages, 1)
+	assert.Contains(t, newMessages[0].Content, "handoff after switch")
 }
 
 func TestHandleMessageTask_PromptFailsWithExecutionNotFound_AutoResumes(t *testing.T) {

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -54,6 +54,10 @@ type Repository interface {
 	// to newSessionID. Used on workflow session switches.
 	TransferSession(ctx context.Context, oldSessionID, newSessionID string) error
 
+	// ReplaceSession replaces a session's queued entries and pending move with
+	// the supplied snapshot, preserving queued-message identity fields.
+	ReplaceSession(ctx context.Context, sessionID string, entries []QueuedMessage, pendingMove *PendingMove) error
+
 	// SetPendingMove upserts the deferred workflow move for a session.
 	SetPendingMove(ctx context.Context, sessionID string, move *PendingMove) error
 

--- a/apps/backend/internal/orchestrator/messagequeue/repository.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository.go
@@ -57,6 +57,10 @@ type Repository interface {
 	// SetPendingMove upserts the deferred workflow move for a session.
 	SetPendingMove(ctx context.Context, sessionID string, move *PendingMove) error
 
+	// GetPendingMove returns the deferred move for a session without removing it.
+	// Returns nil, nil if absent.
+	GetPendingMove(ctx context.Context, sessionID string) (*PendingMove, error)
+
 	// TakePendingMove returns and removes the deferred move for a session.
 	// Returns nil, nil if absent.
 	TakePendingMove(ctx context.Context, sessionID string) (*PendingMove, error)

--- a/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
@@ -257,6 +257,17 @@ func (r *memoryRepository) SetPendingMove(_ context.Context, sessionID string, m
 	return nil
 }
 
+func (r *memoryRepository) GetPendingMove(_ context.Context, sessionID string) (*PendingMove, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	move, ok := r.pendingMoves[sessionID]
+	if !ok {
+		return nil, nil
+	}
+	clone := *move
+	return &clone, nil
+}
+
 func (r *memoryRepository) TakePendingMove(_ context.Context, sessionID string) (*PendingMove, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_memory.go
@@ -246,6 +246,35 @@ func (r *memoryRepository) TransferSession(_ context.Context, oldSessionID, newS
 	return nil
 }
 
+func (r *memoryRepository) ReplaceSession(_ context.Context, sessionID string, entries []QueuedMessage, pendingMove *PendingMove) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(entries) == 0 {
+		delete(r.entries, sessionID)
+		delete(r.nextPosition, sessionID)
+	} else {
+		replaced := make([]*QueuedMessage, 0, len(entries))
+		var maxPos int64
+		for _, entry := range entries {
+			clone := entry
+			clone.SessionID = sessionID
+			if clone.Position > maxPos {
+				maxPos = clone.Position
+			}
+			replaced = append(replaced, &clone)
+		}
+		r.entries[sessionID] = replaced
+		r.nextPosition[sessionID] = maxPos
+	}
+	if pendingMove == nil {
+		delete(r.pendingMoves, sessionID)
+		return nil
+	}
+	clone := *pendingMove
+	r.pendingMoves[sessionID] = &clone
+	return nil
+}
+
 func (r *memoryRepository) SetPendingMove(_ context.Context, sessionID string, move *PendingMove) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -474,6 +474,62 @@ func (r *sqliteRepository) TransferSession(ctx context.Context, oldSessionID, ne
 	return tx.Commit()
 }
 
+func (r *sqliteRepository) ReplaceSession(ctx context.Context, sessionID string, entries []QueuedMessage, pendingMove *PendingMove) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin replace session tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, r.db.Rebind(`DELETE FROM queued_messages WHERE session_id = ?`), sessionID); err != nil {
+		return fmt.Errorf("clear queued messages: %w", err)
+	}
+	for _, entry := range entries {
+		attachmentsJSON, err := marshalAttachments(entry.Attachments)
+		if err != nil {
+			return err
+		}
+		metadataJSON, err := marshalMetadata(entry.Metadata)
+		if err != nil {
+			return err
+		}
+		queuedAt := entry.QueuedAt
+		if queuedAt.IsZero() {
+			queuedAt = time.Now().UTC()
+		}
+		if _, err := tx.ExecContext(ctx, r.db.Rebind(`
+			INSERT INTO queued_messages
+				(id, session_id, task_id, position, content, model, plan_mode, attachments_json, metadata_json, queued_at, queued_by)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`),
+			entry.ID, sessionID, entry.TaskID, entry.Position, entry.Content, entry.Model,
+			boolToInt(entry.PlanMode), attachmentsJSON, metadataJSON, queuedAt, entry.QueuedBy,
+		); err != nil {
+			return fmt.Errorf("restore queued message: %w", err)
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, r.db.Rebind(`DELETE FROM pending_moves WHERE session_id = ?`), sessionID); err != nil {
+		return fmt.Errorf("clear pending move: %w", err)
+	}
+	if pendingMove != nil {
+		queuedAt := pendingMove.QueuedAt
+		if queuedAt.IsZero() {
+			queuedAt = time.Now().UTC()
+		}
+		if _, err := tx.ExecContext(ctx, r.db.Rebind(`
+			INSERT INTO pending_moves (id, session_id, task_id, workflow_id, workflow_step_id, step_position, queued_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`),
+			uuid.New().String(), sessionID, pendingMove.TaskID, pendingMove.WorkflowID,
+			pendingMove.WorkflowStepID, pendingMove.Position, queuedAt,
+		); err != nil {
+			return fmt.Errorf("restore pending move: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
 func (r *sqliteRepository) SetPendingMove(ctx context.Context, sessionID string, move *PendingMove) error {
 	if move.QueuedAt.IsZero() {
 		move.QueuedAt = time.Now().UTC()

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite.go
@@ -496,6 +496,30 @@ func (r *sqliteRepository) SetPendingMove(ctx context.Context, sessionID string,
 	return nil
 }
 
+func (r *sqliteRepository) GetPendingMove(ctx context.Context, sessionID string) (*PendingMove, error) {
+	var (
+		taskID, workflowID, workflowStepID string
+		position                           int
+		queuedAt                           time.Time
+	)
+	if err := r.ro.QueryRowxContext(ctx, r.db.Rebind(`
+		SELECT task_id, workflow_id, workflow_step_id, step_position, queued_at
+		FROM pending_moves WHERE session_id = ?
+	`), sessionID).Scan(&taskID, &workflowID, &workflowStepID, &position, &queuedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read pending move: %w", err)
+	}
+	return &PendingMove{
+		TaskID:         taskID,
+		WorkflowID:     workflowID,
+		WorkflowStepID: workflowStepID,
+		Position:       position,
+		QueuedAt:       queuedAt,
+	}, nil
+}
+
 func (r *sqliteRepository) TakePendingMove(ctx context.Context, sessionID string) (*PendingMove, error) {
 	tx, err := r.db.BeginTxx(ctx, nil)
 	if err != nil {

--- a/apps/backend/internal/orchestrator/messagequeue/repository_sqlite_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/repository_sqlite_test.go
@@ -304,6 +304,58 @@ func TestSQLiteRepository_TransferSession(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepository_ReplaceSessionPreservesQueuedIdentity(t *testing.T) {
+	repo := newTestSQLiteRepo(t)
+	ctx := context.Background()
+
+	original := &QueuedMessage{
+		SessionID: "s1",
+		TaskID:    "t1",
+		Content:   "original",
+		Model:     "model-a",
+		PlanMode:  true,
+		Metadata:  map[string]interface{}{"sender": "task-a"},
+		QueuedBy:  "agent",
+	}
+	if err := repo.Insert(ctx, original, 0); err != nil {
+		t.Fatalf("insert original: %v", err)
+	}
+	if err := repo.SetPendingMove(ctx, "s1", &PendingMove{TaskID: "t1", WorkflowStepID: "step-a"}); err != nil {
+		t.Fatalf("set pending move: %v", err)
+	}
+	if err := repo.Insert(ctx, &QueuedMessage{SessionID: "s1", TaskID: "t1", Content: "mutated", QueuedBy: "user"}, 0); err != nil {
+		t.Fatalf("insert mutated: %v", err)
+	}
+
+	if err := repo.ReplaceSession(ctx, "s1", []QueuedMessage{*original}, &PendingMove{
+		TaskID:         "t1",
+		WorkflowStepID: "step-a",
+		QueuedAt:       original.QueuedAt,
+	}); err != nil {
+		t.Fatalf("replace session: %v", err)
+	}
+
+	entries, err := repo.ListBySession(ctx, "s1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 restored entry, got %d", len(entries))
+	}
+	restored := entries[0]
+	if restored.ID != original.ID || restored.Position != original.Position || !restored.QueuedAt.Equal(original.QueuedAt) {
+		t.Fatalf("identity changed: got id=%s pos=%d queued_at=%s want id=%s pos=%d queued_at=%s",
+			restored.ID, restored.Position, restored.QueuedAt, original.ID, original.Position, original.QueuedAt)
+	}
+	move, err := repo.TakePendingMove(ctx, "s1")
+	if err != nil {
+		t.Fatalf("take pending move: %v", err)
+	}
+	if move == nil || move.WorkflowStepID != "step-a" {
+		t.Fatalf("pending move = %#v, want step-a", move)
+	}
+}
+
 func TestSQLiteRepository_PendingMove(t *testing.T) {
 	repo := newTestSQLiteRepo(t)
 	ctx := context.Background()

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -258,6 +258,21 @@ func (s *Service) SetPendingMove(ctx context.Context, sessionID string, move *Pe
 		zap.String("workflow_step_id", move.WorkflowStepID))
 }
 
+// GetPendingMove retrieves the pending move for a session without removing it.
+func (s *Service) GetPendingMove(ctx context.Context, sessionID string) (*PendingMove, bool) {
+	move, err := s.repo.GetPendingMove(ctx, sessionID)
+	if err != nil {
+		s.logger.Error("get pending move failed",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return nil, false
+	}
+	if move == nil {
+		return nil, false
+	}
+	return move, true
+}
+
 // TakePendingMove retrieves and removes the pending move for a session.
 func (s *Service) TakePendingMove(ctx context.Context, sessionID string) (*PendingMove, bool) {
 	move, err := s.repo.TakePendingMove(ctx, sessionID)

--- a/apps/backend/internal/orchestrator/messagequeue/service.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service.go
@@ -243,6 +243,22 @@ func (s *Service) TransferSession(ctx context.Context, oldSessionID, newSessionI
 	return nil
 }
 
+// RestoreSession replaces a session's queue and pending move from a snapshot,
+// preserving queued-message identity fields.
+func (s *Service) RestoreSession(ctx context.Context, sessionID string, entries []QueuedMessage, pendingMove *PendingMove) error {
+	if err := s.repo.ReplaceSession(ctx, sessionID, entries, pendingMove); err != nil {
+		s.logger.Error("restore session queue failed",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+		return err
+	}
+	s.logger.Info("restored session queue",
+		zap.String("session_id", sessionID),
+		zap.Int("entries", len(entries)),
+		zap.Bool("pending_move", pendingMove != nil))
+	return nil
+}
+
 // SetPendingMove records a pending move for a session (replaces any existing one).
 // The move is applied by handleAgentReady when the agent's current turn completes.
 func (s *Service) SetPendingMove(ctx context.Context, sessionID string, move *PendingMove) {

--- a/apps/backend/internal/orchestrator/messagequeue/service_test.go
+++ b/apps/backend/internal/orchestrator/messagequeue/service_test.go
@@ -387,6 +387,39 @@ func TestTransferSession(t *testing.T) {
 	})
 }
 
+func TestRestoreSession(t *testing.T) {
+	svc := setupService(t)
+	ctx := context.Background()
+
+	original, err := svc.QueueMessageWithMetadata(ctx, "s", "task-1", "original", "model-a", "agent", true, []MessageAttachment{
+		{Type: "image", Data: "abc", MimeType: "image/png"},
+	}, map[string]interface{}{"sender": "task-a"})
+	require.NoError(t, err)
+	svc.SetPendingMove(ctx, "s", &PendingMove{TaskID: "task-1", WorkflowStepID: "step-a"})
+
+	_, err = svc.QueueMessage(ctx, "s", "task-1", "mutated", "", "user", false, nil)
+	require.NoError(t, err)
+	svc.SetPendingMove(ctx, "s", &PendingMove{TaskID: "task-1", WorkflowStepID: "step-b"})
+
+	require.NoError(t, svc.RestoreSession(ctx, "s", []QueuedMessage{*original}, &PendingMove{
+		TaskID:         "task-1",
+		WorkflowStepID: "step-a",
+		QueuedAt:       original.QueuedAt,
+	}))
+
+	status := svc.GetStatus(ctx, "s")
+	require.Equal(t, 1, status.Count)
+	restored := status.Entries[0]
+	assert.Equal(t, original.ID, restored.ID)
+	assert.Equal(t, original.Position, restored.Position)
+	assert.Equal(t, original.QueuedAt, restored.QueuedAt)
+	assert.Equal(t, original.Content, restored.Content)
+	assert.Equal(t, original.Metadata, restored.Metadata)
+	move, ok := svc.TakePendingMove(ctx, "s")
+	require.True(t, ok)
+	assert.Equal(t, "step-a", move.WorkflowStepID)
+}
+
 func TestPendingMove(t *testing.T) {
 	t.Run("set then take returns and clears", func(t *testing.T) {
 		svc := setupService(t)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -326,7 +326,11 @@ func (s *Service) StartCreatedSession(ctx context.Context, taskID, sessionID, ag
 
 	// Transition task state: CREATED → SCHEDULING → (IN_PROGRESS via executor).
 	// Office tasks keep their workflow-owned status across run launches.
-	if s.isOfficeTask(ctx, taskID) {
+	isOfficeTask, err := s.lookupOfficeTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine office task status: %w", err)
+	}
+	if isOfficeTask {
 		s.logger.Debug("skipping SCHEDULING transition for office task",
 			zap.String("task_id", taskID))
 	} else if err := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateScheduling); err != nil {
@@ -702,8 +706,16 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 // isOfficeTask returns true when the task has an assignee agent profile, which
 // identifies it as an office-managed task (as opposed to a kanban / quick-chat task).
 func (s *Service) isOfficeTask(ctx context.Context, taskID string) bool {
+	isOfficeTask, err := s.lookupOfficeTask(ctx, taskID)
+	return err == nil && isOfficeTask
+}
+
+func (s *Service) lookupOfficeTask(ctx context.Context, taskID string) (bool, error) {
 	dbTask, err := s.repo.GetTask(ctx, taskID)
-	return err == nil && dbTask != nil && dbTask.AssigneeAgentProfileID != ""
+	if err != nil {
+		return false, err
+	}
+	return dbTask != nil && dbTask.AssigneeAgentProfileID != "", nil
 }
 
 // prepareSessionForStart creates the session for a launch and propagates any

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -324,8 +324,12 @@ func (s *Service) StartCreatedSession(ctx context.Context, taskID, sessionID, ag
 		}
 	}
 
-	// Transition task state: CREATED → SCHEDULING → (IN_PROGRESS via executor)
-	if err := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateScheduling); err != nil {
+	// Transition task state: CREATED → SCHEDULING → (IN_PROGRESS via executor).
+	// Office tasks keep their workflow-owned status across run launches.
+	if s.isOfficeTask(ctx, taskID) {
+		s.logger.Debug("skipping SCHEDULING transition for office task",
+			zap.String("task_id", taskID))
+	} else if err := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateScheduling); err != nil {
 		s.logger.Warn("failed to update task state to SCHEDULING",
 			zap.String("task_id", taskID),
 			zap.Error(err))

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -560,6 +560,11 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 		zap.Bool("auto_start", autoStart),
 		zap.Int("attachments", len(attachments)))
 
+	isOfficeTask, err := s.lookupOfficeTask(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine office task status: %w", err)
+	}
+
 	// Office tasks do NOT transition through SCHEDULING / IN_PROGRESS on
 	// every run. Their lifecycle status (todo / in_review / done /
 	// blocked / cancelled) reflects the *user-meaningful workflow*, not
@@ -569,7 +574,7 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	// transition here avoids gratuitous flicker (REVIEW → SCHEDULING →
 	// IN_PROGRESS → REVIEW for a single comment-reply cycle) and matches
 	// the user's mental model.
-	if s.isOfficeTask(ctx, taskID) {
+	if isOfficeTask {
 		s.logger.Debug("skipping SCHEDULING transition for office task",
 			zap.String("task_id", taskID))
 	} else if err := s.taskRepo.UpdateTaskState(ctx, taskID, v1.TaskStateScheduling); err != nil {
@@ -672,7 +677,7 @@ func (s *Service) startTask(ctx context.Context, taskID string, agentProfileID s
 	// task, etc.) are excluded because office agents call those via the
 	// kandev CLI ($KANDEV_CLI). See docs/specs/office-agent-cli/spec.md.
 	mcpMode := ""
-	if s.isOfficeTask(ctx, taskID) {
+	if isOfficeTask {
 		mcpMode = executor.McpModeOffice
 	}
 

--- a/apps/backend/internal/orchestrator/task_operations_test.go
+++ b/apps/backend/internal/orchestrator/task_operations_test.go
@@ -808,6 +808,43 @@ func TestStartCreatedSession_EmptyProfileFallsBackToWorkflowDefault(t *testing.T
 	}
 }
 
+func TestStartCreatedSession_OfficeTaskSkipsSchedulingState(t *testing.T) {
+	ctx := context.Background()
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateCreated)
+	seedExecutorRunning(t, repo, "session1", "task1", "exec-1")
+
+	dbTask, err := repo.GetTask(ctx, "task1")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	dbTask.State = v1.TaskStateReview
+	dbTask.WorkflowStepID = "step-office"
+	dbTask.AssigneeAgentProfileID = "office-agent"
+	if err := repo.UpdateTask(ctx, dbTask); err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{ID: "task1", Title: "Office Task", State: v1.TaskStateReview}
+	agentMgr := &mockAgentManager{repoForExecutionLookup: repo}
+	stepGetter := newMockStepGetter()
+	stepGetter.steps["step-office"] = &wfmodels.WorkflowStep{ID: "step-office", WorkflowID: "wf1"}
+	svc := createTestServiceWithScheduler(repo, stepGetter, taskRepo, agentMgr)
+	svc.messageCreator = &mockMessageCreator{}
+
+	if _, err := svc.StartCreatedSession(ctx, "task1", "session1", "profile1", "Do the work", true, false, true, nil); err != nil {
+		t.Fatalf("StartCreatedSession: %v", err)
+	}
+
+	if writes := taskRepo.stateWrites["task1"]; writes != 0 {
+		t.Fatalf("office task should not write SCHEDULING, got %d state writes", writes)
+	}
+	if got := taskRepo.tasks["task1"].State; got != v1.TaskStateReview {
+		t.Fatalf("office task state = %s, want REVIEW", got)
+	}
+}
+
 // --- recordInitialMessage ---
 
 // mockMessageCreator implements MessageCreator for testing.

--- a/apps/backend/internal/task/service/service_messages.go
+++ b/apps/backend/internal/task/service/service_messages.go
@@ -295,11 +295,15 @@ func (s *Service) SearchMessages(ctx context.Context, sessionID, query string, l
 
 // DeleteMessage deletes a message
 func (s *Service) DeleteMessage(ctx context.Context, id string) error {
+	message, getErr := s.messages.GetMessage(ctx, id)
 	if err := s.messages.DeleteMessage(ctx, id); err != nil {
 		s.logger.Error("failed to delete message", zap.String("message_id", id), zap.Error(err))
 		return err
 	}
 
+	if getErr == nil && message != nil {
+		s.publishMessageEvent(ctx, events.MessageDeleted, message)
+	}
 	s.logger.Info("message deleted", zap.String("message_id", id))
 	return nil
 }

--- a/apps/backend/internal/task/service/service_requests.go
+++ b/apps/backend/internal/task/service/service_requests.go
@@ -56,13 +56,14 @@ type CreateTaskRequest struct {
 
 // UpdateTaskRequest contains the data for updating a task
 type UpdateTaskRequest struct {
-	Title        *string                `json:"title,omitempty"`
-	Description  *string                `json:"description,omitempty"`
-	Priority     *string                `json:"priority,omitempty"`
-	State        *v1.TaskState          `json:"state,omitempty"`
-	Repositories []TaskRepositoryInput  `json:"repositories,omitempty"`
-	Position     *int                   `json:"position,omitempty"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty"`
+	Title          *string                `json:"title,omitempty"`
+	Description    *string                `json:"description,omitempty"`
+	Priority       *string                `json:"priority,omitempty"`
+	State          *v1.TaskState          `json:"state,omitempty"`
+	WorkflowStepID *string                `json:"workflow_step_id,omitempty"`
+	Repositories   []TaskRepositoryInput  `json:"repositories,omitempty"`
+	Position       *int                   `json:"position,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // CreateWorkflowRequest contains the data for creating a new workflow

--- a/apps/backend/internal/task/service/service_tasks.go
+++ b/apps/backend/internal/task/service/service_tasks.go
@@ -690,6 +690,9 @@ func (s *Service) UpdateTask(ctx context.Context, id string, req *UpdateTaskRequ
 		task.State = *req.State
 		stateChanged = true
 	}
+	if req.WorkflowStepID != nil {
+		task.WorkflowStepID = *req.WorkflowStepID
+	}
 	if req.Position != nil {
 		task.Position = *req.Position
 	}

--- a/apps/backend/pkg/websocket/actions.go
+++ b/apps/backend/pkg/websocket/actions.go
@@ -181,6 +181,7 @@ const (
 	ActionWorkflowStepDeleted      = "workflow.step.deleted"
 	ActionSessionMessageAdded      = "session.message.added"
 	ActionSessionMessageUpdated    = "session.message.updated"
+	ActionSessionMessageDeleted    = "session.message.deleted"
 	ActionSessionStateChanged      = "session.state_changed"
 	ActionSessionWaitingForInput   = "session.waiting_for_input"
 	ActionSessionAgentctlStarting  = "session.agentctl_starting"

--- a/apps/web/components/task/simple/OfficeSimplePane.test.tsx
+++ b/apps/web/components/task/simple/OfficeSimplePane.test.tsx
@@ -132,7 +132,7 @@ const runningSession: TaskSession = {
   ...completedSession,
   id: "session-running",
   state: "RUNNING",
-  completedAt: null,
+  completedAt: undefined,
   updatedAt: "2026-05-01T10:07:00Z",
 };
 

--- a/apps/web/lib/state/slices/session/session-slice.ts
+++ b/apps/web/lib/state/slices/session/session-slice.ts
@@ -49,6 +49,10 @@ function mergeMessageFields(target: Record<string, unknown>, source: Record<stri
   }
 }
 
+function removeMessageByID(messages: Message[], messageId: string) {
+  return messages.filter((message) => message.id !== messageId);
+}
+
 /** Eagerly populate session→environment mapping and migrate any data stored under the fallback key.
  *  `draft` must be the combined store state (SessionSlice + SessionRuntimeSlice). */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -182,6 +186,15 @@ function buildMessageActions(set: ImmerSet) {
           message as unknown as Record<string, unknown>,
         );
         messages[index] = merged;
+      }),
+    removeMessage: (
+      sessionId: Parameters<SessionSlice["removeMessage"]>[0],
+      messageId: Parameters<SessionSlice["removeMessage"]>[1],
+    ) =>
+      set((draft) => {
+        const messages = draft.messages.bySession[sessionId];
+        if (!messages) return;
+        draft.messages.bySession[sessionId] = removeMessageByID(messages, messageId);
       }),
     mergeMessages: (
       sessionId: string,

--- a/apps/web/lib/state/slices/session/types.ts
+++ b/apps/web/lib/state/slices/session/types.ts
@@ -156,6 +156,7 @@ export type SessionSliceActions = {
   ) => void;
   addMessage: (message: Message) => void;
   updateMessage: (message: Message) => void;
+  removeMessage: (sessionId: string, messageId: string) => void;
   /**
    * Idempotent full-snapshot merge: reconciles `messages` against the current
    * stored array, preserving object identity for unchanged messages and the

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -405,6 +405,7 @@ export type AppState = {
   ) => void;
   setActiveTurn: (sessionId: string, turnId: string | null) => void;
   updateMessage: (message: Message) => void;
+  removeMessage: (sessionId: string, messageId: string) => void;
   prependMessages: (
     sessionId: string,
     messages: Message[],

--- a/apps/web/lib/types/backend.ts
+++ b/apps/web/lib/types/backend.ts
@@ -31,6 +31,7 @@ export type BackendMessageType =
   | "workflow.step.deleted"
   | "session.message.added"
   | "session.message.updated"
+  | "session.message.deleted"
   | "session.state_changed"
   | "session.waiting_for_input"
   | "session.agentctl_starting"
@@ -94,6 +95,7 @@ import type {
 import type { SecretListItem } from "@/lib/types/http-secrets";
 import type { GitEventPayload } from "@/lib/types/git-events";
 import type { GitHubRateLimitUpdate, TaskCIAutomationOptions, TaskPR } from "@/lib/types/github";
+import type { SystemMetricsSnapshot } from "./system";
 import type { FileChangeNotificationPayload } from "./workspace-files";
 import type {
   AgentCapabilitiesPayload,
@@ -549,10 +551,7 @@ export type BackendMessageMap = OfficeBackendMessageMap & {
   "session.git.event": BackendMessage<"session.git.event", GitEventPayload>;
   "system.error": BackendMessage<"system.error", SystemErrorPayload>;
   "system.job.update": BackendMessage<"system.job.update", import("./system").SystemJob>;
-  "system.metrics.updated": BackendMessage<
-    "system.metrics.updated",
-    import("./system").SystemMetricsSnapshot
-  >;
+  "system.metrics.updated": BackendMessage<"system.metrics.updated", SystemMetricsSnapshot>;
   "workspace.created": BackendMessage<"workspace.created", WorkspacePayload>;
   "workspace.updated": BackendMessage<"workspace.updated", WorkspacePayload>;
   "workspace.deleted": BackendMessage<"workspace.deleted", WorkspacePayload>;
@@ -564,6 +563,7 @@ export type BackendMessageMap = OfficeBackendMessageMap & {
   "workflow.step.deleted": BackendMessage<"workflow.step.deleted", WorkflowStepEventPayload>;
   "session.message.added": BackendMessage<"session.message.added", MessageAddedPayload>;
   "session.message.updated": BackendMessage<"session.message.updated", MessageAddedPayload>;
+  "session.message.deleted": BackendMessage<"session.message.deleted", MessageAddedPayload>;
   "session.state_changed": BackendMessage<"session.state_changed", TaskSessionStateChangedPayload>;
   "session.waiting_for_input": BackendMessage<
     "session.waiting_for_input",

--- a/apps/web/lib/ws/client.ts
+++ b/apps/web/lib/ws/client.ts
@@ -11,6 +11,7 @@ const debugDispatch = createDebugLogger("ws:dispatch");
 const DISPATCH_LOG_DENYLIST = new Set<string>([
   "session.message.added",
   "session.message.updated",
+  "session.message.deleted",
   "session.shell.output",
   "session.process.output",
 ]);

--- a/apps/web/lib/ws/handlers/messages.ts
+++ b/apps/web/lib/ws/handlers/messages.ts
@@ -47,5 +47,12 @@ export function registerMessagesHandlers(store: StoreApi<AppState>): WsHandlers 
         updated_at: payload.updated_at,
       });
     },
+    "session.message.deleted": (message) => {
+      const payload = message.payload;
+      if (!payload.session_id) {
+        return;
+      }
+      store.getState().removeMessage(sessionId(payload.session_id), payload.message_id);
+    },
   };
 }


### PR DESCRIPTION
Agent-to-agent task messages should behave like a user turn when the target task is idle, so review-step feedback can reopen the workflow. Idle and created `message_task_kandev` deliveries now clear Review state, run `on_turn_start`, and route through any session selected by that transition.

## Important Changes

- Runs the same turn-start preparation for immediate cross-task messages that normal chat messages already use.
- Reloads the target session after `on_turn_start` so agent-profile workflow switches receive the peer message on the new primary session.
- Updates a stale web test fixture to use `undefined` for an unfinished running session timestamp.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->