### PR TITLE
fix: add task lifecycle diagnostics

### DIFF
--- a/apps/backend/internal/gateway/websocket/task_notifications.go
+++ b/apps/backend/internal/gateway/websocket/task_notifications.go
@@ -168,23 +168,16 @@ func (b *TaskEventBroadcaster) logLifecycleBroadcast(action string, data map[str
 	default:
 		return
 	}
-	b.logger.Info("ws lifecycle broadcast",
+	b.logger.Debug("ws lifecycle broadcast",
 		zap.String("action", action),
-		zap.String("task_id", lifecycleString(data, "task_id")),
+		zap.Any("task_id", data["task_id"]),
 		zap.String("session_id", sessionID),
-		zap.String("state", lifecycleString(data, "state")),
-		zap.String("old_state", lifecycleString(data, "old_state")),
-		zap.String("new_state", lifecycleString(data, "new_state")),
-		zap.String("primary_session_id", lifecycleString(data, "primary_session_id")),
-		zap.String("primary_session_state", lifecycleString(data, "primary_session_state")),
-		zap.String("updated_at", lifecycleString(data, "updated_at")),
+		zap.Any("state", data["state"]),
+		zap.Any("old_state", data["old_state"]),
+		zap.Any("new_state", data["new_state"]),
+		zap.Any("primary_session_id", data["primary_session_id"]),
+		zap.Any("primary_session_state", data["primary_session_state"]),
+		zap.Any("updated_at", data["updated_at"]),
 		zap.Int("connected_clients", b.hub.GetClientCount()),
 	)
-}
-
-func lifecycleString(data map[string]interface{}, key string) string {
-	if value, ok := data[key].(string); ok {
-		return value
-	}
-	return ""
 }

--- a/apps/backend/internal/gateway/websocket/task_notifications.go
+++ b/apps/backend/internal/gateway/websocket/task_notifications.go
@@ -120,6 +120,9 @@ func (b *TaskEventBroadcaster) subscribe(eventBus bus.EventBus, subject, action 
 				}
 			}
 		}
+		if data, ok := event.Data.(map[string]interface{}); ok {
+			b.logLifecycleBroadcast(action, data, sessionID)
+		}
 
 		switch action {
 		case ws.ActionSessionAgentctlStarting, ws.ActionSessionAgentctlReady, ws.ActionSessionAgentctlError:
@@ -156,4 +159,32 @@ func (b *TaskEventBroadcaster) subscribe(eventBus bus.EventBus, subject, action 
 		return
 	}
 	b.subscriptions = append(b.subscriptions, sub)
+}
+
+func (b *TaskEventBroadcaster) logLifecycleBroadcast(action string, data map[string]interface{}, sessionID string) {
+	switch action {
+	case ws.ActionTaskCreated, ws.ActionTaskUpdated, ws.ActionTaskStateChanged,
+		ws.ActionTaskDeleted, ws.ActionSessionStateChanged:
+	default:
+		return
+	}
+	b.logger.Info("ws lifecycle broadcast",
+		zap.String("action", action),
+		zap.String("task_id", lifecycleString(data, "task_id")),
+		zap.String("session_id", sessionID),
+		zap.String("state", lifecycleString(data, "state")),
+		zap.String("old_state", lifecycleString(data, "old_state")),
+		zap.String("new_state", lifecycleString(data, "new_state")),
+		zap.String("primary_session_id", lifecycleString(data, "primary_session_id")),
+		zap.String("primary_session_state", lifecycleString(data, "primary_session_state")),
+		zap.String("updated_at", lifecycleString(data, "updated_at")),
+		zap.Int("connected_clients", b.hub.GetClientCount()),
+	)
+}
+
+func lifecycleString(data map[string]interface{}, key string) string {
+	if value, ok := data[key].(string); ok {
+		return value
+	}
+	return ""
 }

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -137,6 +137,8 @@ func (s *Service) addTaskSessionEventFields(ctx context.Context, taskID string, 
 	}
 	sessionInfo, ok := primarySessionInfoMap[taskID]
 	if !ok || sessionInfo == nil {
+		data["primary_session_id"] = nil
+		data["primary_session_state"] = nil
 		return
 	}
 	data["primary_session_id"] = sessionInfo.ID
@@ -145,6 +147,8 @@ func (s *Service) addTaskSessionEventFields(ctx context.Context, taskID string, 
 	}
 	if sessionInfo.State != "" {
 		data["primary_session_state"] = string(sessionInfo.State)
+	} else {
+		data["primary_session_state"] = nil
 	}
 	if sessionInfo.ExecutorID != "" {
 		data["primary_executor_id"] = sessionInfo.ExecutorID

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -108,24 +108,17 @@ func (s *Service) logTaskLifecycleEventPublished(eventType string, task *models.
 	default:
 		return
 	}
-	s.logger.Info("task lifecycle event published",
+	s.logger.Debug("task lifecycle event published",
 		zap.String("event_type", eventType),
 		zap.String("task_id", task.ID),
-		zap.String("state", eventString(data, "state")),
-		zap.String("workflow_step_id", eventString(data, "workflow_step_id")),
-		zap.String("primary_session_id", eventString(data, "primary_session_id")),
-		zap.String("primary_session_state", eventString(data, "primary_session_state")),
+		zap.Any("state", data["state"]),
+		zap.Any("workflow_step_id", data["workflow_step_id"]),
+		zap.Any("primary_session_id", data["primary_session_id"]),
+		zap.Any("primary_session_state", data["primary_session_state"]),
 		zap.Any("session_count", data["session_count"]),
-		zap.String("old_state", eventString(data, "old_state")),
-		zap.String("new_state", eventString(data, "new_state")),
+		zap.Any("old_state", data["old_state"]),
+		zap.Any("new_state", data["new_state"]),
 	)
-}
-
-func eventString(data map[string]interface{}, key string) string {
-	if value, ok := data[key].(string); ok {
-		return value
-	}
-	return ""
 }
 
 // addTaskSessionEventFields merges session count, primary session info, and

--- a/apps/backend/internal/task/service/service_events.go
+++ b/apps/backend/internal/task/service/service_events.go
@@ -97,7 +97,35 @@ func (s *Service) publishTaskEventWithExtra(ctx context.Context, eventType strin
 			zap.String("event_type", eventType),
 			zap.String("task_id", task.ID),
 			zap.Error(err))
+		return
 	}
+	s.logTaskLifecycleEventPublished(eventType, task, data)
+}
+
+func (s *Service) logTaskLifecycleEventPublished(eventType string, task *models.Task, data map[string]interface{}) {
+	switch eventType {
+	case events.TaskCreated, events.TaskUpdated, events.TaskStateChanged, events.TaskDeleted:
+	default:
+		return
+	}
+	s.logger.Info("task lifecycle event published",
+		zap.String("event_type", eventType),
+		zap.String("task_id", task.ID),
+		zap.String("state", eventString(data, "state")),
+		zap.String("workflow_step_id", eventString(data, "workflow_step_id")),
+		zap.String("primary_session_id", eventString(data, "primary_session_id")),
+		zap.String("primary_session_state", eventString(data, "primary_session_state")),
+		zap.Any("session_count", data["session_count"]),
+		zap.String("old_state", eventString(data, "old_state")),
+		zap.String("new_state", eventString(data, "new_state")),
+	)
+}
+
+func eventString(data map[string]interface{}, key string) string {
+	if value, ok := data[key].(string); ok {
+		return value
+	}
+	return ""
 }
 
 // addTaskSessionEventFields merges session count, primary session info, and

--- a/apps/backend/internal/task/service/service_events_test.go
+++ b/apps/backend/internal/task/service/service_events_test.go
@@ -14,6 +14,11 @@ type failingTaskRepoRepository struct {
 	err error
 }
 
+type primarySessionInfoRepository struct {
+	repository.SessionRepository
+	info map[string]*models.TaskSession
+}
+
 type taskEventTestRepository interface {
 	CreateWorkspace(context.Context, *models.Workspace) error
 	CreateWorkflow(context.Context, *models.Workflow) error
@@ -22,6 +27,14 @@ type taskEventTestRepository interface {
 
 func (r failingTaskRepoRepository) ListTaskRepositories(ctx context.Context, taskID string) ([]*models.TaskRepository, error) {
 	return nil, r.err
+}
+
+func (r primarySessionInfoRepository) GetPrimarySessionInfoByTaskIDs(ctx context.Context, taskIDs []string) (map[string]*models.TaskSession, error) {
+	return r.info, nil
+}
+
+func (r primarySessionInfoRepository) GetSessionCountsByTaskIDs(ctx context.Context, taskIDs []string) (map[string]int, error) {
+	return map[string]int{}, nil
 }
 
 // TestPublishTaskUpdated_FallbackRepositoryID exercises the DB fallback in
@@ -117,6 +130,25 @@ func TestPublishTaskUpdated_EmitsNullPrimarySessionFieldsWhenNoPrimaryExists(t *
 	data := singlePublishedEventData(t, eventBus)
 	if value, ok := data["primary_session_id"]; !ok || value != nil {
 		t.Fatalf("primary_session_id = %#v, want explicit nil", value)
+	}
+	if value, ok := data["primary_session_state"]; !ok || value != nil {
+		t.Fatalf("primary_session_state = %#v, want explicit nil", value)
+	}
+}
+
+func TestAddTaskSessionEventFields_EmitsNullPrimarySessionStateWhenEmpty(t *testing.T) {
+	svc, _, _ := createTestService(t)
+	svc.sessions = primarySessionInfoRepository{
+		info: map[string]*models.TaskSession{
+			"task-1": {ID: "session-1", TaskID: "task-1"},
+		},
+	}
+	data := map[string]interface{}{}
+
+	svc.addTaskSessionEventFields(context.Background(), "task-1", data)
+
+	if value := data["primary_session_id"]; value != "session-1" {
+		t.Fatalf("primary_session_id = %#v, want session-1", value)
 	}
 	if value, ok := data["primary_session_state"]; !ok || value != nil {
 		t.Fatalf("primary_session_state = %#v, want explicit nil", value)

--- a/apps/backend/internal/task/service/service_events_test.go
+++ b/apps/backend/internal/task/service/service_events_test.go
@@ -103,6 +103,26 @@ func TestPublishTaskUpdated_EmitsEmptyRepositories(t *testing.T) {
 	}
 }
 
+func TestPublishTaskUpdated_EmitsNullPrimarySessionFieldsWhenNoPrimaryExists(t *testing.T) {
+	svc, eventBus, repo := createTestService(t)
+	ctx := context.Background()
+
+	createTaskWithoutRepositories(t, ctx, repo)
+	eventBus.ClearEvents()
+
+	svc.PublishTaskUpdated(ctx, &models.Task{
+		ID: "task-1", WorkspaceID: "ws-1", WorkflowID: "wf-1", WorkflowStepID: "step-1",
+	})
+
+	data := singlePublishedEventData(t, eventBus)
+	if value, ok := data["primary_session_id"]; !ok || value != nil {
+		t.Fatalf("primary_session_id = %#v, want explicit nil", value)
+	}
+	if value, ok := data["primary_session_state"]; !ok || value != nil {
+		t.Fatalf("primary_session_state = %#v, want explicit nil", value)
+	}
+}
+
 func TestPublishTaskUpdated_OmitsRepositoriesOnLookupError(t *testing.T) {
 	svc, eventBus, repo := createTestService(t)
 	ctx := context.Background()

--- a/apps/web/components/kanban-card-content.tsx
+++ b/apps/web/components/kanban-card-content.tsx
@@ -20,7 +20,7 @@ import {
   KanbanCardDropdownMenuItems,
   type KanbanCardMenuEntry,
 } from "@/components/kanban-card-menu-items";
-import { useAppStore } from "@/components/state-provider";
+import { useAppStore, useAppStoreApi } from "@/components/state-provider";
 import { RemoteCloudTooltip } from "@/components/task/remote-cloud-tooltip";
 import { useTaskPendingClarification } from "@/hooks/use-task-pending-clarification";
 import { createDebugLogger, isDebug } from "@/lib/debug/log";
@@ -220,11 +220,11 @@ function KanbanCardActions({
   isArchiving,
 }: KanbanCardActionProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [storePrimarySessionState, setStorePrimarySessionState] = useState<string | null>(null);
+  const storeApi = useAppStoreApi();
+  const debugEnabled = isDebug();
   const effectiveMenuOpen = menuOpen || Boolean(isDeleting) || Boolean(isArchiving);
   const hasPendingClarificationRequest = useTaskPendingClarification(task.primarySessionId);
-  const storePrimarySessionState = useAppStore((s) =>
-    task.primarySessionId ? (s.taskSessions.items[task.primarySessionId]?.state ?? null) : null,
-  );
   const showQuestionIcon = shouldUseQuestionTaskIcon(task.state, hasPendingClarificationRequest);
   const showRunningSpinner = shouldShowTaskRunningSpinner(task.state, task.primarySessionState);
   const storeWouldShowRunningSpinner =
@@ -244,7 +244,25 @@ function KanbanCardActions({
     Boolean(task.primarySessionId) || Boolean(task.sessionCount && task.sessionCount > 0);
 
   useEffect(() => {
-    if (!hasSpinnerMismatch || !isDebug()) return;
+    if (!debugEnabled || !task.primarySessionId) {
+      setStorePrimarySessionState(null);
+      return;
+    }
+
+    const primarySessionId = task.primarySessionId;
+    const readPrimarySessionState = () =>
+      storeApi.getState().taskSessions.items[primarySessionId]?.state ?? null;
+    const syncPrimarySessionState = () => {
+      const nextState = readPrimarySessionState();
+      setStorePrimarySessionState((current) => (current === nextState ? current : nextState));
+    };
+
+    syncPrimarySessionState();
+    return storeApi.subscribe(syncPrimarySessionState);
+  }, [debugEnabled, storeApi, task.primarySessionId]);
+
+  useEffect(() => {
+    if (!hasSpinnerMismatch || !debugEnabled) return;
     kanbanStatusDebug("spinner mismatch", {
       task_id: task.id,
       taskState: task.state ?? "-",
@@ -254,6 +272,7 @@ function KanbanCardActions({
       showSpinner: showRunningSpinner,
     });
   }, [
+    debugEnabled,
     hasSpinnerMismatch,
     showRunningSpinner,
     storePrimarySessionState,

--- a/apps/web/components/kanban-card-content.tsx
+++ b/apps/web/components/kanban-card-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CSS, type Transform } from "@dnd-kit/utilities";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
 import {
@@ -23,6 +23,7 @@ import {
 import { useAppStore } from "@/components/state-provider";
 import { RemoteCloudTooltip } from "@/components/task/remote-cloud-tooltip";
 import { useTaskPendingClarification } from "@/hooks/use-task-pending-clarification";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import {
   getTaskStateIcon,
   shouldShowTaskRunningSpinner,
@@ -31,6 +32,8 @@ import {
 import { cn } from "@/lib/utils";
 import { needsAction } from "@/lib/utils/needs-action";
 import type { RepositoryChip, Task } from "@/components/kanban-card";
+
+const kanbanStatusDebug = createDebugLogger("kanban:task-status");
 
 type KanbanCardActionProps = {
   task: Task;
@@ -219,8 +222,19 @@ function KanbanCardActions({
   const [menuOpen, setMenuOpen] = useState(false);
   const effectiveMenuOpen = menuOpen || Boolean(isDeleting) || Boolean(isArchiving);
   const hasPendingClarificationRequest = useTaskPendingClarification(task.primarySessionId);
+  const storePrimarySessionState = useAppStore((s) =>
+    task.primarySessionId ? (s.taskSessions.items[task.primarySessionId]?.state ?? null) : null,
+  );
   const showQuestionIcon = shouldUseQuestionTaskIcon(task.state, hasPendingClarificationRequest);
   const showRunningSpinner = shouldShowTaskRunningSpinner(task.state, task.primarySessionState);
+  const storeWouldShowRunningSpinner =
+    storePrimarySessionState === null
+      ? null
+      : shouldShowTaskRunningSpinner(task.state, storePrimarySessionState);
+  const hasSpinnerMismatch =
+    showRunningSpinner &&
+    storeWouldShowRunningSpinner === false &&
+    task.primarySessionState !== storePrimarySessionState;
   const statusIcon = showRunningSpinner ? (
     <IconLoader2 className="h-4 w-4 text-blue-500 animate-spin" />
   ) : (
@@ -228,6 +242,26 @@ function KanbanCardActions({
   );
   const hasKnownSession =
     Boolean(task.primarySessionId) || Boolean(task.sessionCount && task.sessionCount > 0);
+
+  useEffect(() => {
+    if (!hasSpinnerMismatch || !isDebug()) return;
+    kanbanStatusDebug("spinner mismatch", {
+      task_id: task.id,
+      taskState: task.state ?? "-",
+      primarySessionId: task.primarySessionId ?? "-",
+      taskPrimarySessionState: task.primarySessionState ?? "-",
+      storePrimarySessionState: storePrimarySessionState ?? "-",
+      showSpinner: showRunningSpinner,
+    });
+  }, [
+    hasSpinnerMismatch,
+    showRunningSpinner,
+    storePrimarySessionState,
+    task.id,
+    task.primarySessionId,
+    task.primarySessionState,
+    task.state,
+  ]);
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/web/lib/debug/log.ts
+++ b/apps/web/lib/debug/log.ts
@@ -155,6 +155,20 @@
  *                             handlers. A `turn.completed` line with no following
  *                             `[session:state] newState=WAITING_FOR_INPUT` is the
  *                             smoking gun: the turn ended but running-state stuck.
+ *     [task-lifecycle:ws]     task/session lifecycle WS cache merge trace:
+ *                             task.created / task.updated / task.state_changed
+ *                             logs payload-vs-existing primary session state,
+ *                             and session.state_changed logs whether kanban and
+ *                             multi-workflow snapshots were patched. For stale
+ *                             kanban spinners, look for task.updated preserving
+ *                             beforeTaskPrimaryState=RUNNING after the session
+ *                             store already moved to WAITING_FOR_INPUT.
+ *     [kanban:task-status]    Kanban card mismatch detector. Emits only when
+ *                             the card would render a spinner from
+ *                             task.primarySessionState while the loaded
+ *                             taskSessions row for the primary session would
+ *                             not spin. This is the direct smoking gun for
+ *                             sidebar-correct / kanban-still-spinning reports.
  *
  *   Review / Diff pipeline (bug: Review or Diff panel shows empty when
  *   commits exist — distinguishes "no cumulative diff" vs "missing PR data"

--- a/apps/web/lib/ws/handlers/agent-session-diagnostics.ts
+++ b/apps/web/lib/ws/handlers/agent-session-diagnostics.ts
@@ -1,0 +1,95 @@
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
+import type { KanbanState, WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
+import type { AppState } from "@/lib/state/store";
+import type { TaskSessionState } from "@/lib/types/http";
+
+type KanbanTask = KanbanState["tasks"][number];
+
+const lifecycleDebug = createDebugLogger("task-lifecycle:ws");
+
+function findSnapshotTask(
+  snapshots: Record<string, WorkflowSnapshotData>,
+  workflowId: string,
+  taskId: string,
+  sessionId: string,
+): KanbanTask | undefined {
+  return snapshots[workflowId]?.tasks.find(
+    (task) => task.id === taskId && task.primarySessionId === sessionId,
+  );
+}
+
+function didPatchTaskPrimaryState(
+  beforeTask: KanbanTask | undefined,
+  afterTask: KanbanTask | undefined,
+  newState: TaskSessionState,
+): boolean {
+  return (
+    beforeTask?.primarySessionState !== newState && afterTask?.primarySessionState === newState
+  );
+}
+
+export function buildKanbanPrimarySessionSyncLog(params: {
+  beforeState: AppState;
+  afterState: AppState;
+  taskId: string;
+  sessionId: string;
+  newState: TaskSessionState;
+}): {
+  beforeTask: KanbanTask | undefined;
+  patchedKanban: boolean;
+  patchedSnapshotIds: string[];
+} {
+  const beforeTask =
+    params.beforeState.kanban.tasks.find((task) => task.id === params.taskId) ??
+    Object.values(params.beforeState.kanbanMulti.snapshots)
+      .flatMap((snapshot) => snapshot.tasks)
+      .find((task) => task.id === params.taskId);
+  const beforeKanbanTask = params.beforeState.kanban.tasks.find(
+    (task) => task.id === params.taskId && task.primarySessionId === params.sessionId,
+  );
+  const afterKanbanTask = params.afterState.kanban.tasks.find(
+    (task) => task.id === params.taskId && task.primarySessionId === params.sessionId,
+  );
+  const patchedSnapshotIds = Object.keys(params.afterState.kanbanMulti.snapshots).filter(
+    (workflowId) => {
+      const beforeSnapshotTask = findSnapshotTask(
+        params.beforeState.kanbanMulti.snapshots,
+        workflowId,
+        params.taskId,
+        params.sessionId,
+      );
+      const afterSnapshotTask = findSnapshotTask(
+        params.afterState.kanbanMulti.snapshots,
+        workflowId,
+        params.taskId,
+        params.sessionId,
+      );
+      return didPatchTaskPrimaryState(beforeSnapshotTask, afterSnapshotTask, params.newState);
+    },
+  );
+  return {
+    beforeTask,
+    patchedKanban: didPatchTaskPrimaryState(beforeKanbanTask, afterKanbanTask, params.newState),
+    patchedSnapshotIds,
+  };
+}
+
+export function logKanbanPrimarySessionSync(params: {
+  taskId: string;
+  sessionId: string;
+  newState: TaskSessionState;
+  beforeTask: KanbanTask | undefined;
+  patchedKanban: boolean;
+  patchedSnapshotIds: string[];
+}): void {
+  if (!isDebug()) return;
+  lifecycleDebug("session.state_changed kanban sync", {
+    task_id: params.taskId,
+    sessionId: params.sessionId,
+    newState: params.newState,
+    beforeTaskPrimarySessionId: params.beforeTask?.primarySessionId ?? "-",
+    beforeTaskPrimaryState: params.beforeTask?.primarySessionState ?? "-",
+    patchedKanban: params.patchedKanban,
+    patchedSnapshots: params.patchedSnapshotIds.join(",") || "-",
+  });
+}

--- a/apps/web/lib/ws/handlers/agent-session-kanban-sync.ts
+++ b/apps/web/lib/ws/handlers/agent-session-kanban-sync.ts
@@ -1,0 +1,130 @@
+import type { StoreApi } from "zustand";
+import { isDebug } from "@/lib/debug/log";
+import type { KanbanState, WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
+import type { AppState } from "@/lib/state/store";
+import type { SessionId, TaskId, TaskSessionState } from "@/lib/types/http";
+import {
+  buildKanbanPrimarySessionSyncLog,
+  logKanbanPrimarySessionSync,
+} from "@/lib/ws/handlers/agent-session-diagnostics";
+
+function snapshotKanbanStateForLog(state: AppState): AppState {
+  return {
+    ...state,
+    kanban: { ...state.kanban },
+    kanbanMulti: {
+      ...state.kanbanMulti,
+      snapshots: { ...state.kanbanMulti.snapshots },
+    },
+  };
+}
+
+function patchTaskPrimarySessionState(
+  tasks: KanbanState["tasks"],
+  taskId: string,
+  sessionId: string,
+  newState: TaskSessionState,
+): KanbanState["tasks"] {
+  let changed = false;
+  const nextTasks = tasks.map((task) => {
+    if (task.id !== taskId || task.primarySessionId !== sessionId) return task;
+    if (task.primarySessionState === newState) return task;
+    changed = true;
+    return { ...task, primarySessionState: newState };
+  });
+  return changed ? nextTasks : tasks;
+}
+
+function patchSnapshotPrimarySessionState(
+  snapshot: WorkflowSnapshotData,
+  taskId: string,
+  sessionId: string,
+  newState: TaskSessionState,
+): WorkflowSnapshotData {
+  const tasks = patchTaskPrimarySessionState(snapshot.tasks, taskId, sessionId, newState);
+  return tasks === snapshot.tasks ? snapshot : { ...snapshot, tasks };
+}
+
+function patchWorkflowSnapshotPrimarySessionStates(
+  snapshots: Record<string, WorkflowSnapshotData>,
+  taskId: string,
+  sessionId: string,
+  newState: TaskSessionState,
+): {
+  nextSnapshots: Record<string, WorkflowSnapshotData>;
+  snapshotsChanged: boolean;
+} {
+  let snapshotsChanged = false;
+  const nextSnapshots = Object.fromEntries(
+    Object.entries(snapshots).map(([workflowId, snapshot]) => {
+      const nextSnapshot = patchSnapshotPrimarySessionState(snapshot, taskId, sessionId, newState);
+      if (nextSnapshot !== snapshot) snapshotsChanged = true;
+      return [workflowId, nextSnapshot];
+    }),
+  );
+  return { nextSnapshots, snapshotsChanged };
+}
+
+export function syncKanbanPrimarySessionState(
+  store: StoreApi<AppState>,
+  taskId: TaskId,
+  sessionId: SessionId,
+  newState: TaskSessionState | undefined,
+): void {
+  if (!newState) return;
+
+  const state = store.getState();
+  if (!state.kanban?.tasks || !state.kanbanMulti?.snapshots) return;
+
+  const debugMode = isDebug();
+  const beforeState = debugMode ? snapshotKanbanStateForLog(state) : state;
+
+  store.setState((currentState) => {
+    if (!currentState.kanban?.tasks || !currentState.kanbanMulti?.snapshots) return currentState;
+    const nextKanbanTasks = patchTaskPrimarySessionState(
+      currentState.kanban.tasks,
+      taskId,
+      sessionId,
+      newState,
+    );
+    const { nextSnapshots, snapshotsChanged } = patchWorkflowSnapshotPrimarySessionStates(
+      currentState.kanbanMulti.snapshots,
+      taskId,
+      sessionId,
+      newState,
+    );
+
+    if (nextKanbanTasks === currentState.kanban.tasks && !snapshotsChanged) return currentState;
+
+    return {
+      ...currentState,
+      kanban:
+        nextKanbanTasks === currentState.kanban.tasks
+          ? currentState.kanban
+          : { ...currentState.kanban, tasks: nextKanbanTasks },
+      kanbanMulti: snapshotsChanged
+        ? {
+            ...currentState.kanbanMulti,
+            snapshots: nextSnapshots,
+          }
+        : currentState.kanbanMulti,
+    };
+  });
+
+  if (!debugMode) return;
+  const syncLog = buildKanbanPrimarySessionSyncLog({
+    beforeState,
+    afterState: store.getState(),
+    taskId,
+    sessionId,
+    newState,
+  });
+  logKanbanPrimarySessionSync({
+    taskId,
+    sessionId,
+    newState,
+    beforeTask: syncLog.beforeTask,
+    patchedKanban: syncLog.patchedKanban,
+    patchedSnapshotIds: syncLog.patchedSnapshotIds,
+  });
+}

--- a/apps/web/lib/ws/handlers/agent-session-kanban.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session-kanban.test.ts
@@ -49,52 +49,55 @@ function makeMessage(payload: TaskSessionStateChangedPayload) {
   };
 }
 
+function makeKanbanTask(primarySessionId: string) {
+  return {
+    id: "t-1",
+    workflowStepId: "step-1",
+    title: TASK_TITLE,
+    position: 0,
+    primarySessionId,
+    primarySessionState: "WAITING_FOR_INPUT",
+  };
+}
+
+function makeTaskSession(id: string) {
+  return {
+    id: sessionId(id),
+    task_id: taskId("t-1"),
+    state: "WAITING_FOR_INPUT",
+    started_at: "",
+    updated_at: "",
+  };
+}
+
+function makeSnapshotTaskStore(primarySessionId: string) {
+  const task = makeKanbanTask(primarySessionId);
+  return {
+    isLoading: false,
+    snapshots: {
+      "wf-1": {
+        workflowId: "wf-1",
+        workflowName: "Development",
+        steps: [],
+        tasks: [task],
+      },
+    },
+  };
+}
+
 describe("session.state_changed -> primary kanban card state", () => {
   it("updates kanban card primary session state in workflow snapshots", () => {
+    const task = makeKanbanTask("s-1");
     const store = makeStore({
       kanban: {
         workflowId: "wf-1",
         steps: [],
-        tasks: [
-          {
-            id: "t-1",
-            workflowStepId: "step-1",
-            title: TASK_TITLE,
-            position: 0,
-            primarySessionId: "s-1",
-            primarySessionState: "WAITING_FOR_INPUT",
-          },
-        ],
+        tasks: [task],
       },
-      kanbanMulti: {
-        isLoading: false,
-        snapshots: {
-          "wf-1": {
-            workflowId: "wf-1",
-            workflowName: "Development",
-            steps: [],
-            tasks: [
-              {
-                id: "t-1",
-                workflowStepId: "step-1",
-                title: TASK_TITLE,
-                position: 0,
-                primarySessionId: "s-1",
-                primarySessionState: "WAITING_FOR_INPUT",
-              },
-            ],
-          },
-        },
-      },
+      kanbanMulti: makeSnapshotTaskStore("s-1"),
       taskSessions: {
         items: {
-          "s-1": {
-            id: sessionId("s-1"),
-            task_id: taskId("t-1"),
-            state: "WAITING_FOR_INPUT",
-            started_at: "",
-            updated_at: "",
-          },
+          "s-1": makeTaskSession("s-1"),
         },
       },
     });
@@ -106,6 +109,33 @@ describe("session.state_changed -> primary kanban card state", () => {
     expect(store.getState().kanbanMulti.snapshots["wf-1"]?.tasks[0]?.primarySessionState).toBe(
       "RUNNING",
     );
+  });
+
+  it("logs the previous primary state when the task only exists in a workflow snapshot", () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf-other",
+        steps: [],
+        tasks: [],
+      },
+      kanbanMulti: makeSnapshotTaskStore("s-1"),
+      taskSessions: {
+        items: {
+          "s-1": makeTaskSession("s-1"),
+        },
+      },
+    });
+    const handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
+
+    handler(makeMessage({ task_id: "t-1", session_id: "s-1", new_state: "RUNNING" }));
+
+    expect(
+      debugSpy.mock.calls.some((call) =>
+        String(call[0]).includes("beforeTaskPrimaryState=WAITING_FOR_INPUT"),
+      ),
+    ).toBe(true);
+    debugSpy.mockRestore();
   });
 });
 

--- a/apps/web/lib/ws/handlers/agent-session-kanban.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session-kanban.test.ts
@@ -8,7 +8,10 @@ import { sessionId, taskId, type TaskSessionState } from "@/lib/types/http";
 const STATE_CHANGED_EVENT = "session.state_changed";
 const TASK_TITLE = "Running task";
 
-function makeStore(overrides: Partial<AppState> = {}) {
+function makeStore(
+  overrides: Partial<AppState> = {},
+  beforeApplyState?: (state: AppState) => void,
+) {
   const state = {
     kanban: { workflowId: null, steps: [], tasks: [] },
     kanbanMulti: { snapshots: {}, isLoading: false },
@@ -28,6 +31,7 @@ function makeStore(overrides: Partial<AppState> = {}) {
     ...overrides,
   } as unknown as AppState;
   const setState = vi.fn((updater: unknown) => {
+    beforeApplyState?.(state);
     const next = typeof updater === "function" ? updater(state) : updater;
     if (next && next !== state) Object.assign(state, next);
   });
@@ -136,6 +140,37 @@ describe("session.state_changed -> primary kanban card state", () => {
       ),
     ).toBe(true);
     debugSpy.mockRestore();
+  });
+
+  it("preserves concurrent store changes while syncing kanban session state", () => {
+    const task = makeKanbanTask("s-1");
+    const store = makeStore(
+      {
+        kanban: {
+          workflowId: "wf-1",
+          steps: [],
+          tasks: [task],
+        },
+        kanbanMulti: makeSnapshotTaskStore("s-1"),
+        taskSessions: {
+          items: {
+            "s-1": makeTaskSession("s-1"),
+          },
+        },
+      },
+      (state) => {
+        state.tasks = {
+          ...state.tasks,
+          activeTaskId: taskId("concurrent-task"),
+        };
+      },
+    );
+    const handler = registerTaskSessionHandlers(store)[STATE_CHANGED_EVENT]!;
+
+    handler(makeMessage({ task_id: "t-1", session_id: "s-1", new_state: "RUNNING" }));
+
+    expect(store.getState().kanban.tasks[0]?.primarySessionState).toBe("RUNNING");
+    expect(store.getState().tasks.activeTaskId).toBe(taskId("concurrent-task"));
   });
 });
 

--- a/apps/web/lib/ws/handlers/agent-session-kanban.test.ts
+++ b/apps/web/lib/ws/handlers/agent-session-kanban.test.ts
@@ -3,7 +3,7 @@ import type { StoreApi } from "zustand";
 import { registerTaskSessionHandlers } from "./agent-session";
 import type { AppState } from "@/lib/state/store";
 import type { TaskSessionStateChangedPayload } from "@/lib/types/backend";
-import { sessionId, taskId } from "@/lib/types/http";
+import { sessionId, taskId, type TaskSessionState } from "@/lib/types/http";
 
 const STATE_CHANGED_EVENT = "session.state_changed";
 const TASK_TITLE = "Running task";
@@ -64,7 +64,7 @@ function makeTaskSession(id: string) {
   return {
     id: sessionId(id),
     task_id: taskId("t-1"),
-    state: "WAITING_FOR_INPUT",
+    state: "WAITING_FOR_INPUT" as TaskSessionState,
     started_at: "",
     updated_at: "",
   };

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -1,5 +1,5 @@
 import type { StoreApi } from "zustand";
-import { createDebugLogger, isDebug } from "@/lib/debug/log";
+import { createDebugLogger } from "@/lib/debug/log";
 import type { AppState } from "@/lib/state/store";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
 import {
@@ -10,10 +10,9 @@ import {
   type TaskSessionState,
 } from "@/lib/types/http";
 import type { QueuedMessage } from "@/lib/state/slices/session/types";
-import type { KanbanState, WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
+import { syncKanbanPrimarySessionState } from "@/lib/ws/handlers/agent-session-kanban-sync";
 
 const debug = createDebugLogger("session:state");
-const lifecycleDebug = createDebugLogger("task-lifecycle:ws");
 
 const TERMINAL_SESSION_STATES: ReadonlySet<TaskSessionState> = new Set([
   "COMPLETED",
@@ -223,161 +222,6 @@ function maybeFanOutOfficeRefetch(
   if (!setOfficeTrigger) return;
   setOfficeTrigger("dashboard");
   setOfficeTrigger("agents");
-}
-
-function patchTaskPrimarySessionState(
-  tasks: KanbanState["tasks"],
-  taskId: string,
-  sessionId: string,
-  newState: TaskSessionState,
-): KanbanState["tasks"] {
-  let changed = false;
-  const nextTasks = tasks.map((task) => {
-    if (task.id !== taskId || task.primarySessionId !== sessionId) return task;
-    if (task.primarySessionState === newState) return task;
-    changed = true;
-    return { ...task, primarySessionState: newState };
-  });
-  return changed ? nextTasks : tasks;
-}
-
-function patchSnapshotPrimarySessionState(
-  snapshot: WorkflowSnapshotData,
-  taskId: string,
-  sessionId: string,
-  newState: TaskSessionState,
-): WorkflowSnapshotData {
-  const tasks = patchTaskPrimarySessionState(snapshot.tasks, taskId, sessionId, newState);
-  return tasks === snapshot.tasks ? snapshot : { ...snapshot, tasks };
-}
-
-function findKanbanTaskForLog(
-  state: AppState,
-  taskId: string,
-): KanbanState["tasks"][number] | undefined {
-  const activeTask = state.kanban.tasks.find((task) => task.id === taskId);
-  if (activeTask) return activeTask;
-  for (const snapshot of Object.values(state.kanbanMulti.snapshots)) {
-    const snapshotTask = snapshot.tasks.find((task) => task.id === taskId);
-    if (snapshotTask) return snapshotTask;
-  }
-  return undefined;
-}
-
-function patchWorkflowSnapshotPrimarySessionStates(
-  snapshots: Record<string, WorkflowSnapshotData>,
-  taskId: string,
-  sessionId: string,
-  newState: TaskSessionState,
-  patchedSnapshotIds?: string[],
-): {
-  nextSnapshots: Record<string, WorkflowSnapshotData>;
-  snapshotsChanged: boolean;
-} {
-  let snapshotsChanged = false;
-  const nextSnapshots = Object.fromEntries(
-    Object.entries(snapshots).map(([workflowId, snapshot]) => {
-      const nextSnapshot = patchSnapshotPrimarySessionState(snapshot, taskId, sessionId, newState);
-      if (nextSnapshot !== snapshot) {
-        snapshotsChanged = true;
-        patchedSnapshotIds?.push(workflowId);
-      }
-      return [workflowId, nextSnapshot];
-    }),
-  );
-  return { nextSnapshots, snapshotsChanged };
-}
-
-function logKanbanPrimarySessionSync(params: {
-  taskId: string;
-  sessionId: string;
-  newState: TaskSessionState;
-  beforeTask: KanbanState["tasks"][number] | undefined;
-  patchedKanban: boolean;
-  patchedSnapshotIds: string[];
-}): void {
-  if (!isDebug()) return;
-  lifecycleDebug("session.state_changed kanban sync", {
-    task_id: params.taskId,
-    sessionId: params.sessionId,
-    newState: params.newState,
-    beforeTaskPrimarySessionId: params.beforeTask?.primarySessionId ?? "-",
-    beforeTaskPrimaryState: params.beforeTask?.primarySessionState ?? "-",
-    patchedKanban: params.patchedKanban,
-    patchedSnapshots: params.patchedSnapshotIds.join(",") || "-",
-  });
-}
-
-function syncKanbanPrimarySessionState(
-  store: StoreApi<AppState>,
-  taskId: TaskId,
-  sessionId: SessionId,
-  newState: TaskSessionState | undefined,
-): void {
-  if (!newState) return;
-
-  const state = store.getState();
-  if (!state.kanban?.tasks || !state.kanbanMulti?.snapshots) return;
-
-  const debugMode = isDebug();
-  const beforeTask = debugMode ? findKanbanTaskForLog(state, taskId) : undefined;
-  let syncLog:
-    | {
-        patchedKanban: boolean;
-        patchedSnapshotIds: string[];
-      }
-    | undefined;
-
-  store.setState((currentState) => {
-    if (!currentState.kanban?.tasks || !currentState.kanbanMulti?.snapshots) return currentState;
-    const patchedSnapshotIds = debugMode ? [] : undefined;
-    const nextKanbanTasks = patchTaskPrimarySessionState(
-      currentState.kanban.tasks,
-      taskId,
-      sessionId,
-      newState,
-    );
-    const { nextSnapshots, snapshotsChanged } = patchWorkflowSnapshotPrimarySessionStates(
-      currentState.kanbanMulti.snapshots,
-      taskId,
-      sessionId,
-      newState,
-      patchedSnapshotIds,
-    );
-    if (debugMode) {
-      syncLog = {
-        patchedKanban: nextKanbanTasks !== currentState.kanban.tasks,
-        patchedSnapshotIds: patchedSnapshotIds ?? [],
-      };
-    }
-
-    if (nextKanbanTasks === currentState.kanban.tasks && !snapshotsChanged) return currentState;
-
-    return {
-      ...currentState,
-      kanban:
-        nextKanbanTasks === currentState.kanban.tasks
-          ? currentState.kanban
-          : { ...currentState.kanban, tasks: nextKanbanTasks },
-      kanbanMulti: snapshotsChanged
-        ? {
-            ...currentState.kanbanMulti,
-            snapshots: nextSnapshots,
-          }
-        : currentState.kanbanMulti,
-    };
-  });
-
-  if (debugMode && syncLog) {
-    logKanbanPrimarySessionSync({
-      taskId,
-      sessionId,
-      newState,
-      beforeTask,
-      patchedKanban: syncLog.patchedKanban,
-      patchedSnapshotIds: syncLog.patchedSnapshotIds,
-    });
-  }
 }
 
 /** Extract context window data from payload metadata and store it. */

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -269,6 +269,7 @@ function patchWorkflowSnapshotPrimarySessionStates(
   taskId: string,
   sessionId: string,
   newState: TaskSessionState,
+  debugMode: boolean,
 ): {
   nextSnapshots: Record<string, WorkflowSnapshotData>;
   snapshotsChanged: boolean;
@@ -281,7 +282,7 @@ function patchWorkflowSnapshotPrimarySessionStates(
       const nextSnapshot = patchSnapshotPrimarySessionState(snapshot, taskId, sessionId, newState);
       if (nextSnapshot !== snapshot) {
         snapshotsChanged = true;
-        patchedSnapshotIds.push(workflowId);
+        if (debugMode) patchedSnapshotIds.push(workflowId);
       }
       return [workflowId, nextSnapshot];
     }),
@@ -320,7 +321,8 @@ function syncKanbanPrimarySessionState(
   const state = store.getState();
   if (!state.kanban?.tasks || !state.kanbanMulti?.snapshots) return;
 
-  const beforeTask = findKanbanTaskForLog(state, taskId);
+  const debugMode = isDebug();
+  const beforeTask = debugMode ? findKanbanTaskForLog(state, taskId) : undefined;
   const nextKanbanTasks = patchTaskPrimarySessionState(
     state.kanban.tasks,
     taskId,
@@ -333,6 +335,7 @@ function syncKanbanPrimarySessionState(
       taskId,
       sessionId,
       newState,
+      debugMode,
     );
 
   logKanbanPrimarySessionSync({

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -251,6 +251,19 @@ function patchSnapshotPrimarySessionState(
   return tasks === snapshot.tasks ? snapshot : { ...snapshot, tasks };
 }
 
+function findKanbanTaskForLog(
+  state: AppState,
+  taskId: string,
+): KanbanState["tasks"][number] | undefined {
+  const activeTask = state.kanban.tasks.find((task) => task.id === taskId);
+  if (activeTask) return activeTask;
+  for (const snapshot of Object.values(state.kanbanMulti.snapshots)) {
+    const snapshotTask = snapshot.tasks.find((task) => task.id === taskId);
+    if (snapshotTask) return snapshotTask;
+  }
+  return undefined;
+}
+
 function patchWorkflowSnapshotPrimarySessionStates(
   snapshots: Record<string, WorkflowSnapshotData>,
   taskId: string,
@@ -307,7 +320,7 @@ function syncKanbanPrimarySessionState(
   const state = store.getState();
   if (!state.kanban?.tasks || !state.kanbanMulti?.snapshots) return;
 
-  const beforeTask = state.kanban.tasks.find((task) => task.id === taskId);
+  const beforeTask = findKanbanTaskForLog(state, taskId);
   const nextKanbanTasks = patchTaskPrimarySessionState(
     state.kanban.tasks,
     taskId,

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -1,5 +1,5 @@
 import type { StoreApi } from "zustand";
-import { createDebugLogger } from "@/lib/debug/log";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import type { AppState } from "@/lib/state/store";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
 import {
@@ -13,6 +13,7 @@ import type { QueuedMessage } from "@/lib/state/slices/session/types";
 import type { KanbanState, WorkflowSnapshotData } from "@/lib/state/slices/kanban/types";
 
 const debug = createDebugLogger("session:state");
+const lifecycleDebug = createDebugLogger("task-lifecycle:ws");
 
 const TERMINAL_SESSION_STATES: ReadonlySet<TaskSessionState> = new Set([
   "COMPLETED",
@@ -259,6 +260,8 @@ function syncKanbanPrimarySessionState(
   if (!newState) return;
 
   store.setState((state) => {
+    const beforeTask = state.kanban.tasks.find((task) => task.id === taskId);
+    const patchedSnapshotIds: string[] = [];
     const nextKanbanTasks = patchTaskPrimarySessionState(
       state.kanban.tasks,
       taskId,
@@ -274,10 +277,25 @@ function syncKanbanPrimarySessionState(
           sessionId,
           newState,
         );
-        if (nextSnapshot !== snapshot) snapshotsChanged = true;
+        if (nextSnapshot !== snapshot) {
+          snapshotsChanged = true;
+          patchedSnapshotIds.push(workflowId);
+        }
         return [workflowId, nextSnapshot];
       }),
     );
+
+    if (isDebug()) {
+      lifecycleDebug("session.state_changed kanban sync", {
+        task_id: taskId,
+        sessionId,
+        newState,
+        beforeTaskPrimarySessionId: beforeTask?.primarySessionId ?? "-",
+        beforeTaskPrimaryState: beforeTask?.primarySessionState ?? "-",
+        patchedKanban: nextKanbanTasks !== state.kanban.tasks,
+        patchedSnapshots: patchedSnapshotIds.join(",") || "-",
+      });
+    }
 
     if (nextKanbanTasks === state.kanban.tasks && !snapshotsChanged) return state;
 

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -269,25 +269,23 @@ function patchWorkflowSnapshotPrimarySessionStates(
   taskId: string,
   sessionId: string,
   newState: TaskSessionState,
-  debugMode: boolean,
+  patchedSnapshotIds?: string[],
 ): {
   nextSnapshots: Record<string, WorkflowSnapshotData>;
   snapshotsChanged: boolean;
-  patchedSnapshotIds: string[];
 } {
   let snapshotsChanged = false;
-  const patchedSnapshotIds: string[] = [];
   const nextSnapshots = Object.fromEntries(
     Object.entries(snapshots).map(([workflowId, snapshot]) => {
       const nextSnapshot = patchSnapshotPrimarySessionState(snapshot, taskId, sessionId, newState);
       if (nextSnapshot !== snapshot) {
         snapshotsChanged = true;
-        if (debugMode) patchedSnapshotIds.push(workflowId);
+        patchedSnapshotIds?.push(workflowId);
       }
       return [workflowId, nextSnapshot];
     }),
   );
-  return { nextSnapshots, snapshotsChanged, patchedSnapshotIds };
+  return { nextSnapshots, snapshotsChanged };
 }
 
 function logKanbanPrimarySessionSync(params: {
@@ -332,24 +330,26 @@ function syncKanbanPrimarySessionState(
 
   store.setState((currentState) => {
     if (!currentState.kanban?.tasks || !currentState.kanbanMulti?.snapshots) return currentState;
+    const patchedSnapshotIds = debugMode ? [] : undefined;
     const nextKanbanTasks = patchTaskPrimarySessionState(
       currentState.kanban.tasks,
       taskId,
       sessionId,
       newState,
     );
-    const { nextSnapshots, snapshotsChanged, patchedSnapshotIds } =
-      patchWorkflowSnapshotPrimarySessionStates(
-        currentState.kanbanMulti.snapshots,
-        taskId,
-        sessionId,
-        newState,
-        debugMode,
-      );
-    syncLog = {
-      patchedKanban: nextKanbanTasks !== currentState.kanban.tasks,
+    const { nextSnapshots, snapshotsChanged } = patchWorkflowSnapshotPrimarySessionStates(
+      currentState.kanbanMulti.snapshots,
+      taskId,
+      sessionId,
+      newState,
       patchedSnapshotIds,
-    };
+    );
+    if (debugMode) {
+      syncLog = {
+        patchedKanban: nextKanbanTasks !== currentState.kanban.tasks,
+        patchedSnapshotIds: patchedSnapshotIds ?? [],
+      };
+    }
 
     if (nextKanbanTasks === currentState.kanban.tasks && !snapshotsChanged) return currentState;
 
@@ -368,7 +368,7 @@ function syncKanbanPrimarySessionState(
     };
   });
 
-  if (syncLog) {
+  if (debugMode && syncLog) {
     logKanbanPrimarySessionSync({
       taskId,
       sessionId,

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -323,45 +323,61 @@ function syncKanbanPrimarySessionState(
 
   const debugMode = isDebug();
   const beforeTask = debugMode ? findKanbanTaskForLog(state, taskId) : undefined;
-  const nextKanbanTasks = patchTaskPrimarySessionState(
-    state.kanban.tasks,
-    taskId,
-    sessionId,
-    newState,
-  );
-  const { nextSnapshots, snapshotsChanged, patchedSnapshotIds } =
-    patchWorkflowSnapshotPrimarySessionStates(
-      state.kanbanMulti.snapshots,
+  let syncLog:
+    | {
+        patchedKanban: boolean;
+        patchedSnapshotIds: string[];
+      }
+    | undefined;
+
+  store.setState((currentState) => {
+    if (!currentState.kanban?.tasks || !currentState.kanbanMulti?.snapshots) return currentState;
+    const nextKanbanTasks = patchTaskPrimarySessionState(
+      currentState.kanban.tasks,
       taskId,
       sessionId,
       newState,
-      debugMode,
     );
+    const { nextSnapshots, snapshotsChanged, patchedSnapshotIds } =
+      patchWorkflowSnapshotPrimarySessionStates(
+        currentState.kanbanMulti.snapshots,
+        taskId,
+        sessionId,
+        newState,
+        debugMode,
+      );
+    syncLog = {
+      patchedKanban: nextKanbanTasks !== currentState.kanban.tasks,
+      patchedSnapshotIds,
+    };
 
-  logKanbanPrimarySessionSync({
-    taskId,
-    sessionId,
-    newState,
-    beforeTask,
-    patchedKanban: nextKanbanTasks !== state.kanban.tasks,
-    patchedSnapshotIds,
+    if (nextKanbanTasks === currentState.kanban.tasks && !snapshotsChanged) return currentState;
+
+    return {
+      ...currentState,
+      kanban:
+        nextKanbanTasks === currentState.kanban.tasks
+          ? currentState.kanban
+          : { ...currentState.kanban, tasks: nextKanbanTasks },
+      kanbanMulti: snapshotsChanged
+        ? {
+            ...currentState.kanbanMulti,
+            snapshots: nextSnapshots,
+          }
+        : currentState.kanbanMulti,
+    };
   });
 
-  if (nextKanbanTasks === state.kanban.tasks && !snapshotsChanged) return;
-
-  store.setState({
-    ...state,
-    kanban:
-      nextKanbanTasks === state.kanban.tasks
-        ? state.kanban
-        : { ...state.kanban, tasks: nextKanbanTasks },
-    kanbanMulti: snapshotsChanged
-      ? {
-          ...state.kanbanMulti,
-          snapshots: nextSnapshots,
-        }
-      : state.kanbanMulti,
-  });
+  if (syncLog) {
+    logKanbanPrimarySessionSync({
+      taskId,
+      sessionId,
+      newState,
+      beforeTask,
+      patchedKanban: syncLog.patchedKanban,
+      patchedSnapshotIds: syncLog.patchedSnapshotIds,
+    });
+  }
 }
 
 /** Extract context window data from payload metadata and store it. */

--- a/apps/web/lib/ws/handlers/agent-session.ts
+++ b/apps/web/lib/ws/handlers/agent-session.ts
@@ -251,6 +251,51 @@ function patchSnapshotPrimarySessionState(
   return tasks === snapshot.tasks ? snapshot : { ...snapshot, tasks };
 }
 
+function patchWorkflowSnapshotPrimarySessionStates(
+  snapshots: Record<string, WorkflowSnapshotData>,
+  taskId: string,
+  sessionId: string,
+  newState: TaskSessionState,
+): {
+  nextSnapshots: Record<string, WorkflowSnapshotData>;
+  snapshotsChanged: boolean;
+  patchedSnapshotIds: string[];
+} {
+  let snapshotsChanged = false;
+  const patchedSnapshotIds: string[] = [];
+  const nextSnapshots = Object.fromEntries(
+    Object.entries(snapshots).map(([workflowId, snapshot]) => {
+      const nextSnapshot = patchSnapshotPrimarySessionState(snapshot, taskId, sessionId, newState);
+      if (nextSnapshot !== snapshot) {
+        snapshotsChanged = true;
+        patchedSnapshotIds.push(workflowId);
+      }
+      return [workflowId, nextSnapshot];
+    }),
+  );
+  return { nextSnapshots, snapshotsChanged, patchedSnapshotIds };
+}
+
+function logKanbanPrimarySessionSync(params: {
+  taskId: string;
+  sessionId: string;
+  newState: TaskSessionState;
+  beforeTask: KanbanState["tasks"][number] | undefined;
+  patchedKanban: boolean;
+  patchedSnapshotIds: string[];
+}): void {
+  if (!isDebug()) return;
+  lifecycleDebug("session.state_changed kanban sync", {
+    task_id: params.taskId,
+    sessionId: params.sessionId,
+    newState: params.newState,
+    beforeTaskPrimarySessionId: params.beforeTask?.primarySessionId ?? "-",
+    beforeTaskPrimaryState: params.beforeTask?.primarySessionState ?? "-",
+    patchedKanban: params.patchedKanban,
+    patchedSnapshots: params.patchedSnapshotIds.join(",") || "-",
+  });
+}
+
 function syncKanbanPrimarySessionState(
   store: StoreApi<AppState>,
   taskId: TaskId,
@@ -259,59 +304,47 @@ function syncKanbanPrimarySessionState(
 ): void {
   if (!newState) return;
 
-  store.setState((state) => {
-    const beforeTask = state.kanban.tasks.find((task) => task.id === taskId);
-    const patchedSnapshotIds: string[] = [];
-    const nextKanbanTasks = patchTaskPrimarySessionState(
-      state.kanban.tasks,
+  const state = store.getState();
+  if (!state.kanban?.tasks || !state.kanbanMulti?.snapshots) return;
+
+  const beforeTask = state.kanban.tasks.find((task) => task.id === taskId);
+  const nextKanbanTasks = patchTaskPrimarySessionState(
+    state.kanban.tasks,
+    taskId,
+    sessionId,
+    newState,
+  );
+  const { nextSnapshots, snapshotsChanged, patchedSnapshotIds } =
+    patchWorkflowSnapshotPrimarySessionStates(
+      state.kanbanMulti.snapshots,
       taskId,
       sessionId,
       newState,
     );
-    let snapshotsChanged = false;
-    const nextSnapshots = Object.fromEntries(
-      Object.entries(state.kanbanMulti.snapshots).map(([workflowId, snapshot]) => {
-        const nextSnapshot = patchSnapshotPrimarySessionState(
-          snapshot,
-          taskId,
-          sessionId,
-          newState,
-        );
-        if (nextSnapshot !== snapshot) {
-          snapshotsChanged = true;
-          patchedSnapshotIds.push(workflowId);
+
+  logKanbanPrimarySessionSync({
+    taskId,
+    sessionId,
+    newState,
+    beforeTask,
+    patchedKanban: nextKanbanTasks !== state.kanban.tasks,
+    patchedSnapshotIds,
+  });
+
+  if (nextKanbanTasks === state.kanban.tasks && !snapshotsChanged) return;
+
+  store.setState({
+    ...state,
+    kanban:
+      nextKanbanTasks === state.kanban.tasks
+        ? state.kanban
+        : { ...state.kanban, tasks: nextKanbanTasks },
+    kanbanMulti: snapshotsChanged
+      ? {
+          ...state.kanbanMulti,
+          snapshots: nextSnapshots,
         }
-        return [workflowId, nextSnapshot];
-      }),
-    );
-
-    if (isDebug()) {
-      lifecycleDebug("session.state_changed kanban sync", {
-        task_id: taskId,
-        sessionId,
-        newState,
-        beforeTaskPrimarySessionId: beforeTask?.primarySessionId ?? "-",
-        beforeTaskPrimaryState: beforeTask?.primarySessionState ?? "-",
-        patchedKanban: nextKanbanTasks !== state.kanban.tasks,
-        patchedSnapshots: patchedSnapshotIds.join(",") || "-",
-      });
-    }
-
-    if (nextKanbanTasks === state.kanban.tasks && !snapshotsChanged) return state;
-
-    return {
-      ...state,
-      kanban:
-        nextKanbanTasks === state.kanban.tasks
-          ? state.kanban
-          : { ...state.kanban, tasks: nextKanbanTasks },
-      kanbanMulti: snapshotsChanged
-        ? {
-            ...state.kanbanMulti,
-            snapshots: nextSnapshots,
-          }
-        : state.kanbanMulti,
-    };
+      : state.kanbanMulti,
   });
 }
 

--- a/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
+++ b/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
@@ -216,3 +216,36 @@ describe("task lifecycle diagnostics", () => {
     debugSpy.mockRestore();
   });
 });
+
+describe("task primary-session clears", () => {
+  it("does not preserve primary session fields when the payload explicitly clears them", () => {
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+      kanbanMulti: {
+        isLoading: false,
+        snapshots: {
+          wf1: { workflowId: "wf1", workflowName: "WF1", steps: [], tasks: [existingTask] },
+        },
+      } as unknown as AppState["kanbanMulti"],
+    });
+
+    registerTasksHandlers(store)["task.updated"]!(
+      makeUpdatedMessage({
+        ...makeTask("t1", null),
+        primary_session_state: null,
+      }),
+    );
+
+    const state = store.getState();
+    const kanbanTask = state.kanban.tasks.find((task) => task.id === "t1");
+    const snapshotTask = state.kanbanMulti.snapshots.wf1.tasks.find((task) => task.id === "t1");
+    expect(kanbanTask?.primarySessionId).toBeUndefined();
+    expect(kanbanTask?.primarySessionState).toBeUndefined();
+    expect(snapshotTask?.primarySessionId).toBeUndefined();
+    expect(snapshotTask?.primarySessionState).toBeUndefined();
+  });
+});

--- a/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
+++ b/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
@@ -248,4 +248,35 @@ describe("task primary-session clears", () => {
     expect(snapshotTask?.primarySessionId).toBeUndefined();
     expect(snapshotTask?.primarySessionState).toBeUndefined();
   });
+
+  it("does not preserve primary session fields on explicit state-change clears", () => {
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+      kanbanMulti: {
+        isLoading: false,
+        snapshots: {
+          wf1: { workflowId: "wf1", workflowName: "WF1", steps: [], tasks: [existingTask] },
+        },
+      } as unknown as AppState["kanbanMulti"],
+    });
+
+    registerTasksHandlers(store)["task.state_changed"]!(
+      makeStateChangedMessage({
+        ...makeTask("t1", null),
+        primary_session_state: null,
+      }),
+    );
+
+    const state = store.getState();
+    const kanbanTask = state.kanban.tasks.find((task) => task.id === "t1");
+    const snapshotTask = state.kanbanMulti.snapshots.wf1.tasks.find((task) => task.id === "t1");
+    expect(kanbanTask?.primarySessionId).toBeUndefined();
+    expect(kanbanTask?.primarySessionState).toBeUndefined();
+    expect(snapshotTask?.primarySessionId).toBeUndefined();
+    expect(snapshotTask?.primarySessionState).toBeUndefined();
+  });
 });

--- a/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
+++ b/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { StoreApi } from "zustand";
 import type { AppState } from "@/lib/state/store";
-import { registerTasksHandlers } from "./tasks";
+import { didPreservePrimaryState, registerTasksHandlers } from "./tasks";
 
 type Listener = (state: AppState) => void;
 
@@ -62,6 +62,15 @@ function makeUpdatedMessage(payload: Record<string, unknown>) {
   } as Parameters<NonNullable<ReturnType<typeof registerTasksHandlers>["task.updated"]>>[0];
 }
 
+function makeCreatedMessage(payload: Record<string, unknown>) {
+  return {
+    id: "msg-1",
+    type: "notification" as const,
+    action: "task.created" as const,
+    payload,
+  } as Parameters<NonNullable<ReturnType<typeof registerTasksHandlers>["task.created"]>>[0];
+}
+
 function makeStateChangedMessage(payload: Record<string, unknown>) {
   return {
     id: "msg-1",
@@ -76,10 +85,50 @@ const existingTask = {
   workflowStepId: "step1",
   title: "Old",
   position: 0,
-  state: "IN_PROGRESS",
+  state: "IN_PROGRESS" as const,
   primarySessionId: "sess-1",
   primarySessionState: "RUNNING",
 };
+
+function taskWithPrimaryState(primarySessionState: string | undefined) {
+  return {
+    ...existingTask,
+    primarySessionState,
+  };
+}
+
+describe("didPreservePrimaryState", () => {
+  it("detects only omitted payload primary state that stayed preserved", () => {
+    expect(
+      didPreservePrimaryState(
+        { workflow_id: "wf1", primary_session_state: "RUNNING" },
+        taskWithPrimaryState("COMPLETED"),
+        taskWithPrimaryState("COMPLETED"),
+      ),
+    ).toBe(false);
+    expect(
+      didPreservePrimaryState(
+        { workflow_id: "wf1" },
+        taskWithPrimaryState(undefined),
+        taskWithPrimaryState("RUNNING"),
+      ),
+    ).toBe(false);
+    expect(
+      didPreservePrimaryState(
+        { workflow_id: "wf1" },
+        taskWithPrimaryState("RUNNING"),
+        taskWithPrimaryState("RUNNING"),
+      ),
+    ).toBe(true);
+    expect(
+      didPreservePrimaryState(
+        { workflow_id: "wf1" },
+        taskWithPrimaryState("RUNNING"),
+        taskWithPrimaryState("COMPLETED"),
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("task lifecycle diagnostics", () => {
   it("upserts task state and primary session state into both kanban stores", () => {
@@ -122,6 +171,19 @@ describe("task lifecycle diagnostics", () => {
         ...makeTask("t-ephemeral", "sess-1"),
         is_ephemeral: true,
         state: "REVIEW",
+      }),
+    );
+
+    expect(store.getState().kanban.tasks).toEqual([]);
+  });
+
+  it("skips ephemeral task creation", () => {
+    const store = makeStore();
+
+    registerTasksHandlers(store)["task.created"]!(
+      makeCreatedMessage({
+        ...makeTask("t-ephemeral", "sess-1"),
+        is_ephemeral: true,
       }),
     );
 

--- a/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
+++ b/apps/web/lib/ws/handlers/task-lifecycle-diagnostics.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import type { StoreApi } from "zustand";
+import type { AppState } from "@/lib/state/store";
+import { registerTasksHandlers } from "./tasks";
+
+type Listener = (state: AppState) => void;
+
+function makeStore(initial: Partial<AppState> = {}) {
+  let state = {
+    kanban: { workflowId: "wf1", steps: [], tasks: [] },
+    kanbanMulti: { snapshots: {}, isLoading: false },
+    tasks: {
+      activeTaskId: null,
+      activeSessionId: null,
+      pinnedSessionId: null,
+      lastSessionByTaskId: {},
+    },
+    taskSessionsByTask: { itemsByTaskId: {}, loadedByTaskId: {}, loadingByTaskId: {} },
+    environmentIdBySessionId: {},
+    setActiveSessionAuto: vi.fn(),
+    removeTaskFromSidebarPrefs: vi.fn(),
+    ...initial,
+  } as unknown as AppState;
+
+  const listeners = new Set<Listener>();
+  return {
+    getState: () => state,
+    setState: (updater: AppState | ((s: AppState) => AppState)) => {
+      const next =
+        typeof updater === "function" ? (updater as (s: AppState) => AppState)(state) : updater;
+      state = { ...state, ...next };
+      for (const l of listeners) l(state);
+    },
+    subscribe: (l: Listener) => {
+      listeners.add(l);
+      return () => listeners.delete(l);
+    },
+    destroy: vi.fn(),
+    getInitialState: vi.fn(),
+  } as unknown as StoreApi<AppState> & { getState: () => AppState };
+}
+
+function makeTask(id: string, primarySessionId: string | null, workflowId = "wf1") {
+  return {
+    task_id: id,
+    workflow_id: workflowId,
+    workflow_step_id: "step1",
+    title: "Test",
+    description: "",
+    state: "IN_PROGRESS",
+    primary_session_id: primarySessionId,
+    is_ephemeral: false,
+  } as Record<string, unknown>;
+}
+
+function makeUpdatedMessage(payload: Record<string, unknown>) {
+  return {
+    id: "msg-1",
+    type: "notification" as const,
+    action: "task.updated" as const,
+    payload,
+  } as Parameters<NonNullable<ReturnType<typeof registerTasksHandlers>["task.updated"]>>[0];
+}
+
+function makeStateChangedMessage(payload: Record<string, unknown>) {
+  return {
+    id: "msg-1",
+    type: "notification" as const,
+    action: "task.state_changed" as const,
+    payload,
+  } as Parameters<NonNullable<ReturnType<typeof registerTasksHandlers>["task.state_changed"]>>[0];
+}
+
+const existingTask = {
+  id: "t1",
+  workflowStepId: "step1",
+  title: "Old",
+  position: 0,
+  state: "IN_PROGRESS",
+  primarySessionId: "sess-1",
+  primarySessionState: "RUNNING",
+};
+
+describe("task lifecycle diagnostics", () => {
+  it("upserts task state and primary session state into both kanban stores", () => {
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+      kanbanMulti: {
+        isLoading: false,
+        snapshots: {
+          wf1: { workflowId: "wf1", workflowName: "WF1", steps: [], tasks: [existingTask] },
+        },
+      } as unknown as AppState["kanbanMulti"],
+    });
+
+    registerTasksHandlers(store)["task.state_changed"]!(
+      makeStateChangedMessage({
+        ...makeTask("t1", "sess-1"),
+        state: "REVIEW",
+        primary_session_state: "WAITING_FOR_INPUT",
+      }),
+    );
+
+    const state = store.getState();
+    const kanbanTask = state.kanban.tasks.find((task) => task.id === "t1");
+    const snapshotTask = state.kanbanMulti.snapshots.wf1.tasks.find((task) => task.id === "t1");
+    expect(kanbanTask?.state).toBe("REVIEW");
+    expect(kanbanTask?.primarySessionState).toBe("WAITING_FOR_INPUT");
+    expect(snapshotTask?.state).toBe("REVIEW");
+    expect(snapshotTask?.primarySessionState).toBe("WAITING_FOR_INPUT");
+  });
+
+  it("skips ephemeral task state changes", () => {
+    const store = makeStore();
+
+    registerTasksHandlers(store)["task.state_changed"]!(
+      makeStateChangedMessage({
+        ...makeTask("t-ephemeral", "sess-1"),
+        is_ephemeral: true,
+        state: "REVIEW",
+      }),
+    );
+
+    expect(store.getState().kanban.tasks).toEqual([]);
+  });
+
+  it("logs whether a task update preserved an omitted primary session state", () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    const store = makeStore({
+      kanban: {
+        workflowId: "wf1",
+        steps: [],
+        tasks: [existingTask],
+      } as unknown as AppState["kanban"],
+    });
+    const handlers = registerTasksHandlers(store);
+
+    handlers["task.updated"]!(makeUpdatedMessage(makeTask("t1", "sess-1")));
+    handlers["task.updated"]!(
+      makeUpdatedMessage({
+        ...makeTask("t1", "sess-1"),
+        primary_session_state: null,
+      }),
+    );
+
+    const logs = debugSpy.mock.calls.map((call) => String(call[0]));
+    expect(logs.some((line) => line.includes("preservedPrimaryState=true"))).toBe(true);
+    expect(logs.some((line) => line.includes("payloadPrimarySessionState=null"))).toBe(true);
+    expect(logs.some((line) => line.includes("preservedPrimaryState=false"))).toBe(true);
+    debugSpy.mockRestore();
+  });
+});

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -19,28 +19,47 @@ import {
 type KanbanTask = KanbanState["tasks"][number];
 const lifecycleDebug = createDebugLogger("task-lifecycle:ws");
 
-function mergeTaskUpdate(existing: KanbanTask | undefined, nextTask: KanbanTask): KanbanTask {
+function hasPayloadField(payload: TaskEventPayload, field: keyof TaskEventPayload): boolean {
+  return Object.prototype.hasOwnProperty.call(payload, field);
+}
+
+function mergeTaskUpdate(
+  existing: KanbanTask | undefined,
+  nextTask: KanbanTask,
+  options: { preservePrimarySessionId: boolean; preservePrimarySessionState: boolean },
+): KanbanTask {
   if (!existing) return nextTask;
   const merged = {
     ...nextTask,
     ...mergeTaskRepositoryFields(existing, nextTask),
   };
-  if (nextTask.primarySessionId === undefined) merged.primarySessionId = existing.primarySessionId;
-  if (nextTask.primarySessionState === undefined) {
+  if (options.preservePrimarySessionId && nextTask.primarySessionId === undefined) {
+    merged.primarySessionId = existing.primarySessionId;
+  }
+  if (options.preservePrimarySessionState && nextTask.primarySessionState === undefined) {
     merged.primarySessionState = existing.primarySessionState;
   }
   return merged;
 }
 
-function upsertTask(tasks: KanbanTask[], nextTask: KanbanTask): KanbanTask[] {
+function upsertTask(
+  tasks: KanbanTask[],
+  nextTask: KanbanTask,
+  options: { preservePrimarySessionId: boolean; preservePrimarySessionState: boolean },
+): KanbanTask[] {
   const existing = tasks.find((task) => task.id === nextTask.id);
-  const merged = mergeTaskUpdate(existing, nextTask);
+  const merged = mergeTaskUpdate(existing, nextTask, options);
   return existing
     ? tasks.map((task) => (task.id === nextTask.id ? merged : task))
     : [...tasks, merged];
 }
 
-function upsertMultiTask(state: AppState, workflowId: string, task: KanbanTask): AppState {
+function upsertMultiTask(
+  state: AppState,
+  workflowId: string,
+  task: KanbanTask,
+  options: { preservePrimarySessionId: boolean; preservePrimarySessionState: boolean },
+): AppState {
   const snapshot = state.kanbanMulti.snapshots[workflowId];
   if (!snapshot) return state;
   return {
@@ -51,7 +70,7 @@ function upsertMultiTask(state: AppState, workflowId: string, task: KanbanTask):
         ...state.kanbanMulti.snapshots,
         [workflowId]: {
           ...snapshot,
-          tasks: upsertTask(snapshot.tasks, task),
+          tasks: upsertTask(snapshot.tasks, task, options),
         },
       },
     },
@@ -77,14 +96,21 @@ function upsertTaskInBothKanbans(
   }
 
   const nextTask = toKanbanTask(payload);
+  const mergeOptions = {
+    preservePrimarySessionId: !hasPayloadField(payload, "primary_session_id"),
+    preservePrimarySessionState: !hasPayloadField(payload, "primary_session_state"),
+  };
   let next = state;
 
   if (state.kanban.workflowId === wfId) {
-    next = { ...next, kanban: { ...next.kanban, tasks: upsertTask(next.kanban.tasks, nextTask) } };
+    next = {
+      ...next,
+      kanban: { ...next.kanban, tasks: upsertTask(next.kanban.tasks, nextTask, mergeOptions) },
+    };
   }
 
   if (state.kanbanMulti.snapshots[wfId]) {
-    next = upsertMultiTask(next, wfId, nextTask);
+    next = upsertMultiTask(next, wfId, nextTask, mergeOptions);
   }
 
   return next;

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -122,7 +122,7 @@ function taskPrimaryStateForLog(task: KanbanTask | undefined): string {
   return task?.primarySessionState ?? "-";
 }
 
-function didPreservePrimaryState(
+export function didPreservePrimaryState(
   payload: TaskEventPayload,
   beforeTask: KanbanTask | undefined,
   afterTask: KanbanTask | undefined,
@@ -228,7 +228,10 @@ function redirectAwayFromRemovedTask(taskId: string): void {
 }
 
 type TaskUpdatedMessage = Parameters<NonNullable<WsHandlers["task.updated"]>>[0];
+type TaskCreatedMessage = Parameters<NonNullable<WsHandlers["task.created"]>>[0];
 type TaskStateChangedMessage = Parameters<NonNullable<WsHandlers["task.state_changed"]>>[0];
+type TaskUpsertMessage = TaskCreatedMessage | TaskStateChangedMessage;
+type TaskUpsertAction = "task.created" | "task.state_changed";
 
 function handleTaskUpdated(store: StoreApi<AppState>, message: TaskUpdatedMessage): void {
   // Skip ephemeral tasks (e.g., quick chat) - they shouldn't appear on the Kanban board
@@ -292,7 +295,11 @@ function handleTaskUpdated(store: StoreApi<AppState>, message: TaskUpdatedMessag
   }
 }
 
-function handleTaskStateChanged(store: StoreApi<AppState>, message: TaskStateChangedMessage): void {
+function handleTaskUpsert(
+  action: TaskUpsertAction,
+  store: StoreApi<AppState>,
+  message: TaskUpsertMessage,
+): void {
   // Skip ephemeral tasks (e.g., quick chat) - they shouldn't appear on the Kanban board
   if (message.payload.is_ephemeral) return;
 
@@ -300,19 +307,13 @@ function handleTaskStateChanged(store: StoreApi<AppState>, message: TaskStateCha
   store.setState((state) =>
     upsertTaskInBothKanbans(state, message.payload.workflow_id, message.payload),
   );
-  logTaskMerge("task.state_changed", beforeState, store.getState(), message.payload);
+  logTaskMerge(action, beforeState, store.getState(), message.payload);
 }
 
 export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
     "task.created": (message) => {
-      // Skip ephemeral tasks (e.g., quick chat) - they shouldn't appear on the Kanban board
-      if (message.payload.is_ephemeral) return;
-      const beforeState = store.getState();
-      store.setState((state) =>
-        upsertTaskInBothKanbans(state, message.payload.workflow_id, message.payload),
-      );
-      logTaskMerge("task.created", beforeState, store.getState(), message.payload);
+      handleTaskUpsert("task.created", store, message);
     },
     "task.updated": (message) => handleTaskUpdated(store, message),
     "task.deleted": (message) => {
@@ -376,7 +377,7 @@ export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
       }
     },
     "task.state_changed": (message) => {
-      handleTaskStateChanged(store, message);
+      handleTaskUpsert("task.state_changed", store, message);
     },
   };
 }

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -21,10 +21,15 @@ const lifecycleDebug = createDebugLogger("task-lifecycle:ws");
 
 function mergeTaskUpdate(existing: KanbanTask | undefined, nextTask: KanbanTask): KanbanTask {
   if (!existing) return nextTask;
-  return {
+  const merged = {
     ...nextTask,
     ...mergeTaskRepositoryFields(existing, nextTask),
   };
+  if (nextTask.primarySessionId === undefined) merged.primarySessionId = existing.primarySessionId;
+  if (nextTask.primarySessionState === undefined) {
+    merged.primarySessionState = existing.primarySessionState;
+  }
+  return merged;
 }
 
 function upsertTask(tasks: KanbanTask[], nextTask: KanbanTask): KanbanTask[] {

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -1,4 +1,5 @@
 import type { StoreApi } from "zustand";
+import { createDebugLogger, isDebug } from "@/lib/debug/log";
 import type { AppState } from "@/lib/state/store";
 import type { WsHandlers } from "@/lib/ws/handlers/types";
 import type { KanbanState } from "@/lib/state/slices/kanban/types";
@@ -16,6 +17,7 @@ import {
 } from "@/lib/ws/handlers/agent-session";
 
 type KanbanTask = KanbanState["tasks"][number];
+const lifecycleDebug = createDebugLogger("task-lifecycle:ws");
 
 function mergeTaskUpdate(existing: KanbanTask | undefined, nextTask: KanbanTask): KanbanTask {
   if (!existing) return nextTask;
@@ -94,6 +96,61 @@ function findTaskInState(state: AppState, taskId: string): KanbanTask | undefine
   return undefined;
 }
 
+function taskEventIdForLog(payload: TaskEventPayload): string {
+  return payload.task_id ?? payload.id ?? "";
+}
+
+function valueForLog(value: string | null | undefined): string {
+  return value ?? "-";
+}
+
+function payloadPrimaryStateForLog(payload: TaskEventPayload): string {
+  if (payload.primary_session_state === undefined) return "-";
+  return payload.primary_session_state ?? "null";
+}
+
+function taskStateForLog(task: KanbanTask | undefined): string {
+  return task?.state ?? "-";
+}
+
+function taskPrimaryStateForLog(task: KanbanTask | undefined): string {
+  return task?.primarySessionState ?? "-";
+}
+
+function didPreservePrimaryState(
+  payload: TaskEventPayload,
+  beforeTask: KanbanTask | undefined,
+  afterTask: KanbanTask | undefined,
+): boolean {
+  if (payload.primary_session_state !== undefined) return false;
+  const previousPrimaryState = beforeTask?.primarySessionState;
+  if (previousPrimaryState === undefined) return false;
+  return previousPrimaryState === afterTask?.primarySessionState;
+}
+
+function logTaskMerge(
+  action: "task.created" | "task.updated" | "task.state_changed",
+  beforeState: AppState,
+  afterState: AppState,
+  payload: TaskEventPayload,
+): void {
+  if (!isDebug()) return;
+  const taskId = taskEventIdForLog(payload);
+  const beforeTask = findTaskInState(beforeState, taskId);
+  const afterTask = findTaskInState(afterState, taskId);
+  lifecycleDebug(`${action} merge`, {
+    task_id: taskId,
+    payloadState: valueForLog(payload.state),
+    payloadPrimarySessionId: valueForLog(payload.primary_session_id),
+    payloadPrimarySessionState: payloadPrimaryStateForLog(payload),
+    beforeTaskState: taskStateForLog(beforeTask),
+    beforeTaskPrimaryState: taskPrimaryStateForLog(beforeTask),
+    afterTaskState: taskStateForLog(afterTask),
+    afterTaskPrimaryState: taskPrimaryStateForLog(afterTask),
+    preservedPrimaryState: didPreservePrimaryState(payload, beforeTask, afterTask),
+  });
+}
+
 /** Remove a task from both single-kanban and multi-kanban snapshots. */
 function removeTaskFromBothKanbans(state: AppState, taskId: string): AppState {
   let next = state;
@@ -166,6 +223,7 @@ function redirectAwayFromRemovedTask(taskId: string): void {
 }
 
 type TaskUpdatedMessage = Parameters<NonNullable<WsHandlers["task.updated"]>>[0];
+type TaskStateChangedMessage = Parameters<NonNullable<WsHandlers["task.state_changed"]>>[0];
 
 function handleTaskUpdated(store: StoreApi<AppState>, message: TaskUpdatedMessage): void {
   // Skip ephemeral tasks (e.g., quick chat) - they shouldn't appear on the Kanban board
@@ -215,6 +273,7 @@ function handleTaskUpdated(store: StoreApi<AppState>, message: TaskUpdatedMessag
   // This makes workflow profile switches transparent for unpinned users
   // without yanking users off a live session they deliberately selected.
   const afterState = store.getState();
+  logTaskMerge("task.updated", beforeState, afterState, message.payload);
   const newPrimary = findTaskInState(afterState, taskId)?.primarySessionId ?? null;
   if (
     newPrimary &&
@@ -228,14 +287,27 @@ function handleTaskUpdated(store: StoreApi<AppState>, message: TaskUpdatedMessag
   }
 }
 
+function handleTaskStateChanged(store: StoreApi<AppState>, message: TaskStateChangedMessage): void {
+  // Skip ephemeral tasks (e.g., quick chat) - they shouldn't appear on the Kanban board
+  if (message.payload.is_ephemeral) return;
+
+  const beforeState = store.getState();
+  store.setState((state) =>
+    upsertTaskInBothKanbans(state, message.payload.workflow_id, message.payload),
+  );
+  logTaskMerge("task.state_changed", beforeState, store.getState(), message.payload);
+}
+
 export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
   return {
     "task.created": (message) => {
       // Skip ephemeral tasks (e.g., quick chat) - they shouldn't appear on the Kanban board
       if (message.payload.is_ephemeral) return;
+      const beforeState = store.getState();
       store.setState((state) =>
         upsertTaskInBothKanbans(state, message.payload.workflow_id, message.payload),
       );
+      logTaskMerge("task.created", beforeState, store.getState(), message.payload);
     },
     "task.updated": (message) => handleTaskUpdated(store, message),
     "task.deleted": (message) => {
@@ -299,12 +371,7 @@ export function registerTasksHandlers(store: StoreApi<AppState>): WsHandlers {
       }
     },
     "task.state_changed": (message) => {
-      // Skip ephemeral tasks (e.g., quick chat) - they shouldn't appear on the Kanban board
-      if (message.payload.is_ephemeral) return;
-
-      store.setState((state) =>
-        upsertTaskInBothKanbans(state, message.payload.workflow_id, message.payload),
-      );
+      handleTaskStateChanged(store, message);
     },
   };
 }

--- a/apps/web/lib/ws/handlers/tasks.ts
+++ b/apps/web/lib/ws/handlers/tasks.ts
@@ -26,17 +26,20 @@ function hasPayloadField(payload: TaskEventPayload, field: keyof TaskEventPayloa
 function mergeTaskUpdate(
   existing: KanbanTask | undefined,
   nextTask: KanbanTask,
-  options: { preservePrimarySessionId: boolean; preservePrimarySessionState: boolean },
+  payload: TaskEventPayload,
 ): KanbanTask {
   if (!existing) return nextTask;
   const merged = {
     ...nextTask,
     ...mergeTaskRepositoryFields(existing, nextTask),
   };
-  if (options.preservePrimarySessionId && nextTask.primarySessionId === undefined) {
+  if (!hasPayloadField(payload, "primary_session_id") && nextTask.primarySessionId === undefined) {
     merged.primarySessionId = existing.primarySessionId;
   }
-  if (options.preservePrimarySessionState && nextTask.primarySessionState === undefined) {
+  if (
+    !hasPayloadField(payload, "primary_session_state") &&
+    nextTask.primarySessionState === undefined
+  ) {
     merged.primarySessionState = existing.primarySessionState;
   }
   return merged;
@@ -45,10 +48,10 @@ function mergeTaskUpdate(
 function upsertTask(
   tasks: KanbanTask[],
   nextTask: KanbanTask,
-  options: { preservePrimarySessionId: boolean; preservePrimarySessionState: boolean },
+  payload: TaskEventPayload,
 ): KanbanTask[] {
   const existing = tasks.find((task) => task.id === nextTask.id);
-  const merged = mergeTaskUpdate(existing, nextTask, options);
+  const merged = mergeTaskUpdate(existing, nextTask, payload);
   return existing
     ? tasks.map((task) => (task.id === nextTask.id ? merged : task))
     : [...tasks, merged];
@@ -58,7 +61,7 @@ function upsertMultiTask(
   state: AppState,
   workflowId: string,
   task: KanbanTask,
-  options: { preservePrimarySessionId: boolean; preservePrimarySessionState: boolean },
+  payload: TaskEventPayload,
 ): AppState {
   const snapshot = state.kanbanMulti.snapshots[workflowId];
   if (!snapshot) return state;
@@ -70,7 +73,7 @@ function upsertMultiTask(
         ...state.kanbanMulti.snapshots,
         [workflowId]: {
           ...snapshot,
-          tasks: upsertTask(snapshot.tasks, task, options),
+          tasks: upsertTask(snapshot.tasks, task, payload),
         },
       },
     },
@@ -96,21 +99,17 @@ function upsertTaskInBothKanbans(
   }
 
   const nextTask = toKanbanTask(payload);
-  const mergeOptions = {
-    preservePrimarySessionId: !hasPayloadField(payload, "primary_session_id"),
-    preservePrimarySessionState: !hasPayloadField(payload, "primary_session_state"),
-  };
   let next = state;
 
   if (state.kanban.workflowId === wfId) {
     next = {
       ...next,
-      kanban: { ...next.kanban, tasks: upsertTask(next.kanban.tasks, nextTask, mergeOptions) },
+      kanban: { ...next.kanban, tasks: upsertTask(next.kanban.tasks, nextTask, payload) },
     };
   }
 
   if (state.kanbanMulti.snapshots[wfId]) {
-    next = upsertMultiTask(next, wfId, nextTask, mergeOptions);
+    next = upsertMultiTask(next, wfId, nextTask, payload);
   }
 
   return next;


### PR DESCRIPTION
The previous kanban/sidebar spinner disagreement was hard to diagnose after the fact, so this adds targeted lifecycle logs across task event publishing, websocket delivery, and frontend cache merges. The logs identify whether stale primary session state came from the backend payload, websocket broadcast, or client-side kanban cache.

## Important Changes

- Added frontend debug namespaces for task lifecycle websocket merges and kanban spinner mismatches.
- Added backend info logs for task lifecycle event publishing and websocket broadcast fan-out.
- Documented the new frontend debug namespaces in the existing debug logger cheat sheet.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->