### PR TITLE
fix: persist live executor runtime state (#1585)

### DIFF
--- a/apps/backend/internal/agent/runtime/lifecycle/manager.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager.go
@@ -202,6 +202,7 @@ func NewManager(
 
 	// Set session manager dependencies for full orchestration
 	sessionManager.SetDependencies(eventPublisher, mgr.streamManager, executionStore, historyManager)
+	sessionManager.SetStatusUpdater(mgr.UpdateStatus)
 
 	mgr.pollAggregator = newWorkspacePollAggregator(mgr)
 

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_events.go
@@ -123,8 +123,10 @@ func (m *Manager) handleCompleteEventMarkState(execution *AgentExecution, event 
 		m.logger.Info("flipping Ready→Running for empty wakeup turn before publishing AgentReady",
 			zap.String("execution_id", execution.ID),
 			zap.String("session_id", execution.SessionID))
-		if m.executionStore != nil {
-			m.executionStore.UpdateStatus(execution.ID, v1.AgentStatusRunning)
+		if err := m.UpdateStatus(execution.ID, v1.AgentStatusRunning); err != nil {
+			m.logger.Warn("failed to persist empty wakeup turn running status",
+				zap.String("execution_id", execution.ID),
+				zap.Error(err))
 		}
 		m.eventPublisher.PublishAgentEvent(context.Background(), events.AgentRunning, execution)
 	}
@@ -369,7 +371,12 @@ func (m *Manager) recordActivity(execution *AgentExecution, event agentctl.Agent
 	if _, ok := turnContentEventTypes[event.Type]; !ok {
 		return
 	}
-	m.executionStore.UpdateStatus(execution.ID, v1.AgentStatusRunning)
+	if err := m.UpdateStatus(execution.ID, v1.AgentStatusRunning); err != nil {
+		m.logger.Warn("failed to persist wakeup-driven running status",
+			zap.String("execution_id", execution.ID),
+			zap.Error(err))
+		return
+	}
 	m.logger.Info("wakeup-driven turn detected; flipping execution back to Running",
 		zap.String("execution_id", execution.ID),
 		zap.String("session_id", execution.SessionID),
@@ -386,8 +393,10 @@ func (m *Manager) handleStreamDisconnect(execution *AgentExecution, err error) {
 		zap.String("session_id", execution.SessionID),
 		zap.Error(err))
 
-	if m.executionStore != nil {
-		m.executionStore.UpdateStatus(execution.ID, v1.AgentStatusFailed)
+	if err := m.UpdateStatus(execution.ID, v1.AgentStatusFailed); err != nil {
+		m.logger.Warn("failed to persist stream disconnect failed status",
+			zap.String("execution_id", execution.ID),
+			zap.Error(err))
 	}
 
 	m.eventPublisher.PublishAgentctlEvent(

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -1117,6 +1117,7 @@ func (m *Manager) markReadyEventWithContext(ctx context.Context, executionID, ev
 		zap.String("execution_id", executionID),
 		zap.String("event_type", eventType))
 
+	m.persistExecutorRunning(ctx, execution)
 	m.eventPublisher.PublishAgentEvent(ctx, eventType, execution)
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_interaction.go
@@ -739,7 +739,9 @@ func (m *Manager) initializeACPSessionForRestart(
 	// Mark execution as ready. This is a *boot* signal — initializeACPSessionForRestart
 	// is the post-restart init path and no turn has run yet, so AgentBootReady (not
 	// AgentReady) is what subscribers want to route on.
-	m.executionStore.UpdateStatus(execution.ID, v1.AgentStatusReady)
+	if err := m.updateStatusAndPersist(ctx, execution.ID, v1.AgentStatusReady); err != nil {
+		return err
+	}
 	m.eventPublisher.PublishAgentEvent(ctx, events.AgentBootReady, execution)
 
 	return nil
@@ -1031,8 +1033,14 @@ func (m *Manager) RecoverAgentPromptStream(ctx context.Context, sessionID string
 
 // UpdateStatus updates the status of an execution
 func (m *Manager) UpdateStatus(executionID string, status v1.AgentStatus) error {
+	return m.updateStatusAndPersist(context.Background(), executionID, status)
+}
+
+func (m *Manager) updateStatusAndPersist(ctx context.Context, executionID string, status v1.AgentStatus) error {
+	var updated *AgentExecution
 	if err := m.executionStore.WithLock(executionID, func(execution *AgentExecution) {
 		execution.Status = status
+		updated = execution
 	}); err != nil {
 		if errors.Is(err, ErrExecutionNotFound) {
 			return fmt.Errorf("execution %q not found", executionID)
@@ -1044,6 +1052,9 @@ func (m *Manager) UpdateStatus(executionID string, status v1.AgentStatus) error 
 		zap.String("execution_id", executionID),
 		zap.String("status", string(status)))
 
+	if updated != nil {
+		m.persistExecutorRunning(context.WithoutCancel(ctx), updated)
+	}
 	return nil
 }
 
@@ -1111,13 +1122,14 @@ func (m *Manager) markReadyEventWithContext(ctx context.Context, executionID, ev
 		return nil
 	}
 
-	m.executionStore.UpdateStatus(executionID, v1.AgentStatusReady)
+	if err := m.updateStatusAndPersist(ctx, executionID, v1.AgentStatusReady); err != nil {
+		return err
+	}
 
 	m.logger.Info("execution ready",
 		zap.String("execution_id", executionID),
 		zap.String("event_type", eventType))
 
-	m.persistExecutorRunning(ctx, execution)
 	m.eventPublisher.PublishAgentEvent(ctx, eventType, execution)
 	return nil
 }

--- a/apps/backend/internal/agent/runtime/lifecycle/manager_passthrough.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/manager_passthrough.go
@@ -36,7 +36,9 @@ func (m *Manager) MarkPassthroughRunning(sessionID string) error {
 
 	// Only publish if not already running (prevents duplicate events)
 	if execution.Status != v1.AgentStatusRunning {
-		m.executionStore.UpdateStatus(execution.ID, v1.AgentStatusRunning)
+		if err := m.UpdateStatus(execution.ID, v1.AgentStatusRunning); err != nil {
+			return err
+		}
 		m.eventPublisher.PublishAgentEvent(context.Background(), events.AgentRunning, execution)
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/persistence.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/persistence.go
@@ -3,10 +3,14 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"net/url"
+	"strconv"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
 )
 
 // ExecutorRunningWriter is the narrow persistence interface the lifecycle manager
@@ -50,19 +54,32 @@ func (m *Manager) SetExecutorRunningWriter(w ExecutorRunningWriter) {
 // pre-existing row (a previous run's resume state) so the lifecycle write
 // doesn't clobber data the orchestrator's narrow CAS update wrote earlier.
 func buildRunningFromExecution(execution *AgentExecution, prior *models.ExecutorRunning) *models.ExecutorRunning {
+	agentctlURL := execution.AgentctlURL()
+	agentctlPort := agentctlPortFromExecution(execution, agentctlURL)
+	pid := agentctlPIDFromExecution(execution)
+	var lastSeenAt *time.Time
+	if agentctlURL != "" || agentctlPort > 0 || pid > 0 {
+		now := time.Now().UTC()
+		lastSeenAt = &now
+	}
+
 	running := &models.ExecutorRunning{
 		ID:               execution.SessionID,
 		SessionID:        execution.SessionID,
 		TaskID:           execution.TaskID,
 		Runtime:          execution.RuntimeName,
-		Status:           models.ExecutorRunningStatusStarting,
+		Status:           executorRunningStatusFromExecution(execution),
 		Resumable:        true,
 		AgentExecutionID: execution.ID,
 		ContainerID:      execution.ContainerID,
+		AgentctlURL:      agentctlURL,
+		AgentctlPort:     agentctlPort,
+		PID:              pid,
 		WorktreeID:       getMetadataString(execution.Metadata, MetadataKeyWorktreeID),
 		WorktreePath:     getMetadataString(execution.Metadata, "worktree_path"),
 		WorktreeBranch:   getMetadataString(execution.Metadata, MetadataKeyWorktreeBranch),
 		Metadata:         FilterPersistentMetadata(execution.Metadata),
+		LastSeenAt:       lastSeenAt,
 	}
 	if prior != nil {
 		running.ExecutorID = prior.ExecutorID
@@ -82,6 +99,82 @@ func buildRunningFromExecution(execution *AgentExecution, prior *models.Executor
 		}
 	}
 	return running
+}
+
+func agentctlPortFromExecution(execution *AgentExecution, agentctlURL string) int {
+	if execution == nil {
+		return 0
+	}
+	if execution.standalonePort > 0 {
+		return execution.standalonePort
+	}
+	if port := metadataInt(execution.Metadata, MetadataKeySSHLocalForwardPort); port > 0 {
+		return port
+	}
+	if port := metadataInt(execution.Metadata, MetadataKeyLocalPort); port > 0 {
+		return port
+	}
+	if agentctlURL == "" {
+		return 0
+	}
+	parsed, err := url.Parse(agentctlURL)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		return 0
+	}
+	return port
+}
+
+func agentctlPIDFromExecution(execution *AgentExecution) int {
+	if execution == nil {
+		return 0
+	}
+	return metadataInt(execution.Metadata, MetadataKeySSHRemoteAgentctlPID)
+}
+
+func metadataInt(metadata map[string]interface{}, key string) int {
+	if metadata == nil {
+		return 0
+	}
+	switch v := metadata[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return 0
+		}
+		return n
+	default:
+		return 0
+	}
+}
+
+func executorRunningStatusFromExecution(execution *AgentExecution) string {
+	if execution == nil {
+		return models.ExecutorRunningStatusStarting
+	}
+	switch execution.Status {
+	case v1.AgentStatusRunning:
+		return models.ExecutorRunningStatusRunning
+	case v1.AgentStatusReady:
+		return models.ExecutorRunningStatusReady
+	case v1.AgentStatusFailed:
+		return models.ExecutorRunningStatusFailed
+	case v1.AgentStatusStopped:
+		return models.ExecutorRunningStatusStopped
+	case v1.AgentStatusCompleted:
+		return models.ExecutorRunningStatusComplete
+	default:
+		return models.ExecutorRunningStatusStarting
+	}
 }
 
 // persistExecutorRunning writes the executors_running row for an execution that

--- a/apps/backend/internal/agent/runtime/lifecycle/persistence.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/persistence.go
@@ -213,6 +213,11 @@ func (m *Manager) persistExecutorRunning(ctx context.Context, execution *AgentEx
 	if reader, ok := m.runningWriter.(executorRunningReader); ok {
 		if existing, err := reader.GetExecutorRunningBySessionID(ctx, execution.SessionID); err == nil {
 			prior = existing
+		} else if !errors.Is(err, models.ErrExecutorRunningNotFound) {
+			m.logger.Warn("failed to read prior executors_running row; orchestrator-owned columns may be cleared",
+				zap.String("execution_id", execution.ID),
+				zap.String("session_id", execution.SessionID),
+				zap.Error(err))
 		}
 	}
 

--- a/apps/backend/internal/agent/runtime/lifecycle/persistence_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/persistence_test.go
@@ -1,0 +1,118 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	agentctl "github.com/kandev/kandev/internal/agent/runtime/agentctl"
+	"github.com/kandev/kandev/internal/agentruntime"
+	"github.com/kandev/kandev/internal/task/models"
+	v1 "github.com/kandev/kandev/pkg/api/v1"
+)
+
+type captureExecutorRunningWriter struct {
+	running *models.ExecutorRunning
+}
+
+func (w *captureExecutorRunningWriter) UpsertExecutorRunning(_ context.Context, running *models.ExecutorRunning) error {
+	w.running = running
+	return nil
+}
+
+func (w *captureExecutorRunningWriter) DeleteExecutorRunningBySessionID(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestBuildRunningFromExecutionPersistsLiveAgentctlEndpoint(t *testing.T) {
+	log := newNopLogger(t)
+	client := agentctl.NewClient("127.0.0.1", 45678, log)
+
+	running := buildRunningFromExecution(&AgentExecution{
+		ID:             "exec-1",
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RuntimeName:    agentruntime.RuntimeStandalone,
+		Status:         v1.AgentStatusRunning,
+		agentctl:       client,
+		standalonePort: 45678,
+	}, nil)
+
+	if running.Status != models.ExecutorRunningStatusRunning {
+		t.Fatalf("Status = %q, want running", running.Status)
+	}
+	if running.AgentctlURL != "http://127.0.0.1:45678" {
+		t.Fatalf("AgentctlURL = %q, want live client URL", running.AgentctlURL)
+	}
+	if running.AgentctlPort != 45678 {
+		t.Fatalf("AgentctlPort = %d, want 45678", running.AgentctlPort)
+	}
+	if running.LastSeenAt == nil {
+		t.Fatal("LastSeenAt = nil, want live endpoint observation timestamp")
+	}
+}
+
+func TestBuildRunningFromExecutionPersistsSSHRuntimePID(t *testing.T) {
+	log := newNopLogger(t)
+	client := agentctl.NewClient("127.0.0.1", 43001, log)
+
+	running := buildRunningFromExecution(&AgentExecution{
+		ID:          "exec-ssh",
+		TaskID:      "task-1",
+		SessionID:   "session-1",
+		RuntimeName: agentruntime.RuntimeSSH,
+		Status:      v1.AgentStatusRunning,
+		agentctl:    client,
+		Metadata: map[string]interface{}{
+			MetadataKeySSHLocalForwardPort:   "43001",
+			MetadataKeySSHRemoteAgentctlPID:  "9321",
+			MetadataKeySSHRemoteAgentctlPort: "43000",
+		},
+	}, nil)
+
+	if running.AgentctlURL != "http://127.0.0.1:43001" {
+		t.Fatalf("AgentctlURL = %q, want local forward URL", running.AgentctlURL)
+	}
+	if running.AgentctlPort != 43001 {
+		t.Fatalf("AgentctlPort = %d, want local forward port", running.AgentctlPort)
+	}
+	if running.PID != 9321 {
+		t.Fatalf("PID = %d, want remote agentctl pid", running.PID)
+	}
+	if running.LastSeenAt == nil {
+		t.Fatal("LastSeenAt = nil, want live endpoint observation timestamp")
+	}
+}
+
+func TestMarkReadyPersistsReadyExecutorRunningStatus(t *testing.T) {
+	log := newNopLogger(t)
+	client := agentctl.NewClient("127.0.0.1", 45678, log)
+	writer := &captureExecutorRunningWriter{}
+	mgr := newTestManager(t)
+	mgr.SetExecutorRunningWriter(writer)
+
+	if err := mgr.executionStore.Add(&AgentExecution{
+		ID:             "exec-ready",
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RuntimeName:    agentruntime.RuntimeStandalone,
+		Status:         v1.AgentStatusRunning,
+		agentctl:       client,
+		standalonePort: 45678,
+	}); err != nil {
+		t.Fatalf("Add execution: %v", err)
+	}
+
+	if err := mgr.MarkReady("exec-ready"); err != nil {
+		t.Fatalf("MarkReady: %v", err)
+	}
+
+	if writer.running == nil {
+		t.Fatal("expected MarkReady to persist executors_running row")
+	}
+	if writer.running.Status != models.ExecutorRunningStatusReady {
+		t.Fatalf("persisted status = %q, want ready", writer.running.Status)
+	}
+	if writer.running.AgentctlPort != 45678 {
+		t.Fatalf("persisted port = %d, want 45678", writer.running.AgentctlPort)
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/persistence_test.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/persistence_test.go
@@ -116,3 +116,34 @@ func TestMarkReadyPersistsReadyExecutorRunningStatus(t *testing.T) {
 		t.Fatalf("persisted port = %d, want 45678", writer.running.AgentctlPort)
 	}
 }
+
+func TestUpdateStatusPersistsRunningExecutorRunningStatus(t *testing.T) {
+	log := newNopLogger(t)
+	client := agentctl.NewClient("127.0.0.1", 45678, log)
+	writer := &captureExecutorRunningWriter{}
+	mgr := newTestManager(t)
+	mgr.SetExecutorRunningWriter(writer)
+
+	if err := mgr.executionStore.Add(&AgentExecution{
+		ID:             "exec-running",
+		TaskID:         "task-1",
+		SessionID:      "session-1",
+		RuntimeName:    agentruntime.RuntimeStandalone,
+		Status:         v1.AgentStatusReady,
+		agentctl:       client,
+		standalonePort: 45678,
+	}); err != nil {
+		t.Fatalf("Add execution: %v", err)
+	}
+
+	if err := mgr.UpdateStatus("exec-running", v1.AgentStatusRunning); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	if writer.running == nil {
+		t.Fatal("expected UpdateStatus to persist executors_running row")
+	}
+	if writer.running.Status != models.ExecutorRunningStatusRunning {
+		t.Fatalf("persisted status = %q, want running", writer.running.Status)
+	}
+}

--- a/apps/backend/internal/agent/runtime/lifecycle/session.go
+++ b/apps/backend/internal/agent/runtime/lifecycle/session.go
@@ -27,6 +27,7 @@ type SessionManager struct {
 	eventPublisher *EventPublisher
 	streamManager  *StreamManager
 	executionStore *ExecutionStore
+	statusUpdater  func(executionID string, status v1.AgentStatus) error
 	historyManager *SessionHistoryManager
 	stopCh         <-chan struct{} // For graceful shutdown coordination
 }
@@ -46,6 +47,10 @@ func (sm *SessionManager) SetDependencies(ep *EventPublisher, strm *StreamManage
 	sm.streamManager = strm
 	sm.executionStore = store
 	sm.historyManager = history
+}
+
+func (sm *SessionManager) SetStatusUpdater(updater func(executionID string, status v1.AgentStatus) error) {
+	sm.statusUpdater = updater
 }
 
 // InitializeResult contains the result of session initialization
@@ -605,7 +610,11 @@ func (sm *SessionManager) SendPrompt(
 		if execution.Status != v1.AgentStatusRunning && execution.Status != v1.AgentStatusReady {
 			return nil, fmt.Errorf("execution %q is not ready for prompts (status: %s)", execution.ID, execution.Status)
 		}
-		if sm.executionStore != nil {
+		if sm.statusUpdater != nil {
+			if err := sm.statusUpdater(execution.ID, v1.AgentStatusRunning); err != nil {
+				return nil, err
+			}
+		} else if sm.executionStore != nil {
 			sm.executionStore.UpdateStatus(execution.ID, v1.AgentStatusRunning)
 		}
 	}

--- a/apps/backend/internal/backendapp/branch_materializer.go
+++ b/apps/backend/internal/backendapp/branch_materializer.go
@@ -30,9 +30,10 @@ type branchMaterializerRepo interface {
 
 // agentctlRescanner is the lifecycle-tier surface the materializer uses to
 // reach a running agentctl by session_id. The lifecycle manager owns the
-// agentctl URL in memory — the executors_running row never persists it —
-// so the materializer can't HTTP-POST agentctl directly. Defined as an
-// interface so the materializer stays decoupled from the lifecycle package.
+// authenticated agentctl client; executors_running may carry endpoint metadata
+// for diagnostics/recovery, but callers should not bypass lifecycle ownership.
+// Defined as an interface so the materializer stays decoupled from the
+// lifecycle package.
 type agentctlRescanner interface {
 	RescanWorkspaceForSession(ctx context.Context, sessionID, workDir string) error
 	NotifyWorktreeMaterialized(ctx context.Context, wt lifecycle.MaterializedWorktree)
@@ -228,9 +229,8 @@ func (b *branchMaterializer) promoteWorkspacePathIfNeeded(ctx context.Context, e
 // notifyAgentctlRescan tells the running agentctl instance attached to
 // this session to re-discover repo subdirs and add per-repo trackers for
 // new sibling worktrees. Routes through the lifecycle manager because the
-// agentctl URL is in-memory runtime state — the executors_running row
-// never persists it — and the lifecycle manager is the single owner of
-// per-execution agentctl clients.
+// lifecycle manager is the single owner of authenticated per-execution
+// agentctl clients.
 //
 // No-op when no rescanner is wired (test stubs, agentless test envs) or
 // when the session has no active execution (agent stopped). The next

--- a/apps/backend/internal/orchestrator/executor/executor_execute.go
+++ b/apps/backend/internal/orchestrator/executor/executor_execute.go
@@ -698,10 +698,11 @@ func (e *Executor) finalizeLaunch(ctx context.Context, task *v1.Task, session *m
 	} else {
 		// Prepare-only launch: the workspace + agentctl are up but the agent
 		// process is intentionally not being started. The lifecycle manager
-		// always writes status='starting' on row creation; flip it to
-		// 'prepared' so the row doesn't look stuck mid-launch. When the user
-		// later starts the agent (StartCreatedSession), Launch re-runs and
-		// rewrites the row with status='starting' via the usual path.
+		// writes an active runtime status on row creation; flip it to
+		// 'prepared' so the row doesn't look like an agent process is running.
+		// When the user later starts the agent (StartCreatedSession), Launch
+		// re-runs and rewrites the row with the active runtime status via the
+		// usual path.
 		//
 		// Detach from the caller context so a client disconnect / WS timeout
 		// right after launch returns can't drop this write — that would leave

--- a/apps/backend/internal/orchestrator/executor/executor_test.go
+++ b/apps/backend/internal/orchestrator/executor/executor_test.go
@@ -581,8 +581,8 @@ func TestLaunchPreparedSession_WorkspaceOnly(t *testing.T) {
 
 // TestLaunchPreparedSession_WorkspaceOnly_FlipsExecutorRunningStatus asserts
 // the prepare-only branch in finalizeLaunch updates executors_running.status
-// from the lifecycle-manager default "starting" to "prepared", so the row
-// doesn't look stuck mid-launch on a session that's actually ready by design.
+// from an active launch status to "prepared", so the row doesn't look like an
+// agent process is running on a session that's actually ready by design.
 func TestLaunchPreparedSession_WorkspaceOnly_FlipsExecutorRunningStatus(t *testing.T) {
 	repo := newMockRepository()
 
@@ -597,11 +597,11 @@ func TestLaunchPreparedSession_WorkspaceOnly_FlipsExecutorRunningStatus(t *testi
 	repo.sessions[session.ID] = session
 
 	// Seed the executors_running row the way production's lifecycle manager
-	// would after LaunchAgent — status="starting" until something flips it.
+	// would after LaunchAgent — active until the prepare-only branch flips it.
 	repo.executorsRunning[session.ID] = &models.ExecutorRunning{
 		SessionID: session.ID,
 		TaskID:    session.TaskID,
-		Status:    models.ExecutorRunningStatusStarting,
+		Status:    models.ExecutorRunningStatusRunning,
 	}
 
 	agentManager := &mockAgentManager{

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1100,6 +1100,7 @@ func (s *Service) reconcileOneSessionOnStartup(ctx context.Context, running *mod
 				zap.Error(err))
 		}
 	}
+	s.abandonOpenTurnsOnStartup(ctx, sessionID, "active session reconciled to waiting")
 
 	// PRESERVE executors_running.agent_execution_id post-restart. The in-memory
 	// process is gone, but the stored ID still serves as a "this session was
@@ -1160,6 +1161,19 @@ func (s *Service) handleMissingSessionOnStartup(ctx context.Context, running *mo
 	}
 }
 
+func (s *Service) abandonOpenTurnsOnStartup(ctx context.Context, sessionID, reason string) {
+	if s.turnService == nil {
+		return
+	}
+	s.activeTurns.Delete(sessionID)
+	if err := s.turnService.AbandonOpenTurns(ctx, sessionID); err != nil {
+		s.logger.Warn("failed to abandon open turns during startup reconciliation",
+			zap.String("session_id", sessionID),
+			zap.String("reason", reason),
+			zap.Error(err))
+	}
+}
+
 func isTaskSessionNotFound(err error) bool {
 	return errors.Is(err, models.ErrTaskSessionNotFound)
 }
@@ -1174,6 +1188,7 @@ func (s *Service) handleTerminalSessionOnStartup(ctx context.Context, session *m
 			zap.String("session_id", sessionID),
 			zap.String("task_id", session.TaskID),
 			zap.String("state", string(previousState)))
+		s.abandonOpenTurnsOnStartup(ctx, sessionID, "terminal session cleanup")
 		executionID := strings.TrimSpace(running.AgentExecutionID)
 		if executionID != "" && s.agentManager != nil {
 			if err := s.agentManager.StopAgentWithReason(ctx, executionID, "startup terminal session cleanup", true); err != nil {

--- a/apps/backend/internal/orchestrator/service.go
+++ b/apps/backend/internal/orchestrator/service.go
@@ -1215,6 +1215,7 @@ func (s *Service) handleTerminalSessionOnStartup(ctx context.Context, session *m
 // handleFailedSessionOnStartup handles a failed session during startup recovery.
 func (s *Service) handleFailedSessionOnStartup(ctx context.Context, session *models.TaskSession, running *models.ExecutorRunning) {
 	sessionID := session.ID
+	s.abandonOpenTurnsOnStartup(ctx, sessionID, "failed session cleanup")
 	// If session failed, ensure task is in REVIEW state (not stuck IN_PROGRESS)
 	if session.TaskID != "" {
 		task, taskErr := s.taskRepo.GetTask(ctx, session.TaskID)

--- a/apps/backend/internal/orchestrator/turn_lifecycle_test.go
+++ b/apps/backend/internal/orchestrator/turn_lifecycle_test.go
@@ -351,3 +351,45 @@ func TestReconcileSessionsOnStartupAbandonsOpenTurns(t *testing.T) {
 			got.StartedAt, *got.CompletedAt)
 	}
 }
+
+func TestReconcileTerminalSessionOnStartupAbandonsOpenTurns(t *testing.T) {
+	svc, repo := newTurnLifecycleTestService(t)
+	ctx := context.Background()
+
+	stale, err := svc.turnService.StartTurn(ctx, "session1")
+	if err != nil {
+		t.Fatalf("seed turn: %v", err)
+	}
+	if err := repo.UpdateTaskSessionState(ctx, "session1", models.TaskSessionStateCompleted, ""); err != nil {
+		t.Fatalf("mark session completed: %v", err)
+	}
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session1",
+		SessionID:        "session1",
+		TaskID:           "task1",
+		AgentExecutionID: "exec-before-restart",
+		Status:           models.ExecutorRunningStatusRunning,
+	}); err != nil {
+		t.Fatalf("seed executors_running: %v", err)
+	}
+
+	svc.reconcileSessionsOnStartup(ctx)
+
+	if open := openTurnCount(t, repo, "session1"); open != 0 {
+		t.Fatalf("expected 0 open turns after terminal startup reconciliation, got %d", open)
+	}
+	got, err := repo.GetTurn(ctx, stale.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("expected terminal startup reconciliation to set completed_at")
+	}
+	if !got.CompletedAt.Equal(got.StartedAt) {
+		t.Fatalf("expected completed_at == started_at, got started=%v completed=%v",
+			got.StartedAt, *got.CompletedAt)
+	}
+	if _, err := repo.GetExecutorRunningBySessionID(ctx, "session1"); !errors.Is(err, models.ErrExecutorRunningNotFound) {
+		t.Fatalf("expected executor row cleanup, got err=%v", err)
+	}
+}

--- a/apps/backend/internal/orchestrator/turn_lifecycle_test.go
+++ b/apps/backend/internal/orchestrator/turn_lifecycle_test.go
@@ -393,3 +393,51 @@ func TestReconcileTerminalSessionOnStartupAbandonsOpenTurns(t *testing.T) {
 		t.Fatalf("expected executor row cleanup, got err=%v", err)
 	}
 }
+
+func TestReconcileFailedSessionOnStartupAbandonsOpenTurns(t *testing.T) {
+	svc, repo := newTurnLifecycleTestService(t)
+	ctx := context.Background()
+
+	stale, err := svc.turnService.StartTurn(ctx, "session1")
+	if err != nil {
+		t.Fatalf("seed turn: %v", err)
+	}
+	if err := repo.UpdateTaskSessionState(ctx, "session1", models.TaskSessionStateFailed, "boom"); err != nil {
+		t.Fatalf("mark session failed: %v", err)
+	}
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session1",
+		SessionID:        "session1",
+		TaskID:           "task1",
+		AgentExecutionID: "exec-before-restart",
+		Status:           models.ExecutorRunningStatusFailed,
+		Resumable:        true,
+		ResumeToken:      "resume-token",
+	}); err != nil {
+		t.Fatalf("seed executors_running: %v", err)
+	}
+
+	svc.reconcileSessionsOnStartup(ctx)
+
+	if open := openTurnCount(t, repo, "session1"); open != 0 {
+		t.Fatalf("expected 0 open turns after failed startup reconciliation, got %d", open)
+	}
+	got, err := repo.GetTurn(ctx, stale.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("expected failed startup reconciliation to set completed_at")
+	}
+	if !got.CompletedAt.Equal(got.StartedAt) {
+		t.Fatalf("expected completed_at == started_at, got started=%v completed=%v",
+			got.StartedAt, *got.CompletedAt)
+	}
+	running, err := repo.GetExecutorRunningBySessionID(ctx, "session1")
+	if err != nil {
+		t.Fatalf("expected resumable failed executor row to be preserved: %v", err)
+	}
+	if running.ResumeToken != "resume-token" {
+		t.Fatalf("resume token = %q, want preserved token", running.ResumeToken)
+	}
+}

--- a/apps/backend/internal/orchestrator/turn_lifecycle_test.go
+++ b/apps/backend/internal/orchestrator/turn_lifecycle_test.go
@@ -308,3 +308,46 @@ func TestAbandonOpenTurnsHandlesMultipleZombies(t *testing.T) {
 		t.Fatalf("expected 0 open turns after abandon, got %d", open)
 	}
 }
+
+func TestReconcileSessionsOnStartupAbandonsOpenTurns(t *testing.T) {
+	svc, repo := newTurnLifecycleTestService(t)
+	ctx := context.Background()
+
+	stale, err := svc.turnService.StartTurn(ctx, "session1")
+	if err != nil {
+		t.Fatalf("seed turn: %v", err)
+	}
+	if err := repo.UpsertExecutorRunning(ctx, &models.ExecutorRunning{
+		ID:               "session1",
+		SessionID:        "session1",
+		TaskID:           "task1",
+		AgentExecutionID: "exec-before-restart",
+		Status:           models.ExecutorRunningStatusStarting,
+	}); err != nil {
+		t.Fatalf("seed executors_running: %v", err)
+	}
+
+	svc.reconcileSessionsOnStartup(ctx)
+
+	session, err := repo.GetTaskSession(ctx, "session1")
+	if err != nil {
+		t.Fatalf("GetTaskSession: %v", err)
+	}
+	if session.State != models.TaskSessionStateWaitingForInput {
+		t.Fatalf("session state = %s, want WAITING_FOR_INPUT", session.State)
+	}
+	if open := openTurnCount(t, repo, "session1"); open != 0 {
+		t.Fatalf("expected 0 open turns after startup reconciliation, got %d", open)
+	}
+	got, err := repo.GetTurn(ctx, stale.ID)
+	if err != nil {
+		t.Fatalf("GetTurn: %v", err)
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("expected startup reconciliation to set completed_at")
+	}
+	if !got.CompletedAt.Equal(got.StartedAt) {
+		t.Fatalf("expected completed_at == started_at, got started=%v completed=%v",
+			got.StartedAt, *got.CompletedAt)
+	}
+}

--- a/apps/backend/internal/task/models/models.go
+++ b/apps/backend/internal/task/models/models.go
@@ -33,12 +33,17 @@ var ErrExecutorNotFound = errors.New("executor not found")
 // will produce its own events.
 var ErrExecutionRotated = errors.New("execution rotated; CAS write rejected")
 
-// Status values for executors_running.status. The lifecycle manager defaults
-// rows to "starting" on creation (see runtime/lifecycle/persistence.go); the
-// orchestrator flips a row to "prepared" when a prepare-only launch finishes
-// with the agent process intentionally not started.
+// Status values for executors_running.status. The lifecycle manager mirrors
+// active execution state into this column; the orchestrator flips a row to
+// "prepared" when a prepare-only launch finishes with the agent process
+// intentionally not started.
 const (
 	ExecutorRunningStatusStarting = "starting"
+	ExecutorRunningStatusRunning  = "running"
+	ExecutorRunningStatusReady    = "ready"
+	ExecutorRunningStatusFailed   = "failed"
+	ExecutorRunningStatusStopped  = "stopped"
+	ExecutorRunningStatusComplete = "completed"
 	ExecutorRunningStatusPrepared = "prepared"
 )
 


### PR DESCRIPTION
Executor/session persistence could report live runs as stuck in `starting`, leaving stale agentctl metadata and open turns behind after lifecycle transitions. Persist live runtime state from the lifecycle manager and clean up dangling turns during startup reconciliation so durable state matches recoverable session state.

## Important Changes

- `executors_running` now mirrors live execution status and agentctl endpoint metadata when executions are created or become ready.
- Startup reconciliation now abandons open turns for active sessions normalized to `WAITING_FOR_INPUT` and terminal sessions being cleaned up.
- Added regression coverage for runtime persistence and startup turn cleanup.

## Validation

- `rtk make fmt`
- `rtk make typecheck`
- `rtk make test`
- `rtk make lint`
- `rtk git diff --check`

## Possible Improvements

Medium risk: local standalone `pid` remains unset per session because the shared agentctl control process is not a per-session runtime handle.

Closes #1585

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->