### PR TITLE
feat: add Download option to file browser context menu

### DIFF
--- a/apps/web/components/task/file-browser-parts.tsx
+++ b/apps/web/components/task/file-browser-parts.tsx
@@ -43,6 +43,7 @@ type TreeNodeRowProps = {
   onOpenFile: (path: string) => void;
   onDeleteFile?: (path: string) => Promise<boolean>;
   onRenameFile?: (oldPath: string, newPath: string) => Promise<boolean>;
+  onDownloadFile?: (path: string) => Promise<boolean>;
   setTree: React.Dispatch<React.SetStateAction<FileTreeNode | null>>;
   isSelectedFn?: (path: string) => boolean;
   onSelect?: (path: string, e: React.MouseEvent) => boolean;
@@ -135,8 +136,16 @@ function getTreeNodeRowClass(
 
 export function TreeNodeItem(props: TreeNodeRowProps) {
   const { row, activeFolderPath, activeFilePath, visibleLoadingPaths } = props;
-  const { fileStatuses, tree, onToggleExpand, onOpenFile, onDeleteFile, onRenameFile, setTree } =
-    props;
+  const {
+    fileStatuses,
+    tree,
+    onToggleExpand,
+    onOpenFile,
+    onDeleteFile,
+    onRenameFile,
+    onDownloadFile,
+    setTree,
+  } = props;
   const node = row.node;
 
   const isExpanded = row.isExpanded;
@@ -204,6 +213,7 @@ export function TreeNodeItem(props: TreeNodeRowProps) {
       setTree={setTree}
       onDeleteFile={onDeleteFile}
       onRenameFile={onRenameFile}
+      onDownloadFile={onDownloadFile}
       onStartRename={rename.handleStartRename}
       selectedCount={props.selectedCount}
       selectedPaths={props.selectedPaths}
@@ -288,6 +298,7 @@ type FileBrowserContentAreaProps = {
   onToggleExpand: (node: FileTreeNode) => void;
   onDeleteFile?: (path: string) => Promise<boolean>;
   onRenameFile?: (oldPath: string, newPath: string) => Promise<boolean>;
+  onDownloadFile?: (path: string) => Promise<boolean>;
   onCreateFileSubmit: (parentPath: string, name: string) => void;
   onCancelCreate: () => void;
   onRetry: () => void;
@@ -317,6 +328,7 @@ function rowToItemProps(props: FileBrowserContentAreaProps, row: FileBrowserRow)
     onOpenFile: props.onOpenFile,
     onDeleteFile: props.onDeleteFile,
     onRenameFile: props.onRenameFile,
+    onDownloadFile: props.onDownloadFile,
     setTree: props.setTree,
     isSelectedFn: props.isSelectedFn,
     onSelect: props.onSelect,

--- a/apps/web/components/task/file-browser.tsx
+++ b/apps/web/components/task/file-browser.tsx
@@ -90,6 +90,7 @@ type FileBrowserProps = {
   onCreateFile?: (path: string) => Promise<boolean>;
   onDeleteFile?: (path: string) => Promise<boolean>;
   onRenameFile?: (oldPath: string, newPath: string) => Promise<boolean>;
+  onDownloadFile?: (path: string) => Promise<boolean>;
   activeFilePath?: string | null;
 };
 
@@ -372,6 +373,41 @@ function useFileBrowserResetKey(sessionId: string, environmentId?: string | null
   return environmentId ? `${environmentId}:${worktreeCount}` : undefined;
 }
 
+function useFileBrowserData(sessionId: string, environmentId: string | null | undefined) {
+  const { session, isFailed: isSessionFailed, errorMessage: sessionError } = useSession(sessionId);
+  const repository = useRepository(session?.repository_id ?? null);
+  const gitStatus = useSessionGitStatus(sessionId);
+  const { open: openFolder } = useOpenSessionFolder(sessionId);
+  const { copied, copy: copyPath } = useCopyToClipboard(1000);
+  const search = useFileBrowserSearch(sessionId);
+  const resetKey = useFileBrowserResetKey(sessionId, environmentId);
+  const treeState = useFileBrowserTree(sessionId, resetKey);
+  const isTreeLoaded = !treeState.isLoadingTree && treeState.tree !== null;
+  const fileStatuses = useMemo(
+    () =>
+      new Map(Object.entries(gitStatus?.files ?? {}).map(([path, info]) => [path, info.status])),
+    [gitStatus?.files],
+  );
+  const paths = resolveFileBrowserPaths({
+    sessionWorktreePath: session?.worktree_path,
+    repositoryLocalPath: repository?.local_path,
+    treePath: treeState.tree?.path,
+    treeLoaded: isTreeLoaded,
+  });
+  return {
+    isSessionFailed,
+    sessionError,
+    openFolder,
+    copied,
+    copyPath,
+    search,
+    treeState,
+    isTreeLoaded,
+    fileStatuses,
+    ...paths,
+  };
+}
+
 export function FileBrowser({
   sessionId,
   environmentId,
@@ -379,34 +415,26 @@ export function FileBrowser({
   onCreateFile,
   onDeleteFile,
   onRenameFile,
+  onDownloadFile,
   activeFilePath,
 }: FileBrowserProps) {
-  const { session, isFailed: isSessionFailed, errorMessage: sessionError } = useSession(sessionId);
-  const repository = useRepository(session?.repository_id ?? null);
-  const gitStatus = useSessionGitStatus(sessionId);
-  const { open: openFolder } = useOpenSessionFolder(sessionId);
-  const { copied, copy: copyPath } = useCopyToClipboard(1000);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  const search = useFileBrowserSearch(sessionId);
-  const resetKey = useFileBrowserResetKey(sessionId, environmentId);
-  const treeState = useFileBrowserTree(sessionId, resetKey);
-  const isTreeLoaded = !treeState.isLoadingTree && treeState.tree !== null;
+  const data = useFileBrowserData(sessionId, environmentId);
+  const {
+    isSessionFailed,
+    sessionError,
+    openFolder,
+    copied,
+    copyPath,
+    search,
+    treeState,
+    isTreeLoaded,
+    fileStatuses,
+    fullPath,
+    displayPath,
+  } = data;
   useScrollPersistence(sessionId, isTreeLoaded, scrollAreaRef, treeState.tree);
-
-  const fileStatuses = useMemo(
-    () =>
-      new Map(Object.entries(gitStatus?.files ?? {}).map(([path, info]) => [path, info.status])),
-    [gitStatus?.files],
-  );
-  const { fullPath, displayPath } = resolveFileBrowserPaths({
-    sessionWorktreePath: session?.worktree_path,
-    repositoryLocalPath: repository?.local_path,
-    treePath: treeState.tree?.path,
-    treeLoaded: isTreeLoaded,
-  });
-
   const handlers = useFileBrowserHandlers(sessionId, onOpenFile, onCreateFile, treeState);
   const { multiSelect, dnd, handleClickOutside } = useSelectionInteractions(
     treeState,
@@ -455,6 +483,7 @@ export function FileBrowser({
           onToggleExpand={handlers.toggleExpand}
           onDeleteFile={onDeleteFile}
           onRenameFile={onRenameFile}
+          onDownloadFile={onDownloadFile}
           onCreateFileSubmit={handlers.handleCreateFileSubmit}
           onCancelCreate={handlers.handleCancelCreate}
           onRetry={() => void treeState.loadTree({ resetRetry: true })}

--- a/apps/web/components/task/file-context-menu.test.tsx
+++ b/apps/web/components/task/file-context-menu.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FileTreeNode } from "@/lib/types/backend";
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import { FileContextMenu } from "./file-context-menu";
+
+const FILE_NODE: FileTreeNode = { name: "README.md", path: "README.md", is_dir: false, size: 0 };
+const DIR_NODE: FileTreeNode = { name: "src", path: "src", is_dir: true, size: 0 };
+
+afterEach(cleanup);
+
+function openMenu(triggerTestId: string) {
+  const trigger = screen.getByTestId(triggerTestId);
+  fireEvent.contextMenu(trigger);
+}
+
+describe("FileContextMenu Download item", () => {
+  it("shows a Download item for a file when onDownloadFile is provided", () => {
+    const onDownloadFile = vi.fn().mockResolvedValue(true);
+    render(
+      <FileContextMenu
+        node={FILE_NODE}
+        tree={null}
+        setTree={() => {}}
+        onDownloadFile={onDownloadFile}
+        onStartRename={() => {}}
+      >
+        <div data-testid="file-row">row</div>
+      </FileContextMenu>,
+    );
+
+    openMenu("file-row");
+    const item = screen.getByText("Download");
+    expect(item).toBeTruthy();
+  });
+
+  it("calls onDownloadFile with the node path when Download is selected", () => {
+    const onDownloadFile = vi.fn().mockResolvedValue(true);
+    render(
+      <FileContextMenu
+        node={FILE_NODE}
+        tree={null}
+        setTree={() => {}}
+        onDownloadFile={onDownloadFile}
+        onStartRename={() => {}}
+      >
+        <div data-testid="file-row">row</div>
+      </FileContextMenu>,
+    );
+
+    openMenu("file-row");
+    fireEvent.click(screen.getByText("Download"));
+
+    expect(onDownloadFile).toHaveBeenCalledWith("README.md");
+  });
+
+  it("does not show a Download item for directories", () => {
+    const onDownloadFile = vi.fn().mockResolvedValue(true);
+    render(
+      <FileContextMenu
+        node={DIR_NODE}
+        tree={null}
+        setTree={() => {}}
+        onDeleteFile={vi.fn().mockResolvedValue(true)}
+        onDownloadFile={onDownloadFile}
+        onStartRename={() => {}}
+      >
+        <div data-testid="dir-row">row</div>
+      </FileContextMenu>,
+    );
+
+    openMenu("dir-row");
+    expect(screen.queryByText("Download")).toBeNull();
+  });
+
+  it("does not show a Download item when a bulk selection is active", () => {
+    const onDownloadFile = vi.fn().mockResolvedValue(true);
+    render(
+      <FileContextMenu
+        node={FILE_NODE}
+        tree={null}
+        setTree={() => {}}
+        onDeleteFile={vi.fn().mockResolvedValue(true)}
+        onDownloadFile={onDownloadFile}
+        onStartRename={() => {}}
+        selectedCount={3}
+        selectedPaths={new Set(["a", "b", "c"])}
+      >
+        <div data-testid="file-row">row</div>
+      </FileContextMenu>,
+    );
+
+    openMenu("file-row");
+    expect(screen.queryByText("Download")).toBeNull();
+  });
+});

--- a/apps/web/components/task/file-context-menu.tsx
+++ b/apps/web/components/task/file-context-menu.tsx
@@ -117,7 +117,7 @@ function FileContextMenuItems({
 }: FileContextMenuItemsProps) {
   const deleteLabel = isBulk ? `Delete ${selectedCount} items` : "Delete";
   const showRename = !!onRenameFile && !isBulk;
-  const canDownload = !!onDownloadFile && !node.is_dir && !isBulk;
+  const download = !node.is_dir && !isBulk ? onDownloadFile : undefined;
   return (
     <>
       {onDeleteFile && (
@@ -133,9 +133,9 @@ function FileContextMenuItems({
           Rename
         </ContextMenuItem>
       )}
-      {canDownload && (showRename || onDeleteFile) && <ContextMenuSeparator />}
-      {canDownload && onDownloadFile && (
-        <ContextMenuItem onSelect={() => void onDownloadFile(node.path)}>
+      {download && (showRename || onDeleteFile) && <ContextMenuSeparator />}
+      {download && (
+        <ContextMenuItem onSelect={() => void download(node.path)}>
           <IconDownload className="h-3.5 w-3.5" />
           Download
         </ContextMenuItem>

--- a/apps/web/components/task/file-context-menu.tsx
+++ b/apps/web/components/task/file-context-menu.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import { Input } from "@kandev/ui/input";
-import { IconPencil, IconTrash } from "@tabler/icons-react";
+import { IconDownload, IconPencil, IconTrash } from "@tabler/icons-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -94,7 +94,58 @@ function DeleteConfirmDialog({
   );
 }
 
-/** Context menu for file nodes with Rename and Delete options */
+type FileContextMenuItemsProps = {
+  node: FileTreeNode;
+  isBulk: boolean;
+  selectedCount: number;
+  onDeleteFile?: (path: string) => Promise<boolean>;
+  onRenameFile?: (oldPath: string, newPath: string) => Promise<boolean>;
+  onDownloadFile?: (path: string) => Promise<boolean>;
+  onStartRename: () => void;
+  onDelete: () => void;
+};
+
+function FileContextMenuItems({
+  node,
+  isBulk,
+  selectedCount,
+  onDeleteFile,
+  onRenameFile,
+  onDownloadFile,
+  onStartRename,
+  onDelete,
+}: FileContextMenuItemsProps) {
+  const deleteLabel = isBulk ? `Delete ${selectedCount} items` : "Delete";
+  const showDelete = !!onDeleteFile;
+  const showRename = !!onRenameFile && !isBulk;
+  const showDownload = !!onDownloadFile && !node.is_dir && !isBulk;
+  return (
+    <>
+      {showDelete && (
+        <ContextMenuItem variant="destructive" onSelect={onDelete}>
+          <IconTrash className="h-3.5 w-3.5" />
+          {deleteLabel}
+        </ContextMenuItem>
+      )}
+      {showRename && showDelete && <ContextMenuSeparator />}
+      {showRename && (
+        <ContextMenuItem onSelect={onStartRename}>
+          <IconPencil className="h-3.5 w-3.5" />
+          Rename
+        </ContextMenuItem>
+      )}
+      {showDownload && (showRename || showDelete) && <ContextMenuSeparator />}
+      {showDownload && (
+        <ContextMenuItem onSelect={() => void onDownloadFile!(node.path)}>
+          <IconDownload className="h-3.5 w-3.5" />
+          Download
+        </ContextMenuItem>
+      )}
+    </>
+  );
+}
+
+/** Context menu for file nodes with Download, Rename, and Delete options */
 export function FileContextMenu({
   children,
   node,
@@ -102,6 +153,7 @@ export function FileContextMenu({
   setTree,
   onDeleteFile,
   onRenameFile,
+  onDownloadFile,
   onStartRename,
   selectedCount = 0,
   selectedPaths,
@@ -112,6 +164,7 @@ export function FileContextMenu({
   setTree: React.Dispatch<React.SetStateAction<FileTreeNode | null>>;
   onDeleteFile?: (path: string) => Promise<boolean>;
   onRenameFile?: (oldPath: string, newPath: string) => Promise<boolean>;
+  onDownloadFile?: (path: string) => Promise<boolean>;
   onStartRename: () => void;
   selectedCount?: number;
   selectedPaths?: Set<string>;
@@ -152,28 +205,23 @@ export function FileContextMenu({
     }
   }, [tree, setTree, node.path, onDeleteFile, needsConfirmation]);
 
-  if (!onDeleteFile && !onRenameFile) return <>{children}</>;
-
-  const deleteLabel = isBulk ? `Delete ${selectedCount} items` : "Delete";
+  if (!onDeleteFile && !onRenameFile && !onDownloadFile) return <>{children}</>;
 
   return (
     <>
       <ContextMenu>
         <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
         <ContextMenuContent>
-          {onDeleteFile && (
-            <ContextMenuItem variant="destructive" onSelect={handleDelete}>
-              <IconTrash className="h-3.5 w-3.5" />
-              {deleteLabel}
-            </ContextMenuItem>
-          )}
-          {onRenameFile && onDeleteFile && !isBulk && <ContextMenuSeparator />}
-          {onRenameFile && !isBulk && (
-            <ContextMenuItem onSelect={onStartRename}>
-              <IconPencil className="h-3.5 w-3.5" />
-              Rename
-            </ContextMenuItem>
-          )}
+          <FileContextMenuItems
+            node={node}
+            isBulk={isBulk}
+            selectedCount={selectedCount}
+            onDeleteFile={onDeleteFile}
+            onRenameFile={onRenameFile}
+            onDownloadFile={onDownloadFile}
+            onStartRename={onStartRename}
+            onDelete={handleDelete}
+          />
         </ContextMenuContent>
       </ContextMenu>
       {needsConfirmation && (

--- a/apps/web/components/task/file-context-menu.tsx
+++ b/apps/web/components/task/file-context-menu.tsx
@@ -116,27 +116,26 @@ function FileContextMenuItems({
   onDelete,
 }: FileContextMenuItemsProps) {
   const deleteLabel = isBulk ? `Delete ${selectedCount} items` : "Delete";
-  const showDelete = !!onDeleteFile;
   const showRename = !!onRenameFile && !isBulk;
-  const showDownload = !!onDownloadFile && !node.is_dir && !isBulk;
+  const canDownload = !!onDownloadFile && !node.is_dir && !isBulk;
   return (
     <>
-      {showDelete && (
+      {onDeleteFile && (
         <ContextMenuItem variant="destructive" onSelect={onDelete}>
           <IconTrash className="h-3.5 w-3.5" />
           {deleteLabel}
         </ContextMenuItem>
       )}
-      {showRename && showDelete && <ContextMenuSeparator />}
+      {showRename && onDeleteFile && <ContextMenuSeparator />}
       {showRename && (
         <ContextMenuItem onSelect={onStartRename}>
           <IconPencil className="h-3.5 w-3.5" />
           Rename
         </ContextMenuItem>
       )}
-      {showDownload && (showRename || showDelete) && <ContextMenuSeparator />}
-      {showDownload && (
-        <ContextMenuItem onSelect={() => void onDownloadFile!(node.path)}>
+      {canDownload && (showRename || onDeleteFile) && <ContextMenuSeparator />}
+      {canDownload && onDownloadFile && (
+        <ContextMenuItem onSelect={() => void onDownloadFile(node.path)}>
           <IconDownload className="h-3.5 w-3.5" />
           Download
         </ContextMenuItem>

--- a/apps/web/components/task/files-panel.tsx
+++ b/apps/web/components/task/files-panel.tsx
@@ -28,7 +28,9 @@ const FilesPanel = memo(function FilesPanel({ onOpenFile }: FilesPanelProps) {
   });
   const activeFilePath = useDockviewStore((s) => s.activeFilePath);
   const isArchived = useIsTaskArchived();
-  const { createFile, deleteFile, renameFile } = useFileOperations(activeSessionId ?? null);
+  const { createFile, deleteFile, renameFile, downloadFile } = useFileOperations(
+    activeSessionId ?? null,
+  );
 
   const handleCreateFile = useCallback(
     async (path: string): Promise<boolean> => {
@@ -65,6 +67,7 @@ const FilesPanel = memo(function FilesPanel({ onOpenFile }: FilesPanelProps) {
             onCreateFile={handleCreateFile}
             onDeleteFile={deleteFile}
             onRenameFile={renameFile}
+            onDownloadFile={downloadFile}
             activeFilePath={activeFilePath}
           />
         ) : (

--- a/apps/web/components/task/task-files-panel-hooks.ts
+++ b/apps/web/components/task/task-files-panel-hooks.ts
@@ -11,6 +11,7 @@ export function useFilesPanelData(onOpenFile: (file: OpenFileTab) => void) {
     createFile: baseCreateFile,
     deleteFile: hookDeleteFile,
     renameFile: hookRenameFile,
+    downloadFile: hookDownloadFile,
   } = useFileOperations(activeSessionId ?? null);
 
   const handleCreateFile = useCallback(
@@ -38,6 +39,7 @@ export function useFilesPanelData(onOpenFile: (file: OpenFileTab) => void) {
     activeSessionId,
     hookDeleteFile,
     hookRenameFile,
+    hookDownloadFile,
     handleCreateFile,
   };
 }

--- a/apps/web/components/task/task-files-panel.tsx
+++ b/apps/web/components/task/task-files-panel.tsx
@@ -12,6 +12,7 @@ function FilesTabContent({
   handleCreateFile,
   hookDeleteFile,
   hookRenameFile,
+  hookDownloadFile,
   activeFilePath,
 }: {
   sessionId: string | null;
@@ -19,6 +20,7 @@ function FilesTabContent({
   handleCreateFile: (path: string) => Promise<boolean>;
   hookDeleteFile: (path: string) => Promise<boolean>;
   hookRenameFile: (oldPath: string, newPath: string) => Promise<boolean>;
+  hookDownloadFile: (path: string) => Promise<boolean>;
   activeFilePath?: string | null;
 }) {
   if (!sessionId) {
@@ -35,6 +37,7 @@ function FilesTabContent({
       onCreateFile={handleCreateFile}
       onDeleteFile={hookDeleteFile}
       onRenameFile={hookRenameFile}
+      onDownloadFile={hookDownloadFile}
       activeFilePath={activeFilePath}
     />
   );
@@ -49,7 +52,7 @@ const TaskFilesPanel = memo(function TaskFilesPanel({
   onOpenFile,
   activeFilePath,
 }: TaskFilesPanelProps) {
-  const { activeSessionId, hookDeleteFile, hookRenameFile, handleCreateFile } =
+  const { activeSessionId, hookDeleteFile, hookRenameFile, hookDownloadFile, handleCreateFile } =
     useFilesPanelData(onOpenFile);
 
   return (
@@ -61,6 +64,7 @@ const TaskFilesPanel = memo(function TaskFilesPanel({
           handleCreateFile={handleCreateFile}
           hookDeleteFile={hookDeleteFile}
           hookRenameFile={hookRenameFile}
+          hookDownloadFile={hookDownloadFile}
           activeFilePath={activeFilePath}
         />
       </SessionPanelContent>

--- a/apps/web/e2e/tests/task/file-tree-download.spec.ts
+++ b/apps/web/e2e/tests/task/file-tree-download.spec.ts
@@ -1,0 +1,98 @@
+import { type Page } from "@playwright/test";
+import path from "node:path";
+import fs from "node:fs";
+import { test, expect } from "../../fixtures/test-base";
+import type { ApiClient } from "../../helpers/api-client";
+import {
+  GitHelper,
+  makeGitEnv,
+  openTaskSession,
+  createStandardProfile,
+} from "../../helpers/git-helper";
+
+// Download is wired in file-context-menu.tsx → useFileOperations.downloadFile →
+// downloadFileContent → triggerFileDownload (Blob + <a download>). We drive
+// the visible flow: right-click a file, pick Download, assert the browser
+// download event fires with the right filename and content.
+
+async function setupTask(
+  testPage: Page,
+  apiClient: ApiClient,
+  seedData: { workspaceId: string; workflowId: string; startStepId: string; repositoryId: string },
+  profileName: string,
+  taskTitle: string,
+) {
+  const profile = await createStandardProfile(apiClient, profileName);
+  await apiClient.createTaskWithAgent(seedData.workspaceId, taskTitle, profile.id, {
+    description: "/e2e:simple-message",
+    workflow_id: seedData.workflowId,
+    workflow_step_id: seedData.startStepId,
+    repository_ids: [seedData.repositoryId],
+  });
+  const session = await openTaskSession(testPage, taskTitle);
+  await session.clickTab("Files");
+  return session;
+}
+
+test.describe("File tree Download", () => {
+  test("Download menu item downloads the file with its original name and content", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    const git = new GitHelper(repoDir, makeGitEnv(backend.tmpDir));
+    const fileName = "download-me.txt";
+    const fileContent = "kandev download test payload";
+    git.createFile(fileName, fileContent);
+    git.stageAll();
+    git.commit("seed download file");
+
+    const session = await setupTask(testPage, apiClient, seedData, "ft-dl", "FT Download");
+
+    const node = session.fileTreeNode(fileName);
+    await expect(node).toBeVisible({ timeout: 15_000 });
+
+    await node.click({ button: "right" });
+    const downloadItem = testPage.getByRole("menuitem", { name: "Download" });
+    await expect(downloadItem).toBeVisible({ timeout: 5_000 });
+
+    const downloadPromise = testPage.waitForEvent("download");
+    await downloadItem.click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe(fileName);
+
+    // Read the downloaded bytes and verify they match the seeded content.
+    const tmpPath = path.join(backend.tmpDir, `dl-${Date.now()}.txt`);
+    await download.saveAs(tmpPath);
+    expect(fs.readFileSync(tmpPath, "utf8")).toBe(fileContent);
+  });
+
+  test("Download is hidden for directory nodes", async ({
+    testPage,
+    apiClient,
+    seedData,
+    backend,
+  }) => {
+    const repoDir = path.join(backend.tmpDir, "repos", "e2e-repo");
+    const git = new GitHelper(repoDir, makeGitEnv(backend.tmpDir));
+    // Seed a directory (via a file inside it).
+    git.createFile("subdir/inside.txt", "child");
+    git.stageAll();
+    git.commit("seed subdir");
+
+    const session = await setupTask(testPage, apiClient, seedData, "ft-dl-dir", "FT Download Dir");
+
+    const dirNode = session.fileTreeNode("subdir");
+    await expect(dirNode).toBeVisible({ timeout: 15_000 });
+    await dirNode.click({ button: "right" });
+
+    // The menu itself must render (Delete/Rename are still available), but
+    // Download must not be part of it for a directory.
+    const renameItem = testPage.getByRole("menuitem", { name: "Rename" });
+    await expect(renameItem).toBeVisible({ timeout: 5_000 });
+    await expect(testPage.getByRole("menuitem", { name: "Download" })).toHaveCount(0);
+  });
+});

--- a/apps/web/hooks/use-file-operations.test.ts
+++ b/apps/web/hooks/use-file-operations.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const requestFileContentMock = vi.fn();
+const triggerFileDownloadMock = vi.fn();
+
+vi.mock("@/lib/ws/workspace-files", () => ({
+  requestFileContent: (...args: unknown[]) => requestFileContentMock(...args),
+}));
+vi.mock("@/lib/utils/file-download", () => ({
+  triggerFileDownload: (...args: unknown[]) => triggerFileDownloadMock(...args),
+}));
+
+import { downloadFileContent } from "./use-file-operations";
+
+const SESSION_ID = "sess-1";
+const FAKE_CLIENT = {} as unknown as Parameters<typeof downloadFileContent>[0];
+
+beforeEach(() => {
+  requestFileContentMock.mockReset();
+  triggerFileDownloadMock.mockReset();
+});
+
+describe("downloadFileContent", () => {
+  it("fetches file content and triggers browser download using the file basename", async () => {
+    requestFileContentMock.mockResolvedValueOnce({
+      path: "src/foo/bar.ts",
+      content: "hello",
+      is_binary: false,
+    });
+
+    const result = await downloadFileContent(FAKE_CLIENT, SESSION_ID, "src/foo/bar.ts");
+
+    expect(result).toEqual({ ok: true });
+    expect(requestFileContentMock).toHaveBeenCalledWith(FAKE_CLIENT, SESSION_ID, "src/foo/bar.ts");
+    expect(triggerFileDownloadMock).toHaveBeenCalledWith({
+      fileName: "bar.ts",
+      content: "hello",
+      isBinary: false,
+    });
+  });
+
+  it("passes isBinary=true through so binary content is decoded correctly", async () => {
+    requestFileContentMock.mockResolvedValueOnce({
+      path: "assets/logo.png",
+      content: "aGk=",
+      is_binary: true,
+    });
+
+    await downloadFileContent(FAKE_CLIENT, SESSION_ID, "assets/logo.png");
+
+    expect(triggerFileDownloadMock).toHaveBeenCalledWith({
+      fileName: "logo.png",
+      content: "aGk=",
+      isBinary: true,
+    });
+  });
+
+  it("returns {ok: false, error} when the backend returns an error", async () => {
+    requestFileContentMock.mockResolvedValueOnce({
+      path: "src/foo.ts",
+      content: "",
+      error: "Permission denied",
+    });
+
+    const result = await downloadFileContent(FAKE_CLIENT, SESSION_ID, "src/foo.ts");
+
+    expect(result).toEqual({ ok: false, error: "Permission denied" });
+    expect(triggerFileDownloadMock).not.toHaveBeenCalled();
+  });
+
+  it("returns {ok: false} when the request throws", async () => {
+    requestFileContentMock.mockRejectedValueOnce(new Error("boom"));
+
+    const result = await downloadFileContent(FAKE_CLIENT, SESSION_ID, "src/foo.ts");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("boom");
+    expect(triggerFileDownloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/hooks/use-file-operations.test.ts
+++ b/apps/web/hooks/use-file-operations.test.ts
@@ -4,11 +4,18 @@ const requestFileContentMock = vi.fn();
 const triggerFileDownloadMock = vi.fn();
 
 vi.mock("@/lib/ws/workspace-files", () => ({
+  createFile: vi.fn(),
+  deleteFile: vi.fn(),
+  renameFile: vi.fn(),
   requestFileContent: (...args: unknown[]) => requestFileContentMock(...args),
 }));
-vi.mock("@/lib/utils/file-download", () => ({
-  triggerFileDownload: (...args: unknown[]) => triggerFileDownloadMock(...args),
-}));
+vi.mock("@/lib/utils/file-download", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/utils/file-download")>();
+  return {
+    ...actual,
+    triggerFileDownload: (...args: unknown[]) => triggerFileDownloadMock(...args),
+  };
+});
 
 import { downloadFileContent } from "./use-file-operations";
 

--- a/apps/web/hooks/use-file-operations.test.ts
+++ b/apps/web/hooks/use-file-operations.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/lib/utils/file-download", async (importOriginal) => {
 import { downloadFileContent } from "./use-file-operations";
 
 const SESSION_ID = "sess-1";
+const NESTED_PATH = "src/foo/bar.ts";
 const FAKE_CLIENT = {} as unknown as Parameters<typeof downloadFileContent>[0];
 
 beforeEach(() => {
@@ -28,19 +29,19 @@ beforeEach(() => {
 });
 
 describe("downloadFileContent", () => {
-  it("fetches file content and triggers browser download using the file basename", async () => {
+  it("fetches file content and forwards the full path so the util can derive the basename", async () => {
     requestFileContentMock.mockResolvedValueOnce({
-      path: "src/foo/bar.ts",
+      path: NESTED_PATH,
       content: "hello",
       is_binary: false,
     });
 
-    const result = await downloadFileContent(FAKE_CLIENT, SESSION_ID, "src/foo/bar.ts");
+    const result = await downloadFileContent(FAKE_CLIENT, SESSION_ID, NESTED_PATH);
 
     expect(result).toEqual({ ok: true });
-    expect(requestFileContentMock).toHaveBeenCalledWith(FAKE_CLIENT, SESSION_ID, "src/foo/bar.ts");
+    expect(requestFileContentMock).toHaveBeenCalledWith(FAKE_CLIENT, SESSION_ID, NESTED_PATH);
     expect(triggerFileDownloadMock).toHaveBeenCalledWith({
-      fileName: "bar.ts",
+      fileName: NESTED_PATH,
       content: "hello",
       isBinary: false,
     });
@@ -56,7 +57,7 @@ describe("downloadFileContent", () => {
     await downloadFileContent(FAKE_CLIENT, SESSION_ID, "assets/logo.png");
 
     expect(triggerFileDownloadMock).toHaveBeenCalledWith({
-      fileName: "logo.png",
+      fileName: "assets/logo.png",
       content: "aGk=",
       isBinary: true,
     });

--- a/apps/web/hooks/use-file-operations.ts
+++ b/apps/web/hooks/use-file-operations.ts
@@ -1,10 +1,63 @@
 import { useCallback } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
-import { createFile, deleteFile, renameFile } from "@/lib/ws/workspace-files";
+import type { WebSocketClient } from "@/lib/ws/client";
+import { createFile, deleteFile, renameFile, requestFileContent } from "@/lib/ws/workspace-files";
+import { triggerFileDownload } from "@/lib/utils/file-download";
 import { useToast } from "@/components/toast-provider";
+
+type ToastFn = ReturnType<typeof useToast>["toast"];
 
 const ERROR_VARIANT = "error" as const;
 const UNKNOWN_ERROR = "An unknown error occurred";
+
+type DownloadResult = { ok: true } | { ok: false; error?: string };
+
+function fileBasename(path: string): string {
+  const idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+/**
+ * Fetch a file from the workspace and trigger a browser download.
+ * Extracted from the hook so it can be unit-tested without React.
+ */
+export async function downloadFileContent(
+  client: WebSocketClient,
+  sessionId: string,
+  path: string,
+): Promise<DownloadResult> {
+  try {
+    const response = await requestFileContent(client, sessionId, path);
+    if (response.error) return { ok: false, error: response.error };
+    triggerFileDownload({
+      fileName: fileBasename(path),
+      content: response.content,
+      isBinary: !!response.is_binary,
+    });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : UNKNOWN_ERROR };
+  }
+}
+
+async function runFileOp<T extends { success: boolean; error?: string }>(
+  op: () => Promise<T>,
+  title: string,
+  toast: ToastFn,
+): Promise<boolean> {
+  try {
+    const response = await op();
+    if (!response.success) {
+      toast({ title, description: response.error || UNKNOWN_ERROR, variant: ERROR_VARIANT });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    const description = error instanceof Error ? error.message : UNKNOWN_ERROR;
+    toast({ title, description, variant: ERROR_VARIANT });
+    return false;
+  }
+}
 
 export function useFileOperations(sessionId: string | null) {
   const { toast } = useToast();
@@ -13,26 +66,7 @@ export function useFileOperations(sessionId: string | null) {
     async (path: string): Promise<boolean> => {
       const client = getWebSocketClient();
       if (!client || !sessionId) return false;
-
-      try {
-        const response = await createFile(client, sessionId, path);
-        if (!response.success) {
-          toast({
-            title: "Failed to create file",
-            description: response.error || UNKNOWN_ERROR,
-            variant: ERROR_VARIANT,
-          });
-          return false;
-        }
-        return true;
-      } catch (error) {
-        toast({
-          title: "Failed to create file",
-          description: error instanceof Error ? error.message : UNKNOWN_ERROR,
-          variant: ERROR_VARIANT,
-        });
-        return false;
-      }
+      return runFileOp(() => createFile(client, sessionId, path), "Failed to create file", toast);
     },
     [sessionId, toast],
   );
@@ -41,26 +75,7 @@ export function useFileOperations(sessionId: string | null) {
     async (path: string): Promise<boolean> => {
       const client = getWebSocketClient();
       if (!client || !sessionId) return false;
-
-      try {
-        const response = await deleteFile(client, sessionId, path);
-        if (!response.success) {
-          toast({
-            title: "Failed to delete item",
-            description: response.error || UNKNOWN_ERROR,
-            variant: ERROR_VARIANT,
-          });
-          return false;
-        }
-        return true;
-      } catch (error) {
-        toast({
-          title: "Failed to delete item",
-          description: error instanceof Error ? error.message : UNKNOWN_ERROR,
-          variant: ERROR_VARIANT,
-        });
-        return false;
-      }
+      return runFileOp(() => deleteFile(client, sessionId, path), "Failed to delete item", toast);
     },
     [sessionId, toast],
   );
@@ -69,26 +84,29 @@ export function useFileOperations(sessionId: string | null) {
     async (oldPath: string, newPath: string): Promise<boolean> => {
       const client = getWebSocketClient();
       if (!client || !sessionId) return false;
+      return runFileOp(
+        () => renameFile(client, sessionId, oldPath, newPath),
+        "Failed to rename item",
+        toast,
+      );
+    },
+    [sessionId, toast],
+  );
 
-      try {
-        const response = await renameFile(client, sessionId, oldPath, newPath);
-        if (!response.success) {
-          toast({
-            title: "Failed to rename item",
-            description: response.error || UNKNOWN_ERROR,
-            variant: ERROR_VARIANT,
-          });
-          return false;
-        }
-        return true;
-      } catch (error) {
+  const handleDownloadFile = useCallback(
+    async (path: string): Promise<boolean> => {
+      const client = getWebSocketClient();
+      if (!client || !sessionId) return false;
+      const result = await downloadFileContent(client, sessionId, path);
+      if (!result.ok) {
         toast({
-          title: "Failed to rename item",
-          description: error instanceof Error ? error.message : UNKNOWN_ERROR,
+          title: "Failed to download file",
+          description: result.error || UNKNOWN_ERROR,
           variant: ERROR_VARIANT,
         });
         return false;
       }
+      return true;
     },
     [sessionId, toast],
   );
@@ -97,5 +115,6 @@ export function useFileOperations(sessionId: string | null) {
     createFile: handleCreateFile,
     deleteFile: handleDeleteFile,
     renameFile: handleRenameFile,
+    downloadFile: handleDownloadFile,
   };
 }

--- a/apps/web/hooks/use-file-operations.ts
+++ b/apps/web/hooks/use-file-operations.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import type { WebSocketClient } from "@/lib/ws/client";
 import { createFile, deleteFile, renameFile, requestFileContent } from "@/lib/ws/workspace-files";
-import { triggerFileDownload } from "@/lib/utils/file-download";
+import { fileBasename, triggerFileDownload } from "@/lib/utils/file-download";
 import { useToast } from "@/components/toast-provider";
 
 type ToastFn = ReturnType<typeof useToast>["toast"];
@@ -11,11 +11,6 @@ const ERROR_VARIANT = "error" as const;
 const UNKNOWN_ERROR = "An unknown error occurred";
 
 type DownloadResult = { ok: true } | { ok: false; error?: string };
-
-function fileBasename(path: string): string {
-  const idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
-  return idx >= 0 ? path.slice(idx + 1) : path;
-}
 
 /**
  * Fetch a file from the workspace and trigger a browser download.

--- a/apps/web/hooks/use-file-operations.ts
+++ b/apps/web/hooks/use-file-operations.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { getWebSocketClient } from "@/lib/ws/connection";
 import type { WebSocketClient } from "@/lib/ws/client";
 import { createFile, deleteFile, renameFile, requestFileContent } from "@/lib/ws/workspace-files";
-import { fileBasename, triggerFileDownload } from "@/lib/utils/file-download";
+import { triggerFileDownload } from "@/lib/utils/file-download";
 import { useToast } from "@/components/toast-provider";
 
 type ToastFn = ReturnType<typeof useToast>["toast"];
@@ -25,7 +25,7 @@ export async function downloadFileContent(
     const response = await requestFileContent(client, sessionId, path);
     if (response.error) return { ok: false, error: response.error };
     triggerFileDownload({
-      fileName: fileBasename(path),
+      fileName: path,
       content: response.content,
       isBinary: !!response.is_binary,
     });

--- a/apps/web/lib/utils/file-download.test.ts
+++ b/apps/web/lib/utils/file-download.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { triggerFileDownload } from "./file-download";
+
+const createObjectURLMock = vi.fn((_blob: Blob): string => "blob:mock");
+const revokeObjectURLMock = vi.fn((_url: string): void => undefined);
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+beforeEach(() => {
+  URL.createObjectURL = createObjectURLMock as unknown as typeof URL.createObjectURL;
+  URL.revokeObjectURL = revokeObjectURLMock as unknown as typeof URL.revokeObjectURL;
+  createObjectURLMock.mockClear();
+  revokeObjectURLMock.mockClear();
+});
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  vi.restoreAllMocks();
+});
+
+function spyAnchorClick(): { click: ReturnType<typeof vi.fn>; download: () => string } {
+  const click = vi.fn();
+  const originalCreate = document.createElement.bind(document);
+  let capturedAnchor: HTMLAnchorElement | null = null;
+  vi.spyOn(document, "createElement").mockImplementation(
+    (tagName: string, options?: ElementCreationOptions) => {
+      const el = originalCreate(tagName as keyof HTMLElementTagNameMap, options);
+      if (tagName === "a") {
+        const anchor = el as HTMLAnchorElement;
+        anchor.click = click;
+        capturedAnchor = anchor;
+      }
+      return el;
+    },
+  );
+  return { click, download: () => capturedAnchor?.download ?? "" };
+}
+
+describe("triggerFileDownload", () => {
+  it("creates a text blob and clicks a link with the file name", () => {
+    const { click } = spyAnchorClick();
+
+    triggerFileDownload({ fileName: "hello.txt", content: "hi", isBinary: false });
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    const blob = createObjectURLMock.mock.calls[0]?.[0] as unknown as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toContain("text/plain");
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:mock");
+  });
+
+  it("decodes base64 content when isBinary is true", () => {
+    spyAnchorClick();
+
+    triggerFileDownload({ fileName: "hello.bin", content: btoa("hi"), isBinary: true });
+
+    const blob = createObjectURLMock.mock.calls[0]?.[0] as unknown as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/octet-stream");
+    // "hi" -> 2 bytes
+    expect(blob.size).toBe(2);
+  });
+
+  it("sets the download attribute to just the file name (basename)", () => {
+    const { download } = spyAnchorClick();
+
+    triggerFileDownload({ fileName: "src/lib/notes.md", content: "hi", isBinary: false });
+
+    expect(download()).toBe("notes.md");
+  });
+});

--- a/apps/web/lib/utils/file-download.ts
+++ b/apps/web/lib/utils/file-download.ts
@@ -1,0 +1,46 @@
+export type TriggerFileDownloadParams = {
+  fileName: string;
+  content: string;
+  isBinary: boolean;
+};
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const buffer = new ArrayBuffer(binary.length);
+  const view = new Uint8Array(buffer);
+  for (let i = 0; i < binary.length; i++) view[i] = binary.charCodeAt(i);
+  return buffer;
+}
+
+/**
+ * Trigger a browser download for the given file content by creating a Blob
+ * and clicking a temporary anchor. Binary content is expected to be
+ * base64-encoded (matches the workspace.file.get contract).
+ */
+export function triggerFileDownload({
+  fileName,
+  content,
+  isBinary,
+}: TriggerFileDownloadParams): void {
+  const blob = isBinary
+    ? new Blob([base64ToArrayBuffer(content)], { type: "application/octet-stream" })
+    : new Blob([content], { type: "text/plain;charset=utf-8" });
+
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = basename(fileName);
+    anchor.rel = "noopener";
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function basename(path: string): string {
+  const idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}

--- a/apps/web/lib/utils/file-download.ts
+++ b/apps/web/lib/utils/file-download.ts
@@ -4,6 +4,12 @@ export type TriggerFileDownloadParams = {
   isBinary: boolean;
 };
 
+/** Return the last path segment of a POSIX or Windows path. */
+export function fileBasename(path: string): string {
+  const idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
   const binary = atob(base64);
   const buffer = new ArrayBuffer(binary.length);
@@ -30,7 +36,7 @@ export function triggerFileDownload({
   try {
     const anchor = document.createElement("a");
     anchor.href = url;
-    anchor.download = basename(fileName);
+    anchor.download = fileBasename(fileName);
     anchor.rel = "noopener";
     document.body.appendChild(anchor);
     anchor.click();
@@ -38,9 +44,4 @@ export function triggerFileDownload({
   } finally {
     URL.revokeObjectURL(url);
   }
-}
-
-function basename(path: string): string {
-  const idx = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
-  return idx >= 0 ? path.slice(idx + 1) : path;
 }

--- a/apps/web/lib/utils/file-download.ts
+++ b/apps/web/lib/utils/file-download.ts
@@ -37,7 +37,6 @@ export function triggerFileDownload({
     const anchor = document.createElement("a");
     anchor.href = url;
     anchor.download = fileBasename(fileName);
-    anchor.rel = "noopener";
     document.body.appendChild(anchor);
     anchor.click();
     document.body.removeChild(anchor);


### PR DESCRIPTION
While an agent is creating files in the workspace, the file browser context menu only offered Delete and Rename — there was no way to pull a copy of the file down to the user's machine. This adds a **Download** entry alongside Delete/Rename so users can save an agent-created (or any workspace) file locally with one click.

## Important Changes

- New `Download` item in the file tree context menu (`file-context-menu.tsx`), shown only for files — hidden for directories and bulk selections.
- Content is fetched over the existing `workspace.file.get` WS channel via a new `downloadFileContent()` helper in `use-file-operations.ts`; base64 payloads (binary files) are decoded before writing the `Blob`.
- New `lib/utils/file-download.ts` utility encapsulates the `Blob` + anchor-click download trigger so the same logic can be reused elsewhere and unit-tested without React.

## Validation

- `pnpm run typecheck` — clean.
- `eslint --max-warnings 0` on the whole web app — clean.
- `vitest run` — full web suite (499 files / 4126 tests) passes; 11 new tests cover the download utility, the `downloadFileContent` helper (text, binary, error, throw), and the context-menu item (renders for files, invoked with correct path, hidden for directories, hidden for bulk selections).
- Manual verification in a `make dev` instance: right-click a file → Download saves the file with the correct name and contents; right-click a directory → no Download item.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have manually tested my changes and they work as expected.
- [x] My changes have tests that cover the new functionality and edge cases.
- [x] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

