### PR TITLE
fix: correct Linear ticket-number search filter

### DIFF
--- a/apps/backend/internal/linear/graphql_client.go
+++ b/apps/backend/internal/linear/graphql_client.go
@@ -554,12 +554,13 @@ func parseIssueNumber(q string) (int, bool) {
 	return n, true
 }
 
-// searchableContentFilter matches free text across an issue's title and
-// description. `searchableContent` is a Linear ContentComparator whose only
-// text operator is `contains`, which is already case-insensitive full-text —
-// it deliberately does NOT expose `containsIgnoreCase` (sending that field
-// makes Linear reject the whole query with BAD_USER_INPUT / status 400).
-func searchableContentFilter(q string) map[string]interface{} {
+// searchableContentComparator matches free text across an issue's title and
+// description. It returns Linear's ContentComparator value (the inner map) that
+// callers nest under the `searchableContent` key — not the full filter. Its one
+// text operator, `contains`, is already case-insensitive full-text; the
+// ContentComparator deliberately does NOT expose `containsIgnoreCase` (sending
+// that field makes Linear reject the whole query with BAD_USER_INPUT / 400).
+func searchableContentComparator(q string) map[string]interface{} {
 	return map[string]interface{}{"contains": q}
 }
 
@@ -571,10 +572,10 @@ func searchableContentFilter(q string) map[string]interface{} {
 // ticket. The searchableContent branch stays in the OR so cross-references like
 // "duplicate of ENG-123" pasted into another issue's body still surface.
 func applyQueryFilter(out map[string]interface{}, q string) {
-	content := map[string]interface{}{"searchableContent": searchableContentFilter(q)}
+	content := searchableContentComparator(q)
 	if teamKey, num, ok := parseIssueIdentifier(q); ok {
 		out["or"] = []map[string]interface{}{
-			content,
+			{"searchableContent": content},
 			{
 				"team":   map[string]interface{}{"key": map[string]interface{}{"eq": teamKey}},
 				"number": map[string]interface{}{"eq": num},
@@ -584,12 +585,12 @@ func applyQueryFilter(out map[string]interface{}, q string) {
 	}
 	if num, ok := parseIssueNumber(q); ok {
 		out["or"] = []map[string]interface{}{
-			content,
+			{"searchableContent": content},
 			{"number": map[string]interface{}{"eq": num}},
 		}
 		return
 	}
-	out["searchableContent"] = searchableContentFilter(q)
+	out["searchableContent"] = content
 }
 
 // buildIssueFilter translates our SearchFilter into Linear's IssueFilter input.

--- a/apps/backend/internal/linear/graphql_client.go
+++ b/apps/backend/internal/linear/graphql_client.go
@@ -534,34 +534,71 @@ func parseIssueIdentifier(q string) (string, int, bool) {
 	return m[1], n, true
 }
 
+// issueNumberRe matches a bare issue number like "2438" — what a user types
+// when searching for a ticket by its number without the team prefix.
+var issueNumberRe = regexp.MustCompile(`^\d+$`)
+
+// parseIssueNumber returns the issue number when q is a bare integer. ok=false
+// means q is not a plain number (an out-of-range value also fails and is then
+// treated as free text). This lets "2438" resolve to an exact number match in
+// addition to the free-text branch.
+func parseIssueNumber(q string) (int, bool) {
+	q = strings.TrimSpace(q)
+	if !issueNumberRe.MatchString(q) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(q)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// searchableContentFilter matches free text across an issue's title and
+// description. `searchableContent` is a Linear ContentComparator whose only
+// text operator is `contains`, which is already case-insensitive full-text —
+// it deliberately does NOT expose `containsIgnoreCase` (sending that field
+// makes Linear reject the whole query with BAD_USER_INPUT / status 400).
+func searchableContentFilter(q string) map[string]interface{} {
+	return map[string]interface{}{"contains": q}
+}
+
+// applyQueryFilter translates the free-text portion of a search into Linear's
+// IssueFilter. `searchableContent` matches across title and description but
+// never indexes the issue identifier or number, so when the query looks like a
+// ticket reference (ENG-123, or a bare number like 2438) we OR in an exact
+// match — otherwise searching by ID/number returns zero hits for the target
+// ticket. The searchableContent branch stays in the OR so cross-references like
+// "duplicate of ENG-123" pasted into another issue's body still surface.
+func applyQueryFilter(out map[string]interface{}, q string) {
+	content := map[string]interface{}{"searchableContent": searchableContentFilter(q)}
+	if teamKey, num, ok := parseIssueIdentifier(q); ok {
+		out["or"] = []map[string]interface{}{
+			content,
+			{
+				"team":   map[string]interface{}{"key": map[string]interface{}{"eq": teamKey}},
+				"number": map[string]interface{}{"eq": num},
+			},
+		}
+		return
+	}
+	if num, ok := parseIssueNumber(q); ok {
+		out["or"] = []map[string]interface{}{
+			content,
+			{"number": map[string]interface{}{"eq": num}},
+		}
+		return
+	}
+	out["searchableContent"] = searchableContentFilter(q)
+}
+
 // buildIssueFilter translates our SearchFilter into Linear's IssueFilter input.
 // Empty fields are dropped so we don't send `{ "team": null }` and similar
 // (which Linear treats as a typed null and rejects).
 func buildIssueFilter(f SearchFilter) map[string]interface{} {
 	out := map[string]interface{}{}
 	if q := strings.TrimSpace(f.Query); q != "" {
-		// Linear has no top-level free-text field, but `searchableContent`
-		// matches across title and description. When the query looks like a
-		// ticket identifier (ENG-123) we OR in an exact team+number branch,
-		// because `searchableContent` never indexes the identifier itself —
-		// without the extra branch, searching by ID would return zero hits
-		// for the target ticket. We keep the `searchableContent` branch in
-		// the OR so cross-references like "duplicate of ENG-123" pasted into
-		// another issue's title or description still surface.
-		// `containsIgnoreCase` so identifier cross-references ("see ENG-123")
-		// match regardless of the user's input casing, and so free-text
-		// queries behave intuitively case-insensitively.
-		if teamKey, num, ok := parseIssueIdentifier(q); ok {
-			out["or"] = []map[string]interface{}{
-				{"searchableContent": map[string]interface{}{"containsIgnoreCase": q}},
-				{
-					"team":   map[string]interface{}{"key": map[string]interface{}{"eq": teamKey}},
-					"number": map[string]interface{}{"eq": num},
-				},
-			}
-		} else {
-			out["searchableContent"] = map[string]interface{}{"containsIgnoreCase": q}
-		}
+		applyQueryFilter(out, q)
 	}
 	if f.TeamKey != "" {
 		out["team"] = map[string]interface{}{"key": map[string]interface{}{"eq": f.TeamKey}}

--- a/apps/backend/internal/linear/graphql_client_test.go
+++ b/apps/backend/internal/linear/graphql_client_test.go
@@ -342,8 +342,11 @@ func TestBuildIssueFilter_IdentifierQuery(t *testing.T) {
 		t.Fatalf("expected or with 2 branches, got %+v", got["or"])
 	}
 	sc, _ := or[0]["searchableContent"].(map[string]interface{})
-	if sc["containsIgnoreCase"] != "ENG-123" {
-		t.Errorf("first OR branch should match searchableContent.containsIgnoreCase on raw query, got %+v", or[0])
+	if sc["contains"] != "ENG-123" {
+		t.Errorf("first OR branch should match searchableContent.contains on raw query, got %+v", or[0])
+	}
+	if _, bad := sc["containsIgnoreCase"]; bad {
+		t.Error("searchableContent must not use containsIgnoreCase (Linear rejects it with 400)")
 	}
 	team, _ := or[1]["team"].(map[string]interface{})
 	teamKey, _ := team["key"].(map[string]interface{})
@@ -363,8 +366,8 @@ func TestBuildIssueFilter_IdentifierLowercase(t *testing.T) {
 		t.Fatalf("expected or with 2 branches, got %+v", got["or"])
 	}
 	sc, _ := or[0]["searchableContent"].(map[string]interface{})
-	if sc["containsIgnoreCase"] != "eng-123" {
-		t.Errorf("searchableContent branch should preserve raw query under containsIgnoreCase, got %+v", sc)
+	if sc["contains"] != "eng-123" {
+		t.Errorf("searchableContent branch should preserve raw query under contains, got %+v", sc)
 	}
 	team, _ := or[1]["team"].(map[string]interface{})
 	teamKey, _ := team["key"].(map[string]interface{})
@@ -400,10 +403,67 @@ func TestBuildIssueFilter_NonIdentifierUnchanged(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected top-level searchableContent for non-identifier query, got %+v", got)
 	}
-	if sc["containsIgnoreCase"] != "auth bug" {
-		t.Errorf("searchableContent.containsIgnoreCase mismatch: %+v", sc)
+	if sc["contains"] != "auth bug" {
+		t.Errorf("searchableContent.contains mismatch: %+v", sc)
+	}
+	if _, bad := sc["containsIgnoreCase"]; bad {
+		t.Error("searchableContent must not use containsIgnoreCase (Linear rejects it with 400)")
 	}
 	if _, ok := got["or"]; ok {
 		t.Error("non-identifier query must not produce an or branch")
+	}
+}
+
+// TestBuildIssueFilter_BareNumber is the regression test for the "error when
+// searching" bug: searching a bare ticket number (e.g. "2438") must (a) never
+// emit containsIgnoreCase — the field Linear's ContentComparator rejects with a
+// BAD_USER_INPUT / status 400 — and (b) OR in an exact number match so the
+// target ticket is actually found (searchableContent never indexes the number).
+func TestBuildIssueFilter_BareNumber(t *testing.T) {
+	got := buildIssueFilter(SearchFilter{Query: "2438"})
+	if _, ok := got["searchableContent"]; ok {
+		t.Error("bare-number query should not set a top-level searchableContent filter")
+	}
+	or, ok := got["or"].([]map[string]interface{})
+	if !ok || len(or) != 2 {
+		t.Fatalf("expected or with 2 branches, got %+v", got["or"])
+	}
+	sc, _ := or[0]["searchableContent"].(map[string]interface{})
+	if sc["contains"] != "2438" {
+		t.Errorf("first OR branch should match searchableContent.contains on raw query, got %+v", or[0])
+	}
+	if _, bad := sc["containsIgnoreCase"]; bad {
+		t.Error("searchableContent must not use containsIgnoreCase (Linear rejects it with 400)")
+	}
+	num, _ := or[1]["number"].(map[string]interface{})
+	if num["eq"] != 2438 {
+		t.Errorf("second OR branch should match number.eq=2438, got %+v", or[1])
+	}
+	if _, ok := or[1]["team"]; ok {
+		t.Error("bare-number branch must not scope to a team key (number is matched across teams)")
+	}
+}
+
+func TestParseIssueNumber(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantN  int
+		wantOK bool
+	}{
+		{"2438", 2438, true},
+		{" 2438 ", 2438, true},
+		{"007", 7, true},
+		{"", 0, false},
+		{"ENG-123", 0, false},
+		{"12a", 0, false},
+		{"-5", 0, false},
+		{"+5", 0, false},
+		{"99999999999999999999999999", 0, false}, // overflow → treated as free text
+	}
+	for _, tc := range cases {
+		gotN, gotOK := parseIssueNumber(tc.in)
+		if gotOK != tc.wantOK || gotN != tc.wantN {
+			t.Errorf("parseIssueNumber(%q) = (%d,%v), want (%d,%v)", tc.in, gotN, gotOK, tc.wantN, tc.wantOK)
+		}
 	}
 }

--- a/apps/backend/internal/linear/graphql_client_test.go
+++ b/apps/backend/internal/linear/graphql_client_test.go
@@ -444,6 +444,23 @@ func TestBuildIssueFilter_BareNumber(t *testing.T) {
 	}
 }
 
+// TestBuildIssueFilter_BareNumberComposesWithTeam mirrors the identifier
+// compose test for the bare-number path: a selected team must AND with the
+// number OR branch (Linear ANDs all top-level conditions) so the number search
+// is scoped to that team, and no separate top-level searchableContent leaks in.
+func TestBuildIssueFilter_BareNumberComposesWithTeam(t *testing.T) {
+	got := buildIssueFilter(SearchFilter{Query: "2438", TeamKey: "ENG"})
+	if _, ok := got["or"]; !ok {
+		t.Error("expected or branch for bare-number query")
+	}
+	if _, ok := got["team"]; !ok {
+		t.Error("expected top-level team filter to AND with the or branches")
+	}
+	if _, ok := got["searchableContent"]; ok {
+		t.Error("bare-number query must not set a separate top-level searchableContent")
+	}
+}
+
 func TestParseIssueNumber(t *testing.T) {
 	cases := []struct {
 		in     string


### PR DESCRIPTION
Searching Linear by a bare ticket number (e.g. `2438`) failed with `status 400` because the filter sent `searchableContent: { containsIgnoreCase }`, a field Linear's `ContentComparator` doesn't define; this corrects the operator and makes numeric queries actually resolve to the target ticket.

## Important Changes

- Use `contains` (already case-insensitive full-text) for `searchableContent` in every branch, so the query is no longer rejected with `BAD_USER_INPUT`.
- OR in a `number.eq` match for bare-number queries — `searchableContent` never indexes the issue number, so without this a numeric search would return zero hits even once the 400 is fixed.

## Validation

- `go build ./...` (apps/backend) — compiles clean
- `go test ./internal/linear/...` — pass, including new `TestBuildIssueFilter_BareNumber`, `TestParseIssueNumber`, and `containsIgnoreCase` regression guards
- `gofmt -l` on changed files — clean
- `golangci-lint run ./internal/linear/... --new-from-rev=main` — 0 issues

## Possible Improvements

Low risk — a bare-number query matches issues with that number across all teams when no team filter is set (it is scoped to the team when one is selected). Could tighten to team-scoped only if it proves noisy.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

