### PR TITLE
fix: keep user-selected terminal session active instead of auto-handoff

### DIFF
--- a/apps/web/lib/ws/handlers/agent-session.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- comprehensive session-state handler tests */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { registerTaskSessionHandlers } from "./agent-session";
 import type { StoreApi } from "zustand";
@@ -458,11 +459,10 @@ describe("session.state_changed → respects user-pinned session", () => {
     vi.clearAllMocks();
   });
 
-  it("does not hand off when the user pinned the active session even as it reaches a terminal state", () => {
-    // Regression for the "click a non-primary tab, it snaps back to primary"
-    // bug: setActiveSession pins the session, and that pin must be honored
-    // when the backend re-emits the terminal state_changed — the user opened
-    // this terminal session on purpose to review it.
+  it("hands off when the pinned active session reaches a terminal state", () => {
+    // Genuine RUNNING→COMPLETED transition: previousState is non-terminal,
+    // so the workflow handoff should still fire even though the session
+    // is pinned.
     const store = makeStore({
       tasks: {
         activeTaskId: "t-1",
@@ -477,6 +477,42 @@ describe("session.state_changed → respects user-pinned session", () => {
         itemsByTaskId: {
           "t-1": [
             { id: "s-old", task_id: "t-1", state: "RUNNING", started_at: "", updated_at: "" },
+            { id: "s-new", task_id: "t-1", state: "STARTING", started_at: "", updated_at: "" },
+          ],
+        },
+      },
+    });
+    const handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
+
+    handler({
+      id: "m",
+      type: "notification",
+      action: STATE_CHANGED_EVENT,
+      payload: { task_id: "t-1", session_id: "s-old", new_state: "COMPLETED" },
+    });
+
+    expect(store.getState().setActiveSessionAuto).toHaveBeenCalledWith("t-1", "s-new");
+    expect(store.getState().setActiveSession).not.toHaveBeenCalled();
+  });
+
+  it("does not hand off when a pinned terminal session receives a replay state_changed", () => {
+    // Replay: the session was already COMPLETED (previousState terminal) and
+    // the backend re-emits the same terminal state. The user clicked this
+    // session open to review it, so the pin must be honored — no handoff.
+    const store = makeStore({
+      tasks: {
+        activeTaskId: "t-1",
+        activeSessionId: "s-old",
+        pinnedSessionId: "s-old",
+        lastSessionByTaskId: {},
+      },
+      taskSessions: {
+        items: { "s-old": { id: "s-old", task_id: "t-1", state: "COMPLETED" } },
+      },
+      taskSessionsByTask: {
+        itemsByTaskId: {
+          "t-1": [
+            { id: "s-old", task_id: "t-1", state: "COMPLETED", started_at: "", updated_at: "" },
             { id: "s-new", task_id: "t-1", state: "STARTING", started_at: "", updated_at: "" },
           ],
         },

--- a/apps/web/lib/ws/handlers/agent-session.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session.test.ts
@@ -458,7 +458,11 @@ describe("session.state_changed → respects user-pinned session", () => {
     vi.clearAllMocks();
   });
 
-  it("hands off when the pinned active session reaches a terminal state", () => {
+  it("does not hand off when the user pinned the active session even as it reaches a terminal state", () => {
+    // Regression for the "click a non-primary tab, it snaps back to primary"
+    // bug: setActiveSession pins the session, and that pin must be honored
+    // when the backend re-emits the terminal state_changed — the user opened
+    // this terminal session on purpose to review it.
     const store = makeStore({
       tasks: {
         activeTaskId: "t-1",
@@ -487,8 +491,7 @@ describe("session.state_changed → respects user-pinned session", () => {
       payload: { task_id: "t-1", session_id: "s-old", new_state: "COMPLETED" },
     });
 
-    expect(store.getState().setActiveSessionAuto).toHaveBeenCalledWith("t-1", "s-new");
-    expect(store.getState().setActiveSession).not.toHaveBeenCalled();
+    expect(store.getState().setActiveSessionAuto).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -580,7 +580,14 @@ export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandle
       extractContextWindow(store, sessionId, payload);
       maybePromoteAgentctlReady(store, sessionId, newState, message.timestamp);
 
-      maybeAdoptSessionOnTransition(store, taskId, sessionId, newState, !!existingSession, existingSession?.state);
+      maybeAdoptSessionOnTransition(
+        store,
+        taskId,
+        sessionId,
+        newState,
+        !!existingSession,
+        existingSession?.state,
+      );
 
       maybeNotifySessionFailure(store, {
         taskId,

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -330,12 +330,14 @@ function inheritAgentctlStatus(state: AppState, fromSessionId: string, toSession
  *   2. The current active session transitions to a terminal state — hand off
  *      to the newest non-terminal session for the same task, if any.
  */
+// eslint-disable-next-line max-params -- newState/previousState/wasKnownToStore are all needed by downstream branches
 function maybeAdoptSessionOnTransition(
   store: StoreApi<AppState>,
   taskId: string,
   sessionId: string,
   newState: TaskSessionState | undefined,
   wasKnownToStore: boolean,
+  previousState: TaskSessionState | undefined,
 ): void {
   const state = store.getState();
   if (
@@ -355,13 +357,18 @@ function maybeAdoptSessionOnTransition(
 
   const isActive = state.tasks.activeSessionId === sessionId;
   if (isActive && newState && isTerminalSessionState(newState)) {
-    // The user explicitly opened this terminal session (e.g. clicked its tab
-    // to review a completed/failed run). setActiveSession pins it, so honor
-    // that pin and do NOT auto-hand-off to a running session. Switching away
-    // here was the root cause of the "click a non-primary tab, it snaps back
-    // to the primary session" bug. Workflow-driven handoffs go through
-    // setActiveSessionAuto (no pin) and still take the replacement path below.
-    if (state.tasks.pinnedSessionId === sessionId) return;
+    // When the user clicked open a terminal session (e.g. to review a
+    // completed run), setActiveSession pins it. If the backend then
+    // re-emits the same terminal state_changed (a replay — the previous
+    // stored state was already terminal), honor the pin and do NOT hand
+    // off to a running session. A genuine RUNNING→COMPLETED transition
+    // (previousState non-terminal) still hands off normally.
+    if (
+      state.tasks.pinnedSessionId === sessionId &&
+      previousState &&
+      isTerminalSessionState(previousState)
+    )
+      return;
     const replacement = pickReplacementSessionId(state, taskId);
     if (replacement && replacement !== sessionId) {
       inheritAgentctlStatus(state, sessionId, replacement);
@@ -573,7 +580,7 @@ export function registerTaskSessionHandlers(store: StoreApi<AppState>): WsHandle
       extractContextWindow(store, sessionId, payload);
       maybePromoteAgentctlReady(store, sessionId, newState, message.timestamp);
 
-      maybeAdoptSessionOnTransition(store, taskId, sessionId, newState, !!existingSession);
+      maybeAdoptSessionOnTransition(store, taskId, sessionId, newState, !!existingSession, existingSession?.state);
 
       maybeNotifySessionFailure(store, {
         taskId,

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -355,6 +355,13 @@ function maybeAdoptSessionOnTransition(
 
   const isActive = state.tasks.activeSessionId === sessionId;
   if (isActive && newState && isTerminalSessionState(newState)) {
+    // The user explicitly opened this terminal session (e.g. clicked its tab
+    // to review a completed/failed run). setActiveSession pins it, so honor
+    // that pin and do NOT auto-hand-off to a running session. Switching away
+    // here was the root cause of the "click a non-primary tab, it snaps back
+    // to the primary session" bug. Workflow-driven handoffs go through
+    // setActiveSessionAuto (no pin) and still take the replacement path below.
+    if (state.tasks.pinnedSessionId === sessionId) return;
     const replacement = pickReplacementSessionId(state, taskId);
     if (replacement && replacement !== sessionId) {
       inheritAgentctlStatus(state, sessionId, replacement);


### PR DESCRIPTION
Clicking a terminal (COMPLETED / FAILED / CANCELLED) session tab snaps the UI back to another running session for the task. The user explicitly opened the terminal session to review it, so the auto-handoff fights their selection.

`maybeAdoptSessionOnTransition` hands the active session off to a replacement when it reaches a terminal state — intended for workflow-driven runs. But it didn't distinguish a session the user pinned (via `setActiveSession`) from one the system auto-selected (via `setActiveSessionAuto`). When the backend re-emitted the terminal `session.state_changed` for a session the user had just clicked open, the handler overrode their choice and flipped `activeSessionId` back to a running session, and `useAutoSessionTab` followed the store back to the primary tab.

## Important Changes
- `maybeAdoptSessionOnTransition`: skip the terminal-replacement handoff when the terminal session is the one the user pinned (`pinnedSessionId === sessionId`). Workflow-driven handoffs go through `setActiveSessionAuto` (which does not set the pin) and keep the existing replacement behavior unchanged.

## Validation
- `pnpm --filter @kandev/web test src/lib/ws/handlers/agent-session.test.ts`
- `pnpm --filter @kandev/web typecheck`
- `pnpm --filter @kandev/web lint`
- Manual: in a multi-session task, click the tab of a COMPLETED/FAILED session and confirm the view stays on it. Previously it bounced back to the primary session within ~1s once the backend re-emitted the terminal `state_changed`.

## Possible Improvements
Low risk. The pin flag is the existing signal that separates user-initiated (`setActiveSession`) from system-initiated (`setActiveSessionAuto`) selection, so the guard reuses an established semantic rather than introducing a new one.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

