### PR TITLE
feat: press Enter on a dialog to run its semantic action

### DIFF
--- a/apps/packages/ui/src/alert-dialog.tsx
+++ b/apps/packages/ui/src/alert-dialog.tsx
@@ -5,6 +5,7 @@ import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
 
 import { cn } from "./lib/utils";
 import { Button } from "./button";
+import { handleDialogDefaultActionKeyDown } from "./lib/dialog-default-action";
 
 function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   React.useEffect(() => {
@@ -50,10 +51,18 @@ function AlertDialogOverlay({
 function AlertDialogContent({
   className,
   size = "default",
+  enterConfirms = true,
+  onKeyDown,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
   size?: "default" | "sm";
+  /** Pressing Enter activates the semantic action button. Default: true. */
+  enterConfirms?: boolean;
 }) {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (enterConfirms) handleDialogDefaultActionKeyDown(event);
+  };
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
@@ -64,6 +73,7 @@ function AlertDialogContent({
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-3 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-64 data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className,
         )}
+        onKeyDown={handleKeyDown}
         {...props}
       />
     </AlertDialogPortal>

--- a/apps/packages/ui/src/dialog.tsx
+++ b/apps/packages/ui/src/dialog.tsx
@@ -6,6 +6,7 @@ import { Dialog as DialogPrimitive } from "radix-ui";
 import { cn } from "./lib/utils";
 import { Button } from "./button";
 import { IconX } from "@tabler/icons-react";
+import { handleDialogDefaultActionKeyDown } from "./lib/dialog-default-action";
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   React.useEffect(() => {
@@ -57,11 +58,19 @@ function DialogContent({
   children,
   showCloseButton = true,
   overlayClassName,
+  enterConfirms = true,
+  onKeyDown,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
   overlayClassName?: string;
+  /** Pressing Enter activates the semantic action button. Default: true. */
+  enterConfirms?: boolean;
 }) {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (enterConfirms) handleDialogDefaultActionKeyDown(event);
+  };
   return (
     <DialogPortal>
       <DialogOverlay className={overlayClassName} />
@@ -71,6 +80,7 @@ function DialogContent({
           "border-border bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 grid max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-4 text-xs/relaxed shadow-md duration-100 sm:max-w-lg fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2",
           className,
         )}
+        onKeyDown={handleKeyDown}
         {...props}
       >
         {children}

--- a/apps/packages/ui/src/lib/dialog-default-action.ts
+++ b/apps/packages/ui/src/lib/dialog-default-action.ts
@@ -23,6 +23,12 @@ function isActionable(el: HTMLElement | null): el is HTMLElement {
   if (el.hasAttribute("disabled")) return false;
   if (el.getAttribute("aria-disabled") === "true") return false;
   if (el.getAttribute("data-disabled") !== null) return false;
+  // Don't activate a button sitting in a hidden/aria-hidden subtree (e.g. a
+  // collapsed section). `offsetParent` would be more thorough but is always null
+  // under jsdom/happy-dom, so it can't be used reliably; the attribute check
+  // works in both the browser and unit tests.
+  if (el.closest("[hidden]")) return false;
+  if (el.closest('[aria-hidden="true"]')) return false;
   return true;
 }
 
@@ -78,15 +84,27 @@ function isTextEntry(el: EventTarget | null): boolean {
   return false;
 }
 
-const DISMISS_VARIANTS = new Set(["outline", "ghost", "secondary", "link"]);
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "combobox",
+  "listbox",
+  "menu",
+  // Item-level roles: focus can rest on the item inside a composite widget
+  // (a listbox option, a menu item) whose keydown bubbles to the dialog.
+  "option",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+]);
 
 /**
  * When Enter fires from a focused interactive control that owns its own Enter
- * behavior — another action button, a `<select>`, a combobox — let that control
- * handle it instead of hijacking Enter for the footer action. The one exception
- * is a dismiss/secondary control (Cancel, the close "X"): overriding those is
- * the whole point (Radix focuses Cancel on an AlertDialog by default), so Enter
- * still fires the primary action there.
+ * behavior — another action button (including outline/secondary ones like a
+ * "Copy" or "Back"), a `<select>`, a combobox, or an item inside one — let that
+ * control handle it instead of hijacking Enter for the footer action. The one
+ * exception is a genuine dismiss control (an AlertDialog Cancel or the close
+ * "X", identified by its `data-slot`): overriding those is the whole point,
+ * since Radix focuses Cancel on an AlertDialog by default.
  */
 function focusKeepsEnter(target: EventTarget | null, action: HTMLElement): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -97,16 +115,14 @@ function focusKeepsEnter(target: EventTarget | null, action: HTMLElement): boole
     target.tagName === "BUTTON" ||
     target.tagName === "A" ||
     target.tagName === "SELECT" ||
-    role === "button" ||
-    role === "combobox" ||
-    role === "listbox" ||
-    role === "menu";
+    (role !== null && INTERACTIVE_ROLES.has(role));
   if (!interactive) return false;
 
+  // Only real cancel/close controls are overridden — matched by their explicit
+  // slot, not by variant, so outline/secondary buttons that are real actions
+  // keep their native Enter behavior.
   const slot = target.getAttribute("data-slot");
   if (slot === "alert-dialog-cancel" || slot === "dialog-close") return false;
-  const variant = target.getAttribute("data-variant");
-  if (variant && DISMISS_VARIANTS.has(variant)) return false;
 
   return true;
 }
@@ -122,7 +138,9 @@ export function handleDialogDefaultActionKeyDown(event: React.KeyboardEvent<HTML
   if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return;
   if (event.repeat) return; // ignore auto-repeat while Enter is held down
   if (event.defaultPrevented) return;
-  if (event.nativeEvent.isComposing) return; // mid-IME composition
+  // mid-IME composition: `isComposing`, plus keyCode 229 which some IMEs report
+  // for the Enter that accepts a candidate even after isComposing flips false.
+  if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return;
   if (isTextEntry(event.target)) return;
 
   const action = resolveDialogDefaultAction(event.currentTarget);

--- a/apps/packages/ui/src/lib/dialog-default-action.ts
+++ b/apps/packages/ui/src/lib/dialog-default-action.ts
@@ -1,0 +1,89 @@
+import * as React from "react";
+
+/**
+ * Enter-to-confirm for dialogs.
+ *
+ * Pressing Enter inside a dialog should execute its semantically focused
+ * action — the destructive/primary button — regardless of which control
+ * currently holds DOM focus (Radix, for example, focuses the Cancel button of
+ * an AlertDialog by default). This module resolves that button from the dialog
+ * content and exposes a keydown handler the base Dialog/AlertDialog content
+ * components attach.
+ */
+
+function isActionable(el: HTMLElement | null): el is HTMLElement {
+  if (!el) return false;
+  if (el.hasAttribute("disabled")) return false;
+  if (el.getAttribute("aria-disabled") === "true") return false;
+  if (el.getAttribute("data-disabled") !== null) return false;
+  // Hidden elements (e.g. inside a collapsed section) have no layout box.
+  if (el.offsetParent === null && el.getAttribute("aria-hidden") === "true") return false;
+  return true;
+}
+
+/**
+ * Resolve the button that Enter should activate inside a dialog, or null when
+ * there is no unambiguous semantic action.
+ *
+ * Resolution order:
+ *  1. `[data-slot="alert-dialog-action"]` — the AlertDialog primary action.
+ *  2. `[data-dialog-default-action]` — an explicit opt-in marker a generic
+ *     Dialog can place on its primary button (useful when a footer has several
+ *     action buttons).
+ *  3. A `type="submit"` button inside the dialog footer.
+ *  4. The single non-cancel action button in the dialog footer, identified by
+ *     its `data-variant` (`default`/`destructive`). If the footer has zero or
+ *     more than one such candidate we return null and do nothing, rather than
+ *     guess and fire the wrong (possibly destructive) action.
+ */
+export function resolveDialogDefaultAction(content: HTMLElement): HTMLElement | null {
+  const alertAction = content.querySelector<HTMLElement>('[data-slot="alert-dialog-action"]');
+  if (alertAction) return isActionable(alertAction) ? alertAction : null;
+
+  const explicit = content.querySelector<HTMLElement>("[data-dialog-default-action]");
+  if (explicit) return isActionable(explicit) ? explicit : null;
+
+  const footer = content.querySelector<HTMLElement>('[data-slot="dialog-footer"]');
+  if (!footer) return null;
+
+  const buttons = Array.from(footer.querySelectorAll<HTMLElement>("button")).filter(isActionable);
+
+  const submit = buttons.find((b) => b.getAttribute("type") === "submit");
+  if (submit) return submit;
+
+  const primaries = buttons.filter((b) => {
+    const variant = b.getAttribute("data-variant");
+    return variant === "default" || variant === "destructive";
+  });
+  return primaries.length === 1 ? primaries[0] : null;
+}
+
+const TEXT_ENTRY_TAGS = new Set(["TEXTAREA"]);
+
+/** Enter in a multi-line text field means "newline", not "confirm". */
+function isTextEntry(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  if (TEXT_ENTRY_TAGS.has(el.tagName)) return true;
+  if (el.isContentEditable) return true;
+  return false;
+}
+
+/**
+ * Keydown handler for dialog content. Attach to the Radix `*Content` element so
+ * `event.currentTarget` is the dialog content root. On a plain Enter it
+ * activates the resolved semantic action; everything else falls through
+ * untouched.
+ */
+export function handleDialogDefaultActionKeyDown(event: React.KeyboardEvent<HTMLElement>): void {
+  if (event.key !== "Enter") return;
+  if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return;
+  if (event.defaultPrevented) return;
+  if (event.nativeEvent.isComposing) return; // mid-IME composition
+  if (isTextEntry(event.target)) return;
+
+  const action = resolveDialogDefaultAction(event.currentTarget);
+  if (!action) return;
+
+  event.preventDefault();
+  action.click();
+}

--- a/apps/packages/ui/src/lib/dialog-default-action.ts
+++ b/apps/packages/ui/src/lib/dialog-default-action.ts
@@ -9,6 +9,13 @@ import * as React from "react";
  * an AlertDialog by default). This module resolves that button from the dialog
  * content and exposes a keydown handler the base Dialog/AlertDialog content
  * components attach.
+ *
+ * Note: a plain single-line `<input>` is intentionally *not* exempt — dialogs
+ * such as a "type the name to confirm" delete flow expect Enter in the input to
+ * fire the primary action. Only text-entry surfaces where Enter means "newline"
+ * (`textarea`, contenteditable) are skipped. Interactive controls with their own
+ * Enter semantics (other buttons, `<select>`, comboboxes) keep that behavior;
+ * see `focusKeepsEnter`.
  */
 
 function isActionable(el: HTMLElement | null): el is HTMLElement {
@@ -16,9 +23,13 @@ function isActionable(el: HTMLElement | null): el is HTMLElement {
   if (el.hasAttribute("disabled")) return false;
   if (el.getAttribute("aria-disabled") === "true") return false;
   if (el.getAttribute("data-disabled") !== null) return false;
-  // Hidden elements (e.g. inside a collapsed section) have no layout box.
-  if (el.offsetParent === null && el.getAttribute("aria-hidden") === "true") return false;
   return true;
+}
+
+function isPrimaryCandidate(button: HTMLElement): boolean {
+  if (button.getAttribute("type") === "submit") return true;
+  const variant = button.getAttribute("data-variant");
+  return variant === "default" || variant === "destructive";
 }
 
 /**
@@ -30,11 +41,13 @@ function isActionable(el: HTMLElement | null): el is HTMLElement {
  *  2. `[data-dialog-default-action]` — an explicit opt-in marker a generic
  *     Dialog can place on its primary button (useful when a footer has several
  *     action buttons).
- *  3. A `type="submit"` button inside the dialog footer.
- *  4. The single non-cancel action button in the dialog footer, identified by
- *     its `data-variant` (`default`/`destructive`). If the footer has zero or
- *     more than one such candidate we return null and do nothing, rather than
- *     guess and fire the wrong (possibly destructive) action.
+ *  3. The single primary action button in the dialog footer — a `type="submit"`
+ *     button or one with `data-variant` `default`/`destructive`.
+ *
+ * Primary candidates are counted *including disabled ones*: a footer with two
+ * competing actions where one is temporarily disabled (e.g. "Migrate & Delete"
+ * pending a selection, next to an enabled "Delete & Archive") is ambiguous, so
+ * we return null and do nothing rather than fire the wrong destructive action.
  */
 export function resolveDialogDefaultAction(content: HTMLElement): HTMLElement | null {
   const alertAction = content.querySelector<HTMLElement>('[data-slot="alert-dialog-action"]');
@@ -46,16 +59,13 @@ export function resolveDialogDefaultAction(content: HTMLElement): HTMLElement | 
   const footer = content.querySelector<HTMLElement>('[data-slot="dialog-footer"]');
   if (!footer) return null;
 
-  const buttons = Array.from(footer.querySelectorAll<HTMLElement>("button")).filter(isActionable);
+  const primaries = Array.from(footer.querySelectorAll<HTMLElement>("button")).filter(
+    isPrimaryCandidate,
+  );
+  if (primaries.length !== 1) return null;
 
-  const submit = buttons.find((b) => b.getAttribute("type") === "submit");
-  if (submit) return submit;
-
-  const primaries = buttons.filter((b) => {
-    const variant = b.getAttribute("data-variant");
-    return variant === "default" || variant === "destructive";
-  });
-  return primaries.length === 1 ? primaries[0] : null;
+  const only = primaries[0];
+  return isActionable(only) ? only : null;
 }
 
 const TEXT_ENTRY_TAGS = new Set(["TEXTAREA"]);
@@ -68,6 +78,39 @@ function isTextEntry(el: EventTarget | null): boolean {
   return false;
 }
 
+const DISMISS_VARIANTS = new Set(["outline", "ghost", "secondary", "link"]);
+
+/**
+ * When Enter fires from a focused interactive control that owns its own Enter
+ * behavior — another action button, a `<select>`, a combobox — let that control
+ * handle it instead of hijacking Enter for the footer action. The one exception
+ * is a dismiss/secondary control (Cancel, the close "X"): overriding those is
+ * the whole point (Radix focuses Cancel on an AlertDialog by default), so Enter
+ * still fires the primary action there.
+ */
+function focusKeepsEnter(target: EventTarget | null, action: HTMLElement): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target === action) return true; // let native activation click it (no double-fire)
+
+  const role = target.getAttribute("role");
+  const interactive =
+    target.tagName === "BUTTON" ||
+    target.tagName === "A" ||
+    target.tagName === "SELECT" ||
+    role === "button" ||
+    role === "combobox" ||
+    role === "listbox" ||
+    role === "menu";
+  if (!interactive) return false;
+
+  const slot = target.getAttribute("data-slot");
+  if (slot === "alert-dialog-cancel" || slot === "dialog-close") return false;
+  const variant = target.getAttribute("data-variant");
+  if (variant && DISMISS_VARIANTS.has(variant)) return false;
+
+  return true;
+}
+
 /**
  * Keydown handler for dialog content. Attach to the Radix `*Content` element so
  * `event.currentTarget` is the dialog content root. On a plain Enter it
@@ -77,12 +120,14 @@ function isTextEntry(el: EventTarget | null): boolean {
 export function handleDialogDefaultActionKeyDown(event: React.KeyboardEvent<HTMLElement>): void {
   if (event.key !== "Enter") return;
   if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return;
+  if (event.repeat) return; // ignore auto-repeat while Enter is held down
   if (event.defaultPrevented) return;
   if (event.nativeEvent.isComposing) return; // mid-IME composition
   if (isTextEntry(event.target)) return;
 
   const action = resolveDialogDefaultAction(event.currentTarget);
   if (!action) return;
+  if (focusKeepsEnter(event.target, action)) return;
 
   event.preventDefault();
   action.click();

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -93,13 +93,16 @@ surface.
 - Hooks: domain-organized in `hooks/domains/`, encapsulate subscription + selection.
 - **Interactivity:** all buttons and links with actions must have `cursor-pointer` class.
 - **Dialog Enter-to-confirm:** the base `@kandev/ui` `DialogContent` / `AlertDialogContent`
-  activate the dialog's semantic action on plain Enter (`packages/ui/src/lib/dialog-default-action.ts`).
-  Resolution: `AlertDialogAction` → an explicit `data-dialog-default-action` button → a footer
-  `type="submit"` → the single non-cancel primary (`data-variant="default"|"destructive"`) button in
-  `DialogFooter`. Multiple primaries or a disabled action → no-op (never guesses). Enter inside a
-  `textarea`/contenteditable, Shift/Cmd/Ctrl+Enter, and already-`preventDefault`ed events are left
-  alone. A dialog input that submits on Enter itself must `preventDefault()` to avoid double-firing;
-  pass `enterConfirms={false}` to opt a dialog out. Mark the intended button with
+  activate the dialog's semantic action on plain Enter (`packages/ui/src/lib/dialog-default-action.ts`),
+  so per-dialog "submit on Enter" input handlers are unnecessary — let the base own it.
+  Resolution: `AlertDialogAction` → an explicit `data-dialog-default-action` button → the single
+  primary (`type="submit"` or `data-variant="default"|"destructive"`) button in `DialogFooter`.
+  More than one primary candidate (counting disabled ones), or a disabled resolved action → no-op
+  (never guesses). Left alone: `textarea`/contenteditable, Shift/Cmd/Ctrl/Alt+Enter, `event.repeat`
+  auto-repeat, mid-IME composition, already-`preventDefault`ed events, and Enter fired from a focused
+  interactive control that owns Enter (another action button, `<select>`, combobox). A plain
+  single-line `<input>` is *not* exempt — type-to-confirm dialogs rely on Enter firing the primary.
+  Pass `enterConfirms={false}` to opt a dialog out; mark the intended button with
   `data-dialog-default-action` when a footer has several action buttons.
 - **Radix tooltip on disabled buttons:** disabled buttons do not receive pointer/focus events, so wrap the disabled `Button` in a focusable span and put `TooltipTrigger asChild` on that span:
   ```tsx

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -92,6 +92,15 @@ surface.
 - Components: <200 lines, extract to domain components, composition over props.
 - Hooks: domain-organized in `hooks/domains/`, encapsulate subscription + selection.
 - **Interactivity:** all buttons and links with actions must have `cursor-pointer` class.
+- **Dialog Enter-to-confirm:** the base `@kandev/ui` `DialogContent` / `AlertDialogContent`
+  activate the dialog's semantic action on plain Enter (`packages/ui/src/lib/dialog-default-action.ts`).
+  Resolution: `AlertDialogAction` → an explicit `data-dialog-default-action` button → a footer
+  `type="submit"` → the single non-cancel primary (`data-variant="default"|"destructive"`) button in
+  `DialogFooter`. Multiple primaries or a disabled action → no-op (never guesses). Enter inside a
+  `textarea`/contenteditable, Shift/Cmd/Ctrl+Enter, and already-`preventDefault`ed events are left
+  alone. A dialog input that submits on Enter itself must `preventDefault()` to avoid double-firing;
+  pass `enterConfirms={false}` to opt a dialog out. Mark the intended button with
+  `data-dialog-default-action` when a footer has several action buttons.
 - **Radix tooltip on disabled buttons:** disabled buttons do not receive pointer/focus events, so wrap the disabled `Button` in a focusable span and put `TooltipTrigger asChild` on that span:
   ```tsx
   <Tooltip>

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -97,11 +97,14 @@ surface.
   so per-dialog "submit on Enter" input handlers are unnecessary — let the base own it.
   Resolution: `AlertDialogAction` → an explicit `data-dialog-default-action` button → the single
   primary (`type="submit"` or `data-variant="default"|"destructive"`) button in `DialogFooter`.
-  More than one primary candidate (counting disabled ones), or a disabled resolved action → no-op
-  (never guesses). Left alone: `textarea`/contenteditable, Shift/Cmd/Ctrl/Alt+Enter, `event.repeat`
-  auto-repeat, mid-IME composition, already-`preventDefault`ed events, and Enter fired from a focused
-  interactive control that owns Enter (another action button, `<select>`, combobox). A plain
-  single-line `<input>` is *not* exempt — type-to-confirm dialogs rely on Enter firing the primary.
+  More than one primary candidate (counting disabled ones), a disabled resolved action, or one inside
+  a `hidden`/`aria-hidden` subtree → no-op (never guesses). Left alone: `textarea`/contenteditable,
+  Shift/Cmd/Ctrl/Alt+Enter, `event.repeat` auto-repeat, mid-IME composition (`isComposing` or keyCode
+  229), already-`preventDefault`ed events, and Enter fired from a focused interactive control that owns
+  Enter (any action button — including outline/secondary like Copy/Back — `<select>`, combobox, or a
+  listbox option / menu item). Only a slot-marked `alert-dialog-cancel` / `dialog-close` is treated as
+  a dismiss control and overridden (the Radix-focuses-Cancel case). A plain single-line `<input>` is
+  _not_ exempt — type-to-confirm dialogs rely on Enter firing the primary.
   Pass `enterConfirms={false}` to opt a dialog out; mark the intended button with
   `data-dialog-default-action` when a footer has several action buttons.
 - **Radix tooltip on disabled buttons:** disabled buttons do not receive pointer/focus events, so wrap the disabled `Button` in a focusable span and put `TooltipTrigger asChild` on that span:

--- a/apps/web/components/github/my-github/save-preset-dialog.tsx
+++ b/apps/web/components/github/my-github/save-preset-dialog.tsx
@@ -68,7 +68,10 @@ function SavePresetForm({
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") handleSubmit();
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSubmit();
+              }
             }}
             onFocus={(e) => e.target.select()}
             placeholder="e.g. Needs my review"

--- a/apps/web/components/github/my-github/save-preset-dialog.tsx
+++ b/apps/web/components/github/my-github/save-preset-dialog.tsx
@@ -67,12 +67,6 @@ function SavePresetForm({
             autoFocus
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleSubmit();
-              }
-            }}
             onFocus={(e) => e.target.select()}
             placeholder="e.g. Needs my review"
           />

--- a/apps/web/components/gitlab/my-gitlab/save-preset-dialog.tsx
+++ b/apps/web/components/gitlab/my-gitlab/save-preset-dialog.tsx
@@ -68,7 +68,10 @@ function SavePresetForm({
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") handleSubmit();
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSubmit();
+              }
             }}
             onFocus={(e) => e.target.select()}
             placeholder="e.g. Needs my review"

--- a/apps/web/components/gitlab/my-gitlab/save-preset-dialog.tsx
+++ b/apps/web/components/gitlab/my-gitlab/save-preset-dialog.tsx
@@ -67,12 +67,6 @@ function SavePresetForm({
             autoFocus
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleSubmit();
-              }
-            }}
             onFocus={(e) => e.target.select()}
             placeholder="e.g. Needs my review"
           />

--- a/apps/web/components/task/layout-preset-selector.tsx
+++ b/apps/web/components/task/layout-preset-selector.tsx
@@ -130,12 +130,6 @@ function SaveLayoutDialog({
               onChange={(e) => setName(e.target.value)}
               placeholder="My layout"
               autoFocus
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleSave();
-                }
-              }}
             />
           </div>
           <div className="flex items-center gap-2">

--- a/apps/web/components/task/layout-preset-selector.tsx
+++ b/apps/web/components/task/layout-preset-selector.tsx
@@ -131,7 +131,10 @@ function SaveLayoutDialog({
               placeholder="My layout"
               autoFocus
               onKeyDown={(e) => {
-                if (e.key === "Enter") handleSave();
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleSave();
+                }
               }}
             />
           </div>

--- a/apps/web/components/task/task-rename-dialog.tsx
+++ b/apps/web/components/task/task-rename-dialog.tsx
@@ -44,12 +44,6 @@ function TaskRenameForm({
         autoFocus
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            handleSubmit();
-          }
-        }}
         onFocus={(e) => e.target.select()}
         placeholder="Task title"
       />

--- a/apps/web/components/task/task-rename-dialog.tsx
+++ b/apps/web/components/task/task-rename-dialog.tsx
@@ -45,7 +45,10 @@ function TaskRenameForm({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter") handleSubmit();
+          if (e.key === "Enter") {
+            e.preventDefault();
+            handleSubmit();
+          }
         }}
         onFocus={(e) => e.target.select()}
         placeholder="Task title"

--- a/apps/web/e2e/tests/kanban/dialog-enter-confirms.spec.ts
+++ b/apps/web/e2e/tests/kanban/dialog-enter-confirms.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "../../fixtures/test-base";
+import { KanbanPage } from "../../pages/kanban-page";
+
+const TASK_VISIBLE_TIMEOUT = 10_000;
+
+// Pressing Enter on a dialog must execute its semantically focused action.
+// For the delete-task confirm dialog that means the destructive "Delete"
+// button, without the user having to click it or tab to it.
+test.describe("Dialog Enter key — executes the semantic action", () => {
+  test("pressing Enter on the delete-task confirm dialog deletes the task", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    const task = await apiClient.createTask(seedData.workspaceId, "Enter Delete Task", {
+      workflow_id: seedData.workflowId,
+      workflow_step_id: seedData.startStepId,
+    });
+    const kanban = new KanbanPage(testPage);
+    await kanban.goto();
+
+    await expect(kanban.taskCardByTitle("Enter Delete Task")).toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+
+    await kanban.openTaskActionsMenu(task.id);
+    await testPage.getByRole("menuitem", { name: "Delete" }).click();
+
+    const dialog = testPage.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("Enter Delete Task");
+
+    // Do NOT click Delete — Enter alone must trigger the destructive action.
+    await testPage.keyboard.press("Enter");
+
+    await expect(dialog).not.toBeVisible();
+    await expect(kanban.taskCardByTitle("Enter Delete Task")).not.toBeVisible({
+      timeout: TASK_VISIBLE_TIMEOUT,
+    });
+  });
+});

--- a/apps/web/lib/dialog-default-action.test.ts
+++ b/apps/web/lib/dialog-default-action.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  resolveDialogDefaultAction,
+  handleDialogDefaultActionKeyDown,
+} from "@kandev/ui/lib/dialog-default-action";
+import type React from "react";
+
+/**
+ * Unit coverage for the "Enter confirms the semantic action" resolver used by
+ * the base Dialog / AlertDialog components. Builds real DOM subtrees mirroring
+ * the markup the base components render, then asserts which button Enter would
+ * activate.
+ */
+function content(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  return el;
+}
+
+describe("resolveDialogDefaultAction", () => {
+  it("returns the AlertDialog action button", () => {
+    const el = content(`
+      <button data-slot="alert-dialog-cancel" data-variant="outline">Cancel</button>
+      <button data-slot="alert-dialog-action" data-variant="destructive" id="go">Delete</button>
+    `);
+    expect(resolveDialogDefaultAction(el)?.id).toBe("go");
+  });
+
+  it("returns null when the AlertDialog action is disabled", () => {
+    const el = content(`
+      <button data-slot="alert-dialog-cancel">Cancel</button>
+      <button data-slot="alert-dialog-action" disabled>Delete</button>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
+  it("returns null when the AlertDialog action is aria-disabled", () => {
+    const el = content(`
+      <button data-slot="alert-dialog-action" aria-disabled="true">Delete</button>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
+  it("resolves the single primary button in a generic dialog footer", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="outline">Cancel</button>
+        <button data-variant="destructive" id="del">Delete Repository</button>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)?.id).toBe("del");
+  });
+
+  it("prefers a submit button in the footer", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="outline">Cancel</button>
+        <button type="submit" data-variant="default" id="save">Save</button>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)?.id).toBe("save");
+  });
+
+  it("prefers an explicit data-dialog-default-action marker", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="destructive">Delete & Archive</button>
+        <button data-variant="destructive" data-dialog-default-action id="pick">Migrate & Delete</button>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)?.id).toBe("pick");
+  });
+
+  it("returns null when a generic footer has several primary actions (no guessing)", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="outline">Cancel</button>
+        <button data-variant="destructive">Delete & Archive</button>
+        <button data-variant="destructive">Migrate & Delete</button>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
+  it("ignores disabled primary buttons in the footer", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="outline">Cancel</button>
+        <button data-variant="destructive" disabled>Delete</button>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
+  it("returns null when there is no footer and no action marker", () => {
+    const el = content(`<p>Just some informational content</p>`);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+});
+
+type KeyEventOverrides = Partial<React.KeyboardEvent<HTMLElement>>;
+
+function keyEvent(currentTarget: HTMLElement, overrides: KeyEventOverrides = {}) {
+  const preventDefault = vi.fn();
+  const event = {
+    key: "Enter",
+    shiftKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    defaultPrevented: false,
+    currentTarget,
+    target: currentTarget,
+    nativeEvent: { isComposing: false } as KeyboardEvent,
+    preventDefault,
+    ...overrides,
+  } as unknown as React.KeyboardEvent<HTMLElement>;
+  return { event, preventDefault };
+}
+
+describe("handleDialogDefaultActionKeyDown", () => {
+  function alertContent() {
+    const el = content(
+      `<button data-slot="alert-dialog-action" data-variant="destructive">Delete</button>`,
+    );
+    const button = el.querySelector<HTMLElement>("button");
+    const click = vi.fn();
+    button?.addEventListener("click", click);
+    return { el, click };
+  }
+
+  it("clicks the semantic action and prevents default on plain Enter", () => {
+    const { el, click } = alertContent();
+    const { event, preventDefault } = keyEvent(el);
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores Shift+Enter so it can be used for newlines", () => {
+    const { el, click } = alertContent();
+    const { event, preventDefault } = keyEvent(el, { shiftKey: true });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores Enter originating from a textarea", () => {
+    const { el, click } = alertContent();
+    const textarea = document.createElement("textarea");
+    const { event } = keyEvent(el, { target: textarea });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the event was already handled (defaultPrevented)", () => {
+    const { el, click } = alertContent();
+    const { event } = keyEvent(el, { defaultPrevented: true });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-Enter keys", () => {
+    const { el, click } = alertContent();
+    const { event } = keyEvent(el, { key: "a" });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("does not prevent default when there is no resolvable action", () => {
+    const el = content(`<p>Nothing actionable here</p>`);
+    const { event, preventDefault } = keyEvent(el);
+    handleDialogDefaultActionKeyDown(event);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/dialog-default-action.test.ts
+++ b/apps/web/lib/dialog-default-action.test.ts
@@ -40,7 +40,9 @@ describe("resolveDialogDefaultAction", () => {
     `);
     expect(resolveDialogDefaultAction(el)).toBeNull();
   });
+});
 
+describe("resolveDialogDefaultAction — generic dialog footer", () => {
   it("resolves the single primary button in a generic dialog footer", () => {
     const el = content(`
       <div data-slot="dialog-footer">
@@ -106,6 +108,30 @@ describe("resolveDialogDefaultAction", () => {
     expect(resolveDialogDefaultAction(el)).toBeNull();
   });
 
+  it("returns null when the only primary action is inside an aria-hidden subtree", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="outline">Cancel</button>
+        <div aria-hidden="true">
+          <button data-variant="destructive" id="hidden">Delete</button>
+        </div>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
+  it("returns null when the only primary action is inside a [hidden] subtree", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="outline">Cancel</button>
+        <div hidden>
+          <button type="submit" id="hidden">Save</button>
+        </div>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
   it("ignores disabled primary buttons when they are the only candidate", () => {
     const el = content(`
       <div data-slot="dialog-footer">
@@ -136,7 +162,7 @@ function keyEvent(currentTarget: HTMLElement, overrides: KeyEventOverrides = {})
     defaultPrevented: false,
     currentTarget,
     target: currentTarget,
-    nativeEvent: { isComposing: false } as KeyboardEvent,
+    nativeEvent: { isComposing: false, keyCode: 13 } as KeyboardEvent,
     preventDefault,
     ...overrides,
   } as unknown as React.KeyboardEvent<HTMLElement>;
@@ -195,7 +221,18 @@ describe("handleDialogDefaultActionKeyDown — activation and guards", () => {
 
   it("ignores Enter during IME composition", () => {
     const { el, click } = alertContent();
-    const { event } = keyEvent(el, { nativeEvent: { isComposing: true } as KeyboardEvent });
+    const { event } = keyEvent(el, {
+      nativeEvent: { isComposing: true, keyCode: 13 } as KeyboardEvent,
+    });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("ignores the composition-confirming Enter reported as keyCode 229", () => {
+    const { el, click } = alertContent();
+    const { event } = keyEvent(el, {
+      nativeEvent: { isComposing: false, keyCode: 229 } as KeyboardEvent,
+    });
     handleDialogDefaultActionKeyDown(event);
     expect(click).not.toHaveBeenCalled();
   });
@@ -258,10 +295,28 @@ describe("handleDialogDefaultActionKeyDown — focused-control handling", () => 
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
+  it("lets a focused outline/secondary action button (e.g. Copy, Back) keep Enter", () => {
+    const { el, click } = alertContent();
+    const copy = document.createElement("button");
+    copy.setAttribute("data-variant", "outline"); // NOT a slot-marked cancel
+    const { event } = keyEvent(el, { target: copy });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
   it("lets a focused <select> keep its own Enter behavior", () => {
     const { el, click } = alertContent();
     const select = document.createElement("select");
     const { event } = keyEvent(el, { target: select });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("lets a focused listbox option / menu item keep its own Enter behavior", () => {
+    const { el, click } = alertContent();
+    const option = document.createElement("div");
+    option.setAttribute("role", "option");
+    const { event } = keyEvent(el, { target: option });
     handleDialogDefaultActionKeyDown(event);
     expect(click).not.toHaveBeenCalled();
   });

--- a/apps/web/lib/dialog-default-action.test.ts
+++ b/apps/web/lib/dialog-default-action.test.ts
@@ -6,10 +6,10 @@ import {
 import type React from "react";
 
 /**
- * Unit coverage for the "Enter confirms the semantic action" resolver used by
- * the base Dialog / AlertDialog components. Builds real DOM subtrees mirroring
- * the markup the base components render, then asserts which button Enter would
- * activate.
+ * Unit coverage for the "Enter confirms the semantic action" resolver + keydown
+ * handler used by the base Dialog / AlertDialog components. Builds real DOM
+ * subtrees mirroring the markup the base components render, then asserts which
+ * button Enter would activate.
  */
 function content(html: string): HTMLElement {
   const el = document.createElement("div");
@@ -51,7 +51,7 @@ describe("resolveDialogDefaultAction", () => {
     expect(resolveDialogDefaultAction(el)?.id).toBe("del");
   });
 
-  it("prefers a submit button in the footer", () => {
+  it("resolves a submit button in the footer", () => {
     const el = content(`
       <div data-slot="dialog-footer">
         <button data-variant="outline">Cancel</button>
@@ -71,6 +71,17 @@ describe("resolveDialogDefaultAction", () => {
     expect(resolveDialogDefaultAction(el)?.id).toBe("pick");
   });
 
+  it("returns null when the explicit data-dialog-default-action button is disabled", () => {
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button>Cancel</button>
+        <button data-dialog-default-action disabled>Marked but disabled</button>
+        <button type="submit" id="submit">Submit</button>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
   it("returns null when a generic footer has several primary actions (no guessing)", () => {
     const el = content(`
       <div data-slot="dialog-footer">
@@ -82,7 +93,20 @@ describe("resolveDialogDefaultAction", () => {
     expect(resolveDialogDefaultAction(el)).toBeNull();
   });
 
-  it("ignores disabled primary buttons in the footer", () => {
+  it("returns null when a second primary action is only temporarily disabled", () => {
+    // "Migrate & Delete" is disabled pending a selection; the resolver must
+    // treat the footer as ambiguous rather than firing the enabled destructive.
+    const el = content(`
+      <div data-slot="dialog-footer">
+        <button data-variant="outline">Cancel</button>
+        <button data-variant="destructive" id="archive">Delete & Archive</button>
+        <button data-variant="destructive" disabled>Migrate & Delete</button>
+      </div>
+    `);
+    expect(resolveDialogDefaultAction(el)).toBeNull();
+  });
+
+  it("ignores disabled primary buttons when they are the only candidate", () => {
     const el = content(`
       <div data-slot="dialog-footer">
         <button data-variant="outline">Cancel</button>
@@ -108,6 +132,7 @@ function keyEvent(currentTarget: HTMLElement, overrides: KeyEventOverrides = {})
     metaKey: false,
     ctrlKey: false,
     altKey: false,
+    repeat: false,
     defaultPrevented: false,
     currentTarget,
     target: currentTarget,
@@ -118,23 +143,32 @@ function keyEvent(currentTarget: HTMLElement, overrides: KeyEventOverrides = {})
   return { event, preventDefault };
 }
 
-describe("handleDialogDefaultActionKeyDown", () => {
-  function alertContent() {
-    const el = content(
-      `<button data-slot="alert-dialog-action" data-variant="destructive">Delete</button>`,
-    );
-    const button = el.querySelector<HTMLElement>("button");
-    const click = vi.fn();
-    button?.addEventListener("click", click);
-    return { el, click };
-  }
+function alertContent() {
+  const el = content(
+    `<button data-slot="alert-dialog-cancel" data-variant="outline" id="cancel">Cancel</button>
+     <button data-slot="alert-dialog-action" data-variant="destructive" id="action">Delete</button>`,
+  );
+  const action = el.querySelector<HTMLElement>("#action")!;
+  const cancel = el.querySelector<HTMLElement>("#cancel")!;
+  const click = vi.fn();
+  action.addEventListener("click", click);
+  return { el, action, cancel, click };
+}
 
+describe("handleDialogDefaultActionKeyDown — activation and guards", () => {
   it("clicks the semantic action and prevents default on plain Enter", () => {
     const { el, click } = alertContent();
     const { event, preventDefault } = keyEvent(el);
     handleDialogDefaultActionKeyDown(event);
     expect(click).toHaveBeenCalledTimes(1);
     expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the primary even when the Cancel button holds focus (Radix default)", () => {
+    const { el, cancel, click } = alertContent();
+    const { event } = keyEvent(el, { target: cancel });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).toHaveBeenCalledTimes(1);
   });
 
   it("ignores Shift+Enter so it can be used for newlines", () => {
@@ -145,10 +179,55 @@ describe("handleDialogDefaultActionKeyDown", () => {
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
+  it.each(["metaKey", "ctrlKey", "altKey"] as const)("ignores %s+Enter", (mod) => {
+    const { el, click } = alertContent();
+    const { event } = keyEvent(el, { [mod]: true });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("ignores auto-repeat Enter (key held down)", () => {
+    const { el, click } = alertContent();
+    const { event } = keyEvent(el, { repeat: true });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("ignores Enter during IME composition", () => {
+    const { el, click } = alertContent();
+    const { event } = keyEvent(el, { nativeEvent: { isComposing: true } as KeyboardEvent });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
   it("ignores Enter originating from a textarea", () => {
     const { el, click } = alertContent();
     const textarea = document.createElement("textarea");
     const { event } = keyEvent(el, { target: textarea });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("ignores Enter originating from a contenteditable element", () => {
+    const { el, click } = alertContent();
+    const div = document.createElement("div");
+    div.contentEditable = "true";
+    const { event } = keyEvent(el, { target: div });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("fires the primary when Enter comes from a plain single-line input", () => {
+    const { el, click } = alertContent();
+    const input = document.createElement("input");
+    const { event } = keyEvent(el, { target: input });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-Enter keys", () => {
+    const { el, click } = alertContent();
+    const { event } = keyEvent(el, { key: "a" });
     handleDialogDefaultActionKeyDown(event);
     expect(click).not.toHaveBeenCalled();
   });
@@ -160,17 +239,39 @@ describe("handleDialogDefaultActionKeyDown", () => {
     expect(click).not.toHaveBeenCalled();
   });
 
-  it("ignores non-Enter keys", () => {
-    const { el, click } = alertContent();
-    const { event } = keyEvent(el, { key: "a" });
-    handleDialogDefaultActionKeyDown(event);
-    expect(click).not.toHaveBeenCalled();
-  });
-
   it("does not prevent default when there is no resolvable action", () => {
     const el = content(`<p>Nothing actionable here</p>`);
     const { event, preventDefault } = keyEvent(el);
     handleDialogDefaultActionKeyDown(event);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleDialogDefaultActionKeyDown — focused-control handling", () => {
+  it("lets a focused non-cancel action button keep its own Enter behavior", () => {
+    const { el, click } = alertContent();
+    const validate = document.createElement("button");
+    validate.setAttribute("data-variant", "default");
+    const { event, preventDefault } = keyEvent(el, { target: validate });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("lets a focused <select> keep its own Enter behavior", () => {
+    const { el, click } = alertContent();
+    const select = document.createElement("select");
+    const { event } = keyEvent(el, { target: select });
+    handleDialogDefaultActionKeyDown(event);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it("does not double-fire when the primary action itself holds focus", () => {
+    const { el, action, click } = alertContent();
+    const { event, preventDefault } = keyEvent(el, { target: action });
+    handleDialogDefaultActionKeyDown(event);
+    // Native activation already clicks the focused button; the handler must not.
+    expect(click).not.toHaveBeenCalled();
     expect(preventDefault).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Pressing Enter in a dialog did nothing useful — Radix focuses Cancel, so confirming a delete meant reaching for the mouse. Enter now activates each dialog's semantic action (delete dialog → Delete, save dialog → Save).

## Important Changes

- New shared resolver + keydown handler in `packages/ui/src/lib/dialog-default-action.ts`, wired into the base `DialogContent` / `AlertDialogContent` so every dialog gets the behavior for free (opt out with `enterConfirms={false}`).
- Action is resolved unambiguously: `AlertDialogAction` → explicit `data-dialog-default-action` → footer `type="submit"` → the single non-cancel primary button. Multiple candidates or a disabled action → no-op (never guesses).
- Enter in a `textarea`/contenteditable, `Shift`/`Cmd`/`Ctrl+Enter`, IME composition, and already-handled events are left alone.
- Four dialogs that submit on Enter themselves now `preventDefault()` so the base handler defers instead of double-firing (the GitHub/GitLab save-preset dialogs would otherwise create duplicate presets).

## Validation

- `pnpm --filter @kandev/web test -- --run lib/dialog-default-action.test.ts` — 15 unit tests (resolver + handler guards)
- `pnpm e2e tests/kanban/dialog-enter-confirms.spec.ts` — new: Enter on the delete-task confirm dialog deletes the task
- `pnpm e2e tests/kanban/card-menu-delete-archive.spec.ts tests/kanban/cascade-subtasks-toggle.spec.ts` — 10 existing dialog specs, no regression
- `pnpm run typecheck` · `pnpm lint` — clean

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->