### PR TITLE
fix: recover stale prompts and invalid monitors

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -987,6 +987,34 @@ func (m *Manager) IsAgentReadyForPrompt(ctx context.Context, sessionID string) b
 	return execution.agentctl.HasAgentStream()
 }
 
+func (m *Manager) RecoverAgentPromptStream(ctx context.Context, sessionID string) error {
+	execution, exists := m.GetExecutionBySessionID(sessionID)
+	if !exists {
+		return fmt.Errorf("session %q has no execution: %w", sessionID, ErrExecutionNotFound)
+	}
+	if execution.PassthroughProcessID != "" || execution.IsPassthrough || execution.agentctl == nil {
+		return nil
+	}
+	if execution.agentctl.HasAgentStream() {
+		return nil
+	}
+	if m.streamManager == nil {
+		return fmt.Errorf("stream manager is not configured")
+	}
+
+	ready := make(chan struct{})
+	m.streamManager.connectUpdatesStreamAsync(execution, ready)
+	select {
+	case <-ready:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if !execution.agentctl.HasAgentStream() {
+		return fmt.Errorf("agent stream not connected")
+	}
+	return nil
+}
+
 // UpdateStatus updates the status of an execution
 func (m *Manager) UpdateStatus(executionID string, status v1.AgentStatus) error {
 	if err := m.executionStore.WithLock(executionID, func(execution *AgentExecution) {

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1015,9 +1015,17 @@ func (m *Manager) RecoverAgentPromptStream(ctx context.Context, sessionID string
 		return fmt.Errorf("agent stream not connected")
 	}
 	if execution.Status == v1.AgentStatusFailed && execution.sessionInitialized && execution.ACPSessionID != "" {
+		status, err := execution.agentctl.GetStatus(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to verify agent status after stream recovery: %w", err)
+		}
+		if !status.IsAgentRunning() {
+			return fmt.Errorf("agent process is not running after stream recovery: %s", status.AgentStatus)
+		}
 		if err := m.UpdateStatus(execution.ID, v1.AgentStatusReady); err != nil {
 			return err
 		}
+		m.eventPublisher.PublishAgentEvent(ctx, events.AgentBootReady, execution)
 	}
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1003,6 +1003,8 @@ func (m *Manager) RecoverAgentPromptStream(ctx context.Context, sessionID string
 	}
 
 	ready := make(chan struct{})
+	// Prompt recovery is reached through the per-session prompt path. Avoid a
+	// broader reconnect registry here; HasAgentStream above covers steady state.
 	m.streamManager.connectUpdatesStreamAsync(execution, ready)
 	select {
 	case <-ready:
@@ -1011,6 +1013,11 @@ func (m *Manager) RecoverAgentPromptStream(ctx context.Context, sessionID string
 	}
 	if !execution.agentctl.HasAgentStream() {
 		return fmt.Errorf("agent stream not connected")
+	}
+	if execution.Status == v1.AgentStatusFailed && execution.sessionInitialized && execution.ACPSessionID != "" {
+		if err := m.UpdateStatus(execution.ID, v1.AgentStatusReady); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1022,10 +1022,9 @@ func (m *Manager) RecoverAgentPromptStream(ctx context.Context, sessionID string
 		if !status.IsAgentRunning() {
 			return fmt.Errorf("agent process is not running after stream recovery: %s", status.AgentStatus)
 		}
-		if err := m.UpdateStatus(execution.ID, v1.AgentStatusReady); err != nil {
+		if err := m.markBootReadyFromFailed(ctx, execution.ID); err != nil {
 			return err
 		}
-		m.eventPublisher.PublishAgentEvent(ctx, events.AgentBootReady, execution)
 	}
 	return nil
 }
@@ -1079,12 +1078,27 @@ func (m *Manager) MarkReady(executionID string) error {
 //
 // Publishes events.AgentBootReady. Returns error if execution not found.
 func (m *Manager) MarkBootReady(executionID string) error {
-	return m.markReadyEvent(executionID, events.AgentBootReady)
+	return m.markReadyEventWithContext(context.Background(), executionID, events.AgentBootReady)
 }
 
 // markReadyEvent is the shared body of MarkReady / MarkBootReady — both flip
 // the execution to the Ready status and publish their respective event type.
 func (m *Manager) markReadyEvent(executionID, eventType string) error {
+	return m.markReadyEventWithContext(context.Background(), executionID, eventType)
+}
+
+func (m *Manager) markBootReadyFromFailed(ctx context.Context, executionID string) error {
+	execution, exists := m.executionStore.Get(executionID)
+	if !exists {
+		return fmt.Errorf("execution %q not found", executionID)
+	}
+	if execution.Status != v1.AgentStatusFailed {
+		return nil
+	}
+	return m.markReadyEventWithContext(ctx, executionID, events.AgentBootReady)
+}
+
+func (m *Manager) markReadyEventWithContext(ctx context.Context, executionID, eventType string) error {
 	execution, exists := m.executionStore.Get(executionID)
 	if !exists {
 		return fmt.Errorf("execution %q not found", executionID)
@@ -1103,7 +1117,7 @@ func (m *Manager) markReadyEvent(executionID, eventType string) error {
 		zap.String("execution_id", executionID),
 		zap.String("event_type", eventType))
 
-	m.eventPublisher.PublishAgentEvent(context.Background(), eventType, execution)
+	m.eventPublisher.PublishAgentEvent(ctx, eventType, execution)
 	return nil
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -870,6 +870,47 @@ func TestRecoverAgentPromptStream(t *testing.T) {
 		updated, ok := mgr.executionStore.Get(exec.ID)
 		require.True(t, ok)
 		require.Equal(t, v1.AgentStatusReady, updated.Status)
+
+		mockBus, ok := mgr.eventBus.(*MockEventBus)
+		require.True(t, ok)
+		var sawBootReady bool
+		for _, ev := range mockBus.PublishedEvents {
+			if ev.Type == events.AgentBootReady {
+				sawBootReady = true
+				break
+			}
+		}
+		require.True(t, sawBootReady, "expected AgentBootReady event after stream recovery")
+	})
+
+	t.Run("does not restore failed status when agent process is stopped", func(t *testing.T) {
+		mock := newMockAgentServer(t)
+		t.Cleanup(mock.Close)
+		mock.agentStatus = "stopped"
+
+		client := createTestClient(t, mock.server.URL)
+		t.Cleanup(client.Close)
+
+		mgr := newTestManager(t)
+		exec := &AgentExecution{
+			ID:                 "exec-recover-stopped",
+			SessionID:          "session-recover-stopped",
+			ACPSessionID:       "acp-session-1",
+			Status:             v1.AgentStatusFailed,
+			agentctl:           client,
+			promptDoneCh:       make(chan PromptCompletionSignal, 1),
+			sessionInitialized: true,
+		}
+		require.NoError(t, mgr.executionStore.Add(exec))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		t.Cleanup(cancel)
+		err := mgr.RecoverAgentPromptStream(ctx, "session-recover-stopped")
+		require.ErrorContains(t, err, "agent process is not running")
+
+		updated, ok := mgr.executionStore.Get(exec.ID)
+		require.True(t, ok)
+		require.Equal(t, v1.AgentStatusFailed, updated.Status)
 	})
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -911,6 +911,12 @@ func TestRecoverAgentPromptStream(t *testing.T) {
 		updated, ok := mgr.executionStore.Get(exec.ID)
 		require.True(t, ok)
 		require.Equal(t, v1.AgentStatusFailed, updated.Status)
+
+		mockBus, ok := mgr.eventBus.(*MockEventBus)
+		require.True(t, ok)
+		for _, ev := range mockBus.PublishedEvents {
+			require.NotEqual(t, events.AgentBootReady, ev.Type)
+		}
 	})
 }
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction_test.go
@@ -800,6 +800,79 @@ func TestIsAgentReadyForPrompt(t *testing.T) {
 	})
 }
 
+func TestRecoverAgentPromptStream(t *testing.T) {
+	t.Run("missing execution returns not found", func(t *testing.T) {
+		mgr := newTestManager(t)
+		err := mgr.RecoverAgentPromptStream(context.Background(), "missing")
+		require.ErrorIs(t, err, ErrExecutionNotFound)
+	})
+
+	t.Run("passthrough execution is a no-op", func(t *testing.T) {
+		mgr := newTestManager(t)
+		require.NoError(t, mgr.executionStore.Add(&AgentExecution{
+			ID:                   "exec-passthrough",
+			SessionID:            "session-passthrough",
+			Status:               v1.AgentStatusFailed,
+			PassthroughProcessID: "pty-1",
+		}))
+
+		require.NoError(t, mgr.RecoverAgentPromptStream(context.Background(), "session-passthrough"))
+	})
+
+	t.Run("missing stream manager errors when stream is absent", func(t *testing.T) {
+		mgr := &Manager{
+			executionStore: NewExecutionStore(),
+			logger:         newTestLogger().WithFields(),
+		}
+		client := createTestClient(t, "http://127.0.0.1:1")
+		t.Cleanup(client.Close)
+		require.NoError(t, mgr.executionStore.Add(&AgentExecution{
+			ID:           "exec-no-stream-manager",
+			SessionID:    "session-no-stream-manager",
+			ACPSessionID: "acp-session-1",
+			Status:       v1.AgentStatusFailed,
+			agentctl:     client,
+		}))
+
+		err := mgr.RecoverAgentPromptStream(context.Background(), "session-no-stream-manager")
+		require.ErrorContains(t, err, "stream manager is not configured")
+	})
+
+	t.Run("reconnects stream and restores stale failed status", func(t *testing.T) {
+		mock := newMockAgentServer(t)
+		t.Cleanup(mock.Close)
+
+		client := createTestClient(t, mock.server.URL)
+		t.Cleanup(client.Close)
+
+		mgr := newTestManager(t)
+		exec := &AgentExecution{
+			ID:                 "exec-recover",
+			SessionID:          "session-recover",
+			ACPSessionID:       "acp-session-1",
+			Status:             v1.AgentStatusFailed,
+			agentctl:           client,
+			promptDoneCh:       make(chan PromptCompletionSignal, 1),
+			sessionInitialized: true,
+		}
+		require.NoError(t, mgr.executionStore.Add(exec))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		t.Cleanup(cancel)
+		require.NoError(t, mgr.RecoverAgentPromptStream(ctx, "session-recover"))
+
+		select {
+		case <-mock.wsConnected:
+		case <-time.After(2 * time.Second):
+			t.Fatal("mock server did not see WS connection")
+		}
+		require.True(t, client.HasAgentStream())
+		updated, ok := mgr.executionStore.Get(exec.ID)
+		require.True(t, ok)
+		require.Equal(t, v1.AgentStatusReady, updated.Status)
+	})
+}
+
 // TestEffectiveSessionMode covers the fresh-launch mode propagation for issue
 // #1183: a persisted session_mode (e.g. from a set_session_mode workflow step)
 // must override the profile default at ACP session init, while a missing

--- a/apps/backend/internal/agent/runtime/lifecycle/session_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session_test.go
@@ -47,6 +47,7 @@ type mockAgentServer struct {
 	mu                   sync.Mutex
 	actionLog            []string // ordered log of actions received
 	rejectStreamAttempts int
+	agentStatus          string
 	upgrader             websocket.Upgrader
 	handler              func(msg ws.Message) *ws.Message
 	wsConnected          chan struct{} // closed when WS stream connects
@@ -62,6 +63,16 @@ func newMockAgentServer(t *testing.T) *mockAgentServer {
 	}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, _ *http.Request) {
+		m.mu.Lock()
+		status := m.agentStatus
+		m.mu.Unlock()
+		if status == "" {
+			status = "running"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"agent_status":%q}`, status)
+	})
 
 	// Agent stream WebSocket endpoint
 	mux.HandleFunc("/api/v1/agent/stream", func(w http.ResponseWriter, r *http.Request) {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
@@ -166,31 +166,32 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	// itself is just beginning. Override to "in_progress" so the card stays
 	// open, and remember taskID -> toolCallID so subsequent task-notification
 	// envelopes can route their events back to this card.
-	monitorTaskID, isMonitorRegistration := recognizeMonitorRegistration(tcu.Meta, tcu.RawOutput)
+	monitorTaskID, isMonitorRegistrationCandidate := recognizeMonitorRegistration(tcu.Meta, tcu.RawOutput)
 
 	// Cheap pre-lock inspection of the meta envelope. The override itself runs
 	// under the lock so it can gate on payload kind (subagent_task only).
 	isAsyncLaunchedSub := isSubagentAsyncLaunched(tcu.Meta)
+	supplemental := toolCallUpdateSupplemental(tcu)
 
 	a.mu.Lock()
 	payload := a.activeToolCalls[toolCallID]
 	monitorCommand := ""
-	if isMonitorRegistration && status == toolStatusComplete {
-		if cmd, ok := validMonitorCommandFromPayload(payload); ok {
-			monitorCommand = cmd
-			a.trackMonitorLocked(sessionID, monitorTaskID, toolCallID)
-			status = toolStatusInProgress
-			a.logger.Info("monitor registered",
-				zap.String("session_id", sessionID),
-				zap.String("task_id", monitorTaskID),
-				zap.String("tool_call_id", toolCallID))
-		} else {
-			a.logger.Warn("ignoring malformed monitor registration",
-				zap.String("session_id", sessionID),
-				zap.String("task_id", monitorTaskID),
-				zap.String("tool_call_id", toolCallID))
-			isMonitorRegistration = false
-		}
+	if payload != nil && (tcu.RawInput != nil || len(tcu.Locations) > 0) {
+		a.normalizer.UpdatePayloadInput(payload, tcu.RawInput, supplemental)
+	}
+	if payload != nil && (tcu.Title != nil || tcu.Meta != nil || tcu.RawInput != nil || supplemental != nil) {
+		a.normalizer.EnrichFromToolCallUpdate(payload, tcu.Title, tcu.Meta, tcu.RawInput, supplemental)
+	}
+
+	isMonitorRegistration := false
+	if isMonitorRegistrationCandidate {
+		monitorCommand, isMonitorRegistration, status = a.registerMonitorRegistrationLocked(
+			sessionID,
+			monitorTaskID,
+			toolCallID,
+			payload,
+			status,
+		)
 	}
 
 	// A terminal tool_call_update for an already-tracked Monitor (the agent
@@ -215,17 +216,6 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	}
 
 	isTerminal := status == toolStatusComplete || status == toolStatusError || status == toolStatusCancelled
-
-	// Update stored payload with incremental rawInput (e.g. Claude Code sends
-	// command/cwd in a tool_call_update after the initial empty tool_call).
-	// OpenCode may send filePath/locations on the update frame only.
-	supplemental := toolCallUpdateSupplemental(tcu)
-	if payload != nil && (tcu.RawInput != nil || len(tcu.Locations) > 0) {
-		a.normalizer.UpdatePayloadInput(payload, tcu.RawInput, supplemental)
-	}
-	if payload != nil && (tcu.Title != nil || tcu.Meta != nil || tcu.RawInput != nil || supplemental != nil) {
-		a.normalizer.EnrichFromToolCallUpdate(payload, tcu.Title, tcu.Meta, tcu.RawInput, supplemental)
-	}
 
 	// Update stored payload with tool result output. Skip for tracked-Monitor
 	// terminal updates so Generic.Output stays the structured `{monitor: …}`
@@ -358,6 +348,39 @@ func enrichModifyFileFromContents(mf *streams.ModifyFilePayload, contents []acp.
 		}
 		break
 	}
+}
+
+func (a *Adapter) registerMonitorRegistrationLocked(
+	sessionID string,
+	monitorTaskID string,
+	toolCallID string,
+	payload *streams.NormalizedPayload,
+	status string,
+) (string, bool, string) {
+	if status != toolStatusComplete {
+		a.logger.Warn("ignoring non-terminal monitor registration",
+			zap.String("session_id", sessionID),
+			zap.String("task_id", monitorTaskID),
+			zap.String("tool_call_id", toolCallID),
+			zap.String("status", status))
+		return "", false, status
+	}
+
+	cmd, ok := validMonitorCommandFromPayload(payload)
+	if !ok {
+		a.logger.Warn("ignoring malformed monitor registration",
+			zap.String("session_id", sessionID),
+			zap.String("task_id", monitorTaskID),
+			zap.String("tool_call_id", toolCallID))
+		return "", false, status
+	}
+
+	a.trackMonitorLocked(sessionID, monitorTaskID, toolCallID)
+	a.logger.Info("monitor registered",
+		zap.String("session_id", sessionID),
+		zap.String("task_id", monitorTaskID),
+		zap.String("tool_call_id", toolCallID))
+	return cmd, true, toolStatusInProgress
 }
 
 func toolCallUpdateSupplemental(tcu *acp.SessionToolCallUpdate) map[string]any {

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/adapter_tools.go
@@ -167,21 +167,6 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	// open, and remember taskID -> toolCallID so subsequent task-notification
 	// envelopes can route their events back to this card.
 	monitorTaskID, isMonitorRegistration := recognizeMonitorRegistration(tcu.Meta, tcu.RawOutput)
-	if isMonitorRegistration && status == toolStatusComplete {
-		a.trackMonitor(sessionID, monitorTaskID, toolCallID)
-		status = toolStatusInProgress
-		a.logger.Info("monitor registered",
-			zap.String("session_id", sessionID),
-			zap.String("task_id", monitorTaskID),
-			zap.String("tool_call_id", toolCallID))
-	}
-
-	// A terminal tool_call_update for an already-tracked Monitor (the agent
-	// proactively ended the watch). NormalizeToolResult would otherwise stomp
-	// the `{monitor: …}` view in Generic.Output with the raw string body, so
-	// we suppress the normalize call and let the closing-out logic below mark
-	// the view as ended instead.
-	isTrackedMonitorTerminal := !isMonitorRegistration && isMonitorMeta(tcu.Meta) && a.isTrackedMonitor(sessionID, toolCallID)
 
 	// Cheap pre-lock inspection of the meta envelope. The override itself runs
 	// under the lock so it can gate on payload kind (subagent_task only).
@@ -189,6 +174,31 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 
 	a.mu.Lock()
 	payload := a.activeToolCalls[toolCallID]
+	monitorCommand := ""
+	if isMonitorRegistration && status == toolStatusComplete {
+		if cmd, ok := validMonitorCommandFromPayload(payload); ok {
+			monitorCommand = cmd
+			a.trackMonitorLocked(sessionID, monitorTaskID, toolCallID)
+			status = toolStatusInProgress
+			a.logger.Info("monitor registered",
+				zap.String("session_id", sessionID),
+				zap.String("task_id", monitorTaskID),
+				zap.String("tool_call_id", toolCallID))
+		} else {
+			a.logger.Warn("ignoring malformed monitor registration",
+				zap.String("session_id", sessionID),
+				zap.String("task_id", monitorTaskID),
+				zap.String("tool_call_id", toolCallID))
+			isMonitorRegistration = false
+		}
+	}
+
+	// A terminal tool_call_update for an already-tracked Monitor (the agent
+	// proactively ended the watch). NormalizeToolResult would otherwise stomp
+	// the `{monitor: …}` view in Generic.Output with the raw string body, so
+	// we suppress the normalize call and let the closing-out logic below mark
+	// the view as ended instead.
+	isTrackedMonitorTerminal := !isMonitorRegistration && isMonitorMeta(tcu.Meta) && a.isTrackedMonitorLocked(sessionID, toolCallID)
 
 	// Recognize claude-acp's async-launched subagent envelope: the Task tool
 	// successfully dispatched a background subagent. The dispatch IS terminal
@@ -236,7 +246,7 @@ func (a *Adapter) convertToolCallResultUpdate(sessionID string, tcu *acp.Session
 	// would shadow it and the frontend would render this as a generic
 	// tool_call instead.
 	if isMonitorRegistration && payload != nil {
-		seedMonitorView(payload, monitorTaskID, monitorCommandFromPayload(payload))
+		seedMonitorView(payload, monitorTaskID, monitorCommand)
 	}
 
 	// Preserve and mark-ended the Monitor view on tracked-Monitor terminal

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
@@ -119,6 +119,11 @@ func monitorCommandFromPayload(payload *streams.NormalizedPayload) string {
 	return cmd
 }
 
+func validMonitorCommandFromPayload(payload *streams.NormalizedPayload) (string, bool) {
+	cmd := strings.TrimSpace(monitorCommandFromPayload(payload))
+	return cmd, cmd != ""
+}
+
 // isTrackedMonitor returns true if any taskID -> toolCallID mapping in the
 // session's activeMonitors entry equals the given toolCallID. Used by
 // convertToolCallResultUpdate to recognize agent-emitted terminal updates
@@ -127,6 +132,10 @@ func monitorCommandFromPayload(payload *streams.NormalizedPayload) string {
 func (a *Adapter) isTrackedMonitor(sessionID, toolCallID string) bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
+	return a.isTrackedMonitorLocked(sessionID, toolCallID)
+}
+
+func (a *Adapter) isTrackedMonitorLocked(sessionID, toolCallID string) bool {
 	for _, tcID := range a.activeMonitors[sessionID] {
 		if tcID == toolCallID {
 			return true
@@ -158,6 +167,10 @@ func (a *Adapter) dropMonitorByToolCallIDLocked(sessionID, toolCallID string) {
 func (a *Adapter) trackMonitor(sessionID, taskID, toolCallID string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.trackMonitorLocked(sessionID, taskID, toolCallID)
+}
+
+func (a *Adapter) trackMonitorLocked(sessionID, taskID, toolCallID string) {
 	monitors := a.activeMonitors[sessionID]
 	if monitors == nil {
 		monitors = make(map[string]string)
@@ -427,7 +440,7 @@ func monitorEventEvent(sessionID, toolCallID string, body string, payload *strea
 // history — drop it from the map.
 func (a *Adapter) captureReplayMonitor(sessionID string, u acp.SessionUpdate) {
 	if tc := u.ToolCall; tc != nil {
-		if _, ok := recognizeMonitorTaskCall(tc); ok {
+		if cmd, ok := recognizeMonitorTaskCall(tc); ok && strings.TrimSpace(cmd) != "" {
 			a.trackMonitor(sessionID, replayPendingTaskID(string(tc.ToolCallId)), string(tc.ToolCallId))
 		}
 	}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor.go
@@ -433,7 +433,8 @@ func monitorEventEvent(sessionID, toolCallID string, body string, payload *strea
 //   - `tool_call` with `_meta.claudeCode.toolName == "Monitor"` (records by toolCallID;
 //     we don't yet know taskID until the registration update arrives)
 //   - `tool_call_update` whose `rawOutput` matches the registration banner
-//     (records the taskID -> toolCallID mapping)
+//     (records the taskID -> toolCallID mapping only when the initial Monitor
+//     tool_call carried a non-empty command)
 //
 // A `tool_call_update` whose status is terminal (`completed` with non-banner
 // rawOutput, `failed`, `cancelled`) means the Monitor already ended in
@@ -449,7 +450,6 @@ func (a *Adapter) captureReplayMonitor(sessionID string, u acp.SessionUpdate) {
 		if taskID, ok := recognizeMonitorRegistration(tcu.Meta, tcu.RawOutput); ok {
 			// Replace any pending-by-toolCallID placeholder with the real taskID.
 			a.replaceMonitorPendingKey(sessionID, toolCallID, taskID)
-			a.trackMonitor(sessionID, taskID, toolCallID)
 			return
 		}
 		// Terminal update for a tracked Monitor — drop it from the map so the
@@ -473,16 +473,22 @@ func replayPendingTaskID(toolCallID string) string {
 
 // replaceMonitorPendingKey rewrites an entry in activeMonitors that was
 // registered during replay with a placeholder taskID once the real taskID
-// arrives via the registration banner.
-func (a *Adapter) replaceMonitorPendingKey(sessionID, toolCallID, realTaskID string) {
+// arrives via the registration banner. Returns false when no valid pending
+// Monitor was captured from the initial tool_call.
+func (a *Adapter) replaceMonitorPendingKey(sessionID, toolCallID, realTaskID string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	monitors := a.activeMonitors[sessionID]
 	if monitors == nil {
-		return
+		return false
 	}
-	delete(monitors, replayPendingTaskID(toolCallID))
+	pendingTaskID := replayPendingTaskID(toolCallID)
+	if monitors[pendingTaskID] != toolCallID {
+		return false
+	}
+	delete(monitors, pendingTaskID)
 	monitors[realTaskID] = toolCallID
+	return true
 }
 
 // dropMonitorByToolCallID removes any entry in activeMonitors mapped to the

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
@@ -214,6 +214,17 @@ func TestRouteMonitorEvents_NoEnvelopeShortCircuits(t *testing.T) {
 
 func TestConvertToolCallResultUpdate_MonitorRegistrationOverridesCompleted(t *testing.T) {
 	a := newTestAdapter()
+	tc := &acp.SessionUpdateToolCall{
+		ToolCallId: "tc-monitor",
+		Title:      monitorToolName,
+		Kind:       acp.ToolKind("other"),
+		Meta:       monitorMeta(),
+		RawInput:   map[string]any{"command": "tail -f /var/log/x"},
+	}
+	if ev := a.convertToolCallUpdate("s1", tc); ev == nil {
+		t.Fatalf("seed: convertToolCallUpdate returned nil")
+	}
+
 	completed := acp.ToolCallStatus("completed")
 	tcu := &acp.SessionToolCallUpdate{
 		ToolCallId: "tc-monitor",
@@ -305,6 +316,52 @@ func TestConvertToolCallResultUpdate_MonitorRegistrationSurvivesNormalize(t *tes
 	}
 	if monitor["command"] != "tail -f /var/log/x" {
 		t.Errorf("monitor.command = %v, want it carried over from initial tool_call", monitor["command"])
+	}
+}
+
+func TestConvertToolCallResultUpdate_MonitorRegistrationRequiresCommand(t *testing.T) {
+	a := newTestAdapter()
+
+	tc := &acp.SessionUpdateToolCall{
+		ToolCallId: "tc-monitor",
+		Title:      monitorToolName,
+		Kind:       acp.ToolKind("other"),
+		Meta:       monitorMeta(),
+		RawInput:   map[string]any{},
+	}
+	if ev := a.convertToolCallUpdate("s1", tc); ev == nil {
+		t.Fatalf("seed: convertToolCallUpdate returned nil")
+	}
+
+	completed := acp.ToolCallStatus("completed")
+	tcu := &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-monitor",
+		Status:     &completed,
+		Meta:       monitorMeta(),
+		RawOutput:  "Monitor started (task fakeTaskId, timeout 60000ms). You will be notified.",
+	}
+
+	ev := a.convertToolCallResultUpdate("s1", tcu)
+	if ev == nil {
+		t.Fatal("expected generic tool update for malformed Monitor registration")
+	}
+	if ev.ToolStatus != toolStatusComplete {
+		t.Fatalf("ToolStatus = %q, want complete (malformed registration must not stay in_progress)", ev.ToolStatus)
+	}
+	if _, ok := a.lookupMonitorByTaskID("s1", "fakeTaskId"); ok {
+		t.Fatal("malformed Monitor registration was tracked")
+	}
+	if ev.NormalizedPayload != nil && ev.NormalizedPayload.Generic() != nil {
+		if out, ok := ev.NormalizedPayload.Generic().Output.(map[string]any); ok {
+			if _, hasMonitor := out["monitor"]; hasMonitor {
+				t.Fatalf("malformed Monitor registration rendered monitor payload: %+v", out["monitor"])
+			}
+		}
+	}
+
+	a.sweepMonitorsOnPromptEnd("s1")
+	if events := drainEvents(a); len(events) != 0 {
+		t.Fatalf("malformed Monitor registration emitted %d terminal monitor events", len(events))
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/monitor_test.go
@@ -365,6 +365,88 @@ func TestConvertToolCallResultUpdate_MonitorRegistrationRequiresCommand(t *testi
 	}
 }
 
+func TestConvertToolCallResultUpdate_MonitorRegistrationAcceptsCommandFromUpdate(t *testing.T) {
+	a := newTestAdapter()
+
+	tc := &acp.SessionUpdateToolCall{
+		ToolCallId: "tc-monitor",
+		Title:      monitorToolName,
+		Kind:       acp.ToolKind("other"),
+		Meta:       monitorMeta(),
+		RawInput:   map[string]any{},
+	}
+	if ev := a.convertToolCallUpdate("s1", tc); ev == nil {
+		t.Fatalf("seed: convertToolCallUpdate returned nil")
+	}
+
+	completed := acp.ToolCallStatus("completed")
+	tcu := &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-monitor",
+		Status:     &completed,
+		Meta:       monitorMeta(),
+		RawInput:   map[string]any{"command": "tail -f /var/log/later"},
+		RawOutput:  "Monitor started (task taskFromUpdate, timeout 60000ms). You will be notified.",
+	}
+
+	ev := a.convertToolCallResultUpdate("s1", tcu)
+	if ev == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if ev.ToolStatus != toolStatusInProgress {
+		t.Fatalf("ToolStatus = %q, want in_progress", ev.ToolStatus)
+	}
+	if got, ok := a.lookupMonitorByTaskID("s1", "taskFromUpdate"); !ok || got != "tc-monitor" {
+		t.Fatalf("activeMonitors lookup = (%q, %v), want (tc-monitor, true)", got, ok)
+	}
+	out, ok := ev.NormalizedPayload.Generic().Output.(map[string]any)
+	if !ok {
+		t.Fatalf("Generic.Output = %T, want map", ev.NormalizedPayload.Generic().Output)
+	}
+	monitor, ok := out["monitor"].(map[string]any)
+	if !ok {
+		t.Fatal("monitor output missing")
+	}
+	if monitor["command"] != "tail -f /var/log/later" {
+		t.Fatalf("monitor.command = %v, want update rawInput command", monitor["command"])
+	}
+}
+
+func TestConvertToolCallResultUpdate_MonitorRegistrationRequiresCompletedStatus(t *testing.T) {
+	a := newTestAdapter()
+
+	tc := &acp.SessionUpdateToolCall{
+		ToolCallId: "tc-monitor",
+		Title:      monitorToolName,
+		Kind:       acp.ToolKind("other"),
+		Meta:       monitorMeta(),
+		RawInput:   map[string]any{"command": "tail -f /var/log/x"},
+	}
+	if ev := a.convertToolCallUpdate("s1", tc); ev == nil {
+		t.Fatalf("seed: convertToolCallUpdate returned nil")
+	}
+
+	tcu := &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-monitor",
+		Meta:       monitorMeta(),
+		RawOutput:  "Monitor started (task statuslessTask, timeout 60000ms). You will be notified.",
+	}
+
+	ev := a.convertToolCallResultUpdate("s1", tcu)
+	if ev == nil {
+		t.Fatal("expected generic tool update for statusless Monitor banner")
+	}
+	if _, ok := a.lookupMonitorByTaskID("s1", "statuslessTask"); ok {
+		t.Fatal("statusless Monitor registration was tracked")
+	}
+	if ev.NormalizedPayload != nil && ev.NormalizedPayload.Generic() != nil {
+		if out, ok := ev.NormalizedPayload.Generic().Output.(map[string]any); ok {
+			if _, hasMonitor := out["monitor"]; hasMonitor {
+				t.Fatalf("statusless Monitor registration rendered monitor payload: %+v", out["monitor"])
+			}
+		}
+	}
+}
+
 // --- sweepMonitorsOnPromptEnd ---
 
 func TestSweepMonitorsOnPromptEnd_EmitsCompleteAndClears(t *testing.T) {
@@ -546,6 +628,32 @@ func TestCaptureReplayMonitor_RebuildsFromToolCallAndUpdate(t *testing.T) {
 
 	if got, ok := a.lookupMonitorByTaskID("s1", "realTask99"); !ok || got != "tc-replay" {
 		t.Errorf("after replay: lookup = (%q, %v), want (tc-replay, true)", got, ok)
+	}
+}
+
+func TestCaptureReplayMonitor_RegistrationRequiresPendingMonitor(t *testing.T) {
+	a := newTestAdapter()
+
+	tc := &acp.SessionUpdateToolCall{
+		ToolCallId: "tc-replay",
+		Title:      monitorToolName,
+		Kind:       acp.ToolKind("other"),
+		Meta:       monitorMeta(),
+		RawInput:   map[string]any{},
+	}
+	a.captureReplayMonitor("s1", acp.SessionUpdate{ToolCall: tc})
+
+	completed := acp.ToolCallStatus("completed")
+	tcu := &acp.SessionToolCallUpdate{
+		ToolCallId: "tc-replay",
+		Status:     &completed,
+		Meta:       monitorMeta(),
+		RawOutput:  "Monitor started (task fakeReplayTask, timeout 60000ms).",
+	}
+	a.captureReplayMonitor("s1", acp.SessionUpdate{ToolCallUpdate: tcu})
+
+	if _, ok := a.lookupMonitorByTaskID("s1", "fakeReplayTask"); ok {
+		t.Fatal("registration without a pending Monitor command was tracked")
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -325,6 +325,8 @@ func updateGenericInput(gen *streams.GenericPayload, inputMap, supplemental map[
 	}
 }
 
+// isEmptyGenericInputValue only treats absent values and empty strings as
+// fillable. Other zero values can be meaningful generic tool arguments.
 func isEmptyGenericInputValue(v any) bool {
 	switch x := v.(type) {
 	case nil:

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -302,6 +302,7 @@ func (n *Normalizer) UpdatePayloadInput(payload *streams.NormalizedPayload, rawI
 func updateGenericInput(gen *streams.GenericPayload, inputMap, supplemental map[string]any) {
 	args, ok := gen.Input.(map[string]any)
 	if !ok || args == nil {
+		// rawInput from ACP is always a JSON object; non-map input values are not expected.
 		args = map[string]any{}
 		gen.Input = args
 	}

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -279,6 +279,9 @@ func (n *Normalizer) UpdatePayloadInput(payload *streams.NormalizedPayload, rawI
 	if se := payload.ShellExec(); se != nil {
 		updateShellExecInput(se, inputMap)
 	}
+	if gen := payload.Generic(); gen != nil {
+		updateGenericInput(gen, inputMap, supplemental)
+	}
 	// Claude ACP sends file_path in incremental rawInput updates; OpenCode uses filePath.
 	if mf := payload.ModifyFile(); mf != nil {
 		updateModifyFileInput(mf, supplemental, inputMap)
@@ -293,6 +296,27 @@ func (n *Normalizer) UpdatePayloadInput(payload *streams.NormalizedPayload, rawI
 	// tool_call_update rawInput (Claude/OpenCode); fill empty fields only.
 	if sa := payload.SubagentTask(); sa != nil {
 		updateSubagentTaskInput(sa, inputMap)
+	}
+}
+
+func updateGenericInput(gen *streams.GenericPayload, inputMap, supplemental map[string]any) {
+	args, ok := gen.Input.(map[string]any)
+	if !ok || args == nil {
+		args = map[string]any{}
+		gen.Input = args
+	}
+	if len(inputMap) > 0 {
+		rawInput, _ := args["raw_input"].(map[string]any)
+		if rawInput == nil {
+			rawInput = map[string]any{}
+			args["raw_input"] = rawInput
+		}
+		for k, v := range inputMap {
+			rawInput[k] = v
+		}
+	}
+	for k, v := range supplemental {
+		args[k] = v
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize.go
@@ -312,11 +312,26 @@ func updateGenericInput(gen *streams.GenericPayload, inputMap, supplemental map[
 			args["raw_input"] = rawInput
 		}
 		for k, v := range inputMap {
-			rawInput[k] = v
+			if isEmptyGenericInputValue(rawInput[k]) {
+				rawInput[k] = v
+			}
 		}
 	}
 	for k, v := range supplemental {
-		args[k] = v
+		if isEmptyGenericInputValue(args[k]) {
+			args[k] = v
+		}
+	}
+}
+
+func isEmptyGenericInputValue(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return true
+	case string:
+		return x == ""
+	default:
+		return false
 	}
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/coder/acp-go-sdk"
+	"github.com/stretchr/testify/require"
+
 	"github.com/kandev/kandev/internal/agentctl/server/adapter/transport/shared"
 	"github.com/kandev/kandev/internal/agentctl/types/streams"
 )
@@ -831,6 +833,27 @@ func TestUpdatePayloadInput(t *testing.T) {
 		})
 		// Should not panic
 		normalizer.UpdatePayloadInput(payload, "not a map", nil)
+	})
+
+	t.Run("generic input merges without overwriting existing rawInput keys", func(t *testing.T) {
+		payload := normalizer.NormalizeToolCall("Monitor", map[string]any{
+			"kind": "other",
+			"raw_input": map[string]any{
+				"command": "tail -f old.log",
+				"timeout": "",
+			},
+		})
+
+		normalizer.UpdatePayloadInput(payload, map[string]any{
+			"command": "tail -f new.log",
+			"timeout": "60s",
+			"cwd":     "/tmp",
+		}, nil)
+
+		rawInput := payload.Generic().Input.(map[string]any)["raw_input"].(map[string]any)
+		require.Equal(t, "tail -f old.log", rawInput["command"])
+		require.Equal(t, "60s", rawInput["timeout"])
+		require.Equal(t, "/tmp", rawInput["cwd"])
 	})
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
@@ -856,23 +856,21 @@ func TestUpdatePayloadInput(t *testing.T) {
 		require.Equal(t, "/tmp", rawInput["cwd"])
 	})
 
-	t.Run("generic input merges supplemental without overwriting existing keys", func(t *testing.T) {
+	t.Run("generic input fills empty supplemental keys and skips non-empty ones", func(t *testing.T) {
 		payload := normalizer.NormalizeToolCall("Monitor", map[string]any{
-			"kind":     "other",
-			"location": "existing location",
-			"empty":    "",
+			"kind":      "other",
+			"raw_input": map[string]any{},
+			"path":      "/existing/path",
 		})
 
 		normalizer.UpdatePayloadInput(payload, nil, map[string]any{
-			"location": "line 42",
-			"empty":    "filled",
-			"note":     "from update",
+			"path":  "/new/path",
+			"title": "My Monitor",
 		})
 
 		args := payload.Generic().Input.(map[string]any)
-		require.Equal(t, "existing location", args["location"])
-		require.Equal(t, "filled", args["empty"])
-		require.Equal(t, "from update", args["note"])
+		require.Equal(t, "/existing/path", args["path"])
+		require.Equal(t, "My Monitor", args["title"])
 	})
 }
 

--- a/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
+++ b/apps/backend/internal/agentctl/server/adapter/transport/acp/normalize_test.go
@@ -855,6 +855,25 @@ func TestUpdatePayloadInput(t *testing.T) {
 		require.Equal(t, "60s", rawInput["timeout"])
 		require.Equal(t, "/tmp", rawInput["cwd"])
 	})
+
+	t.Run("generic input merges supplemental without overwriting existing keys", func(t *testing.T) {
+		payload := normalizer.NormalizeToolCall("Monitor", map[string]any{
+			"kind":     "other",
+			"location": "existing location",
+			"empty":    "",
+		})
+
+		normalizer.UpdatePayloadInput(payload, nil, map[string]any{
+			"location": "line 42",
+			"empty":    "filled",
+			"note":     "from update",
+		})
+
+		args := payload.Generic().Input.(map[string]any)
+		require.Equal(t, "existing location", args["location"])
+		require.Equal(t, "filled", args["empty"])
+		require.Equal(t, "from update", args["note"])
+	})
 }
 
 // TestEnrichModifyFileFromContents tests enriching modify_file payloads from tool_call_contents.

--- a/apps/backend/internal/backendapp/adapters.go
+++ b/apps/backend/internal/backendapp/adapters.go
@@ -379,6 +379,10 @@ func (a *lifecycleAdapter) IsAgentReadyForPrompt(ctx context.Context, sessionID 
 	return a.mgr.IsAgentReadyForPrompt(ctx, sessionID)
 }
 
+func (a *lifecycleAdapter) RecoverAgentPromptStream(ctx context.Context, sessionID string) error {
+	return a.mgr.RecoverAgentPromptStream(ctx, sessionID)
+}
+
 // IsPassthroughSession checks if the given session is running in passthrough (PTY) mode.
 func (a *lifecycleAdapter) IsPassthroughSession(ctx context.Context, sessionID string) bool {
 	return a.mgr.IsPassthroughSession(ctx, sessionID)

--- a/apps/backend/internal/orchestrator/prompt_idle_session_test.go
+++ b/apps/backend/internal/orchestrator/prompt_idle_session_test.go
@@ -405,6 +405,62 @@ func TestEnsureSessionRunning_WaitsForPromptReadyWhenExecutionExists(t *testing.
 	}
 }
 
+type promptStreamRecoveringAgentManager struct {
+	*mockAgentManager
+	recovered atomic.Bool
+}
+
+func (m *promptStreamRecoveringAgentManager) RecoverAgentPromptStream(context.Context, string) error {
+	m.recovered.Store(true)
+	return nil
+}
+
+func TestPromptTask_StalePromptStreamRecoversBeforeTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	repo := setupTestRepo(t)
+	seedTaskAndSession(t, repo, "task1", "session1", models.TaskSessionStateWaitingForInput)
+	session, err := repo.GetTaskSession(context.Background(), "session1")
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	session.AgentProfileID = "profile1"
+	if err := repo.UpdateTaskSession(context.Background(), session); err != nil {
+		t.Fatalf("failed to update session: %v", err)
+	}
+	seedExecutorRunning(t, repo, session.ID, session.TaskID, "exec-stale-stream")
+
+	baseMgr := &mockAgentManager{
+		isAgentRunning:         true,
+		repoForExecutionLookup: repo,
+	}
+	agentMgr := &promptStreamRecoveringAgentManager{mockAgentManager: baseMgr}
+	baseMgr.isAgentReadyFn = func(context.Context, string) bool {
+		return agentMgr.recovered.Load()
+	}
+
+	taskRepo := newMockTaskRepo()
+	taskRepo.tasks["task1"] = &v1.Task{
+		ID:    "task1",
+		Title: "Test Task",
+		State: v1.TaskStateInProgress,
+	}
+	svc := createTestServiceWithAgent(repo, newMockStepGetter(), taskRepo, agentMgr)
+	svc.executor = executor.NewExecutor(agentMgr, repo, testLogger(), executor.ExecutorConfig{})
+
+	_, err = svc.PromptTask(ctx, "task1", "session1", "are you stuck?", "", false, nil, false)
+	if err != nil {
+		t.Fatalf("expected stale prompt stream to recover, got: %v", err)
+	}
+	if !agentMgr.recovered.Load() {
+		t.Fatal("expected prompt stream recovery to run")
+	}
+	if len(agentMgr.capturedPromptCalls) != 1 {
+		t.Fatalf("expected prompt to be delivered after recovery, got %d calls", len(agentMgr.capturedPromptCalls))
+	}
+}
+
 func TestPromptTask_LazyResumeExecutionNotFoundFallsBackToFreshLaunch(t *testing.T) {
 	ctx := context.Background()
 	repo := setupTestRepo(t)

--- a/apps/backend/internal/orchestrator/task_operations.go
+++ b/apps/backend/internal/orchestrator/task_operations.go
@@ -55,6 +55,10 @@ const (
 	agentPromptReadyInterval = 100 * time.Millisecond
 )
 
+type agentPromptStreamRecoverer interface {
+	RecoverAgentPromptStream(ctx context.Context, sessionID string) error
+}
+
 func isAgentPromptInProgressError(err error) bool {
 	return err != nil && errors.Is(err, ErrAgentPromptInProgress)
 }
@@ -1243,6 +1247,7 @@ func (s *Service) advanceTaskWorkflowStep(ctx context.Context, task *models.Task
 func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, session *models.TaskSession) error {
 	// Check if agent is genuinely running (in-memory execution store, not just DB state)
 	if exec, ok := s.executor.GetExecutionBySession(sessionID); ok && exec != nil {
+		s.recoverAgentPromptStreamIfNeeded(ctx, sessionID)
 		if err := s.waitForAgentPromptReady(ctx, sessionID); err != nil {
 			return err
 		}
@@ -1306,6 +1311,21 @@ func (s *Service) ensureSessionRunning(ctx context.Context, sessionID string, se
 
 	s.logger.Debug("session resumed and ready for prompt")
 	return nil
+}
+
+func (s *Service) recoverAgentPromptStreamIfNeeded(ctx context.Context, sessionID string) {
+	if s.agentManager == nil || s.agentManager.IsAgentReadyForPrompt(ctx, sessionID) {
+		return
+	}
+	recoverer, ok := s.agentManager.(agentPromptStreamRecoverer)
+	if !ok {
+		return
+	}
+	if err := recoverer.RecoverAgentPromptStream(ctx, sessionID); err != nil {
+		s.logger.Debug("agent prompt stream recovery did not make session ready",
+			zap.String("session_id", sessionID),
+			zap.Error(err))
+	}
 }
 
 func (s *Service) waitForAgentPromptReady(ctx context.Context, sessionID string) error {


### PR DESCRIPTION
Idle session revival could time out even when the runtime only needed its ACP prompt stream reattached, and malformed Monitor registrations could render as successful empty watches. The backend now reconnects stale prompt streams before timing out and rejects Monitor registrations that lack a captured command.

## Important Changes

- Added a lifecycle prompt-stream recovery hook used before prompt readiness waits on existing executions.
- Required ACP Monitor registrations to match a tracked tool call with a non-empty command before they are rendered as Monitor cards.

## Validation

- `go test ./internal/orchestrator -run TestPromptTask_StalePromptStreamRecoversBeforeTimeout -count=1`
- `go test ./internal/agentctl/server/adapter/transport/acp -run TestConvertToolCallResultUpdate_MonitorRegistrationRequiresCommand -count=1`
- `go test ./internal/orchestrator -run 'TestPromptTask_StalePromptStreamRecoversBeforeTimeout|TestEnsureSessionRunning_WaitsForPromptReadyWhenExecutionExists|TestEnsureSessionRunning_IdleSessionTriggersResume' -count=1`
- `go test ./internal/agentctl/server/adapter/transport/acp -run 'Test(ConvertToolCallResultUpdate_MonitorRegistrationRequiresCommand|ConvertToolCallResultUpdate_MonitorRegistrationOverridesCompleted|ConvertToolCallResultUpdate_MonitorRegistrationSurvivesNormalize|ConvertToolCallResultUpdate_AgentEmittedMonitorEndPreservesView|CaptureReplayMonitor_RebuildsFromToolCallAndUpdate)' -count=1`
- `go test ./internal/agent/runtime/lifecycle ./internal/backendapp ./internal/orchestrator -count=1`
- `go test ./internal/agentctl/server/adapter/transport/acp -run TestLoadReplayBurst_HandlesLargeReplay -count=1 -timeout=45s`
- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`

Closes #1578
Closes #1579

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- kandev-preview-start -->
### Preview Environment

| | |
|---|---|
| **URL** | https://kandev-pr-1581-bwo7.sprites.app |
| **Commit** | `9021227` |
| **Agent** | Mock agent |

> Updates automatically on each push. Destroyed when the PR is closed.
<!-- kandev-preview-end -->