### PR TITLE
fix: preserve task create defaults after refresh

### DIFF
--- a/apps/web/components/settings/editors-settings-state.tsx
+++ b/apps/web/components/settings/editors-settings-state.tsx
@@ -11,6 +11,7 @@ import {
   parseChangesPanelLayout,
   parseSystemMetricsDisplay,
   parseTerminalLinkBehavior,
+  taskCreateLastUsedHasValue,
   parseVoiceMode,
 } from "@/lib/ssr/user-settings";
 import { fromApiSidebarDraft, fromApiSidebarView } from "@/lib/state/slices/ui/sidebar-view-wire";
@@ -269,6 +270,7 @@ function mapEditorSyncedLocalFields(
       branch: s.task_create_last_used?.branch || null,
       agentProfileId: s.task_create_last_used?.agent_profile_id || null,
       executorProfileId: s.task_create_last_used?.executor_profile_id || null,
+      synced: taskCreateLastUsedHasValue(s.task_create_last_used),
     },
     jiraSavedViews: s.jira_saved_views,
     jiraTaskPresets: s.jira_task_presets,

--- a/apps/web/components/state-provider.test.tsx
+++ b/apps/web/components/state-provider.test.tsx
@@ -157,14 +157,25 @@ describe("StateProvider task-create cache", () => {
 });
 
 describe("StateProvider task-create cache fallback", () => {
+  const cachedRepositoryId = "repo-cached";
+  const cachedBranch = "feature-cached";
+  const cachedAgentProfileId = "agent-cached";
+  const cachedExecutorProfileId = "exec-cached";
+
   it("keeps cached task-create choices when loaded backend settings omit them", async () => {
     const onSeen = vi.fn();
-    window.localStorage.setItem(STORAGE_KEYS.LAST_REPOSITORY_ID, JSON.stringify("repo-cached"));
-    window.localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify("feature-cached"));
-    window.localStorage.setItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID, JSON.stringify("agent-cached"));
+    window.localStorage.setItem(
+      STORAGE_KEYS.LAST_REPOSITORY_ID,
+      JSON.stringify(cachedRepositoryId),
+    );
+    window.localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify(cachedBranch));
+    window.localStorage.setItem(
+      STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
+      JSON.stringify(cachedAgentProfileId),
+    );
     window.localStorage.setItem(
       STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
-      JSON.stringify("exec-cached"),
+      JSON.stringify(cachedExecutorProfileId),
     );
 
     render(
@@ -186,21 +197,64 @@ describe("StateProvider task-create cache fallback", () => {
       </StateProvider>,
     );
 
-    expect(onSeen).toHaveBeenCalledWith(JSON.stringify("repo-cached"));
+    expect(onSeen).toHaveBeenCalledWith(JSON.stringify(cachedRepositoryId));
     // Give any potential deferred deletions a chance to fire (old code used setTimeout(0)).
     await new Promise((resolve) => window.setTimeout(resolve, 10));
     expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBe(
-      JSON.stringify("repo-cached"),
+      JSON.stringify(cachedRepositoryId),
     );
     expect(window.localStorage.getItem(STORAGE_KEYS.LAST_BRANCH)).toBe(
-      JSON.stringify("feature-cached"),
+      JSON.stringify(cachedBranch),
     );
     expect(window.localStorage.getItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID)).toBe(
-      JSON.stringify("agent-cached"),
+      JSON.stringify(cachedAgentProfileId),
     );
     expect(window.localStorage.getItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID)).toBe(
-      JSON.stringify("exec-cached"),
+      JSON.stringify(cachedExecutorProfileId),
     );
+  });
+
+  it("clears cached task-create choices when loaded backend settings explicitly sync empty values", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEYS.LAST_REPOSITORY_ID,
+      JSON.stringify(cachedRepositoryId),
+    );
+    window.localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify(cachedBranch));
+    window.localStorage.setItem(
+      STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
+      JSON.stringify(cachedAgentProfileId),
+    );
+    window.localStorage.setItem(
+      STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
+      JSON.stringify(cachedExecutorProfileId),
+    );
+
+    render(
+      <StateProvider
+        initialState={{
+          userSettings: {
+            ...defaultSettingsState.userSettings,
+            loaded: true,
+            taskCreateLastUsed: {
+              repositoryId: null,
+              branch: null,
+              agentProfileId: null,
+              executorProfileId: null,
+              synced: true,
+            },
+          },
+        }}
+      >
+        <div>ready</div>
+      </StateProvider>,
+    );
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBeNull();
+      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_BRANCH)).toBeNull();
+      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID)).toBeNull();
+      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID)).toBeNull();
+    });
   });
 });
 

--- a/apps/web/components/state-provider.test.tsx
+++ b/apps/web/components/state-provider.test.tsx
@@ -45,6 +45,47 @@ function ObserveLastUsedCache({ onSeen }: { onSeen: (value: string | null) => vo
   return null;
 }
 
+const cachedTaskCreateChoices = {
+  repositoryId: "repo-cached",
+  branch: "feature-cached",
+  agentProfileId: "agent-cached",
+  executorProfileId: "exec-cached",
+};
+
+function seedCachedTaskCreateChoices() {
+  window.localStorage.setItem(
+    STORAGE_KEYS.LAST_REPOSITORY_ID,
+    JSON.stringify(cachedTaskCreateChoices.repositoryId),
+  );
+  window.localStorage.setItem(
+    STORAGE_KEYS.LAST_BRANCH,
+    JSON.stringify(cachedTaskCreateChoices.branch),
+  );
+  window.localStorage.setItem(
+    STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
+    JSON.stringify(cachedTaskCreateChoices.agentProfileId),
+  );
+  window.localStorage.setItem(
+    STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
+    JSON.stringify(cachedTaskCreateChoices.executorProfileId),
+  );
+}
+
+function expectCachedTaskCreateChoices() {
+  expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBe(
+    JSON.stringify(cachedTaskCreateChoices.repositoryId),
+  );
+  expect(window.localStorage.getItem(STORAGE_KEYS.LAST_BRANCH)).toBe(
+    JSON.stringify(cachedTaskCreateChoices.branch),
+  );
+  expect(window.localStorage.getItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID)).toBe(
+    JSON.stringify(cachedTaskCreateChoices.agentProfileId),
+  );
+  expect(window.localStorage.getItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID)).toBe(
+    JSON.stringify(cachedTaskCreateChoices.executorProfileId),
+  );
+}
+
 beforeEach(() => {
   window.localStorage.clear();
   resetTaskCreateLastUsedSync({ clearQueued: true });
@@ -157,26 +198,9 @@ describe("StateProvider task-create cache", () => {
 });
 
 describe("StateProvider task-create cache fallback", () => {
-  const cachedRepositoryId = "repo-cached";
-  const cachedBranch = "feature-cached";
-  const cachedAgentProfileId = "agent-cached";
-  const cachedExecutorProfileId = "exec-cached";
-
   it("keeps cached task-create choices when loaded backend settings omit them", async () => {
     const onSeen = vi.fn();
-    window.localStorage.setItem(
-      STORAGE_KEYS.LAST_REPOSITORY_ID,
-      JSON.stringify(cachedRepositoryId),
-    );
-    window.localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify(cachedBranch));
-    window.localStorage.setItem(
-      STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
-      JSON.stringify(cachedAgentProfileId),
-    );
-    window.localStorage.setItem(
-      STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
-      JSON.stringify(cachedExecutorProfileId),
-    );
+    seedCachedTaskCreateChoices();
 
     render(
       <StateProvider
@@ -197,37 +221,14 @@ describe("StateProvider task-create cache fallback", () => {
       </StateProvider>,
     );
 
-    expect(onSeen).toHaveBeenCalledWith(JSON.stringify(cachedRepositoryId));
+    expect(onSeen).toHaveBeenCalledWith(JSON.stringify(cachedTaskCreateChoices.repositoryId));
     // Give any potential deferred deletions a chance to fire (old code used setTimeout(0)).
     await new Promise((resolve) => window.setTimeout(resolve, 10));
-    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBe(
-      JSON.stringify(cachedRepositoryId),
-    );
-    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_BRANCH)).toBe(
-      JSON.stringify(cachedBranch),
-    );
-    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID)).toBe(
-      JSON.stringify(cachedAgentProfileId),
-    );
-    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID)).toBe(
-      JSON.stringify(cachedExecutorProfileId),
-    );
+    expectCachedTaskCreateChoices();
   });
 
-  it("clears cached task-create choices when loaded backend settings explicitly sync empty values", async () => {
-    window.localStorage.setItem(
-      STORAGE_KEYS.LAST_REPOSITORY_ID,
-      JSON.stringify(cachedRepositoryId),
-    );
-    window.localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify(cachedBranch));
-    window.localStorage.setItem(
-      STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
-      JSON.stringify(cachedAgentProfileId),
-    );
-    window.localStorage.setItem(
-      STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
-      JSON.stringify(cachedExecutorProfileId),
-    );
+  it("keeps cached task-create choices when loaded backend settings sync an empty object", async () => {
+    seedCachedTaskCreateChoices();
 
     render(
       <StateProvider
@@ -237,6 +238,41 @@ describe("StateProvider task-create cache fallback", () => {
             loaded: true,
             taskCreateLastUsed: {
               repositoryId: null,
+              branch: null,
+              agentProfileId: null,
+              executorProfileId: null,
+              synced: false,
+            },
+          },
+        }}
+      >
+        <div>ready</div>
+      </StateProvider>,
+    );
+
+    await waitFor(() => {
+      expectCachedTaskCreateChoices();
+    });
+  });
+
+  it("clears stale cached fields when loaded backend settings contain real task-create choices", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEYS.LAST_BRANCH,
+      JSON.stringify(cachedTaskCreateChoices.branch),
+    );
+    window.localStorage.setItem(
+      STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
+      JSON.stringify(cachedTaskCreateChoices.agentProfileId),
+    );
+
+    render(
+      <StateProvider
+        initialState={{
+          userSettings: {
+            ...defaultSettingsState.userSettings,
+            loaded: true,
+            taskCreateLastUsed: {
+              repositoryId: "repo-server",
               branch: null,
               agentProfileId: null,
               executorProfileId: null,
@@ -250,10 +286,11 @@ describe("StateProvider task-create cache fallback", () => {
     );
 
     await waitFor(() => {
-      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBeNull();
+      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBe(
+        JSON.stringify("repo-server"),
+      );
       expect(window.localStorage.getItem(STORAGE_KEYS.LAST_BRANCH)).toBeNull();
       expect(window.localStorage.getItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID)).toBeNull();
-      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID)).toBeNull();
     });
   });
 });

--- a/apps/web/components/state-provider.test.tsx
+++ b/apps/web/components/state-provider.test.tsx
@@ -187,6 +187,7 @@ describe("StateProvider task-create cache fallback", () => {
     );
 
     expect(onSeen).toHaveBeenCalledWith(JSON.stringify("repo-cached"));
+    // Give any potential deferred deletions a chance to fire (old code used setTimeout(0)).
     await new Promise((resolve) => window.setTimeout(resolve, 10));
     expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBe(
       JSON.stringify("repo-cached"),

--- a/apps/web/components/state-provider.test.tsx
+++ b/apps/web/components/state-provider.test.tsx
@@ -156,8 +156,8 @@ describe("StateProvider task-create cache", () => {
   });
 });
 
-describe("StateProvider task-create cache clearing", () => {
-  it("lets children read cached task-create choices before clearing missing backend values", async () => {
+describe("StateProvider task-create cache fallback", () => {
+  it("keeps cached task-create choices when loaded backend settings omit them", async () => {
     const onSeen = vi.fn();
     window.localStorage.setItem(STORAGE_KEYS.LAST_REPOSITORY_ID, JSON.stringify("repo-cached"));
     window.localStorage.setItem(STORAGE_KEYS.LAST_BRANCH, JSON.stringify("feature-cached"));
@@ -187,12 +187,19 @@ describe("StateProvider task-create cache clearing", () => {
     );
 
     expect(onSeen).toHaveBeenCalledWith(JSON.stringify("repo-cached"));
-    await waitFor(() => {
-      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBeNull();
-      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_BRANCH)).toBeNull();
-      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID)).toBeNull();
-      expect(window.localStorage.getItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID)).toBeNull();
-    });
+    await new Promise((resolve) => window.setTimeout(resolve, 10));
+    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_REPOSITORY_ID)).toBe(
+      JSON.stringify("repo-cached"),
+    );
+    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_BRANCH)).toBe(
+      JSON.stringify("feature-cached"),
+    );
+    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_AGENT_PROFILE_ID)).toBe(
+      JSON.stringify("agent-cached"),
+    );
+    expect(window.localStorage.getItem(STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID)).toBe(
+      JSON.stringify("exec-cached"),
+    );
   });
 });
 

--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -6,7 +6,7 @@ import { useStore } from "zustand";
 import { isDebug, registerSessionTaskResolver } from "@/lib/debug/log";
 import type { AppState, StoreProviderProps } from "@/lib/state/store";
 import { createAppStore } from "@/lib/state/store";
-import { setLocalStorage } from "@/lib/local-storage";
+import { removeLocalStorage, setLocalStorage } from "@/lib/local-storage";
 import { STORAGE_KEYS } from "@/lib/settings/constants";
 import { clearQueuedTaskCreateLastUsedIfSynced } from "./task-create-dialog-handlers";
 
@@ -66,20 +66,35 @@ export function StateProvider({ children, initialState }: StoreProviderProps) {
 function syncTaskCreateLastUsedCache(state: AppState) {
   if (!state.userSettings.loaded) return;
   const lastUsed = state.userSettings.taskCreateLastUsed;
-  syncTaskCreateLastUsedCacheField(STORAGE_KEYS.LAST_REPOSITORY_ID, lastUsed?.repositoryId);
-  syncTaskCreateLastUsedCacheField(STORAGE_KEYS.LAST_BRANCH, lastUsed?.branch);
-  syncTaskCreateLastUsedCacheField(STORAGE_KEYS.LAST_AGENT_PROFILE_ID, lastUsed?.agentProfileId);
+  syncTaskCreateLastUsedCacheField(
+    STORAGE_KEYS.LAST_REPOSITORY_ID,
+    lastUsed?.repositoryId,
+    lastUsed?.synced,
+  );
+  syncTaskCreateLastUsedCacheField(STORAGE_KEYS.LAST_BRANCH, lastUsed?.branch, lastUsed?.synced);
+  syncTaskCreateLastUsedCacheField(
+    STORAGE_KEYS.LAST_AGENT_PROFILE_ID,
+    lastUsed?.agentProfileId,
+    lastUsed?.synced,
+  );
   syncTaskCreateLastUsedCacheField(
     STORAGE_KEYS.LAST_EXECUTOR_PROFILE_ID,
     lastUsed?.executorProfileId,
+    lastUsed?.synced,
   );
   clearQueuedTaskCreateLastUsedIfSynced(lastUsed);
 }
 
-function syncTaskCreateLastUsedCacheField(key: string, value: string | null | undefined) {
-  // A missing backend field is not a clear request; keep the browser fallback.
-  if (!value) return;
-  setLocalStorage(key, value);
+function syncTaskCreateLastUsedCacheField(
+  key: string,
+  value: string | null | undefined,
+  synced: boolean | undefined,
+) {
+  if (value) {
+    setLocalStorage(key, value);
+    return;
+  }
+  if (synced) removeLocalStorage(key);
 }
 
 function taskCreateLastUsedEqual(
@@ -90,7 +105,8 @@ function taskCreateLastUsedEqual(
     a?.repositoryId === b?.repositoryId &&
     a?.branch === b?.branch &&
     a?.agentProfileId === b?.agentProfileId &&
-    a?.executorProfileId === b?.executorProfileId
+    a?.executorProfileId === b?.executorProfileId &&
+    a?.synced === b?.synced
   );
 }
 

--- a/apps/web/components/state-provider.tsx
+++ b/apps/web/components/state-provider.tsx
@@ -6,7 +6,7 @@ import { useStore } from "zustand";
 import { isDebug, registerSessionTaskResolver } from "@/lib/debug/log";
 import type { AppState, StoreProviderProps } from "@/lib/state/store";
 import { createAppStore } from "@/lib/state/store";
-import { removeLocalStorage, setLocalStorage } from "@/lib/local-storage";
+import { setLocalStorage } from "@/lib/local-storage";
 import { STORAGE_KEYS } from "@/lib/settings/constants";
 import { clearQueuedTaskCreateLastUsedIfSynced } from "./task-create-dialog-handlers";
 
@@ -77,21 +77,9 @@ function syncTaskCreateLastUsedCache(state: AppState) {
 }
 
 function syncTaskCreateLastUsedCacheField(key: string, value: string | null | undefined) {
-  if (value) {
-    setLocalStorage(key, value);
-    return;
-  }
-  deferRemoveTaskCreateLastUsedCacheField(key);
-}
-
-function deferRemoveTaskCreateLastUsedCacheField(key: string) {
-  const cachedValue = window.localStorage.getItem(key);
-  if (cachedValue === null) return;
-  window.setTimeout(() => {
-    if (window.localStorage.getItem(key) === cachedValue) {
-      removeLocalStorage(key);
-    }
-  }, 0);
+  // A missing backend field is not a clear request; keep the browser fallback.
+  if (!value) return;
+  setLocalStorage(key, value);
 }
 
 function taskCreateLastUsedEqual(

--- a/apps/web/hooks/use-ensure-user-settings.test.ts
+++ b/apps/web/hooks/use-ensure-user-settings.test.ts
@@ -171,6 +171,7 @@ describe("useEnsureUserSettings", () => {
       branch: "main",
       agentProfileId: "agent-2",
       executorProfileId: "exec-profile-1",
+      synced: true,
     });
   });
 

--- a/apps/web/lib/ssr/user-settings.test.ts
+++ b/apps/web/lib/ssr/user-settings.test.ts
@@ -59,6 +59,35 @@ describe("buildCoreFields", () => {
     const result = buildCoreFields(settings);
     expect(result.terminalFontFamily).toBeNull();
   });
+
+  it("does not mark an empty task-create last-used object as synced", () => {
+    const settings = {
+      task_create_last_used: {},
+    } as unknown as Parameters<typeof buildCoreFields>[0];
+
+    const result = buildCoreFields(settings);
+    expect(result.taskCreateLastUsed).toEqual({
+      repositoryId: null,
+      branch: null,
+      agentProfileId: null,
+      executorProfileId: null,
+      synced: false,
+    });
+  });
+
+  it("marks task-create last-used as synced when a field is present", () => {
+    const settings = {
+      task_create_last_used: {
+        repository_id: "repo-1",
+      },
+    } as unknown as Parameters<typeof buildCoreFields>[0];
+
+    const result = buildCoreFields(settings);
+    expect(result.taskCreateLastUsed).toMatchObject({
+      repositoryId: "repo-1",
+      synced: true,
+    });
+  });
 });
 
 describe("buildTerminalFields via buildCoreFields", () => {

--- a/apps/web/lib/ssr/user-settings.ts
+++ b/apps/web/lib/ssr/user-settings.ts
@@ -70,6 +70,7 @@ function parseTaskCreateLastUsed(value: UserSettingsData["task_create_last_used"
     branch: value?.branch || null,
     agentProfileId: value?.agent_profile_id || null,
     executorProfileId: value?.executor_profile_id || null,
+    synced: value !== undefined,
   };
 }
 

--- a/apps/web/lib/ssr/user-settings.ts
+++ b/apps/web/lib/ssr/user-settings.ts
@@ -64,13 +64,21 @@ function parseSidebarTaskPrefs(value: SidebarTaskPrefsApi | undefined) {
   };
 }
 
+export function taskCreateLastUsedHasValue(
+  value: UserSettingsData["task_create_last_used"] | undefined,
+) {
+  return Boolean(
+    value?.repository_id || value?.branch || value?.agent_profile_id || value?.executor_profile_id,
+  );
+}
+
 function parseTaskCreateLastUsed(value: UserSettingsData["task_create_last_used"] | undefined) {
   return {
     repositoryId: value?.repository_id || null,
     branch: value?.branch || null,
     agentProfileId: value?.agent_profile_id || null,
     executorProfileId: value?.executor_profile_id || null,
-    synced: value !== undefined,
+    synced: taskCreateLastUsedHasValue(value),
   };
 }
 

--- a/apps/web/lib/state/slices/settings/settings-slice.ts
+++ b/apps/web/lib/state/slices/settings/settings-slice.ts
@@ -47,6 +47,7 @@ export const defaultSettingsState: SettingsSliceState = {
       branch: null,
       agentProfileId: null,
       executorProfileId: null,
+      synced: false,
     },
     jiraSavedViews: undefined,
     jiraTaskPresets: undefined,

--- a/apps/web/lib/state/slices/settings/types.ts
+++ b/apps/web/lib/state/slices/settings/types.ts
@@ -181,6 +181,7 @@ export type TaskCreateLastUsedState = {
   branch: string | null;
   agentProfileId: string | null;
   executorProfileId: string | null;
+  synced?: boolean;
 };
 
 export type VoiceModeState = {

--- a/apps/web/lib/ws/handlers/users.test.ts
+++ b/apps/web/lib/ws/handlers/users.test.ts
@@ -89,7 +89,9 @@ describe("user settings websocket handler", () => {
 
     expect(store.getState().sidebarViews.draft).toBeNull();
   });
+});
 
+describe("user settings websocket task-create last-used", () => {
   it("does not mark empty task-create last-used broadcasts as synced", () => {
     const store = makeStore();
 
@@ -115,6 +117,35 @@ describe("user settings websocket handler", () => {
 
     expect(store.getState().userSettings.taskCreateLastUsed).toMatchObject({
       repositoryId: "repo-1",
+      synced: true,
+    });
+  });
+
+  it("preserves task-create last-used state when broadcasts omit it", () => {
+    const store = makeStore();
+    store.setState((state) => ({
+      ...state,
+      userSettings: {
+        ...state.userSettings,
+        taskCreateLastUsed: {
+          repositoryId: "repo-1",
+          branch: "main",
+          agentProfileId: "agent-1",
+          executorProfileId: "exec-1",
+          synced: true,
+        },
+      },
+    }));
+
+    registerUsersHandlers(store)["user.settings.updated"]?.(
+      userSettingsMessage({ keyboard_shortcuts: {} }),
+    );
+
+    expect(store.getState().userSettings.taskCreateLastUsed).toEqual({
+      repositoryId: "repo-1",
+      branch: "main",
+      agentProfileId: "agent-1",
+      executorProfileId: "exec-1",
       synced: true,
     });
   });

--- a/apps/web/lib/ws/handlers/users.test.ts
+++ b/apps/web/lib/ws/handlers/users.test.ts
@@ -89,6 +89,35 @@ describe("user settings websocket handler", () => {
 
     expect(store.getState().sidebarViews.draft).toBeNull();
   });
+
+  it("does not mark empty task-create last-used broadcasts as synced", () => {
+    const store = makeStore();
+
+    registerUsersHandlers(store)["user.settings.updated"]?.(
+      userSettingsMessage({ task_create_last_used: {} }),
+    );
+
+    expect(store.getState().userSettings.taskCreateLastUsed).toEqual({
+      repositoryId: null,
+      branch: null,
+      agentProfileId: null,
+      executorProfileId: null,
+      synced: false,
+    });
+  });
+
+  it("marks task-create last-used broadcasts as synced when a field is present", () => {
+    const store = makeStore();
+
+    registerUsersHandlers(store)["user.settings.updated"]?.(
+      userSettingsMessage({ task_create_last_used: { repository_id: "repo-1" } }),
+    );
+
+    expect(store.getState().userSettings.taskCreateLastUsed).toMatchObject({
+      repositoryId: "repo-1",
+      synced: true,
+    });
+  });
 });
 
 describe("user settings websocket sidebar settings", () => {

--- a/apps/web/lib/ws/handlers/users.ts
+++ b/apps/web/lib/ws/handlers/users.ts
@@ -54,6 +54,7 @@ function buildSyncedLocalSettings(payload: UserSettingsUpdatedPayload) {
       branch: payload.task_create_last_used?.branch || null,
       agentProfileId: payload.task_create_last_used?.agent_profile_id || null,
       executorProfileId: payload.task_create_last_used?.executor_profile_id || null,
+      synced: Object.prototype.hasOwnProperty.call(payload, "task_create_last_used"),
     },
     jiraSavedViews: payload.jira_saved_views,
     jiraTaskPresets: payload.jira_task_presets,

--- a/apps/web/lib/ws/handlers/users.ts
+++ b/apps/web/lib/ws/handlers/users.ts
@@ -5,6 +5,7 @@ import type { WsHandlers } from "@/lib/ws/handlers/types";
 import {
   parseChangesPanelLayout,
   parseSystemMetricsDisplay,
+  taskCreateLastUsedHasValue,
   parseVoiceMode,
 } from "@/lib/ssr/user-settings";
 import { fromApiSidebarDraft, fromApiSidebarView } from "@/lib/state/slices/ui/sidebar-view-wire";
@@ -54,7 +55,7 @@ function buildSyncedLocalSettings(payload: UserSettingsUpdatedPayload) {
       branch: payload.task_create_last_used?.branch || null,
       agentProfileId: payload.task_create_last_used?.agent_profile_id || null,
       executorProfileId: payload.task_create_last_used?.executor_profile_id || null,
-      synced: Object.prototype.hasOwnProperty.call(payload, "task_create_last_used"),
+      synced: taskCreateLastUsedHasValue(payload.task_create_last_used),
     },
     jiraSavedViews: payload.jira_saved_views,
     jiraTaskPresets: payload.jira_task_presets,

--- a/apps/web/lib/ws/handlers/users.ts
+++ b/apps/web/lib/ws/handlers/users.ts
@@ -30,7 +30,7 @@ function buildUserSettingsState(state: AppState, payload: UserSettingsUpdatedPay
     ...buildBehaviorSettings(payload),
     ...buildSidebarSettings(state, payload),
     ...buildLspSettings(payload),
-    ...buildSyncedLocalSettings(payload),
+    ...buildSyncedLocalSettings(state, payload),
     defaultUtilityAgentId: payload.default_utility_agent_id || null,
     keyboardShortcuts: payload.keyboard_shortcuts ?? {},
     changesPanelLayout: parseChangesPanelLayout(payload.changes_panel_layout),
@@ -47,16 +47,19 @@ function buildLspSettings(payload: UserSettingsUpdatedPayload) {
   };
 }
 
-function buildSyncedLocalSettings(payload: UserSettingsUpdatedPayload) {
+function buildSyncedLocalSettings(state: AppState, payload: UserSettingsUpdatedPayload) {
   return {
     savedLayouts: payload.saved_layouts ?? [],
-    taskCreateLastUsed: {
-      repositoryId: payload.task_create_last_used?.repository_id || null,
-      branch: payload.task_create_last_used?.branch || null,
-      agentProfileId: payload.task_create_last_used?.agent_profile_id || null,
-      executorProfileId: payload.task_create_last_used?.executor_profile_id || null,
-      synced: taskCreateLastUsedHasValue(payload.task_create_last_used),
-    },
+    taskCreateLastUsed:
+      payload.task_create_last_used === undefined
+        ? state.userSettings.taskCreateLastUsed
+        : {
+            repositoryId: payload.task_create_last_used?.repository_id || null,
+            branch: payload.task_create_last_used?.branch || null,
+            agentProfileId: payload.task_create_last_used?.agent_profile_id || null,
+            executorProfileId: payload.task_create_last_used?.executor_profile_id || null,
+            synced: taskCreateLastUsedHasValue(payload.task_create_last_used),
+          },
     jiraSavedViews: payload.jira_saved_views,
     jiraTaskPresets: payload.jira_task_presets,
     githubSavedPresets: payload.github_saved_presets,


### PR DESCRIPTION
Cold refreshes could erase the browser fallback for create-task choices before the dialog opened, so previous repo/profile defaults sometimes disappeared. Missing backend task-create fields now leave the validated local fallback intact, keeping the dialog prefilled across sessions.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs && node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `pnpm --filter @kandev/web test -- --run components/state-provider.test.tsx`
- `pnpm --filter @kandev/web test -- --run components/task-create-dialog-repository-autopick.test.ts components/task-create-dialog-effects.test.ts components/task-create-dialog-effects-executor.test.ts hooks/use-ensure-user-settings.test.ts`
- `cd apps/web && pnpm run typecheck`
- `pnpm --filter @kandev/web lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->