### PR TITLE
fix: keep acknowledged agent errors hidden

### DIFF
--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -28,6 +28,7 @@ import { findTaskInSnapshots } from "@/lib/kanban/find-task";
 import { repositorySlug } from "@/lib/repository-slug";
 import { resolvePreferredSessionId } from "../task-select-helpers";
 import { agentErrorMessageForTask } from "@/lib/task-agent-error";
+import { usePersistResolvedAgentErrorAcknowledgements } from "../use-agent-error-acknowledgements";
 
 // Map workflow snapshot to kanban state on workspace switch.
 function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) {
@@ -93,6 +94,7 @@ type SheetItemCtx = {
   envIdBySessionId: Parameters<typeof getSessionInfoForTask>[3];
   messagesBySession: Parameters<typeof hasPendingClarificationForSession>[0];
   dismissedAgentErrors: Record<string, string>;
+  acknowledgedAgentErrors: Record<string, string>;
 };
 
 function toSheetItem(
@@ -149,6 +151,7 @@ export function useSheetData(workspaceId: string | null) {
   const envIdBySessionId = useAppStore((state) => state.environmentIdBySessionId);
   const messagesBySession = useAppStore((state) => state.messages.bySession);
   const dismissedAgentErrors = useAppStore((state) => state.dismissedAgentErrors);
+  const acknowledgedAgentErrors = useAppStore((state) => state.acknowledgedAgentErrors);
   const {
     allTasks,
     allSteps,
@@ -159,6 +162,13 @@ export function useSheetData(workspaceId: string | null) {
   const steps = useAppStore((state) => state.kanban.steps);
   const workspaces = useAppStore((state) => state.workspaces.items);
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
+
+  usePersistResolvedAgentErrorAcknowledgements({
+    sessionsById,
+    messagesBySession,
+    dismissedAgentErrors,
+    acknowledgedAgentErrors,
+  });
 
   const selectedTaskId = useMemo(() => {
     if (activeSessionId) return sessionsById[activeSessionId]?.task_id ?? activeTaskId;
@@ -179,6 +189,7 @@ export function useSheetData(workspaceId: string | null) {
       envIdBySessionId,
       messagesBySession,
       dismissedAgentErrors,
+      acknowledgedAgentErrors,
     };
     return allTasks.map((task) => toSheetItem(task, ctx));
   }, [
@@ -193,6 +204,7 @@ export function useSheetData(workspaceId: string | null) {
     envIdBySessionId,
     messagesBySession,
     dismissedAgentErrors,
+    acknowledgedAgentErrors,
   ]);
 
   const dialogSteps = useMemo(

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -28,7 +28,10 @@ import { findTaskInSnapshots } from "@/lib/kanban/find-task";
 import { repositorySlug } from "@/lib/repository-slug";
 import { resolvePreferredSessionId } from "../task-select-helpers";
 import { agentErrorMessageForTask } from "@/lib/task-agent-error";
-import { usePersistResolvedAgentErrorAcknowledgements } from "../use-agent-error-acknowledgements";
+import {
+  agentErrorAcknowledgementSessionIds,
+  usePersistResolvedAgentErrorAcknowledgements,
+} from "../use-agent-error-acknowledgements";
 
 // Map workflow snapshot to kanban state on workspace switch.
 function mapSnapshotToKanban(snapshot: WorkflowSnapshot, newWorkflowId: string) {
@@ -168,16 +171,13 @@ export function useSheetData(workspaceId: string | null) {
     return activeTaskId;
   }, [activeSessionId, activeTaskId, sessionsById]);
 
-  const primarySessionIds = useMemo(
-    () =>
-      allTasks
-        .map((task) => task.primarySessionId)
-        .filter((sessionId): sessionId is string => Boolean(sessionId)),
-    [allTasks],
+  const acknowledgementSessionIds = useMemo(
+    () => agentErrorAcknowledgementSessionIds(allTasks, sessionsByTaskId),
+    [allTasks, sessionsByTaskId],
   );
   usePersistResolvedAgentErrorAcknowledgements({
     sessionsById,
-    sessionIds: primarySessionIds,
+    sessionIds: acknowledgementSessionIds,
     messagesBySession,
     dismissedAgentErrors,
   });

--- a/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
+++ b/apps/web/components/task/mobile/session-task-switcher-sheet-hooks.ts
@@ -163,17 +163,24 @@ export function useSheetData(workspaceId: string | null) {
   const workspaces = useAppStore((state) => state.workspaces.items);
   const repositoriesByWorkspace = useAppStore((state) => state.repositories.itemsByWorkspaceId);
 
-  usePersistResolvedAgentErrorAcknowledgements({
-    sessionsById,
-    messagesBySession,
-    dismissedAgentErrors,
-    acknowledgedAgentErrors,
-  });
-
   const selectedTaskId = useMemo(() => {
     if (activeSessionId) return sessionsById[activeSessionId]?.task_id ?? activeTaskId;
     return activeTaskId;
   }, [activeSessionId, activeTaskId, sessionsById]);
+
+  const primarySessionIds = useMemo(
+    () =>
+      allTasks
+        .map((task) => task.primarySessionId)
+        .filter((sessionId): sessionId is string => Boolean(sessionId)),
+    [allTasks],
+  );
+  usePersistResolvedAgentErrorAcknowledgements({
+    sessionsById,
+    sessionIds: primarySessionIds,
+    messagesBySession,
+    dismissedAgentErrors,
+  });
 
   const tasksWithRepositories = useMemo(() => {
     const repositories = workspaceId ? (repositoriesByWorkspace[workspaceId] ?? []) : [];

--- a/apps/web/components/task/simple/OfficeSimplePane.test.tsx
+++ b/apps/web/components/task/simple/OfficeSimplePane.test.tsx
@@ -132,7 +132,7 @@ const runningSession: TaskSession = {
   ...completedSession,
   id: "session-running",
   state: "RUNNING",
-  completedAt: null,
+  completedAt: undefined,
   updatedAt: "2026-05-01T10:07:00Z",
 };
 

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -29,6 +29,7 @@ import { useGroupedSidebarView } from "./task-session-sidebar-grouped-view";
 import { useSidebarLinkActions } from "./task-session-sidebar-link-actions";
 import { useShallow } from "zustand/react/shallow";
 import { type AgentErrorOptions, agentErrorMessageForTask } from "@/lib/task-agent-error";
+import { usePersistResolvedAgentErrorAcknowledgements } from "./use-agent-error-acknowledgements";
 
 /**
  * Stabilize a derived array of primary session IDs so the reference only
@@ -215,7 +216,15 @@ function useSidebarData(workspaceId: string | null) {
   const taskPRsByTaskId = useAppStore((state) => state.taskPRs.byTaskId);
   const messagesBySession = useAppStore((state) => state.messages.bySession);
   const dismissedAgentErrors = useAppStore((state) => state.dismissedAgentErrors);
+  const acknowledgedAgentErrors = useAppStore((state) => state.acknowledgedAgentErrors);
   const archivedState = useArchivedTaskState();
+
+  usePersistResolvedAgentErrorAcknowledgements({
+    sessionsById,
+    messagesBySession,
+    dismissedAgentErrors,
+    acknowledgedAgentErrors,
+  });
 
   const selectedTaskId = useMemo(() => {
     if (activeSessionId) return sessionsById[activeSessionId]?.task_id ?? activeTaskId;
@@ -258,6 +267,7 @@ function useSidebarData(workspaceId: string | null) {
       workflowNameById,
       stepTitleById,
       dismissedAgentErrors,
+      acknowledgedAgentErrors,
       messagesBySession,
     };
     const items: SidebarItem[] = allTasks.map((task) => toSidebarItem(task, mapCtx));
@@ -282,6 +292,7 @@ function useSidebarData(workspaceId: string | null) {
     taskPRsByTaskId,
     pendingFlags,
     dismissedAgentErrors,
+    acknowledgedAgentErrors,
     messagesBySession,
     archivedState,
   ]);

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -29,25 +29,14 @@ import { useGroupedSidebarView } from "./task-session-sidebar-grouped-view";
 import { useSidebarLinkActions } from "./task-session-sidebar-link-actions";
 import { useShallow } from "zustand/react/shallow";
 import { type AgentErrorOptions, agentErrorMessageForTask } from "@/lib/task-agent-error";
-import { usePersistResolvedAgentErrorAcknowledgements } from "./use-agent-error-acknowledgements";
+import {
+  agentErrorAcknowledgementSessionIds,
+  stablePrimarySessionIdsKey,
+  usePersistResolvedAgentErrorAcknowledgements,
+} from "./use-agent-error-acknowledgements";
 
-/**
- * Stabilize a derived array of primary session IDs so the reference only
- * changes when the actual contents change. This prevents the bulk-subscribe
- * effect from tearing down and recreating all subscriptions on every kanban
- * snapshot update.
- */
-function useStablePrimarySessionIds(
-  allTasks: Array<{ primarySessionId?: string | null }>,
-): string[] {
-  const key = useMemo(
-    () =>
-      allTasks
-        .map((t) => t.primarySessionId)
-        .filter((id): id is string => id != null)
-        .join("\0"),
-    [allTasks],
-  );
+function useStablePrimarySessionIds(allTasks: Array<{ primarySessionId?: string | null }>) {
+  const key = useMemo(() => stablePrimarySessionIdsKey(allTasks), [allTasks]);
   return useMemo(() => (key ? key.split("\0") : []), [key]);
 }
 
@@ -236,9 +225,13 @@ function useSidebarData(workspaceId: string | null) {
   // narrow pending-flag selector below. Derived from kanban tasks (always
   // available) rather than sessionsByTaskId (loaded on-demand).
   const primarySessionIds = useStablePrimarySessionIds(allTasks);
+  const acknowledgementSessionIds = useMemo(
+    () => agentErrorAcknowledgementSessionIds(allTasks, sessionsByTaskId),
+    [allTasks, sessionsByTaskId],
+  );
   usePersistResolvedAgentErrorAcknowledgements({
     sessionsById,
-    sessionIds: primarySessionIds,
+    sessionIds: acknowledgementSessionIds,
     messagesBySession,
     dismissedAgentErrors,
   });

--- a/apps/web/components/task/task-session-sidebar.tsx
+++ b/apps/web/components/task/task-session-sidebar.tsx
@@ -219,13 +219,6 @@ function useSidebarData(workspaceId: string | null) {
   const acknowledgedAgentErrors = useAppStore((state) => state.acknowledgedAgentErrors);
   const archivedState = useArchivedTaskState();
 
-  usePersistResolvedAgentErrorAcknowledgements({
-    sessionsById,
-    messagesBySession,
-    dismissedAgentErrors,
-    acknowledgedAgentErrors,
-  });
-
   const selectedTaskId = useMemo(() => {
     if (activeSessionId) return sessionsById[activeSessionId]?.task_id ?? activeTaskId;
     return activeTaskId;
@@ -243,6 +236,12 @@ function useSidebarData(workspaceId: string | null) {
   // narrow pending-flag selector below. Derived from kanban tasks (always
   // available) rather than sessionsByTaskId (loaded on-demand).
   const primarySessionIds = useStablePrimarySessionIds(allTasks);
+  usePersistResolvedAgentErrorAcknowledgements({
+    sessionsById,
+    sessionIds: primarySessionIds,
+    messagesBySession,
+    dismissedAgentErrors,
+  });
   const pendingFlags = useAppStore(
     useShallow((state) => buildPendingFlags(state.messages.bySession, primarySessionIds)),
   );

--- a/apps/web/components/task/use-agent-error-acknowledgements.test.tsx
+++ b/apps/web/components/task/use-agent-error-acknowledgements.test.tsx
@@ -11,6 +11,7 @@ import {
 import { sessionId, taskId, type Message, type TaskSession } from "@/lib/types/http";
 import {
   agentErrorAcknowledgementSessionIds,
+  stablePrimarySessionIdsKey,
   usePersistResolvedAgentErrorAcknowledgements,
 } from "./use-agent-error-acknowledgements";
 
@@ -159,5 +160,17 @@ describe("agentErrorAcknowledgementSessionIds", () => {
         },
       ),
     ).toEqual(["primary", "fallback-1", "fallback-2"]);
+  });
+});
+
+describe("stablePrimarySessionIdsKey", () => {
+  it("uses a NUL separator so comma-containing IDs do not collide", () => {
+    expect(
+      stablePrimarySessionIdsKey([{ primarySessionId: "x,y" }, { primarySessionId: "x,y" }]),
+    ).toBe("x,y\0x,y");
+  });
+
+  it("drops nullish primary session IDs", () => {
+    expect(stablePrimarySessionIdsKey([{ primarySessionId: null }, {}])).toBe("");
   });
 });

--- a/apps/web/components/task/use-agent-error-acknowledgements.test.tsx
+++ b/apps/web/components/task/use-agent-error-acknowledgements.test.tsx
@@ -1,0 +1,143 @@
+import type { PropsWithChildren } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StateProvider } from "@/components/state-provider";
+import {
+  getStoredAcknowledgedAgentErrors,
+  lastAgentErrorStamp,
+  setStoredAcknowledgedAgentErrors,
+} from "@/lib/session-last-agent-error";
+import { sessionId, taskId, type Message, type TaskSession } from "@/lib/types/http";
+import { usePersistResolvedAgentErrorAcknowledgements } from "./use-agent-error-acknowledgements";
+
+const ERROR_OCCURRED_AT = "2026-06-14T10:00:00Z";
+const AGENT_MESSAGE_AFTER_ERROR_AT = "2026-06-14T10:00:01Z";
+const ERROR_MESSAGE = "agent failed";
+const ERROR_STAMP = lastAgentErrorStamp({
+  message: ERROR_MESSAGE,
+  occurredAt: ERROR_OCCURRED_AT,
+});
+
+function wrapper() {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <StateProvider>{children}</StateProvider>;
+  };
+}
+
+function session(id: string, metadata: TaskSession["metadata"]): TaskSession {
+  return {
+    id: sessionId(id),
+    task_id: taskId("task-1"),
+    state: "WAITING_FOR_INPUT",
+    started_at: ERROR_OCCURRED_AT,
+    updated_at: ERROR_OCCURRED_AT,
+    metadata,
+  } as TaskSession;
+}
+
+function sessionWithError(id: string): TaskSession {
+  return session(id, {
+    last_agent_error: {
+      message: ERROR_MESSAGE,
+      occurred_at: ERROR_OCCURRED_AT,
+    },
+  });
+}
+
+function agentMessage(session: string, createdAt: string): Message {
+  return {
+    id: `message-${session}`,
+    session_id: sessionId(session),
+    task_id: taskId("task-1"),
+    author_type: "agent",
+    content: "",
+    type: "agent_message",
+    created_at: createdAt,
+  } as unknown as Message;
+}
+
+describe("usePersistResolvedAgentErrorAcknowledgements", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("acknowledges sessions whose error is followed by an agent message", async () => {
+    renderHook(
+      () =>
+        usePersistResolvedAgentErrorAcknowledgements({
+          sessionsById: { "session-1": sessionWithError("session-1") },
+          sessionIds: ["session-1"],
+          messagesBySession: {
+            "session-1": [agentMessage("session-1", AGENT_MESSAGE_AFTER_ERROR_AT)],
+          },
+          dismissedAgentErrors: {},
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(getStoredAcknowledgedAgentErrors()).toEqual({ "session-1": ERROR_STAMP });
+    });
+  });
+
+  it("does not rewrite a stamp that is already acknowledged", async () => {
+    setStoredAcknowledgedAgentErrors({ "session-1": ERROR_STAMP });
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+    renderHook(
+      () =>
+        usePersistResolvedAgentErrorAcknowledgements({
+          sessionsById: { "session-1": sessionWithError("session-1") },
+          sessionIds: ["session-1"],
+          messagesBySession: {
+            "session-1": [agentMessage("session-1", AGENT_MESSAGE_AFTER_ERROR_AT)],
+          },
+          dismissedAgentErrors: {},
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("does not acknowledge when the error is not followed by an agent message", async () => {
+    renderHook(
+      () =>
+        usePersistResolvedAgentErrorAcknowledgements({
+          sessionsById: { "session-1": sessionWithError("session-1") },
+          sessionIds: ["session-1"],
+          messagesBySession: {
+            "session-1": [agentMessage("session-1", ERROR_OCCURRED_AT)],
+          },
+          dismissedAgentErrors: {},
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(getStoredAcknowledgedAgentErrors()).toEqual({});
+    });
+  });
+
+  it("does not acknowledge a session with no last agent error", async () => {
+    renderHook(
+      () =>
+        usePersistResolvedAgentErrorAcknowledgements({
+          sessionsById: { "session-1": session("session-1", {}) },
+          sessionIds: ["session-1"],
+          messagesBySession: {
+            "session-1": [agentMessage("session-1", AGENT_MESSAGE_AFTER_ERROR_AT)],
+          },
+          dismissedAgentErrors: {},
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => {
+      expect(getStoredAcknowledgedAgentErrors()).toEqual({});
+    });
+  });
+});

--- a/apps/web/components/task/use-agent-error-acknowledgements.test.tsx
+++ b/apps/web/components/task/use-agent-error-acknowledgements.test.tsx
@@ -9,7 +9,10 @@ import {
   setStoredAcknowledgedAgentErrors,
 } from "@/lib/session-last-agent-error";
 import { sessionId, taskId, type Message, type TaskSession } from "@/lib/types/http";
-import { usePersistResolvedAgentErrorAcknowledgements } from "./use-agent-error-acknowledgements";
+import {
+  agentErrorAcknowledgementSessionIds,
+  usePersistResolvedAgentErrorAcknowledgements,
+} from "./use-agent-error-acknowledgements";
 
 const ERROR_OCCURRED_AT = "2026-06-14T10:00:00Z";
 const AGENT_MESSAGE_AFTER_ERROR_AT = "2026-06-14T10:00:01Z";
@@ -139,5 +142,22 @@ describe("usePersistResolvedAgentErrorAcknowledgements", () => {
     await waitFor(() => {
       expect(getStoredAcknowledgedAgentErrors()).toEqual({});
     });
+  });
+});
+
+describe("agentErrorAcknowledgementSessionIds", () => {
+  it("includes primary and non-terminal fallback sessions for rendered tasks", () => {
+    expect(
+      agentErrorAcknowledgementSessionIds(
+        [
+          { id: "task-1", primarySessionId: "primary" },
+          { id: "task-2", primarySessionId: null },
+        ],
+        {
+          "task-1": [session("fallback-1", {}), { ...session("done", {}), state: "COMPLETED" }],
+          "task-2": [session("fallback-2", {})],
+        },
+      ),
+    ).toEqual(["primary", "fallback-1", "fallback-2"]);
   });
 });

--- a/apps/web/components/task/use-agent-error-acknowledgements.ts
+++ b/apps/web/components/task/use-agent-error-acknowledgements.ts
@@ -16,6 +16,12 @@ type UseAgentErrorAcknowledgementsParams = {
   dismissedAgentErrors: Record<string, string>;
 };
 
+/**
+ * Mirrors the sessions `agentErrorMessageForTask` can inspect for visible task
+ * rows. Primary sessions are included directly; fallback sessions are included
+ * only while non-terminal because terminal sessions will not produce a later
+ * agent message that can make their error acknowledgement stale.
+ */
 export function agentErrorAcknowledgementSessionIds(
   tasks: Array<{ id: string; primarySessionId?: string | null }>,
   sessionsByTaskId: Record<string, TaskSession[] | undefined>,
@@ -30,6 +36,11 @@ export function agentErrorAcknowledgementSessionIds(
   return [...sessionIds];
 }
 
+/**
+ * Builds a stable content key for primary session IDs so derived arrays only
+ * change when their contents change. The NUL separator avoids collisions with
+ * commas or newlines in IDs, preventing avoidable bulk WS re-subscriptions.
+ */
 export function stablePrimarySessionIdsKey(
   tasks: Array<{ primarySessionId?: string | null }>,
 ): string {

--- a/apps/web/components/task/use-agent-error-acknowledgements.ts
+++ b/apps/web/components/task/use-agent-error-acknowledgements.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAppStore } from "@/components/state-provider";
+import {
+  type AgentErrorOptions,
+  resolvedAgentErrorAcknowledgementStamp,
+} from "@/lib/task-agent-error";
+import type { TaskSession } from "@/lib/types/http";
+
+type UseAgentErrorAcknowledgementsParams = {
+  sessionsById: Record<string, TaskSession>;
+  messagesBySession: AgentErrorOptions["messagesBySession"];
+  dismissedAgentErrors: Record<string, string>;
+  acknowledgedAgentErrors: Record<string, string>;
+};
+
+export function usePersistResolvedAgentErrorAcknowledgements({
+  sessionsById,
+  messagesBySession,
+  dismissedAgentErrors,
+  acknowledgedAgentErrors,
+}: UseAgentErrorAcknowledgementsParams) {
+  const acknowledgeAgentError = useAppStore((state) => state.acknowledgeAgentError);
+
+  useEffect(() => {
+    for (const [sessionId, session] of Object.entries(sessionsById)) {
+      const stamp = resolvedAgentErrorAcknowledgementStamp(sessionId, session, {
+        messagesBySession,
+        dismissedAgentErrors,
+        acknowledgedAgentErrors,
+      });
+      if (stamp) acknowledgeAgentError(sessionId, stamp);
+    }
+  }, [
+    acknowledgeAgentError,
+    acknowledgedAgentErrors,
+    dismissedAgentErrors,
+    messagesBySession,
+    sessionsById,
+  ]);
+}

--- a/apps/web/components/task/use-agent-error-acknowledgements.ts
+++ b/apps/web/components/task/use-agent-error-acknowledgements.ts
@@ -7,6 +7,7 @@ import {
   resolvedAgentErrorAcknowledgementStamp,
 } from "@/lib/task-agent-error";
 import type { TaskSession } from "@/lib/types/http";
+import { isTerminalSessionState } from "@/lib/ws/handlers/agent-session";
 
 type UseAgentErrorAcknowledgementsParams = {
   sessionsById: Record<string, TaskSession>;
@@ -14,6 +15,29 @@ type UseAgentErrorAcknowledgementsParams = {
   messagesBySession: AgentErrorOptions["messagesBySession"];
   dismissedAgentErrors: Record<string, string>;
 };
+
+export function agentErrorAcknowledgementSessionIds(
+  tasks: Array<{ id: string; primarySessionId?: string | null }>,
+  sessionsByTaskId: Record<string, TaskSession[] | undefined>,
+): string[] {
+  const sessionIds = new Set<string>();
+  for (const task of tasks) {
+    if (task.primarySessionId) sessionIds.add(task.primarySessionId);
+    for (const session of sessionsByTaskId[task.id] ?? []) {
+      if (!isTerminalSessionState(session.state)) sessionIds.add(session.id);
+    }
+  }
+  return [...sessionIds];
+}
+
+export function stablePrimarySessionIdsKey(
+  tasks: Array<{ primarySessionId?: string | null }>,
+): string {
+  return tasks
+    .map((task) => task.primarySessionId)
+    .filter((sessionId): sessionId is string => sessionId != null)
+    .join("\0");
+}
 
 export function usePersistResolvedAgentErrorAcknowledgements({
   sessionsById,

--- a/apps/web/components/task/use-agent-error-acknowledgements.ts
+++ b/apps/web/components/task/use-agent-error-acknowledgements.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import {
   type AgentErrorOptions,
   resolvedAgentErrorAcknowledgementStamp,
@@ -10,33 +10,40 @@ import type { TaskSession } from "@/lib/types/http";
 
 type UseAgentErrorAcknowledgementsParams = {
   sessionsById: Record<string, TaskSession>;
+  sessionIds: readonly string[];
   messagesBySession: AgentErrorOptions["messagesBySession"];
   dismissedAgentErrors: Record<string, string>;
-  acknowledgedAgentErrors: Record<string, string>;
 };
 
 export function usePersistResolvedAgentErrorAcknowledgements({
   sessionsById,
+  sessionIds,
   messagesBySession,
   dismissedAgentErrors,
-  acknowledgedAgentErrors,
 }: UseAgentErrorAcknowledgementsParams) {
-  const acknowledgeAgentError = useAppStore((state) => state.acknowledgeAgentError);
+  const store = useAppStoreApi();
+  const acknowledgeAgentErrors = useAppStore((state) => state.acknowledgeAgentErrors);
 
   useEffect(() => {
-    for (const [sessionId, session] of Object.entries(sessionsById)) {
+    const acknowledgedAgentErrors = store.getState().acknowledgedAgentErrors;
+    const stamps: Record<string, string> = {};
+    for (const sessionId of sessionIds) {
+      const session = sessionsById[sessionId];
+      if (!session) continue;
       const stamp = resolvedAgentErrorAcknowledgementStamp(sessionId, session, {
         messagesBySession,
         dismissedAgentErrors,
         acknowledgedAgentErrors,
       });
-      if (stamp) acknowledgeAgentError(sessionId, stamp);
+      if (stamp) stamps[sessionId] = stamp;
     }
+    acknowledgeAgentErrors(stamps);
   }, [
-    acknowledgeAgentError,
-    acknowledgedAgentErrors,
+    acknowledgeAgentErrors,
     dismissedAgentErrors,
     messagesBySession,
+    sessionIds,
     sessionsById,
+    store,
   ]);
 }

--- a/apps/web/lib/session-last-agent-error.test.ts
+++ b/apps/web/lib/session-last-agent-error.test.ts
@@ -1,15 +1,21 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  getStoredAcknowledgedAgentErrors,
   getStoredDismissedAgentErrors,
   lastAgentErrorStamp,
   readLastAgentError,
+  setStoredAcknowledgedAgentErrors,
   setStoredDismissedAgentErrors,
 } from "./session-last-agent-error";
 
 const AGENT_ERROR_MESSAGE = "agent process exited";
 const AGENT_EXECUTION_ID = "exec-1";
 const OCCURRED_AT = "2026-06-14T12:00:00Z";
+const OTHER_TAB_SESSION_ID = "session-other-tab";
+const THIS_TAB_SESSION_ID = "session-this-tab";
+const OTHER_TAB_STAMP = "stamp-other";
+const THIS_TAB_STAMP = "stamp-this";
 
 describe("readLastAgentError", () => {
   it("reads snake_case metadata and keeps occurredAt optional", () => {
@@ -86,15 +92,15 @@ describe("setStoredDismissedAgentErrors", () => {
 
   it("merges with existing entries so a concurrent tab's writes are not clobbered", () => {
     // Simulate a write from another tab landing first.
-    setStoredDismissedAgentErrors({ "session-other-tab": "stamp-other" });
+    setStoredDismissedAgentErrors({ [OTHER_TAB_SESSION_ID]: OTHER_TAB_STAMP });
 
     // This tab then dismisses for a different session using a stale snapshot
     // (i.e. one that does not include `session-other-tab`).
-    setStoredDismissedAgentErrors({ "session-this-tab": "stamp-this" });
+    setStoredDismissedAgentErrors({ [THIS_TAB_SESSION_ID]: THIS_TAB_STAMP });
 
     expect(getStoredDismissedAgentErrors()).toEqual({
-      "session-other-tab": "stamp-other",
-      "session-this-tab": "stamp-this",
+      [OTHER_TAB_SESSION_ID]: OTHER_TAB_STAMP,
+      [THIS_TAB_SESSION_ID]: THIS_TAB_STAMP,
     });
   });
 
@@ -102,5 +108,27 @@ describe("setStoredDismissedAgentErrors", () => {
     setStoredDismissedAgentErrors({ "session-a": "stamp-v1" });
     setStoredDismissedAgentErrors({ "session-a": "stamp-v2" });
     expect(getStoredDismissedAgentErrors()).toEqual({ "session-a": "stamp-v2" });
+  });
+});
+
+describe("setStoredAcknowledgedAgentErrors", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("merges with existing sidebar acknowledgement entries", () => {
+    setStoredAcknowledgedAgentErrors({ [OTHER_TAB_SESSION_ID]: OTHER_TAB_STAMP });
+    setStoredAcknowledgedAgentErrors({ [THIS_TAB_SESSION_ID]: THIS_TAB_STAMP });
+
+    expect(getStoredAcknowledgedAgentErrors()).toEqual({
+      [OTHER_TAB_SESSION_ID]: OTHER_TAB_STAMP,
+      [THIS_TAB_SESSION_ID]: THIS_TAB_STAMP,
+    });
+  });
+
+  it("overwrites existing sidebar acknowledgement entries for the same session id", () => {
+    setStoredAcknowledgedAgentErrors({ "session-a": "stamp-v1" });
+    setStoredAcknowledgedAgentErrors({ "session-a": "stamp-v2" });
+    expect(getStoredAcknowledgedAgentErrors()).toEqual({ "session-a": "stamp-v2" });
   });
 });

--- a/apps/web/lib/session-last-agent-error.ts
+++ b/apps/web/lib/session-last-agent-error.ts
@@ -7,12 +7,12 @@ export type LastAgentError = {
   dismissedAt?: string;
 };
 
-// --- Dismissed agent errors (localStorage, global) ---
+// --- Agent error visibility state (localStorage, global) ---
 //
-// Tracks the most recent dismissed `last_agent_error` stamp per session so the
-// red error icon in the sidebar and the chat banner can share dismissal state
-// across components and reloads. Bounded growth: one entry per session that
-// ever had an error.
+// `dismissedAgentErrors` tracks explicit chat-banner dismissals and hides both
+// the banner and task-row badge. `acknowledgedAgentErrors` tracks sidebar-only
+// stale-error acknowledgements and hides task-row badges without hiding chat.
+// Bounded growth: one entry per session that ever had an error.
 
 const DISMISSED_AGENT_ERRORS_KEY = "kandev.dismissedAgentErrors";
 const ACKNOWLEDGED_AGENT_ERRORS_KEY = "kandev.acknowledgedAgentErrors";

--- a/apps/web/lib/session-last-agent-error.ts
+++ b/apps/web/lib/session-last-agent-error.ts
@@ -15,10 +15,16 @@ export type LastAgentError = {
 // ever had an error.
 
 const DISMISSED_AGENT_ERRORS_KEY = "kandev.dismissedAgentErrors";
+const ACKNOWLEDGED_AGENT_ERRORS_KEY = "kandev.acknowledgedAgentErrors";
 
 export function getStoredDismissedAgentErrors(): Record<string, string> {
   return getLocalStorage<Record<string, string>>(DISMISSED_AGENT_ERRORS_KEY, {});
 }
+
+export function getStoredAcknowledgedAgentErrors(): Record<string, string> {
+  return getLocalStorage<Record<string, string>>(ACKNOWLEDGED_AGENT_ERRORS_KEY, {});
+}
+
 /**
  * Merge `map` into whatever is currently in localStorage so concurrent writes
  * from other tabs (or older versions of this tab's state) are not clobbered.
@@ -27,6 +33,11 @@ export function getStoredDismissedAgentErrors(): Record<string, string> {
 export function setStoredDismissedAgentErrors(map: Record<string, string>): void {
   const current = getStoredDismissedAgentErrors();
   setLocalStorage(DISMISSED_AGENT_ERRORS_KEY, { ...current, ...map });
+}
+
+export function setStoredAcknowledgedAgentErrors(map: Record<string, string>): void {
+  const current = getStoredAcknowledgedAgentErrors();
+  setLocalStorage(ACKNOWLEDGED_AGENT_ERRORS_KEY, { ...current, ...map });
 }
 
 export function readLastAgentError(metadata: Record<string, unknown> | null | undefined) {

--- a/apps/web/lib/state/slices/ui/dismissed-agent-errors-actions.ts
+++ b/apps/web/lib/state/slices/ui/dismissed-agent-errors-actions.ts
@@ -14,10 +14,10 @@ export function buildDismissedAgentErrors(set: ImmerSet) {
     dismissedAgentErrors: getStoredDismissedAgentErrors(),
     acknowledgeAgentError: (sessionId: string, stamp: string) => {
       if (!sessionId || !stamp) return;
-      set((draft) => {
-        draft.acknowledgedAgentErrors[sessionId] = stamp;
-      });
-      setStoredAcknowledgedAgentErrors({ [sessionId]: stamp });
+      setAcknowledgedAgentErrors(set, { [sessionId]: stamp });
+    },
+    acknowledgeAgentErrors: (stamps: Record<string, string>) => {
+      setAcknowledgedAgentErrors(set, stamps);
     },
     dismissAgentError: (sessionId: string, stamp: string) => {
       if (!sessionId || !stamp) return;
@@ -31,4 +31,16 @@ export function buildDismissedAgentErrors(set: ImmerSet) {
       setStoredDismissedAgentErrors({ [sessionId]: stamp });
     },
   };
+}
+
+function setAcknowledgedAgentErrors(set: ImmerSet, stamps: Record<string, string>) {
+  const entries = Object.entries(stamps).filter(([sessionId, stamp]) => sessionId && stamp);
+  if (entries.length === 0) return;
+  const next = Object.fromEntries(entries);
+  set((draft) => {
+    for (const [sessionId, stamp] of entries) {
+      draft.acknowledgedAgentErrors[sessionId] = stamp;
+    }
+  });
+  setStoredAcknowledgedAgentErrors(next);
 }

--- a/apps/web/lib/state/slices/ui/dismissed-agent-errors-actions.ts
+++ b/apps/web/lib/state/slices/ui/dismissed-agent-errors-actions.ts
@@ -12,10 +12,6 @@ export function buildDismissedAgentErrors(set: ImmerSet) {
   return {
     acknowledgedAgentErrors: getStoredAcknowledgedAgentErrors(),
     dismissedAgentErrors: getStoredDismissedAgentErrors(),
-    acknowledgeAgentError: (sessionId: string, stamp: string) => {
-      if (!sessionId || !stamp) return;
-      setAcknowledgedAgentErrors(set, { [sessionId]: stamp });
-    },
     acknowledgeAgentErrors: (stamps: Record<string, string>) => {
       setAcknowledgedAgentErrors(set, stamps);
     },

--- a/apps/web/lib/state/slices/ui/dismissed-agent-errors-actions.ts
+++ b/apps/web/lib/state/slices/ui/dismissed-agent-errors-actions.ts
@@ -1,5 +1,7 @@
 import {
+  getStoredAcknowledgedAgentErrors,
   getStoredDismissedAgentErrors,
+  setStoredAcknowledgedAgentErrors,
   setStoredDismissedAgentErrors,
 } from "@/lib/session-last-agent-error";
 import type { UISlice } from "./types";
@@ -8,7 +10,15 @@ type ImmerSet = (recipe: (draft: UISlice) => void) => void;
 
 export function buildDismissedAgentErrors(set: ImmerSet) {
   return {
+    acknowledgedAgentErrors: getStoredAcknowledgedAgentErrors(),
     dismissedAgentErrors: getStoredDismissedAgentErrors(),
+    acknowledgeAgentError: (sessionId: string, stamp: string) => {
+      if (!sessionId || !stamp) return;
+      set((draft) => {
+        draft.acknowledgedAgentErrors[sessionId] = stamp;
+      });
+      setStoredAcknowledgedAgentErrors({ [sessionId]: stamp });
+    },
     dismissAgentError: (sessionId: string, stamp: string) => {
       if (!sessionId || !stamp) return;
       set((draft) => {

--- a/apps/web/lib/state/slices/ui/types.ts
+++ b/apps/web/lib/state/slices/ui/types.ts
@@ -249,8 +249,6 @@ export type UISliceActions = {
   toggleAppSidebarSection: (sectionId: string, defaultExpanded?: boolean) => void;
   setAppSidebarWidth: (width: number) => void;
   toggleAppSidebarSettingsMode: () => void;
-  /** Record that `stamp` has been acknowledged for sidebar badge purposes. */
-  acknowledgeAgentError: (sessionId: string, stamp: string) => void;
   /** Record multiple sidebar badge acknowledgements with one localStorage merge. */
   acknowledgeAgentErrors: (stamps: Record<string, string>) => void;
   /** Record that `stamp` has been dismissed for `sessionId`. */

--- a/apps/web/lib/state/slices/ui/types.ts
+++ b/apps/web/lib/state/slices/ui/types.ts
@@ -251,6 +251,8 @@ export type UISliceActions = {
   toggleAppSidebarSettingsMode: () => void;
   /** Record that `stamp` has been acknowledged for sidebar badge purposes. */
   acknowledgeAgentError: (sessionId: string, stamp: string) => void;
+  /** Record multiple sidebar badge acknowledgements with one localStorage merge. */
+  acknowledgeAgentErrors: (stamps: Record<string, string>) => void;
   /** Record that `stamp` has been dismissed for `sessionId`. */
   dismissAgentError: (sessionId: string, stamp: string) => void;
 };

--- a/apps/web/lib/state/slices/ui/types.ts
+++ b/apps/web/lib/state/slices/ui/types.ts
@@ -172,6 +172,12 @@ export type UISliceState = {
    * hides the icon. Persisted to localStorage.
    */
   dismissedAgentErrors: Record<string, string>;
+  /**
+   * Most recently acknowledged sidebar `last_agent_error` stamp per sessionId.
+   * This suppresses task-row badges after the sidebar can prove an error is
+   * stale, without hiding the chat banner.
+   */
+  acknowledgedAgentErrors: Record<string, string>;
 };
 
 export type UISliceActions = {
@@ -243,6 +249,8 @@ export type UISliceActions = {
   toggleAppSidebarSection: (sectionId: string, defaultExpanded?: boolean) => void;
   setAppSidebarWidth: (width: number) => void;
   toggleAppSidebarSettingsMode: () => void;
+  /** Record that `stamp` has been acknowledged for sidebar badge purposes. */
+  acknowledgeAgentError: (sessionId: string, stamp: string) => void;
   /** Record that `stamp` has been dismissed for `sessionId`. */
   dismissAgentError: (sessionId: string, stamp: string) => void;
 };

--- a/apps/web/lib/state/slices/ui/ui-slice.test.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.test.ts
@@ -420,15 +420,6 @@ describe("agent error sidebar acknowledgements", () => {
     expect(store.getState().acknowledgedAgentErrors).toEqual({ "session-1": "stamp-1" });
   });
 
-  it("records and persists an acknowledged sidebar error stamp", () => {
-    const store = makeStore();
-
-    store.getState().acknowledgeAgentError("session-1", "stamp-1");
-
-    expect(store.getState().acknowledgedAgentErrors).toEqual({ "session-1": "stamp-1" });
-    expect(getStoredAcknowledgedAgentErrors()).toEqual({ "session-1": "stamp-1" });
-  });
-
   it("records and persists acknowledged sidebar error stamps in one batch", () => {
     const store = makeStore();
 

--- a/apps/web/lib/state/slices/ui/ui-slice.test.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.test.ts
@@ -428,6 +428,26 @@ describe("agent error sidebar acknowledgements", () => {
     expect(store.getState().acknowledgedAgentErrors).toEqual({ "session-1": "stamp-1" });
     expect(getStoredAcknowledgedAgentErrors()).toEqual({ "session-1": "stamp-1" });
   });
+
+  it("records and persists acknowledged sidebar error stamps in one batch", () => {
+    const store = makeStore();
+
+    store.getState().acknowledgeAgentErrors({
+      "session-1": "stamp-1",
+      "session-2": "stamp-2",
+      "": "ignored",
+      "session-3": "",
+    });
+
+    expect(store.getState().acknowledgedAgentErrors).toEqual({
+      "session-1": "stamp-1",
+      "session-2": "stamp-2",
+    });
+    expect(getStoredAcknowledgedAgentErrors()).toEqual({
+      "session-1": "stamp-1",
+      "session-2": "stamp-2",
+    });
+  });
 });
 
 describe("reorderSidebarViews", () => {

--- a/apps/web/lib/state/slices/ui/ui-slice.test.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.test.ts
@@ -7,6 +7,10 @@ import { createUISlice } from "./ui-slice";
 import { APP_SIDEBAR_EXPANDED_WIDTH } from "@/components/app-sidebar/app-sidebar-constants";
 import type { SidebarViewDraft } from "./sidebar-view-types";
 import type { UISlice } from "./types";
+import {
+  getStoredAcknowledgedAgentErrors,
+  setStoredAcknowledgedAgentErrors,
+} from "@/lib/session-last-agent-error";
 
 vi.mock("@/lib/api/domains/settings-api", () => ({
   updateUserSettings: vi.fn(() => Promise.resolve({ settings: {} })),
@@ -400,6 +404,29 @@ describe("appSidebar actions", () => {
     store.getState().toggleAppSidebarSettingsMode(); // off
     expect(store.getState().appSidebar.settingsMode).toBe(false);
     expect(store.getState().appSidebar.collapsed).toBe(false);
+  });
+});
+
+describe("agent error sidebar acknowledgements", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("hydrates acknowledged errors from localStorage", () => {
+    setStoredAcknowledgedAgentErrors({ "session-1": "stamp-1" });
+
+    const store = makeStore();
+
+    expect(store.getState().acknowledgedAgentErrors).toEqual({ "session-1": "stamp-1" });
+  });
+
+  it("records and persists an acknowledged sidebar error stamp", () => {
+    const store = makeStore();
+
+    store.getState().acknowledgeAgentError("session-1", "stamp-1");
+
+    expect(store.getState().acknowledgedAgentErrors).toEqual({ "session-1": "stamp-1" });
+    expect(getStoredAcknowledgedAgentErrors()).toEqual({ "session-1": "stamp-1" });
   });
 });
 

--- a/apps/web/lib/state/slices/ui/ui-slice.ts
+++ b/apps/web/lib/state/slices/ui/ui-slice.ts
@@ -103,6 +103,7 @@ export const defaultUIState: UISliceState = {
     width: APP_SIDEBAR_EXPANDED_WIDTH,
     settingsMode: false,
   },
+  acknowledgedAgentErrors: {},
   dismissedAgentErrors: {},
 };
 

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -235,6 +235,7 @@ export type AppState = {
   kanbanPreviewedTaskId: (typeof defaultUIState)["kanbanPreviewedTaskId"];
   sidebarTaskPrefs: (typeof defaultUIState)["sidebarTaskPrefs"];
   appSidebar: (typeof defaultUIState)["appSidebar"];
+  acknowledgedAgentErrors: (typeof defaultUIState)["acknowledgedAgentErrors"];
   dismissedAgentErrors: (typeof defaultUIState)["dismissedAgentErrors"];
 
   // GitLab actions
@@ -532,6 +533,7 @@ export type AppState = {
   toggleAppSidebarSection: UIA["toggleAppSidebarSection"];
   setAppSidebarWidth: UIA["setAppSidebarWidth"];
   toggleAppSidebarSettingsMode: UIA["toggleAppSidebarSettingsMode"];
+  acknowledgeAgentError: UIA["acknowledgeAgentError"];
   dismissAgentError: UIA["dismissAgentError"];
   // Office actions
   setOfficeAgentProfiles: (agents: AgentProfile[]) => void;

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -534,6 +534,7 @@ export type AppState = {
   setAppSidebarWidth: UIA["setAppSidebarWidth"];
   toggleAppSidebarSettingsMode: UIA["toggleAppSidebarSettingsMode"];
   acknowledgeAgentError: UIA["acknowledgeAgentError"];
+  acknowledgeAgentErrors: UIA["acknowledgeAgentErrors"];
   dismissAgentError: UIA["dismissAgentError"];
   // Office actions
   setOfficeAgentProfiles: (agents: AgentProfile[]) => void;

--- a/apps/web/lib/state/store.ts
+++ b/apps/web/lib/state/store.ts
@@ -533,7 +533,6 @@ export type AppState = {
   toggleAppSidebarSection: UIA["toggleAppSidebarSection"];
   setAppSidebarWidth: UIA["setAppSidebarWidth"];
   toggleAppSidebarSettingsMode: UIA["toggleAppSidebarSettingsMode"];
-  acknowledgeAgentError: UIA["acknowledgeAgentError"];
   acknowledgeAgentErrors: UIA["acknowledgeAgentErrors"];
   dismissAgentError: UIA["dismissAgentError"];
   // Office actions

--- a/apps/web/lib/task-agent-error.test.ts
+++ b/apps/web/lib/task-agent-error.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from "vitest";
 import type { Message, TaskSession } from "@/lib/types/http";
 import { sessionId, taskId } from "@/lib/types/http";
 import { lastAgentErrorStamp } from "@/lib/session-last-agent-error";
-import { agentErrorMessageForTask } from "./task-agent-error";
+import {
+  agentErrorMessageForTask,
+  resolvedAgentErrorAcknowledgementStamp,
+} from "./task-agent-error";
 
 const ERROR_OCCURRED_AT = "2026-06-14T10:00:00Z";
+const AGENT_MESSAGE_AFTER_ERROR_AT = "2026-06-14T10:00:01Z";
 const PRIMARY_ERROR = "primary error";
 const PRIMARY_TASK = { id: "task-1", primarySessionId: "primary" };
 
@@ -97,6 +101,24 @@ describe("agentErrorMessageForTask", () => {
     ).toBeNull();
   });
 
+  it("hides the error when the matching stamp is sidebar-acknowledged", () => {
+    const primary = primarySession();
+    const stamp = lastAgentErrorStamp({
+      message: PRIMARY_ERROR,
+      occurredAt: ERROR_OCCURRED_AT,
+    });
+    expect(
+      agentErrorMessageForTask(
+        PRIMARY_TASK,
+        { primary },
+        { "task-1": [primary] },
+        { acknowledgedAgentErrors: { primary: stamp } },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("agentErrorMessageForTask (hide conditions)", () => {
   it("hides the error when the session metadata is server-dismissed", () => {
     const primary = primarySession({
       metadata: {
@@ -129,7 +151,11 @@ describe("agentErrorMessageForTask", () => {
         PRIMARY_TASK,
         { primary },
         { "task-1": [primary] },
-        { messagesBySession: { primary: [agentMessage({ created_at: "2026-06-14T10:00:01Z" })] } },
+        {
+          messagesBySession: {
+            primary: [agentMessage({ created_at: AGENT_MESSAGE_AFTER_ERROR_AT })],
+          },
+        },
       ),
     ).toBeNull();
   });
@@ -143,11 +169,48 @@ describe("agentErrorMessageForTask", () => {
         { "task-1": [primary] },
         {
           messagesBySession: {
-            primary: [agentMessage({ author_type: "user", created_at: "2026-06-14T10:00:01Z" })],
+            primary: [
+              agentMessage({ author_type: "user", created_at: AGENT_MESSAGE_AFTER_ERROR_AT }),
+            ],
           },
         },
       ),
     ).toBe(PRIMARY_ERROR);
+  });
+});
+
+describe("resolvedAgentErrorAcknowledgementStamp", () => {
+  it("returns a stamp when a later agent message makes the sidebar error stale", () => {
+    const primary = primarySession();
+    const stamp = lastAgentErrorStamp({
+      message: PRIMARY_ERROR,
+      occurredAt: ERROR_OCCURRED_AT,
+    });
+
+    expect(
+      resolvedAgentErrorAcknowledgementStamp("primary", primary, {
+        messagesBySession: {
+          primary: [agentMessage({ created_at: AGENT_MESSAGE_AFTER_ERROR_AT })],
+        },
+      }),
+    ).toBe(stamp);
+  });
+
+  it("does not return a stamp when the sidebar acknowledgement is already stored", () => {
+    const primary = primarySession();
+    const stamp = lastAgentErrorStamp({
+      message: PRIMARY_ERROR,
+      occurredAt: ERROR_OCCURRED_AT,
+    });
+
+    expect(
+      resolvedAgentErrorAcknowledgementStamp("primary", primary, {
+        acknowledgedAgentErrors: { primary: stamp },
+        messagesBySession: {
+          primary: [agentMessage({ created_at: AGENT_MESSAGE_AFTER_ERROR_AT })],
+        },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/lib/task-agent-error.ts
+++ b/apps/web/lib/task-agent-error.ts
@@ -9,6 +9,8 @@ import { isTerminalSessionState } from "@/lib/ws/handlers/agent-session";
 export type AgentErrorOptions = {
   /** Most recently dismissed `last_agent_error` stamp per sessionId. */
   dismissedAgentErrors?: Record<string, string>;
+  /** Sidebar-only acknowledgements for stale errors that should no longer badge task rows. */
+  acknowledgedAgentErrors?: Record<string, string>;
   /** Messages keyed by sessionId. Used to auto-hide the icon once the agent
    *  produces a new message after the error timestamp. */
   messagesBySession?: Record<string, readonly Message[] | undefined>;
@@ -43,8 +45,30 @@ function shouldHideError(
   error: LastAgentError,
   options: AgentErrorOptions,
 ): boolean {
-  if (options.dismissedAgentErrors?.[sessionId] === lastAgentErrorStamp(error)) return true;
+  const stamp = lastAgentErrorStamp(error);
+  if (hasStoredStamp(sessionId, stamp, options)) return true;
   return hasAgentMessageAfter(options.messagesBySession?.[sessionId], error.occurredAt);
+}
+
+export function resolvedAgentErrorAcknowledgementStamp(
+  sessionId: string,
+  session: Pick<TaskSession, "metadata"> | null | undefined,
+  options: AgentErrorOptions = {},
+): string | null {
+  const error = readLastAgentError(session?.metadata);
+  if (!error) return null;
+  const stamp = lastAgentErrorStamp(error);
+  if (hasStoredStamp(sessionId, stamp, options)) return null;
+  return hasAgentMessageAfter(options.messagesBySession?.[sessionId], error.occurredAt)
+    ? stamp
+    : null;
+}
+
+function hasStoredStamp(sessionId: string, stamp: string, options: AgentErrorOptions): boolean {
+  return (
+    options.dismissedAgentErrors?.[sessionId] === stamp ||
+    options.acknowledgedAgentErrors?.[sessionId] === stamp
+  );
 }
 
 function hasAgentMessageAfter(


### PR DESCRIPTION
Acknowledged historical agent errors could reappear in the task sidebar when another task was focused. The sidebar now persists stale-error acknowledgement separately from explicit chat dismissal, so old badges stay hidden without hiding the chat notice unless the user dismisses it.

## Important Changes

- Added sidebar-only agent-error acknowledgements in UI state/localStorage so task rows can suppress stale errors across task switches and reloads.
- Shared the acknowledgement persistence hook between desktop sidebar and mobile task switcher paths.
- Kept explicit chat dismissal backed by the existing backend `dismissed_at` flow.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- Focused Vitest runs for agent-error helpers, UI slice state, task item/sidebar rendering, and mobile task switcher/layout.

## Possible Improvements

Low risk: sidebar-only acknowledgement is browser-local, while explicit chat dismissal remains backend-persisted for cross-browser state.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->