### PR TITLE
fix: support postgres database stats page

### DIFF
--- a/apps/backend/internal/backendapp/storage.go
+++ b/apps/backend/internal/backendapp/storage.go
@@ -174,9 +174,9 @@ func provideSupportRepos(writer, reader *sqlx.DB) (supportRepositorySet, []func(
 // recordSchemaVersion writes the current binary version into kandev_meta so the
 // next boot can detect upgrades. A failure here is non-fatal: the stored
 // version stays at the previous value and the next boot will take a fresh
-// backup (idempotent). Skipped for postgres, which has no kandev_meta table.
-func recordSchemaVersion(writer *sqlx.DB, driver, version string, log *logger.Logger) {
-	if version == "" || driver == "postgres" {
+// backup (idempotent).
+func recordSchemaVersion(writer *sqlx.DB, _ string, version string, log *logger.Logger) {
+	if version == "" {
 		return
 	}
 	if err := persistence.WriteVersion(writer, version); err != nil {

--- a/apps/backend/internal/backendapp/storage_test.go
+++ b/apps/backend/internal/backendapp/storage_test.go
@@ -1,0 +1,39 @@
+package backendapp
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/kandev/kandev/internal/db"
+)
+
+func TestRecordSchemaVersionRecordsForPostgres(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "kandev.db")
+	raw, err := db.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	writer := sqlx.NewDb(raw, "sqlite3")
+	t.Cleanup(func() { _ = writer.Close() })
+
+	if _, err := writer.Exec(`
+		CREATE TABLE kandev_meta (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("create kandev_meta: %v", err)
+	}
+
+	recordSchemaVersion(writer, "postgres", "v9.9.9", nil)
+
+	var version string
+	if err := writer.QueryRow(`SELECT value FROM kandev_meta WHERE key = ?`, "kandev_version").Scan(&version); err != nil {
+		t.Fatalf("read kandev_version: %v", err)
+	}
+	if version != "v9.9.9" {
+		t.Fatalf("kandev_version = %q, want v9.9.9", version)
+	}
+}

--- a/apps/backend/internal/backendapp/storage_test.go
+++ b/apps/backend/internal/backendapp/storage_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kandev/kandev/internal/db"
 )
 
-func TestRecordSchemaVersionRecordsForPostgres(t *testing.T) {
+func TestRecordSchemaVersionIgnoresDriver(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "kandev.db")
 	raw, err := db.OpenSQLite(dbPath)
 	if err != nil {
@@ -27,6 +27,8 @@ func TestRecordSchemaVersionRecordsForPostgres(t *testing.T) {
 		t.Fatalf("create kandev_meta: %v", err)
 	}
 
+	// The driver argument is accepted for compatibility but ignored; even a
+	// "postgres" value must not skip recording the schema version.
 	recordSchemaVersion(writer, "postgres", "v9.9.9", nil)
 
 	var version string

--- a/apps/backend/internal/system/database/maintenance.go
+++ b/apps/backend/internal/system/database/maintenance.go
@@ -18,8 +18,8 @@ func (s *Service) Vacuum(ctx context.Context) string {
 }
 
 func (s *Service) runVacuum(_ context.Context) (map[string]interface{}, error) {
-	if s.pool == nil {
-		return nil, fmt.Errorf("vacuum: no database pool")
+	if err := s.requireSQLiteMaintenance("vacuum"); err != nil {
+		return nil, err
 	}
 	before, _ := readDatabaseSize(s.pool.Reader())
 	if _, err := s.pool.Writer().Exec("VACUUM"); err != nil {
@@ -47,13 +47,24 @@ func (s *Service) Optimize(ctx context.Context) string {
 }
 
 func (s *Service) runOptimize(_ context.Context) (map[string]interface{}, error) {
-	if s.pool == nil {
-		return nil, fmt.Errorf("optimize: no database pool")
+	if err := s.requireSQLiteMaintenance("optimize"); err != nil {
+		return nil, err
 	}
 	if _, err := s.pool.Writer().Exec("PRAGMA optimize"); err != nil {
 		return nil, fmt.Errorf("pragma optimize: %w", err)
 	}
 	return map[string]interface{}{"status": "ok"}, nil
+}
+
+func (s *Service) requireSQLiteMaintenance(operation string) error {
+	if s.pool == nil {
+		return fmt.Errorf("%s: no database pool", operation)
+	}
+	driver := s.databaseDriver()
+	if driver != databaseDriverSQLite {
+		return fmt.Errorf("%s: not supported for %s driver", operation, driver)
+	}
+	return nil
 }
 
 // HandleVacuum returns a gin handler for POST /api/v1/system/database/vacuum.

--- a/apps/backend/internal/system/database/maintenance.go
+++ b/apps/backend/internal/system/database/maintenance.go
@@ -57,7 +57,7 @@ func (s *Service) runOptimize(_ context.Context) (map[string]interface{}, error)
 }
 
 func (s *Service) requireSQLiteMaintenance(operation string) error {
-	if s.pool == nil {
+	if s.pool == nil || s.pool.Writer() == nil {
 		return fmt.Errorf("%s: no database pool", operation)
 	}
 	driver := s.databaseDriver()

--- a/apps/backend/internal/system/database/maintenance.go
+++ b/apps/backend/internal/system/database/maintenance.go
@@ -21,11 +21,11 @@ func (s *Service) runVacuum(_ context.Context) (map[string]interface{}, error) {
 	if s.pool == nil {
 		return nil, fmt.Errorf("vacuum: no database pool")
 	}
-	before, _ := readDBSize(s.pool.Reader())
+	before, _ := readDatabaseSize(s.pool.Reader())
 	if _, err := s.pool.Writer().Exec("VACUUM"); err != nil {
 		return nil, fmt.Errorf("vacuum: %w", err)
 	}
-	after, _ := readDBSize(s.pool.Reader())
+	after, _ := readDatabaseSize(s.pool.Reader())
 	reclaimed := before - after
 	if reclaimed < 0 {
 		reclaimed = 0

--- a/apps/backend/internal/system/database/maintenance_test.go
+++ b/apps/backend/internal/system/database/maintenance_test.go
@@ -106,6 +106,55 @@ func TestOptimize_StartsJobAndSucceeds(t *testing.T) {
 	}
 }
 
+func TestMaintenanceOperationsRejectPostgres(t *testing.T) {
+	svc := NewService(newFakePostgresStatsPool(t), t.TempDir(), ResetDirs{}, nil, nil)
+	shutdownCalled := false
+	svc.OrchestratorShutdown = func() { shutdownCalled = true }
+
+	cases := []struct {
+		name    string
+		run     func() error
+		wantErr string
+	}{
+		{
+			name: "vacuum",
+			run: func() error {
+				_, err := svc.runVacuum(context.Background())
+				return err
+			},
+			wantErr: "vacuum: not supported for postgres driver",
+		},
+		{
+			name: "optimize",
+			run: func() error {
+				_, err := svc.runOptimize(context.Background())
+				return err
+			},
+			wantErr: "optimize: not supported for postgres driver",
+		},
+		{
+			name: "factory reset",
+			run: func() error {
+				_, err := svc.runFactoryReset(context.Background())
+				return err
+			},
+			wantErr: "factory reset: not supported for postgres driver",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("err = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+	if shutdownCalled {
+		t.Fatal("factory reset called orchestrator shutdown before rejecting postgres")
+	}
+}
+
 func TestHandleVacuum_Returns202WithJobID(t *testing.T) {
 	svc, tracker, _, _ := newTestService(t)
 	gin.SetMode(gin.TestMode)

--- a/apps/backend/internal/system/database/maintenance_test.go
+++ b/apps/backend/internal/system/database/maintenance_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/kandev/kandev/internal/db"
 	"github.com/kandev/kandev/internal/system/jobs"
 )
 
@@ -152,6 +153,15 @@ func TestMaintenanceOperationsRejectPostgres(t *testing.T) {
 	}
 	if shutdownCalled {
 		t.Fatal("factory reset called orchestrator shutdown before rejecting postgres")
+	}
+}
+
+func TestMaintenanceOperationsRejectNilWriter(t *testing.T) {
+	svc := NewService(db.NewPool(nil, nil), t.TempDir(), ResetDirs{}, nil, nil)
+
+	_, err := svc.runVacuum(context.Background())
+	if err == nil || err.Error() != "vacuum: no database pool" {
+		t.Fatalf("err = %v, want vacuum: no database pool", err)
 	}
 }
 

--- a/apps/backend/internal/system/database/reset.go
+++ b/apps/backend/internal/system/database/reset.go
@@ -47,6 +47,10 @@ func (s *Service) FactoryReset(ctx context.Context, confirm string) (string, err
 }
 
 func (s *Service) runFactoryReset(_ context.Context) (map[string]interface{}, error) {
+	if err := s.requireSQLiteMaintenance("factory reset"); err != nil {
+		return nil, err
+	}
+
 	if s.OrchestratorShutdown != nil {
 		s.OrchestratorShutdown()
 	}

--- a/apps/backend/internal/system/database/stats.go
+++ b/apps/backend/internal/system/database/stats.go
@@ -1,8 +1,7 @@
 // Package database serves the System -> Database page. It exposes read-only
-// SQLite stats (path, size, WAL size, schema version, last-backup timestamp)
-// and three maintenance operations: VACUUM, PRAGMA optimize, and Factory
-// Reset. Long-running operations are tracked via the jobs.Tracker so the
-// frontend can observe progress over the event bus.
+// database stats plus SQLite maintenance operations: VACUUM, PRAGMA optimize,
+// and Factory Reset. Long-running operations are tracked via the jobs.Tracker
+// so the frontend can observe progress over the event bus.
 package database
 
 import (
@@ -17,18 +16,26 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
 
 	"github.com/kandev/kandev/internal/common/logger"
 	"github.com/kandev/kandev/internal/db"
+	"github.com/kandev/kandev/internal/db/dialect"
 	"github.com/kandev/kandev/internal/system/jobs"
 )
 
-// Stats is the read-only SQLite-state payload returned to the frontend.
+const (
+	databaseDriverPostgres = "postgres"
+	databaseDriverSQLite   = "sqlite"
+)
+
+// Stats is the read-only database-state payload returned to the frontend.
 //
 // LastBackupAt is a pointer so the JSON shape is `null` when no backup
 // exists. Serialising a zero time.Time as "0001-01-01T00:00:00Z" would
 // defeat the frontend's "Never" fallback in database-stats-card.tsx.
 type Stats struct {
+	Driver        string     `json:"driver"`
 	Path          string     `json:"path"`
 	SizeBytes     int64      `json:"size_bytes"`
 	WALSizeBytes  int64      `json:"wal_size_bytes"`
@@ -80,14 +87,19 @@ func NewService(pool *db.Pool, dataDir string, dirs ResetDirs, j *jobs.Tracker, 
 	}
 }
 
-// Stats returns the current SQLite stats. The size is computed from
-// PRAGMA page_count * page_size (cheaper than os.Stat on hot writes and
-// more accurate during a VACUUM that creates a sibling file).
+// Stats returns the current database stats. SQLite size is computed from
+// PRAGMA page_count * page_size (cheaper than os.Stat on hot writes and more
+// accurate during a VACUUM that creates a sibling file). Postgres size is
+// reported from pg_database_size(current_database()).
 func (s *Service) Stats() (Stats, error) {
-	out := Stats{Path: s.dbPath}
+	driver := s.databaseDriver()
+	out := Stats{Driver: driver}
+	if driver == databaseDriverSQLite {
+		out.Path = s.dbPath
+	}
 
 	if s.pool != nil {
-		size, err := readDBSize(s.pool.Reader())
+		size, err := readDatabaseSize(s.pool.Reader())
 		if err != nil {
 			return Stats{}, err
 		}
@@ -100,19 +112,42 @@ func (s *Service) Stats() (Stats, error) {
 		out.SchemaVersion = version
 	}
 
-	if wal, err := walSize(s.dbPath); err == nil {
-		out.WALSizeBytes = wal
-	}
+	if driver == databaseDriverSQLite {
+		if wal, err := walSize(s.dbPath); err == nil {
+			out.WALSizeBytes = wal
+		}
 
-	if last := lastBackupAt(filepath.Join(s.dataDir, "backups")); !last.IsZero() {
-		out.LastBackupAt = &last
+		if last := lastBackupAt(filepath.Join(s.dataDir, "backups")); !last.IsZero() {
+			out.LastBackupAt = &last
+		}
 	}
 	return out, nil
 }
 
-// readDBSize returns the database size in bytes via PRAGMA page_count *
+func (s *Service) databaseDriver() string {
+	if s.pool == nil || s.pool.Writer() == nil {
+		return databaseDriverSQLite
+	}
+	switch driver := s.pool.Writer().DriverName(); {
+	case dialect.IsPostgres(driver):
+		return databaseDriverPostgres
+	case driver == dialect.SQLite3:
+		return databaseDriverSQLite
+	default:
+		return driver
+	}
+}
+
+func readDatabaseSize(d *sqlx.DB) (int64, error) {
+	if dialect.IsPostgres(d.DriverName()) {
+		return readPostgresDBSize(d)
+	}
+	return readSQLiteDBSize(d)
+}
+
+// readSQLiteDBSize returns the database size in bytes via PRAGMA page_count *
 // page_size. Both PRAGMAs return a single integer row.
-func readDBSize(d interface {
+func readSQLiteDBSize(d interface {
 	QueryRow(query string, args ...interface{}) *sql.Row
 }) (int64, error) {
 	var pages, pageSize int64
@@ -125,14 +160,22 @@ func readDBSize(d interface {
 	return pages * pageSize, nil
 }
 
+func readPostgresDBSize(d interface {
+	QueryRow(query string, args ...interface{}) *sql.Row
+}) (int64, error) {
+	var size int64
+	if err := d.QueryRow("SELECT pg_database_size(current_database())").Scan(&size); err != nil {
+		return 0, fmt.Errorf("pg_database_size: %w", err)
+	}
+	return size, nil
+}
+
 // readSchemaVersion reads the binary version recorded by
 // cmd/kandev/storage.go:recordSchemaVersion. Missing key returns "" with
 // no error (fresh DB on first boot).
-func readSchemaVersion(d interface {
-	QueryRow(query string, args ...interface{}) *sql.Row
-}) (string, error) {
+func readSchemaVersion(d *sqlx.DB) (string, error) {
 	var value string
-	err := d.QueryRow(`SELECT value FROM kandev_meta WHERE key = ?`, "kandev_version").Scan(&value)
+	err := d.QueryRow(d.Rebind(`SELECT value FROM kandev_meta WHERE key = ?`), "kandev_version").Scan(&value)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}

--- a/apps/backend/internal/system/database/stats_test.go
+++ b/apps/backend/internal/system/database/stats_test.go
@@ -2,8 +2,13 @@ package database
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +22,79 @@ import (
 	"github.com/kandev/kandev/internal/events/bus"
 	"github.com/kandev/kandev/internal/system/jobs"
 )
+
+const fakePostgresStatsDriverName = "kandev-system-database-stats-postgres"
+
+var registerFakePostgresStatsDriverOnce sync.Once
+
+type fakePostgresStatsDriver struct{}
+
+func (fakePostgresStatsDriver) Open(string) (driver.Conn, error) {
+	return fakePostgresStatsConn{}, nil
+}
+
+type fakePostgresStatsConn struct{}
+
+func (fakePostgresStatsConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare is not implemented")
+}
+
+func (fakePostgresStatsConn) Close() error {
+	return nil
+}
+
+func (fakePostgresStatsConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("transactions are not implemented")
+}
+
+func (fakePostgresStatsConn) QueryContext(
+	_ context.Context,
+	query string,
+	args []driver.NamedValue,
+) (driver.Rows, error) {
+	normalized := strings.Join(strings.Fields(query), " ")
+	switch normalized {
+	case "SELECT pg_database_size(current_database())":
+		return newFakeRows([]string{"pg_database_size"}, []driver.Value{int64(4096)}), nil
+	case "SELECT value FROM kandev_meta WHERE key = $1":
+		if len(args) != 1 || args[0].Value != "kandev_version" {
+			return nil, fmt.Errorf("unexpected args for schema version: %#v", args)
+		}
+		return newFakeRows([]string{"value"}, []driver.Value{"v0.99.0"}), nil
+	default:
+		if strings.HasPrefix(normalized, "PRAGMA ") {
+			return nil, fmt.Errorf(`ERROR: syntax error at or near "PRAGMA" (SQLSTATE 42601)`)
+		}
+		return nil, fmt.Errorf("unexpected query: %s", normalized)
+	}
+}
+
+type fakeRows struct {
+	columns []string
+	values  []driver.Value
+	read    bool
+}
+
+func newFakeRows(columns []string, values []driver.Value) *fakeRows {
+	return &fakeRows{columns: columns, values: values}
+}
+
+func (r *fakeRows) Columns() []string {
+	return r.columns
+}
+
+func (r *fakeRows) Close() error {
+	return nil
+}
+
+func (r *fakeRows) Next(dest []driver.Value) error {
+	if r.read {
+		return io.EOF
+	}
+	r.read = true
+	copy(dest, r.values)
+	return nil
+}
 
 func newTestLogger(t *testing.T) *logger.Logger {
 	t.Helper()
@@ -131,6 +209,21 @@ func newTestService(t *testing.T) (*Service, *jobs.Tracker, *stubBus, string) {
 	return svc, tracker, stub, dataDir
 }
 
+func newFakePostgresStatsPool(t *testing.T) *db.Pool {
+	t.Helper()
+	registerFakePostgresStatsDriverOnce.Do(func() {
+		sql.Register(fakePostgresStatsDriverName, fakePostgresStatsDriver{})
+	})
+	raw, err := sql.Open(fakePostgresStatsDriverName, "")
+	if err != nil {
+		t.Fatalf("open fake postgres: %v", err)
+	}
+	pg := sqlx.NewDb(raw, "pgx")
+	pool := db.NewPool(pg, pg)
+	t.Cleanup(func() { _ = pool.Close() })
+	return pool
+}
+
 // waitForState mirrors jobs.waitForState — wait until the tracker reports
 // the target state for the given id, or fail after 2s.
 func waitForState(t *testing.T, tracker *jobs.Tracker, id string, target jobs.State) *jobs.Job {
@@ -166,6 +259,34 @@ func TestStats_ReturnsPathSizeAndSchemaVersion(t *testing.T) {
 	}
 	if stats.LastBackupAt != nil {
 		t.Errorf("LastBackupAt = %v, want nil (no backups yet)", *stats.LastBackupAt)
+	}
+}
+
+func TestStats_PostgresDoesNotUseSQLitePragmas(t *testing.T) {
+	dataDir := t.TempDir()
+	svc := NewService(newFakePostgresStatsPool(t), dataDir, ResetDirs{}, nil, nil)
+
+	stats, err := svc.Stats()
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.Driver != "postgres" {
+		t.Errorf("Driver = %q, want postgres", stats.Driver)
+	}
+	if stats.Path != "" {
+		t.Errorf("Path = %q, want empty for postgres", stats.Path)
+	}
+	if stats.SizeBytes != 4096 {
+		t.Errorf("SizeBytes = %d, want 4096", stats.SizeBytes)
+	}
+	if stats.WALSizeBytes != 0 {
+		t.Errorf("WALSizeBytes = %d, want 0 for postgres", stats.WALSizeBytes)
+	}
+	if stats.SchemaVersion != "v0.99.0" {
+		t.Errorf("SchemaVersion = %q, want v0.99.0", stats.SchemaVersion)
+	}
+	if stats.LastBackupAt != nil {
+		t.Errorf("LastBackupAt = %v, want nil for postgres", *stats.LastBackupAt)
 	}
 }
 
@@ -213,7 +334,7 @@ func TestHandleStats_Returns200JSON(t *testing.T) {
 		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
 	}
 	body := w.Body.String()
-	if !contains(body, `"path"`) || !contains(body, `"schema_version"`) {
+	if !contains(body, `"driver"`) || !contains(body, `"path"`) || !contains(body, `"schema_version"`) {
 		t.Errorf("body missing fields: %s", body)
 	}
 }

--- a/apps/web/app/settings/system/database/page.tsx
+++ b/apps/web/app/settings/system/database/page.tsx
@@ -16,7 +16,7 @@ export default async function SystemDatabasePage() {
     <StateProvider initialState={initialState}>
       <SystemPageShell
         title="Database"
-        description="SQLite path and size, plus VACUUM, optimize, and factory reset."
+        description="Database driver, size, and available maintenance controls."
       >
         <DatabaseStatsCard />
       </SystemPageShell>

--- a/apps/web/components/settings/system/database-stats-card.tsx
+++ b/apps/web/components/settings/system/database-stats-card.tsx
@@ -68,7 +68,7 @@ function databaseDriver(database: DatabaseStats): string {
 function formatDriver(driver: string): string {
   if (driver === "postgres") return "PostgreSQL";
   if (driver === "sqlite") return "SQLite";
-  return driver || "SQLite";
+  return driver;
 }
 
 function StatsTable({ database }: { database: DatabaseStats }) {

--- a/apps/web/components/settings/system/database-stats-card.tsx
+++ b/apps/web/components/settings/system/database-stats-card.tsx
@@ -14,6 +14,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@kandev/ui/tooltip";
 import { useDatabaseStats } from "@/hooks/domains/system/use-database-stats";
 import { optimizeDatabase, vacuumDatabase } from "@/lib/api/domains/system-api";
+import type { DatabaseStats } from "@/lib/types/system";
 import { formatBytes } from "@/lib/utils/format-bytes";
 import { useActionFeedback, type ActionFeedbackState } from "@/hooks/use-action-feedback";
 import { ActionButtonContent } from "./action-button-content";
@@ -60,35 +61,49 @@ function StatRow({ label, value, testid, info }: Row) {
   );
 }
 
-type DBStats = {
-  path: string;
-  size_bytes: number;
-  wal_size_bytes: number;
-  schema_version: string;
-  last_backup_at: string | null;
-};
+function databaseDriver(database: DatabaseStats): string {
+  return database.driver || "sqlite";
+}
 
-function StatsTable({ database }: { database: DBStats }) {
+function formatDriver(driver: string): string {
+  if (driver === "postgres") return "PostgreSQL";
+  if (driver === "sqlite") return "SQLite";
+  return driver || "SQLite";
+}
+
+function StatsTable({ database }: { database: DatabaseStats }) {
+  const driver = databaseDriver(database);
+  const isSQLite = driver === "sqlite";
+
   return (
     <div className="rounded-md border px-3 py-2">
-      <StatRow label="Path" value={database.path} testid="system-db-path" />
-      <StatRow label="Size" value={formatBytes(database.size_bytes)} testid="system-db-size" />
+      <StatRow label="Driver" value={formatDriver(driver)} testid="system-db-driver" />
+      {isSQLite && <StatRow label="Path" value={database.path} testid="system-db-path" />}
       <StatRow
-        label="WAL"
-        value={formatBytes(database.wal_size_bytes)}
-        testid="system-db-wal"
-        info={WAL_HELP}
+        label={isSQLite ? "Size" : "Database size"}
+        value={formatBytes(database.size_bytes)}
+        testid="system-db-size"
       />
+      {isSQLite && (
+        <StatRow
+          label="WAL"
+          value={formatBytes(database.wal_size_bytes)}
+          testid="system-db-wal"
+          info={WAL_HELP}
+        />
+      )}
       <StatRow
         label="Schema version"
         value={database.schema_version || "-"}
         testid="system-db-schema-version"
       />
-      <StatRow
-        label="Last backup"
-        value={formatTimestamp(database.last_backup_at)}
-        testid="system-db-last-backup"
-      />
+      {isSQLite && (
+        <StatRow
+          label="Last backup"
+          value={formatTimestamp(database.last_backup_at)}
+          testid="system-db-last-backup"
+        />
+      )}
     </div>
   );
 }
@@ -116,31 +131,48 @@ function OperationRow({
 }) {
   return (
     <div
-      className="flex items-start justify-between gap-3 rounded-md border p-3"
+      className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-start sm:justify-between"
       data-testid={testid}
     >
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium">{label}</p>
         <p className="text-xs text-muted-foreground mt-1">{description}</p>
       </div>
-      <div className="shrink-0">{button}</div>
+      <div className="shrink-0 self-start sm:self-auto">{button}</div>
     </div>
   );
 }
 
+function UnsupportedMaintenance({ driver }: { driver: string }) {
+  return (
+    <p
+      className="text-xs text-muted-foreground"
+      data-testid="system-database-maintenance-unavailable"
+    >
+      SQLite maintenance actions are unavailable for {formatDriver(driver)}.
+    </p>
+  );
+}
+
 function MaintenanceButtons({
+  driver,
   vacuumState,
   optimizeState,
   onVacuum,
   onOptimize,
   onResetOpen,
 }: {
+  driver: string;
   vacuumState: ActionFeedbackState;
   optimizeState: ActionFeedbackState;
   onVacuum: () => void;
   onOptimize: () => void;
   onResetOpen: () => void;
 }) {
+  if (driver !== "sqlite") {
+    return <UnsupportedMaintenance driver={driver} />;
+  }
+
   return (
     <div className="space-y-2">
       <OperationRow
@@ -227,6 +259,7 @@ export function DatabaseStatsCard() {
   const vacuum = useActionFeedback();
   const optimize = useActionFeedback();
   const [resetOpen, setResetOpen] = useState(false);
+  const driver = database ? databaseDriver(database) : "sqlite";
 
   const onVacuum = () =>
     void vacuum.run(async () => {
@@ -259,6 +292,7 @@ export function DatabaseStatsCard() {
         )}
         {database && <StatsTable database={database} />}
         <MaintenanceButtons
+          driver={driver}
           vacuumState={vacuum.state}
           optimizeState={optimize.state}
           onVacuum={onVacuum}

--- a/apps/web/components/settings/system/database-stats-card.tsx
+++ b/apps/web/components/settings/system/database-stats-card.tsx
@@ -154,25 +154,21 @@ function UnsupportedMaintenance({ driver }: { driver: string }) {
   );
 }
 
-function MaintenanceButtons({
-  driver,
-  vacuumState,
-  optimizeState,
-  onVacuum,
-  onOptimize,
-  onResetOpen,
-}: {
-  driver: string;
+type SQLiteMaintenanceButtonsProps = {
   vacuumState: ActionFeedbackState;
   optimizeState: ActionFeedbackState;
   onVacuum: () => void;
   onOptimize: () => void;
   onResetOpen: () => void;
-}) {
-  if (driver !== "sqlite") {
-    return <UnsupportedMaintenance driver={driver} />;
-  }
+};
 
+function SQLiteMaintenanceButtons({
+  vacuumState,
+  optimizeState,
+  onVacuum,
+  onOptimize,
+  onResetOpen,
+}: SQLiteMaintenanceButtonsProps) {
   return (
     <div className="space-y-2">
       <OperationRow
@@ -254,12 +250,27 @@ function MaintenanceButtons({
   );
 }
 
+function MaintenanceButtons({
+  driver,
+  ...props
+}: SQLiteMaintenanceButtonsProps & { driver: string | null }) {
+  if (driver === null) {
+    return null;
+  }
+
+  if (driver !== "sqlite") {
+    return <UnsupportedMaintenance driver={driver} />;
+  }
+
+  return <SQLiteMaintenanceButtons {...props} />;
+}
+
 export function DatabaseStatsCard() {
   const { database, isLoading, error, reload } = useDatabaseStats();
   const vacuum = useActionFeedback();
   const optimize = useActionFeedback();
   const [resetOpen, setResetOpen] = useState(false);
-  const driver = database ? databaseDriver(database) : "sqlite";
+  const driver = database ? databaseDriver(database) : null;
 
   const onVacuum = () =>
     void vacuum.run(async () => {

--- a/apps/web/e2e/tests/system/database-page.spec.ts
+++ b/apps/web/e2e/tests/system/database-page.spec.ts
@@ -10,7 +10,13 @@ test.describe("System Database page", () => {
     await expect(testPage.getByTestId("system-database-card")).toBeVisible();
 
     // Each stat row must render a non-empty value.
-    const rows = ["system-db-path", "system-db-size", "system-db-wal", "system-db-schema-version"];
+    const rows = [
+      "system-db-driver",
+      "system-db-path",
+      "system-db-size",
+      "system-db-wal",
+      "system-db-schema-version",
+    ];
     for (const id of rows) {
       const value = await testPage.getByTestId(id).innerText();
       expect(value.trim().length).toBeGreaterThan(0);

--- a/apps/web/e2e/tests/system/mobile-database-page.spec.ts
+++ b/apps/web/e2e/tests/system/mobile-database-page.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "../../fixtures/test-base";
+
+test.describe("Mobile System Database page", () => {
+  test("renders database stats and maintenance controls", async ({ testPage }) => {
+    await testPage.goto("/settings/system/database");
+
+    await expect(testPage.getByTestId("system-page-title")).toHaveText("Database");
+    await expect(testPage.getByTestId("system-database-card")).toBeVisible();
+
+    for (const id of [
+      "system-db-driver",
+      "system-db-size",
+      "system-db-schema-version",
+      "system-vacuum-button",
+      "system-optimize-button",
+      "system-factory-reset-button",
+    ]) {
+      await expect(testPage.getByTestId(id)).toBeVisible();
+    }
+  });
+});

--- a/apps/web/e2e/tests/system/mobile-database-page.spec.ts
+++ b/apps/web/e2e/tests/system/mobile-database-page.spec.ts
@@ -7,7 +7,7 @@ test.describe("Mobile System Database page", () => {
     await expect(testPage.getByTestId("system-page-title")).toHaveText("Database");
     await expect(testPage.getByTestId("system-database-card")).toBeVisible();
 
-    // The default E2E backend uses SQLite, so SQLite-only maintenance buttons render.
+    // Maintenance buttons are only rendered for SQLite; this spec assumes a SQLite backend.
     for (const id of [
       "system-db-driver",
       "system-db-size",

--- a/apps/web/e2e/tests/system/mobile-database-page.spec.ts
+++ b/apps/web/e2e/tests/system/mobile-database-page.spec.ts
@@ -7,6 +7,7 @@ test.describe("Mobile System Database page", () => {
     await expect(testPage.getByTestId("system-page-title")).toHaveText("Database");
     await expect(testPage.getByTestId("system-database-card")).toBeVisible();
 
+    // The default E2E backend uses SQLite, so SQLite-only maintenance buttons render.
     for (const id of [
       "system-db-driver",
       "system-db-size",

--- a/apps/web/lib/api/domains/system-api.test.ts
+++ b/apps/web/lib/api/domains/system-api.test.ts
@@ -106,6 +106,7 @@ describe("fetchDatabaseStats", () => {
   it("GETs /database", async () => {
     fetchSpy.mockResolvedValueOnce(
       jsonResponse({
+        driver: "sqlite",
         path: "/data/kandev.db",
         size_bytes: 1,
         wal_size_bytes: 0,
@@ -116,6 +117,7 @@ describe("fetchDatabaseStats", () => {
     const stats = await fetchDatabaseStats();
     expect(lastCall().url).toBe(`${BASE}/database`);
     expect(method()).toBe("GET");
+    expect(stats.driver).toBe("sqlite");
     expect(stats.path).toBe("/data/kandev.db");
   });
 });

--- a/apps/web/lib/state/slices/system/system-slice.test.ts
+++ b/apps/web/lib/state/slices/system/system-slice.test.ts
@@ -51,6 +51,7 @@ const DISK_USAGE: DiskUsageResponse = {
 };
 
 const DB_STATS: DatabaseStats = {
+  driver: "sqlite",
   path: "/data/kandev.db",
   size_bytes: 12345,
   wal_size_bytes: 678,

--- a/apps/web/lib/types/system.ts
+++ b/apps/web/lib/types/system.ts
@@ -34,6 +34,7 @@ export interface DiskUsageResponse {
 }
 
 export interface DatabaseStats {
+  driver: string;
   path: string;
   size_bytes: number;
   wal_size_bytes: number;

--- a/apps/web/src/settings-routes.tsx
+++ b/apps/web/src/settings-routes.tsx
@@ -156,7 +156,7 @@ const SETTINGS_ROUTES: Record<string, RouteRenderer> = {
   "/settings/system/database": () => (
     <SystemPageShell
       title="Database"
-      description="SQLite path and size, plus VACUUM, optimize, and factory reset."
+      description="Database driver, size, and available maintenance controls."
     >
       <DatabaseStatsCard />
     </SystemPageShell>

--- a/docs/specs/system-page/spec.md
+++ b/docs/specs/system-page/spec.md
@@ -163,6 +163,7 @@ All System endpoints require the same "logged-in install user" check as the exis
 - **GitHub poll failure** — log + keep the previous `kandev_meta` row; `/api/v1/system/updates` returns the stale value.
 - **Disk walk failure** (permission error on a subdir) — return the partial result with a `warnings: [...]` array per subdir; the page renders a per-row warning icon.
 - **VACUUM failure** — DB is unaffected (VACUUM is atomic); the job ends `failed` with the SQLite error string. Status page shows a recoverable error issue.
+- **Non-SQLite maintenance call** — `vacuum`, `optimize`, and `reset` jobs fail with `not supported for <driver> driver` before running SQLite-only SQL; factory reset also rejects before stopping active executions.
 - **Factory reset failure mid-run** — the pre-reset snapshot remains in `<data-dir>/backups/`; the user can restore it from the Backups page on next boot. Recovery is documented inline in the failure UI.
 - **Restore failure** — original DB file is left untouched; restore writes to a temp file and atomic-renames only on success.
 - **Log file missing / unreadable** — viewer renders an empty state with the file path so the user can investigate manually.

--- a/docs/specs/system-page/spec.md
+++ b/docs/specs/system-page/spec.md
@@ -10,7 +10,7 @@ owner: tbd
 
 Today, settings-style operational concerns (health, disk usage, current version, OSS attribution, log access, database maintenance) have no home in kandev's UI. The existing settings sidebar is product-configuration only (executors, agents, integrations); the only system-shaped entry — Changelog — sits awkwardly inside it. When something goes wrong, users have no path inside the app to see "where is my database, how big is it, what version am I on, is there an update, where are the logs." This forces them into the filesystem and into GitHub, and it makes recoverable problems (bloated SQLite, corrupt state) look unrecoverable.
 
-Radarr and Sonarr solve this with a dedicated **System** area: a group of read-only diagnostic pages plus a small number of gated maintenance actions. This spec brings the same shape to kandev, scoped to the kandev-specific surface (SQLite + worktrees + GitHub releases + lumberjack log files).
+Radarr and Sonarr solve this with a dedicated **System** area: a group of read-only diagnostic pages plus a small number of gated maintenance actions. This spec brings the same shape to kandev, scoped to the kandev-specific surface (database diagnostics, SQLite backups/maintenance, worktrees, GitHub releases, and lumberjack log files).
 
 ## What (v1)
 
@@ -23,10 +23,10 @@ A new **System** group is added to the existing settings sidebar (`apps/web/comp
    - **Disk usage** card: shows total kandev data footprint with a per-subdirectory breakdown (`data dir / worktrees / repos / sessions / tasks / quick-chat / backups`), an "as of HH:MM" timestamp, and a **Refresh** button. The disk walk is lazy and asynchronous: the first visit after a cold start (or after the 2h cache expires) returns `null` immediately and the page shows a loading spinner while the walk runs in the background; subsequent visits within 2h return the cached value instantly.
    - **Version + update** card: short summary of current version and "update available" badge, with a CTA to the Updates page.
 2. **Database** — `/settings/system/database`
-   - Read-only: SQLite file path, file size, WAL size, schema version, last-backup timestamp (from `<data-dir>/backups/`).
-   - **VACUUM** button — safe, reclaims space; shows progress and final size delta.
-   - **Optimize** button — runs `PRAGMA optimize`; shows progress.
-   - **Factory Reset** button — destructive. Wipes the full kandev install (database + worktrees + repo clones + session dirs + tasks dir + quick-chat dir), equivalent to deleting `~/.kandev/` and starting over. Opens a modal that requires (a) typing the literal string `RESET` to enable the confirm button, (b) acknowledging that the backend will create a pre-reset snapshot first and then restart. Server-side: stop orchestrator and running executions → snapshot DB to `<data-dir>/backups/pre-reset-<ts>.db` → drop DB tables and re-run migrations → `rm -rf` the worktrees/repos/sessions/tasks/quick-chat subdirs → restart backend process. The frontend disables the UI and waits for the backend to come back, then routes to the empty onboarding state.
+   - Read-only: database driver, database size, and schema version. SQLite additionally shows file path, WAL size, and last-backup timestamp (from `<data-dir>/backups/`). Postgres shows database-level size and does not render SQLite file/WAL/backup rows.
+   - SQLite-only **VACUUM** button — safe, reclaims space; shows progress and final size delta.
+   - SQLite-only **Optimize** button — runs `PRAGMA optimize`; shows progress.
+   - SQLite-only **Factory Reset** button — destructive. Wipes the full kandev install (database + worktrees + repo clones + session dirs + tasks dir + quick-chat dir), equivalent to deleting `~/.kandev/` and starting over. Opens a modal that requires (a) typing the literal string `RESET` to enable the confirm button, (b) acknowledging that the backend will create a pre-reset snapshot first and then restart. Server-side: stop orchestrator and running executions → snapshot DB to `<data-dir>/backups/pre-reset-<ts>.db` → drop DB tables and re-run migrations → `rm -rf` the worktrees/repos/sessions/tasks/quick-chat subdirs → restart backend process. The frontend disables the UI and waits for the backend to come back, then routes to the empty onboarding state.
 3. **Backups** — `/settings/system/backups`
    - Lists existing snapshots in `<data-dir>/backups/` with name, size, and mtime.
    - Per-row actions: **Download**, **Restore** (gated like Factory Reset), **Delete** (confirm-only).
@@ -59,7 +59,7 @@ GET    /api/v1/system/health                      (existing; unchanged)
 GET    /api/v1/system/info                        - versions, commit, build time, OS/arch
 GET    /api/v1/system/disk-usage                  - cached breakdown + computedAt; null while computing
 POST   /api/v1/system/disk-usage/refresh          - kick async recompute; 202
-GET    /api/v1/system/database                    - path, sizeBytes, walSizeBytes, schemaVersion, lastBackupAt
+GET    /api/v1/system/database                    - driver, path, sizeBytes, walSizeBytes, schemaVersion, lastBackupAt
 POST   /api/v1/system/database/vacuum             - 202 + jobId
 POST   /api/v1/system/database/optimize           - 202 + jobId
 POST   /api/v1/system/database/reset              - factory reset; body { confirm: "RESET" }
@@ -124,6 +124,7 @@ The page reads the JSON statically; no backend endpoint is needed.
 - **GIVEN** the user is running a kandev-managed user service and a newer release exists, **WHEN** they open `/settings/system/updates`, **THEN** the page shows **Apply update** and the confirmation queues a `self-update` job.
 - **GIVEN** the user is not running as a kandev-managed service or is running a `--system` service, **WHEN** they open `/settings/system/updates`, **THEN** the page does not render an update-apply control and instead shows the manual update commands.
 - **GIVEN** the user clicks **VACUUM** on the Database page, **WHEN** the operation completes, **THEN** the DB size delta is shown ("Reclaimed 12.3 MB"), the page Database stats refresh, and a transient info issue appears on the Status page.
+- **GIVEN** the backend uses Postgres, **WHEN** the user opens the Database page, **THEN** the page shows the PostgreSQL driver and database size without issuing SQLite-only PRAGMA queries, and SQLite-only maintenance controls are not rendered.
 - **GIVEN** the user clicks **Factory Reset**, types `RESET`, and confirms, **WHEN** the backend executes, **THEN** a fresh snapshot is created first, all tables are dropped and migrations re-run, the backend restarts, and the frontend redirects to the empty onboarding state once it reconnects.
 - **GIVEN** the backend cannot reach GitHub, **WHEN** the poller fires, **THEN** the failure is logged but the previous `latest_version` and `latest_version_checked_at` remain in `kandev_meta`; the Updates page surfaces the stale value with a "Last checked <time>" subtitle.
 - **GIVEN** the user clicks **Check now** twice within 30 seconds, **WHEN** the second click fires, **THEN** the endpoint returns `429 Too Many Requests` and the UI shows "Already checked, try again in <N>s".


### PR DESCRIPTION
Postgres installs hit a SQLite-only PRAGMA on the System Database page, which surfaced as a red `pragma page_count` error instead of usable database stats. The page now reports driver-aware stats and hides SQLite-only maintenance controls when the backend is using Postgres.

## Validation

- `make fmt`
- `node apps/web/scripts/generate-release-notes.mjs`
- `node apps/web/scripts/generate-changelog.mjs`
- `make typecheck`
- `make test`
- `make lint`
- `go test ./internal/system/database`
- `cd apps/web && pnpm run typecheck`
- `cd apps/web && pnpm run lint`
- `cd apps/web && pnpm --filter @kandev/web test -- --run lib/api/domains/system-api.test.ts lib/state/slices/system/system-slice.test.ts`
- `make build-backend build-web`
- `cd apps/web && pnpm e2e --project=mobile-chrome tests/system/mobile-database-page.spec.ts`
- `cd apps/web && pnpm e2e --project=chromium tests/system/database-page.spec.ts`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->