### PR TITLE
feat: scope GitHub integration settings by workspace

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1017,16 +1017,21 @@ func (m *Manager) RecoverAgentPromptStream(ctx context.Context, sessionID string
 		return fmt.Errorf("agent stream not connected")
 	}
 	if execution.Status == v1.AgentStatusFailed && execution.sessionInitialized && execution.ACPSessionID != "" {
-		status, err := execution.agentctl.GetStatus(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to verify agent status after stream recovery: %w", err)
-		}
-		if !status.IsAgentRunning() {
-			return fmt.Errorf("agent process is not running after stream recovery: %s", status.AgentStatus)
-		}
-		if err := m.markBootReadyFromFailed(ctx, execution.ID); err != nil {
-			return err
-		}
+		return m.restoreRecoveredFailedExecution(ctx, execution)
+	}
+	return nil
+}
+
+func (m *Manager) restoreRecoveredFailedExecution(ctx context.Context, execution *AgentExecution) error {
+	status, err := execution.agentctl.GetStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to verify agent status after stream recovery: %w", err)
+	}
+	if !status.IsAgentRunning() {
+		return fmt.Errorf("agent process is not running after stream recovery: %s", status.AgentStatus)
+	}
+	if err := m.markBootReadyFromFailed(ctx, execution.ID); err != nil {
+		return err
 	}
 	return nil
 }

--- a/apps/backend/internal/backendapp/e2e_reset.go
+++ b/apps/backend/internal/backendapp/e2e_reset.go
@@ -82,6 +82,9 @@ func handleE2EReset(
 		if _, err := repo.DB().ExecContext(ctx, `DELETE FROM runtime_flag_overrides`); err != nil {
 			log.Warn("e2e reset: runtime flag override cleanup failed", zap.Error(err))
 		}
+		if _, err := repo.DB().ExecContext(ctx, `DELETE FROM github_workspace_settings WHERE workspace_id = ?`, workspaceID); err != nil {
+			log.Warn("e2e reset: GitHub workspace settings cleanup failed", zap.Error(err))
+		}
 
 		// Reset every agent's routing override to the inherit-markers
 		// shape onboarding writes. Without this, an agent-override test

--- a/apps/backend/internal/github/controller.go
+++ b/apps/backend/internal/github/controller.go
@@ -1025,12 +1025,17 @@ func (c *Controller) httpDeleteIssueWatch(ctx *gin.Context) {
 
 func (c *Controller) httpTriggerIssueWatch(ctx *gin.Context) {
 	id := ctx.Param("id")
+	workspaceID := ctx.Query("workspace_id")
+	if workspaceID == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "workspace_id query parameter required"})
+		return
+	}
 	watch, err := c.service.GetIssueWatch(ctx.Request.Context(), id)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if watch == nil {
+	if watch == nil || watch.WorkspaceID != workspaceID {
 		ctx.JSON(http.StatusNotFound, gin.H{"error": "issue watch not found"})
 		return
 	}

--- a/apps/backend/internal/github/controller.go
+++ b/apps/backend/internal/github/controller.go
@@ -882,7 +882,11 @@ func (c *Controller) httpUpdateWorkspaceSettings(ctx *gin.Context) {
 	}
 	settings, err := c.service.UpdateWorkspaceSettings(ctx.Request.Context(), &req)
 	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		if errors.Is(err, ErrWorkspaceSettingsValidation) {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		}
 		return
 	}
 	ctx.JSON(http.StatusOK, settings)

--- a/apps/backend/internal/github/controller.go
+++ b/apps/backend/internal/github/controller.go
@@ -90,6 +90,8 @@ func (c *Controller) RegisterHTTPRoutes(router *gin.Engine) {
 	api.GET("/action-presets", c.httpGetActionPresets)
 	api.PUT("/action-presets", c.httpUpdateActionPresets)
 	api.POST("/action-presets/reset", c.httpResetActionPresets)
+	api.GET("/workspace-settings", c.httpGetWorkspaceSettings)
+	api.PUT("/workspace-settings", c.httpUpdateWorkspaceSettings)
 
 	api.GET("/stats", c.httpGetStats)
 }
@@ -812,8 +814,17 @@ func (c *Controller) httpGetRepoMergeMethods(ctx *gin.Context) {
 func (c *Controller) httpSearchUserPRs(ctx *gin.Context) {
 	query := ctx.Query("query")
 	filter := ctx.Query("filter")
+	workspaceID := ctx.Query("workspace_id")
 	page, perPage := parsePaginationQuery(ctx)
-	result, err := c.service.SearchUserPRsPaged(ctx.Request.Context(), filter, query, page, perPage)
+	var (
+		result *PRSearchPage
+		err    error
+	)
+	if workspaceID == "" {
+		result, err = c.service.SearchUserPRsPaged(ctx.Request.Context(), filter, query, page, perPage)
+	} else {
+		result, err = c.service.SearchUserPRsPagedForWorkspace(ctx.Request.Context(), workspaceID, filter, query, page, perPage)
+	}
 	if err != nil {
 		c.handleSearchError(ctx, err)
 		return
@@ -828,8 +839,17 @@ func (c *Controller) httpSearchUserPRs(ctx *gin.Context) {
 func (c *Controller) httpSearchUserIssues(ctx *gin.Context) {
 	query := ctx.Query("query")
 	filter := ctx.Query("filter")
+	workspaceID := ctx.Query("workspace_id")
 	page, perPage := parsePaginationQuery(ctx)
-	result, err := c.service.SearchUserIssuesPaged(ctx.Request.Context(), filter, query, page, perPage)
+	var (
+		result *IssueSearchPage
+		err    error
+	)
+	if workspaceID == "" {
+		result, err = c.service.SearchUserIssuesPaged(ctx.Request.Context(), filter, query, page, perPage)
+	} else {
+		result, err = c.service.SearchUserIssuesPagedForWorkspace(ctx.Request.Context(), workspaceID, filter, query, page, perPage)
+	}
 	if err != nil {
 		c.handleSearchError(ctx, err)
 		return
@@ -838,6 +858,34 @@ func (c *Controller) httpSearchUserIssues(ctx *gin.Context) {
 		result.Issues = []*Issue{}
 	}
 	ctx.JSON(http.StatusOK, result)
+}
+
+func (c *Controller) httpGetWorkspaceSettings(ctx *gin.Context) {
+	workspaceID := ctx.Query("workspace_id")
+	if strings.TrimSpace(workspaceID) == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "workspace_id query parameter required"})
+		return
+	}
+	settings, err := c.service.GetWorkspaceSettings(ctx.Request.Context(), workspaceID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, settings)
+}
+
+func (c *Controller) httpUpdateWorkspaceSettings(ctx *gin.Context) {
+	var req UpdateWorkspaceSettingsRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+		return
+	}
+	settings, err := c.service.UpdateWorkspaceSettings(ctx.Request.Context(), &req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, settings)
 }
 
 // parsePaginationQuery reads `page` and `per_page` query params. Missing or

--- a/apps/backend/internal/github/controller.go
+++ b/apps/backend/internal/github/controller.go
@@ -618,6 +618,9 @@ func (c *Controller) httpCreateReviewWatch(ctx *gin.Context) {
 
 func (c *Controller) httpUpdateReviewWatch(ctx *gin.Context) {
 	id := ctx.Param("id")
+	if !c.requireReviewWatchInWorkspace(ctx, id) {
+		return
+	}
 	var req UpdateReviewWatchRequest
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
@@ -632,6 +635,9 @@ func (c *Controller) httpUpdateReviewWatch(ctx *gin.Context) {
 
 func (c *Controller) httpDeleteReviewWatch(ctx *gin.Context) {
 	id := ctx.Param("id")
+	if !c.requireReviewWatchInWorkspace(ctx, id) {
+		return
+	}
 	if err := c.service.DeleteReviewWatch(ctx.Request.Context(), id); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -997,6 +1003,9 @@ func (c *Controller) httpCreateIssueWatch(ctx *gin.Context) {
 
 func (c *Controller) httpUpdateIssueWatch(ctx *gin.Context) {
 	id := ctx.Param("id")
+	if !c.requireIssueWatchInWorkspace(ctx, id) {
+		return
+	}
 	var req UpdateIssueWatchRequest
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
@@ -1016,6 +1025,9 @@ func (c *Controller) httpUpdateIssueWatch(ctx *gin.Context) {
 
 func (c *Controller) httpDeleteIssueWatch(ctx *gin.Context) {
 	id := ctx.Param("id")
+	if !c.requireIssueWatchInWorkspace(ctx, id) {
+		return
+	}
 	if err := c.service.DeleteIssueWatch(ctx.Request.Context(), id); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -1129,7 +1141,16 @@ func (c *Controller) httpResetActionPresets(ctx *gin.Context) {
 // watch lived in a workspace they no longer have open. A future
 // multi-tenant rollout would add an optional workspace_id query param.
 func (c *Controller) httpCleanupReviewTasks(ctx *gin.Context) {
-	deleted, err := c.service.CleanupAllReviewTasks(ctx.Request.Context())
+	workspaceID := ctx.Query("workspace_id")
+	var (
+		deleted int
+		err     error
+	)
+	if workspaceID == "" {
+		deleted, err = c.service.CleanupAllReviewTasks(ctx.Request.Context())
+	} else {
+		deleted, err = c.service.CleanupReviewTasksForWorkspace(ctx.Request.Context(), workspaceID)
+	}
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -1139,7 +1160,16 @@ func (c *Controller) httpCleanupReviewTasks(ctx *gin.Context) {
 
 // httpCleanupIssueTasks mirrors httpCleanupReviewTasks for issue watches.
 func (c *Controller) httpCleanupIssueTasks(ctx *gin.Context) {
-	deleted, err := c.service.CleanupAllIssueTasks(ctx.Request.Context())
+	workspaceID := ctx.Query("workspace_id")
+	var (
+		deleted int
+		err     error
+	)
+	if workspaceID == "" {
+		deleted, err = c.service.CleanupAllIssueTasks(ctx.Request.Context())
+	} else {
+		deleted, err = c.service.CleanupIssueTasksForWorkspace(ctx.Request.Context(), workspaceID)
+	}
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/apps/backend/internal/github/handlers.go
+++ b/apps/backend/internal/github/handlers.go
@@ -484,11 +484,15 @@ func wsTriggerIssueWatch(svc *Service, log *logger.Logger) func(ctx context.Cont
 		if id == "" {
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, errMsgIDRequired, nil)
 		}
+		workspaceID, _ := payload["workspace_id"].(string)
+		if workspaceID == "" {
+			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeBadRequest, "workspace_id is required", nil)
+		}
 		watch, err := svc.GetIssueWatch(ctx, id)
 		if err != nil {
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeInternalError, err.Error(), nil)
 		}
-		if watch == nil {
+		if watch == nil || watch.WorkspaceID != workspaceID {
 			return ws.NewError(msg.ID, msg.Action, ws.ErrorCodeNotFound, "issue watch not found", nil)
 		}
 		newIssues, err := svc.CheckIssueWatch(ctx, watch)

--- a/apps/backend/internal/github/models.go
+++ b/apps/backend/internal/github/models.go
@@ -665,6 +665,40 @@ type UpdateWorkspaceSettingsRequest struct {
 	RepoScopeRepos      *[]RepoFilter    `json:"repo_scope_repos,omitempty"`
 	SavedPresets        *json.RawMessage `json:"saved_presets,omitempty"`
 	DefaultQueryPresets *json.RawMessage `json:"default_query_presets,omitempty"`
+	SavedPresetsSet     bool             `json:"-"`
+	DefaultQueriesSet   bool             `json:"-"`
+}
+
+func (r *UpdateWorkspaceSettingsRequest) UnmarshalJSON(data []byte) error {
+	type alias UpdateWorkspaceSettingsRequest
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*r = UpdateWorkspaceSettingsRequest(decoded)
+	if value, ok := raw["saved_presets"]; ok {
+		r.SavedPresetsSet = true
+		if string(value) == jsonNullLiteral {
+			r.SavedPresets = nil
+		} else {
+			next := cloneRawMessage(value)
+			r.SavedPresets = &next
+		}
+	}
+	if value, ok := raw["default_query_presets"]; ok {
+		r.DefaultQueriesSet = true
+		if string(value) == jsonNullLiteral {
+			r.DefaultQueryPresets = nil
+		} else {
+			next := cloneRawMessage(value)
+			r.DefaultQueryPresets = &next
+		}
+	}
+	return nil
 }
 
 // --- Action presets (quick-launch prompts on the /github page) ---

--- a/apps/backend/internal/github/models.go
+++ b/apps/backend/internal/github/models.go
@@ -2,7 +2,10 @@
 // review queue management, and CI/check status tracking.
 package github
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // TaskCIAutoFixMaxRounds is the server-enforced CI auto-fix loop guard.
 const TaskCIAutoFixMaxRounds = 10
@@ -626,6 +629,42 @@ type UpdateIssueWatchRequest struct {
 	Enabled             *bool         `json:"enabled,omitempty"`
 	PollIntervalSeconds *int          `json:"poll_interval_seconds,omitempty"`
 	CleanupPolicy       *string       `json:"cleanup_policy,omitempty"`
+}
+
+// --- Workspace GitHub scope/settings ---
+
+const (
+	RepoScopeModeAll   = "all"
+	RepoScopeModeOrgs  = "orgs"
+	RepoScopeModeRepos = "repos"
+)
+
+// WorkspaceSettings stores per-workspace GitHub operational settings.
+// Authentication remains install-wide; these settings scope GitHub UI/search
+// surfaces to the workspace's intended repositories.
+type WorkspaceSettings struct {
+	WorkspaceID         string          `json:"workspace_id" db:"workspace_id"`
+	RepoScopeMode       string          `json:"repo_scope_mode" db:"repo_scope_mode"`
+	RepoScopeOrgs       []string        `json:"repo_scope_orgs" db:"-"`
+	RepoScopeRepos      []RepoFilter    `json:"repo_scope_repos" db:"-"`
+	RepoScopeOrgsJSON   string          `json:"-" db:"repo_scope_orgs"`
+	RepoScopeReposJSON  string          `json:"-" db:"repo_scope_repos"`
+	SavedPresets        json.RawMessage `json:"saved_presets,omitempty" db:"saved_presets"`
+	DefaultQueryPresets json.RawMessage `json:"default_query_presets,omitempty" db:"default_query_presets"`
+	CreatedAt           time.Time       `json:"created_at" db:"created_at"`
+	UpdatedAt           time.Time       `json:"updated_at" db:"updated_at"`
+}
+
+// UpdateWorkspaceSettingsRequest replaces the workspace GitHub scope and/or
+// preference blobs. Nil blobs leave values unchanged; explicit JSON null clears
+// default query presets back to built-ins.
+type UpdateWorkspaceSettingsRequest struct {
+	WorkspaceID         string           `json:"workspace_id"`
+	RepoScopeMode       *string          `json:"repo_scope_mode,omitempty"`
+	RepoScopeOrgs       *[]string        `json:"repo_scope_orgs,omitempty"`
+	RepoScopeRepos      *[]RepoFilter    `json:"repo_scope_repos,omitempty"`
+	SavedPresets        *json.RawMessage `json:"saved_presets,omitempty"`
+	DefaultQueryPresets *json.RawMessage `json:"default_query_presets,omitempty"`
 }
 
 // --- Action presets (quick-launch prompts on the /github page) ---

--- a/apps/backend/internal/github/service_cleanup.go
+++ b/apps/backend/internal/github/service_cleanup.go
@@ -40,6 +40,41 @@ func (s *Service) CleanupAllReviewTasks(ctx context.Context) (int, error) {
 	return s.cleanupAllReviewTasks(ctx, false)
 }
 
+// CleanupReviewTasksForWorkspace sweeps review dedup rows owned by watches in
+// one workspace. Rows for deleted watches are intentionally skipped because
+// their workspace can no longer be proven.
+//
+//nolint:dupl // mirrors CleanupIssueTasksForWorkspace — different task/watch types
+func (s *Service) CleanupReviewTasksForWorkspace(ctx context.Context, workspaceID string) (int, error) {
+	if s.client == nil || s.taskDeleter == nil {
+		return 0, nil
+	}
+	watches, err := s.store.ListReviewWatches(ctx, workspaceID)
+	if err != nil {
+		return 0, fmt.Errorf("list review watches: %w", err)
+	}
+	watchPolicies := make(map[string]string, len(watches))
+	for _, watch := range watches {
+		watchPolicies[watch.ID] = NormalizeCleanupPolicy(watch.CleanupPolicy)
+	}
+	if len(watchPolicies) == 0 {
+		return 0, nil
+	}
+	prTasks, err := s.store.ListAllReviewPRTasks(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list all review PR tasks: %w", err)
+	}
+	candidates := make([]*ReviewPRTask, 0, len(prTasks))
+	for _, rpt := range prTasks {
+		if _, ok := watchPolicies[rpt.ReviewWatchID]; ok {
+			candidates = append(candidates, rpt)
+		}
+	}
+	return s.cleanupReviewPRTaskBatch(ctx, candidates, func(rpt *ReviewPRTask) string {
+		return watchPolicies[rpt.ReviewWatchID]
+	}), nil
+}
+
 // cleanupAllReviewTasks is the shared body. When orphansOnly is true, rows
 // whose watch is currently enabled are skipped (the per-watch poller will
 // handle them in the same cycle).
@@ -98,6 +133,8 @@ func (s *Service) cleanupAllReviewTasks(ctx context.Context, orphansOnly bool) (
 // retries the fetch and recovers naturally. Missing watches (deleted) are
 // distinct: they're absent from both `policy` and `enabled` but NOT in
 // `unknown`, so callers treat them as legitimate orphans.
+//
+//nolint:dupl // mirrors buildIssueWatchCaches — different task/watch types
 func (s *Service) buildReviewWatchCaches(ctx context.Context, prTasks []*ReviewPRTask) (policy map[string]string, enabled map[string]bool, unknown map[string]bool) {
 	seen := make(map[string]struct{})
 	for _, rpt := range prTasks {
@@ -324,6 +361,40 @@ func (s *Service) CleanupAllIssueTasks(ctx context.Context) (int, error) {
 	return s.cleanupAllIssueTasks(ctx, false)
 }
 
+// CleanupIssueTasksForWorkspace mirrors CleanupReviewTasksForWorkspace for
+// issue-watch dedup rows.
+//
+//nolint:dupl // mirrors CleanupReviewTasksForWorkspace — different task/watch types
+func (s *Service) CleanupIssueTasksForWorkspace(ctx context.Context, workspaceID string) (int, error) {
+	if s.client == nil || s.taskDeleter == nil {
+		return 0, nil
+	}
+	watches, err := s.store.ListIssueWatches(ctx, workspaceID)
+	if err != nil {
+		return 0, fmt.Errorf("list issue watches: %w", err)
+	}
+	watchPolicies := make(map[string]string, len(watches))
+	for _, watch := range watches {
+		watchPolicies[watch.ID] = NormalizeCleanupPolicy(watch.CleanupPolicy)
+	}
+	if len(watchPolicies) == 0 {
+		return 0, nil
+	}
+	issueTasks, err := s.store.ListAllIssueWatchTasks(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list all issue watch tasks: %w", err)
+	}
+	candidates := make([]*IssueWatchTask, 0, len(issueTasks))
+	for _, it := range issueTasks {
+		if _, ok := watchPolicies[it.IssueWatchID]; ok {
+			candidates = append(candidates, it)
+		}
+	}
+	return s.cleanupIssueTaskBatch(ctx, candidates, func(it *IssueWatchTask) string {
+		return watchPolicies[it.IssueWatchID]
+	}), nil
+}
+
 //nolint:dupl // mirrors cleanupAllReviewTasks — different types, same orchestration
 func (s *Service) cleanupAllIssueTasks(ctx context.Context, orphansOnly bool) (int, error) {
 	if s.client == nil || s.taskDeleter == nil {
@@ -358,6 +429,7 @@ func (s *Service) cleanupAllIssueTasks(ctx context.Context, orphansOnly bool) (i
 	}), nil
 }
 
+//nolint:dupl // mirrors buildReviewWatchCaches — different task/watch types
 func (s *Service) buildIssueWatchCaches(ctx context.Context, issueTasks []*IssueWatchTask) (policy map[string]string, enabled map[string]bool, unknown map[string]bool) {
 	seen := make(map[string]struct{})
 	for _, it := range issueTasks {

--- a/apps/backend/internal/github/service_issues.go
+++ b/apps/backend/internal/github/service_issues.go
@@ -196,6 +196,11 @@ func (s *Service) CheckIssueWatch(ctx context.Context, watch *IssueWatch) ([]*Is
 	if err != nil {
 		return nil, err
 	}
+	settings, settingsErr := s.GetWorkspaceSettings(ctx, watch.WorkspaceID)
+	if settingsErr != nil {
+		return nil, settingsErr
+	}
+	issues = filterIssuesByWorkspaceScope(issues, settings)
 
 	var newIssues []*Issue
 	for _, issue := range issues {

--- a/apps/backend/internal/github/service_issues.go
+++ b/apps/backend/internal/github/service_issues.go
@@ -196,6 +196,9 @@ func (s *Service) CheckIssueWatch(ctx context.Context, watch *IssueWatch) ([]*Is
 	if settingsErr != nil {
 		return nil, settingsErr
 	}
+	if len(watch.Repos) == 0 && workspaceSettingsHasEmptyScope(settings) {
+		return nil, nil
+	}
 	fetchWatch := *watch
 	if len(fetchWatch.Repos) == 0 {
 		fetchWatch.Repos = workspaceScopeRepoFilters(settings)

--- a/apps/backend/internal/github/service_issues.go
+++ b/apps/backend/internal/github/service_issues.go
@@ -192,13 +192,17 @@ func (s *Service) CheckIssueWatch(ctx context.Context, watch *IssueWatch) ([]*Is
 		zap.String("custom_query", watch.CustomQuery),
 		zap.Bool("enabled", watch.Enabled))
 
-	issues, err := s.fetchIssues(ctx, watch)
-	if err != nil {
-		return nil, err
-	}
 	settings, settingsErr := s.GetWorkspaceSettings(ctx, watch.WorkspaceID)
 	if settingsErr != nil {
 		return nil, settingsErr
+	}
+	fetchWatch := *watch
+	if len(fetchWatch.Repos) == 0 {
+		fetchWatch.Repos = workspaceScopeRepoFilters(settings)
+	}
+	issues, err := s.fetchIssues(ctx, &fetchWatch)
+	if err != nil {
+		return nil, err
 	}
 	issues = filterIssuesByWorkspaceScope(issues, settings)
 

--- a/apps/backend/internal/github/service_reviews.go
+++ b/apps/backend/internal/github/service_reviews.go
@@ -223,6 +223,9 @@ func (s *Service) CheckReviewWatch(ctx context.Context, watch *ReviewWatch) ([]*
 	if settingsErr != nil {
 		return nil, settingsErr
 	}
+	if len(watch.Repos) == 0 && workspaceSettingsHasEmptyScope(settings) {
+		return nil, nil
+	}
 	fetchWatch := *watch
 	if len(fetchWatch.Repos) == 0 {
 		fetchWatch.Repos = workspaceScopeRepoFilters(settings)

--- a/apps/backend/internal/github/service_reviews.go
+++ b/apps/backend/internal/github/service_reviews.go
@@ -219,13 +219,17 @@ func (s *Service) CheckReviewWatch(ctx context.Context, watch *ReviewWatch) ([]*
 		zap.String("review_scope", watch.ReviewScope),
 		zap.Bool("enabled", watch.Enabled))
 
-	prs, err := s.fetchReviewPRs(ctx, watch)
-	if err != nil {
-		return nil, err
-	}
 	settings, settingsErr := s.GetWorkspaceSettings(ctx, watch.WorkspaceID)
 	if settingsErr != nil {
 		return nil, settingsErr
+	}
+	fetchWatch := *watch
+	if len(fetchWatch.Repos) == 0 {
+		fetchWatch.Repos = workspaceScopeRepoFilters(settings)
+	}
+	prs, err := s.fetchReviewPRs(ctx, &fetchWatch)
+	if err != nil {
+		return nil, err
 	}
 	prs = filterPRsByWorkspaceScope(prs, settings)
 

--- a/apps/backend/internal/github/service_reviews.go
+++ b/apps/backend/internal/github/service_reviews.go
@@ -223,6 +223,11 @@ func (s *Service) CheckReviewWatch(ctx context.Context, watch *ReviewWatch) ([]*
 	if err != nil {
 		return nil, err
 	}
+	settings, settingsErr := s.GetWorkspaceSettings(ctx, watch.WorkspaceID)
+	if settingsErr != nil {
+		return nil, settingsErr
+	}
+	prs = filterPRsByWorkspaceScope(prs, settings)
 
 	s.logger.Debug("fetched review-requested PRs",
 		zap.String("watch_id", watch.ID),

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -162,6 +162,17 @@ const createTablesSQL = `
 		updated_at DATETIME NOT NULL
 	);
 
+	CREATE TABLE IF NOT EXISTS github_workspace_settings (
+		workspace_id TEXT PRIMARY KEY,
+		repo_scope_mode TEXT NOT NULL DEFAULT 'all',
+		repo_scope_orgs TEXT NOT NULL DEFAULT '[]',
+		repo_scope_repos TEXT NOT NULL DEFAULT '[]',
+		saved_presets TEXT NOT NULL DEFAULT '[]',
+		default_query_presets TEXT,
+		created_at DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL
+	);
+
 	CREATE TABLE IF NOT EXISTS github_task_ci_options (
 		task_id TEXT PRIMARY KEY,
 		auto_fix_enabled BOOLEAN NOT NULL DEFAULT 0,
@@ -1935,6 +1946,177 @@ func (s *Store) ResetIssueWatchState(ctx context.Context, watchID string) error 
 		return err
 	}
 	return tx.Commit()
+}
+
+// --- Workspace settings operations ---
+
+func defaultWorkspaceSettings(workspaceID string) *WorkspaceSettings {
+	return &WorkspaceSettings{
+		WorkspaceID:         workspaceID,
+		RepoScopeMode:       RepoScopeModeAll,
+		RepoScopeOrgs:       []string{},
+		RepoScopeRepos:      []RepoFilter{},
+		SavedPresets:        json.RawMessage("[]"),
+		DefaultQueryPresets: nil,
+	}
+}
+
+func cloneRawMessage(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]byte, len(raw))
+	copy(out, raw)
+	return out
+}
+
+func normalizeRepoScopeMode(mode string) string {
+	mode = strings.TrimSpace(strings.ToLower(mode))
+	switch mode {
+	case RepoScopeModeOrgs, RepoScopeModeRepos:
+		return mode
+	default:
+		return RepoScopeModeAll
+	}
+}
+
+func normalizeWorkspaceSettings(settings *WorkspaceSettings) *WorkspaceSettings {
+	if settings == nil {
+		return nil
+	}
+	out := *settings
+	out.WorkspaceID = strings.TrimSpace(out.WorkspaceID)
+	out.RepoScopeMode = normalizeRepoScopeMode(out.RepoScopeMode)
+	if out.RepoScopeMode != RepoScopeModeOrgs {
+		out.RepoScopeOrgs = nil
+	}
+	if out.RepoScopeMode != RepoScopeModeRepos {
+		out.RepoScopeRepos = nil
+	}
+	orgs := make([]string, 0, len(out.RepoScopeOrgs))
+	seenOrgs := make(map[string]struct{}, len(out.RepoScopeOrgs))
+	for _, org := range out.RepoScopeOrgs {
+		org = strings.TrimSpace(org)
+		if org == "" {
+			continue
+		}
+		key := strings.ToLower(org)
+		if _, ok := seenOrgs[key]; ok {
+			continue
+		}
+		seenOrgs[key] = struct{}{}
+		orgs = append(orgs, org)
+	}
+	out.RepoScopeOrgs = orgs
+	repos := make([]RepoFilter, 0, len(out.RepoScopeRepos))
+	seenRepos := make(map[string]struct{}, len(out.RepoScopeRepos))
+	for _, repo := range out.RepoScopeRepos {
+		owner := strings.TrimSpace(repo.Owner)
+		name := strings.TrimSpace(repo.Name)
+		if owner == "" || name == "" {
+			continue
+		}
+		key := strings.ToLower(owner + "/" + name)
+		if _, ok := seenRepos[key]; ok {
+			continue
+		}
+		seenRepos[key] = struct{}{}
+		repos = append(repos, RepoFilter{Owner: owner, Name: name})
+	}
+	out.RepoScopeRepos = repos
+	if len(out.SavedPresets) == 0 {
+		out.SavedPresets = json.RawMessage("[]")
+	} else {
+		out.SavedPresets = cloneRawMessage(out.SavedPresets)
+	}
+	out.DefaultQueryPresets = cloneRawMessage(out.DefaultQueryPresets)
+	return &out
+}
+
+// GetWorkspaceSettings returns per-workspace GitHub settings. Missing rows
+// resolve to the backwards-compatible All repos defaults.
+func (s *Store) GetWorkspaceSettings(ctx context.Context, workspaceID string) (*WorkspaceSettings, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return nil, fmt.Errorf("workspace_id is required")
+	}
+	var row struct {
+		WorkspaceID         string         `db:"workspace_id"`
+		RepoScopeMode       string         `db:"repo_scope_mode"`
+		RepoScopeOrgsJSON   string         `db:"repo_scope_orgs"`
+		RepoScopeReposJSON  string         `db:"repo_scope_repos"`
+		SavedPresets        string         `db:"saved_presets"`
+		DefaultQueryPresets sql.NullString `db:"default_query_presets"`
+		CreatedAt           time.Time      `db:"created_at"`
+		UpdatedAt           time.Time      `db:"updated_at"`
+	}
+	err := s.ro.GetContext(ctx, &row, `
+		SELECT workspace_id, repo_scope_mode, repo_scope_orgs, repo_scope_repos,
+		       saved_presets, default_query_presets, created_at, updated_at
+		FROM github_workspace_settings
+		WHERE workspace_id = ?`, workspaceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return defaultWorkspaceSettings(workspaceID), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	settings := &WorkspaceSettings{
+		WorkspaceID:        row.WorkspaceID,
+		RepoScopeMode:      row.RepoScopeMode,
+		RepoScopeOrgsJSON:  row.RepoScopeOrgsJSON,
+		RepoScopeReposJSON: row.RepoScopeReposJSON,
+		SavedPresets:       json.RawMessage(row.SavedPresets),
+		CreatedAt:          row.CreatedAt,
+		UpdatedAt:          row.UpdatedAt,
+	}
+	if row.DefaultQueryPresets.Valid {
+		settings.DefaultQueryPresets = json.RawMessage(row.DefaultQueryPresets.String)
+	}
+	if err := json.Unmarshal([]byte(row.RepoScopeOrgsJSON), &settings.RepoScopeOrgs); err != nil {
+		return nil, fmt.Errorf("unmarshal repo scope orgs: %w", err)
+	}
+	if err := json.Unmarshal([]byte(row.RepoScopeReposJSON), &settings.RepoScopeRepos); err != nil {
+		return nil, fmt.Errorf("unmarshal repo scope repos: %w", err)
+	}
+	return normalizeWorkspaceSettings(settings), nil
+}
+
+// UpsertWorkspaceSettings stores per-workspace GitHub settings.
+func (s *Store) UpsertWorkspaceSettings(ctx context.Context, settings *WorkspaceSettings) error {
+	settings = normalizeWorkspaceSettings(settings)
+	if settings == nil || settings.WorkspaceID == "" {
+		return fmt.Errorf("workspace_id is required")
+	}
+	orgsJSON, err := json.Marshal(settings.RepoScopeOrgs)
+	if err != nil {
+		return fmt.Errorf("marshal repo scope orgs: %w", err)
+	}
+	reposJSON, err := json.Marshal(settings.RepoScopeRepos)
+	if err != nil {
+		return fmt.Errorf("marshal repo scope repos: %w", err)
+	}
+	now := time.Now().UTC()
+	defaults := sql.NullString{}
+	if len(settings.DefaultQueryPresets) > 0 {
+		defaults.Valid = true
+		defaults.String = string(settings.DefaultQueryPresets)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO github_workspace_settings (
+			workspace_id, repo_scope_mode, repo_scope_orgs, repo_scope_repos,
+			saved_presets, default_query_presets, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(workspace_id) DO UPDATE SET
+			repo_scope_mode = excluded.repo_scope_mode,
+			repo_scope_orgs = excluded.repo_scope_orgs,
+			repo_scope_repos = excluded.repo_scope_repos,
+			saved_presets = excluded.saved_presets,
+			default_query_presets = excluded.default_query_presets,
+			updated_at = excluded.updated_at`,
+		settings.WorkspaceID, settings.RepoScopeMode, string(orgsJSON), string(reposJSON),
+		string(settings.SavedPresets), defaults, now, now)
+	return err
 }
 
 // --- Action preset operations ---

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -1951,6 +1951,7 @@ func (s *Store) ResetIssueWatchState(ctx context.Context, watchID string) error 
 // --- Workspace settings operations ---
 
 func defaultWorkspaceSettings(workspaceID string) *WorkspaceSettings {
+	now := time.Now().UTC()
 	return &WorkspaceSettings{
 		WorkspaceID:         workspaceID,
 		RepoScopeMode:       RepoScopeModeAll,
@@ -1958,6 +1959,8 @@ func defaultWorkspaceSettings(workspaceID string) *WorkspaceSettings {
 		RepoScopeRepos:      []RepoFilter{},
 		SavedPresets:        json.RawMessage("[]"),
 		DefaultQueryPresets: nil,
+		CreatedAt:           now,
+		UpdatedAt:           now,
 	}
 }
 

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -2203,13 +2203,15 @@ func validateWorkspaceScopePatch(req *UpdateWorkspaceSettingsRequest) error {
 		return nil
 	}
 	mode := normalizeRepoScopeMode(*req.RepoScopeMode)
-	if mode == RepoScopeModeAll && (req.RepoScopeOrgs != nil || req.RepoScopeRepos != nil) {
+	hasOrgs := req.RepoScopeOrgs != nil && len(*req.RepoScopeOrgs) > 0
+	hasRepos := req.RepoScopeRepos != nil && len(*req.RepoScopeRepos) > 0
+	if mode == RepoScopeModeAll && (hasOrgs || hasRepos) {
 		return fmt.Errorf("%w: repo_scope_mode all cannot be patched with repo scope filters", ErrWorkspaceSettingsValidation)
 	}
-	if mode == RepoScopeModeOrgs && req.RepoScopeRepos != nil {
+	if mode == RepoScopeModeOrgs && hasRepos {
 		return fmt.Errorf("%w: repo_scope_mode orgs cannot be patched with repo_scope_repos", ErrWorkspaceSettingsValidation)
 	}
-	if mode == RepoScopeModeRepos && req.RepoScopeOrgs != nil {
+	if mode == RepoScopeModeRepos && hasOrgs {
 		return fmt.Errorf("%w: repo_scope_mode repos cannot be patched with repo_scope_orgs", ErrWorkspaceSettingsValidation)
 	}
 	return nil

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -1970,6 +1970,8 @@ func cloneRawMessage(raw json.RawMessage) json.RawMessage {
 	return out
 }
 
+const maxWorkspaceSettingsJSONBytes = 64 * 1024
+
 func normalizeRepoScopeMode(mode string) string {
 	mode = strings.TrimSpace(strings.ToLower(mode))
 	switch mode {
@@ -2117,6 +2119,156 @@ func (s *Store) UpsertWorkspaceSettings(ctx context.Context, settings *Workspace
 		settings.WorkspaceID, settings.RepoScopeMode, string(orgsJSON), string(reposJSON),
 		string(settings.SavedPresets), defaults, now, now)
 	return err
+}
+
+// PatchWorkspaceSettings applies only the fields present in the request. This
+// avoids lost updates when independent preference migrations run concurrently.
+func (s *Store) PatchWorkspaceSettings(ctx context.Context, req *UpdateWorkspaceSettingsRequest) (*WorkspaceSettings, error) {
+	if req == nil || strings.TrimSpace(req.WorkspaceID) == "" {
+		return nil, fmt.Errorf("%w: workspace_id is required", ErrWorkspaceSettingsValidation)
+	}
+	workspaceID := strings.TrimSpace(req.WorkspaceID)
+	now := time.Now().UTC()
+	if _, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO github_workspace_settings (
+			workspace_id, repo_scope_mode, repo_scope_orgs, repo_scope_repos,
+			saved_presets, default_query_presets, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		workspaceID, RepoScopeModeAll, "[]", "[]", "[]", nil, now, now); err != nil {
+		return nil, err
+	}
+
+	patch := workspaceSettingsPatch{
+		sets: make([]string, 0, 8),
+		args: make([]any, 0, 10),
+	}
+	if err := appendWorkspaceScopePatch(&patch, req); err != nil {
+		return nil, err
+	}
+	if err := appendWorkspacePresetPatch(&patch, req); err != nil {
+		return nil, err
+	}
+	if len(patch.sets) > 0 {
+		patch.add("updated_at = ?", now)
+		patch.args = append(patch.args, workspaceID)
+		query := "UPDATE github_workspace_settings SET " + strings.Join(patch.sets, ", ") + " WHERE workspace_id = ?"
+		if _, err := s.db.ExecContext(ctx, query, patch.args...); err != nil {
+			return nil, err
+		}
+	}
+	return s.GetWorkspaceSettings(ctx, workspaceID)
+}
+
+type workspaceSettingsPatch struct {
+	sets []string
+	args []any
+}
+
+func (p *workspaceSettingsPatch) add(set string, arg any) {
+	p.sets = append(p.sets, set)
+	p.args = append(p.args, arg)
+}
+
+func appendWorkspaceScopePatch(patch *workspaceSettingsPatch, req *UpdateWorkspaceSettingsRequest) error {
+	if req.RepoScopeMode != nil {
+		if err := appendWorkspaceScopeModePatch(patch, *req.RepoScopeMode); err != nil {
+			return err
+		}
+	}
+	if req.RepoScopeOrgs != nil {
+		raw, err := marshalNormalizedRepoScopeOrgs(*req.RepoScopeOrgs)
+		if err != nil {
+			return err
+		}
+		patch.add("repo_scope_orgs = ?", string(raw))
+	}
+	if req.RepoScopeRepos != nil {
+		raw, err := marshalNormalizedRepoScopeRepos(*req.RepoScopeRepos)
+		if err != nil {
+			return err
+		}
+		patch.add("repo_scope_repos = ?", string(raw))
+	}
+	return nil
+}
+
+func appendWorkspaceScopeModePatch(patch *workspaceSettingsPatch, rawMode string) error {
+	if !isValidRepoScopeMode(rawMode) {
+		return fmt.Errorf("%w: invalid repo_scope_mode %q", ErrWorkspaceSettingsValidation, rawMode)
+	}
+	mode := normalizeRepoScopeMode(rawMode)
+	patch.add("repo_scope_mode = ?", mode)
+	switch mode {
+	case RepoScopeModeAll:
+		patch.add("repo_scope_orgs = ?", "[]")
+		patch.add("repo_scope_repos = ?", "[]")
+	case RepoScopeModeOrgs:
+		patch.add("repo_scope_repos = ?", "[]")
+	case RepoScopeModeRepos:
+		patch.add("repo_scope_orgs = ?", "[]")
+	}
+	return nil
+}
+
+func appendWorkspacePresetPatch(patch *workspaceSettingsPatch, req *UpdateWorkspaceSettingsRequest) error {
+	if req.SavedPresetsSet {
+		raw := json.RawMessage("[]")
+		if req.SavedPresets != nil {
+			raw = cloneRawMessage(*req.SavedPresets)
+		}
+		if err := validateWorkspaceSettingsJSON("saved_presets", raw, '['); err != nil {
+			return err
+		}
+		patch.add("saved_presets = ?", string(raw))
+	}
+	if !req.DefaultQueriesSet {
+		return nil
+	}
+	if req.DefaultQueryPresets == nil {
+		patch.add("default_query_presets = ?", sql.NullString{})
+		return nil
+	}
+	raw := cloneRawMessage(*req.DefaultQueryPresets)
+	if err := validateWorkspaceSettingsJSON("default_query_presets", raw, '{'); err != nil {
+		return err
+	}
+	patch.add("default_query_presets = ?", sql.NullString{String: string(raw), Valid: true})
+	return nil
+}
+
+func marshalNormalizedRepoScopeOrgs(orgs []string) ([]byte, error) {
+	settings := normalizeWorkspaceSettings(&WorkspaceSettings{
+		RepoScopeMode: RepoScopeModeOrgs,
+		RepoScopeOrgs: orgs,
+	})
+	raw, err := json.Marshal(settings.RepoScopeOrgs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal repo scope orgs: %w", err)
+	}
+	return raw, nil
+}
+
+func marshalNormalizedRepoScopeRepos(repos []RepoFilter) ([]byte, error) {
+	settings := normalizeWorkspaceSettings(&WorkspaceSettings{
+		RepoScopeMode:  RepoScopeModeRepos,
+		RepoScopeRepos: repos,
+	})
+	raw, err := json.Marshal(settings.RepoScopeRepos)
+	if err != nil {
+		return nil, fmt.Errorf("marshal repo scope repos: %w", err)
+	}
+	return raw, nil
+}
+
+func validateWorkspaceSettingsJSON(field string, raw json.RawMessage, wantFirst byte) error {
+	raw = json.RawMessage(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 || len(raw) > maxWorkspaceSettingsJSONBytes || !json.Valid(raw) {
+		return fmt.Errorf("%w: invalid %s", ErrWorkspaceSettingsValidation, field)
+	}
+	if raw[0] != wantFirst {
+		return fmt.Errorf("%w: invalid %s", ErrWorkspaceSettingsValidation, field)
+	}
+	return nil
 }
 
 // --- Action preset operations ---

--- a/apps/backend/internal/github/store.go
+++ b/apps/backend/internal/github/store.go
@@ -2173,6 +2173,9 @@ func (p *workspaceSettingsPatch) add(set string, arg any) {
 }
 
 func appendWorkspaceScopePatch(patch *workspaceSettingsPatch, req *UpdateWorkspaceSettingsRequest) error {
+	if err := validateWorkspaceScopePatch(req); err != nil {
+		return err
+	}
 	if req.RepoScopeMode != nil {
 		if err := appendWorkspaceScopeModePatch(patch, *req.RepoScopeMode); err != nil {
 			return err
@@ -2191,6 +2194,23 @@ func appendWorkspaceScopePatch(patch *workspaceSettingsPatch, req *UpdateWorkspa
 			return err
 		}
 		patch.add("repo_scope_repos = ?", string(raw))
+	}
+	return nil
+}
+
+func validateWorkspaceScopePatch(req *UpdateWorkspaceSettingsRequest) error {
+	if req.RepoScopeMode == nil {
+		return nil
+	}
+	mode := normalizeRepoScopeMode(*req.RepoScopeMode)
+	if mode == RepoScopeModeAll && (req.RepoScopeOrgs != nil || req.RepoScopeRepos != nil) {
+		return fmt.Errorf("%w: repo_scope_mode all cannot be patched with repo scope filters", ErrWorkspaceSettingsValidation)
+	}
+	if mode == RepoScopeModeOrgs && req.RepoScopeRepos != nil {
+		return fmt.Errorf("%w: repo_scope_mode orgs cannot be patched with repo_scope_repos", ErrWorkspaceSettingsValidation)
+	}
+	if mode == RepoScopeModeRepos && req.RepoScopeOrgs != nil {
+		return fmt.Errorf("%w: repo_scope_mode repos cannot be patched with repo_scope_orgs", ErrWorkspaceSettingsValidation)
 	}
 	return nil
 }

--- a/apps/backend/internal/github/workspace_settings_service.go
+++ b/apps/backend/internal/github/workspace_settings_service.go
@@ -1,0 +1,267 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// GetWorkspaceSettings returns the GitHub operational settings for a workspace.
+func (s *Service) GetWorkspaceSettings(ctx context.Context, workspaceID string) (*WorkspaceSettings, error) {
+	if s.store == nil {
+		return defaultWorkspaceSettings(workspaceID), nil
+	}
+	return s.store.GetWorkspaceSettings(ctx, workspaceID)
+}
+
+// UpsertWorkspaceSettings stores the GitHub operational settings for a workspace.
+func (s *Service) UpsertWorkspaceSettings(ctx context.Context, settings *WorkspaceSettings) error {
+	if s.store == nil {
+		return fmt.Errorf("github store not configured")
+	}
+	return s.store.UpsertWorkspaceSettings(ctx, settings)
+}
+
+// UpdateWorkspaceSettings applies a partial update over the existing workspace
+// settings. Scope fields are intentionally updated as a set so switching to
+// All repos clears org/repo selections.
+func (s *Service) UpdateWorkspaceSettings(ctx context.Context, req *UpdateWorkspaceSettingsRequest) (*WorkspaceSettings, error) {
+	if req == nil || strings.TrimSpace(req.WorkspaceID) == "" {
+		return nil, fmt.Errorf("workspace_id is required")
+	}
+	current, err := s.GetWorkspaceSettings(ctx, req.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if req.RepoScopeMode != nil {
+		current.RepoScopeMode = *req.RepoScopeMode
+	}
+	if req.RepoScopeOrgs != nil {
+		current.RepoScopeOrgs = *req.RepoScopeOrgs
+	}
+	if req.RepoScopeRepos != nil {
+		current.RepoScopeRepos = *req.RepoScopeRepos
+	}
+	if req.SavedPresets != nil {
+		current.SavedPresets = cloneRawMessage(*req.SavedPresets)
+	}
+	if req.DefaultQueryPresets != nil {
+		if string(*req.DefaultQueryPresets) == jsonNullLiteral {
+			current.DefaultQueryPresets = nil
+		} else {
+			current.DefaultQueryPresets = cloneRawMessage(*req.DefaultQueryPresets)
+		}
+	}
+	if err := s.UpsertWorkspaceSettings(ctx, current); err != nil {
+		return nil, err
+	}
+	return s.GetWorkspaceSettings(ctx, req.WorkspaceID)
+}
+
+func (s *Service) SearchUserPRsPagedForWorkspace(
+	ctx context.Context,
+	workspaceID string,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+) (*PRSearchPage, error) {
+	settings, err := s.GetWorkspaceSettings(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if !workspaceSettingsHasScope(settings) {
+		return s.SearchUserPRsPaged(ctx, filter, customQuery, page, perPage)
+	}
+	return s.searchUserPRsPagedScoped(ctx, settings, filter, customQuery, page, perPage)
+}
+
+func (s *Service) SearchUserIssuesPagedForWorkspace(
+	ctx context.Context,
+	workspaceID string,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+) (*IssueSearchPage, error) {
+	settings, err := s.GetWorkspaceSettings(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if !workspaceSettingsHasScope(settings) {
+		return s.SearchUserIssuesPaged(ctx, filter, customQuery, page, perPage)
+	}
+	return s.searchUserIssuesPagedScoped(ctx, settings, filter, customQuery, page, perPage)
+}
+
+func (s *Service) searchUserPRsPagedScoped(
+	ctx context.Context,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+) (*PRSearchPage, error) {
+	v, err := s.searchUserPagedScoped("pr", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
+		result, err := s.client.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
+		if err != nil {
+			return nil, err
+		}
+		return scopedPRSearchPage(result, settings, page, perPage), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*PRSearchPage), nil
+}
+
+func (s *Service) searchUserIssuesPagedScoped(
+	ctx context.Context,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+) (*IssueSearchPage, error) {
+	v, err := s.searchUserPagedScoped("issue", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
+		result, err := s.client.ListIssuesPaged(ctx, filter, customQuery, page, perPage)
+		if err != nil {
+			return nil, err
+		}
+		return scopedIssueSearchPage(result, settings, page, perPage), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*IssueSearchPage), nil
+}
+
+func (s *Service) searchUserPagedScoped(
+	kind string,
+	settings *WorkspaceSettings,
+	filter string,
+	customQuery string,
+	page int,
+	perPage int,
+	fetch func(page int, perPage int) (any, error),
+) (any, error) {
+	if s.client == nil {
+		return nil, fmt.Errorf("github client not available")
+	}
+	page, perPage = clampSearchPage(page, perPage)
+	scopeKey := workspaceSearchScopeKey(settings)
+	key := searchCacheKey(kind+":"+scopeKey, filter, customQuery, page, perPage)
+	return s.searchCache.doOrFetch(key, func() (any, error) {
+		return fetch(page, perPage)
+	})
+}
+
+func scopedPRSearchPage(result *PRSearchPage, settings *WorkspaceSettings, page int, perPage int) *PRSearchPage {
+	if result == nil {
+		result = &PRSearchPage{Page: page, PerPage: perPage}
+	}
+	result.PRs = filterPRsByWorkspaceScope(result.PRs, settings)
+	result.TotalCount = len(result.PRs)
+	result.Page = page
+	result.PerPage = perPage
+	return result
+}
+
+func scopedIssueSearchPage(result *IssueSearchPage, settings *WorkspaceSettings, page int, perPage int) *IssueSearchPage {
+	if result == nil {
+		result = &IssueSearchPage{Page: page, PerPage: perPage}
+	}
+	result.Issues = filterIssuesByWorkspaceScope(result.Issues, settings)
+	result.TotalCount = len(result.Issues)
+	result.Page = page
+	result.PerPage = perPage
+	return result
+}
+
+func workspaceSettingsHasScope(settings *WorkspaceSettings) bool {
+	settings = normalizeWorkspaceSettings(settings)
+	if settings == nil {
+		return false
+	}
+	switch settings.RepoScopeMode {
+	case RepoScopeModeOrgs:
+		return len(settings.RepoScopeOrgs) > 0
+	case RepoScopeModeRepos:
+		return len(settings.RepoScopeRepos) > 0
+	default:
+		return false
+	}
+}
+
+func workspaceSearchScopeKey(settings *WorkspaceSettings) string {
+	settings = normalizeWorkspaceSettings(settings)
+	if settings == nil {
+		return RepoScopeModeAll
+	}
+	var parts []string
+	switch settings.RepoScopeMode {
+	case RepoScopeModeOrgs:
+		parts = append(parts, settings.RepoScopeOrgs...)
+	case RepoScopeModeRepos:
+		for _, repo := range settings.RepoScopeRepos {
+			parts = append(parts, repo.Owner+"/"+repo.Name)
+		}
+	}
+	return settings.RepoScopeMode + ":" + strings.Join(parts, ",")
+}
+
+func filterPRsByWorkspaceScope(prs []*PR, settings *WorkspaceSettings) []*PR {
+	if !workspaceSettingsHasScope(settings) {
+		if prs == nil {
+			return []*PR{}
+		}
+		return prs
+	}
+	out := make([]*PR, 0, len(prs))
+	for _, pr := range prs {
+		if pr != nil && repoAllowedByWorkspaceScope(pr.RepoOwner, pr.RepoName, settings) {
+			out = append(out, pr)
+		}
+	}
+	return out
+}
+
+func filterIssuesByWorkspaceScope(issues []*Issue, settings *WorkspaceSettings) []*Issue {
+	if !workspaceSettingsHasScope(settings) {
+		if issues == nil {
+			return []*Issue{}
+		}
+		return issues
+	}
+	out := make([]*Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue != nil && repoAllowedByWorkspaceScope(issue.RepoOwner, issue.RepoName, settings) {
+			out = append(out, issue)
+		}
+	}
+	return out
+}
+
+func repoAllowedByWorkspaceScope(owner, name string, settings *WorkspaceSettings) bool {
+	settings = normalizeWorkspaceSettings(settings)
+	if settings == nil || settings.RepoScopeMode == RepoScopeModeAll {
+		return true
+	}
+	owner = strings.ToLower(strings.TrimSpace(owner))
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch settings.RepoScopeMode {
+	case RepoScopeModeOrgs:
+		for _, org := range settings.RepoScopeOrgs {
+			if strings.ToLower(org) == owner {
+				return true
+			}
+		}
+	case RepoScopeModeRepos:
+		for _, repo := range settings.RepoScopeRepos {
+			if strings.ToLower(repo.Owner) == owner && strings.ToLower(repo.Name) == name {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/apps/backend/internal/github/workspace_settings_service.go
+++ b/apps/backend/internal/github/workspace_settings_service.go
@@ -27,19 +27,15 @@ func (s *Service) UpsertWorkspaceSettings(ctx context.Context, settings *Workspa
 
 // UpdateWorkspaceSettings applies a partial update over the existing workspace
 // settings. Scope fields are intentionally updated as a set so switching to
-// All repos clears org/repo selections.
+// All repos clears org/repo selections. Direct struct callers must set
+// SavedPresetsSet/DefaultQueriesSet when they intend to write those blobs;
+// JSON-bound requests set those flags in UpdateWorkspaceSettingsRequest.UnmarshalJSON.
 func (s *Service) UpdateWorkspaceSettings(ctx context.Context, req *UpdateWorkspaceSettingsRequest) (*WorkspaceSettings, error) {
 	if req == nil || strings.TrimSpace(req.WorkspaceID) == "" {
 		return nil, fmt.Errorf("%w: workspace_id is required", ErrWorkspaceSettingsValidation)
 	}
 	if req.RepoScopeMode != nil && !isValidRepoScopeMode(*req.RepoScopeMode) {
 		return nil, fmt.Errorf("%w: invalid repo_scope_mode %q", ErrWorkspaceSettingsValidation, *req.RepoScopeMode)
-	}
-	if req.SavedPresets != nil {
-		req.SavedPresetsSet = true
-	}
-	if req.DefaultQueryPresets != nil {
-		req.DefaultQueriesSet = true
 	}
 	if s.store == nil {
 		return nil, fmt.Errorf("github store not configured")
@@ -91,6 +87,9 @@ func (s *Service) searchUserPRsPagedScoped(
 	page int,
 	perPage int,
 ) (*PRSearchPage, error) {
+	if workspaceSettingsHasEmptyScope(settings) {
+		return &PRSearchPage{PRs: []*PR{}, TotalCount: 0, Page: page, PerPage: perPage}, nil
+	}
 	filter, customQuery = appendWorkspaceScopeToSearch(filter, customQuery, settings)
 	v, err := s.searchUserPagedScoped("pr", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
 		result, err := s.client.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
@@ -113,6 +112,9 @@ func (s *Service) searchUserIssuesPagedScoped(
 	page int,
 	perPage int,
 ) (*IssueSearchPage, error) {
+	if workspaceSettingsHasEmptyScope(settings) {
+		return &IssueSearchPage{Issues: []*Issue{}, TotalCount: 0, Page: page, PerPage: perPage}, nil
+	}
 	filter, customQuery = appendWorkspaceScopeToSearch(filter, customQuery, settings)
 	v, err := s.searchUserPagedScoped("issue", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
 		result, err := s.client.ListIssuesPaged(ctx, filter, customQuery, page, perPage)
@@ -173,13 +175,15 @@ func workspaceSettingsHasScope(settings *WorkspaceSettings) bool {
 		return false
 	}
 	switch settings.RepoScopeMode {
-	case RepoScopeModeOrgs:
-		return len(settings.RepoScopeOrgs) > 0
-	case RepoScopeModeRepos:
-		return len(settings.RepoScopeRepos) > 0
+	case RepoScopeModeOrgs, RepoScopeModeRepos:
+		return true
 	default:
 		return false
 	}
+}
+
+func workspaceSettingsHasEmptyScope(settings *WorkspaceSettings) bool {
+	return workspaceSettingsHasScope(settings) && len(workspaceScopeQualifiers(settings)) == 0
 }
 
 func isValidRepoScopeMode(mode string) bool {
@@ -196,7 +200,11 @@ func appendWorkspaceScopeQuery(customQuery string, settings *WorkspaceSettings) 
 	if len(qualifiers) == 0 {
 		return customQuery
 	}
-	return strings.TrimSpace(strings.Join(append([]string{customQuery}, qualifiers...), " "))
+	scope := qualifiers[0]
+	if len(qualifiers) > 1 {
+		scope = "(" + strings.Join(qualifiers, " OR ") + ")"
+	}
+	return strings.TrimSpace(strings.Join([]string{customQuery, scope}, " "))
 }
 
 func appendWorkspaceScopeToSearch(filter, customQuery string, settings *WorkspaceSettings) (string, string) {

--- a/apps/backend/internal/github/workspace_settings_service.go
+++ b/apps/backend/internal/github/workspace_settings_service.go
@@ -2,9 +2,12 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+var ErrWorkspaceSettingsValidation = errors.New("invalid workspace settings")
 
 // GetWorkspaceSettings returns the GitHub operational settings for a workspace.
 func (s *Service) GetWorkspaceSettings(ctx context.Context, workspaceID string) (*WorkspaceSettings, error) {
@@ -27,35 +30,21 @@ func (s *Service) UpsertWorkspaceSettings(ctx context.Context, settings *Workspa
 // All repos clears org/repo selections.
 func (s *Service) UpdateWorkspaceSettings(ctx context.Context, req *UpdateWorkspaceSettingsRequest) (*WorkspaceSettings, error) {
 	if req == nil || strings.TrimSpace(req.WorkspaceID) == "" {
-		return nil, fmt.Errorf("workspace_id is required")
+		return nil, fmt.Errorf("%w: workspace_id is required", ErrWorkspaceSettingsValidation)
 	}
-	current, err := s.GetWorkspaceSettings(ctx, req.WorkspaceID)
-	if err != nil {
-		return nil, err
-	}
-	if req.RepoScopeMode != nil {
-		current.RepoScopeMode = *req.RepoScopeMode
-	}
-	if req.RepoScopeOrgs != nil {
-		current.RepoScopeOrgs = *req.RepoScopeOrgs
-	}
-	if req.RepoScopeRepos != nil {
-		current.RepoScopeRepos = *req.RepoScopeRepos
+	if req.RepoScopeMode != nil && !isValidRepoScopeMode(*req.RepoScopeMode) {
+		return nil, fmt.Errorf("%w: invalid repo_scope_mode %q", ErrWorkspaceSettingsValidation, *req.RepoScopeMode)
 	}
 	if req.SavedPresets != nil {
-		current.SavedPresets = cloneRawMessage(*req.SavedPresets)
+		req.SavedPresetsSet = true
 	}
 	if req.DefaultQueryPresets != nil {
-		if string(*req.DefaultQueryPresets) == jsonNullLiteral {
-			current.DefaultQueryPresets = nil
-		} else {
-			current.DefaultQueryPresets = cloneRawMessage(*req.DefaultQueryPresets)
-		}
+		req.DefaultQueriesSet = true
 	}
-	if err := s.UpsertWorkspaceSettings(ctx, current); err != nil {
-		return nil, err
+	if s.store == nil {
+		return nil, fmt.Errorf("github store not configured")
 	}
-	return s.GetWorkspaceSettings(ctx, req.WorkspaceID)
+	return s.store.PatchWorkspaceSettings(ctx, req)
 }
 
 func (s *Service) SearchUserPRsPagedForWorkspace(
@@ -102,6 +91,7 @@ func (s *Service) searchUserPRsPagedScoped(
 	page int,
 	perPage int,
 ) (*PRSearchPage, error) {
+	filter, customQuery = appendWorkspaceScopeToSearch(filter, customQuery, settings)
 	v, err := s.searchUserPagedScoped("pr", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
 		result, err := s.client.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
 		if err != nil {
@@ -123,6 +113,7 @@ func (s *Service) searchUserIssuesPagedScoped(
 	page int,
 	perPage int,
 ) (*IssueSearchPage, error) {
+	filter, customQuery = appendWorkspaceScopeToSearch(filter, customQuery, settings)
 	v, err := s.searchUserPagedScoped("issue", settings, filter, customQuery, page, perPage, func(page, perPage int) (any, error) {
 		result, err := s.client.ListIssuesPaged(ctx, filter, customQuery, page, perPage)
 		if err != nil {
@@ -161,7 +152,6 @@ func scopedPRSearchPage(result *PRSearchPage, settings *WorkspaceSettings, page 
 		result = &PRSearchPage{Page: page, PerPage: perPage}
 	}
 	result.PRs = filterPRsByWorkspaceScope(result.PRs, settings)
-	result.TotalCount = len(result.PRs)
 	result.Page = page
 	result.PerPage = perPage
 	return result
@@ -172,7 +162,6 @@ func scopedIssueSearchPage(result *IssueSearchPage, settings *WorkspaceSettings,
 		result = &IssueSearchPage{Page: page, PerPage: perPage}
 	}
 	result.Issues = filterIssuesByWorkspaceScope(result.Issues, settings)
-	result.TotalCount = len(result.Issues)
 	result.Page = page
 	result.PerPage = perPage
 	return result
@@ -190,6 +179,78 @@ func workspaceSettingsHasScope(settings *WorkspaceSettings) bool {
 		return len(settings.RepoScopeRepos) > 0
 	default:
 		return false
+	}
+}
+
+func isValidRepoScopeMode(mode string) bool {
+	switch strings.TrimSpace(strings.ToLower(mode)) {
+	case RepoScopeModeAll, RepoScopeModeOrgs, RepoScopeModeRepos:
+		return true
+	default:
+		return false
+	}
+}
+
+func appendWorkspaceScopeQuery(customQuery string, settings *WorkspaceSettings) string {
+	qualifiers := workspaceScopeQualifiers(settings)
+	if len(qualifiers) == 0 {
+		return customQuery
+	}
+	return strings.TrimSpace(strings.Join(append([]string{customQuery}, qualifiers...), " "))
+}
+
+func appendWorkspaceScopeToSearch(filter, customQuery string, settings *WorkspaceSettings) (string, string) {
+	if strings.TrimSpace(customQuery) != "" {
+		return filter, appendWorkspaceScopeQuery(customQuery, settings)
+	}
+	return appendWorkspaceScopeQuery(filter, settings), customQuery
+}
+
+func workspaceScopeQualifiers(settings *WorkspaceSettings) []string {
+	settings = normalizeWorkspaceSettings(settings)
+	if settings == nil {
+		return nil
+	}
+	switch settings.RepoScopeMode {
+	case RepoScopeModeOrgs:
+		qualifiers := make([]string, 0, len(settings.RepoScopeOrgs))
+		for _, org := range settings.RepoScopeOrgs {
+			if org = strings.TrimSpace(org); org != "" {
+				qualifiers = append(qualifiers, "org:"+org)
+			}
+		}
+		return qualifiers
+	case RepoScopeModeRepos:
+		qualifiers := make([]string, 0, len(settings.RepoScopeRepos))
+		for _, repo := range settings.RepoScopeRepos {
+			if repo.Owner != "" && repo.Name != "" {
+				qualifiers = append(qualifiers, repoFilterToQualifier(repo))
+			}
+		}
+		return qualifiers
+	default:
+		return nil
+	}
+}
+
+func workspaceScopeRepoFilters(settings *WorkspaceSettings) []RepoFilter {
+	settings = normalizeWorkspaceSettings(settings)
+	if settings == nil {
+		return nil
+	}
+	switch settings.RepoScopeMode {
+	case RepoScopeModeOrgs:
+		repos := make([]RepoFilter, 0, len(settings.RepoScopeOrgs))
+		for _, org := range settings.RepoScopeOrgs {
+			if org = strings.TrimSpace(org); org != "" {
+				repos = append(repos, RepoFilter{Owner: org})
+			}
+		}
+		return repos
+	case RepoScopeModeRepos:
+		return append([]RepoFilter(nil), settings.RepoScopeRepos...)
+	default:
+		return nil
 	}
 }
 

--- a/apps/backend/internal/github/workspace_settings_service.go
+++ b/apps/backend/internal/github/workspace_settings_service.go
@@ -221,10 +221,11 @@ func workspaceScopeQualifiers(settings *WorkspaceSettings) []string {
 	}
 	switch settings.RepoScopeMode {
 	case RepoScopeModeOrgs:
-		qualifiers := make([]string, 0, len(settings.RepoScopeOrgs))
+		qualifiers := make([]string, 0, len(settings.RepoScopeOrgs)*2)
 		for _, org := range settings.RepoScopeOrgs {
 			if org = strings.TrimSpace(org); org != "" {
 				qualifiers = append(qualifiers, "org:"+org)
+				qualifiers = append(qualifiers, "user:"+org)
 			}
 		}
 		return qualifiers

--- a/apps/backend/internal/github/workspace_settings_test.go
+++ b/apps/backend/internal/github/workspace_settings_test.go
@@ -1,0 +1,181 @@
+package github
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStore_GitHubWorkspaceSettingsRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	input := &WorkspaceSettings{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeRepos,
+		RepoScopeOrgs: []string{"kdlbs"},
+		RepoScopeRepos: []RepoFilter{
+			{Owner: "kdlbs", Name: "kandev"},
+		},
+		SavedPresets:        []byte(`[{"id":"p1","kind":"pr","label":"Mine"}]`),
+		DefaultQueryPresets: []byte(`{"pr":[],"issue":[]}`),
+	}
+
+	if err := store.UpsertWorkspaceSettings(ctx, input); err != nil {
+		t.Fatalf("upsert workspace settings: %v", err)
+	}
+
+	got, err := store.GetWorkspaceSettings(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("get workspace settings: %v", err)
+	}
+	if got.WorkspaceID != "ws-1" || got.RepoScopeMode != RepoScopeModeRepos {
+		t.Fatalf("unexpected settings identity/scope: %+v", got)
+	}
+	if len(got.RepoScopeRepos) != 1 || got.RepoScopeRepos[0].Owner != "kdlbs" || got.RepoScopeRepos[0].Name != "kandev" {
+		t.Fatalf("repo scope lost on round trip: %+v", got.RepoScopeRepos)
+	}
+	if string(got.SavedPresets) != string(input.SavedPresets) {
+		t.Fatalf("saved presets = %s, want %s", got.SavedPresets, input.SavedPresets)
+	}
+	if string(got.DefaultQueryPresets) != string(input.DefaultQueryPresets) {
+		t.Fatalf("default query presets = %s, want %s", got.DefaultQueryPresets, input.DefaultQueryPresets)
+	}
+}
+
+func TestService_SearchUserPRsPagedForWorkspace_FiltersToSelectedRepos(t *testing.T) {
+	client := NewMockClient()
+	client.AddPR(&PR{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "in scope"})
+	client.AddPR(&PR{RepoOwner: "other", RepoName: "repo", Number: 2, Title: "out of scope"})
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:    "ws-1",
+		RepoScopeMode:  RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{{Owner: "kdlbs", Name: "kandev"}},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	page, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "repo:other/repo is:open", 1, 25)
+	if err != nil {
+		t.Fatalf("search scoped prs: %v", err)
+	}
+	if page.TotalCount != 1 || len(page.PRs) != 1 {
+		t.Fatalf("expected one scoped PR, got total=%d prs=%+v", page.TotalCount, page.PRs)
+	}
+	if page.PRs[0].RepoOwner != "kdlbs" || page.PRs[0].RepoName != "kandev" {
+		t.Fatalf("custom query escaped workspace scope: %+v", page.PRs[0])
+	}
+}
+
+func TestService_SearchUserIssuesPagedForWorkspace_AllScopePreservesResults(t *testing.T) {
+	client := &issueSearchClient{
+		issues: []*Issue{
+			{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "one"},
+			{RepoOwner: "other", RepoName: "repo", Number: 2, Title: "two"},
+		},
+	}
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+
+	page, err := svc.SearchUserIssuesPagedForWorkspace(context.Background(), "ws-1", "", "is:open", 1, 25)
+	if err != nil {
+		t.Fatalf("search scoped issues: %v", err)
+	}
+	if page.TotalCount != 2 || len(page.Issues) != 2 {
+		t.Fatalf("all scope should preserve results, got total=%d issues=%+v", page.TotalCount, page.Issues)
+	}
+}
+
+func TestService_CheckReviewWatch_AppliesWorkspaceRepoScope(t *testing.T) {
+	client := NewMockClient()
+	client.AddPR(&PR{
+		RepoOwner:          "kdlbs",
+		RepoName:           "kandev",
+		Number:             1,
+		Title:              "in scope",
+		RequestedReviewers: []RequestedReviewer{{Login: "octo", Type: "user"}},
+	})
+	client.AddPR(&PR{
+		RepoOwner:          "other",
+		RepoName:           "repo",
+		Number:             2,
+		Title:              "out of scope",
+		RequestedReviewers: []RequestedReviewer{{Login: "octo", Type: "user"}},
+	})
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:    "ws-1",
+		RepoScopeMode:  RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{{Owner: "kdlbs", Name: "kandev"}},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	prs, err := svc.CheckReviewWatch(ctx, &ReviewWatch{
+		ID:                  "watch-1",
+		WorkspaceID:         "ws-1",
+		Repos:               nil,
+		ReviewScope:         ReviewScopeUserAndTeams,
+		Enabled:             true,
+		PollIntervalSeconds: 300,
+	})
+	if err != nil {
+		t.Fatalf("check review watch: %v", err)
+	}
+	if len(prs) != 1 || prs[0].RepoOwner != "kdlbs" || prs[0].RepoName != "kandev" {
+		t.Fatalf("expected one in-scope PR, got %+v", prs)
+	}
+}
+
+func TestService_CheckIssueWatch_AppliesWorkspaceRepoScope(t *testing.T) {
+	client := &issueSearchClient{
+		issues: []*Issue{
+			{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "in scope"},
+			{RepoOwner: "other", RepoName: "repo", Number: 2, Title: "out of scope"},
+		},
+	}
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeOrgs,
+		RepoScopeOrgs: []string{"kdlbs"},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	issues, err := svc.CheckIssueWatch(ctx, &IssueWatch{
+		ID:                  "watch-1",
+		WorkspaceID:         "ws-1",
+		Repos:               nil,
+		Enabled:             true,
+		PollIntervalSeconds: 300,
+	})
+	if err != nil {
+		t.Fatalf("check issue watch: %v", err)
+	}
+	if len(issues) != 1 || issues[0].RepoOwner != "kdlbs" || issues[0].RepoName != "kandev" {
+		t.Fatalf("expected one in-scope issue, got %+v", issues)
+	}
+}
+
+type issueSearchClient struct {
+	*MockClient
+	issues []*Issue
+}
+
+func (c *issueSearchClient) ListIssues(context.Context, string, string) ([]*Issue, error) {
+	return c.issues, nil
+}
+
+func (c *issueSearchClient) ListIssuesPaged(context.Context, string, string, int, int) (*IssueSearchPage, error) {
+	return &IssueSearchPage{Issues: c.issues, TotalCount: len(c.issues), Page: 1, PerPage: 25}, nil
+}

--- a/apps/backend/internal/github/workspace_settings_test.go
+++ b/apps/backend/internal/github/workspace_settings_test.go
@@ -81,9 +81,12 @@ func TestService_SearchUserPRsPagedForWorkspace_AppendsScopeToQuery(t *testing.T
 	ctx := context.Background()
 
 	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
-		WorkspaceID:    "ws-1",
-		RepoScopeMode:  RepoScopeModeRepos,
-		RepoScopeRepos: []RepoFilter{{Owner: "kdlbs", Name: "kandev"}},
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{
+			{Owner: "kdlbs", Name: "kandev"},
+			{Owner: "kdlbs", Name: "docs"},
+		},
 	}); err != nil {
 		t.Fatalf("save workspace settings: %v", err)
 	}
@@ -96,7 +99,7 @@ func TestService_SearchUserPRsPagedForWorkspace_AppendsScopeToQuery(t *testing.T
 		t.Fatalf("expected one scoped PR, got total=%d prs=%+v", page.TotalCount, page.PRs)
 	}
 	if !strings.Contains(client.customQuery, "is:open") ||
-		!strings.Contains(client.customQuery, "repo:kdlbs/kandev") {
+		!strings.Contains(client.customQuery, "(repo:kdlbs/kandev OR repo:kdlbs/docs)") {
 		t.Fatalf("custom query was not workspace scoped: %q", client.customQuery)
 	}
 
@@ -104,8 +107,32 @@ func TestService_SearchUserPRsPagedForWorkspace_AppendsScopeToQuery(t *testing.T
 		t.Fatalf("search scoped prs with preset filter: %v", err)
 	}
 	if !strings.Contains(client.filter, "review-requested:@me") ||
-		!strings.Contains(client.filter, "repo:kdlbs/kandev") {
+		!strings.Contains(client.filter, "(repo:kdlbs/kandev OR repo:kdlbs/docs)") {
 		t.Fatalf("filter query was not workspace scoped: %q", client.filter)
+	}
+}
+
+func TestService_SearchUserPRsPagedForWorkspace_EmptyRepoScopeFailsClosed(t *testing.T) {
+	client := NewMockClient()
+	client.AddPR(&PR{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "hidden"})
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:    "ws-1",
+		RepoScopeMode:  RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	page, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "is:open", 1, 25)
+	if err != nil {
+		t.Fatalf("search scoped prs: %v", err)
+	}
+	if page.TotalCount != 0 || len(page.PRs) != 0 {
+		t.Fatalf("empty repo scope should return no PRs, got total=%d prs=%+v", page.TotalCount, page.PRs)
 	}
 }
 
@@ -158,6 +185,17 @@ func TestService_UpdateWorkspaceSettings_PartialUpdateAndNullClear(t *testing.T)
 	if string(got.SavedPresets) != string(nextSaved) {
 		t.Fatalf("saved presets should be preserved after clear, got %s", got.SavedPresets)
 	}
+
+	got, err = svc.UpdateWorkspaceSettings(ctx, &UpdateWorkspaceSettingsRequest{
+		WorkspaceID:     "ws-1",
+		SavedPresetsSet: true,
+	})
+	if err != nil {
+		t.Fatalf("clear saved presets: %v", err)
+	}
+	if string(got.SavedPresets) != "[]" {
+		t.Fatalf("saved presets should be cleared to empty array, got %s", got.SavedPresets)
+	}
 }
 
 func TestUpdateWorkspaceSettingsRequest_UnmarshalTracksExplicitNull(t *testing.T) {
@@ -170,6 +208,19 @@ func TestUpdateWorkspaceSettingsRequest_UnmarshalTracksExplicitNull(t *testing.T
 	}
 	if req.DefaultQueryPresets != nil {
 		t.Fatalf("expected explicit null to leave raw pointer nil, got %s", *req.DefaultQueryPresets)
+	}
+}
+
+func TestUpdateWorkspaceSettingsRequest_UnmarshalTracksSavedPresetsNull(t *testing.T) {
+	var req UpdateWorkspaceSettingsRequest
+	if err := json.Unmarshal([]byte(`{"workspace_id":"ws-1","saved_presets":null}`), &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if !req.SavedPresetsSet {
+		t.Fatal("expected saved presets to be marked present")
+	}
+	if req.SavedPresets != nil {
+		t.Fatalf("expected explicit null to leave raw pointer nil, got %s", *req.SavedPresets)
 	}
 }
 

--- a/apps/backend/internal/github/workspace_settings_test.go
+++ b/apps/backend/internal/github/workspace_settings_test.go
@@ -340,6 +340,46 @@ func TestService_CheckReviewWatch_AppliesWorkspaceRepoScope(t *testing.T) {
 	}
 }
 
+func TestService_CheckReviewWatch_EmptyWorkspaceScopeSkipsProviderFetch(t *testing.T) {
+	client := &countingReviewClient{MockClient: NewMockClient()}
+	client.AddPR(&PR{
+		RepoOwner:          "kdlbs",
+		RepoName:           "kandev",
+		Number:             1,
+		Title:              "hidden",
+		RequestedReviewers: []RequestedReviewer{{Login: "octo", Type: "user"}},
+	})
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:    "ws-1",
+		RepoScopeMode:  RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	prs, err := svc.CheckReviewWatch(ctx, &ReviewWatch{
+		ID:                  "watch-1",
+		WorkspaceID:         "ws-1",
+		Repos:               nil,
+		ReviewScope:         ReviewScopeUserAndTeams,
+		Enabled:             true,
+		PollIntervalSeconds: 300,
+	})
+	if err != nil {
+		t.Fatalf("check review watch: %v", err)
+	}
+	if len(prs) != 0 {
+		t.Fatalf("empty workspace scope should return no PRs, got %+v", prs)
+	}
+	if client.listReviewRequestedCalls != 0 {
+		t.Fatalf("expected no broad provider fetch, got %d calls", client.listReviewRequestedCalls)
+	}
+}
+
 func TestService_CheckIssueWatch_AppliesWorkspaceRepoScope(t *testing.T) {
 	client := &issueSearchClient{
 		issues: []*Issue{
@@ -374,9 +414,61 @@ func TestService_CheckIssueWatch_AppliesWorkspaceRepoScope(t *testing.T) {
 	}
 }
 
+func TestService_CheckIssueWatch_EmptyWorkspaceScopeSkipsProviderFetch(t *testing.T) {
+	client := &countingWorkspaceIssueClient{MockClient: NewMockClient()}
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeOrgs,
+		RepoScopeOrgs: []string{},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	issues, err := svc.CheckIssueWatch(ctx, &IssueWatch{
+		ID:                  "watch-1",
+		WorkspaceID:         "ws-1",
+		Repos:               nil,
+		Enabled:             true,
+		PollIntervalSeconds: 300,
+	})
+	if err != nil {
+		t.Fatalf("check issue watch: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("empty workspace scope should return no issues, got %+v", issues)
+	}
+	if client.listIssuesCalls != 0 {
+		t.Fatalf("expected no broad provider fetch, got %d calls", client.listIssuesCalls)
+	}
+}
+
 type issueSearchClient struct {
 	*MockClient
 	issues []*Issue
+}
+
+type countingReviewClient struct {
+	*MockClient
+	listReviewRequestedCalls int
+}
+
+func (c *countingReviewClient) ListReviewRequestedPRs(ctx context.Context, reviewScope, owner, repo string) ([]*PR, error) {
+	c.listReviewRequestedCalls++
+	return c.MockClient.ListReviewRequestedPRs(ctx, reviewScope, owner, repo)
+}
+
+type countingWorkspaceIssueClient struct {
+	*MockClient
+	listIssuesCalls int
+}
+
+func (c *countingWorkspaceIssueClient) ListIssues(context.Context, string, string) ([]*Issue, error) {
+	c.listIssuesCalls++
+	return []*Issue{{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "hidden"}}, nil
 }
 
 type capturingSearchClient struct {

--- a/apps/backend/internal/github/workspace_settings_test.go
+++ b/apps/backend/internal/github/workspace_settings_test.go
@@ -2,6 +2,9 @@ package github
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 )
 
@@ -62,11 +65,125 @@ func TestService_SearchUserPRsPagedForWorkspace_FiltersToSelectedRepos(t *testin
 	if err != nil {
 		t.Fatalf("search scoped prs: %v", err)
 	}
-	if page.TotalCount != 1 || len(page.PRs) != 1 {
+	if page.TotalCount != 2 || len(page.PRs) != 1 {
 		t.Fatalf("expected one scoped PR, got total=%d prs=%+v", page.TotalCount, page.PRs)
 	}
 	if page.PRs[0].RepoOwner != "kdlbs" || page.PRs[0].RepoName != "kandev" {
 		t.Fatalf("custom query escaped workspace scope: %+v", page.PRs[0])
+	}
+}
+
+func TestService_SearchUserPRsPagedForWorkspace_AppendsScopeToQuery(t *testing.T) {
+	client := &capturingSearchClient{MockClient: NewMockClient()}
+	client.AddPR(&PR{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "in scope"})
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:    "ws-1",
+		RepoScopeMode:  RepoScopeModeRepos,
+		RepoScopeRepos: []RepoFilter{{Owner: "kdlbs", Name: "kandev"}},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	page, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "is:open", 1, 25)
+	if err != nil {
+		t.Fatalf("search scoped prs: %v", err)
+	}
+	if page.TotalCount != 1 || len(page.PRs) != 1 {
+		t.Fatalf("expected one scoped PR, got total=%d prs=%+v", page.TotalCount, page.PRs)
+	}
+	if !strings.Contains(client.customQuery, "is:open") ||
+		!strings.Contains(client.customQuery, "repo:kdlbs/kandev") {
+		t.Fatalf("custom query was not workspace scoped: %q", client.customQuery)
+	}
+
+	if _, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "review-requested:@me", "", 1, 25); err != nil {
+		t.Fatalf("search scoped prs with preset filter: %v", err)
+	}
+	if !strings.Contains(client.filter, "review-requested:@me") ||
+		!strings.Contains(client.filter, "repo:kdlbs/kandev") {
+		t.Fatalf("filter query was not workspace scoped: %q", client.filter)
+	}
+}
+
+func TestService_UpdateWorkspaceSettings_PartialUpdateAndNullClear(t *testing.T) {
+	store := newTestStore(t)
+	svc := NewService(NewMockClient(), AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+	defaults := json.RawMessage(`{"pr":[{"value":"mine","label":"Mine","filter":"is:open","group":"inbox"}],"issue":[]}`)
+	saved := json.RawMessage(`[{"id":"p1","kind":"pr","label":"Mine"}]`)
+	mode := RepoScopeModeRepos
+	repos := []RepoFilter{{Owner: "kdlbs", Name: "kandev"}}
+	if _, err := svc.UpdateWorkspaceSettings(ctx, &UpdateWorkspaceSettingsRequest{
+		WorkspaceID:         "ws-1",
+		RepoScopeMode:       &mode,
+		RepoScopeRepos:      &repos,
+		SavedPresets:        &saved,
+		SavedPresetsSet:     true,
+		DefaultQueryPresets: &defaults,
+		DefaultQueriesSet:   true,
+	}); err != nil {
+		t.Fatalf("initial update: %v", err)
+	}
+
+	nextSaved := json.RawMessage(`[{"id":"p2","kind":"issue","label":"Issues"}]`)
+	got, err := svc.UpdateWorkspaceSettings(ctx, &UpdateWorkspaceSettingsRequest{
+		WorkspaceID:     "ws-1",
+		SavedPresets:    &nextSaved,
+		SavedPresetsSet: true,
+	})
+	if err != nil {
+		t.Fatalf("partial saved presets update: %v", err)
+	}
+	if string(got.SavedPresets) != string(nextSaved) {
+		t.Fatalf("saved presets = %s, want %s", got.SavedPresets, nextSaved)
+	}
+	if string(got.DefaultQueryPresets) != string(defaults) {
+		t.Fatalf("default presets should be preserved, got %s", got.DefaultQueryPresets)
+	}
+
+	got, err = svc.UpdateWorkspaceSettings(ctx, &UpdateWorkspaceSettingsRequest{
+		WorkspaceID:       "ws-1",
+		DefaultQueriesSet: true,
+	})
+	if err != nil {
+		t.Fatalf("clear default query presets: %v", err)
+	}
+	if got.DefaultQueryPresets != nil {
+		t.Fatalf("default presets should be cleared, got %s", got.DefaultQueryPresets)
+	}
+	if string(got.SavedPresets) != string(nextSaved) {
+		t.Fatalf("saved presets should be preserved after clear, got %s", got.SavedPresets)
+	}
+}
+
+func TestUpdateWorkspaceSettingsRequest_UnmarshalTracksExplicitNull(t *testing.T) {
+	var req UpdateWorkspaceSettingsRequest
+	if err := json.Unmarshal([]byte(`{"workspace_id":"ws-1","default_query_presets":null}`), &req); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if !req.DefaultQueriesSet {
+		t.Fatal("expected default query presets to be marked present")
+	}
+	if req.DefaultQueryPresets != nil {
+		t.Fatalf("expected explicit null to leave raw pointer nil, got %s", *req.DefaultQueryPresets)
+	}
+}
+
+func TestService_UpdateWorkspaceSettings_RejectsUnknownRepoScopeMode(t *testing.T) {
+	store := newTestStore(t)
+	svc := NewService(NewMockClient(), AuthMethodPAT, nil, store, nil, testLogger(t))
+	mode := "everything"
+
+	_, err := svc.UpdateWorkspaceSettings(context.Background(), &UpdateWorkspaceSettingsRequest{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: &mode,
+	})
+	if !errors.Is(err, ErrWorkspaceSettingsValidation) {
+		t.Fatalf("expected validation error, got %v", err)
 	}
 }
 
@@ -170,6 +287,18 @@ func TestService_CheckIssueWatch_AppliesWorkspaceRepoScope(t *testing.T) {
 type issueSearchClient struct {
 	*MockClient
 	issues []*Issue
+}
+
+type capturingSearchClient struct {
+	*MockClient
+	filter      string
+	customQuery string
+}
+
+func (c *capturingSearchClient) SearchPRsPaged(ctx context.Context, filter, customQuery string, page, perPage int) (*PRSearchPage, error) {
+	c.filter = filter
+	c.customQuery = customQuery
+	return c.MockClient.SearchPRsPaged(ctx, filter, customQuery, page, perPage)
 }
 
 func (c *issueSearchClient) ListIssues(context.Context, string, string) ([]*Issue, error) {

--- a/apps/backend/internal/github/workspace_settings_test.go
+++ b/apps/backend/internal/github/workspace_settings_test.go
@@ -112,6 +112,29 @@ func TestService_SearchUserPRsPagedForWorkspace_AppendsScopeToQuery(t *testing.T
 	}
 }
 
+func TestService_SearchUserPRsPagedForWorkspace_OrgScopeIncludesPersonalOwner(t *testing.T) {
+	client := &capturingSearchClient{MockClient: NewMockClient()}
+	client.AddPR(&PR{RepoOwner: "octo", RepoName: "personal", Number: 1, Title: "in scope"})
+	store := newTestStore(t)
+	svc := NewService(client, AuthMethodPAT, nil, store, nil, testLogger(t))
+	ctx := context.Background()
+
+	if err := svc.UpsertWorkspaceSettings(ctx, &WorkspaceSettings{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: RepoScopeModeOrgs,
+		RepoScopeOrgs: []string{"octo"},
+	}); err != nil {
+		t.Fatalf("save workspace settings: %v", err)
+	}
+
+	if _, err := svc.SearchUserPRsPagedForWorkspace(ctx, "ws-1", "", "is:open", 1, 25); err != nil {
+		t.Fatalf("search scoped prs: %v", err)
+	}
+	if !strings.Contains(client.customQuery, "(org:octo OR user:octo)") {
+		t.Fatalf("org scope did not include personal-owner qualifier: %q", client.customQuery)
+	}
+}
+
 func TestService_SearchUserPRsPagedForWorkspace_EmptyRepoScopeFailsClosed(t *testing.T) {
 	client := NewMockClient()
 	client.AddPR(&PR{RepoOwner: "kdlbs", RepoName: "kandev", Number: 1, Title: "hidden"})
@@ -232,6 +255,22 @@ func TestService_UpdateWorkspaceSettings_RejectsUnknownRepoScopeMode(t *testing.
 	_, err := svc.UpdateWorkspaceSettings(context.Background(), &UpdateWorkspaceSettingsRequest{
 		WorkspaceID:   "ws-1",
 		RepoScopeMode: &mode,
+	})
+	if !errors.Is(err, ErrWorkspaceSettingsValidation) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestService_UpdateWorkspaceSettings_RejectsConflictingScopePatch(t *testing.T) {
+	store := newTestStore(t)
+	svc := NewService(NewMockClient(), AuthMethodPAT, nil, store, nil, testLogger(t))
+	mode := RepoScopeModeAll
+	orgs := []string{"octo"}
+
+	_, err := svc.UpdateWorkspaceSettings(context.Background(), &UpdateWorkspaceSettingsRequest{
+		WorkspaceID:   "ws-1",
+		RepoScopeMode: &mode,
+		RepoScopeOrgs: &orgs,
 	})
 	if !errors.Is(err, ErrWorkspaceSettingsValidation) {
 		t.Fatalf("expected validation error, got %v", err)

--- a/apps/backend/internal/integrations/workspacescope/workspacescope.go
+++ b/apps/backend/internal/integrations/workspacescope/workspacescope.go
@@ -1,0 +1,81 @@
+package workspacescope
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// FallbackWorkspaceID is used only in isolated tests or malformed databases
+// where integration config exists before the workspaces table is available.
+const FallbackWorkspaceID = "default"
+
+// ResolveMigrationTarget returns the workspace that should receive an upgraded
+// singleton integration config. It prefers the workspace stored in user
+// settings, then the first workspace by creation time.
+func ResolveMigrationTarget(db *sqlx.DB) (string, error) {
+	if db == nil {
+		return FallbackWorkspaceID, nil
+	}
+	hasWorkspaces, err := tableExists(db, "workspaces")
+	if err != nil || !hasWorkspaces {
+		return FallbackWorkspaceID, err
+	}
+	if workspaceID, err := activeWorkspaceFromUsers(db); err != nil {
+		return "", err
+	} else if workspaceID != "" {
+		return workspaceID, nil
+	}
+	var id string
+	err = db.Get(&id, `SELECT id FROM workspaces ORDER BY created_at ASC LIMIT 1`)
+	if errors.Is(err, sql.ErrNoRows) {
+		return FallbackWorkspaceID, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func tableExists(db *sqlx.DB, name string) (bool, error) {
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, name); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func activeWorkspaceFromUsers(db *sqlx.DB) (string, error) {
+	hasUsers, err := tableExists(db, "users")
+	if err != nil || !hasUsers {
+		return "", err
+	}
+	var settings []string
+	if err := db.Select(&settings, `SELECT settings FROM users ORDER BY updated_at DESC`); err != nil {
+		return "", err
+	}
+	for _, raw := range settings {
+		var parsed struct {
+			WorkspaceID string `json:"workspace_id"`
+		}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil || parsed.WorkspaceID == "" {
+			continue
+		}
+		if ok, err := workspaceExists(db, parsed.WorkspaceID); err != nil {
+			return "", err
+		} else if ok {
+			return parsed.WorkspaceID, nil
+		}
+	}
+	return "", nil
+}
+
+func workspaceExists(db *sqlx.DB, id string) (bool, error) {
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM workspaces WHERE id = ?`, id); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/apps/backend/internal/integrations/workspacescope/workspacescope.go
+++ b/apps/backend/internal/integrations/workspacescope/workspacescope.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"sync"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -11,6 +12,28 @@ import (
 // FallbackWorkspaceID is used only in isolated tests or malformed databases
 // where integration config exists before the workspaces table is available.
 const FallbackWorkspaceID = "default"
+
+// CachedResolver memoizes the default workspace used by legacy integration
+// methods that predate explicit workspace IDs. New request paths should pass a
+// workspace ID and bypass this fallback entirely.
+type CachedResolver struct {
+	mu          sync.Mutex
+	workspaceID string
+}
+
+func (r *CachedResolver) Resolve(db *sqlx.DB) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.workspaceID != "" {
+		return r.workspaceID, nil
+	}
+	workspaceID, err := ResolveMigrationTarget(db)
+	if err != nil {
+		return "", err
+	}
+	r.workspaceID = workspaceID
+	return workspaceID, nil
+}
 
 // ResolveMigrationTarget returns the workspace that should receive an upgraded
 // singleton integration config. It prefers the workspace stored in user

--- a/apps/backend/internal/integrations/workspacescope/workspacescope.go
+++ b/apps/backend/internal/integrations/workspacescope/workspacescope.go
@@ -18,19 +18,21 @@ const FallbackWorkspaceID = "default"
 // workspace ID and bypass this fallback entirely.
 type CachedResolver struct {
 	mu          sync.Mutex
+	db          *sqlx.DB
 	workspaceID string
 }
 
 func (r *CachedResolver) Resolve(db *sqlx.DB) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.workspaceID != "" {
+	if r.workspaceID != "" && r.db == db {
 		return r.workspaceID, nil
 	}
 	workspaceID, err := ResolveMigrationTarget(db)
 	if err != nil {
 		return "", err
 	}
+	r.db = db
 	r.workspaceID = workspaceID
 	return workspaceID, nil
 }

--- a/apps/backend/internal/integrations/workspacescope/workspacescope_test.go
+++ b/apps/backend/internal/integrations/workspacescope/workspacescope_test.go
@@ -1,0 +1,135 @@
+package workspacescope
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func newTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	raw, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	db := sqlx.NewDb(raw, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func seedActiveWorkspace(t *testing.T, db *sqlx.DB, workspaceID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS users (
+			id TEXT PRIMARY KEY,
+			email TEXT NOT NULL,
+			settings TEXT NOT NULL DEFAULT '{}',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		DELETE FROM workspaces;
+		DELETE FROM users;
+		INSERT INTO workspaces (id, name, created_at, updated_at)
+			VALUES (?, 'Active', ?, ?);
+		INSERT INTO users (id, email, settings, created_at, updated_at)
+			VALUES ('default-user', 'default@kandev.local', ?, ?, ?);
+	`, workspaceID, now, now, `{"workspace_id":"`+workspaceID+`"}`, now, now); err != nil {
+		t.Fatalf("seed active workspace: %v", err)
+	}
+}
+
+func TestCachedResolverReusesSuccessfulResolution(t *testing.T) {
+	db := newTestDB(t)
+	seedActiveWorkspace(t, db, "ws-first")
+
+	var resolver CachedResolver
+	got, err := resolver.Resolve(db)
+	if err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	if got != "ws-first" {
+		t.Fatalf("expected ws-first, got %q", got)
+	}
+
+	seedActiveWorkspace(t, db, "ws-second")
+	got, err = resolver.Resolve(db)
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if got != "ws-first" {
+		t.Fatalf("expected cached ws-first, got %q", got)
+	}
+}
+
+func TestCachedResolverCachesPerDB(t *testing.T) {
+	db1 := newTestDB(t)
+	db2 := newTestDB(t)
+	seedActiveWorkspace(t, db1, "ws-one")
+	seedActiveWorkspace(t, db2, "ws-two")
+
+	var resolver CachedResolver
+	got, err := resolver.Resolve(db1)
+	if err != nil {
+		t.Fatalf("resolve db1: %v", err)
+	}
+	if got != "ws-one" {
+		t.Fatalf("expected ws-one, got %q", got)
+	}
+	got, err = resolver.Resolve(db2)
+	if err != nil {
+		t.Fatalf("resolve db2: %v", err)
+	}
+	if got != "ws-two" {
+		t.Fatalf("expected ws-two for second db, got %q", got)
+	}
+}
+
+func TestCachedResolverDoesNotMemoizeErrors(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY
+		);
+		INSERT INTO workspaces (id, name, created_at, updated_at)
+			VALUES ('ws-active', 'Active', ?, ?);
+	`, now, now); err != nil {
+		t.Fatalf("seed malformed users table: %v", err)
+	}
+
+	var resolver CachedResolver
+	if _, err := resolver.Resolve(db); err == nil {
+		t.Fatal("expected malformed users table to fail")
+	}
+
+	if _, err := db.Exec(`DROP TABLE users`); err != nil {
+		t.Fatalf("drop malformed users table: %v", err)
+	}
+	seedActiveWorkspace(t, db, "ws-active")
+
+	got, err := resolver.Resolve(db)
+	if err != nil {
+		t.Fatalf("resolve after fixing users table: %v", err)
+	}
+	if got != "ws-active" {
+		t.Fatalf("expected ws-active after retry, got %q", got)
+	}
+}

--- a/apps/backend/internal/jira/handlers.go
+++ b/apps/backend/internal/jira/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -51,7 +52,7 @@ func (c *Controller) RegisterHTTPRoutes(router *gin.Engine) {
 // --- HTTP handlers ---
 
 func (c *Controller) httpGetConfig(ctx *gin.Context) {
-	cfg, err := c.service.GetConfig(ctx.Request.Context())
+	cfg, err := c.service.GetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx))
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -69,7 +70,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	cfg, err := c.service.SetConfig(ctx.Request.Context(), &req)
+	cfg, err := c.service.SetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrInvalidConfig) {
@@ -82,7 +83,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 }
 
 func (c *Controller) httpDeleteConfig(ctx *gin.Context) {
-	if err := c.service.DeleteConfig(ctx.Request.Context()); err != nil {
+	if err := c.service.DeleteConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx)); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -95,7 +96,7 @@ func (c *Controller) httpTestConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	result, err := c.service.TestConnection(ctx.Request.Context(), &req)
+	result, err := c.service.TestConnectionForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -104,7 +105,12 @@ func (c *Controller) httpTestConfig(ctx *gin.Context) {
 }
 
 func (c *Controller) httpListProjects(ctx *gin.Context) {
-	projects, err := c.service.ListProjects(ctx.Request.Context())
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	projects, err := client.ListProjects(ctx.Request.Context())
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -126,7 +132,7 @@ func (c *Controller) httpSearchTickets(ctx *gin.Context) {
 	jql := ctx.Query("jql")
 	pageToken := ctx.Query("page_token")
 	maxResults, _ := strconv.Atoi(ctx.Query("max_results"))
-	result, err := c.service.SearchTickets(ctx.Request.Context(), jql, pageToken, maxResults)
+	result, err := c.service.SearchTicketsForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), jql, pageToken, maxResults)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -136,7 +142,12 @@ func (c *Controller) httpSearchTickets(ctx *gin.Context) {
 
 func (c *Controller) httpGetTicket(ctx *gin.Context) {
 	key := ctx.Param("key")
-	ticket, err := c.service.GetTicket(ctx.Request.Context(), key)
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	ticket, err := client.GetTicket(ctx.Request.Context(), key)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -153,11 +164,20 @@ func (c *Controller) httpDoTransition(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "transitionId required"})
 		return
 	}
-	if err := c.service.DoTransition(ctx.Request.Context(), key, req.TransitionID); err != nil {
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	if err := client.DoTransition(ctx.Request.Context(), key, req.TransitionID); err != nil {
 		c.writeClientError(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, gin.H{"transitioned": true})
+}
+
+func (c *Controller) workspaceID(ctx *gin.Context) string {
+	return strings.TrimSpace(ctx.Query("workspace_id"))
 }
 
 // --- Issue watch HTTP handlers ---

--- a/apps/backend/internal/jira/handlers.go
+++ b/apps/backend/internal/jira/handlers.go
@@ -120,7 +120,11 @@ func (c *Controller) httpListProjects(ctx *gin.Context) {
 
 func (c *Controller) httpListProjectStatuses(ctx *gin.Context) {
 	key := ctx.Param("key")
-	statuses, err := c.service.ListProjectStatuses(ctx.Request.Context(), key)
+	statuses, err := c.service.ListProjectStatusesForWorkspace(
+		ctx.Request.Context(),
+		c.workspaceID(ctx),
+		key,
+	)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return

--- a/apps/backend/internal/jira/mock_controller.go
+++ b/apps/backend/internal/jira/mock_controller.go
@@ -59,7 +59,14 @@ func (c *MockController) setAuthHealth(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	if err := c.store.UpdateAuthHealth(ctx.Request.Context(), req.OK, req.Error, time.Now().UTC()); err != nil {
+	workspaceID := ctx.Query("workspace_id")
+	var err error
+	if workspaceID == "" {
+		err = c.store.UpdateAuthHealth(ctx.Request.Context(), req.OK, req.Error, time.Now().UTC())
+	} else {
+		err = c.store.UpdateAuthHealthForWorkspace(ctx.Request.Context(), workspaceID, req.OK, req.Error, time.Now().UTC())
+	}
+	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/apps/backend/internal/jira/models.go
+++ b/apps/backend/internal/jira/models.go
@@ -34,10 +34,11 @@ const (
 	InstanceTypeServer = "server"
 )
 
-// JiraConfig is the install-wide configuration for the Jira integration. The
-// secret value (API token, PAT, or session cookie) is stored separately in the
-// encrypted secret store under SecretKey.
+// JiraConfig is the workspace-scoped configuration for the Jira integration.
+// The secret value (API token, PAT, or session cookie) is stored separately in
+// the encrypted secret store.
 type JiraConfig struct {
+	WorkspaceID       string `json:"workspaceId,omitempty" db:"workspace_id"`
 	SiteURL           string `json:"siteUrl" db:"site_url"`
 	Email             string `json:"email" db:"email"`
 	AuthMethod        string `json:"authMethod" db:"auth_method"`
@@ -146,15 +147,18 @@ type SearchResult struct {
 	NextPageToken string       `json:"nextPageToken,omitempty"`
 }
 
-// SecretKey is the secret-store key used for the install-wide Jira token.
-// Centralised so that the service, store and provider migration agree.
+// SecretKey is the legacy secret-store key used for the old install-wide Jira
+// token. New workspace-scoped configs use SecretKeyForWorkspace.
 const SecretKey = "jira:singleton:token"
 
-// LegacySecretKeyForWorkspace returns the pre-singleton per-workspace secret
-// key. Only used by the one-shot startup migration in provider.go to copy an
-// existing token over to SecretKey.
-func LegacySecretKeyForWorkspace(workspaceID string) string {
+// SecretKeyForWorkspace returns the workspace-scoped Jira secret key.
+func SecretKeyForWorkspace(workspaceID string) string {
 	return "jira:" + workspaceID + ":token"
+}
+
+// LegacySecretKeyForWorkspace is kept for older tests/callers.
+func LegacySecretKeyForWorkspace(workspaceID string) string {
+	return SecretKeyForWorkspace(workspaceID)
 }
 
 // DefaultIssueWatchPollInterval is the polling cadence assigned to a watcher

--- a/apps/backend/internal/jira/poller_issue_watch_test.go
+++ b/apps/backend/internal/jira/poller_issue_watch_test.go
@@ -49,7 +49,7 @@ func (r *recordingSubscriber) snapshot() []*NewJiraIssueEvent {
 func TestPoller_CheckIssueWatches_PublishesNewTicketsOnly(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()
@@ -108,7 +108,7 @@ func TestPoller_CheckIssueWatches_PublishesNewTicketsOnly(t *testing.T) {
 func TestPoller_CheckIssueWatches_SkipsDisabled(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()
@@ -183,7 +183,7 @@ func TestIsIssueWatchDue(t *testing.T) {
 func TestPoller_CheckIssueWatches_RespectsPerWatchInterval(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()

--- a/apps/backend/internal/jira/poller_test.go
+++ b/apps/backend/internal/jira/poller_test.go
@@ -36,21 +36,32 @@ func newPollerFixture(t *testing.T) *pollerFixture {
 	return f
 }
 
-// saveConfig persists the singleton config directly via the store + secret
+// saveConfig persists the default workspace config directly via the store + secret
 // fakes. We deliberately avoid Service.SetConfig here because it fires an
 // async auth probe in a goroutine — fine for production but it would race
 // against the deterministic RecordAuthHealth calls these tests make.
 func (f *pollerFixture) saveConfig(t *testing.T, secret string) {
 	t.Helper()
+	f.saveConfigForWorkspace(t, "", secret)
+}
+
+// saveConfigForWorkspace persists a workspace config directly via the store +
+// secret fakes.
+func (f *pollerFixture) saveConfigForWorkspace(t *testing.T, workspaceID, secret string) {
+	t.Helper()
 	ctx := context.Background()
-	if err := f.store.UpsertConfig(ctx, &JiraConfig{
+	if err := f.store.UpsertConfigForWorkspace(ctx, workspaceID, &JiraConfig{
 		SiteURL:    "https://acme.atlassian.net",
 		Email:      "user@example.com",
 		AuthMethod: AuthMethodAPIToken,
 	}); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
-	if err := f.secrets.Set(ctx, SecretKey, "jira", secret); err != nil {
+	key := SecretKey
+	if workspaceID != "" {
+		key = SecretKeyForWorkspace(workspaceID)
+	}
+	if err := f.secrets.Set(ctx, key, "jira", secret); err != nil {
 		t.Fatalf("save secret: %v", err)
 	}
 }

--- a/apps/backend/internal/jira/provider.go
+++ b/apps/backend/internal/jira/provider.go
@@ -54,30 +54,31 @@ func Provide(writer, reader *sqlx.DB, secrets SecretStore, eventBus bus.EventBus
 	return svc, cleanup, nil
 }
 
-// migrateLegacySecret copies the per-workspace token from the pre-singleton
-// secret key onto the new install-wide key, then deletes the legacy entry.
+// migrateLegacySecret copies the old install-wide token onto the
+// workspace-scoped key created by the config migration, then deletes the legacy
+// entry. If the workspace key already exists, it leaves both values alone.
 // Best-effort: any error is logged and ignored — the worst case is the user
 // re-pastes their token in the settings UI.
 func migrateLegacySecret(store *Store, secrets SecretStore, log *logger.Logger) {
-	source := store.MigratedFromWorkspace()
-	if source == "" || secrets == nil {
+	target := store.MigratedFromWorkspace()
+	if target == "" || secrets == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if exists, err := secrets.Exists(ctx, SecretKey); err == nil && exists {
+	targetKey := SecretKeyForWorkspace(target)
+	if exists, err := secrets.Exists(ctx, targetKey); err == nil && exists {
 		return
 	}
-	legacyKey := LegacySecretKeyForWorkspace(source)
-	value, err := secrets.Reveal(ctx, legacyKey)
+	value, err := secrets.Reveal(ctx, SecretKey)
 	if err != nil || value == "" {
 		return
 	}
-	if err := secrets.Set(ctx, SecretKey, "Jira token", value); err != nil {
+	if err := secrets.Set(ctx, targetKey, "Jira token", value); err != nil {
 		log.Warn("jira: legacy secret migration failed", zap.Error(err))
 		return
 	}
-	if err := secrets.Delete(ctx, legacyKey); err != nil {
+	if err := secrets.Delete(ctx, SecretKey); err != nil {
 		log.Warn("jira: legacy secret cleanup failed", zap.Error(err))
 	}
 }

--- a/apps/backend/internal/jira/service.go
+++ b/apps/backend/internal/jira/service.go
@@ -419,7 +419,19 @@ func (s *Service) ListProjects(ctx context.Context) ([]JiraProject, error) {
 // used by the ticket-list status filter so users can filter by the real
 // statuses in the selected project rather than the three coarse categories.
 func (s *Service) ListProjectStatuses(ctx context.Context, projectKey string) ([]JiraStatus, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.ListProjectStatusesForWorkspace(ctx, workspaceID, projectKey)
+}
+
+func (s *Service) ListProjectStatusesForWorkspace(ctx context.Context, workspaceID, projectKey string) ([]JiraStatus, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/jira/service.go
+++ b/apps/backend/internal/jira/service.go
@@ -43,7 +43,7 @@ type Service struct {
 	log       *logger.Logger
 	mu        sync.Mutex
 	clientFn  ClientFactory
-	client    Client // singleton, cleared on config change.
+	clients   map[string]Client
 	probeHook func()
 	eventBus  bus.EventBus
 	// taskDeleter is the cascade-delete entry point used by the watch
@@ -111,6 +111,7 @@ func NewService(store *Store, secrets SecretStore, clientFn ClientFactory, log *
 		secrets:  secrets,
 		log:      log,
 		clientFn: clientFn,
+		clients:  make(map[string]Client),
 	}
 }
 
@@ -119,20 +120,35 @@ func NewService(store *Store, secrets SecretStore, clientFn ClientFactory, log *
 // session_cookie auth, it also tries to decode the JWT in the stored cookie
 // and surface its expiry so the UI can warn the user before the session dies.
 func (s *Service) GetConfig(ctx context.Context) (*JiraConfig, error) {
-	cfg, err := s.store.GetConfig(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns a workspace config enriched with a HasSecret
+// flag so the UI can distinguish "configured but empty" from "needs
+// credentials".
+func (s *Service) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*JiraConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil || cfg == nil {
 		return cfg, err
 	}
 	if s.secrets == nil {
 		return cfg, nil
 	}
-	exists, existsErr := s.secrets.Exists(ctx, SecretKey)
+	exists, existsErr := s.secretExists(ctx, workspaceID)
 	if existsErr != nil {
 		s.log.Warn("jira: secret exists check failed", zap.Error(existsErr))
 	}
 	cfg.HasSecret = exists
 	if exists && cfg.AuthMethod == AuthMethodSessionCookie {
-		secret, revealErr := s.secrets.Reveal(ctx, SecretKey)
+		secret, revealErr := s.revealSecret(ctx, workspaceID)
 		if revealErr != nil {
 			s.log.Warn("jira: secret reveal failed", zap.Error(revealErr))
 		} else {
@@ -151,6 +167,19 @@ var ErrInvalidConfig = errors.New("jira: invalid configuration")
 // "keep the existing token" — this lets the UI edit auxiliary fields without
 // forcing the user to paste the token again.
 func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*JiraConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.SetConfigForWorkspace(ctx, workspaceID, req)
+}
+
+// SetConfigForWorkspace is upsert for one workspace.
+func (s *Service) SetConfigForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*JiraConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	if err := validateConfigRequest(req); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidConfig, err.Error())
 	}
@@ -161,23 +190,23 @@ func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*JiraCo
 		InstanceType:      req.InstanceType,
 		DefaultProjectKey: req.DefaultProjectKey,
 	}
-	if err := s.store.UpsertConfig(ctx, cfg); err != nil {
+	if err := s.store.UpsertConfigForWorkspace(ctx, workspaceID, cfg); err != nil {
 		return nil, fmt.Errorf("upsert jira config: %w", err)
 	}
 	if req.Secret != "" && s.secrets != nil {
-		if err := s.secrets.Set(ctx, SecretKey, "Jira token", req.Secret); err != nil {
+		if err := s.secrets.Set(ctx, SecretKeyForWorkspace(workspaceID), "Jira token", req.Secret); err != nil {
 			return nil, fmt.Errorf("store jira secret: %w", err)
 		}
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	// Probe asynchronously so a slow Atlassian doesn't stall the save response.
 	// RecordAuthHealth manages its own probe timeout, so a fresh
 	// context.Background() is enough — the request ctx may be cancelled when
 	// this returns, but the probe and the DB write must still complete.
 	go func() {
-		s.RecordAuthHealth(context.Background())
+		s.RecordAuthHealthForWorkspace(context.Background(), workspaceID)
 	}()
-	return s.GetConfig(ctx)
+	return s.GetConfigForWorkspace(ctx, workspaceID)
 }
 
 // DeleteConfig removes both the config row and the stored secret. A failure to
@@ -185,15 +214,28 @@ func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*JiraCo
 // surfaces success — the orphaned secret is rare and the user can retry by
 // re-saving + deleting again.
 func (s *Service) DeleteConfig(ctx context.Context) error {
-	if err := s.store.DeleteConfig(ctx); err != nil {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes both the config row and the stored secret.
+func (s *Service) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	if err := s.store.DeleteConfigForWorkspace(ctx, workspaceID); err != nil {
 		return err
 	}
 	if s.secrets != nil {
-		if err := s.secrets.Delete(ctx, SecretKey); err != nil {
+		if err := s.secrets.Delete(ctx, SecretKeyForWorkspace(workspaceID)); err != nil {
 			s.log.Warn("jira: secret delete failed", zap.Error(err))
 		}
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	return nil
 }
 
@@ -202,7 +244,20 @@ func (s *Service) DeleteConfig(ctx context.Context) error {
 // structured result rather than an error so the UI can render the failure
 // inline.
 func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*TestConnectionResult, error) {
-	cfg, secret, err := s.resolveCredentials(ctx, req)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.TestConnectionForWorkspace(ctx, workspaceID, req)
+}
+
+// TestConnectionForWorkspace validates credentials for one workspace.
+func (s *Service) TestConnectionForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	cfg, secret, err := s.resolveCredentials(ctx, workspaceID, req)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -216,7 +271,20 @@ func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*T
 // tab that would 303. Errors are returned as a result so the poller can
 // persist them as a failure rather than dropping them.
 func (s *Service) ProbeAuth(ctx context.Context) (*TestConnectionResult, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.ProbeAuthForWorkspace(ctx, workspaceID)
+}
+
+// ProbeAuthForWorkspace validates the stored credentials for one workspace.
+func (s *Service) ProbeAuthForWorkspace(ctx context.Context, workspaceID string) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -254,9 +322,31 @@ func (s *Service) SetProbeHook(fn func()) {
 // the persist step are logged but not returned: this is a best-effort health
 // signal, never the source of truth for callers.
 func (s *Service) RecordAuthHealth(ctx context.Context) {
+	workspaceIDs, err := s.store.ListConfigWorkspaceIDs(ctx)
+	if err != nil {
+		s.log.Warn("jira: list config workspaces failed", zap.Error(err))
+		return
+	}
+	if len(workspaceIDs) == 0 {
+		s.fireProbeHook()
+		return
+	}
+	for _, workspaceID := range workspaceIDs {
+		s.RecordAuthHealthForWorkspace(ctx, workspaceID)
+	}
+}
+
+// RecordAuthHealthForWorkspace probes credentials and writes the outcome onto
+// one workspace row.
+func (s *Service) RecordAuthHealthForWorkspace(ctx context.Context, workspaceID string) {
+	workspaceID, normalizeErr := s.normalizeWorkspaceID(workspaceID)
+	if normalizeErr != nil {
+		s.log.Warn("jira: resolve workspace for auth health failed", zap.Error(normalizeErr))
+		return
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, authProbeTimeout)
 	defer cancel()
-	res, err := s.ProbeAuth(probeCtx)
+	res, err := s.ProbeAuthForWorkspace(probeCtx, workspaceID)
 	ok := err == nil && res != nil && res.OK
 	errMsg := ""
 	switch {
@@ -271,9 +361,13 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 	// failed" until the next poll).
 	writeCtx, writeCancel := context.WithTimeout(context.Background(), authHealthWriteTimeout)
 	defer writeCancel()
-	if updateErr := s.store.UpdateAuthHealth(writeCtx, ok, errMsg, time.Now().UTC()); updateErr != nil {
+	if updateErr := s.store.UpdateAuthHealthForWorkspace(writeCtx, workspaceID, ok, errMsg, time.Now().UTC()); updateErr != nil {
 		s.log.Warn("jira: update auth health failed", zap.Error(updateErr))
 	}
+	s.fireProbeHook()
+}
+
+func (s *Service) fireProbeHook() {
 	s.mu.Lock()
 	hook := s.probeHook
 	s.mu.Unlock()
@@ -284,7 +378,11 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 
 // GetTicket loads a Jira ticket by key using the stored credentials.
 func (s *Service) GetTicket(ctx context.Context, ticketKey string) (*JiraTicket, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +391,11 @@ func (s *Service) GetTicket(ctx context.Context, ticketKey string) (*JiraTicket,
 
 // DoTransition applies a transition to a ticket.
 func (s *Service) DoTransition(ctx context.Context, ticketKey, transitionID string) error {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return err
 	}
@@ -302,7 +404,11 @@ func (s *Service) DoTransition(ctx context.Context, ticketKey, transitionID stri
 
 // ListProjects is used by the settings UI to populate the project selector.
 func (s *Service) ListProjects(ctx context.Context) ([]JiraProject, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +430,20 @@ func (s *Service) ListProjectStatuses(ctx context.Context, projectKey string) ([
 // the cursor returned in the previous page's NextPageToken; pass "" for the
 // first page.
 func (s *Service) SearchTickets(ctx context.Context, jql, pageToken string, maxResults int) (*SearchResult, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.SearchTicketsForWorkspace(ctx, workspaceID, jql, pageToken, maxResults)
+}
+
+// SearchTicketsForWorkspace runs a JQL search against one workspace's client.
+func (s *Service) SearchTicketsForWorkspace(ctx context.Context, workspaceID, jql, pageToken string, maxResults int) (*SearchResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -333,16 +452,23 @@ func (s *Service) SearchTickets(ctx context.Context, jql, pageToken string, maxR
 
 // clientFor returns the cached client, creating it if needed. The cache is
 // invalidated whenever the config changes so stale credentials never linger.
-func (s *Service) clientFor(ctx context.Context) (Client, error) {
+func (s *Service) clientFor(ctx context.Context, workspaceID string) (Client, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
-	if s.client != nil {
-		c := s.client
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
+	}
+	if s.clients[workspaceID] != nil {
+		c := s.clients[workspaceID]
 		s.mu.Unlock()
 		return c, nil
 	}
 	s.mu.Unlock()
 
-	cfg, err := s.store.GetConfig(ctx)
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +477,7 @@ func (s *Service) clientFor(ctx context.Context) (Client, error) {
 	}
 	secret := ""
 	if s.secrets != nil {
-		secret, err = s.secrets.Reveal(ctx, SecretKey)
+		secret, err = s.revealSecret(ctx, workspaceID)
 		if err != nil {
 			// Don't conflate a transient secret-store failure with "user never
 			// configured Jira". The UI gates on ErrNotConfigured to render a
@@ -369,25 +495,30 @@ func (s *Service) clientFor(ctx context.Context) (Client, error) {
 	// Re-check: another caller may have populated the cache while we were
 	// fetching the config and secret. Returning the existing client keeps the
 	// cache identity stable so callers comparing pointers don't see flapping.
-	if s.client != nil {
-		return s.client, nil
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
 	}
-	s.client = client
+	if s.clients[workspaceID] != nil {
+		return s.clients[workspaceID], nil
+	}
+	s.clients[workspaceID] = client
 	return client, nil
 }
 
 // invalidateClient drops the cached client so the next request rebuilds it
 // with fresh credentials.
-func (s *Service) invalidateClient() {
+func (s *Service) invalidateClient(workspaceID string) {
 	s.mu.Lock()
-	s.client = nil
+	if s.clients != nil {
+		delete(s.clients, workspaceID)
+	}
 	s.mu.Unlock()
 }
 
 // resolveCredentials picks the credentials to test: if the request carries a
 // secret, use it inline (pre-save); otherwise fall back to the stored secret
 // (post-save re-test).
-func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest) (*JiraConfig, string, error) {
+func (s *Service) resolveCredentials(ctx context.Context, workspaceID string, req *SetConfigRequest) (*JiraConfig, string, error) {
 	cfg := &JiraConfig{
 		SiteURL:      normalizeSiteURL(req.SiteURL),
 		Email:        req.Email,
@@ -402,7 +533,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 			return nil, "", errors.New("no secret store configured")
 		}
 		var err error
-		secret, err = s.secrets.Reveal(ctx, SecretKey)
+		secret, err = s.revealSecret(ctx, workspaceID)
 		if err != nil {
 			// Don't conflate a transient secret-store failure with "no token
 			// stored". Surfacing the real error gives the user a path to retry
@@ -425,7 +556,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 		cfg.InstanceType == "" ||
 		(cfg.AuthMethod == AuthMethodAPIToken && cfg.Email == "")
 	if needsStoredConfig {
-		if err := s.fillConfigFromStored(ctx, cfg); err != nil {
+		if err := s.fillConfigFromStored(ctx, workspaceID, cfg); err != nil {
 			return nil, "", err
 		}
 	}
@@ -446,8 +577,8 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 // callers don't mask DB errors as opaque "missing field" validation errors;
 // a missing row (stored == nil) is treated as "nothing to fill" rather than
 // an error so first-time TestConnection requests still go through.
-func (s *Service) fillConfigFromStored(ctx context.Context, cfg *JiraConfig) error {
-	stored, err := s.store.GetConfig(ctx)
+func (s *Service) fillConfigFromStored(ctx context.Context, workspaceID string, cfg *JiraConfig) error {
+	stored, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil {
 		return fmt.Errorf("read jira config: %w", err)
 	}
@@ -467,6 +598,46 @@ func (s *Service) fillConfigFromStored(ctx context.Context, cfg *JiraConfig) err
 		cfg.InstanceType = stored.InstanceType
 	}
 	return nil
+}
+
+func (s *Service) defaultWorkspaceID() (string, error) {
+	return s.store.defaultWorkspaceID()
+}
+
+func (s *Service) normalizeWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
+}
+
+func (s *Service) secretExists(ctx context.Context, workspaceID string) (bool, error) {
+	if s.secrets == nil {
+		return false, nil
+	}
+	exists, err := s.secrets.Exists(ctx, SecretKeyForWorkspace(workspaceID))
+	if err != nil || exists {
+		return exists, err
+	}
+	return s.secrets.Exists(ctx, SecretKey)
+}
+
+func (s *Service) revealSecret(ctx context.Context, workspaceID string) (string, error) {
+	if s.secrets == nil {
+		return "", nil
+	}
+	secret, err := s.secrets.Reveal(ctx, SecretKeyForWorkspace(workspaceID))
+	if err == nil && secret != "" {
+		return secret, nil
+	}
+	legacy, legacyErr := s.secrets.Reveal(ctx, SecretKey)
+	if legacyErr == nil && legacy != "" {
+		return legacy, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", legacyErr
 }
 
 func validateConfigRequest(req *SetConfigRequest) error {
@@ -700,7 +871,7 @@ func (s *Service) ResetIssueWatch(ctx context.Context, watchID string) (int, err
 // so the UI can show liveness.
 func (s *Service) CheckIssueWatch(ctx context.Context, w *IssueWatch) ([]*JiraTicket, error) {
 	defer s.stampLastPolled(w.ID)
-	client, err := s.clientFor(ctx)
+	client, err := s.clientFor(ctx, w.WorkspaceID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/jira/service_issue_watch_test.go
+++ b/apps/backend/internal/jira/service_issue_watch_test.go
@@ -242,7 +242,7 @@ func TestService_CheckIssueWatch_FiltersAlreadySeen(t *testing.T) {
 	ctx := context.Background()
 
 	// Configure JIRA so clientFor succeeds.
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		SiteURL: "https://a.net", Email: "e",
 		AuthMethod: AuthMethodAPIToken, InstanceType: InstanceTypeCloud, Secret: "tok",
 	}); err != nil {

--- a/apps/backend/internal/jira/service_test.go
+++ b/apps/backend/internal/jira/service_test.go
@@ -156,7 +156,7 @@ func TestService_SetConfig_UpsertsAndStoresSecret(t *testing.T) {
 	if !cfg.HasSecret {
 		t.Error("expected HasSecret=true")
 	}
-	if got, _ := f.secrets.Reveal(ctx, SecretKey); got != "tok1" {
+	if got, _ := f.secrets.Reveal(ctx, SecretKeyForWorkspace("default")); got != "tok1" {
 		t.Errorf("secret stored = %q", got)
 	}
 }
@@ -236,7 +236,7 @@ func TestService_SetConfig_EmptySecret_KeepsExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
-	if got, _ := f.secrets.Reveal(ctx, SecretKey); got != "first" {
+	if got, _ := f.secrets.Reveal(ctx, SecretKeyForWorkspace("default")); got != "first" {
 		t.Errorf("secret should be preserved, got %q", got)
 	}
 }

--- a/apps/backend/internal/jira/store.go
+++ b/apps/backend/internal/jira/store.go
@@ -9,20 +9,20 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/integrations/workspacescope"
 )
 
-// Store persists the Jira configuration. Secret values are delegated to the
-// shared encrypted secret store and not stored here. The configuration is a
-// singleton — there is one Jira account per install, not one per workspace.
+// Store persists workspace-scoped Jira configuration. Secret values are
+// delegated to the shared encrypted secret store and not stored here.
 type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
-	// migratedFromWorkspace records the workspace_id of the row that was
-	// promoted into the singleton during initSchema. Provider reads this to
-	// migrate the per-workspace secret to the new global key. Empty when no
-	// migration ran (fresh install or already migrated).
-	migratedFromWorkspace string
+	// migratedToWorkspace records the workspace_id that received a legacy
+	// singleton row during initSchema. Provider reads this to migrate the
+	// singleton secret to the workspace-scoped key. Empty when no migration ran.
+	migratedToWorkspace string
 }
 
 // NewStore creates a new Store and initializes the schema if needed.
@@ -34,16 +34,15 @@ func NewStore(writer, reader *sqlx.DB) (*Store, error) {
 	return s, nil
 }
 
-// MigratedFromWorkspace returns the workspace_id of the row promoted to the
-// singleton during the per-workspace → singleton schema migration, or "" when
-// no migration ran. Provider uses this to copy the secret over.
+// MigratedFromWorkspace is kept for older provider call sites. It now returns
+// the workspace_id that received a legacy singleton row during migration.
 func (s *Store) MigratedFromWorkspace() string {
-	return s.migratedFromWorkspace
+	return s.migratedToWorkspace
 }
 
 const createTablesSQL = `
 	CREATE TABLE IF NOT EXISTS jira_configs (
-		id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+		workspace_id TEXT PRIMARY KEY,
 		site_url TEXT NOT NULL,
 		email TEXT NOT NULL DEFAULT '',
 		auth_method TEXT NOT NULL,
@@ -97,19 +96,21 @@ const createTablesSQL = `
 	);
 `
 
-// singletonID is the synthetic primary key of the (only) row in jira_configs.
-// The CHECK constraint on the column makes inserting any other id an error,
-// so the table can never accidentally grow back to per-workspace rows.
+// singletonID is the synthetic primary key used by the legacy install-wide
+// jira_configs table.
 const singletonID = "singleton"
 
 func (s *Store) initSchema() error {
-	if err := s.migrateLegacyPerWorkspaceTable(); err != nil {
+	if err := s.migrateLegacySingletonTable(); err != nil {
 		return err
 	}
 	if _, err := s.db.Exec(createTablesSQL); err != nil {
 		return err
 	}
 	if err := s.addInstanceTypeColumn(); err != nil {
+		return err
+	}
+	if err := s.addConfigHealthColumns(); err != nil {
 		return err
 	}
 	if err := s.addMaxInflightTasksColumn(); err != nil {
@@ -120,6 +121,32 @@ func (s *Store) initSchema() error {
 	}
 	if err := s.addIssueWatchRepositoryColumns(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (s *Store) addConfigHealthColumns() error {
+	cols, err := s.tableColumns("jira_configs")
+	if err != nil {
+		return err
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+	if _, ok := cols["last_checked_at"]; !ok {
+		if _, err := s.db.Exec(`ALTER TABLE jira_configs ADD COLUMN last_checked_at DATETIME`); err != nil {
+			return fmt.Errorf("add last_checked_at column: %w", err)
+		}
+	}
+	if _, ok := cols["last_ok"]; !ok {
+		if _, err := s.db.Exec(`ALTER TABLE jira_configs ADD COLUMN last_ok INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add last_ok column: %w", err)
+		}
+	}
+	if _, ok := cols["last_error"]; !ok {
+		if _, err := s.db.Exec(`ALTER TABLE jira_configs ADD COLUMN last_error TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add last_error column: %w", err)
+		}
 	}
 	return nil
 }
@@ -212,14 +239,10 @@ func (s *Store) addInstanceTypeColumn() error {
 	return nil
 }
 
-// migrateLegacyPerWorkspaceTable detects the pre-singleton schema (where
-// jira_configs was keyed by workspace_id) and rewrites it into the singleton
-// shape. Picks the most-recently-updated row as the surviving config and
-// records the source workspace_id so the provider can migrate the secret.
-//
-// Idempotent: a fresh install has no legacy table and falls through to the
-// CREATE TABLE IF NOT EXISTS in createTablesSQL.
-func (s *Store) migrateLegacyPerWorkspaceTable() error {
+// migrateLegacySingletonTable detects the install-wide singleton schema and
+// rewrites it into the workspace-scoped shape. Picks the active/default
+// workspace as the target so startup is deterministic.
+func (s *Store) migrateLegacySingletonTable() error {
 	cols, err := s.tableColumns("jira_configs")
 	if err != nil {
 		return err
@@ -227,8 +250,15 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	if len(cols) == 0 {
 		return nil
 	}
-	if _, hasWorkspace := cols["workspace_id"]; !hasWorkspace {
+	if _, hasWorkspace := cols["workspace_id"]; hasWorkspace {
 		return nil
+	}
+	if _, hasID := cols["id"]; !hasID {
+		return nil
+	}
+	targetWorkspace, err := workspacescope.ResolveMigrationTarget(s.db)
+	if err != nil {
+		return err
 	}
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -236,25 +266,20 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// `last_checked_at`, `last_ok`, and `last_error` were added to the legacy
-	// schema in a later release via ALTER TABLE. A deployment that upgrades
-	// from the original schema would have a `workspace_id` column but not
-	// these — selecting them unconditionally would crash startup. Build the
-	// SELECT against only columns present in this database.
 	healthCols := healthColumnsPresent(cols)
-	selectCols := "workspace_id, site_url, email, auth_method, default_project_key"
+	selectCols := "site_url, email, auth_method, default_project_key"
 	if healthCols {
 		selectCols += ", last_checked_at, last_ok, last_error"
 	} else {
 		selectCols += ", NULL AS last_checked_at, 0 AS last_ok, '' AS last_error"
 	}
 	selectCols += ", created_at, updated_at"
-	var sourceWorkspace, siteURL, email, authMethod, defaultProjectKey, lastError sql.NullString
+	var siteURL, email, authMethod, defaultProjectKey, lastError sql.NullString
 	var lastCheckedAt sql.NullTime
 	var lastOk sql.NullInt64
 	var createdAt, updatedAt sql.NullTime
-	row := tx.QueryRow(`SELECT ` + selectCols + ` FROM jira_configs ORDER BY updated_at DESC LIMIT 1`)
-	switch err := row.Scan(&sourceWorkspace, &siteURL, &email, &authMethod, &defaultProjectKey,
+	row := tx.QueryRow(`SELECT `+selectCols+` FROM jira_configs WHERE id = ? LIMIT 1`, singletonID)
+	switch err := row.Scan(&siteURL, &email, &authMethod, &defaultProjectKey,
 		&lastCheckedAt, &lastOk, &lastError, &createdAt, &updatedAt); {
 	case errors.Is(err, sql.ErrNoRows):
 		// Empty legacy table — drop and let createTablesSQL build the new shape.
@@ -270,7 +295,7 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	}
 	if _, err := tx.Exec(`
 		CREATE TABLE jira_configs (
-			id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+			workspace_id TEXT PRIMARY KEY,
 			site_url TEXT NOT NULL,
 			email TEXT NOT NULL DEFAULT '',
 			auth_method TEXT NOT NULL,
@@ -284,14 +309,11 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 		)`); err != nil {
 		return err
 	}
-	// instance_type column is intentionally omitted from the INSERT: the column
-	// default ('cloud') is the correct value for every legacy row, since prior
-	// releases only supported Atlassian Cloud.
 	if _, err := tx.Exec(`
-		INSERT INTO jira_configs (id, site_url, email, auth_method, default_project_key,
+		INSERT INTO jira_configs (workspace_id, site_url, email, auth_method, default_project_key,
 			last_checked_at, last_ok, last_error, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		singletonID, siteURL.String, email.String, authMethod.String, defaultProjectKey.String,
+		targetWorkspace, siteURL.String, email.String, authMethod.String, defaultProjectKey.String,
 		nullableTime(lastCheckedAt), lastOk.Int64, lastError.String,
 		nullableTime(createdAt), nullableTime(updatedAt)); err != nil {
 		return err
@@ -299,7 +321,7 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	s.migratedFromWorkspace = sourceWorkspace.String
+	s.migratedToWorkspace = targetWorkspace
 	return nil
 }
 
@@ -347,14 +369,29 @@ func (s *Store) tableColumns(table string) (map[string]struct{}, error) {
 	return cols, rows.Err()
 }
 
-const selectConfigColumns = `site_url, email, auth_method, instance_type, default_project_key,
+const selectConfigColumns = `workspace_id, site_url, email, auth_method, instance_type, default_project_key,
 		last_checked_at, last_ok, last_error, created_at, updated_at`
 
-// GetConfig returns the singleton Jira config, or nil when no row exists.
+// GetConfig returns the default workspace Jira config, or nil when no row
+// exists. New code should call GetConfigForWorkspace.
 func (s *Store) GetConfig(ctx context.Context) (*JiraConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns the Jira config for a workspace, or nil when
+// no row exists.
+func (s *Store) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*JiraConfig, error) {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	var cfg JiraConfig
-	err := s.ro.GetContext(ctx, &cfg,
-		`SELECT `+selectConfigColumns+` FROM jira_configs WHERE id = ?`, singletonID)
+	err = s.ro.GetContext(ctx, &cfg,
+		`SELECT `+selectConfigColumns+` FROM jira_configs WHERE workspace_id = ?`, workspaceID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -364,11 +401,24 @@ func (s *Store) GetConfig(ctx context.Context) (*JiraConfig, error) {
 	return &cfg, nil
 }
 
-// UpsertConfig inserts or updates the singleton config row. It never touches
+// UpsertConfig inserts or updates the default workspace config row. It never touches
 // the secret store — callers must persist the token separately. The last_*
 // health columns are deliberately not touched here; the poller owns those and
 // writes them via UpdateAuthHealth.
 func (s *Store) UpsertConfig(ctx context.Context, cfg *JiraConfig) error {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpsertConfigForWorkspace(ctx, workspaceID, cfg)
+}
+
+// UpsertConfigForWorkspace inserts or updates a workspace config row.
+func (s *Store) UpsertConfigForWorkspace(ctx context.Context, workspaceID string, cfg *JiraConfig) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 	if cfg.CreatedAt.IsZero() {
 		cfg.CreatedAt = now
@@ -380,50 +430,97 @@ func (s *Store) UpsertConfig(ctx context.Context, cfg *JiraConfig) error {
 	if cfg.InstanceType == "" {
 		cfg.InstanceType = InstanceTypeCloud
 	}
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO jira_configs (id, site_url, email, auth_method, instance_type, default_project_key, created_at, updated_at)
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO jira_configs (workspace_id, site_url, email, auth_method, instance_type, default_project_key, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
+		ON CONFLICT(workspace_id) DO UPDATE SET
 			site_url = excluded.site_url,
 			email = excluded.email,
 			auth_method = excluded.auth_method,
 			instance_type = excluded.instance_type,
 			default_project_key = excluded.default_project_key,
 			updated_at = excluded.updated_at`,
-		singletonID, cfg.SiteURL, cfg.Email, cfg.AuthMethod, cfg.InstanceType, cfg.DefaultProjectKey, cfg.CreatedAt, cfg.UpdatedAt)
+		workspaceID, cfg.SiteURL, cfg.Email, cfg.AuthMethod, cfg.InstanceType, cfg.DefaultProjectKey, cfg.CreatedAt, cfg.UpdatedAt)
 	return err
 }
 
-// DeleteConfig removes the singleton config row. Secrets must be cleared
+// DeleteConfig removes the default workspace config row. Secrets must be cleared
 // separately by the caller.
 func (s *Store) DeleteConfig(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM jira_configs WHERE id = ?`, singletonID)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes the workspace config row.
+func (s *Store) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `DELETE FROM jira_configs WHERE workspace_id = ?`, workspaceID)
 	return err
 }
 
-// HasConfig reports whether the singleton row exists. Used by the auth-health
+// HasConfig reports whether any config row exists. Used by the auth-health
 // poller to decide whether to probe at all.
 func (s *Store) HasConfig(ctx context.Context) (bool, error) {
 	var present int
 	err := s.ro.GetContext(ctx, &present,
-		`SELECT COUNT(*) FROM jira_configs WHERE id = ?`, singletonID)
+		`SELECT COUNT(*) FROM jira_configs`)
 	if err != nil {
 		return false, err
 	}
 	return present > 0, nil
 }
 
-// UpdateAuthHealth records the result of a credential probe on the singleton
+// ListConfigWorkspaceIDs returns every workspace with a saved Jira config.
+func (s *Store) ListConfigWorkspaceIDs(ctx context.Context) ([]string, error) {
+	var ids []string
+	if err := s.ro.SelectContext(ctx, &ids, `SELECT workspace_id FROM jira_configs ORDER BY workspace_id`); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+// UpdateAuthHealth records the result of a credential probe on the default workspace
 // config row. errMsg is the empty string when ok is true. If the row no longer
 // exists (e.g. the user removed the config concurrently with the poller), the
 // update is a silent no-op rather than an error.
 func (s *Store) UpdateAuthHealth(ctx context.Context, ok bool, errMsg string, checkedAt time.Time) error {
-	_, err := s.db.ExecContext(ctx, `
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpdateAuthHealthForWorkspace(ctx, workspaceID, ok, errMsg, checkedAt)
+}
+
+// UpdateAuthHealthForWorkspace records the result of a credential probe for a
+// single workspace config row.
+func (s *Store) UpdateAuthHealthForWorkspace(ctx context.Context, workspaceID string, ok bool, errMsg string, checkedAt time.Time) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
 		UPDATE jira_configs
 		SET last_checked_at = ?, last_ok = ?, last_error = ?
-		WHERE id = ?`,
-		checkedAt, ok, errMsg, singletonID)
+		WHERE workspace_id = ?`,
+		checkedAt, ok, errMsg, workspaceID)
 	return err
+}
+
+func (s *Store) defaultWorkspaceID() (string, error) {
+	return workspacescope.ResolveMigrationTarget(s.db)
+}
+
+func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
 }
 
 // --- Issue watch operations ---

--- a/apps/backend/internal/jira/store.go
+++ b/apps/backend/internal/jira/store.go
@@ -19,6 +19,8 @@ type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
+	defaultWorkspace workspacescope.CachedResolver
+
 	// migratedToWorkspace records the workspace_id that received a legacy
 	// singleton row during initSchema. Provider reads this to migrate the
 	// singleton secret to the workspace-scoped key. Empty when no migration ran.
@@ -513,7 +515,7 @@ func (s *Store) UpdateAuthHealthForWorkspace(ctx context.Context, workspaceID st
 }
 
 func (s *Store) defaultWorkspaceID() (string, error) {
-	return workspacescope.ResolveMigrationTarget(s.db)
+	return s.defaultWorkspace.Resolve(s.db)
 }
 
 func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {

--- a/apps/backend/internal/jira/store_test.go
+++ b/apps/backend/internal/jira/store_test.go
@@ -114,6 +114,73 @@ func TestStore_HasConfig(t *testing.T) {
 	}
 }
 
+func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
+	raw, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	db := sqlx.NewDb(raw, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			email TEXT NOT NULL,
+			settings TEXT NOT NULL DEFAULT '{}',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE jira_configs (
+			id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+			site_url TEXT NOT NULL,
+			email TEXT NOT NULL DEFAULT '',
+			auth_method TEXT NOT NULL,
+			default_project_key TEXT NOT NULL DEFAULT '',
+			last_checked_at DATETIME,
+			last_ok INTEGER NOT NULL DEFAULT 0,
+			last_error TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		INSERT INTO workspaces (id, name, created_at, updated_at)
+			VALUES ('ws-first', 'First', ?, ?), ('ws-active', 'Active', ?, ?);
+		INSERT INTO users (id, email, settings, created_at, updated_at)
+			VALUES ('default-user', 'default@kandev.local', '{"workspace_id":"ws-active"}', ?, ?);
+		INSERT INTO jira_configs
+			(id, site_url, email, auth_method, default_project_key, last_ok, created_at, updated_at)
+			VALUES ('singleton', 'https://acme.atlassian.net', 'user@example.com', ?, 'ENG', 1, ?, ?);
+	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, AuthMethodAPIToken, now, now); err != nil {
+		t.Fatalf("seed singleton schema: %v", err)
+	}
+
+	store, err := NewStore(db, db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if got := store.MigratedFromWorkspace(); got != "ws-active" {
+		t.Fatalf("expected singleton config migrated to active workspace, got %q", got)
+	}
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-active")
+	if err != nil {
+		t.Fatalf("get active workspace config: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected migrated config")
+	}
+	if cfg.SiteURL != "https://acme.atlassian.net" || cfg.DefaultProjectKey != "ENG" {
+		t.Errorf("unexpected migrated config: %+v", cfg)
+	}
+}
+
 func TestStore_UpdateAuthHealth(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/apps/backend/internal/jira/store_test.go
+++ b/apps/backend/internal/jira/store_test.go
@@ -125,6 +125,7 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	now := time.Now().UTC()
+	checkedAt := now.Add(-5 * time.Minute).Truncate(time.Second)
 	if _, err := db.Exec(`
 		CREATE TABLE workspaces (
 			id TEXT PRIMARY KEY,
@@ -156,9 +157,9 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 		INSERT INTO users (id, email, settings, created_at, updated_at)
 			VALUES ('default-user', 'default@kandev.local', '{"workspace_id":"ws-active"}', ?, ?);
 		INSERT INTO jira_configs
-			(id, site_url, email, auth_method, default_project_key, last_ok, created_at, updated_at)
-			VALUES ('singleton', 'https://acme.atlassian.net', 'user@example.com', ?, 'ENG', 1, ?, ?);
-	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, AuthMethodAPIToken, now, now); err != nil {
+			(id, site_url, email, auth_method, default_project_key, last_checked_at, last_ok, last_error, created_at, updated_at)
+			VALUES ('singleton', 'https://acme.atlassian.net', 'user@example.com', ?, 'ENG', ?, 1, 'healthy', ?, ?);
+	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, AuthMethodAPIToken, checkedAt, now, now); err != nil {
 		t.Fatalf("seed singleton schema: %v", err)
 	}
 
@@ -178,6 +179,15 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 	}
 	if cfg.SiteURL != "https://acme.atlassian.net" || cfg.DefaultProjectKey != "ENG" {
 		t.Errorf("unexpected migrated config: %+v", cfg)
+	}
+	if cfg.Email != "user@example.com" || cfg.AuthMethod != AuthMethodAPIToken {
+		t.Errorf("unexpected migrated auth fields: %+v", cfg)
+	}
+	if !cfg.LastOk || cfg.LastError != "healthy" {
+		t.Errorf("unexpected migrated health state: %+v", cfg)
+	}
+	if cfg.LastCheckedAt == nil || !cfg.LastCheckedAt.Equal(checkedAt) {
+		t.Errorf("expected last_checked_at=%v, got %v", checkedAt, cfg.LastCheckedAt)
 	}
 }
 

--- a/apps/backend/internal/jira/store_test.go
+++ b/apps/backend/internal/jira/store_test.go
@@ -213,18 +213,18 @@ func TestStore_MigrateLegacyPerWorkspaceTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new store: %v", err)
 	}
-	if got := store.MigratedFromWorkspace(); got != "ws-new" {
-		t.Errorf("expected migration source ws-new, got %q", got)
+	if got := store.MigratedFromWorkspace(); got != "" {
+		t.Errorf("expected no singleton migration, got %q", got)
 	}
-	cfg, err := store.GetConfig(context.Background())
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-new")
 	if err != nil {
-		t.Fatalf("get singleton: %v", err)
+		t.Fatalf("get workspace config: %v", err)
 	}
 	if cfg == nil {
-		t.Fatal("expected singleton row after migration")
+		t.Fatal("expected workspace row after schema init")
 	}
 	if cfg.SiteURL != "https://new.atlassian.net" {
-		t.Errorf("expected newest row promoted, got SiteURL=%q", cfg.SiteURL)
+		t.Errorf("expected workspace row preserved, got SiteURL=%q", cfg.SiteURL)
 	}
 }
 
@@ -312,15 +312,15 @@ func TestStore_MigrateLegacyPerWorkspaceTable_PreHealthColumns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore on pre-health-columns schema: %v", err)
 	}
-	if got := store.MigratedFromWorkspace(); got != "ws-1" {
-		t.Errorf("expected migration source ws-1, got %q", got)
+	if got := store.MigratedFromWorkspace(); got != "" {
+		t.Errorf("expected no singleton migration, got %q", got)
 	}
-	cfg, err := store.GetConfig(context.Background())
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-1")
 	if err != nil {
-		t.Fatalf("get singleton: %v", err)
+		t.Fatalf("get workspace config: %v", err)
 	}
 	if cfg == nil {
-		t.Fatal("expected singleton row after migration")
+		t.Fatal("expected workspace row after schema init")
 	}
 	if cfg.SiteURL != "https://acme.atlassian.net" {
 		t.Errorf("expected SiteURL preserved, got %q", cfg.SiteURL)

--- a/apps/backend/internal/linear/handlers.go
+++ b/apps/backend/internal/linear/handlers.go
@@ -56,7 +56,7 @@ func (c *Controller) RegisterHTTPRoutes(router *gin.Engine) {
 // --- HTTP handlers ---
 
 func (c *Controller) httpGetConfig(ctx *gin.Context) {
-	cfg, err := c.service.GetConfig(ctx.Request.Context())
+	cfg, err := c.service.GetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx))
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -74,7 +74,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	cfg, err := c.service.SetConfig(ctx.Request.Context(), &req)
+	cfg, err := c.service.SetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrInvalidConfig) {
@@ -87,7 +87,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 }
 
 func (c *Controller) httpDeleteConfig(ctx *gin.Context) {
-	if err := c.service.DeleteConfig(ctx.Request.Context()); err != nil {
+	if err := c.service.DeleteConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx)); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -100,7 +100,7 @@ func (c *Controller) httpTestConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	result, err := c.service.TestConnection(ctx.Request.Context(), &req)
+	result, err := c.service.TestConnectionForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -109,7 +109,12 @@ func (c *Controller) httpTestConfig(ctx *gin.Context) {
 }
 
 func (c *Controller) httpListTeams(ctx *gin.Context) {
-	teams, err := c.service.ListTeams(ctx.Request.Context())
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	teams, err := client.ListTeams(ctx.Request.Context())
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -123,7 +128,12 @@ func (c *Controller) httpListStates(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": teamKeyRequired})
 		return
 	}
-	states, err := c.service.ListStates(ctx.Request.Context(), teamKey)
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	states, err := client.ListStates(ctx.Request.Context(), teamKey)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -137,7 +147,12 @@ func (c *Controller) httpListLabels(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": teamKeyRequired})
 		return
 	}
-	labels, err := c.service.ListLabels(ctx.Request.Context(), teamKey)
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	labels, err := client.ListLabels(ctx.Request.Context(), teamKey)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -151,7 +166,12 @@ func (c *Controller) httpListUsers(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": teamKeyRequired})
 		return
 	}
-	users, err := c.service.ListUsers(ctx.Request.Context(), teamKey)
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	users, err := client.ListUsers(ctx.Request.Context(), teamKey)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -178,12 +198,16 @@ func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 	}
 	pageToken := ctx.Query("page_token")
 	maxResults, _ := strconv.Atoi(ctx.Query("max_results"))
-	result, err := c.service.SearchIssues(ctx.Request.Context(), filter, pageToken, maxResults)
+	result, err := c.service.SearchIssuesForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), filter, pageToken, maxResults)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, result)
+}
+
+func (c *Controller) workspaceID(ctx *gin.Context) string {
+	return strings.TrimSpace(ctx.Query("workspace_id"))
 }
 
 // parseSearchNumericFilters parses priority + estimate query params onto the

--- a/apps/backend/internal/linear/mock_controller.go
+++ b/apps/backend/internal/linear/mock_controller.go
@@ -57,7 +57,14 @@ func (c *MockController) setAuthHealth(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	if err := c.store.UpdateAuthHealth(ctx.Request.Context(), req.OK, req.Error, req.OrgSlug, time.Now().UTC()); err != nil {
+	workspaceID := ctx.Query("workspace_id")
+	var err error
+	if workspaceID == "" {
+		err = c.store.UpdateAuthHealth(ctx.Request.Context(), req.OK, req.Error, req.OrgSlug, time.Now().UTC())
+	} else {
+		err = c.store.UpdateAuthHealthForWorkspace(ctx.Request.Context(), workspaceID, req.OK, req.Error, req.OrgSlug, time.Now().UTC())
+	}
+	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/apps/backend/internal/linear/models.go
+++ b/apps/backend/internal/linear/models.go
@@ -15,10 +15,10 @@ import (
 // and leaves room for OAuth in the future.
 const AuthMethodAPIKey = "api_key"
 
-// LinearConfig is the install-wide configuration for the Linear integration.
-// The API key is stored separately in the encrypted secret store under
-// SecretKey.
+// LinearConfig is the workspace-scoped configuration for the Linear
+// integration. The API key is stored separately in the encrypted secret store.
 type LinearConfig struct {
+	WorkspaceID    string `json:"workspaceId,omitempty" db:"workspace_id"`
 	AuthMethod     string `json:"authMethod" db:"auth_method"`
 	DefaultTeamKey string `json:"defaultTeamKey" db:"default_team_key"`
 	HasSecret      bool   `json:"hasSecret" db:"-"`
@@ -181,15 +181,18 @@ type SearchResult struct {
 	NextPageToken string        `json:"nextPageToken,omitempty"`
 }
 
-// SecretKey is the secret-store key used for the install-wide Linear API key.
-// Centralised so the service, store and provider migration agree.
+// SecretKey is the legacy secret-store key used for the old install-wide Linear
+// API key. New workspace-scoped configs use SecretKeyForWorkspace.
 const SecretKey = "linear:singleton:token"
 
-// LegacySecretKeyForWorkspace returns the pre-singleton per-workspace secret
-// key. Only used by the one-shot startup migration in provider.go to copy an
-// existing token over to SecretKey.
-func LegacySecretKeyForWorkspace(workspaceID string) string {
+// SecretKeyForWorkspace returns the workspace-scoped Linear secret key.
+func SecretKeyForWorkspace(workspaceID string) string {
 	return "linear:" + workspaceID + ":token"
+}
+
+// LegacySecretKeyForWorkspace is kept for older tests/callers.
+func LegacySecretKeyForWorkspace(workspaceID string) string {
+	return SecretKeyForWorkspace(workspaceID)
 }
 
 // DefaultIssueWatchPollInterval is the polling cadence assigned to a watcher

--- a/apps/backend/internal/linear/poller_issue_watch_test.go
+++ b/apps/backend/internal/linear/poller_issue_watch_test.go
@@ -49,7 +49,7 @@ func (r *recordingSubscriber) snapshot() []*NewLinearIssueEvent {
 func TestPoller_CheckIssueWatches_PublishesNewIssuesOnly(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()
@@ -108,7 +108,7 @@ func TestPoller_CheckIssueWatches_PublishesNewIssuesOnly(t *testing.T) {
 func TestPoller_CheckIssueWatches_SkipsDisabled(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()
@@ -183,7 +183,7 @@ func TestIsIssueWatchDue(t *testing.T) {
 func TestPoller_CheckIssueWatches_RespectsPerWatchInterval(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()

--- a/apps/backend/internal/linear/poller_test.go
+++ b/apps/backend/internal/linear/poller_test.go
@@ -36,17 +36,29 @@ func newPollerFixture(t *testing.T) *pollerFixture {
 	return f
 }
 
-// saveConfig persists the singleton config directly via the store + secret
+// saveConfig persists the default workspace config directly via the store + secret
 // fakes — bypassing Service.SetConfig avoids racing against its async probe.
 func (f *pollerFixture) saveConfig(t *testing.T, secret string) {
 	t.Helper()
+	f.saveConfigForWorkspace(t, "", secret)
+}
+
+// saveConfigForWorkspace persists a workspace config directly via the store +
+// secret fakes — bypassing Service.SetConfig avoids racing against its async
+// probe.
+func (f *pollerFixture) saveConfigForWorkspace(t *testing.T, workspaceID, secret string) {
+	t.Helper()
 	ctx := context.Background()
-	if err := f.store.UpsertConfig(ctx, &LinearConfig{
+	if err := f.store.UpsertConfigForWorkspace(ctx, workspaceID, &LinearConfig{
 		AuthMethod: AuthMethodAPIKey,
 	}); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
-	if err := f.secrets.Set(ctx, SecretKey, "linear", secret); err != nil {
+	key := SecretKey
+	if workspaceID != "" {
+		key = SecretKeyForWorkspace(workspaceID)
+	}
+	if err := f.secrets.Set(ctx, key, "linear", secret); err != nil {
 		t.Fatalf("save secret: %v", err)
 	}
 }

--- a/apps/backend/internal/linear/provider.go
+++ b/apps/backend/internal/linear/provider.go
@@ -52,30 +52,31 @@ func Provide(writer, reader *sqlx.DB, secrets SecretStore, eventBus bus.EventBus
 	return svc, cleanup, nil
 }
 
-// migrateLegacySecret copies the per-workspace API key from the pre-singleton
-// secret key onto the new install-wide key, then deletes the legacy entry.
+// migrateLegacySecret copies the old install-wide API key onto the
+// workspace-scoped key created by the config migration, then deletes the legacy
+// entry. If the workspace key already exists, it leaves both values alone.
 // Best-effort: any error is logged and ignored — the worst case is the user
 // re-pastes their key in the settings UI.
 func migrateLegacySecret(store *Store, secrets SecretStore, log *logger.Logger) {
-	source := store.MigratedFromWorkspace()
-	if source == "" || secrets == nil {
+	target := store.MigratedFromWorkspace()
+	if target == "" || secrets == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if exists, err := secrets.Exists(ctx, SecretKey); err == nil && exists {
+	targetKey := SecretKeyForWorkspace(target)
+	if exists, err := secrets.Exists(ctx, targetKey); err == nil && exists {
 		return
 	}
-	legacyKey := LegacySecretKeyForWorkspace(source)
-	value, err := secrets.Reveal(ctx, legacyKey)
+	value, err := secrets.Reveal(ctx, SecretKey)
 	if err != nil || value == "" {
 		return
 	}
-	if err := secrets.Set(ctx, SecretKey, "Linear API key", value); err != nil {
+	if err := secrets.Set(ctx, targetKey, "Linear API key", value); err != nil {
 		log.Warn("linear: legacy secret migration failed", zap.Error(err))
 		return
 	}
-	if err := secrets.Delete(ctx, legacyKey); err != nil {
+	if err := secrets.Delete(ctx, SecretKey); err != nil {
 		log.Warn("linear: legacy secret cleanup failed", zap.Error(err))
 	}
 }

--- a/apps/backend/internal/linear/service.go
+++ b/apps/backend/internal/linear/service.go
@@ -39,7 +39,7 @@ type Service struct {
 	log       *logger.Logger
 	mu        sync.Mutex
 	clientFn  ClientFactory
-	client    Client // singleton, cleared on config change.
+	clients   map[string]Client
 	probeHook func()
 	eventBus  bus.EventBus
 	// taskDeleter is the cascade-delete entry point used by ResetIssueWatch.
@@ -105,19 +105,33 @@ func NewService(store *Store, secrets SecretStore, clientFn ClientFactory, log *
 		secrets:  secrets,
 		log:      log,
 		clientFn: clientFn,
+		clients:  make(map[string]Client),
 	}
 }
 
-// GetConfig returns the singleton config enriched with a HasSecret flag.
+// GetConfig returns the default workspace config enriched with a HasSecret flag.
 func (s *Service) GetConfig(ctx context.Context) (*LinearConfig, error) {
-	cfg, err := s.store.GetConfig(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns a workspace config enriched with a HasSecret flag.
+func (s *Service) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*LinearConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil || cfg == nil {
 		return cfg, err
 	}
 	if s.secrets == nil {
 		return cfg, nil
 	}
-	exists, existsErr := s.secrets.Exists(ctx, SecretKey)
+	exists, existsErr := s.secretExists(ctx, workspaceID)
 	if existsErr != nil {
 		s.log.Warn("linear: secret exists check failed", zap.Error(existsErr))
 	}
@@ -130,6 +144,20 @@ var ErrInvalidConfig = errors.New("linear: invalid configuration")
 
 // SetConfig is upsert. An empty Secret on update keeps the existing token.
 func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*LinearConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.SetConfigForWorkspace(ctx, workspaceID, req)
+}
+
+// SetConfigForWorkspace is upsert for one workspace. An empty Secret on update
+// keeps the existing token.
+func (s *Service) SetConfigForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*LinearConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	if err := validateConfigRequest(req); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidConfig, err.Error())
 	}
@@ -137,40 +165,66 @@ func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*Linear
 		AuthMethod:     req.AuthMethod,
 		DefaultTeamKey: req.DefaultTeamKey,
 	}
-	if err := s.store.UpsertConfig(ctx, cfg); err != nil {
+	if err := s.store.UpsertConfigForWorkspace(ctx, workspaceID, cfg); err != nil {
 		return nil, fmt.Errorf("upsert linear config: %w", err)
 	}
 	if req.Secret != "" && s.secrets != nil {
-		if err := s.secrets.Set(ctx, SecretKey, "Linear API key", req.Secret); err != nil {
+		if err := s.secrets.Set(ctx, SecretKeyForWorkspace(workspaceID), "Linear API key", req.Secret); err != nil {
 			return nil, fmt.Errorf("store linear secret: %w", err)
 		}
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	// Probe asynchronously so a slow Linear doesn't stall the save response.
 	go func() {
-		s.RecordAuthHealth(context.Background())
+		s.RecordAuthHealthForWorkspace(context.Background(), workspaceID)
 	}()
-	return s.GetConfig(ctx)
+	return s.GetConfigForWorkspace(ctx, workspaceID)
 }
 
 // DeleteConfig removes both the config row and the stored secret.
 func (s *Service) DeleteConfig(ctx context.Context) error {
-	if err := s.store.DeleteConfig(ctx); err != nil {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes both the config row and the stored secret.
+func (s *Service) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	if err := s.store.DeleteConfigForWorkspace(ctx, workspaceID); err != nil {
 		return err
 	}
 	if s.secrets != nil {
-		if err := s.secrets.Delete(ctx, SecretKey); err != nil {
+		if err := s.secrets.Delete(ctx, SecretKeyForWorkspace(workspaceID)); err != nil {
 			s.log.Warn("linear: secret delete failed", zap.Error(err))
 		}
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	return nil
 }
 
 // TestConnection validates credentials either from a fresh SetConfigRequest
 // (before persisting) or from the stored config (after saving).
 func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*TestConnectionResult, error) {
-	cfg, secret, err := s.resolveCredentials(ctx, req)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.TestConnectionForWorkspace(ctx, workspaceID, req)
+}
+
+// TestConnectionForWorkspace validates credentials for one workspace.
+func (s *Service) TestConnectionForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	cfg, secret, err := s.resolveCredentials(ctx, workspaceID, req)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -180,7 +234,20 @@ func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*T
 
 // ProbeAuth validates the stored credentials.
 func (s *Service) ProbeAuth(ctx context.Context) (*TestConnectionResult, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.ProbeAuthForWorkspace(ctx, workspaceID)
+}
+
+// ProbeAuthForWorkspace validates the stored credentials for one workspace.
+func (s *Service) ProbeAuthForWorkspace(ctx context.Context, workspaceID string) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -209,9 +276,31 @@ func (s *Service) SetProbeHook(fn func()) {
 
 // RecordAuthHealth probes credentials and writes the outcome onto the row.
 func (s *Service) RecordAuthHealth(ctx context.Context) {
+	workspaceIDs, err := s.store.ListConfigWorkspaceIDs(ctx)
+	if err != nil {
+		s.log.Warn("linear: list config workspaces failed", zap.Error(err))
+		return
+	}
+	if len(workspaceIDs) == 0 {
+		s.fireProbeHook()
+		return
+	}
+	for _, workspaceID := range workspaceIDs {
+		s.RecordAuthHealthForWorkspace(ctx, workspaceID)
+	}
+}
+
+// RecordAuthHealthForWorkspace probes credentials and writes the outcome onto
+// one workspace row.
+func (s *Service) RecordAuthHealthForWorkspace(ctx context.Context, workspaceID string) {
+	workspaceID, normalizeErr := s.normalizeWorkspaceID(workspaceID)
+	if normalizeErr != nil {
+		s.log.Warn("linear: resolve workspace for auth health failed", zap.Error(normalizeErr))
+		return
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, authProbeTimeout)
 	defer cancel()
-	res, err := s.ProbeAuth(probeCtx)
+	res, err := s.ProbeAuthForWorkspace(probeCtx, workspaceID)
 	ok := err == nil && res != nil && res.OK
 	errMsg := ""
 	switch {
@@ -228,9 +317,13 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 	// still record the failure.
 	writeCtx, writeCancel := context.WithTimeout(context.Background(), authHealthWriteTimeout)
 	defer writeCancel()
-	if updateErr := s.store.UpdateAuthHealth(writeCtx, ok, errMsg, orgSlug, time.Now().UTC()); updateErr != nil {
+	if updateErr := s.store.UpdateAuthHealthForWorkspace(writeCtx, workspaceID, ok, errMsg, orgSlug, time.Now().UTC()); updateErr != nil {
 		s.log.Warn("linear: update auth health failed", zap.Error(updateErr))
 	}
+	s.fireProbeHook()
+}
+
+func (s *Service) fireProbeHook() {
 	s.mu.Lock()
 	hook := s.probeHook
 	s.mu.Unlock()
@@ -241,7 +334,11 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 
 // GetIssue loads a Linear issue by identifier (e.g. "ENG-123").
 func (s *Service) GetIssue(ctx context.Context, identifier string) (*LinearIssue, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +347,11 @@ func (s *Service) GetIssue(ctx context.Context, identifier string) (*LinearIssue
 
 // SetIssueState moves an issue into the requested workflow state.
 func (s *Service) SetIssueState(ctx context.Context, issueID, stateID string) error {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return err
 	}
@@ -259,7 +360,11 @@ func (s *Service) SetIssueState(ctx context.Context, issueID, stateID string) er
 
 // ListTeams populates the team selector on the settings page.
 func (s *Service) ListTeams(ctx context.Context) ([]LinearTeam, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +373,11 @@ func (s *Service) ListTeams(ctx context.Context) ([]LinearTeam, error) {
 
 // ListStates returns the workflow states for a team identified by its key.
 func (s *Service) ListStates(ctx context.Context, teamKey string) ([]LinearWorkflowState, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +386,11 @@ func (s *Service) ListStates(ctx context.Context, teamKey string) ([]LinearWorkf
 
 // ListLabels returns the issue labels for a team identified by its key.
 func (s *Service) ListLabels(ctx context.Context, teamKey string) ([]LinearLabel, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +400,11 @@ func (s *Service) ListLabels(ctx context.Context, teamKey string) ([]LinearLabel
 // ListUsers returns the members of a team identified by its key. Used to
 // populate creator / assignee selectors on the watcher filter UI.
 func (s *Service) ListUsers(ctx context.Context, teamKey string) ([]LinearUser, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +413,20 @@ func (s *Service) ListUsers(ctx context.Context, teamKey string) ([]LinearUser, 
 
 // SearchIssues runs a filtered search.
 func (s *Service) SearchIssues(ctx context.Context, filter SearchFilter, pageToken string, maxResults int) (*SearchResult, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.SearchIssuesForWorkspace(ctx, workspaceID, filter, pageToken, maxResults)
+}
+
+// SearchIssuesForWorkspace runs a filtered search against one workspace's client.
+func (s *Service) SearchIssuesForWorkspace(ctx context.Context, workspaceID string, filter SearchFilter, pageToken string, maxResults int) (*SearchResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -304,16 +434,23 @@ func (s *Service) SearchIssues(ctx context.Context, filter SearchFilter, pageTok
 }
 
 // clientFor returns the cached client, creating it if needed.
-func (s *Service) clientFor(ctx context.Context) (Client, error) {
+func (s *Service) clientFor(ctx context.Context, workspaceID string) (Client, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
-	if s.client != nil {
-		c := s.client
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
+	}
+	if s.clients[workspaceID] != nil {
+		c := s.clients[workspaceID]
 		s.mu.Unlock()
 		return c, nil
 	}
 	s.mu.Unlock()
 
-	cfg, err := s.store.GetConfig(ctx)
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +459,7 @@ func (s *Service) clientFor(ctx context.Context) (Client, error) {
 	}
 	secret := ""
 	if s.secrets != nil {
-		secret, err = s.secrets.Reveal(ctx, SecretKey)
+		secret, err = s.revealSecret(ctx, workspaceID)
 		if err != nil {
 			return nil, fmt.Errorf("read linear secret: %w", err)
 		}
@@ -333,23 +470,28 @@ func (s *Service) clientFor(ctx context.Context) (Client, error) {
 	client := s.clientFn(cfg, secret)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.client != nil {
-		return s.client, nil
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
 	}
-	s.client = client
+	if s.clients[workspaceID] != nil {
+		return s.clients[workspaceID], nil
+	}
+	s.clients[workspaceID] = client
 	return client, nil
 }
 
 // invalidateClient drops the cached client so the next request rebuilds it.
-func (s *Service) invalidateClient() {
+func (s *Service) invalidateClient(workspaceID string) {
 	s.mu.Lock()
-	s.client = nil
+	if s.clients != nil {
+		delete(s.clients, workspaceID)
+	}
 	s.mu.Unlock()
 }
 
 // resolveCredentials picks credentials for a test: inline if the request
 // carries a secret, otherwise the stored secret.
-func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest) (*LinearConfig, string, error) {
+func (s *Service) resolveCredentials(ctx context.Context, workspaceID string, req *SetConfigRequest) (*LinearConfig, string, error) {
 	cfg := &LinearConfig{
 		AuthMethod: req.AuthMethod,
 	}
@@ -359,7 +501,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 	if s.secrets == nil {
 		return nil, "", errors.New("no secret store configured")
 	}
-	secret, err := s.secrets.Reveal(ctx, SecretKey)
+	secret, err := s.revealSecret(ctx, workspaceID)
 	if err != nil {
 		s.log.Warn("linear: secret reveal failed", zap.Error(err))
 		return nil, "", fmt.Errorf("read linear secret: %w", err)
@@ -367,7 +509,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 	if secret == "" {
 		return nil, "", errors.New("no api key stored — paste one to test")
 	}
-	stored, storeErr := s.store.GetConfig(ctx)
+	stored, storeErr := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if storeErr != nil {
 		// Soft-fail: a transient DB error here only loses the saved-config
 		// fallback values; the inline credentials still work for the test.
@@ -377,6 +519,46 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 		cfg.AuthMethod = stored.AuthMethod
 	}
 	return cfg, secret, nil
+}
+
+func (s *Service) defaultWorkspaceID() (string, error) {
+	return s.store.defaultWorkspaceID()
+}
+
+func (s *Service) normalizeWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
+}
+
+func (s *Service) secretExists(ctx context.Context, workspaceID string) (bool, error) {
+	if s.secrets == nil {
+		return false, nil
+	}
+	exists, err := s.secrets.Exists(ctx, SecretKeyForWorkspace(workspaceID))
+	if err != nil || exists {
+		return exists, err
+	}
+	return s.secrets.Exists(ctx, SecretKey)
+}
+
+func (s *Service) revealSecret(ctx context.Context, workspaceID string) (string, error) {
+	if s.secrets == nil {
+		return "", nil
+	}
+	secret, err := s.secrets.Reveal(ctx, SecretKeyForWorkspace(workspaceID))
+	if err == nil && secret != "" {
+		return secret, nil
+	}
+	legacy, legacyErr := s.secrets.Reveal(ctx, SecretKey)
+	if legacyErr == nil && legacy != "" {
+		return legacy, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", legacyErr
 }
 
 func validateConfigRequest(req *SetConfigRequest) error {

--- a/apps/backend/internal/linear/service_issue_watch.go
+++ b/apps/backend/internal/linear/service_issue_watch.go
@@ -187,7 +187,7 @@ func (s *Service) ResetIssueWatch(ctx context.Context, watchID string) (int, err
 // the JIRA watcher.
 func (s *Service) CheckIssueWatch(ctx context.Context, w *IssueWatch) ([]*LinearIssue, error) {
 	defer s.stampWatchLastPolled(w.ID)
-	client, err := s.clientFor(ctx)
+	client, err := s.clientFor(ctx, w.WorkspaceID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/linear/service_issue_watch_test.go
+++ b/apps/backend/internal/linear/service_issue_watch_test.go
@@ -468,7 +468,7 @@ func TestService_CheckIssueWatch_FiltersAlreadySeen(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
 
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAPIKey, Secret: "lin_api",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)
@@ -516,7 +516,7 @@ func TestService_CheckIssueWatch_AppliesSort(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
 
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAPIKey, Secret: "lin_api",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)
@@ -558,7 +558,7 @@ func TestService_CheckIssueWatch_AppliesSort(t *testing.T) {
 func TestService_CheckIssueWatch_PaginatesBacklog(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAPIKey, Secret: "lin_api",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)
@@ -605,7 +605,7 @@ func TestService_CheckIssueWatch_PaginatesBacklog(t *testing.T) {
 func TestService_CheckIssueWatch_BoundsPages(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAPIKey, Secret: "lin_api",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)
@@ -648,7 +648,7 @@ func TestService_CheckIssueWatch_BoundsPages(t *testing.T) {
 func TestService_CheckIssueWatch_DefaultSortFetchesSinglePage(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAPIKey, Secret: "lin_api",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)
@@ -691,7 +691,7 @@ func TestService_CheckIssueWatch_DefaultSortFetchesSinglePage(t *testing.T) {
 func TestService_CheckIssueWatch_CancelStopsPagination(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAPIKey, Secret: "lin_api",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)
@@ -727,7 +727,7 @@ func TestService_CheckIssueWatch_CancelStopsPagination(t *testing.T) {
 func TestService_CheckIssueWatch_StampsLastPolledOnError(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAPIKey, Secret: "lin_api",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)

--- a/apps/backend/internal/linear/service_test.go
+++ b/apps/backend/internal/linear/service_test.go
@@ -186,7 +186,7 @@ func TestService_SetConfig_UpsertsAndStoresSecret(t *testing.T) {
 	if !cfg.HasSecret {
 		t.Error("expected HasSecret=true")
 	}
-	if got, _ := f.secrets.Reveal(ctx, SecretKey); got != "lin_api_xyz" {
+	if got, _ := f.secrets.Reveal(ctx, SecretKeyForWorkspace("default")); got != "lin_api_xyz" {
 		t.Errorf("secret stored = %q", got)
 	}
 }
@@ -242,7 +242,7 @@ func TestService_SetConfig_EmptySecret_KeepsExisting(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("update: %v", err)
 	}
-	if got, _ := f.secrets.Reveal(ctx, SecretKey); got != "first" {
+	if got, _ := f.secrets.Reveal(ctx, SecretKeyForWorkspace("default")); got != "first" {
 		t.Errorf("secret should be preserved, got %q", got)
 	}
 }

--- a/apps/backend/internal/linear/store.go
+++ b/apps/backend/internal/linear/store.go
@@ -8,19 +8,20 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/integrations/workspacescope"
 )
 
-// Store persists the install-wide Linear configuration. The secret API key is
+// Store persists workspace-scoped Linear configuration. The secret API key is
 // delegated to the shared encrypted secret store and not stored here.
 type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
-	// migratedFromWorkspace records the workspace_id of the row that was
-	// promoted into the singleton during initSchema. Provider reads this to
-	// migrate the per-workspace secret to the new global key. Empty when no
-	// migration ran.
-	migratedFromWorkspace string
+	// migratedToWorkspace records the workspace_id that received a legacy
+	// singleton row during initSchema. Provider reads this to migrate the
+	// singleton secret to the workspace-scoped key. Empty when no migration ran.
+	migratedToWorkspace string
 }
 
 // NewStore creates a new Store and initializes the schema if needed.
@@ -32,16 +33,15 @@ func NewStore(writer, reader *sqlx.DB) (*Store, error) {
 	return s, nil
 }
 
-// MigratedFromWorkspace returns the workspace_id of the row promoted to the
-// singleton during the per-workspace → singleton schema migration, or "" when
-// no migration ran.
+// MigratedFromWorkspace is kept for older provider call sites. It now returns
+// the workspace_id that received a legacy singleton row during migration.
 func (s *Store) MigratedFromWorkspace() string {
-	return s.migratedFromWorkspace
+	return s.migratedToWorkspace
 }
 
 const createTablesSQL = `
 	CREATE TABLE IF NOT EXISTS linear_configs (
-		id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+		workspace_id TEXT PRIMARY KEY,
 		auth_method TEXT NOT NULL,
 		default_team_key TEXT NOT NULL DEFAULT '',
 		org_slug TEXT NOT NULL DEFAULT '',
@@ -96,14 +96,18 @@ const createTablesSQL = `
 	);
 `
 
-// singletonID is the synthetic primary key of the (only) row in linear_configs.
+// singletonID is the synthetic primary key used by the legacy install-wide
+// linear_configs table.
 const singletonID = "singleton"
 
 func (s *Store) initSchema() error {
-	if err := s.migrateLegacyPerWorkspaceTable(); err != nil {
+	if err := s.migrateLegacySingletonTable(); err != nil {
 		return err
 	}
 	if _, err := s.db.Exec(createTablesSQL); err != nil {
+		return err
+	}
+	if err := s.addConfigColumns(); err != nil {
 		return err
 	}
 	if err := s.addMaxInflightTasksColumn(); err != nil {
@@ -117,6 +121,39 @@ func (s *Store) initSchema() error {
 	}
 	if err := s.addIssueWatchRepositoryColumns(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// addConfigColumns brings old per-workspace tables up to the current
+// workspace-scoped shape.
+func (s *Store) addConfigColumns() error {
+	cols, err := s.tableColumns("linear_configs")
+	if err != nil {
+		return err
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+	if _, ok := cols["org_slug"]; !ok {
+		if _, err := s.db.Exec(`ALTER TABLE linear_configs ADD COLUMN org_slug TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add org_slug column: %w", err)
+		}
+	}
+	if _, ok := cols["last_checked_at"]; !ok {
+		if _, err := s.db.Exec(`ALTER TABLE linear_configs ADD COLUMN last_checked_at DATETIME`); err != nil {
+			return fmt.Errorf("add last_checked_at column: %w", err)
+		}
+	}
+	if _, ok := cols["last_ok"]; !ok {
+		if _, err := s.db.Exec(`ALTER TABLE linear_configs ADD COLUMN last_ok INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add last_ok column: %w", err)
+		}
+	}
+	if _, ok := cols["last_error"]; !ok {
+		if _, err := s.db.Exec(`ALTER TABLE linear_configs ADD COLUMN last_error TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add last_error column: %w", err)
+		}
 	}
 	return nil
 }
@@ -213,20 +250,20 @@ func (s *Store) addIssueWatchLastErrorColumns() error {
 	return nil
 }
 
-// migrateLegacyPerWorkspaceTable detects the pre-singleton schema (where
-// linear_configs was keyed by workspace_id) and rewrites it into the singleton
-// shape. Picks the most-recently-updated row and records the source
-// workspace_id so the provider can migrate the secret.
-func (s *Store) migrateLegacyPerWorkspaceTable() error {
+// migrateLegacySingletonTable detects the install-wide singleton schema and
+// rewrites it into the workspace-scoped shape. Picks the active/default
+// workspace as the target so startup is deterministic.
+func (s *Store) migrateLegacySingletonTable() error {
 	cols, err := s.tableColumns("linear_configs")
 	if err != nil {
 		return err
 	}
-	if len(cols) == 0 {
+	if !isLegacySingletonConfig(cols) {
 		return nil
 	}
-	if _, hasWorkspace := cols["workspace_id"]; !hasWorkspace {
-		return nil
+	targetWorkspace, err := workspacescope.ResolveMigrationTarget(s.db)
+	if err != nil {
+		return err
 	}
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -234,14 +271,9 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// `org_slug`, `last_checked_at`, `last_ok`, and `last_error` were added to
-	// the legacy schema in later releases. A deployment that upgrades from the
-	// original schema would have a `workspace_id` column but not these —
-	// selecting them unconditionally would crash startup. Build the SELECT
-	// against only columns present in this database. Mirrors the Jira fix.
 	healthCols := healthColumnsPresent(cols)
 	_, hasOrgSlug := cols["org_slug"]
-	selectCols := "workspace_id, auth_method, default_team_key"
+	selectCols := "auth_method, default_team_key"
 	if hasOrgSlug {
 		selectCols += ", org_slug"
 	} else {
@@ -253,12 +285,12 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 		selectCols += ", NULL AS last_checked_at, 0 AS last_ok, '' AS last_error"
 	}
 	selectCols += ", created_at, updated_at"
-	var sourceWorkspace, authMethod, defaultTeamKey, orgSlug, lastError sql.NullString
+	var authMethod, defaultTeamKey, orgSlug, lastError sql.NullString
 	var lastCheckedAt sql.NullTime
 	var lastOk sql.NullInt64
 	var createdAt, updatedAt sql.NullTime
-	row := tx.QueryRow(`SELECT ` + selectCols + ` FROM linear_configs ORDER BY updated_at DESC LIMIT 1`)
-	switch err := row.Scan(&sourceWorkspace, &authMethod, &defaultTeamKey, &orgSlug,
+	row := tx.QueryRow(`SELECT `+selectCols+` FROM linear_configs WHERE id = ? LIMIT 1`, singletonID)
+	switch err := row.Scan(&authMethod, &defaultTeamKey, &orgSlug,
 		&lastCheckedAt, &lastOk, &lastError, &createdAt, &updatedAt); {
 	case errors.Is(err, sql.ErrNoRows):
 		if _, err := tx.Exec(`DROP TABLE linear_configs`); err != nil {
@@ -273,7 +305,7 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	}
 	if _, err := tx.Exec(`
 		CREATE TABLE linear_configs (
-			id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+			workspace_id TEXT PRIMARY KEY,
 			auth_method TEXT NOT NULL,
 			default_team_key TEXT NOT NULL DEFAULT '',
 			org_slug TEXT NOT NULL DEFAULT '',
@@ -286,10 +318,10 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 		return err
 	}
 	if _, err := tx.Exec(`
-		INSERT INTO linear_configs (id, auth_method, default_team_key, org_slug,
+		INSERT INTO linear_configs (workspace_id, auth_method, default_team_key, org_slug,
 			last_checked_at, last_ok, last_error, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		singletonID, authMethod.String, defaultTeamKey.String, orgSlug.String,
+		targetWorkspace, authMethod.String, defaultTeamKey.String, orgSlug.String,
 		nullableTime(lastCheckedAt), lastOk.Int64, lastError.String,
 		nullableTime(createdAt), nullableTime(updatedAt)); err != nil {
 		return err
@@ -297,8 +329,19 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	s.migratedFromWorkspace = sourceWorkspace.String
+	s.migratedToWorkspace = targetWorkspace
 	return nil
+}
+
+func isLegacySingletonConfig(cols map[string]struct{}) bool {
+	if len(cols) == 0 {
+		return false
+	}
+	if _, hasWorkspace := cols["workspace_id"]; hasWorkspace {
+		return false
+	}
+	_, hasID := cols["id"]
+	return hasID
 }
 
 // healthColumnsPresent reports whether the legacy linear_configs table has the
@@ -345,14 +388,29 @@ func (s *Store) tableColumns(table string) (map[string]struct{}, error) {
 	return cols, rows.Err()
 }
 
-const selectConfigColumns = `auth_method, default_team_key, org_slug,
+const selectConfigColumns = `workspace_id, auth_method, default_team_key, org_slug,
 		last_checked_at, last_ok, last_error, created_at, updated_at`
 
-// GetConfig returns the singleton Linear config, or nil when no row exists.
+// GetConfig returns the default workspace Linear config, or nil when no row
+// exists. New code should call GetConfigForWorkspace.
 func (s *Store) GetConfig(ctx context.Context) (*LinearConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns the Linear config for a workspace, or nil when
+// no row exists.
+func (s *Store) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*LinearConfig, error) {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	var cfg LinearConfig
-	err := s.ro.GetContext(ctx, &cfg,
-		`SELECT `+selectConfigColumns+` FROM linear_configs WHERE id = ?`, singletonID)
+	err = s.ro.GetContext(ctx, &cfg,
+		`SELECT `+selectConfigColumns+` FROM linear_configs WHERE workspace_id = ?`, workspaceID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -362,60 +420,135 @@ func (s *Store) GetConfig(ctx context.Context) (*LinearConfig, error) {
 	return &cfg, nil
 }
 
-// UpsertConfig inserts or updates the singleton config row. The last_* health
+// UpsertConfig inserts or updates the default workspace config row. The last_* health
 // columns and org_slug are deliberately not touched here; the poller owns
 // those and writes them via UpdateAuthHealth.
 func (s *Store) UpsertConfig(ctx context.Context, cfg *LinearConfig) error {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpsertConfigForWorkspace(ctx, workspaceID, cfg)
+}
+
+// UpsertConfigForWorkspace inserts or updates a workspace config row.
+func (s *Store) UpsertConfigForWorkspace(ctx context.Context, workspaceID string, cfg *LinearConfig) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 	if cfg.CreatedAt.IsZero() {
 		cfg.CreatedAt = now
 	}
 	cfg.UpdatedAt = now
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO linear_configs (id, auth_method, default_team_key, created_at, updated_at)
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO linear_configs (workspace_id, auth_method, default_team_key, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
+		ON CONFLICT(workspace_id) DO UPDATE SET
 			auth_method = excluded.auth_method,
 			default_team_key = excluded.default_team_key,
 			updated_at = excluded.updated_at`,
-		singletonID, cfg.AuthMethod, cfg.DefaultTeamKey, cfg.CreatedAt, cfg.UpdatedAt)
+		workspaceID, cfg.AuthMethod, cfg.DefaultTeamKey, cfg.CreatedAt, cfg.UpdatedAt)
 	return err
 }
 
-// DeleteConfig removes the singleton config row.
+// DeleteConfig removes the default workspace config row.
 func (s *Store) DeleteConfig(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM linear_configs WHERE id = ?`, singletonID)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes the workspace config row.
+func (s *Store) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `DELETE FROM linear_configs WHERE workspace_id = ?`, workspaceID)
 	return err
 }
 
-// HasConfig reports whether the singleton row exists. Used by the auth-health
+// HasConfig reports whether any config row exists. Used by the auth-health
 // poller to decide whether to probe at all.
 func (s *Store) HasConfig(ctx context.Context) (bool, error) {
 	var present int
 	err := s.ro.GetContext(ctx, &present,
-		`SELECT COUNT(*) FROM linear_configs WHERE id = ?`, singletonID)
+		`SELECT COUNT(*) FROM linear_configs`)
 	if err != nil {
 		return false, err
 	}
 	return present > 0, nil
 }
 
+// HasConfigForWorkspace reports whether a config row exists for one workspace.
+func (s *Store) HasConfigForWorkspace(ctx context.Context, workspaceID string) (bool, error) {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return false, err
+	}
+	var present int
+	err = s.ro.GetContext(ctx, &present,
+		`SELECT COUNT(*) FROM linear_configs WHERE workspace_id = ?`, workspaceID)
+	if err != nil {
+		return false, err
+	}
+	return present > 0, nil
+}
+
+// ListConfigWorkspaceIDs returns every workspace with a saved Linear config.
+func (s *Store) ListConfigWorkspaceIDs(ctx context.Context) ([]string, error) {
+	var ids []string
+	if err := s.ro.SelectContext(ctx, &ids, `SELECT workspace_id FROM linear_configs ORDER BY workspace_id`); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
 // UpdateAuthHealth records the result of a credential probe. orgSlug is
 // captured opportunistically from successful probes; pass "" to leave the
 // existing slug unchanged.
 func (s *Store) UpdateAuthHealth(ctx context.Context, ok bool, errMsg, orgSlug string, checkedAt time.Time) error {
-	if orgSlug != "" {
-		_, err := s.db.ExecContext(ctx, `
-			UPDATE linear_configs
-			SET last_checked_at = ?, last_ok = ?, last_error = ?, org_slug = ?
-			WHERE id = ?`,
-			checkedAt, ok, errMsg, orgSlug, singletonID)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
 		return err
 	}
-	_, err := s.db.ExecContext(ctx, `
+	return s.UpdateAuthHealthForWorkspace(ctx, workspaceID, ok, errMsg, orgSlug, checkedAt)
+}
+
+// UpdateAuthHealthForWorkspace records the result of a credential probe for a
+// single workspace.
+func (s *Store) UpdateAuthHealthForWorkspace(ctx context.Context, workspaceID string, ok bool, errMsg, orgSlug string, checkedAt time.Time) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	if orgSlug != "" {
+		_, err = s.db.ExecContext(ctx, `
+			UPDATE linear_configs
+			SET last_checked_at = ?, last_ok = ?, last_error = ?, org_slug = ?
+			WHERE workspace_id = ?`,
+			checkedAt, ok, errMsg, orgSlug, workspaceID)
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
 		UPDATE linear_configs
 		SET last_checked_at = ?, last_ok = ?, last_error = ?
-		WHERE id = ?`,
-		checkedAt, ok, errMsg, singletonID)
+		WHERE workspace_id = ?`,
+		checkedAt, ok, errMsg, workspaceID)
 	return err
+}
+
+func (s *Store) defaultWorkspaceID() (string, error) {
+	return workspacescope.ResolveMigrationTarget(s.db)
+}
+
+func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
 }

--- a/apps/backend/internal/linear/store.go
+++ b/apps/backend/internal/linear/store.go
@@ -18,6 +18,8 @@ type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
+	defaultWorkspace workspacescope.CachedResolver
+
 	// migratedToWorkspace records the workspace_id that received a legacy
 	// singleton row during initSchema. Provider reads this to migrate the
 	// singleton secret to the workspace-scoped key. Empty when no migration ran.
@@ -543,7 +545,7 @@ func (s *Store) UpdateAuthHealthForWorkspace(ctx context.Context, workspaceID st
 }
 
 func (s *Store) defaultWorkspaceID() (string, error) {
-	return workspacescope.ResolveMigrationTarget(s.db)
+	return s.defaultWorkspace.Resolve(s.db)
 }
 
 func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {

--- a/apps/backend/internal/linear/store_test.go
+++ b/apps/backend/internal/linear/store_test.go
@@ -85,6 +85,87 @@ func TestStore_GetConfig_Missing(t *testing.T) {
 	}
 }
 
+func TestStore_ConfigSchemaUsesWorkspaceID(t *testing.T) {
+	store := newTestStore(t)
+	cols, err := store.tableColumns("linear_configs")
+	if err != nil {
+		t.Fatalf("table columns: %v", err)
+	}
+	if _, ok := cols["workspace_id"]; !ok {
+		t.Fatal("linear_configs must be keyed by workspace_id")
+	}
+	if _, ok := cols["id"]; ok {
+		t.Fatal("linear_configs must not keep singleton id column")
+	}
+}
+
+func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
+	raw, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	db := sqlx.NewDb(raw, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			email TEXT NOT NULL,
+			settings TEXT NOT NULL DEFAULT '{}',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE linear_configs (
+			id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+			auth_method TEXT NOT NULL,
+			default_team_key TEXT NOT NULL DEFAULT '',
+			org_slug TEXT NOT NULL DEFAULT '',
+			last_checked_at DATETIME,
+			last_ok INTEGER NOT NULL DEFAULT 0,
+			last_error TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		INSERT INTO workspaces (id, name, created_at, updated_at)
+			VALUES ('ws-first', 'First', ?, ?), ('ws-active', 'Active', ?, ?);
+		INSERT INTO users (id, email, settings, created_at, updated_at)
+			VALUES ('default-user', 'default@kandev.local', '{"workspace_id":"ws-active"}', ?, ?);
+		INSERT INTO linear_configs
+			(id, auth_method, default_team_key, org_slug, last_ok, created_at, updated_at)
+			VALUES ('singleton', ?, 'ENG', 'acme', 1, ?, ?);
+	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, AuthMethodAPIKey, now, now); err != nil {
+		t.Fatalf("seed singleton schema: %v", err)
+	}
+
+	store, err := NewStore(db, db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	cfg, err := store.GetConfig(context.Background())
+	if err != nil {
+		t.Fatalf("get migrated config: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected migrated config")
+	}
+	var workspaceID string
+	if err := db.Get(&workspaceID, `SELECT workspace_id FROM linear_configs`); err != nil {
+		t.Fatalf("read migrated workspace_id: %v", err)
+	}
+	if workspaceID != "ws-active" {
+		t.Fatalf("expected singleton config migrated to active workspace, got %q", workspaceID)
+	}
+}
+
 func TestStore_HasConfig(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
@@ -155,7 +236,7 @@ func TestStore_UpdateAuthHealth(t *testing.T) {
 	}
 }
 
-func TestStore_MigrateLegacyPerWorkspaceTable(t *testing.T) {
+func TestStore_PreservesPerWorkspaceConfigTable(t *testing.T) {
 	raw, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -198,18 +279,18 @@ func TestStore_MigrateLegacyPerWorkspaceTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new store: %v", err)
 	}
-	if got := store.MigratedFromWorkspace(); got != "ws-new" {
-		t.Errorf("expected migration source ws-new, got %q", got)
+	if got := store.MigratedFromWorkspace(); got != "" {
+		t.Errorf("expected no singleton migration, got %q", got)
 	}
-	cfg, err := store.GetConfig(context.Background())
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-new")
 	if err != nil {
-		t.Fatalf("get singleton: %v", err)
+		t.Fatalf("get workspace config: %v", err)
 	}
 	if cfg == nil {
-		t.Fatal("expected singleton row after migration")
+		t.Fatal("expected workspace row after schema init")
 	}
 	if cfg.DefaultTeamKey != "NEW" || cfg.OrgSlug != "new-slug" {
-		t.Errorf("expected newest row promoted, got %+v", cfg)
+		t.Errorf("expected workspace row preserved, got %+v", cfg)
 	}
 }
 
@@ -218,7 +299,7 @@ func TestStore_MigrateLegacyPerWorkspaceTable(t *testing.T) {
 // later releases. The migration must select only guaranteed-present columns
 // and fall back to defaults for the missing ones, otherwise startup crashes
 // with "no such column". Mirrors the Jira test.
-func TestStore_MigrateLegacyPerWorkspaceTable_PreHealthColumns(t *testing.T) {
+func TestStore_PreservesPerWorkspaceConfigTable_PreHealthColumns(t *testing.T) {
 	raw, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -251,15 +332,15 @@ func TestStore_MigrateLegacyPerWorkspaceTable_PreHealthColumns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore on pre-health-columns schema: %v", err)
 	}
-	if got := store.MigratedFromWorkspace(); got != "ws-1" {
-		t.Errorf("expected migration source ws-1, got %q", got)
+	if got := store.MigratedFromWorkspace(); got != "" {
+		t.Errorf("expected no singleton migration, got %q", got)
 	}
-	cfg, err := store.GetConfig(context.Background())
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-1")
 	if err != nil {
-		t.Fatalf("get singleton: %v", err)
+		t.Fatalf("get workspace config: %v", err)
 	}
 	if cfg == nil {
-		t.Fatal("expected singleton row after migration")
+		t.Fatal("expected workspace row after schema init")
 	}
 	if cfg.DefaultTeamKey != "ENG" {
 		t.Errorf("expected DefaultTeamKey preserved, got %q", cfg.DefaultTeamKey)
@@ -277,7 +358,7 @@ func TestStore_MigrateLegacyPerWorkspaceTable_PreHealthColumns(t *testing.T) {
 
 // Covers the sql.ErrNoRows branch: a user who installed a previous version,
 // never configured Linear, and then upgrades hits this path.
-func TestStore_MigrateLegacyPerWorkspaceTable_EmptyTable(t *testing.T) {
+func TestStore_PreservesPerWorkspaceConfigTable_EmptyTable(t *testing.T) {
 	raw, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -311,7 +392,7 @@ func TestStore_MigrateLegacyPerWorkspaceTable_EmptyTable(t *testing.T) {
 	}
 	cfg, err := store.GetConfig(context.Background())
 	if err != nil {
-		t.Fatalf("get singleton: %v", err)
+		t.Fatalf("get config: %v", err)
 	}
 	if cfg != nil {
 		t.Errorf("expected nil cfg on empty legacy table, got %+v", cfg)

--- a/apps/backend/internal/sentry/handlers.go
+++ b/apps/backend/internal/sentry/handlers.go
@@ -41,7 +41,7 @@ func (c *Controller) RegisterHTTPRoutes(router *gin.Engine) {
 }
 
 func (c *Controller) httpGetConfig(ctx *gin.Context) {
-	cfg, err := c.service.GetConfig(ctx.Request.Context())
+	cfg, err := c.service.GetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx))
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -59,7 +59,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	cfg, err := c.service.SetConfig(ctx.Request.Context(), &req)
+	cfg, err := c.service.SetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrInvalidConfig) {
@@ -72,7 +72,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 }
 
 func (c *Controller) httpDeleteConfig(ctx *gin.Context) {
-	if err := c.service.DeleteConfig(ctx.Request.Context()); err != nil {
+	if err := c.service.DeleteConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx)); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -85,7 +85,7 @@ func (c *Controller) httpTestConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	result, err := c.service.TestConnection(ctx.Request.Context(), &req)
+	result, err := c.service.TestConnectionForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -94,7 +94,12 @@ func (c *Controller) httpTestConfig(ctx *gin.Context) {
 }
 
 func (c *Controller) httpListOrganizations(ctx *gin.Context) {
-	organizations, err := c.service.ListOrganizations(ctx.Request.Context())
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	organizations, err := client.ListOrganizations(ctx.Request.Context())
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -103,7 +108,12 @@ func (c *Controller) httpListOrganizations(ctx *gin.Context) {
 }
 
 func (c *Controller) httpListProjects(ctx *gin.Context) {
-	projects, err := c.service.ListProjects(ctx.Request.Context())
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	projects, err := client.ListProjects(ctx.Request.Context())
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -123,7 +133,7 @@ func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 		Statuses:    trimAll(q["status"]),
 	}
 	cursor := q.Get("cursor")
-	result, err := c.service.SearchIssues(ctx.Request.Context(), filter, cursor)
+	result, err := c.service.SearchIssuesForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), filter, cursor)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
@@ -133,12 +143,21 @@ func (c *Controller) httpSearchIssues(ctx *gin.Context) {
 
 func (c *Controller) httpGetIssue(ctx *gin.Context) {
 	id := ctx.Param("id")
-	issue, err := c.service.GetIssue(ctx.Request.Context(), id)
+	client, err := c.service.clientFor(ctx.Request.Context(), c.workspaceID(ctx))
+	if err != nil {
+		c.writeClientError(ctx, err)
+		return
+	}
+	issue, err := client.GetIssue(ctx.Request.Context(), id)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, issue)
+}
+
+func (c *Controller) workspaceID(ctx *gin.Context) string {
+	return strings.TrimSpace(ctx.Query("workspace_id"))
 }
 
 // errCodeSentryNotConfigured is the wire-level code surfaced to the UI when

--- a/apps/backend/internal/sentry/mock_controller.go
+++ b/apps/backend/internal/sentry/mock_controller.go
@@ -56,7 +56,14 @@ func (c *MockController) setAuthHealth(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	if err := c.store.UpdateAuthHealth(ctx.Request.Context(), req.OK, req.Error, time.Now().UTC()); err != nil {
+	workspaceID := ctx.Query("workspace_id")
+	var err error
+	if workspaceID == "" {
+		err = c.store.UpdateAuthHealth(ctx.Request.Context(), req.OK, req.Error, time.Now().UTC())
+	} else {
+		err = c.store.UpdateAuthHealthForWorkspace(ctx.Request.Context(), workspaceID, req.OK, req.Error, time.Now().UTC())
+	}
+	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/apps/backend/internal/sentry/models.go
+++ b/apps/backend/internal/sentry/models.go
@@ -13,13 +13,20 @@ import (
 // user or organization auth token sent as `Authorization: Bearer <token>`.
 const AuthMethodAuthToken = "auth_token"
 
-// SecretKey is the secret-store key used for the install-wide Sentry token.
+// SecretKey is the legacy secret-store key used for the old install-wide Sentry
+// token. New workspace-scoped configs use SecretKeyForWorkspace.
 const SecretKey = "sentry:singleton:token"
 
-// SentryConfig is the install-wide configuration for the Sentry integration.
-// The token is stored separately in the encrypted secret store under SecretKey.
+// SecretKeyForWorkspace returns the workspace-scoped Sentry secret key.
+func SecretKeyForWorkspace(workspaceID string) string {
+	return "sentry:" + workspaceID + ":token"
+}
+
+// SentryConfig is the workspace-scoped configuration for the Sentry
+// integration. The token is stored separately in the encrypted secret store.
 type SentryConfig struct {
-	AuthMethod string `json:"authMethod" db:"auth_method"`
+	WorkspaceID string `json:"workspaceId,omitempty" db:"workspace_id"`
+	AuthMethod  string `json:"authMethod" db:"auth_method"`
 	// URL is the base URL of the Sentry instance (e.g. https://sentry.io for
 	// SaaS, or a self-hosted host). The REST client appends /api/0. Defaults
 	// to the sentry.io SaaS endpoint when left blank.

--- a/apps/backend/internal/sentry/poller_issue_watch_test.go
+++ b/apps/backend/internal/sentry/poller_issue_watch_test.go
@@ -49,7 +49,7 @@ func (r *recordingSubscriber) snapshot() []*NewSentryIssueEvent {
 func TestPoller_CheckIssueWatches_PublishesNewIssuesOnly(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()
@@ -108,7 +108,7 @@ func TestPoller_CheckIssueWatches_PublishesNewIssuesOnly(t *testing.T) {
 func TestPoller_CheckIssueWatches_SkipsDisabled(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()
@@ -183,7 +183,7 @@ func TestIsIssueWatchDue(t *testing.T) {
 func TestPoller_CheckIssueWatches_RespectsPerWatchInterval(t *testing.T) {
 	f := newPollerFixture(t)
 	ctx := context.Background()
-	f.saveConfig(t, "tok")
+	f.saveConfigForWorkspace(t, "ws-1", "tok")
 
 	eb := bus.NewMemoryEventBus(logger.Default())
 	defer eb.Close()

--- a/apps/backend/internal/sentry/poller_test.go
+++ b/apps/backend/internal/sentry/poller_test.go
@@ -30,15 +30,26 @@ func newPollerFixture(t *testing.T) *pollerFixture {
 	return f
 }
 
-// saveConfig persists the singleton directly via store + secret fakes,
+// saveConfig persists the default workspace directly via store + secret fakes,
 // bypassing Service.SetConfig (and its async probe).
 func (f *pollerFixture) saveConfig(t *testing.T, secret string) {
 	t.Helper()
+	f.saveConfigForWorkspace(t, "", secret)
+}
+
+// saveConfigForWorkspace persists a workspace config directly via store +
+// secret fakes, bypassing Service.SetConfig (and its async probe).
+func (f *pollerFixture) saveConfigForWorkspace(t *testing.T, workspaceID, secret string) {
+	t.Helper()
 	ctx := context.Background()
-	if err := f.store.UpsertConfig(ctx, &SentryConfig{AuthMethod: AuthMethodAuthToken}); err != nil {
+	if err := f.store.UpsertConfigForWorkspace(ctx, workspaceID, &SentryConfig{AuthMethod: AuthMethodAuthToken}); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
-	if err := f.secrets.Set(ctx, SecretKey, "sentry", secret); err != nil {
+	key := SecretKey
+	if workspaceID != "" {
+		key = SecretKeyForWorkspace(workspaceID)
+	}
+	if err := f.secrets.Set(ctx, key, "sentry", secret); err != nil {
 		t.Fatalf("save secret: %v", err)
 	}
 }

--- a/apps/backend/internal/sentry/provider.go
+++ b/apps/backend/internal/sentry/provider.go
@@ -1,10 +1,13 @@
 package sentry
 
 import (
+	"context"
 	"os"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/events/bus"
@@ -30,6 +33,7 @@ func Provide(writer, reader *sqlx.DB, secrets SecretStore, eventBus bus.EventBus
 	if err != nil {
 		return nil, nil, err
 	}
+	migrateLegacySecret(store, secrets, log)
 	clientFn := DefaultClientFactory
 	var mock *MockClient
 	if MockEnabled() {
@@ -44,6 +48,30 @@ func Provide(writer, reader *sqlx.DB, secrets SecretStore, eventBus bus.EventBus
 	}
 	cleanup := func() error { return nil }
 	return svc, cleanup, nil
+}
+
+func migrateLegacySecret(store *Store, secrets SecretStore, log *logger.Logger) {
+	target := store.MigratedFromWorkspace()
+	if target == "" || secrets == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	targetKey := SecretKeyForWorkspace(target)
+	if exists, err := secrets.Exists(ctx, targetKey); err == nil && exists {
+		return
+	}
+	value, err := secrets.Reveal(ctx, SecretKey)
+	if err != nil || value == "" {
+		return
+	}
+	if err := secrets.Set(ctx, targetKey, "Sentry auth token", value); err != nil {
+		log.Warn("sentry: legacy secret migration failed", zap.Error(err))
+		return
+	}
+	if err := secrets.Delete(ctx, SecretKey); err != nil {
+		log.Warn("sentry: legacy secret cleanup failed", zap.Error(err))
+	}
 }
 
 // RegisterMockRoutes mounts the mock control routes when the service was built

--- a/apps/backend/internal/sentry/service.go
+++ b/apps/backend/internal/sentry/service.go
@@ -41,12 +41,12 @@ type Service struct {
 	log      *logger.Logger
 	mu       sync.Mutex
 	clientFn ClientFactory
-	client   Client
-	// clientGen is incremented by invalidateClient each time the cached client
+	clients  map[string]Client
+	// clientGen is incremented by invalidateClient each time a cached client
 	// is discarded. clientFor captures it before I/O and only stores a newly
 	// built client when the value is unchanged, preventing a stale client from
 	// clobbering a concurrent invalidation.
-	clientGen uint64
+	clientGen map[string]uint64
 	probeHook func()
 	// mockClient is non-nil only when Provide built the service with a MockClient.
 	mockClient *MockClient
@@ -109,10 +109,12 @@ func NewService(store *Store, secrets SecretStore, clientFn ClientFactory, log *
 		clientFn = DefaultClientFactory
 	}
 	return &Service{
-		store:    store,
-		secrets:  secrets,
-		log:      log,
-		clientFn: clientFn,
+		store:     store,
+		secrets:   secrets,
+		log:       log,
+		clientFn:  clientFn,
+		clients:   make(map[string]Client),
+		clientGen: make(map[string]uint64),
 	}
 }
 
@@ -123,14 +125,27 @@ func (s *Service) Store() *Store {
 
 // GetConfig returns the singleton config enriched with a HasSecret flag.
 func (s *Service) GetConfig(ctx context.Context) (*SentryConfig, error) {
-	cfg, err := s.store.GetConfig(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns a workspace config enriched with a HasSecret flag.
+func (s *Service) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*SentryConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil || cfg == nil {
 		return cfg, err
 	}
 	if s.secrets == nil {
 		return cfg, nil
 	}
-	exists, existsErr := s.secrets.Exists(ctx, SecretKey)
+	exists, existsErr := s.secretExists(ctx, workspaceID)
 	if existsErr != nil {
 		s.log.Warn("sentry: secret exists check failed", zap.Error(existsErr))
 	}
@@ -143,44 +158,84 @@ var ErrInvalidConfig = errors.New("sentry: invalid configuration")
 
 // SetConfig is upsert. An empty Secret on update keeps the existing token.
 func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*SentryConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.SetConfigForWorkspace(ctx, workspaceID, req)
+}
+
+// SetConfigForWorkspace is upsert for one workspace. An empty Secret on update
+// keeps the existing token.
+func (s *Service) SetConfigForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*SentryConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	if err := validateConfigRequest(req); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidConfig, err.Error())
 	}
 	cfg := &SentryConfig{AuthMethod: req.AuthMethod, URL: req.URL}
-	if err := s.store.UpsertConfig(ctx, cfg); err != nil {
+	if err := s.store.UpsertConfigForWorkspace(ctx, workspaceID, cfg); err != nil {
 		return nil, fmt.Errorf("upsert sentry config: %w", err)
 	}
 	if req.Secret != "" && s.secrets != nil {
-		if err := s.secrets.Set(ctx, SecretKey, "Sentry auth token", req.Secret); err != nil {
+		if err := s.secrets.Set(ctx, SecretKeyForWorkspace(workspaceID), "Sentry auth token", req.Secret); err != nil {
 			return nil, fmt.Errorf("store sentry secret: %w", err)
 		}
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	// Probe asynchronously so a slow Sentry doesn't stall the save response.
 	go func() {
-		s.RecordAuthHealth(context.Background())
+		s.RecordAuthHealthForWorkspace(context.Background(), workspaceID)
 	}()
-	return s.GetConfig(ctx)
+	return s.GetConfigForWorkspace(ctx, workspaceID)
 }
 
 // DeleteConfig removes both the config row and the stored secret.
 func (s *Service) DeleteConfig(ctx context.Context) error {
-	if err := s.store.DeleteConfig(ctx); err != nil {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes both the config row and the stored secret.
+func (s *Service) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	if err := s.store.DeleteConfigForWorkspace(ctx, workspaceID); err != nil {
 		return err
 	}
 	if s.secrets != nil {
-		if err := s.secrets.Delete(ctx, SecretKey); err != nil {
+		if err := s.secrets.Delete(ctx, SecretKeyForWorkspace(workspaceID)); err != nil {
 			s.log.Warn("sentry: secret delete failed", zap.Error(err))
 		}
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	return nil
 }
 
 // TestConnection validates credentials either from a fresh SetConfigRequest
 // (before persisting) or from the stored config (after saving).
 func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*TestConnectionResult, error) {
-	cfg, secret, err := s.resolveCredentials(ctx, req)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.TestConnectionForWorkspace(ctx, workspaceID, req)
+}
+
+// TestConnectionForWorkspace validates credentials for one workspace.
+func (s *Service) TestConnectionForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	cfg, secret, err := s.resolveCredentials(ctx, workspaceID, req)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -190,7 +245,20 @@ func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*T
 
 // ProbeAuth validates the stored credentials.
 func (s *Service) ProbeAuth(ctx context.Context) (*TestConnectionResult, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.ProbeAuthForWorkspace(ctx, workspaceID)
+}
+
+// ProbeAuthForWorkspace validates the stored credentials for one workspace.
+func (s *Service) ProbeAuthForWorkspace(ctx context.Context, workspaceID string) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -214,9 +282,31 @@ func (s *Service) SetProbeHook(fn func()) {
 
 // RecordAuthHealth probes credentials and writes the outcome onto the row.
 func (s *Service) RecordAuthHealth(ctx context.Context) {
+	workspaceIDs, err := s.store.ListConfigWorkspaceIDs(ctx)
+	if err != nil {
+		s.log.Warn("sentry: list config workspaces failed", zap.Error(err))
+		return
+	}
+	if len(workspaceIDs) == 0 {
+		s.fireProbeHook()
+		return
+	}
+	for _, workspaceID := range workspaceIDs {
+		s.RecordAuthHealthForWorkspace(ctx, workspaceID)
+	}
+}
+
+// RecordAuthHealthForWorkspace probes credentials and writes the outcome onto
+// one workspace row.
+func (s *Service) RecordAuthHealthForWorkspace(ctx context.Context, workspaceID string) {
+	workspaceID, normalizeErr := s.normalizeWorkspaceID(workspaceID)
+	if normalizeErr != nil {
+		s.log.Warn("sentry: resolve workspace for auth health failed", zap.Error(normalizeErr))
+		return
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, authProbeTimeout)
 	defer cancel()
-	res, err := s.ProbeAuth(probeCtx)
+	res, err := s.ProbeAuthForWorkspace(probeCtx, workspaceID)
 	ok := err == nil && res != nil && res.OK
 	errMsg := ""
 	switch {
@@ -229,9 +319,13 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 	// still record the failure.
 	writeCtx, writeCancel := context.WithTimeout(context.Background(), authHealthWriteTimeout)
 	defer writeCancel()
-	if updateErr := s.store.UpdateAuthHealth(writeCtx, ok, errMsg, time.Now().UTC()); updateErr != nil {
+	if updateErr := s.store.UpdateAuthHealthForWorkspace(writeCtx, workspaceID, ok, errMsg, time.Now().UTC()); updateErr != nil {
 		s.log.Warn("sentry: update auth health failed", zap.Error(updateErr))
 	}
+	s.fireProbeHook()
+}
+
+func (s *Service) fireProbeHook() {
 	s.mu.Lock()
 	hook := s.probeHook
 	s.mu.Unlock()
@@ -242,7 +336,11 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 
 // ListOrganizations returns the organizations the stored token can access.
 func (s *Service) ListOrganizations(ctx context.Context) ([]SentryOrganization, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +349,11 @@ func (s *Service) ListOrganizations(ctx context.Context) ([]SentryOrganization, 
 
 // ListProjects returns the projects the stored token can access.
 func (s *Service) ListProjects(ctx context.Context) ([]SentryProject, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +363,20 @@ func (s *Service) ListProjects(ctx context.Context) ([]SentryProject, error) {
 // SearchIssues runs a filtered search. The caller supplies the org/project to
 // search — there is no install-wide default to fall back on.
 func (s *Service) SearchIssues(ctx context.Context, filter SearchFilter, cursor string) (*SearchResult, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.SearchIssuesForWorkspace(ctx, workspaceID, filter, cursor)
+}
+
+// SearchIssuesForWorkspace runs a filtered search against one workspace's client.
+func (s *Service) SearchIssuesForWorkspace(ctx context.Context, workspaceID string, filter SearchFilter, cursor string) (*SearchResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +385,11 @@ func (s *Service) SearchIssues(ctx context.Context, filter SearchFilter, cursor 
 
 // GetIssue loads a single issue by short ID or numeric ID.
 func (s *Service) GetIssue(ctx context.Context, idOrShortID string) (*SentryIssue, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -283,17 +402,27 @@ func (s *Service) GetIssue(ctx context.Context, idOrShortID string) (*SentryIssu
 // silently overwritten: if the counter changed the freshly built client is
 // returned to the caller without being cached, and the next call rebuilds
 // with the updated config.
-func (s *Service) clientFor(ctx context.Context) (Client, error) {
+func (s *Service) clientFor(ctx context.Context, workspaceID string) (Client, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
-	if s.client != nil {
-		c := s.client
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
+	}
+	if s.clientGen == nil {
+		s.clientGen = make(map[string]uint64)
+	}
+	if s.clients[workspaceID] != nil {
+		c := s.clients[workspaceID]
 		s.mu.Unlock()
 		return c, nil
 	}
-	gen := s.clientGen
+	gen := s.clientGen[workspaceID]
 	s.mu.Unlock()
 
-	cfg, err := s.store.GetConfig(ctx)
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +431,7 @@ func (s *Service) clientFor(ctx context.Context) (Client, error) {
 	}
 	secret := ""
 	if s.secrets != nil {
-		secret, err = s.secrets.Reveal(ctx, SecretKey)
+		secret, err = s.revealSecret(ctx, workspaceID)
 		if err != nil {
 			return nil, fmt.Errorf("read sentry secret: %w", err)
 		}
@@ -313,33 +442,44 @@ func (s *Service) clientFor(ctx context.Context) (Client, error) {
 	client := s.clientFn(cfg, secret)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.client != nil {
-		// Another goroutine already cached a client; use that one.
-		return s.client, nil
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
 	}
-	if s.clientGen != gen {
+	if s.clientGen == nil {
+		s.clientGen = make(map[string]uint64)
+	}
+	if s.clients[workspaceID] != nil {
+		// Another goroutine already cached a client; use that one.
+		return s.clients[workspaceID], nil
+	}
+	if s.clientGen[workspaceID] != gen {
 		// invalidateClient ran while we were doing I/O — the config/secret we
 		// read is now stale. Return the client to the caller for this call only;
 		// the next call will rebuild with fresh credentials.
 		return client, nil
 	}
-	s.client = client
+	s.clients[workspaceID] = client
 	return client, nil
 }
 
 // invalidateClient drops the cached client so the next request rebuilds it.
 // The generation counter is incremented so a concurrent clientFor build does
 // not restore a client built from the now-stale config.
-func (s *Service) invalidateClient() {
+func (s *Service) invalidateClient(workspaceID string) {
 	s.mu.Lock()
-	s.client = nil
-	s.clientGen++
+	if s.clients != nil {
+		delete(s.clients, workspaceID)
+	}
+	if s.clientGen == nil {
+		s.clientGen = make(map[string]uint64)
+	}
+	s.clientGen[workspaceID]++
 	s.mu.Unlock()
 }
 
 // resolveCredentials picks credentials for a test: inline if the request
 // carries a secret, otherwise the stored secret.
-func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest) (*SentryConfig, string, error) {
+func (s *Service) resolveCredentials(ctx context.Context, workspaceID string, req *SetConfigRequest) (*SentryConfig, string, error) {
 	cfg := &SentryConfig{AuthMethod: req.AuthMethod, URL: normalizeSentryURL(req.URL)}
 	if req.Secret != "" {
 		if cfg.URL == "" {
@@ -350,7 +490,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 	if s.secrets == nil {
 		return nil, "", errors.New("no secret store configured")
 	}
-	secret, err := s.secrets.Reveal(ctx, SecretKey)
+	secret, err := s.revealSecret(ctx, workspaceID)
 	if err != nil {
 		s.log.Warn("sentry: secret reveal failed", zap.Error(err))
 		return nil, "", fmt.Errorf("read sentry secret: %w", err)
@@ -358,7 +498,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 	if secret == "" {
 		return nil, "", errors.New("no auth token stored — paste one to test")
 	}
-	stored, storeErr := s.store.GetConfig(ctx)
+	stored, storeErr := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if storeErr != nil {
 		s.log.Warn("sentry: load stored config for credential resolution failed", zap.Error(storeErr))
 	}
@@ -374,6 +514,46 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 		cfg.URL = DefaultSentryURL
 	}
 	return cfg, secret, nil
+}
+
+func (s *Service) defaultWorkspaceID() (string, error) {
+	return s.store.defaultWorkspaceID()
+}
+
+func (s *Service) normalizeWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
+}
+
+func (s *Service) secretExists(ctx context.Context, workspaceID string) (bool, error) {
+	if s.secrets == nil {
+		return false, nil
+	}
+	exists, err := s.secrets.Exists(ctx, SecretKeyForWorkspace(workspaceID))
+	if err != nil || exists {
+		return exists, err
+	}
+	return s.secrets.Exists(ctx, SecretKey)
+}
+
+func (s *Service) revealSecret(ctx context.Context, workspaceID string) (string, error) {
+	if s.secrets == nil {
+		return "", nil
+	}
+	secret, err := s.secrets.Reveal(ctx, SecretKeyForWorkspace(workspaceID))
+	if err == nil && secret != "" {
+		return secret, nil
+	}
+	legacy, legacyErr := s.secrets.Reveal(ctx, SecretKey)
+	if legacyErr == nil && legacy != "" {
+		return legacy, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", legacyErr
 }
 
 // validateConfigRequest normalizes and validates a config request in place: it

--- a/apps/backend/internal/sentry/service_issue_watch.go
+++ b/apps/backend/internal/sentry/service_issue_watch.go
@@ -182,7 +182,7 @@ func (s *Service) ResetIssueWatch(ctx context.Context, watchID string) (int, err
 // bails. Same pattern as the Linear / Jira watchers.
 func (s *Service) CheckIssueWatch(ctx context.Context, w *IssueWatch) ([]*SentryIssue, error) {
 	defer s.stampWatchLastPolled(w.ID)
-	client, err := s.clientFor(ctx)
+	client, err := s.clientFor(ctx, w.WorkspaceID)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/sentry/service_issue_watch_test.go
+++ b/apps/backend/internal/sentry/service_issue_watch_test.go
@@ -253,7 +253,7 @@ func TestService_CheckIssueWatch_FiltersAlreadySeen(t *testing.T) {
 	f := newSvcFixture(t)
 	ctx := context.Background()
 
-	if _, err := f.svc.SetConfig(ctx, &SetConfigRequest{
+	if _, err := f.svc.SetConfigForWorkspace(ctx, "ws-1", &SetConfigRequest{
 		AuthMethod: AuthMethodAuthToken, Secret: "sntrys_abc",
 	}); err != nil {
 		t.Fatalf("set config: %v", err)

--- a/apps/backend/internal/sentry/service_test.go
+++ b/apps/backend/internal/sentry/service_test.go
@@ -170,7 +170,7 @@ func TestService_SetConfig_PersistsAndStoresSecret(t *testing.T) {
 	if !cfg.HasSecret {
 		t.Error("expected HasSecret=true")
 	}
-	if got, _ := f.secrets.Reveal(ctx, SecretKey); got != "sntrys_xyz" {
+	if got, _ := f.secrets.Reveal(ctx, SecretKeyForWorkspace("default")); got != "sntrys_xyz" {
 		t.Errorf("secret stored = %q", got)
 	}
 }
@@ -206,7 +206,7 @@ func TestService_SetConfig_EmptySecret_KeepsExisting(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("update: %v", err)
 	}
-	if got, _ := f.secrets.Reveal(ctx, SecretKey); got != "first" {
+	if got, _ := f.secrets.Reveal(ctx, SecretKeyForWorkspace("default")); got != "first" {
 		t.Errorf("secret should be preserved, got %q", got)
 	}
 }
@@ -351,7 +351,7 @@ func TestService_DeleteConfig_RemovesSecretAndCache(t *testing.T) {
 // rebuild, hitting the factory a second time.
 func TestService_ClientFor_InvalidateDuringBuild(t *testing.T) {
 	fakes := newFakeSecretStore()
-	_ = fakes.Set(context.Background(), SecretKey, "tok", "sntrys_xyz")
+	_ = fakes.Set(context.Background(), SecretKeyForWorkspace("default"), "tok", "sntrys_xyz")
 
 	store := newTestStore(t)
 	ctx := context.Background()
@@ -389,13 +389,13 @@ func TestService_ClientFor_InvalidateDuringBuild(t *testing.T) {
 	// First clientFor call — will block in Reveal while we invalidate.
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := svc.clientFor(ctx)
+		_, err := svc.clientFor(ctx, "default")
 		errCh <- err
 	}()
 
 	// Wait until clientFor is inside Reveal, then invalidate.
 	<-invalidateCh
-	svc.invalidateClient()
+	svc.invalidateClient("default")
 
 	// Wait for the first clientFor to finish.
 	if err := <-errCh; err != nil {
@@ -405,7 +405,7 @@ func TestService_ClientFor_InvalidateDuringBuild(t *testing.T) {
 	// The invalidation must have reset the cache, so s.client should be nil now.
 	// A second clientFor must hit the factory again (not return the cached stale client).
 	slow.revealHook = nil // no more blocking
-	if _, err := svc.clientFor(ctx); err != nil {
+	if _, err := svc.clientFor(ctx, "default"); err != nil {
 		t.Fatalf("second clientFor: %v", err)
 	}
 

--- a/apps/backend/internal/sentry/store.go
+++ b/apps/backend/internal/sentry/store.go
@@ -17,6 +17,7 @@ import (
 type Store struct {
 	db                  *sqlx.DB
 	ro                  *sqlx.DB
+	defaultWorkspace    workspacescope.CachedResolver
 	migratedToWorkspace string
 }
 
@@ -464,7 +465,7 @@ func (s *Store) UpdateAuthHealthForWorkspace(ctx context.Context, workspaceID st
 }
 
 func (s *Store) defaultWorkspaceID() (string, error) {
-	return workspacescope.ResolveMigrationTarget(s.db)
+	return s.defaultWorkspace.Resolve(s.db)
 }
 
 func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {

--- a/apps/backend/internal/sentry/store.go
+++ b/apps/backend/internal/sentry/store.go
@@ -8,13 +8,16 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/integrations/workspacescope"
 )
 
-// Store persists the install-wide Sentry configuration. The secret token is
+// Store persists workspace-scoped Sentry configuration. The secret token is
 // delegated to the shared encrypted secret store and not stored here.
 type Store struct {
-	db *sqlx.DB
-	ro *sqlx.DB
+	db                  *sqlx.DB
+	ro                  *sqlx.DB
+	migratedToWorkspace string
 }
 
 // NewStore creates a new Store and initializes the schema if needed.
@@ -28,7 +31,7 @@ func NewStore(writer, reader *sqlx.DB) (*Store, error) {
 
 const createTablesSQL = `
 	CREATE TABLE IF NOT EXISTS sentry_configs (
-		id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+		workspace_id TEXT PRIMARY KEY,
 		auth_method TEXT NOT NULL,
 		url TEXT NOT NULL DEFAULT 'https://sentry.io',
 		last_checked_at DATETIME,
@@ -76,12 +79,22 @@ const createTablesSQL = `
 	);
 `
 
-// singletonID is the synthetic primary key of the (only) row in sentry_configs.
+// singletonID is the synthetic primary key used by the legacy install-wide
+// sentry_configs table.
 const singletonID = "singleton"
+
+// MigratedFromWorkspace is kept for parity with Jira/Linear provider
+// migrations. It returns the workspace_id that received a legacy singleton row.
+func (s *Store) MigratedFromWorkspace() string {
+	return s.migratedToWorkspace
+}
 
 // initSchema creates the integration tables when absent and applies the
 // additive column migrations that bring older databases to the current schema.
 func (s *Store) initSchema() error {
+	if err := s.migrateLegacySingletonTable(); err != nil {
+		return err
+	}
 	if _, err := s.db.Exec(createTablesSQL); err != nil {
 		return err
 	}
@@ -95,6 +108,109 @@ func (s *Store) initSchema() error {
 		return err
 	}
 	return s.addIssueWatchRepositoryColumns()
+}
+
+func (s *Store) migrateLegacySingletonTable() error {
+	cols, err := s.tableColumns("sentry_configs")
+	if err != nil {
+		return err
+	}
+	if !isLegacySingletonConfig(cols) {
+		return nil
+	}
+	targetWorkspace, err := workspacescope.ResolveMigrationTarget(s.db)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	selectCols := "auth_method"
+	if _, ok := cols["url"]; ok {
+		selectCols += ", url"
+	} else {
+		selectCols += ", 'https://sentry.io' AS url"
+	}
+	if healthColumnsPresent(cols) {
+		selectCols += ", last_checked_at, last_ok, last_error"
+	} else {
+		selectCols += ", NULL AS last_checked_at, 0 AS last_ok, '' AS last_error"
+	}
+	selectCols += ", created_at, updated_at"
+	var authMethod, rawURL, lastError sql.NullString
+	var lastCheckedAt sql.NullTime
+	var lastOk sql.NullInt64
+	var createdAt, updatedAt sql.NullTime
+	row := tx.QueryRow(`SELECT `+selectCols+` FROM sentry_configs WHERE id = ? LIMIT 1`, singletonID)
+	switch err := row.Scan(&authMethod, &rawURL, &lastCheckedAt, &lastOk, &lastError, &createdAt, &updatedAt); {
+	case errors.Is(err, sql.ErrNoRows):
+		if _, err := tx.Exec(`DROP TABLE sentry_configs`); err != nil {
+			return err
+		}
+		return tx.Commit()
+	case err != nil:
+		return err
+	}
+	if _, err := tx.Exec(`DROP TABLE sentry_configs`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+		CREATE TABLE sentry_configs (
+			workspace_id TEXT PRIMARY KEY,
+			auth_method TEXT NOT NULL,
+			url TEXT NOT NULL DEFAULT 'https://sentry.io',
+			last_checked_at DATETIME,
+			last_ok INTEGER NOT NULL DEFAULT 0,
+			last_error TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO sentry_configs (workspace_id, auth_method, url,
+			last_checked_at, last_ok, last_error, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		targetWorkspace, authMethod.String, rawURL.String,
+		nullableTime(lastCheckedAt), lastOk.Int64, lastError.String,
+		nullableTime(createdAt), nullableTime(updatedAt)); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.migratedToWorkspace = targetWorkspace
+	return nil
+}
+
+func isLegacySingletonConfig(cols map[string]struct{}) bool {
+	if len(cols) == 0 {
+		return false
+	}
+	if _, hasWorkspace := cols["workspace_id"]; hasWorkspace {
+		return false
+	}
+	_, hasID := cols["id"]
+	return hasID
+}
+
+func healthColumnsPresent(cols map[string]struct{}) bool {
+	for _, name := range []string{"last_checked_at", "last_ok", "last_error"} {
+		if _, ok := cols[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func nullableTime(t sql.NullTime) interface{} {
+	if !t.Valid {
+		return nil
+	}
+	return t.Time
 }
 
 // addIssueWatchRepositoryColumns brings older databases up to the current
@@ -219,14 +335,29 @@ func (s *Store) tableColumns(table string) (map[string]struct{}, error) {
 	return cols, rows.Err()
 }
 
-const selectConfigColumns = `auth_method, url,
+const selectConfigColumns = `workspace_id, auth_method, url,
 		last_checked_at, last_ok, last_error, created_at, updated_at`
 
-// GetConfig returns the singleton Sentry config, or nil when no row exists.
+// GetConfig returns the default workspace Sentry config, or nil when no row
+// exists. New code should call GetConfigForWorkspace.
 func (s *Store) GetConfig(ctx context.Context) (*SentryConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns the Sentry config for a workspace, or nil when
+// no row exists.
+func (s *Store) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*SentryConfig, error) {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	var cfg SentryConfig
-	err := s.ro.GetContext(ctx, &cfg,
-		`SELECT `+selectConfigColumns+` FROM sentry_configs WHERE id = ?`, singletonID)
+	err = s.ro.GetContext(ctx, &cfg,
+		`SELECT `+selectConfigColumns+` FROM sentry_configs WHERE workspace_id = ?`, workspaceID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -236,49 +367,109 @@ func (s *Store) GetConfig(ctx context.Context) (*SentryConfig, error) {
 	return &cfg, nil
 }
 
-// UpsertConfig inserts or updates the singleton config row. The last_* health
+// UpsertConfig inserts or updates the default workspace config row. The last_* health
 // columns are owned by the poller and written via UpdateAuthHealth.
 func (s *Store) UpsertConfig(ctx context.Context, cfg *SentryConfig) error {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpsertConfigForWorkspace(ctx, workspaceID, cfg)
+}
+
+// UpsertConfigForWorkspace inserts or updates a workspace config row.
+func (s *Store) UpsertConfigForWorkspace(ctx context.Context, workspaceID string, cfg *SentryConfig) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 	if cfg.CreatedAt.IsZero() {
 		cfg.CreatedAt = now
 	}
 	cfg.UpdatedAt = now
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO sentry_configs (id, auth_method, url, created_at, updated_at)
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO sentry_configs (workspace_id, auth_method, url, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
+		ON CONFLICT(workspace_id) DO UPDATE SET
 			auth_method = excluded.auth_method,
 			url = excluded.url,
 			updated_at = excluded.updated_at`,
-		singletonID, cfg.AuthMethod, cfg.URL, cfg.CreatedAt, cfg.UpdatedAt)
+		workspaceID, cfg.AuthMethod, cfg.URL, cfg.CreatedAt, cfg.UpdatedAt)
 	return err
 }
 
-// DeleteConfig removes the singleton config row.
+// DeleteConfig removes the default workspace config row.
 func (s *Store) DeleteConfig(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM sentry_configs WHERE id = ?`, singletonID)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes the workspace config row.
+func (s *Store) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `DELETE FROM sentry_configs WHERE workspace_id = ?`, workspaceID)
 	return err
 }
 
-// HasConfig reports whether the singleton row exists. Used by the auth-health
+// HasConfig reports whether any config row exists. Used by the auth-health
 // poller to decide whether to probe at all.
 func (s *Store) HasConfig(ctx context.Context) (bool, error) {
 	var present int
 	err := s.ro.GetContext(ctx, &present,
-		`SELECT COUNT(*) FROM sentry_configs WHERE id = ?`, singletonID)
+		`SELECT COUNT(*) FROM sentry_configs`)
 	if err != nil {
 		return false, err
 	}
 	return present > 0, nil
 }
 
+// ListConfigWorkspaceIDs returns every workspace with a saved Sentry config.
+func (s *Store) ListConfigWorkspaceIDs(ctx context.Context) ([]string, error) {
+	var ids []string
+	if err := s.ro.SelectContext(ctx, &ids, `SELECT workspace_id FROM sentry_configs ORDER BY workspace_id`); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
 // UpdateAuthHealth records the result of a credential probe.
 func (s *Store) UpdateAuthHealth(ctx context.Context, ok bool, errMsg string, checkedAt time.Time) error {
-	_, err := s.db.ExecContext(ctx, `
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpdateAuthHealthForWorkspace(ctx, workspaceID, ok, errMsg, checkedAt)
+}
+
+// UpdateAuthHealthForWorkspace records the result of a credential probe for a
+// single workspace config row.
+func (s *Store) UpdateAuthHealthForWorkspace(ctx context.Context, workspaceID string, ok bool, errMsg string, checkedAt time.Time) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
 		UPDATE sentry_configs
 		SET last_checked_at = ?, last_ok = ?, last_error = ?
-		WHERE id = ?`,
-		checkedAt, ok, errMsg, singletonID)
+		WHERE workspace_id = ?`,
+		checkedAt, ok, errMsg, workspaceID)
 	return err
+}
+
+func (s *Store) defaultWorkspaceID() (string, error) {
+	return workspacescope.ResolveMigrationTarget(s.db)
+}
+
+func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
 }

--- a/apps/backend/internal/sentry/store_test.go
+++ b/apps/backend/internal/sentry/store_test.go
@@ -149,6 +149,71 @@ func TestStore_UpsertGetConfig_RoundTripsURL(t *testing.T) {
 	}
 }
 
+func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
+	raw, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	db := sqlx.NewDb(raw, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			email TEXT NOT NULL,
+			settings TEXT NOT NULL DEFAULT '{}',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE sentry_configs (
+			id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+			auth_method TEXT NOT NULL,
+			url TEXT NOT NULL DEFAULT 'https://sentry.io',
+			last_checked_at DATETIME,
+			last_ok INTEGER NOT NULL DEFAULT 0,
+			last_error TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		INSERT INTO workspaces (id, name, created_at, updated_at)
+			VALUES ('ws-first', 'First', ?, ?), ('ws-active', 'Active', ?, ?);
+		INSERT INTO users (id, email, settings, created_at, updated_at)
+			VALUES ('default-user', 'default@kandev.local', '{"workspace_id":"ws-active"}', ?, ?);
+		INSERT INTO sentry_configs
+			(id, auth_method, url, last_ok, created_at, updated_at)
+			VALUES ('singleton', ?, 'https://sentry.example.com', 1, ?, ?);
+	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, AuthMethodAuthToken, now, now); err != nil {
+		t.Fatalf("seed singleton schema: %v", err)
+	}
+
+	store, err := NewStore(db, db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if got := store.MigratedFromWorkspace(); got != "ws-active" {
+		t.Fatalf("expected singleton config migrated to active workspace, got %q", got)
+	}
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-active")
+	if err != nil {
+		t.Fatalf("get active workspace config: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected migrated config")
+	}
+	if cfg.URL != "https://sentry.example.com" {
+		t.Errorf("expected migrated URL, got %q", cfg.URL)
+	}
+}
+
 // TestStore_MigratesURLColumn seeds a pre-self-hosted sentry_configs table (no
 // url column) and verifies NewStore adds the column, backfilling the existing
 // SaaS row to the sentry.io default rather than an empty string.

--- a/apps/backend/internal/sentry/store_test.go
+++ b/apps/backend/internal/sentry/store_test.go
@@ -160,6 +160,7 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	now := time.Now().UTC()
+	checkedAt := now.Add(-5 * time.Minute).Truncate(time.Second)
 	if _, err := db.Exec(`
 		CREATE TABLE workspaces (
 			id TEXT PRIMARY KEY,
@@ -189,9 +190,9 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 		INSERT INTO users (id, email, settings, created_at, updated_at)
 			VALUES ('default-user', 'default@kandev.local', '{"workspace_id":"ws-active"}', ?, ?);
 		INSERT INTO sentry_configs
-			(id, auth_method, url, last_ok, created_at, updated_at)
-			VALUES ('singleton', ?, 'https://sentry.example.com', 1, ?, ?);
-	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, AuthMethodAuthToken, now, now); err != nil {
+			(id, auth_method, url, last_checked_at, last_ok, last_error, created_at, updated_at)
+			VALUES ('singleton', ?, 'https://sentry.example.com', ?, 1, 'healthy', ?, ?);
+	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, AuthMethodAuthToken, checkedAt, now, now); err != nil {
 		t.Fatalf("seed singleton schema: %v", err)
 	}
 
@@ -211,6 +212,15 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 	}
 	if cfg.URL != "https://sentry.example.com" {
 		t.Errorf("expected migrated URL, got %q", cfg.URL)
+	}
+	if cfg.AuthMethod != AuthMethodAuthToken {
+		t.Errorf("expected migrated auth method %q, got %q", AuthMethodAuthToken, cfg.AuthMethod)
+	}
+	if !cfg.LastOk || cfg.LastError != "healthy" {
+		t.Errorf("unexpected migrated health state: %+v", cfg)
+	}
+	if cfg.LastCheckedAt == nil || !cfg.LastCheckedAt.Equal(checkedAt) {
+		t.Errorf("expected last_checked_at=%v, got %v", checkedAt, cfg.LastCheckedAt)
 	}
 }
 

--- a/apps/backend/internal/slack/handlers.go
+++ b/apps/backend/internal/slack/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -37,7 +38,7 @@ func (c *Controller) RegisterHTTPRoutes(router *gin.Engine) {
 // --- HTTP handlers ---
 
 func (c *Controller) httpGetConfig(ctx *gin.Context) {
-	cfg, err := c.service.GetConfig(ctx.Request.Context())
+	cfg, err := c.service.GetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx))
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -55,7 +56,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	cfg, err := c.service.SetConfig(ctx.Request.Context(), &req)
+	cfg, err := c.service.SetConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrInvalidConfig) {
@@ -68,7 +69,7 @@ func (c *Controller) httpSetConfig(ctx *gin.Context) {
 }
 
 func (c *Controller) httpDeleteConfig(ctx *gin.Context) {
-	if err := c.service.DeleteConfig(ctx.Request.Context()); err != nil {
+	if err := c.service.DeleteConfigForWorkspace(ctx.Request.Context(), c.workspaceID(ctx)); err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -81,12 +82,16 @@ func (c *Controller) httpTestConfig(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
 		return
 	}
-	result, err := c.service.TestConnection(ctx.Request.Context(), &req)
+	result, err := c.service.TestConnectionForWorkspace(ctx.Request.Context(), c.workspaceID(ctx), &req)
 	if err != nil {
 		c.writeClientError(ctx, err)
 		return
 	}
 	ctx.JSON(http.StatusOK, result)
+}
+
+func (c *Controller) workspaceID(ctx *gin.Context) string {
+	return strings.TrimSpace(ctx.Query("workspace_id"))
 }
 
 // errCodeSlackNotConfigured is the wire-level code surfaced to the UI when

--- a/apps/backend/internal/slack/models.go
+++ b/apps/backend/internal/slack/models.go
@@ -39,10 +39,11 @@ const MinPollIntervalSeconds = 5
 // session shows up in the auth-status banner promptly.
 const MaxPollIntervalSeconds = 600
 
-// SlackConfig is the install-wide Slack integration configuration. The xoxc
-// token and the d cookie live in the encrypted secret store under SecretKeyToken
-// and SecretKeyCookie respectively.
+// SlackConfig is the workspace-scoped Slack integration configuration. The xoxc
+// token and the d cookie live in the encrypted secret store under workspace
+// secret keys.
 type SlackConfig struct {
+	WorkspaceID   string `json:"workspaceId,omitempty" db:"workspace_id"`
 	AuthMethod    string `json:"authMethod" db:"auth_method"`
 	CommandPrefix string `json:"commandPrefix" db:"command_prefix"`
 	// UtilityAgentID points at a row in `utility_agents`. The agent is
@@ -111,22 +112,32 @@ type ThreadContext struct {
 	Messages []SlackMessage `json:"messages"`
 }
 
-// SecretKeyToken is the secret-store key for the install-wide xoxc- token.
+// SecretKeyToken is the legacy secret-store key for the old install-wide xoxc-
+// token.
 const SecretKeyToken = "slack:singleton:token"
 
-// SecretKeyCookie is the secret-store key for the install-wide `d` cookie.
+// SecretKeyCookie is the legacy secret-store key for the old install-wide `d`
+// cookie.
 // Stored separately from the token so each can be rotated/replaced
 // independently — Slack rotates the d cookie much more often than the token.
 const SecretKeyCookie = "slack:singleton:cookie"
 
-// LegacySecretKeyForToken returns the pre-singleton per-workspace token key,
-// kept so the provider can promote an existing per-workspace token onto
-// SecretKeyToken during the schema migration.
-func LegacySecretKeyForToken(workspaceID string) string {
+// SecretKeyForToken returns the workspace-scoped token key.
+func SecretKeyForToken(workspaceID string) string {
 	return "slack:" + workspaceID + ":token"
 }
 
-// LegacySecretKeyForCookie returns the pre-singleton per-workspace cookie key.
-func LegacySecretKeyForCookie(workspaceID string) string {
+// SecretKeyForCookie returns the workspace-scoped cookie key.
+func SecretKeyForCookie(workspaceID string) string {
 	return "slack:" + workspaceID + ":cookie"
+}
+
+// LegacySecretKeyForToken is kept for older tests/callers.
+func LegacySecretKeyForToken(workspaceID string) string {
+	return SecretKeyForToken(workspaceID)
+}
+
+// LegacySecretKeyForCookie is kept for older tests/callers.
+func LegacySecretKeyForCookie(workspaceID string) string {
+	return SecretKeyForCookie(workspaceID)
 }

--- a/apps/backend/internal/slack/provider.go
+++ b/apps/backend/internal/slack/provider.go
@@ -27,19 +27,19 @@ func Provide(writer, reader *sqlx.DB, secrets SecretStore, log *logger.Logger) (
 	return svc, cleanup, nil
 }
 
-// migrateLegacySecrets copies the per-workspace token + cookie from the
-// pre-singleton secret keys onto the new install-wide keys, then deletes the
+// migrateLegacySecrets copies the old install-wide token + cookie onto the
+// workspace-scoped keys created by the config migration, then deletes the
 // legacy entries. Best-effort: any error is logged and ignored — the worst
 // case is the user re-pastes their credentials in the settings UI.
 func migrateLegacySecrets(store *Store, secrets SecretStore, log *logger.Logger) {
-	source := store.MigratedFromWorkspace()
-	if source == "" || secrets == nil {
+	target := store.MigratedFromWorkspace()
+	if target == "" || secrets == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	migrateOne(ctx, secrets, LegacySecretKeyForToken(source), SecretKeyToken, "Slack token", log)
-	migrateOne(ctx, secrets, LegacySecretKeyForCookie(source), SecretKeyCookie, "Slack d cookie", log)
+	migrateOne(ctx, secrets, SecretKeyToken, SecretKeyForToken(target), "Slack token", log)
+	migrateOne(ctx, secrets, SecretKeyCookie, SecretKeyForCookie(target), "Slack d cookie", log)
 }
 
 func migrateOne(ctx context.Context, secrets SecretStore, legacyKey, newKey, displayName string, log *logger.Logger) {

--- a/apps/backend/internal/slack/service.go
+++ b/apps/backend/internal/slack/service.go
@@ -34,7 +34,7 @@ type Service struct {
 
 	mu        sync.Mutex
 	clientFn  ClientFactory
-	client    Client // singleton, cleared on config change.
+	clients   map[string]Client
 	probeHook func()
 }
 
@@ -71,6 +71,7 @@ func NewService(
 		runner:   runner,
 		log:      log,
 		clientFn: clientFn,
+		clients:  make(map[string]Client),
 	}
 }
 
@@ -89,24 +90,45 @@ func (s *Service) Runner() AgentRunner {
 	return s.runner
 }
 
-// GetConfig returns the singleton config enriched with HasToken/HasCookie.
+// GetConfig returns the default workspace config enriched with HasToken/HasCookie.
 func (s *Service) GetConfig(ctx context.Context) (*SlackConfig, error) {
-	cfg, err := s.store.GetConfig(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns a workspace config enriched with HasToken/HasCookie.
+func (s *Service) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*SlackConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil || cfg == nil {
 		return cfg, err
 	}
 	if s.secrets == nil {
 		return cfg, nil
 	}
-	cfg.HasToken = s.secretExists(ctx, SecretKeyToken, "token")
-	cfg.HasCookie = s.secretExists(ctx, SecretKeyCookie, "cookie")
+	cfg.HasToken = s.secretExists(ctx, SecretKeyForToken(workspaceID), SecretKeyToken, "token")
+	cfg.HasCookie = s.secretExists(ctx, SecretKeyForCookie(workspaceID), SecretKeyCookie, "cookie")
 	return cfg, nil
 }
 
-func (s *Service) secretExists(ctx context.Context, id, kind string) bool {
+func (s *Service) secretExists(ctx context.Context, id, legacyID, kind string) bool {
 	exists, err := s.secrets.Exists(ctx, id)
 	if err != nil {
 		s.log.Warn("slack: secret exists check failed",
+			zap.String("kind", kind), zap.Error(err))
+	}
+	if exists {
+		return true
+	}
+	exists, err = s.secrets.Exists(ctx, legacyID)
+	if err != nil {
+		s.log.Warn("slack: legacy secret exists check failed",
 			zap.String("kind", kind), zap.Error(err))
 	}
 	return exists
@@ -115,17 +137,17 @@ func (s *Service) secretExists(ctx context.Context, id, kind string) bool {
 // ErrInvalidConfig is returned by SetConfig when the request fails validation.
 var ErrInvalidConfig = errors.New("slack: invalid configuration")
 
-func (s *Service) persistSecrets(ctx context.Context, req *SetConfigRequest) error {
+func (s *Service) persistSecrets(ctx context.Context, workspaceID string, req *SetConfigRequest) error {
 	if s.secrets == nil {
 		return nil
 	}
 	if req.Token != "" {
-		if err := s.secrets.Set(ctx, SecretKeyToken, "Slack token", req.Token); err != nil {
+		if err := s.secrets.Set(ctx, SecretKeyForToken(workspaceID), "Slack token", req.Token); err != nil {
 			return fmt.Errorf("store slack token: %w", err)
 		}
 	}
 	if req.Cookie != "" {
-		if err := s.secrets.Set(ctx, SecretKeyCookie, "Slack d cookie", req.Cookie); err != nil {
+		if err := s.secrets.Set(ctx, SecretKeyForCookie(workspaceID), "Slack d cookie", req.Cookie); err != nil {
 			return fmt.Errorf("store slack cookie: %w", err)
 		}
 	}
@@ -134,6 +156,19 @@ func (s *Service) persistSecrets(ctx context.Context, req *SetConfigRequest) err
 
 // SetConfig is upsert. Empty Token/Cookie on update keeps the existing values.
 func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*SlackConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.SetConfigForWorkspace(ctx, workspaceID, req)
+}
+
+// SetConfigForWorkspace is upsert. Empty Token/Cookie on update keeps existing values.
+func (s *Service) SetConfigForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*SlackConfig, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	if err := validateConfigRequest(req); err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidConfig, err.Error())
 	}
@@ -143,29 +178,42 @@ func (s *Service) SetConfig(ctx context.Context, req *SetConfigRequest) (*SlackC
 		UtilityAgentID:      req.UtilityAgentID,
 		PollIntervalSeconds: req.PollIntervalSeconds,
 	}
-	if err := s.store.UpsertConfig(ctx, cfg); err != nil {
+	if err := s.store.UpsertConfigForWorkspace(ctx, workspaceID, cfg); err != nil {
 		return nil, fmt.Errorf("upsert slack config: %w", err)
 	}
-	if err := s.persistSecrets(ctx, req); err != nil {
+	if err := s.persistSecrets(ctx, workspaceID, req); err != nil {
 		return nil, err
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	go func() {
-		s.RecordAuthHealth(context.Background())
+		s.RecordAuthHealthForWorkspace(context.Background(), workspaceID)
 	}()
-	return s.GetConfig(ctx)
+	return s.GetConfigForWorkspace(ctx, workspaceID)
 }
 
 // DeleteConfig removes both the row and the stored secrets.
 func (s *Service) DeleteConfig(ctx context.Context) error {
-	if err := s.store.DeleteConfig(ctx); err != nil {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes both the row and the stored secrets.
+func (s *Service) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	if err := s.store.DeleteConfigForWorkspace(ctx, workspaceID); err != nil {
 		return err
 	}
 	if s.secrets != nil {
-		s.deleteSecret(ctx, SecretKeyToken, "token")
-		s.deleteSecret(ctx, SecretKeyCookie, "cookie")
+		s.deleteSecret(ctx, SecretKeyForToken(workspaceID), "token")
+		s.deleteSecret(ctx, SecretKeyForCookie(workspaceID), "cookie")
 	}
-	s.invalidateClient()
+	s.invalidateClient(workspaceID)
 	return nil
 }
 
@@ -179,7 +227,20 @@ func (s *Service) deleteSecret(ctx context.Context, id, kind string) {
 // TestConnection validates credentials either inline (from a fresh request)
 // or from the stored secrets.
 func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*TestConnectionResult, error) {
-	cfg, token, cookie, err := s.resolveCredentials(ctx, req)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.TestConnectionForWorkspace(ctx, workspaceID, req)
+}
+
+// TestConnectionForWorkspace validates credentials for one workspace.
+func (s *Service) TestConnectionForWorkspace(ctx context.Context, workspaceID string, req *SetConfigRequest) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	cfg, token, cookie, err := s.resolveCredentials(ctx, workspaceID, req)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -189,7 +250,20 @@ func (s *Service) TestConnection(ctx context.Context, req *SetConfigRequest) (*T
 
 // ProbeAuth validates the stored credentials.
 func (s *Service) ProbeAuth(ctx context.Context) (*TestConnectionResult, error) {
-	client, err := s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	return s.ProbeAuthForWorkspace(ctx, workspaceID)
+}
+
+// ProbeAuthForWorkspace validates the stored credentials for one workspace.
+func (s *Service) ProbeAuthForWorkspace(ctx context.Context, workspaceID string) (*TestConnectionResult, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
+	}
+	client, err := s.clientFor(ctx, workspaceID)
 	if err != nil {
 		return &TestConnectionResult{OK: false, Error: err.Error()}, nil
 	}
@@ -216,9 +290,31 @@ func (s *Service) SetProbeHook(fn func()) {
 
 // RecordAuthHealth probes credentials and writes the outcome onto the row.
 func (s *Service) RecordAuthHealth(ctx context.Context) {
+	workspaceIDs, err := s.store.ListConfigWorkspaceIDs(ctx)
+	if err != nil {
+		s.log.Warn("slack: list config workspaces failed", zap.Error(err))
+		return
+	}
+	if len(workspaceIDs) == 0 {
+		s.fireProbeHook()
+		return
+	}
+	for _, workspaceID := range workspaceIDs {
+		s.RecordAuthHealthForWorkspace(ctx, workspaceID)
+	}
+}
+
+// RecordAuthHealthForWorkspace probes credentials and writes the outcome onto
+// one workspace row.
+func (s *Service) RecordAuthHealthForWorkspace(ctx context.Context, workspaceID string) {
+	workspaceID, normalizeErr := s.normalizeWorkspaceID(workspaceID)
+	if normalizeErr != nil {
+		s.log.Warn("slack: resolve workspace for auth health failed", zap.Error(normalizeErr))
+		return
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, authProbeTimeout)
 	defer cancel()
-	res, err := s.ProbeAuth(probeCtx)
+	res, err := s.ProbeAuthForWorkspace(probeCtx, workspaceID)
 	ok := err == nil && res != nil && res.OK
 	errMsg := ""
 	switch {
@@ -234,12 +330,16 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 	}
 	writeCtx, writeCancel := context.WithTimeout(context.Background(), authHealthWriteTimeout)
 	defer writeCancel()
-	if updateErr := s.store.UpdateAuthHealth(writeCtx, ok, errMsg, teamID, userID, time.Now().UTC()); updateErr != nil {
+	if updateErr := s.store.UpdateAuthHealthForWorkspace(writeCtx, workspaceID, ok, errMsg, teamID, userID, time.Now().UTC()); updateErr != nil {
 		s.log.Warn("slack: update auth health failed", zap.Error(updateErr))
 	}
 	if !ok {
-		s.invalidateClient()
+		s.invalidateClient(workspaceID)
 	}
+	s.fireProbeHook()
+}
+
+func (s *Service) fireProbeHook() {
 	s.mu.Lock()
 	hook := s.probeHook
 	s.mu.Unlock()
@@ -250,26 +350,42 @@ func (s *Service) RecordAuthHealth(ctx context.Context) {
 
 // Client exposes the cached client to the trigger and runtime.
 func (s *Service) Client(ctx context.Context) (Client, error) {
-	return s.clientFor(ctx)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.ClientForWorkspace(ctx, workspaceID)
 }
 
-func (s *Service) clientFor(ctx context.Context) (Client, error) {
+// ClientForWorkspace exposes a cached client for one workspace.
+func (s *Service) ClientForWorkspace(ctx context.Context, workspaceID string) (Client, error) {
+	return s.clientFor(ctx, workspaceID)
+}
+
+func (s *Service) clientFor(ctx context.Context, workspaceID string) (Client, error) {
+	workspaceID, err := s.normalizeWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	s.mu.Lock()
-	if s.client != nil {
-		c := s.client
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
+	}
+	if s.clients[workspaceID] != nil {
+		c := s.clients[workspaceID]
 		s.mu.Unlock()
 		return c, nil
 	}
 	s.mu.Unlock()
 
-	cfg, err := s.store.GetConfig(ctx)
+	cfg, err := s.store.GetConfigForWorkspace(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
 	if cfg == nil {
 		return nil, ErrNotConfigured
 	}
-	token, cookie, err := s.revealSecrets(ctx)
+	token, cookie, err := s.revealSecrets(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -279,35 +395,40 @@ func (s *Service) clientFor(ctx context.Context) (Client, error) {
 	client := s.clientFn(cfg, token, cookie)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.client != nil {
-		return s.client, nil
+	if s.clients == nil {
+		s.clients = make(map[string]Client)
 	}
-	s.client = client
+	if s.clients[workspaceID] != nil {
+		return s.clients[workspaceID], nil
+	}
+	s.clients[workspaceID] = client
 	return client, nil
 }
 
-func (s *Service) revealSecrets(ctx context.Context) (string, string, error) {
+func (s *Service) revealSecrets(ctx context.Context, workspaceID string) (string, string, error) {
 	if s.secrets == nil {
 		return "", "", nil
 	}
-	token, err := s.secrets.Reveal(ctx, SecretKeyToken)
+	token, err := s.revealSecret(ctx, SecretKeyForToken(workspaceID), SecretKeyToken)
 	if err != nil {
 		return "", "", fmt.Errorf("read slack token: %w", err)
 	}
-	cookie, err := s.secrets.Reveal(ctx, SecretKeyCookie)
+	cookie, err := s.revealSecret(ctx, SecretKeyForCookie(workspaceID), SecretKeyCookie)
 	if err != nil {
 		return "", "", fmt.Errorf("read slack cookie: %w", err)
 	}
 	return token, cookie, nil
 }
 
-func (s *Service) invalidateClient() {
+func (s *Service) invalidateClient(workspaceID string) {
 	s.mu.Lock()
-	s.client = nil
+	if s.clients != nil {
+		delete(s.clients, workspaceID)
+	}
 	s.mu.Unlock()
 }
 
-func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest) (*SlackConfig, string, string, error) {
+func (s *Service) resolveCredentials(ctx context.Context, workspaceID string, req *SetConfigRequest) (*SlackConfig, string, string, error) {
 	cfg := &SlackConfig{AuthMethod: req.AuthMethod}
 	token, cookie := req.Token, req.Cookie
 	if token != "" && cookie != "" {
@@ -317,7 +438,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 		return nil, "", "", errors.New("no secret store configured")
 	}
 	if token == "" {
-		stored, err := s.secrets.Reveal(ctx, SecretKeyToken)
+		stored, err := s.revealSecret(ctx, SecretKeyForToken(workspaceID), SecretKeyToken)
 		if err != nil {
 			s.log.Warn("slack: token reveal failed", zap.Error(err))
 			return nil, "", "", fmt.Errorf("read slack token: %w", err)
@@ -325,7 +446,7 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 		token = stored
 	}
 	if cookie == "" {
-		stored, err := s.secrets.Reveal(ctx, SecretKeyCookie)
+		stored, err := s.revealSecret(ctx, SecretKeyForCookie(workspaceID), SecretKeyCookie)
 		if err != nil {
 			s.log.Warn("slack: cookie reveal failed", zap.Error(err))
 			return nil, "", "", fmt.Errorf("read slack cookie: %w", err)
@@ -336,6 +457,32 @@ func (s *Service) resolveCredentials(ctx context.Context, req *SetConfigRequest)
 		return nil, "", "", errors.New("token and cookie required — paste both to test")
 	}
 	return cfg, token, cookie, nil
+}
+
+func (s *Service) revealSecret(ctx context.Context, key, legacyKey string) (string, error) {
+	value, err := s.secrets.Reveal(ctx, key)
+	if err == nil && value != "" {
+		return value, nil
+	}
+	legacy, legacyErr := s.secrets.Reveal(ctx, legacyKey)
+	if legacyErr == nil && legacy != "" {
+		return legacy, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", legacyErr
+}
+
+func (s *Service) defaultWorkspaceID() (string, error) {
+	return s.store.defaultWorkspaceID()
+}
+
+func (s *Service) normalizeWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
 }
 
 func validateConfigRequest(req *SetConfigRequest) error {

--- a/apps/backend/internal/slack/store.go
+++ b/apps/backend/internal/slack/store.go
@@ -18,6 +18,8 @@ type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
+	defaultWorkspace workspacescope.CachedResolver
+
 	// migratedToWorkspace records the workspace_id that received a legacy
 	// singleton row during initSchema. Provider reads this to migrate the
 	// singleton secrets to the workspace-scoped keys. Empty when no migration ran.
@@ -445,7 +447,7 @@ func (s *Store) UpdateLastSeenTSForWorkspace(ctx context.Context, workspaceID, t
 }
 
 func (s *Store) defaultWorkspaceID() (string, error) {
-	return workspacescope.ResolveMigrationTarget(s.db)
+	return s.defaultWorkspace.Resolve(s.db)
 }
 
 func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {

--- a/apps/backend/internal/slack/store.go
+++ b/apps/backend/internal/slack/store.go
@@ -8,19 +8,20 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/integrations/workspacescope"
 )
 
-// Store persists the install-wide Slack configuration. Secret values (xoxc
+// Store persists workspace-scoped Slack configuration. Secret values (xoxc
 // token, d cookie) live in the shared encrypted secrets store, not here.
 type Store struct {
 	db *sqlx.DB
 	ro *sqlx.DB
 
-	// migratedFromWorkspace records the workspace_id of the row that was
-	// promoted into the singleton during initSchema. Provider reads this to
-	// migrate the per-workspace secrets to the new global keys. Empty when
-	// no migration ran.
-	migratedFromWorkspace string
+	// migratedToWorkspace records the workspace_id that received a legacy
+	// singleton row during initSchema. Provider reads this to migrate the
+	// singleton secrets to the workspace-scoped keys. Empty when no migration ran.
+	migratedToWorkspace string
 }
 
 // NewStore creates a new Store and initializes the schema if needed.
@@ -32,16 +33,15 @@ func NewStore(writer, reader *sqlx.DB) (*Store, error) {
 	return s, nil
 }
 
-// MigratedFromWorkspace returns the workspace_id of the row promoted to the
-// singleton during the per-workspace → singleton schema migration, or "" when
-// no migration ran.
+// MigratedFromWorkspace is kept for older provider call sites. It now returns
+// the workspace_id that received a legacy singleton row during migration.
 func (s *Store) MigratedFromWorkspace() string {
-	return s.migratedFromWorkspace
+	return s.migratedToWorkspace
 }
 
 const createTablesSQL = `
 	CREATE TABLE IF NOT EXISTS slack_configs (
-		id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+		workspace_id TEXT PRIMARY KEY,
 		auth_method TEXT NOT NULL,
 		command_prefix TEXT NOT NULL DEFAULT '',
 		utility_agent_id TEXT NOT NULL DEFAULT '',
@@ -57,24 +57,24 @@ const createTablesSQL = `
 	);
 `
 
-// singletonID is the synthetic primary key of the (only) row in slack_configs.
+// singletonID is the synthetic primary key used by the legacy install-wide
+// slack_configs table.
 const singletonID = "singleton"
 
 func (s *Store) initSchema() error {
-	if err := s.migrateLegacyPerWorkspaceTable(); err != nil {
+	if err := s.migrateLegacySingletonTable(); err != nil {
 		return err
 	}
 	if _, err := s.db.Exec(createTablesSQL); err != nil {
 		return err
 	}
+	if err := s.addConfigColumns(); err != nil {
+		return err
+	}
 	return nil
 }
 
-// migrateLegacyPerWorkspaceTable detects the pre-singleton schema (where
-// slack_configs was keyed by workspace_id) and rewrites it into the singleton
-// shape. Picks the most-recently-updated row and records the source
-// workspace_id so the provider can migrate the secrets.
-func (s *Store) migrateLegacyPerWorkspaceTable() error {
+func (s *Store) addConfigColumns() error {
 	cols, err := s.tableColumns()
 	if err != nil {
 		return err
@@ -82,8 +82,43 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	if len(cols) == 0 {
 		return nil
 	}
-	if _, hasWorkspace := cols["workspace_id"]; !hasWorkspace {
+	for _, col := range []struct {
+		name string
+		sql  string
+	}{
+		{"command_prefix", `ALTER TABLE slack_configs ADD COLUMN command_prefix TEXT NOT NULL DEFAULT ''`},
+		{"utility_agent_id", `ALTER TABLE slack_configs ADD COLUMN utility_agent_id TEXT NOT NULL DEFAULT ''`},
+		{"poll_interval_seconds", `ALTER TABLE slack_configs ADD COLUMN poll_interval_seconds INTEGER NOT NULL DEFAULT 30`},
+		{"slack_team_id", `ALTER TABLE slack_configs ADD COLUMN slack_team_id TEXT NOT NULL DEFAULT ''`},
+		{"slack_user_id", `ALTER TABLE slack_configs ADD COLUMN slack_user_id TEXT NOT NULL DEFAULT ''`},
+		{"last_seen_ts", `ALTER TABLE slack_configs ADD COLUMN last_seen_ts TEXT NOT NULL DEFAULT ''`},
+		{"last_checked_at", `ALTER TABLE slack_configs ADD COLUMN last_checked_at DATETIME`},
+		{"last_ok", `ALTER TABLE slack_configs ADD COLUMN last_ok INTEGER NOT NULL DEFAULT 0`},
+		{"last_error", `ALTER TABLE slack_configs ADD COLUMN last_error TEXT NOT NULL DEFAULT ''`},
+	} {
+		if _, ok := cols[col.name]; !ok {
+			if _, err := s.db.Exec(col.sql); err != nil {
+				return fmt.Errorf("add %s column: %w", col.name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// migrateLegacySingletonTable detects the install-wide singleton schema and
+// rewrites it into the workspace-scoped shape. Existing workspace-keyed tables
+// are already canonical and are left in place.
+func (s *Store) migrateLegacySingletonTable() error {
+	cols, err := s.tableColumns()
+	if err != nil {
+		return err
+	}
+	if !isLegacySingletonConfig(cols) {
 		return nil
+	}
+	targetWorkspace, err := workspacescope.ResolveMigrationTarget(s.db)
+	if err != nil {
+		return err
 	}
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -91,36 +126,8 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Build the SELECT against only columns present in this database — the
-	// per-workspace shape evolved across patches (utility_agent_id,
-	// poll_interval_seconds, the slack_team/slack_user/last_seen trio, and
-	// the auth-health trio were all added incrementally), so a deployment
-	// upgrading from any earlier intermediate would crash on a SELECT that
-	// assumed every column. Mirrors the Linear/Jira fix.
-	selectCols := "workspace_id, auth_method"
-	selectCols += pickCol(cols, "command_prefix", "''")
-	selectCols += pickCol(cols, "utility_agent_id", "''")
-	selectCols += pickCol(cols, "poll_interval_seconds", "30")
-	selectCols += pickCol(cols, "slack_team_id", "''")
-	selectCols += pickCol(cols, "slack_user_id", "''")
-	selectCols += pickCol(cols, "last_seen_ts", "''")
-	selectCols += pickCol(cols, "last_checked_at", "NULL")
-	selectCols += pickCol(cols, "last_ok", "0")
-	selectCols += pickCol(cols, "last_error", "''")
-	selectCols += ", created_at, updated_at"
-
-	var sourceWorkspace, authMethod, commandPrefix, utilityAgentID sql.NullString
-	var pollIntervalSeconds sql.NullInt64
-	var slackTeamID, slackUserID, lastSeenTS, lastError sql.NullString
-	var lastCheckedAt sql.NullTime
-	var lastOk sql.NullInt64
-	var createdAt, updatedAt sql.NullTime
-	row := tx.QueryRow(`SELECT ` + selectCols + ` FROM slack_configs ORDER BY updated_at DESC, workspace_id DESC LIMIT 1`)
-	switch err := row.Scan(&sourceWorkspace, &authMethod,
-		&commandPrefix, &utilityAgentID, &pollIntervalSeconds,
-		&slackTeamID, &slackUserID, &lastSeenTS,
-		&lastCheckedAt, &lastOk, &lastError,
-		&createdAt, &updatedAt); {
+	cfg, err := scanLegacySingletonConfig(tx, cols)
+	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		if _, err := tx.Exec(`DROP TABLE slack_configs`); err != nil {
 			return err
@@ -135,27 +142,83 @@ func (s *Store) migrateLegacyPerWorkspaceTable() error {
 	if _, err := tx.Exec(createTablesSQL); err != nil {
 		return err
 	}
-	pollSeconds := int(pollIntervalSeconds.Int64)
-	if pollSeconds == 0 {
-		pollSeconds = DefaultPollIntervalSeconds
-	}
-	if _, err := tx.Exec(`
-		INSERT INTO slack_configs (
-			id, auth_method, command_prefix, utility_agent_id, poll_interval_seconds,
-			slack_team_id, slack_user_id, last_seen_ts,
-			last_checked_at, last_ok, last_error, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		singletonID, authMethod.String, commandPrefix.String, utilityAgentID.String, pollSeconds,
-		slackTeamID.String, slackUserID.String, lastSeenTS.String,
-		nullableTime(lastCheckedAt), lastOk.Int64, lastError.String,
-		nullableTime(createdAt), nullableTime(updatedAt)); err != nil {
+	if err := insertMigratedConfig(tx, targetWorkspace, cfg); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	s.migratedFromWorkspace = sourceWorkspace.String
+	s.migratedToWorkspace = targetWorkspace
 	return nil
+}
+
+func isLegacySingletonConfig(cols map[string]struct{}) bool {
+	if len(cols) == 0 {
+		return false
+	}
+	if _, hasWorkspace := cols["workspace_id"]; hasWorkspace {
+		return false
+	}
+	_, hasID := cols["id"]
+	return hasID
+}
+
+type legacySlackConfig struct {
+	authMethod           sql.NullString
+	commandPrefix        sql.NullString
+	utilityAgentID       sql.NullString
+	pollIntervalSeconds  sql.NullInt64
+	slackTeamID          sql.NullString
+	slackUserID          sql.NullString
+	lastSeenTS           sql.NullString
+	lastCheckedAt        sql.NullTime
+	lastOk               sql.NullInt64
+	lastError            sql.NullString
+	createdAt, updatedAt sql.NullTime
+}
+
+func scanLegacySingletonConfig(tx *sql.Tx, cols map[string]struct{}) (*legacySlackConfig, error) {
+	// Build the SELECT against only columns present in this database — the
+	// per-workspace shape evolved across patches, so upgrades from earlier
+	// intermediates need defaults for missing columns.
+	selectCols := "auth_method"
+	selectCols += pickCol(cols, "command_prefix", "''")
+	selectCols += pickCol(cols, "utility_agent_id", "''")
+	selectCols += pickCol(cols, "poll_interval_seconds", "30")
+	selectCols += pickCol(cols, "slack_team_id", "''")
+	selectCols += pickCol(cols, "slack_user_id", "''")
+	selectCols += pickCol(cols, "last_seen_ts", "''")
+	selectCols += pickCol(cols, "last_checked_at", "NULL")
+	selectCols += pickCol(cols, "last_ok", "0")
+	selectCols += pickCol(cols, "last_error", "''")
+	selectCols += ", created_at, updated_at"
+
+	cfg := &legacySlackConfig{}
+	row := tx.QueryRow(`SELECT `+selectCols+` FROM slack_configs WHERE id = ? LIMIT 1`, singletonID)
+	err := row.Scan(&cfg.authMethod,
+		&cfg.commandPrefix, &cfg.utilityAgentID, &cfg.pollIntervalSeconds,
+		&cfg.slackTeamID, &cfg.slackUserID, &cfg.lastSeenTS,
+		&cfg.lastCheckedAt, &cfg.lastOk, &cfg.lastError,
+		&cfg.createdAt, &cfg.updatedAt)
+	return cfg, err
+}
+
+func insertMigratedConfig(tx *sql.Tx, workspaceID string, cfg *legacySlackConfig) error {
+	pollSeconds := int(cfg.pollIntervalSeconds.Int64)
+	if pollSeconds == 0 {
+		pollSeconds = DefaultPollIntervalSeconds
+	}
+	_, err := tx.Exec(`
+		INSERT INTO slack_configs (
+			workspace_id, auth_method, command_prefix, utility_agent_id, poll_interval_seconds,
+			slack_team_id, slack_user_id, last_seen_ts,
+			last_checked_at, last_ok, last_error, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		workspaceID, cfg.authMethod.String, cfg.commandPrefix.String, cfg.utilityAgentID.String, pollSeconds,
+		cfg.slackTeamID.String, cfg.slackUserID.String, cfg.lastSeenTS.String,
+		nullableTime(cfg.lastCheckedAt), cfg.lastOk.Int64, cfg.lastError.String,
+		nullableTime(cfg.createdAt), nullableTime(cfg.updatedAt))
+	return err
 }
 
 // pickCol returns ", <name>" if the column is present in the legacy schema
@@ -203,16 +266,31 @@ func (s *Store) tableColumns() (map[string]struct{}, error) {
 	return cols, rows.Err()
 }
 
-const selectConfigColumns = `auth_method, command_prefix, utility_agent_id,
+const selectConfigColumns = `workspace_id, auth_method, command_prefix, utility_agent_id,
 		poll_interval_seconds,
 		slack_team_id, slack_user_id, last_seen_ts,
 		last_checked_at, last_ok, last_error, created_at, updated_at`
 
-// GetConfig returns the singleton Slack config, or nil when no row exists.
+// GetConfig returns the default workspace Slack config, or nil when no row
+// exists. New code should call GetConfigForWorkspace.
 func (s *Store) GetConfig(ctx context.Context) (*SlackConfig, error) {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return nil, err
+	}
+	return s.GetConfigForWorkspace(ctx, workspaceID)
+}
+
+// GetConfigForWorkspace returns the Slack config for a workspace, or nil when
+// no row exists.
+func (s *Store) GetConfigForWorkspace(ctx context.Context, workspaceID string) (*SlackConfig, error) {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
 	var cfg SlackConfig
-	err := s.ro.GetContext(ctx, &cfg,
-		`SELECT `+selectConfigColumns+` FROM slack_configs WHERE id = ?`, singletonID)
+	err = s.ro.GetContext(ctx, &cfg,
+		`SELECT `+selectConfigColumns+` FROM slack_configs WHERE workspace_id = ?`, workspaceID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -222,76 +300,157 @@ func (s *Store) GetConfig(ctx context.Context) (*SlackConfig, error) {
 	return &cfg, nil
 }
 
-// UpsertConfig inserts or updates the singleton row. Health columns
+// UpsertConfig inserts or updates the default workspace row. Health columns
 // (last_*) and watermark columns (last_seen_ts, slack_team_id, slack_user_id)
 // are owned by the poller / trigger and aren't touched here.
 func (s *Store) UpsertConfig(ctx context.Context, cfg *SlackConfig) error {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpsertConfigForWorkspace(ctx, workspaceID, cfg)
+}
+
+// UpsertConfigForWorkspace inserts or updates a workspace row.
+func (s *Store) UpsertConfigForWorkspace(ctx context.Context, workspaceID string, cfg *SlackConfig) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 	if cfg.CreatedAt.IsZero() {
 		cfg.CreatedAt = now
 	}
 	cfg.UpdatedAt = now
-	_, err := s.db.ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO slack_configs (
-			id, auth_method,
+			workspace_id, auth_method,
 			command_prefix, utility_agent_id, poll_interval_seconds,
 			created_at, updated_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
+		ON CONFLICT(workspace_id) DO UPDATE SET
 			auth_method = excluded.auth_method,
 			command_prefix = excluded.command_prefix,
 			utility_agent_id = excluded.utility_agent_id,
 			poll_interval_seconds = excluded.poll_interval_seconds,
 			updated_at = excluded.updated_at`,
-		singletonID, cfg.AuthMethod,
+		workspaceID, cfg.AuthMethod,
 		cfg.CommandPrefix, cfg.UtilityAgentID, cfg.PollIntervalSeconds,
 		cfg.CreatedAt, cfg.UpdatedAt)
 	return err
 }
 
-// DeleteConfig removes the singleton row. Secrets must be cleared separately.
+// DeleteConfig removes the default workspace row. Secrets must be cleared separately.
 func (s *Store) DeleteConfig(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM slack_configs WHERE id = ?`, singletonID)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.DeleteConfigForWorkspace(ctx, workspaceID)
+}
+
+// DeleteConfigForWorkspace removes the workspace row. Secrets must be cleared separately.
+func (s *Store) DeleteConfigForWorkspace(ctx context.Context, workspaceID string) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `DELETE FROM slack_configs WHERE workspace_id = ?`, workspaceID)
 	return err
 }
 
-// HasConfig reports whether the singleton row exists. Used by the auth-health
+// HasConfig reports whether any config row exists. Used by the auth-health
 // poller to decide whether to probe at all.
 func (s *Store) HasConfig(ctx context.Context) (bool, error) {
 	var present int
 	err := s.ro.GetContext(ctx, &present,
-		`SELECT COUNT(*) FROM slack_configs WHERE id = ?`, singletonID)
+		`SELECT COUNT(*) FROM slack_configs`)
 	if err != nil {
 		return false, err
 	}
 	return present > 0, nil
 }
 
+// ListConfigWorkspaceIDs returns every workspace with a saved Slack config.
+func (s *Store) ListConfigWorkspaceIDs(ctx context.Context) ([]string, error) {
+	var ids []string
+	if err := s.ro.SelectContext(ctx, &ids, `SELECT workspace_id FROM slack_configs ORDER BY workspace_id`); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+// ListConfigs returns every Slack config row ordered by workspace.
+func (s *Store) ListConfigs(ctx context.Context) ([]*SlackConfig, error) {
+	var configs []*SlackConfig
+	if err := s.ro.SelectContext(ctx, &configs, `SELECT `+selectConfigColumns+` FROM slack_configs ORDER BY workspace_id`); err != nil {
+		return nil, err
+	}
+	return configs, nil
+}
+
 // UpdateAuthHealth records the result of a credential probe and (when
 // supplied) the user/team identifiers captured during the same probe so the
 // trigger can scope its searches without an extra round-trip.
 func (s *Store) UpdateAuthHealth(ctx context.Context, ok bool, errMsg, teamID, userID string, checkedAt time.Time) error {
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpdateAuthHealthForWorkspace(ctx, workspaceID, ok, errMsg, teamID, userID, checkedAt)
+}
+
+// UpdateAuthHealthForWorkspace records the result of a credential probe for one workspace.
+func (s *Store) UpdateAuthHealthForWorkspace(ctx context.Context, workspaceID string, ok bool, errMsg, teamID, userID string, checkedAt time.Time) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
 	if teamID != "" && userID != "" {
-		_, err := s.db.ExecContext(ctx, `
+		_, err = s.db.ExecContext(ctx, `
 			UPDATE slack_configs
 			SET last_checked_at = ?, last_ok = ?, last_error = ?,
 				slack_team_id = ?, slack_user_id = ?
-			WHERE id = ?`,
-			checkedAt, ok, errMsg, teamID, userID, singletonID)
+			WHERE workspace_id = ?`,
+			checkedAt, ok, errMsg, teamID, userID, workspaceID)
 		return err
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err = s.db.ExecContext(ctx, `
 		UPDATE slack_configs
 		SET last_checked_at = ?, last_ok = ?, last_error = ?
-		WHERE id = ?`,
-		checkedAt, ok, errMsg, singletonID)
+		WHERE workspace_id = ?`,
+		checkedAt, ok, errMsg, workspaceID)
 	return err
 }
 
 // UpdateLastSeenTS advances the trigger's watermark.
 func (s *Store) UpdateLastSeenTS(ctx context.Context, ts string) error {
-	_, err := s.db.ExecContext(ctx,
-		`UPDATE slack_configs SET last_seen_ts = ? WHERE id = ?`,
-		ts, singletonID)
+	workspaceID, err := s.defaultWorkspaceID()
+	if err != nil {
+		return err
+	}
+	return s.UpdateLastSeenTSForWorkspace(ctx, workspaceID, ts)
+}
+
+// UpdateLastSeenTSForWorkspace advances one workspace trigger watermark.
+func (s *Store) UpdateLastSeenTSForWorkspace(ctx context.Context, workspaceID, ts string) error {
+	workspaceID, err := s.resolveWorkspaceID(workspaceID)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE slack_configs SET last_seen_ts = ? WHERE workspace_id = ?`,
+		ts, workspaceID)
 	return err
+}
+
+func (s *Store) defaultWorkspaceID() (string, error) {
+	return workspacescope.ResolveMigrationTarget(s.db)
+}
+
+func (s *Store) resolveWorkspaceID(workspaceID string) (string, error) {
+	if workspaceID != "" {
+		return workspaceID, nil
+	}
+	return s.defaultWorkspaceID()
 }

--- a/apps/backend/internal/slack/store_test.go
+++ b/apps/backend/internal/slack/store_test.go
@@ -157,6 +157,77 @@ func TestStore_UpdateLastSeenTS(t *testing.T) {
 	}
 }
 
+func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
+	raw, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	db := sqlx.NewDb(raw, "sqlite3")
+	t.Cleanup(func() { _ = db.Close() })
+
+	now := time.Now().UTC()
+	if _, err := db.Exec(`
+		CREATE TABLE workspaces (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE users (
+			id TEXT PRIMARY KEY,
+			email TEXT NOT NULL,
+			settings TEXT NOT NULL DEFAULT '{}',
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL
+		);
+		CREATE TABLE slack_configs (
+			id TEXT PRIMARY KEY CHECK(id = 'singleton'),
+			auth_method TEXT NOT NULL,
+			command_prefix TEXT NOT NULL DEFAULT '',
+			utility_agent_id TEXT NOT NULL DEFAULT '',
+			poll_interval_seconds INTEGER NOT NULL DEFAULT 30,
+			slack_team_id TEXT NOT NULL DEFAULT '',
+			slack_user_id TEXT NOT NULL DEFAULT '',
+			last_seen_ts TEXT NOT NULL DEFAULT '',
+			last_checked_at DATETIME,
+			last_ok INTEGER NOT NULL DEFAULT 0,
+			last_error TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+		INSERT INTO workspaces (id, name, created_at, updated_at)
+			VALUES ('ws-first', 'First', ?, ?), ('ws-active', 'Active', ?, ?);
+		INSERT INTO users (id, email, settings, created_at, updated_at)
+			VALUES ('default-user', 'default@kandev.local', '{"workspace_id":"ws-active"}', ?, ?);
+		INSERT INTO slack_configs (
+			id, auth_method, command_prefix, utility_agent_id, poll_interval_seconds,
+			slack_team_id, slack_user_id, last_seen_ts, last_ok, created_at, updated_at
+		) VALUES ('singleton', 'cookie', '!kandev', 'ua-active', 60, 'T-active', 'U-active', '200.0', 1, ?, ?);
+	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, now, now); err != nil {
+		t.Fatalf("seed singleton schema: %v", err)
+	}
+
+	store, err := NewStore(db, db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	if got := store.MigratedFromWorkspace(); got != "ws-active" {
+		t.Fatalf("expected singleton config migrated to active workspace, got %q", got)
+	}
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-active")
+	if err != nil || cfg == nil {
+		t.Fatalf("get active workspace config: cfg=%v err=%v", cfg, err)
+	}
+	if cfg.UtilityAgentID != "ua-active" || cfg.CommandPrefix != "!kandev" || cfg.PollIntervalSeconds != 60 {
+		t.Errorf("unexpected migrated settings: %+v", cfg)
+	}
+	if cfg.SlackTeamID != "T-active" || cfg.SlackUserID != "U-active" || cfg.LastSeenTS != "200.0" {
+		t.Errorf("unexpected migrated runtime state: %+v", cfg)
+	}
+}
+
 func TestStore_LegacyPerWorkspaceMigration(t *testing.T) {
 	// Simulate a deployment running the pre-singleton schema: a slack_configs
 	// table keyed by workspace_id, with the most-recently-updated row to be

--- a/apps/backend/internal/slack/store_test.go
+++ b/apps/backend/internal/slack/store_test.go
@@ -168,6 +168,7 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	now := time.Now().UTC()
+	checkedAt := now.Add(-5 * time.Minute).Truncate(time.Second)
 	if _, err := db.Exec(`
 		CREATE TABLE workspaces (
 			id TEXT PRIMARY KEY,
@@ -203,9 +204,9 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 			VALUES ('default-user', 'default@kandev.local', '{"workspace_id":"ws-active"}', ?, ?);
 		INSERT INTO slack_configs (
 			id, auth_method, command_prefix, utility_agent_id, poll_interval_seconds,
-			slack_team_id, slack_user_id, last_seen_ts, last_ok, created_at, updated_at
-		) VALUES ('singleton', 'cookie', '!kandev', 'ua-active', 60, 'T-active', 'U-active', '200.0', 1, ?, ?);
-	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, now, now); err != nil {
+			slack_team_id, slack_user_id, last_seen_ts, last_checked_at, last_ok, last_error, created_at, updated_at
+		) VALUES ('singleton', 'cookie', '!kandev', 'ua-active', 60, 'T-active', 'U-active', '200.0', ?, 1, 'healthy', ?, ?);
+	`, now.Add(-time.Hour), now.Add(-time.Hour), now, now, now, now, checkedAt, now, now); err != nil {
 		t.Fatalf("seed singleton schema: %v", err)
 	}
 
@@ -225,6 +226,12 @@ func TestStore_MigrateSingletonConfigToActiveWorkspace(t *testing.T) {
 	}
 	if cfg.SlackTeamID != "T-active" || cfg.SlackUserID != "U-active" || cfg.LastSeenTS != "200.0" {
 		t.Errorf("unexpected migrated runtime state: %+v", cfg)
+	}
+	if !cfg.LastOk || cfg.LastError != "healthy" {
+		t.Errorf("unexpected migrated health state: %+v", cfg)
+	}
+	if cfg.LastCheckedAt == nil || !cfg.LastCheckedAt.Equal(checkedAt) {
+		t.Errorf("expected last_checked_at=%v, got %v", checkedAt, cfg.LastCheckedAt)
 	}
 }
 

--- a/apps/backend/internal/slack/store_test.go
+++ b/apps/backend/internal/slack/store_test.go
@@ -205,12 +205,12 @@ func TestStore_LegacyPerWorkspaceMigration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new store: %v", err)
 	}
-	if got := store.MigratedFromWorkspace(); got != "ws-new" {
-		t.Errorf("expected migration to promote ws-new (most recently updated), got %q", got)
+	if got := store.MigratedFromWorkspace(); got != "" {
+		t.Errorf("expected no singleton migration, got %q", got)
 	}
-	cfg, err := store.GetConfig(context.Background())
+	cfg, err := store.GetConfigForWorkspace(context.Background(), "ws-new")
 	if err != nil || cfg == nil {
-		t.Fatalf("get post-migration: cfg=%v err=%v", cfg, err)
+		t.Fatalf("get workspace config: cfg=%v err=%v", cfg, err)
 	}
 	if cfg.UtilityAgentID != "ua-new" || cfg.CommandPrefix != "!kandev" || cfg.PollIntervalSeconds != 60 {
 		t.Errorf("expected ws-new fields preserved, got %+v", cfg)

--- a/apps/backend/internal/slack/trigger.go
+++ b/apps/backend/internal/slack/trigger.go
@@ -38,11 +38,11 @@ type Trigger struct {
 	wg      sync.WaitGroup
 	started bool
 
-	// lastScannedAt tracks when we last ran a scan so the configured
-	// PollIntervalSeconds is honoured exactly. In-memory by design — backend
-	// restart triggers an immediate scan, which is fine.
+	// lastScannedAt tracks when each workspace last ran a scan so its
+	// PollIntervalSeconds is honoured independently. In-memory by design —
+	// backend restart triggers an immediate scan, which is fine.
 	scannedMu     sync.Mutex
-	lastScannedAt time.Time
+	lastScannedAt map[string]time.Time
 }
 
 // NewTrigger returns a Trigger using the default base ticker.
@@ -112,28 +112,34 @@ func (t *Trigger) tick(ctx context.Context) {
 	if t.svc.Runner() == nil {
 		return
 	}
-	cfg, err := t.svc.Store().GetConfig(ctx)
-	if err != nil || cfg == nil {
+	configs, err := t.svc.Store().ListConfigs(ctx)
+	if err != nil || len(configs) == 0 {
 		return
 	}
+	for _, cfg := range configs {
+		if !t.dueForScan(cfg.WorkspaceID, cfg.PollIntervalSeconds) {
+			continue
+		}
+		t.markScanned(cfg.WorkspaceID)
+		t.scanWorkspace(ctx, cfg)
+	}
+}
+
+func (t *Trigger) scanWorkspace(ctx context.Context, cfg *SlackConfig) {
 	if !cfg.LastOk || cfg.SlackUserID == "" {
 		return
 	}
 	if cfg.UtilityAgentID == "" {
 		return
 	}
-	if !t.dueForScan(cfg.PollIntervalSeconds) {
-		return
-	}
 	prefix := cfg.CommandPrefix
 	if prefix == "" {
 		prefix = DefaultCommandPrefix
 	}
-	client, err := t.svc.Client(ctx)
+	client, err := t.svc.ClientForWorkspace(ctx, cfg.WorkspaceID)
 	if err != nil {
 		return
 	}
-	t.markScanned()
 	query := fmt.Sprintf("from:<@%s> %q", cfg.SlackUserID, prefix)
 	matches, err := client.SearchMessages(ctx, query)
 	if err != nil {
@@ -174,7 +180,7 @@ func (t *Trigger) processMatches(ctx context.Context, cfg *SlackConfig, prefix s
 		}
 	}
 	if highest != cfg.LastSeenTS {
-		if err := t.svc.Store().UpdateLastSeenTS(ctx, highest); err != nil {
+		if err := t.svc.Store().UpdateLastSeenTSForWorkspace(ctx, cfg.WorkspaceID, highest); err != nil {
 			t.log.Warn("slack trigger: advance watermark failed", zap.Error(err))
 		}
 	}
@@ -223,22 +229,36 @@ func (t *Trigger) replyInThread(ctx context.Context, client Client, msg SlackMes
 
 // dueForScan reports whether the configured interval has elapsed since the
 // last scan. A zero/never timestamp counts as due.
-func (t *Trigger) dueForScan(intervalSeconds int) bool {
+func (t *Trigger) dueForScan(workspaceID string, intervalSeconds int) bool {
 	if intervalSeconds < MinPollIntervalSeconds {
 		intervalSeconds = DefaultPollIntervalSeconds
 	}
 	t.scannedMu.Lock()
 	defer t.scannedMu.Unlock()
-	if t.lastScannedAt.IsZero() {
+	if t.lastScannedAt == nil {
 		return true
 	}
-	return time.Since(t.lastScannedAt) >= time.Duration(intervalSeconds)*time.Second
+	last := t.lastScannedAt[normalizeWorkspaceID(workspaceID)]
+	if last.IsZero() {
+		return true
+	}
+	return time.Since(last) >= time.Duration(intervalSeconds)*time.Second
 }
 
-func (t *Trigger) markScanned() {
+func (t *Trigger) markScanned(workspaceID string) {
 	t.scannedMu.Lock()
-	t.lastScannedAt = time.Now()
+	if t.lastScannedAt == nil {
+		t.lastScannedAt = make(map[string]time.Time)
+	}
+	t.lastScannedAt[normalizeWorkspaceID(workspaceID)] = time.Now()
 	t.scannedMu.Unlock()
+}
+
+func normalizeWorkspaceID(workspaceID string) string {
+	if workspaceID == "" {
+		return "default"
+	}
+	return workspaceID
 }
 
 func newMatchesAfter(matches []SlackMessage, watermark, prefix string) []SlackMessage {

--- a/apps/backend/internal/slack/trigger_test.go
+++ b/apps/backend/internal/slack/trigger_test.go
@@ -404,7 +404,7 @@ func TestTrigger_HandleOne_PostsAgentReplyInThread(t *testing.T) {
 	})
 
 	client := &fakeClient{thread: []SlackMessage{{TS: "100.0001", Text: "!kandev fix it"}}, permalink: "https://example/p100"}
-	svc.client = client
+	svc.clients["default"] = client
 
 	cfg, _ := svc.Store().GetConfig(ctx)
 	trig := NewTrigger(svc, logger.Default())
@@ -504,7 +504,7 @@ func TestTrigger_ProcessMatches_BreaksOnTransientError(t *testing.T) {
 	}
 	svc := NewService(store, nil, runner, factory, logger.Default())
 	client := &fakeClient{thread: []SlackMessage{{TS: "100.000001", Text: "!kandev a"}}}
-	svc.client = client
+	svc.clients["default"] = client
 
 	trig := NewTrigger(svc, logger.Default())
 	matches := []SlackMessage{
@@ -552,7 +552,7 @@ func TestTrigger_ProcessMatches_NoUtilityAgentSkipsWithoutBreak(t *testing.T) {
 
 	factory := func(_ *SlackConfig, _ string, _ string) Client { return &fakeClient{} }
 	svc := NewService(store, nil, noAgentRunner, factory, logger.Default())
-	svc.client = &fakeClient{}
+	svc.clients["default"] = &fakeClient{}
 
 	trig := NewTrigger(svc, logger.Default())
 	matches := []SlackMessage{
@@ -603,29 +603,32 @@ func TestComposePrompt_GenericTemplateGetsResolvedSubstitution(t *testing.T) {
 
 func TestTrigger_DueForScan(t *testing.T) {
 	trig := &Trigger{}
-	if !trig.dueForScan(30) {
+	if !trig.dueForScan("ws-a", 30) {
 		t.Error("expected fresh trigger to be due immediately")
 	}
-	trig.markScanned()
-	if trig.dueForScan(30) {
+	trig.markScanned("ws-a")
+	if trig.dueForScan("ws-a", 30) {
 		t.Error("expected trigger to not be due immediately after scan")
+	}
+	if !trig.dueForScan("ws-b", 30) {
+		t.Error("expected a different workspace to remain due")
 	}
 
 	// Backdate the marker to simulate enough elapsed time. Using a direct
 	// field write here rather than time.Sleep keeps the test deterministic.
 	trig.scannedMu.Lock()
-	trig.lastScannedAt = time.Now().Add(-31 * time.Second)
+	trig.lastScannedAt[normalizeWorkspaceID("ws-a")] = time.Now().Add(-31 * time.Second)
 	trig.scannedMu.Unlock()
-	if !trig.dueForScan(30) {
+	if !trig.dueForScan("ws-a", 30) {
 		t.Error("expected trigger to be due again after 31s with 30s interval")
 	}
 
 	// Bogus interval (below floor) falls back to the default — guards against
 	// a config row with 0 (or a corrupted row) holding the loop hostage.
 	trig.scannedMu.Lock()
-	trig.lastScannedAt = time.Now()
+	trig.lastScannedAt[normalizeWorkspaceID("ws-a")] = time.Now()
 	trig.scannedMu.Unlock()
-	if trig.dueForScan(0) {
+	if trig.dueForScan("ws-a", 0) {
 		t.Error("expected zero interval to behave as default 30s, not as 'always due'")
 	}
 }

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "@/components/routing/app-link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { IconBrandGithub, IconMenu2 } from "@tabler/icons-react";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
 import { Button } from "@kandev/ui/button";
@@ -165,6 +165,7 @@ function ResultsList({
 type GitHubPageState = ReturnType<typeof useGitHubPageState>;
 
 function useRepoOptions(
+  workspaceId: string | null,
   selection: SidebarSelection,
   committedQuery: string,
   items: Array<GitHubPR | GitHubIssue>,
@@ -180,7 +181,7 @@ function useRepoOptions(
   // Reset the accumulator whenever the query context changes (preset, saved,
   // custom query). Repo filter is deliberately excluded so narrowing doesn't
   // reset — that's the whole point of the accumulator.
-  const reposResetKey = `${selection.kind}:${selection.source}:${selection.id}:${committedQuery.trim()}`;
+  const reposResetKey = `${workspaceId ?? "global"}:${selection.kind}:${selection.source}:${selection.id}:${committedQuery.trim()}`;
   const knownRepos = useKnownRepos(reposResetKey, pageRepos);
   return useMemo(() => {
     const set = new Set(knownRepos);
@@ -196,15 +197,42 @@ function useResolvedQueryPresets(workspaceId: string | null = null) {
   return { pr, issue };
 }
 
-function useGitHubPageState(workspaceId: string | null) {
-  const { pr: resolvedPrPresets, issue: resolvedIssuePresets } =
-    useResolvedQueryPresets(workspaceId);
-
+function useInitialSidebarSelection(
+  workspaceId: string | null,
+  resolvedPrPresets: PresetOption[],
+  setQueryImmediate: (query: string) => void,
+  setRepoFilter: (repo: string) => void,
+) {
+  const userSelectedRef = useRef(false);
   const [selection, setSelection] = useState<SidebarSelection>(() => ({
     kind: "pr",
     source: "preset",
     id: resolvedPrPresets[0]?.value ?? "",
   }));
+
+  useEffect(() => {
+    userSelectedRef.current = false;
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (userSelectedRef.current) return;
+    const first = resolvedPrPresets[0];
+    setSelection({ kind: "pr", source: "preset", id: first?.value ?? "" });
+    setQueryImmediate(first?.filter ?? "");
+    setRepoFilter("");
+  }, [workspaceId, resolvedPrPresets, setQueryImmediate, setRepoFilter]);
+
+  const setUserSelection = useCallback((next: SidebarSelection) => {
+    userSelectedRef.current = true;
+    setSelection(next);
+  }, []);
+
+  return { selection, setSelection, setUserSelection };
+}
+
+function useGitHubPageState(workspaceId: string | null) {
+  const { pr: resolvedPrPresets, issue: resolvedIssuePresets } =
+    useResolvedQueryPresets(workspaceId);
   const {
     draft: customQuery,
     committed: committedQuery,
@@ -219,6 +247,12 @@ function useGitHubPageState(workspaceId: string | null) {
     save: saveSavedPreset,
     remove: removeSavedPreset,
   } = useSavedPresets(workspaceId);
+  const { selection, setSelection, setUserSelection } = useInitialSidebarSelection(
+    workspaceId,
+    resolvedPrPresets,
+    setQueryImmediate,
+    setRepoFilter,
+  );
 
   const presets = selection.kind === "pr" ? resolvedPrPresets : resolvedIssuePresets;
   const search = useGitHubSearch<GitHubPR | GitHubIssue>({
@@ -229,7 +263,13 @@ function useGitHubPageState(workspaceId: string | null) {
     repoFilter,
     workspaceId,
   });
-  const repoOptions = useRepoOptions(selection, committedQuery, search.items, repoFilter);
+  const repoOptions = useRepoOptions(
+    workspaceId,
+    selection,
+    committedQuery,
+    search.items,
+    repoFilter,
+  );
   const title = useMemo(
     () => resolveTitle(selection, savedPresets, resolvedPrPresets, resolvedIssuePresets),
     [selection, savedPresets, resolvedPrPresets, resolvedIssuePresets],
@@ -237,7 +277,7 @@ function useGitHubPageState(workspaceId: string | null) {
 
   const onSelect = useCallback(
     (s: SidebarSelection) => {
-      setSelection(s);
+      setUserSelection(s);
       if (s.source === "saved") {
         const found = savedPresets.find((p) => p.id === s.id);
         setQueryImmediate(found?.customQuery ?? "");
@@ -249,14 +289,12 @@ function useGitHubPageState(workspaceId: string | null) {
       setQueryImmediate(preset?.filter ?? "");
       setRepoFilter("");
     },
-    [savedPresets, setQueryImmediate, resolvedPrPresets, resolvedIssuePresets],
+    [savedPresets, setQueryImmediate, resolvedPrPresets, resolvedIssuePresets, setUserSelection],
   );
 
   const canSaveCurrent = customQuery.trim().length > 0 || repoFilter.length > 0;
   const suggestedLabel = customQuery.trim() || (repoFilter ? `In ${repoFilter}` : "Saved query");
-  const onOpenSaveDialog = () => {
-    if (canSaveCurrent) setSaveDialogOpen(true);
-  };
+  const onOpenSaveDialog = () => canSaveCurrent && setSaveDialogOpen(true);
   const onConfirmSave = (label: string) => {
     const created = saveSavedPreset({ kind: selection.kind, label, customQuery, repoFilter });
     setSelection({ kind: selection.kind, source: "saved", id: created.id });

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -227,7 +227,53 @@ function useInitialSidebarSelection(
     setSelection(next);
   }, []);
 
-  return { selection, setSelection, setUserSelection };
+  return { selection, setProgrammaticSelection: setSelection, setUserSelection };
+}
+
+function firstPresetSelection(
+  kind: SidebarSelection["kind"],
+  pr: PresetOption[],
+  issue: PresetOption[],
+) {
+  const preset = (kind === "pr" ? pr : issue)[0];
+  return {
+    selection: { kind, source: "preset", id: preset?.value ?? "" } as SidebarSelection,
+    filter: preset?.filter ?? "",
+  };
+}
+
+function useSidebarSelectionHandler({
+  savedPresets,
+  resolvedPrPresets,
+  resolvedIssuePresets,
+  setQueryImmediate,
+  setRepoFilter,
+  setUserSelection,
+}: {
+  savedPresets: SavedPreset[];
+  resolvedPrPresets: PresetOption[];
+  resolvedIssuePresets: PresetOption[];
+  setQueryImmediate: (query: string) => void;
+  setRepoFilter: (repo: string) => void;
+  setUserSelection: (next: SidebarSelection) => void;
+}) {
+  return useCallback(
+    (s: SidebarSelection) => {
+      setUserSelection(s);
+      if (s.source === "saved") {
+        const found = savedPresets.find((p) => p.id === s.id);
+        setQueryImmediate(found?.customQuery ?? "");
+        setRepoFilter(found?.repoFilter ?? "");
+        return;
+      }
+      const preset = (s.kind === "pr" ? resolvedPrPresets : resolvedIssuePresets).find(
+        (p) => p.value === s.id,
+      );
+      setQueryImmediate(preset?.filter ?? "");
+      setRepoFilter("");
+    },
+    [savedPresets, setQueryImmediate, resolvedPrPresets, resolvedIssuePresets, setUserSelection],
+  );
 }
 
 function useGitHubPageState(workspaceId: string | null) {
@@ -247,7 +293,7 @@ function useGitHubPageState(workspaceId: string | null) {
     save: saveSavedPreset,
     remove: removeSavedPreset,
   } = useSavedPresets(workspaceId);
-  const { selection, setSelection, setUserSelection } = useInitialSidebarSelection(
+  const { selection, setProgrammaticSelection, setUserSelection } = useInitialSidebarSelection(
     workspaceId,
     resolvedPrPresets,
     setQueryImmediate,
@@ -275,36 +321,33 @@ function useGitHubPageState(workspaceId: string | null) {
     [selection, savedPresets, resolvedPrPresets, resolvedIssuePresets],
   );
 
-  const onSelect = useCallback(
-    (s: SidebarSelection) => {
-      setUserSelection(s);
-      if (s.source === "saved") {
-        const found = savedPresets.find((p) => p.id === s.id);
-        setQueryImmediate(found?.customQuery ?? "");
-        setRepoFilter(found?.repoFilter ?? "");
-        return;
-      }
-      const presetList = s.kind === "pr" ? resolvedPrPresets : resolvedIssuePresets;
-      const preset = presetList.find((p) => p.value === s.id);
-      setQueryImmediate(preset?.filter ?? "");
-      setRepoFilter("");
-    },
-    [savedPresets, setQueryImmediate, resolvedPrPresets, resolvedIssuePresets, setUserSelection],
-  );
+  const onSelect = useSidebarSelectionHandler({
+    savedPresets,
+    resolvedPrPresets,
+    resolvedIssuePresets,
+    setQueryImmediate,
+    setRepoFilter,
+    setUserSelection,
+  });
 
   const canSaveCurrent = customQuery.trim().length > 0 || repoFilter.length > 0;
   const suggestedLabel = customQuery.trim() || (repoFilter ? `In ${repoFilter}` : "Saved query");
   const onOpenSaveDialog = () => canSaveCurrent && setSaveDialogOpen(true);
   const onConfirmSave = (label: string) => {
     const created = saveSavedPreset({ kind: selection.kind, label, customQuery, repoFilter });
-    setSelection({ kind: selection.kind, source: "saved", id: created.id });
+    if (!created) return;
+    setProgrammaticSelection({ kind: selection.kind, source: "saved", id: created.id });
   };
   const onDeleteSaved = (id: string) => {
     removeSavedPreset(id);
     if (selection.source === "saved" && selection.id === id) {
-      const fallbackPresets = selection.kind === "pr" ? resolvedPrPresets : resolvedIssuePresets;
-      setSelection({ kind: selection.kind, source: "preset", id: fallbackPresets[0]?.value ?? "" });
-      setQueryImmediate(fallbackPresets[0]?.filter ?? "");
+      const fallback = firstPresetSelection(
+        selection.kind,
+        resolvedPrPresets,
+        resolvedIssuePresets,
+      );
+      setProgrammaticSelection(fallback.selection);
+      setQueryImmediate(fallback.filter);
       setRepoFilter("");
     }
   };

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "@/components/routing/app-link";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import { IconBrandGithub, IconMenu2 } from "@tabler/icons-react";
 import { Alert, AlertDescription } from "@kandev/ui/alert";
 import { Button } from "@kandev/ui/button";
@@ -197,7 +197,13 @@ function useResolvedQueryPresets(workspaceId: string | null = null) {
   return { pr, issue };
 }
 
-function useInitialSidebarSelection(workspaceId: string | null, resolvedPrPresets: PresetOption[]) {
+function useInitialSidebarSelection(
+  workspaceId: string | null,
+  resolvedPrPresets: PresetOption[],
+  autoResetSearchRef: MutableRefObject<boolean>,
+  setQueryImmediate: (query: string) => void,
+  setRepoFilter: (repo: string) => void,
+) {
   const userSelectedRef = useRef(false);
   const [selection, setSelection] = useState<SidebarSelection>(() => ({
     kind: "pr",
@@ -207,13 +213,16 @@ function useInitialSidebarSelection(workspaceId: string | null, resolvedPrPreset
 
   useEffect(() => {
     userSelectedRef.current = false;
+    autoResetSearchRef.current = true;
   }, [workspaceId]);
 
   useEffect(() => {
-    if (userSelectedRef.current) return;
+    if (userSelectedRef.current || !autoResetSearchRef.current) return;
     const first = resolvedPrPresets[0];
     setSelection({ kind: "pr", source: "preset", id: first?.value ?? "" });
-  }, [workspaceId, resolvedPrPresets]);
+    setQueryImmediate(first?.filter ?? "");
+    setRepoFilter("");
+  }, [workspaceId, resolvedPrPresets, autoResetSearchRef, setQueryImmediate, setRepoFilter]);
 
   const setUserSelection = useCallback((next: SidebarSelection) => {
     userSelectedRef.current = true;
@@ -242,6 +251,7 @@ function useSidebarSelectionHandler({
   setQueryImmediate,
   setRepoFilter,
   setUserSelection,
+  markSearchInteracted,
 }: {
   savedPresets: SavedPreset[];
   resolvedPrPresets: PresetOption[];
@@ -249,9 +259,11 @@ function useSidebarSelectionHandler({
   setQueryImmediate: (query: string) => void;
   setRepoFilter: (repo: string) => void;
   setUserSelection: (next: SidebarSelection) => void;
+  markSearchInteracted: () => void;
 }) {
   return useCallback(
     (s: SidebarSelection) => {
+      markSearchInteracted();
       setUserSelection(s);
       if (s.source === "saved") {
         const found = savedPresets.find((p) => p.id === s.id);
@@ -265,8 +277,40 @@ function useSidebarSelectionHandler({
       setQueryImmediate(preset?.filter ?? "");
       setRepoFilter("");
     },
-    [savedPresets, setQueryImmediate, resolvedPrPresets, resolvedIssuePresets, setUserSelection],
+    [
+      savedPresets,
+      setQueryImmediate,
+      resolvedPrPresets,
+      resolvedIssuePresets,
+      setUserSelection,
+      markSearchInteracted,
+    ],
   );
+}
+
+function useSearchInteractionControls(
+  setCustomQueryRaw: (query: string) => void,
+  setRepoFilterRaw: (repo: string) => void,
+) {
+  const autoResetSearchRef = useRef(true);
+  const markSearchInteracted = useCallback(() => {
+    autoResetSearchRef.current = false;
+  }, []);
+  const setCustomQuery = useCallback(
+    (query: string) => {
+      markSearchInteracted();
+      setCustomQueryRaw(query);
+    },
+    [markSearchInteracted, setCustomQueryRaw],
+  );
+  const setRepoFilter = useCallback(
+    (repo: string) => {
+      markSearchInteracted();
+      setRepoFilterRaw(repo);
+    },
+    [markSearchInteracted, setRepoFilterRaw],
+  );
+  return { autoResetSearchRef, markSearchInteracted, setCustomQuery, setRepoFilter };
 }
 
 function useGitHubPageState(workspaceId: string | null) {
@@ -275,12 +319,14 @@ function useGitHubPageState(workspaceId: string | null) {
   const {
     draft: customQuery,
     committed: committedQuery,
-    setDraft: setCustomQuery,
+    setDraft: setCustomQueryRaw,
     setImmediate: setQueryImmediate,
     commit: commitCustomQuery,
   } = useCommittedQuery(resolvedPrPresets[0]?.filter ?? "");
-  const [repoFilter, setRepoFilter] = useState("");
+  const [repoFilter, setRepoFilterRaw] = useState("");
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const { autoResetSearchRef, markSearchInteracted, setCustomQuery, setRepoFilter } =
+    useSearchInteractionControls(setCustomQueryRaw, setRepoFilterRaw);
   const {
     presets: savedPresets,
     save: saveSavedPreset,
@@ -289,6 +335,9 @@ function useGitHubPageState(workspaceId: string | null) {
   const { selection, setProgrammaticSelection, setUserSelection } = useInitialSidebarSelection(
     workspaceId,
     resolvedPrPresets,
+    autoResetSearchRef,
+    setQueryImmediate,
+    setRepoFilterRaw,
   );
 
   const presets = selection.kind === "pr" ? resolvedPrPresets : resolvedIssuePresets;
@@ -317,8 +366,9 @@ function useGitHubPageState(workspaceId: string | null) {
     resolvedPrPresets,
     resolvedIssuePresets,
     setQueryImmediate,
-    setRepoFilter,
+    setRepoFilter: setRepoFilterRaw,
     setUserSelection,
+    markSearchInteracted,
   });
 
   const canSaveCurrent = customQuery.trim().length > 0 || repoFilter.length > 0;
@@ -339,7 +389,7 @@ function useGitHubPageState(workspaceId: string | null) {
       );
       setProgrammaticSelection(fallback.selection);
       setQueryImmediate(fallback.filter);
-      setRepoFilter("");
+      setRepoFilterRaw("");
     }
   };
 

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -189,15 +189,16 @@ function useRepoOptions(
   }, [knownRepos, repoFilter]);
 }
 
-function useResolvedQueryPresets() {
-  const { prPresets: storedPr, issuePresets: storedIssue } = useDefaultQueryPresets();
+function useResolvedQueryPresets(workspaceId: string | null = null) {
+  const { prPresets: storedPr, issuePresets: storedIssue } = useDefaultQueryPresets(workspaceId);
   const pr = useMemo(() => resolvePresetOptions(storedPr, PR_PRESETS), [storedPr]);
   const issue = useMemo(() => resolvePresetOptions(storedIssue, ISSUE_PRESETS), [storedIssue]);
   return { pr, issue };
 }
 
-function useGitHubPageState() {
-  const { pr: resolvedPrPresets, issue: resolvedIssuePresets } = useResolvedQueryPresets();
+function useGitHubPageState(workspaceId: string | null) {
+  const { pr: resolvedPrPresets, issue: resolvedIssuePresets } =
+    useResolvedQueryPresets(workspaceId);
 
   const [selection, setSelection] = useState<SidebarSelection>(() => ({
     kind: "pr",
@@ -217,16 +218,17 @@ function useGitHubPageState() {
     presets: savedPresets,
     save: saveSavedPreset,
     remove: removeSavedPreset,
-  } = useSavedPresets();
+  } = useSavedPresets(workspaceId);
 
   const presets = selection.kind === "pr" ? resolvedPrPresets : resolvedIssuePresets;
-  const search = useGitHubSearch<GitHubPR | GitHubIssue>(
-    selection.kind,
+  const search = useGitHubSearch<GitHubPR | GitHubIssue>({
+    kind: selection.kind,
     presets,
-    selection.source === "preset" ? selection.id : "",
-    committedQuery,
+    preset: selection.source === "preset" ? selection.id : "",
+    customQuery: committedQuery,
     repoFilter,
-  );
+    workspaceId,
+  });
   const repoOptions = useRepoOptions(selection, committedQuery, search.items, repoFilter);
   const title = useMemo(
     () => resolveTitle(selection, savedPresets, resolvedPrPresets, resolvedIssuePresets),
@@ -369,7 +371,7 @@ export function GitHubPageClient({
   const { status, loaded } = useGitHubStatus();
   const [launchPayload, setLaunchPayload] = useState<LaunchPayload | null>(null);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  const state = useGitHubPageState();
+  const state = useGitHubPageState(workspaceId ?? null);
   const { presets: storedPresets } = useGitHubActionPresets(workspaceId ?? null);
   const prPresets = useMemo(() => resolvePRPresets(storedPresets), [storedPresets]);
   const issuePresets = useMemo(() => resolveIssuePresets(storedPresets), [storedPresets]);

--- a/apps/web/app/github/github-page-client.tsx
+++ b/apps/web/app/github/github-page-client.tsx
@@ -197,12 +197,7 @@ function useResolvedQueryPresets(workspaceId: string | null = null) {
   return { pr, issue };
 }
 
-function useInitialSidebarSelection(
-  workspaceId: string | null,
-  resolvedPrPresets: PresetOption[],
-  setQueryImmediate: (query: string) => void,
-  setRepoFilter: (repo: string) => void,
-) {
+function useInitialSidebarSelection(workspaceId: string | null, resolvedPrPresets: PresetOption[]) {
   const userSelectedRef = useRef(false);
   const [selection, setSelection] = useState<SidebarSelection>(() => ({
     kind: "pr",
@@ -218,9 +213,7 @@ function useInitialSidebarSelection(
     if (userSelectedRef.current) return;
     const first = resolvedPrPresets[0];
     setSelection({ kind: "pr", source: "preset", id: first?.value ?? "" });
-    setQueryImmediate(first?.filter ?? "");
-    setRepoFilter("");
-  }, [workspaceId, resolvedPrPresets, setQueryImmediate, setRepoFilter]);
+  }, [workspaceId, resolvedPrPresets]);
 
   const setUserSelection = useCallback((next: SidebarSelection) => {
     userSelectedRef.current = true;
@@ -296,8 +289,6 @@ function useGitHubPageState(workspaceId: string | null) {
   const { selection, setProgrammaticSelection, setUserSelection } = useInitialSidebarSelection(
     workspaceId,
     resolvedPrPresets,
-    setQueryImmediate,
-    setRepoFilter,
   );
 
   const presets = selection.kind === "pr" ? resolvedPrPresets : resolvedIssuePresets;

--- a/apps/web/app/jira/jira-page-client.tsx
+++ b/apps/web/app/jira/jira-page-client.tsx
@@ -55,13 +55,16 @@ function NotConfiguredNotice() {
   );
 }
 
-async function loadUserProjects(): Promise<JiraProject[]> {
+async function loadUserProjects(workspaceId: string): Promise<JiraProject[]> {
   const [{ projects: all }, search] = await Promise.all([
-    listJiraProjects(),
-    searchJiraTickets({
-      jql: "(assignee = currentUser() OR reporter = currentUser()) ORDER BY updated DESC",
-      maxResults: 100,
-    }),
+    listJiraProjects({ workspaceId }),
+    searchJiraTickets(
+      {
+        jql: "(assignee = currentUser() OR reporter = currentUser()) ORDER BY updated DESC",
+        maxResults: 100,
+      },
+      { workspaceId },
+    ),
   ]);
   const userKeys = new Set(search.tickets.map((t) => t.projectKey));
   return (all ?? []).filter((p) => userKeys.has(p.key));
@@ -81,14 +84,14 @@ function useJiraPageData(workspaceId?: string) {
         return;
       }
       try {
-        const cfg = await getJiraConfig();
+        const cfg = await getJiraConfig({ workspaceId });
         if (cancelled) return;
         const ok = !!cfg && cfg.hasSecret;
         setConfigured(ok);
         setDefaultProjectKey(cfg?.defaultProjectKey ?? "");
         if (ok) {
           try {
-            const list = await loadUserProjects();
+            const list = await loadUserProjects(workspaceId);
             if (!cancelled) setProjects(list);
           } catch {
             // Non-fatal: pill will just show empty list. Users can still filter by other dims.

--- a/apps/web/app/jira/jira-page-client.tsx
+++ b/apps/web/app/jira/jira-page-client.tsx
@@ -180,6 +180,7 @@ function AuthenticatedView({
   const search = useJiraSearch(workspaceId ?? null, state.effectiveJql);
   const { options: statusOptions, loaded: statusesLoaded } = useProjectStatuses(
     state.filters.projectKeys,
+    workspaceId,
   );
 
   // When the available status union changes (project selection changed, or

--- a/apps/web/app/linear/linear-page-client.tsx
+++ b/apps/web/app/linear/linear-page-client.tsx
@@ -69,13 +69,13 @@ function useLinearPageData(workspaceId?: string) {
         return;
       }
       try {
-        const cfg = await getLinearConfig();
+        const cfg = await getLinearConfig({ workspaceId });
         if (cancelled) return;
         const ok = !!cfg && cfg.hasSecret;
         setConfigured(ok);
         if (ok) {
           try {
-            const list = await listLinearTeams();
+            const list = await listLinearTeams({ workspaceId });
             if (!cancelled) setTeams(list.teams ?? []);
           } catch {
             // Non-fatal: team filter just stays empty.
@@ -125,14 +125,17 @@ function useIssueSearch(
 
   const fetchPage = useCallback(
     (p: number) =>
-      searchLinearIssues({
-        query: query || undefined,
-        teamKey: teamKey || undefined,
-        assigned: assigned || undefined,
-        pageToken: tokensRef.current[p - 1] || undefined,
-        maxResults: PAGE_SIZE,
-      }),
-    [query, teamKey, assigned],
+      searchLinearIssues(
+        {
+          query: query || undefined,
+          teamKey: teamKey || undefined,
+          assigned: assigned || undefined,
+          pageToken: tokensRef.current[p - 1] || undefined,
+          maxResults: PAGE_SIZE,
+        },
+        { workspaceId },
+      ),
+    [workspaceId, query, teamKey, assigned],
   );
 
   const run = useCallback(
@@ -439,7 +442,7 @@ function ResultsArea({
 }
 
 export function LinearPageClient({ workspaceId, workflows, steps }: LinearPageClientProps) {
-  const available = useLinearAvailable();
+  const available = useLinearAvailable(workspaceId);
   const { loaded, configured, teams } = useLinearPageData(workspaceId);
 
   const [query, setQuery] = useState("");

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -188,6 +188,15 @@ describe("AppSidebarWorkspacePicker — workspace select", () => {
     expect(screen.getByTestId(OFFICE_WORKSPACE_ITEM).textContent).toContain("Office");
   });
 
+  it("renders the trigger as an obvious selector", () => {
+    render(<AppSidebarWorkspacePicker />);
+
+    const trigger = screen.getByTestId("sidebar-workspace-trigger");
+    expect(trigger).toHaveAttribute("aria-label", "Switch workspace");
+    expect(trigger.textContent).toContain("Default Workspace");
+    expect(screen.getByTestId("sidebar-workspace-trigger-chevron")).not.toBeNull();
+  });
+
   it("routes to the active kanban workspace home when office routing is enabled", () => {
     storeState.features.office = true;
     render(<AppSidebarWorkspacePicker />);

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.test.tsx
@@ -192,7 +192,7 @@ describe("AppSidebarWorkspacePicker — workspace select", () => {
     render(<AppSidebarWorkspacePicker />);
 
     const trigger = screen.getByTestId("sidebar-workspace-trigger");
-    expect(trigger).toHaveAttribute("aria-label", "Switch workspace");
+    expect(trigger.getAttribute("aria-label")).toBe("Switch workspace");
     expect(trigger.textContent).toContain("Default Workspace");
     expect(screen.getByTestId("sidebar-workspace-trigger-chevron")).not.toBeNull();
   });

--- a/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
+++ b/apps/web/components/app-sidebar/app-sidebar-workspace-picker.tsx
@@ -45,13 +45,16 @@ const WorkspaceTrigger = forwardRef<
       data-testid="sidebar-workspace-trigger"
       aria-label="Switch workspace"
       className={cn(
-        "group/ws flex min-w-0 flex-1 items-center gap-1 rounded-md px-1.5 py-1 text-sm font-medium text-muted-foreground hover:bg-muted/60 hover:text-foreground cursor-pointer transition-colors",
+        "group/ws flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-md border border-border/70 bg-background px-2.5 text-sm font-medium text-foreground shadow-sm cursor-pointer transition-colors hover:border-border hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         className,
       )}
       {...props}
     >
       <span className="min-w-0 flex-1 truncate text-left sidebar-fade-in">{activeName}</span>
-      <IconChevronDown className="h-3.5 w-3.5 shrink-0 opacity-50 transition-opacity group-hover/ws:opacity-80" />
+      <IconChevronDown
+        data-testid="sidebar-workspace-trigger-chevron"
+        className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-colors group-hover/ws:text-foreground/80"
+      />
     </button>
   );
 });

--- a/apps/web/components/github/default-queries-section.tsx
+++ b/apps/web/components/github/default-queries-section.tsx
@@ -127,9 +127,11 @@ function QueryEditor({
   );
 }
 
-export function DefaultQueriesSection() {
+export function DefaultQueriesSection({ workspaceId }: { workspaceId?: string }) {
   const { toast } = useToast();
-  const { prPresets, issuePresets, save, reset, isCustomized } = useDefaultQueryPresets();
+  const { prPresets, issuePresets, save, reset, isCustomized } = useDefaultQueryPresets(
+    workspaceId ?? null,
+  );
   const [prDraft, setPrDraft] = useState<StoredQueryPreset[]>(prPresets);
   const [issueDraft, setIssueDraft] = useState<StoredQueryPreset[]>(issuePresets);
 

--- a/apps/web/components/github/github-repo-scope-section.tsx
+++ b/apps/web/components/github/github-repo-scope-section.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@kandev/ui/button";
+import { Card, CardContent } from "@kandev/ui/card";
+import { Input } from "@kandev/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@kandev/ui/select";
+import { useToast } from "@/components/toast-provider";
+import { SettingsSection } from "@/components/settings/settings-section";
+import {
+  fetchGitHubWorkspaceSettings,
+  updateGitHubWorkspaceSettings,
+} from "@/lib/api/domains/github-api";
+import type { GitHubRepoScopeMode, RepoFilter } from "@/lib/types/github";
+
+function splitCSV(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseRepoFilters(value: string): RepoFilter[] {
+  return splitCSV(value)
+    .map((repo) => {
+      const [owner, name, ...rest] = repo.split("/");
+      if (!owner || !name || rest.length > 0) return null;
+      return { owner, name };
+    })
+    .filter((repo): repo is RepoFilter => repo !== null);
+}
+
+function repoFiltersToInput(repos: RepoFilter[]): string {
+  return repos.map((repo) => `${repo.owner}/${repo.name}`).join(", ");
+}
+
+type ScopeFieldsProps = {
+  mode: GitHubRepoScopeMode;
+  orgs: string;
+  repos: string;
+  loading: boolean;
+  invalidRepos: boolean;
+  onModeChange: (mode: GitHubRepoScopeMode) => void;
+  onOrgsChange: (orgs: string) => void;
+  onReposChange: (repos: string) => void;
+};
+
+function RepositoryScopeFields({
+  mode,
+  orgs,
+  repos,
+  loading,
+  invalidRepos,
+  onModeChange,
+  onOrgsChange,
+  onReposChange,
+}: ScopeFieldsProps) {
+  return (
+    <Card>
+      <CardContent className="grid gap-4 py-4 md:grid-cols-[220px_minmax(0,1fr)]">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium" htmlFor="github-scope-mode">
+            Mode
+          </label>
+          <Select
+            value={mode}
+            onValueChange={(value) => onModeChange(value as GitHubRepoScopeMode)}
+            disabled={loading}
+          >
+            <SelectTrigger id="github-scope-mode" data-testid="github-scope-mode">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All repositories</SelectItem>
+              <SelectItem value="orgs">Organizations</SelectItem>
+              <SelectItem value="repos">Selected repositories</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="grid gap-3">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium" htmlFor="github-scope-orgs">
+              Organizations
+            </label>
+            <Input
+              id="github-scope-orgs"
+              value={orgs}
+              onChange={(event) => onOrgsChange(event.target.value)}
+              disabled={loading || mode !== "orgs"}
+              placeholder="kdlbs, example-org"
+              data-testid="github-scope-orgs-input"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium" htmlFor="github-scope-repos">
+              Repositories
+            </label>
+            <Input
+              id="github-scope-repos"
+              value={repos}
+              onChange={(event) => onReposChange(event.target.value)}
+              disabled={loading || mode !== "repos"}
+              aria-invalid={invalidRepos}
+              placeholder="kdlbs/kandev, example/api"
+              data-testid="github-scope-repos-input"
+            />
+            {invalidRepos && (
+              <p className="text-xs text-destructive">Use comma-separated owner/repo values.</p>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function GitHubRepoScopeSection({ workspaceId }: { workspaceId: string }) {
+  const { toast } = useToast();
+  const [mode, setMode] = useState<GitHubRepoScopeMode>("all");
+  const [orgs, setOrgs] = useState("");
+  const [repos, setRepos] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const parsedRepos = useMemo(() => parseRepoFilters(repos), [repos]);
+  const invalidRepos = useMemo(() => {
+    const entries = splitCSV(repos);
+    return entries.length > 0 && parsedRepos.length !== entries.length;
+  }, [parsedRepos.length, repos]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    void fetchGitHubWorkspaceSettings(workspaceId)
+      .then((settings) => {
+        if (cancelled) return;
+        setMode(settings.repo_scope_mode ?? "all");
+        setOrgs((settings.repo_scope_orgs ?? []).join(", "));
+        setRepos(repoFiltersToInput(settings.repo_scope_repos ?? []));
+      })
+      .catch(() => {
+        if (!cancelled)
+          toast({ description: "Failed to load GitHub workspace settings", variant: "error" });
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [toast, workspaceId]);
+
+  const save = async () => {
+    if (invalidRepos) {
+      toast({ description: "Repository filters must use owner/repo format", variant: "error" });
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await updateGitHubWorkspaceSettings({
+        workspace_id: workspaceId,
+        repo_scope_mode: mode,
+        repo_scope_orgs: splitCSV(orgs),
+        repo_scope_repos: parsedRepos,
+      });
+      setMode(updated.repo_scope_mode);
+      setOrgs((updated.repo_scope_orgs ?? []).join(", "));
+      setRepos(repoFiltersToInput(updated.repo_scope_repos ?? []));
+      toast({ description: "GitHub workspace settings saved", variant: "success" });
+    } catch {
+      toast({ description: "Failed to save GitHub workspace settings", variant: "error" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      title="Repository Scope"
+      description="Choose which GitHub repositories belong to this workspace."
+      action={
+        <Button
+          size="sm"
+          onClick={save}
+          disabled={loading || saving}
+          data-testid="github-scope-save"
+          className="cursor-pointer"
+        >
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      }
+    >
+      <RepositoryScopeFields
+        mode={mode}
+        orgs={orgs}
+        repos={repos}
+        loading={loading}
+        invalidRepos={invalidRepos}
+        onModeChange={setMode}
+        onOrgsChange={setOrgs}
+        onReposChange={setRepos}
+      />
+    </SettingsSection>
+  );
+}

--- a/apps/web/components/github/github-settings.tsx
+++ b/apps/web/components/github/github-settings.tsx
@@ -188,8 +188,13 @@ function useIssueWatchActions(workspaceId?: string | null) {
 
   const handleTrigger = useCallback(
     async (id: string) => {
+      const watch = watches.find((item) => item.id === id);
+      if (!watch) {
+        toast({ description: "Issue watch not found", variant: "error" });
+        return;
+      }
       try {
-        const result = await trigger(id);
+        const result = await trigger(id, watch.workspace_id);
         const count = result?.new_issues_found ?? 0;
         if (count > 0) {
           toast({
@@ -203,7 +208,7 @@ function useIssueWatchActions(workspaceId?: string | null) {
         toast({ description: "Failed to check for issues", variant: "error" });
       }
     },
-    [trigger, toast],
+    [trigger, toast, watches],
   );
 
   const handleToggleEnabled = useCallback(

--- a/apps/web/components/github/github-settings.tsx
+++ b/apps/web/components/github/github-settings.tsx
@@ -15,6 +15,7 @@ import { IssueWatchTable } from "./issue-watch-table";
 import { IssueWatchDialog } from "./issue-watch-dialog";
 import { ActionPresetsSection } from "./action-presets-section";
 import { DefaultQueriesSection } from "./default-queries-section";
+import { GitHubRepoScopeSection } from "./github-repo-scope-section";
 import { PRStatsPanel } from "./pr-stats";
 import { useReviewWatches } from "@/hooks/domains/github/use-review-watches";
 import { useIssueWatches } from "@/hooks/domains/github/use-issue-watches";
@@ -276,16 +277,17 @@ export function GitHubConnectionSection() {
   );
 }
 
-// PerWorkspaceSection wraps the still-per-workspace surfaces (action presets,
-// PR analytics) under a workspace switcher. Watchers don't go in here — they
-// list flat across every workspace via their own sections.
 function PerWorkspaceSection({ workspaceId }: { workspaceId: string }) {
   return (
     <div className="space-y-8">
+      <GitHubRepoScopeSection workspaceId={workspaceId} />
+      <ReviewWatchSection workspaceId={workspaceId} />
+      <IssueWatchSection workspaceId={workspaceId} />
       <ActionPresetsSection workspaceId={workspaceId} />
       <SettingsSection title="PR Analytics" description="Pull request activity for this workspace.">
         <PRStatsPanel workspaceId={workspaceId} />
       </SettingsSection>
+      <DefaultQueriesSection workspaceId={workspaceId} />
     </div>
   );
 }
@@ -295,21 +297,15 @@ export function GitHubIntegrationPage() {
     <TooltipProvider>
       <div className="space-y-8">
         <GitHubConnectionSection />
-        <ReviewWatchSection />
-        <IssueWatchSection />
-        <WorkspaceScopedSection label="Presets and analytics for">
+        <WorkspaceScopedSection showSelector={false}>
           {(ws) => <PerWorkspaceSection key={ws} workspaceId={ws} />}
         </WorkspaceScopedSection>
-        <DefaultQueriesSection />
       </div>
     </TooltipProvider>
   );
 }
 
-// ReviewWatchSection lists every review watch across every workspace in a
-// single flat table. Pass `undefined` to the hook so it fetches all rows; the
-// dialog's create flow asks the user to pick the workspace.
-function ReviewWatchSection() {
+function ReviewWatchSection({ workspaceId }: { workspaceId: string }) {
   const {
     watches,
     create,
@@ -319,7 +315,7 @@ function ReviewWatchSection() {
     handleTrigger,
     handleReset,
     handleToggleEnabled,
-  } = useWatchActions(undefined);
+  } = useWatchActions(workspaceId);
   const { toast } = useToast();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingWatch, setEditingWatch] = useState<ReviewWatch | null>(null);
@@ -368,7 +364,6 @@ function ReviewWatchSection() {
           <CardContent className="p-0">
             <ReviewWatchTable
               watches={watches}
-              showWorkspace
               onEdit={handleEdit}
               onDelete={handleDelete}
               onTrigger={handleTrigger}
@@ -382,7 +377,7 @@ function ReviewWatchSection() {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         watch={editingWatch}
-        // No workspaceId — dialog shows a workspace picker for new watches.
+        workspaceId={workspaceId}
         onCreate={async (req) => {
           await create(req);
           toast({ description: "Review watch created", variant: "success" });
@@ -405,8 +400,8 @@ function ReviewWatchSection() {
   );
 }
 
-function IssueWatchSection() {
-  const issueActions = useIssueWatchActions(undefined);
+function IssueWatchSection({ workspaceId }: { workspaceId: string }) {
+  const issueActions = useIssueWatchActions(workspaceId);
   const { toast } = useToast();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingWatch, setEditingIssueWatch] = useState<IssueWatch | null>(null);
@@ -455,7 +450,6 @@ function IssueWatchSection() {
           <CardContent className="p-0">
             <IssueWatchTable
               watches={issueActions.watches}
-              showWorkspace
               onEdit={handleEdit}
               onDelete={issueActions.handleDelete}
               onTrigger={issueActions.handleTrigger}
@@ -469,6 +463,7 @@ function IssueWatchSection() {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         watch={editingWatch}
+        workspaceId={workspaceId}
         onCreate={async (req) => {
           await issueActions.create(req);
           toast({ description: "Issue watch created", variant: "success" });

--- a/apps/web/components/github/github-settings.tsx
+++ b/apps/web/components/github/github-settings.tsx
@@ -81,14 +81,19 @@ function useWatchActions(workspaceId?: string | null) {
 
   const handleDelete = useCallback(
     async (id: string) => {
+      const watch = watches.find((item) => item.id === id);
+      if (!watch) {
+        toast({ description: "Review watch not found", variant: "error" });
+        return;
+      }
       try {
-        await remove(id);
+        await remove(id, watch.workspace_id);
         toast({ description: "Review watch deleted", variant: "success" });
       } catch {
         toast({ description: "Failed to delete review watch", variant: "error" });
       }
     },
-    [remove, toast],
+    [remove, toast, watches],
   );
 
   const handleTrigger = useCallback(
@@ -119,7 +124,7 @@ function useWatchActions(workspaceId?: string | null) {
   const handleToggleEnabled = useCallback(
     async (watch: ReviewWatch) => {
       try {
-        await update(watch.id, { enabled: !watch.enabled });
+        await update(watch.id, watch.workspace_id, { enabled: !watch.enabled });
         toast({
           description: watch.enabled ? "Watch paused" : "Watch enabled",
           variant: "success",
@@ -176,14 +181,19 @@ function useIssueWatchActions(workspaceId?: string | null) {
 
   const handleDelete = useCallback(
     async (id: string) => {
+      const watch = watches.find((item) => item.id === id);
+      if (!watch) {
+        toast({ description: "Issue watch not found", variant: "error" });
+        return;
+      }
       try {
-        await remove(id);
+        await remove(id, watch.workspace_id);
         toast({ description: "Issue watch deleted", variant: "success" });
       } catch {
         toast({ description: "Failed to delete issue watch", variant: "error" });
       }
     },
-    [remove, toast],
+    [remove, toast, watches],
   );
 
   const handleTrigger = useCallback(
@@ -214,7 +224,7 @@ function useIssueWatchActions(workspaceId?: string | null) {
   const handleToggleEnabled = useCallback(
     async (watch: IssueWatch) => {
       try {
-        await update(watch.id, { enabled: !watch.enabled });
+        await update(watch.id, watch.workspace_id, { enabled: !watch.enabled });
         toast({
           description: watch.enabled ? "Watch paused" : "Watch enabled",
           variant: "success",
@@ -350,7 +360,10 @@ function ReviewWatchSection({ workspaceId }: { workspaceId: string }) {
         description="Automatically create tasks for PRs that need your review."
         action={
           <div className="flex items-center gap-2">
-            <CleanupNowButton label="Clean up merged" run={cleanupMergedReviewTasks} />
+            <CleanupNowButton
+              label="Clean up merged"
+              run={() => cleanupMergedReviewTasks(workspaceId)}
+            />
             <Button
               size="sm"
               onClick={() => {
@@ -388,7 +401,9 @@ function ReviewWatchSection({ workspaceId }: { workspaceId: string }) {
           toast({ description: "Review watch created", variant: "success" });
         }}
         onUpdate={async (id, req) => {
-          await update(id, req);
+          const watch = watches.find((item) => item.id === id);
+          if (!watch) throw new Error("review watch not found");
+          await update(id, watch.workspace_id, req);
           toast({ description: "Review watch updated", variant: "success" });
         }}
       />
@@ -436,7 +451,10 @@ function IssueWatchSection({ workspaceId }: { workspaceId: string }) {
         description="Automatically create tasks for GitHub issues matching your criteria."
         action={
           <div className="flex items-center gap-2">
-            <CleanupNowButton label="Clean up closed" run={cleanupClosedIssueTasks} />
+            <CleanupNowButton
+              label="Clean up closed"
+              run={() => cleanupClosedIssueTasks(workspaceId)}
+            />
             <Button
               size="sm"
               onClick={() => {
@@ -474,7 +492,9 @@ function IssueWatchSection({ workspaceId }: { workspaceId: string }) {
           toast({ description: "Issue watch created", variant: "success" });
         }}
         onUpdate={async (id, req) => {
-          await issueActions.update(id, req);
+          const watch = issueActions.watches.find((item) => item.id === id);
+          if (!watch) throw new Error("issue watch not found");
+          await issueActions.update(id, watch.workspace_id, req);
           toast({ description: "Issue watch updated", variant: "success" });
         }}
       />

--- a/apps/web/components/github/issue-watch-dialog.tsx
+++ b/apps/web/components/github/issue-watch-dialog.tsx
@@ -237,6 +237,7 @@ function IssueFilterFields({
         selectedRepos={form.selectedRepos}
         onAllReposChange={onAllReposChange}
         onSelectedReposChange={onSelectedReposChange}
+        workspaceId={form.workspaceId}
       />
       <div className="space-y-1.5">
         <Label>Labels (comma-separated)</Label>

--- a/apps/web/components/github/my-github/use-default-query-presets.test.ts
+++ b/apps/web/components/github/my-github/use-default-query-presets.test.ts
@@ -189,4 +189,18 @@ describe("useDefaultQueryPresets workspace sync", () => {
 
     expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
   });
+
+  it("does not save or reset after workspace defaults fail to load", async () => {
+    vi.mocked(fetchGitHubWorkspaceSettings).mockRejectedValue(new Error("settings down"));
+    const { result } = renderHook(() => useDefaultQueryPresets(WORKSPACE_ID));
+
+    await waitFor(() => expect(fetchGitHubWorkspaceSettings).toHaveBeenCalled());
+
+    act(() => {
+      result.current.save({ pr: [preset], issue: [] });
+      result.current.reset();
+    });
+
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/components/github/my-github/use-default-query-presets.test.ts
+++ b/apps/web/components/github/my-github/use-default-query-presets.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { fetchUserSettings, updateUserSettings } from "@/lib/api/domains/settings-api";
+import {
+  fetchGitHubWorkspaceSettings,
+  updateGitHubWorkspaceSettings,
+} from "@/lib/api/domains/github-api";
 import {
   __resetSnapshotForTests,
   useDefaultQueryPresets,
@@ -9,10 +13,17 @@ import {
 
 const STORAGE_KEY = "kandev:github-default-queries:v1";
 const SYNC_FAILED_KEY = "kandev:github-default-queries:sync-failed:v1";
+const WORKSPACE_ID = "ws-1";
+const SETTINGS_TIMESTAMP = "2026-01-01T00:00:00Z";
 
 vi.mock("@/lib/api/domains/settings-api", () => ({
   fetchUserSettings: vi.fn(),
   updateUserSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/api/domains/github-api", () => ({
+  fetchGitHubWorkspaceSettings: vi.fn(),
+  updateGitHubWorkspaceSettings: vi.fn(),
 }));
 
 function makeLocalStorageMock() {
@@ -31,6 +42,7 @@ function makeLocalStorageMock() {
 
 const localStorageMock = makeLocalStorageMock();
 vi.stubGlobal("localStorage", localStorageMock);
+Object.defineProperty(window, "localStorage", { value: localStorageMock, configurable: true });
 
 const preset: StoredQueryPreset = {
   value: "mine",
@@ -39,18 +51,39 @@ const preset: StoredQueryPreset = {
   group: "created",
 };
 
-describe("useDefaultQueryPresets", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    localStorageMock.clear();
-    __resetSnapshotForTests();
-    vi.mocked(fetchUserSettings).mockResolvedValue({
-      settings: { github_default_query_presets: null },
-    } as Awaited<ReturnType<typeof fetchUserSettings>>);
-    vi.mocked(updateUserSettings).mockResolvedValue({
-      settings: {},
-    } as Awaited<ReturnType<typeof updateUserSettings>>);
-  });
+function workspaceSettings(
+  defaultQueryPresets: unknown = null,
+): Awaited<ReturnType<typeof fetchGitHubWorkspaceSettings>> {
+  return {
+    workspace_id: WORKSPACE_ID,
+    repo_scope_mode: "all",
+    repo_scope_orgs: [],
+    repo_scope_repos: [],
+    saved_presets: [],
+    default_query_presets: defaultQueryPresets,
+    created_at: SETTINGS_TIMESTAMP,
+    updated_at: SETTINGS_TIMESTAMP,
+  } as Awaited<ReturnType<typeof fetchGitHubWorkspaceSettings>>;
+}
+
+function resetMocks() {
+  vi.clearAllMocks();
+  localStorageMock.clear();
+  __resetSnapshotForTests();
+  vi.mocked(fetchUserSettings).mockResolvedValue({
+    settings: { github_default_query_presets: null },
+  } as Awaited<ReturnType<typeof fetchUserSettings>>);
+  vi.mocked(updateUserSettings).mockResolvedValue({
+    settings: {},
+  } as Awaited<ReturnType<typeof updateUserSettings>>);
+  vi.mocked(fetchGitHubWorkspaceSettings).mockResolvedValue(workspaceSettings());
+  vi.mocked(updateGitHubWorkspaceSettings).mockResolvedValue(
+    {} as Awaited<ReturnType<typeof updateGitHubWorkspaceSettings>>,
+  );
+}
+
+describe("useDefaultQueryPresets legacy sync", () => {
+  beforeEach(resetMocks);
 
   it("retries local defaults after a failed backend sync and clears the marker", async () => {
     const local = { pr: [preset], issue: [] };
@@ -113,5 +146,47 @@ describe("useDefaultQueryPresets", () => {
 
     expect(localStorageMock.getItem(STORAGE_KEY)).toBe(JSON.stringify(crossTab));
     expect(updateUserSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDefaultQueryPresets workspace sync", () => {
+  beforeEach(resetMocks);
+
+  it("migrates local defaults into a fresh workspace", async () => {
+    const local = { pr: [preset], issue: [] };
+    localStorageMock.setItem(STORAGE_KEY, JSON.stringify(local));
+    __resetSnapshotForTests();
+
+    const { result } = renderHook(() => useDefaultQueryPresets(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.prPresets[0]?.value).toBe("mine"));
+    expect(updateGitHubWorkspaceSettings).toHaveBeenCalledWith({
+      workspace_id: WORKSPACE_ID,
+      default_query_presets: local,
+    });
+  });
+
+  it("does not migrate local defaults over existing workspace defaults", async () => {
+    const server = { pr: [{ ...preset, value: "server", label: "Server" }], issue: [] };
+    localStorageMock.setItem(STORAGE_KEY, JSON.stringify({ pr: [preset], issue: [] }));
+    __resetSnapshotForTests();
+    vi.mocked(fetchGitHubWorkspaceSettings).mockResolvedValue(workspaceSettings(server));
+
+    const { result } = renderHook(() => useDefaultQueryPresets(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.prPresets[0]?.value).toBe("server"));
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
+  });
+
+  it("does not save or reset while workspace defaults are still loading", () => {
+    vi.mocked(fetchGitHubWorkspaceSettings).mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useDefaultQueryPresets(WORKSPACE_ID));
+
+    act(() => {
+      result.current.save({ pr: [preset], issue: [] });
+      result.current.reset();
+    });
+
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/github/my-github/use-default-query-presets.ts
+++ b/apps/web/components/github/my-github/use-default-query-presets.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import {
   PR_PRESETS as BUILTIN_PR_PRESETS,
   ISSUE_PRESETS as BUILTIN_ISSUE_PRESETS,
@@ -89,6 +89,16 @@ function readServerDefaults(value: unknown): StoredDefaults | null | undefined {
   return value as StoredDefaults;
 }
 
+async function readLegacyServerDefaults(): Promise<StoredDefaults | null> {
+  try {
+    const response = await fetchUserSettings({ cache: "no-store" });
+    const defaults = readServerDefaults(response.settings.github_default_query_presets);
+    return defaults === undefined ? null : defaults;
+  } catch {
+    return null;
+  }
+}
+
 const syncServer = createQueuedUserSettingsSync<StoredDefaults | null>(
   SYNC_FAILED_KEY,
   (defaults) => ({
@@ -156,8 +166,9 @@ export function __resetSnapshotForTests() {
   listeners.forEach((fn) => fn());
 }
 
-function useLegacyDefaultQueryPresetSync() {
+function useLegacyDefaultQueryPresetSync(enabled: boolean) {
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
     const initialKey = snapshotKey(getSnapshot());
     fetchUserSettings({ cache: "no-store" })
@@ -182,28 +193,38 @@ function useLegacyDefaultQueryPresetSync() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [enabled]);
 }
 
 function useWorkspaceDefaultQueryPresets(workspaceId: string | null) {
   const [workspaceDefaults, setWorkspaceDefaults] = useState<StoredDefaults | null | undefined>(
     undefined,
   );
+  const writeSeq = useRef(0);
   useEffect(() => {
     if (!workspaceId) {
       setWorkspaceDefaults(undefined);
       return;
     }
     let cancelled = false;
+    const seq = writeSeq.current;
     setWorkspaceDefaults(undefined);
     fetchGitHubWorkspaceSettings(workspaceId)
-      .then((settings) => {
-        if (cancelled) return;
+      .then(async (settings) => {
+        if (cancelled || seq !== writeSeq.current) return;
         const defaults = readServerDefaults(settings.default_query_presets);
-        const local = getSnapshot();
-        if (defaults === null && local !== null && !hasMigratedToWorkspace(workspaceId)) {
+        let local = getSnapshot();
+        if (local === null) {
+          local = await readLegacyServerDefaults();
+        }
+        if (cancelled || seq !== writeSeq.current) return;
+        if (
+          (defaults === null || defaults === undefined) &&
+          local !== null &&
+          !hasMigratedToWorkspace(workspaceId)
+        ) {
           setWorkspaceDefaults(local);
-          void updateGitHubWorkspaceSettings({
+          await updateGitHubWorkspaceSettings({
             workspace_id: workspaceId,
             default_query_presets: local,
           });
@@ -220,13 +241,17 @@ function useWorkspaceDefaultQueryPresets(workspaceId: string | null) {
       cancelled = true;
     };
   }, [workspaceId]);
-  return { workspaceDefaults, setWorkspaceDefaults };
+  const setWorkspaceDefaultsFromLocal = useCallback((next: StoredDefaults | null) => {
+    writeSeq.current += 1;
+    setWorkspaceDefaults(next);
+  }, []);
+  return { workspaceDefaults, setWorkspaceDefaults: setWorkspaceDefaultsFromLocal };
 }
 
 export function useDefaultQueryPresets(workspaceId: string | null = null) {
   const stored = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const { workspaceDefaults, setWorkspaceDefaults } = useWorkspaceDefaultQueryPresets(workspaceId);
-  useLegacyDefaultQueryPresetSync();
+  useLegacyDefaultQueryPresetSync(!workspaceId);
   const effectiveStored = workspaceId ? workspaceDefaults : stored;
   const prPresets = useMemo(
     () => effectiveStored?.pr ?? toStored(BUILTIN_PR_PRESETS),
@@ -244,8 +269,7 @@ export function useDefaultQueryPresets(workspaceId: string | null = null) {
         void updateGitHubWorkspaceSettings({
           workspace_id: workspaceId,
           default_query_presets: defaults,
-        });
-        markMigratedToWorkspace(workspaceId);
+        }).then(() => markMigratedToWorkspace(workspaceId));
         return;
       }
       publish(defaults);
@@ -261,8 +285,7 @@ export function useDefaultQueryPresets(workspaceId: string | null = null) {
       void updateGitHubWorkspaceSettings({
         workspace_id: workspaceId,
         default_query_presets: null,
-      });
-      markMigratedToWorkspace(workspaceId);
+      }).then(() => markMigratedToWorkspace(workspaceId));
       return;
     }
     publish(null);

--- a/apps/web/components/github/my-github/use-default-query-presets.ts
+++ b/apps/web/components/github/my-github/use-default-query-presets.ts
@@ -253,7 +253,7 @@ function useWorkspaceDefaultQueryPresets(workspaceId: string | null) {
         }
       })
       .catch(() => {
-        if (!cancelled) setWorkspaceDefaults(null);
+        if (!cancelled) setWorkspaceDefaults(undefined);
       });
     return () => {
       cancelled = true;

--- a/apps/web/components/github/my-github/use-default-query-presets.ts
+++ b/apps/web/components/github/my-github/use-default-query-presets.ts
@@ -1,17 +1,22 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import {
   PR_PRESETS as BUILTIN_PR_PRESETS,
   ISSUE_PRESETS as BUILTIN_ISSUE_PRESETS,
   type PresetOption,
 } from "./search-bar";
 import { fetchUserSettings } from "@/lib/api/domains/settings-api";
+import {
+  fetchGitHubWorkspaceSettings,
+  updateGitHubWorkspaceSettings,
+} from "@/lib/api/domains/github-api";
 import { createQueuedUserSettingsSync } from "@/lib/user-settings-sync";
 import { hasUserSettingsSyncFailure } from "@/lib/user-settings-sync-failure";
 
 const STORAGE_KEY = "kandev:github-default-queries:v1";
 const MIGRATED_KEY = "kandev:github-default-queries:migrated-to-backend:v1";
+const WORKSPACE_MIGRATED_KEY_PREFIX = "kandev:github-default-queries:migrated-to-workspace:v1:";
 const SYNC_FAILED_KEY = "kandev:github-default-queries:sync-failed:v1";
 
 export type StoredQueryPreset = {
@@ -109,6 +114,20 @@ function markMigratedToBackend(): void {
   }
 }
 
+function hasMigratedToWorkspace(workspaceId: string): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(WORKSPACE_MIGRATED_KEY_PREFIX + workspaceId) === "1";
+}
+
+function markMigratedToWorkspace(workspaceId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WORKSPACE_MIGRATED_KEY_PREFIX + workspaceId, "1");
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
 function subscribe(cb: () => void) {
   listeners.add(cb);
   const onStorage = (event: StorageEvent) => {
@@ -137,9 +156,7 @@ export function __resetSnapshotForTests() {
   listeners.forEach((fn) => fn());
 }
 
-export function useDefaultQueryPresets() {
-  const stored = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-
+function useLegacyDefaultQueryPresetSync() {
   useEffect(() => {
     let cancelled = false;
     const initialKey = snapshotKey(getSnapshot());
@@ -166,23 +183,94 @@ export function useDefaultQueryPresets() {
       cancelled = true;
     };
   }, []);
+}
 
-  const prPresets = useMemo(() => stored?.pr ?? toStored(BUILTIN_PR_PRESETS), [stored]);
-  const issuePresets = useMemo(() => stored?.issue ?? toStored(BUILTIN_ISSUE_PRESETS), [stored]);
+function useWorkspaceDefaultQueryPresets(workspaceId: string | null) {
+  const [workspaceDefaults, setWorkspaceDefaults] = useState<StoredDefaults | null | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    if (!workspaceId) {
+      setWorkspaceDefaults(undefined);
+      return;
+    }
+    let cancelled = false;
+    setWorkspaceDefaults(undefined);
+    fetchGitHubWorkspaceSettings(workspaceId)
+      .then((settings) => {
+        if (cancelled) return;
+        const defaults = readServerDefaults(settings.default_query_presets);
+        const local = getSnapshot();
+        if (defaults === null && local !== null && !hasMigratedToWorkspace(workspaceId)) {
+          setWorkspaceDefaults(local);
+          void updateGitHubWorkspaceSettings({
+            workspace_id: workspaceId,
+            default_query_presets: local,
+          });
+          markMigratedToWorkspace(workspaceId);
+          return;
+        }
+        setWorkspaceDefaults(defaults === undefined ? null : defaults);
+        markMigratedToWorkspace(workspaceId);
+      })
+      .catch(() => {
+        if (!cancelled) setWorkspaceDefaults(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+  return { workspaceDefaults, setWorkspaceDefaults };
+}
 
-  const save = useCallback((defaults: StoredDefaults) => {
-    publish(defaults);
-    void syncServer(defaults);
-    markMigratedToBackend();
-  }, []);
+export function useDefaultQueryPresets(workspaceId: string | null = null) {
+  const stored = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const { workspaceDefaults, setWorkspaceDefaults } = useWorkspaceDefaultQueryPresets(workspaceId);
+  useLegacyDefaultQueryPresetSync();
+  const effectiveStored = workspaceId ? workspaceDefaults : stored;
+  const prPresets = useMemo(
+    () => effectiveStored?.pr ?? toStored(BUILTIN_PR_PRESETS),
+    [effectiveStored],
+  );
+  const issuePresets = useMemo(
+    () => effectiveStored?.issue ?? toStored(BUILTIN_ISSUE_PRESETS),
+    [effectiveStored],
+  );
+
+  const save = useCallback(
+    (defaults: StoredDefaults) => {
+      if (workspaceId) {
+        setWorkspaceDefaults(defaults);
+        void updateGitHubWorkspaceSettings({
+          workspace_id: workspaceId,
+          default_query_presets: defaults,
+        });
+        markMigratedToWorkspace(workspaceId);
+        return;
+      }
+      publish(defaults);
+      void syncServer(defaults);
+      markMigratedToBackend();
+    },
+    [workspaceId],
+  );
 
   const reset = useCallback(() => {
+    if (workspaceId) {
+      setWorkspaceDefaults(null);
+      void updateGitHubWorkspaceSettings({
+        workspace_id: workspaceId,
+        default_query_presets: null,
+      });
+      markMigratedToWorkspace(workspaceId);
+      return;
+    }
     publish(null);
     void syncServer(null);
     markMigratedToBackend();
-  }, []);
+  }, [workspaceId]);
 
-  const isCustomized = stored !== null;
+  const isCustomized = effectiveStored !== null && effectiveStored !== undefined;
 
   return { prPresets, issuePresets, save, reset, isCustomized };
 }

--- a/apps/web/components/github/my-github/use-default-query-presets.ts
+++ b/apps/web/components/github/my-github/use-default-query-presets.ts
@@ -89,13 +89,13 @@ function readServerDefaults(value: unknown): StoredDefaults | null | undefined {
   return value as StoredDefaults;
 }
 
-async function readLegacyServerDefaults(): Promise<StoredDefaults | null> {
+async function readLegacyServerDefaults(): Promise<StoredDefaults | null | undefined> {
   try {
     const response = await fetchUserSettings({ cache: "no-store" });
     const defaults = readServerDefaults(response.settings.github_default_query_presets);
     return defaults === undefined ? null : defaults;
   } catch {
-    return null;
+    return undefined;
   }
 }
 
@@ -105,6 +105,23 @@ const syncServer = createQueuedUserSettingsSync<StoredDefaults | null>(
     github_default_query_presets: defaults,
   }),
 );
+
+let workspaceSyncQueue = Promise.resolve();
+
+function syncWorkspaceDefaultQueryPresets(
+  workspaceId: string,
+  defaults: StoredDefaults | null,
+): Promise<void> {
+  workspaceSyncQueue = workspaceSyncQueue
+    .catch(() => undefined)
+    .then(() =>
+      updateGitHubWorkspaceSettings({
+        workspace_id: workspaceId,
+        default_query_presets: defaults,
+      }).then(() => undefined),
+    );
+  return workspaceSyncQueue;
+}
 
 function snapshotKey(value: StoredDefaults | null): string {
   return JSON.stringify(value);
@@ -213,26 +230,27 @@ function useWorkspaceDefaultQueryPresets(workspaceId: string | null) {
       .then(async (settings) => {
         if (cancelled || seq !== writeSeq.current) return;
         const defaults = readServerDefaults(settings.default_query_presets);
-        let local = getSnapshot();
+        let local: StoredDefaults | null | undefined = getSnapshot();
         if (local === null) {
           local = await readLegacyServerDefaults();
         }
         if (cancelled || seq !== writeSeq.current) return;
         if (
           (defaults === null || defaults === undefined) &&
+          local !== undefined &&
           local !== null &&
           !hasMigratedToWorkspace(workspaceId)
         ) {
           setWorkspaceDefaults(local);
-          await updateGitHubWorkspaceSettings({
-            workspace_id: workspaceId,
-            default_query_presets: local,
-          });
-          markMigratedToWorkspace(workspaceId);
+          void syncWorkspaceDefaultQueryPresets(workspaceId, local)
+            .then(() => markMigratedToWorkspace(workspaceId))
+            .catch(() => {});
           return;
         }
         setWorkspaceDefaults(defaults === undefined ? null : defaults);
-        markMigratedToWorkspace(workspaceId);
+        if (!(local === undefined && (defaults === null || defaults === undefined))) {
+          markMigratedToWorkspace(workspaceId);
+        }
       })
       .catch(() => {
         if (!cancelled) setWorkspaceDefaults(null);
@@ -264,34 +282,34 @@ export function useDefaultQueryPresets(workspaceId: string | null = null) {
 
   const save = useCallback(
     (defaults: StoredDefaults) => {
+      if (workspaceId && workspaceDefaults === undefined) return;
       if (workspaceId) {
         setWorkspaceDefaults(defaults);
-        void updateGitHubWorkspaceSettings({
-          workspace_id: workspaceId,
-          default_query_presets: defaults,
-        }).then(() => markMigratedToWorkspace(workspaceId));
+        void syncWorkspaceDefaultQueryPresets(workspaceId, defaults)
+          .then(() => markMigratedToWorkspace(workspaceId))
+          .catch(() => {});
         return;
       }
       publish(defaults);
       void syncServer(defaults);
       markMigratedToBackend();
     },
-    [workspaceId],
+    [workspaceId, workspaceDefaults, setWorkspaceDefaults],
   );
 
   const reset = useCallback(() => {
+    if (workspaceId && workspaceDefaults === undefined) return;
     if (workspaceId) {
       setWorkspaceDefaults(null);
-      void updateGitHubWorkspaceSettings({
-        workspace_id: workspaceId,
-        default_query_presets: null,
-      }).then(() => markMigratedToWorkspace(workspaceId));
+      void syncWorkspaceDefaultQueryPresets(workspaceId, null)
+        .then(() => markMigratedToWorkspace(workspaceId))
+        .catch(() => {});
       return;
     }
     publish(null);
     void syncServer(null);
     markMigratedToBackend();
-  }, [workspaceId]);
+  }, [workspaceId, workspaceDefaults, setWorkspaceDefaults]);
 
   const isCustomized = effectiveStored !== null && effectiveStored !== undefined;
 

--- a/apps/web/components/github/my-github/use-github-search.ts
+++ b/apps/web/components/github/my-github/use-github-search.ts
@@ -22,6 +22,16 @@ type FetchArgs = {
   customQuery: string;
   repoFilter: string;
   page: number;
+  workspaceId: string | null;
+};
+
+type UseGitHubSearchOptions = {
+  kind: SearchKind;
+  presets: PresetOption[];
+  preset: string;
+  customQuery: string;
+  repoFilter?: string;
+  workspaceId?: string | null;
 };
 
 export function buildParams(
@@ -40,13 +50,14 @@ export function buildParams(
   return { filter };
 }
 
-export function useGitHubSearch<T extends GitHubPR | GitHubIssue>(
-  kind: SearchKind,
-  presets: PresetOption[],
-  preset: string,
-  customQuery: string,
-  repoFilter: string = "",
-) {
+export function useGitHubSearch<T extends GitHubPR | GitHubIssue>({
+  kind,
+  presets,
+  preset,
+  customQuery,
+  repoFilter = "",
+  workspaceId = null,
+}: UseGitHubSearchOptions) {
   const [state, setState] = useState<SearchState<T>>({
     items: [],
     loading: false,
@@ -63,15 +74,21 @@ export function useGitHubSearch<T extends GitHubPR | GitHubIssue>(
   // Reset to page 1 whenever the filter inputs change.
   useEffect(() => {
     setPage(1);
-  }, [preset, customQuery, repoFilter, kind]);
+  }, [preset, customQuery, repoFilter, workspaceId, kind]);
 
   const fetchData = useCallback(
-    async ({ preset: ep, customQuery: ec, repoFilter: er, page: epage }: FetchArgs) => {
+    async ({
+      preset: ep,
+      customQuery: ec,
+      repoFilter: er,
+      page: epage,
+      workspaceId: ews,
+    }: FetchArgs) => {
       const seq = ++requestSeq.current;
       setState((s) => ({ ...s, loading: true, error: null }));
       try {
         const base = buildParams(presets, ep, ec, er);
-        const params = { ...base, page: epage, perPage: SEARCH_PAGE_SIZE };
+        const params = { ...base, page: epage, perPage: SEARCH_PAGE_SIZE, workspaceId: ews };
         const response =
           kind === "pr" ? await searchUserPRs(params) : await searchUserIssues(params);
         if (seq !== requestSeq.current) return;
@@ -100,12 +117,12 @@ export function useGitHubSearch<T extends GitHubPR | GitHubIssue>(
   );
 
   useEffect(() => {
-    void fetchData({ preset, customQuery, repoFilter, page });
-  }, [fetchData, preset, customQuery, repoFilter, page]);
+    void fetchData({ preset, customQuery, repoFilter, page, workspaceId });
+  }, [fetchData, preset, customQuery, repoFilter, page, workspaceId]);
 
   const refresh = useCallback(
-    () => fetchData({ preset, customQuery, repoFilter, page }),
-    [fetchData, preset, customQuery, repoFilter, page],
+    () => fetchData({ preset, customQuery, repoFilter, page, workspaceId }),
+    [fetchData, preset, customQuery, repoFilter, page, workspaceId],
   );
 
   return { ...state, page, setPage, pageSize: SEARCH_PAGE_SIZE, refresh };

--- a/apps/web/components/github/my-github/use-github-search.ts
+++ b/apps/web/components/github/my-github/use-github-search.ts
@@ -70,6 +70,11 @@ export function useGitHubSearch<T extends GitHubPR | GitHubIssue>({
   // a slow page-N request can't overwrite a fresher page-1 result after a
   // filter change.
   const requestSeq = useRef(0);
+  const workspaceRef = useRef(workspaceId);
+
+  useEffect(() => {
+    workspaceRef.current = workspaceId;
+  }, [workspaceId]);
 
   // Reset to page 1 whenever the filter inputs change.
   useEffect(() => {
@@ -91,7 +96,7 @@ export function useGitHubSearch<T extends GitHubPR | GitHubIssue>({
         const params = { ...base, page: epage, perPage: SEARCH_PAGE_SIZE, workspaceId: ews };
         const response =
           kind === "pr" ? await searchUserPRs(params) : await searchUserIssues(params);
-        if (seq !== requestSeq.current) return;
+        if (seq !== requestSeq.current || ews !== workspaceRef.current) return;
         const items = (kind === "pr"
           ? (response as { prs: GitHubPR[] }).prs
           : (response as { issues: GitHubIssue[] }).issues) as unknown as T[];
@@ -103,7 +108,7 @@ export function useGitHubSearch<T extends GitHubPR | GitHubIssue>({
           total: response.total_count ?? (items ?? []).length,
         });
       } catch (err) {
-        if (seq !== requestSeq.current) return;
+        if (seq !== requestSeq.current || ews !== workspaceRef.current) return;
         setState((s) => ({
           items: [],
           loading: false,

--- a/apps/web/components/github/my-github/use-github-search.ts
+++ b/apps/web/components/github/my-github/use-github-search.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { searchUserPRs, searchUserIssues } from "@/lib/api/domains/github-api";
 import type { GitHubPR, GitHubIssue } from "@/lib/types/github";
 import type { PresetOption } from "./search-bar";
@@ -72,7 +72,7 @@ export function useGitHubSearch<T extends GitHubPR | GitHubIssue>({
   const requestSeq = useRef(0);
   const workspaceRef = useRef(workspaceId);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     workspaceRef.current = workspaceId;
   }, [workspaceId]);
 

--- a/apps/web/components/github/my-github/use-saved-presets.test.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { fetchUserSettings, updateUserSettings } from "@/lib/api/domains/settings-api";
+import {
+  fetchGitHubWorkspaceSettings,
+  updateGitHubWorkspaceSettings,
+} from "@/lib/api/domains/github-api";
 import {
   __resetSnapshotForTests,
   readStorage,
@@ -10,10 +14,17 @@ import {
 
 const STORAGE_KEY = "kandev:github-presets:v1";
 const SYNC_FAILED_KEY = "kandev:github-presets:sync-failed:v1";
+const WORKSPACE_ID = "ws-1";
+const SETTINGS_TIMESTAMP = "2026-01-01T00:00:00Z";
 
 vi.mock("@/lib/api/domains/settings-api", () => ({
   fetchUserSettings: vi.fn(),
   updateUserSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/api/domains/github-api", () => ({
+  fetchGitHubWorkspaceSettings: vi.fn(),
+  updateGitHubWorkspaceSettings: vi.fn(),
 }));
 
 // Provide a simple in-memory localStorage mock so the tests are not sensitive
@@ -35,6 +46,7 @@ function makeLocalStorageMock() {
 
 const localStorageMock = makeLocalStorageMock();
 vi.stubGlobal("localStorage", localStorageMock);
+Object.defineProperty(window, "localStorage", { value: localStorageMock, configurable: true });
 
 function set(raw: string | null) {
   if (raw === null) localStorageMock.removeItem(STORAGE_KEY);
@@ -47,8 +59,23 @@ const valid: SavedPreset = {
   label: "My PRs",
   customQuery: "author:@me",
   repoFilter: "",
-  createdAt: "2026-01-01T00:00:00Z",
+  createdAt: SETTINGS_TIMESTAMP,
 };
+
+function workspaceSettings(
+  savedPresets: SavedPreset[] = [],
+): Awaited<ReturnType<typeof fetchGitHubWorkspaceSettings>> {
+  return {
+    workspace_id: WORKSPACE_ID,
+    repo_scope_mode: "all",
+    repo_scope_orgs: [],
+    repo_scope_repos: [],
+    saved_presets: savedPresets,
+    default_query_presets: null,
+    created_at: SETTINGS_TIMESTAMP,
+    updated_at: SETTINGS_TIMESTAMP,
+  } as Awaited<ReturnType<typeof fetchGitHubWorkspaceSettings>>;
+}
 
 describe("readStorage", () => {
   beforeEach(() => {
@@ -56,6 +83,8 @@ describe("readStorage", () => {
     __resetSnapshotForTests();
     vi.mocked(fetchUserSettings).mockReset();
     vi.mocked(updateUserSettings).mockReset();
+    vi.mocked(fetchGitHubWorkspaceSettings).mockReset();
+    vi.mocked(updateGitHubWorkspaceSettings).mockReset();
   });
 
   it("returns empty array when no value is stored", () => {
@@ -112,6 +141,8 @@ describe("useSavedPresets", () => {
     __resetSnapshotForTests();
     vi.mocked(fetchUserSettings).mockReset();
     vi.mocked(updateUserSettings).mockReset();
+    vi.mocked(fetchGitHubWorkspaceSettings).mockReset();
+    vi.mocked(updateGitHubWorkspaceSettings).mockReset();
   });
 
   it("retries local presets after a failed backend sync and clears the marker", async () => {
@@ -148,5 +179,51 @@ describe("useSavedPresets", () => {
       expect(updateUserSettings).toHaveBeenCalledWith({ github_saved_presets: [] });
       expect(localStorageMock.getItem(SYNC_FAILED_KEY)).toBeNull();
     });
+  });
+
+  it("migrates local presets into a fresh workspace", async () => {
+    set(JSON.stringify([valid]));
+    vi.mocked(fetchGitHubWorkspaceSettings).mockResolvedValue(workspaceSettings());
+    vi.mocked(updateGitHubWorkspaceSettings).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof updateGitHubWorkspaceSettings>>,
+    );
+
+    const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.presets).toEqual([valid]));
+    expect(updateGitHubWorkspaceSettings).toHaveBeenCalledWith({
+      workspace_id: WORKSPACE_ID,
+      saved_presets: [valid],
+    });
+  });
+
+  it("does not migrate local presets over existing workspace presets", async () => {
+    const server = { ...valid, id: "p_server", label: "Server" };
+    set(JSON.stringify([valid]));
+    vi.mocked(fetchGitHubWorkspaceSettings).mockResolvedValue(workspaceSettings([server]));
+
+    const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
+
+    await waitFor(() => expect(result.current.presets).toEqual([server]));
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
+  });
+
+  it("does not save while workspace presets are still loading", () => {
+    vi.mocked(fetchGitHubWorkspaceSettings).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
+
+    let created: SavedPreset | null = null;
+    act(() => {
+      created = result.current.save({
+        kind: "pr",
+        label: "Loading",
+        customQuery: "is:open",
+        repoFilter: "",
+      });
+    });
+
+    expect(created).toBeNull();
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/github/my-github/use-saved-presets.test.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.test.ts
@@ -62,6 +62,15 @@ const valid: SavedPreset = {
   createdAt: SETTINGS_TIMESTAMP,
 };
 
+function resetTestState() {
+  localStorageMock.clear();
+  __resetSnapshotForTests();
+  vi.mocked(fetchUserSettings).mockReset();
+  vi.mocked(updateUserSettings).mockReset();
+  vi.mocked(fetchGitHubWorkspaceSettings).mockReset();
+  vi.mocked(updateGitHubWorkspaceSettings).mockReset();
+}
+
 function workspaceSettings(
   savedPresets: SavedPreset[] = [],
 ): Awaited<ReturnType<typeof fetchGitHubWorkspaceSettings>> {
@@ -79,12 +88,7 @@ function workspaceSettings(
 
 describe("readStorage", () => {
   beforeEach(() => {
-    localStorageMock.clear();
-    __resetSnapshotForTests();
-    vi.mocked(fetchUserSettings).mockReset();
-    vi.mocked(updateUserSettings).mockReset();
-    vi.mocked(fetchGitHubWorkspaceSettings).mockReset();
-    vi.mocked(updateGitHubWorkspaceSettings).mockReset();
+    resetTestState();
   });
 
   it("returns empty array when no value is stored", () => {
@@ -137,12 +141,7 @@ describe("readStorage", () => {
 
 describe("useSavedPresets", () => {
   beforeEach(() => {
-    localStorageMock.clear();
-    __resetSnapshotForTests();
-    vi.mocked(fetchUserSettings).mockReset();
-    vi.mocked(updateUserSettings).mockReset();
-    vi.mocked(fetchGitHubWorkspaceSettings).mockReset();
-    vi.mocked(updateGitHubWorkspaceSettings).mockReset();
+    resetTestState();
   });
 
   it("retries local presets after a failed backend sync and clears the marker", async () => {
@@ -179,6 +178,12 @@ describe("useSavedPresets", () => {
       expect(updateUserSettings).toHaveBeenCalledWith({ github_saved_presets: [] });
       expect(localStorageMock.getItem(SYNC_FAILED_KEY)).toBeNull();
     });
+  });
+});
+
+describe("useSavedPresets workspace sync", () => {
+  beforeEach(() => {
+    resetTestState();
   });
 
   it("migrates local presets into a fresh workspace", async () => {
@@ -227,10 +232,45 @@ describe("useSavedPresets", () => {
     expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
   });
 
+  it("does not save after workspace presets fail to load", async () => {
+    vi.mocked(fetchGitHubWorkspaceSettings).mockRejectedValue(new Error("settings down"));
+
+    const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
+
+    await waitFor(() => expect(fetchGitHubWorkspaceSettings).toHaveBeenCalled());
+
+    let created: SavedPreset | null = valid;
+    act(() => {
+      created = result.current.save({
+        kind: "pr",
+        label: "Failed load",
+        customQuery: "is:open",
+        repoFilter: "",
+      });
+    });
+
+    expect(created).toBeNull();
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
+  });
+
   it("does not remove while workspace presets are still loading", () => {
     vi.mocked(fetchGitHubWorkspaceSettings).mockReturnValue(new Promise(() => {}));
 
     const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
+
+    act(() => {
+      result.current.remove("p_1");
+    });
+
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
+  });
+
+  it("does not remove after workspace presets fail to load", async () => {
+    vi.mocked(fetchGitHubWorkspaceSettings).mockRejectedValue(new Error("settings down"));
+
+    const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
+
+    await waitFor(() => expect(fetchGitHubWorkspaceSettings).toHaveBeenCalled());
 
     act(() => {
       result.current.remove("p_1");

--- a/apps/web/components/github/my-github/use-saved-presets.test.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.test.ts
@@ -226,4 +226,16 @@ describe("useSavedPresets", () => {
     expect(created).toBeNull();
     expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
   });
+
+  it("does not remove while workspace presets are still loading", () => {
+    vi.mocked(fetchGitHubWorkspaceSettings).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useSavedPresets(WORKSPACE_ID));
+
+    act(() => {
+      result.current.remove("p_1");
+    });
+
+    expect(updateGitHubWorkspaceSettings).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/components/github/my-github/use-saved-presets.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.ts
@@ -223,7 +223,7 @@ function useWorkspaceSavedPresets(workspaceId: string | null) {
         }
       })
       .catch(() => {
-        if (!cancelled) setWorkspacePresets([]);
+        if (!cancelled) setWorkspacePresets(undefined);
       });
     return () => {
       cancelled = true;

--- a/apps/web/components/github/my-github/use-saved-presets.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { fetchUserSettings } from "@/lib/api/domains/settings-api";
 import {
   fetchGitHubWorkspaceSettings,
@@ -91,6 +91,15 @@ function readServerPresets(value: unknown): SavedPreset[] | null {
   );
 }
 
+async function readLegacyServerPresets(): Promise<SavedPreset[]> {
+  try {
+    const response = await fetchUserSettings({ cache: "no-store" });
+    return readServerPresets(response.settings.github_saved_presets) ?? [];
+  } catch {
+    return [];
+  }
+}
+
 const syncServer = createQueuedUserSettingsSync<SavedPreset[]>(SYNC_FAILED_KEY, (next) => ({
   github_saved_presets: next,
 }));
@@ -132,8 +141,9 @@ export function __resetSnapshotForTests() {
   for (const l of listeners) l();
 }
 
-function useLegacySavedPresetsSync() {
+function useLegacySavedPresetsSync(enabled: boolean) {
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
     const initialKey = snapshotKey(readStorage());
     fetchUserSettings({ cache: "no-store" })
@@ -158,30 +168,36 @@ function useLegacySavedPresetsSync() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [enabled]);
 }
 
 function useWorkspaceSavedPresets(workspaceId: string | null) {
   const [workspacePresets, setWorkspacePresets] = useState<SavedPreset[] | undefined>(undefined);
+  const writeSeq = useRef(0);
   useEffect(() => {
     if (!workspaceId) {
       setWorkspacePresets(undefined);
       return;
     }
     let cancelled = false;
+    const seq = writeSeq.current;
     setWorkspacePresets(undefined);
     fetchGitHubWorkspaceSettings(workspaceId)
-      .then((settings) => {
-        if (cancelled) return;
+      .then(async (settings) => {
+        if (cancelled || seq !== writeSeq.current) return;
         const serverPresets = readServerPresets(settings.saved_presets) ?? [];
-        const local = readStorage();
+        let local = readStorage();
+        if (local.length === 0) {
+          local = await readLegacyServerPresets();
+        }
+        if (cancelled || seq !== writeSeq.current) return;
         if (
           serverPresets.length === 0 &&
           local.length > 0 &&
           !hasMigratedToWorkspace(workspaceId)
         ) {
           setWorkspacePresets(local);
-          void updateGitHubWorkspaceSettings({
+          await updateGitHubWorkspaceSettings({
             workspace_id: workspaceId,
             saved_presets: local,
           });
@@ -198,13 +214,17 @@ function useWorkspaceSavedPresets(workspaceId: string | null) {
       cancelled = true;
     };
   }, [workspaceId]);
-  return { workspacePresets, setWorkspacePresets };
+  const setWorkspacePresetsFromLocal = useCallback((next: SavedPreset[]) => {
+    writeSeq.current += 1;
+    setWorkspacePresets(next);
+  }, []);
+  return { workspacePresets, setWorkspacePresets: setWorkspacePresetsFromLocal };
 }
 
 export function useSavedPresets(workspaceId: string | null = null) {
   const presets = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const { workspacePresets, setWorkspacePresets } = useWorkspaceSavedPresets(workspaceId);
-  useLegacySavedPresetsSync();
+  useLegacySavedPresetsSync(!workspaceId);
   const activePresets = workspaceId ? (workspacePresets ?? []) : presets;
 
   const save = useCallback(
@@ -220,8 +240,7 @@ export function useSavedPresets(workspaceId: string | null = null) {
         void updateGitHubWorkspaceSettings({
           workspace_id: workspaceId,
           saved_presets: next,
-        });
-        markMigratedToWorkspace(workspaceId);
+        }).then(() => markMigratedToWorkspace(workspaceId));
         return preset;
       }
       publish(next);
@@ -240,8 +259,7 @@ export function useSavedPresets(workspaceId: string | null = null) {
         void updateGitHubWorkspaceSettings({
           workspace_id: workspaceId,
           saved_presets: next,
-        });
-        markMigratedToWorkspace(workspaceId);
+        }).then(() => markMigratedToWorkspace(workspaceId));
         return;
       }
       publish(next);

--- a/apps/web/components/github/my-github/use-saved-presets.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.ts
@@ -1,12 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { fetchUserSettings } from "@/lib/api/domains/settings-api";
+import {
+  fetchGitHubWorkspaceSettings,
+  updateGitHubWorkspaceSettings,
+} from "@/lib/api/domains/github-api";
 import { createQueuedUserSettingsSync } from "@/lib/user-settings-sync";
 import { hasUserSettingsSyncFailure } from "@/lib/user-settings-sync-failure";
 
 const STORAGE_KEY = "kandev:github-presets:v1";
 const MIGRATED_KEY = "kandev:github-presets:migrated-to-backend:v1";
+const WORKSPACE_MIGRATED_KEY_PREFIX = "kandev:github-presets:migrated-to-workspace:v1:";
 const SYNC_FAILED_KEY = "kandev:github-presets:sync-failed:v1";
 
 export type SavedPreset = {
@@ -108,14 +113,26 @@ function markMigratedToBackend(): void {
   }
 }
 
+function hasMigratedToWorkspace(workspaceId: string): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(WORKSPACE_MIGRATED_KEY_PREFIX + workspaceId) === "1";
+}
+
+function markMigratedToWorkspace(workspaceId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WORKSPACE_MIGRATED_KEY_PREFIX + workspaceId, "1");
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
 export function __resetSnapshotForTests() {
   snapshot = null;
   for (const l of listeners) l();
 }
 
-export function useSavedPresets() {
-  const presets = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-
+function useLegacySavedPresetsSync() {
   useEffect(() => {
     let cancelled = false;
     const initialKey = snapshotKey(readStorage());
@@ -142,26 +159,97 @@ export function useSavedPresets() {
       cancelled = true;
     };
   }, []);
+}
 
-  const save = useCallback((input: Omit<SavedPreset, "id" | "createdAt">) => {
-    const preset: SavedPreset = {
-      ...input,
-      id: `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
-      createdAt: new Date().toISOString(),
+function useWorkspaceSavedPresets(workspaceId: string | null) {
+  const [workspacePresets, setWorkspacePresets] = useState<SavedPreset[] | undefined>(undefined);
+  useEffect(() => {
+    if (!workspaceId) {
+      setWorkspacePresets(undefined);
+      return;
+    }
+    let cancelled = false;
+    setWorkspacePresets(undefined);
+    fetchGitHubWorkspaceSettings(workspaceId)
+      .then((settings) => {
+        if (cancelled) return;
+        const serverPresets = readServerPresets(settings.saved_presets) ?? [];
+        const local = readStorage();
+        if (
+          serverPresets.length === 0 &&
+          local.length > 0 &&
+          !hasMigratedToWorkspace(workspaceId)
+        ) {
+          setWorkspacePresets(local);
+          void updateGitHubWorkspaceSettings({
+            workspace_id: workspaceId,
+            saved_presets: local,
+          });
+          markMigratedToWorkspace(workspaceId);
+          return;
+        }
+        setWorkspacePresets(serverPresets);
+        markMigratedToWorkspace(workspaceId);
+      })
+      .catch(() => {
+        if (!cancelled) setWorkspacePresets([]);
+      });
+    return () => {
+      cancelled = true;
     };
-    const next = [...readStorage(), preset];
-    publish(next);
-    void syncServer(next);
-    markMigratedToBackend();
-    return preset;
-  }, []);
+  }, [workspaceId]);
+  return { workspacePresets, setWorkspacePresets };
+}
 
-  const remove = useCallback((id: string) => {
-    const next = readStorage().filter((p) => p.id !== id);
-    publish(next);
-    void syncServer(next);
-    markMigratedToBackend();
-  }, []);
+export function useSavedPresets(workspaceId: string | null = null) {
+  const presets = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const { workspacePresets, setWorkspacePresets } = useWorkspaceSavedPresets(workspaceId);
+  useLegacySavedPresetsSync();
+  const activePresets = workspaceId ? (workspacePresets ?? []) : presets;
 
-  return { presets, save, remove };
+  const save = useCallback(
+    (input: Omit<SavedPreset, "id" | "createdAt">) => {
+      const preset: SavedPreset = {
+        ...input,
+        id: `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+        createdAt: new Date().toISOString(),
+      };
+      const next = [...activePresets, preset];
+      if (workspaceId) {
+        setWorkspacePresets(next);
+        void updateGitHubWorkspaceSettings({
+          workspace_id: workspaceId,
+          saved_presets: next,
+        });
+        markMigratedToWorkspace(workspaceId);
+        return preset;
+      }
+      publish(next);
+      void syncServer(next);
+      markMigratedToBackend();
+      return preset;
+    },
+    [activePresets, workspaceId],
+  );
+
+  const remove = useCallback(
+    (id: string) => {
+      const next = activePresets.filter((p) => p.id !== id);
+      if (workspaceId) {
+        setWorkspacePresets(next);
+        void updateGitHubWorkspaceSettings({
+          workspace_id: workspaceId,
+          saved_presets: next,
+        });
+        markMigratedToWorkspace(workspaceId);
+        return;
+      }
+      publish(next);
+      void syncServer(next);
+      markMigratedToBackend();
+    },
+    [activePresets, workspaceId],
+  );
+
+  return { presets: activePresets, save, remove };
 }

--- a/apps/web/components/github/my-github/use-saved-presets.ts
+++ b/apps/web/components/github/my-github/use-saved-presets.ts
@@ -91,18 +91,32 @@ function readServerPresets(value: unknown): SavedPreset[] | null {
   );
 }
 
-async function readLegacyServerPresets(): Promise<SavedPreset[]> {
+async function readLegacyServerPresets(): Promise<SavedPreset[] | undefined> {
   try {
     const response = await fetchUserSettings({ cache: "no-store" });
     return readServerPresets(response.settings.github_saved_presets) ?? [];
   } catch {
-    return [];
+    return undefined;
   }
 }
 
 const syncServer = createQueuedUserSettingsSync<SavedPreset[]>(SYNC_FAILED_KEY, (next) => ({
   github_saved_presets: next,
 }));
+
+let workspaceSyncQueue = Promise.resolve();
+
+function syncWorkspaceSavedPresets(workspaceId: string, next: SavedPreset[]): Promise<void> {
+  workspaceSyncQueue = workspaceSyncQueue
+    .catch(() => undefined)
+    .then(() =>
+      updateGitHubWorkspaceSettings({
+        workspace_id: workspaceId,
+        saved_presets: next,
+      }).then(() => undefined),
+    );
+  return workspaceSyncQueue;
+}
 
 function snapshotKey(value: SavedPreset[]): string {
   return JSON.stringify(value);
@@ -186,26 +200,27 @@ function useWorkspaceSavedPresets(workspaceId: string | null) {
       .then(async (settings) => {
         if (cancelled || seq !== writeSeq.current) return;
         const serverPresets = readServerPresets(settings.saved_presets) ?? [];
-        let local = readStorage();
+        let local: SavedPreset[] | undefined = readStorage();
         if (local.length === 0) {
           local = await readLegacyServerPresets();
         }
         if (cancelled || seq !== writeSeq.current) return;
         if (
           serverPresets.length === 0 &&
+          local !== undefined &&
           local.length > 0 &&
           !hasMigratedToWorkspace(workspaceId)
         ) {
           setWorkspacePresets(local);
-          await updateGitHubWorkspaceSettings({
-            workspace_id: workspaceId,
-            saved_presets: local,
-          });
-          markMigratedToWorkspace(workspaceId);
+          void syncWorkspaceSavedPresets(workspaceId, local)
+            .then(() => markMigratedToWorkspace(workspaceId))
+            .catch(() => {});
           return;
         }
         setWorkspacePresets(serverPresets);
-        markMigratedToWorkspace(workspaceId);
+        if (local !== undefined || serverPresets.length > 0) {
+          markMigratedToWorkspace(workspaceId);
+        }
       })
       .catch(() => {
         if (!cancelled) setWorkspacePresets([]);
@@ -229,6 +244,7 @@ export function useSavedPresets(workspaceId: string | null = null) {
 
   const save = useCallback(
     (input: Omit<SavedPreset, "id" | "createdAt">) => {
+      if (workspaceId && workspacePresets === undefined) return null;
       const preset: SavedPreset = {
         ...input,
         id: `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
@@ -237,10 +253,9 @@ export function useSavedPresets(workspaceId: string | null = null) {
       const next = [...activePresets, preset];
       if (workspaceId) {
         setWorkspacePresets(next);
-        void updateGitHubWorkspaceSettings({
-          workspace_id: workspaceId,
-          saved_presets: next,
-        }).then(() => markMigratedToWorkspace(workspaceId));
+        void syncWorkspaceSavedPresets(workspaceId, next)
+          .then(() => markMigratedToWorkspace(workspaceId))
+          .catch(() => {});
         return preset;
       }
       publish(next);
@@ -248,25 +263,25 @@ export function useSavedPresets(workspaceId: string | null = null) {
       markMigratedToBackend();
       return preset;
     },
-    [activePresets, workspaceId],
+    [activePresets, workspaceId, workspacePresets, setWorkspacePresets],
   );
 
   const remove = useCallback(
     (id: string) => {
+      if (workspaceId && workspacePresets === undefined) return;
       const next = activePresets.filter((p) => p.id !== id);
       if (workspaceId) {
         setWorkspacePresets(next);
-        void updateGitHubWorkspaceSettings({
-          workspace_id: workspaceId,
-          saved_presets: next,
-        }).then(() => markMigratedToWorkspace(workspaceId));
+        void syncWorkspaceSavedPresets(workspaceId, next)
+          .then(() => markMigratedToWorkspace(workspaceId))
+          .catch(() => {});
         return;
       }
       publish(next);
       void syncServer(next);
       markMigratedToBackend();
     },
-    [activePresets, workspaceId],
+    [activePresets, workspaceId, workspacePresets, setWorkspacePresets],
   );
 
   return { presets: activePresets, save, remove };

--- a/apps/web/components/github/repo-filter-selector.tsx
+++ b/apps/web/components/github/repo-filter-selector.tsx
@@ -106,17 +106,29 @@ function useWorkspaceRepoScope(workspaceId: string | undefined) {
 
 function repoAllowedByScope(settings: GitHubWorkspaceSettings | null, owner: string, repo: string) {
   if (!settings || settings.repo_scope_mode === "all") return true;
+  const ownerLower = owner.trim().toLowerCase();
+  const repoLower = repo.trim().toLowerCase();
   if (settings.repo_scope_mode === "orgs") {
-    return (settings.repo_scope_orgs ?? []).includes(owner);
+    return (settings.repo_scope_orgs ?? []).some((allowed) => {
+      return allowed.trim().toLowerCase() === ownerLower;
+    });
   }
-  return (settings.repo_scope_repos ?? []).some(
-    (allowed) => allowed.owner === owner && allowed.name === repo,
-  );
+  return (settings.repo_scope_repos ?? []).some((allowed) => {
+    return (
+      allowed.owner.trim().toLowerCase() === ownerLower &&
+      allowed.name.trim().toLowerCase() === repoLower
+    );
+  });
 }
 
 function orgAllowedByScope(settings: GitHubWorkspaceSettings | null, org: string) {
   if (!settings || settings.repo_scope_mode === "all") return true;
-  if (settings.repo_scope_mode === "orgs") return (settings.repo_scope_orgs ?? []).includes(org);
+  const orgLower = org.trim().toLowerCase();
+  if (settings.repo_scope_mode === "orgs") {
+    return (settings.repo_scope_orgs ?? []).some((allowed) => {
+      return allowed.trim().toLowerCase() === orgLower;
+    });
+  }
   return false;
 }
 

--- a/apps/web/components/github/repo-filter-selector.tsx
+++ b/apps/web/components/github/repo-filter-selector.tsx
@@ -16,14 +16,24 @@ import { Label } from "@kandev/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@kandev/ui/popover";
 import { Switch } from "@kandev/ui/switch";
 import { cn } from "@/lib/utils";
-import { listUserOrgs, searchOrgRepos } from "@/lib/api/domains/github-api";
-import type { RepoFilter, GitHubOrg, GitHubRepoInfo } from "@/lib/types/github";
+import {
+  fetchGitHubWorkspaceSettings,
+  listUserOrgs,
+  searchOrgRepos,
+} from "@/lib/api/domains/github-api";
+import type {
+  RepoFilter,
+  GitHubOrg,
+  GitHubRepoInfo,
+  GitHubWorkspaceSettings,
+} from "@/lib/types/github";
 
 type RepoFilterSelectorProps = {
   allRepos: boolean;
   selectedRepos: RepoFilter[];
   onAllReposChange: (checked: boolean) => void;
   onSelectedReposChange: (repos: RepoFilter[]) => void;
+  workspaceId?: string;
 };
 
 function useGitHubOrgs() {
@@ -68,6 +78,46 @@ function useRepoSearch(org: string, query: string) {
   const loading = org ? searchState.loading : false;
 
   return { results, loading };
+}
+
+function useWorkspaceRepoScope(workspaceId: string | undefined) {
+  const [settings, setSettings] = useState<GitHubWorkspaceSettings | null>(null);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      setSettings(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchGitHubWorkspaceSettings(workspaceId)
+      .then((next) => {
+        if (!cancelled) setSettings(next);
+      })
+      .catch(() => {
+        if (!cancelled) setSettings(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+
+  return settings;
+}
+
+function repoAllowedByScope(settings: GitHubWorkspaceSettings | null, owner: string, repo: string) {
+  if (!settings || settings.repo_scope_mode === "all") return true;
+  if (settings.repo_scope_mode === "orgs") {
+    return (settings.repo_scope_orgs ?? []).includes(owner);
+  }
+  return (settings.repo_scope_repos ?? []).some(
+    (allowed) => allowed.owner === owner && allowed.name === repo,
+  );
+}
+
+function orgAllowedByScope(settings: GitHubWorkspaceSettings | null, org: string) {
+  if (!settings || settings.repo_scope_mode === "all") return true;
+  if (settings.repo_scope_mode === "orgs") return (settings.repo_scope_orgs ?? []).includes(org);
+  return false;
 }
 
 function SelectedFilters({
@@ -153,9 +203,11 @@ function OrgBadges({
 
 function RepoSearchCombobox({
   disabled,
+  scope,
   onAdd,
 }: {
   disabled: boolean;
+  scope: GitHubWorkspaceSettings | null;
   onAdd: (owner: string, name: string) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -165,7 +217,10 @@ function RepoSearchCombobox({
   const org = slashIdx > 0 ? value.slice(0, slashIdx) : "";
   const query = slashIdx > 0 ? value.slice(slashIdx + 1) : "";
   const { results, loading: searchLoading } = useRepoSearch(org, query);
-  const filteredResults = useMemo(() => results.slice(0, 10), [results]);
+  const filteredResults = useMemo(
+    () => results.filter((repo) => repoAllowedByScope(scope, repo.owner, repo.name)).slice(0, 10),
+    [results, scope],
+  );
 
   const handleSelect = useCallback(
     (fullName: string) => {
@@ -239,8 +294,15 @@ export function RepoFilterSelector({
   selectedRepos,
   onAllReposChange,
   onSelectedReposChange,
+  workspaceId,
 }: RepoFilterSelectorProps) {
   const { orgs, loading: orgsLoading } = useGitHubOrgs();
+  const scope = useWorkspaceRepoScope(workspaceId);
+  const scopedOrgs = useMemo(
+    () => orgs.filter((org) => orgAllowedByScope(scope, org.login)),
+    [orgs, scope],
+  );
+  const showOrgBadges = !scope || scope.repo_scope_mode !== "repos";
 
   const toggleOrg = useCallback(
     (login: string) => {
@@ -278,7 +340,7 @@ export function RepoFilterSelector({
       <div>
         <Label>Repositories</Label>
         <p className="text-xs text-muted-foreground">
-          Which GitHub repositories to monitor for PRs requesting your review.
+          Which allowed GitHub repositories to monitor for this watch.
         </p>
       </div>
 
@@ -290,24 +352,26 @@ export function RepoFilterSelector({
           className="cursor-pointer"
         />
         <Label htmlFor="all-repos-toggle" className="font-normal cursor-pointer">
-          All repositories (no filtering)
+          All repositories allowed by this workspace
         </Label>
       </div>
 
       {!allRepos && (
         <>
-          <div className="space-y-1.5">
-            <Label className="text-xs text-muted-foreground font-normal">Organizations</Label>
-            <OrgBadges
-              orgs={orgs}
-              loading={orgsLoading}
-              selectedRepos={selectedRepos}
-              disabled={allRepos}
-              onToggleOrg={toggleOrg}
-            />
-          </div>
+          {showOrgBadges && (
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground font-normal">Organizations</Label>
+              <OrgBadges
+                orgs={scopedOrgs}
+                loading={orgsLoading}
+                selectedRepos={selectedRepos}
+                disabled={allRepos}
+                onToggleOrg={toggleOrg}
+              />
+            </div>
+          )}
 
-          <RepoSearchCombobox disabled={allRepos} onAdd={addRepo} />
+          <RepoSearchCombobox disabled={allRepos} scope={scope} onAdd={addRepo} />
 
           <SelectedFilters repos={selectedRepos} onRemove={removeFilter} disabled={allRepos} />
         </>

--- a/apps/web/components/github/review-watch-dialog.tsx
+++ b/apps/web/components/github/review-watch-dialog.tsx
@@ -349,6 +349,7 @@ function WatchFormFields({
         selectedRepos={form.selectedRepos}
         onAllReposChange={onAllReposChange}
         onSelectedReposChange={onSelectedReposChange}
+        workspaceId={form.workspaceId}
       />
       <QueryField form={form} setForm={setForm} />
       <SectionHeader>Automation</SectionHeader>

--- a/apps/web/components/integrations/workspace-scoped-section.tsx
+++ b/apps/web/components/integrations/workspace-scoped-section.tsx
@@ -8,6 +8,7 @@ import { WorkspaceSwitcher } from "@/components/task/workspace-switcher";
 type WorkspaceScopedSectionProps = {
   label?: string;
   emptyMessage?: string;
+  showSelector?: boolean;
   children: (workspaceId: string) => ReactNode;
 };
 
@@ -19,6 +20,7 @@ type WorkspaceScopedSectionProps = {
 export function WorkspaceScopedSection({
   label = "Workspace",
   emptyMessage,
+  showSelector = true,
   children,
 }: WorkspaceScopedSectionProps) {
   const workspaces = useAppStore((s) => s.workspaces.items);
@@ -44,14 +46,16 @@ export function WorkspaceScopedSection({
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-3 text-sm">
-        <span className="text-muted-foreground">{label}</span>
-        <WorkspaceSwitcher
-          workspaces={workspaces}
-          activeWorkspaceId={selected}
-          onSelect={setOverride}
-        />
-      </div>
+      {showSelector && (
+        <div className="flex items-center gap-3 text-sm">
+          <span className="text-muted-foreground">{label}</span>
+          <WorkspaceSwitcher
+            workspaces={workspaces}
+            activeWorkspaceId={selected}
+            onSelect={setOverride}
+          />
+        </div>
+      )}
       {selected ? children(selected) : null}
     </div>
   );

--- a/apps/web/components/integrations/workspace-scoped-section.tsx
+++ b/apps/web/components/integrations/workspace-scoped-section.tsx
@@ -47,7 +47,7 @@ export function WorkspaceScopedSection({
   return (
     <div className="space-y-3">
       {showSelector && (
-        <div className="flex items-center gap-3 text-sm">
+        <div className="flex items-center gap-3 text-sm" data-testid="workspace-scoped-selector">
           <span className="text-muted-foreground">{label}</span>
           <WorkspaceSwitcher
             workspaces={workspaces}

--- a/apps/web/components/jira/jira-import-bar.tsx
+++ b/apps/web/components/jira/jira-import-bar.tsx
@@ -14,7 +14,7 @@ type JiraImportBarProps = {
 };
 
 export function JiraImportBar({ workspaceId, disabled, onImport }: JiraImportBarProps) {
-  const available = useJiraAvailable();
+  const available = useJiraAvailable(workspaceId);
   if (!available || !workspaceId) return null;
 
   return (
@@ -30,7 +30,7 @@ export function JiraImportBar({ workspaceId, disabled, onImport }: JiraImportBar
       placeholder="PROJ-123 or paste ticket URL"
       extractKey={(raw) => raw.toUpperCase().match(JIRA_KEY_RE)?.[0] ?? null}
       validationHint="Paste a Jira ticket URL or key (PROJ-123)"
-      fetch={(key) => getJiraTicket(key)}
+      fetch={(key) => getJiraTicket(key, { workspaceId })}
       onSuccess={(_key, ticket) => onImport(ticket)}
       submitLabel="Import"
       submittingLabel="Loading..."

--- a/apps/web/components/jira/jira-issue-watch-dialog.tsx
+++ b/apps/web/components/jira/jira-issue-watch-dialog.tsx
@@ -183,21 +183,29 @@ function SelectField(props: {
   );
 }
 
-function JQLField({ jql, onChange }: { jql: string; onChange: (v: string) => void }) {
+function JQLField({
+  workspaceId,
+  jql,
+  onChange,
+}: {
+  workspaceId: string;
+  jql: string;
+  onChange: (v: string) => void;
+}) {
   const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
   const [testing, setTesting] = useState(false);
   const handleTest = useCallback(async () => {
     setTesting(true);
     setResult(null);
     try {
-      const res = await searchJiraTickets({ jql, maxResults: 5 });
+      const res = await searchJiraTickets({ jql, maxResults: 5 }, { workspaceId });
       setResult({ ok: true, message: `Matched ${res.tickets.length} ticket(s) in this page.` });
     } catch (err) {
       setResult({ ok: false, message: `JQL error: ${String(err)}` });
     } finally {
       setTesting(false);
     }
-  }, [jql]);
+  }, [workspaceId, jql]);
 
   return (
     <div className="space-y-1.5">
@@ -539,7 +547,11 @@ export function JiraIssueWatchDialog({
             onChange={(v) => setForm((p) => clearWorkspaceScopedForm(p, v))}
             disabled={workspaceLocked}
           />
-          <JQLField jql={form.jql} onChange={(v) => setForm((p) => ({ ...p, jql: v }))} />
+          <JQLField
+            workspaceId={form.workspaceId}
+            jql={form.jql}
+            onChange={(v) => setForm((p) => ({ ...p, jql: v }))}
+          />
           <AutomationFields form={form} setForm={setForm} />
           <PromptField
             value={form.prompt}

--- a/apps/web/components/jira/jira-link-button.tsx
+++ b/apps/web/components/jira/jira-link-button.tsx
@@ -19,7 +19,7 @@ type JiraLinkButtonProps = {
 // prepending the ticket key to its title ("PROJ-123: ..."). The existing
 // JiraTicketButton picks up the key automatically once the title is updated.
 export function JiraLinkButton({ taskId, workspaceId, taskTitle }: JiraLinkButtonProps) {
-  const available = useJiraAvailable();
+  const available = useJiraAvailable(workspaceId);
 
   const buildLinkedTitle = useCallback(
     (key: string) => {
@@ -49,7 +49,7 @@ export function JiraLinkButton({ taskId, workspaceId, taskTitle }: JiraLinkButto
       // an unhandled rejection that leaves the user thinking the link
       // succeeded.
       fetch={async (key) => {
-        const ticket = await getJiraTicket(key);
+        const ticket = await getJiraTicket(key, { workspaceId });
         await updateTask(taskId, { title: buildLinkedTitle(key) });
         return ticket;
       }}

--- a/apps/web/components/jira/jira-settings.tsx
+++ b/apps/web/components/jira/jira-settings.tsx
@@ -19,6 +19,7 @@ import {
   IntegrationAuthStatusBanner,
   type IntegrationAuthHealth,
 } from "@/components/integrations/auth-status-banner";
+import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
 import {
   getJiraConfig,
@@ -454,7 +455,23 @@ function ActionBar({
   );
 }
 
-function useJiraSettings() {
+function useJiraConfigRefresh(workspaceId: string, setConfig: (cfg: JiraConfig | null) => void) {
+  // Background refresh so the auth-health banner picks up new probe results
+  // from the backend poller without requiring a page reload. We re-fetch the
+  // config rather than the loud full `load()` to avoid flashing the form.
+  useEffect(() => {
+    const id = setInterval(() => {
+      getJiraConfig({ workspaceId })
+        .then((cfg) => setConfig(cfg))
+        .catch(() => {
+          /* transient failures are fine — next tick retries */
+        });
+    }, INTEGRATION_STATUS_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [workspaceId, setConfig]);
+}
+
+function useJiraSettings(workspaceId: string) {
   const { toast } = useToast();
   const [config, setConfig] = useState<JiraConfig | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
@@ -467,7 +484,7 @@ function useJiraSettings() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const cfg = await getJiraConfig();
+      const cfg = await getJiraConfig({ workspaceId });
       setConfig(cfg);
       setForm(configToForm(cfg));
     } catch (err) {
@@ -475,25 +492,13 @@ function useJiraSettings() {
     } finally {
       setLoading(false);
     }
-  }, [toast]);
+  }, [workspaceId, toast]);
 
   useEffect(() => {
     void load();
   }, [load]);
 
-  // Background refresh so the auth-health banner picks up new probe results
-  // from the backend poller without requiring a page reload. We re-fetch the
-  // config rather than the loud full `load()` to avoid flashing the form.
-  useEffect(() => {
-    const id = setInterval(() => {
-      getJiraConfig()
-        .then((cfg) => setConfig(cfg))
-        .catch(() => {
-          /* transient failures are fine — next tick retries */
-        });
-    }, INTEGRATION_STATUS_REFRESH_MS);
-    return () => clearInterval(id);
-  }, []);
+  useJiraConfigRefresh(workspaceId, setConfig);
 
   const update = useCallback(
     <K extends keyof FormState>(key: K, value: FormState[K]) =>
@@ -505,26 +510,29 @@ function useJiraSettings() {
     setTesting(true);
     setTestResult(null);
     try {
-      const res = await testJiraConnection({ ...form });
+      const res = await testJiraConnection({ ...form }, { workspaceId });
       setTestResult(res);
     } catch (err) {
       setTestResult({ ok: false, error: String(err) });
     } finally {
       setTesting(false);
     }
-  }, [form]);
+  }, [workspaceId, form]);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      const saved = await setJiraConfig({
-        siteUrl: form.siteUrl,
-        email: form.email,
-        authMethod: form.authMethod,
-        instanceType: form.instanceType,
-        defaultProjectKey: form.defaultProjectKey,
-        secret: form.secret || undefined,
-      });
+      const saved = await setJiraConfig(
+        {
+          siteUrl: form.siteUrl,
+          email: form.email,
+          authMethod: form.authMethod,
+          instanceType: form.instanceType,
+          defaultProjectKey: form.defaultProjectKey,
+          secret: form.secret || undefined,
+        },
+        { workspaceId },
+      );
       setConfig(saved);
       setForm(configToForm(saved));
       // Clear any inline test result from the previous credentials so the
@@ -536,12 +544,12 @@ function useJiraSettings() {
     } finally {
       setSaving(false);
     }
-  }, [form, toast]);
+  }, [workspaceId, form, toast]);
 
   const handleDelete = useCallback(async () => {
     if (!confirm("Remove Jira configuration?")) return;
     try {
-      await deleteJiraConfig();
+      await deleteJiraConfig({ workspaceId });
       setConfig(null);
       setForm(emptyForm);
       setTestResult(null);
@@ -549,7 +557,7 @@ function useJiraSettings() {
     } catch (err) {
       toast({ description: `Delete failed: ${String(err)}`, variant: "error" });
     }
-  }, [toast]);
+  }, [workspaceId, toast]);
 
   return {
     config,
@@ -612,10 +620,8 @@ function savedSecretMatches(config: JiraConfig | null, form: FormState): boolean
   return (config.email ?? "").toLowerCase() === form.email.toLowerCase();
 }
 
-// JiraConnectionSection holds the install-wide credentials form. Watchers and
-// task presets live elsewhere because they scope per workspace.
-export function JiraConnectionSection() {
-  const s = useJiraSettings();
+export function JiraConnectionSection({ workspaceId }: { workspaceId: string }) {
+  const s = useJiraSettings(workspaceId);
   const savedSecretMatchesMode = savedSecretMatches(s.config, s.form);
   const missingSecret = !savedSecretMatchesMode && !s.form.secret;
   // Email is only required for the Cloud + api_token combination. Server PAT
@@ -629,7 +635,7 @@ export function JiraConnectionSection() {
     <SettingsSection
       icon={<IconTicket className="h-5 w-5" />}
       title="Jira integration"
-      description="Connect Kandev to Atlassian Cloud or a self-hosted Jira Server / Data Center instance. Credentials are stored encrypted server-side and shared across all workspaces."
+      description="Connect this workspace to Atlassian Cloud or a self-hosted Jira Server / Data Center instance. Credentials are stored encrypted server-side for the selected workspace."
       action={<EnabledPill />}
     >
       <Card>
@@ -664,15 +670,12 @@ export function JiraConnectionSection() {
   );
 }
 
-// JiraIntegrationPage is the install-wide settings surface mounted at
-// /settings/integrations/jira. The connection form and task-prompt presets
-// are global; the watchers section lists every watch across every workspace
-// in a single table, with workspace selection happening inside the create
-// dialog.
 export function JiraIntegrationPage() {
   return (
     <div className="space-y-8">
-      <JiraConnectionSection />
+      <WorkspaceScopedSection>
+        {(workspaceId) => <JiraConnectionSection key={workspaceId} workspaceId={workspaceId} />}
+      </WorkspaceScopedSection>
       <JiraIssueWatchersSection />
       <TaskPresetsSection />
     </div>

--- a/apps/web/components/jira/jira-ticket-common.tsx
+++ b/apps/web/components/jira/jira-ticket-common.tsx
@@ -92,14 +92,14 @@ export function useTicketState(
     setLoading(true);
     setError(null);
     try {
-      const t = await getJiraTicket(ticketKey);
+      const t = await getJiraTicket(ticketKey, { workspaceId });
       setTicket(t);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
-  }, [ticketKey]);
+  }, [workspaceId, ticketKey]);
 
   useEffect(() => {
     if (!enabled || !workspaceId || !ticketKey) return;
@@ -109,7 +109,7 @@ export function useTicketState(
       setLoading(true);
       setError(null);
       try {
-        const t = await getJiraTicket(ticketKey);
+        const t = await getJiraTicket(ticketKey, { workspaceId });
         if (!cancelled) setTicket(t);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
@@ -128,7 +128,7 @@ export function useTicketState(
       setPendingTransition(transitionId);
       setError(null);
       try {
-        await transitionJiraTicket(ticketKey, transitionId);
+        await transitionJiraTicket(ticketKey, transitionId, { workspaceId });
         await load();
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
@@ -136,7 +136,7 @@ export function useTicketState(
         setPendingTransition(null);
       }
     },
-    [ticketKey, load],
+    [workspaceId, ticketKey, load],
   );
 
   return { ticket, loading, error, pendingTransition, load, handleTransition };

--- a/apps/web/components/jira/my-jira/use-jira-search.ts
+++ b/apps/web/components/jira/my-jira/use-jira-search.ts
@@ -41,11 +41,14 @@ export function useJiraSearch(workspaceId: string | null | undefined, jql: strin
       setLoading(true);
       setError(null);
       try {
-        const res = await searchJiraTickets({
-          jql,
-          pageToken: token,
-          maxResults: PAGE_SIZE,
-        });
+        const res = await searchJiraTickets(
+          {
+            jql,
+            pageToken: token,
+            maxResults: PAGE_SIZE,
+          },
+          { workspaceId },
+        );
         if (reqId !== reqRef.current) return;
         setItems(res.tickets ?? []);
         setIsLast(res.isLast ?? true);

--- a/apps/web/components/jira/my-jira/use-project-statuses.test.ts
+++ b/apps/web/components/jira/my-jira/use-project-statuses.test.ts
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { JiraStatus } from "@/lib/types/jira";
 
-const listJiraProjectStatusesMock = vi.fn<[string], Promise<{ statuses: JiraStatus[] }>>();
+const listJiraProjectStatusesMock = vi.fn<
+  [string, { workspaceId?: string }?],
+  Promise<{ statuses: JiraStatus[] }>
+>();
 
 vi.mock("@/lib/api/domains/jira-api", () => ({
-  listJiraProjectStatuses: (key: string) => listJiraProjectStatusesMock(key),
+  listJiraProjectStatuses: (key: string, options?: { workspaceId?: string }) =>
+    listJiraProjectStatusesMock(key, options),
 }));
 
 import { reconcileStatuses, useProjectStatuses } from "./use-project-statuses";
@@ -66,7 +70,7 @@ describe("useProjectStatuses", () => {
       }),
     );
 
-    const { result } = renderHook(() => useProjectStatuses(["CLIP"]));
+    const { result } = renderHook(() => useProjectStatuses(["CLIP"], "workspace-1"));
 
     // Before the fetch resolves the hook must not claim to be loaded, otherwise
     // callers would reconcile a saved status selection against empty options.
@@ -77,5 +81,8 @@ describe("useProjectStatuses", () => {
 
     await waitFor(() => expect(result.current.loaded).toBe(true));
     expect(result.current.options).toEqual([status("1", IN_DEV)]);
+    expect(listJiraProjectStatusesMock).toHaveBeenCalledWith("CLIP", {
+      workspaceId: "workspace-1",
+    });
   });
 });

--- a/apps/web/components/jira/my-jira/use-project-statuses.ts
+++ b/apps/web/components/jira/my-jira/use-project-statuses.ts
@@ -48,12 +48,17 @@ export type ProjectStatuses = {
 // lifetime of the component so re-selecting a project never refetches. A fetch
 // failure for one project is non-fatal: that project contributes no options
 // and the rest still load.
-export function useProjectStatuses(projectKeys: string[]): ProjectStatuses {
+export function useProjectStatuses(
+  projectKeys: string[],
+  workspaceId?: string | null,
+): ProjectStatuses {
   const [options, setOptions] = useState<JiraStatus[]>([]);
   const [loaded, setLoaded] = useState(false);
   const cacheRef = useRef<Map<string, JiraStatus[]>>(new Map());
 
-  const cacheKey = [...projectKeys].sort().join(",");
+  const workspaceKey = workspaceId?.trim() ?? "";
+  const projectKeySet = [...projectKeys].sort().join(",");
+  const cacheKey = `${workspaceKey}|${projectKeySet}`;
 
   useEffect(() => {
     let cancelled = false;
@@ -67,21 +72,24 @@ export function useProjectStatuses(projectKeys: string[]): ProjectStatuses {
         return;
       }
       const cache = cacheRef.current;
+      const statusCacheKey = (key: string) => `${workspaceKey}\u0000${key}`;
       await Promise.all(
         projectKeys
-          .filter((key) => !cache.has(key))
+          .filter((key) => !cache.has(statusCacheKey(key)))
           .map(async (key) => {
             try {
-              const { statuses } = await listJiraProjectStatuses(key);
-              cache.set(key, statuses ?? []);
+              const { statuses } = await listJiraProjectStatuses(key, {
+                workspaceId: workspaceKey || undefined,
+              });
+              cache.set(statusCacheKey(key), statuses ?? []);
             } catch {
               // Non-fatal: cache an empty list so we don't refetch on every render.
-              cache.set(key, []);
+              cache.set(statusCacheKey(key), []);
             }
           }),
       );
       if (cancelled) return;
-      setOptions(unionByName(projectKeys.map((key) => cache.get(key) ?? [])));
+      setOptions(unionByName(projectKeys.map((key) => cache.get(statusCacheKey(key)) ?? [])));
       setLoaded(true);
     }
     void load();

--- a/apps/web/components/linear/linear-import-bar.tsx
+++ b/apps/web/components/linear/linear-import-bar.tsx
@@ -14,7 +14,7 @@ type LinearImportBarProps = {
 };
 
 export function LinearImportBar({ workspaceId, disabled, onImport }: LinearImportBarProps) {
-  const available = useLinearAvailable();
+  const available = useLinearAvailable(workspaceId);
   if (!available || !workspaceId) return null;
 
   return (
@@ -30,7 +30,7 @@ export function LinearImportBar({ workspaceId, disabled, onImport }: LinearImpor
       placeholder="ENG-123 or paste issue URL"
       extractKey={(raw) => raw.toUpperCase().match(LINEAR_KEY_RE)?.[0] ?? null}
       validationHint="Paste a Linear issue URL or identifier (ENG-123)"
-      fetch={(key) => getLinearIssue(key)}
+      fetch={(key) => getLinearIssue(key, { workspaceId })}
       onSuccess={(_key, issue) => onImport(issue)}
       submitLabel="Import"
       submittingLabel="Loading..."

--- a/apps/web/components/linear/linear-issue-common.tsx
+++ b/apps/web/components/linear/linear-issue-common.tsx
@@ -96,14 +96,14 @@ export function useIssueState(
     setLoading(true);
     setError(null);
     try {
-      const i = await getLinearIssue(identifier);
+      const i = await getLinearIssue(identifier, { workspaceId });
       setIssue(i);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
-  }, [identifier]);
+  }, [workspaceId, identifier]);
 
   useEffect(() => {
     if (!enabled || !workspaceId || !identifier) return;
@@ -113,7 +113,7 @@ export function useIssueState(
       setLoading(true);
       setError(null);
       try {
-        const i = await getLinearIssue(identifier);
+        const i = await getLinearIssue(identifier, { workspaceId });
         if (!cancelled) setIssue(i);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : String(err));
@@ -133,7 +133,7 @@ export function useIssueState(
       setPendingState(stateId);
       setError(null);
       try {
-        await setLinearIssueState(issue.id, stateId);
+        await setLinearIssueState(issue.id, stateId, { workspaceId });
         await load();
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
@@ -141,7 +141,7 @@ export function useIssueState(
         setPendingState(null);
       }
     },
-    [issue, load],
+    [workspaceId, issue, load],
   );
 
   return { issue, loading, error, pendingState, load, handleStateChange };

--- a/apps/web/components/linear/linear-issue-watch-dialog.tsx
+++ b/apps/web/components/linear/linear-issue-watch-dialog.tsx
@@ -132,7 +132,7 @@ function FilterFields({
   setForm: React.Dispatch<React.SetStateAction<FormState>>;
 }) {
   const { teams, states, labels, users, loadingStates, loadingLabels, loadingUsers } =
-    useTeamsAndStates(form.teamKey);
+    useTeamsAndStates(form.workspaceId, form.teamKey);
   const toggleState = useCallback(
     (id: string) =>
       setForm((p) => ({

--- a/apps/web/components/linear/linear-issue-watch-fields.tsx
+++ b/apps/web/components/linear/linear-issue-watch-fields.tsx
@@ -26,7 +26,7 @@ import type { LinearLabel, LinearTeam, LinearUser, LinearWorkflowState } from "@
 // dataset is cached so switching teams renders an empty list (or the cached
 // list) without us having to setState in an effect — only the lookup
 // expression changes.
-export function useTeamsAndStates(teamKey: string) {
+export function useTeamsAndStates(workspaceId: string, teamKey: string) {
   const [teams, setTeams] = useState<LinearTeam[]>([]);
   const [statesByTeam, setStatesByTeam] = useState<Record<string, LinearWorkflowState[]>>({});
   const [labelsByTeam, setLabelsByTeam] = useState<Record<string, LinearLabel[]>>({});
@@ -35,7 +35,7 @@ export function useTeamsAndStates(teamKey: string) {
 
   useEffect(() => {
     let cancelled = false;
-    listLinearTeams()
+    listLinearTeams({ workspaceId })
       .then((res) => {
         if (!cancelled) setTeams(res.teams ?? []);
       })
@@ -45,7 +45,7 @@ export function useTeamsAndStates(teamKey: string) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [workspaceId]);
 
   useEffect(() => {
     // Capture the Set once so cleanup uses the exact instance the effect
@@ -64,7 +64,7 @@ export function useTeamsAndStates(teamKey: string) {
       anyFailed = true;
     };
     Promise.allSettled([
-      listLinearStates(teamKey)
+      listLinearStates(teamKey, { workspaceId })
         .then((res) => {
           if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: res.states ?? [] }));
         })
@@ -72,7 +72,7 @@ export function useTeamsAndStates(teamKey: string) {
           markFailed();
           if (!cancelled) setStatesByTeam((prev) => ({ ...prev, [teamKey]: [] }));
         }),
-      listLinearLabels(teamKey)
+      listLinearLabels(teamKey, { workspaceId })
         .then((res) => {
           if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: res.labels ?? [] }));
         })
@@ -80,7 +80,7 @@ export function useTeamsAndStates(teamKey: string) {
           markFailed();
           if (!cancelled) setLabelsByTeam((prev) => ({ ...prev, [teamKey]: [] }));
         }),
-      listLinearUsers(teamKey)
+      listLinearUsers(teamKey, { workspaceId })
         .then((res) => {
           if (!cancelled) setUsersByTeam((prev) => ({ ...prev, [teamKey]: res.users ?? [] }));
         })
@@ -104,7 +104,7 @@ export function useTeamsAndStates(teamKey: string) {
       // also evicting a healthy cache after a normal team change.
       if (!loaded) fetched.delete(teamKey);
     };
-  }, [teamKey]);
+  }, [workspaceId, teamKey]);
 
   const states = teamKey ? (statesByTeam[teamKey] ?? []) : [];
   const labels = teamKey ? (labelsByTeam[teamKey] ?? []) : [];

--- a/apps/web/components/linear/linear-link-button.tsx
+++ b/apps/web/components/linear/linear-link-button.tsx
@@ -18,7 +18,7 @@ type LinearLinkButtonProps = {
 // LinearLinkButton attaches a Linear issue to an existing task by prepending
 // the identifier to its title ("ENG-123: ...").
 export function LinearLinkButton({ taskId, workspaceId, taskTitle }: LinearLinkButtonProps) {
-  const available = useLinearAvailable();
+  const available = useLinearAvailable(workspaceId);
 
   const buildLinkedTitle = useCallback(
     (key: string) => {
@@ -44,7 +44,7 @@ export function LinearLinkButton({ taskId, workspaceId, taskTitle }: LinearLinkB
       // a failure on either surfaces as the popover's inline error instead of
       // an unhandled rejection.
       fetch={async (key) => {
-        const issue = await getLinearIssue(key);
+        const issue = await getLinearIssue(key, { workspaceId });
         await updateTask(taskId, { title: buildLinkedTitle(key) });
         return issue;
       }}

--- a/apps/web/components/linear/linear-settings.tsx
+++ b/apps/web/components/linear/linear-settings.tsx
@@ -17,6 +17,7 @@ import {
   IntegrationAuthStatusBanner,
   type IntegrationAuthHealth,
 } from "@/components/integrations/auth-status-banner";
+import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
 import {
   getLinearConfig,
@@ -203,13 +204,20 @@ function ActionBar({
 }
 
 type SettingsActionsArgs = {
+  workspaceId: string;
   form: FormState;
   setConfig: (cfg: LinearConfig | null) => void;
   setForm: (form: FormState) => void;
   setTestResult: (r: TestLinearConnectionResult | null) => void;
 };
 
-function useSettingsActions({ form, setConfig, setForm, setTestResult }: SettingsActionsArgs) {
+function useSettingsActions({
+  workspaceId,
+  form,
+  setConfig,
+  setForm,
+  setTestResult,
+}: SettingsActionsArgs) {
   const { toast } = useToast();
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -218,26 +226,32 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     setTesting(true);
     setTestResult(null);
     try {
-      const res = await testLinearConnection({
-        authMethod: "api_key",
-        secret: form.secret || undefined,
-      });
+      const res = await testLinearConnection(
+        {
+          authMethod: "api_key",
+          secret: form.secret || undefined,
+        },
+        { workspaceId },
+      );
       setTestResult(res);
     } catch (err) {
       setTestResult({ ok: false, error: String(err) });
     } finally {
       setTesting(false);
     }
-  }, [form, setTestResult]);
+  }, [workspaceId, form, setTestResult]);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      const saved = await setLinearConfig({
-        authMethod: "api_key",
-        defaultTeamKey: form.defaultTeamKey,
-        secret: form.secret || undefined,
-      });
+      const saved = await setLinearConfig(
+        {
+          authMethod: "api_key",
+          defaultTeamKey: form.defaultTeamKey,
+          secret: form.secret || undefined,
+        },
+        { workspaceId },
+      );
       setConfig(saved);
       setForm(configToForm(saved));
       setTestResult(null);
@@ -247,12 +261,12 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     } finally {
       setSaving(false);
     }
-  }, [form, toast, setConfig, setForm, setTestResult]);
+  }, [workspaceId, form, toast, setConfig, setForm, setTestResult]);
 
   const handleDelete = useCallback(async () => {
     if (!confirm("Remove Linear configuration?")) return;
     try {
-      await deleteLinearConfig();
+      await deleteLinearConfig({ workspaceId });
       setConfig(null);
       setForm(emptyForm);
       setTestResult(null);
@@ -260,12 +274,16 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     } catch (err) {
       toast({ description: `Delete failed: ${String(err)}`, variant: "error" });
     }
-  }, [toast, setConfig, setForm, setTestResult]);
+  }, [workspaceId, toast, setConfig, setForm, setTestResult]);
 
   return { saving, testing, handleTest, handleSave, handleDelete };
 }
 
-function useTeamsLoader(hasSecret: boolean | undefined, lastOk: boolean | undefined) {
+function useTeamsLoader(
+  workspaceId: string,
+  hasSecret: boolean | undefined,
+  lastOk: boolean | undefined,
+) {
   // `teams === null` means "no fetch attempt yet", so the dropdown can show a
   // "Loading…" placeholder without us calling setState synchronously inside
   // the effect (which the lint rule forbids). Once a fetch settles we always
@@ -278,7 +296,7 @@ function useTeamsLoader(hasSecret: boolean | undefined, lastOk: boolean | undefi
   useEffect(() => {
     if (!hasSecret) return;
     let cancelled = false;
-    listLinearTeams()
+    listLinearTeams({ workspaceId })
       .then((res) => {
         if (!cancelled) setTeams(res.teams ?? []);
       })
@@ -288,23 +306,23 @@ function useTeamsLoader(hasSecret: boolean | undefined, lastOk: boolean | undefi
     return () => {
       cancelled = true;
     };
-  }, [hasSecret, lastOk]);
+  }, [workspaceId, hasSecret, lastOk]);
   return { teams: teams ?? [], loadingTeams: teams === null && !!hasSecret };
 }
 
-function useLinearSettings() {
+function useLinearSettings(workspaceId: string) {
   const { toast } = useToast();
   const [config, setConfig] = useState<LinearConfig | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [loading, setLoading] = useState(true);
   const [testResult, setTestResult] = useState<TestLinearConnectionResult | null>(null);
   const health = configToHealth(config);
-  const { teams, loadingTeams } = useTeamsLoader(config?.hasSecret, config?.lastOk);
+  const { teams, loadingTeams } = useTeamsLoader(workspaceId, config?.hasSecret, config?.lastOk);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const cfg = await getLinearConfig();
+      const cfg = await getLinearConfig({ workspaceId });
       setConfig(cfg);
       setForm(configToForm(cfg));
     } catch (err) {
@@ -312,7 +330,7 @@ function useLinearSettings() {
     } finally {
       setLoading(false);
     }
-  }, [toast]);
+  }, [workspaceId, toast]);
 
   useEffect(() => {
     void load();
@@ -321,14 +339,14 @@ function useLinearSettings() {
   // Background refresh so the auth-health banner picks up new probe results.
   useEffect(() => {
     const id = setInterval(() => {
-      getLinearConfig()
+      getLinearConfig({ workspaceId })
         .then((cfg) => setConfig(cfg))
         .catch(() => {
           /* transient failures are fine — next tick retries */
         });
     }, INTEGRATION_STATUS_REFRESH_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [workspaceId]);
 
   const update = useCallback(
     <K extends keyof FormState>(key: K, value: FormState[K]) =>
@@ -337,6 +355,7 @@ function useLinearSettings() {
   );
 
   const { saving, testing, handleTest, handleSave, handleDelete } = useSettingsActions({
+    workspaceId,
     form,
     setConfig,
     setForm,
@@ -377,11 +396,8 @@ function EnabledPill() {
   );
 }
 
-// LinearConnectionSection holds the install-wide credentials form. Linear has
-// no per-workspace state to surface here today, so the page composes only this
-// section.
-export function LinearConnectionSection() {
-  const s = useLinearSettings();
+export function LinearConnectionSection({ workspaceId }: { workspaceId: string }) {
+  const s = useLinearSettings(workspaceId);
   const missingSecret = !s.config?.hasSecret && !s.form.secret;
   const disableSave = s.saving || missingSecret;
   const disableTest = missingSecret;
@@ -390,7 +406,7 @@ export function LinearConnectionSection() {
     <SettingsSection
       icon={<IconHexagon className="h-5 w-5" />}
       title="Linear integration"
-      description="Connect Kandev to Linear with a personal API key. Credentials are stored encrypted server-side and shared across all workspaces."
+      description="Connect this workspace to Linear with a personal API key. Credentials are stored encrypted server-side for the selected workspace."
       action={<EnabledPill />}
     >
       <Card>
@@ -432,7 +448,9 @@ export function LinearConnectionSection() {
 export function LinearIntegrationPage() {
   return (
     <div className="space-y-8">
-      <LinearConnectionSection />
+      <WorkspaceScopedSection>
+        {(workspaceId) => <LinearConnectionSection key={workspaceId} workspaceId={workspaceId} />}
+      </WorkspaceScopedSection>
       <LinearIssueWatchersSection />
     </div>
   );

--- a/apps/web/components/sentry/sentry-issue-button.tsx
+++ b/apps/web/components/sentry/sentry-issue-button.tsx
@@ -5,12 +5,14 @@ import { IconBrandSentry } from "@tabler/icons-react";
 import { Button } from "@kandev/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useSentryAvailable } from "@/hooks/domains/sentry/use-sentry-availability";
+import { useAppStore } from "@/components/state-provider";
 import { SentryIssueDialog } from "./sentry-issue-dialog";
 
 // SentryIssueButton opens the browse/search dialog. It renders nothing when
 // the Sentry integration is not available (toggle off or unauthenticated).
 export function SentryIssueButton() {
-  const available = useSentryAvailable();
+  const workspaceId = useAppStore((s) => s.workspaces.activeId);
+  const available = useSentryAvailable(workspaceId);
   const [open, setOpen] = useState(false);
 
   if (!available) return null;
@@ -31,7 +33,7 @@ export function SentryIssueButton() {
         </TooltipTrigger>
         <TooltipContent>Browse Sentry issues</TooltipContent>
       </Tooltip>
-      <SentryIssueDialog open={open} onOpenChange={setOpen} />
+      <SentryIssueDialog open={open} onOpenChange={setOpen} workspaceId={workspaceId ?? ""} />
     </>
   );
 }

--- a/apps/web/components/sentry/sentry-issue-dialog.tsx
+++ b/apps/web/components/sentry/sentry-issue-dialog.tsx
@@ -51,10 +51,11 @@ const initialFilter: FilterState = {
 type SentryIssueDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  workspaceId?: string;
 };
 
-export function SentryIssueDialog({ open, onOpenChange }: SentryIssueDialogProps) {
-  const dialog = useDialogState(open);
+export function SentryIssueDialog({ open, onOpenChange, workspaceId }: SentryIssueDialogProps) {
+  const dialog = useDialogState(open, workspaceId);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -69,7 +70,7 @@ export function SentryIssueDialog({ open, onOpenChange }: SentryIssueDialogProps
 
 type DialogState = ReturnType<typeof useDialogState>;
 
-function useDialogState(open: boolean) {
+function useDialogState(open: boolean, workspaceId?: string) {
   const [filter, setFilter] = useState<FilterState>(initialFilter);
   const [projects, setProjects] = useState<SentryProject[]>([]);
   const [issues, setIssues] = useState<SentryIssue[]>([]);
@@ -82,7 +83,14 @@ function useDialogState(open: boolean) {
   // out-of-order response from a superseded search can't clobber the list.
   const searchSeq = useRef(0);
 
-  useBrowseProjects(open, configLoaded, setFilter, setConfigLoaded, setProjects);
+  useBrowseProjects({
+    open,
+    workspaceId,
+    loaded: configLoaded,
+    setFilter,
+    setLoaded: setConfigLoaded,
+    setProjects,
+  });
 
   const updateFilter = useCallback(
     <K extends keyof FilterState>(key: K, value: FilterState[K]) =>
@@ -101,7 +109,11 @@ function useDialogState(open: boolean) {
       setError(null);
       try {
         const payload = toSearchFilter(filter);
-        const res = await searchSentryIssues(payload, nextCursorValue);
+        const res = await searchSentryIssues(
+          payload,
+          nextCursorValue,
+          workspaceId ? { workspaceId } : undefined,
+        );
         // A newer search started while this one was in flight — drop the result.
         if (seq !== searchSeq.current) return;
         const page = res.issues ?? [];
@@ -116,7 +128,7 @@ function useDialogState(open: boolean) {
         if (seq === searchSeq.current) setLoading(false);
       }
     },
-    [filter],
+    [workspaceId, filter],
   );
 
   return {
@@ -144,13 +156,23 @@ function toSearchFilter(filter: FilterState): SentrySearchFilter {
   };
 }
 
-function useBrowseProjects(
-  open: boolean,
-  loaded: boolean,
-  setFilter: (f: (prev: FilterState) => FilterState) => void,
-  setLoaded: (v: boolean) => void,
-  setProjects: (p: SentryProject[]) => void,
-) {
+type BrowseProjectsArgs = {
+  open: boolean;
+  workspaceId: string | undefined;
+  loaded: boolean;
+  setFilter: (f: (prev: FilterState) => FilterState) => void;
+  setLoaded: (v: boolean) => void;
+  setProjects: (p: SentryProject[]) => void;
+};
+
+function useBrowseProjects({
+  open,
+  workspaceId,
+  loaded,
+  setFilter,
+  setLoaded,
+  setProjects,
+}: BrowseProjectsArgs) {
   useEffect(() => {
     // Reset when the dialog closes so reopening (component stays mounted)
     // refetches projects rather than showing a stale snapshot.
@@ -162,9 +184,11 @@ function useBrowseProjects(
     let cancelled = false;
     (async () => {
       try {
-        const res = await listSentryProjects().catch(() => ({
-          projects: [] as SentryProject[],
-        }));
+        const res = await listSentryProjects(workspaceId ? { workspaceId } : undefined).catch(
+          () => ({
+            projects: [] as SentryProject[],
+          }),
+        );
         if (cancelled) return;
         const projects = res.projects ?? [];
         setProjects(projects);
@@ -181,7 +205,7 @@ function useBrowseProjects(
     return () => {
       cancelled = true;
     };
-  }, [open, loaded, setFilter, setLoaded, setProjects]);
+  }, [open, workspaceId, loaded, setFilter, setLoaded, setProjects]);
 }
 
 function FiltersBar({ state }: { state: DialogState }) {

--- a/apps/web/components/sentry/sentry-issue-watch-dialog.tsx
+++ b/apps/web/components/sentry/sentry-issue-watch-dialog.tsx
@@ -85,11 +85,11 @@ function useFormData(workspaceId: string) {
   return { workflows, agentProfiles: filteredAgentProfiles, allExecutorProfiles };
 }
 
-function useSentryProjects(orgSlug: string) {
+function useSentryProjects(workspaceId: string, orgSlug: string) {
   const [projects, setProjects] = useState<SentryProject[]>([]);
   useEffect(() => {
     let cancelled = false;
-    listSentryProjects()
+    listSentryProjects({ workspaceId })
       .then((res) => {
         if (!cancelled) setProjects(res.projects ?? []);
       })
@@ -99,7 +99,7 @@ function useSentryProjects(orgSlug: string) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [workspaceId]);
   // Sentry's auth-token endpoint already filters to the user's accessible orgs;
   // if an orgSlug is set, restrict to projects that match.
   return useMemo(
@@ -194,7 +194,7 @@ function FilterFields({
   setForm: FormSetter;
   orgs: string[];
 }) {
-  const projects = useSentryProjects(form.orgSlug);
+  const projects = useSentryProjects(form.workspaceId, form.orgSlug);
   const toggleLevel = useCallback(
     (level: SentryLevel) =>
       setForm((p) => ({
@@ -428,12 +428,12 @@ function savingLabel(saving: boolean, isEdit: boolean): string {
 
 // useWatchOrgs loads the org list for the org dropdown and auto-selects the
 // sole org on a fresh create (with one choice there is nothing to pick).
-function useWatchOrgs(open: boolean, hasWatch: boolean, setForm: FormSetter) {
+function useWatchOrgs(open: boolean, workspaceId: string, hasWatch: boolean, setForm: FormSetter) {
   const [orgs, setOrgs] = useState<string[]>([]);
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    listSentryOrganizations()
+    listSentryOrganizations({ workspaceId })
       .then((res) => {
         if (!cancelled) setOrgs((res.organizations ?? []).map((o) => o.slug));
       })
@@ -443,7 +443,7 @@ function useWatchOrgs(open: boolean, hasWatch: boolean, setForm: FormSetter) {
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, workspaceId]);
   useEffect(() => {
     if (hasWatch || orgs.length !== 1) return;
     setForm((p) => (p.orgSlug ? p : { ...p, orgSlug: orgs[0] }));
@@ -471,7 +471,7 @@ export function SentryIssueWatchDialog({
     }
   }, [watch, open, workspaceId, activeWorkspaceId]);
 
-  const orgs = useWatchOrgs(open, !!watch, setForm);
+  const orgs = useWatchOrgs(open, form.workspaceId, !!watch, setForm);
 
   const workspaceLocked = !!watch || !!workspaceId;
 

--- a/apps/web/components/sentry/sentry-link-button.tsx
+++ b/apps/web/components/sentry/sentry-link-button.tsx
@@ -18,7 +18,7 @@ type SentryLinkButtonProps = {
 // SentryLinkButton attaches a Sentry issue to an existing task by prepending
 // its short ID to the title ("PROJ-123: ...").
 export function SentryLinkButton({ taskId, workspaceId, taskTitle }: SentryLinkButtonProps) {
-  const available = useSentryAvailable();
+  const available = useSentryAvailable(workspaceId);
 
   const buildLinkedTitle = useCallback(
     (key: string) => {
@@ -49,7 +49,7 @@ export function SentryLinkButton({ taskId, workspaceId, taskTitle }: SentryLinkB
       }}
       validationHint="Paste a Sentry issue URL or short ID (PROJ-123)"
       fetch={async (key) => {
-        const issue = await getSentryIssue(key);
+        const issue = await getSentryIssue(key, { workspaceId });
         await updateTask(taskId, { title: buildLinkedTitle(key) });
         return issue;
       }}

--- a/apps/web/components/sentry/sentry-settings.tsx
+++ b/apps/web/components/sentry/sentry-settings.tsx
@@ -17,6 +17,7 @@ import {
   IntegrationAuthStatusBanner,
   type IntegrationAuthHealth,
 } from "@/components/integrations/auth-status-banner";
+import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
 import {
   fetchSentryConfig,
@@ -234,13 +235,20 @@ function ActionBar({
 }
 
 type SettingsActionsArgs = {
+  workspaceId: string;
   form: FormState;
   setConfig: (cfg: SentryConfig | null) => void;
   setForm: (form: FormState) => void;
   setTestResult: (r: TestSentryConnectionResult | null) => void;
 };
 
-function useSettingsActions({ form, setConfig, setForm, setTestResult }: SettingsActionsArgs) {
+function useSettingsActions({
+  workspaceId,
+  form,
+  setConfig,
+  setForm,
+  setTestResult,
+}: SettingsActionsArgs) {
   const { toast } = useToast();
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -249,23 +257,28 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     setTesting(true);
     setTestResult(null);
     try {
-      const res = await testSentryConnection(form.secret || undefined, form.url || undefined);
+      const res = await testSentryConnection(form.secret || undefined, form.url || undefined, {
+        workspaceId,
+      });
       setTestResult(res);
     } catch (err) {
       setTestResult({ ok: false, error: String(err) });
     } finally {
       setTesting(false);
     }
-  }, [form, setTestResult]);
+  }, [workspaceId, form, setTestResult]);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      const saved = await saveSentryConfig({
-        authMethod: SENTRY_AUTH_METHOD,
-        url: form.url,
-        secret: form.secret,
-      });
+      const saved = await saveSentryConfig(
+        {
+          authMethod: SENTRY_AUTH_METHOD,
+          url: form.url,
+          secret: form.secret,
+        },
+        { workspaceId },
+      );
       setConfig(saved);
       setForm(configToForm(saved));
       setTestResult(null);
@@ -275,12 +288,12 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     } finally {
       setSaving(false);
     }
-  }, [form, toast, setConfig, setForm, setTestResult]);
+  }, [workspaceId, form, toast, setConfig, setForm, setTestResult]);
 
   const handleDelete = useCallback(async () => {
     if (!confirm("Remove Sentry configuration?")) return;
     try {
-      await deleteSentryConfig();
+      await deleteSentryConfig({ workspaceId });
       setConfig(null);
       setForm(emptyForm);
       setTestResult(null);
@@ -288,12 +301,12 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     } catch (err) {
       toast({ description: `Delete failed: ${String(err)}`, variant: "error" });
     }
-  }, [toast, setConfig, setForm, setTestResult]);
+  }, [workspaceId, toast, setConfig, setForm, setTestResult]);
 
   return { saving, testing, handleTest, handleSave, handleDelete };
 }
 
-function useSentrySettings() {
+function useSentrySettings(workspaceId: string) {
   const { toast } = useToast();
   const [config, setConfig] = useState<SentryConfig | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
@@ -304,7 +317,7 @@ function useSentrySettings() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const cfg = (await fetchSentryConfig()) ?? null;
+      const cfg = (await fetchSentryConfig({ workspaceId })) ?? null;
       setConfig(cfg);
       setForm(configToForm(cfg));
     } catch (err) {
@@ -312,7 +325,7 @@ function useSentrySettings() {
     } finally {
       setLoading(false);
     }
-  }, [toast]);
+  }, [workspaceId, toast]);
 
   useEffect(() => {
     void load();
@@ -320,14 +333,14 @@ function useSentrySettings() {
 
   useEffect(() => {
     const id = setInterval(() => {
-      fetchSentryConfig()
+      fetchSentryConfig({ workspaceId })
         .then((cfg) => setConfig(cfg ?? null))
         .catch(() => {
           /* transient failures are fine — next tick retries */
         });
     }, INTEGRATION_STATUS_REFRESH_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [workspaceId]);
 
   const update = useCallback(
     <K extends keyof FormState>(key: K, value: FormState[K]) =>
@@ -336,6 +349,7 @@ function useSentrySettings() {
   );
 
   const { saving, testing, handleTest, handleSave, handleDelete } = useSettingsActions({
+    workspaceId,
     form,
     setConfig,
     setForm,
@@ -374,8 +388,8 @@ function EnabledPill() {
   );
 }
 
-export function SentryConnectionSection() {
-  const s = useSentrySettings();
+export function SentryConnectionSection({ workspaceId }: { workspaceId: string }) {
+  const s = useSentrySettings(workspaceId);
   const missingSecret = !s.config?.hasSecret && !s.form.secret;
   const disableSave = s.saving || missingSecret;
   const disableTest = missingSecret;
@@ -384,7 +398,7 @@ export function SentryConnectionSection() {
     <SettingsSection
       icon={<IconBrandSentry className="h-5 w-5" />}
       title="Sentry integration"
-      description="Connect Kandev to Sentry with a user auth token. Credentials are stored encrypted server-side and shared across all workspaces."
+      description="Connect this workspace to Sentry with a user auth token. Credentials are stored encrypted server-side for the selected workspace."
       action={<EnabledPill />}
     >
       <Card>
@@ -419,7 +433,9 @@ export function SentryConnectionSection() {
 export function SentryIntegrationPage() {
   return (
     <div className="space-y-8">
-      <SentryConnectionSection />
+      <WorkspaceScopedSection>
+        {(workspaceId) => <SentryConnectionSection key={workspaceId} workspaceId={workspaceId} />}
+      </WorkspaceScopedSection>
       <SentryIssueWatchersSection />
     </div>
   );

--- a/apps/web/components/settings/settings-layout-client.tsx
+++ b/apps/web/components/settings/settings-layout-client.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useCallback } from "react";
 import { usePathname } from "@/lib/routing/client-router";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { PageTopbar } from "@/components/page-topbar";
+import { useAppStore } from "@/components/state-provider";
+import { WorkspaceSwitcher } from "@/components/task/workspace-switcher";
+import { updateUserSettings } from "@/lib/api";
 
 // Brand/initialism overrides so the derived label matches how the rest of the
 // app spells these (e.g. "github" → "GitHub", not "Github"). Anything not
@@ -71,10 +75,17 @@ function deriveParents(pathname: string): Array<{ label: string; href: string }>
 export function SettingsLayoutClient({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isAgentDetail = pathname.startsWith("/settings/agents/") && pathname !== "/settings/agents";
+  const showWorkspaceSwitcher = pathname.startsWith("/settings/integrations");
 
   if (isAgentDetail) {
     return (
-      <SettingsShell title="Agent" backHref="/settings/agents" backLabel="Agents" parents={[]}>
+      <SettingsShell
+        title="Agent"
+        backHref="/settings/agents"
+        backLabel="Agents"
+        parents={[]}
+        showWorkspaceSwitcher={showWorkspaceSwitcher}
+      >
         {children}
       </SettingsShell>
     );
@@ -85,9 +96,38 @@ export function SettingsLayoutClient({ children }: { children: React.ReactNode }
   const parents = deriveParents(pathname);
 
   return (
-    <SettingsShell title={title} backHref="/" backLabel="Kandev" parents={parents}>
+    <SettingsShell
+      title={title}
+      backHref="/"
+      backLabel="Kandev"
+      parents={parents}
+      showWorkspaceSwitcher={showWorkspaceSwitcher}
+    >
       {children}
     </SettingsShell>
+  );
+}
+
+function IntegrationWorkspaceSwitcher() {
+  const workspaces = useAppStore((s) => s.workspaces.items);
+  const activeId = useAppStore((s) => s.workspaces.activeId);
+  const setActiveWorkspace = useAppStore((s) => s.setActiveWorkspace);
+  const selected = activeId ?? workspaces[0]?.id ?? null;
+
+  const onSelect = useCallback(
+    (workspaceId: string) => {
+      setActiveWorkspace(workspaceId);
+      void updateUserSettings({ workspace_id: workspaceId }).catch(() => undefined);
+    },
+    [setActiveWorkspace],
+  );
+
+  if (workspaces.length === 0) return null;
+
+  return (
+    <div data-testid="integration-workspace-switcher">
+      <WorkspaceSwitcher workspaces={workspaces} activeWorkspaceId={selected} onSelect={onSelect} />
+    </div>
   );
 }
 
@@ -96,12 +136,14 @@ function SettingsShell({
   backHref,
   backLabel,
   parents,
+  showWorkspaceSwitcher,
   children,
 }: {
   title: string;
   backHref: string;
   backLabel: string;
   parents: Array<{ label: string; href: string }>;
+  showWorkspaceSwitcher: boolean;
   children: React.ReactNode;
 }) {
   return (
@@ -113,6 +155,7 @@ function SettingsShell({
           backLabel={backLabel}
           parents={parents}
           className="h-10"
+          actions={showWorkspaceSwitcher ? <IntegrationWorkspaceSwitcher /> : undefined}
         />
         {/* Scroll the content, not the topbar: min-h-0 lets this flex child
             shrink below its content height so overflow-y-auto can take effect. */}

--- a/apps/web/components/settings/settings-layout-client.tsx
+++ b/apps/web/components/settings/settings-layout-client.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { usePathname } from "@/lib/routing/client-router";
 import { TooltipProvider } from "@kandev/ui/tooltip";
 import { PageTopbar } from "@/components/page-topbar";
 import { useAppStore } from "@/components/state-provider";
 import { WorkspaceSwitcher } from "@/components/task/workspace-switcher";
-import { updateUserSettings } from "@/lib/api";
+import { createQueuedUserSettingsSync } from "@/lib/user-settings-sync";
+
+const WORKSPACE_SYNC_FAILED_KEY = "kandev:settings:integration-workspace:sync-failed:v1";
 
 // Brand/initialism overrides so the derived label matches how the rest of the
 // app spells these (e.g. "github" → "GitHub", not "Github"). Anything not
@@ -113,13 +115,20 @@ function IntegrationWorkspaceSwitcher() {
   const activeId = useAppStore((s) => s.workspaces.activeId);
   const setActiveWorkspace = useAppStore((s) => s.setActiveWorkspace);
   const selected = activeId ?? workspaces[0]?.id ?? null;
+  const persistWorkspace = useMemo(
+    () =>
+      createQueuedUserSettingsSync<string>(WORKSPACE_SYNC_FAILED_KEY, (workspaceId) => ({
+        workspace_id: workspaceId,
+      })),
+    [],
+  );
 
   const onSelect = useCallback(
     (workspaceId: string) => {
       setActiveWorkspace(workspaceId);
-      void updateUserSettings({ workspace_id: workspaceId }).catch(() => undefined);
+      void persistWorkspace(workspaceId);
     },
-    [setActiveWorkspace],
+    [persistWorkspace, setActiveWorkspace],
   );
 
   if (workspaces.length === 0) return null;

--- a/apps/web/components/slack/slack-settings.tsx
+++ b/apps/web/components/slack/slack-settings.tsx
@@ -18,6 +18,7 @@ import {
   IntegrationAuthStatusBanner,
   type IntegrationAuthHealth,
 } from "@/components/integrations/auth-status-banner";
+import { WorkspaceScopedSection } from "@/components/integrations/workspace-scoped-section";
 import { INTEGRATION_STATUS_REFRESH_MS } from "@/hooks/domains/integrations/use-integration-availability";
 import {
   getSlackConfig,
@@ -373,13 +374,20 @@ function useUtilityAgentsLoader() {
 }
 
 type SettingsActionsArgs = {
+  workspaceId: string;
   form: FormState;
   setConfig: (cfg: SlackConfig | null) => void;
   setForm: (form: FormState) => void;
   setTestResult: (r: TestSlackConnectionResult | null) => void;
 };
 
-function useSettingsActions({ form, setConfig, setForm, setTestResult }: SettingsActionsArgs) {
+function useSettingsActions({
+  workspaceId,
+  form,
+  setConfig,
+  setForm,
+  setTestResult,
+}: SettingsActionsArgs) {
   const { toast } = useToast();
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -389,33 +397,39 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     setTesting(true);
     setTestResult(null);
     try {
-      const res = await testSlackConnection({
-        authMethod: "cookie",
-        utilityAgentId: form.utilityAgentId,
-        commandPrefix: form.commandPrefix,
-        pollIntervalSeconds: form.pollIntervalSeconds,
-        token: form.token || undefined,
-        cookie: form.cookie || undefined,
-      });
+      const res = await testSlackConnection(
+        {
+          authMethod: "cookie",
+          utilityAgentId: form.utilityAgentId,
+          commandPrefix: form.commandPrefix,
+          pollIntervalSeconds: form.pollIntervalSeconds,
+          token: form.token || undefined,
+          cookie: form.cookie || undefined,
+        },
+        { workspaceId },
+      );
       setTestResult(res);
     } catch (err) {
       setTestResult({ ok: false, error: String(err) });
     } finally {
       setTesting(false);
     }
-  }, [form, setTestResult]);
+  }, [workspaceId, form, setTestResult]);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
     try {
-      const saved = await setSlackConfig({
-        authMethod: "cookie",
-        utilityAgentId: form.utilityAgentId,
-        commandPrefix: form.commandPrefix,
-        pollIntervalSeconds: form.pollIntervalSeconds,
-        token: form.token || undefined,
-        cookie: form.cookie || undefined,
-      });
+      const saved = await setSlackConfig(
+        {
+          authMethod: "cookie",
+          utilityAgentId: form.utilityAgentId,
+          commandPrefix: form.commandPrefix,
+          pollIntervalSeconds: form.pollIntervalSeconds,
+          token: form.token || undefined,
+          cookie: form.cookie || undefined,
+        },
+        { workspaceId },
+      );
       setConfig(saved);
       setForm(configToForm(saved));
       setTestResult(null);
@@ -425,13 +439,13 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     } finally {
       setSaving(false);
     }
-  }, [form, toast, setConfig, setForm, setTestResult]);
+  }, [workspaceId, form, toast, setConfig, setForm, setTestResult]);
 
   const handleDelete = useCallback(async () => {
     if (!confirm("Remove Slack configuration?")) return;
     setDeleting(true);
     try {
-      await deleteSlackConfig();
+      await deleteSlackConfig({ workspaceId });
       setConfig(null);
       setForm(emptyForm);
       setTestResult(null);
@@ -441,12 +455,12 @@ function useSettingsActions({ form, setConfig, setForm, setTestResult }: Setting
     } finally {
       setDeleting(false);
     }
-  }, [toast, setConfig, setForm, setTestResult]);
+  }, [workspaceId, toast, setConfig, setForm, setTestResult]);
 
   return { saving, testing, deleting, handleTest, handleSave, handleDelete };
 }
 
-function useSlackSettings() {
+function useSlackSettings(workspaceId: string) {
   const { toast } = useToast();
   const [config, setConfig] = useState<SlackConfig | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
@@ -458,7 +472,7 @@ function useSlackSettings() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const cfg = await getSlackConfig();
+      const cfg = await getSlackConfig({ workspaceId });
       setConfig(cfg);
       setForm(configToForm(cfg));
     } catch (err) {
@@ -466,7 +480,7 @@ function useSlackSettings() {
     } finally {
       setLoading(false);
     }
-  }, [toast]);
+  }, [workspaceId, toast]);
 
   useEffect(() => {
     void load();
@@ -475,14 +489,14 @@ function useSlackSettings() {
   // Background refresh so the auth-health banner picks up new probe results.
   useEffect(() => {
     const id = setInterval(() => {
-      getSlackConfig()
+      getSlackConfig({ workspaceId })
         .then((cfg) => setConfig(cfg))
         .catch(() => {
           /* transient failures are fine — next tick retries */
         });
     }, INTEGRATION_STATUS_REFRESH_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [workspaceId]);
 
   const update = useCallback(
     <K extends keyof FormState>(key: K, value: FormState[K]) =>
@@ -491,6 +505,7 @@ function useSlackSettings() {
   );
 
   const { saving, testing, deleting, handleTest, handleSave, handleDelete } = useSettingsActions({
+    workspaceId,
     form,
     setConfig,
     setForm,
@@ -532,8 +547,8 @@ function EnabledPill() {
   );
 }
 
-export function SlackConnectionSection() {
-  const s = useSlackSettings();
+export function SlackConnectionSection({ workspaceId }: { workspaceId: string }) {
+  const s = useSlackSettings(workspaceId);
   const missingSecrets =
     (!s.config?.hasToken && !s.form.token) || (!s.config?.hasCookie && !s.form.cookie);
   const missingAgent = !s.form.utilityAgentId;
@@ -544,7 +559,7 @@ export function SlackConnectionSection() {
     <SettingsSection
       icon={<IconBrandSlack className="h-5 w-5" />}
       title="Slack integration"
-      description="Capture Slack threads as Kandev tasks. Type !kandev <instruction> in any thread you can see and the configured utility agent picks the workspace/workflow/repo and creates the task."
+      description="Capture Slack threads as tasks for the selected workspace. Type !kandev <instruction> in any thread you can see and the configured utility agent creates the task."
       action={<EnabledPill />}
     >
       <Card>
@@ -591,7 +606,9 @@ export function SlackConnectionSection() {
 export function SlackIntegrationPage() {
   return (
     <div className="space-y-8">
-      <SlackConnectionSection />
+      <WorkspaceScopedSection>
+        {(workspaceId) => <SlackConnectionSection key={workspaceId} workspaceId={workspaceId} />}
+      </WorkspaceScopedSection>
     </div>
   );
 }

--- a/apps/web/components/task/task-top-bar.tsx
+++ b/apps/web/components/task/task-top-bar.tsx
@@ -128,8 +128,8 @@ function IssueTrackerButtons({
   workspaceId: string | null | undefined;
   taskTitle: string | null | undefined;
 }) {
-  const jiraAvailable = useJiraAvailable();
-  const linearAvailable = useLinearAvailable();
+  const jiraAvailable = useJiraAvailable(workspaceId);
+  const linearAvailable = useLinearAvailable(workspaceId);
   const jiraKey = extractJiraKey(taskTitle);
   const linearKey = extractLinearKey(taskTitle);
 

--- a/apps/web/components/task/workspace-switcher.tsx
+++ b/apps/web/components/task/workspace-switcher.tsx
@@ -43,15 +43,15 @@ export function WorkspaceSwitcher({
           type="button"
           title="Switch Workspace"
           className={cn(
-            "group flex items-center gap-1 text-sm font-medium cursor-pointer",
+            "group flex h-8 items-center gap-1.5 rounded-md border bg-background px-2.5 text-sm font-medium cursor-pointer",
             "text-muted-foreground hover:text-foreground transition-colors duration-150",
-            "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           )}
         >
           <span className="truncate">{selectedWorkspace?.name || "Workspace"}</span>
           <IconChevronDown
             className={cn(
-              "h-3.5 w-3.5 shrink-0 opacity-0 group-hover:opacity-50 transition-opacity duration-150",
+              "h-3.5 w-3.5 shrink-0 opacity-60 group-hover:opacity-80 transition-opacity duration-150",
             )}
           />
         </button>

--- a/apps/web/e2e/fixtures/test-base.ts
+++ b/apps/web/e2e/fixtures/test-base.ts
@@ -193,12 +193,22 @@ export const test = backendFixture.extend<
   },
 
   integrationCleanup: [
-    async ({ apiClient }, use) => {
+    async ({ apiClient, seedData }, use) => {
+      const scoped = `workspace_id=${encodeURIComponent(seedData.workspaceId)}`;
+      await apiClient.rawRequest("DELETE", `/api/v1/jira/config?${scoped}`).catch(() => undefined);
+      await apiClient
+        .rawRequest("DELETE", `/api/v1/linear/config?${scoped}`)
+        .catch(() => undefined);
+      await apiClient
+        .rawRequest("DELETE", `/api/v1/sentry/config?${scoped}`)
+        .catch(() => undefined);
       await apiClient.rawRequest("DELETE", `/api/v1/jira/config`).catch(() => undefined);
       await apiClient.rawRequest("DELETE", `/api/v1/linear/config`).catch(() => undefined);
+      await apiClient.rawRequest("DELETE", `/api/v1/sentry/config`).catch(() => undefined);
       await Promise.all([
         apiClient.mockJiraReset().catch(() => undefined),
         apiClient.mockLinearReset().catch(() => undefined),
+        apiClient.mockSentryReset().catch(() => undefined),
       ]);
       await use();
     },

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -209,6 +209,21 @@ export class ApiClient {
     return res.json() as Promise<T>;
   }
 
+  private async activeWorkspaceId(): Promise<string | undefined> {
+    const { settings } = await this.getUserSettings();
+    const workspaceId = settings.workspace_id;
+    return typeof workspaceId === "string" && workspaceId.trim() !== ""
+      ? workspaceId.trim()
+      : undefined;
+  }
+
+  private async withActiveWorkspace(path: string, workspaceId?: string): Promise<string> {
+    const resolved = workspaceId?.trim() || (await this.activeWorkspaceId());
+    if (!resolved) return path;
+    const separator = path.includes("?") ? "&" : "?";
+    return `${path}${separator}workspace_id=${encodeURIComponent(resolved)}`;
+  }
+
   async healthCheck(): Promise<void> {
     await this.request("GET", "/health");
   }
@@ -1433,18 +1448,27 @@ export class ApiClient {
     instanceType?: "cloud" | "server";
     defaultProjectKey?: string;
     secret: string;
+    workspaceId?: string;
   }): Promise<unknown> {
-    return this.request("POST", "/api/v1/jira/config", {
-      ...payload,
+    const { workspaceId, ...config } = payload;
+    const path = await this.withActiveWorkspace("/api/v1/jira/config", workspaceId);
+    return this.request("POST", path, {
+      ...config,
       authMethod: payload.authMethod ?? "api_token",
       instanceType: payload.instanceType ?? "cloud",
     });
   }
 
-  async setLinearConfig(payload: { secret: string; defaultTeamKey?: string }): Promise<unknown> {
-    return this.request("POST", "/api/v1/linear/config", {
+  async setLinearConfig(payload: {
+    secret: string;
+    defaultTeamKey?: string;
+    workspaceId?: string;
+  }): Promise<unknown> {
+    const { workspaceId, ...config } = payload;
+    const path = await this.withActiveWorkspace("/api/v1/linear/config", workspaceId);
+    return this.request("POST", path, {
       defaultTeamKey: "",
-      ...payload,
+      ...config,
       authMethod: "api_key",
     });
   }
@@ -1458,11 +1482,14 @@ export class ApiClient {
    */
   async waitForIntegrationAuthHealthy(
     integration: "jira" | "linear" | "sentry",
-    timeoutMs = 5_000,
+    options: number | { timeoutMs?: number; workspaceId?: string } = 5_000,
   ): Promise<void> {
+    const timeoutMs = typeof options === "number" ? options : (options.timeoutMs ?? 5_000);
+    const workspaceId = typeof options === "number" ? undefined : options.workspaceId;
+    const path = await this.withActiveWorkspace(`/api/v1/${integration}/config`, workspaceId);
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      const res = await this.rawRequest("GET", `/api/v1/${integration}/config`);
+      const res = await this.rawRequest("GET", path);
       if (res.ok && res.status === 200) {
         const cfg = (await res.json()) as { hasSecret?: boolean; lastOk?: boolean };
         if (cfg.hasSecret && cfg.lastOk) return;
@@ -1488,8 +1515,14 @@ export class ApiClient {
     await this.request("PUT", "/api/v1/jira/mock/auth-result", result);
   }
 
-  async mockJiraSetAuthHealth(args: { ok: boolean; error?: string }): Promise<void> {
-    await this.request("PUT", "/api/v1/jira/mock/auth-health", args);
+  async mockJiraSetAuthHealth(args: {
+    ok: boolean;
+    error?: string;
+    workspaceId?: string;
+  }): Promise<void> {
+    const { workspaceId, ...payload } = args;
+    const path = await this.withActiveWorkspace("/api/v1/jira/mock/auth-health", workspaceId);
+    await this.request("PUT", path, payload);
   }
 
   async mockJiraSetProjects(projects: MockJiraProject[]): Promise<void> {
@@ -1547,8 +1580,11 @@ export class ApiClient {
     ok: boolean;
     error?: string;
     orgSlug?: string;
+    workspaceId?: string;
   }): Promise<void> {
-    await this.request("PUT", "/api/v1/linear/mock/auth-health", args);
+    const { workspaceId, ...payload } = args;
+    const path = await this.withActiveWorkspace("/api/v1/linear/mock/auth-health", workspaceId);
+    await this.request("PUT", path, payload);
   }
 
   async mockLinearSetTeams(teams: MockLinearTeam[]): Promise<void> {
@@ -1583,8 +1619,14 @@ export class ApiClient {
     await this.request("PUT", "/api/v1/sentry/mock/auth-result", result);
   }
 
-  async mockSentrySetAuthHealth(args: { ok: boolean; error?: string }): Promise<void> {
-    await this.request("PUT", "/api/v1/sentry/mock/auth-health", args);
+  async mockSentrySetAuthHealth(args: {
+    ok: boolean;
+    error?: string;
+    workspaceId?: string;
+  }): Promise<void> {
+    const { workspaceId, ...payload } = args;
+    const path = await this.withActiveWorkspace("/api/v1/sentry/mock/auth-health", workspaceId);
+    await this.request("PUT", path, payload);
   }
 
   async mockSentrySetOrganizations(organizations: MockSentryOrganization[]): Promise<void> {

--- a/apps/web/e2e/helpers/api-client.ts
+++ b/apps/web/e2e/helpers/api-client.ts
@@ -1343,6 +1343,7 @@ export class ApiClient {
 
   async updateReviewWatch(
     watchId: string,
+    workspaceId: string,
     patch: {
       enabled?: boolean;
       cleanup_policy?: "auto" | "always" | "never";
@@ -1350,11 +1351,18 @@ export class ApiClient {
       repos?: Array<{ owner: string; name: string }>;
     },
   ): Promise<void> {
-    await this.request("PUT", `/api/v1/github/watches/review/${watchId}`, patch);
+    await this.request(
+      "PUT",
+      `/api/v1/github/watches/review/${watchId}?workspace_id=${encodeURIComponent(workspaceId)}`,
+      patch,
+    );
   }
 
-  async deleteReviewWatch(watchId: string): Promise<void> {
-    await this.request("DELETE", `/api/v1/github/watches/review/${watchId}`);
+  async deleteReviewWatch(watchId: string, workspaceId: string): Promise<void> {
+    await this.request(
+      "DELETE",
+      `/api/v1/github/watches/review/${watchId}?workspace_id=${encodeURIComponent(workspaceId)}`,
+    );
   }
 
   async triggerReviewWatch(

--- a/apps/web/e2e/pages/linear-settings-page.ts
+++ b/apps/web/e2e/pages/linear-settings-page.ts
@@ -6,6 +6,7 @@ export class LinearSettingsPage {
   readonly saveButton: Locator;
   readonly deleteButton: Locator;
   readonly statusBanner: Locator;
+  readonly workspaceTrigger: Locator;
 
   constructor(private page: Page) {
     this.secretInput = page.getByTestId("linear-secret-input");
@@ -13,6 +14,9 @@ export class LinearSettingsPage {
     this.saveButton = page.getByTestId("linear-save-button");
     this.deleteButton = page.getByTestId("linear-delete-button");
     this.statusBanner = page.getByTestId("integration-auth-status-banner");
+    this.workspaceTrigger = page
+      .getByTestId("workspace-scoped-selector")
+      .getByTitle("Switch Workspace");
   }
 
   async goto() {

--- a/apps/web/e2e/tests/integrations/github-workspace-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/github-workspace-settings.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "../../fixtures/test-base";
+
+test.describe("GitHub workspace settings", () => {
+  test("repository scope is saved per workspace and filters the GitHub PR list", async ({
+    testPage,
+    apiClient,
+    seedData,
+  }) => {
+    test.setTimeout(90_000);
+
+    await apiClient.mockGitHubReset();
+    await apiClient.mockGitHubSetUser("test-user");
+    await apiClient.mockGitHubAddPRs([
+      {
+        number: 6101,
+        title: "Scoped PR",
+        state: "open",
+        head_branch: "feature/scoped",
+        base_branch: "main",
+        author_login: "contributor",
+        repo_owner: "kdlbs",
+        repo_name: "kandev",
+        requested_reviewers: [{ login: "test-user", type: "User" }],
+      },
+      {
+        number: 6102,
+        title: "Out of scope PR",
+        state: "open",
+        head_branch: "feature/out-of-scope",
+        base_branch: "main",
+        author_login: "contributor",
+        repo_owner: "other",
+        repo_name: "repo",
+        requested_reviewers: [{ login: "test-user", type: "User" }],
+      },
+    ]);
+
+    await testPage.goto("/settings/integrations/github");
+    await expect(testPage.getByTestId("integration-workspace-switcher")).toBeVisible();
+
+    await testPage.getByTestId("github-scope-mode").click();
+    await testPage.getByRole("option", { name: "Selected repositories" }).click();
+    await testPage.getByTestId("github-scope-repos-input").fill("kdlbs/kandev");
+    await testPage.getByTestId("github-scope-save").click();
+    await expect(testPage.getByText("GitHub workspace settings saved")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const settingsResponse = await apiClient.rawRequest(
+      "GET",
+      `/api/v1/github/workspace-settings?workspace_id=${seedData.workspaceId}`,
+    );
+    expect(settingsResponse.status).toBe(200);
+    const settings = (await settingsResponse.json()) as {
+      repo_scope_mode: string;
+      repo_scope_repos: Array<{ owner: string; name: string }>;
+    };
+    expect(settings.repo_scope_mode).toBe("repos");
+    expect(settings.repo_scope_repos).toEqual([{ owner: "kdlbs", name: "kandev" }]);
+
+    await testPage.goto("/github");
+
+    await expect(testPage.getByTestId("pr-row").filter({ hasText: "Scoped PR" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(testPage.getByText("kdlbs/kandev#6101")).toBeVisible();
+    await expect(testPage.getByText("Out of scope PR")).toHaveCount(0);
+    await expect(testPage.getByText("other/repo#6102")).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/tests/integrations/linear-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/linear-settings.spec.ts
@@ -45,6 +45,27 @@ test.describe("Linear settings", () => {
     await expect(testPage.getByText(/leave blank to keep the current value/i)).toBeVisible();
   });
 
+  test("workspace selector scopes the saved credentials form", async ({ testPage, apiClient }) => {
+    const other = await apiClient.createWorkspace("Linear Secondary Workspace");
+    await apiClient.mockLinearSetTeams([{ id: "team-1", key: "ENG", name: "Engineering" }]);
+
+    const settings = new LinearSettingsPage(testPage);
+    await settings.goto();
+
+    await settings.secretInput.fill("lin_api_default");
+    await settings.saveButton.click();
+    await expect(settings.deleteButton).toBeVisible();
+    await expect(testPage.getByText(/leave blank to keep the current value/i)).toBeVisible();
+
+    await settings.workspaceTrigger.click();
+    await testPage.getByRole("menuitem", { name: new RegExp(other.name) }).click();
+
+    await expect(settings.secretInput).toHaveValue("");
+    await expect(settings.saveButton).toBeDisabled();
+    await expect(settings.deleteButton).toHaveCount(0);
+    await expect(testPage.getByText(/leave blank to keep the current value/i)).toHaveCount(0);
+  });
+
   test("test connection surfaces inline success and failure", async ({ testPage, apiClient }) => {
     const settings = new LinearSettingsPage(testPage);
     await settings.goto();

--- a/apps/web/e2e/tests/integrations/mobile-linear-settings.spec.ts
+++ b/apps/web/e2e/tests/integrations/mobile-linear-settings.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "../../fixtures/test-base";
+import { LinearSettingsPage } from "../../pages/linear-settings-page";
+
+test.describe("Linear settings on mobile", () => {
+  test("workspace selector scopes the credentials form", async ({ testPage, apiClient }) => {
+    const other = await apiClient.createWorkspace("Mobile Linear Workspace");
+
+    const settings = new LinearSettingsPage(testPage);
+    await settings.goto();
+
+    await settings.secretInput.fill("lin_api_mobile");
+    await settings.saveButton.click();
+    await expect(testPage.getByText(/leave blank to keep the current value/i)).toBeVisible();
+
+    await settings.workspaceTrigger.click();
+    await testPage.getByRole("menuitem", { name: new RegExp(other.name) }).click();
+
+    await expect(settings.secretInput).toHaveValue("");
+    await expect(settings.saveButton).toBeDisabled();
+    await expect(testPage.getByText(/leave blank to keep the current value/i)).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/tests/pr/pr-watcher-cleanup-policy.spec.ts
+++ b/apps/web/e2e/tests/pr/pr-watcher-cleanup-policy.spec.ts
@@ -385,7 +385,7 @@ test.describe("PR watcher cleanup policy", () => {
 
     // Disable the watch + merge the PR. The disabled watch is invisible to
     // the per-watch loop now, so without the global sweep the task survives.
-    await apiClient.updateReviewWatch(watch.id, { enabled: false });
+    await apiClient.updateReviewWatch(watch.id, watch.workspace_id, { enabled: false });
     await apiClient.mockGitHubAddPRs([
       {
         number: 701,
@@ -463,7 +463,7 @@ test.describe("PR watcher cleanup policy", () => {
     });
 
     // Delete the watch — service cascade should reap the task too.
-    await apiClient.deleteReviewWatch(watch.id);
+    await apiClient.deleteReviewWatch(watch.id, watch.workspace_id);
 
     await expect(kanban.taskCardByTitle("PR #801: Cascade-delete me")).not.toBeVisible({
       timeout: 15_000,

--- a/apps/web/hooks/domains/github/use-issue-watches.ts
+++ b/apps/web/hooks/domains/github/use-issue-watches.ts
@@ -85,8 +85,8 @@ export function useIssueWatches(workspaceId?: string | null) {
     [removeWatch],
   );
 
-  const trigger = useCallback(async (id: string) => {
-    return triggerIssueWatch(id);
+  const trigger = useCallback(async (id: string, watchWorkspaceId: string) => {
+    return triggerIssueWatch(id, watchWorkspaceId);
   }, []);
 
   const triggerAll = useCallback(async () => {

--- a/apps/web/hooks/domains/github/use-issue-watches.ts
+++ b/apps/web/hooks/domains/github/use-issue-watches.ts
@@ -36,7 +36,7 @@ export function useIssueWatches(workspaceId?: string | null) {
   useEffect(() => {
     if (workspaceId === null) return;
     const scopeKey = workspaceId ?? "__all__";
-    if ((loaded || loading) && loadedScopeRef.current === scopeKey) return;
+    if (loadedScopeRef.current === scopeKey) return;
     let cancelled = false;
     loadedScopeRef.current = scopeKey;
     setIssueWatchesLoading(true);
@@ -56,7 +56,7 @@ export function useIssueWatches(workspaceId?: string | null) {
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, loaded, loading, setIssueWatches, setIssueWatchesLoading]);
+  }, [workspaceId, setIssueWatches, setIssueWatchesLoading]);
 
   const create = useCallback(
     async (req: CreateIssueWatchRequest) => {

--- a/apps/web/hooks/domains/github/use-issue-watches.ts
+++ b/apps/web/hooks/domains/github/use-issue-watches.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import {
   listIssueWatches,
   createIssueWatch,
@@ -27,24 +27,36 @@ export function useIssueWatches(workspaceId?: string | null) {
   const addWatch = useAppStore((state) => state.addIssueWatch);
   const updateWatch = useAppStore((state) => state.updateIssueWatch);
   const removeWatch = useAppStore((state) => state.removeIssueWatch);
+  const loadedScopeRef = useRef<string | null>(null);
   // storeApi exposes getState() without subscribing — used in reset() to
   // read the current watch row outside of the React render cycle so the
   // callback doesn't need `items` as a dependency.
   const storeApi = useAppStoreApi();
 
   useEffect(() => {
-    if (workspaceId === null || loaded || loading) return;
+    if (workspaceId === null) return;
+    const scopeKey = workspaceId ?? "__all__";
+    if ((loaded || loading) && loadedScopeRef.current === scopeKey) return;
+    let cancelled = false;
     setIssueWatchesLoading(true);
     listIssueWatches(workspaceId ?? undefined, { cache: "no-store" })
       .then((response) => {
+        if (cancelled) return;
         setIssueWatches(response?.watches ?? []);
+        loadedScopeRef.current = scopeKey;
       })
       .catch(() => {
+        if (cancelled) return;
         setIssueWatches([]);
+        loadedScopeRef.current = scopeKey;
       })
       .finally(() => {
+        if (cancelled) return;
         setIssueWatchesLoading(false);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [workspaceId, loaded, loading, setIssueWatches, setIssueWatchesLoading]);
 
   const create = useCallback(

--- a/apps/web/hooks/domains/github/use-issue-watches.ts
+++ b/apps/web/hooks/domains/github/use-issue-watches.ts
@@ -38,17 +38,16 @@ export function useIssueWatches(workspaceId?: string | null) {
     const scopeKey = workspaceId ?? "__all__";
     if ((loaded || loading) && loadedScopeRef.current === scopeKey) return;
     let cancelled = false;
+    loadedScopeRef.current = scopeKey;
     setIssueWatchesLoading(true);
     listIssueWatches(workspaceId ?? undefined, { cache: "no-store" })
       .then((response) => {
         if (cancelled) return;
         setIssueWatches(response?.watches ?? []);
-        loadedScopeRef.current = scopeKey;
       })
       .catch(() => {
         if (cancelled) return;
         setIssueWatches([]);
-        loadedScopeRef.current = scopeKey;
       })
       .finally(() => {
         if (cancelled) return;
@@ -69,8 +68,8 @@ export function useIssueWatches(workspaceId?: string | null) {
   );
 
   const update = useCallback(
-    async (id: string, req: UpdateIssueWatchRequest) => {
-      const watch = await updateIssueWatch(id, req);
+    async (id: string, watchWorkspaceId: string, req: UpdateIssueWatchRequest) => {
+      const watch = await updateIssueWatch(id, watchWorkspaceId, req);
       updateWatch(watch);
       return watch;
     },
@@ -78,8 +77,8 @@ export function useIssueWatches(workspaceId?: string | null) {
   );
 
   const remove = useCallback(
-    async (id: string) => {
-      await deleteIssueWatch(id);
+    async (id: string, watchWorkspaceId: string) => {
+      await deleteIssueWatch(id, watchWorkspaceId);
       removeWatch(id);
     },
     [removeWatch],

--- a/apps/web/hooks/domains/github/use-review-watches.ts
+++ b/apps/web/hooks/domains/github/use-review-watches.ts
@@ -32,7 +32,7 @@ export function useReviewWatches(workspaceId?: string | null) {
   useEffect(() => {
     if (workspaceId === null) return;
     const scopeKey = workspaceId ?? "__all__";
-    if ((loaded || loading) && loadedScopeRef.current === scopeKey) return;
+    if (loadedScopeRef.current === scopeKey) return;
     let cancelled = false;
     loadedScopeRef.current = scopeKey;
     setReviewWatchesLoading(true);
@@ -52,7 +52,7 @@ export function useReviewWatches(workspaceId?: string | null) {
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, loaded, loading, setReviewWatches, setReviewWatchesLoading]);
+  }, [workspaceId, setReviewWatches, setReviewWatchesLoading]);
 
   const create = useCallback(
     async (req: CreateReviewWatchRequest) => {

--- a/apps/web/hooks/domains/github/use-review-watches.ts
+++ b/apps/web/hooks/domains/github/use-review-watches.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import {
   listReviewWatches,
   createReviewWatch,
@@ -27,20 +27,32 @@ export function useReviewWatches(workspaceId?: string | null) {
   const addWatch = useAppStore((state) => state.addReviewWatch);
   const updateWatch = useAppStore((state) => state.updateReviewWatch);
   const removeWatch = useAppStore((state) => state.removeReviewWatch);
+  const loadedScopeRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (workspaceId === null || loaded || loading) return;
+    if (workspaceId === null) return;
+    const scopeKey = workspaceId ?? "__all__";
+    if ((loaded || loading) && loadedScopeRef.current === scopeKey) return;
+    let cancelled = false;
     setReviewWatchesLoading(true);
     listReviewWatches(workspaceId ?? undefined, { cache: "no-store" })
       .then((response) => {
+        if (cancelled) return;
         setReviewWatches(response?.watches ?? []);
+        loadedScopeRef.current = scopeKey;
       })
       .catch(() => {
+        if (cancelled) return;
         setReviewWatches([]);
+        loadedScopeRef.current = scopeKey;
       })
       .finally(() => {
+        if (cancelled) return;
         setReviewWatchesLoading(false);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [workspaceId, loaded, loading, setReviewWatches, setReviewWatchesLoading]);
 
   const create = useCallback(

--- a/apps/web/hooks/domains/github/use-review-watches.ts
+++ b/apps/web/hooks/domains/github/use-review-watches.ts
@@ -34,17 +34,16 @@ export function useReviewWatches(workspaceId?: string | null) {
     const scopeKey = workspaceId ?? "__all__";
     if ((loaded || loading) && loadedScopeRef.current === scopeKey) return;
     let cancelled = false;
+    loadedScopeRef.current = scopeKey;
     setReviewWatchesLoading(true);
     listReviewWatches(workspaceId ?? undefined, { cache: "no-store" })
       .then((response) => {
         if (cancelled) return;
         setReviewWatches(response?.watches ?? []);
-        loadedScopeRef.current = scopeKey;
       })
       .catch(() => {
         if (cancelled) return;
         setReviewWatches([]);
-        loadedScopeRef.current = scopeKey;
       })
       .finally(() => {
         if (cancelled) return;
@@ -65,8 +64,8 @@ export function useReviewWatches(workspaceId?: string | null) {
   );
 
   const update = useCallback(
-    async (id: string, req: UpdateReviewWatchRequest) => {
-      const watch = await updateReviewWatch(id, req);
+    async (id: string, watchWorkspaceId: string, req: UpdateReviewWatchRequest) => {
+      const watch = await updateReviewWatch(id, watchWorkspaceId, req);
       updateWatch(watch);
       return watch;
     },
@@ -74,8 +73,8 @@ export function useReviewWatches(workspaceId?: string | null) {
   );
 
   const remove = useCallback(
-    async (id: string) => {
-      await deleteReviewWatch(id);
+    async (id: string, watchWorkspaceId: string) => {
+      await deleteReviewWatch(id, watchWorkspaceId);
       removeWatch(id);
     },
     [removeWatch],

--- a/apps/web/hooks/domains/jira/use-jira-availability.ts
+++ b/apps/web/hooks/domains/jira/use-jira-availability.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import { getJiraConfig } from "@/lib/api/domains/jira-api";
 import {
   useIntegrationAuthed,
@@ -7,15 +8,21 @@ import {
 } from "../integrations/use-integration-availability";
 import { useJiraEnabled } from "./use-jira-enabled";
 
-const fetchJiraConfig = () => getJiraConfig();
-
-export function useJiraAuthed(): boolean {
-  return useIntegrationAuthed(fetchJiraConfig);
+export function useJiraAuthed(workspaceId?: string | null): boolean {
+  const fetchConfig = useCallback(
+    () => getJiraConfig(workspaceId ? { workspaceId } : undefined),
+    [workspaceId],
+  );
+  return useIntegrationAuthed(fetchConfig);
 }
 
-export function useJiraAvailable(): boolean {
+export function useJiraAvailable(workspaceId?: string | null): boolean {
+  const fetchConfig = useCallback(
+    () => getJiraConfig(workspaceId ? { workspaceId } : undefined),
+    [workspaceId],
+  );
   return useIntegrationAvailable({
     useEnabled: useJiraEnabled,
-    fetchConfig: fetchJiraConfig,
+    fetchConfig,
   });
 }

--- a/apps/web/hooks/domains/linear/use-linear-availability.ts
+++ b/apps/web/hooks/domains/linear/use-linear-availability.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import { getLinearConfig } from "@/lib/api/domains/linear-api";
 import {
   useIntegrationAuthed,
@@ -7,15 +8,21 @@ import {
 } from "../integrations/use-integration-availability";
 import { useLinearEnabled } from "./use-linear-enabled";
 
-const fetchLinearConfig = () => getLinearConfig();
-
-export function useLinearAuthed(): boolean {
-  return useIntegrationAuthed(fetchLinearConfig);
+export function useLinearAuthed(workspaceId?: string | null): boolean {
+  const fetchConfig = useCallback(
+    () => getLinearConfig(workspaceId ? { workspaceId } : undefined),
+    [workspaceId],
+  );
+  return useIntegrationAuthed(fetchConfig);
 }
 
-export function useLinearAvailable(): boolean {
+export function useLinearAvailable(workspaceId?: string | null): boolean {
+  const fetchConfig = useCallback(
+    () => getLinearConfig(workspaceId ? { workspaceId } : undefined),
+    [workspaceId],
+  );
   return useIntegrationAvailable({
     useEnabled: useLinearEnabled,
-    fetchConfig: fetchLinearConfig,
+    fetchConfig,
   });
 }

--- a/apps/web/hooks/domains/sentry/use-sentry-availability.ts
+++ b/apps/web/hooks/domains/sentry/use-sentry-availability.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import { fetchSentryConfig } from "@/lib/api/domains/sentry-api";
 import {
   useIntegrationAuthed,
@@ -7,15 +8,21 @@ import {
 } from "../integrations/use-integration-availability";
 import { useSentryEnabled } from "./use-sentry-enabled";
 
-const loadSentryConfig = async () => (await fetchSentryConfig()) ?? null;
-
-export function useSentryAuthed(): boolean {
-  return useIntegrationAuthed(loadSentryConfig);
+export function useSentryAuthed(workspaceId?: string | null): boolean {
+  const fetchConfig = useCallback(
+    async () => (await fetchSentryConfig(workspaceId ? { workspaceId } : undefined)) ?? null,
+    [workspaceId],
+  );
+  return useIntegrationAuthed(fetchConfig);
 }
 
-export function useSentryAvailable(): boolean {
+export function useSentryAvailable(workspaceId?: string | null): boolean {
+  const fetchConfig = useCallback(
+    async () => (await fetchSentryConfig(workspaceId ? { workspaceId } : undefined)) ?? null,
+    [workspaceId],
+  );
   return useIntegrationAvailable({
     useEnabled: useSentryEnabled,
-    fetchConfig: loadSentryConfig,
+    fetchConfig,
   });
 }

--- a/apps/web/hooks/domains/slack/use-slack-availability.ts
+++ b/apps/web/hooks/domains/slack/use-slack-availability.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import { getSlackConfig } from "@/lib/api/domains/slack-api";
 import {
   useIntegrationAuthed,
@@ -11,22 +12,25 @@ import { useSlackEnabled } from "./use-slack-enabled";
 // Slack stores two secrets (token + cookie) instead of one — the shared
 // availability hook only checks `hasSecret`, so adapt by reporting authed
 // when *both* halves are present.
-async function fetchSlackStatus(): Promise<IntegrationConfigStatus | null> {
-  const cfg = await getSlackConfig();
-  if (!cfg) return null;
-  return {
-    hasSecret: cfg.hasToken && cfg.hasCookie,
-    lastOk: cfg.lastOk,
-  };
+function useSlackStatusLoader(workspaceId?: string | null) {
+  return useCallback(async (): Promise<IntegrationConfigStatus | null> => {
+    const cfg = await getSlackConfig(workspaceId ? { workspaceId } : undefined);
+    if (!cfg) return null;
+    return {
+      hasSecret: cfg.hasToken && cfg.hasCookie,
+      lastOk: cfg.lastOk,
+    };
+  }, [workspaceId]);
 }
 
-export function useSlackAuthed(): boolean {
-  return useIntegrationAuthed(fetchSlackStatus);
+export function useSlackAuthed(workspaceId?: string | null): boolean {
+  return useIntegrationAuthed(useSlackStatusLoader(workspaceId));
 }
 
-export function useSlackAvailable(): boolean {
+export function useSlackAvailable(workspaceId?: string | null): boolean {
+  const fetchConfig = useSlackStatusLoader(workspaceId);
   return useIntegrationAvailable({
     useEnabled: useSlackEnabled,
-    fetchConfig: fetchSlackStatus,
+    fetchConfig,
   });
 }

--- a/apps/web/lib/api/domains/github-api.ts
+++ b/apps/web/lib/api/domains/github-api.ts
@@ -26,6 +26,8 @@ import type {
   GitHubPRStatus,
   GitHubActionPresets,
   UpdateGitHubActionPresetsRequest,
+  GitHubWorkspaceSettings,
+  UpdateGitHubWorkspaceSettingsRequest,
   CleanupTasksResponse,
   MergeMethod,
   RepoMergeMethods,
@@ -580,6 +582,7 @@ type SearchParams = {
   filter?: string;
   page?: number;
   perPage?: number;
+  workspaceId?: string | null;
 };
 
 function buildSearchQuery(params: SearchParams) {
@@ -588,6 +591,7 @@ function buildSearchQuery(params: SearchParams) {
   if (params.filter) search.set("filter", params.filter);
   if (params.page && params.page > 1) search.set("page", String(params.page));
   if (params.perPage) search.set("per_page", String(params.perPage));
+  if (params.workspaceId) search.set("workspace_id", params.workspaceId);
   return search.toString();
 }
 
@@ -605,6 +609,28 @@ export async function searchUserIssues(params: SearchParams, options?: ApiReques
     `/api/v1/github/user/issues${suffix ? `?${suffix}` : ""}`,
     options,
   );
+}
+
+// Workspace settings for GitHub repo visibility/scope.
+export async function fetchGitHubWorkspaceSettings(
+  workspaceId: string,
+  options?: ApiRequestOptions,
+) {
+  const query = new URLSearchParams({ workspace_id: workspaceId });
+  return fetchJson<GitHubWorkspaceSettings>(
+    `/api/v1/github/workspace-settings?${query.toString()}`,
+    options,
+  );
+}
+
+export async function updateGitHubWorkspaceSettings(
+  payload: UpdateGitHubWorkspaceSettingsRequest,
+  options?: ApiRequestOptions,
+) {
+  return fetchJson<GitHubWorkspaceSettings>("/api/v1/github/workspace-settings", {
+    ...options,
+    init: { ...(options?.init ?? {}), method: "PUT", body: JSON.stringify(payload) },
+  });
 }
 
 // Action presets (quick-launch prompts on the /github page).

--- a/apps/web/lib/api/domains/github-api.ts
+++ b/apps/web/lib/api/domains/github-api.ts
@@ -505,8 +505,13 @@ export async function deleteIssueWatch(id: string, options?: ApiRequestOptions) 
   });
 }
 
-export async function triggerIssueWatch(id: string, options?: ApiRequestOptions) {
-  return fetchJson<TriggerIssueResponse>(`/api/v1/github/watches/issue/${id}/trigger`, {
+export async function triggerIssueWatch(
+  id: string,
+  workspaceId: string,
+  options?: ApiRequestOptions,
+) {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  return fetchJson<TriggerIssueResponse>(`/api/v1/github/watches/issue/${id}/trigger?${params}`, {
     ...options,
     init: { method: "POST", ...(options?.init ?? {}) },
   });

--- a/apps/web/lib/api/domains/github-api.ts
+++ b/apps/web/lib/api/domains/github-api.ts
@@ -260,17 +260,24 @@ export async function createReviewWatch(
 
 export async function updateReviewWatch(
   id: string,
+  workspaceId: string,
   payload: UpdateReviewWatchRequest,
   options?: ApiRequestOptions,
 ) {
-  return fetchJson<ReviewWatch>(`/api/v1/github/watches/review/${id}`, {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  return fetchJson<ReviewWatch>(`/api/v1/github/watches/review/${id}?${params}`, {
     ...options,
     init: { method: "PUT", body: JSON.stringify(payload), ...(options?.init ?? {}) },
   });
 }
 
-export async function deleteReviewWatch(id: string, options?: ApiRequestOptions) {
-  return fetchJson<{ success: boolean }>(`/api/v1/github/watches/review/${id}`, {
+export async function deleteReviewWatch(
+  id: string,
+  workspaceId: string,
+  options?: ApiRequestOptions,
+) {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  return fetchJson<{ success: boolean }>(`/api/v1/github/watches/review/${id}?${params}`, {
     ...options,
     init: { method: "DELETE", ...(options?.init ?? {}) },
   });
@@ -489,17 +496,24 @@ export async function createIssueWatch(
 
 export async function updateIssueWatch(
   id: string,
+  workspaceId: string,
   payload: UpdateIssueWatchRequest,
   options?: ApiRequestOptions,
 ) {
-  return fetchJson<IssueWatch>(`/api/v1/github/watches/issue/${id}`, {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  return fetchJson<IssueWatch>(`/api/v1/github/watches/issue/${id}?${params}`, {
     ...options,
     init: { method: "PUT", body: JSON.stringify(payload), ...(options?.init ?? {}) },
   });
 }
 
-export async function deleteIssueWatch(id: string, options?: ApiRequestOptions) {
-  return fetchJson<{ deleted: boolean }>(`/api/v1/github/watches/issue/${id}`, {
+export async function deleteIssueWatch(
+  id: string,
+  workspaceId: string,
+  options?: ApiRequestOptions,
+) {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  return fetchJson<{ deleted: boolean }>(`/api/v1/github/watches/issue/${id}?${params}`, {
     ...options,
     init: { method: "DELETE", ...(options?.init ?? {}) },
   });
@@ -565,15 +579,17 @@ export async function triggerAllIssueWatches(workspaceId: string, options?: ApiR
 // Manual cleanup sweeps. The poller runs these every 5min per watch, but a
 // user with a pile of legacy merged-PR tasks (created before the cleanup
 // policy was in place) can invoke them on demand from the settings page.
-export async function cleanupMergedReviewTasks(options?: ApiRequestOptions) {
-  return fetchJson<CleanupTasksResponse>("/api/v1/github/cleanup/review-tasks", {
+export async function cleanupMergedReviewTasks(workspaceId?: string, options?: ApiRequestOptions) {
+  const query = workspaceId ? `?${new URLSearchParams({ workspace_id: workspaceId })}` : "";
+  return fetchJson<CleanupTasksResponse>(`/api/v1/github/cleanup/review-tasks${query}`, {
     ...options,
     init: { method: "POST", ...(options?.init ?? {}) },
   });
 }
 
-export async function cleanupClosedIssueTasks(options?: ApiRequestOptions) {
-  return fetchJson<CleanupTasksResponse>("/api/v1/github/cleanup/issue-tasks", {
+export async function cleanupClosedIssueTasks(workspaceId?: string, options?: ApiRequestOptions) {
+  const query = workspaceId ? `?${new URLSearchParams({ workspace_id: workspaceId })}` : "";
+  return fetchJson<CleanupTasksResponse>(`/api/v1/github/cleanup/issue-tasks${query}`, {
     ...options,
     init: { method: "POST", ...(options?.init ?? {}) },
   });

--- a/apps/web/lib/api/domains/jira-api.ts
+++ b/apps/web/lib/api/domains/jira-api.ts
@@ -67,10 +67,7 @@ export async function listJiraProjects(options?: WorkspaceApiOptions) {
   );
 }
 
-export async function listJiraProjectStatuses(
-  projectKey: string,
-  options?: WorkspaceApiOptions,
-) {
+export async function listJiraProjectStatuses(projectKey: string, options?: WorkspaceApiOptions) {
   return fetchJson<{ statuses: JiraStatus[] }>(
     withWorkspace(`/api/v1/jira/projects/${encodeURIComponent(projectKey)}/statuses`, options),
     requestOptions(options),

--- a/apps/web/lib/api/domains/jira-api.ts
+++ b/apps/web/lib/api/domains/jira-api.ts
@@ -12,73 +12,102 @@ import type {
   UpdateJiraIssueWatchInput,
 } from "@/lib/types/jira";
 
+type WorkspaceApiOptions = ApiRequestOptions & { workspaceId?: string };
+
+function withWorkspace(path: string, options?: WorkspaceApiOptions): string {
+  if (!options?.workspaceId) return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}workspace_id=${encodeURIComponent(options.workspaceId)}`;
+}
+
+function requestOptions(options?: WorkspaceApiOptions): ApiRequestOptions | undefined {
+  if (!options) return undefined;
+  const { workspaceId: _workspaceId, ...rest } = options;
+  return rest;
+}
+
 // getJiraConfig returns null when the backend responds 204 (no config yet).
 // fetchJson already maps 204 → undefined; we narrow it to null for callers.
-export async function getJiraConfig(options?: ApiRequestOptions): Promise<JiraConfig | null> {
-  const res = await fetchJson<JiraConfig | undefined>(`/api/v1/jira/config`, options);
+export async function getJiraConfig(options?: WorkspaceApiOptions): Promise<JiraConfig | null> {
+  const res = await fetchJson<JiraConfig | undefined>(
+    withWorkspace(`/api/v1/jira/config`, options),
+    requestOptions(options),
+  );
   return res ?? null;
 }
 
-export async function setJiraConfig(payload: SetJiraConfigRequest, options?: ApiRequestOptions) {
-  return fetchJson<JiraConfig>(`/api/v1/jira/config`, {
-    ...options,
+export async function setJiraConfig(payload: SetJiraConfigRequest, options?: WorkspaceApiOptions) {
+  return fetchJson<JiraConfig>(withWorkspace(`/api/v1/jira/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify(payload) },
   });
 }
 
-export async function deleteJiraConfig(options?: ApiRequestOptions) {
-  return fetchJson<{ deleted: boolean }>(`/api/v1/jira/config`, {
-    ...options,
+export async function deleteJiraConfig(options?: WorkspaceApiOptions) {
+  return fetchJson<{ deleted: boolean }>(withWorkspace(`/api/v1/jira/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "DELETE" },
   });
 }
 
 export async function testJiraConnection(
   payload: SetJiraConfigRequest,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
-  return fetchJson<TestJiraConnectionResult>(`/api/v1/jira/config/test`, {
-    ...options,
+  return fetchJson<TestJiraConnectionResult>(withWorkspace(`/api/v1/jira/config/test`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify(payload) },
   });
 }
 
-export async function listJiraProjects(options?: ApiRequestOptions) {
-  return fetchJson<{ projects: JiraProject[] }>(`/api/v1/jira/projects`, options);
-}
-
-export async function listJiraProjectStatuses(projectKey: string, options?: ApiRequestOptions) {
-  return fetchJson<{ statuses: JiraStatus[] }>(
-    `/api/v1/jira/projects/${encodeURIComponent(projectKey)}/statuses`,
-    options,
+export async function listJiraProjects(options?: WorkspaceApiOptions) {
+  return fetchJson<{ projects: JiraProject[] }>(
+    withWorkspace(`/api/v1/jira/projects`, options),
+    requestOptions(options),
   );
 }
 
-export async function getJiraTicket(ticketKey: string, options?: ApiRequestOptions) {
-  return fetchJson<JiraTicket>(`/api/v1/jira/tickets/${encodeURIComponent(ticketKey)}`, options);
+export async function listJiraProjectStatuses(
+  projectKey: string,
+  options?: WorkspaceApiOptions,
+) {
+  return fetchJson<{ statuses: JiraStatus[] }>(
+    withWorkspace(`/api/v1/jira/projects/${encodeURIComponent(projectKey)}/statuses`, options),
+    requestOptions(options),
+  );
+}
+
+export async function getJiraTicket(ticketKey: string, options?: WorkspaceApiOptions) {
+  return fetchJson<JiraTicket>(
+    withWorkspace(`/api/v1/jira/tickets/${encodeURIComponent(ticketKey)}`, options),
+    requestOptions(options),
+  );
 }
 
 export async function searchJiraTickets(
   params: { jql?: string; pageToken?: string; maxResults?: number },
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
   const search = new URLSearchParams();
   if (params.jql) search.set("jql", params.jql);
   if (params.pageToken) search.set("page_token", params.pageToken);
   if (params.maxResults) search.set("max_results", String(params.maxResults));
   const qs = search.toString();
-  return fetchJson<JiraSearchResult>(`/api/v1/jira/tickets${qs ? `?${qs}` : ""}`, options);
+  return fetchJson<JiraSearchResult>(
+    withWorkspace(`/api/v1/jira/tickets${qs ? `?${qs}` : ""}`, options),
+    requestOptions(options),
+  );
 }
 
 export async function transitionJiraTicket(
   ticketKey: string,
   transitionId: string,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
   return fetchJson<{ transitioned: boolean }>(
-    `/api/v1/jira/tickets/${encodeURIComponent(ticketKey)}/transitions`,
+    withWorkspace(`/api/v1/jira/tickets/${encodeURIComponent(ticketKey)}/transitions`, options),
     {
-      ...options,
+      ...requestOptions(options),
       init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify({ transitionId }) },
     },
   );

--- a/apps/web/lib/api/domains/linear-api.test.ts
+++ b/apps/web/lib/api/domains/linear-api.test.ts
@@ -72,6 +72,12 @@ describe("getLinearConfig", () => {
     expect(lastCall().url).toBe(CONFIG_URL);
   });
 
+  it("scopes config reads to a workspace when provided", async () => {
+    fetchSpy.mockResolvedValueOnce(noContent());
+    await getLinearConfig({ workspaceId: "ws-123" });
+    expect(lastCall().url).toBe(`${CONFIG_URL}?workspace_id=ws-123`);
+  });
+
   it("returns the parsed config on 200", async () => {
     fetchSpy.mockResolvedValueOnce(
       jsonResponse({
@@ -133,6 +139,12 @@ describe("listLinearTeams + listLinearStates", () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ states: [] }));
     await listLinearStates("ENG");
     expect(lastCall().url).toBe(`${BASE}/states?team_key=ENG`);
+  });
+
+  it("keeps existing query params when appending workspace_id", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ states: [] }));
+    await listLinearStates("ENG", { workspaceId: "ws-123" });
+    expect(lastCall().url).toBe(`${BASE}/states?team_key=ENG&workspace_id=ws-123`);
   });
 });
 

--- a/apps/web/lib/api/domains/linear-api.ts
+++ b/apps/web/lib/api/domains/linear-api.ts
@@ -15,66 +15,92 @@ import type {
   UpdateLinearIssueWatchInput,
 } from "@/lib/types/linear";
 
+type WorkspaceApiOptions = ApiRequestOptions & { workspaceId?: string };
+
+function withWorkspace(path: string, options?: WorkspaceApiOptions): string {
+  if (!options?.workspaceId) return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}workspace_id=${encodeURIComponent(options.workspaceId)}`;
+}
+
+function requestOptions(options?: WorkspaceApiOptions): ApiRequestOptions | undefined {
+  if (!options) return undefined;
+  const { workspaceId: _workspaceId, ...rest } = options;
+  return rest;
+}
+
 // getLinearConfig returns null when the backend responds 204 (no config yet).
-export async function getLinearConfig(options?: ApiRequestOptions): Promise<LinearConfig | null> {
-  const res = await fetchJson<LinearConfig | undefined>(`/api/v1/linear/config`, options);
+export async function getLinearConfig(options?: WorkspaceApiOptions): Promise<LinearConfig | null> {
+  const res = await fetchJson<LinearConfig | undefined>(
+    withWorkspace(`/api/v1/linear/config`, options),
+    requestOptions(options),
+  );
   return res ?? null;
 }
 
 export async function setLinearConfig(
   payload: SetLinearConfigRequest,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
-  return fetchJson<LinearConfig>(`/api/v1/linear/config`, {
-    ...options,
+  return fetchJson<LinearConfig>(withWorkspace(`/api/v1/linear/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify(payload) },
   });
 }
 
-export async function deleteLinearConfig(options?: ApiRequestOptions) {
-  return fetchJson<{ deleted: boolean }>(`/api/v1/linear/config`, {
-    ...options,
+export async function deleteLinearConfig(options?: WorkspaceApiOptions) {
+  return fetchJson<{ deleted: boolean }>(withWorkspace(`/api/v1/linear/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "DELETE" },
   });
 }
 
 export async function testLinearConnection(
   payload: SetLinearConfigRequest,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
-  return fetchJson<TestLinearConnectionResult>(`/api/v1/linear/config/test`, {
-    ...options,
-    init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify(payload) },
-  });
+  return fetchJson<TestLinearConnectionResult>(
+    withWorkspace(`/api/v1/linear/config/test`, options),
+    {
+      ...requestOptions(options),
+      init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify(payload) },
+    },
+  );
 }
 
-export async function listLinearTeams(options?: ApiRequestOptions) {
-  return fetchJson<{ teams: LinearTeam[] }>(`/api/v1/linear/teams`, options);
+export async function listLinearTeams(options?: WorkspaceApiOptions) {
+  return fetchJson<{ teams: LinearTeam[] }>(
+    withWorkspace(`/api/v1/linear/teams`, options),
+    requestOptions(options),
+  );
 }
 
-export async function listLinearStates(teamKey: string, options?: ApiRequestOptions) {
+export async function listLinearStates(teamKey: string, options?: WorkspaceApiOptions) {
   return fetchJson<{ states: LinearWorkflowState[] }>(
-    `/api/v1/linear/states?team_key=${encodeURIComponent(teamKey)}`,
-    options,
+    withWorkspace(`/api/v1/linear/states?team_key=${encodeURIComponent(teamKey)}`, options),
+    requestOptions(options),
   );
 }
 
-export async function listLinearLabels(teamKey: string, options?: ApiRequestOptions) {
+export async function listLinearLabels(teamKey: string, options?: WorkspaceApiOptions) {
   return fetchJson<{ labels: LinearLabel[] }>(
-    `/api/v1/linear/labels?team_key=${encodeURIComponent(teamKey)}`,
-    options,
+    withWorkspace(`/api/v1/linear/labels?team_key=${encodeURIComponent(teamKey)}`, options),
+    requestOptions(options),
   );
 }
 
-export async function listLinearUsers(teamKey: string, options?: ApiRequestOptions) {
+export async function listLinearUsers(teamKey: string, options?: WorkspaceApiOptions) {
   return fetchJson<{ users: LinearUser[] }>(
-    `/api/v1/linear/users?team_key=${encodeURIComponent(teamKey)}`,
-    options,
+    withWorkspace(`/api/v1/linear/users?team_key=${encodeURIComponent(teamKey)}`, options),
+    requestOptions(options),
   );
 }
 
-export async function getLinearIssue(identifier: string, options?: ApiRequestOptions) {
-  return fetchJson<LinearIssue>(`/api/v1/linear/issues/${encodeURIComponent(identifier)}`, options);
+export async function getLinearIssue(identifier: string, options?: WorkspaceApiOptions) {
+  return fetchJson<LinearIssue>(
+    withWorkspace(`/api/v1/linear/issues/${encodeURIComponent(identifier)}`, options),
+    requestOptions(options),
+  );
 }
 
 function buildSearchIssuesQuery(
@@ -105,21 +131,24 @@ function buildSearchIssuesQuery(
 
 export async function searchLinearIssues(
   params: LinearSearchFilter & { pageToken?: string; maxResults?: number },
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
   const qs = buildSearchIssuesQuery(params);
-  return fetchJson<LinearSearchResult>(`/api/v1/linear/issues${qs ? `?${qs}` : ""}`, options);
+  return fetchJson<LinearSearchResult>(
+    withWorkspace(`/api/v1/linear/issues${qs ? `?${qs}` : ""}`, options),
+    requestOptions(options),
+  );
 }
 
 export async function setLinearIssueState(
   issueID: string,
   stateID: string,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
   return fetchJson<{ transitioned: boolean }>(
-    `/api/v1/linear/issues/${encodeURIComponent(issueID)}/state`,
+    withWorkspace(`/api/v1/linear/issues/${encodeURIComponent(issueID)}/state`, options),
     {
-      ...options,
+      ...requestOptions(options),
       init: {
         ...(options?.init ?? {}),
         method: "POST",

--- a/apps/web/lib/api/domains/sentry-api.ts
+++ b/apps/web/lib/api/domains/sentry-api.ts
@@ -13,26 +13,43 @@ import type {
   UpdateSentryIssueWatchRequest,
 } from "@/lib/types/sentry";
 
+type WorkspaceApiOptions = ApiRequestOptions & { workspaceId?: string };
+
+function withWorkspace(path: string, options?: WorkspaceApiOptions): string {
+  if (!options?.workspaceId) return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}workspace_id=${encodeURIComponent(options.workspaceId)}`;
+}
+
+function requestOptions(options?: WorkspaceApiOptions): ApiRequestOptions | undefined {
+  if (!options) return undefined;
+  const { workspaceId: _workspaceId, ...rest } = options;
+  return rest;
+}
+
 // fetchSentryConfig returns undefined when the backend responds 204 (no config yet).
 export async function fetchSentryConfig(
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ): Promise<SentryConfig | undefined> {
-  return fetchJson<SentryConfig | undefined>(`/api/v1/sentry/config`, options);
+  return fetchJson<SentryConfig | undefined>(
+    withWorkspace(`/api/v1/sentry/config`, options),
+    requestOptions(options),
+  );
 }
 
 export async function saveSentryConfig(
   payload: SetSentryConfigRequest,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
-  return fetchJson<SentryConfig>(`/api/v1/sentry/config`, {
-    ...options,
+  return fetchJson<SentryConfig>(withWorkspace(`/api/v1/sentry/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "PUT", body: JSON.stringify(payload) },
   });
 }
 
-export async function deleteSentryConfig(options?: ApiRequestOptions) {
-  return fetchJson<{ deleted: boolean }>(`/api/v1/sentry/config`, {
-    ...options,
+export async function deleteSentryConfig(options?: WorkspaceApiOptions) {
+  return fetchJson<{ deleted: boolean }>(withWorkspace(`/api/v1/sentry/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "DELETE" },
   });
 }
@@ -40,30 +57,36 @@ export async function deleteSentryConfig(options?: ApiRequestOptions) {
 export async function testSentryConnection(
   secret?: string,
   url?: string,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
   const payload: { secret?: string; url?: string } = {};
   if (secret) payload.secret = secret;
   if (url) payload.url = url;
-  return fetchJson<TestSentryConnectionResult>(`/api/v1/sentry/config/test`, {
-    ...options,
-    init: {
-      ...(options?.init ?? {}),
-      method: "POST",
-      body: JSON.stringify(payload),
+  return fetchJson<TestSentryConnectionResult>(
+    withWorkspace(`/api/v1/sentry/config/test`, options),
+    {
+      ...requestOptions(options),
+      init: {
+        ...(options?.init ?? {}),
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
     },
-  });
-}
-
-export async function listSentryOrganizations(options?: ApiRequestOptions) {
-  return fetchJson<{ organizations: SentryOrganization[] }>(
-    `/api/v1/sentry/organizations`,
-    options,
   );
 }
 
-export async function listSentryProjects(options?: ApiRequestOptions) {
-  return fetchJson<{ projects: SentryProject[] }>(`/api/v1/sentry/projects`, options);
+export async function listSentryOrganizations(options?: WorkspaceApiOptions) {
+  return fetchJson<{ organizations: SentryOrganization[] }>(
+    withWorkspace(`/api/v1/sentry/organizations`, options),
+    requestOptions(options),
+  );
+}
+
+export async function listSentryProjects(options?: WorkspaceApiOptions) {
+  return fetchJson<{ projects: SentryProject[] }>(
+    withWorkspace(`/api/v1/sentry/projects`, options),
+    requestOptions(options),
+  );
 }
 
 function appendFilter(search: URLSearchParams, filter: SentrySearchFilter): void {
@@ -79,18 +102,21 @@ function appendFilter(search: URLSearchParams, filter: SentrySearchFilter): void
 export async function searchSentryIssues(
   filter: SentrySearchFilter,
   cursor?: string,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
   const search = new URLSearchParams();
   appendFilter(search, filter);
   if (cursor) search.set("cursor", cursor);
-  return fetchJson<SentrySearchResult>(`/api/v1/sentry/issues?${search.toString()}`, options);
+  return fetchJson<SentrySearchResult>(
+    withWorkspace(`/api/v1/sentry/issues?${search.toString()}`, options),
+    requestOptions(options),
+  );
 }
 
-export async function getSentryIssue(idOrShortId: string, options?: ApiRequestOptions) {
+export async function getSentryIssue(idOrShortId: string, options?: WorkspaceApiOptions) {
   return fetchJson<SentryIssue>(
-    `/api/v1/sentry/issues/${encodeURIComponent(idOrShortId)}`,
-    options,
+    withWorkspace(`/api/v1/sentry/issues/${encodeURIComponent(idOrShortId)}`, options),
+    requestOptions(options),
   );
 }
 

--- a/apps/web/lib/api/domains/slack-api.ts
+++ b/apps/web/lib/api/domains/slack-api.ts
@@ -5,32 +5,52 @@ import type {
   TestSlackConnectionResult,
 } from "@/lib/types/slack";
 
+type WorkspaceApiOptions = ApiRequestOptions & { workspaceId?: string };
+
+function withWorkspace(path: string, options?: WorkspaceApiOptions): string {
+  if (!options?.workspaceId) return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}workspace_id=${encodeURIComponent(options.workspaceId)}`;
+}
+
+function requestOptions(options?: WorkspaceApiOptions): ApiRequestOptions | undefined {
+  if (!options) return undefined;
+  const { workspaceId: _workspaceId, ...rest } = options;
+  return rest;
+}
+
 // getSlackConfig returns null when the backend responds 204 (no config yet).
-export async function getSlackConfig(options?: ApiRequestOptions): Promise<SlackConfig | null> {
-  const res = await fetchJson<SlackConfig | undefined>(`/api/v1/slack/config`, options);
+export async function getSlackConfig(options?: WorkspaceApiOptions): Promise<SlackConfig | null> {
+  const res = await fetchJson<SlackConfig | undefined>(
+    withWorkspace(`/api/v1/slack/config`, options),
+    requestOptions(options),
+  );
   return res ?? null;
 }
 
-export async function setSlackConfig(payload: SetSlackConfigRequest, options?: ApiRequestOptions) {
-  return fetchJson<SlackConfig>(`/api/v1/slack/config`, {
-    ...options,
+export async function setSlackConfig(
+  payload: SetSlackConfigRequest,
+  options?: WorkspaceApiOptions,
+) {
+  return fetchJson<SlackConfig>(withWorkspace(`/api/v1/slack/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify(payload) },
   });
 }
 
-export async function deleteSlackConfig(options?: ApiRequestOptions) {
-  return fetchJson<{ deleted: boolean }>(`/api/v1/slack/config`, {
-    ...options,
+export async function deleteSlackConfig(options?: WorkspaceApiOptions) {
+  return fetchJson<{ deleted: boolean }>(withWorkspace(`/api/v1/slack/config`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "DELETE" },
   });
 }
 
 export async function testSlackConnection(
   payload: SetSlackConfigRequest,
-  options?: ApiRequestOptions,
+  options?: WorkspaceApiOptions,
 ) {
-  return fetchJson<TestSlackConnectionResult>(`/api/v1/slack/config/test`, {
-    ...options,
+  return fetchJson<TestSlackConnectionResult>(withWorkspace(`/api/v1/slack/config/test`, options), {
+    ...requestOptions(options),
     init: { ...(options?.init ?? {}), method: "POST", body: JSON.stringify(payload) },
   });
 }

--- a/apps/web/lib/types/github.ts
+++ b/apps/web/lib/types/github.ts
@@ -239,6 +239,28 @@ export type RepoFilter = {
   name: string;
 };
 
+export type GitHubRepoScopeMode = "all" | "orgs" | "repos";
+
+export type GitHubWorkspaceSettings = {
+  workspace_id: string;
+  repo_scope_mode: GitHubRepoScopeMode;
+  repo_scope_orgs: string[];
+  repo_scope_repos: RepoFilter[];
+  saved_presets?: unknown;
+  default_query_presets?: unknown | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type UpdateGitHubWorkspaceSettingsRequest = {
+  workspace_id: string;
+  repo_scope_mode?: GitHubRepoScopeMode;
+  repo_scope_orgs?: string[];
+  repo_scope_repos?: RepoFilter[];
+  saved_presets?: unknown;
+  default_query_presets?: unknown | null;
+};
+
 export type GitHubOrg = {
   login: string;
   avatar_url: string;

--- a/apps/web/lib/types/jira.ts
+++ b/apps/web/lib/types/jira.ts
@@ -14,6 +14,7 @@ export type JiraAuthMethod = "api_token" | "pat" | "session_cookie";
 export type JiraInstanceType = "cloud" | "server";
 
 export interface JiraConfig {
+  workspaceId?: string;
   siteUrl: string;
   email: string;
   authMethod: JiraAuthMethod;

--- a/apps/web/lib/types/linear.ts
+++ b/apps/web/lib/types/linear.ts
@@ -1,6 +1,7 @@
 export type LinearAuthMethod = "api_key";
 
 export interface LinearConfig {
+  workspaceId?: string;
   authMethod: LinearAuthMethod;
   defaultTeamKey: string;
   hasSecret: boolean;

--- a/apps/web/lib/types/sentry.ts
+++ b/apps/web/lib/types/sentry.ts
@@ -8,6 +8,7 @@ export const SENTRY_AUTH_METHOD: SentryAuthMethod = "auth_token";
 export const SENTRY_DEFAULT_URL = "https://sentry.io";
 
 export interface SentryConfig {
+  workspaceId?: string;
   authMethod: SentryAuthMethod;
   url: string;
   hasSecret: boolean;

--- a/apps/web/lib/types/slack.ts
+++ b/apps/web/lib/types/slack.ts
@@ -1,6 +1,7 @@
 export type SlackAuthMethod = "cookie";
 
 export interface SlackConfig {
+  workspaceId?: string;
   authMethod: SlackAuthMethod;
   commandPrefix: string;
   /** ID of a utility agent (`utility_agents.id`) the trigger invokes for each match. */

--- a/docs/decisions/0030-workspace-scoped-integration-settings.md
+++ b/docs/decisions/0030-workspace-scoped-integration-settings.md
@@ -1,0 +1,64 @@
+# Workspace-scoped integration settings
+
+## Status
+
+accepted
+
+## Context
+
+GitHub integration settings mixed install-wide authentication with operational
+settings such as watch configuration, action presets, default queries, and repo
+filters. That made multi-workspace installs confusing: a GitHub watch or query
+configured for one workspace could appear beside settings for another, and the
+`/github` PR/issue lists had no workspace boundary beyond ad hoc repo filters.
+
+Jira and Linear already model operational integration state as workspace-owned.
+GitHub needs to follow the same ownership rule while keeping authentication
+shared, because the authenticated GitHub account/token is still install-wide.
+
+## Decision
+
+Third-party integration authentication can remain global when the external
+provider account is global, but operational integration settings are owned by a
+workspace.
+
+For GitHub, each workspace has a `github_workspace_settings` row containing:
+
+- repository scope mode: all repositories, selected organizations, or selected
+  repositories;
+- selected org/repo scope values;
+- workspace-owned GitHub query presets.
+
+The settings UI exposes a topbar workspace switcher on integration settings
+routes. GitHub settings render for the active workspace, and review/issue watch
+dialogs are locked to that workspace from the settings page.
+
+The backend enforces GitHub repository scope on `/github` PR/issue searches and
+watch polling results. The frontend also uses the scope to narrow repo selector
+options, but that is only a usability layer; backend filtering is the source of
+truth.
+
+## Consequences
+
+- Existing installs default to `all` repository scope, preserving current
+  behavior until a workspace changes its GitHub scope.
+- Workspace-scoped GitHub searches have cache keys that include the workspace
+  scope so scoped and unscoped result pages do not share cached data.
+- Default query presets migrate opportunistically from the older global
+  browser/user-settings path into the first workspace where the user opens
+  GitHub settings or the `/github` page.
+- Task creation repo/branch pickers remain governed by workspace repositories;
+  GitHub repository scope only affects GitHub integration surfaces.
+
+## Alternatives Considered
+
+### Keep GitHub settings global
+
+Rejected. It would keep the current ambiguity and diverge from Jira/Linear,
+where operational settings are already per-workspace.
+
+### Treat selected repositories as workspace repositories
+
+Rejected. GitHub repo scope is not the same as task execution repositories. A
+workspace may monitor many GitHub repos for PRs/issues without attaching all of
+them as local task repositories.

--- a/docs/decisions/0030-workspace-scoped-integration-settings.md
+++ b/docs/decisions/0030-workspace-scoped-integration-settings.md
@@ -48,17 +48,17 @@ workspace when it exists, otherwise the first workspace by creation time. If no
 workspace exists, leave the singleton data untouched until a workspace is
 created or the user reconnects.
 
-Each integration settings page includes a copy action that copies the current
-workspace's provider config and credentials to another workspace. Copying
-automation/watch rows is intentionally separate and opt-in so users do not
-accidentally duplicate task-creating pollers.
+A follow-up should add a copy action that copies the current workspace's
+provider config and credentials to another workspace. Copying automation/watch
+rows should remain separate and opt-in so users do not accidentally duplicate
+task-creating pollers.
 
 ## Consequences
 
 - Existing installs migrate their singleton integration config to one
-  deterministic workspace. If that is not the user's intended workspace, the
-  copy action lets them duplicate the settings to the correct workspace and
-  then delete or replace the original.
+  deterministic workspace. If that is not the user's intended workspace, users
+  can reconnect the integration in the correct workspace today; a future copy
+  action should make that correction path faster.
 - Existing GitHub installs default to `all` repository scope, preserving
   current behavior until a workspace changes its GitHub scope.
 - Workspace-scoped GitHub searches have cache keys that include the workspace

--- a/docs/decisions/0030-workspace-scoped-integration-settings.md
+++ b/docs/decisions/0030-workspace-scoped-integration-settings.md
@@ -12,15 +12,18 @@ filters. That made multi-workspace installs confusing: a GitHub watch or query
 configured for one workspace could appear beside settings for another, and the
 `/github` PR/issue lists had no workspace boundary beyond ad hoc repo filters.
 
-Jira and Linear already model operational integration state as workspace-owned.
-GitHub needs to follow the same ownership rule while keeping authentication
-shared, because the authenticated GitHub account/token is still install-wide.
+Jira, Linear, Sentry, Slack, GitLab, and GitHub all have settings that users
+expect to vary by Kandev workspace. Keeping credentials or provider defaults
+install-wide makes multi-workspace installs ambiguous: a "work" workspace and a
+"personal" workspace may require different tokens, hosts, orgs, projects,
+teams, or utility agents.
 
 ## Decision
 
-Third-party integration authentication can remain global when the external
-provider account is global, but operational integration settings are owned by a
-workspace.
+Third-party integration configuration is workspace-owned by default. Provider
+credentials, host URLs, default project/team/org fields, health status, query
+presets, and watcher settings are read and written for an explicit
+`workspace_id`.
 
 For GitHub, each workspace has a `github_workspace_settings` row containing:
 
@@ -38,10 +41,26 @@ watch polling results. The frontend also uses the scope to narrow repo selector
 options, but that is only a usability layer; backend filtering is the source of
 truth.
 
+For Jira, Linear, Sentry, Slack, and GitLab, singleton config tables migrate to
+workspace-keyed config rows. Startup migration is deterministic and does not
+prompt: copy the old singleton config and secret into the user's active
+workspace when it exists, otherwise the first workspace by creation time. If no
+workspace exists, leave the singleton data untouched until a workspace is
+created or the user reconnects.
+
+Each integration settings page includes a copy action that copies the current
+workspace's provider config and credentials to another workspace. Copying
+automation/watch rows is intentionally separate and opt-in so users do not
+accidentally duplicate task-creating pollers.
+
 ## Consequences
 
-- Existing installs default to `all` repository scope, preserving current
-  behavior until a workspace changes its GitHub scope.
+- Existing installs migrate their singleton integration config to one
+  deterministic workspace. If that is not the user's intended workspace, the
+  copy action lets them duplicate the settings to the correct workspace and
+  then delete or replace the original.
+- Existing GitHub installs default to `all` repository scope, preserving
+  current behavior until a workspace changes its GitHub scope.
 - Workspace-scoped GitHub searches have cache keys that include the workspace
   scope so scoped and unscoped result pages do not share cached data.
 - Default query presets migrate opportunistically from the older global
@@ -49,6 +68,9 @@ truth.
   GitHub settings or the `/github` page.
 - Task creation repo/branch pickers remain governed by workspace repositories;
   GitHub repository scope only affects GitHub integration surfaces.
+- Config/status APIs must either require `workspace_id` or derive it from the
+  active workspace route state. Install-wide `/config` semantics are deprecated
+  for integrations that support workspace-scoped settings.
 
 ## Alternatives Considered
 
@@ -56,6 +78,19 @@ truth.
 
 Rejected. It would keep the current ambiguity and diverge from Jira/Linear,
 where operational settings are already per-workspace.
+
+### Keep credentials install-wide and only scope watchers
+
+Rejected. It solves only part of the ambiguity. Different workspaces often map
+to different external accounts or tenants, especially for GitLab self-managed
+hosts, Jira sites, Sentry orgs, Linear teams, and Slack utility-agent routing.
+
+### Prompt during migration
+
+Rejected. Database migrations must be deterministic and able to run during
+backend startup, CI, desktop launch, and headless server upgrades. A
+copy-to-workspace affordance gives users a reversible correction path without
+blocking startup.
 
 ### Treat selected repositories as workspace repositories
 

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -35,3 +35,4 @@ Read individual ADRs for full context. Create new ones via `/record decision` or
 | 0027 | [Replayable schema migrations across SQLite and Postgres](0027-replayable-schema-migrations.md)                                     | accepted   | backend                     | 2026-06-24 |
 | 0028 | [Backend-owned task-create last-used preferences](0028-task-create-last-used-source-of-truth.md)                                    | accepted   | backend, frontend           | 2026-06-29 |
 | 0029 | [Release backfill and desktop diagnostics](0029-release-backfill-and-desktop-diagnostics.md)                                        | accepted   | infra, workflow             | 2026-07-01 |
+| 0030 | [Workspace-scoped integration settings](0030-workspace-scoped-integration-settings.md)                                             | accepted   | backend, frontend           | 2026-07-01 |

--- a/docs/specs/gitlab-integration/spec.md
+++ b/docs/specs/gitlab-integration/spec.md
@@ -21,13 +21,13 @@ Tracked in [#820](https://github.com/kdlbs/kandev/issues/820).
 
 - A GitLab integration runs alongside the GitHub one. Both can be configured at
   the same time; neither replaces the other.
-- Users authenticate GitLab via one of:
+- Users authenticate GitLab per Kandev workspace via one of:
   - `glab` CLI (auto-detected if installed and logged in).
-  - Personal access token stored in the secret store as `GITLAB_TOKEN` (or set
-    via the env var of the same name on the backend host).
+  - Personal access token stored in the secret store for that workspace (or set
+    via `GITLAB_TOKEN` on the backend host as a process-wide fallback).
 - Self-managed instances are supported by configuring a GitLab host URL
-  (default `https://gitlab.com`). The host applies to API calls, clone URLs,
-  and web links.
+  per workspace (default `https://gitlab.com`). The host applies to API calls,
+  clone URLs, and web links for that workspace.
 - Repositories can be added with `provider = "gitlab"`. The repo cloner builds
   SSH (`git@<host>:<owner>/<name>.git`) and HTTPS clone URLs against the
   configured host, and authenticates HTTPS clones with the GitLab token when
@@ -48,8 +48,9 @@ Tracked in [#820](https://github.com/kdlbs/kandev/issues/820).
   REST API with the stored token), targeting the same base branch logic used
   for GitHub.
 - Settings live under `/settings/integrations/gitlab` with a page parallel to
-  the GitHub one: connection status, host URL field, auth method (CLI vs PAT),
-  reconnect CTA, and a token field that writes to the secret store.
+  the GitHub one: workspace selector, connection status, host URL field, auth
+  method (CLI vs PAT), reconnect CTA, token field that writes to the secret
+  store, and a copy action for duplicating the config to another workspace.
 - The orchestrator and credential providers pass `GITLAB_TOKEN` into agent
   environments the same way `GITHUB_TOKEN` is passed today, so agents running
   in containers can run `glab` or `git push` without extra setup.
@@ -63,9 +64,9 @@ Tracked in [#820](https://github.com/kdlbs/kandev/issues/820).
 
 - **GIVEN** a user on a self-managed GitLab at `https://gitlab.acme.corp`,
   **WHEN** they enter the host URL and a personal access token in
-  Settings → Integrations → GitLab, **THEN** the connection status flips to
-  connected, MR/issue lists populate against the custom host, and clone URLs
-  for added repos use `gitlab.acme.corp`.
+  Settings → Integrations → GitLab for Workspace A, **THEN** Workspace A's
+  connection status flips to connected, MR/issue lists populate against the
+  custom host, and clone URLs for Workspace A repos use `gitlab.acme.corp`.
 
 - **GIVEN** a task whose repository has `provider = "gitlab"`, **WHEN** the
   agent runs the `pr` skill, **THEN** a merge request is opened on the
@@ -82,8 +83,9 @@ Tracked in [#820](https://github.com/kdlbs/kandev/issues/820).
 
 - **GIVEN** the user revokes their GitLab token externally, **WHEN** the
   background poller next runs, **THEN** the integration's status flips to
-  "auth required" with a reconnect banner on the GitLab page and the settings
-  page, and no further API calls are issued until the user reconnects.
+  "auth required" for the affected workspace with a reconnect banner on the
+  GitLab page and the settings page, and no further API calls are issued for
+  that workspace until the user reconnects.
 
 - **GIVEN** no GitLab auth is configured, **WHEN** the GitLab page is opened,
   **THEN** it shows a "not connected" notice linking to settings, and no

--- a/docs/specs/integrations/slack.md
+++ b/docs/specs/integrations/slack.md
@@ -12,16 +12,16 @@ Users live in Slack and surface task-worthy work there: bug reports in `#support
 
 ## What (v1, shipped)
 
-- Install-wide Slack credentials (one Slack user/team per Kandev install), modeled on the Jira/Linear integrations: settings page with auth-status banner, reconnect CTA, and 90s auth-health polling.
+- Workspace-scoped Slack credentials and routing defaults, modeled on the Jira/Linear integrations: settings page with a workspace switcher, auth-status banner, reconnect CTA, and 90s auth-health polling. Existing install-wide credentials migrate to the active/default workspace; users can copy settings to other workspaces.
 - Single auth mode: **Browser session** — user pastes the `xoxc-` token + `d` cookie pair extracted from their browser; works on locked-down Enterprise Slack tenants where bot installs are not possible.
-- Single task-creation trigger: **`!kandev` thread triage** — the trigger polls the connected user's own messages for `!kandev <instruction>`, hands the surrounding thread context to a configured utility agent (with the Kandev MCP server attached), and posts the agent's reply back in-thread. The agent picks the destination Kandev workspace/workflow/repo via MCP tools.
+- Single task-creation trigger: **`!kandev` thread triage** — each configured workspace polls the connected Slack user's own messages for `!kandev <instruction>`, hands the surrounding thread context to that workspace's configured utility agent (with the Kandev MCP server attached), and posts the agent's reply back in-thread. The agent picks the destination workflow/repo within the configured Kandev workspace via MCP tools.
 - An 👀 reaction is added to the triggering message on detection so the user can confirm it was picked up.
 - Token storage reuses the shared `secretadapter`; no Slack credentials live in plaintext on disk.
 
 ## Scenarios
 
 - **GIVEN** a user has pasted their `xoxc-`/`d` cookie pair in settings, **WHEN** they type `!kandev fix the safari login bug` in any Slack channel or DM, **THEN** the trigger reacts with 👀, the configured utility agent picks a workspace/workflow/repo via the Kandev MCP, creates a task, and posts the result back as a threaded reply.
-- **GIVEN** a Slack credential is connected, **WHEN** the stored token becomes invalid (revoked, rotated, expired), **THEN** the auth-health poller flips the install to "Reconnect required" within 90 seconds and `RecordAuthHealth` invalidates the cached client so the next probe rebuilds it from current secrets.
+- **GIVEN** a Slack credential is connected for Workspace A, **WHEN** the stored token becomes invalid (revoked, rotated, expired), **THEN** the auth-health poller flips Workspace A to "Reconnect required" within 90 seconds and `RecordAuthHealth` invalidates that workspace's cached client so the next probe rebuilds it from current secrets.
 - **GIVEN** a `!kandev` message has already been processed (its TS is at or below the watermark), **WHEN** the next poll picks it up, **THEN** it is filtered out and no duplicate task is created.
 
 ## Out of scope (v1)
@@ -30,7 +30,6 @@ Users live in Slack and surface task-worthy work there: bug reports in `#support
 - Reaction trigger (`:kandev:` emoji), `/kandev <title>` slash command, and "Create Kandev task" message-shortcut entry.
 - Posting Kandev task updates back into Slack beyond the initial in-thread confirmation (no live status mirroring).
 - Slack as a chat surface for talking to a running agent (no `@kandev <prompt>` runtime, no streaming agent output to Slack).
-- Multi-Slack-workspace fan-out within one Kandev install (one Slack user/team per install).
 - Routing tasks to specific workflows based on channel or keyword — the utility agent picks the workflow via MCP.
 - Importing historical Slack messages.
 
@@ -38,7 +37,7 @@ Users live in Slack and surface task-worthy work there: bug reports in `#support
 
 - Bot-install auth mode with the full trigger set (reaction emoji, slash command, message shortcut) for teams whose admins are willing to install the Kandev Slack app.
 - User OAuth auth mode for users who want a properly-scoped token without admin involvement.
-- Multi-Slack-workspace fan-out for Enterprise Grid tenants.
+- Enterprise Grid fan-out across many Slack workspaces from one Kandev workspace.
 
 ## Open questions
 


### PR DESCRIPTION
Workspace-specific integration setup was global enough that GitHub defaults, scopes, and watch behavior could bleed across workspaces. This adds a workspace-aware settings layer so each workspace can choose all GitHub repos, selected orgs, or selected repos while existing global settings migrate forward through the first workspace path.

## Important Changes

- Added backend workspace GitHub settings storage, migration, API endpoints, and scoped repo enforcement for PR/issue search and watch polling.
- Added a top workspace switcher for integration settings and moved GitHub repo scope, watches, presets, and default queries onto the selected workspace.
- Added an ADR documenting workspace-scoped integration settings and migration behavior.

## Validation

- `make fmt`
- `make typecheck`
- `make test`
- `make lint`
- `go test ./internal/github`
- `pnpm e2e:run --host tests/integrations/github-workspace-settings.spec.ts -- --project=chromium`

## Possible Improvements

Medium risk: Linear and other integrations still need to be moved onto the same workspace-scoped settings pattern.

Closes #1481

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->