### PR TITLE
ci: disable opencode review workflow

### DIFF
--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -228,7 +228,6 @@ jobs:
   # fork review job's label path, this gives per-commit maintainer opt-in.
   strip-safe-to-review:
     if: >
-      vars.OPENCODE_REVIEW_ENABLED == 'true' &&
       github.event_name == 'pull_request_target' &&
       github.event.action == 'synchronize' &&
       github.event.pull_request.head.repo.full_name != github.repository &&

--- a/.github/workflows/opencode-code-review.yml
+++ b/.github/workflows/opencode-code-review.yml
@@ -24,10 +24,12 @@ env:
 jobs:
   opencode-review-same-repo:
     if: >
+      vars.OPENCODE_REVIEW_ENABLED == 'true' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -226,6 +228,7 @@ jobs:
   # fork review job's label path, this gives per-commit maintainer opt-in.
   strip-safe-to-review:
     if: >
+      vars.OPENCODE_REVIEW_ENABLED == 'true' &&
       github.event_name == 'pull_request_target' &&
       github.event.action == 'synchronize' &&
       github.event.pull_request.head.repo.full_name != github.repository &&
@@ -258,12 +261,14 @@ jobs:
     #     blocked on `synchronize` so a contributor push cannot re-use a stale
     #     label — the maintainer must re-apply it after each push.
     if: >
+      vars.OPENCODE_REVIEW_ENABLED == 'true' &&
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name != github.repository &&
       ((github.event.action != 'synchronize' && contains(github.event.pull_request.labels.*.name, 'safe-to-review')) ||
        (vars.OPENCODE_REVIEW_ALLOWLIST != '' && contains(fromJSON(vars.OPENCODE_REVIEW_ALLOWLIST), github.event.pull_request.user.login)))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
OpenCode review jobs currently consume a paid subscription, so the workflow should stay dormant unless explicitly re-enabled. The review jobs now require `OPENCODE_REVIEW_ENABLED` and have a 15-minute job timeout when enabled.

## Validation

- `python3 .github/scripts/lint-action-pinning.py`
- YAML parse check for `.github/workflows/opencode-code-review.yml`
- Full verify fallback: `make fmt`, regenerate release notes/changelog, `make typecheck`, `make test`, `make lint`

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have manually tested my changes and they work as expected.
- [ ] My changes have tests that cover the new functionality and edge cases.
- [ ] If my change touches UI files (`apps/web/`), I have added or updated Playwright e2e tests in `apps/web/e2e/` and verified them with `make test-e2e`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kdlbs/kandev/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->