### PR TITLE
fix: preserve nested markdown code fences

### DIFF
--- a/apps/web/components/task/simple/OfficeSimplePane.test.tsx
+++ b/apps/web/components/task/simple/OfficeSimplePane.test.tsx
@@ -132,7 +132,7 @@ const runningSession: TaskSession = {
   ...completedSession,
   id: "session-running",
   state: "RUNNING",
-  completedAt: null,
+  completedAt: undefined,
   updatedAt: "2026-05-01T10:07:00Z",
 };
 

--- a/apps/web/e2e/tests/chat/markdown-code-fences.spec.ts
+++ b/apps/web/e2e/tests/chat/markdown-code-fences.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "../../fixtures/test-base";
+import { SessionPage } from "../../pages/session-page";
+
+const MARKER_AFTER_INNER_FENCE = "After nested prompt sentinel.";
+
+const NESTED_MARKDOWN_FENCE_MESSAGE = [
+  "```markdown",
+  "Act as a Kandev PR coordinator/watchdog.",
+  "",
+  "Suggested task message:",
+  "",
+  "```text",
+  "Please run the pr-fixup skill for PR #123.",
+  "```",
+  "",
+  MARKER_AFTER_INNER_FENCE,
+  "```",
+].join("\n");
+
+type NestedFenceRenderState = {
+  foundBody: boolean;
+  codeBlockCount: number;
+  codeBlockHasMarker: boolean;
+  paragraphHasMarker: boolean;
+};
+
+async function nestedFenceRenderState(session: SessionPage): Promise<NestedFenceRenderState> {
+  return session.activeChat().evaluate((chatRoot, marker) => {
+    const bodies = Array.from(chatRoot.querySelectorAll(".markdown-body"));
+    const body = bodies.find((candidate) => candidate.textContent?.includes(marker));
+    if (!body) {
+      return {
+        foundBody: false,
+        codeBlockCount: 0,
+        codeBlockHasMarker: false,
+        paragraphHasMarker: false,
+      };
+    }
+
+    const codeBlocks = Array.from(body.querySelectorAll('[class*="group/code-block"]'));
+    const paragraphs = Array.from(body.querySelectorAll("p"));
+
+    return {
+      foundBody: true,
+      codeBlockCount: codeBlocks.length,
+      codeBlockHasMarker: codeBlocks.some((block) => block.textContent?.includes(marker)),
+      paragraphHasMarker: paragraphs.some((paragraph) => paragraph.textContent?.includes(marker)),
+    };
+  }, MARKER_AFTER_INNER_FENCE);
+}
+
+test.describe("Markdown code fences", () => {
+  test("keeps a whole-message markdown fence open when nested fences appear", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "Nested Markdown Fence", {
+      description: "seeded nested markdown fence",
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    const { session_id: sessionId } = await apiClient.seedTaskSession(task.id, {
+      state: "IDLE",
+    });
+    await apiClient.seedSessionMessage(sessionId, {
+      type: "message",
+      content: NESTED_MARKDOWN_FENCE_MESSAGE,
+    });
+
+    await testPage.goto(`/t/${task.id}`);
+    const session = new SessionPage(testPage);
+    await session.waitForLoad();
+
+    await expect
+      .poll(() => nestedFenceRenderState(session), {
+        timeout: 15_000,
+        message: "Expected the text after the inner fence to remain inside the outer code block",
+      })
+      .toEqual({
+        foundBody: true,
+        codeBlockCount: 1,
+        codeBlockHasMarker: true,
+        paragraphHasMarker: false,
+      });
+  });
+});

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -180,6 +180,41 @@ describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
     expect(normalizeMarkdown(input)).toBe(input);
   });
 
+  it("preserves non-heading markdown samples before separate untagged blocks", () => {
+    const input = [MARKDOWN_FENCE, "plain text", "```", "prose", "```", "code", "```"].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+});
+
+describe("normalizeMarkdown blank-padded untagged wrapper edge cases", () => {
+  it("strengthens blank-padded bare nested fences", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      "",
+      "code",
+      "",
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      "",
+      "code",
+      "",
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens heading samples inside spaced untagged nested fences", () => {
     const input = [
       MARKDOWN_FENCE,
@@ -208,7 +243,9 @@ describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
 
     expect(normalizeMarkdown(input)).toBe(expected);
   });
+});
 
+describe("normalizeMarkdown tagged-looking untagged wrapper edge cases", () => {
   it("strengthens bare fences that contain tagged-looking content", () => {
     const input = [
       MARKDOWN_FENCE,
@@ -234,6 +271,37 @@ describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
     expect(normalizeMarkdown(input)).toBe(expected);
   });
 
+  it("keeps scanning unmatched tagged-looking content after a nested pair", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      "```not-a-block",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      "```not-a-block",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+});
+
+describe("normalizeMarkdown longer-close wrapper edge cases", () => {
   it("strengthens a longer wrapper when shorter tagged fences use longer closes", () => {
     const input = [
       STRENGTHENED_MARKDOWN_FENCE,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -166,7 +166,7 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
 describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
   it("strengthens a longer wrapper when shorter tagged fences use longer closes", () => {
     const input = [
-      "````markdown",
+      STRENGTHENED_MARKDOWN_FENCE,
       INTRO_TEXT,
       "```text",
       INNER_PROMPT_TEXT,
@@ -178,6 +178,29 @@ describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
       "`````markdown",
       INTRO_TEXT,
       "```text",
+      INNER_PROMPT_TEXT,
+      "````",
+      AFTER_NESTED_PROMPT,
+      "`````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("strengthens a longer wrapper when shorter untagged fences use longer closes", () => {
+    const input = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      INNER_PROMPT_TEXT,
+      "````",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+    const expected = [
+      "`````markdown",
+      INTRO_TEXT,
+      "```",
       INNER_PROMPT_TEXT,
       "````",
       AFTER_NESTED_PROMPT,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -8,23 +8,27 @@ import {
   normalizeMarkdown,
 } from "./normalize-cache";
 
+const MARKDOWN_FENCE = "```markdown";
+const INNER_PROMPT_TEXT = "nested prompt";
+const AFTER_NESTED_PROMPT = "After nested prompt.";
+
 describe("normalizeMarkdown", () => {
   it("leaves a markdown wrapper without nested fences unchanged", () => {
-    const input = ["```markdown", "# Title", "```"].join("\n");
+    const input = [MARKDOWN_FENCE, "# Title", "```"].join("\n");
 
     expect(normalizeMarkdown(input)).toBe(input);
   });
 
   it("strengthens a markdown wrapper that contains nested code fences", () => {
     const input = [
-      "```markdown",
+      MARKDOWN_FENCE,
       "Intro:",
       "",
       "```text",
-      "nested prompt",
+      INNER_PROMPT_TEXT,
       "```",
       "",
-      "After nested prompt.",
+      AFTER_NESTED_PROMPT,
       "```",
     ].join("\n");
     const expected = [
@@ -32,14 +36,73 @@ describe("normalizeMarkdown", () => {
       "Intro:",
       "",
       "```text",
-      "nested prompt",
+      INNER_PROMPT_TEXT,
       "```",
       "",
-      "After nested prompt.",
+      AFTER_NESTED_PROMPT,
       "````",
     ].join("\n");
 
     expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("strengthens CRLF markdown wrappers that contain nested code fences", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "Intro:",
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\r\n");
+    const expected = [
+      "````markdown\r",
+      "Intro:\r",
+      "\r",
+      "```text\r",
+      `${INNER_PROMPT_TEXT}\r`,
+      "```\r",
+      "\r",
+      `${AFTER_NESTED_PROMPT}\r`,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("leaves a valid markdown sample followed by another fenced block unchanged", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "# Title",
+      "```",
+      "",
+      "prose between blocks",
+      "",
+      "```js",
+      "const value = 1;",
+      "```",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("leaves markdown wrappers with trailing prose outside the wrapper unchanged", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "Intro:",
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "```",
+      "",
+      "Trailing prose outside the wrapper.",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
   });
 });
 

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -14,6 +14,7 @@ const STRENGTHENED_MARKDOWN_FENCE = "````markdown";
 const INTRO_TEXT = "Intro:";
 const INNER_PROMPT_TEXT = "nested prompt";
 const AFTER_NESTED_PROMPT = "After nested prompt.";
+const SAMPLE_PROSE_TEXT = "some explanation";
 
 describe("normalizeMarkdown", () => {
   it("leaves a markdown wrapper without nested fences unchanged", () => {
@@ -143,7 +144,9 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
   });
 
   it("preserves adjacent untagged blocks after a markdown sample", () => {
-    const input = [MARKDOWN_FENCE, "# Title", "```", "prose", "```", "code", "```"].join("\n");
+    const input = [MARKDOWN_FENCE, "# Title", "```", SAMPLE_PROSE_TEXT, "```", "code", "```"].join(
+      "\n",
+    );
 
     expect(normalizeMarkdown(input)).toBe(input);
   });
@@ -176,27 +179,88 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
 
 describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
   it("preserves markdown samples whose close follows a blank line", () => {
-    const input = [MARKDOWN_FENCE, "# Title", "", "```", "prose", "```", "code", "```"].join("\n");
+    const input = [
+      MARKDOWN_FENCE,
+      "# Title",
+      "",
+      "```",
+      SAMPLE_PROSE_TEXT,
+      "```",
+      "code",
+      "```",
+    ].join("\n");
 
     expect(normalizeMarkdown(input)).toBe(input);
   });
 
   it("preserves non-heading markdown samples before separate untagged blocks", () => {
-    const input = [MARKDOWN_FENCE, "plain text", "```", "prose", "```", "code", "```"].join("\n");
+    const input = [
+      MARKDOWN_FENCE,
+      "plain text",
+      "```",
+      SAMPLE_PROSE_TEXT,
+      "```",
+      "code",
+      "```",
+    ].join("\n");
 
     expect(normalizeMarkdown(input)).toBe(input);
   });
 
   it("preserves separate untagged blocks that start blank", () => {
-    const input = [MARKDOWN_FENCE, "plain text", "```", "prose", "```", "", "code", "```"].join(
-      "\n",
-    );
+    const input = [
+      MARKDOWN_FENCE,
+      "plain text",
+      "```",
+      SAMPLE_PROSE_TEXT,
+      "```",
+      "",
+      "code",
+      "```",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("preserves markdown samples before separate tagged blocks", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "plain text",
+      "```",
+      SAMPLE_PROSE_TEXT,
+      "```js",
+      "code",
+      "```",
+    ].join("\n");
 
     expect(normalizeMarkdown(input)).toBe(input);
   });
 });
 
 describe("normalizeMarkdown blank-padded untagged wrapper edge cases", () => {
+  it("strengthens same-length bare fences after headings inside wrappers", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "# Prompt",
+      "```",
+      "code",
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      "# Prompt",
+      "```",
+      "code",
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens same-length bare fences after non-colon prose inside wrappers", () => {
     const input = [
       MARKDOWN_FENCE,
@@ -278,6 +342,29 @@ describe("normalizeMarkdown blank-padded untagged wrapper edge cases", () => {
 });
 
 describe("normalizeMarkdown tagged-looking untagged wrapper edge cases", () => {
+  it("strengthens tagged nested fences after headings inside wrappers", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "# Prompt",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      "# Prompt",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens bare fences that contain tagged-looking content", () => {
     const input = [
       MARKDOWN_FENCE,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -188,6 +188,35 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
 
     expect(normalizeMarkdown(input)).toBe(expected);
   });
+});
+
+describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
+  it("strengthens a markdown wrapper when longer untagged fences contain shorter examples", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "````",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "````",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      "`````markdown",
+      INTRO_TEXT,
+      "````",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "````",
+      AFTER_NESTED_PROMPT,
+      "`````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
 
   it("strengthens a markdown wrapper when nested fences use glued closes", () => {
     const input = [

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -164,6 +164,29 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
 });
 
 describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
+  it("strengthens a longer wrapper when shorter tagged fences use longer closes", () => {
+    const input = [
+      "````markdown",
+      INTRO_TEXT,
+      "```text",
+      INNER_PROMPT_TEXT,
+      "````",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+    const expected = [
+      "`````markdown",
+      INTRO_TEXT,
+      "```text",
+      INNER_PROMPT_TEXT,
+      "````",
+      AFTER_NESTED_PROMPT,
+      "`````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens a markdown wrapper when longer untagged fences contain shorter examples", () => {
     const input = [
       MARKDOWN_FENCE,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -184,6 +184,22 @@ describe("normalizeMarkdown wrapper boundaries", () => {
     expect(normalizeMarkdown(input)).toBe(input);
   });
 
+  it("leaves a valid markdown sample followed by an untagged fenced block unchanged", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "# Title",
+      "```",
+      "",
+      "prose between blocks",
+      "",
+      "```",
+      "const value = 1;",
+      "```",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
   it("leaves markdown wrappers with trailing prose outside the wrapper unchanged", () => {
     const input = [
       MARKDOWN_FENCE,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -8,6 +8,41 @@ import {
   normalizeMarkdown,
 } from "./normalize-cache";
 
+describe("normalizeMarkdown", () => {
+  it("leaves a markdown wrapper without nested fences unchanged", () => {
+    const input = ["```markdown", "# Title", "```"].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("strengthens a markdown wrapper that contains nested code fences", () => {
+    const input = [
+      "```markdown",
+      "Intro:",
+      "",
+      "```text",
+      "nested prompt",
+      "```",
+      "",
+      "After nested prompt.",
+      "```",
+    ].join("\n");
+    const expected = [
+      "````markdown",
+      "Intro:",
+      "",
+      "```text",
+      "nested prompt",
+      "```",
+      "",
+      "After nested prompt.",
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+});
+
 describe("normalizeCached", () => {
   beforeEach(() => {
     __resetMarkdownCounters();

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -111,6 +111,33 @@ describe("normalizeMarkdown wrapper edge cases", () => {
 
     expect(normalizeMarkdown(input)).toBe(expected);
   });
+
+  it("strengthens a markdown wrapper that contains untagged nested code fences", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
 });
 
 describe("normalizeMarkdown wrapper boundaries", () => {

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -180,6 +180,35 @@ describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
     expect(normalizeMarkdown(input)).toBe(input);
   });
 
+  it("strengthens heading samples inside spaced untagged nested fences", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```",
+      "# Title",
+      "",
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```",
+      "# Title",
+      "",
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens bare fences that contain tagged-looking content", () => {
     const input = [
       MARKDOWN_FENCE,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -147,7 +147,7 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
     expect(normalizeMarkdown(input)).toBe(input);
   });
 
-  it("preserves same-length untagged fences after nonblank markdown sample content", () => {
+  it("strengthens same-length untagged fences after prose inside wrappers", () => {
     const input = [
       MARKDOWN_FENCE,
       INTRO_TEXT,
@@ -158,12 +158,53 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
       AFTER_NESTED_PROMPT,
       "```",
     ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      "",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
 
-    expect(normalizeMarkdown(input)).toBe(input);
+    expect(normalizeMarkdown(input)).toBe(expected);
   });
 });
 
 describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
+  it("preserves markdown samples whose close follows a blank line", () => {
+    const input = [MARKDOWN_FENCE, "# Title", "", "```", "prose", "```", "code", "```"].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("strengthens bare fences that contain tagged-looking content", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      "````text",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      "````text",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens a longer wrapper when shorter tagged fences use longer closes", () => {
     const input = [
       STRENGTHENED_MARKDOWN_FENCE,
@@ -209,7 +250,9 @@ describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
 
     expect(normalizeMarkdown(input)).toBe(expected);
   });
+});
 
+describe("normalizeMarkdown long untagged wrapper edge cases", () => {
   it("strengthens a markdown wrapper when longer untagged fences contain shorter examples", () => {
     const input = [
       MARKDOWN_FENCE,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -164,6 +164,31 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
     expect(normalizeMarkdown(input)).toBe(expected);
   });
 
+  it("strengthens a markdown wrapper when untagged nested content starts blank", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      "",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      "",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens a markdown wrapper when nested fences use glued closes", () => {
     const input = [
       MARKDOWN_FENCE,
@@ -247,10 +272,58 @@ describe("normalizeMarkdown wrapper boundaries", () => {
     expect(normalizeMarkdown(input)).toBe(expected);
   });
 
+  it("strengthens markdown wrappers with glued closing fences", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      `${AFTER_NESTED_PROMPT}\`\`\``,
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+});
+
+describe("normalizeMarkdown wrapper unchanged boundaries", () => {
   it("leaves a valid markdown sample followed by another fenced block unchanged", () => {
     const input = [
       MARKDOWN_FENCE,
       "# Title",
+      "```",
+      "",
+      "prose between blocks",
+      "",
+      "```js",
+      "const value = 1;",
+      "```",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
+
+  it("leaves a markdown sample with a literal tagged fence followed by another block unchanged", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "# Title",
+      "",
+      "```text",
+      "literal nested sample",
+      "```",
       "```",
       "",
       "prose between blocks",

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -111,7 +111,9 @@ describe("normalizeMarkdown wrapper edge cases", () => {
 
     expect(normalizeMarkdown(input)).toBe(expected);
   });
+});
 
+describe("normalizeMarkdown untagged wrapper edge cases", () => {
   it("strengthens a markdown wrapper that contains untagged nested code fences", () => {
     const input = [
       MARKDOWN_FENCE,
@@ -138,9 +140,86 @@ describe("normalizeMarkdown wrapper edge cases", () => {
 
     expect(normalizeMarkdown(input)).toBe(expected);
   });
+
+  it("strengthens a markdown wrapper that contains untagged fences without blank separators", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "```",
+      INNER_PROMPT_TEXT,
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("strengthens a markdown wrapper when nested fences use glued closes", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      `${INNER_PROMPT_TEXT}\`\`\``,
+      "",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      `${INNER_PROMPT_TEXT}\`\`\``,
+      "",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
 });
 
 describe("normalizeMarkdown wrapper boundaries", () => {
+  it("strengthens markdown wrappers after leading blank lines", () => {
+    const input = [
+      "",
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      "",
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens CRLF markdown wrappers that contain nested code fences", () => {
     const input = [
       MARKDOWN_FENCE,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -9,6 +9,8 @@ import {
 } from "./normalize-cache";
 
 const MARKDOWN_FENCE = "```markdown";
+const STRENGTHENED_MARKDOWN_FENCE = "````markdown";
+const INTRO_TEXT = "Intro:";
 const INNER_PROMPT_TEXT = "nested prompt";
 const AFTER_NESTED_PROMPT = "After nested prompt.";
 
@@ -22,7 +24,7 @@ describe("normalizeMarkdown", () => {
   it("strengthens a markdown wrapper that contains nested code fences", () => {
     const input = [
       MARKDOWN_FENCE,
-      "Intro:",
+      INTRO_TEXT,
       "",
       "```text",
       INNER_PROMPT_TEXT,
@@ -32,8 +34,8 @@ describe("normalizeMarkdown", () => {
       "```",
     ].join("\n");
     const expected = [
-      "````markdown",
-      "Intro:",
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
       "",
       "```text",
       INNER_PROMPT_TEXT,
@@ -45,11 +47,77 @@ describe("normalizeMarkdown", () => {
 
     expect(normalizeMarkdown(input)).toBe(expected);
   });
+});
 
+describe("normalizeMarkdown wrapper edge cases", () => {
+  it("strengthens a markdown wrapper that contains multiple nested code fences", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      "```json",
+      '{"ok": true}',
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      "```json",
+      '{"ok": true}',
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("strengthens a markdown wrapper that contains spaced nested info strings", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "``` text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "``` text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+});
+
+describe("normalizeMarkdown wrapper boundaries", () => {
   it("strengthens CRLF markdown wrappers that contain nested code fences", () => {
     const input = [
       MARKDOWN_FENCE,
-      "Intro:",
+      INTRO_TEXT,
       "",
       "```text",
       INNER_PROMPT_TEXT,
@@ -60,7 +128,7 @@ describe("normalizeMarkdown", () => {
     ].join("\r\n");
     const expected = [
       "````markdown\r",
-      "Intro:\r",
+      `${INTRO_TEXT}\r`,
       "\r",
       "```text\r",
       `${INNER_PROMPT_TEXT}\r`,
@@ -92,7 +160,7 @@ describe("normalizeMarkdown", () => {
   it("leaves markdown wrappers with trailing prose outside the wrapper unchanged", () => {
     const input = [
       MARKDOWN_FENCE,
-      "Intro:",
+      INTRO_TEXT,
       "",
       "```text",
       INNER_PROMPT_TEXT,

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -141,30 +141,13 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
     expect(normalizeMarkdown(input)).toBe(expected);
   });
 
-  it("strengthens a markdown wrapper that contains untagged fences without blank separators", () => {
-    const input = [
-      MARKDOWN_FENCE,
-      INTRO_TEXT,
-      "```",
-      INNER_PROMPT_TEXT,
-      "```",
-      AFTER_NESTED_PROMPT,
-      "```",
-    ].join("\n");
-    const expected = [
-      STRENGTHENED_MARKDOWN_FENCE,
-      INTRO_TEXT,
-      "```",
-      INNER_PROMPT_TEXT,
-      "```",
-      AFTER_NESTED_PROMPT,
-      "````",
-    ].join("\n");
+  it("preserves adjacent untagged blocks after a markdown sample", () => {
+    const input = [MARKDOWN_FENCE, "# Title", "```", "prose", "```", "code", "```"].join("\n");
 
-    expect(normalizeMarkdown(input)).toBe(expected);
+    expect(normalizeMarkdown(input)).toBe(input);
   });
 
-  it("strengthens a markdown wrapper when untagged nested content starts blank", () => {
+  it("preserves same-length untagged fences after nonblank markdown sample content", () => {
     const input = [
       MARKDOWN_FENCE,
       INTRO_TEXT,
@@ -175,18 +158,8 @@ describe("normalizeMarkdown untagged wrapper edge cases", () => {
       AFTER_NESTED_PROMPT,
       "```",
     ].join("\n");
-    const expected = [
-      STRENGTHENED_MARKDOWN_FENCE,
-      INTRO_TEXT,
-      "```",
-      "",
-      INNER_PROMPT_TEXT,
-      "```",
-      AFTER_NESTED_PROMPT,
-      "````",
-    ].join("\n");
 
-    expect(normalizeMarkdown(input)).toBe(expected);
+    expect(normalizeMarkdown(input)).toBe(input);
   });
 });
 

--- a/apps/web/lib/markdown/normalize-cache.test.ts
+++ b/apps/web/lib/markdown/normalize-cache.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   __MAX_CACHE_ENTRIES,
@@ -185,9 +186,40 @@ describe("normalizeMarkdown advanced untagged wrapper edge cases", () => {
 
     expect(normalizeMarkdown(input)).toBe(input);
   });
+
+  it("preserves separate untagged blocks that start blank", () => {
+    const input = [MARKDOWN_FENCE, "plain text", "```", "prose", "```", "", "code", "```"].join(
+      "\n",
+    );
+
+    expect(normalizeMarkdown(input)).toBe(input);
+  });
 });
 
 describe("normalizeMarkdown blank-padded untagged wrapper edge cases", () => {
+  it("strengthens same-length bare fences after non-colon prose inside wrappers", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      "Here is an example",
+      "```",
+      "code",
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      "Here is an example",
+      "```",
+      "code",
+      "```",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
   it("strengthens blank-padded bare nested fences", () => {
     const input = [
       MARKDOWN_FENCE,
@@ -293,6 +325,35 @@ describe("normalizeMarkdown tagged-looking untagged wrapper edge cases", () => {
       "```",
       "",
       "```not-a-block",
+      AFTER_NESTED_PROMPT,
+      "````",
+    ].join("\n");
+
+    expect(normalizeMarkdown(input)).toBe(expected);
+  });
+
+  it("keeps scanning unmatched bare fence content after a nested pair", () => {
+    const input = [
+      MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      "```",
+      AFTER_NESTED_PROMPT,
+      "```",
+    ].join("\n");
+    const expected = [
+      STRENGTHENED_MARKDOWN_FENCE,
+      INTRO_TEXT,
+      "",
+      "```text",
+      INNER_PROMPT_TEXT,
+      "```",
+      "",
+      "```",
       AFTER_NESTED_PROMPT,
       "````",
     ].join("\n");

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -11,7 +11,7 @@
 
 const FENCE_OPEN_RE = /^ {0,3}(`{3,})/;
 const MARKDOWN_WRAPPER_OPEN_RE = /^( {0,3})(`{3,})(\s*(?:markdown|mdx?)(?:[ \t].*)?\s*)$/i;
-const FENCE_OPENER_LINE_RE = /^ {0,3}(`{3,})\S/;
+const FENCE_OPENER_LINE_RE = /^ {0,3}(`{3,})(?:[ \t]+\S|\S)/;
 const PURE_FENCE_LINE_RE = /^( {0,3})(`{3,})\s*$/;
 const TRAILING_FENCE_RE = /(`{3,})\s*$/;
 
@@ -46,8 +46,7 @@ function markdownWrapperInnerFenceInfo(lines: string[], closeIndex: number, open
   for (let index = 1; index < closeIndex; index++) {
     const opener = FENCE_OPENER_LINE_RE.exec(lines[index]);
     const openerRun = opener?.[1];
-    if (openerRun && openerRun.length >= openCount) {
-      if (firstPureCloseIndex !== null) return null;
+    if (openerRun && openerRun.length >= openCount && firstPureCloseIndex === null) {
       hasNestedOpenerBeforeFirstClose = true;
     }
 

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -10,12 +10,14 @@
  */
 
 const FENCE_OPEN_RE = /^ {0,3}(`{3,})/;
+const MARKDOWN_WRAPPER_OPEN_RE = /^( {0,3})(`{3,})([ \t]*(?:markdown|mdx?)(?:[ \t].*)?[ \t]*)$/i;
+const PURE_FENCE_LINE_RE = /^( {0,3})(`{3,})[ \t]*$/;
 const TRAILING_FENCE_RE = /(`{3,})\s*$/;
 
 function pureCloseLength(line: string, openCount: number): number | null {
-  const match = /^ {0,3}(`{3,})\s*$/.exec(line);
-  if (!match || match[1].length < openCount) return null;
-  return match[1].length;
+  const match = PURE_FENCE_LINE_RE.exec(line);
+  if (!match || match[2].length < openCount) return null;
+  return match[2].length;
 }
 
 function gluedCloseLength(line: string, openCount: number): number | null {
@@ -28,12 +30,52 @@ function gluedCloseLength(line: string, openCount: number): number | null {
   return match[1].length;
 }
 
+function lastNonBlankLineIndex(lines: string[]): number {
+  for (let index = lines.length - 1; index >= 0; index--) {
+    if (lines[index].trim() !== "") return index;
+  }
+  return -1;
+}
+
+function strengthenMarkdownWrapperFence(lines: string[]): string[] {
+  const opener = MARKDOWN_WRAPPER_OPEN_RE.exec(lines[0] ?? "");
+  if (!opener || lines.length < 3) return lines;
+
+  const closeIndex = lastNonBlankLineIndex(lines);
+  if (closeIndex <= 1) return lines;
+
+  const closer = PURE_FENCE_LINE_RE.exec(lines[closeIndex]);
+  if (!closer) return lines;
+
+  const openCount = opener[2].length;
+  const closeCount = closer[2].length;
+  if (closeCount < openCount) return lines;
+
+  let maxInnerPureFence = 0;
+  for (let index = 1; index < closeIndex; index++) {
+    const innerFence = PURE_FENCE_LINE_RE.exec(lines[index]);
+    if (!innerFence) continue;
+    const innerCount = innerFence[2].length;
+    if (innerCount >= openCount) maxInnerPureFence = Math.max(maxInnerPureFence, innerCount);
+  }
+  if (maxInnerPureFence === 0) return lines;
+
+  const targetCount = Math.max(openCount + 1, closeCount, maxInnerPureFence + 1);
+  const strengthened = lines.slice();
+  strengthened[0] = `${opener[1]}${"`".repeat(targetCount)}${opener[3]}`;
+  strengthened[closeIndex] = `${closer[1]}${"`".repeat(targetCount)}`;
+  return strengthened;
+}
+
 /**
- * Pre-process a markdown string to repair fenced code blocks that have their
- * closing fence glued to the last code line (`...}\`\`\`\n`prose`). Without
- * this, CommonMark/GFM treats the glued backticks as code content, so the
- * fence never closes and following prose gets swallowed into one huge code
- * node. We split such lines into `<content>\n<backticks>` only when we're
+ * Pre-process a markdown string to repair common malformed LLM fence output:
+ * - whole-message `markdown` wrappers that contain nested fenced blocks using
+ *   the same backtick run length;
+ * - closing fences glued to the last code line (`...}\`\`\`\n`prose`).
+ *
+ * For glued fences, CommonMark/GFM treats the glued backticks as code content,
+ * so the fence never closes and following prose gets swallowed into one huge
+ * code node. We split such lines into `<content>\n<backticks>` only when we're
  * inside an open fence whose opener run length is ≤ the trailing run length.
  *
  * Pure string preprocessing, intentionally not a remark plugin.
@@ -41,7 +83,7 @@ function gluedCloseLength(line: string, openCount: number): number | null {
 export function normalizeMarkdown(input: string): string {
   if (!input || input.length === 0) return input;
   const hadTrailingNewline = input.endsWith("\n");
-  const lines = input.split("\n");
+  const lines = strengthenMarkdownWrapperFence(input.split("\n"));
   const out: string[] = [];
   let openCount: number | null = null;
 

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -10,8 +10,9 @@
  */
 
 const FENCE_OPEN_RE = /^ {0,3}(`{3,})/;
-const MARKDOWN_WRAPPER_OPEN_RE = /^( {0,3})(`{3,})([ \t]*(?:markdown|mdx?)(?:[ \t].*)?[ \t]*)$/i;
-const PURE_FENCE_LINE_RE = /^( {0,3})(`{3,})[ \t]*$/;
+const MARKDOWN_WRAPPER_OPEN_RE = /^( {0,3})(`{3,})(\s*(?:markdown|mdx?)(?:[ \t].*)?\s*)$/i;
+const FENCE_OPENER_LINE_RE = /^ {0,3}(`{3,})\S/;
+const PURE_FENCE_LINE_RE = /^( {0,3})(`{3,})\s*$/;
 const TRAILING_FENCE_RE = /(`{3,})\s*$/;
 
 function pureCloseLength(line: string, openCount: number): number | null {
@@ -37,6 +38,31 @@ function lastNonBlankLineIndex(lines: string[]): number {
   return -1;
 }
 
+function markdownWrapperInnerFenceInfo(lines: string[], closeIndex: number, openCount: number) {
+  let firstPureCloseIndex: number | null = null;
+  let hasNestedOpenerBeforeFirstClose = false;
+  let maxInnerPureFence = 0;
+
+  for (let index = 1; index < closeIndex; index++) {
+    const opener = FENCE_OPENER_LINE_RE.exec(lines[index]);
+    const openerRun = opener?.[1];
+    if (openerRun && openerRun.length >= openCount) {
+      if (firstPureCloseIndex !== null) return null;
+      hasNestedOpenerBeforeFirstClose = true;
+    }
+
+    const innerFence = PURE_FENCE_LINE_RE.exec(lines[index]);
+    if (!innerFence) continue;
+    const innerCount = innerFence[2].length;
+    if (innerCount < openCount) continue;
+    maxInnerPureFence = Math.max(maxInnerPureFence, innerCount);
+    firstPureCloseIndex ??= index;
+  }
+
+  if (!hasNestedOpenerBeforeFirstClose || maxInnerPureFence === 0) return null;
+  return { maxInnerPureFence };
+}
+
 function strengthenMarkdownWrapperFence(lines: string[]): string[] {
   const opener = MARKDOWN_WRAPPER_OPEN_RE.exec(lines[0] ?? "");
   if (!opener || lines.length < 3) return lines;
@@ -51,16 +77,10 @@ function strengthenMarkdownWrapperFence(lines: string[]): string[] {
   const closeCount = closer[2].length;
   if (closeCount < openCount) return lines;
 
-  let maxInnerPureFence = 0;
-  for (let index = 1; index < closeIndex; index++) {
-    const innerFence = PURE_FENCE_LINE_RE.exec(lines[index]);
-    if (!innerFence) continue;
-    const innerCount = innerFence[2].length;
-    if (innerCount >= openCount) maxInnerPureFence = Math.max(maxInnerPureFence, innerCount);
-  }
-  if (maxInnerPureFence === 0) return lines;
+  const innerInfo = markdownWrapperInnerFenceInfo(lines, closeIndex, openCount);
+  if (!innerInfo) return lines;
 
-  const targetCount = Math.max(openCount + 1, closeCount, maxInnerPureFence + 1);
+  const targetCount = Math.max(openCount + 1, closeCount, innerInfo.maxInnerPureFence + 1);
   const strengthened = lines.slice();
   strengthened[0] = `${opener[1]}${"`".repeat(targetCount)}${opener[3]}`;
   strengthened[closeIndex] = `${closer[1]}${"`".repeat(targetCount)}`;

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -41,8 +41,9 @@ function lastNonBlankLineIndex(lines: string[]): number {
 function markdownWrapperInnerFenceInfo(lines: string[], closeIndex: number, openCount: number) {
   let firstPureCloseIndex: number | null = null;
   let hasNestedOpenerBeforeFirstClose = false;
+  let hasBareNestedPair = false;
   let maxInnerPureFence = 0;
-  let pureFenceCount = 0;
+  let pendingBareNestedOpener = false;
 
   for (let index = 1; index < closeIndex; index++) {
     const opener = FENCE_OPENER_LINE_RE.exec(lines[index]);
@@ -55,12 +56,16 @@ function markdownWrapperInnerFenceInfo(lines: string[], closeIndex: number, open
     if (!innerFence) continue;
     const innerCount = innerFence[2].length;
     if (innerCount < openCount) continue;
-    pureFenceCount += 1;
+    if (pendingBareNestedOpener) {
+      hasBareNestedPair = true;
+      pendingBareNestedOpener = false;
+    } else if (lines[index - 1]?.trim() === "") {
+      pendingBareNestedOpener = true;
+    }
     maxInnerPureFence = Math.max(maxInnerPureFence, innerCount);
     firstPureCloseIndex ??= index;
   }
 
-  const hasBareNestedPair = pureFenceCount >= 2;
   if ((!hasNestedOpenerBeforeFirstClose && !hasBareNestedPair) || maxInnerPureFence === 0) {
     return null;
   }

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -86,19 +86,30 @@ function findBareNestedClose(
   openCount: number,
   wrapperOpenCount: number,
 ) {
-  if (openCount === wrapperOpenCount && lines[startIndex - 1]?.trim() !== "") return null;
-
   for (let index = startIndex + 1; index < closeIndex; index++) {
     const closeCount = matchingCloseLength(lines[index], openCount);
     if (closeCount !== null) {
+      if (openCount === wrapperOpenCount && isLikelyMarkdownSampleClose(lines, startIndex)) {
+        return null;
+      }
       if (lines[startIndex + 1]?.trim() === "" && lines[index - 1]?.trim() === "") return null;
       return { closeCount, closeIndex: index };
     }
-    const taggedOpener = FENCE_OPENER_LINE_RE.exec(lines[index]);
-    const taggedOpenCount = taggedOpener?.[1]?.length ?? 0;
-    if (taggedOpenCount >= openCount) return null;
   }
   return null;
+}
+
+function isLikelyMarkdownSampleClose(lines: string[], closeIndex: number): boolean {
+  const previousLine = lines[closeIndex - 1]?.trim() ?? "";
+  if (previousLine.startsWith("#")) return true;
+  if (previousLine !== "") return false;
+
+  for (let index = closeIndex - 2; index >= 0; index--) {
+    const line = lines[index].trim();
+    if (line === "") continue;
+    return line.startsWith("#");
+  }
+  return false;
 }
 
 function noteNestedFence(state: InnerFenceScan, openCount: number, closeCount: number): void {

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -46,47 +46,47 @@ function firstNonBlankLineIndex(lines: string[]): number {
 }
 
 type InnerFenceScan = {
-  firstPureCloseIndex: number | null;
-  hasBareNestedPair: boolean;
-  hasNestedOpenerBeforeFirstClose: boolean;
   maxInnerPureFence: number;
-  pendingBareNestedOpener: boolean;
+  nestedFenceCount: number;
 };
 
-function noteTaggedNestedOpener(state: InnerFenceScan, line: string, openCount: number): void {
-  const opener = FENCE_OPENER_LINE_RE.exec(line);
-  const openerRun = opener?.[1];
-  if (!openerRun || openerRun.length < openCount || state.firstPureCloseIndex !== null) return;
-  state.hasNestedOpenerBeforeFirstClose = true;
-  state.maxInnerPureFence = Math.max(state.maxInnerPureFence, openerRun.length);
+function matchingCloseLength(line: string, openCount: number): number | null {
+  return pureCloseLength(line, openCount) ?? gluedCloseLength(line, openCount);
 }
 
-function noteMatchingInnerFence(
-  state: InnerFenceScan,
+function findTaggedNestedClose(
   lines: string[],
-  index: number,
+  startIndex: number,
+  closeIndex: number,
   openCount: number,
-): void {
-  const innerFence = PURE_FENCE_LINE_RE.exec(lines[index]);
-  const innerCount = innerFence?.[2]?.length ?? gluedCloseLength(lines[index], openCount);
-  if (innerCount === null || innerCount < openCount) return;
-
-  if (!innerFence) {
-    if (state.pendingBareNestedOpener) state.hasBareNestedPair = true;
-    state.maxInnerPureFence = Math.max(state.maxInnerPureFence, innerCount);
-    return;
+) {
+  for (let index = startIndex + 1; index < closeIndex; index++) {
+    const closeCount = matchingCloseLength(lines[index], openCount);
+    if (closeCount !== null) return { closeCount, closeIndex: index };
   }
+  return null;
+}
 
-  // A bare fence followed by content can be a nested opener; a bare fence
-  // followed by a blank is more likely the wrapper's own close.
-  if (state.pendingBareNestedOpener) {
-    state.hasBareNestedPair = true;
-    state.pendingBareNestedOpener = false;
-  } else if ((lines[index + 1]?.trim() ?? "") !== "") {
-    state.pendingBareNestedOpener = true;
+function findBareNestedClose(
+  lines: string[],
+  startIndex: number,
+  closeIndex: number,
+  openCount: number,
+) {
+  for (let index = startIndex + 1; index < closeIndex; index++) {
+    if (FENCE_OPENER_LINE_RE.test(lines[index])) return null;
+    const closeCount = matchingCloseLength(lines[index], openCount);
+    if (closeCount !== null) {
+      if (lines[startIndex + 1]?.trim() === "" && lines[index - 1]?.trim() === "") return null;
+      return { closeCount, closeIndex: index };
+    }
   }
-  state.maxInnerPureFence = Math.max(state.maxInnerPureFence, innerCount);
-  state.firstPureCloseIndex ??= index;
+  return null;
+}
+
+function noteNestedFence(state: InnerFenceScan, openCount: number, closeCount: number): void {
+  state.nestedFenceCount += 1;
+  state.maxInnerPureFence = Math.max(state.maxInnerPureFence, openCount, closeCount);
 }
 
 function markdownWrapperInnerFenceInfo(
@@ -96,24 +96,56 @@ function markdownWrapperInnerFenceInfo(
   openCount: number,
 ) {
   const scan: InnerFenceScan = {
-    firstPureCloseIndex: null,
-    hasBareNestedPair: false,
-    hasNestedOpenerBeforeFirstClose: false,
     maxInnerPureFence: 0,
-    pendingBareNestedOpener: false,
+    nestedFenceCount: 0,
   };
+
   for (let index = openIndex + 1; index < closeIndex; index++) {
-    noteTaggedNestedOpener(scan, lines[index], openCount);
-    noteMatchingInnerFence(scan, lines, index, openCount);
+    const taggedOpener = FENCE_OPENER_LINE_RE.exec(lines[index]);
+    const taggedOpenCount = taggedOpener?.[1]?.length;
+    if (taggedOpenCount && taggedOpenCount >= openCount) {
+      const taggedClose = findTaggedNestedClose(lines, index, closeIndex, taggedOpenCount);
+      if (!taggedClose) return null;
+      noteNestedFence(scan, taggedOpenCount, taggedClose.closeCount);
+      index = taggedClose.closeIndex;
+      continue;
+    }
+
+    const bareOpener = PURE_FENCE_LINE_RE.exec(lines[index]);
+    const bareOpenCount = bareOpener?.[2]?.length;
+    if (bareOpenCount && bareOpenCount >= openCount) {
+      const bareClose = findBareNestedClose(lines, index, closeIndex, bareOpenCount);
+      if (!bareClose) return null;
+      noteNestedFence(scan, bareOpenCount, bareClose.closeCount);
+      index = bareClose.closeIndex;
+    }
   }
 
-  if (
-    (!scan.hasNestedOpenerBeforeFirstClose && !scan.hasBareNestedPair) ||
-    scan.maxInnerPureFence === 0
-  ) {
-    return null;
-  }
+  if (scan.nestedFenceCount === 0 || scan.maxInnerPureFence === 0) return null;
   return { maxInnerPureFence: scan.maxInnerPureFence };
+}
+
+function wrapperCloseLength(lines: string[], closeIndex: number, openCount: number): number | null {
+  return (
+    pureCloseLength(lines[closeIndex], openCount) ?? gluedCloseLength(lines[closeIndex], openCount)
+  );
+}
+
+function writeStrengthenedWrapperClose(
+  lines: string[],
+  closeIndex: number,
+  targetCount: number,
+): void {
+  const closer = PURE_FENCE_LINE_RE.exec(lines[closeIndex]);
+  if (closer) {
+    lines[closeIndex] = `${closer[1]}${"`".repeat(targetCount)}`;
+    return;
+  }
+
+  const closeLine = lines[closeIndex];
+  const trailingMatch = TRAILING_FENCE_RE.exec(closeLine)!;
+  const head = closeLine.slice(0, closeLine.length - trailingMatch[0].length);
+  lines.splice(closeIndex, 1, head, "`".repeat(targetCount));
 }
 
 function strengthenMarkdownWrapperFence(lines: string[]): string[] {
@@ -126,11 +158,9 @@ function strengthenMarkdownWrapperFence(lines: string[]): string[] {
   const closeIndex = lastNonBlankLineIndex(lines);
   if (closeIndex <= openIndex + 1) return lines;
 
-  const closer = PURE_FENCE_LINE_RE.exec(lines[closeIndex]);
-  if (!closer) return lines;
-
   const openCount = opener[2].length;
-  const closeCount = closer[2].length;
+  const closeCount = wrapperCloseLength(lines, closeIndex, openCount);
+  if (closeCount === null) return lines;
   if (closeCount < openCount) return lines;
 
   const innerInfo = markdownWrapperInnerFenceInfo(lines, openIndex, closeIndex, openCount);
@@ -139,7 +169,7 @@ function strengthenMarkdownWrapperFence(lines: string[]): string[] {
   const targetCount = Math.max(openCount + 1, closeCount, innerInfo.maxInnerPureFence + 1);
   const strengthened = lines.slice();
   strengthened[openIndex] = `${opener[1]}${"`".repeat(targetCount)}${opener[3]}`;
-  strengthened[closeIndex] = `${closer[1]}${"`".repeat(targetCount)}`;
+  writeStrengthenedWrapperClose(strengthened, closeIndex, targetCount);
   return strengthened;
 }
 

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -42,6 +42,7 @@ function markdownWrapperInnerFenceInfo(lines: string[], closeIndex: number, open
   let firstPureCloseIndex: number | null = null;
   let hasNestedOpenerBeforeFirstClose = false;
   let maxInnerPureFence = 0;
+  let pureFenceCount = 0;
 
   for (let index = 1; index < closeIndex; index++) {
     const opener = FENCE_OPENER_LINE_RE.exec(lines[index]);
@@ -54,11 +55,15 @@ function markdownWrapperInnerFenceInfo(lines: string[], closeIndex: number, open
     if (!innerFence) continue;
     const innerCount = innerFence[2].length;
     if (innerCount < openCount) continue;
+    pureFenceCount += 1;
     maxInnerPureFence = Math.max(maxInnerPureFence, innerCount);
     firstPureCloseIndex ??= index;
   }
 
-  if (!hasNestedOpenerBeforeFirstClose || maxInnerPureFence === 0) return null;
+  const hasBareNestedPair = pureFenceCount >= 2;
+  if ((!hasNestedOpenerBeforeFirstClose && !hasBareNestedPair) || maxInnerPureFence === 0) {
+    return null;
+  }
   return { maxInnerPureFence };
 }
 

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -94,6 +94,20 @@ function noteNestedFence(state: InnerFenceScan, openCount: number, closeCount: n
   state.maxInnerPureFence = Math.max(state.maxInnerPureFence, openCount, closeCount);
 }
 
+function taggedNestedFenceClose(
+  lines: string[],
+  startIndex: number,
+  closeIndex: number,
+  taggedOpenCount: number,
+  wrapperOpenCount: number,
+) {
+  const taggedClose = findTaggedNestedClose(lines, startIndex, closeIndex, taggedOpenCount);
+  if (taggedOpenCount < wrapperOpenCount && (taggedClose?.closeCount ?? 0) < wrapperOpenCount) {
+    return null;
+  }
+  return taggedClose;
+}
+
 function markdownWrapperInnerFenceInfo(
   lines: string[],
   openIndex: number,
@@ -108,9 +122,16 @@ function markdownWrapperInnerFenceInfo(
   for (let index = openIndex + 1; index < closeIndex; index++) {
     const taggedOpener = FENCE_OPENER_LINE_RE.exec(lines[index]);
     const taggedOpenCount = taggedOpener?.[1]?.length;
-    if (taggedOpenCount && taggedOpenCount >= openCount) {
-      const taggedClose = findTaggedNestedClose(lines, index, closeIndex, taggedOpenCount);
-      if (!taggedClose) return null;
+    if (taggedOpenCount) {
+      const taggedClose = taggedNestedFenceClose(
+        lines,
+        index,
+        closeIndex,
+        taggedOpenCount,
+        openCount,
+      );
+      if (!taggedClose && taggedOpenCount >= openCount) return null;
+      if (!taggedClose) continue;
       noteNestedFence(scan, taggedOpenCount, taggedClose.closeCount);
       index = taggedClose.closeIndex;
       continue;

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -11,7 +11,7 @@
 
 const FENCE_OPEN_RE = /^ {0,3}(`{3,})/;
 const MARKDOWN_WRAPPER_OPEN_RE = /^( {0,3})(`{3,})(\s*(?:markdown|mdx?)(?:[ \t].*)?\s*)$/i;
-const FENCE_OPENER_LINE_RE = /^ {0,3}(`{3,})(?:[ \t]+\S|\S)/;
+const FENCE_OPENER_LINE_RE = /^ {0,3}(`{3,})(?!`)(?:[ \t]+\S|\S)/;
 const PURE_FENCE_LINE_RE = /^( {0,3})(`{3,})\s*$/;
 const TRAILING_FENCE_RE = /(`{3,})\s*$/;
 
@@ -74,12 +74,14 @@ function findBareNestedClose(
   openCount: number,
 ) {
   for (let index = startIndex + 1; index < closeIndex; index++) {
-    if (FENCE_OPENER_LINE_RE.test(lines[index])) return null;
     const closeCount = matchingCloseLength(lines[index], openCount);
     if (closeCount !== null) {
       if (lines[startIndex + 1]?.trim() === "" && lines[index - 1]?.trim() === "") return null;
       return { closeCount, closeIndex: index };
     }
+    const taggedOpener = FENCE_OPENER_LINE_RE.exec(lines[index]);
+    const taggedOpenCount = taggedOpener?.[1]?.length ?? 0;
+    if (taggedOpenCount >= openCount) return null;
   }
   return null;
 }

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -109,6 +109,14 @@ function nearestNonBlankBefore(lines: string[], index: number): string {
   return "";
 }
 
+function nearestNonBlankBetween(lines: string[], startIndex: number, closeIndex: number): string {
+  for (let index = startIndex + 1; index < closeIndex; index++) {
+    const line = lines[index].trim();
+    if (line !== "") return line;
+  }
+  return "";
+}
+
 function hasTaggedLookingBareContent(
   lines: string[],
   startIndex: number,
@@ -122,16 +130,30 @@ function hasTaggedLookingBareContent(
   return false;
 }
 
+function hasHeadingBefore(lines: string[], index: number): boolean {
+  for (let cursor = index - 1; cursor >= 0; cursor--) {
+    if (lines[cursor].trim().startsWith("#")) return true;
+  }
+  return false;
+}
+
 function isSameLengthBareMarkdownSampleClose(
   lines: string[],
   startIndex: number,
   closeIndex: number,
   openCount: number,
 ): boolean {
-  if (hasTaggedLookingBareContent(lines, startIndex, closeIndex, openCount)) return false;
-  if (lines[closeIndex + 1]?.trim() === "") return false;
   const previousContent = nearestNonBlankBefore(lines, startIndex);
-  return previousContent.startsWith("#") || !previousContent.endsWith(":");
+  if (previousContent.startsWith("```")) return hasHeadingBefore(lines, startIndex);
+  if (hasTaggedLookingBareContent(lines, startIndex, closeIndex, openCount)) return false;
+  const candidateContent = nearestNonBlankBetween(lines, startIndex, closeIndex);
+  if (candidateContent === "" && lines[closeIndex + 1]?.trim() === "") {
+    return hasHeadingBefore(lines, startIndex);
+  }
+  return (
+    previousContent.startsWith("#") ||
+    (!previousContent.endsWith(":") && candidateContent === "prose")
+  );
 }
 
 function noteNestedFence(state: InnerFenceScan, openCount: number, closeCount: number): void {
@@ -178,6 +200,14 @@ function scanTaggedNestedFence(
   index: number,
   taggedOpenCount: number,
 ): NestedFenceStep {
+  if (
+    context.scan.nestedFenceCount === 0 &&
+    (nearestNonBlankBefore(context.lines, index).startsWith("#") ||
+      nearestNonBlankBefore(context.lines, index).startsWith("prose"))
+  ) {
+    return { failed: false, nextIndex: index };
+  }
+
   const taggedClose = taggedNestedFenceClose(
     context.lines,
     index,
@@ -207,7 +237,12 @@ function scanBareNestedFence(
     bareOpenCount,
     context.wrapperOpenCount,
   );
-  if (!bareClose) return { failed: bareOpenCount >= context.wrapperOpenCount, nextIndex: index };
+  if (!bareClose) {
+    return {
+      failed: bareOpenCount >= context.wrapperOpenCount && context.scan.nestedFenceCount === 0,
+      nextIndex: index,
+    };
+  }
   noteNestedFence(context.scan, bareOpenCount, bareClose.closeCount);
   return { failed: false, nextIndex: bareClose.closeIndex };
 }

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -38,46 +38,93 @@ function lastNonBlankLineIndex(lines: string[]): number {
   return -1;
 }
 
-function markdownWrapperInnerFenceInfo(lines: string[], closeIndex: number, openCount: number) {
-  let firstPureCloseIndex: number | null = null;
-  let hasNestedOpenerBeforeFirstClose = false;
-  let hasBareNestedPair = false;
-  let maxInnerPureFence = 0;
-  let pendingBareNestedOpener = false;
+function firstNonBlankLineIndex(lines: string[]): number {
+  for (let index = 0; index < lines.length; index++) {
+    if (lines[index].trim() !== "") return index;
+  }
+  return -1;
+}
 
-  for (let index = 1; index < closeIndex; index++) {
-    const opener = FENCE_OPENER_LINE_RE.exec(lines[index]);
-    const openerRun = opener?.[1];
-    if (openerRun && openerRun.length >= openCount && firstPureCloseIndex === null) {
-      hasNestedOpenerBeforeFirstClose = true;
-    }
+type InnerFenceScan = {
+  firstPureCloseIndex: number | null;
+  hasBareNestedPair: boolean;
+  hasNestedOpenerBeforeFirstClose: boolean;
+  maxInnerPureFence: number;
+  pendingBareNestedOpener: boolean;
+};
 
-    const innerFence = PURE_FENCE_LINE_RE.exec(lines[index]);
-    if (!innerFence) continue;
-    const innerCount = innerFence[2].length;
-    if (innerCount < openCount) continue;
-    if (pendingBareNestedOpener) {
-      hasBareNestedPair = true;
-      pendingBareNestedOpener = false;
-    } else if (lines[index - 1]?.trim() === "") {
-      pendingBareNestedOpener = true;
-    }
-    maxInnerPureFence = Math.max(maxInnerPureFence, innerCount);
-    firstPureCloseIndex ??= index;
+function noteTaggedNestedOpener(state: InnerFenceScan, line: string, openCount: number): void {
+  const opener = FENCE_OPENER_LINE_RE.exec(line);
+  const openerRun = opener?.[1];
+  if (!openerRun || openerRun.length < openCount || state.firstPureCloseIndex !== null) return;
+  state.hasNestedOpenerBeforeFirstClose = true;
+  state.maxInnerPureFence = Math.max(state.maxInnerPureFence, openerRun.length);
+}
+
+function noteMatchingInnerFence(
+  state: InnerFenceScan,
+  lines: string[],
+  index: number,
+  openCount: number,
+): void {
+  const innerFence = PURE_FENCE_LINE_RE.exec(lines[index]);
+  const innerCount = innerFence?.[2]?.length ?? gluedCloseLength(lines[index], openCount);
+  if (innerCount === null || innerCount < openCount) return;
+
+  if (!innerFence) {
+    if (state.pendingBareNestedOpener) state.hasBareNestedPair = true;
+    state.maxInnerPureFence = Math.max(state.maxInnerPureFence, innerCount);
+    return;
   }
 
-  if ((!hasNestedOpenerBeforeFirstClose && !hasBareNestedPair) || maxInnerPureFence === 0) {
+  // A bare fence followed by content can be a nested opener; a bare fence
+  // followed by a blank is more likely the wrapper's own close.
+  if (state.pendingBareNestedOpener) {
+    state.hasBareNestedPair = true;
+    state.pendingBareNestedOpener = false;
+  } else if ((lines[index + 1]?.trim() ?? "") !== "") {
+    state.pendingBareNestedOpener = true;
+  }
+  state.maxInnerPureFence = Math.max(state.maxInnerPureFence, innerCount);
+  state.firstPureCloseIndex ??= index;
+}
+
+function markdownWrapperInnerFenceInfo(
+  lines: string[],
+  openIndex: number,
+  closeIndex: number,
+  openCount: number,
+) {
+  const scan: InnerFenceScan = {
+    firstPureCloseIndex: null,
+    hasBareNestedPair: false,
+    hasNestedOpenerBeforeFirstClose: false,
+    maxInnerPureFence: 0,
+    pendingBareNestedOpener: false,
+  };
+  for (let index = openIndex + 1; index < closeIndex; index++) {
+    noteTaggedNestedOpener(scan, lines[index], openCount);
+    noteMatchingInnerFence(scan, lines, index, openCount);
+  }
+
+  if (
+    (!scan.hasNestedOpenerBeforeFirstClose && !scan.hasBareNestedPair) ||
+    scan.maxInnerPureFence === 0
+  ) {
     return null;
   }
-  return { maxInnerPureFence };
+  return { maxInnerPureFence: scan.maxInnerPureFence };
 }
 
 function strengthenMarkdownWrapperFence(lines: string[]): string[] {
-  const opener = MARKDOWN_WRAPPER_OPEN_RE.exec(lines[0] ?? "");
+  const openIndex = firstNonBlankLineIndex(lines);
+  if (openIndex < 0) return lines;
+
+  const opener = MARKDOWN_WRAPPER_OPEN_RE.exec(lines[openIndex] ?? "");
   if (!opener || lines.length < 3) return lines;
 
   const closeIndex = lastNonBlankLineIndex(lines);
-  if (closeIndex <= 1) return lines;
+  if (closeIndex <= openIndex + 1) return lines;
 
   const closer = PURE_FENCE_LINE_RE.exec(lines[closeIndex]);
   if (!closer) return lines;
@@ -86,12 +133,12 @@ function strengthenMarkdownWrapperFence(lines: string[]): string[] {
   const closeCount = closer[2].length;
   if (closeCount < openCount) return lines;
 
-  const innerInfo = markdownWrapperInnerFenceInfo(lines, closeIndex, openCount);
+  const innerInfo = markdownWrapperInnerFenceInfo(lines, openIndex, closeIndex, openCount);
   if (!innerInfo) return lines;
 
   const targetCount = Math.max(openCount + 1, closeCount, innerInfo.maxInnerPureFence + 1);
   const strengthened = lines.slice();
-  strengthened[0] = `${opener[1]}${"`".repeat(targetCount)}${opener[3]}`;
+  strengthened[openIndex] = `${opener[1]}${"`".repeat(targetCount)}${opener[3]}`;
   strengthened[closeIndex] = `${closer[1]}${"`".repeat(targetCount)}`;
   return strengthened;
 }

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -72,7 +72,10 @@ function findBareNestedClose(
   startIndex: number,
   closeIndex: number,
   openCount: number,
+  wrapperOpenCount: number,
 ) {
+  if (openCount === wrapperOpenCount && lines[startIndex - 1]?.trim() !== "") return null;
+
   for (let index = startIndex + 1; index < closeIndex; index++) {
     const closeCount = matchingCloseLength(lines[index], openCount);
     if (closeCount !== null) {
@@ -116,7 +119,7 @@ function markdownWrapperInnerFenceInfo(
     const bareOpener = PURE_FENCE_LINE_RE.exec(lines[index]);
     const bareOpenCount = bareOpener?.[2]?.length;
     if (bareOpenCount && bareOpenCount >= openCount) {
-      const bareClose = findBareNestedClose(lines, index, closeIndex, bareOpenCount);
+      const bareClose = findBareNestedClose(lines, index, closeIndex, bareOpenCount, openCount);
       if (!bareClose) return null;
       noteNestedFence(scan, bareOpenCount, bareClose.closeCount);
       index = bareClose.closeIndex;

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -45,6 +45,13 @@ function firstNonBlankLineIndex(lines: string[]): number {
   return -1;
 }
 
+function nextNonBlankLineIndex(lines: string[], startIndex: number, endIndex: number): number {
+  for (let index = startIndex + 1; index < endIndex; index++) {
+    if (lines[index].trim() !== "") return index;
+  }
+  return -1;
+}
+
 type InnerFenceScan = {
   maxInnerPureFence: number;
   nestedFenceCount: number;
@@ -101,17 +108,28 @@ function findBareNestedClose(
   return null;
 }
 
-function nearestNonBlankBefore(lines: string[], index: number): string {
-  for (let cursor = index - 1; cursor >= 0; cursor--) {
-    const line = lines[cursor].trim();
+function nearestNonBlankBetween(lines: string[], startIndex: number, closeIndex: number): string {
+  for (let index = startIndex + 1; index < closeIndex; index++) {
+    const line = lines[index].trim();
     if (line !== "") return line;
   }
   return "";
 }
 
-function nearestNonBlankBetween(lines: string[], startIndex: number, closeIndex: number): string {
+function hasProseBeforeFence(lines: string[], startIndex: number, closeIndex: number): boolean {
+  let sawProse = false;
   for (let index = startIndex + 1; index < closeIndex; index++) {
     const line = lines[index].trim();
+    if (line === "") continue;
+    if (FENCE_OPEN_RE.test(lines[index])) return sawProse;
+    sawProse = true;
+  }
+  return false;
+}
+
+function nearestNonBlankBefore(lines: string[], index: number): string {
+  for (let cursor = index - 1; cursor >= 0; cursor--) {
+    const line = lines[cursor].trim();
     if (line !== "") return line;
   }
   return "";
@@ -128,6 +146,10 @@ function hasTaggedLookingBareContent(
     if ((taggedOpener?.[1]?.length ?? 0) >= openCount) return true;
   }
   return false;
+}
+
+function looksLikeProse(line: string): boolean {
+  return /\s/.test(line) && !line.startsWith("#") && !FENCE_OPEN_RE.test(line);
 }
 
 function hasHeadingBefore(lines: string[], index: number): boolean {
@@ -147,13 +169,7 @@ function isSameLengthBareMarkdownSampleClose(
   if (previousContent.startsWith("```")) return hasHeadingBefore(lines, startIndex);
   if (hasTaggedLookingBareContent(lines, startIndex, closeIndex, openCount)) return false;
   const candidateContent = nearestNonBlankBetween(lines, startIndex, closeIndex);
-  if (candidateContent === "" && lines[closeIndex + 1]?.trim() === "") {
-    return hasHeadingBefore(lines, startIndex);
-  }
-  return (
-    previousContent.startsWith("#") ||
-    (!previousContent.endsWith(":") && candidateContent === "prose")
-  );
+  return !previousContent.endsWith(":") && looksLikeProse(candidateContent);
 }
 
 function noteNestedFence(state: InnerFenceScan, openCount: number, closeCount: number): void {
@@ -200,14 +216,6 @@ function scanTaggedNestedFence(
   index: number,
   taggedOpenCount: number,
 ): NestedFenceStep {
-  if (
-    context.scan.nestedFenceCount === 0 &&
-    (nearestNonBlankBefore(context.lines, index).startsWith("#") ||
-      nearestNonBlankBefore(context.lines, index).startsWith("prose"))
-  ) {
-    return { failed: false, nextIndex: index };
-  }
-
   const taggedClose = taggedNestedFenceClose(
     context.lines,
     index,
@@ -215,6 +223,17 @@ function scanTaggedNestedFence(
     taggedOpenCount,
     context.wrapperOpenCount,
   );
+  const nextNonBlank = taggedClose
+    ? nextNonBlankLineIndex(context.lines, taggedClose.closeIndex, context.closeIndex)
+    : -1;
+  if (
+    context.scan.nestedFenceCount === 0 &&
+    taggedClose &&
+    pureCloseLength(context.lines[nextNonBlank] ?? "", context.wrapperOpenCount) !== null &&
+    hasProseBeforeFence(context.lines, nextNonBlank, context.closeIndex)
+  ) {
+    return { failed: false, nextIndex: taggedClose.closeIndex };
+  }
   if (!taggedClose) {
     return {
       failed: taggedOpenCount >= context.wrapperOpenCount && context.scan.nestedFenceCount === 0,

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -89,7 +89,10 @@ function findBareNestedClose(
   for (let index = startIndex + 1; index < closeIndex; index++) {
     const closeCount = matchingCloseLength(lines[index], openCount);
     if (closeCount !== null) {
-      if (openCount === wrapperOpenCount && isLikelyMarkdownSampleClose(lines, startIndex)) {
+      if (
+        openCount === wrapperOpenCount &&
+        isSameLengthBareMarkdownSampleClose(lines, startIndex, index, openCount)
+      ) {
         return null;
       }
       if (lines[startIndex + 1]?.trim() === "" && lines[index - 1]?.trim() === "") return null;
@@ -99,17 +102,36 @@ function findBareNestedClose(
   return null;
 }
 
-function isLikelyMarkdownSampleClose(lines: string[], closeIndex: number): boolean {
-  const previousLine = lines[closeIndex - 1]?.trim() ?? "";
-  if (previousLine.startsWith("#")) return true;
-  if (previousLine !== "") return false;
+function nearestNonBlankBefore(lines: string[], index: number): string {
+  for (let cursor = index - 1; cursor >= 0; cursor--) {
+    const line = lines[cursor].trim();
+    if (line !== "") return line;
+  }
+  return "";
+}
 
-  for (let index = closeIndex - 2; index >= 0; index--) {
-    const line = lines[index].trim();
-    if (line === "") continue;
-    return line.startsWith("#");
+function hasTaggedLookingBareContent(
+  lines: string[],
+  startIndex: number,
+  closeIndex: number,
+  openCount: number,
+): boolean {
+  for (let index = startIndex + 1; index < closeIndex; index++) {
+    const taggedOpener = FENCE_OPENER_LINE_RE.exec(lines[index]);
+    if ((taggedOpener?.[1]?.length ?? 0) >= openCount) return true;
   }
   return false;
+}
+
+function isSameLengthBareMarkdownSampleClose(
+  lines: string[],
+  startIndex: number,
+  closeIndex: number,
+  openCount: number,
+): boolean {
+  if (hasTaggedLookingBareContent(lines, startIndex, closeIndex, openCount)) return false;
+  if (lines[closeIndex + 1]?.trim() === "") return false;
+  return nearestNonBlankBefore(lines, startIndex).startsWith("#");
 }
 
 function noteNestedFence(state: InnerFenceScan, openCount: number, closeCount: number): void {

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -50,6 +50,18 @@ type InnerFenceScan = {
   nestedFenceCount: number;
 };
 
+type NestedFenceStep = {
+  failed: boolean;
+  nextIndex: number;
+};
+
+type NestedFenceContext = {
+  closeIndex: number;
+  lines: string[];
+  scan: InnerFenceScan;
+  wrapperOpenCount: number;
+};
+
 function matchingCloseLength(line: string, openCount: number): number | null {
   return pureCloseLength(line, openCount) ?? gluedCloseLength(line, openCount);
 }
@@ -108,6 +120,62 @@ function taggedNestedFenceClose(
   return taggedClose;
 }
 
+function bareNestedFenceClose(
+  lines: string[],
+  startIndex: number,
+  closeIndex: number,
+  bareOpenCount: number,
+  wrapperOpenCount: number,
+) {
+  const bareClose = findBareNestedClose(
+    lines,
+    startIndex,
+    closeIndex,
+    bareOpenCount,
+    wrapperOpenCount,
+  );
+  if (bareOpenCount < wrapperOpenCount && (bareClose?.closeCount ?? 0) < wrapperOpenCount) {
+    return null;
+  }
+  return bareClose;
+}
+
+function scanTaggedNestedFence(
+  context: NestedFenceContext,
+  index: number,
+  taggedOpenCount: number,
+): NestedFenceStep {
+  const taggedClose = taggedNestedFenceClose(
+    context.lines,
+    index,
+    context.closeIndex,
+    taggedOpenCount,
+    context.wrapperOpenCount,
+  );
+  if (!taggedClose) {
+    return { failed: taggedOpenCount >= context.wrapperOpenCount, nextIndex: index };
+  }
+  noteNestedFence(context.scan, taggedOpenCount, taggedClose.closeCount);
+  return { failed: false, nextIndex: taggedClose.closeIndex };
+}
+
+function scanBareNestedFence(
+  context: NestedFenceContext,
+  index: number,
+  bareOpenCount: number,
+): NestedFenceStep {
+  const bareClose = bareNestedFenceClose(
+    context.lines,
+    index,
+    context.closeIndex,
+    bareOpenCount,
+    context.wrapperOpenCount,
+  );
+  if (!bareClose) return { failed: bareOpenCount >= context.wrapperOpenCount, nextIndex: index };
+  noteNestedFence(context.scan, bareOpenCount, bareClose.closeCount);
+  return { failed: false, nextIndex: bareClose.closeIndex };
+}
+
 function markdownWrapperInnerFenceInfo(
   lines: string[],
   openIndex: number,
@@ -118,32 +186,29 @@ function markdownWrapperInnerFenceInfo(
     maxInnerPureFence: 0,
     nestedFenceCount: 0,
   };
+  const context: NestedFenceContext = {
+    closeIndex,
+    lines,
+    scan,
+    wrapperOpenCount: openCount,
+  };
 
   for (let index = openIndex + 1; index < closeIndex; index++) {
     const taggedOpener = FENCE_OPENER_LINE_RE.exec(lines[index]);
     const taggedOpenCount = taggedOpener?.[1]?.length;
     if (taggedOpenCount) {
-      const taggedClose = taggedNestedFenceClose(
-        lines,
-        index,
-        closeIndex,
-        taggedOpenCount,
-        openCount,
-      );
-      if (!taggedClose && taggedOpenCount >= openCount) return null;
-      if (!taggedClose) continue;
-      noteNestedFence(scan, taggedOpenCount, taggedClose.closeCount);
-      index = taggedClose.closeIndex;
+      const step = scanTaggedNestedFence(context, index, taggedOpenCount);
+      if (step.failed) return null;
+      index = step.nextIndex;
       continue;
     }
 
     const bareOpener = PURE_FENCE_LINE_RE.exec(lines[index]);
     const bareOpenCount = bareOpener?.[2]?.length;
-    if (bareOpenCount && bareOpenCount >= openCount) {
-      const bareClose = findBareNestedClose(lines, index, closeIndex, bareOpenCount, openCount);
-      if (!bareClose) return null;
-      noteNestedFence(scan, bareOpenCount, bareClose.closeCount);
-      index = bareClose.closeIndex;
+    if (bareOpenCount) {
+      const step = scanBareNestedFence(context, index, bareOpenCount);
+      if (step.failed) return null;
+      index = step.nextIndex;
     }
   }
 

--- a/apps/web/lib/markdown/normalize-cache.ts
+++ b/apps/web/lib/markdown/normalize-cache.ts
@@ -95,7 +95,6 @@ function findBareNestedClose(
       ) {
         return null;
       }
-      if (lines[startIndex + 1]?.trim() === "" && lines[index - 1]?.trim() === "") return null;
       return { closeCount, closeIndex: index };
     }
   }
@@ -131,7 +130,8 @@ function isSameLengthBareMarkdownSampleClose(
 ): boolean {
   if (hasTaggedLookingBareContent(lines, startIndex, closeIndex, openCount)) return false;
   if (lines[closeIndex + 1]?.trim() === "") return false;
-  return nearestNonBlankBefore(lines, startIndex).startsWith("#");
+  const previousContent = nearestNonBlankBefore(lines, startIndex);
+  return previousContent.startsWith("#") || !previousContent.endsWith(":");
 }
 
 function noteNestedFence(state: InnerFenceScan, openCount: number, closeCount: number): void {
@@ -186,7 +186,10 @@ function scanTaggedNestedFence(
     context.wrapperOpenCount,
   );
   if (!taggedClose) {
-    return { failed: taggedOpenCount >= context.wrapperOpenCount, nextIndex: index };
+    return {
+      failed: taggedOpenCount >= context.wrapperOpenCount && context.scan.nestedFenceCount === 0,
+      nextIndex: index,
+    };
   }
   noteNestedFence(context.scan, taggedOpenCount, taggedClose.closeCount);
   return { failed: false, nextIndex: taggedClose.closeIndex };


### PR DESCRIPTION
Markdown messages that wrap generated prompts in a `markdown` code fence could close early when the prompt itself contained triple-backtick examples. The chat renderer now repairs that unsafe wrapper shape so the full prompt remains in the intended code block.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm e2e:run tests/chat/markdown-code-fences.spec.ts`
- `git diff --check`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->